### PR TITLE
fix(missions): persist model selection per mission

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -36,13 +36,16 @@ import {
 } from "@houston-ai/chat";
 
 import { useFeedStore } from "../stores/feeds";
+import { useUIStore } from "../stores/ui";
 import { useWorkspaceStore } from "../stores/workspaces";
 import {
+  useActivity,
   useConnectedToolkits,
   useConnections,
   useSkills,
 } from "../hooks/queries";
 import {
+  tauriActivity,
   tauriAttachments,
   tauriChat,
   tauriConfig,
@@ -143,11 +146,12 @@ export function useAgentChatPanel({
   const { t } = useTranslation(["board", "chat"]);
   const { processLabels, getThinkingMessage } = useChatDisplayLabels();
   const queryClient = useQueryClient();
+  const addToast = useUIStore((s) => s.addToast);
 
   const path = agent?.folderPath ?? null;
   const agentModes = agentDef?.config.agents;
 
-  // ── Workspace / agent / chat tier model resolution ────────────────────
+  // ── Workspace / agent / activity tier model resolution ─────────────────
   const workspace = useWorkspaceStore((s) => s.current);
   const wsProvider = workspace?.provider ?? "anthropic";
   const wsModel = workspace?.model ?? getDefaultModel(wsProvider);
@@ -167,20 +171,44 @@ export function useAgentChatPanel({
       })
       .catch(() => {});
   }, [path]);
+
+  const { data: activities } = useActivity(path ?? undefined);
+  const selectedActivity = useMemo(() => {
+    if (!selectedSessionKey || !activities) return null;
+    return activities.find(
+      (a) => (a.session_key ?? `activity-${a.id}`) === selectedSessionKey,
+    ) ?? null;
+  }, [activities, selectedSessionKey]);
+  const activityProvider = selectedActivity?.provider ?? null;
+  const activityModel = selectedActivity?.model ?? null;
+  const selectedActivityId = selectedActivity?.id ?? null;
+
   const [chatProvider, setChatProvider] = useState<string | null>(null);
   const [chatModel, setChatModel] = useState<string | null>(null);
-  // Reset per-chat overrides when the agent changes; the previous agent's
-  // model choice doesn't make sense for a different agent.
   useEffect(() => {
     setChatProvider(null);
     setChatModel(null);
-  }, [path]);
-  const effectiveProvider = chatProvider ?? agentProvider ?? wsProvider;
-  const effectiveModel = chatModel ?? agentModel ?? wsModel;
-  const handleModelSelect = useCallback((prov: string, mod: string) => {
-    setChatProvider(prov);
-    setChatModel(mod);
-  }, []);
+  }, [selectedSessionKey]);
+  const effectiveProvider = chatProvider ?? activityProvider ?? agentProvider ?? wsProvider;
+  const effectiveModel = chatModel ?? activityModel ?? agentModel ?? wsModel;
+  const handleModelSelect = useCallback(
+    (prov: string, mod: string) => {
+      setChatProvider(prov);
+      setChatModel(mod);
+      if (!path || !selectedActivityId) return;
+      tauriActivity.update(path, selectedActivityId, {
+        provider: prov,
+        model: mod,
+      }).catch((err) => {
+        addToast({
+          title: t("chat:errors.modelPersistFailed"),
+          description: String(err),
+          variant: "error",
+        });
+      });
+    },
+    [path, selectedActivityId, addToast, t],
+  );
 
   // ── Composio link card support ────────────────────────────────────────
   const { data: composioStatus } = useConnections();

