### PR TITLE
feat(website): public changelog + Slack release notification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@
 #   SUPABASE_URL                       — Supabase project URL
 #   SUPABASE_ANON_KEY                  — Supabase anon key (client-side, RLS-gated)
 #   SLACK_BUG_WEBHOOK_URL              — Slack incoming-webhook for in-app "Report bug" button
+#   SLACK_RELEASE_WEBHOOK_URL          — Slack incoming-webhook to ping the team when a draft release is built
 #   SENTRY_DSN                         — Sentry crash reporting DSN
 
 name: Release
@@ -641,3 +642,57 @@ jobs:
             checksums-sha256.txt
 
           echo "::notice::Draft release created — review notes then publish at https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
+
+      # Pings the team Slack channel so anyone can grab the DMG and try the
+      # build before we publish. No-ops when SLACK_RELEASE_WEBHOOK_URL is
+      # unset, so forks and personal builds stay quiet.
+      - name: Notify Slack of new draft release
+        if: success()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_RELEASE_WEBHOOK_URL }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_RELEASE_WEBHOOK_URL not set; skipping Slack notification."
+            exit 0
+          fi
+
+          VERSION="${GITHUB_REF_NAME#v}"
+          RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${GITHUB_REF_NAME}"
+          DMG_URL=$(gh release view "$GITHUB_REF_NAME" --json assets --jq '[.assets[] | select(.name | endswith(".dmg")) | .url] | first // empty')
+
+          # First ~700 chars of the release-notes body, skipping the leading "## Houston X.Y.Z" header line.
+          NOTES_PREVIEW=$(tail -n +2 release-notes.md | head -c 700)
+          if [ "$(wc -c < release-notes.md)" -gt 700 ]; then
+            NOTES_PREVIEW="${NOTES_PREVIEW}…"
+          fi
+
+          # Build action buttons: always include "View on GitHub", add "Download DMG" only when we found one.
+          if [ -n "$DMG_URL" ]; then
+            ACTIONS=$(jq -n --arg dmg "$DMG_URL" --arg url "$RELEASE_URL" '[
+              { type: "button", text: { type: "plain_text", text: "Download DMG", emoji: true }, url: $dmg, style: "primary" },
+              { type: "button", text: { type: "plain_text", text: "View on GitHub", emoji: true }, url: $url }
+            ]')
+          else
+            ACTIONS=$(jq -n --arg url "$RELEASE_URL" '[
+              { type: "button", text: { type: "plain_text", text: "View on GitHub", emoji: true }, url: $url }
+            ]')
+          fi
+
+          jq -n \
+            --arg ver "$VERSION" \
+            --arg notes "$NOTES_PREVIEW" \
+            --argjson actions "$ACTIONS" \
+            '{
+              text: ("Houston v" + $ver + " is ready to test"),
+              blocks: [
+                { type: "header", text: { type: "plain_text", text: ("Houston v" + $ver + " is ready to test"), emoji: true } },
+                { type: "context", elements: [ { type: "mrkdwn", text: "Draft release · grab the DMG and try it before we publish" } ] },
+                { type: "section", text: { type: "mrkdwn", text: $notes } },
+                { type: "actions", elements: $actions }
+              ]
+            }' | curl --silent --show-error --fail \
+              -X POST \
+              -H "Content-Type: application/json" \
+              --data @- \
+              "$SLACK_WEBHOOK_URL"

