### PR TITLE
fix(ci): set GH_REPO on finalize job so gh works without checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -935,6 +935,14 @@ jobs:
     needs: [build-macos, build-windows]
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    # No `actions/checkout` step on this job — finalize doesn't need the
+    # source tree, just `gh` + `jq` + `curl`. Without a git remote,
+    # though, `gh` can't infer which repo it's operating on, so we set
+    # GH_REPO at the job level. Every `gh` invocation in the steps
+    # below picks it up automatically without each step having to pass
+    # `--repo`.
+    env:
+      GH_REPO: ${{ github.repository }}
     steps:
       - name: Download release-notes.md artifact
         uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

Hotfix for the v0.4.6 attempt: `prep`, `build-macos`, and `build-windows` all passed (parallelization confirmed!). But `finalize` failed at the first `gh release download` with:

```
failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The finalize job runs on a clean ubuntu runner without `actions/checkout`, so `gh` can't infer which repo to operate on. Adding `GH_REPO: ${{ github.repository }}` at the job level fixes every `gh` call in the steps without each one having to pass `--repo`. Cheaper than cloning the source tree just for the env.

## Affected

- `.github/workflows/release.yml` — 8 lines, job-level `env:` block on `finalize`.

## Test plan

- [x] `actionlint -shellcheck=` clean
- [ ] Retag v0.4.6, confirm finalize completes: `latest.json` extended with `windows-x86_64` entry, Slack message lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)