--- a/app/src/data/activity.ts
+++ b/app/src/data/activity.ts
@@ -20,6 +20,8 @@ export interface Activity {
   routine_id?: string;
   routine_run_id?: string;
   updated_at?: string;
+  provider?: string;
+  model?: string;
 }
 
 export interface ActivityUpdate {
@@ -32,6 +34,8 @@ export interface ActivityUpdate {
   worktree_path?: string | null;
   routine_id?: string;
   routine_run_id?: string;
+  provider?: string;
+  model?: string;
 }
 
 const NAME = "activity";
@@ -47,6 +51,8 @@ export async function create(
   description = "",
   agent?: string,
   worktreePath?: string,
+  provider?: string,
+  model?: string,
 ): Promise<Activity> {
   const items = await list(agentPath);
   const item: Activity = {
@@ -58,6 +64,8 @@ export async function create(
     agent,
     worktree_path: worktreePath ?? null,
     updated_at: now(),
+    provider,
+    model,
   };
   await writeAgentJson(agentPath, NAME, s, [...items, item]);
   return item;

--- a/app/src/hooks/queries/use-activity.ts
+++ b/app/src/hooks/queries/use-activity.ts
@@ -8,6 +8,7 @@ export function useActivity(agentPath: string | undefined) {
     queryKey: queryKeys.activity(agentPath ?? ""),
     queryFn: () => tauriActivity.list(agentPath!),
     enabled: !!agentPath,
+    initialData: [],
   });
 }
 

--- a/app/src/lib/create-mission.ts
+++ b/app/src/lib/create-mission.ts
@@ -107,6 +107,8 @@ export async function createMission(
     description,
     opts.agentMode,
     opts.worktreePath,
+    opts.providerOverride,
+    opts.modelOverride,
   );
   const conversationId = item.id;
   const sessionKey = sessionKeyForActivity(conversationId);

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -547,7 +547,9 @@ export const tauriActivity = {
     description?: string,
     agent?: string,
     worktreePath?: string,
-  ) => activityData.create(agentPath, title, description ?? "", agent, worktreePath),
+    provider?: string,
+    model?: string,
+  ) => activityData.create(agentPath, title, description ?? "", agent, worktreePath, provider, model),
   update: (
     agentPath: string,
     activityId: string,

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -17,7 +17,8 @@
     "description": "Type a message to talk to your assistant."
   },
   "errors": {
-    "sessionStart": "Failed to start session: {{error}}"
+    "sessionStart": "Failed to start session: {{error}}",
+    "modelPersistFailed": "Failed to save model preference"
   },
   "toolRuntimeError": {
     "retryPrompt": "Try again."

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -17,7 +17,8 @@
     "description": "Escribe un mensaje para hablar con tu asistente."
   },
   "errors": {
-    "sessionStart": "No se pudo iniciar la sesión: {{error}}"
+    "sessionStart": "No se pudo iniciar la sesión: {{error}}",
+    "modelPersistFailed": "No se pudo guardar la preferencia de modelo"
   },
   "toolRuntimeError": {
     "retryPrompt": "Intenta de nuevo."

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -17,7 +17,8 @@
     "description": "Digite uma mensagem para falar com seu assistente."
   },
   "errors": {
-    "sessionStart": "Não foi possível iniciar a sessão: {{error}}"
+    "sessionStart": "Não foi possível iniciar a sessão: {{error}}",
+    "modelPersistFailed": "Não foi possível salvar a preferência de modelo"
   },
   "toolRuntimeError": {
     "retryPrompt": "Tente de novo."

--- a/engine/houston-engine-core/src/agents/activity.rs
+++ b/engine/houston-engine-core/src/agents/activity.rs
@@ -37,6 +37,8 @@ pub fn create(root: &Path, input: NewActivity) -> CoreResult<Activity> {
         routine_id: None,
         routine_run_id: None,
         updated_at: Some(now),
+        provider: input.provider,
+        model: input.model,
     };
     items.push(item.clone());
     write_json(root, FILE, &items)?;
@@ -76,6 +78,12 @@ pub fn update(root: &Path, id: &str, updates: ActivityUpdate) -> CoreResult<Acti
     }
     if let Some(routine_run_id) = updates.routine_run_id {
         item.routine_run_id = Some(routine_run_id);
+    }
+    if let Some(provider) = updates.provider {
+        item.provider = Some(provider);
+    }
+    if let Some(model) = updates.model {
+        item.model = Some(model);
     }
 
     item.updated_at = Some(Utc::now().to_rfc3339());

--- a/engine/houston-engine-core/src/agents/mod.rs
+++ b/engine/houston-engine-core/src/agents/mod.rs
@@ -124,6 +124,8 @@ mod tests {
                 description: "desc".into(),
                 agent: Some("execution".into()),
                 worktree_path: None,
+                provider: None,
+                model: None,
             })
             .unwrap();
         assert_eq!(a.title, "first");
