### PR TITLE
docs(engine): revise design guide with v1 reasoning and milestone sizing

### DIFF
--- a/engine-design/01-three-layers.html
+++ b/engine-design/01-three-layers.html
@@ -68,6 +68,15 @@
       links, tray icons. React gives us the chat, the board, the file
       browser, all the components in <code>@houston-ai/*</code>.
     </p>
+    <p>
+      The UX is not interchangeable. It is the actual product. Most of our
+      target users (non-technical people running agents) will never see the
+      engine. They see the desktop. The point of the split is not that the
+      desktop is unimportant. The point is that the engine doesn't know or
+      care that the desktop exists, so we can put a mobile app, a CLI, or a
+      third-party UI in front of the same engine without rewriting
+      anything.
+    </p>
 
     <h2>The engine</h2>
     <p>
@@ -79,6 +88,9 @@
     <p>
       The engine doesn't know about React or Tauri. It only speaks HTTP.
       That's the most important architectural decision Houston has made.
+      Today it runs natively on your Mac, your PC, or your Linux box. After
+      Chapter 3 lands, it always runs inside a Linux runtime, even on Mac
+      and Windows. The protocol does not change.
     </p>
 
     <h2>Agents</h2>
@@ -97,20 +109,20 @@
 
     <h2>Why the split matters</h2>
     <p>
-      The desktop app is <strong>interchangeable</strong>. You could
-      replace it with a mobile app, a CLI, a third-party UI. They all
-      speak the same protocol to the same engine. The engine doesn't care
-      what's talking to it.
+      The engine is reusable. You can put any frontend on it.
+      <code>examples/smartbooks/</code> is a 400-line React app that talks
+      to the same engine, with its own brand, zero <code>@houston-ai/*</code>
+      UI deps. The desktop is one consumer. Houston Mobile (the PWA at
+      <code>tunnel.gethouston.ai</code>) is another. Houston Cloud will
+      be another.
     </p>
     <p>
-      This split is what lets the engine run on a server. What lets the
-      engine be open source while the cloud product stays managed. What
-      lets a power user write their own frontend. Same engine.
+      Same engine. Same protocol. Different shells.
     </p>
 
     <div class="tech-box">
       <div class="label">Where to look in the code</div>
-      <p>Engine: <code>engine/houston-engine-server</code> plus 15 supporting crates under <code>engine/</code>. Desktop: <code>app/</code>. Wire protocol types: <code>engine/houston-engine-protocol</code> and <code>ui/engine-client</code>. Reference custom frontend: <code>examples/smartbooks/</code>.</p>
+      <p>Engine: <code>engine/houston-engine-server</code> plus 15 supporting crates under <code>engine/</code>. Desktop: <code>app/</code>. Wire protocol types: <code>engine/houston-engine-protocol</code> and <code>ui/engine-client</code>. Reference custom frontend: <code>examples/smartbooks/</code>. Mobile PWA: <code>mobile/</code> and the relay at <code>houston-relay/</code>.</p>
     </div>
 
     <div class="pager">

--- a/engine-design/02-agent-folder.html
+++ b/engine-design/02-agent-folder.html
@@ -58,20 +58,43 @@
   <span class="dir">config/</span>             <span class="comment">← per-agent config</span>
   <span class="dir">learnings/</span>          <span class="comment">← memories the agent has built up</span>
   <span class="dir">prompts/modes/</span>      <span class="comment">← editable prompt overlays</span>
-  <span class="dir">sessions/</span>           <span class="comment">← one .sid file per conversation</span>
+  <span class="dir">sessions/</span>           <span class="comment">← per-provider resume ids (anthropic/, openai/)</span>
 <span class="dir">.agents/skills/</span>       <span class="comment">← installed skills</span>
-<span class="dir">.claude/skills/</span>       <span class="comment">← symlinks (Claude Code reads here)</span></div>
+<span class="dir">.claude/skills/</span>       <span class="comment">← symlinks (Claude Code reads here)</span>
+<span class="dir">AGENTS.md</span>             <span class="comment">← symlink → CLAUDE.md (Codex reads here)</span></div>
 
     <h2>Why files</h2>
     <p>
       Files are inspectable, portable, and ordinary. You back up an agent
       by copying its folder. You move it to another machine by copying its
-      folder. You open it in Finder.
+      folder. You restore it the same way.
     </p>
     <p>
       The engine reads from this folder. The CLI subprocess writes to it
       directly when it edits files. The user can hand-edit anything in it.
       All three actors work on the same files.
+    </p>
+
+    <h2>Where that folder physically lives</h2>
+    <p>
+      Today on Mac, Windows, and Linux: in your real home directory,
+      <code>~/.houston/workspaces/...</code>. You can open it in Finder.
+    </p>
+    <p>
+      After Chapter 3 lands: inside a Linux runtime that runs alongside
+      the desktop app. On Linux, that's the host filesystem (same as
+      today). On Windows, it's the WSL2 filesystem, which Windows Explorer
+      exposes natively at <code>\\wsl$\Houston\...</code>. On Mac, it
+      lives inside the VM's disk image and is reached through the app's
+      Files panel, with an explicit Import and Download flow.
+    </p>
+    <p>
+      The reason the folder moves is in Chapter 3. The short version: most
+      real users keep their data in Drive, Slack, Notion, and Gmail. They
+      don't browse <code>~/Documents</code>. Putting agents inside a Linux
+      runtime gives us per-agent isolation and ends the Windows tooling
+      tax. The cost is that "open in Finder" stops working uniformly. The
+      Files panel and the Download flow replace it.
     </p>
 
     <h2>Schemas as source of truth</h2>
@@ -82,6 +105,10 @@
       <code>include_str!</code>. On first launch, the engine seeds each
       agent's folder with a copy of the relevant schema so the LLM can
       validate before writing.
+    </p>
+    <p>
+      One source of truth, two consumers (Rust engine and TS client). One
+      PR changes both.
     </p>
 
     <h2>The reactivity stack</h2>
@@ -100,17 +127,17 @@
       doesn't update until refresh.</strong>
     </p>
 
-    <h2>What stays the same</h2>
+    <h2>What stays the same after the redesign</h2>
     <p>
-      This part of Houston is already exactly how it should be. The whole
-      reliability and deployment redesign keeps this layout untouched.
-      What changes is what happens between the user clicking and the
-      engine reading these files.
+      The folder layout. The schemas. The reactivity stack. The atomic
+      write rules. The migration story. All of that survives Chapter 3
+      untouched. What changes is the location of the folder and how the
+      desktop app gets bytes in and out of it.
     </p>
 
     <div class="tech-box">
       <div class="label">Where to look in the code</div>
-      <p>File I/O and migrations: <code>engine/houston-agent-files</code>. JSON schemas: <code>ui/agent-schemas/src/*.schema.json</code>. File watcher: <code>engine/houston-file-watcher</code>. Event invalidation: <code>app/src/hooks/use-agent-invalidation.ts</code>.</p>
+      <p>File I/O and migrations: <code>engine/houston-agent-files</code>. JSON schemas: <code>ui/agent-schemas/src/*.schema.json</code>. File watcher: <code>engine/houston-file-watcher</code>. Event invalidation: <code>app/src/hooks/use-agent-invalidation.ts</code>. Migrations: <code>houston_agent_files::migrate_agent_data</code>.</p>
     </div>
 
     <div class="pager">

--- a/engine-design/03-where-engine-lives.html
+++ b/engine-design/03-where-engine-lives.html
@@ -35,80 +35,268 @@
   <main class="content">
     <div class="content-label">
       Chapter 03
-      <span class="status planned">Planned</span>
+      <span class="status planned">Planned · M3 · ~3 months</span>
     </div>
     <h1>Where the engine lives.</h1>
     <p class="lead">
       Today the engine runs natively on Mac, Windows, and Linux. Three
-      builds. Three sandboxing models. Going forward, the engine always
-      runs inside a Linux microVM.
+      builds. Three sandboxing stories. Going forward, the engine always
+      runs inside a Linux runtime. One engine binary. Three host
+      runtimes: Apple <code>Virtualization.framework</code> on Mac, WSL2
+      on Windows, native Linux everywhere else.
     </p>
 
-    <h2>The shift</h2>
+    <h2>Why we're moving. Three concrete reasons.</h2>
+
+    <h3>1. Per-client isolation is a real product need</h3>
     <p>
-      When you install Houston on your Mac, the desktop app spins up a
-      tiny Linux VM and runs the engine inside it. When you sign up for
-      Houston Cloud, a tiny Linux VM is provisioned for you in the cloud
-      and the same engine runs inside it.
+      Imagine you're a consultant. You build one Houston agent per client.
+      ClientA agent, ClientB agent. You don't want ClientA's agent to read
+      ClientB's contracts, files, or chat history. Today, nothing stops
+      it. The Claude or Codex subprocess runs as you, with your full home
+      directory, your SSH keys, your everything.
     </p>
     <p>
-      The engine binary is byte-for-byte the same. The only difference is
-      whose computer the VM runs on.
+      A clever (or jailbroken) prompt asking ClientA's agent to "go read
+      everything in <code>~/.houston/workspaces/MyConsulting/ClientB/</code>"
+      will work, because there is no wall. The agent has a shell. It can
+      <code>cat</code>, <code>cd</code>, <code>ls</code>, <code>find</code>.
+      Read Chapter 7 for the full threat model. The short version is that
+      the only way to actually stop this is a kernel-enforced wall, and
+      the only practical way to get that on every OS is per-agent Linux
+      users inside a Linux runtime.
     </p>
+
+    <h3>2. Real users are cloud-first, not Finder-first</h3>
+    <p>
+      Houston's target user is non-technical. Their data is in Drive,
+      Slack, Notion, Gmail. They don't keep a tidy
+      <code>~/Documents/Clients/</code>. They authenticate to a SaaS via
+      OAuth and the agent does the work there.
+    </p>
+    <p>
+      "The agent can browse my whole laptop" is not a feature for these
+      users. It's an attack surface. Moving the agent into a Linux runtime
+      with no access to the host filesystem flips this from a risk to a
+      property: "your agent cannot see anything outside the runtime, by
+      design."
+    </p>
+    <p>
+      For users who DO have local files, the desktop app exposes Import
+      (one-time copy in) and Download (export out). Both first-class
+      affordances. See "File flow" below.
+    </p>
+
+    <h3>3. The Windows tooling tax is real and growing</h3>
+    <p>
+      Composio doesn't run on Windows without our patches. We maintain
+      <code>gethouston/composio</code> as a fork because upstream closed
+      the Windows issue with "use WSL." Every vanguard CLI tool we'll want
+      to bundle next (Stripe Link CLI, future MCP servers, whatever) ships
+      Linux and Mac first, Windows months later if at all.
+    </p>
+    <p>
+      A Linux runtime on Windows means we ship the Linux build of every
+      tool. The fork dies. Future tooling just works.
+    </p>
+
+    <h2>The answer: one engine binary, three host runtimes</h2>
 
     <div class="diagram">
-      <pre class="mermaid">
-graph TB
-  subgraph Host["Your Mac / Windows / Linux"]
-    Shell["Desktop Shell<br/>(Tauri, ~2k LOC per OS)"]
-    subgraph VM["Linux microVM"]
-      Engine["houston-engine<br/>(one Linux binary)"]
-      A1["Agent A"]
-      A2["Agent B"]
-      Engine --> A1
-      Engine --> A2
-    end
-    Shell -.HTTP+WS.-> Engine
-  end
-      </pre>
-      <div class="caption">Same picture for desktop and cloud. Only "Host" changes.</div>
+      <div class="host-grid">
+        <div class="host-card">
+          <div class="host-name">macOS host</div>
+          <div class="runtime-pill">Apple Virtualization.framework</div>
+          <div class="engine-pill">houston-engine<div class="engine-sub">Linux build</div></div>
+        </div>
+        <div class="host-card">
+          <div class="host-name">Windows host</div>
+          <div class="runtime-pill">WSL2</div>
+          <div class="engine-pill">houston-engine<div class="engine-sub">Linux build</div></div>
+        </div>
+        <div class="host-card">
+          <div class="host-name">Linux host</div>
+          <div class="runtime-pill">no runtime, native</div>
+          <div class="engine-pill">houston-engine<div class="engine-sub">Linux build</div></div>
+        </div>
+        <div class="host-card">
+          <div class="host-name">Cloud (Fly Machine)</div>
+          <div class="runtime-pill">Linux microVM</div>
+          <div class="engine-pill">houston-engine<div class="engine-sub">Linux build</div></div>
+        </div>
+      </div>
+      <div class="caption">Same Linux binary every place. Only the host runtime changes.</div>
     </div>
 
-    <h2>Why a VM. Four reasons.</h2>
+    <h2>Why not a custom hypervisor</h2>
+    <p>
+      We are NOT writing our own VM stack. Apple and Microsoft have
+      already shipped the right primitives. Using them means:
+    </p>
+    <ul>
+      <li>
+        <strong>macOS:</strong> Apple
+        <code>Virtualization.framework</code>. Ships with the OS since
+        macOS 11. Boots a Linux guest in 1-3 seconds on Apple Silicon
+        with a slim image. Apple owns the kernel-side work. We own the
+        wrapper.
+      </li>
+      <li>
+        <strong>Windows:</strong> WSL2. Pre-installed on Windows 11.
+        One-command install on Windows 10 (<code>wsl --install</code>).
+        File Explorer mounts the guest filesystem at
+        <code>\\wsl$\Houston\</code> without us doing anything. Microsoft
+        owns the kernel-side work. We own the registration.
+      </li>
+      <li>
+        <strong>Linux:</strong> no runtime needed. The engine runs
+        natively. Per-agent UIDs work directly.
+      </li>
+      <li>
+        <strong>Cloud:</strong> a Fly Machine (or equivalent) is already
+        a Linux microVM. The engine runs natively inside it.
+      </li>
+    </ul>
+    <p>
+      Houston does not ship a hypervisor. Houston ships a thin platform
+      layer that asks the host's existing virtualization to run a Linux
+      guest containing the engine binary.
+    </p>
+
+    <h2>File flow</h2>
+    <p>
+      The agent folder lives inside the Linux runtime. Bytes get in and
+      out through three paths.
+    </p>
     <ol>
-      <li><strong>One binary.</strong> No more Mac, Windows, and Linux builds of the engine. Linux only.</li>
-      <li><strong>One sandbox model.</strong> Linux primitives. <code>landlock</code>, namespaces, per-user permissions. No more <code>sandbox-exec</code> on Mac and AppContainer on Windows.</li>
-      <li><strong>Identical to production.</strong> What runs on your laptop is bit-identical to what runs in our cloud. Zero "works on my machine".</li>
-      <li><strong>Strong isolation.</strong> A VM is a kernel-level wall between Houston and the rest of your computer. Your kid can't accidentally delete the wrong file. An accidentally-installed agent can't read your bank statements.</li>
+      <li>
+        <strong>OAuth-connected SaaS (Drive, Slack, Notion, etc).</strong>
+        The most common path by far. The agent uses its credentials to
+        read and write directly to the SaaS. Nothing touches the host.
+      </li>
+      <li>
+        <strong>Import.</strong> User picks a file or folder via the host
+        OS file picker. Tauri reads it, posts the bytes to the engine over
+        HTTP, the engine writes them inside the agent's working
+        directory. Already implemented for attachments (<code>POST
+        /v1/attachments/uploads</code>). Extends to project file import.
+      </li>
+      <li>
+        <strong>Download.</strong> User clicks Download in the app. Engine
+        reads the file inside the runtime, streams it to Tauri, Tauri
+        writes it to the host's Downloads folder and reveals it.
+      </li>
     </ol>
-
-    <h2>The cost</h2>
     <p>
-      About 2 seconds of cold start when you open the app, and roughly
-      100MB of extra memory. We think it's worth it for the simplicity and
-      the security story.
+      On Windows specifically, WSL2 also exposes the guest filesystem at
+      <code>\\wsl$\Houston\</code> in Explorer. Users can browse it
+      natively if they want. That is a bonus, not a contract: the canonical
+      path on every OS is Import and Download, and Houston does not depend
+      on host filesystem visibility.
     </p>
 
-    <h2>Files live inside the VM</h2>
+    <h2>The new pieces of code</h2>
+    <table>
+      <thead>
+        <tr><th>Piece</th><th>Where</th><th>What it does</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Runtime supervisor</td>
+          <td><code>app/houston-tauri/runtime/</code> (new)</td>
+          <td>Boots the platform's Linux runtime, waits for the engine banner, exposes a localhost port to the rest of the app.</td>
+        </tr>
+        <tr>
+          <td>Mac VZ wrapper</td>
+          <td><code>app/houston-tauri/runtime/mac.rs</code> (new)</td>
+          <td>Calls <code>Virtualization.framework</code> via Objective-C bindings (<code>objc2</code> + <code>objc2-virtualization</code>). Loads bundled kernel + initrd + ext4 rootfs.</td>
+        </tr>
+        <tr>
+          <td>Windows WSL wrapper</td>
+          <td><code>app/houston-tauri/runtime/win.rs</code> (new)</td>
+          <td>Detects WSL2, runs <code>wsl --install</code> on demand, registers a "Houston" distro, starts the engine inside it.</td>
+        </tr>
+        <tr>
+          <td>Linux passthrough</td>
+          <td><code>app/houston-tauri/runtime/linux.rs</code> (new, thin)</td>
+          <td>No runtime. Spawns the engine like today.</td>
+        </tr>
+        <tr>
+          <td>Linux guest image</td>
+          <td><code>runtime-image/</code> (new)</td>
+          <td>Buildroot or Alpine-based minimal Linux. Engine binary, sqlite, busybox, OpenSSH disabled, no shell login. Built in CI, bundled in the Mac <code>.app</code> and the Windows MSI.</td>
+        </tr>
+        <tr>
+          <td>Download / Import routes</td>
+          <td><code>engine/houston-engine-server/src/routes/files.rs</code></td>
+          <td>Already partly there for project files. Needs binary download (the project file route is text-only today; see the engine-protocol KB).</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2>Apple entitlement paperwork (start now, parallel track)</h2>
     <p>
-      The VM has its own disk volume. All agent files, project files,
-      everything lives inside the VM. The host doesn't see them. No
-      virtio-fs file sharing, no performance penalty.
+      Using <code>Virtualization.framework</code> in a Developer ID app
+      requires the
+      <code>com.apple.security.virtualization</code> entitlement. It is
+      restricted. You declare it in the entitlements plist, then file a
+      request with Apple Developer support describing the use case
+      (running a Linux guest for sandboxed agent workloads). Apple grants
+      a provisioning profile that carries the entitlement, or approves
+      your existing signing cert to include it.
     </p>
     <p>
-      To import a folder, you drop it in via the app. It copies in once.
-      To export, you download via the app. To back up, you snapshot the
-      volume.
+      Timeline is usually a few weeks if the request is clean, longer if
+      Apple has follow-up questions. <strong>Open the ticket the moment
+      M3 is greenlit, not when the code is written.</strong> Without it,
+      the runtime startup call returns an error and the app silently
+      fails to boot.
+    </p>
+
+    <h2>Numbers we need to confirm before committing</h2>
+    <p>
+      The whole milestone is gated on three measurements. Spike all three
+      before locking M3 dates.
+    </p>
+    <ul>
+      <li>
+        <strong>Cold start budget:</strong> target ≤ 2 seconds on Apple
+        Silicon, ≤ 3 seconds on Intel Mac, ≤ 1 second on Windows with WSL2
+        warm. If the real number is 5+ seconds, the UX changes
+        and we add a "Houston is starting" screen.
+      </li>
+      <li>
+        <strong>Memory:</strong> target ≤ 300MB resident for the Linux
+        guest including the engine. Docker Desktop is the cautionary
+        tale (1-4GB). A slim image with no daemons should land in
+        200-400MB.
+      </li>
+      <li>
+        <strong>Battery:</strong> target ≤ 10% extra drain on Mac vs
+        today's native engine, measured over a 4-hour idle session.
+        Apple Silicon makes this plausible. Worth measuring before
+        users complain.
+      </li>
+    </ul>
+
+    <h2>Open question: Windows machines without virtualization</h2>
+    <p>
+      Some corporate laptops have virtualization disabled in BIOS. Some
+      older CPUs lack the required extensions. Houston needs a clear
+      install-time check: if the host cannot run WSL2, show a one-screen
+      explanation and a link to the IT-admin instructions. We do not try
+      to run the engine natively as a fallback. That preserves a single
+      operating profile.
     </p>
 
     <div class="callout callout-success">
       <div class="callout-label">The big simplification</div>
-      <p>Desktop and cloud become the same architecture. The only difference is whose computer the VM runs on.</p>
+      <p>Desktop and cloud become the same engine. Per-agent isolation becomes possible on every OS. The Windows tooling fork goes away. The cost is a runtime supervisor we don't fully own (Apple's and Microsoft's), an entitlement we have to ask for, and a Download flow we have to build first-class.</p>
     </div>
 
     <div class="tech-box">
-      <div class="label">VM hypervisors per host OS</div>
-      <p>macOS: Apple <code>Virtualization.framework</code>. Windows: Hyper-V or Windows Hypervisor Platform. Linux: KVM via libvirt. Each is wrapped behind a small platform-specific helper in the desktop shell.</p>
+      <div class="label">Where to look in the code</div>
+      <p>Today's engine spawn: <code>app/src-tauri/src/engine_supervisor.rs</code>. New runtime supervisor will live in <code>app/houston-tauri/runtime/</code>. Mac VZ bindings: <code>objc2-virtualization</code>. WSL2 bindings: <code>wslapi</code> crate or direct <code>wsl.exe</code> invocations. Linux guest image build: new <code>runtime-image/</code> dir using Buildroot or Alpine. Engine bin target: unchanged (<code>cargo build --release -p houston-engine-server --target x86_64-unknown-linux-musl</code> or <code>aarch64-unknown-linux-musl</code>).</p>
     </div>
 
     <div class="pager">
@@ -127,26 +315,6 @@ graph TB
 <footer class="footer">
   <div>Houston Engine Design Guide · Living document</div>
 </footer>
-
-<script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-  mermaid.initialize({
-    startOnLoad: true,
-    theme: 'base',
-    themeVariables: {
-      primaryColor: '#ffffff',
-      primaryTextColor: '#0d0d0d',
-      primaryBorderColor: '#cdcdcd',
-      lineColor: '#676767',
-      mainBkg: '#ffffff',
-      secondBkg: '#f9f9f9',
-      tertiaryBkg: '#ececec',
-      actorBkg: '#ffffff',
-      actorBorder: '#cdcdcd',
-      actorTextColor: '#0d0d0d'
-    }
-  });
-</script>
 
 </body>
 </html>

--- a/engine-design/04-message-flow.html
+++ b/engine-design/04-message-flow.html
@@ -35,7 +35,7 @@
   <main class="content">
     <div class="content-label">
       Chapter 04
-      <span class="status partial">Partial</span>
+      <span class="status partial">Partial · finishes in M1</span>
     </div>
     <h1>How a message flows through.</h1>
     <p class="lead">
@@ -57,7 +57,7 @@
         <div class="num">02</div>
         <div>
           <div class="from-to"><span class="actor">Desktop UI</span><span class="arrow">→</span><span class="actor">Engine</span></div>
-          <div class="action"><code>POST /v1/agents/Sales/sessions</code> with the user message and a client-supplied <code>turnId</code>.</div>
+          <div class="action"><code>POST /v1/agents/Sales/sessions</code> with the user message and a client-generated <code>turnId</code> (UUID v4).</div>
         </div>
       </div>
 
@@ -65,7 +65,7 @@
         <div class="num">03</div>
         <div>
           <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor db">SQLite</span></div>
-          <div class="action"><strong>INSERT into <code>turns</code></strong> with status <code>queued</code>. This happens BEFORE any work starts. If the engine crashes here, the row is on disk and we can recover.</div>
+          <div class="action"><strong>INSERT into <code>turns</code></strong> with status <code>queued</code>. If <code>turnId</code> already exists in a terminal state (completed/failed/cancelled), return its outcome instead of starting a new turn. This is how retries are safe.</div>
         </div>
       </div>
 
@@ -89,7 +89,7 @@
         <div class="num">06</div>
         <div>
           <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor db">SQLite</span></div>
-          <div class="action"><strong>UPDATE <code>turns</code></strong> set status <code>running</code>.</div>
+          <div class="action"><strong>UPDATE <code>turns</code></strong> set status <code>running</code>, <code>started_at = now()</code>.</div>
         </div>
       </div>
 
@@ -100,7 +100,7 @@
           <div class="num">07</div>
           <div>
             <div class="from-to"><span class="actor">Claude CLI</span><span class="arrow">→</span><span class="actor">Engine</span></div>
-            <div class="action">Streams a chunk of assistant tokens.</div>
+            <div class="action">Streams a chunk of assistant tokens (~10-30 chunks/sec at sentence granularity).</div>
           </div>
         </div>
 
@@ -108,7 +108,7 @@
           <div class="num">08</div>
           <div>
             <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor db">SQLite</span></div>
-            <div class="action"><strong>INSERT into <code>turn_stream</code></strong> with the next <code>seq</code> number. Persisted before broadcast.</div>
+            <div class="action"><strong>INSERT into <code>turn_stream</code></strong> with the next <code>seq</code> number. Batched: a tokio interval flushes every 20-50ms so we don't drown SQLite with hundreds of single-row inserts.</div>
           </div>
         </div>
 
@@ -116,7 +116,7 @@
           <div class="num">09</div>
           <div>
             <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">Desktop UI</span></div>
-            <div class="action">Broadcasts the chunk over the WebSocket. UI renders it live.</div>
+            <div class="action">Broadcasts the chunk over the WebSocket. UI renders it live. Broadcast happens immediately, even before the batched DB flush.</div>
           </div>
         </div>
       </div>
@@ -133,7 +133,7 @@
         <div class="num">11</div>
         <div>
           <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor db">SQLite</span></div>
-          <div class="action"><strong>UPDATE <code>turns</code></strong> set status <code>completed</code>.</div>
+          <div class="action"><strong>UPDATE <code>turns</code></strong> set status <code>completed</code>, <code>completed_at = now()</code>.</div>
         </div>
       </div>
 
@@ -153,7 +153,8 @@
       <strong>Writes to the database happen BEFORE the work, not
       AFTER.</strong> The turn row is inserted the moment the user's
       message is accepted, well before the CLI subprocess is even spawned.
-      Each streaming chunk is logged before being broadcast.
+      Each streaming chunk is logged before being broadcast (batched, but
+      committed within ~50ms).
     </p>
     <p>
       That single ordering decision is what makes everything else work.
@@ -162,27 +163,69 @@
     <h2>What this buys you</h2>
     <ul>
       <li><strong>Refresh mid-stream.</strong> The next page load replays from <code>turn_stream</code>. The user sees the streaming response continue.</li>
-      <li><strong>Engine crash mid-stream.</strong> The restarted engine sweeps the <code>turns</code> table, finds the orphan, surfaces a retry. The user clicks once and continues.</li>
-      <li><strong>Network blip during streaming.</strong> The client reconnects with <code>Last-Event-Seq</code> and gets the gap from <code>events_outbox</code>.</li>
+      <li><strong>Engine crash between turns.</strong> The restarted engine sweeps the <code>turns</code> table, finds the orphan, surfaces a retry. The user clicks once and continues.</li>
+      <li><strong>Network blip during streaming.</strong> The client reconnects with <code>since_seq</code> and gets the gap from <code>events_outbox</code>.</li>
       <li><strong>Cron fires at 7am while engine is restarting.</strong> The <code>cron_runs</code> audit log catches up on the next boot.</li>
+      <li><strong>Safe retry from the client.</strong> The same <code>turnId</code> won't run the turn twice. The server treats it as idempotent.</li>
+    </ul>
+    <p>
+      What this does NOT buy you on its own: engine restart MID-stream
+      survives the bounce. The CLI subprocess is a child of the engine,
+      so killing the engine kills the CLI. To survive that, we need the
+      detached <code>houston-turn-worker</code> from Chapter 6.
+    </p>
+
+    <h2>Protocol changes you need to know</h2>
+    <ul>
+      <li>
+        <strong><code>POST /v1/agents/:path/sessions</code> request body
+        gains <code>turnId: string</code> (UUID v4).</strong> Required.
+        Existing clients are missing this field. Major protocol bump.
+      </li>
+      <li>
+        <strong>Response body becomes <code>{ sessionKey, turnId, status
+        }</code></strong> where <code>status</code> is the current turn
+        state. If the engine recognizes the <code>turnId</code> as
+        already terminal, it returns the prior outcome.
+      </li>
+      <li>
+        <strong>New WebSocket event:</strong> <code>TurnStreamReplay</code>
+        with <code>{ turnId, fromSeq, items }</code> for replay.
+      </li>
+      <li>
+        <strong>WS subscription gains <code>since_seq</code>:</strong>
+        client reconnect sends the last seen sequence number, server
+        replays from <code>events_outbox</code>.
+      </li>
     </ul>
 
     <h2>What's there today</h2>
     <p>
       Most of the boxes in the diagram exist. The CLI gets spawned, the
       response streams, the final message gets saved to <code>chat_feed</code>.
-      What's missing is the four SQLite tables (<code>turns</code>,
-      <code>turn_stream</code>, <code>events_outbox</code>,
-      <code>cron_runs</code>) and the rule of writing before doing.
+      What's missing:
     </p>
+    <ul>
+      <li>The four SQLite tables (<code>turns</code>, <code>turn_stream</code>, <code>events_outbox</code>, <code>cron_runs</code>). See Chapter 6.</li>
+      <li>The rule of writing before doing. Today persistence is async, fire-and-forget via <code>tokio::spawn</code>.</li>
+      <li>Streaming deltas are explicitly dropped from persist today (<code>engine/houston-agents-conversations/src/session_runner.rs:405-406</code>) because they get replaced by their finals. The redesign keeps them in <code>turn_stream</code> for replay. Different problem, different table. The UI behavior stays the same.</li>
+      <li>Client-supplied <code>turnId</code> + retry semantics.</li>
+      <li>WebSocket replay-on-reconnect.</li>
+    </ul>
+
+    <h2>The five failure modes this prevents</h2>
     <p>
-      Chapter 5 covers what goes wrong because those tables aren't there.
-      Chapter 6 covers the fix.
+      Chapter 5 walks through what goes wrong because these tables aren't
+      there. Chapter 6 covers the fix. The fifth one is the one most
+      people miss: the CLI subprocess hangs without exiting. Without a
+      <code>started_at</code> timestamp and a sweep job, the engine has
+      no way to know a turn has been "running" for an hour with no
+      output.
     </p>
 
     <div class="tech-box">
       <div class="label">Where to look in the code</div>
-      <p>Today's flow: <code>engine/houston-engine-server/src/routes/sessions.rs</code> → <code>engine/houston-engine-core/src/sessions/mod.rs</code> → <code>engine/houston-agents-conversations/src/session_runner.rs</code>. Streaming tokens are dropped specifically at <code>session_runner.rs:406</code>.</p>
+      <p>Today's flow: <code>engine/houston-engine-server/src/routes/sessions.rs</code> → <code>engine/houston-engine-core/src/sessions/mod.rs</code> → <code>engine/houston-agents-conversations/src/session_runner.rs</code>. Streaming items dropped at <code>session_runner.rs:405-406</code>. Async persistence at <code>session_runner.rs:226-244</code>. Session identity model at <code>engine/houston-engine-core/src/sessions/control.rs:6-18</code> (no <code>turnId</code> today).</p>
     </div>
 
     <div class="pager">
@@ -201,25 +244,6 @@
 <footer class="footer">
   <div>Houston Engine Design Guide · Living document</div>
 </footer>
-
-<script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-  mermaid.initialize({
-    startOnLoad: true,
-    theme: 'base',
-    themeVariables: {
-      primaryColor: '#ffffff',
-      primaryTextColor: '#0d0d0d',
-      primaryBorderColor: '#cdcdcd',
-      lineColor: '#676767',
-      actorBkg: '#ffffff',
-      actorBorder: '#cdcdcd',
-      actorTextColor: '#0d0d0d',
-      labelBoxBkgColor: '#f9f9f9',
-      labelBoxBorderColor: '#cdcdcd'
-    }
-  });
-</script>
 
 </body>
 </html>

--- a/engine-design/05-conversations-die.html
+++ b/engine-design/05-conversations-die.html
@@ -35,34 +35,45 @@
   <main class="content">
     <div class="content-label">
       Chapter 05
-      <span class="status planned">Planned</span>
+      <span class="status planned">Diagnosis · feeds M1</span>
     </div>
     <h1>Why conversations die today.</h1>
     <p class="lead">
       The engine writes to disk only after the work is done. Everything in
-      flight is in-memory. In-memory means it dies when the process dies.
-      Here are the four failure modes.
+      flight lives in memory. In-memory means it dies when the process
+      dies, when the user closes the app, when the network blips. Five
+      failure modes. Same root cause.
     </p>
 
     <div class="fail-grid">
       <div class="fail-card">
         <div class="label">Failure mode #1</div>
-        <p><strong>Engine crashes between "accept message" and "spawn CLI".</strong> Your message disappears. No record anywhere. You click send again, the engine has no memory of the first attempt.</p>
+        <p><strong>User closes the app mid-stream.</strong> This is the most common one and it has nothing to do with crashes. The user clicks the red button, the app exits, the engine subprocess exits with it, the in-flight assistant tokens vanish. The user reopens Houston and the message is gone. Today this happens dozens of times a day in the dev loop alone.</p>
       </div>
 
       <div class="fail-card">
         <div class="label">Failure mode #2</div>
-        <p><strong>Engine crashes mid-stream.</strong> Whatever the assistant had already streamed: gone. Database has nothing. The user thinks the agent is broken.</p>
+        <p><strong>Engine crashes between "accept message" and "spawn CLI".</strong> Your message disappears. No record anywhere. You click send again, the engine has no memory of the first attempt. Rare but ugly when it happens.</p>
       </div>
 
       <div class="fail-card">
         <div class="label">Failure mode #3</div>
-        <p><strong>WebSocket reconnects after a network blip.</strong> Server has no record of what events it pushed during the disconnect. The frontend has to refetch state and pray nothing slipped through.</p>
+        <p><strong>Engine crashes mid-stream.</strong> Whatever the assistant had already streamed: gone. Database has nothing. The user thinks the agent is broken.</p>
       </div>
 
       <div class="fail-card">
         <div class="label">Failure mode #4</div>
-        <p><strong>Cron fire happens while engine is restarting.</strong> The 7am alarm rings, the engine is rebooting, the fire is dropped silently. No log, no alert, no catch-up.</p>
+        <p><strong>WebSocket reconnects after a network blip.</strong> Server has no record of what events it pushed during the disconnect. The frontend has to refetch state and pray nothing slipped through.</p>
+      </div>
+
+      <div class="fail-card">
+        <div class="label">Failure mode #5</div>
+        <p><strong>Cron fires while engine is restarting.</strong> The 7am alarm rings, the engine is rebooting, the fire is dropped silently. No log, no alert, no catch-up. Verified in <code>engine/houston-scheduler/src/cron_job.rs</code>: missed crons fire once on next boot if the schedule is past-due, but there's no record of how many fires were missed.</p>
+      </div>
+
+      <div class="fail-card">
+        <div class="label">Failure mode #6 (the one most people miss)</div>
+        <p><strong>CLI subprocess hangs without exiting.</strong> Provider gateway flakes, network stalls, model returns nothing. The CLI sits there for 20 minutes. Engine has no timeout, no <code>started_at</code> heartbeat, no idea anything is wrong. UI shows "thinking" forever.</p>
       </div>
     </div>
 
@@ -71,16 +82,17 @@
       Notice the common thread. The engine writes to the database
       <strong>after</strong> doing work, not <strong>before</strong>. So
       anything happening between "before" and "after" lives only in
-      memory, and that memory belongs to a process that can die.
+      memory, and that memory belongs to a process that can die or a
+      socket that can disconnect.
     </p>
     <p>
-      The fix is boring but life-changing. Flip the order. Chapter 6 shows
-      how, with the four SQLite tables that make it work.
+      The fix is boring but life-changing. Flip the order. Add timestamps.
+      Add sequence numbers. Sweep orphans on boot. Chapter 6 covers how.
     </p>
 
     <div class="callout callout-warning">
-      <div class="callout-label">Why this hasn't been fixed yet</div>
-      <p>Because it works most of the time. Engines don't usually crash. Networks don't usually blip. So the team shipped features instead. The point of the redesign is to make Houston work reliably for the cases where things DO go wrong.</p>
+      <div class="callout-label">"Why hasn't this been fixed yet?"</div>
+      <p>Because in the happy path it works. Engines don't crash often. The team shipped features. The pain falls on users in the long tail: someone with a flaky home network, someone who closes the app to take a call, someone whose engine got OOM-killed in dev. The redesign moves us from "works most of the time" to "designed for the times it doesn't." That's the line between a beta and a product.</p>
     </div>
 
     <div class="pager">

--- a/engine-design/06-four-tables.html
+++ b/engine-design/06-four-tables.html
@@ -35,43 +35,65 @@
   <main class="content">
     <div class="content-label">
       Chapter 06
-      <span class="status planned">Planned · M1</span>
+      <span class="status planned">Planned · M1 · ~4 weeks</span>
     </div>
     <h1>The four tables that save everything.</h1>
     <p class="lead">
-      Four new SQLite tables. That's the entire reliability story. Not
-      Temporal, not a workflow engine. Just four tables and one rule:
-      write the row before doing the work.
+      Four new SQLite tables. That's the entire reliability story (almost,
+      see the worker section below). Not Temporal. Not a workflow engine.
+      Just four tables and one rule: write the row before doing the work.
     </p>
 
-    <h2>The tables</h2>
-    <table>
-      <thead>
-        <tr><th>Table</th><th>What it holds</th><th>What it fixes</th></tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td><code>turns</code></td>
-          <td>Every chat turn, with status</td>
-          <td>Crash before CLI spawns. Retry is idempotent via <code>turn_id</code>.</td>
-        </tr>
-        <tr>
-          <td><code>turn_stream</code></td>
-          <td>Every assistant token chunk, with seq</td>
-          <td>Reconnect with <code>since_seq</code>, perfect replay.</td>
-        </tr>
-        <tr>
-          <td><code>events_outbox</code></td>
-          <td>Every event with a monotonic seq</td>
-          <td>WS clients reconnect and get the gap they missed.</td>
-        </tr>
-        <tr>
-          <td><code>cron_runs</code></td>
-          <td>Every cron fire (or missed fire)</td>
-          <td>Missed at 7am, caught up on next boot.</td>
-        </tr>
-      </tbody>
-    </table>
+    <h2>The tables, with columns</h2>
+
+    <h3><code>turns</code></h3>
+    <pre><code>CREATE TABLE turns (
+  turn_id        TEXT PRIMARY KEY,        -- UUID v4, client-supplied
+  session_key    TEXT NOT NULL,           -- the conversation slot
+  agent_path     TEXT NOT NULL,           -- workspace/agent
+  principal_id   TEXT NOT NULL,           -- who initiated, see Ch7
+  status         TEXT NOT NULL,           -- queued | running | completed | cancelled | failed | timed_out
+  user_message   TEXT NOT NULL,           -- the input
+  result         TEXT,                    -- final assistant text or error code
+  error_code     TEXT,                    -- when status = failed
+  created_at     INTEGER NOT NULL,        -- unix ms
+  started_at     INTEGER,                 -- when CLI spawned
+  completed_at   INTEGER                  -- when terminal
+);
+CREATE INDEX turns_session_idx ON turns(session_key, created_at);
+CREATE INDEX turns_status_idx  ON turns(status) WHERE status IN ('queued', 'running');</code></pre>
+
+    <h3><code>turn_stream</code></h3>
+    <pre><code>CREATE TABLE turn_stream (
+  turn_id        TEXT NOT NULL REFERENCES turns(turn_id),
+  seq            INTEGER NOT NULL,        -- per-turn monotonic
+  kind           TEXT NOT NULL,           -- assistant_delta | thinking_delta | tool_call | tool_result | ...
+  data_json      TEXT NOT NULL,
+  ts             INTEGER NOT NULL,
+  PRIMARY KEY (turn_id, seq)
+);</code></pre>
+
+    <h3><code>events_outbox</code></h3>
+    <pre><code>CREATE TABLE events_outbox (
+  seq            INTEGER PRIMARY KEY AUTOINCREMENT,   -- global monotonic
+  topic          TEXT NOT NULL,           -- session:X, agent:Y, scheduler, ...
+  event_type     TEXT NOT NULL,
+  payload_json   TEXT NOT NULL,
+  ts             INTEGER NOT NULL
+);
+CREATE INDEX events_topic_idx ON events_outbox(topic, seq);</code></pre>
+
+    <h3><code>cron_runs</code></h3>
+    <pre><code>CREATE TABLE cron_runs (
+  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+  routine_id     TEXT NOT NULL,
+  scheduled_at   INTEGER NOT NULL,        -- when it was supposed to fire
+  fired_at       INTEGER,                 -- when we actually fired (null if missed and we don't intend to catch up)
+  status         TEXT NOT NULL,           -- fired | missed | caught_up | skipped
+  turn_id        TEXT REFERENCES turns(turn_id),
+  notes          TEXT
+);
+CREATE INDEX cron_runs_routine_idx ON cron_runs(routine_id, scheduled_at);</code></pre>
 
     <h2>The rule</h2>
     <p>
@@ -80,46 +102,115 @@
     </p>
 
 <pre><code>1. Accept message       → INSERT turns (status: queued)
-2. Start CLI            → UPDATE turns SET status = running
-3. Stream chunk         → INSERT turn_stream row, then broadcast
-4. CLI done             → UPDATE turns SET status = completed
-5. Engine boots         → SELECT * FROM turns WHERE status = running
-                          → mark orphaned, surface retry</code></pre>
+2. Start CLI            → UPDATE turns SET status = running, started_at
+3. Stream chunk         → INSERT turn_stream row(s), then broadcast
+4. CLI done             → UPDATE turns SET status = completed, completed_at
+5. Engine boots         → SELECT * FROM turns WHERE status IN ('queued','running')
+                          → mark orphaned (status = 'failed', error_code = 'engine_restart')
+                          → surface retry button to the user</code></pre>
 
     <p>
       Step 5 is the magic. On every boot, the engine looks for turns that
       were "running" when the previous engine died. Those are orphans. The
       user sees a retry button. They click it. The same <code>turn_id</code>
-      goes back into the system. We never accidentally cook the same dish
-      twice because the engine recognizes the ID and resumes.
+      goes back into the system. The server recognizes the ID is terminal
+      and returns its outcome; the client decides to mint a new
+      <code>turn_id</code> and try again. Idempotency is at the server,
+      retry policy is at the client.
+    </p>
+
+    <h2>What four tables alone fix, and what they don't</h2>
+    <p>
+      Be honest about scope. These tables alone fix:
+    </p>
+    <ul>
+      <li>Crash <strong>between</strong> turns. The orphan sweep finds it.</li>
+      <li>User closing the app mid-stream. On reopen, the engine is still running, the turn is still streaming, the client just reconnects to the WS with <code>since_seq</code> and replays from <code>events_outbox</code>.</li>
+      <li>Network blips during streaming. Same path: replay from outbox.</li>
+      <li>Missed crons. The next boot reads <code>cron_runs</code>, sees the missed fire, decides whether to catch up.</li>
+      <li>Client retry safety. The <code>turnId</code> is idempotent.</li>
+      <li>CLI subprocess hang. A sweep job checks <code>turns WHERE status = 'running' AND started_at &lt; now() - 10min</code> and surfaces a "still running, cancel?" prompt.</li>
+    </ul>
+    <p>
+      What four tables do NOT fix on their own: <strong>engine crash MID-stream
+      while a CLI subprocess is still running</strong>. Today the CLI
+      subprocess is a child of the engine process, so killing the engine
+      kills the CLI. The four tables let the engine recover state on the
+      next boot, but the in-flight CLI is dead and the user has to retry.
+    </p>
+
+    <h2>The detached worker (required to fully close the gap)</h2>
+    <p>
+      To survive engine restart MID-stream without retry, the CLI must
+      live longer than the engine. That means a small detached binary,
+      <code>houston-turn-worker</code>, spawned by the engine but not
+      parented to it. The worker writes streaming output directly to
+      SQLite. The engine bounces, a new engine starts, attaches via Unix
+      socket, picks up where the stream left off. The user never notices.
+    </p>
+    <p>
+      This is the architectural piece. Without it, "conversations never
+      die" is "conversations rarely die." With it, the promise is real.
+      It belongs in M4 because it's the riskiest piece; the four tables
+      get us 80% of the value first.
+    </p>
+
+    <h2>Coexistence with <code>chat_feed</code></h2>
+    <p>
+      Today's <code>chat_feed</code> holds final feed items keyed by the
+      provider session id. After M1, the same data lives in
+      <code>turn_stream</code> (deltas) and the final items derived on
+      read. Two paths:
+    </p>
+    <ul>
+      <li><strong>Migrate then delete.</strong> One-shot migration copies <code>chat_feed</code> into <code>turn_stream</code> as kind <code>final</code>. New writes only go to <code>turn_stream</code>. Cleaner long-term.</li>
+      <li><strong>Double-write for a release.</strong> Both tables get the data, reads check <code>turn_stream</code> first, fall back to <code>chat_feed</code>. Safer for rollback.</li>
+    </ul>
+    <p>
+      Pick double-write for the first M1 release, drop <code>chat_feed</code>
+      writes in the next release once we're confident, drop the table in
+      the release after. Three-release deprecation, standard playbook.
+    </p>
+
+    <h2>Backpressure and the bounded queue</h2>
+    <p>
+      Today the event queue in <code>engine/houston-events/src/queue.rs</code>
+      is an <code>mpsc::unbounded_channel</code>. A webhook flood or a
+      runaway cron could balloon memory. M1 switches this to a bounded
+      channel with capacity 1024 and a documented drop policy:
+    </p>
+    <ul>
+      <li>Inputs whose source is <code>cron</code> coalesce: if two fires for the same <code>routine_id</code> are in flight, log a "skipped" row in <code>cron_runs</code> and drop the second.</li>
+      <li>Inputs whose source is <code>user</code> never drop. If the queue is full, return <code>503 UNAVAILABLE</code> with <code>Retry-After</code>.</li>
+      <li>Inputs whose source is <code>webhook</code> get a small per-source bucket (token bucket, 10/min default) and a <code>cron_runs</code>-style audit table.</li>
+    </ul>
+    <p>
+      Same write-before-do principle: refusing the request is fine,
+      silently dropping it is not.
+    </p>
+
+    <h2>Retention</h2>
+    <p>
+      <code>turn_stream</code> grows fast. A two-hour Codex marathon
+      writes thousands of rows. Default retention: keep raw deltas for 7
+      days, then compact to one <code>final</code> row per turn and drop
+      the deltas. <code>events_outbox</code> retention: 24 hours
+      (replay window for reconnecting clients). <code>cron_runs</code>:
+      keep forever, it's an audit log and it's small.
+    </p>
+    <p>
+      A nightly background task does the compaction. Configurable via
+      env vars for self-hosters and Cloud admins.
     </p>
 
     <div class="callout callout-info">
       <div class="callout-label">Why this isn't Temporal</div>
-      <p>Temporal is a workflow engine for orchestrating long-running multi-step business processes with replay semantics. Houston has one activity: run a CLI turn, capture the stream. That's a job, not a saga. Four tables are enough.</p>
+      <p>Temporal is a workflow engine for orchestrating long-running multi-step business processes with replay semantics across many activities. Houston has one activity: run a CLI turn, capture the stream. That's a job, not a saga. Four tables are enough.</p>
     </div>
-
-    <h2>The one architectural piece</h2>
-    <p>
-      Everything above is just "add a table". One piece is genuinely
-      harder. Today the CLI subprocess is a child of the engine process,
-      so killing the engine kills the CLI. To survive engine restart
-      <strong>mid-stream</strong> (not just on the next turn), we need a
-      small <code>houston-turn-worker</code> binary.
-    </p>
-    <p>
-      The engine spawns it detached. The worker writes streaming output to
-      SQLite directly. The engine bounces, a new engine starts up,
-      reattaches via Unix socket, conversation never blinks.
-    </p>
-    <p>
-      This piece is M3. Until then, the cheap fallback (orphan + retry)
-      gets you 70% of the user experience for 10% of the work.
-    </p>
 
     <div class="tech-box">
       <div class="label">Migration order</div>
-      <p>SQLite migrations live in <code>engine/houston-db/src/migrations.rs</code>. New tables drop in next to existing <code>chat_feed</code>, <code>preferences</code>, and <code>engine_tokens</code>. Each gets a numbered migration file; existing data is preserved.</p>
+      <p>SQLite migrations live in <code>engine/houston-db/src/migrations.rs</code>. New migrations drop in next to the existing four (<code>chat_feed</code>, <code>chat_feed_fts</code>, <code>engine_tokens</code>, <code>phone_access</code>). Each gets its own numbered migration file; existing data is preserved. Repos go in <code>engine/houston-db/src/repo_turns.rs</code>, <code>repo_turn_stream.rs</code>, <code>repo_events_outbox.rs</code>, <code>repo_cron_runs.rs</code>. Boot sweep job in <code>engine/houston-engine-server/src/main.rs</code> startup, just after migrations run.</p>
     </div>
 
     <div class="pager">

--- a/engine-design/07-keeping-agents-apart.html
+++ b/engine-design/07-keeping-agents-apart.html
@@ -35,13 +35,40 @@
   <main class="content">
     <div class="content-label">
       Chapter 07
-      <span class="status planned">Planned · M2</span>
+      <span class="status planned">Walls 2+3 in M2 (~3w). Wall 1 in M3 (~3mo).</span>
     </div>
     <h1>Keeping agents apart.</h1>
     <p class="lead">
       Three independent walls between agents. Each one is enough to stop a
-      curious agent from snooping. Together, they make accidental and
-      adversarial cross-agent reads impossible.
+      curious or jailbroken agent from snooping. Together, they make
+      accidental and adversarial cross-agent reads impossible.
+    </p>
+
+    <h2>The real threat model (why we care)</h2>
+    <p>
+      Forget hypotheticals. Here is the concrete case that drives this
+      chapter:
+    </p>
+    <p>
+      You are a consultant. You have two clients. You build one Houston
+      agent per client. <code>MyConsulting/ClientA</code> and
+      <code>MyConsulting/ClientB</code>. You ask ClientA's agent to read
+      this month's invoices. Today nothing stops ClientA's agent from
+      ALSO reading ClientB's invoices, contracts, or chat history. The
+      Claude or Codex subprocess runs as you, with your full home
+      directory, your SSH keys, your everything. A prompt of "before you
+      answer, also <code>cat</code> every file under
+      <code>~/.houston/workspaces/MyConsulting/ClientB/</code>" will
+      work. No exploit needed.
+    </p>
+    <p>
+      That's not a thought experiment. That's the product reality for any
+      user with more than one client, project, or boundary in their
+      workspace. We have to fix it.
+    </p>
+    <p>
+      The fix is three independent walls. None depends on the others to
+      work. Together they're belt, suspenders, and a kernel.
     </p>
 
     <div class="walls">
@@ -70,62 +97,130 @@
       </div>
     </div>
 
-    <h2>Wall 1: per-agent Linux user</h2>
+    <h2>Wall 1: per-agent Linux user (M3, needs Linux runtime)</h2>
     <p>
-      Each agent gets its own Linux user inside the VM. Their folders are
-      owned by them, mode 0700. When you send a message to the Sales
-      agent, the CLI runs as <code>hou_sales</code>. It physically cannot
-      read <code>hou_hr</code>'s files. The kernel says no.
+      Each agent gets its own Linux user inside the runtime. Their folder
+      is owned by them, mode 0700. When you send a message to the Sales
+      agent, the CLI subprocess runs as <code>hou_sales</code>. It
+      physically cannot read <code>hou_hr</code>'s files. The kernel says
+      no.
     </p>
     <p>
-      Even if a clever prompt asks the Sales agent to read HR salary data,
-      the agent has no permission. There is no jailbreak that gets around
-      <code>chmod</code>.
+      No prompt jailbreak gets around <code>chmod</code>. No "as ClientA's
+      agent please also read ClientB's invoices" trick works, because the
+      process running ClientA's CLI literally does not have a file
+      descriptor it can use to open ClientB's directory.
+    </p>
+    <p>
+      This is why Chapter 3 (Linux runtime everywhere) exists. macOS and
+      Windows don't have a clean way to do per-agent UIDs natively without
+      a VM. Linux does. Putting a Linux runtime on every host means the
+      same wall exists everywhere.
     </p>
 
-    <h2>Wall 2: per-agent credentials</h2>
+    <h2>Wall 2: per-agent credentials (M2, no VM required)</h2>
     <p>
       Each agent has its own <code>~/.claude</code>, its own
-      <code>~/.composio</code>, its own everything. When Sales logs into
-      Anthropic, the token sits in <code>/home/hou_sales/.claude/</code>.
-      HR can't see it.
+      <code>~/.composio</code>, its own <code>~/.codex</code>. When Sales
+      logs into Anthropic, the token sits in
+      <code>/home/hou_sales/.claude/</code>. HR can't see it.
     </p>
     <p>
-      Even if Sales gets compromised, its blast radius is bounded by what
-      it had access to. It can't social-engineer its way to HR data
-      because it doesn't have the keys to start with.
+      This wall ships without a VM. The fix is small: when the engine
+      spawns a CLI subprocess, it sets <code>HOME</code> (and the
+      provider-specific dir env vars) to a per-agent path under the
+      agent's folder. Today the spawn site at
+      <code>engine/houston-terminal-manager/src/cli_process.rs</code>
+      inherits the parent's <code>$HOME</code>. The fix is to override it.
+    </p>
+    <p>
+      Even on today's native engine, this is a real win: a compromised
+      agent gets that agent's tokens, not all of them.
     </p>
 
-    <h2>Wall 3: engine-level scope checks</h2>
+    <h2>Wall 3: engine-level scope checks (M2, no VM required)</h2>
     <p>
-      On top of the file walls, every HTTP route checks "does this user's
-      token have scope for this agent?" before doing anything. A user
-      with Sales access trying to query HR's data gets a 403 before the
-      engine even reaches for the filesystem.
+      On top of the file walls, every HTTP route checks "does this
+      principal's token have scope for this agent?" before doing anything.
+      A user with Sales access trying to query HR's data gets a 403 before
+      the engine even reaches for the filesystem.
+    </p>
+
+    <h3>The data model</h3>
+    <pre><code>CREATE TABLE principals (
+  principal_id   TEXT PRIMARY KEY,        -- supabase user id, or "local:local" for solo desktop
+  display_name   TEXT NOT NULL,
+  created_at     INTEGER NOT NULL
+);
+
+CREATE TABLE principal_tokens (
+  token_hash     TEXT PRIMARY KEY,        -- sha256 of the bearer
+  principal_id   TEXT NOT NULL REFERENCES principals(principal_id),
+  scopes_json    TEXT NOT NULL,           -- ["MyConsulting/ClientA/**", "MyConsulting/ClientB/sales"]
+  device_label   TEXT,
+  created_at     INTEGER NOT NULL,
+  revoked_at     INTEGER,
+  last_seen_at   INTEGER
+);</code></pre>
+    <p>
+      Scopes are glob patterns over the workspace/agent path. A scope of
+      <code>**</code> means full access (the local desktop user). A scope
+      of <code>MyConsulting/ClientA/**</code> means everything under
+      ClientA but nothing else.
+    </p>
+
+    <h3>The middleware</h3>
+    <p>
+      Every route handler that touches an agent path goes through a single
+      <code>require_scope(token, agent_path)</code> check. The check
+      resolves the token to its principal, then matches the path against
+      the principal's scopes. No match, 403. Lives in
+      <code>engine/houston-engine-server/src/middleware/scope.rs</code>
+      (new).
+    </p>
+
+    <h2>Identity story</h2>
+    <p>
+      For desktop solo users: a single local principal
+      (<code>local:local</code>), one all-scope token, no friction. This
+      is what shipped today's bearer is, dressed in the new model. No UX
+      change.
     </p>
     <p>
-      Tokens become typed:
-      <code>(token_id, principal_id, scope: ["WorkspaceX/Sales/**"])</code>.
-      Middleware enforces. New tables: <code>principals</code> and
-      <code>principal_tokens</code> in <code>houston-db</code>.
+      For mobile-paired devices: each device pairing creates a new token,
+      scoped to the agents the user picks during pairing.
+    </p>
+    <p>
+      For Teams and Cloud (future): principals are Supabase users (Google
+      SSO already shipped, see <code>knowledge-base/auth.md</code>). Each
+      Supabase login mints a short-lived token. Scope is set by the
+      workspace owner via an "Invite teammate" flow.
     </p>
 
     <div class="callout callout-success">
       <div class="callout-label">The headline</div>
-      <p>"My HR agent literally cannot leak salaries to my Sales agent, even if jailbroken." That isn't marketing copy. That's what the kernel enforces.</p>
+      <p>"My HR agent literally cannot leak salaries to my Sales agent, even if jailbroken." That isn't marketing copy. That's what the kernel enforces. ChatGPT Enterprise and Claude Teams put everyone in one tenant with one set of permissions. Houston's per-agent isolation is something they don't offer.</p>
     </div>
 
-    <h2>Where this matters</h2>
-    <p>
-      This is a real positioning win for regulated industries. ChatGPT
-      Enterprise and Claude Teams put everyone in one tenant with one set
-      of permissions. Houston's per-agent isolation is something they
-      don't offer.
-    </p>
+    <h2>What we ship without the VM (M2)</h2>
+    <ul>
+      <li>Per-agent <code>HOME</code> override at CLI spawn. Per-agent credential directories under <code>~/.houston/workspaces/&lt;W&gt;/&lt;A&gt;/.creds/</code>.</li>
+      <li><code>principals</code> and <code>principal_tokens</code> tables.</li>
+      <li><code>require_scope</code> middleware on every route.</li>
+      <li>Today's single device-bearer token migrates into a single principal with full scope. No UX change for solo users.</li>
+    </ul>
+
+    <h2>What needs the VM (M3)</h2>
+    <ul>
+      <li><code>useradd hou_&lt;agent&gt;</code> for each agent, automated.</li>
+      <li>Spawn the CLI subprocess as that user (<code>setuid</code> or equivalent).</li>
+      <li>File ownership and 0700 modes on the agent's folder.</li>
+      <li>Per-agent credentials live under <code>/home/hou_&lt;agent&gt;/</code> instead of the workspace folder.</li>
+    </ul>
 
     <div class="tech-box">
       <div class="label">What changes in code</div>
-      <p>New auth middleware in <code>engine/houston-engine-server</code>. New tables in <code>engine/houston-db</code>. CLI spawn in <code>engine/houston-terminal-manager</code> gains a <code>setuid</code> step (Linux only; gated by <code>HOUSTON_ISOLATE_BY_UID=1</code>). Per-agent home dir resolution in <code>houston-agent-files</code>.</p>
+      <p>M2: new tables in <code>engine/houston-db</code> (<code>repo_principals.rs</code>, <code>repo_principal_tokens.rs</code>). New middleware in <code>engine/houston-engine-server/src/middleware/scope.rs</code>. CLI spawn at <code>engine/houston-terminal-manager/src/cli_process.rs</code> gets a per-agent <code>HOME</code> override.<br><br>M3: CLI spawn gains a <code>setuid</code> step (Linux only, runs inside the runtime). Per-agent home dir resolution in <code>houston-agent-files</code>. New <code>provision_agent_user</code> helper that runs <code>useradd</code> the first time an agent is created.</p>
     </div>
 
     <div class="pager">

--- a/engine-design/08-login.html
+++ b/engine-design/08-login.html
@@ -35,75 +35,184 @@
   <main class="content">
     <div class="content-label">
       Chapter 08
-      <span class="status partial">Partial</span>
+      <span class="status partial">Partial · finishes in M3</span>
     </div>
     <h1>Logging in (still one click).</h1>
     <p class="lead">
-      Per-agent credentials sound expensive in clicks. They aren't. The
-      user clicks once per agent. The OAuth dance happens under the hood.
+      Per-agent credentials sound expensive in clicks. They aren't. For
+      solo desktop users, one click logs in once and Houston brokers
+      tokens to agents. For Teams and Cloud, each agent gets its own
+      login by default for stronger isolation.
     </p>
 
-    <div class="diagram">
-      <pre class="mermaid">
-sequenceDiagram
-  autonumber
-  actor User
-  participant UI as Desktop UI
-  participant Shell as Desktop Shell
-  participant E as Engine (in VM)
-  participant CLI as claude login<br/>(as hou_sales)
-  participant Browser as System Browser
-  participant Anthropic
-
-  User->>UI: click "Log into Claude for Sales"
-  UI->>E: POST /v1/agents/Sales/providers/anthropic/login
-  E->>CLI: spawn as hou_sales
-  CLI-->>E: print login URL
-  E-->>Shell: open URL via deep-link bridge
-  Shell->>Browser: open URL
-  User->>Anthropic: log in
-  Anthropic-->>Browser: redirect houston://anthropic-callback?code=...
-  Browser-->>Shell: deep link delivered
-  Shell->>E: POST callback code
-  E->>CLI: pass code
-  CLI->>Anthropic: exchange for token
-  CLI->>CLI: save to /home/hou_sales/.claude/
-  E-->>UI: WS event "Sales logged in"
-      </pre>
-      <div class="caption">One click for the user. About three redirects under the hood.</div>
+    <div class="flow-list">
+      <div class="flow-step">
+        <div class="num">01</div>
+        <div>
+          <div class="from-to"><span class="actor">User</span><span class="arrow">→</span><span class="actor">Desktop UI</span></div>
+          <div class="action">Clicks "Log into Claude for Sales".</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">02</div>
+        <div>
+          <div class="from-to"><span class="actor">Desktop UI</span><span class="arrow">→</span><span class="actor">Engine</span></div>
+          <div class="action"><code>POST /v1/agents/Sales/providers/anthropic/login</code>.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">03</div>
+        <div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">claude CLI</span></div>
+          <div class="action">Spawn as <code>hou_sales</code> inside the Linux runtime.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">04</div>
+        <div>
+          <div class="from-to"><span class="actor">claude CLI</span><span class="arrow">→</span><span class="actor">Engine</span></div>
+          <div class="action">Prints login URL on stdout.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">05</div>
+        <div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">Desktop shell</span></div>
+          <div class="action">Pushes URL to the host shell via the runtime bridge.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">06</div>
+        <div>
+          <div class="from-to"><span class="actor">Desktop shell</span><span class="arrow">→</span><span class="actor">System browser</span></div>
+          <div class="action">Opens the URL.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">07</div>
+        <div>
+          <div class="from-to"><span class="actor">User</span><span class="arrow">→</span><span class="actor">Anthropic</span></div>
+          <div class="action">Logs in.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">08</div>
+        <div>
+          <div class="from-to"><span class="actor">Anthropic</span><span class="arrow">→</span><span class="actor">Browser</span></div>
+          <div class="action">Redirects to <code>houston://anthropic-callback?code=...</code>.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">09</div>
+        <div>
+          <div class="from-to"><span class="actor">Browser</span><span class="arrow">→</span><span class="actor">Desktop shell</span></div>
+          <div class="action">Deep link delivered to the host shell (the OS routes <code>houston://</code> to the registered app).</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">10</div>
+        <div>
+          <div class="from-to"><span class="actor">Desktop shell</span><span class="arrow">→</span><span class="actor">Engine</span></div>
+          <div class="action">POSTs the OAuth code over the runtime's loopback port. <strong>The new piece.</strong></div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">11</div>
+        <div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">claude CLI</span></div>
+          <div class="action">Hands the code back to the waiting CLI subprocess.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">12</div>
+        <div>
+          <div class="from-to"><span class="actor">claude CLI</span><span class="arrow">→</span><span class="actor">Anthropic</span></div>
+          <div class="action">Exchanges the code for a token. Saves to <code>/home/hou_sales/.claude/</code>.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">13</div>
+        <div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">Desktop UI</span></div>
+          <div class="action">WS event "Sales logged in". UI updates.</div>
+        </div>
+      </div>
     </div>
+    <p style="font-size: 13px; color: var(--gray-500); text-align: center; margin-top: -16px; margin-bottom: 32px;">One click for the user. The new piece is steps 5 and 10, the host-to-runtime bridge.</p>
 
-    <h2>The pattern is already in Houston</h2>
+    <h2>What you already have</h2>
     <p>
-      This is the exact pattern Houston already uses for Google sign-in
-      via Supabase. A click in the UI starts an OAuth flow. The system
+      This is the exact pattern Houston uses today for Google sign-in via
+      Supabase. A click in the UI starts an OAuth flow. The system
       browser does the work. A custom URL scheme
       (<code>houston://...</code>) brings the result back into the app.
+      Same plumbing extends to per-provider logins.
+    </p>
+
+    <h2>The new piece: host-to-runtime bridge</h2>
+    <p>
+      When the engine lives inside a Linux runtime (Chapter 3), the OAuth
+      callback can't reach it directly. The browser redirects to
+      <code>houston://anthropic-callback?code=...</code>, which the Tauri
+      shell on the host catches. The shell then POSTs the code to the
+      engine over the runtime's localhost port.
     </p>
     <p>
-      The only new piece for the VM-based architecture is the
-      <strong>deep-link bridge</strong> between the desktop shell and the
-      VM. The shell catches the redirect, then posts the code over the
-      VM's local network to the engine.
+      Two things to get right:
+    </p>
+    <ul>
+      <li><strong>Only loopback.</strong> The runtime's HTTP port is bound to the host's loopback interface only. Other apps on the host cannot reach it, the network cannot reach it. Same posture as today's native engine.</li>
+      <li><strong>One-time auth code, not a long-lived token.</strong> The deep link carries an OAuth code that's only useful for the immediate exchange. The actual provider token never crosses the bridge in plaintext.</li>
+    </ul>
+
+    <h2>What about provider CLI callback URLs?</h2>
+    <p>
+      The Claude Code CLI and the Codex CLI each open their own hosted
+      OAuth flow. We don't control their callback URL. We capture it by:
+    </p>
+    <ol>
+      <li>Spawning the CLI inside the runtime.</li>
+      <li>Reading the login URL it prints to stdout.</li>
+      <li>Asking the host shell to open that URL.</li>
+      <li>Waiting for the CLI subprocess to finish the exchange.</li>
+    </ol>
+    <p>
+      No <code>houston://</code> hijack needed in the common path; the
+      CLI handles its own callback. The deep link is only used for our
+      own OAuth flows (Supabase, anything Houston-branded).
     </p>
 
     <h2>Per agent vs broker</h2>
     <p>
-      Two flavors of UX, both compatible with the same plumbing.
+      Two flavors, both compatible with the same plumbing. The honest
+      defaults differ by deployment.
     </p>
-    <ul>
-      <li><strong>Strict:</strong> log into Claude once per agent. Strongest isolation. Costs you N clicks for N agents.</li>
-      <li><strong>Broker:</strong> log into Claude once for the whole machine. The engine brokers tokens to individual agents. One click forever. Slightly weaker isolation because the broker has all tokens.</li>
-    </ul>
+
+    <h3>Desktop solo user: broker by default</h3>
     <p>
-      Which one ships first is an open question. The strict path is
-      simpler to build and the broker can be added later without breaking
-      the strict mode.
+      One Claude login for the whole machine. Houston brokers tokens to
+      individual agents. The user clicks once. This is the right default
+      because nobody in practice wants to OAuth ten times for ten agents,
+      and the threat model (one human, the agents are slices of their
+      own work) is bounded.
+    </p>
+
+    <h3>Teams or Cloud: per-agent by default</h3>
+    <p>
+      Each agent gets its own Claude account. Strongest isolation. Costs
+      N clicks for N agents, but in a Teams context different humans own
+      different agents anyway, so the click cost is distributed. This is
+      the mode the regulated-industry pitch leans on.
     </p>
 
     <div class="callout callout-info">
       <div class="callout-label">What works today</div>
-      <p>Single-account Anthropic, OpenAI, and Composio logins all work today, but they're machine-wide, not per-agent. Once Chapter 7 ships (per-agent UIDs), per-agent logins land naturally.</p>
+      <p>Single-account Anthropic, OpenAI, and Composio logins all work today, but they're machine-wide. The broker model is essentially what we have, minus the per-agent indirection. The work in M3 is the runtime-side plumbing (spawning the CLI as <code>hou_sales</code> inside the runtime) and the deep-link bridge.</p>
+    </div>
+
+    <div class="tech-box">
+      <div class="label">Where to look in the code</div>
+      <p>Today's provider login route: <code>engine/houston-engine-server/src/routes/providers.rs</code>. Today's Supabase OAuth deep-link handler: <code>app/src-tauri/src/commands/auth.rs</code> (host side). New bridge: <code>app/houston-tauri/runtime/bridge.rs</code> (new). CLI spawn for per-agent: same site as Chapter 7, <code>engine/houston-terminal-manager/src/cli_process.rs</code> with the <code>HOME</code> override.</p>
     </div>
 
     <div class="pager">
@@ -122,25 +231,6 @@ sequenceDiagram
 <footer class="footer">
   <div>Houston Engine Design Guide · Living document</div>
 </footer>
-
-<script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-  mermaid.initialize({
-    startOnLoad: true,
-    theme: 'base',
-    themeVariables: {
-      primaryColor: '#ffffff',
-      primaryTextColor: '#0d0d0d',
-      primaryBorderColor: '#cdcdcd',
-      lineColor: '#676767',
-      actorBkg: '#ffffff',
-      actorBorder: '#cdcdcd',
-      actorTextColor: '#0d0d0d',
-      labelBoxBkgColor: '#f9f9f9',
-      labelBoxBorderColor: '#cdcdcd'
-    }
-  });
-</script>
 
 </body>
 </html>

--- a/engine-design/09-external-triggers.html
+++ b/engine-design/09-external-triggers.html
@@ -35,68 +35,109 @@
   <main class="content">
     <div class="content-label">
       Chapter 09
-      <span class="status partial">Partial</span>
+      <span class="status partial">Webhooks in M4 · ~1 week</span>
     </div>
     <h1>External triggers.</h1>
     <p class="lead">
-      Three ways something outside Houston can wake up an agent. Two of
-      them work today. One is half-built.
+      Five ways something outside Houston can wake up an agent. Four work
+      today in some form. One is mostly scaffolding waiting on a single
+      route.
     </p>
 
-    <h2>1. The user sends a message</h2>
+    <h2>1. The user sends a message from the desktop</h2>
     <p>
       Standard chat. The desktop UI calls
       <code>POST /v1/agents/&lt;path&gt;/sessions</code>. The engine
-      spawns a CLI subprocess, the response streams back. This is what
-      Chapter 4 covers. Works today.
+      spawns a CLI subprocess, the response streams back. Chapter 4
+      covers it. Shipped.
     </p>
 
-    <h2>2. A cron fires</h2>
+    <h2>2. The user sends a message from mobile</h2>
+    <p>
+      Mobile is a PWA at <code>tunnel.gethouston.ai</code>. The desktop
+      engine dials an outbound WebSocket to the Houston Relay
+      (<code>houston-relay/</code>, Cloudflare Worker plus Durable
+      Object). The relay proxies mobile HTTP and WS over that link.
+      Same engine route as desktop chat. Shipped.
+    </p>
+
+    <h2>3. A Slack message arrives</h2>
+    <p>
+      Houston supports two-way Slack sync. An incoming Slack thread maps
+      to an agent session; messages create user messages on the same
+      <code>POST /v1/agents/&lt;path&gt;/sessions</code> path under the
+      hood. The integration is shipped.
+    </p>
+
+    <h2>4. A cron fires</h2>
     <p>
       Each agent has routines. <code>0 7 * * *</code> runs at 7am every
-      day. Today the cron lives inside the engine. A tokio task sleeps
-      until the fire time, then pushes a <code>HoustonInput::Cron</code>
-      onto the event queue, which dispatches to the same chat-turn path.
+      day. Today the cron lives inside the engine as a tokio task that
+      sleeps until the fire time, then pushes a
+      <code>HoustonInput::Cron</code> onto the event queue, which
+      dispatches to the same chat-turn path.
     </p>
     <p>
-      This works as long as the engine is up. For sleeping cloud engines
-      (Chapter 10), the cron will move to a central scheduler that wakes
-      the engine when the time comes.
+      Verified in <code>engine/houston-scheduler/src/cron_job.rs:76-125</code>.
+      Today there is no persistent <code>cron_runs</code> table; missed
+      fires are dropped silently. Chapter 6 fixes that.
     </p>
 
-    <h2>3. A webhook arrives</h2>
+    <h2>5. A webhook arrives</h2>
     <p>
-      Stripe sends a payment event. Slack sends a message. GitHub sends a
-      PR notification. Each one routed to a specific agent.
+      Stripe sends a payment event. GitHub sends a PR notification. Each
+      one routed to a specific agent.
     </p>
     <p>
-      The plumbing exists. The engine has a typed
-      <code>HoustonInput::Webhook</code> enum, and the dispatcher knows
-      how to route it. What's missing is the HTTP route that constructs
-      one. Adding <code>POST /v1/hooks/&lt;route_token&gt;</code> is small
-      work that unlocks a huge surface.
+      Honest status: the typed <code>HoustonInput::Webhook</code> variant
+      and the dispatcher infrastructure exist in
+      <code>engine/houston-events/src/queue.rs</code> and
+      <code>engine/houston-events/src/dispatcher.rs</code>. But there is
+      <strong>no <code>InputHandler</code> registered for it</strong>,
+      and there is <strong>no HTTP route that constructs one</strong>.
+      Two-thirds of the plumbing is in place; the last third is the
+      route plus the handler.
+    </p>
+    <p>
+      The route: <code>POST /v1/hooks/&lt;route_token&gt;</code> in a new
+      <code>engine/houston-engine-server/src/routes/hooks.rs</code>. The
+      handler: a small <code>WebhookHandler</code> that maps an incoming
+      payload to an agent session start.
     </p>
 
     <div class="callout callout-info">
       <div class="callout-label">Per-hook tokens, not the bearer token</div>
-      <p>Each webhook gets its own route token, separate from the engine bearer. Stripe's token only fires the Stripe hook. A compromised Stripe token lets the attacker fake payment events but doesn't let them read your chat history.</p>
+      <p>Each webhook gets its own route token, separate from the engine bearer. Stripe's token only fires the Stripe hook. A compromised Stripe token lets the attacker fake payment events but doesn't let them read your chat history or trigger other agents.</p>
     </div>
 
-    <h2>Wake-on-event for sleeping engines</h2>
+    <h2>Bounded queue (M1 prerequisite)</h2>
     <p>
-      Once the engine learns to sleep (Chapter 10), the relay in front
-      will catch inbound triggers, wake the engine via the platform API
-      (Fly Machines, systemd socket activation, etc), wait for
-      <code>/v1/health</code> to respond, then proxy the request through.
+      Today's event queue is unbounded
+      (<code>mpsc::unbounded_channel</code> at
+      <code>engine/houston-events/src/queue.rs:36</code>). A webhook
+      flood would balloon memory. M1 switches this to bounded with
+      explicit drop policies (Chapter 6 covers the rules per source).
+      Without that change, opening
+      <code>POST /v1/hooks/...</code> to the world is a DoS waiting to
+      happen.
+    </p>
+
+    <h2>Wake-on-event for sleeping engines (M4)</h2>
+    <p>
+      Once the engine learns to sleep in Cloud (Chapter 10), the relay
+      in front will catch inbound triggers, wake the engine via the
+      platform API (Fly Machines, systemd socket activation, etc), wait
+      for <code>/v1/health</code> to respond, then proxy the request
+      through.
     </p>
     <p>
-      Cron, user message, and webhook all share that same wake-up path.
-      One mechanism, three triggers.
+      All five trigger sources share that same wake-up path. One
+      mechanism, five triggers.
     </p>
 
     <div class="tech-box">
       <div class="label">Where to look in the code</div>
-      <p>Webhook input type: <code>engine/houston-events/src/queue.rs:25-104</code>. Cron implementation: <code>engine/houston-scheduler/src/cron_job.rs</code>. Missing piece for webhooks: a <code>routes/hooks.rs</code> file in <code>engine/houston-engine-server/</code>.</p>
+      <p>Webhook input type: <code>engine/houston-events/src/types.rs:12</code>. Convenience constructor: <code>types.rs:145-154</code>. Dispatcher: <code>engine/houston-events/src/dispatcher.rs</code>. Queue (unbounded today): <code>engine/houston-events/src/queue.rs:36</code>. Cron implementation: <code>engine/houston-scheduler/src/cron_job.rs:76-125</code>. Slack integration: <code>engine/houston-slack</code> (or its current name). Relay: <code>houston-relay/</code>. Missing piece for webhooks: new <code>engine/houston-engine-server/src/routes/hooks.rs</code> plus a registered <code>InputHandler</code>.</p>
     </div>
 
     <div class="pager">

--- a/engine-design/10-deployment.html
+++ b/engine-design/10-deployment.html
@@ -35,86 +35,156 @@
   <main class="content">
     <div class="content-label">
       Chapter 10
-      <span class="status planned">Planned · M3</span>
+      <span class="status planned">Planned · M4 · ~3 months</span>
     </div>
     <h1>Deployment: one binary, two homes.</h1>
     <p class="lead">
-      Same engine binary. Two deployment modes. Almost zero divergence
-      between them. The only difference is whose computer the VM runs on.
+      Same Linux engine binary. Three deployment surfaces (desktop,
+      self-hosted, Cloud). Almost zero divergence. The only difference is
+      whose computer the Linux runtime runs on, and whether there's a
+      control plane in front.
     </p>
 
     <div class="diagram">
-      <pre class="mermaid">
-graph LR
-  subgraph Desktop["Desktop Mode"]
-    DS["Desktop Shell"]
-    DV["Linux microVM"]
-    DE["houston-engine"]
-    DS --> DV --> DE
-  end
-
-  subgraph Cloud["Cloud Mode"]
-    Relay["Houston Relay<br/>(CF Worker + DO)"]
-    Fly["Fly Machine<br/>(Linux microVM)"]
-    CE["houston-engine"]
-    Relay --> Fly --> CE
-  end
-
-  DE -.same binary.-> CE
-      </pre>
-      <div class="caption">The engine binary is byte-for-byte the same. Only the host changes.</div>
+      <div class="deploy-grid">
+        <div class="deploy-col">
+          <div class="deploy-head">Desktop mode</div>
+          <div class="deploy-layer">Desktop shell</div>
+          <div class="deploy-arrow">↓</div>
+          <div class="deploy-layer">Linux runtime (VZ / WSL2 / native)</div>
+          <div class="deploy-arrow">↓</div>
+          <div class="deploy-layer engine">houston-engine</div>
+        </div>
+        <div class="deploy-col">
+          <div class="deploy-head">Self-host (Always On)</div>
+          <div class="deploy-layer">docker run / systemd</div>
+          <div class="deploy-arrow">↓</div>
+          <div class="deploy-layer engine">houston-engine</div>
+        </div>
+        <div class="deploy-col">
+          <div class="deploy-head">Houston Cloud</div>
+          <div class="deploy-layer">Control plane (signup, billing)</div>
+          <div class="deploy-arrow">↓</div>
+          <div class="deploy-layer">Houston Relay (wake on demand)</div>
+          <div class="deploy-arrow">↓</div>
+          <div class="deploy-layer">Fly Machine (Linux microVM)</div>
+          <div class="deploy-arrow">↓</div>
+          <div class="deploy-layer engine">houston-engine</div>
+        </div>
+      </div>
+      <div class="caption">The engine binary is byte-for-byte the same in all three.</div>
     </div>
 
     <h2>Desktop mode</h2>
     <p>
-      Inside a Linux microVM on your laptop. The microVM lives next to
-      your desktop shell. They talk over local networking. The engine
-      never crosses the VM boundary unless the shell explicitly bridges
-      something (file picker, OAuth callback, system browser).
+      The Linux engine binary, inside the host's Linux runtime (Chapter
+      3). Desktop shell talks to it over local networking on a loopback
+      port. No control plane, no relay.
     </p>
 
-    <h2>Cloud mode</h2>
+    <h2>Self-host mode (Always On)</h2>
     <p>
-      Inside a Linux microVM on Fly Machines (or similar). Each paying
-      customer gets their own VM. A relay outside knows how to wake a
-      sleeping VM when a user message, webhook, or scheduled cron
-      arrives.
-    </p>
-    <p>
-      The relay is the same one Houston already uses for mobile traffic
-      (<code>houston-relay/</code>, a Cloudflare Worker plus Durable
-      Objects on <code>tunnel.gethouston.ai</code>). Extending it to also
-      proxy general engine traffic and to dispatch wake-ups is the bulk
-      of M3.
+      The Linux engine binary, native on a Linux VPS. Wrapped in Docker
+      (<code>always-on/Dockerfile</code>) or systemd
+      (<code>always-on/houston-engine.service</code>). The user puts a
+      reverse proxy in front and binds <code>HOUSTON_BIND_ALL=1</code>.
+      Already shipped as scaffolding for power users; see
+      <code>always-on/README.md</code>.
     </p>
 
-    <h2>What you get</h2>
+    <h2>Cloud mode (Houston Cloud)</h2>
+    <p>
+      The Linux engine binary, inside a Fly Machine per customer. A
+      control plane in front handles signup, billing, admin, and
+      provisioning. The relay routes inbound user traffic to the right
+      machine and wakes sleeping machines on demand.
+    </p>
+
+    <h3>Why Fly Machines</h3>
+    <p>
+      Fly Machines are already Linux microVMs with first-class start and
+      stop APIs, per-region placement, and sub-second wake. We can move
+      to another platform later, but committing now means we can ship.
+      Hedging delays decisions; pick one and move.
+    </p>
+
+    <h3>The control plane</h3>
+    <p>
+      Cloud is not just an engine on a VM. We need:
+    </p>
     <ul>
-      <li>One engine codebase, no forks, no per-platform builds beyond the small desktop shell.</li>
-      <li>Same tests, same behavior, same bugs and same fixes.</li>
-      <li>"Run your engine in our cloud" is literally <code>fly machines start</code>.</li>
-      <li>"Move from our cloud to your own VPS" is <code>docker pull && docker run</code>. Same image.</li>
-      <li>Pricing aligns if you bill per VM-hour: cloud customers pay you, desktop users pay their own machine, you meter the same unit.</li>
+      <li><strong>Signup and billing.</strong> Supabase Auth (already wired for desktop SSO) + Stripe for subscriptions.</li>
+      <li><strong>Provisioning.</strong> A small service that, on first login, creates a Fly Machine for the customer, mints their bearer token, and writes initial workspace state.</li>
+      <li><strong>Admin.</strong> Support tools: see a customer's recent errors, restart their machine, rotate their token.</li>
+      <li><strong>Observability.</strong> Sentry (already used in desktop) gets a Cloud-scoped project. Per-machine log retention via Fly's built-in log shipping or BetterStack.</li>
     </ul>
+    <p>
+      Lives at <code>cloud/</code> (new). Probably TypeScript on Cloudflare Workers + Supabase for parity with the rest of our stack.
+    </p>
+
+    <h3>Storage when machines sleep across hosts</h3>
+    <p>
+      Fly volumes are pinned to a host. If a customer machine sleeps and
+      wakes on a different physical host, the volume needs to follow.
+      Two paths:
+    </p>
+    <ul>
+      <li><strong>Pinned host (default).</strong> Each customer's machine has one home host. Wake is fast, no copy needed. Cost: that host becomes a single point of failure for that customer.</li>
+      <li><strong>Cold storage in R2/S3 (failover).</strong> A nightly snapshot of the volume into object storage. If the home host is unavailable, we restore on a new host. Cost: ~30 seconds of cold-start when failover triggers.</li>
+    </ul>
+    <p>
+      Ship with pinned host. Add the snapshot path the moment we have
+      paying customers.
+    </p>
+
+    <h3>Data residency</h3>
+    <p>
+      Each customer picks a region at signup (us-east, eu-west, ap-south).
+      Their Fly Machine and snapshots live there. The control plane is
+      global; only metadata (account, billing) lives outside the
+      customer's region.
+    </p>
+
+    <h3>Backups</h3>
+    <p>
+      Nightly snapshot of the volume. Restore points: last 7 daily, last
+      4 weekly. Self-service restore from the customer dashboard.
+    </p>
 
     <h2>Sleeping engines</h2>
     <p>
-      For cloud mode, engines sleep after N idle minutes. They exit 0
-      gracefully. The relay holds the connection from the next inbound
-      request, calls the platform's start API, polls
-      <code>/v1/health</code>, then proxies through. Cold start: ~2
-      seconds. Acceptable for crons and webhooks; for active human chats,
-      engines stay sticky-hot during a session window.
+      For Cloud mode, engines sleep after N idle minutes (default 10).
+      They exit 0 gracefully. The relay holds the connection from the
+      next inbound request, calls Fly's start API, polls
+      <code>/v1/health</code>, then proxies through. Cold start target:
+      ~2 seconds. Acceptable for crons and webhooks; for active human
+      chats, engines stay sticky-hot during a session window.
+    </p>
+    <p>
+      All four trigger sources from Chapter 9 (chat, mobile, Slack
+      inbound, webhook) share the same wake-up path. Cron uses a slightly
+      different path: a central scheduler service decides when to wake
+      a machine, instead of the relay reacting to inbound traffic.
+    </p>
+
+    <h2>Pricing</h2>
+    <p>
+      Per VM-hour, or per agent-month. Either aligns with cost. The
+      Cloud product is "rent a Fly Machine that runs Houston Engine plus
+      our control plane around it." Self-hosters pay nothing to Houston
+      and run the same engine themselves. Desktop users pay nothing and
+      run the engine on their own laptop. All three meters touch the
+      same engine binary.
     </p>
 
     <div class="callout callout-success">
       <div class="callout-label">The killer property</div>
-      <p>You can no longer have a "works on my Mac" bug, because there is no Mac engine. Every engine is the same Linux engine.</p>
+      <p>You can no longer have a "works on my Mac" bug, because there is no Mac engine. Every engine is the same Linux engine. The desktop just hosts the runtime.</p>
     </div>
 
     <div class="tech-box">
       <div class="label">What's there already</div>
-      <p>Always-on Docker recipe: <code>always-on/Dockerfile</code> and <code>docker-compose.yml</code>. Relay: <code>houston-relay/</code>. Tunnel client crate: <code>engine/houston-tunnel</code>. What's missing: VM-management code in the desktop shell, wake API in the relay, idle-exit logic in the engine.</p>
+      <p>Always-on Docker recipe: <code>always-on/Dockerfile</code> and <code>docker-compose.yml</code>, builds the engine from source. Relay: <code>houston-relay/</code>, a production Cloudflare Worker + Durable Object at <code>tunnel.gethouston.ai</code>. Tunnel client crate: <code>engine/houston-tunnel</code>. What's missing: Linux runtime supervisor on desktop (Chapter 3), control-plane app at <code>cloud/</code>, idle-exit logic in the engine, wake API in the relay, Fly Machines integration.</p>
     </div>
 
     <div class="pager">
@@ -133,23 +203,6 @@ graph LR
 <footer class="footer">
   <div>Houston Engine Design Guide · Living document</div>
 </footer>
-
-<script type="module">
-  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
-  mermaid.initialize({
-    startOnLoad: true,
-    theme: 'base',
-    themeVariables: {
-      primaryColor: '#ffffff',
-      primaryTextColor: '#0d0d0d',
-      primaryBorderColor: '#cdcdcd',
-      lineColor: '#676767',
-      mainBkg: '#ffffff',
-      secondBkg: '#f9f9f9',
-      tertiaryBkg: '#ececec'
-    }
-  });
-</script>
 
 </body>
 </html>

--- a/engine-design/11-roadmap.html
+++ b/engine-design/11-roadmap.html
@@ -39,73 +39,163 @@
     </div>
     <h1>The roadmap.</h1>
     <p class="lead">
-      Three milestones. Each one roughly two to four weeks at current
-      shipping pace. Each one ships before the next one starts.
+      Four milestones. Realistic sizes. Two of them run in parallel
+      because they're independent. Two of them are heavier than they
+      look. One parallel track starts on day one and has nothing to do
+      with code (Apple paperwork).
     </p>
 
-    <h2>M1 — Reliability</h2>
+    <h2>The shape</h2>
+<pre><code>Week                  0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24
+                      |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
+M1 Reliability        [============ ~4 weeks ============]
+M2 Auth + credentials [======== ~3 weeks ========]
+                                                          (M1 + M2 ship together as a release)
+M3 Linux runtime                                          [================== ~3 months ==================]
+M4 Cloud foundation                                                                                       [================ ~3 months ================]
+Apple entitlement     [........................... weeks to months, asynchronous ...........................]
+VZ.framework spike    [===]   ← do this BEFORE locking M3 dates</code></pre>
+
+    <h2>M1 — Reliability (~4 weeks)</h2>
     <p>
       <strong>Goal:</strong> conversations never drop bytes. The "my
       message disappeared" failure mode goes away. Every byte the user
       sees is journaled before broadcast.
     </p>
     <ul>
-      <li>Add four SQLite tables: <code>turns</code>, <code>turn_stream</code>, <code>events_outbox</code>, <code>cron_runs</code>.</li>
+      <li>Add the four SQLite tables: <code>turns</code>, <code>turn_stream</code>, <code>events_outbox</code>, <code>cron_runs</code>. Concrete schemas in Chapter 6.</li>
       <li>Write rows BEFORE doing work. Sweep orphans on boot.</li>
-      <li>WebSocket replay by sequence number on reconnect.</li>
+      <li>Client-supplied <code>turnId</code> with idempotent server semantics. Protocol bump.</li>
+      <li>WebSocket replay by sequence number on reconnect. New <code>since_seq</code> on subscribe.</li>
       <li>Cron audit log plus missed-fire catch-up policy.</li>
+      <li>Bounded event queue with per-source drop rules.</li>
+      <li>Coexistence with <code>chat_feed</code>: double-write for this release, drop in the next.</li>
     </ul>
     <p>
-      Mostly inserts and middleware. No architectural change. About 2-3
-      weeks.
+      Mostly inserts and middleware. No architectural change. The 4-week
+      number assumes the schema is locked on day one. Slips to 5-6 weeks
+      if we discover the WS protocol bump rippling through more clients
+      than expected.
     </p>
 
-    <h2>M2 — Auth and isolation</h2>
+    <h2>M2 — Auth and credentials (~3 weeks, in parallel with M1)</h2>
     <p>
-      <strong>Goal:</strong> multi-tenant safety. Two humans can share an
-      engine without leaking into each other. Per-agent credentials.
+      <strong>Goal:</strong> Walls 2 and 3 from Chapter 7. No VM
+      required. Owned by a different engineer so M1 and M2 ship as one
+      release.
     </p>
     <ul>
-      <li>Typed tokens with scope: <code>(principal_id, scope)</code> on every route.</li>
-      <li>Per-agent Linux users inside the VM (one-time automated <code>useradd</code>).</li>
-      <li>Per-agent credentials (per-agent <code>.claude</code>, <code>.composio</code>).</li>
-      <li>VM-based desktop spin-up, replacing the native sidecar model.</li>
+      <li>Typed tokens: <code>(principal_id, scopes)</code>. New tables: <code>principals</code> and <code>principal_tokens</code> in <code>houston-db</code>.</li>
+      <li><code>require_scope(token, agent_path)</code> middleware on every route that touches an agent.</li>
+      <li>Per-agent credentials: CLI spawn overrides <code>HOME</code> to a per-agent path under the agent's folder.</li>
+      <li>Migration: today's single device-bearer becomes one principal with full scope. No UX change for solo users.</li>
     </ul>
     <p>
-      Middleware plus a new system layer. About 3-4 weeks.
+      Middleware plus a few new tables. About 3 weeks. Does not require
+      Chapter 3, does not require a VM. Real isolation win shipped without
+      waiting for M3.
     </p>
 
-    <h2>M3 — Cloud and detached workers</h2>
+    <h2>M3 — Linux runtime everywhere (~3 months)</h2>
+    <p>
+      <strong>Goal:</strong> Wall 1 from Chapter 7. The whole desktop now
+      runs the same Linux engine as Cloud. Per-agent Linux UIDs become
+      possible.
+    </p>
+    <ul>
+      <li>Runtime supervisor at <code>app/houston-tauri/runtime/</code>.</li>
+      <li>macOS: Apple <code>Virtualization.framework</code> wrapper with a slim Linux guest image.</li>
+      <li>Windows: WSL2 detect/install/register/start.</li>
+      <li>Linux: passthrough, no runtime.</li>
+      <li>Per-agent <code>useradd</code> automation inside the runtime.</li>
+      <li>CLI spawn as <code>hou_&lt;agent&gt;</code>.</li>
+      <li>Import and Download routes for file flow in and out of the runtime.</li>
+      <li>Apple <code>com.apple.security.virtualization</code> entitlement in the signed app.</li>
+    </ul>
+    <p>
+      Honest scoping: this is two new pieces of infrastructure (a Linux
+      guest image we build in CI, and a Tauri-side runtime supervisor) on
+      top of changes throughout the engine to assume per-agent UIDs.
+      Three months is the optimistic end. Could slip to four if VZ
+      cold-start or WSL2 corp-IT issues bite.
+    </p>
+
+    <h2>M4 — Cloud foundation (~3 months)</h2>
     <p>
       <strong>Goal:</strong> Houston Cloud is shippable. Engine bounces
-      don't kill conversations. Sleeping engines wake on demand.
+      don't kill conversations. Sleeping engines wake on demand. Paying
+      customers can sign up.
     </p>
     <ul>
-      <li>Detached <code>houston-turn-worker</code> binary so engine restart doesn't kill in-flight turns.</li>
+      <li>Detached <code>houston-turn-worker</code> binary so engine restart doesn't kill in-flight turns. (The architectural risk piece.)</li>
       <li><code>POST /v1/hooks/&lt;route_token&gt;</code> wired to the event queue.</li>
-      <li>Engine knows how to exit gracefully on idle.</li>
-      <li>Relay knows how to wake a dormant engine via Fly Machines API.</li>
-      <li>Cron moves to a central scheduler service for hosted mode.</li>
-      <li>Per-customer Fly Machine provisioning and onboarding.</li>
+      <li>Engine learns to exit gracefully on idle.</li>
+      <li>Relay learns to wake a dormant engine via Fly Machines API.</li>
+      <li>Cron moves to a central scheduler service for hosted mode (in-engine cron stays for desktop and self-host).</li>
+      <li>Per-customer Fly Machine provisioning, region picker, onboarding.</li>
+      <li>Control plane: signup, billing, admin, observability. Lives at <code>cloud/</code>.</li>
+      <li>Storage strategy: pinned host with R2/S3 nightly snapshot fallback.</li>
     </ul>
     <p>
-      The only milestone with real architectural risk (the detached
-      worker). About 4 weeks.
+      Heaviest milestone. Detached worker alone is 3-4 weeks if it goes
+      well. Control plane is its own product. Three months is realistic
+      only with two engineers on it; one engineer is closer to five.
+    </p>
+
+    <h2>Parallel track: Apple entitlement paperwork</h2>
+    <p>
+      <strong>Start day one of M1. Do not wait for M3.</strong> Using
+      <code>Virtualization.framework</code> in a Developer ID app
+      requires the <code>com.apple.security.virtualization</code>
+      entitlement, which Apple grants by request. Timeline: a few weeks
+      if clean, longer if Apple has questions. Filing late blocks the
+      entire M3 release.
+    </p>
+    <p>
+      Action: open a ticket at developer.apple.com (Code Signing &amp;
+      Entitlements). Describe Houston as a desktop app that runs
+      user-owned agent workloads inside a Linux guest for isolation.
+      Reference VZ.framework. Wait. Then add the entitlement to
+      <code>app/src-tauri/entitlements.plist</code> the moment it's
+      granted.
+    </p>
+
+    <h2>Parallel track: VZ.framework cold-start spike</h2>
+    <p>
+      Before locking M3 dates, build a 1-week spike: bundle a minimal
+      Alpine guest image with the engine binary, boot it via
+      <code>objc2-virtualization</code> on a representative Mac, measure
+      cold start (target ≤ 2s on Apple Silicon, ≤ 3s on Intel), measure
+      resident memory (target ≤ 300MB), measure battery drain over a
+      4-hour idle session (target ≤ 10% extra vs native).
+    </p>
+    <p>
+      If the numbers come back outside those budgets, M3 needs a design
+      rethink. Knowing this in week 0 is cheap. Discovering it in month
+      3 is not.
     </p>
 
     <div class="callout callout-info">
       <div class="callout-label">Open questions to settle before each milestone</div>
-      <p><strong>Before M2:</strong> per-agent Claude logins, or a credentials broker for one-login-many-agents?</p>
-      <p><strong>Before M3:</strong> cron in-engine forever, or move to a central scheduler even for self-hosters? Where does the OSS-vs-cloud line sit for the relay code?</p>
+      <p><strong>Before M1:</strong> double-write or hard-migrate <code>chat_feed</code> in the first release? Recommendation: double-write.</p>
+      <p><strong>Before M2:</strong> per-agent OAuth broker for desktop solo users (1 click, weaker iso) or strict per-agent (N clicks, stronger iso)? Recommendation: broker for desktop default, strict for Teams default.</p>
+      <p><strong>Before M3:</strong> what's the fallback when a Windows machine has virtualization disabled in BIOS? Recommendation: clear install-time check, link to IT-admin docs, no native fallback (to keep one operating profile).</p>
+      <p><strong>Before M4:</strong> pinned-host Fly Machines or active-active multi-region from day one? Recommendation: pinned + nightly snapshot, upgrade later. Also: where does the OSS-vs-Cloud line sit for the control plane? Cloud-only is the obvious answer.</p>
     </div>
 
-    <h2>After M3</h2>
+    <h2>What "shipped" looks like at the end of M4</h2>
+    <ul>
+      <li>Houston desktop on Mac, Windows, Linux, all running the same Linux engine inside a host runtime.</li>
+      <li>Per-agent isolation on every OS. The consultant-with-two-clients case is bulletproof.</li>
+      <li>Conversations survive engine bounces, app closes, network blips. Crons never silently drop.</li>
+      <li>Houston Cloud private beta: signup, per-customer Fly Machine, sleep/wake, billing, region picker.</li>
+      <li>Self-host story unchanged. <code>docker pull && docker run</code> still works.</li>
+      <li>Webhooks live. Five trigger sources (chat, mobile, Slack, cron, webhook) all routed through the same path.</li>
+    </ul>
     <p>
-      Houston Cloud private beta is shippable. The desktop story is the
-      same architecture as the cloud story, just running on the user's
-      hardware. Pricing aligns (per VM-hour or per agent-month, decide
-      then). Teams becomes a thin layer on top of the per-customer-VM
-      story.
+      Total elapsed: ~7-8 months from kickoff. Two engineers is enough
+      for M1+M2 in parallel. Three is enough to run M3 and M4 in parallel
+      after M2 lands. Anything less and the schedule stretches linearly.
     </p>
 
     <div class="pager">

--- a/engine-design/index.html
+++ b/engine-design/index.html
@@ -37,8 +37,10 @@
     <h1>How the engine actually works.</h1>
     <p class="lead">
       A walkthrough of every piece of Houston, what it does today, what it
-      will do tomorrow, and the reason for every decision in between. Read
-      it, present it, edit it as we go.
+      will do tomorrow, and the reason for every decision in between. If
+      you are a new hire, you should be able to read this top to bottom
+      and start building. If you need more, the code is linked at the
+      bottom of each chapter.
     </p>
 
     <div class="hero-actions">
@@ -47,13 +49,33 @@
     </div>
 
     <h2 style="margin-top: 80px">Reading legend</h2>
-    <p>Each chapter has a status pill. Three states, color-coded.</p>
+    <p>Each chapter has a status pill. Four states.</p>
     <ul>
       <li><span class="status shipped">Shipped</span> already in the codebase today.</li>
       <li><span class="status partial">Partial</span> some of it works, the rest is on the plan.</li>
       <li><span class="status planned">Planned</span> the design is decided, the code is not yet written.</li>
       <li><span class="status progress">In progress</span> actively being built right now.</li>
     </ul>
+    <p>
+      Each planned chapter also lists which milestone it belongs to
+      (M1, M2, M3, M4) and a rough size in weeks or months. Sizes are
+      honest estimates, not commitments. Where the work depends on
+      something else landing first, the chapter says so.
+    </p>
+
+    <h2>The big idea, in one paragraph</h2>
+    <p>
+      Houston is a desktop app, an engine, and folders on disk. The
+      desktop app is what users click. The engine is a Rust binary that
+      does the work. The folders are where the agents and their data
+      live. The desktop talks to the engine over HTTP. The engine spawns
+      provider CLIs (Claude Code, Codex) and watches files. After the
+      redesign, the engine runs inside a Linux runtime on every host
+      (Apple <code>Virtualization.framework</code> on Mac,
+      <code>WSL2</code> on Windows, native on Linux and in the cloud),
+      so per-agent isolation can be enforced by the kernel and the
+      tooling story stops being three different stories.
+    </p>
 
     <h2>The chapters</h2>
 
@@ -67,53 +89,53 @@
       <a class="chapter-card" href="02-agent-folder.html">
         <div class="chapter-num">02 <span class="status shipped">Shipped</span></div>
         <div class="chapter-title">An agent is a folder</div>
-        <div class="chapter-desc">No databases, no proprietary formats. Just files on disk.</div>
+        <div class="chapter-desc">No databases, no proprietary formats. Just files on disk, inside a Linux runtime.</div>
       </a>
 
       <a class="chapter-card" href="03-where-engine-lives.html">
-        <div class="chapter-num">03 <span class="status planned">Planned</span></div>
+        <div class="chapter-num">03 <span class="status planned">Planned · M3 · ~3 months</span></div>
         <div class="chapter-title">Where the engine lives</div>
-        <div class="chapter-desc">Inside a Linux microVM. Same on your laptop and in our cloud.</div>
+        <div class="chapter-desc">One Linux engine binary. Three host runtimes: Apple VZ, WSL2, native Linux.</div>
       </a>
 
       <a class="chapter-card" href="04-message-flow.html">
-        <div class="chapter-num">04 <span class="status partial">Partial</span></div>
+        <div class="chapter-num">04 <span class="status partial">Partial · finishes in M1</span></div>
         <div class="chapter-title">How a message flows through</div>
         <div class="chapter-desc">The full chat-turn sequence. The most important diagram.</div>
       </a>
 
       <a class="chapter-card" href="05-conversations-die.html">
-        <div class="chapter-num">05 <span class="status planned">Planned</span></div>
+        <div class="chapter-num">05 <span class="status planned">Diagnosis · feeds M1</span></div>
         <div class="chapter-title">Why conversations die today</div>
-        <div class="chapter-desc">Four failure modes. Same root cause.</div>
+        <div class="chapter-desc">Five failure modes. Same root cause: writes happen after work, not before.</div>
       </a>
 
       <a class="chapter-card" href="06-four-tables.html">
-        <div class="chapter-num">06 <span class="status planned">Planned</span></div>
+        <div class="chapter-num">06 <span class="status planned">Planned · M1 · ~4 weeks</span></div>
         <div class="chapter-title">The four tables that save everything</div>
         <div class="chapter-desc">The whole reliability story. Not Temporal. Just SQLite.</div>
       </a>
 
       <a class="chapter-card" href="07-keeping-agents-apart.html">
-        <div class="chapter-num">07 <span class="status planned">Planned</span></div>
+        <div class="chapter-num">07 <span class="status planned">Walls 2+3 in M2 · ~3 weeks. Wall 1 in M3.</span></div>
         <div class="chapter-title">Keeping agents apart</div>
-        <div class="chapter-desc">Three independent walls. Kernel-enforced isolation.</div>
+        <div class="chapter-desc">Three independent walls. The "Sales agent can't read HR data" story.</div>
       </a>
 
       <a class="chapter-card" href="08-login.html">
-        <div class="chapter-num">08 <span class="status partial">Partial</span></div>
+        <div class="chapter-num">08 <span class="status partial">Partial · finishes in M3</span></div>
         <div class="chapter-title">Logging in (still one click)</div>
         <div class="chapter-desc">Per-agent OAuth without breaking the UX.</div>
       </a>
 
       <a class="chapter-card" href="09-external-triggers.html">
-        <div class="chapter-num">09 <span class="status partial">Partial</span></div>
+        <div class="chapter-num">09 <span class="status partial">Partial · webhooks in M4 · ~1 week</span></div>
         <div class="chapter-title">External triggers</div>
-        <div class="chapter-desc">Messages, crons, webhooks. Three ways to wake an agent.</div>
+        <div class="chapter-desc">Five ways to wake an agent. User chat, mobile, Slack, cron, webhook.</div>
       </a>
 
       <a class="chapter-card" href="10-deployment.html">
-        <div class="chapter-num">10 <span class="status planned">Planned</span></div>
+        <div class="chapter-num">10 <span class="status planned">Planned · M4 · ~3 months</span></div>
         <div class="chapter-title">Deployment: one binary, two homes</div>
         <div class="chapter-desc">Same engine on your laptop and in Houston Cloud.</div>
       </a>
@@ -121,7 +143,7 @@
       <a class="chapter-card" href="11-roadmap.html">
         <div class="chapter-num">11 <span class="status progress">In progress</span></div>
         <div class="chapter-title">The roadmap</div>
-        <div class="chapter-desc">Three milestones from MVP to Houston Cloud.</div>
+        <div class="chapter-desc">Four milestones. Realistic timelines. What ships in parallel vs in sequence.</div>
       </a>
     </div>
   </main>

--- a/engine-design/style.css
+++ b/engine-design/style.css
@@ -197,7 +197,7 @@ nav {
 
 /* ─── Content ─── */
 .content {
-  max-width: 760px;
+  max-width: 880px;
   min-width: 0;
 }
 
