### PR TITLE
ci: fix release workflow — build engine sidecar before tauri

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,23 @@ jobs:
           mkdir -p ~/.appstoreconnect/private_keys
           echo "${{ secrets.APPLE_API_KEY_CONTENT }}" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPLE_API_KEY }}.p8
 
+      # Build the engine sidecar BEFORE the Tauri app build. The app's
+      # `build.rs` stages `target/release/houston-engine` into
+      # `src-tauri/binaries/houston-engine-<triple>` for Tauri's `externalBin`
+      # to bundle. Without this step the Tauri build fails with
+      # `resource path 'binaries/houston-engine-...' doesn't exist` — which
+      # silently broke v0.3.3's release pipeline.
+      - name: Build houston-engine sidecar
+        run: |
+          TRIPLE="aarch64-apple-darwin"
+          cargo build --release --target "$TRIPLE" -p houston-engine-server
+          # The target-specific cargo output lives at `target/<triple>/release/`.
+          # `build.rs` also looks at `target/release/` (no triple) so mirror the
+          # binary there so both paths resolve.
+          mkdir -p target/release
+          cp "target/$TRIPLE/release/houston-engine" target/release/houston-engine
+          ls -la target/release/houston-engine "target/$TRIPLE/release/houston-engine"
+
       # Build only — no release creation (no tagName).
       # tauri-action handles certificate import, code signing, .app notarization + stapling.
       - name: Build Tauri app


### PR DESCRIPTION
## Summary
The v0.4.0 release (and both v0.3.3 attempts before it) failed at the `Build Tauri app` step with:

\`\`\`
resource path 'binaries/houston-engine-aarch64-apple-darwin' doesn't exist
\`\`\`

Root cause: \`app/src-tauri/build.rs\` expects the engine binary to already be built so it can stage it into \`src-tauri/binaries/\` for Tauri's \`externalBin\` bundling. The script's comment claimed \"CI wires that into the release workflow\" — but no step actually did. Pre-existing workflow bug.

Fix: new \`Build houston-engine sidecar\` step runs \`cargo build --release --target aarch64-apple-darwin -p houston-engine-server\` before \`tauri build\`, and mirrors the binary to \`target/release/\` so \`build.rs\`'s lookup works either way.

## Test plan
- [x] \`actionlint\` clean on the new step.
- [ ] CI: tag v0.4.0 again after merge, watch the workflow pass the Build step this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)