### PR TITLE
fix: consolidate data under ~/.houston + surface provider login errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "houston-agent-files",
  "houston-agents-conversations",

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.1",
+  "version": "0.4.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2021"
 
 [lib]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -109,8 +109,12 @@ pub fn run() {
                     .expect("Failed to open database")
             });
 
-            let root = houston.join("workspaces");
-            std::fs::create_dir_all(&root).ok();
+            // One-time migration: earlier versions stored workspaces under
+            // `~/Documents/Houston/`. New default is `$HOUSTON_HOME/workspaces/`
+            // so everything Houston owns is under a single discoverable root.
+            // Move the legacy directory if it exists and the new location is
+            // empty. Idempotent on subsequent launches.
+            migrate_legacy_docs_dir(&houston);
 
             // AppState keeps a DB handle for any OS-native lookup (log
             // reading, session search). Domain state now lives in the
@@ -139,18 +143,11 @@ pub fn run() {
             // as opaque strings — it has no hardcoded Houston copy.
             //
             // Also pin HOUSTON_HOME + HOUSTON_DOCS so the engine uses the
-            // same data roots as the app (matters if someone ever runs a
-            // release engine binary against a debug app or vice-versa).
-            // Dev: workspaces live INSIDE `~/.dev-houston/workspaces/`.
-            // Release: preserve legacy `~/Documents/Houston/` for existing users.
-            let docs_dir = if cfg!(debug_assertions) {
-                houston.join("workspaces")
-            } else {
-                houston
-                    .parent()
-                    .map(|h| h.join("Documents").join("Houston"))
-                    .unwrap_or_else(|| PathBuf::from("Documents").join("Houston"))
-            };
+            // same data roots as the app. Workspaces live under
+            // `$HOUSTON_HOME/workspaces/` in both debug (`~/.dev-houston/`)
+            // and release (`~/.houston/`) — everything Houston writes is
+            // rooted at a single discoverable location.
+            let docs_dir = houston.join("workspaces");
             let engine_env: Vec<(String, String)> = vec![
                 (
                     "HOUSTON_APP_SYSTEM_PROMPT".into(),
@@ -270,4 +267,78 @@ pub fn run() {
                 _ => {}
             }
         });
+}
+
+/// Move `~/Documents/Houston/` to `$houston/workspaces/` if:
+///   - the legacy dir exists and has content (workspaces.json),
+///   - the new location is empty or missing workspaces.json.
+///
+/// Idempotent. Safe to call on every launch — real work only on the
+/// first v0.4.2+ boot for anyone who previously ran v0.3.x/v0.4.0–v0.4.1.
+/// On any error we log + bail; the engine will still run against the new
+/// empty path. Original legacy dir is left in place as manual rollback.
+fn migrate_legacy_docs_dir(houston: &std::path::Path) {
+    let home = match std::env::var("HOME") {
+        Ok(h) => PathBuf::from(h),
+        Err(_) => return,
+    };
+    let legacy = home.join("Documents").join("Houston");
+    let new_root = houston.join("workspaces");
+
+    let legacy_manifest = legacy.join("workspaces.json");
+    if !legacy_manifest.is_file() {
+        return; // nothing to migrate
+    }
+
+    let new_manifest = new_root.join("workspaces.json");
+    if new_manifest.is_file() {
+        tracing::debug!(
+            "[migrate] skipping — {} already has content",
+            new_root.display()
+        );
+        return;
+    }
+
+    if let Err(e) = std::fs::create_dir_all(&new_root) {
+        tracing::warn!("[migrate] create_dir_all({}) failed: {e}", new_root.display());
+        return;
+    }
+
+    let entries = match std::fs::read_dir(&legacy) {
+        Ok(it) => it,
+        Err(e) => {
+            tracing::warn!("[migrate] read_dir({}) failed: {e}", legacy.display());
+            return;
+        }
+    };
+
+    let mut moved = 0u32;
+    for entry in entries.flatten() {
+        let src = entry.path();
+        let name = match src.file_name() {
+            Some(n) => n.to_os_string(),
+            None => continue,
+        };
+        let dst = new_root.join(&name);
+        if dst.exists() {
+            continue; // don't clobber anything at the new root
+        }
+        if let Err(e) = std::fs::rename(&src, &dst) {
+            tracing::warn!(
+                "[migrate] rename {} -> {} failed: {e}",
+                src.display(),
+                dst.display()
+            );
+            continue;
+        }
+        moved += 1;
+    }
+
+    if moved > 0 {
+        tracing::info!(
+            "[migrate] moved {moved} entries from {} to {}",
+            legacy.display(),
+            new_root.display()
+        );
+    }
 }

