### PR TITLE
release: v0.4.14

### DIFF
--- a/.github/release-notes/0.4.14.md
+++ b/.github/release-notes/0.4.14.md
@@ -1,0 +1,20 @@
+## Houston 0.4.14
+
+Patch on top of 0.4.13. Two Windows UX fixes that surfaced once OAuth and PortableGit stopped breaking and we could actually live-test the onboarding tutorial end to end.
+
+### Fixed
+
+- **Tutorial dead-zone is gone.** On the "Plan my next working day" tutorial chip, the chat would show **nothing** between the click and "Mission in progress…" for 1-2 seconds, then snap in. Two stacked bugs underneath: the chip click wasn't pushing the prompt into the feed (so the thinking indicator never had a chance to render), and the tutorial directive that asks "Google or Microsoft?" was being written to the agent's CLAUDE.md in a fire-and-forget effect that fast clicks on Windows could beat (the agent would then ignore the tutorial flow and produce a generic working-day template). The chip handler now pushes the prompt into the feed immediately AND awaits the directive write before spawning the session, so the pulsing logo appears instantly and the agent actually follows the tutorial script: ask Google or Microsoft, read your real calendar and inbox in parallel, draft three replies, post a structured plan.
+- **Activity board no longer flashes empty on every app open.** `useActivity` set TanStack Query's `initialData: []`, which made the query report "successfully resolved with empty data" the instant a consumer mounted. The "no missions" empty state flashed for 50ms to 1s on every reopen before the real fetch landed, which read as "your missions got wiped." The empty state for "no missions exist" is also gone outright per product call (the **+ New mission** CTA in the toolbar covers the same affordance); the search-no-results empty state stays.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward automatically. The MSI is still not OS-code-signed (SignPath integration is still pending), so expect one SmartScreen "Run anyway" prompt on first install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install. Download the ARM64 MSI manually, uninstall the x64 build first, then install the ARM64 one. Future ARM64 to ARM64 updates apply automatically.
+
+### Known limitations
+
+- **Windows MSI not yet OS-code-signed.** SignPath integration still pending. One SmartScreen "Run anyway" click on first install only, both x64 and ARM64.
+- **"Continue with Microsoft" sign-in for Houston itself remains hidden** while we reconcile the Supabase Azure provider with the production callback URL. Google sign-in is unaffected. The Microsoft 365 + Outlook tutorial path is unaffected.
+- **Mobile companion is still beta.** Expect occasional reconnect hiccups. Keep your Mac awake while using it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "chrono",
  "serde",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2419,7 +2419,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "futures-util",
  "hex",
@@ -2439,7 +2439,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2467,7 +2467,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2480,7 +2480,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2510,7 +2510,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2522,7 +2522,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2573,7 +2573,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2584,7 +2584,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2614,7 +2614,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "houston-agent-files",
  "houston-agents-conversations",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "dirs 5.0.1",
  "houston-cli-bundle",
@@ -2644,7 +2644,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,20 +32,20 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.13", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.13", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.13", path = "app/houston-tauri" }
-houston-events = { version = "0.4.13", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.13", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.13", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.13", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.13", path = "engine/houston-agent-files" }
-houston-ui-events = { version = "0.4.13", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.13", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.13", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.13", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.13", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.13", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.13", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.13", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.13", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.14", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.14", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.14", path = "app/houston-tauri" }
+houston-events = { version = "0.4.14", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.14", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.14", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.14", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.14", path = "engine/houston-agent-files" }
+houston-ui-events = { version = "0.4.14", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.14", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.14", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.14", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.14", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.14", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.14", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.14", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.14", path = "engine/houston-engine-server" }

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Summary

Patch on top of v0.4.13. Ships the tutorial dead-zone fix + activity empty-state flash fix from #131.

## Contents

- Version bump 0.4.13 → 0.4.14.
- Release notes at \`.github/release-notes/0.4.14.md\`.

## Test plan

- [x] \`cargo check --workspace\` clean
- [x] \`pnpm tsc --noEmit\` clean (verified in #131)
- [x] Tutorial chip + close/reopen activity tab verified live on UTM via win.sh deploy loop
- [ ] Install draft MSI on Windows after CI: full onboarding tutorial completes with structured plan reply, no empty-state flash on app reopen

🤖 Generated with [Claude Code](https://claude.com/claude-code)