### PR TITLE
fix(claude-runner): disallow AskUserQuestion in headless -p mode

### DIFF
--- a/engine/houston-terminal-manager/src/claude_runner.rs
+++ b/engine/houston-terminal-manager/src/claude_runner.rs
@@ -149,6 +149,13 @@ fn configure_claude_command(
         cmd.arg("--allowedTools").arg("");
     } else {
         cmd.arg("--dangerously-skip-permissions");
+        // AskUserQuestion is Claude Code's stdin-driven interactive prompt
+        // tool. In `-p` (headless) mode there is no TTY, so the tool returns
+        // a no-op result and the user sees an empty tool block instead of
+        // the questions. Houston's UI has no bidirectional answer surface
+        // for it either — agents must ask via plain text in the assistant
+        // message, which is what the system prompt already instructs.
+        cmd.arg("--disallowedTools").arg("AskUserQuestion");
         if disable_builtin_tools {
             cmd.arg("--disallowedTools")
                 .arg("Edit")
@@ -220,5 +227,47 @@ mod tests {
             CliRunOutcome::Completed,
             Some("claude-session-id"),
         ));
+    }
+
+    fn collect_args(cmd: &Command) -> Vec<String> {
+        cmd.as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    #[test]
+    fn disallows_ask_user_question_by_default() {
+        // Headless `-p` mode has no TTY for AskUserQuestion's stdin
+        // prompt; without this flag the tool returns a no-op result and
+        // the UI shows an empty tool block. Agents must ask via plain
+        // text in the assistant message instead.
+        let mut cmd = Command::new("dummy");
+        configure_claude_command(&mut cmd, None, None, None, None, None, None, false, false);
+        let args = collect_args(&cmd);
+        assert!(args.iter().any(|a| a == "--disallowedTools"));
+        assert!(args.iter().any(|a| a == "AskUserQuestion"));
+    }
+
+    #[test]
+    fn disallows_ask_user_question_when_builtin_tools_disabled() {
+        let mut cmd = Command::new("dummy");
+        configure_claude_command(&mut cmd, None, None, None, None, None, None, true, false);
+        let args = collect_args(&cmd);
+        assert!(args.iter().any(|a| a == "AskUserQuestion"));
+        assert!(args.iter().any(|a| a == "Edit"));
+        assert!(args.iter().any(|a| a == "Write"));
+        assert!(args.iter().any(|a| a == "NotebookEdit"));
+    }
+
+    #[test]
+    fn disable_all_tools_skips_disallowed_list() {
+        // `--allowedTools ""` blocks every tool including AskUserQuestion,
+        // so the disallow list is redundant and not emitted.
+        let mut cmd = Command::new("dummy");
+        configure_claude_command(&mut cmd, None, None, None, None, None, None, false, true);
+        let args = collect_args(&cmd);
+        assert!(args.iter().any(|a| a == "--allowedTools"));
+        assert!(!args.iter().any(|a| a == "--disallowedTools"));
     }
 }


### PR DESCRIPTION
## Summary
- Always pass `--disallowedTools AskUserQuestion` to the claude CLI subprocess.
- `AskUserQuestion` expects a stdin/TTY prompt; in headless `-p` mode it returned an empty result, leaving the chat with two collapsed empty tool blocks and forcing the agent to text-ask anyway (the user-visible bug).
- Three new unit tests in `claude_runner::tests` pin the flag across both `disable_builtin_tools=false/true` and verify `disable_all_tools` correctly skips the disallow list.

## User impact
Before: Bookkeeper-style agents that wanted clarifying questions emitted two empty `AskUserQuestion` tool blocks, then re-asked in text — confusing double-ask.

After: agents go straight to text via the assistant message (which is what the system prompt already instructs).

## Test plan
- [x] `cargo test -p houston-terminal-manager --lib` — 197 tests pass including 3 new ones.
- [x] `cargo build -p houston-engine-server` — clean.
- [x] Rebuilt engine binary contains the literal: `strings target/debug/houston-engine | grep AskUserQuestion` → 1 match.
- [x] Standalone engine run against a real Bookkeeper agent — `ps` on the spawned claude shows `--disallowedTools AskUserQuestion`; persisted `chat_feed` shows `assistant_text=1, tool_call=0` with the agent's three questions in a single markdown response.

🤖 Generated with [Claude Code](https://claude.com/claude-code)