### PR TITLE
feat(routines): cancel in-flight runs + cascade on delete

### DIFF
--- a/app/src/components/tabs/routines-tab.tsx
+++ b/app/src/components/tabs/routines-tab.tsx
@@ -9,6 +9,7 @@ import {
   useUpdateRoutine,
   useDeleteRoutine,
   useRunRoutineNow,
+  useCancelRoutineRun,
 } from "../../hooks/queries";
 import { useTimezonePreference } from "../../hooks/use-timezone-preference";
 import type { TabProps } from "../../lib/types";
@@ -57,6 +58,7 @@ export default function RoutinesTab({ agent }: TabProps) {
   const updateRoutine = useUpdateRoutine(path);
   const deleteRoutine = useDeleteRoutine(path);
   const runNow = useRunRoutineNow(path);
+  const cancelRun = useCancelRoutineRun(path);
 
   const [view, setView] = useState<View>({ type: "grid" });
   const [form, setForm] = useState<RoutineFormData>(EMPTY_FORM);
@@ -146,6 +148,13 @@ export default function RoutinesTab({ agent }: TabProps) {
     [runNow],
   );
 
+  const handleCancelRun = useCallback(
+    (routineId: string, runId: string) => {
+      cancelRun.mutate({ routineId, runId });
+    },
+    [cancelRun],
+  );
+
   // `useTimezonePreference` auto-seeds on first call, so `tz.timezone` is
   // non-null from the first render. We still wait for the roundtrip to
   // finish so the cron schedule renders against the real zone instead of
@@ -175,6 +184,11 @@ export default function RoutinesTab({ agent }: TabProps) {
         routine={editing}
         runs={editingRuns}
         onRunNow={editing ? () => handleRunNow(editing.id) : undefined}
+        onCancelRun={
+          editing
+            ? (runId: string) => handleCancelRun(editing.id, runId)
+            : undefined
+        }
         onToggle={
           editing ? (enabled) => handleToggle(editing.id, enabled) : undefined
         }

--- a/app/src/components/tabs/routines-tab.tsx
+++ b/app/src/components/tabs/routines-tab.tsx
@@ -184,6 +184,7 @@ export default function RoutinesTab({ agent }: TabProps) {
         routine={editing}
         runs={editingRuns}
         onRunNow={editing ? () => handleRunNow(editing.id) : undefined}
+        runNowPending={runNow.isPending}
         onCancelRun={
           editing
             ? (runId: string) => handleCancelRun(editing.id, runId)

--- a/app/src/hooks/queries/index.ts
+++ b/app/src/hooks/queries/index.ts
@@ -20,6 +20,7 @@ export {
   useUpdateRoutine,
   useDeleteRoutine,
   useRunRoutineNow,
+  useCancelRoutineRun,
 } from "./use-routines";
 export {
   useLearnings,

--- a/app/src/hooks/queries/use-routines.ts
+++ b/app/src/hooks/queries/use-routines.ts
@@ -69,3 +69,14 @@ export function useRunRoutineNow(agentPath: string) {
     },
   });
 }
+
+export function useCancelRoutineRun(agentPath: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ routineId, runId }: { routineId: string; runId: string }) =>
+      tauriRoutines.cancelRun(agentPath, routineId, runId),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["routine-runs", agentPath] });
+    },
+  });
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -547,6 +547,10 @@ export const tauriRoutines = {
     call<void>("run_routine_now", () =>
       getEngine().runRoutineNow(agentPath, routineId),
     ),
+  cancelRun: (agentPath: string, routineId: string, runId: string) =>
+    call("cancel_routine_run", () =>
+      getEngine().cancelRoutineRun(agentPath, routineId, runId),
+    ),
   startScheduler: (agentPath: string) =>
     call<void>("start_routine_scheduler", () =>
       getEngine().startRoutineScheduler(agentPath),

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -8,9 +8,22 @@ use crate::session_pids::SessionPidMap;
 use houston_db::Database;
 use houston_terminal_manager::auth_error::{is_auth_error, is_auth_retry_marker};
 use houston_terminal_manager::provider_auth::ProviderAuthState;
+use houston_terminal_manager::provider_error_kind::ProviderError;
 use houston_terminal_manager::{FeedItem, Provider, SessionManager, SessionStatus, SessionUpdate};
 use houston_ui_events::{DynEventSink, HoustonEvent};
 use std::path::PathBuf;
+use std::sync::Arc;
+
+/// Hook into provider-emitted lifecycle signals the generic session loop
+/// can't act on directly. Today fires on `UsageLimitPaused` (the CLI
+/// went to sleep waiting for its plan-window reset) and again when
+/// output resumes — so the embedder can persist run-specific state
+/// (e.g. `routine_run.paused_until`) without `agents-conversations`
+/// needing to know about routines.
+pub trait SessionLifecycle: Send + Sync {
+    fn on_paused(&self, resets_at: Option<String>, message: String);
+    fn on_resumed(&self);
+}
 
 /// Result of a completed session.
 pub struct SessionResult {
@@ -30,6 +43,11 @@ pub struct PersistOptions {
     /// Set automatically once the session reports its ID via
     /// SessionUpdate::SessionId. Do not set manually.
     pub claude_session_id: Option<String>,
+    /// Optional lifecycle hook for pause/resume signals. Currently used by
+    /// the routine dispatcher to flip a `routine_run.paused_until` field on
+    /// disk when the Anthropic CLI sleeps on a plan-window usage limit.
+    #[allow(clippy::type_complexity)]
+    pub lifecycle: Option<Arc<dyn SessionLifecycle>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -115,6 +133,7 @@ pub fn spawn_and_monitor(
         let mut saw_auth_error = false;
         let mut sent_auth_checking = false;
         let mut sent_auth_required = false;
+        let mut paused_signaled = false;
 
         while let Some(update) = rx.recv().await {
             match update {
@@ -128,6 +147,16 @@ pub fn spawn_and_monitor(
                     if let FeedItem::AssistantText(text) = item {
                         response_text = Some(text.clone());
                     }
+
+                    // Lifecycle hook: usage-limit pause/resume. The CLI
+                    // sleeps internally until its reset window, so the
+                    // stream stays open but goes quiet. Notify the
+                    // embedder so it can flip persisted state (e.g.
+                    // `routine_run.paused_until`). Any subsequent
+                    // assistant/tool output is treated as the resume.
+                    let lifecycle_ref =
+                        persist.as_ref().and_then(|p| p.lifecycle.as_deref());
+                    notify_lifecycle(item, lifecycle_ref, &mut paused_signaled);
                     // Collapse ALL auth-flavored system messages into a single
                     // "Checking connection..." banner. Covers three shapes we've
                     // seen in the wild:
@@ -425,6 +454,47 @@ fn is_opaque_claude_auth_error(provider: Provider, message: &str) -> bool {
     provider.id() == "anthropic" && message.trim() == "Error: Unknown error"
 }
 
+/// Dispatch a feed item to the optional `SessionLifecycle` hook.
+///
+/// Two transitions are interesting:
+/// - `UsageLimitPaused` → call `on_paused` and remember the paused state.
+/// - When `paused_signaled` is set and any assistant/tool/thinking item
+///   arrives, the CLI has resumed → call `on_resumed` and clear the flag.
+///
+/// Everything else is a no-op. Extracted as a free function so the
+/// transition table is testable without driving a real subprocess.
+fn notify_lifecycle(
+    item: &FeedItem,
+    lifecycle: Option<&dyn SessionLifecycle>,
+    paused_signaled: &mut bool,
+) {
+    if let FeedItem::ProviderError(ProviderError::UsageLimitPaused {
+        resets_at, message, ..
+    }) = item
+    {
+        if let Some(lc) = lifecycle {
+            lc.on_paused(resets_at.clone(), message.clone());
+        }
+        *paused_signaled = true;
+        return;
+    }
+
+    let is_progress = matches!(
+        item,
+        FeedItem::AssistantText(_)
+            | FeedItem::AssistantTextStreaming(_)
+            | FeedItem::ToolCall { .. }
+            | FeedItem::Thinking(_)
+            | FeedItem::ThinkingStreaming(_)
+    );
+    if *paused_signaled && is_progress {
+        if let Some(lc) = lifecycle {
+            lc.on_resumed();
+        }
+        *paused_signaled = false;
+    }
+}
+
 fn restore_pending_user_message(current: &mut Option<String>, original: &Option<String>) {
     if current.is_none() {
         *current = original.clone();
@@ -503,6 +573,88 @@ mod tests {
         restore_pending_user_message(&mut current, &original);
 
         assert_eq!(current.as_deref(), Some("current"));
+    }
+
+    #[derive(Default)]
+    struct RecordingLifecycle {
+        paused_calls: std::sync::Mutex<Vec<(Option<String>, String)>>,
+        resume_calls: std::sync::Mutex<u32>,
+    }
+
+    impl SessionLifecycle for RecordingLifecycle {
+        fn on_paused(&self, resets_at: Option<String>, message: String) {
+            self.paused_calls.lock().unwrap().push((resets_at, message));
+        }
+        fn on_resumed(&self) {
+            *self.resume_calls.lock().unwrap() += 1;
+        }
+    }
+
+    #[test]
+    fn notify_lifecycle_fires_on_usage_limit_paused() {
+        let lc = RecordingLifecycle::default();
+        let mut paused = false;
+        let item = FeedItem::ProviderError(ProviderError::UsageLimitPaused {
+            provider: "anthropic".into(),
+            resets_at: Some("5pm".into()),
+            message: "banner".into(),
+        });
+        notify_lifecycle(&item, Some(&lc), &mut paused);
+        assert!(paused);
+        assert_eq!(lc.paused_calls.lock().unwrap().len(), 1);
+        assert_eq!(*lc.resume_calls.lock().unwrap(), 0);
+    }
+
+    #[test]
+    fn notify_lifecycle_fires_resumed_only_after_pause() {
+        let lc = RecordingLifecycle::default();
+        let mut paused = false;
+        // Plain content before any pause → no resume call.
+        notify_lifecycle(
+            &FeedItem::AssistantText("hi".into()),
+            Some(&lc),
+            &mut paused,
+        );
+        assert!(!paused);
+        assert_eq!(*lc.resume_calls.lock().unwrap(), 0);
+
+        // Pause.
+        notify_lifecycle(
+            &FeedItem::ProviderError(ProviderError::UsageLimitPaused {
+                provider: "anthropic".into(),
+                resets_at: None,
+                message: "b".into(),
+            }),
+            Some(&lc),
+            &mut paused,
+        );
+        assert!(paused);
+
+        // Content after pause → resume fires once.
+        notify_lifecycle(
+            &FeedItem::AssistantText("hello again".into()),
+            Some(&lc),
+            &mut paused,
+        );
+        assert!(!paused);
+        assert_eq!(*lc.resume_calls.lock().unwrap(), 1);
+    }
+
+    #[test]
+    fn notify_lifecycle_ignored_when_no_handler() {
+        let mut paused = false;
+        notify_lifecycle(
+            &FeedItem::ProviderError(ProviderError::UsageLimitPaused {
+                provider: "anthropic".into(),
+                resets_at: None,
+                message: "b".into(),
+            }),
+            None,
+            &mut paused,
+        );
+        // Without a handler we still track the paused flag so the next
+        // resume signal doesn't fire spuriously when one is installed.
+        assert!(paused);
     }
 
     #[test]

--- a/engine/houston-engine-core/src/routines/engine_dispatcher.rs
+++ b/engine/houston-engine-core/src/routines/engine_dispatcher.rs
@@ -13,12 +13,15 @@ use crate::agents::{
 use crate::routines::runner::{
     ActivitySurface, DispatchContext, DispatchOutcome, RoutineDispatcher,
 };
+use crate::routines::runs as routine_runs;
+use crate::routines::types::RoutineRunUpdate;
 use crate::sessions::{self, SessionRuntime};
 use async_trait::async_trait;
-use houston_agents_conversations::session_runner::{self, PersistOptions};
+use houston_agents_conversations::session_runner::{self, PersistOptions, SessionLifecycle};
 use houston_db::Database;
-use houston_ui_events::DynEventSink;
-use std::path::Path;
+use houston_ui_events::{DynEventSink, HoustonEvent};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 /// Dispatcher that spawns a real session via `houston-agents-conversations`
 /// and waits for completion.
@@ -92,6 +95,12 @@ impl RoutineDispatcher for EngineRoutineDispatcher {
                 source: "routine".into(),
                 user_message: Some(ctx.prompt.to_string()),
                 claude_session_id: None,
+                lifecycle: Some(Arc::new(RoutineRunLifecycle {
+                    root: ctx.working_dir.to_path_buf(),
+                    run_id: ctx.run.id.clone(),
+                    agent_path: ctx.agent_path.to_string(),
+                    events: self.events.clone(),
+                })),
             }),
             Some(self.rt.pid_map.clone()),
             resolved.provider,
@@ -109,6 +118,123 @@ impl RoutineDispatcher for EngineRoutineDispatcher {
                 error: Some(format!("session task failed: {e}")),
             },
         }
+    }
+}
+
+/// Persist `routine_run.paused_until` when the underlying CLI sleeps on a
+/// usage-limit window, and clear it when output resumes. `tracing::error!`
+/// is the right surface on failure here: this hook runs inside the event
+/// loop with no UI thread to toast on (the documented carve-out to the
+/// otherwise-banned silent-failure pattern). The persisted state is a
+/// hint; a missed write degrades to "we'll just show Running" rather
+/// than corrupting anything.
+struct RoutineRunLifecycle {
+    root: PathBuf,
+    run_id: String,
+    agent_path: String,
+    events: DynEventSink,
+}
+
+impl RoutineRunLifecycle {
+    fn write(&self, paused: Option<Option<String>>) {
+        if let Err(e) = routine_runs::update(
+            &self.root,
+            &self.run_id,
+            RoutineRunUpdate {
+                paused_until: paused,
+                ..Default::default()
+            },
+        ) {
+            tracing::error!(
+                "[routines] failed to persist paused_until for run {}: {e}",
+                self.run_id
+            );
+            return;
+        }
+        self.events.emit(HoustonEvent::RoutineRunsChanged {
+            agent_path: self.agent_path.clone(),
+        });
+    }
+}
+
+impl SessionLifecycle for RoutineRunLifecycle {
+    fn on_paused(&self, resets_at: Option<String>, _message: String) {
+        self.write(Some(Some(resets_at.unwrap_or_else(|| "soon".into()))));
+    }
+
+    fn on_resumed(&self) {
+        self.write(Some(None));
+    }
+}
+
+#[cfg(test)]
+mod lifecycle_tests {
+    use super::*;
+    use crate::routines::{create, types::NewRoutine};
+    use houston_ui_events::NoopEventSink;
+    use tempfile::TempDir;
+
+    fn mk_routine() -> NewRoutine {
+        NewRoutine {
+            name: "n".into(),
+            description: "d".into(),
+            prompt: "p".into(),
+            schedule: "0 9 * * *".into(),
+            enabled: true,
+            suppress_when_silent: true,
+            timezone: None,
+            integrations: vec![],
+        }
+    }
+
+    #[test]
+    fn on_paused_writes_hint_then_on_resumed_clears() {
+        let d = TempDir::new().unwrap();
+        let r = create(d.path(), mk_routine()).unwrap();
+        let run = routine_runs::create(d.path(), &r.id).unwrap();
+        assert!(run.paused_until.is_none());
+
+        let lc = RoutineRunLifecycle {
+            root: d.path().to_path_buf(),
+            run_id: run.id.clone(),
+            agent_path: d.path().to_string_lossy().to_string(),
+            events: Arc::new(NoopEventSink),
+        };
+
+        lc.on_paused(
+            Some("5pm (America/Los_Angeles)".into()),
+            "banner".into(),
+        );
+        let after_pause = routine_runs::find_by_id(d.path(), &run.id).unwrap();
+        assert_eq!(
+            after_pause.paused_until.as_deref(),
+            Some("5pm (America/Los_Angeles)")
+        );
+
+        lc.on_resumed();
+        let after_resume = routine_runs::find_by_id(d.path(), &run.id).unwrap();
+        assert!(after_resume.paused_until.is_none());
+    }
+
+    #[test]
+    fn on_paused_falls_back_when_banner_has_no_hint() {
+        // Defensive: if the classifier couldn't extract a hint we still
+        // surface *something* so the UI can show "Paused" rather than
+        // pretending the run is making progress.
+        let d = TempDir::new().unwrap();
+        let r = create(d.path(), mk_routine()).unwrap();
+        let run = routine_runs::create(d.path(), &r.id).unwrap();
+
+        let lc = RoutineRunLifecycle {
+            root: d.path().to_path_buf(),
+            run_id: run.id.clone(),
+            agent_path: d.path().to_string_lossy().to_string(),
+            events: Arc::new(NoopEventSink),
+        };
+        lc.on_paused(None, "raw banner".into());
+
+        let after = routine_runs::find_by_id(d.path(), &run.id).unwrap();
+        assert_eq!(after.paused_until.as_deref(), Some("soon"));
     }
 }
 

--- a/engine/houston-engine-core/src/routines/runner.rs
+++ b/engine/houston-engine-core/src/routines/runner.rs
@@ -116,6 +116,18 @@ pub async fn run_routine(
     let response = outcome.response_text;
     let is_silent = routine.suppress_when_silent && response_is_silent(&response);
 
+    // Cancellation race: the cancel handler may have written status="cancelled"
+    // (and SIGTERM'd the PID) while we were awaiting dispatch. In that case the
+    // disk record is already terminal — don't overwrite it with `error`/`silent`/
+    // `surfaced`, and don't create an activity for a cancelled run.
+    let current = routine_runs::find_by_id(&working_dir, &run.id)?;
+    if current.status == "cancelled" {
+        events.emit(HoustonEvent::RoutineRunsChanged {
+            agent_path: agent_path.to_string(),
+        });
+        return Ok(());
+    }
+
     if is_silent {
         routine_runs::update(
             &working_dir,
@@ -180,6 +192,53 @@ pub async fn run_routine(
     });
 
     Ok(())
+}
+
+/// Cancel an in-flight routine run end-to-end.
+///
+/// Writes `status="cancelled"` to disk FIRST so a concurrent dispatch
+/// completion can't overwrite the terminal state (see `run_routine`'s
+/// race-protection branch). Then SIGTERMs the provider subprocess via
+/// `sessions::cancel`. Finally emits `RoutineRunsChanged` so clients
+/// re-fetch.
+///
+/// Returns `Conflict` if the run is not in `running` status — the UI
+/// shouldn't offer cancel on a terminal run, so this is treated as a
+/// caller bug rather than a no-op.
+pub async fn cancel_run(
+    rt: &crate::sessions::SessionRuntime,
+    events: &DynEventSink,
+    root: &Path,
+    agent_path: &str,
+    run_id: &str,
+) -> CoreResult<RoutineRun> {
+    let run = routine_runs::find_by_id(root, run_id)?;
+    if run.status != "running" {
+        return Err(CoreError::Conflict(format!(
+            "routine run {run_id} is not running (status={})",
+            run.status
+        )));
+    }
+
+    let now = Utc::now().to_rfc3339();
+    let updated = routine_runs::update(
+        root,
+        run_id,
+        RoutineRunUpdate {
+            status: Some("cancelled".into()),
+            completed_at: Some(now),
+            summary: Some("Stopped by user".into()),
+            ..Default::default()
+        },
+    )?;
+
+    crate::sessions::cancel(rt, events, agent_path, &run.session_key).await;
+
+    events.emit(HoustonEvent::RoutineRunsChanged {
+        agent_path: agent_path.to_string(),
+    });
+
+    Ok(updated)
 }
 
 /// Expand a leading `~` to the user's home dir. Copy of
@@ -363,6 +422,114 @@ mod tests {
         let runs = routine_runs::list(d.path()).unwrap();
         assert_eq!(runs[0].status, "surfaced");
         assert_eq!(runs[0].activity_id.as_deref(), Some("act-1"));
+    }
+
+    #[tokio::test]
+    async fn cancelled_status_on_disk_is_preserved_through_dispatch() {
+        // Race: user cancels while the dispatcher is mid-flight. The cancel
+        // handler writes "cancelled" + completed_at, then kills the PID, which
+        // causes the dispatcher to return with an error. The runner must NOT
+        // overwrite that terminal state, and must NOT create an activity.
+        let d = TempDir::new().unwrap();
+        let agent_path = d.path().to_string_lossy().to_string();
+        let r = create(d.path(), sample_routine()).unwrap();
+
+        // A dispatcher that flips the on-disk run to "cancelled" before
+        // returning, simulating the cancel-then-dispatch-completes ordering.
+        struct CancelDuringDispatch(PathBuf);
+        #[async_trait]
+        impl RoutineDispatcher for CancelDuringDispatch {
+            async fn dispatch(&self, ctx: DispatchContext<'_>) -> DispatchOutcome {
+                routine_runs::update(
+                    &self.0,
+                    &ctx.run.id,
+                    RoutineRunUpdate {
+                        status: Some("cancelled".into()),
+                        completed_at: Some(Utc::now().to_rfc3339()),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+                DispatchOutcome {
+                    response_text: String::new(),
+                    error: Some("terminated by user".into()),
+                }
+            }
+        }
+
+        let dispatcher = Arc::new(CancelDuringDispatch(d.path().to_path_buf()));
+        let surface = Arc::new(RecordingSurface::default());
+
+        run_routine(
+            Arc::new(NoopEventSink),
+            dispatcher,
+            surface.clone(),
+            &agent_path,
+            &r.id,
+        )
+        .await
+        .unwrap();
+
+        let runs = routine_runs::list(d.path()).unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].status, "cancelled");
+        assert!(surface.calls.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancel_run_marks_cancelled_when_running() {
+        let d = TempDir::new().unwrap();
+        let agent_path = d.path().to_string_lossy().to_string();
+        let r = create(d.path(), sample_routine()).unwrap();
+        let run = routine_runs::create(d.path(), &r.id).unwrap();
+
+        let rt = crate::sessions::SessionRuntime::default();
+        let events: DynEventSink = Arc::new(NoopEventSink);
+
+        let updated = cancel_run(&rt, &events, d.path(), &agent_path, &run.id)
+            .await
+            .unwrap();
+
+        assert_eq!(updated.status, "cancelled");
+        assert!(updated.completed_at.is_some());
+        assert_eq!(updated.summary.as_deref(), Some("Stopped by user"));
+    }
+
+    #[tokio::test]
+    async fn cancel_run_conflicts_when_already_terminal() {
+        let d = TempDir::new().unwrap();
+        let agent_path = d.path().to_string_lossy().to_string();
+        let r = create(d.path(), sample_routine()).unwrap();
+        let run = routine_runs::create(d.path(), &r.id).unwrap();
+        routine_runs::update(
+            d.path(),
+            &run.id,
+            RoutineRunUpdate {
+                status: Some("silent".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let rt = crate::sessions::SessionRuntime::default();
+        let events: DynEventSink = Arc::new(NoopEventSink);
+
+        let err = cancel_run(&rt, &events, d.path(), &agent_path, &run.id)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CoreError::Conflict(_)));
+    }
+
+    #[tokio::test]
+    async fn cancel_run_not_found_for_missing_run() {
+        let d = TempDir::new().unwrap();
+        let rt = crate::sessions::SessionRuntime::default();
+        let events: DynEventSink = Arc::new(NoopEventSink);
+
+        let err = cancel_run(&rt, &events, d.path(), "agent", "nope")
+            .await
+            .unwrap_err();
+        assert!(matches!(err, CoreError::NotFound(_)));
     }
 
     #[tokio::test]

--- a/engine/houston-engine-core/src/routines/runner.rs
+++ b/engine/houston-engine-core/src/routines/runner.rs
@@ -91,6 +91,29 @@ pub async fn run_routine(
         .clone();
 
     ensure_houston_dir(&working_dir)?;
+
+    // Reject early if a run is already in flight for this agent. Without
+    // this, repeated `run-now` clicks (a) pollute the on-disk history
+    // with `status="error", summary="conflict: another mission..."` rows
+    // from the workdir-lock failure inside the dispatcher, and (b) leave
+    // the UI unable to pick out the "real" running run vs. the noise
+    // since `lastRuns` keys by latest `started_at`. Fail fast at the
+    // route level instead — frontend gets a 409 and surfaces a toast.
+    //
+    // We treat "in flight" as "status=running on disk". The workdir lock
+    // would be a more precise signal, but it lives on `SessionRuntime`
+    // and isn't reachable from this transport-neutral runner. Disk state
+    // is reliable for the common case (one run completes, status flips
+    // terminal); orphan `running` rows from a crashed engine are swept
+    // by `sweep_orphan_running` at agent-scheduler start.
+    let existing = routine_runs::list(&working_dir)?;
+    if let Some(busy) = existing.iter().find(|r| r.status == "running") {
+        return Err(CoreError::Conflict(format!(
+            "another routine run is already in progress (run {})",
+            busy.id
+        )));
+    }
+
     let run = routine_runs::create(&working_dir, routine_id)?;
     events.emit(HoustonEvent::RoutineRunsChanged {
         agent_path: agent_path.to_string(),
@@ -422,6 +445,41 @@ mod tests {
         let runs = routine_runs::list(d.path()).unwrap();
         assert_eq!(runs[0].status, "surfaced");
         assert_eq!(runs[0].activity_id.as_deref(), Some("act-1"));
+    }
+
+    #[tokio::test]
+    async fn run_routine_rejects_when_another_run_is_in_flight() {
+        // Reproduces the original repro: user spam-clicks Run Now while a
+        // previous run is still active. The second call must 409 (Conflict)
+        // and must NOT create a new routine_run row — otherwise the history
+        // fills with confusing "another mission is already running" error
+        // rows and the UI loses track of which run is the real one.
+        let d = TempDir::new().unwrap();
+        let agent_path = d.path().to_string_lossy().to_string();
+        let r = create(d.path(), sample_routine()).unwrap();
+
+        // Seed an in-flight run on disk — what the previous click left.
+        let in_flight = routine_runs::create(d.path(), &r.id).unwrap();
+        assert_eq!(in_flight.status, "running");
+
+        let dispatcher = Arc::new(FakeDispatcher(DispatchOutcome::default()));
+        let surface = Arc::new(RecordingSurface::default());
+
+        let err = run_routine(
+            Arc::new(NoopEventSink),
+            dispatcher,
+            surface,
+            &agent_path,
+            &r.id,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, CoreError::Conflict(_)));
+
+        // Disk must still hold exactly one run — the original in-flight one.
+        let runs = routine_runs::list(d.path()).unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].id, in_flight.id);
     }
 
     #[tokio::test]

--- a/engine/houston-engine-core/src/routines/runs.rs
+++ b/engine/houston-engine-core/src/routines/runs.rs
@@ -44,6 +44,7 @@ pub fn create(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
         summary: None,
         started_at: Utc::now().to_rfc3339(),
         completed_at: None,
+        paused_until: None,
     };
     runs.push(run.clone());
     prune(&mut runs);
@@ -69,6 +70,9 @@ pub fn update(root: &Path, id: &str, updates: RoutineRunUpdate) -> CoreResult<Ro
     }
     if let Some(completed_at) = updates.completed_at {
         run.completed_at = Some(completed_at);
+    }
+    if let Some(paused) = updates.paused_until {
+        run.paused_until = paused;
     }
 
     let result = run.clone();
@@ -172,6 +176,67 @@ mod tests {
             find_by_id(d.path(), "nope").unwrap_err(),
             CoreError::NotFound(_)
         ));
+    }
+
+    #[test]
+    fn paused_until_set_and_clear() {
+        let d = TempDir::new().unwrap();
+        let run = create(d.path(), "rid").unwrap();
+        assert!(run.paused_until.is_none());
+
+        // Set
+        let after_set = update(
+            d.path(),
+            &run.id,
+            RoutineRunUpdate {
+                paused_until: Some(Some("5pm (America/Los_Angeles)".into())),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(
+            after_set.paused_until.as_deref(),
+            Some("5pm (America/Los_Angeles)")
+        );
+
+        // Clear via Some(None)
+        let after_clear = update(
+            d.path(),
+            &run.id,
+            RoutineRunUpdate {
+                paused_until: Some(None),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(after_clear.paused_until.is_none());
+    }
+
+    #[test]
+    fn paused_until_untouched_when_omitted() {
+        // None (outer) on RoutineRunUpdate.paused_until must leave the
+        // persisted value alone — the field is opt-in PATCH semantics.
+        let d = TempDir::new().unwrap();
+        let run = create(d.path(), "rid").unwrap();
+        let _ = update(
+            d.path(),
+            &run.id,
+            RoutineRunUpdate {
+                paused_until: Some(Some("9am UTC".into())),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        let after = update(
+            d.path(),
+            &run.id,
+            RoutineRunUpdate {
+                summary: Some("noise".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(after.paused_until.as_deref(), Some("9am UTC"));
     }
 
     #[test]

--- a/engine/houston-engine-core/src/routines/runs.rs
+++ b/engine/houston-engine-core/src/routines/runs.rs
@@ -23,6 +23,13 @@ pub fn list_for_routine(root: &Path, routine_id: &str) -> CoreResult<Vec<Routine
         .collect())
 }
 
+pub fn find_by_id(root: &Path, id: &str) -> CoreResult<RoutineRun> {
+    list(root)?
+        .into_iter()
+        .find(|r| r.id == id)
+        .ok_or_else(|| CoreError::NotFound(format!("routine run {id}")))
+}
+
 pub fn create(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
     ensure_houston_dir(root)?;
     let mut runs = list(root)?;
@@ -146,6 +153,23 @@ mod tests {
         let d = TempDir::new().unwrap();
         assert!(matches!(
             update(d.path(), "nope", RoutineRunUpdate::default()).unwrap_err(),
+            CoreError::NotFound(_)
+        ));
+    }
+
+    #[test]
+    fn find_by_id_returns_run() {
+        let d = TempDir::new().unwrap();
+        let run = create(d.path(), "rid").unwrap();
+        let found = find_by_id(d.path(), &run.id).unwrap();
+        assert_eq!(found.id, run.id);
+    }
+
+    #[test]
+    fn find_by_id_missing_errors() {
+        let d = TempDir::new().unwrap();
+        assert!(matches!(
+            find_by_id(d.path(), "nope").unwrap_err(),
             CoreError::NotFound(_)
         ));
     }

--- a/engine/houston-engine-core/src/routines/runs.rs
+++ b/engine/houston-engine-core/src/routines/runs.rs
@@ -30,6 +30,40 @@ pub fn find_by_id(root: &Path, id: &str) -> CoreResult<RoutineRun> {
         .ok_or_else(|| CoreError::NotFound(format!("routine run {id}")))
 }
 
+/// Mark every `status="running"` row as `error` with a clear summary.
+///
+/// Engine call sites invoke this once per agent at scheduler-start time
+/// because there's no way to distinguish a row from a still-alive
+/// subprocess vs. one that's been orphaned by a previous engine crash
+/// (the row is written before the dispatch awaits, and the dispatch
+/// process is gone after a hard restart). Without this sweep, an
+/// orphan would permanently block every future `run-now` for that
+/// agent via the precondition in [`crate::routines::runner::run_routine`].
+///
+/// Returns the number of rows reaped. Safe to call when there are no
+/// orphan rows — it's a no-op.
+pub fn sweep_orphan_running(root: &Path) -> CoreResult<usize> {
+    let mut runs = list(root)?;
+    if runs.is_empty() {
+        return Ok(0);
+    }
+    let now = Utc::now().to_rfc3339();
+    let mut reaped = 0;
+    for run in runs.iter_mut() {
+        if run.status == "running" {
+            run.status = "error".into();
+            run.summary = Some("Engine restarted before this run finished".into());
+            run.completed_at = Some(now.clone());
+            run.paused_until = None;
+            reaped += 1;
+        }
+    }
+    if reaped > 0 {
+        write_json(root, FILE, &runs)?;
+    }
+    Ok(reaped)
+}
+
 pub fn create(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
     ensure_houston_dir(root)?;
     let mut runs = list(root)?;
@@ -210,6 +244,53 @@ mod tests {
         )
         .unwrap();
         assert!(after_clear.paused_until.is_none());
+    }
+
+    #[test]
+    fn sweep_orphan_running_marks_only_running_rows() {
+        let d = TempDir::new().unwrap();
+        let orphan = create(d.path(), "rid").unwrap();
+        let done = create(d.path(), "rid").unwrap();
+        update(
+            d.path(),
+            &done.id,
+            RoutineRunUpdate {
+                status: Some("silent".into()),
+                completed_at: Some(chrono::Utc::now().to_rfc3339()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        let reaped = sweep_orphan_running(d.path()).unwrap();
+        assert_eq!(reaped, 1);
+
+        let runs = list(d.path()).unwrap();
+        let orphan_after = runs.iter().find(|r| r.id == orphan.id).unwrap();
+        let done_after = runs.iter().find(|r| r.id == done.id).unwrap();
+        assert_eq!(orphan_after.status, "error");
+        assert_eq!(
+            orphan_after.summary.as_deref(),
+            Some("Engine restarted before this run finished")
+        );
+        assert!(orphan_after.completed_at.is_some());
+        assert_eq!(done_after.status, "silent");
+    }
+
+    #[test]
+    fn sweep_orphan_running_is_noop_when_clean() {
+        let d = TempDir::new().unwrap();
+        let done = create(d.path(), "rid").unwrap();
+        update(
+            d.path(),
+            &done.id,
+            RoutineRunUpdate {
+                status: Some("silent".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(sweep_orphan_running(d.path()).unwrap(), 0);
     }
 
     #[test]

--- a/engine/houston-engine-core/src/routines/scheduler.rs
+++ b/engine/houston-engine-core/src/routines/scheduler.rs
@@ -13,7 +13,7 @@ use crate::routines::{
 use chrono::Utc;
 use chrono_tz::Tz;
 use cron::Schedule;
-use houston_ui_events::DynEventSink;
+use houston_ui_events::{DynEventSink, HoustonEvent};
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -220,6 +220,29 @@ impl RoutineSchedulerState {
                 existing.sync();
             }
             None => {
+                // First-time start for this agent in this engine process —
+                // sweep any `status="running"` rows left behind by a
+                // previous run that didn't reach a terminal state (engine
+                // crash, OS kill). Without this, the in-flight precondition
+                // in `run_routine` would block every future `run-now`.
+                let dir = crate::routines::runner::expand_tilde(
+                    &std::path::PathBuf::from(agent_path),
+                );
+                match crate::routines::runs::sweep_orphan_running(&dir) {
+                    Ok(0) => {}
+                    Ok(n) => {
+                        tracing::warn!(
+                            "[routines] swept {n} orphan running run(s) for agent {agent_path}"
+                        );
+                        events.emit(HoustonEvent::RoutineRunsChanged {
+                            agent_path: agent_path.to_string(),
+                        });
+                    }
+                    Err(e) => tracing::error!(
+                        "[routines] orphan sweep failed for {agent_path}: {e}"
+                    ),
+                }
+
                 let mut sched =
                     AgentScheduler::new(agent_path, default_tz, events, dispatcher, surface);
                 sched.sync();

--- a/engine/houston-engine-core/src/routines/types.rs
+++ b/engine/houston-engine-core/src/routines/types.rs
@@ -90,6 +90,13 @@ pub struct RoutineRun {
     pub started_at: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub completed_at: Option<String>,
+    /// Human-readable reset hint captured from the provider CLI's
+    /// usage-limit-paused banner (e.g. `"5pm (America/Los_Angeles)"`).
+    /// Set while `status == "running"` to indicate the subprocess is
+    /// sleeping until the reset window. Irrelevant once the run reaches
+    /// a terminal state; consumers should treat it as a hint only.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paused_until: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -98,4 +105,7 @@ pub struct RoutineRunUpdate {
     pub activity_id: Option<String>,
     pub summary: Option<String>,
     pub completed_at: Option<String>,
+    /// `Some(Some("..."))` sets the hint; `Some(None)` clears it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub paused_until: Option<Option<String>>,
 }

--- a/engine/houston-engine-core/src/routines/types.rs
+++ b/engine/houston-engine-core/src/routines/types.rs
@@ -75,7 +75,10 @@ pub struct RoutineUpdate {
 pub struct RoutineRun {
     pub id: String,
     pub routine_id: String,
-    /// `"running" | "silent" | "surfaced" | "error"`.
+    /// `"running" | "silent" | "surfaced" | "error" | "cancelled"`.
+    /// `cancelled` is set when the user stops an in-flight run via
+    /// `POST /v1/routines/:id/runs/:run_id:cancel` or when the parent
+    /// routine is deleted while a run is still in flight.
     pub status: String,
     /// Session key for chat history lookup (`"routine-{rid}-run-{id}"`).
     pub session_key: String,

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -313,6 +313,7 @@ async fn run_start(
         source,
         user_message: Some(prompt.clone()),
         claude_session_id: None,
+        lifecycle: None,
     });
 
     let events_for_end = events.clone();

--- a/engine/houston-engine-server/src/routes/agents.rs
+++ b/engine/houston-engine-server/src/routes/agents.rs
@@ -194,6 +194,25 @@ async fn delete_routine(
     Query(q): Query<AgentQuery>,
 ) -> Result<(), ApiError> {
     let root = resolve_root(&q.agent_path)?;
+
+    // Cascade: kill any in-flight runs of this routine before removing it,
+    // otherwise the spawned provider subprocess keeps burning tokens with
+    // no UI handle to stop it. Mirrors the same logic on the sibling
+    // `/routines/:id` route. The frontend currently hits THIS path (per
+    // `engine-client::deleteRoutine`), so the cascade has to live here too.
+    for run in routine_runs::list_for_routine(&root, &id)? {
+        if run.status == "running" {
+            houston_engine_core::routines::runner::cancel_run(
+                &st.engine.sessions,
+                &st.engine.events,
+                &root,
+                &q.agent_path,
+                &run.id,
+            )
+            .await?;
+        }
+    }
+
     routines::delete(&root, &id)?;
     st.routine_scheduler.sync_agent(&q.agent_path).await;
     emit(

--- a/engine/houston-engine-server/src/routes/routines.rs
+++ b/engine/houston-engine-server/src/routes/routines.rs
@@ -15,7 +15,7 @@ use houston_engine_core::preferences;
 use houston_engine_core::routines::{
     self,
     engine_dispatcher::{EngineActivitySurface, EngineRoutineDispatcher},
-    runner::run_routine,
+    runner::{cancel_run, run_routine},
     runs as routine_runs,
     types::{NewRoutine, Routine, RoutineRun, RoutineUpdate},
 };
@@ -48,6 +48,7 @@ pub fn router() -> Router<Arc<ServerState>> {
         .route("/routine-runs", get(list_runs))
         .route("/routine-runs/:id", patch(update_run))
         .route("/routines/:id/runs", post(create_run))
+        .route("/routines/:id/runs/:run_action", post(run_action))
         // Scheduler lifecycle + manual trigger
         .route("/routines/:id/run-now", post(run_now))
         .route("/routines/scheduler/start", post(scheduler_start))
@@ -88,7 +89,26 @@ async fn remove(
     Path(id): Path<String>,
     Query(q): Query<AgentQuery>,
 ) -> Result<(), ApiError> {
-    routines::delete(&agent_root(&q.agent_path), &id)?;
+    let root = agent_root(&q.agent_path);
+
+    // Cancel any in-flight runs before removing the routine. Without this,
+    // deleting a routine leaves the spawned session subprocess running and
+    // burning provider tokens — the user has no UI handle to stop it once
+    // the routine is gone.
+    for run in routine_runs::list_for_routine(&root, &id)? {
+        if run.status == "running" {
+            cancel_run(
+                &st.engine.sessions,
+                &st.engine.events,
+                &root,
+                &q.agent_path,
+                &run.id,
+            )
+            .await?;
+        }
+    }
+
+    routines::delete(&root, &id)?;
     st.routine_scheduler.sync_agent(&q.agent_path).await;
     Ok(())
 }
@@ -151,6 +171,33 @@ async fn run_now(
     )
     .await?;
     Ok(())
+}
+
+/// Sub-resource action dispatcher: `POST /routines/:id/runs/:run_id:cancel`.
+/// Following the same `key:action` convention as `sessions/:key:cancel`.
+async fn run_action(
+    State(st): State<Arc<ServerState>>,
+    Path((_routine_id, run_action)): Path<(String, String)>,
+    Query(q): Query<AgentQuery>,
+) -> Result<Json<RoutineRun>, ApiError> {
+    let run_id = match run_action.strip_suffix(":cancel") {
+        Some(k) if !k.is_empty() => k.to_string(),
+        _ => {
+            return Err(houston_engine_core::CoreError::BadRequest(format!(
+                "path action must be `:cancel`, got {run_action:?}"
+            ))
+            .into());
+        }
+    };
+    let updated = cancel_run(
+        &st.engine.sessions,
+        &st.engine.events,
+        &agent_root(&q.agent_path),
+        &q.agent_path,
+        &run_id,
+    )
+    .await?;
+    Ok(Json(updated))
 }
 
 async fn scheduler_start(

--- a/engine/houston-engine-server/tests/routines.rs
+++ b/engine/houston-engine-server/tests/routines.rs
@@ -210,6 +210,196 @@ async fn routine_runs_create_update_filter() {
 }
 
 #[tokio::test]
+async fn cancel_run_marks_cancelled_then_409_on_repeat() {
+    let (addr, tok, docs) = spawn().await;
+    let agent = docs.path().join("ws").join("alpha");
+    std::fs::create_dir_all(&agent).unwrap();
+    let agent_path = agent.to_string_lossy().to_string();
+    let c = reqwest::Client::new();
+
+    let r: serde_json::Value = c
+        .post(format!("http://{addr}/v1/routines"))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .json(&serde_json::json!({
+            "name": "X",
+            "description": "",
+            "prompt": "p",
+            "schedule": "* * * * *",
+            "enabled": true,
+            "suppress_when_silent": true,
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let rid = r["id"].as_str().unwrap().to_string();
+
+    let run: serde_json::Value = c
+        .post(format!("http://{addr}/v1/routines/{rid}/runs"))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let run_id = run["id"].as_str().unwrap().to_string();
+
+    // First cancel: 200, status flips to cancelled.
+    let cancelled: serde_json::Value = c
+        .post(format!(
+            "http://{addr}/v1/routines/{rid}/runs/{run_id}:cancel"
+        ))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(cancelled["status"], "cancelled");
+    assert_eq!(cancelled["summary"], "Stopped by user");
+
+    // Second cancel: 409 — already terminal.
+    let again = c
+        .post(format!(
+            "http://{addr}/v1/routines/{rid}/runs/{run_id}:cancel"
+        ))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(again.status(), 409);
+
+    // Unknown action verb: 400.
+    let bad = c
+        .post(format!(
+            "http://{addr}/v1/routines/{rid}/runs/{run_id}:nuke"
+        ))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bad.status(), 400);
+
+    // Missing run: 404.
+    let missing = c
+        .post(format!(
+            "http://{addr}/v1/routines/{rid}/runs/nope:cancel"
+        ))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(missing.status(), 404);
+}
+
+#[tokio::test]
+async fn delete_routine_cancels_in_flight_runs() {
+    let (addr, tok, docs) = spawn().await;
+    let agent = docs.path().join("ws").join("alpha");
+    std::fs::create_dir_all(&agent).unwrap();
+    let agent_path = agent.to_string_lossy().to_string();
+    let c = reqwest::Client::new();
+
+    let r: serde_json::Value = c
+        .post(format!("http://{addr}/v1/routines"))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .json(&serde_json::json!({
+            "name": "X",
+            "description": "",
+            "prompt": "p",
+            "schedule": "* * * * *",
+            "enabled": true,
+            "suppress_when_silent": true,
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let rid = r["id"].as_str().unwrap().to_string();
+
+    // Two runs: one terminal, one running.
+    let run_running: serde_json::Value = c
+        .post(format!("http://{addr}/v1/routines/{rid}/runs"))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let run_done: serde_json::Value = c
+        .post(format!("http://{addr}/v1/routines/{rid}/runs"))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let _: serde_json::Value = c
+        .patch(format!(
+            "http://{addr}/v1/routine-runs/{}",
+            run_done["id"].as_str().unwrap()
+        ))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .json(&serde_json::json!({ "status": "silent" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    // Delete the routine.
+    let del = c
+        .delete(format!("http://{addr}/v1/routines/{rid}"))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap();
+    assert!(del.status().is_success());
+
+    // The running run should now be `cancelled`; the terminal run unchanged.
+    let runs: serde_json::Value = c
+        .get(format!("http://{addr}/v1/routine-runs"))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let running_id = run_running["id"].as_str().unwrap();
+    let done_id = run_done["id"].as_str().unwrap();
+    for run in runs.as_array().unwrap() {
+        let id = run["id"].as_str().unwrap();
+        if id == running_id {
+            assert_eq!(run["status"], "cancelled");
+        } else if id == done_id {
+            assert_eq!(run["status"], "silent");
+        }
+    }
+}
+
+#[tokio::test]
 async fn requires_auth() {
     let (addr, _tok, _docs) = spawn().await;
     let c = reqwest::Client::new();

--- a/engine/houston-engine-server/tests/routines.rs
+++ b/engine/houston-engine-server/tests/routines.rs
@@ -400,6 +400,76 @@ async fn delete_routine_cancels_in_flight_runs() {
 }
 
 #[tokio::test]
+async fn run_now_returns_409_when_another_run_is_in_flight() {
+    // Repros the spam-click scenario: a previous "Run now" is still active
+    // (status=running on disk). The next click must 409 BEFORE spawning a
+    // CLI, BEFORE creating a new routine_run row — keeping history free of
+    // "conflict: another mission..." noise.
+    let (addr, tok, docs) = spawn().await;
+    let agent = docs.path().join("ws").join("alpha");
+    std::fs::create_dir_all(&agent).unwrap();
+    let agent_path = agent.to_string_lossy().to_string();
+    let c = reqwest::Client::new();
+
+    let r: serde_json::Value = c
+        .post(format!("http://{addr}/v1/routines"))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .json(&serde_json::json!({
+            "name": "Spam",
+            "description": "",
+            "prompt": "p",
+            "schedule": "* * * * *",
+            "enabled": true,
+            "suppress_when_silent": true,
+        }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let rid = r["id"].as_str().unwrap().to_string();
+
+    // Seed an in-flight run via the runs POST so disk shows status=running.
+    let _: serde_json::Value = c
+        .post(format!("http://{addr}/v1/routines/{rid}/runs"))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+
+    // Now POST run-now — should reject with 409.
+    let res = c
+        .post(format!("http://{addr}/v1/routines/{rid}/run-now"))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 409);
+
+    // Disk must still hold exactly one run — the rejected run-now didn't
+    // create a new row.
+    let runs: serde_json::Value = c
+        .get(format!("http://{addr}/v1/routine-runs"))
+        .query(&[("agentPath", &agent_path)])
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(runs.as_array().unwrap().len(), 1);
+    assert_eq!(runs[0]["status"], "running");
+}
+
+#[tokio::test]
 async fn requires_auth() {
     let (addr, _tok, _docs) = spawn().await;
     let c = reqwest::Client::new();

--- a/engine/houston-terminal-manager/src/provider/anthropic_classify.rs
+++ b/engine/houston-terminal-manager/src/provider/anthropic_classify.rs
@@ -70,6 +70,20 @@ pub(crate) fn classify_stderr(line: &str) -> Option<ProviderError> {
         });
     }
 
+    // Plan-window usage limit the CLI auto-recovers from. claude-code prints
+    // a banner like "Claude usage limit reached. Your limit will reset at
+    // 5pm (America/Los_Angeles)" then sleeps internally until the reset
+    // window. Must precede the QuotaExhausted branch below, which would
+    // otherwise swallow the substring "usage limit" as a terminal error.
+    if lower.contains("usage limit") && lower.contains("reset") {
+        let resets_at = parse_resets_at_hint(line);
+        return Some(ProviderError::UsageLimitPaused {
+            provider: PROVIDER.into(),
+            resets_at,
+            message: truncate_excerpt(line.trim()),
+        });
+    }
+
     // Long-window quota — the user needs a plan upgrade, not a wait.
     if (lower.contains("quota") && lower.contains("exhaust"))
         || lower.contains("usage limit")
@@ -139,6 +153,27 @@ pub(crate) fn classify_result_error(
     // the same auth/quota/rate-limit phrasing the CLI prints to stderr,
     // so we get exhaustive coverage from one set of patterns.
     classify_stderr(error_message)
+}
+
+/// Extract the human-readable reset hint from a claude-code usage-limit
+/// banner like `"Claude usage limit reached. Your limit will reset at
+/// 5pm (America/Los_Angeles)"`. Returns the substring after `reset at`
+/// trimmed of trailing punctuation, or `None` if the marker isn't present.
+fn parse_resets_at_hint(line: &str) -> Option<String> {
+    let lower = line.to_lowercase();
+    let marker_idx = lower
+        .find("reset at ")
+        .map(|i| i + "reset at ".len())
+        .or_else(|| lower.find("resets at ").map(|i| i + "resets at ".len()))?;
+    let hint = line[marker_idx..]
+        .trim()
+        .trim_end_matches(|c: char| c == '.' || c == ',')
+        .trim();
+    if hint.is_empty() {
+        None
+    } else {
+        Some(hint.to_string())
+    }
 }
 
 /// Pull `N` from "retry after N seconds" / "retry-after: N" patterns.
@@ -238,6 +273,46 @@ mod tests {
             } => {}
             other => panic!("expected RateLimited with retry_after=30, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn usage_limit_with_reset_classified_as_paused_with_hint() {
+        let line = "Claude usage limit reached. Your limit will reset at 5pm (America/Los_Angeles).";
+        match classify_stderr(line).unwrap() {
+            ProviderError::UsageLimitPaused { resets_at, .. } => {
+                assert_eq!(resets_at.as_deref(), Some("5pm (America/Los_Angeles)"));
+            }
+            other => panic!("expected UsageLimitPaused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn usage_limit_with_resets_at_phrasing_classified_as_paused() {
+        let line = "Claude usage limit reached. Your limit resets at 11:30am UTC";
+        match classify_stderr(line).unwrap() {
+            ProviderError::UsageLimitPaused { resets_at, .. } => {
+                assert_eq!(resets_at.as_deref(), Some("11:30am UTC"));
+            }
+            other => panic!("expected UsageLimitPaused, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn usage_limit_paused_wins_over_quota_exhausted_for_same_phrase() {
+        // "usage limit" alone (no reset) is still quota-exhausted — but with
+        // a reset hint it must be paused, not exhausted. Guards against the
+        // ordering of the two branches in `classify_stderr` regressing.
+        let with_reset =
+            "Claude usage limit reached. Your limit will reset at 9am (Europe/London)";
+        let without_reset = "Monthly usage limit exhausted for your plan";
+        assert!(matches!(
+            classify_stderr(with_reset).unwrap(),
+            ProviderError::UsageLimitPaused { .. }
+        ));
+        assert!(matches!(
+            classify_stderr(without_reset).unwrap(),
+            ProviderError::QuotaExhausted { .. }
+        ));
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/provider_error_kind.rs
+++ b/engine/houston-terminal-manager/src/provider_error_kind.rs
@@ -101,6 +101,20 @@ pub enum ProviderError {
         message: String,
         upgrade_url: Option<String>,
     },
+    /// Plan-window usage limit the CLI auto-recovers from by sleeping
+    /// internally until the reset window. The CLI subprocess is still
+    /// alive — Houston should surface this as a non-terminal "paused"
+    /// state, NOT an error. Today this only fires for the Anthropic
+    /// claude-code CLI's "Claude usage limit reached. Your limit will
+    /// reset at HH:MM (TZ)" banner.
+    UsageLimitPaused {
+        provider: String,
+        /// Human-readable reset hint extracted from the banner
+        /// (e.g. `"5pm (America/Los_Angeles)"`). `None` if the banner
+        /// didn't include a parseable hint.
+        resets_at: Option<String>,
+        message: String,
+    },
     /// Model the user requested isn't available to this account.
     ModelUnavailable {
         provider: String,
@@ -166,6 +180,7 @@ impl ProviderError {
         match self {
             Self::RateLimited { provider, .. }
             | Self::QuotaExhausted { provider, .. }
+            | Self::UsageLimitPaused { provider, .. }
             | Self::ModelUnavailable { provider, .. }
             | Self::Unauthenticated { provider, .. }
             | Self::NetworkUnreachable { provider, .. }
@@ -185,6 +200,7 @@ impl ProviderError {
         match self {
             Self::RateLimited { .. } => "rate_limited",
             Self::QuotaExhausted { .. } => "quota_exhausted",
+            Self::UsageLimitPaused { .. } => "usage_limit_paused",
             Self::ModelUnavailable { .. } => "model_unavailable",
             Self::Unauthenticated { .. } => "unauthenticated",
             Self::NetworkUnreachable { .. } => "network_unreachable",
@@ -228,6 +244,20 @@ mod tests {
         let json = serde_json::to_string(&e).unwrap();
         assert!(json.contains(r#""kind":"quota_exhausted""#));
         assert!(json.contains(r#""scope":"free_tier""#));
+        let back: ProviderError = serde_json::from_str(&json).unwrap();
+        assert_eq!(e, back);
+    }
+
+    #[test]
+    fn round_trip_usage_limit_paused() {
+        let e = ProviderError::UsageLimitPaused {
+            provider: "anthropic".into(),
+            resets_at: Some("5pm (America/Los_Angeles)".into()),
+            message: "Claude usage limit reached. Your limit will reset at 5pm (America/Los_Angeles)".into(),
+        };
+        let json = serde_json::to_string(&e).unwrap();
+        assert!(json.contains(r#""kind":"usage_limit_paused""#));
+        assert!(json.contains(r#""resets_at":"5pm (America/Los_Angeles)""#));
         let back: ProviderError = serde_json::from_str(&json).unwrap();
         assert_eq!(e, back);
     }

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -169,6 +169,7 @@ not user-facing copy.
 | GET/POST | `/v1/routines` | List/create (by `?agentPath`) |
 | PATCH/DELETE | `/v1/routines/:id` | Update/delete |
 | POST | `/v1/routines/:id/runs` | Create run |
+| POST | `/v1/routines/:id/runs/:run_id:cancel` | Stop an in-flight run (kills the provider PID, marks status `cancelled`). 409 if the run is already terminal. Deleting a routine cascades to this for any `running` runs. |
 | POST | `/v1/routines/:id/run-now` | Manual trigger |
 | GET | `/v1/routine-runs` | List (optional `?routineId`) |
 | PATCH | `/v1/routine-runs/:id` | Update run |

--- a/knowledge-base/provider-errors.md
+++ b/knowledge-base/provider-errors.md
@@ -25,6 +25,7 @@ and mirrored in `ui/chat/src/types.ts`. The two MUST stay in sync.
 |----------------------------|-----------------------------------------------------------------------------------------|------------------------------------------------------|
 | `RateLimited`              | Per-minute / short-window throttle. Wait helps.                                         | Retry, Switch model, optional `retry_after_seconds`. |
 | `QuotaExhausted`           | Long-window / billing-period limit. Wait won't help.                                    | Upgrade plan (`upgrade_url`), Switch provider.       |
+| `UsageLimitPaused`         | CLI is sleeping internally until the plan-window reset (today: Anthropic claude-code).  | None — non-terminal. Routines surface "Waiting · resumes at HH:MM" via `routine_run.paused_until`. |
 | `ModelUnavailable`         | The requested model isn't available to this account (preview, deprecated, regioned).    | Switch to `suggested_fallback`, Pick another model.  |
 | `Unauthenticated`          | Auth missing/expired/invalid. `cause` narrows the body copy.                            | Reconnect (drives `tauriProvider.launchLogin`).      |
 | `NetworkUnreachable`       | Cannot reach the provider's API (DNS, connect refused, ECONNRESET).                     | Retry, Check status page.                            |

--- a/ui/agent-schemas/src/routine_runs.schema.json
+++ b/ui/agent-schemas/src/routine_runs.schema.json
@@ -14,7 +14,11 @@
       "activity_id": { "type": "string" },
       "summary": { "type": "string" },
       "started_at": { "type": "string", "format": "date-time" },
-      "completed_at": { "type": "string", "format": "date-time" }
+      "completed_at": { "type": "string", "format": "date-time" },
+      "paused_until": {
+        "type": "string",
+        "description": "Human-readable reset hint while the provider CLI is sleeping on a usage-limit window. Only meaningful when status is 'running'."
+      }
     },
     "additionalProperties": false
   }

--- a/ui/agent-schemas/src/routine_runs.schema.json
+++ b/ui/agent-schemas/src/routine_runs.schema.json
@@ -9,7 +9,7 @@
     "properties": {
       "id": { "type": "string" },
       "routine_id": { "type": "string" },
-      "status": { "type": "string", "enum": ["running", "silent", "surfaced", "error"] },
+      "status": { "type": "string", "enum": ["running", "silent", "surfaced", "error", "cancelled"] },
       "session_key": { "type": "string" },
       "activity_id": { "type": "string" },
       "summary": { "type": "string" },

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -651,6 +651,18 @@ export class HoustonClient {
       agentPath,
     });
   }
+  cancelRoutineRun(
+    agentPath: string,
+    routineId: string,
+    runId: string,
+  ): Promise<RoutineRun> {
+    return this.request(
+      "POST",
+      `/routines/${this.seg(routineId)}/runs/${this.seg(runId)}:cancel`,
+      undefined,
+      { agentPath },
+    );
+  }
   startRoutineScheduler(agentPath: string): Promise<void> {
     return this.request("POST", "/routines/scheduler/start", undefined, { agentPath });
   }

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -201,7 +201,12 @@ export interface RoutineUpdate {
   integrations?: string[];
 }
 
-export type RoutineRunStatus = "running" | "silent" | "surfaced" | "error";
+export type RoutineRunStatus =
+  | "running"
+  | "silent"
+  | "surfaced"
+  | "error"
+  | "cancelled";
 
 export interface RoutineRun {
   id: string;
@@ -212,6 +217,9 @@ export interface RoutineRun {
   summary?: string;
   started_at: string;
   completed_at?: string;
+  /** Human-readable reset hint while the provider CLI is sleeping on a
+   *  usage-limit window. Only meaningful when status is `running`. */
+  paused_until?: string;
 }
 
 export interface RoutineRunUpdate {
@@ -219,6 +227,8 @@ export interface RoutineRunUpdate {
   activity_id?: string;
   summary?: string;
   completed_at?: string;
+  /** Pass `string` to set the hint, `null` to clear, omit to leave alone. */
+  paused_until?: string | null;
 }
 
 export interface ProjectConfig {

--- a/ui/routines/src/routine-editor.tsx
+++ b/ui/routines/src/routine-editor.tsx
@@ -21,6 +21,7 @@ import {
   ArrowLeft,
   Play,
   Pause,
+  Square,
   Trash2,
   Globe,
   CalendarClock,
@@ -53,6 +54,10 @@ export interface RoutineEditorProps {
   routine?: Routine
   runs?: RoutineRun[]
   onRunNow?: () => void
+  /** Stop an in-flight run. When present + a run is `running`, the header
+   *  "Run now" button swaps to "Stop" and the matching run row shows a stop
+   *  control. */
+  onCancelRun?: (runId: string) => void
   onToggle?: (enabled: boolean) => void
   onDelete?: () => void
   onViewActivity?: (activityId: string) => void
@@ -142,12 +147,14 @@ export function RoutineEditor({
   routine,
   runs = [],
   onRunNow,
+  onCancelRun,
   onToggle,
   onDelete,
   onViewActivity,
   accountTimezone,
   hasChanges,
 }: RoutineEditorProps) {
+  const runningRun = runs.find((r) => r.status === "running")
   const isEdit = !!routine
   const canSubmit =
     !!value.name.trim() &&
@@ -192,11 +199,23 @@ export function RoutineEditor({
           </p>
 
           <div className="flex items-center gap-1.5 shrink-0">
-            {isEdit && onRunNow && (
-              <Button variant="ghost" size="sm" onClick={onRunNow}>
-                <Play className="size-3.5" />
-                Run now
+            {isEdit && runningRun && onCancelRun ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => onCancelRun(runningRun.id)}
+              >
+                <Square className="size-3.5" />
+                Stop
               </Button>
+            ) : (
+              isEdit &&
+              onRunNow && (
+                <Button variant="ghost" size="sm" onClick={onRunNow}>
+                  <Play className="size-3.5" />
+                  Run now
+                </Button>
+              )
             )}
             <Button onClick={onSubmit} size="sm" disabled={!canSubmit}>
               {isEdit ? "Save changes" : "Create routine"}
@@ -381,7 +400,11 @@ export function RoutineEditor({
 
           {isEdit && (
             <SectionCard title="Recent runs">
-              <RunHistory runs={runs} onViewActivity={onViewActivity} />
+              <RunHistory
+                runs={runs}
+                onViewActivity={onViewActivity}
+                onCancelRun={onCancelRun}
+              />
             </SectionCard>
           )}
         </div>

--- a/ui/routines/src/routine-editor.tsx
+++ b/ui/routines/src/routine-editor.tsx
@@ -54,6 +54,13 @@ export interface RoutineEditorProps {
   routine?: Routine
   runs?: RoutineRun[]
   onRunNow?: () => void
+  /** Disable the "Run now" button while a manual-run request is in flight.
+   *  Guards against spam-click races where the disk-state `running` row
+   *  hasn't propagated through TanStack invalidation yet — without this,
+   *  each extra click queues a redundant request that the engine then
+   *  rejects with 409 (or, on older builds, recorded as a conflict-error
+   *  row in run history). */
+  runNowPending?: boolean
   /** Stop an in-flight run. When present + a run is `running`, the header
    *  "Run now" button swaps to "Stop" and the matching run row shows a stop
    *  control. */
@@ -147,6 +154,7 @@ export function RoutineEditor({
   routine,
   runs = [],
   onRunNow,
+  runNowPending,
   onCancelRun,
   onToggle,
   onDelete,
@@ -211,9 +219,14 @@ export function RoutineEditor({
             ) : (
               isEdit &&
               onRunNow && (
-                <Button variant="ghost" size="sm" onClick={onRunNow}>
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={onRunNow}
+                  disabled={runNowPending}
+                >
                   <Play className="size-3.5" />
-                  Run now
+                  {runNowPending ? "Starting…" : "Run now"}
                 </Button>
               )
             )}

--- a/ui/routines/src/routine-row.tsx
+++ b/ui/routines/src/routine-row.tsx
@@ -36,6 +36,7 @@ const STATUS_DOT: Record<string, string> = {
   surfaced: "bg-foreground",
   running: "bg-blue-500",
   error: "bg-red-500",
+  cancelled: "bg-gray-400",
 }
 
 function lastRunLabel(lastRun: RoutineRun | undefined, now: Date): string | null {
@@ -63,6 +64,7 @@ export function RoutineRow({
   const next = routine.enabled ? nextFire(routine.schedule, tz, now) : null
   const nextDescr = next ? describeNextFire(next, tz, now) : null
   const lastLabel = lastRunLabel(lastRun, now)
+  const isPaused = lastRun?.status === "running" && !!lastRun.paused_until
 
   return (
     <div
@@ -83,14 +85,18 @@ export function RoutineRow({
         !routine.enabled && "opacity-55",
       )}
     >
-      {/* Status dot — small but always present */}
+      {/* Status dot — small but always present. Amber when the in-flight run
+          is sleeping on a usage-limit window so the row reads as "waiting"
+          rather than "thrashing". */}
       <div
         className={cn(
           "size-2 rounded-full shrink-0",
-          routine.enabled
-            ? STATUS_DOT[lastRun?.status ?? "silent"] ?? "bg-gray-300"
-            : "bg-gray-300",
-          lastRun?.status === "running" && "animate-pulse",
+          !routine.enabled
+            ? "bg-gray-300"
+            : isPaused
+              ? "bg-amber-500"
+              : STATUS_DOT[lastRun?.status ?? "silent"] ?? "bg-gray-300",
+          lastRun?.status === "running" && !isPaused && "animate-pulse",
         )}
         aria-hidden
       />
@@ -124,10 +130,16 @@ export function RoutineRow({
         ) : (
           <p className="text-xs text-muted-foreground">Paused</p>
         )}
-        {lastLabel && (
-          <p className="text-[11px] text-muted-foreground/70 mt-0.5 tabular-nums">
-            {lastLabel}
+        {isPaused ? (
+          <p className="text-[11px] text-amber-700 mt-0.5 tabular-nums">
+            Waiting · resumes at {lastRun?.paused_until}
           </p>
+        ) : (
+          lastLabel && (
+            <p className="text-[11px] text-muted-foreground/70 mt-0.5 tabular-nums">
+              {lastLabel}
+            </p>
+          )
         )}
       </div>
 

--- a/ui/routines/src/run-history.tsx
+++ b/ui/routines/src/run-history.tsx
@@ -5,7 +5,7 @@
  * get a "View" affordance that links back to the activity board.
  */
 import { cn, Button } from "@houston-ai/core"
-import { ArrowUpRight, Square } from "lucide-react"
+import { ArrowUpRight, PauseCircle, Square } from "lucide-react"
 import type { RoutineRun } from "./types"
 
 export interface RunHistoryProps {
@@ -76,6 +76,16 @@ export function RunHistory({ runs, onViewActivity, onCancelRun }: RunHistoryProp
       {sorted.map((run) => {
         const duration = formatDuration(run.started_at, run.completed_at)
         const isSurfaced = run.status === "surfaced" && run.activity_id && onViewActivity
+        const isPaused = run.status === "running" && !!run.paused_until
+        // While paused, the CLI is sleeping — show an amber dot instead of
+        // the blue pulse so a long-running routine reads as "waiting" not
+        // "thrashing", and overwrite the summary slot with the reset hint.
+        const dotClass = isPaused
+          ? "bg-amber-500"
+          : (STATUS_DOT[run.status] ?? "bg-gray-300")
+        const statusLabel = isPaused
+          ? "Paused"
+          : (STATUS_LABEL[run.status] ?? run.status)
         return (
           <li
             key={run.id}
@@ -87,10 +97,7 @@ export function RunHistory({ runs, onViewActivity, onCancelRun }: RunHistoryProp
             )}
           >
             <span
-              className={cn(
-                "size-1.5 rounded-full shrink-0",
-                STATUS_DOT[run.status] ?? "bg-gray-300",
-              )}
+              className={cn("size-1.5 rounded-full shrink-0", dotClass)}
               aria-hidden
             />
             <span className="text-xs text-muted-foreground tabular-nums w-36 shrink-0">
@@ -99,16 +106,33 @@ export function RunHistory({ runs, onViewActivity, onCancelRun }: RunHistoryProp
             <span
               className={cn(
                 "text-xs w-16 shrink-0",
-                run.status === "error" ? "text-red-500" : "text-muted-foreground",
+                run.status === "error"
+                  ? "text-red-500"
+                  : isPaused
+                    ? "text-amber-600"
+                    : "text-muted-foreground",
               )}
             >
-              {STATUS_LABEL[run.status] ?? run.status}
+              {statusLabel}
             </span>
             <span className="text-[11px] text-muted-foreground tabular-nums w-12 shrink-0">
               {duration ?? "—"}
             </span>
-            <span className="text-xs text-muted-foreground/80 truncate flex-1 min-w-0">
-              {run.summary ?? ""}
+            <span
+              className={cn(
+                "text-xs truncate flex-1 min-w-0 flex items-center gap-1",
+                isPaused ? "text-amber-700" : "text-muted-foreground/80",
+              )}
+            >
+              {isPaused && (
+                <PauseCircle
+                  className="size-3 shrink-0 text-amber-600"
+                  aria-hidden
+                />
+              )}
+              {isPaused
+                ? `Waiting for usage limit — resumes at ${run.paused_until}`
+                : (run.summary ?? "")}
             </span>
             {isSurfaced && (
               <button

--- a/ui/routines/src/run-history.tsx
+++ b/ui/routines/src/run-history.tsx
@@ -4,13 +4,15 @@
  * Visual: dense one-line rows so a long history scans quickly. Surfaced runs
  * get a "View" affordance that links back to the activity board.
  */
-import { cn } from "@houston-ai/core"
-import { ArrowUpRight } from "lucide-react"
+import { cn, Button } from "@houston-ai/core"
+import { ArrowUpRight, Square } from "lucide-react"
 import type { RoutineRun } from "./types"
 
 export interface RunHistoryProps {
   runs: RoutineRun[]
   onViewActivity?: (activityId: string) => void
+  /** Stop an in-flight `running` run. When omitted, the stop button is not rendered. */
+  onCancelRun?: (runId: string) => void
 }
 
 const STATUS_DOT: Record<string, string> = {
@@ -18,6 +20,7 @@ const STATUS_DOT: Record<string, string> = {
   surfaced: "bg-foreground",
   running: "bg-blue-500 animate-pulse",
   error: "bg-red-500",
+  cancelled: "bg-gray-400",
 }
 
 const STATUS_LABEL: Record<string, string> = {
@@ -25,6 +28,7 @@ const STATUS_LABEL: Record<string, string> = {
   surfaced: "Surfaced",
   running: "Running",
   error: "Error",
+  cancelled: "Cancelled",
 }
 
 function formatRunTime(iso: string): string {
@@ -52,7 +56,7 @@ function formatDuration(startedAt: string, completedAt?: string): string | null 
   return `${Math.round(ms / 60_000)}m`
 }
 
-export function RunHistory({ runs, onViewActivity }: RunHistoryProps) {
+export function RunHistory({ runs, onViewActivity, onCancelRun }: RunHistoryProps) {
   const sorted = [...runs].sort(
     (a, b) => new Date(b.started_at).getTime() - new Date(a.started_at).getTime(),
   )
@@ -117,6 +121,17 @@ export function RunHistory({ runs, onViewActivity }: RunHistoryProps) {
                 View
                 <ArrowUpRight className="size-3" />
               </button>
+            )}
+            {run.status === "running" && onCancelRun && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => onCancelRun(run.id)}
+                aria-label="Stop run"
+                className="shrink-0"
+              >
+                <Square className="size-3" />
+              </Button>
             )}
           </li>
         )

--- a/ui/routines/src/types.ts
+++ b/ui/routines/src/types.ts
@@ -33,6 +33,10 @@ export interface RoutineRun {
   summary?: string
   started_at: string
   completed_at?: string
+  /** Human-readable reset hint (e.g. `"5pm (America/Los_Angeles)"`) when the
+   *  provider CLI is sleeping on a plan-window usage limit. Only meaningful
+   *  while `status === "running"`. */
+  paused_until?: string
 }
 
 export type SchedulePreset =

--- a/ui/routines/src/types.ts
+++ b/ui/routines/src/types.ts
@@ -19,7 +19,7 @@ export interface Routine {
   updated_at: string
 }
 
-export type RunStatus = "running" | "silent" | "surfaced" | "error"
+export type RunStatus = "running" | "silent" | "surfaced" | "error" | "cancelled"
 
 export interface RoutineRun {
   id: string


### PR DESCRIPTION
## Summary

- Add cancellation end-to-end for in-flight routine runs (new `cancel` action route + UI Stop button).
- `DELETE /v1/routines/:id` now cascades to any `running` runs of that routine, terminating the provider subprocess and marking the run `cancelled`.
- New terminal status `cancelled` (distinct from `error`) with race-safe write ordering — a cancel that lands mid-dispatch wins; the runner never overwrites it with `silent`/`surfaced`/`error` and never surfaces a board activity for a cancelled run.

Closes #232.

## What changed

**Engine**
- `engine/houston-engine-core/src/routines/runs.rs` — `find_by_id` helper.
- `engine/houston-engine-core/src/routines/runner.rs` — `cancel_run(rt, events, root, agent_path, run_id)` core primitive + race-protection branch in `run_routine`.
- `engine/houston-engine-server/src/routes/routines.rs` — `POST /v1/routines/:id/runs/:run_id:cancel` route. `DELETE /v1/routines/:id` cancels in-flight runs before deleting.
- `engine/houston-engine-core/src/routines/types.rs` — doc the new `cancelled` status.
- `ui/agent-schemas/src/routine_runs.schema.json` — `cancelled` in the enum.

**Frontend**
- `ui/engine-client/src/client.ts` — `cancelRoutineRun(agentPath, routineId, runId)`.
- `ui/routines/src/run-history.tsx` — per-row Stop button when status is `running`, new `Cancelled` status pill, accepts `onCancelRun` prop.
- `ui/routines/src/routine-editor.tsx` — header `Run now` button swaps to `Stop` while a run is in flight, threads `onCancelRun` into `RunHistory`.
- `ui/routines/src/types.ts` — `RunStatus` adds `cancelled`.
- `app/src/lib/tauri.ts` + `app/src/hooks/queries/use-routines.ts` + `app/src/components/tabs/routines-tab.tsx` — `tauriRoutines.cancelRun`, `useCancelRoutineRun` mutation, wiring.

**Tests**
- 6 new unit tests in `houston-engine-core::routines::*` covering `find_by_id`, `cancel_run` happy/conflict/missing, race-protection branch.
- 2 new integration tests in `engine/houston-engine-server/tests/routines.rs` covering the cancel route (200/409/400/404) and the delete-cascade.

**Docs**
- `knowledge-base/engine-protocol.md` — new route documented.

## Test plan

- [x] `cargo test -p houston-engine-core --lib routines::` → 26 passing (6 new).
- [x] `cargo test -p houston-engine-server --test routines` → 5 passing (2 new).
- [x] `cd app && pnpm typecheck` → clean.
- [x] `cd app && pnpm check-locales` → clean.
- [x] Start an Anthropic-backed routine via Run now. While it's running, click Stop. Verify the run row flips to `Cancelled — Stopped by user`, the provider subprocess is gone, no board activity created.
- [x] Start a routine via Run now. While running, delete the routine. Verify the in-flight run flips to `cancelled` and the subprocess is gone.
- [ ] Try to cancel an already-terminal run via the API → 409.

## Out of scope (intentional)

- The CLI's silent **pause-and-resume on Anthropic usage limit** — the underlying reason the original user's routine ran far longer than usual. Cancel gives them the off-switch; surfacing the paused state ("Paused — resumes at HH:MM") is a separate piece of work. **A follow-up commit on this branch will start that surface so the user sees *why* a routine is taking long.**
- App-window-close not propagating to the engine subprocess (engine supervisor concern, separate).
- Logout-while-running not invalidating in-flight runs (creds live in the subprocess at spawn time).

🤖 Generated with [Claude Code](https://claude.com/claude-code)