### PR TITLE
feat(settings): advanced mode — context meter, chat + composer (A2 of 2)

### DIFF
--- a/app/src/components/FeatureGate.tsx
+++ b/app/src/components/FeatureGate.tsx
@@ -1,0 +1,32 @@
+/**
+ * `FeatureGate` — render `children` only when the named feature flag is on.
+ *
+ * Pattern (per `docs/plans/2026-05-22-houston-advanced-settings.html` §4):
+ *
+ *     <FeatureGate flag="advanced.git_panel">
+ *       <GitTab ... />
+ *     </FeatureGate>
+ *
+ *     <FeatureGate flag="advanced.git_panel" fallback={<EmptyHint />}>
+ *       <GitTab ... />
+ *     </FeatureGate>
+ *
+ * The fallback is what renders when the flag is off; default is `null` (nothing).
+ * Use a fallback to surface a one-time "Enable in Settings → Advanced" empty-state hint
+ * where it makes sense (rule: only when the user would actually want the feature).
+ */
+import type { ReactNode } from "react";
+import { useFeatureFlag } from "../hooks/useFeatureFlag";
+
+interface Props {
+  /** Flag key. e.g. `"advanced.git_panel"`. Must exist in `FLAG_REGISTRY`. */
+  flag: string;
+  children: ReactNode;
+  /** Rendered when the flag is off. Default: `null`. */
+  fallback?: ReactNode;
+}
+
+export function FeatureGate({ flag, children, fallback = null }: Props) {
+  const enabled = useFeatureFlag(flag);
+  return <>{enabled ? children : fallback}</>;
+}

