### PR TITLE
feat(provider): OAuth sign-in via the browser for remote Houston engines

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,64 @@
+name: Docker Publish
+
+# Manual publish of the houston-engine container image to GHCR.
+#
+# Trigger from the Actions tab → "Docker Publish" → "Run workflow", pick a
+# branch, set the tag (e.g. "latest", "dev", "v0.1.0"). Image is always
+# also tagged with the short commit SHA for traceability.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Primary image tag (e.g. latest, dev, v0.1.0)'
+        required: true
+        default: 'latest'
+      extra_tag:
+        description: 'Optional additional tag (leave blank to skip)'
+        required: false
+        default: ''
+
+jobs:
+  publish:
+    name: Build & push houston-engine
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute short SHA
+        id: vars
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Assemble tag list
+        id: tags
+        run: |
+          {
+            echo "list<<EOF"
+            echo "ghcr.io/gethouston/houston-engine:${{ inputs.tag }}"
+            echo "ghcr.io/gethouston/houston-engine:sha-${{ steps.vars.outputs.sha_short }}"
+            if [ -n "${{ inputs.extra_tag }}" ]; then
+              echo "ghcr.io/gethouston/houston-engine:${{ inputs.extra_tag }}"
+            fi
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: always-on/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.tags.outputs.list }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           context: .
           file: always-on/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
           tags: |
             ghcr.io/gethouston/houston-engine:latest

--- a/always-on/Dockerfile
+++ b/always-on/Dockerfile
@@ -23,6 +23,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Cache the dependency compile by copying the manifests first.
 COPY Cargo.toml Cargo.lock ./
 COPY engine/ engine/
+# Workspace lists `app/houston-tauri` and `app/src-tauri` as members, so their
+# manifests must exist for cargo to load the workspace — even though `-p
+# houston-engine-server` will not compile them (no path in its dep tree).
+COPY app/houston-tauri/ app/houston-tauri/
+COPY app/src-tauri/ app/src-tauri/
+# `houston-agent-files` embeds the `@houston-ai/agent-schemas` JSON files
+# (activity / routines / routine_runs / config / learnings) at compile time via
+# `include_str!("../../../ui/agent-schemas/src/*.schema.json")` — that subtree
+# is the source of truth for the `.houston/*` data layout, see
+# `knowledge-base/architecture.md`.
+COPY ui/agent-schemas/ ui/agent-schemas/
 
 # Only build the engine server binary — excludes the desktop app crates.
 RUN cargo build --release -p houston-engine-server --bin houston-engine