--- a/website/eleventy.config.js
+++ b/website/eleventy.config.js
@@ -1,4 +1,15 @@
+import { marked } from "marked";
+
+marked.setOptions({ gfm: true, breaks: false });
+
 export default function (eleventyConfig) {
+  // Render a markdown string to HTML. Used by the changelog page to render
+  // GitHub release bodies fetched at build time.
+  eleventyConfig.addFilter("markdown", (str) => {
+    if (!str) return "";
+    return marked.parse(str);
+  });
+
   // Pass through static assets unchanged
   eleventyConfig.addPassthroughCopy("src/favicon.svg");
   eleventyConfig.addPassthroughCopy("src/houston-black.svg");

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -8,7 +8,8 @@
       "name": "website",
       "version": "1.0.0",
       "dependencies": {
-        "@11ty/eleventy": "^3.1.5"
+        "@11ty/eleventy": "^3.1.5",
+        "marked": "^18.0.2"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -1030,6 +1031,18 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.2.tgz",
+      "integrity": "sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/mdurl": {

--- a/website/package.json
+++ b/website/package.json
@@ -9,6 +9,7 @@
     "deploy": "npm run build && npx wrangler pages deploy _site --branch=main --commit-dirty=true"
   },
   "dependencies": {
-    "@11ty/eleventy": "^3.1.5"
+    "@11ty/eleventy": "^3.1.5",
+    "marked": "^18.0.2"
   }
 }

--- a/website/src/_data/changelog.js
+++ b/website/src/_data/changelog.js
@@ -1,0 +1,48 @@
+// Fetched at build time. Eleventy 3.x supports async data files.
+// Falls back to an empty list if GitHub is unreachable so builds never break.
+const REPO = "ja-818/houston";
+const PER_PAGE = 30;
+
+export default async function () {
+  try {
+    const headers = {
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "houston-website-build",
+    };
+    if (process.env.GITHUB_TOKEN) {
+      headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+    const res = await fetch(
+      `https://api.github.com/repos/${REPO}/releases?per_page=${PER_PAGE}`,
+      { headers }
+    );
+    if (!res.ok) {
+      console.warn(`[changelog] GitHub API ${res.status}; rendering empty list.`);
+      return [];
+    }
+    const releases = await res.json();
+    return releases
+      .filter((r) => !r.draft)
+      .map((r) => {
+        const date = new Date(r.published_at);
+        return {
+          tag: r.tag_name,
+          name: r.name || r.tag_name,
+          publishedAt: r.published_at,
+          publishedDate: date.toLocaleDateString("en-US", {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+          }),
+          body: r.body || "",
+          url: r.html_url,
+          isPrerelease: !!r.prerelease,
+          dmgAsset: (r.assets || []).find((a) => a.name.endsWith(".dmg")) || null,
+        };
+      });
+  } catch (err) {
+    console.warn("[changelog] fetch failed:", err.message);
+    return [];
+  }
+}

--- a/website/src/_includes/footer-landing.njk
+++ b/website/src/_includes/footer-landing.njk
@@ -27,6 +27,7 @@
     <div>
       <div style="font-size: 12px; font-weight: 500; color: var(--gray-400); margin-bottom: 12px;">Resources</div>
       <div style="display: flex; flex-direction: column; gap: 8px;">
+        <a href="/changelog/" style="font-size: 13px;">Changelog</a>
         <a href="https://github.com/ja-818/houston" target="_blank" rel="noopener noreferrer" style="font-size: 13px;">GitHub</a>
         <a href="https://x.com/ja818_" target="_blank" rel="noopener noreferrer" style="font-size: 13px;">Twitter / X</a>
       </div>

--- a/website/src/_includes/footer-learn.njk
+++ b/website/src/_includes/footer-learn.njk
@@ -1,6 +1,11 @@
 <footer class="footer">
-  Houston is free and open source. Made for people who want their apps to
-  bend.
+  <div>
+    Houston is free and open source. Made for people who want their apps to
+    bend.
+  </div>
+  <div style="margin-top: 12px; display: flex; gap: 16px; font-size: 12px; color: var(--gray-500); flex-wrap: wrap;">
+    <a href="/changelog/" style="color: var(--gray-500);">Changelog</a>
+  </div>
 </footer>
 
 <script>

--- a/website/src/_includes/footer-startups.njk
+++ b/website/src/_includes/footer-startups.njk
@@ -9,6 +9,7 @@
       <div style="display: flex; flex-direction: column; gap: 8px;">
         <a href="../learn/index.html" style="font-size: 13px;">Learn (8 chapters)</a>
         <a href="../vision/index.html" style="font-size: 13px;">Vision essay</a>
+        <a href="../changelog/" style="font-size: 13px;">Changelog</a>
         <a href="https://github.com/ja-818/houston" target="_blank" rel="noopener noreferrer" style="font-size: 13px;">GitHub</a>
       </div>
     </div>

--- a/website/src/_includes/nav-landing.njk
+++ b/website/src/_includes/nav-landing.njk
@@ -3,6 +3,7 @@
   <div class="nav-center">
     <a href="#agents">Agents</a>
     <a href="#features">Features</a>
+    <a href="changelog/index.html">Changelog</a>
     <a href="startups/index.html">For Startups</a>
   </div>
   <div class="nav-right">
@@ -19,6 +20,7 @@
 <div class="nav-dropdown" id="nav-dropdown">
   <a href="#agents">Agents</a>
   <a href="#features">Features</a>
+  <a href="changelog/index.html">Changelog</a>
   <a href="startups/index.html">For Startups</a>
   <a href="https://github.com/ja-818/houston" target="_blank" rel="noopener noreferrer">
     <svg viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0024 12c0-6.63-5.37-12-12-12z"/></svg>

--- a/website/src/changelog/index.html
+++ b/website/src/changelog/index.html
@@ -1,0 +1,343 @@
+---
+rootPath: "../"
+---
+{% extends "base.njk" %}
+{% block title %}Changelog — Houston{% endblock %}
+{% block favicon %}<link rel="icon" type="image/svg+xml" href="../favicon.svg">{% endblock %}
+{% block meta %}
+<meta name="description" content="Every Houston release, what changed, and how it affects you. Plain language, no jargon.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://gethouston.ai/changelog/">
+<meta property="og:title" content="Changelog — Houston">
+<meta property="og:description" content="Every Houston release, what changed, and how it affects you.">
+<meta property="og:site_name" content="Houston">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Changelog — Houston">
+<meta name="twitter:description" content="Every Houston release, what changed, and how it affects you.">
+{% endblock %}
+{% block inlineStyles %}
+<style>
+  :root {
+    --background: #ffffff;
+    --foreground: #0d0d0d;
+    --secondary: #f9f9f9;
+    --muted-foreground: #5d5d5d;
+    --border: #e5e5e5;
+    --gray-50: #f9f9f9;
+    --gray-100: #ececec;
+    --gray-200: #e3e3e3;
+    --gray-300: #cdcdcd;
+    --gray-400: #b4b4b4;
+    --gray-500: #9b9b9b;
+    --gray-600: #676767;
+    --gray-700: #424242;
+    --gray-950: #0d0d0d;
+    --border-light: rgba(13,13,13,0.05);
+    --border-medium: rgba(0,0,0,0.15);
+  }
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    font-family: ui-sans-serif, -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+    color: var(--foreground);
+    background: var(--background);
+    -webkit-font-smoothing: antialiased;
+    line-height: 1.6;
+  }
+  a { color: inherit; text-decoration: none; }
+
+  /* Top nav — mirrors landing */
+  body { padding-top: 65px; }
+  nav {
+    position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+    padding: 16px 40px;
+    display: flex; align-items: center; justify-content: space-between;
+    background: rgba(255,255,255,0.85);
+    backdrop-filter: blur(20px); -webkit-backdrop-filter: blur(20px);
+    border-bottom: 1px solid transparent;
+    transition: border-color 0.2s, background 0.2s;
+  }
+  nav.scrolled { border-bottom-color: var(--border-light); }
+  .nav-logo {
+    font-family: 'General Sans', sans-serif;
+    font-size: 22px; font-weight: 500; letter-spacing: -0.02em;
+    color: var(--gray-950);
+  }
+  .nav-center {
+    position: absolute; left: 50%; transform: translateX(-50%);
+    display: flex; gap: 32px; align-items: center;
+  }
+  .nav-center a { font-size: 14px; color: var(--gray-700); }
+  .nav-center a:hover { color: var(--gray-950); }
+  .nav-right { display: flex; align-items: center; gap: 12px; }
+  .nav-right a { font-size: 14px; color: var(--gray-700); }
+  .btn {
+    display: inline-flex; align-items: center; gap: 8px;
+    padding: 0 16px; height: 36px; border-radius: 10px;
+    font-size: 14px; font-weight: 500;
+    border: 1px solid transparent; cursor: pointer;
+    transition: all 0.15s;
+  }
+  .btn-primary {
+    background: var(--gray-950); color: white; border-color: var(--gray-950);
+  }
+  .btn-primary:hover { background: black; }
+
+  /* Page header */
+  .page-header {
+    max-width: 760px; margin: 0 auto;
+    padding: 80px 40px 48px;
+    text-align: center;
+  }
+  .page-eyebrow {
+    font-size: 13px; font-weight: 500; color: var(--gray-500);
+    text-transform: uppercase; letter-spacing: 0.08em;
+    margin-bottom: 16px;
+  }
+  .page-header h1 {
+    font-family: 'General Sans', sans-serif;
+    font-size: clamp(40px, 5vw, 56px);
+    font-weight: 600; letter-spacing: -0.035em; line-height: 1.05;
+    color: var(--gray-950);
+    margin-bottom: 20px;
+  }
+  .page-header p {
+    font-size: 18px; color: var(--gray-600);
+    max-width: 560px; margin: 0 auto;
+  }
+  .page-header .links {
+    margin-top: 24px;
+    display: inline-flex; align-items: center; gap: 16px;
+    font-size: 13px; color: var(--gray-500);
+  }
+  .page-header .links a {
+    color: var(--gray-700);
+    border-bottom: 1px solid var(--gray-300);
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .page-header .links a:hover {
+    color: var(--gray-950);
+    border-bottom-color: var(--gray-950);
+  }
+
+  /* Timeline rail */
+  .timeline {
+    max-width: 760px; margin: 0 auto;
+    padding: 0 40px 120px;
+    position: relative;
+  }
+  .timeline::before {
+    content: "";
+    position: absolute;
+    left: 60px; top: 16px; bottom: 16px;
+    width: 1px; background: var(--border);
+  }
+  @media (max-width: 720px) {
+    .timeline::before { left: 24px; }
+  }
+
+  .release {
+    position: relative;
+    padding: 16px 0 56px 120px;
+  }
+  @media (max-width: 720px) {
+    .release { padding-left: 56px; }
+  }
+  .release-marker {
+    position: absolute;
+    left: 53px; top: 22px;
+    width: 14px; height: 14px;
+    border-radius: 50%;
+    background: white;
+    border: 2px solid var(--gray-300);
+    z-index: 1;
+  }
+  @media (max-width: 720px) {
+    .release-marker { left: 17px; }
+  }
+  .release.is-latest .release-marker {
+    border-color: var(--gray-950);
+    background: var(--gray-950);
+    box-shadow: 0 0 0 4px rgba(13,13,13,0.06);
+  }
+
+  .release-meta {
+    display: flex; align-items: center; gap: 12px;
+    margin-bottom: 14px;
+    flex-wrap: wrap;
+  }
+  .release-version {
+    font-family: 'General Sans', sans-serif;
+    font-size: 28px; font-weight: 600; letter-spacing: -0.03em;
+    color: var(--gray-950);
+    line-height: 1;
+  }
+  .release-date {
+    font-size: 13px; color: var(--gray-500);
+  }
+  .release-badge {
+    display: inline-flex; align-items: center;
+    padding: 2px 10px; border-radius: 999px;
+    font-size: 11px; font-weight: 600; letter-spacing: 0.04em;
+    text-transform: uppercase;
+    background: var(--gray-950); color: white;
+  }
+  .release-badge.beta {
+    background: var(--gray-100); color: var(--gray-700);
+  }
+
+  .release-body {
+    font-size: 15.5px; color: var(--gray-700);
+    line-height: 1.65;
+  }
+  .release-body h1, .release-body h2, .release-body h3, .release-body h4 {
+    font-family: 'General Sans', sans-serif;
+    color: var(--gray-950);
+    font-weight: 600; letter-spacing: -0.015em; line-height: 1.3;
+    margin: 28px 0 12px;
+  }
+  .release-body h1 { font-size: 22px; margin-top: 0; }
+  .release-body h2 { font-size: 18px; }
+  .release-body h3 { font-size: 16px; }
+  .release-body h4 { font-size: 15px; }
+  .release-body > :first-child { margin-top: 0; }
+  .release-body p {
+    margin: 0 0 14px;
+  }
+  .release-body ul, .release-body ol {
+    margin: 0 0 14px 24px;
+    padding: 0;
+  }
+  .release-body li {
+    margin-bottom: 8px;
+  }
+  .release-body strong {
+    color: var(--gray-950); font-weight: 600;
+  }
+  .release-body a {
+    color: var(--gray-950);
+    border-bottom: 1px solid var(--gray-300);
+  }
+  .release-body a:hover { border-bottom-color: var(--gray-950); }
+  .release-body code {
+    font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+    font-size: 13.5px;
+    padding: 2px 6px;
+    background: var(--gray-100);
+    border-radius: 4px;
+  }
+  .release-body pre {
+    background: var(--gray-50);
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 12px 14px;
+    overflow-x: auto;
+    font-size: 13px;
+    margin: 0 0 14px;
+  }
+  .release-body pre code {
+    background: transparent; padding: 0;
+  }
+  .release-body hr {
+    border: 0; border-top: 1px solid var(--border-light);
+    margin: 24px 0;
+  }
+  .release-body blockquote {
+    border-left: 3px solid var(--gray-200);
+    padding-left: 16px;
+    color: var(--gray-600);
+    margin: 0 0 14px;
+  }
+
+  .release-actions {
+    display: inline-flex; gap: 16px; align-items: center;
+    margin-top: 18px;
+    font-size: 13px;
+    color: var(--gray-500);
+  }
+  .release-actions a {
+    color: var(--gray-700);
+    border-bottom: 1px solid var(--gray-300);
+    transition: border-color 0.15s, color 0.15s;
+  }
+  .release-actions a:hover {
+    color: var(--gray-950);
+    border-bottom-color: var(--gray-950);
+  }
+
+  .empty {
+    max-width: 480px; margin: 80px auto;
+    padding: 48px;
+    text-align: center;
+    background: var(--gray-50);
+    border-radius: 16px;
+    color: var(--gray-600);
+  }
+  .empty p { margin-bottom: 16px; }
+</style>
+{% endblock %}
+{% block body %}
+<nav>
+  <a href="../" class="nav-logo">Houston</a>
+  <div class="nav-center">
+    <a href="../#agents">Agents</a>
+    <a href="../#features">Features</a>
+    <a href="../changelog/">Changelog</a>
+    <a href="../startups/">For Startups</a>
+  </div>
+  <div class="nav-right">
+    <a class="btn btn-primary" href="../#download">Download</a>
+  </div>
+</nav>
+
+<div class="page-header">
+  <div class="page-eyebrow">Changelog</div>
+  <h1>What's new in Houston</h1>
+  <p>Every release. Plain language. What changed and how it affects you.</p>
+  <div class="links">
+    <a href="https://github.com/ja-818/houston/releases" target="_blank" rel="noopener noreferrer">Releases on GitHub →</a>
+  </div>
+</div>
+
+<div class="timeline">
+  {% if changelog and changelog.length %}
+    {% for release in changelog %}
+      <article class="release {% if loop.first %}is-latest{% endif %}" id="{{ release.tag }}">
+        <div class="release-marker"></div>
+        <div class="release-meta">
+          <div class="release-version">{{ release.tag }}</div>
+          <div class="release-date">{{ release.publishedDate }}</div>
+          {% if loop.first and not release.isPrerelease %}<span class="release-badge">Latest</span>{% endif %}
+          {% if release.isPrerelease %}<span class="release-badge beta">Beta</span>{% endif %}
+        </div>
+        <div class="release-body">
+          {{ release.body | markdown | safe }}
+        </div>
+        <div class="release-actions">
+          <a href="{{ release.url }}" target="_blank" rel="noopener noreferrer">View on GitHub</a>
+          {% if release.dmgAsset %}<a href="{{ release.dmgAsset.browser_download_url }}">Download DMG</a>{% endif %}
+        </div>
+      </article>
+    {% endfor %}
+  {% else %}
+    <div class="empty">
+      <p>The changelog couldn't load right now.</p>
+      <p><a href="https://github.com/ja-818/houston/releases" target="_blank" rel="noopener noreferrer" style="border-bottom: 1px solid currentColor;">Read the release notes on GitHub →</a></p>
+    </div>
+  {% endif %}
+</div>
+
+{% include "footer-landing.njk" %}
+
+<script>
+  (function() {
+    var nav = document.querySelector('nav');
+    if (!nav) return;
+    function check() {
+      if (window.scrollY > 10) nav.classList.add('scrolled');
+      else nav.classList.remove('scrolled');
+    }
+    window.addEventListener('scroll', check, { passive: true });
+    check();
+  })();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary

Two related improvements for release visibility, one outward-facing, one inward.

### Public changelog at \`/changelog/\`

Non-technical users won't go to GitHub Releases. So we surface release notes on the website, in plain language, in Houston's design system.

- Eleventy fetches the last 30 GitHub releases at build time via REST API (\`_data/changelog.js\`)
- \`marked\` renders each release body markdown to HTML
- Page is a timeline with version markers, latest badge, full release body, and per-release \"View on GitHub\" + \"Download DMG\" actions
- Linked from the landing nav (desktop + mobile dropdown) and all three footers
- Empty-state fallback if the GitHub API is unreachable
- PostHog \`\$pageview\` already auto-fires on this page from the snippet shipped in #50

### Slack release notification

When the release workflow creates a draft release, the team channel gets a Block Kit message so anyone can grab the DMG and try the build before publish.

- New step \`Notify Slack of new draft release\` runs at the end of the release job, after the draft is created and assets are uploaded
- Posts a Block Kit message: header, draft-release context line, ~700 chars of release notes preview, two buttons (Download DMG + View on GitHub)
- Reads \`SLACK_RELEASE_WEBHOOK_URL\` from secrets; no-ops cleanly when unset so forks and personal builds stay quiet
- Documented at the top of \`release.yml\` alongside the existing \`SLACK_BUG_WEBHOOK_URL\`

## What you need to do once

1. Slack admin → https://api.slack.com/apps → New App → enable Incoming Webhooks → add to channel → copy URL
2. Repo settings → Secrets and variables → Actions → add \`SLACK_RELEASE_WEBHOOK_URL\`

After that every new tag push that produces a draft release will ping Slack.

## Note on changelog freshness

The website is wrangler-deployed (not git-connected on CF Pages), so the changelog only updates when \`cd website && npm run deploy\` runs. After publishing a release, just deploy. ~10 sec. If you want this automated, that's a follow-up: switch CF Pages to git-connected build + add a release.published GH webhook.

## Files

- \`.github/workflows/release.yml\` — Slack notification step
- \`website/eleventy.config.js\` — \`markdown\` filter via \`marked\`
- \`website/package.json\`, \`website/package-lock.json\` — \`marked\` dep
- \`website/src/_data/changelog.js\` — build-time GitHub releases fetch
- \`website/src/changelog/index.html\` — the page
- \`website/src/_includes/nav-landing.njk\` — desktop + mobile nav links
- \`website/src/_includes/footer-landing.njk\`, \`footer-learn.njk\`, \`footer-startups.njk\` — Changelog link in each footer

## Test plan

- [x] Build clean (\`POSTHOG_KEY=… npm run build\`)
- [x] Changelog page renders 7 releases with rendered markdown bodies
- [x] Empty-state fallback triggers when GitHub API blocked
- [x] Slack JSON payload validates as Block Kit (jq composition tested locally)
- [x] actionlint clean on the new \`Notify Slack\` step
- [ ] After deploy: visit \`gethouston.ai/changelog/\` → all releases visible, Latest badge on v0.4.2
- [ ] Future release: tag push → draft created → Slack message arrives in the channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)