### PR TITLE
fix(engine): spawn claude via absolute install path, not PATH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2411,11 +2411,11 @@ dependencies = [
 name = "houston-claude-installer"
 version = "0.4.6"
 dependencies = [
- "dirs 5.0.1",
  "futures-util",
  "hex",
  "houston-cli-bundle",
  "houston-db",
+ "houston-terminal-manager",
  "houston-ui-events",
  "reqwest 0.12.28",
  "serde",

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -106,6 +106,16 @@ export function classifyAnalyticsError(message: string): string {
   if (lower.includes("network") || lower.includes("fetch") || lower.includes("timeout")) return "network";
   if (lower.includes("permission") || lower.includes("denied")) return "permission";
   if (lower.includes("provider") || lower.includes("openai") || lower.includes("anthropic")) return "provider";
+  if (
+    lower.includes("unknown option") ||
+    lower.includes("enoent") ||
+    lower.includes("spawn") ||
+    lower.includes("not found") ||
+    lower.includes("claude hit a runtime error") ||
+    lower.includes("codex hit a runtime error")
+  ) {
+    return "cli";
+  }
   return "unknown";
 }
 

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -18,10 +18,15 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 sha2 = "0.10"
 hex = "0.4"
 futures-util = "0.3"
-dirs = "5"
 houston-cli-bundle = { workspace = true }
 houston-ui-events = { workspace = true }
 houston-db = { workspace = true }
+# Single source of truth for `cli_path` / `install_dir` / `is_installed`.
+# Lives in terminal-manager so the spawn-side code (`claude_path`,
+# `claude_runner`) and the install-side code (this crate) resolve the
+# exact same absolute path without forming a dependency cycle through
+# `houston-ui-events`.
+houston-terminal-manager = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/engine/houston-claude-installer/src/lib.rs
+++ b/engine/houston-claude-installer/src/lib.rs
@@ -48,6 +48,15 @@ use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use tokio::io::AsyncWriteExt;
 
+// Path-resolution functions live in `houston-terminal-manager` so the
+// spawn-side code (`claude_path`, `claude_runner`) shares one source of
+// truth with the install-side code below. Re-exported here for callers
+// that import from this crate (e.g. `routes/claude.rs`,
+// `provider/resolve.rs`).
+pub use houston_terminal_manager::claude_install_path::{
+    binary_name, cli_path, install_dir, is_installed,
+};
+
 /// Engine-DB preferences key holding the last successfully-installed
 /// claude-code version. Lifecycle compares it against the manifest's
 /// pinned version on every boot.
@@ -56,63 +65,6 @@ const PREF_INSTALLED_VERSION: &str = "claude_code_installed_version";
 /// CLI key inside `cli-deps.json`. Constant so we don't string-literal
 /// the same value across modules.
 const CLI_KEY: &str = "claude-code";
-
-/// Final install target. `claude --version` uses this exact path; the
-/// upstream installer drops there too, so users who already had Claude
-/// Code installed via `claude.ai/install.sh` get an automatic upgrade.
-pub fn cli_path() -> PathBuf {
-    install_dir().join(binary_name())
-}
-
-/// Directory `cli_path()` lives in. Created on demand by `install()`.
-pub fn install_dir() -> PathBuf {
-    #[cfg(unix)]
-    {
-        // `~/.local/bin` is on PATH for most users via the shells'
-        // default profile; the engine also force-adds it via
-        // `claude_path` so it's always discoverable.
-        dirs::home_dir().unwrap_or_default().join(".local").join("bin")
-    }
-    #[cfg(windows)]
-    {
-        // `%LOCALAPPDATA%\Programs\claude\` is the conventional
-        // Windows install location for per-user CLIs and matches the
-        // upstream PowerShell installer.
-        dirs::data_local_dir()
-            .unwrap_or_default()
-            .join("Programs")
-            .join("claude")
-    }
-}
-
-fn binary_name() -> &'static str {
-    if cfg!(windows) {
-        "claude.exe"
-    } else {
-        "claude"
-    }
-}
-
-/// True if the binary exists and is executable. Does not validate the
-/// version — that's the lifecycle's job.
-pub fn is_installed() -> bool {
-    let p = cli_path();
-    if !p.is_file() {
-        return false;
-    }
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        if let Ok(meta) = std::fs::metadata(&p) {
-            return meta.permissions().mode() & 0o111 != 0;
-        }
-        false
-    }
-    #[cfg(not(unix))]
-    {
-        true
-    }
-}
 
 /// Lifecycle entry — call once at engine startup as a background task.
 ///

