### PR TITLE
fix: keep sidebar controls visible for long agent names

### DIFF
--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -176,6 +176,12 @@ export function Sidebar({ children }: { children: ReactNode }) {
         onAdd={() => setDialogOpen(true)}
         onRename={handleRename}
         onDelete={handleDelete}
+        labels={{
+          addItem: t("shell:sidebar.addAgent"),
+          moreActions: t("shell:sidebar.agentActions"),
+          renameItem: t("common:actions.rename"),
+          deleteItem: t("common:actions.delete"),
+        }}
         footer={
           <div className="flex flex-col">
             <UserMenu />

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -6,6 +6,8 @@
     "yourAgents": "Your Agents",
     "selectWorkspace": "Select workspace",
     "connectPhone": "Connect phone",
+    "addAgent": "Add agent",
+    "agentActions": "Agent actions",
     "needsYouCount_one": "{{count}} issue needs you",
     "needsYouCount_other": "{{count}} issues need you",
     "runningCount_one": "{{count}} issue running",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -6,6 +6,8 @@
     "yourAgents": "Tus agentes",
     "selectWorkspace": "Elige un espacio de trabajo",
     "connectPhone": "Conectar celular",
+    "addAgent": "Añadir agente",
+    "agentActions": "Acciones del agente",
     "needsYouCount_one": "{{count}} asunto necesita tu atención",
     "needsYouCount_other": "{{count}} asuntos necesitan tu atención",
     "runningCount_one": "{{count}} asunto en curso",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -6,6 +6,8 @@
     "yourAgents": "Seus agentes",
     "selectWorkspace": "Escolha um espaço de trabalho",
     "connectPhone": "Conectar celular",
+    "addAgent": "Adicionar agente",
+    "agentActions": "Ações do agente",
     "needsYouCount_one": "{{count}} assunto precisa de você",
     "needsYouCount_other": "{{count}} assuntos precisam de você",
     "runningCount_one": "{{count}} assunto em execução",

--- a/ui/layout/README.md
+++ b/ui/layout/README.md
@@ -20,6 +20,12 @@ import "@houston-ai/layout/src/styles.css"
   selectedId={activeId}
   onSelect={setActiveId}
   onAdd={createProject}
+  labels={{
+    addItem: "Add project",
+    moreActions: "Project actions",
+    renameItem: "Rename",
+    deleteItem: "Delete",
+  }}
 />
 
 <TabBar
@@ -34,7 +40,7 @@ import "@houston-ai/layout/src/styles.css"
 
 ## Exports
 
-- `AppSidebar` -- project/chat list sidebar with logo, add, delete, keyboard shortcuts
+- `AppSidebar` -- project/chat list sidebar with logo, add, delete, keyboard shortcuts, and optional labels for app-level i18n
 - `TabBar` -- horizontal tab strip with badges and action slots
 - `SplitView` -- two-pane layout with resizable divider
 - `ResizablePanelGroup`, `ResizablePanel`, `ResizableHandle` -- lower-level resizable primitives

--- a/ui/layout/src/index.ts
+++ b/ui/layout/src/index.ts
@@ -1,5 +1,10 @@
 export { AppSidebar } from "./sidebar";
-export type { SidebarProps, SidebarItem, SidebarNavItemEntry } from "./sidebar";
+export type {
+  SidebarProps,
+  SidebarItem,
+  SidebarNavItemEntry,
+  SidebarLabels,
+} from "./sidebar";
 
 export { SidebarNavItem } from "./sidebar-nav";
 export type { SidebarNavItemProps } from "./sidebar-nav";

--- a/ui/layout/src/sidebar-classes.ts
+++ b/ui/layout/src/sidebar-classes.ts
@@ -1,0 +1,17 @@
+export const sidebarClasses = {
+  itemsList: "w-0 min-w-full space-y-0.5 pb-2",
+} as const;
+
+export const sidebarItemRowClasses = {
+  root: "group flex w-full min-w-0 items-center rounded-lg transition-colors duration-100",
+  editInput:
+    "min-w-0 flex-1 px-3 py-1.5 text-[13px] bg-background outline-none border border-border rounded-lg focus:border-foreground/30",
+  selectButton:
+    "flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left text-[13px]",
+  icon: "shrink-0",
+  name: "min-w-0 flex-1 truncate",
+  actions: "mr-1 flex shrink-0 items-center justify-end gap-1",
+  trailing: "flex shrink-0 items-center pointer-events-none",
+  menuButton:
+    "flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground opacity-80 transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring group-hover:opacity-100",
+} as const;

--- a/ui/layout/src/sidebar-item-row.tsx
+++ b/ui/layout/src/sidebar-item-row.tsx
@@ -8,6 +8,19 @@ import {
   DropdownMenuItem,
 } from "@houston-ai/core";
 import type { SidebarItem } from "./sidebar";
+import { sidebarItemRowClasses } from "./sidebar-classes";
+
+export interface SidebarItemRowLabels {
+  moreActions?: string;
+  renameItem?: string;
+  deleteItem?: string;
+}
+
+const DEFAULT_LABELS: Required<SidebarItemRowLabels> = {
+  moreActions: "More actions",
+  renameItem: "Rename",
+  deleteItem: "Delete",
+};
 
 export interface SidebarItemRowProps {
   item: SidebarItem;
@@ -22,6 +35,7 @@ export interface SidebarItemRowProps {
   onCancelEdit: () => void;
   onStartRename?: (id: string, name: string) => void;
   onDelete?: (id: string) => void;
+  labels?: SidebarItemRowLabels;
 }
 
 export function SidebarItemRow({
@@ -37,11 +51,14 @@ export function SidebarItemRow({
   onCancelEdit,
   onStartRename,
   onDelete,
+  labels,
 }: SidebarItemRowProps) {
+  const l = { ...DEFAULT_LABELS, ...labels };
+
   return (
     <div
       className={cn(
-        "group flex items-center rounded-lg transition-colors duration-100",
+        sidebarItemRowClasses.root,
         isActive ? "bg-accent" : "hover:bg-accent/50",
       )}
     >
@@ -55,31 +72,28 @@ export function SidebarItemRow({
             if (e.key === "Enter") onCommitRename(item.id);
             if (e.key === "Escape") onCancelEdit();
           }}
-          className="flex-1 min-w-0 px-3 py-1.5 text-[13px] bg-background outline-none border border-border rounded-lg focus:border-foreground/30"
+          className={sidebarItemRowClasses.editInput}
         />
       ) : (
         <button
           onClick={() => onSelect(item.id)}
           onKeyDown={(e) => onKeyDown(e, item.id)}
           className={cn(
-            "flex-1 flex items-center gap-2 text-left px-3 py-1.5 text-[13px] min-w-0",
+            sidebarItemRowClasses.selectButton,
             isActive ? "text-foreground" : "text-accent-foreground",
           )}
         >
-          {item.icon}
-          <span className="min-w-0 flex-1 truncate">{item.name}</span>
+          {item.icon && (
+            <span className={sidebarItemRowClasses.icon}>{item.icon}</span>
+          )}
+          <span className={sidebarItemRowClasses.name}>{item.name}</span>
         </button>
       )}
 
       {!isEditing && (item.trailing || hasMenu) && (
-        <div className="relative shrink-0 mr-1 h-7 min-w-7 flex items-center justify-end">
+        <div className={sidebarItemRowClasses.actions}>
           {item.trailing && (
-            <span
-              className={cn(
-                "absolute right-0 top-1/2 -translate-y-1/2 pointer-events-none",
-                hasMenu && "transition-opacity group-hover:opacity-0",
-              )}
-            >
+            <span className={sidebarItemRowClasses.trailing}>
               {item.trailing}
             </span>
           )}
@@ -87,18 +101,19 @@ export function SidebarItemRow({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
-                  className="absolute right-0 top-1/2 -translate-y-1/2 size-7 flex items-center justify-center rounded-md text-muted-foreground opacity-0 group-hover:opacity-100 hover:text-foreground hover:bg-accent transition-opacity"
+                  aria-label={l.moreActions}
+                  className={sidebarItemRowClasses.menuButton}
                   onClick={(e) => e.stopPropagation()}
                 >
                   <MoreHorizontal className="size-4" />
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="start" side="bottom">
+              <DropdownMenuContent align="end" side="bottom">
                 {onStartRename && (
                   <DropdownMenuItem
                     onClick={() => onStartRename(item.id, item.name)}
                   >
-                    Rename
+                    {l.renameItem}
                   </DropdownMenuItem>
                 )}
                 {onDelete && (
@@ -106,7 +121,7 @@ export function SidebarItemRow({
                     onClick={() => onDelete(item.id)}
                     className="text-destructive focus:text-destructive"
                   >
-                    Delete
+                    {l.deleteItem}
                   </DropdownMenuItem>
                 )}
               </DropdownMenuContent>

--- a/ui/layout/src/sidebar.tsx
+++ b/ui/layout/src/sidebar.tsx
@@ -3,6 +3,8 @@ import { Plus } from "lucide-react";
 import { ScrollArea } from "@houston-ai/core";
 import { SidebarNavItem } from "./sidebar-nav";
 import { SidebarItemRow } from "./sidebar-item-row";
+import type { SidebarItemRowLabels } from "./sidebar-item-row";
+import { sidebarClasses } from "./sidebar-classes";
 
 export interface SidebarItem {
   id: string;
@@ -39,8 +41,20 @@ export interface SidebarProps {
   sectionLabel?: string;
   /** Footer area rendered at the very bottom of the sidebar */
   footer?: ReactNode;
+  labels?: SidebarLabels;
   children?: ReactNode;
 }
+
+export interface SidebarLabels extends SidebarItemRowLabels {
+  addItem?: string;
+}
+
+const DEFAULT_LABELS: Required<SidebarLabels> = {
+  addItem: "Add item",
+  moreActions: "More actions",
+  renameItem: "Rename",
+  deleteItem: "Delete",
+};
 
 export function AppSidebar({
   logo,
@@ -55,11 +69,13 @@ export function AppSidebar({
   onRename,
   sectionLabel,
   footer,
+  labels,
   children,
 }: SidebarProps) {
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
   const hasMenu = !!onDelete || !!onRename;
+  const l = { ...DEFAULT_LABELS, ...labels };
 
   const startRename = (id: string, currentName: string) => {
     setEditingId(id);
@@ -124,6 +140,7 @@ export function AppSidebar({
             )}
             {onAdd && (
               <button
+                aria-label={l.addItem}
                 onClick={onAdd}
                 className="text-muted-foreground hover:text-foreground transition-colors"
               >
@@ -135,7 +152,7 @@ export function AppSidebar({
 
         {/* Items list */}
         <ScrollArea className="flex-1 px-2">
-          <div className="space-y-0.5 pb-2">
+          <div className={sidebarClasses.itemsList}>
             {items.map((item) => (
               <SidebarItemRow
                 key={item.id}
@@ -151,6 +168,7 @@ export function AppSidebar({
                 onCancelEdit={() => setEditingId(null)}
                 onStartRename={onRename ? startRename : undefined}
                 onDelete={onDelete}
+                labels={l}
               />
             ))}
           </div>

--- a/ui/layout/tests/sidebar-item-row-layout.test.ts
+++ b/ui/layout/tests/sidebar-item-row-layout.test.ts
@@ -1,0 +1,35 @@
+import { ok } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  sidebarClasses,
+  sidebarItemRowClasses,
+} from "../src/sidebar-classes.ts";
+
+function tokens(className: string): Set<string> {
+  return new Set(className.split(/\s+/).filter(Boolean));
+}
+
+function includes(className: string, token: string): boolean {
+  return tokens(className).has(token);
+}
+
+describe("sidebar item row layout", () => {
+  it("constrains long names before trailing controls", () => {
+    ok(includes(sidebarItemRowClasses.root, "min-w-0"));
+    ok(includes(sidebarItemRowClasses.root, "w-full"));
+    ok(includes(sidebarItemRowClasses.selectButton, "min-w-0"));
+    ok(includes(sidebarItemRowClasses.selectButton, "flex-1"));
+    ok(includes(sidebarItemRowClasses.name, "min-w-0"));
+    ok(includes(sidebarItemRowClasses.name, "flex-1"));
+    ok(includes(sidebarItemRowClasses.name, "truncate"));
+    ok(includes(sidebarItemRowClasses.actions, "shrink-0"));
+    ok(includes(sidebarClasses.itemsList, "w-0"));
+    ok(includes(sidebarClasses.itemsList, "min-w-full"));
+  });
+
+  it("keeps menu trigger in its own visible slot", () => {
+    ok(includes(sidebarItemRowClasses.menuButton, "size-7"));
+    ok(includes(sidebarItemRowClasses.menuButton, "shrink-0"));
+    ok(!includes(sidebarItemRowClasses.menuButton, "opacity-0"));
+  });
+});


### PR DESCRIPTION
## Summary
- Constrain sidebar row width so long agent names truncate before badges and menu controls
- Keep agent action menu visible and accessible, with app-provided i18n labels
- Add layout regression coverage and document sidebar labels

## Tests
- node --experimental-strip-types --test ui/layout/tests/sidebar-item-row-layout.test.ts
- COREPACK_ENABLE_AUTO_PIN=0 pnpm typecheck
- COREPACK_ENABLE_AUTO_PIN=0 pnpm --dir app check-locales
- Playwright visual check for long unbroken agent name, badge visibility, and clickable menu