### PR TITLE
fix(windows): accept implicit-flow OAuth callback in addition to PKCE

### DIFF
--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -140,22 +140,56 @@ export function installDeepLinkListener(): () => void {
         return;
       }
 
-      if (!code) {
-        logger.warn("[auth] deep-link had no `code` param — ignoring");
-        emitAuthError(
-          "Sign-in callback was missing the authorization code.",
+      // Two callback shapes can land here:
+      //   PKCE   →  ?code=...                  (the `flowType: "pkce"`
+      //                                         path; client owns the
+      //                                         verifier in storage).
+      //   Implicit → #access_token=...&refresh_token=...
+      //
+      // Our client config asks for PKCE, but on Windows the desktop build
+      // has been observed to receive implicit-flow URLs (Supabase project
+      // config + an async Keychain adapter that silently swallows storage
+      // failures combine to make the JS lib generate an OAuth URL without
+      // `code_challenge`). The user got all the way through Google consent;
+      // the only thing left is installing the session — there is no reason
+      // to leave them stranded just because the URL shape doesn't match
+      // what we expected. Handle both, prefer PKCE when both are present
+      // (which never happens in practice — Supabase emits one or the other).
+      if (code) {
+        const { data, error } = await supabase.auth.exchangeCodeForSession(code);
+        if (error) {
+          logger.error(`[auth] exchangeCodeForSession failed: ${error.message}`);
+          emitAuthError(error.message);
+          return;
+        }
+        logger.info(`[auth] session established (pkce) for ${data.user?.email}`);
+        return;
+      }
+
+      const accessToken = fragmentParams.get("access_token");
+      const refreshToken = fragmentParams.get("refresh_token");
+      if (accessToken && refreshToken) {
+        const { data, error } = await supabase.auth.setSession({
+          access_token: accessToken,
+          refresh_token: refreshToken,
+        });
+        if (error) {
+          logger.error(`[auth] setSession failed: ${error.message}`);
+          emitAuthError(error.message);
+          return;
+        }
+        logger.info(
+          `[auth] session established (implicit) for ${data.user?.email}`,
         );
         return;
       }
 
-      const { data, error } = await supabase.auth.exchangeCodeForSession(code);
-      if (error) {
-        logger.error(`[auth] exchangeCodeForSession failed: ${error.message}`);
-        emitAuthError(error.message);
-        return;
-      }
-
-      logger.info(`[auth] session established for ${data.user?.email}`);
+      logger.warn(
+        "[auth] deep-link had neither `code` nor `access_token` — ignoring",
+      );
+      emitAuthError(
+        "Sign-in callback was missing the authorization code.",
+      );
     } catch (e) {
       logger.error(`[auth] failed to handle deep-link: ${e}`);
       emitAuthError(String(e));


### PR DESCRIPTION
## Symptom

On v0.4.12 (where the single-instance plugin correctly routes \`houston://\` URLs into the running Houston), Continue with Google still leaves the user stranded on the login screen with a warning in \`frontend.log\`:

\`\`\`
[auth] deep-link received: houston://auth-callback/#access_token=eyJ...&refresh_token=...
[auth] deep-link had no \`code\` param — ignoring
\`\`\`

## Root cause

That URL is an OAuth **implicit-flow** response (token in URL fragment), not the PKCE response (\`?code=...\`) the client config asks Supabase to send via \`flowType: \"pkce\"\`. Why Supabase returns implicit despite the client config is worth investigating separately, but the user already finished Google consent and Supabase issued valid tokens — the client should not strand them just because the response shape is unexpected.

## Fix

\`installDeepLinkListener\` now handles both shapes. PKCE \`?code=\` continues to call \`exchangeCodeForSession\`. The new fallback reads \`access_token\` + \`refresh_token\` from the URL fragment and calls \`setSession\` to install the session directly. The \"no code or access_token\" log line replaces the old warning so we get a real signal if a future provider returns something unrecognized.

No engine changes; pure frontend. Cross-platform — implicit flow arrives in the same \`auth://deep-link\` event on every OS.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] Implicit-flow URL shape captured live in a real v0.4.12 user's \`frontend.log\`
- [ ] Install v0.4.13 MSI on Windows, click Continue with Google, end on dashboard
- [ ] Verify \`frontend.log\` contains \`[auth] session established (implicit) for <email>\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)