### PR TITLE
feat: tighten PostHog analytics

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -55,13 +55,12 @@ export default function App() {
   useConnections();
   useComposioApps();
 
-  // Track app launch + load theme. Identify the persistent install_id
-  // with PostHog before the first event fires, and derive `user_returned`
-  // from whether the install_id already existed on disk.
+  // Track active installs once per day. This is the canonical DAU/WAU/MAU
+  // signal; launch counts are intentionally not captured.
   useEffect(() => {
     analytics.init().then(({ isNew }) => {
-      analytics.track("app_launched");
-      if (!isNew) analytics.track("user_returned");
+      analytics.trackActive();
+      if (isNew) analytics.track("install_created");
     });
     loadTheme();
   }, []);
@@ -77,18 +76,13 @@ export default function App() {
 
   // Identify / alias the user in PostHog on sign-in; reset on sign-out.
   // Runs AFTER analytics.init() has claimed the install_id as distinct_id,
-  // so `alias(userId)` correctly merges prior anonymous history.
+  // so `alias(userId, profile)` correctly merges prior anonymous history.
   const prevUserIdRef = useRef<string | null>(null);
   useEffect(() => {
     const userId = session?.user?.id ?? null;
+    const userEmail = session?.user?.email ?? null;
     if (userId && userId !== prevUserIdRef.current) {
-      analytics.alias(userId, {
-        email: session?.user?.email ?? "",
-        name:
-          (session?.user?.user_metadata?.full_name as string | undefined) ??
-          (session?.user?.user_metadata?.name as string | undefined) ??
-          "",
-      });
+      analytics.alias(userId, { email: userEmail });
       prevUserIdRef.current = userId;
     } else if (!userId && prevUserIdRef.current) {
       analytics.reset();
@@ -236,7 +230,6 @@ export default function App() {
                     }))}
                     activeTab={viewMode}
                     onTabChange={(tab) => {
-                      analytics.track("tab_switched", { tab });
                       setViewMode(tab);
                     }}
                     actions={
@@ -390,7 +383,7 @@ export function CreateWorkspaceDialog({
         setCurrentWorkspace(imported);
         await loadAgents(imported.id);
       }
-      analytics.track("workspace_imported");
+      analytics.track("workspace_created", { source: "github_import" });
       handleClose();
     } catch (e) {
       setImportError(e instanceof Error ? e.message : String(e));

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -7,7 +7,6 @@ import { useWorkspaceStore } from "../../stores/workspaces";
 import { useAgentStore } from "../../stores/agents";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { useUIStore } from "../../stores/ui";
-import { analytics } from "../../lib/analytics";
 import { AgentMiniAvatar } from "./experience-card";
 import { UpdateChecker } from "./update-checker";
 import { UserMenu } from "./user-menu";
@@ -67,7 +66,6 @@ export function Sidebar({ children }: { children: ReactNode }) {
     setCurrentAgent(agent);
     const def = getById(agent.configId);
     const tab = def?.config.defaultTab ?? "chat";
-    analytics.track("tab_switched", { tab });
     setViewMode(tab);
   };
 

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -332,7 +332,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
       setLoading((prev) => ({ ...prev, [sessionKey]: true }));
       // createMission bypassed useCreateActivity so invalidate manually.
       queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) });
-      analytics.track("mission_created", { agent_id: agent.id, agent_mode: agentMode ?? "default" });
+      analytics.track("mission_created", { agent_mode: agentMode ?? "default" });
       return conversationId;
     },
     [path, agent.id, agent.name, agent.color, pushFeedItem, pendingAgentMode, agentModes, chatProvider, chatModel, queryClient],

