### PR TITLE
feat(website): gated Windows download (x64 + ARM64) on landing page

### DIFF
--- a/website/src/index.html
+++ b/website/src/index.html
@@ -2242,11 +2242,21 @@ visionPath: "vision/index.html"
 
 <div class="dl-overlay" id="dl-overlay-windows">
   <div class="dl-card">
-    <h3>Windows is in beta</h3>
-    <p>Windows is under active development. Join the waiting list to get early access when it's ready.</p>
+    <h3>We're on a closed beta</h3>
+    <p>If you were invited, paste your code and pick your Windows version.</p>
+    <input type="text" class="dl-input" id="dl-windows-code" placeholder="Paste your invite code" autocomplete="off" spellcheck="false">
     <div class="dl-actions">
-      <a id="dl-windows-waitlist" href="https://forms.gle/ac24qrKSufYvfudt8" target="_blank" rel="noopener noreferrer" class="btn btn-primary btn-lg">Join the waiting list</a>
+      <a id="dl-windows-x64-btn" class="btn btn-primary btn-lg btn-disabled"><svg viewBox="0 0 448 512" fill="currentColor" width="16" height="16"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg> Windows (x64 / Intel / AMD)</a>
+      <a id="dl-windows-arm64-btn" class="btn btn-secondary btn-lg btn-disabled"><svg viewBox="0 0 448 512" fill="currentColor" width="16" height="16"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg> Windows (ARM64 / Surface, Snapdragon)</a>
+      <span class="dl-divider">or join our waiting list to get access</span>
+      <a id="dl-windows-waitlist" href="https://forms.gle/ac24qrKSufYvfudt8" target="_blank" rel="noopener noreferrer" class="btn btn-secondary btn-lg">Join the waiting list</a>
     </div>
+    <details class="dl-skip" id="dl-windows-skip">
+      <summary>Not sure which one to pick?</summary>
+      <div class="dl-skip-body">
+        <p>Most laptops and desktops are x64 (Intel or AMD CPUs). Pick ARM64 only if you're on a Surface Pro X, Surface Pro 9 5G, a Snapdragon X laptop, or another ARM-based Windows machine. On first install you'll see one SmartScreen "Run anyway" prompt; we're working on full code-signing.</p>
+      </div>
+    </details>
   </div>
 </div>
 
@@ -2543,15 +2553,23 @@ visionPath: "vision/index.html"
     var skipDetails = document.getElementById('dl-skip');
     var xLink = document.getElementById('dl-x-link');
     var dmgUrl = null;
+    var winX64Url = null;
+    var winArm64Url = null;
     var unlockedFired = false;
+    var winUnlockedFired = false;
     var lastSource = 'unknown';
 
-    // Fetch latest release DMG URL
+    // Fetch latest release artifact URLs (Mac DMG + Windows MSIs)
     fetch('https://api.github.com/repos/gethouston/houston/releases/latest')
       .then(function(r) { return r.json(); })
       .then(function(data) {
-        var dmg = data.assets && data.assets.find(function(a) { return a.name.endsWith('.dmg'); });
+        var assets = data.assets || [];
+        var dmg = assets.find(function(a) { return a.name.endsWith('.dmg'); });
         if (dmg) dmgUrl = dmg.browser_download_url;
+        var winX64 = assets.find(function(a) { return /_x64.*\.msi$/.test(a.name); });
+        if (winX64) winX64Url = winX64.browser_download_url;
+        var winArm64 = assets.find(function(a) { return /_arm64.*\.msi$/.test(a.name); });
+        if (winArm64) winArm64Url = winArm64.browser_download_url;
       });
 
     // Open modal
@@ -2608,10 +2626,25 @@ visionPath: "vision/index.html"
       });
     }
 
-    // Windows beta modal
+    // Windows download modal (mirrors Mac: invite code gate + per-arch button)
     var winOverlay = document.getElementById('dl-overlay-windows');
+    var winInput = document.getElementById('dl-windows-code');
+    var winX64Btn = document.getElementById('dl-windows-x64-btn');
+    var winArm64Btn = document.getElementById('dl-windows-arm64-btn');
     var winWaitlist = document.getElementById('dl-windows-waitlist');
