### PR TITLE
Move agent mission search to header

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -45,6 +45,7 @@ import { IntegrationsView } from "./components/tabs/integrations-view";
 import { SettingsView } from "./components/tabs/settings-view";
 import { WorkspaceSetupFlow } from "./components/shell/workspace-setup-flow";
 import { DetailPanelProvider } from "./components/shell/detail-panel-context";
+import { MissionSearchInput } from "./components/mission-search-input";
 
 export default function App() {
   useHoustonInit();
@@ -114,7 +115,7 @@ export default function App() {
     return () => document.removeEventListener("contextmenu", handler);
   }, []);
 
-  const { t } = useTranslation(["agents", "shell", "common"]);
+  const { t } = useTranslation(["agents", "shell", "common", "board"]);
   const wsLoading = useWorkspaceStore((s) => s.loading);
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const createWorkspace = useWorkspaceStore((s) => s.create);
@@ -129,12 +130,20 @@ export default function App() {
   const dismissToast = useUIStore((s) => s.dismissToast);
   const onStartMission = useUIStore((s) => s.onStartMission);
   const boardActions = useUIStore((s) => s.boardActions);
+  const agentMissionSearchQuery = useUIStore((s) =>
+    currentAgent ? s.agentMissionSearchQueries[currentAgent.folderPath] ?? "" : "",
+  );
+  const agentMissionSearchLoading = useUIStore((s) =>
+    currentAgent ? s.agentMissionSearchLoading[currentAgent.folderPath] ?? false : false,
+  );
+  const setAgentMissionSearchQuery = useUIStore((s) => s.setAgentMissionSearchQuery);
   const missionPanelOpen = useUIStore((s) => s.missionPanelOpen);
   const setCreateAgentDialogOpen = useUIStore((s) => s.setCreateAgentDialogOpen);
   const [panelContainer, setPanelContainer] = useState<HTMLDivElement | null>(null);
 
   const agentDef = currentAgent ? getById(currentAgent.configId) : undefined;
   const tabs = agentDef?.config.tabs ?? [];
+  const hasActivityTab = tabs.some((tab) => tab.id === "activity");
   const { data: activities } = useActivity(currentAgent?.folderPath);
   const needsYouCount = (activities ?? []).filter((a) => a.status === "needs_you").length;
 
@@ -234,6 +243,22 @@ export default function App() {
                     }}
                     actions={
                       <div data-keep-panel-open className="flex items-center gap-2">
+                        {currentAgent && hasActivityTab && (
+                          <MissionSearchInput
+                            value={agentMissionSearchQuery}
+                            isSearchingText={agentMissionSearchLoading}
+                            labels={{
+                              placeholder: t("board:search.placeholder"),
+                              clear: t("board:search.clear"),
+                              searchingText: t("board:search.searchingText"),
+                            }}
+                            className="relative w-[240px]"
+                            onChange={(value) => {
+                              setAgentMissionSearchQuery(currentAgent.folderPath, value);
+                              if (viewMode !== "activity") setViewMode("activity");
+                            }}
+                          />
+                        )}
                         {onStartMission && (
                           <Button
                             onClick={() => {
@@ -244,7 +269,7 @@ export default function App() {
                             }}
                           >
                             <HoustonLogo size={16} />
-                            New mission
+                            {t("shell:tabActions.newMission")}
                           </Button>
                         )}
                         {boardActions.map((action) => (

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -32,7 +32,6 @@ import { HoustonThinkingIndicator } from "../shell/experience-card";
 import { AgentCardAvatar } from "../shell/agent-card-avatar";
 import { AgentPanelAvatar } from "../shell/agent-panel-avatar";
 import { useQueuedMessageLabels } from "../use-queued-message-labels";
-import { MissionSearchInput } from "../mission-search-input";
 import { MissionBoardEmptyState } from "../mission-board-empty-state";
 import { useMissionSearch } from "../use-mission-search";
 
@@ -64,13 +63,15 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
   const path = agent.folderPath;
   const agentModes = agentDef.config.agents;
   const [pendingAgentMode, setPendingAgentMode] = useState<string | null>(null);
-  const [missionSearchQuery, setMissionSearchQuery] = useState("");
   const { data: rawItems } = useActivity(path);
   const deleteActivity = useDeleteActivity(path);
   const updateActivity = useUpdateActivity(path);
   const queryClient = useQueryClient();
   const setOnStartMission = useUIStore((s) => s.setOnStartMission);
   const setBoardActions = useUIStore((s) => s.setBoardActions);
+  const missionSearchQuery = useUIStore((s) => s.agentMissionSearchQueries[path] ?? "");
+  const setAgentMissionSearchQuery = useUIStore((s) => s.setAgentMissionSearchQuery);
+  const setAgentMissionSearchLoading = useUIStore((s) => s.setAgentMissionSearchLoading);
   const setMissionPanelOpen = useUIStore((s) => s.setMissionPanelOpen);
   const missionPanelOpen = useUIStore((s) => s.missionPanelOpen);
   const addToast = useUIStore((s) => s.addToast);
@@ -262,6 +263,11 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
     loadHistory,
     onHistoryLoadError: handleMissionSearchError,
   });
+
+  useEffect(() => {
+    setAgentMissionSearchLoading(path, missionSearch.isSearchingText);
+    return () => setAgentMissionSearchLoading(path, false);
+  }, [missionSearch.isSearchingText, path, setAgentMissionSearchLoading]);
 
   useEffect(() => {
     if (!rawItems) return;
@@ -539,25 +545,12 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
         if (agentModes?.length) setPendingAgentMode(agentModes[0].id);
         openerRef.current?.();
       }}
-      onClearSearch={() => setMissionSearchQuery("")}
+      onClearSearch={() => setAgentMissionSearchQuery(path, "")}
     />
   );
 
   return (
     <div className="flex flex-col h-full">
-      <div className="shrink-0 px-3 pt-3">
-        <MissionSearchInput
-          value={missionSearchQuery}
-          isSearchingText={missionSearch.isSearchingText}
-          labels={{
-            placeholder: t("search.placeholder"),
-            clear: t("search.clear"),
-            searchingText: t("search.searchingText"),
-          }}
-          className="relative max-w-sm"
-          onChange={setMissionSearchQuery}
-        />
-      </div>
       <div className="flex-1 min-h-0">
         <AIBoard
           items={missionSearch.items}

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -23,6 +23,10 @@ interface UIState {
   onStartMission: (() => void) | null;
   /** Extra create actions registered by the board tab (e.g. "New Planning Session"). */
   boardActions: Array<{ id: string; label: string; onClick: () => void }>;
+  /** Per-agent mission search query shown in the agent header. */
+  agentMissionSearchQueries: Record<string, string>;
+  /** Whether a per-agent mission search is loading conversation text. */
+  agentMissionSearchLoading: Record<string, boolean>;
   /** Whether the mission chat panel is open (hides tab bar for full-height panel) */
   missionPanelOpen: boolean;
   jobDescriptionTarget: JobDescriptionTarget | null;
@@ -36,6 +40,8 @@ interface UIState {
   setCreateAgentDialogOpen: (open: boolean) => void;
   setOnStartMission: (cb: (() => void) | null) => void;
   setBoardActions: (actions: Array<{ id: string; label: string; onClick: () => void }>) => void;
+  setAgentMissionSearchQuery: (agentPath: string, query: string) => void;
+  setAgentMissionSearchLoading: (agentPath: string, loading: boolean) => void;
   setMissionPanelOpen: (open: boolean) => void;
   setJobDescriptionTarget: (target: JobDescriptionTarget | null) => void;
 }
@@ -52,6 +58,8 @@ export const useUIStore = create<UIState>((set) => ({
   createAgentDialogOpen: false,
   onStartMission: null,
   boardActions: [],
+  agentMissionSearchQueries: {},
+  agentMissionSearchLoading: {},
   missionPanelOpen: false,
   jobDescriptionTarget: null,
 
@@ -84,6 +92,20 @@ export const useUIStore = create<UIState>((set) => ({
 
   setOnStartMission: (onStartMission) => set({ onStartMission }),
   setBoardActions: (boardActions) => set({ boardActions }),
+  setAgentMissionSearchQuery: (agentPath, query) =>
+    set((s) => {
+      const next = { ...s.agentMissionSearchQueries };
+      if (query) next[agentPath] = query;
+      else delete next[agentPath];
+      return { agentMissionSearchQueries: next };
+    }),
+  setAgentMissionSearchLoading: (agentPath, loading) =>
+    set((s) => {
+      const next = { ...s.agentMissionSearchLoading };
+      if (loading) next[agentPath] = true;
+      else delete next[agentPath];
+      return { agentMissionSearchLoading: next };
+    }),
   setMissionPanelOpen: (missionPanelOpen) => set({ missionPanelOpen }),
   setJobDescriptionTarget: (jobDescriptionTarget) => set({ jobDescriptionTarget }),
 }));


### PR DESCRIPTION
## Summary
- Move per-agent mission search into the agent header before New mission.
- Keep Activity tab search behavior by storing per-agent queries in UI state and switching to Activity when typing.
- Remove the duplicate in-tab search row.

## Affected files
- app/src/App.tsx
- app/src/components/tabs/board-tab.tsx
- app/src/stores/ui.ts

## Tests
- pnpm typecheck
- pnpm check-locales
- node --experimental-strip-types --test app/tests/mission-search.test.ts
- git diff --check
- pnpm build