### PR TITLE
fix(app): make Connect phone copy cross-platform (en/es/pt)

### DIFF
--- a/app/src/components/settings/sections/connect-phone.tsx
+++ b/app/src/components/settings/sections/connect-phone.tsx
@@ -134,7 +134,7 @@ export function ConnectPhoneSection() {
         )}
 
         <p className="text-[11px] text-muted-foreground leading-relaxed text-center max-w-[260px]">
-          {t("settings:connectPhone.keepMacAwake")}
+          {t("settings:connectPhone.keepComputerAwake")}
           <br />
           <Trans
             i18nKey="settings:connectPhone.alwaysOnHint"

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -42,10 +42,10 @@
   },
   "connectPhone": {
     "title": "Connect phone",
-    "description": "Scan this code to manage Houston from your iPhone. The same code keeps working as long as this Mac is on and Houston is open.",
+    "description": "Scan this code to manage Houston from your phone. The same code keeps working as long as this computer is on and Houston is open.",
     "loading": "Getting ready to connect your phone…",
     "connectingStatus": "Connecting to the phone service. This usually takes a few seconds.",
-    "keepMacAwake": "Keep this Mac awake while you use Houston on your phone.",
+    "keepComputerAwake": "Keep this computer awake while you use Houston on your phone.",
     "alwaysOnHint": "For 24/7 access, <emph>Always On</emph> runs Houston on our servers.",
     "errors": {
       "noInternet": "Houston needs an internet connection the first time you open the app. Please connect and reopen Houston to enable phone pairing.",
@@ -53,10 +53,10 @@
     },
     "reset": {
       "title": "Disconnect all phones",
-      "description": "Resets the QR and signs out every phone currently connected to this Mac.",
+      "description": "Resets the QR and signs out every phone currently connected to this computer.",
       "button": "Disconnect all phones",
       "confirmTitle": "Disconnect all phones?",
-      "confirmDescription": "This resets the QR and signs out every phone currently connected to this Mac. Scan the new QR to connect again.",
+      "confirmDescription": "This resets the QR and signs out every phone currently connected to this computer. Scan the new QR to connect again.",
       "confirmLabel": "Disconnect",
       "toast": "Phone access reset"
     }

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -42,10 +42,10 @@
   },
   "connectPhone": {
     "title": "Conectar celular",
-    "description": "Escanea este código para manejar Houston desde tu iPhone. El mismo código sigue funcionando mientras este Mac esté encendido y Houston esté abierto.",
+    "description": "Escanea este código para manejar Houston desde tu celular. El mismo código sigue funcionando mientras esta computadora esté encendida y Houston esté abierto.",
     "loading": "Preparando la conexión con tu celular…",
     "connectingStatus": "Conectando con el servicio del celular. Suele tomar unos segundos.",
-    "keepMacAwake": "Mantén este Mac despierto mientras usas Houston en tu celular.",
+    "keepComputerAwake": "Mantén esta computadora despierta mientras usas Houston en tu celular.",
     "alwaysOnHint": "Para acceso 24/7, <emph>Always On</emph> ejecuta Houston en nuestros servidores.",
     "errors": {
       "noInternet": "Houston necesita conexión a internet la primera vez que lo abres. Conéctate y reabre Houston para habilitar el emparejamiento del celular.",
@@ -53,10 +53,10 @@
     },
     "reset": {
       "title": "Desconectar todos los celulares",
-      "description": "Restablece el QR y cierra la sesión de todos los celulares conectados a este Mac.",
+      "description": "Restablece el QR y cierra la sesión de todos los celulares conectados a esta computadora.",
       "button": "Desconectar todos los celulares",
       "confirmTitle": "¿Desconectar todos los celulares?",
-      "confirmDescription": "Esto restablece el QR y cierra la sesión de todos los celulares conectados a este Mac. Escanea el nuevo QR para conectarte otra vez.",
+      "confirmDescription": "Esto restablece el QR y cierra la sesión de todos los celulares conectados a esta computadora. Escanea el nuevo QR para conectarte otra vez.",
       "confirmLabel": "Desconectar",
       "toast": "Acceso desde el celular restablecido"
     }

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -42,10 +42,10 @@
   },
   "connectPhone": {
     "title": "Conectar celular",
-    "description": "Escaneie este código para usar o Houston no seu iPhone. O mesmo código continua funcionando enquanto este Mac estiver ligado e o Houston estiver aberto.",
+    "description": "Escaneie este código para usar o Houston no seu celular. O mesmo código continua funcionando enquanto este computador estiver ligado e o Houston estiver aberto.",
     "loading": "Preparando a conexão com seu celular…",
     "connectingStatus": "Conectando ao serviço do celular. Costuma levar alguns segundos.",
-    "keepMacAwake": "Mantenha este Mac aberto enquanto você usa o Houston no celular.",
+    "keepComputerAwake": "Mantenha este computador aberto enquanto você usa o Houston no celular.",
     "alwaysOnHint": "Para acesso 24/7, <emph>Always On</emph> roda o Houston nos nossos servidores.",
     "errors": {
       "noInternet": "O Houston precisa de internet na primeira vez que você abre o app. Conecte-se e reabra o Houston para habilitar o pareamento do celular.",
@@ -53,10 +53,10 @@
     },
     "reset": {
       "title": "Desconectar todos os celulares",
-      "description": "Redefine o QR e sai de todos os celulares conectados a este Mac.",
+      "description": "Redefine o QR e sai de todos os celulares conectados a este computador.",
       "button": "Desconectar todos os celulares",
       "confirmTitle": "Desconectar todos os celulares?",
-      "confirmDescription": "Isso redefine o QR e sai de todos os celulares conectados a este Mac. Escaneie o novo QR para conectar de novo.",
+      "confirmDescription": "Isso redefine o QR e sai de todos os celulares conectados a este computador. Escaneie o novo QR para conectar de novo.",
       "confirmLabel": "Desconectar",
       "toast": "Acesso pelo celular redefinido"
     }


### PR DESCRIPTION
## Summary

- Settings → Connect phone copy assumed the user was on a Mac with an iPhone. With Windows engine support shipped in #209 and Houston Mobile being a PWA that runs in any modern phone browser, those refs are wrong.
- Swap "this Mac" → "this computer" / "esta computadora" / "este computador" (with Spanish gender agreement), and "iPhone" → "phone" / "celular" / "celular" to match the section title in each locale.
- Rename the i18n key `connectPhone.keepMacAwake` → `keepComputerAwake` so the internal name matches the user-facing copy.

Closes #215

## Test plan

- [x] `pnpm check-locales` — passes locally (all 3 locales in sync)
- [x] `pnpm tsc --noEmit` in `app/` — no type errors from the renamed i18n key
- [x] `pnpm tauri dev` → Settings → Connect phone, verify copy in en, es, pt