### PR TITLE
ci(release): prefer author-written notes at .github/release-notes/<ver>.md

### DIFF
--- a/.github/release-notes/0.4.0.md
+++ b/.github/release-notes/0.4.0.md
@@ -1,0 +1,23 @@
+## Houston 0.4.0
+
+First release on the new engine architecture.
+
+### What's new
+
+- Product prompts now live in the app, engine is a standalone platform binary
+- Data consolidates under `~/.houston/` (workspaces move out of `~/Documents/Houston/` automatically on first launch)
+- Real-time reactivity restored — the board updates live when agents write files
+- Race-free engine startup + sidecar signing + notarization verified in CI
+- Drag-and-drop file attachments fixed
+- Onboarding detects your Claude/Codex CLI from any standard install location
+- Routines tab auto-detects your timezone (change it in Settings)
+
+### Before you upgrade
+
+- Quit Houston before installing. macOS doesn't always replace a running app. If in doubt: `rm -rf /Applications/Houston.app` and drag the new copy in.
+- Your workspaces will move from `~/Documents/Houston/` to `~/.houston/workspaces/` on first launch. The old location stays as a backup.
+- If you have custom scripts pointing at the old path, update them.
+
+### Known limitations
+
+- Claude and Codex CLIs must still be installed separately. Bundled-CLI install is coming in a later release.

--- a/.github/release-notes/README.md
+++ b/.github/release-notes/README.md
@@ -1,0 +1,44 @@
+# Release notes
+
+Drop a `<version>.md` file in this directory before tagging a release.
+The CI workflow (`.github/workflows/release.yml`) reads
+`.github/release-notes/<version>.md` and uses it verbatim as the
+GitHub release body. Filename matches the tag minus the leading `v`:
+
+| Tag      | File                                |
+| -------- | ----------------------------------- |
+| `v0.4.0` | `.github/release-notes/0.4.0.md`    |
+| `v0.4.1` | `.github/release-notes/0.4.1.md`    |
+| `v1.0.0` | `.github/release-notes/1.0.0.md`    |
+
+If no file is present, the workflow auto-generates a changelog from
+conventional-commit subjects between the previous tag and HEAD —
+useful for quick hotfixes that don't justify hand-written notes.
+
+## What good notes look like
+
+Every release a non-technical user sees should explain:
+
+1. **What changed for them.** Plain language, not commit subjects.
+2. **What to do before upgrading.** Quit-the-app reminder, manual
+   migration steps, etc. Always include the macOS drag-install
+   caveat — it bites every release.
+3. **Known limitations.** Things the user might hit and wonder why
+   they're broken.
+
+The release ships as a *draft*, so the author can still polish in
+the GitHub UI before clicking Publish. The file in this directory is
+the starting point, not the final word.
+
+## Workflow
+
+1. Land all changes on `main` via the normal PR flow.
+2. Bump version in `app/src-tauri/Cargo.toml`, `app/houston-tauri/Cargo.toml`,
+   `app/package.json`, `package.json`.
+3. Write `.github/release-notes/<version>.md` (or skip if you want the
+   auto-fallback).
+4. Commit + push `main`.
+5. `git tag v<version> && git push origin v<version>` — CI builds,
+   signs, notarizes, creates a draft release with your notes.
+6. Smoke-test the draft DMG.
+7. Edit the draft notes if needed, then click Publish.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,67 +272,72 @@ jobs:
             > checksums-sha256.txt
           cat checksums-sha256.txt
 
-      # Build `release-notes.md` by grouping conventional-commit subjects
-      # between the previous tag and HEAD.
+      # Resolve `release-notes.md`. Two paths:
       #
-      # We do commit-based, not PR-based, grouping because:
-      #   - squash-merge policy means 1 commit ≈ 1 logical change
-      #   - direct tag pushes (hotfixes, version bumps) are included
-      #   - no dependency on GitHub's release-notes generator which can
-      #     rate-limit, change format, or surface unwanted contributor
-      #     spam
+      # 1. Author-written notes at `.github/release-notes/<version>.md`
+      #    — preferred. Whoever drives the release (Claude in our flow,
+      #    or a human) drops a markdown file alongside the version-bump
+      #    commit, tagged commit, etc. Used verbatim.
       #
-      # Sections:
-      #   - Features         (feat, feat(scope))
-      #   - Fixes            (fix)
-      #   - Docs             (docs)
-      #   - CI & infra       (ci)
-      #   - Changes          (refactor, perf, style, test — short list)
-      # `chore:` and version-bump commits are intentionally hidden.
+      # 2. Auto-generated fallback grouping conventional-commit subjects
+      #    in `git log <prev-tag>..HEAD` by prefix:
+      #      Features (feat) / Fixes (fix) / Docs (docs) /
+      #      CI & infra (ci) / Changes (refactor|perf|style|test)
+      #    `chore:` and untyped commits are hidden. Use this when a fast
+      #    hotfix doesn't justify hand-written notes.
       #
