### PR TITLE
feat: bundle codex + composio into .app, runtime-install claude-code

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,52 @@ jobs:
           mkdir -p ~/.appstoreconnect/private_keys
           echo "${{ secrets.APPLE_API_KEY_CONTENT }}" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPLE_API_KEY }}.p8
 
+      # Stage bundled CLI binaries (codex universal, composio per-arch)
+      # into `app/src-tauri/resources/bin/` so Tauri's `bundle.resources`
+      # picks them up. The fetch script:
+      #   - Downloads each CLI for both arches from URLs pinned in
+      #     cli-deps.json
+      #   - Verifies SHA-256 against pinned checksums (any mismatch
+      #     fails the release — release artifacts must be reproducible)
+      #   - lipos codex into a single universal Mach-O binary
+      #   - Prunes cross-platform composio acp-adapters that the
+      #     resolved arch can never execute (saves ~580 MB)
+      #   - Stages cli-deps.json itself so the runtime claude-code
+      #     installer can read pinned URLs + checksums offline
+      #
+      # macos-latest comes with curl + unzip + jq + lipo preinstalled.
+      # If a future runner image drops jq, install it explicitly
+      # rather than rewriting the script in a dep-free language; jq is
+      # the right tool for cli-deps.json.
+      - name: Stage bundled CLI dependencies (codex, composio)
+        run: |
+          set -euo pipefail
+          if ! command -v jq >/dev/null 2>&1; then
+            echo "::group::Installing jq (missing on runner)"
+            brew install jq
+            echo "::endgroup::"
+          fi
+          ./scripts/fetch-cli-deps.sh both
+
+          echo "=== Staged bundle ==="
+          ls -lah app/src-tauri/resources/bin/
+          echo "=== Sizes ==="
+          du -sh app/src-tauri/resources/bin/*
+
+          # Sanity: every shippable artifact must be present and the
+          # codex binary must be a fat (universal) Mach-O.
+          test -x app/src-tauri/resources/bin/codex
+          test -x app/src-tauri/resources/bin/composio-aarch64/composio
+          test -x app/src-tauri/resources/bin/composio-x86_64/composio
+          test -f app/src-tauri/resources/bin/cli-deps.json
+
+          LIPO_INFO=$(lipo -info app/src-tauri/resources/bin/codex)
+          echo "$LIPO_INFO"
+          echo "$LIPO_INFO" | grep -q 'arm64' \
+            || { echo "::error::bundled codex missing arm64 slice"; exit 1; }
+          echo "$LIPO_INFO" | grep -q 'x86_64' \
+            || { echo "::error::bundled codex missing x86_64 slice"; exit 1; }
+
       # Build the engine sidecar for BOTH macOS architectures BEFORE the
       # Tauri app build.
       #
@@ -211,6 +257,73 @@ jobs:
       # hardened-runtime-less sidecar — Gatekeeper would then quarantine-kill
       # it on first launch for upgraders and the app hangs at splash.
       # Fail the release if any of these invariants drifts.
+      # Bundled CLI invariants — codex, composio per-arch + the
+      # cli-deps.json manifest must all be present inside the
+      # `.app/Contents/Resources/bin/` tree, and every Mach-O must be
+      # signed with Developer ID + hardened runtime so Gatekeeper +
+      # subprocess execution work post-notarization.
+      #
+      # We assert every check that, if violated, would visibly break
+      # the user experience: missing files, ad-hoc signatures (Gatekeeper
+      # quarantine), missing arch slices, and broken codex universal
+      # layout. Any failure is fatal — a release where the bundled CLI
+      # works for half of users is worse than no release.
+      - name: Verify bundled CLI invariants
+        run: |
+          set -euo pipefail
+          APP="${{ steps.artifacts.outputs.app }}"
+          BIN="$APP/Contents/Resources/bin"
+
+          echo "=== 1. Bundle layout ==="
+          test -d "$BIN" || { echo "::error::Resources/bin/ missing"; exit 1; }
+          test -x "$BIN/codex" || { echo "::error::Resources/bin/codex missing or not executable"; exit 1; }
+          test -x "$BIN/composio-aarch64/composio" || { echo "::error::composio-aarch64/composio missing"; exit 1; }
+          test -x "$BIN/composio-x86_64/composio"  || { echo "::error::composio-x86_64/composio missing"; exit 1; }
+          test -f "$BIN/cli-deps.json" || { echo "::error::cli-deps.json manifest missing"; exit 1; }
+          ls -lah "$BIN"
+
+          echo "=== 2. codex is universal (arm64 + x86_64) ==="
+          LIPO=$(lipo -info "$BIN/codex")
+          echo "$LIPO"
+          echo "$LIPO" | grep -q 'arm64'  || { echo "::error::codex missing arm64 slice"; exit 1; }
+          echo "$LIPO" | grep -q 'x86_64' || { echo "::error::codex missing x86_64 slice"; exit 1; }
+
+          echo "=== 3. Mach-O binaries have Developer ID + hardened runtime ==="
+          # Walk every executable file under Resources/bin/ and assert
+          # signing invariants. We only care about Mach-O — `.mjs` /
+          # `services/` / json files don't need signatures.
+          fail=0
+          while IFS= read -r f; do
+            if file "$f" | grep -q 'Mach-O'; then
+              echo ""
+              echo "Checking: $f"
+              if ! codesign -vvv "$f" 2>&1; then
+                echo "::error::codesign verify failed: $f"
+                fail=1
+                continue
+              fi
+              AUTH=$(codesign -dvv "$f" 2>&1 | grep '^Authority=' | head -1 || echo "")
+              echo "  $AUTH"
+              if ! echo "$AUTH" | grep -q 'Developer ID Application'; then
+                echo "::error::Bundled binary not signed with Developer ID: $f"
+                codesign -dvv "$f" 2>&1 | sed 's/^/  /' || true
+                fail=1
+              fi
+              FLAGS=$(codesign -dv "$f" 2>&1 | grep -E '^CodeDirectory.*flags=' | head -1 || echo "")
+              echo "  $FLAGS"
+              if ! echo "$FLAGS" | grep -q 'runtime'; then
+                echo "::error::Bundled binary missing hardened runtime: $f"
+                fail=1
+              fi
+            fi
+          done < <(find "$BIN" -type f -perm -u+x)
+
+          if [ "$fail" -ne 0 ]; then
+            echo "::error::One or more bundled CLI binaries failed signing checks"
+            exit 1
+          fi
+          echo "=== Bundled CLI checks passed ==="
+
       - name: Verify engine sidecar signing
         run: |
           APP="${{ steps.artifacts.outputs.app }}"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,7 @@ Need specific knowledge? Load on demand:
 - Agent manifest, tiers, sidebar, workspaces → `knowledge-base/agent-manifest.md`
 - Engine wire protocol (REST + WS) → `knowledge-base/engine-protocol.md`
 - `houston-engine` binary ops → `knowledge-base/engine-server.md`
+- Bundled CLIs (codex universal, composio per-arch) + runtime claude-code installer → `knowledge-base/cli-bundling.md`
 - Custom frontend on `houston-engine` (integration reference) → `examples/smartbooks/README.md`
 - Mobile PWA (tunnel, pairing, reactivity) → `docs/mobile-architecture.md` + `docs/relay-operations.md`
 - Updater, analytics, Sentry, env vars, CI → `knowledge-base/production-infra.md`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1232,6 +1242,24 @@ name = "data-encoding"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+
+[[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
 
 [[package]]
 name = "debugid"
@@ -2380,11 +2408,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "houston-claude-installer"
+version = "0.4.1"
+dependencies = [
+ "dirs 5.0.1",
+ "futures-util",
+ "hex",
+ "houston-cli-bundle",
+ "houston-db",
+ "houston-ui-events",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "sha2",
+ "tempfile",
+ "tokio",
+ "tracing",
+ "wiremock",
+]
+
+[[package]]
+name = "houston-cli-bundle"
+version = "0.4.1"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tracing",
+]
+
+[[package]]
 name = "houston-composio"
 version = "0.4.1"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
+ "houston-cli-bundle",
  "houston-db",
  "houston-ui-events",
  "reqwest 0.12.28",
@@ -2421,6 +2480,8 @@ dependencies = [
  "dirs-next",
  "houston-agent-files",
  "houston-agents-conversations",
+ "houston-claude-installer",
+ "houston-cli-bundle",
  "houston-db",
  "houston-engine-protocol",
  "houston-skills",
@@ -2458,6 +2519,8 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "futures-util",
+ "houston-claude-installer",
+ "houston-cli-bundle",
  "houston-composio",
  "houston-db",
  "houston-engine-core",
@@ -2560,6 +2623,7 @@ name = "houston-terminal-manager"
 version = "0.4.1"
 dependencies = [
  "dirs 5.0.1",
+ "houston-cli-bundle",
  "serde",
  "serde_json",
  "tokio",
@@ -3935,6 +3999,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "num_enum"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5143,12 +5217,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
+ "tokio-util",
  "tower 0.5.3",
  "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots 1.0.6",
 ]
@@ -5188,7 +5264,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -7636,6 +7712,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -8376,6 +8465,29 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http 1.4.0",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,8 @@ members = [
     "engine/houston-agents-conversations",
     "engine/houston-file-watcher",
     "engine/houston-composio",
+    "engine/houston-cli-bundle",
+    "engine/houston-claude-installer",
     "engine/houston-engine-core",
     "engine/houston-engine-protocol",
     "engine/houston-engine-server",
@@ -42,6 +44,8 @@ houston-ui-events = { version = "0.4.1", path = "engine/houston-ui-events" }
 houston-agents-conversations = { version = "0.4.1", path = "engine/houston-agents-conversations" }
 houston-file-watcher = { version = "0.4.1", path = "engine/houston-file-watcher" }
 houston-composio = { version = "0.4.1", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.1", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.1", path = "engine/houston-claude-installer" }
 houston-engine-core = { version = "0.4.1", path = "engine/houston-engine-core" }
 houston-engine-protocol = { version = "0.4.1", path = "engine/houston-engine-protocol" }
 houston-engine-server = { version = "0.4.1", path = "engine/houston-engine-server" }

--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -25,7 +25,29 @@ fn main() {
         println!("cargo:warning=houston-engine sidecar staging skipped: {e}");
     }
 
+    // Ensure the bundled-CLI staging directory exists. Tauri's `bundle.resources`
+    // points at `resources/bin` and its resource walker errors out if the
+    // directory is missing entirely (a real config error would still surface
+    // — empty walks are silent). CI populates this dir via
+    // `scripts/fetch-cli-deps.sh both` before invoking the bundler. Local
+    // `pnpm tauri dev` builds don't strictly need bundled CLIs (engine
+    // falls back to PATH lookup / `~/.composio` install), so we create
+    // an empty dir here to keep the config valid without forcing every
+    // developer to fetch ~700 MB of binaries on first checkout.
+    ensure_resources_bin_dir();
+
     tauri_build::build()
+}
+
+fn ensure_resources_bin_dir() {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let dir = manifest.join("resources").join("bin");
+    if let Err(e) = std::fs::create_dir_all(&dir) {
+        println!(
+            "cargo:warning=could not create {} (Tauri bundle.resources may fail): {e}",
+            dir.display()
+        );
+    }
 }
 
 fn stage_engine_sidecar() -> Result<(), String> {

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -45,6 +45,9 @@
     "active": true,
     "targets": ["app", "dmg"],
     "externalBin": ["binaries/houston-engine"],
+    "resources": {
+      "resources/bin": "bin"
+    },
     "macOS": {
       "signingIdentity": "-",
       "entitlements": "entitlements.plist",

--- a/cli-deps.json
+++ b/cli-deps.json
@@ -1,11 +1,12 @@
 {
   "$schema": "./cli-deps.schema.json",
-  "$comment": "Pinned CLI versions shipped with Houston. Codex + Composio are bundled in the .app. Claude Code is downloaded at runtime (proprietary license prevents bundling).",
+  "$comment": "Pinned versions for every CLI Houston ships or runtime-installs. Bundled (codex, composio) ride inside the .app under Contents/Resources/bin. claude-code cannot be bundled (proprietary license) so the runtime installer downloads it on first launch via houston-claude-installer using the URLs + sha256 below. Bumping a version: run `./scripts/bump-cli.sh <name> <version>`, then `./scripts/fetch-cli-deps.sh both` to refresh the staged copies + print the new checksums; pin the printed sha256 back into this file.",
   "claude-code": {
     "version": "2.1.92",
     "bundled": false,
     "binary_name": "claude",
     "license": "PROPRIETARY",
+    "install_target": "$HOME/.local/bin/claude",
     "urls": {
       "darwin-arm64": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/darwin-arm64/claude",
       "darwin-x64": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/darwin-x64/claude",
@@ -21,12 +22,15 @@
     "bundled": true,
     "binary_name": "codex",
     "license": "Apache-2.0",
+    "ship_layout": "lipo-universal",
+    "$ship_layout_comment": "Both arch binaries are downloaded and combined with `lipo -create` into a single Mach-O fat binary at Contents/Resources/bin/codex.",
     "urls": {
       "darwin-arm64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-aarch64-apple-darwin.tar.gz",
       "darwin-x64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-x86_64-apple-darwin.tar.gz"
     },
     "checksums": {
-      "darwin-arm64": "60f7039e63a7de8ae474136ac6f593ec1a913e1ddca0df59ade1f6d6eb5f7fd0"
+      "darwin-arm64": "60f7039e63a7de8ae474136ac6f593ec1a913e1ddca0df59ade1f6d6eb5f7fd0",
+      "darwin-x64": "94e6ba8a552d4625beee857f513fb12bc20e560b9427c4a93733dbd86619f415"
     }
   },
   "composio": {
@@ -34,6 +38,8 @@
     "bundled": true,
     "binary_name": "composio",
     "license": "MIT",
+    "ship_layout": "per-arch-dir",
+    "$ship_layout_comment": "Composio is a Bun-bundled JS app with arch-specific runtime + sibling .mjs/services files; cannot lipo. Each arch ships at Contents/Resources/bin/composio-{aarch64|x86_64}/ and the engine resolves at runtime via std::env::consts::ARCH. Cross-platform acp-adapters that the resolved arch can never execute are pruned at fetch time to keep the .app honest in size.",
     "urls": {
       "darwin-arm64": "https://github.com/ComposioHQ/composio/releases/download/@composio/cli@{version}/composio-darwin-aarch64.zip",
       "darwin-x64": "https://github.com/ComposioHQ/composio/releases/download/@composio/cli@{version}/composio-darwin-x64.zip"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "houston-claude-installer"
+version = "0.4.1"
+edition = "2021"
+description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
+license = "MIT"
+repository = "https://github.com/ja-818/houston"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+# `stream` feature pulls bytes off the wire incrementally so we can emit
+# download progress events instead of buffering the whole binary in
+# memory (claude-code is ~120 MB per arch).
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream"] }
+sha2 = "0.10"
+hex = "0.4"
+futures-util = "0.3"
+dirs = "5"
+houston-cli-bundle = { workspace = true }
+houston-ui-events = { workspace = true }
+houston-db = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"
+# Lightweight HTTP mocker for integration tests of the streaming
+# download path (checksum verify, partial-write recovery, atomic
+# rename). Only pulled in for tests so the runtime crate stays small.
+wiremock = "0.6"

--- a/engine/houston-claude-installer/src/lib.rs
+++ b/engine/houston-claude-installer/src/lib.rs
@@ -1,0 +1,548 @@
+//! Runtime installer for Anthropic's Claude Code CLI.
+//!
+//! Why a runtime installer instead of bundling like codex/composio?
+//! Claude Code is shipped under a proprietary license that doesn't
+//! permit redistribution inside Houston's bundle. So we do the next
+//! best thing for non-technical users: detect the missing CLI on first
+//! launch and download it for them, no terminal required.
+//!
+//! Why not just run `curl https://claude.ai/install.sh | bash`?
+//!   1. **Reproducibility** — we pin a specific version + SHA-256 in
+//!      `cli-deps.json` (bundled inside the .app via
+//!      `houston-cli-bundle`). The upstream install script chases
+//!      "latest", which would silently roll a new version on every
+//!      Houston install and break the version lockstep we use to
+//!      validate compatibility.
+//!   2. **Verifiability** — every byte of the downloaded binary is
+//!      checksum-verified before it's marked executable. The .app is
+//!      signed/notarized; the manifest inside is tamper-evident; this
+//!      installer extends that trust chain to the runtime download.
+//!   3. **No bash dep** — we don't want to require `/bin/bash` at
+//!      install time on every user's machine.
+//!   4. **Progress events** — the installer emits `HoustonEvent`s so
+//!      the UI shows real progress instead of a frozen splash.
+//!
+//! ## Install flow
+//!
+//! 1. Resolve manifest: prefer the bundled `cli-deps.json`, fall back
+//!    to a same-shape JSON at the dev-checkout repo root.
+//! 2. Look up the `claude-code` entry. Bail early if `bundled: true`
+//!    (defensive — bundling claude-code would need a license change).
+//! 3. Fetch the per-platform URL + checksum (`darwin-arm64`,
+//!    `darwin-x64`, …) and download to a temp file alongside the final
+//!    install target so the rename at the end is atomic on the same
+//!    filesystem.
+//! 4. Stream the response, accumulating SHA-256 as bytes arrive. Emit
+//!    `HoustonEvent::ClaudeCliInstalling { progress_pct }` every ~250 ms.
+//! 5. On EOF, compare the digest to the pinned checksum. Mismatch =>
+//!    delete the temp file, return error (treated as fatal by the
+//!    lifecycle entry).
+//! 6. Mark executable (Unix), atomically rename into place, persist the
+//!    installed version in the engine DB so the next boot can decide
+//!    whether to re-install.
+
+use futures_util::StreamExt;
+use houston_db::db::Database;
+use houston_ui_events::{DynEventSink, HoustonEvent};
+use sha2::{Digest, Sha256};
+use std::path::PathBuf;
+use tokio::io::AsyncWriteExt;
+
+/// Engine-DB preferences key holding the last successfully-installed
+/// claude-code version. Lifecycle compares it against the manifest's
+/// pinned version on every boot.
+const PREF_INSTALLED_VERSION: &str = "claude_code_installed_version";
+
+/// CLI key inside `cli-deps.json`. Constant so we don't string-literal
+/// the same value across modules.
+const CLI_KEY: &str = "claude-code";
+
+/// Final install target. `claude --version` uses this exact path; the
+/// upstream installer drops there too, so users who already had Claude
+/// Code installed via `claude.ai/install.sh` get an automatic upgrade.
+pub fn cli_path() -> PathBuf {
+    install_dir().join(binary_name())
+}
+
+/// Directory `cli_path()` lives in. Created on demand by `install()`.
+pub fn install_dir() -> PathBuf {
+    #[cfg(unix)]
+    {
+        // `~/.local/bin` is on PATH for most users via the shells'
+        // default profile; the engine also force-adds it via
+        // `claude_path` so it's always discoverable.
+        dirs::home_dir().unwrap_or_default().join(".local").join("bin")
+    }
+    #[cfg(windows)]
+    {
+        // `%LOCALAPPDATA%\Programs\claude\` is the conventional
+        // Windows install location for per-user CLIs and matches the
+        // upstream PowerShell installer.
+        dirs::data_local_dir()
+            .unwrap_or_default()
+            .join("Programs")
+            .join("claude")
+    }
+}
+
+fn binary_name() -> &'static str {
+    if cfg!(windows) {
+        "claude.exe"
+    } else {
+        "claude"
+    }
+}
+
+/// True if the binary exists and is executable. Does not validate the
+/// version — that's the lifecycle's job.
+pub fn is_installed() -> bool {
+    let p = cli_path();
+    if !p.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = std::fs::metadata(&p) {
+            return meta.permissions().mode() & 0o111 != 0;
+        }
+        false
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}
+
+/// Lifecycle entry — call once at engine startup as a background task.
+///
+/// Decision tree:
+/// - No manifest available → log + emit `ClaudeCliReady` (best-effort,
+///   user can install manually or use Codex). The engine never blocks
+///   on claude install: the user might be on Codex.
+/// - Already installed at the pinned version → emit `ClaudeCliReady`.
+/// - Not installed, or installed at a different version →
+///   download/verify/install, then emit `ClaudeCliReady`.
+/// - Download/verify failure → emit `ClaudeCliFailed { message }` with
+///   actionable hint.
+pub async fn ensure_and_upgrade(sink: DynEventSink, db: Database) {
+    // Resolve the manifest. In dev (no bundle), we fall back to the
+    // checkout's `cli-deps.json` so engineers get the same auto-install
+    // behavior they'd hit in a packaged release. Production always finds
+    // the bundled copy.
+    let Some(manifest) = resolve_manifest() else {
+        tracing::warn!(
+            "[claude-installer] no cli-deps.json available — skipping auto-install"
+        );
+        sink.emit(HoustonEvent::ClaudeCliReady);
+        return;
+    };
+
+    let Some(entry) = manifest.entry(CLI_KEY) else {
+        tracing::warn!(
+            "[claude-installer] cli-deps.json missing '{}' entry — skipping auto-install",
+            CLI_KEY
+        );
+        sink.emit(HoustonEvent::ClaudeCliReady);
+        return;
+    };
+
+    if entry.bundled {
+        // Defensive — shouldn't be possible without a license change.
+        // Treat the bundled binary as authoritative if it's there.
+        tracing::info!("[claude-installer] manifest reports claude-code as bundled; trusting bundle");
+        sink.emit(HoustonEvent::ClaudeCliReady);
+        return;
+    }
+
+    let pinned_version = entry.version.clone();
+
+    // Already installed at the pinned version? Skip the download.
+    let last_version = db
+        .get_preference(PREF_INSTALLED_VERSION)
+        .await
+        .ok()
+        .flatten()
+        .unwrap_or_default();
+
+    if is_installed() && last_version == pinned_version {
+        tracing::info!(
+            "[claude-installer] already at pinned version {}, skipping",
+            pinned_version
+        );
+        sink.emit(HoustonEvent::ClaudeCliReady);
+        return;
+    }
+
+    tracing::info!(
+        "[claude-installer] installing claude-code v{} ({} → {})",
+        pinned_version,
+        if last_version.is_empty() { "none" } else { &last_version },
+        pinned_version
+    );
+
+    sink.emit(HoustonEvent::ClaudeCliInstalling { progress_pct: 0 });
+
+    let sink_for_progress = sink.clone();
+    let result = install(&entry, move |pct| {
+        sink_for_progress.emit(HoustonEvent::ClaudeCliInstalling { progress_pct: pct });
+    })
+    .await;
+
+    match result {
+        Ok(path) => {
+            tracing::info!("[claude-installer] installed at {}", path.display());
+            if let Err(e) = db.set_preference(PREF_INSTALLED_VERSION, &pinned_version).await {
+                tracing::warn!("[claude-installer] failed to persist version marker: {e}");
+            }
+            sink.emit(HoustonEvent::ClaudeCliReady);
+        }
+        Err(e) => {
+            tracing::error!("[claude-installer] install failed: {e}");
+            sink.emit(HoustonEvent::ClaudeCliFailed { message: e });
+        }
+    }
+}
+
+/// Resolve the `cli-deps.json` manifest. Prefers the bundled copy
+/// (production) and falls back to the dev-checkout root so engineers
+/// running `cargo run -p houston-engine-server` against an unbundled
+/// build still get auto-install.
+fn resolve_manifest() -> Option<houston_cli_bundle::CliDepsManifest> {
+    if let Some(m) = houston_cli_bundle::load_bundled_manifest() {
+        return Some(m);
+    }
+    // Dev fallback: walk up from CWD looking for `cli-deps.json`.
+    let cwd = std::env::current_dir().ok()?;
+    let mut here = cwd.as_path();
+    loop {
+        let candidate = here.join("cli-deps.json");
+        if candidate.is_file() {
+            return houston_cli_bundle::CliDepsManifest::load(&candidate).ok();
+        }
+        match here.parent() {
+            Some(p) => here = p,
+            None => return None,
+        }
+    }
+}
+
+/// Download + verify + install. Public so callers (e.g. an explicit
+/// "Reinstall Claude" UI button) can re-run the same path without going
+/// through the full lifecycle.
+///
+/// Writes to the production install location. Tests use [`install_to`]
+/// directly to point at a temp dir.
+pub async fn install(
+    entry: &houston_cli_bundle::CliEntry,
+    progress: impl FnMut(u8) + Send + 'static,
+) -> Result<PathBuf, String> {
+    install_to(entry, &install_dir(), binary_name(), progress).await
+}
+
+/// Parameterized variant of [`install`]: download `entry` for the
+/// current host platform, verify SHA-256, write atomically into
+/// `install_dir/binary_name`. Used by tests to redirect into a temp
+/// directory; production callers should use [`install`].
+pub async fn install_to(
+    entry: &houston_cli_bundle::CliEntry,
+    install_dir: &std::path::Path,
+    binary_name: &str,
+    mut progress: impl FnMut(u8) + Send + 'static,
+) -> Result<PathBuf, String> {
+    let platform = houston_cli_bundle::host_platform_key();
+    let url = entry
+        .url_for(platform)
+        .ok_or_else(|| format!("no claude-code URL for platform '{platform}'"))?;
+    let expected_checksum = entry
+        .checksum_for(platform)
+        .ok_or_else(|| format!("no claude-code checksum for platform '{platform}'"))?
+        .to_string();
+
+    tracing::info!("[claude-installer] GET {url}");
+
+    tokio::fs::create_dir_all(install_dir)
+        .await
+        .map_err(|e| format!("failed to create install dir {}: {e}", install_dir.display()))?;
+
+    let final_path = install_dir.join(binary_name);
+    // Temp path on the same filesystem so the final rename is atomic
+    // and we never leave a half-downloaded binary at the install
+    // target if the process crashes mid-stream.
+    let tmp_path = install_dir.join(format!(".{binary_name}.partial"));
+    // Drop any leftover partial from a prior aborted install.
+    let _ = tokio::fs::remove_file(&tmp_path).await;
+
+    let client = reqwest::Client::builder()
+        .connect_timeout(std::time::Duration::from_secs(15))
+        .build()
+        .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+
+    let resp = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("download request failed: {e}"))?;
+
+    if !resp.status().is_success() {
+        return Err(format!(
+            "download returned HTTP {}: {url}",
+            resp.status()
+        ));
+    }
+
+    let total = resp.content_length();
+    let mut stream = resp.bytes_stream();
+    let mut hasher = Sha256::new();
+    let mut downloaded: u64 = 0;
+    let mut last_pct_emitted: u8 = 0;
+
+    let mut tmp_file = tokio::fs::File::create(&tmp_path)
+        .await
+        .map_err(|e| format!("failed to open temp file {}: {e}", tmp_path.display()))?;
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("download stream error: {e}"))?;
+        hasher.update(&chunk);
+        tmp_file
+            .write_all(&chunk)
+            .await
+            .map_err(|e| format!("failed to write chunk: {e}"))?;
+        downloaded = downloaded.saturating_add(chunk.len() as u64);
+
+        // Throttle progress events so we don't flood the WebSocket.
+        // 10% increments are smooth enough for a ~120 MB download
+        // without producing noise during the rest of engine boot.
+        if let Some(total) = total {
+            if total > 0 {
+                let pct = ((downloaded.min(total) * 100) / total) as u8;
+                if pct >= last_pct_emitted.saturating_add(10).min(100) {
+                    last_pct_emitted = pct;
+                    progress(pct);
+                }
+            }
+        }
+    }
+
+    tmp_file
+        .flush()
+        .await
+        .map_err(|e| format!("flush failed: {e}"))?;
+    drop(tmp_file);
+
+    // Always emit a final 100% so the UI can transition out of
+    // "installing" even when content-length was missing or we hit a
+    // weird edge case in the throttle math above.
+    progress(100);
+
+    let actual_checksum = hex::encode(hasher.finalize());
+    if !checksum_matches(&actual_checksum, &expected_checksum) {
+        let _ = tokio::fs::remove_file(&tmp_path).await;
+        return Err(format!(
+            "claude-code checksum mismatch: expected {expected_checksum}, got {actual_checksum} \
+             — download may be tampered or the pinned manifest is stale"
+        ));
+    }
+
+    // Make the binary executable BEFORE the rename so a racing reader
+    // never sees a non-executable file at the install target.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = std::fs::Permissions::from_mode(0o755);
+        std::fs::set_permissions(&tmp_path, perms)
+            .map_err(|e| format!("failed to chmod +x: {e}"))?;
+    }
+
+    // Atomic rename within the same dir. On Unix this is a syscall;
+    // on Windows we have to remove the existing target first because
+    // `rename` fails if the destination exists.
+    #[cfg(windows)]
+    {
+        if final_path.exists() {
+            let _ = std::fs::remove_file(&final_path);
+        }
+    }
+    std::fs::rename(&tmp_path, &final_path).map_err(|e| {
+        format!(
+            "failed to install to {}: {e} — check the directory is writable",
+            final_path.display()
+        )
+    })?;
+
+    Ok(final_path)
+}
+
+/// Hex string equality is case-insensitive in our manifest convention,
+/// but we still want a constant-time-ish compare to avoid leaking
+/// whether the prefix matched in profiling. Use `subtle`? Overkill for
+/// a checksum compare in a desktop app — equality is fine, just be
+/// explicit about case folding.
+fn checksum_matches(actual: &str, expected: &str) -> bool {
+    actual.eq_ignore_ascii_case(expected)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::Digest;
+    use std::sync::atomic::{AtomicU8, Ordering};
+    use std::sync::Arc;
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn checksum_match_ignores_case() {
+        assert!(checksum_matches("DEADBEEF", "deadbeef"));
+        assert!(checksum_matches("abc123", "abc123"));
+        assert!(!checksum_matches("abc", "abd"));
+    }
+
+    #[test]
+    fn cli_path_is_under_install_dir() {
+        let cli = cli_path();
+        let dir = install_dir();
+        assert!(cli.starts_with(&dir), "{} not under {}", cli.display(), dir.display());
+    }
+
+    /// Build a `CliEntry` parsed from a JSON document whose URL points
+    /// at the wiremock server and whose checksum reflects `payload`.
+    /// Mirrors the shape of `cli-deps.json` so the test exercises the
+    /// real deserialization path.
+    fn entry_for(server_uri: &str, payload: &[u8]) -> houston_cli_bundle::CliEntry {
+        let actual = hex::encode(sha2::Sha256::digest(payload));
+        let manifest = serde_json::json!({
+            "claude-code": {
+                "version": "9.9.9",
+                "bundled": false,
+                "binary_name": "claude",
+                "license": "PROPRIETARY",
+                "urls": {
+                    houston_cli_bundle::host_platform_key(): format!("{server_uri}/claude")
+                },
+                "checksums": {
+                    houston_cli_bundle::host_platform_key(): actual
+                }
+            }
+        });
+        let raw = serde_json::to_string(&manifest).unwrap();
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), raw).unwrap();
+        let m = houston_cli_bundle::CliDepsManifest::load(tmp.path()).unwrap();
+        m.entry("claude-code").unwrap()
+    }
+
+    #[tokio::test]
+    async fn install_downloads_verifies_and_chmods() {
+        let server = MockServer::start().await;
+        let payload = b"#!/bin/sh\necho 'fake claude'\n".repeat(50_000); // ~1.5 MB
+
+        Mock::given(method("GET"))
+            .and(path("/claude"))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .insert_header("content-type", "application/octet-stream")
+                    .set_body_bytes(payload.clone()),
+            )
+            .mount(&server)
+            .await;
+
+        let entry = entry_for(&server.uri(), &payload);
+        let dest_dir = tempfile::tempdir().unwrap();
+        let progress = Arc::new(AtomicU8::new(0));
+        let progress_clone = progress.clone();
+
+        let result = install_to(&entry, dest_dir.path(), "claude", move |pct| {
+            progress_clone.store(pct, Ordering::Relaxed);
+        })
+        .await;
+
+        let installed = result.expect("install should succeed");
+        assert_eq!(installed, dest_dir.path().join("claude"));
+        assert_eq!(std::fs::read(&installed).unwrap(), payload);
+        assert_eq!(progress.load(Ordering::Relaxed), 100);
+
+        // Temp file must be cleaned up after atomic rename.
+        let tmp = dest_dir.path().join(".claude.partial");
+        assert!(!tmp.exists(), "leftover partial at {}", tmp.display());
+
+        // Unix: chmod +x must be set so the binary can be exec'd.
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mode = std::fs::metadata(&installed).unwrap().permissions().mode();
+            assert!(
+                mode & 0o111 != 0,
+                "binary not executable (mode={mode:o}): {}",
+                installed.display()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn install_rejects_checksum_mismatch_and_cleans_temp() {
+        let server = MockServer::start().await;
+        let payload = b"corrupt payload";
+
+        Mock::given(method("GET"))
+            .and(path("/claude"))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(payload.to_vec()))
+            .mount(&server)
+            .await;
+
+        // Build entry with a fake checksum that won't match the actual.
+        let manifest = serde_json::json!({
+            "claude-code": {
+                "version": "9.9.9",
+                "bundled": false,
+                "binary_name": "claude",
+                "urls": {
+                    houston_cli_bundle::host_platform_key(): format!("{}/claude", server.uri())
+                },
+                "checksums": {
+                    houston_cli_bundle::host_platform_key():
+                        "0000000000000000000000000000000000000000000000000000000000000000"
+                }
+            }
+        });
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(tmp.path(), serde_json::to_string(&manifest).unwrap()).unwrap();
+        let entry = houston_cli_bundle::CliDepsManifest::load(tmp.path())
+            .unwrap()
+            .entry("claude-code")
+            .unwrap();
+
+        let dest_dir = tempfile::tempdir().unwrap();
+        let result = install_to(&entry, dest_dir.path(), "claude", |_| {}).await;
+
+        let err = result.expect_err("checksum mismatch must error");
+        assert!(
+            err.contains("checksum mismatch"),
+            "unexpected error: {err}"
+        );
+        // Both the partial and the final must be absent — we never want
+        // a tampered binary on disk after a verification failure.
+        assert!(!dest_dir.path().join("claude").exists());
+        assert!(!dest_dir.path().join(".claude.partial").exists());
+    }
+
+    #[tokio::test]
+    async fn install_surfaces_http_errors() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/claude"))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+
+        let entry = entry_for(&server.uri(), b"unused");
+        let dest_dir = tempfile::tempdir().unwrap();
+        let result = install_to(&entry, dest_dir.path(), "claude", |_| {}).await;
+
+        let err = result.expect_err("server 500 must error");
+        assert!(
+            err.contains("HTTP") || err.contains("500"),
+            "unexpected error: {err}"
+        );
+    }
+}

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "houston-cli-bundle"
+version = "0.4.1"
+edition = "2021"
+description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
+license = "MIT"
+repository = "https://github.com/ja-818/houston"
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/engine/houston-cli-bundle/src/lib.rs
+++ b/engine/houston-cli-bundle/src/lib.rs
@@ -1,0 +1,467 @@
+//! Resolve bundled CLI binaries that ship inside the Houston `.app`.
+//!
+//! Houston bundles two upstream CLIs into the signed/notarized desktop app
+//! so non-technical users get them preinstalled with zero terminal exposure:
+//!
+//! - **codex** (Apache-2.0, OpenAI) — Rust binary, `lipo`'d into a single
+//!   universal Mach-O shipped at `Contents/Resources/bin/codex`.
+//! - **composio** (MIT, Composio) — Bun-bundled JS app with arch-specific
+//!   runtime + sibling `.mjs`/`services` files; cannot be lipo'd, ships
+//!   per-arch under `Contents/Resources/bin/composio-{aarch64|x86_64}/`.
+//!
+//! `claude-code` cannot be bundled (proprietary license). The runtime
+//! `houston-claude-installer` downloads it on first launch using URLs +
+//! SHA-256 checksums pinned in `cli-deps.json` (also bundled inside the
+//! .app via [`bundled_cli_deps_manifest`]).
+//!
+//! ## Resolution model
+//!
+//! Every function in this crate returns `Option<PathBuf>` and is `None`
+//! when not running inside a recognizable bundle layout. That keeps dev
+//! builds (`pnpm tauri dev`, `cargo run -p houston-engine-server`)
+//! working unchanged — callers fall back to PATH lookup or a one-time
+//! `~/.composio` install.
+//!
+//! Detection is **structural** — we walk parent directories and check
+//! known names — so we don't depend on any env var that could be
+//! stripped by macOS `.app` launchers or scrubbed in Spotlight indexing.
+//!
+//! ## Bundle layouts
+//!
+//! macOS `.app`:
+//! ```text
+//! Houston.app/
+//!   Contents/
+//!     MacOS/
+//!       houston-app                ← parent app binary
+//!       houston-engine[-<triple>]  ← engine sidecar (current_exe here)
+//!     Resources/
+//!       bin/                       ← bundled_bin_dir() returns this
+//!         codex                    (universal)
+//!         composio-aarch64/composio
+//!         composio-x86_64/composio
+//!         cli-deps.json
+//! ```
+//!
+//! Windows MSI / NSIS:
+//! ```text
+//! C:\Program Files\Houston\
+//!   houston-app.exe
+//!   houston-engine.exe                ← current_exe here
+//!   resources\
+//!     bin\                            ← bundled_bin_dir() returns this
+//!       ...
+//! ```
+//!
+//! Linux AppImage / deb / rpm: not yet supported by Houston releases.
+
+use std::path::{Path, PathBuf};
+
+/// Subdirectory under `Resources/` (macOS) or alongside the exe
+/// (Windows) that holds bundled CLI binaries. Must match the destination
+/// in `tauri.conf.json#bundle.resources` and the layout produced by
+/// `scripts/fetch-cli-deps.sh`.
+pub const BIN_SUBDIR: &str = "bin";
+
+/// File name of the runtime install manifest (used by
+/// `houston-claude-installer`).
+pub const CLI_DEPS_MANIFEST: &str = "cli-deps.json";
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Top of the bundled CLI directory, or `None` if the current process is
+/// not running inside a recognizable bundle layout (dev build, cargo run,
+/// CI test harness, etc.).
+pub fn bundled_bin_dir() -> Option<PathBuf> {
+    let exe = std::env::current_exe().ok()?;
+    bundled_bin_dir_for(&exe)
+}
+
+/// As [`bundled_bin_dir`] but resolves relative to an explicit
+/// executable path. Used by tests and by code paths that have already
+/// resolved the engine binary (e.g. the supervisor that spawned it).
+pub fn bundled_bin_dir_for(exe: &Path) -> Option<PathBuf> {
+    if let Some(dir) = macos_app_bin_dir(exe) {
+        return Some(dir);
+    }
+    if let Some(dir) = sibling_resources_bin_dir(exe) {
+        return Some(dir);
+    }
+    None
+}
+
+/// Universal `codex` binary inside the bundle, or `None`.
+pub fn bundled_codex_path() -> Option<PathBuf> {
+    let p = bundled_bin_dir()?.join(codex_binary_name());
+    if p.is_file() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+/// Per-arch composio directory inside the bundle. Composio is multi-file
+/// (binary + sibling `.mjs`/`services`) so callers that want to spawn the
+/// binary should use [`bundled_composio_binary`]; callers that need to
+/// add the dir to `PATH` (so e.g. agents can shell out to `composio`)
+/// should use [`bundled_path_entries`].
+pub fn bundled_composio_dir() -> Option<PathBuf> {
+    let arch = host_arch_for_composio();
+    let p = bundled_bin_dir()?.join(format!("composio-{arch}"));
+    if p.is_dir() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+/// Per-arch composio binary, or `None`.
+pub fn bundled_composio_binary() -> Option<PathBuf> {
+    let p = bundled_composio_dir()?.join(composio_binary_name());
+    if p.is_file() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+/// Path to the bundled `cli-deps.json` manifest, or `None`.
+pub fn bundled_cli_deps_manifest() -> Option<PathBuf> {
+    let p = bundled_bin_dir()?.join(CLI_DEPS_MANIFEST);
+    if p.is_file() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
+/// Directories to prepend to `PATH` so subprocesses spawned by the engine
+/// (`claude`, `codex`, agent-side `composio search`/`composio execute`,
+/// …) resolve to the bundled binaries. Returned in priority order
+/// (front-of-PATH first). Empty if not bundled, in which case the caller
+/// falls back to its existing PATH-augmentation behavior.
+///
+/// Order:
+///   1. `<bundle>/bin/`                  — codex (and any future single-file CLIs)
+///   2. `<bundle>/bin/composio-<arch>/`  — composio (multi-file bundle)
+pub fn bundled_path_entries() -> Vec<PathBuf> {
+    let Some(bin) = bundled_bin_dir() else {
+        return Vec::new();
+    };
+    let mut out = Vec::with_capacity(2);
+    out.push(bin.clone());
+    let arch = host_arch_for_composio();
+    let composio_dir = bin.join(format!("composio-{arch}"));
+    if composio_dir.is_dir() {
+        out.push(composio_dir);
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Pinned manifest accessors (cli-deps.json)
+//
+// Reading the manifest lets callers (notably houston-claude-installer)
+// pull pinned download URLs + SHA-256 checksums for runtime-installed
+// CLIs without a separate network round-trip to a remote manifest. The
+// .app bundle is signed + notarized, so the file is tamper-evident at
+// rest; using compile-time `include_str!` would force a Houston rebuild
+// on every claude-code version bump, which we explicitly want to avoid.
+// ---------------------------------------------------------------------------
+
+/// Subset of `cli-deps.json` that callers care about. Generic over the
+/// CLI key — claude-code, codex, composio all share this shape.
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct CliEntry {
+    pub version: String,
+    /// Whether this CLI is bundled inside the .app. `false` means it's
+    /// downloaded at runtime (`claude-code`).
+    pub bundled: bool,
+    /// Final invocable name (`claude`, `codex`, `composio`).
+    pub binary_name: String,
+    /// SPDX-style license tag for audit/build-noise (no logic depends on
+    /// it, but keeping it accessible from runtime helps support diagnose
+    /// distribution questions).
+    #[serde(default)]
+    pub license: Option<String>,
+    /// `darwin-arm64` / `darwin-x64` / etc. → URL template (replace
+    /// `{version}` at install time).
+    #[serde(default)]
+    pub urls: std::collections::BTreeMap<String, String>,
+    /// `darwin-arm64` / `darwin-x64` / etc. → SHA-256 hex digest.
+    #[serde(default)]
+    pub checksums: std::collections::BTreeMap<String, String>,
+    /// Optional install target hint for runtime-installed CLIs (e.g.
+    /// `$HOME/.local/bin/claude`).
+    #[serde(default)]
+    pub install_target: Option<String>,
+}
+
+impl CliEntry {
+    /// URL for the given platform (`darwin-arm64`, `darwin-x64`, …) with
+    /// `{version}` substituted. Returns `None` if no URL is registered
+    /// for the requested platform.
+    pub fn url_for(&self, platform: &str) -> Option<String> {
+        self.urls
+            .get(platform)
+            .map(|tmpl| tmpl.replace("{version}", &self.version))
+    }
+
+    /// SHA-256 for the given platform, hex-encoded.
+    pub fn checksum_for(&self, platform: &str) -> Option<&str> {
+        self.checksums.get(platform).map(String::as_str)
+    }
+}
+
+/// Parsed `cli-deps.json`. Only the three known CLIs are exposed as
+/// strongly-typed getters; the raw map is kept around so future entries
+/// stay readable without a Houston rebuild.
+#[derive(Debug, Clone)]
+pub struct CliDepsManifest {
+    raw: serde_json::Value,
+}
+
+impl CliDepsManifest {
+    /// Parse a manifest from disk. Returns a structured error string if
+    /// the file is missing or unparseable.
+    pub fn load(path: &Path) -> Result<Self, String> {
+        let bytes = std::fs::read(path)
+            .map_err(|e| format!("failed to read {}: {e}", path.display()))?;
+        let raw: serde_json::Value = serde_json::from_slice(&bytes)
+            .map_err(|e| format!("invalid JSON in {}: {e}", path.display()))?;
+        Ok(Self { raw })
+    }
+
+    /// Look up an entry by CLI key (`claude-code`, `codex`, `composio`).
+    pub fn entry(&self, key: &str) -> Option<CliEntry> {
+        let val = self.raw.get(key)?;
+        serde_json::from_value::<CliEntry>(val.clone()).ok()
+    }
+}
+
+/// Convenience: load the bundled manifest. `None` if not bundled.
+pub fn load_bundled_manifest() -> Option<CliDepsManifest> {
+    let path = bundled_cli_deps_manifest()?;
+    match CliDepsManifest::load(&path) {
+        Ok(m) => Some(m),
+        Err(e) => {
+            tracing::warn!("[cli-bundle] failed to load bundled manifest: {e}");
+            None
+        }
+    }
+}
+
+/// The platform key used inside `cli-deps.json` for the current host
+/// (`darwin-arm64` / `darwin-x64` / `windows-x64`). Used by the runtime
+/// installer to look up its download URL + checksum without each caller
+/// recomputing the mapping.
+pub fn host_platform_key() -> &'static str {
+    #[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+    {
+        "darwin-arm64"
+    }
+    #[cfg(all(target_os = "macos", target_arch = "x86_64"))]
+    {
+        "darwin-x64"
+    }
+    #[cfg(all(target_os = "windows", target_arch = "x86_64"))]
+    {
+        "windows-x64"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+    {
+        "linux-x64"
+    }
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    {
+        "linux-arm64"
+    }
+    #[cfg(not(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "x86_64"),
+        all(target_os = "linux", target_arch = "aarch64"),
+    )))]
+    {
+        "unknown"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Internals — layout detection
+// ---------------------------------------------------------------------------
+
+fn macos_app_bin_dir(exe: &Path) -> Option<PathBuf> {
+    let macos_dir = exe.parent()?;
+    if macos_dir.file_name()?.to_str()? != "MacOS" {
+        return None;
+    }
+    let contents = macos_dir.parent()?;
+    if contents.file_name()?.to_str()? != "Contents" {
+        return None;
+    }
+    let app = contents.parent()?;
+    let app_name = app.file_name()?.to_str()?;
+    if !app_name.ends_with(".app") {
+        return None;
+    }
+    let bin = contents.join("Resources").join(BIN_SUBDIR);
+    bin.is_dir().then_some(bin)
+}
+
+fn sibling_resources_bin_dir(exe: &Path) -> Option<PathBuf> {
+    let exe_dir = exe.parent()?;
+    let bin = exe_dir.join("resources").join(BIN_SUBDIR);
+    bin.is_dir().then_some(bin)
+}
+
+fn codex_binary_name() -> &'static str {
+    if cfg!(windows) {
+        "codex.exe"
+    } else {
+        "codex"
+    }
+}
+
+fn composio_binary_name() -> &'static str {
+    if cfg!(windows) {
+        "composio.exe"
+    } else {
+        "composio"
+    }
+}
+
+/// Composio's per-arch directory uses Rust `std::env::consts::ARCH`
+/// names ("aarch64", "x86_64") so the runtime resolver doesn't need a
+/// translation table from upstream's "arm64"/"x64" naming. Matches the
+/// directory layout produced by `scripts/fetch-cli-deps.sh`.
+fn host_arch_for_composio() -> &'static str {
+    std::env::consts::ARCH
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    /// Build a fake `Houston.app/Contents/{MacOS,Resources/bin}` tree under
+    /// `root` and return `(engine_exe_path, bin_dir)`.
+    fn fake_app(root: &Path, bin_contents: &[&str]) -> (PathBuf, PathBuf) {
+        let app = root.join("Houston.app");
+        let macos = app.join("Contents").join("MacOS");
+        let bin = app.join("Contents").join("Resources").join(BIN_SUBDIR);
+        fs::create_dir_all(&macos).unwrap();
+        fs::create_dir_all(&bin).unwrap();
+        let exe = macos.join("houston-engine");
+        fs::write(&exe, b"").unwrap();
+        for name in bin_contents {
+            let p = bin.join(name);
+            if let Some(parent) = p.parent() {
+                fs::create_dir_all(parent).unwrap();
+            }
+            fs::write(&p, b"").unwrap();
+        }
+        (exe, bin)
+    }
+
+    #[test]
+    fn detects_macos_app_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let (exe, bin) = fake_app(tmp.path(), &["codex"]);
+        let resolved = bundled_bin_dir_for(&exe).expect("should detect bundle");
+        assert_eq!(resolved, bin);
+    }
+
+    #[test]
+    fn rejects_non_app_macos_layout() {
+        let tmp = tempfile::tempdir().unwrap();
+        let macos = tmp.path().join("Contents").join("MacOS");
+        fs::create_dir_all(&macos).unwrap();
+        // No `.app` parent — should not match.
+        let exe = macos.join("houston-engine");
+        fs::write(&exe, b"").unwrap();
+        assert!(bundled_bin_dir_for(&exe).is_none());
+    }
+
+    #[test]
+    fn rejects_random_path() {
+        let tmp = tempfile::tempdir().unwrap();
+        let exe = tmp.path().join("random").join("houston-engine");
+        fs::create_dir_all(exe.parent().unwrap()).unwrap();
+        fs::write(&exe, b"").unwrap();
+        assert!(bundled_bin_dir_for(&exe).is_none());
+    }
+
+    #[test]
+    fn detects_windows_sibling_layout() {
+        // Even on macOS, the sibling-layout fallback should resolve when
+        // `<exe-dir>/resources/bin/` exists. Used by Windows + a future
+        // generic install layout.
+        let tmp = tempfile::tempdir().unwrap();
+        let exe_dir = tmp.path().join("install");
+        fs::create_dir_all(&exe_dir).unwrap();
+        let exe = exe_dir.join("houston-engine");
+        fs::write(&exe, b"").unwrap();
+        let bin = exe_dir.join("resources").join(BIN_SUBDIR);
+        fs::create_dir_all(&bin).unwrap();
+        assert_eq!(bundled_bin_dir_for(&exe), Some(bin));
+    }
+
+    #[test]
+    fn manifest_round_trip() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("cli-deps.json");
+        fs::write(
+            &path,
+            br#"{
+              "claude-code": {
+                "version": "1.2.3",
+                "bundled": false,
+                "binary_name": "claude",
+                "license": "PROPRIETARY",
+                "install_target": "$HOME/.local/bin/claude",
+                "urls": {
+                  "darwin-arm64": "https://example.com/{version}/darwin-arm64/claude",
+                  "darwin-x64":   "https://example.com/{version}/darwin-x64/claude"
+                },
+                "checksums": {
+                  "darwin-arm64": "deadbeef",
+                  "darwin-x64":   "cafebabe"
+                }
+              }
+            }"#,
+        )
+        .unwrap();
+
+        let manifest = CliDepsManifest::load(&path).unwrap();
+        let entry = manifest.entry("claude-code").unwrap();
+        assert_eq!(entry.version, "1.2.3");
+        assert!(!entry.bundled);
+        assert_eq!(entry.binary_name, "claude");
+        assert_eq!(
+            entry.url_for("darwin-arm64").as_deref(),
+            Some("https://example.com/1.2.3/darwin-arm64/claude")
+        );
+        assert_eq!(entry.checksum_for("darwin-x64"), Some("cafebabe"));
+        assert!(manifest.entry("does-not-exist").is_none());
+    }
+
+    #[test]
+    fn host_platform_key_is_known() {
+        // Just assert it's not "unknown" on the platforms we actually
+        // build for. CI runs macOS only today; the assertion still
+        // catches regressions on dev machines.
+        let k = host_platform_key();
+        assert!(
+            matches!(k, "darwin-arm64" | "darwin-x64" | "windows-x64" | "linux-x64" | "linux-arm64"),
+            "unknown host platform: {k}"
+        );
+    }
+}

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -17,6 +17,7 @@ base64 = "0.22"
 sha2 = "0.10"
 houston-ui-events = { workspace = true }
 houston-db = { workspace = true }
+houston-cli-bundle = { workspace = true }
 # Cross-platform home-directory resolution (used by install.rs to locate
 # `~/.composio/composio[.exe]` on macOS/Linux and `%USERPROFILE%\.composio\…`
 # on Windows).

--- a/engine/houston-composio/src/install.rs
+++ b/engine/houston-composio/src/install.rs
@@ -1,45 +1,76 @@
-//! Detect and install the Composio CLI.
+//! Detect, install, and resolve the Composio CLI.
 //!
-//! Houston's composio integration is a thin wrapper around the `composio`
-//! CLI (https://composio.dev/install). We don't bundle the binary with
-//! Houston because (a) it's ~80 MB per architecture, (b) the CLI has its
-//! own self-update path (`composio upgrade`), and (c) Composio's install
-//! script already handles platform detection and SHA-256 verification.
+//! Houston's composio integration is a thin wrapper around the upstream
+//! `composio` CLI (https://composio.dev). There are two distribution paths
+//! the engine handles transparently:
 //!
-//! This module runs Composio's official install script the first time
-//! the user needs the CLI. It's a one-time step per machine.
+//! 1. **Bundled** (production `.app`/`.msi`): the CLI ships inside
+//!    `Contents/Resources/bin/composio-<arch>/` (per-arch because composio
+//!    is a Bun runtime that can't be lipo'd). Resolved via
+//!    `houston_cli_bundle`. No install step — `install()` is a no-op
+//!    that returns the bundled path.
+//!
+//! 2. **Standalone** (dev / non-bundled engine builds): the CLI is
+//!    fetched on first use via Composio's official install script and
+//!    lands in `~/.composio/`. This preserves backwards compatibility
+//!    with developers running `cargo run -p houston-engine-server`
+//!    against a checkout that has not staged bundled binaries.
+//!
+//! The state-ownership contract is the same in both paths: the CLI
+//! owns everything under `~/.composio/` (auth tokens, user_data.json,
+//! cache). Houston only invokes the binary and reads structured
+//! stdout — never touches that state directly.
 
 use std::path::PathBuf;
 
-/// Absolute path to the composio binary the installer drops.
-///
-/// Composio's installer drops `composio` on Unix and `composio.exe` on
-/// Windows; we resolve to whichever is appropriate for the current
-/// target so `is_installed()` and PATH lookups match.
-pub fn cli_path() -> PathBuf {
-    #[cfg(windows)]
-    {
-        home_dir().join(".composio").join("composio.exe")
-    }
-    #[cfg(not(windows))]
-    {
-        home_dir().join(".composio").join("composio")
-    }
+/// Where Composio's official installer drops the CLI when run with the
+/// default install prefix. Used as the fallback / dev-build location;
+/// production builds resolve via `houston_cli_bundle` instead.
+pub fn standalone_cli_path() -> PathBuf {
+    let bin = if cfg!(windows) {
+        "composio.exe"
+    } else {
+        "composio"
+    };
+    home_dir().join(".composio").join(bin)
 }
 
-/// Directory that contains the composio binary + its support files.
-pub fn install_dir() -> PathBuf {
+/// Standalone install directory (sibling files, services/, …).
+pub fn standalone_install_dir() -> PathBuf {
     home_dir().join(".composio")
 }
 
-/// True if the CLI is present AND executable at the expected location.
+/// Resolve the active composio binary, preferring the bundle when
+/// available. Public callers (`cli.rs`, `lifecycle.rs`) should use this
+/// rather than picking a path themselves so the resolution stays in one
+/// place and the bundle/standalone fallback order is consistent.
+pub fn cli_path() -> PathBuf {
+    houston_cli_bundle::bundled_composio_binary().unwrap_or_else(standalone_cli_path)
+}
+
+/// Resolve the active install directory (the parent of `cli_path`,
+/// containing the binary plus its sibling files).
+pub fn install_dir() -> PathBuf {
+    houston_cli_bundle::bundled_composio_dir().unwrap_or_else(standalone_install_dir)
+}
+
+/// True if the bundled CLI is shipped with this build of Houston.
+/// Lifecycle code uses this to decide whether to skip the install /
+/// upgrade dance entirely.
+pub fn is_bundled() -> bool {
+    houston_cli_bundle::bundled_composio_binary().is_some()
+}
+
+/// True if the active CLI (bundled or standalone) is present and
+/// executable. Bundled wins over standalone — if both exist on a dev
+/// machine, the engine uses the bundled one and ignores `~/.composio`.
 pub fn is_installed() -> bool {
     let path = cli_path();
     if !path.is_file() {
         return false;
     }
-    // On Unix, make sure the execute bit is actually set — a partial
-    // download or aborted install would leave the file but no +x.
+    // On Unix, make sure the execute bit is actually set — partial
+    // downloads or a recovered backup can leave the file but no +x.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
@@ -54,28 +85,31 @@ pub fn is_installed() -> bool {
     }
 }
 
-/// Run Composio's official install script. Blocks until the CLI is in
-/// place and returns the install path on success.
+/// Run Composio's official install script (standalone path only). When
+/// the bundled CLI is shipped with Houston this is a no-op that returns
+/// the bundled path immediately.
 ///
-/// The script downloads the latest release tarball from
-/// `github.com/ComposioHQ/composio/releases`, SHA-256-verifies it against
-/// the published `checksums.txt`, and extracts to `~/.composio/`.
-/// Intentionally reuses Composio's installer instead of reimplementing
-/// the download/verify/extract logic — the upstream script handles
-/// platform detection (darwin-x64, darwin-aarch64, linux-*) and
-/// Rosetta 2 edge cases we'd otherwise have to maintain ourselves.
-///
-/// Uses `std::process::Command` (synchronous) via `spawn_blocking` with
-/// stdout/stderr redirected to temp files. This bypasses the
-/// `tokio::process::Command::output()` hang observed on macOS inside
-/// Tauri `.app` bundles — the same fix applied to `start_login()` in
-/// `composio_cli.rs`.
+/// Implementation notes:
+///   - Uses `std::process::Command` (synchronous) inside `spawn_blocking`
+///     with stdout/stderr redirected to temp files. The
+///     `tokio::process::Command::output()` async pipe path hangs on
+///     macOS inside Tauri `.app` bundles — see the matching workaround
+///     in `cli.rs::start_login()`.
+///   - Captures HOME and PATH up front because `.app` bundles launched
+///     from Finder strip the env, leaving `bash`/`curl` unfindable.
 #[cfg(windows)]
 pub async fn install() -> Result<PathBuf, String> {
-    // The upstream installer is a POSIX `curl | bash` one-liner. Composio
-    // publishes Windows binaries but the install path is different; until
-    // we wire it up, surface a clear error so the UI can direct the user.
-    // Tracked in `knowledge-base/platform-matrix.md`.
+    if let Some(p) = houston_cli_bundle::bundled_composio_binary() {
+        tracing::info!(
+            "[composio:install] bundled CLI present at {} — skipping standalone install",
+            p.display()
+        );
+        return Ok(p);
+    }
+    // Composio's POSIX `curl | bash` installer doesn't apply on Windows;
+    // until the Windows ship target lands we surface a clear error so the
+    // UI can direct the user. Tracked in
+    // `knowledge-base/platform-matrix.md`.
     Err(
         "Composio CLI auto-install is not supported on Windows yet. \
          Install `composio` manually (https://composio.dev/install) and \
@@ -86,11 +120,16 @@ pub async fn install() -> Result<PathBuf, String> {
 
 #[cfg(not(windows))]
 pub async fn install() -> Result<PathBuf, String> {
-    tracing::info!("[composio:install] running install script…");
+    if let Some(p) = houston_cli_bundle::bundled_composio_binary() {
+        tracing::info!(
+            "[composio:install] bundled CLI present at {} — skipping standalone install",
+            p.display()
+        );
+        return Ok(p);
+    }
 
-    // Capture HOME and PATH before entering spawn_blocking — macOS
-    // `.app` bundles launched from Finder can have a stripped env where
-    // `curl` and `bash` aren't on PATH.
+    tracing::info!("[composio:install] running standalone install script…");
+
     let home = std::env::var("HOME").unwrap_or_default();
     let path = std::env::var("PATH").unwrap_or_default();
 
@@ -105,9 +144,10 @@ pub async fn install() -> Result<PathBuf, String> {
             let stderr_file = std::fs::File::create(&tmp_err)
                 .map_err(|e| format!("Failed to create temp file: {e}"))?;
 
-            // `curl | bash` is the documented install command on composio.dev.
-            // We shell out to `bash -c` so `set -euo pipefail` in the script
-            // still takes effect. stdin is closed so the script can't prompt.
+            // `curl | bash` is the documented install command on
+            // composio.dev. We shell out to `bash -c` so `set -euo
+            // pipefail` in the upstream script still takes effect.
+            // stdin is closed so the script can't prompt.
             let status = std::process::Command::new("bash")
                 .arg("-c")
                 .arg("curl -fsSL https://composio.dev/install | bash")
@@ -162,12 +202,29 @@ pub async fn install() -> Result<PathBuf, String> {
         ));
     }
 
-    tracing::info!("[composio:install] installed at {}", cli_path().display());
-    Ok(cli_path())
+    let resolved = cli_path();
+    tracing::info!("[composio:install] installed at {}", resolved.display());
+    Ok(resolved)
 }
 
 fn home_dir() -> PathBuf {
-    // Cross-platform: macOS/Linux set HOME, Windows sets USERPROFILE. The
-    // `dirs` crate papers over both.
+    // Cross-platform: macOS/Linux set HOME, Windows sets USERPROFILE.
+    // The `dirs` crate papers over both.
     dirs::home_dir().unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `cli_path()` falls back to the standalone path when no bundle is
+    /// present. The bundle path branch is exercised by integration tests
+    /// that fake an `.app` layout in `houston-cli-bundle::tests`.
+    #[test]
+    fn cli_path_falls_back_to_standalone_in_dev() {
+        // Tests run inside cargo's target dir, never inside an `.app`
+        // bundle — so the fallback should always be standalone here.
+        let p = cli_path();
+        assert!(p.ends_with(".composio/composio") || p.ends_with(".composio/composio.exe"));
+    }
 }

--- a/engine/houston-composio/src/lifecycle.rs
+++ b/engine/houston-composio/src/lifecycle.rs
@@ -1,17 +1,29 @@
-//! Composio CLI lifecycle — auto-install and auto-upgrade.
+//! Composio CLI lifecycle — bundle-aware install + upgrade.
 //!
-//! Called once during app startup as a background task:
-//! 1. If the CLI is missing → install it automatically (no user button).
-//! 2. If Houston's version changed since the last check → run `composio upgrade`.
+//! Called once during engine startup as a background task:
 //!
-//! Emits `HoustonEvent::ComposioCliReady` on success so the frontend can
-//! invalidate the connections query and update the integrations tab.
+//! - **Bundled build**: detect the bundled CLI, emit `ComposioCliReady`,
+//!   record the Houston version marker, return. No install, no upgrade
+//!   — the bundled binary is the version we shipped, and overwriting it
+//!   with `composio upgrade` would either fail (read-only `.app`) or
+//!   silently write to `~/.composio/` and confuse the resolver next
+//!   boot.
+//!
+//! - **Standalone build**: install the CLI if missing (one-time
+//!   `curl | bash`), then run `composio upgrade` whenever Houston's
+//!   version changes since the last successful check (so security fixes
+//!   in the upstream CLI roll out alongside Houston releases without
+//!   requiring user action).
+//!
+//! Emits `HoustonEvent::ComposioCliReady` on success so the frontend
+//! invalidates the connections query and the integrations tab refreshes.
 
 use crate::install;
-use houston_ui_events::{DynEventSink, HoustonEvent};
 use houston_db::db::Database;
+use houston_ui_events::{DynEventSink, HoustonEvent};
 
-/// Preferences key storing the Houston version that last ensured the CLI.
+/// Preferences key storing the Houston version that last successfully
+/// ensured the standalone CLI. Skipped entirely for bundled builds.
 const PREF_CLI_VERSION: &str = "composio_cli_houston_version";
 
 /// Current Houston version (read from Cargo.toml at compile time).
@@ -20,9 +32,16 @@ const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 /// Run the full lifecycle check: install if missing, upgrade if Houston
 /// version changed. Emits events so the frontend reacts.
 pub async fn ensure_and_upgrade(sink: DynEventSink, db: Database) {
-    let installed = install::is_installed();
+    if install::is_bundled() {
+        tracing::info!(
+            "[composio:lifecycle] bundled CLI detected at {} — skipping install/upgrade",
+            install::cli_path().display()
+        );
+        sink.emit(HoustonEvent::ComposioCliReady);
+        return;
+    }
 
-    if !installed {
+    if !install::is_installed() {
         tracing::info!("[composio:lifecycle] CLI not found — auto-installing");
         match install::install().await {
             Ok(path) => {
@@ -39,7 +58,8 @@ pub async fn ensure_and_upgrade(sink: DynEventSink, db: Database) {
         }
     }
 
-    // Upgrade if Houston's version changed since last check.
+    // Upgrade if Houston's version changed since last check. Bundled
+    // builds never reach this branch — they returned early above.
     let last_version = db
         .get_preference(PREF_CLI_VERSION)
         .await
@@ -50,7 +70,11 @@ pub async fn ensure_and_upgrade(sink: DynEventSink, db: Database) {
     if last_version != APP_VERSION && install::is_installed() {
         tracing::info!(
             "[composio:lifecycle] Houston version changed ({} → {}) — upgrading CLI",
-            if last_version.is_empty() { "none" } else { &last_version },
+            if last_version.is_empty() {
+                "none"
+            } else {
+                &last_version
+            },
             APP_VERSION
         );
         match run_upgrade().await {
@@ -58,12 +82,13 @@ pub async fn ensure_and_upgrade(sink: DynEventSink, db: Database) {
                 tracing::info!("[composio:lifecycle] CLI upgrade succeeded");
             }
             Err(e) => {
-                // Upgrade failure is non-fatal — the existing CLI still works.
+                // Upgrade failure is non-fatal — the existing CLI still
+                // works. We log + record the version anyway so we don't
+                // retry every launch; the next Houston update tries
+                // again.
                 tracing::warn!("[composio:lifecycle] CLI upgrade failed (non-fatal): {e}");
             }
         }
-        // Record the version even if upgrade failed — we don't want to
-        // retry every launch. The next Houston update will try again.
         if let Err(e) = db.set_preference(PREF_CLI_VERSION, APP_VERSION).await {
             tracing::warn!("[composio:lifecycle] failed to persist version marker: {e}");
         }
@@ -73,7 +98,9 @@ pub async fn ensure_and_upgrade(sink: DynEventSink, db: Database) {
 }
 
 /// Run `composio upgrade` via the same sync-Command + spawn_blocking
-/// pattern used by the install function.
+/// pattern used by the install function. Standalone-only — never called
+/// when the bundled CLI is present (would try to overwrite a read-only
+/// signed binary inside the `.app`).
 async fn run_upgrade() -> Result<(), String> {
     let bin = install::cli_path();
     let home = std::env::var("HOME").unwrap_or_default();

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -22,6 +22,8 @@ houston-agent-files = { workspace = true }
 houston-skills = { workspace = true, features = ["remote"] }
 houston-engine-protocol = { workspace = true }
 houston-agents-conversations = { workspace = true }
+houston-cli-bundle = { workspace = true }
+houston-claude-installer = { workspace = true }
 dirs-next = "2"
 dirs = "5"
 reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }

--- a/engine/houston-engine-core/src/provider.rs
+++ b/engine/houston-engine-core/src/provider.rs
@@ -13,6 +13,28 @@ use std::time::Duration;
 
 pub const DEFAULT_PROVIDER_KEY: &str = "default_provider";
 
+/// Where the resolved CLI binary came from. Surfaced to the UI so users
+/// understand which version of `claude` / `codex` is in play (matches
+/// the "bundled by Houston vs. your existing install" UX clarification
+/// users have asked for).
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum InstallSource {
+    /// Shipped inside the Houston `.app` (`Contents/Resources/bin/`).
+    /// Codex falls in this bucket on production builds; composio too;
+    /// claude-code never (proprietary license).
+    Bundled,
+    /// Downloaded by Houston at runtime to a Houston-managed location
+    /// (`~/.local/bin/claude` etc.). Claude-code falls in this bucket
+    /// after the first-launch installer completes.
+    Managed,
+    /// Found on the user's PATH outside Houston's control (homebrew,
+    /// npm, manual install, …). Houston uses it as-is.
+    Path,
+    /// Not installed anywhere Houston knows about.
+    Missing,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone)]
 #[serde(rename_all = "camelCase")]
 pub struct ProviderStatus {
@@ -20,6 +42,11 @@ pub struct ProviderStatus {
     pub cli_installed: bool,
     pub authenticated: bool,
     pub cli_name: String,
+    /// Where Houston found the CLI binary. Used for UI labelling.
+    pub install_source: InstallSource,
+    /// Absolute path to the binary that will be spawned. `None` when
+    /// `install_source == Missing`.
+    pub cli_path: Option<String>,
 }
 
 /// Parse a provider name string, mapping errors onto `CoreError::BadRequest`.
@@ -75,14 +102,42 @@ pub fn launch_login(provider: Provider) -> CoreResult<()> {
 }
 
 async fn check_claude_status() -> ProviderStatus {
-    let cli_installed = claude_path::is_command_available("claude");
-    let authenticated = if cli_installed { check_claude_auth().await } else { false };
+    let (install_source, cli_path) = resolve_claude();
+    let cli_installed = !matches!(install_source, InstallSource::Missing);
+    let authenticated = if cli_installed {
+        check_claude_auth().await
+    } else {
+        false
+    };
     ProviderStatus {
         provider: "anthropic".into(),
         cli_installed,
         authenticated,
         cli_name: "claude".into(),
+        install_source,
+        cli_path: cli_path.map(|p| p.to_string_lossy().into_owned()),
     }
+}
+
+/// Resolve the active claude binary in priority order:
+///   1. **Managed** — installed by `houston-claude-installer` at the
+///      Houston-controlled location. We trust this most because we
+///      sha256-verified the download against the pinned manifest.
+///   2. **Path** — anything else on PATH (homebrew, npm, manual). Used
+///      verbatim; Houston does NOT validate the version when the
+///      binary is user-managed.
+///
+/// Claude is never bundled (proprietary license), so the `Bundled`
+/// branch is intentionally absent here — see the `cli-bundle` module
+/// doc for the policy reasoning.
+fn resolve_claude() -> (InstallSource, Option<PathBuf>) {
+    if houston_claude_installer::is_installed() {
+        return (InstallSource::Managed, Some(houston_claude_installer::cli_path()));
+    }
+    if let Some(path) = which_on_path("claude") {
+        return (InstallSource::Path, Some(path));
+    }
+    (InstallSource::Missing, None)
 }
 
 /// `claude --version` succeeds without auth; `claude auth status` returns
@@ -112,7 +167,8 @@ async fn check_claude_auth() -> bool {
 }
 
 async fn check_codex_status() -> ProviderStatus {
-    let cli_installed = claude_path::is_command_available("codex");
+    let (install_source, cli_path) = resolve_codex();
+    let cli_installed = !matches!(install_source, InstallSource::Missing);
     let authenticated = if cli_installed {
         let home = std::env::var("HOME").unwrap_or_default();
         if check_codex_auth(&home) {
@@ -130,7 +186,48 @@ async fn check_codex_status() -> ProviderStatus {
         cli_installed,
         authenticated,
         cli_name: "codex".into(),
+        install_source,
+        cli_path: cli_path.map(|p| p.to_string_lossy().into_owned()),
     }
+}
+
+/// Resolve the active codex binary:
+///   1. **Bundled** — universal Mach-O at `Resources/bin/codex` shipped
+///      with the Houston `.app`. Production users never hit anything
+///      else.
+///   2. **Path** — user-installed copy (homebrew, manual). Allowed for
+///      developers who want to test against a newer codex than the
+///      pinned bundled version.
+fn resolve_codex() -> (InstallSource, Option<PathBuf>) {
+    if let Some(p) = houston_cli_bundle::bundled_codex_path() {
+        return (InstallSource::Bundled, Some(p));
+    }
+    if let Some(path) = which_on_path("codex") {
+        return (InstallSource::Path, Some(path));
+    }
+    (InstallSource::Missing, None)
+}
+
+/// Walk the resolved PATH (login shell + Houston-augmented dirs) for a
+/// command. Returns the first hit's absolute path.
+fn which_on_path(command: &str) -> Option<PathBuf> {
+    let shell_path = claude_path::shell_path();
+    for dir in std::env::split_paths(&shell_path) {
+        let candidate = dir.join(command);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        {
+            for ext in ["exe", "cmd", "bat", "ps1"] {
+                let c = dir.join(format!("{command}.{ext}"));
+                if c.is_file() {
+                    return Some(c);
+                }
+            }
+        }
+    }
+    None
 }
 
 fn check_codex_auth(home: &str) -> bool {
@@ -189,5 +286,17 @@ mod tests {
         assert!(parse("gemini").is_err());
         assert!(parse("anthropic").is_ok());
         assert!(parse("openai").is_ok());
+    }
+
+    #[test]
+    fn install_source_serializes_lowercase() {
+        let s = serde_json::to_string(&InstallSource::Bundled).unwrap();
+        assert_eq!(s, "\"bundled\"");
+        let s = serde_json::to_string(&InstallSource::Managed).unwrap();
+        assert_eq!(s, "\"managed\"");
+        let s = serde_json::to_string(&InstallSource::Path).unwrap();
+        assert_eq!(s, "\"path\"");
+        let s = serde_json::to_string(&InstallSource::Missing).unwrap();
+        assert_eq!(s, "\"missing\"");
     }
 }

--- a/engine/houston-engine-protocol/src/lib.rs
+++ b/engine/houston-engine-protocol/src/lib.rs
@@ -148,6 +148,9 @@ pub fn event_topic(event: &HoustonEvent) -> String {
         HoustonEvent::ComposioCliReady | HoustonEvent::ComposioCliFailed { .. } => {
             "composio".into()
         }
+        HoustonEvent::ClaudeCliInstalling { .. }
+        | HoustonEvent::ClaudeCliReady
+        | HoustonEvent::ClaudeCliFailed { .. } => "claude".into(),
     }
 }
 

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -28,6 +28,8 @@ futures-util = "0.3"
 houston-engine-protocol = { version = "0.4.0", path = "../houston-engine-protocol" }
 houston-engine-core = { version = "0.4.0", path = "../houston-engine-core" }
 houston-composio = { workspace = true }
+houston-claude-installer = { workspace = true }
+houston-cli-bundle = { workspace = true }
 houston-tunnel = { workspace = true }
 houston-db = { workspace = true }
 async-trait = { workspace = true }

--- a/engine/houston-engine-server/src/lib.rs
+++ b/engine/houston-engine-server/src/lib.rs
@@ -38,6 +38,7 @@ pub fn build_router(state: Arc<ServerState>) -> Router {
         .merge(routes::agents::router())
         .merge(routes::agent_files::router())
         .merge(routes::composio::router())
+        .merge(routes::claude::router())
         .merge(routes::tunnel::router())
         .merge(routes::watcher::router())
         .layer(middleware::from_fn_with_state(

--- a/engine/houston-engine-server/src/main.rs
+++ b/engine/houston-engine-server/src/main.rs
@@ -92,6 +92,15 @@ async fn main() {
     // port, which we know now.
     spawn_tunnel_if_allocated(state.clone(), actual.port());
 
+    // Bundled-/runtime-CLI lifecycles. Fire-and-forget — both publish
+    // `HoustonEvent`s for the frontend to react to and never block the
+    // engine's HTTP server from coming up. Composio resolves to the
+    // bundled .app binary in production (no install step) or runs the
+    // upstream `curl | bash` installer for dev / unbundled builds.
+    // Claude Code is downloaded with sha256 verification using the
+    // pinned manifest in cli-deps.json.
+    spawn_cli_lifecycles(state.clone());
+
     let app = build_router(state);
 
     // Block on PATH resolution just before serving. DB init usually
@@ -106,6 +115,32 @@ async fn main() {
     if let Err(err) = axum::serve(listener, app).await {
         tracing::error!("server error: {err}");
         std::process::exit(1);
+    }
+}
+
+/// Kick off the bundled-/runtime-CLI lifecycles in the background.
+///
+/// Both run on independent tasks so a slow/failed claude-code download
+/// can't delay composio readiness (or vice versa). Each lifecycle emits
+/// its own ready/failed events; the frontend listens on the WS firehose
+/// and updates the relevant queries.
+///
+/// The DB and event sink are cloned into each task — both are cheap
+/// `Arc` clones internally.
+fn spawn_cli_lifecycles(state: Arc<ServerState>) {
+    {
+        let sink = state.engine.events.clone();
+        let db = state.engine.db.clone();
+        tokio::spawn(async move {
+            houston_composio::lifecycle::ensure_and_upgrade(sink, db).await;
+        });
+    }
+    {
+        let sink = state.engine.events.clone();
+        let db = state.engine.db.clone();
+        tokio::spawn(async move {
+            houston_claude_installer::ensure_and_upgrade(sink, db).await;
+        });
     }
 }
 

--- a/engine/houston-engine-server/src/routes/claude.rs
+++ b/engine/houston-engine-server/src/routes/claude.rs
@@ -1,0 +1,138 @@
+//! `/v1/claude/*` REST routes — runtime installer for Claude Code.
+//!
+//! Status + manual reinstall trigger for the proprietary Claude Code
+//! CLI that Houston downloads on first launch (see
+//! `houston_claude_installer`).
+//!
+//! Provides three endpoints:
+//!
+//! - `GET  /v1/claude/cli-installed` — quick boolean for the UI.
+//! - `GET  /v1/claude/status`        — richer status (path, pinned vs
+//!   installed version, manifest availability) for the diagnostics
+//!   panel.
+//! - `POST /v1/claude/install`       — re-run the install flow on
+//!   demand (e.g. after the user fixes a network issue and clicks
+//!   "Retry"). Returns 202-style — the install runs in the background
+//!   and progress events stream over the WS firehose.
+
+use crate::routes::error::ApiError;
+use crate::state::ServerState;
+use axum::{
+    extract::State,
+    routing::{get, post},
+    Json, Router,
+};
+use houston_engine_core::CoreError;
+use serde::Serialize;
+use std::sync::Arc;
+
+pub fn router() -> Router<Arc<ServerState>> {
+    Router::new()
+        .route("/claude/cli-installed", get(cli_installed))
+        .route("/claude/status", get(status))
+        .route("/claude/install", post(install))
+}
+
+#[derive(Serialize)]
+struct CliInstalled {
+    installed: bool,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ClaudeStatus {
+    /// True iff a `claude` binary exists at the install target with
+    /// the executable bit set.
+    installed: bool,
+    /// Absolute install target, even if the binary isn't there yet.
+    install_path: String,
+    /// Version pinned by the bundled `cli-deps.json`. `None` when the
+    /// manifest isn't available (degraded dev environment).
+    pinned_version: Option<String>,
+    /// Version we last successfully installed. `None` on first boot.
+    /// Used by the lifecycle to decide whether to re-download on a
+    /// Houston upgrade that bumps the pinned version.
+    installed_version: Option<String>,
+}
+
+fn lift(e: String) -> ApiError {
+    ApiError(CoreError::Internal(e))
+}
+
+async fn cli_installed(State(_st): State<Arc<ServerState>>) -> Json<CliInstalled> {
+    Json(CliInstalled {
+        installed: houston_claude_installer::is_installed(),
+    })
+}
+
+async fn status(State(st): State<Arc<ServerState>>) -> Json<ClaudeStatus> {
+    let installed = houston_claude_installer::is_installed();
+    let install_path = houston_claude_installer::cli_path()
+        .to_string_lossy()
+        .to_string();
+
+    let pinned_version = houston_cli_bundle::load_bundled_manifest()
+        .and_then(|m| m.entry("claude-code").map(|e| e.version));
+
+    let installed_version = st
+        .engine
+        .db
+        .get_preference("claude_code_installed_version")
+        .await
+        .ok()
+        .flatten();
+
+    Json(ClaudeStatus {
+        installed,
+        install_path,
+        pinned_version,
+        installed_version,
+    })
+}
+
+/// Trigger a fresh install in the background. The request returns
+/// immediately; install progress + completion are emitted as
+/// `HoustonEvent::ClaudeCliInstalling` / `ClaudeCliReady` /
+/// `ClaudeCliFailed` over the WebSocket firehose.
+async fn install(State(st): State<Arc<ServerState>>) -> Result<(), ApiError> {
+    let manifest = houston_cli_bundle::load_bundled_manifest()
+        .ok_or_else(|| lift("cli-deps.json manifest not available — install pinned manifest first".into()))?;
+    let entry = manifest
+        .entry("claude-code")
+        .ok_or_else(|| lift("cli-deps.json missing 'claude-code' entry".into()))?;
+    let pinned_version = entry.version.clone();
+
+    // Run the actual install on a background task so the HTTP request
+    // returns immediately. The lifecycle entry would emit the same
+    // events, but going through `install()` directly lets us run the
+    // install even when the version marker already matches (manual
+    // "reinstall" from the UI).
+    let sink = st.engine.events.clone();
+    let db = st.engine.db.clone();
+    tokio::spawn(async move {
+        sink.emit(houston_ui_events::HoustonEvent::ClaudeCliInstalling { progress_pct: 0 });
+        let sink_for_progress = sink.clone();
+        let result =
+            houston_claude_installer::install(&entry, move |pct| {
+                sink_for_progress
+                    .emit(houston_ui_events::HoustonEvent::ClaudeCliInstalling { progress_pct: pct });
+            })
+            .await;
+        match result {
+            Ok(_) => {
+                if let Err(e) = db
+                    .set_preference("claude_code_installed_version", &pinned_version)
+                    .await
+                {
+                    tracing::warn!("[claude:install] failed to persist version marker: {e}");
+                }
+                sink.emit(houston_ui_events::HoustonEvent::ClaudeCliReady);
+            }
+            Err(e) => {
+                sink.emit(houston_ui_events::HoustonEvent::ClaudeCliFailed { message: e });
+            }
+        }
+    });
+
+    Ok(())
+}

--- a/engine/houston-engine-server/src/routes/mod.rs
+++ b/engine/houston-engine-server/src/routes/mod.rs
@@ -4,6 +4,7 @@ pub mod agent_configs;
 pub mod agent_files;
 pub mod agents;
 pub mod attachments;
+pub mod claude;
 pub mod composio;
 pub mod conversations;
 pub mod error;

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -15,3 +15,8 @@ tracing = { workspace = true }
 # Windows). Used by `claude_path` to expand `~/...` entries in the common
 # install-dir list.
 dirs = "5"
+# Bundled-CLI resolver (codex, composio) for the Houston `.app`. Lets
+# `claude_path` prepend the bundled-bin directories to the resolved PATH
+# so subprocess spawns of `claude`/`codex`/`composio` find them without
+# any user-side shell config.
+houston-cli-bundle = { workspace = true }

--- a/engine/houston-terminal-manager/src/claude_path.rs
+++ b/engine/houston-terminal-manager/src/claude_path.rs
@@ -59,6 +59,19 @@ pub fn init() {
         let mut final_path =
             shell_resolved.unwrap_or_else(|| std::env::var_os("PATH").unwrap_or_default());
 
+        // Bundled-CLI directories — codex (single binary) and composio
+        // (per-arch directory). These ride inside the signed `.app` so
+        // subprocess spawns must be able to resolve them without any
+        // user-side shell config (PATH manipulation in `~/.zshrc`,
+        // homebrew, nvm, etc.). Returned in priority order; we
+        // `prepend_path` so the bundled copies WIN over any same-named
+        // binaries from the user's shell — production users get the
+        // exact version we shipped + signed, not whatever happens to be
+        // first on their PATH.
+        for dir in houston_cli_bundle::bundled_path_entries() {
+            prepend_path(&mut final_path, &dir);
+        }
+
         // Expand `~` against the user home directory using the cross-platform
         // `dirs` resolver (HOME on Unix, USERPROFILE on Windows). Falls back
         // to the raw prefix if home can't be resolved — the directory check
@@ -133,6 +146,26 @@ pub fn is_command_available(command: &str) -> bool {
         }
     }
     false
+}
+
+/// Prepend `dir` to `base` so it wins over any same-named binary later
+/// in PATH. Used for bundled CLIs — the production-shipped version must
+/// take precedence over whatever the user has installed via
+/// homebrew/npm/nvm. Idempotent: if `dir` is already first, no change;
+/// if present elsewhere it's moved to the front.
+fn prepend_path(base: &mut OsString, dir: &std::path::Path) {
+    let mut parts: Vec<PathBuf> = std::env::split_paths(base).collect();
+    // Drop any existing occurrence so we don't double-list.
+    parts.retain(|p| p != dir);
+    parts.insert(0, dir.to_path_buf());
+    if let Ok(joined) = std::env::join_paths(&parts) {
+        *base = joined;
+    } else {
+        tracing::debug!(
+            "[claude_path] prepend_path/join_paths failed for {}",
+            dir.display()
+        );
+    }
 }
 
 /// Append `dir` to `base` using the platform-appropriate PATH separator
@@ -280,5 +313,47 @@ mod tests {
         assert!(!is_command_available(
             "definitely-not-a-real-binary-xyz-zzz-houston-test"
         ));
+    }
+
+    #[test]
+    fn prepend_path_moves_existing_to_front() {
+        let mut p = if cfg!(windows) {
+            OsString::from("C:\\a;C:\\b;C:\\c")
+        } else {
+            OsString::from("/a:/b:/c")
+        };
+        let middle = if cfg!(windows) {
+            PathBuf::from("C:\\b")
+        } else {
+            PathBuf::from("/b")
+        };
+        prepend_path(&mut p, &middle);
+        let expected = if cfg!(windows) {
+            OsString::from("C:\\b;C:\\a;C:\\c")
+        } else {
+            OsString::from("/b:/a:/c")
+        };
+        assert_eq!(p, expected);
+    }
+
+    #[test]
+    fn prepend_path_inserts_new_dir_at_front() {
+        let mut p = if cfg!(windows) {
+            OsString::from("C:\\a")
+        } else {
+            OsString::from("/a")
+        };
+        let new_dir = if cfg!(windows) {
+            PathBuf::from("C:\\b")
+        } else {
+            PathBuf::from("/b")
+        };
+        prepend_path(&mut p, &new_dir);
+        let expected = if cfg!(windows) {
+            OsString::from("C:\\b;C:\\a")
+        } else {
+            OsString::from("/b:/a")
+        };
+        assert_eq!(p, expected);
     }
 }

--- a/engine/houston-ui-events/src/lib.rs
+++ b/engine/houston-ui-events/src/lib.rs
@@ -127,6 +127,25 @@ pub enum HoustonEvent {
     ComposioCliReady,
     /// Composio CLI install or upgrade failed.
     ComposioCliFailed { message: String },
+
+    // ----- Claude Code CLI lifecycle -----
+    //
+    // Claude Code can't be bundled (proprietary license) so the engine
+    // downloads it on first launch via `houston-claude-installer`. The
+    // frontend uses these events to render the install progress banner
+    // and re-check provider auth status once ready.
+
+    /// Claude Code CLI download in progress. `progress_pct` is 0-100;
+    /// emitted at most every 10 percentage points so the channel isn't
+    /// flooded during a ~120 MB download.
+    ClaudeCliInstalling { progress_pct: u8 },
+    /// Claude Code CLI is installed (either freshly downloaded or
+    /// already at the pinned version). Frontend invalidates the
+    /// `provider_status` query so the Anthropic provider chip updates.
+    ClaudeCliReady,
+    /// Claude Code CLI install or upgrade failed. `message` is intended
+    /// to be user-readable (network/region/permissions/disk-space hints).
+    ClaudeCliFailed { message: String },
 }
 
 // ---------------------------------------------------------------------------

--- a/knowledge-base/architecture.md
+++ b/knowledge-base/architecture.md
@@ -40,7 +40,7 @@ Houston = open platform. Organized as **6 products + 3 code libraries**.
 
 ## Engine crates (`engine/`)
 
-13 crates. All pure libraries. No frontend assumptions. Full list in
+15 crates. All pure libraries. No frontend assumptions. Full list in
 the workspace root `Cargo.toml`.
 
 - `houston-db` — libSQL. `chat_feed`, `preferences`, `engine_tokens` tables.
@@ -51,12 +51,20 @@ the workspace root `Cargo.toml`.
 - `houston-agents-conversations` — chat feed persistence
 - `houston-ui-events` — typed event bus + `EventSink` trait (Tauri/broadcast impls, frontend-neutral)
 - `houston-file-watcher` — `notify` on `.houston/`, emits events
-- `houston-composio` — Composio MCP server lifecycle
+- `houston-composio` — Composio CLI lifecycle (bundle-aware: skips install when shipped inside the .app)
+- `houston-cli-bundle` — resolve bundled CLI binaries (codex universal, composio per-arch) inside the `.app`/MSI; reads pinned `cli-deps.json` manifest
+- `houston-claude-installer` — runtime download of Claude Code CLI (proprietary license, can't bundle); pinned URL + sha256 verification, atomic install, progress events
 - `houston-tunnel` — outbound reverse tunnel client; desktop engine dials the relay so mobile can reach it through NAT. Heartbeat + watchdog + identity re-allocation on persistent auth failure.
 - `houston-skills` — skill discovery + management
 - `houston-engine-core` — runtime container (`EngineState`, paths, `workspaces::*`, `agents::{activity,routines,routine_runs,config,conversations,files,prompt,self_improvement}`, `sessions::{history,provider,summarize}`, `routines::{runner,runs,scheduler,engine_dispatcher}`, `store`, `sync`, `worktree`, `provider`, `attachments`, `preferences`, `conversations`, `skills`, `agent_configs`). Domain logic relocated from the Tauri adapter.
 - `houston-engine-protocol` — wire types (REST DTOs, WS envelope, error codes, `PROTOCOL_VERSION`). Matches `ui/engine-client/src/types.ts`.
-- `houston-engine-server` — axum HTTP+WS binary `houston-engine`. The process every client talks to. Full REST surface live — 16 route modules covering workspaces, agents CRUD, sessions, agent data + files, routines + scheduler, skills, store, composio, tunnel + pairing, worktrees, shell, attachments, preferences, providers, agent-configs, conversations, watcher. See `knowledge-base/engine-protocol.md` for the complete table.
+- `houston-engine-server` — axum HTTP+WS binary `houston-engine`. The process every client talks to. Full REST surface live — 17 route modules covering workspaces, agents CRUD, sessions, agent data + files, routines + scheduler, skills, store, composio, claude (runtime install), tunnel + pairing, worktrees, shell, attachments, preferences, providers, agent-configs, conversations, watcher. See `knowledge-base/engine-protocol.md` for the complete table.
+
+**Bundled provider CLIs:** Houston ships the codex CLI (Apache-2.0) and
+composio CLI (MIT) inside the signed/notarized `.app` so non-technical
+users get them preinstalled. The proprietary Claude Code CLI is
+downloaded on first launch with sha256 verification. Resolution + install
+flow detailed in `knowledge-base/cli-bundling.md`.
 
 **Standalone engine, shipped:** the desktop app spawns `houston-engine`
 as a subprocess on startup (sidecar via Tauri `externalBin`), parses

--- a/knowledge-base/cli-bundling.md
+++ b/knowledge-base/cli-bundling.md
@@ -1,0 +1,183 @@
+# Bundled CLIs — codex, composio, claude-code
+
+Houston ships two upstream CLIs inside the signed/notarized desktop
+`.app` and runtime-downloads a third. The goal is zero terminal exposure
+for non-technical users — they install Houston, click in, and the chat
+agent works without ever opening a shell.
+
+## What ships where
+
+| CLI         | License       | Distribution      | Where it lives                                                        |
+|-------------|---------------|-------------------|------------------------------------------------------------------------|
+| codex       | Apache-2.0    | Bundled (universal) | `Houston.app/Contents/Resources/bin/codex` — single Mach-O fat binary |
+| composio    | MIT           | Bundled (per-arch)  | `Resources/bin/composio-aarch64/`, `Resources/bin/composio-x86_64/`   |
+| claude-code | PROPRIETARY   | Runtime download    | `~/.local/bin/claude` (`%LOCALAPPDATA%\Programs\claude\claude.exe`)   |
+
+claude-code is licensed in a way that doesn't permit redistribution, so
+we can't bundle it. Instead the engine downloads + sha256-verifies on
+first launch using a manifest pinned in `cli-deps.json`.
+
+codex is a Rust binary so we `lipo -create` the two arch tarballs into
+one universal binary. composio is a Bun-bundled JS app whose runtime is
+arch-specific — `lipo` can't combine them, so we ship both and the
+engine resolves the right directory at runtime via `std::env::consts::ARCH`.
+
+## Pinned manifest — `cli-deps.json`
+
+`cli-deps.json` at the repo root is the single source of truth for
+versions, URLs, and SHA-256 checksums. CI fetches based on it. The
+runtime claude-code installer reads it from the bundle. Bumping a
+version:
+
+```bash
+./scripts/bump-cli.sh codex 0.122.0
+./scripts/fetch-cli-deps.sh both    # downloads + prints new checksums
+# paste the printed checksums into cli-deps.json
+./scripts/fetch-cli-deps.sh both    # re-run, this time verifies
+```
+
+The manifest is staged into the .app at
+`Resources/bin/cli-deps.json` so the runtime claude-code installer can
+read pinned URLs + checksums without a separate network round-trip.
+
+## Build pipeline
+
+`scripts/fetch-cli-deps.sh both`:
+1. Downloads each bundled CLI for both arches using URLs from the manifest.
+2. Verifies sha256 against pinned checksums (mismatch is fatal).
+3. `lipo -create`s the two codex slices into a single universal Mach-O.
+4. Stages each composio arch under `composio-aarch64/` / `composio-x86_64/`.
+5. Prunes cross-platform `acp-adapters/codex/<plat>/` directories that the
+   resolved arch can never execute (~580 MB savings).
+6. Stages `cli-deps.json` itself for the runtime installer.
+
+`tauri.conf.json#bundle.resources` then maps the staging dir verbatim
+into the `.app`:
+
+```jsonc
+"resources": { "resources/bin": "bin" }
+```
+
+CI: `.github/workflows/release.yml` calls `fetch-cli-deps.sh both` before
+the tauri build, then verifies layout + signing invariants for every
+Mach-O inside `Resources/bin/` (Developer ID, hardened runtime, both
+arch slices).
+
+## Runtime resolution
+
+`engine/houston-cli-bundle/` is the resolver crate. Public functions:
+
+- `bundled_bin_dir() -> Option<PathBuf>` — top of the bundle dir, or
+  `None` outside a recognizable .app/MSI layout.
+- `bundled_codex_path()` — universal codex binary if bundled.
+- `bundled_composio_binary()` — composio binary for the host arch.
+- `bundled_path_entries()` — dirs to prepend to PATH so subprocesses
+  resolve the bundled copies.
+- `load_bundled_manifest()` → `CliDepsManifest` with typed `CliEntry`
+  accessors.
+
+Detection is structural — we walk parent dirs of `current_exe()`
+checking for `Houston.app/Contents/MacOS/<exe>` (macOS) or a sibling
+`resources/bin/` (Windows). No env vars; works even when launched from
+Spotlight, Dock, or Finder.
+
+`engine/houston-terminal-manager/src/claude_path.rs` prepends the
+bundled paths to the resolved login-shell PATH so subprocess
+spawns of `claude`/`codex`/`composio` find the bundled copies before
+anything on the user's PATH.
+
+## Lifecycle — auto-install + auto-upgrade
+
+`engine/houston-engine-server/src/main.rs` spawns two background tasks at
+boot:
+
+1. `houston_composio::lifecycle::ensure_and_upgrade` — emits
+   `ComposioCliReady` immediately when bundled is present (production).
+   For dev / unbundled builds, runs the upstream `curl | bash` installer
+   into `~/.composio` and runs `composio upgrade` on Houston version
+   bumps.
+
+2. `houston_claude_installer::ensure_and_upgrade` — reads
+   `cli-deps.json` for the pinned `claude-code` version and:
+   - If installed at the pinned version → emit `ClaudeCliReady`.
+   - Else → stream-download with sha256 verification, atomic rename
+     into `~/.local/bin/claude`, persist version marker, emit
+     `ClaudeCliInstalling { progress_pct }` then `ClaudeCliReady`.
+   - On failure → `ClaudeCliFailed { message }`.
+
+Both run on independent tasks so a slow claude download never blocks
+composio readiness.
+
+## API surface — `/v1/claude/*`
+
+Mirrors `/v1/composio/*`:
+
+- `GET /v1/claude/cli-installed` → `{ installed: bool }`.
+- `GET /v1/claude/status` → `{ installed, installPath, pinnedVersion, installedVersion }`.
+- `POST /v1/claude/install` → kicks off a fresh install in the
+  background. Progress + completion stream over the WS firehose as
+  `ClaudeCliInstalling` / `ClaudeCliReady` / `ClaudeCliFailed` events.
+
+`ProviderStatus` (returned by `GET /v1/providers/<name>/status`) gains
+two new fields:
+
+- `installSource: "bundled" | "managed" | "path" | "missing"` —
+  Houston's view of where the binary came from. Renders as a chip in
+  the provider settings UI.
+- `cliPath: string | null` — absolute path Houston will spawn.
+  Surfaces in diagnostics.
+
+## DMG size
+
+Bundled CLIs add ~700 MB to `Resources/`:
+
+- codex universal: 340 MB
+- composio-aarch64: ~180 MB
+- composio-x86_64:  ~190 MB
+
+DMG compression brings the user-facing download to ~350-450 MB. This is
+a deliberate trade — the target user is non-technical and would not
+successfully run a separate installer for each provider CLI.
+
+## Adding a new bundled CLI
+
+1. Add an entry to `cli-deps.json` with `bundled: true`, the upstream
+   URLs per platform, and (initially) empty checksums.
+2. Update `scripts/fetch-cli-deps.sh` if the archive layout differs from
+   the existing patterns (single binary vs. multi-file Bun-style bundle).
+3. Run `./scripts/fetch-cli-deps.sh both` and pin the printed checksums.
+4. Add a resolver in `houston-cli-bundle::lib.rs`
+   (`bundled_<name>_path()`).
+5. If the CLI needs to be on PATH for agents to invoke it, add the
+   directory to `bundled_path_entries()`.
+6. Update the CI bundle-invariant check in `release.yml`.
+
+## Adding a new runtime-downloaded CLI
+
+1. Add an entry to `cli-deps.json` with `bundled: false`,
+   `install_target` (file path), per-platform URLs, and pinned
+   sha256 checksums.
+2. Mirror the `houston-claude-installer` crate structure (or extend it
+   if the auth + version-marker pattern is identical).
+3. Wire into `main.rs::spawn_cli_lifecycles`.
+4. Add `<Name>CliInstalling/Ready/Failed` events to `HoustonEvent` and
+   route them in `engine_protocol::event_topic`.
+5. Add `/v1/<name>/*` REST routes mirroring `routes/claude.rs`.
+
+## Files involved
+
+- `cli-deps.json` — pinned versions, URLs, checksums.
+- `scripts/fetch-cli-deps.sh` — fetch + lipo + prune + stage.
+- `scripts/bump-cli.sh` — version bumper (clears stale checksums).
+- `scripts/install-claude-code.sh` — legacy bash installer; kept for
+  manual recovery / debugging. The Rust runtime installer is the
+  blessed path.
+- `app/src-tauri/tauri.conf.json#bundle.resources` — Tauri-side wiring.
+- `app/src-tauri/build.rs` — ensures the staging dir exists for `pnpm tauri dev`.
+- `engine/houston-cli-bundle/` — resolver crate.
+- `engine/houston-claude-installer/` — runtime download crate.
+- `engine/houston-composio/src/install.rs` — bundle-aware composio resolver.
+- `engine/houston-engine-core/src/provider.rs` — `InstallSource` enum + status.
+- `engine/houston-terminal-manager/src/claude_path.rs` — PATH augmentation.
+- `engine/houston-engine-server/src/routes/claude.rs` — `/v1/claude/*`.
+- `.github/workflows/release.yml` — fetch + verify steps.

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -178,7 +178,7 @@ module.
 | Method | Path | Description |
 |---|---|---|
 | GET/PUT | `/v1/preferences/:key` | String KV (DB-backed) |
-| GET | `/v1/providers/:name/status` | `{cli_installed, authenticated}` |
+| GET | `/v1/providers/:name/status` | `{cli_installed, authenticated, install_source, cli_path}` |
 | POST | `/v1/providers/:name/login` | Launch CLI login |
 | GET | `/v1/agent-configs` | List installed agent definitions |
 
@@ -187,11 +187,18 @@ module.
 |---|---|---|
 | GET | `/v1/composio/status` | Full status bundle |
 | GET | `/v1/composio/cli-installed` | Bool |
-| POST | `/v1/composio/cli` | Install Composio CLI |
+| POST | `/v1/composio/cli` | Install Composio CLI (no-op when bundled — see `knowledge-base/cli-bundling.md`) |
 | POST | `/v1/composio/login` | Start OAuth |
 | POST | `/v1/composio/login/complete` | Finish OAuth w/ `cli_key` |
 | GET | `/v1/composio/apps` | Catalog |
 | GET/POST | `/v1/composio/connections` | List / start connect |
+
+**Claude Code (runtime install — proprietary CLI not bundled)**
+| Method | Path | Description |
+|---|---|---|
+| GET | `/v1/claude/cli-installed` | Bool |
+| GET | `/v1/claude/status` | `{installed, install_path, pinned_version, installed_version}` |
+| POST | `/v1/claude/install` | Trigger background download + sha256 verify; progress streams as `ClaudeCliInstalling` events on the WS firehose |
 
 **Worktrees + shell**
 | Method | Path | Description |

--- a/scripts/fetch-cli-deps.sh
+++ b/scripts/fetch-cli-deps.sh
@@ -1,21 +1,49 @@
 #!/usr/bin/env bash
+# ============================================================================
+# Fetch CLI dependencies pinned in `cli-deps.json` and stage them under
+# `app/src-tauri/resources/bin/` so Tauri's `bundle.resources` glob picks
+# them up at .app build time.
+#
+# Output layout (production, universal .app):
+#
+#   app/src-tauri/resources/bin/
+#     codex                          # universal Mach-O (arm64 + x86_64)
+#     composio-aarch64/              # Apple Silicon Bun bundle
+#       composio
+#       services/
+#       *.mjs
+#     composio-x86_64/               # Intel Bun bundle
+#       composio
+#       services/
+#       *.mjs
+#     cli-deps.json                  # pinned URLs + checksums for runtime
+#                                    # downloads (claude-code) — read by the
+#                                    # houston-claude-installer crate.
+#
+# Why this layout:
+#   - codex is a Rust binary — `lipo` produces one fat universal binary so we
+#     ship a single file regardless of host arch.
+#   - composio is a Bun-bundled JavaScript runtime — CANNOT be lipo'd; the
+#     binary contains an arch-specific Bun runtime + sibling .mjs/services
+#     files. Both arches must be shipped side-by-side under a per-arch dir.
+#   - cli-deps.json travels with the app so the runtime claude-code
+#     installer can read pinned URL+SHA256 without needing network access
+#     to a separate manifest endpoint.
+#
+# Modes:
+#   ./scripts/fetch-cli-deps.sh                # both arches (production)
+#   ./scripts/fetch-cli-deps.sh arm64          # arm64 only (dev convenience)
+#   ./scripts/fetch-cli-deps.sh x64            # x64 only
+#   ./scripts/fetch-cli-deps.sh host           # auto-detect host arch
+#
+# CI ALWAYS uses no-arg form (both arches). Local dev can use `host` to
+# skip downloading the cross-arch slice they don't need.
+#
+# Strict mode: any download or checksum failure is fatal (set -euo pipefail).
+# Partial bundles are unacceptable — we'd ship a broken .app to half the
+# user base.
+# ============================================================================
 set -euo pipefail
-
-# Fetch CLI dependencies defined in cli-deps.json.
-# Downloads binaries for the target platform and places them in
-# app/src-tauri/resources/bin/ for Tauri to bundle into the .app.
-#
-# Output structure:
-#   resources/bin/codex              ← single binary
-#   resources/bin/composio/          ← directory (binary + helpers)
-#     composio
-#     services/
-#     *.mjs
-#
-# Usage:
-#   ./scripts/fetch-cli-deps.sh              # auto-detect arch
-#   ./scripts/fetch-cli-deps.sh arm64        # force arm64
-#   ./scripts/fetch-cli-deps.sh x64          # force x64
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEPS_FILE="$REPO_ROOT/cli-deps.json"
@@ -26,112 +54,319 @@ if [ ! -f "$DEPS_FILE" ]; then
   exit 1
 fi
 
-detect_arch() {
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not installed (brew install jq)" >&2
+  exit 1
+fi
+
+detect_host_arch() {
   case "$(uname -m)" in
     arm64|aarch64) echo "arm64" ;;
     x86_64|amd64)  echo "x64" ;;
-    *) echo "ERROR: unsupported arch $(uname -m)" >&2; exit 1 ;;
+    *) echo "ERROR: unsupported host arch $(uname -m)" >&2; exit 1 ;;
   esac
 }
 
-ARCH="${1:-$(detect_arch)}"
-PLATFORM="darwin-$ARCH"
+MODE="${1:-both}"
+case "$MODE" in
+  both)            ARCHES=("arm64" "x64") ;;
+  arm64)           ARCHES=("arm64") ;;
+  x64)             ARCHES=("x64") ;;
+  host)            ARCHES=("$(detect_host_arch)") ;;
+  *) echo "ERROR: unknown mode '$MODE' (expected: both|arm64|x64|host)" >&2; exit 1 ;;
+esac
 
 mkdir -p "$OUT_DIR"
 
-CLIS=$(jq -r 'keys[] | select(startswith("$") | not)' "$DEPS_FILE")
+# --- Helpers ----------------------------------------------------------------
 
-for cli in $CLIS; do
-  bundled=$(jq -r ".[\"$cli\"].bundled" "$DEPS_FILE")
-  version=$(jq -r ".[\"$cli\"].version" "$DEPS_FILE")
-  binary_name=$(jq -r ".[\"$cli\"].binary_name" "$DEPS_FILE")
+# Download with fail-fast + retry. Avoids a half-written file leaking past a
+# transient network error (curl with --output writes incrementally).
+download() {
+  local url="$1" dest="$2"
+  local attempts=3 i=1
+  while [ "$i" -le "$attempts" ]; do
+    if curl -fsSL --retry 3 --retry-delay 2 -o "$dest" "$url"; then
+      return 0
+    fi
+    echo "  download attempt $i/$attempts failed; retrying…" >&2
+    i=$((i + 1))
+  done
+  return 1
+}
 
-  if [ "$bundled" != "true" ]; then
-    echo "SKIP $cli v$version (downloaded at runtime)"
-    continue
+# Verify SHA-256 checksum. Empty `expected` prints the actual so the user
+# can pin it (used when bumping a CLI version with `bump-cli.sh`).
+verify_or_print_checksum() {
+  local file="$1" expected="$2" label="$3"
+  local actual
+  actual=$(shasum -a 256 "$file" | cut -d' ' -f1)
+  if [ -n "$expected" ]; then
+    if [ "$actual" != "$expected" ]; then
+      echo "ERROR: checksum mismatch for $label" >&2
+      echo "  expected: $expected" >&2
+      echo "  actual:   $actual" >&2
+      return 1
+    fi
+    echo "  $label checksum: OK"
+  else
+    echo "  $label checksum (pin this in cli-deps.json): $actual"
   fi
+  return 0
+}
 
-  url_template=$(jq -r ".[\"$cli\"].urls[\"$PLATFORM\"] // empty" "$DEPS_FILE")
-  expected_checksum=$(jq -r ".[\"$cli\"].checksums[\"$PLATFORM\"] // empty" "$DEPS_FILE")
+# Find the main binary inside an extracted archive. Some archives put the
+# binary at the root, others under a versioned subdirectory.
+find_binary() {
+  local extract_dir="$1" binary_name="$2"
+  find "$extract_dir" -type f \( -name "$binary_name" -o -name "$binary_name-*" \) \
+    | head -1
+}
+
+# Stage a fetched single binary (codex) into a per-arch staging slot.
+# We don't write directly to the final path — codex needs to wait for
+# both arches before lipo'ing.
+stage_codex_arch() {
+  local arch="$1"
+  local platform="darwin-$arch"
+  local version url_template expected url tmp extract_dir bin_path
+  version=$(jq -r '.codex.version' "$DEPS_FILE")
+  url_template=$(jq -r ".codex.urls[\"$platform\"] // empty" "$DEPS_FILE")
+  expected=$(jq -r ".codex.checksums[\"$platform\"] // empty" "$DEPS_FILE")
 
   if [ -z "$url_template" ]; then
-    echo "WARN: no URL for $cli $PLATFORM, skipping" >&2
-    continue
-  fi
-
-  url="${url_template//\{version\}/$version}"
-
-  echo "FETCH $cli v$version ($PLATFORM)"
-  echo "  URL: $url"
-
-  # Download
-  tmp_file=$(mktemp)
-  if ! curl -fsSL -o "$tmp_file" "$url"; then
-    echo "ERROR: download failed for $cli" >&2
-    rm -f "$tmp_file"
+    echo "ERROR: cli-deps.json missing codex URL for $platform" >&2
     exit 1
   fi
 
-  # Verify checksum of the download BEFORE extraction
-  actual_checksum=$(shasum -a 256 "$tmp_file" | cut -d' ' -f1)
-  if [ -n "$expected_checksum" ]; then
-    if [ "$actual_checksum" != "$expected_checksum" ]; then
-      echo "ERROR: checksum mismatch for $cli $PLATFORM" >&2
-      echo "  expected: $expected_checksum" >&2
-      echo "  actual:   $actual_checksum" >&2
-      rm -f "$tmp_file"
-      exit 1
-    fi
-    echo "  Download checksum: OK"
-  else
-    echo "  Download checksum (pin this): $actual_checksum"
-  fi
+  url="${url_template//\{version\}/$version}"
+  echo "FETCH codex v$version ($platform)"
+  echo "  URL: $url"
 
-  # Extract
+  tmp=$(mktemp)
+  download "$url" "$tmp" || { echo "ERROR: codex download failed for $platform" >&2; rm -f "$tmp"; exit 1; }
+  verify_or_print_checksum "$tmp" "$expected" "codex/$platform" || { rm -f "$tmp"; exit 1; }
+
   extract_dir=$(mktemp -d)
   case "$url" in
-    *.tar.gz|*.tgz) tar xzf "$tmp_file" -C "$extract_dir" ;;
-    *.zip)          unzip -q "$tmp_file" -d "$extract_dir" ;;
-    *)              cp "$tmp_file" "$extract_dir/$binary_name" ;;
+    *.tar.gz|*.tgz) tar xzf "$tmp" -C "$extract_dir" ;;
+    *.zip)          unzip -q "$tmp" -d "$extract_dir" ;;
+    *)              cp "$tmp" "$extract_dir/codex" ;;
   esac
-  rm -f "$tmp_file"
+  rm -f "$tmp"
 
-  # Find the main binary — might be named exactly or with platform suffix
-  main_binary=$(find "$extract_dir" -type f \( -name "$binary_name" -o -name "$binary_name-*" \) | head -1)
-
-  if [ -z "$main_binary" ]; then
-    echo "ERROR: binary not found in archive for $cli" >&2
+  bin_path=$(find_binary "$extract_dir" "codex")
+  if [ -z "$bin_path" ]; then
+    echo "ERROR: codex binary not found in archive for $platform" >&2
     find "$extract_dir" -type f | head -20 >&2
     rm -rf "$extract_dir"
     exit 1
   fi
 
-  # Check if the binary has sibling support files (like composio's .mjs + services/)
-  binary_dir=$(dirname "$main_binary")
-  sibling_count=$(find "$binary_dir" -mindepth 1 -maxdepth 1 | wc -l | tr -d ' ')
+  local stage_dir="$OUT_DIR/.staging/codex"
+  mkdir -p "$stage_dir"
+  cp "$bin_path" "$stage_dir/codex-$arch"
+  chmod +x "$stage_dir/codex-$arch"
+  rm -rf "$extract_dir"
 
-  if [ "$sibling_count" -gt 1 ]; then
-    # Multi-file CLI — copy the whole directory
-    dest_dir="$OUT_DIR/$binary_name"
-    rm -rf "$dest_dir"
-    cp -R "$binary_dir" "$dest_dir"
-    actual_name=$(basename "$main_binary")
-    if [ "$actual_name" != "$binary_name" ]; then
-      mv "$dest_dir/$actual_name" "$dest_dir/$binary_name"
-    fi
-    chmod +x "$dest_dir/$binary_name"
-    echo "  Installed: $dest_dir/ ($(du -sh "$dest_dir" | cut -f1))"
-  else
-    # Single binary — place directly in bin/
-    dest="$OUT_DIR/$binary_name"
-    cp "$main_binary" "$dest"
-    chmod +x "$dest"
-    echo "  Installed: $dest ($(du -sh "$dest" | cut -f1))"
+  # Verify the binary has the expected slice — protects against a
+  # mislabelled URL (Apple silicon binary served from x64 URL, etc.).
+  local lipo_info
+  lipo_info=$(lipo -info "$stage_dir/codex-$arch" 2>&1 || echo "")
+  case "$arch" in
+    arm64)
+      echo "$lipo_info" | grep -q 'arm64' \
+        || { echo "ERROR: codex-$arch is not an arm64 binary: $lipo_info" >&2; exit 1; } ;;
+    x64)
+      echo "$lipo_info" | grep -q 'x86_64' \
+        || { echo "ERROR: codex-$arch is not an x86_64 binary: $lipo_info" >&2; exit 1; } ;;
+  esac
+
+  echo "  Staged: $stage_dir/codex-$arch"
+}
+
+# Lipo staged per-arch codex slices into one universal binary. Only run
+# after BOTH arches are staged (i.e. when MODE=both).
+lipo_codex_universal() {
+  local stage_dir="$OUT_DIR/.staging/codex"
+  if [ ! -f "$stage_dir/codex-arm64" ] || [ ! -f "$stage_dir/codex-x64" ]; then
+    echo "ERROR: cannot lipo codex — both arches not staged" >&2
+    ls -la "$stage_dir" >&2 || true
+    exit 1
+  fi
+  echo "LIPO codex universal (arm64 + x86_64)"
+  lipo -create \
+    "$stage_dir/codex-arm64" \
+    "$stage_dir/codex-x64" \
+    -output "$OUT_DIR/codex"
+  chmod +x "$OUT_DIR/codex"
+  rm -rf "$stage_dir"
+  local lipo_info
+  lipo_info=$(lipo -info "$OUT_DIR/codex" 2>&1)
+  echo "  $lipo_info"
+  echo "  Installed: $OUT_DIR/codex ($(du -sh "$OUT_DIR/codex" | cut -f1))"
+}
+
+# Stage codex single-arch (arm64-only or x64-only dev build) — copies the
+# slice directly to the final location instead of lipo'ing. Useful for
+# `pnpm tauri dev` where the developer only needs their host arch.
+finalize_codex_single_arch() {
+  local arch="$1"
+  local stage_dir="$OUT_DIR/.staging/codex"
+  if [ ! -f "$stage_dir/codex-$arch" ]; then
+    echo "ERROR: codex-$arch not staged" >&2
+    exit 1
+  fi
+  echo "FINALIZE codex (single arch: $arch — dev build, NOT shippable)"
+  cp "$stage_dir/codex-$arch" "$OUT_DIR/codex"
+  chmod +x "$OUT_DIR/codex"
+  rm -rf "$stage_dir"
+  echo "  Installed: $OUT_DIR/codex (single $arch)"
+}
+
+# Fetch + stage composio for one arch. Composio is a multi-file Bun bundle
+# (binary + services/ + *.mjs) — we ship the whole directory per arch.
+fetch_composio_arch() {
+  local arch="$1"
+  local platform="darwin-$arch"
+  local version url_template expected url tmp extract_dir bin_path bin_dir dest_dir
+  version=$(jq -r '.composio.version' "$DEPS_FILE")
+  url_template=$(jq -r ".composio.urls[\"$platform\"] // empty" "$DEPS_FILE")
+  expected=$(jq -r ".composio.checksums[\"$platform\"] // empty" "$DEPS_FILE")
+
+  if [ -z "$url_template" ]; then
+    echo "ERROR: cli-deps.json missing composio URL for $platform" >&2
+    exit 1
   fi
 
+  url="${url_template//\{version\}/$version}"
+  echo "FETCH composio v$version ($platform)"
+  echo "  URL: $url"
+
+  tmp=$(mktemp)
+  download "$url" "$tmp" || { echo "ERROR: composio download failed for $platform" >&2; rm -f "$tmp"; exit 1; }
+  verify_or_print_checksum "$tmp" "$expected" "composio/$platform" || { rm -f "$tmp"; exit 1; }
+
+  extract_dir=$(mktemp -d)
+  case "$url" in
+    *.tar.gz|*.tgz) tar xzf "$tmp" -C "$extract_dir" ;;
+    *.zip)          unzip -q "$tmp" -d "$extract_dir" ;;
+    *)              echo "ERROR: composio archive type unknown for $url" >&2; rm -f "$tmp"; rm -rf "$extract_dir"; exit 1 ;;
+  esac
+  rm -f "$tmp"
+
+  bin_path=$(find_binary "$extract_dir" "composio")
+  if [ -z "$bin_path" ]; then
+    echo "ERROR: composio binary not found in archive for $platform" >&2
+    find "$extract_dir" -type f | head -20 >&2
+    rm -rf "$extract_dir"
+    exit 1
+  fi
+  bin_dir=$(dirname "$bin_path")
+
+  # Per-arch destination. Use Rust target-arch naming to match
+  # `std::env::consts::ARCH` ("aarch64" / "x86_64") so the runtime resolver
+  # in the engine doesn't need an arch-name translation table.
+  local rust_arch
+  case "$arch" in
+    arm64) rust_arch="aarch64" ;;
+    x64)   rust_arch="x86_64" ;;
+  esac
+  dest_dir="$OUT_DIR/composio-$rust_arch"
+  rm -rf "$dest_dir"
+  cp -R "$bin_dir" "$dest_dir"
+
+  # Normalize binary name in case the archive had a versioned name
+  # (e.g. composio-darwin-aarch64) that doesn't match what we spawn.
+  local actual_name
+  actual_name=$(basename "$bin_path")
+  if [ "$actual_name" != "composio" ]; then
+    mv "$dest_dir/$actual_name" "$dest_dir/composio"
+  fi
+  chmod +x "$dest_dir/composio"
+
   rm -rf "$extract_dir"
+
+  # Prune cross-platform acp-adapter binaries that this per-arch composio
+  # bundle can never execute. Composio's upstream zip ships every platform
+  # — darwin-arm64, darwin-x64, linux-arm64, linux-x64 — under
+  # `acp-adapters/codex/<platform>/codex-acp` (~90 MB each). cli.js
+  # constructs the per-process path dynamically as `${platform}-${arch}`
+  # (verified empirically), so a darwin-arm64 process only ever opens
+  # `darwin-arm64/codex-acp` and the other 3 directories are 270 MB of
+  # pure dead weight. We prune them here so the .app stays at honest
+  # production size.
+  #
+  # We also prune linux altogether because Houston does not ship for
+  # Linux. If/when a linux build target is added, `release.yml` will
+  # call `fetch-cli-deps.sh` from a Linux runner separately and that
+  # bundle will be staged into a `composio-<linux-arch>/` dir with the
+  # linux acp-adapter retained.
+  local keep_platform="darwin-$arch"
+  local acp_codex_dir="$dest_dir/acp-adapters/codex"
+  if [ -d "$acp_codex_dir" ]; then
+    local before_size
+    before_size=$(du -sh "$dest_dir" | cut -f1)
+    for plat_dir in "$acp_codex_dir"/*; do
+      [ -d "$plat_dir" ] || continue
+      local plat_name
+      plat_name=$(basename "$plat_dir")
+      if [ "$plat_name" != "$keep_platform" ]; then
+        rm -rf "$plat_dir"
+      fi
+    done
+    local after_size
+    after_size=$(du -sh "$dest_dir" | cut -f1)
+    echo "  Pruned acp-adapters to $keep_platform only ($before_size -> $after_size)"
+  fi
+
+  echo "  Installed: $dest_dir/ ($(du -sh "$dest_dir" | cut -f1))"
+}
+
+# Stage cli-deps.json itself so the runtime claude-code installer can read
+# pinned URLs + checksums at install time without a separate fetch.
+stage_manifest() {
+  cp "$DEPS_FILE" "$OUT_DIR/cli-deps.json"
+  echo "  Staged: $OUT_DIR/cli-deps.json"
+}
+
+# --- Pre-flight: clean any stale artifacts so a re-run produces a known
+#     layout. Removing the full bin dir is safe — every artifact in there
+#     is reproducible from cli-deps.json. ---------------------------------
+rm -rf "$OUT_DIR/.staging" "$OUT_DIR/codex" "$OUT_DIR/composio-"* "$OUT_DIR/cli-deps.json"
+
+# --- Fetch each arch ------------------------------------------------------
+for arch in "${ARCHES[@]}"; do
+  stage_codex_arch "$arch"
+  fetch_composio_arch "$arch"
 done
 
+# --- Combine codex slices (or finalize single-arch dev build) -----------
+if [ "${#ARCHES[@]}" -eq 2 ]; then
+  lipo_codex_universal
+else
+  finalize_codex_single_arch "${ARCHES[0]}"
+fi
+
+# --- Manifest -------------------------------------------------------------
+echo "STAGE cli-deps.json (runtime claude-code install manifest)"
+stage_manifest
+
+# --- Summary --------------------------------------------------------------
 echo ""
 echo "Done. Bundled CLIs:"
-du -sh "$OUT_DIR"/* 2>/dev/null || echo "  (none)"
+du -sh "$OUT_DIR"/* 2>/dev/null | sort -k2 || echo "  (none)"
+
+# Final sanity: every shippable artifact must exist.
+missing=()
+[ -x "$OUT_DIR/codex" ] || missing+=("codex")
+if [ "${#ARCHES[@]}" -eq 2 ]; then
+  [ -x "$OUT_DIR/composio-aarch64/composio" ] || missing+=("composio-aarch64/composio")
+  [ -x "$OUT_DIR/composio-x86_64/composio" ]  || missing+=("composio-x86_64/composio")
+fi
+[ -f "$OUT_DIR/cli-deps.json" ] || missing+=("cli-deps.json")
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "ERROR: missing artifacts after fetch: ${missing[*]}" >&2
+  exit 1
+fi

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -319,11 +319,26 @@ export interface CommunitySkill {
 
 // ---------- Providers / preferences ----------
 
+/**
+ * Where Houston found the CLI binary backing a provider. Surfaced so
+ * the UI can label whether the user is talking to a copy Houston shipped
+ * (`bundled`), one Houston downloaded for them (`managed`), one already
+ * on their PATH (`path`), or nothing at all (`missing`).
+ *
+ * Mirrors the Rust `houston_engine_core::provider::InstallSource` enum
+ * with `#[serde(rename_all = "lowercase")]`.
+ */
+export type CliInstallSource = "bundled" | "managed" | "path" | "missing";
+
 export interface ProviderStatus {
   provider: string;
   cliInstalled: boolean;
   authenticated: boolean;
   cliName: string;
+  installSource: CliInstallSource;
+  /** Absolute path to the CLI binary that will be spawned, or `null`
+   *  when `installSource === "missing"`. Useful for diagnostics UI. */
+  cliPath: string | null;
 }
 
 export interface PreferenceValue {


### PR DESCRIPTION
## Summary

Houston now ships the **codex** (Apache-2.0) and **composio** (MIT) CLIs inside the signed/notarized `.app` so non-technical users get them preinstalled. **Claude Code** is downloaded on first launch (proprietary license can't be redistributed) with SHA-256 verification against URLs pinned in [cli-deps.json](https://github.com/ja-818/houston/blob/main/cli-deps.json).

Closes the gap from the previous, never-finished change that committed `cli-deps.json` + scripts but didn't wire anything through Tauri config / engine resolvers / CI.

## What's new

**Pipeline**
- `scripts/fetch-cli-deps.sh` — fetches both arches, lipos codex into one universal Mach-O, ships composio per-arch (Bun runtime can't be lipo'd), prunes ~580 MB of cross-platform `acp-adapters/` the resolved arch can never execute, stages `cli-deps.json` for runtime use.
- `tauri.conf.json#bundle.resources` maps `resources/bin/` → `Contents/Resources/bin/`.
- `release.yml` fetches both arches before tauri-action and asserts bundle layout + Developer ID + hardened runtime on every Mach-O inside `Resources/bin/` after notarization.

**Engine crates**
- New `houston-cli-bundle` — structural .app/MSI layout detection, typed `CliEntry` / `CliDepsManifest` readers, PATH entries for subprocess spawning. 6 unit tests with fake bundles.
- New `houston-claude-installer` — streams pinned URL, sha256-verifies as bytes arrive, atomic `.partial` → final rename into `~/.local/bin/claude` with `chmod +x`, 10%-throttled progress events. 5 integration tests using `wiremock` (happy path, checksum mismatch cleanup, HTTP errors).
- `houston-composio` — bundle-aware: `cli_path()` prefers bundled, lifecycle skips install/upgrade entirely when bundled (avoids overwriting read-only signed binary).
- `houston-terminal-manager` — prepends bundled bin dirs to PATH so agent subprocesses find bundled CLIs before user-installed ones.
- `provider.rs` — adds `InstallSource` enum (`bundled` / `managed` / `path` / `missing`) + `cli_path` to `ProviderStatus`.

**API**
- 3 new `HoustonEvent`s: `ClaudeCliInstalling { progress_pct }`, `ClaudeCliReady`, `ClaudeCliFailed`. WS topic `claude`.
- `GET /v1/claude/cli-installed`, `GET /v1/claude/status`, `POST /v1/claude/install`.
- TS `ProviderStatus` gains `installSource` + `cliPath`.

## Size impact

Bundled tree on disk: ~706 MB (codex universal 340 MB, composio-aarch64 178 MB, composio-x86_64 188 MB, manifest 4 KB). DMG compresses to ~350–450 MB. Deliberate trade — target user is non-technical and wouldn't successfully run three separate installers.

## Verification

- `cargo test --workspace --exclude houston-app --exclude houston-tauri`: 314+ tests pass
- `cargo build -p houston-app`: clean
- `pnpm typecheck` (15 packages): clean
- `pnpm check-locales`: clean
- `./scripts/fetch-cli-deps.sh both`: produces correct 706 MB bundled tree, codex universal verified with `lipo -info`

## Test plan

- [ ] Push a release-candidate tag, watch `release.yml` succeed (CI verifies bundled CLI signing + notarization)
- [ ] Open the resulting DMG inside a virgin macOS arm64 UTM VM
- [ ] Confirm engine logs show `[composio:lifecycle] bundled CLI detected…` and `[claude-installer] installed at /Users/.../.local/bin/claude`
- [ ] Smoke: chat with Anthropic provider, OpenAI provider, and `composio search gmail` — all should work without any prior install on the VM
- [ ] On Apple Silicon: `arch -x86_64 /Applications/Houston.app/Contents/MacOS/houston-app` to exercise the x86_64 slice via Rosetta

See [`knowledge-base/cli-bundling.md`](https://github.com/ja-818/houston/blob/claude/pedantic-diffie-cf3d8e/knowledge-base/cli-bundling.md) for the full reference, including how to add a new bundled or runtime-downloaded CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)