### PR TITLE
feat(onboarding): add Composio sign-in step and inline sign-in card

### DIFF
--- a/app/src-tauri/src/houston_prompt/integrations.rs
+++ b/app/src-tauri/src/houston_prompt/integrations.rs
@@ -8,6 +8,17 @@ Quick reference:\n\
 - `composio execute <TOOL_SLUG> --get-schema` - see required params\n\n\
 Search first, inspect the schema when needed, then execute only after the \
 interaction procedure says the task is ready.\n\n\
+## When the user is not signed into Composio at all\n\n\
+If `composio search` / `composio execute` / `composio link` fails with an \
+authentication / login / not-signed-in error (the user has no Composio \
+session at all, not just a missing per-toolkit connection), DO NOT tell \
+the user to open settings or visit a website. Instead, post a Composio \
+sign-in card directly in chat by writing the markdown link exactly as: \
+`[Sign in to Composio](https://composio.dev/#houston_composio_signin=1)`. \
+The Houston chat renders this as a rich sign-in card with a one-click \
+button. Then add ONE short line, e.g. \"I need you to sign into Composio \
+first so I can use your apps.\" Wait for the user to confirm they're back, \
+then retry the original command.\n\n\
 ## When an app is not connected\n\n\
 If `composio execute` fails because no account is linked for that \
 toolkit, DO NOT open the browser for the user and DO NOT tell them \

--- a/app/src/components/composio-signin-card.tsx
+++ b/app/src/components/composio-signin-card.tsx
@@ -1,0 +1,99 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Check, ExternalLink, Loader2 } from "lucide-react";
+import { useConnections, useResetConnections } from "../hooks/queries";
+import { useComposioAuth } from "../hooks/use-composio-auth";
+import { ComposioAuthDialog } from "./composio-auth-dialog";
+
+const COMPOSIO_LOGO =
+  "https://www.google.com/s2/favicons?domain=composio.dev&sz=128";
+
+/**
+ * Inline card the agent posts when its Composio call fails because the
+ * user isn't signed into Composio at all (no token, not just a missing
+ * per-toolkit connection). Mirrors `ComposioLinkCard` visually so the
+ * agent can hand the user a one-click sign-in directly in chat instead
+ * of telling them to "go to settings".
+ *
+ * Reflects live `useConnections()` state — flips to a green "Connected"
+ * pill the moment auth completes.
+ */
+export function ComposioSigninCard() {
+  const { t } = useTranslation("chat");
+  const { data: status } = useConnections();
+  const reset = useResetConnections();
+  const auth = useComposioAuth(() => reset());
+  const isSignedIn = status?.status === "ok";
+
+  const handleSignIn = useCallback(() => {
+    void auth.startAuth();
+  }, [auth]);
+
+  return (
+    <span className="not-prose inline-flex my-1 max-w-full align-middle">
+      <span className="inline-flex items-center gap-3 px-3 py-2.5 rounded-xl border border-black/5 bg-background min-w-0">
+        <img
+          src={COMPOSIO_LOGO}
+          alt="Composio"
+          className="size-8 rounded-lg object-contain shrink-0"
+        />
+        <span className="flex-1 min-w-0 flex flex-col">
+          <span className="text-[13px] font-medium text-foreground truncate">
+            {t("composioSignin.appName")}
+          </span>
+          <span className="text-[11px] text-muted-foreground truncate">
+            {isSignedIn
+              ? t("composioSignin.alreadySignedIn")
+              : t("composioSignin.description")}
+          </span>
+        </span>
+        {isSignedIn ? (
+          <span className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full bg-emerald-50 text-emerald-700 text-xs font-medium shrink-0">
+            <Check className="size-3" />
+            {t("composioSignin.signedIn")}
+          </span>
+        ) : (
+          <button
+            type="button"
+            onClick={handleSignIn}
+            disabled={auth.state.phase === "waiting"}
+            className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full border border-border bg-foreground text-background text-xs font-medium hover:opacity-90 transition-opacity duration-200 disabled:opacity-50 shrink-0"
+          >
+            {auth.state.phase === "waiting" ? (
+              <Loader2 className="size-3 animate-spin" />
+            ) : (
+              <>
+                {t("composioSignin.signIn")}
+                <ExternalLink className="size-3" />
+              </>
+            )}
+          </button>
+        )}
+      </span>
+      <ComposioAuthDialog
+        state={auth.state}
+        onClose={auth.close}
+        onReopenBrowser={auth.reopenBrowser}
+      />
+    </span>
+  );
+}
+
+/**
+ * Detects URLs the agent posts to request Composio account sign-in.
+ * Pattern: any URL with `#houston_composio_signin=1` (or just the
+ * marker present) in the hash fragment. Mirrors
+ * `parseComposioToolkitFromHref` so both card types share the same
+ * mental model.
+ */
+export function isComposioSigninHref(href: string): boolean {
+  try {
+    const url = new URL(href);
+    const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+    if (!hash) return false;
+    const params = new URLSearchParams(hash);
+    return params.has("houston_composio_signin");
+  } catch {
+    return false;
+  }
+}

