### PR TITLE
fix(engine): resolve shell PATH before handling provider-status routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2320,7 +2320,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.2"
+version = "0.4.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.2"
+version = "0.4.0"
 dependencies = [
  "houston-agent-files",
  "houston-agents-conversations",

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.2"
+version = "0.4.0"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.2"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/engine/houston-engine-server/src/main.rs
+++ b/engine/houston-engine-server/src/main.rs
@@ -24,6 +24,17 @@ struct EngineManifest<'a> {
 #[tokio::main]
 async fn main() {
     init_tracing();
+
+    // Resolve the real user PATH (login + interactive shell + common install
+    // dirs) BEFORE any route handler runs. Without this, the engine inherits
+    // the minimal GUI PATH passed by the Tauri supervisor (which itself ran
+    // in a Gatekeeper-launched .app) and `is_command_available("claude")`
+    // falsely reports the user's CLI as missing — which is what made the
+    // onboarding "Connect your AI" screen show "claude CLI not found" even
+    // for users with claude installed via Homebrew / nvm / npm.
+    // `init` is idempotent thanks to a `OnceLock`.
+    houston_terminal_manager::claude_path::init();
+
     let cfg = ServerConfig::from_env();
     let listener = TcpListener::bind(cfg.bind)
         .await

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.2",
+  "version": "0.4.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Problem
Onboarding in the shipped DMG shows \"claude CLI not found\" + \"codex CLI not found\" even for users who have both installed via Homebrew / nvm / npm. Works fine in local \`pnpm tauri dev\`.

## Root cause
\`claude_path::init()\` resolves the user's real shell PATH (login shell → interactive shell → common install dirs), cached in a \`OnceLock\`. It was only called:
1. In the Tauri app process — the \`OnceLock\` doesn't cross process boundaries, so the engine subprocess doesn't see it.
2. Inside \`session_runner::spawn_and_monitor\` — which only runs AFTER the user starts a chat.

Onboarding calls \`/v1/providers/:name/status\` BEFORE any session exists. At that point, engine's \`is_command_available\` uses the minimal GUI PATH (\`/usr/bin:/bin:/usr/sbin:/sbin\`) Gatekeeper passed through the supervisor chain.

Local dev bypassed this because the terminal's PATH is inherited directly.

## Fix
Call \`claude_path::init()\` at engine startup in \`main.rs\`, before any route handler runs. Idempotent via \`OnceLock\`.

## Verified locally
Ran the release engine with Gatekeeper-style env:
\`\`\`
env -i PATH=/usr/bin:/bin:/usr/sbin:/sbin ./target/release/houston-engine
curl .../v1/providers/anthropic/status
→ {\"cliInstalled\":true,...}
curl .../v1/providers/openai/status
→ {\"cliInstalled\":true,...}
\`\`\`

## Also
Reverts version to 0.4.0. Draft releases for 0.4.0 / 0.4.1 / 0.4.2 all shipped variants of this broken onboarding. They're deleted. Consolidating under a single v0.4.0 tag once this passes the smoke test.

## Test plan
- [x] Repro'd the broken state with minimal PATH + verified the fix against the release binary locally.
- [ ] DMG: install fresh → Connect your AI screen shows CLI status correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)