### PR TITLE
fix: hide redundant action picker tabs

### DIFF
--- a/app/src/components/new-mission-picker-dialog.tsx
+++ b/app/src/components/new-mission-picker-dialog.tsx
@@ -1,17 +1,23 @@
-import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  cn,
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogDescription,
-  Spinner,
 } from "@houston-ai/core";
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import { useSkills } from "../hooks/queries";
 import { SkillCard } from "./skill-card";
+import { SkillList } from "./new-mission-picker-skill-list";
+import {
+  buildActionPickerTabs,
+  FEATURED_ACTIONS_TAB_ID,
+  OTHER_ACTIONS_TAB_ID,
+  resolveActiveActionPickerTab,
+  shouldShowActionPickerTabs,
+} from "./new-mission-picker-tab-model";
+import { ScrollableTabs } from "./new-mission-picker-tabs";
 import type { Agent, SkillSummary } from "../lib/types";
 
 interface Props {
@@ -26,18 +32,8 @@ interface Props {
   agents?: Agent[];
   onBlank?: (agentPath: string | undefined) => void;
   onSkill: (agentPath: string, skillName: string) => void;
-  /** Hide the "Blank conversation" card on the Featured tab. */
+  /** Hide the "Blank conversation" card in the action-only picker. */
   hideBlank?: boolean;
-}
-
-const FEATURED_TAB = "__featured__";
-const OTHER_TAB = "__other__";
-
-/** Turn a skill slug like "do-something_cool" into "Do something cool". */
-function humanizeSkillName(slug: string): string {
-  const spaced = slug.replace(/[-_]+/g, " ").trim();
-  if (spaced.length === 0) return slug;
-  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
 }
 
 export function NewMissionPickerDialog({
@@ -65,40 +61,50 @@ export function NewMissionPickerDialog({
     const featured: SkillSummary[] = [];
     for (const s of skills ?? []) {
       if (s.featured) featured.push(s);
-      const cat = s.category?.trim() || OTHER_TAB;
+      const cat = s.category?.trim() || OTHER_ACTIONS_TAB_ID;
       const list = byCategory.get(cat) ?? [];
       list.push(s);
       byCategory.set(cat, list);
     }
     const names = Array.from(byCategory.keys())
-      .filter((c) => c !== OTHER_TAB)
+      .filter((c) => c !== OTHER_ACTIONS_TAB_ID)
       .sort((a, b) => a.localeCompare(b));
     return { categoryNames: names, byCategory, featured };
   }, [skills]);
 
-  const hasOther = byCategory.has(OTHER_TAB);
+  const hasOther = byCategory.has(OTHER_ACTIONS_TAB_ID);
+  const hasFeatured = featured.length > 0;
 
-  const [activeTab, setActiveTab] = useState<string>(FEATURED_TAB);
+  const tabs = useMemo(
+    () => buildActionPickerTabs({
+      categoryNames,
+      hasFeatured,
+      hasOther,
+      featuredLabel: t("actionPicker.featuredTab"),
+      otherLabel: t("actionPicker.otherTab"),
+    }),
+    [categoryNames, hasFeatured, hasOther, t],
+  );
+
+  const [activeTab, setActiveTab] = useState<string>("");
+  const firstTabId = tabs[0]?.id ?? "";
+  const activeTabId = resolveActiveActionPickerTab(tabs, activeTab);
 
   useEffect(() => {
-    if (open) setActiveTab(FEATURED_TAB);
-  }, [open, activeAgentPath]);
-
-  const tabs: { id: string; label: string }[] = [
-    { id: FEATURED_TAB, label: t("actionPicker.featuredTab") },
-    ...categoryNames.map((c) => ({ id: c, label: c })),
-    ...(hasOther ? [{ id: OTHER_TAB, label: t("actionPicker.otherTab") }] : []),
-  ];
+    if (open) setActiveTab(firstTabId);
+  }, [open, activeAgentPath, firstTabId]);
 
   const skillsForActiveTab: SkillSummary[] =
-    activeTab === FEATURED_TAB ? featured : byCategory.get(activeTab) ?? [];
+    activeTabId === FEATURED_ACTIONS_TAB_ID
+      ? featured
+      : byCategory.get(activeTabId) ?? [];
 
   const sortedSkills = useMemo(
     () => [...skillsForActiveTab].sort((a, b) => a.name.localeCompare(b.name)),
     [skillsForActiveTab],
   );
 
-  const showBlankCard = !hideBlank && activeTab === FEATURED_TAB;
+  const showBlankCard = !hideBlank && (tabs.length === 0 || activeTabId === firstTabId);
 
   const handleBlank = () => {
     if (!onBlank) return;
@@ -148,11 +154,15 @@ export function NewMissionPickerDialog({
           </div>
         )}
 
-        <ScrollableTabs
-          tabs={tabs}
-          activeTab={activeTab}
-          onTabChange={setActiveTab}
-        />
+        {shouldShowActionPickerTabs(tabs) && (
+          <ScrollableTabs
+            tabs={tabs}
+            activeTab={activeTabId}
+            onTabChange={setActiveTab}
+            scrollLeftLabel={t("actionPicker.scrollTabsLeft")}
+            scrollRightLabel={t("actionPicker.scrollTabsRight")}
+          />
+        )}
 
         <div className="flex-1 min-h-0 overflow-y-auto px-6 pb-6">
           <div className="flex flex-col gap-2">
@@ -171,9 +181,7 @@ export function NewMissionPickerDialog({
               loading={skillsLoading}
               skills={sortedSkills}
               emptyLabel={
-                activeTab === FEATURED_TAB
-                  ? t("actionPicker.featuredEmpty")
-                  : t("actionPicker.skillsEmpty")
+                activeTabId ? t("actionPicker.skillsEmpty") : t("actionPicker.empty")
               }
               pickAgentLabel={t("actionPicker.pickAgentFirst")}
               loadingLabel={t("actionPicker.skillsLoading")}
@@ -184,154 +192,5 @@ export function NewMissionPickerDialog({
         </div>
       </DialogContent>
     </Dialog>
-  );
-}
-
-function SkillList({
-  agentReady,
-  loading,
-  skills,
-  emptyLabel,
-  pickAgentLabel,
-  loadingLabel,
-  hideEmpty,
-  onSkill,
-}: {
-  agentReady: boolean;
-  loading: boolean;
-  skills: SkillSummary[];
-  emptyLabel: string;
-  pickAgentLabel: string;
-  loadingLabel: string;
-  hideEmpty?: boolean;
-  onSkill: (name: string) => void;
-}) {
-  if (!agentReady) {
-    return <p className="text-sm text-muted-foreground">{pickAgentLabel}</p>;
-  }
-  if (loading) {
-    return (
-      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-        <Spinner className="size-3.5" />
-        {loadingLabel}
-      </div>
-    );
-  }
-  if (skills.length === 0) {
-    if (hideEmpty) return null;
-    return <p className="text-sm text-muted-foreground">{emptyLabel}</p>;
-  }
-  return (
-    <>
-      {skills.map((s) => (
-        <SkillCard
-          key={s.name}
-          image={s.image}
-          title={humanizeSkillName(s.name)}
-          description={s.description}
-          integrations={s.integrations}
-          onClick={() => onSkill(s.name)}
-        />
-      ))}
-    </>
-  );
-}
-
-interface ScrollableTabsProps {
-  tabs: { id: string; label: string }[];
-  activeTab: string;
-  onTabChange: (id: string) => void;
-}
-
-/**
- * Horizontal pill-tab list with subtle chevron arrows when overflow exists.
- * Arrows fade in/out based on scroll position; native horizontal scroll is
- * preserved for trackpad users but the visible scrollbar is hidden.
- *
- * Clicking the active tab also scrolls it into view, so users tabbing across
- * a wide list don't lose orientation.
- */
-function ScrollableTabs({ tabs, activeTab, onTabChange }: ScrollableTabsProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canLeft, setCanLeft] = useState(false);
-  const [canRight, setCanRight] = useState(false);
-
-  const measure = () => {
-    const el = scrollRef.current;
-    if (!el) return;
-    setCanLeft(el.scrollLeft > 1);
-    setCanRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
-  };
-
-  useLayoutEffect(() => {
-    measure();
-    const el = scrollRef.current;
-    if (!el) return;
-    const ro = new ResizeObserver(measure);
-    ro.observe(el);
-    return () => ro.disconnect();
-  }, [tabs.length]);
-
-  const scrollBy = (dir: -1 | 1) => {
-    const el = scrollRef.current;
-    if (!el) return;
-    el.scrollBy({ left: dir * Math.max(120, el.clientWidth * 0.6), behavior: "smooth" });
-  };
-
-  // When the active tab changes, scroll it into view so the user always sees it.
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const active = el.querySelector<HTMLElement>(`[data-tab-id="${activeTab}"]`);
-    active?.scrollIntoView({ block: "nearest", inline: "nearest", behavior: "smooth" });
-  }, [activeTab]);
-
-  return (
-    <div className="shrink-0 relative px-6 pb-3">
-      <div
-        ref={scrollRef}
-        onScroll={measure}
-        className="flex gap-1 overflow-x-auto scrollbar-none"
-        style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-      >
-        {tabs.map((tab) => (
-          <button
-            key={tab.id}
-            data-tab-id={tab.id}
-            type="button"
-            onClick={() => onTabChange(tab.id)}
-            className={cn(
-              "px-3 py-1.5 text-sm rounded-full transition-colors whitespace-nowrap",
-              activeTab === tab.id
-                ? "bg-accent text-foreground font-medium"
-                : "text-muted-foreground hover:bg-accent hover:text-foreground",
-            )}
-          >
-            {tab.label}
-          </button>
-        ))}
-      </div>
-
-      {canLeft && (
-        <button
-          type="button"
-          onClick={() => scrollBy(-1)}
-          aria-label="Scroll tabs left"
-          className="absolute left-2 top-1/2 -translate-y-1/2 size-6 rounded-full bg-background/90 border border-border shadow-sm flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors -mt-1.5"
-        >
-          <ChevronLeft className="size-3.5" />
-        </button>
-      )}
-      {canRight && (
-        <button
-          type="button"
-          onClick={() => scrollBy(1)}
-          aria-label="Scroll tabs right"
-          className="absolute right-2 top-1/2 -translate-y-1/2 size-6 rounded-full bg-background/90 border border-border shadow-sm flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors -mt-1.5"
-        >
-          <ChevronRight className="size-3.5" />
-        </button>
-      )}
-    </div>
   );
 }

--- a/app/src/components/new-mission-picker-skill-list.tsx
+++ b/app/src/components/new-mission-picker-skill-list.tsx
@@ -1,0 +1,60 @@
+import { Spinner } from "@houston-ai/core";
+import type { SkillSummary } from "../lib/types";
+import { SkillCard } from "./skill-card";
+
+/** Turn a skill slug like "do-something_cool" into "Do something cool". */
+function humanizeSkillName(slug: string): string {
+  const spaced = slug.replace(/[-_]+/g, " ").trim();
+  if (spaced.length === 0) return slug;
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1);
+}
+
+export function SkillList({
+  agentReady,
+  loading,
+  skills,
+  emptyLabel,
+  pickAgentLabel,
+  loadingLabel,
+  hideEmpty,
+  onSkill,
+}: {
+  agentReady: boolean;
+  loading: boolean;
+  skills: SkillSummary[];
+  emptyLabel: string;
+  pickAgentLabel: string;
+  loadingLabel: string;
+  hideEmpty?: boolean;
+  onSkill: (name: string) => void;
+}) {
+  if (!agentReady) {
+    return <p className="text-sm text-muted-foreground">{pickAgentLabel}</p>;
+  }
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+        <Spinner className="size-3.5" />
+        {loadingLabel}
+      </div>
+    );
+  }
+  if (skills.length === 0) {
+    if (hideEmpty) return null;
+    return <p className="text-sm text-muted-foreground">{emptyLabel}</p>;
+  }
+  return (
+    <>
+      {skills.map((s) => (
+        <SkillCard
+          key={s.name}
+          image={s.image}
+          title={humanizeSkillName(s.name)}
+          description={s.description}
+          integrations={s.integrations}
+          onClick={() => onSkill(s.name)}
+        />
+      ))}
+    </>
+  );
+}