@@ -32,7 +43,9 @@ FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
  && rm -rf /var/lib/apt/lists/* \
- && useradd --system --create-home --home-dir /data houston
+ && useradd --system --create-home --home-dir /data houston \
+ && mkdir -p /data/.houston /data/Houston \
+ && chown -R houston:houston /data
 
 COPY --from=build /src/target/release/houston-engine /usr/local/bin/houston-engine
 

--- a/always-on/Dockerfile
+++ b/always-on/Dockerfile
@@ -1,7 +1,9 @@
 # Houston Engine — standalone deployment image.
 #
-# Produces a minimal image that runs the `houston-engine` binary.
-# Typical deployment: VPS (Houston Always On), behind a reverse proxy with TLS.
+# Produces a self-contained image that runs `houston-engine` and ships
+# the three provider CLIs Houston agents need (Claude Code, Codex,
+# Composio). Typical deployment: VPS (Houston Always On) or Kubernetes,
+# behind a reverse proxy with TLS.
 #
 #   docker build -t houston/engine:dev -f always-on/Dockerfile .
 #   docker run -p 7777:7777 \
@@ -12,7 +14,7 @@
 #     -v houston-docs:/data/Houston \
 #     houston/engine:dev
 
-# ---------- Build stage ----------
+# ---------- Build stage (Rust engine) ----------
 FROM rust:1-slim-bookworm AS build
 WORKDIR /src
 
@@ -38,23 +40,86 @@ COPY ui/agent-schemas/ ui/agent-schemas/
 # Only build the engine server binary — excludes the desktop app crates.
 RUN cargo build --release -p houston-engine-server --bin houston-engine
 
+# ---------- Provider-CLI install stage ----------
+# Pre-installs Claude Code, Codex, and Composio into `/data` (matching
+# the runtime stage's `houston` home) so the runtime stage can COPY the
+# whole tree in without rewriting symlinks. The Claude installer writes
+# ABSOLUTE-path symlinks like `~/.local/bin/claude -> $HOME/.local/share/
+# claude/versions/<v>/...`, so $HOME has to match the runtime layout or
+# the symlink dangles after the COPY.
+#
+# Rationale: cli-deps.json does not publish linux-x64 URLs for these
+# binaries (only darwin + windows), so the engine's runtime claude-
+# installer would skip with a warn and the composio lifecycle would
+# shell out to `curl | bash` on every boot — which fails because the
+# runtime image is debian-slim with no curl. Pre-installing here means
+# the engine sees them as "already installed" via the standard PATH
+# (`~/.local/bin`) and `$HOME/.composio/composio` lookups in
+# `engine/houston-terminal-manager/src/claude_path.rs` and
+# `engine/houston-composio/src/install.rs`.
+FROM debian:bookworm-slim AS cli-tools
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl bash tar unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV HOME=/data
+WORKDIR /data
+RUN mkdir -p /data/.local/bin
+
+# Claude Code (proprietary). Upstream installer is non-interactive,
+# writes to `$HOME/.local/bin/claude` with a sibling `~/.local/share/
+# claude/versions/<v>/` tree. Pinned to whatever's stable at build
+# time — Anthropic does not publish a linux-x64 URL in cli-deps.json,
+# so there's no SHA-256 anchor available. Rebuild the image to upgrade.
+RUN curl -fsSL https://claude.ai/install.sh | bash \
+ && test -L /data/.local/bin/claude \
+ && test -e "$(readlink -f /data/.local/bin/claude)"
+
+# Codex (Apache-2.0). Static-musl binary from the openai/codex GitHub
+# release. Version pinned to match `cli-deps.json#codex.version`.
+# The tarball contains a binary named after the target triple — rename
+# to `codex` so PATH lookup picks it up.
+ARG CODEX_VERSION=0.130.0
+RUN curl -fsSL "https://github.com/openai/codex/releases/download/rust-v${CODEX_VERSION}/codex-x86_64-unknown-linux-musl.tar.gz" -o /tmp/codex.tgz \
+ && tar -xzf /tmp/codex.tgz -C /tmp \
+ && install -m 755 /tmp/codex-x86_64-unknown-linux-musl /data/.local/bin/codex \
+ && /data/.local/bin/codex --version \
+ && rm -rf /tmp/codex*
+
+# Composio (MIT). Upstream installer writes to `$HOME/.composio/composio`
+# — that's exactly where `houston_composio::install::standalone_cli_path`
+# looks (`engine/houston-composio/src/install.rs:35`).
+RUN curl -fsSL https://composio.dev/install | bash \
+ && test -x /data/.composio/composio
+
 # ---------- Runtime stage ----------
+# Stays slim. Runtime needs: ca-certs for HTTPS, bash + git + python3
+# because agents spawn these through their Bash tool, and the
+# pre-installed provider binaries from `cli-tools`.
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates \
+    ca-certificates bash git python3 \
  && rm -rf /var/lib/apt/lists/* \
  && useradd --system --create-home --home-dir /data houston \
  && mkdir -p /data/.houston /data/Houston \
  && chown -R houston:houston /data
 
 COPY --from=build /src/target/release/houston-engine /usr/local/bin/houston-engine
+# Provider CLIs land under the houston user's home so the engine
+# resolves them via the standard `~/.local/bin` PATH entry and the
+# `$HOME/.composio/composio` lookup that's already baked in. The
+# cli-tools stage installed with HOME=/data so absolute-path symlinks
+# inside `.local/bin/claude` already point at `/data/...`.
+COPY --from=cli-tools --chown=houston:houston /data/.local /data/.local
+COPY --from=cli-tools --chown=houston:houston /data/.composio /data/.composio
 
 USER houston
 WORKDIR /data
 ENV HOUSTON_HOME=/data/.houston \
     HOUSTON_DOCS=/data/Houston \
     HOUSTON_BIND=0.0.0.0:7777 \
-    HOUSTON_BIND_ALL=1
+    HOUSTON_BIND_ALL=1 \
+    PATH=/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 EXPOSE 7777
 CMD ["/usr/local/bin/houston-engine"]

--- a/app/src/components/shell/provider-login-dialog.tsx
+++ b/app/src/components/shell/provider-login-dialog.tsx
@@ -1,0 +1,187 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ExternalLink, Copy } from "lucide-react";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@houston-ai/core";
+import type { ProviderInfo } from "../../lib/providers";
+import { tauriProvider } from "../../lib/tauri";
+import { useUIStore } from "../../stores/ui";
+
+/**
+ * OAuth verification-code dialog for remote/headless Houston Engines.
+ *
+ * When the engine spawns a provider CLI (`claude auth login`, `codex
+ * login`) inside a Docker container or on an Always-On VPS, the CLI
+ * can't open the user's browser — the browser is on a different
+ * machine entirely. The CLI prints a fallback OAuth URL to stdout and
+ * waits for a verification code on stdin. The engine surfaces that
+ * URL via a `ProviderLoginUrl` WS event; this dialog shows it (and
+ * auto-opens it in a new tab) plus a paste-code input. Submitting
+ * relays the code through `POST /v1/providers/:name/login/code`,
+ * which the engine writes into the CLI's stdin.
+ *
+ * On desktop Houston this dialog still pops because claude prints the
+ * fallback URL unconditionally — but claude finishes via its own
+ * `127.0.0.1` callback before the user ever needs to paste, the
+ * `ProviderLoginComplete` event arrives, and the dialog auto-closes.
+ */
+interface Props {
+  provider: ProviderInfo | null;
+  url: string | null;
+  onClose: () => void;
+}
+
+export function ProviderLoginDialog({ provider, url, onClose }: Props) {
+  const { t } = useTranslation("providers");
+  const addToast = useUIStore((s) => s.addToast);
+  const [code, setCode] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Reset code state every time a new provider opens the dialog so a
+  // stale code from a prior failed attempt doesn't leak across.
+  // Deliberately do NOT `window.open` here: claude/codex print the
+  // fallback URL unconditionally, including on desktop where the CLI
+  // already opened the user's browser via xdg-open/open. Auto-opening
+  // a duplicate tab would be a regression for personal-use Houston.
+  // The "Open URL" button below is the explicit action for remote
+  // deployments where the browser hasn't been opened.
+  useEffect(() => {
+    if (provider && url) {
+      setCode("");
+      setError(null);
+      setSubmitting(false);
+    }
+  }, [provider, url]);
+
+  if (!provider || !url) return null;
+
+  const handleCopyUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      addToast({
+        title: t("providerLogin.urlCopied"),
+        variant: "success",
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      addToast({
+        title: t("providerLogin.urlCopyFailed"),
+        description: msg,
+        variant: "error",
+      });
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const trimmed = code.trim();
+    if (!trimmed) {
+      setError(t("providerLogin.codeRequired"));
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      await tauriProvider.submitLoginCode(provider.id, trimmed);
+      // Do NOT close the dialog here — wait for
+      // `ProviderLoginComplete` to fire so the user sees confirmation
+      // that the CLI actually finished the OAuth exchange. The parent
+      // listens for that event and calls `onClose`.
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setError(msg);
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog
+      open={provider !== null && url !== null}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {t("providerLogin.title", { name: provider.name })}
+          </DialogTitle>
+          <DialogDescription>
+            {t("providerLogin.description", { name: provider.name })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="rounded-md border bg-muted/40 p-3 text-[12px] break-all font-mono">
+            {url}
+          </div>
+
+          <div className="flex gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={() => window.open(url, "_blank", "noopener,noreferrer")}
+            >
+              <ExternalLink className="size-3.5" />
+              {t("providerLogin.openUrl")}
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="gap-1.5"
+              onClick={handleCopyUrl}
+            >
+              <Copy className="size-3.5" />
+              {t("providerLogin.copyUrl")}
+            </Button>
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="provider-login-code" className="text-[13px] font-medium">
+              {t("providerLogin.codeLabel")}
+            </label>
+            <input
+              id="provider-login-code"
+              type="text"
+              autoComplete="off"
+              autoFocus
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder={t("providerLogin.codePlaceholder")}
+              className="w-full rounded-md border bg-background px-3 py-2 text-[13px] font-mono focus:outline-none focus:ring-2 focus:ring-ring"
+              disabled={submitting}
+            />
+          </div>
+
+          {error && (
+            <p className="text-[12px] text-destructive" role="alert">
+              {error}
+            </p>
+          )}
+
+          <DialogFooter className="gap-2">
+            <Button type="button" variant="outline" onClick={onClose}>
+              {t("providerLogin.cancel")}
+            </Button>
+            <Button type="submit" disabled={submitting || !code.trim()}>
+              {submitting
+                ? t("providerLogin.submitting")
+                : t("providerLogin.submit")}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/shell/provider-settings.tsx
+++ b/app/src/components/shell/provider-settings.tsx
@@ -1,11 +1,14 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import type { HoustonEvent } from "@houston-ai/core";
 import { Spinner, ConfirmDialog } from "@houston-ai/core";
 import { tauriProvider, type ProviderStatus } from "../../lib/tauri";
 import { PROVIDERS, type ProviderInfo } from "../../lib/providers";
 import { useUIStore } from "../../stores/ui";
 import { analytics } from "../../lib/analytics";
+import { subscribeHoustonEvents } from "../../lib/events";
 import { GeminiConnectDialog } from "./gemini-connect-dialog";
+import { ProviderLoginDialog } from "./provider-login-dialog";
 import { ProviderAccountRow } from "./provider-account-row";
 
 /**
@@ -28,6 +31,13 @@ export function ProviderSettings() {
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [confirmSignOutFor, setConfirmSignOutFor] = useState<ProviderInfo | null>(null);
   const [apiKeyDialogFor, setApiKeyDialogFor] = useState<ProviderInfo | null>(null);
+  // OAuth URL surfaced by the engine when the CLI couldn't open the
+  // user's browser itself (remote/headless deployments). Cleared on
+  // ProviderLoginComplete or when the user closes the dialog.
+  const [loginDialog, setLoginDialog] = useState<{
+    provider: ProviderInfo;
+    url: string;
+  } | null>(null);
   const addToast = useUIStore((s) => s.addToast);
 
   // First scan is treated as the baseline so opening Settings while a
@@ -81,6 +91,54 @@ export function ProviderSettings() {
       setPendingId(null);
     }
   }, [pendingId, statuses]);
+
+  // OAuth URL relay for remote/headless engines (Docker container,
+  // Always-On VPS). When the engine spawns claude/codex login and the
+  // CLI can't open the user's browser, it surfaces the fallback URL
+  // via `ProviderLoginUrl`. We show <ProviderLoginDialog> with the
+  // URL + a paste-code field. `ProviderLoginComplete` closes the
+  // dialog and refreshes provider status. The status-poll effect
+  // above flips the chip to Connected once the CLI's credential file
+  // lands. Functional setState avoids stale-closure reads on
+  // loginDialog / pendingId — multiple providers could fire events
+  // concurrently and we only want to clear state for the one the
+  // event names.
+  useEffect(() => {
+    const off = subscribeHoustonEvents((ev: HoustonEvent) => {
+      if (ev.type === "ProviderLoginUrl") {
+        const prov = PROVIDERS.find((p) => p.id === ev.data.provider);
+        if (prov) {
+          setLoginDialog({ provider: prov, url: ev.data.url });
+        }
+      } else if (ev.type === "ProviderLoginComplete") {
+        const prov = PROVIDERS.find((p) => p.id === ev.data.provider);
+        if (ev.data.success) {
+          addToast({
+            title: t("toast.signInSucceeded", { provider: prov?.name ?? ev.data.provider }),
+            variant: "success",
+          });
+        } else if (ev.data.error) {
+          addToast({
+            title: t("toast.signInFailed", { provider: prov?.name ?? ev.data.provider }),
+            description: ev.data.error,
+            variant: "error",
+          });
+        }
+        // Only clear the dialog if it's showing THIS provider's URL —
+        // a completion for a different provider must not clobber an
+        // in-flight sign-in.
+        setLoginDialog((current) =>
+          current?.provider.id === ev.data.provider ? null : current,
+        );
+        // Same rule for the spinner-tracking pending id: on failure
+        // the status poll won't ever see authenticated, so without
+        // this clear the row would spin forever.
+        setPendingId((current) => (current === ev.data.provider ? null : current));
+        loadStatuses();
+      }
+    });
+    return off;
+  }, [addToast, loadStatuses, t]);
 
   const handleConnect = async (provider: ProviderInfo) => {
     if (provider.loginKind === "apiKey") {
@@ -192,6 +250,12 @@ export function ProviderSettings() {
         onLoginStarted={(providerId) => {
           setPendingId(providerId);
         }}
+      />
+
+      <ProviderLoginDialog
+        provider={loginDialog?.provider ?? null}
+        url={loginDialog?.url ?? null}
+        onClose={() => setLoginDialog(null)}
       />
     </>
   );

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -710,6 +710,18 @@ export const tauriProvider = {
   launchLogout: (provider: string) =>
     call<void>("launch_provider_logout", () => getEngine().providerLogout(provider)),
   /**
+   * Submit the OAuth verification code the user pasted from their
+   * browser. Only meaningful for remote/headless engines (container,
+   * Always-On VPS) where the CLI can't open the user's browser
+   * directly — the engine surfaces the sign-in URL via the
+   * `ProviderLoginUrl` WS event, the UI shows the dialog, and this
+   * call relays the code back to the CLI's stdin.
+   */
+  submitLoginCode: (provider: string, code: string) =>
+    call<void>("submit_provider_login_code", () =>
+      getEngine().submitProviderLoginCode(provider, code),
+    ),
+  /**
    * Save a Gemini API key to `~/.gemini/.env` via the engine. Errors
    * surface through `call`'s standard rejection path; the caller is
    * expected to render them with `errorMessage(err)` + `addToast`.

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -26,7 +26,22 @@
   },
   "toast": {
     "signInFailed": "Couldn't open {{provider}} sign-in",
-    "signOutFailed": "Couldn't sign out of {{provider}}"
+    "signOutFailed": "Couldn't sign out of {{provider}}",
+    "signInSucceeded": "Signed in to {{provider}}"
+  },
+  "providerLogin": {
+    "title": "Finish signing in to {{name}}",
+    "description": "Open the URL below in your browser, complete sign-in, then paste the verification code back here.",
+    "openUrl": "Open URL",
+    "copyUrl": "Copy URL",
+    "urlCopied": "URL copied to clipboard",
+    "urlCopyFailed": "Couldn't copy the URL",
+    "codeLabel": "Verification code",
+    "codePlaceholder": "Paste the code from your browser",
+    "codeRequired": "Enter the verification code first.",
+    "submit": "Submit code",
+    "submitting": "Submitting...",
+    "cancel": "Cancel"
   },
   "geminiConnect": {
     "title": "Connect {{name}}",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -26,7 +26,22 @@
   },
   "toast": {
     "signInFailed": "No se pudo abrir el inicio de sesión de {{provider}}",
-    "signOutFailed": "No se pudo cerrar sesión de {{provider}}"
+    "signOutFailed": "No se pudo cerrar sesión de {{provider}}",
+    "signInSucceeded": "Sesión iniciada en {{provider}}"
+  },
+  "providerLogin": {
+    "title": "Termina de iniciar sesión en {{name}}",
+    "description": "Abre la URL de abajo en tu navegador, completa el inicio de sesión y luego pega aquí el código de verificación.",
+    "openUrl": "Abrir URL",
+    "copyUrl": "Copiar URL",
+    "urlCopied": "URL copiada al portapapeles",
+    "urlCopyFailed": "No se pudo copiar la URL",
+    "codeLabel": "Código de verificación",
+    "codePlaceholder": "Pega el código de tu navegador",
+    "codeRequired": "Primero ingresa el código de verificación.",
+    "submit": "Enviar código",
+    "submitting": "Enviando...",
+    "cancel": "Cancelar"
   },
   "geminiConnect": {
     "title": "Conectar {{name}}",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -26,7 +26,22 @@
   },
   "toast": {
     "signInFailed": "Não foi possível abrir o login de {{provider}}",
-    "signOutFailed": "Não foi possível sair de {{provider}}"
+    "signOutFailed": "Não foi possível sair de {{provider}}",
+    "signInSucceeded": "Conectado a {{provider}}"
+  },
+  "providerLogin": {
+    "title": "Termine de entrar em {{name}}",
+    "description": "Abra a URL abaixo no seu navegador, finalize o login e cole aqui o código de verificação.",
+    "openUrl": "Abrir URL",
+    "copyUrl": "Copiar URL",
+    "urlCopied": "URL copiada para a área de transferência",
+    "urlCopyFailed": "Não foi possível copiar a URL",
+    "codeLabel": "Código de verificação",
+    "codePlaceholder": "Cole o código do seu navegador",
+    "codeRequired": "Informe primeiro o código de verificação.",
+    "submit": "Enviar código",
+    "submitting": "Enviando...",
+    "cancel": "Cancelar"
   },
   "geminiConnect": {
     "title": "Conectar {{name}}",

--- a/engine/houston-engine-core/src/provider/login_relay.rs
+++ b/engine/houston-engine-core/src/provider/login_relay.rs
@@ -1,0 +1,383 @@
+//! OAuth URL-relay for provider sign-in subprocesses.
+//!
+//! When [`crate::provider::launch_login`] runs in a remote/headless
+//! deployment (Docker container, Always-On VPS, future Cloud), the
+//! provider CLI (`claude auth login`, `codex login`) can't open the
+//! user's browser — the browser lives on a different machine. The
+//! CLI prints a fallback OAuth URL to stdout and waits for the user
+//! to paste the verification code on stdin. This module surfaces
+//! that URL to the frontend (via [`HoustonEvent::ProviderLoginUrl`])
+//! and writes the code the user submitted back to the CLI's stdin
+//! (via [`submit_login_code`]). When the CLI finally exits — either
+//! cleanly after exchanging the code, or with an error — the relay
+//! task emits [`HoustonEvent::ProviderLoginComplete`] so the
+//! frontend can close the sign-in dialog and refresh
+//! `providerStatus`.
+//!
+//! Same machinery handles desktop too: claude prints the URL
+//! unconditionally, but completes via its own local callback before
+//! the user needs to interact with the Houston dialog. The dialog
+//! pops, then auto-dismisses on `ProviderLoginComplete`.
+
+use crate::error::{CoreError, CoreResult};
+use houston_terminal_manager::Provider;
+use houston_ui_events::{DynEventSink, HoustonEvent};
+use once_cell::sync::Lazy;
+use regex::Regex;
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+use tokio::process::{Child, ChildStdin, ChildStdout};
+use tokio::sync::Mutex;
+
+/// Hard ceiling on a single OAuth login subprocess lifetime. If the
+/// CLI hasn't exited by then (e.g. user abandoned the browser flow
+/// or claude got stuck) the relay task force-emits a
+/// `ProviderLoginComplete` with a timeout error and the session is
+/// removed so the next Connect click can spawn a fresh subprocess.
+const LOGIN_SESSION_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// In-flight OAuth login sessions, keyed by provider id (e.g.
+/// `"anthropic"`, `"openai"`). Single-entry-per-provider by design:
+/// [`insert_session`] rejects a second concurrent attempt with
+/// `BadRequest` so a fast double-click can't orphan a subprocess.
+/// Removed by [`relay_login_output`] when the child exits.
+///
+/// `stdin` is wrapped in its own `Arc<Mutex<_>>` so
+/// [`submit_login_code`] can clone the handle out of this map under
+/// a brief outer-lock acquisition, then await the `write_all` against
+/// the inner lock — never holding the outer mutex across an `.await`
+/// (which would jam the whole map under any slow write).
+static LOGIN_SESSIONS: Lazy<Mutex<HashMap<String, LoginSession>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+struct LoginSession {
+    stdin: Arc<Mutex<ChildStdin>>,
+}
+
+/// Regex over a single line of CLI stdout, looking for an HTTPS URL
+/// the user should open in their browser. Claude (`claude auth
+/// login`), codex (`codex login`), and other OAuth device-flow CLIs
+/// all print at least one — we capture the first one on the first
+/// matching line. The trailing-punctuation guard in
+/// [`extract_login_url`] strips characters that are legal inside a
+/// URL but almost always sentence terminators in CLI output.
+static LOGIN_URL_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r"(https://[A-Za-z0-9._~:/?#\[\]@!$&'()*+,;=%-]+)")
+        .expect("login url regex must compile")
+});
+
+/// Extract an OAuth URL from a CLI stdout line, with trailing-
+/// punctuation cleanup. The regex character class is permissive on
+/// purpose (URLs legitimately contain `.` `,` `;`), so we trim
+/// terminators after the match — a sentence-ending period from
+/// `"visit https://example.com/auth?x=1."` would otherwise become
+/// part of the URL and break the OAuth state round-trip.
+fn extract_login_url(line: &str) -> Option<String> {
+    let cap = LOGIN_URL_RE.captures(line)?;
+    let raw = cap.get(1)?.as_str();
+    let trimmed = raw.trim_end_matches(|c: char| ".,;:)]}>'\"".contains(c));
+    Some(trimmed.to_string())
+}
+
+/// Register a new login session, taking ownership of the CLI's
+/// stdin handle. Returns `BadRequest` if a session is already in
+/// flight for the same provider — the caller should kill its own
+/// child and surface the conflict so the user can wait or restart.
+pub(super) async fn insert_session(
+    provider_id: &str,
+    cli_name: &str,
+    stdin: ChildStdin,
+) -> CoreResult<()> {
+    let mut sessions = LOGIN_SESSIONS.lock().await;
+    if sessions.contains_key(provider_id) {
+        return Err(CoreError::BadRequest(format!(
+            "{cli_name} sign-in is already pending. Finish the open sign-in or restart Houston to retry.",
+        )));
+    }
+    sessions.insert(
+        provider_id.to_string(),
+        LoginSession {
+            stdin: Arc::new(Mutex::new(stdin)),
+        },
+    );
+    Ok(())
+}
+
+/// Spawn the background task that drives a single login session:
+/// stream stdout looking for the OAuth URL, drain stderr into a
+/// buffer for the failure path, and wait for the child to exit
+/// (with a hard timeout). Emits `ProviderLoginUrl` once and
+/// `ProviderLoginComplete` exactly once.
+pub(super) fn spawn_relay(
+    provider_id: String,
+    cli_name: String,
+    child: Child,
+    stdout: ChildStdout,
+    stderr: Option<tokio::process::ChildStderr>,
+    sink: DynEventSink,
+) {
+    tokio::spawn(async move {
+        relay_login_output(provider_id, cli_name, child, stdout, stderr, sink).await;
+    });
+}
+
+async fn relay_login_output(
+    provider_id: String,
+    cli_name: String,
+    mut child: Child,
+    stdout: ChildStdout,
+    stderr: Option<tokio::process::ChildStderr>,
+    sink: DynEventSink,
+) {
+    // Drain stderr in a sibling task so a verbose CLI can't fill the
+    // 64KB stderr pipe buffer and deadlock the child on write.
+    // Captured stderr is appended to the `ProviderLoginComplete`
+    // error message on failure — without this drain a non-zero exit
+    // surfaces only "claude exited with status: 1" instead of the
+    // actionable reason (no-silent-failures policy).
+    let stderr_handle = stderr.map(|mut s| {
+        tokio::spawn(async move {
+            let mut buf = String::new();
+            let _ = s.read_to_string(&mut buf).await;
+            buf
+        })
+    });
+
+    let mut url_emitted = false;
+    let mut reader = BufReader::new(stdout).lines();
+
+    // Outer timeout protects against a CLI that keeps stdout open
+    // and never exits (user abandoned the browser flow, claude
+    // wedged on a network call, …). When the timeout fires we kill
+    // the child so its `wait()` resolves quickly below.
+    let work = async {
+        loop {
+            tokio::select! {
+                line = reader.next_line() => {
+                    match line {
+                        Ok(Some(line)) => {
+                            if !url_emitted {
+                                if let Some(url) = extract_login_url(&line) {
+                                    tracing::info!(
+                                        "[houston:provider] {cli_name} login URL surfaced: {url}"
+                                    );
+                                    sink.emit(HoustonEvent::ProviderLoginUrl {
+                                        provider: provider_id.clone(),
+                                        url,
+                                    });
+                                    url_emitted = true;
+                                }
+                            }
+                        }
+                        Ok(None) => break, // stdout EOF — fall through to child.wait
+                        Err(e) => {
+                            tracing::warn!(
+                                "[houston:provider] {cli_name} login stdout read error: {e}"
+                            );
+                            break;
+                        }
+                    }
+                }
+                exit = child.wait() => {
+                    return Ok::<_, ()>(exit);
+                }
+            }
+        }
+        // Stdout EOF without seeing the child exit — wait for it
+        // explicitly so we still observe the exit status.
+        Ok(child.wait().await)
+    };
+
+    let (success, error) = match tokio::time::timeout(LOGIN_SESSION_TIMEOUT, work).await {
+        Ok(Ok(Ok(status))) => {
+            tracing::info!("[houston:provider] {cli_name} login exited: {status}");
+            let stderr_text = drain_stderr(stderr_handle).await;
+            (
+                status.success(),
+                if status.success() {
+                    None
+                } else {
+                    Some(format_exit_error(&cli_name, &format!("{status}"), &stderr_text))
+                },
+            )
+        }
+        Ok(Ok(Err(e))) => {
+            tracing::warn!("[houston:provider] {cli_name} login wait failed: {e}");
+            let stderr_text = drain_stderr(stderr_handle).await;
+            (
+                false,
+                Some(format_exit_error(&cli_name, &format!("wait failed: {e}"), &stderr_text)),
+            )
+        }
+        Ok(Err(())) => unreachable!(
+            "the inner async block returns Ok variants only — Err(()) is just for type inference"
+        ),
+        Err(_) => {
+            tracing::warn!(
+                "[houston:provider] {cli_name} login timed out after {}s — killing subprocess",
+                LOGIN_SESSION_TIMEOUT.as_secs()
+            );
+            let _ = child.kill().await;
+            let stderr_text = drain_stderr(stderr_handle).await;
+            (
+                false,
+                Some(format_exit_error(
+                    &cli_name,
+                    &format!("timed out after {}s", LOGIN_SESSION_TIMEOUT.as_secs()),
+                    &stderr_text,
+                )),
+            )
+        }
+    };
+
+    LOGIN_SESSIONS.lock().await.remove(&provider_id);
+    sink.emit(HoustonEvent::ProviderLoginComplete {
+        provider: provider_id,
+        success,
+        error,
+    });
+}
+
+async fn drain_stderr(handle: Option<tokio::task::JoinHandle<String>>) -> String {
+    match handle {
+        Some(h) => h.await.unwrap_or_default(),
+        None => String::new(),
+    }
+}
+
+fn format_exit_error(cli_name: &str, status: &str, stderr: &str) -> String {
+    let stderr = stderr.trim();
+    if stderr.is_empty() {
+        format!("{cli_name} {status}")
+    } else {
+        format!("{cli_name} {status}: {stderr}")
+    }
+}
+
+/// Submit the OAuth verification code the user pasted from their
+/// browser. Locks the global session map only long enough to clone
+/// the per-session stdin handle, then writes against the inner lock
+/// so a slow CLI can't block other provider operations.
+///
+/// Does NOT remove the session on success — the relay task does
+/// that when the child actually exits, which is how the
+/// `ProviderLoginComplete` event lands on the WS.
+pub async fn submit_login_code(provider: Provider, code: &str) -> CoreResult<()> {
+    // Brief outer-lock acquisition — no .await between get and clone.
+    let stdin = {
+        let sessions = LOGIN_SESSIONS.lock().await;
+        let session = sessions.get(provider.id()).ok_or_else(|| {
+            CoreError::BadRequest(format!(
+                "no pending sign-in for {}. Click Connect first.",
+                provider.cli_name()
+            ))
+        })?;
+        Arc::clone(&session.stdin)
+    };
+
+    let mut stdin = stdin.lock().await;
+    let line = format!("{}\n", code.trim());
+    stdin
+        .write_all(line.as_bytes())
+        .await
+        .map_err(|e| CoreError::Internal(format!("write code to stdin: {e}")))?;
+    stdin
+        .flush()
+        .await
+        .map_err(|e| CoreError::Internal(format!("flush stdin: {e}")))?;
+    tracing::info!(
+        "[houston:provider] {} login code submitted",
+        provider.cli_name()
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::provider::parse;
+
+    #[test]
+    fn extract_url_from_claude_oauth_line() {
+        let line = "If the browser didn't open, visit: \
+                    https://claude.com/cai/oauth/authorize?code=true&client_id=abc&state=xyz";
+        assert_eq!(
+            extract_login_url(line).unwrap(),
+            "https://claude.com/cai/oauth/authorize?code=true&client_id=abc&state=xyz"
+        );
+    }
+
+    #[test]
+    fn extract_url_returns_none_for_prose_lines() {
+        assert!(extract_login_url("Opening browser to sign in…").is_none());
+        assert!(extract_login_url("Paste code here if prompted >").is_none());
+    }
+
+    #[test]
+    fn extract_url_stops_at_whitespace() {
+        let line = "visit: https://example.com/oauth?x=1 and then come back";
+        assert_eq!(extract_login_url(line).unwrap(), "https://example.com/oauth?x=1");
+    }
+
+    #[test]
+    fn extract_url_trims_sentence_punctuation() {
+        // Claude has shipped lines like "Visit https://example.com/auth." with
+        // a sentence-ending period in the past. The character class includes
+        // `.` (legal in URLs) so we'd otherwise capture the period and break
+        // OAuth state validation.
+        assert_eq!(
+            extract_login_url("Visit https://example.com/auth.").unwrap(),
+            "https://example.com/auth"
+        );
+        assert_eq!(
+            extract_login_url("See (https://example.com/auth) for details").unwrap(),
+            "https://example.com/auth"
+        );
+        assert_eq!(
+            extract_login_url("URL: https://example.com/auth, then paste code").unwrap(),
+            "https://example.com/auth"
+        );
+    }
+
+    #[tokio::test]
+    async fn submit_login_code_errors_without_pending_session() {
+        let provider = parse("anthropic").unwrap();
+        let err = submit_login_code(provider, "abc123").await.unwrap_err();
+        assert!(format!("{err:?}").contains("no pending sign-in"));
+    }
+
+    #[tokio::test]
+    async fn insert_session_rejects_duplicate() {
+        // Spawn a long-running subprocess to grab a real ChildStdin —
+        // `sleep` blocks until killed, so its stdin handle stays alive
+        // long enough for both insert attempts.
+        async fn make_stdin() -> ChildStdin {
+            let mut cmd = tokio::process::Command::new("sleep");
+            cmd.arg("60")
+                .stdin(std::process::Stdio::piped())
+                .stdout(std::process::Stdio::null())
+                .stderr(std::process::Stdio::null())
+                .kill_on_drop(true);
+            let mut child = cmd.spawn().expect("spawn sleep");
+            child.stdin.take().expect("stdin piped")
+        }
+        // Use a unique provider id so this test doesn't collide with
+        // other tests touching LOGIN_SESSIONS in the same process.
+        let provider_id = "test-duplicate-reject";
+        let cli_name = "test-cli";
+        insert_session(provider_id, cli_name, make_stdin().await)
+            .await
+            .expect("first insert succeeds");
+        let err = insert_session(provider_id, cli_name, make_stdin().await)
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:?}").contains("already pending"),
+            "unexpected error shape: {err:?}"
+        );
+        // Cleanup so subsequent tests in this process see an empty map.
+        LOGIN_SESSIONS.lock().await.remove(provider_id);
+    }
+}

--- a/engine/houston-engine-core/src/provider/mod.rs
+++ b/engine/houston-engine-core/src/provider/mod.rs
@@ -13,13 +13,16 @@
 mod gemini_credentials;
 mod gemini_disconnect;
 mod gemini_login;
+mod login_relay;
 
 pub use gemini_credentials::set_gemini_api_key;
 pub use gemini_disconnect::disconnect_gemini;
+pub use login_relay::submit_login_code;
 
 use crate::error::{CoreError, CoreResult};
 use houston_terminal_manager::provider_auth::ProviderAuthState;
 use houston_terminal_manager::{claude_path, InstallSource, Provider};
+use houston_ui_events::DynEventSink;
 use serde::{Deserialize, Serialize};
 use std::ffi::OsString;
 use std::path::PathBuf;
@@ -78,9 +81,16 @@ pub async fn check_status(provider: Provider) -> CoreResult<ProviderStatus> {
 /// forever on a "waiting" dialog.
 ///
 /// If the CLI is still running after the 3-second probe window, we
-/// detach it: the OAuth flow continues in the background and the
-/// frontend polls `check_status` to observe completion, as before.
-pub async fn launch_login(provider: Provider) -> CoreResult<()> {
+/// stash its stdin handle in [`LOGIN_SESSIONS`] and spawn a background
+/// task that reads stdout line-by-line. The first HTTPS URL we see
+/// goes out as a [`HoustonEvent::ProviderLoginUrl`] so the frontend
+/// can show it to the user. When the child eventually exits (after
+/// the user pastes their verification code via [`submit_login_code`]),
+/// we emit [`HoustonEvent::ProviderLoginComplete`] with the exit
+/// status. This makes "click Connect → OAuth in browser → done" work
+/// for remote/headless engines (containers, Always-On) where the CLI
+/// can't open the user's browser itself.
+pub async fn launch_login(provider: Provider, sink: DynEventSink) -> CoreResult<()> {
     // Gemini has no `gemini auth login` subcommand. Instead, gemini-cli
     // exposes an `authenticate` JSON-RPC method over its `--acp` mode
     // (Agent Communication Protocol) that triggers Google's OAuth flow
@@ -108,7 +118,12 @@ pub async fn launch_login(provider: Provider) -> CoreResult<()> {
     let mut cmd = tokio::process::Command::new(&path);
     cmd.args(&args)
         .env("PATH", shell_path)
-        .stdin(std::process::Stdio::null())
+        // Piped (was `null`) because remote/headless engines need to
+        // write the user's OAuth verification code back into the CLI
+        // after the user completes the browser flow. On desktop this
+        // pipe is never used — claude finishes via its 127.0.0.1
+        // callback before we'd ever write — but harmless either way.
+        .stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .kill_on_drop(false);
@@ -143,6 +158,14 @@ pub async fn launch_login(provider: Provider) -> CoreResult<()> {
     let mut child = cmd
         .spawn()
         .map_err(|e| CoreError::Internal(format!("failed to spawn {cli_name} login: {e}")))?;
+
+    // Take stdin BEFORE the probe. `tokio::process::Child::wait` calls
+    // `drop(self.stdin.take())` internally to avoid the classic
+    // deadlock where the parent waits for exit while the child is
+    // blocked on stdin. If we don't lift the handle out first,
+    // `child.stdin.take()` returns `None` after the probe and the
+    // URL-relay branch can't write the user's verification code back.
+    let stdin = child.stdin.take();
 
     // Probe window: if the CLI exits within 3 seconds, the OAuth flow
     // couldn't have completed — that's a real failure to surface.
@@ -192,39 +215,41 @@ pub async fn launch_login(provider: Provider) -> CoreResult<()> {
             )))
         }
         Err(_) => {
-            // Still running after 3s — detach and let the OAuth flow
-            // continue. Frontend polls check_status to observe success.
+            // Still running after 3s — the OAuth flow is in progress.
+            // Hand the stdin handle off to the session map and the
+            // stdout/stderr handles off to the relay task. Insert is
+            // exclusive: a duplicate Connect click on the same
+            // provider while one is pending is rejected here, so the
+            // first subprocess can't be orphaned by overwrite. The
+            // relay task emits ProviderLoginUrl + ProviderLoginComplete
+            // and removes the session on child exit.
             tracing::info!(
-                "[houston:provider] {cli_name} login still running after 3s probe; detaching"
+                "[houston:provider] {cli_name} login still running after 3s probe; relaying URL"
             );
+            let provider_id = provider.id().to_string();
             let cli_name_owned = cli_name.to_string();
-            tokio::spawn(async move {
-                let result =
-                    tokio::time::timeout(Duration::from_secs(120), child.wait_with_output()).await;
-                match result {
-                    Ok(Ok(output)) => {
-                        let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-                        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-                        if output.status.success() {
-                            tracing::info!(
-                                "[houston:provider] {cli_name_owned} login exited: {}",
-                                output.status
-                            );
-                        } else {
-                            tracing::warn!(
-                                "[houston:provider] {cli_name_owned} login exited: {} stdout={stdout:?} stderr={stderr:?}",
-                                output.status
-                            );
-                        }
-                    }
-                    Ok(Err(e)) => tracing::warn!(
-                        "[houston:provider] {cli_name_owned} login wait failed: {e}"
-                    ),
-                    Err(_) => tracing::warn!(
-                        "[houston:provider] {cli_name_owned} login timed out after 120s"
-                    ),
-                }
-            });
+
+            let stdin = stdin.ok_or_else(|| {
+                CoreError::Internal(format!(
+                    "{cli_name} login: stdin handle missing (Stdio::piped wasn't applied?)"
+                ))
+            })?;
+            let stdout = child.stdout.take().ok_or_else(|| {
+                CoreError::Internal(format!(
+                    "{cli_name} login: child stdout was unexpectedly None"
+                ))
+            })?;
+            let stderr = child.stderr.take();
+
+            login_relay::insert_session(&provider_id, cli_name, stdin).await?;
+            login_relay::spawn_relay(
+                provider_id,
+                cli_name_owned,
+                child,
+                stdout,
+                stderr,
+                sink,
+            );
             Ok(())
         }
     }
@@ -453,6 +478,9 @@ mod tests {
         let s = serde_json::to_string(&InstallSource::Missing).unwrap();
         assert_eq!(s, "\"missing\"");
     }
+
+    // URL-relay tests live in `provider/login_relay.rs` alongside
+    // the regex + session map they exercise.
 
     #[test]
     fn login_command_uses_resolved_cli_path() {

--- a/engine/houston-engine-protocol/src/lib.rs
+++ b/engine/houston-engine-protocol/src/lib.rs
@@ -160,6 +160,9 @@ pub fn event_topic(event: &HoustonEvent) -> String {
         HoustonEvent::ClaudeCliInstalling { .. }
         | HoustonEvent::ClaudeCliReady
         | HoustonEvent::ClaudeCliFailed { .. } => "claude".into(),
+        HoustonEvent::ProviderLoginUrl { .. } | HoustonEvent::ProviderLoginComplete { .. } => {
+            "providers".into()
+        }
     }
 }
 

--- a/engine/houston-engine-server/src/routes/providers.rs
+++ b/engine/houston-engine-server/src/routes/providers.rs
@@ -25,6 +25,15 @@ pub fn router() -> Router<Arc<ServerState>> {
         // `claude auth login --claudeai` and `codex login` for the
         // other providers.
         .route("/providers/:name/login", post(login))
+        // POST /providers/:name/login/code submits the OAuth
+        // verification code the user pasted from their browser.
+        // Required for remote/headless engines (container, Always-On)
+        // where the CLI can't open the user's browser itself; the
+        // engine then surfaces the sign-in URL via the WebSocket
+        // `ProviderLoginUrl` event, the UI shows it + a paste-code
+        // input, and the submitted code is written back to the CLI's
+        // stdin so it can exchange for an OAuth token.
+        .route("/providers/:name/login/code", post(login_code))
         .route("/providers/:name/logout", post(logout))
         // Gemini-only: persist an API key the user pasted in the picker
         // dialog to `~/.gemini/.env`. Alternative to the OAuth flow for
@@ -44,11 +53,27 @@ async fn status(
 }
 
 async fn login(
-    State(_st): State<Arc<ServerState>>,
+    State(st): State<Arc<ServerState>>,
     Path(name): Path<String>,
 ) -> Result<(), ApiError> {
     let p = provider::parse(&name)?;
-    provider::launch_login(p).await?;
+    provider::launch_login(p, st.engine.events.clone()).await?;
+    Ok(())
+}
+
+#[derive(serde::Deserialize)]
+struct LoginCode {
+    /// Verification code the user pasted from the OAuth callback page.
+    code: String,
+}
+
+async fn login_code(
+    State(_st): State<Arc<ServerState>>,
+    Path(name): Path<String>,
+    Json(body): Json<LoginCode>,
+) -> Result<(), ApiError> {
+    let p = provider::parse(&name)?;
+    provider::submit_login_code(p, &body.code).await?;
     Ok(())
 }
 

--- a/engine/houston-ui-events/src/lib.rs
+++ b/engine/houston-ui-events/src/lib.rs
@@ -157,6 +157,29 @@ pub enum HoustonEvent {
     /// Claude Code CLI install or upgrade failed. `message` is intended
     /// to be user-readable (network/region/permissions/disk-space hints).
     ClaudeCliFailed { message: String },
+
+    // ----- Provider OAuth login (URL relay) -----
+    //
+    // When the engine runs in a remote/headless context (container,
+    // Always-On VPS, future Cloud), the CLI can't open the user's
+    // browser — the browser is on a different machine entirely. Each
+    // CLI prints a fallback OAuth URL to stdout and waits for the
+    // verification code on stdin. These events surface that URL to
+    // the UI so the user can open it in their own browser and paste
+    // the code back through `POST /v1/providers/:name/login/code`.
+
+    /// A provider's OAuth login subprocess produced a sign-in URL.
+    /// Frontend should display it (and optionally `window.open` it)
+    /// plus a paste-code input that submits to the code-relay route.
+    ProviderLoginUrl { provider: String, url: String },
+    /// The OAuth subprocess exited. `success` reflects the exit
+    /// status; on failure, `error` is best-effort stderr/stdout.
+    /// Frontend closes the dialog and re-fetches `providerStatus`.
+    ProviderLoginComplete {
+        provider: String,
+        success: bool,
+        error: Option<String>,
+    },
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/core/src/types.ts
+++ b/ui/core/src/types.ts
@@ -119,4 +119,24 @@ export type HoustonEvent =
   | {
       type: "ComposioConnectionAdded";
       data: { toolkit: string };
+    }
+  | {
+      type: "ClaudeCliInstalling";
+      data: { progress_pct: number };
+    }
+  | {
+      type: "ClaudeCliReady";
+      data: Record<string, never>;
+    }
+  | {
+      type: "ClaudeCliFailed";
+      data: { message: string };
+    }
+  | {
+      type: "ProviderLoginUrl";
+      data: { provider: string; url: string };
+    }
+  | {
+      type: "ProviderLoginComplete";
+      data: { provider: string; success: boolean; error: string | null };
     };

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -453,6 +453,21 @@ export class HoustonClient {
     return this.request("POST", `/providers/${this.seg(name)}/logout`);
   }
   /**
+   * Submit the OAuth verification code the user pasted from their
+   * browser. Required for remote/headless engines (container,
+   * Always-On VPS, future Cloud) where the CLI can't open the user's
+   * browser itself: the engine surfaces the sign-in URL via the WS
+   * `ProviderLoginUrl` event, the UI displays it + a paste-code
+   * input, and this call writes the code back to the CLI's stdin so
+   * it can exchange for an OAuth token. The engine emits
+   * `ProviderLoginComplete` when the CLI exits.
+   */
+  submitProviderLoginCode(name: string, code: string): Promise<void> {
+    return this.request("POST", `/providers/${this.seg(name)}/login/code`, {
+      code,
+    });
+  }
+  /**
    * Persist a Gemini API key to `~/.gemini/.env`. The engine validates
    * the key shape, writes atomically, and chmods 0600 on Unix. The
    * next `providerStatus("gemini")` poll will return `Authenticated`

--- a/ui/engine-client/src/ws.ts
+++ b/ui/engine-client/src/ws.ts
@@ -21,6 +21,8 @@
  * - `agent:{agent_path}` — ActivityChanged, SkillsChanged, FilesChanged,
  *    ConfigChanged, ContextChanged, LearningsChanged, ConversationsChanged
  * - `composio` — ComposioCliReady, ComposioCliFailed, ComposioConnectionAdded
+ * - `claude` — ClaudeCliInstalling, ClaudeCliReady, ClaudeCliFailed
+ * - `providers` — ProviderLoginUrl, ProviderLoginComplete
  *
  * (The legacy `sync` topic was removed — mobile now uses the same WS
  * directly through the reverse tunnel.)
@@ -44,6 +46,8 @@ export const topics = {
   events: "events",
   scheduler: "scheduler",
   composio: "composio",
+  claude: "claude",
+  providers: "providers",
 } as const;
 
 type ReconnectHandler = () => void;


### PR DESCRIPTION
> **Stacks on top of #239.** This branch is built off `chore/k8s-setup` from #239 — merge that first, then this PR's diff against `main` will shrink to just the OAuth-relay + CLI-bundling changes below.

## Summary
- Houston UI can now complete provider OAuth against an engine running anywhere — desktop today, Docker container / Always-On VPS / Cloud tomorrow. Previously Connect Anthropic against a remote engine spun forever because the CLI's OAuth URL was buried in unread stdout.
- Engine streams the CLI's stdout, surfaces the URL via a new `HoustonEvent::ProviderLoginUrl`, accepts the user's verification code via `POST /v1/providers/:name/login/code`, and emits `ProviderLoginComplete` when the CLI exits. New `ProviderLoginDialog` shows the URL + paste-code form and auto-dismisses on completion.
- The `always-on/Dockerfile` also gains a `cli-tools` build stage that pre-installs Claude Code, Codex, and Composio — without this, an agent session in the container fails at provider spawn (`cli-deps.json` doesn't publish linux-x64 URLs, so runtime auto-install doesn't work).

## How it works
1. Engine spawns `claude auth login --claudeai` with `stdin=piped`.
2. 3-second early-failure probe (unchanged).
3. If still running, stdin handle stashed in a per-provider `LOGIN_SESSIONS` map; relay task takes stdout + stderr.
4. Relay sees first OAuth URL → emits `ProviderLoginUrl` over WS.
5. UI dialog appears. User completes OAuth in their browser, copies the code from `platform.claude.com/oauth/code/callback`, pastes into dialog.
6. `submitProviderLoginCode` → engine writes code to CLI's stdin.
7. CLI exchanges code, writes credential file, exits. Relay sees exit → emits `ProviderLoginComplete` → dialog closes, status poll flips chip to Connected.

## Bugs caught + fixed during code review
The first iteration shipped with bugs that a structured code review surfaced. All fixed before this PR:
- **stderr never drained** in the relay task — silent failures violated the no-silent-failures policy. Now read in parallel and appended to the failure message.
- **`LOGIN_SESSIONS.insert` overwrite** orphaned the first subprocess and let its delayed exit clobber the second session's map entry. Replaced with exclusive `insert_session` that rejects duplicates with an actionable error.
- **`submit_login_code` held the global mutex across `await stdin.write_all`** — could jam every provider operation under a slow write. Fixed via `Arc<Mutex<ChildStdin>>` so the inner write doesn't block the outer map.
- **URL regex captured trailing sentence punctuation** — `Visit https://example.com/auth.` produced `https://example.com/auth.` with a trailing period and broke OAuth state validation. Added a post-match trim.
- **No overall timeout** if stdout stayed open and the child never exited — process leak. Added a 10-minute hard ceiling that force-kills the subprocess.
- **`pendingId` never cleared on `ProviderLoginComplete{success: false}`** — UI stuck in pending state forever, 2-second status poll never stopped. Now cleared via functional setState.
- **`ProviderLoginComplete` handler always cleared the dialog** regardless of which provider the event named — cross-provider race. Now filtered by `ev.data.provider`.

Also extracted the new relay code from the already-oversize `provider/mod.rs` into a focused `provider/login_relay.rs` module per the 200-line file rule in `CLAUDE.md`.

## Tokio gotcha worth knowing
`tokio::process::Child::wait()` calls `drop(self.stdin.take())` internally to avoid the classic parent↔child deadlock. If you spawn with `stdin=piped` and then call `child.wait()`, **stdin is gone by the time wait returns** — even if `tokio::time::timeout` cancels the future. `launch_login` now takes stdin out of the child *before* the probe, holds it locally, then hands it to the session map only when the probe times out.

## Known follow-ups (not blocking)
- `POST /providers/:name/login/cancel` + UI Cancel button wiring. Today an abandoned sign-in stays alive until the 10-min ceiling. Acceptable for MVP because `insert_session` rejects duplicates with an actionable error.
- Suppressing the dialog on desktop (it pops briefly during the existing local-callback flow). Requires an engine deployment-mode signal set by the Tauri supervisor. Functionally correct as-is — dialog auto-closes on `ProviderLoginComplete`.
- Wiring the same URL relay into Gemini's `gemini_login.rs` ACP path so remote Gemini sign-in works too.
- Dialog UX when the CLI re-prompts instead of exiting on a bad code (no `ProviderLoginComplete` arrives, dialog stays in submitting state). Depends on real CLI behavior; ship if reported.

## Test plan
- [x] `pnpm tsc --noEmit` clean
- [x] `pnpm check-locales` reports `[es] OK / [pt] OK / All locales in sync`
- [x] `docker compose build engine` succeeds (unit tests run as part of the build, see `provider/login_relay.rs::tests`)
- [x] End-to-end against the containerised engine: clicked Connect Anthropic in the browser, dialog appeared with the OAuth URL, completed sign-in on claude.com, pasted code back, chip flipped to Connected
- [ ] Manual: try this on a `pnpm tauri dev` desktop build before tagging a release, to confirm the dialog UX regression is tolerable
- [ ] Manual: try Codex sign-in (haven't tested live; same code path as Anthropic so should work)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
