### PR TITLE
fix(ci): unblock Windows release builds (x64 SHA bump, arm64 Bun zip name)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -819,7 +819,12 @@ jobs:
             $bunBundle = "bun-windows-x64"
           } else {
             $bunVersion = (Get-Content cli-deps.json | ConvertFrom-Json).composio.build.'windows-arm64'.bun_version
-            $bunBundle = "bun-windows-arm64"
+            # Bun's GitHub release artifact for Windows ARM64 is published
+            # as `bun-windows-aarch64.zip` (asymmetric with the
+            # `--target=bun-windows-arm64` CLI flag in cli-deps.json,
+            # which still uses `arm64`). Both the URL stem and the zip's
+            # inner folder use `aarch64`.
+            $bunBundle = "bun-windows-aarch64"
           }
           Write-Host "Installing Bun $bunVersion ($bunBundle, direct GitHub release download)"
           $bunDir = "$HOME\.bun\bin"

--- a/cli-deps.json
+++ b/cli-deps.json
@@ -57,12 +57,12 @@
       "darwin-arm64": "fba0a57788ea50335507b2a38eccc67ebc051272f8393284b239875c4fdff8ef",
       "darwin-x64": "94af160e5bb10be80218dd9377c79a72d5c5ab7e172a65da0607ec4ee4d019c6"
     },
-    "$build_comment": "Upstream ComposioHQ/composio does not yet publish Windows artifacts (issue #3057, closed: 'use WSL'). Until that ships, we build composio.exe from a fork at gethouston/composio that adds Windows targets to TARGET_MAP, win32 entries to RUN_CODEX_ACP_BINARY_TARGETS, and a Windows Credential Manager backend in cli-keyring. The `windows-arm64` build additionally needs the bun:ffi fallback from `houston-windows-arm64` branch — Bun 1.3.10's windows-arm64 target ships without TinyCC so the FFI keyring store has to downshift to NoStorageAccess at import time. Builds are reproducible: pinned commit SHA, pinned Bun version, pinned bun_target. The `pnpm` package manager + Bun runtime installed on the build host must match the values in the fork's `package.json#packageManager` and `.bun-version` respectively.",
+    "$build_comment": "Upstream ComposioHQ/composio does not yet publish Windows artifacts (issue #3057, closed: 'use WSL'). Until that ships, we build composio.exe from a fork at gethouston/composio that adds Windows targets to TARGET_MAP, win32 entries to RUN_CODEX_ACP_BINARY_TARGETS, and a Windows Credential Manager backend in cli-keyring. Both x64 and arm64 builds share the same `houston-windows-support` branch. The arm64 build relies on a bun:ffi fallback patch on that branch, because Bun 1.3.10's windows-arm64 target ships without TinyCC so the FFI keyring store has to downshift to NoStorageAccess at import time. Builds are reproducible: pinned commit SHA, pinned Bun version, pinned bun_target. The `pnpm` package manager + Bun runtime installed on the build host must match the values in the fork's `package.json#packageManager` and `.bun-version` respectively.",
     "build": {
       "windows-x64": {
         "source_repo": "https://github.com/gethouston/composio.git",
         "source_ref": "houston-windows-support",
-        "source_sha": "771a0bd7be8478b2cf6ca56a8d51158d4a24b1bb",
+        "source_sha": "4608b1cd8b75b8533713f2c2ae1424d1fafb3e8a",
         "package_path": "ts/packages/cli",
         "bun_target": "bun-windows-x64-modern",
         "bun_version": "1.3.10",
@@ -71,8 +71,8 @@
       },
       "windows-arm64": {
         "source_repo": "https://github.com/gethouston/composio.git",
-        "source_ref": "houston-windows-arm64",
-        "source_sha": "c17c8fb88d4d771666e4b2d70ec9a61169758317",
+        "source_ref": "houston-windows-support",
+        "source_sha": "4608b1cd8b75b8533713f2c2ae1424d1fafb3e8a",
         "package_path": "ts/packages/cli",
         "bun_target": "bun-windows-arm64",
         "bun_version": "1.3.10",


### PR DESCRIPTION
## Summary

Two stacked breakages in the v0.4.10 CI run (run id 25737791426), both first exposed by PR #115's parallel Windows x64 + Windows arm64 build matrix:

1. **composio fork SHA mismatch (x64).** The `houston-windows-support` branch was advanced from `771a0bd7` to `4608b1cd` to add the bun:ffi fallback that the arm64 build needs, but `cli-deps.json#composio.build."windows-x64".source_sha` was never bumped. `fetch-cli-deps.sh`'s safety check refused to build when the branch HEAD didn't match the pin. Both windows-x64 AND windows-arm64 are now pinned to `4608b1cd` on the same `houston-windows-support` branch (the separate `houston-windows-arm64` branch was deleted in the fork when the patch consolidated).
2. **Bun GitHub-release artifact name typo (arm64).** Bun publishes the ARM64 Windows binary as `bun-windows-aarch64.zip`, even though the `bun build --compile --target=bun-windows-arm64` CLI flag uses `arm64`. release.yml was deriving the URL from the latter and 404'd. Hardcoded `bun-windows-aarch64` for the arm64 matrix leg and commented the asymmetry inline.

Both bugs were latent: windows-arm64 had never been exercised by release CI before, and windows-x64 only broke once the fork branch was advanced.

## Test plan

- [ ] Next release-tag push triggers a CI run where both `build-windows (x86_64 ...)` and `build-windows (aarch64 ...)` succeed end-to-end
- [ ] Mac build job is unaffected