### PR TITLE
fix(app,ui): keep mission panel open through model picker, close it on Esc from empty new mission

### DIFF
--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -65,6 +65,7 @@ export function Dashboard() {
   // the user clicks a different card.
   const [pendingAgent, setPendingAgent] = useState<Agent | null>(null);
   const openerRef = useRef<NewPanelOpener | null>(null);
+  const closerRef = useRef<(() => void) | null>(null);
   const emptyAutoOpenKeyRef = useRef<string | null>(null);
   const openNewMission = useCallback(() => setAgentPickerOpen(true), [setAgentPickerOpen]);
   useEffect(() => {
@@ -118,16 +119,32 @@ export function Dashboard() {
     };
   }, [setOnBoardNavigate, setOnBoardOpen, setMissionControlSelectedId]);
 
-  // Register Escape-to-close while a card is open. Cleared when nothing
-  // is selected so the global handler can't fire into a stale callback.
+  // Register Escape-to-close whenever the panel is open — covers both a
+  // selected card AND the empty new-mission panel. For the new-mission
+  // case `selectedId` is null and the panel state lives inside AIBoard,
+  // so we delegate to the closer AIBoard hands back via
+  // `onPanelCloserReady`. Clearing the highlight too on close is a
+  // no-op when nothing's selected.
   useEffect(() => {
-    if (!mc.selectedId) {
+    if (!missionPanelOpen) {
       setOnPanelClose(null);
       return;
     }
-    setOnPanelClose(() => setMissionControlSelectedId(null));
+    setOnPanelClose(() => {
+      closerRef.current?.();
+      setMissionControlSelectedId(null);
+    });
     return () => setOnPanelClose(null);
-  }, [mc.selectedId, setOnPanelClose, setMissionControlSelectedId]);
+  }, [missionPanelOpen, setOnPanelClose, setMissionControlSelectedId]);
+
+  // Reset the pending agent (set by the New Mission picker) when the
+  // panel closes without a card being selected — otherwise the next
+  // panel open scopes to a stale agent.
+  useEffect(() => {
+    if (!missionPanelOpen && !mc.selectedId) {
+      setPendingAgent(null);
+    }
+  }, [missionPanelOpen, mc.selectedId]);
 
   // Mouse selection (or any external selection change) drags the
   // highlight ring along, so closing the panel leaves it in place.
