### PR TITLE
fix(workspaces): self-heal corrupt index + per-call tmp filename (0.4.11)

### DIFF
--- a/.github/release-notes/0.4.11.md
+++ b/.github/release-notes/0.4.11.md
@@ -1,31 +1,21 @@
 ## Houston 0.4.11
 
-The Windows first-launch crash-loop fix. If you installed the v0.4.10 MSI on Windows and saw a black Houston window, a small "loading" dialog beside it, the Houston window close, and then nothing, this release is for you. Everything in 0.4.10 is still here; this is a pure bug-fix on top of it.
+A hotfix release. 0.4.10 shipped a race condition that could leave your workspace index on disk with a few stray bytes at the end after two rapid actions on the same workspace, for example two provider changes back to back. Once that happened, Houston would fail to load workspaces and agents on next launch and drop you on the "start tutorial" screen with nothing reachable.
 
-### Fixed
+### What this fixes
 
-- **Windows: first-launch crash loop is gone.** On 0.4.10 the bundled PortableGit archive was extracted by running its self-extracting `.exe` as a subprocess. That subprocess always renders its own progress dialog regardless of how it is launched (the "small loading window" users reported), and the extraction blocked the engine from coming up before the Tauri app's health-check budget expired. The result: the engine crashed mid-extract every launch, no PortableGit ever finalized, and clicking Houston put you back at the same screen. v0.4.11 decodes the embedded 7z archive in-process (no subprocess, no dialog), runs PortableGit provisioning in the background so the engine HTTP layer is responsive immediately, and stages the extraction in a temporary directory that is renamed into place atomically so a partial extraction can never poison the install. Houston starts on the first click and the agent chat is reachable inside of a second.
+- **Self-healing workspace index.** On launch, Houston now detects the corrupted shape, recovers the valid part, and rewrites the file cleanly. If you have been stuck on the start tutorial after a recent update, just install 0.4.11 and relaunch. Your workspaces and agents come back automatically. No manual file editing, no data loss.
+- **No more race on the workspace index.** The writer now uses a unique temp filename per save, so two concurrent updates can never stomp each other again.
 
 ### Before you upgrade
 
 - **Mac:** quit Houston before installing. macOS does not always replace a running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag the new copy in.
-- **Windows x64:** if you are stuck in the 0.4.10 install loop, uninstall Houston from Add/Remove Programs first, then install the 0.4.11 MSI. Auto-update from any working install (0.4.7 through 0.4.9 inclusive) pulls you forward automatically. The MSI is still not OS-code-signed (SignPath integration is still pending), so expect one SmartScreen "Run anyway" prompt on first install.
-- **Windows ARM64:** there is no auto-update path from an emulated x64 install. Download the ARM64 MSI manually, uninstall the x64 build first, then install the ARM64 one. Future ARM64 to ARM64 updates apply automatically.
 
-### If you are on 0.4.5 or later (Mac / Windows x64 that is actually running)
+### If you are currently stuck on the start tutorial
 
-Houston should detect 0.4.11, download it, install it, and relaunch into the new version on its own.
-
-### If you installed the 0.4.10 MSI on Windows and were stuck
-
-Auto-update never had a chance to run because Houston never reached a steady state. Uninstall 0.4.10 from Add/Remove Programs, download the 0.4.11 MSI from the GitHub release page, and install. After that one manual step you are back on the healthy updater path and future versions apply automatically.
-
-### If you are on 0.4.2 or earlier (Mac)
-
-Auto-update will not pull you forward from those builds. Quit Houston, drag a fresh DMG over `/Applications/Houston.app`, and reopen. After that one manual step you are back on the healthy updater path and future versions apply automatically.
+Auto-update should still reach you because the update notification lives outside the broken workspace surface. If for any reason it does not, download the 0.4.11 DMG from the GitHub release page and drag it over `/Applications/Houston.app`. The new app reads your existing `~/.houston/` and repairs the file on first launch.
 
 ### Known limitations
 
