### PR TITLE
fix(windows+files): "New files" section + clickable file links work for md and on Windows

### DIFF
--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -21,7 +21,8 @@ import {
   useUpdateActivity,
 } from "../../hooks/queries";
 import { useAgentChatPanel } from "../use-agent-chat-panel";
-import { tauriActivity, tauriChat, tauriAttachments, tauriSystem, tauriWorktree, tauriShell, tauriTerminal, tauriConfig, tauriPreferences } from "../../lib/tauri";
+import { tauriActivity, tauriChat, tauriAttachments, tauriWorktree, tauriShell, tauriTerminal, tauriConfig, tauriPreferences } from "../../lib/tauri";
+import { openAgentHref } from "../../lib/open-href";
 import { createMission } from "../../lib/create-mission";
 import { formatVisibleMessageText } from "../../lib/queued-chat";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
@@ -78,9 +79,12 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
     (message: string) => addToast({ title: message }),
     [addToast],
   );
-  const handleOpenLink = useCallback((url: string) => {
-    tauriSystem.openUrl(url).catch(console.error);
-  }, []);
+  const handleOpenLink = useCallback(
+    (url: string) => {
+      openAgentHref(url, path);
+    },
+    [path],
+  );
 
   const openerRef = useRef<NewPanelOpener | null>(null);
   const emptyAutoOpenKeyRef = useRef<string | null>(null);

--- a/app/src/components/tabs/chat-tab.tsx
+++ b/app/src/components/tabs/chat-tab.tsx
@@ -18,7 +18,8 @@ import { useWorkspaceStore } from "../../stores/workspaces";
 import { useDraftStore, useDraftText, useDraftFiles } from "../../stores/drafts";
 import { isActiveSessionStatus, useSessionStatus } from "../../stores/session-status";
 import { useSessionMessageQueue } from "../../hooks/use-session-message-queue";
-import { tauriChat, tauriAttachments, tauriSystem, tauriConfig } from "../../lib/tauri";
+import { tauriChat, tauriAttachments, tauriConfig } from "../../lib/tauri";
+import { openAgentHref } from "../../lib/open-href";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { useFileToolRenderer } from "../../hooks/use-file-tool-renderer";
 import { useConnectedToolkits, useConnections } from "../../hooks/queries";
@@ -147,9 +148,12 @@ export default function ChatTab({ agent }: TabProps) {
     }
   }, [sessionStatus]);
 
-  const handleOpenLink = useCallback((url: string) => {
-    tauriSystem.openUrl(url).catch(console.error);
-  }, []);
+  const handleOpenLink = useCallback(
+    (url: string) => {
+      openAgentHref(url, agentPath);
+    },
+    [agentPath],
+  );
 
   // Connection state for inline Composio connect cards. Only query
   // when the user is signed in — otherwise the CLI call will fail.

--- a/app/src/components/turn-file-summary.tsx
+++ b/app/src/components/turn-file-summary.tsx
@@ -160,9 +160,16 @@ function semanticIcon(kind: SemanticUpdateKind) {
   return Lightbulb;
 }
 
+/** Last path segment, separator-agnostic. See `turn-summary-items.ts`
+ * for why `.split("/")` alone is wrong on Windows. */
+function fileNameOf(path: string): string {
+  const segments = path.split(/[\\/]/);
+  return segments[segments.length - 1] || path;
+}
+
 function itemIcon(item: TurnSummaryItem) {
   if (item.kind === "semantic") return semanticIcon(item.update);
-  const fileName = item.path.split("/").pop() ?? item.path;
+  const fileName = fileNameOf(item.path);
   const ext = fileName.includes(".")
     ? fileName.split(".").pop()?.toLowerCase()
     : undefined;
@@ -175,5 +182,5 @@ function itemLabel(item: TurnSummaryItem, t: TFunction<"chat">): string {
     if (item.update === "skills") return t("summary.skillsUpdated");
     return t("summary.learningsUpdated");
   }
-  return item.path.split("/").pop() ?? item.path;
+  return fileNameOf(item.path);
 }

--- a/app/src/lib/open-href.ts
+++ b/app/src/lib/open-href.ts
@@ -1,0 +1,58 @@
+import { tauriFiles, tauriSystem } from "./tauri";
+import { logger } from "./logger";
+
+/**
+ * Open a link the agent emitted in chat. Two shapes land here:
+ *
+ *   1. Absolute URLs — `https://...`, `http://...`, `mailto:...`, `houston://...`,
+ *      `composio.dev/#houston_toolkit=...`, etc. These go to the system
+ *      browser via `tauriSystem.openUrl`.
+ *
+ *   2. Relative or bare paths — e.g. `perfil.md`, `subfolder/output.docx`,
+ *      `./report.pdf`. The agent's prompt structure encourages it to drop
+ *      these straight after writing a file. They are NOT URLs; calling
+ *      `openUrl("perfil.md")` on Windows silently does nothing
+ *      (a real user reported "perfil.md pill doesn't open"). Resolve
+ *      them against the current agent's working directory via
+ *      `tauriFiles.open`, which goes through the engine's
+ *      `open_file_in_agent` route and ends up at the OS's
+ *      default-app handler.
+ *
+ * The detection is "does it look like a URL" — anything with a scheme
+ * (`<word>:`) or starting with `//` is treated as a URL. Everything
+ * else is a path.
+ */
+export function openAgentHref(href: string, agentPath: string): void {
+  const trimmed = href.trim();
+  if (!trimmed) return;
+  if (looksLikeUrl(trimmed)) {
+    tauriSystem.openUrl(trimmed).catch((e) => {
+      logger.warn(`[open-href] openUrl(${trimmed}) failed: ${e}`);
+    });
+    return;
+  }
+  tauriFiles.open(agentPath, trimmed).catch((e) => {
+    logger.warn(`[open-href] openFile(${trimmed}) failed: ${e}`);
+  });
+}
+
+function looksLikeUrl(value: string): boolean {
+  if (value.startsWith("//")) return true;
+  // Scheme: a leading run of letters / digits / + - . followed by `:`.
+  // Catches http, https, mailto, file, houston (deep-link), composio://,
+  // etc. without false-positiving on Windows-style `C:\...` paths
+  // because `C:` is followed by `\`, not by a non-`/`-non-`\` payload
+  // — we additionally require a `/` immediately after the colon OR
+  // a non-path-separator character (e.g. `mailto:user@example.com`).
+  const schemeMatch = /^([a-zA-Z][a-zA-Z0-9+\-.]*):(.+)/.exec(value);
+  if (!schemeMatch) return false;
+  const rest = schemeMatch[2];
+  // Windows drive paths look like `C:\foo` or `C:/foo`. Both have a
+  // path separator immediately after the colon. Treat as path, not URL.
+  if (rest.startsWith("\\")) return false;
+  // `c:/foo` is ambiguous — could be a Windows path or a single-letter
+  // custom scheme. We side with "path" because no real Houston-emitted
+  // scheme is one letter.
+  if (rest.startsWith("/") && schemeMatch[1].length === 1) return false;
+  return true;
+}

