### PR TITLE
Collapse chat process details

### DIFF
--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -309,6 +309,8 @@ export function Dashboard() {
           afterMessages={panel.afterMessages}
           isSpecialTool={panel.isSpecialTool}
           renderToolResult={panel.renderToolResult}
+          processLabels={panel.processLabels}
+          getThinkingMessage={panel.getThinkingMessage}
           renderTurnSummary={panel.renderTurnSummary}
           renderLink={panel.renderLink}
         />

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -495,6 +495,8 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
         afterMessages={panel.afterMessages}
         isSpecialTool={panel.isSpecialTool}
         renderToolResult={panel.renderToolResult}
+        processLabels={panel.processLabels}
+        getThinkingMessage={panel.getThinkingMessage}
         renderTurnSummary={panel.renderTurnSummary}
         renderLink={panel.renderLink}
       />

--- a/app/src/components/tabs/chat-tab.tsx
+++ b/app/src/components/tabs/chat-tab.tsx
@@ -23,6 +23,7 @@ import { analytics } from "../../lib/analytics";
 import type { TabProps } from "../../lib/types";
 import { HoustonThinkingIndicator } from "../shell/experience-card";
 import { ChatModelSelector } from "../chat-model-selector";
+import { useChatDisplayLabels } from "../use-chat-display-labels";
 import { getDefaultModel } from "../../lib/providers";
 import { ProviderReconnectCard } from "../shell/provider-reconnect-card";
 import {
@@ -33,6 +34,7 @@ import {
 
 export default function ChatTab({ agent }: TabProps) {
   const { t } = useTranslation("chat");
+  const { processLabels, getThinkingMessage } = useChatDisplayLabels();
   const { isSpecialTool, renderToolResult, renderTurnSummary } = useFileToolRenderer(agent.folderPath);
   // Free-form chat tab gets its own UUID-scoped session key per agent.
   // Must be stable across renders so streaming events land in the same bucket.
@@ -201,6 +203,8 @@ export default function ChatTab({ agent }: TabProps) {
         renderLink={renderLink}
         isSpecialTool={isSpecialTool}
         renderToolResult={renderToolResult}
+        processLabels={processLabels}
+        getThinkingMessage={getThinkingMessage}
         renderTurnSummary={renderTurnSummary}
         renderSystemMessage={(msg) => {
           if (isProviderAuthMessage(msg.content)) {

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -58,6 +58,7 @@ import { SkillCard } from "./skill-card";
 import { NewMissionPickerDialog } from "./new-mission-picker-dialog";
 import { UserActionMessage } from "./user-action-message";
 import { ProviderReconnectCard } from "./shell/provider-reconnect-card";
+import { useChatDisplayLabels } from "./use-chat-display-labels";
 import {
   filterProviderAuthFeedItems,
   isProviderAuthMessage,
@@ -91,6 +92,8 @@ interface AgentChatPanelProps {
   /** Forwarded to AIBoard / ChatPanel for tool rendering. */
   isSpecialTool: ChatPanelProps["isSpecialTool"];
   renderToolResult: ChatPanelProps["renderToolResult"];
+  processLabels: ChatPanelProps["processLabels"];
+  getThinkingMessage: ChatPanelProps["getThinkingMessage"];
   renderTurnSummary: ChatPanelProps["renderTurnSummary"];
   renderSystemMessage: AIBoardProps["renderSystemMessage"];
   mapFeedItems: AIBoardProps["mapFeedItems"];
@@ -114,6 +117,7 @@ export function useAgentChatPanel({
   onSelectSession,
 }: UseAgentChatPanelArgs): AgentChatPanelProps {
   const { t } = useTranslation("board");
+  const { processLabels, getThinkingMessage } = useChatDisplayLabels();
   const queryClient = useQueryClient();
 
   const path = agent?.folderPath ?? null;
@@ -436,6 +440,8 @@ export function useAgentChatPanel({
     renderUserMessage,
     isSpecialTool,
     renderToolResult,
+    processLabels,
+    getThinkingMessage,
     renderTurnSummary,
     renderSystemMessage,
     mapFeedItems,

--- a/app/src/components/use-chat-display-labels.tsx
+++ b/app/src/components/use-chat-display-labels.tsx
@@ -1,0 +1,32 @@
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { Shimmer } from "@houston-ai/chat";
+import type { ChatPanelProps } from "@houston-ai/chat";
+
+export function useChatDisplayLabels(): Pick<
+  ChatPanelProps,
+  "processLabels" | "getThinkingMessage"
+> {
+  const { t } = useTranslation("chat");
+  const processLabels = useMemo(
+    () => ({
+      active: t("process.active"),
+      complete: t("process.complete"),
+    }),
+    [t],
+  );
+  const getThinkingMessage = useCallback<
+    NonNullable<ChatPanelProps["getThinkingMessage"]>
+  >(
+    (isStreaming, duration) => {
+      if (isStreaming || duration === 0) {
+        return <Shimmer duration={1}>{t("reasoning.thinking")}</Shimmer>;
+      }
+      if (duration === undefined) return <span>{t("reasoning.thoughtForFew")}</span>;
+      return <span>{t("reasoning.thoughtFor", { count: duration })}</span>;
+    },
+    [t],
+  );
+
+  return { processLabels, getThinkingMessage };
+}

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -25,6 +25,10 @@
     "thoughtFor": "Thought for {{count}} seconds",
     "thoughtForFew": "Thought for a few seconds"
   },
+  "process": {
+    "active": "Mission in progress...",
+    "complete": "Mission log"
+  },
   "filesUpdated_one": "1 file updated",
   "filesUpdated_other": "{{count}} files updated"
 }

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -25,6 +25,10 @@
     "thoughtFor": "Pensó durante {{count}} segundos",
     "thoughtForFew": "Pensó durante unos segundos"
   },
+  "process": {
+    "active": "Misión en curso...",
+    "complete": "Registro de misión"
+  },
   "filesUpdated_one": "1 archivo actualizado",
   "filesUpdated_other": "{{count}} archivos actualizados"
 }

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -25,6 +25,10 @@
     "thoughtFor": "Pensou por {{count}} segundos",
     "thoughtForFew": "Pensou por alguns segundos"
   },
+  "process": {
+    "active": "Missão em andamento...",
+    "complete": "Registro da missão"
+  },
   "filesUpdated_one": "1 arquivo atualizado",
   "filesUpdated_other": "{{count}} arquivos atualizados"
 }

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom"
 import type { ReactNode } from "react"
 
 import { ChatPanel } from "@houston-ai/chat"
-import type { FeedItem, ToolsAndCardsProps } from "@houston-ai/chat"
+import type { ChatPanelProps, FeedItem, ToolsAndCardsProps } from "@houston-ai/chat"
 import { SplitView } from "@houston-ai/layout"
 import { KanbanBoard } from "./kanban-board"
 import { KanbanDetailPanel } from "./kanban-detail-panel"
@@ -58,6 +58,10 @@ export interface AIBoardProps {
   isSpecialTool?: ToolsAndCardsProps["isSpecialTool"]
   /** Custom renderer for special tool results. */
   renderToolResult?: ToolsAndCardsProps["renderToolResult"]
+  /** Translated labels for the collapsed process/details block. */
+  processLabels?: ChatPanelProps["processLabels"]
+  /** Translated reasoning text inside the process/details block. */
+  getThinkingMessage?: ChatPanelProps["getThinkingMessage"]
   /** Custom tool name → human label mappings. */
   toolLabels?: ToolsAndCardsProps["toolLabels"]
   /** Render prop for an end-of-turn summary (e.g., list of edited files). Forwarded to ChatPanel. */
@@ -153,6 +157,8 @@ export function AIBoard({
   onDraftChange,
   isSpecialTool,
   renderToolResult,
+  processLabels,
+  getThinkingMessage,
   toolLabels,
   renderTurnSummary,
   renderSystemMessage,
@@ -370,6 +376,8 @@ export function AIBoard({
           onValueChange={onDraftChange ? (text: string) => onDraftChange(activeDraftKey, text) : undefined}
           isSpecialTool={isSpecialTool}
           renderToolResult={renderToolResult}
+          processLabels={processLabels}
+          getThinkingMessage={getThinkingMessage}
           toolLabels={toolLabels}
           renderTurnSummary={renderTurnSummary}
           renderSystemMessage={renderSystemMessage}

--- a/ui/chat/README.md
+++ b/ui/chat/README.md
@@ -1,6 +1,6 @@
 # @houston-ai/chat
 
-Full-featured AI chat interface. Streaming markdown, thinking blocks, tool activity, prompt input -- one component or pick individual pieces.
+Full-featured AI chat interface. Streaming markdown, grouped technical details, prompt input -- one component or pick individual pieces.
 
 ## Install
 
@@ -34,6 +34,8 @@ import "@houston-ai/chat/src/styles.css"
 ## How it works
 
 `ChatPanel` accepts an array of `FeedItem` discriminated unions (user messages, assistant text, thinking, tool calls, tool results, final results) and renders the full conversation. Status is derived automatically from the feed, or you can override it.
+
+Thinking and tool activity are grouped into a single technical-details accordion per assistant turn. The active group stays open while work is happening, then collapses when the assistant returns user-facing text or the session becomes ready.
 
 The AI Elements are composable -- use `ChatPanel` for the batteries-included experience, or build your own layout with the primitives.
 

--- a/ui/chat/src/chat-drop-overlay.tsx
+++ b/ui/chat/src/chat-drop-overlay.tsx
@@ -1,0 +1,28 @@
+import { FilesIcon } from "lucide-react";
+
+export interface ChatDropOverlayProps {
+  visible: boolean;
+}
+
+export function ChatDropOverlay({ visible }: ChatDropOverlayProps) {
+  if (!visible) return null;
+  return (
+    <div
+      className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-white/80 backdrop-blur-sm"
+      aria-hidden="true"
+    >
+      <div className="flex w-full max-w-sm -translate-y-12 flex-col items-center gap-3 px-6 text-center">
+        <FilesIcon
+          className="size-8 text-muted-foreground"
+          strokeWidth={1.5}
+        />
+        <div className="text-2xl font-semibold tracking-tight text-foreground">
+          Add anything
+        </div>
+        <p className="text-sm/relaxed text-muted-foreground">
+          Drop your files in here to add it to the conversation
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -6,7 +6,6 @@
 
 import { useMemo } from "react";
 import type { ReactNode } from "react";
-import { FilesIcon } from "lucide-react";
 import {
   Conversation,
   ConversationAutoScroll,
@@ -19,13 +18,12 @@ import {
   MessageResponse,
 } from "./ai-elements/message";
 import type { RenderLinkProps } from "./ai-elements/message";
-import {
-  Reasoning,
-  ReasoningContent,
-  ReasoningTrigger,
-} from "./ai-elements/reasoning";
-import { ToolsAndCards } from "./chat-helpers";
+import type { ReasoningTriggerProps } from "./ai-elements/reasoning";
 import type { ToolsAndCardsProps } from "./chat-helpers";
+import { ChatProcessBlock } from "./chat-process-block";
+import type { ChatProcessLabels } from "./chat-process-block";
+import { getChatDisplayItems } from "./chat-process-groups";
+import { computeTurnEndTools } from "./turn-tools";
 import type { ChatMessage, ToolEntry } from "./feed-to-messages";
 
 export interface ChatMessagesProps {
@@ -39,6 +37,8 @@ export interface ChatMessagesProps {
   toolLabels?: ToolsAndCardsProps["toolLabels"];
   isSpecialTool?: ToolsAndCardsProps["isSpecialTool"];
   renderToolResult?: ToolsAndCardsProps["renderToolResult"];
+  processLabels?: ChatProcessLabels;
+  getThinkingMessage?: ReasoningTriggerProps["getThinkingMessage"];
   renderMessageAvatar?: (msg: ChatMessage) => ReactNode | undefined;
   renderTurnSummary?: (tools: ToolEntry[]) => ReactNode;
   /** Custom renderer for system messages. Return a node to replace the default,
@@ -60,33 +60,6 @@ export interface ChatMessagesProps {
   renderLink?: (props: RenderLinkProps) => ReactNode;
 }
 
-/**
- * Build a map of message-index -> aggregated tools for that turn. Only set
- * on the *last* assistant message of a *complete* turn (next message is
- * non-assistant, OR it's the final message and the chat status is "ready").
- */
-function computeTurnEndTools(
-  messages: ChatMessage[],
-  status: "ready" | "streaming" | "submitted",
-): Map<number, ToolEntry[]> {
-  const result = new Map<number, ToolEntry[]>();
-  for (let i = 0; i < messages.length; i++) {
-    const msg = messages[i];
-    if (msg.from !== "assistant") continue;
-    const next = messages[i + 1];
-    const isEndOfTurn = next ? next.from !== "assistant" : status === "ready";
-    if (!isEndOfTurn) continue;
-    const tools: ToolEntry[] = [];
-    for (let j = i; j >= 0; j--) {
-      const m = messages[j];
-      if (m.from !== "assistant") break;
-      tools.unshift(...m.tools);
-    }
-    result.set(i, tools);
-  }
-  return result;
-}
-
 export function ChatMessages({
   messages,
   status,
@@ -95,6 +68,8 @@ export function ChatMessages({
   toolLabels,
   isSpecialTool,
   renderToolResult,
+  processLabels,
+  getThinkingMessage,
   renderMessageAvatar,
   renderTurnSummary,
   renderSystemMessage,
@@ -107,11 +82,46 @@ export function ChatMessages({
     () => computeTurnEndTools(messages, status),
     [messages, status],
   );
+  const displayItems = useMemo(
+    () => getChatDisplayItems(messages, status),
+    [messages, status],
+  );
   return (
     <Conversation className="flex-1 min-h-0">
       <ConversationAutoScroll status={status} />
       <ConversationContent className="max-w-3xl mx-auto">
-        {messages.map((msg, idx) => {
+        {displayItems.map((item) => {
+          if (item.kind === "process") {
+            return (
+              <Message
+                from="assistant"
+                key={item.key}
+                className="-my-6"
+                avatar={renderMessageAvatar?.(item.segments[0].message)}
+              >
+                <div>
+                  <ChatProcessBlock
+                    segments={item.segments}
+                    isActive={item.isActive}
+                    labels={processLabels}
+                    toolLabels={toolLabels}
+                    isSpecialTool={isSpecialTool}
+                    renderToolResult={renderToolResult}
+                    getThinkingMessage={getThinkingMessage}
+                  />
+                  {(() => {
+                    if (!item.isTrailing || item.isActive || !renderTurnSummary) return null;
+                    const turnTools = turnEndTools.get(item.sourceIndex);
+                    if (!turnTools) return null;
+                    return renderTurnSummary(turnTools);
+                  })()}
+                </div>
+              </Message>
+            );
+          }
+
+          const msg = item.message;
+          const idx = item.sourceIndex;
           if (msg.from === "system") {
             const custom = renderSystemMessage?.(msg);
             if (custom !== undefined) return <div key={msg.key}>{custom}</div>;
@@ -128,26 +138,6 @@ export function ChatMessages({
           return (
             <Message from={msg.from} key={msg.key} avatar={renderMessageAvatar?.(msg)}>
               <div>
-                {msg.reasoning && (
-                  <Reasoning
-                    isStreaming={msg.reasoning.isStreaming && isLastMsg}
-                    defaultOpen={msg.reasoning.isStreaming && isLastMsg}
-                  >
-                    <ReasoningTrigger />
-                    <ReasoningContent>
-                      {msg.reasoning.content}
-                    </ReasoningContent>
-                  </Reasoning>
-                )}
-                {msg.tools.length > 0 && (
-                  <ToolsAndCards
-                    tools={msg.tools}
-                    isStreaming={streaming}
-                    toolLabels={toolLabels}
-                    isSpecialTool={isSpecialTool}
-                    renderToolResult={renderToolResult}
-                  />
-                )}
                 {msg.content && (() => {
                   if (msg.from === "user" && renderUserMessage) {
                     const custom = renderUserMessage(msg);
@@ -191,32 +181,5 @@ export function ChatMessages({
       </ConversationContent>
       <ConversationScrollButton />
     </Conversation>
-  );
-}
-
-export interface ChatDropOverlayProps {
-  visible: boolean;
-}
-
-export function ChatDropOverlay({ visible }: ChatDropOverlayProps) {
-  if (!visible) return null;
-  return (
-    <div
-      className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-white/80 backdrop-blur-sm"
-      aria-hidden="true"
-    >
-      <div className="flex w-full max-w-sm flex-col items-center gap-3 px-6 text-center -translate-y-12">
-        <FilesIcon
-          className="size-8 text-muted-foreground"
-          strokeWidth={1.5}
-        />
-        <div className="text-2xl font-semibold tracking-tight text-foreground">
-          Add anything
-        </div>
-        <p className="text-sm/relaxed text-muted-foreground">
-          Drop your files in here to add it to the conversation
-        </p>
-      </div>
-    </div>
   );
 }

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -1,0 +1,40 @@
+import type { ReactNode } from "react";
+import type { ToolsAndCardsProps } from "./chat-helpers";
+import type { ChatMessagesProps } from "./chat-messages";
+import type { ChatMessage, ToolEntry } from "./feed-to-messages";
+import type { FeedItem } from "./types";
+
+export type ChatStatus = "ready" | "streaming" | "submitted";
+
+export interface ChatPanelProps {
+  sessionKey: string;
+  feedItems: FeedItem[];
+  onSend: (text: string, files: File[]) => void;
+  onStop?: () => void;
+  onBack?: () => void;
+  isLoading: boolean;
+  placeholder?: string;
+  emptyState?: ReactNode;
+  value?: string;
+  onValueChange?: (value: string) => void;
+  attachments?: File[];
+  onAttachmentsChange?: (files: File[]) => void;
+  onNotice?: (message: string) => void;
+  footer?: ReactNode;
+  status?: ChatStatus;
+  thinkingIndicator?: ReactNode;
+  transformContent?: (content: string) => { content: string; extra?: ReactNode };
+  toolLabels?: ToolsAndCardsProps["toolLabels"];
+  isSpecialTool?: ToolsAndCardsProps["isSpecialTool"];
+  renderToolResult?: ToolsAndCardsProps["renderToolResult"];
+  processLabels?: ChatMessagesProps["processLabels"];
+  getThinkingMessage?: ChatMessagesProps["getThinkingMessage"];
+  renderMessageAvatar?: (msg: ChatMessage) => ReactNode | undefined;
+  renderSystemMessage?: (msg: ChatMessage) => ReactNode | undefined;
+  renderUserMessage?: (msg: ChatMessage) => ReactNode | undefined;
+  afterMessages?: ReactNode;
+  renderTurnSummary?: (tools: ToolEntry[]) => ReactNode;
+  onOpenLink?: (url: string) => void;
+  renderLink?: ChatMessagesProps["renderLink"];
+  composerOverride?: ReactNode;
+}

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -4,119 +4,16 @@
  * Generic version: accepts feedItems/status as props, no store dependencies.
  */
 import { useCallback, useMemo } from "react";
-import type { FeedItem } from "./types";
-import type { ReactNode } from "react";
-
 import { feedItemsToMessages } from "./chat-helpers";
-import type { ToolsAndCardsProps } from "./chat-helpers";
-import type { ToolEntry } from "./feed-to-messages";
 import { ChatInput } from "./chat-input";
-import { ChatMessages, ChatDropOverlay } from "./chat-messages";
-import type { ChatMessagesProps } from "./chat-messages";
+import { ChatDropOverlay } from "./chat-drop-overlay";
+import { ChatMessages } from "./chat-messages";
+import type { ChatPanelProps } from "./chat-panel-types";
+import { deriveStatus } from "./chat-status";
 import { Shimmer } from "./ai-elements/shimmer";
 import { useFileDropZone, useControllable, mergeUniqueFiles } from "./use-file-drop-zone";
 
-// ---------------------------------------------------------------------------
-// ChatPanel props
-// ---------------------------------------------------------------------------
-
-type ChatStatus = "ready" | "streaming" | "submitted";
-
-export interface ChatPanelProps {
-  sessionKey: string;
-  feedItems: FeedItem[];
-  onSend: (text: string, files: File[]) => void;
-  onStop?: () => void;
-  onBack?: () => void;
-  isLoading: boolean;
-  placeholder?: string;
-  emptyState?: ReactNode;
-  /** Controlled composer text. Forwarded to ChatInput. */
-  value?: string;
-  /** Required if `value` is provided. */
-  onValueChange?: (value: string) => void;
-  /** Controlled composer attachments. Forwarded to ChatInput. */
-  attachments?: File[];
-  /** Required if `attachments` is provided. */
-  onAttachmentsChange?: (files: File[]) => void;
-  /** Emitted when the library wants to surface a short notice to the user
-   *  (e.g. a duplicate-file drop). The app decides how to display it. */
-  onNotice?: (message: string) => void;
-  /** Optional content rendered in the composer footer (e.g. model selector). */
-  footer?: ReactNode;
-  /** Override status derivation. If not provided, status is derived from feedItems. */
-  status?: ChatStatus;
-  /**
-   * Custom loading indicator shown when status is "submitted" and no messages yet.
-   * Defaults to a shimmering "Thinking..." text.
-   */
-  thinkingIndicator?: ReactNode;
-  /**
-   * Optional transform applied to each assistant message's content before rendering.
-   * Return { content, extra } where content is the cleaned text and extra is
-   * an optional ReactNode rendered below the message response.
-   */
-  transformContent?: (content: string) => {
-    content: string;
-    extra?: ReactNode;
-  };
-  /** Props forwarded to ToolsAndCards for custom tool rendering */
-  toolLabels?: ToolsAndCardsProps["toolLabels"];
-  isSpecialTool?: ToolsAndCardsProps["isSpecialTool"];
-  renderToolResult?: ToolsAndCardsProps["renderToolResult"];
-  /** Optional callback to render an avatar for a message (e.g., channel logo). */
-  renderMessageAvatar?: (msg: import("./feed-to-messages").ChatMessage) => ReactNode | undefined;
-  /** Custom renderer for system messages. Return a node to replace the default,
-   *  or undefined to use the default italic text. */
-  renderSystemMessage?: (msg: import("./feed-to-messages").ChatMessage) => ReactNode | undefined;
-  /** Custom renderer for user messages. Return a node to replace the
-   *  default user bubble, or `undefined` to keep the markdown body. */
-  renderUserMessage?: (msg: import("./feed-to-messages").ChatMessage) => ReactNode | undefined;
-  /** Node rendered after the last message (inside the scroll container).
-   *  Useful for inline end-of-feed cards like auth reconnect prompts. */
-  afterMessages?: ReactNode;
-  /**
-   * Optional render prop called once per *completed* assistant turn, on the
-   * last assistant message of that turn. Receives all tools from every
-   * assistant message in the turn (aggregated). Returned node is rendered
-   * below the assistant comment. The app uses this to show a summary of
-   * files edited/created during the turn. Not called while the turn is
-   * still streaming.
-   */
-  renderTurnSummary?: (tools: ToolEntry[]) => ReactNode;
-  /** Called when the user clicks the open button on an inline link. */
-  onOpenLink?: (url: string) => void;
-  /**
-   * Custom renderer for markdown links — replaces the default button.
-   * The app layer uses this to render rich inline cards for certain
-   * URL patterns (e.g. Composio connect flows). When omitted, links
-   * render as the default `onOpenLink` button.
-   */
-  renderLink?: ChatMessagesProps["renderLink"];
-  /**
-   * Replaces the composer entirely with this node. Apps use it to render
-   * a focused interaction surface (e.g. an action-input form) that should
-   * own the bottom of the panel until the user submits or cancels. While
-   * `composerOverride` is set, the textarea, file picker, and footer are
-   * not rendered.
-   */
-  composerOverride?: ReactNode;
-}
-
-function deriveStatus(items: FeedItem[], isLoading: boolean): ChatStatus {
-  const last = items[items.length - 1];
-  if (
-    last?.feed_type === "assistant_text_streaming" ||
-    last?.feed_type === "thinking_streaming" ||
-    last?.feed_type === "thinking" ||
-    last?.feed_type === "tool_call" ||
-    last?.feed_type === "tool_result"
-  )
-    return "streaming";
-  if (last?.feed_type === "user_message") return "submitted";
-  if (isLoading && items.length === 0) return "submitted";
-  return "ready";
-}
+export type { ChatPanelProps } from "./chat-panel-types";
 
 const DefaultThinkingIndicator = () => (
   <div className="py-1">
@@ -138,6 +35,8 @@ export function ChatPanel({
   toolLabels,
   isSpecialTool,
   renderToolResult,
+  processLabels,
+  getThinkingMessage,
   renderMessageAvatar,
   renderSystemMessage,
   renderUserMessage,
@@ -213,6 +112,8 @@ export function ChatPanel({
           toolLabels={toolLabels}
           isSpecialTool={isSpecialTool}
           renderToolResult={renderToolResult}
+          processLabels={processLabels}
+          getThinkingMessage={getThinkingMessage}
           renderMessageAvatar={renderMessageAvatar}
           renderSystemMessage={renderSystemMessage}
           renderUserMessage={renderUserMessage}

--- a/ui/chat/src/chat-process-block.tsx
+++ b/ui/chat/src/chat-process-block.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+  HoustonHelmet,
+  cn,
+} from "@houston-ai/core";
+import { ChevronDownIcon } from "lucide-react";
+import { Shimmer } from "./ai-elements/shimmer";
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from "./ai-elements/reasoning";
+import type { ReasoningTriggerProps } from "./ai-elements/reasoning";
+import { ToolsAndCards } from "./chat-helpers";
+import type { ToolsAndCardsProps } from "./chat-helpers";
+import type { ChatProcessSegment } from "./chat-process-groups";
+
+export interface ChatProcessLabels {
+  active?: string;
+  complete?: string;
+}
+
+export interface ChatProcessBlockProps {
+  segments: ChatProcessSegment[];
+  isActive: boolean;
+  labels?: ChatProcessLabels;
+  toolLabels?: ToolsAndCardsProps["toolLabels"];
+  isSpecialTool?: ToolsAndCardsProps["isSpecialTool"];
+  renderToolResult?: ToolsAndCardsProps["renderToolResult"];
+  getThinkingMessage?: ReasoningTriggerProps["getThinkingMessage"];
+}
+
+const DEFAULT_LABELS: Required<ChatProcessLabels> = {
+  active: "Mission in progress...",
+  complete: "Mission log",
+};
+
+export function ChatProcessBlock({
+  segments,
+  isActive,
+  labels,
+  toolLabels,
+  isSpecialTool,
+  renderToolResult,
+  getThinkingMessage,
+}: ChatProcessBlockProps) {
+  const l = useMemo(() => ({ ...DEFAULT_LABELS, ...labels }), [labels]);
+  const [isOpen, setIsOpen] = useState(isActive);
+  const wasActiveRef = useRef(isActive);
+
+  useEffect(() => {
+    if (isActive) {
+      setIsOpen(true);
+    } else if (wasActiveRef.current) {
+      setIsOpen(false);
+    }
+    wasActiveRef.current = isActive;
+  }, [isActive]);
+
+  return (
+    <Collapsible
+      className="not-prose"
+      open={isOpen}
+      onOpenChange={setIsOpen}
+    >
+      <CollapsibleTrigger
+        className="inline-flex max-w-full items-center gap-1.5 text-xs text-muted-foreground/65 transition-colors hover:text-muted-foreground"
+      >
+        <HoustonHelmet color="currentColor" size={13} />
+        <span className="min-w-0 truncate text-left">
+          {isActive ? <Shimmer duration={1}>{l.active}</Shimmer> : l.complete}
+        </span>
+        <ChevronDownIcon
+          className={cn(
+            "size-3.5 shrink-0 transition-transform",
+            isOpen ? "rotate-180" : "rotate-0",
+          )}
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          "mt-3 space-y-3 text-sm text-muted-foreground outline-none",
+          "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2",
+          "data-[state=open]:slide-in-from-top-2",
+          "data-[state=closed]:animate-out data-[state=open]:animate-in",
+        )}
+      >
+        {segments.map((segment, index) => {
+          const isLastSegment = index === segments.length - 1;
+          const segmentActive = isActive && isLastSegment;
+          return (
+            <div key={segment.key} className="space-y-3">
+              {segment.reasoning && (
+                <Reasoning
+                  isStreaming={segmentActive && segment.reasoning.isStreaming}
+                  defaultOpen={segmentActive && segment.reasoning.isStreaming}
+                >
+                  <ReasoningTrigger getThinkingMessage={getThinkingMessage} />
+                  <ReasoningContent>{segment.reasoning.content}</ReasoningContent>
+                </Reasoning>
+              )}
+              {segment.tools.length > 0 && (
+                <ToolsAndCards
+                  tools={segment.tools}
+                  isStreaming={segmentActive}
+                  toolLabels={toolLabels}
+                  isSpecialTool={isSpecialTool}
+                  renderToolResult={renderToolResult}
+                />
+              )}
+            </div>
+          );
+        })}
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}

--- a/ui/chat/src/chat-process-groups.ts
+++ b/ui/chat/src/chat-process-groups.ts
@@ -1,0 +1,100 @@
+import type { ChatMessage, ToolEntry } from "./feed-to-messages";
+
+type ChatStatus = "ready" | "streaming" | "submitted";
+
+export interface ChatProcessSegment {
+  key: string;
+  sourceIndex: number;
+  message: ChatMessage;
+  reasoning?: ChatMessage["reasoning"];
+  tools: ToolEntry[];
+}
+
+export type ChatDisplayItem =
+  | { kind: "message"; message: ChatMessage; sourceIndex: number }
+  | {
+      kind: "process";
+      key: string;
+      segments: ChatProcessSegment[];
+      isActive: boolean;
+      isTrailing: boolean;
+      sourceIndex: number;
+    };
+
+function hasProcess(message: ChatMessage): boolean {
+  return Boolean(message.reasoning) || message.tools.length > 0;
+}
+
+function contentOnly(message: ChatMessage): ChatMessage {
+  if (!hasProcess(message)) return message;
+  return {
+    ...message,
+    key: `${message.key}-content`,
+    reasoning: undefined,
+    tools: [],
+  };
+}
+
+function segmentFrom(message: ChatMessage, sourceIndex: number): ChatProcessSegment {
+  return {
+    key: message.key,
+    sourceIndex,
+    message,
+    reasoning: message.reasoning,
+    tools: message.tools,
+  };
+}
+
+function processKey(segments: ChatProcessSegment[]): string {
+  const first = segments[0]?.key ?? "empty";
+  const last = segments[segments.length - 1]?.key ?? first;
+  return `process-${first}-${last}`;
+}
+
+export function getChatDisplayItems(
+  messages: ChatMessage[],
+  status: ChatStatus,
+): ChatDisplayItem[] {
+  const items: ChatDisplayItem[] = [];
+  let pending: ChatProcessSegment[] = [];
+
+  const flushProcess = (isActive: boolean, isTrailing: boolean) => {
+    if (pending.length === 0) return;
+    const lastSegment = pending[pending.length - 1];
+    items.push({
+      kind: "process",
+      key: processKey(pending),
+      segments: pending,
+      isActive,
+      isTrailing,
+      sourceIndex: lastSegment.sourceIndex,
+    });
+    pending = [];
+  };
+
+  for (let sourceIndex = 0; sourceIndex < messages.length; sourceIndex++) {
+    const message = messages[sourceIndex];
+    if (message.from !== "assistant") {
+      flushProcess(false, false);
+      items.push({ kind: "message", message, sourceIndex });
+      continue;
+    }
+
+    const messageHasProcess = hasProcess(message);
+    const messageHasContent = message.content.length > 0;
+
+    if (messageHasProcess) {
+      pending.push(segmentFrom(message, sourceIndex));
+    }
+
+    if (messageHasContent) {
+      flushProcess(false, false);
+      items.push({ kind: "message", message: contentOnly(message), sourceIndex });
+    } else if (!messageHasProcess) {
+      items.push({ kind: "message", message, sourceIndex });
+    }
+  }
+
+  flushProcess(status !== "ready", true);
+  return items;
+}

--- a/ui/chat/src/chat-status.ts
+++ b/ui/chat/src/chat-status.ts
@@ -1,0 +1,18 @@
+import type { ChatStatus } from "./chat-panel-types";
+import type { FeedItem } from "./types";
+
+export function deriveStatus(items: FeedItem[], isLoading: boolean): ChatStatus {
+  const last = items[items.length - 1];
+  if (
+    last?.feed_type === "assistant_text_streaming" ||
+    last?.feed_type === "thinking_streaming" ||
+    last?.feed_type === "thinking" ||
+    last?.feed_type === "tool_call" ||
+    last?.feed_type === "tool_result"
+  ) {
+    return "streaming";
+  }
+  if (last?.feed_type === "user_message") return "submitted";
+  if (isLoading && items.length === 0) return "submitted";
+  return "ready";
+}

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -159,6 +159,7 @@ export type { SuggestionsProps, SuggestionProps } from "./ai-elements/suggestion
 // === Chat Components ===
 export { ChatPanel } from "./chat-panel";
 export type { ChatPanelProps } from "./chat-panel";
+export type { ChatProcessLabels } from "./chat-process-block";
 
 export { ChatInput } from "./chat-input";
 export type { ChatInputProps } from "./chat-input";

--- a/ui/chat/src/turn-tools.ts
+++ b/ui/chat/src/turn-tools.ts
@@ -1,0 +1,24 @@
+import type { ChatStatus } from "./chat-panel-types";
+import type { ChatMessage, ToolEntry } from "./feed-to-messages";
+
+export function computeTurnEndTools(
+  messages: ChatMessage[],
+  status: ChatStatus,
+): Map<number, ToolEntry[]> {
+  const result = new Map<number, ToolEntry[]>();
+  for (let i = 0; i < messages.length; i++) {
+    const msg = messages[i];
+    if (msg.from !== "assistant") continue;
+    const next = messages[i + 1];
+    const isEndOfTurn = next ? next.from !== "assistant" : status === "ready";
+    if (!isEndOfTurn) continue;
+    const tools: ToolEntry[] = [];
+    for (let j = i; j >= 0; j--) {
+      const m = messages[j];
+      if (m.from !== "assistant") break;
+      tools.unshift(...m.tools);
+    }
+    result.set(i, tools);
+  }
+  return result;
+}

--- a/ui/chat/test/chat-process-groups.test.mjs
+++ b/ui/chat/test/chat-process-groups.test.mjs
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { getChatDisplayItems } from "../src/chat-process-groups.ts";
+
+const assistant = (key, content, extras = {}) => ({
+  key,
+  from: "assistant",
+  content,
+  isStreaming: false,
+  tools: extras.tools ?? [],
+  reasoning: extras.reasoning,
+});
+
+test("groups thinking and tools into one process block before assistant text", () => {
+  const items = getChatDisplayItems(
+    [
+      assistant("a1", "First message"),
+      assistant("a2", "", {
+        reasoning: { content: "Thinking", isStreaming: false },
+      }),
+      assistant("a3", "Second message", {
+        tools: [
+          {
+            name: "Read",
+            input: { file_path: "notes.md" },
+            result: { content: "ok", is_error: false },
+          },
+        ],
+      }),
+    ],
+    "ready",
+  );
+
+  assert.deepEqual(
+    items.map((item) => item.kind),
+    ["message", "process", "message"],
+  );
+  assert.equal(items[1].isActive, false);
+  assert.equal(items[1].segments.length, 2);
+  assert.equal(items[2].message.content, "Second message");
+  assert.equal(items[2].message.tools.length, 0);
+});
+
+test("keeps trailing process block active while session streams", () => {
+  const items = getChatDisplayItems(
+    [
+      assistant("a1", "First message"),
+      assistant("a2", "", {
+        tools: [{ name: "Bash", input: { command: "pwd" } }],
+      }),
+    ],
+    "streaming",
+  );
+
+  assert.deepEqual(
+    items.map((item) => item.kind),
+    ["message", "process"],
+  );
+  assert.equal(items[1].isActive, true);
+});
+
+test("collapses trailing process block once session is ready", () => {
+  const items = getChatDisplayItems(
+    [
+      assistant("a1", "First message"),
+      assistant("a2", "", {
+        tools: [
+          {
+            name: "Bash",
+            input: { command: "pwd" },
+            result: { content: "/tmp", is_error: false },
+          },
+        ],
+      }),
+    ],
+    "ready",
+  );
+
+  assert.equal(items[1].kind, "process");
+  assert.equal(items[1].isActive, false);
+});


### PR DESCRIPTION
## Summary
- group reasoning and tool activity into one compact Mission log accordion per assistant turn
- keep active process details open while work runs, then collapse between user-facing messages
- add translated process labels and focused grouping tests

## Checks
- pnpm typecheck
- cd app && pnpm check-locales
- node --experimental-strip-types --test ui/chat/test/chat-process-groups.test.mjs