### PR TITLE
fix: make provider model menus scroll

### DIFF
--- a/app/src/components/shell/naming-step.tsx
+++ b/app/src/components/shell/naming-step.tsx
@@ -228,7 +228,7 @@ function InlineModelSelector({
       </button>
 
       {open && (
-        <div className="mt-2 rounded-xl border border-border bg-card p-1 space-y-0.5">
+        <div className="mt-2 max-h-72 overflow-y-auto overscroll-contain rounded-xl border border-border bg-card p-1 space-y-0.5">
           {PROVIDERS.map((prov) => {
             const status = statuses[prov.id];
             const connected = (status?.cli_installed && status?.authenticated) ?? false;

--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -239,7 +239,13 @@ function ProviderCard({
                 <ChevronDown className="size-3 text-muted-foreground" />
               </Button>
             </DropdownMenuTrigger>
-            <DropdownMenuContent align="center" className="w-64">
+            <DropdownMenuContent
+              align="center"
+              className="w-64 overscroll-contain"
+              style={{
+                maxHeight: "min(22rem, var(--radix-dropdown-menu-content-available-height, 22rem))",
+              }}
+            >
               <DropdownMenuLabel className="text-xs text-muted-foreground font-normal">
                 {t("card.modelDropdownLabel")}
               </DropdownMenuLabel>


### PR DESCRIPTION
## Summary
- cap the provider-card model dropdown height so long model lists can scroll
- add the same scroll behavior to the new-agent inline model selector

## Tests
- cd app && pnpm run typecheck
- cd app && pnpm run check-locales
- cd app && pnpm run build