### PR TITLE
feat(app): reveal exported agent in file manager from save toast

### DIFF
--- a/app/src-tauri/src/commands/os.rs
+++ b/app/src-tauri/src/commands/os.rs
@@ -176,6 +176,19 @@ pub async fn reveal_agent(agent_path: String) -> Result<(), String> {
         .map_err(|e| format!("Failed to open folder: {e}"))
 }
 
+/// Reveal an arbitrary absolute path in the OS file manager. Used by flows
+/// that produce a file outside any agent root (e.g. the portable-agent
+/// exporter writes a `.houstonagent` wherever the user picked in the save
+/// dialog — Desktop, Downloads, USB drive, …).
+#[tauri::command(rename_all = "snake_case")]
+pub async fn reveal_path(path: String) -> Result<(), String> {
+    let target = expand(&path);
+    if !target.exists() {
+        return Err(format!("Path does not exist: {}", target.display()));
+    }
+    reveal_in_file_manager(&target).map_err(|e| format!("Failed to reveal path: {e}"))
+}
+
 /// Open the OS file manager with the given path selected (Finder reveal /
 /// Explorer /select / xdg-open on parent dir).
 fn reveal_in_file_manager(path: &Path) -> Result<(), String> {

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -323,6 +323,7 @@ pub fn run() {
             commands::os::open_file,
             commands::os::reveal_file,
             commands::os::reveal_agent,
+            commands::os::reveal_path,
             commands::terminal::open_terminal,
             commands::os::check_claude_cli,
             commands::portable::save_portable_agent,

--- a/app/src/components/portable/export-wizard.tsx
+++ b/app/src/components/portable/export-wizard.tsx
@@ -24,6 +24,7 @@ import {
 import { useUIStore } from "../../stores/ui";
 import { useAgentStore } from "../../stores/agents";
 import { getEngine } from "../../lib/engine";
+import { osRevealPath } from "../../lib/os-bridge";
 import { IntegrationLogos } from "../integration-logos";
 import type {
   PortableAnonymizeResponse,
@@ -220,6 +221,18 @@ export function ExportAgentWizard() {
           variant: "success",
           title: t("export.toasts.savedTitle"),
           description: t("export.toasts.savedDescription", { path: savedPath }),
+          action: {
+            label: t("export.toasts.revealAction"),
+            onClick: () => {
+              void osRevealPath(savedPath).catch((err) =>
+                addToast({
+                  variant: "error",
+                  title: t("export.errors.revealFailed"),
+                  description: String(err),
+                }),
+              );
+            },
+          },
         });
         handleClose();
       }

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -55,6 +55,12 @@ export function osRevealAgent(agentPath: string): Promise<void> {
   return invoke<void>("reveal_agent", { agent_path: agentPath });
 }
 
+/** Reveal an arbitrary absolute path in Finder / Explorer. For files written
+ * outside any agent root (e.g. the portable-agent exporter's save dialog). */
+export function osRevealPath(path: string): Promise<void> {
+  return invoke<void>("reveal_path", { path });
+}
+
 /** Open an agent-relative file with the user's default application. */
 export function osOpenFile(agentPath: string, relativePath: string): Promise<void> {
   return invoke<void>("open_file", { agent_path: agentPath, relative_path: relativePath });

--- a/app/src/locales/en/portable.json
+++ b/app/src/locales/en/portable.json
@@ -57,11 +57,13 @@
       "previewFailed": "Could not read your agent.",
       "anonymizeFailed": "Anonymize step failed.",
       "saveFailed": "Could not save the file.",
-      "noPreview": "No preview available."
+      "noPreview": "No preview available.",
+      "revealFailed": "Could not open that folder."
     },
     "toasts": {
       "savedTitle": "File saved",
-      "savedDescription": "Saved to {{path}}"
+      "savedDescription": "Saved to {{path}}",
+      "revealAction": "Show in folder"
     }
   },
   "import": {

--- a/app/src/locales/es/portable.json
+++ b/app/src/locales/es/portable.json
@@ -57,11 +57,13 @@
       "previewFailed": "No pude leer tu agente.",
       "anonymizeFailed": "Falló la anonimización.",
       "saveFailed": "No pude guardar el archivo.",
-      "noPreview": "No hay vista previa."
+      "noPreview": "No hay vista previa.",
+      "revealFailed": "No pude abrir esa carpeta."
     },
     "toasts": {
       "savedTitle": "Archivo guardado",
-      "savedDescription": "Guardado en {{path}}"
+      "savedDescription": "Guardado en {{path}}",
+      "revealAction": "Mostrar en la carpeta"
     }
   },
   "import": {

--- a/app/src/locales/pt/portable.json
+++ b/app/src/locales/pt/portable.json
@@ -57,11 +57,13 @@
       "previewFailed": "Não consegui ler seu agente.",
       "anonymizeFailed": "Falha na anonimização.",
       "saveFailed": "Não consegui salvar o arquivo.",
-      "noPreview": "Sem prévia."
+      "noPreview": "Sem prévia.",
+      "revealFailed": "Não consegui abrir essa pasta."
     },
     "toasts": {
       "savedTitle": "Arquivo salvo",
-      "savedDescription": "Salvo em {{path}}"
+      "savedDescription": "Salvo em {{path}}",
+      "revealAction": "Mostrar na pasta"
     }
   },
   "import": {


### PR DESCRIPTION
## Summary

- The Share-with-a-friend success toast now carries a **"Show in folder"** action that opens the OS file manager at the export location with the `.houstonagent` file selected (Finder reveal on macOS, `explorer /select,` on Windows, `xdg-open` on the parent dir on Linux).
- Adds a new `reveal_path` Tauri command for revealing any absolute path — distinct from the existing agent-scoped `reveal_file`, since exports land wherever the save dialog goes (Desktop, Downloads, USB drive).
- Reveal failures surface as an error toast — no silent failures, per the beta-stage policy in `CLAUDE.md`.

## Why

Non-technical users — the product's target audience — used to read the absolute path out of the toast, switch to Finder/Explorer, and navigate by hand. Three steps for what should be one click.

## Affected files

- `app/src-tauri/src/commands/os.rs` — new `reveal_path` command.
- `app/src-tauri/src/lib.rs` — register the command in `invoke_handler!`.
- `app/src/lib/os-bridge.ts` — `osRevealPath(path)` bridge (keeps the CI-enforced single-file `invoke(...)` invariant).
- `app/src/components/portable/export-wizard.tsx` — attach `action: { label, onClick }` to the success toast; surface reveal errors.
- `app/src/locales/{en,es,pt}/portable.json` — `export.toasts.revealAction` + `export.errors.revealFailed`.

## Test plan

- [x] `cd app && pnpm tsc --noEmit`
- [x] `cd app && pnpm check-locales`
- [x] `cd app/src-tauri && cargo check`
- [x] macOS: export an agent, click **Show in folder** in the toast → Finder opens with the file selected.
- [x] Windows: same flow → Explorer opens with the file highlighted.
- [x] Linux: same flow → file manager opens at the parent directory.
- [ ] Force a reveal failure (point at a deleted path) → error toast appears.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)