### PR TITLE
fix(files): correctly render the agent files browser on Windows + empty folders

### DIFF
--- a/app/src-tauri/src/commands/os.rs
+++ b/app/src-tauri/src/commands/os.rs
@@ -187,8 +187,12 @@ fn reveal_in_file_manager(path: &Path) -> Result<(), String> {
         // explorer.exe /select,<path> opens the parent folder with the
         // file highlighted. Note: no quotes around the path arg — explorer
         // parses the comma + path as a single token, and quoting it
-        // breaks the selection.
-        let select_arg = format!("/select,{}", path.display());
+        // breaks the selection. Explorer also refuses mixed separators, so
+        // normalize / to \ first (relative paths arrive as forward-slash
+        // per the engine's ProjectFile.path contract, and Path::join keeps
+        // them when appended to a backslash agent root).
+        let native = path.to_string_lossy().replace('/', "\\");
+        let select_arg = format!("/select,{native}");
         std::process::Command::new("explorer")
             .arg(select_arg)
             .spawn()

--- a/app/src-tauri/src/commands/os.rs
+++ b/app/src-tauri/src/commands/os.rs
@@ -149,8 +149,14 @@ pub async fn open_file(agent_path: String, relative_path: String) -> Result<(), 
     if !full.exists() {
         return Err(format!("File does not exist: {}", full.display()));
     }
-    spawn_default_open(&full.to_string_lossy())
-        .map_err(|e| format!("Failed to open file: {e}"))
+    // Relative paths arrive forward-slash per the engine's ProjectFile.path
+    // contract, and Path::join keeps them when appended to a backslash agent
+    // root. Some Windows shell handlers (notably Office) reject the mixed
+    // form, so normalize before handing off to `cmd /C start`.
+    let target = full.to_string_lossy();
+    #[cfg(target_os = "windows")]
+    let target = target.replace('/', "\\");
+    spawn_default_open(&target).map_err(|e| format!("Failed to open file: {e}"))
 }
 
 #[tauri::command(rename_all = "snake_case")]
@@ -185,16 +191,21 @@ fn reveal_in_file_manager(path: &Path) -> Result<(), String> {
     #[cfg(target_os = "windows")]
     {
         // explorer.exe /select,<path> opens the parent folder with the
-        // file highlighted. Note: no quotes around the path arg — explorer
-        // parses the comma + path as a single token, and quoting it
-        // breaks the selection. Explorer also refuses mixed separators, so
-        // normalize / to \ first (relative paths arrive as forward-slash
-        // per the engine's ProjectFile.path contract, and Path::join keeps
-        // them when appended to a backslash agent root).
+        // file highlighted. Two Windows quirks to handle:
+        //   1. Explorer refuses mixed separators. Relative paths arrive
+        //      forward-slash per the engine's ProjectFile.path contract,
+        //      and Path::join keeps them when appended to a backslash
+        //      agent root, so the joined string is mixed. Normalize to \.
+        //   2. Command::arg auto-wraps any arg containing spaces in double
+        //      quotes on Windows. Explorer can't parse `"/select,...` —
+        //      the leading quote makes it ignore the verb and open the
+        //      default folder (Documents). Use raw_arg so the cmdline goes
+        //      out exactly as `/select,C:\path with space\file.txt`.
+        use std::os::windows::process::CommandExt;
         let native = path.to_string_lossy().replace('/', "\\");
         let select_arg = format!("/select,{native}");
         std::process::Command::new("explorer")
-            .arg(select_arg)
+            .raw_arg(&select_arg)
             .spawn()
             .map(|_| ())
             .map_err(|e| e.to_string())

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -417,6 +417,7 @@ export const tauriFiles = {
         extension: f.extension,
         size: f.size,
         is_directory: f.is_directory,
+        dateModified: f.date_modified,
       })),
     ),
   open: (agentPath: string, relativePath: string) =>

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -416,6 +416,7 @@ export const tauriFiles = {
         name: f.name,
         extension: f.extension,
         size: f.size,
+        is_directory: f.is_directory,
       })),
     ),
   open: (agentPath: string, relativePath: string) =>

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -171,6 +171,7 @@ export interface FileEntry {
   extension: string;
   size: number;
   is_directory?: boolean;
+  dateModified?: number;
 }
 
 /** A listing from the Houston Store registry */

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -170,6 +170,7 @@ export interface FileEntry {
   name: string;
   extension: string;
   size: number;
+  is_directory?: boolean;
 }
 
 /** A listing from the Houston Store registry */

