### PR TITLE
fix(sessions): stop missions vanishing or sticking on "running"

### DIFF
--- a/app/src/components/mission-board-columns.ts
+++ b/app/src/components/mission-board-columns.ts
@@ -19,7 +19,7 @@ export function buildMissionBoardColumns(
       onAdd: onNewMission,
       addLabel: labels.newMission,
     },
-    { id: "needs_you", label: labels.needsYou, statuses: ["needs_you"] },
+    { id: "needs_you", label: labels.needsYou, statuses: ["needs_you", "error"] },
     { id: "done", label: labels.done, statuses: ["done", "cancelled"] },
   ];
 }

--- a/engine/houston-engine-core/src/agents/activity.rs
+++ b/engine/houston-engine-core/src/agents/activity.rs
@@ -149,3 +149,121 @@ pub fn set_status_by_session_key(
     write_json(root, FILE, &items)?;
     Ok(Some(result))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn seed_activity(root: &Path, session_key: Option<&str>, status: &str) -> Activity {
+        let activity = create(
+            root,
+            NewActivity {
+                title: "Test mission".into(),
+                description: String::new(),
+                agent: None,
+                worktree_path: None,
+                provider: None,
+                model: None,
+            },
+        )
+        .expect("create activity");
+        let updates = ActivityUpdate {
+            status: Some(status.to_string()),
+            session_key: session_key.map(str::to_string),
+            ..ActivityUpdate::default()
+        };
+        update(root, &activity.id, updates).expect("seed status")
+    }
+
+    #[test]
+    fn flips_running_to_needs_you_when_queued_turn_cancelled() {
+        // Repro of the "stuck on running" bug: the desktop UI optimistically
+        // writes status=running on send, then the queued turn is cancelled
+        // before run_start spawns the subprocess. set_status_by_session_key
+        // must reset the row to a terminal status so the board doesn't show
+        // a permanently-spinning mission.
+        let dir = tempfile::TempDir::new().unwrap();
+        let seeded = seed_activity(dir.path(), Some("chat-abc"), "running");
+
+        let result = set_status_by_session_key(dir.path(), "chat-abc", "needs_you")
+            .expect("status flip");
+
+        let updated = result.expect("matching activity found");
+        assert_eq!(updated.id, seeded.id);
+        assert_eq!(updated.status, "needs_you");
+
+        let persisted = list(dir.path()).unwrap();
+        assert_eq!(persisted.len(), 1);
+        assert_eq!(persisted[0].status, "needs_you");
+    }
+
+    #[test]
+    fn flips_running_to_error_when_start_fails_early() {
+        // Repro of the "stuck on running" bug on the early-failure path:
+        // run_start returns Err before reaching its end-flip, the outer
+        // wrapper must surface that as status=error on the activity row.
+        let dir = tempfile::TempDir::new().unwrap();
+        let seeded = seed_activity(dir.path(), Some("chat-xyz"), "running");
+
+        let result =
+            set_status_by_session_key(dir.path(), "chat-xyz", "error").expect("status flip");
+
+        let updated = result.expect("matching activity found");
+        assert_eq!(updated.id, seeded.id);
+        assert_eq!(updated.status, "error");
+    }
+
+    #[test]
+    fn matches_legacy_activity_id_when_session_key_missing() {
+        // Legacy rows created before `session_key` was persisted are
+        // addressable via the `activity-{id}` convention. The session
+        // lifecycle relies on this fallback to flip those rows out of
+        // their stale boot status.
+        let dir = tempfile::TempDir::new().unwrap();
+        let seeded = seed_activity(dir.path(), None, "running");
+        let legacy_key = format!("activity-{}", seeded.id);
+
+        let result = set_status_by_session_key(dir.path(), &legacy_key, "needs_you")
+            .expect("status flip");
+
+        let updated = result.expect("matching activity found via legacy id");
+        assert_eq!(updated.status, "needs_you");
+        // The fallback opportunistically backfills session_key so the next
+        // lookup hits the fast path.
+        assert_eq!(updated.session_key.as_deref(), Some(legacy_key.as_str()));
+    }
+
+    #[test]
+    fn returns_none_for_ad_hoc_session_with_no_board_row() {
+        // Ad-hoc sessions (no associated activity row) must not error —
+        // the lifecycle code paths interpret Ok(None) as "no row to
+        // flip" and continue.
+        let dir = tempfile::TempDir::new().unwrap();
+        seed_activity(dir.path(), Some("chat-other"), "running");
+
+        let result = set_status_by_session_key(dir.path(), "chat-nonexistent", "error")
+            .expect("call succeeds");
+
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn updates_timestamp_on_status_flip() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let seeded = seed_activity(dir.path(), Some("chat-ts"), "running");
+        let before = seeded.updated_at.clone().expect("seeded timestamp");
+
+        // chrono RFC3339 has millisecond precision; nudge the clock so the
+        // comparison is meaningful even on fast machines.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+
+        let result = set_status_by_session_key(dir.path(), "chat-ts", "needs_you")
+            .expect("status flip")
+            .expect("matching activity");
+        let after = result.updated_at.expect("post-flip timestamp");
+        assert!(
+            after > before,
+            "updated_at should advance on status change: before={before} after={after}"
+        );
+    }
+}

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -111,6 +111,7 @@ pub async fn start(
     params: StartParams,
 ) -> Result<String, crate::CoreError> {
     let session_key = params.session_key.clone();
+    let agent_dir = params.agent_dir.clone();
     let agent_path = params.agent_dir.to_string_lossy().to_string();
     let identity = SessionIdentity::new(agent_path.clone(), session_key.clone());
     let generation = rt.control.register(&identity).await;
@@ -135,6 +136,30 @@ pub async fn start(
             {
                 rt.control.finish(&identity).await;
                 tracing::warn!("[sessions] queued start failed: {e}");
+                // The optimistic UI flip already wrote `running` to the
+                // activity row when the user pressed send. If `run_start`
+                // bails before reaching its end-flip (e.g., `create_dir_all`
+                // failed, `seed_agent` failed), the row would stay stuck on
+                // `running` forever — visible as a permanently-spinning
+                // mission. Flip to `error` here so the board reflects the
+                // real terminal state.
+                match crate::agents::activity::set_status_by_session_key(
+                    &agent_dir,
+                    &session_key,
+                    "error",
+                ) {
+                    Ok(Some(_)) => {
+                        events.emit(HoustonEvent::ActivityChanged {
+                            agent_path: agent_path.clone(),
+                        });
+                    }
+                    Ok(None) => { /* ad-hoc session, no board row to flip */ }
+                    Err(activity_err) => {
+                        tracing::warn!(
+                            "[sessions] failed to flip activity on start failure: {activity_err} (session_key={session_key})"
+                        );
+                    }
+                }
                 events.emit(HoustonEvent::SessionStatus {
                     agent_path,
                     session_key,
@@ -176,6 +201,31 @@ async fn run_start(
     let _turn_guard = rt.acquire_turn(&identity).await;
     if rt.control.is_stale(&identity, generation).await {
         tracing::info!("[sessions] skipping cancelled queued turn session_key={session_key}");
+        // The desktop UI optimistically wrote `running` to the activity
+        // row when the user pressed send (see the comment at the
+        // `set_status_by_session_key("running")` call below). If we exit
+        // here without resetting, the row stays stuck on `running`
+        // forever — the kanban "running" column shows a permanently
+        // spinning mission for work that never actually started, because
+        // `cancel()` only kills the process / dequeues the turn and
+        // doesn't touch the activity file. Flip to `needs_you` so the
+        // user can retry, edit, or move to done.
+        let agent_path = agent_dir.to_string_lossy().to_string();
+        match crate::agents::activity::set_status_by_session_key(
+            &agent_dir,
+            &session_key,
+            "needs_you",
+        ) {
+            Ok(Some(_)) => {
+                events.emit(HoustonEvent::ActivityChanged { agent_path });
+            }
+            Ok(None) => { /* ad-hoc session, no board row to flip */ }
+            Err(e) => {
+                tracing::warn!(
+                    "[sessions] failed to flip cancelled queued activity: {e} (session_key={session_key})"
+                );
+            }
+        }
         rt.control.finish(&identity).await;
         return Ok(());
     }

--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -77,7 +77,9 @@ from being retried by the provider that rejected it.
 All writes: temp file + rename. Path-traversal safe via `houston-agent-files::safe_relative`.
 
 ## Activity statuses
-`queue` · `running` · `needs_you` · `done` · `cancelled`
+`running` · `needs_you` · `done` · `error`
+
+Source of truth: `ui/agent-schemas/src/activity.schema.json`. The board renders `error` inside the **needs you** column with a red border so failed sessions don't vanish. Any code path that may have flipped a row to `running` (optimistic UI write, engine `set_status_by_session_key("running")`) MUST guarantee a terminal status on exit — including cancel-of-queued and early start-failure, both handled in `engine/houston-engine-core/src/sessions/mod.rs`. Skipping the terminal flip leaves missions visibly stuck on "running" forever.
 
 ## Skills discovery
 Skills live at `.agents/skills/<name>/SKILL.md`. Houston mirrors to `.claude/skills/<name>` via symlink (Claude Code reads). Flat `.md` under `.agents/skills/` auto-migrated to `<name>/SKILL.md` on next `list_skills`.

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -37,6 +37,7 @@ export interface AIBoardProps {
   sessionKeyFor?: (activityId: string) => string
   runningStatuses?: string[]
   approveStatuses?: string[]
+  errorStatuses?: string[]
   /** Load persisted chat history for a session. Called once per session key when selected. */
   onLoadHistory?: (sessionKey: string) => Promise<FeedItem[]>
   /** Called with the loaded history so the parent can merge it into its
@@ -168,6 +169,7 @@ export function AIBoard({
   sessionKeyFor = defaultSessionKey,
   runningStatuses = ["running"],
   approveStatuses = ["needs_you"],
+  errorStatuses = ["error"],
   onLoadHistory,
   onHistoryLoaded,
   onNewPanelOpenerReady,
@@ -408,6 +410,7 @@ export function AIBoard({
         selectedId={selectedId}
         runningStatuses={runningStatuses}
         approveStatuses={approveStatuses}
+        errorStatuses={errorStatuses}
         onSelect={handleCardSelect}
         onDelete={onDelete ? handleDelete : undefined}
         onApprove={onApprove}

--- a/ui/board/src/kanban-board.tsx
+++ b/ui/board/src/kanban-board.tsx
@@ -15,6 +15,7 @@ export interface KanbanBoardProps {
   renderCard?: (item: KanbanItem) => React.ReactNode
   runningStatuses?: string[]
   approveStatuses?: string[]
+  errorStatuses?: string[]
   actions?: (item: KanbanItem) => React.ReactNode
   avatar?: React.ReactNode
   cardLabels?: KanbanCardLabels
@@ -32,6 +33,7 @@ export function KanbanBoard({
   renderCard,
   runningStatuses,
   approveStatuses,
+  errorStatuses,
   actions,
   avatar,
   cardLabels,
@@ -74,6 +76,7 @@ export function KanbanBoard({
           renderCard={renderCard}
           runningStatuses={runningStatuses}
           approveStatuses={approveStatuses}
+          errorStatuses={errorStatuses}
           actions={actions}
           avatar={avatar}
           cardLabels={cardLabels}

--- a/ui/board/src/kanban-card.tsx
+++ b/ui/board/src/kanban-card.tsx
@@ -38,6 +38,7 @@ export interface KanbanCardProps {
   onRename?: (newTitle: string) => void
   runningStatuses?: string[]
   approveStatuses?: string[]
+  errorStatuses?: string[]
   actions?: React.ReactNode
   avatar?: React.ReactNode
   labels?: KanbanCardLabels
@@ -53,6 +54,7 @@ export function KanbanCard({
   onRename,
   runningStatuses = ["running"],
   approveStatuses = ["needs_you"],
+  errorStatuses = ["error"],
   actions,
   avatar,
   labels,
@@ -61,6 +63,7 @@ export function KanbanCard({
   const l = { ...DEFAULT_LABELS, ...labels }
   const isRunning = runningStatuses.includes(item.status)
   const isNeedsApproval = approveStatuses.includes(item.status)
+  const isError = errorStatuses.includes(item.status)
   const [showConfirm, setShowConfirm] = useState(false)
   const [editing, setEditing] = useState(false)
   const [editValue, setEditValue] = useState(item.title)
@@ -130,9 +133,11 @@ export function KanbanCard({
           // otherwise) so toggling selection doesn't shift layout.
           isRunning
             ? "card-running-glow shadow-[0_2px_12px_rgba(59,130,246,0.12)]"
-            : selected
-              ? "border border-transparent"
-              : "border border-border/20 shadow-sm hover:shadow-md",
+            : isError
+              ? "border border-destructive/60 shadow-sm hover:shadow-md"
+              : selected
+                ? "border border-transparent"
+                : "border border-border/20 shadow-sm hover:shadow-md",
         )}
       >
         {/* Top row: agent info + action buttons */}

--- a/ui/board/src/kanban-column.tsx
+++ b/ui/board/src/kanban-column.tsx
@@ -15,6 +15,7 @@ export interface KanbanColumnProps {
   onRename?: (item: KanbanItem, newTitle: string) => void
   runningStatuses?: string[]
   approveStatuses?: string[]
+  errorStatuses?: string[]
   renderCard?: (item: KanbanItem) => React.ReactNode
   actions?: (item: KanbanItem) => React.ReactNode
   avatar?: React.ReactNode
@@ -33,6 +34,7 @@ export function KanbanColumn({
   onRename,
   runningStatuses,
   approveStatuses,
+  errorStatuses,
   renderCard,
   actions,
   avatar,
@@ -77,6 +79,7 @@ export function KanbanColumn({
                   onRename={onRename ? (title) => onRename(item, title) : undefined}
                   runningStatuses={runningStatuses}
                   approveStatuses={approveStatuses}
+                  errorStatuses={errorStatuses}
                   actions={actions?.(item)}
                   avatar={avatar}
                   labels={cardLabels}


### PR DESCRIPTION
## Summary

Fixes three paths that made missions disappear from the board or appear to spin forever.

1. **`status: "error"` was invisible.** No kanban column listed it in `statuses`, so any session that errored out got silently filtered out by `KanbanBoard`. Now rendered in the **Needs you** column with a `border-destructive/60` red border via a new `errorStatuses` prop threaded through `KanbanBoard → KanbanColumn → KanbanCard` (default `["error"]`).
2. **Cancel-of-queued left activity stuck on `"running"`.** When the user pressed send and then cancelled before `run_start` spawned the subprocess, the optimistic UI flip to `"running"` was never reversed — the stale-exit path at `sessions/mod.rs:177-181` returned `Ok(())` before reaching the end-flip. Now flips to `"needs_you"` + emits `ActivityChanged`.
3. **Early start-failure left activity stuck on `"running"`.** When `run_start` returned `Err` before reaching the end-flip (e.g. `create_dir_all` / `seed_agent` failed), the wrapper at `sessions/mod.rs:125-144` emitted a `SessionStatus` event but never touched the activity file. Now flips to `"error"` + emits `ActivityChanged`.

## Tests

5 new unit tests in `agents::activity` pin the `set_status_by_session_key` contract that both new call sites depend on:
- `flips_running_to_needs_you_when_queued_turn_cancelled` (repro of bug #2)
- `flips_running_to_error_when_start_fails_early` (repro of bug #3)
- `matches_legacy_activity_id_when_session_key_missing`
- `returns_none_for_ad_hoc_session_with_no_board_row`
- `updates_timestamp_on_status_flip`

\`cargo test --workspace\` and \`pnpm typecheck\` both green.

## Test plan

- [ ] Send a message, then immediately cancel before the agent spawns — activity should land in **Needs you**, not stay spinning in **Running**.
- [ ] Trigger an error mid-session (e.g., kill the provider CLI) — activity should appear in **Needs you** with a red border, not vanish.
- [ ] Cause an early start-failure (e.g., agent dir creation conflict) — activity should land in **Needs you** with a red border, not stay spinning.
- [ ] Normal happy path: send → reply → status flips to **needs_you** unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)