### PR TITLE
ci: bump GitHub Actions to Node 24 majors

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -26,7 +26,7 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Compute short SHA
         id: vars
@@ -45,15 +45,15 @@ jobs:
             echo "EOF"
           } >> "$GITHUB_OUTPUT"
 
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: always-on/Dockerfile

--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -23,7 +23,7 @@ jobs:
           - target: x86_64-apple-darwin
             os: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
@@ -40,7 +40,7 @@ jobs:
           cp target/${{ matrix.target }}/release/houston-engine \
             dist/houston-engine-${{ matrix.target }}
           chmod +x dist/houston-engine-${{ matrix.target }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: houston-engine-${{ matrix.target }}
           path: dist/*
@@ -52,11 +52,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true
-      - uses: softprops/action-gh-release@v2
+      - uses: softprops/action-gh-release@v3
         with:
           files: dist/*
           generate_release_notes: true
@@ -69,14 +69,14 @@ jobs:
       packages: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@v6
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v6
+      - uses: docker/build-push-action@v7
         with:
           context: .
           file: always-on/Dockerfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -142,7 +142,7 @@ jobs:
       # finalize, updater-manifest builder in build-macos) without each of
       # them re-running the notes-resolution logic on its own runner.
       - name: Upload release-notes.md artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-notes
           path: release-notes.md
@@ -154,7 +154,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full history + all tags so the release-notes step can diff
           # against the previous release tag (`git log <prev>..HEAD`).
@@ -164,10 +164,10 @@ jobs:
           fetch-tags: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -181,7 +181,7 @@ jobs:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache Rust artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -625,7 +625,7 @@ jobs:
       # step embeds the notes verbatim into latest.json so existing users
       # see the new-version description on the auto-update prompt.
       - name: Download release-notes.md artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-notes
 
@@ -771,16 +771,16 @@ jobs:
             runner: windows-11-arm
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           fetch-tags: true
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -794,7 +794,7 @@ jobs:
           targets: ${{ matrix.target }}
 
       - name: Cache Rust artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -998,7 +998,7 @@ jobs:
       GH_REPO: ${{ github.repository }}
     steps:
       - name: Download release-notes.md artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-notes
 


### PR DESCRIPTION
## Summary

- Bumps every action that bundles Node 20 to its latest Node 24 major across all three workflows.
- Silences the deprecation warning emitted on every CI run and stays ahead of GitHub's June 2 / Sept 16 2026 Node 20 removal.

## Bumps

| Action | From | To |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-node` | v4 | v6 |
| `actions/cache` | v4 | v5 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `pnpm/action-setup` | v4 | v6 |
| `docker/setup-buildx-action` | v3 | v4 |
| `docker/login-action` | v3 | v4 |
| `docker/build-push-action` | v6 | v7 |
| `softprops/action-gh-release` | v2 | v3 |

`dtolnay/rust-toolchain` + `tauri-apps/tauri-action` are composite/Docker, no Node bump needed.

## Files

- `.github/workflows/docker-publish.yml`
- `.github/workflows/engine-release.yml`
- `.github/workflows/release.yml`

## Breaking-change check

- `download-artifact` v5 changed path behavior for single artifact downloads **by ID** — we download **by name**, unaffected.
- `upload/download-artifact` v7/v8 added direct-upload + hash-mismatch-errors-by-default — transparent for our patterns; uploads and downloads are bumped together so artifact format stays consistent.
- `pnpm/action-setup` v6 adds pnpm v11 support (additive).
- `softprops/action-gh-release` v3 is Node 24 only — no API surface change.

YAML parses clean (`python3 -c "import yaml; yaml.safe_load(...)"`).

## Test plan

- [ ] Manually trigger `Docker Publish` from the Actions tab on `main` after merge — verify it pushes `ghcr.io/gethouston/houston-engine:latest` without the deprecation banner.
- [ ] Wait for the next tagged release (`v*`) to exercise `release.yml` end-to-end.
- [ ] Next `engine-v*` tag exercises `engine-release.yml`.

Closes #260