### PR TITLE
Avoid duplicate mission search clear button

### DIFF
--- a/app/src/components/mission-search-input.tsx
+++ b/app/src/components/mission-search-input.tsx
@@ -26,7 +26,8 @@ export function MissionSearchInput({
     <div className={className ?? "relative"}>
       <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
       <Input
-        type="search"
+        type="text"
+        role="searchbox"
         value={value}
         onChange={(event) => onChange(event.target.value)}
         placeholder={labels.placeholder}


### PR DESCRIPTION
## Summary
- Keep the styled custom mission-search clear button.
- Change the input away from native browser search controls so WebKit does not render a second clear X.
- Preserve searchbox semantics with role=searchbox.

## Affected files
- app/src/components/mission-search-input.tsx

## Tests
- pnpm typecheck
- pnpm check-locales
- git diff --check
- pnpm build