### PR TITLE
fix: stop mutating codex config

### DIFF
--- a/engine/houston-engine-core/src/agents/prompt.rs
+++ b/engine/houston-engine-core/src/agents/prompt.rs
@@ -227,6 +227,16 @@ mod tests {
         assert_eq!(fs::read_to_string(d.path().join("CLAUDE.md")).unwrap(), "first");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn seed_agent_exposes_claude_md_to_codex() {
+        let d = TempDir::new().unwrap();
+        seed_agent(d.path()).unwrap();
+
+        let agents_md = d.path().join("AGENTS.md");
+        assert_eq!(fs::read_link(agents_md).unwrap(), Path::new("CLAUDE.md"));
+    }
+
     #[test]
     fn build_system_prompt_assembles_known_sections() {
         let d = TempDir::new().unwrap();

--- a/engine/houston-engine-core/src/provider.rs
+++ b/engine/houston-engine-core/src/provider.rs
@@ -214,7 +214,6 @@ async fn check_codex_status() -> ProviderStatus {
     let authenticated = if let Some(path) = cli_path.as_deref() {
         let home = std::env::var("HOME").unwrap_or_default();
         if check_codex_auth(path, &home).await {
-            ensure_codex_fallback_config(&home);
             true
         } else {
             false
@@ -343,36 +342,6 @@ fn check_codex_auth_file(home: &str) -> bool {
                 || v.get("tokens").is_some()
         })
         .unwrap_or(false)
-}
-
-/// Append `HOUSTON.md` to Codex's `project_doc_fallback_filenames` so it
-/// auto-reads our agent doc like it does `AGENTS.md`.
-fn ensure_codex_fallback_config(home: &str) {
-    let config_path = PathBuf::from(home).join(".codex").join("config.toml");
-    let content = std::fs::read_to_string(&config_path).unwrap_or_default();
-
-    if content.contains("HOUSTON.md") {
-        return;
-    }
-
-    let line = if content.contains("project_doc_fallback_filenames") {
-        tracing::info!(
-            "[houston:codex] project_doc_fallback_filenames exists but missing HOUSTON.md — \
-             add it manually to ~/.codex/config.toml for full Houston integration"
-        );
-        return;
-    } else {
-        "\nproject_doc_fallback_filenames = [\"HOUSTON.md\"]\n"
-    };
-
-    if let Err(e) = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&config_path)
-        .and_then(|mut f| std::io::Write::write_all(&mut f, line.as_bytes()))
-    {
-        tracing::warn!("[houston:codex] failed to update config.toml: {e}");
-    }
 }
 
 #[cfg(test)]

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -121,3 +121,8 @@ OpenAI provider status should prefer `codex login status` over shallow
 `~/.codex/auth.json` parsing. Keep the auth-file check only as fallback for old
 Codex versions or unrelated config-load failures, because config drift should
 not look like sign-out.
+
+Never mutate `~/.codex/config.toml` to make Codex read Houston agent
+instructions. Agent directories already expose `CLAUDE.md` through an
+`AGENTS.md` symlink, and global Codex config writes can land under the active
+TOML table and break Codex startup.


### PR DESCRIPTION
## Summary
- stop Houston from appending legacy HOUSTON.md fallback config into ~/.codex/config.toml
- rely on per-agent AGENTS.md -> CLAUDE.md for Codex instructions
- document why global Codex config mutation is banned

## Tests
- cargo test -p houston-engine-core
- cargo build -p houston-engine-server
- git diff --check

## Note
- cargo test --workspace was attempted before commit and blocked by local disk exhaustion: linker failed with errno=28, No space left on device.