### PR TITLE
docs: flag engine sidecar staleness in dev workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,6 +109,12 @@ Ask: "Ready to commit? (yes/no/skip)" **STOP.** Yes → stage specific files, co
 | app/ | `cd app && pnpm tsc --noEmit` | `cd app/src-tauri && cargo check` | `cd app && pnpm tauri build` |
 | app/ i18n | `cd app && pnpm check-locales` | — | — |
 
+### Engine sidecar staleness (dev only)
+
+`pnpm tauri dev` spawns the engine as a subprocess from `app/src-tauri/binaries/houston-engine-<triple>`, which `build.rs` stages from `target/{debug,release}/houston-engine`. Tauri does NOT rebuild the engine on its own — frontend HMR works fine but the sidecar is whatever binary was last compiled.
+
+**Rule**: any time a PR touches `engine/**` (including merges that bring engine changes from `main`), run `cargo build -p houston-engine-server` BEFORE the next `pnpm tauri dev` and restart it. Symptoms of a stale sidecar: 404s on routes that exist in the current source, missing event types, schema mismatches. Production users never hit this — release CI builds the engine from scratch on every tag.
+
 ---
 
 ## Hard rules (ALWAYS)


### PR DESCRIPTION
Adds a CLAUDE.md note about `pnpm tauri dev` not rebuilding the engine. Caught us this week after merging PR #28's tunnel routes — symptom is a 404 on routes that exist in source.