### PR TITLE
fix(board): clearer Needs You action — icon-only "Move to done" + tooltips

### DIFF
--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -26,12 +26,22 @@ import { useDetailPanelContainer } from "./shell/detail-panel-context";
 import { AgentMiniAvatar, HoustonThinkingIndicator } from "./shell/experience-card";
 
 export function Dashboard() {
-  const { t } = useTranslation(["dashboard", "common"]);
+  const { t } = useTranslation(["dashboard", "board", "common"]);
   const MC_COLUMNS: KanbanColumnConfig[] = [
     { id: "running", label: t("dashboard:columns.running"), statuses: ["running"] },
     { id: "needs_you", label: t("dashboard:columns.needsYou"), statuses: ["needs_you"] },
     { id: "done", label: t("dashboard:columns.done"), statuses: ["done", "cancelled"] },
   ];
+  // Card-action tooltips (Approve / Rename / Delete) — shared with the
+  // per-agent board tab so the affordance reads the same everywhere.
+  const cardLabels = {
+    approve: t("board:cardActions.approve"),
+    approveTooltip: t("board:cardActions.approveTooltip"),
+    renameTooltip: t("board:cardActions.renameTooltip"),
+    deleteTooltip: t("board:cardActions.deleteTooltip"),
+    deleteTitle: (name: string) => t("board:deleteCard.titleWithName", { name }),
+    deleteDescription: t("board:deleteCard.description"),
+  };
   const panelContainer = useDetailPanelContainer();
   const agents = useAgentStore((s) => s.agents);
   const setDialogOpen = useUIStore((s) => s.setCreateAgentDialogOpen);
@@ -200,6 +210,7 @@ export function Dashboard() {
             )
           }
           thinkingIndicator={<HoustonThinkingIndicator />}
+          cardLabels={cardLabels}
         />
       </div>
 

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -61,6 +61,9 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
   const { t } = useTranslation(["board", "dashboard"]);
   const cardLabels = {
     approve: t("board:cardActions.approve"),
+    approveTooltip: t("board:cardActions.approveTooltip"),
+    renameTooltip: t("board:cardActions.renameTooltip"),
+    deleteTooltip: t("board:cardActions.deleteTooltip"),
     deleteTitle: (name: string) => t("board:deleteCard.titleWithName", { name }),
     deleteDescription: t("board:deleteCard.description"),
   };

