### PR TITLE
feat(ui): anonymize Composio as integrations provider

### DIFF
--- a/app/src/components/composio-signin-card.tsx
+++ b/app/src/components/composio-signin-card.tsx
@@ -34,7 +34,7 @@ export function ComposioSigninCard() {
       <span className="inline-flex items-center gap-3 px-3 py-2.5 rounded-xl border border-black/5 bg-background min-w-0">
         <img
           src={COMPOSIO_LOGO}
-          alt="Composio"
+          alt={t("composioSignin.appName")}
           className="size-8 rounded-lg object-contain shrink-0"
         />
         <span className="flex-1 min-w-0 flex flex-col">

--- a/app/src/components/onboarding/missions/tools.tsx
+++ b/app/src/components/onboarding/missions/tools.tsx
@@ -9,9 +9,6 @@ import {
 import { useComposioAuth } from "../../../hooks/use-composio-auth";
 import { ComposioAuthDialog } from "../../composio-auth-dialog";
 
-const COMPOSIO_LOGO =
-  "https://www.google.com/s2/favicons?domain=composio.dev&sz=128";
-
 interface ToolsMissionProps {
   onContinue: () => void;
 }
@@ -41,11 +38,6 @@ export function ToolsMission({ onContinue }: ToolsMissionProps) {
           isSignedIn ? "border-emerald-200" : "border-black/5",
         )}
       >
-        <img
-          src={COMPOSIO_LOGO}
-          alt="Composio"
-          className="size-10 rounded-lg object-contain shrink-0"
-        />
         <div className="flex min-w-0 flex-1 flex-col">
           <p className="text-sm font-medium text-foreground">
             {t("tutorial.missions.tools.cardTitle")}

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -33,15 +33,15 @@
     }
   },
   "composio": {
-    "integration": "Composio integration",
+    "integration": "App integration",
     "alreadyConnected": "Already connected",
     "connected": "Connected",
     "connect": "Connect"
   },
   "composioSignin": {
-    "appName": "Composio",
-    "description": "Sign in to let your assistant use your apps",
-    "alreadySignedIn": "You're signed into Composio",
+    "appName": "Integrations provider",
+    "description": "Sign in to let your assistant use your apps. Default provider: Composio.",
+    "alreadySignedIn": "You're signed in to your integrations provider",
     "signedIn": "Signed in",
     "signIn": "Sign in"
   },

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -2,29 +2,29 @@
   "title": "Integrations",
   "loading": {
     "title": "Loading your integrations",
-    "body": "Checking Composio state…"
+    "body": "Checking your integrations provider…"
   },
   "notInstalled": {
     "title": "Connect your apps",
-    "body": "Houston uses the Composio CLI to let your agent use Gmail, Slack, Google Drive, and 100+ other services on your behalf. One-time install, about 80 MB.",
-    "install": "Install Composio",
+    "body": "Houston uses an integrations provider to let your agent use Gmail, Slack, Google Drive, and 100+ other services on your behalf. The default provider is Composio. One-time install, about 80 MB.",
+    "install": "Install provider",
     "installing": "Installing…"
   },
   "needsAuth": {
-    "title": "Connect to Composio",
-    "body": "Sign in to Composio so your agent can use Gmail, Slack, Google Drive, and 100+ other services on your behalf.",
-    "signIn": "Sign in to Composio"
+    "title": "Connect your integrations provider",
+    "body": "Sign in to your integrations provider so your agent can use Gmail, Slack, Google Drive, and 100+ other services on your behalf. We use Composio by default.",
+    "signIn": "Sign in"
   },
   "error": {
     "title": "Couldn't load integrations",
     "retry": "Retry",
-    "openDashboard": "Open Composio dashboard"
+    "openDashboard": "Open provider dashboard"
   },
   "connected": {
     "title": "Connected",
     "count_one": "{{count}} app",
     "count_other": "{{count}} apps",
-    "manageOn": "Manage {{name}} on Composio",
+    "manageOn": "Manage {{name}}",
     "dotAria": "Connected"
   },
   "browse": {
@@ -38,13 +38,13 @@
     "connectTitle": "Connect {{name}}"
   },
   "authDialog": {
-    "title": "Connecting to Composio",
+    "title": "Connecting your integrations provider",
     "description": "Complete the sign-in in your browser, then return here.",
     "waiting": "Waiting for you to approve in the browser…",
     "openInBrowser": "Open link in browser"
   },
   "linkCard": {
-    "integration": "Composio integration",
+    "integration": "App integration",
     "alreadyConnected": "Already connected",
     "connected": "Connected",
     "connect": "Connect"

--- a/app/src/locales/en/setup.json
+++ b/app/src/locales/en/setup.json
@@ -59,11 +59,11 @@
       },
       "tools": {
         "title": "Give it your own tools",
-        "body": "Houston connects to Gmail, Calendar and 1000+ apps through Composio. Sign in once so your assistant can actually do work with your real apps.",
-        "cardTitle": "Composio",
-        "cardBody": "Sign in to let your assistant use your apps",
+        "body": "Houston connects to Gmail, Calendar and 1000+ apps through your integrations provider. We use Composio by default. Sign in once so your assistant can actually do work with your real apps.",
+        "cardTitle": "Integrations provider",
+        "cardBody": "Sign in to let your assistant use your apps. Default provider: Composio.",
         "cardSignedInBody": "Your assistant can now use your apps",
-        "signIn": "Sign in to Composio",
+        "signIn": "Sign in",
         "signedInPill": "Signed in",
         "continue": "Continue",
         "continueHint": "Your assistant will ask for each app the first time it needs it."

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -33,15 +33,15 @@
     }
   },
   "composio": {
-    "integration": "Integración de Composio",
+    "integration": "Integración de app",
     "alreadyConnected": "Ya está conectado",
     "connected": "Conectado",
     "connect": "Conectar"
   },
   "composioSignin": {
-    "appName": "Composio",
-    "description": "Inicia sesión para que tu asistente use tus apps",
-    "alreadySignedIn": "Ya iniciaste sesión en Composio",
+    "appName": "Proveedor de integraciones",
+    "description": "Inicia sesión para que tu asistente use tus apps. Proveedor por defecto: Composio.",
+    "alreadySignedIn": "Ya iniciaste sesión en tu proveedor de integraciones",
     "signedIn": "Conectado",
     "signIn": "Iniciar sesión"
   },

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -2,29 +2,29 @@
   "title": "Integraciones",
   "loading": {
     "title": "Cargando tus integraciones",
-    "body": "Verificando el estado de Composio…"
+    "body": "Verificando tu proveedor de integraciones…"
   },
   "notInstalled": {
     "title": "Conecta tus apps",
-    "body": "Houston usa la herramienta de Composio para que tu agente pueda usar Gmail, Slack, Google Drive y más de 100 servicios por ti. Se instala una sola vez y pesa unos 80 MB.",
-    "install": "Instalar Composio",
+    "body": "Houston usa un proveedor de integraciones para que tu agente pueda usar Gmail, Slack, Google Drive y más de 100 servicios por ti. El proveedor por defecto es Composio. Se instala una sola vez y pesa unos 80 MB.",
+    "install": "Instalar proveedor",
     "installing": "Instalando…"
   },
   "needsAuth": {
-    "title": "Conéctate a Composio",
-    "body": "Inicia sesión en Composio para que tu agente pueda usar Gmail, Slack, Google Drive y más de 100 servicios por ti.",
-    "signIn": "Iniciar sesión en Composio"
+    "title": "Conecta tu proveedor de integraciones",
+    "body": "Inicia sesión en tu proveedor de integraciones para que tu agente pueda usar Gmail, Slack, Google Drive y más de 100 servicios por ti. Por defecto usamos Composio.",
+    "signIn": "Iniciar sesión"
   },
   "error": {
     "title": "No se pudieron cargar las integraciones",
     "retry": "Reintentar",
-    "openDashboard": "Abrir el panel de Composio"
+    "openDashboard": "Abrir el panel del proveedor"
   },
   "connected": {
     "title": "Conectadas",
     "count_one": "{{count}} app",
     "count_other": "{{count}} apps",
-    "manageOn": "Gestionar {{name}} en Composio",
+    "manageOn": "Gestionar {{name}}",
     "dotAria": "Conectado"
   },
   "browse": {
@@ -38,13 +38,13 @@
     "connectTitle": "Conectar {{name}}"
   },
   "authDialog": {
-    "title": "Conectando con Composio",
+    "title": "Conectando tu proveedor de integraciones",
     "description": "Completa el inicio de sesión en tu navegador y vuelve aquí.",
     "waiting": "Esperando tu aprobación en el navegador…",
     "openInBrowser": "Abrir enlace en el navegador"
   },
   "linkCard": {
-    "integration": "Integración de Composio",
+    "integration": "Integración de app",
     "alreadyConnected": "Ya está conectado",
     "connected": "Conectado",
     "connect": "Conectar"

--- a/app/src/locales/es/setup.json
+++ b/app/src/locales/es/setup.json
@@ -59,11 +59,11 @@
       },
       "tools": {
         "title": "Dale tus propias herramientas",
-        "body": "Houston se conecta con Gmail, Calendar y más de 1000 apps a través de Composio. Inicia sesión una vez para que tu asistente pueda trabajar con tus apps reales.",
-        "cardTitle": "Composio",
-        "cardBody": "Inicia sesión para que tu asistente use tus apps",
+        "body": "Houston se conecta con Gmail, Calendar y más de 1000 apps a través de tu proveedor de integraciones. Por defecto usamos Composio. Inicia sesión una vez para que tu asistente pueda trabajar con tus apps reales.",
+        "cardTitle": "Proveedor de integraciones",
+        "cardBody": "Inicia sesión para que tu asistente use tus apps. Proveedor por defecto: Composio.",
         "cardSignedInBody": "Tu asistente ya puede usar tus apps",
-        "signIn": "Iniciar sesión en Composio",
+        "signIn": "Iniciar sesión",
         "signedInPill": "Conectado",
         "continue": "Continuar",
         "continueHint": "Tu asistente pedirá cada app la primera vez que la necesite."

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -33,15 +33,15 @@
     }
   },
   "composio": {
-    "integration": "Integração do Composio",
+    "integration": "Integração de app",
     "alreadyConnected": "Já conectado",
     "connected": "Conectado",
     "connect": "Conectar"
   },
   "composioSignin": {
-    "appName": "Composio",
-    "description": "Entre para que seu assistente use seus apps",
-    "alreadySignedIn": "Você já está conectado ao Composio",
+    "appName": "Provedor de integrações",
+    "description": "Entre para seu assistente usar seus apps. Provedor padrão: Composio.",
+    "alreadySignedIn": "Você já está conectado ao seu provedor de integrações",
     "signedIn": "Conectado",
     "signIn": "Entrar"
   },

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -2,29 +2,29 @@
   "title": "Integrações",
   "loading": {
     "title": "Carregando suas integrações",
-    "body": "Verificando o estado do Composio…"
+    "body": "Verificando seu provedor de integrações…"
   },
   "notInstalled": {
     "title": "Conecte seus apps",
-    "body": "O Houston usa a ferramenta do Composio para deixar seu agente usar Gmail, Slack, Google Drive e mais de 100 serviços por você. Instalação única, cerca de 80 MB.",
-    "install": "Instalar o Composio",
+    "body": "O Houston usa um provedor de integrações para deixar seu agente usar Gmail, Slack, Google Drive e mais de 100 serviços por você. O provedor padrão é o Composio. Instalação única, cerca de 80 MB.",
+    "install": "Instalar provedor",
     "installing": "Instalando…"
   },
   "needsAuth": {
-    "title": "Conecte-se ao Composio",
-    "body": "Entre no Composio para seu agente poder usar Gmail, Slack, Google Drive e mais de 100 serviços por você.",
-    "signIn": "Entrar no Composio"
+    "title": "Conecte seu provedor de integrações",
+    "body": "Entre no seu provedor de integrações para seu agente poder usar Gmail, Slack, Google Drive e mais de 100 serviços por você. Por padrão usamos o Composio.",
+    "signIn": "Entrar"
   },
   "error": {
     "title": "Não foi possível carregar as integrações",
     "retry": "Tentar de novo",
-    "openDashboard": "Abrir o painel do Composio"
+    "openDashboard": "Abrir o painel do provedor"
   },
   "connected": {
     "title": "Conectados",
     "count_one": "{{count}} app",
     "count_other": "{{count}} apps",
-    "manageOn": "Gerenciar {{name}} no Composio",
+    "manageOn": "Gerenciar {{name}}",
     "dotAria": "Conectado"
   },
   "browse": {
@@ -38,13 +38,13 @@
     "connectTitle": "Conectar {{name}}"
   },
   "authDialog": {
-    "title": "Conectando ao Composio",
+    "title": "Conectando seu provedor de integrações",
     "description": "Conclua o login no navegador e volte para cá.",
     "waiting": "Aguardando sua aprovação no navegador…",
     "openInBrowser": "Abrir link no navegador"
   },
   "linkCard": {
-    "integration": "Integração do Composio",
+    "integration": "Integração de app",
     "alreadyConnected": "Já conectado",
     "connected": "Conectado",
     "connect": "Conectar"

--- a/app/src/locales/pt/setup.json
+++ b/app/src/locales/pt/setup.json
@@ -59,11 +59,11 @@
       },
       "tools": {
         "title": "Dê as suas próprias ferramentas",
-        "body": "O Houston se conecta ao Gmail, Calendar e mais de 1000 apps via Composio. Entre uma vez para seu assistente poder trabalhar com seus apps reais.",
-        "cardTitle": "Composio",
-        "cardBody": "Entre para seu assistente usar seus apps",
+        "body": "O Houston se conecta ao Gmail, Calendar e mais de 1000 apps através do seu provedor de integrações. Por padrão usamos o Composio. Entre uma vez para seu assistente poder trabalhar com seus apps reais.",
+        "cardTitle": "Provedor de integrações",
+        "cardBody": "Entre para seu assistente usar seus apps. Provedor padrão: Composio.",
         "cardSignedInBody": "Seu assistente já pode usar seus apps",
-        "signIn": "Entrar no Composio",
+        "signIn": "Entrar",
         "signedInPill": "Conectado",
         "continue": "Continuar",
         "continueHint": "Seu assistente vai pedir cada app na primeira vez que precisar."


### PR DESCRIPTION
## Summary
- User-facing copy in the integrations tab, onboarding M3 tools mission, and inline chat sign-in/connect cards now reads "integrations provider"; Composio is mentioned only as "default provider".
- Removed the Composio favicon from the tutorial sign-in card.
- Backend, engine routes, agent system prompts, hook/component identifiers, and CLI bundling are untouched (agents still call Composio exactly as before).

## Affected files
- \`app/src/locales/{en,es,pt}/integrations.json\`
- \`app/src/locales/{en,es,pt}/setup.json\` (tutorial M3 tools mission)
- \`app/src/locales/{en,es,pt}/chat.json\` (inline composio + composioSignin cards)
- \`app/src/components/composio-signin-card.tsx\` (alt text via t())
- \`app/src/components/onboarding/missions/tools.tsx\` (alt text via t(), logo removed)

## Test plan
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm check-locales\` reports all 15 namespaces in sync across en/es/pt
- [ ] Visual: open Integrations tab and the tutorial M3 step in all three locales
- [ ] Visual: verify inline chat connect/sign-in cards still render with new copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)