### PR TITLE
fix(dashboard): Mission Control parity with per-agent board (history + rename)

### DIFF
--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -188,8 +188,10 @@ export function Dashboard() {
           isLoading={mc.loading}
           onDelete={mc.handleDelete}
           onApprove={mc.handleApprove}
+          onRename={mc.handleRename}
           onSendMessage={mc.handleSendMessage}
           onLoadHistory={mc.loadHistory}
+          onHistoryLoaded={mc.handleHistoryLoaded}
           emptyState={emptyBoard}
           panelContainer={panelContainer}
           onPanelOpenChange={setMissionPanelOpen}

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -98,6 +98,38 @@ export function useMissionControl(agents: Agent[]) {
     [],
   );
 
+  const handleRename = useCallback(
+    async (item: KanbanItem, newTitle: string) => {
+      const agentPath = pathMapRef.current[item.id];
+      if (!agentPath) return;
+      await tauriActivity.update(agentPath, item.id, { title: newTitle });
+    },
+    [],
+  );
+
+  const setFeed = useFeedStore((s) => s.setFeed);
+  const handleHistoryLoaded = useCallback(
+    (sessionKey: string, history: FeedItem[]) => {
+      // Mirror board-tab's hydration: when AIBoard loads persisted chat
+      // for an activity, drop the server slice into the feed store so
+      // the ChatPanel renders it. Without this Mission Control would
+      // open a conversation and show an empty chat (history was loaded
+      // but had nowhere to land).
+      const activityId = sessionKey.replace("activity-", "");
+      const agentPath = pathMapRef.current[activityId];
+      if (!agentPath) return;
+      const current = useFeedStore.getState().items[agentPath]?.[sessionKey] ?? [];
+      // Server history is authoritative for what's persisted; anything
+      // currently in `current` that isn't on the server is either an
+      // optimistic overlay we pushed or a WS event that landed
+      // mid-load. Append those after the server slice.
+      const serverIds = new Set(history.map((it) => JSON.stringify(it)));
+      const tail = current.filter((it) => !serverIds.has(JSON.stringify(it)));
+      setFeed(agentPath, sessionKey, [...history, ...tail]);
+    },
+    [setFeed],
+  );
+
   const handleSendMessage = useCallback(
     async (sessionKey: string, text: string, files: File[]) => {
       const activityId = sessionKey.replace("activity-", "");
@@ -137,8 +169,10 @@ export function useMissionControl(agents: Agent[]) {
     loading,
     feedItems,
     loadHistory,
+    handleHistoryLoaded,
     handleDelete,
     handleApprove,
+    handleRename,
     handleSendMessage,
     handleCreate,
   };


### PR DESCRIPTION
## Summary

Two bugs reported on Mission Control:
1. Opening a conversation showed an empty chat — history loaded but had nowhere to land.
2. Couldn't rename a card.

Root cause: \`dashboard.tsx\` and \`board-tab.tsx\` each wire their own AIBoard props. When PR #28 added \`onHistoryLoaded\` (replacing the old liveFeed hack), only \`board-tab\` was updated. Same story for \`onRename\` — added to per-agent board months ago, never to Mission Control.

This PR adds \`handleHistoryLoaded\` and \`handleRename\` to \`useMissionControl\` and wires them in \`dashboard.tsx\`.

## Architectural note

Both surfaces use AIBoard but compose props through different hooks. Whenever AIBoard gains a new prop, both consumers need to wire it — that's the source of drift. Future cleanup candidate: \`useBoardSurfaceProps\` hook so the two stay in lock-step.

## Test plan
- [x] \`pnpm tsc --noEmit\` clean
- [ ] Mission Control: click a conversation card → chat history renders
- [ ] Mission Control: pencil icon on a card → inline rename works → title persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)