### PR TITLE
fix(chat): restore plus icon and left-align model picker

### DIFF
--- a/ui/chat/src/chat-input-attachments.tsx
+++ b/ui/chat/src/chat-input-attachments.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { ChangeEvent, ReactNode, RefObject } from "react";
-import { Paperclip } from "lucide-react";
+import { Plus } from "lucide-react";
 import { Popover, PopoverContent, PopoverTrigger } from "@houston-ai/core";
 import { AttachmentChip } from "./attachment-chip";
 
@@ -73,7 +73,7 @@ export function ChatInputAttachButton({
       className="flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground hover:bg-accent transition-colors"
       aria-label={ariaLabel}
     >
-      <Paperclip className="size-5" />
+      <Plus className="size-5" />
     </button>
   );
 

--- a/ui/chat/src/chat-input.tsx
+++ b/ui/chat/src/chat-input.tsx
@@ -182,7 +182,7 @@ export function ChatInput({
         </PromptInput>
 
         {footer && (
-          <div className="flex items-center px-1 pt-1">
+          <div className="flex items-center px-2.5 pt-1">
             {footer}
           </div>
         )}


### PR DESCRIPTION
## Summary

- Swap the chat composer's leading attach button icon from `Paperclip` back to `Plus` (`lucide-react`), matching the ChatGPT-style design.
- Align the model picker footer flush with the attach button's left edge by bumping the footer wrapper from `px-1` to `px-2.5` so it matches the composer's internal `p-2.5` content padding.

Both changes are confined to `ui/chat`; no app-side wiring touched.

Closes #205

## Files

- `ui/chat/src/chat-input-attachments.tsx` — `Paperclip` -> `Plus`
- `ui/chat/src/chat-input.tsx` — footer wrapper `px-1 pt-1` -> `px-2.5 pt-1`

## Test plan

- [x] `pnpm -F @houston-ai/chat typecheck` (clean)
- [x] `cd app && pnpm tsc --noEmit` — pre-existing unrelated error in `create-workspace-dialog.tsx:220` only; no new errors from this PR (verified by re-running on baseline)
- [x] Visual check in `pnpm tauri dev`: composer shows `+` icon; model picker footer's left edge aligns with the `+` button's left edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)