### PR TITLE
fix(windows+onboarding): persistent sessions, surface storage errors, send-logs CTA, skip-tutorial escape hatch

### DIFF
--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -46,3 +46,17 @@ tracing-appender = { workspace = true }
 # app natively.
 [target."cfg(any(target_os = \"windows\", target_os = \"linux\"))".dependencies]
 tauri-plugin-single-instance = { version = "2", features = ["deep-link"] }
+
+# Windows-only: DPAPI session storage. The Windows Credential Manager
+# (which the `keyring` crate uses) caps `CredentialBlob` at ~2560 bytes,
+# and a Supabase session payload (JWT access_token + JWT user object +
+# provider_token + refresh_token) is reliably 3-4 KB. CredWrite returns
+# ERROR_INVALID_PARAMETER, the keyring crate returns Err, and our
+# previous storage adapter silently swallowed it — sessions worked
+# in-memory but never persisted to disk, so every app close forced a
+# fresh sign-in. We now write the session to a per-user DPAPI-encrypted
+# file under `%LOCALAPPDATA%\com.houston.app\auth\<key>.dpapi` instead.
+# DPAPI binds the ciphertext to the Windows user account so a copied
+# file is useless to another user. See `src/auth.rs` storage module.
+[target."cfg(target_os = \"windows\")".dependencies]
+windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security_Cryptography"] }

--- a/app/src-tauri/src/auth.rs
+++ b/app/src-tauri/src/auth.rs
@@ -1,79 +1,263 @@
 //! Keychain-backed storage for Supabase auth sessions + deep-link callback
 //! handling for Google OAuth.
 //!
-//! The frontend Supabase client uses these Tauri commands as its storage
-//! adapter (see `app/src/lib/supabase.ts`), so auth tokens never hit
-//! localStorage on disk — they live in macOS Keychain / Windows Credential
-//! Manager via the `keyring` crate.
+//! Storage layout per OS:
+//! - **macOS**: `keyring` crate writes to the user's Keychain under
+//!   `com.houston.app.auth`. Apple Keychain has no per-blob size limit
+//!   that matters for our session sizes, so this Just Works.
+//! - **Windows**: per-user **DPAPI-encrypted file** under
+//!   `%LOCALAPPDATA%\com.houston.app\auth\<key>.dpapi`. We do NOT use
+//!   Credential Manager here because its `CredentialBlob` field caps at
+//!   ~2560 bytes, and a Supabase session — a JWT access_token plus
+//!   user metadata plus refresh_token plus provider_token — is
+//!   reliably 3-4 KB. The earlier keyring-based path silently dropped
+//!   every session on disk (the `set_password` Err was swallowed by
+//!   the JS storage adapter) so every Windows user was forced to
+//!   re-sign-in on every app open. DPAPI's `CryptProtectData` has no
+//!   such limit and still binds the ciphertext to the Windows user.
+//! - **Other Unix**: `keyring` falls through to whatever backend the
+//!   user has (libsecret, KWallet, etc.). Not officially supported.
 //!
 //! Deep-link flow:
 //!   1. Frontend calls `supabase.auth.signInWithOAuth({ provider: "google",
 //!      options: { redirectTo: "houston://auth-callback" } })`.
 //!   2. User completes consent in their system browser.
-//!   3. Supabase redirects to `houston://auth-callback?code=...` (PKCE).
-//!   4. macOS hands the URL to the running app via tauri-plugin-deep-link.
+//!   3. Supabase redirects to `houston://auth-callback?code=...` (PKCE) or
+//!      `houston://auth-callback/#access_token=...` (implicit).
+//!   4. macOS hands the URL to the running app via tauri-plugin-deep-link;
+//!      Windows hands it via tauri-plugin-single-instance argv forwarding
+//!      into the same plugin (see `lib.rs`).
 //!   5. This module emits `auth://deep-link` with the URL to the frontend.
