### PR TITLE
docs(engine): add engine design guide

### DIFF
--- a/engine-design/01-three-layers.html
+++ b/engine-design/01-three-layers.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The three layers — Houston Engine Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html" class="active"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 01
+      <span class="status shipped">Shipped</span>
+    </div>
+    <h1>The three layers.</h1>
+    <p class="lead">
+      There are exactly three pieces of Houston. Once you understand them,
+      everything else clicks into place.
+    </p>
+
+    <div class="stack">
+      <div class="stack-layer top">
+        <div class="name">Desktop app</div>
+        <div class="desc">Tauri shell, React UI. What you click. Doesn't do real work, just talks to the engine.</div>
+      </div>
+      <div class="stack-layer mid">
+        <div class="name">Engine</div>
+        <div class="desc">A Rust binary called <code>houston-engine</code>. Speaks HTTP and WebSocket. The actual brain.</div>
+      </div>
+      <div class="stack-layer bot">
+        <div class="name">Agents</div>
+        <div class="desc">Folders on disk under <code>~/.houston/workspaces/</code>. Each one a self-contained worker.</div>
+      </div>
+    </div>
+
+    <h2>The desktop app</h2>
+    <p>
+      Tauri shell plus a React UI. What you see when you launch Houston. It
+      doesn't do any real work. It's a window onto the engine.
+    </p>
+    <p>
+      Tauri gives us OS integration: file pickers, notifications, deep
+      links, tray icons. React gives us the chat, the board, the file
+      browser, all the components in <code>@houston-ai/*</code>.
+    </p>
+
+    <h2>The engine</h2>
+    <p>
+      A Rust binary called <code>houston-engine</code>. It speaks HTTP under
+      <code>/v1/*</code> and a WebSocket at <code>/v1/ws</code>. Every
+      action a user takes goes through this protocol. The engine spawns the
+      Claude or Codex CLI, watches files, fires crons, writes to SQLite.
+    </p>
+    <p>
+      The engine doesn't know about React or Tauri. It only speaks HTTP.
+      That's the most important architectural decision Houston has made.
+    </p>
+
+    <h2>Agents</h2>
+    <p>
+      Folders on disk. Each agent lives at
+      <code>~/.houston/workspaces/&lt;Workspace&gt;/&lt;Agent&gt;/</code>.
+      Inside that folder: a <code>CLAUDE.md</code> file with instructions,
+      a <code>.houston/</code> directory with typed data files, and an
+      <code>.agents/skills/</code> directory with installed skills.
+    </p>
+    <p>
+      An agent has no process attached to it. It's not "running" except
+      when the engine spawns its CLI to handle a turn. Otherwise it's just
+      a folder waiting to be invoked.
+    </p>
+
+    <h2>Why the split matters</h2>
+    <p>
+      The desktop app is <strong>interchangeable</strong>. You could
+      replace it with a mobile app, a CLI, a third-party UI. They all
+      speak the same protocol to the same engine. The engine doesn't care
+      what's talking to it.
+    </p>
+    <p>
+      This split is what lets the engine run on a server. What lets the
+      engine be open source while the cloud product stays managed. What
+      lets a power user write their own frontend. Same engine.
+    </p>
+
+    <div class="tech-box">
+      <div class="label">Where to look in the code</div>
+      <p>Engine: <code>engine/houston-engine-server</code> plus 15 supporting crates under <code>engine/</code>. Desktop: <code>app/</code>. Wire protocol types: <code>engine/houston-engine-protocol</code> and <code>ui/engine-client</code>. Reference custom frontend: <code>examples/smartbooks/</code>.</p>
+    </div>
+
+    <div class="pager">
+      <a href="index.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Overview</div>
+      </a>
+      <a href="02-agent-folder.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">An agent is a folder</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/engine-design/02-agent-folder.html
+++ b/engine-design/02-agent-folder.html
@@ -1,0 +1,134 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>An agent is a folder — Houston Engine Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html" class="active"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 02
+      <span class="status shipped">Shipped</span>
+    </div>
+    <h1>An agent is a folder.</h1>
+    <p class="lead">
+      When you create a new agent in Houston, what really happens is that
+      we make a folder. No databases. No proprietary formats. Just files.
+    </p>
+
+    <h2>What's inside</h2>
+    <p>
+      Open <code>~/.houston/workspaces/MyCompany/Sales/</code> and you see
+      this:
+    </p>
+
+<div class="tree"><span class="dir">CLAUDE.md</span>             <span class="comment">← the agent's instructions</span>
+<span class="dir">.houston/</span>
+  <span class="dir">agent.json</span>          <span class="comment">← metadata (id, created_at)</span>
+  <span class="dir">activity/</span>           <span class="comment">← things the agent should do</span>
+  <span class="dir">routines/</span>           <span class="comment">← scheduled prompts (cron)</span>
+  <span class="dir">routine_runs/</span>       <span class="comment">← audit of past cron fires</span>
+  <span class="dir">config/</span>             <span class="comment">← per-agent config</span>
+  <span class="dir">learnings/</span>          <span class="comment">← memories the agent has built up</span>
+  <span class="dir">prompts/modes/</span>      <span class="comment">← editable prompt overlays</span>
+  <span class="dir">sessions/</span>           <span class="comment">← one .sid file per conversation</span>
+<span class="dir">.agents/skills/</span>       <span class="comment">← installed skills</span>
+<span class="dir">.claude/skills/</span>       <span class="comment">← symlinks (Claude Code reads here)</span></div>
+
+    <h2>Why files</h2>
+    <p>
+      Files are inspectable, portable, and ordinary. You back up an agent
+      by copying its folder. You move it to another machine by copying its
+      folder. You open it in Finder.
+    </p>
+    <p>
+      The engine reads from this folder. The CLI subprocess writes to it
+      directly when it edits files. The user can hand-edit anything in it.
+      All three actors work on the same files.
+    </p>
+
+    <h2>Schemas as source of truth</h2>
+    <p>
+      Each typed file (activity, routines, config, etc) has a JSON Schema.
+      Those schemas live in <code>ui/agent-schemas/</code> and get embedded
+      into the Rust binary at compile time via
+      <code>include_str!</code>. On first launch, the engine seeds each
+      agent's folder with a copy of the relevant schema so the LLM can
+      validate before writing.
+    </p>
+
+    <h2>The reactivity stack</h2>
+    <p>
+      Files change in three ways: the user writes via the UI, the LLM
+      writes via its CLI tools, or a human edits with a text editor. All
+      three need to update the UI in real time.
+    </p>
+    <ol>
+      <li><strong>Engine writes</strong> emit a <code>HoustonEvent</code> on the broadcast bus.</li>
+      <li><strong>Direct CLI writes</strong> are caught by a <code>notify</code> file watcher in <code>houston-file-watcher</code>, which emits the same event.</li>
+      <li><strong>The frontend</strong> uses TanStack Query keyed on the file path. Events invalidate the query, which refetches.</li>
+    </ol>
+    <p>
+      The rule: <strong>no feature where the agent changes data but the UI
+      doesn't update until refresh.</strong>
+    </p>
+
+    <h2>What stays the same</h2>
+    <p>
+      This part of Houston is already exactly how it should be. The whole
+      reliability and deployment redesign keeps this layout untouched.
+      What changes is what happens between the user clicking and the
+      engine reading these files.
+    </p>
+
+    <div class="tech-box">
+      <div class="label">Where to look in the code</div>
+      <p>File I/O and migrations: <code>engine/houston-agent-files</code>. JSON schemas: <code>ui/agent-schemas/src/*.schema.json</code>. File watcher: <code>engine/houston-file-watcher</code>. Event invalidation: <code>app/src/hooks/use-agent-invalidation.ts</code>.</p>
+    </div>
+
+    <div class="pager">
+      <a href="01-three-layers.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">The three layers</div>
+      </a>
+      <a href="03-where-engine-lives.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Where the engine lives</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/engine-design/03-where-engine-lives.html
+++ b/engine-design/03-where-engine-lives.html
@@ -1,0 +1,152 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Where the engine lives — Houston Engine Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html" class="active"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 03
+      <span class="status planned">Planned</span>
+    </div>
+    <h1>Where the engine lives.</h1>
+    <p class="lead">
+      Today the engine runs natively on Mac, Windows, and Linux. Three
+      builds. Three sandboxing models. Going forward, the engine always
+      runs inside a Linux microVM.
+    </p>
+
+    <h2>The shift</h2>
+    <p>
+      When you install Houston on your Mac, the desktop app spins up a
+      tiny Linux VM and runs the engine inside it. When you sign up for
+      Houston Cloud, a tiny Linux VM is provisioned for you in the cloud
+      and the same engine runs inside it.
+    </p>
+    <p>
+      The engine binary is byte-for-byte the same. The only difference is
+      whose computer the VM runs on.
+    </p>
+
+    <div class="diagram">
+      <pre class="mermaid">
+graph TB
+  subgraph Host["Your Mac / Windows / Linux"]
+    Shell["Desktop Shell<br/>(Tauri, ~2k LOC per OS)"]
+    subgraph VM["Linux microVM"]
+      Engine["houston-engine<br/>(one Linux binary)"]
+      A1["Agent A"]
+      A2["Agent B"]
+      Engine --> A1
+      Engine --> A2
+    end
+    Shell -.HTTP+WS.-> Engine
+  end
+      </pre>
+      <div class="caption">Same picture for desktop and cloud. Only "Host" changes.</div>
+    </div>
+
+    <h2>Why a VM. Four reasons.</h2>
+    <ol>
+      <li><strong>One binary.</strong> No more Mac, Windows, and Linux builds of the engine. Linux only.</li>
+      <li><strong>One sandbox model.</strong> Linux primitives. <code>landlock</code>, namespaces, per-user permissions. No more <code>sandbox-exec</code> on Mac and AppContainer on Windows.</li>
+      <li><strong>Identical to production.</strong> What runs on your laptop is bit-identical to what runs in our cloud. Zero "works on my machine".</li>
+      <li><strong>Strong isolation.</strong> A VM is a kernel-level wall between Houston and the rest of your computer. Your kid can't accidentally delete the wrong file. An accidentally-installed agent can't read your bank statements.</li>
+    </ol>
+
+    <h2>The cost</h2>
+    <p>
+      About 2 seconds of cold start when you open the app, and roughly
+      100MB of extra memory. We think it's worth it for the simplicity and
+      the security story.
+    </p>
+
+    <h2>Files live inside the VM</h2>
+    <p>
+      The VM has its own disk volume. All agent files, project files,
+      everything lives inside the VM. The host doesn't see them. No
+      virtio-fs file sharing, no performance penalty.
+    </p>
+    <p>
+      To import a folder, you drop it in via the app. It copies in once.
+      To export, you download via the app. To back up, you snapshot the
+      volume.
+    </p>
+
+    <div class="callout callout-success">
+      <div class="callout-label">The big simplification</div>
+      <p>Desktop and cloud become the same architecture. The only difference is whose computer the VM runs on.</p>
+    </div>
+
+    <div class="tech-box">
+      <div class="label">VM hypervisors per host OS</div>
+      <p>macOS: Apple <code>Virtualization.framework</code>. Windows: Hyper-V or Windows Hypervisor Platform. Linux: KVM via libvirt. Each is wrapped behind a small platform-specific helper in the desktop shell.</p>
+    </div>
+
+    <div class="pager">
+      <a href="02-agent-folder.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">An agent is a folder</div>
+      </a>
+      <a href="04-message-flow.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">How a message flows through</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document</div>
+</footer>
+
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    themeVariables: {
+      primaryColor: '#ffffff',
+      primaryTextColor: '#0d0d0d',
+      primaryBorderColor: '#cdcdcd',
+      lineColor: '#676767',
+      mainBkg: '#ffffff',
+      secondBkg: '#f9f9f9',
+      tertiaryBkg: '#ececec',
+      actorBkg: '#ffffff',
+      actorBorder: '#cdcdcd',
+      actorTextColor: '#0d0d0d'
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/engine-design/04-message-flow.html
+++ b/engine-design/04-message-flow.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>How a message flows through — Houston Engine Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html" class="active"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 04
+      <span class="status partial">Partial</span>
+    </div>
+    <h1>How a message flows through.</h1>
+    <p class="lead">
+      This is the most important diagram in the guide. If you remember
+      only one thing, remember this one. The flow shown here is the
+      <em>target</em> flow, with reliability tables in place.
+    </p>
+
+    <div class="flow-list">
+      <div class="flow-step">
+        <div class="num">01</div>
+        <div>
+          <div class="from-to"><span class="actor">User</span><span class="arrow">→</span><span class="actor">Desktop UI</span></div>
+          <div class="action">Types "draft Q3 report" and hits send.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">02</div>
+        <div>
+          <div class="from-to"><span class="actor">Desktop UI</span><span class="arrow">→</span><span class="actor">Engine</span></div>
+          <div class="action"><code>POST /v1/agents/Sales/sessions</code> with the user message and a client-supplied <code>turnId</code>.</div>
+        </div>
+      </div>
+
+      <div class="flow-step db-write">
+        <div class="num">03</div>
+        <div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor db">SQLite</span></div>
+          <div class="action"><strong>INSERT into <code>turns</code></strong> with status <code>queued</code>. This happens BEFORE any work starts. If the engine crashes here, the row is on disk and we can recover.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">04</div>
+        <div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">Desktop UI</span></div>
+          <div class="action">Returns <code>200 OK</code> with <code>{ sessionKey, turnId }</code>. UI shows the message as accepted.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">05</div>
+        <div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">Claude CLI</span></div>
+          <div class="action">Spawns the Claude CLI subprocess as Linux user <code>hou_sales</code>, in the agent's folder.</div>
+        </div>
+      </div>
+
+      <div class="flow-step db-write">
+        <div class="num">06</div>
+        <div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor db">SQLite</span></div>
+          <div class="action"><strong>UPDATE <code>turns</code></strong> set status <code>running</code>.</div>
+        </div>
+      </div>
+
+      <div class="flow-loop">
+        <div class="flow-loop-label">Streaming loop · repeats per token chunk</div>
+
+        <div class="flow-step">
+          <div class="num">07</div>
+          <div>
+            <div class="from-to"><span class="actor">Claude CLI</span><span class="arrow">→</span><span class="actor">Engine</span></div>
+            <div class="action">Streams a chunk of assistant tokens.</div>
+          </div>
+        </div>
+
+        <div class="flow-step db-write">
+          <div class="num">08</div>
+          <div>
+            <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor db">SQLite</span></div>
+            <div class="action"><strong>INSERT into <code>turn_stream</code></strong> with the next <code>seq</code> number. Persisted before broadcast.</div>
+          </div>
+        </div>
+
+        <div class="flow-step">
+          <div class="num">09</div>
+          <div>
+            <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">Desktop UI</span></div>
+            <div class="action">Broadcasts the chunk over the WebSocket. UI renders it live.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">10</div>
+        <div>
+          <div class="from-to"><span class="actor">Claude CLI</span><span class="arrow">→</span><span class="actor">Engine</span></div>
+          <div class="action">Subprocess exits cleanly.</div>
+        </div>
+      </div>
+
+      <div class="flow-step db-write">
+        <div class="num">11</div>
+        <div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor db">SQLite</span></div>
+          <div class="action"><strong>UPDATE <code>turns</code></strong> set status <code>completed</code>.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">12</div>
+        <div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">Desktop UI</span></div>
+          <div class="action">Final completion event over the WebSocket. UI marks the turn as done.</div>
+        </div>
+      </div>
+    </div>
+
+    <p style="font-size: 13px; color: var(--gray-500); text-align: center; margin-top: -16px; margin-bottom: 32px;">Green steps are SQLite writes. Every byte the user sees is journaled to disk first.</p>
+
+    <h2>The key insight</h2>
+    <p>
+      <strong>Writes to the database happen BEFORE the work, not
+      AFTER.</strong> The turn row is inserted the moment the user's
+      message is accepted, well before the CLI subprocess is even spawned.
+      Each streaming chunk is logged before being broadcast.
+    </p>
+    <p>
+      That single ordering decision is what makes everything else work.
+    </p>
+
+    <h2>What this buys you</h2>
+    <ul>
+      <li><strong>Refresh mid-stream.</strong> The next page load replays from <code>turn_stream</code>. The user sees the streaming response continue.</li>
+      <li><strong>Engine crash mid-stream.</strong> The restarted engine sweeps the <code>turns</code> table, finds the orphan, surfaces a retry. The user clicks once and continues.</li>
+      <li><strong>Network blip during streaming.</strong> The client reconnects with <code>Last-Event-Seq</code> and gets the gap from <code>events_outbox</code>.</li>
+      <li><strong>Cron fires at 7am while engine is restarting.</strong> The <code>cron_runs</code> audit log catches up on the next boot.</li>
+    </ul>
+
+    <h2>What's there today</h2>
+    <p>
+      Most of the boxes in the diagram exist. The CLI gets spawned, the
+      response streams, the final message gets saved to <code>chat_feed</code>.
+      What's missing is the four SQLite tables (<code>turns</code>,
+      <code>turn_stream</code>, <code>events_outbox</code>,
+      <code>cron_runs</code>) and the rule of writing before doing.
+    </p>
+    <p>
+      Chapter 5 covers what goes wrong because those tables aren't there.
+      Chapter 6 covers the fix.
+    </p>
+
+    <div class="tech-box">
+      <div class="label">Where to look in the code</div>
+      <p>Today's flow: <code>engine/houston-engine-server/src/routes/sessions.rs</code> → <code>engine/houston-engine-core/src/sessions/mod.rs</code> → <code>engine/houston-agents-conversations/src/session_runner.rs</code>. Streaming tokens are dropped specifically at <code>session_runner.rs:406</code>.</p>
+    </div>
+
+    <div class="pager">
+      <a href="03-where-engine-lives.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Where the engine lives</div>
+      </a>
+      <a href="05-conversations-die.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Why conversations die today</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document</div>
+</footer>
+
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    themeVariables: {
+      primaryColor: '#ffffff',
+      primaryTextColor: '#0d0d0d',
+      primaryBorderColor: '#cdcdcd',
+      lineColor: '#676767',
+      actorBkg: '#ffffff',
+      actorBorder: '#cdcdcd',
+      actorTextColor: '#0d0d0d',
+      labelBoxBkgColor: '#f9f9f9',
+      labelBoxBorderColor: '#cdcdcd'
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/engine-design/05-conversations-die.html
+++ b/engine-design/05-conversations-die.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Why conversations die today — Houston Engine Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html" class="active"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 05
+      <span class="status planned">Planned</span>
+    </div>
+    <h1>Why conversations die today.</h1>
+    <p class="lead">
+      The engine writes to disk only after the work is done. Everything in
+      flight is in-memory. In-memory means it dies when the process dies.
+      Here are the four failure modes.
+    </p>
+
+    <div class="fail-grid">
+      <div class="fail-card">
+        <div class="label">Failure mode #1</div>
+        <p><strong>Engine crashes between "accept message" and "spawn CLI".</strong> Your message disappears. No record anywhere. You click send again, the engine has no memory of the first attempt.</p>
+      </div>
+
+      <div class="fail-card">
+        <div class="label">Failure mode #2</div>
+        <p><strong>Engine crashes mid-stream.</strong> Whatever the assistant had already streamed: gone. Database has nothing. The user thinks the agent is broken.</p>
+      </div>
+
+      <div class="fail-card">
+        <div class="label">Failure mode #3</div>
+        <p><strong>WebSocket reconnects after a network blip.</strong> Server has no record of what events it pushed during the disconnect. The frontend has to refetch state and pray nothing slipped through.</p>
+      </div>
+
+      <div class="fail-card">
+        <div class="label">Failure mode #4</div>
+        <p><strong>Cron fire happens while engine is restarting.</strong> The 7am alarm rings, the engine is rebooting, the fire is dropped silently. No log, no alert, no catch-up.</p>
+      </div>
+    </div>
+
+    <h2>The pattern</h2>
+    <p>
+      Notice the common thread. The engine writes to the database
+      <strong>after</strong> doing work, not <strong>before</strong>. So
+      anything happening between "before" and "after" lives only in
+      memory, and that memory belongs to a process that can die.
+    </p>
+    <p>
+      The fix is boring but life-changing. Flip the order. Chapter 6 shows
+      how, with the four SQLite tables that make it work.
+    </p>
+
+    <div class="callout callout-warning">
+      <div class="callout-label">Why this hasn't been fixed yet</div>
+      <p>Because it works most of the time. Engines don't usually crash. Networks don't usually blip. So the team shipped features instead. The point of the redesign is to make Houston work reliably for the cases where things DO go wrong.</p>
+    </div>
+
+    <div class="pager">
+      <a href="04-message-flow.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">How a message flows through</div>
+      </a>
+      <a href="06-four-tables.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">The four tables that save everything</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/engine-design/06-four-tables.html
+++ b/engine-design/06-four-tables.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The four tables — Houston Engine Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html" class="active"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 06
+      <span class="status planned">Planned · M1</span>
+    </div>
+    <h1>The four tables that save everything.</h1>
+    <p class="lead">
+      Four new SQLite tables. That's the entire reliability story. Not
+      Temporal, not a workflow engine. Just four tables and one rule:
+      write the row before doing the work.
+    </p>
+
+    <h2>The tables</h2>
+    <table>
+      <thead>
+        <tr><th>Table</th><th>What it holds</th><th>What it fixes</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>turns</code></td>
+          <td>Every chat turn, with status</td>
+          <td>Crash before CLI spawns. Retry is idempotent via <code>turn_id</code>.</td>
+        </tr>
+        <tr>
+          <td><code>turn_stream</code></td>
+          <td>Every assistant token chunk, with seq</td>
+          <td>Reconnect with <code>since_seq</code>, perfect replay.</td>
+        </tr>
+        <tr>
+          <td><code>events_outbox</code></td>
+          <td>Every event with a monotonic seq</td>
+          <td>WS clients reconnect and get the gap they missed.</td>
+        </tr>
+        <tr>
+          <td><code>cron_runs</code></td>
+          <td>Every cron fire (or missed fire)</td>
+          <td>Missed at 7am, caught up on next boot.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>The rule</h2>
+    <p>
+      Write the row before doing the work. Mark it complete after. Here is
+      what that looks like for a single chat turn.
+    </p>
+
+<pre><code>1. Accept message       → INSERT turns (status: queued)
+2. Start CLI            → UPDATE turns SET status = running
+3. Stream chunk         → INSERT turn_stream row, then broadcast
+4. CLI done             → UPDATE turns SET status = completed
+5. Engine boots         → SELECT * FROM turns WHERE status = running
+                          → mark orphaned, surface retry</code></pre>
+
+    <p>
+      Step 5 is the magic. On every boot, the engine looks for turns that
+      were "running" when the previous engine died. Those are orphans. The
+      user sees a retry button. They click it. The same <code>turn_id</code>
+      goes back into the system. We never accidentally cook the same dish
+      twice because the engine recognizes the ID and resumes.
+    </p>
+
+    <div class="callout callout-info">
+      <div class="callout-label">Why this isn't Temporal</div>
+      <p>Temporal is a workflow engine for orchestrating long-running multi-step business processes with replay semantics. Houston has one activity: run a CLI turn, capture the stream. That's a job, not a saga. Four tables are enough.</p>
+    </div>
+
+    <h2>The one architectural piece</h2>
+    <p>
+      Everything above is just "add a table". One piece is genuinely
+      harder. Today the CLI subprocess is a child of the engine process,
+      so killing the engine kills the CLI. To survive engine restart
+      <strong>mid-stream</strong> (not just on the next turn), we need a
+      small <code>houston-turn-worker</code> binary.
+    </p>
+    <p>
+      The engine spawns it detached. The worker writes streaming output to
+      SQLite directly. The engine bounces, a new engine starts up,
+      reattaches via Unix socket, conversation never blinks.
+    </p>
+    <p>
+      This piece is M3. Until then, the cheap fallback (orphan + retry)
+      gets you 70% of the user experience for 10% of the work.
+    </p>
+
+    <div class="tech-box">
+      <div class="label">Migration order</div>
+      <p>SQLite migrations live in <code>engine/houston-db/src/migrations.rs</code>. New tables drop in next to existing <code>chat_feed</code>, <code>preferences</code>, and <code>engine_tokens</code>. Each gets a numbered migration file; existing data is preserved.</p>
+    </div>
+
+    <div class="pager">
+      <a href="05-conversations-die.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Why conversations die today</div>
+      </a>
+      <a href="07-keeping-agents-apart.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Keeping agents apart</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/engine-design/07-keeping-agents-apart.html
+++ b/engine-design/07-keeping-agents-apart.html
@@ -1,0 +1,149 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Keeping agents apart — Houston Engine Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html" class="active"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 07
+      <span class="status planned">Planned · M2</span>
+    </div>
+    <h1>Keeping agents apart.</h1>
+    <p class="lead">
+      Three independent walls between agents. Each one is enough to stop a
+      curious agent from snooping. Together, they make accidental and
+      adversarial cross-agent reads impossible.
+    </p>
+
+    <div class="walls">
+      <div class="agent-col">
+        <h4>Sales agent</h4>
+        <ul>
+          <li>Linux user: <code>hou_sales</code></li>
+          <li>Folder: <code>/agents/sales/</code> (mode 0700)</li>
+          <li>Claude login: <code>/home/hou_sales/.claude/</code></li>
+          <li>Composio: <code>/home/hou_sales/.composio/</code></li>
+          <li>Tools: Slack, CRM, Email</li>
+        </ul>
+      </div>
+      <div class="wall">
+        <span>NO ACCESS</span>
+      </div>
+      <div class="agent-col">
+        <h4>HR agent</h4>
+        <ul>
+          <li>Linux user: <code>hou_hr</code></li>
+          <li>Folder: <code>/agents/hr/</code> (mode 0700)</li>
+          <li>Claude login: <code>/home/hou_hr/.claude/</code></li>
+          <li>Composio: <code>/home/hou_hr/.composio/</code></li>
+          <li>Tools: Payroll, Benefits, Workday</li>
+        </ul>
+      </div>
+    </div>
+
+    <h2>Wall 1: per-agent Linux user</h2>
+    <p>
+      Each agent gets its own Linux user inside the VM. Their folders are
+      owned by them, mode 0700. When you send a message to the Sales
+      agent, the CLI runs as <code>hou_sales</code>. It physically cannot
+      read <code>hou_hr</code>'s files. The kernel says no.
+    </p>
+    <p>
+      Even if a clever prompt asks the Sales agent to read HR salary data,
+      the agent has no permission. There is no jailbreak that gets around
+      <code>chmod</code>.
+    </p>
+
+    <h2>Wall 2: per-agent credentials</h2>
+    <p>
+      Each agent has its own <code>~/.claude</code>, its own
+      <code>~/.composio</code>, its own everything. When Sales logs into
+      Anthropic, the token sits in <code>/home/hou_sales/.claude/</code>.
+      HR can't see it.
+    </p>
+    <p>
+      Even if Sales gets compromised, its blast radius is bounded by what
+      it had access to. It can't social-engineer its way to HR data
+      because it doesn't have the keys to start with.
+    </p>
+
+    <h2>Wall 3: engine-level scope checks</h2>
+    <p>
+      On top of the file walls, every HTTP route checks "does this user's
+      token have scope for this agent?" before doing anything. A user
+      with Sales access trying to query HR's data gets a 403 before the
+      engine even reaches for the filesystem.
+    </p>
+    <p>
+      Tokens become typed:
+      <code>(token_id, principal_id, scope: ["WorkspaceX/Sales/**"])</code>.
+      Middleware enforces. New tables: <code>principals</code> and
+      <code>principal_tokens</code> in <code>houston-db</code>.
+    </p>
+
+    <div class="callout callout-success">
+      <div class="callout-label">The headline</div>
+      <p>"My HR agent literally cannot leak salaries to my Sales agent, even if jailbroken." That isn't marketing copy. That's what the kernel enforces.</p>
+    </div>
+
+    <h2>Where this matters</h2>
+    <p>
+      This is a real positioning win for regulated industries. ChatGPT
+      Enterprise and Claude Teams put everyone in one tenant with one set
+      of permissions. Houston's per-agent isolation is something they
+      don't offer.
+    </p>
+
+    <div class="tech-box">
+      <div class="label">What changes in code</div>
+      <p>New auth middleware in <code>engine/houston-engine-server</code>. New tables in <code>engine/houston-db</code>. CLI spawn in <code>engine/houston-terminal-manager</code> gains a <code>setuid</code> step (Linux only; gated by <code>HOUSTON_ISOLATE_BY_UID=1</code>). Per-agent home dir resolution in <code>houston-agent-files</code>.</p>
+    </div>
+
+    <div class="pager">
+      <a href="06-four-tables.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">The four tables</div>
+      </a>
+      <a href="08-login.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Logging in</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/engine-design/08-login.html
+++ b/engine-design/08-login.html
@@ -1,0 +1,146 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Logging in — Houston Engine Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html" class="active"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 08
+      <span class="status partial">Partial</span>
+    </div>
+    <h1>Logging in (still one click).</h1>
+    <p class="lead">
+      Per-agent credentials sound expensive in clicks. They aren't. The
+      user clicks once per agent. The OAuth dance happens under the hood.
+    </p>
+
+    <div class="diagram">
+      <pre class="mermaid">
+sequenceDiagram
+  autonumber
+  actor User
+  participant UI as Desktop UI
+  participant Shell as Desktop Shell
+  participant E as Engine (in VM)
+  participant CLI as claude login<br/>(as hou_sales)
+  participant Browser as System Browser
+  participant Anthropic
+
+  User->>UI: click "Log into Claude for Sales"
+  UI->>E: POST /v1/agents/Sales/providers/anthropic/login
+  E->>CLI: spawn as hou_sales
+  CLI-->>E: print login URL
+  E-->>Shell: open URL via deep-link bridge
+  Shell->>Browser: open URL
+  User->>Anthropic: log in
+  Anthropic-->>Browser: redirect houston://anthropic-callback?code=...
+  Browser-->>Shell: deep link delivered
+  Shell->>E: POST callback code
+  E->>CLI: pass code
+  CLI->>Anthropic: exchange for token
+  CLI->>CLI: save to /home/hou_sales/.claude/
+  E-->>UI: WS event "Sales logged in"
+      </pre>
+      <div class="caption">One click for the user. About three redirects under the hood.</div>
+    </div>
+
+    <h2>The pattern is already in Houston</h2>
+    <p>
+      This is the exact pattern Houston already uses for Google sign-in
+      via Supabase. A click in the UI starts an OAuth flow. The system
+      browser does the work. A custom URL scheme
+      (<code>houston://...</code>) brings the result back into the app.
+    </p>
+    <p>
+      The only new piece for the VM-based architecture is the
+      <strong>deep-link bridge</strong> between the desktop shell and the
+      VM. The shell catches the redirect, then posts the code over the
+      VM's local network to the engine.
+    </p>
+
+    <h2>Per agent vs broker</h2>
+    <p>
+      Two flavors of UX, both compatible with the same plumbing.
+    </p>
+    <ul>
+      <li><strong>Strict:</strong> log into Claude once per agent. Strongest isolation. Costs you N clicks for N agents.</li>
+      <li><strong>Broker:</strong> log into Claude once for the whole machine. The engine brokers tokens to individual agents. One click forever. Slightly weaker isolation because the broker has all tokens.</li>
+    </ul>
+    <p>
+      Which one ships first is an open question. The strict path is
+      simpler to build and the broker can be added later without breaking
+      the strict mode.
+    </p>
+
+    <div class="callout callout-info">
+      <div class="callout-label">What works today</div>
+      <p>Single-account Anthropic, OpenAI, and Composio logins all work today, but they're machine-wide, not per-agent. Once Chapter 7 ships (per-agent UIDs), per-agent logins land naturally.</p>
+    </div>
+
+    <div class="pager">
+      <a href="07-keeping-agents-apart.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Keeping agents apart</div>
+      </a>
+      <a href="09-external-triggers.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">External triggers</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document</div>
+</footer>
+
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    themeVariables: {
+      primaryColor: '#ffffff',
+      primaryTextColor: '#0d0d0d',
+      primaryBorderColor: '#cdcdcd',
+      lineColor: '#676767',
+      actorBkg: '#ffffff',
+      actorBorder: '#cdcdcd',
+      actorTextColor: '#0d0d0d',
+      labelBoxBkgColor: '#f9f9f9',
+      labelBoxBorderColor: '#cdcdcd'
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/engine-design/09-external-triggers.html
+++ b/engine-design/09-external-triggers.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>External triggers — Houston Engine Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html" class="active"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 09
+      <span class="status partial">Partial</span>
+    </div>
+    <h1>External triggers.</h1>
+    <p class="lead">
+      Three ways something outside Houston can wake up an agent. Two of
+      them work today. One is half-built.
+    </p>
+
+    <h2>1. The user sends a message</h2>
+    <p>
+      Standard chat. The desktop UI calls
+      <code>POST /v1/agents/&lt;path&gt;/sessions</code>. The engine
+      spawns a CLI subprocess, the response streams back. This is what
+      Chapter 4 covers. Works today.
+    </p>
+
+    <h2>2. A cron fires</h2>
+    <p>
+      Each agent has routines. <code>0 7 * * *</code> runs at 7am every
+      day. Today the cron lives inside the engine. A tokio task sleeps
+      until the fire time, then pushes a <code>HoustonInput::Cron</code>
+      onto the event queue, which dispatches to the same chat-turn path.
+    </p>
+    <p>
+      This works as long as the engine is up. For sleeping cloud engines
+      (Chapter 10), the cron will move to a central scheduler that wakes
+      the engine when the time comes.
+    </p>
+
+    <h2>3. A webhook arrives</h2>
+    <p>
+      Stripe sends a payment event. Slack sends a message. GitHub sends a
+      PR notification. Each one routed to a specific agent.
+    </p>
+    <p>
+      The plumbing exists. The engine has a typed
+      <code>HoustonInput::Webhook</code> enum, and the dispatcher knows
+      how to route it. What's missing is the HTTP route that constructs
+      one. Adding <code>POST /v1/hooks/&lt;route_token&gt;</code> is small
+      work that unlocks a huge surface.
+    </p>
+
+    <div class="callout callout-info">
+      <div class="callout-label">Per-hook tokens, not the bearer token</div>
+      <p>Each webhook gets its own route token, separate from the engine bearer. Stripe's token only fires the Stripe hook. A compromised Stripe token lets the attacker fake payment events but doesn't let them read your chat history.</p>
+    </div>
+
+    <h2>Wake-on-event for sleeping engines</h2>
+    <p>
+      Once the engine learns to sleep (Chapter 10), the relay in front
+      will catch inbound triggers, wake the engine via the platform API
+      (Fly Machines, systemd socket activation, etc), wait for
+      <code>/v1/health</code> to respond, then proxy the request through.
+    </p>
+    <p>
+      Cron, user message, and webhook all share that same wake-up path.
+      One mechanism, three triggers.
+    </p>
+
+    <div class="tech-box">
+      <div class="label">Where to look in the code</div>
+      <p>Webhook input type: <code>engine/houston-events/src/queue.rs:25-104</code>. Cron implementation: <code>engine/houston-scheduler/src/cron_job.rs</code>. Missing piece for webhooks: a <code>routes/hooks.rs</code> file in <code>engine/houston-engine-server/</code>.</p>
+    </div>
+
+    <div class="pager">
+      <a href="08-login.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Logging in</div>
+      </a>
+      <a href="10-deployment.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Deployment</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/engine-design/10-deployment.html
+++ b/engine-design/10-deployment.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Deployment — Houston Engine Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html" class="active"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 10
+      <span class="status planned">Planned · M3</span>
+    </div>
+    <h1>Deployment: one binary, two homes.</h1>
+    <p class="lead">
+      Same engine binary. Two deployment modes. Almost zero divergence
+      between them. The only difference is whose computer the VM runs on.
+    </p>
+
+    <div class="diagram">
+      <pre class="mermaid">
+graph LR
+  subgraph Desktop["Desktop Mode"]
+    DS["Desktop Shell"]
+    DV["Linux microVM"]
+    DE["houston-engine"]
+    DS --> DV --> DE
+  end
+
+  subgraph Cloud["Cloud Mode"]
+    Relay["Houston Relay<br/>(CF Worker + DO)"]
+    Fly["Fly Machine<br/>(Linux microVM)"]
+    CE["houston-engine"]
+    Relay --> Fly --> CE
+  end
+
+  DE -.same binary.-> CE
+      </pre>
+      <div class="caption">The engine binary is byte-for-byte the same. Only the host changes.</div>
+    </div>
+
+    <h2>Desktop mode</h2>
+    <p>
+      Inside a Linux microVM on your laptop. The microVM lives next to
+      your desktop shell. They talk over local networking. The engine
+      never crosses the VM boundary unless the shell explicitly bridges
+      something (file picker, OAuth callback, system browser).
+    </p>
+
+    <h2>Cloud mode</h2>
+    <p>
+      Inside a Linux microVM on Fly Machines (or similar). Each paying
+      customer gets their own VM. A relay outside knows how to wake a
+      sleeping VM when a user message, webhook, or scheduled cron
+      arrives.
+    </p>
+    <p>
+      The relay is the same one Houston already uses for mobile traffic
+      (<code>houston-relay/</code>, a Cloudflare Worker plus Durable
+      Objects on <code>tunnel.gethouston.ai</code>). Extending it to also
+      proxy general engine traffic and to dispatch wake-ups is the bulk
+      of M3.
+    </p>
+
+    <h2>What you get</h2>
+    <ul>
+      <li>One engine codebase, no forks, no per-platform builds beyond the small desktop shell.</li>
+      <li>Same tests, same behavior, same bugs and same fixes.</li>
+      <li>"Run your engine in our cloud" is literally <code>fly machines start</code>.</li>
+      <li>"Move from our cloud to your own VPS" is <code>docker pull && docker run</code>. Same image.</li>
+      <li>Pricing aligns if you bill per VM-hour: cloud customers pay you, desktop users pay their own machine, you meter the same unit.</li>
+    </ul>
+
+    <h2>Sleeping engines</h2>
+    <p>
+      For cloud mode, engines sleep after N idle minutes. They exit 0
+      gracefully. The relay holds the connection from the next inbound
+      request, calls the platform's start API, polls
+      <code>/v1/health</code>, then proxies through. Cold start: ~2
+      seconds. Acceptable for crons and webhooks; for active human chats,
+      engines stay sticky-hot during a session window.
+    </p>
+
+    <div class="callout callout-success">
+      <div class="callout-label">The killer property</div>
+      <p>You can no longer have a "works on my Mac" bug, because there is no Mac engine. Every engine is the same Linux engine.</p>
+    </div>
+
+    <div class="tech-box">
+      <div class="label">What's there already</div>
+      <p>Always-on Docker recipe: <code>always-on/Dockerfile</code> and <code>docker-compose.yml</code>. Relay: <code>houston-relay/</code>. Tunnel client crate: <code>engine/houston-tunnel</code>. What's missing: VM-management code in the desktop shell, wake API in the relay, idle-exit logic in the engine.</p>
+    </div>
+
+    <div class="pager">
+      <a href="09-external-triggers.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">External triggers</div>
+      </a>
+      <a href="11-roadmap.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">The roadmap</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document</div>
+</footer>
+
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    themeVariables: {
+      primaryColor: '#ffffff',
+      primaryTextColor: '#0d0d0d',
+      primaryBorderColor: '#cdcdcd',
+      lineColor: '#676767',
+      mainBkg: '#ffffff',
+      secondBkg: '#f9f9f9',
+      tertiaryBkg: '#ececec'
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/engine-design/11-roadmap.html
+++ b/engine-design/11-roadmap.html
@@ -1,0 +1,129 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The roadmap — Houston Engine Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html" class="active"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 11
+      <span class="status progress">In progress</span>
+    </div>
+    <h1>The roadmap.</h1>
+    <p class="lead">
+      Three milestones. Each one roughly two to four weeks at current
+      shipping pace. Each one ships before the next one starts.
+    </p>
+
+    <h2>M1 — Reliability</h2>
+    <p>
+      <strong>Goal:</strong> conversations never drop bytes. The "my
+      message disappeared" failure mode goes away. Every byte the user
+      sees is journaled before broadcast.
+    </p>
+    <ul>
+      <li>Add four SQLite tables: <code>turns</code>, <code>turn_stream</code>, <code>events_outbox</code>, <code>cron_runs</code>.</li>
+      <li>Write rows BEFORE doing work. Sweep orphans on boot.</li>
+      <li>WebSocket replay by sequence number on reconnect.</li>
+      <li>Cron audit log plus missed-fire catch-up policy.</li>
+    </ul>
+    <p>
+      Mostly inserts and middleware. No architectural change. About 2-3
+      weeks.
+    </p>
+
+    <h2>M2 — Auth and isolation</h2>
+    <p>
+      <strong>Goal:</strong> multi-tenant safety. Two humans can share an
+      engine without leaking into each other. Per-agent credentials.
+    </p>
+    <ul>
+      <li>Typed tokens with scope: <code>(principal_id, scope)</code> on every route.</li>
+      <li>Per-agent Linux users inside the VM (one-time automated <code>useradd</code>).</li>
+      <li>Per-agent credentials (per-agent <code>.claude</code>, <code>.composio</code>).</li>
+      <li>VM-based desktop spin-up, replacing the native sidecar model.</li>
+    </ul>
+    <p>
+      Middleware plus a new system layer. About 3-4 weeks.
+    </p>
+
+    <h2>M3 — Cloud and detached workers</h2>
+    <p>
+      <strong>Goal:</strong> Houston Cloud is shippable. Engine bounces
+      don't kill conversations. Sleeping engines wake on demand.
+    </p>
+    <ul>
+      <li>Detached <code>houston-turn-worker</code> binary so engine restart doesn't kill in-flight turns.</li>
+      <li><code>POST /v1/hooks/&lt;route_token&gt;</code> wired to the event queue.</li>
+      <li>Engine knows how to exit gracefully on idle.</li>
+      <li>Relay knows how to wake a dormant engine via Fly Machines API.</li>
+      <li>Cron moves to a central scheduler service for hosted mode.</li>
+      <li>Per-customer Fly Machine provisioning and onboarding.</li>
+    </ul>
+    <p>
+      The only milestone with real architectural risk (the detached
+      worker). About 4 weeks.
+    </p>
+
+    <div class="callout callout-info">
+      <div class="callout-label">Open questions to settle before each milestone</div>
+      <p><strong>Before M2:</strong> per-agent Claude logins, or a credentials broker for one-login-many-agents?</p>
+      <p><strong>Before M3:</strong> cron in-engine forever, or move to a central scheduler even for self-hosters? Where does the OSS-vs-cloud line sit for the relay code?</p>
+    </div>
+
+    <h2>After M3</h2>
+    <p>
+      Houston Cloud private beta is shippable. The desktop story is the
+      same architecture as the cloud story, just running on the user's
+      hardware. Pricing aligns (per VM-hour or per agent-month, decide
+      then). Teams becomes a thin layer on top of the per-customer-VM
+      story.
+    </p>
+
+    <div class="pager">
+      <a href="10-deployment.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Deployment</div>
+      </a>
+      <a href="index.html" class="next">
+        <div class="pager-label">Back to start</div>
+        <div class="pager-title">Overview</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/engine-design/README.md
+++ b/engine-design/README.md
@@ -1,0 +1,7 @@
+## Houston Engine Design Guide
+
+The single source of truth for how the Houston engine works (and how it will work).
+
+Open `index.html` in any browser. Self-contained: dark theme, Mermaid diagrams via CDN, presentable as-is. Each chapter has a status pill so you can see at a glance what's shipped, what's in progress, and what's planned.
+
+This document is the working design. Edit it as decisions get made. New deep-dives go in this directory as separate HTML or markdown files; `index.html` stays the readable, presentation-ready overview.

--- a/engine-design/index.html
+++ b/engine-design/index.html
@@ -1,0 +1,135 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Houston Engine Design — The Guide</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Engine Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Engine Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html" class="active"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-three-layers.html"><span class="num">01</span>The three layers<span class="sb-status shipped"></span></a></li>
+      <li><a href="02-agent-folder.html"><span class="num">02</span>An agent is a folder<span class="sb-status shipped"></span></a></li>
+      <li><a href="03-where-engine-lives.html"><span class="num">03</span>Where the engine lives<span class="sb-status planned"></span></a></li>
+      <li><a href="04-message-flow.html"><span class="num">04</span>How a message flows<span class="sb-status partial"></span></a></li>
+      <li><a href="05-conversations-die.html"><span class="num">05</span>Why conversations die today<span class="sb-status planned"></span></a></li>
+      <li><a href="06-four-tables.html"><span class="num">06</span>The four tables<span class="sb-status planned"></span></a></li>
+      <li><a href="07-keeping-agents-apart.html"><span class="num">07</span>Keeping agents apart<span class="sb-status planned"></span></a></li>
+      <li><a href="08-login.html"><span class="num">08</span>Logging in<span class="sb-status partial"></span></a></li>
+      <li><a href="09-external-triggers.html"><span class="num">09</span>External triggers<span class="sb-status partial"></span></a></li>
+      <li><a href="10-deployment.html"><span class="num">10</span>Deployment<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content hero">
+    <div class="content-label">Houston · Engine Design Guide</div>
+    <h1>How the engine actually works.</h1>
+    <p class="lead">
+      A walkthrough of every piece of Houston, what it does today, what it
+      will do tomorrow, and the reason for every decision in between. Read
+      it, present it, edit it as we go.
+    </p>
+
+    <div class="hero-actions">
+      <a class="btn btn-primary" href="01-three-layers.html">Start reading</a>
+      <a class="btn btn-secondary" href="11-roadmap.html">Jump to roadmap</a>
+    </div>
+
+    <h2 style="margin-top: 80px">Reading legend</h2>
+    <p>Each chapter has a status pill. Three states, color-coded.</p>
+    <ul>
+      <li><span class="status shipped">Shipped</span> already in the codebase today.</li>
+      <li><span class="status partial">Partial</span> some of it works, the rest is on the plan.</li>
+      <li><span class="status planned">Planned</span> the design is decided, the code is not yet written.</li>
+      <li><span class="status progress">In progress</span> actively being built right now.</li>
+    </ul>
+
+    <h2>The chapters</h2>
+
+    <div class="chapter-grid">
+      <a class="chapter-card" href="01-three-layers.html">
+        <div class="chapter-num">01 <span class="status shipped">Shipped</span></div>
+        <div class="chapter-title">The three layers</div>
+        <div class="chapter-desc">Desktop app, engine, agents. Three pieces, one architecture.</div>
+      </a>
+
+      <a class="chapter-card" href="02-agent-folder.html">
+        <div class="chapter-num">02 <span class="status shipped">Shipped</span></div>
+        <div class="chapter-title">An agent is a folder</div>
+        <div class="chapter-desc">No databases, no proprietary formats. Just files on disk.</div>
+      </a>
+
+      <a class="chapter-card" href="03-where-engine-lives.html">
+        <div class="chapter-num">03 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">Where the engine lives</div>
+        <div class="chapter-desc">Inside a Linux microVM. Same on your laptop and in our cloud.</div>
+      </a>
+
+      <a class="chapter-card" href="04-message-flow.html">
+        <div class="chapter-num">04 <span class="status partial">Partial</span></div>
+        <div class="chapter-title">How a message flows through</div>
+        <div class="chapter-desc">The full chat-turn sequence. The most important diagram.</div>
+      </a>
+
+      <a class="chapter-card" href="05-conversations-die.html">
+        <div class="chapter-num">05 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">Why conversations die today</div>
+        <div class="chapter-desc">Four failure modes. Same root cause.</div>
+      </a>
+
+      <a class="chapter-card" href="06-four-tables.html">
+        <div class="chapter-num">06 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">The four tables that save everything</div>
+        <div class="chapter-desc">The whole reliability story. Not Temporal. Just SQLite.</div>
+      </a>
+
+      <a class="chapter-card" href="07-keeping-agents-apart.html">
+        <div class="chapter-num">07 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">Keeping agents apart</div>
+        <div class="chapter-desc">Three independent walls. Kernel-enforced isolation.</div>
+      </a>
+
+      <a class="chapter-card" href="08-login.html">
+        <div class="chapter-num">08 <span class="status partial">Partial</span></div>
+        <div class="chapter-title">Logging in (still one click)</div>
+        <div class="chapter-desc">Per-agent OAuth without breaking the UX.</div>
+      </a>
+
+      <a class="chapter-card" href="09-external-triggers.html">
+        <div class="chapter-num">09 <span class="status partial">Partial</span></div>
+        <div class="chapter-title">External triggers</div>
+        <div class="chapter-desc">Messages, crons, webhooks. Three ways to wake an agent.</div>
+      </a>
+
+      <a class="chapter-card" href="10-deployment.html">
+        <div class="chapter-num">10 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">Deployment: one binary, two homes</div>
+        <div class="chapter-desc">Same engine on your laptop and in Houston Cloud.</div>
+      </a>
+
+      <a class="chapter-card" href="11-roadmap.html">
+        <div class="chapter-num">11 <span class="status progress">In progress</span></div>
+        <div class="chapter-title">The roadmap</div>
+        <div class="chapter-desc">Three milestones from MVP to Houston Cloud.</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Engine Design Guide · Living document · Edit as decisions get made.</div>
+</footer>
+
+</body>
+</html>

--- a/engine-design/style.css
+++ b/engine-design/style.css
@@ -1,0 +1,791 @@
+/* ═══════════════════════════════════════════
+   Houston Engine Design — Mirrors learn/style.css
+   ═══════════════════════════════════════════ */
+
+:root {
+  --background: #ffffff;
+  --foreground: #0d0d0d;
+  --secondary: #f9f9f9;
+  --muted-foreground: #5d5d5d;
+  --border: #e5e5e5;
+  --gray-50: #f9f9f9;
+  --gray-100: #ececec;
+  --gray-200: #e3e3e3;
+  --gray-300: #cdcdcd;
+  --gray-400: #b4b4b4;
+  --gray-500: #9b9b9b;
+  --gray-600: #676767;
+  --gray-700: #424242;
+  --gray-900: #1a1a1a;
+  --gray-950: #0d0d0d;
+  --success: #00a240;
+  --info: #2964aa;
+  --warning: #e0ac00;
+  --danger: #e02e2a;
+  --border-light: rgba(13, 13, 13, 0.05);
+  --border-medium: rgba(0, 0, 0, 0.12);
+  --border-heavy: rgba(13, 13, 13, 0.15);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+@media (prefers-reduced-motion: no-preference) {
+  html { scroll-behavior: smooth; }
+}
+
+body {
+  font-family: ui-sans-serif, -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+  color: var(--foreground);
+  background: var(--background);
+  -webkit-font-smoothing: antialiased;
+  font-size: 16px;
+  line-height: 1.6;
+  padding-top: 65px;
+}
+
+code, .mono {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+a { color: inherit; text-decoration: none; }
+
+/* ─── Top nav ─── */
+nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 100;
+  padding: 16px 40px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid var(--border-light);
+}
+
+.nav-logo {
+  font-family: 'General Sans', sans-serif;
+  font-size: 22px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--gray-950);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.nav-logo .nav-sub {
+  font-size: 14px;
+  color: var(--gray-500);
+  font-weight: 400;
+  margin-left: 4px;
+}
+
+.nav-right {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  font-size: 14px;
+  color: var(--gray-600);
+}
+
+@media (max-width: 700px) {
+  nav { padding: 16px 20px; }
+  .nav-logo .nav-sub { display: none; }
+}
+
+/* ─── Layout ─── */
+.layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  max-width: 1280px;
+  margin: 0 auto;
+  gap: 48px;
+  padding: 48px 32px 120px;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+    gap: 0;
+    padding: 32px 24px 80px;
+  }
+}
+
+/* ─── Sidebar ─── */
+.sidebar {
+  position: sticky;
+  top: 88px;
+  align-self: start;
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+@media (max-width: 900px) {
+  .sidebar {
+    position: static;
+    max-height: none;
+    margin-bottom: 32px;
+    padding-right: 0;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--border-light);
+  }
+}
+
+.sidebar-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-500);
+  margin-bottom: 12px;
+  padding: 0 10px;
+}
+
+.sidebar-nav {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebar-nav a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 14px;
+  color: var(--gray-700);
+  transition: background 0.15s, color 0.15s;
+  position: relative;
+}
+
+.sidebar-nav a:hover {
+  background: var(--gray-50);
+  color: var(--gray-950);
+}
+
+.sidebar-nav a.active {
+  background: var(--gray-100);
+  color: var(--gray-950);
+  font-weight: 500;
+}
+
+.sidebar-nav .num {
+  color: var(--gray-400);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  min-width: 18px;
+}
+
+.sidebar-nav a.active .num {
+  color: var(--gray-600);
+}
+
+.sidebar-nav .sb-status {
+  margin-left: auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.sidebar-nav .sb-status.shipped { background: var(--success); }
+.sidebar-nav .sb-status.partial { background: var(--warning); }
+.sidebar-nav .sb-status.progress { background: var(--info); }
+.sidebar-nav .sb-status.planned { background: var(--gray-300); }
+
+/* ─── Content ─── */
+.content {
+  max-width: 760px;
+  min-width: 0;
+}
+
+.content-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gray-500);
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.content h1 {
+  font-size: clamp(32px, 4vw, 44px);
+  font-weight: 400;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: var(--gray-950);
+  margin-bottom: 20px;
+}
+
+.content .lead {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--muted-foreground);
+  margin-bottom: 48px;
+  max-width: 640px;
+}
+
+.content h2 {
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
+  color: var(--gray-950);
+  margin-top: 56px;
+  margin-bottom: 16px;
+  scroll-margin-top: 88px;
+}
+.content h2:first-of-type { margin-top: 0; }
+
+.content h3 {
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--gray-950);
+  margin-top: 32px;
+  margin-bottom: 10px;
+}
+
+.content p {
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--gray-700);
+  margin-bottom: 16px;
+}
+.content p strong { color: var(--gray-950); font-weight: 600; }
+
+.content ul, .content ol {
+  margin-bottom: 20px;
+  padding-left: 22px;
+  color: var(--gray-700);
+}
+
+.content li { margin-bottom: 8px; line-height: 1.65; }
+.content li::marker { color: var(--gray-400); }
+
+.content code {
+  background: var(--gray-100);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 14px;
+  color: var(--gray-950);
+}
+
+.content pre {
+  background: var(--gray-950);
+  color: #f0f0f0;
+  padding: 20px 24px;
+  border-radius: 12px;
+  overflow-x: auto;
+  margin-bottom: 24px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.content pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-size: 14px;
+}
+
+/* ─── Status pills ─── */
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.status::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+.status.shipped {
+  background: color-mix(in oklch, var(--success) 12%, white);
+  color: var(--success);
+}
+.status.shipped::before { background: var(--success); }
+.status.partial {
+  background: color-mix(in oklch, var(--warning) 14%, white);
+  color: #a07b00;
+}
+.status.partial::before { background: var(--warning); }
+.status.progress {
+  background: color-mix(in oklch, var(--info) 12%, white);
+  color: var(--info);
+}
+.status.progress::before { background: var(--info); }
+.status.planned {
+  background: var(--gray-100);
+  color: var(--gray-600);
+}
+.status.planned::before { background: var(--gray-400); }
+
+/* ─── On-this-page TOC ─── */
+.toc {
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin-bottom: 48px;
+}
+
+.toc-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-500);
+  margin-bottom: 12px;
+}
+
+.toc ol { list-style: none; padding: 0; counter-reset: toc; margin: 0; }
+.toc li {
+  counter-increment: toc;
+  margin-bottom: 6px;
+  font-size: 14px;
+  padding-left: 0;
+}
+.toc li::marker { color: transparent; }
+.toc li::before {
+  content: counter(toc) ".";
+  color: var(--gray-400);
+  margin-right: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.toc a { color: var(--gray-700); transition: color 0.15s; }
+.toc a:hover { color: var(--gray-950); text-decoration: underline; text-underline-offset: 3px; }
+
+/* ─── Callouts ─── */
+.callout {
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 16px 20px;
+  margin: 24px 0;
+  background: var(--gray-50);
+}
+.callout-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--gray-600);
+  margin-bottom: 6px;
+}
+.callout p { margin-bottom: 0; font-size: 15px; color: var(--gray-700); }
+.callout p + p { margin-top: 10px; }
+
+.callout-info {
+  background: color-mix(in oklch, var(--info) 6%, white);
+  border-color: color-mix(in oklch, var(--info) 20%, transparent);
+}
+.callout-info .callout-label { color: var(--info); }
+
+.callout-warning {
+  background: color-mix(in oklch, var(--warning) 6%, white);
+  border-color: color-mix(in oklch, var(--warning) 20%, transparent);
+}
+.callout-warning .callout-label { color: var(--warning); }
+
+.callout-success {
+  background: color-mix(in oklch, var(--success) 6%, white);
+  border-color: color-mix(in oklch, var(--success) 20%, transparent);
+}
+.callout-success .callout-label { color: var(--success); }
+
+.callout-danger {
+  background: color-mix(in oklch, var(--danger) 6%, white);
+  border-color: color-mix(in oklch, var(--danger) 20%, transparent);
+}
+.callout-danger .callout-label { color: var(--danger); }
+
+/* ─── Diagrams ─── */
+.diagram {
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 32px 24px;
+  margin: 32px 0;
+  text-align: center;
+  overflow-x: auto;
+}
+.diagram .caption {
+  color: var(--gray-500);
+  font-size: 13px;
+  margin-top: 16px;
+}
+.mermaid { display: inline-block; }
+
+/* Flow steps (replaces sequence diagram) */
+.flow-list {
+  margin: 32px 0;
+  display: grid;
+  gap: 8px;
+}
+.flow-step {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  gap: 16px;
+  padding: 14px 18px;
+  background: white;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  align-items: start;
+}
+.flow-step .num {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--gray-400);
+  font-variant-numeric: tabular-nums;
+  padding-top: 4px;
+}
+.flow-step .from-to {
+  font-size: 12px;
+  color: var(--gray-500);
+  margin-bottom: 4px;
+  letter-spacing: 0.01em;
+}
+.flow-step .from-to .actor {
+  font-weight: 600;
+  color: var(--gray-700);
+}
+.flow-step .from-to .arrow {
+  margin: 0 6px;
+  color: var(--gray-400);
+}
+.flow-step .action {
+  font-size: 14.5px;
+  color: var(--gray-950);
+  line-height: 1.5;
+}
+.flow-step .action code { font-size: 13px; }
+.flow-step.db-write {
+  background: color-mix(in oklch, var(--success) 5%, white);
+  border-color: color-mix(in oklch, var(--success) 18%, transparent);
+}
+.flow-step.db-write .num { color: var(--success); }
+.flow-step.db-write .from-to .actor.db { color: var(--success); }
+.flow-loop {
+  border: 1.5px dashed var(--border-medium);
+  border-radius: 12px;
+  padding: 14px;
+  background: var(--gray-50);
+  display: grid;
+  gap: 8px;
+}
+.flow-loop-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--gray-600);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 2px;
+  padding-left: 4px;
+}
+
+/* HTML/CSS stack diagram */
+.stack {
+  display: grid;
+  gap: 12px;
+  max-width: 460px;
+  margin: 32px auto;
+}
+.stack-layer {
+  padding: 22px 24px;
+  border-radius: 10px;
+  text-align: left;
+  background: white;
+  border: 1px solid var(--border-medium);
+}
+.stack-layer .name {
+  font-weight: 700;
+  font-size: 17px;
+  margin-bottom: 4px;
+  color: var(--gray-950);
+}
+.stack-layer .desc {
+  font-size: 14px;
+  color: var(--gray-600);
+}
+.stack-layer.top { border-top: 3px solid var(--info); }
+.stack-layer.mid { border-top: 3px solid var(--success); }
+.stack-layer.bot { border-top: 3px solid var(--warning); }
+
+/* Walls (isolation diagram) */
+.walls {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0;
+  margin: 32px 0;
+  align-items: stretch;
+}
+.agent-col {
+  background: white;
+  border: 1px solid var(--border-medium);
+  border-radius: 12px;
+  padding: 24px;
+}
+.agent-col h4 {
+  margin: 0 0 12px;
+  font-size: 15px;
+  color: var(--gray-950);
+  font-weight: 600;
+}
+.agent-col ul {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 13px;
+  color: var(--gray-600);
+}
+.agent-col ul li { margin-bottom: 4px; }
+.wall {
+  position: relative;
+  width: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--danger);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+.wall::before, .wall::after {
+  content: '';
+  position: absolute;
+  width: 3px;
+  background: repeating-linear-gradient(0deg, var(--danger) 0 8px, transparent 8px 14px);
+  top: 0;
+  bottom: 0;
+}
+.wall::before { left: 22px; }
+.wall::after { right: 22px; }
+@media (max-width: 700px) {
+  .walls { grid-template-columns: 1fr; gap: 12px; }
+  .wall { width: 100%; height: 36px; }
+  .wall::before, .wall::after { width: auto; height: 3px; left: 0; right: 0; bottom: auto; }
+  .wall::before { top: 16px; background: repeating-linear-gradient(90deg, var(--danger) 0 8px, transparent 8px 14px); }
+  .wall::after { top: 22px; background: repeating-linear-gradient(90deg, var(--danger) 0 8px, transparent 8px 14px); }
+}
+
+/* Failure cards (a row of small problem callouts) */
+.fail-grid {
+  display: grid;
+  gap: 12px;
+  margin: 24px 0;
+}
+.fail-card {
+  background: color-mix(in oklch, var(--danger) 5%, white);
+  border: 1px solid color-mix(in oklch, var(--danger) 18%, transparent);
+  border-left: 3px solid var(--danger);
+  border-radius: 10px;
+  padding: 16px 20px;
+}
+.fail-card .label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--danger);
+  letter-spacing: 0.05em;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+.fail-card p { margin: 0; font-size: 14px; color: var(--gray-700); }
+.fail-card strong { color: var(--gray-950); }
+
+/* Tech detail box */
+.tech-box {
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  border-left: 3px solid var(--gray-400);
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin: 24px 0;
+  font-size: 13.5px;
+  color: var(--gray-600);
+}
+.tech-box .label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--gray-500);
+  letter-spacing: 0.05em;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+.tech-box code { font-size: 12.5px; background: white; }
+
+/* ─── Tables ─── */
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 24px 0;
+  background: white;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--border-light);
+  font-size: 14px;
+}
+.content th {
+  text-align: left;
+  padding: 12px 16px;
+  background: var(--gray-50);
+  color: var(--gray-600);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--border-light);
+}
+.content td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-light);
+  vertical-align: top;
+  color: var(--gray-700);
+}
+.content tr:last-child td { border-bottom: none; }
+.content td code { font-size: 12.5px; }
+
+/* ─── Index page bits ─── */
+.chapter-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin-top: 48px;
+}
+@media (max-width: 700px) { .chapter-grid { grid-template-columns: 1fr; } }
+
+.chapter-card {
+  display: block;
+  padding: 22px 24px;
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  background: white;
+  transition: border-color 0.15s, box-shadow 0.2s, transform 0.15s;
+}
+.chapter-card:hover {
+  border-color: var(--border-medium);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03), 0 8px 24px rgba(0, 0, 0, 0.04);
+  transform: translateY(-1px);
+}
+.chapter-card .chapter-num {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-400);
+  margin-bottom: 6px;
+  font-variant-numeric: tabular-nums;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.chapter-card .chapter-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--gray-950);
+  letter-spacing: -0.01em;
+  margin-bottom: 8px;
+}
+.chapter-card .chapter-desc {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--muted-foreground);
+}
+
+.hero { padding-top: 24px; padding-bottom: 24px; }
+.hero h1 {
+  font-size: clamp(36px, 5vw, 52px);
+  font-weight: 400;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  margin-bottom: 24px;
+}
+.hero .lead { font-size: 20px; margin-bottom: 36px; }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 44px;
+  padding: 0 22px;
+  border-radius: 9999px;
+  font-size: 15px;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.btn-primary { background: var(--gray-950); color: white; }
+.btn-primary:hover { background: var(--gray-700); }
+.btn-secondary { background: white; color: var(--gray-950); border: 1px solid var(--border-medium); }
+.btn-secondary:hover { background: var(--gray-50); }
+
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
+/* ─── Pager ─── */
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 72px;
+  padding-top: 32px;
+  border-top: 1px solid var(--border-light);
+}
+.pager a {
+  display: flex;
+  flex-direction: column;
+  padding: 18px 22px;
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  transition: border-color 0.15s, background 0.15s;
+}
+.pager a:hover { border-color: var(--border-medium); background: var(--gray-50); }
+.pager .pager-label {
+  font-size: 12px;
+  color: var(--gray-500);
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+.pager .pager-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--gray-950);
+}
+.pager .next { text-align: right; }
+.pager .spacer { border: none; background: transparent; cursor: default; }
+.pager .spacer:hover { background: transparent; border: none; }
+
+/* ─── File tree ─── */
+.tree {
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin: 24px 0;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font-size: 13.5px;
+  color: var(--gray-700);
+  line-height: 1.75;
+  white-space: pre;
+  overflow-x: auto;
+}
+.tree .dir { color: var(--gray-950); font-weight: 600; }
+.tree .comment { color: var(--gray-500); }
+
+/* ─── Footer ─── */
+.footer {
+  border-top: 1px solid var(--border-light);
+  padding: 32px;
+  text-align: center;
+  color: var(--gray-500);
+  font-size: 13px;
+}


### PR DESCRIPTION
## Summary
- 12-chapter HTML walkthrough of the Houston engine: what's shipped today, what should change, why
- Sidebar navigation, per-chapter status pills (Shipped / Partial / Planned / In progress), prev/next pager
- Light theme mirroring the website Learn section
- Covers: 3-layer architecture, agent-as-folder, Linux microVM plan, message flow, reliability tables (turns / turn_stream / events_outbox / cron_runs), per-agent kernel-enforced isolation, login flow, external triggers, deployment, roadmap (M1-M3)

Living document, edited as design decisions get made. Lives at \`engine-design/\`, open \`index.html\` to read.

## Test plan
- [x] Open \`engine-design/index.html\` in a browser
- [x] Click through every chapter via sidebar
- [x] Prev/next pager links work on every chapter
- [x] Status pills + sidebar dot indicators render

🤖 Generated with [Claude Code](https://claude.com/claude-code)