### PR TITLE
Fix chat summary file attribution

### DIFF
--- a/app/src/components/tabs/job-description-tab.tsx
+++ b/app/src/components/tabs/job-description-tab.tsx
@@ -34,6 +34,7 @@ import {
   useUpdateLearning,
 } from "../../hooks/queries";
 import type { TabProps } from "../../lib/types";
+import { useUIStore } from "../../stores/ui";
 
 type SubTab = "instructions" | "skills" | "learnings";
 
@@ -56,6 +57,8 @@ export default function JobDescriptionTab({ agent }: TabProps) {
   };
   const path = agent.folderPath;
   const [activeTab, setActiveTab] = useState<SubTab>("instructions");
+  const targetTab = useUIStore((s) => s.jobDescriptionTarget);
+  const setTargetTab = useUIStore((s) => s.setJobDescriptionTarget);
 
   // Instructions (CLAUDE.md)
   const { data: instructions } = useInstructions(path);
@@ -64,6 +67,12 @@ export default function JobDescriptionTab({ agent }: TabProps) {
   // Skills
   const { data: summaries, isLoading: skillsLoading } = useSkills(path);
   const [selectedSkillName, setSelectedSkillName] = useState<string | null>(null);
+  useEffect(() => {
+    if (!targetTab) return;
+    setActiveTab(targetTab);
+    setSelectedSkillName(null);
+    setTargetTab(null);
+  }, [targetTab, setTargetTab]);
   const { data: skillDetail } = useSkillDetail(path, selectedSkillName ?? undefined);
   const saveSkill = useSaveSkill(path);
   const deleteSkill = useDeleteSkill(path);

--- a/app/src/components/turn-file-summary.tsx
+++ b/app/src/components/turn-file-summary.tsx
@@ -1,18 +1,29 @@
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChevronDownIcon } from "lucide-react";
+import type { TFunction } from "i18next";
+import { ChevronDownIcon, Lightbulb, Play, ScrollText } from "lucide-react";
 import { cn } from "@houston-ai/core";
 import { tauriFiles } from "../lib/tauri";
+import type { JobDescriptionTarget } from "../stores/ui";
+import { useAgentStore } from "../stores/agents";
+import { useAgentCatalogStore } from "../stores/agent-catalog";
+import { useUIStore } from "../stores/ui";
+import {
+  groupTurnSummaryItems,
+  type SemanticUpdateKind,
+  type TurnSummaryItem,
+} from "../lib/turn-summary-items";
 import { getFileIcon } from "./file-card";
 
 interface TurnFileSummaryProps {
-  filePaths: string[];
+  items: TurnSummaryItem[];
   agentPath: string;
 }
 
