### PR TITLE
fix: recover from missing Codex resume rollouts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,6 +2377,7 @@ dependencies = [
  "houston-ui-events",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
 ]

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -14,3 +14,6 @@ tracing = { workspace = true }
 houston-terminal-manager = { workspace = true }
 houston-db = { workspace = true }
 houston-ui-events = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3"

--- a/engine/houston-agents-conversations/src/lib.rs
+++ b/engine/houston-agents-conversations/src/lib.rs
@@ -4,10 +4,10 @@
 //! command layer. Responsibilities:
 //!
 //! - `session_runner` — spawn a CLI session, stream updates, emit UI events,
-//!   optionally persist feed items to the database, track the Claude session
-//!   ID for `--resume`.
-//! - `session_id_tracker` — per-conversation Claude session ID registry with
-//!   disk persistence (`.houston/sessions/{key}.sid`).
+//!   optionally persist feed items to the database, track the provider resume
+//!   ID.
+//! - `session_id_tracker` — per-conversation provider resume ID registry with
+//!   disk persistence (`.houston/sessions/{provider}/{key}.sid`).
 //! - `session_pids` — map of `session_key → pid` so stop requests can kill
 //!   the right subprocess.
 //! - `supervisor` — panic-isolating wrapper so one session crashing doesn't

--- a/engine/houston-agents-conversations/src/session_id_tracker.rs
+++ b/engine/houston-agents-conversations/src/session_id_tracker.rs
@@ -1,54 +1,137 @@
-//! Tracks Claude CLI session IDs per `(agent_dir, session_key)` pair so
-//! `--resume` continues the right conversation across turns and app restarts.
+//! Tracks provider CLI session IDs per `(agent_dir, provider, session_key)` pair
+//! so resume continues the right conversation across turns and app restarts.
 //!
-//! Each handle owns its disk path: setting a new ID updates the in-memory
-//! slot AND persists to `.houston/sessions/{session_key}.sid` under the
-//! agent directory. No shared "main" session file — every conversation is
-//! independently scoped.
+//! Current IDs are provider-scoped under `.houston/sessions/{provider}/`.
+//! The legacy flat `.houston/sessions/{session_key}.sid` path is still read as a
+//! fallback for existing user data.
 