+    var winSkipDetails = document.getElementById('dl-windows-skip');
     var winLastSource = 'unknown';
+
+    function setWinButton(btn, url, match) {
+      if (!btn) return;
+      if (match && url) {
+        btn.href = url;
+        btn.classList.remove('btn-disabled');
+      } else {
+        btn.removeAttribute('href');
+        btn.classList.add('btn-disabled');
+      }
+    }
 
     if (winOverlay) {
       document.querySelectorAll('[data-dl-windows-trigger]').forEach(function(el) {
@@ -2620,6 +2653,7 @@ visionPath: "vision/index.html"
           winLastSource = el.getAttribute('data-dl-source') || 'unknown';
           track('windows_modal_opened', { source: winLastSource });
           winOverlay.classList.add('open');
+          setTimeout(function() { if (winInput) winInput.focus(); }, 200);
         });
       });
 
@@ -2631,9 +2665,50 @@ visionPath: "vision/index.html"
         if (e.key === 'Escape') winOverlay.classList.remove('open');
       });
 
+      // Validate code → unlock both Windows download buttons
+      if (winInput) {
+        winInput.addEventListener('input', function() {
+          var match = winInput.value.trim() === CODE;
+          winInput.classList.toggle('valid', match);
+          setWinButton(winX64Btn, winX64Url, match);
+          setWinButton(winArm64Btn, winArm64Url, match);
+          if (match && !winUnlockedFired) {
+            winUnlockedFired = true;
+            track('windows_download_unlocked', { source: winLastSource });
+          }
+        });
+      }
+
+      // Track actual downloads
+      if (winX64Btn) {
+        winX64Btn.addEventListener('click', function(e) {
+          if (winX64Btn.classList.contains('btn-disabled')) {
+            e.preventDefault();
+            return;
+          }
+          track('windows_download_started', { source: winLastSource, arch: 'x64', msi_url: winX64Url || '' });
+        });
+      }
+      if (winArm64Btn) {
+        winArm64Btn.addEventListener('click', function(e) {
+          if (winArm64Btn.classList.contains('btn-disabled')) {
+            e.preventDefault();
+            return;
+          }
+          track('windows_download_started', { source: winLastSource, arch: 'arm64', msi_url: winArm64Url || '' });
+        });
+      }
+
       if (winWaitlist) {
         winWaitlist.addEventListener('click', function() {
           track('windows_waitlist_clicked', { source: winLastSource });
+        });
+      }
+      if (winSkipDetails) {
+        winSkipDetails.addEventListener('toggle', function() {
+          if (winSkipDetails.open) {
+            track('windows_arch_help_expanded', { source: winLastSource });
+          }
         });
       }
     }


### PR DESCRIPTION
## Summary

Now that v0.4.10 ships native Windows x64 + ARM64 MSIs, the landing page can actually hand them out instead of routing to a waitlist.

- Windows modal now mirrors the Mac modal: invite-code gate, then two download buttons (one per arch).
- Both MSI URLs come from the same \`GET /repos/gethouston/houston/releases/latest\` call that already runs for the DMG — one round-trip, three artifacts extracted.
- Waitlist stays as a secondary "still don't have a code" CTA.
- New "Not sure which one to pick?" details element disambiguates x64 vs ARM64 for non-technical users and mentions the one-time SmartScreen prompt (MSI is not OS-code-signed yet).

## PostHog events

- \`windows_modal_opened\` (existing)
- \`windows_download_unlocked\` (new — fires once when code validates)
- \`windows_download_started\` (new — fires with \`arch\` + \`msi_url\`)
- \`windows_arch_help_expanded\` (new)
- \`windows_waitlist_clicked\` (existing)

## Test plan

Already deployed live to https://gethouston.ai via \`wrangler pages\`. To verify:
- [ ] Click "Download for Windows" on hero or pricing → modal opens
- [ ] Paste invite code → both Windows buttons become clickable, both hrefs point at the v0.4.10 MSIs
- [ ] x64 button downloads \`Houston_0.4.10_x64_en-US.msi\`
- [ ] ARM64 button downloads \`Houston_0.4.10_arm64_en-US.msi\`
- [ ] Expanding "Not sure which one to pick?" fires \`windows_arch_help_expanded\`