-- **Windows MSI not yet OS-code-signed.** SignPath integration still pending. One SmartScreen "Run anyway" click on first install only, both x64 and ARM64.
-- **"Continue with Microsoft" sign-in for Houston itself remains hidden** while we reconcile the Supabase Azure provider with the production callback URL. Google sign-in is unaffected. The Microsoft 365 + Outlook tutorial path is unaffected.
-- **Mobile companion is still beta.** Expect occasional reconnect hiccups. Keep your Mac awake while using it.
+- If you manually edited `~/.houston/workspaces/workspaces.json` to recover from this bug earlier, you do not need to do anything. Your file is already clean.
+- The self-healing only catches the specific "valid JSON + trailing bytes" pattern this bug produced. A file that is mangled in a different way will still surface a real error so you can see it.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2632,7 +2632,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "houston-agent-files",
  "houston-agents-conversations",

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.10",
+  "version": "0.4.11",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 
 [lib]

--- a/engine/houston-engine-core/src/workspaces/io.rs
+++ b/engine/houston-engine-core/src/workspaces/io.rs
@@ -1,0 +1,138 @@
+//! Workspace index file I/O: read, atomic write, and self-healing recovery.
+//!
+//! The recovery path exists because 0.4.19 shipped a writer that shared a
+//! single `workspaces.json.tmp` path across all callers. Two concurrent
+//! writes could race on that path and commit a target file with valid JSON
+//! followed by a few leftover bytes from the longer writer. The new writer
+//! uses a per-call tmp filename so the race cannot recur; the reader still
+//! knows how to fix existing files in the field.
+
+use super::Workspace;
+use crate::error::CoreResult;
+use std::fs;
+use std::path::{Path, PathBuf};
+use uuid::Uuid;
+
+pub(super) fn json_path(root: &Path) -> PathBuf {
+    root.join("workspaces.json")
+}
+
+pub fn read_all(root: &Path) -> CoreResult<Vec<Workspace>> {
+    let path = json_path(root);
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let contents = fs::read_to_string(&path)?;
+    match serde_json::from_str::<Vec<Workspace>>(&contents) {
+        Ok(v) => Ok(v),
+        Err(e) => recover_trailing_garbage(&path, &contents, e),
+    }
+}
+
+pub(super) fn write_all(root: &Path, workspaces: &[Workspace]) -> CoreResult<()> {
+    fs::create_dir_all(root)?;
+    write_atomic(root, workspaces)
+}
+
+fn write_atomic(root: &Path, workspaces: &[Workspace]) -> CoreResult<()> {
+    let target = json_path(root);
+    let tmp = root.join(format!("workspaces.json.{}.tmp", Uuid::new_v4()));
+    let json = serde_json::to_string_pretty(workspaces)?;
+    if let Err(e) = fs::write(&tmp, &json) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    if let Err(e) = fs::rename(&tmp, &target) {
+        let _ = fs::remove_file(&tmp);
+        return Err(e.into());
+    }
+    Ok(())
+}
+
+fn recover_trailing_garbage(
+    path: &Path,
+    contents: &str,
+    original: serde_json::Error,
+) -> CoreResult<Vec<Workspace>> {
+    let bracket_positions: Vec<usize> = contents.match_indices(']').map(|(i, _)| i).collect();
+    let mut recovered: Option<(Vec<Workspace>, usize)> = None;
+    for end in bracket_positions.into_iter().rev() {
+        let prefix = &contents[..=end];
+        if let Ok(v) = serde_json::from_str::<Vec<Workspace>>(prefix) {
+            recovered = Some((v, end + 1));
+            break;
+        }
+    }
+    let (parsed, consumed) = match recovered {
+        Some(r) => r,
+        None => return Err(original.into()),
+    };
+    let dropped = contents.len().saturating_sub(consumed);
+    if let Some(root) = path.parent() {
+        if let Err(e) = write_atomic(root, &parsed) {
+            tracing::warn!(
+                "[workspaces] recovered {} from corrupt {} but failed to re-save: {e}",
+                parsed.len(),
+                path.display()
+            );
+            return Ok(parsed);
+        }
+    }
+    tracing::warn!(
+        "[workspaces] repaired corrupt {} — recovered {} entries, dropped {} trailing bytes",
+        path.display(),
+        parsed.len(),
+        dropped
+    );
+    Ok(parsed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn tmp() -> TempDir {
+        TempDir::new().unwrap()
+    }
+
+    /// Reproduces the 0.4.19 corruption shape: valid JSON array followed by
+    /// trailing bytes ` }\n]`. `read_all` must recover the valid prefix and
+    /// repair the file on disk.
+    #[test]
+    fn read_recovers_from_trailing_garbage() {
+        let d = tmp();
+        fs::create_dir_all(d.path()).unwrap();
+        let valid = r#"[
+  {
+    "id": "5ae9e699-a5d7-4f8a-9ae1-17be89aafcf9",
+    "name": "Personal",
+    "isDefault": false,
+    "createdAt": "2026-05-15T13:39:01.200349+00:00",
+    "provider": "anthropic",
+    "model": "sonnet"
+  }
+]"#;
+        let corrupt = format!("{valid} }}\n]");
+        fs::write(d.path().join("workspaces.json"), &corrupt).unwrap();
+
+        let got = read_all(d.path()).unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].name, "Personal");
+
+        let on_disk = fs::read_to_string(d.path().join("workspaces.json")).unwrap();
+        let reparsed: Vec<Workspace> = serde_json::from_str(&on_disk).unwrap();
+        assert_eq!(reparsed.len(), 1);
+        assert_eq!(reparsed[0].name, "Personal");
+    }
+
+    /// Truly malformed JSON (not "valid prefix + trailing junk") must still
+    /// error. We don't want recovery to silently mask bad files.
+    #[test]
+    fn read_errors_on_unrecoverable_json() {
+        let d = tmp();
+        fs::create_dir_all(d.path()).unwrap();
+        fs::write(d.path().join("workspaces.json"), "{not json at all").unwrap();
+        assert!(read_all(d.path()).is_err());
+    }
+}