-use std::collections::HashMap;
+use houston_terminal_manager::Provider;
+use std::collections::{HashMap, HashSet};
+use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 
-/// Return the disk path where a given session_key's Claude session ID is persisted.
-pub fn session_id_path(agent_dir: &Path, session_key: &str) -> PathBuf {
+const PROVIDERS: [Provider; 2] = [Provider::Anthropic, Provider::OpenAI];
+
+fn sessions_dir(agent_dir: &Path) -> PathBuf {
+    agent_dir.join(".houston").join("sessions")
+}
+
+/// Return the legacy flat path where older Houston versions persisted a resume ID.
+pub fn legacy_session_id_path(agent_dir: &Path, session_key: &str) -> PathBuf {
     agent_dir
         .join(".houston")
         .join("sessions")
         .join(format!("{session_key}.sid"))
 }
 
-/// Handle to a single conversation's Claude session ID. Cheap to clone.
-/// Setting a new ID persists to disk atomically.
+/// Return the current provider-scoped resume ID path for a conversation.
+pub fn session_id_path(agent_dir: &Path, provider: Provider, session_key: &str) -> PathBuf {
+    sessions_dir(agent_dir)
+        .join(provider.to_string())
+        .join(format!("{session_key}.sid"))
+}
+
+/// Return the provider-scoped history list path for a conversation.
+pub fn session_history_path(agent_dir: &Path, provider: Provider, session_key: &str) -> PathBuf {
+    sessions_dir(agent_dir)
+        .join(provider.to_string())
+        .join(format!("{session_key}.history"))
+}
+
+fn session_invalid_path(agent_dir: &Path, provider: Provider, session_key: &str) -> PathBuf {
+    sessions_dir(agent_dir)
+        .join(provider.to_string())
+        .join(format!("{session_key}.invalid"))
+}
+
+/// Return every known resume ID for a session key, across legacy and
+/// provider-scoped current/history files. Used for DB-backed chat history.
+pub fn session_ids_for_history(agent_dir: &Path, session_key: &str) -> Vec<String> {
+    let mut ids = Vec::new();
+    let mut seen = HashSet::new();
+
+    push_unique_file_id(
+        &mut ids,
+        &mut seen,
+        &legacy_session_id_path(agent_dir, session_key),
+    );
+
+    for provider in PROVIDERS {
+        push_unique_file_id(
+            &mut ids,
+            &mut seen,
+            &session_id_path(agent_dir, provider, session_key),
+        );
+        for id in read_history_ids(&session_history_path(agent_dir, provider, session_key)) {
+            push_unique_id(&mut ids, &mut seen, id);
+        }
+    }
+
+    ids
+}
+
+/// Handle to a single conversation's provider resume ID. Cheap to clone.
+/// Setting a new ID persists to disk and records it in provider history.
 #[derive(Clone)]
 pub struct SessionIdHandle {
     id: Arc<Mutex<Option<String>>>,
     sid_path: PathBuf,
+    history_path: PathBuf,
+    invalid_path: PathBuf,
 }
 
 impl SessionIdHandle {
-    /// Get the current session ID for resuming.
+    /// Get the current resume ID.
     pub async fn get(&self) -> Option<String> {
         self.id.lock().await.clone()
     }
 
-    /// Store a new session ID and persist to disk so `--resume` survives app restarts.
+    /// Store a new resume ID and persist it so resume survives app restarts.
     pub async fn set(&self, id: String) {
         *self.id.lock().await = Some(id.clone());
-        if let Some(parent) = self.sid_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
+        if let Err(e) = write_atomic(&self.sid_path, &id) {
+            tracing::warn!(
+                path = %self.sid_path.display(),
+                error = %e,
+                "failed to persist session id"
+            );
         }
-        let _ = std::fs::write(&self.sid_path, &id);
+        append_history_id(&self.history_path, &id);
     }
 
-    /// Clear the session ID (e.g. on conversation reset). Does not remove the disk file.
+    /// Clear the in-memory resume ID. Does not remove the disk file.
     pub async fn clear(&self) {
         *self.id.lock().await = None;
     }
+
+    /// Clear the current provider-scoped resume ID after the CLI rejects it,
+    /// while keeping it in history so already-persisted chat rows remain visible.
+    pub async fn clear_current_preserving_history(&self) {
+        let current = self.id.lock().await.take();
+        let current = current.or_else(|| read_trimmed_file(&self.sid_path));
+        if let Some(id) = current {
+            append_history_id(&self.history_path, &id);
+            append_history_id(&self.invalid_path, &id);
+        }
+
+        match fs::remove_file(&self.sid_path) {
+            Ok(()) => {}
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {}
+            Err(e) => {
+                tracing::warn!(
+                    path = %self.sid_path.display(),
+                    error = %e,
+                    "failed to remove invalid session id"
+                );
+            }
+        }
+    }
 }
 
-/// Managed Tauri state: one `SessionIdHandle` per `(agent_dir, session_key)`.
+/// Managed state: one `SessionIdHandle` per `(agent_dir, provider, session_key)`.
 /// Lazy-loads persisted IDs from disk on first access.
 #[derive(Default, Clone)]
 pub struct SessionIdTracker {
@@ -56,17 +139,18 @@ pub struct SessionIdTracker {
 }
 
 impl SessionIdTracker {
-    /// Get (or lazily create) the handle for a given conversation.
+    /// Get (or lazily create) the provider-scoped handle for a conversation.
     ///
-    /// `agent_key` is a unique identifier combining agent + session
-    /// (e.g. `"{agent_dir}:{session_key}"`).
-    /// `agent_dir` is the expanded agent filesystem path — where
-    /// `.houston/sessions/{session_key}.sid` is stored.
+    /// `agent_key` is a unique identifier combining agent + provider + session
+    /// (e.g. `"{agent_dir}:{provider}:{session_key}"`).
+    /// `agent_dir` is the expanded agent filesystem path where
+    /// `.houston/sessions/{provider}/{session_key}.sid` is stored.
     pub async fn get_for_session(
         &self,
         agent_key: &str,
         agent_dir: &Path,
         session_key: &str,
+        provider: Provider,
     ) -> SessionIdHandle {
         // Fast path: already in memory.
         {
@@ -77,21 +161,30 @@ impl SessionIdTracker {
         }
 
         // Slow path: create handle and try to load the persisted ID from disk.
-        let sid_path = session_id_path(agent_dir, session_key);
-        let initial = std::fs::read_to_string(&sid_path)
-            .ok()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty());
+        let sid_path = session_id_path(agent_dir, provider, session_key);
+        let history_path = session_history_path(agent_dir, provider, session_key);
+        let invalid_path = session_invalid_path(agent_dir, provider, session_key);
+        let initial = read_trimmed_file(&sid_path).or_else(|| {
+            let legacy = read_trimmed_file(&legacy_session_id_path(agent_dir, session_key))?;
+            if read_history_ids(&invalid_path)
+                .iter()
+                .any(|invalid| invalid == &legacy)
+            {
+                None
+            } else {
+                Some(legacy)
+            }
+        });
 
         let handle = SessionIdHandle {
             id: Arc::new(Mutex::new(initial)),
             sid_path,
+            history_path,
+            invalid_path,
         };
 
         let mut map = self.inner.write().await;
-        map.entry(agent_key.to_string())
-            .or_insert(handle)
-            .clone()
+        map.entry(agent_key.to_string()).or_insert(handle).clone()
     }
 
     /// Remove in-memory handles for a deleted agent.
@@ -99,5 +192,237 @@ impl SessionIdTracker {
     pub async fn remove_agent(&self, agent_key_prefix: &str) {
         let mut map = self.inner.write().await;
         map.retain(|k, _| !k.starts_with(agent_key_prefix));
+    }
+}
+
+fn push_unique_file_id(ids: &mut Vec<String>, seen: &mut HashSet<String>, path: &Path) {
+    if let Some(id) = read_trimmed_file(path) {
+        push_unique_id(ids, seen, id);
+    }
+}
+
+fn push_unique_id(ids: &mut Vec<String>, seen: &mut HashSet<String>, id: String) {
+    let id = id.trim().to_string();
+    if id.is_empty() || !seen.insert(id.clone()) {
+        return;
+    }
+    ids.push(id);
+}
+
+fn read_trimmed_file(path: &Path) -> Option<String> {
+    match fs::read_to_string(path) {
+        Ok(body) => {
+            let value = body.trim().to_string();
+            (!value.is_empty()).then_some(value)
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => None,
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "failed to read session id file"
+            );
+            None
+        }
+    }
+}
+
+fn read_history_ids(path: &Path) -> Vec<String> {
+    match fs::read_to_string(path) {
+        Ok(body) => {
+            let mut ids = Vec::new();
+            let mut seen = HashSet::new();
+            for line in body.lines() {
+                push_unique_id(&mut ids, &mut seen, line.to_string());
+            }
+            ids
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Vec::new(),
+        Err(e) => {
+            tracing::warn!(
+                path = %path.display(),
+                error = %e,
+                "failed to read session history file"
+            );
+            Vec::new()
+        }
+    }
+}
+
+fn append_history_id(path: &Path, id: &str) {
+    let id = id.trim();
+    if id.is_empty() {
+        return;
+    }
+
+    let mut ids = read_history_ids(path);
+    if ids.iter().any(|existing| existing == id) {
+        return;
+    }
+    ids.push(id.to_string());
+
+    let mut body = ids.join("\n");
+    body.push('\n');
+    if let Err(e) = write_atomic(path, &body) {
+        tracing::warn!(
+            path = %path.display(),
+            error = %e,
+            "failed to persist session history"
+        );
+    }
+}
+
+fn write_atomic(path: &Path, content: &str) -> io::Result<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file_name = path
+        .file_name()
+        .map(|name| name.to_string_lossy().to_string())
+        .unwrap_or_else(|| "session".to_string());
+    let tmp_path = path.with_file_name(format!("{file_name}.tmp"));
+    fs::write(&tmp_path, content)?;
+    fs::rename(tmp_path, path)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn write_file(path: &Path, body: &str) {
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(path, body).unwrap();
+    }
+
+    #[test]
+    fn provider_paths_are_distinct() {
+        let dir = TempDir::new().unwrap();
+
+        let anthropic = session_id_path(dir.path(), Provider::Anthropic, "chat");
+        let openai = session_id_path(dir.path(), Provider::OpenAI, "chat");
+
+        assert_ne!(anthropic, openai);
+        assert!(anthropic.ends_with(".houston/sessions/anthropic/chat.sid"));
+        assert!(openai.ends_with(".houston/sessions/openai/chat.sid"));
+    }
+
+    #[tokio::test]
+    async fn legacy_sid_falls_back_for_provider() {
+        let dir = TempDir::new().unwrap();
+        write_file(&legacy_session_id_path(dir.path(), "chat"), "legacy-id\n");
+
+        let tracker = SessionIdTracker::default();
+        let handle = tracker
+            .get_for_session("agent:openai:chat", dir.path(), "chat", Provider::OpenAI)
+            .await;
+
+        assert_eq!(handle.get().await, Some("legacy-id".to_string()));
+    }
+
+    #[tokio::test]
+    async fn set_writes_provider_sid_and_history() {
+        let dir = TempDir::new().unwrap();
+        let tracker = SessionIdTracker::default();
+        let handle = tracker
+            .get_for_session("agent:openai:chat", dir.path(), "chat", Provider::OpenAI)
+            .await;
+
+        handle.set("openai-id".to_string()).await;
+        handle.set("openai-id".to_string()).await;
+
+        let sid =
+            fs::read_to_string(session_id_path(dir.path(), Provider::OpenAI, "chat")).unwrap();
+        let history =
+            fs::read_to_string(session_history_path(dir.path(), Provider::OpenAI, "chat")).unwrap();
+
+        assert_eq!(sid, "openai-id");
+        assert_eq!(history, "openai-id\n");
+        assert!(!legacy_session_id_path(dir.path(), "chat").exists());
+    }
+
+    #[tokio::test]
+    async fn clear_current_preserving_history_removes_only_current_sid() {
+        let dir = TempDir::new().unwrap();
+        let tracker = SessionIdTracker::default();
+        let handle = tracker
+            .get_for_session("agent:openai:chat", dir.path(), "chat", Provider::OpenAI)
+            .await;
+
+        handle.set("bad-id".to_string()).await;
+        handle.clear_current_preserving_history().await;
+
+        assert_eq!(handle.get().await, None);
+        assert!(!session_id_path(dir.path(), Provider::OpenAI, "chat").exists());
+        let history =
+            fs::read_to_string(session_history_path(dir.path(), Provider::OpenAI, "chat")).unwrap();
+        let invalid =
+            fs::read_to_string(session_invalid_path(dir.path(), Provider::OpenAI, "chat")).unwrap();
+        assert_eq!(history, "bad-id\n");
+        assert_eq!(invalid, "bad-id\n");
+    }
+
+    #[tokio::test]
+    async fn invalid_legacy_sid_does_not_fallback_again_for_same_provider() {
+        let dir = TempDir::new().unwrap();
+        write_file(&legacy_session_id_path(dir.path(), "chat"), "legacy-id\n");
+
+        let tracker = SessionIdTracker::default();
+        let handle = tracker
+            .get_for_session("agent:openai:chat", dir.path(), "chat", Provider::OpenAI)
+            .await;
+        assert_eq!(handle.get().await, Some("legacy-id".to_string()));
+
+        handle.clear_current_preserving_history().await;
+
+        let restarted_tracker = SessionIdTracker::default();
+        let openai_handle = restarted_tracker
+            .get_for_session("agent:openai:chat", dir.path(), "chat", Provider::OpenAI)
+            .await;
+        let anthropic_handle = restarted_tracker
+            .get_for_session(
+                "agent:anthropic:chat",
+                dir.path(),
+                "chat",
+                Provider::Anthropic,
+            )
+            .await;
+
+        assert_eq!(openai_handle.get().await, None);
+        assert_eq!(anthropic_handle.get().await, Some("legacy-id".to_string()));
+    }
+
+    #[test]
+    fn session_ids_for_history_reads_legacy_current_and_history_once() {
+        let dir = TempDir::new().unwrap();
+        write_file(&legacy_session_id_path(dir.path(), "chat"), "legacy\n");
+        write_file(
+            &session_id_path(dir.path(), Provider::Anthropic, "chat"),
+            "claude-current\n",
+        );
+        write_file(
+            &session_id_path(dir.path(), Provider::OpenAI, "chat"),
+            "codex-current\n",
+        );
+        write_file(
+            &session_history_path(dir.path(), Provider::Anthropic, "chat"),
+            "legacy\nclaude-old\n",
+        );
+        write_file(
+            &session_history_path(dir.path(), Provider::OpenAI, "chat"),
+            "codex-old\ncodex-current\n",
+        );
+
+        assert_eq!(
+            session_ids_for_history(dir.path(), "chat"),
+            vec![
+                "legacy".to_string(),
+                "claude-current".to_string(),
+                "claude-old".to_string(),
+                "codex-current".to_string(),
+                "codex-old".to_string(),
+            ]
+        );
     }
 }

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -23,7 +23,7 @@ pub struct SessionResult {
 pub struct PersistOptions {
     pub db: Database,
     pub source: String,
-    /// The user message that started this turn. Persisted once the Claude
+    /// The user message that started this turn. Persisted once the provider
     /// session ID is known. Runner consumes this on SessionUpdate::SessionId.
     pub user_message: Option<String>,
     /// Set automatically once the session reports its ID via
@@ -48,7 +48,7 @@ fn classify_auth_feed_message(provider: Provider, message: &str) -> AuthFeedActi
     }
 }
 
-/// Spawn a Claude session, emit events, optionally persist feed items, and return
+/// Spawn a provider session, emit events, optionally persist feed items, and return
 /// a JoinHandle that resolves to the final response.
 ///
 /// Automatically calls `claude_path::init()` (idempotent via `OnceLock`)
@@ -176,7 +176,7 @@ pub fn spawn_and_monitor(
                         session_key: key.clone(),
                         item: item.clone(),
                     });
-                    // Persist non-streaming items once the Claude session id is known.
+                    // Persist non-streaming items once the provider session id is known.
                     if let Some(ref opts) = persist {
                         if let (Some(sid), Some((ft, dj))) =
                             (opts.claude_session_id.as_ref(), serialize_for_persist(item))
@@ -185,11 +185,22 @@ pub fn spawn_and_monitor(
                             let src = opts.source.clone();
                             let sid = sid.clone();
                             tokio::spawn(async move {
-                                let _ =
-                                    db.add_chat_feed_item_by_session(&sid, &ft, &dj, &src).await;
+                                if let Err(e) =
+                                    db.add_chat_feed_item_by_session(&sid, &ft, &dj, &src).await
+                                {
+                                    tracing::warn!(
+                                        "[session_runner] failed to persist feed item: {e}"
+                                    );
+                                }
                             });
                         }
                     }
+                }
+                SessionUpdate::ResumeInvalid => {
+                    if let Some(ref h) = session_id_handle {
+                        h.clear_current_preserving_history().await;
+                    }
+                    continue;
                 }
                 SessionUpdate::SessionId(sid) => {
                     claude_session_id = Some(sid.clone());
@@ -218,14 +229,19 @@ pub fn spawn_and_monitor(
                             let sid_clone = sid.clone();
                             let data = serde_json::Value::String(user_msg).to_string();
                             tokio::spawn(async move {
-                                let _ = db
+                                if let Err(e) = db
                                     .add_chat_feed_item_by_session(
                                         &sid_clone,
                                         "user_message",
                                         &data,
                                         &src,
                                     )
-                                    .await;
+                                    .await
+                                {
+                                    tracing::warn!(
+                                        "[session_runner] failed to persist user message: {e}"
+                                    );
+                                }
                             });
                         }
                     }

