### PR TITLE
feat(website): Windows download button + beta waitlist modal

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npx @11ty/eleventy",
     "dev": "npx @11ty/eleventy --serve",
-    "deploy": "npm run build && npx wrangler pages deploy _site --branch=main --commit-dirty=true"
+    "deploy": "npm run build && npx wrangler pages deploy _site --project-name=houston-site --branch=main --commit-dirty=true"
   },
   "dependencies": {
     "@11ty/eleventy": "^3.1.5",

--- a/website/src/index.html
+++ b/website/src/index.html
@@ -1766,6 +1766,7 @@ visionPath: "vision/index.html"
 
   <div class="hero-actions">
     <button class="btn btn-primary btn-lg" data-dl-trigger data-dl-source="hero"><svg viewBox="0 0 384 512" fill="currentColor" width="16" height="16"><path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg> Download for Mac</button>
+    <button class="btn btn-secondary btn-lg" data-dl-windows-trigger data-dl-source="hero-windows"><svg viewBox="0 0 448 512" fill="currentColor" width="16" height="16"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg> Download for Windows</button>
   </div>
 
   <div class="app-mockup" style="max-width: 1152px; width: 100%; margin-top: 64px; animation: float-up 0.6s ease 0.25s both;">
@@ -2175,7 +2176,10 @@ visionPath: "vision/index.html"
           <li style="display: flex; align-items: center; gap: 8px;"><svg viewBox="0 0 12 12" fill="none" stroke="var(--gray-950)" stroke-width="2" width="12" height="12"><path d="M2 6l3 3 5-5"/></svg> Phone companion app</li>
           <li style="display: flex; align-items: center; gap: 8px;"><svg viewBox="0 0 12 12" fill="none" stroke="var(--gray-950)" stroke-width="2" width="12" height="12"><path d="M2 6l3 3 5-5"/></svg> 1000+ integrations</li>
         </ul>
-        <button class="btn btn-primary btn-lg" data-dl-trigger data-dl-source="pricing"><svg viewBox="0 0 384 512" fill="currentColor" width="16" height="16"><path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg> Download for Mac</button>
+        <div style="display: flex; flex-direction: column; gap: 8px;">
+          <button class="btn btn-primary btn-lg" data-dl-trigger data-dl-source="pricing"><svg viewBox="0 0 384 512" fill="currentColor" width="16" height="16"><path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg> Download for Mac</button>
+          <button class="btn btn-secondary btn-lg" data-dl-windows-trigger data-dl-source="pricing-windows"><svg viewBox="0 0 448 512" fill="currentColor" width="16" height="16"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg> Download for Windows</button>
+        </div>
       </div>
       <div class="final-cta-card" style="border-left: 1px solid var(--border-light); display: flex; flex-direction: column; position: relative; overflow: hidden;">
         <div style="position: absolute; inset: 0; background: radial-gradient(ellipse 80% 60% at 20% 100%, rgba(59,130,246,0.08), transparent), radial-gradient(ellipse 60% 50% at 80% 0%, rgba(249,115,22,0.06), transparent); pointer-events: none;"></div>
@@ -2229,6 +2233,20 @@ visionPath: "vision/index.html"
         <a id="dl-x-link" href="https://x.com/ja818_" target="_blank" rel="noopener noreferrer">Follow @ja818_ on X →</a>
       </div>
     </details>
+  </div>
+</div>
+
+<!-- ═══════════════════════════════════════════
+     WINDOWS BETA MODAL
+     ═══════════════════════════════════════════ -->
+
+<div class="dl-overlay" id="dl-overlay-windows">
+  <div class="dl-card">
+    <h3>Windows is in beta</h3>
+    <p>Windows is under active development. Join the waiting list to get early access when it's ready.</p>
+    <div class="dl-actions">
+      <a id="dl-windows-waitlist" href="https://forms.gle/ac24qrKSufYvfudt8" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-lg">Join the waiting list</a>
+    </div>
   </div>
 </div>
 
@@ -2588,6 +2606,36 @@ visionPath: "vision/index.html"
       waitlistLink.addEventListener('click', function() {
         track('waitlist_clicked', { source: lastSource });
       });
+    }
+
+    // Windows beta modal
+    var winOverlay = document.getElementById('dl-overlay-windows');
+    var winWaitlist = document.getElementById('dl-windows-waitlist');
+    var winLastSource = 'unknown';
+
+    if (winOverlay) {
+      document.querySelectorAll('[data-dl-windows-trigger]').forEach(function(el) {
+        el.addEventListener('click', function(e) {
+          e.preventDefault();
+          winLastSource = el.getAttribute('data-dl-source') || 'unknown';
+          track('windows_modal_opened', { source: winLastSource });
+          winOverlay.classList.add('open');
+        });
+      });
+
+      winOverlay.addEventListener('click', function(e) {
+        if (e.target === winOverlay) winOverlay.classList.remove('open');
+      });
+
+      document.addEventListener('keydown', function(e) {
+        if (e.key === 'Escape') winOverlay.classList.remove('open');
+      });
+
+      if (winWaitlist) {
+        winWaitlist.addEventListener('click', function() {
+          track('windows_waitlist_clicked', { source: winLastSource });
+        });
+      }
     }
 
     // Track skip-waitlist accordion + X link


### PR DESCRIPTION
## Summary
- Adds a "Download for Windows" button next to the Mac download in the hero and pricing card
- Clicking opens a modal explaining Windows is in beta and under active development, with a button to join the waiting list (same Google Form as the Mac waitlist)
- Tracks `windows_modal_opened` and `windows_waitlist_clicked` in PostHog so we can size Windows demand
- Fixes the `deploy` npm script to include `--project-name=houston-site` so `npm run deploy` works without manual flags

## Test plan
- [x] `npm run build` succeeds
- [x] Both buttons render in hero + pricing card
- [x] Modal opens on click, closes on backdrop click and Escape
- [x] "Join the waiting list" links to https://forms.gle/ac24qrKSufYvfudt8
- [x] Deployed to production: https://gethouston.ai

Affected files:
- `website/src/index.html` — buttons, modal HTML, JS wiring
- `website/package.json` — deploy script fix