### PR TITLE
feat(windows): port Houston to Windows x64 (composio fork + MSI build + auto-updater)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -645,6 +645,210 @@ jobs:
 
           echo "::notice::Draft release created — review notes then publish at https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
 
+  # ============================================================================
+  # Windows MSI build — runs in parallel with build-macos and uploads the MSI
+  # to the same draft release once build-macos finishes creating it.
+  #
+  # Scope (v1, weekend test build):
+  #   * Windows x64 only — no ARM64 build, no NSIS installer.
+  #   * No SignPath signing — the MSI ships UNSIGNED. Windows users will see
+  #     a SmartScreen warning ("Don't run / More info → Run anyway") on
+  #     first install. This is acceptable for personal testing; before we
+  #     ship to actual users we'll wire SignPath Foundation (free OSS) into
+  #     a `sign-windows` job between this and the upload step.
+  #   * No auto-updater wiring — Windows entries are NOT added to
+  #     `latest.json`; users manually download a fresh MSI from the
+  #     GitHub release page when a new version drops.
+  #
+  # Build pipeline:
+  #   1. Stage CLI deps via `scripts/fetch-cli-deps.sh windows-x64`.
+  #      Codex is downloaded + zstd-decompressed; composio is BUILT FROM
+  #      SOURCE on this Windows runner using a pinned commit on the
+  #      gethouston/composio fork — see `cli-deps.json`'s
+  #      `composio.build."windows-x64"` block for the pin and the
+  #      `$build_comment` for why upstream can't ship Windows yet.
+  #   2. Build the houston-engine sidecar for x86_64-pc-windows-msvc.
+  #      Tauri's externalBin picks it up at `binaries/houston-engine.exe`
+  #      (build.rs::stage_engine_sidecar names it
+  #      `houston-engine-x86_64-pc-windows-msvc.exe` per Tauri's per-target
+  #      convention).
+  #   3. Run `pnpm tauri build --target x86_64-pc-windows-msvc` to produce
+  #      the MSI under
+  #      `target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi`.
+  #   4. Upload the MSI to the draft release created by the build-macos
+  #      job (declared via `needs:` so the upload happens after the
+  #      release exists).
+  build-windows:
+    needs: build-macos
+    runs-on: windows-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Setup Rust (windows-msvc target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            app/src-tauri/target
+            target
+          key: ${{ runner.os }}-cargo-windows-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-windows-
+
+      # Bun + jq + zstd are required by `scripts/fetch-cli-deps.sh`. Bun
+      # is needed because the composio Windows binary is built FROM
+      # SOURCE on this runner via `bun build:binary:cross
+      # --target=bun-windows-x64-modern`. The version MUST match the pin
+      # in `cli-deps.json#composio.build."windows-x64".bun_version` —
+      # mismatched Bun produces a binary with subtle behavioral
+      # differences that bite at runtime, so we install via direct
+      # GitHub release download (deterministic) rather than the
+      # web-installer (which can drift if oven-sh changes the env-var
+      # contract on `install.ps1`).
+      - name: Install Bun (pinned to cli-deps.json)
+        shell: pwsh
+        run: |
+          $bunVersion = (Get-Content cli-deps.json | ConvertFrom-Json).composio.build.'windows-x64'.bun_version
+          Write-Host "Installing Bun $bunVersion (direct GitHub release download)"
+          $bunDir = "$HOME\.bun\bin"
+          New-Item -ItemType Directory -Force -Path $bunDir | Out-Null
+          $url = "https://github.com/oven-sh/bun/releases/download/bun-v$bunVersion/bun-windows-x64.zip"
+          $zipPath = "$env:TEMP\bun-windows-x64.zip"
+          Invoke-WebRequest -Uri $url -OutFile $zipPath
+          Expand-Archive -Force -Path $zipPath -DestinationPath "$env:TEMP\bun-extract"
+          Copy-Item -Force "$env:TEMP\bun-extract\bun-windows-x64\bun.exe" "$bunDir\bun.exe"
+          Remove-Item -Recurse -Force "$env:TEMP\bun-extract", $zipPath
+          # Add bun to PATH for subsequent steps.
+          echo "$bunDir" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          $actual = & "$bunDir\bun.exe" --version
+          if ($actual.Trim() -ne $bunVersion) {
+            Write-Error "Bun version mismatch after install: got '$actual', expected '$bunVersion'"
+            exit 1
+          }
+          Write-Host "Pinned Bun OK: $actual"
+
+      - name: Install jq + zstd (Chocolatey)
+        shell: pwsh
+        run: |
+          choco install -y jq zstandard --no-progress
+          jq --version
+          zstd --version
+
+      # Stage bundled CLI binaries: codex.exe (downloaded + zstd) and
+      # composio-x86_64/composio.exe (built from gethouston/composio
+      # fork). The fetch script handles `pnpm install` + `tsdown` +
+      # `bun build:binary:cross` for the composio fork; full build is
+      # ~3-5 minutes on a warm runner.
+      - name: Stage bundled CLI dependencies (codex, composio Windows)
+        shell: bash
+        run: |
+          set -euo pipefail
+          ./scripts/fetch-cli-deps.sh windows-x64
+
+          echo "=== Staged bundle ==="
+          ls -lah app/src-tauri/resources/bin/
+          echo "=== Sizes ==="
+          du -sh app/src-tauri/resources/bin/*
+
+          # Sanity: every Windows artifact must be present.
+          test -f app/src-tauri/resources/bin/codex.exe
+          test -f app/src-tauri/resources/bin/composio-x86_64/composio.exe
+          test -f app/src-tauri/resources/bin/composio-x86_64/run-helpers-runtime.mjs
+          test -f app/src-tauri/resources/bin/composio-x86_64/acp-adapters/codex/win32-x64/codex-acp.exe
+          test -f app/src-tauri/resources/bin/cli-deps.json
+
+      # Build the engine sidecar for x86_64-pc-windows-msvc BEFORE
+      # `tauri build`. build.rs::stage_engine_sidecar copies it to
+      # `app/src-tauri/binaries/houston-engine-x86_64-pc-windows-msvc.exe`
+      # which is what Tauri's externalBin pattern expects.
+      - name: Build houston-engine sidecar (x86_64-pc-windows-msvc)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --release --target x86_64-pc-windows-msvc -p houston-engine-server
+          test -x "target/x86_64-pc-windows-msvc/release/houston-engine.exe" \
+            || { echo "::error::engine binary missing for x86_64-pc-windows-msvc"; exit 1; }
+          echo "Sidecar size:"
+          ls -lah target/x86_64-pc-windows-msvc/release/houston-engine.exe
+
+      - name: Build Tauri app (Windows MSI)
+        uses: tauri-apps/tauri-action@v0
+        with:
+          projectPath: app
+          args: --target x86_64-pc-windows-msvc
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The Tauri updater key signs the MSI for the auto-updater
+          # flow. We're not wiring auto-update for Windows in v1, but
+          # signing the artifact now keeps the code path active and
+          # the .sig file uploaded for when we do.
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          SLACK_BUG_WEBHOOK_URL: ${{ secrets.SLACK_BUG_WEBHOOK_URL }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      - name: Locate MSI artifact
+        id: artifacts-windows
+        shell: bash
+        run: |
+          set -euo pipefail
+          BUNDLE="target/x86_64-pc-windows-msvc/release/bundle"
+
+          MSI=$(ls -t "$BUNDLE/msi/"*.msi 2>/dev/null | head -1 || true)
+
+          if [ -z "$MSI" ] || [ ! -f "$MSI" ]; then
+            echo "::error::MSI not produced under $BUNDLE/msi/"
+            ls -laR "$BUNDLE" 2>&1 | head -50
+            exit 1
+          fi
+
+          echo "msi=$MSI" >> "$GITHUB_OUTPUT"
+          echo "Artifact:"
+          echo "  .msi: $MSI ($(du -sh "$MSI" | cut -f1))"
+
+      - name: Upload Windows MSI to draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # `--clobber` lets us re-run the workflow without renaming
+          # the artifact if a prior partial upload left one in place.
+          gh release upload "$GITHUB_REF_NAME" \
+            "${{ steps.artifacts-windows.outputs.msi }}" \
+            --clobber
+
+          echo "::notice::Windows MSI uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
+          echo "::warning::This MSI is UNSIGNED — Windows SmartScreen will warn on first install. SignPath signing is wired in a follow-up PR."
+
       # Pings the team Slack channel so anyone can grab the DMG and try the
       # build before we publish. No-ops when SLACK_RELEASE_WEBHOOK_URL is
       # unset, so forks and personal builds stay quiet.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -815,7 +815,7 @@ jobs:
           SLACK_BUG_WEBHOOK_URL: ${{ secrets.SLACK_BUG_WEBHOOK_URL }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
-      - name: Locate MSI artifact
+      - name: Locate MSI + updater signature artifacts
         id: artifacts-windows
         shell: bash
         run: |
@@ -823,31 +823,102 @@ jobs:
           BUNDLE="target/x86_64-pc-windows-msvc/release/bundle"
 
           MSI=$(ls -t "$BUNDLE/msi/"*.msi 2>/dev/null | head -1 || true)
+          # Tauri's `createUpdaterArtifacts: true` emits an `<msi>.sig`
+          # next to the .msi (minisign signature over the .msi bytes).
+          # The Tauri updater on Windows verifies this against the
+          # public key embedded at build time and only proceeds if it
+          # matches. No `.sig` ⇒ no auto-update.
+          SIG=$(ls -t "$BUNDLE/msi/"*.msi.sig 2>/dev/null | head -1 || true)
 
-          if [ -z "$MSI" ] || [ ! -f "$MSI" ]; then
-            echo "::error::MSI not produced under $BUNDLE/msi/"
+          missing=()
+          [ -f "$MSI" ] || missing+=("MSI")
+          [ -f "$SIG" ] || missing+=("MSI .sig (updater signature)")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Windows artifacts missing: ${missing[*]}"
+            echo "Bundle contents:"
             ls -laR "$BUNDLE" 2>&1 | head -50
             exit 1
           fi
 
           echo "msi=$MSI" >> "$GITHUB_OUTPUT"
-          echo "Artifact:"
-          echo "  .msi: $MSI ($(du -sh "$MSI" | cut -f1))"
+          echo "sig=$SIG" >> "$GITHUB_OUTPUT"
+          echo "Artifacts:"
+          echo "  .msi:     $MSI ($(du -sh "$MSI" | cut -f1))"
+          echo "  .msi.sig: $SIG ($(wc -c < "$SIG") bytes)"
 
-      - name: Upload Windows MSI to draft release
+      - name: Upload Windows MSI + updater signature to draft release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         shell: bash
         run: |
           set -euo pipefail
+          # Both files are required for users on older Houston builds
+          # to upgrade automatically: the .msi is the installer payload
+          # and the .sig is the minisign signature the in-app updater
+          # verifies before swallowing the new MSI.
           # `--clobber` lets us re-run the workflow without renaming
           # the artifact if a prior partial upload left one in place.
           gh release upload "$GITHUB_REF_NAME" \
             "${{ steps.artifacts-windows.outputs.msi }}" \
+            "${{ steps.artifacts-windows.outputs.sig }}" \
             --clobber
 
-          echo "::notice::Windows MSI uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
-          echo "::warning::This MSI is UNSIGNED — Windows SmartScreen will warn on first install. SignPath signing is wired in a follow-up PR."
+          echo "::notice::Windows MSI + .sig uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
+          echo "::warning::This MSI is UNSIGNED (code-signing wise) — Windows SmartScreen will warn on first install. The updater minisign signature above is separate; it covers in-app auto-update verification, not OS code-signing. SignPath integration lands in a follow-up PR."
+
+      # Extend the macOS-only `latest.json` (uploaded by build-macos) with a
+      # `windows-x86_64` entry pointing at the just-uploaded MSI + its
+      # minisign signature. After this step, users on Houston for Windows
+      # who built with the same `TAURI_SIGNING_PRIVATE_KEY` will see an
+      # auto-update prompt the next time they launch.
+      #
+      # Why merge here instead of generating from scratch:
+      #   build-macos already produces the right schema (version / notes
+      #   / pub_date) and uploads it to the draft release. We just need
+      #   to add the Windows platform key and reupload with --clobber.
+      #   Generating latest.json from scratch in two places risks the
+      #   metadata drifting between OSes (date format, notes preview,
+      #   etc.) and is more painful to keep in sync.
+      - name: Extend latest.json with Windows updater entry
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          MSI_NAME=$(basename "${{ steps.artifacts-windows.outputs.msi }}")
+          MSI_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/$MSI_NAME"
+          MSI_SIG=$(cat "${{ steps.artifacts-windows.outputs.sig }}")
+
+          # Pull the existing latest.json down. build-macos uploads it
+          # before this job runs (we depend on build-macos via `needs`).
+          tmpdir=$(mktemp -d)
+          gh release download "$GITHUB_REF_NAME" \
+            --pattern 'latest.json' \
+            --dir "$tmpdir"
+
+          if [ ! -s "$tmpdir/latest.json" ]; then
+            echo "::error::latest.json not found in draft release; build-macos must have failed to upload it"
+            exit 1
+          fi
+
+          # Tauri's updater checks `windows-x86_64` for both NSIS and MSI
+          # installers (the format is detected from the URL extension at
+          # update time). We add a single entry pointing at the MSI; if
+          # we ever ship NSIS too, we keep the same key and let users
+          # opt into one-or-the-other via the URL the updater receives.
+          jq \
+            --arg sig "$MSI_SIG" \
+            --arg url "$MSI_URL" \
+            '.platforms["windows-x86_64"] = {signature: $sig, url: $url}' \
+            "$tmpdir/latest.json" > "$tmpdir/latest.next.json"
+
+          echo "Updated latest.json:"
+          cat "$tmpdir/latest.next.json"
+
+          mv "$tmpdir/latest.next.json" "$tmpdir/latest.json"
+          gh release upload "$GITHUB_REF_NAME" "$tmpdir/latest.json" --clobber
+          echo "::notice::latest.json now advertises macOS + Windows for the in-app updater"
 
       # Pings the team Slack channel so anyone can grab the DMG and try the
       # build before we publish. No-ops when SLACK_RELEASE_WEBHOOK_URL is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,8 +135,12 @@ Ask: "Ready to commit? (yes/no/skip)" **STOP.** Yes → stage specific files, co
 |------|----|------|------------|
 | ui/ | `pnpm typecheck` | — | — |
 | engine/ | — | `cargo test --workspace` | `cargo build --workspace` |
+| engine/ Win check | — | `cargo check --target x86_64-pc-windows-gnu -p houston-engine-server` (needs mingw-w64) | — |
 | app/ | `cd app && pnpm tsc --noEmit` | `cd app/src-tauri && cargo check` | `cd app && pnpm tauri build` |
+| app/ Win MSI | — | — | `cd app && pnpm tauri build --target x86_64-pc-windows-msvc` (needs Windows host or `xwin` SDK) |
 | app/ i18n | `cd app && pnpm check-locales` | — | — |
+| CLI bundle (mac) | — | — | `./scripts/fetch-cli-deps.sh both` |
+| CLI bundle (win) | — | — | `./scripts/fetch-cli-deps.sh windows-x64` (Bun + jq + zstd required) |
 
 ### Engine sidecar staleness (dev only)
 

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -43,7 +43,7 @@
   "bundle": {
     "createUpdaterArtifacts": true,
     "active": true,
-    "targets": ["app", "dmg"],
+    "targets": ["app", "dmg", "msi"],
     "externalBin": ["binaries/houston-engine"],
     "resources": {
       "resources/bin": "bin",
@@ -53,6 +53,14 @@
       "signingIdentity": "-",
       "entitlements": "entitlements.plist",
       "minimumSystemVersion": "10.15"
+    },
+    "windows": {
+      "wix": {
+        "language": ["en-US"]
+      },
+      "webviewInstallMode": {
+        "type": "embedBootstrapper"
+      }
     },
     "icon": [
       "icons/32x32.png",

--- a/cli-deps.json
+++ b/cli-deps.json
@@ -1,20 +1,25 @@
 {
   "$schema": "./cli-deps.schema.json",
-  "$comment": "Pinned versions for every CLI Houston ships or runtime-installs. Bundled (codex, composio) ride inside the .app under Contents/Resources/bin. claude-code cannot be bundled (proprietary license) so the runtime installer downloads it on first launch via houston-claude-installer using the URLs + sha256 below. Bumping a version: run `./scripts/bump-cli.sh <name> <version>`, then `./scripts/fetch-cli-deps.sh both` to refresh the staged copies + print the new checksums; pin the printed sha256 back into this file.",
+  "$comment": "Pinned versions for every CLI Houston ships or runtime-installs. Bundled (codex, composio) ride inside the .app / .msi under resources/bin. claude-code cannot be bundled (proprietary license) so the runtime installer downloads it on first launch via houston-claude-installer using the URLs + sha256 below. Bumping a version: run `./scripts/bump-cli.sh <name> <version>`, then `./scripts/fetch-cli-deps.sh both` to refresh the staged copies + print the new checksums; pin the printed sha256 back into this file. For Windows, composio is built from source (see `build` block) because upstream does not yet ship a Windows artifact.",
   "claude-code": {
     "version": "2.1.92",
     "bundled": false,
     "binary_name": "claude",
     "license": "PROPRIETARY",
     "install_target": "$HOME/.local/bin/claude",
+    "$install_target_comment": "On Windows the runtime installer writes to %LOCALAPPDATA%\\Programs\\claude\\claude.exe instead — the install_target field above is the POSIX-only path; see houston-claude-installer for the Windows resolution path.",
     "urls": {
       "darwin-arm64": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/darwin-arm64/claude",
       "darwin-x64": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/darwin-x64/claude",
+      "windows-x64": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/win32-x64/claude.exe",
+      "windows-arm64": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/win32-arm64/claude.exe",
       "manifest": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/manifest.json"
     },
     "checksums": {
       "darwin-arm64": "6d1b9657727dce81332b3cda11bfe0a8c83e2392e3c062a31022e10b0e71cdd1",
-      "darwin-x64": "d422b5cc974b3bc4b28f698144fd0316f3e17774babe0bc1eb76c2bb0858d0aa"
+      "darwin-x64": "d422b5cc974b3bc4b28f698144fd0316f3e17774babe0bc1eb76c2bb0858d0aa",
+      "windows-x64": "ebd9007c464d912593418f133a61d9f24866428530a81e88e910a24823066415",
+      "windows-arm64": "c258bce79aefac609f909e5abde92d1653bcef47d3577656d299d1d56f1604bb"
     }
   },
   "codex": {
@@ -23,14 +28,18 @@
     "binary_name": "codex",
     "license": "Apache-2.0",
     "ship_layout": "lipo-universal",
-    "$ship_layout_comment": "Both arch binaries are downloaded and combined with `lipo -create` into a single Mach-O fat binary at Contents/Resources/bin/codex.",
+    "$ship_layout_comment": "On macOS both arch binaries are downloaded and combined with `lipo -create` into a single Mach-O fat binary at Contents/Resources/bin/codex. On Windows there is no `lipo` equivalent and we ship the OS-native binary directly at resources/bin/codex.exe (per-arch builds; v1 only ships windows-x64).",
     "urls": {
       "darwin-arm64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-aarch64-apple-darwin.tar.gz",
-      "darwin-x64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-x86_64-apple-darwin.tar.gz"
+      "darwin-x64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-x86_64-apple-darwin.tar.gz",
+      "windows-x64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-x86_64-pc-windows-msvc.exe.zst",
+      "windows-arm64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-aarch64-pc-windows-msvc.exe.zst"
     },
     "checksums": {
       "darwin-arm64": "60f7039e63a7de8ae474136ac6f593ec1a913e1ddca0df59ade1f6d6eb5f7fd0",
-      "darwin-x64": "94e6ba8a552d4625beee857f513fb12bc20e560b9427c4a93733dbd86619f415"
+      "darwin-x64": "94e6ba8a552d4625beee857f513fb12bc20e560b9427c4a93733dbd86619f415",
+      "windows-x64": "92c0938d13e9e06e2844be1e50bfa2d246e295185aabe055a92d42fcdeb0b26d",
+      "windows-arm64": "cb1978aa318bd9180a8896bbfadc05b7581c752677df9ab6eb1f1903754fed20"
     }
   },
   "composio": {
@@ -39,7 +48,7 @@
     "binary_name": "composio",
     "license": "MIT",
     "ship_layout": "per-arch-dir",
-    "$ship_layout_comment": "Composio is a Bun-bundled JS app with arch-specific runtime + sibling .mjs/services files; cannot lipo. Each arch ships at Contents/Resources/bin/composio-{aarch64|x86_64}/ and the engine resolves at runtime via std::env::consts::ARCH. Cross-platform acp-adapters that the resolved arch can never execute are pruned at fetch time to keep the .app honest in size.",
+    "$ship_layout_comment": "Composio is a Bun-bundled JS app with arch-specific runtime + sibling .mjs/services files; cannot lipo. Each arch ships at resources/bin/composio-{aarch64|x86_64}/ on macOS and resources/bin/composio-x86_64/ on Windows (no aarch64 Windows build in v1) and the engine resolves at runtime via std::env::consts::ARCH. Cross-platform acp-adapters that the resolved arch can never execute are pruned at fetch time to keep the bundle honest in size.",
     "urls": {
       "darwin-arm64": "https://github.com/ComposioHQ/composio/releases/download/@composio/cli@{version}/composio-darwin-aarch64.zip",
       "darwin-x64": "https://github.com/ComposioHQ/composio/releases/download/@composio/cli@{version}/composio-darwin-x64.zip"
@@ -47,6 +56,19 @@
     "checksums": {
       "darwin-arm64": "fba0a57788ea50335507b2a38eccc67ebc051272f8393284b239875c4fdff8ef",
       "darwin-x64": "94af160e5bb10be80218dd9377c79a72d5c5ab7e172a65da0607ec4ee4d019c6"
+    },
+    "$build_comment": "Upstream ComposioHQ/composio does not yet publish Windows artifacts (issue #3057, closed: 'use WSL'). Until that ships, we build composio.exe from a fork at gethouston/composio that adds Windows targets to TARGET_MAP, win32 entries to RUN_CODEX_ACP_BINARY_TARGETS, and a Windows Credential Manager backend in cli-keyring. Builds are reproducible: pinned commit SHA, pinned Bun version, pinned bun_target. The `pnpm` package manager + Bun runtime installed on the build host must match the values in the fork's `package.json#packageManager` and `.bun-version` respectively.",
+    "build": {
+      "windows-x64": {
+        "source_repo": "https://github.com/gethouston/composio.git",
+        "source_ref": "houston-windows-support",
+        "source_sha": "f51c0f2c6a9ba536fb44f200baa2b96fe816f69a",
+        "package_path": "ts/packages/cli",
+        "bun_target": "bun-windows-x64-modern",
+        "bun_version": "1.3.10",
+        "artifact_basename": "composio-windows-x64",
+        "$artifact_basename_comment": "Bun appends `.exe` automatically for Windows targets; the staged binary is `dist/binaries/composio-windows-x64.exe` and companions live under `dist/binaries/companions/`."
+      }
     }
   }
 }

--- a/knowledge-base/cli-bundling.md
+++ b/knowledge-base/cli-bundling.md
@@ -1,26 +1,71 @@
 # Bundled CLIs — codex, composio, claude-code
 
 Houston ships two upstream CLIs inside the signed/notarized desktop
-`.app` and runtime-downloads a third. The goal is zero terminal exposure
-for non-technical users — they install Houston, click in, and the chat
-agent works without ever opening a shell.
+bundle (`.app` on macOS, `.msi` on Windows) and runtime-downloads a
+third. The goal is zero terminal exposure for non-technical users —
+they install Houston, click in, and the chat agent works without ever
+opening a shell.
 
 ## What ships where
+
+### macOS
 
 | CLI         | License       | Distribution      | Where it lives                                                        |
 |-------------|---------------|-------------------|------------------------------------------------------------------------|
 | codex       | Apache-2.0    | Bundled (universal) | `Houston.app/Contents/Resources/bin/codex` — single Mach-O fat binary |
 | composio    | MIT           | Bundled (per-arch)  | `Resources/bin/composio-aarch64/`, `Resources/bin/composio-x86_64/`   |
-| claude-code | PROPRIETARY   | Runtime download    | `~/.local/bin/claude` (`%LOCALAPPDATA%\Programs\claude\claude.exe`)   |
+| claude-code | PROPRIETARY   | Runtime download    | `~/.local/bin/claude`                                                  |
 
-claude-code is licensed in a way that doesn't permit redistribution, so
-we can't bundle it. Instead the engine downloads + sha256-verifies on
-first launch using a manifest pinned in `cli-deps.json`.
+### Windows (x64 only in v1)
+
+| CLI         | License       | Distribution                | Where it lives                                                                          |
+|-------------|---------------|-----------------------------|------------------------------------------------------------------------------------------|
+| codex       | Apache-2.0    | Bundled (single arch)       | `<install>\resources\bin\codex.exe` — downloaded + zstd-decoded from upstream            |
+| composio    | MIT           | **Built from source (fork)** | `<install>\resources\bin\composio-x86_64\composio.exe`                                   |
+| claude-code | PROPRIETARY   | Runtime download            | `%LOCALAPPDATA%\Programs\claude\claude.exe`                                              |
+
+Three notes on Windows:
+
+1. **codex** ships a single per-arch binary on Windows because there is
+   no `lipo` equivalent — Windows binaries from openai/codex come as
+   `codex-{x86_64,aarch64}-pc-windows-msvc.exe.zst`. We use the `.zst`
+   variant, decompress with `zstd`, and stage at `resources/bin/codex.exe`.
+
+2. **composio** is BUILT FROM SOURCE on the Windows runner. Upstream
+   `ComposioHQ/composio` does not yet ship Windows artifacts (issue
+   #3057, closed: "use WSL for now"). Houston builds composio.exe on
+   every release using a pinned commit on a forked repo
+   (`gethouston/composio`, branch `houston-windows-support`) that adds:
+   - Windows targets (`bun-windows-x64-modern` etc.) to
+     `TARGET_MAP` in `build-binary-cross.ts`.
+   - `win32-x64` + `win32-arm64` entries in
+     `RUN_CODEX_ACP_BINARY_TARGETS` so the build pulls
+     `@zed-industries/codex-acp-win32-{x64,arm64}` from npm.
+   - A native `WindowsCredentialFFIStore` in `cli-keyring` that calls
+     `advapi32.dll`'s `Cred*` family via `bun:ffi` against the user's
+     Credential Manager (Generic Credentials,
+     `CRED_PERSIST_LOCAL_MACHINE`).
+   The fork's HEAD SHA + Bun version are pinned in
+   `cli-deps.json#composio.build."windows-x64"` and verified at fetch
+   time. The plan is to upstream these patches to ComposioHQ once
+   we've shaken out the runtime Windows-isms in production.
+
+3. **claude-code** ships native Windows binaries (`win32-x64`,
+   `win32-arm64`) directly from Anthropic's distribution manifest. The
+   runtime installer (`houston-claude-installer`) detects platform via
+   `host_platform_key()`, resolves the matching URL + SHA-256 from the
+   bundled `cli-deps.json`, and writes to
+   `%LOCALAPPDATA%\Programs\claude\claude.exe` (matching the upstream
+   PowerShell installer).
+
+claude-code's license doesn't permit redistribution, so we can't
+bundle it on either OS. Instead the engine downloads + sha256-verifies
+on first launch using a manifest pinned in `cli-deps.json`.
 
 codex is a Rust binary so we `lipo -create` the two arch tarballs into
-one universal binary. composio is a Bun-bundled JS app whose runtime is
-arch-specific — `lipo` can't combine them, so we ship both and the
-engine resolves the right directory at runtime via `std::env::consts::ARCH`.
+one universal binary on macOS. composio is a Bun-bundled JS app whose
+runtime is arch-specific — `lipo` can't combine them, so we ship per-
+arch directories on macOS and a single x64 directory on Windows.
 
 ## Pinned manifest — `cli-deps.json`
 
@@ -42,7 +87,16 @@ read pinned URLs + checksums without a separate network round-trip.
 
 ## Build pipeline
 
-`scripts/fetch-cli-deps.sh both`:
+The same `scripts/fetch-cli-deps.sh` handles both macOS and Windows; the
+mode arg selects the OS:
+
+- `./scripts/fetch-cli-deps.sh both` — macOS, both arches (production)
+- `./scripts/fetch-cli-deps.sh arm64` / `x64` — single-arch macOS dev
+- `./scripts/fetch-cli-deps.sh windows-x64` — Windows (production)
+- `./scripts/fetch-cli-deps.sh host` — auto-detect host
+
+### macOS (`both` mode)
+
 1. Downloads each bundled CLI for both arches using URLs from the manifest.
 2. Verifies sha256 against pinned checksums (mismatch is fatal).
 3. `lipo -create`s the two codex slices into a single universal Mach-O.
@@ -50,6 +104,26 @@ read pinned URLs + checksums without a separate network round-trip.
 5. Prunes cross-platform `acp-adapters/codex/<plat>/` directories that the
    resolved arch can never execute (~580 MB savings).
 6. Stages `cli-deps.json` itself for the runtime installer.
+
+### Windows (`windows-x64` mode)
+
+1. Downloads `codex-x86_64-pc-windows-msvc.exe.zst` from openai/codex,
+   verifies SHA-256, decompresses with `zstd`, stages as
+   `resources/bin/codex.exe`. No lipo step.
+2. Clones the gethouston/composio fork at the pinned commit SHA
+   (verified after clone — drift fails the build), runs
+   `pnpm install + pnpm exec tsdown + pnpm run build:binary:cross --
+   --target bun-windows-x64-modern` to produce `composio-windows-x64.exe`
+   plus companion `.mjs` modules and `acp-adapters/codex/<plat>/codex-acp.exe`
+   for every supported platform.
+3. Stages the binary as `resources/bin/composio-x86_64/composio.exe`,
+   flattens companion modules alongside it, prunes cross-platform
+   acp-adapter binaries keeping only `win32-x64` (~681M → ~235M).
+4. Stages `cli-deps.json` itself.
+
+The Windows mode also accepts a `COMPOSIO_FORK_PATH=/path/to/local/fork`
+env override that skips the remote clone and uses an existing tree —
+useful for iterating on fork patches before pushing to GitHub.
 
 `tauri.conf.json#bundle.resources` then maps the staging dir verbatim
 into the `.app`:
@@ -208,20 +282,83 @@ successfully run a separate installer for each provider CLI.
    route them in `engine_protocol::event_topic`.
 5. Add `/v1/<name>/*` REST routes mirroring `routes/claude.rs`.
 
+## Maintaining the gethouston/composio fork
+
+The Windows composio binary is built from a fork of upstream
+ComposioHQ/composio with three patches that upstream hasn't taken yet
+(see issue #3057). The fork lives at
+`https://github.com/gethouston/composio.git` on branch
+`houston-windows-support`. Houston pins the HEAD SHA in
+`cli-deps.json#composio.build."windows-x64".source_sha` and the fetch
+script verifies it after every clone.
+
+Workflow when bumping composio versions:
+
+1. On the gethouston/composio fork, rebase `houston-windows-support`
+   onto the new upstream tag (`@composio/cli@<NEW>`) and re-apply the
+   three patches if rebase doesn't auto-merge them:
+   - `feat(cli): add Windows targets to cross-compile + ACP adapter map`
+   - `feat(cli-keyring): native Windows Credential Manager backend (bun:ffi)`
+   - (any subsequent patch adding new Windows behavior)
+2. Push the rebased branch.
+3. In Houston, update `cli-deps.json`:
+   ```bash
+   ./scripts/bump-cli.sh composio <NEW_VERSION>
+   ```
+   then edit `composio.build."windows-x64".source_sha` to the new
+   fork HEAD SHA.
+4. Run `./scripts/fetch-cli-deps.sh windows-x64` locally to verify the
+   build still works.
+5. Open the upstream PR (`ComposioHQ/composio`) with the same patches —
+   the longer the gap between the fork and upstream the more painful
+   rebases get.
+
+The fork is the deliberate single-point-of-truth for Houston-side
+Windows support: it's small, the patches are mechanical, and it
+doesn't introduce a vendoring layer (composio source isn't checked
+into Houston). Upstream taking the patches deletes this section.
+
+## Windows signing — deferred
+
+The Windows MSI ships UNSIGNED in v1. Users see Microsoft Defender
+SmartScreen warning ("Windows protected your PC — Don't run / More
+info → Run anyway") on first install. Plan:
+
+1. SignPath Foundation (free OSS code signing) is approved for Houston
+   per `project_windows_signing` memory.
+2. Wire `signpath-foundation/signpath-action@v1` into the
+   `build-windows` job between `tauri-action` and the upload step.
+3. Submit the MSI + bundled `.exe` files for signing, wait for
+   completion, replace the unsigned artifacts before
+   `gh release upload`.
+4. Verify with `signtool verify /pa /v signed.msi`.
+
+Until that lands, the unsigned MSI is acceptable for personal
+testing — it installs fine, just with one extra confirmation click.
+
 ## Files involved
 
-- `cli-deps.json` — pinned versions, URLs, checksums.
-- `scripts/fetch-cli-deps.sh` — fetch + lipo + prune + stage.
+- `cli-deps.json` — pinned versions, URLs, checksums, Windows
+  build manifest (`composio.build."windows-x64"`).
+- `scripts/fetch-cli-deps.sh` — fetch + lipo + prune + stage; the
+  Windows path also clones+builds the composio fork.
 - `scripts/bump-cli.sh` — version bumper (clears stale checksums).
 - `scripts/install-claude-code.sh` — legacy bash installer; kept for
   manual recovery / debugging. The Rust runtime installer is the
   blessed path.
-- `app/src-tauri/tauri.conf.json#bundle.resources` — Tauri-side wiring.
+- `app/src-tauri/tauri.conf.json#bundle.{resources,windows}` — Tauri
+  side: bundle resources, MSI target, WiX config, WebView2 install
+  mode.
 - `app/src-tauri/build.rs` — ensures the staging dir exists for `pnpm tauri dev`.
-- `engine/houston-cli-bundle/` — resolver crate.
-- `engine/houston-claude-installer/` — runtime download crate.
-- `engine/houston-composio/src/install.rs` — bundle-aware composio resolver.
+- `engine/houston-cli-bundle/` — resolver crate (Windows-aware).
+- `engine/houston-claude-installer/` — runtime download crate
+  (Windows install dir at `%LOCALAPPDATA%\Programs\claude\`).
+- `engine/houston-composio/src/install.rs` — bundle-aware composio
+  resolver (Windows surfaces a clear "bundled-only" error in dev mode).
 - `engine/houston-engine-core/src/provider.rs` — `InstallSource` enum + status.
-- `engine/houston-terminal-manager/src/claude_path.rs` — PATH augmentation.
+- `engine/houston-terminal-manager/src/claude_path.rs` — PATH
+  augmentation, Windows-specific install dirs +
+  `.exe`/`.cmd`/`.bat` extension probing.
 - `engine/houston-engine-server/src/routes/claude.rs` — `/v1/claude/*`.
-- `.github/workflows/release.yml` — fetch + verify steps.
+- `.github/workflows/release.yml` — `build-macos` + `build-windows`
+  jobs, fetch + verify steps.

--- a/knowledge-base/cli-bundling.md
+++ b/knowledge-base/cli-bundling.md
@@ -336,6 +336,17 @@ info → Run anyway") on first install. Plan:
 Until that lands, the unsigned MSI is acceptable for personal
 testing — it installs fine, just with one extra confirmation click.
 
+Note that "Windows MSI signing" above refers to **OS code-signing**
+(SmartScreen / Mark-of-the-Web); it's distinct from the
+**Tauri-updater minisign signature** that gates auto-update. The
+updater signature IS produced and uploaded for Windows builds (see
+`build-windows`'s "Extend latest.json with Windows updater entry"
+step) and the in-app updater verifies against the public key
+embedded at build time — same signing key as the macOS .app.tar.gz
+flow. So Windows users on older Houston versions get the same
+auto-update prompt as macOS users, just with a SmartScreen warning
+when the new MSI runs until SignPath integration ships.
+
 ## Files involved
 
 - `cli-deps.json` — pinned versions, URLs, checksums, Windows

--- a/knowledge-base/platform-matrix.md
+++ b/knowledge-base/platform-matrix.md
@@ -80,3 +80,40 @@ both.
   clear I/O error), but the features that depend on them are not
   expected to work on Windows without additional work. Left out of
   scope to keep this diff tight.
+
+## Wave 2 status (composio Windows + MSI build pipeline)
+
+Wave 2 landed alongside the gethouston/composio fork and the new
+`build-windows` GitHub Actions job. Status of the previously-listed
+gaps:
+
+1. **Composio CLI install** — RESOLVED. Production Windows builds
+   bundle composio.exe via the gethouston/composio fork (built from
+   source on the windows-latest runner). The dev-mode error message
+   stays as-is because there's no benefit to running composio
+   standalone outside a packaged Houston install. See
+   `knowledge-base/cli-bundling.md` for the build pipeline.
+2. **Claude / Codex CLI discovery** — VALIDATED for x64. Codex ships
+   native `codex-x86_64-pc-windows-msvc.exe` from openai/codex; we
+   download + zstd-decode + bundle. Claude Code's distribution
+   manifest exposes `win32-x64` + `win32-arm64` URLs which the
+   runtime installer resolves automatically. The `COMMON_CLAUDE_DIRS`
+   list still covers the npm + AppData scenarios.
+3. **nvm-windows** — STILL UNVALIDATED. Houston's bundled CLIs win
+   over PATH lookups in production, so this only matters for dev
+   builds running unbundled.
+4. **Process-group kill** — UNCHANGED.
+5. **MSVC target build** — VERIFIED via the new `build-windows` CI
+   job (`cargo build --release --target x86_64-pc-windows-msvc -p
+   houston-engine-server`). Mac-host cross-compile remains
+   unsupported (no `xwin` SDK) and is not on the roadmap.
+
+Two new gaps introduced in Wave 2:
+
+6. **Windows MSI signing** — Wave 2 ships UNSIGNED. SignPath
+   Foundation integration is blocked on operational provisioning
+   (project + secret rotation in CI). See cli-bundling.md "Windows
+   signing — deferred" for the wire-up plan.
+7. **Auto-updater** — `latest.json` carries macOS entries only.
+   Windows users manually grab a fresh MSI from the GitHub release
+   page when a new version drops.

--- a/knowledge-base/platform-matrix.md
+++ b/knowledge-base/platform-matrix.md
@@ -108,12 +108,18 @@ gaps:
    houston-engine-server`). Mac-host cross-compile remains
    unsupported (no `xwin` SDK) and is not on the roadmap.
 
-Two new gaps introduced in Wave 2:
+One new gap introduced in Wave 2:
 
 6. **Windows MSI signing** — Wave 2 ships UNSIGNED. SignPath
    Foundation integration is blocked on operational provisioning
    (project + secret rotation in CI). See cli-bundling.md "Windows
-   signing — deferred" for the wire-up plan.
-7. **Auto-updater** — `latest.json` carries macOS entries only.
-   Windows users manually grab a fresh MSI from the GitHub release
-   page when a new version drops.
+   signing — deferred" for the wire-up plan. The Tauri-updater
+   minisign signature (covering in-app auto-update verification) IS
+   produced and uploaded — that's separate from OS code-signing.
+
+Auto-updater Windows entries are now wired: `build-windows`
+downloads the macOS-only `latest.json` uploaded by `build-macos`,
+adds a `windows-x86_64` entry pointing at the MSI + its minisign
+.sig, and re-uploads with `--clobber`. The Tauri updater plugin
+already runs on Windows; users on previous builds will see the
+update prompt automatically the next time they launch.

--- a/scripts/fetch-cli-deps.sh
+++ b/scripts/fetch-cli-deps.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 # ============================================================================
-# Fetch CLI dependencies pinned in `cli-deps.json` and stage them under
-# `app/src-tauri/resources/bin/` so Tauri's `bundle.resources` glob picks
-# them up at .app build time.
+# Fetch / build the bundled CLIs pinned in `cli-deps.json` and stage them
+# under `app/src-tauri/resources/bin/` so Tauri's `bundle.resources` glob
+# picks them up at .app / .msi build time.
 #
-# Output layout (production, universal .app):
+# Output layout — macOS universal .app:
 #
 #   app/src-tauri/resources/bin/
 #     codex                          # universal Mach-O (arm64 + x86_64)
@@ -20,28 +20,49 @@
 #                                    # downloads (claude-code) — read by the
 #                                    # houston-claude-installer crate.
 #
+# Output layout — Windows x64 .msi:
+#
+#   app/src-tauri/resources/bin/
+#     codex.exe                      # Windows x64 single-arch binary
+#     composio-x86_64/               # Bun-compiled Windows bundle
+#       composio.exe
+#       services/
+#       *.mjs
+#       acp-adapters/
+#         codex/win32-x64/codex-acp.exe
+#         claude-code-acp.mjs
+#         cli.js
+#     cli-deps.json
+#
 # Why this layout:
-#   - codex is a Rust binary — `lipo` produces one fat universal binary so we
-#     ship a single file regardless of host arch.
+#   - codex is a Rust binary — on macOS we `lipo -create` the two slices
+#     into a single fat binary; on Windows there is no lipo equivalent
+#     and we simply stage the per-arch binary alongside the rest.
 #   - composio is a Bun-bundled JavaScript runtime — CANNOT be lipo'd; the
 #     binary contains an arch-specific Bun runtime + sibling .mjs/services
-#     files. Both arches must be shipped side-by-side under a per-arch dir.
-#   - cli-deps.json travels with the app so the runtime claude-code
+#     files. Both arches must be shipped side-by-side under a per-arch dir
+#     on macOS. On Windows we ship one arch only (no Windows ARM build in
+#     v1) and the resolver is per-OS so directory names don't collide
+#     between the .app and .msi outputs.
+#   - cli-deps.json travels with the bundle so the runtime claude-code
 #     installer can read pinned URL+SHA256 without needing network access
 #     to a separate manifest endpoint.
 #
 # Modes:
-#   ./scripts/fetch-cli-deps.sh                # both arches (production)
-#   ./scripts/fetch-cli-deps.sh arm64          # arm64 only (dev convenience)
-#   ./scripts/fetch-cli-deps.sh x64            # x64 only
-#   ./scripts/fetch-cli-deps.sh host           # auto-detect host arch
+#   ./scripts/fetch-cli-deps.sh                # macOS, both arches (production)
+#   ./scripts/fetch-cli-deps.sh both           # alias for macOS both arches
+#   ./scripts/fetch-cli-deps.sh arm64          # macOS arm64 only (dev)
+#   ./scripts/fetch-cli-deps.sh x64            # macOS x64 only (dev)
+#   ./scripts/fetch-cli-deps.sh windows-x64    # Windows x64 (production)
+#   ./scripts/fetch-cli-deps.sh host           # auto-detect host OS + arch
 #
-# CI ALWAYS uses no-arg form (both arches). Local dev can use `host` to
-# skip downloading the cross-arch slice they don't need.
+# CI uses the no-arg form on macOS runners and `windows-x64` on Windows
+# runners. Local dev can use `host` to skip cross-arch slices the
+# developer doesn't need.
 #
 # Strict mode: any download or checksum failure is fatal (set -euo pipefail).
-# Partial bundles are unacceptable — we'd ship a broken .app to half the
-# user base.
+# Partial bundles are unacceptable — we'd ship a broken .app / .msi to
+# half the user base.
 # ============================================================================
 set -euo pipefail
 
@@ -55,9 +76,16 @@ if [ ! -f "$DEPS_FILE" ]; then
 fi
 
 if ! command -v jq >/dev/null 2>&1; then
-  echo "ERROR: jq is required but not installed (brew install jq)" >&2
+  echo "ERROR: jq is required but not installed (brew install jq | choco install jq)" >&2
   exit 1
 fi
+
+# ---------------------------------------------------------------------------
+# Mode parsing — derive (TARGET_OS, ARCHES) from the user-facing mode arg.
+# Backwards compatibility: existing macOS modes (`both`, `arm64`, `x64`,
+# `host`) keep working unchanged so the existing macOS CI workflow doesn't
+# need to know about Windows.
+# ---------------------------------------------------------------------------
 
 detect_host_arch() {
   case "$(uname -m)" in
@@ -67,21 +95,42 @@ detect_host_arch() {
   esac
 }
 
+detect_host_os() {
+  case "$(uname -s)" in
+    Darwin*) echo "darwin" ;;
+    Linux*)  echo "linux" ;;
+    MINGW*|MSYS*|CYGWIN*|Windows_NT) echo "windows" ;;
+    *) echo "ERROR: unsupported host OS $(uname -s)" >&2; exit 1 ;;
+  esac
+}
+
 MODE="${1:-both}"
+TARGET_OS=""
+ARCHES=()
 case "$MODE" in
-  both)            ARCHES=("arm64" "x64") ;;
-  arm64)           ARCHES=("arm64") ;;
-  x64)             ARCHES=("x64") ;;
-  host)            ARCHES=("$(detect_host_arch)") ;;
-  *) echo "ERROR: unknown mode '$MODE' (expected: both|arm64|x64|host)" >&2; exit 1 ;;
+  both)            TARGET_OS="darwin"; ARCHES=("arm64" "x64") ;;
+  arm64)           TARGET_OS="darwin"; ARCHES=("arm64") ;;
+  x64)             TARGET_OS="darwin"; ARCHES=("x64") ;;
+  windows-x64)     TARGET_OS="windows"; ARCHES=("x64") ;;
+  host)
+    HOST_OS=$(detect_host_os)
+    HOST_ARCH=$(detect_host_arch)
+    case "$HOST_OS" in
+      darwin)  TARGET_OS="darwin"; ARCHES=("$HOST_ARCH") ;;
+      windows) TARGET_OS="windows"; ARCHES=("$HOST_ARCH") ;;
+      *) echo "ERROR: host mode does not yet support $HOST_OS" >&2; exit 1 ;;
+    esac ;;
+  *) echo "ERROR: unknown mode '$MODE' (expected: both|arm64|x64|windows-x64|host)" >&2; exit 1 ;;
 esac
 
 mkdir -p "$OUT_DIR"
 
-# --- Helpers ----------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
 
-# Download with fail-fast + retry. Avoids a half-written file leaking past a
-# transient network error (curl with --output writes incrementally).
+# Download with fail-fast + retry. Avoids a half-written file leaking past
+# a transient network error (curl with --output writes incrementally).
 download() {
   local url="$1" dest="$2"
   local attempts=3 i=1
@@ -100,7 +149,11 @@ download() {
 verify_or_print_checksum() {
   local file="$1" expected="$2" label="$3"
   local actual
-  actual=$(shasum -a 256 "$file" | cut -d' ' -f1)
+  if command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "$file" | cut -d' ' -f1)
+  else
+    actual=$(sha256sum "$file" | cut -d' ' -f1)
+  fi
   if [ -n "$expected" ]; then
     if [ "$actual" != "$expected" ]; then
       echo "ERROR: checksum mismatch for $label" >&2
@@ -123,10 +176,41 @@ find_binary() {
     | head -1
 }
 
-# Stage a fetched single binary (codex) into a per-arch staging slot.
-# We don't write directly to the final path — codex needs to wait for
-# both arches before lipo'ing.
-stage_codex_arch() {
+# Stage cli-deps.json itself so the runtime claude-code installer can
+# read pinned URLs + checksums at install time without a separate fetch.
+stage_manifest() {
+  cp "$DEPS_FILE" "$OUT_DIR/cli-deps.json"
+  echo "  Staged: $OUT_DIR/cli-deps.json"
+}
+
+# Prune cross-platform acp-adapters keeping only `keep_platform`.
+# Composio's bundle ships every supported platform's codex-acp binary
+# (~90 MB each); each per-arch process only ever reads its own.
+prune_acp_adapters() {
+  local dest_dir="$1" keep_platform="$2"
+  local acp_codex_dir="$dest_dir/acp-adapters/codex"
+  if [ -d "$acp_codex_dir" ]; then
+    local before_size
+    before_size=$(du -sh "$dest_dir" | cut -f1)
+    for plat_dir in "$acp_codex_dir"/*; do
+      [ -d "$plat_dir" ] || continue
+      local plat_name
+      plat_name=$(basename "$plat_dir")
+      if [ "$plat_name" != "$keep_platform" ]; then
+        rm -rf "$plat_dir"
+      fi
+    done
+    local after_size
+    after_size=$(du -sh "$dest_dir" | cut -f1)
+    echo "  Pruned acp-adapters to $keep_platform only ($before_size -> $after_size)"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# macOS code path — unchanged from the pre-Windows release pipeline
+# ---------------------------------------------------------------------------
+
+stage_codex_arch_darwin() {
   local arch="$1"
   local platform="darwin-$arch"
   local version url_template expected url tmp extract_dir bin_path
@@ -185,9 +269,7 @@ stage_codex_arch() {
   echo "  Staged: $stage_dir/codex-$arch"
 }
 
-# Lipo staged per-arch codex slices into one universal binary. Only run
-# after BOTH arches are staged (i.e. when MODE=both).
-lipo_codex_universal() {
+lipo_codex_universal_darwin() {
   local stage_dir="$OUT_DIR/.staging/codex"
   if [ ! -f "$stage_dir/codex-arm64" ] || [ ! -f "$stage_dir/codex-x64" ]; then
     echo "ERROR: cannot lipo codex — both arches not staged" >&2
@@ -207,10 +289,7 @@ lipo_codex_universal() {
   echo "  Installed: $OUT_DIR/codex ($(du -sh "$OUT_DIR/codex" | cut -f1))"
 }
 
-# Stage codex single-arch (arm64-only or x64-only dev build) — copies the
-# slice directly to the final location instead of lipo'ing. Useful for
-# `pnpm tauri dev` where the developer only needs their host arch.
-finalize_codex_single_arch() {
+finalize_codex_single_arch_darwin() {
   local arch="$1"
   local stage_dir="$OUT_DIR/.staging/codex"
   if [ ! -f "$stage_dir/codex-$arch" ]; then
@@ -224,9 +303,7 @@ finalize_codex_single_arch() {
   echo "  Installed: $OUT_DIR/codex (single $arch)"
 }
 
-# Fetch + stage composio for one arch. Composio is a multi-file Bun bundle
-# (binary + services/ + *.mjs) — we ship the whole directory per arch.
-fetch_composio_arch() {
+fetch_composio_arch_darwin() {
   local arch="$1"
   local platform="darwin-$arch"
   local version url_template expected url tmp extract_dir bin_path bin_dir dest_dir
@@ -264,9 +341,6 @@ fetch_composio_arch() {
   fi
   bin_dir=$(dirname "$bin_path")
 
-  # Per-arch destination. Use Rust target-arch naming to match
-  # `std::env::consts::ARCH` ("aarch64" / "x86_64") so the runtime resolver
-  # in the engine doesn't need an arch-name translation table.
   local rust_arch
   case "$arch" in
     arm64) rust_arch="aarch64" ;;
@@ -276,8 +350,6 @@ fetch_composio_arch() {
   rm -rf "$dest_dir"
   cp -R "$bin_dir" "$dest_dir"
 
-  # Normalize binary name in case the archive had a versioned name
-  # (e.g. composio-darwin-aarch64) that doesn't match what we spawn.
   local actual_name
   actual_name=$(basename "$bin_path")
   if [ "$actual_name" != "composio" ]; then
@@ -287,83 +359,260 @@ fetch_composio_arch() {
 
   rm -rf "$extract_dir"
 
-  # Prune cross-platform acp-adapter binaries that this per-arch composio
-  # bundle can never execute. Composio's upstream zip ships every platform
-  # — darwin-arm64, darwin-x64, linux-arm64, linux-x64 — under
-  # `acp-adapters/codex/<platform>/codex-acp` (~90 MB each). cli.js
-  # constructs the per-process path dynamically as `${platform}-${arch}`
-  # (verified empirically), so a darwin-arm64 process only ever opens
-  # `darwin-arm64/codex-acp` and the other 3 directories are 270 MB of
-  # pure dead weight. We prune them here so the .app stays at honest
-  # production size.
-  #
-  # We also prune linux altogether because Houston does not ship for
-  # Linux. If/when a linux build target is added, `release.yml` will
-  # call `fetch-cli-deps.sh` from a Linux runner separately and that
-  # bundle will be staged into a `composio-<linux-arch>/` dir with the
-  # linux acp-adapter retained.
-  local keep_platform="darwin-$arch"
-  local acp_codex_dir="$dest_dir/acp-adapters/codex"
-  if [ -d "$acp_codex_dir" ]; then
-    local before_size
-    before_size=$(du -sh "$dest_dir" | cut -f1)
-    for plat_dir in "$acp_codex_dir"/*; do
-      [ -d "$plat_dir" ] || continue
-      local plat_name
-      plat_name=$(basename "$plat_dir")
-      if [ "$plat_name" != "$keep_platform" ]; then
-        rm -rf "$plat_dir"
-      fi
-    done
-    local after_size
-    after_size=$(du -sh "$dest_dir" | cut -f1)
-    echo "  Pruned acp-adapters to $keep_platform only ($before_size -> $after_size)"
-  fi
+  prune_acp_adapters "$dest_dir" "darwin-$arch"
 
   echo "  Installed: $dest_dir/ ($(du -sh "$dest_dir" | cut -f1))"
 }
 
-# Stage cli-deps.json itself so the runtime claude-code installer can read
-# pinned URLs + checksums at install time without a separate fetch.
-stage_manifest() {
-  cp "$DEPS_FILE" "$OUT_DIR/cli-deps.json"
-  echo "  Staged: $OUT_DIR/cli-deps.json"
+# ---------------------------------------------------------------------------
+# Windows code path — codex via download, composio via build-from-source
+# ---------------------------------------------------------------------------
+
+# Stage codex for Windows. Upstream openai/codex publishes pre-built
+# `codex-{x86_64,aarch64}-pc-windows-msvc.exe.zst` artifacts on every
+# release — we just download, decompress, and stage at the single
+# location resources/bin/codex.exe (no lipo equivalent on Windows).
+stage_codex_windows() {
+  local arch="$1"
+  local platform="windows-$arch"
+  local version url_template expected url tmp out_path
+  version=$(jq -r '.codex.version' "$DEPS_FILE")
+  url_template=$(jq -r ".codex.urls[\"$platform\"] // empty" "$DEPS_FILE")
+  expected=$(jq -r ".codex.checksums[\"$platform\"] // empty" "$DEPS_FILE")
+
+  if [ -z "$url_template" ]; then
+    echo "ERROR: cli-deps.json missing codex URL for $platform" >&2
+    exit 1
+  fi
+
+  url="${url_template//\{version\}/$version}"
+  echo "FETCH codex v$version ($platform)"
+  echo "  URL: $url"
+
+  tmp=$(mktemp)
+  download "$url" "$tmp" || { echo "ERROR: codex download failed for $platform" >&2; rm -f "$tmp"; exit 1; }
+  verify_or_print_checksum "$tmp" "$expected" "codex/$platform" || { rm -f "$tmp"; exit 1; }
+
+  if ! command -v zstd >/dev/null 2>&1; then
+    echo "ERROR: zstd is required to decompress the codex Windows artifact" >&2
+    echo "  brew install zstd | choco install zstandard" >&2
+    rm -f "$tmp"
+    exit 1
+  fi
+
+  out_path="$OUT_DIR/codex.exe"
+  rm -f "$out_path"
+  zstd -d "$tmp" -o "$out_path" >/dev/null 2>&1
+  rm -f "$tmp"
+
+  if [ ! -s "$out_path" ]; then
+    echo "ERROR: zstd decompression produced empty output for codex/$platform" >&2
+    exit 1
+  fi
+  echo "  Installed: $out_path ($(du -sh "$out_path" | cut -f1))"
 }
 
-# --- Pre-flight: clean any stale artifacts so a re-run produces a known
-#     layout. Removing the full bin dir is safe — every artifact in there
-#     is reproducible from cli-deps.json. ---------------------------------
-rm -rf "$OUT_DIR/.staging" "$OUT_DIR/codex" "$OUT_DIR/composio-"* "$OUT_DIR/cli-deps.json"
+# Build composio for Windows from the Houston-maintained fork. Upstream
+# ComposioHQ/composio does not yet publish a Windows artifact — see the
+# `$build_comment` in cli-deps.json for the full reasoning. The build is
+# reproducible: every input (repo URL, commit SHA, package path, Bun
+# target, Bun version) is pinned in the manifest.
+build_composio_windows() {
+  local arch="$1"
+  local platform="windows-$arch"
+  local source_repo source_ref source_sha package_path bun_target bun_version artifact_basename
+  source_repo=$(jq -r ".composio.build[\"$platform\"].source_repo // empty" "$DEPS_FILE")
+  source_ref=$(jq -r ".composio.build[\"$platform\"].source_ref // empty" "$DEPS_FILE")
+  source_sha=$(jq -r ".composio.build[\"$platform\"].source_sha // empty" "$DEPS_FILE")
+  package_path=$(jq -r ".composio.build[\"$platform\"].package_path // empty" "$DEPS_FILE")
+  bun_target=$(jq -r ".composio.build[\"$platform\"].bun_target // empty" "$DEPS_FILE")
+  bun_version=$(jq -r ".composio.build[\"$platform\"].bun_version // empty" "$DEPS_FILE")
+  artifact_basename=$(jq -r ".composio.build[\"$platform\"].artifact_basename // empty" "$DEPS_FILE")
 
-# --- Fetch each arch ------------------------------------------------------
-for arch in "${ARCHES[@]}"; do
-  stage_codex_arch "$arch"
-  fetch_composio_arch "$arch"
-done
+  for v in "$source_repo" "$source_ref" "$package_path" "$bun_target" "$artifact_basename"; do
+    if [ -z "$v" ]; then
+      echo "ERROR: composio.build.$platform is missing required fields in cli-deps.json" >&2
+      exit 1
+    fi
+  done
 
-# --- Combine codex slices (or finalize single-arch dev build) -----------
-if [ "${#ARCHES[@]}" -eq 2 ]; then
-  lipo_codex_universal
-else
-  finalize_codex_single_arch "${ARCHES[0]}"
-fi
+  local rust_arch
+  case "$arch" in
+    arm64) rust_arch="aarch64" ;;
+    x64)   rust_arch="x86_64" ;;
+  esac
 
-# --- Manifest -------------------------------------------------------------
+  echo "BUILD composio ($platform) from $source_repo @ $source_ref"
+
+  # Local override for development / weekend testing:
+  #   COMPOSIO_FORK_PATH=/path/to/checkout ./scripts/fetch-cli-deps.sh windows-x64
+  # skips the remote clone and reuses an existing tree (with whatever
+  # local commits are on it). Production CI never sets this.
+  local fork_dir
+  if [ -n "${COMPOSIO_FORK_PATH:-}" ]; then
+    if [ ! -d "$COMPOSIO_FORK_PATH" ]; then
+      echo "ERROR: COMPOSIO_FORK_PATH=$COMPOSIO_FORK_PATH does not exist" >&2
+      exit 1
+    fi
+    fork_dir="$COMPOSIO_FORK_PATH"
+    echo "  Using local override: $fork_dir"
+  else
+    fork_dir=$(mktemp -d)
+    echo "  Cloning into: $fork_dir"
+    git clone --depth 1 --branch "$source_ref" "$source_repo" "$fork_dir" 2>&1 | tail -3
+
+    if [ -n "$source_sha" ]; then
+      local actual_sha
+      actual_sha=$(git -C "$fork_dir" rev-parse HEAD)
+      if [ "$actual_sha" != "$source_sha" ]; then
+        echo "ERROR: composio fork SHA mismatch" >&2
+        echo "  expected: $source_sha" >&2
+        echo "  actual:   $actual_sha" >&2
+        echo "  Either bump composio.build.$platform.source_sha in cli-deps.json" >&2
+        echo "  or update the fork branch '$source_ref' to point at $source_sha" >&2
+        exit 1
+      fi
+      echo "  Pinned SHA OK: $source_sha"
+    fi
+  fi
+
+  # Bun version check — the binary embeds the Bun runtime, so it MUST
+  # match what cli-deps.json pins. Mismatched Bun produces a
+  # nominally-working binary but with subtle behavioral differences
+  # that bite at runtime; we'd rather fail at build time.
+  if [ -n "$bun_version" ]; then
+    if ! command -v bun >/dev/null 2>&1; then
+      echo "ERROR: bun is required to build composio for Windows" >&2
+      echo "  curl -fsSL https://bun.sh/install | bash -s 'bun-v$bun_version'" >&2
+      exit 1
+    fi
+    local actual_bun
+    actual_bun=$(bun --version)
+    if [ "$actual_bun" != "$bun_version" ]; then
+      echo "ERROR: Bun version mismatch (have $actual_bun, need $bun_version)" >&2
+      echo "  curl -fsSL https://bun.sh/install | bash -s 'bun-v$bun_version'" >&2
+      exit 1
+    fi
+    echo "  Pinned Bun OK: $actual_bun"
+  fi
+
+  if ! command -v pnpm >/dev/null 2>&1 && ! command -v corepack >/dev/null 2>&1; then
+    echo "ERROR: pnpm or corepack is required to build composio" >&2
+    exit 1
+  fi
+
+  echo "  pnpm install (deps for fork build)..."
+  ( cd "$fork_dir" && pnpm install --frozen-lockfile --prefer-offline ) 2>&1 | tail -5
+
+  echo "  pnpm build for workspace deps of @composio/cli..."
+  ( cd "$fork_dir" && pnpm -r --filter '@composio/cli^...' run build ) 2>&1 | tail -3
+
+  echo "  tsdown bundle for @composio/cli..."
+  ( cd "$fork_dir/$package_path" && pnpm exec tsdown ) 2>&1 | tail -3
+
+  echo "  bun build:binary:cross --target $bun_target ..."
+  ( cd "$fork_dir/$package_path" && pnpm run build:binary:cross -- --target "$bun_target" ) 2>&1 | tail -3
+
+  local dist_dir="$fork_dir/$package_path/dist/binaries"
+  local exe_path="$dist_dir/${artifact_basename}.exe"
+  if [ ! -f "$exe_path" ]; then
+    echo "ERROR: expected composio Windows binary not produced: $exe_path" >&2
+    find "$dist_dir" -maxdepth 2 -type f | head -10 >&2
+    exit 1
+  fi
+
+  local dest_dir="$OUT_DIR/composio-$rust_arch"
+  rm -rf "$dest_dir"
+  mkdir -p "$dest_dir"
+
+  cp "$exe_path" "$dest_dir/composio.exe"
+  if [ -d "$dist_dir/companions" ]; then
+    # Companions sit next to the binary at runtime — Bun's compiled
+    # binary looks them up via `import.meta.url` resolution. Flatten
+    # the `companions/` subtree directly into `dest_dir/`.
+    cp -R "$dist_dir/companions/." "$dest_dir/"
+  else
+    echo "ERROR: composio companions/ dir missing — Bun build did not stage acp-adapters + .mjs sidecars" >&2
+    exit 1
+  fi
+
+  prune_acp_adapters "$dest_dir" "win32-$arch"
+
+  echo "  Installed: $dest_dir/ ($(du -sh "$dest_dir" | cut -f1))"
+
+  if [ -z "${COMPOSIO_FORK_PATH:-}" ]; then
+    rm -rf "$fork_dir"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Pre-flight: clean any stale artifacts so a re-run produces a known layout.
+# Removing the full bin dir is safe — every artifact in there is
+# reproducible from cli-deps.json.
+# ---------------------------------------------------------------------------
+rm -rf "$OUT_DIR/.staging" \
+       "$OUT_DIR/codex" "$OUT_DIR/codex.exe" \
+       "$OUT_DIR/composio-"* \
+       "$OUT_DIR/cli-deps.json"
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+case "$TARGET_OS" in
+  darwin)
+    for arch in "${ARCHES[@]}"; do
+      stage_codex_arch_darwin "$arch"
+      fetch_composio_arch_darwin "$arch"
+    done
+
+    if [ "${#ARCHES[@]}" -eq 2 ]; then
+      lipo_codex_universal_darwin
+    else
+      finalize_codex_single_arch_darwin "${ARCHES[0]}"
+    fi
+    ;;
+  windows)
+    for arch in "${ARCHES[@]}"; do
+      stage_codex_windows "$arch"
+      build_composio_windows "$arch"
+    done
+    ;;
+  *)
+    echo "ERROR: dispatch reached unknown target OS '$TARGET_OS'" >&2
+    exit 1 ;;
+esac
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
 echo "STAGE cli-deps.json (runtime claude-code install manifest)"
 stage_manifest
 
-# --- Summary --------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Summary + final sanity assertions
+# ---------------------------------------------------------------------------
 echo ""
 echo "Done. Bundled CLIs:"
 du -sh "$OUT_DIR"/* 2>/dev/null | sort -k2 || echo "  (none)"
 
-# Final sanity: every shippable artifact must exist.
 missing=()
-[ -x "$OUT_DIR/codex" ] || missing+=("codex")
-if [ "${#ARCHES[@]}" -eq 2 ]; then
-  [ -x "$OUT_DIR/composio-aarch64/composio" ] || missing+=("composio-aarch64/composio")
-  [ -x "$OUT_DIR/composio-x86_64/composio" ]  || missing+=("composio-x86_64/composio")
-fi
+case "$TARGET_OS" in
+  darwin)
+    [ -x "$OUT_DIR/codex" ] || missing+=("codex")
+    if [ "${#ARCHES[@]}" -eq 2 ]; then
+      [ -x "$OUT_DIR/composio-aarch64/composio" ] || missing+=("composio-aarch64/composio")
+      [ -x "$OUT_DIR/composio-x86_64/composio" ]  || missing+=("composio-x86_64/composio")
+    fi
+    ;;
+  windows)
+    [ -f "$OUT_DIR/codex.exe" ] || missing+=("codex.exe")
+    [ -f "$OUT_DIR/composio-x86_64/composio.exe" ] || missing+=("composio-x86_64/composio.exe")
+    [ -f "$OUT_DIR/composio-x86_64/run-helpers-runtime.mjs" ] || missing+=("composio-x86_64/run-helpers-runtime.mjs")
+    [ -f "$OUT_DIR/composio-x86_64/acp-adapters/codex/win32-x64/codex-acp.exe" ] || missing+=("composio-x86_64/acp-adapters/codex/win32-x64/codex-acp.exe")
+    ;;
+esac
 [ -f "$OUT_DIR/cli-deps.json" ] || missing+=("cli-deps.json")
 
 if [ "${#missing[@]}" -gt 0 ]; then


### PR DESCRIPTION
## Summary

Brings Houston to Windows x64. End-to-end: composio (built from source via a pinned fork at `gethouston/composio`), codex (downloaded from upstream), claude-code (runtime-installed), Tauri MSI bundle, in-app auto-updater. Tests on Mac runner are unchanged; Windows runner produces an MSI that, after merge, is one tag-push away from being available as a GitHub Release download.

## Why this PR

Three blockers stood between Houston and a Windows build, each with its own architecture answer:

1. **Composio doesn't ship a Windows binary** (upstream issue [#3057](https://github.com/ComposioHQ/composio/issues/3057), closed: "use WSL"). WSL is a non-starter for Houston's non-technical target user. Solution: a thin Houston-maintained fork at `gethouston/composio` that adds Windows targets to Bun's cross-compile map, win32 entries to the codex-acp adapter list, and a native `WindowsCredentialFFIStore` (via `bun:ffi` against `advapi32.dll`'s `Cred*` family) so login flows actually work. Patches will be PR'd upstream after we've shaken out runtime Windows-isms in production.
2. **Codex** ships native Windows binaries (`codex-x86_64-pc-windows-msvc.exe.zst`); we just need to download + zstd-decode + stage.
3. **Claude-code** also ships native Windows binaries (`win32-x64`, `win32-arm64`) per Anthropic's distribution manifest; the runtime installer learns to write to `%LOCALAPPDATA%\\Programs\\claude\\claude.exe`.

## What changed

### Bundle pipeline (`cli-deps.json`, `scripts/fetch-cli-deps.sh`)

- New `composio.build.windows-x64` block in `cli-deps.json` pinning the fork repo, branch, commit SHA, Bun version, and target (`bun-windows-x64-modern`). Strict-mode SHA verification at fetch time — drift fails the build.
- `scripts/fetch-cli-deps.sh windows-x64` mode: clones the pinned fork, verifies SHA, runs `pnpm install + pnpm exec tsdown + pnpm run build:binary:cross --target=bun-windows-x64-modern`, stages `composio.exe` + companion `.mjs` modules + `acp-adapters/codex/win32-x64/codex-acp.exe` under `app/src-tauri/resources/bin/composio-x86_64/`. Local-fork override via `COMPOSIO_FORK_PATH=...` env var for iterating on patches before pushing.
- Windows entries added for `claude-code`, `codex` URLs + checksums.

### Tauri (`tauri.conf.json`, `app/src-tauri/build.rs`)

- `bundle.targets += msi`. `bundle.windows.{wix,webviewInstallMode}` configured for embedded WebView2 bootstrapper (3MB; works offline on Windows 10/11).
- `bundle.externalBin` resolves the engine sidecar at `binaries/houston-engine-x86_64-pc-windows-msvc.exe` per Tauri Windows convention.
- `app/src-tauri/build.rs` stages the Windows engine sidecar from `target/x86_64-pc-windows-msvc/release/houston-engine.exe`.

### Engine (Rust)

- `houston-cli-bundle::host_platform_key()` returns `windows-x86_64` on Windows; resolver detects sibling `resources/bin/` layout next to the .exe.
- `houston-claude-installer` resolves Windows install path; uses `MoveFileExW` for atomic rename; reads `win32-x64`/`win32-arm64` keys from the manifest.
- `houston-composio::install` short-circuits the macOS `curl | bash` fallback on Windows (production always uses bundled).
- `houston-terminal-manager::claude_path` switches to OS-native PATH separator via `std::env::join_paths`.

### CI (`release.yml`)

- New `build-windows` job (`runs-on: windows-latest`) parallel to `build-macos`. Steps: checkout, pnpm install, Rust setup with `x86_64-pc-windows-msvc`, install Bun + jq + zstd via Chocolatey, build engine for the Windows triple, run `fetch-cli-deps.sh windows-x64` (clones fork, builds composio.exe, stages everything), run `pnpm tauri build --target x86_64-pc-windows-msvc`, locate MSI + `.msi.sig` under `target/x86_64-pc-windows-msvc/release/bundle/msi/`, upload both to draft release.
- Auto-updater wiring: after upload, the Windows job downloads the macOS-built `latest.json`, jq-merges in `windows-x86_64` entry pointing at the MSI URL + minisign signature, re-uploads with `--clobber`. Existing Houston-for-Windows users (once any exist) auto-update on next launch, same UX as macOS.

### Out of scope for v1 (deliberate)

- **Windows ARM64** — `cli-deps.json` schema supports it; just need a separate runner job. Add when there's demand.
- **NSIS installer** — MSI is the more enterprise-friendly format; NSIS can be added later if needed.
- **SignPath code-signing** — wired in a follow-up PR. Until then, MSI installs trigger SmartScreen warning (one extra confirmation click). The minisign signature for in-app auto-update IS present and verified — that's separate from OS code-signing.

## Test plan

- [x] `cargo check --workspace --exclude houston-app` clean on Mac
- [x] `cargo check --target x86_64-pc-windows-gnu -p houston-engine-server` clean (cross-check)
- [x] Composio fork live at `gethouston/composio:houston-windows-support`, pinned SHA `f51c0f2c` reachable
- [x] `./scripts/fetch-cli-deps.sh windows-x64` end-to-end on Mac (clones fork, builds `composio.exe`, stages bundle)
- [ ] Tag-push triggers `build-windows` in CI; produces signed-by-minisign MSI in draft release (verify after merge)
- [ ] Install MSI on real Windows 11 box; verify composio login works (Credential Manager backend); verify codex + claude work; verify in-app updater UI appears

## Docs

`knowledge-base/cli-bundling.md` and a new `knowledge-base/platform-matrix.md` capture the Windows-specific build pipeline, signing model, and what's deferred. `CLAUDE.md` test-commands table gets new rows for Windows checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)