--- a/engine/houston-terminal-manager/src/claude_install_path.rs
+++ b/engine/houston-terminal-manager/src/claude_install_path.rs
@@ -1,0 +1,77 @@
+//! Where Houston's runtime-installed `claude` binary lives on disk.
+//!
+//! Lives in `houston-terminal-manager` (not `houston-claude-installer`)
+//! so that both the installer and the spawn machinery (`claude_path`,
+//! `claude_runner`) can resolve the same absolute path without forming a
+//! dependency cycle through `houston-ui-events` (which depends on
+//! `houston-terminal-manager` for `FeedItem`).
+//!
+//! Why spawn the absolute path instead of `Command::new("claude")`? We
+//! pin a specific claude-code version in `cli-deps.json` and pass flags
+//! (`--include-partial-messages`, …) that only newer versions support.
+//! PATH lookup can hit an older `claude` from npm-global / homebrew /
+//! prior install, which then rejects the flag with
+//! `error: unknown option '--include-partial-messages'` and the session
+//! dies before producing any output.
+
+use std::path::PathBuf;
+
+/// Final install target. `claude --version` uses this exact path; the
+/// upstream installer drops there too, so users who already had Claude
+/// Code installed via `claude.ai/install.sh` get an automatic upgrade.
+pub fn cli_path() -> PathBuf {
+    install_dir().join(binary_name())
+}
+
+/// Directory `cli_path()` lives in. Created on demand by the installer.
+pub fn install_dir() -> PathBuf {
+    #[cfg(unix)]
+    {
+        // `~/.local/bin` is on PATH for most users via the shells'
+        // default profile; the engine also force-adds it via
+        // `claude_path` so it's always discoverable.
+        dirs::home_dir()
+            .unwrap_or_default()
+            .join(".local")
+            .join("bin")
+    }
+    #[cfg(windows)]
+    {
+        // `%LOCALAPPDATA%\Programs\claude\` is the conventional
+        // Windows install location for per-user CLIs and matches the
+        // upstream PowerShell installer.
+        dirs::data_local_dir()
+            .unwrap_or_default()
+            .join("Programs")
+            .join("claude")
+    }
+}
+
+pub fn binary_name() -> &'static str {
+    if cfg!(windows) {
+        "claude.exe"
+    } else {
+        "claude"
+    }
+}
+
+/// True if the binary exists and is executable. Does not validate the
+/// version — that's the installer lifecycle's job.
+pub fn is_installed() -> bool {
+    let p = cli_path();
+    if !p.is_file() {
+        return false;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = std::fs::metadata(&p) {
+            return meta.permissions().mode() & 0o111 != 0;
+        }
+        false
+    }
+    #[cfg(not(unix))]
+    {
+        true
+    }
+}

--- a/engine/houston-terminal-manager/src/claude_path.rs
+++ b/engine/houston-terminal-manager/src/claude_path.rs
@@ -71,6 +71,22 @@ pub fn init() {
             prepend_path(&mut final_path, &dir);
         }
 
+        // Runtime-installed claude-code lives at a known absolute path
+        // (`~/.local/bin/claude` on Unix,
+        // `%LOCALAPPDATA%\Programs\claude\claude.exe` on Windows). Prepend
+        // its directory so the version Houston pinned + downloaded wins
+        // over any older `claude` from npm-global / homebrew / nvm / a
+        // prior install that happens to sit earlier in the user's shell
+        // PATH. Without this prepend, an older `claude` rejects the
+        // `--include-partial-messages` flag and every session dies before
+        // producing output. (Direct spawn in `claude_runner` already uses
+        // the absolute path; this PATH precedence is defense in depth for
+        // any other code that resolves `claude` via PATH.)
+        let claude_install_dir = crate::claude_install_path::install_dir();
+        if claude_install_dir.is_dir() {
+            prepend_path(&mut final_path, &claude_install_dir);
+        }
+
         // Expand `~` against the user home directory using the cross-platform
         // `dirs` resolver (HOME on Unix, USERPROFILE on Windows). Falls back
         // to the raw prefix if home can't be resolved — the directory check

--- a/engine/houston-terminal-manager/src/claude_runner.rs
+++ b/engine/houston-terminal-manager/src/claude_runner.rs
@@ -1,9 +1,32 @@
 use super::types::{Provider, SessionStatus};
+use crate::claude_install_path;
 use crate::cli_process::{run_cli_process, CliRunOutcome};
 use crate::provider_error::MALFORMED_PROVIDER_JSON_MESSAGE;
 use crate::session_update::SessionUpdate;
+use std::ffi::OsString;
 use tokio::process::Command;
 use tokio::sync::mpsc;
