### PR TITLE
fix(ci): per-arch tail verification in fetch-cli-deps.sh

### DIFF
--- a/scripts/fetch-cli-deps.sh
+++ b/scripts/fetch-cli-deps.sh
@@ -657,9 +657,20 @@ case "$TARGET_OS" in
     ;;
   windows)
     [ -f "$OUT_DIR/codex.exe" ] || missing+=("codex.exe")
-    [ -f "$OUT_DIR/composio-x86_64/composio.exe" ] || missing+=("composio-x86_64/composio.exe")
-    [ -f "$OUT_DIR/composio-x86_64/run-helpers-runtime.mjs" ] || missing+=("composio-x86_64/run-helpers-runtime.mjs")
-    [ -f "$OUT_DIR/composio-x86_64/acp-adapters/codex/win32-x64/codex-acp.exe" ] || missing+=("composio-x86_64/acp-adapters/codex/win32-x64/codex-acp.exe")
+    # Verify only the arches that were actually requested. Previously
+    # this hardcoded composio-x86_64/... paths which made
+    # `windows-arm64` (and any future single-arch mode) fail at the
+    # tail check even when the requested arch built cleanly.
+    for arch in "${ARCHES[@]}"; do
+      case "$arch" in
+        x86_64)  bun_dir="composio-x86_64";  acp_target="win32-x64"  ;;
+        aarch64) bun_dir="composio-aarch64"; acp_target="win32-arm64" ;;
+        *) echo "ERROR: unknown windows arch '$arch' in verification block" >&2; exit 1 ;;
+      esac
+      [ -f "$OUT_DIR/$bun_dir/composio.exe" ] || missing+=("$bun_dir/composio.exe")
+      [ -f "$OUT_DIR/$bun_dir/run-helpers-runtime.mjs" ] || missing+=("$bun_dir/run-helpers-runtime.mjs")
+      [ -f "$OUT_DIR/$bun_dir/acp-adapters/codex/$acp_target/codex-acp.exe" ] || missing+=("$bun_dir/acp-adapters/codex/$acp_target/codex-acp.exe")
+    done
     ;;
 esac
 [ -f "$OUT_DIR/cli-deps.json" ] || missing+=("cli-deps.json")


### PR DESCRIPTION
## Summary

Third stacked bug in the v0.4.10 Windows CI matrix (after #122). The Windows post-fetch sanity check in `scripts/fetch-cli-deps.sh` hardcoded `composio-x86_64/...` paths even when the script was invoked as `windows-arm64`. The CI run staged composio-aarch64/ cleanly, then failed at the tail check looking for x86_64 paths the run had never produced.

Mirrors the darwin branch: iterate `ARCHES` and check the matching `composio-<arch>` directory + the matching codex-acp adapter (`win32-x64` for x86_64, `win32-arm64` for aarch64). Unknown arch -> exit 1 with a clear message.

Latent since PR #115 — never tripped because no release CI run had exercised `windows-arm64` mode until v0.4.10.

## Test plan

- [ ] Next CI run: `build-windows (aarch64 ...)` passes the staging step
- [ ] `build-windows (x86_64 ...)` is unaffected