### PR TITLE
feat(providers): show Gemini, SubQ, DeepSeek, MiniMax as coming soon

### DIFF
--- a/app/src/components/onboarding/missions/brain.tsx
+++ b/app/src/components/onboarding/missions/brain.tsx
@@ -10,7 +10,12 @@ import {
 } from "lucide-react";
 import { Button, cn } from "@houston-ai/core";
 import { tauriProvider, tauriSystem, type ProviderStatus } from "../../../lib/tauri";
-import { PROVIDERS, type ProviderInfo } from "../../../lib/providers";
+import {
+  PROVIDERS,
+  COMING_SOON_PROVIDERS,
+  type ProviderInfo,
+  type ComingSoonProviderInfo,
+} from "../../../lib/providers";
 
 interface BrainMissionProps {
   provider: string | null;
@@ -79,6 +84,9 @@ export function BrainMission({
             onRefresh={refresh}
             costLabel={prov.cost}
           />
+        ))}
+        {COMING_SOON_PROVIDERS.map((prov) => (
+          <ComingSoonCard key={prov.id} provider={prov} />
         ))}
       </div>
       <div className="flex justify-end">
@@ -175,6 +183,29 @@ function ProviderCard({
         </p>
       )}
     </button>
+  );
+}
+
+function ComingSoonCard({ provider }: { provider: ComingSoonProviderInfo }) {
+  const { t } = useTranslation("providers");
+  return (
+    <div
+      aria-disabled="true"
+      className={cn(
+        "flex w-full cursor-not-allowed flex-col gap-3 rounded-xl border bg-background/60 p-4 text-left",
+        "border-black/5 opacity-60 select-none",
+      )}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <p className="text-sm font-medium text-foreground">{provider.name}</p>
+          <p className="text-xs text-muted-foreground">{provider.subtitle}</p>
+        </div>
+        <span className="rounded-full bg-secondary px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+          {t("card.comingSoon")}
+        </span>
+      </div>
+    </div>
   );
 }
 

--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -11,7 +11,12 @@ import {
   Button,
 } from "@houston-ai/core";
 import { tauriProvider, tauriSystem, type ProviderStatus } from "../../lib/tauri";
-import { PROVIDERS, type ProviderInfo } from "../../lib/providers";
+import {
+  PROVIDERS,
+  COMING_SOON_PROVIDERS,
+  type ProviderInfo,
+  type ComingSoonProviderInfo,
+} from "../../lib/providers";
 import { analytics } from "../../lib/analytics";
 
 interface Props {
@@ -122,6 +127,9 @@ export function ProviderPicker({ value, model: controlledModel, onSelect }: Prop
             />
           );
         })}