--- a/app/src/components/onboarding/missions/tools.tsx
+++ b/app/src/components/onboarding/missions/tools.tsx
@@ -1,0 +1,105 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { Check, ExternalLink, Loader2 } from "lucide-react";
+import { Button, cn } from "@houston-ai/core";
+import {
+  useConnections,
+  useResetConnections,
+} from "../../../hooks/queries";
+import { useComposioAuth } from "../../../hooks/use-composio-auth";
+import { ComposioAuthDialog } from "../../composio-auth-dialog";
+
+const COMPOSIO_LOGO =
+  "https://www.google.com/s2/favicons?domain=composio.dev&sz=128";
+
+interface ToolsMissionProps {
+  onContinue: () => void;
+}
+
+/**
+ * M3 Tools — sign the user into Composio (the account-level token) so
+ * the assistant can call any toolkit later. Per-toolkit connections are
+ * still posted by the agent in M4 as connect cards. Continue is gated
+ * on `useConnections().status === "ok"`.
+ */
+export function ToolsMission({ onContinue }: ToolsMissionProps) {
+  const { t } = useTranslation("setup");
+  const { data: status, isLoading } = useConnections();
+  const reset = useResetConnections();
+  const auth = useComposioAuth(() => reset());
+  const isSignedIn = status?.status === "ok";
+
+  const handleSignIn = useCallback(() => {
+    void auth.startAuth();
+  }, [auth]);
+
+  return (
+    <div className="flex flex-1 flex-col gap-6">
+      <div
+        className={cn(
+          "flex items-center gap-4 rounded-xl border bg-background p-4 transition-colors",
+          isSignedIn ? "border-emerald-200" : "border-black/5",
+        )}
+      >
+        <img
+          src={COMPOSIO_LOGO}
+          alt="Composio"
+          className="size-10 rounded-lg object-contain shrink-0"
+        />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <p className="text-sm font-medium text-foreground">
+            {t("tutorial.missions.tools.cardTitle")}
+          </p>
+          <p className="text-xs text-muted-foreground">
+            {isSignedIn
+              ? t("tutorial.missions.tools.cardSignedInBody")
+              : t("tutorial.missions.tools.cardBody")}
+          </p>
+        </div>
+        {isLoading ? (
+          <Loader2 className="size-4 animate-spin text-muted-foreground" />
+        ) : isSignedIn ? (
+          <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700">
+            <Check className="size-3" />
+            {t("tutorial.missions.tools.signedInPill")}
+          </span>
+        ) : (
+          <Button
+            type="button"
+            size="sm"
+            className="rounded-full"
+            onClick={handleSignIn}
+            disabled={auth.state.phase === "waiting"}
+          >
+            {auth.state.phase === "waiting" ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              <ExternalLink className="size-3.5" />
+            )}
+            {t("tutorial.missions.tools.signIn")}
+          </Button>
+        )}
+      </div>
+      <div className="flex justify-end">
+        <Button
+          type="button"
+          className="rounded-full"
+          disabled={!isSignedIn}
+          onClick={onContinue}
+        >
+          {t("tutorial.missions.tools.continue")}
+        </Button>
+      </div>
+      {isSignedIn && (
+        <p className="text-xs text-muted-foreground">
+          {t("tutorial.missions.tools.continueHint")}
+        </p>
+      )}
+      <ComposioAuthDialog
+        state={auth.state}
+        onClose={auth.close}
+        onReopenBrowser={auth.reopenBrowser}
+      />
+    </div>
+  );
+}

--- a/app/src/components/onboarding/missions/try.tsx
+++ b/app/src/components/onboarding/missions/try.tsx
@@ -21,6 +21,10 @@ import {
   ComposioLinkCard,
   parseComposioToolkitFromHref,
 } from "../../composio-link-card";
