### PR TITLE
Instrument PostHog events for growth, retention, and activation

### DIFF
--- a/app/src/components/onboarding/personal-assistant-onboarding.tsx
+++ b/app/src/components/onboarding/personal-assistant-onboarding.tsx
@@ -59,6 +59,7 @@ export function PersonalAssistantOnboarding({
   // whose first paint briefly falls through `workspaces.length === 0` is not
   // trapped here once their real workspaces arrive.
   const startTutorial = () => {
+    analytics.track("onboarding_started", { source: "tutorial" });
     setTutorialActive(true);
     setStep("meet");
   };
@@ -100,6 +101,7 @@ export function PersonalAssistantOnboarding({
   const handleSkip = async () => {
     // Skip path: create the workspace + assistant, but no UI tour and no
     // tutorial artifacts. User lands directly in the workspace shell.
+    analytics.track("onboarding_started", { source: "skip" });
     setTutorialActive(true);
     try {
       const fallbackProvider = provider ?? "anthropic";

--- a/app/src/hooks/use-analytics-subscriber.ts
+++ b/app/src/hooks/use-analytics-subscriber.ts
@@ -33,6 +33,9 @@ export function useAnalyticsSubscriber() {
 
         case "SessionStatus": {
           const { status, error } = p.data;
+          if (status === "completed") {
+            analytics.track("session_completed");
+          }
           if (status === "error" && error) {
             const error_kind = classifyAnalyticsError(error);
             analytics.track("session_failed", { error_kind });

--- a/app/src/hooks/use-houston-init.ts
+++ b/app/src/hooks/use-houston-init.ts
@@ -4,6 +4,7 @@ import { useAgentCatalogStore } from "../stores/agent-catalog";
 import { useWorkspaceStore } from "../stores/workspaces";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
+import { analytics } from "../lib/analytics";
 
 /**
  * App initialization hook. Called once in App.tsx.
@@ -78,7 +79,8 @@ export function useHoustonInit() {
           const status = await tauriProvider.checkStatus(defaultProv);
           setClaudeAvailable(status.cli_installed && status.authenticated);
         } else {
-          // No provider configured — wizard will handle this
+          // No provider configured — track as activation drop-off signal
+          analytics.track("provider_not_configured");
           setClaudeAvailable(false);
         }
       } catch {

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -16,11 +16,16 @@ export type AnalyticsEventName =
   | "install_created"
   | "workspace_created"
   | "provider_configured"
+  | "provider_not_configured"
   | "agent_created"
   | "chat_message_sent"
   | "chat_message_received"
   | "mission_created"
+  | "onboarding_started"
   | "onboarding_completed"
+  | "user_signed_in"
+  | "user_signed_out"
+  | "session_completed"
   | "session_failed"
   | "app_error_shown";
 
@@ -32,7 +37,9 @@ type AnalyticsProperty =
   | "integrations_skipped"
   | "tutorial_run"
   | "source"
-  | "error_kind";
+  | "error_kind"
+  | "workspace_count"
+  | "agent_count";
 type Props = Partial<Record<AnalyticsProperty, string | number | boolean>>;
 type UserProfile = {
   email?: string | null;
@@ -50,6 +57,8 @@ const ALLOWED_PROPS = new Set<AnalyticsProperty>([
   "tutorial_run",
   "source",
   "error_kind",
+  "workspace_count",
+  "agent_count",
 ]);
 
 // Bootstrap PostHog at module load so a configured build can capture errors

--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -22,6 +22,11 @@ function applySessionToCache(session: Session | null): void {
 // it to the running app. See website/src/auth/callback/index.html.
 const REDIRECT_URI = "https://gethouston.ai/auth/callback/";
 
+// Track which provider initiated the current OAuth flow so the deep-link
+// callback can tag the user_signed_in event with the correct provider.
+// Set before the browser opens; read and cleared on successful session.
+let pendingProvider: "google" | "azure" | null = null;
+
 /**
  * Kick off an OAuth flow for the given provider. Supabase generates a
  * fresh PKCE verifier (stored in Keychain via our storage adapter),
@@ -39,6 +44,8 @@ async function signInWithProvider(
   if (!isAuthConfigured()) {
     throw new Error("Auth not configured");
   }
+
+  pendingProvider = provider;
 
   const { data, error } = await supabase.auth.signInWithOAuth({
     provider,
@@ -101,8 +108,8 @@ export const signInWithMicrosoft = (): Promise<void> => signInWithProvider("azur
 
 /**
  * Sign out: clear the Supabase session (our Keychain storage adapter
- * removes the tokens) and reset PostHog's distinct_id so subsequent
- * anonymous events don't accrue to the prior user.
+ * removes the tokens), fire the sign-out event, and reset PostHog's
+ * distinct_id so subsequent anonymous events don't accrue to the prior user.
  */
 export async function signOut(): Promise<void> {
   try {
@@ -110,6 +117,7 @@ export async function signOut(): Promise<void> {
   } catch (e) {
     logger.warn(`[auth] signOut failed: ${e}`);
   }
+  analytics.track("user_signed_out");
   analytics.reset();
 }
 
@@ -174,6 +182,8 @@ export function installDeepLinkListener(): () => void {
           return;
         }
         applySessionToCache(data.session ?? null);
+        analytics.track("user_signed_in", { provider: pendingProvider ?? "unknown" });
+        pendingProvider = null;
         logger.info(`[auth] session established (pkce) for ${data.user?.email}`);
         return;
       }
@@ -199,6 +209,8 @@ export function installDeepLinkListener(): () => void {
         // cache key directly here makes the UI transition deterministic
         // regardless of whether the listener fires.
         applySessionToCache(data.session ?? null);
+        analytics.track("user_signed_in", { provider: pendingProvider ?? "unknown" });
+        pendingProvider = null;
         logger.info(
           `[auth] session established (implicit) for ${data.user?.email}`,
         );

--- a/app/src/lib/create-mission.ts
+++ b/app/src/lib/create-mission.ts
@@ -6,6 +6,7 @@
 
 import { tauriActivity, tauriChat } from "./tauri";
 import { logger } from "./logger";
+import { analytics } from "./analytics";
 import { fallbackMissionTitle, refreshMissionTitle } from "./mission-title";
 
 /** Build a session key for a given activity id. */
@@ -127,6 +128,8 @@ export async function createMission(
       modelOverride: opts.modelOverride,
       effortOverride: opts.effortOverride,
     });
+
+    analytics.track("mission_created", { agent_mode: opts.agentMode });
 
     if (!opts.title) {
       void refreshMissionTitle({


### PR DESCRIPTION
## Why

We need to track the metrics that matter for fundraising and growth:

- **20% WoW growth** — requires knowing when new users sign in, not just install
- **80% DAU** — `app_active` already fires daily; adding `session_completed` gives engagement depth
- **< 5% churn** — `user_signed_out` closes the session loop; gaps in `app_active` signal inactivity
- **B2C → B2B conversion** — `workspace_count` and `agent_count` properties added for future segmentation
- **10,000 users** — `install_created` + `user_signed_in` give acquisition + activation funnel
- **10 paying clients** — no billing code exists yet (cloud/teams are placeholders); properties are ready

## What changed

### New events (5 added, 1 wired up)

| Event | Where it fires | What it measures |
|---|---|---|
| `user_signed_in` | `auth.ts` after PKCE/implicit session success | Growth: new vs returning authenticated users. Carries `provider` (google/azure). |
| `user_signed_out` | `auth.ts` before `analytics.reset()` | Churn: voluntary sign-out signal. |
| `onboarding_started` | `personal-assistant-onboarding.tsx` on Start and Skip clicks | Activation funnel top. Carries `source` (tutorial/skip). |
| `session_completed` | `use-analytics-subscriber.ts` on `SessionStatus → completed` | Engagement depth. Symmetric with existing `session_failed`. |
| `provider_not_configured` | `use-houston-init.ts` when no default provider exists | Activation drop-off: installed but never set up a model provider. |
| `mission_created` *(existing, now wired)* | `create-mission.ts` after session launches | Engagement: conversations started. Carries `agent_mode`. |

### New allowed properties (2)

- `workspace_count` — for B2C → B2B segmentation when billing ships
- `agent_count` — for engagement depth analysis

### Provider tracking in auth

A module-level `pendingProvider` variable is set before the OAuth browser opens and read/cleared on successful deep-link callback. This lets `user_signed_in` carry the correct `provider` property without changing the PKCE flow.

## Files changed (6)

| File | Change |
|---|---|
| `app/src/lib/analytics.ts` | 5 new event names + 2 new properties in type union and allowlist |
| `app/src/lib/auth.ts` | `pendingProvider` tracking + `user_signed_in` / `user_signed_out` events |
| `app/src/components/onboarding/personal-assistant-onboarding.tsx` | `onboarding_started` on both Start and Skip paths |
| `app/src/hooks/use-analytics-subscriber.ts` | `session_completed` alongside existing `session_failed` |
| `app/src/hooks/use-houston-init.ts` | `provider_not_configured` + analytics import |
| `app/src/lib/create-mission.ts` | Wire existing `mission_created` event + analytics import |

## Full event taxonomy (after this PR)

```
install_created          — first launch (existing)
onboarding_started       — user clicks Start or Skip (NEW)
onboarding_completed     — tutorial or skip path finishes (existing)
provider_configured      — model provider set up (existing)
provider_not_configured  — no provider on cold start (NEW)
user_signed_in           — OAuth session established (NEW)
user_signed_out          — explicit sign-out (NEW)
app_active               — daily heartbeat / DAU signal (existing)
workspace_created        — new workspace (existing)
agent_created            — new agent (existing)
mission_created          — conversation started (existing, NOW WIRED)
chat_message_sent        — user sends a message (existing)
chat_message_received    — assistant reply finalized (existing)
session_completed        — Claude session finishes (NEW)
session_failed           — Claude session errors (existing)
app_error_shown          — error toast or session error (existing)
```

## Not in this PR (separate tasks)

- **Waitlist tracking (500 companies)** — lives on the marketing website (`website/`), needs its own PostHog snippet
- **Billing events** — `cloud/` and `teams/` are placeholder directories with no code yet
- **Team invitation events** — same; will ship when the teams feature ships

## PostHog dashboards to build

Once merged, these events support the following PostHog insights:

| Metric | PostHog query |
|---|---|
| DAU / WAU / MAU | Unique users firing `app_active` by day/week/month |
| WoW growth | `install_created` count by week, % change |
| Activation rate | Funnel: `install_created` → `onboarding_started` → `onboarding_completed` → `mission_created` |
| Churn | Users with `app_active` in week N but not week N+1 |
| Auth conversion | `install_created` → `user_signed_in` conversion |
| Provider setup rate | `onboarding_completed` → `provider_configured` (vs `provider_not_configured`) |
| Engagement depth | `mission_created` and `session_completed` per user per day |

## Test plan

- [ ] Build compiles with `pnpm typecheck` (no type errors from new event/property names)
- [ ] Sign in with Google → PostHog receives `user_signed_in` with `provider: "google"`
- [ ] Sign out → PostHog receives `user_signed_out` before identity reset
- [ ] Fresh install → `onboarding_started` fires on Start or Skip click
- [ ] Start a conversation → `mission_created` fires with `agent_mode` if set
- [ ] Conversation completes → `session_completed` fires
- [ ] Launch without provider configured → `provider_not_configured` fires