+        {COMING_SOON_PROVIDERS.map((prov) => (
+          <ComingSoonCard key={prov.id} provider={prov} />
+        ))}
       </div>
 
       {/* Setup guidance — rendered below the grid when a disconnected card
@@ -336,6 +344,46 @@ function ProviderCard({
   );
 }
 
+function ComingSoonCard({ provider }: { provider: ComingSoonProviderInfo }) {
+  const { t } = useTranslation("providers");
+  return (
+    <div
+      aria-disabled="true"
+      className="relative rounded-xl p-5 flex flex-col items-center gap-3 cursor-not-allowed border border-black/[0.05] opacity-60 select-none"
+    >
+      <div className="h-10 w-10 flex items-center justify-center">
+        <ComingSoonLogo provider={provider} />
+      </div>
+      <div className="text-center">
+        <div className="text-sm font-medium text-foreground">{provider.name}</div>
+        <div className="text-xs text-muted-foreground mt-0.5">{provider.subtitle}</div>
+      </div>
+      <span className="rounded-full bg-secondary px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+        {t("card.comingSoon")}
+      </span>
+    </div>
+  );
+}
+
+function ComingSoonLogo({ provider }: { provider: ComingSoonProviderInfo }) {
+  switch (provider.id) {
+    case "gemini":
+      return <GeminiLogo />;
+    case "deepseek":
+      return <DeepSeekLogo />;
+    case "minimax":
+      return <MiniMaxLogo />;
+    default:
+      return (
+        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-secondary">
+          <span className="text-xs font-semibold tracking-tight text-foreground">
+            {provider.mark}
+          </span>
+        </div>
+      );
+  }
+}
+
 function SetupGuidance({
   provider,
   status,
@@ -478,6 +526,30 @@ function OpenAILogo() {
   return (
     <svg viewBox="0 0 24 24" className="h-8 w-8" fill="currentColor">
       <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.998 5.998 0 0 0-3.998 2.9 6.047 6.047 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
+    </svg>
+  );
+}
+
+function GeminiLogo() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-8 w-8" fill="currentColor">
+      <path d="M11.04 19.32Q12 21.51 12 24q0-2.49.93-4.68.96-2.19 2.58-3.81t3.81-2.55Q21.51 12 24 12q-2.49 0-4.68-.93a12.3 12.3 0 0 1-3.81-2.58 12.3 12.3 0 0 1-2.58-3.81Q12 2.49 12 0q0 2.49-.96 4.68-.93 2.19-2.55 3.81a12.3 12.3 0 0 1-3.81 2.58Q2.49 12 0 12q2.49 0 4.68.96 2.19.93 3.81 2.55t2.55 3.81" />
+    </svg>
+  );
+}
+
+function DeepSeekLogo() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-8 w-8" fill="currentColor">
+      <path d="M23.748 4.651c-.254-.124-.364.113-.512.233-.051.04-.094.09-.137.137-.372.397-.806.657-1.373.626-.829-.046-1.537.214-2.163.848-.133-.782-.575-1.248-1.247-1.548-.352-.155-.708-.311-.955-.65-.172-.24-.219-.509-.305-.774-.055-.16-.11-.323-.293-.35-.2-.031-.278.136-.356.276-.313.572-.434 1.202-.422 1.84.027 1.436.633 2.58 1.838 3.393.137.094.172.187.129.323-.082.28-.18.553-.266.833-.055.179-.137.218-.328.14a5.5 5.5 0 0 1-1.737-1.179c-.857-.828-1.631-1.743-2.597-2.46a12 12 0 0 0-.689-.47c-.985-.957.13-1.743.387-1.836.27-.098.094-.433-.778-.428-.872.003-1.67.295-2.687.685a3 3 0 0 1-.465.136 9.6 9.6 0 0 0-2.883-.101c-1.885.21-3.39 1.1-4.497 2.622C.082 8.776-.231 10.854.152 13.02c.403 2.284 1.568 4.175 3.36 5.653 1.857 1.533 3.997 2.284 6.438 2.14 1.482-.085 3.132-.284 4.994-1.86.47.234.962.328 1.78.398.629.058 1.235-.031 1.705-.129.735-.155.684-.836.418-.961-2.155-1.004-1.682-.595-2.112-.926 1.095-1.295 2.768-3.598 3.284-6.733.05-.346.115-.834.108-1.114-.004-.171.035-.238.23-.257a4.2 4.2 0 0 0 1.545-.475c1.397-.763 1.96-2.016 2.093-3.517.02-.23-.004-.467-.247-.588M11.58 18.168c-2.088-1.642-3.101-2.183-3.52-2.16-.39.024-.32.472-.234.763.09.288.207.487.371.74.114.167.192.416-.113.603-.673.416-1.842-.14-1.897-.168-1.361-.801-2.5-1.86-3.301-3.306-.775-1.393-1.225-2.888-1.299-4.482-.02-.385.094-.522.477-.592a4.7 4.7 0 0 1 1.53-.038c2.131.311 3.946 1.264 5.467 2.774.868.86 1.525 1.887 2.202 2.89.72 1.066 1.494 2.082 2.48 2.915.348.291.626.513.892.677-.802.09-2.14.109-3.055-.615zm1.001-6.44a.306.306 0 0 1 .415-.287.3.3 0 0 1 .113.074.3.3 0 0 1 .086.214c0 .17-.136.307-.308.307a.303.303 0 0 1-.306-.307m3.11 1.596c-.2.081-.4.151-.591.16a1.25 1.25 0 0 1-.798-.254c-.274-.23-.47-.358-.551-.758a1.7 1.7 0 0 1 .015-.588c.07-.327-.007-.537-.238-.727-.188-.156-.426-.199-.689-.199a.6.6 0 0 1-.254-.078.253.253 0 0 1-.114-.358 1 1 0 0 1 .192-.21c.356-.202.767-.136 1.146.016.352.144.618.408 1.001.782.392.451.462.576.685.915.176.264.336.536.446.848.066.194-.02.353-.25.45" />
+    </svg>
+  );
+}
+
+function MiniMaxLogo() {
+  return (
+    <svg viewBox="0 0 24 24" className="h-8 w-8" fill="currentColor">
+      <path d="M11.43 3.92a.86.86 0 1 0-1.718 0v14.236a1.999 1.999 0 0 1-3.997 0V9.022a.86.86 0 1 0-1.718 0v3.87a1.999 1.999 0 0 1-3.997 0V11.49a.57.57 0 0 1 1.139 0v1.404a.86.86 0 0 0 1.719 0V9.022a1.999 1.999 0 0 1 3.997 0v9.134a.86.86 0 0 0 1.719 0V3.92a1.998 1.998 0 1 1 3.996 0v11.788a.57.57 0 1 1-1.139 0zm10.572 3.105a2 2 0 0 0-1.999 1.997v7.63a.86.86 0 0 1-1.718 0V3.923a1.999 1.999 0 0 0-3.997 0v16.16a.86.86 0 0 1-1.719 0V18.08a.57.57 0 1 0-1.138 0v2a1.998 1.998 0 0 0 3.996 0V3.92a.86.86 0 0 1 1.719 0v12.73a1.999 1.999 0 0 0 3.996 0V9.023a.86.86 0 1 1 1.72 0v6.686a.57.57 0 0 0 1.138 0V9.022a2 2 0 0 0-1.998-1.997" />
     </svg>
   );
 }

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -63,3 +63,17 @@ export function getModel(providerId: string, modelId: string): ModelOption | und
 export function getDefaultModel(providerId: string): string {
   return getProvider(providerId)?.defaultModel ?? "sonnet";
 }
+
+export interface ComingSoonProviderInfo {
+  readonly id: string;
+  readonly name: string;
+  readonly subtitle: string;
+  readonly mark: string;
+}
+
+export const COMING_SOON_PROVIDERS: readonly ComingSoonProviderInfo[] = [
+  { id: "gemini", name: "Google", subtitle: "Gemini CLI", mark: "G" },
+  { id: "subq", name: "SubQ", subtitle: "SubQ Code", mark: "SQ" },
+  { id: "deepseek", name: "DeepSeek", subtitle: "DeepSeek Coder", mark: "DS" },
+  { id: "minimax", name: "MiniMax", subtitle: "M2", mark: "MM" },
+] as const;

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -7,7 +7,8 @@
     "modelDropdownLabel": "Model",
     "signOut": "Sign out",
     "signingOut": "Signing out...",
-    "signOutError": "Couldn't sign out of {{provider}}"
+    "signOutError": "Couldn't sign out of {{provider}}",
+    "comingSoon": "Coming soon"
   },
   "setup": {
     "headline": "Set up {{provider}}",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -7,7 +7,8 @@
     "modelDropdownLabel": "Modelo",
     "signOut": "Cerrar sesión",
     "signingOut": "Cerrando sesión...",
-    "signOutError": "No se pudo cerrar sesión de {{provider}}"
+    "signOutError": "No se pudo cerrar sesión de {{provider}}",
+    "comingSoon": "Próximamente"
   },
   "setup": {
     "headline": "Configurar {{provider}}",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -7,7 +7,8 @@
     "modelDropdownLabel": "Modelo",
     "signOut": "Sair",
     "signingOut": "Saindo...",
-    "signOutError": "Não foi possível sair de {{provider}}"
+    "signOutError": "Não foi possível sair de {{provider}}",
+    "comingSoon": "Em breve"
   },
   "setup": {
     "headline": "Configurar {{provider}}",


### PR DESCRIPTION
## Summary
- Adds 4 non-clickable "Coming soon" provider cards (Google/Gemini CLI, SubQ/SubQ Code, DeepSeek/DeepSeek Coder, MiniMax/M2) alongside the existing OpenAI and Anthropic cards
- Surfaces them in two places: the onboarding brain mission and the settings provider picker
- Renders real brand SVGs for Gemini, DeepSeek, and MiniMax (sourced from simple-icons); SubQ uses a styled "SQ" monogram since the brand is text-only
- Coming-soon entries live in a separate \`COMING_SOON_PROVIDERS\` list so \`chat-model-selector\` and \`naming-step\` keep iterating only real providers

## Files
- \`app/src/lib/providers.ts\` — new \`COMING_SOON_PROVIDERS\` constant + \`ComingSoonProviderInfo\` type
- \`app/src/components/onboarding/missions/brain.tsx\` — render disabled cards in tutorial grid
- \`app/src/components/shell/provider-picker.tsx\` — render disabled cards + brand SVG components in settings grid
- \`app/src/locales/{en,es,pt}/providers.json\` — \`card.comingSoon\` string

## Test plan
- [x] \`pnpm tsc --noEmit\` passes
- [x] \`pnpm check-locales\` passes (es and pt in sync, no em dashes)
- [ ] Visual: open onboarding tutorial, brain mission shows 6 cards with 4 muted "Coming soon" entries
- [ ] Visual: Settings, AI provider section shows 6 cards with 4 muted "Coming soon" entries; brand logos render correctly for Gemini/DeepSeek/MiniMax

🤖 Generated with [Claude Code](https://claude.com/claude-code)