--- a/engine/houston-engine-core/src/routines/engine_dispatcher.rs
+++ b/engine/houston-engine-core/src/routines/engine_dispatcher.rs
@@ -59,19 +59,24 @@ impl RoutineDispatcher for EngineRoutineDispatcher {
             format!("{}\n\n---\n\n{agent_context}", self.app_system_prompt)
         };
 
+        let resolved = sessions::resolve_provider(&self.paths, ctx.working_dir);
         let agent_key = format!(
-            "{}:{}",
+            "{}:{}:{}",
             ctx.working_dir.to_string_lossy(),
+            resolved.provider,
             ctx.run.session_key
         );
         let sid_handle = self
             .rt
             .session_ids
-            .get_for_session(&agent_key, ctx.working_dir, &ctx.run.session_key)
+            .get_for_session(
+                &agent_key,
+                ctx.working_dir,
+                &ctx.run.session_key,
+                resolved.provider,
+            )
             .await;
         let resume_id = sid_handle.get().await;
-
-        let resolved = sessions::resolve_provider(&self.paths, ctx.working_dir);
 
         let join_handle = session_runner::spawn_and_monitor(
             self.events.clone(),

--- a/engine/houston-engine-core/src/sessions/history.rs
+++ b/engine/houston-engine-core/src/sessions/history.rs
@@ -1,12 +1,11 @@
 //! Chat history read — relocated from `app/src-tauri/src/commands/chat.rs`.
 //!
-//! Given an agent path + session key, resolves the Claude session ID recorded
-//! under `.houston/sessions/<key>.sid` and loads the associated chat-feed
-//! rows from the engine DB. Transport-neutral: REST handlers and tests call
-//! it the same way.
+//! Given an agent path + session key, resolves every known provider resume ID
+//! for that key and loads the associated chat-feed rows from the engine DB.
+//! Transport-neutral: REST handlers and tests call it the same way.
 
 use crate::error::{CoreError, CoreResult};
-use houston_agents_conversations::session_id_tracker::session_id_path;
+use houston_agents_conversations::session_id_tracker::session_ids_for_history;
 use houston_db::Database;
 use serde::Serialize;
 use std::path::Path;
@@ -23,19 +22,19 @@ pub async fn load(
     working_dir: &Path,
     session_key: &str,
 ) -> CoreResult<Vec<ChatHistoryEntry>> {
-    let sid_path = session_id_path(working_dir, session_key);
-    let Some(claude_session_id) = std::fs::read_to_string(&sid_path)
-        .ok()
-        .map(|s| s.trim().to_string())
-        .filter(|s| !s.is_empty())
-    else {
+    let session_ids = session_ids_for_history(working_dir, session_key);
+    if session_ids.is_empty() {
         return Ok(Vec::new());
-    };
+    }
 
-    let mut rows = db
-        .list_chat_feed_by_session(&claude_session_id)
-        .await
-        .map_err(|e| CoreError::Internal(e.to_string()))?;
+    let mut rows = Vec::new();
+    for session_id in session_ids {
+        rows.extend(
+            db.list_chat_feed_by_session(&session_id)
+                .await
+                .map_err(|e| CoreError::Internal(e.to_string()))?,
+        );
+    }
 
     rows.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
 

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -3,7 +3,7 @@
 //! Each Houston "session" is one running Claude/Codex CLI subprocess with a
 //! stable `session_key` so follow-up turns can `--resume`. This module owns:
 //!
-//! - [`SessionRuntime`] — per-engine state (Claude session-ID tracker,
+//! - [`SessionRuntime`] — per-engine state (provider session-ID tracker,
 //!   session-key → PID map). Held on `EngineState`, cloned per request.
 //! - [`start`] — spawn + monitor a session via
 //!   `houston-agents-conversations`, streaming updates to the engine's event
@@ -140,10 +140,15 @@ pub async fn start(
             None
         }
     };
-    let agent_key = format!("{}:{}", working_dir.to_string_lossy(), session_key);
+    let agent_key = format!(
+        "{}:{}:{}",
+        working_dir.to_string_lossy(),
+        provider,
+        session_key
+    );
     let sid_handle = rt
         .session_ids
-        .get_for_session(&agent_key, &working_dir, &session_key)
+        .get_for_session(&agent_key, &working_dir, &session_key, provider)
         .await;
     let resume_id = sid_handle.get().await;
 

--- a/engine/houston-terminal-manager/src/codex_command.rs
+++ b/engine/houston-terminal-manager/src/codex_command.rs
@@ -1,0 +1,100 @@
+use std::ffi::OsString;
+use std::path::Path;
+
+/// Build `codex exec` args with exec-level flags before the optional
+/// `resume` subcommand. Older Codex CLIs reject global flags placed after
+/// `resume <id>`.
+pub(crate) fn build_args(
+    resume_session_id: Option<&str>,
+    working_dir: Option<&Path>,
+    model: Option<&str>,
+    system_prompt: Option<&str>,
+) -> Vec<OsString> {
+    let mut args = vec![
+        OsString::from("exec"),
+        OsString::from("--json"),
+        OsString::from("--dangerously-bypass-approvals-and-sandbox"),
+        OsString::from("--skip-git-repo-check"),
+    ];
+
+    if let Some(sp) = system_prompt {
+        let json_val = serde_json::to_string(sp).unwrap_or_else(|_| format!("\"{sp}\""));
+        args.push(OsString::from("-c"));
+        args.push(OsString::from(format!("developer_instructions={json_val}")));
+    }
+
+    if let Some(m) = model {
+        args.push(OsString::from("--model"));
+        args.push(OsString::from(m));
+    }
+
+    if let Some(dir) = working_dir {
+        args.push(OsString::from("--cd"));
+        args.push(dir.as_os_str().to_os_string());
+    }
+
+    if let Some(session_id) = resume_session_id {
+        args.push(OsString::from("resume"));
+        args.push(OsString::from(session_id));
+    }
+    args.push(OsString::from("-"));
+
+    args
+}
+
+pub(crate) fn is_missing_rollout_error(line: &str) -> bool {
+    let lower = line.to_lowercase();
+    lower.contains("thread/resume")
+        && lower.contains("no rollout found")
+        && lower.contains("thread id")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn strings(args: Vec<OsString>) -> Vec<String> {
+        args.into_iter()
+            .map(|arg| arg.to_string_lossy().to_string())
+            .collect()
+    }
+
+    #[test]
+    fn resume_args_keep_exec_flags_before_subcommand() {
+        let dir = PathBuf::from("/tmp/work");
+        let args = strings(build_args(
+            Some("019dd59b-5e8c-7f63-a8c6-18fb825874ad"),
+            Some(&dir),
+            Some("gpt-5.4"),
+            Some("system"),
+        ));
+
+        let resume_pos = args.iter().position(|arg| arg == "resume").unwrap();
+        let json_pos = args.iter().position(|arg| arg == "--json").unwrap();
+        let cd_pos = args.iter().position(|arg| arg == "--cd").unwrap();
+
+        assert!(json_pos < resume_pos);
+        assert!(cd_pos < resume_pos);
+        assert_eq!(args[resume_pos + 1], "019dd59b-5e8c-7f63-a8c6-18fb825874ad");
+        assert_eq!(args[resume_pos + 2], "-");
+    }
+
+    #[test]
+    fn fresh_args_read_prompt_from_stdin() {
+        let args = strings(build_args(None, None, None, None));
+
+        assert_eq!(args.last().map(String::as_str), Some("-"));
+        assert!(!args.iter().any(|arg| arg == "resume"));
+    }
+
+    #[test]
+    fn detects_codex_missing_rollout_error() {
+        assert!(is_missing_rollout_error(
+            "Error: thread/resume: thread/resume failed: no rollout found for thread id 1088f5a4-c484-44d4-b594-585b74a8f859"
+        ));
+        assert!(!is_missing_rollout_error(
+            "unexpected status 401 Unauthorized"
+        ));
+    }
+}

--- a/engine/houston-terminal-manager/src/lib.rs
+++ b/engine/houston-terminal-manager/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod auth_error;
 pub mod claude_path;
+mod codex_command;
 pub mod codex_parser;
 pub mod concurrency;
 pub mod manager;

--- a/engine/houston-terminal-manager/src/manager.rs
+++ b/engine/houston-terminal-manager/src/manager.rs
@@ -1,6 +1,7 @@
 use super::session_io;
 use super::types::{FeedItem, Provider, SessionStatus};
 use crate::auth_error::is_auth_error;
+use crate::codex_command;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
 use tokio::process::Command;
@@ -159,33 +160,6 @@ async fn spawn_codex(
         resume_session_id
     );
 
-    let mut cmd = Command::new("codex");
-    cmd.env("PATH", super::claude_path::shell_path());
-
-    let is_resume = resume_session_id.is_some();
-
-    if let Some(ref session_id) = resume_session_id {
-        cmd.arg("exec").arg("resume").arg(session_id);
-    } else {
-        cmd.arg("exec");
-    }
-
-    cmd.arg("--json")
-        .arg("--dangerously-bypass-approvals-and-sandbox")
-        .arg("--skip-git-repo-check");
-
-    // Inject system prompt via developer_instructions config override.
-    // Codex has no --system-prompt flag; this is the supported injection point.
-    if let Some(ref sp) = system_prompt {
-        let json_val = serde_json::to_string(sp).unwrap_or_else(|_| format!("\"{sp}\""));
-        cmd.arg("-c")
-            .arg(format!("developer_instructions={json_val}"));
-    }
-
-    if let Some(ref m) = model {
-        cmd.arg("--model").arg(m);
-    }
-
     if let Some(ref dir) = working_dir {
         if !dir.is_dir() {
             let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(format!(
@@ -194,15 +168,49 @@ async fn spawn_codex(
             ))));
             return;
         }
-        // --cd is only valid for `codex exec`, not `codex exec resume`
-        if is_resume {
-            cmd.current_dir(dir);
-        } else {
-            cmd.arg("--cd").arg(dir);
-        }
     }
 
