### PR TITLE
fix: show provider reconnect card for CLI auth expiry

### DIFF
--- a/app/houston-tauri/src/tray.rs
+++ b/app/houston-tauri/src/tray.rs
@@ -6,7 +6,7 @@
 //!
 //! # Usage
 //!
-//! ```rust,no_run
+//! ```rust,ignore
 //! // In your Tauri setup closure:
 //! houston_tauri::tray::setup_tray(app, "MyApp")?;
 //!
@@ -64,7 +64,7 @@ pub fn setup_tray(
 /// Window event handler that hides the window instead of closing it.
 ///
 /// Use with `tauri::Builder::on_window_event`:
-/// ```rust,no_run
+/// ```rust,ignore
 /// tauri::Builder::default()
 ///     .on_window_event(houston_tauri::tray::hide_on_close)
 /// ```

--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -269,6 +269,9 @@ export function Dashboard() {
           composerOverride={panel.composerOverride}
           footer={panel.footer}
           renderUserMessage={panel.renderUserMessage}
+          renderSystemMessage={panel.renderSystemMessage}
+          mapFeedItems={panel.mapFeedItems}
+          afterMessages={panel.afterMessages}
           isSpecialTool={panel.isSpecialTool}
           renderToolResult={panel.renderToolResult}
           renderTurnSummary={panel.renderTurnSummary}

--- a/app/src/components/shell/provider-reconnect-card.tsx
+++ b/app/src/components/shell/provider-reconnect-card.tsx
@@ -5,88 +5,111 @@ import { useUIStore } from "../../stores/ui";
 import { tauriProvider } from "../../lib/tauri";
 import { getProvider } from "../../lib/providers";
 
-export function ProviderReconnectCard() {
+interface ProviderReconnectCardProps {
+  providerId?: string;
+  signalKey?: string;
+}
+
+export function ProviderReconnectCard({
+  providerId,
+  signalKey,
+}: ProviderReconnectCardProps) {
   const { t } = useTranslation(["shell", "common"]);
   const authRequired = useUIStore((s) => s.authRequired);
   const setAuthRequired = useUIStore((s) => s.setAuthRequired);
   const [loginLaunched, setLoginLaunched] = useState(false);
+  const [loginError, setLoginError] = useState(false);
+  const [resolvedSignal, setResolvedSignal] = useState<string | null>(null);
 
-  const provider = authRequired ? getProvider(authRequired) : null;
+  const activeProviderId = authRequired ?? (
+    signalKey && signalKey !== resolvedSignal ? providerId : null
+  );
+  const provider = activeProviderId ? getProvider(activeProviderId) : null;
 
   useEffect(() => {
-    if (!authRequired) return;
+    setLoginLaunched(false);
+    setLoginError(false);
+  }, [activeProviderId, authRequired, providerId, signalKey]);
+
+  useEffect(() => {
+    if (!activeProviderId) return;
     const interval = setInterval(async () => {
       try {
-        const status = await tauriProvider.checkStatus(authRequired);
+        const status = await tauriProvider.checkStatus(activeProviderId);
         if (status.cli_installed && status.authenticated) {
           setAuthRequired(null);
+          if (signalKey) setResolvedSignal(signalKey);
           setLoginLaunched(false);
         }
       } catch {
-        // ignore check failures
+        // Keep the reconnect card visible; the next poll may succeed.
       }
     }, 3000);
     return () => clearInterval(interval);
-  }, [authRequired, setAuthRequired]);
+  }, [activeProviderId, signalKey, setAuthRequired]);
 
   const handleSignIn = useCallback(async () => {
-    if (!authRequired) return;
+    if (!activeProviderId) return;
     try {
-      await tauriProvider.launchLogin(authRequired);
+      await tauriProvider.launchLogin(activeProviderId);
+      setLoginError(false);
       setLoginLaunched(true);
     } catch {
-      // CLI not available
+      setLoginLaunched(false);
+      setLoginError(true);
     }
-  }, [authRequired]);
+  }, [activeProviderId]);
 
