### PR TITLE
fix(app): drop timezone gate + eagerly migrate per-agent data

### DIFF
--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -116,6 +116,15 @@ pub fn run() {
             // empty. Idempotent on subsequent launches.
             migrate_legacy_docs_dir(&houston);
 
+            // Eagerly run the intra-agent data-layout migration on every
+            // agent the user already has. Previously this only fired the
+            // first time a user started a session on each agent, which
+            // meant upgraders who just BROWSED the Activity tab saw an
+            // empty board even though their `.houston/activity.json` was
+            // sitting next to it. Walk the workspaces dir here so existing
+            // activities, routines, learnings show up immediately.
+            migrate_all_agents(&houston.join("workspaces"));
+
             // AppState keeps a DB handle for any OS-native lookup (log
             // reading, session search). Domain state now lives in the
             // engine subprocess.
@@ -267,6 +276,64 @@ pub fn run() {
                 _ => {}
             }
         });
+}
+
+/// Walk every agent under `<workspaces>/<workspace>/<agent>/` and run
+/// `houston_agent_files::migrate_agent_data` on each. Idempotent — only
+/// does real work for agents whose `.houston/` is still in the legacy flat
+/// layout or still has a `memory/learnings.md` that needs rewriting.
+///
+/// Exists because the per-agent migration used to be gated behind
+/// `seed_agent()`, which only runs when the user starts a session, creates
+/// an agent, or fires a routine. Upgraders from v0.3.x who simply browsed
+/// the Activity / Learnings tabs saw empty boards even though the legacy
+/// files sat right beside the new paths the UI was polling.
+fn migrate_all_agents(workspaces_root: &std::path::Path) {
+    let entries = match std::fs::read_dir(workspaces_root) {
+        Ok(it) => it,
+        Err(_) => return, // no workspaces yet — nothing to migrate
+    };
+
+    for ws_entry in entries.flatten() {
+        let ws_path = ws_entry.path();
+        if !ws_path.is_dir() {
+            continue;
+        }
+        let ws_name = ws_path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+        if ws_name.starts_with('.') {
+            continue;
+        }
+
+        let agent_entries = match std::fs::read_dir(&ws_path) {
+            Ok(it) => it,
+            Err(e) => {
+                tracing::warn!("[migrate-agents] read_dir({}) failed: {e}", ws_path.display());
+                continue;
+            }
+        };
+
+        for agent_entry in agent_entries.flatten() {
+            let agent_path = agent_entry.path();
+            if !agent_path.is_dir() {
+                continue;
+            }
+            let agent_name = agent_path.file_name().and_then(|s| s.to_str()).unwrap_or("");
+            if agent_name.starts_with('.') {
+                continue;
+            }
+            // Only agents that already have a `.houston/` dir — otherwise
+            // we'd eagerly create one for every random folder in the tree.
+            if !agent_path.join(".houston").is_dir() {
+                continue;
+            }
+            if let Err(e) = houston_tauri::houston_agent_files::migrate_agent_data(&agent_path) {
+                tracing::warn!(
+                    "[migrate-agents] migrate_agent_data({}) failed: {e}",
+                    agent_path.display()
+                );
+            }
+        }
+    }
 }
 
 /// Move `~/Documents/Houston/` to `$houston/workspaces/` if:

--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -102,7 +102,18 @@ export function ProviderPicker({ value, model: controlledModel, onSelect }: Prop
                 if (isSelected) onSelect(prov.id, m);
               }}
               onSelect={() => onSelect(prov.id, models[prov.id] ?? prov.defaultModel)}
-              onExpand={() => setExpanded(isExpanded ? null : prov.id)}
+              // Settle the expanded state based on what got clicked:
+              //   - connected card              → collapse (no setup needed)
+              //   - disconnected card currently expanded → collapse (toggle off)
+              //   - disconnected card not expanded       → switch to it
+              // Previously we only called onExpand when !connected, so
+              // clicking a connected card while a disconnected card's
+              // SetupGuidance was open left that stale card behind.
+              onExpand={() =>
+                setExpanded(
+                  connected ? null : isExpanded ? null : prov.id,
+                )
+              }
             />
           );
         })}