-export function TurnFileSummary({ filePaths, agentPath }: TurnFileSummaryProps) {
+export function TurnFileSummary({ items, agentPath }: TurnFileSummaryProps) {
   const { t } = useTranslation("chat");
-  const [open, setOpen] = useState(false);
+  const [openUpdates, setOpenUpdates] = useState(false);
+  const [openFiles, setOpenFiles] = useState(false);
 
   const handleOpen = useCallback(
     (path: string) => {
@@ -21,13 +32,81 @@ export function TurnFileSummary({ filePaths, agentPath }: TurnFileSummaryProps) 
     [agentPath],
   );
 
-  if (filePaths.length === 0) return null;
+  const handleOpenSemantic = useCallback(
+    (kind: SemanticUpdateKind) => {
+      const agents = useAgentStore.getState().agents;
+      const agent = agents.find((a) => a.folderPath === agentPath);
+      const ui = useUIStore.getState();
+      if (agent) {
+        useAgentStore.getState().setCurrent(agent);
+        const def = useAgentCatalogStore.getState().getById(agent.configId);
+        const tabIds = new Set(def?.config.tabs.map((tab) => tab.id) ?? []);
+        const target = semanticTarget(kind);
+        if (tabIds.has("job-description")) {
+          ui.setJobDescriptionTarget(target);
+          ui.setViewMode("job-description");
+        } else {
+          ui.setViewMode(fallbackTab(kind, tabIds));
+        }
+      }
+      ui.setMissionPanelOpen(false);
+    },
+    [agentPath],
+  );
+
+  if (items.length === 0) return null;
+  const groups = groupTurnSummaryItems(items);
 
   return (
-    <div className="mt-3 rounded-lg border border-border/50 bg-secondary overflow-hidden">
+    <div className="mt-3 flex flex-col gap-2">
+      {groups.updates.length > 0 && (
+        <SummarySection
+          title={t("summary.updatesMade")}
+          items={groups.updates}
+          open={openUpdates}
+          onOpenChange={setOpenUpdates}
+          onOpenFile={handleOpen}
+          onOpenSemantic={handleOpenSemantic}
+          t={t}
+        />
+      )}
+      {groups.files.length > 0 && (
+        <SummarySection
+          title={t("summary.newFiles", { count: groups.files.length })}
+          items={groups.files}
+          open={openFiles}
+          onOpenChange={setOpenFiles}
+          onOpenFile={handleOpen}
+          onOpenSemantic={handleOpenSemantic}
+          t={t}
+        />
+      )}
+    </div>
+  );
+}
+
+function SummarySection({
+  title,
+  items,
+  open,
+  onOpenChange,
+  onOpenFile,
+  onOpenSemantic,
+  t,
+}: {
+  title: string;
+  items: TurnSummaryItem[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onOpenFile: (path: string) => void;
+  onOpenSemantic: (kind: SemanticUpdateKind) => void;
+  t: TFunction<"chat">;
+}) {
+  return (
+    <div className="rounded-lg border border-border/50 bg-secondary overflow-hidden">
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => onOpenChange(!open)}
         className="w-full flex items-center gap-2 px-3 py-2 text-sm text-muted-foreground hover:text-foreground transition-colors"
       >
         <ChevronDownIcon
@@ -36,27 +115,24 @@ export function TurnFileSummary({ filePaths, agentPath }: TurnFileSummaryProps) 
             open ? "rotate-0" : "-rotate-90",
           )}
         />
-        <span>
-          {t("filesUpdated", { count: filePaths.length })}
-        </span>
+        <span>{title}</span>
       </button>
       {open && (
         <div className="border-t border-border/50 divide-y divide-border/50">
-          {filePaths.map((path) => {
-            const fileName = path.split("/").pop() ?? path;
-            const ext = fileName.includes(".")
-              ? fileName.split(".").pop()?.toLowerCase()
-              : undefined;
-            const Icon = getFileIcon(ext);
+          {items.map((item) => {
+            const key = item.kind === "file" ? item.path : item.update;
+            const Icon = itemIcon(item);
             return (
               <button
-                key={path}
+                key={key}
                 type="button"
-                onClick={() => handleOpen(path)}
+                onClick={() =>
+                  item.kind === "file" ? onOpenFile(item.path) : onOpenSemantic(item.update)
+                }
                 className="w-full flex items-center gap-2 px-3 py-2 text-sm text-left hover:bg-accent transition-colors"
               >
                 <Icon className="h-4 w-4 text-muted-foreground shrink-0" />
-                <span className="truncate">{fileName}</span>
+                <span className="truncate">{itemLabel(item, t)}</span>
               </button>
             );
           })}
@@ -64,4 +140,41 @@ export function TurnFileSummary({ filePaths, agentPath }: TurnFileSummaryProps) 
       )}
     </div>
   );
+}
+
+function semanticTarget(kind: SemanticUpdateKind): JobDescriptionTarget {
+  if (kind === "actions") return "skills";
+  return kind;
+}
+
+function fallbackTab(kind: SemanticUpdateKind, tabIds: Set<string>): string {
+  if (kind === "actions" && tabIds.has("skills")) return "skills";
+  if (kind === "learnings" && tabIds.has("learnings")) return "learnings";
+  if (kind === "instructions" && tabIds.has("prompts")) return "prompts";
+  if (tabIds.has("configure")) return "configure";
+  return "activity";
+}
+
+function semanticIcon(kind: SemanticUpdateKind) {
+  if (kind === "instructions") return ScrollText;
+  if (kind === "actions") return Play;
+  return Lightbulb;
+}
+
+function itemIcon(item: TurnSummaryItem) {
+  if (item.kind === "semantic") return semanticIcon(item.update);
+  const fileName = item.path.split("/").pop() ?? item.path;
+  const ext = fileName.includes(".")
+    ? fileName.split(".").pop()?.toLowerCase()
+    : undefined;
+  return getFileIcon(ext);
+}
+
+function itemLabel(item: TurnSummaryItem, t: TFunction<"chat">): string {
+  if (item.kind === "semantic") {
+    if (item.update === "instructions") return t("summary.instructionsUpdated");
+    if (item.update === "actions") return t("summary.actionsUpdated");
+    return t("summary.learningsUpdated");
+  }
+  return item.path.split("/").pop() ?? item.path;
 }

--- a/app/src/hooks/use-file-tool-renderer.tsx
+++ b/app/src/hooks/use-file-tool-renderer.tsx
@@ -3,40 +3,13 @@ import { ToolBlock } from "@houston-ai/chat";
 import type { ToolEntry } from "@houston-ai/chat";
 import { FileCard } from "../components/file-card";
 import { TurnFileSummary } from "../components/turn-file-summary";
+import { buildTurnSummaryItems } from "../lib/turn-summary-items";
 
 /** Tool short names that produce files the user might want to open. */
 const FILE_TOOLS = new Set(["Write", "Edit"]);
 
 function shortName(name: string): string {
   return name.includes("__") ? name.split("__").pop()! : name;
-}
-
-/**
- * Extract file paths from Bash stdout. Catches two patterns Claude uses
- * when creating files via shell/Python:
- *
- * 1. Labeled — "Saved: /path/to/file.ext", "Created: /path/...", etc.
- * 2. Bare   — a standalone absolute path on its own line
- */
-function extractPathsFromBashOutput(output: string): string[] {
-  const paths: string[] = [];
-  const seen = new Set<string>();
-
-  const add = (raw: string) => {
-    const p = raw.trim();
-    if (p && !seen.has(p)) { seen.add(p); paths.push(p); }
-  };
-
-  // "Saved: /…/file.xlsx", "Created: /…/file.py", etc.
-  const labeled = /(?:saved|created|wrote|written|output|file):\s*([^\r\n]+\.[a-zA-Z0-9]{1,10})/gi;
-  let m: RegExpExecArray | null;
-  while ((m = labeled.exec(output)) !== null) add(m[1]);
-
-  // Bare absolute path alone on a line: "/Users/…/file.ext"
-  const bare = /^(\/[^\r\n]+\.[a-zA-Z0-9]{1,10})\s*$/gm;
-  while ((m = bare.exec(output)) !== null) add(m[1]);
-
-  return paths;
 }
 
 /**
@@ -70,32 +43,9 @@ export function useFileToolRenderer(agentPath: string) {
 
   const renderTurnSummary = useCallback(
     (tools: ToolEntry[]) => {
-      const seen = new Set<string>();
-      const filePaths: string[] = [];
-
-      const add = (fp: string) => {
-        if (!seen.has(fp)) { seen.add(fp); filePaths.push(fp); }
-      };
-
-      for (const tool of tools) {
-        if (!tool.result || tool.result.is_error) continue;
-        const sn = shortName(tool.name);
-
-        if (FILE_TOOLS.has(sn)) {
-          // Write / Edit: file path is in the tool input
-          const inp = tool.input as Record<string, unknown> | null | undefined;
-          const fp = inp?.file_path as string | undefined;
-          if (fp) add(fp);
-        } else if (sn === "Bash") {
-          // Bash: Claude typically prints the path when it creates a file
-          for (const fp of extractPathsFromBashOutput(tool.result.content)) {
-            add(fp);
-          }
-        }
-      }
-
-      if (filePaths.length === 0) return null;
-      return <TurnFileSummary filePaths={filePaths} agentPath={agentPath} />;
+      const items = buildTurnSummaryItems(tools, agentPath);
+      if (items.length === 0) return null;
+      return <TurnFileSummary items={items} agentPath={agentPath} />;
     },
     [agentPath],
   );

--- a/app/src/hooks/use-file-tool-renderer.tsx
+++ b/app/src/hooks/use-file-tool-renderer.tsx
@@ -1,12 +1,12 @@
 import { useCallback, useMemo } from "react";
 import { ToolBlock } from "@houston-ai/chat";
-import type { ToolEntry } from "@houston-ai/chat";
+import type { ToolEntry, TurnEndSummary } from "@houston-ai/chat";
 import { FileCard } from "../components/file-card";
 import { TurnFileSummary } from "../components/turn-file-summary";
-import { buildTurnSummaryItems } from "../lib/turn-summary-items";
+import { buildTurnSummaryItems, isUserVisibleFilePath } from "../lib/turn-summary-items";
 
 /** Tool short names that produce files the user might want to open. */
-const FILE_TOOLS = new Set(["Write", "Edit"]);
+const FILE_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
 
 function shortName(name: string): string {
   return name.includes("__") ? name.split("__").pop()! : name;
@@ -32,7 +32,7 @@ export function useFileToolRenderer(agentPath: string) {
       return (
         <div key={index} className="space-y-2">
           <ToolBlock tool={tool} isActive={false} />
-          {filePath && !isError && (
+          {filePath && !isError && isUserVisibleFilePath(filePath) && (
             <FileCard filePath={filePath} agentPath={agentPath} />
           )}
         </div>
@@ -42,8 +42,12 @@ export function useFileToolRenderer(agentPath: string) {
   );
 
   const renderTurnSummary = useCallback(
-    (tools: ToolEntry[]) => {
-      const items = buildTurnSummaryItems(tools, agentPath);
+    (summary: TurnEndSummary) => {
+      const items = buildTurnSummaryItems(
+        summary.tools,
+        agentPath,
+        summary.fileChanges,
+      );
       if (items.length === 0) return null;
       return <TurnFileSummary items={items} agentPath={agentPath} />;
     },

--- a/app/src/lib/turn-summary-items.test.mjs
+++ b/app/src/lib/turn-summary-items.test.mjs
@@ -45,7 +45,26 @@ test("keeps normal files in the summary", () => {
     agentPath,
   );
 
-  assert.deepEqual(items, [{ kind: "file", path: `${agentPath}/deck.pptx` }]);
+  assert.deepEqual(items, [
+    { kind: "file", path: `${agentPath}/deck.pptx`, change: "created" },
+  ]);
+});
+
+test("puts edited files under updates", () => {
+  const items = buildTurnSummaryItems(
+    [
+      {
+        name: "Edit",
+        input: { file_path: `${agentPath}/brief.txt` },
+        result: { content: "ok", is_error: false },
+      },
+    ],
+    agentPath,
+  );
+
+  assert.deepEqual(items, [
+    { kind: "file", path: `${agentPath}/brief.txt`, change: "modified" },
+  ]);
 });
 
 test("extracts labeled bash output paths", () => {
@@ -63,15 +82,46 @@ test("extracts labeled bash output paths", () => {
     agentPath,
   );
 
-  assert.deepEqual(items, [{ kind: "file", path: `${agentPath}/presentation.pptx` }]);
+  assert.deepEqual(items, [
+    { kind: "file", path: `${agentPath}/presentation.pptx`, change: "created" },
+  ]);
+});
+
+test("uses session file changes and ignores python helpers", () => {
+  const items = buildTurnSummaryItems(
+    [
+      {
+        name: "Write",
+        input: { file_path: `${agentPath}/make_deck.py` },
+        result: { content: "ok", is_error: false },
+      },
+    ],
+    agentPath,
+    [
+      { path: `${agentPath}/make_deck.py`, status: "created" },
+      { path: `${agentPath}/presentation.pptx`, status: "created" },
+      { path: `${agentPath}/notes.txt`, status: "modified" },
+    ],
+  );
+
+  assert.deepEqual(items, [
+    { kind: "file", path: `${agentPath}/presentation.pptx`, change: "created" },
+    { kind: "file", path: `${agentPath}/notes.txt`, change: "modified" },
+  ]);
 });
 
 test("groups semantic updates and files separately", () => {
   const groups = groupTurnSummaryItems([
     { kind: "semantic", update: "actions" },
-    { kind: "file", path: `${agentPath}/deck.pptx` },
+    { kind: "file", path: `${agentPath}/deck.pptx`, change: "created" },
+    { kind: "file", path: `${agentPath}/notes.txt`, change: "modified" },
   ]);
 
-  assert.deepEqual(groups.updates, [{ kind: "semantic", update: "actions" }]);
-  assert.deepEqual(groups.files, [{ kind: "file", path: `${agentPath}/deck.pptx` }]);
+  assert.deepEqual(groups.updates, [
+    { kind: "semantic", update: "actions" },
+    { kind: "file", path: `${agentPath}/notes.txt`, change: "modified" },
+  ]);
+  assert.deepEqual(groups.files, [
+    { kind: "file", path: `${agentPath}/deck.pptx`, change: "created" },
+  ]);
 });

--- a/app/src/lib/turn-summary-items.test.mjs
+++ b/app/src/lib/turn-summary-items.test.mjs
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { buildTurnSummaryItems, groupTurnSummaryItems } from "./turn-summary-items.ts";
+
+const agentPath = "/Users/me/Houston/Agent";
+
+test("summarizes internal agent files as semantic updates", () => {
+  const items = buildTurnSummaryItems(
+    [
+      {
+        name: "Write",
+        input: { file_path: `${agentPath}/CLAUDE.md` },
+        result: { content: "ok", is_error: false },
+      },
+      {
+        name: "Edit",
+        input: { file_path: `${agentPath}/.agents/skills/report/SKILL.md` },
+        result: { content: "ok", is_error: false },
+      },
+      {
+        name: "Write",
+        input: { file_path: `${agentPath}/.houston/learnings/learnings.json` },
+        result: { content: "ok", is_error: false },
+      },
+    ],
+    agentPath,
+  );
+
+  assert.deepEqual(items, [
+    { kind: "semantic", update: "instructions" },
+    { kind: "semantic", update: "actions" },
+    { kind: "semantic", update: "learnings" },
+  ]);
+});
+
+test("keeps normal files in the summary", () => {
+  const items = buildTurnSummaryItems(
+    [
+      {
+        name: "Write",
+        input: { file_path: `${agentPath}/deck.pptx` },
+        result: { content: "ok", is_error: false },
+      },
+    ],
+    agentPath,
+  );
+
+  assert.deepEqual(items, [{ kind: "file", path: `${agentPath}/deck.pptx` }]);
+});
+
+test("extracts labeled bash output paths", () => {
+  const items = buildTurnSummaryItems(
+    [
+      {
+        name: "Bash",
+        input: { command: "python make_deck.py" },
+        result: {
+          content: `Saved: ${agentPath}/presentation.pptx\nDone`,
+          is_error: false,
+        },
+      },
+    ],
+    agentPath,
+  );
+
+  assert.deepEqual(items, [{ kind: "file", path: `${agentPath}/presentation.pptx` }]);
+});
+
+test("groups semantic updates and files separately", () => {
+  const groups = groupTurnSummaryItems([
+    { kind: "semantic", update: "actions" },
+    { kind: "file", path: `${agentPath}/deck.pptx` },
+  ]);
+
+  assert.deepEqual(groups.updates, [{ kind: "semantic", update: "actions" }]);
+  assert.deepEqual(groups.files, [{ kind: "file", path: `${agentPath}/deck.pptx` }]);
+});

--- a/app/src/lib/turn-summary-items.ts
+++ b/app/src/lib/turn-summary-items.ts
@@ -1,17 +1,22 @@
-import type { ToolEntry } from "@houston-ai/chat";
+import type { FileChangeEntry, ToolEntry } from "@houston-ai/chat";
 
 export type SemanticUpdateKind = "instructions" | "actions" | "learnings";
+export type FileUpdateKind = "created" | "modified";
 
 export type TurnSummaryItem =
-  | { kind: "file"; path: string }
+  | { kind: "file"; path: string; change: FileUpdateKind }
   | { kind: "semantic"; update: SemanticUpdateKind };
 
 export interface TurnSummaryGroups {
-  updates: Extract<TurnSummaryItem, { kind: "semantic" }>[];
+  updates: TurnSummaryItem[];
   files: Extract<TurnSummaryItem, { kind: "file" }>[];
 }
 
-const FILE_TOOLS = new Set(["Write", "Edit"]);
+const FILE_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
+const USER_FILE_EXTENSIONS = new Set([
+  "docx", "doc", "xlsx", "xls", "pptx", "ppt", "pdf", "png", "jpg", "jpeg",
+  "svg", "gif", "txt", "rtf", "csv",
+]);
 
 function shortName(name: string): string {
   return name.includes("__") ? name.split("__").pop()! : name;
@@ -34,6 +39,12 @@ function classifyPath(path: string, agentPath: string): SemanticUpdateKind | nul
   }
   if (fileName === "skill.md" || fileName === "skills.md") return "actions";
   return null;
+}
+
+export function isUserVisibleFilePath(path: string): boolean {
+  const fileName = path.split("/").pop() ?? path;
+  const ext = fileName.includes(".") ? fileName.split(".").pop()?.toLowerCase() : "";
+  return Boolean(ext && USER_FILE_EXTENSIONS.has(ext));
 }
 
 function extractPathsFromBashOutput(output: string): string[] {
@@ -60,22 +71,35 @@ function extractPathsFromBashOutput(output: string): string[] {
 export function buildTurnSummaryItems(
   tools: ToolEntry[],
   agentPath: string,
+  fileChanges: FileChangeEntry[] = [],
 ): TurnSummaryItem[] {
   const semantic = new Set<SemanticUpdateKind>();
-  const files: string[] = [];
-  const seenFiles = new Set<string>();
+  const files: Array<{ path: string; change: FileUpdateKind }> = [];
+  const seenFiles = new Map<string, FileUpdateKind>();
 
-  const addPath = (path: string) => {
+  const addPath = (path: string, change: FileUpdateKind) => {
     const update = classifyPath(path, agentPath);
     if (update) {
       semantic.add(update);
       return;
     }
-    if (!seenFiles.has(path)) {
-      seenFiles.add(path);
-      files.push(path);
+    if (!isUserVisibleFilePath(path)) return;
+
+    const existing = seenFiles.get(path);
+    if (existing === "created" || existing === change) return;
+    if (existing === "modified" && change === "created") {
+      seenFiles.set(path, change);
+      const item = files.find((file) => file.path === path);
+      if (item) item.change = change;
+      return;
     }
+    seenFiles.set(path, change);
+    files.push({ path, change });
   };
+
+  for (const change of fileChanges) {
+    addPath(change.path, change.status);
+  }
 
   for (const tool of tools) {
     if (!tool.result || tool.result.is_error) continue;
@@ -84,21 +108,31 @@ export function buildTurnSummaryItems(
     if (FILE_TOOLS.has(sn)) {
       const inp = tool.input as Record<string, unknown> | null | undefined;
       const fp = inp?.file_path as string | undefined;
-      if (fp) addPath(fp);
+      if (fp) addPath(fp, sn === "Write" ? "created" : "modified");
     } else if (sn === "Bash") {
-      for (const fp of extractPathsFromBashOutput(tool.result.content)) addPath(fp);
+      for (const fp of extractPathsFromBashOutput(tool.result.content)) {
+        addPath(fp, "created");
+      }
     }
   }
 
   return [
     ...Array.from(semantic).map((update) => ({ kind: "semantic" as const, update })),
-    ...files.map((path) => ({ kind: "file" as const, path })),
+    ...files.map((file) => ({ kind: "file" as const, ...file })),
   ];
 }
 
 export function groupTurnSummaryItems(items: TurnSummaryItem[]): TurnSummaryGroups {
   return {
-    updates: items.filter((item) => item.kind === "semantic"),
-    files: items.filter((item) => item.kind === "file"),
+    updates: items.filter(
+      (item) => item.kind === "semantic" || item.change === "modified",
+    ),
+    files: items.filter(isCreatedFile),
   };
+}
+
+function isCreatedFile(
+  item: TurnSummaryItem,
+): item is Extract<TurnSummaryItem, { kind: "file" }> {
+  return item.kind === "file" && item.change === "created";
 }

--- a/app/src/lib/turn-summary-items.ts
+++ b/app/src/lib/turn-summary-items.ts
@@ -1,0 +1,104 @@
+import type { ToolEntry } from "@houston-ai/chat";
+
+export type SemanticUpdateKind = "instructions" | "actions" | "learnings";
+
+export type TurnSummaryItem =
+  | { kind: "file"; path: string }
+  | { kind: "semantic"; update: SemanticUpdateKind };
+
+export interface TurnSummaryGroups {
+  updates: Extract<TurnSummaryItem, { kind: "semantic" }>[];
+  files: Extract<TurnSummaryItem, { kind: "file" }>[];
+}
+
+const FILE_TOOLS = new Set(["Write", "Edit"]);
+
+function shortName(name: string): string {
+  return name.includes("__") ? name.split("__").pop()! : name;
+}
+
+function normalizePath(path: string, agentPath: string): string {
+  const trimmed = path.trim();
+  if (trimmed.startsWith(`${agentPath}/`)) return trimmed.slice(agentPath.length + 1);
+  return trimmed;
+}
+
+function classifyPath(path: string, agentPath: string): SemanticUpdateKind | null {
+  const relative = normalizePath(path, agentPath).toLowerCase();
+  const fileName = relative.split("/").pop() ?? relative;
+
+  if (fileName === "claude.md" || fileName === "agents.md") return "instructions";
+  if (relative === ".houston/learnings/learnings.json") return "learnings";
+  if (relative.includes("/.agents/skills/") || relative.includes("/.claude/skills/")) {
+    return "actions";
+  }
+  if (fileName === "skill.md" || fileName === "skills.md") return "actions";
+  return null;
+}
+
+function extractPathsFromBashOutput(output: string): string[] {
+  const paths: string[] = [];
+  const seen = new Set<string>();
+  const add = (raw: string) => {
+    const p = raw.trim();
+    if (p && !seen.has(p)) {
+      seen.add(p);
+      paths.push(p);
+    }
+  };
+
+  const labeled = /(?:saved|created|wrote|written|output|file):\s*([^\r\n]+\.[a-zA-Z0-9]{1,10})/gi;
+  let match: RegExpExecArray | null;
+  while ((match = labeled.exec(output)) !== null) add(match[1]);
+
+  const bare = /^(\/[^\r\n]+\.[a-zA-Z0-9]{1,10})\s*$/gm;
+  while ((match = bare.exec(output)) !== null) add(match[1]);
+
+  return paths;
+}
+
+export function buildTurnSummaryItems(
+  tools: ToolEntry[],
+  agentPath: string,
+): TurnSummaryItem[] {
+  const semantic = new Set<SemanticUpdateKind>();
+  const files: string[] = [];
+  const seenFiles = new Set<string>();
+
+  const addPath = (path: string) => {
+    const update = classifyPath(path, agentPath);
+    if (update) {
+      semantic.add(update);
+      return;
+    }
+    if (!seenFiles.has(path)) {
+      seenFiles.add(path);
+      files.push(path);
+    }
+  };
+
+  for (const tool of tools) {
+    if (!tool.result || tool.result.is_error) continue;
+    const sn = shortName(tool.name);
+
+    if (FILE_TOOLS.has(sn)) {
+      const inp = tool.input as Record<string, unknown> | null | undefined;
+      const fp = inp?.file_path as string | undefined;
+      if (fp) addPath(fp);
+    } else if (sn === "Bash") {
+      for (const fp of extractPathsFromBashOutput(tool.result.content)) addPath(fp);
+    }
+  }
+
+  return [
+    ...Array.from(semantic).map((update) => ({ kind: "semantic" as const, update })),
+    ...files.map((path) => ({ kind: "file" as const, path })),
+  ];
+}
+
+export function groupTurnSummaryItems(items: TurnSummaryItem[]): TurnSummaryGroups {
+  return {
+    updates: items.filter((item) => item.kind === "semantic"),
+    files: items.filter((item) => item.kind === "file"),
+  };
+}

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -29,6 +29,14 @@
     "active": "Mission in progress...",
     "complete": "Mission log"
   },
+  "summary": {
+    "updatesMade": "Updates made",
+    "newFiles_one": "1 new file",
+    "newFiles_other": "{{count}} new files",
+    "instructionsUpdated": "Instructions updated",
+    "actionsUpdated": "Actions updated",
+    "learningsUpdated": "Learnings updated"
+  },
   "filesUpdated_one": "1 file updated",
   "filesUpdated_other": "{{count}} files updated"
 }

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -29,6 +29,14 @@
     "active": "Misión en curso...",
     "complete": "Registro de misión"
   },
+  "summary": {
+    "updatesMade": "Actualizaciones hechas",
+    "newFiles_one": "1 archivo nuevo",
+    "newFiles_other": "{{count}} archivos nuevos",
+    "instructionsUpdated": "Instrucciones actualizadas",
+    "actionsUpdated": "Acciones actualizadas",
+    "learningsUpdated": "Aprendizajes actualizados"
+  },
   "filesUpdated_one": "1 archivo actualizado",
   "filesUpdated_other": "{{count}} archivos actualizados"
 }

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -29,6 +29,14 @@
     "active": "Missão em andamento...",
     "complete": "Registro da missão"
   },
+  "summary": {
+    "updatesMade": "Atualizações feitas",
+    "newFiles_one": "1 arquivo novo",
+    "newFiles_other": "{{count}} arquivos novos",
+    "instructionsUpdated": "Instruções atualizadas",
+    "actionsUpdated": "Ações atualizadas",
+    "learningsUpdated": "Aprendizados atualizados"
+  },
   "filesUpdated_one": "1 arquivo atualizado",
   "filesUpdated_other": "{{count}} arquivos atualizados"
 }

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -8,6 +8,8 @@ export interface ToastItem {
   action?: { label: string; onClick: () => void };
 }
 
+export type JobDescriptionTarget = "instructions" | "skills" | "learnings";
+
 interface UIState {
   viewMode: string;
   assistantPanelOpen: boolean;
@@ -23,6 +25,7 @@ interface UIState {
   boardActions: Array<{ id: string; label: string; onClick: () => void }>;
   /** Whether the mission chat panel is open (hides tab bar for full-height panel) */
   missionPanelOpen: boolean;
+  jobDescriptionTarget: JobDescriptionTarget | null;
   setViewMode: (mode: string) => void;
   setAssistantPanelOpen: (open: boolean) => void;
   setActivityPanelId: (id: string | null) => void;
@@ -34,6 +37,7 @@ interface UIState {
   setOnStartMission: (cb: (() => void) | null) => void;
   setBoardActions: (actions: Array<{ id: string; label: string; onClick: () => void }>) => void;
   setMissionPanelOpen: (open: boolean) => void;
+  setJobDescriptionTarget: (target: JobDescriptionTarget | null) => void;
 }
 
 let toastCounter = 0;
@@ -49,6 +53,7 @@ export const useUIStore = create<UIState>((set) => ({
   onStartMission: null,
   boardActions: [],
   missionPanelOpen: false,
+  jobDescriptionTarget: null,
 
   setViewMode: (viewMode) => set({ viewMode }),
   setAssistantPanelOpen: (assistantPanelOpen) => set({ assistantPanelOpen }),
@@ -80,4 +85,5 @@ export const useUIStore = create<UIState>((set) => ({
   setOnStartMission: (onStartMission) => set({ onStartMission }),
   setBoardActions: (boardActions) => set({ boardActions }),
   setMissionPanelOpen: (missionPanelOpen) => set({ missionPanelOpen }),
+  setJobDescriptionTarget: (jobDescriptionTarget) => set({ jobDescriptionTarget }),
 }));

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -288,6 +288,13 @@ fn serialize_for_persist(item: &FeedItem) -> Option<(String, String)> {
             });
             Some(("final_result".into(), data.to_string()))
         }
+        FeedItem::FileChanges(changes) => {
+            let data = serde_json::json!({
+                "created": changes.created,
+                "modified": changes.modified
+            });
+            Some(("file_changes".into(), data.to_string()))
+        }
         FeedItem::Thinking(t) => Some(("thinking".into(), json_str(t))),
         // Skip streaming items — they get replaced by finals.
         FeedItem::AssistantTextStreaming(_) | FeedItem::ThinkingStreaming(_) => None,

--- a/engine/houston-engine-core/src/routines/engine_dispatcher.rs
+++ b/engine/houston-engine-core/src/routines/engine_dispatcher.rs
@@ -35,6 +35,16 @@ pub struct EngineRoutineDispatcher {
 #[async_trait]
 impl RoutineDispatcher for EngineRoutineDispatcher {
     async fn dispatch(&self, ctx: DispatchContext<'_>) -> DispatchOutcome {
+        let _workdir_guard = match self.rt.try_acquire_workdir(ctx.working_dir).await {
+            Ok(guard) => guard,
+            Err(e) => {
+                return DispatchOutcome {
+                    response_text: String::new(),
+                    error: Some(e.to_string()),
+                };
+            }
+        };
+
         if let Err(e) = agent_prompt::seed_agent(ctx.working_dir) {
             return DispatchOutcome {
                 response_text: String::new(),

--- a/engine/houston-engine-core/src/sessions/file_changes.rs
+++ b/engine/houston-engine-core/src/sessions/file_changes.rs
@@ -1,0 +1,99 @@
+use crate::agents::files::list_project_files;
+use crate::CoreResult;
+use houston_terminal_manager::FileChanges;
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::UNIX_EPOCH;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FileSnapshot {
+    files: BTreeMap<String, FileState>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct FileState {
+    len: u64,
+    modified_ms: Option<u128>,
+}
+
+pub fn snapshot(root: &Path) -> CoreResult<FileSnapshot> {
+    let mut files = BTreeMap::new();
+    for file in list_project_files(root)?
+        .into_iter()
+        .filter(|file| !file.is_directory)
+    {
+        let path = root.join(&file.path);
+        let state = match std::fs::metadata(&path) {
+            Ok(meta) => FileState {
+                len: meta.len(),
+                modified_ms: meta
+                    .modified()
+                    .ok()
+                    .and_then(|time| time.duration_since(UNIX_EPOCH).ok())
+                    .map(|duration| duration.as_millis()),
+            },
+            Err(_) => continue,
+        };
+        let absolute = path.to_string_lossy().to_string();
+        files.insert(absolute, state);
+    }
+    Ok(FileSnapshot { files })
+}
+
+pub fn diff(before: &FileSnapshot, after: &FileSnapshot) -> FileChanges {
+    let mut changes = FileChanges::default();
+
+    for (path, after_state) in &after.files {
+        match before.files.get(path) {
+            None => changes.created.push(path.clone()),
+            Some(before_state) if before_state != after_state => {
+                changes.modified.push(path.clone());
+            }
+            Some(_) => {}
+        }
+    }
+
+    changes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    #[test]
+    fn detects_created_user_visible_files_only() {
+        let dir = TempDir::new().unwrap();
+        let before = snapshot(dir.path()).unwrap();
+
+        std::fs::write(dir.path().join("deck.pptx"), "ppt").unwrap();
+        std::fs::write(dir.path().join("make_deck.py"), "print('x')").unwrap();
+
+        let after = snapshot(dir.path()).unwrap();
+        let changes = diff(&before, &after);
+
+        assert_eq!(
+            changes.created,
+            vec![dir.path().join("deck.pptx").to_string_lossy()]
+        );
+        assert!(changes.modified.is_empty());
+    }
+
+    #[test]
+    fn detects_modified_visible_files() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("brief.txt");
+        std::fs::write(&path, "first").unwrap();
+        let before = snapshot(dir.path()).unwrap();
+
+        std::thread::sleep(Duration::from_millis(5));
+        std::fs::write(&path, "second").unwrap();
+
+        let after = snapshot(dir.path()).unwrap();
+        let changes = diff(&before, &after);
+
+        assert!(changes.created.is_empty());
+        assert_eq!(changes.modified, vec![path.to_string_lossy()]);
+    }
+}

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -21,16 +21,19 @@ pub mod file_changes;
 pub mod history;
 pub mod provider;
 pub mod summarize;
+mod workdir_locks;
 
 use crate::agents::prompt as agent_prompt;
 use crate::paths::EnginePaths;
+use crate::{CoreError, CoreResult};
 use houston_agents_conversations::session_id_tracker::SessionIdTracker;
 use houston_agents_conversations::session_pids::SessionPidMap;
 use houston_agents_conversations::session_runner::{self, PersistOptions};
 use houston_db::Database;
 use houston_terminal_manager::{FeedItem, Provider};
 use houston_ui_events::{DynEventSink, HoustonEvent};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use workdir_locks::{WorkdirLocks, WorkdirSessionGuard};
 
 pub use provider::{resolve_provider, ResolvedProvider};
 
@@ -39,6 +42,21 @@ pub use provider::{resolve_provider, ResolvedProvider};
 pub struct SessionRuntime {
     pub session_ids: SessionIdTracker,
     pub pid_map: SessionPidMap,
+    workdir_locks: WorkdirLocks,
+}
+
+impl SessionRuntime {
+    pub(crate) async fn try_acquire_workdir(
+        &self,
+        working_dir: &Path,
+    ) -> CoreResult<WorkdirSessionGuard> {
+        self.workdir_locks
+            .try_acquire(working_dir)
+            .await
+            .ok_or_else(|| {
+                CoreError::Conflict("another mission is already running in this folder".to_string())
+            })
+    }
 }
 
 /// Parameters for [`start`]. Mirrors the shape of the old Tauri `send_message`
@@ -88,6 +106,7 @@ pub async fn start(
     if !agent_dir.exists() {
         std::fs::create_dir_all(&agent_dir)?;
     }
+    let workdir_guard = rt.try_acquire_workdir(&working_dir).await?;
     agent_prompt::seed_agent(&agent_dir).map_err(crate::CoreError::Internal)?;
 
     // Final system prompt is always `<product_prompt>\n\n---\n\n<agent_context>`.
@@ -199,6 +218,7 @@ pub async fn start(
     let session_key_for_end = session_key.clone();
     let agent_path_for_end = agent_path;
     tokio::spawn(async move {
+        let _workdir_guard = workdir_guard;
         let session_result = handle.await;
         if let (Ok(result), Some(before)) = (&session_result, before_files.as_ref()) {
             if result.error.is_none() {

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -17,6 +17,7 @@
 //! lives in the adapter today; it will move into `engine-core` in a later
 //! phase once `agent_store` is ported.
 
+pub mod file_changes;
 pub mod history;
 pub mod provider;
 pub mod summarize;
@@ -110,6 +111,16 @@ pub async fn start(
     };
 
     let source = source.unwrap_or_else(|| "desktop".to_string());
+    let before_files = match file_changes::snapshot(&working_dir) {
+        Ok(snapshot) => Some(snapshot),
+        Err(e) => {
+            tracing::warn!(
+                "[sessions] failed to snapshot files before run: {e} (working_dir={})",
+                working_dir.display()
+            );
+            None
+        }
+    };
     let agent_key = format!("{}:{}", working_dir.to_string_lossy(), session_key);
     let sid_handle = rt
         .session_ids
@@ -151,6 +162,8 @@ pub async fn start(
         }
     }
 
+    let db_for_file_changes = db.clone();
+    let source_for_file_changes = source.clone();
     let persist = Some(PersistOptions {
         db,
         source,
@@ -159,6 +172,7 @@ pub async fn start(
     });
 
     let events_for_end = events.clone();
+    let working_dir_for_end = working_dir.clone();
     let handle = session_runner::spawn_and_monitor(
         events,
         agent_path.clone(),
@@ -185,7 +199,58 @@ pub async fn start(
     let session_key_for_end = session_key.clone();
     let agent_path_for_end = agent_path;
     tokio::spawn(async move {
-        let next_status = match handle.await {
+        let session_result = handle.await;
+        if let (Ok(result), Some(before)) = (&session_result, before_files.as_ref()) {
+            if result.error.is_none() {
+                match file_changes::snapshot(&working_dir_for_end) {
+                    Ok(after) => {
+                        let changes = file_changes::diff(before, &after);
+                        if !changes.is_empty() {
+                            let item = FeedItem::FileChanges(changes.clone());
+                            events_for_end.emit(HoustonEvent::FeedItem {
+                                agent_path: agent_path_for_end.clone(),
+                                session_key: session_key_for_end.clone(),
+                                item,
+                            });
+                            events_for_end.emit(HoustonEvent::FilesChanged {
+                                agent_path: agent_path_for_end.clone(),
+                            });
+                            if let Some(sid) = result.claude_session_id.as_ref() {
+                                let db = db_for_file_changes.clone();
+                                let sid = sid.clone();
+                                let source = source_for_file_changes.clone();
+                                let data = serde_json::json!({
+                                    "created": changes.created,
+                                    "modified": changes.modified,
+                                })
+                                .to_string();
+                                tokio::spawn(async move {
+                                    if let Err(e) = db
+                                        .add_chat_feed_item_by_session(
+                                            &sid,
+                                            "file_changes",
+                                            &data,
+                                            &source,
+                                        )
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "[sessions] failed to persist file changes: {e}"
+                                        );
+                                    }
+                                });
+                            }
+                        }
+                    }
+                    Err(e) => tracing::warn!(
+                        "[sessions] failed to snapshot files after run: {e} (working_dir={})",
+                        working_dir_for_end.display()
+                    ),
+                }
+            }
+        }
+
+        let next_status = match session_result {
             Ok(result) if result.error.is_none() => "needs_you",
             Ok(_) => "error",
             Err(e) => {

--- a/engine/houston-engine-core/src/sessions/workdir_locks.rs
+++ b/engine/houston-engine-core/src/sessions/workdir_locks.rs
@@ -1,0 +1,72 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use tokio::sync::{Mutex, OwnedMutexGuard};
+
+pub type WorkdirSessionGuard = OwnedMutexGuard<()>;
+
+#[derive(Default, Clone)]
+pub struct WorkdirLocks {
+    inner: Arc<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>>,
+}
+
+impl WorkdirLocks {
+    pub async fn try_acquire(&self, working_dir: &Path) -> Option<WorkdirSessionGuard> {
+        let key = normalize_key(working_dir);
+        let lock = {
+            let mut locks = self.inner.lock().await;
+            locks
+                .entry(key)
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        lock.try_lock_owned().ok()
+    }
+}
+
+fn normalize_key(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[tokio::test]
+    async fn rejects_same_workdir_until_guard_drops() {
+        let dir = TempDir::new().unwrap();
+        let locks = WorkdirLocks::default();
+
+        let first = locks.try_acquire(dir.path()).await;
+        assert!(first.is_some());
+        assert!(locks.try_acquire(dir.path()).await.is_none());
+
+        drop(first);
+        assert!(locks.try_acquire(dir.path()).await.is_some());
+    }
+
+    #[tokio::test]
+    async fn allows_different_workdirs() {
+        let one = TempDir::new().unwrap();
+        let two = TempDir::new().unwrap();
+        let locks = WorkdirLocks::default();
+
+        let first = locks.try_acquire(one.path()).await;
+        let second = locks.try_acquire(two.path()).await;
+
+        assert!(first.is_some());
+        assert!(second.is_some());
+    }
+
+    #[tokio::test]
+    async fn canonicalizes_equivalent_existing_paths() {
+        let dir = TempDir::new().unwrap();
+        let locks = WorkdirLocks::default();
+        let equivalent = dir.path().join(".");
+
+        let first = locks.try_acquire(dir.path()).await;
+        assert!(first.is_some());
+        assert!(locks.try_acquire(&equivalent).await.is_none());
+    }
+}

--- a/engine/houston-terminal-manager/src/lib.rs
+++ b/engine/houston-terminal-manager/src/lib.rs
@@ -14,7 +14,9 @@ pub mod session_pump;
 pub mod types;
 
 // Re-export key types for convenience.
-pub use codex_parser::{CodexAccumulator, extract_thread_id, parse_codex_event};
+pub use codex_parser::{extract_thread_id, parse_codex_event, CodexAccumulator};
 pub use manager::{SessionHandle, SessionManager, SessionUpdate};
-pub use parser::{StreamAccumulator, extract_session_id, parse_event};
-pub use types::{ClaudeEvent, ContentBlock, FeedItem, Provider, SessionFeedBuffer, SessionStatus};
+pub use parser::{extract_session_id, parse_event, StreamAccumulator};
+pub use types::{
+    ClaudeEvent, ContentBlock, FeedItem, FileChanges, Provider, SessionFeedBuffer, SessionStatus,
+};

--- a/engine/houston-terminal-manager/src/types.rs
+++ b/engine/houston-terminal-manager/src/types.rs
@@ -147,6 +147,19 @@ pub enum ContentBlock {
     Unknown,
 }
 
+/// Visible files created or modified during a session.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct FileChanges {
+    pub created: Vec<String>,
+    pub modified: Vec<String>,
+}
+
+impl FileChanges {
+    pub fn is_empty(&self) -> bool {
+        self.created.is_empty() && self.modified.is_empty()
+    }
+}
+
 /// Processed feed items for rendering in the UI.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "feed_type", content = "data", rename_all = "snake_case")]
@@ -176,6 +189,8 @@ pub enum FeedItem {
         cost_usd: Option<f64>,
         duration_ms: Option<u64>,
     },
+    /// Visible files created or changed during the session.
+    FileChanges(FileChanges),
 }
 
 /// In-memory buffer for a live session's feed items.

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -110,6 +110,13 @@ module.
 | GET | `/v1/agents/:agent_path/sessions/:key/history` | Load chat history |
 | POST | `/v1/sessions/summarize` | Activity title/description |
 
+Session starts are exclusive per `workingDir`. If another chat or routine
+session is already running in the same directory, start returns
+`CONFLICT`. This keeps session file-change attribution correct. On
+successful completion, the engine may emit and persist a `FeedItem` with
+`feed_type: "file_changes"` and `data: { created: string[], modified:
+string[] }`; clients should render this as session-owned project artifacts.
+
 **Agent data** (`?agent_path=` query; writes emit event)
 | Method | Path | Description |
 |---|---|---|

--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -69,6 +69,20 @@ Only two tables:
 
 Everything else lives in files.
 
+## Session file-change attribution
+Chat sessions snapshot user-visible project files before and after the
+CLI run. The engine diffs those snapshots and persists a `file_changes`
+feed item with `created` and `modified` absolute paths. The visible-file
+filter is shared with the project file browser, so helper files such as
+Python scripts, JSON, Markdown, `.houston/`, `.agents/`, and dotdirs stay
+out of non-technical chat summaries.
+
+Attribution is strict only when one session owns a working directory. The
+engine enforces that by holding a per-`working_dir` guard for chat and
+routine sessions. Different worktrees/folders can run in parallel. A
+second session in the same folder gets a conflict instead of producing a
+false file summary.
+
 ## AI-native reactivity (MANDATORY)
 
 Users + LLMs equal participants. Both read/write all workspace data. All changes visible to both immediately.

--- a/ui/chat/src/ai-elements/conversation.tsx
+++ b/ui/chat/src/ai-elements/conversation.tsx
@@ -104,11 +104,7 @@ export type ConversationAutoScrollProps = {
   status: "ready" | "streaming" | "submitted";
 };
 
-/**
- * Mount inside a <Conversation> to auto-scroll to the bottom on two events:
- * - User sends a message (status → "submitted"): re-enables sticky + scrolls down
- * - Agent finishes (status → "ready"): scrolls to bottom one final time
- */
+/** Mount inside a <Conversation> to bring new user submissions into view. */
 export const ConversationAutoScroll = ({ status }: ConversationAutoScrollProps) => {
   const { scrollToBottom } = useStickToBottomContext();
   const prevStatusRef = useRef(status);
@@ -118,8 +114,6 @@ export const ConversationAutoScroll = ({ status }: ConversationAutoScrollProps) 
     prevStatusRef.current = status;
 
     if (status === "submitted" && prev !== "submitted") {
-      scrollToBottom();
-    } else if (status === "ready" && prev !== "ready") {
       scrollToBottom();
     }
   }, [status, scrollToBottom]);

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -23,8 +23,9 @@ import type { ToolsAndCardsProps } from "./chat-helpers";
 import { ChatProcessBlock } from "./chat-process-block";
 import type { ChatProcessLabels } from "./chat-process-block";
 import { getChatDisplayItems } from "./chat-process-groups";
-import { computeTurnEndTools } from "./turn-tools";
-import type { ChatMessage, ToolEntry } from "./feed-to-messages";
+import { computeTurnEndSummary } from "./turn-tools";
+import type { TurnEndSummary } from "./turn-tools";
+import type { ChatMessage } from "./feed-to-messages";
 
 export interface ChatMessagesProps {
   messages: ChatMessage[];
@@ -40,7 +41,7 @@ export interface ChatMessagesProps {
   processLabels?: ChatProcessLabels;
   getThinkingMessage?: ReasoningTriggerProps["getThinkingMessage"];
   renderMessageAvatar?: (msg: ChatMessage) => ReactNode | undefined;
-  renderTurnSummary?: (tools: ToolEntry[]) => ReactNode;
+  renderTurnSummary?: (summary: TurnEndSummary) => ReactNode;
   /** Custom renderer for system messages. Return a node to replace the default,
    *  or undefined to use the default italic text. */
   renderSystemMessage?: (msg: ChatMessage) => ReactNode | undefined;
@@ -78,8 +79,8 @@ export function ChatMessages({
   onOpenLink,
   renderLink,
 }: ChatMessagesProps) {
-  const turnEndTools = useMemo(
-    () => computeTurnEndTools(messages, status),
+  const turnEndSummaries = useMemo(
+    () => computeTurnEndSummary(messages, status),
     [messages, status],
   );
   const displayItems = useMemo(
@@ -111,9 +112,9 @@ export function ChatMessages({
                   />
                   {(() => {
                     if (!item.isTrailing || item.isActive || !renderTurnSummary) return null;
-                    const turnTools = turnEndTools.get(item.sourceIndex);
-                    if (!turnTools) return null;
-                    return renderTurnSummary(turnTools);
+                    const summary = turnEndSummaries.get(item.sourceIndex);
+                    if (!summary) return null;
+                    return renderTurnSummary(summary);
                   })()}
                 </div>
               </Message>
@@ -162,9 +163,9 @@ export function ChatMessages({
                 })()}
                 {(() => {
                   if (!renderTurnSummary) return null;
-                  const turnTools = turnEndTools.get(idx);
-                  if (!turnTools) return null;
-                  return renderTurnSummary(turnTools);
+                  const summary = turnEndSummaries.get(idx);
+                  if (!summary) return null;
+                  return renderTurnSummary(summary);
                 })()}
               </div>
             </Message>

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -1,7 +1,7 @@
 import type { ReactNode } from "react";
 import type { ToolsAndCardsProps } from "./chat-helpers";
 import type { ChatMessagesProps } from "./chat-messages";
-import type { ChatMessage, ToolEntry } from "./feed-to-messages";
+import type { ChatMessage } from "./feed-to-messages";
 import type { FeedItem } from "./types";
 
 export type ChatStatus = "ready" | "streaming" | "submitted";
@@ -33,7 +33,7 @@ export interface ChatPanelProps {
   renderSystemMessage?: (msg: ChatMessage) => ReactNode | undefined;
   renderUserMessage?: (msg: ChatMessage) => ReactNode | undefined;
   afterMessages?: ReactNode;
-  renderTurnSummary?: (tools: ToolEntry[]) => ReactNode;
+  renderTurnSummary?: ChatMessagesProps["renderTurnSummary"];
   onOpenLink?: (url: string) => void;
   renderLink?: ChatMessagesProps["renderLink"];
   composerOverride?: ReactNode;

--- a/ui/chat/src/chat-process-groups.ts
+++ b/ui/chat/src/chat-process-groups.ts
@@ -32,6 +32,7 @@ function contentOnly(message: ChatMessage): ChatMessage {
     key: `${message.key}-content`,
     reasoning: undefined,
     tools: [],
+    fileChanges: [],
   };
 }
 

--- a/ui/chat/src/feed-to-messages.ts
+++ b/ui/chat/src/feed-to-messages.ts
@@ -14,6 +14,11 @@ export interface ToolEntry {
   result?: { content: string; is_error: boolean };
 }
 
+export interface FileChangeEntry {
+  path: string;
+  status: "created" | "modified";
+}
+
 export interface ChatMessage {
   key: string;
   from: "user" | "assistant" | "system";
@@ -21,6 +26,7 @@ export interface ChatMessage {
   isStreaming: boolean;
   reasoning?: { content: string; isStreaming: boolean };
   tools: ToolEntry[];
+  fileChanges: FileChangeEntry[];
   /** Source channel if the message came from an external channel. */
   source?: string;
 }
@@ -49,9 +55,25 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
         content: "",
         isStreaming: false,
         tools: [],
+        fileChanges: [],
       };
     }
     return cur;
+  };
+
+  const attachFileChanges = (changes: FileChangeEntry[]) => {
+    const target =
+      cur?.from === "assistant"
+        ? cur
+        : [...messages].reverse().find((msg) => msg.from === "assistant");
+    if (!target) return;
+
+    const seen = new Set(target.fileChanges.map((change) => change.path));
+    for (const change of changes) {
+      if (seen.has(change.path)) continue;
+      seen.add(change.path);
+      target.fileChanges.push(change);
+    }
   };
 
   for (const item of items) {
@@ -65,6 +87,7 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
           content: text,
           isStreaming: false,
           tools: [],
+          fileChanges: [],
           source,
         });
         break;
@@ -163,7 +186,16 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
           content: item.data,
           isStreaming: false,
           tools: [],
+          fileChanges: [],
         });
+        break;
+      }
+
+      case "file_changes": {
+        attachFileChanges([
+          ...item.data.created.map((path) => ({ path, status: "created" as const })),
+          ...item.data.modified.map((path) => ({ path, status: "modified" as const })),
+        ]);
         break;
       }
 

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -1,6 +1,7 @@
 // === Types ===
 export type { FeedItem, RunStatus } from "./types";
-export type { ToolEntry, ChatMessage } from "./feed-to-messages";
+export type { ToolEntry, ChatMessage, FileChangeEntry } from "./feed-to-messages";
+export type { TurnEndSummary } from "./turn-tools";
 
 // === AI Elements: Conversation ===
 export {

--- a/ui/chat/src/turn-tools.ts
+++ b/ui/chat/src/turn-tools.ts
@@ -1,11 +1,16 @@
 import type { ChatStatus } from "./chat-panel-types";
-import type { ChatMessage, ToolEntry } from "./feed-to-messages";
+import type { ChatMessage, FileChangeEntry, ToolEntry } from "./feed-to-messages";
 
-export function computeTurnEndTools(
+export interface TurnEndSummary {
+  tools: ToolEntry[];
+  fileChanges: FileChangeEntry[];
+}
+
+export function computeTurnEndSummary(
   messages: ChatMessage[],
   status: ChatStatus,
-): Map<number, ToolEntry[]> {
-  const result = new Map<number, ToolEntry[]>();
+): Map<number, TurnEndSummary> {
+  const summaries = new Map<number, TurnEndSummary>();
   for (let i = 0; i < messages.length; i++) {
     const msg = messages[i];
     if (msg.from !== "assistant") continue;
@@ -13,12 +18,14 @@ export function computeTurnEndTools(
     const isEndOfTurn = next ? next.from !== "assistant" : status === "ready";
     if (!isEndOfTurn) continue;
     const tools: ToolEntry[] = [];
+    const fileChanges: FileChangeEntry[] = [];
     for (let j = i; j >= 0; j--) {
       const m = messages[j];
       if (m.from !== "assistant") break;
       tools.unshift(...m.tools);
+      fileChanges.unshift(...m.fileChanges);
     }
-    result.set(i, tools);
+    summaries.set(i, { tools, fileChanges });
   }
-  return result;
+  return summaries;
 }

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -11,6 +11,10 @@ export type FeedItem =
   | { feed_type: "tool_result"; data: { content: string; is_error: boolean } }
   | { feed_type: "system_message"; data: string }
   | {
+      feed_type: "file_changes";
+      data: { created: string[]; modified: string[] };
+    }
+  | {
       feed_type: "final_result";
       data: {
         result: string;

--- a/ui/chat/test/chat-process-groups.test.mjs
+++ b/ui/chat/test/chat-process-groups.test.mjs
@@ -8,6 +8,7 @@ const assistant = (key, content, extras = {}) => ({
   content,
   isStreaming: false,
   tools: extras.tools ?? [],
+  fileChanges: extras.fileChanges ?? [],
   reasoning: extras.reasoning,
 });
 

--- a/ui/chat/test/feed-to-messages.test.mjs
+++ b/ui/chat/test/feed-to-messages.test.mjs
@@ -1,0 +1,27 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { feedItemsToMessages } from "../src/feed-to-messages.ts";
+
+test("attaches file changes to the previous assistant message after final result", () => {
+  const messages = feedItemsToMessages([
+    { feed_type: "user_message", data: "make a deck" },
+    { feed_type: "assistant_text", data: "Done." },
+    {
+      feed_type: "final_result",
+      data: { result: "Done.", cost_usd: null, duration_ms: 10 },
+    },
+    {
+      feed_type: "file_changes",
+      data: {
+        created: ["/tmp/deck.pptx"],
+        modified: ["/tmp/notes.txt"],
+      },
+    },
+  ]);
+
+  assert.equal(messages.length, 2);
+  assert.deepEqual(messages[1].fileChanges, [
+    { path: "/tmp/deck.pptx", status: "created" },
+    { path: "/tmp/notes.txt", status: "modified" },
+  ]);
+});


### PR DESCRIPTION
## Summary
- split chat summaries into updates vs new files and hide technical helper files
- persist engine-detected file changes so generated artifacts appear in chat summaries
- serialize sessions per working directory to keep file attribution correct

## Tests
- pnpm typecheck
- cd app && pnpm check-locales
- node --experimental-strip-types --test app/src/lib/turn-summary-items.test.mjs ui/chat/test/chat-process-groups.test.mjs ui/chat/test/feed-to-messages.test.mjs
- cargo test -p houston-engine-core
- cargo test --workspace
- cargo build -p houston-engine-server
- git diff --check