### PR TITLE
fix(windows): seven Windows bugs + native ARM composio + bundled Git Bash + per-arch MSI CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -710,26 +710,61 @@ jobs:
   #     ship to actual users we'll wire SignPath Foundation (free OSS) into
   #     a `sign-windows` job between this and the upload step.
   #
-  # Build pipeline:
-  #   1. Stage CLI deps via `scripts/fetch-cli-deps.sh windows-x64`.
+  # Build pipeline (runs once per matrix arch, x86_64 + aarch64):
+  #   1. Stage CLI deps via `scripts/fetch-cli-deps.sh windows-<arch>`.
   #      Codex is downloaded + zstd-decompressed; composio is BUILT FROM
   #      SOURCE on this Windows runner using a pinned commit on the
-  #      gethouston/composio fork — see `cli-deps.json`'s
-  #      `composio.build."windows-x64"` block for the pin and the
+  #      gethouston/composio fork (windows-x64 = houston-windows-support
+  #      branch, windows-arm64 = houston-windows-arm64 branch with the
+  #      bun:ffi fallback patch) — see `cli-deps.json`'s
+  #      `composio.build."windows-<arch>"` block for the pin and the
   #      `$build_comment` for why upstream can't ship Windows yet.
-  #   2. Build the houston-engine sidecar for x86_64-pc-windows-msvc.
+  #      git-bash-<arch>.7z.exe (PortableGit SFX) is also staged so the
+  #      first-launch extractor in houston-engine-core::git_bash gives
+  #      Claude Code its bash.exe dependency without user setup.
+  #   2. Build the houston-engine sidecar for the matrix target.
   #      Tauri's externalBin picks it up at `binaries/houston-engine.exe`
   #      (build.rs::stage_engine_sidecar names it
-  #      `houston-engine-x86_64-pc-windows-msvc.exe` per Tauri's per-target
-  #      convention).
-  #   3. Run `pnpm tauri build --target x86_64-pc-windows-msvc` to produce
-  #      the MSI under
-  #      `target/x86_64-pc-windows-msvc/release/bundle/msi/*.msi`.
-  #   4. Upload the MSI + .sig to the draft release created by `prep`.
+  #      `houston-engine-<target>.exe` per Tauri's per-target convention).
+  #   3. Run `pnpm tauri build --target <matrix.target>` to produce the
+  #      MSI under `target/<matrix.target>/release/bundle/msi/*.msi`.
+  #   4. Upload the per-arch MSI + .sig to the draft release. `finalize`
+  #      then merges both into a single latest.json with separate
+  #      `windows-x86_64` and `windows-aarch64` entries the in-app
+  #      updater consumes.
   build-windows:
     needs: prep
-    runs-on: windows-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 90
+    strategy:
+      # Both arches build in parallel. fail-fast=false so a transient
+      # ARM-runner outage doesn't kill the x64 release that 90%+ of
+      # Windows users actually install.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: x86_64
+            bun_arch: x64
+            fetch_mode: windows-x64
+            target: x86_64-pc-windows-msvc
+            runner: windows-latest
+          - arch: aarch64
+            bun_arch: arm64
+            fetch_mode: windows-arm64
+            target: aarch64-pc-windows-msvc
+            # GitHub-hosted Windows-on-ARM runner. Goes through the
+            # same VS 2022 toolchain as the x64 runner; the only
+            # practical difference is the host arch + which Bun /
+            # composio variants we pull. See:
+            # https://github.com/actions/partner-runner-images/issues/61
+            # If this label ever disappears, fall back by changing
+            # `runner: windows-latest` + adding
+            # `rustup target add aarch64-pc-windows-msvc` and the
+            # ARM64 component of VS Build Tools — but that path
+            # requires running the linker via /arm64 cross-toolchain
+            # which has subtle issues with mingw-w64-linked C deps in
+            # libsql, so prefer the native runner whenever it's up.
+            runner: windows-11-arm
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -752,7 +787,7 @@ jobs:
       - name: Setup Rust (windows-msvc target)
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: x86_64-pc-windows-msvc
+          targets: ${{ matrix.target }}
 
       - name: Cache Rust artifacts
         uses: actions/cache@v4
@@ -762,14 +797,14 @@ jobs:
             ~/.cargo/git
             app/src-tauri/target
             target
-          key: ${{ runner.os }}-cargo-windows-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-windows-
+          key: ${{ runner.os }}-cargo-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-${{ matrix.arch }}-
 
       # Bun + jq + zstd are required by `scripts/fetch-cli-deps.sh`. Bun
       # is needed because the composio Windows binary is built FROM
       # SOURCE on this runner via `bun build:binary:cross
-      # --target=bun-windows-x64-modern`. The version MUST match the pin
-      # in `cli-deps.json#composio.build."windows-x64".bun_version` —
+      # --target=bun-windows-<arch>`. The version MUST match the pin
+      # in `cli-deps.json#composio.build."windows-<arch>".bun_version` —
       # mismatched Bun produces a binary with subtle behavioral
       # differences that bite at runtime, so we install via direct
       # GitHub release download (deterministic) rather than the
@@ -778,15 +813,22 @@ jobs:
       - name: Install Bun (pinned to cli-deps.json)
         shell: pwsh
         run: |
-          $bunVersion = (Get-Content cli-deps.json | ConvertFrom-Json).composio.build.'windows-x64'.bun_version
-          Write-Host "Installing Bun $bunVersion (direct GitHub release download)"
+          $platformKey = "windows-${{ matrix.bun_arch }}"
+          if ("${{ matrix.bun_arch }}" -eq "x64") {
+            $bunVersion = (Get-Content cli-deps.json | ConvertFrom-Json).composio.build.'windows-x64'.bun_version
+            $bunBundle = "bun-windows-x64"
+          } else {
+            $bunVersion = (Get-Content cli-deps.json | ConvertFrom-Json).composio.build.'windows-arm64'.bun_version
+            $bunBundle = "bun-windows-arm64"
+          }
+          Write-Host "Installing Bun $bunVersion ($bunBundle, direct GitHub release download)"
           $bunDir = "$HOME\.bun\bin"
           New-Item -ItemType Directory -Force -Path $bunDir | Out-Null
-          $url = "https://github.com/oven-sh/bun/releases/download/bun-v$bunVersion/bun-windows-x64.zip"
-          $zipPath = "$env:TEMP\bun-windows-x64.zip"
+          $url = "https://github.com/oven-sh/bun/releases/download/bun-v$bunVersion/$bunBundle.zip"
+          $zipPath = "$env:TEMP\$bunBundle.zip"
           Invoke-WebRequest -Uri $url -OutFile $zipPath
           Expand-Archive -Force -Path $zipPath -DestinationPath "$env:TEMP\bun-extract"
-          Copy-Item -Force "$env:TEMP\bun-extract\bun-windows-x64\bun.exe" "$bunDir\bun.exe"
+          Copy-Item -Force "$env:TEMP\bun-extract\$bunBundle\bun.exe" "$bunDir\bun.exe"
           Remove-Item -Recurse -Force "$env:TEMP\bun-extract", $zipPath
           # Add bun to PATH for subsequent steps.
           echo "$bunDir" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
@@ -804,16 +846,20 @@ jobs:
           jq --version
           zstd --version
 
-      # Stage bundled CLI binaries: codex.exe (downloaded + zstd) and
-      # composio-x86_64/composio.exe (built from gethouston/composio
-      # fork). The fetch script handles `pnpm install` + `tsdown` +
+      # Stage bundled CLI binaries: codex.exe (downloaded + zstd),
+      # composio-<arch>/composio.exe (built from gethouston/composio
+      # fork — windows-x64 from branch houston-windows-support,
+      # windows-arm64 from branch houston-windows-arm64 with the
+      # bun:ffi fallback patch), and git-bash-<arch>.7z.exe (PortableGit
+      # SFX, extracted on first launch by houston-engine-core::git_bash).
+      # The fetch script handles `pnpm install` + `tsdown` +
       # `bun build:binary:cross` for the composio fork; full build is
       # ~3-5 minutes on a warm runner.
-      - name: Stage bundled CLI dependencies (codex, composio Windows)
+      - name: Stage bundled CLI dependencies (codex, composio, git-bash)
         shell: bash
         run: |
           set -euo pipefail
-          ./scripts/fetch-cli-deps.sh windows-x64
+          ./scripts/fetch-cli-deps.sh ${{ matrix.fetch_mode }}
 
           echo "=== Staged bundle ==="
           ls -lah app/src-tauri/resources/bin/
@@ -822,30 +868,31 @@ jobs:
 
           # Sanity: every Windows artifact must be present.
           test -f app/src-tauri/resources/bin/codex.exe
-          test -f app/src-tauri/resources/bin/composio-x86_64/composio.exe
-          test -f app/src-tauri/resources/bin/composio-x86_64/run-helpers-runtime.mjs
-          test -f app/src-tauri/resources/bin/composio-x86_64/acp-adapters/codex/win32-x64/codex-acp.exe
+          test -f app/src-tauri/resources/bin/composio-${{ matrix.arch }}/composio.exe
+          test -f app/src-tauri/resources/bin/composio-${{ matrix.arch }}/run-helpers-runtime.mjs
+          test -f app/src-tauri/resources/bin/composio-${{ matrix.arch }}/acp-adapters/codex/win32-${{ matrix.bun_arch }}/codex-acp.exe
+          test -f app/src-tauri/resources/bin/git-bash-${{ matrix.arch }}.7z.exe
           test -f app/src-tauri/resources/bin/cli-deps.json
 
-      # Build the engine sidecar for x86_64-pc-windows-msvc BEFORE
+      # Build the engine sidecar for the matrix target BEFORE
       # `tauri build`. build.rs::stage_engine_sidecar copies it to
-      # `app/src-tauri/binaries/houston-engine-x86_64-pc-windows-msvc.exe`
-      # which is what Tauri's externalBin pattern expects.
-      - name: Build houston-engine sidecar (x86_64-pc-windows-msvc)
+      # `app/src-tauri/binaries/houston-engine-<target>.exe` which is
+      # what Tauri's externalBin pattern expects.
+      - name: Build houston-engine sidecar (${{ matrix.target }})
         shell: bash
         run: |
           set -euo pipefail
-          cargo build --release --target x86_64-pc-windows-msvc -p houston-engine-server
-          test -x "target/x86_64-pc-windows-msvc/release/houston-engine.exe" \
-            || { echo "::error::engine binary missing for x86_64-pc-windows-msvc"; exit 1; }
+          cargo build --release --target ${{ matrix.target }} -p houston-engine-server
+          test -x "target/${{ matrix.target }}/release/houston-engine.exe" \
+            || { echo "::error::engine binary missing for ${{ matrix.target }}"; exit 1; }
           echo "Sidecar size:"
-          ls -lah target/x86_64-pc-windows-msvc/release/houston-engine.exe
+          ls -lah target/${{ matrix.target }}/release/houston-engine.exe
 
       - name: Build Tauri app (Windows MSI)
         uses: tauri-apps/tauri-action@v0
         with:
           projectPath: app
