### PR TITLE
fix(windows): embed LINEAR_API_KEY + LINEAR_TEAM_ID in Windows MSI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -910,7 +910,8 @@ jobs:
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
           SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
-          SLACK_BUG_WEBHOOK_URL: ${{ secrets.SLACK_BUG_WEBHOOK_URL }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Locate MSI + updater signature artifacts


### PR DESCRIPTION
## Summary

- Windows MSI was shipping with no Linear bug-report keys baked in, so the in-app "Report bug" button failed with `Bug reporting not configured (missing LINEAR_API_KEY and LINEAR_TEAM_ID)` on every Windows user (see attached toast in issue thread).
- Root cause: `app/src-tauri/build.rs::configure_bug_report_env` reads `LINEAR_API_KEY` / `LINEAR_TEAM_ID` from the environment at compile time and emits `cargo:rustc-env=...` so `option_env!()` in `bug_report/mod.rs` resolves them. The macOS `tauri-action` step passed both secrets; the Windows step did not.
- Fix: add the two secrets to the Windows `Build Tauri app` `env:` block. Same `secrets.LINEAR_API_KEY` / `secrets.LINEAR_TEAM_ID` macOS already consumes — no new secrets required.
- Drive-by: dropped the unused `SLACK_BUG_WEBHOOK_URL` env wiring (grep returned zero hits in code).

## Test plan

- [ ] Tag a release and confirm the Windows MSI's "Report bug" button creates a Linear issue end-to-end.
- [ ] Verify macOS bug reporting still works (env block unchanged for macOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)