### PR TITLE
feat(app): functional bug-report toast with friendly Houston copy

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@
 #   POSTHOG_HOST                       — PostHog ingest host (e.g. https://us.i.posthog.com)
 #   SUPABASE_URL                       — Supabase project URL
 #   SUPABASE_ANON_KEY                  — Supabase anon key (client-side, RLS-gated)
+#   SLACK_BUG_WEBHOOK_URL              — Slack incoming-webhook for in-app "Report bug" button
 #   SENTRY_DSN                         — Sentry crash reporting DSN
 
 name: Release
@@ -155,6 +156,7 @@ jobs:
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SLACK_BUG_WEBHOOK_URL: ${{ secrets.SLACK_BUG_WEBHOOK_URL }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Locate build artifacts

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -154,8 +154,8 @@ export default function App() {
 
   const mappedToasts: Toast[] = toasts.map((t) => ({
     id: t.id,
-    message: t.description ? `${t.title}: ${t.description}` : t.title,
-    variant: (t.title.startsWith("Error") ? "error" : "info") as Toast["variant"],
+    message: t.description ? `${t.title} ${t.description}` : t.title,
+    variant: t.variant ?? "info",
     action: t.action,
   }));
 

--- a/app/src/lib/bug-report.ts
+++ b/app/src/lib/bug-report.ts
@@ -1,17 +1,19 @@
 import { osReadRecentLogs } from "./os-bridge";
 
-const SLACK_WEBHOOK_URL = "https://hooks.slack.com/services/PLACEHOLDER";
+declare const __SLACK_BUG_WEBHOOK__: string;
+const WEBHOOK_URL =
+  typeof __SLACK_BUG_WEBHOOK__ !== "undefined" ? __SLACK_BUG_WEBHOOK__ : "";
 
 interface BugReportContext {
   command: string;
   error: string;
   spaceName?: string;
   workspaceName?: string;
+  userEmail?: string | null;
   timestamp: string;
   appVersion: string;
 }
 
-/** Fetch the last N lines from backend + frontend log files. */
 async function getRecentLogs(lines = 50): Promise<{ backend: string; frontend: string }> {
   try {
     return await osReadRecentLogs(lines);
@@ -21,6 +23,12 @@ async function getRecentLogs(lines = 50): Promise<{ backend: string; frontend: s
 }
 
 export async function reportBug(context: BugReportContext): Promise<void> {
+  if (!WEBHOOK_URL) {
+    throw new Error(
+      "Bug reporting not configured (missing SLACK_BUG_WEBHOOK_URL at build time)",
+    );
+  }
+
   const logs = await getRecentLogs();
 
   const fields = [
@@ -29,6 +37,9 @@ export async function reportBug(context: BugReportContext): Promise<void> {
     { title: "App Version", value: context.appVersion, short: true },
   ];
 
+  if (context.userEmail) {
+    fields.push({ title: "User", value: context.userEmail, short: true });
+  }
   if (context.spaceName) {
     fields.push({ title: "Space", value: context.spaceName, short: true });
   }
@@ -36,7 +47,6 @@ export async function reportBug(context: BugReportContext): Promise<void> {
     fields.push({ title: "Workspace", value: context.workspaceName, short: true });
   }
 
-  // Truncate logs to fit Slack's 3000 char limit per field
   const truncate = (s: string, max: number) =>
     s.length > max ? `...\n${s.slice(-max)}` : s;
 
@@ -63,7 +73,7 @@ export async function reportBug(context: BugReportContext): Promise<void> {
     ],
   };
 
-  const response = await fetch(SLACK_WEBHOOK_URL, {
+  const response = await fetch(WEBHOOK_URL, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(payload),

--- a/app/src/lib/current-user.ts
+++ b/app/src/lib/current-user.ts
@@ -1,0 +1,30 @@
+import { supabase, isAuthConfigured } from "./supabase";
+
+/**
+ * Synchronous accessor for the signed-in user's email. Returns `null`
+ * when signed out or when Supabase isn't configured (dev builds without
+ * SUPABASE_URL).
+ *
+ * Why a module-level cache instead of `supabase.auth.getSession()`:
+ * call sites are inside non-async UI callbacks (toast actions) and
+ * Slack webhook payload construction. The cache is kept fresh by
+ * subscribing once to `onAuthStateChange` at module load, mirroring
+ * how `useSession` keeps the React tree in sync.
+ */
+let cachedEmail: string | null = null;
+
+if (isAuthConfigured()) {
+  // Seed from any persisted session so reports fired before the first
+  // auth-state event still carry the email.
+  supabase.auth.getSession().then(({ data }) => {
+    cachedEmail = data.session?.user?.email ?? null;
+  });
+
+  supabase.auth.onAuthStateChange((_event, session) => {
+    cachedEmail = session?.user?.email ?? null;
+  });
+}
+
+export function getCurrentUserEmail(): string | null {
+  return cachedEmail;
+}

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -1,0 +1,46 @@
+import { useUIStore } from "../stores/ui";
+import { reportBug } from "./bug-report";
+import { getCurrentUserEmail } from "./current-user";
+
+/**
+ * Surface an error to the user as a toast with a working "Report bug" action.
+ * `command` is a short machine-readable tag (e.g. "list_workspaces",
+ * "uncaught_error") that goes into the Slack payload for triage.
+ */
+export function showErrorToast(command: string, message: string): void {
+  const timestamp = new Date().toISOString();
+  const addToast = useUIStore.getState().addToast;
+
+  addToast({
+    title: "Houston, we have a problem!",
+    description: message,
+    variant: "error",
+    action: {
+      label: "Report bug",
+      onClick: () => {
+        reportBug({
+          command,
+          error: message,
+          timestamp,
+          appVersion: __APP_VERSION__,
+          userEmail: getCurrentUserEmail(),
+        })
+          .then(() => {
+            addToast({
+              title: "Roger that, report received.",
+              description: "Mission control is on it, deploying a fix.",
+              variant: "success",
+            });
+          })
+          .catch((e) => {
+            console.error("Failed to report bug:", e);
+            addToast({
+              title: "Couldn't send report",
+              description: e instanceof Error ? e.message : String(e),
+              variant: "error",
+            });
+          });
+      },
+    },
+  });
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -53,24 +53,8 @@ async function surfaceToast(
   const message =
     err instanceof Error ? err.message : typeof err === "string" ? err : String(err);
   logger.error(`[engine:${label}] ${message}`, context ? JSON.stringify(context) : undefined);
-  const { useUIStore } = await import("../stores/ui");
-  const { reportBug } = await import("./bug-report");
-  const timestamp = new Date().toISOString();
-  useUIStore.getState().addToast({
-    title: `Error: ${label.replace(/_/g, " ")}`,
-    description: message,
-    action: {
-      label: "Report bug",
-      onClick: () => {
-        reportBug({
-          command: label,
-          error: message,
-          timestamp,
-          appVersion: __APP_VERSION__,
-        }).catch((e) => console.error("Failed to report bug:", e));
-      },
-    },
-  });
+  const { showErrorToast } = await import("./error-toast");
+  showErrorToast(label, message);
 }
 
 // ─── Workspaces ────────────────────────────────────────────────────────

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -11,12 +11,12 @@ import { TooltipProvider } from "@houston-ai/core";
 import { queryClient } from "./lib/query-client";
 import App from "./App";
 import "./styles/globals.css";
-import { useUIStore } from "./stores/ui";
 import { initFrontendLogging, logger } from "./lib/logger";
 import { whenEngineReady, isEngineReady } from "./lib/engine";
 import i18n from "./lib/i18n";
 import { DisclaimerGate } from "./components/shell/disclaimer-gate";
 import { LanguageGate } from "./components/shell/language-gate";
+import { showErrorToast } from "./lib/error-toast";
 
 // Initialize file-based logging — patches console.error/warn to write to
 // ~/.houston/logs/frontend.log (or ~/.dev-houston/logs/frontend.log in dev).
@@ -27,19 +27,13 @@ initFrontendLogging();
 window.onerror = (_event, _source, _line, _col, error) => {
   const message = error?.message ?? String(_event);
   console.error("[global:error]", message, error);
-  useUIStore.getState().addToast({
-    title: "Uncaught error",
-    description: message,
-  });
+  showErrorToast("uncaught_error", message);
 };
 
 window.onunhandledrejection = (event: PromiseRejectionEvent) => {
   const message = event.reason?.message ?? String(event.reason);
   console.error("[global:unhandledrejection]", message, event.reason);
-  useUIStore.getState().addToast({
-    title: "Unhandled promise rejection",
-    description: message,
-  });
+  showErrorToast("unhandled_rejection", message);
 };
 
 class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | null }> {
@@ -47,10 +41,7 @@ class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | 
   static getDerivedStateFromError(error: Error) { return { error }; }
   componentDidCatch(error: Error) {
     logger.error(`[react-crash] ${error.message}`, error.stack);
-    useUIStore.getState().addToast({
-      title: "React crash",
-      description: error.message,
-    });
+    showErrorToast("react_crash", error.message);
   }
   render() {
     if (this.state.error) {

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -4,6 +4,7 @@ export interface ToastItem {
   id: string;
   title: string;
   description?: string;
+  variant?: "error" | "success" | "info";
   action?: { label: string; onClick: () => void };
 }
 

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -20,6 +20,7 @@ export default defineConfig(({ mode }) => {
     ),
     __SUPABASE_URL__: JSON.stringify(env.SUPABASE_URL ?? ""),
     __SUPABASE_ANON_KEY__: JSON.stringify(env.SUPABASE_ANON_KEY ?? ""),
+    __SLACK_BUG_WEBHOOK__: JSON.stringify(env.SLACK_BUG_WEBHOOK_URL ?? ""),
   },
   clearScreen: false,
   // Exclude workspace packages from Vite's dep pre-bundling so live edits


### PR DESCRIPTION
## Summary

- Error toasts now read **"Houston, we have a problem!"** and the **Report bug** button actually posts to Slack — previously the webhook URL was a placeholder so the click was a no-op.
- Slack payload includes the signed-in user's email (sourced from the Supabase session merged in #36) so reports are attributable.
- Consolidates three duplicated error toasts (engine call failures + global `window.onerror` + `unhandledrejection` + React crash) behind a single `showErrorToast()` helper, so every error path now offers Report bug.

## Setup needed before this works

1. Create a Slack incoming webhook for the bug-report channel.
2. Add `SLACK_BUG_WEBHOOK_URL` to:
   - `app/.env.local` for local dev (gitignored).
   - GitHub Actions repo secrets so production builds pick it up via `release.yml` (already wired in this PR).

If the env var is missing the button surfaces a clear "Bug reporting not configured" toast instead of failing silently.

## UX detail

- Success toast on post: *"Roger that, report received. Mission control is on it, deploying a fix."*
- Failure toast on post: *"Couldn't send report <reason>"*
- `ToastItem` gains an explicit `variant` field; the App.tsx mapping no longer sniffs the title string.
- The `: ` joiner between toast title + description was producing awkward `"Houston, we have a problem!: ..."`. Now a single space.

## Test plan

- [ ] With `SLACK_BUG_WEBHOOK_URL` set in `app/.env.local`, force an engine call to fail (e.g. stop the engine then click around) → red toast appears with "Houston, we have a problem!" + Report bug button.
- [ ] Click Report bug → green success toast renders.
- [ ] Slack channel receives the report with Command, Timestamp, App Version, **User** (email), and last 50 lines of backend + frontend logs.
- [ ] Sign out → trigger an error → click Report bug → Slack payload omits the User field (no crash).
- [ ] With the env var unset, click Report bug → red toast: "Couldn't send report — Bug reporting not configured…".

🤖 Generated with [Claude Code](https://claude.com/claude-code)