### PR TITLE
fix: attachment 422 + engine banner stall

### DIFF
--- a/engine/houston-engine-server/src/main.rs
+++ b/engine/houston-engine-server/src/main.rs
@@ -25,15 +25,17 @@ struct EngineManifest<'a> {
 async fn main() {
     init_tracing();
 
-    // Resolve the real user PATH (login + interactive shell + common install
-    // dirs) BEFORE any route handler runs. Without this, the engine inherits
-    // the minimal GUI PATH passed by the Tauri supervisor (which itself ran
-    // in a Gatekeeper-launched .app) and `is_command_available("claude")`
-    // falsely reports the user's CLI as missing — which is what made the
-    // onboarding "Connect your AI" screen show "claude CLI not found" even
-    // for users with claude installed via Homebrew / nvm / npm.
-    // `init` is idempotent thanks to a `OnceLock`.
-    houston_terminal_manager::claude_path::init();
+    // PATH resolution runs `zsh -l -c 'echo $PATH'` + scans install dirs
+    // (~0.5-2s). Previously we did it here synchronously, which blocked
+    // the main thread until finished and delayed the `HOUSTON_ENGINE_LISTENING`
+    // banner — so the Tauri supervisor saw a longer startup and the
+    // "Starting Houston engine…" splash lingered. Kick it off on a
+    // blocking thread so bind/banner happen immediately, then await the
+    // result before `axum::serve` starts accepting so no route handler
+    // can read an unresolved PATH.
+    let path_init = tokio::task::spawn_blocking(|| {
+        houston_terminal_manager::claude_path::init();
+    });
 
     let cfg = ServerConfig::from_env();
     let listener = TcpListener::bind(cfg.bind)
@@ -44,6 +46,8 @@ async fn main() {
     write_manifest(&cfg, actual.port());
 
     // Emit the port on stdout so the desktop supervisor can parse it.
+    // Must print BEFORE any potentially-slow work so the supervisor's
+    // banner-wait timer doesn't race startup.
     println!("HOUSTON_ENGINE_LISTENING port={} token={}", actual.port(), cfg.token);
     tracing::info!(
         "houston-engine {} (protocol v{}) listening on {}",
@@ -58,6 +62,15 @@ async fn main() {
             .expect("engine state init failed"),
     );
     let app = build_router(state);
+
+    // Block on PATH resolution just before serving. DB init usually
+    // takes longer than `zsh -l`, so this await is typically a no-op.
+    // If PATH init panicked, log and continue with whatever the OnceLock
+    // holds — routes fall back to the process PATH, which is degraded
+    // but not fatal.
+    if let Err(e) = path_init.await {
+        tracing::warn!("[boot] claude_path::init panicked: {e}");
+    }
 
     if let Err(err) = axum::serve(listener, app).await {
         tracing::error!("server error: {err}");

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -412,9 +412,13 @@ export class HoustonClient {
   // ---------- attachments ----------
 
   saveAttachments(scopeId: string, files: AttachmentInput[]): Promise<string[]> {
+    // Wire contract is camelCase (server uses `#[serde(rename_all = "camelCase")]`
+    // on `SaveAttachmentsRequest` + `AttachmentInput`). Previously sent
+    // `scope_id` / `data_base64` snake_case, which the server rejected with
+    // 422 Unprocessable Entity — drag-and-drop file uploads broke silently.
     return this.request("POST", "/attachments", {
-      scope_id: scopeId,
-      files: files.map((f) => ({ name: f.name, data_base64: f.dataBase64 })),
+      scopeId,
+      files: files.map((f) => ({ name: f.name, dataBase64: f.dataBase64 })),
     });
   }
   deleteAttachments(scopeId: string): Promise<void> {


### PR DESCRIPTION
Two fixes before shipping v0.4.0.

- Attachments POST returned 422 because `SaveAttachmentsRequest` is camelCase on the server but the client sent snake_case. Drag-and-drop upload broken.
- Engine `claude_path::init()` was blocking the banner by ~1-2s. Move to `tokio::task::spawn_blocking` so TCP bind/banner fire immediately while PATH resolution runs in parallel. `await` the handle before `axum::serve` so routes still can't read an unresolved PATH.