### PR TITLE
feat(app): non-Tauri engine config fallback via localStorage

### DIFF
--- a/app/src/lib/engine.ts
+++ b/app/src/lib/engine.ts
@@ -33,6 +33,24 @@ function resolveConfig(): { baseUrl: string; token: string } | null {
     (import.meta as any).env?.VITE_HOUSTON_ENGINE_BASE ?? null;
   const token = (import.meta as any).env?.VITE_HOUSTON_ENGINE_TOKEN ?? null;
   if (baseUrl && token) return { baseUrl, token };
+  // Custom-frontend fallback — mirrors examples/smartbooks/src/lib/config.ts.
+  // Lets the Houston frontend bootstrap from any browser (not just the Tauri
+  // WebView) by reading a JSON-encoded `{baseUrl, token}` from localStorage.
+  // Devs/agents set this from the console or a Connect screen; production
+  // Tauri builds still win via window.__HOUSTON_ENGINE__ above.
+  if (typeof localStorage !== "undefined") {
+    try {
+      const raw = localStorage.getItem("houston.engine");
+      if (raw) {
+        const cfg = JSON.parse(raw);
+        if (cfg?.baseUrl && cfg?.token) {
+          return { baseUrl: cfg.baseUrl, token: cfg.token };
+        }
+      }
+    } catch {
+      /* malformed entry — fall through to null */
+    }
+  }
   return null;
 }
 


### PR DESCRIPTION
Tracks #243 — RFC: bstack primitives + control-metalayer.

---

## Summary

Adds a third tier — `localStorage["houston.engine"]` — to the engine-client config resolver at `app/src/lib/engine.ts:resolveConfig`. Mirrors the three-tier pattern `examples/smartbooks/src/lib/config.ts` already documents. Production Tauri builds keep winning on the existing `window.__HOUSTON_ENGINE__` tier; this only matters when the page loads outside the Tauri WebView.

```diff
   if (baseUrl && token) return { baseUrl, token };
+  // Custom-frontend fallback — mirrors examples/smartbooks/src/lib/config.ts.
+  // Lets the Houston frontend bootstrap from any browser (not just the Tauri
+  // WebView) by reading a JSON-encoded `{baseUrl, token}` from localStorage.
+  // Devs/agents set this from the console or a Connect screen; production
+  // Tauri builds still win via window.__HOUSTON_ENGINE__ above.
+  if (typeof localStorage !== "undefined") {
+    try {
+      const raw = localStorage.getItem("houston.engine");
+      if (raw) {
+        const cfg = JSON.parse(raw);
+        if (cfg?.baseUrl && cfg?.token) {
+          return { baseUrl: cfg.baseUrl, token: cfg.token };
+        }
+      }
+    } catch {
+      /* malformed entry — fall through to null */
+    }
+  }
   return null;
 }
```

## Why

`@vitejs/plugin-react`'s fast-refresh can't reload `main.tsx`, so a plain reload of `http://localhost:1420` in any other browser was trapped at `EngineGate` because `getEngine()` threw — no `window.__HOUSTON_ENGINE__`, no Vite env, nothing to do. SmartBooks already solves this with a three-tier resolver; the Houston app's own resolver only had two tiers. This brings parity.

Set the blob and reload:

```js
localStorage.setItem("houston.engine", JSON.stringify({
  baseUrl: "http://127.0.0.1:7777",
  token: "<token from ~/.dev-houston/engine.json or HOUSTON_ENGINE_TOKEN>"
}));
location.reload();
```

… and the frontend bootstraps against any reachable engine. Same React, same engine, same bearer.

## Runtime validation

Drove a full Houston session in Chrome end-to-end with this patch in place via the Interceptor browser-automation extension:

1. Standalone engine on `127.0.0.1:7777` with a known `HOUSTON_ENGINE_TOKEN`.
2. Set `localStorage["houston.engine"]` to `{baseUrl, token}` via the Chrome console.
3. Reload `:1420`. Frontend bootstrapped against the standalone engine (sha256 of token matched `token_hash` in `~/.dev-houston/engine.json`).
4. Clicked through the language picker — `useLocalePreference` mutation hit `PUT /v1/preferences/locale`. Engine recorded `{"value": "en"}`.
5. Reached Mission Control. Clicked "Nuevo agente". Selected Bookkeeping template. Typed name `Bookkeeper-broomva`. Clicked Crear agente.
6. Engine recorded the agent at `/Users/broomva/.dev-houston/workspaces/BstackPort/Bookkeeper-broomva` with `configId: "bookkeeping"` and a fresh UUID. `GET /v1/workspaces/<id>/agents` returned length 1 (was 0 before the click).
7. Agent dashboard rendered with the full template skill catalog.

Identical bootstrap behavior in the actual Tauri build — tier 1 short-circuits before tier 3 is evaluated, so production paths are unchanged.

## Convention compliance

- Conventional commit `feat(engine-client):` per CONTRIBUTING.md §"Commit Messages"
- No new dependencies
- Strict three-tier order preserved; tier 1 (Tauri) always wins when present
- Comment style + voice match the rest of `engine.ts`
- Malformed `localStorage` value falls through to `null` (same as the existing tiers) — no silent throw
- `typeof localStorage !== "undefined"` guard so the resolver still works in SSR / Workers / older test envs

## Out of scope

- A Connect screen UI for setting the localStorage value (`examples/smartbooks/src/components/ConnectScreen.tsx` is the reference shape; this PR is just the resolver tier — UI for it would be a separate change)
- Removing the `Tauri-only` listener path at the bottom of `engine.ts`. The `houston-engine-ready` / `-restarted` listeners stay; they're a no-op in non-Tauri envs because `listen()` rejects, and the `.catch(() => {})` already documents this.

## Pairs with

`docs(knowledge-base): add agent-dogfood-loop` (separate PR) — documents the full Chrome-driven dogfood loop this change enables.