+
+/// Absolute path to the Houston-managed `claude` if the runtime installer
+/// dropped it (`~/.local/bin/claude` on Unix,
+/// `%LOCALAPPDATA%\Programs\claude\claude.exe` on Windows). Falls back to
+/// the bare name `"claude"` (PATH lookup) only when the installer hasn't
+/// run yet, e.g. dev checkouts without `cli-deps.json`.
+///
+/// Spawning the absolute path matters: we pin a specific claude-code
+/// version in `cli-deps.json` and pass flags
+/// (`--include-partial-messages`, `--dangerously-skip-permissions`, ...)
+/// that only newer versions support. PATH lookup can hit an older
+/// `claude` from npm-global, homebrew, or a prior install, which then
+/// rejects the flag with `error: unknown option '--include-partial-messages'`
+/// and the session dies before producing any output.
+fn claude_command_name() -> OsString {
+    if claude_install_path::is_installed() {
+        claude_install_path::cli_path().into_os_string()
+    } else {
+        OsString::from("claude")
+    }
+}
 
 /// Spawn a Claude CLI session (`claude -p --output-format stream-json`).
 pub(crate) async fn spawn_claude(
@@ -33,7 +56,7 @@ pub(crate) async fn spawn_claude(
         }
     }
 
-    let mut cmd = Command::new("claude");
+    let mut cmd = Command::new(claude_command_name());
     configure_claude_command(
         &mut cmd,
         resume_session_id.as_deref(),
@@ -80,7 +103,7 @@ async fn retry_fresh(
     disable_builtin_tools: bool,
     disable_all_tools: bool,
 ) {
-    let mut fresh_cmd = Command::new("claude");
+    let mut fresh_cmd = Command::new(claude_command_name());
     configure_claude_command(
         &mut fresh_cmd,
         None,

--- a/engine/houston-terminal-manager/src/lib.rs
+++ b/engine/houston-terminal-manager/src/lib.rs
@@ -4,6 +4,7 @@
 //! concurrency control, and PATH resolution for AI CLI tools.
 
 pub mod auth_error;
+pub mod claude_install_path;
 pub mod claude_path;
 mod claude_runner;
 mod cli_process;


### PR DESCRIPTION
## Summary

Fixes the "app error" Jorge Solano (and likely other users with a stale `claude` on PATH) is hitting on every session start. Backend logs:

```
cli stderr: error: unknown option '--include-partial-messages'
[houston:stdout:claude] stream ended. 0 lines, 0 feed items
[session_runner] session error: "claude hit a runtime error"
```

Houston spawns `Command::new("claude")` and lets the OS resolve via PATH. If anything earlier on the user's PATH (npm-global, homebrew, prior install) is older than the flag's introduction, the spawn dies before any output. Frontend buckets it as `error_kind: "unknown"` so PostHog gives no signal.

## Changes

- **`engine/houston-terminal-manager/src/claude_runner.rs`** — both `Command::new("claude")` call sites now use `houston_claude_installer::cli_path()` (absolute), falling back to bare name only when the installer hasn't run yet (dev checkouts).
- **`engine/houston-terminal-manager/src/claude_path.rs`** — prepends Houston's install dir to the resolved login-shell PATH so the Houston-managed binary wins over any user copy. Defense in depth.
- **`engine/houston-terminal-manager/src/claude_install_path.rs`** (new) — owns `cli_path()` / `install_dir()` / `is_installed()` / `binary_name()`. Lives in terminal-manager so spawn-side + install-side share one source of truth without cycling through `houston-ui-events`.
- **`engine/houston-claude-installer/src/lib.rs`** — re-exports the moved functions from terminal-manager so external callers (`routes/claude.rs`, `provider/resolve.rs`) need no changes.
- **`app/src/lib/analytics.ts::classifyAnalyticsError`** — new `cli` bucket for `"unknown option"`, `"ENOENT"`, `"spawn"`, `"not found"`, `"claude/codex hit a runtime error"`. The bug we just hunted would have shown up as `error_kind: cli` instead of `unknown`.

## Test plan

- [x] `cargo test -p houston-terminal-manager -p houston-claude-installer` — 69 pass / 0 fail
- [x] `cargo build -p houston-engine-server` — green
- [x] `cd app && pnpm tsc --noEmit` — green
- [ ] Manual: install Houston with a stale `claude` on PATH (e.g. `npm i -g @anthropic-ai/claude-code@2.0.0`), confirm session no longer fails
- [ ] Manual: uninstall claude entirely, confirm Houston re-installs to `~/.local/bin/claude` and sessions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)