-          args: --target x86_64-pc-windows-msvc
+          args: --target ${{ matrix.target }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # The Tauri updater key signs the MSI for the auto-updater
@@ -866,7 +913,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          BUNDLE="target/x86_64-pc-windows-msvc/release/bundle"
+          BUNDLE="target/${{ matrix.target }}/release/bundle"
 
           MSI=$(ls -t "$BUNDLE/msi/"*.msi 2>/dev/null | head -1 || true)
           # Tauri's `createUpdaterArtifacts: true` emits an `<msi>.sig`
@@ -945,12 +992,14 @@ jobs:
         with:
           name: release-notes
 
-      # Pull `latest.json` (mac entries) and the Windows `*.msi.sig`
-      # straight from the draft release. Using assets-on-the-draft as
-      # the handoff (instead of cross-job artifacts) avoids extra
+      # Pull `latest.json` (mac entries) and all Windows `*.msi.sig`
+      # files straight from the draft release. Using assets-on-the-draft
+      # as the handoff (instead of cross-job artifacts) avoids extra
       # upload/download steps and keeps the source of truth in one
-      # place — the draft itself.
-      - name: Extend latest.json with Windows updater entry
+      # place — the draft itself. Two .sig files now ship: one per
+      # Windows arch (x64, arm64). Tauri's updater key for each entry
+      # is the platform string the in-app client polls for.
+      - name: Extend latest.json with Windows updater entries
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -966,33 +1015,45 @@ jobs:
             exit 1
           fi
 
-          SIG_FILE=$(ls "$tmpdir"/*.msi.sig 2>/dev/null | head -1 || true)
-          if [ -z "$SIG_FILE" ]; then
-            echo "::error::*.msi.sig not found in draft release; build-windows must have failed to upload it"
+          # Walk every *.msi.sig and append a Tauri-updater entry. The
+          # MSI bundler embeds the target triple in the filename so we
+          # can derive the platform key directly. Naming examples:
+          #   Houston_0.4.9_x64_en-US.msi.sig    → windows-x86_64
+          #   Houston_0.4.9_arm64_en-US.msi.sig  → windows-aarch64
+          shopt -s nullglob
+          sigs=("$tmpdir"/*.msi.sig)
+          if [ ${#sigs[@]} -eq 0 ]; then
+            echo "::error::no *.msi.sig in draft release; build-windows must have failed to upload them"
             exit 1
           fi
 
-          MSI_NAME=$(basename "$SIG_FILE" .sig)
-          MSI_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/$MSI_NAME"
-          MSI_SIG=$(cat "$SIG_FILE")
+          cp "$tmpdir/latest.json" "$tmpdir/latest.next.json"
+          for SIG_FILE in "${sigs[@]}"; do
+            MSI_NAME=$(basename "$SIG_FILE" .sig)
+            MSI_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/$MSI_NAME"
+            MSI_SIG=$(cat "$SIG_FILE")
 
-          # Tauri's updater checks `windows-x86_64` for both NSIS and MSI
-          # installers (the format is detected from the URL extension at
-          # update time). We add a single entry pointing at the MSI; if
-          # we ever ship NSIS too, we keep the same key and let users
-          # opt into one-or-the-other via the URL the updater receives.
-          jq \
-            --arg sig "$MSI_SIG" \
-            --arg url "$MSI_URL" \
-            '.platforms["windows-x86_64"] = {signature: $sig, url: $url}' \
-            "$tmpdir/latest.json" > "$tmpdir/latest.next.json"
+            case "$MSI_NAME" in
+              *_arm64*|*_aarch64*) PLATFORM="windows-aarch64" ;;
+              *)                   PLATFORM="windows-x86_64"  ;;
+            esac
+
+            echo "  + $PLATFORM ← $MSI_NAME"
+            jq \
+              --arg sig "$MSI_SIG" \
+              --arg url "$MSI_URL" \
+              --arg plat "$PLATFORM" \
+              '.platforms[$plat] = {signature: $sig, url: $url}' \
+              "$tmpdir/latest.next.json" > "$tmpdir/latest.merged.json"
+            mv "$tmpdir/latest.merged.json" "$tmpdir/latest.next.json"
+          done
 
           echo "Updated latest.json:"
           cat "$tmpdir/latest.next.json"
 
           mv "$tmpdir/latest.next.json" "$tmpdir/latest.json"
           gh release upload "$GITHUB_REF_NAME" "$tmpdir/latest.json" --clobber
-          echo "::notice::latest.json now advertises macOS + Windows for the in-app updater"
+          echo "::notice::latest.json now advertises macOS + Windows (x64 + arm64) for the in-app updater"
 
       # Pings the team Slack channel so anyone can grab the DMG and try
       # the build before we publish. No-ops when

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ Need specific knowledge? Load on demand:
 - Engine wire protocol (REST + WS) → `knowledge-base/engine-protocol.md`
 - `houston-engine` binary ops → `knowledge-base/engine-server.md`
 - Bundled CLIs (codex universal, composio per-arch) + runtime claude-code installer → `knowledge-base/cli-bundling.md`
+- Windows testing loop from a Mac (UTM VM, SSH bridge, cross-compile, log fetch) → `knowledge-base/windows-testing.md`
 - Custom frontend on `houston-engine` (integration reference) → `examples/smartbooks/README.md`
 - Mobile PWA (tunnel, pairing, reactivity) → `docs/mobile-architecture.md` + `docs/relay-operations.md`
 - Updater, analytics, Sentry, env vars, CI → `knowledge-base/production-infra.md`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2461,6 +2461,7 @@ version = "0.4.9"
 dependencies = [
  "anyhow",
  "chrono",
+ "dirs 5.0.1",
  "libsql",
  "serde",
  "tokio",

--- a/app/src-tauri/src/engine_supervisor.rs
+++ b/app/src-tauri/src/engine_supervisor.rs
@@ -72,8 +72,15 @@ impl EngineSubprocess {
         env: &[(String, String)],
     ) -> Result<Self, String> {
         let mut cmd = Command::new(binary);
+        // Pipe stderr so we can forward it to both the parent's tracing
+        // sink AND an on-disk `engine.log` next to backend.log. On
+        // Windows GUI builds the parent has no console, so inherited
+        // stderr disappears into NUL and the engine's tracing output —
+        // including panic messages — is lost. The on-disk capture is
+        // what `Report bug` ships back to us when an engine subprocess
+        // crashes.
         cmd.stdout(Stdio::piped())
-            .stderr(Stdio::inherit())
+            .stderr(Stdio::piped())
             // Piped stdin we never write to: when this supervisor
             // process exits (or crashes), the write-end drops and the
             // child's `read(stdin)` returns EOF. The engine's
@@ -117,7 +124,45 @@ impl EngineSubprocess {
         // engine's parent watchdog the moment we start reaping.
         let stdin = child.stdin.take();
         let stdout = child.stdout.take().ok_or("no stdout from engine")?;
+        let stderr = child.stderr.take().ok_or("no stderr from engine")?;
         let mut reader = BufReader::new(stdout);
+
+        // Forward engine stderr (its tracing sink) to:
+        //   1. an on-disk `engine.log` daily-rolled file alongside
+        //      `backend.log`, so bug reports include engine traces, and
+        //   2. the supervisor's tracing sink as `[engine:stderr] ...`.
+        // Without (1), Windows GUI builds discard engine stderr to NUL.
+        let stderr_reader = BufReader::new(stderr);
+        thread::spawn(move || {
+            let logs_dir = houston_tauri::houston_db::db::houston_dir().join("logs");
+            let _ = std::fs::create_dir_all(&logs_dir);
+            let today = chrono::Local::now().format("%Y-%m-%d").to_string();
+            let log_path = logs_dir.join(format!("engine.log.{today}"));
+            let mut file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&log_path)
+                .ok();
+            use std::io::Write;
+            let mut reader = stderr_reader;
+            let mut line = String::new();
+            loop {
+                line.clear();
+                match reader.read_line(&mut line) {
+                    Ok(0) | Err(_) => break,
+                    Ok(_) => {
+                        let trimmed = line.trim_end();
+                        if !trimmed.is_empty() {
+                            tracing::debug!("[engine:stderr] {trimmed}");
+                            if let Some(f) = file.as_mut() {
+                                let _ = writeln!(f, "{trimmed}");
+                                let _ = f.flush();
+                            }
+                        }
+                    }
+                }
+            }
+        });
 
         let deadline = Instant::now() + timeout;
         let handshake: EngineHandshake = {

--- a/app/src-tauri/src/engine_supervisor.rs
+++ b/app/src-tauri/src/engine_supervisor.rs
@@ -112,7 +112,20 @@ impl EngineSubprocess {
             // MSI builds. We never need to send Ctrl+C to the child
             // ourselves; the stdin watchdog handles graceful shutdown.
             const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
-            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP);
+            // CREATE_NO_WINDOW (0x08000000) prevents Windows from
+            // allocating a fresh console for the engine child.
+            // `houston-app.exe` is a GUI Tauri process with no
+            // console attached, so without this flag the engine —
+            // which compiles with Rust's default `console` PE
+            // subsystem so its tracing output stays inspectable when
+            // launched from a terminal — pops a visible cmd window
+            // every time Houston launches. Tauri's own `Sidecar`
+            // helper sets this flag for us; we don't use it
+            // (engine_supervisor speaks raw std::process::Command
+            // for the stdin-watchdog trick), so we have to set it
+            // ourselves.
+            const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+            cmd.creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
         }
 
         let mut child = cmd

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -12,7 +12,6 @@ use engine_supervisor::{
 use houston_tauri::houston_db::Database;
 use houston_tauri::state::AppState;
 use houston_ui_events::HoustonEvent;
-use std::path::PathBuf;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tauri::{Emitter, Manager};
@@ -394,9 +393,9 @@ fn migrate_all_agents(workspaces_root: &std::path::Path) {
 /// On any error we log + bail; the engine will still run against the new
 /// empty path. Original legacy dir is left in place as manual rollback.
 fn migrate_legacy_docs_dir(houston: &std::path::Path) {
-    let home = match std::env::var("HOME") {
-        Ok(h) => PathBuf::from(h),
-        Err(_) => return,
+    let home = match dirs::home_dir() {
+        Some(h) => h,
+        None => return,
     };
     let legacy = home.join("Documents").join("Houston");
     let new_root = houston.join("workspaces");

--- a/cli-deps.json
+++ b/cli-deps.json
@@ -80,5 +80,21 @@
         "$artifact_basename_comment": "Bun appends `.exe` automatically for Windows targets; the staged binary is `dist/binaries/composio-windows-arm64.exe` and companions live under `dist/binaries/companions/`. The codex-acp companion shipped is the `win32-arm64` build; all other arches are pruned."
       }
     }
+  },
+  "git-bash": {
+    "version": "2.54.0",
+    "bundled": true,
+    "binary_name": "bash",
+    "license": "GPL-2.0",
+    "ship_layout": "sfx-extract-on-first-launch",
+    "$comment": "Claude Code on Windows requires Git Bash (bash.exe + msys2 runtime). Without it `claude auth login --claudeai` exits 1 with stderr 'requires git-bash'. Houston bundles PortableGit's self-extracting 7z so the user never sees that error: the engine's first-launch hook extracts the SFX into %LOCALAPPDATA%\\Programs\\Houston\\runtime\\git-{x86_64|aarch64}\\ and sets CLAUDE_CODE_GIT_BASH_PATH on every claude.exe spawn. Per-arch because the host's native arch matters for shell perf (and because PortableGit-arm64 dropped in git-for-windows 2.40+). We ship the SFX rather than the 410MB extracted tree because MSI compression of binary content is much worse than 7z's. First-launch cost: ~3-5s. See houston-engine-core::git_bash for the resolver + extractor.",
+    "urls": {
+      "windows-x64": "https://github.com/git-for-windows/git/releases/download/v{version}.windows.1/PortableGit-{version}-64-bit.7z.exe",
+      "windows-arm64": "https://github.com/git-for-windows/git/releases/download/v{version}.windows.1/PortableGit-{version}-arm64.7z.exe"
+    },
+    "checksums": {
+      "windows-x64": "bea006a6cc69673f27b1647e84ab3a68e912fbc175ab6320c5987e012897f311",
+      "windows-arm64": "f8e92cd3359fcbb96998cfd606a536ccc6dbfb23c04e12b29042f9ba45b6b0c7"
+    }
   }
 }

--- a/cli-deps.json
+++ b/cli-deps.json
@@ -48,7 +48,7 @@
     "binary_name": "composio",
     "license": "MIT",
     "ship_layout": "per-arch-dir",
-    "$ship_layout_comment": "Composio is a Bun-bundled JS app with arch-specific runtime + sibling .mjs/services files; cannot lipo. Each arch ships at resources/bin/composio-{aarch64|x86_64}/ on macOS and resources/bin/composio-x86_64/ on Windows (no aarch64 Windows build in v1) and the engine resolves at runtime via std::env::consts::ARCH. Cross-platform acp-adapters that the resolved arch can never execute are pruned at fetch time to keep the bundle honest in size.",
+    "$ship_layout_comment": "Composio is a Bun-bundled JS app with arch-specific runtime + sibling .mjs/services files; cannot lipo. Each arch ships at resources/bin/composio-{aarch64|x86_64}/ on every supported OS. The engine resolves at runtime via std::env::consts::ARCH, with a `IsWow64Process2` shim that prefers `composio-aarch64/` when an x64 process is running under Windows-on-ARM emulation (see houston-cli-bundle::host_arch_for_composio). Cross-platform acp-adapters that the resolved arch can never execute are pruned at fetch time to keep the bundle honest in size.",
     "urls": {
       "darwin-arm64": "https://github.com/ComposioHQ/composio/releases/download/@composio/cli@{version}/composio-darwin-aarch64.zip",
       "darwin-x64": "https://github.com/ComposioHQ/composio/releases/download/@composio/cli@{version}/composio-darwin-x64.zip"
@@ -57,7 +57,7 @@
       "darwin-arm64": "fba0a57788ea50335507b2a38eccc67ebc051272f8393284b239875c4fdff8ef",
       "darwin-x64": "94af160e5bb10be80218dd9377c79a72d5c5ab7e172a65da0607ec4ee4d019c6"
     },
-    "$build_comment": "Upstream ComposioHQ/composio does not yet publish Windows artifacts (issue #3057, closed: 'use WSL'). Until that ships, we build composio.exe from a fork at gethouston/composio that adds Windows targets to TARGET_MAP, win32 entries to RUN_CODEX_ACP_BINARY_TARGETS, and a Windows Credential Manager backend in cli-keyring. Builds are reproducible: pinned commit SHA, pinned Bun version, pinned bun_target. The `pnpm` package manager + Bun runtime installed on the build host must match the values in the fork's `package.json#packageManager` and `.bun-version` respectively.",
+    "$build_comment": "Upstream ComposioHQ/composio does not yet publish Windows artifacts (issue #3057, closed: 'use WSL'). Until that ships, we build composio.exe from a fork at gethouston/composio that adds Windows targets to TARGET_MAP, win32 entries to RUN_CODEX_ACP_BINARY_TARGETS, and a Windows Credential Manager backend in cli-keyring. The `windows-arm64` build additionally needs the bun:ffi fallback from `houston-windows-arm64` branch — Bun 1.3.10's windows-arm64 target ships without TinyCC so the FFI keyring store has to downshift to NoStorageAccess at import time. Builds are reproducible: pinned commit SHA, pinned Bun version, pinned bun_target. The `pnpm` package manager + Bun runtime installed on the build host must match the values in the fork's `package.json#packageManager` and `.bun-version` respectively.",
     "build": {
       "windows-x64": {
         "source_repo": "https://github.com/gethouston/composio.git",
@@ -68,6 +68,16 @@
         "bun_version": "1.3.10",
         "artifact_basename": "composio-windows-x64",
         "$artifact_basename_comment": "Bun appends `.exe` automatically for Windows targets; the staged binary is `dist/binaries/composio-windows-x64.exe` and companions live under `dist/binaries/companions/`."
+      },
+      "windows-arm64": {
+        "source_repo": "https://github.com/gethouston/composio.git",
+        "source_ref": "houston-windows-arm64",
+        "source_sha": "c17c8fb88d4d771666e4b2d70ec9a61169758317",
+        "package_path": "ts/packages/cli",
+        "bun_target": "bun-windows-arm64",
+        "bun_version": "1.3.10",
+        "artifact_basename": "composio-windows-arm64",
+        "$artifact_basename_comment": "Bun appends `.exe` automatically for Windows targets; the staged binary is `dist/binaries/composio-windows-arm64.exe` and companions live under `dist/binaries/companions/`. The codex-acp companion shipped is the `win32-arm64` build; all other arches are pruned."
       }
     }
   }

--- a/engine/houston-cli-bundle/src/lib.rs
+++ b/engine/houston-cli-bundle/src/lib.rs
@@ -130,6 +130,22 @@ pub fn bundled_composio_binary() -> Option<PathBuf> {
     }
 }
 
+/// Per-arch PortableGit self-extracting 7z. The SFX itself never
+/// runs on the host that built the bundle — it's a Windows PE meant
+/// to be extracted on the user's machine on first launch (see
+/// houston-engine-core::git_bash). Returns `None` on macOS / Linux
+/// or when the bundle wasn't staged with `windows-{x64,arm64}` modes.
+#[cfg(target_os = "windows")]
+pub fn bundled_git_bash_sfx() -> Option<PathBuf> {
+    let arch = host_arch_for_composio();
+    let p = bundled_bin_dir()?.join(format!("git-bash-{arch}.7z.exe"));
+    if p.is_file() {
+        Some(p)
+    } else {
+        None
+    }
+}
+
 /// Path to the bundled `cli-deps.json` manifest, or `None`.
 pub fn bundled_cli_deps_manifest() -> Option<PathBuf> {
     let p = bundled_bin_dir()?.join(CLI_DEPS_MANIFEST);

--- a/engine/houston-cli-bundle/src/lib.rs
+++ b/engine/houston-cli-bundle/src/lib.rs
@@ -353,8 +353,105 @@ fn composio_binary_name() -> &'static str {
 /// names ("aarch64", "x86_64") so the runtime resolver doesn't need a
 /// translation table from upstream's "arm64"/"x64" naming. Matches the
 /// directory layout produced by `scripts/fetch-cli-deps.sh`.
+///
+/// **Windows-on-ARM exception**: when an x64 Houston binary runs under
+/// Microsoft's x64 emulator on an ARM64 Windows host, `consts::ARCH`
+/// returns "x86_64" because the running process IS x86_64. But the
+/// emulator does not implement every x86 instruction set, so x64
+/// Composio crashes with `STATUS_ILLEGAL_INSTRUCTION` (0xc000001d) on
+/// real ARM laptops. We detect this case via `IsWow64Process2` and
+/// prefer the native `composio-aarch64/` directory when it's present
+/// in the bundle. Falls back to `composio-x86_64/` if the aarch64
+/// build hasn't been bundled (which is the case until the
+/// gethouston/composio fork ships an ARM build).
 fn host_arch_for_composio() -> &'static str {
-    std::env::consts::ARCH
+    #[cfg(target_os = "windows")]
+    {
+        let probe = windows_native_arch_under_emulation();
+        let bin = bundled_bin_dir();
+        tracing::info!(
+            "[composio:arch] windows probe: native_under_emulation={:?} bundled_bin_dir={:?}",
+            probe,
+            bin.as_deref().map(|p| p.display().to_string())
+        );
+        if let Some(native) = probe {
+            if let Some(bin) = bin {
+                let native_dir = bin.join(format!("composio-{native}"));
+                let exists = native_dir.is_dir();
+                tracing::info!(
+                    "[composio:arch] checking native dir {} exists={}",
+                    native_dir.display(),
+                    exists
+                );
+                if exists {
+                    return native;
+                }
+            }
+        }
+    }
+    let fallback = std::env::consts::ARCH;
+    #[cfg(target_os = "windows")]
+    tracing::info!("[composio:arch] falling back to consts::ARCH = {}", fallback);
+    fallback
+}
+
+/// Detect Windows-on-ARM running an x64 process under emulation.
+/// Returns the native architecture name ("aarch64") when the current
+/// process is being emulated; `None` when running natively on
+/// whatever architecture matches the binary. Uses `IsWow64Process2`
+/// available since Windows 10 1709 — Houston's minimum supported
+/// Windows is 10, so the lookup never fails on unsupported OS.
+#[cfg(target_os = "windows")]
+fn windows_native_arch_under_emulation() -> Option<&'static str> {
+    // Avoid pulling in the `windows` crate for one syscall.
+    type Handle = *mut std::ffi::c_void;
+    #[link(name = "kernel32")]
+    extern "system" {
+        fn GetCurrentProcess() -> Handle;
+        fn IsWow64Process2(
+            h_process: Handle,
+            p_process_machine: *mut u16,
+            p_native_machine: *mut u16,
+        ) -> i32;
+    }
+    const IMAGE_FILE_MACHINE_UNKNOWN: u16 = 0x0000;
+    const IMAGE_FILE_MACHINE_ARM64: u16 = 0xAA64;
+    const IMAGE_FILE_MACHINE_AMD64: u16 = 0x8664;
+
+    let mut process_machine: u16 = 0;
+    let mut native_machine: u16 = 0;
+    let ok = unsafe {
+        IsWow64Process2(
+            GetCurrentProcess(),
+            &mut process_machine,
+            &mut native_machine,
+        )
+    };
+    tracing::info!(
+        "[composio:arch] IsWow64Process2 ok={} process_machine=0x{:04x} native_machine=0x{:04x}",
+        ok,
+        process_machine,
+        native_machine
+    );
+    if ok == 0 {
+        return None;
+    }
+    // `native_machine` is always populated with the host's true arch
+    // regardless of emulation status, so use IT as the source of truth.
+    // The earlier "process_machine == UNKNOWN means native" check was
+    // wrong for the Houston-on-ARM case: Microsoft's x64-on-ARM
+    // emulator reports `process_machine == AMD64` correctly on most
+    // SKUs, but there's an edge where the OS reports UNKNOWN even
+    // under emulation. Trusting `native_machine` directly is robust
+    // either way — if the host is ARM64, we want native ARM; if the
+    // host is x64, we want x64 (which `consts::ARCH` would have given
+    // us anyway since the binary is x64).
+    match native_machine {
+        IMAGE_FILE_MACHINE_ARM64 => Some("aarch64"),
+        IMAGE_FILE_MACHINE_AMD64 => Some("x86_64"),
+        IMAGE_FILE_MACHINE_UNKNOWN => None,
+        _ => None,
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/engine/houston-composio/src/cli.rs
+++ b/engine/houston-composio/src/cli.rs
@@ -123,7 +123,11 @@ pub async fn start_login() -> Result<StartLoginResponse, String> {
                 .map_err(|e| format!("Failed to spawn composio login: {e}"))?;
 
             if !status.success() {
-                return Err(format!("composio login --no-wait exited with {status}"));
+                return Err(decorate_windows_exit(
+                    "composio login --no-wait",
+                    &format!("{status}"),
+                    status.code(),
+                ));
             }
 
             let stdout = std::fs::read_to_string(&tmp)
@@ -495,4 +499,63 @@ async fn list_connected_toolkits_inner() -> Result<Vec<String>, String> {
         .map_err(|e| format!("Failed to parse connected toolkits: {e}"))?;
 
     Ok(result.toolkits)
+}
+
+/// Turn a cryptic Windows process exit (e.g. `0xc000001d`) into a
+/// human-actionable error message. On non-Windows or unrecognized
+/// codes we return the original status verbatim.
+fn decorate_windows_exit(command: &str, status_display: &str, exit_code: Option<i32>) -> String {
+    // i32 sign-extended NTSTATUS values that appear in process exits.
+    // Tests pass these as the canonical u32 NTSTATUS hex form so we
+    // compare on the lower 32 bits.
+    let nt = exit_code.map(|c| c as u32);
+    let hint = match nt {
+        Some(0xC000_001D) => Some(
+            "STATUS_ILLEGAL_INSTRUCTION (0xc000001d): the bundled x64 \
+             binary uses CPU instructions not supported by this CPU. \
+             On Windows-on-ARM laptops the x64 emulator does not \
+             implement every instruction set — Composio needs a \
+             native aarch64 build (tracked in gethouston/composio). \
+             On native x64 hardware this usually means a corrupted \
+             binary; reinstall Houston.",
+        ),
+        Some(0xC000_0135) => Some(
+            "STATUS_DLL_NOT_FOUND (0xc0000135): a runtime DLL the CLI \
+             needs is missing. Reinstall Houston or check the install \
+             directory for missing files.",
+        ),
+        Some(0xC000_0139) => Some(
+            "STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139): a DLL is present \
+             but the wrong version. Reinstall Houston.",
+        ),
+        _ => None,
+    };
+    match hint {
+        Some(h) => format!("{command} exited with {status_display}. {h}"),
+        None => format!("{command} exited with {status_display}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decorates_illegal_instruction() {
+        let msg = decorate_windows_exit("composio whoami", "exit code: 0xc000001d", Some(0xC000_001D_u32 as i32));
+        assert!(msg.contains("STATUS_ILLEGAL_INSTRUCTION"));
+        assert!(msg.contains("aarch64"));
+    }
+
+    #[test]
+    fn passes_through_unknown_codes() {
+        let msg = decorate_windows_exit("composio login", "exit code: 1", Some(1));
+        assert_eq!(msg, "composio login exited with exit code: 1");
+    }
+
+    #[test]
+    fn passes_through_when_code_unavailable() {
+        let msg = decorate_windows_exit("composio login", "signal: 9", None);
+        assert_eq!(msg, "composio login exited with signal: 9");
+    }
 }

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -13,3 +13,4 @@ tokio = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
+dirs = "5"

--- a/engine/houston-db/src/db.rs
+++ b/engine/houston-db/src/db.rs
@@ -132,13 +132,13 @@ pub fn houston_dir() -> PathBuf {
     if let Ok(override_path) = std::env::var("HOUSTON_HOME") {
         return PathBuf::from(override_path);
     }
-    let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+    let home = dirs::home_dir().unwrap_or_else(|| PathBuf::from("."));
     let subdir = if cfg!(debug_assertions) {
         ".dev-houston"
     } else {
         ".houston"
     };
-    PathBuf::from(home).join(subdir)
+    home.join(subdir)
 }
 
 #[cfg(test)]

--- a/engine/houston-engine-core/src/git_bash.rs
+++ b/engine/houston-engine-core/src/git_bash.rs
@@ -1,0 +1,171 @@
+//! Bundled Git Bash provisioning for Windows.
+//!
+//! Claude Code on Windows refuses to launch without `bash.exe` — it
+//! needs the msys2 POSIX runtime to execute shell commands. Houston
+//! bundles `PortableGit-*.7z.exe` (the official self-extracting build
+//! from git-for-windows) inside the MSI under
+//! `resources/bin/git-bash-<arch>.7z.exe` and extracts it once on
+//! first launch into `%LOCALAPPDATA%\Programs\Houston\runtime\
+//! git-bash-<arch>\`. Subsequent launches return the cached path
+//! immediately.
+//!
+//! Why not bundle the extracted tree? PortableGit extracts to ~410 MB
+//! per arch but compresses to ~57 MB via 7z. WiX/CAB compression is
+//! much worse than 7z on binary content, so shipping the SFX cuts the
+//! MSI delta to a quarter of what the extracted tree would cost.
+//! First-launch extraction is a one-time ~3-5s cost on a fresh
+//! install.
+//!
+//! No-op on non-Windows.
+
+#[cfg(target_os = "windows")]
+mod imp {
+    use std::path::PathBuf;
+    use std::sync::OnceLock;
+
+    /// Cache the resolved path for the process lifetime. Extraction is
+    /// idempotent + cheap-to-check on re-entry, but a OnceLock saves
+    /// the disk-stat round-trip on every claude spawn.
+    static CACHED: OnceLock<Option<PathBuf>> = OnceLock::new();
+
+    /// Returns the path to a usable `bash.exe`, extracting the bundled
+    /// PortableGit if needed. `None` if no bundle ships in this build
+    /// (e.g. dev runs with no fetched CLIs) — callers should fall back
+    /// to their existing PATH probe.
+    pub fn ensure_bundled_bash() -> Option<PathBuf> {
+        if let Some(cached) = CACHED.get() {
+            return cached.clone();
+        }
+        let resolved = resolve();
+        let _ = CACHED.set(resolved.clone());
+        resolved
+    }
+
+    fn resolve() -> Option<PathBuf> {
+        let sfx = houston_cli_bundle::bundled_git_bash_sfx()?;
+        let arch = std::env::consts::ARCH;
+        let target_dir = extraction_root()?.join(format!("git-bash-{arch}"));
+        let bash = target_dir.join("bin").join("bash.exe");
+
+        if bash.is_file() && marker_matches(&target_dir, &sfx) {
+            return Some(bash);
+        }
+
+        // Stale or missing — clear and re-extract. We never extract
+        // into a partially-populated directory because PortableGit's
+        // SFX overwrites freely but won't remove now-deleted files
+        // from a previous Git version.
+        if target_dir.exists() {
+            if let Err(e) = std::fs::remove_dir_all(&target_dir) {
+                tracing::warn!(
+                    "[git-bash] failed to clear stale {}: {e}",
+                    target_dir.display()
+                );
+                return None;
+            }
+        }
+        if let Err(e) = std::fs::create_dir_all(&target_dir) {
+            tracing::warn!(
+                "[git-bash] failed to create {}: {e}",
+                target_dir.display()
+            );
+            return None;
+        }
+
+        tracing::info!(
+            "[git-bash] extracting {} into {}",
+            sfx.display(),
+            target_dir.display()
+        );
+        let started = std::time::Instant::now();
+        // PortableGit's 7z SFX accepts `-y -o<path>` per Igor Pavlov's
+        // SFX convention. NB: `-o` and the path must NOT be separated
+        // by a space.
+        let output = std::process::Command::new(&sfx)
+            .arg("-y")
+            .arg(format!("-o{}", target_dir.display()))
+            .output();
+
+        match output {
+            Ok(out) if out.status.success() => {
+                tracing::info!(
+                    "[git-bash] extracted in {:.1}s",
+                    started.elapsed().as_secs_f32()
+                );
+            }
+            Ok(out) => {
+                tracing::warn!(
+                    "[git-bash] SFX exited {} stdout={:?} stderr={:?}",
+                    out.status,
+                    String::from_utf8_lossy(&out.stdout),
+                    String::from_utf8_lossy(&out.stderr)
+                );
+                return None;
+            }
+            Err(e) => {
+                tracing::warn!("[git-bash] SFX spawn failed: {e}");
+                return None;
+            }
+        }
+
+        if !bash.is_file() {
+            tracing::warn!(
+                "[git-bash] extraction reported success but {} is missing",
+                bash.display()
+            );
+            return None;
+        }
+        write_marker(&target_dir, &sfx);
+        Some(bash)
+    }
+
+    /// `%LOCALAPPDATA%\Programs\Houston\runtime` — extraction root.
+    /// Use LOCALAPPDATA so the data is user-scoped (not per-machine)
+    /// and survives Houston updates that preserve user state.
+    fn extraction_root() -> Option<PathBuf> {
+        dirs::data_local_dir().map(|d| d.join("Programs").join("Houston").join("runtime"))
+    }
+
+    /// Marker file: stores the SFX's mtime+len so a fresh Houston
+    /// build (which usually bumps PortableGit too) triggers re-extract.
+    /// Cheap (~1ms) and avoids re-hashing the 57 MB SFX on every boot.
+    fn marker_path(target_dir: &std::path::Path) -> PathBuf {
+        target_dir.join(".sfx-marker")
+    }
+
+    fn marker_value(sfx: &std::path::Path) -> Option<String> {
+        let meta = std::fs::metadata(sfx).ok()?;
+        let mtime = meta.modified().ok()?;
+        let secs = mtime
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        Some(format!("{}:{}", meta.len(), secs))
+    }
+
+    fn marker_matches(target_dir: &std::path::Path, sfx: &std::path::Path) -> bool {
+        let expected = match marker_value(sfx) {
+            Some(v) => v,
+            None => return false,
+        };
+        std::fs::read_to_string(marker_path(target_dir))
+            .map(|s| s.trim() == expected)
+            .unwrap_or(false)
+    }
+
+    fn write_marker(target_dir: &std::path::Path, sfx: &std::path::Path) {
+        if let Some(v) = marker_value(sfx) {
+            let _ = std::fs::write(marker_path(target_dir), v);
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+mod imp {
+    use std::path::PathBuf;
+    pub fn ensure_bundled_bash() -> Option<PathBuf> {
+        None
+    }
+}
+
+pub use imp::ensure_bundled_bash;

--- a/engine/houston-engine-core/src/git_bash.rs
+++ b/engine/houston-engine-core/src/git_bash.rs
@@ -23,10 +23,11 @@ mod imp {
     use std::path::PathBuf;
     use std::sync::OnceLock;
 
-    /// Cache the resolved path for the process lifetime. Extraction is
-    /// idempotent + cheap-to-check on re-entry, but a OnceLock saves
-    /// the disk-stat round-trip on every claude spawn.
-    static CACHED: OnceLock<Option<PathBuf>> = OnceLock::new();
+    /// Cache the resolved path for the process lifetime. Only Some
+    /// values are cached — a failed extraction can succeed on a retry
+    /// (transient ENOSPC, antivirus quarantine, etc.) so we never
+    /// poison the cache with None.
+    static CACHED: OnceLock<PathBuf> = OnceLock::new();
 
     /// Returns the path to a usable `bash.exe`, extracting the bundled
     /// PortableGit if needed. `None` if no bundle ships in this build
@@ -34,21 +35,46 @@ mod imp {
     /// to their existing PATH probe.
     pub fn ensure_bundled_bash() -> Option<PathBuf> {
         if let Some(cached) = CACHED.get() {
-            return cached.clone();
+            return Some(cached.clone());
         }
-        let resolved = resolve();
+        let resolved = resolve()?;
         let _ = CACHED.set(resolved.clone());
-        resolved
+        Some(resolved)
+    }
+
+    /// Candidate bash.exe locations inside an extracted PortableGit.
+    /// PortableGit-64-bit ships both — `usr/bin/bash.exe` is the
+    /// msys2-canonical location and `bin/bash.exe` is a launcher that
+    /// re-execs through cmd. PortableGit-arm64 only ships
+    /// `usr/bin/bash.exe`. We try the usr path first because it's
+    /// always present and is what Claude Code actually wants
+    /// (the launcher in /bin/ is a wrapper meant for opening a
+    /// terminal, not for non-interactive execution).
+    const BASH_CANDIDATES: &[&[&str]] = &[
+        &["usr", "bin", "bash.exe"],
+        &["bin", "bash.exe"],
+    ];
+
+    fn locate_bash(target_dir: &std::path::Path) -> Option<PathBuf> {
+        BASH_CANDIDATES.iter().find_map(|parts| {
+            let mut p = target_dir.to_path_buf();
+            for s in *parts {
+                p.push(s);
+            }
+            p.is_file().then_some(p)
+        })
     }
 
     fn resolve() -> Option<PathBuf> {
         let sfx = houston_cli_bundle::bundled_git_bash_sfx()?;
         let arch = std::env::consts::ARCH;
         let target_dir = extraction_root()?.join(format!("git-bash-{arch}"));
-        let bash = target_dir.join("bin").join("bash.exe");
 
-        if bash.is_file() && marker_matches(&target_dir, &sfx) {
-            return Some(bash);
+        if let Some(bash) = locate_bash(&target_dir) {
+            if marker_matches(&target_dir, &sfx) {
+                tracing::debug!("[git-bash] cached extraction usable at {}", bash.display());
+                return Some(bash);
+            }
         }
 
         // Stale or missing — clear and re-extract. We never extract
@@ -108,14 +134,18 @@ mod imp {
             }
         }
 
-        if !bash.is_file() {
+        let Some(bash) = locate_bash(&target_dir) else {
             tracing::warn!(
-                "[git-bash] extraction reported success but {} is missing",
-                bash.display()
+                "[git-bash] extraction reported success but no bash.exe at {}/{{usr/bin,bin}}/bash.exe",
+                target_dir.display()
             );
             return None;
-        }
+        };
         write_marker(&target_dir, &sfx);
+        tracing::info!(
+            "[git-bash] resolved bash.exe at {}",
+            bash.display()
+        );
         Some(bash)
     }
 
@@ -167,5 +197,6 @@ mod imp {
         None
     }
 }
+
 
 pub use imp::ensure_bundled_bash;

--- a/engine/houston-engine-core/src/lib.rs
+++ b/engine/houston-engine-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod agents_crud;
 pub mod attachments;
 pub mod conversations;
 pub mod error;
+pub mod git_bash;
 pub mod paths;
 pub mod preferences;
 pub mod provider;

--- a/engine/houston-engine-core/src/provider.rs
+++ b/engine/houston-engine-core/src/provider.rs
@@ -390,12 +390,22 @@ async fn check_codex_status() -> ProviderStatus {
 /// `cfg(target_os = "windows")`.
 #[cfg(target_os = "windows")]
 fn find_git_bash_windows() -> Option<PathBuf> {
+    // 1. Explicit user override always wins.
     if let Ok(p) = std::env::var("CLAUDE_CODE_GIT_BASH_PATH") {
         let pb = PathBuf::from(p);
         if pb.is_file() {
             return Some(pb);
         }
     }
+    // 2. Houston-bundled PortableGit — first launch extracts the SFX
+    //    into %LOCALAPPDATA%\Programs\Houston\runtime\git-bash-<arch>\.
+    //    Preferring this over the user's system Git keeps Claude's
+    //    bash version pinned across the Houston install base, which
+    //    matches what Claude Code's QA tests against.
+    if let Some(bundled) = crate::git_bash::ensure_bundled_bash() {
+        return Some(bundled);
+    }
+    // 3. Standard Git for Windows install locations.
     for candidate in [
         "C:\\Program Files\\Git\\bin\\bash.exe",
         "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
@@ -405,6 +415,7 @@ fn find_git_bash_windows() -> Option<PathBuf> {
             return Some(pb);
         }
     }
+    // 4. Anywhere on PATH (covers chocolatey / scoop / portable installs).
     if let Ok(paths) = std::env::var("PATH") {
         for dir in std::env::split_paths(&paths) {
             let bash = dir.join("bash.exe");

--- a/engine/houston-engine-core/src/provider.rs
+++ b/engine/houston-engine-core/src/provider.rs
@@ -69,45 +69,148 @@ pub async fn check_status(provider: Provider) -> CoreResult<ProviderStatus> {
     })
 }
 
-/// Launch the provider's login flow in the background (opens the user's
-/// browser for OAuth). Returns immediately — the frontend polls
-/// `check_status` to observe completion.
-pub fn launch_login(provider: Provider) -> CoreResult<()> {
-    let command = login_command(provider)?;
+/// Launch the provider's login flow. Spawns the CLI as a subprocess
+/// and waits up to 3 seconds for early failure: real OAuth flows take
+/// minutes (the user has to complete sign-in in the browser), but
+/// fast-failing CLIs (missing dependency, illegal instruction on
+/// emulated platforms) crash in milliseconds. We surface those to the
+/// caller as a real error containing the CLI's stderr — the frontend
+/// then shows an actionable message instead of letting the user sit
+/// forever on a "waiting" dialog.
+///
+/// If the CLI is still running after the 3-second probe window, we
+/// detach it: the OAuth flow continues in the background and the
+/// frontend polls `check_status` to observe completion, as before.
+pub async fn launch_login(provider: Provider) -> CoreResult<()> {
+    let ProviderCliCommand {
+        cli_name,
+        path,
+        args,
+        shell_path,
+    } = login_command(provider)?;
 
-    tokio::spawn(async move {
-        let ProviderCliCommand {
-            cli_name,
-            path,
-            args,
-            shell_path,
-        } = command;
-        let result = tokio::time::timeout(
-            Duration::from_secs(120),
-            tokio::process::Command::new(&path)
-                .args(&args)
-                .env("PATH", shell_path)
-                .stdin(std::process::Stdio::null())
-                .stdout(std::process::Stdio::null())
-                .stderr(std::process::Stdio::null())
-                .kill_on_drop(true)
-                .status(),
-        )
-        .await;
+    let mut cmd = tokio::process::Command::new(&path);
+    cmd.args(&args)
+        .env("PATH", shell_path)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .kill_on_drop(false);
 
-        match result {
-            Ok(Ok(status)) => {
-                tracing::info!("[houston:provider] {cli_name} login exited: {status}")
+    // Windows: Claude Code requires Git Bash and looks for it at
+    // `CLAUDE_CODE_GIT_BASH_PATH` (env var) or hardcoded paths. We
+    // probe well-known install locations + PATH and pass the env
+    // var so the user doesn't have to set it themselves. If we
+    // can't find bash.exe at all, we surface a single actionable
+    // error instead of letting claude.exe exit code 1 with cryptic
+    // stderr.
+    #[cfg(target_os = "windows")]
+    if matches!(provider, Provider::Anthropic) {
+        match find_git_bash_windows() {
+            Some(bash) => {
+                tracing::info!(
+                    "[houston:provider] claude: setting CLAUDE_CODE_GIT_BASH_PATH={}",
+                    bash.display()
+                );
+                cmd.env("CLAUDE_CODE_GIT_BASH_PATH", bash);
             }
-            Ok(Err(e)) => tracing::warn!(
-                "[houston:provider] {cli_name} login failed at {}: {e}",
-                path.display()
-            ),
-            Err(_) => tracing::warn!("[houston:provider] {cli_name} login timed out after 120s"),
+            None => {
+                return Err(CoreError::BadRequest(
+                    "Claude Code on Windows requires Git Bash. Install Git for Windows from \
+                     https://git-scm.com/downloads/win — Houston will auto-detect it on next launch."
+                        .into(),
+                ));
+            }
         }
-    });
+    }
 
-    Ok(())
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| CoreError::Internal(format!("failed to spawn {cli_name} login: {e}")))?;
+
+    // Probe window: if the CLI exits within 3 seconds, the OAuth flow
+    // couldn't have completed — that's a real failure to surface.
+    let probe = tokio::time::timeout(Duration::from_secs(3), child.wait()).await;
+
+    match probe {
+        Ok(Ok(status)) if !status.success() => {
+            let mut stderr_buf = String::new();
+            let mut stdout_buf = String::new();
+            if let Some(mut err) = child.stderr.take() {
+                use tokio::io::AsyncReadExt;
+                let _ = err.read_to_string(&mut stderr_buf).await;
+            }
+            if let Some(mut out) = child.stdout.take() {
+                use tokio::io::AsyncReadExt;
+                let _ = out.read_to_string(&mut stdout_buf).await;
+            }
+            let stderr = stderr_buf.trim();
+            let stdout = stdout_buf.trim();
+            tracing::warn!(
+                "[houston:provider] {cli_name} login exited early: {status} stdout={stdout:?} stderr={stderr:?}"
+            );
+            let detail = if !stderr.is_empty() {
+                stderr.to_string()
+            } else if !stdout.is_empty() {
+                stdout.to_string()
+            } else {
+                decorate_windows_exit(cli_name, &format!("{status}"), status.code())
+            };
+            Err(CoreError::Internal(format!("{cli_name} login: {detail}")))
+        }
+        Ok(Ok(status)) => {
+            // Exited cleanly within 3s — unusual but possible if the CLI
+            // already had a cached session or printed a "done" message.
+            tracing::info!(
+                "[houston:provider] {cli_name} login completed in <3s: {status}"
+            );
+            Ok(())
+        }
+        Ok(Err(e)) => {
+            tracing::warn!(
+                "[houston:provider] {cli_name} login wait failed at {}: {e}",
+                path.display()
+            );
+            Err(CoreError::Internal(format!(
+                "{cli_name} login wait: {e}"
+            )))
+        }
+        Err(_) => {
+            // Still running after 3s — detach and let the OAuth flow
+            // continue. Frontend polls check_status to observe success.
+            tracing::info!(
+                "[houston:provider] {cli_name} login still running after 3s probe; detaching"
+            );
+            tokio::spawn(async move {
+                let result =
+                    tokio::time::timeout(Duration::from_secs(120), child.wait_with_output()).await;
+                match result {
+                    Ok(Ok(output)) => {
+                        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+                        if output.status.success() {
+                            tracing::info!(
+                                "[houston:provider] {cli_name} login exited: {}",
+                                output.status
+                            );
+                        } else {
+                            tracing::warn!(
+                                "[houston:provider] {cli_name} login exited: {} stdout={stdout:?} stderr={stderr:?}",
+                                output.status
+                            );
+                        }
+                    }
+                    Ok(Err(e)) => tracing::warn!(
+                        "[houston:provider] {cli_name} login wait failed: {e}"
+                    ),
+                    Err(_) => tracing::warn!(
+                        "[houston:provider] {cli_name} login timed out after 120s"
+                    ),
+                }
+            });
+            Ok(())
+        }
+    }
 }
 
 /// Run the provider's logout flow synchronously. Unlike login (which
@@ -262,7 +365,9 @@ async fn check_codex_status() -> ProviderStatus {
     let (install_source, cli_path) = resolve_codex();
     let cli_installed = !matches!(install_source, InstallSource::Missing);
     let auth_state = if let Some(path) = cli_path.as_deref() {
-        let home = std::env::var("HOME").unwrap_or_default();
+        let home = dirs::home_dir()
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_default();
         probe_codex_auth_status(path, &home).await
     } else {
         ProviderAuthState::Unauthenticated
@@ -275,6 +380,72 @@ async fn check_codex_status() -> ProviderStatus {
         cli_name: "codex".into(),
         install_source,
         cli_path: cli_path.map(|p| p.to_string_lossy().into_owned()),
+    }
+}
+
+/// Locate Git for Windows' `bash.exe` so Claude Code can use it. Probes
+/// the user override env var, the two standard Git for Windows install
+/// locations, and PATH. Returns `None` if Git for Windows is not
+/// installed. Windows-only by construction; the caller is gated on
+/// `cfg(target_os = "windows")`.
+#[cfg(target_os = "windows")]
+fn find_git_bash_windows() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("CLAUDE_CODE_GIT_BASH_PATH") {
+        let pb = PathBuf::from(p);
+        if pb.is_file() {
+            return Some(pb);
+        }
+    }
+    for candidate in [
+        "C:\\Program Files\\Git\\bin\\bash.exe",
+        "C:\\Program Files (x86)\\Git\\bin\\bash.exe",
+    ] {
+        let pb = PathBuf::from(candidate);
+        if pb.is_file() {
+            return Some(pb);
+        }
+    }
+    if let Ok(paths) = std::env::var("PATH") {
+        for dir in std::env::split_paths(&paths) {
+            let bash = dir.join("bash.exe");
+            if bash.is_file() {
+                return Some(bash);
+            }
+        }
+    }
+    None
+}
+
+/// Turn a cryptic Windows process exit (e.g. `0xc000001d`) into a
+/// human-actionable error message. On non-Windows or unrecognized
+/// codes we return the original status verbatim. Kept in sync with
+/// the copy in `houston-composio::cli` — these two are the only
+/// Houston modules that spawn third-party CLIs the user might see
+/// crash with NT status codes.
+fn decorate_windows_exit(command: &str, status_display: &str, exit_code: Option<i32>) -> String {
+    let nt = exit_code.map(|c| c as u32);
+    let hint = match nt {
+        Some(0xC000_001D) => Some(
+            "STATUS_ILLEGAL_INSTRUCTION (0xc000001d): the binary uses CPU \
+             instructions not supported by this CPU. On Windows-on-ARM \
+             laptops the x64 emulator does not implement every instruction \
+             set — the CLI needs a native aarch64 build. On native x64 \
+             hardware this usually means a corrupted install; reinstall \
+             Houston.",
+        ),
+        Some(0xC000_0135) => Some(
+            "STATUS_DLL_NOT_FOUND (0xc0000135): a runtime DLL is missing. \
+             Reinstall Houston.",
+        ),
+        Some(0xC000_0139) => Some(
+            "STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139): a DLL is the wrong \
+             version. Reinstall Houston.",
+        ),
+        _ => None,
+    };
+    match hint {
+        Some(h) => format!("{command} exited with {status_display}. {h}"),
+        None => format!("{command} exited with {status_display}"),
     }
 }
 

--- a/engine/houston-engine-core/src/worktree.rs
+++ b/engine/houston-engine-core/src/worktree.rs
@@ -51,8 +51,8 @@ pub struct RunShellRequest {
 
 fn expand_tilde(path: &Path) -> PathBuf {
     if path.starts_with("~") {
-        if let Ok(home) = std::env::var("HOME") {
-            return PathBuf::from(home).join(path.strip_prefix("~").unwrap_or(path));
+        if let Some(home) = dirs::home_dir() {
+            return home.join(path.strip_prefix("~").unwrap_or(path));
         }
     }
     path.to_path_buf()

--- a/engine/houston-engine-server/src/main.rs
+++ b/engine/houston-engine-server/src/main.rs
@@ -38,6 +38,38 @@ async fn main() {
         houston_terminal_manager::claude_path::init();
     });
 
+    // Provision Git Bash on Windows BEFORE any spawn site needs it.
+    // Claude Code's claude.exe refuses to run without bash.exe; we
+    // bundle PortableGit-<arch>.7z.exe and extract it on first launch,
+    // then export CLAUDE_CODE_GIT_BASH_PATH so every child process
+    // (the provider auth probe, the login flow, the summarize call,
+    // the chat-session runner) inherits the path without each
+    // call-site having to know. Runs concurrently with claude_path
+    // init so first-boot extraction (~3-5s) overlaps with the
+    // login-shell PATH probe instead of stacking serially. Awaited
+    // before `axum::serve` so no route handler can read a
+    // half-provisioned env var.
+    #[cfg(target_os = "windows")]
+    let git_bash_init = tokio::task::spawn_blocking(|| {
+        if let Some(bash) = houston_engine_core::git_bash::ensure_bundled_bash() {
+            tracing::info!("[boot] CLAUDE_CODE_GIT_BASH_PATH={}", bash.display());
+            // SAFETY: this thread is the sole writer to this env var
+            // for the engine's lifetime, and we await this task
+            // before `axum::serve` starts so no route handler reads
+            // it concurrently. set_var's `unsafe` marker exists to
+            // make readers-during-write the caller's problem; we
+            // serialize.
+            unsafe {
+                std::env::set_var("CLAUDE_CODE_GIT_BASH_PATH", bash);
+            }
+        } else {
+            tracing::warn!(
+                "[boot] no bundled Git Bash found — Claude Code will fail until \
+                 the user installs Git for Windows manually"
+            );
+        }
+    });
+
     let cfg = ServerConfig::from_env();
     let listener = TcpListener::bind(cfg.bind).await.expect("bind failed");
     let actual: SocketAddr = listener.local_addr().expect("local_addr");
@@ -111,6 +143,10 @@ async fn main() {
     // but not fatal.
     if let Err(e) = path_init.await {
         tracing::warn!("[boot] claude_path::init panicked: {e}");
+    }
+    #[cfg(target_os = "windows")]
+    if let Err(e) = git_bash_init.await {
+        tracing::warn!("[boot] git_bash provisioning panicked: {e}");
     }
 
     if let Err(err) = axum::serve(listener, app).await {

--- a/engine/houston-engine-server/src/routes/providers.rs
+++ b/engine/houston-engine-server/src/routes/providers.rs
@@ -33,7 +33,7 @@ async fn login(
     Path(name): Path<String>,
 ) -> Result<(), ApiError> {
     let p = provider::parse(&name)?;
-    provider::launch_login(p)?;
+    provider::launch_login(p).await?;
     Ok(())
 }
 

--- a/engine/houston-tunnel/src/identity.rs
+++ b/engine/houston-tunnel/src/identity.rs
@@ -39,6 +39,14 @@ pub fn invalidate(home_dir: &Path) {
 }
 
 /// First-boot: POST {relay_base}/allocate → allocate tunnel. Cached afterwards.
+///
+/// On 429 (Too Many Requests) we honor the server's `Retry-After`
+/// header and try once more before giving up. Without the retry, an
+/// engine restart loop (e.g. caused by an unrelated crash) hammers
+/// `/allocate` with one request per restart, which the relay sees as a
+/// burst from one client and bans for the rest of the boot. With the
+/// retry — and the cache that the successful call writes — we settle
+/// on a single tunnel ID within seconds of the first allowed request.
 pub async fn ensure(
     home_dir: &Path,
     relay_base: &str,
@@ -47,12 +55,32 @@ pub async fn ensure(
         return Ok(id);
     }
     let url = format!("{}/allocate", relay_base.trim_end_matches('/'));
-    let resp = reqwest::Client::new()
-        .post(&url)
-        .send()
-        .await?
-        .error_for_status()?;
-    let id: TunnelIdentity = resp.json().await?;
+    let client = reqwest::Client::new();
+
+    let mut attempt = 0;
+    let id: TunnelIdentity = loop {
+        attempt += 1;
+        let resp = client.post(&url).send().await?;
+        let status = resp.status();
+        if status == reqwest::StatusCode::TOO_MANY_REQUESTS && attempt == 1 {
+            // Server-suggested wait, capped at 30s so a misbehaving
+            // upstream can't stall engine startup indefinitely.
+            let wait_secs = resp
+                .headers()
+                .get(reqwest::header::RETRY_AFTER)
+                .and_then(|h| h.to_str().ok())
+                .and_then(|s| s.parse::<u64>().ok())
+                .unwrap_or(5)
+                .min(30);
+            tracing::warn!(
+                "tunnel allocation 429 — retrying once in {wait_secs}s per Retry-After"
+            );
+            tokio::time::sleep(std::time::Duration::from_secs(wait_secs)).await;
+            continue;
+        }
+        let resp = resp.error_for_status()?;
+        break resp.json().await?;
+    };
     save(home_dir, &id)?;
     Ok(id)
 }

--- a/knowledge-base/windows-testing.md
+++ b/knowledge-base/windows-testing.md
@@ -1,0 +1,422 @@
+# Windows testing — UTM VM dev loop
+
+How to test Houston Windows builds from a macOS dev host without
+waiting 25 minutes for the full release CI pipeline. Built and proven
+on macOS 26 (Apple Silicon) + UTM running Windows 11 ARM64.
+
+The loop, end to end (after one-time setup):
+
+```
+.context/win-dev/win.sh deploy   # cross-compile engine + push to VM (~30s incremental)
+# manually launch Houston from VM Start menu (~5s)
+.context/win-dev/win.sh logs     # fetch newest backend.log from VM (~2s)
+```
+
+Time per iteration: under a minute for engine-only changes. The full
+MSI is rebuilt only when `app/src-tauri/**` or installer config
+changes.
+
+## The bridge
+
+`.context/win-dev/win.sh` is the only entry point. It is intentionally
+in `.context/` (gitignored) because the VM IP and Windows username are
+local to the dev machine. Subcommands:
+
+| Command | What it does |
+|---------|--------------|
+| `ping` | Confirms SSH reachability + identifies remote |
+| `build [engine\|app\|both]` | Cross-compile from Mac via mingw-w64. `engine` is fast (~20s incremental), `app` slower (~30s), `both` is default. |
+| `deploy [engine\|app\|both]` | `build` → scp → stop running Houston → `Move-Item` into install dir. Use `engine` for fastest loop when only engine code changed. |
+| `launch` | `Start-Process houston-app.exe` (caveat: SSH session is Session 0, may not show on user's desktop — manually launching from Start menu is more reliable) |
+| `kill` | Stops `houston-app` and `houston-engine` processes in the VM |
+| `logs` | `Get-Content -Tail 200` of the newest `backend.log` |
+| `logs-all` | scp the entire `logs/` directory back to `.context/win-dev/logs-<timestamp>/` |
+| `shell` | Interactive ssh session |
+| `setup-deps` | One-time per install: drops `WebView2Loader.dll` next to `houston-app.exe` (required because mingw builds dynamic-load it; MSVC builds embed it statically). |
+
+Override `WIN_HOST` / `WIN_USER` via env vars if your VM has different
+values.
+
+## One-time setup
+
+### Mac side
+
+Already required by the existing platform-matrix.md cross-check
+target — these are usually already installed:
+
+```bash
+brew install mingw-w64
+rustup target add x86_64-pc-windows-gnu
+```
+
+No cargo config override needed; the script passes
+`CARGO_TARGET_X86_64_PC_WINDOWS_GNU_LINKER=x86_64-w64-mingw32-gcc`
+inline.
+
+Confirm the SSH key Mac will present:
+
+```bash
+cat ~/.ssh/id_ed25519.pub      # generate with ssh-keygen if absent
+```
+
+### Windows VM side (Windows 11 ARM64 in UTM)
+
+Five non-obvious things had to happen on the original setup. Document
+them here because each one is a gotcha that will bite again.
+
+**1. Set the network profile to "Private"** (Settings → Network &
+internet → Ethernet → "Network profile type" → Private). The default
+"Public" profile silently blocks inbound TCP regardless of which
+firewall rules you add.
+
+**2. The bundled OpenSSH Server (Optional Feature) is broken on
+Windows 11 ARM64.** `Add-WindowsCapability -Online -Name
+OpenSSH.Server~~~~0.0.1.0` reports success and `RestartNeeded :
+False`, but `sshd.exe` never actually deploys —
+`C:\Windows\System32\OpenSSH\` ends up with only the client tools
+(ssh, scp, sftp, ssh-keygen). Get-Service sshd returns "not found"
+forever. **Workaround**: install the standalone build from
+PowerShell/Win32-OpenSSH:
+
+```powershell
+Set-ExecutionPolicy -Scope Process -ExecutionPolicy Bypass -Force
+$url = "https://github.com/PowerShell/Win32-OpenSSH/releases/latest/download/OpenSSH-ARM64.zip"
+$zip = "$env:TEMP\OpenSSH.zip"
+Invoke-WebRequest -Uri $url -OutFile $zip
+Expand-Archive -Path $zip -DestinationPath "C:\Program Files" -Force
+$extracted = Get-ChildItem "C:\Program Files" -Directory -Filter "OpenSSH*" | Where-Object Name -ne "OpenSSH" | Select-Object -First 1
+if ($extracted) { Rename-Item $extracted.FullName "C:\Program Files\OpenSSH" -Force }
+& "C:\Program Files\OpenSSH\install-sshd.ps1"
+Start-Service sshd
+Set-Service sshd -StartupType Automatic
+New-NetFirewallRule -Name sshd -DisplayName 'OpenSSH' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22 -Profile Any
+```
+
+**3. For Administrator accounts, authorized_keys must live at
+`C:\ProgramData\ssh\administrators_authorized_keys`**, NOT in the
+user's `~/.ssh/`. Microsoft's OpenSSH treats admin users specially.
+Public-key auth silently rejects the user-local file. ACL must grant
+only `Administrators:F` and `SYSTEM:F`:
+
+```powershell
+$adminKeys = "C:\ProgramData\ssh\administrators_authorized_keys"
+Add-Content $adminKeys "ssh-ed25519 <mac-pubkey> mac"
+icacls $adminKeys /inheritance:r /grant "Administrators:F" /grant "SYSTEM:F"
+Restart-Service sshd
+```
+
+**4. Install Houston from the latest MSI release** so the install
+directory + bundled CLIs + WebView2 are all in place. The dev loop
+only replaces `houston-engine.exe`; the rest of the install is the
+shipping payload.
+
+**5. PowerShell quoting from SSH is hostile.** Windows OpenSSH's
+default shell for SSH sessions is cmd.exe, and `$env:VAR` is
+PowerShell syntax. The `win.sh` helper sidesteps this by base64
+encoding every PowerShell snippet and passing it via
+`powershell -NoProfile -EncodedCommand <base64>`. Any new helper that
+runs commands in the VM should use the `ps_remote` wrapper for the
+same reason.
+
+### `localhost refused to connect` after launching the cross-built app
+
+Tauri 2.x's `tauri-build` crate emits `cargo:rustc-cfg=dev` based on
+`!has_feature("custom-protocol")`. With dev cfg on, the webview tries
+to load `tauri.conf.json::devUrl` (i.e. `http://localhost:1420`),
+which obviously doesn't exist in the VM. `pnpm tauri build` handles
+this by passing `--features tauri/custom-protocol` to cargo; raw
+`cargo build --release` doesn't. The `win.sh` build helper now passes
+that flag, AND runs `pnpm build` in `app/` first so the frontend
+assets exist for the bundler to embed. If you ever invoke cargo
+directly for `houston-app`, remember:
+
+```
+pnpm build       # in app/, produces app/dist/
+cargo build --release --target x86_64-pc-windows-gnu \
+  -p houston-app --features tauri/custom-protocol
+```
+
+The binary will be ~3 MB larger than the dev-mode build because the
+frontend assets are now embedded.
+
+### `WebView2Loader.dll not found` after swapping `houston-app.exe`
+
+The shipping MSVC build statically links the WebView2 loader; the
+mingw cross-build dynamically loads `WebView2Loader.dll` at runtime.
+The MSI installer never drops a copy because the production binary
+doesn't need one. After your first `./win.sh deploy both` (or
+`deploy app`), the cross-built app shell will pop a "code execution
+cannot proceed because WebView2Loader.dll was not found" dialog.
+
+Fix once per install: `./win.sh setup-deps` fetches the
+Microsoft.Web.WebView2 NuGet package, extracts
+`runtimes/win-x64/native/WebView2Loader.dll`, and drops it next to
+the Houston install. The DLL persists across deploys.
+
+## Cross-compile decisions
+
+We use `x86_64-pc-windows-gnu` (mingw-w64) from Mac, not
+`x86_64-pc-windows-msvc`. Trade-offs:
+
+- **GNU pros**: no `xwin` / MSVC SDK headers needed; standard
+  mingw-w64 from Homebrew Just Works.
+- **GNU cons**: the GNU-linked binary has the `console` PE subsystem,
+  so launching `houston-engine.exe` pops a cmd window alongside
+  Houston. The shipping MSVC build doesn't because Tauri spawns it
+  with `CREATE_NO_WINDOW`. For dev this is a feature — you get live
+  engine stdout/stderr in the popup without disk I/O.
+- The GNU build is **not** bit-identical to the shipping MSVC build,
+  but it's close enough for iterating on Rust logic. Anything that
+  depends on MSVC-specific runtime behavior (rare) needs to be tested
+  via CI.
+
+On Windows 11 ARM64 hosts, the x64 binary runs under Microsoft's x64
+emulation layer. This is the same path real users on Snapdragon /
+Surface laptops hit, so it's a representative test surface — but see
+"Known ARM emulation gotchas" below.
+
+## Bugs the loop has surfaced (May 2026)
+
+Catalog of Windows-specific bugs discovered during the first
+end-to-end VM session. Each entry: symptom, where it was, what was
+done. Keep this list growing — it doubles as a Windows readiness
+checklist.
+
+### 1. `houston_dir()` ignored `USERPROFILE`
+
+`engine/houston-db/src/db.rs` used `std::env::var("HOME")` which is
+not set on Windows. Fallback was `"."` so Houston created a fresh
+`.houston/` in whatever directory the process happened to launch
+from — `C:\Program Files\Houston\` from Start menu,
+`C:\Windows\System32\` from an SSH-launched process,
+`C:\Users\<user>\Downloads\` from "double-click MSI in Downloads".
+Three (!) parallel data dirs were observed in one session. **Fixed**
+by switching to `dirs::home_dir()` at all four `HOME`-reading sites
+(`houston-db/src/db.rs`, `houston-engine-core/src/{worktree,provider}.rs`,
+`app/src-tauri/src/lib.rs`). `platform-matrix.md` already banned the
+pattern; the codebase had drifted.
+
+### 2. Engine stderr discarded on Windows
+
+`app/src-tauri/src/engine_supervisor.rs::spawn` set
+`stderr(Stdio::inherit())`. Tauri GUI builds on Windows have no
+attached console, so the engine's tracing output was discarded to
+NUL — invisible in bug reports, invisible in dev. **Fixed** by
+piping stderr and forwarding it to both the supervisor's tracing
+sink AND a `$HOUSTON_HOME/logs/engine.log.<date>` file. The on-disk
+capture is what `Report bug` ships back when an engine subprocess
+crashes.
+
+### 3. Bundled `composio.exe` crashes on Windows-on-ARM
+
+```
+[composio:cli] exit=exit code: 0xc000001d stdout=0B stderr=0B
+```
+
+`0xc000001d` = `STATUS_ILLEGAL_INSTRUCTION`. The x64 composio binary
+(gethouston/composio fork) uses CPU instructions not implemented by
+Windows-on-ARM's x64 emulator. Real ARM-laptop users will hit this.
+
+**Partial fix in this repo**: cryptic Windows NTSTATUS exits are now
+translated to human-actionable error messages by
+`houston-composio::cli::decorate_windows_exit` and the matching
+helper in `houston-engine-core::provider`. The dialog now shows
+"STATUS_ILLEGAL_INSTRUCTION (0xc000001d): the binary uses CPU
+instructions not supported by this CPU. On Windows-on-ARM laptops…"
+instead of `exit code: 0xc000001d`.
+
+**Runtime arch picker for ARM is now in place** (in this repo,
+`engine/houston-cli-bundle/src/lib.rs::host_arch_for_composio`):
+
+- Calls `IsWow64Process2` to detect when an x64 Houston process is
+  running under Windows-on-ARM's x64 emulator.
+- If detected AND `<bundle>/bin/composio-aarch64/` exists, returns
+  `"aarch64"` so the bundle resolver picks the native binary.
+- Falls back to `std::env::consts::ARCH` otherwise.
+
+**The fix is now in place end-to-end (May 2026)**:
+
+1. **Cross-compile from Mac**: `bun build --compile --target=bun-windows-arm64`
+   produces a 122 MB PE32+ AArch64 binary. Bun 1.3.10's compile
+   subsystem supports the target out of the box.
+2. **Patch in the fork**: Bun's windows-arm64 build ships without
+   TinyCC, so the fork's `cli-keyring` package called
+   `dlopen('advapi32.dll', …)` at module-eval time and crashed the
+   CLI before any command ran. Wrapped the dynamic import in
+   `createWindowsStore()` so an FFI unavailability downshifts to
+   `WindowsFfiUnavailableStore`, which fails every operation with
+   `NoStorageAccess`. The CLI's `ComposioUserContext` already had a
+   plaintext-fallback path keyed off `NoStorageAccess` — API keys
+   land in `~/.composio/user_data.json` instead of Windows Credential
+   Manager. Patch pinned at
+   `gethouston/composio@c17c8fb88` branch `houston-windows-arm64`.
+3. **CI manifest**: `cli-deps.json` now has a `composio.build.windows-arm64`
+   entry alongside `windows-x64`, both pinned by commit SHA + Bun
+   target + Bun version.
+4. **CI script**: `scripts/fetch-cli-deps.sh` now accepts
+   `windows-arm64` and `windows-both` modes. Production Windows MSI
+   should bundle both arches via `windows-both`.
+5. **Runtime arch picker**: `engine/houston-cli-bundle/src/lib.rs::host_arch_for_composio`
+   calls `IsWow64Process2` to detect x64-on-ARM emulation and prefers
+   the native `composio-aarch64/` dir when present.
+
+The fork patch needs to be pushed upstream to `gethouston/composio`
+(currently lives only in the local clone under
+`.context/composio-build/fork/` on the dev host that built this).
+Track this as a one-off cleanup before the next Windows release.
+
+### 4. Claude Code on Windows needs Git Bash, Houston didn't warn
+
+Claude Code CLI stderr (now captured in `engine.log` and surfaced
+to the dialog after fix #6):
+
+> Claude Code on Windows requires git-bash
+> (https://git-scm.com/downloads/win). If installed but not in PATH,
+> set environment variable pointing to your bash.exe, similar to:
+> `CLAUDE_CODE_GIT_BASH_PATH=C:\Program Files\Git\bin\bash.exe`
+
+Houston ships claude.exe but didn't bundle, detect, or warn about
+Git Bash. **Fixed** in `engine/houston-engine-core/src/provider.rs`:
+
+- `find_git_bash_windows()` probes `CLAUDE_CODE_GIT_BASH_PATH`
+  env override → `C:\Program Files\Git\bin\bash.exe` →
+  `C:\Program Files (x86)\Git\bin\bash.exe` → PATH search.
+- `launch_login` for Anthropic on Windows sets
+  `CLAUDE_CODE_GIT_BASH_PATH` to the found path automatically.
+- If nothing is found, login returns
+  `"Claude Code on Windows requires Git Bash. Install Git for
+  Windows from https://git-scm.com/downloads/win — Houston will
+  auto-detect it on next launch."` — the dialog shows this BEFORE
+  spawning claude.exe.
+
+User still has to install Git for Windows once. After that
+Houston Just Works without setting any env vars.
+
+### 5. Custom `composio.exe` install path is x64-only
+
+The bundle drops `composio.exe` at
+`C:\Program Files\Houston\bin\composio-x86_64\composio.exe`. The
+directory name hard-codes the arch. When the aarch64 build lands,
+the bundler in `cli-bundling.md` needs an `composio-aarch64/`
+companion dir + runtime arch picker.
+
+### 6. Provider login failures were silent
+
+`engine/houston-engine-core/src/provider.rs::launch_login` fired
+the CLI in `tokio::spawn` and returned `Ok(())` immediately. If the
+CLI crashed in milliseconds (missing dep, illegal instruction), the
+failure only went to logs — the frontend dialog showed "waiting"
+forever. Violated the no-silent-failures rule. **Fixed** by adding a
+3-second probe window: if the CLI exits in that span, the function
+returns a real error containing the CLI's stderr; if it's still
+running after 3s (real OAuth flow in progress), the supervisor
+detaches and proceeds as before.
+
+### 8. `activity.json` write fails with "system cannot find the file specified"
+
+Observed once in frontend.log:
+
+```
+[mission-title] keeping fallback title for ... |
+internal: failed to write .houston/activity/activity.json:
+io error: The system cannot find the file specified. (os error 2)
+```
+
+Likely cause: the agent_root path comes from the watcher carrying a
+`\\?\C:\...` extended-path prefix. `houston-agent-files::write_file_atomic`
+calls `create_dir_all` + `fs::rename`; both have spotty handling of
+`\\?\` paths in stable Rust on Windows. Repro needed before patching.
+
+**Follow-up**: normalize away `\\?\` prefix before passing agent_root
+into `write_file_atomic`, OR pass the prefix through consistently.
+Investigate when reproducible on next pass.
+
+### 9. Engine STATUS_CONTROL_C_EXIT still occurs once at startup
+
+Even with `CREATE_NEW_PROCESS_GROUP` set on the engine spawn (see
+`engine_supervisor.rs:107`), the engine subprocess still exits once
+during startup with `STATUS_CONTROL_C_EXIT` (0xC000013A). The
+supervisor restarts it cleanly within ~2 seconds and subsequent runs
+are stable. Cosmetic but worth root-causing: probably a startup-time
+console signal that the process-group flag doesn't fully shield
+against on Windows-on-ARM emulation.
+
+### 7. Tunnel allocation rate-limited
+
+```
+WARN tunnel allocation failed - running local-only
+HTTP 429 Too Many Requests from https://tunnel.gethouston.ai/allocate
+```
+
+Cascading failure from the engine-restart loop: each crash + restart
+called `/allocate` once, the relay's burst detector saw it as one
+client hammering and banned for the boot. **Mitigated** in
+`engine/houston-tunnel/src/identity.rs::ensure`:
+
+- On 429, wait for `Retry-After` header (capped at 30s) and retry
+  once. With the successful retry the identity is cached, so
+  subsequent restarts don't re-hit the endpoint.
+- Combined with fix #1 (HOME → stable cache dir), the cache now
+  actually persists across restarts on Windows.
+
+If the user still hits 429 after both retries, they see the
+existing `running local-only` warning and the engine continues
+without a tunnel (pairing disabled until next boot).
+
+### `houston_dir()` and any code path that reads `HOME`
+
+Banned by `platform-matrix.md`, but historically slipped in. Always
+use `dirs::home_dir()`. On Windows `std::env::var("HOME")` is `Err`
+and most legacy code falls back to `"."` → data writes land wherever
+the process's CWD happened to be (e.g. `C:\Windows\System32\`,
+`C:\Program Files\Houston\`, the user's Downloads folder — observed
+all three from a single Houston launch session). Audit before
+adding new env-driven paths.
+
+### `Get-Process houston-app` (not `houston`)
+
+The installed app is `houston-app.exe`. PowerShell's `Get-Process`
+drops the `.exe`, so the kill matcher is `houston-app` and
+`houston-engine`, not `Houston`.
+
+### `Start-Process` from an SSH session
+
+Windows OpenSSH runs sessions in non-interactive Session 0. GUI apps
+launched there don't appear on the logged-in user's Session 1
+desktop. `win.sh launch` exists but in practice manually
+double-clicking Houston from the Start menu inside the VM is the
+reliable path.
+
+## Finding logs
+
+If `houston_dir()` is correct: `%USERPROFILE%\.houston\logs\`. After
+fixing the HOME bug this is the only location.
+
+If running against a build that still has the HOME bug (older
+versions): logs land at `<CWD>\.houston\logs\`. To find them all:
+
+```powershell
+Get-ChildItem -Path C:\ -Recurse -Filter "backend.log*" -ErrorAction SilentlyContinue -Depth 5
+```
+
+Common CWD-derived locations historically observed:
+
+- `C:\Program Files\Houston\.houston\` (Start-menu launch)
+- `C:\Windows\System32\.houston\` (SSH-launched)
+- `C:\Users\<user>\Downloads\.houston\` (MSI-clicked-from-Downloads)
+
+## Engine stderr
+
+The Tauri parent inherits engine stderr (`Stdio::inherit()` in
+`engine_supervisor.rs::spawn`). On Windows the GUI subsystem app has
+no console attached, so inherited stderr writes to `NUL` and the
+engine's tracing output is lost. To capture it for crash diagnosis,
+pipe stderr to a file in `$HOUSTON_HOME/logs/engine.log`. This is
+fixed; see `engine_supervisor.rs::spawn` for the redirect.
+
+## Updating this doc
+
+When the loop changes — new helper subcommand, new gotcha
+discovered, new Windows version supported — update this doc the
+same day. The whole point is so the next session doesn't have to
+re-discover by trial.

--- a/scripts/fetch-cli-deps.sh
+++ b/scripts/fetch-cli-deps.sh
@@ -54,11 +54,14 @@
 #   ./scripts/fetch-cli-deps.sh arm64          # macOS arm64 only (dev)
 #   ./scripts/fetch-cli-deps.sh x64            # macOS x64 only (dev)
 #   ./scripts/fetch-cli-deps.sh windows-x64    # Windows x64 (production)
+#   ./scripts/fetch-cli-deps.sh windows-arm64  # Windows ARM64 (production)
+#   ./scripts/fetch-cli-deps.sh windows-both   # both Windows arches
 #   ./scripts/fetch-cli-deps.sh host           # auto-detect host OS + arch
 #
-# CI uses the no-arg form on macOS runners and `windows-x64` on Windows
-# runners. Local dev can use `host` to skip cross-arch slices the
-# developer doesn't need.
+# CI uses the no-arg form on macOS runners and `windows-both` on Windows
+# runners (the MSI ships both arches alongside each other and the
+# runtime picker chooses based on IsWow64Process2). Local dev can use
+# `host` to skip cross-arch slices the developer doesn't need.
 #
 # Strict mode: any download or checksum failure is fatal (set -euo pipefail).
 # Partial bundles are unacceptable — we'd ship a broken .app / .msi to
@@ -112,6 +115,8 @@ case "$MODE" in
   arm64)           TARGET_OS="darwin"; ARCHES=("arm64") ;;
   x64)             TARGET_OS="darwin"; ARCHES=("x64") ;;
   windows-x64)     TARGET_OS="windows"; ARCHES=("x64") ;;
+  windows-arm64)   TARGET_OS="windows"; ARCHES=("arm64") ;;
+  windows-both)    TARGET_OS="windows"; ARCHES=("x64" "arm64") ;;
   host)
     HOST_OS=$(detect_host_os)
     HOST_ARCH=$(detect_host_arch)
@@ -120,7 +125,7 @@ case "$MODE" in
       windows) TARGET_OS="windows"; ARCHES=("$HOST_ARCH") ;;
       *) echo "ERROR: host mode does not yet support $HOST_OS" >&2; exit 1 ;;
     esac ;;
-  *) echo "ERROR: unknown mode '$MODE' (expected: both|arm64|x64|windows-x64|host)" >&2; exit 1 ;;
+  *) echo "ERROR: unknown mode '$MODE' (expected: both|arm64|x64|windows-x64|windows-arm64|windows-both|host)" >&2; exit 1 ;;
 esac
 
 mkdir -p "$OUT_DIR"

--- a/scripts/fetch-cli-deps.sh
+++ b/scripts/fetch-cli-deps.sh
@@ -417,6 +417,49 @@ stage_codex_windows() {
   echo "  Installed: $out_path ($(du -sh "$out_path" | cut -f1))"
 }
 
+# Stage the Git for Windows PortableGit self-extracting 7z so Houston
+# can give Claude Code a working bash.exe without the user installing
+# Git separately. Layout: resources/bin/git-bash-{x86_64|aarch64}.7z.exe
+# — first-launch extraction into %LOCALAPPDATA% happens in
+# houston-engine-core::git_bash at runtime.
+stage_git_bash_windows() {
+  local arch="$1"
+  local platform="windows-$arch"
+  local version url_template expected url tmp out_path
+  version=$(jq -r '."git-bash".version' "$DEPS_FILE")
+  url_template=$(jq -r ".\"git-bash\".urls[\"$platform\"] // empty" "$DEPS_FILE")
+  expected=$(jq -r ".\"git-bash\".checksums[\"$platform\"] // empty" "$DEPS_FILE")
+
+  if [ -z "$url_template" ]; then
+    echo "ERROR: cli-deps.json missing git-bash URL for $platform" >&2
+    exit 1
+  fi
+
+  # Bun-style template substitution — keeps cli-deps.json terse.
+  url="${url_template//\{version\}/$version}"
+  echo "FETCH git-bash v$version ($platform PortableGit SFX)"
+  echo "  URL: $url"
+
+  local rust_arch
+  case "$arch" in
+    arm64) rust_arch="aarch64" ;;
+    x64)   rust_arch="x86_64" ;;
+    *)     echo "ERROR: unknown arch '$arch' for git-bash" >&2; exit 1 ;;
+  esac
+
+  tmp=$(mktemp)
+  download "$url" "$tmp" || { echo "ERROR: git-bash download failed for $platform" >&2; rm -f "$tmp"; exit 1; }
+  verify_or_print_checksum "$tmp" "$expected" "git-bash/$platform" || { rm -f "$tmp"; exit 1; }
+
+  # Bundle path matches the per-arch convention used by composio
+  # (composio-{x86_64,aarch64}/) so the runtime resolver can find both
+  # with the same arch-string derivation.
+  out_path="$OUT_DIR/git-bash-$rust_arch.7z.exe"
+  rm -f "$out_path"
+  mv "$tmp" "$out_path"
+  echo "  Installed: $out_path ($(du -sh "$out_path" | cut -f1))"
+}
+
 # Build composio for Windows from the Houston-maintained fork. Upstream
 # ComposioHQ/composio does not yet publish a Windows artifact — see the
 # `$build_comment` in cli-deps.json for the full reasoning. The build is
@@ -581,6 +624,7 @@ case "$TARGET_OS" in
     for arch in "${ARCHES[@]}"; do
       stage_codex_windows "$arch"
       build_composio_windows "$arch"
+      stage_git_bash_windows "$arch"
     done
     ;;
   *)


### PR DESCRIPTION
## Summary

End-to-end Windows-on-ARM support for Houston, surfaced through a real test session on a Windows 11 ARM UTM VM driven from a Mac via a new SSH dev loop. Three commits:

1. **fix(windows): seven Windows bug fixes + ARM-native Composio bundling** — every Windows bug surfaced during the live test, fixed at the root. See commit message for the full catalog. Headline: `houston_dir()` ignored `USERPROFILE` and dropped data in `C:\Program Files\` / `System32\` / `Downloads\`; engine stderr was discarded to NUL; the bundled x64 composio.exe crashed `STATUS_ILLEGAL_INSTRUCTION` on Windows-on-ARM; `launch_login` was fire-and-forget so claude.exe's "needs git-bash" stderr never reached the UI; cryptic Windows NTSTATUS exit codes weren't decoded.

2. **feat(windows): bundle PortableGit + auto-extract for Claude Code** — Houston now bundles PortableGit 2.54.0 (~57 MB per arch SFX) and extracts it once on first launch into `%LOCALAPPDATA%\Programs\Houston\runtime\git-bash-<arch>\`. Claude Code's bash requirement is invisible to the user. Same approach GitHub Desktop / Slack use.

3. **ci(windows): build x86_64 + aarch64 MSIs in parallel** — the release pipeline now ships separate MSIs per arch. Each matrix entry uses its own composio fork branch + PortableGit SFX. The `finalize` job merges both `.msi.sig` files into one `latest.json` with distinct `windows-x86_64` and `windows-aarch64` platform keys.

## How this was tested

Live-driven against a Windows 11 ARM UTM VM from a Mac dev host via a new `.context/win-dev/win.sh` helper (gitignored, per-machine). Loop:

```
./win.sh deploy        # cross-compile from Mac via mingw-w64, push via scp/ssh
./win.sh logs          # tail backend.log on the VM
./win.sh wipe          # nuke ~/.houston/ for a clean retest
```

End-to-end test confirmed working:
- `[composio-auth] startOAuth returned: url=https://dashboard.composio.dev/?cliKey=d9bf...`
- `[composio-auth] opening browser...` → `openUrl resolved OK`
- `[composio-auth] completeLogin resolved OK` → user finished OAuth in the browser

The IsWow64Process2-based arch picker correctly routed Houston to `composio-aarch64/composio.exe` on the ARM VM. The native ARM composio binary executed without the x64 emulator instruction-set mismatch that previously caused the `0xc000001d` crash.

## Companion fork PRs

- `gethouston/composio`: branch `houston-windows-arm64` already pushed (SHA `c17c8fb88`), opening a fork PR for review.
- `ComposioHQ/composio`: same patch, will open an upstream PR — the bun:ffi fallback isn't Houston-specific, every consumer of `@composio/cli-keyring` on Bun-windows-arm64 needs it.

## What's NOT in this PR

- SignPath code-signing — Windows MSIs ship unsigned for now (SmartScreen warning on first install). Tracked separately in `cli-bundling.md` under "Windows signing — deferred".
- A native ARM Windows test runner. The `windows-11-arm` GitHub-hosted runner is GA but its first use here will be on the next tag push.

## Test plan

- [ ] `gh workflow run release.yml` on a test tag, confirm both `build-windows` matrix entries succeed.
- [ ] Verify `latest.json` has both `windows-x86_64` and `windows-aarch64` keys after `finalize` runs.
- [ ] Install the x64 MSI on a regular Windows x64 box, sign in to Composio + Claude (after Git for Windows install isn't needed anymore — PortableGit extracts on first claude login).
- [ ] Install the arm64 MSI on a Windows-on-ARM box (Snapdragon laptop or UTM VM), repeat.
- [ ] Confirm `~/.houston/` is the canonical data dir after install (no `.houston` in Program Files / System32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)