### PR TITLE
release: v0.4.11

### DIFF
--- a/.github/release-notes/0.4.11.md
+++ b/.github/release-notes/0.4.11.md
@@ -1,0 +1,31 @@
+## Houston 0.4.11
+
+The Windows first-launch crash-loop fix. If you installed the v0.4.10 MSI on Windows and saw a black Houston window, a small "loading" dialog beside it, the Houston window close, and then nothing, this release is for you. Everything in 0.4.10 is still here; this is a pure bug-fix on top of it.
+
+### Fixed
+
+- **Windows: first-launch crash loop is gone.** On 0.4.10 the bundled PortableGit archive was extracted by running its self-extracting `.exe` as a subprocess. That subprocess always renders its own progress dialog regardless of how it is launched (the "small loading window" users reported), and the extraction blocked the engine from coming up before the Tauri app's health-check budget expired. The result: the engine crashed mid-extract every launch, no PortableGit ever finalized, and clicking Houston put you back at the same screen. v0.4.11 decodes the embedded 7z archive in-process (no subprocess, no dialog), runs PortableGit provisioning in the background so the engine HTTP layer is responsive immediately, and stages the extraction in a temporary directory that is renamed into place atomically so a partial extraction can never poison the install. Houston starts on the first click and the agent chat is reachable inside of a second.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag the new copy in.
+- **Windows x64:** if you are stuck in the 0.4.10 install loop, uninstall Houston from Add/Remove Programs first, then install the 0.4.11 MSI. Auto-update from any working install (0.4.7 through 0.4.9 inclusive) pulls you forward automatically. The MSI is still not OS-code-signed (SignPath integration is still pending), so expect one SmartScreen "Run anyway" prompt on first install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install. Download the ARM64 MSI manually, uninstall the x64 build first, then install the ARM64 one. Future ARM64 to ARM64 updates apply automatically.
+
+### If you are on 0.4.5 or later (Mac / Windows x64 that is actually running)
+
+Houston should detect 0.4.11, download it, install it, and relaunch into the new version on its own.
+
+### If you installed the 0.4.10 MSI on Windows and were stuck
+
+Auto-update never had a chance to run because Houston never reached a steady state. Uninstall 0.4.10 from Add/Remove Programs, download the 0.4.11 MSI from the GitHub release page, and install. After that one manual step you are back on the healthy updater path and future versions apply automatically.
+
+### If you are on 0.4.2 or earlier (Mac)
+
+Auto-update will not pull you forward from those builds. Quit Houston, drag a fresh DMG over `/Applications/Houston.app`, and reopen. After that one manual step you are back on the healthy updater path and future versions apply automatically.
+
+### Known limitations
+
+- **Windows MSI not yet OS-code-signed.** SignPath integration still pending. One SmartScreen "Run anyway" click on first install only, both x64 and ARM64.
+- **"Continue with Microsoft" sign-in for Houston itself remains hidden** while we reconcile the Supabase Azure provider with the production callback URL. Google sign-in is unaffected. The Microsoft 365 + Outlook tutorial path is unaffected.
+- **Mobile companion is still beta.** Expect occasional reconnect hiccups. Keep your Mac awake while using it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "chrono",
  "serde",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2418,7 +2418,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "futures-util",
  "hex",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -2448,7 +2448,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2466,7 +2466,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2479,7 +2479,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2521,7 +2521,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2558,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2572,7 +2572,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2583,7 +2583,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2597,7 +2597,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2613,7 +2613,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "houston-agent-files",
  "houston-agents-conversations",
@@ -2631,7 +2631,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "dirs 5.0.1",
  "houston-cli-bundle",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2663,7 +2663,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,20 +32,20 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.10", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.10", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.10", path = "app/houston-tauri" }
-houston-events = { version = "0.4.10", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.10", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.10", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.10", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.10", path = "engine/houston-agent-files" }
-houston-ui-events = { version = "0.4.10", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.10", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.10", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.10", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.10", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.10", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.10", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.10", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.10", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.11", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.11", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.11", path = "app/houston-tauri" }
+houston-events = { version = "0.4.11", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.11", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.11", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.11", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.11", path = "engine/houston-agent-files" }
+houston-ui-events = { version = "0.4.11", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.11", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.11", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.11", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.11", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.11", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.11", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.11", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.11", path = "engine/houston-engine-server" }

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Summary

Patch release on top of v0.4.10. Pure bug-fix: ships the Windows first-launch crash-loop fix that landed via #125 yesterday.

## Contents

- Version bump to 0.4.11 across all crates, npm workspaces, and Cargo.lock (via `./scripts/version.sh 0.4.11`).
- Hand-written release notes at `.github/release-notes/0.4.11.md` — leads with the Windows fix, includes the standard upgrade caveats, and tells anyone stuck in the 0.4.10 install loop how to recover.

## Test plan

- [x] `cargo check --workspace` clean
- [x] `pnpm tsc --noEmit` clean
- [ ] Tag `v0.4.11` after merge, CI builds + signs + creates draft release
- [ ] Install draft MSI on a Windows 11 host that previously hit the 0.4.10 loop, confirm Houston starts cleanly on first launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)