### PR TITLE
fix: stabilize OpenAI reconnect state

### DIFF
--- a/app/src/components/shell/provider-reconnect-card.tsx
+++ b/app/src/components/shell/provider-reconnect-card.tsx
@@ -20,10 +20,11 @@ export function ProviderReconnectCard({
   const [loginLaunched, setLoginLaunched] = useState(false);
   const [loginError, setLoginError] = useState(false);
   const [resolvedSignal, setResolvedSignal] = useState<string | null>(null);
+  const [signalNeedsAuth, setSignalNeedsAuth] = useState(false);
 
-  const activeProviderId = authRequired ?? (
-    signalKey && signalKey !== resolvedSignal ? providerId : null
-  );
+  const shouldCheckSignal =
+    !authRequired && !!providerId && !!signalKey && signalKey !== resolvedSignal;
+  const activeProviderId = authRequired ?? (signalNeedsAuth ? providerId : null);
   const provider = activeProviderId ? getProvider(activeProviderId) : null;
 
   useEffect(() => {
@@ -32,10 +33,33 @@ export function ProviderReconnectCard({
   }, [activeProviderId, authRequired, providerId, signalKey]);
 
   useEffect(() => {
+    setSignalNeedsAuth(false);
+    if (!shouldCheckSignal || !providerId || !signalKey) return;
+    let cancelled = false;
+    tauriProvider.checkStatus(providerId)
+      .then((status) => {
+        if (cancelled) return;
+        if (status.cli_installed && status.authenticated) {
+          setResolvedSignal(signalKey);
+        } else {
+          setSignalNeedsAuth(true);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setSignalNeedsAuth(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [providerId, shouldCheckSignal, signalKey]);
+
+  useEffect(() => {
     if (!activeProviderId) return;
-    const interval = setInterval(async () => {
+    let cancelled = false;
+    const check = async () => {
       try {
         const status = await tauriProvider.checkStatus(activeProviderId);
+        if (cancelled) return;
         if (status.cli_installed && status.authenticated) {
           setAuthRequired(null);
           if (signalKey) setResolvedSignal(signalKey);
@@ -44,8 +68,13 @@ export function ProviderReconnectCard({
       } catch {
         // Keep the reconnect card visible; the next poll may succeed.
       }
-    }, 3000);
-    return () => clearInterval(interval);
+    };
+    void check();
+    const interval = setInterval(check, 3000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
   }, [activeProviderId, signalKey, setAuthRequired]);
 
   const handleSignIn = useCallback(async () => {

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -31,6 +31,23 @@ pub struct PersistOptions {
     pub claude_session_id: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AuthFeedAction {
+    None,
+    DeferUntilExit,
+    RequireNow,
+}
+
+fn classify_auth_feed_message(provider: Provider, message: &str) -> AuthFeedAction {
+    if is_auth_retry_marker(message) {
+        AuthFeedAction::DeferUntilExit
+    } else if is_auth_error(message) || is_opaque_claude_auth_error(provider, message) {
+        AuthFeedAction::RequireNow
+    } else {
+        AuthFeedAction::None
+    }
+}
+
 /// Spawn a Claude session, emit events, optionally persist feed items, and return
 /// a JoinHandle that resolves to the final response.
 ///
@@ -105,44 +122,53 @@ pub fn spawn_and_monitor(
                     //      retry loop prints "Reconnecting...".
                     //   3. `not authenticated` / stderr-dumped auth errors.
                     //
-                    // All three are auth noise, not user-visible content. We
-                    // suppress the raw message, emit AuthRequired once, and
-                    // emit "Checking connection..." exactly once.
+                    // All three are auth noise, not user-visible content.
+                    // Retry markers are provisional: Codex may refresh and
+                    // recover, so only remember them and wait for session
+                    // exit. Terminal auth messages emit AuthRequired once
+                    // and emit "Checking connection..." exactly once.
                     if let FeedItem::SystemMessage(msg) = item {
-                        let is_auth_noise = is_auth_retry_marker(msg)
-                            || is_auth_error(msg)
-                            || is_opaque_claude_auth_error(provider_kind, msg);
-                        if is_auth_noise {
-                            saw_auth_error = true;
-                            if !sent_auth_required {
-                                sent_auth_required = true;
+                        match classify_auth_feed_message(provider_kind, msg) {
+                            AuthFeedAction::None => {}
+                            AuthFeedAction::DeferUntilExit => {
+                                saw_auth_error = true;
                                 tracing::info!(
-                                    "[session_runner] emitting AuthRequired for provider={provider_str} from feed"
+                                    "[session_runner] auth retry marker detected — deferring AuthRequired until session exit"
                                 );
-                                sink.emit(HoustonEvent::AuthRequired {
-                                    provider: provider_str.clone(),
-                                    message: msg.clone(),
-                                });
+                                continue;
                             }
-                            if !sent_auth_checking {
-                                sent_auth_checking = true;
-                                tracing::info!(
-                                    "[session_runner] auth issue detected ({msg:?}) — emitting Checking connection..."
-                                );
-                                sink.emit(HoustonEvent::FeedItem {
-                                    agent_path: agent_path_for_events.clone(),
-                                    session_key: key.clone(),
-                                    item: FeedItem::SystemMessage(
-                                        "Checking connection...".to_string(),
-                                    ),
-                                });
-                            } else {
-                                tracing::debug!(
-                                    "[session_runner] additional auth noise suppressed: {msg:?}"
-                                );
+                            AuthFeedAction::RequireNow => {
+                                saw_auth_error = true;
+                                if !sent_auth_required {
+                                    sent_auth_required = true;
+                                    tracing::info!(
+                                        "[session_runner] emitting AuthRequired for provider={provider_str} from feed"
+                                    );
+                                    sink.emit(HoustonEvent::AuthRequired {
+                                        provider: provider_str.clone(),
+                                        message: msg.clone(),
+                                    });
+                                }
+                                if !sent_auth_checking {
+                                    sent_auth_checking = true;
+                                    tracing::info!(
+                                        "[session_runner] auth issue detected ({msg:?}) — emitting Checking connection..."
+                                    );
+                                    sink.emit(HoustonEvent::FeedItem {
+                                        agent_path: agent_path_for_events.clone(),
+                                        session_key: key.clone(),
+                                        item: FeedItem::SystemMessage(
+                                            "Checking connection...".to_string(),
+                                        ),
+                                    });
+                                } else {
+                                    tracing::debug!(
+                                        "[session_runner] additional auth noise suppressed: {msg:?}"
+                                    );
+                                }
+                                // Skip persisting and emitting the raw message.
+                                continue;
                             }
-                            // Skip persisting and emitting the raw message.
-                            continue;
                         }
                     }
                     sink.emit(HoustonEvent::FeedItem {
@@ -327,5 +353,24 @@ mod tests {
             Provider::OpenAI,
             "Error: Unknown error"
         ));
+    }
+
+    #[test]
+    fn codex_retry_marker_defers_auth_required_until_exit() {
+        assert_eq!(
+            classify_auth_feed_message(Provider::OpenAI, "__auth_retry__"),
+            AuthFeedAction::DeferUntilExit
+        );
+    }
+
+    #[test]
+    fn codex_terminal_auth_message_requires_auth_now() {
+        assert_eq!(
+            classify_auth_feed_message(
+                Provider::OpenAI,
+                "Error: unexpected status 401 Unauthorized: Missing bearer"
+            ),
+            AuthFeedAction::RequireNow
+        );
     }
 }

--- a/engine/houston-engine-core/src/provider.rs
+++ b/engine/houston-engine-core/src/provider.rs
@@ -211,9 +211,9 @@ async fn check_claude_auth(cli_path: &std::path::Path) -> bool {
 async fn check_codex_status() -> ProviderStatus {
     let (install_source, cli_path) = resolve_codex();
     let cli_installed = !matches!(install_source, InstallSource::Missing);
-    let authenticated = if cli_installed {
+    let authenticated = if let Some(path) = cli_path.as_deref() {
         let home = std::env::var("HOME").unwrap_or_default();
-        if check_codex_auth(&home) {
+        if check_codex_auth(path, &home).await {
             ensure_codex_fallback_config(&home);
             true
         } else {
@@ -272,7 +272,63 @@ fn which_on_path(command: &str) -> Option<PathBuf> {
     None
 }
 
-fn check_codex_auth(home: &str) -> bool {
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexAuthProbe {
+    Authenticated,
+    Unauthenticated,
+    Unknown,
+}
+
+async fn check_codex_auth(cli_path: &std::path::Path, home: &str) -> bool {
+    match probe_codex_login_status(cli_path).await {
+        CodexAuthProbe::Authenticated => true,
+        CodexAuthProbe::Unauthenticated => false,
+        CodexAuthProbe::Unknown => check_codex_auth_file(home),
+    }
+}
+
+async fn probe_codex_login_status(cli_path: &std::path::Path) -> CodexAuthProbe {
+    let shell_path = claude_path::shell_path();
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        tokio::process::Command::new(cli_path)
+            .args(["login", "status", "-c", "model_reasoning_effort=high"])
+            .env("PATH", &shell_path)
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await;
+
+    let output = match result {
+        Ok(Ok(o)) => o,
+        _ => return CodexAuthProbe::Unknown,
+    };
+    classify_codex_login_status_output(
+        output.status.success(),
+        &String::from_utf8_lossy(&output.stdout),
+        &String::from_utf8_lossy(&output.stderr),
+    )
+}
+
+fn classify_codex_login_status_output(success: bool, stdout: &str, stderr: &str) -> CodexAuthProbe {
+    let text = format!("{stdout}\n{stderr}").to_lowercase();
+    if text.contains("not logged in")
+        || text.contains("not authenticated")
+        || text.contains("please login")
+        || text.contains("please log in")
+        || text.contains("signed out")
+        || text.contains("no auth credentials")
+        || text.contains("run codex login")
+    {
+        return CodexAuthProbe::Unauthenticated;
+    }
+    if success && (text.contains("logged in") || text.contains("authenticated")) {
+        return CodexAuthProbe::Authenticated;
+    }
+    CodexAuthProbe::Unknown
+}
+
+fn check_codex_auth_file(home: &str) -> bool {
     let auth_path = PathBuf::from(home).join(".codex").join("auth.json");
     let content = match std::fs::read_to_string(&auth_path) {
         Ok(c) => c,
@@ -354,5 +410,24 @@ mod tests {
         assert_eq!(command.cli_name, "claude");
         assert_eq!(command.path, path);
         assert_eq!(command.args, vec!["auth", "login", "--claudeai"]);
+    }
+
+    #[test]
+    fn codex_login_status_classifies_logged_in_output() {
+        let status = classify_codex_login_status_output(true, "Logged in using ChatGPT", "");
+        assert_eq!(status, CodexAuthProbe::Authenticated);
+    }
+
+    #[test]
+    fn codex_login_status_classifies_not_logged_in_output_first() {
+        let status = classify_codex_login_status_output(true, "Not logged in", "");
+        assert_eq!(status, CodexAuthProbe::Unauthenticated);
+    }
+
+    #[test]
+    fn codex_login_status_falls_back_on_config_errors() {
+        let stderr = "Error loading configuration: unknown variant `xhigh`";
+        let status = classify_codex_login_status_output(false, "", stderr);
+        assert_eq!(status, CodexAuthProbe::Unknown);
     }
 }

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -110,3 +110,14 @@ expired OAuth/API-key messages) and `houston-agents-conversations` emits
 `ChatPanel.afterMessages`. The card opens `claude auth login --claudeai` or
 `codex login` through `/v1/providers/:name/login` and polls provider status
 until the CLI reports authenticated.
+
+Codex has one extra wrinkle: it can emit retry-shaped 401 messages while it
+refreshes or reconnects, then continue successfully. Treat the synthetic
+`__auth_retry__` marker as provisional. Suppress it, remember it, and emit
+`AuthRequired` only if the session exits with an auth-flavored error. Terminal
+401 / unauthenticated messages still emit `AuthRequired` immediately.
+
+OpenAI provider status should prefer `codex login status` over shallow
+`~/.codex/auth.json` parsing. Keep the auth-file check only as fallback for old
+Codex versions or unrelated config-load failures, because config drift should
+not look like sign-out.


### PR DESCRIPTION
## Summary
- defer Codex retry auth markers until the session actually exits with auth failure
- make OpenAI provider status prefer real codex login status over shallow auth-file checks
- verify stale auth feed signals before rendering the reconnect card
- document Codex provider reauth behavior

## Tests
- cargo test --workspace
- cd app && pnpm build
- cd app && pnpm check-locales