### PR TITLE
release: v0.4.20

### DIFF
--- a/.github/release-notes/0.4.20.md
+++ b/.github/release-notes/0.4.20.md
@@ -1,0 +1,36 @@
+## Houston 0.4.20
+
+Codex-on-ChatGPT fixes plus the run of mission-control, onboarding, and platform work that landed since v0.4.19.
+
+### Fixed
+
+- **Codex sign-in, sign-out, and mission runs work again on ChatGPT accounts.** `codex login` and `codex logout` were aborting with `unknown variant 'xhigh'` whenever the user had a newer codex CLI installed globally (which writes `model_reasoning_effort = "xhigh"` into `~/.codex/config.toml`). Houston now passes `-c model_reasoning_effort=high` to both, the same trick the runner has used for a while.
+- **Phantom `gpt-5.5-codex` model removed from the OpenAI picker.** OpenAI never shipped that SKU; every call returned 400 `"not supported when using Codex with a ChatGPT account"` regardless of plan. Catalog now lists only `gpt-5.5`. Stored configs that point at the retired model fall back to `gpt-5.5` automatically.
+- **Mission panel stays open through the model picker** and closes cleanly on Esc when the new-mission field is empty.
+- **Connect-phone copy is cross-platform** in English, Spanish, and Portuguese — no more macOS-only wording on Windows.
+- **Plus icon and left-aligned model picker** restored after the previous chat header refactor.
+- **Self-healing workspace index** plus per-call tmp filename so two concurrent writes can't corrupt each other.
+- **Sessions no longer vanish or stick on "running"** after an unexpected provider exit.
+- **Agent files browser renders correctly on Windows** including empty folders.
+
+### Changed
+
+- **Per-agent provider + model storage.** Workspace-level defaults are retired; each agent now carries its own provider and model in its `.houston/config/config.json`. Existing workspaces migrate idempotently on next launch.
+- **Create-with-AI for new agents.** Type a sentence describing what you want the agent to do; the provider you pick generates a CLAUDE.md, suggests Composio integrations, and proposes a starting routine.
+- **Paste images straight from the OS clipboard** into chat.
+- **Global keyboard shortcuts** across mission control, board, and chat, plus a command-palette-style sidebar Commands menu and chat attach menu.
+- **"Finder" renamed to "File Manager"** everywhere in the UI so Windows users see terminology that matches their OS.
+- **Gemini provider paused** in the picker while the engine adapter is hardened. Existing Gemini agents keep working; new agents can't select it until it returns.
+- **Settings sidebar shows the app version** at the bottom so bug reports include it without users having to dig.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward automatically. The MSI is still not OS-code-signed (SignPath integration still pending).
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install. Download the ARM64 MSI manually, uninstall the x64 build first, then install the ARM64 one.
+
+### Known limitations
+
+- **Windows MSI not yet OS-code-signed.** SignPath integration still pending.
+- **"Continue with Microsoft" sign-in for Houston itself remains hidden** while we reconcile the Supabase Azure provider with the production callback URL. Google sign-in is unaffected.
+- **Mobile companion is still beta.** Expect occasional reconnect hiccups.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2365,7 +2365,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "chrono",
  "serde",
@@ -2379,7 +2379,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "chrono",
  "serde",
@@ -2392,7 +2392,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2406,7 +2406,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.11"
+version = "0.4.20"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2433,7 +2433,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "futures-util",
  "hex",
@@ -2453,7 +2453,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -2463,7 +2463,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2481,7 +2481,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2494,7 +2494,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2530,7 +2530,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2542,7 +2542,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2580,7 +2580,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2635,7 +2635,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.11"
+version = "0.4.20"
 dependencies = [
  "houston-agent-files",
  "houston-agents-conversations",
@@ -2653,7 +2653,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "dirs 5.0.1",
  "houston-cli-bundle",
@@ -2666,7 +2666,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2686,7 +2686,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.10"
+version = "0.4.20"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,21 +33,21 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.10", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.10", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.10", path = "app/houston-tauri" }
-houston-events = { version = "0.4.10", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.10", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.10", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.10", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.10", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.10", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.10", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.10", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.10", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.10", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.10", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.10", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.10", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.10", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.10", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.20", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.20", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.20", path = "app/houston-tauri" }
+houston-events = { version = "0.4.20", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.20", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.20", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.20", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.20", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.20", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.20", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.20", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.20", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.20", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.20", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.20", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.20", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.20", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.20", path = "engine/houston-engine-server" }

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.11"
+version = "0.4.20"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.11",
+  "version": "0.4.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.11"
+version = "0.4.20"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.10"
+version = "0.4.20"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.11",
+  "version": "0.4.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.10",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.10",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.10",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.10",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.10",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.10",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.10",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.10",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Version bump + release notes for v0.4.20.

Notes drafted at `.github/release-notes/0.4.20.md`. Once this PR merges, tag `v0.4.20` from main and the release workflow will pick up the notes verbatim, build signed/notarized artifacts for macOS + Windows, and create a draft release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)