### PR TITLE
fix(integrations): route through composio.dev fragment + add gpt-5.5-codex

### DIFF
--- a/app/src/components/tabs/connected-apps-section.tsx
+++ b/app/src/components/tabs/connected-apps-section.tsx
@@ -72,7 +72,15 @@ interface AppInfo {
 }
 
 function composioAppUrl(toolkit: string): string {
-  return `https://dashboard.composio.dev/~/connect/apps/${toolkit}`;
+  // Route through Composio's marketing site with the Houston-tagged
+  // fragment instead of `dashboard.composio.dev/~/connect/apps/<toolkit>`.
+  // The bare-dashboard URL relies on `~` resolving to the user's default
+  // workspace, which was observed not to work for at least one alpha
+  // user (Composio routed them to a workspace-less page that does
+  // nothing). The marketing-site URL is the same one the tutorial chat
+  // card emits and it goes through Composio's auth → user's workspace
+  // → connect-app routing, which works reliably.
+  return `https://composio.dev/#houston_toolkit=${toolkit}`;
 }
 
 

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -25,10 +25,26 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     installUrl: "https://github.com/openai/codex",
     loginCommand: "codex login",
     cost: "Your ChatGPT subscription",
+    // `gpt-5.5-codex` is the default — it is tuned for the agent / tool-use
+    // workload Houston actually runs (the tutorial reads calendar + mail,
+    // drafts emails, edits files, etc.) and is the model the codex CLI was
+    // built around. The vanilla `gpt-5.5` stays available for users who
+    // want it for chat-style tasks where coding-tuned behavior is less
+    // helpful, but the picker (and the tutorial via `defaultModel`)
+    // start on codex.
     models: [
-      { id: "gpt-5.5", label: "GPT-5.5", description: "Flagship. Best reasoning and tool use." },
+      {
+        id: "gpt-5.5-codex",
+        label: "GPT-5.5 Codex",
+        description: "Tuned for coding and agent tool use. Best for Houston's tutorial flow.",
+      },
+      {
+        id: "gpt-5.5",
+        label: "GPT-5.5",
+        description: "Flagship general model. Best for plain chat and reasoning.",
+      },
     ],
-    defaultModel: "gpt-5.5",
+    defaultModel: "gpt-5.5-codex",
   },
   {
     id: "anthropic",


### PR DESCRIPTION
## 1. Integrations tab Composio URL

`connected-apps-section.tsx` was opening `https://dashboard.composio.dev/~/connect/apps/<toolkit>` for the "open this app" button. The `~` placeholder was supposed to resolve to the user's default Composio workspace but doesn't work in practice — real user landed on a workspace-less page that does nothing. The working URL has the workspace name explicitly in the path (`dashboard.composio.dev/<workspace>/~/connect/apps/...`), which we don't know client-side.

Fix: route through the marketing-site URL the tutorial chat card already uses (`composio.dev/#houston_toolkit=<slug>`). Composio's marketing site does the workspace routing for us.

## 2. OpenAI gets gpt-5.5-codex as the new default

OpenAI provider now exposes two models in the picker:

- **GPT-5.5 Codex** (default) — tuned for coding / agent tool use. Better fit for Houston's tutorial flow (calendar + mail + draft replies + file edits).
- **GPT-5.5** — flagship general model. For users who prefer the chat-style behavior.

Codex is the default so the tutorial picks it automatically when the user chooses OpenAI in M2.

## Test plan

- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm check-locales` clean
- [ ] Integrations tab: click any app → opens `composio.dev/#houston_toolkit=<slug>` → Composio routes user to their workspace → connect page works
- [ ] M2 onboarding: pick OpenAI → model picker shows both options, codex is selected
- [ ] Tutorial mission with OpenAI: agent runs on `gpt-5.5-codex`

🤖 Generated with [Claude Code](https://claude.com/claude-code)