@@ -141,6 +143,51 @@ mod tests {
         assert_eq!(updated.status, "completed");
         s.delete_activity(&a.id).unwrap();
         assert!(s.list_activity().unwrap().is_empty());
+    }
+
+    #[test]
+    fn per_mission_model_isolation() {
+        let d = tmp();
+        let s = AgentStore::new(d.path());
+        s.ensure_houston_dir().unwrap();
+        let a1 = s
+            .create_activity(NewActivity {
+                title: "mission-one".into(),
+                description: String::new(),
+                provider: Some("anthropic".into()),
+                model: Some("opus".into()),
+                ..Default::default()
+            })
+            .unwrap();
+        let a2 = s
+            .create_activity(NewActivity {
+                title: "mission-two".into(),
+                description: String::new(),
+                ..Default::default()
+            })
+            .unwrap();
+        assert_eq!(a1.provider.as_deref(), Some("anthropic"));
+        assert_eq!(a1.model.as_deref(), Some("opus"));
+        assert_eq!(a2.provider, None);
+        assert_eq!(a2.model, None);
+
+        s.update_activity(
+            &a2.id,
+            ActivityUpdate {
+                provider: Some("openai".into()),
+                model: Some("gpt-5.4".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let items = s.list_activity().unwrap();
+        let r1 = items.iter().find(|a| a.id == a1.id).unwrap();
+        let r2 = items.iter().find(|a| a.id == a2.id).unwrap();
+        assert_eq!(r1.provider.as_deref(), Some("anthropic"));
+        assert_eq!(r1.model.as_deref(), Some("opus"));
+        assert_eq!(r2.provider.as_deref(), Some("openai"));
+        assert_eq!(r2.model.as_deref(), Some("gpt-5.4"));
     }
 
     #[test]

--- a/engine/houston-engine-core/src/agents/types.rs
+++ b/engine/houston-engine-core/src/agents/types.rs
@@ -33,6 +33,10 @@ pub struct Activity {
     /// ISO-8601 timestamp — set on create and every update.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -46,6 +50,8 @@ pub struct ActivityUpdate {
     pub worktree_path: Option<Option<String>>,
     pub routine_id: Option<String>,
     pub routine_run_id: Option<String>,
+    pub provider: Option<String>,
+    pub model: Option<String>,
 }
 
 /// Fields for creating a new activity (no id — generated).
@@ -58,6 +64,10 @@ pub struct NewActivity {
     pub agent: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub worktree_path: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 // -- Routines --

--- a/engine/houston-engine-core/src/routines/engine_dispatcher.rs
+++ b/engine/houston-engine-core/src/routines/engine_dispatcher.rs
@@ -132,6 +132,8 @@ impl ActivitySurface for EngineActivitySurface {
                 description: description.to_string(),
                 agent: None,
                 worktree_path: None,
+                provider: None,
+                model: None,
             },
         )
         .map_err(|e| e.to_string())?;

--- a/ui/agent-schemas/src/activity.schema.json
+++ b/ui/agent-schemas/src/activity.schema.json
@@ -17,7 +17,9 @@
       "worktree_path": { "type": ["string", "null"] },
       "routine_id": { "type": "string" },
       "routine_run_id": { "type": "string" },
-      "updated_at": { "type": "string", "format": "date-time" }
+      "updated_at": { "type": "string", "format": "date-time" },
+      "provider": { "type": "string" },
+      "model": { "type": "string" }
     },
     "additionalProperties": false
   }

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -128,6 +128,8 @@ export interface Activity {
   routine_id?: string;
   routine_run_id?: string;
   updated_at?: string;
+  provider?: string;
+  model?: string;
 }
 
 export interface ActivityUpdate {
@@ -140,6 +142,8 @@ export interface ActivityUpdate {
   worktree_path?: string | null;
   routine_id?: string;
   routine_run_id?: string;
+  provider?: string;
+  model?: string;
 }
 
 export interface NewActivity {
@@ -147,6 +151,8 @@ export interface NewActivity {
   description?: string;
   agent?: string;
   worktree_path?: string;
+  provider?: string;
+  model?: string;
 }
 
 export interface Routine {


### PR DESCRIPTION
## Who this is for

Anyone running several missions at the same time — a sales person researching three accounts in parallel, an operator drafting two emails while a long research task runs in another mission.

## The problem

Each mission has a model picker under the chat input — the little "Sonnet / Opus / Haiku" selector that controls which AI is doing the work.

Users want fast and cheap (Haiku) for short replies, and deeper but slower (Opus) for hard research. The picker LOOKED like it was per-mission, but it wasn't: switching it on one mission silently changed it on every other mission too.

Esteban Jaramillo flagged this in the beta-users WhatsApp group on Friday. Felipe confirmed it's a bug:

> "Es un bug. La manera en que debería funcionar es que cada vez que abras una misión, debajo de la barra de texto, puedes elegir el modelo."

## What's different now

The picker is honestly per-mission:

- Pick Opus on mission A → mission B is unaffected.
- Switch to Haiku on mission B → mission A still on Opus.
- Quit Houston and reopen → each mission remembers what you left it on.

If saving the choice ever fails (rare — would need disk to be unreachable), the user gets a visible toast instead of silent inconsistency, in line with the beta-stage error policy already documented in CLAUDE.md.

## Why it matters for the user

The picker is the only knob between "fast and cheap" and "deep but slow". Power users were either accidentally running their cheap work on Opus (burning tokens) or their hard work on Haiku (getting weaker answers) without realising. The bug had a direct cost-and-quality impact every time they switched contexts.

## How it was verified

- Repro confirmed on macOS desktop build: two missions side by side, model switched, restart, each mission held its choice.
- Engine unit test (`per_mission_model_isolation`) covers the isolation guarantee.
- App typecheck, locale validation (en/es/pt), and full engine test suite green.

Repro video below.

<!-- Drag the .mp4 here when you upload -->
