### PR TITLE
feat(workspace): WORKSPACE.md + USER.md context injected into every agent prompt

### DIFF
--- a/app/src/components/settings/sections/workspace-context.tsx
+++ b/app/src/components/settings/sections/workspace-context.tsx
@@ -1,0 +1,66 @@
+import { useTranslation } from "react-i18next";
+import { useWorkspaceStore } from "../../../stores/workspaces";
+import {
+  useSaveWorkspaceContext,
+  useWorkspaceContext,
+} from "../../../hooks/queries/use-workspace-context";
+import {
+  InstructionsContent,
+  type InstructionsContentLabels,
+} from "../../tabs/job-description-parts";
+
+type Slot = "workspace" | "user";
+
+function useSlotEditor(slot: Slot) {
+  const currentWorkspace = useWorkspaceStore((s) => s.current);
+  const { data } = useWorkspaceContext(currentWorkspace?.id);
+  const save = useSaveWorkspaceContext(currentWorkspace?.id);
+
+  const content = data?.[slot] ?? "";
+
+  const onSave = async (next: string) => {
+    if (!data) return;
+    await save.mutateAsync({ ...data, [slot]: next });
+  };
+
+  return { ready: !!currentWorkspace && !!data, content, onSave };
+}
+
+function useSlotLabels(prefix: "workspaceContext" | "userContext"): InstructionsContentLabels {
+  const { t } = useTranslation("settings");
+  return {
+    emptyTitle: t(`${prefix}.emptyTitle`),
+    emptyDescription: t(`${prefix}.emptyDescription`),
+    writeButton: t(`${prefix}.writeButton`),
+    helper: t(`${prefix}.helper`),
+    saving: t(`${prefix}.saving`),
+    saved: t(`${prefix}.saved`),
+    placeholder: t(`${prefix}.placeholder`),
+  };
+}
+
+export function WorkspaceContextSection() {
+  const editor = useSlotEditor("workspace");
+  const labels = useSlotLabels("workspaceContext");
+  if (!editor.ready) return null;
+  return (
+    <InstructionsContent
+      content={editor.content}
+      onSave={editor.onSave}
+      labels={labels}
+    />
+  );
+}
+
+export function UserContextSection() {
+  const editor = useSlotEditor("user");
+  const labels = useSlotLabels("userContext");
+  if (!editor.ready) return null;
+  return (
+    <InstructionsContent
+      content={editor.content}
+      onSave={editor.onSave}
+      labels={labels}
+    />
+  );
+}