-    run_cli_process(tx, &mut cmd, &prompt, Provider::OpenAI).await;
+    let mut cmd = build_codex_command(
+        resume_session_id.as_deref(),
+        working_dir.as_deref(),
+        model.as_deref(),
+        system_prompt.as_deref(),
+    );
+
+    let outcome = run_cli_process(tx, &mut cmd, &prompt, Provider::OpenAI).await;
+    if outcome == CliRunOutcome::CodexResumeMissing && resume_session_id.is_some() {
+        tracing::warn!(
+            "[houston:session] codex resume rollout missing; retrying with fresh thread"
+        );
+        let _ = tx.send(SessionUpdate::ResumeInvalid);
+        let mut fresh_cmd = build_codex_command(
+            None,
+            working_dir.as_deref(),
+            model.as_deref(),
+            system_prompt.as_deref(),
+        );
+        run_cli_process(tx, &mut fresh_cmd, &prompt, Provider::OpenAI).await;
+    }
+}
+
+fn build_codex_command(
+    resume_session_id: Option<&str>,
+    working_dir: Option<&std::path::Path>,
+    model: Option<&str>,
+    system_prompt: Option<&str>,
+) -> Command {
+    let mut cmd = Command::new("codex");
+    cmd.env("PATH", super::claude_path::shell_path());
+    cmd.args(codex_command::build_args(
+        resume_session_id,
+        working_dir,
+        model,
+        system_prompt,
+    ));
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+    cmd
 }
 
 /// Shared subprocess lifecycle: spawn, write prompt to stdin, read stdout/stderr, wait.
