### PR TITLE
fix(chat): restore visible scrollbar in chat message list

### DIFF
--- a/ui/chat/src/ai-elements/conversation.tsx
+++ b/ui/chat/src/ai-elements/conversation.tsx
@@ -41,7 +41,7 @@ export const ConversationContent = ({
     // library binds its scrollRef to). The `conversation-scroll-pane`
     // marker class is the stable selector the keyboard-shortcut layer
     // uses to step-scroll the log with arrow keys.
-    scrollClassName="conversation-scroll-pane [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+    scrollClassName="conversation-scroll-pane"
     className={cn("flex flex-col gap-8 p-4", className)}
     {...props}
   />


### PR DESCRIPTION
## Summary

- Drops `[scrollbar-width:none] [&::-webkit-scrollbar]:hidden` from the chat's `<StickToBottom.Content>` `scrollClassName`.
- The hide was added incidentally in #197 while wiring up the `.conversation-scroll-pane` marker class for arrow-key step-scroll; the design system already defines a thin custom scrollbar globally in `@houston-ai/core` (`globals.css:197`), so removing the override restores it.
- `.conversation-scroll-pane` marker class stays — keyboard step-scroll still depends on it.

## Test plan

- [x] `pnpm --filter @houston-ai/chat typecheck`
- [x] `pnpm tauri dev`, open chat panel with several messages, confirm thin scrollbar is visible on the right while scrolling
- [x] Arrow-key step-scroll (↑/↓) still scrolls the chat log

Closes #224

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>