-//!   6. Frontend calls `supabase.auth.exchangeCodeForSession(code)` — the
-//!      PKCE verifier was stashed in Keychain during step 1 and is read
-//!      back out of the same storage adapter to complete the exchange.
+//!   6. Frontend calls `supabase.auth.exchangeCodeForSession(code)` for
+//!      PKCE or `setSession({access_token, refresh_token})` for implicit
+//!      — and writes the result directly into the TanStack Query cache so
+//!      the auth gate flips without relying on supabase's listener.
 
-use keyring::Entry;
 use tauri::{AppHandle, Emitter};
 
+#[cfg(not(target_os = "windows"))]
 const SERVICE: &str = "com.houston.app.auth";
 
-fn entry(key: &str) -> Result<Entry, String> {
-    Entry::new(SERVICE, key).map_err(|e| format!("keyring entry({key}): {e}"))
+/// Reject keys that try to escape the storage directory. Supabase only
+/// ever passes its own well-formed storage keys, but the API surface is
+/// reachable from the webview so we still sanitize.
+fn validate_key(key: &str) -> Result<(), String> {
+    if key.is_empty() {
+        return Err("auth key must not be empty".into());
+    }
+    if key.contains('/') || key.contains('\\') || key.contains("..") || key.contains('\0') {
+        return Err(format!("auth key contains invalid characters: {key:?}"));
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "windows")]
+mod storage {
+    //! DPAPI-encrypted file storage.
+
+    use std::path::PathBuf;
+    use windows_sys::Win32::Foundation::LocalFree;
+    use windows_sys::Win32::Security::Cryptography::{
+        CryptProtectData, CryptUnprotectData, CRYPT_INTEGER_BLOB,
+    };
+
+    fn auth_dir() -> Result<PathBuf, String> {
+        let local =
+            dirs::data_local_dir().ok_or_else(|| "no LocalAppData dir".to_string())?;
+        let dir = local.join("com.houston.app").join("auth");
+        std::fs::create_dir_all(&dir)
+            .map_err(|e| format!("create auth dir {}: {e}", dir.display()))?;
+        Ok(dir)
+    }
+
+    fn file_for(key: &str) -> Result<PathBuf, String> {
+        Ok(auth_dir()?.join(format!("{key}.dpapi")))
+    }
+
+    /// Wrap a slice in a `CRYPT_INTEGER_BLOB` for the duration of the call.
+    /// The blob does not own the data — it borrows the slice's pointer
+    /// for `CryptProtectData` / `CryptUnprotectData`.
+    fn blob_from_slice(bytes: &[u8]) -> CRYPT_INTEGER_BLOB {
+        CRYPT_INTEGER_BLOB {
+            cbData: bytes.len() as u32,
+            pbData: bytes.as_ptr() as *mut u8,
+        }
+    }
+
+    fn encrypt(plaintext: &[u8]) -> Result<Vec<u8>, String> {
+        let mut input = blob_from_slice(plaintext);
+        let mut output = CRYPT_INTEGER_BLOB {
+            cbData: 0,
+            pbData: std::ptr::null_mut(),
+        };
+        let ok = unsafe {
+            CryptProtectData(
+                &mut input,
+                std::ptr::null(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                0,
+                &mut output,
+            )
+        };
+        if ok == 0 {
+            return Err(format!(
+                "CryptProtectData failed (last error {})",
+                unsafe { windows_sys::Win32::Foundation::GetLastError() }
+            ));
+        }
+        let result = unsafe {
+            std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec()
+        };
+        unsafe {
+            LocalFree(output.pbData as _);
+        }
+        Ok(result)
+    }
+
+    fn decrypt(ciphertext: &[u8]) -> Result<Vec<u8>, String> {
+        let mut input = blob_from_slice(ciphertext);
+        let mut output = CRYPT_INTEGER_BLOB {
+            cbData: 0,
+            pbData: std::ptr::null_mut(),
+        };
+        let ok = unsafe {
+            CryptUnprotectData(
+                &mut input,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                0,
+                &mut output,
+            )
+        };
+        if ok == 0 {
+            return Err(format!(
+                "CryptUnprotectData failed (last error {})",
+                unsafe { windows_sys::Win32::Foundation::GetLastError() }
+            ));
+        }
+        let result = unsafe {
+            std::slice::from_raw_parts(output.pbData, output.cbData as usize).to_vec()
+        };
+        unsafe {
+            LocalFree(output.pbData as _);
+        }
+        Ok(result)
+    }
+
+    pub fn get(key: &str) -> Result<Option<String>, String> {
+        let path = file_for(key)?;
+        let ciphertext = match std::fs::read(&path) {
+            Ok(b) => b,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+            Err(e) => return Err(format!("read {}: {e}", path.display())),
+        };
+        let plaintext = decrypt(&ciphertext)?;
+        String::from_utf8(plaintext)
+            .map(Some)
+            .map_err(|e| format!("session blob not utf-8: {e}"))
+    }
+
+    pub fn set(key: &str, value: &str) -> Result<(), String> {
+        let path = file_for(key)?;
+        let ciphertext = encrypt(value.as_bytes())?;
+        // Write to a temp file and atomic-rename into place so a crash
+        // mid-write never leaves a half-encrypted blob that future
+        // decrypt calls would barf on.
+        let tmp = path.with_extension("dpapi.tmp");
+        std::fs::write(&tmp, &ciphertext)
+            .map_err(|e| format!("write {}: {e}", tmp.display()))?;
+        std::fs::rename(&tmp, &path)
+            .map_err(|e| format!("rename {} -> {}: {e}", tmp.display(), path.display()))?;
+        Ok(())
+    }
+
+    pub fn remove(key: &str) -> Result<(), String> {
+        let path = file_for(key)?;
+        match std::fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(format!("remove {}: {e}", path.display())),
+        }
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+mod storage {
+    //! macOS Keychain / generic libsecret storage via the `keyring` crate.
+
+    use keyring::Entry;
+    use super::SERVICE;
+
+    fn entry(key: &str) -> Result<Entry, String> {
+        Entry::new(SERVICE, key).map_err(|e| format!("keyring entry({key}): {e}"))
+    }
+
+    pub fn get(key: &str) -> Result<Option<String>, String> {
+        let e = entry(key)?;
+        match e.get_password() {
+            Ok(v) => Ok(Some(v)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(err) => Err(format!("keyring get({key}): {err}")),
+        }
+    }
+
+    pub fn set(key: &str, value: &str) -> Result<(), String> {
+        let e = entry(key)?;
+        e.set_password(value)
+            .map_err(|err| format!("keyring set({key}): {err}"))
+    }
+
+    pub fn remove(key: &str) -> Result<(), String> {
+        let e = entry(key)?;
+        match e.delete_credential() {
+            Ok(_) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(err) => Err(format!("keyring delete({key}): {err}")),
+        }
+    }
 }
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn auth_get_item(key: String) -> Result<Option<String>, String> {
-    let e = entry(&key)?;
-    match e.get_password() {
-        Ok(v) => Ok(Some(v)),
-        Err(keyring::Error::NoEntry) => Ok(None),
-        Err(err) => Err(format!("keyring get({key}): {err}")),
-    }
+    validate_key(&key)?;
+    storage::get(&key)
 }
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn auth_set_item(key: String, value: String) -> Result<(), String> {
-    let e = entry(&key)?;
-    e.set_password(&value)
-        .map_err(|err| format!("keyring set({key}): {err}"))
+    validate_key(&key)?;
+    storage::set(&key, &value)
 }
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn auth_remove_item(key: String) -> Result<(), String> {
-    let e = entry(&key)?;
-    match e.delete_credential() {
-        Ok(_) | Err(keyring::Error::NoEntry) => Ok(()),
-        Err(err) => Err(format!("keyring delete({key}): {err}")),
-    }
+    validate_key(&key)?;
+    storage::remove(&key)
 }
 
 /// Forward a deep-link URL to the frontend. Called by the tauri-plugin-deep-link
-/// handler installed in `lib.rs`. The frontend extracts the `code` param and
-/// runs `supabase.auth.exchangeCodeForSession(code)`.
+/// handler installed in `lib.rs`. The frontend extracts the `code` (PKCE) or
+/// `access_token` + `refresh_token` (implicit) and installs the session.
 pub fn emit_deep_link(handle: &AppHandle, url: &str) {
     if let Err(e) = handle.emit("auth://deep-link", url) {
         tracing::error!("[auth] failed to emit deep-link event: {e}");
     }
 }
 
-/// Best-effort read of the persisted Supabase session from Keychain, returning
-/// the user_id if present. Called at engine spawn time so the subprocess can
-/// stamp `HOUSTON_APP_USER_ID` on its own operations. Failures (no entry,
-/// corrupt JSON, locked Keychain) all resolve to `None` silently — the engine
-/// runs fine without an identity.
+/// Best-effort read of the persisted Supabase session, returning the user_id
+/// if present. Called at engine spawn time so the subprocess can stamp
+/// `HOUSTON_APP_USER_ID` on its own operations. Failures (no entry, corrupt
+/// JSON, keychain locked, DPAPI ciphertext from a different Windows user)
+/// all resolve to `None` silently — the engine runs fine without an identity.
 pub fn persisted_user_id() -> Option<String> {
     if option_env!("HOUSTON_AUTH_STORAGE_MODE") != Some("keychain") {
         return None;
     }
-
     // Storage key must match `storageKey` in app/src/lib/supabase.ts.
-    let entry = Entry::new(SERVICE, "houston-auth").ok()?;
-    let raw = entry.get_password().ok()?;
+    let raw = storage::get("houston-auth").ok().flatten()?;
     let parsed: serde_json::Value = serde_json::from_str(&raw).ok()?;
     parsed
         .get("user")
@@ -85,6 +269,22 @@ pub fn persisted_user_id() -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn validate_key_rejects_traversal() {
+        assert!(validate_key("../escape").is_err());
+        assert!(validate_key("a/b").is_err());
+        assert!(validate_key("a\\b").is_err());
+        assert!(validate_key("a\0b").is_err());
+        assert!(validate_key("").is_err());
+    }
+
+    #[test]
+    fn validate_key_accepts_supabase_keys() {
+        assert!(validate_key("houston-auth").is_ok());
+        assert!(validate_key("houston-auth-code-verifier").is_ok());
+        assert!(validate_key("houston-auth-local-default").is_ok());
+    }
 
     /// Round-trip set / get / remove against the real Keychain.
     ///

--- a/app/src/components/auth/sign-in-screen.tsx
+++ b/app/src/components/auth/sign-in-screen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from "react";
 import { Button } from "@houston-ai/core";
 import { HoustonLogo } from "../shell/experience-card";
 import { onAuthError, signInWithGoogle } from "../../lib/auth";
+import { reportBug } from "../../lib/bug-report";
 import { logger } from "../../lib/logger";
 
 // Microsoft sign-in is temporarily disabled in the UI while the Azure
@@ -23,6 +24,13 @@ type Provider = "google";
 export function SignInScreen() {
   const [pending, setPending] = useState<Provider | null>(null);
   const [error, setError] = useState<string | null>(null);
+  // "Send logs to support" affordance — for non-technical alpha users
+  // who can't reach the in-app Settings → Report Bug flow because they're
+  // stuck on this screen. Three states: idle / sending / sent.
+  const [logsStatus, setLogsStatus] = useState<"idle" | "sending" | "sent">(
+    "idle",
+  );
+  const [logsIssueId, setLogsIssueId] = useState<string | null>(null);
 
   // Surface OAuth errors that happen AFTER the browser hands off (provider
   // rejection, code-exchange failure, identity already linked to another
@@ -48,6 +56,28 @@ export function SignInScreen() {
       // SignInScreen itself unmounts when the deep-link callback flips the
       // session, so we don't need a "waiting for callback" loading state.
       setPending(null);
+    }
+  };
+
+  const handleSendLogs = async () => {
+    setLogsStatus("sending");
+    try {
+      const issueId = await reportBug({
+        command: "signin_screen_stuck",
+        error:
+          "User reported they are stuck on the sign-in screen and could not reach the in-app Report Bug flow. Logs attached from the SignInScreen send-logs button.",
+        userEmail: null,
+        timestamp: new Date().toISOString(),
+        appVersion: __APP_VERSION__,
+      });
+      setLogsIssueId(issueId);
+      setLogsStatus("sent");
+    } catch (e) {
+      logger.error(`[auth] send-logs failed: ${e}`);
+      setLogsStatus("idle");
+      setError(
+        `Could not send logs automatically: ${e instanceof Error ? e.message : String(e)}. Email them to support manually.`,
+      );
     }
   };
 
@@ -80,6 +110,33 @@ export function SignInScreen() {
         {error && (
           <p className="text-xs text-destructive text-center">{error}</p>
         )}
+
+        {/* Last-resort "send logs" affordance for non-technical alpha users
+         * stuck on this screen. The in-app Settings → Report Bug flow is
+         * unreachable until they're signed in, so we expose the same
+         * report_bug command here with a fixed description. Hardcoded
+         * English / Spanish copy because this whole screen is currently
+         * English-only and adding i18n is its own scope. */}
+        <div className="mt-2 flex flex-col items-center gap-1">
+          {logsStatus === "sent" ? (
+            <p className="text-xs text-muted-foreground text-center">
+              Logs sent to support
+              {logsIssueId ? ` (ref ${logsIssueId})` : ""}. Thanks, we'll
+              follow up.
+            </p>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void handleSendLogs()}
+              disabled={logsStatus === "sending"}
+              className="text-xs text-muted-foreground underline-offset-2 hover:underline disabled:opacity-50"
+            >
+              {logsStatus === "sending"
+                ? "Sending logs..."
+                : "Stuck? Send logs to support / ¿Atascado? Enviar logs a soporte"}
+            </button>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/app/src/components/onboarding/missions/try.tsx
+++ b/app/src/components/onboarding/missions/try.tsx
@@ -35,8 +35,16 @@ import { TryDoneScreen } from "../try-done-screen";
  * Magic word the agent emits to signal "tutorial step done, frontend may
  * advance". Stripped from display via `transformContent`. Detected via a
  * feed scan in `tutorialDone`.
+ *
+ * The detection regex is intentionally lenient: codex's gpt-5.5 sometimes
+ * wraps the token in markdown (`**[TUTORIAL_COMPLETE]**`), escapes the
+ * underscore (`[TUTORIAL\_COMPLETE]`), capitalizes a different way, or
+ * tacks on "D" (`[TUTORIAL_COMPLETED]`). The display-stripping replace
+ * uses the same regex so whatever shape lands gets removed from the
+ * final card.
  */
-const TUTORIAL_END_MARKER = "[TUTORIAL_COMPLETE]";
+const TUTORIAL_END_RE = /\[\s*\\?TUTORIAL[_\s\\]+COMPLETED?\s*\]/i;
+const TUTORIAL_END_STRIP_RE = /\*{0,2}\[\s*\\?TUTORIAL[_\s\\]+COMPLETED?\s*\]\*{0,2}/gi;
 
 interface FrameLabels {
   brandLabel: string;
@@ -154,8 +162,8 @@ export function TryMission({
       const item = (feedItems ?? [])[i];
       if (item.feed_type !== "assistant_text") continue;
       const data = item.data;
-      if (typeof data !== "string" || !data.includes(TUTORIAL_END_MARKER)) continue;
-      return data.replace(TUTORIAL_END_MARKER, "").trim();
+      if (typeof data !== "string" || !TUTORIAL_END_RE.test(data)) continue;
+      return data.replace(TUTORIAL_END_STRIP_RE, "").trim();
     }
     return null;
   }, [feedItems]);
@@ -184,8 +192,8 @@ export function TryMission({
   );
 
   const transformContent = useCallback((content: string) => {
-    if (!content.includes(TUTORIAL_END_MARKER)) return { content };
-    return { content: content.replace(TUTORIAL_END_MARKER, "").trim() };
+    if (!TUTORIAL_END_RE.test(content)) return { content };
+    return { content: content.replace(TUTORIAL_END_STRIP_RE, "").trim() };
   }, []);
 
   // Free-typing path. Wrapped by `useSessionMessageQueue` so messages typed
@@ -240,6 +248,22 @@ export function TryMission({
     if (!missionSessionKey) return;
     tauriChat.stop(agentPath, missionSessionKey).catch(console.error);
   }, [agentPath, missionSessionKey]);
+
+  /**
+   * Escape hatch when the agent stalls and never emits the completion
+   * token — observed real users sitting on step 4 for minutes when codex
+   * + gpt-5.5 wraps the marker in markdown or just decides not to emit
+   * it. Stop the in-flight session so the agent doesn't keep producing
+   * output behind the user's back, then call `onContinue` so the parent
+   * advances to the workspace shell. The `useEffect` cleanup that strips
+   * the tutorial section from CLAUDE.md still runs on unmount.
+   */
+  const handleSkipTutorial = useCallback(() => {
+    if (missionSessionKey) {
+      tauriChat.stop(agentPath, missionSessionKey).catch(console.error);
+    }
+    onContinue();
+  }, [agentPath, missionSessionKey, onContinue]);
 
   // Chip click → `createMission` mints an activity, sends the chip text as
   // the first user prompt, and returns the session key. From then on the
@@ -332,6 +356,18 @@ export function TryMission({
               <p className="mt-2 text-sm text-muted-foreground">
                 {t("setup:tutorial.missions.try.workingBody")}
               </p>
+              {/* Escape hatch — only visible once the mission has started,
+               * so it doesn't compete with the chip CTA on the empty
+               * left panel. Hard-coded EN/ES copy because adding i18n
+               * keys for a single line during a hotfix isn't worth the
+               * locale churn. */}
+              <button
+                type="button"
+                onClick={handleSkipTutorial}
+                className="mt-3 text-xs text-muted-foreground underline-offset-2 hover:underline"
+              >
+                Skip tutorial / Saltar tutorial
+              </button>
             </div>
           )}
           {error && (

--- a/app/src/lib/supabase.ts
+++ b/app/src/lib/supabase.ts
@@ -1,6 +1,7 @@
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 import { invoke } from "@tauri-apps/api/core";
 import { resolveAuthStorageConfig } from "./auth-storage";
+import { logger } from "./logger";
 
 // __SUPABASE_URL__ / __SUPABASE_ANON_KEY__ baked at build time by Vite.
 // Empty values → Supabase client still constructs but all auth calls are
@@ -10,31 +11,46 @@ const KEY = typeof __SUPABASE_ANON_KEY__ !== "undefined" ? __SUPABASE_ANON_KEY__
 
 /**
  * Release storage adapter that round-trips to Rust via the `auth_*` Tauri
- * commands, so Supabase session tokens live in macOS Keychain / Windows
- * Credential Manager, never localStorage or disk. Supabase stores the PKCE
- * code verifier here too during OAuth, so release auth is Keychain-backed.
+ * commands. Sessions live in macOS Keychain or a DPAPI-encrypted file on
+ * Windows (see `app/src-tauri/src/auth.rs`), never localStorage. The PKCE
+ * code verifier is stored here too during OAuth, so release auth is
+ * encrypted-at-rest end to end.
+ *
+ * Errors are NOT silently swallowed (they were until v0.4.15, which is
+ * how Windows users ended up with sessions that worked in-memory but
+ * never persisted to disk — every `setItem` was failing in Credential
+ * Manager and we never told anyone). `setItem` and `removeItem` rethrow
+ * so supabase-js's `_saveSession` surfaces the error up through
+ * `setSession` / `exchangeCodeForSession`, where `app/src/lib/auth.ts`
+ * turns it into a user-visible toast via `emitAuthError`. `getItem`
+ * still returns null on error because "no entry yet" is the common
+ * case and not worth a toast.
  */
 const keychainStorage = {
   async getItem(key: string): Promise<string | null> {
     try {
       return await invoke<string | null>("auth_get_item", { key });
-    } catch {
+    } catch (e) {
+      logger.warn(`[auth] keychain getItem(${key}) failed: ${e}`);
       return null;
     }
   },
   async setItem(key: string, value: string): Promise<void> {
     try {
       await invoke("auth_set_item", { key, value });
-    } catch {
-      // Keychain unavailable — session won't persist across launches, but the
-      // in-memory session on this run still works.
+    } catch (e) {
+      logger.error(`[auth] keychain setItem(${key}) failed: ${e}`);
+      throw new Error(`Sign-in storage failed: ${e}`);
     }
   },
   async removeItem(key: string): Promise<void> {
     try {
       await invoke("auth_remove_item", { key });
-    } catch {
-      // best-effort
+    } catch (e) {
+      logger.warn(`[auth] keychain removeItem(${key}) failed: ${e}`);
+      // Sign-out is best-effort: if we can't clear the keychain entry
+      // the in-memory sign-out still runs, and a future setItem will
+      // overwrite the stale entry.
     }
   },
 };


### PR DESCRIPTION
## Five fixes bundled from real alpha-user reports on v0.4.15

### 1. DPAPI-encrypted file session storage on Windows (the headline fix)

Three real users (\`facturacion@maizkernel.co\`, \`ru.gonza@gmail.com\`, \`jupablo.2593@gmail.com\`) shipped logs with the exact same pattern:

\`\`\`
INITIAL_SESSION (session=null)    ← every app reopen
SIGNED_IN                          ← user signs in with Google
... normal use for ~30-50 min ...
INITIAL_SESSION (session=null)    ← they reopen, session is gone
\`\`\`

Root cause: Windows Credential Manager caps the credential blob at ~2560 bytes; a Supabase session payload (JWT access_token + JWT user object + provider_token + refresh_token) is reliably 3-4 KB. CredWrite returned ERROR_INVALID_PARAMETER, the keyring crate returned Err, and our JS storage adapter swallowed it silently. Sessions worked in-memory, never persisted, every reopen forced a fresh sign-in.

Windows storage now writes per-user DPAPI-encrypted files to \`%LOCALAPPDATA%\com.houston.app\auth\<key>.dpapi\` via CryptProtectData / CryptUnprotectData. No size limit, still bound to the Windows user account. macOS Keychain path unchanged.

### 2. Stop swallowing keychain errors in the JS adapter

\`keychainStorage.setItem\` now throws on Tauri command failure so supabase-js's \`_saveSession\` surfaces the error up through \`setSession\` / \`exchangeCodeForSession\` into our existing \`emitAuthError\` toast. If the new DPAPI path ever fails (LocalAppData inaccessible, etc.) the user sees a real message instead of an invisible loop. This is also how we discovered the original bug had been silently failing for weeks.

### 3. "Send logs to support" button on SignInScreen

The in-app Report Bug flow lives behind sign-in, which is exactly where stuck users can't reach. SignInScreen now has a small "Stuck? Send logs to support / ¿Atascado? Enviar logs a soporte" button under the sign-in CTA that calls the existing \`report_bug\` command with the latest logs. Spanish-speaking alpha users no longer need a PowerShell one-liner.

### 4. "Skip tutorial" button on M3 (Try a mission)

Codex + gpt-5.5 sometimes stalls at the tutorial completion token. Real user "Juan Pablo" sat on step 4 for minutes. New "Skip tutorial / Saltar tutorial" link in the Try mission's left panel, visible once the chat has started, stops the in-flight session and calls \`onContinue()\` to advance to the workspace shell. The useEffect cleanup that strips the tutorial directive from CLAUDE.md still runs on unmount.

### 5. Loosen TUTORIAL_COMPLETE detection

The detector was a strict \`.includes("[TUTORIAL_COMPLETE]")\`. Now it's a regex that accepts the variants gpt-5.5 actually produces: markdown bolding, escaped underscores, whitespace inside brackets, "COMPLETED" instead of "COMPLETE", any casing. The strip regex used for display also matches the same variants so the marker doesn't leak into the final card.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`cargo check --target x86_64-pc-windows-gnu -p houston-app\` clean
- [x] \`cargo check\` on macOS host clean (Keychain path unchanged)
- [ ] Install v0.4.16 MSI on Windows: sign in once, close, reopen — should land on dashboard without re-signing
- [ ] Tutorial chip on M3: if codex stalls, "Skip tutorial" link in left panel exits to workspace shell
- [ ] Stuck on sign-in screen: "Send logs to support" button creates a Linear issue with logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)