@@ -211,7 +219,7 @@ async fn run_cli_process(
     cmd: &mut Command,
     prompt: &str,
     provider: Provider,
-) {
+) -> CliRunOutcome {
     let cli_name = match provider {
         Provider::Anthropic => "claude",
         Provider::OpenAI => "codex",
@@ -227,7 +235,7 @@ async fn run_cli_process(
             let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(format!(
                 "Failed to spawn {cli_name}: {e}"
             ))));
-            return;
+            return CliRunOutcome::Failed;
         }
     };
 
@@ -236,7 +244,7 @@ async fn run_cli_process(
             let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(format!(
                 "Failed to write prompt to stdin: {e}"
             ))));
-            return;
+            return CliRunOutcome::Failed;
         }
         drop(stdin);
     }
@@ -274,7 +282,7 @@ async fn run_cli_process(
                 tracing::info!("[houston:session] {msg}");
                 let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(msg)));
                 let _ = child.kill().await;
-                return;
+                return CliRunOutcome::Failed;
             }
         }
     }
@@ -286,7 +294,18 @@ async fn run_cli_process(
             let is_sigterm = status.code() == Some(143);
             if status.success() || is_sigterm {
                 let _ = tx.send(SessionUpdate::Status(SessionStatus::Completed));
+                CliRunOutcome::Completed
             } else {
+                if provider == Provider::OpenAI
+                    && stderr_lines
+                        .iter()
+                        .any(|line| codex_command::is_missing_rollout_error(line))
+                {
+                    tracing::warn!(
+                        "[houston:session] codex resume failed because rollout was missing"
+                    );
+                    return CliRunOutcome::CodexResumeMissing;
+                }
                 // Check if stderr indicates an auth failure (e.g. Codex 401 retries).
                 let has_auth_error = stderr_lines.iter().any(|l| is_auth_error(l));
 
@@ -295,6 +314,7 @@ async fn run_cli_process(
                     let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(
                         "Authentication expired — sign in again to continue".to_string(),
                     )));
+                    CliRunOutcome::Failed
                 } else {
                     let stderr_summary = if stderr_lines.is_empty() {
                         "no stderr output captured".to_string()
@@ -308,6 +328,7 @@ async fn run_cli_process(
                     let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(format!(
                         "{cli_name} exited with {status}"
                     ))));
+                    CliRunOutcome::Failed
                 }
             }
         }
