### PR TITLE
docs: harden engine design plan

### DIFF
--- a/engine-design/02-agent-folder.html
+++ b/engine-design/02-agent-folder.html
@@ -81,20 +81,21 @@
       <code>~/.houston/workspaces/...</code>. You can open it in Finder.
     </p>
     <p>
-      After Chapter 3 lands: inside a Linux runtime that runs alongside
-      the desktop app. On Linux, that's the host filesystem (same as
-      today). On Windows, it's the WSL2 filesystem, which Windows Explorer
-      exposes natively at <code>\\wsl$\Houston\...</code>. On Mac, it
-      lives inside the VM's disk image and is reached through the app's
-      Files panel, with an explicit Import and Download flow.
+      If Chapter 3 ships: inside a Linux runtime that runs alongside the
+      desktop app. On Linux, that's the host filesystem (same as today). On
+      Windows, it's the WSL2 filesystem, which Windows Explorer exposes at
+      <code>\\wsl$\Houston\...</code>. On Mac, it lives inside the VM's disk
+      image and is reached through the app's Files panel, with explicit
+      Import, Download, and Export flows.
     </p>
     <p>
-      The reason the folder moves is in Chapter 3. The short version: most
-      real users keep their data in Drive, Slack, Notion, and Gmail. They
-      don't browse <code>~/Documents</code>. Putting agents inside a Linux
-      runtime gives us per-agent isolation and ends the Windows tooling
-      tax. The cost is that "open in Finder" stops working uniformly. The
-      Files panel and the Download flow replace it.
+      The reason the folder might move is in Chapter 3. The short version:
+      most real users keep their data in Drive, Slack, Notion, and Gmail.
+      They don't browse <code>~/Documents</code>. Putting agents inside a
+      Linux runtime could give us per-agent isolation and reduce Windows
+      tooling differences. The cost is that host file access stops working
+      uniformly. The Files panel, Import, Download, and Export flows replace
+      direct host access where needed.
     </p>
 
     <h2>Schemas as source of truth</h2>

--- a/engine-design/03-where-engine-lives.html
+++ b/engine-design/03-where-engine-lives.html
@@ -35,16 +35,22 @@
   <main class="content">
     <div class="content-label">
       Chapter 03
-      <span class="status planned">Planned · M3 · ~3 months</span>
+      <span class="status planned">Spike-gated · M3 candidate</span>
     </div>
     <h1>Where the engine lives.</h1>
     <p class="lead">
       Today the engine runs natively on Mac, Windows, and Linux. Three
-      builds. Three sandboxing stories. Going forward, the engine always
-      runs inside a Linux runtime. One engine binary. Three host
-      runtimes: Apple <code>Virtualization.framework</code> on Mac, WSL2
-      on Windows, native Linux everywhere else.
+      builds. Three sandboxing stories. The proposed next step is a
+      Linux-runtime engine on Mac and Windows, native Linux everywhere
+      else. This is not a committed migration yet. It is a high-leverage
+      isolation bet that must pass hard measurements before we move user
+      data into it.
     </p>
+
+    <div class="callout callout-warning">
+      <div class="callout-label">Commitment rule</div>
+      <p>Do not schedule this as build work until the spike proves startup, memory, battery, entitlement, WSL install, migration, import/download, and support-story risks. If any one fails, redesign before building.</p>
+    </div>
 
     <h2>Why we're moving. Three concrete reasons.</h2>
 
@@ -96,11 +102,12 @@
       Linux and Mac first, Windows months later if at all.
     </p>
     <p>
-      A Linux runtime on Windows means we ship the Linux build of every
-      tool. The fork dies. Future tooling just works.
+      A Linux runtime on Windows means we can ship the Linux build of most
+      tools. That reduces fork pressure and Windows-specific patching. It
+      does not remove the need to test every bundled CLI on Windows hosts.
     </p>
 
-    <h2>The answer: one engine binary, three host runtimes</h2>
+    <h2>The target: one Linux operating profile</h2>
 
     <div class="diagram">
       <div class="host-grid">
@@ -120,12 +127,12 @@
           <div class="engine-pill">houston-engine<div class="engine-sub">Linux build</div></div>
         </div>
         <div class="host-card">
-          <div class="host-name">Cloud (Fly Machine)</div>
+          <div class="host-name">Cloud runtime</div>
           <div class="runtime-pill">Linux microVM</div>
           <div class="engine-pill">houston-engine<div class="engine-sub">Linux build</div></div>
         </div>
       </div>
-      <div class="caption">Same Linux binary every place. Only the host runtime changes.</div>
+      <div class="caption">Same Linux operating profile every place. Separate artifacts still exist for CPU architecture and packaging.</div>
     </div>
 
     <h2>Why not a custom hypervisor</h2>
@@ -138,13 +145,17 @@
         <strong>macOS:</strong> Apple
         <code>Virtualization.framework</code>. Ships with the OS since
         macOS 11. Boots a Linux guest in 1-3 seconds on Apple Silicon
-        with a slim image. Apple owns the kernel-side work. We own the
-        wrapper.
+        with a slim image if our measurements prove it. Apple owns the
+        kernel-side work. We own the wrapper, image, persistence, updates,
+        logs, and failure UX.
       </li>
       <li>
         <strong>Windows:</strong> WSL2. Pre-installed on Windows 11.
-        One-command install on Windows 10 (<code>wsl --install</code>).
-        File Explorer mounts the guest filesystem at
+        Usually present on Windows 11. One-command install on many
+        Windows 10 machines (<code>wsl --install</code>), but corporate
+        laptops may block virtualization, Store installs, or WSL distro
+        registration.
+        File Explorer can mount the guest filesystem at
         <code>\\wsl$\Houston\</code> without us doing anything. Microsoft
         owns the kernel-side work. We own the registration.
       </li>
@@ -153,8 +164,8 @@
         natively. Per-agent UIDs work directly.
       </li>
       <li>
-        <strong>Cloud:</strong> a Fly Machine (or equivalent) is already
-        a Linux microVM. The engine runs natively inside it.
+        <strong>Cloud:</strong> candidate platforms such as Fly Machines
+        already provide Linux microVMs. The engine runs natively inside them.
       </li>
     </ul>
     <p>
@@ -163,10 +174,11 @@
       guest containing the engine binary.
     </p>
 
-    <h2>File flow</h2>
+    <h2>File flow, migration, and rollback</h2>
     <p>
-      The agent folder lives inside the Linux runtime. Bytes get in and
-      out through three paths.
+      If this ships, the agent folder lives inside the Linux runtime.
+      That changes a user-data root, so it needs an idempotent migration
+      and an escape hatch. Bytes get in and out through four paths.
     </p>
     <ol>
       <li>
@@ -186,14 +198,28 @@
         reads the file inside the runtime, streams it to Tauri, Tauri
         writes it to the host's Downloads folder and reveals it.
       </li>
+      <li>
+        <strong>Migration/export.</strong> First launch after upgrade copies
+        existing <code>~/.houston/workspaces</code> into the runtime, verifies
+        checksums, leaves the host copy untouched, and records a reversible
+        migration marker. Export produces a normal folder backup.
+      </li>
     </ol>
     <p>
       On Windows specifically, WSL2 also exposes the guest filesystem at
       <code>\\wsl$\Houston\</code> in Explorer. Users can browse it
       natively if they want. That is a bonus, not a contract: the canonical
-      path on every OS is Import and Download, and Houston does not depend
-      on host filesystem visibility.
+      path on every OS is Import, Download, and Export. Houston must not
+      depend on host filesystem visibility for correctness.
     </p>
+
+    <h2>What must stay native-host owned</h2>
+    <ul>
+      <li><strong>OS pickers and reveal-in-file-manager.</strong> Tauri host shell still owns them.</li>
+      <li><strong>Crash reporting and logs.</strong> Host must collect both app logs and runtime engine logs for Report bug.</li>
+      <li><strong>Updates.</strong> App update must update runtime image, engine binary, and bundled CLIs as one signed unit.</li>
+      <li><strong>Recovery.</strong> If runtime fails to boot, user sees a visible recovery screen with export/repair options.</li>
+    </ul>
 
     <h2>The new pieces of code</h2>
     <table>
@@ -228,8 +254,8 @@
         </tr>
         <tr>
           <td>Download / Import routes</td>
-          <td><code>engine/houston-engine-server/src/routes/files.rs</code></td>
-          <td>Already partly there for project files. Needs binary download (the project file route is text-only today; see the engine-protocol KB).</td>
+          <td><code>engine/houston-engine-server/src/routes/agent_files.rs</code></td>
+          <td>Import-bytes exists. Project read is text-only today. Runtime mode needs binary download, folder export, checksum verification, and host-side save/reveal.</td>
         </tr>
       </tbody>
     </table>
@@ -247,10 +273,10 @@
     </p>
     <p>
       Timeline is usually a few weeks if the request is clean, longer if
-      Apple has follow-up questions. <strong>Open the ticket the moment
-      M3 is greenlit, not when the code is written.</strong> Without it,
-      the runtime startup call returns an error and the app silently
-      fails to boot.
+      Apple has follow-up questions. <strong>Open the ticket early, while
+      M3 is still being validated, not when the code is written.</strong> Without it,
+      the runtime startup call returns an error. That error must be visible
+      and reportable, never a silent boot failure.
     </p>
 
     <h2>Numbers we need to confirm before committing</h2>
@@ -282,16 +308,17 @@
     <h2>Open question: Windows machines without virtualization</h2>
     <p>
       Some corporate laptops have virtualization disabled in BIOS. Some
-      older CPUs lack the required extensions. Houston needs a clear
-      install-time check: if the host cannot run WSL2, show a one-screen
-      explanation and a link to the IT-admin instructions. We do not try
-      to run the engine natively as a fallback. That preserves a single
-      operating profile.
+      older CPUs lack the required extensions. Some IT policies block WSL
+      registration. Houston needs an install-time check and an upgrade-time
+      check before moving data. Recommended default for beta: keep native
+      engine available as a visible fallback until runtime success rates
+      are measured. Remove fallback only after data says support cost is
+      lower than divergence cost.
     </p>
 
     <div class="callout callout-success">
       <div class="callout-label">The big simplification</div>
-      <p>Desktop and cloud become the same engine. Per-agent isolation becomes possible on every OS. The Windows tooling fork goes away. The cost is a runtime supervisor we don't fully own (Apple's and Microsoft's), an entitlement we have to ask for, and a Download flow we have to build first-class.</p>
+      <p>Desktop and Cloud move toward one Linux operating profile. Per-agent kernel isolation becomes possible on supported machines. Windows-specific tool patches shrink. The cost is a runtime supervisor we do not fully own, an entitlement we have to win, and Import/Download/Export flows we have to build first-class.</p>
     </div>
 
     <div class="tech-box">

--- a/engine-design/04-message-flow.html
+++ b/engine-design/04-message-flow.html
@@ -35,14 +35,21 @@
   <main class="content">
     <div class="content-label">
       Chapter 04
-      <span class="status partial">Partial · finishes in M1</span>
+      <span class="status partial">Target · M1a reliability</span>
     </div>
     <h1>How a message flows through.</h1>
     <p class="lead">
       This is the most important diagram in the guide. If you remember
-      only one thing, remember this one. The flow shown here is the
-      <em>target</em> flow, with reliability tables in place.
+      only one thing, remember this one: accept work durably first, then
+      run it. The flow shown here is the <em>target</em> flow for M1
+      reliability. It does not claim app-close survival until the detached
+      worker exists.
     </p>
+
+    <div class="callout callout-info">
+      <div class="callout-label">Reliability contract</div>
+      <p>M1 guarantees accepted turns are recorded, reconnects can replay recent stream events, engine crashes produce visible retry state, and scheduled triggers are audited. M1 does not guarantee an in-flight CLI keeps running after the engine process dies. That needs the worker in Chapter 6.</p>
+    </div>
 
     <div class="flow-list">
       <div class="flow-step">
@@ -116,7 +123,7 @@
           <div class="num">09</div>
           <div>
             <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">Desktop UI</span></div>
-            <div class="action">Broadcasts the chunk over the WebSocket. UI renders it live. Broadcast happens immediately, even before the batched DB flush.</div>
+            <div class="action">Broadcasts the chunk over the WebSocket only after the batch that contains it has been accepted by SQLite. The batch window is small, but durability still comes before user-visible delivery.</div>
           </div>
         </div>
       </div>
@@ -146,15 +153,16 @@
       </div>
     </div>
 