-  if (!authRequired || !provider) return null;
+  if (!activeProviderId || !provider) return null;
 
   return (
     <div className="w-full px-1 py-2">
-      <div className="relative overflow-hidden rounded-2xl border border-black/[0.08] bg-gradient-to-br from-secondary via-white to-secondary">
-        <div className="absolute inset-x-0 top-0 h-[2px] bg-gradient-to-r from-transparent via-foreground/15 to-transparent" />
+      <div className="flex items-start gap-4 rounded-2xl bg-secondary p-4 text-left">
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full bg-background border border-border">
+          {activeProviderId === "anthropic" ? <ClaudeLogo /> : <OpenAILogo />}
+        </div>
 
-        <div className="p-5">
-          {/* Provider logo */}
-          <div className="flex h-11 w-11 items-center justify-center rounded-xl bg-secondary border border-black/[0.06] mb-4">
-            {authRequired === "anthropic" ? <ClaudeLogo /> : <OpenAILogo />}
-          </div>
-
-          {/* Copy */}
-          <p className="text-[15px] font-semibold text-foreground mb-1">
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <p className="text-sm font-semibold text-foreground">
             {t("shell:providerReconnect.title")}
           </p>
-          <p className="text-sm text-muted-foreground leading-relaxed mb-4">
+          <p className="text-xs text-muted-foreground leading-relaxed">
             {t("shell:providerReconnect.body", { provider: provider.subtitle })}
           </p>
 
-          {/* Action */}
-          {!loginLaunched ? (
-            <Button
-              onClick={handleSignIn}
-              className="rounded-full gap-2"
-              size="sm"
-            >
-              {authRequired === "anthropic" ? (
-                <ClaudeLogoSmall />
-              ) : (
-                <OpenAILogoSmall />
-              )}
-              {t("shell:providerReconnect.reconnect", { provider: provider.subtitle })}
-            </Button>
-          ) : (
-            <div className="flex items-center gap-3">
-              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                <Spinner className="h-3.5 w-3.5" />
-                <span>{t("shell:providerReconnect.waiting")}</span>
-              </div>
-              <button
+          <div className="mt-2">
+            {!loginLaunched ? (
+              <Button
                 onClick={handleSignIn}
-                className="text-xs text-muted-foreground underline underline-offset-2 hover:text-foreground transition-colors"
+                className="h-8 rounded-full gap-2 text-xs px-3"
+                size="sm"
               >
-                {t("common:actions.tryAgain")}
-              </button>
-            </div>
+                {activeProviderId === "anthropic" ? (
+                  <ClaudeLogoSmall />
+                ) : (
+                  <OpenAILogoSmall />
+                )}
+                {t("shell:authReconnect.signInWith", { provider: provider.name })}
+              </Button>
+            ) : (
+              <div className="flex items-center gap-3">
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <Spinner className="h-3.5 w-3.5" />
+                  <span>{t("shell:providerReconnect.waiting")}</span>
+                </div>
+                <button
+                  onClick={handleSignIn}
+                  className="text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  {t("common:actions.tryAgain")}
+                </button>
+              </div>
+            )}
+          </div>
+          {loginError && (
+            <p className="mt-2 text-xs text-destructive">
+              {t("shell:providerReconnect.launchError")}
+            </p>
           )}
         </div>
       </div>

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -467,6 +467,9 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
         composerOverride={panel.composerOverride}
         footer={panel.footer}
         renderUserMessage={panel.renderUserMessage}
+        renderSystemMessage={panel.renderSystemMessage}
+        mapFeedItems={panel.mapFeedItems}
+        afterMessages={panel.afterMessages}
         isSpecialTool={panel.isSpecialTool}
         renderToolResult={panel.renderToolResult}
         renderTurnSummary={panel.renderTurnSummary}

--- a/app/src/components/tabs/chat-tab.tsx
+++ b/app/src/components/tabs/chat-tab.tsx
@@ -25,6 +25,11 @@ import { HoustonThinkingIndicator } from "../shell/experience-card";
 import { ChatModelSelector } from "../chat-model-selector";
 import { getDefaultModel } from "../../lib/providers";
 import { ProviderReconnectCard } from "../shell/provider-reconnect-card";
+import {
+  filterProviderAuthFeedItems,
+  isProviderAuthMessage,
+  providerAuthSignalKey,
+} from "./provider-auth-feed";
 
 export default function ChatTab({ agent }: TabProps) {
   const { t } = useTranslation("chat");
@@ -86,6 +91,14 @@ export default function ChatTab({ agent }: TabProps) {
   // Effective = chat override > agent config > workspace default
   const effectiveProvider = chatProvider ?? agentProvider ?? wsProvider;
   const effectiveModel = chatModel ?? agentModel ?? wsModel;
+  const authSignalKey = useMemo(
+    () => providerAuthSignalKey(feedItems ?? []),
+    [feedItems],
+  );
+  const visibleFeedItems = useMemo(
+    () => filterProviderAuthFeedItems(feedItems ?? []),
+    [feedItems],
+  );
 
   const handleModelSelect = useCallback((prov: string, mod: string) => {
     setChatProvider(prov);
@@ -180,7 +193,7 @@ export default function ChatTab({ agent }: TabProps) {
     <div className="h-full w-full flex flex-col">
       <ChatPanel
         sessionKey={sessionKey}
-        feedItems={feedItems ?? []}
+        feedItems={visibleFeedItems}
         isLoading={isLoading}
         onSend={handleSend}
         onStop={handleStop}
@@ -189,7 +202,21 @@ export default function ChatTab({ agent }: TabProps) {
         isSpecialTool={isSpecialTool}
         renderToolResult={renderToolResult}
         renderTurnSummary={renderTurnSummary}
-        afterMessages={<ProviderReconnectCard />}
+        renderSystemMessage={(msg) => {
+          if (isProviderAuthMessage(msg.content)) {
+            return null;
+          }
+          if (authSignalKey && msg.content.startsWith("Session error:")) {
+            return null;
+          }
+          return undefined;
+        }}
+        afterMessages={
+          <ProviderReconnectCard
+            providerId={authSignalKey ? effectiveProvider : undefined}
+            signalKey={authSignalKey ?? undefined}
+          />
+        }
         thinkingIndicator={<HoustonThinkingIndicator />}
         placeholder={t("composer.placeholder")}
         value={composerText}
@@ -202,7 +229,7 @@ export default function ChatTab({ agent }: TabProps) {
             provider={effectiveProvider}
             model={effectiveModel}
             onSelect={handleModelSelect}
-            lockedProvider={(feedItems ?? []).length > 0 ? effectiveProvider : null}
+            lockedProvider={visibleFeedItems.length > 0 ? effectiveProvider : null}
           />
         }
         emptyState={

--- a/app/src/components/tabs/provider-auth-feed.ts
+++ b/app/src/components/tabs/provider-auth-feed.ts
@@ -1,0 +1,61 @@
+import type { FeedItem } from "@houston-ai/chat";
+
+const AUTH_PATTERNS = [
+  "401",
+  "unauthorized",
+  "not authenticated",
+  "not logged in",
+  "authentication expired",
+  "auth expired",
+  "session expired",
+  "oauth token",
+  "missing bearer",
+  "invalid api key",
+  "invalid_api_key",
+  "please login",
+  "please log in",
+  "please run /login",
+] as const;
+
+export function isProviderAuthMessage(message: string): boolean {
+  const lower = message.toLowerCase();
+  return AUTH_PATTERNS.some((pattern) => lower.includes(pattern));
+}
+
+export function isProviderAuthFeedItem(item: FeedItem): boolean {
+  switch (item.feed_type) {
+    case "assistant_text":
+    case "assistant_text_streaming":
+    case "system_message":
+      return item.data === "Checking connection..." || isProviderAuthMessage(item.data);
+    case "tool_result":
+      return isProviderAuthMessage(item.data.content);
+    case "final_result":
+      return isProviderAuthMessage(item.data.result);
+    default:
+      return false;
+  }
+}
+
+function isProviderAuthSessionError(item: FeedItem): boolean {
+  return item.feed_type === "system_message" && item.data.startsWith("Session error:");
+}
+
+export function filterProviderAuthFeedItems(items: FeedItem[]): FeedItem[] {
+  const hasAuthSignal = providerAuthSignalKey(items) !== null;
+  return items.filter(
+    (item) =>
+      !isProviderAuthFeedItem(item) &&
+      !(hasAuthSignal && isProviderAuthSessionError(item)),
+  );
+}
+
+export function providerAuthSignalKey(items: FeedItem[]): string | null {
+  for (let index = items.length - 1; index >= 0; index--) {
+    const item = items[index];
+    if (isProviderAuthFeedItem(item)) {
+      return `${index}:${item.feed_type}`;
+    }
+  }
+  return null;
+}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -57,9 +57,15 @@ import { ActionForm } from "./action-form";
 import { SkillCard } from "./skill-card";
 import { NewMissionPickerDialog } from "./new-mission-picker-dialog";
 import { UserActionMessage } from "./user-action-message";
+import { ProviderReconnectCard } from "./shell/provider-reconnect-card";
+import {
+  filterProviderAuthFeedItems,
+  isProviderAuthMessage,
+  providerAuthSignalKey,
+} from "./tabs/provider-auth-feed";
 
 import type { AIBoardProps } from "@houston-ai/board";
-import type { ChatPanelProps } from "@houston-ai/chat";
+import type { ChatMessage, ChatPanelProps, FeedItem } from "@houston-ai/chat";
 import type { Agent, AgentDefinition, SkillSummary } from "../lib/types";
 
 interface UseAgentChatPanelArgs {
@@ -86,6 +92,9 @@ interface AgentChatPanelProps {
   isSpecialTool: ChatPanelProps["isSpecialTool"];
   renderToolResult: ChatPanelProps["renderToolResult"];
   renderTurnSummary: ChatPanelProps["renderTurnSummary"];
+  renderSystemMessage: AIBoardProps["renderSystemMessage"];
+  mapFeedItems: AIBoardProps["mapFeedItems"];
+  afterMessages: AIBoardProps["afterMessages"];
   /** Custom Composio inline-link rendering. */
   renderLink: AIBoardProps["renderLink"];
   /** Hidden picker dialog mounted in the consumer. */
@@ -308,6 +317,30 @@ export function useAgentChatPanel({
     },
     [],
   );
+  const renderSystemMessage = useCallback(
+    (msg: ChatMessage) => {
+      if (isProviderAuthMessage(msg.content)) return null;
+      return undefined;
+    },
+    [],
+  );
+  const mapFeedItems = useCallback(
+    ({ items }: { sessionKey: string; items: FeedItem[] }) =>
+      filterProviderAuthFeedItems(items),
+    [],
+  );
+  const afterMessages = useCallback(
+    ({ feedItems }: { sessionKey: string; feedItems: FeedItem[] }) => {
+      const signalKey = providerAuthSignalKey(feedItems);
+      return (
+        <ProviderReconnectCard
+          providerId={signalKey ? effectiveProvider : undefined}
+          signalKey={signalKey ?? undefined}
+        />
+      );
+    },
+    [effectiveProvider],
+  );
 
   const composerOverride = useMemo<AIBoardProps["composerOverride"]>(() => {
     if (!agent || !activeAction) return undefined;
@@ -404,6 +437,9 @@ export function useAgentChatPanel({
     isSpecialTool,
     renderToolResult,
     renderTurnSummary,
+    renderSystemMessage,
+    mapFeedItems,
+    afterMessages,
     renderLink,
     pickerDialog,
     effectiveProvider,

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -41,7 +41,8 @@
     "body": "Your {{provider}} connection ended, this happens from time to time. Sign back in and you're good to go.",
     "reconnect": "Reconnect to {{provider}}",
     "waiting": "Waiting for browser sign-in...",
-    "tryAgain": "Try again"
+    "tryAgain": "Try again",
+    "launchError": "Could not open sign-in. Try again."
   },
   "updateChecker": {
     "available": "v{{version}} available",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -41,7 +41,8 @@
     "body": "Tu conexión con {{provider}} se terminó, pasa de vez en cuando. Inicia sesión otra vez y listo.",
     "reconnect": "Reconectar a {{provider}}",
     "waiting": "Esperando el inicio de sesión en el navegador...",
-    "tryAgain": "Intentar de nuevo"
+    "tryAgain": "Intentar de nuevo",
+    "launchError": "No se pudo abrir el inicio de sesión. Intenta otra vez."
   },
   "updateChecker": {
     "available": "v{{version}} disponible",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -41,7 +41,8 @@
     "body": "Sua conexão com o {{provider}} encerrou, isso acontece de vez em quando. Entre de novo e está tudo certo.",
     "reconnect": "Reconectar ao {{provider}}",
     "waiting": "Aguardando o login no navegador...",
-    "tryAgain": "Tentar de novo"
+    "tryAgain": "Tentar de novo",
+    "launchError": "Não foi possível abrir o login. Tente de novo."
   },
   "updateChecker": {
     "available": "v{{version}} disponível",

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -6,6 +6,7 @@
 use crate::session_id_tracker::SessionIdHandle;
 use crate::session_pids::SessionPidMap;
 use houston_db::Database;
+use houston_terminal_manager::auth_error::{is_auth_error, is_auth_retry_marker};
 use houston_terminal_manager::{FeedItem, Provider, SessionManager, SessionStatus, SessionUpdate};
 use houston_ui_events::{DynEventSink, HoustonEvent};
 use std::path::PathBuf;
@@ -53,6 +54,7 @@ pub fn spawn_and_monitor(
     // OnceLock inside init() makes this a no-op after the first call.
     houston_terminal_manager::claude_path::init();
 
+    let provider_kind = provider;
     let provider_str = provider.to_string();
 
     let (mut rx, _handle) = SessionManager::spawn_session(
@@ -61,7 +63,7 @@ pub fn spawn_and_monitor(
         resume_id,
         Some(working_dir),
         model,
-        None,  // effort
+        None, // effort
         system_prompt,
         None,  // mcp_config
         false, // disable_builtin_tools
@@ -78,6 +80,7 @@ pub fn spawn_and_monitor(
         let mut error: Option<String> = None;
         let mut saw_auth_error = false;
         let mut sent_auth_checking = false;
+        let mut sent_auth_required = false;
 
         while let Some(update) = rx.recv().await {
             match update {
@@ -103,17 +106,24 @@ pub fn spawn_and_monitor(
                     //   3. `not authenticated` / stderr-dumped auth errors.
                     //
                     // All three are auth noise, not user-visible content. We
-                    // suppress the raw message, track `saw_auth_error` so the
-                    // Status branch knows to emit AuthRequired + the reconnect
-                    // card marker, and emit "Checking connection..." exactly once.
+                    // suppress the raw message, emit AuthRequired once, and
+                    // emit "Checking connection..." exactly once.
                     if let FeedItem::SystemMessage(msg) = item {
-                        let lower = msg.to_lowercase();
-                        let is_auth_noise = msg == "__auth_retry__"
-                            || lower.contains("401")
-                            || lower.contains("unauthorized")
-                            || lower.contains("not authenticated");
+                        let is_auth_noise = is_auth_retry_marker(msg)
+                            || is_auth_error(msg)
+                            || is_opaque_claude_auth_error(provider_kind, msg);
                         if is_auth_noise {
                             saw_auth_error = true;
+                            if !sent_auth_required {
+                                sent_auth_required = true;
+                                tracing::info!(
+                                    "[session_runner] emitting AuthRequired for provider={provider_str} from feed"
+                                );
+                                sink.emit(HoustonEvent::AuthRequired {
+                                    provider: provider_str.clone(),
+                                    message: msg.clone(),
+                                });
+                            }
                             if !sent_auth_checking {
                                 sent_auth_checking = true;
                                 tracing::info!(
@@ -149,9 +159,8 @@ pub fn spawn_and_monitor(
                             let src = opts.source.clone();
                             let sid = sid.clone();
                             tokio::spawn(async move {
-                                let _ = db
-                                    .add_chat_feed_item_by_session(&sid, &ft, &dj, &src)
-                                    .await;
+                                let _ =
+                                    db.add_chat_feed_item_by_session(&sid, &ft, &dj, &src).await;
                             });
                         }
                     }
@@ -213,20 +222,17 @@ pub fn spawn_and_monitor(
                     // slot). No feed marker needed — the card is anchored to
                     // store state, not to a specific FeedItem.
                     if let SessionStatus::Error(ref e) = status {
-                        let lower = e.to_lowercase();
-                        let is_auth_error = saw_auth_error
-                            || lower.contains("401")
-                            || lower.contains("unauthorized")
-                            || lower.contains("authentication")
-                            || lower.contains("api key")
-                            || lower.contains("invalid_api_key")
-                            || lower.contains("not authenticated")
-                            || lower.contains("expired");
+                        let auth_error = saw_auth_error
+                            || is_auth_error(e)
+                            || is_opaque_claude_auth_error(provider_kind, e);
                         tracing::info!(
-                            "[session_runner] session error: {e:?} | saw_auth_error={saw_auth_error} | is_auth_error={is_auth_error} | provider={provider_str}"
+                            "[session_runner] session error: {e:?} | saw_auth_error={saw_auth_error} | is_auth_error={auth_error} | provider={provider_str}"
                         );
-                        if is_auth_error {
-                            tracing::info!("[session_runner] emitting AuthRequired for provider={provider_str}");
+                        if auth_error && !sent_auth_required {
+                            sent_auth_required = true;
+                            tracing::info!(
+                                "[session_runner] emitting AuthRequired for provider={provider_str}"
+                            );
                             sink.emit(HoustonEvent::AuthRequired {
                                 provider: provider_str.clone(),
                                 message: e.clone(),
@@ -272,7 +278,11 @@ fn serialize_for_persist(item: &FeedItem) -> Option<(String, String)> {
             Some(("tool_result".into(), data.to_string()))
         }
         FeedItem::SystemMessage(t) => Some(("system_message".into(), json_str(t))),
-        FeedItem::FinalResult { result, cost_usd, duration_ms } => {
+        FeedItem::FinalResult {
+            result,
+            cost_usd,
+            duration_ms,
+        } => {
             let data = serde_json::json!({
                 "result": result, "cost_usd": cost_usd, "duration_ms": duration_ms
             });
@@ -286,4 +296,29 @@ fn serialize_for_persist(item: &FeedItem) -> Option<(String, String)> {
 
 fn json_str(s: &str) -> String {
     serde_json::Value::String(s.to_string()).to_string()
+}
+
+fn is_opaque_claude_auth_error(provider: Provider, message: &str) -> bool {
+    provider == Provider::Anthropic && message.trim() == "Error: Unknown error"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn treats_opaque_claude_result_error_as_auth() {
+        assert!(is_opaque_claude_auth_error(
+            Provider::Anthropic,
+            "Error: Unknown error"
+        ));
+    }
+
+    #[test]
+    fn does_not_treat_codex_unknown_error_as_auth() {
+        assert!(!is_opaque_claude_auth_error(
+            Provider::OpenAI,
+            "Error: Unknown error"
+        ));
+    }
 }

--- a/engine/houston-terminal-manager/src/auth_error.rs
+++ b/engine/houston-terminal-manager/src/auth_error.rs
@@ -1,0 +1,71 @@
+//! Shared detection for provider CLI authentication failures.
+
+pub const AUTH_RETRY_MARKER: &str = "__auth_retry__";
+
+pub fn is_auth_retry_marker(message: &str) -> bool {
+    message == AUTH_RETRY_MARKER
+}
+
+pub fn is_auth_error(message: &str) -> bool {
+    let lower = message.to_lowercase();
+    let api_key_problem = lower.contains("api key")
+        && (lower.contains("invalid")
+            || lower.contains("missing")
+            || lower.contains("not set")
+            || lower.contains("expired"));
+    lower.contains("401")
+        || lower.contains("unauthorized")
+        || lower.contains("not authenticated")
+        || lower.contains("not logged in")
+        || lower.contains("authentication expired")
+        || lower.contains("auth expired")
+        || lower.contains("session expired")
+        || lower.contains("oauth token")
+        || lower.contains("missing bearer")
+        || lower.contains("invalid api key")
+        || lower.contains("invalid_api_key")
+        || api_key_problem
+        || lower.contains("no auth credentials")
+        || lower.contains("please login")
+        || lower.contains("please log in")
+        || lower.contains("please run /login")
+        || lower.contains("run claude auth login")
+        || lower.contains("run codex login")
+        || lower.contains("claude auth login")
+        || lower.contains("codex login")
+}
+
+pub fn is_auth_retry_noise(message: &str) -> bool {
+    let lower = message.to_lowercase();
+    is_auth_error(message) && (lower.contains("reconnecting") || lower.contains("retrying"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_common_cli_auth_failures() {
+        let cases = [
+            "unexpected status 401 Unauthorized: Missing bearer",
+            "Claude Code is not authenticated. Run claude auth login",
+            "Not logged in · Please run /login",
+            "Invalid API key. Please login again.",
+            "No API key found. Run claude auth login",
+            "OAuth token has expired",
+            "Reconnecting... 1/5 (unexpected status 401 Unauthorized)",
+        ];
+
+        for case in cases {
+            assert!(is_auth_error(case), "{case}");
+        }
+    }
+
+    #[test]
+    fn detects_retry_noise_subset() {
+        assert!(is_auth_retry_noise(
+            "Reconnecting... 1/5 (unexpected status 401 Unauthorized)",
+        ));
+        assert!(!is_auth_retry_noise("Invalid API key. Please login again."));
+    }
+}

--- a/engine/houston-terminal-manager/src/codex_parser.rs
+++ b/engine/houston-terminal-manager/src/codex_parser.rs
@@ -3,6 +3,7 @@
 //! Maps Codex events to the same `FeedItem` variants used by the Claude parser,
 //! so the rest of the stack (session_runner, frontend) is provider-agnostic.
 
+use super::auth_error::{AUTH_RETRY_MARKER, is_auth_retry_noise};
 use super::types::FeedItem;
 use serde::Deserialize;
 
@@ -122,9 +123,7 @@ pub fn parse_codex_event(line: &str, acc: &mut CodexAccumulator) -> Vec<FeedItem
                 )));
             }
             if !acc.thinking_buffer.is_empty() {
-                items.push(FeedItem::Thinking(std::mem::take(
-                    &mut acc.thinking_buffer,
-                )));
+                items.push(FeedItem::Thinking(std::mem::take(&mut acc.thinking_buffer)));
             }
             // Emit usage as FinalResult
             if let Some(usage) = &event.usage {
@@ -146,13 +145,10 @@ pub fn parse_codex_event(line: &str, acc: &mut CodexAccumulator) -> Vec<FeedItem
             tracing::info!("[codex] error/turn.failed: {msg}");
             // Auth retry noise (e.g. "Reconnecting... 1/5 (unexpected status 401 Unauthorized...)")
             // Show a single friendly "Checking connection..." instead of raw retries.
-            let lower = msg.to_lowercase();
-            let is_auth_retry = (lower.contains("401") || lower.contains("unauthorized") || lower.contains("not authenticated"))
-                && (lower.contains("reconnecting") || lower.contains("retrying"));
-            if is_auth_retry {
+            if is_auth_retry_noise(&msg) {
                 tracing::info!("[codex] auth retry detected — suppressing raw error");
                 // Return a marker so session_runner can track it, but don't show raw noise.
-                vec![FeedItem::SystemMessage("__auth_retry__".to_string())]
+                vec![FeedItem::SystemMessage(AUTH_RETRY_MARKER.to_string())]
             } else {
                 vec![FeedItem::SystemMessage(format!("Error: {msg}"))]
             }
@@ -285,7 +281,9 @@ fn parse_item_completed(event: &CodexEvent, acc: &mut CodexAccumulator) -> Vec<F
             }]
         }
         "error" => {
-            let msg = item.message.as_deref()
+            let msg = item
+                .message
+                .as_deref()
                 .or(item.text.as_deref())
                 .unwrap_or("Unknown error");
             // Codex emits a transient error when the model changes mid-session
@@ -327,7 +325,8 @@ mod tests {
 
     #[test]
     fn parse_thread_started() {
-        let line = r#"{"type":"thread.started","thread_id":"0199a213-81c0-7800-8aa1-bbab2a035a53"}"#;
+        let line =
+            r#"{"type":"thread.started","thread_id":"0199a213-81c0-7800-8aa1-bbab2a035a53"}"#;
         let items = parse_codex_event(line, &mut acc());
         assert!(items.is_empty());
         assert_eq!(
@@ -447,14 +446,21 @@ mod tests {
     }
 
     #[test]
-    fn parse_turn_failed() {
-        let line =
-            r#"{"type":"turn.failed","error":{"message":"Context window exceeded"}}"#;
+    fn parse_codex_auth_failure_remains_detectable() {
+        let line = r#"{"type":"turn.failed","error":{"message":"unexpected status 401 Unauthorized: Missing bearer"}}"#;
         let items = parse_codex_event(line, &mut acc());
         assert_eq!(items.len(), 1);
         assert!(
-            matches!(&items[0], FeedItem::SystemMessage(m) if m.contains("Context window"))
+            matches!(&items[0], FeedItem::SystemMessage(m) if crate::auth_error::is_auth_error(m))
         );
+    }
+
+    #[test]
+    fn parse_turn_failed() {
+        let line = r#"{"type":"turn.failed","error":{"message":"Context window exceeded"}}"#;
+        let items = parse_codex_event(line, &mut acc());
+        assert_eq!(items.len(), 1);
+        assert!(matches!(&items[0], FeedItem::SystemMessage(m) if m.contains("Context window")));
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/lib.rs
+++ b/engine/houston-terminal-manager/src/lib.rs
@@ -3,6 +3,7 @@
 //! Provides session spawning, NDJSON stream parsing, event pumping,
 //! concurrency control, and PATH resolution for AI CLI tools.
 
+pub mod auth_error;
 pub mod claude_path;
 pub mod codex_parser;
 pub mod concurrency;
@@ -13,7 +14,7 @@ pub mod session_pump;
 pub mod types;
 
 // Re-export key types for convenience.
+pub use codex_parser::{CodexAccumulator, extract_thread_id, parse_codex_event};
 pub use manager::{SessionHandle, SessionManager, SessionUpdate};
-pub use parser::{parse_event, extract_session_id, StreamAccumulator};
-pub use codex_parser::{parse_codex_event, extract_thread_id, CodexAccumulator};
+pub use parser::{StreamAccumulator, extract_session_id, parse_event};
 pub use types::{ClaudeEvent, ContentBlock, FeedItem, Provider, SessionFeedBuffer, SessionStatus};

--- a/engine/houston-terminal-manager/src/manager.rs
+++ b/engine/houston-terminal-manager/src/manager.rs
@@ -1,5 +1,6 @@
 use super::session_io;
 use super::types::{FeedItem, Provider, SessionStatus};
+use crate::auth_error::is_auth_error;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -41,15 +42,29 @@ impl SessionManager {
             match provider {
                 Provider::Anthropic => {
                     spawn_claude(
-                        &tx, prompt, resume_session_id, working_dir, model, effort,
-                        system_prompt, mcp_config, disable_builtin_tools, disable_all_tools,
-                    ).await;
+                        &tx,
+                        prompt,
+                        resume_session_id,
+                        working_dir,
+                        model,
+                        effort,
+                        system_prompt,
+                        mcp_config,
+                        disable_builtin_tools,
+                        disable_all_tools,
+                    )
+                    .await;
                 }
                 Provider::OpenAI => {
                     spawn_codex(
-                        &tx, prompt, resume_session_id, working_dir, model,
+                        &tx,
+                        prompt,
+                        resume_session_id,
+                        working_dir,
+                        model,
                         system_prompt,
-                    ).await;
+                    )
+                    .await;
                 }
             }
         });
@@ -163,7 +178,8 @@ async fn spawn_codex(
     // Codex has no --system-prompt flag; this is the supported injection point.
     if let Some(ref sp) = system_prompt {
         let json_val = serde_json::to_string(sp).unwrap_or_else(|_| format!("\"{sp}\""));
-        cmd.arg("-c").arg(format!("developer_instructions={json_val}"));
+        cmd.arg("-c")
+            .arg(format!("developer_instructions={json_val}"));
     }
 
     if let Some(ref m) = model {
@@ -238,9 +254,7 @@ async fn run_cli_process(
 
     if let Some(stderr) = stderr {
         let tx2 = tx.clone();
-        io_set.spawn(async move {
-            Some(session_io::read_stderr_lines(stderr, tx2).await)
-        });
+        io_set.spawn(async move { Some(session_io::read_stderr_lines(stderr, tx2).await) });
     }
     if let Some(stdout) = stdout {
         let tx2 = tx.clone();
@@ -274,12 +288,7 @@ async fn run_cli_process(
                 let _ = tx.send(SessionUpdate::Status(SessionStatus::Completed));
             } else {
                 // Check if stderr indicates an auth failure (e.g. Codex 401 retries).
-                let has_auth_error = stderr_lines.iter().any(|l| {
-                    let lower = l.to_lowercase();
-                    lower.contains("401")
-                        || lower.contains("unauthorized")
-                        || lower.contains("not authenticated")
-                });
+                let has_auth_error = stderr_lines.iter().any(|l| is_auth_error(l));
 
                 if has_auth_error {
                     // Clean error — no noisy stderr dump.

--- a/engine/houston-terminal-manager/src/parser.rs
+++ b/engine/houston-terminal-manager/src/parser.rs
@@ -104,8 +104,7 @@ impl StreamAccumulator {
                 // Finalize a tool_use block.
                 if let Some(tool) = self.tools.remove(&index) {
                     let json_str: String = tool.json_parts.concat();
-                    let input =
-                        serde_json::from_str(&json_str).unwrap_or(serde_json::Value::Null);
+                    let input = serde_json::from_str(&json_str).unwrap_or(serde_json::Value::Null);
                     return vec![FeedItem::ToolCall {
                         name: tool.name,
                         input,
@@ -156,11 +155,19 @@ pub fn parse_event(line: &str, acc: &mut StreamAccumulator) -> Vec<FeedItem> {
         }
         ClaudeEvent::User { message, .. } => parse_user_event(message),
         ClaudeEvent::Result {
+            subtype,
             result,
+            is_error,
             cost_usd,
             duration_ms,
             ..
         } => {
+            if subtype.as_deref() == Some("error") || is_error == Some(true) {
+                return vec![FeedItem::SystemMessage(format!(
+                    "Error: {}",
+                    result.unwrap_or_else(|| "Unknown error".to_string()),
+                ))];
+            }
             vec![FeedItem::FinalResult {
                 result: result.unwrap_or_default(),
                 cost_usd,
@@ -299,8 +306,17 @@ mod tests {
     }
 
     #[test]
+    fn parse_result_error_as_system_message() {
+        let line = r#"{"type":"result","subtype":"error","is_error":true,"result":"Claude Code is not authenticated. Run claude auth login"}"#;
+        let items = parse_event(line, &mut acc());
+        assert_eq!(items.len(), 1);
+        assert!(matches!(&items[0], FeedItem::SystemMessage(m) if m.contains("not authenticated")));
+    }
+
+    #[test]
     fn parse_assistant_text() {
-        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello world"}]}}"#;
+        let line =
+            r#"{"type":"assistant","message":{"content":[{"type":"text","text":"Hello world"}]}}"#;
         let items = parse_event(line, &mut acc());
         assert_eq!(items.len(), 1);
         assert!(matches!(&items[0], FeedItem::AssistantText(t) if t == "Hello world"));

--- a/engine/houston-terminal-manager/src/session_io.rs
+++ b/engine/houston-terminal-manager/src/session_io.rs
@@ -2,6 +2,7 @@ use super::codex_parser;
 use super::manager::SessionUpdate;
 use super::parser;
 use super::types::{FeedItem, Provider};
+use crate::auth_error::{AUTH_RETRY_MARKER, is_auth_retry_noise};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc;
 
@@ -18,12 +19,12 @@ pub async fn read_stderr_lines(
     while let Ok(Some(line)) = reader_lines.next_line().await {
         tracing::debug!("cli stderr: {line}");
         if is_auth_retry_noise(&line) {
-            // Show a single friendly message on the first auth retry;
-            // suppress subsequent retry lines entirely.
+            // Send one internal marker; session_runner owns user-visible copy
+            // and AuthRequired emission.
             if !sent_auth_checking {
                 sent_auth_checking = true;
                 let _ = tx.send(SessionUpdate::Feed(FeedItem::SystemMessage(
-                    "Checking connection...".to_string(),
+                    AUTH_RETRY_MARKER.to_string(),
                 )));
             }
         } else if is_meaningful_stderr(&line) {
@@ -56,13 +57,6 @@ fn is_meaningful_stderr(line: &str) -> bool {
         return false;
     }
     true
-}
-
-/// Detect auth retry lines that should not be surfaced to the user.
-fn is_auth_retry_noise(line: &str) -> bool {
-    let lower = line.to_lowercase();
-    (lower.contains("401") || lower.contains("unauthorized") || lower.contains("not authenticated"))
-        && (lower.contains("reconnecting") || lower.contains("retrying"))
 }
 
 /// Read all stdout lines, parsing each as NDJSON and sending parsed feed items

--- a/engine/houston-terminal-manager/src/types.rs
+++ b/engine/houston-terminal-manager/src/types.rs
@@ -62,6 +62,7 @@ pub enum ClaudeEvent {
     Result {
         subtype: Option<String>,
         result: Option<String>,
+        is_error: Option<bool>,
         cost_usd: Option<f64>,
         duration_ms: Option<u64>,
         session_id: Option<String>,

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -98,3 +98,15 @@ create trigger on_auth_user_created after insert on auth.users
 - Mobile (Capacitor) — Supabase JS works there too; deep-link scheme registered separately per platform.
 - In-app NPS — PostHog has it built in; configure later.
 - Teams / orgs, Stripe billing — future Supabase schema extensions.
+
+## Provider CLI re-auth (Claude Code / Codex)
+
+Separate from Houston account auth. Claude Code and Codex keep their own CLI
+sessions. When those sessions expire mid-chat, `houston-terminal-manager`
+classifies auth-shaped stderr/stdout (`401`, `unauthorized`, `not authenticated`,
+expired OAuth/API-key messages) and `houston-agents-conversations` emits
+`HoustonEvent::AuthRequired`. Desktop listens in `use-session-events.ts`, sets
+`authRequired`, and `ProviderReconnectCard` renders inside chat via
+`ChatPanel.afterMessages`. The card opens `claude auth login --claudeai` or
+`codex login` through `/v1/providers/:name/login` and polls provider status
+until the CLI reports authenticated.

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -62,6 +62,12 @@ export interface AIBoardProps {
   toolLabels?: ToolsAndCardsProps["toolLabels"]
   /** Render prop for an end-of-turn summary (e.g., list of edited files). Forwarded to ChatPanel. */
   renderTurnSummary?: import("@houston-ai/chat").ChatPanelProps["renderTurnSummary"]
+  /** Custom renderer for system messages. Forwarded to ChatPanel. */
+  renderSystemMessage?: import("@houston-ai/chat").ChatPanelProps["renderSystemMessage"]
+  /** Map active feed items before rendering. */
+  mapFeedItems?: (ctx: { sessionKey: string; items: FeedItem[] }) => FeedItem[]
+  /** Node rendered after the last chat message. */
+  afterMessages?: ReactNode | ((ctx: { sessionKey: string; feedItems: FeedItem[] }) => ReactNode)
   /** Custom renderer for user messages. Forwarded to ChatPanel. */
   renderUserMessage?: import("@houston-ai/chat").ChatPanelProps["renderUserMessage"]
   /** Emitted by ChatPanel to surface short notices to the user
@@ -149,6 +155,9 @@ export function AIBoard({
   renderToolResult,
   toolLabels,
   renderTurnSummary,
+  renderSystemMessage,
+  mapFeedItems,
+  afterMessages,
   renderUserMessage,
   onNotice,
   onOpenLink,
@@ -250,8 +259,17 @@ export function AIBoard({
     },
     [selectedItem, onSendMessage, sessionKeyFor, newPanelOpen, onCreateConversation, setSelectedId, onDraftChange, activeDraftKey],
   )
-  const activeFeed = activeSessionKey ? (feedItems[activeSessionKey] ?? []) : []
+  const rawActiveFeed = activeSessionKey ? (feedItems[activeSessionKey] ?? []) : []
+  const activeFeed = activeSessionKey && mapFeedItems
+    ? mapFeedItems({ sessionKey: activeSessionKey, items: rawActiveFeed })
+    : rawActiveFeed
   const activeLoading = activeSessionKey ? (isLoading[activeSessionKey] ?? false) : false
+  const renderedAfterMessages = typeof afterMessages === "function"
+    ? afterMessages({
+      sessionKey: activeSessionKey ?? "new-conversation",
+      feedItems: rawActiveFeed,
+    })
+    : afterMessages
 
   const showPanel = selectedItem || newPanelOpen
   const panelTitle = selectedItem?.title ?? "New conversation"
@@ -354,7 +372,9 @@ export function AIBoard({
           renderToolResult={renderToolResult}
           toolLabels={toolLabels}
           renderTurnSummary={renderTurnSummary}
+          renderSystemMessage={renderSystemMessage}
           renderUserMessage={renderUserMessage}
+          afterMessages={renderedAfterMessages}
           onNotice={onNotice}
           onOpenLink={onOpenLink}
           renderLink={renderLink}


### PR DESCRIPTION
## Summary
- detect Claude/Codex CLI auth expiry in shared terminal auth helpers
- emit auth-required events and hide raw auth/session noise from chat feeds
- render the reconnect card in chat and board panels using existing Houston card styling

## Verification
- pnpm typecheck
- cd app && pnpm check-locales
- cargo test -p houston-terminal-manager
- cargo test -p houston-agents-conversations
- cargo test -p houston-tauri
- cargo build -p houston-engine-server
- cd app/src-tauri && cargo check
- git diff --check