--- a/engine/houston-engine-core/src/workspaces/mod.rs
+++ b/engine/houston-engine-core/src/workspaces/mod.rs
@@ -1,12 +1,18 @@
 //! Workspace CRUD — relocated from `app/src-tauri/src/commands/workspaces.rs`.
 //!
 //! Transport-neutral: operates on a filesystem root. HTTP routes call these
-//! functions; so do tests and CLI tools.
+//! functions; so do tests and CLI tools. File I/O lives in [`io`], which
+//! also owns the self-healing read used to recover `workspaces.json` files
+//! corrupted by the 0.4.19 concurrent-writer race.
+
+mod io;
+
+pub use io::read_all;
 
 use crate::error::{CoreError, CoreResult};
 use serde::{Deserialize, Serialize};
 use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use uuid::Uuid;
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
@@ -43,31 +49,8 @@ pub struct RenameWorkspace {
     pub new_name: String,
 }
 
-fn json_path(root: &Path) -> PathBuf {
-    root.join("workspaces.json")
-}
-
 fn now_iso() -> String {
     chrono::Utc::now().to_rfc3339()
-}
-
-pub fn read_all(root: &Path) -> CoreResult<Vec<Workspace>> {
-    let path = json_path(root);
-    if !path.exists() {
-        return Ok(Vec::new());
-    }
-    let contents = fs::read_to_string(&path)?;
-    serde_json::from_str(&contents).map_err(Into::into)
-}
-
-fn write_all(root: &Path, workspaces: &[Workspace]) -> CoreResult<()> {
-    let target = json_path(root);
-    let tmp = root.join("workspaces.json.tmp");
-    fs::create_dir_all(root)?;
-    let json = serde_json::to_string_pretty(workspaces)?;
-    fs::write(&tmp, &json)?;
-    fs::rename(&tmp, &target)?;
-    Ok(())
 }
 
 pub fn list(root: &Path) -> CoreResult<Vec<Workspace>> {
@@ -98,7 +81,7 @@ pub fn create(root: &Path, req: CreateWorkspace) -> CoreResult<Workspace> {
         fs::write(&connections, "[]")?;
     }
     workspaces.push(ws.clone());
-    write_all(root, &workspaces)?;
+    io::write_all(root, &workspaces)?;
     Ok(ws)
 }
 
@@ -127,7 +110,7 @@ pub fn rename(root: &Path, id: &str, req: RenameWorkspace) -> CoreResult<Workspa
     }
     ws.name = req.new_name;
     let updated = ws.clone();
-    write_all(root, &workspaces)?;
+    io::write_all(root, &workspaces)?;
     Ok(updated)
 }
 
@@ -144,7 +127,7 @@ pub fn delete(root: &Path, id: &str) -> CoreResult<()> {
     }
     let ws_dir = root.join(&ws.name);
     let remaining: Vec<Workspace> = workspaces.iter().filter(|w| w.id != id).cloned().collect();