--- a/engine/houston-engine-core/src/agents/files.rs
+++ b/engine/houston-engine-core/src/agents/files.rs
@@ -150,11 +150,6 @@ fn modified_millis(metadata: &std::fs::Metadata) -> Option<i64> {
     i64::try_from(since_epoch.as_millis()).ok()
 }
 
-fn modified_millis_of(path: &Path) -> Option<i64> {
-    let metadata = std::fs::metadata(path).ok()?;
-    modified_millis(&metadata)
-}
-
 /// List user-facing files in an agent folder. Returns an empty vec if the
 /// folder doesn't exist (matches legacy Tauri behaviour).
 pub fn list_project_files(agent_root: &Path) -> CoreResult<Vec<ProjectFile>> {
@@ -358,7 +353,7 @@ fn collect_files(root: &Path, dir: &Path, out: &mut Vec<ProjectFile>) {
                 continue;
             }
             let relative = relative_path_string(root, &path);
-            let date_modified = modified_millis_of(&path);
+            let date_modified = entry.metadata().ok().as_ref().and_then(modified_millis);
             out.push(ProjectFile {
                 path: relative,
                 name,

--- a/engine/houston-engine-core/src/agents/files.rs
+++ b/engine/houston-engine-core/src/agents/files.rs
@@ -21,6 +21,7 @@ use houston_agent_files as files;
 use houston_ui_events::HoustonEvent;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::time::UNIX_EPOCH;
 
 // ---------------------------------------------------------------------------
 // Agent-data files
@@ -122,6 +123,11 @@ pub struct ProjectFile {
     pub extension: String,
     pub size: u64,
     pub is_directory: bool,
+    /// Last modification time in milliseconds since the UNIX epoch. `None`
+    /// when the filesystem doesn't expose mtime for the entry (rare; the
+    /// frontend renders an em-dash in that case).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub date_modified: Option<i64>,
 }
 
 /// Build the relative-path string used in `ProjectFile.path`: strip the agent
@@ -134,6 +140,19 @@ fn relative_path_string(root: &Path, path: &Path) -> String {
     } else {
         rel.replace(std::path::MAIN_SEPARATOR, "/")
     }
+}
+
+/// Read the modification time as millis-since-epoch, returning `None` when
+/// the filesystem doesn't expose it (network mounts, exotic FSes).
+fn modified_millis(metadata: &std::fs::Metadata) -> Option<i64> {
+    let modified = metadata.modified().ok()?;
+    let since_epoch = modified.duration_since(UNIX_EPOCH).ok()?;
+    i64::try_from(since_epoch.as_millis()).ok()
+}
+
+fn modified_millis_of(path: &Path) -> Option<i64> {
+    let metadata = std::fs::metadata(path).ok()?;
+    modified_millis(&metadata)
 }
 
 /// List user-facing files in an agent folder. Returns an empty vec if the
@@ -268,7 +287,9 @@ pub fn import_files(
                     .extension()
                     .map(|e| e.to_string_lossy().to_lowercase())
                     .unwrap_or_default();
-                let size = dest.metadata().map(|m| m.len()).unwrap_or(0);
+                let metadata = dest.metadata().ok();
+                let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+                let date_modified = metadata.as_ref().and_then(modified_millis);
                 let relative = relative_path_string(agent_root, &dest);
                 imported.push(ProjectFile {
                     path: relative,
@@ -276,6 +297,7 @@ pub fn import_files(
                     extension: ext,
                     size,
                     is_directory: false,
+                    date_modified,
                 });
             }
             Err(e) => tracing::error!("[agents] import failed for {src_str}: {e}"),
@@ -298,13 +320,16 @@ pub fn write_file_bytes(
         .extension()
         .map(|e| e.to_string_lossy().to_lowercase())
         .unwrap_or_default();
-    let size = dest.metadata().map(|m| m.len()).unwrap_or(0);
+    let metadata = dest.metadata().ok();
+    let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+    let date_modified = metadata.as_ref().and_then(modified_millis);
     Ok(ProjectFile {
         path: final_name.clone(),
         name: final_name,
         extension: ext,
         size,
         is_directory: false,
+        date_modified,
     })
 }
 
@@ -333,12 +358,14 @@ fn collect_files(root: &Path, dir: &Path, out: &mut Vec<ProjectFile>) {
                 continue;
             }
             let relative = relative_path_string(root, &path);
+            let date_modified = modified_millis_of(&path);
             out.push(ProjectFile {
                 path: relative,
                 name,
                 extension: String::new(),
                 size: 0,
                 is_directory: true,
+                date_modified,
             });
             collect_files(root, &path, out);
             continue;
@@ -351,13 +378,16 @@ fn collect_files(root: &Path, dir: &Path, out: &mut Vec<ProjectFile>) {
             continue;
         }
         let relative = relative_path_string(root, &path);
-        let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
+        let metadata = entry.metadata().ok();
+        let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
+        let date_modified = metadata.as_ref().and_then(modified_millis);
         out.push(ProjectFile {
             path: relative,
             name,
             extension: ext,
             size,
             is_directory: false,
+            date_modified,
         });
     }
 }
@@ -430,6 +460,26 @@ mod tests {
         assert!(names.contains(&"notes.txt"));
         assert!(!names.contains(&"script.py"));
         assert!(!names.iter().any(|n| n.starts_with('.')));
+    }
+
+    #[test]
+    fn list_project_files_populates_date_modified() {
+        let d = tmp();
+        std::fs::create_dir_all(d.path().join("docs")).unwrap();
+        std::fs::write(d.path().join("docs/note.txt"), "x").unwrap();
+
+        let files = list_project_files(d.path()).unwrap();
+        let note = files
+            .iter()
+            .find(|f| f.path == "docs/note.txt")
+            .expect("note.txt missing");
+        let dir = files
+            .iter()
+            .find(|f| f.path == "docs")
+            .expect("docs missing");
+        assert!(note.date_modified.is_some(), "file mtime should populate");
+        assert!(dir.date_modified.is_some(), "dir mtime should populate");
+        assert!(note.date_modified.unwrap() > 0);
     }
 
     #[test]

--- a/engine/houston-engine-core/src/agents/files.rs
+++ b/engine/houston-engine-core/src/agents/files.rs
@@ -114,11 +114,26 @@ fn should_skip_dir(name: &str) -> bool {
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct ProjectFile {
+    /// Relative path from the agent root, always forward-slash separated
+    /// regardless of host OS. The frontend file tree depends on this contract
+    /// to split path segments and nest entries correctly.
     pub path: String,
     pub name: String,
     pub extension: String,
     pub size: u64,
     pub is_directory: bool,
+}
+
+/// Build the relative-path string used in `ProjectFile.path`: strip the agent
+/// root prefix and force forward slashes so the frontend tree builder works
+/// the same on Windows and Unix.
+fn relative_path_string(root: &Path, path: &Path) -> String {
+    let rel = path.strip_prefix(root).unwrap_or(path).to_string_lossy();
+    if std::path::MAIN_SEPARATOR == '/' {
+        rel.into_owned()
+    } else {
+        rel.replace(std::path::MAIN_SEPARATOR, "/")
+    }
 }
 
 /// List user-facing files in an agent folder. Returns an empty vec if the
@@ -254,11 +269,7 @@ pub fn import_files(
                     .map(|e| e.to_string_lossy().to_lowercase())
                     .unwrap_or_default();
                 let size = dest.metadata().map(|m| m.len()).unwrap_or(0);
-                let relative = dest
-                    .strip_prefix(agent_root)
-                    .unwrap_or(&dest)
-                    .to_string_lossy()
-                    .to_string();
+                let relative = relative_path_string(agent_root, &dest);
                 imported.push(ProjectFile {
                     path: relative,
                     name: final_name,
@@ -321,11 +332,7 @@ fn collect_files(root: &Path, dir: &Path, out: &mut Vec<ProjectFile>) {
             if should_skip_dir(&name) {
                 continue;
             }
-            let relative = path
-                .strip_prefix(root)
-                .unwrap_or(&path)
-                .to_string_lossy()
-                .to_string();
+            let relative = relative_path_string(root, &path);
             out.push(ProjectFile {
                 path: relative,
                 name,
@@ -343,11 +350,7 @@ fn collect_files(root: &Path, dir: &Path, out: &mut Vec<ProjectFile>) {
         if !USER_EXTENSIONS.contains(&ext.as_str()) {
             continue;
         }
-        let relative = path
-            .strip_prefix(root)
-            .unwrap_or(&path)
-            .to_string_lossy()
-            .to_string();
+        let relative = relative_path_string(root, &path);
         let size = entry.metadata().map(|m| m.len()).unwrap_or(0);
         out.push(ProjectFile {
             path: relative,
@@ -427,6 +430,22 @@ mod tests {
         assert!(names.contains(&"notes.txt"));
         assert!(!names.contains(&"script.py"));
         assert!(!names.iter().any(|n| n.starts_with('.')));
+    }
+
+    #[test]
+    fn list_project_files_uses_forward_slashes_on_all_platforms() {
+        let d = tmp();
+        std::fs::create_dir_all(d.path().join("docs/inner")).unwrap();
+        std::fs::write(d.path().join("docs/inner/note.txt"), "x").unwrap();
+        std::fs::create_dir_all(d.path().join("empty")).unwrap();
+
+        let files = list_project_files(d.path()).unwrap();
+        let paths: Vec<&str> = files.iter().map(|f| f.path.as_str()).collect();
+        assert!(paths.contains(&"docs"));
+        assert!(paths.contains(&"docs/inner"));
+        assert!(paths.contains(&"docs/inner/note.txt"));
+        assert!(paths.contains(&"empty"));
+        assert!(!paths.iter().any(|p| p.contains('\\')));
     }
 
     #[test]

--- a/ui/agent/src/files-browser.tsx
+++ b/ui/agent/src/files-browser.tsx
@@ -146,7 +146,7 @@ export function FilesBrowser({
       className="relative flex flex-col overflow-hidden bg-background border border-border rounded-xl h-full"
       {...(onFilesDropped || onMove ? dragHandlers : {})}
     >
-      <div className="h-[24px] shrink-0 border-b border-border bg-muted/40 select-none flex items-center rounded-t-xl">
+      <div className="h-[24px] shrink-0 border-b border-border bg-muted/40 select-none flex items-center rounded-t-xl px-1">
         <div className="flex-1 min-w-0 items-center h-full" style={{ display: "grid", gridTemplateColumns: COL_GRID }}>
           <HeaderCell label={l.columnName} col="name" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} className="pl-7" />
           <HeaderCell label={l.columnDateModified} col="dateModified" sortKey={sortKey} sortDir={sortDir} onSort={handleSort} />

--- a/ui/agent/src/tree.ts
+++ b/ui/agent/src/tree.ts
@@ -34,12 +34,13 @@ export function buildTree(files: FileEntry[]): FolderNode {
     if (file.is_directory) {
       const parts = file.path.split("/")
       let node = root
-      for (const segment of parts) {
+      for (let i = 0; i < parts.length; i++) {
+        const segment = parts[i]
         let child = node.children.find(
           (c): c is FolderNode => c.kind === "folder" && c.name === segment,
         )
         if (!child) {
-          const folderPath = parts.slice(0, parts.indexOf(segment) + 1).join("/")
+          const folderPath = parts.slice(0, i + 1).join("/")
           child = { kind: "folder", name: segment, path: folderPath, children: [] }
           node.children.push(child)
         }

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -235,6 +235,9 @@ export interface ProjectFile {
   extension: string;
   size: number;
   is_directory: boolean;
+  /** Last modification time in milliseconds since the UNIX epoch. Omitted
+   * when the filesystem doesn't expose mtime for the entry. */
+  date_modified?: number;
 }
 
 export interface InstalledConfig {


### PR DESCRIPTION
Closes #191

## Summary

Five related bugs that together broke the agent files browser. All surfaced (or were latent) on Windows and around empty-folder rendering:

1. **Empty folders rendered as files.** `tauriFiles.list` dropped `is_directory` when mapping the engine's `ProjectFile` to the frontend `FileEntry`, so `buildTree` never saw a directory entry. Original scope of this PR.

2. **On Windows, all files appeared at the top level instead of nested inside their parent folders.** The engine returned project file paths using the host OS path separator (`\` on Windows), but the frontend tree builder splits on `/`. Fixed at the source so the contract is "`ProjectFile.path` is always `/`-separated", documented on the type and covered by a new test that fails on Windows without the fix.

3. **Latent `buildTree` bug exposed by fix 1.** The directory branch computed `folderPath` via `parts.indexOf(segment)`, which returns the FIRST occurrence — wrong for paths with repeated segments like `projects/2025/projects`. Switched to an indexed for-loop.

4. **Date Modified column showed `—` for every row.** The engine's `ProjectFile` didn't carry mtime. Added `date_modified` (millis since UNIX epoch, `Option<i64>`) populated from `metadata.modified()` in `list_project_files`, `import_files`, and `write_file_bytes`. Mirrored through the engine-client TS type and the app's `FileEntry` mapper so `formatFinderDate` gets a real timestamp.

5. **Date column visually drifted off its header boundary.** The content scroll container had `px-1` padding; the header grid wrapper didn't. Rows sat 4px right of where the headers said the column started, so the em-dash placeholder appeared close to the column separator instead of under the header label. Added matching `px-1` to the header.

6. **Right-click "Reveal in Finder/Explorer" did nothing on Windows.** `reveal_in_file_manager` built the `/select` argument straight from `path.display()`. After fix 2, relative paths arrive forward-slash, and `Path::join` keeps them, producing mixed-separator paths like `C:\agent\docs/inner/file.txt`. `explorer.exe` refuses to parse those. Normalize to backslashes before handing off.

## Changes

- `app/src/lib/tauri.ts` — include `is_directory` and `date_modified` → `dateModified` in the `tauriFiles.list` mapping.
- `app/src/lib/types.ts` — add optional `is_directory?: boolean` and `dateModified?: number` to `FileEntry`.
- `app/src-tauri/src/commands/os.rs` — normalize `/` → `\` in the Windows reveal path.
- `engine/houston-engine-core/src/agents/files.rs` — `relative_path_string` helper for the `/` contract; `modified_millis` / `modified_millis_of` helpers for mtime; `date_modified` field on `ProjectFile` populated by `collect_files`, `import_files`, and `write_file_bytes`. Two new tests (`*_uses_forward_slashes_on_all_platforms`, `*_populates_date_modified`).
- `ui/engine-client/src/types.ts` — add optional `date_modified?: number` to `ProjectFile`.
- `ui/agent/src/tree.ts` — indexed for-loop in the directory branch.
- `ui/agent/src/files-browser.tsx` — `px-1` on the header wrapper so header columns line up with content rows.

## Test plan

- [x] `cargo test -p houston-engine-core agents::files` — 11/11 pass on Windows host.
- [x] `pnpm typecheck` (all packages) + `cd app && pnpm tsc --noEmit` — clean.
- [x] Open an agent on Windows, create a nested folder structure with files inside, confirm files render nested under their folders (not flat).
- [ ] Create an empty folder via the UI, confirm it renders as a folder (icon + expandable).
- [ ] Create a folder whose name repeats a parent name (`projects/2025/projects`), confirm the inner `projects` folder appears at the correct depth.
- [x] Confirm Date Modified column shows actual timestamps for files (and `—` only for entries the FS won't expose mtime for, which should be rare).
- [x] Confirm header columns and row columns visually line up.
- [x] Right-click a file, "Reveal in Explorer" — Explorer opens with the file highlighted.