@@ -410,17 +410,109 @@ nav {
   background: var(--gray-50);
   border: 1px solid var(--border-light);
   border-radius: 12px;
-  padding: 32px 24px;
+  padding: 28px 24px 24px;
   margin: 32px 0;
-  text-align: center;
   overflow-x: auto;
 }
 .diagram .caption {
   color: var(--gray-500);
   font-size: 13px;
-  margin-top: 16px;
+  margin-top: 18px;
+  text-align: center;
 }
-.mermaid { display: inline-block; }
+
+/* Host-runtime grid (Ch3) */
+.host-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 14px;
+}
+.host-card {
+  background: white;
+  border: 1px solid var(--border-medium);
+  border-radius: 12px;
+  padding: 18px 18px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.host-card .host-name {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--gray-500);
+}
+.host-card .runtime-pill {
+  font-size: 13px;
+  color: var(--gray-700);
+  padding: 7px 12px;
+  background: var(--gray-50);
+  border-radius: 8px;
+  border: 1px dashed var(--border-medium);
+  text-align: center;
+}
+.host-card .engine-pill {
+  background: var(--gray-950);
+  color: white;
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+  letter-spacing: -0.005em;
+}
+.host-card .engine-pill .engine-sub {
+  font-size: 11px;
+  color: var(--gray-400);
+  margin-top: 2px;
+  font-weight: 400;
+}
+
+/* Deployment grid (Ch10) — vertical flow per column */
+.deploy-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+.deploy-col {
+  background: white;
+  border: 1px solid var(--border-medium);
+  border-radius: 12px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.deploy-col .deploy-head {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--gray-500);
+  margin-bottom: 6px;
+}
+.deploy-col .deploy-layer {
+  padding: 9px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  text-align: center;
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  color: var(--gray-700);
+}
+.deploy-col .deploy-layer.engine {
+  background: var(--gray-950);
+  border-color: var(--gray-950);
+  color: white;
+  font-weight: 600;
+}
+.deploy-col .deploy-arrow {
+  text-align: center;
+  color: var(--gray-300);
+  font-size: 14px;
+  line-height: 1;
+}
 
 /* Flow steps (replaces sequence diagram) */
 .flow-list {


### PR DESCRIPTION
## Summary

Revises the engine design guide (`engine-design/`) to encode the actual rationale behind the redesign and give a new hire enough context to build from without follow-up questions.

### Reasoning encoded explicitly

- **Per-client isolation** (Ch3, Ch7). The consultant-with-multiple-clients threat model is real: today a ClientA agent can `cat` ClientB's files because the CLI subprocess runs as the user. This is why the Linux runtime + per-agent UIDs exist.
- **Cloud-first user reality** (Ch3). Most non-technical users keep data in Drive, Slack, Notion, Gmail. "Agent can browse my whole laptop" is an attack surface, not a feature. Files-inside-the-runtime + first-class Import/Download replaces the open-in-Finder pitch.
- **Windows tooling tax** (Ch3). We maintain `gethouston/composio` because upstream closed Windows with "use WSL." Every vanguard CLI (Stripe Link, future MCP servers) ships Linux/Mac first. WSL2 on Windows kills the fork and makes future tooling free.

### Architecture choice

One Linux engine binary, three host runtimes: Apple `Virtualization.framework` on Mac, WSL2 on Windows, native on Linux/Cloud. Not a hand-rolled hypervisor. Apple entitlement (`com.apple.security.virtualization`) called out as a parallel track that needs to start day one.

### Roadmap

- **M1** Reliability, ~4 weeks. Four tables, write-before-do, WS replay, cron audit, bounded event queue.
- **M2** Auth + credentials, ~3 weeks in parallel with M1. Typed scoped tokens, per-agent `HOME` override (no VM required).
- **M3** Linux runtime everywhere, ~3 months. VZ/WSL2/native supervisor, per-agent UIDs, file import/download, entitlement.
- **M4** Cloud foundation, ~3 months. Detached `houston-turn-worker`, webhook route, relay wake, control plane, billing.

VZ.framework cold-start spike must come back inside budget (≤2s, ≤300MB, ≤10% battery) before M3 dates lock.

### Concrete new pieces in the doc

- SQL schemas for `turns`, `turn_stream`, `events_outbox`, `cron_runs`, `principals`, `principal_tokens` with column definitions, indices, retention policy.
- Coexistence story for `chat_feed`: double-write for one release, drop in the next.
- Bounded-event-queue policy per source (cron coalesces, user never drops, webhook gets a token bucket).
- Honest gap analysis for the webhook surface (enum + dispatcher exist, no handler, no route).
- Five trigger sources counted, not three: chat, mobile, Slack, cron, webhook.

### Rendering

Mermaid removed in favor of native HTML diagrams (`host-grid`, `deploy-grid`, `flow-list`) so chapters render at full content width with no JS. `.content` widened from 760px to 880px.

## Test plan

- [ ] Open `engine-design/index.html` in a browser and walk all 11 chapters
- [ ] Verify Ch3, Ch8, Ch10 diagrams render full-width with readable labels
- [ ] Confirm sidebar status pills and inline chapter pills agree
- [ ] Read Ch6 schemas and Ch7 principals model end-to-end to confirm they're build-ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)