### PR TITLE
ci(release): auto-generate grouped changelog for draft releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,13 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Full history + all tags so the release-notes step can diff
+          # against the previous release tag (`git log <prev>..HEAD`).
+          # Default is shallow depth=1 with no tags, which would make the
+          # notes builder fall through to the HEAD~50 fallback every time.
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -265,6 +272,72 @@ jobs:
             > checksums-sha256.txt
           cat checksums-sha256.txt
 
+      # Build `release-notes.md` by grouping conventional-commit subjects
+      # between the previous tag and HEAD.
+      #
+      # We do commit-based, not PR-based, grouping because:
+      #   - squash-merge policy means 1 commit ≈ 1 logical change
+      #   - direct tag pushes (hotfixes, version bumps) are included
+      #   - no dependency on GitHub's release-notes generator which can
+      #     rate-limit, change format, or surface unwanted contributor
+      #     spam
+      #
+      # Sections:
+      #   - Features         (feat, feat(scope))
+      #   - Fixes            (fix)
+      #   - Docs             (docs)
+      #   - CI & infra       (ci)
+      #   - Changes          (refactor, perf, style, test — short list)
+      # `chore:` and version-bump commits are intentionally hidden.
+      #
+      # Uses `git tag --sort=-v:refname` to find the previous semver
+      # release; falls back to HEAD~50 if this is the first one.
+      - name: Build release notes
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          PREV_TAG=$(git tag --sort=-v:refname --list 'v*' | grep -v "^${GITHUB_REF_NAME}$" | head -1)
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag; diffing against HEAD~50"
+            RANGE="HEAD~50..HEAD"
+            COMPARE=""
+          else
+            RANGE="$PREV_TAG..HEAD"
+            COMPARE="**Full changelog**: https://github.com/${{ github.repository }}/compare/$PREV_TAG...${GITHUB_REF_NAME}"
+          fi
+
+          section() {
+            local title="$1"; shift
+            local pattern="$1"; shift
+            local matches
+            matches=$(git log "$RANGE" --no-merges --pretty='- %s' | grep -E "^- ($pattern)(\([^)]+\))?:" || true)
+            if [ -n "$matches" ]; then
+              printf '\n### %s\n\n%s\n' "$title" "$matches"
+            fi
+          }
+
+          {
+            echo "## Houston v$VERSION"
+            section "Features"  "feat"
+            section "Fixes"     "fix"
+            section "Docs"      "docs"
+            section "CI & infra" "ci"
+            section "Changes"   "refactor|perf|style|test"
+            echo
+            # Keep the upgrade reminder everyone needs — drag-install
+            # doesn't reliably replace a running .app.
+            echo "### Before you upgrade"
+            echo ""
+            echo "- Quit Houston before installing. macOS doesn't always replace a running app. If in doubt: \`rm -rf /Applications/Houston.app\` and drag the new copy in."
+            echo ""
+            if [ -n "$COMPARE" ]; then
+              echo "$COMPARE"
+            fi
+          } > release-notes.md
+
+          echo "----- release-notes.md -----"
+          cat release-notes.md
+          echo "----- end -----"
+
       - name: Generate updater manifest
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
@@ -307,7 +380,7 @@ jobs:
 
           gh release create "$GITHUB_REF_NAME" \
             --title "Houston v$VERSION" \
-            --notes "See the assets to download and install this version." \
+            --notes-file release-notes.md \
             --draft \
             "${{ steps.artifacts.outputs.dmg }}" \
             "${{ steps.artifacts.outputs.tar }}" \
@@ -315,4 +388,4 @@ jobs:
             latest.json \
             checksums-sha256.txt
 
-          echo "::notice::Draft release created — publish at https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
+          echo "::notice::Draft release created — review notes then publish at https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"


### PR DESCRIPTION
Replace the placeholder "See the assets to download..." notes with a conv-commit-grouped changelog built from `git log <prev-tag>..HEAD`. Features / Fixes / Docs / CI & infra / Changes. `chore:` hidden. Release stays draft so author can still edit before publishing.