### PR TITLE
feat(provider): retire workspace defaults for per-agent storage

### DIFF
--- a/app/src/components/onboarding/personal-assistant-onboarding.tsx
+++ b/app/src/components/onboarding/personal-assistant-onboarding.tsx
@@ -5,7 +5,7 @@ import { analytics } from "../../lib/analytics";
 import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { useAgentStore } from "../../stores/agents";
-import { tauriWorkspaces } from "../../lib/tauri";
+import { tauriProvider, tauriWorkspaces } from "../../lib/tauri";
 import type { Agent } from "../../lib/types";
 import { MissionFrame } from "./mission-frame";
 import { MeetMission } from "./missions/meet";
@@ -87,11 +87,10 @@ export function PersonalAssistantOnboarding({
       approvalRule: t("setup:tutorial.defaults.approvalRule"),
     });
     setup.color = assistantColor;
-    const ws = await tauriWorkspaces.create(
-      setup.workspaceName.trim(),
-      pickedProvider,
-      pickedModel,
-    );
+    const ws = await tauriWorkspaces.create(setup.workspaceName.trim());
+    // Persist the picked pair as the new global default so the next new agent
+    // starts from the same place the user just chose during onboarding.
+    await tauriProvider.setLastUsed(pickedProvider, pickedModel);
     analytics.track("workspace_created", { provider: pickedProvider, source: "onboarding" });
     const created = await createPersonalAssistantForWorkspace(ws.id, {
       name: setup.assistantName.trim(),

--- a/app/src/components/portable/import-wizard.tsx
+++ b/app/src/components/portable/import-wizard.tsx
@@ -15,7 +15,7 @@
  * `NamingStep` for name+color, so it feels exactly like creating an
  * agent from scratch.
  */
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
 import {
@@ -35,7 +35,7 @@ import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { useAgentStore } from "../../stores/agents";
 import { getEngine } from "../../lib/engine";
-import { tauriConfig } from "../../lib/tauri";
+import { tauriConfig, tauriProvider } from "../../lib/tauri";
 import { getDefaultModel } from "../../lib/providers";
 import { IntegrationLogos } from "../integration-logos";
 import { InlineModelSelector } from "../shell/naming-step";
@@ -70,9 +70,6 @@ export function ImportAgentWizard() {
   const currentWorkspace = useWorkspaceStore((s) => s.current);
   const loadAgents = useAgentStore((s) => s.loadAgents);
 
-  const wsProvider = currentWorkspace?.provider ?? "anthropic";
-  const wsModel = currentWorkspace?.model ?? getDefaultModel(wsProvider);
-
   const [stepIndex, setStepIndex] = useState(0);
   const [uploaded, setUploaded] =
     useState<PortableUploadPreviewResponse | null>(null);
@@ -81,8 +78,26 @@ export function ImportAgentWizard() {
   const [scan, setScan] = useState<PortableScanResponse | null>(null);
   const [name, setName] = useState("");
   const [color, setColor] = useState<string>(AGENT_COLORS[0].id);
-  const [provider, setProvider] = useState(wsProvider);
-  const [model, setModel] = useState(wsModel);
+  const [provider, setProvider] = useState<string>("anthropic");
+  const [model, setModel] = useState<string>(getDefaultModel("anthropic"));
+
+  // Read the sticky default whenever the wizard opens so the picker starts
+  // from the user's last pick (made in the create-agent dialog, AI-assist
+  // step, or chat-tab picker). Falls back to Anthropic if nothing was ever
+  // stored (fresh install).
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    tauriProvider.getLastUsed().then(({ provider: p, model: m }) => {
+      if (cancelled) return;
+      const next = p ?? "anthropic";
+      setProvider(next);
+      setModel(m ?? getDefaultModel(next));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
   const [selection, setSelection] = useState<Selection>({
     skillSlugs: new Set(),
     routineIds: new Set(),
@@ -113,14 +128,14 @@ export function ImportAgentWizard() {
     setWantScan(null);
     setName("");
     setColor(AGENT_COLORS[0].id);
-    setProvider(wsProvider);
-    setModel(wsModel);
+    // Provider/model intentionally NOT reset here — the open-effect above
+    // re-hydrates them from `tauriProvider.getLastUsed()` on the next open.
     setSelection({
       skillSlugs: new Set(),
       routineIds: new Set(),
       learningIds: new Set(),
     });
-  }, [wsProvider, wsModel]);
+  }, []);
 
   const runScan = async (packageId: string) => {
     setScanning(true);
@@ -192,16 +207,16 @@ export function ImportAgentWizard() {
           includeLearningIds: Array.from(selection.learningIds),
         },
       });
-      // Mirror NamingStep: if user picked a different model, persist it on
-      // the agent's local config so the chat starts on the right brain.
-      if (provider !== wsProvider || model !== wsModel) {
-        const cfg = await tauriConfig.read(installed.agentPath);
-        await tauriConfig.write(installed.agentPath, {
-          ...cfg,
-          provider: provider as "anthropic" | "openai",
-          model,
-        });
-      }
+      // Always persist provider/model on the imported agent's config — same
+      // contract as the create-agent dialog. Workspace-level defaults are
+      // gone, so a blank field would resolve to the platform default.
+      const cfg = await tauriConfig.read(installed.agentPath);
+      await tauriConfig.write(installed.agentPath, {
+        ...cfg,
+        provider: provider as "anthropic" | "openai",
+        model,
+      });
+      await tauriProvider.setLastUsed(provider, model);
       await loadAgents(currentWorkspace.id);
       addToast({
         variant: "success",

--- a/app/src/components/settings/sections/provider.tsx
+++ b/app/src/components/settings/sections/provider.tsx
@@ -1,28 +1,8 @@
 import { Trans, useTranslation } from "react-i18next";
-import { ProviderPicker } from "../../shell/provider-picker";
-import { getProvider } from "../../../lib/providers";
-import { useWorkspaceStore } from "../../../stores/workspaces";
-import { useUIStore } from "../../../stores/ui";
+import { ProviderSettings } from "../../shell/provider-settings";
 
 export function ProviderSection() {
   const { t } = useTranslation("settings");
-  const currentWorkspace = useWorkspaceStore((s) => s.current);
-  const updateProvider = useWorkspaceStore((s) => s.updateProvider);
-  const addToast = useUIStore((s) => s.addToast);
-
-  if (!currentWorkspace) return null;
-
-  const handleProviderSelect = async (provider: string, model: string) => {
-    await updateProvider(currentWorkspace.id, provider, model);
-    // Source the display name from the canonical frontend catalog so adding
-    // a provider to `PROVIDERS` (e.g. Gemini → "Google") flows through to
-    // this toast automatically. The previous ternary hardcoded only OpenAI
-    // and Anthropic, mislabeling every other provider as "Anthropic".
-    const provName = getProvider(provider)?.name ?? provider;
-    addToast({
-      title: t("toasts.providerSwitched", { provider: provName, model }),
-    });
-  };
 
   return (
     <section>
@@ -33,11 +13,7 @@ export function ProviderSection() {
           components={{ emph: <strong className="text-foreground font-medium" /> }}
         />
       </p>
-      <ProviderPicker
-        value={currentWorkspace.provider ?? null}
-        model={currentWorkspace.model ?? null}
-        onSelect={handleProviderSelect}
-      />
+      <ProviderSettings />
     </section>
   );
 }

--- a/app/src/components/shell/ai-assist-step.tsx
+++ b/app/src/components/shell/ai-assist-step.tsx
@@ -2,14 +2,18 @@ import { useState, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { DialogTitle } from "@houston-ai/core";
 import type { SuggestedIntegration, SuggestedRoutine } from "@houston-ai/engine-client";
-import { tauriAgents } from "../../lib/tauri";
+import { tauriAgents, tauriProvider } from "../../lib/tauri";
 import { AgentSetupForm, type AgentSetupFormValues } from "./agent-setup-form";
 import { AiStepFooter } from "./ai-step-footer";
 import { serializeFormValues } from "./agent-setup-utils";
+import { InlineModelSelector } from "./naming-step";
 
 interface AiAssistStepProps {
   provider: string;
   model: string;
+  /** Lift the picker change so the parent dialog can use it as the brain for
+   * the assist call AND the saved provider/model on the created agent. */
+  onProviderChange: (provider: string, model: string) => void;
   onBack: () => void;
   /** Called with the final CLAUDE.md content, suggested name, integrations, and an optional routine. */
   onContinue: (
@@ -28,12 +32,25 @@ const DEFAULT_FORM: AgentSetupFormValues = {
   extra: "",
 };
 
-export function AiAssistStep({ provider, model, onBack, onContinue }: AiAssistStepProps) {
+export function AiAssistStep({
+  provider,
+  model,
+  onProviderChange,
+  onBack,
+  onContinue,
+}: AiAssistStepProps) {
   const { t } = useTranslation("shell");
   const [form, setForm] = useState<AgentSetupFormValues>(DEFAULT_FORM);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const abortRef = useRef<AbortController | null>(null);
+
+  const handlePickerChange = (next: string, nextModel: string) => {
+    onProviderChange(next, nextModel);
+    // Sticky default is updated only after the user actually generates with
+    // this brain (see handleGenerate). Updating on every dropdown poke would
+    // make the next new agent inherit a model the user never committed to.
+  };
 
   const canGenerate = !!form.focus && !generating;
 
@@ -50,6 +67,9 @@ export function AiAssistStep({ provider, model, onBack, onContinue }: AiAssistSt
     const controller = new AbortController();
     abortRef.current = controller;
     try {
+      // Persist the brain choice once the user commits to generating. This
+      // keeps the sticky default in sync with what actually built the agent.
+      await tauriProvider.setLastUsed(provider, model);
       const result = await tauriAgents.generateInstructions(description, {
         provider,
         model,
@@ -86,6 +106,17 @@ export function AiAssistStep({ provider, model, onBack, onContinue }: AiAssistSt
           <div>
             <h2 className="text-base font-semibold">{t("aiAssist.stepTitle")}</h2>
             <p className="text-sm text-muted-foreground">{t("aiAssist.cardDescription")}</p>
+          </div>
+
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-muted-foreground">
+              {t("aiAssist.brainLabel")}
+            </p>
+            <InlineModelSelector
+              provider={provider}
+              model={model}
+              onSelect={handlePickerChange}
+            />
           </div>
 
           <AgentSetupForm values={form} onChange={setForm} disabled={generating} />

--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -10,7 +10,7 @@ import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { useAgentStore } from "../../stores/agents";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { useUIStore } from "../../stores/ui";
-import { tauriConfig, tauriRoutines } from "../../lib/tauri";
+import { tauriConfig, tauriProvider, tauriRoutines } from "../../lib/tauri";
 import { logger } from "../../lib/logger";
 import type { SuggestedIntegration, SuggestedRoutine } from "@houston-ai/engine-client";
 import type { RoutineFormData } from "@houston-ai/routines";
@@ -52,11 +52,13 @@ export function CreateAgentDialog() {
   const [creating, setCreating] = useState(false);
   const [search, setSearch] = useState("");
   const [existingPath, setExistingPath] = useState<string | null>(null);
-  const wsProvider = currentWorkspace?.provider ?? "anthropic";
-  const wsModel = currentWorkspace?.model ?? getDefaultModel(wsProvider);
-  const [provider, setProvider] = useState(wsProvider);
-  const [model, setModel] = useState(wsModel);
+  const [provider, setProvider] = useState<string>("anthropic");
+  const [model, setModel] = useState<string>(getDefaultModel("anthropic"));
 
+  // Reset form on close. On open, sync the picker to the sticky last-used
+  // pair. Reading on open (not mount) prevents the old "stale workspace
+  // default baked into the new agent's config" bug: the picker always
+  // reflects whatever the user actually picked last.
   useEffect(() => {
     if (!open) {
       setStep(1);
@@ -72,10 +74,19 @@ export function CreateAgentDialog() {
       setCreating(false);
       setSearch("");
       setExistingPath(null);
-      setProvider(wsProvider);
-      setModel(wsModel);
+      return;
     }
-  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+    let cancelled = false;
+    tauriProvider.getLastUsed().then(({ provider: p, model: m }) => {
+      if (cancelled) return;
+      const nextProvider = p ?? "anthropic";
+      setProvider(nextProvider);
+      setModel(m ?? getDefaultModel(nextProvider));
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
 
   const handleClose = () => {
     setOpen(false);
@@ -99,15 +110,19 @@ export function CreateAgentDialog() {
         selectedDef?.config.agentSeeds,
         existingPath ?? undefined,
       );
-      // Write provider/model to agent config if different from workspace default
-      if (provider !== wsProvider || model !== wsModel) {
-        const cfg = await tauriConfig.read(agent.folderPath);
-        await tauriConfig.write(agent.folderPath, {
-          ...cfg,
-          provider: provider as "anthropic" | "openai",
-          model,
-        });
-      }
+      // Always write provider/model to the agent's own config. With workspace
+      // defaults retired, the agent is the single source of truth — leaving
+      // the field blank would make the engine resolver fall back to its
+      // platform default rather than the user's pick.
+      const cfg = await tauriConfig.read(agent.folderPath);
+      await tauriConfig.write(agent.folderPath, {
+        ...cfg,
+        provider: provider as "anthropic" | "openai",
+        model,
+      });
+      // Keep the sticky last-used in sync so the next new agent inherits
+      // the user's most recent choice.
+      await tauriProvider.setLastUsed(provider, model);
       if (routineAccepted && routineForm) {
         // The agent is brand new, so its scheduler was never started
         // (create() doesn't go through setCurrent, and use-houston-init
@@ -207,6 +222,10 @@ export function CreateAgentDialog() {
           <AiAssistStep
             provider={provider}
             model={model}
+            onProviderChange={(p, m) => {
+              setProvider(p);
+              setModel(m);
+            }}
             onBack={() => setStep(1)}
             onContinue={(instructions, suggestedName, integrations, routine) => {
               setGeneratedClaudeMd(instructions);

--- a/app/src/components/shell/provider-account-row.tsx
+++ b/app/src/components/shell/provider-account-row.tsx
@@ -1,0 +1,107 @@
+import { useTranslation } from "react-i18next";
+import { Loader2 } from "lucide-react";
+import type { ProviderInfo, ComingSoonProviderInfo } from "../../lib/providers";
+import {
+  ClaudeLogo,
+  OpenAILogo,
+  GeminiLogo,
+  DeepSeekLogo,
+  MiniMaxLogo,
+} from "./provider-logos";
+
+function ProviderLogo({ provider }: { provider: ProviderInfo }) {
+  switch (provider.id) {
+    case "anthropic":
+      return <ClaudeLogo />;
+    case "openai":
+      return <OpenAILogo />;
+    case "gemini":
+      return <GeminiLogo />;
+    default:
+      return (
+        <span className="text-[10px] font-semibold tracking-tight text-muted-foreground">
+          {provider.name.slice(0, 1).toUpperCase()}
+        </span>
+      );
+  }
+}
+
+function ComingSoonLogo({ provider }: { provider: ComingSoonProviderInfo }) {
+  switch (provider.id) {
+    case "deepseek":
+      return <DeepSeekLogo />;
+    case "minimax":
+      return <MiniMaxLogo />;
+    default:
+      return (
+        <span className="text-[10px] font-semibold tracking-tight text-muted-foreground">
+          {provider.mark}
+        </span>
+      );
+  }
+}
+
+export function ProviderAccountRow({
+  provider,
+  connected,
+  pending,
+  onConnect,
+  onSignOut,
+}: {
+  provider: ProviderInfo;
+  connected: boolean;
+  pending: boolean;
+  onConnect: () => void;
+  onSignOut: () => void;
+}) {
+  const { t } = useTranslation("providers");
+
+  return (
+    <div className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-secondary">
+      <div className="size-8 rounded-lg bg-background flex items-center justify-center shrink-0">
+        <ProviderLogo provider={provider} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-[13px] font-medium text-foreground truncate">{provider.name}</p>
+        <p className="text-[11px] text-muted-foreground truncate">
+          {connected ? t("card.connected") : provider.subtitle}
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={connected ? onSignOut : onConnect}
+        disabled={pending}
+        className="text-[12px] font-medium px-2.5 py-1 rounded-md border border-input bg-background hover:bg-black/[0.05] transition-colors disabled:opacity-60 disabled:cursor-wait focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40 shrink-0"
+      >
+        {pending ? (
+          <Loader2 className="size-3.5 animate-spin" />
+        ) : connected ? (
+          t("row.signOut")
+        ) : (
+          t("row.connect")
+        )}
+      </button>
+    </div>
+  );
+}
+
+export function ComingSoonRow({ provider }: { provider: ComingSoonProviderInfo }) {
+  const { t } = useTranslation("providers");
+  return (
+    <div
+      aria-disabled="true"
+      className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-secondary opacity-60 cursor-not-allowed select-none"
+    >
+      <div className="size-8 rounded-lg bg-background flex items-center justify-center shrink-0">
+        <ComingSoonLogo provider={provider} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-[13px] font-medium text-foreground truncate">{provider.name}</p>
+        <p className="text-[11px] text-muted-foreground truncate">{provider.subtitle}</p>
+      </div>
+      <span className="rounded-full bg-foreground/5 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground shrink-0">
+        {t("card.comingSoon")}
+      </span>
+    </div>
+  );
+}

--- a/app/src/components/shell/provider-account-row.tsx
+++ b/app/src/components/shell/provider-account-row.tsx
@@ -1,13 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { Loader2 } from "lucide-react";
-import type { ProviderInfo, ComingSoonProviderInfo } from "../../lib/providers";
-import {
-  ClaudeLogo,
-  OpenAILogo,
-  GeminiLogo,
-  DeepSeekLogo,
-  MiniMaxLogo,
-} from "./provider-logos";
+import type { ProviderInfo } from "../../lib/providers";
+import { ClaudeLogo, OpenAILogo, GeminiLogo } from "./provider-logos";
 
 function ProviderLogo({ provider }: { provider: ProviderInfo }) {
   switch (provider.id) {
@@ -21,21 +15,6 @@ function ProviderLogo({ provider }: { provider: ProviderInfo }) {
       return (
         <span className="text-[10px] font-semibold tracking-tight text-muted-foreground">
           {provider.name.slice(0, 1).toUpperCase()}
-        </span>
-      );
-  }
-}
-
-function ComingSoonLogo({ provider }: { provider: ComingSoonProviderInfo }) {
-  switch (provider.id) {
-    case "deepseek":
-      return <DeepSeekLogo />;
-    case "minimax":
-      return <MiniMaxLogo />;
-    default:
-      return (
-        <span className="text-[10px] font-semibold tracking-tight text-muted-foreground">
-          {provider.mark}
         </span>
       );
   }
@@ -56,16 +35,36 @@ export function ProviderAccountRow({
 }) {
   const { t } = useTranslation("providers");
 
+  // Disconnected rows get a faded background via the `bg-secondary/40` alpha
+  // modifier AND a CSS-opacity dim on the identity cluster (logo + name +
+  // subtitle). The button is kept OUTSIDE the inner opacity wrapper and
+  // uses a non-opacity-derived background, so it pops at full strength —
+  // same visual weight as the Sign out button on a connected row.
+  //
+  // Why a Tailwind alpha modifier instead of `opacity-40` on the outer div:
+  // CSS opacity cascades to descendants and can't be undone by a child
+  // class, which would mute the button too. `bg-secondary/40` only thins
+  // the bg color, leaving children rendering at their own colors.
   return (
-    <div className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-secondary">
-      <div className="size-8 rounded-lg bg-background flex items-center justify-center shrink-0">
-        <ProviderLogo provider={provider} />
-      </div>
-      <div className="flex-1 min-w-0">
-        <p className="text-[13px] font-medium text-foreground truncate">{provider.name}</p>
-        <p className="text-[11px] text-muted-foreground truncate">
-          {connected ? t("card.connected") : provider.subtitle}
-        </p>
+    <div
+      className={`flex items-center gap-3 px-3 py-2.5 rounded-xl transition-colors ${
+        connected ? "bg-secondary" : "bg-secondary/40"
+      }`}
+    >
+      <div
+        className={`flex items-center gap-3 flex-1 min-w-0 transition-opacity ${
+          connected ? "" : "opacity-50"
+        }`}
+      >
+        <div className="size-8 rounded-lg bg-background flex items-center justify-center shrink-0">
+          <ProviderLogo provider={provider} />
+        </div>
+        <div className="flex-1 min-w-0">
+          <p className="text-[13px] font-medium text-foreground truncate">{provider.name}</p>
+          <p className="text-[11px] text-muted-foreground truncate">
+            {connected ? t("card.connected") : provider.subtitle}
+          </p>
+        </div>
       </div>
       <button
         type="button"
@@ -81,27 +80,6 @@ export function ProviderAccountRow({
           t("row.connect")
         )}
       </button>
-    </div>
-  );
-}
-
-export function ComingSoonRow({ provider }: { provider: ComingSoonProviderInfo }) {
-  const { t } = useTranslation("providers");
-  return (
-    <div
-      aria-disabled="true"
-      className="flex items-center gap-3 px-3 py-2.5 rounded-xl bg-secondary opacity-60 cursor-not-allowed select-none"
-    >
-      <div className="size-8 rounded-lg bg-background flex items-center justify-center shrink-0">
-        <ComingSoonLogo provider={provider} />
-      </div>
-      <div className="flex-1 min-w-0">
-        <p className="text-[13px] font-medium text-foreground truncate">{provider.name}</p>
-        <p className="text-[11px] text-muted-foreground truncate">{provider.subtitle}</p>
-      </div>
-      <span className="rounded-full bg-foreground/5 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground shrink-0">
-        {t("card.comingSoon")}
-      </span>
     </div>
   );
 }

--- a/app/src/components/shell/provider-settings.tsx
+++ b/app/src/components/shell/provider-settings.tsx
@@ -1,0 +1,189 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { Spinner, ConfirmDialog } from "@houston-ai/core";
+import { tauriProvider, type ProviderStatus } from "../../lib/tauri";
+import {
+  PROVIDERS,
+  COMING_SOON_PROVIDERS,
+  type ProviderInfo,
+} from "../../lib/providers";
+import { useUIStore } from "../../stores/ui";
+import { analytics } from "../../lib/analytics";
+import { GeminiConnectDialog } from "./gemini-connect-dialog";
+import { ProviderAccountRow, ComingSoonRow } from "./provider-account-row";
+
+/**
+ * Settings-screen variant of the AI provider UI: accounts only.
+ *
+ * Houston used to also expose a workspace-level "default provider" picker
+ * here, but the workspace layer was retired in favor of per-agent storage.
+ * The agent-creation dialog reads its picker default from
+ * `tauriProvider.getLastUsed()`, and the chat-tab picker persists straight
+ * to the agent's config — so this screen has only one job left: sign in or
+ * sign out of the providers Houston knows about.
+ *
+ * Setup/onboarding still uses `<ProviderPicker>` — there the user has zero
+ * connections and the goal is exactly one decision (pick + connect).
+ */
+export function ProviderSettings() {
+  const { t } = useTranslation("providers");
+  const [statuses, setStatuses] = useState<Record<string, ProviderStatus>>({});
+  const [loading, setLoading] = useState(true);
+  const [pendingId, setPendingId] = useState<string | null>(null);
+  const [confirmSignOutFor, setConfirmSignOutFor] = useState<ProviderInfo | null>(null);
+  const [apiKeyDialogFor, setApiKeyDialogFor] = useState<ProviderInfo | null>(null);
+  const addToast = useUIStore((s) => s.addToast);
+
+  // First scan is treated as the baseline so opening Settings while a
+  // provider is already connected doesn't fire a fake "X connected" toast.
+  // Subsequent scans react to transitions normally.
+  const hasBaseline = useRef(false);
+  const prevStatuses = useRef<Record<string, ProviderStatus>>({});
+  const loadStatuses = useCallback(async () => {
+    const results = await Promise.all(
+      PROVIDERS.map(async (p) => [p.id, await tauriProvider.checkStatus(p.id)] as const),
+    );
+    const next: Record<string, ProviderStatus> = {};
+    for (const [id, status] of results) {
+      next[id] = status;
+    }
+    if (hasBaseline.current) {
+      for (const prov of PROVIDERS) {
+        const wasConnected =
+          prevStatuses.current[prov.id]?.cli_installed &&
+          prevStatuses.current[prov.id]?.authenticated;
+        const isConnected = next[prov.id]?.cli_installed && next[prov.id]?.authenticated;
+        if (!wasConnected && isConnected) {
+          analytics.track("provider_configured", { provider: prov.id });
+        }
+      }
+    }
+    prevStatuses.current = next;
+    hasBaseline.current = true;
+    setStatuses(next);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    loadStatuses();
+  }, [loadStatuses]);
+
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  useEffect(() => {
+    if (pendingId) {
+      pollRef.current = setInterval(loadStatuses, 2000);
+    }
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+    };
+  }, [pendingId, loadStatuses]);
+
+  useEffect(() => {
+    if (!pendingId) return;
+    const status = statuses[pendingId];
+    if (status?.cli_installed && status?.authenticated) {
+      setPendingId(null);
+    }
+  }, [pendingId, statuses]);
+
+  const handleConnect = async (provider: ProviderInfo) => {
+    if (provider.loginKind === "apiKey") {
+      setApiKeyDialogFor(provider);
+      return;
+    }
+    setPendingId(provider.id);
+    try {
+      await tauriProvider.launchLogin(provider.id);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[provider-settings] launchLogin(${provider.id}) failed:`, msg);
+      addToast({
+        title: t("toast.signInFailed", { provider: provider.name }),
+        description: msg,
+        variant: "error",
+      });
+      setPendingId(null);
+    }
+  };
+
+  const handleSignOut = async (provider: ProviderInfo) => {
+    setPendingId(provider.id);
+    try {
+      await tauriProvider.launchLogout(provider.id);
+      await loadStatuses();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[provider-settings] launchLogout(${provider.id}) failed:`, msg);
+      addToast({
+        title: t("toast.signOutFailed", { provider: provider.name }),
+        description: msg,
+        variant: "error",
+      });
+    } finally {
+      setPendingId(null);
+    }
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <Spinner className="h-5 w-5" />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="grid grid-cols-1 gap-2">
+        {PROVIDERS.map((prov) => {
+          const status = statuses[prov.id];
+          const connected = (status?.cli_installed && status?.authenticated) ?? false;
+          return (
+            <ProviderAccountRow
+              key={prov.id}
+              provider={prov}
+              connected={connected}
+              pending={pendingId === prov.id}
+              onConnect={() => handleConnect(prov)}
+              onSignOut={() => setConfirmSignOutFor(prov)}
+            />
+          );
+        })}
+        {COMING_SOON_PROVIDERS.map((prov) => (
+          <ComingSoonRow key={prov.id} provider={prov} />
+        ))}
+      </div>
+
+      <ConfirmDialog
+        open={confirmSignOutFor !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmSignOutFor(null);
+        }}
+        title={t("signOutConfirm.title", { provider: confirmSignOutFor?.name ?? "" })}
+        description={t("signOutConfirm.description", { provider: confirmSignOutFor?.name ?? "" })}
+        confirmLabel={t("signOutConfirm.confirm")}
+        cancelLabel={t("signOutConfirm.cancel")}
+        variant="destructive"
+        onConfirm={() => {
+          const target = confirmSignOutFor;
+          setConfirmSignOutFor(null);
+          if (target) handleSignOut(target);
+        }}
+      />
+
+      <GeminiConnectDialog
+        provider={apiKeyDialogFor}
+        onOpenChange={(open) => {
+          if (!open) setApiKeyDialogFor(null);
+        }}
+        onSaved={(providerId) => {
+          setPendingId(providerId);
+          loadStatuses();
+        }}
+        onLoginStarted={(providerId) => {
+          setPendingId(providerId);
+        }}
+      />
+    </>
+  );
+}

--- a/app/src/components/shell/provider-settings.tsx
+++ b/app/src/components/shell/provider-settings.tsx
@@ -1,16 +1,12 @@
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Spinner, ConfirmDialog } from "@houston-ai/core";
 import { tauriProvider, type ProviderStatus } from "../../lib/tauri";
-import {
-  PROVIDERS,
-  COMING_SOON_PROVIDERS,
-  type ProviderInfo,
-} from "../../lib/providers";
+import { PROVIDERS, type ProviderInfo } from "../../lib/providers";
 import { useUIStore } from "../../stores/ui";
 import { analytics } from "../../lib/analytics";
 import { GeminiConnectDialog } from "./gemini-connect-dialog";
-import { ProviderAccountRow, ComingSoonRow } from "./provider-account-row";
+import { ProviderAccountRow } from "./provider-account-row";
 
 /**
  * Settings-screen variant of the AI provider UI: accounts only.
@@ -124,6 +120,22 @@ export function ProviderSettings() {
     }
   };
 
+  // Connected providers float to the top so the user lands on what's
+  // already working. Within each group we preserve `PROVIDERS` order — the
+  // catalog is the source of truth for "which brand should be more prominent
+  // when nothing is connected yet," and we don't want connect/disconnect to
+  // shuffle siblings around each other.
+  const orderedProviders = useMemo(() => {
+    const connected: ProviderInfo[] = [];
+    const disconnected: ProviderInfo[] = [];
+    for (const p of PROVIDERS) {
+      const s = statuses[p.id];
+      if (s?.cli_installed && s?.authenticated) connected.push(p);
+      else disconnected.push(p);
+    }
+    return [...connected, ...disconnected];
+  }, [statuses]);
+
   if (loading) {
     return (
       <div className="flex justify-center py-12">
@@ -135,7 +147,7 @@ export function ProviderSettings() {
   return (
     <>
       <div className="grid grid-cols-1 gap-2">
-        {PROVIDERS.map((prov) => {
+        {orderedProviders.map((prov) => {
           const status = statuses[prov.id];
           const connected = (status?.cli_installed && status?.authenticated) ?? false;
           return (
@@ -149,9 +161,6 @@ export function ProviderSettings() {
             />
           );
         })}
-        {COMING_SOON_PROVIDERS.map((prov) => (
-          <ComingSoonRow key={prov.id} provider={prov} />
-        ))}
       </div>
 
       <ConfirmDialog

--- a/app/src/components/shell/workspace-dialog.tsx
+++ b/app/src/components/shell/workspace-dialog.tsx
@@ -10,7 +10,7 @@ import {
   cn,
 } from "@houston-ai/core";
 import { analytics } from "../../lib/analytics";
-import { tauriStore } from "../../lib/tauri";
+import { tauriProvider, tauriStore } from "../../lib/tauri";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { useAgentStore } from "../../stores/agents";
 import { useWorkspaceStore } from "../../stores/workspaces";
@@ -99,7 +99,7 @@ export function CreateWorkspaceDialog({
           <WorkspaceSetupFlow
             mode="dialog"
             onComplete={async (name, provider, model) => {
-              const ws = await createWorkspace(name, provider, model);
+              const ws = await createWorkspace(name);
               const setup = defaultAssistantSetup({
                 workspaceName: name,
                 assistantName: t("setup:tutorial.defaults.assistantName"),
@@ -115,6 +115,7 @@ export function CreateWorkspaceDialog({
                 provider,
                 model,
               });
+              await tauriProvider.setLastUsed(provider, model);
               setCurrentWorkspace(ws);
               await loadAgents(ws.id);
               handleClose();

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -164,7 +164,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
     selectedSessionKey,
     onSelectSession: setSelectedId,
   });
-  const { chatProvider, chatModel, effectiveProvider, effectiveModel } = panel;
+  const { effectiveProvider, effectiveModel } = panel;
 
   // Scope to this agent only — cross-agent bleeding is structurally blocked
   // because AIBoard can only see this agent's slice of the feed store.
@@ -454,7 +454,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
       analytics.track("mission_created", { agent_mode: agentMode ?? "default" });
       return conversationId;
     },
-    [path, agent.id, agent.name, agent.color, pushFeedItem, pendingAgentMode, agentModes, chatProvider, chatModel, queryClient, t],
+    [path, agent.id, agent.name, agent.color, pushFeedItem, pendingAgentMode, agentModes, effectiveProvider, effectiveModel, queryClient, t],
   );
 
   // Derive the session key for an activity, using custom key if set by routine runner
@@ -505,7 +505,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
         throw err;
       }
     },
-    [path, pushFeedItem, rawItems, agentModes, chatProvider, chatModel, t],
+    [path, pushFeedItem, rawItems, agentModes, effectiveProvider, effectiveModel, t],
   );
 
   const selectedSessionActive = selectedSessionKey

--- a/app/src/components/tabs/chat-tab.tsx
+++ b/app/src/components/tabs/chat-tab.tsx
@@ -14,11 +14,10 @@ import {
 } from "@houston-ai/core";
 import { useFeedStore } from "../../stores/feeds";
 import { useUIStore } from "../../stores/ui";
-import { useWorkspaceStore } from "../../stores/workspaces";
 import { useDraftStore, useDraftText, useDraftFiles } from "../../stores/drafts";
 import { isActiveSessionStatus, useSessionStatus } from "../../stores/session-status";
 import { useSessionMessageQueue } from "../../hooks/use-session-message-queue";
-import { tauriChat, tauriAttachments, tauriConfig } from "../../lib/tauri";
+import { tauriChat, tauriAttachments, tauriConfig, tauriProvider } from "../../lib/tauri";
 import { openAgentHref } from "../../lib/open-href";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { useFileToolRenderer } from "../../hooks/use-file-tool-renderer";
@@ -91,13 +90,10 @@ export default function ChatTab({ agent }: TabProps) {
   const sendingRef = useRef(false);
   const loadedRef = useRef<string | null>(null);
 
-  // --- Model selector: three-tier resolution ---
-  // Workspace default → agent config override → chat-level override (ephemeral)
-  const workspace = useWorkspaceStore((s) => s.current);
-  const wsProvider = workspace?.provider ?? "anthropic";
-  const wsModel = workspace?.model ?? getDefaultModel(wsProvider);
-
-  // Agent-level config (loaded once per agent)
+  // --- Model selector ---
+  // Provider/model lives on the agent. The chat picker writes through to the
+  // agent's `.houston/config/config.json` so the next session opens with the
+  // user's last pick and no other ephemeral state is involved.
   const [agentProvider, setAgentProvider] = useState<string | null>(null);
   const [agentModel, setAgentModel] = useState<string | null>(null);
   useEffect(() => {
@@ -107,17 +103,10 @@ export default function ChatTab({ agent }: TabProps) {
     }).catch(() => {});
   }, [agentPath]);
 
-  // Chat-level override (ephemeral, resets per agent)
-  const [chatProvider, setChatProvider] = useState<string | null>(null);
-  const [chatModel, setChatModel] = useState<string | null>(null);
-  useEffect(() => {
-    setChatProvider(null);
-    setChatModel(null);
-  }, [agent.id]);
-
-  // Effective = chat override > agent config > workspace default
-  const effectiveProvider = chatProvider ?? agentProvider ?? wsProvider;
-  const effectiveModel = chatModel ?? agentModel ?? wsModel;
+  // Effective = agent config > Anthropic default. Workspace-level defaults
+  // were retired; existing values were migrated into agent configs at boot.
+  const effectiveProvider = agentProvider ?? "anthropic";
+  const effectiveModel = agentModel ?? getDefaultModel(effectiveProvider);
   const authSignalKey = useMemo(
     () => providerAuthSignalKey(feedItems ?? []),
     [feedItems],
@@ -127,10 +116,40 @@ export default function ChatTab({ agent }: TabProps) {
     [feedItems],
   );
 
-  const handleModelSelect = useCallback((prov: string, mod: string) => {
-    setChatProvider(prov);
-    setChatModel(mod);
-  }, []);
+  const handleModelSelect = useCallback(
+    async (prov: string, mod: string) => {
+      // Optimistic local update so the dropdown flips immediately; the engine
+      // round-trip is the slow part and re-reading config to confirm would
+      // add a flash of the previous label.
+      setAgentProvider(prov);
+      setAgentModel(mod);
+      try {
+        const cfg = await tauriConfig.read(agentPath);
+        await tauriConfig.write(agentPath, {
+          ...cfg,
+          provider: prov as "anthropic" | "openai",
+          model: mod,
+        });
+        // Keep the sticky default in sync so the next new agent inherits
+        // whatever the user just settled on.
+        await tauriProvider.setLastUsed(prov, mod);
+      } catch (e) {
+        // Roll back the optimistic update so the picker doesn't lie about
+        // persisted state. Toast surfacing happens through the `call`
+        // wrapper inside `tauriConfig.write` / `tauriProvider.setLastUsed`.
+        console.error("[chat-tab] persist model selection failed:", e);
+        try {
+          const cfg = await tauriConfig.read(agentPath);
+          setAgentProvider(cfg.provider ?? null);
+          setAgentModel(cfg.model ?? null);
+        } catch {
+          setAgentProvider(null);
+          setAgentModel(null);
+        }
+      }
+    },
+    [agentPath],
+  );
 
   // Variant-aware model switcher fed to ProviderErrorCard.
   // - ModelUnavailable with `suggested_fallback`: stay in same provider,
@@ -243,7 +262,7 @@ export default function ChatTab({ agent }: TabProps) {
         sendingRef.current = false;
       }
     },
-    [agentPath, sessionKey, attachmentScope, pushFeedItem, setComposerText, setComposerFiles, chatProvider, chatModel, t],
+    [agentPath, sessionKey, attachmentScope, pushFeedItem, setComposerText, setComposerFiles, effectiveProvider, effectiveModel, t],
   );
   const handleQueued = useCallback(() => {
     setComposerText("");
@@ -294,17 +313,7 @@ export default function ChatTab({ agent }: TabProps) {
                   messageQueue.sendOrQueue(t("toolRuntimeError.retryPrompt"), [])
                 }
                 onSwitchModel={
-                  isModelUnsupported
-                    ? async () => {
-                        if (workspace?.id) {
-                          await useWorkspaceStore
-                            .getState()
-                            .updateProvider(workspace.id, "openai", "gpt-5.5");
-                        }
-                        setChatProvider("openai");
-                        setChatModel("gpt-5.5");
-                      }
-                    : undefined
+                  isModelUnsupported ? () => handleModelSelect("openai", "gpt-5.5") : undefined
                 }
               />
             );

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -37,7 +37,6 @@ import {
 
 import { useFeedStore } from "../stores/feeds";
 import { useUIStore } from "../stores/ui";
-import { useWorkspaceStore } from "../stores/workspaces";
 import {
   useActivity,
   useConnectedToolkits,
@@ -49,6 +48,7 @@ import {
   tauriAttachments,
   tauriChat,
   tauriConfig,
+  tauriProvider,
   tauriShell,
   tauriWorktree,
   withAttachmentPaths,
@@ -134,9 +134,6 @@ interface AgentChatPanelProps {
   /** Effective provider/model for sending. */
   effectiveProvider: string;
   effectiveModel: string;
-  /** Per-chat overrides chosen via the model selector. */
-  chatProvider: string | null;
-  chatModel: string | null;
 }
 
 export function useAgentChatPanel({
@@ -153,10 +150,10 @@ export function useAgentChatPanel({
   const path = agent?.folderPath ?? null;
   const agentModes = agentDef?.config.agents;
 
-  // ── Workspace / agent / activity tier model resolution ─────────────────
-  const workspace = useWorkspaceStore((s) => s.current);
-  const wsProvider = workspace?.provider ?? "anthropic";
-  const wsModel = workspace?.model ?? getDefaultModel(wsProvider);
+  // ── Activity / agent tier model resolution ─────────────────────────────
+  // Activity is the per-mission override; agent config is the per-agent
+  // default. Workspace-level defaults were retired; existing values were
+  // migrated into agent configs at engine boot.
   const [agentProvider, setAgentProvider] = useState<string | null>(null);
   const [agentModel, setAgentModel] = useState<string | null>(null);
   useEffect(() => {
@@ -185,29 +182,36 @@ export function useAgentChatPanel({
   const activityModel = selectedActivity?.model ?? null;
   const selectedActivityId = selectedActivity?.id ?? null;
 
-  const [chatProvider, setChatProvider] = useState<string | null>(null);
-  const [chatModel, setChatModel] = useState<string | null>(null);
-  useEffect(() => {
-    setChatProvider(null);
-    setChatModel(null);
-  }, [selectedSessionKey]);
-  const effectiveProvider = chatProvider ?? activityProvider ?? agentProvider ?? wsProvider;
-  const effectiveModel = chatModel ?? activityModel ?? agentModel ?? wsModel;
+  const effectiveProvider = activityProvider ?? agentProvider ?? "anthropic";
+  const effectiveModel = activityModel ?? agentModel ?? getDefaultModel(effectiveProvider);
   const handleModelSelect = useCallback(
-    (prov: string, mod: string) => {
-      setChatProvider(prov);
-      setChatModel(mod);
-      if (!path || !selectedActivityId) return;
-      tauriActivity.update(path, selectedActivityId, {
-        provider: prov,
-        model: mod,
-      }).catch((err) => {
+    async (prov: string, mod: string) => {
+      // Optimistic UI: the picker flips instantly while the writes fan out.
+      setAgentProvider(prov);
+      setAgentModel(mod);
+      try {
+        if (path) {
+          const cfg = await tauriConfig.read(path);
+          await tauriConfig.write(path, {
+            ...cfg,
+            provider: prov as "anthropic" | "openai",
+            model: mod,
+          });
+        }
+        if (path && selectedActivityId) {
+          await tauriActivity.update(path, selectedActivityId, {
+            provider: prov,
+            model: mod,
+          });
+        }
+        await tauriProvider.setLastUsed(prov, mod);
+      } catch (err) {
         addToast({
           title: t("chat:errors.modelPersistFailed"),
           description: String(err),
           variant: "error",
         });
-      });
+      }
     },
     [path, selectedActivityId, addToast, t],
   );
@@ -387,8 +391,8 @@ export function useAgentChatPanel({
       agent,
       path,
       agentModes,
-      chatProvider,
-      chatModel,
+      effectiveProvider,
+      effectiveModel,
       pushFeedItem,
       queryClient,
       t,
@@ -449,31 +453,7 @@ export function useAgentChatPanel({
             }}
             onSwitchModel={
               isModelUnsupported
-                ? async () => {
-                    // Demote the workspace default first so future sessions
-                    // use a model the user's ChatGPT plan accepts.
-                    if (workspace?.id) {
-                      await useWorkspaceStore
-                        .getState()
-                        .updateProvider(workspace.id, "openai", "gpt-5.5");
-                    }
-                    // If this activity carries an explicit codex override,
-                    // clear it too — otherwise the resolver will keep using
-                    // the activity-level value and the workspace fix won't
-                    // take effect for this mission.
-                    if (
-                      path &&
-                      selectedActivityId &&
-                      activityModel === "gpt-5.5-codex"
-                    ) {
-                      await tauriActivity.update(path, selectedActivityId, {
-                        provider: "openai",
-                        model: "gpt-5.5",
-                      });
-                      setChatProvider("openai");
-                      setChatModel("gpt-5.5");
-                    }
-                  }
+                ? () => handleModelSelect("openai", "gpt-5.5")
                 : undefined
             }
           />
@@ -482,7 +462,7 @@ export function useAgentChatPanel({
       if (isProviderAuthMessage(msg.content)) return null;
       return undefined;
     },
-    [chatModel, chatProvider, path, pushFeedItem, selectedSessionKey, t],
+    [effectiveModel, effectiveProvider, handleModelSelect, path, pushFeedItem, selectedSessionKey, t],
   );
   const mapFeedItems = useCallback(
     ({ items }: { sessionKey: string; items: FeedItem[] }) =>
@@ -645,7 +625,5 @@ export function useAgentChatPanel({
     pickerDialog,
     effectiveProvider,
     effectiveModel,
-    chatProvider,
-    chatModel,
   };
 }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -71,19 +71,13 @@ async function surfaceError(
 
 export const tauriWorkspaces = {
   list: () => call<Workspace[]>("list_workspaces", () => getEngine().listWorkspaces()),
-  create: (name: string, provider?: string, model?: string) =>
-    call<Workspace>("create_workspace", () =>
-      getEngine().createWorkspace({ name, provider, model }),
-    ),
+  create: (name: string) =>
+    call<Workspace>("create_workspace", () => getEngine().createWorkspace({ name })),
   delete: (id: string) => call<void>("delete_workspace", () => getEngine().deleteWorkspace(id)),
   rename: (id: string, newName: string) =>
     call<void>("rename_workspace", async () => {
       await getEngine().renameWorkspace(id, { newName });
     }),
-  updateProvider: (id: string, provider: string, model?: string) =>
-    call<Workspace>("update_workspace_provider", () =>
-      getEngine().setWorkspaceProvider(id, { provider, model }),
-    ),
   getContext: (id: string) =>
     call<import("@houston-ai/engine-client").WorkspaceContext>(
       "get_workspace_context",
@@ -655,6 +649,7 @@ export interface ProviderStatus {
 }
 
 const DEFAULT_PROVIDER_PREF_KEY = "default_provider";
+const DEFAULT_MODEL_PREF_KEY = "default_model";
 
 export const tauriProvider = {
   checkStatus: (provider: string) =>
@@ -677,6 +672,35 @@ export const tauriProvider = {
     call<void>("set_default_provider", () =>
       getEngine().setPreference(DEFAULT_PROVIDER_PREF_KEY, provider),
     ),
+  /**
+   * Last (provider, model) pair the user picked anywhere — agent creation
+   * dialog, AI-assist step, or chat-tab model picker. Used as the default
+   * for the next new agent. Returns `(null, null)` on a fresh install.
+   *
+   * Provider is stored under the existing `default_provider` key so an
+   * already-onboarded install carries its old preference forward without a
+   * migration step. The companion model key is new (no upgrade path needed
+   * because a missing value just falls back to the provider's
+   * `defaultModel`).
+   */
+  getLastUsed: () =>
+    call<{ provider: string | null; model: string | null }>(
+      "get_last_used_provider",
+      async () => {
+        const eng = getEngine();
+        const [provider, model] = await Promise.all([
+          eng.getPreference(DEFAULT_PROVIDER_PREF_KEY),
+          eng.getPreference(DEFAULT_MODEL_PREF_KEY),
+        ]);
+        return { provider: provider ?? null, model: model ?? null };
+      },
+    ),
+  setLastUsed: (provider: string, model: string) =>
+    call<void>("set_last_used_provider", async () => {
+      const eng = getEngine();
+      await eng.setPreference(DEFAULT_PROVIDER_PREF_KEY, provider);
+      await eng.setPreference(DEFAULT_MODEL_PREF_KEY, model);
+    }),
   launchLogin: (provider: string) =>
     call<void>("launch_provider_login", () => getEngine().providerLogin(provider)),
   launchLogout: (provider: string) =>

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -11,10 +11,6 @@ export interface Workspace {
   name: string;
   isDefault: boolean;
   createdAt: string;
-  /** AI provider for this workspace ("anthropic" or "openai"). */
-  provider?: string;
-  /** Default model for this workspace (e.g. "sonnet", "gpt-5.5"). */
-  model?: string;
 }
 
 /** Tab definition in an agent config */

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -6,6 +6,10 @@
     "connectTitle": "Connect {{name}}",
     "signOutTitle": "Sign out of {{name}}"
   },
+  "row": {
+    "connect": "Connect",
+    "signOut": "Sign out"
+  },
   "setup": {
     "installHint": "Install the {{cli}} CLI on your machine. Houston will pick it up automatically.",
     "installGuide": "Install guide",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -175,6 +175,7 @@
     "dialogTitle": "New agent"
   },
   "aiAssist": {
+    "brainLabel": "Set up with",
     "cardTitle": "Create with AI",
     "cardDescription": "Answer a few quick questions and we'll write your agent's instructions",
     "stepTitle": "Set up your agent",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -6,6 +6,10 @@
     "connectTitle": "Conectar {{name}}",
     "signOutTitle": "Cerrar sesión de {{name}}"
   },
+  "row": {
+    "connect": "Conectar",
+    "signOut": "Cerrar sesión"
+  },
   "setup": {
     "installHint": "Instala la CLI de {{cli}} en tu computador. Houston la detecta sola.",
     "installGuide": "Guía de instalación",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -175,6 +175,7 @@
     "dialogTitle": "Nuevo agente"
   },
   "aiAssist": {
+    "brainLabel": "Configurar con",
     "cardTitle": "Crear con IA",
     "cardDescription": "Responde algunas preguntas rápidas y escribiremos las instrucciones de tu agente",
     "stepTitle": "Configura tu agente",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -6,6 +6,10 @@
     "connectTitle": "Conectar {{name}}",
     "signOutTitle": "Sair de {{name}}"
   },
+  "row": {
+    "connect": "Conectar",
+    "signOut": "Sair"
+  },
   "setup": {
     "installHint": "Instale a CLI {{cli}} no seu computador. Houston detecta sozinho.",
     "installGuide": "Guia de instalação",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -175,6 +175,7 @@
     "dialogTitle": "Novo agente"
   },
   "aiAssist": {
+    "brainLabel": "Configurar com",
     "cardTitle": "Criar com IA",
     "cardDescription": "Responda algumas perguntas rápidas e escreveremos as instruções do seu agente",
     "stepTitle": "Configure seu agente",

--- a/app/src/stores/workspaces.ts
+++ b/app/src/stores/workspaces.ts
@@ -9,8 +9,7 @@ interface WorkspaceState {
   loading: boolean;
   loadWorkspaces: () => Promise<void>;
   setCurrent: (ws: Workspace) => void;
-  create: (name: string, provider?: string, model?: string) => Promise<Workspace>;
-  updateProvider: (id: string, provider: string, model?: string) => Promise<void>;
+  create: (name: string) => Promise<Workspace>;
   delete: (id: string) => Promise<void>;
   rename: (id: string, newName: string) => Promise<void>;
 }
@@ -43,24 +42,13 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
     tauriPreferences.set("last_workspace_id", ws.id);
   },
 
-  create: async (name, provider, model) => {
-    const ws = await tauriWorkspaces.create(name, provider, model);
-    analytics.track("workspace_created", {
-      provider: provider ?? "none",
-      source: "manual",
-    });
+  create: async (name) => {
+    const ws = await tauriWorkspaces.create(name);
+    analytics.track("workspace_created", { source: "manual" });
     set((s) => ({
       workspaces: [...s.workspaces, ws],
     }));
     return ws;
-  },
-
-  updateProvider: async (id, provider, model) => {
-    const updated = await tauriWorkspaces.updateProvider(id, provider, model);
-    set((s) => ({
-      workspaces: s.workspaces.map((w) => (w.id === id ? updated : w)),
-      current: s.current?.id === id ? updated : s.current,
-    }));
   },
 
   delete: async (id) => {

--- a/engine/houston-engine-core/src/agents_crud.rs
+++ b/engine/houston-engine-core/src/agents_crud.rs
@@ -363,11 +363,7 @@ mod tests {
     fn setup_ws(root: &Path) -> String {
         workspaces::create(
             root,
-            CreateWorkspace {
-                name: "alpha".into(),
-                provider: None,
-                model: None,
-            },
+            CreateWorkspace { name: "alpha".into() },
         )
         .unwrap()
         .id

--- a/engine/houston-engine-core/src/routines/engine_dispatcher.rs
+++ b/engine/houston-engine-core/src/routines/engine_dispatcher.rs
@@ -59,7 +59,7 @@ impl RoutineDispatcher for EngineRoutineDispatcher {
             format!("{}\n\n---\n\n{agent_context}", self.app_system_prompt)
         };
 
-        let resolved = sessions::resolve_provider(&self.paths, ctx.working_dir);
+        let resolved = sessions::resolve_provider(ctx.working_dir);
         let agent_key = format!(
             "{}:{}:{}",
             ctx.working_dir.to_string_lossy(),

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -10,7 +10,7 @@
 //!   sink (which WS clients subscribe to via `session:{key}` topics).
 //! - [`cancel`] — SIGTERM the running CLI for a given session_key and emit
 //!   a "Stopped by user" feed item + `completed` status.
-//! - [`resolve_provider`] — agent-config → workspace → default fallback.
+//! - [`resolve_provider`] — agent-config → Anthropic default fallback.
 //!
 //! Callers (REST handlers, Tauri adapter) supply the already-resolved
 //! `working_dir` and an optional pre-built `system_prompt`. Prompt assembly
@@ -539,7 +539,6 @@ pub async fn start_onboarding(
     rt: &SessionRuntime,
     events: DynEventSink,
     db: Database,
-    paths: &EnginePaths,
     app_system_prompt: &str,
     app_onboarding_prompt: &str,
     agent_dir: PathBuf,
@@ -551,7 +550,7 @@ pub async fn start_onboarding(
     // appends its own agent context in `start()` below.
     let product_prompt = format!("{app_system_prompt}{app_onboarding_prompt}");
 
-    let resolved = resolve_provider(paths, &agent_dir);
+    let resolved = resolve_provider(&agent_dir);
 
     start(
         rt,

--- a/engine/houston-engine-core/src/sessions/provider.rs
+++ b/engine/houston-engine-core/src/sessions/provider.rs
@@ -1,11 +1,14 @@
 //! Provider + model resolution for a session.
 //!
-//! Priority: agent-level `.houston/config/config.json` → workspace entry in
-//! `workspaces.json` → default Anthropic. Callers typically pass chat-level
-//! overrides in front of this resolution chain.
+//! Resolution: agent-level `.houston/config/config.json` → `Provider::default()`
+//! (Anthropic, no model). Callers typically pass chat-level overrides in
+//! front of this resolution chain.
+//!
+//! The workspace layer used to live here as an intermediate fallback. It was
+//! retired in favor of per-agent storage — see
+//! `workspaces::migrate_workspace_provider_into_agents` for the one-shot
+//! backfill that pushed every workspace default down into its agents.
 
-use crate::paths::EnginePaths;
-use crate::workspaces;
 use houston_terminal_manager::Provider;
 use serde::Deserialize;
 use std::path::Path;
@@ -36,31 +39,21 @@ struct AgentConfig {
 /// Resolve the provider + model for an agent.
 ///
 /// Order:
-/// 1. `agent_dir/.houston/config/config.json` — per-agent override.
-/// 2. Workspace entry (workspace dir = parent of agent dir, workspaces root =
-///    parent of workspace dir OR `paths.docs()`).
-/// 3. `Provider::default()` (Anthropic), no model (factory default).
-pub fn resolve_provider(paths: &EnginePaths, agent_dir: &Path) -> ResolvedProvider {
-    if let Some(from_agent) = read_agent_config(agent_dir) {
-        // Agent-level config exists — but model can come from workspace if
-        // the agent only overrides one field. Match the old Tauri behavior.
-        if let Some(ref p_str) = from_agent.provider {
-            if let Ok(provider) = p_str.parse::<Provider>() {
-                return ResolvedProvider {
-                    provider,
-                    model: from_agent.model.clone(),
-                };
-            }
-        }
-        if from_agent.model.is_some() {
-            let ws = resolve_workspace(paths, agent_dir);
-            return ResolvedProvider {
-                provider: ws.provider,
-                model: from_agent.model,
-            };
-        }
+/// 1. `agent_dir/.houston/config/config.json` — per-agent setting.
+/// 2. `Provider::default()` (Anthropic), no model — factory fallback.
+pub fn resolve_provider(agent_dir: &Path) -> ResolvedProvider {
+    let Some(from_agent) = read_agent_config(agent_dir) else {
+        return ResolvedProvider::default();
+    };
+    let provider = from_agent
+        .provider
+        .as_deref()
+        .and_then(|p| p.parse::<Provider>().ok())
+        .unwrap_or_default();
+    ResolvedProvider {
+        provider,
+        model: from_agent.model,
     }
-    resolve_workspace(paths, agent_dir)
 }
 
 fn read_agent_config(agent_dir: &Path) -> Option<AgentConfig> {
@@ -70,37 +63,6 @@ fn read_agent_config(agent_dir: &Path) -> Option<AgentConfig> {
         return None;
     }
     serde_json::from_str(&raw).ok()
-}
-
-fn resolve_workspace(paths: &EnginePaths, agent_dir: &Path) -> ResolvedProvider {
-    let Some(workspace_dir) = agent_dir.parent() else {
-        return ResolvedProvider::default();
-    };
-    let ws_name = match workspace_dir.file_name().and_then(|n| n.to_str()) {
-        Some(n) => n,
-        None => return ResolvedProvider::default(),
-    };
-    // Workspaces root is `paths.docs()` or the workspace's parent (matches
-    // adapter behavior when the agent lives under a non-standard location).
-    let roots = [workspace_dir.parent(), Some(paths.docs())];
-    for root in roots.iter().flatten() {
-        let all = match workspaces::read_all(root) {
-            Ok(v) => v,
-            Err(_) => continue,
-        };
-        if let Some(ws) = all.iter().find(|w| w.name == ws_name) {
-            let provider = ws
-                .provider
-                .as_deref()
-                .and_then(|p| p.parse::<Provider>().ok())
-                .unwrap_or_default();
-            return ResolvedProvider {
-                provider,
-                model: ws.model.clone(),
-            };
-        }
-    }
-    ResolvedProvider::default()
 }
 
 #[cfg(test)]
@@ -125,8 +87,17 @@ mod tests {
         let d = TempDir::new().unwrap();
         let agent = d.path().join("ws").join("agent");
         std::fs::create_dir_all(&agent).unwrap();
-        let paths = EnginePaths::new(d.path().to_path_buf(), d.path().to_path_buf());
-        let r = resolve_provider(&paths, &agent);
+        let r = resolve_provider(&agent);
+        assert_eq!(r.provider, anthropic());
+        assert!(r.model.is_none());
+    }
+
+    #[test]
+    fn empty_config_falls_through_to_default() {
+        let d = TempDir::new().unwrap();
+        let agent = d.path().join("ws").join("agent");
+        write_json(&agent.join(".houston/config/config.json"), "{}");
+        let r = resolve_provider(&agent);
         assert_eq!(r.provider, anthropic());
         assert!(r.model.is_none());
     }
@@ -139,43 +110,22 @@ mod tests {
             &agent.join(".houston/config/config.json"),
             r#"{"provider":"openai","model":"gpt-5.5"}"#,
         );
-        let paths = EnginePaths::new(d.path().to_path_buf(), d.path().to_path_buf());
-        let r = resolve_provider(&paths, &agent);
+        let r = resolve_provider(&agent);
         assert_eq!(r.provider, openai());
         assert_eq!(r.model.as_deref(), Some("gpt-5.5"));
     }
 
     #[test]
-    fn workspace_fallback() {
+    fn agent_model_only_uses_default_provider() {
+        // With workspace fallback retired, an agent that only stores `model`
+        // gets the platform-default provider (no longer the workspace's).
+        // Migration backfills concrete provider+model pairs, so this branch
+        // is reachable only for hand-edited configs.
         let d = TempDir::new().unwrap();
-        let workspaces_json = d.path().join("workspaces.json");
-        write_json(
-            &workspaces_json,
-            r#"[{"id":"x","name":"ws","isDefault":true,"createdAt":"t","provider":"openai","model":"gpt-5"}]"#,
-        );
         let agent = d.path().join("ws").join("agent");
-        std::fs::create_dir_all(&agent).unwrap();
-        let paths = EnginePaths::new(d.path().to_path_buf(), d.path().to_path_buf());
-        let r = resolve_provider(&paths, &agent);
-        assert_eq!(r.provider, openai());
-        assert_eq!(r.model.as_deref(), Some("gpt-5"));
-    }
-
-    #[test]
-    fn agent_model_only_uses_workspace_provider() {
-        let d = TempDir::new().unwrap();
-        write_json(
-            &d.path().join("workspaces.json"),
-            r#"[{"id":"x","name":"ws","isDefault":true,"createdAt":"t","provider":"openai"}]"#,
-        );
-        let agent = d.path().join("ws").join("agent");
-        write_json(
-            &agent.join(".houston/config/config.json"),
-            r#"{"model":"sonnet"}"#,
-        );
-        let paths = EnginePaths::new(d.path().to_path_buf(), d.path().to_path_buf());
-        let r = resolve_provider(&paths, &agent);
-        assert_eq!(r.provider, openai());
+        write_json(&agent.join(".houston/config/config.json"), r#"{"model":"sonnet"}"#);
+        let r = resolve_provider(&agent);
+        assert_eq!(r.provider, anthropic());
         assert_eq!(r.model.as_deref(), Some("sonnet"));
     }
 }

--- a/engine/houston-engine-core/src/store.rs
+++ b/engine/houston-engine-core/src/store.rs
@@ -371,11 +371,7 @@ pub async fn install_workspace_from_github(
 
     let ws = workspaces::create(
         docs_dir,
-        CreateWorkspace {
-            name: ws_name.clone(),
-            provider: None,
-            model: None,
-        },
+        CreateWorkspace { name: ws_name.clone() },
     )?;
     let ws_dir = docs_dir.join(&ws_name);
 

--- a/engine/houston-engine-core/src/store/bundled.rs
+++ b/engine/houston-engine-core/src/store/bundled.rs
@@ -727,11 +727,7 @@ mod tests {
 
         let ws = workspaces::create(
             docs.path(),
-            CreateWorkspace {
-                name: "Acme".into(),
-                provider: None,
-                model: None,
-            },
+            CreateWorkspace { name: "Acme".into() },
         )
         .unwrap();
         agents_crud::create(
@@ -810,11 +806,7 @@ Package v2 body
 
         let ws = workspaces::create(
             docs.path(),
-            CreateWorkspace {
-                name: "Acme".into(),
-                provider: None,
-                model: None,
-            },
+            CreateWorkspace { name: "Acme".into() },
         )
         .unwrap();
         agents_crud::create(
@@ -882,11 +874,7 @@ User customized body
 
         let ws = workspaces::create(
             docs.path(),
-            CreateWorkspace {
-                name: "Acme".into(),
-                provider: None,
-                model: None,
-            },
+            CreateWorkspace { name: "Acme".into() },
         )
         .unwrap();
         agents_crud::create(
@@ -1174,11 +1162,7 @@ User customized body
         // 2. User creates a workspace agent and tweaks the body.
         let ws = workspaces::create(
             docs.path(),
-            CreateWorkspace {
-                name: "Acme".into(),
-                provider: None,
-                model: None,
-            },
+            CreateWorkspace { name: "Acme".into() },
         )
         .unwrap();
         agents_crud::create(
@@ -1274,11 +1258,7 @@ User customized body
 
         let ws = workspaces::create(
             docs.path(),
-            CreateWorkspace {
-                name: "Acme".into(),
-                provider: None,
-                model: None,
-            },
+            CreateWorkspace { name: "Acme".into() },
         )
         .unwrap();
         agents_crud::create(

--- a/engine/houston-engine-core/src/workspaces/migrate.rs
+++ b/engine/houston-engine-core/src/workspaces/migrate.rs
@@ -1,0 +1,323 @@
+//! One-shot migration that retires `workspace.provider` / `workspace.model`
+//! in favor of per-agent storage.
+//!
+//! Houston used to keep the provider+model on the workspace as the implicit
+//! default for every agent inside it. That created two foot-guns:
+//!
+//! 1. Stale defaults inside the agent-creation dialog could silently bake a
+//!    different provider into a new agent's `config.json` even when the user
+//!    never touched the picker — the workspace was the source of truth at
+//!    write-time but a stale value at mount-time.
+//! 2. Users who changed the workspace default after creating agents had no
+//!    obvious way to tell which agents would inherit the new value and which
+//!    had a baked-in override.
+//!
+//! We're moving to "the agent owns its provider, full stop." This migration
+//! preserves existing intent: for each workspace that has a default set, we
+//! write that pair into every contained agent's `config.json` (only when the
+//! field is missing on that agent), then strip the field from the workspace
+//! entry. After the migration runs, the workspace JSON no longer carries
+//! `provider` / `model` and the engine's provider resolver no longer reads
+//! them.
+//!
+//! Idempotent: a workspace without provider/model is skipped on every call.
+
+use super::{io, Workspace};
+use crate::error::CoreResult;
+use serde_json::{Map, Value};
+use std::fs;
+use std::path::Path;
+
+/// Walk every workspace in `root`. For each one that has a non-empty
+/// `provider` or `model`, push those values down into the contained agents'
+/// `.houston/config/config.json` (filling missing fields only, never
+/// overwriting) and then clear them from the workspace entry.
+pub fn migrate_workspace_provider_into_agents(root: &Path) -> CoreResult<()> {
+    let mut workspaces = io::read_all(root)?;
+    let mut workspaces_dirty = false;
+
+    for ws in workspaces.iter_mut() {
+        if ws.provider.is_none() && ws.model.is_none() {
+            continue;
+        }
+        let ws_dir = root.join(&ws.name);
+        if ws_dir.is_dir() {
+            if let Err(e) = backfill_workspace_agents(&ws_dir, ws) {
+                // Log and skip clearing the workspace fields — re-running the
+                // migration will retry. We never want to lose the workspace's
+                // intent because one agent dir was unreadable.
+                tracing::warn!(
+                    "[workspaces.migrate] backfill failed for {}: {e}",
+                    ws_dir.display()
+                );
+                continue;
+            }
+        }
+        // Either the directory is missing (no agents to backfill) or every
+        // agent inside has been updated. Drop the workspace-level fields so
+        // subsequent boots skip this entry.
+        ws.provider = None;
+        ws.model = None;
+        workspaces_dirty = true;
+    }
+
+    if workspaces_dirty {
+        io::write_all(root, &workspaces)?;
+    }
+    Ok(())
+}
+
+fn backfill_workspace_agents(ws_dir: &Path, ws: &Workspace) -> CoreResult<()> {
+    for entry in fs::read_dir(ws_dir)? {
+        let entry = entry?;
+        if !entry.file_type()?.is_dir() {
+            continue;
+        }
+        let name = entry.file_name();
+        let name_str = name.to_string_lossy();
+        if name_str.starts_with('.') {
+            continue;
+        }
+        let agent_dir = entry.path();
+        backfill_agent_config(&agent_dir, ws)?;
+    }
+    Ok(())
+}
+
+fn backfill_agent_config(agent_dir: &Path, ws: &Workspace) -> CoreResult<()> {
+    let cfg_dir = agent_dir.join(".houston").join("config");
+    let cfg_path = cfg_dir.join("config.json");
+
+    let mut cfg: Map<String, Value> = if cfg_path.exists() {
+        let raw = fs::read_to_string(&cfg_path)?;
+        if raw.trim().is_empty() {
+            Map::new()
+        } else {
+            match serde_json::from_str::<Value>(&raw) {
+                Ok(Value::Object(m)) => m,
+                Ok(_) | Err(_) => {
+                    // The file exists but isn't a JSON object. Don't clobber
+                    // it — the user might be holding their own format we
+                    // don't recognize. Skip this agent.
+                    tracing::warn!(
+                        "[workspaces.migrate] {} is not a JSON object — skipping",
+                        cfg_path.display()
+                    );
+                    return Ok(());
+                }
+            }
+        }
+    } else {
+        Map::new()
+    };
+
+    let mut dirty = false;
+    if !cfg.contains_key("provider") {
+        if let Some(p) = ws.provider.as_deref() {
+            cfg.insert("provider".into(), Value::String(p.to_string()));
+            dirty = true;
+        }
+    }
+    if !cfg.contains_key("model") {
+        if let Some(m) = ws.model.as_deref() {
+            cfg.insert("model".into(), Value::String(m.to_string()));
+            dirty = true;
+        }
+    }
+
+    if dirty {
+        fs::create_dir_all(&cfg_dir)?;
+        let body = serde_json::to_string_pretty(&Value::Object(cfg))?;
+        fs::write(&cfg_path, body)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::workspaces::Workspace;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn write_workspaces(root: &Path, body: Value) {
+        fs::write(root.join("workspaces.json"), body.to_string()).unwrap();
+    }
+
+    fn read_workspaces(root: &Path) -> Vec<Workspace> {
+        let raw = fs::read_to_string(root.join("workspaces.json")).unwrap();
+        serde_json::from_str(&raw).unwrap()
+    }
+
+    fn read_agent_cfg(agent_dir: &Path) -> Value {
+        let raw = fs::read_to_string(agent_dir.join(".houston/config/config.json")).unwrap();
+        serde_json::from_str(&raw).unwrap()
+    }
+
+    #[test]
+    fn empty_agent_config_gets_workspace_defaults() {
+        let d = TempDir::new().unwrap();
+        let root = d.path();
+        let ws_dir = root.join("Personal");
+        let agent = ws_dir.join("Agent A");
+        fs::create_dir_all(agent.join(".houston/config")).unwrap();
+        fs::write(agent.join(".houston/config/config.json"), "{}").unwrap();
+        write_workspaces(
+            root,
+            json!([{
+                "id": "w1",
+                "name": "Personal",
+                "isDefault": false,
+                "createdAt": "t",
+                "provider": "openai",
+                "model": "gpt-5.5",
+            }]),
+        );
+
+        migrate_workspace_provider_into_agents(root).unwrap();
+
+        let cfg = read_agent_cfg(&agent);
+        assert_eq!(cfg["provider"], "openai");
+        assert_eq!(cfg["model"], "gpt-5.5");
+        let workspaces = read_workspaces(root);
+        assert!(workspaces[0].provider.is_none());
+        assert!(workspaces[0].model.is_none());
+    }
+
+    #[test]
+    fn existing_agent_provider_is_preserved() {
+        let d = TempDir::new().unwrap();
+        let root = d.path();
+        let agent = root.join("Personal").join("Agent A");
+        fs::create_dir_all(agent.join(".houston/config")).unwrap();
+        fs::write(
+            agent.join(".houston/config/config.json"),
+            r#"{"provider":"anthropic","model":"opus"}"#,
+        )
+        .unwrap();
+        write_workspaces(
+            root,
+            json!([{
+                "id": "w1",
+                "name": "Personal",
+                "isDefault": false,
+                "createdAt": "t",
+                "provider": "openai",
+                "model": "gpt-5.5",
+            }]),
+        );
+
+        migrate_workspace_provider_into_agents(root).unwrap();
+
+        let cfg = read_agent_cfg(&agent);
+        assert_eq!(cfg["provider"], "anthropic");
+        assert_eq!(cfg["model"], "opus");
+    }
+
+    #[test]
+    fn missing_config_file_is_created() {
+        let d = TempDir::new().unwrap();
+        let root = d.path();
+        let agent = root.join("Personal").join("Agent A");
+        fs::create_dir_all(&agent).unwrap();
+        write_workspaces(
+            root,
+            json!([{
+                "id": "w1",
+                "name": "Personal",
+                "isDefault": false,
+                "createdAt": "t",
+                "provider": "openai",
+                "model": "gpt-5.5",
+            }]),
+        );
+
+        migrate_workspace_provider_into_agents(root).unwrap();
+
+        let cfg = read_agent_cfg(&agent);
+        assert_eq!(cfg["provider"], "openai");
+        assert_eq!(cfg["model"], "gpt-5.5");
+    }
+
+    #[test]
+    fn idempotent_on_already_migrated_workspaces() {
+        let d = TempDir::new().unwrap();
+        let root = d.path();
+        let agent = root.join("Personal").join("Agent A");
+        fs::create_dir_all(agent.join(".houston/config")).unwrap();
+        fs::write(
+            agent.join(".houston/config/config.json"),
+            r#"{"provider":"anthropic","model":"opus"}"#,
+        )
+        .unwrap();
+        // Workspaces.json already has no provider/model — i.e. already migrated.
+        write_workspaces(
+            root,
+            json!([{
+                "id": "w1",
+                "name": "Personal",
+                "isDefault": false,
+                "createdAt": "t",
+            }]),
+        );
+
+        migrate_workspace_provider_into_agents(root).unwrap();
+        migrate_workspace_provider_into_agents(root).unwrap();
+
+        let cfg = read_agent_cfg(&agent);
+        assert_eq!(cfg["provider"], "anthropic");
+        assert_eq!(cfg["model"], "opus");
+    }
+
+    #[test]
+    fn workspace_without_directory_clears_fields() {
+        let d = TempDir::new().unwrap();
+        let root = d.path();
+        // No "Personal" dir on disk.
+        write_workspaces(
+            root,
+            json!([{
+                "id": "w1",
+                "name": "Personal",
+                "isDefault": false,
+                "createdAt": "t",
+                "provider": "openai",
+                "model": "gpt-5.5",
+            }]),
+        );
+
+        migrate_workspace_provider_into_agents(root).unwrap();
+        let workspaces = read_workspaces(root);
+        assert!(workspaces[0].provider.is_none());
+        assert!(workspaces[0].model.is_none());
+    }
+
+    #[test]
+    fn hidden_dirs_are_skipped() {
+        let d = TempDir::new().unwrap();
+        let root = d.path();
+        let ws = root.join("Personal");
+        fs::create_dir_all(ws.join(".houston")).unwrap();
+        fs::create_dir_all(ws.join("Agent A").join(".houston/config")).unwrap();
+        fs::write(ws.join("Agent A/.houston/config/config.json"), "{}").unwrap();
+        write_workspaces(
+            root,
+            json!([{
+                "id": "w1",
+                "name": "Personal",
+                "isDefault": false,
+                "createdAt": "t",
+                "provider": "openai",
+                "model": "gpt-5.5",
+            }]),
+        );
+
+        migrate_workspace_provider_into_agents(root).unwrap();
+
+        // The `.houston` sibling under Personal/ must NOT have been treated
+        // as an agent (no config file dropped inside it).
+        assert!(!ws.join(".houston/config/config.json").exists());
+        let cfg = read_agent_cfg(&ws.join("Agent A"));
+        assert_eq!(cfg["provider"], "openai");
+    }
+}

--- a/engine/houston-engine-core/src/workspaces/mod.rs
+++ b/engine/houston-engine-core/src/workspaces/mod.rs
@@ -6,8 +6,10 @@
 //! corrupted by the 0.4.19 concurrent-writer race.
 
 mod io;
+mod migrate;
 
 pub use io::read_all;
+pub use migrate::migrate_workspace_provider_into_agents;
 
 use crate::error::{CoreError, CoreResult};
 use serde::{Deserialize, Serialize};
@@ -22,6 +24,11 @@ pub struct Workspace {
     pub name: String,
     pub is_default: bool,
     pub created_at: String,
+    // Legacy fields. They're still parsed here so the migration can read
+    // pre-0.5 workspace files; once `migrate_workspace_provider_into_agents`
+    // runs they're stripped from disk and the resolver no longer consults
+    // them. Keep `skip_serializing_if = "Option::is_none"` so a freshly
+    // written `workspaces.json` doesn't carry the dead keys forward.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -32,15 +39,6 @@ pub struct Workspace {
 #[serde(rename_all = "camelCase")]
 pub struct CreateWorkspace {
     pub name: String,
-    pub provider: Option<String>,
-    pub model: Option<String>,
-}
-
-#[derive(Deserialize, Debug)]
-#[serde(rename_all = "camelCase")]
-pub struct UpdateProvider {
-    pub provider: String,
-    pub model: Option<String>,
 }
 
 #[derive(Deserialize, Debug)]
@@ -71,8 +69,8 @@ pub fn create(root: &Path, req: CreateWorkspace) -> CoreResult<Workspace> {
         name: req.name.clone(),
         is_default: false,
         created_at: now_iso(),
-        provider: req.provider,
-        model: req.model,
+        provider: None,
+        model: None,
     };
     let ws_dir = root.join(&req.name);
     fs::create_dir_all(ws_dir.join(".houston"))?;
@@ -134,21 +132,6 @@ pub fn delete(root: &Path, id: &str) -> CoreResult<()> {
     Ok(())
 }
 
-pub fn update_provider(root: &Path, id: &str, req: UpdateProvider) -> CoreResult<Workspace> {
-    let mut workspaces = read_all(root)?;
-    let ws = workspaces
-        .iter_mut()
-        .find(|w| w.id == id)
-        .ok_or_else(|| CoreError::NotFound(format!("workspace {id}")))?;
-    ws.provider = Some(req.provider);
-    if let Some(m) = req.model {
-        ws.model = Some(m);
-    }
-    let updated = ws.clone();
-    io::write_all(root, &workspaces)?;
-    Ok(updated)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -167,15 +150,7 @@ mod tests {
     #[test]
     fn create_then_list() {
         let d = tmp();
-        let ws = create(
-            d.path(),
-            CreateWorkspace {
-                name: "alpha".into(),
-                provider: Some("anthropic".into()),
-                model: None,
-            },
-        )
-        .unwrap();
+        let ws = create(d.path(), CreateWorkspace { name: "alpha".into() }).unwrap();
         assert_eq!(ws.name, "alpha");
         let all = list(d.path()).unwrap();
         assert_eq!(all.len(), 1);
@@ -185,34 +160,31 @@ mod tests {
     #[test]
     fn create_duplicate_conflicts() {
         let d = tmp();
-        create(d.path(), CreateWorkspace { name: "a".into(), provider: None, model: None }).unwrap();
-        let err = create(d.path(), CreateWorkspace { name: "a".into(), provider: None, model: None }).unwrap_err();
+        create(d.path(), CreateWorkspace { name: "a".into() }).unwrap();
+        let err = create(d.path(), CreateWorkspace { name: "a".into() }).unwrap_err();
         assert!(matches!(err, CoreError::Conflict(_)));
     }
 
     #[test]
     fn rename_and_delete() {
         let d = tmp();
-        let ws = create(d.path(), CreateWorkspace { name: "a".into(), provider: None, model: None }).unwrap();
+        let ws = create(d.path(), CreateWorkspace { name: "a".into() }).unwrap();
         let renamed = rename(d.path(), &ws.id, RenameWorkspace { new_name: "b".into() }).unwrap();
         assert_eq!(renamed.name, "b");
         delete(d.path(), &ws.id).unwrap();
         assert!(list(d.path()).unwrap().is_empty());
     }
 
-    /// Concurrent writers must not corrupt the target. With the shared
-    /// `workspaces.json.tmp` path this test produced trailing-garbage files;
-    /// with per-call tmp paths every read parses cleanly.
+    /// Concurrent writers must not corrupt `workspaces.json`. Mirrors the
+    /// original `update_provider` race test (since retired with the
+    /// workspace-level provider field) — same code path through
+    /// `io::write_all`, exercised here via `rename`.
     #[test]
-    fn concurrent_update_provider_never_corrupts() {
+    fn concurrent_renames_never_corrupt_index() {
         use std::sync::Arc;
         use std::thread;
         let d = tmp();
-        let ws = create(
-            d.path(),
-            CreateWorkspace { name: "alpha".into(), provider: Some("anthropic".into()), model: None },
-        )
-        .unwrap();
+        let ws = create(d.path(), CreateWorkspace { name: "alpha".into() }).unwrap();
         let root = Arc::new(d.path().to_path_buf());
         let id = Arc::new(ws.id.clone());
         let mut handles = Vec::new();
@@ -220,11 +192,11 @@ mod tests {
             let root = root.clone();
             let id = id.clone();
             handles.push(thread::spawn(move || {
-                let provider = if i % 2 == 0 { "anthropic" } else { "openai" };
-                let _ = update_provider(
+                let next = if i % 2 == 0 { "alpha" } else { "beta" };
+                let _ = rename(
                     &root,
                     &id,
-                    UpdateProvider { provider: provider.into(), model: None },
+                    RenameWorkspace { new_name: next.into() },
                 );
             }));
         }

--- a/engine/houston-engine-server/src/routes/sessions.rs
+++ b/engine/houston-engine-server/src/routes/sessions.rs
@@ -104,9 +104,9 @@ async fn start_session(
         .map(|p| sessions::expand_tilde(std::path::Path::new(p)))
         .unwrap_or_else(|| agent_dir.clone());
 
-    // Override > agent config > workspace > default.
+    // Override > agent config > Anthropic default.
     let ResolvedProviderChoice { provider, model } =
-        resolve_provider_with_overrides(&st, &agent_dir, req.provider.as_deref(), req.model.clone())?;
+        resolve_provider_with_overrides(&agent_dir, req.provider.as_deref(), req.model.clone())?;
 
     let params = StartParams {
         agent_dir,
@@ -153,7 +153,6 @@ async fn start_onboarding(
         &rt,
         sink,
         db,
-        &st.engine.paths,
         &st.engine.app_system_prompt,
         &st.engine.app_onboarding_prompt,
         agent_dir,
@@ -194,7 +193,7 @@ async fn summarize_activity(
         (provider, req.model)
     } else if let Some(agent_path) = req.agent_path.as_deref() {
         let agent_dir = resolve_agent_dir(&st.engine.paths, agent_path);
-        let resolved = resolve_provider(&st.engine.paths, &agent_dir);
+        let resolved = resolve_provider(&agent_dir);
         (resolved.provider, req.model.or(resolved.model))
     } else {
         (Provider::default(), req.model)
@@ -301,7 +300,6 @@ struct ResolvedProviderChoice {
 }
 
 fn resolve_provider_with_overrides(
-    st: &Arc<ServerState>,
     agent_dir: &std::path::Path,
     provider_override: Option<&str>,
     model_override: Option<String>,
@@ -315,7 +313,7 @@ fn resolve_provider_with_overrides(
             model: model_override,
         });
     }
-    let mut resolved = resolve_provider(&st.engine.paths, agent_dir);
+    let mut resolved = resolve_provider(agent_dir);
     if let Some(m) = model_override {
         resolved.model = Some(m);
     }

--- a/engine/houston-engine-server/src/routes/workspaces.rs
+++ b/engine/houston-engine-server/src/routes/workspaces.rs
@@ -9,9 +9,7 @@ use axum::{
 };
 use houston_engine_core::agents_crud::{self, Agent, CreateAgent, CreateAgentResult, UpdateAgent};
 use houston_engine_core::workspace_context::{self, WorkspaceContext};
-use houston_engine_core::workspaces::{
-    self, CreateWorkspace, RenameWorkspace, UpdateProvider, Workspace,
-};
+use houston_engine_core::workspaces::{self, CreateWorkspace, RenameWorkspace, Workspace};
 use serde::Deserialize;
 use std::sync::Arc;
 
@@ -20,7 +18,6 @@ pub fn router() -> Router<Arc<ServerState>> {
         .route("/workspaces", get(list).post(create))
         .route("/workspaces/:id", delete(remove))
         .route("/workspaces/:id/rename", post(rename))
-        .route("/workspaces/:id/provider", patch(set_provider))
         .route(
             "/workspaces/:id/context",
             get(get_context).put(put_context),
@@ -65,18 +62,6 @@ async fn rename(
     Json(req): Json<RenameWorkspace>,
 ) -> Result<Json<Workspace>, ApiError> {
     Ok(Json(workspaces::rename(st.engine.paths.docs(), &id, req)?))
-}
-
-async fn set_provider(
-    State(st): State<Arc<ServerState>>,
-    Path(id): Path<String>,
-    Json(req): Json<UpdateProvider>,
-) -> Result<Json<Workspace>, ApiError> {
-    Ok(Json(workspaces::update_provider(
-        st.engine.paths.docs(),
-        &id,
-        req,
-    )?))
 }
 
 async fn get_context(

--- a/engine/houston-engine-server/src/state.rs
+++ b/engine/houston-engine-server/src/state.rs
@@ -67,6 +67,17 @@ impl ServerState {
         let events = BroadcastEventSink::new(1024);
         let paths = EnginePaths::new(config.docs_dir.clone(), config.home_dir.clone());
 
+        // Retire `workspace.provider` / `workspace.model` in favor of
+        // per-agent storage. Idempotent — subsequent boots are a no-op.
+        // Logged-and-swallowed because a stale workspace default isn't worth
+        // failing the engine boot over; the resolver falls back to the
+        // platform default if a per-agent config doesn't exist yet.
+        if let Err(e) =
+            houston_engine_core::workspaces::migrate_workspace_provider_into_agents(paths.docs())
+        {
+            tracing::warn!("[boot] workspace provider migration failed: {e}");
+        }
+
         let engine = EngineState::new(paths, Arc::new(events.clone()), db.clone())
             .with_app_prompts(
                 config.app_system_prompt.clone(),


### PR DESCRIPTION
## Summary

- Workspace-level `provider`/`model` was the source of the "I picked OpenAI but my new agent uses Anthropic" bug. Mount-time stale state in the create-agent dialog could silently bake one provider into an agent while the workspace default said another.
- Layer is now retired. Provider/model lives on the agent. Settings → AI provider becomes account-only (Connect / Sign out).
- The create-agent dialog, AI-assist step, and chat-tab model picker share a sticky last-used preference (`tauriProvider.getLastUsed/setLastUsed`). The chat-tab picker also writes through to the agent's `config.json`, so per-agent choice persists across sessions.
- AI-assist step gets a "Set up with" picker — the brain that drafts an agent's instructions is the brain that runs it.
- Engine ships a one-shot startup migration (`migrate_workspace_provider_into_agents`) that pushes existing workspace defaults down into each contained agent's empty `config.json` and strips the fields from `workspaces.json`. Idempotent. Tested.

## Test plan

- [ ] `cargo test --workspace` (all green pre-PR)
- [ ] `pnpm tsc --noEmit` (clean except one pre-existing `RoutineFormData.integrations` error on `main`)
- [ ] `pnpm check-locales` (en/es/pt in sync)
- [ ] Smoke test in `pnpm tauri dev` after `cargo build -p houston-engine-server`:
  - [ ] Settings → AI provider: accounts-only, no default zone
  - [ ] Create new agent twice in a row — picker remembers last pick both times
  - [ ] Create one via AI assist: "Set up with" picker visible; chosen brain runs the assist AND becomes the agent's brain
  - [ ] Switch model in chat-tab → persists to agent's `config.json` (no restart needed)
  - [ ] After first launch, `~/.houston/workspaces/workspaces.json` has no `provider`/`model` keys and existing empty agent configs got the migrated values

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #214
