### PR TITLE
Render attachment chat messages

### DIFF
--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -21,9 +21,10 @@ import {
   useUpdateActivity,
 } from "../../hooks/queries";
 import { useAgentChatPanel } from "../use-agent-chat-panel";
-import { tauriActivity, tauriChat, tauriAttachments, tauriSystem, tauriWorktree, tauriShell, tauriTerminal, tauriConfig, tauriPreferences, withAttachmentPaths } from "../../lib/tauri";
+import { tauriActivity, tauriChat, tauriAttachments, tauriSystem, tauriWorktree, tauriShell, tauriTerminal, tauriConfig, tauriPreferences } from "../../lib/tauri";
 import { createMission } from "../../lib/create-mission";
 import { formatVisibleMessageText } from "../../lib/queued-chat";
+import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { queryKeys } from "../../lib/query-keys";
 import { analytics } from "../../lib/analytics";
 import type { TabProps } from "../../lib/types";
@@ -346,6 +347,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
         files,
         (names) => t("chat:queue.attached", { names }),
       );
+      let userMessage = text;
       const { conversationId, sessionKey } = await createMission(
         { id: agent.id, name: agent.name, color: agent.color, folderPath: path },
         text,
@@ -358,11 +360,12 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
           titleText: visible,
           buildPrompt: async (activityId) => {
             const saved = await tauriAttachments.save(`activity-${activityId}`, files);
-            return withAttachmentPaths(text, saved);
+            userMessage = buildAttachmentPrompt(text, files, saved);
+            return userMessage;
           },
         },
       );
-      pushFeedItem(path, sessionKey, { feed_type: "user_message", data: visible });
+      pushFeedItem(path, sessionKey, { feed_type: "user_message", data: userMessage });
       setLoading((prev) => ({ ...prev, [sessionKey]: true }));
       setPendingAgentMode(null);
       // createMission bypassed useCreateActivity so invalidate manually.