-    write_all(root, &remaining)?;
+    io::write_all(root, &remaining)?;
     if ws_dir.exists() {
         fs::remove_dir_all(&ws_dir)?;
     }
@@ -162,7 +145,7 @@ pub fn update_provider(root: &Path, id: &str, req: UpdateProvider) -> CoreResult
         ws.model = Some(m);
     }
     let updated = ws.clone();
-    write_all(root, &workspaces)?;
+    io::write_all(root, &workspaces)?;
     Ok(updated)
 }
 
@@ -215,5 +198,47 @@ mod tests {
         assert_eq!(renamed.name, "b");
         delete(d.path(), &ws.id).unwrap();
         assert!(list(d.path()).unwrap().is_empty());
+    }
+
+    /// Concurrent writers must not corrupt the target. With the shared
+    /// `workspaces.json.tmp` path this test produced trailing-garbage files;
+    /// with per-call tmp paths every read parses cleanly.
+    #[test]
+    fn concurrent_update_provider_never_corrupts() {
+        use std::sync::Arc;
+        use std::thread;
+        let d = tmp();
+        let ws = create(
+            d.path(),
+            CreateWorkspace { name: "alpha".into(), provider: Some("anthropic".into()), model: None },
+        )
+        .unwrap();
+        let root = Arc::new(d.path().to_path_buf());
+        let id = Arc::new(ws.id.clone());
+        let mut handles = Vec::new();
+        for i in 0..16 {
+            let root = root.clone();
+            let id = id.clone();
+            handles.push(thread::spawn(move || {
+                let provider = if i % 2 == 0 { "anthropic" } else { "openai" };
+                let _ = update_provider(
+                    &root,
+                    &id,
+                    UpdateProvider { provider: provider.into(), model: None },
+                );
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        let raw = fs::read_to_string(d.path().join("workspaces.json")).unwrap();
+        let parsed: Vec<Workspace> = serde_json::from_str(&raw)
+            .expect("concurrent writes left a non-parseable workspaces.json");
+        assert_eq!(parsed.len(), 1);
+        for entry in fs::read_dir(d.path()).unwrap() {
+            let name = entry.unwrap().file_name();
+            let s = name.to_string_lossy();
+            assert!(!s.ends_with(".tmp"), "leftover tmp file: {s}");
+        }
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.10",
+  "version": "0.4.11",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- Eliminates the 0.4.10 race in `workspaces::write_all` (shared `workspaces.json.tmp` path) by switching to a per-call `workspaces.json.<uuid>.tmp` filename.
- `read_all` now self-heals files corrupted by that race: detects valid-prefix-plus-trailing-bytes shape, recovers the longest parseable prefix, atomically re-saves, and logs a warning.
- Bumps to 0.4.11 with release notes.

## Background

Two users (myself + cofounder, on the shipped 0.4.10 build) independently hit the same corruption shape — `workspaces.json` containing valid JSON followed by ` }\n]` trailing bytes. Smoking gun in the local logs:

```
2026-05-18T02:05:27 [error] [engine:update_workspace_provider] io error: No such file or directory (os error 2)
2026-05-18T02:08:43 [error] [engine:update_workspace_provider] json error: trailing characters at line 10 column 3
```

The `ENOENT` is the losing side of a race where two callers shared the same tmp path: the first rename succeeds; the second finds tmp already gone but commits its target file with the longer writer's tail leftover.

Once `workspaces.json` is corrupt, every downstream call (`list_workspaces`, `list_agents`, `create_workspace`, `update_workspace_provider`) errors and the user lands on the start tutorial with nothing reachable.

## Test plan

- [x] `cargo test -p houston-engine-core --lib workspaces` — 7/7 pass
  - `read_recovers_from_trailing_garbage` uses the exact corruption shape from the field
  - `read_errors_on_unrecoverable_json` confirms we don't silently mask unrelated corruption
  - `concurrent_update_provider_never_corrupts` spawns 16 racing writers, asserts the final file parses cleanly and no leftover tmp files remain
- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` — no regressions
- [ ] Manual verification on local stuck `~/.houston/` after install of 0.4.11 build

## Notes

- Recovery emits `tracing::warn!` only — no toast. The fix is provably-correct (we only return data that re-parses as `Vec<Workspace>`) and toasting on every list call would be obnoxious. The single warn line per launch is enough for log forensics.
- File was split into `workspaces/{mod,io}.rs` to keep both files under the 200-line non-test rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)