### PR TITLE
fix(provider): unblock codex on ChatGPT accounts

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -66,7 +66,7 @@ import {
   isComposioSigninHref,
 } from "./composio-signin-card";
 import { ChatModelSelector } from "./chat-model-selector";
-import { getDefaultModel } from "../lib/providers";
+import { getDefaultModel, validModelOrNull } from "../lib/providers";
 import { analytics } from "../lib/analytics";
 import {
   buildSkillClaudePrompt,
@@ -183,7 +183,10 @@ export function useAgentChatPanel({
   const selectedActivityId = selectedActivity?.id ?? null;
 
   const effectiveProvider = activityProvider ?? agentProvider ?? "anthropic";
-  const effectiveModel = activityModel ?? agentModel ?? getDefaultModel(effectiveProvider);
+  const effectiveModel =
+    validModelOrNull(effectiveProvider, activityModel) ??
+    validModelOrNull(effectiveProvider, agentModel) ??
+    getDefaultModel(effectiveProvider);
   const handleModelSelect = useCallback(
     async (prov: string, mod: string) => {
       // Optimistic UI: the picker flips instantly while the writes fan out.

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -49,22 +49,11 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     installUrl: "https://github.com/openai/codex",
     loginCommand: "codex login",
     cost: "Your ChatGPT subscription",
-    // `gpt-5.5` is the default because the `-codex` variant is not granted
-    // on every ChatGPT plan (Business / Enterprise users hit a hard 400
-    // "model is not supported when using Codex with a ChatGPT account").
-    // Plain `gpt-5.5` works on every plan that Codex accepts at all, so we
-    // default there and let users opt into `-codex` via the picker if their
-    // plan allows it.
     models: [
       {
         id: "gpt-5.5",
         label: "GPT-5.5",
-        description: "Works on every ChatGPT plan. Recommended default.",
-      },
-      {
-        id: "gpt-5.5-codex",
-        label: "GPT-5.5 Codex",
-        description: "Coding-tuned. Some ChatGPT plans (e.g. Business) do not include it.",
+        description: "OpenAI's frontier model.",
       },
     ],
     defaultModel: "gpt-5.5",
@@ -111,6 +100,20 @@ export function getDefaultModel(providerId: string): string {
  */
 export function validProviderOrNull(providerId: string | null | undefined): string | null {
   return providerId && getProvider(providerId) ? providerId : null;
+}
+
+/**
+ * Return `modelId` only when it names a model currently listed in `PROVIDERS`
+ * for `providerId`. Stored configs can point at retired SKUs (e.g. the
+ * phantom `gpt-5.5-codex` that ChatGPT never shipped); chain with `??
+ * getDefaultModel(provider)` so the picker and the wire call agree on a
+ * model the server will actually accept.
+ */
+export function validModelOrNull(
+  providerId: string | null | undefined,
+  modelId: string | null | undefined,
+): string | null {
+  return providerId && modelId && getModel(providerId, modelId) ? modelId : null;
 }
 
 export interface ComingSoonProviderInfo {

--- a/engine/houston-engine-core/src/provider/mod.rs
+++ b/engine/houston-engine-core/src/provider/mod.rs
@@ -471,6 +471,25 @@ mod tests {
     }
 
     #[test]
+    fn login_command_codex_includes_reasoning_effort_override() {
+        let provider = parse("openai").unwrap();
+        let path = PathBuf::from("/tmp/houston-test-codex");
+        let command = build_cli_command(
+            provider,
+            provider.login_args().unwrap().to_vec(),
+            Some(path.clone()),
+            OsString::from("/not/on/path"),
+        )
+        .unwrap();
+        assert_eq!(command.cli_name, "codex");
+        assert_eq!(command.path, path);
+        assert_eq!(
+            command.args,
+            vec!["login", "-c", "model_reasoning_effort=high"]
+        );
+    }
+
+    #[test]
     fn logout_command_claude_uses_auth_logout() {
         let provider = parse("anthropic").unwrap();
         let path = PathBuf::from("/tmp/houston-test-claude");
@@ -499,7 +518,10 @@ mod tests {
         .unwrap();
         assert_eq!(command.cli_name, "codex");
         assert_eq!(command.path, path);
-        assert_eq!(command.args, vec!["logout"]);
+        assert_eq!(
+            command.args,
+            vec!["logout", "-c", "model_reasoning_effort=high"]
+        );
     }
 
     #[test]

--- a/engine/houston-engine-core/src/sessions/generate_instructions.rs
+++ b/engine/houston-engine-core/src/sessions/generate_instructions.rs
@@ -16,7 +16,7 @@ use std::time::Duration;
 
 const GENERATE_TIMEOUT: Duration = Duration::from_secs(60);
 const CLAUDE_GEN_MODEL: &str = "sonnet";
-const CODEX_GEN_MODEL: &str = "gpt-5.5-codex";
+const CODEX_GEN_MODEL: &str = "gpt-5.5";
 /// Gemini generation model. Flash-Lite — matches the only Gemini model
 /// currently offered by the frontend catalog (`app/src/lib/providers.ts`),
 /// so when a user pins Gemini to their workspace and hits Create-with-AI

--- a/engine/houston-terminal-manager/src/provider/openai.rs
+++ b/engine/houston-terminal-manager/src/provider/openai.rs
@@ -44,13 +44,25 @@ impl ProviderAdapter for OpenAiAdapter {
     }
 
     fn login_args(&self) -> Option<&'static [&'static str]> {
-        Some(&["login"])
+        // Same `xhigh` guard as `logout_args` and the runner: codex loads
+        // `~/.codex/config.toml` before any subcommand, and a stale
+        // `model_reasoning_effort = "xhigh"` written by a newer CLI makes
+        // the bundled one bail out before the OAuth flow can even start.
+        Some(&["login", "-c", "model_reasoning_effort=high"])
     }
 
     fn logout_args(&self) -> Option<&'static [&'static str]> {
         // `codex logout` revokes the ChatGPT refresh token server-side
         // then deletes `~/.codex/auth.json`.
-        Some(&["logout"])
+        //
+        // Codex loads `~/.codex/config.toml` before running any subcommand,
+        // including `logout`. Newer Codex CLIs write
+        // `model_reasoning_effort = "xhigh"`, which the bundled CLI rejects
+        // ("unknown variant `xhigh`"), so logout exits 1 with a config error
+        // and the user is stuck signed in. Force a known-good value, same
+        // trick `provider_auth::probe_codex_auth_status` uses for
+        // `login status`.
+        Some(&["logout", "-c", "model_reasoning_effort=high"])
     }
 
     fn classify_stderr(&self, line: &str) -> Option<ProviderError> {


### PR DESCRIPTION
## Summary

- **Codex login + logout no longer die on `xhigh`.** `codex login` / `codex logout` read `~/.codex/config.toml` before doing anything; a `model_reasoning_effort = "xhigh"` written by a newer codex makes the bundled CLI exit 1 with `unknown variant 'xhigh'`. Force `-c model_reasoning_effort=high` on both commands, matching what `login status`, `codex exec`, and one-shot generation already do.
- **Drop the phantom `gpt-5.5-codex` SKU.** OpenAI never shipped that model; every call returned 400 `"not supported when using Codex with a ChatGPT account"`. The OpenAI catalog now lists only `gpt-5.5`.
- **`validModelOrNull` fallback.** Stored agent configs that point at the retired `gpt-5.5-codex` now fall back to `gpt-5.5` via the chat panel's effective-model chain, instead of being sent verbatim to the CLI.
- **Fix `CODEX_GEN_MODEL`.** `generate_instructions.rs` had the same phantom hardcoded — Create-with-AI on an OpenAI agent would have hit the same 400. Flipped to `gpt-5.5`.

## Test plan

- [x] `cargo test -p houston-engine-core -p houston-terminal-manager` (216 + 190 passed)
- [x] `pnpm tsc --noEmit` in `app/`
- [x] Manual: signin/signout with `xhigh` in `~/.codex/config.toml` — completes cleanly.
- [ ] Manual: send a message to an OpenAI agent on a Pro plan — completes on `gpt-5.5`.
- [ ] Manual: Create-with-AI from an OpenAI agent — runs without 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)