### PR TITLE
feat: search missions by title and history

### DIFF
--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -8,13 +8,8 @@ import {
   EmptyTitle,
   EmptyDescription,
   Button,
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
 } from "@houston-ai/core";
-import { ChevronDown, Plus } from "lucide-react";
-import { HoustonLogo } from "./shell/experience-card";
+import { Plus } from "lucide-react";
 import { HoustonHelmet } from "./shell/experience-card";
 import { resolveAgentColor } from "../lib/agent-colors";
 import { useAgentStore } from "../stores/agents";
@@ -27,6 +22,9 @@ import { useAgentChatPanel } from "./use-agent-chat-panel";
 import type { Agent } from "../lib/types";
 import { useDetailPanelContainer } from "./shell/detail-panel-context";
 import { AgentMiniAvatar, HoustonThinkingIndicator } from "./shell/experience-card";
+import { MissionControlToolbar } from "./mission-control-toolbar";
+import { MissionBoardEmptyState } from "./mission-board-empty-state";
+import { useMissionSearch } from "./use-mission-search";
 
 export function Dashboard() {
   const { t } = useTranslation(["dashboard", "board", "common"]);
@@ -51,8 +49,10 @@ export function Dashboard() {
   const setDialogOpen = useUIStore((s) => s.setCreateAgentDialogOpen);
   const setMissionPanelOpen = useUIStore((s) => s.setMissionPanelOpen);
   const missionPanelOpen = useUIStore((s) => s.missionPanelOpen);
+  const addToast = useUIStore((s) => s.addToast);
 
   const [filterPath, setFilterPath] = useState("");
+  const [missionSearchQuery, setMissionSearchQuery] = useState("");
   const [agentPickerOpen, setAgentPickerOpen] = useState(false);
   const [newPanelOpenerReady, setNewPanelOpenerReady] = useState(false);
   // Agent the user just picked for "New Mission". Stays in scope until
@@ -100,7 +100,7 @@ export function Dashboard() {
     return map;
   }, [agents]);
 
-  const filteredItems = useMemo(() => {
+  const agentFilteredItems = useMemo(() => {
     const base = filterPath
       ? mc.items.filter((i) => i.metadata?.agentPath === filterPath)
       : mc.items;
@@ -113,11 +113,25 @@ export function Dashboard() {
     () => (filterPath ? agents.filter((a) => a.folderPath === filterPath) : agents),
     [agents, filterPath],
   );
+  const handleMissionSearchError = useCallback(() => {
+    addToast({
+      title: t("dashboard:search.historyErrorTitle"),
+      description: t("dashboard:search.historyErrorDescription"),
+      variant: "error",
+    });
+  }, [addToast, t]);
+  const missionSearch = useMissionSearch({
+    items: agentFilteredItems,
+    query: missionSearchQuery,
+    loadHistory: mc.loadHistory,
+    onHistoryLoadError: handleMissionSearchError,
+  });
 
   useEffect(() => {
     if (!mc.isLoaded) return;
+    if (missionSearch.hasQuery) return;
     const emptyKey = filterPath || "all";
-    if (filteredItems.length > 0) {
+    if (agentFilteredItems.length > 0) {
       if (emptyAutoOpenKeyRef.current === emptyKey) emptyAutoOpenKeyRef.current = null;
       return;
     }
@@ -132,9 +146,10 @@ export function Dashboard() {
   }, [
     agentPickerOpen,
     filterPath,
-    filteredItems.length,
+    agentFilteredItems.length,
     handlePickAgent,
     mc.isLoaded,
+    missionSearch.hasQuery,
     missionPanelOpen,
     newPanelOpenerReady,
     visibleAgents,
@@ -196,73 +211,40 @@ export function Dashboard() {
   }
 
   const emptyBoard = (
-    <Empty className="border-0">
-      <EmptyHeader>
-        <EmptyTitle>{t("dashboard:empty.boardTitle")}</EmptyTitle>
-        <EmptyDescription>
-          {t("dashboard:empty.boardDescription")}
-        </EmptyDescription>
-      </EmptyHeader>
-      <Button
-        className="mt-4 rounded-full gap-1.5"
-        size="sm"
-        onClick={() => setAgentPickerOpen(true)}
-      >
-        <HoustonLogo size={16} />
-        {t("dashboard:empty.newMission")}
-      </Button>
-    </Empty>
+    <MissionBoardEmptyState
+      isSearch={missionSearch.hasQuery}
+      isSearchingText={missionSearch.isSearchingText}
+      labels={{
+        emptyTitle: t("dashboard:empty.boardTitle"),
+        emptyDescription: t("dashboard:empty.boardDescription"),
+        newMission: t("dashboard:empty.newMission"),
+        searchEmptyTitle: t("dashboard:search.emptyTitle"),
+        searchEmptyDescription: t("dashboard:search.emptyDescription"),
+        searchSearchingTitle: t("dashboard:search.searchingTitle"),
+        searchSearchingDescription: t("dashboard:search.searchingDescription"),
+        clearSearch: t("dashboard:search.clearCta"),
+      }}
+      onNewMission={() => setAgentPickerOpen(true)}
+      onClearSearch={() => setMissionSearchQuery("")}
+    />
   );
 
   return (
     <div className="h-full flex flex-col overflow-hidden">
-      {/* Header */}
-      <div className="shrink-0 px-5 pt-4">
-        <div className="flex items-center gap-2 mb-3">
-          <h1 className="text-xl font-semibold text-foreground">
-            {t("dashboard:title")}
-          </h1>
-          <div className="ml-auto flex items-center gap-2">
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button variant="outline" className="rounded-full gap-1.5">
-                  {filterPath
-                    ? agents.find((a) => a.folderPath === filterPath)?.name ?? t("dashboard:filter.allAgents")
-                    : t("dashboard:filter.allAgents")}
-                  <ChevronDown className="size-3.5 text-muted-foreground" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem onClick={() => setFilterPath("")}>
-                  {t("dashboard:filter.allAgents")}
-                </DropdownMenuItem>
-                {agents.map((a) => (
-                  <DropdownMenuItem
-                    key={a.id}
-                    onClick={() => setFilterPath(a.folderPath)}
-                    className="gap-2"
-                  >
-                    <AgentMiniAvatar color={a.color} />
-                    {a.name}
-                  </DropdownMenuItem>
-                ))}
-              </DropdownMenuContent>
-            </DropdownMenu>
-            <Button
-              data-keep-panel-open
-              onClick={() => setAgentPickerOpen(true)}
-            >
-              <HoustonLogo size={16} />
-              New mission
-            </Button>
-          </div>
-        </div>
-      </div>
+      <MissionControlToolbar
+        agents={agents}
+        filterPath={filterPath}
+        search={missionSearchQuery}
+        isSearchingText={missionSearch.isSearchingText}
+        onFilterPathChange={setFilterPath}
+        onSearchChange={setMissionSearchQuery}
+        onNewMission={() => setAgentPickerOpen(true)}
+      />
 
       {/* Board */}
       <div className="flex-1 min-h-0">
         <AIBoard
-          items={filteredItems}
+          items={missionSearch.items}
           columns={MC_COLUMNS}
           selectedId={mc.selectedId}
           onSelect={mc.setSelectedId}

--- a/app/src/components/mission-board-empty-state.tsx
+++ b/app/src/components/mission-board-empty-state.tsx
@@ -1,0 +1,84 @@
+import {
+  Button,
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyTitle,
+} from "@houston-ai/core";
+import { Loader2 } from "lucide-react";
+import { HoustonLogo } from "./shell/experience-card";
+
+interface MissionBoardEmptyLabels {
+  emptyTitle: string;
+  emptyDescription: string;
+  newMission: string;
+  searchEmptyTitle: string;
+  searchEmptyDescription: string;
+  searchSearchingTitle: string;
+  searchSearchingDescription: string;
+  clearSearch: string;
+}
+
+interface MissionBoardEmptyStateProps {
+  isSearch: boolean;
+  isSearchingText: boolean;
+  labels: MissionBoardEmptyLabels;
+  onNewMission: () => void;
+  onClearSearch: () => void;
+}
+
+export function MissionBoardEmptyState({
+  isSearch,
+  isSearchingText,
+  labels,
+  onNewMission,
+  onClearSearch,
+}: MissionBoardEmptyStateProps) {
+  if (isSearch) {
+    return (
+      <Empty className="border-0">
+        <EmptyHeader>
+          <EmptyTitle>
+            {isSearchingText ? labels.searchSearchingTitle : labels.searchEmptyTitle}
+          </EmptyTitle>
+          <EmptyDescription>
+            {isSearchingText ? labels.searchSearchingDescription : labels.searchEmptyDescription}
+          </EmptyDescription>
+        </EmptyHeader>
+        {isSearchingText ? (
+          <div className="mt-4 flex h-9 items-center justify-center">
+            <Loader2 className="size-4 animate-spin text-muted-foreground" />
+          </div>
+        ) : (
+          <Button
+            className="mt-4 rounded-full"
+            size="sm"
+            variant="outline"
+            onClick={onClearSearch}
+          >
+            {labels.clearSearch}
+          </Button>
+        )}
+      </Empty>
+    );
+  }
+
+  return (
+    <Empty className="border-0">
+      <EmptyHeader>
+        <EmptyTitle>{labels.emptyTitle}</EmptyTitle>
+        <EmptyDescription>
+          {labels.emptyDescription}
+        </EmptyDescription>
+      </EmptyHeader>
+      <Button
+        className="mt-4 rounded-full gap-1.5"
+        size="sm"
+        onClick={onNewMission}
+      >
+        <HoustonLogo size={16} />
+        {labels.newMission}
+      </Button>
+    </Empty>
+  );
+}

--- a/app/src/components/mission-control-toolbar.tsx
+++ b/app/src/components/mission-control-toolbar.tsx
@@ -1,0 +1,88 @@
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@houston-ai/core";
+import { ChevronDown } from "lucide-react";
+import { HoustonLogo } from "./shell/experience-card";
+import { AgentMiniAvatar } from "./shell/experience-card";
+import type { Agent } from "../lib/types";
+import { MissionSearchInput } from "./mission-search-input";
+
+interface MissionControlToolbarProps {
+  agents: Agent[];
+  filterPath: string;
+  search: string;
+  isSearchingText: boolean;
+  onFilterPathChange: (path: string) => void;
+  onSearchChange: (value: string) => void;
+  onNewMission: () => void;
+}
+
+export function MissionControlToolbar({
+  agents,
+  filterPath,
+  search,
+  isSearchingText,
+  onFilterPathChange,
+  onSearchChange,
+  onNewMission,
+}: MissionControlToolbarProps) {
+  const { t } = useTranslation("dashboard");
+  const selectedAgent = agents.find((agent) => agent.folderPath === filterPath);
+
+  return (
+    <div className="shrink-0 px-5 pt-4">
+      <div className="mb-3 flex flex-col gap-3 lg:flex-row lg:items-center">
+        <h1 className="text-xl font-semibold text-foreground">
+          {t("title")}
+        </h1>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center lg:ml-auto">
+          <MissionSearchInput
+            value={search}
+            isSearchingText={isSearchingText}
+            labels={{
+              placeholder: t("search.placeholder"),
+              clear: t("search.clear"),
+              searchingText: t("search.searchingText"),
+            }}
+            className="relative sm:w-[280px] lg:w-[320px]"
+            onChange={onSearchChange}
+          />
+          <div className="flex items-center gap-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline" className="rounded-full gap-1.5">
+                  {selectedAgent?.name ?? t("filter.allAgents")}
+                  <ChevronDown className="size-3.5 text-muted-foreground" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => onFilterPathChange("")}>
+                  {t("filter.allAgents")}
+                </DropdownMenuItem>
+                {agents.map((agent) => (
+                  <DropdownMenuItem
+                    key={agent.id}
+                    onClick={() => onFilterPathChange(agent.folderPath)}
+                    className="gap-2"
+                  >
+                    <AgentMiniAvatar color={agent.color} />
+                    {agent.name}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+            <Button data-keep-panel-open onClick={onNewMission}>
+              <HoustonLogo size={16} />
+              {t("empty.newMission")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/mission-search-input.tsx
+++ b/app/src/components/mission-search-input.tsx
@@ -1,0 +1,55 @@
+import { Input } from "@houston-ai/core";
+import { Loader2, Search, X } from "lucide-react";
+
+interface MissionSearchInputLabels {
+  placeholder: string;
+  clear: string;
+  searchingText: string;
+}
+
+interface MissionSearchInputProps {
+  value: string;
+  isSearchingText: boolean;
+  labels: MissionSearchInputLabels;
+  className?: string;
+  onChange: (value: string) => void;
+}
+
+export function MissionSearchInput({
+  value,
+  isSearchingText,
+  labels,
+  className,
+  onChange,
+}: MissionSearchInputProps) {
+  return (
+    <div className={className ?? "relative"}>
+      <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+      <Input
+        type="search"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={labels.placeholder}
+        aria-label={labels.placeholder}
+        autoComplete="off"
+        className="rounded-full border-border bg-background pl-9 pr-16 text-sm focus:bg-background"
+      />
+      {isSearchingText && (
+        <Loader2
+          className="pointer-events-none absolute right-9 top-1/2 size-4 -translate-y-1/2 animate-spin text-muted-foreground"
+          aria-label={labels.searchingText}
+        />
+      )}
+      {value && (
+        <button
+          type="button"
+          onClick={() => onChange("")}
+          className="absolute right-2 top-1/2 flex size-6 -translate-y-1/2 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+          aria-label={labels.clear}
+        >
+          <X className="size-3.5" />
+        </button>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/mission-search.ts
+++ b/app/src/components/mission-search.ts
@@ -1,0 +1,89 @@
+import type { KanbanItem } from "@houston-ai/board";
+import type { FeedItem } from "@houston-ai/chat";
+
+export type MissionSearchMode = "none" | "title" | "text";
+
+export interface MissionSearchResult<T> {
+  items: T[];
+  mode: MissionSearchMode;
+  query: string;
+  hasQuery: boolean;
+}
+
+const COMBINING_MARKS = /[\u0300-\u036f]/g;
+
+export function normalizeMissionSearchQuery(value: string): string {
+  return value
+    .normalize("NFKD")
+    .replace(COMBINING_MARKS, "")
+    .trim()
+    .toLocaleLowerCase();
+}
+
+function queryTerms(query: string): string[] {
+  return normalizeMissionSearchQuery(query).split(/\s+/).filter(Boolean);
+}
+
+function matchesTerms(value: string | undefined, terms: string[]): boolean {
+  if (!value || terms.length === 0) return false;
+  const normalized = normalizeMissionSearchQuery(value);
+  return terms.every((term) => normalized.includes(term));
+}
+
+function feedValueToText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+function feedItemToSearchText(item: FeedItem): string {
+  switch (item.feed_type) {
+    case "tool_call":
+      return `${item.data.name} ${feedValueToText(item.data.input)}`;
+    case "tool_result":
+      return item.data.content;
+    case "file_changes":
+      return [...item.data.created, ...item.data.modified].join("\n");
+    case "final_result":
+      return item.data.result;
+    default:
+      return feedValueToText(item.data);
+  }
+}
+
+export function buildMissionHistorySearchText(items: FeedItem[]): string {
+  return items.map(feedItemToSearchText).filter(Boolean).join("\n");
+}
+
+export function searchMissions<T extends KanbanItem>(
+  items: T[],
+  rawQuery: string,
+  historyTextById: Record<string, string> = {},
+): MissionSearchResult<T> {
+  const query = normalizeMissionSearchQuery(rawQuery);
+  const terms = queryTerms(rawQuery);
+  if (terms.length === 0) {
+    return { items, mode: "none", query, hasQuery: false };
+  }
+
+  const titleMatches = items.filter((item) => matchesTerms(item.title, terms));
+  if (titleMatches.length > 0) {
+    return { items: titleMatches, mode: "title", query, hasQuery: true };
+  }
+
+  const textMatches = items.filter((item) => {
+    const text = [item.description, historyTextById[item.id]]
+      .filter(Boolean)
+      .join("\n");
+    return matchesTerms(text, terms);
+  });
+
+  return { items: textMatches, mode: "text", query, hasQuery: true };
+}

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -23,6 +23,9 @@ import type { TabProps } from "../../lib/types";
 import { useDetailPanelContainer } from "../shell/detail-panel-context";
 import { HoustonHelmet, HoustonThinkingIndicator } from "../shell/experience-card";
 import { resolveAgentColor } from "../../lib/agent-colors";
+import { MissionSearchInput } from "../mission-search-input";
+import { MissionBoardEmptyState } from "../mission-board-empty-state";
+import { useMissionSearch } from "../use-mission-search";
 
 // Stable empty reference so the feed store selector doesn't return a new
 // object every render when this agent has no feeds yet (which would otherwise
@@ -70,6 +73,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
   const path = agent.folderPath;
   const agentModes = agentDef.config.agents;
   const [pendingAgentMode, setPendingAgentMode] = useState<string | null>(null);
+  const [missionSearchQuery, setMissionSearchQuery] = useState("");
   const { data: rawItems } = useActivity(path);
   const deleteActivity = useDeleteActivity(path);
   const updateActivity = useUpdateActivity(path);
@@ -91,24 +95,27 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
   const emptyAutoOpenKeyRef = useRef<string | null>(null);
   const [newPanelOpenerReady, setNewPanelOpenerReady] = useState(false);
 
-  const items: KanbanItem[] = (rawItems ?? []).map((t) => {
-    const mode = agentModes?.find((m) => m.id === t.agent);
-    return {
-      id: t.id,
-      title: t.title,
-      description: t.description,
-      status: t.status,
-      updatedAt: t.updated_at ?? new Date().toISOString(),
-      group: agent.name,
-      tags: mode ? [mode.name] : (t.routine_id ? ["Routine"] : undefined),
-      metadata: {
-        ...(t.session_key ? { sessionKey: t.session_key } : {}),
-        ...(t.routine_id ? { routineId: t.routine_id } : {}),
-        ...(t.agent ? { agent: t.agent } : {}),
-        ...(t.worktree_path ? { worktreePath: t.worktree_path } : {}),
-      },
-    };
-  });
+  const items: KanbanItem[] = useMemo(
+    () => (rawItems ?? []).map((t) => {
+      const mode = agentModes?.find((m) => m.id === t.agent);
+      return {
+        id: t.id,
+        title: t.title,
+        description: t.description,
+        status: t.status,
+        updatedAt: t.updated_at ?? new Date().toISOString(),
+        group: agent.name,
+        tags: mode ? [mode.name] : (t.routine_id ? ["Routine"] : undefined),
+        metadata: {
+          ...(t.session_key ? { sessionKey: t.session_key } : {}),
+          ...(t.routine_id ? { routineId: t.routine_id } : {}),
+          ...(t.agent ? { agent: t.agent } : {}),
+          ...(t.worktree_path ? { worktreePath: t.worktree_path } : {}),
+        },
+      };
+    }),
+    [agent.name, agentModes, rawItems],
+  );
 
   // Read and consume pending selection from Mission Control
   const pendingId = useUIStore((s) => s.activityPanelId);
@@ -233,8 +240,30 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
     [setOnStartMission, setBoardActions, agentModes],
   );
 
+  const loadHistory = useCallback(
+    async (sessionKey: string) => {
+      const history = await tauriChat.loadHistory(path, sessionKey);
+      return history as FeedItem[];
+    },
+    [path],
+  );
+  const handleMissionSearchError = useCallback(() => {
+    addToast({
+      title: t("search.historyErrorTitle"),
+      description: t("search.historyErrorDescription"),
+      variant: "error",
+    });
+  }, [addToast, t]);
+  const missionSearch = useMissionSearch({
+    items,
+    query: missionSearchQuery,
+    loadHistory,
+    onHistoryLoadError: handleMissionSearchError,
+  });
+
   useEffect(() => {
     if (!rawItems) return;
+    if (missionSearch.hasQuery) return;
     if (rawItems.length > 0) {
       if (emptyAutoOpenKeyRef.current === path) emptyAutoOpenKeyRef.current = null;
       return;
@@ -247,6 +276,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
   }, [
     agentModes,
     missionPanelOpen,
+    missionSearch.hasQuery,
     newPanelOpenerReady,
     path,
     rawItems,
@@ -260,14 +290,6 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
       setBoardActions([]);
     };
   }, [setOnStartMission, setBoardActions]);
-
-  const loadHistory = useCallback(
-    async (sessionKey: string) => {
-      const history = await tauriChat.loadHistory(path, sessionKey);
-      return history as FeedItem[];
-    },
-    [path],
-  );
 
   const handleDelete = useCallback(
     async (item: KanbanItem) => {
@@ -443,65 +465,103 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
     [handleRunInTerminal, t],
   );
 
+  const emptyBoard = (
+    <MissionBoardEmptyState
+      isSearch={missionSearch.hasQuery}
+      isSearchingText={missionSearch.isSearchingText}
+      labels={{
+        emptyTitle: t("empty.title"),
+        emptyDescription: t("empty.description"),
+        newMission: t("empty.newMission"),
+        searchEmptyTitle: t("search.emptyTitle"),
+        searchEmptyDescription: t("search.emptyDescription"),
+        searchSearchingTitle: t("search.searchingTitle"),
+        searchSearchingDescription: t("search.searchingDescription"),
+        clearSearch: t("search.clearCta"),
+      }}
+      onNewMission={() => {
+        if (agentModes?.length) setPendingAgentMode(agentModes[0].id);
+        openerRef.current?.();
+      }}
+      onClearSearch={() => setMissionSearchQuery("")}
+    />
+  );
+
   return (
     <div className="flex flex-col h-full">
-      <AIBoard
-        items={items}
-        columns={boardColumns}
-        selectedId={selectedId}
-        onSelect={setSelectedId}
-        panelContainer={panelContainer}
-        feedItems={feedItems}
-        isLoading={effectiveLoading}
-        sessionKeyFor={sessionKeyFor}
-        onDelete={handleDelete}
-        onApprove={handleApprove}
-        onRename={(item, newTitle) => {
-          tauriActivity.update(path, item.id, { title: newTitle }).catch(console.error);
-        }}
-        onCreateConversation={handleCreateConversation}
-        onSendMessage={handleSendMessage}
-        onLoadHistory={loadHistory}
-        onHistoryLoaded={handleHistoryLoaded}
-        onNewPanelOpenerReady={handleOpenerReady}
-        onPanelOpenChange={setMissionPanelOpen}
-        onStopSession={handleStopSession}
-        drafts={boardDrafts}
-        onDraftChange={handleDraftChange}
-        onNotice={handleNotice}
-        onOpenLink={handleOpenLink}
-        actions={agentModes ? cardActions : undefined}
-        panelActions={panelActions}
-        cardAvatar={<HoustonHelmet color={resolveAgentColor(agent.color)} size={14} />}
-        thinkingIndicator={<HoustonThinkingIndicator />}
-        panelAgentName={agent.name}
-        panelAvatar={
-          <PanelAvatar
-            color={agent.color}
-            isRunning={(rawItems ?? []).some((a) => a.id === selectedId && a.status === "running")}
-          />
-        }
-        cardLabels={cardLabels}
-        // Per-agent panel features (skill cards, selected Action, model
-        // selector, Actions button, tool/link renderers) all come
-        // from the shared `useAgentChatPanel` hook so Mission Control
-        // and the per-agent BoardTab share one implementation.
-        chatEmptyState={panel.chatEmptyState}
-        composerHeader={panel.composerHeader}
-        canSendEmpty={panel.canSendEmpty}
-        onComposerSubmit={panel.onComposerSubmit}
-        footer={panel.footer}
-        renderUserMessage={panel.renderUserMessage}
-        renderSystemMessage={panel.renderSystemMessage}
-        mapFeedItems={panel.mapFeedItems}
-        afterMessages={panel.afterMessages}
-        isSpecialTool={panel.isSpecialTool}
-        renderToolResult={panel.renderToolResult}
-        processLabels={panel.processLabels}
-        getThinkingMessage={panel.getThinkingMessage}
-        renderTurnSummary={panel.renderTurnSummary}
-        renderLink={panel.renderLink}
-      />
+      <div className="shrink-0 px-3 pt-3">
+        <MissionSearchInput
+          value={missionSearchQuery}
+          isSearchingText={missionSearch.isSearchingText}
+          labels={{
+            placeholder: t("search.placeholder"),
+            clear: t("search.clear"),
+            searchingText: t("search.searchingText"),
+          }}
+          className="relative max-w-sm"
+          onChange={setMissionSearchQuery}
+        />
+      </div>
+      <div className="flex-1 min-h-0">
+        <AIBoard
+          items={missionSearch.items}
+          columns={boardColumns}
+          selectedId={selectedId}
+          onSelect={setSelectedId}
+          panelContainer={panelContainer}
+          feedItems={feedItems}
+          isLoading={effectiveLoading}
+          sessionKeyFor={sessionKeyFor}
+          onDelete={handleDelete}
+          onApprove={handleApprove}
+          onRename={(item, newTitle) => {
+            tauriActivity.update(path, item.id, { title: newTitle }).catch(console.error);
+          }}
+          onCreateConversation={handleCreateConversation}
+          onSendMessage={handleSendMessage}
+          onLoadHistory={loadHistory}
+          onHistoryLoaded={handleHistoryLoaded}
+          onNewPanelOpenerReady={handleOpenerReady}
+          emptyState={emptyBoard}
+          onPanelOpenChange={setMissionPanelOpen}
+          onStopSession={handleStopSession}
+          drafts={boardDrafts}
+          onDraftChange={handleDraftChange}
+          onNotice={handleNotice}
+          onOpenLink={handleOpenLink}
+          actions={agentModes ? cardActions : undefined}
+          panelActions={panelActions}
+          cardAvatar={<HoustonHelmet color={resolveAgentColor(agent.color)} size={14} />}
+          thinkingIndicator={<HoustonThinkingIndicator />}
+          panelAgentName={agent.name}
+          panelAvatar={
+            <PanelAvatar
+              color={agent.color}
+              isRunning={(rawItems ?? []).some((a) => a.id === selectedId && a.status === "running")}
+            />
+          }
+          cardLabels={cardLabels}
+          // Per-agent panel features (skill cards, selected Action, model
+          // selector, Actions button, tool/link renderers) all come
+          // from the shared `useAgentChatPanel` hook so Mission Control
+          // and the per-agent BoardTab share one implementation.
+          chatEmptyState={panel.chatEmptyState}
+          composerHeader={panel.composerHeader}
+          canSendEmpty={panel.canSendEmpty}
+          onComposerSubmit={panel.onComposerSubmit}
+          footer={panel.footer}
+          renderUserMessage={panel.renderUserMessage}
+          renderSystemMessage={panel.renderSystemMessage}
+          mapFeedItems={panel.mapFeedItems}
+          afterMessages={panel.afterMessages}
+          isSpecialTool={panel.isSpecialTool}
+          renderToolResult={panel.renderToolResult}
+          processLabels={panel.processLabels}
+          getThinkingMessage={panel.getThinkingMessage}
+          renderTurnSummary={panel.renderTurnSummary}
+          renderLink={panel.renderLink}
+        />
+      </div>
       {panel.pickerDialog}
     </div>
   );

--- a/app/src/components/use-mission-search.ts
+++ b/app/src/components/use-mission-search.ts
@@ -1,0 +1,95 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { KanbanItem } from "@houston-ai/board";
+import type { FeedItem } from "@houston-ai/chat";
+import {
+  buildMissionHistorySearchText,
+  normalizeMissionSearchQuery,
+  searchMissions,
+} from "./mission-search";
+
+interface UseMissionSearchOptions {
+  items: KanbanItem[];
+  query: string;
+  loadHistory: (sessionKey: string) => Promise<FeedItem[]>;
+  onHistoryLoadError?: () => void;
+}
+
+function sessionKeyFor(item: KanbanItem): string {
+  const key = item.metadata?.sessionKey;
+  return typeof key === "string" ? key : `activity-${item.id}`;
+}
+
+export function useMissionSearch({
+  items,
+  query,
+  loadHistory,
+  onHistoryLoadError,
+}: UseMissionSearchOptions) {
+  const [historyTextById, setHistoryTextById] = useState<Record<string, string>>({});
+  const [pendingCount, setPendingCount] = useState(0);
+  const loadingIdsRef = useRef<Set<string>>(new Set());
+  const mountedRef = useRef(true);
+  const normalizedQuery = normalizeMissionSearchQuery(query);
+
+  const result = useMemo(
+    () => searchMissions(items, query, historyTextById),
+    [items, query, historyTextById],
+  );
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!normalizedQuery || result.mode === "title") return;
+    const missing = items.filter(
+      (item) => historyTextById[item.id] === undefined && !loadingIdsRef.current.has(item.id),
+    );
+    if (missing.length === 0) return;
+
+    for (const item of missing) loadingIdsRef.current.add(item.id);
+    setPendingCount((count) => count + missing.length);
+
+    Promise.allSettled(
+      missing.map(async (item) => {
+        const history = await loadHistory(sessionKeyFor(item));
+        return [item.id, buildMissionHistorySearchText(history)] as const;
+      }),
+    )
+      .then((settled) => {
+        const next: Record<string, string> = {};
+        let failed = false;
+
+        settled.forEach((entry, index) => {
+          const item = missing[index];
+          if (entry.status === "fulfilled") {
+            const [id, text] = entry.value;
+            next[id] = text;
+            return;
+          }
+          console.error("[mission-search] history load failed", entry.reason);
+          next[item.id] = "";
+          failed = true;
+        });
+
+        if (!mountedRef.current) return;
+        setHistoryTextById((prev) => ({ ...prev, ...next }));
+        if (failed) onHistoryLoadError?.();
+      })
+      .finally(() => {
+        for (const item of missing) loadingIdsRef.current.delete(item.id);
+        if (mountedRef.current) {
+          setPendingCount((count) => Math.max(0, count - missing.length));
+        }
+      });
+  }, [historyTextById, items, loadHistory, normalizedQuery, onHistoryLoadError, result.mode]);
+
+  return {
+    items: result.items,
+    mode: result.mode,
+    hasQuery: result.hasQuery,
+    isSearchingText: result.mode === "text" && pendingCount > 0,
+  };
+}

--- a/app/src/locales/en/board.json
+++ b/app/src/locales/en/board.json
@@ -13,7 +13,20 @@
   },
   "empty": {
     "title": "No conversations yet",
-    "description": "Start a new conversation to delegate work to an agent."
+    "description": "Start a new conversation to delegate work to an agent.",
+    "newMission": "New mission"
+  },
+  "search": {
+    "placeholder": "Search missions",
+    "clear": "Clear search",
+    "clearCta": "Clear search",
+    "searchingText": "Searching mission text",
+    "searchingTitle": "Searching mission text",
+    "searchingDescription": "Looking through older messages now.",
+    "emptyTitle": "No matching missions",
+    "emptyDescription": "Try a different search or clear the current one.",
+    "historyErrorTitle": "Couldn't search every mission",
+    "historyErrorDescription": "Some older mission text could not be loaded."
   },
   "toasts": {
     "attached": "Attached: {{names}}"

--- a/app/src/locales/en/dashboard.json
+++ b/app/src/locales/en/dashboard.json
@@ -3,6 +3,18 @@
   "filter": {
     "allAgents": "All agents"
   },
+  "search": {
+    "placeholder": "Search missions",
+    "clear": "Clear search",
+    "clearCta": "Clear search",
+    "searchingText": "Searching mission text",
+    "searchingTitle": "Searching mission text",
+    "searchingDescription": "Looking through older messages now.",
+    "emptyTitle": "No matching missions",
+    "emptyDescription": "Try a different search or clear the current one.",
+    "historyErrorTitle": "Couldn't search every mission",
+    "historyErrorDescription": "Some older mission text could not be loaded."
+  },
   "columns": {
     "running": "Running",
     "needsYou": "Needs you",

--- a/app/src/locales/es/board.json
+++ b/app/src/locales/es/board.json
@@ -13,7 +13,20 @@
   },
   "empty": {
     "title": "Aún no hay conversaciones",
-    "description": "Inicia una conversación nueva para delegarle trabajo a un agente."
+    "description": "Inicia una conversación nueva para delegarle trabajo a un agente.",
+    "newMission": "Nueva misión"
+  },
+  "search": {
+    "placeholder": "Buscar misiones",
+    "clear": "Borrar búsqueda",
+    "clearCta": "Borrar búsqueda",
+    "searchingText": "Buscando en el texto de las misiones",
+    "searchingTitle": "Buscando en el texto de las misiones",
+    "searchingDescription": "Revisando mensajes anteriores.",
+    "emptyTitle": "No hay misiones que coincidan",
+    "emptyDescription": "Prueba otra búsqueda o borra la actual.",
+    "historyErrorTitle": "No se pudieron buscar todas las misiones",
+    "historyErrorDescription": "No se pudo cargar parte del texto de misiones anteriores."
   },
   "toasts": {
     "attached": "Adjuntó: {{names}}"

--- a/app/src/locales/es/dashboard.json
+++ b/app/src/locales/es/dashboard.json
@@ -3,6 +3,18 @@
   "filter": {
     "allAgents": "Todos los agentes"
   },
+  "search": {
+    "placeholder": "Buscar misiones",
+    "clear": "Borrar búsqueda",
+    "clearCta": "Borrar búsqueda",
+    "searchingText": "Buscando en el texto de las misiones",
+    "searchingTitle": "Buscando en el texto de las misiones",
+    "searchingDescription": "Revisando mensajes anteriores.",
+    "emptyTitle": "No hay misiones que coincidan",
+    "emptyDescription": "Prueba otra búsqueda o borra la actual.",
+    "historyErrorTitle": "No se pudieron buscar todas las misiones",
+    "historyErrorDescription": "No se pudo cargar parte del texto de misiones anteriores."
+  },
   "columns": {
     "running": "En curso",
     "needsYou": "Necesita tu atención",

--- a/app/src/locales/pt/board.json
+++ b/app/src/locales/pt/board.json
@@ -13,7 +13,20 @@
   },
   "empty": {
     "title": "Ainda sem conversas",
-    "description": "Comece uma conversa nova para delegar trabalho a um agente."
+    "description": "Comece uma conversa nova para delegar trabalho a um agente.",
+    "newMission": "Nova missão"
+  },
+  "search": {
+    "placeholder": "Buscar missões",
+    "clear": "Limpar busca",
+    "clearCta": "Limpar busca",
+    "searchingText": "Buscando no texto das missões",
+    "searchingTitle": "Buscando no texto das missões",
+    "searchingDescription": "Verificando mensagens antigas agora.",
+    "emptyTitle": "Nenhuma missão encontrada",
+    "emptyDescription": "Tente outra busca ou limpe a atual.",
+    "historyErrorTitle": "Não foi possível buscar todas as missões",
+    "historyErrorDescription": "Parte do texto de missões antigas não pôde ser carregada."
   },
   "toasts": {
     "attached": "Anexou: {{names}}"

--- a/app/src/locales/pt/dashboard.json
+++ b/app/src/locales/pt/dashboard.json
@@ -3,6 +3,18 @@
   "filter": {
     "allAgents": "Todos os agentes"
   },
+  "search": {
+    "placeholder": "Buscar missões",
+    "clear": "Limpar busca",
+    "clearCta": "Limpar busca",
+    "searchingText": "Buscando no texto das missões",
+    "searchingTitle": "Buscando no texto das missões",
+    "searchingDescription": "Verificando mensagens antigas agora.",
+    "emptyTitle": "Nenhuma missão encontrada",
+    "emptyDescription": "Tente outra busca ou limpe a atual.",
+    "historyErrorTitle": "Não foi possível buscar todas as missões",
+    "historyErrorDescription": "Parte do texto de missões antigas não pôde ser carregada."
+  },
   "columns": {
     "running": "Em execução",
     "needsYou": "Precisa de você",

--- a/app/tests/mission-search.test.ts
+++ b/app/tests/mission-search.test.ts
@@ -1,0 +1,75 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  buildMissionHistorySearchText,
+  normalizeMissionSearchQuery,
+  searchMissions,
+} from "../src/components/mission-search.ts";
+
+const missions = [
+  {
+    id: "one",
+    title: "Budget review",
+    description: "Discuss launch plan",
+    status: "done",
+    updatedAt: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "two",
+    title: "Weekly report",
+    description: "Find budget notes in transcript",
+    status: "done",
+    updatedAt: "2026-01-02T00:00:00Z",
+  },
+  {
+    id: "three",
+    title: "Customer follow-up",
+    description: "Send agenda",
+    status: "running",
+    updatedAt: "2026-01-03T00:00:00Z",
+  },
+];
+
+describe("mission search", () => {
+  it("normalizes whitespace, case, and accents", () => {
+    strictEqual(normalizeMissionSearchQuery("  São PAULO  "), "sao paulo");
+  });
+
+  it("returns title matches before body matches", () => {
+    const result = searchMissions(missions, "budget");
+
+    strictEqual(result.mode, "title");
+    deepStrictEqual(result.items.map((item) => item.id), ["one"]);
+  });
+
+  it("falls back to mission descriptions when no title matches", () => {
+    const result = searchMissions(missions, "transcript budget");
+
+    strictEqual(result.mode, "text");
+    deepStrictEqual(result.items.map((item) => item.id), ["two"]);
+  });
+
+  it("falls back to loaded chat history text", () => {
+    const result = searchMissions(missions, "vendor contract", {
+      three: "Assistant found the vendor contract in old messages.",
+    });
+
+    strictEqual(result.mode, "text");
+    deepStrictEqual(result.items.map((item) => item.id), ["three"]);
+  });
+
+  it("builds searchable text from feed items", () => {
+    const text = buildMissionHistorySearchText([
+      { feed_type: "user_message", data: "Send invoice" },
+      { feed_type: "tool_call", data: { name: "Grep", input: { pattern: "invoice" } } },
+      { feed_type: "tool_result", data: { content: "Found billing.csv", is_error: false } },
+      { feed_type: "file_changes", data: { created: ["out.md"], modified: ["billing.csv"] } },
+      { feed_type: "final_result", data: { result: "Invoice sent", cost_usd: null, duration_ms: null } },
+    ]);
+
+    strictEqual(text.includes("Send invoice"), true);
+    strictEqual(text.includes("Grep"), true);
+    strictEqual(text.includes("billing.csv"), true);
+    strictEqual(text.includes("Invoice sent"), true);
+  });
+});


### PR DESCRIPTION
## Summary
- add shared mission search for Mission Control and per-agent boards
- search titles first, then mission descriptions and loaded chat history text
- add localized search and empty states for en, es, and pt

## Affected files
- app/src/components/dashboard.tsx
- app/src/components/tabs/board-tab.tsx
- app/src/components/mission-search*.tsx
- app/src/components/use-mission-search.ts
- app/src/locales/{en,es,pt}/{board,dashboard}.json
- app/tests/mission-search.test.ts

## Verification
- pnpm typecheck
- pnpm check-locales
- pnpm build
- node --experimental-strip-types --test app/tests/mission-search.test.ts