--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -264,13 +264,20 @@ function SetupGuidance({
   const installed = status?.cli_installed ?? false;
   const authenticated = status?.authenticated ?? false;
   const [loginLaunched, setLoginLaunched] = useState(false);
+  const [loginError, setLoginError] = useState<string | null>(null);
 
   const handleSignIn = async () => {
+    setLoginError(null);
     try {
       await tauriProvider.launchLogin(provider.id);
       setLoginLaunched(true);
-    } catch {
-      // CLI not installed — fall through to install guidance
+    } catch (e) {
+      // Surface it. Previously we swallowed every error which made the
+      // onboarding screen look completely unresponsive to users whose
+      // `claude`/`codex` CLI was on a PATH the .app bundle couldn't see.
+      const msg = e instanceof Error ? e.message : String(e);
+      console.error(`[provider-picker] launchLogin(${provider.id}) failed:`, msg);
+      setLoginError(msg);
     }
   };
 
@@ -329,6 +336,13 @@ function SetupGuidance({
           >
             Open browser again
           </button>
+        </div>
+      )}
+
+      {loginError && (
+        <div className="rounded-lg border border-destructive/30 bg-destructive/5 p-2.5 text-xs text-destructive">
+          <div className="font-medium mb-0.5">Couldn't launch {provider.cliName}</div>
+          <div className="text-destructive/80">{loginError}</div>
         </div>
       )}
 

--- a/engine/houston-engine-server/src/config.rs
+++ b/engine/houston-engine-server/src/config.rs
@@ -61,17 +61,13 @@ impl ServerConfig {
         let docs_dir = std::env::var("HOUSTON_DOCS")
             .map(PathBuf::from)
             .unwrap_or_else(|_| {
-                if cfg!(debug_assertions) {
-                    // Dev: workspaces live INSIDE `~/.dev-houston/workspaces/`.
-                    dirs_home()
-                        .map(|h| h.join(".dev-houston").join("workspaces"))
-                        .expect("no home directory")
-                } else {
-                    // Release: preserve legacy `~/Documents/Houston/`.
-                    dirs_home()
-                        .map(|h| h.join("Documents").join("Houston"))
-                        .expect("no home directory")
-                }
+                // Workspaces always live under `$HOUSTON_HOME/workspaces/` so
+                // everything Houston writes is rooted at one discoverable
+                // location. Applies to both debug (`~/.dev-houston/`) and
+                // release (`~/.houston/`). The Houston desktop app handles a
+                // one-time migration from the legacy `~/Documents/Houston/`
+                // path in `app/src-tauri/src/lib.rs::migrate_legacy_docs_dir`.
+                home_dir.join("workspaces")
             });
 
         let app_system_prompt = std::env::var("HOUSTON_APP_SYSTEM_PROMPT").unwrap_or_default();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Two user-reported v0.4.1 issues.

## 1. Data split felt schizophrenic
Release stored DB+logs at \`~/.houston/\` but workspaces at \`~/Documents/Houston/\`. In-flight code even pre-created \`~/.houston/workspaces/\` as a dead dir. Both visible to any user who peeked at their filesystem.

**Fix:** everything Houston writes now lives under \`\$HOUSTON_HOME/workspaces/\` → \`~/.houston/workspaces/\` on release, \`~/.dev-houston/workspaces/\` on debug. One-time migration moves \`~/Documents/Houston/\` contents on next launch, idempotent. Env override (\`HOUSTON_DOCS\`) still wins.

## 2. Onboarding provider-connect silently failed
\`launchLogin\` threw → \`try/catch { }\` swallowed it → button did nothing → user saw unresponsive UI. Settings worked only because Settings users typically already signed in.

**Fix:** surface the error under the Sign In button as a destructive banner + log to \`frontend.log\` with \`[provider-picker]\` prefix. Next crash we'll know the real cause from one log line.

Bump to v0.4.2.

## Test plan
- [x] cargo + TS clean.
- [ ] Smoke: install v0.4.1 DMG, let it run, upgrade to v0.4.2, confirm:
  - data at \`~/Documents/Houston/\` moved to \`~/.houston/workspaces/\`
  - existing agents still load
  - onboarding sign-in failure now shows a red error banner instead of doing nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)