@@ -148,7 +159,11 @@ function ProviderCard({
 }) {
   const handleClick = () => {
     onSelect();
-    if (!connected) onExpand();
+    // Always settle the expansion state — the parent decides whether this
+    // means "open me", "close me", or "close whoever was open". Must NOT
+    // gate on `!connected` here or a connected card's click leaves the
+    // previously-open disconnected card's SetupGuidance orphaned below.
+    onExpand();
   };
 
   const selectedModelObj = provider.models.find((m) => m.id === selectedModel) ?? provider.models[0];

--- a/app/src/components/tabs/routines-tab.tsx
+++ b/app/src/components/tabs/routines-tab.tsx
@@ -1,9 +1,5 @@
 import { useCallback, useMemo, useState } from "react";
-import {
-  RoutinesGrid,
-  RoutineEditor,
-  TimezoneGate,
-} from "@houston-ai/routines";
+import { RoutinesGrid, RoutineEditor } from "@houston-ai/routines";
 import type { RoutineFormData, RoutineRun } from "@houston-ai/routines";
 import {
   useRoutines,
@@ -138,18 +134,16 @@ export default function RoutinesTab({ agent }: TabProps) {
     [runNow],
   );
 
-  // ------- Render order: timezone gate first, then routines UI -------
-
-  if (!tz.loaded) {
+  // `useTimezonePreference` auto-seeds on first call, so `tz.timezone` is
+  // non-null from the first render. We still wait for the roundtrip to
+  // finish so the cron schedule renders against the real zone instead of
+  // an empty placeholder.
+  if (!tz.loaded || !tz.timezone) {
     return (
       <div className="flex-1 flex items-center justify-center">
         <p className="text-sm text-muted-foreground animate-pulse">Loading…</p>
       </div>
     );
-  }
-
-  if (!tz.timezone) {
-    return <TimezoneGate detected={tz.detected} onConfirm={tz.confirm} />;
   }
 
   if (view.type === "editor") {

--- a/app/src/components/tabs/settings-view.tsx
+++ b/app/src/components/tabs/settings-view.tsx
@@ -7,6 +7,10 @@ import { useAgentStore } from "../../stores/agents";
 import { useUIStore } from "../../stores/ui";
 import { tauriPreferences } from "../../lib/tauri";
 import { setTheme, type Theme } from "../../lib/theme";
+import {
+  useTimezonePreference,
+  detectTimezone,
+} from "../../hooks/use-timezone-preference";
 
 export function SettingsView() {
   const workspaces = useWorkspaceStore((s) => s.workspaces);
@@ -21,6 +25,12 @@ export function SettingsView() {
   const [theme, setCurrentTheme] = useState<Theme>("light");
   const [wsName, setWsName] = useState("");
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const tz = useTimezonePreference();
+  const [tzDraft, setTzDraft] = useState("");
+  useEffect(() => {
+    setTzDraft(tz.timezone ?? "");
+  }, [tz.timezone]);
 
   useEffect(() => {
     tauriPreferences.get("theme").then((v) => {
@@ -101,6 +111,48 @@ export function SettingsView() {
             model={currentWorkspace.model ?? null}
             onSelect={handleProviderSelect}
           />
+        </section>
+
+        {/* Timezone */}
+        <section className="pt-2 border-t border-border">
+          <h2 className="text-sm font-medium mb-1">Timezone</h2>
+          <p className="text-xs text-muted-foreground mb-4">
+            Used when your routines fire — 9am means 9am in this zone.
+          </p>
+          <div>
+            <label className="text-xs text-muted-foreground block mb-1.5">
+              IANA zone
+            </label>
+            <input
+              type="text"
+              value={tzDraft}
+              onChange={(e) => setTzDraft(e.target.value)}
+              onBlur={async () => {
+                const trimmed = tzDraft.trim();
+                if (!trimmed || trimmed === tz.timezone) return;
+                await tz.confirm(trimmed);
+                addToast({ title: `Timezone set to ${trimmed}` });
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") (e.target as HTMLInputElement).blur();
+              }}
+              placeholder="e.g. America/Bogota"
+              className="w-full rounded-xl border border-border bg-card px-4 py-2.5 text-sm outline-none focus:ring-1 focus:ring-ring transition-all"
+            />
+            <div className="flex items-center justify-between mt-1.5 text-xs text-muted-foreground">
+              <button
+                onClick={async () => {
+                  const d = detectTimezone();
+                  setTzDraft(d);
+                  await tz.confirm(d);
+                  addToast({ title: `Timezone set to ${d}` });
+                }}
+                className="underline underline-offset-2 hover:text-foreground transition-colors"
+              >
+                Use detected ({tz.detected})
+              </button>
+            </div>
+          </div>
         </section>
 
         {/* Appearance */}

--- a/app/src/hooks/use-timezone-preference.ts
+++ b/app/src/hooks/use-timezone-preference.ts
@@ -32,7 +32,26 @@ async function fetchOnce(): Promise<string | null> {
   inflight = (async () => {
     try {
       const stored = await tauriPreferences.get(TIMEZONE_KEY);
-      cache = { value: stored && stored.trim() ? stored : null, loaded: true };
+      let value = stored && stored.trim() ? stored : null;
+
+      // Auto-seed: if the user has never set a timezone, save their
+      // browser-detected one silently. Previously we showed a full-page
+      // "What's your timezone?" gate that blocked the Routines tab. The
+      // detected zone is almost always correct; users who need to change
+      // it later do so in Settings → Timezone.
+      if (!value) {
+        const detected = detectTimezone();
+        try {
+          await tauriPreferences.set(TIMEZONE_KEY, detected);
+          value = detected;
+        } catch {
+          // If persisting fails, fall back to the detected value in memory
+          // so the UI still has something to render a cron schedule against.
+          value = detected;
+        }
+      }
+
+      cache = { value, loaded: true };
       notify();
       return cache.value;
     } finally {
@@ -60,9 +79,9 @@ export interface TimezoneState {
 }
 
 /**
- * Read-only-ish hook: returns the user's IANA tz only after they've explicitly
- * confirmed it (no silent autosave on boot). Components should treat
- * `timezone === null` as "user hasn't told us yet" and gate accordingly.
+ * Returns the user's IANA timezone. On first call we auto-save the
+ * browser-detected zone, so `timezone` is non-null from the first render
+ * onwards (no "timezone gate" UX). Users can change it later in Settings.
  */
 export function useTimezonePreference(): TimezoneState {
   const [, force] = useState(0);


### PR DESCRIPTION
Two v0.4.0 upgrade-UX fixes.

- **Timezone gate**: routines tab auto-saves browser-detected timezone, drops the "What's your timezone?" full-page gate. Users change it later in Settings → Timezone (new section with detected-value shortcut).
- **Stale data on upgrade**: per-agent data-layout migration was only triggered by session start. Browsing Activity/Learnings tabs never ran it, so upgraders saw empty boards despite having `.houston/activity.json` sitting next to the new path. New `migrate_all_agents()` walks the workspace root at app boot and runs the migration on every agent. Idempotent.