+import {
+  ComposioSigninCard,
+  isComposioSigninHref,
+} from "../../composio-signin-card";
 import type { Agent } from "../../../lib/types";
 import type { MissionId } from "../personal-assistant-missions";
 import type { MissionMeta } from "../mission-frame";
@@ -157,6 +161,9 @@ export function TryMission({
 
   const renderLink = useCallback(
     ({ href, onOpen }: { href: string; onOpen: () => void }) => {
+      if (isComposioSigninHref(href)) {
+        return <ComposioSigninCard />;
+      }
       const toolkit = parseComposioToolkitFromHref(href);
       if (!toolkit) return undefined;
       return (

--- a/app/src/components/onboarding/personal-assistant-onboarding.tsx
+++ b/app/src/components/onboarding/personal-assistant-onboarding.tsx
@@ -10,6 +10,7 @@ import type { Agent } from "../../lib/types";
 import { MissionFrame } from "./mission-frame";
 import { MeetMission } from "./missions/meet";
 import { BrainMission } from "./missions/brain";
+import { ToolsMission } from "./missions/tools";
 import { TryMission } from "./missions/try";
 import { WelcomeScreen } from "./welcome-screen";
 import { createPersonalAssistantForWorkspace } from "./create-personal-assistant";
@@ -145,6 +146,7 @@ export function PersonalAssistantOnboarding({
           steps={[
             t("setup:tutorial.welcome.steps.meet"),
             t("setup:tutorial.welcome.steps.brain"),
+            t("setup:tutorial.welcome.steps.tools"),
             t("setup:tutorial.welcome.steps.try"),
           ]}
           startLabel={t("setup:tutorial.welcome.start")}
@@ -177,9 +179,14 @@ export function PersonalAssistantOnboarding({
             onContinue={async () => {
               if (!provider || !model) return;
               await createWorkspaceAndAssistant(provider, model);
-              setStep("try");
+              setStep("tools");
             }}
           />
+        </MissionFrame>
+      )}
+      {meta && frame && step === "tools" && (
+        <MissionFrame meta={meta} {...frame}>
+          <ToolsMission onContinue={() => setStep("try")} />
         </MissionFrame>
       )}
       {meta && frame && step === "try" && agent && (

--- a/app/src/components/onboarding/tutorial-copy.test.mjs
+++ b/app/src/components/onboarding/tutorial-copy.test.mjs
@@ -14,23 +14,23 @@ const t = (key, options) => {
   );
 };
 
-test("tutorial covers three mission stages in order", () => {
-  assert.deepEqual(TUTORIAL_STEPS, ["meet", "brain", "try"]);
+test("tutorial covers four mission stages in order", () => {
+  assert.deepEqual(TUTORIAL_STEPS, ["meet", "brain", "tools", "try"]);
 });
 
 test("mission meta exposes counter, title, body and the single next mission", () => {
   const meta = buildMissionMeta(t, "brain");
   assert.equal(meta.index, 1);
-  assert.equal(meta.total, 3);
+  assert.equal(meta.total, 4);
   assert.equal(meta.eyebrow, "setup:tutorial.eyebrow");
   assert.equal(meta.title, "setup:tutorial.missions.brain.title");
   assert.equal(meta.body, "setup:tutorial.missions.brain.body");
-  assert.equal(meta.nextTitle, "setup:tutorial.missions.try.title");
+  assert.equal(meta.nextTitle, "setup:tutorial.missions.tools.title");
 });
 
 test("final mission has no next mission", () => {
   const meta = buildMissionMeta(t, "try");
-  assert.equal(meta.index, 2);
+  assert.equal(meta.index, 3);
   assert.equal(meta.nextTitle, null);
 });
 

--- a/app/src/components/onboarding/tutorial-copy.ts
+++ b/app/src/components/onboarding/tutorial-copy.ts
@@ -7,11 +7,11 @@ import type { MissionMeta } from "./mission-frame";
  */
 export type OnboardingStep = "welcome" | TutorialStep;
 
-export type TutorialStep = "meet" | "brain" | "try";
+export type TutorialStep = "meet" | "brain" | "tools" | "try";
 
 type Translate = (key: string, options?: Record<string, unknown>) => string;
 
-export const TUTORIAL_STEPS: TutorialStep[] = ["meet", "brain", "try"];
+export const TUTORIAL_STEPS: TutorialStep[] = ["meet", "brain", "tools", "try"];
 
 export function buildMissionMeta(t: Translate, step: TutorialStep): MissionMeta {
   const index = TUTORIAL_STEPS.indexOf(step);

--- a/app/src/components/onboarding/tutorial-system-prompt.ts
+++ b/app/src/components/onboarding/tutorial-system-prompt.ts
@@ -22,9 +22,11 @@ This is the user's first time running you in Houston. Follow this exact pattern.
 
 2. Then SILENTLY check Composio for those connections (use \`composio search\` / \`composio execute\` per the integrations guide). Do NOT narrate the check to the user.
 
-3. If the apps are already connected, say so in one short line ("Both connected, here we go.") and continue to step 5.
+3. If composio itself returns an authentication / not-signed-in error (the user has no Composio session at all), STOP. Post the Composio sign-in card by writing exactly: \`[Sign in to Composio](https://composio.dev/#houston_composio_signin=1)\` and add one short line ("I need you to sign into Composio first so I can use your apps."). Wait for the user, then restart from step 2. Never fabricate results when you cannot reach Composio.
 
-4. If any app is missing, briefly say which one(s), then post a connect card per missing app using the standard #houston_toolkit pattern (one markdown link per app). Wait for the user to come back, then retry.
+4. If the apps are already connected, say so in one short line ("Both connected, here we go.") and continue to step 5.
+
+4b. If any app is missing, briefly say which one(s), then post a connect card per missing app using the standard #houston_toolkit pattern (one markdown link per app). Wait for the user to come back, then retry.
 
 5. Complete the task. Reply with the actual result the user asked for (the brief / prep / recap itself), formatted clearly.
 

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -58,6 +58,10 @@ import {
   ComposioLinkCard,
   parseComposioToolkitFromHref,
 } from "./composio-link-card";
+import {
+  ComposioSigninCard,
+  isComposioSigninHref,
+} from "./composio-signin-card";
 import { ChatModelSelector } from "./chat-model-selector";
 import { getDefaultModel } from "../lib/providers";
 import { analytics } from "../lib/analytics";
@@ -188,6 +192,9 @@ export function useAgentChatPanel({
   );
   const renderLink = useCallback(
     ({ href, onOpen }: { href: string; onOpen: () => void }) => {
+      if (isComposioSigninHref(href)) {
+        return <ComposioSigninCard />;
+      }
       const toolkit = parseComposioToolkitFromHref(href);
       if (!toolkit) return undefined;
       return (

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -38,6 +38,13 @@
     "connected": "Connected",
     "connect": "Connect"
   },
+  "composioSignin": {
+    "appName": "Composio",
+    "description": "Sign in to let your assistant use your apps",
+    "alreadySignedIn": "You're signed into Composio",
+    "signedIn": "Signed in",
+    "signIn": "Sign in"
+  },
   "modelSelector": {
     "selectModel": "Select model",
     "model": "Model",

--- a/app/src/locales/en/setup.json
+++ b/app/src/locales/en/setup.json
@@ -27,6 +27,7 @@
       "steps": {
         "meet": "Meet your assistant",
         "brain": "Connect an AI provider so it can think",
+        "tools": "Give it your own tools",
         "try": "Try a real mission with your assistant"
       },
       "start": "Start tutorial",
@@ -55,6 +56,17 @@
         "continue": "Create my assistant",
         "creating": "Creating",
         "continueHint": "Houston will create your assistant and open the next mission."
+      },
+      "tools": {
+        "title": "Give it your own tools",
+        "body": "Houston connects to Gmail, Calendar and 1000+ apps through Composio. Sign in once so your assistant can actually do work with your real apps.",
+        "cardTitle": "Composio",
+        "cardBody": "Sign in to let your assistant use your apps",
+        "cardSignedInBody": "Your assistant can now use your apps",
+        "signIn": "Sign in to Composio",
+        "signedInPill": "Signed in",
+        "continue": "Continue",
+        "continueHint": "Your assistant will ask for each app the first time it needs it."
       },
       "try": {
         "title": "Try a real mission",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -38,6 +38,13 @@
     "connected": "Conectado",
     "connect": "Conectar"
   },
+  "composioSignin": {
+    "appName": "Composio",
+    "description": "Inicia sesión para que tu asistente use tus apps",
+    "alreadySignedIn": "Ya iniciaste sesión en Composio",
+    "signedIn": "Conectado",
+    "signIn": "Iniciar sesión"
+  },
   "modelSelector": {
     "selectModel": "Elige un modelo",
     "model": "Modelo",

--- a/app/src/locales/es/setup.json
+++ b/app/src/locales/es/setup.json
@@ -27,6 +27,7 @@
       "steps": {
         "meet": "Conoce a tu asistente",
         "brain": "Conecta un proveedor de IA para que piense",
+        "tools": "Dale tus propias herramientas",
         "try": "Prueba una misión real con tu asistente"
       },
       "start": "Empezar tutorial",
@@ -55,6 +56,17 @@
         "continue": "Crear mi asistente",
         "creating": "Creando",
         "continueHint": "Houston creará tu asistente y abrirá la siguiente misión."
+      },
+      "tools": {
+        "title": "Dale tus propias herramientas",
+        "body": "Houston se conecta con Gmail, Calendar y más de 1000 apps a través de Composio. Inicia sesión una vez para que tu asistente pueda trabajar con tus apps reales.",
+        "cardTitle": "Composio",
+        "cardBody": "Inicia sesión para que tu asistente use tus apps",
+        "cardSignedInBody": "Tu asistente ya puede usar tus apps",
+        "signIn": "Iniciar sesión en Composio",
+        "signedInPill": "Conectado",
+        "continue": "Continuar",
+        "continueHint": "Tu asistente pedirá cada app la primera vez que la necesite."
       },
       "try": {
         "title": "Prueba una misión real",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -38,6 +38,13 @@
     "connected": "Conectado",
     "connect": "Conectar"
   },
+  "composioSignin": {
+    "appName": "Composio",
+    "description": "Entre para que seu assistente use seus apps",
+    "alreadySignedIn": "Você já está conectado ao Composio",
+    "signedIn": "Conectado",
+    "signIn": "Entrar"
+  },
   "modelSelector": {
     "selectModel": "Escolha um modelo",
     "model": "Modelo",

--- a/app/src/locales/pt/setup.json
+++ b/app/src/locales/pt/setup.json
@@ -27,6 +27,7 @@
       "steps": {
         "meet": "Conheça seu assistente",
         "brain": "Conecte um provedor de IA para ele pensar",
+        "tools": "Dê as suas próprias ferramentas",
         "try": "Teste uma missão real com seu assistente"
       },
       "start": "Começar tutorial",
@@ -55,6 +56,17 @@
         "continue": "Criar meu assistente",
         "creating": "Criando",
         "continueHint": "O Houston vai criar seu assistente e abrir a próxima missão."
+      },
+      "tools": {
+        "title": "Dê as suas próprias ferramentas",
+        "body": "O Houston se conecta ao Gmail, Calendar e mais de 1000 apps via Composio. Entre uma vez para seu assistente poder trabalhar com seus apps reais.",
+        "cardTitle": "Composio",
+        "cardBody": "Entre para seu assistente usar seus apps",
+        "cardSignedInBody": "Seu assistente já pode usar seus apps",
+        "signIn": "Entrar no Composio",
+        "signedInPill": "Conectado",
+        "continue": "Continuar",
+        "continueHint": "Seu assistente vai pedir cada app na primeira vez que precisar."
       },
       "try": {
         "title": "Teste uma missão real",


### PR DESCRIPTION
## Summary
- Add a new tutorial mission **M3 Tools** between Brain and Try; user signs into Composio before the AHA mission runs. Fixes the case where M3 (now M4 Try) started with no Composio session and the agent silently failed.
- New `ComposioSigninCard` mirrors the existing per-toolkit connect card. The agent posts the card directly in chat (any chat, not just tutorial) when a Composio call errors for lack of auth, instead of redirecting to settings.
- General agent prompt (`integrations.rs`) and tutorial system prompt updated to instruct the agent to emit the sign-in card when Composio itself is not authenticated. The previous per-toolkit cards path is preserved.
- Tutorial flow is now `meet → brain → tools → try` (4 missions). Locales updated in en/es/pt; tests updated to match.

## Test plan
- [ ] `pnpm tauri dev`, walk welcome → meet → brain → tools → try; confirm Continue on Tools is gated until Composio sign-in succeeds.
- [ ] In a regular workspace chat, force a Composio call without a Composio session; confirm the agent posts the sign-in card and it flips to "Signed in" after auth.
- [ ] Confirm agents still post per-toolkit connect cards (`#houston_toolkit=...`) for missing apps once Composio itself is signed in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)