### PR TITLE
fix: refresh composio integrations after connect

### DIFF
--- a/app/src/components/tabs/connections-tab.tsx
+++ b/app/src/components/tabs/connections-tab.tsx
@@ -30,7 +30,7 @@ export default function ConnectionsTab(_props: TabProps) {
     setInstallError(null);
     try {
       await tauriConnections.installCli();
-      invalidate();
+      await invalidate();
     } catch (e) {
       setInstallError(String(e));
     } finally {

--- a/app/src/hooks/queries/use-connections.ts
+++ b/app/src/hooks/queries/use-connections.ts
@@ -1,6 +1,7 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriConnections } from "../../lib/tauri";
+import { normalizeToolkitSlugs } from "../../lib/composio-toolkits";
 
 export function useConnections() {
   return useQuery({
@@ -17,7 +18,7 @@ export function useConnections() {
 
 export function useComposioApps() {
   return useQuery({
-    queryKey: ["composio-apps"],
+    queryKey: queryKeys.composioApps(),
     queryFn: () => tauriConnections.listApps(),
     staleTime: 1000 * 60 * 60,
   });
@@ -30,7 +31,8 @@ export function useComposioApps() {
 export function useConnectedToolkits(enabled: boolean) {
   return useQuery({
     queryKey: queryKeys.connectedToolkits(),
-    queryFn: () => tauriConnections.listConnectedToolkits(),
+    queryFn: async () =>
+      normalizeToolkitSlugs(await tauriConnections.listConnectedToolkits()),
     enabled,
     staleTime: 1000 * 60,
     refetchOnWindowFocus: false,
@@ -39,13 +41,27 @@ export function useConnectedToolkits(enabled: boolean) {
 
 export function useInvalidateConnections() {
   const qc = useQueryClient();
-  return () => qc.invalidateQueries({ queryKey: queryKeys.connections() });
+  return async () => {
+    await Promise.all([
+      qc.invalidateQueries({ queryKey: queryKeys.connections() }),
+      qc.invalidateQueries({ queryKey: queryKeys.composioApps() }),
+      qc.invalidateQueries({ queryKey: queryKeys.connectedToolkits() }),
+    ]);
+  };
 }
 
 export function useResetConnections() {
   const qc = useQueryClient();
   return async () => {
-    await qc.cancelQueries({ queryKey: queryKeys.connections() });
+    await Promise.all([
+      qc.cancelQueries({ queryKey: queryKeys.connections() }),
+      qc.cancelQueries({ queryKey: queryKeys.composioApps() }),
+      qc.cancelQueries({ queryKey: queryKeys.connectedToolkits() }),
+    ]);
     await qc.resetQueries({ queryKey: queryKeys.connections() });
+    await Promise.all([
+      qc.invalidateQueries({ queryKey: queryKeys.composioApps() }),
+      qc.invalidateQueries({ queryKey: queryKeys.connectedToolkits() }),
+    ]);
   };
 }

--- a/app/src/hooks/use-agent-invalidation.ts
+++ b/app/src/hooks/use-agent-invalidation.ts
@@ -57,6 +57,8 @@ export function useAgentInvalidation() {
         // Composio CLI became available — refresh integrations state.
         case "ComposioCliReady":
           qc.invalidateQueries({ queryKey: queryKeys.connections() });
+          qc.invalidateQueries({ queryKey: queryKeys.composioApps() });
+          qc.invalidateQueries({ queryKey: queryKeys.connectedToolkits() });
           break;
       }
     });

--- a/app/src/hooks/use-composio-refetch-on-return.ts
+++ b/app/src/hooks/use-composio-refetch-on-return.ts
@@ -3,6 +3,10 @@ import { useQueryClient } from "@tanstack/react-query";
 import { tauriConnections } from "../lib/tauri";
 import { queryKeys } from "../lib/query-keys";
 import { logger } from "../lib/logger";
+import {
+  normalizeToolkitSlug,
+  normalizeToolkitSlugs,
+} from "../lib/composio-toolkits";
 
 /**
  * Shared helper for any surface that initiates a Composio OAuth flow
@@ -43,29 +47,33 @@ export function useComposioRefetchOnReturn(): (slug: string) => void {
 
   return useCallback(
     (slug: string) => {
-      if (!slug) return;
-      if (pollersRef.current.has(slug)) return;
+      const targetSlug = normalizeToolkitSlug(slug);
+      if (!targetSlug) return;
+      if (pollersRef.current.has(targetSlug)) return;
 
-      waitingRef.current.add(slug);
+      waitingRef.current.add(targetSlug);
       let attempts = 0;
       const MAX_ATTEMPTS = 15;
       const INTERVAL_MS = 4000;
 
       const stop = () => {
-        const handle = pollersRef.current.get(slug);
+        const handle = pollersRef.current.get(targetSlug);
         if (handle !== undefined) {
           window.clearInterval(handle);
-          pollersRef.current.delete(slug);
+          pollersRef.current.delete(targetSlug);
         }
-        waitingRef.current.delete(slug);
+        waitingRef.current.delete(targetSlug);
       };
 
       const tick = async () => {
         attempts += 1;
         try {
-          const connected = await tauriConnections.listConnectedToolkits();
-          if (connected.includes(slug)) {
-            qc.invalidateQueries({
+          const connected = normalizeToolkitSlugs(
+            await tauriConnections.listConnectedToolkits(),
+          );
+          if (connected.includes(targetSlug)) {
+            qc.setQueryData(queryKeys.connectedToolkits(), connected);
+            await qc.invalidateQueries({
               queryKey: queryKeys.connectedToolkits(),
             });
             stop();
@@ -73,7 +81,7 @@ export function useComposioRefetchOnReturn(): (slug: string) => void {
           }
         } catch (e) {
           logger.warn(
-            `[composio] poll for ${slug} failed: ${String(e)}`,
+            `[composio] poll for ${targetSlug} failed: ${String(e)}`,
           );
         }
         if (attempts >= MAX_ATTEMPTS) {
@@ -82,7 +90,7 @@ export function useComposioRefetchOnReturn(): (slug: string) => void {
       };
 
       const handle = window.setInterval(tick, INTERVAL_MS);
-      pollersRef.current.set(slug, handle);
+      pollersRef.current.set(targetSlug, handle);
       void tick();
     },
     [qc],

--- a/app/src/lib/composio-toolkits.test.mjs
+++ b/app/src/lib/composio-toolkits.test.mjs
@@ -1,0 +1,17 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  normalizeToolkitSlug,
+  normalizeToolkitSlugs,
+} from "./composio-toolkits.ts";
+
+test("normalizes toolkit slugs for query matching", () => {
+  assert.equal(normalizeToolkitSlug(" POSTHOG "), "posthog");
+});
+
+test("dedupes and sorts connected toolkit slugs", () => {
+  assert.deepEqual(
+    normalizeToolkitSlugs(["GMAIL", "posthog", "gmail", "", " PostHog "]),
+    ["gmail", "posthog"],
+  );
+});

--- a/app/src/lib/composio-toolkits.ts
+++ b/app/src/lib/composio-toolkits.ts
@@ -1,0 +1,13 @@
+export function normalizeToolkitSlug(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
+export function normalizeToolkitSlugs(slugs: string[]): string[] {
+  return Array.from(
+    new Set(
+      slugs
+        .map(normalizeToolkitSlug)
+        .filter((slug) => slug.length > 0),
+    ),
+  ).sort();
+}

--- a/app/src/lib/query-keys.ts
+++ b/app/src/lib/query-keys.ts
@@ -30,5 +30,6 @@ export const queryKeys = {
 
   // App-scoped (less reactive, loaded on init)
   connections: () => ["connections"] as const,
+  composioApps: () => ["composio-apps"] as const,
   connectedToolkits: () => ["connected-toolkits"] as const,
 };

--- a/engine/houston-composio/src/apps.rs
+++ b/engine/houston-composio/src/apps.rs
@@ -5,6 +5,8 @@
 
 use serde::{Deserialize, Serialize};
 
+use crate::toolkits::normalize_toolkit_slug;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ComposioAppEntry {
     pub toolkit: String,
@@ -119,11 +121,10 @@ fn parse_toolkits(body: &serde_json::Value) -> Result<Vec<ComposioAppEntry>, Str
 
     let mut apps = Vec::with_capacity(items.len());
     for item in items {
-        let slug = item
+        let slug = normalize_toolkit_slug(item
             .get("slug")
             .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_string();
+            .unwrap_or_default());
         if slug.is_empty() {
             continue;
         }

--- a/engine/houston-composio/src/commands.rs
+++ b/engine/houston-composio/src/commands.rs
@@ -9,6 +9,7 @@
 
 use crate::cli::{self, ComposioStatus, StartLinkResponse, StartLoginResponse};
 use crate::install;
+use crate::toolkits::normalize_toolkit_slugs;
 
 /// Current state of Houston's composio integration.
 pub async fn list_composio_connections() -> ComposioStatus {
@@ -48,5 +49,5 @@ pub async fn list_composio_apps() -> Vec<crate::apps::ComposioAppEntry> {
 
 /// List all connected toolkit slugs in the consumer namespace.
 pub async fn list_composio_connected_toolkits() -> Vec<String> {
-    cli::list_connected_toolkits().await
+    normalize_toolkit_slugs(cli::list_connected_toolkits().await)
 }

--- a/engine/houston-composio/src/lib.rs
+++ b/engine/houston-composio/src/lib.rs
@@ -11,3 +11,4 @@ pub mod commands;
 pub mod install;
 pub mod lifecycle;
 pub mod mcp;
+pub mod toolkits;

--- a/engine/houston-composio/src/toolkits.rs
+++ b/engine/houston-composio/src/toolkits.rs
@@ -1,0 +1,38 @@
+pub fn normalize_toolkit_slug(slug: &str) -> String {
+    slug.trim().to_ascii_lowercase()
+}
+
+pub fn normalize_toolkit_slugs(slugs: Vec<String>) -> Vec<String> {
+    let mut normalized = slugs
+        .into_iter()
+        .map(|slug| normalize_toolkit_slug(&slug))
+        .filter(|slug| !slug.is_empty())
+        .collect::<Vec<_>>();
+    normalized.sort();
+    normalized.dedup();
+    normalized
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalizes_toolkit_slug() {
+        assert_eq!(normalize_toolkit_slug(" POSTHOG "), "posthog");
+    }
+
+    #[test]
+    fn normalizes_dedupes_and_sorts_toolkit_slugs() {
+        assert_eq!(
+            normalize_toolkit_slugs(vec![
+                "GMAIL".into(),
+                "posthog".into(),
+                "gmail".into(),
+                "".into(),
+                " PostHog ".into(),
+            ]),
+            vec!["gmail", "posthog"]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- refresh Composio status, app catalog, and connected toolkit queries after first login and CLI readiness
- update connected app polling to write normalized connected toolkit data into TanStack Query immediately
- normalize toolkit slugs in app and engine with focused tests

## Verification
- cd app && pnpm tsc --noEmit
- cd app && pnpm check-locales
- node --experimental-strip-types --test app/src/lib/composio-toolkits.test.mjs
- cargo build -p houston-engine-server
- cargo test -p houston-composio toolkits
- cargo test --workspace