@@ -150,6 +167,10 @@ export function Dashboard() {
   const handleOpenerReady = useCallback((opener: NewPanelOpener) => {
     openerRef.current = opener;
     setNewPanelOpenerReady(true);
+  }, []);
+
+  const handleCloserReady = useCallback((close: () => void) => {
+    closerRef.current = close;
   }, []);
 
   const handleStopSession = useCallback(
@@ -379,6 +400,7 @@ export function Dashboard() {
           onLoadHistory={mc.loadHistory}
           onHistoryLoaded={mc.handleHistoryLoaded}
           onNewPanelOpenerReady={handleOpenerReady}
+          onPanelCloserReady={handleCloserReady}
           emptyState={emptyBoard}
           panelContainer={panelContainer}
           onPanelOpenChange={setMissionPanelOpen}

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -91,6 +91,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
   );
 
   const openerRef = useRef<NewPanelOpener | null>(null);
+  const closerRef = useRef<(() => void) | null>(null);
   const emptyAutoOpenKeyRef = useRef<string | null>(null);
   const [newPanelOpenerReady, setNewPanelOpenerReady] = useState(false);
   const openDefaultMission = useCallback(() => {
@@ -264,6 +265,10 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
     [setOnStartMission, setBoardActions, agentModes, openDefaultMission],
   );
 
+  const handleCloserReady = useCallback((close: () => void) => {
+    closerRef.current = close;
+  }, []);
+
   const loadHistory = useCallback(
     async (sessionKey: string) => {
       const history = await tauriChat.loadHistory(path, sessionKey);
@@ -361,16 +366,30 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
   }, [setOnBoardNavigate, setOnBoardOpen]);
 
   // Wire the global Escape handler to close THIS board's chat panel
-  // when a card is open. The hook drops the registration when nothing
-  // is selected so a stray Escape can't fire into a stale callback.
+  // whenever the panel is open — covers both selected-card and the
+  // empty new-mission panel. For the new-mission case `selectedId` is
+  // null and the panel state lives inside AIBoard, so we delegate to
+  // the closer AIBoard hands back via `onPanelCloserReady`.
   useEffect(() => {
-    if (!selectedId) {
+    if (!missionPanelOpen) {
       setOnPanelClose(null);
       return;
     }
-    setOnPanelClose(() => setSelectedId(null));
+    setOnPanelClose(() => {
+      closerRef.current?.();
+      setSelectedId(null);
+    });
     return () => setOnPanelClose(null);
-  }, [selectedId, setOnPanelClose]);
+  }, [missionPanelOpen, setOnPanelClose]);
+
+  // Reset the pending agent mode (set by the New Mission button) when
+  // the panel closes without a card being selected — otherwise the next
+  // new-mission panel inherits the previous mode.
+  useEffect(() => {
+    if (!missionPanelOpen && !selectedId) {
+      setPendingAgentMode(null);
+    }
+  }, [missionPanelOpen, selectedId]);
 
   // Keep the highlight aligned with the currently-open card so that
   // closing the panel leaves the ring where the user last was.
@@ -662,6 +681,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
           onLoadHistory={loadHistory}
           onHistoryLoaded={handleHistoryLoaded}
           onNewPanelOpenerReady={handleOpenerReady}
+          onPanelCloserReady={handleCloserReady}
           emptyState={emptyBoard}
           onPanelOpenChange={setMissionPanelOpen}
           onStopSession={handleStopSession}

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -50,6 +50,13 @@ export interface AIBoardProps {
   onHistoryLoaded?: (sessionKey: string, items: FeedItem[]) => void
   /** Called with the openNewPanel function so the parent can trigger it externally (e.g. from a header button). */
   onNewPanelOpenerReady?: (opener: NewPanelOpener) => void
+  /** Called with a panel-close function so the parent can dismiss the
+   *  detail panel from outside (e.g. global Escape handler). Necessary
+   *  for the empty new-mission panel where the parent has no
+   *  `selectedId` to clear — `closePanel` here also resets AIBoard's
+   *  internal `newPanelOpen` state, which `setSelectedId(null)` does
+   *  not touch. */
+  onPanelCloserReady?: (close: () => void) => void
   /** Custom empty state for the chat panel when no messages exist. */
   chatEmptyState?: ReactNode
   /** Custom thinking indicator for the chat panel. */
@@ -188,6 +195,7 @@ export function AIBoard({
   onLoadHistory,
   onHistoryLoaded,
   onNewPanelOpenerReady,
+  onPanelCloserReady,
   chatEmptyState,
   thinkingIndicator,
   cardAvatar,
@@ -384,32 +392,63 @@ export function AIBoard({
     setSelectedId(null)
   }, [setSelectedId])
 
+  // Expose closer to parent so external triggers (global Escape, etc.)
+  // can dismiss the panel without needing to know whether it's a
+  // selected-card panel or the empty new-mission panel.
+  useEffect(() => {
+    onPanelCloserReady?.(closePanel)
+  }, [onPanelCloserReady, closePanel])
+
   // Refs for outside-click detection.
   const boardRef = useRef<HTMLDivElement | null>(null)
   const panelRef = useRef<HTMLDivElement | null>(null)
 
-  // Close the panel when the user clicks anywhere outside the board or the
-  // detail panel (sidebar, tab bar, other app chrome, etc.).
+  // Close the panel when the user clicks anywhere outside the board or
+  // the detail panel (sidebar, tab bar, other app chrome, etc.).
+  //
+  // We listen for `pointerdown` at the CAPTURE phase rather than
+  // `mousedown` at bubble. Two reasons:
+  //  1. Radix DismissableLayer (used by every popover / dropdown /
+  //     select / menu) dismisses on `pointerdown`. By the time a
+  //     bubble-phase `mousedown` fires, Radix has already called
+  //     `onOpenChange(false)`, flipped `data-state` to "closed", and —
+  //     when the component has no exit animation — unmounted the
+  //     popper wrapper entirely. Any "is a popper currently open"
+  //     check we run from `mousedown` is too late: the DOM no longer
+  //     shows one.
+  //  2. Capture phase runs root → target. By listening at capture on
+  //     `document`, we see the event before any descendant handler
+  //     (including Radix's, which is registered later on the layer
+  //     after the popper opens). At that moment the popper is still
+  //     open with `data-state="open"`, so we can detect it reliably.
   useEffect(() => {
     if (!showPanel) return
-    const handler = (e: MouseEvent) => {
+    const handler = (e: PointerEvent) => {
       const target = e.target as Node | null
       if (!target) return
       if (boardRef.current?.contains(target)) return
       if (panelRef.current?.contains(target)) return
       if (target instanceof Element) {
-        // Radix popovers/dropdowns/menus render outside the panel DOM.
+        // Clicks INSIDE a Radix popper (its portal lives outside the
+        // panel DOM) — the user is interacting with a menu we opened
+        // from the panel, not dismissing the panel itself.
         if (target.closest("[data-radix-popper-content-wrapper]")) return
-        // Any Radix popper currently OPEN swallows this mousedown as its
-        // own dismiss gesture (e.g. clicking outside the chat-model
-        // dropdown). The detail panel should not also close — Radix
-        // closes the popper, the user can decide whether to dismiss the
-        // panel with a follow-up click.
-        if (document.querySelector('[data-radix-popper-content-wrapper] [data-state="open"]')) return
-        // Radix Dialog content + overlay also live in a portal outside both
-        // refs. Clicking inside a dialog (or its overlay) is the user
-        // interacting with a modal we just opened FROM the panel, not an
-        // intent to dismiss the panel.
+        // Any Radix popper currently open (anywhere in the document)
+        // intercepts this pointerdown as its own dismiss gesture. The
+        // panel should not also close — Radix dismisses the popper,
+        // user can decide whether to dismiss the panel with a follow-
+        // up click. Because we're at capture phase + pointerdown,
+        // Radix hasn't flipped `data-state` yet, so the open selector
+        // matches.
+        if (document.querySelector('[data-state="open"][data-slot$="-content"]')) return
+        // Belt-and-suspenders fallback for non-shadcn-styled poppers
+        // that don't carry the `data-slot$="-content"` marker but
+        // still use Radix Popper under the hood.
+        if (document.querySelector("[data-radix-popper-content-wrapper]")) return
+        // Radix Dialog content + overlay also live in a portal outside
+        // both refs. Clicking inside a dialog (or its overlay) is the
+        // user interacting with a modal we just opened FROM the panel,
+        // not an intent to dismiss the panel.
         if (target.closest("[data-slot='dialog-content']")) return
         if (target.closest("[data-slot='dialog-overlay']")) return
         // Generic opt-out: any ancestor with `data-keep-panel-open` is
@@ -420,8 +459,8 @@ export function AIBoard({
       }
       closePanel()
     }
-    document.addEventListener("mousedown", handler)
-    return () => document.removeEventListener("mousedown", handler)
+    document.addEventListener("pointerdown", handler, true)
+    return () => document.removeEventListener("pointerdown", handler, true)
   }, [showPanel, closePanel])
 
   const board = (


### PR DESCRIPTION
Closes #211.

## Summary
- Empty new-mission chat panels can now be dismissed with `Esc`. `AIBoard` exposes a new `onPanelCloserReady` opener; the dashboard and per-agent board register `onPanelClose` whenever the panel is open (not just when a card is selected) and delegate to that closer so AIBoard's internal `newPanelOpen` state is reset too. Pending agent / pending agent mode are cleared on close so the next open starts fresh.
- Clicking outside the composer's model picker (or any other Radix popper) no longer also closes the chat panel. The outside-click handler in `AIBoard` now listens on `pointerdown` at capture phase, runs before any Radix `DismissableLayer`, and detects open `@houston-ai/core` poppers via `[data-state="open"][data-slot$=\"-content\"]` — with the popper-wrapper presence kept as a fallback.

## Files
- `ui/board/src/ai-board.tsx`
- `app/src/components/dashboard.tsx`
- `app/src/components/tabs/board-tab.tsx`

## Test plan
- [x] `pnpm -F @houston-ai/board typecheck` clean.
- [x] `pnpm -r typecheck` clean for ui/* and app/* (one pre-existing unrelated error in `create-workspace-dialog.tsx` only).
- [x] Empty new-mission flow (Mission Control): ⌘/Ctrl+N → pick agent → `Esc` (leaves composer) → `Esc` (closes panel).
- [x] Empty new-mission flow (per-agent BoardTab): New Mission button → `Esc` → `Esc` closes.
- [x] Non-empty chat: `Esc`, `Esc` still closes (regression).
- [ ] Auto-opened empty board (first-time agent with no missions): `Esc` closes and does NOT immediately re-open.
- [ ] Close empty new-mission, reopen with a different agent → composer scoped to the new agent (no stale `pendingAgent`).
- [ ] Open model picker → click anywhere outside (sidebar, board, header) → dropdown closes, panel stays open.
- [ ] Pick a model from the dropdown → model selects, dropdown closes, panel stays open.
- [x] Click outside panel with NO popper open → panel still closes normally.
- [x] Composer attach menu (paperclip) → same outside-click behavior as the model picker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)