@@ -315,8 +336,16 @@ async fn run_cli_process(
             let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(format!(
                 "Failed to wait for {cli_name}: {e}"
             ))));
+            CliRunOutcome::Failed
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CliRunOutcome {
+    Completed,
+    Failed,
+    CodexResumeMissing,
 }
 
 /// Updates sent from the session manager to consumers (monitors, pumps).
@@ -326,4 +355,5 @@ pub enum SessionUpdate {
     SessionId(String),
     Feed(FeedItem),
     ProcessPid(u32),
+    ResumeInvalid,
 }

--- a/engine/houston-terminal-manager/src/session_io.rs
+++ b/engine/houston-terminal-manager/src/session_io.rs
@@ -1,8 +1,9 @@
+use super::codex_command;
 use super::codex_parser;
 use super::manager::SessionUpdate;
 use super::parser;
 use super::types::{FeedItem, Provider};
-use crate::auth_error::{AUTH_RETRY_MARKER, is_auth_retry_noise};
+use crate::auth_error::{is_auth_retry_noise, AUTH_RETRY_MARKER};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc;
 
@@ -54,6 +55,11 @@ fn is_meaningful_stderr(line: &str) -> bool {
     // Auth retry noise (e.g. "Error: Reconnecting... 1/5 (unexpected status 401 Unauthorized...)")
     // These are internal retries — the session runner handles the auth failure at exit.
     if is_auth_retry_noise(trimmed) {
+        return false;
+    }
+    // If Codex lost the local rollout backing a stored resume id, the manager
+    // retries fresh. Do not show the transient stderr line to the user.
+    if codex_command::is_missing_rollout_error(trimmed) {
         return false;
     }
     true

--- a/engine/houston-terminal-manager/src/session_pump.rs
+++ b/engine/houston-terminal-manager/src/session_pump.rs
@@ -51,6 +51,7 @@ pub async fn pump_session(
             SessionUpdate::ProcessPid(pid) => {
                 on_pid(pid);
             }
+            SessionUpdate::ResumeInvalid => {}
         }
     }
 

