### PR TITLE
docs(readme): correct monorepo layout counts and missing directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Three tiers:
 
 ## Monorepo layout
 
-Organized as **6 end-user products + 3 code libraries**.
+Cargo workspace (**17 Rust crates** in `engine/`) plus pnpm workspace (**11 `@houston-ai/*` React packages** in `ui/`), alongside the desktop, mobile, store, website, and always-on products.
 
 ```
 houston/
@@ -150,16 +150,21 @@ houston/
 │   ├── src/                 React frontend
 │   ├── src-tauri/           Tauri binary
 │   └── houston-tauri/       Tauri adapter (applies Engine to desktop)
-├── mobile/                  Houston Mobile companion
-├── desktop-mobile-bridge/   Cloudflare Worker — pairs Desktop ↔ Mobile
+├── mobile/                  Houston Mobile companion (PWA)
+├── houston-relay/           Cloudflare Worker — pairs Desktop ↔ Mobile
 ├── store/                   Houston Store — agent registry
 ├── website/                 Houston Website — gethouston.ai
 ├── always-on/               Houston Always On — VPS deploy (Dockerfile + compose + systemd)
 ├── teams/                   Houston Teams (TBD — hosted multi-tenant)
 │
-├── ui/                      Houston UI — @houston-ai/* React packages
-├── engine/                  Houston Engine — Rust crates (frontend-agnostic)
+├── ui/                      Houston UI — 11 @houston-ai/* React packages
+├── engine/                  Houston Engine — 17 Rust crates (frontend-agnostic)
 ├── cloud/                   Houston Cloud (TBD — managed Engine hosting)
+│
+├── supabase/                Auth + storage — config.toml + migrations (Google SSO, Keychain)
+├── skills/                  Repo-level Claude skills (build-app-local, debug, release)
+├── knowledge-base/          Load-on-demand contributor docs (architecture, design-system, …)
+├── engine-design/           Engine architecture explainers (HTML)
 │
 └── examples/                Reference consumers of houston-engine
     └── smartbooks/            Bookkeeping app built on a custom React frontend


### PR DESCRIPTION
Tracks #243 — RFC: bstack primitives + control-metalayer.

---

## Summary

Corrects the "Monorepo layout" section of `README.md` so it reflects the actual tree. Maps to bstack **P11 (truthful state)** from the RFC — the README is the first thing contributors read; understated counts produce a wrong mental model of the project surface.

## What was inaccurate

1. **Lead sentence claim "6 end-user products + 3 code libraries"** — actual workspace has 17 Rust crates in `engine/` (Cargo.toml lines 4-22 list `engine/houston-*` × 17, plus `app/houston-tauri` + `app/src-tauri`) and 11 `@houston-ai/*` React packages in `ui/` (pnpm-workspace.yaml `ui/*` glob → `agent, agent-schemas, board, chat, core, engine-client, events, layout, review, routines, skills`).
2. **`desktop-mobile-bridge/` referenced in the tree** — the actual directory is `houston-relay/` (per pnpm-workspace.yaml line 5). No dir named `desktop-mobile-bridge` exists in the repo.
3. **Missing directories**: `supabase/`, `skills/`, `knowledge-base/`, `engine-design/` — all are top-level dirs in main but absent from the README tree.

## Changes

- Lead sentence rewritten to surface the two workspaces (Cargo + pnpm) with verified counts
- `houston-relay/` row replaces the `desktop-mobile-bridge/` row
- `engine/` annotation says "17 Rust crates" instead of "Houston Engine — Rust crates (frontend-agnostic)"
- `ui/` annotation says "11 @houston-ai/* React packages"
- Four new rows: `supabase/`, `skills/`, `knowledge-base/`, `engine-design/`

## Out of scope

- `CONTRIBUTING.md` line 39 and `CHANGELOG.md` line 150 still reference `desktop-mobile-bridge/` (the rename is incomplete at repo level). Filing those as a follow-up rather than expanding this PR's scope.
- No restructuring of other README sections — the "For everyone / For founders" voice and surrounding narrative are preserved untouched.

## Test plan

- [ ] `ls /Users/broomva/broomva/work/houston/engine/ | wc -l` confirms 17
- [ ] `ls /Users/broomva/broomva/work/houston/ui/ | wc -l` confirms 11
- [ ] `ls /Users/broomva/broomva/work/houston/houston-relay` exists; `ls /Users/broomva/broomva/work/houston/desktop-mobile-bridge` does not
- [ ] README renders correctly on GitHub (tree code block preserved)
