### PR TITLE
fix(openai): revert gpt-5.5 default + clear card when ChatGPT plan rejects codex

### DIFF
--- a/app/src/components/shell/tool-runtime-error-card.tsx
+++ b/app/src/components/shell/tool-runtime-error-card.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { BugIcon, RotateCcwIcon, WrenchIcon } from "lucide-react";
+import { BugIcon, RotateCcwIcon, WrenchIcon, ArrowRightLeftIcon } from "lucide-react";
 import { Button, Spinner } from "@houston-ai/core";
 import type { ToolRuntimeErrorEntry } from "@houston-ai/chat";
 import { reportBug } from "../../lib/bug-report";
@@ -11,17 +11,28 @@ import { useWorkspaceStore } from "../../stores/workspaces";
 interface ToolRuntimeErrorCardProps {
   error: ToolRuntimeErrorEntry;
   onRetry?: () => Promise<void> | void;
+  /**
+   * Invoked when the user clicks "Switch to GPT-5.5" on a
+   * `provider_model_unsupported` card. The caller is expected to update
+   * whatever scope still pins the unsupported model (workspace, activity,
+   * agent override) and then drive a retry.
+   */
+  onSwitchModel?: () => Promise<void> | void;
 }
 
 export function ToolRuntimeErrorCard({
   error,
   onRetry,
+  onSwitchModel,
 }: ToolRuntimeErrorCardProps) {
   const { t } = useTranslation(["shell", "common"]);
   const addToast = useUIStore((s) => s.addToast);
   const workspaceName = useWorkspaceStore((s) => s.current?.name);
   const [retrying, setRetrying] = useState(false);
   const [reporting, setReporting] = useState(false);
+  const [switching, setSwitching] = useState(false);
+
+  const isModelUnsupported = error.kind === "provider_model_unsupported";
 
   const retry = async () => {
     if (!onRetry || retrying) return;
@@ -55,16 +66,45 @@ export function ToolRuntimeErrorCard({
         description: t("shell:toolRuntimeError.reportSuccessDescription"),
         variant: "success",
       });
-    } catch {
+    } catch (e) {
+      // Surface the actual failure reason. The bare `catch {}` here used
+      // to mask "Bug reporting not configured (missing LINEAR_API_KEY ...)"
+      // for months on Windows builds, making the button look broken.
       addToast({
         title: t("shell:toolRuntimeError.reportErrorTitle"),
-        description: t("shell:toolRuntimeError.reportErrorDescription"),
+        description: e instanceof Error ? e.message : String(e),
         variant: "error",
       });
     } finally {
       setReporting(false);
     }
   };
