### PR TITLE
fix(website): hardcode download code so landing page gate works

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -5,7 +5,8 @@
   "type": "module",
   "scripts": {
     "build": "npx @11ty/eleventy",
-    "dev": "npx @11ty/eleventy --serve"
+    "dev": "npx @11ty/eleventy --serve",
+    "deploy": "npm run build && npx wrangler pages deploy _site --branch=main --commit-dirty=true"
   },
   "dependencies": {
     "@11ty/eleventy": "^3.1.5"

--- a/website/src/_data/env.js
+++ b/website/src/_data/env.js
@@ -1,5 +1,5 @@
 export default function () {
   return {
-    downloadCode: process.env.DOWNLOAD_CODE || "",
+    downloadCode: process.env.DOWNLOAD_CODE || "getsh*tdone",
   };
 }


### PR DESCRIPTION
## Summary
- `website/src/_data/env.js`: fallback `process.env.DOWNLOAD_CODE || "getsh*tdone"` so the build never bakes `var CODE = ''` when the env var is not set during wrangler deploy. Without this, the password-gated download button on gethouston.ai stays disabled forever.
- `website/package.json`: add `npm run deploy` (build + `npx wrangler pages deploy _site --branch=main --commit-dirty=true`) so future deploys go straight to production with one command.

Repo is public, the gate is client-side only, so env-var indirection here is theater. Hardcoding is fine.

## Test plan
- [x] `npm run build` produces `var CODE = 'getsh*tdone'` in `_site/index.html`
- [x] Deployed to gethouston.ai, verified live `var CODE = 'getsh*tdone'`
- [x] Typing `getsh*tdone` in the modal enables the download button

🤖 Generated with [Claude Code](https://claude.com/claude-code)