### PR TITLE
fix(app): locate bundled engine sidecar — unblocks v0.4.x release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "houston-agent-files",
  "houston-agents-conversations",

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.0",
+  "version": "0.4.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 
 [lib]

--- a/app/src-tauri/src/engine_supervisor.rs
+++ b/app/src-tauri/src/engine_supervisor.rs
@@ -184,19 +184,44 @@ impl Drop for EngineSubprocess {
 /// Resolve the `houston-engine` binary path.
 ///
 /// Resolution order:
-/// 1. `HOUSTON_ENGINE_BIN` env var (dev override).
-/// 2. In debug builds: cargo workspace target first (freshest during
-///    `pnpm tauri dev` — the staged sidecar can be stale if you rebuild
-///    just the engine crate).
-/// 3. Tauri bundle sidecar: `<resources>/binaries/houston-engine`
-///    (authoritative in release builds, where the binary is bundled by
-///    `externalBin`).
-/// 4. In release builds: cargo workspace target (last-resort fallback).
+/// 1. `HOUSTON_ENGINE_BIN` env var (dev override / SSH deploy).
+/// 2. Debug builds: cargo workspace target (freshest during `pnpm tauri
+///    dev` — the staged sidecar can be stale if you rebuild just the
+///    engine crate).
+/// 3. Sibling of the current executable — this is where Tauri's
+///    `externalBin` places sidecars in shipped app bundles:
+///      - macOS: `Houston.app/Contents/MacOS/houston-engine`
+///      - Windows: next to `houston-app.exe`
+///      - Linux AppImage: inside the mounted AppImage root
+///    Authoritative for release builds. (Tauri's `resource_dir()` points
+///    at `Contents/Resources/` on macOS which is the WRONG place for
+///    externalBin — sidecars are not resources.)
+/// 4. `<resource_dir>/binaries/houston-engine` — legacy / belt-and-braces
+///    fallback for platforms that stage externalBin into the resources
+///    tree.
+/// 5. Release builds: cargo workspace target (last-resort, exists only
+///    when running `cargo run --release` outside a bundled `.app`).
+///
+/// Returning `Err` here causes the Tauri `setup()` closure to abort the
+/// app on launch — so this function is a hot path during the "download
+/// the new DMG, open it, nothing happens" user experience. Every path we
+/// check is worth the extra stat call.
 pub fn resolve_engine_binary(resource_dir: Option<&PathBuf>) -> Result<PathBuf, String> {
+    let mut tried: Vec<PathBuf> = Vec::new();
+    let try_candidate = |p: PathBuf, tried: &mut Vec<PathBuf>| -> Option<PathBuf> {
+        if p.exists() {
+            Some(p)
+        } else {
+            tried.push(p);
+            None
+        }
+    };
+
+    // 1. Explicit env override.
     if let Ok(p) = std::env::var("HOUSTON_ENGINE_BIN") {
         let pb = PathBuf::from(p);
-        if pb.exists() {
-            return Ok(pb);
+        if let Some(hit) = try_candidate(pb, &mut tried) {
+            return Ok(hit);
         }
     }
 
@@ -206,45 +231,68 @@ pub fn resolve_engine_binary(resource_dir: Option<&PathBuf>) -> Result<PathBuf, 
     let target_debug = workspace_root.join("target").join("debug").join(bin_name());
     let target_release = workspace_root.join("target").join("release").join(bin_name());
 
+    // 2. Debug: prefer cargo target (freshest under `tauri dev`).
     #[cfg(debug_assertions)]
     {
-        // Dev: prefer the freshest cargo target.
-        if target_debug.exists() {
-            return Ok(target_debug);
+        if let Some(hit) = try_candidate(target_debug.clone(), &mut tried) {
+            return Ok(hit);
         }
-        if target_release.exists() {
-            return Ok(target_release);
+        if let Some(hit) = try_candidate(target_release.clone(), &mut tried) {
+            return Ok(hit);
         }
     }
 
-    if let Some(resources) = resource_dir {
-        let candidates = [
-            resources.join("binaries").join(bin_name_no_triple()),
-            resources
-                .join("binaries")
-                .join(format!("{}-{}", bin_name_no_triple(), host_triple())),
-        ];
-        for c in candidates {
-            if c.exists() {
-                return Ok(c);
+    // 3. Sibling of the current executable — the bundled-sidecar location
+    //    Tauri actually uses on every shipping platform.
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(exe_dir) = exe.parent() {
+            if let Some(hit) = try_candidate(exe_dir.join(bin_name_no_triple()), &mut tried) {
+                return Ok(hit);
+            }
+            if let Some(hit) = try_candidate(
+                exe_dir.join(format!("{}-{}", bin_name_no_triple(), host_triple())),
+                &mut tried,
+            ) {
+                return Ok(hit);
             }
         }
     }
 
+    // 4. Resources dir — legacy fallback.
+    if let Some(resources) = resource_dir {
+        if let Some(hit) =
+            try_candidate(resources.join("binaries").join(bin_name_no_triple()), &mut tried)
+        {
+            return Ok(hit);
+        }
+        if let Some(hit) = try_candidate(
+            resources
+                .join("binaries")
+                .join(format!("{}-{}", bin_name_no_triple(), host_triple())),
+            &mut tried,
+        ) {
+            return Ok(hit);
+        }
+    }
+
+    // 5. Release: cargo target as last resort.
     #[cfg(not(debug_assertions))]
     {
-        // Release: only fall back to cargo target if no sidecar bundled.
-        if target_release.exists() {
-            return Ok(target_release);
+        if let Some(hit) = try_candidate(target_release.clone(), &mut tried) {
+            return Ok(hit);
         }
-        if target_debug.exists() {
-            return Ok(target_debug);
+        if let Some(hit) = try_candidate(target_debug.clone(), &mut tried) {
+            return Ok(hit);
         }
     }
 
     Err(format!(
-        "houston-engine binary not found (resource_dir={:?})",
-        resource_dir
+        "houston-engine binary not found. Tried:\n  - {}",
+        tried
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join("\n  - ")
     ))
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

v0.4.0 DMG users saw this abort on first launch (provided by QA):

\`\`\`
Thread 0 Crashed:: main
12  houston-app  tao::platform_impl::platform::app_delegate::did_finish_launching + 272
11  houston-app  core::panicking::panic_cannot_unwind + 24
\`\`\`

Root cause: \`resolve_engine_binary\` looks in \`Contents/Resources/binaries/\` and the cargo workspace target, but Tauri's \`externalBin\` places the sidecar at \`Contents/MacOS/houston-engine\` (next to the main exe). Neither existing path exists on a shipped DMG, so \`.expect(\"houston-engine binary missing\")\` inside \`setup()\` aborts the Tauri app before the window is shown.

## Fix
- Add a candidate based on \`std::env::current_exe().parent()\` — the bundled-sidecar location Tauri actually uses on every platform.
- Check it BEFORE the resources-dir fallback so release builds resolve the sidecar.
- Rewrite the lookup as a closure that collects misses; the \`Err\` message now lists every path tried so future \"binary not found\" is diagnosable from a single log line.
- Bump to v0.4.1.

## Test plan
- [x] \`cargo build --workspace\` + \`cargo test -p houston-app\` pass locally.
- [ ] CI: tag v0.4.1 after merge; download DMG; confirm the app actually opens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)