--- a/app/src/components/new-mission-picker-tab-model.ts
+++ b/app/src/components/new-mission-picker-tab-model.ts
@@ -1,0 +1,44 @@
+export const FEATURED_ACTIONS_TAB_ID = "__featured__";
+export const OTHER_ACTIONS_TAB_ID = "__other__";
+
+export interface PickerTab {
+  id: string;
+  label: string;
+}
+
+export function buildActionPickerTabs({
+  categoryNames,
+  hasFeatured,
+  hasOther,
+  featuredLabel,
+  otherLabel,
+}: {
+  categoryNames: string[];
+  hasFeatured: boolean;
+  hasOther: boolean;
+  featuredLabel: string;
+  otherLabel: string;
+}): PickerTab[] {
+  return [
+    ...(hasFeatured
+      ? [{ id: FEATURED_ACTIONS_TAB_ID, label: featuredLabel }]
+      : []),
+    ...categoryNames.map((category) => ({
+      id: category,
+      label: category,
+    })),
+    ...(hasOther ? [{ id: OTHER_ACTIONS_TAB_ID, label: otherLabel }] : []),
+  ];
+}
+
+export function resolveActiveActionPickerTab(
+  tabs: PickerTab[],
+  activeTab: string,
+): string {
+  if (tabs.some((tab) => tab.id === activeTab)) return activeTab;
+  return tabs[0]?.id ?? "";
+}
+
+export function shouldShowActionPickerTabs(tabs: PickerTab[]): boolean {
+  return tabs.length > 1;
+}