--- a/app/src/components/tabs/chat-tab.tsx
+++ b/app/src/components/tabs/chat-tab.tsx
@@ -164,10 +164,7 @@ export default function ChatTab({ agent }: TabProps) {
         ? `${text}${text ? "\n\n" : ""}Attached: ${files.map((f) => f.name).join(", ")}`
         : text;
       pushFeedItem(agentPath, sessionKey, { feed_type: "user_message", data: visible });
-      if (!feedItems?.length) {
-        analytics.track("session_started", { agent_id: agent.id, agent_name: agent.name });
-      }
-      analytics.track("chat_message_sent", { agent_id: agent.id });
+      analytics.track("chat_message_sent");
       // Clear composer immediately so the user sees the send.
       setComposerText("");
       setComposerFiles([]);

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -286,7 +286,6 @@ export function useAgentChatPanel({
         });
         queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) });
         analytics.track("mission_created", {
-          agent_id: agent.id,
           agent_mode: agentMode ?? "default",
         });
         onSelectSessionRef.current?.(conversationId);

--- a/app/src/hooks/use-analytics-subscriber.ts
+++ b/app/src/hooks/use-analytics-subscriber.ts
@@ -1,24 +1,18 @@
 import { useEffect, useRef } from "react";
 import type { HoustonEvent } from "@houston-ai/core";
 import { subscribeHoustonEvents } from "../lib/events";
