### PR TITLE
fix: harden community skill search

### DIFF
--- a/app/src/components/tabs/configure-tab.tsx
+++ b/app/src/components/tabs/configure-tab.tsx
@@ -71,7 +71,7 @@ export default function ConfigureTab({ agent, agentDef }: TabProps) {
   const installCommunity = useInstallCommunitySkill(path);
   const listFromRepo = useListSkillsFromRepo();
   const installFromRepo = useInstallSkillFromRepo(path);
-  const searchCommunity = useSearchCommunitySkills();
+  const { mutateAsync: searchCommunitySkills } = useSearchCommunitySkills();
 
   const { data: learningsData } = useLearnings(path);
   const addLearning = useAddLearning(path);
@@ -94,7 +94,7 @@ export default function ConfigureTab({ agent, agentDef }: TabProps) {
   const handleSkillClick = useCallback((s: Skill) => setSelectedSkillName(s.name), []);
   const handleSkillSave = useCallback(async (n: string, c: string) => { await saveSkill.mutateAsync({ name: n, content: c }); }, [saveSkill]);
   const handleSkillDelete = useCallback(async (n: string) => { await deleteSkill.mutateAsync(n); setSelectedSkillName(null); }, [deleteSkill]);
-  const handleSearch = useCallback(async (q: string) => (await searchCommunity.mutateAsync(q)) as CommunitySkill[], [searchCommunity]);
+  const handleSearch = useCallback(async (q: string) => (await searchCommunitySkills(q)) as CommunitySkill[], [searchCommunitySkills]);
   const handleInstallCommunity = useCallback(async (s: CommunitySkill) => await installCommunity.mutateAsync({ source: s.source, skillId: s.skillId }), [installCommunity]);
   const handleListFromRepo = useCallback(async (src: string) => await listFromRepo.mutateAsync(src), [listFromRepo]);
   const handleInstallFromRepo = useCallback(async (src: string, s: import("@houston-ai/skills").RepoSkill[]) => await installFromRepo.mutateAsync({ source: src, skills: s }), [installFromRepo]);

--- a/app/src/components/tabs/job-description-tab.tsx
+++ b/app/src/components/tabs/job-description-tab.tsx
@@ -68,7 +68,7 @@ export default function JobDescriptionTab({ agent }: TabProps) {
   const installCommunity = useInstallCommunitySkill(path);
   const listFromRepo = useListSkillsFromRepo();
   const installFromRepo = useInstallSkillFromRepo(path);
-  const searchCommunity = useSearchCommunitySkills();
+  const { mutateAsync: searchCommunitySkills } = useSearchCommunitySkills();
 
   // Learnings
   const { data: learningsData } = useLearnings(path);
@@ -120,9 +120,9 @@ export default function JobDescriptionTab({ agent }: TabProps) {
 
   const handleSearch = useCallback(
     async (query: string) => {
-      return (await searchCommunity.mutateAsync(query)) as CommunitySkill[];
+      return (await searchCommunitySkills(query)) as CommunitySkill[];
     },
-    [searchCommunity],
+    [searchCommunitySkills],
   );
 
   const handleInstallCommunity = useCallback(

--- a/app/src/components/tabs/skills-tab.tsx
+++ b/app/src/components/tabs/skills-tab.tsx
@@ -27,7 +27,7 @@ export default function SkillsTab({ agent }: TabProps) {
   const installCommunity = useInstallCommunitySkill(path);
   const listFromRepo = useListSkillsFromRepo();
   const installFromRepo = useInstallSkillFromRepo(path);
-  const searchCommunity = useSearchCommunitySkills();
+  const { mutateAsync: searchCommunitySkills } = useSearchCommunitySkills();
 
   const skills: Skill[] = (summaries ?? []).map((s) => ({
     id: s.name, name: s.name, description: s.description,
@@ -41,7 +41,7 @@ export default function SkillsTab({ agent }: TabProps) {
   const handleSkillClick = useCallback((s: Skill) => setSelectedSkillName(s.name), []);
   const handleSkillSave = useCallback(async (n: string, c: string) => { await saveSkill.mutateAsync({ name: n, content: c }); }, [saveSkill]);
   const handleSkillDelete = useCallback(async (n: string) => { await deleteSkill.mutateAsync(n); setSelectedSkillName(null); }, [deleteSkill]);
-  const handleSearch = useCallback(async (q: string) => (await searchCommunity.mutateAsync(q)) as CommunitySkill[], [searchCommunity]);
+  const handleSearch = useCallback(async (q: string) => (await searchCommunitySkills(q)) as CommunitySkill[], [searchCommunitySkills]);
   const handleInstallCommunity = useCallback(async (s: CommunitySkill) => await installCommunity.mutateAsync({ source: s.source, skillId: s.skillId }), [installCommunity]);
   const handleListFromRepo = useCallback(async (src: string) => await listFromRepo.mutateAsync(src), [listFromRepo]);
   const handleInstallFromRepo = useCallback(async (src: string, s: import("@houston-ai/skills").RepoSkill[]) => await installFromRepo.mutateAsync({ source: src, skills: s }), [installFromRepo]);

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -31,28 +31,35 @@ import { getEngine } from "./engine";
 import { osPickDirectory } from "./os-bridge";
 import { logger } from "./logger";
 
-/** Wrap an engine call and surface errors as toasts — never fail silently. */
+interface EngineCallOptions {
+  toast?: boolean;
+}
+
+/** Wrap an engine call and surface errors as toasts unless caller handles them inline. */
 async function call<T>(
   label: string,
   fn: () => Promise<T>,
   context?: Record<string, unknown>,
+  options?: EngineCallOptions,
 ): Promise<T> {
   try {
     return await fn();
   } catch (err) {
-    await surfaceToast(label, err, context);
+    await surfaceError(label, err, context, options);
     throw err;
   }
 }
 
-async function surfaceToast(
+async function surfaceError(
   label: string,
   err: unknown,
   context?: Record<string, unknown>,
+  options?: EngineCallOptions,
 ): Promise<void> {
   const message =
     err instanceof Error ? err.message : typeof err === "string" ? err : String(err);
   logger.error(`[engine:${label}] ${message}`, context ? JSON.stringify(context) : undefined);
+  if (options?.toast === false) return;
   const { showErrorToast } = await import("./error-toast");
   showErrorToast(label, message);
 }
@@ -271,6 +278,8 @@ export const tauriSkills = {
         installs: s.installs,
         source: s.source,
       })),
+      undefined,
+      { toast: false },
     ),
   installCommunity: (agentPath: string, source: string, skillId: string) =>
     call<string>("install_community_skill", () =>

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -17,7 +17,7 @@ thiserror = "2"
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 reqwest = { version = "0.12", features = ["json"], optional = true }
-tokio = { version = "1", features = ["time"], optional = true }
+tokio = { version = "1", features = ["sync", "time"], optional = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/engine/houston-skills/src/remote.rs
+++ b/engine/houston-skills/src/remote.rs
@@ -9,8 +9,19 @@
 use crate::{CreateSkillInput, SkillError};
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::Path;
-use std::time::Duration;
+use std::sync::OnceLock;
+use std::time::{Duration, Instant};
+use tokio::sync::Mutex;
+
+const SEARCH_ENDPOINT: &str = "https://skills.sh/api/search";
+const SEARCH_RETRY_DELAY: Duration = Duration::from_secs(3);
+const SEARCH_CACHE_TTL: Duration = Duration::from_secs(10 * 60);
+const SEARCH_STALE_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+const SEARCH_MIN_INTERVAL: Duration = Duration::from_millis(750);
+
+static SEARCH_CACHE: OnceLock<Mutex<SearchCache>> = OnceLock::new();
 
 // ── Public types ──────────────────────────────────────────────────
 
@@ -44,6 +55,75 @@ struct SearchResponse {
     skills: Vec<CommunitySkill>,
 }
 
+#[derive(Clone)]
+struct CachedSearch {
+    skills: Vec<CommunitySkill>,
+    fetched_at: Instant,
+}
+
+#[derive(Default)]
+struct SearchCache {
+    entries: HashMap<String, CachedSearch>,
+    last_request_at: Option<Instant>,
+}
+
+impl SearchCache {
+    async fn search(
+        &mut self,
+        client: &Client,
+        endpoint: &str,
+        query: &str,
+        retry_delay: Duration,
+        fresh_ttl: Duration,
+        stale_ttl: Duration,
+        min_interval: Duration,
+    ) -> Result<Vec<CommunitySkill>, SkillError> {
+        let query = query.trim();
+        if query.chars().count() < 2 {
+            return Ok(Vec::new());
+        }
+
+        let key = normalize_search_query(query);
+        if let Some(cached) = self.entries.get(&key) {
+            if cached.fetched_at.elapsed() <= fresh_ttl {
+                return Ok(cached.skills.clone());
+            }
+        }
+
+        if let Some(last) = self.last_request_at {
+            let elapsed = last.elapsed();
+            if elapsed < min_interval {
+                tokio::time::sleep(min_interval - elapsed).await;
+            }
+        }
+        self.last_request_at = Some(Instant::now());
+
+        match search_skills_at(client, endpoint, query, retry_delay).await {
+            Ok(skills) => {
+                self.entries.insert(
+                    key,
+                    CachedSearch {
+                        skills: skills.clone(),
+                        fetched_at: Instant::now(),
+                    },
+                );
+                Ok(skills)
+            }
+            Err(err) => {
+                if let Some(cached) = self.entries.get(&key) {
+                    if cached.fetched_at.elapsed() <= stale_ttl {
+                        tracing::warn!(
+                            "[houston-skills] community search failed, returning cached results: {err}"
+                        );
+                        return Ok(cached.skills.clone());
+                    }
+                }
+                Err(err)
+            }
+        }
+    }
+}
+
 // ── GitHub API types ──────────────────────────────────────────────
 
 #[derive(Deserialize)]
@@ -64,13 +144,21 @@ struct GitTreeEntry {
 /// Search the skills.sh community directory.
 pub async fn search_skills(query: &str) -> Result<Vec<CommunitySkill>, SkillError> {
     let client = build_client()?;
-    search_skills_at(
-        &client,
-        "https://skills.sh/api/search",
-        query,
-        Duration::from_secs(1),
-    )
-    .await
+    let mut cache = SEARCH_CACHE
+        .get_or_init(|| Mutex::new(SearchCache::default()))
+        .lock()
+        .await;
+    cache
+        .search(
+            &client,
+            SEARCH_ENDPOINT,
+            query,
+            SEARCH_RETRY_DELAY,
+            SEARCH_CACHE_TTL,
+            SEARCH_STALE_TTL,
+            SEARCH_MIN_INTERVAL,
+        )
+        .await
 }
 
 /// Search endpoint implementation.
@@ -132,8 +220,7 @@ pub async fn install_skill(
     source: &str,
     skill_id: &str,
 ) -> Result<String, SkillError> {
-    std::fs::create_dir_all(skills_dir)
-        .map_err(|e| SkillError::Io(e.to_string()))?;
+    std::fs::create_dir_all(skills_dir).map_err(|e| SkillError::Io(e.to_string()))?;
 
     let client = build_client()?;
 
@@ -263,7 +350,9 @@ pub async fn list_skills_from_repo(source: &str) -> Result<Vec<RepoSkill>, Skill
         .map_err(|e| SkillError::Io(format!("Failed to parse repo tree: {e}")))?;
 
     if tree.truncated {
-        tracing::warn!("[houston-skills] repo tree for {source} was truncated — some skills may be missing");
+        tracing::warn!(
+            "[houston-skills] repo tree for {source} was truncated — some skills may be missing"
+        );
     }
 
     // Collect all blob paths named SKILL.md.
@@ -295,7 +384,12 @@ pub async fn list_skills_from_repo(source: &str) -> Result<Vec<RepoSkill>, Skill
             }
             Err(_) => (kebab_to_title(&id), String::new()),
         };
-        skills.push(RepoSkill { id, name, description, path });
+        skills.push(RepoSkill {
+            id,
+            name,
+            description,
+            path,
+        });
     }
 
     Ok(skills)
@@ -313,8 +407,7 @@ pub async fn install_from_repo(
 ) -> Result<Vec<String>, SkillError> {
     let normalized = normalize_source(source);
     let source = normalized.as_str();
-    std::fs::create_dir_all(skills_dir)
-        .map_err(|e| SkillError::Io(e.to_string()))?;
+    std::fs::create_dir_all(skills_dir).map_err(|e| SkillError::Io(e.to_string()))?;
 
     let client = build_client()?;
     let mut installed = Vec::new();
@@ -356,6 +449,10 @@ fn build_client() -> Result<Client, SkillError> {
         .map_err(|e| SkillError::Io(format!("HTTP client error: {e}")))
 }
 
+fn normalize_search_query(query: &str) -> String {
+    query.trim().to_lowercase()
+}
+
 /// Derive an install ID from a SKILL.md path within the repo.
 /// `research/SKILL.md` → `research`
 /// `tools/code-review/SKILL.md` → `code-review`
@@ -385,9 +482,7 @@ async fn find_skill_path_in_repo(
     source: &str,
     skill_id: &str,
 ) -> Result<Option<String>, SkillError> {
-    let tree_url = format!(
-        "https://api.github.com/repos/{source}/git/trees/HEAD?recursive=1"
-    );
+    let tree_url = format!("https://api.github.com/repos/{source}/git/trees/HEAD?recursive=1");
     let resp = client
         .get(&tree_url)
         .send()
@@ -560,12 +655,24 @@ mod tests {
     #[test]
     fn normalize_github_urls() {
         assert_eq!(normalize_source("owner/repo"), "owner/repo");
-        assert_eq!(normalize_source("https://github.com/owner/repo"), "owner/repo");
-        assert_eq!(normalize_source("https://github.com/owner/repo/"), "owner/repo");
-        assert_eq!(normalize_source("http://github.com/owner/repo"), "owner/repo");
+        assert_eq!(
+            normalize_source("https://github.com/owner/repo"),
+            "owner/repo"
+        );
+        assert_eq!(
+            normalize_source("https://github.com/owner/repo/"),
+            "owner/repo"
+        );
+        assert_eq!(
+            normalize_source("http://github.com/owner/repo"),
+            "owner/repo"
+        );
         assert_eq!(normalize_source("github.com/owner/repo"), "owner/repo");
         // Extra path segments are stripped
-        assert_eq!(normalize_source("https://github.com/owner/repo/tree/main"), "owner/repo");
+        assert_eq!(
+            normalize_source("https://github.com/owner/repo/tree/main"),
+            "owner/repo"
+        );
     }
 
     #[test]
@@ -576,7 +683,10 @@ mod tests {
     #[test]
     fn skill_id_from_nested_path() {
         assert_eq!(skill_id_from_path("research/SKILL.md", "repo"), "research");
-        assert_eq!(skill_id_from_path("tools/code-review/SKILL.md", "repo"), "code-review");
+        assert_eq!(
+            skill_id_from_path("tools/code-review/SKILL.md", "repo"),
+            "code-review"
+        );
     }
 
     #[test]
@@ -624,7 +734,10 @@ Some content without a heading.";
 
     #[test]
     fn kebab_to_title_basic() {
-        assert_eq!(kebab_to_title("react-best-practices"), "React Best Practices");
+        assert_eq!(
+            kebab_to_title("react-best-practices"),
+            "React Best Practices"
+        );
         assert_eq!(kebab_to_title("single"), "Single");
     }
 
@@ -655,14 +768,9 @@ Some content without a heading.";
     #[tokio::test]
     async fn search_ignores_queries_under_two_chars() {
         let client = build_client().unwrap();
-        let skills = search_skills_at(
-            &client,
-            "http://127.0.0.1:1/search",
-            " a ",
-            Duration::ZERO,
-        )
-        .await
-        .unwrap();
+        let skills = search_skills_at(&client, "http://127.0.0.1:1/search", " a ", Duration::ZERO)
+            .await
+            .unwrap();
 
         assert!(skills.is_empty());
     }
@@ -688,5 +796,109 @@ Some content without a heading.";
         .unwrap_err();
 
         assert!(matches!(err, SkillError::RateLimited(_)));
+    }
+
+    #[tokio::test]
+    async fn cached_search_reuses_fresh_results_without_network() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/search"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "skills": [{
+                    "id": "owner/repo/writing",
+                    "skillId": "writing",
+                    "name": "writing",
+                    "installs": 7,
+                    "source": "owner/repo"
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = build_client().unwrap();
+        let mut cache = SearchCache::default();
+        let first = cache
+            .search(
+                &client,
+                &format!("{}/search", server.uri()),
+                "Writing",
+                Duration::ZERO,
+                Duration::from_secs(60),
+                Duration::from_secs(60),
+                Duration::ZERO,
+            )
+            .await
+            .unwrap();
+        let second = cache
+            .search(
+                &client,
+                "http://127.0.0.1:1/search",
+                " writing ",
+                Duration::ZERO,
+                Duration::from_secs(60),
+                Duration::from_secs(60),
+                Duration::ZERO,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(first[0].id, "owner/repo/writing");
+        assert_eq!(second[0].id, "owner/repo/writing");
+    }
+
+    #[tokio::test]
+    async fn cached_search_returns_stale_results_on_rate_limit() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/ok"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "skills": [{
+                    "id": "owner/repo/bookkeeping",
+                    "skillId": "bookkeeping",
+                    "name": "bookkeeping",
+                    "installs": 12,
+                    "source": "owner/repo"
+                }]
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/limited"))
+            .respond_with(ResponseTemplate::new(429))
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        let client = build_client().unwrap();
+        let mut cache = SearchCache::default();
+        cache
+            .search(
+                &client,
+                &format!("{}/ok", server.uri()),
+                "bookkeeping",
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::from_secs(60),
+                Duration::ZERO,
+            )
+            .await
+            .unwrap();
+
+        let skills = cache
+            .search(
+                &client,
+                &format!("{}/limited", server.uri()),
+                "bookkeeping",
+                Duration::ZERO,
+                Duration::ZERO,
+                Duration::from_secs(60),
+                Duration::ZERO,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(skills[0].id, "owner/repo/bookkeeping");
     }
 }

--- a/knowledge-base/actions.md
+++ b/knowledge-base/actions.md
@@ -77,6 +77,15 @@ Step-by-step instructions Claude follows when the action runs.
    - `renderUserMessage` — decodes the action marker into a card
 5. Both **BoardTab** (per-agent kanban) and **Dashboard** (Mission Control / cross-agent kanban) consume this hook so the right panel is identical in both views.
 
+## Community search behavior
+
+`POST /v1/skills/community/search` calls `skills.sh`, which can rate-limit.
+Engine owns the resilience: successful searches are cached in-memory, outbound
+requests are globally spaced, and stale cached results are returned during a
+temporary 429/network failure. App search callers handle remaining failures
+inline in the Add Skills UI; they should not show global "Houston problem" bug
+toasts for marketplace search misses.
+
 ## Action invocation marker (chat persistence)
 
 When the user runs an action, the persisted user_message body is:

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -179,7 +179,7 @@ string[] }`; clients should render this as session-owned project artifacts.
 |---|---|---|
 | GET/POST | `/v1/skills` | List/create |
 | GET/PUT/DELETE | `/v1/skills/:name` | Load/save/delete |
-| POST | `/v1/skills/community/search` | Search community registry |
+| POST | `/v1/skills/community/search` | Search community registry, cached/throttled server-side |
 | POST | `/v1/skills/community/install` | Install community skill |
 | POST | `/v1/skills/repo/list` | List skills in a repo |
 | POST | `/v1/skills/repo/install` | Install from repo |

--- a/ui/skills/src/add-skill-dialog-store-view.tsx
+++ b/ui/skills/src/add-skill-dialog-store-view.tsx
@@ -12,6 +12,8 @@ import {
 } from "./add-skill-dialog-store-labels"
 import { StoreRow } from "./add-skill-dialog-store-row"
 
+const SEARCH_DEBOUNCE_MS = 650
+
 export interface StoreViewProps {
   open: boolean
   onSearch: (query: string) => Promise<CommunitySkill[]>
@@ -93,7 +95,7 @@ export function StoreView({ open, onSearch, onInstall, labels }: StoreViewProps)
       } finally {
         if (mountedRef.current && searchSeqRef.current === requestId) setLoading(false)
       }
-    }, 350)
+    }, SEARCH_DEBOUNCE_MS)
     return () => clearTimeout(timer)
   }, [query, onSearch])
 

--- a/ui/skills/src/community-skills-browser.tsx
+++ b/ui/skills/src/community-skills-browser.tsx
@@ -2,53 +2,86 @@
  * CommunitySkillsSection — Search and install skills from a community marketplace.
  * Fully props-driven: host app provides search + install callbacks.
  */
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import type { CommunitySkill } from "./types"
 import { CommunitySkillRow } from "./community-skill-row"
 import { Search } from "lucide-react"
 
 const PAGE_SIZE = 20
+const SEARCH_DEBOUNCE_MS = 650
 
 export interface CommunitySkillsSectionProps {
-  /** Called when the user types a search query (debounced internally at 350ms). */
+  /** Called when the user types a search query (debounced internally). */
   onSearch: (query: string) => Promise<CommunitySkill[]>
   /** Called when the user clicks install on a community skill. Should return the installed skill name. */
   onInstall: (skill: CommunitySkill) => Promise<string>
+  labels?: {
+    searchUnavailable?: string
+  }
 }
 
 export function CommunitySkillsSection({
   onSearch,
   onInstall,
+  labels,
 }: CommunitySkillsSectionProps) {
+  const l = {
+    searchUnavailable: "Skill search is busy. Wait a moment and try again.",
+    ...labels,
+  }
   const [query, setQuery] = useState("")
   const [results, setResults] = useState<CommunitySkill[]>([])
   const [loading, setLoading] = useState(false)
   const [showAll, setShowAll] = useState(false)
+  const [searchError, setSearchError] = useState(false)
   const [installingIds, setInstallingIds] = useState<Set<string>>(new Set())
   const [installedIds, setInstalledIds] = useState<Set<string>>(new Set())
+  const mountedRef = useRef(true)
+  const searchSeqRef = useRef(0)
 
   useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    const requestId = searchSeqRef.current + 1
+    searchSeqRef.current = requestId
     const q = query.trim()
+    setSearchError(false)
     if (!q) {
       setResults([])
+      setLoading(false)
+      return
+    }
+    if (q.length < 2) {
+      setResults([])
+      setLoading(false)
       return
     }
     const timer = setTimeout(() => {
-      doSearch(q)
+      doSearch(q, requestId)
       setShowAll(false)
-    }, 350)
+    }, SEARCH_DEBOUNCE_MS)
     return () => clearTimeout(timer)
   }, [query])
 
-  const doSearch = async (q: string) => {
+  const doSearch = async (q: string, requestId: number) => {
     setLoading(true)
     try {
       const skills = await onSearch(q)
-      setResults(skills)
+      if (mountedRef.current && searchSeqRef.current === requestId) {
+        setResults(skills)
+      }
     } catch {
-      setResults([])
+      if (mountedRef.current && searchSeqRef.current === requestId) {
+        setResults([])
+        setSearchError(true)
+      }
     } finally {
-      setLoading(false)
+      if (mountedRef.current && searchSeqRef.current === requestId) setLoading(false)
     }
   }
 
@@ -101,7 +134,13 @@ export function CommunitySkillsSection({
         <p className="text-sm text-muted-foreground animate-pulse">Loading...</p>
       )}
 
-      {!loading && results.length === 0 && query.trim() && (
+      {!loading && searchError && query.trim().length >= 2 && (
+        <p className="text-sm text-muted-foreground">
+          {l.searchUnavailable}
+        </p>
+      )}
+
+      {!loading && !searchError && results.length === 0 && query.trim().length >= 2 && (
         <p className="text-sm text-muted-foreground">
           No skills found for "{query.trim()}"
         </p>


### PR DESCRIPTION
## Summary
- cache and throttle skills.sh community search in the engine, with stale-cache fallback on temporary 429/network failures
- keep community search failures inline in the skills UI instead of global bug-report toasts
- increase UI search debounce and document the resilient marketplace search behavior

## Affected files
- engine/houston-skills/src/remote.rs
- engine/houston-skills/Cargo.toml
- app/src/lib/tauri.ts
- app/src/components/tabs/skills-tab.tsx
- app/src/components/tabs/configure-tab.tsx
- app/src/components/tabs/job-description-tab.tsx
- ui/skills/src/add-skill-dialog-store-view.tsx
- ui/skills/src/community-skills-browser.tsx
- knowledge-base/actions.md
- knowledge-base/engine-protocol.md

## Tests
- cargo test --workspace
- cargo build -p houston-engine-server
- pnpm typecheck
- pnpm check-locales
- pnpm --filter @houston-ai/skills typecheck
- git diff --check