### PR TITLE
feat(onboarding): provider choice + faster tutorial + report success screen

### DIFF
--- a/app/src/components/onboarding/missions/try.tsx
+++ b/app/src/components/onboarding/missions/try.tsx
@@ -1,8 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { ArrowRight } from "lucide-react";
 import { ChatPanel, type FeedItem } from "@houston-ai/chat";
-import { Button, HoustonAvatar, cn, resolveAgentColor } from "@houston-ai/core";
+import { HoustonAvatar, cn, resolveAgentColor } from "@houston-ai/core";
 import {
   useConnectedToolkits,
   useConnections,
@@ -29,6 +28,7 @@ import {
 import type { Agent } from "../../../lib/types";
 import type { MissionMeta } from "../mission-frame";
 import { MissionWithChatFrame } from "../mission-with-chat-frame";
+import { TryDoneScreen } from "../try-done-screen";
 
 /**
  * Magic word the agent emits to signal "tutorial step done, frontend may
@@ -136,13 +136,17 @@ export function TryMission({
   // Magic-word completion signal. Restricted to `assistant_text` (the agent's
   // final visible reply) so reasoning / tool plumbing that incidentally
   // mentions the marker doesn't false-positive.
-  const tutorialDone = useMemo(() => {
-    return (feedItems ?? []).some((item) => {
-      if (item.feed_type !== "assistant_text") return false;
+  const finalReportMarkdown = useMemo(() => {
+    for (let i = (feedItems ?? []).length - 1; i >= 0; i--) {
+      const item = (feedItems ?? [])[i];
+      if (item.feed_type !== "assistant_text") continue;
       const data = item.data;
-      return typeof data === "string" && data.includes(TUTORIAL_END_MARKER);
-    });
+      if (typeof data !== "string" || !data.includes(TUTORIAL_END_MARKER)) continue;
+      return data.replace(TUTORIAL_END_MARKER, "").trim();
+    }
+    return null;
   }, [feedItems]);
+  const tutorialDone = finalReportMarkdown !== null;
 
   const handleOpenLink = useCallback((url: string) => {
     tauriSystem.openUrl(url).catch(console.error);
@@ -252,46 +256,43 @@ export function TryMission({
 
   const visibleFeed = (feedItems ?? []) as FeedItem[];
 
+  if (tutorialDone && finalReportMarkdown) {
+    return (
+      <TryDoneScreen
+        brandLabel={frame.brandLabel}
+        assistantName={agent.name}
+        assistantColor={assistantColor}
+        title={t("setup:tutorial.missions.try.doneTitle")}
+        reportMarkdown={finalReportMarkdown}
+        continueLabel={t("setup:tutorial.missions.try.continueChip")}
+        onContinue={onContinue}
+      />
+    );
+  }
+
   return (
     <MissionWithChatFrame
       meta={meta}
       {...frame}
       left={
         <div className="flex flex-1 flex-col gap-4">
-          {tutorialDone ? (
-            <div className="card-running-glow rounded-xl p-4">
-              <p className="text-sm font-medium text-foreground">
-                {t("setup:tutorial.missions.try.doneTitle")}
+          <div className="rounded-xl border border-black/5 bg-secondary/40 p-4">
+            <p className="text-sm font-medium">
+              {t("setup:tutorial.missions.try.tipTitle")}
+            </p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              {t("setup:tutorial.missions.try.tipBody")}
+            </p>
+          </div>
+          {pickedAny && (
+            <div className="rounded-xl border border-black/5 bg-secondary/40 p-4">
+              <p className="text-sm font-medium">
+                {t("setup:tutorial.missions.try.workingTitle")}
               </p>
               <p className="mt-2 text-sm text-muted-foreground">
-                {t("setup:tutorial.missions.try.doneBody")}
+                {t("setup:tutorial.missions.try.workingBody")}
               </p>
-              <Button className="mt-3 rounded-full" onClick={onContinue}>
-                {t("setup:tutorial.missions.try.continueChip")}
-                <ArrowRight className="ml-1 size-4" />
-              </Button>
             </div>
-          ) : (
-            <>
-              <div className="rounded-xl border border-black/5 bg-secondary/40 p-4">
-                <p className="text-sm font-medium">
-                  {t("setup:tutorial.missions.try.tipTitle")}
-                </p>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  {t("setup:tutorial.missions.try.tipBody")}
-                </p>
-              </div>
-              {pickedAny && (
-                <div className="rounded-xl border border-black/5 bg-secondary/40 p-4">
-                  <p className="text-sm font-medium">
-                    {t("setup:tutorial.missions.try.workingTitle")}
-                  </p>
-                  <p className="mt-2 text-sm text-muted-foreground">
-                    {t("setup:tutorial.missions.try.workingBody")}
-                  </p>
-                </div>
-              )}
-            </>
           )}
           {error && (
             <p className="rounded-xl border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">

--- a/app/src/components/onboarding/personal-assistant-artifacts.test.mjs
+++ b/app/src/components/onboarding/personal-assistant-artifacts.test.mjs
@@ -6,13 +6,12 @@ import {
 } from "./personal-assistant-artifacts.ts";
 import { TUTORIAL_MISSION } from "./personal-assistant-missions.ts";
 
-test("tutorial mission is the single Plan-my-next-working-day skill with three integrations", () => {
+test("tutorial mission is the single Plan-my-next-working-day skill with mail + calendar integrations", () => {
   assert.equal(TUTORIAL_MISSION.id, "plan-next-workday");
   assert.equal(TUTORIAL_MISSION.skillName, "plan-my-next-working-day");
   assert.deepEqual(TUTORIAL_MISSION.integrations, [
     "gmail",
     "googlecalendar",
-    "googlesheets",
   ]);
 });
 

--- a/app/src/components/onboarding/personal-assistant-missions.ts
+++ b/app/src/components/onboarding/personal-assistant-missions.ts
@@ -10,6 +10,6 @@ export interface MissionTemplate {
 export const TUTORIAL_MISSION: MissionTemplate = {
   id: "plan-next-workday",
   skillName: "plan-my-next-working-day",
-  integrations: ["gmail", "googlecalendar", "googlesheets"],
+  integrations: ["gmail", "googlecalendar"],
   image: "spiral-notepad",
 };

--- a/app/src/components/onboarding/try-done-screen.tsx
+++ b/app/src/components/onboarding/try-done-screen.tsx
@@ -1,0 +1,59 @@
+import { ArrowRight } from "lucide-react";
+import { MessageResponse } from "@houston-ai/chat";
+import { Button, HoustonAvatar, resolveAgentColor } from "@houston-ai/core";
+import { HoustonLogo } from "../shell/experience-card";
+
+interface TryDoneScreenProps {
+  brandLabel: string;
+  assistantName: string;
+  assistantColor: string;
+  title: string;
+  reportMarkdown: string;
+  continueLabel: string;
+  onContinue: () => void;
+}
+
+export function TryDoneScreen({
+  brandLabel,
+  assistantName,
+  assistantColor,
+  title,
+  reportMarkdown,
+  continueLabel,
+  onContinue,
+}: TryDoneScreenProps) {
+  return (
+    <div className="flex h-screen flex-col bg-background text-foreground">
+      <header className="shrink-0 bg-background/95 px-5 py-4 backdrop-blur">
+        <div className="mx-auto flex max-w-3xl items-center gap-2">
+          <HoustonLogo size={24} />
+          <span className="text-sm font-medium">{brandLabel}</span>
+        </div>
+      </header>
+      <main className="flex-1 overflow-y-auto px-6 py-8">
+        <div className="mx-auto flex w-full max-w-2xl flex-col gap-6">
+          <div className="flex flex-col items-center gap-4 text-center">
+            <HoustonAvatar
+              color={resolveAgentColor(assistantColor)}
+              diameter={48}
+              running
+            />
+            <h1 className="text-[28px] font-normal leading-tight">{title}</h1>
+            <p className="text-xs text-muted-foreground">{assistantName}</p>
+          </div>
+          <article className="prose prose-sm max-w-none rounded-xl border border-black/5 bg-secondary/30 p-6">
+            <MessageResponse>{reportMarkdown}</MessageResponse>
+          </article>
+        </div>
+      </main>
+      <footer className="shrink-0 border-t border-black/5 bg-background/95 px-6 py-4 backdrop-blur">
+        <div className="mx-auto flex w-full max-w-2xl justify-center">
+          <Button className="rounded-full px-6" onClick={onContinue}>
+            {continueLabel}
+            <ArrowRight className="ml-1 size-4" />
+          </Button>
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/app/src/components/onboarding/tutorial-system-prompt.ts
+++ b/app/src/components/onboarding/tutorial-system-prompt.ts
@@ -16,55 +16,72 @@ const END = "<!-- HOUSTON_TUTORIAL_END -->";
 
 const TUTORIAL_SECTION = `## Tutorial mode (first run)
 
-This is the user's first time running you in Houston. The user just clicked "Plan my next working day". Follow this exact pattern. Do not deviate.
+This is the user's first time running you in Houston. The user just clicked the localized "Plan my next working day" chip. Follow this exact pattern. Do not deviate.
 
-The mission: cross-reference the user's Google Calendar, Gmail, and Google Sheets to produce a structured plan for their next working day. The aha is that you do work no single tool can do alone, AND you surface things they would have missed.
+**LANGUAGE — read this first.** Detect the user's language from their FIRST message (the chip text they just sent) and reply in that same language for the entire tutorial, including section headers, draft replies, and the summary email subject + body. If they switch language mid-tutorial, follow them. Every English string below is a TEMPLATE for meaning and tone — translate it idiomatically, do not copy it verbatim. For Spanish use Latin-American neutral (tú, computador). For Portuguese use Brazilian (você). The following items are NEVER translated and must stay literal: the \`[TUTORIAL_COMPLETE]\` token, the \`[Sign in to Composio](...)\` link text and URL, all \`#houston_toolkit=...\` markdown links, all \`composio\` CLI commands, all toolkit slugs (\`gmail\`, \`googlecalendar\`, \`outlook\`, \`outlook_calendar\`), and the markdown structure itself (bold, bullets, emojis).
 
-1. Open with a concise PLAN paragraph in plain language, 2-3 short sentences. Cover: (a) you'll work the next working day (tomorrow if today is Mon-Thu, Monday if today is Fri-Sun), (b) you'll spawn parallel subagents to read Calendar and Gmail at the same time, then cross-reference them, (c) you'll write the result into a Google Sheet and email them the link. Don't list bullet points, don't use headings, just a tight paragraph the user can read in one breath. Then move on without waiting for confirmation.
+The mission: cross-reference the user's mail and calendar to produce a structured plan for their next working day, post it in chat with clear sections and bold headings, and create real draft replies in their mailbox for the top 3 emails worth answering. The aha is that you do work no single tool can do alone, AND you surface things they would have missed.
 
-2. SILENTLY check Composio for gmail, googlecalendar, and googlesheets connections (use \`composio search\` / \`composio execute\` per the integrations guide). Do NOT narrate the check.
+1. FIRST, ask the user one short question to pick their stack. Reply with exactly two short lines:
 
-3. If composio itself returns an authentication / not-signed-in error (no Composio session at all), STOP. Post the Composio sign-in card by writing exactly: \`[Sign in to Composio](https://composio.dev/#houston_composio_signin=1)\` and add one short line ("I need you to sign into Composio first so I can use your apps."). Wait for the user, then restart from step 2. Never fabricate results when you cannot reach Composio.
+   - "Quick check first: are you on **Google** (Gmail + Google Calendar) or **Microsoft** (Outlook + Outlook Calendar)?"
+   - "Just reply **Google** or **Microsoft** and I'll take it from there."
 
-4. If all three apps are connected, say so in one short line ("All three connected, here we go.") and continue to step 5.
+   Then STOP and wait for their answer. Do not announce a plan, do not start working, do not check connections yet. Just ask and wait.
 
-4b. If any app is missing, briefly say which one(s), then post a connect card per missing app using the standard #houston_toolkit pattern (one markdown link per app). Wait for the user to come back, then retry.
+2. Once they reply, bind the toolkits:
+   - "Google" / "Gmail" / "Google Calendar" / anything Google-flavored → MAIL_TOOLKIT = \`gmail\`, CAL_TOOLKIT = \`googlecalendar\`.
+   - "Microsoft" / "Outlook" / "Outlook Calendar" / "Office" / "365" → MAIL_TOOLKIT and CAL_TOOLKIT are the Microsoft equivalents on Composio. The Composio slugs vary slightly (commonly \`outlook\` for mail and \`outlook_calendar\` for calendar, but they may differ). Resolve them by running \`composio search outlook\` and \`composio search outlook calendar\` ONCE and picking the matching toolkit slugs from the results. Do this silently, do not narrate.
+   - If the answer is ambiguous, default to Google and say so in one short line ("Going with Google, tell me if you'd rather use Outlook.").
 
-5. Determine the target date. If today is Mon-Thu, target = tomorrow. If today is Fri/Sat/Sun, target = next Monday. Note this date as both ISO (YYYY-MM-DD) and short label "{Day} {Mon} {DD}" (e.g. "Mon May 11"). The Google Sheet title MUST be exactly "{Day} {Mon} {DD} Plan" (e.g. "Mon May 11 Plan").
+3. Post a tight PLAN paragraph (2-3 short sentences) in plain language. Cover: (a) you'll work the next working day (tomorrow if today is Mon-Thu, Monday if today is Fri-Sun), (b) you'll read calendar and mail in parallel and cross-reference them, (c) you'll post a structured plan in chat and save 3 draft replies in their inbox. No bullet points, no headings here, just one tight paragraph.
 
-6. Spawn two subagents IN PARALLEL using the Task tool. Both subagents must be launched in a single message with two tool uses so they actually run concurrently:
+4. SILENTLY check Composio for the chosen MAIL_TOOLKIT and CAL_TOOLKIT connections (use \`composio search\` / \`composio execute\` per the integrations guide). Do NOT narrate the check.
 
-   - **Calendar subagent**: read every Calendar event on the target date. For each event capture: time, title, attendees (especially external), location/meeting link, description. Return a clean structured list. If there are no events, say so explicitly.
+5. If composio itself returns an authentication / not-signed-in error (no Composio session at all), STOP. Post the Composio sign-in card by writing exactly: \`[Sign in to Composio](https://composio.dev/#houston_composio_signin=1)\` and add one short line ("I need you to sign into Composio first so I can use your apps."). Wait for the user, then restart from step 4. Never fabricate results when you cannot reach Composio.
 
-   - **Gmail subagent**: read the user's last 48 hours of Gmail. Return three buckets: (a) unread emails awaiting your reply, ranked by sender importance and staleness, (b) commitments the user themselves made in sent mail ("I'll send X by Friday", "I'll loop you in tomorrow", etc.), (c) any thread that mentions an event happening on the target date.
+6. If both apps are connected, say so in one short line ("Both connected, here we go.") and continue to step 7.
 
-7. CROSS-REFERENCE pass. Once both subagents return, look for things a human would miss. This is the magic. Examples of what to flag:
-   - "You have a 10am with Acme — they sent an updated agenda 6 hours ago you haven't opened."
+6b. If either app is missing, briefly say which one(s), then post a connect card per missing app using the standard #houston_toolkit pattern (one markdown link per app, with the chosen slug in the fragment). Wait for the user to come back, then retry.
+
+7. Determine the target date. If today is Mon-Thu, target = tomorrow. If today is Fri/Sat/Sun, target = next Monday. Note this date as both ISO (YYYY-MM-DD) and short label "{Day} {Mon} {DD}" (e.g. "Mon May 11").
+
+8. Read calendar and mail INLINE, in parallel. Do NOT spawn Task subagents for this. Speed matters. In a SINGLE message emit exactly two tool calls so they execute concurrently:
+
+   - One \`composio execute\` call against CAL_TOOLKIT to list events on the target date. Capture per event: time, title, attendees (especially external), location/meeting link, description. Use a date-range filter so the response is just the target day, not the whole week.
+
+   - One \`composio execute\` call against MAIL_TOOLKIT to fetch the most recent **20** messages from INBOX (last 48 hours is fine if the toolkit supports it; otherwise just take 20 most recent). Ask the toolkit to include sender name, sender email, thread/message ID, subject, snippet/body, and timestamp so you have everything needed to draft a reply without a second fetch.
+
+   Run them in the same assistant turn as parallel tool calls — do not wait for one before issuing the other.
+
+9. CROSS-REFERENCE pass. Once both calls return, reason directly over the merged data: pick the top 3 emails worth replying to (rank by sender importance and staleness, ignore obvious newsletters / receipts / automated noise), pull out commitments the user made in their own sent mail visible in any returned thread ("I'll send X by Friday", "I'll loop you in tomorrow", etc.), and look for things a human would miss. This is the magic. Examples of what to flag:
+   - "You have a 10am with Acme, they sent an updated agenda 6 hours ago you haven't opened."
    - "Your 2pm got rescheduled by email yesterday but your calendar still says 2pm."
-   - "You promised Tom a deck by EOD tomorrow (email Apr 28) — nothing on your calendar to do it."
-   - "Sarah asked if Friday still works — it's on your calendar, you haven't confirmed."
+   - "You promised Tom a deck by EOD tomorrow (email Apr 28), nothing on your calendar to do it."
+   - "Sarah asked if Friday still works, it's on your calendar, you haven't confirmed."
    Aim for 3 to 5 items. If genuinely nothing surprising, say so honestly rather than padding.
 
-8. Create a NEW Google Sheet titled exactly "{Day} {Mon} {DD} Plan". The sheet must have FOUR tabs in this order:
+10. Reply in chat with a STRUCTURED markdown message. Use **bold** for section headers and key names. Keep lines short. No walls of text. No em dashes (use commas or sentence breaks). Use this exact structure and order, and OMIT any section that has nothing to report:
 
-   - **Schedule** — columns: Time | Event | Attendees | Prep needed | Email context. One row per Calendar event.
-   - **Replies needed** — columns: Priority | From | Subject | Why it matters | Suggested reply (1 line) | Days waiting. One row per email that needs a reply.
-   - **Commitments** — columns: Promised to | What | Source email | Due | Status. One row per commitment the user made.
-   - **Don't miss** — columns: Heads-up | Why I flagged it | Action. One row per cross-reference finding from step 7. THIS IS THE MAGIC TAB.
+    First line: "Here's your **{Day} {Mon} {DD}** plan."
 
-   Use the googlesheets toolkit. Get the share URL of the new sheet.
+    **Don't miss**
+    (Only include this section if the cross-reference pass found anything. Put it FIRST so it cannot be skimmed past. One bullet per finding, each starting with a bold short label, then a comma, then the detail. Keep each bullet to one short line.)
 
-9. Reply in chat with:
-   - One sentence: "I built your {Day} {Mon} {DD} plan." with the sheet link inline.
-   - Three short bullets summarizing scale: how many events, how many emails need replies, how many commitments.
-   - The "Don't miss" section inlined verbatim (just the heads-ups, one per line). This is what makes the user say "wow, I didn't notice this."
-   - Format clearly. No walls of text.
+    **Your day**
+    (Chronological agenda, one bullet per event. Format each line as: \`**{HH:MM}** · {Title}\` followed by a short tail with attendees if external and a one-line prep note if relevant. If there are no events, say "Nothing on the calendar." in one line and skip the bullets.)
 
-10. THEN send an email to the user themselves containing the same summary + sheet link. Look up the user's email via a Gmail profile / current-user tool. Subject: "Your {Day} {Mon} {DD} plan". Body: the summary you just posted in chat, lightly formatted. After sending, add ONE short line in chat ("Also sent it to your inbox.").
+    **Worth replying, drafts ready in your inbox**
+    (Top **3** emails awaiting a reply, no more. Before posting this section, ACTUALLY create the 3 draft replies in the user's mailbox using MAIL_TOOLKIT, threaded on the original message so each shows up under the existing thread. **Issue all 3 create-draft tool calls in a SINGLE assistant turn so they run in parallel** — do not create them one by one. The draft body should be a short, warm, on-tone reply, ready to send with light edits, signed with the user's first name if you can read it from their profile. Format each bullet as: \`**{From}** · {Subject}\` then a one-line "why it matters", then a sub-line "Draft saved, tweak and send." Omit the whole section if the inbox is genuinely empty of things worth replying to. The section header itself signals that the drafts are already in the inbox, so do NOT also write a separate "I created drafts" sentence above or below.)
 
-11. End your final message with the literal token [TUTORIAL_COMPLETE] on its own line. The frontend uses this token to advance the tutorial. Emit it ONLY after you have created the sheet AND posted the chat reply AND sent the email. Never emit it before.
+    **Your commitments**
+    (Promises the user made that are coming due. Format: \`**{What}** · promised to {Person}\` then a short tail with the deadline or source date. Omit the section entirely if there are none.)
 
-Be tight. No apologies. No "let me think about that". No narration of your process. Announce, check connections, post cards if needed, run the parallel subagents, cross-reference, build the sheet, deliver the chat summary with the magic tab inlined, send the email, emit the token. Done.
+    Final line, one sentence: a short, warm closing tied to the day (e.g. "Light day, focus on Acme prep." or "Heavy on meetings, protect the morning."). One sentence, no fluff.
+
+11. End your final message with the literal token [TUTORIAL_COMPLETE] on its own line, AFTER the structured chat reply. The frontend uses this token to advance the tutorial. Emit it ONLY after you have posted the structured chat reply (with the 3 drafts already saved). Never emit it before.
+
+Be tight. No apologies. No "let me think about that". No narration of your process. Ask the Google/Microsoft question first, wait, bind toolkits, announce the plan, check connections, post cards if needed, fire the two read tool calls (calendar + mail) in parallel inline, cross-reference, fire the 3 create-draft tool calls in parallel, deliver the structured chat summary with bold sections, emit the token. Done.
 `;
 
 /** Append the tutorial section to CLAUDE.md if not already present. */

--- a/app/src/locales/en/setup.json
+++ b/app/src/locales/en/setup.json
@@ -36,7 +36,8 @@
     "toolkits": {
       "gmail": "Gmail",
       "googlecalendar": "Google Calendar",
-      "googlesheets": "Google Sheets"
+      "outlook": "Outlook",
+      "outlook_calendar": "Outlook Calendar"
     },
     "defaults": {
       "workspaceName": "Personal",
@@ -60,7 +61,7 @@
       },
       "tools": {
         "title": "Give it your own tools",
-        "body": "Houston connects to Gmail, Calendar and 1000+ apps through your integrations provider. We use Composio by default. Sign in once so your assistant can actually do work with your real apps.",
+        "body": "Houston connects to your mail, calendar and 1000+ apps through your integrations provider. We use Composio by default. Sign in once so your assistant can actually do work with your real apps.",
         "cardTitle": "Integrations provider",
         "cardBody": "Sign in to let your assistant use your apps. Default provider: Composio.",
         "cardSignedInBody": "Your assistant can now use your apps",
@@ -71,21 +72,20 @@
       },
       "try": {
         "title": "Try a real mission",
-        "body": "Real chat with your assistant. Click the mission to start. Your assistant will ask for Gmail, Calendar, or Sheets right here in the chat if it needs them.",
+        "body": "Real chat with your assistant. Click the mission to start. Your assistant will ask whether you use Google or Microsoft, then request mail and calendar access right here in the chat if it needs them.",
         "tipTitle": "This is the real chat",
         "tipBody": "Same chat you'll use after the tutorial. Click the mission to start, then reply naturally. Connection requests show up as cards your assistant posts in the chat.",
         "workingTitle": "Working on it",
         "workingBody": "Reply in the chat as you would normally. The tutorial will continue automatically once your assistant finishes.",
         "doneTitle": "You did it. First mission complete.",
-        "doneBody": "Your assistant just did real work with your real apps. Take a quick tour of Houston, then you're free.",
         "placeholder": "Reply to your assistant...",
         "skill": {
           "title": "Plan my next working day",
-          "description": "Read your Calendar and Gmail in parallel, cross-reference them for things you'd miss, and write a structured plan into a Google Sheet."
+          "description": "Read your calendar and inbox in parallel, cross-reference them for things you'd miss, and post a structured plan with what's urgent, your agenda and what to reply."
         },
         "chip": "Plan my next working day",
         "composerHint": "Click to start the mission.",
-        "continueChip": "Take the tour"
+        "continueChip": "Enter Houston"
       }
     }
   }

