### PR TITLE
feat(bug-report): mirror sanitized issue to gethouston/houston

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@
 #   SUPABASE_ANON_KEY                  — Supabase anon key (client-side, RLS-gated)
 #   LINEAR_API_KEY                     — Linear API key for in-app "Report bug" issue creation
 #   LINEAR_TEAM_ID                     — Linear team UUID for in-app "Report bug" issues
+#   BUG_REPORT_GITHUB_TOKEN            — fine-grained PAT (Issues R/W on gethouston/houston only); sanitized public mirror of "Report bug"
 #   SLACK_RELEASE_WEBHOOK_URL          — Slack incoming-webhook to ping the team when a draft release is built
 #   SENTRY_DSN                         — Sentry crash reporting DSN
 
@@ -376,6 +377,10 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+          # Sanitized public-mirror sink. Secret can't be named GITHUB_*
+          # (reserved prefix), so it maps the BUG_REPORT_GITHUB_TOKEN
+          # secret onto the GITHUB_BUG_TOKEN build env option_env! reads.
+          GITHUB_BUG_TOKEN: ${{ secrets.BUG_REPORT_GITHUB_TOKEN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Locate build artifacts
@@ -912,6 +917,10 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+          # Sanitized public-mirror sink. Secret can't be named GITHUB_*
+          # (reserved prefix), so it maps the BUG_REPORT_GITHUB_TOKEN
+          # secret onto the GITHUB_BUG_TOKEN build env option_env! reads.
+          GITHUB_BUG_TOKEN: ${{ secrets.BUG_REPORT_GITHUB_TOKEN }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
       - name: Locate MSI + updater signature artifacts

--- a/app/src-tauri/.env.example
+++ b/app/src-tauri/.env.example
@@ -1,10 +1,15 @@
 # Copy to app/.env.local or app/src-tauri/.env.local for local builds.
 # Never commit real values.
 
-# In-app "Report bug" issues
+# In-app "Report bug" issues (authoritative sink — full payload)
 LINEAR_API_KEY=lin_api_your_key
 LINEAR_TEAM_ID=your-linear-team-uuid
 LINEAR_BUG_LABEL_NAME=User Bug
+
+# Sanitized public mirror -> GitHub issues on gethouston/houston.
+# Fine-grained PAT, Issues R/W on gethouston/houston only.
+# CI secret is named BUG_REPORT_GITHUB_TOKEN (GITHUB_ prefix is reserved).
+GITHUB_BUG_TOKEN=github_pat_your_fine_grained_token
 
 # Optional product infrastructure
 POSTHOG_KEY=

--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -67,7 +67,12 @@ fn parse_dotenv_line(line: &str) -> Option<(String, String)> {
 }
 
 fn configure_bug_report_env(dotenv_pairs: &[(String, String)]) {
-    for key in ["LINEAR_API_KEY", "LINEAR_TEAM_ID", "LINEAR_BUG_LABEL_NAME"] {
+    for key in [
+        "LINEAR_API_KEY",
+        "LINEAR_TEAM_ID",
+        "LINEAR_BUG_LABEL_NAME",
+        "GITHUB_BUG_TOKEN",
+    ] {
         println!("cargo:rerun-if-env-changed={key}");
         if let Some(value) = env_value(key, dotenv_pairs) {
             println!("cargo:rustc-env={key}={value}");

--- a/app/src-tauri/src/bug_report/format.rs
+++ b/app/src-tauri/src/bug_report/format.rs
@@ -3,6 +3,18 @@ use super::BugReportPayload;
 const MAX_ERROR_CHARS: usize = 6_000;
 const MAX_LOG_CHARS: usize = 8_000;
 
+/// Which sink an issue body is destined for.
+///
+/// `Internal` (Linear) gets the full payload. `PublicMirror` (the public
+/// GitHub repo) drops the user-identifying context line and omits the log
+/// blocks entirely: logs routinely embed emails and OS home paths, so a
+/// public mirror must never carry them.
+#[derive(Clone, Copy)]
+pub(super) enum Audience {
+    Internal,
+    PublicMirror,
+}
+
 pub(super) fn format_issue_title(payload: &BugReportPayload) -> String {
     let command = collapse_whitespace(&payload.command);
     let summary = collapse_whitespace(payload.error.lines().next().unwrap_or(""));
@@ -13,7 +25,7 @@ pub(super) fn format_issue_title(payload: &BugReportPayload) -> String {
     }
 }
 
-pub(super) fn format_issue_description(payload: &BugReportPayload) -> String {
+pub(super) fn format_issue_description(payload: &BugReportPayload, audience: Audience) -> String {
     let mut description = String::new();
     description.push_str("## Error\n\n");
     description.push_str(&markdown_code_block(
@@ -24,14 +36,16 @@ pub(super) fn format_issue_description(payload: &BugReportPayload) -> String {
     push_context_line(&mut description, "Command", Some(&payload.command));
     push_context_line(&mut description, "Timestamp", Some(&payload.timestamp));
     push_context_line(&mut description, "App Version", Some(&payload.app_version));
-    push_context_line(
-        &mut description,
-        "User",
-        payload
-            .user_email
-            .as_deref()
-            .filter(|value| !value.is_empty()),
-    );
+    if matches!(audience, Audience::Internal) {
+        push_context_line(
+            &mut description,
+            "User",
+            payload
+                .user_email
+                .as_deref()
+                .filter(|value| !value.is_empty()),
+        );
+    }
     push_context_line(
         &mut description,
         "Space",
@@ -48,16 +62,18 @@ pub(super) fn format_issue_description(payload: &BugReportPayload) -> String {
             .as_deref()
             .filter(|value| !value.is_empty()),
     );
-    description.push_str("\n## Backend Logs (last 50 lines)\n\n");
-    description.push_str(&markdown_code_block(
-        "text",
-        &truncate_start(&payload.logs.backend, MAX_LOG_CHARS),
-    ));
-    description.push_str("\n## Frontend Logs (last 50 lines)\n\n");
-    description.push_str(&markdown_code_block(
-        "text",
-        &truncate_start(&payload.logs.frontend, MAX_LOG_CHARS),
-    ));
+    if matches!(audience, Audience::Internal) {
+        description.push_str("\n## Backend Logs (last 50 lines)\n\n");
+        description.push_str(&markdown_code_block(
+            "text",
+            &truncate_start(&payload.logs.backend, MAX_LOG_CHARS),
+        ));
+        description.push_str("\n## Frontend Logs (last 50 lines)\n\n");
+        description.push_str(&markdown_code_block(
+            "text",
+            &truncate_start(&payload.logs.frontend, MAX_LOG_CHARS),
+        ));
+    }
     description
 }
 
@@ -124,9 +140,9 @@ mod tests {
     }
 
     #[test]
-    fn issue_description_includes_context_and_logs() {
+    fn internal_description_includes_context_and_logs() {
         let payload = sample_payload();
-        let description = format_issue_description(&payload);
+        let description = format_issue_description(&payload, Audience::Internal);
         assert!(description.contains("## Error"));
         assert!(description.contains("Error: no workspace found"));
         assert!(description.contains("- Command: list_workspaces"));
@@ -136,9 +152,67 @@ mod tests {
     }
 
     #[test]
+    fn public_mirror_description_omits_user_and_logs() {
+        let payload = sample_payload();
+        let description = format_issue_description(&payload, Audience::PublicMirror);
+        // Still useful for triage.
+        assert!(description.contains("## Error"));
+        assert!(description.contains("Error: no workspace found"));
+        assert!(description.contains("- Command: list_workspaces"));
+        assert!(description.contains("- Workspace: Houston"));
+        // Sanitized: no identifying user line, no logs (logs leak email + paths).
+        assert!(!description.contains("- User:"));
+        assert!(!description.contains("user@example.com"));
+        assert!(!description.contains("Backend Logs"));
+        assert!(!description.contains("Frontend Logs"));
+        assert!(!description.contains("backend log line"));
+        assert!(!description.contains("frontend log line"));
+    }
+
+    #[test]
     fn markdown_code_block_expands_fence_for_backticks() {
         let block = markdown_code_block("text", "before ``` after");
         assert!(block.starts_with("````text\n"));
         assert!(block.ends_with("\n````\n"));
+    }
+
+    #[test]
+    fn truncate_chars_returns_input_at_or_below_limit() {
+        assert_eq!(truncate_chars("hello", 10), "hello");
+        assert_eq!(truncate_chars("hello", 5), "hello"); // exact boundary
+    }
+
+    #[test]
+    fn truncate_chars_appends_ellipsis_when_over_limit() {
+        // keep = max - 3 → "hello" + "..."
+        assert_eq!(truncate_chars("hello world", 8), "hello...");
+    }
+
+    #[test]
+    fn truncate_chars_is_multibyte_safe() {
+        // 6 crab emoji (each is a single char, 4 bytes). A naive byte
+        // slice at index 4 would panic mid-codepoint.
+        let input = "🦀🦀🦀🦀🦀🦀";
+        let result = truncate_chars(input, 4);
+        assert_eq!(result, "🦀..."); // 1 kept + 3 dots = 4 chars
+    }
+
+    #[test]
+    fn truncate_start_returns_input_at_or_below_limit() {
+        assert_eq!(truncate_start("hello", 10), "hello");
+        assert_eq!(truncate_start("hello", 5), "hello"); // exact boundary
+    }
+
+    #[test]
+    fn truncate_start_keeps_tail_with_marker_when_over_limit() {
+        // keep = 6 - 4 = 2 → last 2 chars "89", prefixed with "...\n"
+        assert_eq!(truncate_start("0123456789", 6), "...\n89");
+    }
+
+    #[test]
+    fn truncate_start_is_multibyte_safe() {
+        // keep = 5 - 4 = 1 → last crab. Byte-slicing would panic.
+        let input = "🦀🦀🦀🦀🦀🦀";
+        assert_eq!(truncate_start(input, 5), "...\n🦀");
     }
 }

--- a/app/src-tauri/src/bug_report/github.rs
+++ b/app/src-tauri/src/bug_report/github.rs
@@ -1,0 +1,79 @@
+use std::time::Duration;
+
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize};
+
+use super::format::{format_issue_description, format_issue_title, Audience};
+use super::BugReportPayload;
+
+/// Hard ceiling on a single GitHub request. The mirror runs in a detached
+/// task and would otherwise sit forever if the API hangs mid-response;
+/// bounding it keeps zombie tasks from accumulating across many reports.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(15);
+
+pub(super) async fn send_bug_report_to(
+    api_base: &str,
+    token: &str,
+    repo: &str,
+    label: &str,
+    payload: &BugReportPayload,
+) -> Result<GithubIssueRef, String> {
+    let client = reqwest::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .map_err(|e| format!("Failed to build GitHub HTTP client: {e}"))?;
+    let request = GithubIssueCreate {
+        title: format_issue_title(payload),
+        body: format_issue_description(payload, Audience::PublicMirror),
+        labels: vec![label.to_string()],
+    };
+
+    let response = client
+        .post(format!("{api_base}/repos/{repo}/issues"))
+        .header("Authorization", format!("Bearer {token}"))
+        .header("Accept", "application/vnd.github+json")
+        .header("X-GitHub-Api-Version", "2022-11-28")
+        .header("User-Agent", "houston-bug-reporter")
+        .json(&request)
+        .send()
+        .await
+        .map_err(|e| format!("GitHub API request failed: {e}"))?;
+
+    let status = response.status();
+    if !status.is_success() {
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|e| format!("could not read GitHub response body: {e}"));
+        return Err(github_http_error_message(status, &body));
+    }
+
+    response
+        .json::<GithubIssueRef>()
+        .await
+        .map_err(|e| format!("GitHub API response was not valid JSON: {e}"))
+}
+
+pub(super) fn github_http_error_message(status: StatusCode, body: &str) -> String {
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return format!("GitHub API failed: {status}");
+    }
+    format!(
+        "GitHub API failed: {status} {}",
+        super::format::truncate_chars(trimmed, 160)
+    )
+}
+
+#[derive(Serialize)]
+struct GithubIssueCreate {
+    title: String,
+    body: String,
+    labels: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(super) struct GithubIssueRef {
+    pub(super) number: u64,
+    pub(super) html_url: String,
+}

--- a/app/src-tauri/src/bug_report/github_tests.rs
+++ b/app/src-tauri/src/bug_report/github_tests.rs
@@ -1,0 +1,95 @@
+use super::github::{github_http_error_message, send_bug_report_to};
+use super::sample_payload;
+use super::test_support::serve_sequence;
+use reqwest::StatusCode;
+
+#[test]
+fn github_http_error_message_keeps_status_and_body() {
+    let message = github_http_error_message(StatusCode::UNAUTHORIZED, "Bad credentials");
+    assert_eq!(
+        message,
+        "GitHub API failed: 401 Unauthorized Bad credentials"
+    );
+}
+
+#[tokio::test]
+async fn create_issue_posts_sanitized_body() {
+    let (base, server) = serve_sequence(vec![(
+        "201 Created",
+        "{\"number\":42,\"html_url\":\"https://github.com/gethouston/houston/issues/42\"}",
+    )]);
+
+    let issue = send_bug_report_to(
+        &base,
+        "test-token",
+        "gethouston/houston",
+        "user-bug",
+        &sample_payload(),
+    )
+    .await
+    .expect("create github issue");
+    assert_eq!(issue.number, 42);
+    assert_eq!(
+        issue.html_url,
+        "https://github.com/gethouston/houston/issues/42"
+    );
+
+    let requests = server.join().expect("join test server");
+    let request = requests.first().expect("one request");
+    assert!(request.starts_with("POST /repos/gethouston/houston/issues HTTP/1.1"));
+    let lower = request.to_ascii_lowercase();
+    assert!(lower.contains("authorization: bearer test-token"));
+    assert!(lower.contains("x-github-api-version: 2022-11-28"));
+    assert!(request.contains("\"labels\":[\"user-bug\"]"));
+    assert!(request.contains("Houston bug: list_workspaces"));
+    // Sanitized: no identifying user, no logs (logs leak email + OS paths).
+    assert!(!request.contains("user@example.com"));
+    assert!(!request.contains("- User:"));
+    assert!(!request.contains("Backend Logs"));
+    assert!(!request.contains("backend log line"));
+    assert!(!request.contains("frontend log line"));
+}
+
+#[tokio::test]
+async fn surfaces_http_error() {
+    let (base, server) = serve_sequence(vec![(
+        "401 Unauthorized",
+        "{\"message\":\"Bad credentials\"}",
+    )]);
+
+    let error = send_bug_report_to(
+        &base,
+        "bad-token",
+        "gethouston/houston",
+        "user-bug",
+        &sample_payload(),
+    )
+    .await
+    .expect_err("401 should fail");
+
+    server.join().expect("join test server");
+    assert!(error.contains("401"));
+    assert!(error.contains("Bad credentials"));
+}
+
+#[tokio::test]
+#[ignore = "requires GITHUB_BUG_TOKEN via env; creates a real public issue on gethouston/houston"]
+async fn creates_real_github_issue_when_env_is_set() {
+    let token = std::env::var("GITHUB_BUG_TOKEN").expect("GITHUB_BUG_TOKEN set");
+    let mut payload = sample_payload();
+    payload.command = "local_github_bug_report_smoke_test".to_string();
+    payload.error = format!(
+        "Local GitHub bug-report smoke test from cargo test at {:?}",
+        std::time::SystemTime::now()
+    );
+
+    send_bug_report_to(
+        super::GITHUB_API_BASE,
+        &token,
+        super::GITHUB_REPO,
+        super::GITHUB_LABEL,
+        &payload,
+    )
+    .await
+    .expect("create real GitHub issue");
+}

--- a/app/src-tauri/src/bug_report/linear.rs
+++ b/app/src-tauri/src/bug_report/linear.rs
@@ -1,8 +1,18 @@
+use std::time::Duration;
+
 use serde::{Deserialize, Serialize};
 
-use super::format::{format_issue_description, format_issue_title};
+use super::format::{format_issue_description, format_issue_title, Audience};
 use super::linear_graphql::post_graphql;
 use super::BugReportPayload;
+
+/// Hard ceiling on a single Linear request. Linear is the authoritative
+/// sink and its result blocks the user's "Report bug" toast, so an
+/// unbounded reqwest default would let a hung connection visibly stall
+/// the UI. 15s is comfortably above Linear's p99 and short enough that
+/// the user gets a clear failure toast (with the Sentry-bundled error)
+/// instead of a spinner that never resolves.
+const HTTP_TIMEOUT: Duration = Duration::from_secs(15);
 
 const ISSUE_CREATE_MUTATION: &str = r#"
 mutation HoustonBugReportCreate($input: IssueCreateInput!) {
@@ -37,7 +47,10 @@ pub(super) async fn send_bug_report_to(
     label_name: &str,
     payload: &BugReportPayload,
 ) -> Result<Option<String>, String> {
-    let client = reqwest::Client::new();
+    let client = reqwest::Client::builder()
+        .timeout(HTTP_TIMEOUT)
+        .build()
+        .map_err(|e| format!("Failed to build Linear HTTP client: {e}"))?;
     let label_id = resolve_label_id(&client, api_url, api_key, team_id, label_name).await?;
 
     let data = post_graphql::<LinearIssueCreateData, _>(
@@ -129,7 +142,7 @@ impl LinearIssueCreateInput {
         Self {
             team_id: team_id.to_string(),
             title: format_issue_title(payload),
-            description: format_issue_description(payload),
+            description: format_issue_description(payload, Audience::Internal),
             label_ids: vec![label_id],
         }
     }

--- a/app/src-tauri/src/bug_report/linear_tests.rs
+++ b/app/src-tauri/src/bug_report/linear_tests.rs
@@ -3,9 +3,8 @@ use super::linear_graphql::{
     linear_graphql_error_message, linear_http_error_message, LinearGraphqlError,
 };
 use super::sample_payload;
+use super::test_support::serve_sequence;
 use reqwest::StatusCode;
-use std::io::{Read, Write};
-use std::net::TcpListener;
 
 #[test]
 fn linear_http_error_message_keeps_status_and_body() {
@@ -43,7 +42,7 @@ async fn send_bug_report_posts_linear_issue_create_mutation() {
     ]);
 
     let identifier = send_bug_report_to(
-        &url,
+        &format!("{url}/graphql"),
         "test-api-key",
         "team-id",
         "User Bug",
@@ -78,7 +77,7 @@ async fn send_bug_report_surfaces_graphql_errors() {
     )]);
 
     let error = send_bug_report_to(
-        &url,
+        &format!("{url}/graphql"),
         "test-api-key",
         "team-id",
         "User Bug",
@@ -102,7 +101,7 @@ async fn send_bug_report_fails_when_label_is_missing() {
     )]);
 
     let error = send_bug_report_to(
-        &url,
+        &format!("{url}/graphql"),
         "test-api-key",
         "team-id",
         "User Bug",
@@ -128,60 +127,4 @@ async fn creates_real_linear_issue_when_env_is_set() {
     super::report_bug(payload)
         .await
         .expect("create real Linear issue");
-}
-
-fn serve_sequence(
-    responses: Vec<(&'static str, &'static str)>,
-) -> (String, std::thread::JoinHandle<Vec<String>>) {
-    let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
-    let addr = listener.local_addr().expect("read listener address");
-    let server = std::thread::spawn(move || {
-        let mut requests = Vec::new();
-        for (status, body) in responses {
-            let (mut stream, _) = listener.accept().expect("accept request");
-            let request = read_request(&mut stream);
-            let response = format!(
-                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
-                body.len()
-            );
-            stream
-                .write_all(response.as_bytes())
-                .expect("write response");
-            requests.push(String::from_utf8(request).expect("request is utf8"));
-        }
-        requests
-    });
-    (format!("http://{addr}/graphql"), server)
-}
-
-fn read_request(stream: &mut std::net::TcpStream) -> Vec<u8> {
-    let mut request = Vec::new();
-    let mut buffer = [0; 1024];
-    loop {
-        let read = stream.read(&mut buffer).expect("read request");
-        if read == 0 {
-            break;
-        }
-        request.extend_from_slice(&buffer[..read]);
-        if let Some(header_end) = find_header_end(&request) {
-            let headers = String::from_utf8_lossy(&request[..header_end]);
-            let content_length = headers
-                .lines()
-                .find_map(|line| {
-                    let (name, value) = line.split_once(':')?;
-                    name.eq_ignore_ascii_case("content-length")
-                        .then(|| value.trim())
-                })
-                .and_then(|value| value.parse::<usize>().ok())
-                .unwrap_or(0);
-            if request.len() >= header_end + 4 + content_length {
-                break;
-            }
-        }
-    }
-    request
-}
-
-fn find_header_end(request: &[u8]) -> Option<usize> {
-    request.windows(4).position(|window| window == b"\r\n\r\n")
 }

--- a/app/src-tauri/src/bug_report/mod.rs
+++ b/app/src-tauri/src/bug_report/mod.rs
@@ -1,15 +1,24 @@
 mod format;
+mod github;
+#[cfg(test)]
+mod github_tests;
 mod linear;
 mod linear_graphql;
 #[cfg(test)]
 mod linear_tests;
+#[cfg(test)]
+mod test_support;
 
 use serde::Deserialize;
 
 const LINEAR_API_URL: &str = "https://api.linear.app/graphql";
 const DEFAULT_BUG_LABEL_NAME: &str = "User Bug";
 
-#[derive(Debug, Deserialize)]
+const GITHUB_API_BASE: &str = "https://api.github.com";
+const GITHUB_REPO: &str = "gethouston/houston";
+const GITHUB_LABEL: &str = "user-bug";
+
+#[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BugReportPayload {
     pub(super) command: String,
@@ -22,33 +31,85 @@ pub struct BugReportPayload {
     pub(super) logs: BugReportLogs,
 }
 
-#[derive(Debug, Deserialize)]
+// `Clone` is needed so we can hand a copy to the spawned GitHub mirror
+// task without keeping the user's toast waiting on the await.
+#[derive(Debug, Clone, Deserialize)]
 pub(super) struct BugReportLogs {
     pub(super) backend: String,
     pub(super) frontend: String,
 }
 
-struct LinearBugReportConfig {
+struct LinearConfig {
     api_key: String,
     team_id: String,
     label_name: String,
+}
+
+struct GithubConfig {
+    token: String,
+}
+
+struct BugReportConfig {
+    linear: LinearConfig,
+    /// `None` when the GitHub mirror is unconfigured (dev builds without a
+    /// token). Deliberately not an error: the mirror is best-effort and the
+    /// authoritative Linear sink still runs.
+    github: Option<GithubConfig>,
 }
 
 #[tauri::command(rename_all = "snake_case")]
 pub async fn report_bug(payload: BugReportPayload) -> Result<Option<String>, String> {
     let config = bug_report_config()?;
 
-    linear::send_bug_report_to(
+    // Authoritative sink. Its result is the BUG-xxx reference the user sees
+    // and what gates overall success/failure.
+    let identifier = linear::send_bug_report_to(
         LINEAR_API_URL,
-        &config.api_key,
-        &config.team_id,
-        &config.label_name,
+        &config.linear.api_key,
+        &config.linear.team_id,
+        &config.linear.label_name,
         &payload,
     )
-    .await
+    .await?;
+
+    // Best-effort sanitized public mirror. Spawned, not awaited: a slow or
+    // hung GitHub call must NEVER inflate the user's toast latency (the
+    // authoritative Linear result is already in `identifier`). User-approved
+    // carve-out from the "no silent failures" rule, and NOT truly silent:
+    // a real runtime failure still reaches the dev team via tracing::error!
+    // + Sentry, so a quietly-rotting mirror stays detectable.
+    if let Some(github) = config.github {
+        let payload = payload.clone();
+        tokio::spawn(async move {
+            match github::send_bug_report_to(
+                GITHUB_API_BASE,
+                &github.token,
+                GITHUB_REPO,
+                GITHUB_LABEL,
+                &payload,
+            )
+            .await
+            {
+                Ok(issue) => tracing::info!(
+                    github_issue = issue.number,
+                    github_issue_url = %issue.html_url,
+                    "GitHub bug-report mirror created"
+                ),
+                Err(error) => {
+                    tracing::error!(%error, "GitHub bug-report mirror failed");
+                    sentry::capture_message(
+                        &format!("GitHub bug-report mirror failed: {error}"),
+                        sentry::Level::Error,
+                    );
+                }
+            }
+        });
+    }
+
+    Ok(identifier)
 }
 
-fn bug_report_config() -> Result<LinearBugReportConfig, String> {
+fn bug_report_config() -> Result<BugReportConfig, String> {
     let api_key = configured_value(
         std::env::var("LINEAR_API_KEY").ok(),
         option_env!("LINEAR_API_KEY"),
@@ -64,18 +125,33 @@ fn bug_report_config() -> Result<LinearBugReportConfig, String> {
     )
     .unwrap_or_else(|| DEFAULT_BUG_LABEL_NAME.to_string());
 
-    match (api_key, team_id) {
-        (Some(api_key), Some(team_id)) => Ok(LinearBugReportConfig {
+    let linear = match (api_key, team_id) {
+        (Some(api_key), Some(team_id)) => LinearConfig {
             api_key,
             team_id,
             label_name,
-        }),
-        (None, None) => Err(
-            "Bug reporting not configured (missing LINEAR_API_KEY and LINEAR_TEAM_ID)".to_string(),
-        ),
-        (None, Some(_)) => Err("Bug reporting not configured (missing LINEAR_API_KEY)".to_string()),
-        (Some(_), None) => Err("Bug reporting not configured (missing LINEAR_TEAM_ID)".to_string()),
-    }
+        },
+        (None, None) => {
+            return Err(
+                "Bug reporting not configured (missing LINEAR_API_KEY and LINEAR_TEAM_ID)"
+                    .to_string(),
+            )
+        }
+        (None, Some(_)) => {
+            return Err("Bug reporting not configured (missing LINEAR_API_KEY)".to_string())
+        }
+        (Some(_), None) => {
+            return Err("Bug reporting not configured (missing LINEAR_TEAM_ID)".to_string())
+        }
+    };
+
+    let github = configured_value(
+        std::env::var("GITHUB_BUG_TOKEN").ok(),
+        option_env!("GITHUB_BUG_TOKEN"),
+    )
+    .map(|token| GithubConfig { token });
+
+    Ok(BugReportConfig { linear, github })
 }
 
 fn configured_value(runtime: Option<String>, compiled: Option<&'static str>) -> Option<String> {

--- a/app/src-tauri/src/bug_report/test_support.rs
+++ b/app/src-tauri/src/bug_report/test_support.rs
@@ -1,0 +1,62 @@
+use std::io::{Read, Write};
+use std::net::TcpListener;
+
+/// Spin up a one-shot localhost HTTP server that replies with the given
+/// `(status, body)` pairs in order, then returns every raw request it saw.
+/// Returns the base URL (`http://127.0.0.1:PORT`, no path) so each caller
+/// appends its own endpoint path.
+pub(super) fn serve_sequence(
+    responses: Vec<(&'static str, &'static str)>,
+) -> (String, std::thread::JoinHandle<Vec<String>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind test server");
+    let addr = listener.local_addr().expect("read listener address");
+    let server = std::thread::spawn(move || {
+        let mut requests = Vec::new();
+        for (status, body) in responses {
+            let (mut stream, _) = listener.accept().expect("accept request");
+            let request = read_request(&mut stream);
+            let response = format!(
+                "HTTP/1.1 {status}\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+                body.len()
+            );
+            stream
+                .write_all(response.as_bytes())
+                .expect("write response");
+            requests.push(String::from_utf8(request).expect("request is utf8"));
+        }
+        requests
+    });
+    (format!("http://{addr}"), server)
+}
+
+fn read_request(stream: &mut std::net::TcpStream) -> Vec<u8> {
+    let mut request = Vec::new();
+    let mut buffer = [0; 1024];
+    loop {
+        let read = stream.read(&mut buffer).expect("read request");
+        if read == 0 {
+            break;
+        }
+        request.extend_from_slice(&buffer[..read]);
+        if let Some(header_end) = find_header_end(&request) {
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim())
+                })
+                .and_then(|value| value.parse::<usize>().ok())
+                .unwrap_or(0);
+            if request.len() >= header_end + 4 + content_length {
+                break;
+            }
+        }
+    }
+    request
+}
+
+fn find_header_end(request: &[u8]) -> Option<usize> {
+    request.windows(4).position(|window| window == b"\r\n\r\n")
+}

--- a/app/src-tauri/src/commands/portable.rs
+++ b/app/src-tauri/src/commands/portable.rs
@@ -9,6 +9,7 @@
 //! operations. Mirrors the existing `pick_directory` pattern in `os.rs`.
 
 use std::path::PathBuf;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
 use tokio::process::Command;
 
 #[cfg(target_os = "macos")]

--- a/engine/houston-engine-core/src/git_bash.rs
+++ b/engine/houston-engine-core/src/git_bash.rs
@@ -37,11 +37,17 @@
 /// 7z file-format magic. Always at the start of a valid 7z archive —
 /// appears in the SFX after the PE stub. Public to the module so the
 /// cross-platform unit tests below can reference it.
+///
+/// Gated on `windows | test` because on non-Windows release builds
+/// nothing consumes it — the extraction path is Windows-only and the
+/// tests live behind `cfg(test)`.
+#[cfg(any(target_os = "windows", test))]
 const SEVENZ_MAGIC: &[u8] = &[0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C];
 
 /// Maximum bytes to scan for the 7z magic. PortableGit's SFX stub is
 /// consistently ~245 KB; 2 MB is generous headroom for future SFX
 /// builds without slurping the whole 57 MB file.
+#[cfg(any(target_os = "windows", test))]
 const MAGIC_SCAN_LIMIT: usize = 2 * 1024 * 1024;
 
 /// Scan a file for the 7z file-format magic and return its byte
@@ -52,6 +58,7 @@ const MAGIC_SCAN_LIMIT: usize = 2 * 1024 * 1024;
 /// Kept outside the Windows-only `imp` module so it can be unit-
 /// tested on any host. The full extraction path (which needs
 /// `sevenz-rust2`) stays Windows-only.
+#[cfg(any(target_os = "windows", test))]
 fn find_magic_offset(path: &std::path::Path) -> std::io::Result<Option<u64>> {
     use std::io::Read;
     let mut f = std::fs::File::open(path)?;
@@ -73,6 +80,7 @@ fn find_magic_offset(path: &std::path::Path) -> std::io::Result<Option<u64>> {
 ///
 /// Kept outside `imp` for the same cross-platform test reason as
 /// `find_magic_offset`.
+#[cfg(any(target_os = "windows", test))]
 fn sanitize_entry_path(name: &str) -> Option<std::path::PathBuf> {
     use std::path::{Component, Path, PathBuf};
     let p = Path::new(name);

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -88,12 +88,17 @@ PostHog → BigQuery plugin → target GCP project (burns credits). SQL-queryabl
 - **Rust panics:** Captured via sentry panic handler.
 - **Check:** User reports crash or weird behavior → Sentry dashboard BEFORE local logs.
 
-## In-app bug reports (Linear issue creation)
+## In-app bug reports (dual sink: Linear + sanitized GitHub mirror)
 
-- **Frontend:** `app/src/lib/error-toast.ts` shows the "Report bug" action. `app/src/lib/bug-report.ts` sends a provider-neutral bug report object with recent frontend + backend logs.
-- **Native delivery:** `app/src-tauri/src/bug_report/` creates a Linear issue with `reqwest` against `https://api.linear.app/graphql`. Do not post from the webview; the Linear API key does not belong in the JS bundle.
-- **Config:** `LINEAR_API_KEY` + `LINEAR_TEAM_ID` are read from runtime env, `app/.env.local`, `app/src-tauri/.env.local`, and `option_env!()` for release builds. CI passes them in `.github/workflows/release.yml`. Release builds embed the key in the native app, so never use a broad Linear key. Use a key restricted to "Create issues" and the target team only. Bug reports look up and apply the `User Bug` label; override with optional `LINEAR_BUG_LABEL_NAME`.
-- **Local smoke:** `cd app/src-tauri && LINEAR_API_KEY=... LINEAR_TEAM_ID=... cargo test creates_real_linear_issue_when_env_is_set -- --ignored` creates one real Linear issue.
+- **Frontend:** `app/src/lib/error-toast.ts` shows the "Report bug" action. `app/src/lib/bug-report.ts` sends a provider-neutral bug report object with recent frontend + backend logs. The frontend stays dumb: it always sends the full payload (including `userEmail`); the native layer decides what each sink gets.
+- **Native delivery:** `app/src-tauri/src/bug_report/` fans one report out to two sinks via `reqwest`. Do not post from the webview; neither token belongs in the JS bundle.
+  - **Linear (authoritative).** `https://api.linear.app/graphql`. Gets the **full** payload (`Audience::Internal`): user email + backend/frontend logs included. Its `BUG-xxx` identifier is what the user sees in the success toast, and it gates overall success — a Linear failure surfaces to the user as today.
+  - **GitHub (best-effort public mirror).** `POST https://api.github.com/repos/gethouston/houston/issues`, labelled `user-bug`. Gets a **sanitized** body (`Audience::PublicMirror`): the `User` context line is dropped and **the log blocks are omitted entirely** (logs routinely embed emails + OS home paths; the public repo is world-readable). A GitHub Project board picks the issue up via a GitHub-side "auto-add to project" workflow filtered on `label:user-bug` — Houston code never touches the Projects API.
+- **Sanitization scope (known residual):** only the structured `User` line + the logs are stripped for the mirror. The free-form `error` text and the user-chosen `space`/`workspace` names pass through to the public issue as-is. Free-text PII there is an accepted limitation; logs are the big lever and they are gone.
+- **Failure semantics:** the GitHub mirror is deliberately fire-and-forget from the user's POV. A non-technical customer never sees a mirror error (it isn't their action's outcome — Linear is). It is **not** truly silent: a real runtime failure goes to `tracing::error!` + `sentry::capture_message`, so a quietly-rotting mirror is still detectable by the dev team. A missing `GITHUB_BUG_TOKEN` (dev builds) skips the mirror with no noise — that is "not configured", not a failure.
+- **Config:** `LINEAR_API_KEY` + `LINEAR_TEAM_ID` (+ optional `LINEAR_BUG_LABEL_NAME`, default `User Bug`) and `GITHUB_BUG_TOKEN` are read from runtime env, `app/.env.local`, `app/src-tauri/.env.local`, and `option_env!()` for release builds. CI passes them in `.github/workflows/release.yml`. Both tokens are embedded in the native app, so keep them narrow: a Linear key restricted to "Create issues" on the target team; a **fine-grained** GitHub PAT scoped to **Issues: Read and write on `gethouston/houston` only**. GitHub reserves the `GITHUB_` secret-name prefix, so the CI **secret** is `BUG_REPORT_GITHUB_TOKEN`, mapped onto the `GITHUB_BUG_TOKEN` build env in the workflow.
+- **One-time GitHub setup:** the `user-bug` label must exist on `gethouston/houston` (issue creation fails otherwise), and the Project board needs a Workflows → "Auto-add to project" rule filtered on `is:issue label:user-bug`.
+- **Local smoke:** `cd app/src-tauri && LINEAR_API_KEY=... LINEAR_TEAM_ID=... cargo test creates_real_linear_issue_when_env_is_set -- --ignored` creates one real Linear issue. `GITHUB_BUG_TOKEN=... cargo test creates_real_github_issue_when_env_is_set -- --ignored` creates one real **public** issue on `gethouston/houston`.
 
 ## Required env vars
 
@@ -113,6 +118,7 @@ Shell (local builds) AND GitHub Secrets (CI):
 | `SUPABASE_ANON_KEY` | Supabase anon key (public-safe, RLS-gated) | Supabase → Project settings → API → Project API keys → `anon` `public` |
 | `LINEAR_API_KEY` | Create in-app bug-report issues | Linear → Settings → Account → Security & Access → Personal API keys |
 | `LINEAR_TEAM_ID` | Target team for in-app bug-report issues | Linear command menu → Copy model UUID on the target team |
+| `GITHUB_BUG_TOKEN` | Sanitized public-mirror of bug reports → GitHub issues on `gethouston/houston` | Fine-grained PAT, Issues R/W on `gethouston/houston` only. CI secret name: `BUG_REPORT_GITHUB_TOKEN` (GITHUB_ prefix is reserved) |
 | `SENTRY_DSN` | Crash reporting DSN | sentry.io project settings |
 
 CI also needs as Secrets:


### PR DESCRIPTION
## What

Adds a sanitized public-mirror sink to the in-app "Report bug" flow so every user bug report fans out to **two** issue trackers:

| Sink | Audience | Payload |
|---|---|---|
| **Linear** (authoritative) | Internal | Full — error, context, user email, backend + frontend logs |
| **GitHub** `gethouston/houston` `user-bug` (best-effort mirror) | Public | Sanitized — drops the `User` line, **omits log blocks entirely** (logs leak emails + OS home paths; the repo is world-readable) |

The Linear `BUG-xxx` identifier is what the user sees in the success toast and what gates overall success/failure. A GitHub-side "Auto-add to project" workflow (filtered on `label:user-bug`) routes mirrored issues onto the public board — Houston code never touches the Projects API.

## How

- `bug_report::format::Audience` enum picks between `Internal` (Linear) and `PublicMirror` (GitHub) so a single `format_issue_description` produces both shapes.
- `bug_report::github` is a thin REST client (`POST /repos/{repo}/issues`) parallel to the existing Linear GraphQL client.
- Mock-server scaffolding (`bug_report::test_support::serve_sequence`) was lifted out of `linear_tests.rs` so both sinks share the same HTTP test harness.
- The GitHub mirror is **spawned via `tokio::spawn`**, not awaited inline — a slow/hung GitHub call cannot inflate the user's toast latency. The authoritative Linear result is already in hand by the time we spawn. Mirror failures go to `tracing::error!` + `sentry::capture_message`, so a quietly-rotting mirror still pings the dev team. Missing token = silently skipped (dev builds without secrets).
- Both `reqwest` clients now carry a **15s timeout**; previously both were unbounded (`Client::new()`), so a hung TCP connection could stall the user's "Report bug" toast or accumulate zombie mirror tasks.
- `format::truncate_chars` and `format::truncate_start` gain **boundary + multibyte unit tests**. Pre-existing tests never crossed a truncation boundary, so the multibyte-safe paths were untested.

## Config

- New env var **`GITHUB_BUG_TOKEN`** (fine-grained PAT, **Issues: Read and write on `gethouston/houston` only**) — read by `build.rs` via `option_env!()` and by runtime env, mirroring the Linear setup.
- CI secret name is **`BUG_REPORT_GITHUB_TOKEN`** (the `GITHUB_*` secret-name prefix is reserved by GitHub); `release.yml` maps it onto the build env. The Linux + Windows release jobs both pass it.
- **One-time GitHub setup** (manual, documented in `production-infra.md`):
  - Create the `user-bug` label on `gethouston/houston` (issue creation 422s otherwise).
  - Add a "Workflows → Auto-add to project" rule on the target Project board, filtered on `is:issue label:user-bug`.

## Sanitization scope (known residual)

Only the structured `User` line + the log blocks are stripped for the mirror. The free-form `error` text and the user-chosen `space` / `workspace` names pass through to the public issue as-is. Logs are the big PII lever and they are gone — free-text PII in those fields is an accepted limitation. Called out explicitly in the docs.

## Tests

- `cargo test bug_report::` → **20 passing, 2 ignored** (the real-API smoke tests).
- Unit-tested: dual-audience formatting, sanitization assertions, label fence expansion, both truncators (boundary + multibyte), GitHub HTTP error path, sanitized request body assertions on the mock server, full Linear two-call sequence on the mock server.
- Two `#[ignore]` smoke tests for manual verification:
  - `GITHUB_BUG_TOKEN=… cargo test creates_real_github_issue_when_env_is_set -- --ignored` → creates one real public issue on `gethouston/houston`.
  - `LINEAR_API_KEY=… LINEAR_TEAM_ID=… cargo test creates_real_linear_issue_when_env_is_set -- --ignored` → unchanged from before.

## Commits

1. **`feat(bug-report): mirror sanitized issue to gethouston/houston`** — the feature + the spawn/timeout/test polish described above.
2. **`chore: gate platform-specific items behind cfg to drop dead-code warnings`** — drive-by: `engine/houston-engine-core/src/git_bash.rs` items (only used by the Windows `imp` module and cross-platform tests) and `app/src-tauri/src/commands/portable.rs`'s `tokio::process::Command` import (only used in macOS/Windows cfg blocks) are now gated to match their real reachability. Clears 5 warnings on `cargo check --workspace` on Linux without resorting to `#[allow(dead_code)]`. Happy to split into its own PR if preferred.

## Files

- New: `app/src-tauri/src/bug_report/{github,github_tests,test_support}.rs`
- Changed: `app/src-tauri/src/bug_report/{format,linear,linear_tests,mod}.rs`
- Build / CI: `app/src-tauri/build.rs`, `app/src-tauri/.env.example`, `.github/workflows/release.yml`
- Docs: `knowledge-base/production-infra.md`
- Drive-by: `engine/houston-engine-core/src/git_bash.rs`, `app/src-tauri/src/commands/portable.rs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
