### PR TITLE
feat(composio): bulletproof connect-card refresh + manual recovery

### DIFF
--- a/app/src/components/composio-link-card.tsx
+++ b/app/src/components/composio-link-card.tsx
@@ -1,8 +1,28 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { Check, ExternalLink, Loader2 } from "lucide-react";
+import { useQueryClient } from "@tanstack/react-query";
+import { Check, ExternalLink, Loader2, RefreshCw } from "lucide-react";
 import { useComposioApps } from "../hooks/queries";
+import { useComposioConnectionWatcher } from "../hooks/use-composio-connection-watcher";
 import { useComposioRefetchOnReturn } from "../hooks/use-composio-refetch-on-return";
+import {
+  normalizeToolkitSlug,
+  normalizeToolkitSlugs,
+} from "../lib/composio-toolkits";
+import { queryKeys } from "../lib/query-keys";
+import { useUIStore } from "../stores/ui";
+
+/**
+ * After clicking Connect, the user goes to the browser to authorize.
+ * This is how long we leave the spinner up before flipping to a
+ * manual "I've connected" button. Short enough that a stuck card
+ * recovers quickly; long enough to cover the typical OAuth round-trip
+ * + Composio backend propagation when the engine-side watcher catches
+ * the event for us.
+ */
+const OPENING_GRACE_MS = 6_000;
+
+type Phase = "idle" | "opening" | "verify" | "verifying";
 
 interface ComposioLinkCardProps {
   toolkit: string;
@@ -40,14 +60,40 @@ export function ComposioLinkCard({
   onOpen,
 }: ComposioLinkCardProps) {
   const { t } = useTranslation("chat");
-  const [opening, setOpening] = useState(false);
+  const [phase, setPhase] = useState<Phase>("idle");
+  const graceTimer = useRef<number | null>(null);
+  const qc = useQueryClient();
+  const addToast = useUIStore((s) => s.addToast);
   const { data: apiApps } = useComposioApps();
   const markWaitingForAuth = useComposioRefetchOnReturn();
+  // Ambient freshness: while the card shows "not connected", keep the
+  // connectedToolkits query honest so the card flips the instant a
+  // connection lands via any path (this Connect, Integrations tab,
+  // another agent, CLI, stale cache from a prior session).
+  useComposioConnectionWatcher(isConnected);
 
-  // When the probe comes back connected, clear the local spinner.
+  // Once the probe comes back connected, drop any local intermediate
+  // state — the parent owns the visual now.
   useEffect(() => {
-    if (isConnected) setOpening(false);
+    if (isConnected) {
+      setPhase("idle");
+      if (graceTimer.current !== null) {
+        window.clearTimeout(graceTimer.current);
+        graceTimer.current = null;
+      }
+    }
   }, [isConnected]);
+
+  // Always clean up the grace timer on unmount so it never fires
+  // against a dead component.
+  useEffect(() => {
+    return () => {
+      if (graceTimer.current !== null) {
+        window.clearTimeout(graceTimer.current);
+        graceTimer.current = null;
+      }
+    };
+  }, []);
 
   const app = (() => {
     const fromApi = apiApps?.find((a) => a.toolkit === toolkit);
@@ -68,15 +114,107 @@ export function ComposioLinkCard({
   })();
 
   const handleConnect = useCallback(() => {
-    setOpening(true);
+    setPhase("opening");
     markWaitingForAuth(toolkit);
     onOpen();
-    // Safety net: if the user never returns focus and never completes
-    // auth (closes the browser tab), clear the spinner after 90s so
-    // the button becomes clickable again. The polling loop in
-    // `useComposioRefetchOnReturn` stops itself at 60s.
-    window.setTimeout(() => setOpening(false), 90_000);
+    // After the grace window, hand control to the user. The engine
+    // watcher and the ambient connection watcher are both still
+    // running; if a connection lands while we're in `verify` state,
+    // the parent's `isConnected` will flip and the effect above
+    // resets the phase.
+    if (graceTimer.current !== null) window.clearTimeout(graceTimer.current);
+    graceTimer.current = window.setTimeout(() => {
+      setPhase((p) => (p === "opening" ? "verify" : p));
+      graceTimer.current = null;
+    }, OPENING_GRACE_MS);
   }, [onOpen, markWaitingForAuth, toolkit]);
+
+  const handleVerify = useCallback(async () => {
+    setPhase("verifying");
+    // Hard refresh: cancel anything in flight so a stale "[]" can't
+    // race past us, force the registered query to refetch, then read
+    // the freshly-written cache. We don't trust the cached
+    // `isConnected` prop here — the user explicitly asked us to
+    // re-check.
+    await qc.cancelQueries({ queryKey: queryKeys.connectedToolkits() });
+    await qc.refetchQueries({
+      queryKey: queryKeys.connectedToolkits(),
+      type: "active",
+    });
+    const target = normalizeToolkitSlug(toolkit);
+    const fresh = normalizeToolkitSlugs(
+      qc.getQueryData<string[]>(queryKeys.connectedToolkits()) ?? [],
+    );
+    const connected = fresh.includes(target);
+    if (connected) {
+      addToast({
+        title: t("composio.verifiedToast", { name: app.name }),
+        variant: "success",
+      });
+      // Parent's isConnected will flip on the next render; effect
+      // above resets phase to idle.
+    } else {
+      addToast({
+        title: t("composio.notVerified"),
+        variant: "info",
+      });
+      setPhase("verify");
+    }
+  }, [qc, toolkit, addToast, t, app.name]);
+
+  const renderRightSlot = () => {
+    if (isConnected) {
+      return (
+        <span className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full bg-emerald-50 text-emerald-700 text-xs font-medium shrink-0">
+          <Check className="size-3" />
+          {t("composio.connected")}
+        </span>
+      );
+    }
+    if (phase === "opening") {
+      return (
+        <button
+          type="button"
+          disabled
+          className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full border border-border bg-foreground text-background text-xs font-medium opacity-50 shrink-0"
+        >
+          <Loader2 className="size-3 animate-spin" />
+        </button>
+      );
+    }
+    if (phase === "verify" || phase === "verifying") {
+      return (
+        <button
+          type="button"
+          onClick={phase === "verifying" ? undefined : handleVerify}
+          disabled={phase === "verifying"}
+          className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full border border-border bg-secondary text-foreground text-xs font-medium hover:bg-black/[0.05] transition-colors duration-200 disabled:opacity-50 shrink-0"
+        >
+          {phase === "verifying" ? (
+            <>
+              <Loader2 className="size-3 animate-spin" />
+              {t("composio.verifying")}
+            </>
+          ) : (
+            <>
+              <RefreshCw className="size-3" />
+              {t("composio.verify")}
+            </>
+          )}
+        </button>
+      );
+    }
+    return (
+      <button
+        type="button"
+        onClick={handleConnect}
+        className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full border border-border bg-foreground text-background text-xs font-medium hover:opacity-90 transition-opacity duration-200 shrink-0"
+      >
+        {t("composio.connect")}
+        <ExternalLink className="size-3" />
+      </button>
+    );
+  };
 
   return (
     <span className="not-prose inline-flex my-1 max-w-full align-middle">
@@ -90,28 +228,7 @@ export function ComposioLinkCard({
             {isConnected ? t("composio.alreadyConnected") : app.description}
           </span>
         </span>
-        {isConnected ? (
-          <span className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full bg-emerald-50 text-emerald-700 text-xs font-medium shrink-0">
-            <Check className="size-3" />
-            {t("composio.connected")}
-          </span>
-        ) : (
-          <button
-            type="button"
-            onClick={handleConnect}
-            disabled={opening}
-            className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full border border-border bg-foreground text-background text-xs font-medium hover:opacity-90 transition-opacity duration-200 disabled:opacity-50 shrink-0"
-          >
-            {opening ? (
-              <Loader2 className="size-3 animate-spin" />
-            ) : (
-              <>
-                {t("composio.connect")}
-                <ExternalLink className="size-3" />
-              </>
-            )}
-          </button>
-        )}
+        {renderRightSlot()}
       </span>
     </span>
   );

--- a/app/src/hooks/use-agent-invalidation.ts
+++ b/app/src/hooks/use-agent-invalidation.ts
@@ -60,6 +60,11 @@ export function useAgentInvalidation() {
           qc.invalidateQueries({ queryKey: queryKeys.composioApps() });
           qc.invalidateQueries({ queryKey: queryKeys.connectedToolkits() });
           break;
+        // Engine-side watcher saw a toolkit land in the consumer
+        // connections list — flip every visible Composio card.
+        case "ComposioConnectionAdded":
+          qc.invalidateQueries({ queryKey: queryKeys.connectedToolkits() });
+          break;
       }
     });
 

--- a/app/src/hooks/use-composio-connection-watcher.ts
+++ b/app/src/hooks/use-composio-connection-watcher.ts
@@ -1,0 +1,52 @@
+import { useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "../lib/query-keys";
+
+const HEARTBEAT_MS = 10_000;
+
+/**
+ * Keeps the `connectedToolkits` query fresh while a Composio card is
+ * showing "not connected", so the card flips to "Connected" the moment
+ * the connection appears regardless of where it was made (this card's
+ * Connect button, the Integrations tab, another agent, the CLI, or a
+ * prior session whose cache is now stale).
+ *
+ * Mechanics:
+ *   - Invalidate immediately on mount / on transition to not-connected.
+ *   - Invalidate on window focus and on tab visibility return.
+ *   - Heartbeat invalidate every 10s while the document is visible.
+ *   - Stops fully once `isConnected` flips true (or on unmount).
+ *
+ * TanStack dedupes the underlying fetch across observers, so N visible
+ * not-connected cards still produce 1 in-flight request per tick.
+ */
+export function useComposioConnectionWatcher(isConnected: boolean): void {
+  const qc = useQueryClient();
+
+  useEffect(() => {
+    if (isConnected) return;
+
+    const invalidate = () => {
+      qc.invalidateQueries({ queryKey: queryKeys.connectedToolkits() });
+    };
+
+    invalidate();
+
+    const onFocus = () => invalidate();
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") invalidate();
+    };
+    window.addEventListener("focus", onFocus);
+    document.addEventListener("visibilitychange", onVisibility);
+
+    const heartbeat = window.setInterval(() => {
+      if (document.visibilityState === "visible") invalidate();
+    }, HEARTBEAT_MS);
+
+    return () => {
+      window.removeEventListener("focus", onFocus);
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.clearInterval(heartbeat);
+    };
+  }, [isConnected, qc]);
+}

--- a/app/src/hooks/use-composio-refetch-on-return.ts
+++ b/app/src/hooks/use-composio-refetch-on-return.ts
@@ -13,9 +13,18 @@ import {
  * by opening a browser (Integrations tab Connect button, inline
  * `ComposioLinkCard` in chat, etc.).
  *
- * `markWaitingForAuth(slug)` kicks off a ~60s poll loop that checks
- * `composio connections list` every 4s until the slug appears in the
- * result, then invalidates the shared query so every surface updates.
+ * `markWaitingForAuth(slug)` does two things:
+ *
+ *   1. Asks the engine to start a server-side watch on this toolkit.
+ *      The engine polls Composio's consumer connections endpoint for
+ *      up to 5 minutes and emits `ComposioConnectionAdded` over WS
+ *      when the slug appears. That event invalidates the shared
+ *      `connectedToolkits` query so every visible card flips at
+ *      once. Push-based, no UI lifecycle dependencies.
+ *
+ *   2. Runs a short client-side polling loop (~60s) as defense in
+ *      depth — survives engine restarts mid-OAuth and covers the
+ *      brief window before the engine watch is registered.
  */
 export function useComposioRefetchOnReturn(): (slug: string) => void {
   const qc = useQueryClient();
@@ -49,6 +58,17 @@ export function useComposioRefetchOnReturn(): (slug: string) => void {
     (slug: string) => {
       const targetSlug = normalizeToolkitSlug(slug);
       if (!targetSlug) return;
+
+      // Push-path: ask the engine to watch. Fires
+      // `ComposioConnectionAdded` over WS when the connection lands.
+      // Idempotent server-side, so duplicate calls (chat card +
+      // integrations tab racing on the same toolkit) collapse into
+      // one watch.
+      void tauriConnections.watchConnection(targetSlug).catch(() => {
+        // Engine watch is best-effort. The pull-path below covers the
+        // failure case.
+      });
+
       if (pollersRef.current.has(targetSlug)) return;
 
       waitingRef.current.add(targetSlug);

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -338,6 +338,17 @@ export const tauriConnections = {
         toolkit: r.toolkit,
       };
     }),
+  watchConnection: (toolkit: string) =>
+    call<void>(
+      "watch_composio_connection",
+      () => getEngine().composioWatchConnection(toolkit),
+      { toolkit },
+      // Fire-and-forget — caller awaits only to know the request was
+      // accepted; the result is delivered as a `ComposioConnectionAdded`
+      // WS event. Don't toast; failure here just means we fall back to
+      // the client-side watcher.
+      { toast: false },
+    ),
   startOAuth: () =>
     call<StartLoginResponse>("start_composio_oauth", async () => {
       const r = await getEngine().composioStartLogin();

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -36,7 +36,11 @@
     "integration": "Composio integration",
     "alreadyConnected": "Already connected",
     "connected": "Connected",
-    "connect": "Connect"
+    "connect": "Connect",
+    "verify": "I've connected",
+    "verifying": "Checking...",
+    "notVerified": "Couldn't verify yet, try again",
+    "verifiedToast": "{{name}} is connected"
   },
   "composioSignin": {
     "appName": "Composio",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -36,7 +36,11 @@
     "integration": "Integración de Composio",
     "alreadyConnected": "Ya está conectado",
     "connected": "Conectado",
-    "connect": "Conectar"
+    "connect": "Conectar",
+    "verify": "Ya me conecté",
+    "verifying": "Comprobando...",
+    "notVerified": "Aún no podemos verificar, intenta de nuevo",
+    "verifiedToast": "{{name}} está conectado"
   },
   "composioSignin": {
     "appName": "Composio",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -36,7 +36,11 @@
     "integration": "Integração do Composio",
     "alreadyConnected": "Já conectado",
     "connected": "Conectado",
-    "connect": "Conectar"
+    "connect": "Conectar",
+    "verify": "Já me conectei",
+    "verifying": "Verificando...",
+    "notVerified": "Ainda não consigo verificar, tente de novo",
+    "verifiedToast": "{{name}} está conectado"
   },
   "composioSignin": {
     "appName": "Composio",

--- a/engine/houston-composio/src/cli.rs
+++ b/engine/houston-composio/src/cli.rs
@@ -425,6 +425,11 @@ pub async fn list_connected_toolkits() -> Vec<String> {
     match list_connected_toolkits_inner().await {
         Ok(mut slugs) => {
             slugs.sort();
+            tracing::info!(
+                "[composio] connected_toolkits returned {} slugs: {:?}",
+                slugs.len(),
+                slugs
+            );
             slugs
         }
         Err(e) => {

--- a/engine/houston-composio/src/connection_watcher.rs
+++ b/engine/houston-composio/src/connection_watcher.rs
@@ -1,0 +1,181 @@
+//! Per-toolkit connection watcher — engine-side push for OAuth landings.
+//!
+//! When the user clicks "Connect" in the inline chat card or the
+//! Integrations tab, the frontend asks the engine to watch for a
+//! specific toolkit slug. This module polls
+//! `cli::list_connected_toolkits` (which hits Composio's consumer
+//! REST endpoint) on a tight cadence and emits
+//! `HoustonEvent::ComposioConnectionAdded` exactly once when the
+//! toolkit appears, then exits.
+//!
+//! Why engine-side, not pure frontend polling:
+//!   - No browser lifecycle quirks (focus, visibility, tab switch,
+//!     component remount). The watcher runs in a tokio task that
+//!     doesn't care if the user is in the OAuth tab, on the dock, or
+//!     looking at a different agent.
+//!   - Composio's `connected_toolkits` endpoint exhibits propagation
+//!     lag after authorization. The watcher retries for several
+//!     minutes, far longer than any frontend polling loop tied to a
+//!     visible card would survive.
+//!   - Single in-flight request per toolkit globally (not per visible
+//!     card), so 5 cards for the same slug = 1 request stream.
+//!
+//! Lifecycle: spawn-and-forget. The task self-terminates on success
+//! (toolkit appeared), on idle deadline (`MAX_LIFETIME`), or when
+//! `cancel` is called.
+
+use crate::cli;
+use crate::toolkits::{normalize_toolkit_slug, normalize_toolkit_slugs};
+use houston_ui_events::{DynEventSink, HoustonEvent};
+use std::collections::HashMap;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+use tokio::task::AbortHandle;
+
+/// First-tick delay. The OAuth completion redirect happens nearly
+/// instantly, but Composio's consumer endpoint takes a few seconds to
+/// reflect it. Starting too eager just wastes calls; this gives the
+/// backend a head start.
+const FIRST_DELAY: Duration = Duration::from_secs(2);
+
+/// Steady-state poll interval. Tight enough that the card flips
+/// within ~2s of the connection landing; loose enough that 5 minutes
+/// of misses is only ~150 requests, well within Composio's rate
+/// limits.
+const POLL_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Hard cap on how long a single watch runs before giving up.
+/// Longer than any reasonable OAuth flow (browser auth, MFA, account
+/// switch, etc.). The frontend separately surfaces a manual recovery
+/// path when this expires without a hit.
+const MAX_LIFETIME: Duration = Duration::from_secs(5 * 60);
+
+struct WatcherRegistry {
+    handles: HashMap<String, AbortHandle>,
+}
+
+fn registry() -> &'static Mutex<WatcherRegistry> {
+    static REGISTRY: OnceLock<Mutex<WatcherRegistry>> = OnceLock::new();
+    REGISTRY.get_or_init(|| {
+        Mutex::new(WatcherRegistry {
+            handles: HashMap::new(),
+        })
+    })
+}
+
+/// Start watching for `toolkit` to appear in the consumer connections
+/// list. Idempotent: if a watch for the same normalized slug is
+/// already running, this is a no-op.
+///
+/// Emits `HoustonEvent::ComposioConnectionAdded { toolkit }` on
+/// success. Silently exits on timeout — the frontend has its own
+/// fallback UX after the deadline.
+pub fn watch(toolkit: &str, sink: DynEventSink) {
+    let normalized = normalize_toolkit_slug(toolkit);
+    if normalized.is_empty() {
+        return;
+    }
+
+    {
+        let reg = registry().lock().expect("watcher registry poisoned");
+        if reg.handles.contains_key(&normalized) {
+            tracing::debug!(
+                "[composio:watch] {} already being watched — skipping",
+                normalized
+            );
+            return;
+        }
+    }
+
+    let slug = normalized.clone();
+    let handle = tokio::spawn(async move {
+        run_watch(slug, sink).await;
+    });
+
+    let abort_handle = handle.abort_handle();
+    {
+        let mut reg = registry().lock().expect("watcher registry poisoned");
+        reg.handles.insert(normalized, abort_handle);
+    }
+}
+
+/// Best-effort cancel. Used when the engine knows a watch is no
+/// longer needed (e.g., a sign-out clears all state). The watch will
+/// also self-cancel on `MAX_LIFETIME`, so callers don't strictly need
+/// this.
+pub fn cancel(toolkit: &str) {
+    let normalized = normalize_toolkit_slug(toolkit);
+    if normalized.is_empty() {
+        return;
+    }
+    let mut reg = registry().lock().expect("watcher registry poisoned");
+    if let Some(handle) = reg.handles.remove(&normalized) {
+        handle.abort();
+    }
+}
+
+async fn run_watch(slug: String, sink: DynEventSink) {
+    let started = Instant::now();
+    tokio::time::sleep(FIRST_DELAY).await;
+
+    loop {
+        if started.elapsed() >= MAX_LIFETIME {
+            tracing::info!(
+                "[composio:watch] {} timed out after {:?} without appearing in consumer list",
+                slug,
+                MAX_LIFETIME
+            );
+            break;
+        }
+
+        let connected = normalize_toolkit_slugs(cli::list_connected_toolkits().await);
+        if connected.iter().any(|s| s == &slug) {
+            tracing::info!("[composio:watch] {} connection landed — emitting event", slug);
+            sink.emit(HoustonEvent::ComposioConnectionAdded {
+                toolkit: slug.clone(),
+            });
+            break;
+        }
+
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+
+    let mut reg = registry().lock().expect("watcher registry poisoned");
+    reg.handles.remove(&slug);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use houston_ui_events::BroadcastEventSink;
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn empty_slug_is_a_noop() {
+        let sink: DynEventSink = Arc::new(BroadcastEventSink::new(8));
+        watch("", sink);
+        // Registry should still be empty — no crash, no entry.
+        let reg = registry().lock().unwrap();
+        assert!(!reg.handles.contains_key(""));
+    }
+
+    #[tokio::test]
+    async fn second_watch_for_same_slug_is_idempotent() {
+        let sink: BroadcastEventSink = BroadcastEventSink::new(8);
+        let dyn_sink: DynEventSink = Arc::new(sink.clone());
+
+        // Use a slug that will never resolve (no real API key set in tests).
+        // Both calls should land on the same registry entry.
+        watch("__test_idempotent_slug__", dyn_sink.clone());
+        watch("__test_idempotent_slug__", dyn_sink);
+
+        let reg = registry().lock().unwrap();
+        // Exactly one handle, regardless of double-call.
+        assert!(reg.handles.contains_key("__test_idempotent_slug__"));
+        drop(reg);
+
+        cancel("__test_idempotent_slug__");
+        let reg = registry().lock().unwrap();
+        assert!(!reg.handles.contains_key("__test_idempotent_slug__"));
+    }
+}

--- a/engine/houston-composio/src/lib.rs
+++ b/engine/houston-composio/src/lib.rs
@@ -8,6 +8,7 @@ pub mod apps;
 pub mod auth;
 pub mod cli;
 pub mod commands;
+pub mod connection_watcher;
 pub mod install;
 pub mod lifecycle;
 pub mod mcp;

--- a/engine/houston-engine-protocol/src/lib.rs
+++ b/engine/houston-engine-protocol/src/lib.rs
@@ -145,9 +145,9 @@ pub fn event_topic(event: &HoustonEvent) -> String {
         | HoustonEvent::ContextChanged { agent_path }
         | HoustonEvent::LearningsChanged { agent_path } => format!("agent:{agent_path}"),
         HoustonEvent::ConversationsChanged { agent_path, .. } => format!("agent:{agent_path}"),
-        HoustonEvent::ComposioCliReady | HoustonEvent::ComposioCliFailed { .. } => {
-            "composio".into()
-        }
+        HoustonEvent::ComposioCliReady
+        | HoustonEvent::ComposioCliFailed { .. }
+        | HoustonEvent::ComposioConnectionAdded { .. } => "composio".into(),
         HoustonEvent::ClaudeCliInstalling { .. }
         | HoustonEvent::ClaudeCliReady
         | HoustonEvent::ClaudeCliFailed { .. } => "claude".into(),

--- a/engine/houston-engine-server/src/routes/composio.rs
+++ b/engine/houston-engine-server/src/routes/composio.rs
@@ -14,6 +14,7 @@ use axum::{
 use houston_composio::apps::ComposioAppEntry;
 use houston_composio::cli::{ComposioStatus, StartLinkResponse, StartLoginResponse};
 use houston_composio::commands as inner;
+use houston_composio::connection_watcher;
 use houston_engine_core::CoreError;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -30,6 +31,7 @@ pub fn router() -> Router<Arc<ServerState>> {
             "/composio/connections",
             get(list_connections).post(connect_app),
         )
+        .route("/composio/connections/watch", post(watch_connection))
 }
 
 #[derive(Serialize)]
@@ -45,6 +47,11 @@ struct CompleteLogin {
 
 #[derive(Deserialize)]
 struct ConnectApp {
+    toolkit: String,
+}
+
+#[derive(Deserialize)]
+struct WatchConnection {
     toolkit: String,
 }
 
@@ -97,4 +104,24 @@ async fn connect_app(
         .await
         .map(Json)
         .map_err(lift)
+}
+
+/// Start an engine-side watch for `toolkit` to land in the consumer
+/// connections list. Returns immediately; the watcher emits
+/// `ComposioConnectionAdded` over the WS firehose when it sees the
+/// slug appear (or self-cancels after a 5-minute deadline).
+///
+/// Idempotent: a second call for the same slug while a watch is
+/// already running is a no-op. Safe to call from multiple frontends
+/// (chat card, integrations tab) racing on the same connect.
+async fn watch_connection(
+    State(st): State<Arc<ServerState>>,
+    Json(req): Json<WatchConnection>,
+) -> Result<(), ApiError> {
+    let toolkit = req.toolkit.trim();
+    if toolkit.is_empty() {
+        return Err(lift("toolkit must not be empty".into()));
+    }
+    connection_watcher::watch(toolkit, Arc::new(st.events.clone()));
+    Ok(())
 }

--- a/engine/houston-ui-events/src/lib.rs
+++ b/engine/houston-ui-events/src/lib.rs
@@ -127,6 +127,17 @@ pub enum HoustonEvent {
     ComposioCliReady,
     /// Composio CLI install or upgrade failed.
     ComposioCliFailed { message: String },
+    /// A toolkit became visible in the consumer `connected_toolkits`
+    /// endpoint after a `start_link` flow. Emitted at most once per
+    /// watch by `houston_composio::connection_watcher`. Frontend
+    /// invalidates the `connectedToolkits` query so the inline chat
+    /// card and the Integrations tab flip to "Connected".
+    ///
+    /// Single source of truth for "connection landed" — replaces the
+    /// frontend's focus/visibility/interval probing, which fights
+    /// browser lifecycle and Composio's eventual-consistency lag on
+    /// `GET /api/v3/org/consumer/connected_toolkits`.
+    ComposioConnectionAdded { toolkit: String },
 
     // ----- Claude Code CLI lifecycle -----
     //

--- a/ui/core/src/types.ts
+++ b/ui/core/src/types.ts
@@ -115,4 +115,8 @@ export type HoustonEvent =
   | {
       type: "ComposioCliFailed";
       data: { message: string };
+    }
+  | {
+      type: "ComposioConnectionAdded";
+      data: { toolkit: string };
     };

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -645,6 +645,16 @@ export class HoustonClient {
   composioConnectApp(toolkit: string): Promise<ComposioStartLinkResponse> {
     return this.request("POST", "/composio/connections", { toolkit });
   }
+  /**
+   * Ask the engine to actively watch for `toolkit` to land in the
+   * consumer connections list and emit `ComposioConnectionAdded` over
+   * the WS firehose when it does. Idempotent — duplicate calls while
+   * a watch is active are no-ops on the engine. Returns immediately;
+   * the result arrives as a WS event.
+   */
+  composioWatchConnection(toolkit: string): Promise<void> {
+    return this.request("POST", "/composio/connections/watch", { toolkit });
+  }
 
   // ---------- WebSocket access (see ws.ts) ----------
 

--- a/ui/engine-client/src/ws.ts
+++ b/ui/engine-client/src/ws.ts
@@ -20,7 +20,7 @@
  * - `routines:{agent_path}` — RoutinesChanged, RoutineRunsChanged
  * - `agent:{agent_path}` — ActivityChanged, SkillsChanged, FilesChanged,
  *    ConfigChanged, ContextChanged, LearningsChanged, ConversationsChanged
- * - `composio` — ComposioCliReady, ComposioCliFailed
+ * - `composio` — ComposioCliReady, ComposioCliFailed, ComposioConnectionAdded
  *
  * (The legacy `sync` topic was removed — mobile now uses the same WS
  * directly through the reverse tunnel.)


### PR DESCRIPTION
## Summary

Replaces the chat Composio connect card's 90s endless spinner with a layered system that makes "Connected" state reliably visible no matter how the connection was made or how slowly Composio's backend propagates it.

- **Engine-side push** — new `HoustonEvent::ComposioConnectionAdded` emitted by a tokio watcher that polls the consumer connections endpoint every 2s for up to 5 minutes after the user clicks Connect. Survives focus/visibility/remount quirks and Composio backend lag. Wired through `POST /v1/composio/connections/watch`.
- **Client-side ambient watcher** — per-card mount-time invalidation, focus/visibility refresh, and a 10s heartbeat while visible and not connected. Catches connections made elsewhere (Integrations tab, another agent, CLI) and stale-cache cases from prior sessions. TanStack dedupes so N visible cards = 1 fetch.
- **Manual recovery** — 6s after Connect the spinner becomes an "I've connected" button that does cancel + refetch + normalized-match with toast feedback. No more "stuck until restart."
- **Diagnostic logging** — `cli::list_connected_toolkits` now logs the slug list it gets back so future stuck reports are debuggable.

## Test plan

- [ ] Restart `pnpm tauri dev` (engine sidecar staleness — engine touched).
- [ ] In a chat where the agent emits a Composio connect card, click Connect, complete OAuth in browser, return to Houston. Card should flip to green within ~2s of the connection actually landing on Composio's side.
- [ ] If Composio is slow / lagging, after 6s the card shows "I've connected". Clicking it does a hard refetch and either flips green or surfaces a "Couldn't verify yet" toast.
- [ ] In Integrations tab, click Connect on an app while a chat card is visible for the same app. Both should flip Connected together.
- [ ] Open a chat where the agent emits a card for an *already-connected* toolkit. Card should show green on first paint (or within one fetch tick) without user action.
- [ ] `cargo test -p houston-composio` (9 tests; new idempotency + empty-slug coverage).
- [ ] `pnpm tsc --noEmit` and `pnpm check-locales` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)