-    <p style="font-size: 13px; color: var(--gray-500); text-align: center; margin-top: -16px; margin-bottom: 32px;">Green steps are SQLite writes. Every byte the user sees is journaled to disk first.</p>
+    <p style="font-size: 13px; color: var(--gray-500); text-align: center; margin-top: -16px; margin-bottom: 32px;">Green steps are SQLite writes. Anything rendered as durable must be written first.</p>
 
     <h2>The key insight</h2>
     <p>
       <strong>Writes to the database happen BEFORE the work, not
       AFTER.</strong> The turn row is inserted the moment the user's
       message is accepted, well before the CLI subprocess is even spawned.
-      Each streaming chunk is logged before being broadcast (batched, but
-      committed within ~50ms).
+      Each streaming chunk is assigned a sequence number and written in a
+      small batch before broadcast. If SQLite is backpressured, the stream
+      slows down; it does not pretend data is durable before it is.
     </p>
     <p>
       That single ordering decision is what makes everything else work.
@@ -162,17 +170,18 @@
 
     <h2>What this buys you</h2>
     <ul>
-      <li><strong>Refresh mid-stream.</strong> The next page load replays from <code>turn_stream</code>. The user sees the streaming response continue.</li>
-      <li><strong>Engine crash between turns.</strong> The restarted engine sweeps the <code>turns</code> table, finds the orphan, surfaces a retry. The user clicks once and continues.</li>
-      <li><strong>Network blip during streaming.</strong> The client reconnects with <code>since_seq</code> and gets the gap from <code>events_outbox</code>.</li>
-      <li><strong>Cron fires at 7am while engine is restarting.</strong> The <code>cron_runs</code> audit log catches up on the next boot.</li>
-      <li><strong>Safe retry from the client.</strong> The same <code>turnId</code> won't run the turn twice. The server treats it as idempotent.</li>
+      <li><strong>Refresh mid-stream.</strong> The next page load replays committed chunks from <code>turn_stream</code>.</li>
+      <li><strong>Engine crash before spawn.</strong> The restarted engine sweeps <code>turns</code>, finds queued/running orphans, and surfaces retry.</li>
+      <li><strong>Network blip during streaming.</strong> The client reconnects with <code>sinceSeq</code> and gets recent gaps from <code>events_outbox</code>.</li>
+      <li><strong>Cron fires while engine is restarting.</strong> <code>trigger_runs</code> records due work and catch-up policy decides whether to run or mark skipped.</li>
+      <li><strong>Safe client retry.</strong> Same <code>turnId</code> cannot create duplicate work.</li>
     </ul>
     <p>
-      What this does NOT buy you on its own: engine restart MID-stream
-      survives the bounce. The CLI subprocess is a child of the engine,
-      so killing the engine kills the CLI. To survive that, we need the
-      detached <code>houston-turn-worker</code> from Chapter 6.
+      What this does NOT buy you on its own: engine restart mid-stream
+      survives the bounce. Today the CLI subprocess is a child of the
+      engine, so killing the engine kills the CLI. To survive that, we
+      need the detached <code>houston-turn-worker</code> from Chapter 6
+      or a different process-lifecycle contract.
     </p>
 
     <h2>Protocol changes you need to know</h2>
@@ -193,9 +202,10 @@
         with <code>{ turnId, fromSeq, items }</code> for replay.
       </li>
       <li>
-        <strong>WS subscription gains <code>since_seq</code>:</strong>
-        client reconnect sends the last seen sequence number, server
-        replays from <code>events_outbox</code>.
+        <strong>WS subscription gains <code>sinceSeq</code>:</strong>
+        client reconnect sends the last seen global event sequence number,
+        server replays authorized events from <code>events_outbox</code>.
+        Replay must run the same scope checks as fresh events.
       </li>
     </ul>
 
@@ -206,7 +216,7 @@
       What's missing:
     </p>
     <ul>
-      <li>The four SQLite tables (<code>turns</code>, <code>turn_stream</code>, <code>events_outbox</code>, <code>cron_runs</code>). See Chapter 6.</li>
+      <li>The four SQLite tables (<code>turns</code>, <code>turn_stream</code>, <code>events_outbox</code>, <code>trigger_runs</code>). See Chapter 6.</li>
       <li>The rule of writing before doing. Today persistence is async, fire-and-forget via <code>tokio::spawn</code>.</li>
       <li>Streaming deltas are explicitly dropped from persist today (<code>engine/houston-agents-conversations/src/session_runner.rs:405-406</code>) because they get replaced by their finals. The redesign keeps them in <code>turn_stream</code> for replay. Different problem, different table. The UI behavior stays the same.</li>
       <li>Client-supplied <code>turnId</code> + retry semantics.</li>
@@ -216,11 +226,10 @@
     <h2>The five failure modes this prevents</h2>
     <p>
       Chapter 5 walks through what goes wrong because these tables aren't
-      there. Chapter 6 covers the fix. The fifth one is the one most
-      people miss: the CLI subprocess hangs without exiting. Without a
-      <code>started_at</code> timestamp and a sweep job, the engine has
-      no way to know a turn has been "running" for an hour with no
-      output.
+      there. Chapter 6 covers the fix. The one people miss: the CLI
+      subprocess hangs without exiting. Without <code>started_at</code>,
+      <code>last_heartbeat_at</code>, and a sweep job, the engine has no
+      way to know a turn has been running for an hour with no output.
     </p>
 
     <div class="tech-box">

--- a/engine-design/05-conversations-die.html
+++ b/engine-design/05-conversations-die.html
@@ -39,16 +39,16 @@
     </div>
     <h1>Why conversations die today.</h1>
     <p class="lead">
-      The engine writes to disk only after the work is done. Everything in
-      flight lives in memory. In-memory means it dies when the process
-      dies, when the user closes the app, when the network blips. Five
-      failure modes. Same root cause.
+      Today too much session state is either in memory or persisted after
+      the user already saw it. In-memory state dies when the process dies.
+      Late persistence means accepted work can disappear. Six failure
+      modes, two fixes: durable turn records now, detached workers later.
     </p>
 
     <div class="fail-grid">
       <div class="fail-card">
         <div class="label">Failure mode #1</div>
-        <p><strong>User closes the app mid-stream.</strong> This is the most common one and it has nothing to do with crashes. The user clicks the red button, the app exits, the engine subprocess exits with it, the in-flight assistant tokens vanish. The user reopens Houston and the message is gone. Today this happens dozens of times a day in the dev loop alone.</p>
+        <p><strong>User closes the app mid-stream.</strong> This is common and it is not a crash. The desktop exits, the supervised engine exits, the provider CLI dies with it. Four tables alone can preserve accepted input and streamed chunks already committed, but they cannot keep the CLI alive. Full survival needs the detached worker.</p>
       </div>
 
       <div class="fail-card">
@@ -58,17 +58,17 @@
 
       <div class="fail-card">
         <div class="label">Failure mode #3</div>
-        <p><strong>Engine crashes mid-stream.</strong> Whatever the assistant had already streamed: gone. Database has nothing. The user thinks the agent is broken.</p>
+        <p><strong>Engine crashes mid-stream.</strong> Committed chunks can be replayed after M1. The in-flight provider process still dies unless the worker owns it. User should see "interrupted, retry" with preserved partial output, not a blank disappearance.</p>
       </div>
 
       <div class="fail-card">
         <div class="label">Failure mode #4</div>
-        <p><strong>WebSocket reconnects after a network blip.</strong> Server has no record of what events it pushed during the disconnect. The frontend has to refetch state and pray nothing slipped through.</p>
+        <p><strong>WebSocket reconnects after a network blip.</strong> Current clients refetch active queries after reconnect because events are not replayed. That is good as a safety net, but not enough for exact stream continuity. M1 adds an outbox and sequence-based replay.</p>
       </div>
 
       <div class="fail-card">
         <div class="label">Failure mode #5</div>
-        <p><strong>Cron fires while engine is restarting.</strong> The 7am alarm rings, the engine is rebooting, the fire is dropped silently. No log, no alert, no catch-up. Verified in <code>engine/houston-scheduler/src/cron_job.rs</code>: missed crons fire once on next boot if the schedule is past-due, but there's no record of how many fires were missed.</p>
+        <p><strong>Cron fires while engine is restarting.</strong> Current active routines scheduler is in-process. A sleeping or restarting engine has no durable due-work ledger. M1 needs an audit table and explicit catch-up/skip policy for every scheduled trigger.</p>
       </div>
 
       <div class="fail-card">
@@ -79,15 +79,16 @@
 
     <h2>The pattern</h2>
     <p>
-      Notice the common thread. The engine writes to the database
-      <strong>after</strong> doing work, not <strong>before</strong>. So
-      anything happening between "before" and "after" lives only in
-      memory, and that memory belongs to a process that can die or a
-      socket that can disconnect.
+      Notice the common thread. Work acceptance, stream delivery, and
+      trigger firing need durable records before side effects. Anything
+      accepted but not recorded can disappear. Anything delivered but not
+      recorded cannot be replayed. Anything running without heartbeat or
+      lease cannot be diagnosed.
     </p>
     <p>
-      The fix is boring but life-changing. Flip the order. Add timestamps.
-      Add sequence numbers. Sweep orphans on boot. Chapter 6 covers how.
+      The fix is boring but life-changing. Flip the order. Add timestamps,
+      leases, sequence numbers, and replay windows. Sweep orphans on boot.
+      Make retry explicit. Chapter 6 covers how.
     </p>
 
     <div class="callout callout-warning">
@@ -102,7 +103,7 @@
       </a>
       <a href="06-four-tables.html" class="next">
         <div class="pager-label">Next →</div>
-        <div class="pager-title">The four tables that save everything</div>
+        <div class="pager-title">The reliability tables</div>
       </a>
     </div>
   </main>

--- a/engine-design/06-four-tables.html
+++ b/engine-design/06-four-tables.html
@@ -35,31 +35,40 @@
   <main class="content">
     <div class="content-label">
       Chapter 06
-      <span class="status planned">Planned · M1 · ~4 weeks</span>
+      <span class="status planned">M1a · 4-6 weeks</span>
     </div>
-    <h1>The four tables that save everything.</h1>
+    <h1>The four tables that make reliability explicit.</h1>
     <p class="lead">
-      Four new SQLite tables. That's the entire reliability story (almost,
-      see the worker section below). Not Temporal. Not a workflow engine.
-      Just four tables and one rule: write the row before doing the work.
+      Four new SQLite tables give Houston a durable turn ledger, durable
+      stream replay, a WS replay outbox, and a trigger audit log. They do
+      not magically keep a dead subprocess alive. That requires the detached
+      worker below.
     </p>
 
     <h2>The tables, with columns</h2>
 
     <h3><code>turns</code></h3>
     <pre><code>CREATE TABLE turns (
-  turn_id        TEXT PRIMARY KEY,        -- UUID v4, client-supplied
-  session_key    TEXT NOT NULL,           -- the conversation slot
-  agent_path     TEXT NOT NULL,           -- workspace/agent
-  principal_id   TEXT NOT NULL,           -- who initiated, see Ch7
-  status         TEXT NOT NULL,           -- queued | running | completed | cancelled | failed | timed_out
-  user_message   TEXT NOT NULL,           -- the input
-  result         TEXT,                    -- final assistant text or error code
-  error_code     TEXT,                    -- when status = failed
-  created_at     INTEGER NOT NULL,        -- unix ms
-  started_at     INTEGER,                 -- when CLI spawned
-  completed_at   INTEGER                  -- when terminal
-);
+	  turn_id        TEXT PRIMARY KEY,        -- UUID v4, client-supplied
+	  session_key    TEXT NOT NULL,           -- the conversation slot
+	  agent_path     TEXT NOT NULL,           -- workspace/agent
+	  principal_id   TEXT NOT NULL,           -- who initiated, see Ch7
+	  provider       TEXT NOT NULL,           -- claude | codex | gemini | ...
+	  model          TEXT,                    -- selected model, nullable only if provider default
+	  source         TEXT NOT NULL,           -- user | routine | webhook | mobile
+	  working_dir    TEXT NOT NULL,
+	  app_prompt_hash TEXT,                   -- prompt version used by app, not owned by engine
+	  trigger_run_id INTEGER,                 -- nullable, links automated starts
+	  status         TEXT NOT NULL,           -- queued | running | completed | cancelled | failed | timed_out
+	  user_message   TEXT NOT NULL,           -- the input
+	  result         TEXT,                    -- final assistant text or error code
+	  error_code     TEXT,                    -- when status = failed
+	  created_at     INTEGER NOT NULL,        -- unix ms
+	  started_at     INTEGER,                 -- when CLI spawned
+	  last_heartbeat_at INTEGER,              -- worker/engine liveness
+	  cancel_requested_at INTEGER,            -- cooperative cancel marker
+	  completed_at   INTEGER                  -- when terminal
+	);
 CREATE INDEX turns_session_idx ON turns(session_key, created_at);
 CREATE INDEX turns_status_idx  ON turns(status) WHERE status IN ('queued', 'running');</code></pre>
 