--- a/app/src/locales/es/setup.json
+++ b/app/src/locales/es/setup.json
@@ -36,7 +36,8 @@
     "toolkits": {
       "gmail": "Gmail",
       "googlecalendar": "Google Calendar",
-      "googlesheets": "Google Sheets"
+      "outlook": "Outlook",
+      "outlook_calendar": "Outlook Calendar"
     },
     "defaults": {
       "workspaceName": "Personal",
@@ -60,7 +61,7 @@
       },
       "tools": {
         "title": "Dale tus propias herramientas",
-        "body": "Houston se conecta con Gmail, Calendar y más de 1000 apps a través de tu proveedor de integraciones. Por defecto usamos Composio. Inicia sesión una vez para que tu asistente pueda trabajar con tus apps reales.",
+        "body": "Houston se conecta con tu correo, calendario y más de 1000 apps a través de tu proveedor de integraciones. Por defecto usamos Composio. Inicia sesión una vez para que tu asistente pueda trabajar con tus apps reales.",
         "cardTitle": "Proveedor de integraciones",
         "cardBody": "Inicia sesión para que tu asistente use tus apps. Proveedor por defecto: Composio.",
         "cardSignedInBody": "Tu asistente ya puede usar tus apps",
@@ -71,21 +72,20 @@
       },
       "try": {
         "title": "Prueba una misión real",
-        "body": "Chat real con tu asistente. Haz clic en la misión para empezar. Tu asistente te pedirá Gmail, Calendar o Sheets aquí mismo si los necesita.",
+        "body": "Chat real con tu asistente. Haz clic en la misión para empezar. Tu asistente te preguntará si usas Google o Microsoft y luego pedirá acceso a tu correo y calendario aquí mismo en el chat si los necesita.",
         "tipTitle": "Este es el chat real",
         "tipBody": "El mismo chat que usarás después del tutorial. Haz clic en la misión para empezar y responde con naturalidad. Las solicitudes de conexión aparecen como tarjetas que tu asistente publica en el chat.",
         "workingTitle": "Trabajando en ello",
         "workingBody": "Responde en el chat como lo harías normalmente. El tutorial continuará automáticamente cuando tu asistente termine.",
         "doneTitle": "Lo lograste. Primera misión completada.",
-        "doneBody": "Tu asistente acaba de hacer trabajo real con tus apps reales. Toma un tour rápido de Houston y listo.",
         "placeholder": "Responde a tu asistente...",
         "skill": {
           "title": "Planea mi siguiente día de trabajo",
-          "description": "Lee tu Calendar y Gmail en paralelo, los cruza para encontrar cosas que se te escaparían y escribe un plan estructurado en un Google Sheet."
+          "description": "Lee tu calendario y correo en paralelo, los cruza para encontrar cosas que se te escaparían y publica un plan estructurado con lo urgente, tu agenda y a quién responder."
         },
         "chip": "Planea mi siguiente día de trabajo",
         "composerHint": "Haz clic para empezar la misión.",
-        "continueChip": "Hacer el tour"
+        "continueChip": "Entra a Houston"
       }
     }
   }

