### PR TITLE
fix: avoid keychain auth for local builds

### DIFF
--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -1,19 +1,28 @@
 use std::path::PathBuf;
 
 fn main() {
+    let mut dotenv_pairs: Vec<(String, String)> = Vec::new();
+
     // Load .env file so env!() macros in slack.rs can read credentials at build time.
     if let Ok(env_path) = std::fs::canonicalize(".env") {
-        for line in std::fs::read_to_string(&env_path).unwrap_or_default().lines() {
+        for line in std::fs::read_to_string(&env_path)
+            .unwrap_or_default()
+            .lines()
+        {
             let line = line.trim();
             if line.is_empty() || line.starts_with('#') {
                 continue;
             }
             if let Some((key, value)) = line.split_once('=') {
-                println!("cargo:rustc-env={}={}", key.trim(), value.trim());
+                let key = key.trim().to_string();
+                let value = value.trim().to_string();
+                println!("cargo:rustc-env={key}={value}");
+                dotenv_pairs.push((key, value));
             }
         }
         println!("cargo:rerun-if-changed={}", env_path.display());
     }
+    configure_auth_storage(&dotenv_pairs);
 
     // Stage the houston-engine binary into `binaries/houston-engine-<triple>`
     // so tauri's `externalBin` picks it up for bundling. The user is expected
@@ -39,6 +48,43 @@ fn main() {
     tauri_build::build()
 }
 
+fn configure_auth_storage(dotenv_pairs: &[(String, String)]) {
+    println!("cargo:rerun-if-env-changed=HOUSTON_AUTH_STORAGE");
+    println!("cargo:rerun-if-env-changed=CI");
+
+    let mode = resolve_auth_storage_mode(dotenv_pairs);
+    println!("cargo:rustc-env=HOUSTON_AUTH_STORAGE_MODE={mode}");
+}
+
+fn resolve_auth_storage_mode(dotenv_pairs: &[(String, String)]) -> &'static str {
+    if let Some(override_mode) = env_value("HOUSTON_AUTH_STORAGE", dotenv_pairs) {
+        let normalized = override_mode.trim().to_ascii_lowercase();
+        return match normalized.as_str() {
+            "keychain" => "keychain",
+            "browser" => "browser",
+            _ => panic!("HOUSTON_AUTH_STORAGE must be keychain or browser"),
+        };
+    }
+
+    if env_value("CI", dotenv_pairs).as_deref() == Some("true") {
+        return "keychain";
+    }
+    "browser"
+}
+
+fn env_value(key: &str, dotenv_pairs: &[(String, String)]) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| {
+            dotenv_pairs
+                .iter()
+                .find(|(candidate, _)| candidate == key)
+                .map(|(_, value)| value.clone())
+                .filter(|value| !value.trim().is_empty())
+        })
+}
+
 fn ensure_resources_bin_dir() {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     let dir = manifest.join("resources").join("bin");
@@ -52,9 +98,10 @@ fn ensure_resources_bin_dir() {
 
 fn stage_engine_sidecar() -> Result<(), String> {
     let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    let workspace = manifest.parent().and_then(|p| p.parent()).ok_or(
-        "could not resolve workspace root from CARGO_MANIFEST_DIR",
-    )?;
+    let workspace = manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or("could not resolve workspace root from CARGO_MANIFEST_DIR")?;
     let triple = std::env::var("TARGET").unwrap_or_default();
     let bin_name = if cfg!(windows) {
         "houston-engine.exe"
@@ -72,11 +119,23 @@ fn stage_engine_sidecar() -> Result<(), String> {
     //   4. `target/debug/` — default dev build.
     let mut candidates: Vec<PathBuf> = Vec::new();
     if !triple.is_empty() {
-        candidates.push(workspace.join("target").join(&triple).join("release").join(bin_name));
+        candidates.push(
+            workspace
+                .join("target")
+                .join(&triple)
+                .join("release")
+                .join(bin_name),
+        );
     }
     candidates.push(workspace.join("target").join("release").join(bin_name));
     if !triple.is_empty() {
-        candidates.push(workspace.join("target").join(&triple).join("debug").join(bin_name));
+        candidates.push(
+            workspace
+                .join("target")
+                .join(&triple)
+                .join("debug")
+                .join(bin_name),
+        );
     }
     candidates.push(workspace.join("target").join("debug").join(bin_name));
     let src = candidates
@@ -104,9 +163,6 @@ fn stage_engine_sidecar() -> Result<(), String> {
         perms.set_mode(0o755);
         std::fs::set_permissions(&dest, perms).map_err(|e| format!("chmod sidecar: {e}"))?;
     }
-    println!(
-        "cargo:rerun-if-changed={}",
-        src.display()
-    );
+    println!("cargo:rerun-if-changed={}", src.display());
     Ok(())
 }

--- a/app/src-tauri/src/auth.rs
+++ b/app/src-tauri/src/auth.rs
@@ -67,6 +67,10 @@ pub fn emit_deep_link(handle: &AppHandle, url: &str) {
 /// corrupt JSON, locked Keychain) all resolve to `None` silently — the engine
 /// runs fine without an identity.
 pub fn persisted_user_id() -> Option<String> {
+    if option_env!("HOUSTON_AUTH_STORAGE_MODE") != Some("keychain") {
+        return None;
+    }
+
     // Storage key must match `storageKey` in app/src/lib/supabase.ts.
     let entry = Entry::new(SERVICE, "houston-auth").ok()?;
     let raw = entry.get_password().ok()?;
@@ -100,5 +104,12 @@ mod tests {
         auth_remove_item(key.into()).await.unwrap();
         let after = auth_get_item(key.into()).await.unwrap();
         assert!(after.is_none());
+    }
+
+    #[test]
+    fn local_auth_storage_does_not_read_persisted_keychain_user() {
+        if option_env!("HOUSTON_AUTH_STORAGE_MODE") == Some("browser") {
+            assert!(persisted_user_id().is_none());
+        }
     }
 }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -196,7 +196,8 @@ pub fn run() {
             // signed in on a previous launch), stamp the subprocess with the
             // user_id so future cloud-side operations can attribute work to
             // a user. Engine is prompt-agnostic about identity — treats this
-            // as an opaque string.
+            // as an opaque string. Local/ad-hoc builds compile auth storage
+            // in browser mode, so this returns before touching Keychain.
             if let Some(user_id) = auth::persisted_user_id() {
                 engine_env.push(("HOUSTON_APP_USER_ID".into(), user_id));
             }

--- a/app/src/lib/auth-storage.ts
+++ b/app/src/lib/auth-storage.ts
@@ -1,0 +1,42 @@
+export const RELEASE_AUTH_STORAGE_KEY = "houston-auth";
+
+const LOCAL_AUTH_STORAGE_PREFIX = "houston-auth-local";
+const FALLBACK_LOCAL_SCOPE = "default";
+
+export type AuthStorageMode = "keychain" | "browser";
+
+export type AuthStorageConfig = {
+  mode: AuthStorageMode;
+  storageKey: string;
+};
+
+type AuthStorageOptions = {
+  storageMode: string;
+  storageScope: string;
+};
+
+export function normalizeAuthStorageMode(mode: string): AuthStorageMode {
+  return mode === "keychain" ? "keychain" : "browser";
+}
+
+export function createLocalAuthStorageKey(storageScope: string): string {
+  const scope = storageScope.trim() || FALLBACK_LOCAL_SCOPE;
+  return `${LOCAL_AUTH_STORAGE_PREFIX}-${scope}`;
+}
+
+export function resolveAuthStorageConfig({
+  storageMode,
+  storageScope,
+}: AuthStorageOptions): AuthStorageConfig {
+  if (normalizeAuthStorageMode(storageMode) === "keychain") {
+    return {
+      mode: "keychain",
+      storageKey: RELEASE_AUTH_STORAGE_KEY,
+    };
+  }
+
+  return {
+    mode: "browser",
+    storageKey: createLocalAuthStorageKey(storageScope),
+  };
+}

--- a/app/src/lib/supabase.ts
+++ b/app/src/lib/supabase.ts
@@ -1,5 +1,6 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { invoke } from "@tauri-apps/api/core";
+import { resolveAuthStorageConfig } from "./auth-storage";
 
 // __SUPABASE_URL__ / __SUPABASE_ANON_KEY__ baked at build time by Vite.
 // Empty values → Supabase client still constructs but all auth calls are
@@ -8,11 +9,10 @@ const URL_ = typeof __SUPABASE_URL__ !== "undefined" ? __SUPABASE_URL__ : "";
 const KEY = typeof __SUPABASE_ANON_KEY__ !== "undefined" ? __SUPABASE_ANON_KEY__ : "";
 
 /**
- * Custom storage adapter that round-trips to Rust via the `auth_*` Tauri
+ * Release storage adapter that round-trips to Rust via the `auth_*` Tauri
  * commands, so Supabase session tokens live in macOS Keychain / Windows
- * Credential Manager — never localStorage, never disk. Supabase stores
- * the PKCE code verifier here too during OAuth, so the whole auth flow
- * is Keychain-backed end-to-end.
+ * Credential Manager, never localStorage or disk. Supabase stores the PKCE
+ * code verifier here too during OAuth, so release auth is Keychain-backed.
  */
 const keychainStorage = {
   async getItem(key: string): Promise<string | null> {
@@ -39,13 +39,49 @@ const keychainStorage = {
   },
 };
 
+const browserStorage = {
+  getItem(key: string): string | null {
+    try {
+      return globalThis.localStorage?.getItem(key) ?? null;
+    } catch {
+      return null;
+    }
+  },
+  setItem(key: string, value: string): void {
+    try {
+      globalThis.localStorage?.setItem(key, value);
+    } catch {
+      // Dev fallback. Session won't persist if browser storage is blocked.
+    }
+  },
+  removeItem(key: string): void {
+    try {
+      globalThis.localStorage?.removeItem(key);
+    } catch {
+      // best-effort
+    }
+  },
+};
+
+const authStorageConfig = resolveAuthStorageConfig({
+  storageMode:
+    typeof __HOUSTON_AUTH_STORAGE_MODE__ !== "undefined"
+      ? __HOUSTON_AUTH_STORAGE_MODE__
+      : "browser",
+  storageScope:
+    typeof __HOUSTON_AUTH_STORAGE_SCOPE__ !== "undefined"
+      ? __HOUSTON_AUTH_STORAGE_SCOPE__
+      : "",
+});
+
 export const supabase: SupabaseClient = createClient(
   URL_ || "https://placeholder.supabase.co",
   KEY || "placeholder-anon-key",
   {
     auth: {
-      storage: keychainStorage,
-      storageKey: "houston-auth",
+      storage:
+        authStorageConfig.mode === "keychain" ? keychainStorage : browserStorage,
+      storageKey: authStorageConfig.storageKey,
       autoRefreshToken: true,
       persistSession: true,
       // We listen for the deep-link URL in the app and call

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -5,3 +5,5 @@ declare const __POSTHOG_KEY__: string;
 declare const __POSTHOG_HOST__: string;
 declare const __SUPABASE_URL__: string;
 declare const __SUPABASE_ANON_KEY__: string;
+declare const __HOUSTON_AUTH_STORAGE_MODE__: string;
+declare const __HOUSTON_AUTH_STORAGE_SCOPE__: string;

--- a/app/tests/auth-storage.test.ts
+++ b/app/tests/auth-storage.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  RELEASE_AUTH_STORAGE_KEY,
+  createLocalAuthStorageKey,
+  normalizeAuthStorageMode,
+  resolveAuthStorageConfig,
+} from "../src/lib/auth-storage.ts";
+
+test("release auth storage uses Keychain-backed production key", () => {
+  assert.deepEqual(
+    resolveAuthStorageConfig({
+      storageMode: "keychain",
+      storageScope: "worktree-a",
+    }),
+    {
+      mode: "keychain",
+      storageKey: RELEASE_AUTH_STORAGE_KEY,
+    },
+  );
+});
+
+test("local auth storage uses browser storage scoped to worktree", () => {
+  assert.deepEqual(
+    resolveAuthStorageConfig({ storageMode: "browser", storageScope: "abc123" }),
+    {
+      mode: "browser",
+      storageKey: "houston-auth-local-abc123",
+    },
+  );
+});
+
+test("local auth storage falls back to stable nonempty scope", () => {
+  assert.equal(createLocalAuthStorageKey("   "), "houston-auth-local-default");
+});
+
+test("unknown auth storage mode fails closed to browser storage", () => {
+  assert.equal(normalizeAuthStorageMode("bad-value"), "browser");
+});

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,48 +1,73 @@
+import { createHash } from "node:crypto";
+import { realpathSync } from "node:fs";
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
 import tailwindcss from "@tailwindcss/vite";
 import { version } from "./package.json";
 
 const host = process.env.TAURI_DEV_HOST;
+const appRoot = realpathSync(process.cwd());
+const authStorageScope = createHash("sha256")
+  .update(appRoot)
+  .digest("hex")
+  .slice(0, 16);
+
+function resolveAuthStorageMode(
+  mode: string,
+  env: Record<string, string | undefined>,
+) {
+  const override = env.HOUSTON_AUTH_STORAGE?.trim().toLowerCase();
+  if (override === "keychain" || override === "browser") return override;
+  if (override) {
+    throw new Error("HOUSTON_AUTH_STORAGE must be keychain or browser");
+  }
+
+  if (mode !== "production") return "browser";
+  if (env.CI === "true") return "keychain";
+  return "browser";
+}
 
 // Pick from either the shell or a local `.env.local` (gitignored). CI sets
 // the vars in the shell via GitHub Secrets; locally you drop them in
 // `app/.env.local` so `pnpm tauri dev` picks them up without exports.
 export default defineConfig(({ mode }) => {
   const env = { ...loadEnv(mode, process.cwd(), ""), ...process.env };
+  const authStorageMode = resolveAuthStorageMode(mode, env);
   return {
-  plugins: [react(), tailwindcss()],
-  define: {
-    __APP_VERSION__: JSON.stringify(version),
-    __POSTHOG_KEY__: JSON.stringify(env.POSTHOG_KEY ?? ""),
-    __POSTHOG_HOST__: JSON.stringify(
-      env.POSTHOG_HOST ?? "https://us.i.posthog.com",
-    ),
-    __SUPABASE_URL__: JSON.stringify(env.SUPABASE_URL ?? ""),
-    __SUPABASE_ANON_KEY__: JSON.stringify(env.SUPABASE_ANON_KEY ?? ""),
-  },
-  clearScreen: false,
-  // Exclude workspace packages from Vite's dep pre-bundling so live edits
-  // are picked up immediately without stale cache issues.
-  optimizeDeps: {
-    exclude: [
-      "@houston-ai/chat",
-      "@houston-ai/core",
-      "@houston-ai/board",
-      "@houston-ai/layout",
-      "@houston-ai/events",
-      "@houston-ai/routines",
-      "@houston-ai/skills",
-      "@houston-ai/review",
-      "@houston-ai/agent",
-    ],
-  },
-  server: {
-    port: 1420,
-    strictPort: true,
-    host: host || false,
-    hmr: host ? { protocol: "ws", host, port: 1421 } : undefined,
-    watch: { ignored: ["**/src-tauri/**"] },
-  },
+    plugins: [react(), tailwindcss()],
+    define: {
+      __APP_VERSION__: JSON.stringify(version),
+      __POSTHOG_KEY__: JSON.stringify(env.POSTHOG_KEY ?? ""),
+      __POSTHOG_HOST__: JSON.stringify(
+        env.POSTHOG_HOST ?? "https://us.i.posthog.com",
+      ),
+      __SUPABASE_URL__: JSON.stringify(env.SUPABASE_URL ?? ""),
+      __SUPABASE_ANON_KEY__: JSON.stringify(env.SUPABASE_ANON_KEY ?? ""),
+      __HOUSTON_AUTH_STORAGE_MODE__: JSON.stringify(authStorageMode),
+      __HOUSTON_AUTH_STORAGE_SCOPE__: JSON.stringify(authStorageScope),
+    },
+    clearScreen: false,
+    // Exclude workspace packages from Vite's dep pre-bundling so live edits
+    // are picked up immediately without stale cache issues.
+    optimizeDeps: {
+      exclude: [
+        "@houston-ai/chat",
+        "@houston-ai/core",
+        "@houston-ai/board",
+        "@houston-ai/layout",
+        "@houston-ai/events",
+        "@houston-ai/routines",
+        "@houston-ai/skills",
+        "@houston-ai/review",
+        "@houston-ai/agent",
+      ],
+    },
+    server: {
+      port: 1420,
+      strictPort: true,
+      host: host || false,
+      hmr: host ? { protocol: "ws", host, port: 1421 } : undefined,
+      watch: { ignored: ["**/src-tauri/**"] },
+    },
   };
 });

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -1,18 +1,18 @@
 # Auth (Supabase + Google SSO)
 
-One-click Google sign-in on first launch. Tokens in macOS Keychain / Windows Credential Manager — never localStorage, never disk. Identifies users in PostHog, lays the foundation for Houston Cloud.
+One-click Google sign-in on first launch. CI release tokens live in macOS Keychain / Windows Credential Manager, never localStorage or disk. Local builds use browser storage scoped per worktree to avoid macOS Keychain prompts from changing local signatures. Identifies users in PostHog, lays the foundation for Houston Cloud.
 
 ## The flow (PKCE)
 
 1. User clicks **Continue with Google** in `SignInScreen`.
 2. Frontend calls `supabase.auth.signInWithOAuth({ provider: "google", options: { redirectTo: "houston://auth-callback", skipBrowserRedirect: true } })`.
-3. Supabase generates a PKCE code_verifier, writes it to our Keychain-backed storage adapter, returns an auth URL.
+3. Supabase generates a PKCE code_verifier, writes it to the configured auth storage adapter, returns an auth URL.
 4. Frontend opens the URL in the user's system browser via `tauriSystem.openUrl()`.
 5. User completes Google consent.
 6. Google redirects to Supabase → Supabase redirects to `houston://auth-callback?code=<code>`.
 7. macOS delivers the URL to the running Houston via `tauri-plugin-deep-link`.
 8. Rust handler in `app/src-tauri/src/auth.rs::emit_deep_link` forwards the URL on a Tauri event (`auth://deep-link`).
-9. Frontend listener in `app/src/lib/auth.ts::installDeepLinkListener` extracts `code`, calls `supabase.auth.exchangeCodeForSession(code)` — Supabase reads the verifier from Keychain storage, exchanges, writes the session back.
+9. Frontend listener in `app/src/lib/auth.ts::installDeepLinkListener` extracts `code`, calls `supabase.auth.exchangeCodeForSession(code)` — Supabase reads the verifier from configured auth storage, exchanges, writes the session back.
 10. `supabase.auth.onAuthStateChange` fires → `useSession()` re-queries → `App.tsx` dismisses `SignInScreen` → sidebar footer `UserMenu` + Settings → Account section appear.
 11. PostHog: `analytics.alias(userId, { email, name })` merges the anonymous `install_id` history into the identified user.
 
@@ -20,19 +20,22 @@ One-click Google sign-in on first launch. Tokens in macOS Keychain / Windows Cre
 
 | Piece | Where |
 |---|---|
-| Session JSON (access_token, refresh_token, user) | Keychain entry `com.houston.app.auth` / `houston-auth` |
-| PKCE code verifier | Keychain entry `com.houston.app.auth` / `sb-…-auth-token-code-verifier` (Supabase-managed key) |
-| Storage adapter | `app/src/lib/supabase.ts::keychainStorage` → Tauri commands `auth_get_item` / `auth_set_item` / `auth_remove_item` in `auth.rs` |
+| Session JSON (access_token, refresh_token, user) | CI releases: Keychain entry `com.houston.app.auth` / `houston-auth` |
+| PKCE code verifier | CI releases: Keychain entry `com.houston.app.auth` / `sb-…-auth-token-code-verifier` (Supabase-managed key) |
+| Storage adapter | CI releases: `app/src/lib/supabase.ts::keychainStorage` → Tauri commands `auth_get_item` / `auth_set_item` / `auth_remove_item` in `auth.rs` |
+| Local storage | Browser storage with worktree-scoped key `houston-auth-local-<hash>` |
 | Rust dep | `keyring = "3"` with `apple-native` + `windows-native` features |
 
-Never touches localStorage. If Keychain is locked or unavailable, the in-memory session on the current run still works; nothing persists across launches. Degraded mode, not failure.
+CI releases never touch localStorage. If Keychain is locked or unavailable, the in-memory session on the current run still works; nothing persists across launches. Degraded mode, not failure.
+
+Local builds are different on purpose: Supabase uses browser storage with a worktree-scoped key (`houston-auth-local-<hash>`) and the Rust startup path does not read the persisted Keychain user id. macOS can treat every rebuild or worktree as a different app for Keychain access and show repeated password prompts. CI builds keep Keychain storage. Override with `HOUSTON_AUTH_STORAGE=keychain` or `HOUSTON_AUTH_STORAGE=browser`.
 
 ## Gating + offline behavior
 
 - `isAuthConfigured()` (true when `SUPABASE_URL` + `SUPABASE_ANON_KEY` baked in) is the master switch. Unconfigured builds skip auth entirely — useful for local dev without secrets.
 - `App.tsx` shows a splash while `useSession()` is loading, `SignInScreen` once the session resolves to `null`, the app otherwise.
-- `supabase.auth.getSession()` reads locally from Keychain — transient Supabase blips do NOT kick the user. Silent token refresh handles token TTL under the hood.
-- Hard sign-out: `signOut()` in `app/src/lib/auth.ts` clears Supabase session (removes Keychain entries) and calls `analytics.reset()` so subsequent anonymous events don't attach to the prior user.
+- `supabase.auth.getSession()` reads local auth storage (CI-release Keychain, local browser storage) — transient Supabase blips do NOT kick the user. Silent token refresh handles token TTL under the hood.
+- Hard sign-out: `signOut()` in `app/src/lib/auth.ts` clears the configured Supabase session storage and calls `analytics.reset()` so subsequent anonymous events don't attach to the prior user.
 
 ## PostHog integration
 
@@ -42,8 +45,8 @@ Never touches localStorage. If Keychain is locked or unavailable, the in-memory 
 
 ## Engine identity plumbing
 
-- At engine spawn (`app/src-tauri/src/lib.rs`), Rust reads the persisted Supabase session from Keychain and passes `HOUSTON_APP_USER_ID` as an env var to the subprocess. Engine treats it as an opaque string.
-- The env var is only set when the user was already signed in on a prior launch (i.e. session present at spawn time). First-run signed-in users don't get the env var until the next app restart — engine doesn't need it yet; server-side use is future work.
+- At engine spawn (`app/src-tauri/src/lib.rs`), CI-release builds read the persisted Supabase session from Keychain and pass `HOUSTON_APP_USER_ID` as an env var to the subprocess. Local builds skip this Keychain read. Engine treats the value as an opaque string.
+- The env var is only set when the user was already signed in on a prior launch and the build uses Keychain auth storage. First-run signed-in users don't get the env var until the next app restart — engine doesn't need it yet; server-side use is future work.
 - `HoustonEvent` envelope does NOT carry `user_id` today — deferred until there's a server-side consumer that needs it. When that lands, wrap `HoustonEvent` in an envelope struct in `engine/houston-ui-events` rather than adding `user_id` to each variant.
 
 ## Required secrets

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -61,8 +61,8 @@ PostHog → BigQuery plugin → target GCP project (burns credits). SQL-queryabl
 
 ## Auth (`@supabase/supabase-js` + Google SSO)
 
-- **Session storage:** macOS Keychain / Windows Credential Manager via the `keyring` crate (`app/src-tauri/src/auth.rs`). Frontend Supabase client uses a custom storage adapter that round-trips to Rust — tokens never hit localStorage.
-- **Flow:** One-click Google sign-in → system browser → OAuth redirect to `houston://auth-callback` → `tauri-plugin-deep-link` forwards to frontend → Supabase PKCE exchange → session persisted in Keychain. Full diagram + code pointers: `knowledge-base/auth.md`.
+- **Session storage:** CI releases use macOS Keychain / Windows Credential Manager via the `keyring` crate (`app/src-tauri/src/auth.rs`). Local builds use browser storage scoped per worktree to avoid macOS Keychain prompts from changing local signatures. Override with `HOUSTON_AUTH_STORAGE=keychain` or `HOUSTON_AUTH_STORAGE=browser`.
+- **Flow:** One-click Google sign-in → system browser → OAuth redirect to `houston://auth-callback` → `tauri-plugin-deep-link` forwards to frontend → Supabase PKCE exchange → session persisted in configured auth storage. Full diagram + code pointers: `knowledge-base/auth.md`.
 - **Gating:** `isAuthConfigured()` checks whether `SUPABASE_URL` + `SUPABASE_ANON_KEY` are baked in. Unconfigured builds skip the sign-in screen entirely.
 - **PostHog merge:** On sign-in, `analytics.alias(userId, { email })` merges anonymous install_id history to the identified user and sets `email` / `email_domain` person properties; on sign-out, `analytics.reset()` returns to anonymous.
 


### PR DESCRIPTION
## Summary
- use browser auth storage for local builds, scoped per worktree
- keep Keychain/Credential Manager storage for CI release builds
- skip startup Keychain reads when local auth storage is compiled in browser mode
- document local vs release auth storage behavior

## Tests
- git diff --check
- cd app && pnpm tsc --noEmit
- cargo test -p houston-app
- cd app && pnpm build
- cd app && pnpm check-locales
- node --experimental-strip-types --test app/tests/auth-storage.test.ts