### PR TITLE
release: v0.4.16

### DIFF
--- a/.github/release-notes/0.4.16.md
+++ b/.github/release-notes/0.4.16.md
@@ -1,0 +1,27 @@
+## Houston 0.4.16
+
+Five fixes from a tight alpha-feedback loop on v0.4.15 Windows. The big one is **sessions now persist across app close on Windows**.
+
+### Fixed
+
+- **Sessions now persist across app close on Windows.** On v0.4.10 through v0.4.15, every alpha user got forced to sign in again on every single Houston launch. Their session was being installed in supabase's in-memory state on each sign-in, but the write to disk was silently failing under the hood. Root cause is a Windows Credential Manager limit: the credential blob is capped at about 2.5 KB, and a Supabase session payload (the JWT, the user info, the refresh token, the provider token) lands around 3 to 4 KB. CredWrite was returning an error every time, and our storage layer was swallowing it. Houston now writes the session to a per-user, DPAPI-encrypted file under `%LOCALAPPDATA%\com.houston.app\auth\` instead, which has no size limit and still binds the encrypted file to your Windows user account. Sign in once and you stay signed in. macOS Keychain users see no change.
+- **Storage errors are no longer silent.** The same defect above stayed invisible for weeks because our storage layer caught and discarded any failure. It does not anymore: a real toast surfaces if anything goes wrong with reading or writing the encrypted session, so we hear about it the same day instead of weeks later.
+- **"Send logs to support" button on the sign-in screen.** Alpha users who got stuck on sign-in had no way to reach the in-app Report Bug flow (it lives inside Settings, which is behind sign-in). The sign-in screen now has a small "Stuck? Send logs to support / ¿Atascado? Enviar logs a soporte" link that ships the latest logs straight to our support pipeline with a fixed "stuck on sign-in" description. Non-technical users no longer need a PowerShell one-liner to get help.
+- **"Skip tutorial" escape hatch on the Try-a-mission step.** The tutorial relies on the agent emitting a literal `[TUTORIAL_COMPLETE]` token at the end of its structured plan to advance. Codex with gpt-5.5 sometimes wraps the token in markdown, escapes the underscore, or just declines to emit it at all, and users sat on the same screen for minutes. A small "Skip tutorial / Saltar tutorial" link in the left panel of M3 stops the in-flight session and jumps straight into the workspace.
+- **Tutorial completion detector is lenient about formatting.** The detector was a strict literal match. It now accepts every shape gpt-5.5 actually produces: markdown-bolded brackets, escaped underscores, whitespace inside the brackets, "COMPLETED" instead of "COMPLETE", and any casing. The display-stripping pass uses the same lenient regex so the marker never leaks into the final card.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward automatically. The MSI is still not OS-code-signed (SignPath integration is still pending), so expect one SmartScreen "Run anyway" prompt on first install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install. Download the ARM64 MSI manually, uninstall the x64 build first, then install the ARM64 one. Future ARM64 to ARM64 updates apply automatically.
+
+### Note for Windows users upgrading from 0.4.15 or earlier
+
+Your previous session is not migrated. The old Credential Manager entries are abandoned (they never had a complete session to begin with). Sign in once after upgrading and you stay signed in from then on.
+
+### Known limitations
+
+- **Windows MSI not yet OS-code-signed.** SignPath integration still pending. One SmartScreen "Run anyway" click on first install only, both x64 and ARM64.
+- **"Continue with Microsoft" sign-in for Houston itself remains hidden** while we reconcile the Supabase Azure provider with the production callback URL. Google sign-in is unaffected. The Microsoft 365 + Outlook tutorial path is unaffected.
+- **Mobile companion is still beta.** Expect occasional reconnect hiccups. Keep your Mac awake while using it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "chrono",
  "serde",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2393,7 +2393,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2415,11 +2415,12 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "futures-util",
  "hex",
@@ -2439,7 +2440,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -2449,7 +2450,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2467,7 +2468,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2480,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "async-trait",
  "chrono",
@@ -2510,7 +2511,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2522,7 +2523,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2559,7 +2560,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2573,7 +2574,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2584,7 +2585,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2598,7 +2599,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2614,7 +2615,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "houston-agent-files",
  "houston-agents-conversations",
@@ -2632,7 +2633,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "dirs 5.0.1",
  "houston-cli-bundle",
@@ -2644,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2664,7 +2665,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.15"
+version = "0.4.16"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,20 +32,20 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.15", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.15", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.15", path = "app/houston-tauri" }
-houston-events = { version = "0.4.15", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.15", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.15", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.15", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.15", path = "engine/houston-agent-files" }
-houston-ui-events = { version = "0.4.15", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.15", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.15", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.15", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.15", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.15", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.15", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.15", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.15", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.16", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.16", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.16", path = "app/houston-tauri" }
+houston-events = { version = "0.4.16", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.16", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.16", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.16", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.16", path = "engine/houston-agent-files" }
+houston-ui-events = { version = "0.4.16", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.16", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.16", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.16", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.16", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.16", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.16", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.16", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.16", path = "engine/houston-engine-server" }

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.15"
+version = "0.4.16"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.15",
+  "version": "0.4.16",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Summary

v0.4.16 ships the five fixes from #136 — chiefly persistent Windows session storage. Auto-update should sweep every 0.4.10-0.4.15 user forward.

## Test plan

- [x] cargo check + pnpm tsc clean
- [ ] Install MSI on Windows, sign in once, close, reopen → still signed in
- [ ] Tutorial Skip button advances past M3 even if codex stalls

🤖 Generated with [Claude Code](https://claude.com/claude-code)