--- a/app/src/components/new-mission-picker-tabs.tsx
+++ b/app/src/components/new-mission-picker-tabs.tsx
@@ -1,0 +1,107 @@
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { cn } from "@houston-ai/core";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { PickerTab } from "./new-mission-picker-tab-model";
+
+interface ScrollableTabsProps {
+  tabs: PickerTab[];
+  activeTab: string;
+  onTabChange: (id: string) => void;
+  scrollLeftLabel: string;
+  scrollRightLabel: string;
+}
+
+/**
+ * Horizontal pill-tab list with subtle chevron arrows when overflow exists.
+ * Arrows fade in/out based on scroll position; native horizontal scroll is
+ * preserved for trackpad users but the visible scrollbar is hidden.
+ */
+export function ScrollableTabs({
+  tabs,
+  activeTab,
+  onTabChange,
+  scrollLeftLabel,
+  scrollRightLabel,
+}: ScrollableTabsProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canLeft, setCanLeft] = useState(false);
+  const [canRight, setCanRight] = useState(false);
+
+  const measure = () => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanLeft(el.scrollLeft > 1);
+    setCanRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  };
+
+  useLayoutEffect(() => {
+    measure();
+    const el = scrollRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [tabs.length]);
+
+  const scrollBy = (dir: -1 | 1) => {
+    const el = scrollRef.current;
+    if (!el) return;
+    el.scrollBy({ left: dir * Math.max(120, el.clientWidth * 0.6), behavior: "smooth" });
+  };
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const active = el.querySelector<HTMLElement>(`[data-tab-id="${activeTab}"]`);
+    active?.scrollIntoView({ block: "nearest", inline: "nearest", behavior: "smooth" });
+  }, [activeTab]);
+
+  return (
+    <div className="shrink-0 relative px-6 pb-3">
+      <div
+        ref={scrollRef}
+        onScroll={measure}
+        className="flex gap-1 overflow-x-auto scrollbar-none"
+        style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+      >
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            data-tab-id={tab.id}
+            type="button"
+            onClick={() => onTabChange(tab.id)}
+            className={cn(
+              "px-3 py-1.5 text-sm rounded-full transition-colors whitespace-nowrap",
+              activeTab === tab.id
+                ? "bg-accent text-foreground font-medium"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground",
+            )}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {canLeft && (
+        <button
+          type="button"
+          onClick={() => scrollBy(-1)}
+          aria-label={scrollLeftLabel}
+          className="absolute left-2 top-1/2 -translate-y-1/2 size-6 rounded-full bg-background/90 border border-border shadow-sm flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors -mt-1.5"
+        >
+          <ChevronLeft className="size-3.5" />
+        </button>
+      )}
+      {canRight && (
+        <button
+          type="button"
+          onClick={() => scrollBy(1)}
+          aria-label={scrollRightLabel}
+          className="absolute right-2 top-1/2 -translate-y-1/2 size-6 rounded-full bg-background/90 border border-border shadow-sm flex items-center justify-center text-muted-foreground hover:text-foreground transition-colors -mt-1.5"
+        >
+          <ChevronRight className="size-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/src/locales/en/dashboard.json
+++ b/app/src/locales/en/dashboard.json
@@ -32,9 +32,11 @@
     "blankDescription": "Open a new chat and type your own prompt.",
     "featuredTab": "Featured",
     "otherTab": "Other",
-    "featuredEmpty": "No featured actions yet.",
+    "empty": "No actions yet.",
     "pickAgentFirst": "Pick an agent to see its actions.",
     "skillsLoading": "Loading actions...",
-    "skillsEmpty": "No actions in this category yet."
+    "skillsEmpty": "No actions in this category yet.",
+    "scrollTabsLeft": "Scroll action tabs left",
+    "scrollTabsRight": "Scroll action tabs right"
   }
 }

--- a/app/src/locales/es/dashboard.json
+++ b/app/src/locales/es/dashboard.json
@@ -32,9 +32,11 @@
     "blankDescription": "Abre un chat nuevo y escribe tu propia indicación.",
     "featuredTab": "Destacadas",
     "otherTab": "Otras",
-    "featuredEmpty": "Aún no hay acciones destacadas.",
+    "empty": "Aún no hay acciones.",
     "pickAgentFirst": "Elige un agente para ver sus acciones.",
     "skillsLoading": "Cargando acciones...",
-    "skillsEmpty": "Aún no hay acciones en esta categoría."
+    "skillsEmpty": "Aún no hay acciones en esta categoría.",
+    "scrollTabsLeft": "Desplazar pestañas de acciones a la izquierda",
+    "scrollTabsRight": "Desplazar pestañas de acciones a la derecha"
   }
 }

