### PR TITLE
fix(always-on): make Docker build + first-boot actually work

### DIFF
--- a/always-on/Dockerfile
+++ b/always-on/Dockerfile
@@ -23,6 +23,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Cache the dependency compile by copying the manifests first.
 COPY Cargo.toml Cargo.lock ./
 COPY engine/ engine/
+# Workspace lists `app/houston-tauri` and `app/src-tauri` as members, so their
+# manifests must exist for cargo to load the workspace — even though `-p
+# houston-engine-server` will not compile them (no path in its dep tree).
+COPY app/houston-tauri/ app/houston-tauri/
+COPY app/src-tauri/ app/src-tauri/
+# `houston-agent-files` embeds the `@houston-ai/agent-schemas` JSON files
+# (activity / routines / routine_runs / config / learnings) at compile time via
+# `include_str!("../../../ui/agent-schemas/src/*.schema.json")` — that subtree
+# is the source of truth for the `.houston/*` data layout, see
+# `knowledge-base/architecture.md`.
+COPY ui/agent-schemas/ ui/agent-schemas/
 
 # Only build the engine server binary — excludes the desktop app crates.
 RUN cargo build --release -p houston-engine-server --bin houston-engine
@@ -32,7 +43,9 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
  && rm -rf /var/lib/apt/lists/* \
- && useradd --system --create-home --home-dir /data houston
+ && useradd --system --create-home --home-dir /data houston \
+ && mkdir -p /data/.houston /data/Houston \
+ && chown -R houston:houston /data
 
 COPY --from=build /src/target/release/houston-engine /usr/local/bin/houston-engine
 


### PR DESCRIPTION
Closes #238.

## Summary
- Copy `app/houston-tauri/` and `app/src-tauri/` into the build stage so cargo can load the workspace (both are workspace members; cargo refuses to load the workspace if any member's manifest is missing, even when `-p` excludes them).
- Copy `ui/agent-schemas/` so `houston-agent-files` can `include_str!` the embedded JSON schemas at compile time.
- Pre-create `/data/.houston` + `/data/Houston` and `chown -R houston:houston /data` before `USER houston` so named-volume mounts inherit correct ownership on first attach. Otherwise the unprivileged `houston` user can't write the libSQL DB and the container crash-loops on first boot.

## Test plan
- [x] `docker build -t houston/engine:dev -f always-on/Dockerfile .` succeeds end-to-end.
- [x] `docker compose up -d` (from `always-on/`) brings the container up without restart-loop.
- [x] `curl -H "Authorization: Bearer $TOKEN" http://localhost:7777/v1/health` returns `{"status":"ok","version":"0.4.12","protocol":1}`.
- [x] End-to-end client smoke test: connected a Vite-served `app/` frontend at `http://localhost:1420` (via the `VITE_HOUSTON_ENGINE_BASE` + `VITE_HOUSTON_ENGINE_TOKEN` fallback in `app/src/lib/engine.ts:31-36`) to the containerized engine and bootstrapped the UI.

Note: this PR only fixes the build + first-boot. Provider CLIs (Claude, Codex, Gemini, Composio) are still missing from the runtime image, so agent sessions will fail at provider spawn. Follow-up work to bundle/install those will land separately.

Generated with [Claude Code](https://claude.com/claude-code)
