### PR TITLE
fix(auth): write session into TanStack cache after setSession so the auth gate updates

### DIFF
--- a/app/src/hooks/use-session.ts
+++ b/app/src/hooks/use-session.ts
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import type { Session } from "@supabase/supabase-js";
 import { supabase, isAuthConfigured } from "../lib/supabase";
+import { logger } from "../lib/logger";
 
 const SESSION_KEY = ["session"] as const;
 
@@ -16,7 +17,11 @@ export function useSession() {
 
   useEffect(() => {
     if (!isAuthConfigured()) return;
-    const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+    logger.info("[auth] onAuthStateChange listener attached");
+    const { data } = supabase.auth.onAuthStateChange((event, session) => {
+      logger.info(
+        `[auth] onAuthStateChange fired: ${event} (session=${session ? "present" : "null"})`,
+      );
       qc.setQueryData<Session | null>(SESSION_KEY, session ?? null);
     });
     return () => data.subscription.unsubscribe();

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -1,8 +1,19 @@
 import { listen } from "@tauri-apps/api/event";
+import type { Session } from "@supabase/supabase-js";
 import { supabase, isAuthConfigured } from "./supabase";
+import { queryClient } from "./query-client";
 import { tauriSystem } from "./tauri";
 import { analytics } from "./analytics";
 import { logger } from "./logger";
+
+// Must match `SESSION_KEY` in `hooks/use-session.ts`. Hardcoded here
+// to avoid a hook-importing-from-hook dependency cycle. If you change
+// one, change the other.
+const SESSION_QUERY_KEY = ["session"] as const;
+
+function applySessionToCache(session: Session | null): void {
+  queryClient.setQueryData<Session | null>(SESSION_QUERY_KEY, session);
+}
 
 // HTTPS bridge instead of a raw deep link so the user lands on a polished
 // "Sign-in complete, you can close this tab" page after Google. The bridge
@@ -162,6 +173,7 @@ export function installDeepLinkListener(): () => void {
           emitAuthError(error.message);
           return;
         }
+        applySessionToCache(data.session ?? null);
         logger.info(`[auth] session established (pkce) for ${data.user?.email}`);
         return;
       }
@@ -178,6 +190,15 @@ export function installDeepLinkListener(): () => void {
           emitAuthError(error.message);
           return;
         }
+        // Push the session directly into the TanStack Query cache that
+        // `useSession` reads. Belt-and-suspenders over Supabase's
+        // `onAuthStateChange` listener, which a real Windows v0.4.14
+        // install was observed to skip for `setSession` calls 12 times
+        // in a row — every implicit-flow sign-in succeeded server-side
+        // but the auth gate in App.tsx never re-rendered. Writing the
+        // cache key directly here makes the UI transition deterministic
+        // regardless of whether the listener fires.
+        applySessionToCache(data.session ?? null);
         logger.info(
           `[auth] session established (implicit) for ${data.user?.email}`,
         );


### PR DESCRIPTION
## Symptom

On v0.4.14 Windows: \`Continue with Google\` completes, frontend.log records \`[auth] session established (implicit) for <email>\` — but the SignInScreen stays up. A real user clicked the button **12 times in a row**; every attempt landed a session server-side, none of them moved the UI past the sign-in screen.

## Root cause (hypothesis)

supabase-js fires \`onAuthStateChange\` from \`setSession\` via \`_notifyAllSubscribers\`. Our \`useSession\` hook subscribes and feeds the TanStack Query \`["session"]\` cache. The auth gate in App.tsx reads from that cache. For implicit-flow \`setSession\` calls in real Windows MSI installs the listener is not propagating. Cache stays null → gate keeps rendering SignInScreen.

## Fix

After a successful \`setSession\` (implicit) or \`exchangeCodeForSession\` (PKCE), push the new session **directly into the TanStack Query cache** from \`installDeepLinkListener\`. The gate re-renders deterministically regardless of whether the supabase listener ever fires. Defensive — does not remove the listener, just stops depending on it.

Also adds \`[auth] onAuthStateChange fired: <event>\` log lines so the next time we see this flow we know from frontend.log whether the listener is broken or the cache write is the only thing keeping the UI in sync.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [ ] Install v0.4.15 MSI on the Windows machine that's currently looping on Continue with Google. Expect: one click, lands on dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)