--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -28,7 +28,13 @@ If app-specific → `.houston/`.
     prompts/
       modes/<mode>.md           editable per-mode prompt overlay (user-owned)
     sessions/
-      {session_key}.sid         one file per conversation, holds Claude session id for --resume
+      anthropic/{session_key}.sid       current Claude resume id
+      anthropic/{session_key}.history   all Claude resume ids used by this conversation
+      anthropic/{session_key}.invalid   Claude resume ids rejected by the CLI
+      openai/{session_key}.sid          current Codex resume id
+      openai/{session_key}.history      all Codex resume ids used by this conversation
+      openai/{session_key}.invalid      Codex resume ids rejected by the CLI
+      {session_key}.sid                 legacy flat resume id, read as fallback only
   .agents/
     skills/<name>/SKILL.md      Claude Code skill convention
   .claude/
@@ -59,6 +65,14 @@ not visible in the already-started prompt until the next session.
 ## Migration
 `houston_agent_files::migrate_agent_data()` runs on every `seed_agent()`. Idempotent. Leaves legacy flat-layout data files in place as rollback. Legacy product-prompt seeds (`.houston/prompts/system.md`, `.houston/prompts/self-improvement.md`) are deleted — the Houston product prompt now lives in the app binary (`app/src-tauri/src/houston_prompt/`), not on disk.
 
