### PR TITLE
feat(settings): consolidate into 3 sections, add Report bug

### DIFF
--- a/app/src-tauri/src/bug_report/linear.rs
+++ b/app/src-tauri/src/bug_report/linear.rs
@@ -36,7 +36,7 @@ pub(super) async fn send_bug_report_to(
     team_id: &str,
     label_name: &str,
     payload: &BugReportPayload,
-) -> Result<(), String> {
+) -> Result<Option<String>, String> {
     let client = reqwest::Client::new();
     let label_id = resolve_label_id(&client, api_url, api_key, team_id, label_name).await?;
 
@@ -69,7 +69,7 @@ pub(super) async fn send_bug_report_to(
         "Linear bug report created"
     );
 
-    Ok(())
+    Ok(issue.identifier)
 }
 
 async fn resolve_label_id(

--- a/app/src-tauri/src/bug_report/linear_tests.rs
+++ b/app/src-tauri/src/bug_report/linear_tests.rs
@@ -42,7 +42,7 @@ async fn send_bug_report_posts_linear_issue_create_mutation() {
         ),
     ]);
 
-    send_bug_report_to(
+    let identifier = send_bug_report_to(
         &url,
         "test-api-key",
         "team-id",
@@ -51,6 +51,7 @@ async fn send_bug_report_posts_linear_issue_create_mutation() {
     )
     .await
     .expect("send bug report");
+    assert_eq!(identifier.as_deref(), Some("BUG-1"));
 
     let requests = server.join().expect("join test server");
     let joined = requests.join("\n---REQUEST---\n");

--- a/app/src-tauri/src/bug_report/mod.rs
+++ b/app/src-tauri/src/bug_report/mod.rs
@@ -35,7 +35,7 @@ struct LinearBugReportConfig {
 }
 
 #[tauri::command(rename_all = "snake_case")]
-pub async fn report_bug(payload: BugReportPayload) -> Result<(), String> {
+pub async fn report_bug(payload: BugReportPayload) -> Result<Option<String>, String> {
     let config = bug_report_config()?;
 
     linear::send_bug_report_to(

--- a/app/src/components/settings/sections/report-bug.tsx
+++ b/app/src/components/settings/sections/report-bug.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@houston-ai/core";
+import { reportBug } from "../../../lib/bug-report";
+import { getCurrentUserEmail } from "../../../lib/current-user";
+import { useUIStore } from "../../../stores/ui";
+import { useWorkspaceStore } from "../../../stores/workspaces";
+
+export function ReportBugSection() {
+  const { t } = useTranslation("settings");
+  const addToast = useUIStore((s) => s.addToast);
+  const currentWorkspace = useWorkspaceStore((s) => s.current);
+  const [description, setDescription] = useState("");
+  const [sending, setSending] = useState(false);
+
+  const canSend = description.trim().length > 0 && !sending;
+
+  const handleSend = async () => {
+    const trimmed = description.trim();
+    if (!trimmed) return;
+    setSending(true);
+    try {
+      const issueId = await reportBug({
+        command: "manual_report",
+        error: trimmed,
+        workspaceName: currentWorkspace?.name,
+        userEmail: getCurrentUserEmail(),
+        timestamp: new Date().toISOString(),
+        appVersion: __APP_VERSION__,
+      });
+      setDescription("");
+      addToast({
+        title: t("reportBug.toasts.successTitle"),
+        description: issueId
+          ? t("reportBug.toasts.successBodyWithId", { id: issueId })
+          : t("reportBug.toasts.successBody"),
+        variant: "success",
+      });
+    } catch (e) {
+      addToast({
+        title: t("reportBug.toasts.errorTitle"),
+        description: e instanceof Error ? e.message : String(e),
+        variant: "error",
+      });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-1">{t("reportBug.title")}</h2>
+      <p className="text-sm text-muted-foreground mb-2">
+        {t("reportBug.intro")}
+      </p>
+      <p className="text-sm text-muted-foreground mb-2">
+        {t("reportBug.timingTip")}
+      </p>
+      <p className="text-sm text-muted-foreground mb-4">
+        {t("reportBug.toastEquivalence")}
+      </p>
+      <div>
+        <label className="text-xs text-muted-foreground block mb-1.5">
+          {t("reportBug.label")}
+        </label>
+        <textarea
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+          placeholder={t("reportBug.placeholder")}
+          rows={5}
+          className="w-full rounded-xl border border-border bg-card px-4 py-2.5 text-sm outline-none focus:ring-1 focus:ring-ring transition-all resize-y"
+        />
+      </div>
+      <div className="mt-4">
+        <Button
+          className="rounded-full"
+          disabled={!canSend}
+          onClick={handleSend}
+        >
+          {sending ? t("reportBug.sending") : t("reportBug.send")}
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/app/src/components/settings/settings-view.tsx
+++ b/app/src/components/settings/settings-view.tsx
@@ -1,16 +1,7 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Spinner } from "@houston-ai/core";
-import {
-  User,
-  Smartphone,
-  Folder,
-  Bot,
-  Clock,
-  Languages,
-  Palette,
-  Trash2,
-} from "lucide-react";
+import { User, Smartphone, Folder, Bot, Bug } from "lucide-react";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import {
   SidebarSectionNav,
@@ -19,13 +10,10 @@ import {
 
 type SettingsSectionId =
   | "account"
-  | "phone"
   | "workspace"
   | "provider"
-  | "timezone"
-  | "language"
-  | "appearance"
-  | "danger";
+  | "phone"
+  | "reportBug";
 import { AccountSection, useAccountAvailable } from "./sections/account";
 import { ConnectPhoneSection } from "./sections/connect-phone";
 import { WorkspaceSection } from "./sections/workspace";
@@ -34,6 +22,7 @@ import { TimezoneSection } from "./sections/timezone";
 import { LanguageSection } from "./sections/language";
 import { AppearanceSection } from "./sections/appearance";
 import { DangerSection } from "./sections/danger";
+import { ReportBugSection } from "./sections/report-bug";
 
 export function SettingsView() {
   const { t } = useTranslation(["settings", "common"]);
@@ -47,17 +36,9 @@ export function SettingsView() {
     }
     list.push(
       { id: "workspace", label: t("settings:nav.workspace"), icon: Folder },
-      { id: "phone", label: t("settings:nav.phone"), icon: Smartphone, beta: true },
       { id: "provider", label: t("settings:nav.provider"), icon: Bot },
-      { id: "timezone", label: t("settings:nav.timezone"), icon: Clock },
-      { id: "language", label: t("settings:nav.language"), icon: Languages },
-      { id: "appearance", label: t("settings:nav.appearance"), icon: Palette },
-      {
-        id: "danger",
-        label: t("settings:nav.danger"),
-        icon: Trash2,
-        destructive: true,
-      },
+      { id: "phone", label: t("settings:nav.phone"), icon: Smartphone, beta: true },
+      { id: "reportBug", label: t("settings:nav.reportBug"), icon: Bug },
     );
     return list;
   }, [accountAvailable, t]);
@@ -88,13 +69,18 @@ export function SettingsView() {
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto max-w-xl px-8 py-10">
           {activeVisible === "account" && <AccountSection />}
-          {activeVisible === "workspace" && <WorkspaceSection />}
-          {activeVisible === "phone" && <ConnectPhoneSection />}
+          {activeVisible === "workspace" && (
+            <div className="space-y-10">
+              <WorkspaceSection />
+              <LanguageSection />
+              <TimezoneSection />
+              <AppearanceSection />
+              <DangerSection />
+            </div>
+          )}
           {activeVisible === "provider" && <ProviderSection />}
-          {activeVisible === "timezone" && <TimezoneSection />}
-          {activeVisible === "language" && <LanguageSection />}
-          {activeVisible === "appearance" && <AppearanceSection />}
-          {activeVisible === "danger" && <DangerSection />}
+          {activeVisible === "phone" && <ConnectPhoneSection />}
+          {activeVisible === "reportBug" && <ReportBugSection />}
         </div>
       </div>
     </div>

--- a/app/src/lib/bug-report.ts
+++ b/app/src/lib/bug-report.ts
@@ -18,10 +18,12 @@ async function getRecentLogs(lines = 50): Promise<{ backend: string; frontend: s
   }
 }
 
-export async function reportBug(context: BugReportContext): Promise<void> {
+export async function reportBug(
+  context: BugReportContext,
+): Promise<string | null> {
   const logs = await getRecentLogs();
 
-  await osReportBug({
+  return await osReportBug({
     ...context,
     logs,
   });

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -30,10 +30,12 @@ export function showErrorToast(command: string, message: string): void {
           appVersion: __APP_VERSION__,
           userEmail: getCurrentUserEmail(),
         })
-          .then(() => {
+          .then((issueId) => {
             addToast({
               title: "Roger that, report received.",
-              description: "Mission control is on it, deploying a fix.",
+              description: issueId
+                ? `Mission control is on it, deploying a fix. Reference: ${issueId}`
+                : "Mission control is on it, deploying a fix.",
               variant: "success",
             });
           })

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -104,7 +104,8 @@ export function osReadRecentLogs(
   return invoke<{ backend: string; frontend: string }>("read_recent_logs", { lines });
 }
 
-/** Send a prepared bug report to Houston's native bug-report intake. */
-export function osReportBug(payload: unknown): Promise<void> {
-  return invoke<void>("report_bug", { payload });
+/** Send a prepared bug report to Houston's native bug-report intake.
+ * Resolves with the Linear issue identifier (e.g. "BUG-123") when known. */
+export function osReportBug(payload: unknown): Promise<string | null> {
+  return invoke<string | null>("report_bug", { payload });
 }

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -2,13 +2,10 @@
   "title": "Settings",
   "nav": {
     "account": "Account",
-    "phone": "Connect phone",
     "workspace": "Workspace",
     "provider": "AI provider",
-    "timezone": "Timezone",
-    "language": "Language",
-    "appearance": "Appearance",
-    "danger": "Danger zone"
+    "phone": "Connect phone",
+    "reportBug": "Report bug"
   },
   "account": {
     "title": "Account",
@@ -64,6 +61,22 @@
     "confirmTitle": "Delete \"{{name}}\"?",
     "confirmDescription": "This will permanently delete this workspace and all its agents. This cannot be undone.",
     "confirmLabel": "Delete"
+  },
+  "reportBug": {
+    "title": "Report bug",
+    "intro": "Tell us what went wrong. We'll send your message along with the logs from your last activity so we can see what happened.",
+    "timingTip": "We only get the most recent activity, so send the report as soon as the bug happens for the most useful info.",
+    "toastEquivalence": "This is the same as tapping Report bug on the red error notification, you don't need to send both.",
+    "label": "What happened?",
+    "placeholder": "Describe the bug. What were you doing, what did you expect, what happened instead?",
+    "send": "Send bug report",
+    "sending": "Sending…",
+    "toasts": {
+      "successTitle": "Roger that, report received.",
+      "successBody": "Mission control is on it, deploying a fix.",
+      "successBodyWithId": "Mission control is on it, deploying a fix. Reference: {{id}}",
+      "errorTitle": "Couldn't send report"
+    }
   },
   "toasts": {
     "workspaceRenamed": "Workspace renamed",

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -2,13 +2,10 @@
   "title": "Configuración",
   "nav": {
     "account": "Cuenta",
-    "phone": "Conectar celular",
     "workspace": "Espacio de trabajo",
     "provider": "Proveedor de IA",
-    "timezone": "Zona horaria",
-    "language": "Idioma",
-    "appearance": "Apariencia",
-    "danger": "Zona de peligro"
+    "phone": "Conectar celular",
+    "reportBug": "Reportar bug"
   },
   "account": {
     "title": "Cuenta",
@@ -64,6 +61,22 @@
     "confirmTitle": "¿Eliminar \"{{name}}\"?",
     "confirmDescription": "Esto eliminará de forma permanente este espacio de trabajo y todos sus agentes. No se puede deshacer.",
     "confirmLabel": "Eliminar"
+  },
+  "reportBug": {
+    "title": "Reportar bug",
+    "intro": "Cuéntanos qué salió mal. Enviaremos tu mensaje junto con los registros de tu última actividad para ver qué pasó.",
+    "timingTip": "Solo recibimos la actividad más reciente, así que envía el reporte apenas ocurra el bug para que la información sea útil.",
+    "toastEquivalence": "Esto es lo mismo que tocar Reportar bug en la notificación roja de error, no necesitas enviar las dos.",
+    "label": "¿Qué pasó?",
+    "placeholder": "Describe el bug. ¿Qué estabas haciendo, qué esperabas y qué pasó en realidad?",
+    "send": "Enviar reporte",
+    "sending": "Enviando…",
+    "toasts": {
+      "successTitle": "Recibido, reporte registrado.",
+      "successBody": "El centro de control ya está trabajando en la solución.",
+      "successBodyWithId": "El centro de control ya está trabajando en la solución. Referencia: {{id}}",
+      "errorTitle": "No se pudo enviar el reporte"
+    }
   },
   "toasts": {
     "workspaceRenamed": "Espacio de trabajo renombrado",

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -2,13 +2,10 @@
   "title": "Configurações",
   "nav": {
     "account": "Conta",
-    "phone": "Conectar celular",
     "workspace": "Espaço de trabalho",
     "provider": "Provedor de IA",
-    "timezone": "Fuso horário",
-    "language": "Idioma",
-    "appearance": "Aparência",
-    "danger": "Zona de perigo"
+    "phone": "Conectar celular",
+    "reportBug": "Reportar bug"
   },
   "account": {
     "title": "Conta",
@@ -64,6 +61,22 @@
     "confirmTitle": "Excluir \"{{name}}\"?",
     "confirmDescription": "Isso exclui este espaço de trabalho e todos os seus agentes de forma permanente. Não dá para desfazer.",
     "confirmLabel": "Excluir"
+  },
+  "reportBug": {
+    "title": "Reportar bug",
+    "intro": "Conte para a gente o que deu errado. Vamos enviar sua mensagem junto com os logs da sua última atividade para entender o que aconteceu.",
+    "timingTip": "A gente só recebe a atividade mais recente, então envie o reporte assim que o bug acontecer para a informação ser mais útil.",
+    "toastEquivalence": "Isso é a mesma coisa que tocar em Reportar bug na notificação vermelha de erro, você não precisa enviar os dois.",
+    "label": "O que aconteceu?",
+    "placeholder": "Descreva o bug. O que você estava fazendo, o que esperava e o que aconteceu na verdade?",
+    "send": "Enviar reporte",
+    "sending": "Enviando…",
+    "toasts": {
+      "successTitle": "Recebido, reporte registrado.",
+      "successBody": "O centro de controle já está trabalhando na correção.",
+      "successBodyWithId": "O centro de controle já está trabalhando na correção. Referência: {{id}}",
+      "errorTitle": "Não foi possível enviar o reporte"
+    }
   },
   "toasts": {
     "workspaceRenamed": "Espaço de trabalho renomeado",


### PR DESCRIPTION
## Summary
- Sidebar now collapses to **Workspace / AI provider / Connect phone**. The Workspace page stacks Workspace name, Language, Timezone, Theme, and the Danger zone in that order.
- New fourth entry **Report bug** with a description textarea. Submits via the same Linear pipeline used by the red error toast (`reportBug()` → Tauri `report_bug` → Linear `issueCreate`), so users only need to send one report per incident.
- Both the manual Report bug toast and the red error-toast button now surface the Linear issue identifier (e.g. \`BUG-123\`) so users can reference it in support DMs.

## Test plan
- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm check-locales\` in sync (en / es / pt)
- [x] \`cargo test bug_report\` — 10 passed, including new identifier assertion
- [ ] Open Settings → Workspace, verify the 5 stacked sub-sections render and danger zone still works
- [ ] Open Settings → Report bug, submit a description, verify the success toast shows the \`BUG-…\` reference (requires \`LINEAR_API_KEY\` + \`LINEAR_TEAM_ID\` in \`app/src-tauri/.env\` for local dev)
- [ ] Trigger any red error toast, tap Report bug, verify the success toast also includes the reference