### PR TITLE
fix: surface tool runtime errors as chat recovery cards

### DIFF
--- a/app/src/components/mission-search.ts
+++ b/app/src/components/mission-search.ts
@@ -49,6 +49,8 @@ function feedItemToSearchText(item: FeedItem): string {
       return `${item.data.name} ${feedValueToText(item.data.input)}`;
     case "tool_result":
       return item.data.content;
+    case "tool_runtime_error":
+      return "";
     case "file_changes":
       return [...item.data.created, ...item.data.modified].join("\n");
     case "final_result":

--- a/app/src/components/shell/tool-runtime-error-card.tsx
+++ b/app/src/components/shell/tool-runtime-error-card.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { BugIcon, RotateCcwIcon, WrenchIcon } from "lucide-react";
+import { Button, Spinner } from "@houston-ai/core";
+import type { ToolRuntimeErrorEntry } from "@houston-ai/chat";
+import { reportBug } from "../../lib/bug-report";
+import { getCurrentUserEmail } from "../../lib/current-user";
+import { useUIStore } from "../../stores/ui";
+import { useWorkspaceStore } from "../../stores/workspaces";
+
+interface ToolRuntimeErrorCardProps {
+  error: ToolRuntimeErrorEntry;
+  onRetry?: () => Promise<void> | void;
+}
+
+export function ToolRuntimeErrorCard({
+  error,
+  onRetry,
+}: ToolRuntimeErrorCardProps) {
+  const { t } = useTranslation(["shell", "common"]);
+  const addToast = useUIStore((s) => s.addToast);
+  const workspaceName = useWorkspaceStore((s) => s.current?.name);
+  const [retrying, setRetrying] = useState(false);
+  const [reporting, setReporting] = useState(false);
+
+  const retry = async () => {
+    if (!onRetry || retrying) return;
+    setRetrying(true);
+    try {
+      await onRetry();
+    } catch {
+      addToast({
+        title: t("shell:toolRuntimeError.retryErrorTitle"),
+        variant: "error",
+      });
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  const report = async () => {
+    if (reporting) return;
+    setReporting(true);
+    try {
+      await reportBug({
+        command: `tool_runtime_error:${error.kind}`,
+        error: error.details || "No diagnostic details captured.",
+        timestamp: new Date().toISOString(),
+        appVersion: __APP_VERSION__,
+        userEmail: getCurrentUserEmail(),
+        workspaceName,
+      });
+      addToast({
+        title: t("shell:toolRuntimeError.reportSuccessTitle"),
+        description: t("shell:toolRuntimeError.reportSuccessDescription"),
+        variant: "success",
+      });
+    } catch {
+      addToast({
+        title: t("shell:toolRuntimeError.reportErrorTitle"),
+        description: t("shell:toolRuntimeError.reportErrorDescription"),
+        variant: "error",
+      });
+    } finally {
+      setReporting(false);
+    }
+  };
+
+  return (
+    <div className="w-full px-1 py-2">
+      <div className="flex items-start gap-4 rounded-2xl bg-secondary p-4 text-left">
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-border bg-background text-muted-foreground">
+          <WrenchIcon className="size-5" />
+        </div>
+
+        <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <p className="text-sm font-semibold text-foreground">
+            {t("shell:toolRuntimeError.title")}
+          </p>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            {t("shell:toolRuntimeError.body")}
+          </p>
+
+          <div className="mt-2 flex flex-wrap items-center gap-2">
+            {onRetry && (
+              <Button
+                onClick={retry}
+                className="h-8 gap-2 rounded-full px-3 text-xs"
+                size="sm"
+                disabled={retrying}
+              >
+                {retrying ? (
+                  <Spinner className="size-3.5" />
+                ) : (
+                  <RotateCcwIcon className="size-3.5" />
+                )}
+                {t("common:actions.tryAgain")}
+              </Button>
+            )}
+            <Button
+              onClick={report}
+              className="h-8 gap-2 rounded-full px-3 text-xs"
+              size="sm"
+              variant="outline"
+              disabled={reporting}
+            >
+              {reporting ? (
+                <Spinner className="size-3.5" />
+              ) : (
+                <BugIcon className="size-3.5" />
+              )}
+              {reporting
+                ? t("shell:toolRuntimeError.reporting")
+                : t("shell:toolRuntimeError.report")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/tabs/chat-tab.tsx
+++ b/app/src/components/tabs/chat-tab.tsx
@@ -29,6 +29,8 @@ import { ChatModelSelector } from "../chat-model-selector";
 import { useChatDisplayLabels } from "../use-chat-display-labels";
 import { getDefaultModel } from "../../lib/providers";
 import { ProviderReconnectCard } from "../shell/provider-reconnect-card";
+import { ToolRuntimeErrorCard } from "../shell/tool-runtime-error-card";
+import { isToolRuntimeErrorMessage } from "../tool-runtime-feed";
 import { useQueuedMessageLabels } from "../use-queued-message-labels";
 import {
   filterProviderAuthFeedItems,
@@ -233,6 +235,16 @@ export default function ChatTab({ agent }: TabProps) {
         getThinkingMessage={getThinkingMessage}
         renderTurnSummary={renderTurnSummary}
         renderSystemMessage={(msg) => {
+          if (isToolRuntimeErrorMessage(msg)) {
+            return (
+              <ToolRuntimeErrorCard
+                error={msg.runtimeError}
+                onRetry={() =>
+                  messageQueue.sendOrQueue(t("toolRuntimeError.retryPrompt"), [])
+                }
+              />
+            );
+          }
           if (isProviderAuthMessage(msg.content)) {
             return null;
           }

--- a/app/src/components/tool-runtime-feed.ts
+++ b/app/src/components/tool-runtime-feed.ts
@@ -1,0 +1,11 @@
+import type { FeedItem, ChatMessage } from "@houston-ai/chat";
+
+export function hasToolRuntimeError(items: readonly FeedItem[]): boolean {
+  return items.some((item) => item.feed_type === "tool_runtime_error");
+}
+
+export function isToolRuntimeErrorMessage(
+  msg: ChatMessage,
+): msg is ChatMessage & { runtimeError: NonNullable<ChatMessage["runtimeError"]> } {
+  return msg.runtimeError !== undefined;
+}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -65,6 +65,8 @@ import { NewMissionPickerDialog } from "./new-mission-picker-dialog";
 import { UserActionMessage } from "./user-action-message";
 import { SelectedActionChip } from "./selected-action-chip";
 import { ProviderReconnectCard } from "./shell/provider-reconnect-card";
+import { ToolRuntimeErrorCard } from "./shell/tool-runtime-error-card";
+import { isToolRuntimeErrorMessage } from "./tool-runtime-feed";
 import { useChatDisplayLabels } from "./use-chat-display-labels";
 import {
   filterProviderAuthFeedItems,
@@ -127,7 +129,7 @@ export function useAgentChatPanel({
   selectedSessionKey,
   onSelectSession,
 }: UseAgentChatPanelArgs): AgentChatPanelProps {
-  const { t } = useTranslation("board");
+  const { t } = useTranslation(["board", "chat"]);
   const { processLabels, getThinkingMessage } = useChatDisplayLabels();
   const queryClient = useQueryClient();
 
@@ -347,10 +349,29 @@ export function useAgentChatPanel({
   );
   const renderSystemMessage = useCallback(
     (msg: ChatMessage) => {
+      if (isToolRuntimeErrorMessage(msg)) {
+        return (
+          <ToolRuntimeErrorCard
+            error={msg.runtimeError}
+            onRetry={async () => {
+              if (!path || !selectedSessionKey) return;
+              const text = t("chat:toolRuntimeError.retryPrompt");
+              await tauriChat.send(path, text, selectedSessionKey, {
+                providerOverride: chatProvider ?? undefined,
+                modelOverride: chatModel ?? undefined,
+              });
+              pushFeedItem(path, selectedSessionKey, {
+                feed_type: "user_message",
+                data: text,
+              });
+            }}
+          />
+        );
+      }
       if (isProviderAuthMessage(msg.content)) return null;
       return undefined;
     },
-    [],
+    [chatModel, chatProvider, path, pushFeedItem, selectedSessionKey, t],
   );
   const mapFeedItems = useCallback(
     ({ items }: { sessionKey: string; items: FeedItem[] }) =>

--- a/app/src/hooks/use-session-events.ts
+++ b/app/src/hooks/use-session-events.ts
@@ -8,6 +8,7 @@ import { useAgentStore } from "../stores/agents";
 import { useSessionStatusStore } from "../stores/session-status";
 import { subscribeHoustonEvents, listenOsEvent } from "../lib/events";
 import { logger } from "../lib/logger";
+import { hasToolRuntimeError } from "../components/tool-runtime-feed";
 import {
   consumePendingNav,
   describePendingNotificationNav,
@@ -76,14 +77,17 @@ export function useSessionEvents() {
             // state. Suppress the generic "Session error: ..." system message
             // so the feed doesn't show a raw error *and* the card.
             const isAuth = useUIStore.getState().authRequired !== null;
-            if (!isAuth) {
+            const feedItems =
+              useFeedStore.getState().items[agent_path]?.[session_key] ?? [];
+            const hasRuntimeCard = hasToolRuntimeError(feedItems);
+            if (!isAuth && !hasRuntimeCard) {
               h.pushFeedItem(agent_path, session_key, {
                 feed_type: "system_message",
                 data: `Session error: ${error}`,
               } as FeedItem);
             } else {
               logger.info(
-                `[auth] suppressing Session error system_message for ${agent_path}/${session_key} — card handles it`,
+                `[session] suppressing Session error system_message for ${agent_path}/${session_key}`,
               );
             }
           }

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -15,6 +15,9 @@
   "errors": {
     "sessionStart": "Failed to start session: {{error}}"
   },
+  "toolRuntimeError": {
+    "retryPrompt": "Try again."
+  },
   "attachmentIssues": {
     "title": "Some files were not attached",
     "description": "Houston kept your prompt and the files it can use.",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -48,6 +48,17 @@
     "tryAgain": "Try again",
     "launchError": "Could not open sign-in. Try again."
   },
+  "toolRuntimeError": {
+    "title": "Something got stuck",
+    "body": "A local tool did not start correctly. Try again, and report it if this keeps happening.",
+    "report": "Report bug",
+    "reporting": "Sending report...",
+    "reportSuccessTitle": "Report sent",
+    "reportSuccessDescription": "Houston received the logs.",
+    "reportErrorTitle": "Could not send report",
+    "reportErrorDescription": "Try again in a moment.",
+    "retryErrorTitle": "Could not try again"
+  },
   "updateChecker": {
     "cardLabel": "Houston update available",
     "title": "Houston, we have an update!",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -15,6 +15,9 @@
   "errors": {
     "sessionStart": "No se pudo iniciar la sesión: {{error}}"
   },
+  "toolRuntimeError": {
+    "retryPrompt": "Intenta de nuevo."
+  },
   "attachmentIssues": {
     "title": "Algunos archivos no se adjuntaron",
     "description": "Houston conservó tu mensaje y los archivos que sí puede usar.",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -48,6 +48,17 @@
     "tryAgain": "Intentar de nuevo",
     "launchError": "No se pudo abrir el inicio de sesión. Intenta otra vez."
   },
+  "toolRuntimeError": {
+    "title": "Algo se atascó",
+    "body": "Una herramienta local no se inició correctamente. Intenta de nuevo y repórtalo si sigue pasando.",
+    "report": "Reportar error",
+    "reporting": "Enviando reporte...",
+    "reportSuccessTitle": "Reporte enviado",
+    "reportSuccessDescription": "Houston recibió los registros.",
+    "reportErrorTitle": "No se pudo enviar el reporte",
+    "reportErrorDescription": "Intenta otra vez en un momento.",
+    "retryErrorTitle": "No se pudo intentar de nuevo"
+  },
   "updateChecker": {
     "cardLabel": "Actualización de Houston disponible",
     "title": "¡Houston, tenemos una actualización!",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -15,6 +15,9 @@
   "errors": {
     "sessionStart": "Não foi possível iniciar a sessão: {{error}}"
   },
+  "toolRuntimeError": {
+    "retryPrompt": "Tente de novo."
+  },
   "attachmentIssues": {
     "title": "Alguns arquivos não foram anexados",
     "description": "Houston manteve sua mensagem e os arquivos que pode usar.",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -48,6 +48,17 @@
     "tryAgain": "Tentar de novo",
     "launchError": "Não foi possível abrir o login. Tente de novo."
   },
+  "toolRuntimeError": {
+    "title": "Algo travou",
+    "body": "Uma ferramenta local não iniciou corretamente. Tente de novo e reporte se continuar acontecendo.",
+    "report": "Reportar erro",
+    "reporting": "Enviando relatório...",
+    "reportSuccessTitle": "Relatório enviado",
+    "reportSuccessDescription": "Houston recebeu os registros.",
+    "reportErrorTitle": "Não foi possível enviar o relatório",
+    "reportErrorDescription": "Tente de novo em instantes.",
+    "retryErrorTitle": "Não foi possível tentar de novo"
+  },
   "updateChecker": {
     "cardLabel": "Atualização do Houston disponível",
     "title": "Houston, temos uma atualização!",

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -311,6 +311,10 @@ fn serialize_for_persist(item: &FeedItem) -> Option<(String, String)> {
     match item {
         FeedItem::AssistantText(t) => Some(("assistant_text".into(), json_str(t))),
         FeedItem::UserMessage(t) => Some(("user_message".into(), json_str(t))),
+        FeedItem::ToolRuntimeError { kind, details } => {
+            let data = serde_json::json!({ "kind": kind, "details": details });
+            Some(("tool_runtime_error".into(), data.to_string()))
+        }
         FeedItem::ToolCall { name, input } => {
             let data = serde_json::json!({ "name": name, "input": input });
             Some(("tool_call".into(), data.to_string()))
@@ -388,5 +392,18 @@ mod tests {
             ),
             AuthFeedAction::RequireNow
         );
+    }
+
+    #[test]
+    fn serializes_tool_runtime_error_for_history() {
+        let item = FeedItem::ToolRuntimeError {
+            kind: houston_terminal_manager::ToolRuntimeErrorKind::LocalTool,
+            details: "exec failed".to_string(),
+        };
+
+        let (feed_type, data) = serialize_for_persist(&item).expect("serializes");
+
+        assert_eq!(feed_type, "tool_runtime_error");
+        assert_eq!(data, r#"{"details":"exec failed","kind":"local_tool"}"#);
     }
 }

--- a/engine/houston-terminal-manager/src/lib.rs
+++ b/engine/houston-terminal-manager/src/lib.rs
@@ -12,6 +12,7 @@ pub mod manager;
 pub mod parser;
 pub mod session_io;
 pub mod session_pump;
+mod stderr_filter;
 pub mod types;
 
 // Re-export key types for convenience.
@@ -20,4 +21,5 @@ pub use manager::{SessionHandle, SessionManager, SessionUpdate};
 pub use parser::{extract_session_id, parse_event, StreamAccumulator};
 pub use types::{
     ClaudeEvent, ContentBlock, FeedItem, FileChanges, Provider, SessionFeedBuffer, SessionStatus,
+    ToolRuntimeErrorKind,
 };

--- a/engine/houston-terminal-manager/src/manager.rs
+++ b/engine/houston-terminal-manager/src/manager.rs
@@ -1,5 +1,5 @@
 use super::session_io;
-use super::types::{FeedItem, Provider, SessionStatus};
+use super::types::{FeedItem, Provider, SessionStatus, ToolRuntimeErrorKind};
 use crate::auth_error::is_auth_error;
 use crate::codex_command;
 use std::process::Stdio;
@@ -322,12 +322,17 @@ async fn run_cli_process(
                     } else {
                         stderr_lines.join("\n")
                     };
-                    let _ = tx.send(SessionUpdate::Feed(FeedItem::ToolResult {
-                        content: format!("Process stderr:\n{stderr_summary}"),
-                        is_error: true,
-                    }));
+                    if !stderr_lines
+                        .iter()
+                        .any(|line| crate::stderr_filter::is_tool_runtime_stderr(line))
+                    {
+                        let _ = tx.send(SessionUpdate::Feed(FeedItem::ToolRuntimeError {
+                            kind: ToolRuntimeErrorKind::ProviderProcess,
+                            details: stderr_summary,
+                        }));
+                    }
                     let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(format!(
-                        "{cli_name} exited with {status}"
+                        "{cli_name} hit a runtime error"
                     ))));
                     CliRunOutcome::Failed
                 }

--- a/engine/houston-terminal-manager/src/session_io.rs
+++ b/engine/houston-terminal-manager/src/session_io.rs
@@ -1,68 +1,31 @@
-use super::codex_command;
 use super::codex_parser;
 use super::manager::SessionUpdate;
 use super::parser;
+use super::stderr_filter::{stderr_feed_item, StderrState};
 use super::types::{FeedItem, Provider};
-use crate::auth_error::{is_auth_retry_noise, AUTH_RETRY_MARKER};
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc;
 
-/// Read all stderr lines, emitting each as a `SystemMessage` feed item.
+/// Read all stderr lines, emitting only user-actionable feed items.
 /// Returns the collected lines so the caller can include them in error reports.
 pub async fn read_stderr_lines(
     stderr: tokio::process::ChildStderr,
     tx: mpsc::UnboundedSender<SessionUpdate>,
 ) -> Vec<String> {
     let mut lines = Vec::new();
-    let mut sent_auth_checking = false;
+    let mut state = StderrState::default();
     let reader = BufReader::new(stderr);
     let mut reader_lines = reader.lines();
     while let Ok(Some(line)) = reader_lines.next_line().await {
         tracing::debug!("cli stderr: {line}");
-        if is_auth_retry_noise(&line) {
-            // Send one internal marker; session_runner owns user-visible copy
-            // and AuthRequired emission.
-            if !sent_auth_checking {
-                sent_auth_checking = true;
-                let _ = tx.send(SessionUpdate::Feed(FeedItem::SystemMessage(
-                    AUTH_RETRY_MARKER.to_string(),
-                )));
+        if let Some(item) = stderr_feed_item(&line, &mut state) {
+            if tx.send(SessionUpdate::Feed(item)).is_err() {
+                break;
             }
-        } else if is_meaningful_stderr(&line) {
-            let _ = tx.send(SessionUpdate::Feed(FeedItem::SystemMessage(format!(
-                "stderr: {line}",
-            ))));
         }
         lines.push(line);
     }
     lines
-}
-
-/// Filter out stderr noise that shouldn't be shown to users.
-fn is_meaningful_stderr(line: &str) -> bool {
-    let trimmed = line.trim();
-    if trimmed.is_empty() {
-        return false;
-    }
-    // Codex progress noise
-    if trimmed.starts_with("Reading prompt from stdin") {
-        return false;
-    }
-    // Common non-error stderr patterns
-    if trimmed.starts_with("Downloading") || trimmed.starts_with("Loading") {
-        return false;
-    }
-    // Auth retry noise (e.g. "Error: Reconnecting... 1/5 (unexpected status 401 Unauthorized...)")
-    // These are internal retries — the session runner handles the auth failure at exit.
-    if is_auth_retry_noise(trimmed) {
-        return false;
-    }
-    // If Codex lost the local rollout backing a stored resume id, the manager
-    // retries fresh. Do not show the transient stderr line to the user.
-    if codex_command::is_missing_rollout_error(trimmed) {
-        return false;
-    }
-    true
 }
 
 /// Read all stdout lines, parsing each as NDJSON and sending parsed feed items

--- a/engine/houston-terminal-manager/src/stderr_filter.rs
+++ b/engine/houston-terminal-manager/src/stderr_filter.rs
@@ -1,0 +1,86 @@
+use super::types::{FeedItem, ToolRuntimeErrorKind};
+use crate::auth_error::{is_auth_retry_noise, AUTH_RETRY_MARKER};
+
+#[derive(Default)]
+pub(crate) struct StderrState {
+    sent_auth_checking: bool,
+    sent_tool_runtime: bool,
+}
+
+pub(crate) fn stderr_feed_item(line: &str, state: &mut StderrState) -> Option<FeedItem> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if is_auth_retry_noise(trimmed) {
+        if state.sent_auth_checking {
+            return None;
+        }
+        state.sent_auth_checking = true;
+        return Some(FeedItem::SystemMessage(AUTH_RETRY_MARKER.to_string()));
+    }
+    if is_tool_runtime_stderr(trimmed) {
+        if state.sent_tool_runtime {
+            return None;
+        }
+        state.sent_tool_runtime = true;
+        return Some(FeedItem::ToolRuntimeError {
+            kind: ToolRuntimeErrorKind::LocalTool,
+            details: trimmed.to_string(),
+        });
+    }
+    None
+}
+
+pub(crate) fn is_tool_runtime_stderr(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let lower = trimmed.to_lowercase();
+    (lower.contains("codex_core::tools::router") && lower.contains("exec_command failed"))
+        || lower.contains("failed to create unified exec process")
+        || (lower.contains("createprocess")
+            && lower.contains("no such file or directory")
+            && lower.contains("exec_command"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn maps_codex_exec_stderr_to_tool_runtime_error() {
+        let line = "ERROR codex_core::tools::router: error=exec_command failed for `/bin/zsh -lc 'rg --files'`: CreateProcess { message: \"Rejected(\\\"Failed to create unified exec process: No such file or directory (os error 2)\\\")\" }";
+        let mut state = StderrState::default();
+
+        let item = stderr_feed_item(line, &mut state);
+
+        assert!(matches!(
+            item,
+            Some(FeedItem::ToolRuntimeError {
+                kind: ToolRuntimeErrorKind::LocalTool,
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn suppresses_non_actionable_stderr() {
+        let mut state = StderrState::default();
+
+        assert!(stderr_feed_item("Reading prompt from stdin...", &mut state).is_none());
+        assert!(stderr_feed_item("Downloading model metadata", &mut state).is_none());
+        assert!(stderr_feed_item("warning: harmless provider detail", &mut state).is_none());
+    }
+
+    #[test]
+    fn emits_only_one_tool_runtime_error_per_stderr_stream() {
+        let mut state = StderrState::default();
+        let first = "exec_command failed: Failed to create unified exec process";
+        let second = "exec_command failed: Failed to create unified exec process again";
+
+        assert!(stderr_feed_item(first, &mut state).is_some());
+        assert!(stderr_feed_item(second, &mut state).is_none());
+    }
+}

--- a/engine/houston-terminal-manager/src/types.rs
+++ b/engine/houston-terminal-manager/src/types.rs
@@ -160,6 +160,14 @@ impl FileChanges {
     }
 }
 
+/// Runtime failure surfaced as an actionable, user-facing card.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolRuntimeErrorKind {
+    LocalTool,
+    ProviderProcess,
+}
+
 /// Processed feed items for rendering in the UI.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "feed_type", content = "data", rename_all = "snake_case")]
@@ -174,6 +182,11 @@ pub enum FeedItem {
     ThinkingStreaming(String),
     /// Message from the user (follow-up prompt).
     UserMessage(String),
+    /// A local/provider runtime failure. Details are diagnostic-only.
+    ToolRuntimeError {
+        kind: ToolRuntimeErrorKind,
+        details: String,
+    },
     /// Tool call made by the assistant.
     ToolCall {
         name: String,

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -129,6 +129,11 @@ because the diff cannot be assigned to one model safely. On successful
 non-overlapping completion, the engine may emit and persist a `FeedItem` with
 `feed_type: "file_changes"` and `data: { created: string[], modified:
 string[] }`; clients should render this as session-owned project artifacts.
+Provider/tool execution failures that need user recovery UI are emitted as
+`feed_type: "tool_runtime_error"` with `data: { kind: "local_tool" |
+"provider_process", details: string }`. Clients should render a user-safe retry
+and report-bug surface; `details` is diagnostic context for reports and logs,
+not user-facing copy.
 
 **Agent data** (`?agent_path=` query; writes emit event)
 | Method | Path | Description |

--- a/ui/chat/README.md
+++ b/ui/chat/README.md
@@ -33,7 +33,7 @@ import "@houston-ai/chat/src/styles.css"
 
 ## How it works
 
-`ChatPanel` accepts an array of `FeedItem` discriminated unions (user messages, assistant text, thinking, tool calls, tool results, final results) and renders the full conversation. Status is derived automatically from the feed, or you can override it.
+`ChatPanel` accepts an array of `FeedItem` discriminated unions (user messages, assistant text, thinking, tool calls, tool results, runtime errors, final results) and renders the full conversation. Status is derived automatically from the feed, or you can override it.
 
 Thinking and tool activity are grouped into a single technical-details accordion per assistant turn. The active group stays open while work is happening, then collapses when the assistant returns user-facing text or the session becomes ready.
 

--- a/ui/chat/src/feed-to-messages.ts
+++ b/ui/chat/src/feed-to-messages.ts
@@ -6,7 +6,7 @@
  * their corresponding tool_result items.
  */
 
-import type { FeedItem } from "./types";
+import type { FeedItem, ToolRuntimeErrorEntry } from "./types";
 
 export interface ToolEntry {
   name: string;
@@ -26,6 +26,7 @@ export interface ChatMessage {
   isStreaming: boolean;
   reasoning?: { content: string; isStreaming: boolean };
   tools: ToolEntry[];
+  runtimeError?: ToolRuntimeErrorEntry;
   fileChanges: FileChangeEntry[];
   /** Source channel if the message came from an external channel. */
   source?: string;
@@ -175,6 +176,20 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
             }
           }
         }
+        break;
+      }
+
+      case "tool_runtime_error": {
+        flush();
+        messages.push({
+          key: `tool-runtime-error-${messages.length}`,
+          from: "system",
+          content: "A local tool failed to start.",
+          isStreaming: false,
+          runtimeError: item.data,
+          tools: [],
+          fileChanges: [],
+        });
         break;
       }
 

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -1,6 +1,10 @@
 // === Types ===
-export type { FeedItem, RunStatus } from "./types";
-export type { ToolEntry, ChatMessage, FileChangeEntry } from "./feed-to-messages";
+export type { FeedItem, RunStatus, ToolRuntimeErrorEntry } from "./types";
+export type {
+  ToolEntry,
+  ChatMessage,
+  FileChangeEntry,
+} from "./feed-to-messages";
 export type { TurnEndSummary } from "./turn-tools";
 
 // === AI Elements: Conversation ===

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -7,6 +7,7 @@ export type FeedItem =
   | { feed_type: "thinking"; data: string }
   | { feed_type: "thinking_streaming"; data: string }
   | { feed_type: "user_message"; data: string }
+  | { feed_type: "tool_runtime_error"; data: ToolRuntimeErrorEntry }
   | { feed_type: "tool_call"; data: { name: string; input: unknown } }
   | { feed_type: "tool_result"; data: { content: string; is_error: boolean } }
   | { feed_type: "system_message"; data: string }
@@ -22,6 +23,11 @@ export type FeedItem =
         duration_ms: number | null;
       };
     };
+
+export interface ToolRuntimeErrorEntry {
+  kind: "local_tool" | "provider_process";
+  details: string;
+}
 
 export type RunStatus =
   | "running"


### PR DESCRIPTION
## Summary
- Convert provider/tool stderr failures into typed tool runtime feed items instead of raw system messages
- Render a retry/report bug card in chat using existing shell styling and bug-report plumbing
- Add localized copy, search filtering, persistence serialization, and protocol docs

## Verification
- cargo build -p houston-engine-server --bin houston-engine
- cargo test --workspace
- COREPACK_ENABLE_AUTO_PIN=0 pnpm typecheck
- cd app && COREPACK_ENABLE_AUTO_PIN=0 pnpm check-locales
- Browser visual check for the runtime error card