--- a/app/src/components/context-meter-popover.tsx
+++ b/app/src/components/context-meter-popover.tsx
@@ -1,0 +1,169 @@
+/**
+ * `<ContextMeterPopover />` — the rich breakdown shown when the user clicks
+ * the composer-toolbar context wheel.
+ *
+ * Three blocks:
+ *   1. Header   — model name, used/max + percent, progress bar
+ *   2. Breakdown — per-category token estimates (heuristic) + Free space
+ *   3. Metrics  — turn count, total duration, cost (Claude only),
+ *                 cache-hit rate (Claude only), tool calls, file changes
+ *
+ * The breakdown is intentionally explicit about its estimation: when the
+ * latest `FinalResult` carried real `input_tokens`, the meter total is
+ * authoritative; the per-row split is still a chars/4 estimate. Surfaced
+ * via the "estimated" footnote.
+ */
+import { useTranslation } from "react-i18next";
+import { formatTokens } from "../lib/model-limits";
+import type { ContextStats } from "../hooks/use-context-stats";
+
+interface Props {
+  stats: ContextStats;
+  provider: string | null | undefined;
+  model: string | null | undefined;
+}
+
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${ms}ms`;
+  const s = ms / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rem = Math.round(s % 60);
+  return `${m}m ${rem}s`;
+}
+
+function formatCost(usd: number): string {
+  if (usd < 0.01) return `$${usd.toFixed(4)}`;
+  if (usd < 1) return `$${usd.toFixed(3)}`;
+  return `$${usd.toFixed(2)}`;
+}
+
+function thresholdBg(pct: number): string {
+  if (pct >= 90) return "bg-red-500";
+  if (pct >= 70) return "bg-yellow-500";
+  return "bg-primary";
+}
+
+export function ContextMeterPopover({ stats, provider, model }: Props) {
+  const { t } = useTranslation("chat");
+  const pct = Math.min(stats.usagePercent, 100);
+  const modelLabel = [provider, model].filter(Boolean).join(" · ") || "—";
+
+  return (
+    <div className="flex flex-col gap-3 p-4">
+      {/* Header */}
+      <div>
+        <div className="flex items-baseline justify-between gap-2">
+          <h3 className="text-sm font-semibold">{t("contextMeter.title")}</h3>
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {formatTokens(stats.usedTokens)} / {formatTokens(stats.maxTokens)}
+          </span>
+        </div>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">{modelLabel}</p>
+        <div className="mt-2 h-1.5 w-full rounded-full bg-secondary overflow-hidden">
+          <div
+            className={`h-full ${thresholdBg(pct)} transition-all`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Breakdown */}
+      <div className="flex flex-col gap-1">
+        <BreakdownLine
+          label={t("contextMeter.breakdown.free")}
+          tokens={stats.freeTokens}
+          percent={stats.freePercent}
+          muted
+        />
+        {stats.breakdown
+          .filter((row) => row.tokens > 0)
+          .sort((a, b) => b.tokens - a.tokens)
+          .map((row) => (
+            <BreakdownLine
+              key={row.key}
+              label={t(`contextMeter.breakdown.${row.key}` as never)}
+              tokens={row.tokens}
+              percent={row.percent}
+            />
+          ))}
+        {!stats.hasRealData && (
+          <p className="mt-1 text-[10px] italic text-muted-foreground">
+            {t("contextMeter.estimatedNote")}
+          </p>
+        )}
+      </div>
+
+      {/* Other metrics */}
+      <div className="border-t border-border pt-3 grid grid-cols-2 gap-x-3 gap-y-1 text-xs">
+        <Metric
+          label={t("contextMeter.metrics.turns")}
+          value={String(stats.turnCount)}
+        />
+        <Metric
+          label={t("contextMeter.metrics.duration")}
+          value={
+            stats.totalDurationMs > 0 ? formatDuration(stats.totalDurationMs) : "—"
+          }
+        />
+        <Metric
+          label={t("contextMeter.metrics.cost")}
+          value={stats.totalCostUsd > 0 ? formatCost(stats.totalCostUsd) : "—"}
+        />
+        <Metric
+          label={t("contextMeter.metrics.cacheHit")}
+          value={
+            stats.cacheHitRate != null
+              ? `${Math.round(stats.cacheHitRate * 100)}%`
+              : "—"
+          }
+        />
+        <Metric
+          label={t("contextMeter.metrics.toolCalls")}
+          value={String(stats.toolCallCount)}
+        />
+        <Metric
+          label={t("contextMeter.metrics.fileChanges")}
+          value={String(stats.fileChangeCount)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function BreakdownLine({
+  label,
+  tokens,
+  percent,
+  muted = false,
+}: {
+  label: string;
+  tokens: number;
+  percent: number;
+  muted?: boolean;
+}) {
+  return (
+    <div
+      className={`flex items-baseline justify-between text-[11px] tabular-nums ${
+        muted ? "text-muted-foreground" : "text-foreground"
+      }`}
+    >
+      <span>{label}</span>
+      <span className="text-muted-foreground">
+        {formatTokens(tokens)}{" "}
+        <span className="opacity-60">({percent.toFixed(1)}%)</span>
+      </span>
+    </div>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex flex-col">
+      <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+        {label}
+      </span>
+      <span className="font-medium tabular-nums">{value}</span>
+    </div>
+  );
+}

--- a/app/src/components/context-meter.tsx
+++ b/app/src/components/context-meter.tsx
@@ -1,0 +1,97 @@
+/**
+ * `<ContextMeter />` — composer-toolbar widget showing context-window usage.
+ *
+ * Gated by the `advanced.context_meter` flag (Phase 2 of RFC #248). A small
+ * SVG donut + numeric readout; clicking opens a popover with the full
+ * breakdown (`<ContextMeterPopover />`).
+ *
+ * Drives off `useContextStats(feedItems, provider, model)`; threshold colors
+ * shift from neutral → yellow at 70% → red at 90%.
+ */
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Popover, PopoverTrigger, PopoverContent } from "@houston-ai/core";
+import type { FeedItem } from "@houston-ai/chat";
+import { useContextStats } from "../hooks/use-context-stats";
+import { ContextMeterPopover } from "./context-meter-popover";
+import { formatTokens } from "../lib/model-limits";
+
+interface Props {
+  feedItems: FeedItem[];
+  provider: string | null | undefined;
+  model: string | null | undefined;
+}
+
+const SIZE = 14;
+const STROKE = 2.5;
+const RADIUS = (SIZE - STROKE) / 2;
+const CIRC = 2 * Math.PI * RADIUS;
+
+function thresholdColor(pct: number): string {
+  if (pct >= 90) return "stroke-red-500";
+  if (pct >= 70) return "stroke-yellow-500";
+  return "stroke-primary";
+}
+
+export function ContextMeter({ feedItems, provider, model }: Props) {
+  const { t } = useTranslation("chat");
+  const stats = useContextStats(feedItems, provider, model);
+  const [open, setOpen] = useState(false);
+
+  const pct = Math.min(stats.usagePercent, 100);
+  const dash = (pct / 100) * CIRC;
+  const remainder = CIRC - dash;
+  const usedDisplay = formatTokens(stats.usedTokens);
+  const maxDisplay = formatTokens(stats.maxTokens);
+  const tooltip = t("contextMeter.tooltip", {
+    used: usedDisplay,
+    max: maxDisplay,
+    percent: Math.round(pct),
+  });
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          title={tooltip}
+          aria-label={tooltip}
+          className="flex items-center gap-1.5 px-1.5 py-1 rounded-md text-muted-foreground hover:text-foreground hover:bg-accent transition-colors"
+        >
+          <svg width={SIZE} height={SIZE} viewBox={`0 0 ${SIZE} ${SIZE}`}>
+            <circle
+              cx={SIZE / 2}
+              cy={SIZE / 2}
+              r={RADIUS}
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={STROKE}
+              className="opacity-25"
+            />
+            <circle
+              cx={SIZE / 2}
+              cy={SIZE / 2}
+              r={RADIUS}
+              fill="none"
+              strokeWidth={STROKE}
+              strokeDasharray={`${dash} ${remainder}`}
+              transform={`rotate(-90 ${SIZE / 2} ${SIZE / 2})`}
+              className={`${thresholdColor(pct)} transition-all`}
+              strokeLinecap="round"
+            />
+          </svg>
+          <span className="text-xs font-medium tabular-nums">
+            {usedDisplay}
+          </span>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="end" sideOffset={8} className="w-80 p-0">
+        <ContextMeterPopover
+          stats={stats}
+          provider={provider}
+          model={model}
+        />
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/src/components/settings/sections/advanced.tsx
+++ b/app/src/components/settings/sections/advanced.tsx
@@ -1,0 +1,190 @@
+/**
+ * Advanced settings section.
+ *
+ * Phase 0 ships this with `FLAG_REGISTRY` empty, so the section renders an
+ * empty-state placeholder and a disabled "Reset all" button. Subsequent
+ * phases each add one entry to the registry; this component then iterates
+ * `Object.values(FLAG_REGISTRY)` to render a toggle row per flag with
+ * label / description / switch wired through `useFeatureFlagToggle`.
+ */
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Switch } from "@houston-ai/core";
+import { tauriPreferences } from "../../../lib/tauri";
+import {
+  FLAG_REGISTRY,
+  flagToString,
+  getFlagDefault,
+  stringToFlag,
+  type FlagDef,
+} from "../../../lib/featureFlags";
+
+export function AdvancedSection() {
+  const { t } = useTranslation("settings");
+  const flags = Object.values(FLAG_REGISTRY);
+  const isEmpty = flags.length === 0;
+  const [confirmingReset, setConfirmingReset] = useState(false);
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-1">{t("advanced.title")}</h2>
+      <p className="text-sm text-muted-foreground mb-6">
+        {t("advanced.description")}
+      </p>
+
+      {isEmpty ? (
+        <div className="rounded-xl border border-border bg-card px-4 py-6 text-sm text-muted-foreground">
+          {t("advanced.empty")}
+        </div>
+      ) : (
+        <ul className="flex flex-col gap-3">
+          {flags.map((flag) => (
+            <FlagRow key={flag.key} flag={flag} />
+          ))}
+        </ul>
+      )}
+
+      <div className="mt-8 pt-6 border-t border-border">
+        <button
+          type="button"
+          onClick={() => setConfirmingReset(true)}
+          disabled={isEmpty}
+          className="text-sm text-muted-foreground hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          {t("advanced.resetAll")}
+        </button>
+      </div>
+
+      {confirmingReset && !isEmpty && (
+        <ResetAllDialog onClose={() => setConfirmingReset(false)} />
+      )}
+    </section>
+  );
+}
+
+/**
+ * A single flag toggle row. TanStack Query `useMutation` with optimistic
+ * update + rollback on error. `tauriPreferences.set` surfaces its own
+ * toast on failure via the `call()` wrapper in `tauri.ts`, so the
+ * mutation only needs to handle the cache rollback.
+ */
+function FlagRow({ flag }: { flag: FlagDef }) {
+  const { t } = useTranslation("settings");
+  const qc = useQueryClient();
+  const queryKey = ["preference", flag.key] as const;
+
+  const query = useQuery({
+    queryKey,
+    queryFn: () => tauriPreferences.get(flag.key),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (next: boolean) => {
+      await tauriPreferences.set(flag.key, flagToString(next));
+      return next;
+    },
+    onMutate: async (next: boolean) => {
+      await qc.cancelQueries({ queryKey });
+      const previous = qc.getQueryData<string | null>(queryKey);
+      qc.setQueryData<string | null>(queryKey, flagToString(next));
+      return { previous };
+    },
+    onError: (_err, _next, ctx) => {
+      if (ctx) qc.setQueryData(queryKey, ctx.previous);
+    },
+    onSettled: () => {
+      void qc.invalidateQueries({ queryKey });
+    },
+  });
+
+  const stored = stringToFlag(query.data);
+  const enabled = stored ?? getFlagDefault(flag.key);
+
+  return (
+    <li className="rounded-xl border border-border bg-card px-4 py-3">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-medium text-foreground">
+            {t(flag.labelKey as never)}
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {t(flag.descriptionKey as never)}
+          </p>
+        </div>
+        <Switch
+          checked={enabled}
+          onCheckedChange={(next) => mutation.mutate(next)}
+          disabled={mutation.isPending}
+          aria-label={t(flag.labelKey as never)}
+        />
+      </div>
+    </li>
+  );
+}
+
+/**
+ * "Reset all" confirmation. Wipes every advanced.* key by writing the empty
+ * string back to storage (preferences route has no DELETE handler today; an
+ * empty string is parsed as unset by `stringToFlag`, falling through to the
+ * code default — which is the desired reset behavior).
+ */
+function ResetAllDialog({ onClose }: { onClose: () => void }) {
+  const { t } = useTranslation(["settings", "common"]);
+  const qc = useQueryClient();
+  const flags = Object.values(FLAG_REGISTRY);
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      for (const flag of flags) {
+        await tauriPreferences.set(flag.key, "");
+      }
+    },
+    onSuccess: () => {
+      for (const flag of flags) {
+        void qc.invalidateQueries({ queryKey: ["preference", flag.key] });
+      }
+      onClose();
+    },
+  });
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="w-full max-w-sm rounded-xl border border-border bg-background p-5 shadow-lg">
+        <h3 className="text-base font-semibold mb-1">
+          {t("advanced.resetConfirmTitle")}
+        </h3>
+        <p className="text-sm text-muted-foreground mb-5">
+          {t("advanced.resetConfirmDescription")}
+        </p>
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={mutation.isPending}
+            className="px-3 py-1.5 text-sm rounded-md text-muted-foreground hover:text-foreground transition-colors"
+          >
+            {t("common:actions.cancel")}
+          </button>
+          <button
+            type="button"
+            onClick={() => mutation.mutate()}
+            disabled={mutation.isPending}
+            className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors disabled:opacity-50"
+          >
+            {t("advanced.resetConfirmLabel")}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/settings/settings-view.tsx
+++ b/app/src/components/settings/settings-view.tsx
@@ -1,7 +1,16 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Spinner } from "@houston-ai/core";
-import { User, Smartphone, Folder, Bot, Bug, FileText, UserCircle } from "lucide-react";
+import {
+  User,
+  Smartphone,
+  Folder,
+  Bot,
+  Bug,
+  FileText,
+  UserCircle,
+  SlidersHorizontal,
+} from "lucide-react";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { useUIStore } from "../../stores/ui";
 import {
@@ -15,6 +24,7 @@ type SettingsSectionId =
   | "workspaceContext"
   | "userContext"
   | "provider"
+  | "advanced"
   | "phone"
   | "reportBug";
 import { AccountSection, useAccountAvailable } from "./sections/account";
@@ -28,6 +38,7 @@ import { ProviderSection } from "./sections/provider";
 import { TimezoneSection } from "./sections/timezone";
 import { LanguageSection } from "./sections/language";
 import { AppearanceSection } from "./sections/appearance";
+import { AdvancedSection } from "./sections/advanced";
 import { DangerSection } from "./sections/danger";
 import { ReportBugSection } from "./sections/report-bug";
 
@@ -68,6 +79,12 @@ export function SettingsView() {
         icon: UserCircle,
       },
       { id: "provider", label: t("settings:nav.provider"), icon: Bot },
+      {
+        id: "advanced",
+        label: t("settings:nav.advanced"),
+        icon: SlidersHorizontal,
+        beta: true,
+      },
       { id: "phone", label: t("settings:nav.phone"), icon: Smartphone, beta: true },
       { id: "reportBug", label: t("settings:nav.reportBug"), icon: Bug },
     );
@@ -124,6 +141,7 @@ export function SettingsView() {
               </div>
             )}
             {activeVisible === "provider" && <ProviderSection />}
+            {activeVisible === "advanced" && <AdvancedSection />}
             {activeVisible === "phone" && <ConnectPhoneSection />}
             {activeVisible === "reportBug" && <ReportBugSection />}
           </div>

--- a/app/src/components/tabs/chat-tab.tsx
+++ b/app/src/components/tabs/chat-tab.tsx
@@ -30,6 +30,8 @@ import { analytics } from "../../lib/analytics";
 import type { TabProps } from "../../lib/types";
 import { HoustonThinkingIndicator } from "../shell/experience-card";
 import { ChatModelSelector } from "../chat-model-selector";
+import { ContextMeter } from "../context-meter";
+import { FeatureGate } from "../FeatureGate";
 import { Paperclip } from "lucide-react";
 import { useChatDisplayLabels } from "../use-chat-display-labels";
 import { getDefaultModel, PROVIDERS } from "../../lib/providers";
@@ -361,12 +363,21 @@ export default function ChatTab({ agent }: TabProps) {
         onRemoveQueuedMessage={messageQueue.removeQueuedMessage}
         queuedLabels={queuedLabels}
         footer={
-          <ChatModelSelector
-            provider={effectiveProvider}
-            model={effectiveModel}
-            onSelect={handleModelSelect}
-            lockedProvider={visibleFeedItems.length > 0 ? effectiveProvider : null}
-          />
+          <div className="flex items-center gap-1.5">
+            <ChatModelSelector
+              provider={effectiveProvider}
+              model={effectiveModel}
+              onSelect={handleModelSelect}
+              lockedProvider={visibleFeedItems.length > 0 ? effectiveProvider : null}
+            />
+            <FeatureGate flag="advanced.context_meter">
+              <ContextMeter
+                feedItems={visibleFeedItems}
+                provider={effectiveProvider}
+                model={effectiveModel}
+              />
+            </FeatureGate>
+          </div>
         }
         attachMenu={({ openFilePicker }) => (
           <div className="flex flex-col gap-0.5">

--- a/app/src/components/tabs/configure-sections.tsx
+++ b/app/src/components/tabs/configure-sections.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { tauriConfig } from "../../lib/tauri";
 import { queryKeys } from "../../lib/query-keys";
+import { FeatureGate } from "../FeatureGate";
 
 // ── Section wrapper ──────────────────────────────────────────────
 
@@ -95,28 +96,30 @@ export function SettingsForm({ agentPath, config }: { agentPath: string; config:
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="flex items-center justify-between">
-        <div>
-          <label className="text-xs font-medium text-muted-foreground block">{t("configure.settings.worktreeMode")}</label>
-          <span className="text-xs text-muted-foreground/60">{t("configure.settings.worktreeModeDescription")}</span>
-        </div>
-        <button
-          onClick={() => {
-            const next = !worktreeMode;
-            setWorktreeMode(next);
-            saveConfig({ worktreeMode: next });
-          }}
-          className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ${
-            worktreeMode ? "bg-primary" : "bg-muted"
-          }`}
-        >
-          <span
-            className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform duration-200 ${
-              worktreeMode ? "translate-x-4" : "translate-x-0"
+      <FeatureGate flag="advanced.worktrees">
+        <div className="flex items-center justify-between">
+          <div>
+            <label className="text-xs font-medium text-muted-foreground block">{t("configure.settings.worktreeMode")}</label>
+            <span className="text-xs text-muted-foreground/60">{t("configure.settings.worktreeModeDescription")}</span>
+          </div>
+          <button
+            onClick={() => {
+              const next = !worktreeMode;
+              setWorktreeMode(next);
+              saveConfig({ worktreeMode: next });
+            }}
+            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ${
+              worktreeMode ? "bg-primary" : "bg-muted"
             }`}
-          />
-        </button>
-      </div>
+          >
+            <span
+              className={`pointer-events-none inline-block h-4 w-4 rounded-full bg-white shadow transition-transform duration-200 ${
+                worktreeMode ? "translate-x-4" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
+      </FeatureGate>
       <div>
         <label className="text-xs font-medium text-muted-foreground block mb-1.5">{t("configure.settings.installCommand")}</label>
         <input

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -66,6 +66,8 @@ import {
   isComposioSigninHref,
 } from "./composio-signin-card";
 import { ChatModelSelector } from "./chat-model-selector";
+import { ContextMeter } from "./context-meter";
+import { FeatureGate } from "./FeatureGate";
 import { getDefaultModel, validModelOrNull } from "../lib/providers";
 import { analytics } from "../lib/analytics";
 import {
@@ -537,7 +539,7 @@ export function useAgentChatPanel({
 
   const footer = useMemo<AIBoardProps["footer"]>(() => {
     if (!agent) return undefined;
-    return ({ hasMessages }) => (
+    return ({ hasMessages, feedItems }) => (
       <div className="flex items-center gap-2 w-full">
         <button
           type="button"
@@ -554,6 +556,13 @@ export function useAgentChatPanel({
           onSelect={handleModelSelect}
           lockedProvider={hasMessages ? effectiveProvider : null}
         />
+        <FeatureGate flag="advanced.context_meter">
+          <ContextMeter
+            feedItems={feedItems}
+            provider={effectiveProvider}
+            model={effectiveModel}
+          />
+        </FeatureGate>
       </div>
     );
   }, [agent, t, effectiveProvider, effectiveModel, handleModelSelect]);

--- a/app/src/hooks/use-agent-invalidation.ts
+++ b/app/src/hooks/use-agent-invalidation.ts
@@ -38,6 +38,13 @@ export function useAgentInvalidation() {
           qc.invalidateQueries({ queryKey: queryKeys.conversations(p.data.agent_path) });
           qc.invalidateQueries({ queryKey: ["all-conversations"] });
           break;
+        case "PreferenceChanged":
+          // Cross-tab / cross-client preference invalidation. Every
+          // `useFeatureFlag(key)` call keys its query by `["preference", key]`,
+          // so invalidating that key triggers a re-fetch on every listening
+          // hook (rule 7 in `knowledge-base/feature-flags.md`).
+          qc.invalidateQueries({ queryKey: ["preference", p.data.key] });
+          break;
         case "RoutinesChanged":
           qc.invalidateQueries({ queryKey: queryKeys.routines(p.data.agent_path) });
           break;

--- a/app/src/hooks/use-context-stats.ts
+++ b/app/src/hooks/use-context-stats.ts
@@ -1,0 +1,168 @@
+/**
+ * `useContextStats` — derives the data behind `<ContextMeter />` from a chat
+ * session's feed items. Authoritative `input_tokens` come from the latest
+ * `FinalResult` (provider-reported, chronologically last wins); the
+ * per-category breakdown is estimated via a chars/4 heuristic over feed-item
+ * payloads. Truth + best-effort detail in one hook.
+ *
+ * Phase 2 of RFC #248 / `advanced.context_meter`.
+ */
+import { useMemo } from "react";
+import type { FeedItem } from "@houston-ai/chat";
+import { getContextLimit } from "../lib/model-limits";
+
+const CHARS_PER_TOKEN = 4;
+
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / CHARS_PER_TOKEN);
+}
+
+export interface BreakdownRow {
+  /** Stable i18n key suffix (see `composer.contextMeter.breakdown.<key>`). */
+  key:
+    | "user_messages"
+    | "assistant_messages"
+    | "thinking"
+    | "tool_input"
+    | "tool_output"
+    | "system";
+  tokens: number;
+  percent: number;
+}
+
+export interface ContextStats {
+  /** Context fill the model actually saw last turn. Falls back to the
+   *  estimated sum when no `FinalResult` has token data yet. */
+  usedTokens: number;
+  /** Model's documented context window (or FALLBACK_CONTEXT_LIMIT). */
+  maxTokens: number;
+  /** `usedTokens / maxTokens * 100`, NOT clamped — the popover can decide. */
+  usagePercent: number;
+  /** True when at least one `FinalResult` carried `input_tokens`. */
+  hasRealData: boolean;
+  breakdown: BreakdownRow[];
+  freeTokens: number;
+  freePercent: number;
+  turnCount: number;
+  totalDurationMs: number;
+  totalCostUsd: number;
+  /** `cache_read_input_tokens / input_tokens` from the latest `FinalResult`,
+   *  or null when not provided. */
+  cacheHitRate: number | null;
+  toolCallCount: number;
+  fileChangeCount: number;
+}
+
+export function useContextStats(
+  feedItems: FeedItem[],
+  provider: string | null | undefined,
+  model: string | null | undefined,
+): ContextStats {
+  return useMemo(() => {
+    const maxTokens = getContextLimit(provider, model);
+
+    let latestUsed = 0;
+    let hasRealData = false;
+    let cacheHitRate: number | null = null;
+    let totalCostUsd = 0;
+    let totalDurationMs = 0;
+    let turnCount = 0;
+
+    let userTokens = 0;
+    let assistantTokens = 0;
+    let thinkingTokens = 0;
+    let toolInputTokens = 0;
+    let toolOutputTokens = 0;
+    let systemTokens = 0;
+    let toolCallCount = 0;
+    let fileChangeCount = 0;
+
+    for (const item of feedItems) {
+      switch (item.feed_type) {
+        case "user_message":
+          userTokens += estimateTokens(item.data);
+          break;
+        case "assistant_text":
+        case "assistant_text_streaming":
+          assistantTokens += estimateTokens(item.data);
+          break;
+        case "thinking":
+        case "thinking_streaming":
+          thinkingTokens += estimateTokens(item.data);
+          break;
+        case "system_message":
+          systemTokens += estimateTokens(item.data);
+          break;
+        case "tool_call":
+          toolInputTokens += estimateTokens(JSON.stringify(item.data.input));
+          toolCallCount += 1;
+          break;
+        case "tool_result":
+          toolOutputTokens += estimateTokens(item.data.content);
+          break;
+        case "file_changes":
+          fileChangeCount += 1;
+          break;
+        case "final_result":
+          turnCount += 1;
+          if (item.data.cost_usd != null) totalCostUsd += item.data.cost_usd;
+          if (item.data.duration_ms != null) totalDurationMs += item.data.duration_ms;
+          if (item.data.input_tokens != null) {
+            latestUsed = item.data.input_tokens;
+            hasRealData = true;
+            if (
+              item.data.cache_read_input_tokens != null &&
+              item.data.input_tokens > 0
+            ) {
+              cacheHitRate =
+                item.data.cache_read_input_tokens / item.data.input_tokens;
+            }
+          }
+          break;
+      }
+    }
+
+    const estimatedSum =
+      userTokens +
+      assistantTokens +
+      thinkingTokens +
+      toolInputTokens +
+      toolOutputTokens +
+      systemTokens;
+    const usedTokens = hasRealData ? latestUsed : estimatedSum;
+
+    const seeds: BreakdownRow[] = [
+      { key: "user_messages", tokens: userTokens, percent: 0 },
+      { key: "assistant_messages", tokens: assistantTokens, percent: 0 },
+      { key: "thinking", tokens: thinkingTokens, percent: 0 },
+      { key: "tool_input", tokens: toolInputTokens, percent: 0 },
+      { key: "tool_output", tokens: toolOutputTokens, percent: 0 },
+      { key: "system", tokens: systemTokens, percent: 0 },
+    ];
+    const breakdown: BreakdownRow[] = seeds.map((b) => ({
+      key: b.key,
+      tokens: b.tokens,
+      percent: usedTokens > 0 ? (b.tokens / usedTokens) * 100 : 0,
+    }));
+
+    const freeTokens = Math.max(0, maxTokens - usedTokens);
+    const freePercent = (freeTokens / maxTokens) * 100;
+    const usagePercent = (usedTokens / maxTokens) * 100;
+
+    return {
+      usedTokens,
+      maxTokens,
+      usagePercent,
+      hasRealData,
+      breakdown,
+      freeTokens,
+      freePercent,
+      turnCount,
+      totalDurationMs,
+      totalCostUsd,
+      cacheHitRate,
+      toolCallCount,
+      fileChangeCount,
+    };
+  }, [feedItems, provider, model]);
+}

--- a/app/src/hooks/use-context-stats.ts
+++ b/app/src/hooks/use-context-stats.ts
@@ -27,6 +27,8 @@ export interface BreakdownRow {
     | "tool_output"
     | "system";
   tokens: number;
+  /** Percent of the model's context window (NOT of usedTokens) — so this
+   *  row plus `freePercent` plus the other rows sum to ~100%. */
   percent: number;
 }
 
@@ -139,10 +141,15 @@ export function useContextStats(
       { key: "tool_output", tokens: toolOutputTokens, percent: 0 },
       { key: "system", tokens: systemTokens, percent: 0 },
     ];
+    // Both Free and the per-category rows report `% of context window` so
+    // that they sum to ~100% in the popover (matches Claude Code's
+    // reference behavior in the user-supplied screenshot). Using % of
+    // `usedTokens` would have made small categories visually dominate and
+    // would have prevented Free + categories from sharing a y-axis.
     const breakdown: BreakdownRow[] = seeds.map((b) => ({
       key: b.key,
       tokens: b.tokens,
-      percent: usedTokens > 0 ? (b.tokens / usedTokens) * 100 : 0,
+      percent: maxTokens > 0 ? (b.tokens / maxTokens) * 100 : 0,
     }));
 
     const freeTokens = Math.max(0, maxTokens - usedTokens);

--- a/app/src/hooks/use-houston-init.ts
+++ b/app/src/hooks/use-houston-init.ts
@@ -5,6 +5,7 @@ import { useWorkspaceStore } from "../stores/workspaces";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
 import { analytics } from "../lib/analytics";
+import { runFlagMigrations } from "../lib/featureFlags";
 
 /**
  * App initialization hook. Called once in App.tsx.
@@ -23,6 +24,15 @@ export function useHoustonInit() {
     initRef.current = true;
 
     async function init() {
+      // Apply any pending feature-flag migrations before anything else reads
+      // preferences. Idempotent; phase 0 ships with `FLAG_MIGRATIONS` empty
+      // so this is a no-op until a future rename or delete lands.
+      try {
+        await runFlagMigrations();
+      } catch (e) {
+        console.error("[init] flag migrations failed:", e);
+      }
+
       await loadConfigs();
       await loadWorkspaces();
 

--- a/app/src/hooks/useFeatureFlag.ts
+++ b/app/src/hooks/useFeatureFlag.ts
@@ -1,0 +1,97 @@
+/**
+ * `useFeatureFlag` — five-layer resolution of an advanced-settings flag.
+ *
+ * Resolution chain (top wins):
+ *   1. URL query: `?flag.<key>=on|off|true|false`   — DEV only
+ *   2. `window.__HOUSTON_FLAGS_OVERRIDE__[key]`     — DEV only
+ *   3. `localStorage["flag.<key>"]`                  — DEV only
+ *   4. Engine preference (`/v1/preferences/:key`)   — production source of truth
+ *   5. `getFlagDefault(key)` from the registry       — code default
+ *
+ * Layers 1-3 are wrapped in `import.meta.env.DEV` so they're stripped from
+ * production bundles by Vite's dead-code elimination. Production users only
+ * see layers 4 and 5.
+ *
+ * Caching: TanStack Query, 60s stale time, `refetchOnWindowFocus: false`.
+ * Cross-tab / cross-client invalidation arrives via the `PreferenceChanged`
+ * WS event handled in `use-agent-invalidation.ts`.
+ */
+import { useQuery } from "@tanstack/react-query";
+import { tauriPreferences } from "../lib/tauri";
+import { getFlagDefault, stringToFlag } from "../lib/featureFlags";
+
+declare global {
+  interface Window {
+    /** DEV-only flag override map. Set in DevTools console for ad-hoc testing. */
+    __HOUSTON_FLAGS_OVERRIDE__?: Record<string, string | boolean | undefined>;
+  }
+}
+
+/** Normalize a developer-supplied override token to a boolean, or `null` if unrecognized. */
+function parseOverride(raw: string | boolean | null | undefined): boolean | null {
+  if (raw === true || raw === false) return raw;
+  if (raw === null || raw === undefined) return null;
+  const v = raw.toLowerCase();
+  if (v === "true" || v === "on" || v === "1") return true;
+  if (v === "false" || v === "off" || v === "0") return false;
+  return null;
+}
+
+/** Layer 1: URL query parameter. Returns `null` outside dev or when absent. */
+function readUrlOverride(key: string): boolean | null {
+  if (!import.meta.env.DEV) return null;
+  if (typeof window === "undefined") return null;
+  try {
+    const params = new URLSearchParams(window.location.search);
+    return parseOverride(params.get(`flag.${key}`));
+  } catch {
+    return null;
+  }
+}
+
+/** Layer 2: `window.__HOUSTON_FLAGS_OVERRIDE__`. Returns `null` outside dev or when absent. */
+function readWindowOverride(key: string): boolean | null {
+  if (!import.meta.env.DEV) return null;
+  if (typeof window === "undefined") return null;
+  return parseOverride(window.__HOUSTON_FLAGS_OVERRIDE__?.[key]);
+}
+
+/** Layer 3: localStorage. Returns `null` outside dev, when absent, or when storage throws. */
+function readLocalStorageOverride(key: string): boolean | null {
+  if (!import.meta.env.DEV) return null;
+  if (typeof window === "undefined") return null;
+  try {
+    return parseOverride(window.localStorage.getItem(`flag.${key}`));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve a feature flag to a boolean. Suspends the component on first
+ * fetch (returns the default until the query settles), then reflects the
+ * persisted value. Re-renders on local toggle (cache invalidation) and on
+ * `PreferenceChanged` WS events (cross-tab invalidation).
+ */
+export function useFeatureFlag(key: string): boolean {
+  const urlOverride = readUrlOverride(key);
+  const windowOverride = readWindowOverride(key);
+  const localStorageOverride = readLocalStorageOverride(key);
+
+  const query = useQuery({
+    queryKey: ["preference", key] as const,
+    queryFn: () => tauriPreferences.get(key),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
+    // Engine read failures degrade silently (rule 8: reads degrade, writes
+    // alert). The `tauriPreferences.get` call already logs internally.
+  });
+
+  // Walk the chain. First non-null layer wins.
+  if (urlOverride !== null) return urlOverride;
+  if (windowOverride !== null) return windowOverride;
+  if (localStorageOverride !== null) return localStorageOverride;
+  const stored = stringToFlag(query.data);
+  if (stored !== null) return stored;
+  return getFlagDefault(key);
+}

--- a/app/src/lib/featureFlags.ts
+++ b/app/src/lib/featureFlags.ts
@@ -47,12 +47,24 @@ export interface FlagDef {
 }
 
 /**
- * The flag registry. Phase 0 ships this empty by design — every subsequent
- * phase adds exactly one entry here plus the locale strings under
- * `advanced.flags.<key>.{label,description}` in en/es/pt.
+ * The flag registry. Each entry pairs with locale strings under
+ * `advanced.flags.<key>.{label,description}` in en/es/pt and a knowledge-base
+ * write-up at `knowledge-base/advanced-<learnMoreSlug>.md`.
  */
-// biome-ignore lint/complexity/noBannedTypes: empty registry by design in phase 0
-export const FLAG_REGISTRY: Record<string, FlagDef> = {};
+export const FLAG_REGISTRY: Record<string, FlagDef> = {
+  "advanced.worktrees": {
+    key: "advanced.worktrees",
+    category: "advanced",
+    default: false,
+    labelKey: "advanced.flags.worktrees.label",
+    descriptionKey: "advanced.flags.worktrees.description",
+    enforcementSurface: "ui",
+    status: "beta",
+    learnMoreSlug: "worktrees",
+    since: "0.4.0",
+    graduationTarget: "permanent",
+  },
+};
 
 export type FlagMigration =
   | { type: "rename"; from: string; to: string; since: string }

--- a/app/src/lib/featureFlags.ts
+++ b/app/src/lib/featureFlags.ts
@@ -64,6 +64,18 @@ export const FLAG_REGISTRY: Record<string, FlagDef> = {
     since: "0.4.0",
     graduationTarget: "permanent",
   },
+  "advanced.context_meter": {
+    key: "advanced.context_meter",
+    category: "advanced",
+    default: false,
+    labelKey: "advanced.flags.context_meter.label",
+    descriptionKey: "advanced.flags.context_meter.description",
+    enforcementSurface: "ui",
+    status: "beta",
+    learnMoreSlug: "context-meter",
+    since: "0.4.1",
+    graduationTarget: "permanent",
+  },
 };
 
 export type FlagMigration =

--- a/app/src/lib/featureFlags.ts
+++ b/app/src/lib/featureFlags.ts
@@ -1,0 +1,130 @@
+/**
+ * Feature flag substrate. Phase 0 — plumbing only, registry intentionally
+ * empty. Future phases each add one `FlagDef` to `FLAG_REGISTRY`.
+ *
+ * Design rules (see `knowledge-base/feature-flags.md`):
+ *   1. Stay with string-typed `/v1/preferences/:key` storage; encode booleans
+ *      as `"true"` / `"false"`. Three states: true / false / unset.
+ *   2. Two-level namespace — `<category>.<feature_snake_case>`.
+ *   3. One registry file. No flag exists without a `FlagDef` entry.
+ *   4. Defaults live here, never in storage. Storage absence => code default.
+ *   5. Declare `enforcementSurface` explicitly per flag.
+ *  10. Renames / retirements flow through `FLAG_MIGRATIONS`; idempotent;
+ *      runs once on app startup.
+ *
+ * The registry shape is the API future phases consume. Don't change the
+ * `FlagDef` field set without updating every consumer + the doc.
+ */
+import { tauriPreferences } from "./tauri";
+import { logger } from "./logger";
+
+export type FlagCategory = "advanced"; // future: | "experiment" | "ops"
+
+export type EnforcementSurface = "ui" | "engine" | "both";
+
+export type FlagStatus = "beta" | "stable" | "graduating" | "retiring";
+
+export interface FlagDef {
+  /** Forever-API key. e.g. `"advanced.git_panel"`. Renaming requires `FLAG_MIGRATIONS`. */
+  key: string;
+  category: FlagCategory;
+  /** Code default. Always `false` for new advanced flags. */
+  default: boolean;
+  /** i18n key — usually `"advanced.flags.<name>.label"`. */
+  labelKey: string;
+  /** i18n key — usually `"advanced.flags.<name>.description"`. */
+  descriptionKey: string;
+  enforcementSurface: EnforcementSurface;
+  status: FlagStatus;
+  /** Slug under `knowledge-base/advanced-<slug>.md` (optional). */
+  learnMoreSlug?: string;
+  /** Soft-hint dependencies. Never auto-flipped. */
+  recommends?: string[];
+  /** App version when the flag was introduced. */
+  since: string;
+  /** Version when default flips, or `"permanent"`, or `undefined` (TBD). */
+  graduationTarget?: string;
+}
+
+/**
+ * The flag registry. Phase 0 ships this empty by design — every subsequent
+ * phase adds exactly one entry here plus the locale strings under
+ * `advanced.flags.<key>.{label,description}` in en/es/pt.
+ */
+// biome-ignore lint/complexity/noBannedTypes: empty registry by design in phase 0
+export const FLAG_REGISTRY: Record<string, FlagDef> = {};
+
+export type FlagMigration =
+  | { type: "rename"; from: string; to: string; since: string }
+  | { type: "delete"; key: string; since: string };
+
+/**
+ * Append-only migration log. Each entry runs at most once per install (the
+ * runner is idempotent — applying a `rename` whose `from` key is absent is
+ * a no-op). Never edit an existing entry — add a new one.
+ */
+export const FLAG_MIGRATIONS: FlagMigration[] = [];
+
+/** Encode a boolean for `/v1/preferences/:key` storage. */
+export function flagToString(b: boolean): string {
+  return b ? "true" : "false";
+}
+
+/**
+ * Decode a stored preference value to a flag boolean. Returns `null` when
+ * the value is unset / malformed — the caller falls back to the registry
+ * default. Strict parse: only the literals `"true"` and `"false"` count.
+ */
+export function stringToFlag(s: string | null | undefined): boolean | null {
+  if (s === "true") return true;
+  if (s === "false") return false;
+  return null;
+}
+
+/**
+ * Resolve the code default for a flag key. Returns `false` when the key
+ * isn't in the registry — defensive: never throw on a missing flag (rule 8).
+ */
+export function getFlagDefault(key: string): boolean {
+  return FLAG_REGISTRY[key]?.default ?? false;
+}
+
+/**
+ * Apply pending flag migrations once on app startup. Safe to call multiple
+ * times — each migration is keyed on the storage state of its `from`/`key`
+ * field, so re-runs are no-ops.
+ *
+ * Surfaces errors via the same toast-on-error path as `tauriPreferences`
+ * (the `call()` wrapper in `tauri.ts`). Individual migrations that throw
+ * are logged and skipped so a single bad entry doesn't block boot.
+ */
+export async function runFlagMigrations(): Promise<void> {
+  for (const migration of FLAG_MIGRATIONS) {
+    try {
+      if (migration.type === "rename") {
+        const oldValue = await tauriPreferences.get(migration.from);
+        if (oldValue === null || oldValue === undefined) continue;
+        const newValue = await tauriPreferences.get(migration.to);
+        // Don't clobber an explicit value at the new key (e.g. user toggled
+        // post-rename before the migration ran on this install).
+        if (newValue === null || newValue === undefined) {
+          await tauriPreferences.set(migration.to, oldValue);
+        }
+        // Clearing the old key: writing an empty string is the best the
+        // preferences route gives us today (it has no DELETE handler). A
+        // future engine route can replace this with a real delete.
+        await tauriPreferences.set(migration.from, "");
+      } else {
+        const value = await tauriPreferences.get(migration.key);
+        if (value === null || value === undefined) continue;
+        await tauriPreferences.set(migration.key, "");
+      }
+    } catch (err) {
+      logger.error(
+        `[featureFlags] migration ${migration.type} failed for ${
+          migration.type === "rename" ? migration.from : migration.key
+        }: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+}

--- a/app/src/lib/model-limits.ts
+++ b/app/src/lib/model-limits.ts
@@ -1,0 +1,47 @@
+/**
+ * Context-window limits per provider + model. Drives the
+ * `<ContextMeter />` wheel (Phase 2 of RFC #248 / `advanced.context_meter`).
+ *
+ * Values are the conservative documented limits. The Anthropic [1m] context
+ * variants are opt-in via CLI flag — when Houston starts exposing that toggle
+ * we'll add `sonnet-1m` / `opus-1m` entries.
+ *
+ * Sources (2026-05):
+ *   - Anthropic Claude 4.x: 200K standard context.
+ *   - OpenAI GPT-5.5: 256K (Codex CLI default).
+ *   - Google Gemini 2.5 Pro: 1M (the CLI exposes the long-context variant).
+ *
+ * Keep the values flat (numbers, not strings) so the meter's percentage math
+ * stays trivial. Add to this table whenever a new model lands in `providers.ts`.
+ */
+
+export const MODEL_CONTEXT_LIMITS: Record<string, Record<string, number>> = {
+  anthropic: {
+    sonnet: 200_000,
+    opus: 200_000,
+  },
+  openai: {
+    "gpt-5.5": 256_000,
+  },
+  gemini: {
+    "gemini-2.5-pro": 1_000_000,
+  },
+};
+
+/** Used when (provider, model) is unknown. Safe-ish for any modern coding model. */
+export const FALLBACK_CONTEXT_LIMIT = 200_000;
+
+export function getContextLimit(
+  providerId: string | null | undefined,
+  modelId: string | null | undefined,
+): number {
+  if (!providerId || !modelId) return FALLBACK_CONTEXT_LIMIT;
+  return MODEL_CONTEXT_LIMITS[providerId]?.[modelId] ?? FALLBACK_CONTEXT_LIMIT;
+}
+
+/** Pretty-print a token count like `34.5k`, `1.2M`, `12`. */
+export function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -60,6 +60,28 @@
     "model": "Model",
     "notConnected": "Not connected"
   },
+  "contextMeter": {
+    "title": "Context",
+    "tooltip": "{{used}} of {{max}} tokens ({{percent}}%)",
+    "estimatedNote": "Per-category counts are estimates. Total comes from the model.",
+    "breakdown": {
+      "free": "Free space",
+      "user_messages": "Your messages",
+      "assistant_messages": "Assistant messages",
+      "thinking": "Thinking",
+      "tool_input": "Tool calls",
+      "tool_output": "Tool results",
+      "system": "System"
+    },
+    "metrics": {
+      "turns": "Turns",
+      "duration": "Time",
+      "cost": "Cost",
+      "cacheHit": "Cache hit",
+      "toolCalls": "Tool calls",
+      "fileChanges": "Files changed"
+    }
+  },
   "reasoning": {
     "thinking": "Thinking...",
     "thoughtFor": "Thought for {{count}} seconds",

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -6,6 +6,7 @@
     "workspaceContext": "Workspace context",
     "userContext": "User context",
     "provider": "AI provider",
+    "advanced": "Advanced",
     "phone": "Connect phone",
     "reportBug": "Report bug"
   },
@@ -72,6 +73,15 @@
     "title": "Appearance",
     "light": "Light",
     "dark": "Dark"
+  },
+  "advanced": {
+    "title": "Advanced",
+    "description": "Power-user capabilities. These are off by default, enable only what you need.",
+    "empty": "No advanced capabilities available in this version. Future updates will surface them here.",
+    "resetAll": "Reset all advanced settings",
+    "resetConfirmTitle": "Reset all advanced settings?",
+    "resetConfirmDescription": "Every advanced toggle will return to default. No data is deleted.",
+    "resetConfirmLabel": "Reset"
   },
   "dangerZone": {
     "title": "Danger zone",

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -78,6 +78,12 @@
     "title": "Advanced",
     "description": "Power-user capabilities. These are off by default, enable only what you need.",
     "empty": "No advanced capabilities available in this version. Future updates will surface them here.",
+    "flags": {
+      "worktrees": {
+        "label": "Worktrees",
+        "description": "Show the Worktree mode setting on each agent so missions can run in isolated git worktrees."
+      }
+    },
     "resetAll": "Reset all advanced settings",
     "resetConfirmTitle": "Reset all advanced settings?",
     "resetConfirmDescription": "Every advanced toggle will return to default. No data is deleted.",

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -82,6 +82,10 @@
       "worktrees": {
         "label": "Worktrees",
         "description": "Show the Worktree mode setting on each agent so missions can run in isolated git worktrees."
+      },
+      "context_meter": {
+        "label": "Context meter",
+        "description": "Add a token-usage wheel to the chat composer so you can see how much of the model's context window is in use."
       }
     },
     "resetAll": "Reset all advanced settings",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -60,6 +60,28 @@
     "model": "Modelo",
     "notConnected": "Sin conexión"
   },
+  "contextMeter": {
+    "title": "Contexto",
+    "tooltip": "{{used}} de {{max}} tokens ({{percent}}%)",
+    "estimatedNote": "Los conteos por categoría son estimados. El total viene del modelo.",
+    "breakdown": {
+      "free": "Espacio libre",
+      "user_messages": "Tus mensajes",
+      "assistant_messages": "Mensajes del asistente",
+      "thinking": "Pensamiento",
+      "tool_input": "Llamadas a herramientas",
+      "tool_output": "Resultados de herramientas",
+      "system": "Sistema"
+    },
+    "metrics": {
+      "turns": "Turnos",
+      "duration": "Tiempo",
+      "cost": "Costo",
+      "cacheHit": "Caché",
+      "toolCalls": "Llamadas",
+      "fileChanges": "Archivos cambiados"
+    }
+  },
   "reasoning": {
     "thinking": "Pensando...",
     "thoughtFor": "Pensó durante {{count}} segundos",

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -82,6 +82,10 @@
       "worktrees": {
         "label": "Worktrees",
         "description": "Muestra el ajuste Modo worktree en cada agente para que las misiones puedan correr en worktrees de git aislados."
+      },
+      "context_meter": {
+        "label": "Medidor de contexto",
+        "description": "Agrega una rueda de uso de tokens en el composer del chat para que veas cuánto de la ventana de contexto del modelo está en uso."
       }
     },
     "resetAll": "Restablecer todos los ajustes avanzados",

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -78,6 +78,12 @@
     "title": "Avanzado",
     "description": "Capacidades para usuarios avanzados. Están desactivadas por defecto, activa solo las que necesites.",
     "empty": "No hay capacidades avanzadas disponibles en esta versión. Las próximas actualizaciones las irán habilitando aquí.",
+    "flags": {
+      "worktrees": {
+        "label": "Worktrees",
+        "description": "Muestra el ajuste Modo worktree en cada agente para que las misiones puedan correr en worktrees de git aislados."
+      }
+    },
     "resetAll": "Restablecer todos los ajustes avanzados",
     "resetConfirmTitle": "¿Restablecer todos los ajustes avanzados?",
     "resetConfirmDescription": "Cada interruptor avanzado volverá a su valor por defecto. No se elimina ningún dato.",

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -6,6 +6,7 @@
     "workspaceContext": "Contexto del espacio",
     "userContext": "Contexto del usuario",
     "provider": "Proveedor de IA",
+    "advanced": "Avanzado",
     "phone": "Conectar celular",
     "reportBug": "Reportar bug"
   },
@@ -72,6 +73,15 @@
     "title": "Apariencia",
     "light": "Claro",
     "dark": "Oscuro"
+  },
+  "advanced": {
+    "title": "Avanzado",
+    "description": "Capacidades para usuarios avanzados. Están desactivadas por defecto, activa solo las que necesites.",
+    "empty": "No hay capacidades avanzadas disponibles en esta versión. Las próximas actualizaciones las irán habilitando aquí.",
+    "resetAll": "Restablecer todos los ajustes avanzados",
+    "resetConfirmTitle": "¿Restablecer todos los ajustes avanzados?",
+    "resetConfirmDescription": "Cada interruptor avanzado volverá a su valor por defecto. No se elimina ningún dato.",
+    "resetConfirmLabel": "Restablecer"
   },
   "dangerZone": {
     "title": "Zona de peligro",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -60,6 +60,28 @@
     "model": "Modelo",
     "notConnected": "Sem conexão"
   },
+  "contextMeter": {
+    "title": "Contexto",
+    "tooltip": "{{used}} de {{max}} tokens ({{percent}}%)",
+    "estimatedNote": "Os contadores por categoria são estimados. O total vem do modelo.",
+    "breakdown": {
+      "free": "Espaço livre",
+      "user_messages": "Suas mensagens",
+      "assistant_messages": "Mensagens do assistente",
+      "thinking": "Raciocínio",
+      "tool_input": "Chamadas de ferramentas",
+      "tool_output": "Resultados de ferramentas",
+      "system": "Sistema"
+    },
+    "metrics": {
+      "turns": "Turnos",
+      "duration": "Tempo",
+      "cost": "Custo",
+      "cacheHit": "Cache",
+      "toolCalls": "Chamadas",
+      "fileChanges": "Arquivos alterados"
+    }
+  },
   "reasoning": {
     "thinking": "Pensando...",
     "thoughtFor": "Pensou por {{count}} segundos",

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -78,6 +78,12 @@
     "title": "Avançado",
     "description": "Recursos para usuários avançados. Vêm desativados por padrão, ative só o que você precisar.",
     "empty": "Nenhum recurso avançado disponível nesta versão. As próximas atualizações vão liberar mais aqui.",
+    "flags": {
+      "worktrees": {
+        "label": "Worktrees",
+        "description": "Mostra a opção Modo worktree em cada agente para que as missões possam rodar em worktrees do git separados."
+      }
+    },
     "resetAll": "Redefinir todas as configurações avançadas",
     "resetConfirmTitle": "Redefinir todas as configurações avançadas?",
     "resetConfirmDescription": "Cada interruptor avançado volta ao padrão. Nenhum dado é apagado.",

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -6,6 +6,7 @@
     "workspaceContext": "Contexto do espaço",
     "userContext": "Contexto do usuário",
     "provider": "Provedor de IA",
+    "advanced": "Avançado",
     "phone": "Conectar celular",
     "reportBug": "Reportar bug"
   },
@@ -72,6 +73,15 @@
     "title": "Aparência",
     "light": "Claro",
     "dark": "Escuro"
+  },
+  "advanced": {
+    "title": "Avançado",
+    "description": "Recursos para usuários avançados. Vêm desativados por padrão, ative só o que você precisar.",
+    "empty": "Nenhum recurso avançado disponível nesta versão. As próximas atualizações vão liberar mais aqui.",
+    "resetAll": "Redefinir todas as configurações avançadas",
+    "resetConfirmTitle": "Redefinir todas as configurações avançadas?",
+    "resetConfirmDescription": "Cada interruptor avançado volta ao padrão. Nenhum dado é apagado.",
+    "resetConfirmLabel": "Redefinir"
   },
   "dangerZone": {
     "title": "Zona de perigo",

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -82,6 +82,10 @@
       "worktrees": {
         "label": "Worktrees",
         "description": "Mostra a opção Modo worktree em cada agente para que as missões possam rodar em worktrees do git separados."
+      },
+      "context_meter": {
+        "label": "Medidor de contexto",
+        "description": "Adiciona uma roda de uso de tokens no composer do chat para você ver o quanto da janela de contexto do modelo está em uso."
       }
     },
     "resetAll": "Redefinir todas as configurações avançadas",

--- a/app/tests/feature-flags.test.ts
+++ b/app/tests/feature-flags.test.ts
@@ -115,11 +115,42 @@ test("getFlagDefault matches FlagDef.default when key is in registry", () => {
 
 // ---------- FLAG_REGISTRY shape invariants ----------
 
-test("phase 0 ships FLAG_REGISTRY empty by design", () => {
-  assert.equal(Object.keys(FLAG_REGISTRY).length, 0);
+test("FLAG_REGISTRY contains advanced.worktrees with the expected shape", () => {
+  const flag = FLAG_REGISTRY["advanced.worktrees"];
+  assert.ok(flag, "advanced.worktrees must be registered (Phase 1 of RFC #248)");
+  assert.equal(flag.key, "advanced.worktrees");
+  assert.equal(flag.category, "advanced");
+  assert.equal(flag.default, false, "new advanced flags ship default off (rule 4)");
+  assert.equal(flag.enforcementSurface, "ui");
+  assert.equal(flag.status, "beta");
+  assert.equal(flag.labelKey, "advanced.flags.worktrees.label");
+  assert.equal(flag.descriptionKey, "advanced.flags.worktrees.description");
+  assert.equal(flag.graduationTarget, "permanent");
 });
 
-test("phase 0 ships FLAG_MIGRATIONS empty by design", () => {
+test("every FLAG_REGISTRY entry has the required FlagDef fields", () => {
+  for (const [key, flag] of Object.entries(FLAG_REGISTRY)) {
+    assert.equal(flag.key, key, `key field must match registry key: ${key}`);
+    assert.ok(["advanced"].includes(flag.category), `unknown category for ${key}`);
+    assert.equal(typeof flag.default, "boolean", `${key}.default must be boolean`);
+    assert.ok(flag.labelKey.startsWith("advanced.flags."), `${key}.labelKey shape`);
+    assert.ok(
+      flag.descriptionKey.startsWith("advanced.flags."),
+      `${key}.descriptionKey shape`,
+    );
+    assert.ok(
+      ["ui", "engine", "both"].includes(flag.enforcementSurface),
+      `${key}.enforcementSurface`,
+    );
+    assert.ok(
+      ["beta", "stable", "graduating", "retiring"].includes(flag.status),
+      `${key}.status`,
+    );
+    assert.equal(typeof flag.since, "string", `${key}.since must be a string`);
+  }
+});
+
+test("FLAG_MIGRATIONS empty until a flag rename or retirement is needed", () => {
   assert.equal(FLAG_MIGRATIONS.length, 0);
 });
 

--- a/app/tests/feature-flags.test.ts
+++ b/app/tests/feature-flags.test.ts
@@ -128,6 +128,19 @@ test("FLAG_REGISTRY contains advanced.worktrees with the expected shape", () => 
   assert.equal(flag.graduationTarget, "permanent");
 });
 
+test("FLAG_REGISTRY contains advanced.context_meter with the expected shape", () => {
+  const flag = FLAG_REGISTRY["advanced.context_meter"];
+  assert.ok(flag, "advanced.context_meter must be registered (Phase 2 of RFC #248)");
+  assert.equal(flag.key, "advanced.context_meter");
+  assert.equal(flag.category, "advanced");
+  assert.equal(flag.default, false);
+  assert.equal(flag.enforcementSurface, "ui");
+  assert.equal(flag.status, "beta");
+  assert.equal(flag.labelKey, "advanced.flags.context_meter.label");
+  assert.equal(flag.descriptionKey, "advanced.flags.context_meter.description");
+  assert.equal(flag.graduationTarget, "permanent");
+});
+
 test("every FLAG_REGISTRY entry has the required FlagDef fields", () => {
   for (const [key, flag] of Object.entries(FLAG_REGISTRY)) {
     assert.equal(flag.key, key, `key field must match registry key: ${key}`);

--- a/app/tests/feature-flags.test.ts
+++ b/app/tests/feature-flags.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Feature-flag unit tests. Exercises the pure helpers (flagToString,
+ * stringToFlag, getFlagDefault) and the migration runner. Runs under
+ * `node --test`, matching the rest of `app/tests/`.
+ *
+ * The hook itself (`useFeatureFlag`) is a React+TanStack composition and
+ * is best exercised in integration via the running app — these tests cover
+ * the primitives that compose into the resolution chain so the chain's
+ * behavior is provable from substitution.
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// --- Stub the substrate that `featureFlags.ts` reaches for ---
+// `tauriPreferences` calls into the engine; the migration runner only
+// touches it via .get/.set so we replace the whole module with a
+// programmable fake before importing the unit under test.
+
+import { Module } from "node:module";
+
+const prefStore = new Map<string, string | null>();
+const setLog: Array<[string, string]> = [];
+
+interface ResolveContext {
+  parentURL?: string;
+}
+
+const originalResolve = (Module as unknown as {
+  _resolveFilename: (
+    request: string,
+    parent: unknown,
+    isMain: boolean,
+    options: ResolveContext,
+  ) => string;
+})._resolveFilename;
+
+(Module as unknown as {
+  _resolveFilename: typeof originalResolve;
+})._resolveFilename = function (request, parent, isMain, options) {
+  if (request === "../src/lib/tauri.ts" || request === "../src/lib/tauri") {
+    return require.resolve("./fixtures/feature-flags-tauri-stub.ts");
+  }
+  if (request === "../src/lib/logger.ts" || request === "../src/lib/logger") {
+    return require.resolve("./fixtures/feature-flags-logger-stub.ts");
+  }
+  return originalResolve.call(this, request, parent, isMain, options);
+};
+
+// Import after the resolver hook is installed so the under-test module
+// picks up the stubs instead of the real modules.
+import {
+  flagToString,
+  stringToFlag,
+  getFlagDefault,
+  runFlagMigrations,
+  FLAG_REGISTRY,
+  FLAG_MIGRATIONS,
+} from "../src/lib/featureFlags.ts";
+
+// Re-export the in-memory store so the stub file can wire to it.
+// The stub file reads `globalThis.__test_pref_store__` at import time.
+(globalThis as Record<string, unknown>).__test_pref_store__ = prefStore;
+(globalThis as Record<string, unknown>).__test_set_log__ = setLog;
+
+// ---------- flagToString ----------
+
+test("flagToString encodes true and false canonically", () => {
+  assert.equal(flagToString(true), "true");
+  assert.equal(flagToString(false), "false");
+});
+
+// ---------- stringToFlag ----------
+
+test("stringToFlag accepts only canonical literals", () => {
+  assert.equal(stringToFlag("true"), true);
+  assert.equal(stringToFlag("false"), false);
+});
+
+test("stringToFlag returns null for unset / malformed / non-canonical values", () => {
+  assert.equal(stringToFlag(null), null);
+  assert.equal(stringToFlag(undefined), null);
+  assert.equal(stringToFlag(""), null);
+  assert.equal(stringToFlag("True"), null);
+  assert.equal(stringToFlag("TRUE"), null);
+  assert.equal(stringToFlag("yes"), null);
+  assert.equal(stringToFlag("1"), null);
+  assert.equal(stringToFlag("on"), null);
+});
+
+// ---------- getFlagDefault ----------
+
+test("getFlagDefault returns false for unknown keys (defensive)", () => {
+  assert.equal(getFlagDefault("advanced.does_not_exist"), false);
+});
+
+test("getFlagDefault matches FlagDef.default when key is in registry", () => {
+  // Phase 0 registry is empty; install a temporary entry to exercise the path.
+  const key = "test.synthetic_for_default_lookup";
+  FLAG_REGISTRY[key] = {
+    key,
+    category: "advanced",
+    default: true,
+    labelKey: "x.label",
+    descriptionKey: "x.desc",
+    enforcementSurface: "ui",
+    status: "beta",
+    since: "0.0.0",
+  };
+  try {
+    assert.equal(getFlagDefault(key), true);
+  } finally {
+    delete FLAG_REGISTRY[key];
+  }
+});
+
+// ---------- FLAG_REGISTRY shape invariants ----------
+
+test("phase 0 ships FLAG_REGISTRY empty by design", () => {
+  assert.equal(Object.keys(FLAG_REGISTRY).length, 0);
+});
+
+test("phase 0 ships FLAG_MIGRATIONS empty by design", () => {
+  assert.equal(FLAG_MIGRATIONS.length, 0);
+});
+
+// ---------- runFlagMigrations ----------
+
+function resetPrefStore() {
+  prefStore.clear();
+  setLog.length = 0;
+}
+
+test("runFlagMigrations is a no-op when FLAG_MIGRATIONS is empty", async () => {
+  resetPrefStore();
+  await runFlagMigrations();
+  assert.equal(setLog.length, 0);
+});
+
+test("runFlagMigrations renames a key when the new key is unset", async () => {
+  resetPrefStore();
+  prefStore.set("old.key", "true");
+
+  FLAG_MIGRATIONS.push({
+    type: "rename",
+    from: "old.key",
+    to: "new.key",
+    since: "0.0.0",
+  });
+  try {
+    await runFlagMigrations();
+    assert.equal(prefStore.get("new.key"), "true");
+    // Old key cleared (engine has no DELETE; empty string represents unset).
+    assert.equal(prefStore.get("old.key"), "");
+  } finally {
+    FLAG_MIGRATIONS.length = 0;
+  }
+});
+
+test("runFlagMigrations does NOT clobber an explicit new-key value", async () => {
+  resetPrefStore();
+  prefStore.set("old.key", "true");
+  prefStore.set("new.key", "false");
+
+  FLAG_MIGRATIONS.push({
+    type: "rename",
+    from: "old.key",
+    to: "new.key",
+    since: "0.0.0",
+  });
+  try {
+    await runFlagMigrations();
+    assert.equal(prefStore.get("new.key"), "false", "explicit new-key value preserved");
+    assert.equal(prefStore.get("old.key"), "", "old key still cleared");
+  } finally {
+    FLAG_MIGRATIONS.length = 0;
+  }
+});
+
+test("runFlagMigrations is a no-op when the old key is already absent", async () => {
+  resetPrefStore();
+  // No entry for `old.key` at all.
+
+  FLAG_MIGRATIONS.push({
+    type: "rename",
+    from: "old.key",
+    to: "new.key",
+    since: "0.0.0",
+  });
+  try {
+    await runFlagMigrations();
+    assert.equal(prefStore.has("new.key"), false);
+    assert.equal(setLog.length, 0);
+  } finally {
+    FLAG_MIGRATIONS.length = 0;
+  }
+});
+
+test("runFlagMigrations is idempotent — re-run after a successful rename is a no-op", async () => {
+  resetPrefStore();
+  prefStore.set("old.key", "true");
+
+  FLAG_MIGRATIONS.push({
+    type: "rename",
+    from: "old.key",
+    to: "new.key",
+    since: "0.0.0",
+  });
+  try {
+    await runFlagMigrations();
+    const firstSetCount = setLog.length;
+
+    // Second run: old.key is now empty string (cleared); .get returns ""
+    // which we treat as "exists but blank" — the migration sees a value,
+    // copies the empty string forward. That's still idempotent — running
+    // it a third time gets the same outcome. The invariant is "no harm".
+    await runFlagMigrations();
+    assert.ok(setLog.length >= firstSetCount, "second run does not crash");
+    assert.equal(prefStore.get("new.key"), "true", "new key value preserved");
+  } finally {
+    FLAG_MIGRATIONS.length = 0;
+  }
+});
+
+test("runFlagMigrations clears a deleted key when present", async () => {
+  resetPrefStore();
+  prefStore.set("retired.key", "true");
+
+  FLAG_MIGRATIONS.push({
+    type: "delete",
+    key: "retired.key",
+    since: "0.0.0",
+  });
+  try {
+    await runFlagMigrations();
+    assert.equal(prefStore.get("retired.key"), "");
+  } finally {
+    FLAG_MIGRATIONS.length = 0;
+  }
+});
+
+test("runFlagMigrations skips a delete for a key that was never set", async () => {
+  resetPrefStore();
+
+  FLAG_MIGRATIONS.push({
+    type: "delete",
+    key: "retired.key",
+    since: "0.0.0",
+  });
+  try {
+    await runFlagMigrations();
+    assert.equal(setLog.length, 0);
+  } finally {
+    FLAG_MIGRATIONS.length = 0;
+  }
+});

--- a/app/tests/fixtures/feature-flags-logger-stub.ts
+++ b/app/tests/fixtures/feature-flags-logger-stub.ts
@@ -1,0 +1,14 @@
+/**
+ * Test stub for `lib/logger.ts`.
+ *
+ * The real logger writes to a Tauri-backed file sink that doesn't exist
+ * under `node --test`. This stub swallows all log calls — tests that
+ * care about logging output should assert via a custom spy instead.
+ */
+
+export const logger = {
+  debug: (..._args: unknown[]) => {},
+  info: (..._args: unknown[]) => {},
+  warn: (..._args: unknown[]) => {},
+  error: (..._args: unknown[]) => {},
+};

--- a/app/tests/fixtures/feature-flags-tauri-stub.ts
+++ b/app/tests/fixtures/feature-flags-tauri-stub.ts
@@ -1,0 +1,58 @@
+/**
+ * Test stub for `lib/tauri.ts::tauriPreferences`.
+ *
+ * The real `tauriPreferences` calls into the running engine over the
+ * HoustonClient — we can't reach that under `node --test`. This stub
+ * routes `.get()` / `.set()` through an in-memory `Map` exposed on
+ * `globalThis.__test_pref_store__`, set up by the test file before
+ * importing the unit under test.
+ *
+ * `setLog` is exposed on `globalThis.__test_set_log__` so tests can
+ * assert that writes happened (or didn't) without inspecting the store
+ * directly.
+ *
+ * This file is loaded via the `Module._resolveFilename` monkeypatch at
+ * the top of `app/tests/feature-flags.test.ts`. It is NOT a public test
+ * substrate; if a future test needs preference stubbing, that test
+ * should install its own stub or the helpers here should move into a
+ * shared `app/tests/helpers/` directory.
+ */
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __test_pref_store__: Map<string, string | null> | undefined;
+  // eslint-disable-next-line no-var
+  var __test_set_log__: Array<[string, string]> | undefined;
+}
+
+function store(): Map<string, string | null> {
+  if (!globalThis.__test_pref_store__) {
+    throw new Error(
+      "feature-flags-tauri-stub: __test_pref_store__ not initialized. " +
+        "Tests must populate `globalThis.__test_pref_store__ = new Map()` " +
+        "before importing the unit under test.",
+    );
+  }
+  return globalThis.__test_pref_store__;
+}
+
+function setLog(): Array<[string, string]> {
+  if (!globalThis.__test_set_log__) {
+    throw new Error(
+      "feature-flags-tauri-stub: __test_set_log__ not initialized.",
+    );
+  }
+  return globalThis.__test_set_log__;
+}
+
+export const tauriPreferences = {
+  get: async (key: string): Promise<string | null> => {
+    const s = store();
+    if (!s.has(key)) return null;
+    return s.get(key) ?? null;
+  },
+  set: async (key: string, value: string): Promise<void> => {
+    store().set(key, value);
+    setLog().push([key, value]);
+  },
+};

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -421,9 +421,23 @@ fn serialize_for_persist(item: &FeedItem) -> Option<(String, String)> {
             result,
             cost_usd,
             duration_ms,
+            input_tokens,
+            output_tokens,
+            cache_creation_input_tokens,
+            cache_read_input_tokens,
         } => {
+            // Token fields feed the `advanced.context_meter` wheel; they
+            // are persisted even when null so resumed conversations can
+            // distinguish "unknown" from "actually zero." Anthropic + gemini
+            // populate; codex populates input/output/cache_read only.
             let data = serde_json::json!({
-                "result": result, "cost_usd": cost_usd, "duration_ms": duration_ms
+                "result": result,
+                "cost_usd": cost_usd,
+                "duration_ms": duration_ms,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_creation_input_tokens": cache_creation_input_tokens,
+                "cache_read_input_tokens": cache_read_input_tokens,
             });
             Some(("final_result".into(), data.to_string()))
         }

--- a/engine/houston-engine-protocol/src/lib.rs
+++ b/engine/houston-engine-protocol/src/lib.rs
@@ -163,6 +163,7 @@ pub fn event_topic(event: &HoustonEvent) -> String {
         HoustonEvent::ProviderLoginUrl { .. } | HoustonEvent::ProviderLoginComplete { .. } => {
             "providers".into()
         }
+        HoustonEvent::PreferenceChanged { .. } => "preferences".into(),
     }
 }
 

--- a/engine/houston-engine-server/src/routes/preferences.rs
+++ b/engine/houston-engine-server/src/routes/preferences.rs
@@ -8,6 +8,7 @@ use axum::{
     Json, Router,
 };
 use houston_engine_core::preferences;
+use houston_ui_events::HoustonEvent;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -46,5 +47,18 @@ async fn upsert(
     if key == preferences::TIMEZONE_KEY {
         st.routine_scheduler.update_default_tz(&req.value).await;
     }
+    // Broadcast so other tabs, the mobile companion, and any feature-flag
+    // listeners invalidate their cached read of this key. An empty `value`
+    // string represents "cleared"; we surface that as `None` to match the
+    // event's documented semantics.
+    let event_value = if req.value.is_empty() {
+        None
+    } else {
+        Some(req.value.clone())
+    };
+    st.engine.events.emit(HoustonEvent::PreferenceChanged {
+        key: key.clone(),
+        value: event_value,
+    });
     Ok(())
 }

--- a/engine/houston-terminal-manager/src/codex_parser.rs
+++ b/engine/houston-terminal-manager/src/codex_parser.rs
@@ -173,13 +173,20 @@ pub fn parse_codex_event(line: &str, acc: &mut CodexAccumulator) -> Vec<FeedItem
                 items.push(FeedItem::Thinking(String::new()));
             }
             acc.thinking_placeholder_open = false;
-            // Emit usage as FinalResult
+            // Emit usage as FinalResult. Token fields populate the
+            // `advanced.context_meter` wheel; codex doesn't emit
+            // cost_usd or duration_ms, and Anthropic-style prompt
+            // caching is not exposed by codex either.
             if let Some(usage) = &event.usage {
                 let total = usage.input_tokens.unwrap_or(0) + usage.output_tokens.unwrap_or(0);
                 items.push(FeedItem::FinalResult {
                     result: format!("{total} tokens used"),
                     cost_usd: None,
                     duration_ms: None,
+                    input_tokens: usage.input_tokens,
+                    output_tokens: usage.output_tokens,
+                    cache_creation_input_tokens: None,
+                    cache_read_input_tokens: usage.cached_input_tokens,
                 });
             }
             items

--- a/engine/houston-terminal-manager/src/gemini_parser_state.rs
+++ b/engine/houston-terminal-manager/src/gemini_parser_state.rs
@@ -144,11 +144,22 @@ fn handle_result(
     if status == GeminiStatus::Error {
         items.push(classify_result_error(error.as_ref()));
     }
+    // Gemini stats expose total_tokens / input_tokens / output_tokens /
+    // cached. Map into the FinalResult shape so the
+    // `advanced.context_meter` wheel has data on gemini turns too.
+    let (input_tokens, output_tokens, cache_read_input_tokens) = stats
+        .as_ref()
+        .map(|s| (Some(s.input_tokens), Some(s.output_tokens), Some(s.cached)))
+        .unwrap_or((None, None, None));
     items.push(FeedItem::FinalResult {
         result: result_summary(stats.as_ref()),
         // Gemini emits no cost field — see schema findings §3.
         cost_usd: None,
         duration_ms,
+        input_tokens,
+        output_tokens,
+        cache_creation_input_tokens: None,
+        cache_read_input_tokens,
     });
     items
 }
@@ -344,10 +355,21 @@ mod tests {
         let items = parse_gemini_event(RESULT_OK, &mut acc());
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::FinalResult { result, cost_usd, duration_ms } => {
+            FeedItem::FinalResult {
+                result,
+                cost_usd,
+                duration_ms,
+                input_tokens,
+                output_tokens,
+                cache_read_input_tokens,
+                ..
+            } => {
                 assert_eq!(*duration_ms, Some(1200));
                 assert!(cost_usd.is_none(), "gemini emits no cost field");
                 assert!(result.contains("100 tokens"));
+                assert_eq!(*input_tokens, Some(50));
+                assert_eq!(*output_tokens, Some(50));
+                assert_eq!(*cache_read_input_tokens, Some(0));
             }
             other => panic!("expected FinalResult, got {other:?}"),
         }

--- a/engine/houston-terminal-manager/src/parser.rs
+++ b/engine/houston-terminal-manager/src/parser.rs
@@ -164,6 +164,7 @@ pub fn parse_event(line: &str, acc: &mut StreamAccumulator) -> Vec<FeedItem> {
             is_error,
             cost_usd,
             duration_ms,
+            usage,
             ..
         } => {
             if subtype.as_deref() == Some("error") || is_error == Some(true) {
@@ -183,10 +184,15 @@ pub fn parse_event(line: &str, acc: &mut StreamAccumulator) -> Vec<FeedItem> {
                     });
                 return vec![FeedItem::ProviderError(typed)];
             }
+            let usage = usage.unwrap_or_default();
             vec![FeedItem::FinalResult {
                 result: result.unwrap_or_default(),
                 cost_usd,
                 duration_ms,
+                input_tokens: usage.input_tokens,
+                output_tokens: usage.output_tokens,
+                cache_creation_input_tokens: usage.cache_creation_input_tokens,
+                cache_read_input_tokens: usage.cache_read_input_tokens,
             }]
         }
         ClaudeEvent::StreamEvent { event: inner, .. } => acc.handle(inner),
@@ -444,14 +450,42 @@ mod tests {
             FeedItem::FinalResult {
                 cost_usd,
                 duration_ms,
+                input_tokens,
+                output_tokens,
                 ..
             } => {
                 assert_eq!(*cost_usd, Some(0.05));
                 assert_eq!(*duration_ms, Some(1234));
+                // No `usage` block on this fixture — token fields stay None.
+                assert_eq!(*input_tokens, None);
+                assert_eq!(*output_tokens, None);
             }
             other => panic!("expected FinalResult, got {other:?}"),
         }
         assert_eq!(extract_session_id(line), Some("s1".to_string()));
+    }
+
+    #[test]
+    fn parse_result_event_with_usage_populates_context_meter_fields() {
+        // Real-shape claude-code envelope with prompt caching active.
+        let line = r#"{"type":"result","result":"Done","cost_usd":0.12,"duration_ms":4500,"session_id":"s2","usage":{"input_tokens":24500,"output_tokens":810,"cache_creation_input_tokens":1200,"cache_read_input_tokens":18000}}"#;
+        let items = parse_event(line, &mut acc());
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            FeedItem::FinalResult {
+                input_tokens,
+                output_tokens,
+                cache_creation_input_tokens,
+                cache_read_input_tokens,
+                ..
+            } => {
+                assert_eq!(*input_tokens, Some(24500));
+                assert_eq!(*output_tokens, Some(810));
+                assert_eq!(*cache_creation_input_tokens, Some(1200));
+                assert_eq!(*cache_read_input_tokens, Some(18000));
+            }
+            other => panic!("expected FinalResult, got {other:?}"),
+        }
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/types.rs
+++ b/engine/houston-terminal-manager/src/types.rs
@@ -1,6 +1,21 @@
 use crate::provider_error_kind::ProviderError;
 use serde::{Deserialize, Serialize};
 
+/// Token usage info emitted on the Anthropic `result` envelope.
+///
+/// All fields are optional because (a) older claude-code versions may
+/// omit some and (b) Anthropic only populates cache fields when prompt
+/// caching is active for the request. Consumers should treat absent =
+/// unknown, not zero. The `advanced.context_meter` wheel uses
+/// `input_tokens` as the canonical "context fill" reading.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct UsageInfo {
+    pub input_tokens: Option<u64>,
+    pub output_tokens: Option<u64>,
+    pub cache_creation_input_tokens: Option<u64>,
+    pub cache_read_input_tokens: Option<u64>,
+}
+
 /// Events parsed from Claude's `--output-format stream-json` NDJSON output.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -34,6 +49,10 @@ pub enum ClaudeEvent {
         cost_usd: Option<f64>,
         duration_ms: Option<u64>,
         session_id: Option<String>,
+        /// Token usage emitted by claude-code's `result` event.
+        /// Used by `advanced.context_meter` to populate the in-composer
+        /// wheel. Optional because not every CLI version emits it.
+        usage: Option<UsageInfo>,
         #[serde(flatten)]
         extra: serde_json::Value,
     },
@@ -180,11 +199,19 @@ pub enum FeedItem {
     ToolResult { content: String, is_error: bool },
     /// System message (session start, etc.).
     SystemMessage(String),
-    /// Session completed — cost/duration summary.
+    /// Session completed — cost/duration/usage summary.
+    /// Token fields populate the `advanced.context_meter` wheel; all are
+    /// optional because not every provider emits them (gemini parses
+    /// stats per turn but doesn't always echo back in result; codex
+    /// emits via `turn.completed`).
     FinalResult {
         result: String,
         cost_usd: Option<f64>,
         duration_ms: Option<u64>,
+        input_tokens: Option<u64>,
+        output_tokens: Option<u64>,
+        cache_creation_input_tokens: Option<u64>,
+        cache_read_input_tokens: Option<u64>,
     },
     /// Visible files created or changed during the session.
     FileChanges(FileChanges),

--- a/engine/houston-ui-events/src/lib.rs
+++ b/engine/houston-ui-events/src/lib.rs
@@ -77,6 +77,15 @@ pub enum HoustonEvent {
 
     // ----- Routines -----
 
+    /// Preference key was set. Emitted by `PUT /v1/preferences/:key` so
+    /// other tabs / clients / mobile companions can invalidate their cached
+    /// preference reads. `value` is `None` when the key was cleared (stored
+    /// as an empty string today; reserved for a future explicit DELETE).
+    PreferenceChanged {
+        key: String,
+        value: Option<String>,
+    },
+
     /// Routines list changed (.houston/routines.json).
     RoutinesChanged {
         agent_path: String,

--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -11,6 +11,7 @@ Load on demand. Style: caveman.
 | [agent-manifest.md](agent-manifest.md) | Three tiers, manifest shape, workspace templates, sidebar |
 | [engine-protocol.md](engine-protocol.md) | HTTP + WS wire contract every client speaks (REST, envelope, auth) |
 | [engine-server.md](engine-server.md) | `houston-engine` binary — config, startup handshake, supervision, deployment |
+| [feature-flags.md](feature-flags.md) | Advanced settings, flag registry, 12 rules, adding/migrating/graduating flags |
 | [production-infra.md](production-infra.md) | Auto-updater, analytics, Sentry, env vars, CI/CD |
 
 Mobile-specific docs live under `/docs/`: [mobile-architecture.md](../docs/mobile-architecture.md), [relay-operations.md](../docs/relay-operations.md).

--- a/knowledge-base/advanced-context-meter.md
+++ b/knowledge-base/advanced-context-meter.md
@@ -1,0 +1,72 @@
+# Advanced: Context meter
+
+Surfaced by the `advanced.context_meter` flag in Settings → Advanced.
+
+## What it does
+
+Adds a small token-usage wheel to the chat composer toolbar, sitting next to the model selector. The wheel shows how much of the active model's context window the current session has consumed. Clicking opens a popover with the full breakdown.
+
+## How it works
+
+### Where the number comes from
+
+Two sources, in priority order:
+
+1. **Authoritative** — the latest `FeedItem::FinalResult.input_tokens` for the active session. That's the value the provider reported in its last turn-complete envelope. Anthropic (Claude) emits this in the `result` event's `usage` block; gemini emits it in stats; codex emits it via `turn.completed`.
+2. **Estimated** — when no `FinalResult` carries token data yet (e.g. the user hasn't sent the first turn), the meter falls back to a chars/4 heuristic summed over all feed items.
+
+The popover labels the per-category breakdown as estimated regardless — only the meter total is provider-reported when available.
+
+### Where the limit comes from
+
+`app/src/lib/model-limits.ts::MODEL_CONTEXT_LIMITS` — a hard-coded table keyed by `provider → model → tokens`. Unknown combinations fall through to `FALLBACK_CONTEXT_LIMIT` (200K). When Houston starts exposing the Anthropic `[1m]` context variants, add `sonnet-1m` / `opus-1m` entries here.
+
+### Color thresholds
+
+- `< 70%` neutral (theme primary)
+- `70% – 90%` yellow
+- `≥ 90%` red
+
+Set in `<ContextMeter />` and mirrored in the popover progress bar.
+
+### Popover contents
+
+Three blocks:
+
+1. **Header** — title, `used / max` (e.g. `34.5k / 200.0k`), model name, threshold-colored progress bar.
+2. **Breakdown** — token estimates per feed-item category: Free space, Your messages, Assistant messages, Thinking, Tool calls, Tool results, System. Rows with zero tokens are hidden. Sorted by token count descending (except Free which is always first).
+3. **Other metrics** — Turn count (FinalResult count), total session time (sum of `duration_ms`), total cost (sum of `cost_usd`, Claude only), cache hit rate (`cache_read_input_tokens / input_tokens` from latest FinalResult), tool call count, file change count.
+
+## Why it's gated
+
+Token counts are developer information. Non-technical users don't need them, and a "context filling up" red badge on every chat would be confusing. Default-off, opt-in for power users who actually care.
+
+## Enforcement surface
+
+`enforcementSurface: "ui"`. The engine populates token fields in `FeedItem::FinalResult` and persists them regardless of the flag — Houston Cloud / Always On consumers can read them straight from the chat feed.
+
+## Implementation pointers
+
+- Flag entry: `app/src/lib/featureFlags.ts::FLAG_REGISTRY["advanced.context_meter"]`
+- Stats hook: `app/src/hooks/use-context-stats.ts` (chars/4 heuristic + FinalResult parse)
+- Wheel component: `app/src/components/context-meter.tsx`
+- Popover component: `app/src/components/context-meter-popover.tsx`
+- Mount site: `app/src/components/tabs/chat-tab.tsx` (footer slot next to `<ChatModelSelector>`)
+- Model limits: `app/src/lib/model-limits.ts`
+- Engine substrate: `engine/houston-terminal-manager/src/types.rs::UsageInfo` + `FeedItem::FinalResult` token fields, populated by all three parsers (`parser.rs`, `codex_parser.rs`, `gemini_parser_state.rs`)
+
+## Provider parity
+
+| Provider | input_tokens | output_tokens | cache_read | cache_creation | cost_usd |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Anthropic (Claude) | ✓ | ✓ | ✓ | ✓ | ✓ |
+| OpenAI (Codex) | ✓ | ✓ | ✓ (`cached_input_tokens`) | ✗ | ✗ |
+| Google (Gemini) | ✓ | ✓ | ✓ (`cached`) | ✗ | ✗ |
+
+Codex and gemini don't emit cost; the metrics row shows `—` for cost on those sessions. Anthropic prompt caching only fires when caching is active for the request.
+
+## See also
+
+- `knowledge-base/feature-flags.md` — the 12 rules + adding-a-flag procedure
+- `knowledge-base/advanced-worktrees.md` — sibling advanced flag (Phase 1)
+- RFC: `gethouston/houston#248` — umbrella RFC for the advanced settings wave (this was the "cost display" entry, recast as context meter since the actionable metric is tokens, not $)

--- a/knowledge-base/advanced-worktrees.md
+++ b/knowledge-base/advanced-worktrees.md
@@ -1,0 +1,44 @@
+# Advanced: Worktrees
+
+Surfaced by the `advanced.worktrees` flag in Settings → Advanced.
+
+## What it does
+
+Reveals the **Worktree mode** toggle inside each agent's Configure tab. When that toggle is on for an agent, every mission you start on that agent runs in its own git worktree so parallel work stays in isolated checkouts.
+
+## How it works
+
+The capability itself is per-agent, not global. The `advanced.worktrees` flag controls **whether the Worktree mode toggle appears in the UI**, not whether worktrees are created. Agents that already have `worktreeMode: true` persisted in their config continue creating worktrees regardless of the flag's state. This matters: turning the global flag off later does not break a user's existing worktree-enabled agents.
+
+When a mission starts on a worktree-enabled agent:
+
+1. Houston creates a fresh git worktree under the repo, named with a short uuid slug.
+2. The agent runs the mission with that worktree as the working directory.
+3. If the agent has an `installCommand` configured, it runs once inside the new worktree.
+4. The board card surfaces a "Run terminal" affordance pointing at the worktree path.
+
+## Why it's gated
+
+Worktrees are a developer concept. Most Houston users never need them. Surfacing the toggle by default would clutter the agent Configure tab for the majority of users who run one mission at a time on a single checkout.
+
+The flag also acts as a one-stop disable: turn it off and the Worktree mode toggle disappears from every agent's Configure tab going forward. Existing per-agent settings keep working at runtime.
+
+## Enforcement surface
+
+`enforcementSurface: "ui"`. The engine's `/v1/worktrees` route stays open whether the flag is on or off. Custom frontends consuming the engine directly (for example `examples/smartbooks/`) can use worktrees without involving this flag.
+
+## Implementation pointers
+
+- Flag entry: `app/src/lib/featureFlags.ts::FLAG_REGISTRY["advanced.worktrees"]`
+- Gate site: `app/src/components/tabs/configure-sections.tsx` wraps the Worktree mode row in `<FeatureGate flag="advanced.worktrees">`
+- Engine route (unchanged by this flag): `engine/houston-engine-server/src/routes/worktrees.rs`
+- Mission-send sites that read `cfg.worktreeMode`: `app/src/components/tabs/board-tab.tsx` and `app/src/components/use-agent-chat-panel.tsx`
+
+## Recommended companion flags
+
+None at the moment. A future `advanced.git_panel` flag (RFC #248 Phase 3) pairs well with worktrees but is independently useful, so the two stay decoupled.
+
+## See also
+
+- `knowledge-base/feature-flags.md` — the 12 rules + adding-a-flag procedure
+- RFC: `gethouston/houston#248` — the umbrella RFC for the advanced settings wave

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -318,6 +318,7 @@ forwarder sends — essential for remote clients where bandwidth matters.
 | `toast` | `Toast`, `CompletionToast` |
 | `events` | `EventReceived`, `EventProcessed` |
 | `auth` | `AuthRequired` |
+| `preferences` | `PreferenceChanged` |
 
 ## Auditing conformance
 

--- a/knowledge-base/feature-flags.md
+++ b/knowledge-base/feature-flags.md
@@ -1,0 +1,110 @@
+# Feature flags
+
+Houston's Advanced settings section exposes power-user capabilities as per-flag toggles. Each flag is an opt-in entitlement, persisted per-install via `/v1/preferences/:key`, and gated in the UI through a `useFeatureFlag` hook plus a `FeatureGate` component. Phase 0 ships the plumbing; phases 1-9 each add one flag plus its engine-side capability.
+
+This doc is the rule reference. Read once, then add your entry to `app/src/lib/featureFlags.ts` and follow the established pattern.
+
+## Substrate
+
+| Piece | Path |
+|------|------|
+| Registry, helpers, migrations | [app/src/lib/featureFlags.ts](../app/src/lib/featureFlags.ts) |
+| Resolution hook | [app/src/hooks/useFeatureFlag.ts](../app/src/hooks/useFeatureFlag.ts) |
+| Gate component | [app/src/components/FeatureGate.tsx](../app/src/components/FeatureGate.tsx) |
+| Settings section | [app/src/components/settings/sections/advanced.tsx](../app/src/components/settings/sections/advanced.tsx) |
+| Storage | `/v1/preferences/:key` — same KV used by `theme`, `timezone`, etc. |
+| Cross-tab invalidation | `HoustonEvent::PreferenceChanged` (engine → WS firehose → `use-agent-invalidation.ts`) |
+| Migration runner | `runFlagMigrations()` called once from `useHoustonInit` |
+
+## The 12 rules
+
+1. **String-typed storage, centralized encoding.** The preferences route is string-only. Encode booleans as `"true"` / `"false"` strings via `flagToString` / `stringToFlag`. Three states matter: `true`, `false`, `null` (unset). Never compare raw strings inline.
+
+2. **Two-level namespace, forever-API names.** `<category>.<feature_snake_case>` — e.g. `advanced.git_panel`. Once a key is in user preferences databases, renaming is a migration. `advanced.*` is the only category for now; `experiment.*`, `ops.*`, `workspace.<id>.*` are reserved for future use. Everything else flat (`theme`, `timezone`, `locale`) is legacy non-flag prefs.
+
+3. **One registry file, one entry per flag.** Every flag has a `FlagDef` in `FLAG_REGISTRY`. No flag exists without an entry; no entry exists without a flag. The Settings UI iterates `Object.values(FLAG_REGISTRY)` — adding a flag is one-stop.
+
+4. **Defaults live in the registry, never in storage.** If `stringToFlag(stored) === null`, fall through to `FLAG_REGISTRY[key].default`. Never auto-write a default on first read. When a flag graduates to default-on, you change the code default; users who explicitly chose `false` stay `false`; users who never touched the toggle get the new default automatically.
+
+5. **Declare enforcement surface explicitly.** `FlagDef.enforcementSurface` is `"ui"`, `"engine"`, or `"both"`. UI-only flags don't burden the engine. Engine-enforced flags read the preference at the actual check point (not at startup) so a toggle takes effect immediately. The split keeps reviewers honest about where the security boundary lives.
+
+6. **Soft hints over hard dependencies.** Never auto-flip another flag in response to a user toggle. Use the `recommends?: string[]` field to surface a soft hint in the description (e.g. "Recommended: also enable Claude hooks for reliable pre-action blocking"). Respect user agency.
+
+7. **TanStack Query plus WS-event invalidation.** `useFeatureFlag` keys its query by `["preference", key]` with a 60s stale time. Local toggles invalidate after the PUT settles. Cross-tab and cross-client invalidation arrives via `PreferenceChanged` WS events handled in `use-agent-invalidation.ts`. Mobile companions get flag changes for free.
+
+8. **Writes alert, reads degrade gracefully.** The PUT preference path surfaces failures as toasts with a Report-bug button (via the existing `call()` wrapper in `tauri.ts`). The GET read path tolerates failures silently — it falls back to the code default and logs to the frontend log. Matches Houston's beta-stage no-silent-failures policy on user-initiated actions.
+
+9. **Declare `graduationTarget` at birth.** Every `FlagDef` ships with either a version string (e.g. `"0.7.0"` — the release that flips the default) or `"permanent"`. Quarterly review cross-references registry × adoption telemetry × target to decide promotions. The four statuses (`beta` / `stable` / `graduating` / `retiring`) trace the lifecycle.
+
+10. **Migrations through `FLAG_MIGRATIONS`.** Renames and deletes are append-only entries in the migration log. `runFlagMigrations` runs once at boot from `useHoustonInit` and is idempotent — applying a `rename` whose `from` key is already absent is a no-op. Never lose user choices silently; copy `from` to `to` only when the new key is empty.
+
+11. **Don't fingerprint with the flag-set.** If telemetry on toggle is wired (PostHog `feature_flag.toggled` with `{key, newValue, oldValue}`), emit only on user-initiated PUTs. Never include the full flag-set in analytics events, error reports, or bug-report payloads. Scrub.
+
+12. **Five-layer resolution, dev layers stripped in prod.** `useFeatureFlag` walks: URL query (`?flag.<key>=on`) → `window.__HOUSTON_FLAGS_OVERRIDE__` → `localStorage["flag.<key>"]` → engine preference → registry default. Layers 1-3 are wrapped in `import.meta.env.DEV` so Vite tree-shakes them from production. Production users only see layers 4 and 5.
+
+## Reserved namespaces
+
+| Namespace | Purpose | Status |
+|-----------|---------|--------|
+| `advanced.*` | Permission toggles (this plan) | active |
+| `experiment.*` | A/B testing exposure | reserved (no implementation yet) |
+| `ops.*` | Kill switches / emergency flags | reserved |
+| `workspace.<id>.*` | Per-workspace prefs (future) | reserved |
+| (flat) | Legacy non-flag prefs (`theme`, `locale`, `timezone`, …) | active |
+
+## Adding a flag (the procedure)
+
+When you ship a new advanced capability:
+
+1. **Append the `FlagDef`** to `FLAG_REGISTRY` in `app/src/lib/featureFlags.ts`:
+   ```ts
+   "advanced.git_panel": {
+     key: "advanced.git_panel",
+     category: "advanced",
+     default: false,
+     labelKey: "advanced.flags.gitPanel.label",
+     descriptionKey: "advanced.flags.gitPanel.description",
+     enforcementSurface: "ui",
+     status: "beta",
+     learnMoreSlug: "git-panel",
+     since: "0.5.0",
+     graduationTarget: "permanent",
+   },
+   ```
+
+2. **Add locale strings** to `app/src/locales/{en,es,pt}/settings.json` under `advanced.flags.gitPanel.{label,description}`. All three languages, no em-dashes, neutral Latin-American Spanish, Brazilian Portuguese. `pnpm --filter houston-app check-locales` enforces parity.
+
+3. **Gate the UI** with `<FeatureGate flag="advanced.git_panel">…</FeatureGate>` or `const enabled = useFeatureFlag("advanced.git_panel");` for the inject / replace patterns described in [docs/plans/2026-05-22-houston-advanced-settings.html](../../docs/plans/2026-05-22-houston-advanced-settings.html) §4.
+
+4. **Write tests.** Unit tests for any new helper. Component test asserting the gated UI appears when the flag is on and stays hidden when off. Use `window.__HOUSTON_FLAGS_OVERRIDE__` in tests (DEV-only layer).
+
+5. **Knowledge-base entry** at `knowledge-base/advanced-<learnMoreSlug>.md` documenting what the capability does and how it's enforced. The flag description ends with "(see docs)" so users can read the deeper write-up.
+
+## Migration policy
+
+When a flag is renamed: append a `{ type: "rename", from, to, since }` entry to `FLAG_MIGRATIONS`. Boot copies the old key's value to the new key (unless the new key is already set), then clears the old. Idempotent.
+
+When a flag retires after graduation: append a `{ type: "delete", key, since }` entry. Boot clears the stored value so the registry can drop the entry.
+
+Never edit an existing migration entry. Append-only. The migration log IS the audit trail.
+
+## Graduation policy
+
+Quarterly (or per-release for fast cycles):
+
+1. Sort the registry by `since` ascending.
+2. For each flag, pull telemetry: adoption rate, error rate, last-toggled timestamp.
+3. Apply the promotion rules:
+   - `beta` with stable adoption and zero errors → promote to `stable`.
+   - `stable` whose `graduationTarget` is hit and ≥ 50% power-user adoption → flip default to true, status to `graduating`.
+   - `stable` with zero adoption after six months → consider retire.
+   - `graduating` for two-plus releases with no new opt-outs → promote to `retiring`.
+   - `retiring` for one release with no objection → remove via `FLAG_MIGRATIONS`.
+
+The four statuses (`beta` / `stable` / `graduating` / `retiring`) and the lifecycle path are codified in `FlagStatus` and `FlagDef.graduationTarget`. The review is the discipline; the registry is the surface that makes it easy.
+
+## See also
+
+- Plan: [docs/plans/2026-05-22-houston-advanced-settings.html](../../docs/plans/2026-05-22-houston-advanced-settings.html) — what each phase ships
+- Design doc: [docs/plans/2026-05-22-feature-flag-design.html](../../docs/plans/2026-05-22-feature-flag-design.html) — the deeper why
+- i18n discipline: [knowledge-base/i18n.md](i18n.md) — locale string conventions every flag PR must follow

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -109,10 +109,14 @@ export interface AIBoardProps {
   /** Custom renderer for markdown links. Forwarded to ChatPanel. */
   renderLink?: import("@houston-ai/chat").ChatPanelProps["renderLink"]
   /**
-   * Composer footer content. When a function, called with `{ hasMessages }` so
-   * the consumer can lock the provider for active conversations.
+   * Composer footer content. When a function, called with
+   * `{ hasMessages, feedItems }` so the consumer can both lock the provider
+   * for active conversations AND render derived widgets like a context meter
+   * that need access to the current session's items.
    */
-  footer?: ReactNode | ((ctx: { hasMessages: boolean }) => ReactNode)
+  footer?:
+    | ReactNode
+    | ((ctx: { hasMessages: boolean; feedItems: FeedItem[] }) => ReactNode)
   /** Content rendered inside the composer above the textarea. */
   composerHeader?: ReactNode | ((ctx: { hasMessages: boolean }) => ReactNode)
   /** Popover menu anchored to the composer's paperclip button. When a
@@ -530,7 +534,11 @@ export function AIBoard({
           onAttachmentRejections={onAttachmentRejections}
           onOpenLink={onOpenLink}
           renderLink={renderLink}
-          footer={typeof footer === "function" ? footer({ hasMessages: activeFeed.length > 0 }) : footer}
+          footer={
+            typeof footer === "function"
+              ? footer({ hasMessages: activeFeed.length > 0, feedItems: activeFeed })
+              : footer
+          }
           composerHeader={typeof composerHeader === "function" ? composerHeader({ hasMessages: activeFeed.length > 0 }) : composerHeader}
           attachMenu={
             typeof attachMenu === "function"

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -22,6 +22,14 @@ export type FeedItem =
         result: string;
         cost_usd: number | null;
         duration_ms: number | null;
+        /** Tokens the model saw in its context this turn (Anthropic-only on Claude; codex/gemini may be null). */
+        input_tokens: number | null;
+        /** Tokens the model generated this turn. */
+        output_tokens: number | null;
+        /** Tokens written to Anthropic prompt cache this turn. Null when caching is off. */
+        cache_creation_input_tokens: number | null;
+        /** Tokens served from Anthropic prompt cache this turn. Null when caching is off. */
+        cache_read_input_tokens: number | null;
       };
     };
 

--- a/ui/core/src/types.ts
+++ b/ui/core/src/types.ts
@@ -73,6 +73,10 @@ export type HoustonEvent =
       data: { job_id: string; job_name: string; prompt: string };
     }
   | {
+      type: "PreferenceChanged";
+      data: { key: string; value: string | null };
+    }
+  | {
       type: "RoutinesChanged";
       data: { agent_path: string };
     }


### PR DESCRIPTION
Stacks on **A1 (#267)** — please review A1 first. The shared feature-flag infra appears in both; the **net-new over A1** is two commits:
- `677e430` — `advanced.context_meter` token-usage wheel in the chat composer
- `50001ae` — context meter in mission chat + consistent percent base

All behind the `advanced` flag (RFC #248). Supersedes #268 (strict subset). Once A1 merges, GitHub retargets this to `main` and the diff collapses to just the context-meter changes.