--- a/app/src/locales/pt/setup.json
+++ b/app/src/locales/pt/setup.json
@@ -36,7 +36,8 @@
     "toolkits": {
       "gmail": "Gmail",
       "googlecalendar": "Google Calendar",
-      "googlesheets": "Google Sheets"
+      "outlook": "Outlook",
+      "outlook_calendar": "Outlook Calendar"
     },
     "defaults": {
       "workspaceName": "Pessoal",
@@ -60,7 +61,7 @@
       },
       "tools": {
         "title": "Dê as suas próprias ferramentas",
-        "body": "O Houston se conecta ao Gmail, Calendar e mais de 1000 apps através do seu provedor de integrações. Por padrão usamos o Composio. Entre uma vez para seu assistente poder trabalhar com seus apps reais.",
+        "body": "O Houston se conecta ao seu e-mail, calendário e mais de 1000 apps através do seu provedor de integrações. Por padrão usamos o Composio. Entre uma vez para seu assistente poder trabalhar com seus apps reais.",
         "cardTitle": "Provedor de integrações",
         "cardBody": "Entre para seu assistente usar seus apps. Provedor padrão: Composio.",
         "cardSignedInBody": "Seu assistente já pode usar seus apps",
@@ -71,21 +72,20 @@
       },
       "try": {
         "title": "Teste uma missão real",
-        "body": "Chat real com seu assistente. Clique na missão para começar. Seu assistente vai pedir Gmail, Calendar ou Sheets aqui mesmo se precisar.",
+        "body": "Chat real com seu assistente. Clique na missão para começar. Seu assistente vai perguntar se você usa Google ou Microsoft e depois pedir acesso ao seu e-mail e calendário aqui mesmo no chat se precisar.",
         "tipTitle": "Esse é o chat real",
         "tipBody": "O mesmo chat que você vai usar depois do tutorial. Clique na missão para começar e responda naturalmente. Pedidos de conexão aparecem como cartões que seu assistente posta no chat.",
         "workingTitle": "Trabalhando nisso",
         "workingBody": "Responda no chat como você faria normalmente. O tutorial vai seguir automaticamente quando seu assistente terminar.",
         "doneTitle": "Você conseguiu. Primeira missão concluída.",
-        "doneBody": "Seu assistente acabou de fazer trabalho real com seus apps reais. Faça um tour rápido do Houston e pronto.",
         "placeholder": "Responda ao seu assistente...",
         "skill": {
           "title": "Planeja meu próximo dia de trabalho",
-          "description": "Lê sua agenda e Gmail em paralelo, cruza para achar coisas que você ia perder e escreve um plano estruturado num Google Sheet."
+          "description": "Lê sua agenda e caixa de entrada em paralelo, cruza para achar coisas que você ia perder e posta um plano estruturado com o que é urgente, sua agenda e quem responder."
         },
         "chip": "Planeja meu próximo dia de trabalho",
         "composerHint": "Clique para começar a missão.",
-        "continueChip": "Fazer o tour"
+        "continueChip": "Entre no Houston"
       }
     }
   }