-import { analytics } from "../lib/analytics";
-import { useWorkspaceStore } from "../stores/workspaces";
-import { tauriPreferences } from "../lib/tauri";
-
-const ONBOARDING_KEY_PREFIX = "onboarding_completed:";
+import { analytics, classifyAnalyticsError } from "../lib/analytics";
 
 /**
  * Subscribes to the HoustonEvent firehose and fires analytics for events
- * that originate from the backend (streaming replies, session completion,
+ * that originate from the backend (assistant replies, session failures,
  * backend errors) — i.e. anything that has no obvious call site in the
  * React code.
  *
  * Mount once in App.tsx. Never mounted in ui/ (library boundary rule).
  */
 export function useAnalyticsSubscriber() {
-  // Guard against firing `onboarding_completed` more than once per workspace
-  // within a single session before the tauriPreferences round-trip returns.
-  const onboardingFiredRef = useRef<Set<string>>(new Set());
+  const repliesRef = useRef<Set<string>>(new Set());
 
   useEffect(() => {
     const unlisten = subscribeHoustonEvents((p: HoustonEvent) => {
@@ -29,49 +23,22 @@ export function useAnalyticsSubscriber() {
           // during streaming and would inflate counts. "assistant_text" is
           // emitted once per reply when the stream finalizes.
           if (p.data.item.feed_type === "assistant_text") {
-            analytics.track("chat_message_received", {
-              agent_path: p.data.agent_path,
-              session_key: p.data.session_key,
-            });
+            const key = `${p.data.agent_path}:${p.data.session_key}`;
+            if (repliesRef.current.has(key)) break;
+            repliesRef.current.add(key);
+            analytics.track("chat_message_received");
           }
           break;
         }
 
         case "SessionStatus": {
-          const { status, agent_path, session_key, error } = p.data;
-          if (status !== "completed" && status !== "error") break;
-
-          analytics.track("session_ended", {
-            agent_path,
-            session_key,
-            status,
-          });
-
-          if (status === "completed") {
-            const workspace = useWorkspaceStore.getState().current;
-            if (workspace && !onboardingFiredRef.current.has(workspace.id)) {
-              const prefKey = ONBOARDING_KEY_PREFIX + workspace.id;
-              tauriPreferences
-                .get(prefKey)
-                .then((existing) => {
-                  if (existing) return;
-                  onboardingFiredRef.current.add(workspace.id);
-                  analytics.track("onboarding_completed", {
-                    workspace_id: workspace.id,
-                  });
-                  tauriPreferences
-                    .set(prefKey, new Date().toISOString())
-                    .catch(() => {});
-                })
-                .catch(() => {});
-            }
-          }
-
+          const { status, error } = p.data;
           if (status === "error" && error) {
-            analytics.track("error_shown", {
+            const error_kind = classifyAnalyticsError(error);
+            analytics.track("session_failed", { error_kind });
+            analytics.track("app_error_shown", {
               source: "session",
-              agent_path,
-              error: error.slice(0, 200),
+              error_kind,
             });
           }
           break;
@@ -79,9 +46,9 @@ export function useAnalyticsSubscriber() {
 
         case "Toast": {
           if (p.data.variant === "error") {
-            analytics.track("error_shown", {
+            analytics.track("app_error_shown", {
               source: "toast",
-              message: (p.data.message ?? "").slice(0, 200),
+              error_kind: classifyAnalyticsError(p.data.message ?? ""),
             });
           }
           break;

--- a/app/src/hooks/use-update-checker.ts
+++ b/app/src/hooks/use-update-checker.ts
@@ -1,7 +1,6 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { check } from "@tauri-apps/plugin-updater";
 import { relaunch } from "@tauri-apps/plugin-process";
-import { analytics } from "../lib/analytics";
 
 type UpdateStatus =
   | { state: "idle" }
@@ -32,7 +31,6 @@ export function useUpdateChecker() {
             const pct = totalLength > 0 ? Math.round((downloaded / totalLength) * 100) : 0;
             setStatus({ state: "downloading", progress: pct });
           } else if (event.event === "Finished") {
-            analytics.track("app_update_downloaded", { version: update.version });
             setStatus({ state: "ready" });
           }
         });
@@ -40,7 +38,6 @@ export function useUpdateChecker() {
         setStatus({ state: "ready" });
       };
 
-      analytics.track("app_update_available", { version: update.version });
       setStatus({
         state: "available",
         version: update.version,

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -1,5 +1,6 @@
 import posthog from "posthog-js";
 import { getInstallId } from "./install-id";
+import { tauriPreferences } from "./tauri";
 
 // __POSTHOG_KEY__, __POSTHOG_HOST__, __APP_VERSION__ declared in vite-env.d.ts,
 // baked at build time by Vite from POSTHOG_KEY / POSTHOG_HOST env vars.
@@ -8,21 +9,61 @@ const HOST =
   typeof __POSTHOG_HOST__ !== "undefined" && __POSTHOG_HOST__
     ? __POSTHOG_HOST__
     : "https://us.i.posthog.com";
+const ACTIVE_DATE_KEY = "analytics:last_active_date";
 
-// Bootstrap PostHog at module load so events fired before `analytics.init()`
-// finishes are still captured (posthog-js silently drops capture calls made
-// before init). A temporary auto-generated distinct_id is used until the
-// persisted install_id resolves and `identify()` switches to it.
+export type AnalyticsEventName =
+  | "app_active"
+  | "install_created"
+  | "workspace_created"
+  | "provider_configured"
+  | "agent_created"
+  | "chat_message_sent"
+  | "chat_message_received"
+  | "mission_created"
+  | "session_failed"
+  | "app_error_shown";
+
+type AnalyticsProperty =
+  | "provider"
+  | "config_id"
+  | "agent_mode"
+  | "source"
+  | "error_kind";
+type Props = Partial<Record<AnalyticsProperty, string | number | boolean>>;
+type UserProfile = {
+  email?: string | null;
+};
+type PersonProps = {
+  email?: string;
+  email_domain?: string;
+};
+
+const ALLOWED_PROPS = new Set<AnalyticsProperty>([
+  "provider",
+  "config_id",
+  "agent_mode",
+  "source",
+  "error_kind",
+]);
+
+// Bootstrap PostHog at module load so a configured build can capture errors
+// before `analytics.init()` resolves. Product events are fired after init.
 let bootstrapped = false;
 function bootstrap() {
   if (bootstrapped || !KEY) return;
   bootstrapped = true;
   posthog.init(KEY, {
     api_host: HOST,
-    person_profiles: "always",
+    defaults: "2026-01-30",
+    person_profiles: "identified_only",
     capture_pageview: false,
     capture_pageleave: false,
     autocapture: false,
+    capture_dead_clicks: false,
+    rageclick: false,
+    disable_session_recording: true,
+    enable_heatmaps: false,
+    advanced_disable_flags: true,
     loaded: (ph) => {
       ph.register({
         app_version: typeof __APP_VERSION__ !== "undefined" ? __APP_VERSION__ : "0.0.0",
@@ -34,7 +75,39 @@ function bootstrap() {
 }
 bootstrap();
 
-type Props = Record<string, string | number | boolean>;
+function cleanProps(props?: Props): Props | undefined {
+  if (!props) return undefined;
+  const next: Props = {};
+  for (const key of ALLOWED_PROPS) {
+    if (props[key] !== undefined) next[key] = props[key];
+  }
+  return Object.keys(next).length > 0 ? next : undefined;
+}
+
+function activeDate() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function cleanEmail(email?: string | null): string | undefined {
+  const value = email?.trim().toLowerCase();
+  const at = value?.lastIndexOf("@") ?? -1;
+  return value && at > 0 && at < value.length - 1 ? value : undefined;
+}
+
+function personProps(profile?: UserProfile): PersonProps | undefined {
+  const email = cleanEmail(profile?.email);
+  if (!email) return undefined;
+  return { email, email_domain: email.slice(email.lastIndexOf("@") + 1) };
+}
+
+export function classifyAnalyticsError(message: string): string {
+  const lower = message.toLowerCase();
+  if (lower.includes("auth") || lower.includes("token") || lower.includes("login")) return "auth";
+  if (lower.includes("network") || lower.includes("fetch") || lower.includes("timeout")) return "network";
+  if (lower.includes("permission") || lower.includes("denied")) return "permission";
+  if (lower.includes("provider") || lower.includes("openai") || lower.includes("anthropic")) return "provider";
+  return "unknown";
+}
 
 /**
  * Fire-and-forget analytics wrapper. Never throws, never blocks.
@@ -43,8 +116,7 @@ type Props = Record<string, string | number | boolean>;
 export const analytics = {
   /**
    * Resolve the persistent install_id and identify the PostHog distinct_id.
-   * Call once on app mount. Returns `isNew` so callers can derive the
-   * `user_returned` event.
+   * Call once on app mount. Returns `isNew` so callers can track first install.
    */
   init: async (): Promise<{ installId: string; isNew: boolean }> => {
     if (!KEY) return { installId: "", isNew: false };
@@ -58,20 +130,19 @@ export const analytics = {
     return { installId: id, isNew };
   },
 
-  track: (event: string, props?: Props) => {
+  trackActive: async () => {
     if (!KEY) return;
-    try {
-      posthog.capture(event, props);
-    } catch {
-      // Analytics unavailable
-    }
+    const today = activeDate();
+    const last = await tauriPreferences.get(ACTIVE_DATE_KEY).catch(() => null);
+    if (last === today) return;
+    analytics.track("app_active");
+    await tauriPreferences.set(ACTIVE_DATE_KEY, today).catch(() => {});
   },
 
-  /** Register a PostHog group (e.g., workspace). Enables per-group retention. */
-  group: (type: string, key: string, props?: Props) => {
+  track: (event: AnalyticsEventName, props?: Props) => {
     if (!KEY) return;
     try {
-      posthog.group(type, key, props);
+      posthog.capture(event, cleanProps(props));
     } catch {
       // Analytics unavailable
     }
@@ -79,13 +150,23 @@ export const analytics = {
 
   /**
    * Merge anonymous install_id history into an identified user. Call on sign-in.
-   * Reserved for PR 2 (Supabase auth) — safe to call now, no-op without KEY.
+   * Email is a person property for lookup/filtering, never an event prop.
    */
-  alias: (userId: string, traits?: Props) => {
+  alias: (userId: string, profile?: UserProfile) => {
     if (!KEY) return;
     try {
       posthog.alias(userId);
-      posthog.identify(userId, traits);
+      posthog.identify(userId, personProps(profile));
+    } catch {
+      // Analytics unavailable
+    }
+  },
+
+  captureException: (error: unknown, props?: Props) => {
+    if (!KEY) return;
+    try {
+      const normalized = error instanceof Error ? error : new Error(String(error));
+      posthog.captureException(normalized, cleanProps(props));
     } catch {
       // Analytics unavailable
     }

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -1,4 +1,5 @@
 import { useUIStore } from "../stores/ui";
+import { analytics, classifyAnalyticsError } from "./analytics";
 import { reportBug } from "./bug-report";
 import { getCurrentUserEmail } from "./current-user";
 
@@ -10,6 +11,10 @@ import { getCurrentUserEmail } from "./current-user";
 export function showErrorToast(command: string, message: string): void {
   const timestamp = new Date().toISOString();
   const addToast = useUIStore.getState().addToast;
+  analytics.track("app_error_shown", {
+    source: command,
+    error_kind: classifyAnalyticsError(message),
+  });
 
   addToast({
     title: "Houston, we have a problem!",

--- a/app/src/lib/install-id.ts
+++ b/app/src/lib/install-id.ts
@@ -7,7 +7,7 @@ let cached: { id: string; isNew: boolean } | null = null;
 /**
  * Stable anonymous identifier. Persisted in tauriPreferences so it
  * survives app restarts. `isNew` is true the first time we mint it
- * during this install's lifetime — used to derive `user_returned`.
+ * during this install's lifetime.
  */
 export async function getInstallId(): Promise<{ id: string; isNew: boolean }> {
   if (cached) return cached;

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -17,6 +17,7 @@ import i18n from "./lib/i18n";
 import { DisclaimerGate } from "./components/shell/disclaimer-gate";
 import { LanguageGate } from "./components/shell/language-gate";
 import { showErrorToast } from "./lib/error-toast";
+import { analytics, classifyAnalyticsError } from "./lib/analytics";
 
 // Initialize file-based logging — patches console.error/warn to write to
 // ~/.houston/logs/frontend.log (or ~/.dev-houston/logs/frontend.log in dev).
@@ -27,12 +28,20 @@ initFrontendLogging();
 window.onerror = (_event, _source, _line, _col, error) => {
   const message = error?.message ?? String(_event);
   console.error("[global:error]", message, error);
+  analytics.captureException(error ?? new Error(message), {
+    source: "uncaught_error",
+    error_kind: classifyAnalyticsError(message),
+  });
   showErrorToast("uncaught_error", message);
 };
 
 window.onunhandledrejection = (event: PromiseRejectionEvent) => {
   const message = event.reason?.message ?? String(event.reason);
   console.error("[global:unhandledrejection]", message, event.reason);
+  analytics.captureException(event.reason, {
+    source: "unhandled_rejection",
+    error_kind: classifyAnalyticsError(message),
+  });
   showErrorToast("unhandled_rejection", message);
 };
 
@@ -41,6 +50,10 @@ class ErrorBoundary extends Component<{ children: ReactNode }, { error: Error | 
   static getDerivedStateFromError(error: Error) { return { error }; }
   componentDidCatch(error: Error) {
     logger.error(`[react-crash] ${error.message}`, error.stack);
+    analytics.captureException(error, {
+      source: "react_crash",
+      error_kind: classifyAnalyticsError(error.message),
+    });
     showErrorToast("react_crash", error.message);
   }
   render() {

--- a/app/src/stores/agents.ts
+++ b/app/src/stores/agents.ts
@@ -43,7 +43,6 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   setCurrent: (agent) => {
     set({ current: agent });
     tauriPreferences.set("last_agent_id", agent.id);
-    analytics.track("agent_selected", { agent_id: agent.id, config_id: agent.configId });
     // Start file watcher for AI-native reactivity
     tauriWatcher.start(agent.folderPath).catch((e) =>
       console.error("[watcher] Failed to start:", e),

--- a/app/src/stores/workspaces.ts
+++ b/app/src/stores/workspaces.ts
@@ -36,17 +36,14 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
   setCurrent: (ws) => {
     set({ current: ws });
     tauriPreferences.set("last_workspace_id", ws.id);
-    analytics.track("workspace_opened", { workspace_id: ws.id });
-    // Per-workspace retention in PostHog — subsequent events inherit this group.
-    analytics.group("workspace", ws.id, {
-      name: ws.name,
-      provider: ws.provider ?? "none",
-    });
   },
 
   create: async (name, provider, model) => {
     const ws = await tauriWorkspaces.create(name, provider, model);
-    analytics.track("workspace_created", { provider: provider ?? "none" });
+    analytics.track("workspace_created", {
+      provider: provider ?? "none",
+      source: "manual",
+    });
     set((s) => ({
       workspaces: [...s.workspaces, ws],
     }));

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -13,37 +13,46 @@ Four prod systems. All **dormant by default** — activate only when env vars se
 
 ## Analytics (`posthog-js`)
 
-- **Pure JS** — runs in webview, no Rust plugin. Avoids Tokio runtime conflicts. Works in future Capacitor mobile too.
-- **Init:** `app/src/lib/analytics.ts` — reads `POSTHOG_KEY` + `POSTHOG_HOST` via Vite `define` (baked at build time). Empty key → silent no-op. PostHog `init()` runs at module load; `analytics.init()` is called from `App.tsx` to resolve the install_id and `identify()` the PostHog distinct_id before the first event.
-- **Install identity:** `app/src/lib/install-id.ts` — mints a UUID on first launch, persists via `tauriPreferences` (`install_id` key). Used as the anonymous PostHog `distinct_id` until a user signs in (then `analytics.alias/identify` merges the history to the Supabase user). Gives per-user retention and activation funnels without requiring auth.
+- **Purpose:** investor-grade usage + product decisions only. Avoid broad behavioral surveillance.
+- **Pure JS:** runs in webview, no Rust plugin. Avoids Tokio runtime conflicts. Works in future Capacitor mobile too.
+- **Init:** `app/src/lib/analytics.ts` — reads `POSTHOG_KEY` + `POSTHOG_HOST` via Vite `define` (baked at build time). Empty key → silent no-op. PostHog `init()` runs at module load for JS exception capture; product events fire after `analytics.init()` identifies the persistent install_id.
+- **PostHog config:** autocapture, pageview/pageleave, session replay, heatmaps, dead clicks, rage clicks, and feature-flag `/flags` calls are disabled in code. Enable any of these only with a specific question.
+- **Install identity:** `app/src/lib/install-id.ts` — mints a UUID on first launch, persists via `tauriPreferences` (`install_id` key). Used as anonymous PostHog `distinct_id` until sign-in, then `analytics.alias/identify` merges history to the Supabase user.
+- **User identity:** `distinct_id` is the stable Supabase user id. `email` and `email_domain` are PostHog person properties only, used for lookup, company-domain filtering, and B2B usage checks.
 - **Debug/Release:** `import.meta.env.DEV` → `is_debug` super property. Filter it out in dashboards to exclude dev activity.
-- **Super properties** (set on every event): `app_version`, `os`, `install_id`, `is_debug`.
-- **Group analytics:** `analytics.group("workspace", workspaceId, { name, provider })` fires on `workspace_opened` — unlocks per-workspace retention in PostHog.
+- **Super properties:** `app_version`, `os`, `install_id`, `is_debug`.
+- **Privacy:** no workspace names, agent names, raw prompts, raw message text, file paths, session keys, or raw error text in PostHog event props. Email is allowed only as a person property after auth, never as an event property.
 
 ### Event surface
-- **Lifecycle:** `app_launched`, `user_returned` (derived: `app_launched` + existing install_id), `session_started`, `session_ended`, `onboarding_completed`
-- **Agent / workspace:** `agent_created`, `agent_selected`, `workspace_created`, `workspace_opened`, `workspace_imported`, `provider_configured`
-- **Chat:** `chat_message_sent`, `chat_message_received` (activation event)
-- **UX:** `tab_switched`, `mission_created`, `error_shown`
-- **Updater:** `app_update_available`, `app_update_downloaded`
+- **Growth:** `app_active` (once per install per UTC day), `install_created`
+- **Activation:** `workspace_created`, `provider_configured`, `agent_created`, `chat_message_sent`, `chat_message_received`
+- **Engagement:** `mission_created`
+- **Reliability:** `session_failed`, `app_error_shown`, PostHog `$exception` from JS global handlers + React error boundary
 
 **Activation milestone:** `chat_message_received` — user sent a message and got a reply. Configure as the activation event in PostHog; all retention/funnel insights key off it.
 
 ### Adding event
 ```typescript
 import { analytics } from "@/lib/analytics";
-analytics.track("event_name", { key: "value", flag: true });
+analytics.track("event_name");
 ```
-Props: `Record<string, string | number | boolean>`. Fire-and-forget. Never throws/blocks. Not configured → silent no-op.
+Event names + props are allowlisted in `AnalyticsEventName` / `AnalyticsProperty`. Add only if tied to a dashboard question. Fire-and-forget. Never throws/blocks. Not configured → silent no-op.
 
 **Analytics in `app/` only** — never in `ui/`. Library boundary rule applies.
 
-### PostHog dashboards (configure in UI, not code)
-1. **Overview**: DAU / WAU / MAU (filter out `is_debug = true`)
-2. **Retention**: Weekly-cohort grid on `chat_message_received`
-3. **Activation funnel**: `app_launched` → `agent_created` → `chat_message_sent` → `chat_message_received`
-4. **Engagement depth**: events per user per day, sessions per user per week
-5. **Feature adoption**: `mission_created`, `provider_configured`, `workspace_imported` breakdowns
+### PostHog dashboards
+Create one dashboard: **Houston Growth + Reliability**. Every tile filters `is_debug != true`.
+
+1. **DAU:** unique users, event `app_active`, interval day
+2. **WAU:** unique users, event `app_active`, interval week
+3. **MAU:** unique users, event `app_active`, interval month
+4. **Activation funnel:** `install_created` → `workspace_created` → `provider_configured` → `agent_created` → `chat_message_sent` → `chat_message_received`
+5. **Activated retention:** weekly retention where start + return event = `chat_message_received`
+6. **Engaged users:** unique users with `mission_created` or `chat_message_received`
+7. **Reliability:** count of `session_failed` + `$exception`, broken down by `error_kind`
+8. **Company domains:** active users broken down by person property `email_domain`
+
+Do NOT use raw autocapture event lists for product decisions. If a question needs click-level data, prefer one temporary, named event and delete it after the decision.
 
 ### BigQuery export (optional)
 PostHog → BigQuery plugin → target GCP project (burns credits). SQL-queryable event history forever, immune to PostHog retention limits. Useful for investor-update analytics.
@@ -53,7 +62,7 @@ PostHog → BigQuery plugin → target GCP project (burns credits). SQL-queryabl
 - **Session storage:** macOS Keychain / Windows Credential Manager via the `keyring` crate (`app/src-tauri/src/auth.rs`). Frontend Supabase client uses a custom storage adapter that round-trips to Rust — tokens never hit localStorage.
 - **Flow:** One-click Google sign-in → system browser → OAuth redirect to `houston://auth-callback` → `tauri-plugin-deep-link` forwards to frontend → Supabase PKCE exchange → session persisted in Keychain. Full diagram + code pointers: `knowledge-base/auth.md`.
 - **Gating:** `isAuthConfigured()` checks whether `SUPABASE_URL` + `SUPABASE_ANON_KEY` are baked in. Unconfigured builds skip the sign-in screen entirely.
-- **PostHog merge:** On sign-in, `analytics.alias(userId)` merges anonymous install_id history to the identified user; on sign-out, `analytics.reset()` returns to anonymous.
+- **PostHog merge:** On sign-in, `analytics.alias(userId, { email })` merges anonymous install_id history to the identified user and sets `email` / `email_domain` person properties; on sign-out, `analytics.reset()` returns to anonymous.
 
 ## Crash reporting (`sentry` + `tauri-plugin-sentry`)
 


### PR DESCRIPTION
## Summary
- narrow PostHog event tracking to DAU/MAU, activation, engagement, and reliability metrics
- identify logged-in users with Supabase ids while storing email and email_domain as person properties
- document the analytics event surface and dashboard plan

## Checks
- cd app && pnpm typecheck
- cd app && pnpm check-locales
- git diff --check

## Affected files
- app/src/lib/analytics.ts
- app/src/App.tsx
- app/src/hooks/use-analytics-subscriber.ts
- knowledge-base/production-infra.md