### PR TITLE
fix(app): send bug reports through native webhook

### DIFF
--- a/app/src-tauri/.env.example
+++ b/app/src-tauri/.env.example
@@ -3,3 +3,6 @@
 HOUSTON_SLACK_CLIENT_ID=your-client-id
 HOUSTON_SLACK_CLIENT_SECRET=your-client-secret
 HOUSTON_SLACK_APP_TOKEN=xapp-your-app-token
+
+# Incoming webhook for the in-app "Report bug" action
+SLACK_BUG_WEBHOOK_URL=https://hooks.slack.com/services/your/webhook/url

--- a/app/src-tauri/src/bug_report.rs
+++ b/app/src-tauri/src/bug_report.rs
@@ -1,0 +1,155 @@
+use reqwest::StatusCode;
+use serde_json::Value;
+
+#[tauri::command(rename_all = "snake_case")]
+pub async fn report_bug(payload: Value) -> Result<(), String> {
+    let webhook_url = bug_webhook_url().ok_or_else(|| {
+        "Bug reporting not configured (missing SLACK_BUG_WEBHOOK_URL at build time)".to_string()
+    })?;
+
+    send_bug_report_to(&webhook_url, &payload).await
+}
+
+async fn send_bug_report_to(webhook_url: &str, payload: &Value) -> Result<(), String> {
+    let response = reqwest::Client::new()
+        .post(webhook_url)
+        .json(&payload)
+        .send()
+        .await
+        .map_err(|e| format!("Slack webhook request failed: {e}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("could not read Slack response body: {e}"));
+        let message = slack_error_message(status, &body);
+        tracing::warn!(%message, "bug report webhook rejected payload");
+        return Err(message);
+    }
+
+    Ok(())
+}
+
+fn bug_webhook_url() -> Option<String> {
+    configured_webhook_url(
+        std::env::var("SLACK_BUG_WEBHOOK_URL").ok(),
+        option_env!("SLACK_BUG_WEBHOOK_URL"),
+    )
+}
+
+fn configured_webhook_url(
+    runtime: Option<String>,
+    compiled: Option<&'static str>,
+) -> Option<String> {
+    runtime
+        .as_deref()
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(str::to_string)
+        .or_else(|| {
+            compiled
+                .map(str::trim)
+                .filter(|url| !url.is_empty())
+                .map(str::to_string)
+        })
+}
+
+fn slack_error_message(status: StatusCode, body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return format!("Slack webhook failed: {status}");
+    }
+    let detail = if trimmed.len() > 160 {
+        format!("{}...", trimmed.chars().take(160).collect::<String>())
+    } else {
+        trimmed.to_string()
+    };
+    format!("Slack webhook failed: {status} {detail}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+
+    #[test]
+    fn configured_webhook_prefers_runtime_value() {
+        let url = configured_webhook_url(
+            Some(" https://hooks.slack.test/runtime ".to_string()),
+            Some("https://hooks.slack.test/compiled"),
+        );
+        assert_eq!(url.as_deref(), Some("https://hooks.slack.test/runtime"));
+    }
+
+    #[test]
+    fn configured_webhook_uses_compiled_fallback() {
+        let url = configured_webhook_url(Some(" ".to_string()), Some(" compiled "));
+        assert_eq!(url.as_deref(), Some("compiled"));
+    }
+
+    #[test]
+    fn slack_error_message_keeps_status_and_body() {
+        let message = slack_error_message(StatusCode::BAD_REQUEST, "invalid_payload");
+        assert_eq!(
+            message,
+            "Slack webhook failed: 400 Bad Request invalid_payload"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_bug_report_posts_payload_to_webhook() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind test webhook");
+        let addr = listener.local_addr().expect("read listener address");
+
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let mut request = Vec::new();
+            let mut buffer = [0; 1024];
+            loop {
+                let read = stream.read(&mut buffer).expect("read request");
+                if read == 0 {
+                    break;
+                }
+                request.extend_from_slice(&buffer[..read]);
+                if let Some(header_end) = find_header_end(&request) {
+                    let headers = String::from_utf8_lossy(&request[..header_end]);
+                    let content_length = headers
+                        .lines()
+                        .find_map(|line| {
+                            let (name, value) = line.split_once(':')?;
+                            name.eq_ignore_ascii_case("content-length")
+                                .then(|| value.trim())
+                        })
+                        .and_then(|value| value.parse::<usize>().ok())
+                        .unwrap_or(0);
+                    if request.len() >= header_end + 4 + content_length {
+                        break;
+                    }
+                }
+            }
+            stream
+                .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok")
+                .expect("write response");
+            String::from_utf8(request).expect("request is utf8")
+        });
+
+        let payload = serde_json::json!({
+            "attachments": [{ "title": "Bug Report from Houston" }]
+        });
+        send_bug_report_to(&format!("http://{addr}/slack"), &payload)
+            .await
+            .expect("send bug report");
+
+        let request = server.join().expect("join webhook server");
+        assert!(request.starts_with("POST /slack HTTP/1.1"));
+        assert!(request.contains("application/json"));
+        assert!(request.contains("\"Bug Report from Houston\""));
+    }
+
+    fn find_header_end(request: &[u8]) -> Option<usize> {
+        request.windows(4).position(|window| window == b"\r\n\r\n")
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod bug_report;
 mod commands;
 mod engine_supervisor;
 mod houston_prompt;
@@ -287,6 +288,9 @@ pub fn run() {
             // Logging (writes to local log files).
             logging::write_frontend_log,
             logging::read_recent_logs,
+            // Native network delivery for bug reports. Avoids webview CORS and
+            // keeps the Slack webhook out of the JavaScript bundle.
+            bug_report::report_bug,
             // Engine handshake pull (race-free fallback for `EngineGate`).
             get_engine_handshake,
             // Keychain-backed storage for Supabase auth sessions.

--- a/app/src-tauri/src/logging.rs
+++ b/app/src-tauri/src/logging.rs
@@ -1,6 +1,7 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::OnceLock;
+use std::time::SystemTime;
 use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::{fmt, EnvFilter};
 
@@ -19,8 +20,9 @@ pub fn init(data_dir: &Path) {
     // Store the guard so the background writer thread stays alive
     let _ = GUARD.set(guard);
 
-    let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new("info,houston_terminal_manager=debug,houston_tauri=debug,houston_app=debug"));
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
+        EnvFilter::new("info,houston_terminal_manager=debug,houston_tauri=debug,houston_app=debug")
+    });
 
     fmt()
         .with_env_filter(filter)
@@ -56,12 +58,17 @@ pub fn write_frontend_log(level: String, message: String, context: Option<String
     };
 
     use std::io::Write;
-    if let Ok(mut f) = fs::OpenOptions::new()
+    match fs::OpenOptions::new()
         .create(true)
         .append(true)
         .open(frontend_log_path())
     {
-        let _ = f.write_all(line.as_bytes());
+        Ok(mut f) => {
+            if let Err(e) = f.write_all(line.as_bytes()) {
+                eprintln!("failed to write frontend log: {e}");
+            }
+        }
+        Err(e) => eprintln!("failed to open frontend log: {e}"),
     }
 }
 
