### PR TITLE
feat(settings): show app version at bottom of settings sidebar

### DIFF
--- a/app/src/components/settings/settings-view.tsx
+++ b/app/src/components/settings/settings-view.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { Spinner } from "@houston-ai/core";
 import { User, Smartphone, Folder, Bot, Bug } from "lucide-react";
 import { useWorkspaceStore } from "../../stores/workspaces";
+import { useUIStore } from "../../stores/ui";
 import {
   SidebarSectionNav,
   type SidebarSectionItem,
@@ -28,6 +29,20 @@ export function SettingsView() {
   const { t } = useTranslation(["settings", "common"]);
   const currentWorkspace = useWorkspaceStore((s) => s.current);
   const accountAvailable = useAccountAvailable();
+  const addToast = useUIStore((s) => s.addToast);
+
+  async function handleVersionClick() {
+    try {
+      await navigator.clipboard.writeText(__APP_VERSION__);
+      addToast({ title: t("settings:toasts.versionCopied") });
+    } catch (err) {
+      addToast({
+        title: t("settings:toasts.versionCopyFailed"),
+        description: err instanceof Error ? err.message : String(err),
+        variant: "error",
+      });
+    }
+  }
 
   const items = useMemo<SidebarSectionItem<SettingsSectionId>[]>(() => {
     const list: SidebarSectionItem<SettingsSectionId>[] = [];
@@ -66,9 +81,13 @@ export function SettingsView() {
         active={activeVisible}
         onSelect={setActive}
         footer={
-          <span className="text-xs text-muted-foreground px-2.5">
+          <button
+            type="button"
+            onClick={() => void handleVersionClick()}
+            className="text-xs text-muted-foreground px-2.5 hover:text-foreground transition-colors cursor-pointer"
+          >
             {t("settings:version", { version: __APP_VERSION__ })}
-          </span>
+          </button>
         }
       />
       <div className="flex-1 overflow-y-auto">

--- a/app/src/components/settings/settings-view.tsx
+++ b/app/src/components/settings/settings-view.tsx
@@ -65,6 +65,11 @@ export function SettingsView() {
         items={items}
         active={activeVisible}
         onSelect={setActive}
+        footer={
+          <span className="text-xs text-muted-foreground px-2.5">
+            {t("settings:version", { version: __APP_VERSION__ })}
+          </span>
+        }
       />
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto max-w-xl px-8 py-10">

--- a/app/src/components/shared/sidebar-section-nav.tsx
+++ b/app/src/components/shared/sidebar-section-nav.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from "react";
 import type { LucideIcon } from "lucide-react";
 import { Badge } from "@houston-ai/core";
 
@@ -14,6 +15,7 @@ interface SidebarSectionNavProps<Id extends string> {
   items: SidebarSectionItem<Id>[];
   active: Id;
   onSelect: (id: Id) => void;
+  footer?: ReactNode;
   className?: string;
 }
 
@@ -22,12 +24,13 @@ export function SidebarSectionNav<Id extends string>({
   items,
   active,
   onSelect,
+  footer,
   className,
 }: SidebarSectionNavProps<Id>) {
   return (
     <nav
       aria-label={ariaLabel}
-      className={`relative w-56 shrink-0 px-3 py-6 overflow-y-auto before:absolute before:right-0 before:top-4 before:bottom-0 before:w-px before:bg-border ${className ?? ""}`}
+      className={`relative w-56 shrink-0 px-3 py-6 overflow-y-auto flex flex-col before:absolute before:right-0 before:top-4 before:bottom-0 before:w-px before:bg-border ${className ?? ""}`}
     >
       <ul className="flex flex-col gap-0.5">
         {items.map((item) => {
@@ -62,6 +65,7 @@ export function SidebarSectionNav<Id extends string>({
           );
         })}
       </ul>
+      {footer && <div className="mt-auto pt-4">{footer}</div>}
     </nav>
   );
 }

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -82,6 +82,8 @@
   "toasts": {
     "workspaceRenamed": "Workspace renamed",
     "providerSwitched": "Switched to {{provider}} ({{model}})",
-    "timezoneSet": "Timezone set to {{zone}}"
+    "timezoneSet": "Timezone set to {{zone}}",
+    "versionCopied": "Version copied",
+    "versionCopyFailed": "Couldn't copy version"
   }
 }

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -78,6 +78,7 @@
       "errorTitle": "Couldn't send report"
     }
   },
+  "version": "Version {{version}}",
   "toasts": {
     "workspaceRenamed": "Workspace renamed",
     "providerSwitched": "Switched to {{provider}} ({{model}})",

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -82,6 +82,8 @@
   "toasts": {
     "workspaceRenamed": "Espacio de trabajo renombrado",
     "providerSwitched": "Cambiaste a {{provider}} ({{model}})",
-    "timezoneSet": "Zona horaria establecida en {{zone}}"
+    "timezoneSet": "Zona horaria establecida en {{zone}}",
+    "versionCopied": "Versión copiada",
+    "versionCopyFailed": "No se pudo copiar la versión"
   }
 }

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -78,6 +78,7 @@
       "errorTitle": "No se pudo enviar el reporte"
     }
   },
+  "version": "Versión {{version}}",
   "toasts": {
     "workspaceRenamed": "Espacio de trabajo renombrado",
     "providerSwitched": "Cambiaste a {{provider}} ({{model}})",

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -82,6 +82,8 @@
   "toasts": {
     "workspaceRenamed": "Espaço de trabalho renomeado",
     "providerSwitched": "Mudou para {{provider}} ({{model}})",
-    "timezoneSet": "Fuso horário definido como {{zone}}"
+    "timezoneSet": "Fuso horário definido como {{zone}}",
+    "versionCopied": "Versão copiada",
+    "versionCopyFailed": "Não foi possível copiar a versão"
   }
 }

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -78,6 +78,7 @@
       "errorTitle": "Não foi possível enviar o reporte"
     }
   },
+  "version": "Versão {{version}}",
   "toasts": {
     "workspaceRenamed": "Espaço de trabalho renomeado",
     "providerSwitched": "Mudou para {{provider}} ({{model}})",

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -36,7 +36,7 @@ export default defineConfig(({ mode }) => {
   return {
     plugins: [react(), tailwindcss()],
     define: {
-      __APP_VERSION__: JSON.stringify(version),
+      __APP_VERSION__: JSON.stringify(mode === "production" ? version : `${version}-dev`),
       __POSTHOG_KEY__: JSON.stringify(env.POSTHOG_KEY ?? ""),
       __POSTHOG_HOST__: JSON.stringify(
         env.POSTHOG_HOST ?? "https://us.i.posthog.com",


### PR DESCRIPTION
Adds a version label at the bottom of the settings nav sidebar so it is always visible regardless of which section is active. In dev mode the label reads "Version x.y.z-dev"; production builds show "Version x.y.z".

- SidebarSectionNav gains an optional footer prop (ReactNode, mt-auto)
- settings-view passes the version string via t("settings:version")
- vite.config appends "-dev" suffix when mode !== "production"
- i18n: version key added to en/es/pt settings namespaces

## Screenshot

<img width="1745" height="1026" alt="image" src="https://github.com/user-attachments/assets/a9e886a9-89e4-4473-a645-fe9106519109" />