-      # Uses `git tag --sort=-v:refname` to find the previous semver
-      # release; falls back to HEAD~50 if this is the first one.
+      # Either way the release stays a draft, so the author can still
+      # polish before publishing.
       - name: Build release notes
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
-          PREV_TAG=$(git tag --sort=-v:refname --list 'v*' | grep -v "^${GITHUB_REF_NAME}$" | head -1)
-          if [ -z "$PREV_TAG" ]; then
-            echo "No previous tag; diffing against HEAD~50"
-            RANGE="HEAD~50..HEAD"
-            COMPARE=""
+          AUTHORED=".github/release-notes/${VERSION}.md"
+
+          if [ -f "$AUTHORED" ]; then
+            echo "Using author-written notes from $AUTHORED"
+            cp "$AUTHORED" release-notes.md
           else
-            RANGE="$PREV_TAG..HEAD"
-            COMPARE="**Full changelog**: https://github.com/${{ github.repository }}/compare/$PREV_TAG...${GITHUB_REF_NAME}"
+            echo "No $AUTHORED — falling back to auto-generated changelog"
+
+            PREV_TAG=$(git tag --sort=-v:refname --list 'v*' | grep -v "^${GITHUB_REF_NAME}$" | head -1)
+            if [ -z "$PREV_TAG" ]; then
+              echo "No previous tag; diffing against HEAD~50"
+              RANGE="HEAD~50..HEAD"
+              COMPARE=""
+            else
+              RANGE="$PREV_TAG..HEAD"
+              COMPARE="**Full changelog**: https://github.com/${{ github.repository }}/compare/$PREV_TAG...${GITHUB_REF_NAME}"
+            fi
+
+            section() {
+              local title="$1"; shift
+              local pattern="$1"; shift
+              local matches
+              matches=$(git log "$RANGE" --no-merges --pretty='- %s' | grep -E "^- ($pattern)(\([^)]+\))?:" || true)
+              if [ -n "$matches" ]; then
+                printf '\n### %s\n\n%s\n' "$title" "$matches"
+              fi
+            }
+
+            {
+              echo "## Houston v$VERSION"
+              section "Features"  "feat"
+              section "Fixes"     "fix"
+              section "Docs"      "docs"
+              section "CI & infra" "ci"
+              section "Changes"   "refactor|perf|style|test"
+              echo
+              # Keep the upgrade reminder everyone needs — drag-install
+              # doesn't reliably replace a running .app.
+              echo "### Before you upgrade"
+              echo ""
+              echo "- Quit Houston before installing. macOS doesn't always replace a running app. If in doubt: \`rm -rf /Applications/Houston.app\` and drag the new copy in."
+              echo ""
+              if [ -n "$COMPARE" ]; then
+                echo "$COMPARE"
+              fi
+            } > release-notes.md
           fi
-
-          section() {
-            local title="$1"; shift
-            local pattern="$1"; shift
-            local matches
-            matches=$(git log "$RANGE" --no-merges --pretty='- %s' | grep -E "^- ($pattern)(\([^)]+\))?:" || true)
-            if [ -n "$matches" ]; then
-              printf '\n### %s\n\n%s\n' "$title" "$matches"
-            fi
-          }
-
-          {
-            echo "## Houston v$VERSION"
-            section "Features"  "feat"
-            section "Fixes"     "fix"
-            section "Docs"      "docs"
-            section "CI & infra" "ci"
-            section "Changes"   "refactor|perf|style|test"
-            echo
-            # Keep the upgrade reminder everyone needs — drag-install
-            # doesn't reliably replace a running .app.
-            echo "### Before you upgrade"
-            echo ""
-            echo "- Quit Houston before installing. macOS doesn't always replace a running app. If in doubt: \`rm -rf /Applications/Houston.app\` and drag the new copy in."
-            echo ""
-            if [ -n "$COMPARE" ]; then
-              echo "$COMPARE"
-            fi
-          } > release-notes.md
 
           echo "----- release-notes.md -----"
           cat release-notes.md


### PR DESCRIPTION
Replace the auto-changelog default with: prefer `.github/release-notes/<version>.md` if present, fall back to auto-grouped commits otherwise. Author (you, me, whoever) writes notes alongside the version bump; CI uses them verbatim. Seeded with the v0.4.0 notes you wrote today plus a README documenting the convention.