### PR TITLE
fix(auth): suppress bogus "Something got stuck" card on claude 401 (HOU-214)

### DIFF
--- a/engine/houston-terminal-manager/src/cli_process.rs
+++ b/engine/houston-terminal-manager/src/cli_process.rs
@@ -136,7 +136,7 @@ pub(crate) async fn run_cli_process(
                 let _ = tx.send(SessionUpdate::Status(SessionStatus::Completed));
                 CliRunOutcome::Completed
             } else {
-                handle_failed_exit(tx, cli_name, provider, &stderr_lines)
+                handle_failed_exit(tx, cli_name, provider, &stderr_lines, &stdout_report)
             }
         }
         Err(e) => {
@@ -153,6 +153,7 @@ fn handle_failed_exit(
     cli_name: &str,
     provider: Provider,
     stderr_lines: &[String],
+    stdout_report: &session_io::StdoutReadReport,
 ) -> CliRunOutcome {
     if provider == Provider::OpenAI
         && stderr_lines
@@ -163,7 +164,12 @@ fn handle_failed_exit(
         return CliRunOutcome::CodexResumeMissing;
     }
 
-    let has_auth_error = stderr_lines.iter().any(|l| is_auth_error(l));
+    // Claude reports 401s as a JSON `result` event on stdout, not stderr.
+    // Without checking stdout_report.saw_auth_error here, stderr is empty
+    // and we'd fall through to the "no stderr output captured"
+    // ToolRuntimeError card on top of the legitimate AuthRequired UI.
+    let has_auth_error =
+        stdout_report.saw_auth_error || stderr_lines.iter().any(|l| is_auth_error(l));
     if has_auth_error {
         let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(
             "Authentication expired — sign in again to continue".to_string(),
@@ -212,4 +218,69 @@ fn configure_process_group(_cmd: &mut Command) {}
 #[cfg(unix)]
 extern "C" {
     fn setpgid(pid: i32, pgid: i32) -> i32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::SessionStatus;
+
+    fn drain(rx: &mut mpsc::UnboundedReceiver<SessionUpdate>) -> Vec<SessionUpdate> {
+        let mut out = Vec::new();
+        while let Ok(u) = rx.try_recv() {
+            out.push(u);
+        }
+        out
+    }
+
+    #[test]
+    fn claude_stdout_auth_error_skips_tool_runtime_error() {
+        // Claude 401: empty stderr, stdout reported an auth SystemMessage.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let stdout_report = session_io::StdoutReadReport {
+            malformed_provider_json: false,
+            saw_auth_error: true,
+        };
+
+        let outcome =
+            handle_failed_exit(&tx, "claude", Provider::Anthropic, &[], &stdout_report);
+        assert_eq!(outcome, CliRunOutcome::Failed);
+
+        let updates = drain(&mut rx);
+        assert!(
+            !updates.iter().any(|u| matches!(
+                u,
+                SessionUpdate::Feed(FeedItem::ToolRuntimeError { .. })
+            )),
+            "should not emit ToolRuntimeError when auth was seen on stdout: {updates:?}"
+        );
+        assert!(
+            updates.iter().any(|u| matches!(
+                u,
+                SessionUpdate::Status(SessionStatus::Error(msg))
+                    if msg.to_lowercase().contains("authentication expired")
+            )),
+            "should emit auth-expired status error: {updates:?}"
+        );
+    }
+
+    #[test]
+    fn empty_stderr_without_auth_signal_still_emits_tool_runtime_error() {
+        // Pre-existing behaviour: genuine empty-stderr failures keep the
+        // "no stderr output captured" diagnostic so we don't silently lose
+        // the failure signal.
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        let stdout_report = session_io::StdoutReadReport::default();
+
+        let outcome =
+            handle_failed_exit(&tx, "claude", Provider::Anthropic, &[], &stdout_report);
+        assert_eq!(outcome, CliRunOutcome::Failed);
+
+        let updates = drain(&mut rx);
+        assert!(updates.iter().any(|u| matches!(
+            u,
+            SessionUpdate::Feed(FeedItem::ToolRuntimeError { details, .. })
+                if details == "no stderr output captured"
+        )));
+    }
 }

--- a/engine/houston-terminal-manager/src/session_io.rs
+++ b/engine/houston-terminal-manager/src/session_io.rs
@@ -2,6 +2,7 @@ use super::codex_parser;
 use super::parser;
 use super::stderr_filter::{stderr_feed_item, StderrState};
 use super::types::{FeedItem, Provider};
+use crate::auth_error::is_auth_error;
 use crate::provider_error::is_malformed_provider_json_error;
 use crate::session_update::SessionUpdate;
 use tokio::io::{AsyncBufReadExt, BufReader};
@@ -10,6 +11,12 @@ use tokio::sync::mpsc;
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct StdoutReadReport {
     pub malformed_provider_json: bool,
+    /// True when the provider CLI surfaced an auth failure on stdout (e.g.
+    /// claude's `{"type":"result","is_error":true,"result":"... 401 ..."}`
+    /// event). stderr is empty in that case, so without this flag the
+    /// failed-exit path would emit a generic "no stderr output captured"
+    /// ToolRuntimeError on top of the legitimate AuthRequired reconnect UI.
+    pub saw_auth_error: bool,
 }
 
 /// Read all stderr lines, emitting only user-actionable feed items.
@@ -43,10 +50,7 @@ pub async fn read_stdout_events(
 ) -> StdoutReadReport {
     match provider {
         Provider::Anthropic => read_claude_stdout(stdout, tx).await,
-        Provider::OpenAI => {
-            read_codex_stdout(stdout, tx).await;
-            StdoutReadReport::default()
-        }
+        Provider::OpenAI => read_codex_stdout(stdout, tx).await,
     }
 }
 
@@ -74,6 +78,7 @@ async fn read_claude_stdout(
             continue;
         }
         let items = parser::parse_event(&line, &mut acc);
+        mark_auth_error(&items, &mut report);
         item_count += log_and_send(&tx, items);
     }
     tracing::debug!(
@@ -85,12 +90,13 @@ async fn read_claude_stdout(
 async fn read_codex_stdout(
     stdout: tokio::process::ChildStdout,
     tx: mpsc::UnboundedSender<SessionUpdate>,
-) {
+) -> StdoutReadReport {
     let reader = BufReader::new(stdout);
     let mut lines = reader.lines();
     let mut acc = codex_parser::CodexAccumulator::new();
     let mut line_count = 0u64;
     let mut item_count = 0u64;
+    let mut report = StdoutReadReport::default();
     while let Ok(Some(line)) = lines.next_line().await {
         line_count += 1;
         let line_type = line.trim().chars().take(80).collect::<String>();
@@ -100,11 +106,27 @@ async fn read_codex_stdout(
             let _ = tx.send(SessionUpdate::SessionId(tid));
         }
         let items = codex_parser::parse_codex_event(&line, &mut acc);
+        mark_auth_error(&items, &mut report);
         item_count += log_and_send(&tx, items);
     }
     tracing::debug!(
         "[houston:stdout:codex] stream ended. {line_count} lines, {item_count} feed items"
     );
+    report
+}
+
+fn mark_auth_error(items: &[FeedItem], report: &mut StdoutReadReport) {
+    if report.saw_auth_error {
+        return;
+    }
+    for item in items {
+        if let FeedItem::SystemMessage(msg) = item {
+            if is_auth_error(msg) {
+                report.saw_auth_error = true;
+                return;
+            }
+        }
+    }
 }
 
 fn log_and_send(tx: &mpsc::UnboundedSender<SessionUpdate>, items: Vec<FeedItem>) -> u64 {
@@ -136,4 +158,44 @@ fn log_and_send(tx: &mpsc::UnboundedSender<SessionUpdate>, items: Vec<FeedItem>)
         let _ = tx.send(SessionUpdate::Feed(item));
     }
     count
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mark_auth_error_flags_401_system_message() {
+        let items = vec![FeedItem::SystemMessage(
+            "Error: Failed to authenticate. API Error: 401 Invalid authentication credentials"
+                .to_string(),
+        )];
+        let mut report = StdoutReadReport::default();
+        mark_auth_error(&items, &mut report);
+        assert!(report.saw_auth_error);
+    }
+
+    #[test]
+    fn mark_auth_error_ignores_unrelated_messages() {
+        let items = vec![
+            FeedItem::AssistantText("hello".to_string()),
+            FeedItem::SystemMessage("Some unrelated info".to_string()),
+        ];
+        let mut report = StdoutReadReport::default();
+        mark_auth_error(&items, &mut report);
+        assert!(!report.saw_auth_error);
+    }
+
+    #[test]
+    fn mark_auth_error_flags_claude_result_error_via_parser() {
+        let line = r#"{"type":"result","subtype":"error","is_error":true,"result":"Claude Code is not authenticated. Run claude auth login"}"#;
+        let mut acc = parser::StreamAccumulator::new();
+        let items = parser::parse_event(line, &mut acc);
+        let mut report = StdoutReadReport::default();
+        mark_auth_error(&items, &mut report);
+        assert!(
+            report.saw_auth_error,
+            "claude 401 result event should set saw_auth_error"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Fixes [HOU-214](https://linear.app/houston-ai/issue/HOU-214/houston-bug-tool-runtime-errorprovider-process-no-stderr-output).

Users with invalid Anthropic credentials saw a stack of misleading "Something got stuck / Report bug" cards on every retry (see Linear ticket attachment) on top of the correct reconnect UI. Bug reports from that card contained `tool_runtime_error:provider_process — no stderr output captured`, which is just the empty-stderr placeholder, not a real failure cause.

**Root cause:** Claude CLI reports 401s as a JSON `result` event on **stdout**, not stderr. `cli_process::handle_failed_exit` only scanned `stderr_lines` for auth errors, so stderr-was-empty → `has_auth_error = false` → fell through to emitting `FeedItem::ToolRuntimeError { kind: ProviderProcess, details: "no stderr output captured" }`. session_runner forwarded that feed item to the UI even though it had also (correctly) emitted `AuthRequired` from the parsed `SystemMessage`.

**Fix:** Track auth detection in `StdoutReadReport` via a new `mark_auth_error` helper that scans parsed `SystemMessage`s with `is_auth_error` in both claude and codex stdout. `handle_failed_exit` now OR's `stdout_report.saw_auth_error` into the existing stderr auth check — emits the `"Authentication expired"` status error and skips the `ToolRuntimeError`.

- `engine/houston-terminal-manager/src/session_io.rs` — `StdoutReadReport::saw_auth_error`, `mark_auth_error` wired into claude + codex readers (codex now also returns the report)
- `engine/houston-terminal-manager/src/cli_process.rs` — `handle_failed_exit` takes `stdout_report`, uses it for the auth branch

## Test plan

- [x] `cargo test -p houston-terminal-manager` — 79 pass, 5 new
  - `mark_auth_error_flags_401_system_message`
  - `mark_auth_error_ignores_unrelated_messages`
  - `mark_auth_error_flags_claude_result_error_via_parser` (against the real `{"type":"result","is_error":true,…}` JSON shape from the user's logs)
  - `claude_stdout_auth_error_skips_tool_runtime_error` (end-to-end on `handle_failed_exit`)
  - `empty_stderr_without_auth_signal_still_emits_tool_runtime_error` (guards pre-existing diagnostic path so genuine no-stderr failures still surface)
- [x] `cargo test -p houston-agents-conversations` — 17/17 pass (no regression in session_runner auth flow)
- [x] `cargo build -p houston-engine-server` — clean
- [ ] Manual: log out of Claude CLI, send a message in Houston, confirm only the inline reconnect card appears (no "Something got stuck" stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)