### PR TITLE
feat(scripts): optional contributor tooling — houston-doctor + check-cli-deps

### DIFF
--- a/scripts/check-cli-deps.sh
+++ b/scripts/check-cli-deps.sh
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Report drift between `cli-deps.json` pinned versions and the latest
+# upstream GitHub releases. This is the pre-bump scout for `bump-cli.sh`:
+# run this first to decide whether a bump is worth doing, then `bump-cli.sh`
+# + `fetch-cli-deps.sh` to actually execute the bump.
+#
+# Exit-code contract:
+#   0 — every checked binary is current OR at most patch-level behind
+#       (patches usually carry security fixes only and don't block a release)
+#   1 — at least one binary is ≥1 minor version behind (drift worth a bump)
+#   2 — environmental error (missing tool, missing cli-deps.json) — distinct
+#       from drift so a CI consumer can tell apart "drift detected" from
+#       "couldn't run"
+#
+# Network failures on a single row are reported as `(network error)` and do
+# NOT change the exit code: the row is excluded from the drift vote, so a
+# flaky `gh api` call cannot flip a clean check to a false 1 or a real
+# drift to a false 0. Final code reflects only resolved rows. Rate-limit
+# failures are reported distinctly as `(GitHub rate limit hit — retry
+# after reset)` so the contributor knows to wait 1h vs check connectivity.
+#
+# Why `gh api` and not curl: gh reuses the contributor's authenticated
+# GitHub session (5000 req/hr ceiling) instead of unauthenticated 60/hr.
+# Intended for pre-release-PR integration once wired into
+# `.github/workflows/`; not currently invoked from any workflow file in
+# the repo (call site is a follow-up PR).
+# ============================================================================
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEPS_FILE="$REPO_ROOT/cli-deps.json"
+[ -f "$DEPS_FILE" ] || { echo "ERROR: cli-deps.json not found at $DEPS_FILE" >&2; exit 2; }
+for cmd in jq gh; do
+  command -v "$cmd" >/dev/null 2>&1 || { echo "ERROR: $cmd is required but not installed" >&2; exit 2; }
+done
+
+# ANSI color only when stdout is a tty — piping to a file or `tee` strips
+# the escape codes so CI logs / grep stay clean.
+if [ -t 1 ]; then
+  C_RED=$'\033[31m'; C_YEL=$'\033[33m'; C_DIM=$'\033[2m'; C_RST=$'\033[0m'
+else
+  C_RED=""; C_YEL=""; C_DIM=""; C_RST=""
+fi
+
+# Drift flag — set when any row is ≥1 minor behind. Network errors, rate
+# limits, and patch-only drift do not set this. Final exit reflects only
+# this flag.
+DRIFT=0
+
+# ---------------------------------------------------------------------------
+# Numeric semver compare. Splits "X.Y.Z" on dots, pads to 3 segments, and
+# returns "current | patch:N | minor:N | major:N" where N is the actual
+# gap at that level (so "3 minor behind" is reported when codex is 3
+# minors behind, not the misleading hardcoded "1 minor behind"). We compare
+# as numbers (10# zero-padded form) so `0.130.0` vs `0.131.0` orders
+# correctly — string compare happens to work for these specific values but
+# breaks the moment a two-digit minor meets a three-digit one. Pre-release
+# suffixes (-beta.N, -rc.N) are stripped before split. Non-numeric input
+# falls through to `network`, NOT `current` — silently degrading malformed
+# upstream data to "current" would hide a real failure (this used to be
+# a false-positive vector before the gh_api_tag helper).
+# Bash 3.2: no associative arrays, plain IFS-based split.
+# ---------------------------------------------------------------------------
+compare_versions() {
+  local pinned="${1%%-*}" latest="${2%%-*}"
+  case "$pinned$latest" in *[!0-9.]*) echo "network"; return ;; esac
+  local IFS=.
+  # shellcheck disable=SC2206  # intentional word-split on '.'
+  local p=($pinned) l=($latest)
+  local i p_i l_i gap
+  for i in 0 1 2; do
+    p_i=$((10#${p[$i]:-0})); l_i=$((10#${l[$i]:-0}))
+    if [ "$p_i" -lt "$l_i" ]; then
+      gap=$((l_i - p_i))
+      case $i in 0) echo "major:$gap";; 1) echo "minor:$gap";; 2) echo "patch:$gap";; esac
+      return
+    elif [ "$p_i" -gt "$l_i" ]; then
+      # Pinned ahead of upstream — treat as current. Happens when we pin a
+      # pre-release we built locally that hasn't shipped upstream yet.
+      echo "current"; return
+    fi
+  done
+  echo "current"
+}
+
+# Format one row + accumulate drift. `kind` is compare_versions output OR
+# the sentinel strings `network` / `ratelimit` / `proprietary`.
+emit_row() {
+  local name="$1" pinned="$2" latest="$3" kind="$4"
+  local note="" color="" level="${kind%%:*}" gap="${kind#*:}" unit=""
+  case "$level" in
+    current)     note="current" ;;
+    patch)       unit=$([ "$gap" -eq 1 ] && echo patch || echo patches)
+                 note="$gap $unit behind";                         color="$C_YEL" ;;
+    minor)       unit=$([ "$gap" -eq 1 ] && echo minor || echo minors)
+                 note="$gap $unit behind  (drift)";                color="$C_RED"; DRIFT=1 ;;
+    major)       unit=$([ "$gap" -eq 1 ] && echo major || echo majors)
+                 note="$gap $unit behind  (drift)";                color="$C_RED"; DRIFT=1 ;;
+    network)     note="(network error)";                           color="$C_DIM" ;;
+    ratelimit)   note="(GitHub rate limit hit, retry after reset)"; color="$C_YEL" ;;
+    proprietary) printf "%b%-16s %-8s             %s%b\n" "$C_DIM" "$name" "$pinned" \
+                        "(proprietary, no upstream API)" "$C_RST"; return ;;
+  esac
+  printf "%b%-16s %-8s -> %-8s %s%b\n" "$color" "$name" "$pinned" "$latest" "$note" "$C_RST"
+}
+
+# ---------------------------------------------------------------------------
+# Helper — wraps `gh api ...` with rate-limit detection and null-tag
+# rejection. Returns:
+#   0  -> success; prints tag on stdout
+#   1  -> generic network/API failure, OR upstream returned `null` (zero
+#         releases) — both produce `(network error)` in the row
+#   2  -> GitHub rate-limit hit (5000/hr ceiling on authenticated calls)
+#
+# Distinguishing 1 vs 2 lets the contributor know to wait an hour (rate
+# limit reset) vs check their connection — without this, both surface
+# as `(network error)` and the contributor cannot act on the right
+# remediation. Stderr capture-and-grep against `gh`'s canonical "API rate
+# limit exceeded" wording is the cheapest reliable detector.
+#
+# Null-tag rejection guards against the silent-false-current failure
+# mode: a repo with zero releases makes `gh api .../releases/latest`
+# exit 0 with stdout `null`. Without the explicit reject, the prefix
+# strip yields `null` which compare_versions's non-numeric guard
+# silently degrades to "current" — masking a real lookup failure.
+# ---------------------------------------------------------------------------
+gh_api_tag() {
+  local stderr tag rc=0
+  stderr=$(mktemp)
+  tag=$(gh api "$@" 2>"$stderr") || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    if grep -qi 'rate limit\|api rate\|secondary rate' "$stderr"; then
+      rm -f "$stderr"
+      return 2
+    fi
+    rm -f "$stderr"
+    return 1
+  fi
+  rm -f "$stderr"
+  # Reject null / empty tags — `gh api` exits 0 with stdout "null" when
+  # the repo has zero releases, which would otherwise silently degrade to
+  # a false "current" verdict downstream.
+  [ -n "$tag" ] && [ "$tag" != "null" ] || return 1
+  printf '%s\n' "$tag"
+}
+
+# ---------------------------------------------------------------------------
+# Upstream lookups. Each calls gh_api_tag (so each gets rate-limit
+# distinction + null guard for free) and either prints bare X.Y.Z on
+# stdout, or returns 1/2 to signal network/ratelimit.
+# ---------------------------------------------------------------------------
+
+# openai/codex tags releases as `rust-v0.133.0` — the `rust-v` prefix
+# disambiguates the production Rust port from an older TypeScript prototype
+# on a separate tag namespace in the same repo.
+latest_codex() {
+  local tag
+  tag=$(gh_api_tag repos/openai/codex/releases/latest --jq '.tag_name') || return $?
+  echo "${tag#rust-v}"
+}
+
+# ComposioHQ/composio is a monorepo of ~30 packages; every package gets
+# its own scoped tag (`@composio/cli@X.Y.Z`, `@composio/python@…`, etc.).
+# `releases/latest` returns whichever package shipped most recently —
+# almost never the CLI. So we filter for the CLI prefix AND strip
+# prereleases (`.prerelease == false`): the CLI's cadence is heavy on
+# `-beta.N` tags (256+ betas between 0.2.24 and 0.2.31 at time of
+# writing) and a contributor bumping should land on the latest STABLE,
+# not the bleeding-edge beta.
+latest_composio() {
+  local tag
+  tag=$(gh_api_tag repos/ComposioHQ/composio/releases \
+        --jq '[.[] | select(.tag_name|startswith("@composio/cli@")) | select(.prerelease==false)] | .[0].tag_name') \
+        || return $?
+  echo "${tag#@composio/cli@}"
+}
+
+# google-gemini/gemini-cli uses a vanilla `vX.Y.Z` tag namespace. No quirks.
+latest_gemini() {
+  local tag
+  tag=$(gh_api_tag repos/google-gemini/gemini-cli/releases/latest --jq '.tag_name') || return $?
+  echo "${tag#v}"
+}
+
+# git-for-windows tags every release as `vX.Y.Z.windows.N` — the
+# `.windows.N` is upstream's build number for the Windows-specific
+# packaging of a given upstream Git release. We strip both the leading
+# `v` and the trailing `.windows.N` so the comparison against the pinned
+# `X.Y.Z` works at the semver level. Drift at the `.windows.N` tier
+# would require its own pin field in cli-deps.json — not modeled today.
+latest_git_bash() {
+  local tag rest
+  tag=$(gh_api_tag repos/git-for-windows/git/releases/latest --jq '.tag_name') || return $?
+  rest="${tag#v}"
+  echo "${rest%%.windows.*}"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch one row. Order: claude-code first so the proprietary line sets
+# expectations, then alphabetical for the rest. Each upstream call's exit
+# code threads through `rc`: 0 -> compare normally, 1 -> network row,
+# 2 -> rate-limit row.
+# ---------------------------------------------------------------------------
+check_one() {
+  local name="$1" pinned latest rc=0
+  pinned=$(jq -r ".[\"$name\"].version // empty" "$DEPS_FILE")
+  [ -n "$pinned" ] || { emit_row "$name" "?" "?" "network"; return; }
+  case "$name" in
+    claude-code) emit_row "$name" "$pinned" "" "proprietary"; return ;;
+    codex)    latest=$(latest_codex)    || rc=$? ;;
+    composio) latest=$(latest_composio) || rc=$? ;;
+    gemini)   latest=$(latest_gemini)   || rc=$? ;;
+    git-bash) latest=$(latest_git_bash) || rc=$? ;;
+    *)        emit_row "$name" "$pinned" "?" "network"; return ;;
+  esac
+  case "$rc" in
+    0) emit_row "$name" "$pinned" "$latest" "$(compare_versions "$pinned" "$latest")" ;;
+    1) emit_row "$name" "$pinned" "?" "network" ;;
+    2) emit_row "$name" "$pinned" "?" "ratelimit" ;;
+    *) emit_row "$name" "$pinned" "?" "network" ;;
+  esac
+}
+
+for name in claude-code codex composio gemini git-bash; do
+  check_one "$name"
+done
+
+exit "$DRIFT"

