### PR TITLE
feat(onboarding): Back button + walk through tabs in guided tour

### DIFF
--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -96,16 +96,22 @@ export function CreateAgentDialog() {
   const selectedDef = agentDefs.find((d) => d.config.id === selectedConfigId);
 
   return (
-    <Dialog open={open} onOpenChange={(o) => { if (!o) handleClose(); }}>
+    <Dialog
+      open={open}
+      onOpenChange={(o) => { if (!o) handleClose(); }}
+      // Modal mode applies pointer-events:none to everything outside the
+      // dialog. While the tour is on, that would block the tour's own
+      // Next/Back buttons (rendered outside DialogContent). Drop modality
+      // for the tour and let the tour's overlay own the focus instead.
+      modal={!uiTourActive}
+    >
       <DialogContent
         className="sm:max-w-[900px] h-[85vh] flex flex-col p-0 gap-0 overflow-hidden"
-        // While the guided tour is showing, the tour's Next button lives
-        // outside DialogContent — Radix would interpret that click as
-        // outside-dismiss, swallow it, and the user would have to click
-        // again. Block outside-dismiss for the tour's lifetime; the tour
-        // explicitly closes the dialog when it ends.
+        // Even with modal=false, Radix still calls outside-dismiss on
+        // pointer-down outside the content. Suppress while the tour is
+        // active so clicking the tour's Next button doesn't kill the
+        // dialog mid-step; the tour closes it explicitly on the outro.
         onPointerDownOutside={(e) => { if (uiTourActive) e.preventDefault(); }}
-        onInteractOutside={(e) => { if (uiTourActive) e.preventDefault(); }}
         onEscapeKeyDown={(e) => { if (uiTourActive) e.preventDefault(); }}
       >
         {step === 1 ? (

--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -20,6 +20,7 @@ export function CreateAgentDialog() {
   const { t } = useTranslation("shell");
   const open = useUIStore((s) => s.createAgentDialogOpen);
   const setOpen = useUIStore((s) => s.setCreateAgentDialogOpen);
+  const uiTourActive = useUIStore((s) => s.uiTourActive);
   const agentDefs = useAgentCatalogStore((s) => s.agents);
   const storeCatalog = useAgentCatalogStore((s) => s.storeCatalog);
   const installAgent = useAgentCatalogStore((s) => s.installAgent);
@@ -96,7 +97,17 @@ export function CreateAgentDialog() {
 
   return (
     <Dialog open={open} onOpenChange={(o) => { if (!o) handleClose(); }}>
-      <DialogContent className="sm:max-w-[900px] h-[85vh] flex flex-col p-0 gap-0 overflow-hidden">
+      <DialogContent
+        className="sm:max-w-[900px] h-[85vh] flex flex-col p-0 gap-0 overflow-hidden"
+        // While the guided tour is showing, the tour's Next button lives
+        // outside DialogContent — Radix would interpret that click as
+        // outside-dismiss, swallow it, and the user would have to click
+        // again. Block outside-dismiss for the tour's lifetime; the tour
+        // explicitly closes the dialog when it ends.
+        onPointerDownOutside={(e) => { if (uiTourActive) e.preventDefault(); }}
+        onInteractOutside={(e) => { if (uiTourActive) e.preventDefault(); }}
+        onEscapeKeyDown={(e) => { if (uiTourActive) e.preventDefault(); }}
+      >
         {step === 1 ? (
           <>
             <DialogHeader className="shrink-0 px-6 pt-6 pb-3">

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -146,6 +146,7 @@ export function Sidebar({ children }: { children: ReactNode }) {
         selectedId={!isTopLevel ? currentAgent?.id ?? null : null}
         onSelect={handleSelectAgent}
         onAdd={() => setDialogOpen(true)}
+        addItemDataAttrs={{ "data-tour-target": "newAgent" }}
         onRename={handleRename}
         onDelete={handleDelete}
         labels={{

--- a/app/src/components/shell/store-step.tsx
+++ b/app/src/components/shell/store-step.tsx
@@ -68,7 +68,10 @@ export function StoreStep({
         </div>
       </div>
 
-      <div className="flex-1 min-h-0 overflow-y-auto px-6 pb-6">
+      <div
+        data-tour-target="agentStore"
+        className="flex-1 min-h-0 overflow-y-auto px-6 pb-6"
+      >
         {totalResults > 0 ? (
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
             {filteredAgents.map((def) => (

--- a/app/src/components/shell/ui-tour.tsx
+++ b/app/src/components/shell/ui-tour.tsx
@@ -18,6 +18,15 @@ export interface UiTourStep {
    * user sees the destination, not just a spotlight on the trigger.
    */
   onEnter?: () => void;
+  /**
+   * Override automatic tooltip placement. `viewport-right`/`viewport-left`
+   * pin the card to the corresponding viewport edge instead of anchoring to
+   * the cutout. Useful when the cutout is huge (e.g. a modal interior) and
+   * a card next to it would still cover the content.
+   */
+  placement?: "below" | "above" | "right" | "left" | "viewport-right" | "viewport-left";
+  /** Override the confirm button label on this step (defaults to next/done). */
+  confirmLabel?: string;
 }
 
 interface UiTourProps {
@@ -124,6 +133,21 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
   // (sidebar) prefer left / right. Picks the first side with enough room,
   // falls back to whichever has the most space.
   const tooltip = (() => {
+    // Viewport-anchored placements ignore the cutout entirely. Used when the
+    // cutout is so big a cutout-relative card would still cover content
+    // (e.g. spotlighting the interior of a near-fullscreen dialog).
+    if (step.placement === "viewport-right") {
+      return {
+        top: Math.max(VIEWPORT_MARGIN, viewport.height / 2 - TOOLTIP_H_EST / 2),
+        left: viewport.width - TOOLTIP_W - VIEWPORT_MARGIN,
+      };
+    }
+    if (step.placement === "viewport-left") {
+      return {
+        top: Math.max(VIEWPORT_MARGIN, viewport.height / 2 - TOOLTIP_H_EST / 2),
+        left: VIEWPORT_MARGIN,
+      };
+    }
     if (!cutout) {
       return {
         top: viewport.height / 2 - 140,
@@ -163,6 +187,12 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
     }
 
     const placement: Placement =
+      (step.placement === "below" ||
+      step.placement === "above" ||
+      step.placement === "right" ||
+      step.placement === "left"
+        ? step.placement
+        : undefined) ??
       order.find((p) => fits[p]) ??
       (Object.entries(space).sort((a, b) => b[1] - a[1])[0][0] as Placement);
 
@@ -286,7 +316,7 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
                 isLast ? onDismiss() : setIndex(index + 1)
               }
             >
-              {isLast ? t("uiTour.done") : t("uiTour.next")}
+              {step.confirmLabel ?? (isLast ? t("uiTour.done") : t("uiTour.next"))}
             </Button>
           </div>
         </div>

--- a/app/src/components/shell/ui-tour.tsx
+++ b/app/src/components/shell/ui-tour.tsx
@@ -12,6 +12,12 @@ export interface UiTourStep {
   targetSelector?: string;
   /** Padding (px) around the target element for the spotlight cutout. */
   spotlightPadding?: number;
+  /**
+   * Side-effect to run when this step becomes active (forward or backward).
+   * Use to actually open the tab/section/dialog the step talks about so the
+   * user sees the destination, not just a spotlight on the trigger.
+   */
+  onEnter?: () => void;
 }
 
 interface UiTourProps {
@@ -61,14 +67,25 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
   // the cutout/tooltip render in the right place on the same paint as the
   // step transition (avoids a 1-frame flash at the old position).
   useLayoutEffect(() => {
+    step?.onEnter?.();
     if (!step?.targetSelector) {
       setRect(null);
       return;
     }
+    // The target may not be in the DOM yet if onEnter just switched views or
+    // opened a dialog. Retry a few frames until it appears.
+    let cancelled = false;
+    let raf = 0;
+    let tries = 0;
     const measure = () => {
+      if (cancelled) return;
       const el = document.querySelector(step.targetSelector!);
       if (!el) {
-        setRect(null);
+        if (tries++ < 30) {
+          raf = window.requestAnimationFrame(measure);
+        } else {
+          setRect(null);
+        }
         return;
       }
       const r = el.getBoundingClientRect();
@@ -80,11 +97,16 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
       measure();
     };
     window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    return () => {
+      cancelled = true;
+      if (raf) window.cancelAnimationFrame(raf);
+      window.removeEventListener("resize", onResize);
+    };
   }, [step]);
 
   if (!step) return null;
   const isLast = index === steps.length - 1;
+  const isFirst = index === 0;
 
   const pad = step.spotlightPadding ?? DEFAULT_PAD;
   const cutout = rect
@@ -236,8 +258,8 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
           {step.title}
         </h2>
         <p className="mt-2 text-sm text-muted-foreground">{step.body}</p>
-        <div className="mt-5 flex items-center justify-end gap-2">
-          {!isLast && (
+        <div className="mt-5 flex items-center justify-between gap-2">
+          {!isLast ? (
             <Button
               variant="ghost"
               className="rounded-full"
@@ -245,15 +267,28 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
             >
               {t("uiTour.skip")}
             </Button>
+          ) : (
+            <span />
           )}
-          <Button
-            className="rounded-full"
-            onClick={() =>
-              isLast ? onDismiss() : setIndex(index + 1)
-            }
-          >
-            {isLast ? t("uiTour.done") : t("uiTour.next")}
-          </Button>
+          <div className="flex items-center gap-2">
+            {!isFirst && (
+              <Button
+                variant="secondary"
+                className="rounded-full"
+                onClick={() => setIndex(index - 1)}
+              >
+                {t("uiTour.previous")}
+              </Button>
+            )}
+            <Button
+              className="rounded-full"
+              onClick={() =>
+                isLast ? onDismiss() : setIndex(index + 1)
+              }
+            >
+              {isLast ? t("uiTour.done") : t("uiTour.next")}
+            </Button>
+          </div>
         </div>
       </div>
     </>

--- a/app/src/components/shell/ui-tour.tsx
+++ b/app/src/components/shell/ui-tour.tsx
@@ -203,7 +203,7 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
       {cutout ? (
         <div
           aria-hidden
-          className="pointer-events-auto fixed z-50 rounded-xl ring-2 ring-white/70 transition-[top,left,width,height] duration-200"
+          className="pointer-events-auto fixed z-[60] rounded-xl ring-2 ring-white/70 transition-[top,left,width,height] duration-200"
           style={{
             top: cutout.top,
             left: cutout.left,
@@ -215,7 +215,7 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
       ) : (
         <div
           aria-hidden
-          className="pointer-events-auto fixed inset-0 z-50 bg-foreground/45"
+          className="pointer-events-auto fixed inset-0 z-[60] bg-foreground/45"
         />
       )}
 
@@ -224,7 +224,7 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
       {cutout && (
         <div
           aria-hidden
-          className="pointer-events-none fixed z-50 rounded-xl ring-2 ring-white/40 motion-safe:animate-pulse"
+          className="pointer-events-none fixed z-[60] rounded-xl ring-2 ring-white/40 motion-safe:animate-pulse"
           style={{
             top: cutout.top - 4,
             left: cutout.left - 4,
@@ -238,7 +238,7 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
           is no target. */}
       <div
         className={cn(
-          "fixed z-50 rounded-2xl border border-black/5 bg-background p-5 shadow-[0_10px_40px_rgba(0,0,0,0.18)]",
+          "fixed z-[60] rounded-2xl border border-black/5 bg-background p-5 shadow-[0_10px_40px_rgba(0,0,0,0.18)]",
         )}
         style={{
           top: tooltip.top,

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -60,6 +60,12 @@ export function WorkspaceShell({ toasts, onDismissToast }: WorkspaceShellProps) 
   const needsYouCount = (activities ?? []).filter((a) => a.status === "needs_you").length;
   const isAgentView =
     viewMode !== "dashboard" && viewMode !== "connections" && viewMode !== "settings";
+  const tabIds = new Set(tabs.map((tab) => tab.id));
+  const firstAgentTab = agentDef?.config.defaultTab ?? tabs[0]?.id ?? "activity";
+  // Map a desired tab id to one this agent actually has, falling back to its
+  // default. Keeps the tour from spotlighting an absent tab on agents that
+  // don't expose every built-in.
+  const tabOr = (id: string) => (tabIds.has(id) ? id : firstAgentTab);
 
   useEffect(() => {
     if (isAgentView && tabs.length > 0 && !tabs.some((tab) => tab.id === viewMode)) {
@@ -205,54 +211,86 @@ export function WorkspaceShell({ toasts, onDismissToast }: WorkspaceShellProps) 
               title: t("shell:uiTour.steps.assistant.title"),
               body: t("shell:uiTour.steps.assistant.body"),
               targetSelector: "[data-tour-target='agents']",
+              onEnter: () => setViewMode(firstAgentTab),
             },
             {
               title: t("shell:uiTour.steps.board.title"),
               body: t("shell:uiTour.steps.board.body"),
               targetSelector: "[data-tour-target='main']",
+              onEnter: () => setViewMode(firstAgentTab),
             },
             {
               title: t("shell:uiTour.steps.newMission.title"),
               body: t("shell:uiTour.steps.newMission.body"),
               targetSelector: "[data-tour-target='newMission']",
+              onEnter: () => setViewMode(firstAgentTab),
             },
             {
               title: t("shell:uiTour.steps.tabActivity.title"),
               body: t("shell:uiTour.steps.tabActivity.body"),
               targetSelector: "[data-tour-target='tab-activity']",
+              onEnter: () => setViewMode(tabOr("activity")),
             },
             {
               title: t("shell:uiTour.steps.tabRoutines.title"),
               body: t("shell:uiTour.steps.tabRoutines.body"),
               targetSelector: "[data-tour-target='tab-routines']",
+              onEnter: () => setViewMode(tabOr("routines")),
             },
             {
               title: t("shell:uiTour.steps.tabFiles.title"),
               body: t("shell:uiTour.steps.tabFiles.body"),
               targetSelector: "[data-tour-target='tab-files']",
+              onEnter: () => setViewMode(tabOr("files")),
             },
             {
               title: t("shell:uiTour.steps.tabJobDescription.title"),
               body: t("shell:uiTour.steps.tabJobDescription.body"),
               targetSelector: "[data-tour-target='tab-job-description']",
+              onEnter: () => setViewMode(tabOr("job-description")),
             },
             {
               title: t("shell:uiTour.steps.missionControl.title"),
               body: t("shell:uiTour.steps.missionControl.body"),
               targetSelector: "[data-tour-target='nav-dashboard']",
+              onEnter: () => setViewMode("dashboard"),
             },
             {
               title: t("shell:uiTour.steps.integrations.title"),
               body: t("shell:uiTour.steps.integrations.body"),
               targetSelector: "[data-tour-target='nav-connections']",
+              onEnter: () => setViewMode("connections"),
             },
             {
               title: t("shell:uiTour.steps.appTour.title"),
               body: t("shell:uiTour.steps.appTour.body"),
               targetSelector: "[data-tour-target='appTour']",
+              onEnter: () => {
+                setCreateAgentDialogOpen(false);
+                setViewMode(firstAgentTab);
+              },
+            },
+            {
+              title: t("shell:uiTour.steps.newAgent.title"),
+              body: t("shell:uiTour.steps.newAgent.body"),
+              targetSelector: "[data-tour-target='newAgent']",
+              onEnter: () => {
+                setCreateAgentDialogOpen(false);
+                setViewMode(firstAgentTab);
+              },
+            },
+            {
+              title: t("shell:uiTour.steps.agentStore.title"),
+              body: t("shell:uiTour.steps.agentStore.body"),
+              targetSelector: "[data-tour-target='agentStore']",
+              spotlightPadding: 4,
+              onEnter: () => setCreateAgentDialogOpen(true),
             },
           ]}
-          onDismiss={() => setUiTourActive(false)}
+          onDismiss={() => {
+            setUiTourActive(false);
+            setCreateAgentDialogOpen(false);
+          }}
         />
       )}
     </DetailPanelProvider>

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -284,7 +284,14 @@ export function WorkspaceShell({ toasts, onDismissToast }: WorkspaceShellProps) 
               body: t("shell:uiTour.steps.agentStore.body"),
               targetSelector: "[data-tour-target='agentStore']",
               spotlightPadding: 4,
+              placement: "viewport-right",
               onEnter: () => setCreateAgentDialogOpen(true),
+            },
+            {
+              title: t("shell:uiTour.steps.outro.title"),
+              body: t("shell:uiTour.steps.outro.body"),
+              confirmLabel: t("shell:uiTour.steps.outro.confirm"),
+              onEnter: () => setCreateAgentDialogOpen(false),
             },
           ]}
           onDismiss={() => {

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -43,6 +43,7 @@
   "uiTour": {
     "counter": "Tour {{current}} of {{total}}",
     "next": "Next",
+    "previous": "Back",
     "skip": "Skip tour",
     "done": "Got it",
     "steps": {
@@ -85,6 +86,14 @@
       "appTour": {
         "title": "Replay the tour",
         "body": "Forget how something works? Click this any time to run the tour again."
+      },
+      "newAgent": {
+        "title": "Add another agent",
+        "body": "You can spin up another agent here any time, or keep working with the one you have."
+      },
+      "agentStore": {
+        "title": "Pick where to start",
+        "body": "Choose Start from scratch for a blank agent, or pick one of ours from the store and tweak it to fit."
       }
     }
   },

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -94,6 +94,11 @@
       "agentStore": {
         "title": "Pick where to start",
         "body": "Choose Start from scratch for a blank agent, or pick one of ours from the store and tweak it to fit."
+      },
+      "outro": {
+        "title": "Now go build something amazing",
+        "body": "That's the whole tour. The rest is on you, have fun.",
+        "confirm": "I'll do something amazing"
       }
     }
   },

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -43,6 +43,7 @@
   "uiTour": {
     "counter": "Tour {{current}} de {{total}}",
     "next": "Siguiente",
+    "previous": "Atrás",
     "skip": "Saltar tour",
     "done": "Entendido",
     "steps": {
@@ -85,6 +86,14 @@
       "appTour": {
         "title": "Repite el tour",
         "body": "¿Olvidaste cómo funciona algo? Haz clic aquí cuando quieras para correr el tour de nuevo."
+      },
+      "newAgent": {
+        "title": "Agrega otro agente",
+        "body": "Puedes crear otro agente aquí cuando quieras, o seguir trabajando con el que ya tienes."
+      },
+      "agentStore": {
+        "title": "Elige por dónde empezar",
+        "body": "Elige Empezar desde cero para un agente en blanco, o toma uno de los nuestros desde la tienda y ajústalo a tu medida."
       }
     }
   },

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -94,6 +94,11 @@
       "agentStore": {
         "title": "Elige por dónde empezar",
         "body": "Elige Empezar desde cero para un agente en blanco, o toma uno de los nuestros desde la tienda y ajústalo a tu medida."
+      },
+      "outro": {
+        "title": "Ahora ve a construir algo increíble",
+        "body": "Ese es todo el tour. Lo demás depende de ti, diviértete.",
+        "confirm": "Voy a hacer algo increíble"
       }
     }
   },

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -43,6 +43,7 @@
   "uiTour": {
     "counter": "Tour {{current}} de {{total}}",
     "next": "Próximo",
+    "previous": "Voltar",
     "skip": "Pular tour",
     "done": "Entendi",
     "steps": {
@@ -85,6 +86,14 @@
       "appTour": {
         "title": "Repita o tour",
         "body": "Esqueceu como algo funciona? Clique aqui quando quiser para rodar o tour de novo."
+      },
+      "newAgent": {
+        "title": "Adicione outro agente",
+        "body": "Você pode criar outro agente aqui a qualquer momento, ou continuar com o que já tem."
+      },
+      "agentStore": {
+        "title": "Escolha por onde começar",
+        "body": "Escolha Começar do zero para um agente em branco, ou pegue um dos nossos na loja e ajuste do seu jeito."
       }
     }
   },

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -94,6 +94,11 @@
       "agentStore": {
         "title": "Escolha por onde começar",
         "body": "Escolha Começar do zero para um agente em branco, ou pegue um dos nossos na loja e ajuste do seu jeito."
+      },
+      "outro": {
+        "title": "Agora vai construir algo incrível",
+        "body": "Esse é o tour inteiro. O resto é com você, divirta-se.",
+        "confirm": "Vou fazer algo incrível"
       }
     }
   },

--- a/ui/layout/src/sidebar.tsx
+++ b/ui/layout/src/sidebar.tsx
@@ -40,6 +40,8 @@ export interface SidebarProps {
   selectedId?: string | null;
   onSelect: (id: string) => void;
   onAdd?: () => void;
+  /** Extra DOM attributes (e.g. `data-tour-target`) on the add-item button. */
+  addItemDataAttrs?: Record<string, string>;
   onDelete?: (id: string) => void;
   onRename?: (id: string, newName: string) => void;
   sectionLabel?: string;
@@ -69,6 +71,7 @@ export function AppSidebar({
   selectedId,
   onSelect,
   onAdd,
+  addItemDataAttrs,
   onDelete,
   onRename,
   sectionLabel,
@@ -180,6 +183,7 @@ export function AppSidebar({
                 aria-label={l.addItem}
                 onClick={onAdd}
                 className={sidebarClasses.addButton}
+                {...(addItemDataAttrs ?? {})}
               >
                 <span className={sidebarClasses.addButtonInner}>
                   <Plus className={sidebarClasses.addButtonIcon} />


### PR DESCRIPTION
## Summary
- Guided tour now has a **Back** button (hidden on the first step) so users can step backward without restarting.
- Each step now actually opens the tab/section it talks about (Activity, Routines, Files, Job Description, Mission Control, Integrations) instead of just spotlighting the trigger. Implemented as an optional ` + "`onEnter`" + ` side-effect on each ` + "`UiTourStep`" + `, fired on both Next and Back.
- Two new final steps:
  - **"Add another agent"** spotlights the ` + "`+`" + ` button in the sidebar.
  - **"Pick where to start"** opens the New Agent dialog and spotlights the store grid so users see Start from scratch + the curated agents.
- Dismissing or finishing the tour now also closes the New Agent dialog if it was opened by the tour.
- Spotlight measurement retries up to ~30 frames so it can wait for elements that mount after ` + "`onEnter`" + ` switches view or opens a dialog.
- Library boundary respected: ` + "`AppSidebar`" + ` got an ` + "`addItemDataAttrs`" + ` prop (mirrors existing ` + "`dataAttrs`" + ` pattern on nav items) so the app can tag the add button without ` + "`ui/`" + ` knowing about tours.
- en / es / pt locales updated (` + "`uiTour.previous`" + ` + ` + "`newAgent`" + ` + ` + "`agentStore`" + `). No em dashes, LATAM Spanish, BR Portuguese.

## Files
- ` + "`app/src/components/shell/ui-tour.tsx`" + ` — onEnter, Back button, retry measurement
- ` + "`app/src/components/shell/workspace-shell.tsx`" + ` — onEnter per step, two new final steps, dismiss closes dialog
- ` + "`app/src/components/shell/sidebar.tsx`" + ` — pass ` + "`addItemDataAttrs`" + `
- ` + "`app/src/components/shell/store-step.tsx`" + ` — ` + "`data-tour-target=\"agentStore\"`" + ` on the grid
- ` + "`ui/layout/src/sidebar.tsx`" + ` — new ` + "`addItemDataAttrs`" + ` prop
- ` + "`app/src/locales/{en,es,pt}/shell.json`" + ` — new keys

## Test plan
- [ ] ` + "`pnpm typecheck`" + ` (workspace) — clean
- [ ] ` + "`pnpm check-locales`" + ` — in sync
- [ ] Run ` + "`pnpm tauri dev`" + ` and walk the tour end to end
- [ ] Hit **Back** at every step, confirm view re-snaps to the matching tab/section
- [ ] Confirm "Add another agent" spotlights the sidebar ` + "`+`" + ` button
- [ ] Confirm "Pick where to start" opens the New Agent dialog with the agent grid spotlighted
- [ ] Confirm Skip / Got it close the dialog if it was open