### PR TITLE
fix(onboarding): missing providers.json keys + cancel-and-retry on stuck Waiting state

### DIFF
--- a/app/src/components/onboarding/missions/brain.tsx
+++ b/app/src/components/onboarding/missions/brain.tsx
@@ -175,6 +175,10 @@ function ProviderCard({
           loginError={loginError}
           onSignIn={() => void handleSignIn()}
           onRefresh={() => void onRefresh()}
+          onCancelWaiting={() => {
+            setLoginLaunched(false);
+            setLoginError(null);
+          }}
         />
       )}
       {selected && connected && (
@@ -243,6 +247,7 @@ function SetupHint({
   loginError,
   onSignIn,
   onRefresh,
+  onCancelWaiting,
 }: {
   provider: ProviderInfo;
   installed: boolean;
@@ -250,6 +255,7 @@ function SetupHint({
   loginError: string | null;
   onSignIn: () => void;
   onRefresh: () => void;
+  onCancelWaiting: () => void;
 }) {
   const { t } = useTranslation(["setup", "providers"]);
   return (
@@ -283,9 +289,23 @@ function SetupHint({
         </Button>
       )}
       {installed && loginLaunched && (
-        <div className="flex items-center gap-2 text-xs text-muted-foreground">
-          <Loader2 className="size-3.5 animate-spin" />
-          <span>{t("providers:setup.waiting")}</span>
+        <div className="flex flex-col gap-1.5">
+          <div className="flex items-center gap-2 text-xs text-muted-foreground">
+            <Loader2 className="size-3.5 animate-spin" />
+            <span>{t("providers:setup.waiting")}</span>
+          </div>
+          {/* Escape hatch — if the user closed the browser or the sign-in
+           * stalled, the only signal the UI had until now was a forever
+           * spinner. Real users hit this and reported being "stuck."
+           * `onCancelWaiting` flips loginLaunched back to false so the
+           * Sign-in button reappears and they can re-launch the flow. */}
+          <button
+            type="button"
+            onClick={onCancelWaiting}
+            className="self-start text-[11px] text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+          >
+            {t("providers:setup.cancelWaiting")}
+          </button>
         </div>
       )}
       {!installed && (

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -1,9 +1,18 @@
 {
   "card": {
     "connected": "Connected",
+    "notConnected": "Not connected",
     "comingSoon": "Coming soon",
     "connectTitle": "Connect {{name}}",
     "signOutTitle": "Sign out of {{name}}"
+  },
+  "setup": {
+    "installHint": "Install the {{cli}} CLI on your machine. Houston will pick it up automatically.",
+    "installGuide": "Install guide",
+    "signInWith": "Sign in with {{provider}}",
+    "waiting": "Waiting for the sign-in to finish in your browser...",
+    "cancelWaiting": "Cancel and try again",
+    "installedCheckAgain": "Already installed? Check again"
   },
   "signOutConfirm": {
     "title": "Sign out of {{provider}}?",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -1,9 +1,18 @@
 {
   "card": {
     "connected": "Conectado",
+    "notConnected": "Sin conexión",
     "comingSoon": "Próximamente",
     "connectTitle": "Conectar {{name}}",
     "signOutTitle": "Cerrar sesión de {{name}}"
+  },
+  "setup": {
+    "installHint": "Instala la CLI de {{cli}} en tu computador. Houston la detecta sola.",
+    "installGuide": "Guía de instalación",
+    "signInWith": "Iniciar sesión con {{provider}}",
+    "waiting": "Esperando a que termines de iniciar sesión en tu navegador...",
+    "cancelWaiting": "Cancelar e intentar de nuevo",
+    "installedCheckAgain": "¿Ya la instalaste? Reintentar"
   },
   "signOutConfirm": {
     "title": "¿Cerrar sesión de {{provider}}?",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -1,9 +1,18 @@
 {
   "card": {
     "connected": "Conectado",
+    "notConnected": "Sem conexão",
     "comingSoon": "Em breve",
     "connectTitle": "Conectar {{name}}",
     "signOutTitle": "Sair de {{name}}"
+  },
+  "setup": {
+    "installHint": "Instale a CLI {{cli}} no seu computador. Houston detecta sozinho.",
+    "installGuide": "Guia de instalação",
+    "signInWith": "Entrar com {{provider}}",
+    "waiting": "Esperando você terminar o login no navegador...",
+    "cancelWaiting": "Cancelar e tentar de novo",
+    "installedCheckAgain": "Já está instalado? Verificar de novo"
   },
   "signOutConfirm": {
     "title": "Sair de {{provider}}?",


### PR DESCRIPTION
## Two alpha-user reports on v0.4.16

### 1. Raw i18n keys leaking into M2 (Brain) onboarding cards

The provider cards were rendering \`card.notConnected\`, \`setup.installHint\`, \`setup.installGuide\`, \`setup.signInWith\`, \`setup.waiting\`, and \`setup.installedCheckAgain\` as literal text — the keys had never been added to \`providers.json\`. Added in en/es/pt with proper \`{{cli}}\` and \`{{provider}}\` placeholders.

### 2. Stuck on "Waiting for sign-in" with no escape

When the user clicks Sign in with codex, the SetupHint replaces the button with a "Waiting for sign-in to finish in your browser" spinner. If they close the browser or the OAuth stalls, there's no way back. Real user reported being stuck. Added a "Cancel and try again" link under the spinner that resets \`loginLaunched=false\` so the Sign-in button reappears.

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm check-locales\` clean
- [ ] M2 in en/es/pt: provider cards render translated copy, no literal keys
- [ ] Click Sign in with codex → close browser → "Cancel and try again" appears → click → Sign-in button re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)