--- a/scripts/houston-doctor.sh
+++ b/scripts/houston-doctor.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# ============================================================================
+# houston-doctor — pre-PR diagnostic snapshot of a contributor's environment.
+#
+# Run BEFORE opening a PR to confirm the local checkout, engine sidecar,
+# ~/.houston/ state, and CLI-deps staging are in known-good shape. Read-only:
+# never builds, fetches, or mutates. Exits 0 unless something is genuinely
+# broken — STALE engine sidecars are WARN, not FAIL, because most
+# contributors hit that mid-dev when the frontend HMRs faster than cargo.
+#
+# Section 1 is the explicit detector for the CLAUDE.md §"Engine sidecar
+# staleness" footgun: `pnpm tauri dev` does NOT rebuild engine/ on its own,
+# so the sidecar can be days stale while the frontend looks fresh —
+# symptoms are 404s on routes that exist in the current source.
+#
+# Doctor is a snapshot, not a fixer. Whatever it surfaces, the contributor
+# resolves with the next-command hint printed inline.
+#
+# Bash 3.2 (macOS default) — no associative arrays, no mapfile, no ${var,,}.
+# Deps already in any Houston contributor's env: bash, jq, curl, du, find, git.
+# ============================================================================
+set -euo pipefail
+
+# Deps precheck — fail early with an actionable install hint rather than
+# crash mid-section with bash exit 127. Mirrors the precondition block in
+# scripts/fetch-cli-deps.sh:81-84 so contributors get the same DX whichever
+# script they invoke first.
+for _cmd in jq curl find du git awk; do
+  command -v "$_cmd" >/dev/null 2>&1 || {
+    printf 'FAIL houston-doctor needs `%s` but it is missing from $PATH\n' "$_cmd" >&2
+    printf '     install: brew install %s    (or the distro equivalent)\n' "$_cmd" >&2
+    exit 1
+  }
+done
+unset _cmd
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOUSTON_HOME="${HOUSTON_HOME:-$HOME/.houston}"
+
+# Color discipline: ANSI only on a real tty so piped output (CI logs, files)
+# stays plain-text grep-able. `test -t 1` is the POSIX-portable check.
+if [ -t 1 ]; then
+  C_RED=$'\033[31m'; C_YEL=$'\033[33m'; C_GRN=$'\033[32m'
+  C_DIM=$'\033[2m';  C_RST=$'\033[0m'
+else
+  C_RED=""; C_YEL=""; C_GRN=""; C_DIM=""; C_RST=""
+fi
+
+FAIL_COUNT=0
+WARN_COUNT=0
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); printf '%sFAIL%s %s\n' "$C_RED" "$C_RST" "$1"; }
+warn() { WARN_COUNT=$((WARN_COUNT + 1)); printf '%sWARN%s %s\n' "$C_YEL" "$C_RST" "$1"; }
+ok()   { printf '%sOK%s   %s\n' "$C_GRN" "$C_RST" "$1"; }
+info() { printf '     %s\n' "$1"; }
+hdr()  { printf '\n=== %s ===\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# SECTION 1 — Engine sidecar staleness
+#   CLAUDE.md §"Engine sidecar staleness" footgun: Tauri does NOT rebuild
+#   engine/ on HMR, so a stale `target/release/houston-engine` will run
+#   yesterday's sidecar against today's frontend. We compare mtimes via
+#   `find -newer` (Bash 3.2-safe; no epoch arithmetic) and short-circuit
+#   at the first newer source via `head -1` so this stays cheap on large
+#   worktrees. Windows checkouts use `.exe`; missing binary is INFO, not
+#   FAIL — fresh checkout before `cargo build` is the common case.
+# ---------------------------------------------------------------------------
+hdr "Engine sidecar"
+case "$(uname -s)" in
+  MINGW*|MSYS*|CYGWIN*) ENGINE_BIN="$REPO_ROOT/target/release/houston-engine.exe" ;;
+  *)                    ENGINE_BIN="$REPO_ROOT/target/release/houston-engine" ;;
+esac
+if [ ! -f "$ENGINE_BIN" ]; then
+  info "no release sidecar at $ENGINE_BIN"
+  info "fresh checkout? run: cargo build --release -p houston-engine-server"
+else
+  NEWER="$(find "$REPO_ROOT/engine" -name '*.rs' -type f -newer "$ENGINE_BIN" 2>/dev/null | head -1 || true)"
+  if [ -n "$NEWER" ]; then
+    warn "STALE sidecar — run \`cargo build --release -p houston-engine-server\`"
+    info "newer source: ${NEWER#"$REPO_ROOT/"}"
+    info "(CLAUDE.md §\"Engine sidecar staleness\" — dev-only footgun)"
+  else
+    ok "sidecar up-to-date relative to engine/**/*.rs"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# SECTION 2 — ~/.houston/ state
+#   Missing dir is fine (fresh dev machine that's never run `pnpm tauri dev`).
+#   `du` failing on a *present* dir = perms/disk error and FAIL because the
+#   engine can't run against an unreadable home. Sessions live deep:
+#   ~/.houston/workspaces/<W>/<Agent>/.houston/sessions/<provider>/<id>.sid;
+#   `-mtime -7` keeps the signal contributors care about (cold sessions
+#   tell us nothing about whether the contributor's loop works).
+# ---------------------------------------------------------------------------
+hdr "~/.houston/ state"
+if [ ! -d "$HOUSTON_HOME" ]; then
+  info "no $HOUSTON_HOME — fresh machine, engine has never been started"
+else
+  if SIZE="$(du -sh "$HOUSTON_HOME" 2>/dev/null | cut -f1)"; then
+    info "size:       $SIZE"
+  else
+    fail "cannot stat $HOUSTON_HOME (perms? unreadable?)"
+  fi
+  if [ -d "$HOUSTON_HOME/workspaces" ]; then
+    WS_COUNT="$(find "$HOUSTON_HOME/workspaces" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')"
+    info "workspaces: $WS_COUNT"
+  else
+    info "workspaces: 0 (no workspaces/ dir)"
+  fi
+  RECENT_SID="$(find "$HOUSTON_HOME" -name '*.sid' -type f -mtime -7 2>/dev/null | wc -l | tr -d ' ')"
+  info "recent .sid (<=7d): $RECENT_SID"
+  ok "~/.houston/ readable"
+fi
+
+# ---------------------------------------------------------------------------
+# SECTION 3 — Engine HTTP probe
+#   Engine binds 127.0.0.1:0 (random port) — see
+#   engine/houston-engine-server/src/main.rs::write_manifest — and records
+#   the chosen port in ~/.houston/engine.json. We read it from there rather
+#   than hardcoding (8011/8080/etc. don't exist anywhere in the engine).
+#   Every /v1/* route runs through bearer auth (auth::require_bearer in
+#   engine/houston-engine-server/src/lib.rs); doctor doesn't carry the
+#   token, so the *expected* "engine up" signal is 401 — that means the
+#   auth layer ran, which means the engine is serving. 200 would only
+#   happen if the contributor exported HOUSTON_ENGINE_TOKEN. Both prove
+#   it's running. 1-second timeout because loopback is either there or
+#   not. No engine = INFO (app is just closed).
+# ---------------------------------------------------------------------------
+hdr "Engine HTTP probe"
+MANIFEST="$HOUSTON_HOME/engine.json"
+if [ ! -f "$MANIFEST" ]; then
+  info "no engine.json — engine has never started (or home was cleaned)"
+elif ! ENGINE_PORT="$(jq -er '.port' "$MANIFEST" 2>/dev/null)"; then
+  warn "engine.json present but unparseable (missing .port)"
+else
+  URL="http://127.0.0.1:$ENGINE_PORT/v1/health"
+  CODE="$(curl -s -o /dev/null -w '%{http_code}' --max-time 1 "$URL" 2>/dev/null || echo "000")"
+  case "$CODE" in
+    200) ok "engine running on :$ENGINE_PORT (token-authed, HTTP 200)" ;;
+    401) ok "engine running on :$ENGINE_PORT (HTTP 401 from /v1/health is expected without HOUSTON_ENGINE_TOKEN)" ;;
+    000) info "engine not running on :$ENGINE_PORT (no listener; fine if app is closed)" ;;
+    *)   warn "engine on :$ENGINE_PORT returned HTTP $CODE — unexpected" ;;
+  esac
+fi
+
+# ---------------------------------------------------------------------------
+# SECTION 4 — CLI-deps pin summary
+#   Dollar-prefix keys ($schema, $comment) are manifest metadata and excluded
+#   — same `select(startswith("$") | not)` idiom bump-cli.sh uses.
+#   Resources/bin/ empty is INFO, not FAIL: fresh checkouts haven't run
+#   fetch-cli-deps.sh yet, and only `pnpm tauri build` (not `dev`) reads it.
+# ---------------------------------------------------------------------------
+hdr "CLI-deps pin summary"
+DEPS="$REPO_ROOT/cli-deps.json"
+BIN_DIR="$REPO_ROOT/app/src-tauri/resources/bin"
+if [ ! -f "$DEPS" ]; then
+  fail "cli-deps.json missing at $DEPS"
+else
+  jq -r 'to_entries[] | select(.key | startswith("$") | not) | "\(.key)\t\(.value.version // "?")"' \
+    "$DEPS" | awk -F'\t' '{ printf "     %-14s %s\n", $1, $2 }'
+  if [ -d "$BIN_DIR" ] && [ -n "$(ls -A "$BIN_DIR" 2>/dev/null)" ]; then
+    STAGED="$(ls "$BIN_DIR" | tr '\n' ' ')"
+    info "staged in resources/bin/: ${C_DIM}${STAGED}${C_RST}"
+  else
+    info "resources/bin/ empty — run ./scripts/fetch-cli-deps.sh host"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# SECTION 5 — Git tree state
+#   `git status -sb` summary, ahead/behind vs origin/main, capped list of
+#   dirty files so massive in-progress refactors don't drown the report.
+#   Detached HEAD is FAIL: CLAUDE.md §"Git — Worktree workflow" relies on
+#   a named branch (claude/<worktree-name>) for the PR step; accidentally
+#   detaching strands your work and breaks the commit/push/PR pipeline.
+# ---------------------------------------------------------------------------
+hdr "Git tree state"
+if BRANCH="$(git -C "$REPO_ROOT" symbolic-ref --quiet --short HEAD 2>/dev/null)"; then
+  info "branch: $BRANCH"
+else
+  fail "detached HEAD — checkout your worktree branch before committing"
+fi
+if AHEAD_BEHIND="$(git -C "$REPO_ROOT" rev-list --left-right --count origin/main...HEAD 2>/dev/null)"; then
+  BEHIND="$(printf '%s\n' "$AHEAD_BEHIND" | awk '{print $1}')"
+  AHEAD="$(printf '%s\n' "$AHEAD_BEHIND" | awk '{print $2}')"
+  info "ahead of origin/main: $AHEAD   behind: $BEHIND"
+else
+  info "ahead/behind unknown (origin/main not fetched?)"
+fi
+DIRTY="$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null | wc -l | tr -d ' ')"
+if [ "$DIRTY" -eq 0 ]; then
+  ok "tree clean"
+else
+  info "uncommitted files: $DIRTY (showing first 10)"
+  git -C "$REPO_ROOT" status --porcelain 2>/dev/null | head -10 | sed 's/^/       /'
+fi
+
+# ---------------------------------------------------------------------------
+# SECTION 6 — Verdict
+#   Exit 0 unless a FAIL fired. STALE sidecar is WARN only — half the dev
+#   population would otherwise be blocked mid-flow.
+# ---------------------------------------------------------------------------
+hdr "Verdict"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+  printf '%sFAIL%s — %d failure(s), %d warning(s). Fix the FAILs before opening a PR.\n' "$C_RED" "$C_RST" "$FAIL_COUNT" "$WARN_COUNT"
+  exit 1
+fi
+if [ "$WARN_COUNT" -gt 0 ]; then
+  printf '%sWARN%s — %d warning(s). Safe to open a PR; resolve warnings if related.\n' "$C_YEL" "$C_RST" "$WARN_COUNT"
+else
+  printf '%sPASS%s — all checks green.\n' "$C_GRN" "$C_RST"
+fi
+exit 0


### PR DESCRIPTION
Optional contributor tooling — two standalone scripts, no runtime or product impact.

- `scripts/houston-doctor.sh` — pre-PR environment + state snapshot (versions, branch, ahead/behind, dirty tree).
- `scripts/check-cli-deps.sh` — drift scout: flags when bundled CLI pins fall behind upstream releases.

Both are opt-in helpers; nothing in the build or app depends on them. Pull if useful, ignore if not.

Consolidates #244 + #245.
