### PR TITLE
fix(windows): wire single-instance plugin so OAuth deep-link completes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,6 +2409,7 @@ dependencies = [
  "tauri-plugin-deep-link",
  "tauri-plugin-notification",
  "tauri-plugin-sentry",
+ "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tokio",
  "tracing",
@@ -6608,6 +6609,22 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc61e4822b8f74d68278e09161d3e3fdd1b14b9eb781e24edccaabf10c420e8c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin-deep-link",
+ "thiserror 2.0.18",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -33,3 +33,16 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"], def
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
+
+# Windows + Linux only: the OS protocol handler launches a fresh
+# `houston-app.exe` for every `houston://` URL it receives (Start-menu
+# launches go to `C:\Program Files\Houston\…`, protocol-handler launches
+# go to the 8.3 short form `C:\PROGRA~1\Houston\…`). Without
+# single-instance the second exe holds an orphan webview while the
+# primary sits on the login screen forever, never receiving the OAuth
+# callback. The `deep-link` feature makes the second-instance argv
+# auto-route into the primary's `on_open_url` handler.
+# Not needed on macOS where NSWorkspace delivers URLs to the running
+# app natively.
+[target."cfg(any(target_os = \"windows\", target_os = \"linux\"))".dependencies]
+tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -88,6 +88,38 @@ pub fn run() {
 
     let mut builder = tauri::Builder::default();
 
+    // Single-instance plugin — MUST be registered before the deep-link
+    // plugin on Windows / Linux so its second-instance argv-forwarding
+    // is the one the deep-link plugin attaches to. Without this, every
+    // `houston://auth-callback?...` from the Google OAuth flow launches
+    // a fresh houston-app.exe (the OS protocol handler does this by
+    // design — Start-menu launches resolve to `C:\Program Files\Houston\…`
+    // and protocol-handler launches resolve to the 8.3 short form
+    // `C:\PROGRA~1\Houston\…`, both visible as separate engine spawns
+    // in `backend.log` on the bad path) while the primary instance
+    // sits on the login screen waiting for an event that never arrives.
+    //
+    // The callback below also raises the primary window so the user
+    // sees the auth state transition (browser → app) immediately.
+    //
+    // No-op on macOS — NSWorkspace delivers `houston://` URLs to the
+    // running app natively, no second instance is ever spawned.
+    #[cfg(any(target_os = "windows", target_os = "linux"))]
+    {
+        builder = builder.plugin(tauri_plugin_single_instance::init(
+            |app, _argv, _cwd| {
+                tracing::info!(
+                    "[single-instance] secondary launch routed to primary"
+                );
+                if let Some(window) = app.get_webview_window("main") {
+                    let _ = window.unminimize();
+                    let _ = window.show();
+                    let _ = window.set_focus();
+                }
+            },
+        ));
+    }
+
     // Sentry plugin — only if DSN was provided
     if let Some(ref client) = _sentry_client {
         builder = builder.plugin(tauri_plugin_sentry::init(client));


### PR DESCRIPTION
## Symptom

After installing v0.4.11 on Windows and clicking **Continue with Google**: browser opens, user authenticates, clicks **Open**, and:

1. A fresh Houston window appears next to the original.
2. The original Houston sits on the login screen forever, never advancing past the OAuth callback.

## Root cause

Windows' protocol handler does not deliver \`houston://\` URLs to a running app the way macOS NSWorkspace does. It launches a brand-new \`houston-app.exe\` with the URL as \`argv[1]\`, every time. Without \`tauri-plugin-single-instance\` to forward that argv into the running primary, the new exe runs its own deep-link plugin in a process with no Supabase context, while the primary sits and waits for an \`auth://deep-link\` event that never arrives.

\`backend.log\` confirms — 11 separate \`[engine] spawning ...\` lines in 20 minutes, alternating between \`C:\Program Files\Houston\\\` (Start-menu launch) and \`C:\PROGRA~1\Houston\\\` (the 8.3 short name the Windows protocol-handler registry value uses).

## Fix

Add \`tauri-plugin-single-instance\` with the \`deep-link\` feature on Windows + Linux only (macOS doesn't need it), registered **before** the deep-link plugin so the plugin's internal argv-forwarding latches onto the single-instance forward path. The callback also raises the primary window so the user sees the auth state transition immediately when control returns from the browser.

The existing \`on_open_url\` handler in \`setup()\` is unchanged — it keeps firing for both the initial-launch URL (which single-instance forwards from the killed second instance's argv) and any subsequent deep links delivered during the running session.

## Test plan

- [x] \`cargo check --target x86_64-pc-windows-gnu -p houston-app\` clean
- [ ] On Windows: install fresh build, click Continue with Google, click Open in the browser. Expect: original Houston window receives the callback, login completes, no second window opens.
- [ ] Verify in \`backend.log\` after the OAuth flow: zero new \`[engine] spawning\` lines triggered by the deep link, plus an \`[auth] emit deep-link\` line followed by the existing primary instance progressing past the login screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)