### PR TITLE
feat(chat): suggest first prompts when an agent has no skills yet

### DIFF
--- a/app/src/components/toolkit-suggestions-empty-state.tsx
+++ b/app/src/components/toolkit-suggestions-empty-state.tsx
@@ -1,0 +1,59 @@
+import { useTranslation } from "react-i18next";
+import type { ToolkitSuggestion } from "../lib/toolkit-suggestions";
+import { SkillCard } from "./skill-card";
+
+interface Props {
+  suggestions: ToolkitSuggestion[];
+  onPick: (prompt: string) => void;
+  onConnectClick?: () => void;
+}
+
+export function ToolkitSuggestionsEmptyState({
+  suggestions,
+  onPick,
+  onConnectClick,
+}: Props) {
+  const { t } = useTranslation("board");
+  const isEmpty = suggestions.length === 0;
+  return (
+    <div className="self-stretch w-full h-full overflow-y-auto">
+      <div className="max-w-3xl mx-auto w-full px-6 pt-6 pb-4 flex flex-col gap-3">
+        <div className="text-center mb-1">
+          <h3 className="text-base font-semibold text-foreground">
+            {t(
+              isEmpty
+                ? "chatEmpty.suggestions.headingEmpty"
+                : "chatEmpty.suggestions.heading",
+            )}
+          </h3>
+          <p className="text-sm text-muted-foreground mt-1">
+            {t(
+              isEmpty
+                ? "chatEmpty.suggestions.subheadingEmpty"
+                : "chatEmpty.suggestions.subheading",
+            )}
+          </p>
+        </div>
+        {isEmpty && onConnectClick ? (
+          <SkillCard
+            image="electric-plug"
+            title={t("chatEmpty.suggestions.connectCta.title")}
+            description={t("chatEmpty.suggestions.connectCta.description")}
+            onClick={onConnectClick}
+          />
+        ) : (
+          suggestions.map((s) => (
+            <SkillCard
+              key={s.id}
+              image={s.image}
+              title={t(`chatEmpty.suggestions.${s.id}.title` as const)}
+              description={t(`chatEmpty.suggestions.${s.id}.description` as const)}
+              integrations={s.toolkits}
+              onClick={() => onPick(t(`chatEmpty.suggestions.${s.id}.prompt` as const))}
+            />
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -35,7 +35,9 @@ import {
   type UserAttachmentMessageLabels,
 } from "@houston-ai/chat";
 
+import { useDraftStore } from "../stores/drafts";
 import { useFeedStore } from "../stores/feeds";
+import { useUIStore } from "../stores/ui";
 import { useWorkspaceStore } from "../stores/workspaces";
 import {
   useConnectedToolkits,
@@ -51,6 +53,7 @@ import {
   withAttachmentPaths,
 } from "../lib/tauri";
 import { createMission } from "../lib/create-mission";
+import { deriveToolkitSuggestions } from "../lib/toolkit-suggestions";
 import { queryKeys } from "../lib/query-keys";
 import { humanizeSkillName } from "../lib/humanize-skill-name";
 import { useFileToolRenderer } from "../hooks/use-file-tool-renderer";
@@ -72,6 +75,7 @@ import {
 } from "../lib/skill-message";
 import { attachmentReferences } from "../lib/attachment-message";
 import { SkillCard } from "./skill-card";
+import { ToolkitSuggestionsEmptyState } from "./toolkit-suggestions-empty-state";
 import { NewMissionPickerDialog } from "./new-mission-picker-dialog";
 import { UserSkillMessage } from "./user-skill-message";
 import { SelectedSkillChip } from "./selected-skill-chip";
@@ -223,6 +227,26 @@ export function useAgentChatPanel({
     0,
     (allSkills?.length ?? 0) - emptySkillShowcase.length,
   );
+
+  const toolkitSuggestions = useMemo(
+    () => deriveToolkitSuggestions(connectedSet),
+    [connectedSet],
+  );
+  const handlePickSuggestion = useCallback(
+    (prompt: string) => {
+      const key = selectedSessionKey ?? "new-conversation";
+      useDraftStore.getState().setDraftText(key, prompt);
+      requestAnimationFrame(() => {
+        document
+          .querySelector<HTMLTextAreaElement>('textarea[name="message"]')
+          ?.focus();
+      });
+    },
+    [selectedSessionKey],
+  );
+  const handleConnectClick = useCallback(() => {
+    useUIStore.getState().setViewMode("connections");
+  }, []);
 
   const [pickerOpen, setPickerOpen] = useState(false);
   const [activeSkill, setActiveSkill] = useState<SkillSummary | null>(null);
@@ -445,7 +469,15 @@ export function useAgentChatPanel({
   const chatEmptyState = useMemo<AIBoardProps["chatEmptyState"]>(() => {
     if (!agent) return undefined;
     if (activeSkill) return null;
-    if (emptySkillShowcase.length === 0) return undefined;
+    if (emptySkillShowcase.length === 0) {
+      return (
+        <ToolkitSuggestionsEmptyState
+          suggestions={toolkitSuggestions}
+          onPick={handlePickSuggestion}
+          onConnectClick={handleConnectClick}
+        />
+      );
+    }
     return (
       <div className="self-stretch w-full h-full overflow-y-auto">
         <div className="max-w-3xl mx-auto w-full px-6 pt-6 pb-4 flex flex-col gap-3">
@@ -480,7 +512,18 @@ export function useAgentChatPanel({
         </div>
       </div>
     );
-  }, [agent, activeSkill, emptySkillShowcase, moreSkillsCount, t, applySkill]);
+  }, [
+    agent,
+    activeSkill,
+    emptySkillShowcase,
+    moreSkillsCount,
+    t,
+    applySkill,
+    toolkitSuggestions,
+    selectedSessionKey,
+    handlePickSuggestion,
+    handleConnectClick,
+  ]);
 
   const footer = useMemo<AIBoardProps["footer"]>(() => {
     if (!agent) return undefined;

--- a/app/src/lib/toolkit-suggestions.test.mjs
+++ b/app/src/lib/toolkit-suggestions.test.mjs
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  TOOLKIT_SUGGESTIONS,
+  deriveToolkitSuggestions,
+} from "./toolkit-suggestions.ts";
+
+test("returns empty when nothing is connected", () => {
+  assert.deepEqual(deriveToolkitSuggestions(new Set()), []);
+});
+
+test("returns empty when connected toolkits do not match any suggestion", () => {
+  assert.deepEqual(
+    deriveToolkitSuggestions(new Set(["unknown-toolkit"])),
+    [],
+  );
+});
+
+test("returns one suggestion when a single matching toolkit is connected", () => {
+  const out = deriveToolkitSuggestions(new Set(["googlesheets"]));
+  assert.equal(out.length, 1);
+  assert.equal(out[0].id, "analyzeSpreadsheet");
+});
+
+test("a suggestion appears if ANY of its toolkits is connected", () => {
+  const out = deriveToolkitSuggestions(new Set(["pipedrive"]));
+  assert.equal(out.length, 1);
+  assert.equal(out[0].id, "manageCrm");
+});
+
+test("caps result at max (default 3) when many suggestions match", () => {
+  const allTriggers = new Set([
+    "linkedin",
+    "gmail",
+    "firecrawl",
+    "notion",
+    "googlesheets",
+    "hubspot",
+    "fireflies",
+  ]);
+  const out = deriveToolkitSuggestions(allTriggers);
+  assert.equal(out.length, 3);
+});
+
+test("preserves TOOLKIT_SUGGESTIONS order when picking top N", () => {
+  const allTriggers = new Set([
+    "linkedin",
+    "gmail",
+    "firecrawl",
+    "notion",
+    "googlesheets",
+  ]);
+  const out = deriveToolkitSuggestions(allTriggers, 5);
+  assert.deepEqual(
+    out.map((s) => s.id),
+    [
+      "findLeadsLinkedin",
+      "planMyDay",
+      "researchAccount",
+      "draftOutreach",
+      "writeContent",
+    ],
+  );
+});
+
+test("respects an explicit max parameter", () => {
+  const out = deriveToolkitSuggestions(
+    new Set(["linkedin", "gmail", "firecrawl"]),
+    2,
+  );
+  assert.equal(out.length, 2);
+});
+
+test("all suggestion toolkit slugs are lowercase normalized", () => {
+  for (const suggestion of TOOLKIT_SUGGESTIONS) {
+    for (const slug of suggestion.toolkits) {
+      assert.equal(slug, slug.toLowerCase().trim(), `slug "${slug}" not normalized`);
+    }
+  }
+});
+
+test("all suggestion ids are unique", () => {
+  const ids = TOOLKIT_SUGGESTIONS.map((s) => s.id);
+  assert.equal(new Set(ids).size, ids.length);
+});

--- a/app/src/lib/toolkit-suggestions.ts
+++ b/app/src/lib/toolkit-suggestions.ts
@@ -1,0 +1,62 @@
+export interface ToolkitSuggestion {
+  id: string;
+  toolkits: string[];
+  image: string;
+}
+
+export const TOOLKIT_SUGGESTIONS: ToolkitSuggestion[] = [
+  {
+    id: "findLeadsLinkedin",
+    toolkits: ["linkedin", "apify"],
+    image: "bullseye",
+  },
+  {
+    id: "planMyDay",
+    toolkits: ["gmail", "googlecalendar", "outlook"],
+    image: "calendar",
+  },
+  {
+    id: "researchAccount",
+    toolkits: ["firecrawl", "perplexityai"],
+    image: "magnifying-glass-tilted-left",
+  },
+  {
+    id: "draftOutreach",
+    toolkits: ["gmail", "outlook", "instantly"],
+    image: "envelope",
+  },
+  {
+    id: "writeContent",
+    toolkits: ["notion", "googledocs"],
+    image: "memo",
+  },
+  {
+    id: "analyzeSpreadsheet",
+    toolkits: ["googlesheets"],
+    image: "bar-chart",
+  },
+  {
+    id: "manageCrm",
+    toolkits: ["hubspot", "salesforce", "pipedrive", "attio"],
+    image: "briefcase",
+  },
+  {
+    id: "summarizeCalls",
+    toolkits: ["fireflies", "gong"],
+    image: "headphone",
+  },
+];
+
+export function deriveToolkitSuggestions(
+  connected: Set<string>,
+  max = 3,
+): ToolkitSuggestion[] {
+  const out: ToolkitSuggestion[] = [];
+  for (const suggestion of TOOLKIT_SUGGESTIONS) {
+    if (suggestion.toolkits.some((toolkit) => connected.has(toolkit))) {
+      out.push(suggestion);
+      if (out.length === max) break;
+    }
+  }
+  return out;
+}

--- a/app/src/locales/en/board.json
+++ b/app/src/locales/en/board.json
@@ -39,7 +39,57 @@
     "heading": "What can I help with?",
     "subheading": "Tap a skill to get started, or just type what you need below.",
     "seeMore_one": "See {{count}} more skill",
-    "seeMore_other": "See {{count}} more skills"
+    "seeMore_other": "See {{count}} more skills",
+    "suggestions": {
+      "heading": "What can your agent do?",
+      "subheading": "Pick a starting point based on what you have connected.",
+      "headingEmpty": "Get started",
+      "subheadingEmpty": "Connect a tool and your agent will know what to do.",
+      "connectCta": {
+        "title": "Connect a tool to get started",
+        "description": "Gmail, LinkedIn, Notion, Sheets, and more. Pick one to unlock starter prompts here."
+      },
+      "findLeadsLinkedin": {
+        "title": "Find LinkedIn leads at a target company",
+        "description": "Pull contacts at a specific company with role filters.",
+        "prompt": "Find me 20 contacts at [company] in [role] roles. Return name, title, LinkedIn URL, and company in a table."
+      },
+      "planMyDay": {
+        "title": "Plan my next working day",
+        "description": "Read my inbox and calendar, surface what matters today.",
+        "prompt": "Read my inbox and calendar for today and tomorrow. Build a focus list with replies I owe, meetings to prep, and anything urgent."
+      },
+      "researchAccount": {
+        "title": "Research a target account",
+        "description": "Pull recent news, signals, and key contacts from public sources.",
+        "prompt": "Research [company name]. Surface recent news, leadership changes, funding, tech-stack signals, and 3 plausible reasons to reach out this week."
+      },
+      "draftOutreach": {
+        "title": "Draft a cold outreach message",
+        "description": "Personalized first-touch email or LinkedIn message.",
+        "prompt": "Draft a short, friendly cold outreach email to [prospect name] at [company]. Mention one specific thing about their work and propose a 15-minute chat."
+      },
+      "writeContent": {
+        "title": "Write a draft post or doc",
+        "description": "Long-form draft for a blog, LinkedIn post, or internal doc.",
+        "prompt": "Write a [LinkedIn post / blog draft / internal doc] about [topic]. Audience is [who]. Keep it concrete and human, no buzzwords."
+      },
+      "analyzeSpreadsheet": {
+        "title": "Analyze a Google Sheet",
+        "description": "Summarize trends, anomalies, or build a chart from a sheet.",
+        "prompt": "Look at the Google Sheet at [URL]. Summarize the three most important trends and call out anything that looks off."
+      },
+      "manageCrm": {
+        "title": "Update my CRM after a call",
+        "description": "Log notes, next steps, and stage changes from a meeting recap.",
+        "prompt": "I just had a call with [contact / company]. Here is what we discussed: [summary]. Update the CRM record with notes, next steps, and a suggested stage change. Show me the draft before applying."
+      },
+      "summarizeCalls": {
+        "title": "Summarize this week's calls",
+        "description": "Themes, asks, and action items across recent recordings.",
+        "prompt": "Pull this week's call recordings and give me a recap: top themes, customer asks, blockers, and action items I owe."
+      }
+    }
   },
   "composerSkill": {
     "browse": "Skills"

--- a/app/src/locales/es/board.json
+++ b/app/src/locales/es/board.json
@@ -39,7 +39,57 @@
     "heading": "¿En qué te ayudo?",
     "subheading": "Toca un skill para empezar, o escribe lo que necesitas abajo.",
     "seeMore_one": "Ver {{count}} skill más",
-    "seeMore_other": "Ver {{count}} skills más"
+    "seeMore_other": "Ver {{count}} skills más",
+    "suggestions": {
+      "heading": "¿Qué puede hacer tu agente?",
+      "subheading": "Elige un punto de partida según lo que tienes conectado.",
+      "headingEmpty": "Empieza aquí",
+      "subheadingEmpty": "Conecta una herramienta y tu agente sabrá qué hacer.",
+      "connectCta": {
+        "title": "Conecta una herramienta para empezar",
+        "description": "Gmail, LinkedIn, Notion, Sheets y más. Elige una para desbloquear sugerencias acá."
+      },
+      "findLeadsLinkedin": {
+        "title": "Encuentra leads de LinkedIn en una empresa objetivo",
+        "description": "Trae contactos de una empresa específica filtrando por cargo.",
+        "prompt": "Encuentra 20 contactos en [empresa] en cargos de [rol]. Devuelve nombre, cargo, URL de LinkedIn y empresa en una tabla."
+      },
+      "planMyDay": {
+        "title": "Planifica mi próximo día de trabajo",
+        "description": "Lee mi bandeja de entrada y calendario, destaca lo importante de hoy.",
+        "prompt": "Lee mi bandeja de entrada y calendario para hoy y mañana. Arma una lista de foco con respuestas pendientes, reuniones a preparar y lo urgente."
+      },
+      "researchAccount": {
+        "title": "Investiga una cuenta objetivo",
+        "description": "Busca noticias recientes, señales y contactos clave en fuentes públicas.",
+        "prompt": "Investiga [nombre de la empresa]. Comparte noticias recientes, cambios en liderazgo, financiación, señales de stack y 3 motivos plausibles para contactar esta semana."
+      },
+      "draftOutreach": {
+        "title": "Redacta un mensaje de primer contacto",
+        "description": "Email o mensaje de LinkedIn personalizado para un prospecto.",
+        "prompt": "Redacta un email corto y cercano de primer contacto para [nombre del prospecto] en [empresa]. Menciona algo específico de su trabajo y propón una llamada de 15 minutos."
+      },
+      "writeContent": {
+        "title": "Redacta un borrador de publicación o documento",
+        "description": "Borrador largo para blog, publicación de LinkedIn o documento interno.",
+        "prompt": "Escribe [una publicación de LinkedIn / borrador de blog / documento interno] sobre [tema]. La audiencia es [a quién]. Que sea concreto y humano, sin buzzwords."
+      },
+      "analyzeSpreadsheet": {
+        "title": "Analiza una hoja de cálculo de Google",
+        "description": "Resume tendencias, anomalías o arma un gráfico desde una hoja.",
+        "prompt": "Mira la hoja de cálculo de Google en [URL]. Resume las tres tendencias más importantes y señala cualquier cosa que se vea rara."
+      },
+      "manageCrm": {
+        "title": "Actualiza mi CRM después de una llamada",
+        "description": "Registra notas, próximos pasos y cambios de etapa desde un resumen de reunión.",
+        "prompt": "Acabo de tener una llamada con [contacto / empresa]. Esto fue lo que hablamos: [resumen]. Actualiza el registro del CRM con notas, próximos pasos y un cambio de etapa sugerido. Muéstrame el borrador antes de aplicar."
+      },
+      "summarizeCalls": {
+        "title": "Resume las llamadas de esta semana",
+        "description": "Temas, pedidos y acciones de las grabaciones recientes.",
+        "prompt": "Trae las grabaciones de las llamadas de esta semana y dame un resumen: temas principales, pedidos de clientes, bloqueos y acciones que me corresponden."
+      }
+    }
   },
   "composerSkill": {
     "browse": "Skills"

--- a/app/src/locales/pt/board.json
+++ b/app/src/locales/pt/board.json
@@ -39,7 +39,57 @@
     "heading": "Em que posso ajudar?",
     "subheading": "Toque um skill para começar, ou escreva o que você precisa abaixo.",
     "seeMore_one": "Ver mais {{count}} skill",
-    "seeMore_other": "Ver mais {{count}} skills"
+    "seeMore_other": "Ver mais {{count}} skills",
+    "suggestions": {
+      "heading": "O que seu agente pode fazer?",
+      "subheading": "Escolha um ponto de partida com base no que você tem conectado.",
+      "headingEmpty": "Comece por aqui",
+      "subheadingEmpty": "Conecte uma ferramenta e seu agente vai saber o que fazer.",
+      "connectCta": {
+        "title": "Conecte uma ferramenta para começar",
+        "description": "Gmail, LinkedIn, Notion, Sheets e mais. Escolha uma para desbloquear sugestões aqui."
+      },
+      "findLeadsLinkedin": {
+        "title": "Encontre leads do LinkedIn em uma empresa-alvo",
+        "description": "Traga contatos de uma empresa específica filtrando por cargo.",
+        "prompt": "Encontre 20 contatos em [empresa] em cargos de [cargo]. Retorne nome, cargo, URL do LinkedIn e empresa em uma tabela."
+      },
+      "planMyDay": {
+        "title": "Planeje meu próximo dia de trabalho",
+        "description": "Leia minha caixa de entrada e agenda, destaque o que importa hoje.",
+        "prompt": "Leia minha caixa de entrada e agenda de hoje e amanhã. Monte uma lista de foco com respostas pendentes, reuniões a preparar e o que for urgente."
+      },
+      "researchAccount": {
+        "title": "Pesquise uma conta-alvo",
+        "description": "Busque notícias recentes, sinais e contatos-chave em fontes públicas.",
+        "prompt": "Pesquise [nome da empresa]. Compartilhe notícias recentes, mudanças de liderança, captação, sinais de stack e 3 motivos plausíveis para entrar em contato esta semana."
+      },
+      "draftOutreach": {
+        "title": "Escreva uma mensagem de primeiro contato",
+        "description": "E-mail ou mensagem do LinkedIn personalizada para um prospect.",
+        "prompt": "Escreva um e-mail curto e amigável de primeiro contato para [nome do prospect] em [empresa]. Mencione algo específico do trabalho dele e proponha uma conversa de 15 minutos."
+      },
+      "writeContent": {
+        "title": "Escreva um rascunho de post ou documento",
+        "description": "Rascunho longo para blog, post no LinkedIn ou documento interno.",
+        "prompt": "Escreva [um post no LinkedIn / rascunho de blog / documento interno] sobre [tema]. O público é [quem]. Mantenha concreto e humano, sem buzzwords."
+      },
+      "analyzeSpreadsheet": {
+        "title": "Analise uma planilha do Google",
+        "description": "Resuma tendências, anomalias ou monte um gráfico a partir de uma planilha.",
+        "prompt": "Veja a planilha do Google em [URL]. Resuma as três tendências mais importantes e aponte qualquer coisa que pareça estranha."
+      },
+      "manageCrm": {
+        "title": "Atualize meu CRM depois de uma ligação",
+        "description": "Registre anotações, próximos passos e mudanças de estágio a partir de um resumo de reunião.",
+        "prompt": "Acabei de ter uma ligação com [contato / empresa]. Foi o que conversamos: [resumo]. Atualize o registro do CRM com anotações, próximos passos e uma mudança de estágio sugerida. Me mostre o rascunho antes de aplicar."
+      },
+      "summarizeCalls": {
+        "title": "Resuma as ligações desta semana",
+        "description": "Temas, pedidos e ações das gravações recentes.",
+        "prompt": "Traga as gravações das ligações desta semana e me dê um resumo: temas principais, pedidos dos clientes, bloqueios e ações que devo executar."
+      }
+    }
   },
   "composerSkill": {
     "browse": "Skills"


### PR DESCRIPTION
## Who this is for

Anyone opening Houston for the first time, plus power users who keep creating custom agents from scratch. They have an agent in front of them, an empty chat input, and no obvious next step.

## The problem

A Houston agent without skills shows an empty chat with no guidance. The user looks at "What should the agent work on?" and goes blank, or worse, types something the agent can't actually do because they don't know which integrations are connected.

This came up in the beta-users WhatsApp group on May 9, when one user asked how to actually use Apify inside Houston after connecting it. Another power user wrote a thirty-line starter prompt by hand and dropped it in the chat for the rest of the group. The product itself was not teaching this.

## What is different now

When the user opens a mission in an agent that has no skills, the empty area above the chat input now shows starter cards, in two flavors:

**If no integration is connected yet:**

A single "Connect a tool to get started" card. Clicking it opens the Integrations view.

**If at least one supported integration is connected (Gmail, LinkedIn, Apify, Notion, Sheets, Outlook, CRMs, call recorders, etc.):**

Up to three contextual cards like:

- "Plan my next working day" (Gmail + Calendar)
- "Find LinkedIn leads at a target company" (LinkedIn / Apify)
- "Draft a cold outreach message" (Gmail / Outlook / Instantly)
- "Analyze a Google Sheet"
- "Update my CRM after a call" (HubSpot / Salesforce / Pipedrive / Attio)
- etc.

Each card shows the integration logos it relies on. Clicking one fills the chat input with a starter prompt the user can edit before sending, and focuses the input so they can keep typing right away.

The cards never replace skills. If the agent already has skills, the existing skill-card empty state still wins — this only fills the gap where there was previously nothing.

## Why it matters

New users hit a blank chat and bounce. Existing users with newly connected integrations don't know what their agent can do with them. This turns both moments into a starting point.

The PR is also a step toward the broader "agents teach themselves to the user" direction — every new integration the team adds can add its own suggestion entries and start showing up here automatically.

## How it was verified

- Repro on the macOS desktop build: agent with no skills and no integrations renders the connect CTA; clicking it opens Integrations. Connecting Gmail and reopening the mission renders the Gmail-related suggestions; clicking a suggestion fills the input with the localized prompt and focuses the textarea.
- New unit suite for the suggestion derivation: 9 tests covering empty input, single-toolkit match, any-of toolkit logic, max cap, order preservation, custom max, slug normalization, and id uniqueness.
- `pnpm tsc --noEmit` green.
- `pnpm check-locales` clean across en / es / pt (15 namespaces in sync).

Repro video below.

<!-- Drop the .mp4 here when uploading -->