### PR TITLE
fix(skills): clear selection on agent switch to stop spurious not-found toast

### DIFF
--- a/app/src/components/tabs/use-skill-surface.ts
+++ b/app/src/components/tabs/use-skill-surface.ts
@@ -17,6 +17,13 @@ export function useSkillSurface(agentPath: string) {
   const { skillDetailLabels } = useSkillSurfaceLabels();
   const { data: summaries, isLoading: skillsLoading } = useSkills(agentPath);
   const [selectedSkillName, setSelectedSkillName] = useState<string | null>(null);
+  // Render-time reset on agent switch — a useEffect would race the
+  // auto-toast in `call()` because the stale-name fetch starts first.
+  const [prevAgentPath, setPrevAgentPath] = useState(agentPath);
+  if (agentPath !== prevAgentPath) {
+    setPrevAgentPath(agentPath);
+    setSelectedSkillName(null);
+  }
   const { data: skillDetail } = useSkillDetail(
     agentPath,
     selectedSkillName ?? undefined,


### PR DESCRIPTION
## Summary

Fixes #229.

Switching agents while a skill is open in the Skills tab would surface a spurious **"Skill not found"** toast.

## Root cause

- `app/src/components/shell/experience-renderer.tsx` uses `key={tab.id}` on the per-tab wrapper, so `SkillsTab` is **re-rendered** with a new `agent` prop rather than remounted on agent switch.
- `selectedSkillName` lives in `useState` inside `useSkillSurface`, so it survives that re-render.
- The next render calls `useSkillDetail(newAgentPath, staleSkillName)`. The engine returns `skill_not_found`, which the `call()` wrapper in `app/src/lib/tauri.ts` auto-toasts.

## Why not `useEffect`

A `useEffect(() => setSelectedSkillName(null), [agentPath])` looks tempting but is racy: the effect runs **after** the render that already triggered the stale-name fetch, so the rejected promise — and the toast — fire before the reset takes effect. `tauriSkills.load` does not pass an `AbortSignal`, so the in-flight call is not cancelable.

## Fix

Reset `selectedSkillName` synchronously **during render** when `agentPath` changes (React's prev-state-compare pattern). The query is never enabled with a stale name, so no fetch and no toast.

```ts
const [prevAgentPath, setPrevAgentPath] = useState(agentPath);
if (agentPath !== prevAgentPath) {
  setPrevAgentPath(agentPath);
  setSelectedSkillName(null);
}
```

Narrower than the alternative `key={\`${agent.folderPath}:${tab.id}\`}` on the wrapper, which would also reset unrelated tab state (chat scroll, board filters, etc.).

## Test plan

- [x] Open Agent A → Skills tab → click into a skill (detail view).
- [x] Switch to Agent B without saving. Expect: B's skills list, no toast.
- [x] Switch back to A. Expect: A's skills list, no toast.
- [x] Click into a skill on B, then switch to A — same expectation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)