@@ -70,9 +77,36 @@ pub fn write_frontend_log(level: String, message: String, context: Option<String
 #[tauri::command]
 pub fn read_recent_logs(lines: Option<usize>) -> serde_json::Value {
     let n = lines.unwrap_or(100);
-    let backend = tail_file(&logs_dir().join("backend.log"), n);
+    let backend = tail_file(&latest_backend_log_path(), n);
     let frontend = tail_file(&frontend_log_path(), n);
     serde_json::json!({ "backend": backend, "frontend": frontend })
+}
+
+fn latest_backend_log_path() -> PathBuf {
+    let logs = logs_dir();
+    latest_log_matching(&logs, "backend.log").unwrap_or_else(|| logs.join("backend.log"))
+}
+
+fn latest_log_matching(dir: &Path, prefix: &str) -> Option<PathBuf> {
+    let mut candidates: Vec<(SystemTime, PathBuf)> = fs::read_dir(dir)
+        .ok()?
+        .filter_map(Result::ok)
+        .filter_map(|entry| {
+            let path = entry.path();
+            let name = path.file_name()?.to_str()?;
+            if !name.starts_with(prefix) {
+                return None;
+            }
+            let modified = entry
+                .metadata()
+                .and_then(|metadata| metadata.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            Some((modified, path))
+        })
+        .collect();
+
+    candidates.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    candidates.pop().map(|(_, path)| path)
 }
 
 fn tail_file(path: &Path, n: usize) -> String {
@@ -83,5 +117,30 @@ fn tail_file(path: &Path, n: usize) -> String {
             lines[start..].join("\n")
         }
         Err(_) => String::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn latest_log_matching_uses_newest_rotated_backend_log() {
+        let dir = std::env::temp_dir().join(format!(
+            "houston-log-test-{}",
+            chrono::Utc::now().timestamp_nanos_opt().unwrap_or(0)
+        ));
+        fs::create_dir_all(&dir).expect("create temp log dir");
+
+        let old = dir.join("backend.log.2026-04-27");
+        let current = dir.join("backend.log.2026-04-28");
+        fs::write(&old, "old").expect("write old log");
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        fs::write(&current, "current").expect("write current log");
+
+        let selected = latest_log_matching(&dir, "backend.log");
+        assert_eq!(selected.as_deref(), Some(current.as_path()));
+
+        fs::remove_dir_all(&dir).expect("remove temp log dir");
     }
 }

--- a/app/src/lib/bug-report.ts
+++ b/app/src/lib/bug-report.ts
@@ -1,8 +1,4 @@
-import { osReadRecentLogs } from "./os-bridge";
-
-declare const __SLACK_BUG_WEBHOOK__: string;
-const WEBHOOK_URL =
-  typeof __SLACK_BUG_WEBHOOK__ !== "undefined" ? __SLACK_BUG_WEBHOOK__ : "";
+import { osReadRecentLogs, osReportBug } from "./os-bridge";
 
 interface BugReportContext {
   command: string;
@@ -23,12 +19,6 @@ async function getRecentLogs(lines = 50): Promise<{ backend: string; frontend: s
 }
 
 export async function reportBug(context: BugReportContext): Promise<void> {
-  if (!WEBHOOK_URL) {
-    throw new Error(
-      "Bug reporting not configured (missing SLACK_BUG_WEBHOOK_URL at build time)",
-    );
-  }
-
   const logs = await getRecentLogs();
 
   const fields = [
@@ -73,13 +63,5 @@ export async function reportBug(context: BugReportContext): Promise<void> {
     ],
   };
 
-  const response = await fetch(WEBHOOK_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(payload),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Slack webhook failed: ${response.status}`);
-  }
+  await osReportBug(payload);
 }

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -93,3 +93,8 @@ export function osReadRecentLogs(
 ): Promise<{ backend: string; frontend: string }> {
   return invoke<{ backend: string; frontend: string }>("read_recent_logs", { lines });
 }
+
+/** Send a prepared bug report to Houston's Slack intake from native code. */
+export function osReportBug(payload: unknown): Promise<void> {
+  return invoke<void>("report_bug", { payload });
+}

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -20,7 +20,6 @@ export default defineConfig(({ mode }) => {
     ),
     __SUPABASE_URL__: JSON.stringify(env.SUPABASE_URL ?? ""),
     __SUPABASE_ANON_KEY__: JSON.stringify(env.SUPABASE_ANON_KEY ?? ""),
-    __SLACK_BUG_WEBHOOK__: JSON.stringify(env.SLACK_BUG_WEBHOOK_URL ?? ""),
   },
   clearScreen: false,
   // Exclude workspace packages from Vite's dep pre-bundling so live edits

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -71,6 +71,12 @@ PostHog → BigQuery plugin → target GCP project (burns credits). SQL-queryabl
 - **Rust panics:** Captured via sentry panic handler.
 - **Check:** User reports crash or weird behavior → Sentry dashboard BEFORE local logs.
 
+## In-app bug reports (Slack webhook)
+
+- **Frontend:** `app/src/lib/error-toast.ts` shows the "Report bug" action. `app/src/lib/bug-report.ts` builds the Slack payload and attaches recent frontend + backend logs.
+- **Native delivery:** `app/src-tauri/src/bug_report.rs` posts to Slack with `reqwest`. Do not post the webhook from the webview; Slack webhooks can fail under browser CORS, and the URL does not belong in the JS bundle.
+- **Config:** `SLACK_BUG_WEBHOOK_URL` is read from runtime env for dev and `option_env!()` for release builds. CI passes it in `.github/workflows/release.yml`.
+
 ## Required env vars
 
 Shell (local builds) AND GitHub Secrets (CI):
@@ -87,6 +93,7 @@ Shell (local builds) AND GitHub Secrets (CI):
 | `POSTHOG_HOST` | PostHog ingest host | `https://us.i.posthog.com` (or EU equivalent) |
 | `SUPABASE_URL` | Supabase project URL | Supabase → Project settings → API → Project URL |
 | `SUPABASE_ANON_KEY` | Supabase anon key (public-safe, RLS-gated) | Supabase → Project settings → API → Project API keys → `anon` `public` |
+| `SLACK_BUG_WEBHOOK_URL` | Incoming webhook for in-app bug reports | Slack App → Incoming Webhooks |
 | `SENTRY_DSN` | Crash reporting DSN | sentry.io project settings |
 
 CI also needs as Secrets:


### PR DESCRIPTION
## Summary
- Move Slack bug-report delivery from WebView fetch to native Tauri command
- Keep webhook out of JS bundle and surface Slack response body on failures
- Attach newest rotated backend log file to bug reports
- Document Slack bug-report env wiring

## Tests
- pnpm typecheck
- pnpm check-locales
- cargo test -p houston-app