### PR TITLE
fix(codex): bundle latest CLI, override broken global config, surface progress

### DIFF
--- a/app/src/components/onboarding/missions/try.tsx
+++ b/app/src/components/onboarding/missions/try.tsx
@@ -178,6 +178,11 @@ export function TryMission({
   // Free-typing path. Wrapped by `useSessionMessageQueue` so messages typed
   // while the agent is mid-stream get queued instead of dropped — same
   // behavior as the workspace chat tab.
+  //
+  // Force `effort: "medium"` for both providers. Without it, Codex inherits
+  // whatever sits in `~/.codex/config.toml`, and newer Codex builds happily
+  // write `model_reasoning_effort = "xhigh"` — which the bundled Codex CLI
+  // rejects, killing the tutorial with "A local tool failed to start".
   const sendNow = useCallback(
     async (text: string, _files: File[]) => {
       const trimmed = text.trim();
@@ -190,6 +195,7 @@ export function TryMission({
         await tauriChat.send(agentPath, trimmed, missionSessionKey, {
           providerOverride: provider,
           modelOverride: model,
+          effortOverride: "medium",
         });
       } catch (e) {
         setError(e instanceof Error ? e.message : String(e));
@@ -243,6 +249,7 @@ export function TryMission({
             title: chipLabel,
             providerOverride: provider,
             modelOverride: model,
+            effortOverride: "medium",
           },
         );
         setMissionSessionKey(result.sessionKey);

--- a/app/src/lib/create-mission.ts
+++ b/app/src/lib/create-mission.ts
@@ -68,6 +68,8 @@ export interface CreateMissionOptions {
   providerOverride?: string;
   /** Model override forwarded to tauriChat.send. */
   modelOverride?: string;
+  /** Reasoning-effort override forwarded to tauriChat.send. */
+  effortOverride?: string;
   /**
    * Explicit activity title. Overrides the default `autoTitleFromText(text)`.
    * Used by action invocations where `text` is a structured marker that
@@ -123,6 +125,7 @@ export async function createMission(
       workingDirOverride: opts.worktreePath,
       providerOverride: opts.providerOverride,
       modelOverride: opts.modelOverride,
+      effortOverride: opts.effortOverride,
     });
 
     if (!opts.title) {

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -158,6 +158,7 @@ export const tauriChat = {
       workingDirOverride?: string;
       providerOverride?: string;
       modelOverride?: string;
+      effortOverride?: string;
     },
   ) =>
     call<string>("send_message", async () => {
@@ -168,6 +169,7 @@ export const tauriChat = {
         workingDir: opts?.workingDirOverride,
         provider: opts?.providerOverride,
         model: opts?.modelOverride,
+        effort: opts?.effortOverride,
       });
       return res.sessionKey;
     }),

--- a/cli-deps.json
+++ b/cli-deps.json
@@ -23,7 +23,7 @@
     }
   },
   "codex": {
-    "version": "0.121.0",
+    "version": "0.130.0",
     "bundled": true,
     "binary_name": "codex",
     "license": "Apache-2.0",
@@ -36,10 +36,10 @@
       "windows-arm64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-aarch64-pc-windows-msvc.exe.zst"
     },
     "checksums": {
-      "darwin-arm64": "60f7039e63a7de8ae474136ac6f593ec1a913e1ddca0df59ade1f6d6eb5f7fd0",
-      "darwin-x64": "94e6ba8a552d4625beee857f513fb12bc20e560b9427c4a93733dbd86619f415",
-      "windows-x64": "92c0938d13e9e06e2844be1e50bfa2d246e295185aabe055a92d42fcdeb0b26d",
-      "windows-arm64": "cb1978aa318bd9180a8896bbfadc05b7581c752677df9ab6eb1f1903754fed20"
+      "darwin-arm64": "bc50a4b7f9a0c8ca99179189e4659b601107830770e21547dc0c246bce733577",
+      "darwin-x64": "feddb116bd96d7d83f8bb19b34fbabe6843cc64461baf2e49c017e1206ad5e67",
+      "windows-x64": "b941e5d2f3d59ef38d7b31885be1596566640f1c3b6c5d086bfdeade6c8ff9cd",
+      "windows-arm64": "087f12e44d6da8a6378e39e1448470db6b40836c9775f704de95cd9c84bfce0f"
     }
   },
   "composio": {

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -77,6 +77,7 @@ pub fn spawn_and_monitor(
     pid_map: Option<SessionPidMap>,
     provider: Provider,
     model: Option<String>,
+    effort: Option<String>,
 ) -> tokio::task::JoinHandle<SessionResult> {
     // Ensure the user's shell PATH is resolved before spawning.
     // OnceLock inside init() makes this a no-op after the first call.
@@ -91,7 +92,7 @@ pub fn spawn_and_monitor(
         resume_id,
         Some(working_dir),
         model,
-        None, // effort
+        effort,
         system_prompt,
         None,  // mcp_config
         false, // disable_builtin_tools

--- a/engine/houston-cli-bundle/src/lib.rs
+++ b/engine/houston-cli-bundle/src/lib.rs
@@ -92,6 +92,9 @@ pub fn bundled_bin_dir_for(exe: &Path) -> Option<PathBuf> {
     if let Some(dir) = sibling_bin_dir(exe) {
         return Some(dir);
     }
+    if let Some(dir) = dev_workspace_bin_dir(exe) {
+        return Some(dir);
+    }
     None
 }
 
@@ -349,6 +352,53 @@ fn sibling_bin_dir(exe: &Path) -> Option<PathBuf> {
     bin.is_dir().then_some(bin)
 }
 
+/// Dev fallback: when the engine is running from `<workspace>/target/{debug,
+/// release}/houston-engine` (i.e. `pnpm tauri dev` or `cargo run`), the
+/// bundled CLIs aren't staged next to the binary. Instead they live in
+/// `<workspace>/app/src-tauri/resources/bin/` after the user runs
+/// `./scripts/fetch-cli-deps.sh host`. Resolve that layout so dev sessions
+/// can use the pinned, version-controlled CLI (instead of whatever happens
+/// to be on the user's PATH, which is how we ended up serving an ancient
+/// `codex` from `nvm` to the tutorial).
+fn dev_workspace_bin_dir(exe: &Path) -> Option<PathBuf> {
+    // Only the real engine sidecar should trigger the dev fallback —
+    // otherwise `cargo test` binaries living at `target/debug/deps/<hash>`
+    // would also resolve to the staged bundle, and tests that assume "no
+    // bundled CLIs are visible in dev" (e.g. composio's not-installed
+    // smoke test) start failing whenever a developer has run
+    // `./scripts/fetch-cli-deps.sh`. Restricting to the canonical engine
+    // binary name keeps test isolation intact while still serving real
+    // `pnpm tauri dev` / `cargo run -p houston-engine-server` invocations.
+    let file_name = exe.file_name().and_then(|n| n.to_str())?;
+    let expected = if cfg!(windows) {
+        "houston-engine.exe"
+    } else {
+        "houston-engine"
+    };
+    if file_name != expected {
+        return None;
+    }
+    // The engine sits directly under `target/{debug,release}/`. Walk up two
+    // levels (engine → profile → target → workspace) and check that the
+    // shape matches before consulting the filesystem.
+    let profile_dir = exe.parent()?;
+    let profile = profile_dir.file_name().and_then(|n| n.to_str())?;
+    if profile != "debug" && profile != "release" {
+        return None;
+    }
+    let target_dir = profile_dir.parent()?;
+    if target_dir.file_name().and_then(|n| n.to_str()) != Some("target") {
+        return None;
+    }
+    let workspace = target_dir.parent()?;
+    let bin = workspace
+        .join("app")
+        .join("src-tauri")
+        .join("resources")
+        .join(BIN_SUBDIR);
+    bin.is_dir().then_some(bin)
+}
+
 fn codex_binary_name() -> &'static str {
     if cfg!(windows) {
         "codex.exe"
@@ -540,6 +590,69 @@ mod tests {
         let bin = exe_dir.join("resources").join(BIN_SUBDIR);
         fs::create_dir_all(&bin).unwrap();
         assert_eq!(bundled_bin_dir_for(&exe), Some(bin));
+    }
+
+    #[test]
+    fn detects_dev_workspace_layout() {
+        // Dev: engine spawned from `<workspace>/target/{debug,release}/`.
+        // The staged bin dir lives at `<workspace>/app/src-tauri/resources/bin/`.
+        let tmp = tempfile::tempdir().unwrap();
+        let workspace = tmp.path();
+        let target_debug = workspace.join("target").join("debug");
+        fs::create_dir_all(&target_debug).unwrap();
+        let engine_name = if cfg!(windows) {
+            "houston-engine.exe"
+        } else {
+            "houston-engine"
+        };
+        let exe = target_debug.join(engine_name);
+        fs::write(&exe, b"").unwrap();
+        let bin = workspace
+            .join("app")
+            .join("src-tauri")
+            .join("resources")
+            .join(BIN_SUBDIR);
+        fs::create_dir_all(&bin).unwrap();
+        assert_eq!(bundled_bin_dir_for(&exe), Some(bin));
+    }
+
+    #[test]
+    fn dev_workspace_layout_skips_when_unstaged() {
+        // If the user hasn't run `./scripts/fetch-cli-deps.sh`, the
+        // resources/bin dir doesn't exist and the resolver must fall through
+        // to None — not return a stale-looking phantom path.
+        let tmp = tempfile::tempdir().unwrap();
+        let target_release = tmp.path().join("target").join("release");
+        fs::create_dir_all(&target_release).unwrap();
+        let engine_name = if cfg!(windows) {
+            "houston-engine.exe"
+        } else {
+            "houston-engine"
+        };
+        let exe = target_release.join(engine_name);
+        fs::write(&exe, b"").unwrap();
+        assert_eq!(bundled_bin_dir_for(&exe), None);
+    }
+
+    #[test]
+    fn dev_workspace_layout_skips_for_cargo_test_binaries() {
+        // Cargo test binaries live at `target/debug/deps/<name>-<hash>` and
+        // must NOT trigger the dev bundle resolver — otherwise tests that
+        // assume an empty install state start using the developer's staged
+        // CLIs and fail in confusing ways.
+        let tmp = tempfile::tempdir().unwrap();
+        let deps_dir = tmp.path().join("target").join("debug").join("deps");
+        fs::create_dir_all(&deps_dir).unwrap();
+        let bin = tmp
+            .path()
+            .join("app")
+            .join("src-tauri")
+            .join("resources")
+            .join(BIN_SUBDIR);
+        fs::create_dir_all(&bin).unwrap();
+        let test_bin = deps_dir.join("composio-abc123");
+        fs::write(&test_bin, b"").unwrap();
+        assert_eq!(bundled_bin_dir_for(&test_bin), None);
     }
 
     #[test]

--- a/engine/houston-composio/src/install.rs
+++ b/engine/houston-composio/src/install.rs
@@ -243,7 +243,9 @@ mod tests {
     #[test]
     fn cli_path_falls_back_to_standalone_in_dev() {
         // Tests run inside cargo's target dir, never inside an `.app`
-        // bundle — so the fallback should always be standalone here.
+        // bundle — so the fallback should always be standalone here. The
+        // dev-workspace resolver added in houston-cli-bundle is gated on
+        // the engine binary name, so cargo test binaries don't trigger it.
         let p = cli_path();
         assert!(p.ends_with(".composio/composio") || p.ends_with(".composio/composio.exe"));
     }

--- a/engine/houston-engine-core/src/routines/engine_dispatcher.rs
+++ b/engine/houston-engine-core/src/routines/engine_dispatcher.rs
@@ -96,6 +96,7 @@ impl RoutineDispatcher for EngineRoutineDispatcher {
             Some(self.rt.pid_map.clone()),
             resolved.provider,
             resolved.model,
+            None,
         );
 
         match join_handle.await {

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -92,6 +92,12 @@ pub struct StartParams {
     /// [`resolve_provider`] first).
     pub provider: Provider,
     pub model: Option<String>,
+    /// Reasoning effort override. For Codex, this becomes
+    /// `-c model_reasoning_effort=<value>` (also overrides whatever the user
+    /// has in their global `~/.codex/config.toml`). For Claude, it becomes
+    /// `--effort <value>`. Accepted values vary per provider; the caller is
+    /// responsible for passing something each CLI understands (e.g. "medium").
+    pub effort: Option<String>,
 }
 
 /// Start a session turn. The request is accepted immediately. Turns with the
@@ -160,6 +166,7 @@ async fn run_start(
         source,
         provider,
         model,
+        effort,
     } = params;
 
     if !agent_dir.exists() {
@@ -270,6 +277,7 @@ async fn run_start(
         Some(rt.pid_map.clone()),
         provider,
         model,
+        effort,
     );
 
     // Own the end-of-session activity flip engine-side. Before this, the
@@ -506,6 +514,7 @@ pub async fn start_onboarding(
             source: Some("desktop".into()),
             provider: resolved.provider,
             model: resolved.model,
+            effort: None,
         },
     )
     .await
@@ -572,6 +581,7 @@ mod tests {
                     source: Some("test".to_string()),
                     provider: Provider::OpenAI,
                     model: None,
+                    effort: None,
                 },
             ),
         )

--- a/engine/houston-engine-core/src/sessions/summarize.rs
+++ b/engine/houston-engine-core/src/sessions/summarize.rs
@@ -83,12 +83,23 @@ async fn run_claude_summary(prompt: &str, model: Option<&str>) -> Result<String,
 }
 
 async fn run_codex_summary(prompt: &str, model: Option<&str>) -> Result<String, String> {
-    let mut cmd = tokio::process::Command::new("codex");
+    // Prefer the bundled codex (pinned in `cli-deps.json`) so the title
+    // summarizer can't get sabotaged by a stale `nvm`/`brew` codex on the
+    // user's PATH that doesn't recognize the model we picked.
+    let bin = houston_cli_bundle::bundled_codex_path()
+        .unwrap_or_else(|| std::path::PathBuf::from("codex"));
+    let mut cmd = tokio::process::Command::new(&bin);
     cmd.env("PATH", claude_path::shell_path());
     cmd.arg("exec")
         .arg("--json")
         .arg("--dangerously-bypass-approvals-and-sandbox")
         .arg("--skip-git-repo-check")
+        // Override `model_reasoning_effort` so a stale global
+        // `~/.codex/config.toml` (newer Codex CLIs allow `xhigh`, older ones
+        // reject it) can't kill title generation. We don't need much thought
+        // here — it's a 6-word title.
+        .arg("-c")
+        .arg("model_reasoning_effort=\"low\"")
         .arg("--model")
         .arg(model.unwrap_or(CODEX_TITLE_MODEL))
         .arg("-");

--- a/engine/houston-engine-server/src/routes/sessions.rs
+++ b/engine/houston-engine-server/src/routes/sessions.rs
@@ -72,6 +72,12 @@ pub struct StartRequest {
     /// Model override. Wins over any resolved default.
     #[serde(default)]
     pub model: Option<String>,
+    /// Reasoning effort override. Forwarded to the CLI as `--effort` (Claude)
+    /// or `-c model_reasoning_effort=<value>` (Codex). Used by the onboarding
+    /// tutorial to force a known-good value regardless of what the user has
+    /// in `~/.codex/config.toml`.
+    #[serde(default)]
+    pub effort: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -105,6 +111,7 @@ async fn start_session(
         source: req.source,
         provider,
         model,
+        effort: req.effort,
     };
 
     let rt = SessionRuntime::clone(&st.engine.sessions);

--- a/engine/houston-terminal-manager/src/codex_command.rs
+++ b/engine/houston-terminal-manager/src/codex_command.rs
@@ -8,6 +8,7 @@ pub(crate) fn build_args(
     resume_session_id: Option<&str>,
     working_dir: Option<&Path>,
     model: Option<&str>,
+    effort: Option<&str>,
     system_prompt: Option<&str>,
 ) -> Vec<OsString> {
     let mut args = vec![
@@ -21,6 +22,13 @@ pub(crate) fn build_args(
         let json_val = serde_json::to_string(sp).unwrap_or_else(|_| format!("\"{sp}\""));
         args.push(OsString::from("-c"));
         args.push(OsString::from(format!("developer_instructions={json_val}")));
+    }
+
+    // Override `model_reasoning_effort` so a global `~/.codex/config.toml`
+    // value (newer Codex CLIs allow `xhigh`, bundled doesn't) can't break us.
+    if let Some(e) = effort {
+        args.push(OsString::from("-c"));
+        args.push(OsString::from(format!("model_reasoning_effort=\"{e}\"")));
     }
 
     if let Some(m) = model {
@@ -67,6 +75,7 @@ mod tests {
             Some("019dd59b-5e8c-7f63-a8c6-18fb825874ad"),
             Some(&dir),
             Some("gpt-5.5"),
+            Some("medium"),
             Some("system"),
         ));
 
@@ -82,10 +91,21 @@ mod tests {
 
     #[test]
     fn fresh_args_read_prompt_from_stdin() {
-        let args = strings(build_args(None, None, None, None));
+        let args = strings(build_args(None, None, None, None, None));
 
         assert_eq!(args.last().map(String::as_str), Some("-"));
         assert!(!args.iter().any(|arg| arg == "resume"));
+    }
+
+    #[test]
+    fn effort_emits_model_reasoning_effort_override() {
+        let args = strings(build_args(None, None, None, Some("medium"), None));
+        let pos = args
+            .iter()
+            .position(|arg| arg == "model_reasoning_effort=\"medium\"")
+            .expect("effort override should be present");
+        // Override must arrive as a `-c key=value` pair.
+        assert_eq!(args[pos - 1], "-c");
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/codex_parser.rs
+++ b/engine/houston-terminal-manager/src/codex_parser.rs
@@ -74,6 +74,17 @@ pub struct CodexError {
 pub struct CodexAccumulator {
     text_buffer: String,
     thinking_buffer: String,
+    /// True between `turn.started` and the first event that takes over the
+    /// reasoning slot (real reasoning item, agent_message, command_execution,
+    /// etc.). Codex 0.130's `--json` output emits NO events during the
+    /// 5-10 seconds the model spends reasoning, so we seed an empty
+    /// `ThinkingStreaming` placeholder on `turn.started` to give the UI a
+    /// signal to render "Mission in progress…" immediately. When any
+    /// content-bearing event arrives — or when the turn completes without
+    /// any reasoning — we emit a final `Thinking("")` so the reasoning
+    /// block transitions out of its streaming state and doesn't strand a
+    /// permanent shimmer in the chat.
+    thinking_placeholder_open: bool,
 }
 
 impl CodexAccumulator {
@@ -108,11 +119,29 @@ pub fn parse_codex_event(line: &str, acc: &mut CodexAccumulator) -> Vec<FeedItem
     };
 
     match event.event_type.as_str() {
-        "thread.started" | "turn.started" => vec![],
+        "thread.started" => vec![],
 
-        "item.started" | "item.updated" => parse_item_streaming(&event, acc),
+        // Seed an empty streaming-thinking placeholder so the chat panel
+        // can render "Mission in progress…" without waiting 5-10 seconds
+        // for the first real `item.*` event. Codex 0.130's `--json` mode
+        // does not stream reasoning, so without this the UI looks frozen
+        // after the user hits send.
+        "turn.started" => {
+            acc.thinking_placeholder_open = true;
+            vec![FeedItem::ThinkingStreaming(String::new())]
+        }
 
-        "item.completed" => parse_item_completed(&event, acc),
+        "item.started" | "item.updated" => {
+            let mut items = close_thinking_placeholder_if_open(acc, &event);
+            items.extend(parse_item_streaming(&event, acc));
+            items
+        }
+
+        "item.completed" => {
+            let mut items = close_thinking_placeholder_if_open(acc, &event);
+            items.extend(parse_item_completed(&event, acc));
+            items
+        }
 
         "turn.completed" => {
             let mut items = vec![];
@@ -124,7 +153,13 @@ pub fn parse_codex_event(line: &str, acc: &mut CodexAccumulator) -> Vec<FeedItem
             }
             if !acc.thinking_buffer.is_empty() {
                 items.push(FeedItem::Thinking(std::mem::take(&mut acc.thinking_buffer)));
+            } else if acc.thinking_placeholder_open {
+                // The turn finished without codex ever emitting a reasoning
+                // item. Finalize the placeholder so the chat UI exits its
+                // streaming state instead of leaving a permanent shimmer.
+                items.push(FeedItem::Thinking(String::new()));
             }
+            acc.thinking_placeholder_open = false;
             // Emit usage as FinalResult
             if let Some(usage) = &event.usage {
                 let total = usage.input_tokens.unwrap_or(0) + usage.output_tokens.unwrap_or(0);
@@ -140,24 +175,63 @@ pub fn parse_codex_event(line: &str, acc: &mut CodexAccumulator) -> Vec<FeedItem
         "turn.failed" | "error" => {
             let msg = event
                 .message
-                .or_else(|| event.error.and_then(|e| e.message))
+                .clone()
+                .or_else(|| event.error.clone().and_then(|e| e.message))
                 .unwrap_or_else(|| "Unknown error".into());
             tracing::info!("[codex] error/turn.failed: {msg}");
+            // Close any pending reasoning placeholder so the UI doesn't
+            // strand a shimmer next to the error message.
+            let mut items = vec![];
+            if acc.thinking_placeholder_open {
+                acc.thinking_placeholder_open = false;
+                items.push(FeedItem::Thinking(std::mem::take(&mut acc.thinking_buffer)));
+            }
             // Auth retry noise (e.g. "Reconnecting... 1/5 (unexpected status 401 Unauthorized...)")
             // Show a single friendly "Checking connection..." instead of raw retries.
             if is_auth_retry_noise(&msg) {
                 tracing::info!("[codex] auth retry detected — suppressing raw error");
                 // Return a marker so session_runner can track it, but don't show raw noise.
-                vec![FeedItem::SystemMessage(AUTH_RETRY_MARKER.to_string())]
+                items.push(FeedItem::SystemMessage(AUTH_RETRY_MARKER.to_string()));
             } else {
-                vec![FeedItem::SystemMessage(format!("Error: {msg}"))]
+                items.push(FeedItem::SystemMessage(format!("Error: {msg}")));
             }
+            items
         }
 
         _ => {
             tracing::debug!("[codex] unhandled event type: {}", event.event_type);
             vec![]
         }
+    }
+}
+
+/// If a `turn.started` placeholder is open and the next item is NOT a
+/// reasoning item (which would naturally take over the buffer), emit a
+/// finalizing `Thinking("")` so the chat UI's reasoning block exits its
+/// streaming state. Returns the events to prepend in front of whatever the
+/// real `item.*` handler emits.
+fn close_thinking_placeholder_if_open(
+    acc: &mut CodexAccumulator,
+    event: &CodexEvent,
+) -> Vec<FeedItem> {
+    if !acc.thinking_placeholder_open {
+        return vec![];
+    }
+    // Real reasoning items take over the buffer naturally — let the existing
+    // parser logic populate it instead of pre-finalizing with "".
+    let is_reasoning = event
+        .item
+        .as_ref()
+        .map(|i| i.item_type == "reasoning")
+        .unwrap_or(false);
+    if is_reasoning {
+        return vec![];
+    }
+    acc.thinking_placeholder_open = false;
+    if acc.thinking_buffer.is_empty() {
+        vec![FeedItem::Thinking(String::new())]
+    } else {
+        vec![FeedItem::Thinking(std::mem::take(&mut acc.thinking_buffer))]
     }
 }
 
@@ -321,6 +395,64 @@ mod tests {
 
     fn acc() -> CodexAccumulator {
         CodexAccumulator::new()
+    }
+
+    #[test]
+    fn turn_started_emits_empty_thinking_placeholder() {
+        // Codex 0.130 stays silent between `turn.started` and the first
+        // real item for several seconds. The parser must surface a
+        // `ThinkingStreaming("")` so the chat UI can render
+        // "Mission in progress…" without waiting on the model.
+        let mut a = acc();
+        let items = parse_codex_event(r#"{"type":"turn.started"}"#, &mut a);
+        assert_eq!(items.len(), 1);
+        assert!(matches!(&items[0], FeedItem::ThinkingStreaming(t) if t.is_empty()));
+    }
+
+    #[test]
+    fn first_non_reasoning_item_finalizes_placeholder() {
+        // When the model returns text without any reasoning items, the
+        // placeholder must be finalized as `Thinking("")` so the chat
+        // reasoning block exits its streaming state. The finalizer is
+        // emitted BEFORE the real item, so the UI sees a complete
+        // reasoning block followed by the assistant text.
+        let mut a = acc();
+        let _ = parse_codex_event(r#"{"type":"turn.started"}"#, &mut a);
+        let items = parse_codex_event(
+            r#"{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"Hi"}}"#,
+            &mut a,
+        );
+        assert_eq!(items.len(), 2);
+        assert!(matches!(&items[0], FeedItem::Thinking(t) if t.is_empty()));
+        assert!(matches!(&items[1], FeedItem::AssistantText(t) if t == "Hi"));
+    }
+
+    #[test]
+    fn real_reasoning_takes_over_placeholder() {
+        // If codex does emit a reasoning item (older protocol / fallback),
+        // the parser must NOT pre-finalize with `Thinking("")` — the real
+        // reasoning content owns the buffer instead.
+        let mut a = acc();
+        let _ = parse_codex_event(r#"{"type":"turn.started"}"#, &mut a);
+        let items = parse_codex_event(
+            r#"{"type":"item.updated","item":{"id":"item_0","type":"reasoning","text":"Let me think"}}"#,
+            &mut a,
+        );
+        assert_eq!(items.len(), 1);
+        assert!(matches!(&items[0], FeedItem::ThinkingStreaming(t) if t == "Let me think"));
+    }
+
+    #[test]
+    fn turn_completed_without_items_finalizes_placeholder() {
+        // Edge case: turn ends with no items at all (e.g. cancelled before
+        // any output). Placeholder must still be closed out.
+        let mut a = acc();
+        let _ = parse_codex_event(r#"{"type":"turn.started"}"#, &mut a);
+        let items = parse_codex_event(r#"{"type":"turn.completed"}"#, &mut a);
+        assert!(
+            items.iter().any(|i| matches!(i, FeedItem::Thinking(t) if t.is_empty())),
+            "expected an empty Thinking() to close the placeholder, got {items:?}"
+        );
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/manager.rs
+++ b/engine/houston-terminal-manager/src/manager.rs
@@ -61,6 +61,7 @@ impl SessionManager {
                         resume_session_id,
                         working_dir,
                         model,
+                        effort,
                         system_prompt,
                     )
                     .await;
@@ -73,6 +74,14 @@ impl SessionManager {
     }
 }
 
+/// Default `model_reasoning_effort` used for Codex when the caller doesn't pass
+/// one explicitly. Always emitted as `-c model_reasoning_effort="<value>"` so
+/// the user's global `~/.codex/config.toml` can never break a Codex session.
+/// Newer Codex CLIs allow values (e.g. `xhigh`) that the bundled CLI rejects;
+/// forcing an override on every spawn keeps Houston resilient regardless of
+/// what the user has installed locally.
+const DEFAULT_CODEX_REASONING_EFFORT: &str = "medium";
+
 /// Spawn a Codex CLI session (`codex exec --json --dangerously-bypass-approvals-and-sandbox`).
 async fn spawn_codex(
     tx: &mpsc::UnboundedSender<SessionUpdate>,
@@ -80,11 +89,17 @@ async fn spawn_codex(
     resume_session_id: Option<String>,
     working_dir: Option<std::path::PathBuf>,
     model: Option<String>,
+    effort: Option<String>,
     system_prompt: Option<String>,
 ) {
+    let effort = Some(
+        effort.unwrap_or_else(|| DEFAULT_CODEX_REASONING_EFFORT.to_string()),
+    );
     tracing::info!(
-        "[houston:session] spawning codex exec --json (resume={:?})",
-        resume_session_id
+        "[houston:session] spawning codex exec --json (resume={:?}, model={:?}, effort={:?})",
+        resume_session_id,
+        model,
+        effort,
     );
 
     if let Some(ref dir) = working_dir {
@@ -101,6 +116,7 @@ async fn spawn_codex(
         resume_session_id.as_deref(),
         working_dir.as_deref(),
         model.as_deref(),
+        effort.as_deref(),
         system_prompt.as_deref(),
     );
 
@@ -114,6 +130,7 @@ async fn spawn_codex(
             None,
             working_dir.as_deref(),
             model.as_deref(),
+            effort.as_deref(),
             system_prompt.as_deref(),
         );
         run_cli_process(tx, &mut fresh_cmd, &prompt, Provider::OpenAI).await;
@@ -124,14 +141,26 @@ fn build_codex_command(
     resume_session_id: Option<&str>,
     working_dir: Option<&std::path::Path>,
     model: Option<&str>,
+    effort: Option<&str>,
     system_prompt: Option<&str>,
 ) -> Command {
-    let mut cmd = Command::new("codex");
+    // Always prefer the bundled codex over whatever happens to be on the
+    // user's PATH. The user's PATH might point at a stale `nvm` codex that
+    // doesn't know about the model we just selected (this exact case is
+    // what initially shipped to users as "the conversation disappeared":
+    // PATH's codex was old enough to reject `gpt-5.5`, while the bundled
+    // CLI was current). Fall back to "codex" only when nothing is bundled,
+    // which in practice means a misconfigured dev checkout — and in that
+    // case the user gets the same behavior they had before.
+    let bin = houston_cli_bundle::bundled_codex_path()
+        .unwrap_or_else(|| std::path::PathBuf::from("codex"));
+    let mut cmd = Command::new(&bin);
     cmd.env("PATH", super::claude_path::shell_path());
     cmd.args(codex_command::build_args(
         resume_session_id,
         working_dir,
         model,
+        effort,
         system_prompt,
     ));
     if let Some(dir) = working_dir {

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -481,6 +481,13 @@ export interface SessionStartRequest {
   workingDir?: string;
   provider?: string;
   model?: string;
+  /**
+   * Reasoning-effort override. Forwarded to the CLI as `--effort` (Claude) or
+   * `-c model_reasoning_effort=<value>` (Codex). The tutorial uses this to
+   * force `"medium"` so a stale global `~/.codex/config.toml` value can't
+   * blow up the session.
+   */
+  effort?: string;
 }
 
 export interface SessionStartResponse {


### PR DESCRIPTION
## Summary

Three stacked codex bugs that collapsed to *"A local tool failed to start"* → *"the conversation disappeared"* → *"5–10 second freeze"*. All three are fixed end-to-end.

### 1. Stale global config killed every codex session

If a user had a newer codex CLI somewhere on their machine, it would write `model_reasoning_effort = "xhigh"` to `~/.codex/config.toml`. Houston-spawned codex (often an older bundled or PATH copy) rejected the value and exited 1 before emitting any output.

Engine now always passes `-c model_reasoning_effort="<value>"` (defaulting to `"medium"`) so the user's global config can never block a session. Same override threaded through the title summarizer.

### 2. Bundled codex was too old for `gpt-5.5`

Pinned codex was 0.121.0; the API rejects `gpt-5.5` on anything older than 0.130 with *"requires a newer version of Codex"*. Bumped `cli-deps.json` to 0.130.0 with fresh SHA-256s for all four arches (darwin-arm64/x64, windows-x64/arm64).

Engine was also shelling out to `codex` on PATH, which in dev meant whatever `nvm` had — usually 0.42. Engine now resolves via `bundled_codex_path()` and a new workspace-aware dev fallback discovers the staged binary at `app/src-tauri/resources/bin/codex` whenever the engine runs from `target/{debug,release}/houston-engine`. Gated on the engine binary name so `cargo test` binaries living at `target/debug/deps/<hash>` don't trip it.

### 3. UI looked frozen during codex reasoning

Codex 0.130 in `--json` mode emits `turn.started`, then sits silent for 6–10 seconds while the model reasons internally, then emits the final `item.completed`. The parser treated `turn.started` as a no-op, so the chat panel had no feed item to anchor "Mission in progress…" on. Felt bugged, was actually just an unsurfaced signal.

`turn.started` now seeds an empty `ThinkingStreaming("")` placeholder — chat panel renders "Mission in progress…" immediately. The first non-reasoning item / `turn.completed` / `turn.failed` closes it with `Thinking("")` so the reasoning block exits its streaming state without stranding a permanent shimmer. Real reasoning items take over the buffer naturally.

### Plumbing
`effort` is now wired end-to-end: `SessionStartRequest` (TS + Rust) → `StartParams` → `spawn_and_monitor` → `SessionManager::spawn_session` → `build_codex_command` → `-c model_reasoning_effort`. Tutorial passes `effortOverride: "medium"` explicitly via `createMission` and `tauriChat.send`.

## Test plan

- [x] `cargo test --workspace` — green
- [x] `cd app && pnpm tsc --noEmit` — green
- [x] `cd ui && pnpm typecheck` — green
- [x] Bundled codex 0.130.0 smoke-tested locally against `gpt-5.5` — returns real responses
- [x] 4 new parser tests cover the `ThinkingStreaming`/`Thinking` placeholder lifecycle (start → take-over → finalize → cancelled)
- [x] 2 new cli-bundle tests cover the dev workspace layout (detected with engine binary name, ignored for cargo-test binaries)
- [ ] Reviewer: hard-restart `pnpm tauri dev` (engine sidecar) and confirm the tutorial reports immediately on send and replies cleanly with `gpt-5.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)