--- a/app/src/components/settings/settings-view.tsx
+++ b/app/src/components/settings/settings-view.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Spinner } from "@houston-ai/core";
-import { User, Smartphone, Folder, Bot, Bug } from "lucide-react";
+import { User, Smartphone, Folder, Bot, Bug, FileText, UserCircle } from "lucide-react";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import {
   SidebarSectionNav,
@@ -11,12 +11,18 @@ import {
 type SettingsSectionId =
   | "account"
   | "workspace"
+  | "workspaceContext"
+  | "userContext"
   | "provider"
   | "phone"
   | "reportBug";
 import { AccountSection, useAccountAvailable } from "./sections/account";
 import { ConnectPhoneSection } from "./sections/connect-phone";
 import { WorkspaceSection } from "./sections/workspace";
+import {
+  WorkspaceContextSection,
+  UserContextSection,
+} from "./sections/workspace-context";
 import { ProviderSection } from "./sections/provider";
 import { TimezoneSection } from "./sections/timezone";
 import { LanguageSection } from "./sections/language";
@@ -36,6 +42,16 @@ export function SettingsView() {
     }
     list.push(
       { id: "workspace", label: t("settings:nav.workspace"), icon: Folder },
+      {
+        id: "workspaceContext",
+        label: t("settings:nav.workspaceContext"),
+        icon: FileText,
+      },
+      {
+        id: "userContext",
+        label: t("settings:nav.userContext"),
+        icon: UserCircle,
+      },
       { id: "provider", label: t("settings:nav.provider"), icon: Bot },
       { id: "phone", label: t("settings:nav.phone"), icon: Smartphone, beta: true },
       { id: "reportBug", label: t("settings:nav.reportBug"), icon: Bug },
@@ -67,21 +83,27 @@ export function SettingsView() {
         onSelect={setActive}
       />
       <div className="flex-1 overflow-y-auto">
-        <div className="mx-auto max-w-xl px-8 py-10">
-          {activeVisible === "account" && <AccountSection />}
-          {activeVisible === "workspace" && (
-            <div className="space-y-10">
-              <WorkspaceSection />
-              <LanguageSection />
-              <TimezoneSection />
-              <AppearanceSection />
-              <DangerSection />
-            </div>
-          )}
-          {activeVisible === "provider" && <ProviderSection />}
-          {activeVisible === "phone" && <ConnectPhoneSection />}
-          {activeVisible === "reportBug" && <ReportBugSection />}
-        </div>
+        {activeVisible === "workspaceContext" ? (
+          <WorkspaceContextSection />
+        ) : activeVisible === "userContext" ? (
+          <UserContextSection />
+        ) : (
+          <div className="mx-auto max-w-xl px-8 py-10">
+            {activeVisible === "account" && <AccountSection />}
+            {activeVisible === "workspace" && (
+              <div className="space-y-10">
+                <WorkspaceSection />
+                <LanguageSection />
+                <TimezoneSection />
+                <AppearanceSection />
+                <DangerSection />
+              </div>
+            )}
+            {activeVisible === "provider" && <ProviderSection />}
+            {activeVisible === "phone" && <ConnectPhoneSection />}
+            {activeVisible === "reportBug" && <ReportBugSection />}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/app/src/components/tabs/job-description-parts.tsx
+++ b/app/src/components/tabs/job-description-parts.tsx
@@ -13,14 +13,35 @@ export type SubTab = "instructions" | "skills" | "learnings";
 
 type SaveState = "idle" | "saving" | "saved";
 
+export interface InstructionsContentLabels {
+  emptyTitle: string;
+  emptyDescription: string;
+  writeButton: string;
+  helper: string;
+  saving: string;
+  saved: string;
+  placeholder: string;
+}
+
 export function InstructionsContent({
   content,
   onSave,
+  labels,
 }: {
   content: string;
   onSave: (content: string) => Promise<unknown>;
+  labels?: InstructionsContentLabels;
 }) {
   const { t } = useTranslation("agents");
+  const resolved: InstructionsContentLabels = labels ?? {
+    emptyTitle: t("instructions.emptyTitle"),
+    emptyDescription: t("instructions.emptyDescription"),
+    writeButton: t("instructions.writeButton"),
+    helper: t("instructions.helper"),
+    saving: t("instructions.saving"),
+    saved: t("instructions.saved"),
+    placeholder: t("instructions.placeholder"),
+  };
   const [value, setValue] = useState(content);
   const [editing, setEditing] = useState(false);
   const [state, setState] = useState<SaveState>("idle");
@@ -48,12 +69,12 @@ export function InstructionsContent({
     return (
       <div className="mx-auto max-w-md flex flex-col items-center gap-6 text-center pt-24 px-6">
         <EmptyHeader>
-          <EmptyTitle>{t("instructions.emptyTitle")}</EmptyTitle>
-          <EmptyDescription>{t("instructions.emptyDescription")}</EmptyDescription>
+          <EmptyTitle>{resolved.emptyTitle}</EmptyTitle>
+          <EmptyDescription>{resolved.emptyDescription}</EmptyDescription>
         </EmptyHeader>
         <Button onClick={() => setEditing(true)}>
           <FileText className="size-4" />
-          {t("instructions.writeButton")}
+          {resolved.writeButton}
         </Button>
       </div>
     );
@@ -63,7 +84,7 @@ export function InstructionsContent({
     <div className="max-w-3xl mx-auto w-full px-6 pb-12 pt-2">
       <div className="flex items-baseline justify-between gap-4 mb-4">
         <p className="text-xs text-muted-foreground max-w-md">
-          {t("instructions.helper")}
+          {resolved.helper}
         </p>
         <span
           className={cn(
@@ -72,7 +93,7 @@ export function InstructionsContent({
           )}
           aria-live="polite"
         >
-          {state === "saving" ? t("instructions.saving") : state === "saved" ? t("instructions.saved") : ""}
+          {state === "saving" ? resolved.saving : state === "saved" ? resolved.saved : ""}
         </span>
       </div>
       <section className="rounded-xl bg-secondary p-3">
@@ -81,7 +102,7 @@ export function InstructionsContent({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onBlur={handleBlur}
-          placeholder={t("instructions.placeholder")}
+          placeholder={resolved.placeholder}
           rows={Math.max(12, value.split("\n").length + 2)}
           className={cn(
             "w-full px-4 py-3 text-sm text-foreground leading-relaxed",

--- a/app/src/hooks/queries/use-workspace-context.ts
+++ b/app/src/hooks/queries/use-workspace-context.ts
@@ -1,0 +1,25 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type { WorkspaceContext } from "@houston-ai/engine-client";
+import { tauriWorkspaces } from "../../lib/tauri";
+
+const key = (workspaceId: string) =>
+  ["workspace-context", workspaceId] as const;
+
+export function useWorkspaceContext(workspaceId: string | undefined) {
+  return useQuery({
+    queryKey: key(workspaceId ?? ""),
+    queryFn: () => tauriWorkspaces.getContext(workspaceId!),
+    enabled: !!workspaceId,
+  });
+}
+
+export function useSaveWorkspaceContext(workspaceId: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (body: WorkspaceContext) =>
+      tauriWorkspaces.setContext(workspaceId!, body),
+    onSuccess: (data) => {
+      if (workspaceId) qc.setQueryData(key(workspaceId), data);
+    },
+  });
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -83,6 +83,19 @@ export const tauriWorkspaces = {
     call<Workspace>("update_workspace_provider", () =>
       getEngine().setWorkspaceProvider(id, { provider, model }),
     ),
+  getContext: (id: string) =>
+    call<import("@houston-ai/engine-client").WorkspaceContext>(
+      "get_workspace_context",
+      () => getEngine().getWorkspaceContext(id),
+    ),
+  setContext: (
+    id: string,
+    body: import("@houston-ai/engine-client").WorkspaceContext,
+  ) =>
+    call<import("@houston-ai/engine-client").WorkspaceContext>(
+      "set_workspace_context",
+      () => getEngine().setWorkspaceContext(id, body),
+    ),
 };
 
 // ─── Agents ───────────────────────────────────────────────────────────

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -3,6 +3,8 @@
   "nav": {
     "account": "Account",
     "workspace": "Workspace",
+    "workspaceContext": "Workspace context",
+    "userContext": "User context",
     "provider": "AI provider",
     "phone": "Connect phone",
     "reportBug": "Report bug"
@@ -15,6 +17,24 @@
   "workspace": {
     "title": "Workspace",
     "nameLabel": "Name"
+  },
+  "workspaceContext": {
+    "emptyTitle": "Tell every agent about this workspace",
+    "emptyDescription": "The company, the product, the customers. Loaded into every new chat in this workspace.",
+    "writeButton": "Write workspace context",
+    "helper": "Shared by every agent in this workspace. Loaded into each new chat. Agents can update this when you tell them something new.",
+    "placeholder": "e.g. Acme Corp, B2B fintech, Series A. Customers are CFOs at mid-market companies.",
+    "saving": "Saving…",
+    "saved": "Saved"
+  },
+  "userContext": {
+    "emptyTitle": "Tell every agent about you",
+    "emptyDescription": "Your role, what you care about, how you like to work. Loaded into every new chat in this workspace.",
+    "writeButton": "Write user context",
+    "helper": "Loaded into each new chat in this workspace. Agents can update this when you tell them something new.",
+    "placeholder": "e.g. I'm Juan, head of sales. I care about pipeline velocity and prefer short replies.",
+    "saving": "Saving…",
+    "saved": "Saved"
   },
   "provider": {
     "title": "AI provider",

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -3,6 +3,8 @@
   "nav": {
     "account": "Cuenta",
     "workspace": "Espacio de trabajo",
+    "workspaceContext": "Contexto del espacio",
+    "userContext": "Contexto del usuario",
     "provider": "Proveedor de IA",
     "phone": "Conectar celular",
     "reportBug": "Reportar bug"
@@ -15,6 +17,24 @@
   "workspace": {
     "title": "Espacio de trabajo",
     "nameLabel": "Nombre"
+  },
+  "workspaceContext": {
+    "emptyTitle": "Cuéntale a todo agente sobre este espacio",
+    "emptyDescription": "La empresa, el producto, los clientes. Se carga en cada chat nuevo de este espacio.",
+    "writeButton": "Escribir contexto del espacio",
+    "helper": "Compartido por todos los agentes de este espacio. Se carga en cada chat nuevo. Los agentes pueden actualizarlo cuando les cuentes algo nuevo.",
+    "placeholder": "p. ej. Acme Corp, fintech B2B, Serie A. Los clientes son CFOs de empresas medianas.",
+    "saving": "Guardando…",
+    "saved": "Guardado"
+  },
+  "userContext": {
+    "emptyTitle": "Cuéntale a todo agente sobre ti",
+    "emptyDescription": "Tu rol, lo que te importa, cómo prefieres trabajar. Se carga en cada chat nuevo de este espacio.",
+    "writeButton": "Escribir contexto del usuario",
+    "helper": "Se carga en cada chat nuevo de este espacio. Los agentes pueden actualizarlo cuando les cuentes algo nuevo.",
+    "placeholder": "p. ej. Soy Juan, líder de ventas. Me importa la velocidad del pipeline y prefiero respuestas cortas.",
+    "saving": "Guardando…",
+    "saved": "Guardado"
   },
   "provider": {
     "title": "Proveedor de IA",

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -3,6 +3,8 @@
   "nav": {
     "account": "Conta",
     "workspace": "Espaço de trabalho",
+    "workspaceContext": "Contexto do espaço",
+    "userContext": "Contexto do usuário",
     "provider": "Provedor de IA",
     "phone": "Conectar celular",
     "reportBug": "Reportar bug"
@@ -15,6 +17,24 @@
   "workspace": {
     "title": "Espaço de trabalho",
     "nameLabel": "Nome"
+  },
+  "workspaceContext": {
+    "emptyTitle": "Conte para todo agente sobre este espaço",
+    "emptyDescription": "A empresa, o produto, os clientes. Entra em cada conversa nova deste espaço.",
+    "writeButton": "Escrever contexto do espaço",
+    "helper": "Compartilhado por todos os agentes deste espaço. Entra em cada conversa nova. Os agentes podem atualizar quando você contar algo novo.",
+    "placeholder": "ex. Acme Corp, fintech B2B, Série A. Os clientes são CFOs de empresas médias.",
+    "saving": "Salvando…",
+    "saved": "Salvo"
+  },
+  "userContext": {
+    "emptyTitle": "Conte para todo agente sobre você",
+    "emptyDescription": "Seu papel, o que importa pra você, como prefere trabalhar. Entra em cada conversa nova deste espaço.",
+    "writeButton": "Escrever contexto do usuário",
+    "helper": "Entra em cada conversa nova deste espaço. Os agentes podem atualizar quando você contar algo novo.",
+    "placeholder": "ex. Sou o Juan, líder de vendas. Me importo com velocidade de pipeline e prefiro respostas curtas.",
+    "saving": "Salvando…",
+    "saved": "Salvo"
   },
   "provider": {
     "title": "Provedor de IA",

--- a/engine/houston-engine-core/src/agents/prompt.rs
+++ b/engine/houston-engine-core/src/agents/prompt.rs
@@ -182,6 +182,12 @@ pub fn build_agent_context(
         }
     }
 
+    if let Some(workspace_dir) = dir.parent() {
+        if let Some(section) = crate::workspace_context::build_prompt_section(workspace_dir) {
+            parts.push(section);
+        }
+    }
+
     let integrations_path = dir.join(".houston/integrations.json");
     if let Ok(content) = fs::read_to_string(&integrations_path) {
         let names: Vec<String> =
@@ -274,6 +280,34 @@ mod tests {
         assert!(out.contains("# Persistent Learnings - Frozen Snapshot"));
         assert!(out.contains("User calls this contact Mr. Perkins."));
         assert!(!out.contains("2026-01-01"));
+    }
+
+    #[test]
+    fn build_agent_context_injects_workspace_and_user_context() {
+        let ws = TempDir::new().unwrap();
+        // Mark the parent as a real workspace by creating its `.houston/` dir.
+        fs::create_dir_all(ws.path().join(".houston")).unwrap();
+        fs::write(ws.path().join("WORKSPACE.md"), "Acme Corp, B2B fintech.").unwrap();
+        fs::write(ws.path().join("USER.md"), "Juan, head of sales.").unwrap();
+
+        let agent_dir = ws.path().join("juan-agent");
+        fs::create_dir_all(&agent_dir).unwrap();
+
+        let out = build_agent_context(&agent_dir, None, None);
+
+        assert!(out.contains("# Workspace Context"));
+        assert!(out.contains("Acme Corp, B2B fintech."));
+        assert!(out.contains("# User Context"));
+        assert!(out.contains("Juan, head of sales."));
+    }
+
+    #[test]
+    fn build_agent_context_skips_workspace_section_when_no_workspace_marker() {
+        let d = TempDir::new().unwrap();
+        // No `.houston/` in parent => not a workspace child.
+        let out = build_agent_context(d.path(), None, None);
+        assert!(!out.contains("# Workspace Context"));
+        assert!(!out.contains("# User Context"));
     }
 
     #[test]

--- a/engine/houston-engine-core/src/lib.rs
+++ b/engine/houston-engine-core/src/lib.rs
@@ -20,6 +20,7 @@ pub mod skills;
 pub mod state;
 pub mod store;
 pub mod worktree;
+pub mod workspace_context;
 pub mod workspaces;
 
 pub use error::{CoreError, CoreResult};

--- a/engine/houston-engine-core/src/workspace_context.rs
+++ b/engine/houston-engine-core/src/workspace_context.rs
@@ -1,0 +1,192 @@
+//! Workspace-level context files.
+//!
+//! Two markdown files live at the root of every workspace directory:
+//!
+//! - `WORKSPACE.md` — facts about the company / project / shared environment.
+//!   Same for every agent in this workspace.
+//! - `USER.md` — facts about the human running this workspace (role, goals,
+//!   preferences). Per-workspace today; will become per-account once Houston
+//!   ships multi-user workspaces.
+//!
+//! Both files start empty (the Settings UI shows its empty state until the
+//! user writes something) and get appended to every agent's system prompt at
+//! session start. They are user-editable (Settings UI) and agent-editable
+//! (the agent can update them via the normal file-write tool when the user
+//! shares new info). Changes take effect on the **next** chat — running
+//! sessions keep the copy that was baked into their prompt at spawn.
+
+use crate::error::{CoreError, CoreResult};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+pub const WORKSPACE_MD: &str = "WORKSPACE.md";
+pub const USER_MD: &str = "USER.md";
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceContext {
+    pub workspace: String,
+    pub user: String,
+}
+
+fn workspace_path(ws_dir: &Path) -> PathBuf {
+    ws_dir.join(WORKSPACE_MD)
+}
+
+fn user_path(ws_dir: &Path) -> PathBuf {
+    ws_dir.join(USER_MD)
+}
+
+fn read_or_empty(path: &Path) -> String {
+    fs::read_to_string(path).unwrap_or_default()
+}
+
+/// Read both files. Missing files report as empty strings.
+pub fn read(ws_dir: &Path) -> CoreResult<WorkspaceContext> {
+    Ok(WorkspaceContext {
+        workspace: read_or_empty(&workspace_path(ws_dir)),
+        user: read_or_empty(&user_path(ws_dir)),
+    })
+}
+
+/// Overwrite both files with the supplied content.
+pub fn write(ws_dir: &Path, ctx: &WorkspaceContext) -> CoreResult<()> {
+    fs::create_dir_all(ws_dir)?;
+    fs::write(workspace_path(ws_dir), &ctx.workspace)?;
+    fs::write(user_path(ws_dir), &ctx.user)?;
+    Ok(())
+}
+
+/// Resolve a workspace directory by id under the given root.
+pub fn resolve_dir(root: &Path, id: &str) -> CoreResult<PathBuf> {
+    let workspaces = crate::workspaces::read_all(root)?;
+    let ws = workspaces
+        .iter()
+        .find(|w| w.id == id)
+        .ok_or_else(|| CoreError::NotFound(format!("workspace {id}")))?;
+    Ok(root.join(&ws.name))
+}
+
+/// Build the prompt section the engine appends to every agent's system prompt.
+///
+/// Always present for any agent whose parent dir is a real workspace (has a
+/// `.houston/` subfolder), even when both files are empty: the section tells
+/// the agent the slots exist, what they're for, and that it's authorized to
+/// write them when the user shares new info.
+///
+/// Returns `None` only when `ws_dir` does not look like a real workspace, so
+/// test agent dirs and ad-hoc working dirs are not polluted with stub paths.
+pub fn build_prompt_section(ws_dir: &Path) -> Option<String> {
+    if !ws_dir.join(".houston").exists() {
+        return None;
+    }
+    let workspace_md_path = workspace_path(ws_dir);
+    let user_md_path = user_path(ws_dir);
+
+    let workspace = read_or_empty(&workspace_md_path);
+    let user = read_or_empty(&user_md_path);
+
+    let workspace_body = if workspace.trim().is_empty() {
+        "(empty so far. When the user shares anything about the company, \
+         product, customers, or workspace conventions, write it to the file \
+         path below.)"
+            .to_string()
+    } else {
+        workspace.trim_end().to_string()
+    };
+    let user_body = if user.trim().is_empty() {
+        "(empty so far. When the user tells you about their role, goals, or \
+         how they like to work, write it to the file path below.)"
+            .to_string()
+    } else {
+        user.trim_end().to_string()
+    };
+
+    let mut out = String::new();
+    out.push_str("# Workspace Context\n\n");
+    out.push_str(&workspace_body);
+    out.push_str("\n\n# User Context\n\n");
+    out.push_str(&user_body);
+    out.push_str(&format!(
+        "\n\nThe two sections above are loaded from these files at the root \
+         of the workspace:\n\
+         - `{}` — facts about the workspace, shared by every agent here.\n\
+         - `{}` — facts about the user running this workspace.\n\n\
+         When the user tells you something new about themselves or about the \
+         workspace, update the matching file using its absolute path above so \
+         future chats remember it. These two files are an explicit exception \
+         to your working-directory rule, you are allowed to read and write \
+         them. Edits take effect on the next chat, the current chat keeps the \
+         copy that was loaded at startup.",
+        workspace_md_path.display(),
+        user_md_path.display(),
+    ));
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn read_returns_empty_when_files_absent() {
+        let d = TempDir::new().unwrap();
+        let ctx = read(d.path()).unwrap();
+        assert_eq!(ctx.workspace, "");
+        assert_eq!(ctx.user, "");
+    }
+
+    #[test]
+    fn write_round_trips() {
+        let d = TempDir::new().unwrap();
+        write(
+            d.path(),
+            &WorkspaceContext {
+                workspace: "Acme Corp, B2B fintech.".into(),
+                user: "Juan, sales lead.".into(),
+            },
+        )
+        .unwrap();
+        let ctx = read(d.path()).unwrap();
+        assert_eq!(ctx.workspace, "Acme Corp, B2B fintech.");
+        assert_eq!(ctx.user, "Juan, sales lead.");
+    }
+
+    #[test]
+    fn build_prompt_section_includes_filled_content() {
+        let d = TempDir::new().unwrap();
+        fs::create_dir_all(d.path().join(".houston")).unwrap();
+        fs::write(d.path().join(WORKSPACE_MD), "Acme Corp.").unwrap();
+        fs::write(d.path().join(USER_MD), "Juan, sales.").unwrap();
+        let out = build_prompt_section(d.path()).unwrap();
+        assert!(out.contains("# Workspace Context"));
+        assert!(out.contains("Acme Corp."));
+        assert!(out.contains("# User Context"));
+        assert!(out.contains("Juan, sales."));
+        assert!(out.contains("WORKSPACE.md"));
+        assert!(out.contains("USER.md"));
+    }
+
+    #[test]
+    fn build_prompt_section_uses_empty_markers_when_files_missing() {
+        let d = TempDir::new().unwrap();
+        fs::create_dir_all(d.path().join(".houston")).unwrap();
+        let out = build_prompt_section(d.path()).unwrap();
+        assert!(out.contains("# Workspace Context"));
+        assert!(out.contains("(empty so far"));
+        assert!(out.contains("# User Context"));
+        // Files should NOT have been auto-created — UI relies on absence to
+        // render its empty state.
+        assert!(!d.path().join(WORKSPACE_MD).exists());
+        assert!(!d.path().join(USER_MD).exists());
+    }
+
+    #[test]
+    fn build_prompt_section_returns_none_outside_workspace() {
+        let d = TempDir::new().unwrap();
+        // No `.houston/` => not a real workspace; skip injection.
+        assert!(build_prompt_section(d.path()).is_none());
+    }
+}

--- a/engine/houston-engine-server/src/routes/workspaces.rs
+++ b/engine/houston-engine-server/src/routes/workspaces.rs
@@ -8,6 +8,7 @@ use axum::{
     Json, Router,
 };
 use houston_engine_core::agents_crud::{self, Agent, CreateAgent, CreateAgentResult, UpdateAgent};
+use houston_engine_core::workspace_context::{self, WorkspaceContext};
 use houston_engine_core::workspaces::{
     self, CreateWorkspace, RenameWorkspace, UpdateProvider, Workspace,
 };
@@ -20,6 +21,10 @@ pub fn router() -> Router<Arc<ServerState>> {
         .route("/workspaces/:id", delete(remove))
         .route("/workspaces/:id/rename", post(rename))
         .route("/workspaces/:id/provider", patch(set_provider))
+        .route(
+            "/workspaces/:id/context",
+            get(get_context).put(put_context),
+        )
         // Workspace-scoped agents CRUD.
         .route(
             "/workspaces/:id/agents",
@@ -72,6 +77,24 @@ async fn set_provider(
         &id,
         req,
     )?))
+}
+
+async fn get_context(
+    State(st): State<Arc<ServerState>>,
+    Path(id): Path<String>,
+) -> Result<Json<WorkspaceContext>, ApiError> {
+    let dir = workspace_context::resolve_dir(st.engine.paths.docs(), &id)?;
+    Ok(Json(workspace_context::read(&dir)?))
+}
+
+async fn put_context(
+    State(st): State<Arc<ServerState>>,
+    Path(id): Path<String>,
+    Json(body): Json<WorkspaceContext>,
+) -> Result<Json<WorkspaceContext>, ApiError> {
+    let dir = workspace_context::resolve_dir(st.engine.paths.docs(), &id)?;
+    workspace_context::write(&dir, &body)?;
+    Ok(Json(workspace_context::read(&dir)?))
 }
 
 // -- Workspace-scoped agent CRUD --

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -172,7 +172,7 @@ submenu.
 ## Workspace
 - Storage: `~/.houston/workspaces/workspaces.json` (index) + one dir per workspace `~/.houston/workspaces/{Name}/`. `HOUSTON_DOCS` env var overrides the root.
 - First launch: welcome screen, create first workspace
-- Engine routes: `GET /v1/workspaces`, `POST /v1/workspaces`, `POST /v1/workspaces/:id/rename`, `DELETE /v1/workspaces/:id`, `PATCH /v1/workspaces/:id/provider` (`engine/houston-engine-server/src/routes/workspaces.rs`). Frontend reaches them via `@houston-ai/engine-client` — no Tauri commands in the path.
+- Engine routes: `GET /v1/workspaces`, `POST /v1/workspaces`, `POST /v1/workspaces/:id/rename`, `DELETE /v1/workspaces/:id`, `PATCH /v1/workspaces/:id/provider`, `GET|PUT /v1/workspaces/:id/context` (`engine/houston-engine-server/src/routes/workspaces.rs`). Frontend reaches them via `@houston-ai/engine-client` — no Tauri commands in the path.
 - Store: `useWorkspaceStore` — `loadWorkspaces()`, `setCurrent()`, `create()`, `rename()`, `delete()`
 
 ## Prompt assembly
@@ -186,12 +186,13 @@ Built in `engine/houston-engine-core/src/agents/prompt.rs::build_agent_context`:
 1. **Working directory block** — hard rules scoping file I/O to `<agent-root>`.
 2. Mode file `.houston/prompts/modes/<mode>.md` (optional, user-editable).
 3. Learnings snapshot — `.houston/learnings/learnings.json`, text fields only, rendered as bounded background context. IDs/timestamps stay storage/UI-only.
-4. Skills index — `.agents/skills/` via `houston_skills::build_skills_index`.
-5. Integrations block — based on `.houston/integrations.json` if present.
+4. **Workspace context block** — assembled from `<workspace>/WORKSPACE.md` + `<workspace>/USER.md` (the agent's parent dir) by `workspace_context::build_prompt_section`. Always included for any agent whose parent dir has a `.houston/`. Files are NOT seeded — they only exist once the user or an agent writes them; until then the section renders an "(empty so far, ask the user when relevant)" marker so the agent knows the slot exists. Section explicitly authorizes the agent to read/write these two files (carve-out from the working-directory rule) and tells it that edits take effect on the **next** chat.
+5. Skills index — `.agents/skills/` via `houston_skills::build_skills_index`.
+6. Integrations block — based on `.houston/integrations.json` if present.
 
 `CLAUDE.md` is read by the CLI (claude/codex) itself at startup, not injected by the engine.
 
-Users cannot edit the product prompt — it's compiled into the app binary. Per-agent surfaces that ARE user-editable: `CLAUDE.md` (job description), `.agents/skills/` (skills), `.houston/learnings/learnings.json` (learnings), `.houston/prompts/modes/*.md` (mode overrides).
+Users cannot edit the product prompt — it's compiled into the app binary. Per-agent surfaces that ARE user-editable: `CLAUDE.md` (job description), `.agents/skills/` (skills), `.houston/learnings/learnings.json` (learnings), `.houston/prompts/modes/*.md` (mode overrides). Per-workspace surfaces (shared by every agent in the workspace): `WORKSPACE.md` (about the company/project), `USER.md` (about the human running it). Both edited from Settings → Workspace → Shared context, or directly by agents when the user shares new info.
 
 ## Board / Activity tab
 `@houston-ai/board::AIBoard` = `KanbanBoard` + `KanbanDetailPanel` + `ChatPanel`. Each card = activity from `.houston/activity/activity.json`. Click → opens chat w/ conversation history. App `board-tab.tsx` ~140 lines, thin store wrapper.

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -95,6 +95,8 @@ module.
 | DELETE | `/v1/workspaces/:id` | Delete |
 | POST | `/v1/workspaces/:id/rename` | Rename |
 | PATCH | `/v1/workspaces/:id/provider` | Set provider/model |
+| GET | `/v1/workspaces/:id/context` | Read shared `WORKSPACE.md` + `USER.md` |
+| PUT | `/v1/workspaces/:id/context` | Write shared `WORKSPACE.md` + `USER.md` |
 | GET | `/v1/workspaces/:id/agents` | List agents in workspace |
 | POST | `/v1/workspaces/:id/agents` | Create agent |
 | DELETE | `/v1/workspaces/:id/agents/:agent_id` | Delete agent |

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -68,6 +68,7 @@ import type {
   UpdateProvider,
   VersionResponse,
   Workspace,
+  WorkspaceContext,
   WorktreeInfo,
 } from "./types";
 import { planAttachmentUploadBatches } from "./attachments";
@@ -183,6 +184,12 @@ export class HoustonClient {
   }
   installWorkspaceFromGithub(req: InstallFromGithub): Promise<ImportedWorkspace> {
     return this.request("POST", "/workspaces/install-from-github", req);
+  }
+  getWorkspaceContext(id: string): Promise<WorkspaceContext> {
+    return this.request("GET", `/workspaces/${this.seg(id)}/context`);
+  }
+  setWorkspaceContext(id: string, body: WorkspaceContext): Promise<WorkspaceContext> {
+    return this.request("PUT", `/workspaces/${this.seg(id)}/context`, body);
   }
 
   // ---------- workspace-scoped agents ----------

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -84,6 +84,11 @@ export interface UpdateProvider {
   model?: string;
 }
 
+export interface WorkspaceContext {
+  workspace: string;
+  user: string;
+}
+
 // ---------- Workspace-scoped agent CRUD ----------
 
 export interface Agent {


### PR DESCRIPTION
## Summary

Two markdown files at the root of each workspace now feed every agent's system prompt at session start, so agents in the same workspace share context about the company / product / customers, and pick up details about the specific human running the workspace.

- `WORKSPACE.md` — about the company, product, customers; same for every agent in the workspace
- `USER.md` — about the human running this workspace (role, goals, preferences); per-workspace today, will become per-account once Houston ships multi-user workspaces

Both are editable from two new top-level Settings tabs (Workspace context, User context) that mirror the agent Instructions tab UX exactly: same `InstructionsContent` component with empty-state, auto-save on blur, idle/saving/saved indicator. Agents can also write them through the normal file-write tool when the user shares new info.

## How it flows into agents

`engine/houston-engine-core/src/workspace_context.rs::build_prompt_section` is invoked from `build_agent_context` for every agent whose parent dir is a real workspace. The section is always injected — even when both files are empty it shows "(empty so far, ask the user when relevant)" markers plus the absolute file paths, so the agent always knows the slots exist and is explicitly authorized to write them (carve-out from the working-directory rule). Edits take effect on the next chat — the running session keeps the copy that was loaded at startup, matching the user's intent of "for many small chats rather than one big chat."

Files are NOT pre-seeded with template stubs, so the Settings textarea shows its empty-state UI until the user writes something.

## REST surface

- `GET /v1/workspaces/:id/context` → `{ workspace, user }`
- `PUT /v1/workspaces/:id/context` ← `{ workspace, user }`

Wired through `@houston-ai/engine-client` as `getWorkspaceContext` / `setWorkspaceContext`, then `tauriWorkspaces.{getContext,setContext}`, and TanStack Query hooks `useWorkspaceContext` / `useSaveWorkspaceContext`.

## Test plan

- [x] `cargo test -p houston-engine-core --lib` — 144 pass (4 new tests covering read/write round-trip, prompt-section injection with filled and empty content, no injection outside a workspace, and the agent-context integration)
- [x] `cargo build -p houston-engine-server` — clean
- [x] `pnpm typecheck` — green across all 15 packages
- [x] `pnpm check-locales` — en/es/pt in sync, no em dashes
- [ ] Manual: open Settings → Workspace context → write something → start a new chat in any agent → confirm the agent knows the workspace context
- [ ] Manual: tell an agent something new about the workspace and ask it to remember → confirm `WORKSPACE.md` updates → next chat reflects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)