### PR DESCRIPTION
## Summary

Rework the first-run "Plan my next working day" tutorial along three axes: stack choice, speed, and the success moment.

- **Provider choice.** Agent first asks the user **Google or Microsoft** in chat, binds `gmail` + `googlecalendar` or `outlook` + `outlook_calendar` at runtime (resolves Outlook slugs via `composio search` since they vary slightly). Defaults to Google if the answer is ambiguous. Google Sheets dropped from the flow entirely.
- **Faster.** Two `Task` subagents replaced with two inline `composio execute` tool calls (calendar events on the target date + 20 most recent inbox messages with full sender/thread context) issued in a single turn so they run in parallel. The 3 draft replies are also created in parallel (single turn, 3 tool calls). Expected total runtime drops from ~1-3 min to ~30-60s.
- **Structured report in the user's language.** Chat reply uses bold section headers in this exact order: **Don't miss** (only if findings), **Your day**, **Worth replying, drafts ready in your inbox** (top 3 with real drafts saved), **Your commitments** (only if any). Section headers and bodies are translated by the agent into the user's language. Em dashes banned in user-facing copy per repo convention.
- **Drafts are real.** The agent creates 3 actual draft replies in the user's mailbox via `MAIL_TOOLKIT`, threaded on the original messages, signed with the user's first name from their profile.
- **Drop email-back step.** No more "I also sent it to your inbox." The structured chat report is the deliverable.
- **New success screen.** When `[TUTORIAL_COMPLETE]` lands, the chat split unmounts and a full-bleed `TryDoneScreen` shows the agent's final report rendered through `MessageResponse` (same Streamdown styling as chat) with a sticky footer **Enter Houston** CTA. Old in-frame "comet success card" gone.

