### PR TITLE
feat(app): pause Gemini provider + Windows engine readiness

### DIFF
--- a/app/src/components/chat-model-selector.tsx
+++ b/app/src/components/chat-model-selector.tsx
@@ -47,6 +47,17 @@ export function ChatModelSelector({ provider, model, onSelect, lockedProvider }:
   const currentModel = getModel(provider, model);
   const displayLabel = currentModel?.label ?? currentProvider?.subtitle ?? t("modelSelector.selectModel");
 
+  // Honour `lockedProvider` only when that provider is still installed.
+  // If the chat was created against a provider that the engine now
+  // reports as missing (e.g. Gemini on a Windows install that does not
+  // ship the binary in v1), the user must be able to switch to an
+  // installed alternative — otherwise every send routes back to the
+  // missing CLI and fails. Drop the lock in that case so other
+  // connected providers appear in the dropdown.
+  const lockedStatus = lockedProvider ? statuses[lockedProvider] : undefined;
+  const lockedProviderInstalled = lockedStatus?.cli_installed ?? true;
+  const effectiveLock = lockedProvider && lockedProviderInstalled ? lockedProvider : null;
+
   return (
     // Stop pointer events from bubbling — prevents the board detail panel
     // from interpreting dropdown clicks as "click outside → close panel".
@@ -72,8 +83,11 @@ export function ChatModelSelector({ provider, model, onSelect, lockedProvider }:
             const connected = (status?.cli_installed && status?.authenticated) ?? false;
             // Hide disconnected providers that aren't active
             if (!connected && prov.id !== provider) return null;
-            // When provider is locked, only show the locked provider's models
-            if (lockedProvider && prov.id !== lockedProvider) return null;
+            // When provider is locked AND still installed, only show the
+            // locked provider's models. When the locked provider is
+            // uninstalled, `effectiveLock` is null so other connected
+            // providers stay visible — see the lock-override comment above.
+            if (effectiveLock && prov.id !== effectiveLock) return null;
             return (
               <ProviderModelGroup
                 key={prov.id}
@@ -82,7 +96,7 @@ export function ChatModelSelector({ provider, model, onSelect, lockedProvider }:
                 isActiveProvider={prov.id === provider}
                 activeModel={prov.id === provider ? model : null}
                 onSelect={onSelect}
-                showSeparator={idx > 0 && !lockedProvider}
+                showSeparator={idx > 0 && !effectiveLock}
               />
             );
           })}

--- a/app/src/components/chat-model-selector.tsx
+++ b/app/src/components/chat-model-selector.tsx
@@ -11,7 +11,7 @@ import {
 } from "@houston-ai/core";
 import { tauriProvider, type ProviderStatus } from "../lib/tauri";
 import { PROVIDERS, getProvider, getModel, type ProviderInfo } from "../lib/providers";
-import { ClaudeLogo, OpenAILogo, GeminiLogo } from "./shell/provider-logos";
+import { ClaudeLogo, OpenAILogo } from "./shell/provider-logos";
 
 interface ChatModelSelectorProps {
   /** Current provider id (from workspace/agent config). */
@@ -47,16 +47,27 @@ export function ChatModelSelector({ provider, model, onSelect, lockedProvider }:
   const currentModel = getModel(provider, model);
   const displayLabel = currentModel?.label ?? currentProvider?.subtitle ?? t("modelSelector.selectModel");
 
-  // Honour `lockedProvider` only when that provider is still installed.
-  // If the chat was created against a provider that the engine now
-  // reports as missing (e.g. Gemini on a Windows install that does not
-  // ship the binary in v1), the user must be able to switch to an
-  // installed alternative — otherwise every send routes back to the
-  // missing CLI and fails. Drop the lock in that case so other
-  // connected providers appear in the dropdown.
+  // Honour `lockedProvider` only when it points at a currently-active
+  // provider that the engine reports as installed. Two cases drop the
+  // lock so the user can switch instead of being stuck:
+  //
+  //   * The locked provider is in `COMING_SOON_PROVIDERS` (or unknown),
+  //     so `getProvider` returns undefined. This happens when Gemini is
+  //     paused in the catalog but a stored activity still references
+  //     it.
+  //   * The locked provider is in `PROVIDERS` but the engine reports
+  //     `cli_installed=false` (binary missing on this platform).
+  //
+  // In both cases every send would route to a provider the user cannot
+  // currently invoke, so the dropdown must expose installed
+  // alternatives instead of pinning the broken choice.
+  const lockedProviderEntry = lockedProvider ? getProvider(lockedProvider) : undefined;
   const lockedStatus = lockedProvider ? statuses[lockedProvider] : undefined;
   const lockedProviderInstalled = lockedStatus?.cli_installed ?? true;
-  const effectiveLock = lockedProvider && lockedProviderInstalled ? lockedProvider : null;
+  const effectiveLock =
+    lockedProvider && lockedProviderEntry && lockedProviderInstalled
+      ? lockedProvider
+      : null;
 
   return (
     // Stop pointer events from bubbling — prevents the board detail panel
@@ -179,8 +190,6 @@ function iconFor(providerId: string) {
       return <ClaudeLogo className="size-full" />;
     case "openai":
       return <OpenAILogo className="size-full" />;
-    case "gemini":
-      return <GeminiLogo className="size-full" />;
     default:
       return null;
   }

--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -225,6 +225,7 @@ export function CreateAgentDialog() {
                         schedule: routine.schedule,
                         suppress_when_silent: true,
                         timezone: null,
+                        integrations: [],
                       }
                     : null,
                 );

--- a/app/src/components/shell/provider-cards.tsx
+++ b/app/src/components/shell/provider-cards.tsx
@@ -20,8 +20,6 @@ function ProviderLogo({ provider }: { provider: ProviderInfo }) {
       return <ClaudeLogo />;
     case "openai":
       return <OpenAILogo />;
-    case "gemini":
-      return <GeminiLogo />;
     default:
       return (
         <span className="text-[10px] font-semibold tracking-tight text-muted-foreground">
@@ -33,6 +31,12 @@ function ProviderLogo({ provider }: { provider: ProviderInfo }) {
 
 function ComingSoonLogo({ provider }: { provider: ComingSoonProviderInfo }) {
   switch (provider.id) {
+    case "gemini":
+      // Gemini has a real brand mark — Houston already ships the SVG
+      // for the active-provider card path, so reuse it here while
+      // Gemini sits in the coming-soon slot rather than falling back
+      // to the generic two-letter chip.
+      return <GeminiLogo />;
     case "deepseek":
       return <DeepSeekLogo />;
     case "minimax":

--- a/app/src/components/tabs/chat-tab.tsx
+++ b/app/src/components/tabs/chat-tab.tsx
@@ -33,7 +33,7 @@ import { HoustonThinkingIndicator } from "../shell/experience-card";
 import { ChatModelSelector } from "../chat-model-selector";
 import { Paperclip } from "lucide-react";
 import { useChatDisplayLabels } from "../use-chat-display-labels";
-import { getDefaultModel, PROVIDERS } from "../../lib/providers";
+import { getDefaultModel, PROVIDERS, validProviderOrNull } from "../../lib/providers";
 import type { ProviderError } from "@houston-ai/chat";
 import { ProviderReconnectCard } from "../shell/provider-reconnect-card";
 import { ProviderErrorCard } from "../shell/provider-error-card";
@@ -115,8 +115,16 @@ export default function ChatTab({ agent }: TabProps) {
     setChatModel(null);
   }, [agent.id]);
 
-  // Effective = chat override > agent config > workspace default
-  const effectiveProvider = chatProvider ?? agentProvider ?? wsProvider;
+  // Effective = chat override > agent config > workspace default.
+  // Skip tiers whose provider is no longer in `PROVIDERS` (e.g. a
+  // legacy agent or workspace pointing at Gemini while it sits under
+  // "coming soon") so the resolved value is always something Houston
+  // can actually invoke.
+  const effectiveProvider =
+    validProviderOrNull(chatProvider) ??
+    validProviderOrNull(agentProvider) ??
+    validProviderOrNull(wsProvider) ??
+    "anthropic";
   const effectiveModel = chatModel ?? agentModel ?? wsModel;
   const authSignalKey = useMemo(
     () => providerAuthSignalKey(feedItems ?? []),

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -66,7 +66,7 @@ import {
   isComposioSigninHref,
 } from "./composio-signin-card";
 import { ChatModelSelector } from "./chat-model-selector";
-import { getDefaultModel } from "../lib/providers";
+import { getDefaultModel, validProviderOrNull } from "../lib/providers";
 import { analytics } from "../lib/analytics";
 import {
   buildSkillClaudePrompt,
@@ -191,7 +191,18 @@ export function useAgentChatPanel({
     setChatProvider(null);
     setChatModel(null);
   }, [selectedSessionKey]);
-  const effectiveProvider = chatProvider ?? activityProvider ?? agentProvider ?? wsProvider;
+  // Walk the fallback chain (chat → activity → agent → workspace) but
+  // skip any tier whose provider id is no longer in `PROVIDERS` —
+  // typically a stored value from when Gemini was an active provider.
+  // Falling through means a legacy gemini-defaulted agent or workspace
+  // produces an anthropic/openai chat instead of routing to a paused
+  // provider the engine would reject.
+  const effectiveProvider =
+    validProviderOrNull(chatProvider) ??
+    validProviderOrNull(activityProvider) ??
+    validProviderOrNull(agentProvider) ??
+    validProviderOrNull(wsProvider) ??
+    "anthropic";
   const effectiveModel = chatModel ?? activityModel ?? agentModel ?? wsModel;
   const handleModelSelect = useCallback(
     (prov: string, mod: string) => {

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -83,37 +83,6 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     ],
     defaultModel: "sonnet",
   },
-  {
-    id: "gemini",
-    name: "Google",
-    subtitle: "Gemini CLI",
-    cliName: "gemini",
-    installUrl: "https://github.com/google-gemini/gemini-cli",
-    // Gemini has no `gemini login` command. The engine returns BadRequest
-    // if `launchLogin` is called for this provider; the picker MUST
-    // short-circuit on `loginKind === "apiKey"` and open the API-key
-    // connect dialog instead.
-    loginCommand: "",
-    cost: "Your Google account (free tier) or Gemini API key",
-    // Pro Preview (`gemini-3.1-pro-preview`) is intentionally omitted — it
-    // is gated behind paid Google AI tiers and free-tier OAuth accounts
-    // get zero quota for it. Live test: 10 retries → "exhausted capacity"
-    // on every call → 4+ minute hang with no response. Adding it back
-    // requires either (a) an account-tier check that hides it for free
-    // users, or (b) an "advanced models" disclosure card the user opts
-    // into. Until then, ship the model that actually works.
-    models: [
-      {
-        id: "gemini-3.1-flash-lite",
-        label: "Gemini 3.1 Flash-Lite",
-        description: "Fast and efficient. Works on the free tier.",
-      },
-    ],
-    defaultModel: "gemini-3.1-flash-lite",
-    loginKind: "apiKey",
-    apiKeyConsoleUrl: "https://aistudio.google.com/app/apikey",
-    apiKeyEnvVar: "GEMINI_API_KEY",
-  },
 ] as const;
 
 /** Find a provider by id. */
@@ -131,6 +100,19 @@ export function getDefaultModel(providerId: string): string {
   return getProvider(providerId)?.defaultModel ?? "sonnet";
 }
 
+/**
+ * Return `providerId` only when it names a currently-active provider in
+ * `PROVIDERS`. Used by the chat model selector and the per-chat
+ * effective-provider fallback chain to skip stored values that point at
+ * providers Houston has moved to `COMING_SOON_PROVIDERS` (e.g. an
+ * activity record from a previous Houston version that selected Gemini
+ * before it was paused). Callers chain it with `??` to fall through to
+ * the next tier of preference.
+ */
+export function validProviderOrNull(providerId: string | null | undefined): string | null {
+  return providerId && getProvider(providerId) ? providerId : null;
+}
+
 export interface ComingSoonProviderInfo {
   readonly id: string;
   readonly name: string;
@@ -139,6 +121,11 @@ export interface ComingSoonProviderInfo {
 }
 
 export const COMING_SOON_PROVIDERS: readonly ComingSoonProviderInfo[] = [
+  // Gemini: engine support + bundled CLI machinery are intact in this
+  // codebase. The UI keeps it under "coming soon" until the broader
+  // rollout (account-tier gating, Windows fork-build) is ready. Listed
+  // first so the alphabetised "next up" slot stays prominent.
+  { id: "gemini", name: "Google", subtitle: "Gemini CLI", mark: "GM" },
   { id: "subq", name: "SubQ", subtitle: "SubQ Code", mark: "SQ" },
   { id: "deepseek", name: "DeepSeek", subtitle: "DeepSeek Coder", mark: "DS" },
   { id: "minimax", name: "MiniMax", subtitle: "M2", mark: "MM" },

--- a/engine/houston-agent-files/src/lib.rs
+++ b/engine/houston-agent-files/src/lib.rs
@@ -222,55 +222,76 @@ pub fn migrate_agent_data(agent_root: &Path) -> Result<()> {
         }
     }
 
-    // Backfill the GEMINI.md → CLAUDE.md symlink for agents created
-    // before Houston started seeding it. Same shape as the AGENTS.md
-    // symlink in `houston-engine-core::agents::prompt::seed_agent`:
-    // gemini-cli walks UP from cwd looking for `GEMINI.md` as project
-    // memory, so without this the agent's role/instructions never reach
-    // the model. Idempotent: only runs when CLAUDE.md exists AND
-    // GEMINI.md is absent. We deliberately do NOT replace an existing
-    // GEMINI.md (user may have hand-authored a gemini-specific file).
+    // Backfill `GEMINI.md` for agents created before Houston started
+    // seeding it. gemini-cli walks UP from cwd looking for `GEMINI.md`
+    // as project memory; without this the agent's role/instructions
+    // never reach the model. Idempotent: only runs when CLAUDE.md
+    // exists AND GEMINI.md is absent. We deliberately do NOT replace
+    // an existing GEMINI.md (user may have hand-authored a
+    // gemini-specific file).
+    //
+    // Prefer a relative symlink (drift-free). On Windows without
+    // Developer Mode `symlink_file` returns os error 1314 ("A required
+    // privilege is not held by the client"); fall back to a regular
+    // file copy so the agent role still reaches gemini-cli.
     let claude_md = agent_root.join("CLAUDE.md");
     let gemini_md = agent_root.join("GEMINI.md");
     // `symlink_metadata` so we treat broken/dangling symlinks as
     // "exists" — replacing them would silently swap user config.
     let gemini_present = fs::symlink_metadata(&gemini_md).is_ok();
     if claude_md.exists() && !gemini_present {
-        #[cfg(unix)]
-        {
-            if let Err(e) = std::os::unix::fs::symlink("CLAUDE.md", &gemini_md) {
-                tracing::warn!(
-                    agent_root = %agent_root.display(),
-                    error = %e,
-                    "failed to backfill GEMINI.md symlink"
-                );
-            } else {
-                tracing::info!(
-                    agent_root = %agent_root.display(),
-                    "backfilled GEMINI.md → CLAUDE.md symlink"
-                );
-            }
-        }
-        #[cfg(windows)]
-        {
-            if let Err(e) = std::os::windows::fs::symlink_file("CLAUDE.md", &gemini_md) {
-                tracing::warn!(
-                    agent_root = %agent_root.display(),
-                    error = %e,
-                    "failed to backfill GEMINI.md symlink"
-                );
-            } else {
-                tracing::info!(
-                    agent_root = %agent_root.display(),
-                    "backfilled GEMINI.md → CLAUDE.md symlink"
-                );
-            }
+        match link_or_copy_role_file(&claude_md, &gemini_md) {
+            Ok(Backfill::Symlinked) => tracing::info!(
+                agent_root = %agent_root.display(),
+                "backfilled GEMINI.md → CLAUDE.md symlink"
+            ),
+            Ok(Backfill::Copied) => tracing::info!(
+                agent_root = %agent_root.display(),
+                "backfilled GEMINI.md from CLAUDE.md (copy fallback)"
+            ),
+            Err(e) => tracing::warn!(
+                agent_root = %agent_root.display(),
+                error = %e,
+                "failed to backfill GEMINI.md"
+            ),
         }
     }
 
     // Seed schemas at the end so every migrated agent has them available.
     seed_schemas(agent_root)?;
     Ok(())
+}
+
+/// Outcome of [`link_or_copy_role_file`]: which path the OS accepted.
+/// Reported back to the caller so it can log the right line — copies
+/// drift if `CLAUDE.md` is edited later, symlinks don't.
+enum Backfill {
+    Symlinked,
+    Copied,
+}
+
+/// Create `link_path` so it exposes the content of `target_path`.
+/// Prefers a relative symlink (drift-free); falls back to a regular
+/// file copy when the OS denies symlink creation (Windows without
+/// Developer Mode returns os error 1314).
+fn link_or_copy_role_file(target_path: &Path, link_path: &Path) -> std::io::Result<Backfill> {
+    let target_name = target_path
+        .file_name()
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::InvalidInput, "target has no file name"))?;
+    #[cfg(unix)]
+    {
+        if std::os::unix::fs::symlink(target_name, link_path).is_ok() {
+            return Ok(Backfill::Symlinked);
+        }
+    }
+    #[cfg(windows)]
+    {
+        if std::os::windows::fs::symlink_file(target_name, link_path).is_ok() {
+            return Ok(Backfill::Symlinked);
+        }
+    }
+    fs::copy(target_path, link_path)?;
+    Ok(Backfill::Copied)
 }
 
 #[cfg(test)]
@@ -411,6 +432,25 @@ mod tests {
         migrate_agent_data(dir.path()).unwrap();
         assert!(!dir.path().join("GEMINI.md").exists());
         assert!(fs::symlink_metadata(dir.path().join("GEMINI.md")).is_err());
+    }
+
+    #[test]
+    fn migrate_gemini_md_backfill_reflects_claude_md_content() {
+        // Platform-agnostic check: whether the OS accepted a symlink
+        // (Unix, Windows with Dev Mode) or fell back to a copy
+        // (Windows without Dev Mode), `read_to_string` on GEMINI.md
+        // must yield the CLAUDE.md content. Regression guard for the
+        // Windows "failed to backfill GEMINI.md symlink: A required
+        // privilege is not held by the client (os error 1314)" path.
+        let dir = TempDir::new().unwrap();
+        fs::write(dir.path().join("CLAUDE.md"), "agent role body").unwrap();
+
+        migrate_agent_data(dir.path()).unwrap();
+
+        assert_eq!(
+            fs::read_to_string(dir.path().join("GEMINI.md")).unwrap(),
+            "agent role body",
+        );
     }
 
     #[test]

--- a/engine/houston-engine-core/src/agents/prompt.rs
+++ b/engine/houston-engine-core/src/agents/prompt.rs
@@ -97,6 +97,45 @@ You are a helpful AI assistant.
 - Explain your reasoning when making decisions
 "#;
 
+/// Expose `CLAUDE.md` to a sibling CLI's project-memory filename
+/// (`AGENTS.md` for codex, `GEMINI.md` for gemini-cli). First tries a
+/// relative symlink so the file stays drift-free; on Windows without
+/// Developer Mode that returns "A required privilege is not held by
+/// the client" (os error 1314), so we fall back to a regular file copy.
+/// Idempotent: returns Ok and does nothing if `link_name` already
+/// exists (a previous run staged it, or a user hand-authored a
+/// CLI-specific override we must not clobber).
+fn link_or_copy_role_file(dir: &Path, link_name: &str) -> std::io::Result<()> {
+    let link_path = dir.join(link_name);
+    // `symlink_metadata` so a dangling symlink still counts as "exists"
+    // — replacing it could silently swap user config.
+    if fs::symlink_metadata(&link_path).is_ok() {
+        return Ok(());
+    }
+    let claude_md = dir.join("CLAUDE.md");
+    #[cfg(unix)]
+    {
+        if std::os::unix::fs::symlink("CLAUDE.md", &link_path).is_ok() {
+            return Ok(());
+        }
+    }
+    #[cfg(windows)]
+    {
+        if std::os::windows::fs::symlink_file("CLAUDE.md", &link_path).is_ok() {
+            return Ok(());
+        }
+    }
+    // Symlink denied (Windows without Dev Mode, restricted filesystem,
+    // ...). Copy the canonical file so the sibling CLI still finds an
+    // agent role file. Stale-content risk: if the user edits CLAUDE.md
+    // later this copy goes out of date, but seed_agent only runs on
+    // first creation so this is the documented behavior — the symlink
+    // path would have the same single-snapshot relationship if the
+    // user hand-deleted the link.
+    fs::copy(&claude_md, &link_path)?;
+    Ok(())
+}
+
 /// Seed the Houston agent skeleton into an agent directory.
 ///
 /// Creates `CLAUDE.md` (user-editable job description) and the
@@ -108,32 +147,14 @@ pub fn seed_agent(dir: &Path) -> Result<(), String> {
 
     // Codex (`codex`) reads `AGENTS.md` from project memory; Gemini-cli
     // reads `GEMINI.md`. Houston has one canonical agent role file —
-    // `CLAUDE.md` — and exposes it to the other CLIs via symlink so all
-    // three providers see the same per-agent instructions without us
-    // having to duplicate file content (drift-free).
-    let agents_md = dir.join("AGENTS.md");
-    if !agents_md.exists() {
-        #[cfg(unix)]
-        {
-            let _ = std::os::unix::fs::symlink("CLAUDE.md", &agents_md);
-        }
-        #[cfg(windows)]
-        {
-            let _ = std::os::windows::fs::symlink_file("CLAUDE.md", &agents_md);
-        }
-    }
-
-    let gemini_md = dir.join("GEMINI.md");
-    if !gemini_md.exists() {
-        #[cfg(unix)]
-        {
-            let _ = std::os::unix::fs::symlink("CLAUDE.md", &gemini_md);
-        }
-        #[cfg(windows)]
-        {
-            let _ = std::os::windows::fs::symlink_file("CLAUDE.md", &gemini_md);
-        }
-    }
+    // `CLAUDE.md` — and exposes it to the other CLIs so all three
+    // providers see the same per-agent instructions. Prefer a symlink
+    // (drift-free), fall back to a file copy on Windows installs that
+    // lack Developer Mode (symlink_file returns os error 1314 there).
+    link_or_copy_role_file(dir, "AGENTS.md")
+        .map_err(|e| format!("Failed to seed AGENTS.md: {e}"))?;
+    link_or_copy_role_file(dir, "GEMINI.md")
+        .map_err(|e| format!("Failed to seed GEMINI.md: {e}"))?;
 
     let prompts_dir = dir.join(".houston/prompts");
     let modes_dir = prompts_dir.join("modes");
@@ -264,6 +285,37 @@ mod tests {
 
         let gemini_md = d.path().join("GEMINI.md");
         assert_eq!(fs::read_link(gemini_md).unwrap(), Path::new("CLAUDE.md"));
+    }
+
+    #[test]
+    fn seed_agent_role_files_contain_claude_md_content() {
+        // Platform-agnostic check: regardless of whether the role files
+        // ended up as symlinks (Unix, Windows with Dev Mode) or copies
+        // (Windows without Dev Mode), reading them must yield the
+        // CLAUDE.md content so gemini-cli + codex see the agent role.
+        let d = TempDir::new().unwrap();
+        seed_agent(d.path()).unwrap();
+
+        let claude_body = fs::read_to_string(d.path().join("CLAUDE.md")).unwrap();
+        let agents_body = fs::read_to_string(d.path().join("AGENTS.md")).unwrap();
+        let gemini_body = fs::read_to_string(d.path().join("GEMINI.md")).unwrap();
+        assert_eq!(agents_body, claude_body);
+        assert_eq!(gemini_body, claude_body);
+    }
+
+    #[test]
+    fn link_or_copy_role_file_preserves_existing_override() {
+        // If the user hand-authored a CLI-specific override, seed_agent
+        // must not clobber it. Pre-stage GEMINI.md with bespoke content
+        // and confirm the helper leaves it alone.
+        let d = TempDir::new().unwrap();
+        fs::write(d.path().join("CLAUDE.md"), "houston role").unwrap();
+        fs::write(d.path().join("GEMINI.md"), "user override").unwrap();
+        link_or_copy_role_file(d.path(), "GEMINI.md").unwrap();
+        assert_eq!(
+            fs::read_to_string(d.path().join("GEMINI.md")).unwrap(),
+            "user override"
+        );
     }
 
     #[test]

--- a/engine/houston-engine-core/src/sessions/provider_oneshot.rs
+++ b/engine/houston-engine-core/src/sessions/provider_oneshot.rs
@@ -89,8 +89,30 @@ async fn run_gemini(prompt: &str, model: &str, time_limit: Duration) -> Result<S
     // output format and break parsers. The one-shot path asks for plain
     // text (`--output-format text`) so we don't have to thread through a
     // second NDJSON parser just for this call.
-    let bin = houston_cli_bundle::bundled_gemini_path()
-        .unwrap_or_else(|| std::path::PathBuf::from("gemini"));
+    //
+    // On Windows there is no upstream gemini binary in v1 (see
+    // knowledge-base/cli-bundling.md, phase-2 note), so `bundled_gemini_path`
+    // returns None AND there's nothing on PATH. Surface a clear error
+    // instead of falling through to `Command::new("gemini")` which would
+    // fail with "program not found" and confuse the caller.
+    let bin = match houston_cli_bundle::bundled_gemini_path() {
+        Some(p) => p,
+        None => match houston_terminal_manager::provider::which_on_path("gemini") {
+            Some(p) => p,
+            None => {
+                return Err(if cfg!(windows) {
+                    "Gemini is not available on Windows yet. Switch to Anthropic \
+                     or OpenAI for now, or follow Houston's Windows release notes \
+                     for when Gemini lands."
+                        .into()
+                } else {
+                    "Gemini CLI binary missing. Reinstall Houston to restore the \
+                     bundled CLI."
+                        .into()
+                });
+            }
+        },
+    };
     let mut cmd = tokio::process::Command::new(&bin);
     cmd.env("PATH", claude_path::shell_path());
 

--- a/engine/houston-terminal-manager/src/gemini_home.rs
+++ b/engine/houston-terminal-manager/src/gemini_home.rs
@@ -84,17 +84,33 @@ fn ensure_symlink(target: &Path, link: &Path) -> io::Result<()> {
 /// (small JSON, only re-copied on drift). Atomic in both branches:
 /// build at a sibling temp path, then `rename` over (Rust's `fs::rename`
 /// atomically replaces an existing entry on Windows since 1.45).
+///
+/// Tolerates a missing `target`: Unix's `symlink(2)` creates dangling
+/// links and reads start working once the user logs in. The Windows
+/// `symlink_file` permission-denied path falls through to `fs::copy`,
+/// which fails with ENOENT (os error 2) on a missing source — that
+/// would break first-time gemini users who have not written
+/// `~/.gemini/.env` or completed OAuth yet. Treat the missing source
+/// as "skip this entry": remove any stale entry at `link` so a
+/// previous run's content isn't mistaken for current state.
 #[cfg(windows)]
 fn ensure_symlink(target: &Path, link: &Path) -> io::Result<()> {
     use std::os::windows::fs::symlink_file;
     let tmp = tmp_sibling(link)?;
     let _ = fs::remove_file(&tmp);
-    if symlink_file(target, &tmp).is_err() {
-        // Fallback: bytewise copy when symlinks are denied (no Dev Mode,
-        // no admin, ReFS quirks). Same atomic-rename pattern.
-        fs::copy(target, &tmp)?;
+    if symlink_file(target, &tmp).is_ok() {
+        return fs::rename(&tmp, link);
     }
-    fs::rename(&tmp, link)
+    // Symlink denied. Try copy. If the source is missing, drop any stale
+    // entry at `link` and return Ok — there is nothing to point at yet.
+    match fs::copy(target, &tmp) {
+        Ok(_) => fs::rename(&tmp, link),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            let _ = fs::remove_file(link);
+            Ok(())
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Atomic write-then-rename. Skips the write when content already
@@ -231,6 +247,7 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
+    #[cfg(unix)]
     fn fake_home_with_gemini(tmp: &TempDir, settings: Option<&str>) -> PathBuf {
         let home = tmp.path().join("real-home");
         let gemini = home.join(".gemini");
@@ -391,6 +408,39 @@ mod tests {
             fs::read_to_string(&env).unwrap(),
             "GEMINI_API_KEY=test-key-value\n"
         );
+    }
+
+    #[test]
+    fn ensure_runtime_home_tolerates_missing_credential_files() {
+        // First-time gemini users do not yet have `~/.gemini/oauth_creds.json`,
+        // `google_accounts.json`, or `.env`. On Unix the symlinks dangle and
+        // reads fail with ENOENT; on Windows without Dev Mode the copy
+        // fallback would error with ENOENT and abort the whole runtime-home
+        // prep — exactly the "Failed to prepare gemini runtime home" toast
+        // the user reported. Both platforms must succeed without those
+        // source files, and on Windows the runtime entries must simply be
+        // absent (no stale content masquerading as fresh state).
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path().join("real-home");
+        let gemini = home.join(".gemini");
+        fs::create_dir_all(&gemini).unwrap();
+        // Note: NO oauth_creds.json, google_accounts.json, or .env written.
+        let houston_data = tmp.path().join("houston-data");
+
+        let runtime_home = ensure_gemini_runtime_home(&houston_data, &home).unwrap();
+
+        // settings.json must still exist (Houston-written, not symlinked).
+        assert!(runtime_home.join(".gemini/settings.json").exists());
+
+        #[cfg(windows)]
+        {
+            // Copy fallback on Windows: missing source → no entry. Reads
+            // by gemini-cli will return ENOENT, matching Unix's dangling
+            // symlink behavior at read time.
+            assert!(!runtime_home.join(".gemini/oauth_creds.json").exists());
+            assert!(!runtime_home.join(".gemini/google_accounts.json").exists());
+            assert!(!runtime_home.join(".gemini/.env").exists());
+        }
     }
 
     #[cfg(unix)]

--- a/engine/houston-terminal-manager/src/gemini_runner.rs
+++ b/engine/houston-terminal-manager/src/gemini_runner.rs
@@ -16,10 +16,10 @@
 
 use crate::cli_process::run_cli_process;
 use crate::gemini_home;
+use crate::provider::InstallSource;
 use crate::session_update::SessionUpdate;
 use crate::types::SessionStatus;
 use crate::Provider;
-use houston_cli_bundle::bundled_gemini_path;
 use std::ffi::OsString;
 use std::path::{Path, PathBuf};
 use tokio::process::Command;
@@ -52,7 +52,27 @@ pub(crate) async fn spawn_gemini(
         }
     }
 
+    // Resolve via the adapter so the same code path covers both the
+    // bundled .app/MSI binary and the `gemini` PATH lookup developers
+    // rely on in dev mode. When neither exists we must NOT fall through
+    // to `Command::new("gemini")` — on Windows that surfaces as the
+    // generic "Failed to spawn gemini: program not found" toast, which
+    // doesn't tell the user that Gemini is not yet bundled on Windows
+    // (see knowledge-base/cli-bundling.md, phase-2 note). Emit a
+    // platform-aware error and bail.
+    let (install_source, gemini_path) = provider.resolve();
+    let bin = match (install_source, gemini_path) {
+        (InstallSource::Missing, _) | (_, None) => {
+            let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(
+                gemini_missing_message().to_string(),
+            )));
+            return;
+        }
+        (_, Some(path)) => path,
+    };
+
     let mut cmd = build_gemini_command(
+        &bin,
         resume_session_id.as_deref(),
         working_dir.as_deref(),
         model.as_deref(),
@@ -103,23 +123,73 @@ pub(crate) async fn spawn_gemini(
 }
 
 fn build_gemini_command(
+    bin: &Path,
     resume_session_id: Option<&str>,
     working_dir: Option<&Path>,
     model: Option<&str>,
 ) -> Command {
-    // Prefer the bundled gemini SEA over whatever happens to be on the
-    // user's PATH. The user might have an older `npm i -g @google/gemini-cli`
-    // that doesn't recognize `--yolo` or has a different stream-json
-    // shape. We pin the bundled binary so the schema in
-    // `gemini_parser.rs` always matches what gets spawned.
-    let bin = bundled_gemini_path().unwrap_or_else(|| PathBuf::from("gemini"));
-    let mut cmd = Command::new(&bin);
+    // The caller resolved `bin` via `provider.resolve()` so this is
+    // either the bundled SEA (preferred — we pin the version so the
+    // schema in `gemini_parser.rs` matches what gets spawned) or a
+    // gemini found on the user's PATH. Old PATH installs that don't
+    // recognise `--yolo` / `--skip-trust` will fail visibly in dev mode,
+    // which is acceptable because production builds ship the bundled
+    // version.
+    let mut cmd = Command::new(bin);
     cmd.env("PATH", super::claude_path::shell_path());
     cmd.args(build_gemini_args(resume_session_id, working_dir, model));
     if let Some(dir) = working_dir {
-        cmd.current_dir(dir);
+        // Strip the `\\?\` extended-length prefix on Windows for the
+        // same reason as the `--include-directories` arg: Node's
+        // path-resolution stack inside gemini-cli misparses the prefix.
+        // The cwd ends up surfaced to the model as well (gemini emits
+        // it back in tool messages) so passing a clean path keeps the
+        // whole stack consistent.
+        cmd.current_dir(gemini_compatible_path(dir));
     }
     cmd
+}
+
+/// Make `path` safe to hand to gemini-cli as a directory argument.
+///
+/// On Windows, `std::fs::canonicalize` returns the extended-length
+/// prefix form (`\\?\C:\Users\...`). Node.js's `fs.realpathSync`
+/// (used inside gemini-cli's `WorkspaceContext.resolveAndValidateDir`)
+/// chokes on that prefix and crashes with
+/// `EISDIR: illegal operation on a directory, lstat 'C:'` — it tries
+/// to lstat each path component and parses `C:` as a directory entry
+/// rather than the drive letter. Strip the prefix so gemini sees a
+/// plain `C:\Users\...` path. UNC variant (`\\?\UNC\server\share`) is
+/// rewritten back to the standard UNC form (`\\server\share`).
+///
+/// No-op on Unix. The kernel never produces the `\\?\` prefix there.
+fn gemini_compatible_path(path: &Path) -> PathBuf {
+    #[cfg(windows)]
+    {
+        if let Some(s) = path.to_str() {
+            if let Some(rest) = s.strip_prefix(r"\\?\UNC\") {
+                return PathBuf::from(format!(r"\\{rest}"));
+            }
+            if let Some(rest) = s.strip_prefix(r"\\?\") {
+                return PathBuf::from(rest);
+            }
+        }
+    }
+    path.to_path_buf()
+}
+
+/// User-visible explanation when `provider.resolve()` reports the
+/// gemini binary is missing. Tailored per platform: Windows has no
+/// upstream gemini binary in v1, so users there get a "not yet
+/// supported" message; macOS / Linux builds ship the binary inside
+/// the bundle and a Missing result means the bundle is broken.
+fn gemini_missing_message() -> &'static str {
+    if cfg!(windows) {
+        "Gemini is not available on Windows yet. Switch to Anthropic or OpenAI \
+         for now, or follow Houston's Windows release notes for when Gemini lands."
+    } else {
+        "Gemini CLI binary missing. Reinstall Houston to restore the bundled CLI."
+    }
 }
 
 /// Build the argv for `gemini`. Kept pure so it can be unit-tested
@@ -171,7 +241,7 @@ fn build_gemini_args(
     }
     if let Some(dir) = working_dir {
         args.push(OsString::from("--include-directories"));
-        args.push(dir.as_os_str().to_os_string());
+        args.push(gemini_compatible_path(dir).into_os_string());
     }
     if let Some(sid) = resume_session_id {
         args.push(OsString::from("--resume"));
@@ -255,6 +325,55 @@ mod tests {
         let args = strings(build_gemini_args(None, Some(&dir), None));
         let pos = args.iter().position(|a| a == "--include-directories").unwrap();
         assert_eq!(args[pos + 1], "/tmp/work");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_extended_length_prefix_stripped_from_include_directories() {
+        // std::fs::canonicalize on Windows returns the `\\?\` prefixed
+        // extended-length form. gemini-cli's Node-based
+        // `WorkspaceContext.resolveAndValidateDir` crashes on it:
+        //   Error: EISDIR: illegal operation on a directory, lstat 'C:'
+        // We strip the prefix before handing the path to gemini.
+        let dir = PathBuf::from(r"\\?\C:\Users\danie\workspace\agent");
+        let args = strings(build_gemini_args(None, Some(&dir), None));
+        let pos = args.iter().position(|a| a == "--include-directories").unwrap();
+        assert_eq!(args[pos + 1], r"C:\Users\danie\workspace\agent");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_extended_unc_prefix_normalized() {
+        // `\\?\UNC\server\share\path` is the extended-length form of
+        // `\\server\share\path`. Same Node parse failure; rewrite back
+        // to the standard UNC form.
+        let dir = PathBuf::from(r"\\?\UNC\server\share\agent");
+        let args = strings(build_gemini_args(None, Some(&dir), None));
+        let pos = args.iter().position(|a| a == "--include-directories").unwrap();
+        assert_eq!(args[pos + 1], r"\\server\share\agent");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn windows_plain_path_unchanged() {
+        // Only `\\?\` prefixed paths get rewritten — plain `C:\` paths
+        // pass through verbatim.
+        let dir = PathBuf::from(r"C:\Users\danie\workspace\agent");
+        let args = strings(build_gemini_args(None, Some(&dir), None));
+        let pos = args.iter().position(|a| a == "--include-directories").unwrap();
+        assert_eq!(args[pos + 1], r"C:\Users\danie\workspace\agent");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unix_path_unchanged_through_compatibility_helper() {
+        // The Windows-only `\\?\` rewrite must be a strict no-op on
+        // Unix — the kernel never produces that prefix and any
+        // Unix-y path must reach gemini-cli byte-identical.
+        let dir = PathBuf::from("/Users/danie/workspace/agent");
+        let args = strings(build_gemini_args(None, Some(&dir), None));
+        let pos = args.iter().position(|a| a == "--include-directories").unwrap();
+        assert_eq!(args[pos + 1], "/Users/danie/workspace/agent");
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/provider/resolve.rs
+++ b/engine/houston-terminal-manager/src/provider/resolve.rs
@@ -27,16 +27,35 @@ pub enum InstallSource {
 }
 
 /// Walk the resolved shell PATH and return the first matching binary.
-/// On Windows we additionally check the standard `PATHEXT` extensions so
-/// `codex.cmd` / `claude.exe` / etc. all resolve from a bare command
-/// name. Returns `None` if nothing matches.
+/// On Windows we check the standard `PATHEXT` extensions FIRST so
+/// `codex.cmd` / `claude.exe` / etc. resolve before the bare name.
+///
+/// **Order matters on Windows.** npm-global (the dominant Windows
+/// install path for `@google/gemini-cli`, `@anthropic-ai/claude-code`,
+/// `@openai/codex`) ships both `<name>` (a Unix-style script with a
+/// `#!/usr/bin/env node` shebang) AND `<name>.cmd` (a Windows batch
+/// shim that invokes Node). Returning the bare script means
+/// `Command::new(path)` later calls Windows `CreateProcess` on a
+/// non-PE file and fails with os error 193 ("%1 is not a valid Win32
+/// application"). Returning the `.cmd` shim makes Rust's spawn route
+/// through `cmd.exe` (per the CVE-2024-24576 mitigation) and the
+/// script runs as intended.
+///
+/// Returns `None` if nothing matches.
 pub fn which_on_path(command: &str) -> Option<PathBuf> {
     let shell_path = claude_path::shell_path();
-    for dir in std::env::split_paths(&shell_path) {
-        let candidate = dir.join(command);
-        if candidate.is_file() {
-            return Some(candidate);
-        }
+    which_in_dirs(command, std::env::split_paths(&shell_path))
+}
+
+/// Inner pure-function variant of [`which_on_path`] that takes the PATH
+/// directories explicitly. Exists so tests can stage a real PATH with a
+/// `TempDir` instead of mutating the process-global PATH cache that
+/// `claude_path::shell_path` reads.
+fn which_in_dirs<I>(command: &str, dirs: I) -> Option<PathBuf>
+where
+    I: IntoIterator<Item = PathBuf>,
+{
+    for dir in dirs {
         #[cfg(windows)]
         {
             for ext in ["exe", "cmd", "bat", "ps1"] {
@@ -45,6 +64,10 @@ pub fn which_on_path(command: &str) -> Option<PathBuf> {
                     return Some(candidate);
                 }
             }
+        }
+        let candidate = dir.join(command);
+        if candidate.is_file() {
+            return Some(candidate);
         }
     }
     None
@@ -71,5 +94,97 @@ mod tests {
     #[test]
     fn which_on_path_returns_none_for_garbage() {
         assert!(which_on_path("definitely-not-a-real-binary-xyz-zzz-houston-test").is_none());
+    }
+
+    #[test]
+    fn which_in_dirs_returns_none_when_no_match() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let dirs = vec![tmp.path().to_path_buf()];
+        assert!(which_in_dirs("absent-tool", dirs).is_none());
+    }
+
+    #[test]
+    fn which_in_dirs_walks_dirs_in_order() {
+        // First matching directory wins, even when later directories
+        // also contain the binary. Regression guard for the resolved
+        // path order.
+        let tmp_a = tempfile::TempDir::new().unwrap();
+        let tmp_b = tempfile::TempDir::new().unwrap();
+        let name = bare_executable_name();
+        std::fs::write(tmp_a.path().join(&name), "first").unwrap();
+        std::fs::write(tmp_b.path().join(&name), "second").unwrap();
+        let dirs = vec![tmp_a.path().to_path_buf(), tmp_b.path().to_path_buf()];
+        let resolved = which_in_dirs(executable_lookup_name(), dirs).unwrap();
+        assert_eq!(resolved, tmp_a.path().join(&name));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn which_in_dirs_finds_bare_filename_on_unix() {
+        // Unix CLIs are bare filenames with no extension. The bare-name
+        // branch must keep finding them.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("toolx");
+        std::fs::write(&path, "").unwrap();
+        let resolved = which_in_dirs("toolx", vec![tmp.path().to_path_buf()]).unwrap();
+        assert_eq!(resolved, path);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn which_in_dirs_prefers_cmd_over_bare_on_windows() {
+        // npm-global ships both `gemini` (Unix script, not executable
+        // on Windows) and `gemini.cmd` (Windows shim). The .cmd MUST
+        // win — returning the bare script means the later spawn fails
+        // with os error 193 ("%1 is not a valid Win32 application").
+        // Regression guard for the per-dir extension priority.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let bare = tmp.path().join("gemini");
+        let cmd = tmp.path().join("gemini.cmd");
+        std::fs::write(&bare, "#!/usr/bin/env node\n").unwrap();
+        std::fs::write(&cmd, "@echo off\r\n").unwrap();
+        let resolved = which_in_dirs("gemini", vec![tmp.path().to_path_buf()]).unwrap();
+        assert_eq!(resolved, cmd);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn which_in_dirs_prefers_exe_over_cmd_on_windows() {
+        // When both .exe and .cmd exist, prefer the native PE — it
+        // spawns directly via CreateProcess without going through
+        // cmd.exe and so has lower overhead and a cleaner process tree.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let exe = tmp.path().join("toolx.exe");
+        let cmd = tmp.path().join("toolx.cmd");
+        std::fs::write(&exe, b"").unwrap();
+        std::fs::write(&cmd, b"@echo off\r\n").unwrap();
+        let resolved = which_in_dirs("toolx", vec![tmp.path().to_path_buf()]).unwrap();
+        assert_eq!(resolved, exe);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn which_in_dirs_falls_back_to_bare_on_windows() {
+        // Bare PE files (no `.exe` extension) are rare but legal on
+        // Windows — Windows will execute them as long as the PE
+        // signature is present. When no extensioned variant exists,
+        // the bare filename must still resolve.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let bare = tmp.path().join("toolx");
+        std::fs::write(&bare, b"").unwrap();
+        let resolved = which_in_dirs("toolx", vec![tmp.path().to_path_buf()]).unwrap();
+        assert_eq!(resolved, bare);
+    }
+
+    fn bare_executable_name() -> String {
+        if cfg!(windows) {
+            "toolx.exe".to_string()
+        } else {
+            "toolx".to_string()
+        }
+    }
+
+    fn executable_lookup_name() -> &'static str {
+        "toolx"
     }
 }

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -205,11 +205,23 @@ etc.) and answers Houston tasks with the wrong context.
 `houston-terminal-manager::gemini_home::ensure_gemini_runtime_home`
 builds a Houston-managed HOME at `~/.houston/runtime/gemini-home/`
 containing only `.gemini/oauth_creds.json` + `google_accounts.json`
-symlinked from the real home (so OAuth still works without re-auth)
-plus a minimal `.gemini/settings.json` that mirrors the user's
-`selectedType`. No `GEMINI.md` is present, so global memory discovery
-finds nothing. Per-agent context still flows because gemini-cli walks
-UP from `cwd` and the agent dir contains `GEMINI.md → CLAUDE.md`
-seeded by `seed_agent`. Both `gemini_runner::spawn_gemini` and
++ `.env` symlinked from the real home (so OAuth and API-key auth
+both keep working without re-auth) plus a minimal
+`.gemini/settings.json` that mirrors the user's `selectedType`. No
+`GEMINI.md` is present, so global memory discovery finds nothing.
+Per-agent context still flows because gemini-cli walks UP from
+`cwd` and the agent dir contains `GEMINI.md → CLAUDE.md` seeded by
+`seed_agent`. Both `gemini_runner::spawn_gemini` and
 `sessions::summarize::run_gemini_summary` set `cmd.env("HOME", ...)`
 to this runtime path before spawning.
+
+**Windows symlink fallback.** Stock Windows installs reject
+`symlink_file` (os error 1314, "A required privilege is not held by
+the client") unless Developer Mode or admin is on. `ensure_symlink`
+falls back to `fs::copy`. If the real-home source file does not
+exist yet — common for first-time gemini users who have not
+completed OAuth or pasted an API key — the Windows path treats the
+missing source as "skip this entry" instead of erroring. Without
+that, the user-visible toast was: _"Failed to prepare gemini
+runtime home: The system cannot find the file specified. (os
+error 2). Houston cannot spawn gemini safely without it."_

--- a/knowledge-base/platform-matrix.md
+++ b/knowledge-base/platform-matrix.md
@@ -27,7 +27,28 @@ both.
 - **Symlinks**: `std::os::unix::fs::symlink` on Unix,
   `std::os::windows::fs::symlink_file` / `symlink_dir` on Windows.
   Both branches wired in `agents_crud.rs`, `agents/prompt.rs`,
-  `skills.rs`.
+  `skills.rs`. Windows symlink creation needs Developer Mode or
+  admin; stock installs fail with os error 1314 ("A required
+  privilege is not held by the client"). Call sites that expose
+  agent-role content to a sibling CLI (AGENTS.md/GEMINI.md in
+  `agents/prompt.rs` and `houston-agent-files::migrate_agent_data`)
+  fall back to `fs::copy` so non-admin Windows users still see the
+  role file. The gemini runtime-home staging
+  (`houston-terminal-manager::gemini_home::ensure_symlink`) also
+  tolerates a missing source on the copy fallback so first-time
+  gemini users without `~/.gemini/.env` or OAuth files do not hit
+  "Failed to prepare gemini runtime home".
+- **PATH lookup**: `houston-terminal-manager::provider::which_on_path`
+  walks each PATH directory. On Windows it checks
+  `.exe` / `.cmd` / `.bat` / `.ps1` variants BEFORE the bare filename
+  in each directory so npm-global CLIs (which ship both `<name>` —
+  Unix script — and `<name>.cmd` — Windows shim — in the same dir)
+  resolve to the executable shim instead of the unexecutable script.
+  Without that, `Command::new(...)` later fails with os error 193
+  ("%1 is not a valid Win32 application"). Inner pure helper
+  `which_in_dirs(command, iter)` is exposed for tests so the
+  per-platform priority can be verified without mutating
+  process-global PATH.
 - **PTY**: `portable-pty` (used in `houston-terminal-manager::manager`)
   — ConPTY-backed on Windows 10+, no code change needed.
 - **File watcher**: `notify` — native backends on each OS.
@@ -44,6 +65,7 @@ both.
 | Login-shell PATH probe | `houston-terminal-manager/src/claude_path.rs` | `/bin/zsh -l -c 'echo $PATH'`, fallback `/bin/bash -l`, `-i` | skipped — inherited process PATH is already the user PATH |
 | Common-install-dir probe | same | `~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `~/.cargo/bin`, `~/.composio`, nvm node dirs | `~\.cargo\bin`, `~\.composio`, `~\AppData\Roaming\npm`, `~\AppData\Local\Programs\claude` |
 | Command-exists check | same `is_command_available` | bare filename | bare + `.exe`/`.cmd`/`.bat`/`.ps1` variants |
+| Gemini CLI spawn | `houston-terminal-manager/src/gemini_runner.rs` + `houston-engine-core/src/sessions/provider_oneshot.rs::run_gemini` | bundled SEA per arch (`Resources/bin/gemini-<arch>/gemini`) | bundled binary not shipped in v1; falls back to user-installed gemini-cli on PATH (e.g. `npm i -g @google/gemini-cli`). Two Windows-specific quirks make this work: (a) `which_on_path` prefers `.exe`/`.cmd`/`.bat`/`.ps1` variants over the bare filename so the npm-global `.cmd` shim wins over the unexecutable Unix script that ships in the same dir (avoids os error 193, "%1 is not a valid Win32 application"); (b) `gemini_compatible_path` strips the `\\?\` extended-length prefix from canonicalized agent paths before they hit `--include-directories` because gemini-cli's Node-based `fs.realpathSync` parses each component and crashes with `EISDIR: illegal operation on a directory, lstat 'C:'`. If neither bundled nor PATH-installed, both call sites short-circuit with a platform-aware "not available yet" toast. UI also unlocks the chat-model dropdown when the locked provider has `cli_installed=false` (`chat-model-selector.tsx`). |
 
 ## Known gaps — Windows needs a follow-up
 

--- a/ui/agent-schemas/src/config.schema.json
+++ b/ui/agent-schemas/src/config.schema.json
@@ -5,7 +5,7 @@
   "type": "object",
   "properties": {
     "name": { "type": "string" },
-    "provider": { "type": "string", "enum": ["anthropic", "openai"] },
+    "provider": { "type": "string", "enum": ["anthropic", "openai", "gemini"] },
     "model": { "type": "string" },
     "effort": { "type": "string", "enum": ["low", "medium", "high"] }
   },


### PR DESCRIPTION
## Summary

- Pause Gemini behind the "Coming Soon" card in the UI catalog while
  keeping the entire engine + bundled-CLI plumbing intact for the
  eventual re-enable.
- Land the four Windows engine fixes that surfaced while debugging
  Gemini end-to-end (runtime-home staging, missing-binary error,
  `which_on_path` PATHEXT priority, `\?\` prefix rewrite for
  `--include-directories`).
- Fix a pre-existing TS2345 in `create-workspace-dialog.tsx` where
  the Create-with-AI flow seeded a `RoutineFormData` without the
  required `integrations: string[]` field.

Closes #208.

## What changed

### Engine — Windows readiness (commit `c794656`)

`engine/houston-terminal-manager/src/gemini_home.rs` — Windows
`ensure_symlink` copy-fallback now tolerates a missing source by
removing any stale entry at the link path and returning Ok. Matches
the Unix dangling-symlink semantics first-time gemini users rely on.

`engine/houston-engine-core/src/agents/prompt.rs` +
`engine/houston-agent-files/src/lib.rs` — `seed_agent` and
`migrate_agent_data` now prefer a relative symlink for
`AGENTS.md` / `GEMINI.md` → `CLAUDE.md` and fall back to `fs::copy`
when `symlink_file` is denied (Windows without Dev Mode, os error
1314). Replaces the previous `let _ = symlink(...)` silent failures.

`engine/houston-terminal-manager/src/gemini_runner.rs` +
`engine/houston-engine-core/src/sessions/provider_oneshot.rs` — spawn
sites now resolve the binary via `provider.resolve()` /
`bundled_gemini_path` + `which_on_path` and short-circuit with a
platform-aware error when missing, instead of letting
`Command::new("gemini")` produce the opaque
"Failed to spawn gemini: program not found" toast.

`engine/houston-terminal-manager/src/provider/resolve.rs` —
`which_on_path` now prefers `.exe` / `.cmd` / `.bat` / `.ps1`
variants over the bare filename on Windows. Without this, npm-global
CLIs that ship both `<name>` (Unix script) and `<name>.cmd`
(Windows shim) returned the unexecutable script and the spawn
failed with os error 193. Inner pure helper `which_in_dirs` exposed
for tests.

`engine/houston-terminal-manager/src/gemini_runner.rs` —
`gemini_compatible_path` strips the Windows extended-length prefix
(`\?\C:\...` → `C:\...`, `\?\UNC\server\share` → `\server\share`)
from the `--include-directories` arg and `Command::current_dir`.
gemini-cli's Node `fs.realpathSync` crashes on the prefixed form
(`Error: EISDIR: illegal operation on a directory, lstat 'C:'`).
No-op on Unix.

`ui/agent-schemas/src/config.schema.json` — provider enum gains
`"gemini"` so schema-validated writes accept the per-agent default.

`app/src/components/chat-model-selector.tsx` — drop the
`lockedProvider` lock when the engine reports
`cli_installed=false`, so a Windows install without a bundled Gemini
does not leave the user stuck in a chat they cannot send.

### Frontend — pause Gemini (commit `1741500`)

`app/src/lib/providers.ts` — Gemini removed from `PROVIDERS`, added
to `COMING_SOON_PROVIDERS` ahead of SubQ. New
`validProviderOrNull(id)` helper exported for fallback-chain
consumers.

`app/src/components/shell/provider-cards.tsx` — `ComingSoonLogo`
switch gains a Gemini case that returns the real `GeminiLogo`
component (instead of falling back to the two-letter chip).
`ProviderLogo` drops the now-unreachable `gemini` case.

`app/src/components/chat-model-selector.tsx` — extend the
`effectiveLock` derivation to also drop the lock when
`getProvider(lockedProvider)` is undefined (Gemini chats from
before the pause). Without this, the dropdown would render empty
for those chats. Drop the unreachable `case "gemini":` from
`iconFor` and the unused `GeminiLogo` import.

`app/src/components/use-agent-chat-panel.tsx` +
`app/src/components/tabs/chat-tab.tsx` — wrap each tier of the
effective-provider fallback chain in `validProviderOrNull` so a
legacy gemini-defaulted activity / agent / workspace falls through
to the next preference instead of routing to a paused provider.
Final fallback is the hardcoded `"anthropic"` already in place.

### Pre-existing TS2345 (commit `e952b58`)

`app/src/components/shell/create-workspace-dialog.tsx` — the
Create-with-AI flow seeded a `RoutineFormData` from a
`SuggestedRoutine` and omitted the required `integrations: string[]`
field that `ui/routines/src/routine-editor.tsx::RoutineFormData`
declares. Seed `integrations: []` — the AI suggestion does not
carry toolkit slugs and the user adds them in the routine editor.

### Docs

`knowledge-base/auth.md` — Windows symlink-fallback story for the
gemini runtime-home staging.

`knowledge-base/platform-matrix.md` — new `PATH lookup`
cross-platform primitive bullet covering the
`.exe`/`.cmd`/`.bat`/`.ps1` priority; the Gemini-CLI-spawn row
rewritten to describe the PATH-fallback path that makes Windows
work today via the user's npm-installed gemini-cli.

## Tests

Adds 14 new tests across the touched modules, including:

- `gemini_home::ensure_runtime_home_tolerates_missing_credential_files`
  — first-time-gemini-user path on both platforms.
- `prompt::seed_agent_role_files_contain_claude_md_content` +
  `link_or_copy_role_file_preserves_existing_override` — copy-
  fallback content correctness and hand-authored overrides.
- `agent-files::migrate_gemini_md_backfill_reflects_claude_md_content`
  — platform-agnostic GEMINI.md content check.
- `gemini_runner::windows_extended_length_prefix_stripped_from_include_directories`,
  `windows_extended_unc_prefix_normalized`,
  `windows_plain_path_unchanged`,
  `unix_path_unchanged_through_compatibility_helper`.
- `provider::resolve::which_in_dirs_prefers_cmd_over_bare_on_windows`
  (regression guard for os error 193),
  `which_in_dirs_prefers_exe_over_cmd_on_windows`,
  `which_in_dirs_falls_back_to_bare_on_windows`,
  `which_in_dirs_finds_bare_filename_on_unix`,
  `which_in_dirs_walks_dirs_in_order`,
  `which_in_dirs_returns_none_when_no_match`.

## Test plan

- [x] `cargo test -p houston-terminal-manager --lib` — 188/188 pass on
      Windows host.
- [x] `cargo test -p houston-engine-core --lib agents::prompt` — 9/9 pass.
- [x] `cargo test -p houston-engine-core --lib sessions::provider_oneshot` — 2/2 pass.
- [x] `cargo test -p houston-agent-files --lib` — 10/10 pass.
- [x] `cargo build -p houston-engine-server` — clean.
- [x] `pnpm tsc --noEmit` (app) — clean.
- [x] `pnpm check-locales` (app) — 16/16 namespaces in sync, en/es/pt.
- [x] End-to-end on Windows 11 (no Developer Mode): Gemini Flash-Lite
      via npm-installed gemini-cli v0.42.0 spawns cleanly and streams
      a real response back through the chat panel — verified before
      the UI pause landed.
- [x] Re-verify the frontend pause on a fresh checkout: new chat from
      a workspace whose default was Gemini routes to Anthropic
      without dropdown interaction; existing Gemini-only chat
      auto-unlocks the dropdown.
- [ ] CI macOS test job covers the Unix-gated tests.

## Out of scope

Bundled Gemini binary on Windows (phase-2 fork-build), and the
broader rollout work (account-tier gating, OAuth re-auth UX,
disconnect QA). The engine adapter, gemini connect dialog, API-key
form, and bundled-SEA resolver all stay in the codebase so
re-enabling Gemini is a one-line revert of `PROVIDERS`.