### PR TITLE
fix(board): instant Radix tooltips + plain Check icon

### DIFF
--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -7,6 +7,7 @@ import {
 import { createRoot } from "react-dom/client";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { I18nextProvider } from "react-i18next";
+import { TooltipProvider } from "@houston-ai/core";
 import { queryClient } from "./lib/query-client";
 import App from "./App";
 import "./styles/globals.css";
@@ -135,15 +136,17 @@ function EngineGate({ children }: { children: ReactNode }) {
 createRoot(document.getElementById("root")!).render(
   <QueryClientProvider client={queryClient}>
     <ErrorBoundary>
-      <EngineGate>
-        <I18nextProvider i18n={i18n}>
-          <LanguageGate>
-            <DisclaimerGate>
-              <App />
-            </DisclaimerGate>
-          </LanguageGate>
-        </I18nextProvider>
-      </EngineGate>
+      <TooltipProvider>
+        <EngineGate>
+          <I18nextProvider i18n={i18n}>
+            <LanguageGate>
+              <DisclaimerGate>
+                <App />
+              </DisclaimerGate>
+            </LanguageGate>
+          </I18nextProvider>
+        </EngineGate>
+      </TooltipProvider>
     </ErrorBoundary>
   </QueryClientProvider>,
 );

--- a/ui/board/src/kanban-card.tsx
+++ b/ui/board/src/kanban-card.tsx
@@ -1,6 +1,12 @@
 import { useState, useRef, useEffect } from "react"
-import { cn, ConfirmDialog } from "@houston-ai/core"
-import { Trash2, CheckCircle, Pencil } from "lucide-react"
+import {
+  cn,
+  ConfirmDialog,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@houston-ai/core"
+import { Trash2, Check, Pencil } from "lucide-react"
 import type { KanbanItem } from "./types"
 
 export interface KanbanCardLabels {
@@ -114,34 +120,46 @@ export function KanbanCard({
           </div>
           <div className="flex items-center gap-0.5 shrink-0">
             {!actions && isNeedsApproval && onApprove && (
-              <button
-                onClick={(e) => { e.stopPropagation(); onApprove() }}
-                className="p-1 rounded-md text-[#00a240]/70 hover:text-[#00a240] hover:bg-[#00a240]/10 transition-colors duration-200"
-                aria-label={l.approveTooltip}
-                title={l.approveTooltip}
-              >
-                <CheckCircle className="size-3" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={(e) => { e.stopPropagation(); onApprove() }}
+                    className="p-1 rounded-md text-muted-foreground/40 hover:text-[#00a240] hover:bg-[#00a240]/10 transition-colors duration-200"
+                    aria-label={l.approveTooltip}
+                  >
+                    <Check className="size-3" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">{l.approveTooltip}</TooltipContent>
+              </Tooltip>
             )}
             {onRename && (
-              <button
-                onClick={handleRenameClick}
-                className="p-1 rounded-md text-muted-foreground/40 hover:text-foreground hover:bg-accent transition-colors duration-200"
-                aria-label={l.renameTooltip}
-                title={l.renameTooltip}
-              >
-                <Pencil className="size-3" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={handleRenameClick}
+                    className="p-1 rounded-md text-muted-foreground/40 hover:text-foreground hover:bg-accent transition-colors duration-200"
+                    aria-label={l.renameTooltip}
+                  >
+                    <Pencil className="size-3" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">{l.renameTooltip}</TooltipContent>
+              </Tooltip>
             )}
             {onDelete && (
-              <button
-                onClick={handleDeleteClick}
-                className="p-1 rounded-md text-muted-foreground/40 hover:text-destructive hover:bg-destructive/10 transition-colors duration-200"
-                aria-label={l.deleteTooltip}
-                title={l.deleteTooltip}
-              >
-                <Trash2 className="size-3" />
-              </button>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    onClick={handleDeleteClick}
+                    className="p-1 rounded-md text-muted-foreground/40 hover:text-destructive hover:bg-destructive/10 transition-colors duration-200"
+                    aria-label={l.deleteTooltip}
+                  >
+                    <Trash2 className="size-3" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top">{l.deleteTooltip}</TooltipContent>
+              </Tooltip>
             )}
           </div>
         </div>


### PR DESCRIPTION
## Summary

User feedback on the previous icon-only Approve change:
- Native \`title\` tooltips were slow (OS controls ~500ms+). Replaced with Radix Tooltip (\`delayDuration=0\`) — instant.
- Tooltips now appear **above** the button (\`side=\"top\"\`).
- \`CheckCircle\` swapped for plain \`Check\` to match the visual weight of \`Pencil\` and \`Trash2\`.
- Approve icon is now gray by default (matches Rename and Delete), only turns green on hover.

\`TooltipProvider\` is mounted once in \`main.tsx\` so every component below gets tooltip context for free.

## Test plan
- [x] \`pnpm -r typecheck\` clean
- [ ] Hover any of the three icons on a Needs You card → tooltip appears instantly above the button

🤖 Generated with [Claude Code](https://claude.com/claude-code)