## Files

- `app/src/components/onboarding/tutorial-system-prompt.ts` — full rewrite of the 11-step tutorial flow.
- `app/src/components/onboarding/try-done-screen.tsx` — new full-bleed success screen with sticky footer CTA.
- `app/src/components/onboarding/missions/try.tsx` — early-returns `TryDoneScreen` when done; derives last assistant report from feed; `Button` / `ArrowRight` imports cleaned up.
- `app/src/components/onboarding/personal-assistant-missions.ts` + test — integrations narrowed to `["gmail", "googlecalendar"]`.
- `app/src/locales/{en,es,pt}/setup.json` — toolkit map adds `outlook` / `outlook_calendar` and drops `googlesheets`; `try.body`, `tools.body`, `try.skill.description` reworded; `continueChip` now "Enter Houston" / "Entra a Houston" / "Entre no Houston"; `doneBody` and `doneHighlights` removed (now redundant).

## Test plan

- [ ] `pnpm tsc --noEmit` passes (verified locally).
- [ ] `pnpm check-locales` passes — all locales in sync (verified locally).
- [ ] `personal-assistant-artifacts.test.mjs` passes (verified locally).
- [ ] Run the tutorial end-to-end against a Google account: agent asks Google/Microsoft, posts plan, creates 3 real drafts in Gmail, success screen shows the report with sticky CTA, **Enter Houston** lands in the workspace.
- [ ] Run the tutorial against a Microsoft / Outlook account: same flow with `outlook` + `outlook_calendar` toolkits and drafts in Outlook.
- [ ] Switch app language to Spanish and confirm the agent replies in Spanish (section headers, draft bodies, success-screen report).
- [ ] Confirm no `googlesheets` connect cards are posted.
- [ ] Confirm the success-screen footer stays pinned while scrolling a long report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)