### PR TITLE
fix(windows-arm64): claude-code auto-install was failing because host_platform_key returned 'unknown'

### DIFF
--- a/engine/houston-cli-bundle/src/lib.rs
+++ b/engine/houston-cli-bundle/src/lib.rs
@@ -292,6 +292,16 @@ pub fn host_platform_key() -> &'static str {
     {
         "windows-x64"
     }
+    // Windows ARM64. Required since v0.4.10 shipped the ARM64 MSI — without
+    // this branch the engine binary running natively on Snapdragon /
+    // Surface laptops returns "unknown" here, and houston-claude-installer
+    // bails with `no claude-code URL for platform 'unknown'` instead of
+    // downloading the arm64 claude.exe. cli-deps.json has the URL
+    // (`windows-arm64`), the engine just never asked for it.
+    #[cfg(all(target_os = "windows", target_arch = "aarch64"))]
+    {
+        "windows-arm64"
+    }
     #[cfg(all(target_os = "linux", target_arch = "x86_64"))]
     {
         "linux-x64"
@@ -304,6 +314,7 @@ pub fn host_platform_key() -> &'static str {
         all(target_os = "macos", target_arch = "aarch64"),
         all(target_os = "macos", target_arch = "x86_64"),
         all(target_os = "windows", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "aarch64"),
         all(target_os = "linux", target_arch = "x86_64"),
         all(target_os = "linux", target_arch = "aarch64"),
     )))]
@@ -717,7 +728,7 @@ mod tests {
         // catches regressions on dev machines.
         let k = host_platform_key();
         assert!(
-            matches!(k, "darwin-arm64" | "darwin-x64" | "windows-x64" | "linux-x64" | "linux-arm64"),
+            matches!(k, "darwin-arm64" | "darwin-x64" | "windows-x64" | "windows-arm64" | "linux-x64" | "linux-arm64"),
             "unknown host platform: {k}"
         );
     }


### PR DESCRIPTION
User logs from a real v0.4.16 Windows-on-ARM install:

```
[claude-installer] installing claude-code v2.1.92 (none → 2.1.92)
[claude-installer] install failed: no claude-code URL for platform 'unknown'
```

`host_platform_key()` never had a branch for windows-arm64, so every Windows ARM user since v0.4.10 has been silently failing to download claude.exe. The tutorial card stays on "Install the claude CLI" forever. cli-deps.json has the URL — the engine just never asked. One-line cfg branch fix + test update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)