--- a/app/src/locales/en/board.json
+++ b/app/src/locales/en/board.json
@@ -2,7 +2,10 @@
   "cardActions": {
     "run": "Run",
     "openTerminal": "Open terminal in worktree",
-    "approve": "Approve"
+    "approve": "Move to done",
+    "approveTooltip": "Move to done",
+    "renameTooltip": "Change title",
+    "deleteTooltip": "Delete"
   },
   "deleteCard": {
     "titleWithName": "Delete \"{{name}}\"?",

--- a/app/src/locales/es/board.json
+++ b/app/src/locales/es/board.json
@@ -2,7 +2,10 @@
   "cardActions": {
     "run": "Ejecutar",
     "openTerminal": "Abrir la terminal en el worktree",
-    "approve": "Aprobar"
+    "approve": "Mover a Listo",
+    "approveTooltip": "Mover a Listo",
+    "renameTooltip": "Cambiar título",
+    "deleteTooltip": "Eliminar"
   },
   "deleteCard": {
     "titleWithName": "¿Eliminar \"{{name}}\"?",

--- a/app/src/locales/pt/board.json
+++ b/app/src/locales/pt/board.json
@@ -2,7 +2,10 @@
   "cardActions": {
     "run": "Executar",
     "openTerminal": "Abrir o terminal no worktree",
-    "approve": "Aprovar"
+    "approve": "Mover para Pronto",
+    "approveTooltip": "Mover para Pronto",
+    "renameTooltip": "Mudar título",
+    "deleteTooltip": "Excluir"
   },
   "deleteCard": {
     "titleWithName": "Excluir \"{{name}}\"?",

--- a/ui/board/src/kanban-card.tsx
+++ b/ui/board/src/kanban-card.tsx
@@ -4,14 +4,22 @@ import { Trash2, CheckCircle, Pencil } from "lucide-react"
 import type { KanbanItem } from "./types"
 
 export interface KanbanCardLabels {
+  /** @deprecated kept for backward-compat. Was the visible Approve pill text;
+   *  the action is now an icon-only button with `approveTooltip`. */
   approve?: string
+  approveTooltip?: string
+  renameTooltip?: string
+  deleteTooltip?: string
   /** Delete confirm title, `{name}` substituted with `item.title`. */
   deleteTitle?: (name: string) => string
   deleteDescription?: string
 }
 
 const DEFAULT_LABELS: Required<KanbanCardLabels> = {
-  approve: "Approve",
+  approve: "Move to done",
+  approveTooltip: "Move to done",
+  renameTooltip: "Change title",
+  deleteTooltip: "Delete",
   deleteTitle: (name) => `Delete "${name}"?`,
   deleteDescription: "This item and its history will be permanently removed.",
 }
@@ -105,11 +113,22 @@ export function KanbanCard({
             )}
           </div>
           <div className="flex items-center gap-0.5 shrink-0">
+            {!actions && isNeedsApproval && onApprove && (
+              <button
+                onClick={(e) => { e.stopPropagation(); onApprove() }}
+                className="p-1 rounded-md text-[#00a240]/70 hover:text-[#00a240] hover:bg-[#00a240]/10 transition-colors duration-200"
+                aria-label={l.approveTooltip}
+                title={l.approveTooltip}
+              >
+                <CheckCircle className="size-3" />
+              </button>
+            )}
             {onRename && (
               <button
                 onClick={handleRenameClick}
                 className="p-1 rounded-md text-muted-foreground/40 hover:text-foreground hover:bg-accent transition-colors duration-200"
-                aria-label={`Rename ${item.title}`}
+                aria-label={l.renameTooltip}
+                title={l.renameTooltip}
               >
                 <Pencil className="size-3" />
               </button>
@@ -118,7 +137,8 @@ export function KanbanCard({
               <button
                 onClick={handleDeleteClick}
                 className="p-1 rounded-md text-muted-foreground/40 hover:text-destructive hover:bg-destructive/10 transition-colors duration-200"
-                aria-label={`Delete ${item.title}`}
+                aria-label={l.deleteTooltip}
+                title={l.deleteTooltip}
               >
                 <Trash2 className="size-3" />
               </button>
@@ -153,8 +173,10 @@ export function KanbanCard({
           </p>
         )}
 
-        {/* Footer: tags + actions */}
-        {(item.tags?.length || actions || (isNeedsApproval && onApprove)) && (
+        {/* Footer: tags + custom actions. The Approve action moved to the
+           top-right icon row (see above) so it's visually consistent with
+           Rename / Delete and the tooltip explains exactly what it does. */}
+        {(item.tags?.length || actions) && (
           <div className="flex items-center justify-between mt-2.5">
             <div className="flex items-center gap-1 flex-wrap min-w-0">
               {item.tags?.map((tag) => (
@@ -168,18 +190,6 @@ export function KanbanCard({
             </div>
             <div className="shrink-0">
               {actions}
-              {!actions && isNeedsApproval && onApprove && (
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    onApprove()
-                  }}
-                  className="flex items-center gap-0.5 h-5 pl-1 pr-2 rounded-full bg-primary text-primary-foreground text-[10px] font-medium hover:bg-primary/85 transition-colors duration-200"
-                >
-                  <CheckCircle className="size-2.5" />
-                  {l.approve}
-                </button>
-              )}
             </div>
           </div>
         )}


### PR DESCRIPTION
## Summary

Users were confused by the bottom-right \`Approve\` pill on Needs You cards — they thought clicking it sent a message to the agent. It actually just moves the card to Done.

- Approve action moves to the top-right icon row alongside Rename and Delete (CheckCircle, green hover).
- All three icon buttons get native \`title\` tooltips: "Move to done" / "Change title" / "Delete".
- Default text changed: "Approve" → "Move to done" (matches the actual behavior).
- Translated to es / pt.
- Both Mission Control and the per-agent Activity tab pick up the new labels.

## Test plan
- [x] \`pnpm -r typecheck\` clean (ui/board + app)
- [x] \`pnpm check-locales\` clean
- [ ] Manual: Needs You card on either surface — hover Approve icon, see "Move to done" tooltip; click, card moves to Done

🤖 Generated with [Claude Code](https://claude.com/claude-code)