@@ -401,7 +404,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
       const scopeId = activity ? `activity-${activity.id}` : sessionKey;
       try {
         const paths = await tauriAttachments.save(scopeId, files);
-        const prompt = withAttachmentPaths(text, paths);
+        const prompt = buildAttachmentPrompt(text, files, paths);
         const mode = agentModes?.find((m) => m.id === activity?.agent);
         await tauriChat.send(path, prompt, sessionKey, {
           mode: mode?.promptFile,
@@ -409,12 +412,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
           providerOverride: chatProvider ?? undefined,
           modelOverride: chatModel ?? undefined,
         });
-        const visible = formatVisibleMessageText(
-          text,
-          files,
-          (names) => t("chat:queue.attached", { names }),
-        );
-        pushFeedItem(path, sessionKey, { feed_type: "user_message", data: visible });
+        pushFeedItem(path, sessionKey, { feed_type: "user_message", data: prompt });
         setLoading((prev) => ({ ...prev, [sessionKey]: true }));
       } catch (err) {
         setLoading((prev) => ({ ...prev, [sessionKey]: false }));

--- a/app/src/components/tabs/chat-tab.tsx
+++ b/app/src/components/tabs/chat-tab.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ChatPanel } from "@houston-ai/chat";
+import {
+  ChatPanel,
+  decodeAttachmentMessage,
+  UserAttachmentMessage,
+} from "@houston-ai/chat";
 import type { FeedItem } from "@houston-ai/chat";
 import {
   Empty,
@@ -14,8 +18,8 @@ import { useWorkspaceStore } from "../../stores/workspaces";
 import { useDraftStore, useDraftText, useDraftFiles } from "../../stores/drafts";
 import { isActiveSessionStatus, useSessionStatus } from "../../stores/session-status";
 import { useSessionMessageQueue } from "../../hooks/use-session-message-queue";
-import { tauriChat, tauriAttachments, tauriSystem, tauriConfig, withAttachmentPaths } from "../../lib/tauri";
-import { formatVisibleMessageText } from "../../lib/queued-chat";
+import { tauriChat, tauriAttachments, tauriSystem, tauriConfig } from "../../lib/tauri";
+import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { useFileToolRenderer } from "../../hooks/use-file-tool-renderer";
 import { useConnectedToolkits, useConnections } from "../../hooks/queries";
 import {
@@ -40,6 +44,12 @@ import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
 export default function ChatTab({ agent }: TabProps) {
   const { t } = useTranslation("chat");
   const queuedLabels = useQueuedMessageLabels();
+  const attachmentLabels = useMemo(
+    () => ({
+      attachmentCount: (count: number) => t("attachmentMessage.count", { count }),
+    }),
+    [t],
+  );
   const { processLabels, getThinkingMessage } = useChatDisplayLabels();
   const attachmentValidation = useAttachmentRejectionDialog();
   const { isSpecialTool, renderToolResult, renderTurnSummary } = useFileToolRenderer(agent.folderPath);
@@ -176,18 +186,13 @@ export default function ChatTab({ agent }: TabProps) {
       let started = false;
       try {
         const paths = await tauriAttachments.save(attachmentScope, files);
-        const prompt = withAttachmentPaths(text, paths);
+        const prompt = buildAttachmentPrompt(text, files, paths);
         await tauriChat.send(agentPath, prompt, sessionKey, {
           providerOverride: chatProvider ?? undefined,
           modelOverride: chatModel ?? undefined,
         });
         started = true;
-        const visible = formatVisibleMessageText(
-          text,
-          files,
-          (names) => t("queue.attached", { names }),
-        );
-        pushFeedItem(agentPath, sessionKey, { feed_type: "user_message", data: visible });
+        pushFeedItem(agentPath, sessionKey, { feed_type: "user_message", data: prompt });
         analytics.track("chat_message_sent");
         setComposerText("");
         setComposerFiles([]);
@@ -240,6 +245,16 @@ export default function ChatTab({ agent }: TabProps) {
             return null;
           }
           return undefined;
+        }}
+        renderUserMessage={(msg) => {
+          const invocation = decodeAttachmentMessage(msg.content);
+          if (!invocation) return undefined;
+          return (
+            <UserAttachmentMessage
+              invocation={invocation}
+              labels={attachmentLabels}
+            />
+          );
         }}
         afterMessages={
           <ProviderReconnectCard

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -29,6 +29,11 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@houston-ai/core";
 import { Play } from "lucide-react";
+import {
+  decodeAttachmentMessage,
+  UserAttachmentMessage,
+  type UserAttachmentMessageLabels,
+} from "@houston-ai/chat";
 
 import { useFeedStore } from "../stores/feeds";
 import { useWorkspaceStore } from "../stores/workspaces";
@@ -60,6 +65,7 @@ import {
   decodeActionMessage,
   encodeActionMessage,
 } from "../lib/action-message";
+import { attachmentReferences } from "../lib/attachment-message";
 import { SkillCard } from "./skill-card";
 import { NewMissionPickerDialog } from "./new-mission-picker-dialog";
 import { UserActionMessage } from "./user-action-message";
@@ -222,6 +228,12 @@ export function useAgentChatPanel({
   }, [onSelectSession]);
 
   const pushFeedItem = useFeedStore((s) => s.pushFeedItem);
+  const attachmentLabels = useMemo<UserAttachmentMessageLabels>(
+    () => ({
+      attachmentCount: (count) => t("attachmentMessage.count", { count }),
+    }),
+    [t],
+  );
 
   // While an Action is selected, the regular composer still owns text
   // and attachments. This hook only wraps the submitted message with the
@@ -231,13 +243,8 @@ export function useAgentChatPanel({
       const skill = activeAction;
       if (!skill || !agent || !path) return false;
 
-      const visibleText = actionVisibleText(
-        text,
-        files,
-        (names) => t("toasts.attached", { names }),
-      );
       const claudePrompt = buildActionClaudePrompt(skill, text);
-      const encoded = encodeActionMessage(skill, visibleText, claudePrompt);
+      const encoded = encodeActionMessage(skill, text, claudePrompt);
       const friendlyTitle = humanize(skill.name);
 
       if (sessionKey) {
@@ -246,7 +253,12 @@ export function useAgentChatPanel({
         const scopeId = sessionKey;
         const attachmentPaths = await tauriAttachments.save(scopeId, files);
         const prompt = withAttachmentPaths(claudePrompt, attachmentPaths);
-        const encodedWithAttachments = encodeActionMessage(skill, visibleText, prompt);
+        const encodedWithAttachments = encodeActionMessage(
+          skill,
+          text,
+          prompt,
+          attachmentReferences(files, attachmentPaths),
+        );
         const mode = agentModes?.find((m) => m.id === undefined); // default mode
         await tauriChat.send(path, encodedWithAttachments, sessionKey, {
           mode: mode?.promptFile,
@@ -262,6 +274,7 @@ export function useAgentChatPanel({
         // kanban card reads "Research a company" instead of the marker.
         const agentMode = agentModes?.[0]?.id;
         const mode = agentModes?.find((m) => m.id === agentMode);
+        let encodedUserMessage = encoded;
 
         // Honour worktree mode if the agent's config opts in. Same
         // bootstrap as BoardTab's text-send path.
@@ -298,14 +311,20 @@ export function useAgentChatPanel({
             buildPrompt: async (activityId) => {
               const paths = await tauriAttachments.save(`activity-${activityId}`, files);
               const prompt = withAttachmentPaths(claudePrompt, paths);
-              return encodeActionMessage(skill, visibleText, prompt);
+              encodedUserMessage = encodeActionMessage(
+                skill,
+                text,
+                prompt,
+                attachmentReferences(files, paths),
+              );
+              return encodedUserMessage;
             },
             title: friendlyTitle,
           },
         );
         pushFeedItem(path, sessionKey, {
           feed_type: "user_message",
-          data: encoded,
+          data: encodedUserMessage,
         });
         queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) });
         analytics.track("mission_created", {
@@ -340,10 +359,24 @@ export function useAgentChatPanel({
   const renderUserMessage = useCallback(
     (msg: { content: string }) => {
       const invocation = decodeActionMessage(msg.content);
-      if (!invocation) return undefined;
-      return <UserActionMessage invocation={invocation} />;
+      if (invocation) {
+        return (
+          <UserActionMessage
+            invocation={invocation}
+            attachmentLabels={attachmentLabels}
+          />
+        );
+      }
+      const attachmentInvocation = decodeAttachmentMessage(msg.content);
+      if (!attachmentInvocation) return undefined;
+      return (
+        <UserAttachmentMessage
+          invocation={attachmentInvocation}
+          labels={attachmentLabels}
+        />
+      );
     },
-    [],
+    [attachmentLabels],
   );
   const renderSystemMessage = useCallback(
     (msg: ChatMessage) => {
@@ -485,15 +518,4 @@ function humanize(slug: string): string {
   return spaced.length === 0
     ? slug
     : spaced.charAt(0).toUpperCase() + spaced.slice(1);
-}
-
-function actionVisibleText(
-  text: string,
-  files: File[],
-  formatAttached: (names: string) => string,
-): string {
-  const trimmed = text.trim();
-  if (files.length === 0) return trimmed;
-  const attached = formatAttached(files.map((f) => f.name).join(", "));
-  return trimmed ? `${trimmed}\n\n${attached}` : attached;
 }

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -9,8 +9,8 @@ import {
   useSessionStatusStore,
 } from "../stores/session-status";
 import { useAllConversations } from "../hooks/queries";
-import { tauriActivity, tauriChat, tauriAttachments, withAttachmentPaths } from "../lib/tauri";
-import { formatVisibleMessageText } from "../lib/queued-chat";
+import { tauriActivity, tauriChat, tauriAttachments } from "../lib/tauri";
+import { buildAttachmentPrompt } from "../lib/attachment-message";
 import type { Agent } from "../lib/types";
 import { createElement } from "react";
 import { AgentCardAvatar } from "./shell/agent-card-avatar";
@@ -145,14 +145,9 @@ export function useMissionControl(agents: Agent[]) {
       if (!agentPath) return;
       try {
         const paths = await tauriAttachments.save(`activity-${activityId}`, files);
-        const prompt = withAttachmentPaths(text, paths);
+        const prompt = buildAttachmentPrompt(text, files, paths);
         await tauriChat.send(agentPath, prompt, sessionKey);
-        const visible = formatVisibleMessageText(
-          text,
-          files,
-          (names) => t("queue.attached", { names }),
-        );
-        pushFeedItem(agentPath, sessionKey, { feed_type: "user_message", data: visible });
+        pushFeedItem(agentPath, sessionKey, { feed_type: "user_message", data: prompt });
         setLoading((prev) => ({ ...prev, [sessionKey]: true }));
       } catch (err) {
         setLoading((prev) => ({ ...prev, [sessionKey]: false }));

--- a/app/src/components/user-action-message.tsx
+++ b/app/src/components/user-action-message.tsx
@@ -1,9 +1,14 @@
+import {
+  UserAttachmentBadge,
+  type UserAttachmentMessageLabels,
+} from "@houston-ai/chat";
 import { SkillIcon } from "./skill-icon";
 import { IntegrationLogos } from "./integration-logos";
 import type { ActionInvocation } from "../lib/action-message";
 
 interface Props {
   invocation: ActionInvocation;
+  attachmentLabels?: UserAttachmentMessageLabels;
 }
 
 /**
@@ -15,8 +20,16 @@ interface Props {
  * The card sits in the right column of the conversation (where user
  * bubbles live) so the speaker attribution stays the same.
  */
-export function UserActionMessage({ invocation }: Props) {
-  const { displayName, image, description, integrations, fields, message } = invocation;
+export function UserActionMessage({ invocation, attachmentLabels }: Props) {
+  const {
+    displayName,
+    image,
+    description,
+    integrations,
+    fields,
+    message,
+    attachments,
+  } = invocation;
   return (
     <div className="flex max-w-md flex-col items-end gap-2">
       <div className="inline-block rounded-2xl bg-secondary p-4 text-left">
@@ -62,6 +75,7 @@ export function UserActionMessage({ invocation }: Props) {
           <span className="whitespace-pre-wrap break-words">{message}</span>
         </div>
       )}
+      <UserAttachmentBadge files={attachments} labels={attachmentLabels} />
     </div>
   );
 }

--- a/app/src/lib/action-message.ts
+++ b/app/src/lib/action-message.ts
@@ -17,6 +17,7 @@
 
 import {
   decodeActionMessage as decodeActionMessageFromChat,
+  type AttachmentReference,
   type ActionInvocation,
   type ActionInvocationField,
 } from "@houston-ai/chat";
@@ -38,6 +39,7 @@ export function encodeActionMessage(
   skill: SkillSummary,
   userText: string,
   claudePrompt: string,
+  attachments: readonly AttachmentReference[] = [],
 ): string {
   const trimmedText = userText.trim();
   const payload: ActionInvocation = {
@@ -48,6 +50,7 @@ export function encodeActionMessage(
     integrations: skill.integrations,
     fields: [],
     message: trimmedText,
+    attachments: [...attachments],
   };
   const json = JSON.stringify(payload);
   return `${MARKER_PREFIX}${json}${MARKER_SUFFIX}\n\n${claudePrompt}`;

--- a/app/src/lib/attachment-message.test.mjs
+++ b/app/src/lib/attachment-message.test.mjs
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  attachmentReferences,
+  buildAttachmentPrompt,
+  withAttachmentPaths,
+} from "./attachment-message.ts";
+
+function file(name) {
+  return { name };
+}
+
+test("attachment prompt preserves model-facing file paths", () => {
+  assert.equal(
+    withAttachmentPaths("Read this", ["/tmp/brief.pdf"]),
+    "Read this\n\n[User attached these files. Read them with the Read tool if needed:\n- /tmp/brief.pdf]",
+  );
+});
+
+test("attachment prompt includes display marker and hidden path block", () => {
+  const prompt = buildAttachmentPrompt(
+    "Summarize this",
+    [file("brief.pdf")],
+    ["/Users/ja/.houston/cache/attachments/brief.pdf"],
+  );
+  const match = prompt.match(/^<!--houston:attachments (\{.*\})-->/);
+
+  assert.ok(match);
+  assert.deepEqual(JSON.parse(match[1]), {
+    message: "Summarize this",
+    files: [
+      {
+        name: "brief.pdf",
+        path: "/Users/ja/.houston/cache/attachments/brief.pdf",
+      },
+    ],
+  });
+  assert.match(prompt, /\[User attached these files\. Read them with the Read tool if needed:/);
+  assert.match(prompt, /- \/Users\/ja\/\.houston\/cache\/attachments\/brief\.pdf/);
+});
+
+test("attachment references fall back to file name from path", () => {
+  assert.deepEqual(
+    attachmentReferences([], ["/tmp/report.csv"]),
+    [{ name: "report.csv", path: "/tmp/report.csv" }],
+  );
+});

--- a/app/src/lib/attachment-message.ts
+++ b/app/src/lib/attachment-message.ts
@@ -1,0 +1,53 @@
+import type {
+  AttachmentInvocation,
+  AttachmentReference,
+} from "@houston-ai/chat";
+
+const MARKER_PREFIX = "<!--houston:attachments ";
+const MARKER_SUFFIX = "-->";
+
+export function withAttachmentPaths(text: string, paths: string[]): string {
+  if (paths.length === 0) return text;
+  const list = paths.map((p) => `- ${p}`).join("\n");
+  const block = `[User attached these files. Read them with the Read tool if needed:\n${list}]`;
+  return text.length > 0 ? `${text}\n\n${block}` : block;
+}
+
+export function buildAttachmentPrompt(
+  text: string,
+  files: readonly File[],
+  paths: readonly string[],
+): string {
+  const prompt = withAttachmentPaths(text, [...paths]);
+  const attachments = attachmentReferences(files, paths);
+  if (attachments.length === 0) return prompt;
+  return encodeAttachmentMessage(text, attachments, prompt);
+}
+
+export function attachmentReferences(
+  files: readonly File[],
+  paths: readonly string[],
+): AttachmentReference[] {
+  return paths.map((path, index) => ({
+    path,
+    name: files[index]?.name ?? fileNameFromPath(path),
+  }));
+}
+
+function encodeAttachmentMessage(
+  userText: string,
+  files: readonly AttachmentReference[],
+  claudePrompt: string,
+): string {
+  const payload: AttachmentInvocation = {
+    message: userText.trim(),
+    files: [...files],
+  };
+  const json = JSON.stringify(payload);
+  return `${MARKER_PREFIX}${json}${MARKER_SUFFIX}\n\n${claudePrompt}`;
+}
+
+function fileNameFromPath(path: string): string {
+  const parts = path.split(/[\\/]+/).filter(Boolean);
+  return parts.at(-1) ?? path;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -30,6 +30,7 @@ import type {
 import { getEngine } from "./engine";
 import { osPickDirectory } from "./os-bridge";
 import { logger } from "./logger";
+export { withAttachmentPaths } from "./attachment-message";
 
 /** Wrap an engine call and surface errors as toasts — never fail silently. */
 async function call<T>(
@@ -188,14 +189,6 @@ export const tauriAttachments = {
   delete: (scopeId: string) =>
     call<void>("delete_attachments", () => getEngine().deleteAttachments(scopeId)),
 };
-
-/** Format a prompt with attachment paths appended. Unchanged. */
-export function withAttachmentPaths(text: string, paths: string[]): string {
-  if (paths.length === 0) return text;
-  const list = paths.map((p) => `- ${p}`).join("\n");
-  const block = `[User attached these files. Read them with the Read tool if needed:\n${list}]`;
-  return text.length > 0 ? `${text}\n\n${block}` : block;
-}
 
 // ─── Agent-data files (`.houston/**`) ─────────────────────────────────
 

--- a/app/src/locales/en/board.json
+++ b/app/src/locales/en/board.json
@@ -31,6 +31,10 @@
   "toasts": {
     "attached": "Attached: {{names}}"
   },
+  "attachmentMessage": {
+    "count_one": "1 file attached",
+    "count_other": "{{count}} files attached"
+  },
   "chatEmpty": {
     "heading": "What can I help with?",
     "subheading": "Tap an action to get started, or just type what you need below.",

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -8,6 +8,10 @@
     "attachmentsOnly": "Attachments",
     "attached": "Attached: {{names}}"
   },
+  "attachmentMessage": {
+    "count_one": "1 file attached",
+    "count_other": "{{count}} files attached"
+  },
   "empty": {
     "title": "Start a conversation",
     "description": "Type a message to talk to your assistant."

--- a/app/src/locales/es/board.json
+++ b/app/src/locales/es/board.json
@@ -31,6 +31,10 @@
   "toasts": {
     "attached": "Adjuntó: {{names}}"
   },
+  "attachmentMessage": {
+    "count_one": "1 archivo adjunto",
+    "count_other": "{{count}} archivos adjuntos"
+  },
   "chatEmpty": {
     "heading": "¿En qué te ayudo?",
     "subheading": "Toca una acción para empezar, o escribe lo que necesitas abajo.",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -8,6 +8,10 @@
     "attachmentsOnly": "Archivos adjuntos",
     "attached": "Adjunto: {{names}}"
   },
+  "attachmentMessage": {
+    "count_one": "1 archivo adjunto",
+    "count_other": "{{count}} archivos adjuntos"
+  },
   "empty": {
     "title": "Empieza una conversación",
     "description": "Escribe un mensaje para hablar con tu asistente."

--- a/app/src/locales/pt/board.json
+++ b/app/src/locales/pt/board.json
@@ -31,6 +31,10 @@
   "toasts": {
     "attached": "Anexou: {{names}}"
   },
+  "attachmentMessage": {
+    "count_one": "1 arquivo anexado",
+    "count_other": "{{count}} arquivos anexados"
+  },
   "chatEmpty": {
     "heading": "Em que posso ajudar?",
     "subheading": "Toque uma ação para começar, ou escreva o que você precisa abaixo.",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -8,6 +8,10 @@
     "attachmentsOnly": "Anexos",
     "attached": "Anexo: {{names}}"
   },
+  "attachmentMessage": {
+    "count_one": "1 arquivo anexado",
+    "count_other": "{{count}} arquivos anexados"
+  },
   "empty": {
     "title": "Comece uma conversa",
     "description": "Digite uma mensagem para falar com seu assistente."

--- a/knowledge-base/actions.md
+++ b/knowledge-base/actions.md
@@ -74,7 +74,7 @@ Step-by-step instructions Claude follows when the action runs.
    - composer model selector + Actions button
    - Composio link card renderer
    - file-tool result renderer
-   - `renderUserMessage` — decodes the action marker into a card
+   - `renderUserMessage` — decodes action + attachment markers into cards
 5. Both **BoardTab** (per-agent kanban) and **Dashboard** (Mission Control / cross-agent kanban) consume this hook so the right panel is identical in both views.
 
 ## Action invocation marker (chat persistence)
@@ -82,7 +82,7 @@ Step-by-step instructions Claude follows when the action runs.
 When the user runs an action, the persisted user_message body is:
 
 ```
-<!--houston:action {"skill":"research-company","displayName":"Research a company","image":"...","description":"...","integrations":["tavily"],"fields":[],"message":"Focus on pricing."}-->
+<!--houston:action {"skill":"research-company","displayName":"Research a company","image":"...","description":"...","integrations":["tavily"],"fields":[],"message":"Focus on pricing.","attachments":[]}-->
 
 Use the research-company skill.
 
@@ -91,8 +91,27 @@ Focus on pricing.
 
 - The HTML-comment marker is inert text to Claude (it ignores it) but carries everything the chat renderer needs to draw the card. Single source of truth = single persisted body.
 - The marker `message` is the user's optional composer text. The body is the Claude-facing prompt and always starts with `Use the <skill> skill.`.
+- If files were uploaded with the action, `attachments` carries `{name,path}` entries. The renderer shows only the count badge; the Claude-facing body still contains the `[User attached these files...]` path block.
 - Decoder lives in `@houston-ai/chat`'s `action-message.ts` so desktop AND mobile render the same card from the same payload.
 - Encoder (`encodeActionMessage`) + Claude-prompt assembler (`buildActionClaudePrompt`) live in `app/src/lib/action-message.ts` — only the desktop sends actions today.
+
+## Attachment message marker (chat persistence)
+
+Regular messages with uploaded files follow the same "single persisted body"
+pattern as Actions:
+
+```
+<!--houston:attachments {"message":"Summarize this","files":[{"name":"brief.pdf","path":"/Users/.../brief.pdf"}]}-->
+
+Summarize this
+
+[User attached these files. Read them with the Read tool if needed:
+- /Users/.../brief.pdf]
+```
+
+- The model receives the same path block as before, so file access behavior does not change.
+- The UI decodes the marker and renders the user text plus a compact paperclip badge ("1 file attached" / "N files attached"). Absolute paths are never displayed.
+- Decoder + shared badge renderer live in `@houston-ai/chat` (`attachment-message.ts`, `user-attachment-message.tsx`). Desktop encoder lives in `app/src/lib/attachment-message.ts`.
 
 ## Authoring an action via Claude
 

--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -91,6 +91,12 @@ Only two tables:
 
 Everything else lives in files.
 
+User-message rows may include leading `<!--houston:action ...-->` or
+`<!--houston:attachments ...-->` markers. These are display metadata only;
+the same row still contains the Claude-facing prompt body after the marker.
+Renderers decode the marker so non-technical users see cards/badges instead
+of file paths or internal prompt instructions.
+
 ## Session file-change attribution
 Chat sessions snapshot user-visible project files before and after the
 CLI run. The engine diffs those snapshots and persists a `file_changes`

--- a/mobile/src/components/chat-view.tsx
+++ b/mobile/src/components/chat-view.tsx
@@ -7,7 +7,13 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate, useParams, useSearchParams } from "react-router-dom";
-import { ChatPanel, decodeActionMessage, type FeedItem } from "@houston-ai/chat";
+import {
+  ChatPanel,
+  UserAttachmentMessage,
+  decodeActionMessage,
+  decodeAttachmentMessage,
+  type FeedItem,
+} from "@houston-ai/chat";
 import {
   useChatHistory,
   useCreateMission,
@@ -122,8 +128,10 @@ export function ChatView() {
           }
           renderUserMessage={(msg) => {
             const invocation = decodeActionMessage(msg.content);
-            if (!invocation) return undefined;
-            return <UserActionMessage invocation={invocation} />;
+            if (invocation) return <UserActionMessage invocation={invocation} />;
+            const attachmentInvocation = decodeAttachmentMessage(msg.content);
+            if (!attachmentInvocation) return undefined;
+            return <UserAttachmentMessage invocation={attachmentInvocation} />;
           }}
         />
       </div>

--- a/mobile/src/components/user-action-message.tsx
+++ b/mobile/src/components/user-action-message.tsx
@@ -9,6 +9,7 @@
 
 import { useState } from "react";
 import {
+  UserAttachmentBadge,
   type ActionInvocation,
   resolveActionImage,
 } from "@houston-ai/chat";
@@ -18,7 +19,15 @@ interface Props {
 }
 
 export function UserActionMessage({ invocation }: Props) {
-  const { displayName, image, description, integrations, fields, message } = invocation;
+  const {
+    displayName,
+    image,
+    description,
+    integrations,
+    fields,
+    message,
+    attachments,
+  } = invocation;
   return (
     <div className="flex max-w-sm flex-col items-end gap-2">
       <div className="inline-block rounded-2xl bg-secondary p-4 text-left">
@@ -66,6 +75,7 @@ export function UserActionMessage({ invocation }: Props) {
           <span className="whitespace-pre-wrap break-words">{message}</span>
         </div>
       )}
+      <UserAttachmentBadge files={attachments} />
     </div>
   );
 }

--- a/ui/chat/src/action-message.ts
+++ b/ui/chat/src/action-message.ts
@@ -20,6 +20,11 @@
  *     Use the X skill...
  */
 
+import {
+  normalizeAttachmentReferences,
+  type AttachmentReference,
+} from "./attachment-message.ts";
+
 const MARKER_RE = /^<!--houston:action (\{[\s\S]*?\})-->\s*\n?\n?/;
 
 export interface ActionInvocationField {
@@ -45,6 +50,8 @@ export interface ActionInvocation {
   fields: ActionInvocationField[];
   /** Optional text the user typed alongside the action. */
   message: string;
+  /** Files uploaded with the action. Paths are for model context, not UI display. */
+  attachments: AttachmentReference[];
 }
 
 /**
@@ -56,7 +63,8 @@ export function decodeActionMessage(body: string): ActionInvocation | null {
   const match = body.match(MARKER_RE);
   if (!match) return null;
   try {
-    const payload = JSON.parse(match[1]) as ActionInvocation;
+    const payload = JSON.parse(match[1]) as Partial<ActionInvocation> &
+      Record<string, unknown>;
     if (typeof payload?.skill !== "string") return null;
     return {
       skill: payload.skill,
@@ -66,6 +74,7 @@ export function decodeActionMessage(body: string): ActionInvocation | null {
       integrations: payload.integrations ?? [],
       fields: payload.fields ?? [],
       message: payload.message ?? "",
+      attachments: normalizeAttachmentReferences(payload.attachments),
     };
   } catch {
     return null;

--- a/ui/chat/src/attachment-message.ts
+++ b/ui/chat/src/attachment-message.ts
@@ -1,0 +1,58 @@
+/**
+ * User-attachment message marker.
+ *
+ * The full persisted message still contains the model-facing prompt,
+ * including absolute file paths. The leading HTML-comment marker carries
+ * display metadata so consumers can render a clean attachment summary
+ * instead of leaking the raw path block into chat history.
+ */
+
+const MARKER_RE = /^<!--houston:attachments (\{[\s\S]*?\})-->\s*\n?\n?/;
+
+export interface AttachmentReference {
+  name: string;
+  path: string;
+}
+
+export interface AttachmentInvocation {
+  /** Text the user typed alongside the uploaded files. */
+  message: string;
+  /** Absolute paths are intentionally decodeable but not rendered. */
+  files: AttachmentReference[];
+}
+
+export function normalizeAttachmentReferences(value: unknown): AttachmentReference[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((item) => {
+    if (!item || typeof item !== "object") return [];
+    const record = item as Record<string, unknown>;
+    const path = typeof record.path === "string" ? record.path.trim() : "";
+    if (!path) return [];
+    const name =
+      typeof record.name === "string" && record.name.trim()
+        ? record.name.trim()
+        : fileNameFromPath(path);
+    return [{ name, path }];
+  });
+}
+
+export function decodeAttachmentMessage(body: string): AttachmentInvocation | null {
+  const match = body.match(MARKER_RE);
+  if (!match) return null;
+  try {
+    const payload = JSON.parse(match[1]) as Record<string, unknown>;
+    const files = normalizeAttachmentReferences(payload.files);
+    if (files.length === 0) return null;
+    return {
+      message: typeof payload.message === "string" ? payload.message : "",
+      files,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function fileNameFromPath(path: string): string {
+  const parts = path.split(/[\\/]+/).filter(Boolean);
+  return parts.at(-1) ?? path;
+}

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -192,6 +192,13 @@ export type { ProgressPanelProps } from "./progress-panel";
 // (desktop, mobile) can render the same card.
 export { decodeActionMessage, resolveActionImage } from "./action-message";
 export type { ActionInvocation, ActionInvocationField } from "./action-message";
+export { decodeAttachmentMessage, normalizeAttachmentReferences } from "./attachment-message";
+export type { AttachmentInvocation, AttachmentReference } from "./attachment-message";
+export {
+  UserAttachmentBadge,
+  UserAttachmentMessage,
+} from "./user-attachment-message";
+export type { UserAttachmentMessageLabels } from "./user-attachment-message";
 
 // === Utilities ===
 export { Typewriter } from "./typewriter";

--- a/ui/chat/src/user-attachment-message.tsx
+++ b/ui/chat/src/user-attachment-message.tsx
@@ -1,0 +1,57 @@
+import { Paperclip } from "lucide-react";
+import type { AttachmentInvocation, AttachmentReference } from "./attachment-message";
+
+export interface UserAttachmentMessageLabels {
+  attachmentCount?: (count: number) => string;
+}
+
+interface UserAttachmentMessageProps {
+  invocation: AttachmentInvocation;
+  labels?: UserAttachmentMessageLabels;
+}
+
+interface UserAttachmentBadgeProps {
+  files: readonly AttachmentReference[];
+  labels?: UserAttachmentMessageLabels;
+}
+
+export function UserAttachmentMessage({
+  invocation,
+  labels,
+}: UserAttachmentMessageProps) {
+  const message = invocation.message.trim();
+  return (
+    <div className="flex max-w-md flex-col items-end gap-2">
+      {message.length > 0 && (
+        <div className="inline-block max-w-full rounded-2xl bg-secondary px-4 py-2.5 text-left text-sm leading-6 text-foreground">
+          <span className="whitespace-pre-wrap break-words">{message}</span>
+        </div>
+      )}
+      <UserAttachmentBadge files={invocation.files} labels={labels} />
+    </div>
+  );
+}
+
+export function UserAttachmentBadge({
+  files,
+  labels,
+}: UserAttachmentBadgeProps) {
+  if (files.length === 0) return null;
+  return (
+    <div
+      className="inline-flex max-w-full items-center gap-2 rounded-full border border-black/10 bg-white px-3 py-1.5 text-xs font-medium text-foreground shadow-[0_1px_0_rgba(0,0,0,0.04)]"
+      title={files.map((file) => file.name).join(", ")}
+    >
+      <Paperclip className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+      <span className="truncate">{attachmentCountLabel(files.length, labels)}</span>
+    </div>
+  );
+}
+
+function attachmentCountLabel(
+  count: number,
+  labels: UserAttachmentMessageLabels | undefined,
+): string {
+  if (labels?.attachmentCount) return labels.attachmentCount(count);
+  return count === 1 ? "1 file attached" : `${count} files attached`;
+}

--- a/ui/chat/test/action-message.test.mjs
+++ b/ui/chat/test/action-message.test.mjs
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { decodeActionMessage } from "../src/action-message.ts";
+
+test("action marker decodes uploaded attachment metadata", () => {
+  const body =
+    '<!--houston:action {"skill":"review-contract","displayName":"Review contract","image":null,"description":"","integrations":[],"fields":[],"message":"Please check liability","attachments":[{"name":"msa.pdf","path":"/tmp/msa.pdf"}]}-->\n\nUse the review-contract skill.';
+
+  assert.deepEqual(decodeActionMessage(body)?.attachments, [
+    { name: "msa.pdf", path: "/tmp/msa.pdf" },
+  ]);
+});

--- a/ui/chat/test/attachment-message.test.mjs
+++ b/ui/chat/test/attachment-message.test.mjs
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  decodeAttachmentMessage,
+  normalizeAttachmentReferences,
+} from "../src/attachment-message.ts";
+
+test("decodes attachment marker without exposing prompt body", () => {
+  const body =
+    '<!--houston:attachments {"message":"Read this","files":[{"name":"brief.pdf","path":"/tmp/brief.pdf"}]}-->\n\nRead this\n\n[User attached these files. Read them with the Read tool if needed:\n- /tmp/brief.pdf]';
+
+  assert.deepEqual(decodeAttachmentMessage(body), {
+    message: "Read this",
+    files: [{ name: "brief.pdf", path: "/tmp/brief.pdf" }],
+  });
+});
+
+test("normalizes names from paths when marker omits file name", () => {
+  assert.deepEqual(
+    normalizeAttachmentReferences([{ path: "C:\\Users\\ja\\Desktop\\notes.txt" }]),
+    [{ name: "notes.txt", path: "C:\\Users\\ja\\Desktop\\notes.txt" }],
+  );
+});
+
+test("ignores invalid attachment marker payloads", () => {
+  assert.equal(decodeAttachmentMessage("hello"), null);
+  assert.equal(
+    decodeAttachmentMessage('<!--houston:attachments {"message":"x","files":[]}-->'),
+    null,
+  );
+});


### PR DESCRIPTION
## Summary
- Add structured attachment markers so persisted chat keeps model-facing file paths while UI renders clean paperclip badges.
- Extend Action messages to carry uploaded-file metadata and render the same badge on desktop and mobile.
- Add locale strings, focused marker tests, and knowledge-base docs for the marker contract.

## Verification
- pnpm typecheck
- cd app && pnpm check-locales
- node --experimental-strip-types --test ui/chat/test/attachment-message.test.mjs ui/chat/test/action-message.test.mjs app/src/lib/attachment-message.test.mjs
- COREPACK_ENABLE_AUTO_PIN=0 pnpm --filter houston-app build
- COREPACK_ENABLE_AUTO_PIN=0 pnpm --filter houston-mobile build