+Session resume IDs are provider-scoped for new writes so Claude and Codex
+never overwrite each other's current resume ID. Existing
+`.houston/sessions/{session_key}.sid` files stay in place and are read as
+a fallback until a provider writes its own scoped `.sid`. Chat history
+loads the legacy ID plus every provider current/history ID for the same
+session key. Provider-scoped `.invalid` files stop a rejected legacy ID
+from being retried by the provider that rejected it.
+
 ## Atomic writes
 All writes: temp file + rename. Path-traversal safe via `houston-agent-files::safe_relative`.
 
@@ -72,7 +86,7 @@ Same files surface in the UI as **"Actions"** (per-user vocabulary). Frontmatter
 
 ## SQLite (minimal)
 Only two tables:
-- `chat_feed` — keyed by `claude_session_id`. UI conversation replay on restart.
+- `chat_feed` - keyed by provider CLI session id (`claude_session_id` column name is legacy). UI conversation replay on restart.
 - `preferences` — app-level (last_workspace_id etc). Not scoped.
 
 Everything else lives in files.


### PR DESCRIPTION
## Summary
- scope stored CLI resume IDs by provider while preserving legacy flat .sid fallback
- retry Codex fresh when a stored resume ID points to a missing local rollout
- preserve chat history across legacy, provider-specific current IDs, and provider histories
- document the provider-scoped session file layout

## Verification
- cargo test --workspace
- cargo build -p houston-engine-server
- git diff --check