--- a/app/src/lib/turn-summary-items.ts
+++ b/app/src/lib/turn-summary-items.ts
@@ -16,21 +16,48 @@ const FILE_TOOLS = new Set(["Write", "Edit", "MultiEdit"]);
 const USER_FILE_EXTENSIONS = new Set([
   "docx", "doc", "xlsx", "xls", "pptx", "ppt", "pdf", "png", "jpg", "jpeg",
   "svg", "gif", "txt", "rtf", "csv",
+  // Plain-text formats agents routinely write as user-visible output. `md`
+  // is the one that prompted this: a real user reported a `perfil.md`
+  // from the agent never showed up in the "New files" section because md
+  // wasn't on this allowlist (it was rejected on every OS, the Windows
+  // separator bugs just made it harder to notice).
+  "md", "markdown", "html", "json", "yaml", "yml",
 ]);
 
 function shortName(name: string): string {
   return name.includes("__") ? name.split("__").pop()! : name;
 }
 
+/**
+ * Path separators on Windows are `\`; on macOS / Linux they're `/`. The
+ * engine emits absolute paths in the native separator of the host
+ * (`C:\Users\jul\.houston\…\perfil.md` on Windows, `/Users/jul/…` on Mac),
+ * so any code that did `path.split("/").pop()` to get a filename
+ * returned the WHOLE path on Windows — that's why the "New files"
+ * section never rendered correctly and CLAUDE.md / SKILL.md never
+ * classified as semantic updates. Use this helper everywhere a
+ * separator-aware split is needed.
+ */
+function fileNameOf(path: string): string {
+  const segments = path.split(/[\\/]/);
+  return segments[segments.length - 1] || path;
+}
+
+/** Replace `\` with `/` so prefix comparisons work regardless of OS. */
+function toPosixSeparator(path: string): string {
+  return path.replace(/\\/g, "/");
+}
+
 function normalizePath(path: string, agentPath: string): string {
-  const trimmed = path.trim();
-  if (trimmed.startsWith(`${agentPath}/`)) return trimmed.slice(agentPath.length + 1);
+  const trimmed = toPosixSeparator(path.trim());
+  const root = toPosixSeparator(agentPath);
+  if (trimmed.startsWith(`${root}/`)) return trimmed.slice(root.length + 1);
   return trimmed;
 }
 
 function classifyPath(path: string, agentPath: string): SemanticUpdateKind | null {
   const relative = normalizePath(path, agentPath).toLowerCase();
-  const fileName = relative.split("/").pop() ?? relative;
+  const fileName = fileNameOf(relative);
 
   if (fileName === "claude.md" || fileName === "agents.md") return "instructions";
   if (relative === ".houston/learnings/learnings.json") return "learnings";
@@ -42,7 +69,7 @@ function classifyPath(path: string, agentPath: string): SemanticUpdateKind | nul
 }
 
 export function isUserVisibleFilePath(path: string): boolean {
-  const fileName = path.split("/").pop() ?? path;
+  const fileName = fileNameOf(path);
   const ext = fileName.includes(".") ? fileName.split(".").pop()?.toLowerCase() : "";
   return Boolean(ext && USER_FILE_EXTENSIONS.has(ext));
 }


### PR DESCRIPTION
Real user report: agent writes `perfil.md`, gives a clickable pill in chat, click does nothing, file does not appear in the "New files" section. Three independent bugs:

1. `.md` (and `html`/`json`/`yaml`) were never in `USER_FILE_EXTENSIONS` — filtered out on every OS.
2. `path.split("/").pop()` and `startsWith(agentPath + "/")` are wrong on Windows. Every consumer of file-change paths in `turn-summary-items.ts` and `turn-file-summary.tsx` broke. New `fileNameOf()` + `toPosixSeparator()` helpers handle both separators.
3. Relative file links (`[perfil.md](perfil.md)`) were going to `tauriSystem.openUrl(href)` which is a no-op on a relative path. New `openAgentHref(href, agentPath)` helper routes scheme-less hrefs to `tauriFiles.open(agentPath, path)` instead. Wired into chat-tab + board-tab handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)