### PR TITLE
ci: fix artifact path for cargo workspace layout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,9 @@ jobs:
       - name: Locate build artifacts
         id: artifacts
         run: |
-          BUNDLE="app/src-tauri/target/release/bundle"
+          # Cargo workspace: target dir is at workspace root, not per-crate.
+          # tauri-action emits bundles under `target/release/bundle/`.
+          BUNDLE="target/release/bundle"
 
           APP=$(ls -d "$BUNDLE/macos/"*.app 2>/dev/null | head -1)
           DMG=$(ls -t "$BUNDLE/dmg/"*.dmg 2>/dev/null | head -1)


### PR DESCRIPTION
tauri-action emits bundles at `target/release/bundle/` (cargo workspace root), not `app/src-tauri/target/release/bundle/`. Update the Locate step path. Build + sign + notarize all succeeded in the last run; fixing this should get the draft release created.