--- a/app/src/locales/pt/dashboard.json
+++ b/app/src/locales/pt/dashboard.json
@@ -32,9 +32,11 @@
     "blankDescription": "Abra um chat novo e escreva sua própria instrução.",
     "featuredTab": "Em destaque",
     "otherTab": "Outras",
-    "featuredEmpty": "Ainda sem ações em destaque.",
+    "empty": "Ainda sem ações.",
     "pickAgentFirst": "Escolha um agente para ver suas ações.",
     "skillsLoading": "Carregando ações...",
-    "skillsEmpty": "Ainda sem ações nesta categoria."
+    "skillsEmpty": "Ainda sem ações nesta categoria.",
+    "scrollTabsLeft": "Rolar abas de ações para a esquerda",
+    "scrollTabsRight": "Rolar abas de ações para a direita"
   }
 }

--- a/app/tests/new-mission-picker-tab-model.test.ts
+++ b/app/tests/new-mission-picker-tab-model.test.ts
@@ -1,0 +1,74 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  buildActionPickerTabs,
+  FEATURED_ACTIONS_TAB_ID,
+  OTHER_ACTIONS_TAB_ID,
+  resolveActiveActionPickerTab,
+  shouldShowActionPickerTabs,
+} from "../src/components/new-mission-picker-tab-model.ts";
+
+describe("new mission picker tab model", () => {
+  it("omits Featured when no actions are featured", () => {
+    const tabs = buildActionPickerTabs({
+      categoryNames: ["Research"],
+      hasFeatured: false,
+      hasOther: true,
+      featuredLabel: "Featured",
+      otherLabel: "Other",
+    });
+
+    deepStrictEqual(tabs, [
+      { id: "Research", label: "Research" },
+      { id: OTHER_ACTIONS_TAB_ID, label: "Other" },
+    ]);
+  });
+
+  it("keeps Featured first when featured actions exist", () => {
+    const tabs = buildActionPickerTabs({
+      categoryNames: ["Research"],
+      hasFeatured: true,
+      hasOther: false,
+      featuredLabel: "Featured",
+      otherLabel: "Other",
+    });
+
+    deepStrictEqual(tabs, [
+      { id: FEATURED_ACTIONS_TAB_ID, label: "Featured" },
+      { id: "Research", label: "Research" },
+    ]);
+  });
+
+  it("hides the tab bar when only one action tab exists", () => {
+    const tabs = buildActionPickerTabs({
+      categoryNames: ["Research"],
+      hasFeatured: false,
+      hasOther: false,
+      featuredLabel: "Featured",
+      otherLabel: "Other",
+    });
+
+    strictEqual(shouldShowActionPickerTabs(tabs), false);
+  });
+
+  it("shows the tab bar when multiple action tabs exist", () => {
+    const tabs = buildActionPickerTabs({
+      categoryNames: ["Research"],
+      hasFeatured: false,
+      hasOther: true,
+      featuredLabel: "Featured",
+      otherLabel: "Other",
+    });
+
+    strictEqual(shouldShowActionPickerTabs(tabs), true);
+  });
+
+  it("falls back to the first tab when active tab is missing", () => {
+    const tabs = [
+      { id: "Research", label: "Research" },
+      { id: OTHER_ACTIONS_TAB_ID, label: "Other" },
+    ];
+
+    strictEqual(resolveActiveActionPickerTab(tabs, "missing"), "Research");
+  });
+});


### PR DESCRIPTION
## Summary
- Hide the Featured tab when no Actions are featured
- Hide the tab bar when only one Action category is available
- Extract picker list/tab helpers and add focused tab-model coverage

## Tests
- node --experimental-strip-types --test tests/new-mission-picker-tab-model.test.ts
- cd app && pnpm tsc --noEmit
- cd app && pnpm check-locales