+
+  const switchModel = async () => {
+    if (!onSwitchModel || switching) return;
+    setSwitching(true);
+    try {
+      await onSwitchModel();
+    } catch (e) {
+      addToast({
+        title: t("shell:toolRuntimeError.modelUnsupported.switchErrorTitle"),
+        description:
+          e instanceof Error
+            ? e.message
+            : t("shell:toolRuntimeError.modelUnsupported.switchErrorDescription"),
+        variant: "error",
+      });
+    } finally {
+      setSwitching(false);
+    }
+  };
+
+  const title = isModelUnsupported
+    ? t("shell:toolRuntimeError.modelUnsupported.title")
+    : t("shell:toolRuntimeError.title");
+  const body = isModelUnsupported
+    ? t("shell:toolRuntimeError.modelUnsupported.body")
+    : t("shell:toolRuntimeError.body");
 
   return (
     <div className="w-full px-1 py-2">
@@ -74,15 +114,28 @@ export function ToolRuntimeErrorCard({
         </div>
 
         <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <p className="text-sm font-semibold text-foreground">
-            {t("shell:toolRuntimeError.title")}
-          </p>
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            {t("shell:toolRuntimeError.body")}
-          </p>
+          <p className="text-sm font-semibold text-foreground">{title}</p>
+          <p className="text-xs leading-relaxed text-muted-foreground">{body}</p>
 
           <div className="mt-2 flex flex-wrap items-center gap-2">
-            {onRetry && (
+            {isModelUnsupported && onSwitchModel && (
+              <Button
+                onClick={switchModel}
+                className="h-8 gap-2 rounded-full px-3 text-xs"
+                size="sm"
+                disabled={switching}
+              >
+                {switching ? (
+                  <Spinner className="size-3.5" />
+                ) : (
+                  <ArrowRightLeftIcon className="size-3.5" />
+                )}
+                {switching
+                  ? t("shell:toolRuntimeError.modelUnsupported.switching")
+                  : t("shell:toolRuntimeError.modelUnsupported.switchAction")}
+              </Button>
+            )}
+            {!isModelUnsupported && onRetry && (
               <Button
                 onClick={retry}
                 className="h-8 gap-2 rounded-full px-3 text-xs"

--- a/app/src/components/tabs/chat-tab.tsx
+++ b/app/src/components/tabs/chat-tab.tsx
@@ -245,11 +245,26 @@ export default function ChatTab({ agent }: TabProps) {
         renderTurnSummary={renderTurnSummary}
         renderSystemMessage={(msg) => {
           if (isToolRuntimeErrorMessage(msg)) {
+            const isModelUnsupported =
+              msg.runtimeError.kind === "provider_model_unsupported";
             return (
               <ToolRuntimeErrorCard
                 error={msg.runtimeError}
                 onRetry={() =>
                   messageQueue.sendOrQueue(t("toolRuntimeError.retryPrompt"), [])
+                }
+                onSwitchModel={
+                  isModelUnsupported
+                    ? async () => {
+                        if (workspace?.id) {
+                          await useWorkspaceStore
+                            .getState()
+                            .updateProvider(workspace.id, "openai", "gpt-5.5");
+                        }
+                        setChatProvider("openai");
+                        setChatModel("gpt-5.5");
+                      }
+                    : undefined
                 }
               />
             );

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -419,6 +419,8 @@ export function useAgentChatPanel({
   const renderSystemMessage = useCallback(
     (msg: ChatMessage) => {
       if (isToolRuntimeErrorMessage(msg)) {
+        const isModelUnsupported =
+          msg.runtimeError.kind === "provider_model_unsupported";
         return (
           <ToolRuntimeErrorCard
             error={msg.runtimeError}
@@ -434,6 +436,35 @@ export function useAgentChatPanel({
                 data: text,
               });
             }}
+            onSwitchModel={
+              isModelUnsupported
+                ? async () => {
+                    // Demote the workspace default first so future sessions
+                    // use a model the user's ChatGPT plan accepts.
+                    if (workspace?.id) {
+                      await useWorkspaceStore
+                        .getState()
+                        .updateProvider(workspace.id, "openai", "gpt-5.5");
+                    }
+                    // If this activity carries an explicit codex override,
+                    // clear it too — otherwise the resolver will keep using
+                    // the activity-level value and the workspace fix won't
+                    // take effect for this mission.
+                    if (
+                      path &&
+                      selectedActivityId &&
+                      activityModel === "gpt-5.5-codex"
+                    ) {
+                      await tauriActivity.update(path, selectedActivityId, {
+                        provider: "openai",
+                        model: "gpt-5.5",
+                      });
+                      setChatProvider("openai");
+                      setChatModel("gpt-5.5");
+                    }
+                  }
+                : undefined
+            }
           />
         );
       }

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -25,26 +25,25 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     installUrl: "https://github.com/openai/codex",
     loginCommand: "codex login",
     cost: "Your ChatGPT subscription",
-    // `gpt-5.5-codex` is the default — it is tuned for the agent / tool-use
-    // workload Houston actually runs (the tutorial reads calendar + mail,
-    // drafts emails, edits files, etc.) and is the model the codex CLI was
-    // built around. The vanilla `gpt-5.5` stays available for users who
-    // want it for chat-style tasks where coding-tuned behavior is less
-    // helpful, but the picker (and the tutorial via `defaultModel`)
-    // start on codex.
+    // `gpt-5.5` is the default because the `-codex` variant is not granted
+    // on every ChatGPT plan (Business / Enterprise users hit a hard 400
+    // "model is not supported when using Codex with a ChatGPT account").
+    // Plain `gpt-5.5` works on every plan that Codex accepts at all, so we
+    // default there and let users opt into `-codex` via the picker if their
+    // plan allows it.
     models: [
-      {
-        id: "gpt-5.5-codex",
-        label: "GPT-5.5 Codex",
-        description: "Tuned for coding and agent tool use. Best for Houston's tutorial flow.",
-      },
       {
         id: "gpt-5.5",
         label: "GPT-5.5",
-        description: "Flagship general model. Best for plain chat and reasoning.",
+        description: "Works on every ChatGPT plan. Recommended default.",
+      },
+      {
+        id: "gpt-5.5-codex",
+        label: "GPT-5.5 Codex",
+        description: "Coding-tuned. Some ChatGPT plans (e.g. Business) do not include it.",
       },
     ],
-    defaultModel: "gpt-5.5-codex",
+    defaultModel: "gpt-5.5",
   },
   {
     id: "anthropic",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -132,7 +132,15 @@
     "reportSuccessDescription": "Houston received the logs.",
     "reportErrorTitle": "Could not send report",
     "reportErrorDescription": "Try again in a moment.",
-    "retryErrorTitle": "Could not try again"
+    "retryErrorTitle": "Could not try again",
+    "modelUnsupported": {
+      "title": "Your ChatGPT plan doesn't include GPT-5.5 Codex",
+      "body": "Switch to GPT-5.5 to continue. The Codex variant is only available on some ChatGPT plans (Plus, Pro, Team), not on Business or Enterprise.",
+      "switchAction": "Switch to GPT-5.5",
+      "switching": "Switching...",
+      "switchErrorTitle": "Could not switch model",
+      "switchErrorDescription": "Open the model picker and choose GPT-5.5 manually."
+    }
   },
   "updateChecker": {
     "cardLabel": "Houston update available",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -132,7 +132,15 @@
     "reportSuccessDescription": "Houston recibió los registros.",
     "reportErrorTitle": "No se pudo enviar el reporte",
     "reportErrorDescription": "Intenta otra vez en un momento.",
-    "retryErrorTitle": "No se pudo intentar de nuevo"
+    "retryErrorTitle": "No se pudo intentar de nuevo",
+    "modelUnsupported": {
+      "title": "Tu plan de ChatGPT no incluye GPT-5.5 Codex",
+      "body": "Cambia a GPT-5.5 para continuar. La variante Codex solo está disponible en algunos planes de ChatGPT (Plus, Pro, Team), no en Business ni Enterprise.",
+      "switchAction": "Cambiar a GPT-5.5",
+      "switching": "Cambiando...",
+      "switchErrorTitle": "No se pudo cambiar el modelo",
+      "switchErrorDescription": "Abre el selector de modelo y elige GPT-5.5 manualmente."
+    }
   },
   "updateChecker": {
     "cardLabel": "Actualización de Houston disponible",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -132,7 +132,15 @@
     "reportSuccessDescription": "Houston recebeu os registros.",
     "reportErrorTitle": "Não foi possível enviar o relatório",
     "reportErrorDescription": "Tente de novo em instantes.",
-    "retryErrorTitle": "Não foi possível tentar de novo"
+    "retryErrorTitle": "Não foi possível tentar de novo",
+    "modelUnsupported": {
+      "title": "Seu plano do ChatGPT não inclui GPT-5.5 Codex",
+      "body": "Mude para GPT-5.5 para continuar. A variante Codex só está disponível em alguns planos do ChatGPT (Plus, Pro, Team), não em Business ou Enterprise.",
+      "switchAction": "Mudar para GPT-5.5",
+      "switching": "Mudando...",
+      "switchErrorTitle": "Não foi possível mudar o modelo",
+      "switchErrorDescription": "Abra o seletor de modelo e escolha GPT-5.5 manualmente."
+    }
   },
   "updateChecker": {
     "cardLabel": "Atualização do Houston disponível",

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -82,10 +82,16 @@ export const useUIStore = create<UIState>((set) => ({
 
   addToast: (toast) =>
     set((s) => {
-      const isDuplicate = s.toasts.some(
-        (t) => t.title === toast.title && t.description === toast.description,
-      );
-      if (isDuplicate) return s;
+      // Error toasts must always render. Dedup hid genuine repeated failures:
+      // clicking "Report bug" after the first failure would silently no-op
+      // because the error toast title+description matched the previous one,
+      // making the button feel broken even when it was firing correctly.
+      if (toast.variant !== "error") {
+        const isDuplicate = s.toasts.some(
+          (t) => t.title === toast.title && t.description === toast.description,
+        );
+        if (isDuplicate) return s;
+      }
 
       const id = `toast-${++toastCounter}`;
       const timeout = toast.action ? 10000 : 5000;

--- a/engine/houston-terminal-manager/src/cli_process.rs
+++ b/engine/houston-terminal-manager/src/cli_process.rs
@@ -2,7 +2,9 @@ use super::session_io;
 use super::types::{FeedItem, Provider, SessionStatus, ToolRuntimeErrorKind};
 use crate::auth_error::is_auth_error;
 use crate::codex_command;
-use crate::provider_error::is_malformed_provider_json_error;
+use crate::provider_error::{
+    is_codex_model_unsupported_chatgpt_error, is_malformed_provider_json_error,
+};
 use crate::session_update::SessionUpdate;
 use std::process::Stdio;
 use tokio::io::AsyncWriteExt;
@@ -177,6 +179,30 @@ fn handle_failed_exit(
         return CliRunOutcome::Failed;
     }
 
+    // OpenAI returns a 400 when the configured model is not allowed on the
+    // user's ChatGPT plan (e.g. `gpt-5.5-codex` on Business). The stdout
+    // parser already emitted a dedicated `ProviderModelUnsupported` card,
+    // OR the same error surfaced on stderr — either way, route to the
+    // specific status and skip the generic ProviderProcess card.
+    let model_unsupported = stdout_report.saw_model_unsupported_error
+        || stderr_lines
+            .iter()
+            .any(|line| is_codex_model_unsupported_chatgpt_error(line));
+    if model_unsupported {
+        tracing::warn!("[houston:session] codex rejected model on this ChatGPT account");
+        if !stdout_report.saw_model_unsupported_error {
+            // stderr-only path — emit the card here so the UI still renders it.
+            let _ = tx.send(SessionUpdate::Feed(FeedItem::ToolRuntimeError {
+                kind: ToolRuntimeErrorKind::ProviderModelUnsupported,
+                details: stderr_lines.join("\n"),
+            }));
+        }
+        let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(
+            "Selected model is not available on this ChatGPT plan".to_string(),
+        )));
+        return CliRunOutcome::Failed;
+    }
+
     let stderr_summary = if stderr_lines.is_empty() {
         "no stderr output captured".to_string()
     } else {
@@ -240,6 +266,7 @@ mod tests {
         let stdout_report = session_io::StdoutReadReport {
             malformed_provider_json: false,
             saw_auth_error: true,
+            saw_model_unsupported_error: false,
         };
 
         let outcome =

--- a/engine/houston-terminal-manager/src/codex_parser.rs
+++ b/engine/houston-terminal-manager/src/codex_parser.rs
@@ -4,7 +4,8 @@
 //! so the rest of the stack (session_runner, frontend) is provider-agnostic.
 
 use super::auth_error::{is_auth_retry_noise, AUTH_RETRY_MARKER};
-use super::types::FeedItem;
+use super::types::{FeedItem, ToolRuntimeErrorKind};
+use crate::provider_error::is_codex_model_unsupported_chatgpt_error;
 use serde::Deserialize;
 
 /// Top-level Codex NDJSON event envelope.
@@ -192,6 +193,17 @@ pub fn parse_codex_event(line: &str, acc: &mut CodexAccumulator) -> Vec<FeedItem
                 tracing::info!("[codex] auth retry detected — suppressing raw error");
                 // Return a marker so session_runner can track it, but don't show raw noise.
                 items.push(FeedItem::SystemMessage(AUTH_RETRY_MARKER.to_string()));
+            } else if is_codex_model_unsupported_chatgpt_error(&msg) {
+                // OpenAI rejected the configured model for this ChatGPT plan.
+                // Surface as a dedicated card with a one-click "switch model"
+                // action instead of dumping the raw 400 JSON into the feed.
+                tracing::warn!(
+                    "[codex] model not supported on this ChatGPT account — emitting card"
+                );
+                items.push(FeedItem::ToolRuntimeError {
+                    kind: ToolRuntimeErrorKind::ProviderModelUnsupported,
+                    details: msg,
+                });
             } else {
                 items.push(FeedItem::SystemMessage(format!("Error: {msg}")));
             }
@@ -593,6 +605,20 @@ mod tests {
         let items = parse_codex_event(line, &mut acc());
         assert_eq!(items.len(), 1);
         assert!(matches!(&items[0], FeedItem::SystemMessage(m) if m.contains("Context window")));
+    }
+
+    #[test]
+    fn parse_turn_failed_model_unsupported_emits_card() {
+        let line = r#"{"type":"turn.failed","error":{"message":"The 'gpt-5.5-codex' model is not supported when using Codex with a ChatGPT account."}}"#;
+        let items = parse_codex_event(line, &mut acc());
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            FeedItem::ToolRuntimeError { kind, details } => {
+                assert_eq!(*kind, ToolRuntimeErrorKind::ProviderModelUnsupported);
+                assert!(details.contains("gpt-5.5-codex"));
+            }
+            other => panic!("expected ProviderModelUnsupported card, got {other:?}"),
+        }
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/provider_error.rs
+++ b/engine/houston-terminal-manager/src/provider_error.rs
@@ -6,6 +6,16 @@ pub fn is_malformed_provider_json_error(message: &str) -> bool {
     lower.contains("request body is not valid json") && lower.contains("no low surrogate in string")
 }
 
+/// OpenAI rejects coding-specialised models (gpt-5.5-codex, gpt-5-codex …)
+/// with a 400 when the user is authenticated via a ChatGPT account whose plan
+/// does not include them. The error message OpenAI returns is verbatim:
+/// "The 'gpt-5.5-codex' model is not supported when using Codex with a ChatGPT account."
+/// The CLI surfaces it through both `turn.failed.error.message` and stderr.
+pub fn is_codex_model_unsupported_chatgpt_error(message: &str) -> bool {
+    let lower = message.to_lowercase();
+    lower.contains("is not supported when using codex with a chatgpt account")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -28,6 +38,25 @@ mod tests {
     fn ignores_low_surrogate_without_provider_json_signature() {
         assert!(!is_malformed_provider_json_error(
             "no low surrogate in string",
+        ));
+    }
+
+    #[test]
+    fn detects_codex_chatgpt_model_unsupported_error() {
+        let message = r#"Error: {"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5.5-codex' model is not supported when using Codex with a ChatGPT account."}}"#;
+        assert!(is_codex_model_unsupported_chatgpt_error(message));
+    }
+
+    #[test]
+    fn detects_chatgpt_model_unsupported_case_insensitive() {
+        let message = "the 'gpt-5-codex' MODEL IS NOT SUPPORTED WHEN USING CODEX WITH A CHATGPT ACCOUNT.";
+        assert!(is_codex_model_unsupported_chatgpt_error(message));
+    }
+
+    #[test]
+    fn ignores_other_codex_400s() {
+        assert!(!is_codex_model_unsupported_chatgpt_error(
+            "Error: {\"type\":\"error\",\"status\":400,\"error\":{\"message\":\"context window exceeded\"}}"
         ));
     }
 }

--- a/engine/houston-terminal-manager/src/session_io.rs
+++ b/engine/houston-terminal-manager/src/session_io.rs
@@ -1,7 +1,7 @@
 use super::codex_parser;
 use super::parser;
 use super::stderr_filter::{stderr_feed_item, StderrState};
-use super::types::{FeedItem, Provider};
+use super::types::{FeedItem, Provider, ToolRuntimeErrorKind};
 use crate::auth_error::is_auth_error;
 use crate::provider_error::is_malformed_provider_json_error;
 use crate::session_update::SessionUpdate;
@@ -17,6 +17,12 @@ pub struct StdoutReadReport {
     /// failed-exit path would emit a generic "no stderr output captured"
     /// ToolRuntimeError on top of the legitimate AuthRequired reconnect UI.
     pub saw_auth_error: bool,
+    /// True when codex's `turn.failed` carried OpenAI's "model is not
+    /// supported when using Codex with a ChatGPT account" 400. The parser
+    /// already emitted a dedicated `ProviderModelUnsupported` runtime-error
+    /// card, so `handle_failed_exit` must NOT also emit the generic
+    /// `ProviderProcess` card on top of it.
+    pub saw_model_unsupported_error: bool,
 }
 
 /// Read all stderr lines, emitting only user-actionable feed items.
@@ -107,6 +113,7 @@ async fn read_codex_stdout(
         }
         let items = codex_parser::parse_codex_event(&line, &mut acc);
         mark_auth_error(&items, &mut report);
+        mark_model_unsupported(&items, &mut report);
         item_count += log_and_send(&tx, items);
     }
     tracing::debug!(
@@ -126,6 +133,23 @@ fn mark_auth_error(items: &[FeedItem], report: &mut StdoutReadReport) {
                 return;
             }
         }
+    }
+}
+
+fn mark_model_unsupported(items: &[FeedItem], report: &mut StdoutReadReport) {
+    if report.saw_model_unsupported_error {
+        return;
+    }
+    if items.iter().any(|item| {
+        matches!(
+            item,
+            FeedItem::ToolRuntimeError {
+                kind: ToolRuntimeErrorKind::ProviderModelUnsupported,
+                ..
+            }
+        )
+    }) {
+        report.saw_model_unsupported_error = true;
     }
 }
 

--- a/engine/houston-terminal-manager/src/types.rs
+++ b/engine/houston-terminal-manager/src/types.rs
@@ -166,6 +166,11 @@ impl FileChanges {
 pub enum ToolRuntimeErrorKind {
     LocalTool,
     ProviderProcess,
+    /// Provider rejected the configured model for this account (e.g. OpenAI
+    /// returns 400 "model is not supported when using Codex with a ChatGPT
+    /// account" for `gpt-5.5-codex` on plans that don't include it). The
+    /// UI renders a dedicated card with a "Switch to GPT-5.5" action.
+    ProviderModelUnsupported,
 }
 
 /// Processed feed items for rendering in the UI.

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -25,7 +25,7 @@ export type FeedItem =
     };
 
 export interface ToolRuntimeErrorEntry {
-  kind: "local_tool" | "provider_process";
+  kind: "local_tool" | "provider_process" | "provider_model_unsupported";
   details: string;
 }
 


### PR DESCRIPTION
## Summary

- Reverts the OpenAI default model from \`gpt-5.5-codex\` → \`gpt-5.5\`. Codex variant stays in the picker for users whose plan supports it; description now flags plan compatibility.
- Adds a dedicated **\"Your ChatGPT plan doesn't include GPT-5.5 Codex\"** card with a one-click **\"Switch to GPT-5.5\"** action for the 400 \`is not supported when using Codex with a ChatGPT account\` error that's been spamming ChatGPT Business users since 0.4.19. Replaces the raw JSON dump that was previously showing in chat.
- Fixes two latent issues that hid the underlying bug for weeks:
  - \`tool-runtime-error-card.tsx\` no longer swallows the actual Report-bug failure (bare \`catch {}\` → \`catch (e) {}\` with \`e.message\` surfaced).
  - \`stores/ui.ts\` no longer dedupes error toasts, so repeated failures show repeated toasts instead of feeling like a broken button.

### Why this happened

PR #143 (0.4.19) switched the default to \`gpt-5.5-codex\`. ChatGPT Plus/Pro/Team grant it; **Business** and **Enterprise** don't, and OpenAI returns a hard 400. Workspaces created on 0.4.19 stored \`gpt-5.5-codex\` in \`workspaces.json\`, so even users who were fine before broke when they made a new workspace.

### Switch-model handler scope

- **Workspace**: always updated via \`tauriWorkspaces.updateProvider(id, \"openai\", \"gpt-5.5\")\` so future sessions inherit the working model.
- **Activity**: when an activity has an explicit \`gpt-5.5-codex\` override, the board chat-panel handler clears that too. Otherwise the engine's resolver (agent → activity → workspace) would still find the bad model.
- **Agent-level config**: not touched. Houston's own picker doesn't write into it for OpenAI, and the rare manual override stays the user's choice.

### Wire-protocol change

New \`ToolRuntimeErrorKind::ProviderModelUnsupported\` (engine + ui/chat \`ToolRuntimeErrorEntry.kind\`). Backwards-compatible at the JSON level — old clients fall through to the default branch and render no card (no worse than today).

## Test plan

- [ ] \`cargo test --workspace\` clean
- [ ] \`pnpm typecheck\` clean
- [ ] \`pnpm check-locales\` clean (en/es/pt parity)
- [ ] Manual: simulate the 400 by switching a fresh workspace to \`gpt-5.5-codex\` on a ChatGPT-Business account and triggering a turn — verify the new card renders, \"Switch to GPT-5.5\" updates the workspace, retry succeeds.
- [ ] Manual: click Report bug on a tool-runtime card while Linear is unreachable — verify the toast description shows the real reason instead of \"Try again in a moment.\"
- [ ] Manual: trigger the same error toast twice in a row — verify the second one renders instead of being deduped away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)