### PR TITLE
fix(ui): replace hardcoded colors with semantic tokens for dark mode

### DIFF
--- a/app/src/components/shell/disclaimer-gate.tsx
+++ b/app/src/components/shell/disclaimer-gate.tsx
@@ -158,7 +158,7 @@ function DisclaimerOverlay({
               variant="outline"
               onClick={handleDecline}
               disabled={busy !== null}
-              className="rounded-full border-black/15 bg-white text-foreground hover:bg-gray-50"
+              className="rounded-full border-border/50 bg-card text-foreground hover:bg-muted"
             >
               {busy === "decline" ? t("buttons.decline_busy") : t("buttons.decline")}
             </Button>

--- a/app/src/components/shell/language-gate.tsx
+++ b/app/src/components/shell/language-gate.tsx
@@ -96,7 +96,7 @@ function LanguageOverlay({
                 type="button"
                 onClick={() => handlePick(loc)}
                 disabled={pending !== null}
-                className="flex h-11 w-full items-center justify-center rounded-full border border-black/15 bg-white text-sm font-medium text-foreground transition-colors hover:bg-gray-50 disabled:opacity-60"
+                className="flex h-11 w-full items-center justify-center rounded-full border border-border/50 bg-card text-sm font-medium text-foreground transition-colors hover:bg-muted disabled:opacity-60"
               >
                 {busy ? "…" : DISPLAY_NAMES[loc]}
               </button>

--- a/app/src/components/tabs/integrations-states.tsx
+++ b/app/src/components/tabs/integrations-states.tsx
@@ -30,7 +30,7 @@ export function LoadingState() {
       <div className="w-48 h-[2px] rounded-full bg-black/10 overflow-hidden">
         <div
           ref={barRef}
-          className="h-full bg-black rounded-full"
+          className="h-full bg-foreground rounded-full"
           style={{ width: "0%", transition: "width 5s linear" }}
         />
       </div>

--- a/ui/agent/src/file-row.tsx
+++ b/ui/agent/src/file-row.tsx
@@ -69,9 +69,9 @@ export function FolderSection({
           <FolderIcon />
           <span className="text-[13px] truncate">{node.name}</span>
         </div>
-        <span className="text-[11px] text-[#6d6d6d] truncate px-2">{"\u2014"}</span>
-        <span className="text-[11px] text-[#6d6d6d] text-right px-2">--</span>
-        <span className="text-[11px] text-[#6d6d6d] truncate px-2">Folder</span>
+        <span className="text-[11px] text-muted-foreground truncate px-2">{"\u2014"}</span>
+        <span className="text-[11px] text-muted-foreground text-right px-2">--</span>
+        <span className="text-[11px] text-muted-foreground truncate px-2">Folder</span>
       </div>
       {open &&
         node.children.map((child) =>
@@ -119,7 +119,7 @@ export function FileRow({
   const renameRef = useRef<HTMLInputElement>(null)
   const padLeft = BASE_INDENT + depth * DEPTH_INDENT + TRIANGLE_AREA
   const hasMenu = onOpen || onReveal || onDelete
-  const sec = selected ? "text-white/80" : "text-[#6d6d6d]"
+  const sec = selected ? "text-primary-foreground/80" : "text-muted-foreground"
 
   const startRename = () => {
     if (!onRename) return

--- a/ui/agent/src/files-browser.tsx
+++ b/ui/agent/src/files-browser.tsx
@@ -143,10 +143,10 @@ export function FilesBrowser({
 
   return (
     <div
-      className="relative flex flex-col overflow-hidden bg-white border border-[#e0e0e0] rounded-xl h-full"
+      className="relative flex flex-col overflow-hidden bg-background border border-border rounded-xl h-full"
       {...(onFilesDropped || onMove ? dragHandlers : {})}
     >
-      <div className="h-[24px] shrink-0 border-b border-[#e5e5e5] bg-[#fafafa] select-none flex items-center rounded-t-xl">
+      <div className="h-[24px] shrink-0 border-b border-border bg-muted/40 select-none flex items-center rounded-t-xl">
         <div className="flex-1 min-w-0 items-center h-full" style={{ display: "grid", gridTemplateColumns: COL_GRID }}>
           <HeaderCell label={l.columnName} col="name" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} className="pl-7" />
           <HeaderCell label={l.columnDateModified} col="dateModified" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />
@@ -180,7 +180,7 @@ export function FilesBrowser({
           </div>
         ) : (
           <>
-            <div className="shrink-0 [&>:nth-child(even)]:bg-[#f5f5f5] [&>:nth-child(even)]:rounded-lg">
+            <div className="shrink-0 [&>:nth-child(even)]:bg-muted/30 [&>:nth-child(even)]:rounded-lg">
               {creatingFolder && (
                 <NewFolderInput
                   onConfirm={(n) => { onCreateFolder?.(n); setCreatingFolder(false) }}
@@ -221,8 +221,8 @@ export function FilesBrowser({
         )}
       </div>
 
-      <div className="h-[22px] shrink-0 border-t border-[#e5e5e5] bg-[#fafafa] select-none flex items-center justify-between px-3 rounded-b-xl">
-        <span className="text-[11px] text-[#6d6d6d]">
+      <div className="h-[22px] shrink-0 border-t border-border bg-muted/40 select-none flex items-center justify-between px-3 rounded-b-xl">
+        <span className="text-[11px] text-muted-foreground">
           {fileCount} {fileCount === 1 ? "item" : "items"}
         </span>
         {statusBarAction}
@@ -266,7 +266,7 @@ function FillerStripes({ startIndex, onDeselect, onContextMenu }: {
       {Array.from({ length: count }, (_, i) => (
         <div
           key={i}
-          className={cn("h-[24px]", (startIndex + i) % 2 === 1 && "bg-[#f5f5f5] rounded-lg")}
+          className={cn("h-[24px]", (startIndex + i) % 2 === 1 && "bg-muted/30 rounded-lg")}
           onClick={onDeselect}
           onContextMenu={onContextMenu}
         />
@@ -284,12 +284,12 @@ function BgContextMenu({ position, onNewFolder, onClose }: {
     <>
       <div className="fixed inset-0 z-50" onClick={onClose} onContextMenu={(e) => { e.preventDefault(); onClose() }} />
       <div
-        className="fixed z-50 bg-white/95 backdrop-blur-xl border border-black/10 rounded-lg shadow-lg py-1 min-w-[160px]"
+        className="fixed z-50 bg-popover/95 backdrop-blur-xl border border-border rounded-lg shadow-lg py-1 min-w-[160px]"
         style={{ left: position.x, top: position.y }}
       >
         <button
           onClick={onNewFolder}
-          className="w-full text-left px-3 py-1.5 text-[13px] hover:bg-[#2068d0] hover:text-white rounded-md mx-0.5"
+          className="w-full text-left px-3 py-1.5 text-[13px] hover:bg-primary hover:text-primary-foreground rounded-md mx-0.5"
           style={{ width: "calc(100% - 4px)" }}
         >
           New Folder
@@ -314,8 +314,8 @@ function HeaderCell({ label, col, sortKey, sortDir, onSort, className, last }: {
     <button
       onClick={() => onSort(col)}
       className={cn(
-        "flex items-center justify-between h-full px-2 text-[11px] font-medium text-[#6d6d6d] hover:bg-[#eaeaea] transition-colors",
-        !last && "border-r border-[#e5e5e5]",
+        "flex items-center justify-between h-full px-2 text-[11px] font-medium text-muted-foreground hover:bg-muted transition-colors",
+        !last && "border-r border-border",
         className,
       )}
     >
@@ -325,7 +325,7 @@ function HeaderCell({ label, col, sortKey, sortDir, onSort, className, last }: {
           className="size-[8px] shrink-0"
           viewBox="0 0 8 6"
           fill="none"
-          stroke="#6d6d6d"
+          stroke="currentColor"
           strokeWidth="1.5"
           strokeLinecap="round"
           strokeLinejoin="round"

--- a/ui/board/src/kanban-card.tsx
+++ b/ui/board/src/kanban-card.tsx
@@ -99,7 +99,7 @@ export function KanbanCard({
           "group/card relative rounded-xl bg-background p-3 cursor-pointer transition-all duration-200",
           isRunning
             ? "card-running-glow shadow-[0_2px_12px_rgba(59,130,246,0.12)]"
-            : "border border-black/[0.04] shadow-[0_1px_2px_rgba(0,0,0,0.04)] hover:shadow-[0_2px_6px_rgba(0,0,0,0.08)]",
+            : "border border-border/20 shadow-sm hover:shadow-md",
         )}
       >
         {/* Top row: agent info + action buttons */}

--- a/ui/chat/src/ai-elements/prompt-input.tsx
+++ b/ui/chat/src/ai-elements/prompt-input.tsx
@@ -916,7 +916,7 @@ export const PromptInput = ({
       >
         <div
           data-composer-surface="true"
-          className="group/composer cursor-text overflow-clip rounded-[28px] border border-border/50 bg-card p-2.5 shadow-[0_1px_6px_rgba(0,0,0,0.06)] focus-within:shadow-[0_1px_10px_rgba(0,0,0,0.1)] grid grid-cols-[auto_1fr_auto] [grid-template-areas:'header_header_header'_'leading_primary_trailing'_'._footer_.'] data-[expanded]:[grid-template-areas:'header_header_header'_'primary_primary_primary'_'leading_footer_trailing']"
+          className="group/composer cursor-text overflow-clip rounded-[28px] border border-border/50 bg-card p-2.5 shadow-[0_1px_6px_rgba(0,0,0,0.06)] focus-within:shadow-[0_1px_10px_rgba(0,0,0,0.1)] dark:shadow-[0_1px_6px_rgba(0,0,0,0.2)] dark:focus-within:shadow-[0_1px_10px_rgba(0,0,0,0.3)] grid grid-cols-[auto_1fr_auto] [grid-template-areas:'header_header_header'_'leading_primary_trailing'_'._footer_.'] data-[expanded]:[grid-template-areas:'header_header_header'_'primary_primary_primary'_'leading_footer_trailing']"
           onClick={(e) => {
             if (!(e.target as HTMLElement).closest("button")) {
               formRef.current?.querySelector("textarea")?.focus();

--- a/ui/chat/src/attachment-chip.tsx
+++ b/ui/chat/src/attachment-chip.tsx
@@ -81,7 +81,7 @@ export interface AttachmentChipProps {
 export function AttachmentChip({ name, onRemove }: AttachmentChipProps) {
   const ext = getExt(name);
   return (
-    <div className="relative flex items-center gap-2.5 rounded-xl border border-black/[0.08] bg-white pl-2.5 pr-8 py-2 min-w-0 shrink-0 max-w-[240px] shadow-sm">
+    <div className="relative flex items-center gap-2.5 rounded-xl border border-black/[0.08] bg-background pl-2.5 pr-8 py-2 min-w-0 shrink-0 max-w-[240px] shadow-sm">
       <AttachmentIcon ext={ext} />
       <div className="min-w-0">
         <p className="text-xs font-medium text-foreground truncate leading-tight">
@@ -94,7 +94,7 @@ export function AttachmentChip({ name, onRemove }: AttachmentChipProps) {
       <button
         type="button"
         onClick={onRemove}
-        className="absolute top-1.5 right-1.5 size-4 rounded-full bg-black/50 text-white flex items-center justify-center hover:bg-black/70 transition-colors"
+        className="absolute top-1.5 right-1.5 size-4 rounded-full bg-foreground/60 text-background flex items-center justify-center hover:bg-foreground/80 transition-colors"
         aria-label={`Remove ${name}`}
       >
         <XIcon className="size-2.5" strokeWidth={3} />

--- a/ui/chat/src/chat-drop-overlay.tsx
+++ b/ui/chat/src/chat-drop-overlay.tsx
@@ -8,7 +8,7 @@ export function ChatDropOverlay({ visible }: ChatDropOverlayProps) {
   if (!visible) return null;
   return (
     <div
-      className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-white/80 backdrop-blur-sm"
+      className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center bg-background/80 backdrop-blur-sm"
       aria-hidden="true"
     >
       <div className="flex w-full max-w-sm -translate-y-12 flex-col items-center gap-3 px-6 text-center">

--- a/ui/chat/src/user-attachment-message.tsx
+++ b/ui/chat/src/user-attachment-message.tsx
@@ -39,7 +39,7 @@ export function UserAttachmentBadge({
   if (files.length === 0) return null;
   return (
     <div
-      className="inline-flex max-w-full items-center gap-2 rounded-full border border-black/10 bg-white px-3 py-1.5 text-xs font-medium text-foreground shadow-[0_1px_0_rgba(0,0,0,0.04)]"
+      className="inline-flex max-w-full items-center gap-2 rounded-full border border-border/50 bg-background px-3 py-1.5 text-xs font-medium text-foreground shadow-sm"
       title={files.map((file) => file.name).join(", ")}
     >
       <Paperclip className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />

--- a/ui/core/src/components/dialog.tsx
+++ b/ui/core/src/components/dialog.tsx
@@ -64,7 +64,7 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-5 rounded-2xl border border-black/10 bg-background p-6 shadow-[0_4px_4px_rgba(0,0,0,0.04),0_4px_80px_8px_rgba(0,0,0,0.04),0_0_1px_rgba(0,0,0,0.62)] duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-5 rounded-2xl border border-border/50 bg-background p-6 shadow-[0_4px_4px_rgba(0,0,0,0.04),0_4px_80px_8px_rgba(0,0,0,0.04),0_0_1px_rgba(0,0,0,0.62)] dark:shadow-[0_4px_4px_rgba(0,0,0,0.1),0_4px_80px_8px_rgba(0,0,0,0.2),0_0_1px_rgba(255,255,255,0.1)] duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className
         )}
         {...props}

--- a/ui/routines/src/routine-editor.tsx
+++ b/ui/routines/src/routine-editor.tsx
@@ -124,10 +124,10 @@ function FieldLabel({ children }: { children: React.ReactNode }) {
 }
 
 const baseFieldClass = cn(
-  "w-full rounded-lg border border-black/[0.04] bg-background px-3 py-2 text-sm",
+  "w-full rounded-lg border border-border/20 bg-background px-3 py-2 text-sm",
   "text-foreground placeholder:text-muted-foreground/60",
   "transition-shadow duration-200",
-  "focus:outline-none focus:shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
+  "focus:outline-none focus:shadow-sm",
 )
 
 // ----- Main -----

--- a/ui/routines/src/schedule-picker-fields.tsx
+++ b/ui/routines/src/schedule-picker-fields.tsx
@@ -4,9 +4,9 @@
 import { cn } from "@houston-ai/core"
 
 const inputClass = cn(
-  "px-3 py-2 rounded-lg border border-black/[0.04] bg-background",
+  "px-3 py-2 rounded-lg border border-border/20 bg-background",
   "text-sm text-foreground",
-  "focus:outline-none focus:shadow-[0_1px_2px_rgba(0,0,0,0.04)] transition-shadow",
+  "focus:outline-none focus:shadow-sm transition-shadow",
 )
 
 const labelClass = "text-xs font-medium text-muted-foreground mb-1.5 block"
@@ -60,7 +60,7 @@ export function DayOfWeekPicker({
               "size-8 rounded-lg text-xs font-medium transition-colors",
               value === day.value
                 ? "bg-primary text-primary-foreground"
-                : "bg-background border border-black/[0.04] text-muted-foreground hover:text-foreground",
+                : "bg-background border border-border/20 text-muted-foreground hover:text-foreground",
             )}
           >
             {day.label}

--- a/ui/skills/src/skill-detail-page.tsx
+++ b/ui/skills/src/skill-detail-page.tsx
@@ -172,9 +172,9 @@ export function SkillDetailPage({
               className={cn(
                 "w-full px-4 py-3 text-sm text-foreground leading-relaxed font-mono",
                 "placeholder:text-muted-foreground/60",
-                "bg-background border border-black/[0.04] rounded-lg",
+                "bg-background border border-border/20 rounded-lg",
                 "outline-none resize-y transition-shadow duration-200",
-                "focus:shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
+                "focus:shadow-sm",
               )}
             />
           </section>


### PR DESCRIPTION
Swap literal hex/black/white values across app and ui packages for theme-aware tokens so dialogs, file browser, kanban cards, chat composer, attachment chips, drop overlay, routine editor, schedule picker, and skill detail page render correctly in both light and dark. Add dark-only shadow variants on prompt-input and dialog. Keep the settings toggle knob and attachment-chip close button at fixed/strong contrast so the affordances stay visible in both themes.

## Before/After screenshots

<img width="165" height="111" alt="image" src="https://github.com/user-attachments/assets/bb4bf11f-595b-4b8b-997e-3dda3e0a7fbe" />
<br />
<img width="133" height="108" alt="image" src="https://github.com/user-attachments/assets/cf9bd3b6-5b60-41a2-a40e-900d840761e3" />
<br />

<img width="235" height="193" alt="image" src="https://github.com/user-attachments/assets/17742400-e334-4ebc-bdc5-933fd663373a" />
<br />
<img width="219" height="161" alt="image" src="https://github.com/user-attachments/assets/697b15e6-4ebf-4c0e-9bff-5c81ad19ac14" />
<br />


<img width="1153" height="688" alt="image" src="https://github.com/user-attachments/assets/8fa1dff6-5668-4af5-a419-57c1293777b9" />
<br />
<img width="1128" height="697" alt="image" src="https://github.com/user-attachments/assets/2304eeb1-d359-42d3-9498-5b433cec7d33" />

## Complete screenshots below

### Light theme comparison
<img width="1400" height="3000" alt="screenshot-light" src="https://github.com/user-attachments/assets/17ccfcfb-ae75-4de6-af3e-e7ca116dd28a" />

### Dark theme comparison
<img width="1400" height="3000" alt="screenshot-dark" src="https://github.com/user-attachments/assets/77930328-6705-4d31-accc-252edc50d7bc" />

