### PR TITLE
fix: gate Anthropic reconnect on confirmed auth state

### DIFF
--- a/app/src/components/shell/provider-reconnect-card.tsx
+++ b/app/src/components/shell/provider-reconnect-card.tsx
@@ -4,6 +4,10 @@ import { Button, Spinner } from "@houston-ai/core";
 import { useUIStore } from "../../stores/ui";
 import { tauriProvider } from "../../lib/tauri";
 import { getProvider } from "../../lib/providers";
+import {
+  providerIsAuthenticated,
+  providerReconnectSignalState,
+} from "./provider-reconnect-state";
 
 interface ProviderReconnectCardProps {
   providerId?: string;
@@ -39,14 +43,14 @@ export function ProviderReconnectCard({
     tauriProvider.checkStatus(providerId)
       .then((status) => {
         if (cancelled) return;
-        if (status.cli_installed && status.authenticated) {
-          setResolvedSignal(signalKey);
-        } else {
+        if (providerReconnectSignalState(status) === "needs_auth") {
           setSignalNeedsAuth(true);
+        } else {
+          setResolvedSignal(signalKey);
         }
       })
       .catch(() => {
-        if (!cancelled) setSignalNeedsAuth(true);
+        if (!cancelled) setResolvedSignal(signalKey);
       });
     return () => {
       cancelled = true;
@@ -60,7 +64,7 @@ export function ProviderReconnectCard({
       try {
         const status = await tauriProvider.checkStatus(activeProviderId);
         if (cancelled) return;
-        if (status.cli_installed && status.authenticated) {
+        if (providerIsAuthenticated(status)) {
           setAuthRequired(null);
           if (signalKey) setResolvedSignal(signalKey);
           setLoginLaunched(false);

--- a/app/src/components/shell/provider-reconnect-state.ts
+++ b/app/src/components/shell/provider-reconnect-state.ts
@@ -1,0 +1,20 @@
+type ProviderAuthState = "authenticated" | "unauthenticated" | "unknown";
+
+interface ProviderReconnectStatus {
+  cli_installed: boolean;
+  auth_state: ProviderAuthState;
+}
+
+export type ProviderReconnectSignalState = "needs_auth" | "resolved";
+
+export function providerReconnectSignalState(
+  status: ProviderReconnectStatus,
+): ProviderReconnectSignalState {
+  return status.cli_installed && status.auth_state === "unauthenticated"
+    ? "needs_auth"
+    : "resolved";
+}
+
+export function providerIsAuthenticated(status: ProviderReconnectStatus): boolean {
+  return status.cli_installed && status.auth_state === "authenticated";
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -25,6 +25,7 @@ import type {
 import type {
   ComposioAppEntry as EngineComposioAppEntry,
   ComposioStatus as EngineComposioStatus,
+  ProviderAuthState,
   ProviderStatus as EngineProviderStatus,
 } from "@houston-ai/engine-client";
 import { getEngine } from "./engine";
@@ -573,6 +574,7 @@ export const tauriPreferences = {
 export interface ProviderStatus {
   provider: string;
   cli_installed: boolean;
+  auth_state: ProviderAuthState;
   authenticated: boolean;
   cli_name: string;
 }
@@ -586,7 +588,8 @@ export const tauriProvider = {
       return {
         provider: p.provider,
         cli_installed: p.cliInstalled,
-        authenticated: p.authenticated,
+        auth_state: p.authState,
+        authenticated: p.authState === "authenticated",
         cli_name: p.cliName,
       };
     }),

--- a/app/tests/provider-reconnect-state.test.ts
+++ b/app/tests/provider-reconnect-state.test.ts
@@ -1,0 +1,55 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  providerIsAuthenticated,
+  providerReconnectSignalState,
+} from "../src/components/shell/provider-reconnect-state.ts";
+
+describe("provider reconnect signal state", () => {
+  it("shows reconnect only for confirmed unauthenticated status", () => {
+    strictEqual(
+      providerReconnectSignalState({
+        cli_installed: true,
+        auth_state: "unauthenticated",
+      }),
+      "needs_auth",
+    );
+  });
+
+  it("resolves unknown Anthropic status instead of blinking card", () => {
+    strictEqual(
+      providerReconnectSignalState({
+        cli_installed: true,
+        auth_state: "unknown",
+      }),
+      "resolved",
+    );
+  });
+
+  it("resolves missing CLI status because reconnect cannot fix install state", () => {
+    strictEqual(
+      providerReconnectSignalState({
+        cli_installed: false,
+        auth_state: "unauthenticated",
+      }),
+      "resolved",
+    );
+  });
+
+  it("treats connected only as installed plus authenticated", () => {
+    strictEqual(
+      providerIsAuthenticated({
+        cli_installed: true,
+        auth_state: "authenticated",
+      }),
+      true,
+    );
+    strictEqual(
+      providerIsAuthenticated({
+        cli_installed: false,
+        auth_state: "authenticated",
+      }),
+      false,
+    );
+  });
+});

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -7,9 +7,10 @@ use crate::session_id_tracker::SessionIdHandle;
 use crate::session_pids::SessionPidMap;
 use houston_db::Database;
 use houston_terminal_manager::auth_error::{is_auth_error, is_auth_retry_marker};
+use houston_terminal_manager::provider_auth::{probe_claude_auth_status, ProviderAuthState};
 use houston_terminal_manager::{FeedItem, Provider, SessionManager, SessionStatus, SessionUpdate};
 use houston_ui_events::{DynEventSink, HoustonEvent};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// Result of a completed session.
 pub struct SessionResult {
@@ -35,16 +36,26 @@ pub struct PersistOptions {
 enum AuthFeedAction {
     None,
     DeferUntilExit,
+    VerifyProviderStatus,
     RequireNow,
 }
 
 fn classify_auth_feed_message(provider: Provider, message: &str) -> AuthFeedAction {
     if is_auth_retry_marker(message) {
         AuthFeedAction::DeferUntilExit
-    } else if is_auth_error(message) || is_opaque_claude_auth_error(provider, message) {
+    } else if is_auth_error(message) {
         AuthFeedAction::RequireNow
+    } else if is_opaque_claude_auth_error(provider, message) {
+        AuthFeedAction::VerifyProviderStatus
     } else {
         AuthFeedAction::None
+    }
+}
+
+async fn provider_auth_state(provider: Provider) -> ProviderAuthState {
+    match provider {
+        Provider::Anthropic => probe_claude_auth_status(Path::new("claude")).await,
+        Provider::OpenAI => ProviderAuthState::Unknown,
     }
 }
 
@@ -136,6 +147,40 @@ pub fn spawn_and_monitor(
                                     "[session_runner] auth retry marker detected — deferring AuthRequired until session exit"
                                 );
                                 continue;
+                            }
+                            AuthFeedAction::VerifyProviderStatus => {
+                                let auth_state = provider_auth_state(provider_kind).await;
+                                if auth_state != ProviderAuthState::Unauthenticated {
+                                    tracing::info!(
+                                        "[session_runner] opaque provider error was not confirmed as logout: provider={provider_str}, auth_state={auth_state:?}"
+                                    );
+                                } else {
+                                    saw_auth_error = true;
+                                    if !sent_auth_required {
+                                        sent_auth_required = true;
+                                        tracing::info!(
+                                            "[session_runner] emitting AuthRequired for provider={provider_str} after status verification"
+                                        );
+                                        sink.emit(HoustonEvent::AuthRequired {
+                                            provider: provider_str.clone(),
+                                            message: msg.clone(),
+                                        });
+                                    }
+                                    if !sent_auth_checking {
+                                        sent_auth_checking = true;
+                                        tracing::info!(
+                                            "[session_runner] auth issue detected ({msg:?}) — emitting Checking connection..."
+                                        );
+                                        sink.emit(HoustonEvent::FeedItem {
+                                            agent_path: agent_path_for_events.clone(),
+                                            session_key: key.clone(),
+                                            item: FeedItem::SystemMessage(
+                                                "Checking connection...".to_string(),
+                                            ),
+                                        });
+                                    }
+                                    continue;
+                                }
                             }
                             AuthFeedAction::RequireNow => {
                                 saw_auth_error = true;
@@ -264,9 +309,14 @@ pub fn spawn_and_monitor(
                     // slot). No feed marker needed — the card is anchored to
                     // store state, not to a specific FeedItem.
                     if let SessionStatus::Error(ref e) = status {
-                        let auth_error = saw_auth_error
-                            || is_auth_error(e)
-                            || is_opaque_claude_auth_error(provider_kind, e);
+                        let auth_error = if saw_auth_error || is_auth_error(e) {
+                            true
+                        } else if is_opaque_claude_auth_error(provider_kind, e) {
+                            provider_auth_state(provider_kind).await
+                                == ProviderAuthState::Unauthenticated
+                        } else {
+                            false
+                        };
                         tracing::info!(
                             "[session_runner] session error: {e:?} | saw_auth_error={saw_auth_error} | is_auth_error={auth_error} | provider={provider_str}"
                         );
@@ -356,7 +406,15 @@ mod tests {
     use super::*;
 
     #[test]
-    fn treats_opaque_claude_result_error_as_auth() {
+    fn opaque_claude_result_error_requires_status_verification() {
+        assert_eq!(
+            classify_auth_feed_message(Provider::Anthropic, "Error: Unknown error"),
+            AuthFeedAction::VerifyProviderStatus
+        );
+    }
+
+    #[test]
+    fn identifies_opaque_claude_auth_error_shape() {
         assert!(is_opaque_claude_auth_error(
             Provider::Anthropic,
             "Error: Unknown error"

--- a/engine/houston-engine-core/src/provider.rs
+++ b/engine/houston-engine-core/src/provider.rs
@@ -6,11 +6,17 @@
 //! that want to `get`/`set` the preference directly.
 
 use crate::error::{CoreError, CoreResult};
+use houston_terminal_manager::provider_auth::{
+    probe_claude_auth_status, probe_codex_auth_status, ProviderAuthState,
+};
 use houston_terminal_manager::{claude_path, Provider};
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
 use std::path::PathBuf;
 use std::time::Duration;
+
+mod resolve;
+use resolve::{resolve_claude, resolve_codex};
 
 pub const DEFAULT_PROVIDER_KEY: &str = "default_provider";
 
@@ -41,7 +47,7 @@ pub enum InstallSource {
 pub struct ProviderStatus {
     pub provider: String,
     pub cli_installed: bool,
-    pub authenticated: bool,
+    pub auth_state: ProviderAuthState,
     pub cli_name: String,
     /// Where Houston found the CLI binary. Used for UI labelling.
     pub install_source: InstallSource,
@@ -143,205 +149,39 @@ fn build_login_command(
 async fn check_claude_status() -> ProviderStatus {
     let (install_source, cli_path) = resolve_claude();
     let cli_installed = !matches!(install_source, InstallSource::Missing);
-    let authenticated = if let Some(path) = cli_path.as_deref() {
-        check_claude_auth(path).await
+    let auth_state = if let Some(path) = cli_path.as_deref() {
+        probe_claude_auth_status(path).await
     } else {
-        false
+        ProviderAuthState::Unauthenticated
     };
     ProviderStatus {
         provider: "anthropic".into(),
         cli_installed,
-        authenticated,
+        auth_state,
         cli_name: "claude".into(),
         install_source,
         cli_path: cli_path.map(|p| p.to_string_lossy().into_owned()),
     }
 }
 
-/// Resolve the active claude binary in priority order:
-///   1. **Managed** — installed by `houston-claude-installer` at the
-///      Houston-controlled location. We trust this most because we
-///      sha256-verified the download against the pinned manifest.
-///   2. **Path** — anything else on PATH (homebrew, npm, manual). Used
-///      verbatim; Houston does NOT validate the version when the
-///      binary is user-managed.
-///
-/// Claude is never bundled (proprietary license), so the `Bundled`
-/// branch is intentionally absent here — see the `cli-bundle` module
-/// doc for the policy reasoning.
-fn resolve_claude() -> (InstallSource, Option<PathBuf>) {
-    if houston_claude_installer::is_installed() {
-        return (
-            InstallSource::Managed,
-            Some(houston_claude_installer::cli_path()),
-        );
-    }
-    if let Some(path) = which_on_path("claude") {
-        return (InstallSource::Path, Some(path));
-    }
-    (InstallSource::Missing, None)
-}
-
-/// `claude --version` succeeds without auth; `claude auth status` returns
-/// the real `loggedIn` signal as JSON.
-async fn check_claude_auth(cli_path: &std::path::Path) -> bool {
-    let shell_path = claude_path::shell_path();
-    let result = tokio::time::timeout(
-        Duration::from_secs(5),
-        tokio::process::Command::new(cli_path)
-            .args(["auth", "status"])
-            .env("PATH", &shell_path)
-            .kill_on_drop(true)
-            .output(),
-    )
-    .await;
-
-    let output = match result {
-        Ok(Ok(o)) if o.status.success() => o.stdout,
-        _ => return false,
-    };
-
-    let text = String::from_utf8_lossy(&output);
-    serde_json::from_str::<serde_json::Value>(text.trim())
-        .ok()
-        .and_then(|v| v.get("loggedIn")?.as_bool())
-        .unwrap_or(false)
-}
-
 async fn check_codex_status() -> ProviderStatus {
     let (install_source, cli_path) = resolve_codex();
     let cli_installed = !matches!(install_source, InstallSource::Missing);
-    let authenticated = if let Some(path) = cli_path.as_deref() {
+    let auth_state = if let Some(path) = cli_path.as_deref() {
         let home = std::env::var("HOME").unwrap_or_default();
-        if check_codex_auth(path, &home).await {
-            true
-        } else {
-            false
-        }
+        probe_codex_auth_status(path, &home).await
     } else {
-        false
+        ProviderAuthState::Unauthenticated
     };
 
     ProviderStatus {
         provider: "openai".into(),
         cli_installed,
-        authenticated,
+        auth_state,
         cli_name: "codex".into(),
         install_source,
         cli_path: cli_path.map(|p| p.to_string_lossy().into_owned()),
     }
-}
-
-/// Resolve the active codex binary:
-///   1. **Bundled** — universal Mach-O at `Resources/bin/codex` shipped
-///      with the Houston `.app`. Production users never hit anything
-///      else.
-///   2. **Path** — user-installed copy (homebrew, manual). Allowed for
-///      developers who want to test against a newer codex than the
-///      pinned bundled version.
-fn resolve_codex() -> (InstallSource, Option<PathBuf>) {
-    if let Some(p) = houston_cli_bundle::bundled_codex_path() {
-        return (InstallSource::Bundled, Some(p));
-    }
-    if let Some(path) = which_on_path("codex") {
-        return (InstallSource::Path, Some(path));
-    }
-    (InstallSource::Missing, None)
-}
-
-/// Walk the resolved PATH (login shell + Houston-augmented dirs) for a
-/// command. Returns the first hit's absolute path.
-fn which_on_path(command: &str) -> Option<PathBuf> {
-    let shell_path = claude_path::shell_path();
-    for dir in std::env::split_paths(&shell_path) {
-        let candidate = dir.join(command);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-        #[cfg(windows)]
-        {
-            for ext in ["exe", "cmd", "bat", "ps1"] {
-                let c = dir.join(format!("{command}.{ext}"));
-                if c.is_file() {
-                    return Some(c);
-                }
-            }
-        }
-    }
-    None
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum CodexAuthProbe {
-    Authenticated,
-    Unauthenticated,
-    Unknown,
-}
-
-async fn check_codex_auth(cli_path: &std::path::Path, home: &str) -> bool {
-    match probe_codex_login_status(cli_path).await {
-        CodexAuthProbe::Authenticated => true,
-        CodexAuthProbe::Unauthenticated => false,
-        CodexAuthProbe::Unknown => check_codex_auth_file(home),
-    }
-}
-
-async fn probe_codex_login_status(cli_path: &std::path::Path) -> CodexAuthProbe {
-    let shell_path = claude_path::shell_path();
-    let result = tokio::time::timeout(
-        Duration::from_secs(5),
-        tokio::process::Command::new(cli_path)
-            .args(["login", "status", "-c", "model_reasoning_effort=high"])
-            .env("PATH", &shell_path)
-            .kill_on_drop(true)
-            .output(),
-    )
-    .await;
-
-    let output = match result {
-        Ok(Ok(o)) => o,
-        _ => return CodexAuthProbe::Unknown,
-    };
-    classify_codex_login_status_output(
-        output.status.success(),
-        &String::from_utf8_lossy(&output.stdout),
-        &String::from_utf8_lossy(&output.stderr),
-    )
-}
-
-fn classify_codex_login_status_output(success: bool, stdout: &str, stderr: &str) -> CodexAuthProbe {
-    let text = format!("{stdout}\n{stderr}").to_lowercase();
-    if text.contains("not logged in")
-        || text.contains("not authenticated")
-        || text.contains("please login")
-        || text.contains("please log in")
-        || text.contains("signed out")
-        || text.contains("no auth credentials")
-        || text.contains("run codex login")
-    {
-        return CodexAuthProbe::Unauthenticated;
-    }
-    if success && (text.contains("logged in") || text.contains("authenticated")) {
-        return CodexAuthProbe::Authenticated;
-    }
-    CodexAuthProbe::Unknown
-}
-
-fn check_codex_auth_file(home: &str) -> bool {
-    let auth_path = PathBuf::from(home).join(".codex").join("auth.json");
-    let content = match std::fs::read_to_string(&auth_path) {
-        Ok(c) => c,
-        Err(_) => return false,
-    };
-    serde_json::from_str::<serde_json::Value>(&content)
-        .ok()
-        .map(|v| {
-            v.get("OPENAI_API_KEY")
-                .and_then(|k| k.as_str())
-                .is_some_and(|s| !s.is_empty())
-                || v.get("tokens").is_some()
-        })
-        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -379,24 +219,5 @@ mod tests {
         assert_eq!(command.cli_name, "claude");
         assert_eq!(command.path, path);
         assert_eq!(command.args, vec!["auth", "login", "--claudeai"]);
-    }
-
-    #[test]
-    fn codex_login_status_classifies_logged_in_output() {
-        let status = classify_codex_login_status_output(true, "Logged in using ChatGPT", "");
-        assert_eq!(status, CodexAuthProbe::Authenticated);
-    }
-
-    #[test]
-    fn codex_login_status_classifies_not_logged_in_output_first() {
-        let status = classify_codex_login_status_output(true, "Not logged in", "");
-        assert_eq!(status, CodexAuthProbe::Unauthenticated);
-    }
-
-    #[test]
-    fn codex_login_status_falls_back_on_config_errors() {
-        let stderr = "Error loading configuration: unknown variant `xhigh`";
-        let status = classify_codex_login_status_output(false, "", stderr);
-        assert_eq!(status, CodexAuthProbe::Unknown);
     }
 }

--- a/engine/houston-engine-core/src/provider/resolve.rs
+++ b/engine/houston-engine-core/src/provider/resolve.rs
@@ -1,0 +1,46 @@
+use super::InstallSource;
+use houston_terminal_manager::claude_path;
+use std::path::PathBuf;
+
+pub(super) fn resolve_claude() -> (InstallSource, Option<PathBuf>) {
+    if houston_claude_installer::is_installed() {
+        return (
+            InstallSource::Managed,
+            Some(houston_claude_installer::cli_path()),
+        );
+    }
+    if let Some(path) = which_on_path("claude") {
+        return (InstallSource::Path, Some(path));
+    }
+    (InstallSource::Missing, None)
+}
+
+pub(super) fn resolve_codex() -> (InstallSource, Option<PathBuf>) {
+    if let Some(path) = houston_cli_bundle::bundled_codex_path() {
+        return (InstallSource::Bundled, Some(path));
+    }
+    if let Some(path) = which_on_path("codex") {
+        return (InstallSource::Path, Some(path));
+    }
+    (InstallSource::Missing, None)
+}
+
+fn which_on_path(command: &str) -> Option<PathBuf> {
+    let shell_path = claude_path::shell_path();
+    for dir in std::env::split_paths(&shell_path) {
+        let candidate = dir.join(command);
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+        #[cfg(windows)]
+        {
+            for ext in ["exe", "cmd", "bat", "ps1"] {
+                let candidate = dir.join(format!("{command}.{ext}"));
+                if candidate.is_file() {
+                    return Some(candidate);
+                }
+            }
+        }
+    }
+    None
+}

--- a/engine/houston-engine-server/tests/providers.rs
+++ b/engine/houston-engine-server/tests/providers.rs
@@ -55,7 +55,10 @@ async fn status_returns_shape_for_known_provider() {
     assert_eq!(body["provider"], "anthropic");
     assert_eq!(body["cliName"], "claude");
     assert!(body["cliInstalled"].is_boolean());
-    assert!(body["authenticated"].is_boolean());
+    assert!(matches!(
+        body["authState"].as_str(),
+        Some("authenticated" | "unauthenticated" | "unknown")
+    ));
 }
 
 #[tokio::test]

--- a/engine/houston-terminal-manager/src/lib.rs
+++ b/engine/houston-terminal-manager/src/lib.rs
@@ -10,6 +10,7 @@ pub mod codex_parser;
 pub mod concurrency;
 pub mod manager;
 pub mod parser;
+pub mod provider_auth;
 pub mod session_io;
 pub mod session_pump;
 pub mod types;
@@ -18,6 +19,7 @@ pub mod types;
 pub use codex_parser::{extract_thread_id, parse_codex_event, CodexAccumulator};
 pub use manager::{SessionHandle, SessionManager, SessionUpdate};
 pub use parser::{extract_session_id, parse_event, StreamAccumulator};
+pub use provider_auth::ProviderAuthState;
 pub use types::{
     ClaudeEvent, ContentBlock, FeedItem, FileChanges, Provider, SessionFeedBuffer, SessionStatus,
 };

--- a/engine/houston-terminal-manager/src/provider_auth.rs
+++ b/engine/houston-terminal-manager/src/provider_auth.rs
@@ -1,0 +1,190 @@
+//! Provider CLI auth probes shared by status routes and session error handling.
+
+use crate::claude_path;
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderAuthState {
+    Authenticated,
+    Unauthenticated,
+    Unknown,
+}
+
+impl ProviderAuthState {
+    pub const fn is_authenticated(self) -> bool {
+        matches!(self, Self::Authenticated)
+    }
+}
+
+pub async fn probe_claude_auth_status(cli_path: &Path) -> ProviderAuthState {
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        tokio::process::Command::new(cli_path)
+            .args(["auth", "status"])
+            .env("PATH", claude_path::shell_path())
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await;
+
+    let output = match result {
+        Ok(Ok(output)) => output,
+        _ => return ProviderAuthState::Unknown,
+    };
+
+    classify_claude_auth_status_output(
+        output.status.success(),
+        &String::from_utf8_lossy(&output.stdout),
+        &String::from_utf8_lossy(&output.stderr),
+    )
+}
+
+pub async fn probe_codex_auth_status(cli_path: &Path, home: &str) -> ProviderAuthState {
+    match probe_codex_login_status(cli_path).await {
+        ProviderAuthState::Authenticated => ProviderAuthState::Authenticated,
+        ProviderAuthState::Unauthenticated => ProviderAuthState::Unauthenticated,
+        ProviderAuthState::Unknown => read_codex_auth_file(home),
+    }
+}
+
+async fn probe_codex_login_status(cli_path: &Path) -> ProviderAuthState {
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        tokio::process::Command::new(cli_path)
+            .args(["login", "status", "-c", "model_reasoning_effort=high"])
+            .env("PATH", claude_path::shell_path())
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await;
+
+    let output = match result {
+        Ok(Ok(output)) => output,
+        _ => return ProviderAuthState::Unknown,
+    };
+
+    classify_codex_login_status_output(
+        output.status.success(),
+        &String::from_utf8_lossy(&output.stdout),
+        &String::from_utf8_lossy(&output.stderr),
+    )
+}
+
+fn classify_claude_auth_status_output(
+    success: bool,
+    stdout: &str,
+    stderr: &str,
+) -> ProviderAuthState {
+    if let Ok(value) = serde_json::from_str::<serde_json::Value>(stdout.trim()) {
+        if let Some(logged_in) = value.get("loggedIn").and_then(|v| v.as_bool()) {
+            return if logged_in {
+                ProviderAuthState::Authenticated
+            } else {
+                ProviderAuthState::Unauthenticated
+            };
+        }
+    }
+
+    let text = format!("{stdout}\n{stderr}").to_lowercase();
+    if contains_unauthenticated_text(&text) {
+        return ProviderAuthState::Unauthenticated;
+    }
+    if success && (text.contains("logged in") || text.contains("authenticated")) {
+        return ProviderAuthState::Authenticated;
+    }
+    ProviderAuthState::Unknown
+}
+
+fn classify_codex_login_status_output(
+    success: bool,
+    stdout: &str,
+    stderr: &str,
+) -> ProviderAuthState {
+    let text = format!("{stdout}\n{stderr}").to_lowercase();
+    if contains_unauthenticated_text(&text)
+        || text.contains("signed out")
+        || text.contains("no auth credentials")
+        || text.contains("run codex login")
+    {
+        return ProviderAuthState::Unauthenticated;
+    }
+    if success && (text.contains("logged in") || text.contains("authenticated")) {
+        return ProviderAuthState::Authenticated;
+    }
+    ProviderAuthState::Unknown
+}
+
+fn contains_unauthenticated_text(text: &str) -> bool {
+    text.contains("not logged in")
+        || text.contains("not authenticated")
+        || text.contains("please login")
+        || text.contains("please log in")
+}
+
+fn read_codex_auth_file(home: &str) -> ProviderAuthState {
+    let auth_path = PathBuf::from(home).join(".codex").join("auth.json");
+    let content = match std::fs::read_to_string(&auth_path) {
+        Ok(content) => content,
+        Err(_) => return ProviderAuthState::Unauthenticated,
+    };
+    serde_json::from_str::<serde_json::Value>(&content)
+        .ok()
+        .map(|value| {
+            let has_api_key = value
+                .get("OPENAI_API_KEY")
+                .and_then(|key| key.as_str())
+                .is_some_and(|s| !s.is_empty());
+            let has_tokens = value.get("tokens").is_some();
+            if has_api_key || has_tokens {
+                ProviderAuthState::Authenticated
+            } else {
+                ProviderAuthState::Unauthenticated
+            }
+        })
+        .unwrap_or(ProviderAuthState::Unknown)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn claude_auth_status_classifies_json_logged_in() {
+        let state = classify_claude_auth_status_output(true, r#"{"loggedIn":true}"#, "");
+        assert_eq!(state, ProviderAuthState::Authenticated);
+    }
+
+    #[test]
+    fn claude_auth_status_classifies_json_logged_out() {
+        let state = classify_claude_auth_status_output(true, r#"{"loggedIn":false}"#, "");
+        assert_eq!(state, ProviderAuthState::Unauthenticated);
+    }
+
+    #[test]
+    fn claude_auth_status_keeps_opaque_failures_unknown() {
+        let state = classify_claude_auth_status_output(false, "", "Error: Unknown error");
+        assert_eq!(state, ProviderAuthState::Unknown);
+    }
+
+    #[test]
+    fn codex_login_status_classifies_logged_in_output() {
+        let state = classify_codex_login_status_output(true, "Logged in using ChatGPT", "");
+        assert_eq!(state, ProviderAuthState::Authenticated);
+    }
+
+    #[test]
+    fn codex_login_status_classifies_not_logged_in_output_first() {
+        let state = classify_codex_login_status_output(true, "Not logged in", "");
+        assert_eq!(state, ProviderAuthState::Unauthenticated);
+    }
+
+    #[test]
+    fn codex_login_status_falls_back_on_config_errors() {
+        let stderr = "Error loading configuration: unknown variant `xhigh`";
+        let state = classify_codex_login_status_output(false, "", stderr);
+        assert_eq!(state, ProviderAuthState::Unknown);
+    }
+}

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -125,6 +125,15 @@ OpenAI provider status should prefer `codex login status` over shallow
 Codex versions or unrelated config-load failures, because config drift should
 not look like sign-out.
 
+Provider status uses tri-state auth: `authenticated`, `unauthenticated`, or
+`unknown`. Reconnect UI renders from feed signals only when status confirms
+`unauthenticated`; `unknown` resolves the signal without a card.
+
+Claude Code can sometimes return `Error: Unknown error` for non-auth failures.
+Treat that shape as a prompt to run `claude auth status`, not as logout by
+itself. Emit `AuthRequired` only when the status probe confirms
+`unauthenticated`.
+
 Never mutate `~/.codex/config.toml` to make Codex read Houston agent
 instructions. Agent directories already expose `CLAUDE.md` through an
 `AGENTS.md` symlink, and global Codex config writes can land under the active

--- a/knowledge-base/cli-bundling.md
+++ b/knowledge-base/cli-bundling.md
@@ -159,13 +159,17 @@ Mirrors `/v1/composio/*`:
   `ClaudeCliInstalling` / `ClaudeCliReady` / `ClaudeCliFailed` events.
 
 `ProviderStatus` (returned by `GET /v1/providers/<name>/status`) gains
-two new fields:
+three status fields beyond provider + CLI name:
 
 - `installSource: "bundled" | "managed" | "path" | "missing"` —
   Houston's view of where the binary came from. Renders as a chip in
   the provider settings UI.
 - `cliPath: string | null` — absolute path Houston will spawn.
   Surfaces in diagnostics.
+- `authState: "authenticated" | "unauthenticated" | "unknown"` —
+  tri-state provider auth. `unknown` means the CLI status probe failed
+  or returned an unrecognized shape; reconnect UI must not treat it as
+  logout.
 
 ## DMG size
 

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -198,7 +198,7 @@ string[] }`; clients should render this as session-owned project artifacts.
 | Method | Path | Description |
 |---|---|---|
 | GET/PUT | `/v1/preferences/:key` | String KV (DB-backed) |
-| GET | `/v1/providers/:name/status` | `{cli_installed, authenticated, install_source, cli_path}` |
+| GET | `/v1/providers/:name/status` | `{cliInstalled, authState, installSource, cliPath}` |
 | POST | `/v1/providers/:name/login` | Launch CLI login |
 | GET | `/v1/agent-configs` | List installed agent definitions |
 

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -328,11 +328,12 @@ export interface CommunitySkill {
  * with `#[serde(rename_all = "lowercase")]`.
  */
 export type CliInstallSource = "bundled" | "managed" | "path" | "missing";
+export type ProviderAuthState = "authenticated" | "unauthenticated" | "unknown";
 
 export interface ProviderStatus {
   provider: string;
   cliInstalled: boolean;
-  authenticated: boolean;
+  authState: ProviderAuthState;
   cliName: string;
   installSource: CliInstallSource;
   /** Absolute path to the CLI binary that will be spawned, or `null`


### PR DESCRIPTION
## Summary
- add tri-state provider auth status and shared CLI auth probes
- require Claude auth-status confirmation before showing Anthropic reconnect card for opaque errors
- update app reconnect signal handling, tests, and provider docs

## Verification
- cargo build -p houston-engine-server
- cargo test --workspace
- pnpm typecheck
- pnpm --dir app check-locales
- node --experimental-strip-types --test app/tests/provider-reconnect-state.test.ts
- pnpm --filter @houston-ai/engine-client test
- git diff --check