### PR TITLE
fix(ci): use ARCHES values (x64/arm64) in windows verify case

### DIFF
--- a/scripts/fetch-cli-deps.sh
+++ b/scripts/fetch-cli-deps.sh
@@ -662,9 +662,15 @@ case "$TARGET_OS" in
     # `windows-arm64` (and any future single-arch mode) fail at the
     # tail check even when the requested arch built cleanly.
     for arch in "${ARCHES[@]}"; do
+      # ARCHES holds the mode-arg arch names: `x64` / `arm64` (NOT
+      # `x86_64` / `aarch64` — see the case block at the top of this
+      # file). The staged composio dir uses Rust-style arch names
+      # (matching build_composio_windows' `dest_dir`), and the
+      # codex-acp adapter dir is `win32-<mode-arch>` to match
+      # prune_acp_adapters' `win32-$arch` keep_platform string.
       case "$arch" in
-        x86_64)  bun_dir="composio-x86_64";  acp_target="win32-x64"  ;;
-        aarch64) bun_dir="composio-aarch64"; acp_target="win32-arm64" ;;
+        x64)   bun_dir="composio-x86_64";  acp_target="win32-x64"   ;;
+        arm64) bun_dir="composio-aarch64"; acp_target="win32-arm64" ;;
         *) echo "ERROR: unknown windows arch '$arch' in verification block" >&2; exit 1 ;;
       esac
       [ -f "$OUT_DIR/$bun_dir/composio.exe" ] || missing+=("$bun_dir/composio.exe")


### PR DESCRIPTION
## Summary

Followup to #123. My previous fix used `x86_64` / `aarch64` as the `case` labels in the windows tail verifier, but `ARCHES` actually holds the mode-arg arch names (`x64` / `arm64`); the rust-style names are only locals inside `build_composio_windows`. Both x64 and arm64 hit the `*) exit 1` fallthrough with "unknown windows arch" in run 25740411718.

Smoke-tested the case mapping locally in bash this time:
- `ARCHES=(x64)`   -> `composio-x86_64`  + `win32-x64`
- `ARCHES=(arm64)` -> `composio-aarch64` + `win32-arm64`

## Test plan

- [ ] Next CI run: both `build-windows (x86_64 ...)` and `build-windows (aarch64 ...)` pass the staging step