### PR TITLE
fix(app): hide mobile button + reset provider setup-guidance state

### DIFF
--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -108,9 +108,15 @@ export function ProviderPicker({ value, model: controlledModel, onSelect }: Prop
         })}
       </div>
 
-      {/* Setup guidance — rendered below the grid when a disconnected card is expanded */}
+      {/* Setup guidance — rendered below the grid when a disconnected card
+          is expanded. `key={expanded}` remounts the component when the user
+          switches between OpenAI and Anthropic, resetting local state
+          (`loginLaunched`, `loginError`) so the previous provider's
+          "Waiting for browser sign-in..." banner doesn't linger under the
+          new provider's heading. */}
       {expanded && !(statuses[expanded]?.cli_installed && statuses[expanded]?.authenticated) && (
         <SetupGuidance
+          key={expanded}
           provider={PROVIDERS.find((p) => p.id === expanded)!}
           status={statuses[expanded]}
           isSelected={value === expanded}

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -9,7 +9,10 @@ import { useUIStore } from "../../stores/ui";
 import { analytics } from "../../lib/analytics";
 import { AgentMiniAvatar } from "./experience-card";
 import { UpdateChecker } from "./update-checker";
-import { MobileSyncButton } from "./mobile-sync";
+// Mobile companion app not shipping yet — hide the sidebar entry point
+// so we don't surface a feature that isn't ready. Re-enable once the
+// pairing flow ships end-to-end.
+// import { MobileSyncButton } from "./mobile-sync";
 import { useSyncResponder } from "../../hooks/use-sync-responder";
 import { CreateWorkspaceDialog } from "../../App";
 
@@ -136,12 +139,7 @@ export function Sidebar({ children }: { children: ReactNode }) {
         onAdd={() => setDialogOpen(true)}
         onRename={handleRename}
         onDelete={handleDelete}
-        footer={
-          <>
-            <MobileSyncButton />
-            <UpdateChecker />
-          </>
-        }
+        footer={<UpdateChecker />}
       >
         <div className="flex-1 min-w-0 h-full overflow-hidden flex flex-col">
           {children}


### PR DESCRIPTION
Two small onboarding UX fixes before publishing v0.4.0.

- Hide the `MobileSyncButton` from the sidebar — mobile companion isn't shipped, don't surface it.
- Add `key={expanded}` to `<SetupGuidance>` so switching between OpenAI and Anthropic resets the card's local state (`loginLaunched`, `loginError`). Prevents the "Waiting for browser sign-in..." banner from lingering under the new provider's heading.