### PR TITLE
feat(onboarding): single tutorial mission + comet success card

### DIFF
--- a/app/src/components/onboarding/missions/try.tsx
+++ b/app/src/components/onboarding/missions/try.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { ArrowRight } from "lucide-react";
 import { ChatPanel, type FeedItem } from "@houston-ai/chat";
 import { Button, HoustonAvatar, cn, resolveAgentColor } from "@houston-ai/core";
 import {
@@ -26,7 +27,6 @@ import {
   isComposioSigninHref,
 } from "../../composio-signin-card";
 import type { Agent } from "../../../lib/types";
-import type { MissionId } from "../personal-assistant-missions";
 import type { MissionMeta } from "../mission-frame";
 import { MissionWithChatFrame } from "../mission-with-chat-frame";
 
@@ -50,27 +50,20 @@ interface TryMissionProps {
   assistantColor: string;
   provider: string;
   model: string;
-  selectedMissionId: MissionId;
-  onPick: (missionId: MissionId) => void;
   onContinue: () => void;
 }
 
-const PICKS: { id: MissionId; chipKey: string }[] = [
-  { id: "morning-brief", chipKey: "morningBrief" },
-  { id: "meeting-prep", chipKey: "meetingPrep" },
-  { id: "weekly-recap", chipKey: "weeklyRecap" },
-];
-
 /**
- * "Try a mission" — the AHA. The user picks a chip; we create a real Activity
- * Board mission via `createMission` and run the chat on the resulting
- * `activity-${id}` session key. After graduation the user lands on the board
- * and finds this conversation as a mission card they can scroll back through.
+ * "Try a mission" — the AHA. The user clicks the single chip; we create a
+ * real Activity Board mission via `createMission` and run the chat on the
+ * resulting `activity-${id}` session key. After graduation the user lands on
+ * the board and finds this conversation as a mission card they can scroll
+ * back through.
  *
  * The composer is the workspace's `ChatPanel` (queue, attachments, Composio
  * cards — all free), so once the mission is going the user can reply in the
  * normal chat. Pre-pick the right column shows a centered prompt with the
- * three chips; post-pick it switches to the live chat layout.
+ * single chip; post-pick it switches to the live chat layout.
  */
 export function TryMission({
   meta,
@@ -79,15 +72,11 @@ export function TryMission({
   assistantColor,
   provider,
   model,
-  selectedMissionId,
-  onPick,
   onContinue,
 }: TryMissionProps) {
   const { t } = useTranslation(["setup", "chat"]);
   const agentPath = agent.folderPath;
-  const missionTitle = t(
-    `setup:tutorial.missions.try.skills.${selectedMissionId}.title`,
-  );
+  const missionTitle = t("setup:tutorial.missions.try.skill.title");
 
   // The session key is null until the user picks a chip and `createMission`
   // mints the activity. Pre-pick everything that depends on it just no-ops.
@@ -234,10 +223,9 @@ export function TryMission({
   // chat lives on `activity-${id}` so it shows up as a mission card on the
   // Activity Board after graduation.
   const handlePick = useCallback(
-    async (missionId: MissionId, chipLabel: string) => {
+    async (chipLabel: string) => {
       if (pickedAny) return;
       setPickedAny(true);
-      onPick(missionId);
       try {
         const result = await createMission(
           {
@@ -259,7 +247,7 @@ export function TryMission({
         setError(e instanceof Error ? e.message : String(e));
       }
     },
-    [agent.id, agent.name, agent.color, agent.folderPath, provider, model, onPick, pickedAny],
+    [agent.id, agent.name, agent.color, agent.folderPath, provider, model, pickedAny],
   );
 
   const visibleFeed = (feedItems ?? []) as FeedItem[];
@@ -270,16 +258,8 @@ export function TryMission({
       {...frame}
       left={
         <div className="flex flex-1 flex-col gap-4">
-          <div className="rounded-xl border border-black/5 bg-secondary/40 p-4">
-            <p className="text-sm font-medium">
-              {t("setup:tutorial.missions.try.tipTitle")}
-            </p>
-            <p className="mt-2 text-sm text-muted-foreground">
-              {t("setup:tutorial.missions.try.tipBody")}
-            </p>
-          </div>
           {tutorialDone ? (
-            <div className="rounded-xl border border-[#00a240]/30 bg-[#00a240]/5 p-4">
+            <div className="card-running-glow rounded-xl p-4">
               <p className="text-sm font-medium text-foreground">
                 {t("setup:tutorial.missions.try.doneTitle")}
               </p>
@@ -288,20 +268,31 @@ export function TryMission({
               </p>
               <Button className="mt-3 rounded-full" onClick={onContinue}>
                 {t("setup:tutorial.missions.try.continueChip")}
+                <ArrowRight className="ml-1 size-4" />
               </Button>
             </div>
-          ) : pickedAny ? (
-            <div className="rounded-xl border border-black/5 bg-secondary/40 p-4">
-              <p className="text-sm font-medium">
-                {t("setup:tutorial.missions.try.workingTitle")}
-              </p>
-              <p className="mt-2 text-sm text-muted-foreground">
-                {t("setup:tutorial.missions.try.workingBody", {
-                  missionId: selectedMissionId,
-                })}
-              </p>
-            </div>
-          ) : null}
+          ) : (
+            <>
+              <div className="rounded-xl border border-black/5 bg-secondary/40 p-4">
+                <p className="text-sm font-medium">
+                  {t("setup:tutorial.missions.try.tipTitle")}
+                </p>
+                <p className="mt-2 text-sm text-muted-foreground">
+                  {t("setup:tutorial.missions.try.tipBody")}
+                </p>
+              </div>
+              {pickedAny && (
+                <div className="rounded-xl border border-black/5 bg-secondary/40 p-4">
+                  <p className="text-sm font-medium">
+                    {t("setup:tutorial.missions.try.workingTitle")}
+                  </p>
+                  <p className="mt-2 text-sm text-muted-foreground">
+                    {t("setup:tutorial.missions.try.workingBody")}
+                  </p>
+                </div>
+              )}
+            </>
+          )}
           {error && (
             <p className="rounded-xl border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
               {error}
@@ -354,26 +345,18 @@ export function TryMission({
               <p className="text-sm text-muted-foreground">
                 {t("setup:tutorial.missions.try.composerHint")}
               </p>
-              <div className="flex flex-wrap justify-center gap-2">
-                {PICKS.map((pick) => (
-                  <button
-                    key={pick.id}
-                    type="button"
-                    onClick={() =>
-                      void handlePick(
-                        pick.id,
-                        t(`setup:tutorial.missions.try.chips.${pick.chipKey}`),
-                      )
-                    }
-                    disabled={pickedAny}
-                    className={cn(
-                      "h-9 rounded-full border border-black/15 bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50",
-                    )}
-                  >
-                    {t(`setup:tutorial.missions.try.chips.${pick.chipKey}`)}
-                  </button>
-                ))}
-              </div>
+              <button
+                type="button"
+                onClick={() =>
+                  void handlePick(t("setup:tutorial.missions.try.chip"))
+                }
+                disabled={pickedAny}
+                className={cn(
+                  "h-9 rounded-full border border-black/15 bg-background px-4 text-sm font-medium text-foreground transition-colors hover:bg-secondary disabled:cursor-not-allowed disabled:opacity-50",
+                )}
+              >
+                {t("setup:tutorial.missions.try.chip")}
+              </button>
             </div>
           )}
         </div>

--- a/app/src/components/onboarding/personal-assistant-artifacts.test.mjs
+++ b/app/src/components/onboarding/personal-assistant-artifacts.test.mjs
@@ -1,41 +1,34 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
-  buildSkill,
-  buildRoutineInput,
+  buildAssistantInstructions,
   defaultAssistantSetup,
 } from "./personal-assistant-artifacts.ts";
-import { missionById } from "./personal-assistant-missions.ts";
+import { TUTORIAL_MISSION } from "./personal-assistant-missions.ts";
 
-test("morning brief tutorial creates weekday cron", () => {
+test("tutorial mission is the single Plan-my-next-working-day skill with three integrations", () => {
+  assert.equal(TUTORIAL_MISSION.id, "plan-next-workday");
+  assert.equal(TUTORIAL_MISSION.skillName, "plan-my-next-working-day");
+  assert.deepEqual(TUTORIAL_MISSION.integrations, [
+    "gmail",
+    "googlecalendar",
+    "googlesheets",
+  ]);
+});
+
+test("assistant instructions interpolate the mission title", () => {
   const setup = defaultAssistantSetup({
     workspaceName: "Personal",
     assistantName: "Personal assistant",
     focus: "Help me plan.",
     approvalRule: "Ask first.",
   });
-  setup.routineTime = "08:30";
 
-  const routine = buildRoutineInput(
-    missionById("morning-brief"),
-    "Morning brief",
-    "Prepare the day.",
+  const instructions = buildAssistantInstructions(
     setup,
+    "Plan my next working day",
   );
 
-  assert.equal(routine.schedule, "30 8 * * 1-5");
-  assert.equal(routine.enabled, true);
-});
-
-test("tutorial skill writes current Skill frontmatter", () => {
-  const skill = buildSkill(
-    missionById("morning-brief"),
-    "Morning brief",
-    'Checks "calendar" and email.',
-  );
-
-  assert.match(skill, /name: prepare-my-morning-brief/);
-  assert.match(skill, /featured: yes/);
-  assert.match(skill, /integrations: \["gmail", "googlecalendar"\]/);
-  assert.doesNotMatch(skill, /display_name/);
+  assert.match(instructions, /# Personal assistant/);
+  assert.match(instructions, /Plan my next working day/);
 });

--- a/app/src/components/onboarding/personal-assistant-artifacts.ts
+++ b/app/src/components/onboarding/personal-assistant-artifacts.ts
@@ -1,15 +1,9 @@
-import type { NewRoutine } from "@houston-ai/engine-client";
-import type { SkillSummary } from "../../lib/types";
-import type { MissionTemplate } from "./personal-assistant-missions";
-
 export interface AssistantSetup {
   workspaceName: string;
   assistantName: string;
   color: string;
   focus: string;
   approvalRule: string;
-  routineTime: string;
-  routineEnabled: boolean;
 }
 
 export const PERSONAL_ASSISTANT_CONFIG_ID = "personal-assistant";
@@ -23,8 +17,6 @@ export function defaultAssistantSetup(labels: {
   return {
     ...labels,
     color: "navy",
-    routineTime: "08:30",
-    routineEnabled: true,
   };
 }
 
@@ -50,85 +42,4 @@ ${setup.approvalRule.trim()}
 - Keep updates short and practical.
 - Never send messages, create calendar events, or change connected apps unless I approve first.
 `;
-}
-
-export function buildSkill(
-  mission: MissionTemplate,
-  missionTitle: string,
-  missionDescription: string,
-): string {
-  const integrations = mission.integrations.map((item) => `"${item}"`).join(", ");
-  return `---
-name: ${mission.skillName}
-description: "${escapeYaml(missionDescription)}"
-version: 1
-category: Assistant
-featured: yes
-image: ${mission.image}
-integrations: [${integrations}]
----
-
-# ${missionTitle}
-
-## Procedure
-Use this Skill when the user wants ${missionTitle.toLowerCase()}.
-
-1. Confirm required connected apps are available: ${mission.integrations.join(", ")}.
-2. Read only the information needed for the request.
-3. Produce a short result with what mattered, what changed, and what needs approval.
-4. Ask before sending email, creating calendar events, or changing connected apps.
-5. If a connected app is missing, tell the user exactly which app to connect and stop.
-
-## First run
-Complete the tutorial run now. Use connected apps to gather real context. If there is nothing useful yet, say that clearly and suggest the next useful setup step.
-`;
-}
-
-export function buildRoutineInput(
-  mission: MissionTemplate,
-  missionTitle: string,
-  missionDescription: string,
-  setup: AssistantSetup,
-): NewRoutine {
-  return {
-    name: missionTitle,
-    description: missionDescription,
-    prompt: `Use the ${mission.skillName} skill. Run the scheduled version of ${missionTitle}. Ask before external changes.`,
-    schedule: mission.routineSchedule(setup.routineTime),
-    enabled: setup.routineEnabled,
-    suppress_when_silent: false,
-    timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-  };
-}
-
-export function skillSummary(
-  mission: MissionTemplate,
-  missionDescription: string,
-): SkillSummary {
-  return {
-    name: mission.skillName,
-    description: missionDescription,
-    version: 1,
-    tags: [],
-    created: null,
-    last_used: null,
-    category: "Assistant",
-    featured: true,
-    integrations: mission.integrations,
-    image: mission.image,
-    inputs: [],
-    prompt_template: null,
-  };
-}
-
-export function firstRunPrompt(mission: MissionTemplate, missionTitle: string): string {
-  return `Use the ${mission.skillName} skill.
-
-Run my first Houston tutorial mission: ${missionTitle}.
-
-Use connected apps when available. Do not send email, create calendar events, or change connected apps until I approve. Show me the useful result first, then ask what I want to do next.`;
-}
-
-function escapeYaml(value: string): string {
-  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
 }

--- a/app/src/components/onboarding/personal-assistant-missions.ts
+++ b/app/src/components/onboarding/personal-assistant-missions.ts
@@ -1,89 +1,15 @@
-export type MissionId =
-  | "morning-brief"
-  | "email-draft"
-  | "focus-block"
-  | "follow-up-sweep"
-  | "meeting-prep"
-  | "weekly-recap";
+export type MissionId = "plan-next-workday";
 
 export interface MissionTemplate {
   id: MissionId;
   skillName: string;
   integrations: string[];
   image: string;
-  defaultTime: string;
-  routineSchedule: (time: string) => string;
 }
 
-export const MISSIONS: MissionTemplate[] = [
-  {
-    id: "morning-brief",
-    skillName: "prepare-my-morning-brief",
-    integrations: ["gmail", "googlecalendar"],
-    image: "calendar",
-    defaultTime: "08:30",
-    routineSchedule: weekdaysAt,
-  },
-  {
-    id: "email-draft",
-    skillName: "draft-an-email-reply",
-    integrations: ["gmail"],
-    image: "memo",
-    defaultTime: "16:00",
-    routineSchedule: weekdaysAt,
-  },
-  {
-    id: "focus-block",
-    skillName: "protect-a-focus-block",
-    integrations: ["googlecalendar"],
-    image: "alarm-clock",
-    defaultTime: "09:00",
-    routineSchedule: weekdaysAt,
-  },
-  {
-    id: "follow-up-sweep",
-    skillName: "sweep-my-follow-ups",
-    integrations: ["gmail"],
-    image: "incoming-envelope",
-    defaultTime: "15:30",
-    routineSchedule: weekdaysAt,
-  },
-  {
-    id: "meeting-prep",
-    skillName: "prep-my-next-meeting",
-    integrations: ["gmail", "googlecalendar"],
-    image: "spiral-notepad",
-    defaultTime: "07:45",
-    routineSchedule: weekdaysAt,
-  },
-  {
-    id: "weekly-recap",
-    skillName: "send-my-weekly-recap",
-    integrations: ["gmail", "googlecalendar"],
-    image: "bar-chart",
-    defaultTime: "16:30",
-    routineSchedule: fridayAt,
-  },
-];
-
-export function missionById(id: MissionId): MissionTemplate {
-  return MISSIONS.find((m) => m.id === id) ?? MISSIONS[0];
-}
-
-function weekdaysAt(time: string): string {
-  const { hour, minute } = parseTime(time);
-  return `${minute} ${hour} * * 1-5`;
-}
-
-function fridayAt(time: string): string {
-  const { hour, minute } = parseTime(time);
-  return `${minute} ${hour} * * 5`;
-}
-
-function parseTime(time: string): { hour: number; minute: number } {
-  const [rawHour, rawMinute] = time.split(":").map(Number);
-  return {
-    hour: Number.isFinite(rawHour) ? rawHour : 8,
-    minute: Number.isFinite(rawMinute) ? rawMinute : 30,
-  };
-}
+export const TUTORIAL_MISSION: MissionTemplate = {
+  id: "plan-next-workday",
+  skillName: "plan-my-next-working-day",
+  integrations: ["gmail", "googlecalendar", "googlesheets"],
+  image: "spiral-notepad",
+};

--- a/app/src/components/onboarding/personal-assistant-onboarding.tsx
+++ b/app/src/components/onboarding/personal-assistant-onboarding.tsx
@@ -18,7 +18,7 @@ import {
   buildAssistantInstructions,
   defaultAssistantSetup,
 } from "./personal-assistant-artifacts";
-import { missionById, type MissionId } from "./personal-assistant-missions";
+import { TUTORIAL_MISSION } from "./personal-assistant-missions";
 import {
   buildFrameLabels,
   buildMissionMeta,
@@ -30,8 +30,6 @@ interface PersonalAssistantOnboardingProps {
   toasts: Toast[];
   onDismissToast: (id: string) => void;
 }
-
-const DEFAULT_MISSION_ID = "morning-brief" as const;
 
 export function PersonalAssistantOnboarding({
   toasts,
@@ -48,14 +46,8 @@ export function PersonalAssistantOnboarding({
     t("setup:tutorial.defaults.assistantName"),
   );
   const [assistantColor, setAssistantColor] = useState("navy");
-  const [selectedMissionId, setSelectedMissionId] = useState<MissionId>(
-    DEFAULT_MISSION_ID,
-  );
 
-  const mission = missionById(selectedMissionId);
-  const missionTitle = t(
-    `setup:tutorial.missions.try.skills.${selectedMissionId}.title`,
-  );
+  const missionTitle = t("setup:tutorial.missions.try.skill.title");
 
   const missionStep = step === "welcome" ? null : (step as TutorialStep);
   const meta = missionStep ? buildMissionMeta(t, missionStep) : null;
@@ -114,7 +106,7 @@ export function PersonalAssistantOnboarding({
       const fallbackModel = model ?? "sonnet";
       await createWorkspaceAndAssistant(fallbackProvider, fallbackModel);
       analytics.track("onboarding_completed", {
-        mission: mission.id,
+        mission: TUTORIAL_MISSION.id,
         integrations_skipped: true,
         tutorial_run: false,
       });
@@ -128,7 +120,7 @@ export function PersonalAssistantOnboarding({
   // already up — no flicker of bare workspace.
   const handleTryComplete = () => {
     analytics.track("onboarding_completed", {
-      mission: mission.id,
+      mission: TUTORIAL_MISSION.id,
       integrations_skipped: false,
       tutorial_run: true,
     });
@@ -197,8 +189,6 @@ export function PersonalAssistantOnboarding({
           assistantColor={assistantColor}
           provider={provider ?? "anthropic"}
           model={model ?? "sonnet"}
-          selectedMissionId={selectedMissionId}
-          onPick={(id) => setSelectedMissionId(id)}
           onContinue={handleTryComplete}
         />
       )}

--- a/app/src/components/onboarding/tutorial-system-prompt.ts
+++ b/app/src/components/onboarding/tutorial-system-prompt.ts
@@ -16,25 +16,55 @@ const END = "<!-- HOUSTON_TUTORIAL_END -->";
 
 const TUTORIAL_SECTION = `## Tutorial mode (first run)
 
-This is the user's first time running you in Houston. Follow this exact pattern. Do not deviate.
+This is the user's first time running you in Houston. The user just clicked "Plan my next working day". Follow this exact pattern. Do not deviate.
 
-1. Open with a concise PLAN — what you're going to do, in plain language, in 2-3 short sentences. Cover: (a) the task in your own words, (b) the apps you'll touch and what you'll pull from each, (c) that you'll email the result at the end. Example for "Prep me for my next meeting": *"I'll prepare your next meeting prep. I'll find your next event in Calendar, pull the recent emails about it from Gmail, then write you talking points and email them to your inbox."* Don't list bullet points, don't use headings, just a tight paragraph the user can read in one breath. Then move on without waiting for confirmation.
+The mission: cross-reference the user's Google Calendar, Gmail, and Google Sheets to produce a structured plan for their next working day. The aha is that you do work no single tool can do alone, AND you surface things they would have missed.
 
-2. Then SILENTLY check Composio for those connections (use \`composio search\` / \`composio execute\` per the integrations guide). Do NOT narrate the check to the user.
+1. Open with a concise PLAN paragraph in plain language, 2-3 short sentences. Cover: (a) you'll work the next working day (tomorrow if today is Mon-Thu, Monday if today is Fri-Sun), (b) you'll spawn parallel subagents to read Calendar and Gmail at the same time, then cross-reference them, (c) you'll write the result into a Google Sheet and email them the link. Don't list bullet points, don't use headings, just a tight paragraph the user can read in one breath. Then move on without waiting for confirmation.
 
-3. If composio itself returns an authentication / not-signed-in error (the user has no Composio session at all), STOP. Post the Composio sign-in card by writing exactly: \`[Sign in to Composio](https://composio.dev/#houston_composio_signin=1)\` and add one short line ("I need you to sign into Composio first so I can use your apps."). Wait for the user, then restart from step 2. Never fabricate results when you cannot reach Composio.
+2. SILENTLY check Composio for gmail, googlecalendar, and googlesheets connections (use \`composio search\` / \`composio execute\` per the integrations guide). Do NOT narrate the check.
 
-4. If the apps are already connected, say so in one short line ("Both connected, here we go.") and continue to step 5.
+3. If composio itself returns an authentication / not-signed-in error (no Composio session at all), STOP. Post the Composio sign-in card by writing exactly: \`[Sign in to Composio](https://composio.dev/#houston_composio_signin=1)\` and add one short line ("I need you to sign into Composio first so I can use your apps."). Wait for the user, then restart from step 2. Never fabricate results when you cannot reach Composio.
+
+4. If all three apps are connected, say so in one short line ("All three connected, here we go.") and continue to step 5.
 
 4b. If any app is missing, briefly say which one(s), then post a connect card per missing app using the standard #houston_toolkit pattern (one markdown link per app). Wait for the user to come back, then retry.
 
-5. Complete the task. Reply with the actual result the user asked for (the brief / prep / recap itself), formatted clearly.
+5. Determine the target date. If today is Mon-Thu, target = tomorrow. If today is Fri/Sat/Sun, target = next Monday. Note this date as both ISO (YYYY-MM-DD) and short label "{Day} {Mon} {DD}" (e.g. "Mon May 11"). The Google Sheet title MUST be exactly "{Day} {Mon} {DD} Plan" (e.g. "Mon May 11 Plan").
 
-6. THEN send that same content as an email to the user themselves so they have it in their inbox. The user's own email address is the one connected to Gmail via Composio — look it up using a Gmail profile / current-user tool if you don't have it. Subject line should be the task title (e.g. "Your morning brief"). Body should be the same content as your chat reply, lightly formatted for email. After sending, tell the user in ONE short line that you emailed it (e.g. "Also sent it to your inbox.").
+6. Spawn two subagents IN PARALLEL using the Task tool. Both subagents must be launched in a single message with two tool uses so they actually run concurrently:
 
-7. End your final message with the literal token [TUTORIAL_COMPLETE] on its own line. The frontend uses this token to advance the tutorial. Emit it ONLY after you have delivered the result in chat AND sent the email. Never emit it before.
+   - **Calendar subagent**: read every Calendar event on the target date. For each event capture: time, title, attendees (especially external), location/meeting link, description. Return a clean structured list. If there are no events, say so explicitly.
 
-Be tight. No apologies. No "let me think about that". No narration of your process. Announce, check, post cards if needed, deliver the result, send the email, emit the token. Done.
+   - **Gmail subagent**: read the user's last 48 hours of Gmail. Return three buckets: (a) unread emails awaiting your reply, ranked by sender importance and staleness, (b) commitments the user themselves made in sent mail ("I'll send X by Friday", "I'll loop you in tomorrow", etc.), (c) any thread that mentions an event happening on the target date.
+
+7. CROSS-REFERENCE pass. Once both subagents return, look for things a human would miss. This is the magic. Examples of what to flag:
+   - "You have a 10am with Acme — they sent an updated agenda 6 hours ago you haven't opened."
+   - "Your 2pm got rescheduled by email yesterday but your calendar still says 2pm."
+   - "You promised Tom a deck by EOD tomorrow (email Apr 28) — nothing on your calendar to do it."
+   - "Sarah asked if Friday still works — it's on your calendar, you haven't confirmed."
+   Aim for 3 to 5 items. If genuinely nothing surprising, say so honestly rather than padding.
+
+8. Create a NEW Google Sheet titled exactly "{Day} {Mon} {DD} Plan". The sheet must have FOUR tabs in this order:
+
+   - **Schedule** — columns: Time | Event | Attendees | Prep needed | Email context. One row per Calendar event.
+   - **Replies needed** — columns: Priority | From | Subject | Why it matters | Suggested reply (1 line) | Days waiting. One row per email that needs a reply.
+   - **Commitments** — columns: Promised to | What | Source email | Due | Status. One row per commitment the user made.
+   - **Don't miss** — columns: Heads-up | Why I flagged it | Action. One row per cross-reference finding from step 7. THIS IS THE MAGIC TAB.
+
+   Use the googlesheets toolkit. Get the share URL of the new sheet.
+
+9. Reply in chat with:
+   - One sentence: "I built your {Day} {Mon} {DD} plan." with the sheet link inline.
+   - Three short bullets summarizing scale: how many events, how many emails need replies, how many commitments.
+   - The "Don't miss" section inlined verbatim (just the heads-ups, one per line). This is what makes the user say "wow, I didn't notice this."
+   - Format clearly. No walls of text.
+
+10. THEN send an email to the user themselves containing the same summary + sheet link. Look up the user's email via a Gmail profile / current-user tool. Subject: "Your {Day} {Mon} {DD} plan". Body: the summary you just posted in chat, lightly formatted. After sending, add ONE short line in chat ("Also sent it to your inbox.").
+
+11. End your final message with the literal token [TUTORIAL_COMPLETE] on its own line. The frontend uses this token to advance the tutorial. Emit it ONLY after you have created the sheet AND posted the chat reply AND sent the email. Never emit it before.
+
+Be tight. No apologies. No "let me think about that". No narration of your process. Announce, check connections, post cards if needed, run the parallel subagents, cross-reference, build the sheet, deliver the chat summary with the magic tab inlined, send the email, emit the token. Done.
 `;
 
 /** Append the tutorial section to CLAUDE.md if not already present. */

--- a/app/src/locales/en/setup.json
+++ b/app/src/locales/en/setup.json
@@ -35,7 +35,8 @@
     },
     "toolkits": {
       "gmail": "Gmail",
-      "googlecalendar": "Google Calendar"
+      "googlecalendar": "Google Calendar",
+      "googlesheets": "Google Sheets"
     },
     "defaults": {
       "workspaceName": "Personal",
@@ -70,35 +71,21 @@
       },
       "try": {
         "title": "Try a real mission",
-        "body": "Real chat with your assistant. Pick one of the suggestions or type a reply. If it needs Gmail or Calendar, it will ask right here in the chat.",
+        "body": "Real chat with your assistant. Click the mission to start. Your assistant will ask for Gmail, Calendar, or Sheets right here in the chat if it needs them.",
         "tipTitle": "This is the real chat",
-        "tipBody": "Same chat you'll use after the tutorial. Pick a suggestion to start, then reply naturally. Connection requests show up as cards your assistant posts in the chat.",
+        "tipBody": "Same chat you'll use after the tutorial. Click the mission to start, then reply naturally. Connection requests show up as cards your assistant posts in the chat.",
         "workingTitle": "Working on it",
         "workingBody": "Reply in the chat as you would normally. The tutorial will continue automatically once your assistant finishes.",
-        "doneTitle": "Mission complete",
-        "doneBody": "Your assistant just did real work with your real apps. Take a quick tour of the UI, then you're done.",
+        "doneTitle": "You did it. First mission complete.",
+        "doneBody": "Your assistant just did real work with your real apps. Take a quick tour of Houston, then you're free.",
         "placeholder": "Reply to your assistant...",
-        "skills": {
-          "morning-brief": {
-            "title": "Morning brief",
-            "description": "Read today's calendar and important email, then prepare a short brief."
-          },
-          "meeting-prep": {
-            "title": "Meeting prep",
-            "description": "Read your next meeting and nearby context, then prepare notes."
-          },
-          "weekly-recap": {
-            "title": "Weekly recap",
-            "description": "Summarize the week from calendar and email into a Friday recap."
-          }
+        "skill": {
+          "title": "Plan my next working day",
+          "description": "Read your Calendar and Gmail in parallel, cross-reference them for things you'd miss, and write a structured plan into a Google Sheet."
         },
-        "chips": {
-          "morningBrief": "Give me a daily briefing",
-          "meetingPrep": "Prep me for my next meeting",
-          "weeklyRecap": "Send me a weekly recap on Fridays"
-        },
-        "composerHint": "Pick a mission to start the chat.",
-        "continueChip": "Tutorial complete, go to UI"
+        "chip": "Plan my next working day",
+        "composerHint": "Click to start the mission.",
+        "continueChip": "Take the tour"
       }
     }
   }

--- a/app/src/locales/es/setup.json
+++ b/app/src/locales/es/setup.json
@@ -35,7 +35,8 @@
     },
     "toolkits": {
       "gmail": "Gmail",
-      "googlecalendar": "Google Calendar"
+      "googlecalendar": "Google Calendar",
+      "googlesheets": "Google Sheets"
     },
     "defaults": {
       "workspaceName": "Personal",
@@ -70,35 +71,21 @@
       },
       "try": {
         "title": "Prueba una misión real",
-        "body": "Chat real con tu asistente. Elige una sugerencia o escribe una respuesta. Si necesita Gmail o Calendar, te lo pide aquí mismo en el chat.",
+        "body": "Chat real con tu asistente. Haz clic en la misión para empezar. Tu asistente te pedirá Gmail, Calendar o Sheets aquí mismo si los necesita.",
         "tipTitle": "Este es el chat real",
-        "tipBody": "El mismo chat que usarás después del tutorial. Elige una sugerencia para empezar y responde con naturalidad. Las solicitudes de conexión aparecen como tarjetas que tu asistente publica en el chat.",
+        "tipBody": "El mismo chat que usarás después del tutorial. Haz clic en la misión para empezar y responde con naturalidad. Las solicitudes de conexión aparecen como tarjetas que tu asistente publica en el chat.",
         "workingTitle": "Trabajando en ello",
         "workingBody": "Responde en el chat como lo harías normalmente. El tutorial continuará automáticamente cuando tu asistente termine.",
-        "doneTitle": "Misión completada",
-        "doneBody": "Tu asistente acaba de hacer trabajo real con tus apps reales. Toma un tour rápido del UI y listo.",
+        "doneTitle": "Lo lograste. Primera misión completada.",
+        "doneBody": "Tu asistente acaba de hacer trabajo real con tus apps reales. Toma un tour rápido de Houston y listo.",
         "placeholder": "Responde a tu asistente...",
-        "skills": {
-          "morning-brief": {
-            "title": "Resumen matutino",
-            "description": "Lee el calendario de hoy y los correos importantes, y prepara un resumen breve."
-          },
-          "meeting-prep": {
-            "title": "Preparación de reunión",
-            "description": "Lee tu siguiente reunión y el contexto cercano, y prepara notas."
-          },
-          "weekly-recap": {
-            "title": "Resumen semanal",
-            "description": "Resume la semana desde calendario y correo en un cierre del viernes."
-          }
+        "skill": {
+          "title": "Planea mi siguiente día de trabajo",
+          "description": "Lee tu Calendar y Gmail en paralelo, los cruza para encontrar cosas que se te escaparían y escribe un plan estructurado en un Google Sheet."
         },
-        "chips": {
-          "morningBrief": "Dame un resumen diario",
-          "meetingPrep": "Prepárame para mi siguiente reunión",
-          "weeklyRecap": "Mándame un resumen semanal los viernes"
-        },
-        "composerHint": "Elige una misión para empezar el chat.",
-        "continueChip": "Tutorial completo, ir al UI"
+        "chip": "Planea mi siguiente día de trabajo",
+        "composerHint": "Haz clic para empezar la misión.",
+        "continueChip": "Hacer el tour"
       }
     }
   }

--- a/app/src/locales/pt/setup.json
+++ b/app/src/locales/pt/setup.json
@@ -35,7 +35,8 @@
     },
     "toolkits": {
       "gmail": "Gmail",
-      "googlecalendar": "Google Calendar"
+      "googlecalendar": "Google Calendar",
+      "googlesheets": "Google Sheets"
     },
     "defaults": {
       "workspaceName": "Pessoal",
@@ -70,35 +71,21 @@
       },
       "try": {
         "title": "Teste uma missão real",
-        "body": "Chat real com seu assistente. Escolha uma sugestão ou escreva uma resposta. Se precisar de Gmail ou Calendar, ele pede aqui mesmo no chat.",
+        "body": "Chat real com seu assistente. Clique na missão para começar. Seu assistente vai pedir Gmail, Calendar ou Sheets aqui mesmo se precisar.",
         "tipTitle": "Esse é o chat real",
-        "tipBody": "O mesmo chat que você vai usar depois do tutorial. Escolha uma sugestão para começar e responda naturalmente. Pedidos de conexão aparecem como cartões que seu assistente posta no chat.",
+        "tipBody": "O mesmo chat que você vai usar depois do tutorial. Clique na missão para começar e responda naturalmente. Pedidos de conexão aparecem como cartões que seu assistente posta no chat.",
         "workingTitle": "Trabalhando nisso",
         "workingBody": "Responda no chat como você faria normalmente. O tutorial vai seguir automaticamente quando seu assistente terminar.",
-        "doneTitle": "Missão concluída",
-        "doneBody": "Seu assistente acabou de fazer trabalho real com seus apps reais. Faça um tour rápido do UI e pronto.",
+        "doneTitle": "Você conseguiu. Primeira missão concluída.",
+        "doneBody": "Seu assistente acabou de fazer trabalho real com seus apps reais. Faça um tour rápido do Houston e pronto.",
         "placeholder": "Responda ao seu assistente...",
-        "skills": {
-          "morning-brief": {
-            "title": "Resumo da manhã",
-            "description": "Lê a agenda de hoje e os e-mails importantes, e prepara um resumo curto."
-          },
-          "meeting-prep": {
-            "title": "Preparação de reunião",
-            "description": "Lê sua próxima reunião e o contexto próximo, e prepara notas."
-          },
-          "weekly-recap": {
-            "title": "Resumo semanal",
-            "description": "Resume a semana a partir da agenda e do e-mail num fechamento de sexta."
-          }
+        "skill": {
+          "title": "Planeja meu próximo dia de trabalho",
+          "description": "Lê sua agenda e Gmail em paralelo, cruza para achar coisas que você ia perder e escreve um plano estruturado num Google Sheet."
         },
-        "chips": {
-          "morningBrief": "Me dá um resumo diário",
-          "meetingPrep": "Me prepara para a próxima reunião",
-          "weeklyRecap": "Me manda um resumo semanal nas sextas"
-        },
-        "composerHint": "Escolha uma missão para começar o chat.",
-        "continueChip": "Tutorial completo, ir para o UI"
+        "chip": "Planeja meu próximo dia de trabalho",
+        "composerHint": "Clique para começar a missão.",
+        "continueChip": "Fazer o tour"
       }
     }
   }


### PR DESCRIPTION
## Summary
- Replaces the 6 personal-assistant tutorial missions with a single mission: **Plan my next working day** (gmail + googlecalendar + googlesheets). Time-of-day-sensitive flows like "Morning brief" felt broken at evening demos; this new mission is forward-looking so it works at any hour and on Friday it plans Monday.
- New CLAUDE.md injection in `tutorial-system-prompt.ts` orchestrates: PLAN paragraph → silent Composio check for all 3 toolkits → **two parallel subagents** (Calendar + Gmail in a single message) → **cross-reference pass** for things a human would miss → 4-tab Google Sheet (`{Day} {Mon} {DD} Plan`: Schedule / Replies needed / Commitments / Don't miss) → chat reply with the "Don't miss" tab inlined → email follow-up → `[TUTORIAL_COMPLETE]`.
- The "Don't miss" tab is the AHA: cross-references like "Acme sent an updated agenda 6h ago you haven't opened" or "you promised Tom a deck by EOD tomorrow, nothing on calendar to do it" — things no single tool surfaces alone.
- Tutorial chip is now a single CTA instead of 3 chips. Dropped dead `buildSkill` / `buildRoutineInput` / `skillSummary` / `firstRunPrompt` that were never wired at runtime, plus the `routineTime` / `routineEnabled` setup fields.
- Success card now uses the Activity Board's `card-running-glow` comet border so it actually catches the user's eye when `[TUTORIAL_COMPLETE]` fires.

## Files
- `app/src/components/onboarding/personal-assistant-missions.ts` — 6 missions → single `TUTORIAL_MISSION`
- `app/src/components/onboarding/tutorial-system-prompt.ts` — full rewrite of injected CLAUDE.md section
- `app/src/components/onboarding/personal-assistant-onboarding.tsx` — drop selectedMissionId/onPick
- `app/src/components/onboarding/missions/try.tsx` — single chip + comet success card with arrow CTA
- `app/src/components/onboarding/personal-assistant-artifacts.ts` — drop dead helpers, slim to live ones
- `app/src/components/onboarding/personal-assistant-artifacts.test.mjs` — replace dead-code tests
- `app/src/locales/{en,es,pt}/setup.json` — single skill/chip key, add googlesheets toolkit, punchier doneTitle/CTA

## Test plan
- [x] \`pnpm tsc --noEmit\` (full workspace, 15 projects)
- [x] \`pnpm check-locales\` (es + pt in sync with en)
- [x] \`node --test\` for onboarding test files (6/6 passing)
- [ ] Run \`pnpm tauri dev\` and walk through the tutorial end-to-end with a real Composio session — confirm parallel subagent dispatch, sheet creation with 4 tabs, "Don't miss" inlined in chat, email arrives, comet success card appears and is clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)