### PR TITLE
fix(onboarding+activity): kill tutorial dead-zone + activity empty-state flash

### DIFF
--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -259,7 +259,10 @@ export function Dashboard() {
     );
   }
 
-  const emptyBoard = (
+  // Only render an empty state when the user is actively searching and
+  // got no matches. See the matching comment in board-tab.tsx for why
+  // we don't show a "no missions yet" empty state.
+  const emptyBoard = missionSearch.hasQuery ? (
     <MissionBoardEmptyState
       isSearch={missionSearch.hasQuery}
       isSearchingText={missionSearch.isSearchingText}
@@ -276,7 +279,7 @@ export function Dashboard() {
       onNewMission={openNewMission}
       onClearSearch={() => setMissionSearchQuery("")}
     />
-  );
+  ) : undefined;
 
   return (
     <div className="h-full flex flex-col overflow-hidden">

--- a/app/src/components/onboarding/missions/try.tsx
+++ b/app/src/components/onboarding/missions/try.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChatPanel, type FeedItem } from "@houston-ai/chat";
 import { HoustonAvatar, cn, resolveAgentColor } from "@houston-ai/core";
@@ -7,6 +7,7 @@ import {
   useConnections,
 } from "../../../hooks/queries";
 import { tauriAgent, tauriChat, tauriSystem } from "../../../lib/tauri";
+import { logger } from "../../../lib/logger";
 import { createMission } from "../../../lib/create-mission";
 import { useSessionMessageQueue } from "../../../hooks/use-session-message-queue";
 import { useQueuedMessageLabels } from "../../use-queued-message-labels";
@@ -106,18 +107,30 @@ export function TryMission({
   // Append the tutorial directive to CLAUDE.md while this mission is mounted;
   // strip on unmount. Agent picks it up at session start so the tutorial flow
   // is enforced via system prompt, not user-visible postscripts.
+  //
+  // The write is async, but the chip click that spawns the chat session is
+  // synchronous from the user's POV. If the user clicks before this write
+  // lands on disk the engine reads the un-augmented CLAUDE.md, the tutorial
+  // directive never reaches the agent, and the agent reverts to its base
+  // "look at local files, ask one missing-piece question" behavior — what
+  // a real user saw on Windows after a wipe + fresh boot (NTFS + AV scan
+  // make the race fat). We expose the prep promise via a ref so
+  // `handlePick` can await it before firing `createMission`. Already-done
+  // prep resolves instantly.
+  const tutorialPrepRef = useRef<Promise<void>>(Promise.resolve());
   useEffect(() => {
     let cancelled = false;
-    void (async () => {
+    const prep = (async () => {
       try {
         const current = await tauriAgent.readFile(agentPath, "CLAUDE.md");
         const updated = appendTutorialSection(current);
         if (cancelled || updated === current) return;
         await tauriAgent.writeFile(agentPath, "CLAUDE.md", updated);
       } catch (e) {
-        console.error("[try] could not append tutorial section:", e);
+        logger.warn(`[try] could not append tutorial section: ${e}`);
       }
     })();
+    tutorialPrepRef.current = prep;
     return () => {
       cancelled = true;
       void (async () => {
@@ -127,7 +140,7 @@ export function TryMission({
           if (stripped === current) return;
           await tauriAgent.writeFile(agentPath, "CLAUDE.md", stripped);
         } catch (e) {
-          console.error("[try] could not strip tutorial section:", e);
+          logger.warn(`[try] could not strip tutorial section: ${e}`);
         }
       })();
     };
@@ -236,6 +249,11 @@ export function TryMission({
     async (chipLabel: string) => {
       if (pickedAny) return;
       setPickedAny(true);
+      // Wait for the tutorial-section append to land on disk so the engine
+      // reads the augmented CLAUDE.md when it spawns the chat session.
+      // No-op once the mount-time prep is already done; one short await
+      // on a fast click after a fresh boot.
+      await tutorialPrepRef.current;
       try {
         const result = await createMission(
           {
@@ -252,13 +270,28 @@ export function TryMission({
             effortOverride: "medium",
           },
         );
+        // Mirror the regular composer-send path: push the chip text as
+        // the user_message into the feed the instant we have a session
+        // key. `createMission` already forwarded the same prompt to the
+        // engine — the engine does not re-emit it as a feed event, so
+        // this is not a duplicate, it is the only user-visible bubble
+        // for this turn. Without this push the ChatPanel mounts with
+        // an empty feed and `deriveStatus` skips straight past
+        // "submitted", so the pulsing-logo thinking indicator never
+        // gets a chance to render before codex starts streaming items
+        // 1-2s later. End result on Windows: a dead silent gap between
+        // chip click and "Mission in progress" that reads as a crash.
+        pushFeedItem(agent.folderPath, result.sessionKey, {
+          feed_type: "user_message",
+          data: chipLabel,
+        });
         setMissionSessionKey(result.sessionKey);
       } catch (e) {
         setPickedAny(false);
         setError(e instanceof Error ? e.message : String(e));
       }
     },
-    [agent.id, agent.name, agent.color, agent.folderPath, provider, model, pickedAny],
+    [agent.id, agent.name, agent.color, agent.folderPath, provider, model, pickedAny, pushFeedItem],
   );
 
   const visibleFeed = (feedItems ?? []) as FeedItem[];

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -534,7 +534,14 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
     [handleRunInTerminal, t],
   );
 
-  const emptyBoard = (
+  // Only render an empty state when the user is actively searching and
+  // got no matches — that's contextual feedback they asked for. We
+  // intentionally do NOT show an empty state for "no missions at all",
+  // because the board flashes through that state on every app open
+  // before `useActivity` has finished its first fetch, which reads as
+  // "your data is gone." With no empty state, that window looks like a
+  // brief blank board instead of a fake "everything is gone" prompt.
+  const emptyBoard = missionSearch.hasQuery ? (
     <MissionBoardEmptyState
       isSearch={missionSearch.hasQuery}
       isSearchingText={missionSearch.isSearchingText}
@@ -551,7 +558,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
       onNewMission={openDefaultMission}
       onClearSearch={() => setAgentMissionSearchQuery(path, "")}
     />
-  );
+  ) : undefined;
 
   return (
     <div className="flex flex-col h-full">

--- a/app/src/hooks/queries/use-activity.ts
+++ b/app/src/hooks/queries/use-activity.ts
@@ -8,7 +8,15 @@ export function useActivity(agentPath: string | undefined) {
     queryKey: queryKeys.activity(agentPath ?? ""),
     queryFn: () => tauriActivity.list(agentPath!),
     enabled: !!agentPath,
-    initialData: [],
+    // No `initialData: []` here on purpose. With it, the query is in
+    // "success with empty data" the instant a consumer mounts, so any
+    // empty-state UI gated on `items.length === 0` flashes for the
+    // 50-500ms it takes the queryFn to round-trip through the Tauri
+    // command and engine HTTP. On Windows where engine startup is
+    // slower the flash can be a full second. Returning `undefined`
+    // until the real data lands lets consumers distinguish "loading"
+    // from "loaded and genuinely empty". All call sites already guard
+    // reads with `(activities ?? []).map(...)`.
   });
 }
 


### PR DESCRIPTION
## Two Windows UX regressions surfaced in v0.4.13 QA

### 1. Tutorial chip dead-zone

On M3 "Try a mission" → click "Plan my next working day" → 1-2s of blank chat with no indicator → "Mission in progress…" snaps in. Reads as a crash.

Root cause: \`createMission\` doesn't push the chip text into the feed as a \`user_message\`. ChatPanel mounts with an empty feed, \`deriveStatus\` skips "submitted", thinking indicator never gets to render. Fix: push the chip text into the feed the instant \`createMission\` returns the session key — symmetric with the regular composer-send path.

Also tightened the race against the mount-time append of the tutorial directive into \`CLAUDE.md\`. The chip click now awaits the append promise before calling \`createMission\`, so the engine reads the augmented CLAUDE.md when it spawns the session. On Windows fresh-boot (NTFS + AV) the race was reliably losable from the user side and produced agents that ignored the tutorial directive entirely.

### 2. Activity board flashes empty state on every app open

\`useActivity\` set \`initialData: []\`, which TanStack Query treats as "successfully resolved with empty data" the instant a consumer mounts. Empty-state UI flashed for 50ms–1s on every reopen until the real fetch resolved — reads as "your missions got wiped."

Fix: drop \`initialData: []\`. All four call sites already guard with \`(activities ?? []).map(...)\`. Also removed the "no missions exist" empty state per product call (search-no-results stays — that's contextual feedback the user asked for by typing a query). The "+ New mission" CTA still lives in the toolbar.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] Live on UTM via \`win.sh deploy app\`: chip click → pulsing logo → "Mission in progress" with no dead gap; close + reopen → no empty-state flash on Activity tab
- [ ] After v0.4.14 MSI: same flows on real x64 / arm64 Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)