@@ -75,25 +84,29 @@ CREATE INDEX turns_status_idx  ON turns(status) WHERE status IN ('queued', 'runn
 
     <h3><code>events_outbox</code></h3>
     <pre><code>CREATE TABLE events_outbox (
-  seq            INTEGER PRIMARY KEY AUTOINCREMENT,   -- global monotonic
-  topic          TEXT NOT NULL,           -- session:X, agent:Y, scheduler, ...
-  event_type     TEXT NOT NULL,
-  payload_json   TEXT NOT NULL,
-  ts             INTEGER NOT NULL
-);
-CREATE INDEX events_topic_idx ON events_outbox(topic, seq);</code></pre>
+	  seq            INTEGER PRIMARY KEY AUTOINCREMENT,   -- global monotonic
+	  topic          TEXT NOT NULL,           -- session:X, agent:Y, scheduler, ...
+	  event_type     TEXT NOT NULL,
+	  scope_json     TEXT NOT NULL,           -- replay authorization scope
+	  payload_json   TEXT NOT NULL,
+	  ts             INTEGER NOT NULL
+	);
+	CREATE INDEX events_topic_idx ON events_outbox(topic, seq);</code></pre>
 
-    <h3><code>cron_runs</code></h3>
-    <pre><code>CREATE TABLE cron_runs (
-  id             INTEGER PRIMARY KEY AUTOINCREMENT,
-  routine_id     TEXT NOT NULL,
-  scheduled_at   INTEGER NOT NULL,        -- when it was supposed to fire
-  fired_at       INTEGER,                 -- when we actually fired (null if missed and we don't intend to catch up)
-  status         TEXT NOT NULL,           -- fired | missed | caught_up | skipped
-  turn_id        TEXT REFERENCES turns(turn_id),
-  notes          TEXT
-);
-CREATE INDEX cron_runs_routine_idx ON cron_runs(routine_id, scheduled_at);</code></pre>
+    <h3><code>trigger_runs</code></h3>
+    <pre><code>CREATE TABLE trigger_runs (
+	  id             INTEGER PRIMARY KEY AUTOINCREMENT,
+	  trigger_type   TEXT NOT NULL,           -- routine | webhook | mobile_push | ...
+	  trigger_id     TEXT NOT NULL,           -- routine id, webhook id, etc.
+	  scheduled_at   INTEGER,                 -- for routine triggers
+	  received_at    INTEGER NOT NULL,        -- when Houston accepted/refused it
+	  fired_at       INTEGER,                 -- when we actually fired (null if missed and we don't intend to catch up)
+	  status         TEXT NOT NULL,           -- accepted | fired | missed | caught_up | skipped | rejected
+	  turn_id        TEXT REFERENCES turns(turn_id),
+	  error_code     TEXT,
+	  notes          TEXT
+	);
+	CREATE INDEX trigger_runs_idx ON trigger_runs(trigger_type, trigger_id, received_at);</code></pre>
 
     <h2>The rule</h2>
     <p>
@@ -106,17 +119,17 @@ CREATE INDEX cron_runs_routine_idx ON cron_runs(routine_id, scheduled_at);</code
 3. Stream chunk         → INSERT turn_stream row(s), then broadcast
 4. CLI done             → UPDATE turns SET status = completed, completed_at
 5. Engine boots         → SELECT * FROM turns WHERE status IN ('queued','running')
-                          → mark orphaned (status = 'failed', error_code = 'engine_restart')
-                          → surface retry button to the user</code></pre>
+                          → queued turns resume
+                          → stale running turns become interrupted, unless a worker heartbeat proves they still live
+                          → surface retry/cancel/reattach in the UI</code></pre>
 
     <p>
-      Step 5 is the magic. On every boot, the engine looks for turns that
-      were "running" when the previous engine died. Those are orphans. The
-      user sees a retry button. They click it. The same <code>turn_id</code>
-      goes back into the system. The server recognizes the ID is terminal
-      and returns its outcome; the client decides to mint a new
-      <code>turn_id</code> and try again. Idempotency is at the server,
-      retry policy is at the client.
+      Step 5 is the contract. On every boot, the engine reconciles durable
+      state against real process liveness. Queued work can run. Completed
+      work can replay. Stale running work becomes interrupted unless the
+      detached worker proves it still owns the turn. Retrying an interrupted
+      turn must create a new <code>turn_id</code>; the old one remains an
+      audit record.
     </p>
 
     <h2>What four tables alone fix, and what they don't</h2>
@@ -124,12 +137,12 @@ CREATE INDEX cron_runs_routine_idx ON cron_runs(routine_id, scheduled_at);</code
       Be honest about scope. These tables alone fix:
     </p>
     <ul>
-      <li>Crash <strong>between</strong> turns. The orphan sweep finds it.</li>
-      <li>User closing the app mid-stream. On reopen, the engine is still running, the turn is still streaming, the client just reconnects to the WS with <code>since_seq</code> and replays from <code>events_outbox</code>.</li>
-      <li>Network blips during streaming. Same path: replay from outbox.</li>
-      <li>Missed crons. The next boot reads <code>cron_runs</code>, sees the missed fire, decides whether to catch up.</li>
+      <li>Crash before a turn spawns. The queued row is still present and can resume.</li>
+      <li>Refresh during streaming. Already-committed chunks replay from <code>turn_stream</code> and <code>events_outbox</code>.</li>
+      <li>Network blips during streaming. Same path: reconnect with <code>sinceSeq</code>, scope-check, replay.</li>
+      <li>Missed routines. The next boot reads <code>trigger_runs</code>, sees the missed fire, and decides whether to catch up.</li>
       <li>Client retry safety. The <code>turnId</code> is idempotent.</li>
-      <li>CLI subprocess hang. A sweep job checks <code>turns WHERE status = 'running' AND started_at &lt; now() - 10min</code> and surfaces a "still running, cancel?" prompt.</li>
+      <li>CLI subprocess hang. A sweep job checks <code>last_heartbeat_at</code> and surfaces a visible "still running, cancel?" state.</li>
     </ul>
     <p>
       What four tables do NOT fix on their own: <strong>engine crash MID-stream
@@ -150,39 +163,39 @@ CREATE INDEX cron_runs_routine_idx ON cron_runs(routine_id, scheduled_at);</code
     </p>
     <p>
       This is the architectural piece. Without it, "conversations never
-      die" is "conversations rarely die." With it, the promise is real.
-      It belongs in M4 because it's the riskiest piece; the four tables
-      get us 80% of the value first.
+      die" is false. With it, the promise becomes defensible. If product
+      wants app-close or engine-bounce survival in M1, the worker cannot wait
+      behind Cloud work. Make it M1b and test it directly.
     </p>
 
     <h2>Coexistence with <code>chat_feed</code></h2>
     <p>
-      Today's <code>chat_feed</code> holds final feed items keyed by the
-      provider session id. After M1, the same data lives in
-      <code>turn_stream</code> (deltas) and the final items derived on
-      read. Two paths:
+      Today's <code>chat_feed</code> holds feed items keyed by the provider
+      session id. M1 must avoid a permanent double-write system. Pick one
+      canonical table and make rollback explicit.
     </p>
     <ul>
-      <li><strong>Migrate then delete.</strong> One-shot migration copies <code>chat_feed</code> into <code>turn_stream</code> as kind <code>final</code>. New writes only go to <code>turn_stream</code>. Cleaner long-term.</li>
-      <li><strong>Double-write for a release.</strong> Both tables get the data, reads check <code>turn_stream</code> first, fall back to <code>chat_feed</code>. Safer for rollback.</li>
+      <li><strong>Canonical write path.</strong> New writes go only to <code>turn_stream</code>.</li>
+      <li><strong>Migration.</strong> Existing <code>chat_feed</code> rows migrate into <code>turn_stream</code> as committed items, with idempotent markers.</li>
+      <li><strong>Fallback window.</strong> Reads may fall back to <code>chat_feed</code> for one release if migration markers are missing. No indefinite compatibility layer.</li>
+      <li><strong>FTS.</strong> Search indexes rebuild from the canonical stream-derived feed, not two sources.</li>
     </ul>
     <p>
-      Pick double-write for the first M1 release, drop <code>chat_feed</code>
-      writes in the next release once we're confident, drop the table in
-      the release after. Three-release deprecation, standard playbook.
+      Do not ship long-lived double-write. It creates split-brain bugs and
+      makes replay hard to trust.
     </p>
 
     <h2>Backpressure and the bounded queue</h2>
     <p>
       Today the event queue in <code>engine/houston-events/src/queue.rs</code>
       is an <code>mpsc::unbounded_channel</code>. A webhook flood or a
-      runaway cron could balloon memory. M1 switches this to a bounded
+      runaway routine trigger could balloon memory. M1 switches this to a bounded
       channel with capacity 1024 and a documented drop policy:
     </p>
     <ul>
-      <li>Inputs whose source is <code>cron</code> coalesce: if two fires for the same <code>routine_id</code> are in flight, log a "skipped" row in <code>cron_runs</code> and drop the second.</li>
+      <li>Inputs whose source is <code>routine</code> coalesce: if two fires for the same <code>routine_id</code> are in flight, log a <code>skipped</code> row in <code>trigger_runs</code> and drop the second.</li>
       <li>Inputs whose source is <code>user</code> never drop. If the queue is full, return <code>503 UNAVAILABLE</code> with <code>Retry-After</code>.</li>
-      <li>Inputs whose source is <code>webhook</code> get a small per-source bucket (token bucket, 10/min default) and a <code>cron_runs</code>-style audit table.</li>
+      <li>Inputs whose source is <code>webhook</code> get a small per-source bucket (token bucket, 10/min default) and a <code>trigger_runs</code> audit row for each accepted or rejected attempt.</li>
     </ul>
     <p>
       Same write-before-do principle: refusing the request is fine,
@@ -195,7 +208,7 @@ CREATE INDEX cron_runs_routine_idx ON cron_runs(routine_id, scheduled_at);</code
       writes thousands of rows. Default retention: keep raw deltas for 7
       days, then compact to one <code>final</code> row per turn and drop
       the deltas. <code>events_outbox</code> retention: 24 hours
-      (replay window for reconnecting clients). <code>cron_runs</code>:
+      (replay window for reconnecting clients). <code>trigger_runs</code>:
       keep forever, it's an audit log and it's small.
     </p>
     <p>
@@ -205,12 +218,12 @@ CREATE INDEX cron_runs_routine_idx ON cron_runs(routine_id, scheduled_at);</code
 
     <div class="callout callout-info">
       <div class="callout-label">Why this isn't Temporal</div>
-      <p>Temporal is a workflow engine for orchestrating long-running multi-step business processes with replay semantics across many activities. Houston has one activity: run a CLI turn, capture the stream. That's a job, not a saga. Four tables are enough.</p>
+      <p>Temporal is a workflow engine for orchestrating long-running multi-step business processes with replay semantics across many activities. Houston's first reliability problem is narrower: accept a turn, run a CLI, capture the stream, recover honestly. SQLite plus a worker is enough until Houston has multi-step external workflows.</p>
     </div>
 
     <div class="tech-box">
       <div class="label">Migration order</div>
-      <p>SQLite migrations live in <code>engine/houston-db/src/migrations.rs</code>. New migrations drop in next to the existing four (<code>chat_feed</code>, <code>chat_feed_fts</code>, <code>engine_tokens</code>, <code>phone_access</code>). Each gets its own numbered migration file; existing data is preserved. Repos go in <code>engine/houston-db/src/repo_turns.rs</code>, <code>repo_turn_stream.rs</code>, <code>repo_events_outbox.rs</code>, <code>repo_cron_runs.rs</code>. Boot sweep job in <code>engine/houston-engine-server/src/main.rs</code> startup, just after migrations run.</p>
+      <p>SQLite migrations live in <code>engine/houston-db/src/migrations.rs</code>. First fix: reliability migrations must be checked and observable, not swallowed with <code>.ok()</code>. Add <code>turns</code>, <code>turn_stream</code>, <code>events_outbox</code>, and <code>trigger_runs</code>. Repos go in <code>engine/houston-db/src/repo_turns.rs</code>, <code>repo_turn_stream.rs</code>, <code>repo_events_outbox.rs</code>, and <code>repo_trigger_runs.rs</code>. Boot sweep belongs in server startup after migrations, before accepting new starts.</p>
     </div>
 
     <div class="pager">

--- a/engine-design/07-keeping-agents-apart.html
+++ b/engine-design/07-keeping-agents-apart.html
@@ -35,13 +35,13 @@
   <main class="content">
     <div class="content-label">
       Chapter 07
-      <span class="status planned">Walls 2+3 in M2 (~3w). Wall 1 in M3 (~3mo).</span>
+      <span class="status planned">M2 guards. M3 kernel wall if runtime passes gates.</span>
     </div>
     <h1>Keeping agents apart.</h1>
     <p class="lead">
-      Three independent walls between agents. Each one is enough to stop a
-      curious or jailbroken agent from snooping. Together, they make
-      accidental and adversarial cross-agent reads impossible.
+      Three walls protect three different attack paths. Credential isolation
+      stops token bleed. Scope checks stop API bleed. Only a kernel boundary
+      stops direct filesystem snooping by a jailbroken CLI.
     </p>
 
     <h2>The real threat model (why we care)</h2>
@@ -67,8 +67,9 @@
       workspace. We have to fix it.
     </p>
     <p>
-      The fix is three independent walls. None depends on the others to
-      work. Together they're belt, suspenders, and a kernel.
+      The fix is layered, not interchangeable. M2 makes important leaks
+      harder. M3 is what turns "please do not read that folder" into "the
+      process cannot open that folder."
     </p>
 
     <div class="walls">
@@ -97,7 +98,7 @@
       </div>
     </div>
 
-    <h2>Wall 1: per-agent Linux user (M3, needs Linux runtime)</h2>
+    <h2>Wall 1: per-agent Linux user (M3 candidate, needs runtime)</h2>
     <p>
       Each agent gets its own Linux user inside the runtime. Their folder
       is owned by them, mode 0700. When you send a message to the Sales
@@ -112,18 +113,17 @@
       descriptor it can use to open ClientB's directory.
     </p>
     <p>
-      This is why Chapter 3 (Linux runtime everywhere) exists. macOS and
-      Windows don't have a clean way to do per-agent UIDs natively without
-      a VM. Linux does. Putting a Linux runtime on every host means the
-      same wall exists everywhere.
+      This is why Chapter 3 exists. macOS and Windows do not give Houston a
+      portable per-agent UID story without a runtime. Linux does. The runtime
+      must prove startup, battery, memory, WSL, entitlement, and support
+      gates before this becomes a committed architecture.
     </p>
 
     <h2>Wall 2: per-agent credentials (M2, no VM required)</h2>
     <p>
-      Each agent has its own <code>~/.claude</code>, its own
-      <code>~/.composio</code>, its own <code>~/.codex</code>. When Sales
-      logs into Anthropic, the token sits in
-      <code>/home/hou_sales/.claude/</code>. HR can't see it.
+      Each agent gets its own Claude, Codex, Gemini, and Composio homes.
+      When Sales logs into a provider, its token sits under Sales-owned
+      credential storage, not the machine-wide home.
     </p>
     <p>
       This wall ships without a VM. The fix is small: when the engine
@@ -135,7 +135,9 @@
     </p>
     <p>
       Even on today's native engine, this is a real win: a compromised
-      agent gets that agent's tokens, not all of them.
+      agent gets that agent's tokens, not all provider tokens. It does not
+      stop the same process from reading another agent's files. That is Wall
+      1's job.
     </p>
 
     <h2>Wall 3: engine-level scope checks (M2, no VM required)</h2>
@@ -144,6 +146,11 @@
       principal's token have scope for this agent?" before doing anything.
       A user with Sales access trying to query HR's data gets a 403 before
       the engine even reaches for the filesystem.
+    </p>
+    <p>
+      This wall protects the engine API. It does not protect against a CLI
+      subprocess directly reading the local filesystem. Scope checks and
+      per-agent Linux users are both required for the strong claim.
     </p>
 
     <h3>The data model</h3>
@@ -199,18 +206,20 @@ CREATE TABLE principal_tokens (
 
     <div class="callout callout-success">
       <div class="callout-label">The headline</div>
-      <p>"My HR agent literally cannot leak salaries to my Sales agent, even if jailbroken." That isn't marketing copy. That's what the kernel enforces. ChatGPT Enterprise and Claude Teams put everyone in one tenant with one set of permissions. Houston's per-agent isolation is something they don't offer.</p>
+      <p>"My HR agent literally cannot leak salaries to my Sales agent, even if jailbroken" is only true after Wall 1 ships. Before that, the honest claim is narrower: Houston can separate provider credentials and reject out-of-scope API calls.</p>
     </div>
 
     <h2>What we ship without the VM (M2)</h2>
     <ul>
       <li>Per-agent <code>HOME</code> override at CLI spawn. Per-agent credential directories under <code>~/.houston/workspaces/&lt;W&gt;/&lt;A&gt;/.creds/</code>.</li>
       <li><code>principals</code> and <code>principal_tokens</code> tables.</li>
-      <li><code>require_scope</code> middleware on every route.</li>
+      <li><code>require_scope</code> middleware on every route that reads, writes, streams, downloads, or watches an agent path.</li>
+      <li>A route audit test that fails when a path-touching route lacks scope enforcement.</li>
       <li>Today's single device-bearer token migrates into a single principal with full scope. No UX change for solo users.</li>
+      <li>A clear product label: M2 is credential and API isolation, not kernel filesystem isolation.</li>
     </ul>
 
-    <h2>What needs the VM (M3)</h2>
+    <h2>What needs the runtime (M3, only after gates pass)</h2>
     <ul>
       <li><code>useradd hou_&lt;agent&gt;</code> for each agent, automated.</li>
       <li>Spawn the CLI subprocess as that user (<code>setuid</code> or equivalent).</li>
@@ -218,9 +227,18 @@ CREATE TABLE principal_tokens (
       <li>Per-agent credentials live under <code>/home/hou_&lt;agent&gt;/</code> instead of the workspace folder.</li>
     </ul>
 
+    <h2>Tests that make this real</h2>
+    <ul>
+      <li><strong>Filesystem denial.</strong> A Sales CLI tries to read HR's folder. It must fail with permission denied after Wall 1.</li>
+      <li><strong>API denial.</strong> A Sales-scoped token calls an HR route. It must return 403 before route logic runs.</li>
+      <li><strong>Credential split.</strong> Claude, Codex, Gemini, and Composio homes differ per agent. No provider reads the machine-wide home during agent runs.</li>
+      <li><strong>Mode enforcement.</strong> Agent folders are 0700. Runtime tests verify owner, group, setuid behavior, and failure modes.</li>
+      <li><strong>Regression harness.</strong> Every new route that accepts <code>workspace</code>, <code>agent</code>, <code>path</code>, or <code>session</code> gets a scope test.</li>
+    </ul>
+
     <div class="tech-box">
       <div class="label">What changes in code</div>
-      <p>M2: new tables in <code>engine/houston-db</code> (<code>repo_principals.rs</code>, <code>repo_principal_tokens.rs</code>). New middleware in <code>engine/houston-engine-server/src/middleware/scope.rs</code>. CLI spawn at <code>engine/houston-terminal-manager/src/cli_process.rs</code> gets a per-agent <code>HOME</code> override.<br><br>M3: CLI spawn gains a <code>setuid</code> step (Linux only, runs inside the runtime). Per-agent home dir resolution in <code>houston-agent-files</code>. New <code>provision_agent_user</code> helper that runs <code>useradd</code> the first time an agent is created.</p>
+      <p>M2: new tables in <code>engine/houston-db</code> (<code>repo_principals.rs</code>, <code>repo_principal_tokens.rs</code>). New middleware in <code>engine/houston-engine-server/src/middleware/scope.rs</code>. CLI spawn at <code>engine/houston-terminal-manager/src/cli_process.rs</code> gets a per-agent <code>HOME</code> override. Add route-audit tests in the server crate.<br><br>M3: CLI spawn gains a <code>setuid</code> step (Linux only, inside the runtime). Per-agent home dir resolution in <code>houston-agent-files</code>. New <code>provision_agent_user</code> helper runs <code>useradd</code> the first time an agent is created.</p>
     </div>
 
     <div class="pager">

--- a/engine-design/08-login.html
+++ b/engine-design/08-login.html
@@ -35,14 +35,13 @@
   <main class="content">
     <div class="content-label">
       Chapter 08
-      <span class="status partial">Partial · finishes in M3</span>
+      <span class="status partial">Partial · M2 native homes, M3 runtime users</span>
     </div>
     <h1>Logging in (still one click).</h1>
     <p class="lead">
-      Per-agent credentials sound expensive in clicks. They aren't. For
-      solo desktop users, one click logs in once and Houston brokers
-      tokens to agents. For Teams and Cloud, each agent gets its own
-      login by default for stronger isolation.
+      Per-agent credentials sound expensive in clicks. They do not have to
+      be. Solo desktop can default to brokered convenience. Strict agents,
+      Teams, and Cloud should default to separate provider homes.
     </p>
 
     <div class="flow-list">
@@ -57,7 +56,7 @@
         <div class="num">02</div>
         <div>
           <div class="from-to"><span class="actor">Desktop UI</span><span class="arrow">→</span><span class="actor">Engine</span></div>
-          <div class="action"><code>POST /v1/agents/Sales/providers/anthropic/login</code>.</div>
+          <div class="action"><code>POST /v1/agents/Sales/providers/anthropic/login</code> (new scoped route).</div>
         </div>
       </div>
       <div class="flow-step">
@@ -98,71 +97,76 @@
       <div class="flow-step">
         <div class="num">08</div>
         <div>
-          <div class="from-to"><span class="actor">Anthropic</span><span class="arrow">→</span><span class="actor">Browser</span></div>
-          <div class="action">Redirects to <code>houston://anthropic-callback?code=...</code>.</div>
+          <div class="from-to"><span class="actor">Anthropic</span><span class="arrow">→</span><span class="actor">Provider callback</span></div>
+          <div class="action">Completes the CLI-owned OAuth flow. Houston does not control this callback.</div>
         </div>
       </div>
       <div class="flow-step">
         <div class="num">09</div>
         <div>
-          <div class="from-to"><span class="actor">Browser</span><span class="arrow">→</span><span class="actor">Desktop shell</span></div>
-          <div class="action">Deep link delivered to the host shell (the OS routes <code>houston://</code> to the registered app).</div>
+          <div class="from-to"><span class="actor">Provider</span><span class="arrow">→</span><span class="actor">claude CLI</span></div>
+          <div class="action">CLI detects completion through its own callback or polling path.</div>
         </div>
       </div>
       <div class="flow-step">
         <div class="num">10</div>
         <div>
-          <div class="from-to"><span class="actor">Desktop shell</span><span class="arrow">→</span><span class="actor">Engine</span></div>
-          <div class="action">POSTs the OAuth code over the runtime's loopback port. <strong>The new piece.</strong></div>
+          <div class="from-to"><span class="actor">claude CLI</span><span class="arrow">→</span><span class="actor">Anthropic</span></div>
+          <div class="action">Exchanges provider-owned code and saves token in the agent provider home.</div>
         </div>
       </div>
       <div class="flow-step">
         <div class="num">11</div>
         <div>
-          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">claude CLI</span></div>
-          <div class="action">Hands the code back to the waiting CLI subprocess.</div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">Login state</span></div>
+          <div class="action">Observes CLI success, verifies provider status, records login state.</div>
         </div>
       </div>
       <div class="flow-step">
         <div class="num">12</div>
         <div>
-          <div class="from-to"><span class="actor">claude CLI</span><span class="arrow">→</span><span class="actor">Anthropic</span></div>
-          <div class="action">Exchanges the code for a token. Saves to <code>/home/hou_sales/.claude/</code>.</div>
+          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">Desktop UI</span></div>
+          <div class="action">WS event "Sales logged in". UI updates.</div>
         </div>
       </div>
       <div class="flow-step">
         <div class="num">13</div>
         <div>
-          <div class="from-to"><span class="actor">Engine</span><span class="arrow">→</span><span class="actor">Desktop UI</span></div>
-          <div class="action">WS event "Sales logged in". UI updates.</div>
+          <div class="from-to"><span class="actor">Houston OAuth</span><span class="arrow">→</span><span class="actor">Desktop shell</span></div>
+          <div class="action">Only Houston-owned OAuth flows use <code>houston://...</code> deep links.</div>
         </div>
       </div>
     </div>
-    <p style="font-size: 13px; color: var(--gray-500); text-align: center; margin-top: -16px; margin-bottom: 32px;">One click for the user. The new piece is steps 5 and 10, the host-to-runtime bridge.</p>
+    <p style="font-size: 13px; color: var(--gray-500); text-align: center; margin-top: -16px; margin-bottom: 32px;">One click for the user. Provider tokens stay inside the provider CLI flow. Houston only forwards the login URL out of the runtime and observes success.</p>
 
     <h2>What you already have</h2>
     <p>
-      This is the exact pattern Houston uses today for Google sign-in via
-      Supabase. A click in the UI starts an OAuth flow. The system
-      browser does the work. A custom URL scheme
+      Houston already has host-side OAuth plumbing for Google sign-in via
+      Supabase. A click in the UI starts a Houston-owned OAuth flow. The
+      system browser does the work. A custom URL scheme
       (<code>houston://...</code>) brings the result back into the app.
-      Same plumbing extends to per-provider logins.
+    </p>
+    <p>
+      Provider CLI logins are different. The current provider login route is
+      global (<code>/v1/providers/:name/login</code>). The future scoped
+      route should start a provider login for one agent home, but it should
+      not pretend Houston owns Anthropic or OpenAI callback URLs.
     </p>
 
     <h2>The new piece: host-to-runtime bridge</h2>
     <p>
-      When the engine lives inside a Linux runtime (Chapter 3), the OAuth
-      callback can't reach it directly. The browser redirects to
-      <code>houston://anthropic-callback?code=...</code>, which the Tauri
-      shell on the host catches. The shell then POSTs the code to the
-      engine over the runtime's localhost port.
+      When the engine lives inside a Linux runtime (Chapter 3), the host UI
+      must bridge two things: opening provider login URLs printed by a CLI,
+      and delivering Houston-owned deep links back to the engine. Do not mix
+      those flows.
     </p>
     <p>
       Two things to get right:
     </p>
     <ul>
-      <li><strong>Only loopback.</strong> The runtime's HTTP port is bound to the host's loopback interface only. Other apps on the host cannot reach it, the network cannot reach it. Same posture as today's native engine.</li>
-      <li><strong>One-time auth code, not a long-lived token.</strong> The deep link carries an OAuth code that's only useful for the immediate exchange. The actual provider token never crosses the bridge in plaintext.</li>
+      <li><strong>Only loopback.</strong> The runtime's HTTP port is bound to host loopback only. Same posture as today's native engine.</li>
+      <li><strong>Provider token stays in the provider home.</strong> Houston forwards provider login URLs and observes status. It does not shuttle provider tokens over the bridge.</li>
+      <li><strong>Houston-owned OAuth still uses deep links.</strong> Supabase and future Houston-branded OAuth can pass short-lived codes through <code>houston://...</code>. That is not the provider CLI path.</li>
     </ul>
 
     <h2>What about provider CLI callback URLs?</h2>
@@ -177,9 +181,9 @@
       <li>Waiting for the CLI subprocess to finish the exchange.</li>
     </ol>
     <p>
-      No <code>houston://</code> hijack needed in the common path; the
-      CLI handles its own callback. The deep link is only used for our
-      own OAuth flows (Supabase, anything Houston-branded).
+      No <code>houston://</code> hijack belongs in the common provider path;
+      the CLI handles its own callback. The deep link is only for Houston
+      OAuth flows such as Supabase.
     </p>
 
     <h2>Per agent vs broker</h2>
@@ -190,24 +194,27 @@
 
     <h3>Desktop solo user: broker by default</h3>
     <p>
-      One Claude login for the whole machine. Houston brokers tokens to
-      individual agents. The user clicks once. This is the right default
-      because nobody in practice wants to OAuth ten times for ten agents,
-      and the threat model (one human, the agents are slices of their
-      own work) is bounded.
+      One provider login for the whole desktop profile. Houston can seed or
+      broker agent provider homes for convenience. This is acceptable for a
+      solo user who treats agents as slices of one trust boundary.
+    </p>
+    <p>
+      It is not acceptable for "two clients, two legal boundaries." Desktop
+      needs a visible strict mode per agent or per workspace, before Teams
+      exists.
     </p>
 
     <h3>Teams or Cloud: per-agent by default</h3>
     <p>
-      Each agent gets its own Claude account. Strongest isolation. Costs
-      N clicks for N agents, but in a Teams context different humans own
-      different agents anyway, so the click cost is distributed. This is
-      the mode the regulated-industry pitch leans on.
+      Each agent gets its own provider home and its own login state. It may
+      still be the same human account, but tokens and tool grants are not
+      shared by default. This is the mode the regulated-industry pitch leans
+      on.
     </p>
 
     <div class="callout callout-info">
       <div class="callout-label">What works today</div>
-      <p>Single-account Anthropic, OpenAI, and Composio logins all work today, but they're machine-wide. The broker model is essentially what we have, minus the per-agent indirection. The work in M3 is the runtime-side plumbing (spawning the CLI as <code>hou_sales</code> inside the runtime) and the deep-link bridge.</p>
+      <p>Single-account Anthropic, OpenAI, and Composio logins work today, but they are machine-wide. The current engine route is global, not agent-scoped. M2 should add per-agent provider homes on native hosts. M3 should move those homes under per-agent Linux users if the runtime ships.</p>
     </div>
 
     <div class="tech-box">

--- a/engine-design/09-external-triggers.html
+++ b/engine-design/09-external-triggers.html
@@ -35,13 +35,13 @@
   <main class="content">
     <div class="content-label">
       Chapter 09
-      <span class="status partial">Webhooks in M4 · ~1 week</span>
+      <span class="status partial">Webhooks after M1 queue/replay</span>
     </div>
     <h1>External triggers.</h1>
     <p class="lead">
-      Five ways something outside Houston can wake up an agent. Four work
-      today in some form. One is mostly scaffolding waiting on a single
-      route.
+      Five trigger paths matter. Desktop chat, mobile chat, and routines are
+      real today. Slack-style inbound messages and public webhooks are
+      product work, not shipped features.
     </p>
 
     <h2>1. The user sends a message from the desktop</h2>
@@ -61,26 +61,33 @@
       Same engine route as desktop chat. Shipped.
     </p>
 
-    <h2>3. A Slack message arrives</h2>
+    <h2>3. A Slack-style inbound message arrives</h2>
     <p>
-      Houston supports two-way Slack sync. An incoming Slack thread maps
-      to an agent session; messages create user messages on the same
-      <code>POST /v1/agents/&lt;path&gt;/sessions</code> path under the
-      hood. The integration is shipped.
+      This is not shipped today. Houston can let agents use Slack through
+      Composio tools, and the UI has generic channel concepts, but there is
+      no dedicated engine Slack crate, route, or two-way sync handler in the
+      current repo.
+    </p>
+    <p>
+      Future shape: an inbound channel event maps to one agent session,
+      writes a <code>trigger_runs</code> row, starts a turn through the same
+      durable turn path as chat, and posts the answer back through the
+      channel adapter.
     </p>
 
     <h2>4. A cron fires</h2>
     <p>
       Each agent has routines. <code>0 7 * * *</code> runs at 7am every
-      day. Today the cron lives inside the engine as a tokio task that
-      sleeps until the fire time, then pushes a
-      <code>HoustonInput::Cron</code> onto the event queue, which
-      dispatches to the same chat-turn path.
+      day. Today the active scheduler lives inside
+      <code>engine/houston-engine-core/src/routines/scheduler.rs</code>.
+      It sleeps until the fire time and calls <code>run_routine</code>
+      through a <code>RoutineDispatcher</code>.
     </p>
     <p>
-      Verified in <code>engine/houston-scheduler/src/cron_job.rs:76-125</code>.
-      Today there is no persistent <code>cron_runs</code> table; missed
-      fires are dropped silently. Chapter 6 fixes that.
+      Current routine run history exists in the routines data model, but
+      there is no global SQL <code>trigger_runs</code> ledger tied to durable
+      turn replay. Chapter 6 adds that ledger and makes missed-fire policy
+      explicit.
     </p>
 
     <h2>5. A webhook arrives</h2>
@@ -89,20 +96,17 @@
       one routed to a specific agent.
     </p>
     <p>
-      Honest status: the typed <code>HoustonInput::Webhook</code> variant
-      and the dispatcher infrastructure exist in
-      <code>engine/houston-events/src/queue.rs</code> and
-      <code>engine/houston-events/src/dispatcher.rs</code>. But there is
-      <strong>no <code>InputHandler</code> registered for it</strong>,
-      and there is <strong>no HTTP route that constructs one</strong>.
-      Two-thirds of the plumbing is in place; the last third is the
-      route plus the handler.
+      Honest status: <code>engine/houston-events</code> has typed input
+      scaffolding, including <code>Webhook</code>, plus an unbounded queue.
+      That crate is not the central path for current chat or routines. There
+      is no public HTTP route, webhook token table, signature verification,
+      handler, durable trigger row, or session dispatch integration.
     </p>
     <p>
       The route: <code>POST /v1/hooks/&lt;route_token&gt;</code> in a new
       <code>engine/houston-engine-server/src/routes/hooks.rs</code>. The
-      handler: a small <code>WebhookHandler</code> that maps an incoming
-      payload to an agent session start.
+      handler must verify the hook token and provider signature, insert
+      <code>trigger_runs</code>, then start a durable turn.
     </p>
 
     <div class="callout callout-info">
@@ -112,12 +116,13 @@
 
     <h2>Bounded queue (M1 prerequisite)</h2>
     <p>
-      Today's event queue is unbounded
+      The old event queue is unbounded
       (<code>mpsc::unbounded_channel</code> at
       <code>engine/houston-events/src/queue.rs:36</code>). A webhook
-      flood would balloon memory. M1 switches this to bounded with
-      explicit drop policies (Chapter 6 covers the rules per source).
-      Without that change, opening
+      flood must never be allowed to balloon memory. M1 either wires a
+      bounded queue into the real trigger path or implements bounded intake
+      at the route layer, with explicit accept/reject audit rows. Without
+      that change, opening
       <code>POST /v1/hooks/...</code> to the world is a DoS waiting to
       happen.
     </p>
@@ -131,13 +136,15 @@
       through.
     </p>
     <p>
-      All five trigger sources share that same wake-up path. One
-      mechanism, five triggers.
+      Human chat, mobile chat, Slack-style inbound, webhook, and scheduled
+      routines should converge on the same durable acceptance path. Routines
+      may be woken by a central scheduler instead of a relay request, but
+      they still need the same <code>trigger_runs</code> and turn ledger.
     </p>
 
     <div class="tech-box">
       <div class="label">Where to look in the code</div>
-      <p>Webhook input type: <code>engine/houston-events/src/types.rs:12</code>. Convenience constructor: <code>types.rs:145-154</code>. Dispatcher: <code>engine/houston-events/src/dispatcher.rs</code>. Queue (unbounded today): <code>engine/houston-events/src/queue.rs:36</code>. Cron implementation: <code>engine/houston-scheduler/src/cron_job.rs:76-125</code>. Slack integration: <code>engine/houston-slack</code> (or its current name). Relay: <code>houston-relay/</code>. Missing piece for webhooks: new <code>engine/houston-engine-server/src/routes/hooks.rs</code> plus a registered <code>InputHandler</code>.</p>
+      <p>Webhook input scaffolding: <code>engine/houston-events/src/types.rs</code>. Old queue, unbounded today: <code>engine/houston-events/src/queue.rs:36</code>. Active routines scheduler: <code>engine/houston-engine-core/src/routines/scheduler.rs</code>. Routine runner: <code>engine/houston-engine-core/src/routines/runner.rs</code>. Relay: <code>houston-relay/</code>. Missing pieces for webhooks: route, token model, signature verification, bounded intake, <code>trigger_runs</code>, and durable session dispatch.</p>
     </div>
 
     <div class="pager">

--- a/engine-design/10-deployment.html
+++ b/engine-design/10-deployment.html
@@ -35,14 +35,14 @@
   <main class="content">
     <div class="content-label">
       Chapter 10
-      <span class="status planned">Planned · M4 · ~3 months</span>
+      <span class="status planned">Candidate · M4+ · separate product</span>
     </div>
-    <h1>Deployment: one binary, two homes.</h1>
+    <h1>Deployment: one engine contract, three homes.</h1>
     <p class="lead">
-      Same Linux engine binary. Three deployment surfaces (desktop,
-      self-hosted, Cloud). Almost zero divergence. The only difference is
-      whose computer the Linux runtime runs on, and whether there's a
-      control plane in front.
+      Desktop, self-hosted, and Cloud should share the same engine protocol
+      and core behavior. They will not be literally byte-for-byte identical:
+      desktop runtime packaging, self-host Docker/systemd, and Cloud control
+      plane all have different operational edges.
     </p>
 
     <div class="diagram">
@@ -67,19 +67,19 @@
           <div class="deploy-arrow">↓</div>
           <div class="deploy-layer">Houston Relay (wake on demand)</div>
           <div class="deploy-arrow">↓</div>
-          <div class="deploy-layer">Fly Machine (Linux microVM)</div>
+          <div class="deploy-layer">Linux runtime (candidate: Fly Machine)</div>
           <div class="deploy-arrow">↓</div>
           <div class="deploy-layer engine">houston-engine</div>
         </div>
       </div>
-      <div class="caption">The engine binary is byte-for-byte the same in all three.</div>
+      <div class="caption">Same engine contract. Different packaging and operations.</div>
     </div>
 
     <h2>Desktop mode</h2>
     <p>
-      The Linux engine binary, inside the host's Linux runtime (Chapter
-      3). Desktop shell talks to it over local networking on a loopback
-      port. No control plane, no relay.
+      Today desktop runs a native sidecar. If Chapter 3 passes its gates,
+      desktop can move the engine into the host's Linux runtime. The desktop
+      shell talks over local loopback. No control plane. No Cloud dependency.
     </p>
 
     <h2>Self-host mode (Always On)</h2>
@@ -88,24 +88,25 @@
       (<code>always-on/Dockerfile</code>) or systemd
       (<code>always-on/houston-engine.service</code>). The user puts a
       reverse proxy in front and binds <code>HOUSTON_BIND_ALL=1</code>.
-      Already shipped as scaffolding for power users; see
+      Shipped as scaffolding for power users; see
       <code>always-on/README.md</code>.
     </p>
 
     <h2>Cloud mode (Houston Cloud)</h2>
     <p>
-      The Linux engine binary, inside a Fly Machine per customer. A
-      control plane in front handles signup, billing, admin, and
-      provisioning. The relay routes inbound user traffic to the right
-      machine and wakes sleeping machines on demand.
+      Cloud is not implemented. <code>cloud/</code> is placeholder/TBD
+      today. The likely shape is one isolated Linux runtime per customer or
+      workspace, with a control plane in front for signup, billing, admin,
+      provisioning, wake, backup, and support.
     </p>
 
-    <h3>Why Fly Machines</h3>
+    <h3>Fly Machines are a candidate, not a decision</h3>
     <p>
-      Fly Machines are already Linux microVMs with first-class start and
-      stop APIs, per-region placement, and sub-second wake. We can move
-      to another platform later, but committing now means we can ship.
-      Hedging delays decisions; pick one and move.
+      Fly Machines fit the shape: Linux microVMs, start/stop APIs,
+      per-region placement, and wake-on-demand. But Cloud needs an RFC before
+      committing to a vendor. The decision must include volume behavior,
+      backup restore drills, region guarantees, cost under idle/active load,
+      support burden, and exit path.
     </p>
 
     <h3>The control plane</h3>
@@ -114,35 +115,39 @@
     </p>
     <ul>
       <li><strong>Signup and billing.</strong> Supabase Auth (already wired for desktop SSO) + Stripe for subscriptions.</li>
-      <li><strong>Provisioning.</strong> A small service that, on first login, creates a Fly Machine for the customer, mints their bearer token, and writes initial workspace state.</li>
+      <li><strong>Provisioning.</strong> A small service that, on first login, creates the customer's runtime, mints their bearer token, and writes initial workspace state.</li>
       <li><strong>Admin.</strong> Support tools: see a customer's recent errors, restart their machine, rotate their token.</li>
       <li><strong>Observability.</strong> Sentry (already used in desktop) gets a Cloud-scoped project. Per-machine log retention via Fly's built-in log shipping or BetterStack.</li>
+      <li><strong>Backups and restore.</strong> Automated snapshots are not enough. Restore must be rehearsed and timed.</li>
+      <li><strong>Abuse and quota controls.</strong> Public triggers, model spend, and long-running agents need rate limits from day one.</li>
+      <li><strong>Incident operations.</strong> A person must be able to answer: which customer is down, why, since when, and what changed?</li>
     </ul>
     <p>
-      Lives at <code>cloud/</code> (new). Probably TypeScript on Cloudflare Workers + Supabase for parity with the rest of our stack.
+      This belongs behind a separate Cloud design RFC. Do not hide it inside
+      engine runtime work.
     </p>
 
     <h3>Storage when machines sleep across hosts</h3>
     <p>
-      Fly volumes are pinned to a host. If a customer machine sleeps and
-      wakes on a different physical host, the volume needs to follow.
-      Two paths:
+      Any candidate platform has storage locality rules. On Fly, volumes are
+      pinned to a host. If a customer runtime sleeps and wakes elsewhere, the
+      volume needs to follow. Two paths:
     </p>
     <ul>
       <li><strong>Pinned host (default).</strong> Each customer's machine has one home host. Wake is fast, no copy needed. Cost: that host becomes a single point of failure for that customer.</li>
       <li><strong>Cold storage in R2/S3 (failover).</strong> A nightly snapshot of the volume into object storage. If the home host is unavailable, we restore on a new host. Cost: ~30 seconds of cold-start when failover triggers.</li>
     </ul>
     <p>
-      Ship with pinned host. Add the snapshot path the moment we have
-      paying customers.
+      Do not take paying Cloud customers until backup and restore are proven.
+      Pinned host can be the first private-beta path, but failover limits
+      must be explicit.
     </p>
 
     <h3>Data residency</h3>
     <p>
-      Each customer picks a region at signup (us-east, eu-west, ap-south).
-      Their Fly Machine and snapshots live there. The control plane is
-      global; only metadata (account, billing) lives outside the
-      customer's region.
+      Each customer picks a region at signup. Their runtime and snapshots
+      live there. The control plane may be global; only metadata such as
+      account and billing should live outside the customer's region.
     </p>
 
     <h3>Backups</h3>
@@ -153,38 +158,35 @@
 
     <h2>Sleeping engines</h2>
     <p>
-      For Cloud mode, engines sleep after N idle minutes (default 10).
-      They exit 0 gracefully. The relay holds the connection from the
-      next inbound request, calls Fly's start API, polls
-      <code>/v1/health</code>, then proxies through. Cold start target:
-      ~2 seconds. Acceptable for crons and webhooks; for active human
-      chats, engines stay sticky-hot during a session window.
+      For Cloud mode, engines may sleep after N idle minutes. The relay can
+      hold the next inbound request, call the platform start API, poll
+      <code>/v1/health</code>, then proxy through. This is only safe for
+      active chats after M1 durable replay and M1b detached workers exist.
     </p>
     <p>
-      All four trigger sources from Chapter 9 (chat, mobile, Slack
-      inbound, webhook) share the same wake-up path. Cron uses a slightly
-      different path: a central scheduler service decides when to wake
+      Planned trigger sources from Chapter 9 should share the same durable
+      wake-and-accept path. Routines use a central scheduler service to wake
       a machine, instead of the relay reacting to inbound traffic.
     </p>
 
     <h2>Pricing</h2>
     <p>
       Per VM-hour, or per agent-month. Either aligns with cost. The
-      Cloud product is "rent a Fly Machine that runs Houston Engine plus
-      our control plane around it." Self-hosters pay nothing to Houston
-      and run the same engine themselves. Desktop users pay nothing and
-      run the engine on their own laptop. All three meters touch the
-      same engine binary.
+      Cloud product is "rent a managed Houston runtime plus the control
+      plane around it." Self-hosters pay nothing to Houston and run the same
+      engine themselves. Desktop users pay nothing and run the engine on
+      their own laptop. All three meters touch the same engine protocol and
+      core code, with deployment-specific packaging.
     </p>
 
     <div class="callout callout-success">
       <div class="callout-label">The killer property</div>
-      <p>You can no longer have a "works on my Mac" bug, because there is no Mac engine. Every engine is the same Linux engine. The desktop just hosts the runtime.</p>
+      <p>The useful property is narrower and still valuable: fewer engine behavior differences across deployment targets. Runtime, packaging, networking, and operations still need platform-specific tests.</p>
     </div>
 
     <div class="tech-box">
       <div class="label">What's there already</div>
-      <p>Always-on Docker recipe: <code>always-on/Dockerfile</code> and <code>docker-compose.yml</code>, builds the engine from source. Relay: <code>houston-relay/</code>, a production Cloudflare Worker + Durable Object at <code>tunnel.gethouston.ai</code>. Tunnel client crate: <code>engine/houston-tunnel</code>. What's missing: Linux runtime supervisor on desktop (Chapter 3), control-plane app at <code>cloud/</code>, idle-exit logic in the engine, wake API in the relay, Fly Machines integration.</p>
+      <p>Always-on Docker recipe: <code>always-on/Dockerfile</code> and <code>docker-compose.yml</code>, builds the engine from source. Relay: <code>houston-relay/</code>, a Cloudflare Worker + Durable Object for mobile tunnel. Tunnel client crate: <code>engine/houston-tunnel</code>. <code>cloud/</code> is placeholder today. Missing: desktop Linux runtime supervisor, control-plane RFC and implementation, idle-exit logic, wake API, Cloud provisioning, backups, restore drills, quota controls, and operations runbooks.</p>
     </div>
 
     <div class="pager">

--- a/engine-design/11-roadmap.html
+++ b/engine-design/11-roadmap.html
@@ -35,116 +35,163 @@
   <main class="content">
     <div class="content-label">
       Chapter 11
-      <span class="status progress">In progress</span>
+      <span class="status progress">Gate plan</span>
     </div>
     <h1>The roadmap.</h1>
     <p class="lead">
-      Four milestones. Realistic sizes. Two of them run in parallel
-      because they're independent. Two of them are heavier than they
-      look. One parallel track starts on day one and has nothing to do
-      with code (Apple paperwork).
+      This roadmap separates reliability, isolation, runtime, triggers, and
+      Cloud. It does not hide risky work inside optimistic dates. Every big
+      promise has a gate and a test contract.
     </p>
 
     <h2>The shape</h2>
-<pre><code>Week                  0   1   2   3   4   5   6   7   8   9  10  11  12  13  14  15  16  17  18  19  20  21  22  23  24
-                      |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |   |
-M1 Reliability        [============ ~4 weeks ============]
-M2 Auth + credentials [======== ~3 weeks ========]
-                                                          (M1 + M2 ship together as a release)
-M3 Linux runtime                                          [================== ~3 months ==================]
-M4 Cloud foundation                                                                                       [================ ~3 months ================]
-Apple entitlement     [........................... weeks to months, asynchronous ...........................]
-VZ.framework spike    [===]   ← do this BEFORE locking M3 dates</code></pre>
+<pre><code>Track                         Gate / estimate
+M0 Plan cleanup               1 week
+M1a Durable turns             4-6 weeks after schema lock
+M1b Detached turn worker      3-4 weeks if "never die" is a product promise
+M2 Scopes + credentials       3-5 weeks, can overlap M1 with separate owner
+M3a Runtime spike             1-2 weeks before any M3 date is promised
+M3b Runtime build             3-4 months only if spike passes
+M4 Inbound triggers           after M1a, before Cloud
+M5 Cloud private beta         3-5 months with 2 engineers, separate RFC
+Apple entitlement             start immediately, async weeks to months</code></pre>
 
-    <h2>M1 — Reliability (~4 weeks)</h2>
+    <h2>M0 — Make the plan true (1 week)</h2>
+    <ul>
+      <li>Update design docs to match current repo facts.</li>
+      <li>Name shipped, partial, and proposed work separately.</li>
+      <li>Add acceptance tests for current weak spots before refactors: session start, stream persistence, WS reconnect, routine fire, auth token use.</li>
+      <li>Decide exact schema for <code>turns</code>, <code>turn_stream</code>, <code>events_outbox</code>, and <code>trigger_runs</code>.</li>
+      <li>Decide whether <code>chat_feed</code> migrates hard or gets one-release read fallback. Recommendation: canonical <code>turn_stream</code> writes, one-release read fallback only.</li>
+    </ul>
+
+    <h2>M1a — Durable turn acceptance and replay (4-6 weeks)</h2>
     <p>
-      <strong>Goal:</strong> conversations never drop bytes. The "my
-      message disappeared" failure mode goes away. Every byte the user
-      sees is journaled before broadcast.
+      <strong>Promise after M1a:</strong> accepted turns are recorded before
+      side effects. Committed stream chunks replay after refresh or network
+      reconnect. Stale work surfaces retry/cancel instead of disappearing.
     </p>
     <ul>
-      <li>Add the four SQLite tables: <code>turns</code>, <code>turn_stream</code>, <code>events_outbox</code>, <code>cron_runs</code>. Concrete schemas in Chapter 6.</li>
-      <li>Write rows BEFORE doing work. Sweep orphans on boot.</li>
-      <li>Client-supplied <code>turnId</code> with idempotent server semantics. Protocol bump.</li>
-      <li>WebSocket replay by sequence number on reconnect. New <code>since_seq</code> on subscribe.</li>
-      <li>Cron audit log plus missed-fire catch-up policy.</li>
-      <li>Bounded event queue with per-source drop rules.</li>
-      <li>Coexistence with <code>chat_feed</code>: double-write for this release, drop in the next.</li>
+      <li>Add checked SQLite migrations. Stop swallowing reliability migration failures with <code>.ok()</code>.</li>
+      <li>Add <code>turns</code>, <code>turn_stream</code>, <code>events_outbox</code>, and <code>trigger_runs</code>.</li>
+      <li>Add client-supplied <code>turnId</code> to session start request and idempotent server handling.</li>
+      <li>Insert the turn row before spawning Claude, Codex, Gemini, or any provider.</li>
+      <li>Write stream chunks before broadcasting them.</li>
+      <li>Add WS replay with <code>sinceSeq</code> and authorization checks on replay.</li>
+      <li>Add boot sweep: queued turns resume, stale running turns become interrupted unless a worker heartbeat owns them.</li>
+      <li>Add routine missed-fire policy through <code>trigger_runs</code>.</li>
+      <li>Add bounded intake for real trigger paths, not only the old unbounded event queue.</li>
     </ul>
     <p>
-      Mostly inserts and middleware. No architectural change. The 4-week
-      number assumes the schema is locked on day one. Slips to 5-6 weeks
-      if we discover the WS protocol bump rippling through more clients
-      than expected.
+      This is not "conversations never die." It is "Houston never lies about
+      accepted work, committed chunks, or retry state."
     </p>
 
-    <h2>M2 — Auth and credentials (~3 weeks, in parallel with M1)</h2>
+    <h2>M1b — Detached turn worker (3-4 weeks)</h2>
     <p>
-      <strong>Goal:</strong> Walls 2 and 3 from Chapter 7. No VM
-      required. Owned by a different engineer so M1 and M2 ship as one
-      release.
+      <strong>Promise after M1b:</strong> app close, engine restart, and
+      engine bounce do not kill an in-flight provider turn.
     </p>
     <ul>
-      <li>Typed tokens: <code>(principal_id, scopes)</code>. New tables: <code>principals</code> and <code>principal_tokens</code> in <code>houston-db</code>.</li>
-      <li><code>require_scope(token, agent_path)</code> middleware on every route that touches an agent.</li>
-      <li>Per-agent credentials: CLI spawn overrides <code>HOME</code> to a per-agent path under the agent's folder.</li>
-      <li>Migration: today's single device-bearer becomes one principal with full scope. No UX change for solo users.</li>
+      <li>Add <code>houston-turn-worker</code> as a small detached binary.</li>
+      <li>Worker owns provider subprocess and writes stream chunks directly to SQLite.</li>
+      <li>Engine attaches to worker by turn id after restart.</li>
+      <li>Worker heartbeat updates <code>last_heartbeat_at</code>.</li>
+      <li>Cancel is durable: set <code>cancel_requested_at</code>, worker cooperatively stops provider process.</li>
+      <li>Crash tests kill app, engine, worker, and provider process separately and assert visible state.</li>
     </ul>
     <p>
-      Middleware plus a few new tables. About 3 weeks. Does not require
-      Chapter 3, does not require a VM. Real isolation win shipped without
-      waiting for M3.
+      If the product says "conversations never die," M1b is mandatory. If
+      not, make the promise weaker and ship M1a first.
     </p>
 
-    <h2>M3 — Linux runtime everywhere (~3 months)</h2>
+    <h2>M2 — Scopes and per-agent credentials (3-5 weeks)</h2>
     <p>
-      <strong>Goal:</strong> Wall 1 from Chapter 7. The whole desktop now
-      runs the same Linux engine as Cloud. Per-agent Linux UIDs become
-      possible.
+      <strong>Promise after M2:</strong> engine API calls are scoped, and
+      provider credentials are separated per agent. This still is not kernel
+      filesystem isolation.
     </p>
     <ul>
-      <li>Runtime supervisor at <code>app/houston-tauri/runtime/</code>.</li>
-      <li>macOS: Apple <code>Virtualization.framework</code> wrapper with a slim Linux guest image.</li>
-      <li>Windows: WSL2 detect/install/register/start.</li>
-      <li>Linux: passthrough, no runtime.</li>
-      <li>Per-agent <code>useradd</code> automation inside the runtime.</li>
-      <li>CLI spawn as <code>hou_&lt;agent&gt;</code>.</li>
-      <li>Import and Download routes for file flow in and out of the runtime.</li>
-      <li>Apple <code>com.apple.security.virtualization</code> entitlement in the signed app.</li>
+      <li>Add <code>principals</code> and <code>principal_tokens</code>.</li>
+      <li>Migrate today's device bearer into <code>local:local</code> with full local scope.</li>
+      <li>Add <code>require_scope</code> middleware to every route touching agent data.</li>
+      <li>Add route-audit tests so new path-touching routes cannot skip scope checks.</li>
+      <li>Override provider homes per agent on native hosts: Claude, Codex, Gemini, Composio.</li>
+      <li>Add strict per-agent login mode for desktop workspaces that represent separate clients.</li>
+      <li>Keep brokered convenience as a solo-desktop default, but label the weaker isolation honestly.</li>
+    </ul>
+
+    <h2>M3a — Runtime spike (1-2 weeks)</h2>
+    <p>
+      <strong>Gate:</strong> do this before promising Linux runtime dates.
+    </p>
+    <ul>
+      <li>Bundle a minimal Linux guest image with <code>houston-engine</code>.</li>
+      <li>Boot through macOS <code>Virtualization.framework</code> on Apple Silicon and Intel if supported.</li>
+      <li>Measure cold start target: 2s Apple Silicon, 3s Intel, or write down why target changes.</li>
+      <li>Measure resident memory target: 300MB or less idle.</li>
+      <li>Measure battery: 4-hour idle session, target 10% or less extra drain versus native.</li>
+      <li>Test file import/download latency with realistic workspace size.</li>
+      <li>Test entitlement path on signed Developer ID build.</li>
+      <li>Test WSL2 install/start on clean Windows and corp-locked Windows.</li>
     </ul>
     <p>
-      Honest scoping: this is two new pieces of infrastructure (a Linux
-      guest image we build in CI, and a Tauri-side runtime supervisor) on
-      top of changes throughout the engine to assume per-agent UIDs.
-      Three months is the optimistic end. Could slip to four if VZ
-      cold-start or WSL2 corp-IT issues bite.
+      Fail gate means do not build M3b yet. Keep native engine and ship M1/M2
+      wins.
     </p>
 
-    <h2>M4 — Cloud foundation (~3 months)</h2>
+    <h2>M3b — Runtime build (3-4 months, only if spike passes)</h2>
     <p>
-      <strong>Goal:</strong> Houston Cloud is shippable. Engine bounces
-      don't kill conversations. Sleeping engines wake on demand. Paying
-      customers can sign up.
+      <strong>Promise after M3b:</strong> per-agent Linux users provide real
+      filesystem isolation on supported machines.
     </p>
     <ul>
-      <li>Detached <code>houston-turn-worker</code> binary so engine restart doesn't kill in-flight turns. (The architectural risk piece.)</li>
-      <li><code>POST /v1/hooks/&lt;route_token&gt;</code> wired to the event queue.</li>
-      <li>Engine learns to exit gracefully on idle.</li>
-      <li>Relay learns to wake a dormant engine via Fly Machines API.</li>
-      <li>Cron moves to a central scheduler service for hosted mode (in-engine cron stays for desktop and self-host).</li>
-      <li>Per-customer Fly Machine provisioning, region picker, onboarding.</li>
-      <li>Control plane: signup, billing, admin, observability. Lives at <code>cloud/</code>.</li>
-      <li>Storage strategy: pinned host with R2/S3 nightly snapshot fallback.</li>
+      <li>Runtime supervisor under Tauri adapter code.</li>
+      <li>macOS VZ wrapper, guest image build, update path, logs, recovery.</li>
+      <li>Windows WSL2 detect/install/register/start, with clear unsupported state for blocked machines.</li>
+      <li>Linux passthrough path.</li>
+      <li>Workspace migration into runtime storage with checksum, rollback marker, and host copy preserved until verified.</li>
+      <li>Import, download, export, reveal, and logs flows.</li>
+      <li>Per-agent <code>useradd</code>, folder ownership, 0700 modes.</li>
+      <li>Provider CLI spawn as <code>hou_&lt;agent&gt;</code>.</li>
+      <li>Full permission-denied test: Sales agent cannot read HR folder.</li>
     </ul>
+
+    <h2>M4 — Inbound triggers (after M1a)</h2>
     <p>
-      Heaviest milestone. Detached worker alone is 3-4 weeks if it goes
-      well. Control plane is its own product. Three months is realistic
-      only with two engineers on it; one engineer is closer to five.
+      <strong>Promise after M4:</strong> external systems can safely start
+      agent turns without opening a memory DoS or bypassing scopes.
     </p>
+    <ul>
+      <li>Add <code>POST /v1/hooks/&lt;route_token&gt;</code>.</li>
+      <li>Add hook token table, rotation, revoke, last-used, and scope.</li>
+      <li>Add provider signature verification for each supported webhook source.</li>
+      <li>Insert <code>trigger_runs</code> before dispatch.</li>
+      <li>Use bounded intake and per-source rate limits.</li>
+      <li>Add Slack-style inbound adapter only when route, auth, and dispatch are done.</li>
+      <li>Add replay and audit UI for accepted, rejected, skipped, and failed triggers.</li>
+    </ul>
+
+    <h2>M5 — Cloud private beta (3-5 months, 2 engineers)</h2>
+    <p>
+      <strong>Promise after M5:</strong> Cloud can host private-beta
+      customers with provisioning, wake, backup, restore, billing, support,
+      and observability.
+    </p>
+    <ul>
+      <li>Write Cloud RFC before platform choice. Fly Machines are a candidate, not a done decision.</li>
+      <li>Build control plane: signup, billing, provisioning, admin, support, observability.</li>
+      <li>Add per-customer or per-workspace runtime provisioning.</li>
+      <li>Add idle exit and wake path after M1b exists.</li>
+      <li>Add hosted scheduler for routines.</li>
+      <li>Add quota controls for provider spend, trigger volume, storage, and runtime hours.</li>
+      <li>Backup every workspace. Run restore drills before charging users.</li>
+      <li>Define region, data residency, legal, and vendor-exit story.</li>
+    </ul>
 
     <h2>Parallel track: Apple entitlement paperwork</h2>
     <p>
-      <strong>Start day one of M1. Do not wait for M3.</strong> Using
+      <strong>Start immediately. Do not wait for M3.</strong> Using
       <code>Virtualization.framework</code> in a Developer ID app
       requires the <code>com.apple.security.virtualization</code>
       entitlement, which Apple grants by request. Timeline: a few weeks
@@ -160,42 +207,29 @@ VZ.framework spike    [===]   ← do this BEFORE locking M3 dates</code></pre>
       granted.
     </p>
 
-    <h2>Parallel track: VZ.framework cold-start spike</h2>
-    <p>
-      Before locking M3 dates, build a 1-week spike: bundle a minimal
-      Alpine guest image with the engine binary, boot it via
-      <code>objc2-virtualization</code> on a representative Mac, measure
-      cold start (target ≤ 2s on Apple Silicon, ≤ 3s on Intel), measure
-      resident memory (target ≤ 300MB), measure battery drain over a
-      4-hour idle session (target ≤ 10% extra vs native).
-    </p>
-    <p>
-      If the numbers come back outside those budgets, M3 needs a design
-      rethink. Knowing this in week 0 is cheap. Discovering it in month
-      3 is not.
-    </p>
-
     <div class="callout callout-info">
-      <div class="callout-label">Open questions to settle before each milestone</div>
-      <p><strong>Before M1:</strong> double-write or hard-migrate <code>chat_feed</code> in the first release? Recommendation: double-write.</p>
-      <p><strong>Before M2:</strong> per-agent OAuth broker for desktop solo users (1 click, weaker iso) or strict per-agent (N clicks, stronger iso)? Recommendation: broker for desktop default, strict for Teams default.</p>
-      <p><strong>Before M3:</strong> what's the fallback when a Windows machine has virtualization disabled in BIOS? Recommendation: clear install-time check, link to IT-admin docs, no native fallback (to keep one operating profile).</p>
-      <p><strong>Before M4:</strong> pinned-host Fly Machines or active-active multi-region from day one? Recommendation: pinned + nightly snapshot, upgrade later. Also: where does the OSS-vs-Cloud line sit for the control plane? Cloud-only is the obvious answer.</p>
+      <div class="callout-label">Decisions that must be explicit</div>
+      <p><strong>M1:</strong> canonical <code>turn_stream</code> writes with one-release read fallback, or hard migration only?</p>
+      <p><strong>M1b:</strong> do we make "never die" a product promise now, or delay it and say "retryable" after engine crash?</p>
+      <p><strong>M2:</strong> brokered desktop default plus strict mode, or strict per-agent by default everywhere?</p>
+      <p><strong>M3:</strong> what happens when Windows virtualization is disabled by BIOS or corporate policy?</p>
+      <p><strong>M5:</strong> which Cloud platform, backup objective, region promise, support SLA, and vendor-exit plan?</p>
     </div>
 
-    <h2>What "shipped" looks like at the end of M4</h2>
+    <h2>What "shipped" means by milestone</h2>
     <ul>
-      <li>Houston desktop on Mac, Windows, Linux, all running the same Linux engine inside a host runtime.</li>
-      <li>Per-agent isolation on every OS. The consultant-with-two-clients case is bulletproof.</li>
-      <li>Conversations survive engine bounces, app closes, network blips. Crons never silently drop.</li>
-      <li>Houston Cloud private beta: signup, per-customer Fly Machine, sleep/wake, billing, region picker.</li>
-      <li>Self-host story unchanged. <code>docker pull && docker run</code> still works.</li>
-      <li>Webhooks live. Five trigger sources (chat, mobile, Slack, cron, webhook) all routed through the same path.</li>
+      <li><strong>After M1a:</strong> accepted turns, committed chunks, reconnect replay, and retry state are durable.</li>
+      <li><strong>After M1b:</strong> app close and engine bounce do not kill in-flight provider turns.</li>
+      <li><strong>After M2:</strong> engine API scopes and per-agent provider homes exist.</li>
+      <li><strong>After M3b:</strong> supported desktops get kernel-backed per-agent filesystem isolation.</li>
+      <li><strong>After M4:</strong> public hooks and Slack-style inbound channels use bounded durable trigger dispatch.</li>
+      <li><strong>After M5:</strong> Cloud is private-beta ready, with backups and restore already tested.</li>
     </ul>
     <p>
-      Total elapsed: ~7-8 months from kickoff. Two engineers is enough
-      for M1+M2 in parallel. Three is enough to run M3 and M4 in parallel
-      after M2 lands. Anything less and the schedule stretches linearly.
+      Minimum serious schedule: M1a and M2 can overlap with two engineers.
+      M1b, M3b, and M5 each need focused ownership. One engineer stretches
+      the plan linearly and should not promise Cloud plus runtime in the same
+      half-year.
     </p>
 
     <div class="pager">

--- a/engine-design/README.md
+++ b/engine-design/README.md
@@ -1,7 +1,7 @@
 ## Houston Engine Design Guide
 
-The single source of truth for how the Houston engine works (and how it will work).
+The working source of truth for how the Houston engine works today and which future changes are proposed.
 
-Open `index.html` in any browser. Self-contained: dark theme, Mermaid diagrams via CDN, presentable as-is. Each chapter has a status pill so you can see at a glance what's shipped, what's in progress, and what's planned.
+Open `index.html` in any browser. Self-contained: dark theme, presentable as-is. Each chapter has a status pill so you can see what is shipped, partial, proposed, or gated.
 
 This document is the working design. Edit it as decisions get made. New deep-dives go in this directory as separate HTML or markdown files; `index.html` stays the readable, presentation-ready overview.

--- a/engine-design/index.html
+++ b/engine-design/index.html
@@ -37,7 +37,7 @@
     <h1>How the engine actually works.</h1>
     <p class="lead">
       A walkthrough of every piece of Houston, what it does today, what it
-      will do tomorrow, and the reason for every decision in between. If
+      should do next, and the reason for every decision in between. If
       you are a new hire, you should be able to read this top to bottom
       and start building. If you need more, the code is linked at the
       bottom of each chapter.
@@ -53,12 +53,12 @@
     <ul>
       <li><span class="status shipped">Shipped</span> already in the codebase today.</li>
       <li><span class="status partial">Partial</span> some of it works, the rest is on the plan.</li>
-      <li><span class="status planned">Planned</span> the design is decided, the code is not yet written.</li>
-      <li><span class="status progress">In progress</span> actively being built right now.</li>
+      <li><span class="status planned">Planned</span> proposed design, code not written yet. Some planned work is gated.</li>
+      <li><span class="status progress">Gate plan</span> sequencing, decisions, and acceptance gates.</li>
     </ul>
     <p>
       Each planned chapter also lists which milestone it belongs to
-      (M1, M2, M3, M4) and a rough size in weeks or months. Sizes are
+      (M1a, M1b, M2, M3, M4, M5) and a rough size in weeks or months. Sizes are
       honest estimates, not commitments. Where the work depends on
       something else landing first, the chapter says so.
     </p>
@@ -67,14 +67,13 @@
     <p>
       Houston is a desktop app, an engine, and folders on disk. The
       desktop app is what users click. The engine is a Rust binary that
-      does the work. The folders are where the agents and their data
-      live. The desktop talks to the engine over HTTP. The engine spawns
-      provider CLIs (Claude Code, Codex) and watches files. After the
-      redesign, the engine runs inside a Linux runtime on every host
-      (Apple <code>Virtualization.framework</code> on Mac,
-      <code>WSL2</code> on Windows, native on Linux and in the cloud),
-      so per-agent isolation can be enforced by the kernel and the
-      tooling story stops being three different stories.
+      does the work. The folders are where agents and their data live.
+      The desktop talks to the engine over HTTP. The engine spawns
+      provider CLIs (Claude Code, Codex, Gemini) and watches files. This
+      guide separates shipped truth from proposed work: reliability and
+      scoped auth can improve the native engine now; Linux runtime
+      isolation is a later, spike-gated bet that only ships after cold
+      start, migration, support, and entitlement risks are proven.
     </p>
 
     <h2>The chapters</h2>
@@ -89,17 +88,17 @@
       <a class="chapter-card" href="02-agent-folder.html">
         <div class="chapter-num">02 <span class="status shipped">Shipped</span></div>
         <div class="chapter-title">An agent is a folder</div>
-        <div class="chapter-desc">No databases, no proprietary formats. Just files on disk, inside a Linux runtime.</div>
+        <div class="chapter-desc">No proprietary formats. Just files on disk today, with runtime relocation only if Chapter 3 ships.</div>
       </a>
 
       <a class="chapter-card" href="03-where-engine-lives.html">
-        <div class="chapter-num">03 <span class="status planned">Planned · M3 · ~3 months</span></div>
+        <div class="chapter-num">03 <span class="status planned">Spike-gated · M3 candidate</span></div>
         <div class="chapter-title">Where the engine lives</div>
-        <div class="chapter-desc">One Linux engine binary. Three host runtimes: Apple VZ, WSL2, native Linux.</div>
+        <div class="chapter-desc">Linux runtime is the isolation bet. Useful, expensive, and not committed until measurements pass.</div>
       </a>
 
       <a class="chapter-card" href="04-message-flow.html">
-        <div class="chapter-num">04 <span class="status partial">Partial · finishes in M1</span></div>
+        <div class="chapter-num">04 <span class="status partial">Target · M1a</span></div>
         <div class="chapter-title">How a message flows through</div>
         <div class="chapter-desc">The full chat-turn sequence. The most important diagram.</div>
       </a>
@@ -111,39 +110,39 @@
       </a>
 
       <a class="chapter-card" href="06-four-tables.html">
-        <div class="chapter-num">06 <span class="status planned">Planned · M1 · ~4 weeks</span></div>
-        <div class="chapter-title">The four tables that save everything</div>
-        <div class="chapter-desc">The whole reliability story. Not Temporal. Just SQLite.</div>
+        <div class="chapter-num">06 <span class="status planned">M1a · 4-6 weeks</span></div>
+        <div class="chapter-title">The reliability tables</div>
+        <div class="chapter-desc">The reliability floor: durable turns, replay, audits, and explicit retry semantics.</div>
       </a>
 
       <a class="chapter-card" href="07-keeping-agents-apart.html">
-        <div class="chapter-num">07 <span class="status planned">Walls 2+3 in M2 · ~3 weeks. Wall 1 in M3.</span></div>
+        <div class="chapter-num">07 <span class="status planned">M2 guards · M3 kernel wall</span></div>
         <div class="chapter-title">Keeping agents apart</div>
-        <div class="chapter-desc">Three independent walls. The "Sales agent can't read HR data" story.</div>
+        <div class="chapter-desc">Three walls for three attack paths. Only kernel wall stops direct filesystem snooping.</div>
       </a>
 
       <a class="chapter-card" href="08-login.html">
-        <div class="chapter-num">08 <span class="status partial">Partial · finishes in M3</span></div>
+        <div class="chapter-num">08 <span class="status partial">M2 native homes · M3 runtime users</span></div>
         <div class="chapter-title">Logging in (still one click)</div>
         <div class="chapter-desc">Per-agent OAuth without breaking the UX.</div>
       </a>
 
       <a class="chapter-card" href="09-external-triggers.html">
-        <div class="chapter-num">09 <span class="status partial">Partial · webhooks in M4 · ~1 week</span></div>
+        <div class="chapter-num">09 <span class="status partial">Triggers after M1a</span></div>
         <div class="chapter-title">External triggers</div>
-        <div class="chapter-desc">Five ways to wake an agent. User chat, mobile, Slack, cron, webhook.</div>
+        <div class="chapter-desc">User chat and mobile ship. Cron ships in-app. Webhooks and Slack-style inbound channels need more work.</div>
       </a>
 
       <a class="chapter-card" href="10-deployment.html">
-        <div class="chapter-num">10 <span class="status planned">Planned · M4 · ~3 months</span></div>
-        <div class="chapter-title">Deployment: one binary, two homes</div>
-        <div class="chapter-desc">Same engine on your laptop and in Houston Cloud.</div>
+        <div class="chapter-num">10 <span class="status planned">Candidate · M4+</span></div>
+        <div class="chapter-title">Deployment: desktop, self-host, cloud</div>
+        <div class="chapter-desc">Always On exists. Cloud is a separate product with unresolved control-plane choices.</div>
       </a>
 
       <a class="chapter-card" href="11-roadmap.html">
-        <div class="chapter-num">11 <span class="status progress">In progress</span></div>
+        <div class="chapter-num">11 <span class="status progress">Gate plan</span></div>
         <div class="chapter-title">The roadmap</div>
-        <div class="chapter-desc">Four milestones. Realistic timelines. What ships in parallel vs in sequence.</div>
+        <div class="chapter-desc">Milestones with gates, test contracts, and promises we are allowed to make.</div>
       </a>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- rewrites engine-design plan to separate shipped state, proposed work, and gated bets
- fixes stale claims around Slack, Cloud, runtime, sessions, routine triggers, and replay
- splits roadmap into M1a/M1b/M2/M3/M4/M5 with explicit promises and test gates

## Verification
- xmllint --html --noout engine-design/*.html
- git diff --check -- engine-design