### PR TITLE
feat(ask-user): MCP-backed interactive AskUserQuestion across the agent stack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2545,6 +2545,7 @@ name = "houston-engine-server"
 version = "0.4.12"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "axum 0.7.9",
  "base64 0.22.1",

--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -432,6 +432,7 @@ export function Dashboard() {
           afterMessages={panel.afterMessages}
           isSpecialTool={panel.isSpecialTool}
           renderToolResult={panel.renderToolResult}
+          renderPendingTool={panel.renderPendingTool}
           processLabels={panel.processLabels}
           getThinkingMessage={panel.getThinkingMessage}
           renderTurnSummary={panel.renderTurnSummary}

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -725,6 +725,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
           afterMessages={panel.afterMessages}
           isSpecialTool={panel.isSpecialTool}
           renderToolResult={panel.renderToolResult}
+          renderPendingTool={panel.renderPendingTool}
           processLabels={panel.processLabels}
           getThinkingMessage={panel.getThinkingMessage}
           renderTurnSummary={panel.renderTurnSummary}

--- a/app/src/components/tabs/chat-tab.tsx
+++ b/app/src/components/tabs/chat-tab.tsx
@@ -21,6 +21,8 @@ import { tauriChat, tauriAttachments, tauriConfig, tauriProvider } from "../../l
 import { openAgentHref } from "../../lib/open-href";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { useFileToolRenderer } from "../../hooks/use-file-tool-renderer";
+import { useAskUserQuestionRenderer } from "../../hooks/use-ask-user-question-renderer";
+import { useComposedSpecialToolRenderers } from "../../hooks/use-composed-special-tool-renderers";
 import { useConnectedToolkits, useConnections } from "../../hooks/queries";
 import {
   ComposioLinkCard,
@@ -57,11 +59,23 @@ export default function ChatTab({ agent }: TabProps) {
   );
   const { processLabels, getThinkingMessage } = useChatDisplayLabels();
   const attachmentValidation = useAttachmentRejectionDialog();
-  const { isSpecialTool, renderToolResult, renderTurnSummary } = useFileToolRenderer(agent.folderPath);
+  const fileRenderer = useFileToolRenderer(agent.folderPath);
+  const { renderTurnSummary } = fileRenderer;
   // Free-form chat tab gets its own UUID-scoped session key per agent.
   // Must be stable across renders so streaming events land in the same bucket.
   const sessionKey = `chat-${agent.id}`;
   const agentPath = agent.folderPath;
+  const askUserRenderer = useAskUserQuestionRenderer(agentPath, sessionKey);
+  // Compose: file-tool predicate first (Write/Edit), then ask-user predicate
+  // (`mcp__houston__AskUserQuestion`). Both produce their own
+  // renderPendingTool/renderToolResult callbacks; everything else falls
+  // through to the default `<ToolBlock>` rendering.
+  const composedRenderers = useMemo(
+    () => [fileRenderer, askUserRenderer],
+    [fileRenderer, askUserRenderer],
+  );
+  const { isSpecialTool, renderToolResult, renderPendingTool } =
+    useComposedSpecialToolRenderers(composedRenderers);
   // Attachments scope: keyed by agent so they survive restarts and are
   // wiped only when the agent is deleted.
   const attachmentScope = `agent-${agent.id}`;
@@ -288,6 +302,7 @@ export default function ChatTab({ agent }: TabProps) {
         renderLink={renderLink}
         isSpecialTool={isSpecialTool}
         renderToolResult={renderToolResult}
+        renderPendingTool={renderPendingTool}
         processLabels={processLabels}
         getThinkingMessage={getThinkingMessage}
         renderTurnSummary={renderTurnSummary}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -57,6 +57,8 @@ import { createMission } from "../lib/create-mission";
 import { queryKeys } from "../lib/query-keys";
 import { humanizeSkillName } from "../lib/humanize-skill-name";
 import { useFileToolRenderer } from "../hooks/use-file-tool-renderer";
+import { useAskUserQuestionRenderer } from "../hooks/use-ask-user-question-renderer";
+import { useComposedSpecialToolRenderers } from "../hooks/use-composed-special-tool-renderers";
 import {
   ComposioLinkCard,
   parseComposioToolkitFromHref,
@@ -121,6 +123,7 @@ interface AgentChatPanelProps {
   /** Forwarded to AIBoard / ChatPanel for tool rendering. */
   isSpecialTool: ChatPanelProps["isSpecialTool"];
   renderToolResult: ChatPanelProps["renderToolResult"];
+  renderPendingTool: ChatPanelProps["renderPendingTool"];
   processLabels: ChatPanelProps["processLabels"];
   getThinkingMessage: ChatPanelProps["getThinkingMessage"];
   renderTurnSummary: ChatPanelProps["renderTurnSummary"];
@@ -246,8 +249,23 @@ export function useAgentChatPanel({
   );
 
   // ── File-tool rendering (per-agent path) ──────────────────────────────
-  const { isSpecialTool, renderToolResult, renderTurnSummary } =
-    useFileToolRenderer(path ?? "");
+  const fileRenderer = useFileToolRenderer(path ?? "");
+  const { renderTurnSummary } = fileRenderer;
+  // ── AskUserQuestion interactive card ──────────────────────────────────
+  // `selectedSessionKey` is null when the panel renders the empty state;
+  // an empty string is fine because the card only POSTs after the user
+  // clicks Submit, which only happens once a tool_call has arrived (and
+  // by then the session has a real key).
+  const askUserRenderer = useAskUserQuestionRenderer(
+    path ?? "",
+    selectedSessionKey ?? "",
+  );
+  const composedSpecialRenderers = useMemo(
+    () => [fileRenderer, askUserRenderer],
+    [fileRenderer, askUserRenderer],
+  );
+  const { isSpecialTool, renderToolResult, renderPendingTool } =
+    useComposedSpecialToolRenderers(composedSpecialRenderers);
 
   // ── Skills + selected-skill state ─────────────────────────────────────
   const { data: allSkills } = useSkills(path ?? undefined);
@@ -618,6 +636,7 @@ export function useAgentChatPanel({
     renderUserMessage,
     isSpecialTool,
     renderToolResult,
+    renderPendingTool,
     processLabels,
     getThinkingMessage,
     renderTurnSummary,

--- a/app/src/hooks/use-ask-user-question-renderer.tsx
+++ b/app/src/hooks/use-ask-user-question-renderer.tsx
@@ -1,0 +1,147 @@
+/**
+ * Wires the library-pure `<AskUserQuestionCard>` from `@houston-ai/chat` into
+ * Houston's app shell. The card itself knows nothing about the engine; this
+ * hook supplies the missing pieces:
+ *
+ * - `onSubmit` → `engineClient.submitUserInput(agentPath, sessionKey, …)`,
+ *   which POSTs to `/v1/agents/.../sessions/.../user_input`. The engine's
+ *   blocked MCP handler then delivers the answer to the agent as the
+ *   tool_result, and the agent's turn continues.
+ * - `labels` from `t()` so the card respects en/es/pt locales.
+ * - read-only "answered" view when the card is rendered against an already
+ *   resulted tool_call (history reload, or just after submit).
+ *
+ * Returned in the same shape as `useFileToolRenderer` so chat-tab can compose
+ * both — see `compose-special-tool-renderers.ts`.
+ */
+
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AskUserQuestionCard,
+  type AskUserQuestion,
+  type AskUserQuestionAnswer,
+  type ToolEntry,
+} from "@houston-ai/chat";
+import { getEngine } from "../lib/engine";
+
+const ASK_USER_TOOL_NAME = "mcp__houston__AskUserQuestion";
+
+/**
+ * Extract the questions array from a tool_call's input payload. The MCP
+ * server's JSON schema makes this `{ questions: [...] }`, but parser-emitted
+ * tool_call rows can also arrive with `input: null` for the block_start
+ * placeholder before the full input streams in. Return an empty array
+ * in that case so the card renders a loading shell rather than crashing.
+ */
+function readQuestions(input: unknown): AskUserQuestion[] {
+  if (!input || typeof input !== "object") return [];
+  const candidate = (input as { questions?: unknown }).questions;
+  if (!Array.isArray(candidate)) return [];
+  return candidate as AskUserQuestion[];
+}
+
+/**
+ * Best-effort parse of the persisted tool_result content into the typed
+ * answer shape. The engine writes the JSON the frontend POSTed verbatim,
+ * so this normally round-trips cleanly. Returns `undefined` if the content
+ * isn't recognizable answer JSON (e.g. legacy text-only results, or the
+ * "timeout" error string from a pre-SSE engine build).
+ */
+function readAnswered(result: ToolEntry["result"]): AskUserQuestionAnswer | undefined {
+  if (!result || result.is_error) return undefined;
+  try {
+    const parsed = JSON.parse(result.content) as unknown;
+    if (parsed && typeof parsed === "object" && "answers" in parsed) {
+      const answers = (parsed as { answers?: unknown }).answers;
+      if (Array.isArray(answers)) {
+        return parsed as AskUserQuestionAnswer;
+      }
+    }
+  } catch {
+    // Result wasn't JSON — fall through.
+  }
+  return undefined;
+}
+
+export function useAskUserQuestionRenderer(agentPath: string, sessionKey: string) {
+  // i18n keys live under the `chat` namespace alongside the rest of the
+  // chat-tab strings — see `app/src/locales/en/chat.json`.
+  const { t } = useTranslation("chat");
+
+  const labels = useMemo(
+    () => ({
+      submit: t("askUserQuestion.submit"),
+      submitting: t("askUserQuestion.submitting"),
+      other: t("askUserQuestion.other"),
+      otherPlaceholder: t("askUserQuestion.otherPlaceholder"),
+      selectOne: t("askUserQuestion.selectOne"),
+      selectMany: t("askUserQuestion.selectMany"),
+      answered: t("askUserQuestion.answered"),
+    }),
+    [t],
+  );
+
+  const isSpecialTool = useCallback(
+    (toolName: string) => toolName === ASK_USER_TOOL_NAME,
+    [],
+  );
+
+  const renderPendingTool = useCallback(
+    (tool: ToolEntry, index: number) => {
+      const questions = readQuestions(tool.input);
+      const toolUseId = tool.tool_use_id ?? "";
+      // No tool_use_id means the parser hasn't finalized the block yet
+      // (input still null on the block_start emit). Render a placeholder
+      // so the user sees activity, but don't try to submit against an
+      // empty id.
+      if (!toolUseId) {
+        return (
+          <div key={`ask-pending-${index}`} className="rounded-xl border border-border/50 bg-card/40 px-4 py-3 text-sm text-muted-foreground italic">
+            {t("askUserQuestion.preparing", { defaultValue: "Preparing question..." })}
+          </div>
+        );
+      }
+      return (
+        <AskUserQuestionCard
+          key={`ask-pending-${toolUseId}`}
+          toolUseId={toolUseId}
+          questions={questions}
+          labels={labels}
+          onSubmit={async (answer) => {
+            await getEngine().submitUserInput(agentPath, sessionKey, toolUseId, answer);
+          }}
+        />
+      );
+    },
+    [agentPath, sessionKey, labels, t],
+  );
+
+  const renderToolResult = useCallback(
+    (tool: ToolEntry, index: number) => {
+      const questions = readQuestions(tool.input);
+      const toolUseId = tool.tool_use_id ?? `idx-${index}`;
+      const answered = readAnswered(tool.result);
+      return (
+        <AskUserQuestionCard
+          key={`ask-done-${toolUseId}`}
+          toolUseId={toolUseId}
+          questions={questions}
+          labels={labels}
+          answered={answered}
+          onSubmit={async () => {
+            // Already answered — onSubmit should never fire from the
+            // read-only AnsweredView. Provide a no-op to satisfy the
+            // required prop.
+          }}
+        />
+      );
+    },
+    [labels],
+  );
+
+  return useMemo(
+    () => ({ isSpecialTool, renderPendingTool, renderToolResult }),
+    [isSpecialTool, renderPendingTool, renderToolResult],
+  );
+}

--- a/app/src/hooks/use-composed-special-tool-renderers.tsx
+++ b/app/src/hooks/use-composed-special-tool-renderers.tsx
@@ -1,0 +1,52 @@
+/**
+ * Compose multiple "special tool renderer" hooks into a single
+ * `{ isSpecialTool, renderToolResult, renderPendingTool }` triple that
+ * `<ChatPanel>` can consume.
+ *
+ * Each renderer's predicate is OR'd; the first renderer whose predicate
+ * matches gets to render the tool. This lets the file-card hook claim
+ * Write/Edit/MultiEdit and the ask-user hook claim
+ * `mcp__houston__AskUserQuestion` without either knowing about the other.
+ */
+
+import { useCallback, useMemo } from "react";
+import type { ToolEntry } from "@houston-ai/chat";
+
+interface Renderer {
+  isSpecialTool: (name: string) => boolean;
+  renderToolResult?: (tool: ToolEntry, index: number) => React.ReactNode;
+  renderPendingTool?: (tool: ToolEntry, index: number) => React.ReactNode;
+}
+
+export function useComposedSpecialToolRenderers(renderers: Renderer[]) {
+  const pickRenderer = useCallback(
+    (toolName: string) => renderers.find((r) => r.isSpecialTool(toolName)),
+    [renderers],
+  );
+
+  const isSpecialTool = useCallback(
+    (toolName: string) => !!pickRenderer(toolName),
+    [pickRenderer],
+  );
+
+  const renderToolResult = useCallback(
+    (tool: ToolEntry, index: number) => {
+      const renderer = pickRenderer(tool.name);
+      return renderer?.renderToolResult?.(tool, index) ?? null;
+    },
+    [pickRenderer],
+  );
+
+  const renderPendingTool = useCallback(
+    (tool: ToolEntry, index: number) => {
+      const renderer = pickRenderer(tool.name);
+      return renderer?.renderPendingTool?.(tool, index) ?? null;
+    },
+    [pickRenderer],
+  );
+
+  return useMemo(
+    () => ({ isSpecialTool, renderToolResult, renderPendingTool }),
+    [isSpecialTool, renderToolResult, renderPendingTool],
+  );
+}

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -78,5 +78,15 @@
     "learningsUpdated": "Learnings updated"
   },
   "filesUpdated_one": "1 file updated",
-  "filesUpdated_other": "{{count}} files updated"
+  "filesUpdated_other": "{{count}} files updated",
+  "askUserQuestion": {
+    "submit": "Submit",
+    "submitting": "Submitting...",
+    "other": "Other",
+    "otherPlaceholder": "Type your answer",
+    "selectOne": "Choose one",
+    "selectMany": "Choose one or more",
+    "answered": "Answered",
+    "preparing": "Preparing question..."
+  }
 }

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -78,5 +78,15 @@
     "learningsUpdated": "Aprendizajes actualizados"
   },
   "filesUpdated_one": "1 archivo actualizado",
-  "filesUpdated_other": "{{count}} archivos actualizados"
+  "filesUpdated_other": "{{count}} archivos actualizados",
+  "askUserQuestion": {
+    "submit": "Enviar",
+    "submitting": "Enviando...",
+    "other": "Otra",
+    "otherPlaceholder": "Escribe tu respuesta",
+    "selectOne": "Elige una",
+    "selectMany": "Elige una o más",
+    "answered": "Respondido",
+    "preparing": "Preparando la pregunta..."
+  }
 }

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -78,5 +78,15 @@
     "learningsUpdated": "Aprendizados atualizados"
   },
   "filesUpdated_one": "1 arquivo atualizado",
-  "filesUpdated_other": "{{count}} arquivos atualizados"
+  "filesUpdated_other": "{{count}} arquivos atualizados",
+  "askUserQuestion": {
+    "submit": "Enviar",
+    "submitting": "Enviando...",
+    "other": "Outra",
+    "otherPlaceholder": "Digite sua resposta",
+    "selectOne": "Escolha uma",
+    "selectMany": "Escolha uma ou mais",
+    "answered": "Respondida",
+    "preparing": "Preparando a pergunta..."
+  }
 }

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -100,6 +100,7 @@ pub fn spawn_and_monitor(
     provider: Provider,
     model: Option<String>,
     effort: Option<String>,
+    mcp_config: Option<PathBuf>,
 ) -> tokio::task::JoinHandle<SessionResult> {
     // Ensure the user's shell PATH is resolved before spawning.
     // OnceLock inside init() makes this a no-op after the first call.
@@ -116,7 +117,7 @@ pub fn spawn_and_monitor(
         model,
         effort,
         system_prompt,
-        None,  // mcp_config
+        mcp_config,
         false, // disable_builtin_tools
         false, // disable_all_tools
     );
@@ -408,12 +409,26 @@ fn serialize_for_persist(item: &FeedItem) -> Option<(String, String)> {
             let data = serde_json::json!({ "kind": kind, "details": details });
             Some(("tool_runtime_error".into(), data.to_string()))
         }
-        FeedItem::ToolCall { name, input } => {
-            let data = serde_json::json!({ "name": name, "input": input });
+        FeedItem::ToolCall {
+            name,
+            input,
+            tool_use_id,
+        } => {
+            let mut data = serde_json::json!({ "name": name, "input": input });
+            if let Some(id) = tool_use_id {
+                data["tool_use_id"] = serde_json::Value::String(id.clone());
+            }
             Some(("tool_call".into(), data.to_string()))
         }
-        FeedItem::ToolResult { content, is_error } => {
-            let data = serde_json::json!({ "content": content, "is_error": is_error });
+        FeedItem::ToolResult {
+            content,
+            is_error,
+            tool_use_id,
+        } => {
+            let mut data = serde_json::json!({ "content": content, "is_error": is_error });
+            if let Some(id) = tool_use_id {
+                data["tool_use_id"] = serde_json::Value::String(id.clone());
+            }
             Some(("tool_result".into(), data.to_string()))
         }
         FeedItem::SystemMessage(t) => Some(("system_message".into(), json_str(t))),

--- a/engine/houston-engine-core/src/lib.rs
+++ b/engine/houston-engine-core/src/lib.rs
@@ -25,4 +25,4 @@ pub mod workspace_context;
 pub mod workspaces;
 
 pub use error::{CoreError, CoreResult};
-pub use state::EngineState;
+pub use state::{EngineState, McpSelf};

--- a/engine/houston-engine-core/src/routines/engine_dispatcher.rs
+++ b/engine/houston-engine-core/src/routines/engine_dispatcher.rs
@@ -106,6 +106,9 @@ impl RoutineDispatcher for EngineRoutineDispatcher {
             resolved.provider,
             resolved.model,
             None,
+            // Routines don't open an MCP-ask-user round-trip (no human is
+            // sitting in front of the screen waiting to answer). Always None.
+            None,
         );
 
         match join_handle.await {

--- a/engine/houston-engine-core/src/sessions/ask_user.rs
+++ b/engine/houston-engine-core/src/sessions/ask_user.rs
@@ -1,0 +1,434 @@
+//! Bridge between the NDJSON parser and the in-engine MCP handler for the
+//! Houston `AskUserQuestion` tool.
+//!
+//! When an agent (Claude) calls `mcp__houston__AskUserQuestion`, two events
+//! happen near-simultaneously inside the engine process:
+//!
+//! 1. The NDJSON parser in `houston-terminal-manager` sees the `tool_use`
+//!    block on Claude's stdout and learns the `tool_use_id`.
+//! 2. The Claude CLI subprocess opens an HTTP connection to the in-engine
+//!    MCP server at `/v1/mcp/{session_key}/...` and calls the tool with its
+//!    arguments. The MCP server sees the arguments but NOT the `tool_use_id`.
+//!
+//! Neither component on its own can complete the round-trip:
+//!
+//! - The parser knows the id but can't block Claude waiting for an answer.
+//! - The MCP handler can block, but doesn't know which `tool_use_id` it's
+//!   blocking on — meaning the REST `/user_input` POST has nothing to key
+//!   the answer on.
+//!
+//! This module is the shared rendezvous. The parser pushes
+//! [`parser_saw_tool_use`] every time it sees an `AskUserQuestion` tool_use;
+//! the MCP handler calls [`mcp_invoked`] to claim the next pending id (or
+//! waits briefly if it arrived first); the MCP handler then calls
+//! [`mcp_await_answer`] to block on the user's reply; the REST POST handler
+//! calls [`submit_answer`] to fulfill the wait.
+//!
+//! All orderings are tolerated. Cancellation propagates through dropped
+//! oneshot senders.
+//!
+//! See the plan in `~/.claude/plans/yeah-lets-plan-this-floating-map.md`.
+
+use crate::{CoreError, CoreResult};
+use houston_terminal_manager::FeedItem;
+use houston_ui_events::{DynEventSink, EventSink, HoustonEvent};
+use serde_json::Value;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
+use tokio::sync::{oneshot, Mutex};
+
+/// The MCP tool name the parser watches for. Must match what the in-engine
+/// MCP server registers — see `routes/mcp.rs`. Claude addresses it as
+/// `mcp__houston__AskUserQuestion` (`mcp__<server>__<tool>` convention).
+pub const ASK_USER_TOOL_NAME: &str = "mcp__houston__AskUserQuestion";
+
+/// Shared in-engine state. Cheap to clone — backed by an `Arc<Mutex<...>>`.
+#[derive(Default, Clone)]
+pub struct PendingAskUserRegistry {
+    inner: Arc<Mutex<PendingState>>,
+}
+
+#[derive(Default)]
+struct PendingState {
+    /// Per-session FIFO of `tool_use_id`s the parser has emitted but no MCP
+    /// handler has claimed yet (parser-first ordering).
+    parser_queue: HashMap<String, VecDeque<String>>,
+    /// Per-session FIFO of MCP handlers that arrived before the parser
+    /// emitted an id (mcp-first ordering).
+    mcp_waiters: HashMap<String, VecDeque<oneshot::Sender<String>>>,
+    /// `(session_key, tool_use_id)` → sender that will deliver the user's
+    /// answer to the awaiting MCP handler.
+    awaiting: HashMap<(String, String), oneshot::Sender<Value>>,
+}
+
+impl PendingAskUserRegistry {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Called by the NDJSON parser when an `mcp__houston__AskUserQuestion`
+    /// `tool_use` block is seen. If an MCP handler is already waiting for an
+    /// id on this session, hands it over immediately; otherwise queues the
+    /// id for the next [`mcp_invoked`] on the same session.
+    pub async fn parser_saw_tool_use(&self, session_key: &str, tool_use_id: String) {
+        let mut state = self.inner.lock().await;
+        if let Some(waiters) = state.mcp_waiters.get_mut(session_key) {
+            // Drain any cancelled waiters; deliver to the first live one.
+            while let Some(tx) = waiters.pop_front() {
+                if tx.send(tool_use_id.clone()).is_ok() {
+                    if waiters.is_empty() {
+                        state.mcp_waiters.remove(session_key);
+                    }
+                    return;
+                }
+            }
+            state.mcp_waiters.remove(session_key);
+        }
+        state
+            .parser_queue
+            .entry(session_key.to_string())
+            .or_default()
+            .push_back(tool_use_id);
+    }
+
+    /// Called by the MCP HTTP handler the moment Claude invokes the tool.
+    /// Resolves with the matching `tool_use_id` either immediately (if the
+    /// parser already pushed one) or once the parser does.
+    ///
+    /// Returns [`CoreError::Internal`] if the registry is cancelled before
+    /// the parser pushes — which happens when the session is cancelled
+    /// before Claude's NDJSON output has been fully drained.
+    pub async fn mcp_invoked(&self, session_key: &str) -> CoreResult<String> {
+        let rx = {
+            let mut state = self.inner.lock().await;
+            if let Some(queue) = state.parser_queue.get_mut(session_key) {
+                if let Some(id) = queue.pop_front() {
+                    if queue.is_empty() {
+                        state.parser_queue.remove(session_key);
+                    }
+                    return Ok(id);
+                }
+            }
+            let (tx, rx) = oneshot::channel();
+            state
+                .mcp_waiters
+                .entry(session_key.to_string())
+                .or_default()
+                .push_back(tx);
+            rx
+        };
+        rx.await.map_err(|_| {
+            CoreError::Internal(
+                "ask_user: cancelled before parser emitted tool_use_id".into(),
+            )
+        })
+    }
+
+    /// Called by the MCP HTTP handler after it has its `tool_use_id`.
+    /// Blocks until [`submit_answer`] is called with the matching id or the
+    /// session is cancelled.
+    pub async fn mcp_await_answer(
+        &self,
+        session_key: &str,
+        tool_use_id: &str,
+    ) -> CoreResult<Value> {
+        let rx = {
+            let mut state = self.inner.lock().await;
+            let key = (session_key.to_string(), tool_use_id.to_string());
+            // If a previous waiter on the same (session, id) exists, it's a
+            // bug (two MCP calls claiming the same id). Refuse the new one
+            // so the bug surfaces instead of silently dropping the old.
+            if state.awaiting.contains_key(&key) {
+                return Err(CoreError::Conflict(format!(
+                    "ask_user: another handler is already awaiting answer for {tool_use_id}"
+                )));
+            }
+            let (tx, rx) = oneshot::channel();
+            state.awaiting.insert(key, tx);
+            rx
+        };
+        rx.await
+            .map_err(|_| CoreError::Internal("ask_user: cancelled before answer arrived".into()))
+    }
+
+    /// Called by the REST `POST /v1/agents/:p/sessions/:k/user_input`
+    /// handler. Delivers the user's answer to the awaiting MCP handler.
+    ///
+    /// Returns [`CoreError::NotFound`] if no MCP handler is currently
+    /// awaiting this `(session_key, tool_use_id)`. Common reasons:
+    /// session ended, question already answered, or the id is just wrong.
+    pub async fn submit_answer(
+        &self,
+        session_key: &str,
+        tool_use_id: &str,
+        answer: Value,
+    ) -> CoreResult<()> {
+        let tx = {
+            let mut state = self.inner.lock().await;
+            let key = (session_key.to_string(), tool_use_id.to_string());
+            state.awaiting.remove(&key).ok_or_else(|| {
+                CoreError::NotFound(format!(
+                    "ask_user: no pending question session={session_key} tool_use_id={tool_use_id}"
+                ))
+            })?
+        };
+        tx.send(answer).map_err(|_| {
+            // The receiver was dropped between us reading the map and
+            // sending — likely the MCP handler was cancelled in the same
+            // tick. Surface as Conflict so the UI shows "submit failed,
+            // session may have ended" rather than a generic 500.
+            CoreError::Conflict("ask_user: MCP handler dropped before answer landed".into())
+        })
+    }
+
+    /// Drop all pending state for a session. Called when the session is
+    /// cancelled or otherwise terminated. Any in-flight `mcp_await_answer`
+    /// or `mcp_invoked` resolves with an Err because the oneshot sender is
+    /// dropped here.
+    pub async fn cancel(&self, session_key: &str) {
+        let mut state = self.inner.lock().await;
+        state.parser_queue.remove(session_key);
+        state.mcp_waiters.remove(session_key);
+        state.awaiting.retain(|(sk, _), _| sk != session_key);
+    }
+}
+
+/// Decorator [`EventSink`] that taps the per-session feed stream and notifies
+/// the registry whenever an `mcp__houston__AskUserQuestion` `ToolCall` flies
+/// by. Everything else (text deltas, file changes, every other tool call)
+/// passes through unchanged.
+///
+/// This lives in front of the WS-broadcasting sink, so the registry learns
+/// about the `tool_use_id` BEFORE the UI does — which closes the window where
+/// a fast user could submit an answer before the MCP handler had registered
+/// its waiter.
+pub struct AskUserSinkTap {
+    inner: DynEventSink,
+    registry: PendingAskUserRegistry,
+    session_key: String,
+}
+
+impl AskUserSinkTap {
+    pub fn wrap(
+        inner: DynEventSink,
+        registry: PendingAskUserRegistry,
+        session_key: String,
+    ) -> DynEventSink {
+        Arc::new(Self {
+            inner,
+            registry,
+            session_key,
+        })
+    }
+}
+
+impl EventSink for AskUserSinkTap {
+    fn emit(&self, event: HoustonEvent) {
+        // Pre-flight: when the parser finalizes an AskUserQuestion
+        // tool_use, push the id into the registry's queue before the
+        // event is broadcast. Two emits-per-tool arrive (null-input on
+        // block_start, real-input on block_stop); both carry the same
+        // tool_use_id. We push on the first one we see and ignore the
+        // second — the queue is keyed by FIFO push, and the second push
+        // would create a phantom waiter that never resolves. Tracking
+        // "already pushed" via the tool_use_id itself keeps this clean
+        // without us holding parser-shaped state in this layer.
+        if let HoustonEvent::FeedItem {
+            session_key, item, ..
+        } = &event
+        {
+            if session_key == &self.session_key {
+                if let FeedItem::ToolCall {
+                    name,
+                    tool_use_id: Some(id),
+                    input,
+                    ..
+                } = item
+                {
+                    if name == ASK_USER_TOOL_NAME && input.is_null() {
+                        // Only the initial null-input emission counts as
+                        // the "saw the tool_use" event; the second emit on
+                        // content_block_stop carries the same id with the
+                        // final input and would duplicate the queue push.
+                        let registry = self.registry.clone();
+                        let session_key = self.session_key.clone();
+                        let id = id.clone();
+                        tokio::spawn(async move {
+                            registry.parser_saw_tool_use(&session_key, id).await;
+                        });
+                    }
+                }
+            }
+        }
+        self.inner.emit(event);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::Duration;
+    use tokio::time::timeout;
+
+    const SK: &str = "test-session";
+
+    fn answer(s: &str) -> Value {
+        serde_json::json!({ "answer": s })
+    }
+
+    #[tokio::test]
+    async fn parser_first_ordering() {
+        // Parser emits the tool_use_id first, then the MCP handler arrives
+        // and should pick it up immediately.
+        let reg = PendingAskUserRegistry::new();
+        reg.parser_saw_tool_use(SK, "tu_first".into()).await;
+        let id = timeout(Duration::from_millis(50), reg.mcp_invoked(SK))
+            .await
+            .expect("should not block")
+            .unwrap();
+        assert_eq!(id, "tu_first");
+    }
+
+    #[tokio::test]
+    async fn mcp_first_ordering() {
+        // MCP handler arrives first, blocks; parser emits the id later
+        // and the handler unblocks with that id.
+        let reg = PendingAskUserRegistry::new();
+        let reg_for_task = reg.clone();
+        let handle = tokio::spawn(async move {
+            reg_for_task.mcp_invoked(SK).await.unwrap()
+        });
+
+        // Give the spawned task time to register as a waiter.
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        reg.parser_saw_tool_use(SK, "tu_late".into()).await;
+
+        let id = timeout(Duration::from_millis(100), handle).await.unwrap().unwrap();
+        assert_eq!(id, "tu_late");
+    }
+
+    #[tokio::test]
+    async fn submit_answer_unblocks_await() {
+        let reg = PendingAskUserRegistry::new();
+        reg.parser_saw_tool_use(SK, "tu_x".into()).await;
+        let id = reg.mcp_invoked(SK).await.unwrap();
+        let reg_for_task = reg.clone();
+        let id_for_task = id.clone();
+        let handle = tokio::spawn(async move {
+            reg_for_task.mcp_await_answer(SK, &id_for_task).await.unwrap()
+        });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        reg.submit_answer(SK, &id, answer("Balance Sheet")).await.unwrap();
+
+        let got = timeout(Duration::from_millis(100), handle).await.unwrap().unwrap();
+        assert_eq!(got, answer("Balance Sheet"));
+    }
+
+    #[tokio::test]
+    async fn cancel_propagates_to_pending_await() {
+        let reg = PendingAskUserRegistry::new();
+        reg.parser_saw_tool_use(SK, "tu_c".into()).await;
+        let id = reg.mcp_invoked(SK).await.unwrap();
+        let reg_for_task = reg.clone();
+        let id_for_task = id.clone();
+        let handle = tokio::spawn(async move {
+            reg_for_task.mcp_await_answer(SK, &id_for_task).await
+        });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        reg.cancel(SK).await;
+
+        let result = timeout(Duration::from_millis(100), handle).await.unwrap().unwrap();
+        assert!(result.is_err(), "expected Err on cancel, got {result:?}");
+    }
+
+    #[tokio::test]
+    async fn cancel_propagates_to_pending_invocation() {
+        // MCP handler waiting for an id, session cancelled before parser
+        // emits — the wait should resolve with Err.
+        let reg = PendingAskUserRegistry::new();
+        let reg_for_task = reg.clone();
+        let handle = tokio::spawn(async move { reg_for_task.mcp_invoked(SK).await });
+
+        tokio::time::sleep(Duration::from_millis(10)).await;
+        reg.cancel(SK).await;
+
+        let result = timeout(Duration::from_millis(100), handle).await.unwrap().unwrap();
+        assert!(result.is_err(), "expected Err on cancel, got {result:?}");
+    }
+
+    #[tokio::test]
+    async fn double_submit_returns_not_found() {
+        let reg = PendingAskUserRegistry::new();
+        reg.parser_saw_tool_use(SK, "tu_d".into()).await;
+        let id = reg.mcp_invoked(SK).await.unwrap();
+        let reg_for_task = reg.clone();
+        let id_for_task = id.clone();
+        let _handle = tokio::spawn(async move {
+            reg_for_task.mcp_await_answer(SK, &id_for_task).await.unwrap()
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        reg.submit_answer(SK, &id, answer("first")).await.unwrap();
+        let second = reg.submit_answer(SK, &id, answer("second")).await;
+        assert!(matches!(second, Err(CoreError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn submit_unknown_id_returns_not_found() {
+        let reg = PendingAskUserRegistry::new();
+        let result = reg.submit_answer(SK, "tu_never", answer("anything")).await;
+        assert!(matches!(result, Err(CoreError::NotFound(_))));
+    }
+
+    #[tokio::test]
+    async fn sessions_are_isolated() {
+        // Pushing an id for session A must not satisfy an MCP handler
+        // waiting on session B.
+        let reg = PendingAskUserRegistry::new();
+        let reg_for_task = reg.clone();
+        let handle = tokio::spawn(async move {
+            timeout(Duration::from_millis(40), reg_for_task.mcp_invoked("session-b")).await
+        });
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        reg.parser_saw_tool_use("session-a", "tu_for_a".into()).await;
+        // session-b should still be waiting (and eventually timeout).
+        let outer = handle.await.unwrap();
+        assert!(outer.is_err(), "session-b should have timed out, got {outer:?}");
+    }
+
+    #[tokio::test]
+    async fn queue_drains_in_fifo_order() {
+        // Multiple parser pushes followed by multiple mcp_invoked calls
+        // should pair up in FIFO order. This is the safety net for the
+        // unlikely-but-possible case where two tool_use_ids land before
+        // any MCP handler arrives.
+        let reg = PendingAskUserRegistry::new();
+        reg.parser_saw_tool_use(SK, "tu_1".into()).await;
+        reg.parser_saw_tool_use(SK, "tu_2".into()).await;
+        let id1 = reg.mcp_invoked(SK).await.unwrap();
+        let id2 = reg.mcp_invoked(SK).await.unwrap();
+        assert_eq!(id1, "tu_1");
+        assert_eq!(id2, "tu_2");
+    }
+
+    #[tokio::test]
+    async fn double_await_same_id_is_conflict() {
+        // Two MCP handlers claiming the same (session, tool_use_id) is a
+        // bug — surface as Conflict so it doesn't silently drop the first.
+        let reg = PendingAskUserRegistry::new();
+        reg.parser_saw_tool_use(SK, "tu_dup".into()).await;
+        let id = reg.mcp_invoked(SK).await.unwrap();
+
+        let reg_for_task = reg.clone();
+        let id_for_task = id.clone();
+        let _first = tokio::spawn(async move {
+            reg_for_task.mcp_await_answer(SK, &id_for_task).await
+        });
+        tokio::time::sleep(Duration::from_millis(10)).await;
+
+        let second = reg.mcp_await_answer(SK, &id).await;
+        assert!(matches!(second, Err(CoreError::Conflict(_))));
+    }
+}

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -534,6 +534,10 @@ fn write_mcp_config_file(
         .collect();
     let path = dir.join(format!("{safe_key}.json"));
     let url = format!("{}/v1/mcp/{}/", mcp.base_url.trim_end_matches('/'), session_key);
+    // `timeout` raises the tool-call watchdog from the 60-second default to
+    // 1 hour — humans answering a clarifying question may take a while.
+    // (The 60-second first-byte fetch budget is separate; we beat that
+    // by streaming SSE keepalives from the `tools/call` handler.)
     let body = serde_json::json!({
         "mcpServers": {
             "houston": {
@@ -541,7 +545,8 @@ fn write_mcp_config_file(
                 "url": url,
                 "headers": {
                     "Authorization": format!("Bearer {}", mcp.token),
-                }
+                },
+                "timeout": 3_600_000_u32,
             }
         }
     });

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -17,6 +17,7 @@
 //! lives in the adapter today; it will move into `engine-core` in a later
 //! phase once `agent_store` is ported.
 
+pub mod ask_user;
 mod control;
 pub mod file_changes;
 pub mod generate_instructions;
@@ -54,6 +55,16 @@ pub struct SessionRuntime {
     control: SessionControl,
     turn_locks: SessionTurnLocks,
     workdir_activity: WorkdirActivity,
+    /// Pairs Houston MCP `AskUserQuestion` tool calls with answers
+    /// submitted by the user over REST. See [`ask_user`] for the protocol.
+    pub ask_user: ask_user::PendingAskUserRegistry,
+    /// Self-loopback identity for the in-engine MCP server. When set, every
+    /// new Claude session gets a per-session mcp_config pointing at
+    /// `<base_url>/v1/mcp/<session_key>/`. The server binary populates this
+    /// once it knows its own bind address and token; embedding scenarios
+    /// without an HTTP server leave it `None` and the ask-user tool stays
+    /// unavailable to the agent.
+    pub mcp_self: Option<crate::state::McpSelf>,
 }
 
 impl SessionRuntime {
@@ -111,6 +122,7 @@ pub async fn start(
     events: DynEventSink,
     db: Database,
     app_system_prompt: &str,
+    paths: &EnginePaths,
     params: StartParams,
 ) -> Result<String, crate::CoreError> {
     let session_key = params.session_key.clone();
@@ -120,6 +132,7 @@ pub async fn start(
     let generation = rt.control.register(&identity).await;
     let rt = rt.clone();
     let app_system_prompt = app_system_prompt.to_string();
+    let paths = paths.clone();
 
     tokio::spawn({
         let events = events.clone();
@@ -131,6 +144,7 @@ pub async fn start(
                 events.clone(),
                 db,
                 &app_system_prompt,
+                &paths,
                 params,
                 identity.clone(),
                 generation,
@@ -181,6 +195,7 @@ async fn run_start(
     events: DynEventSink,
     db: Database,
     app_system_prompt: &str,
+    paths: &EnginePaths,
     params: StartParams,
     identity: SessionIdentity,
     generation: u64,
@@ -200,6 +215,14 @@ async fn run_start(
     if !agent_dir.exists() {
         std::fs::create_dir_all(&agent_dir)?;
     }
+
+    // Wrap the events sink with the ask-user tap. The tap snoops every
+    // FeedItem flying through this session and tells the registry the
+    // moment a `mcp__houston__AskUserQuestion` tool_use lands, so the
+    // in-engine MCP handler (which will be invoked any millisecond now
+    // by the spawned claude subprocess) can correlate its call with
+    // the `tool_use_id`. Non-ask-user events pass through unchanged.
+    let events = ask_user::AskUserSinkTap::wrap(events, rt.ask_user.clone(), session_key.clone());
 
     let _turn_guard = rt.acquire_turn(&identity).await;
     if rt.control.is_stale(&identity, generation).await {
@@ -316,6 +339,25 @@ async fn run_start(
         lifecycle: None,
     });
 
+    // Generate the per-session MCP config file pointing the spawned claude
+    // CLI at this engine's in-process MCP server. Only when (a) the server
+    // binary has populated `rt.mcp_self` (i.e. we know our own URL+token)
+    // AND (b) the provider is anthropic (codex/gemini don't wire MCP in
+    // v1). Failure to write is non-fatal — we just disable the ask-user
+    // tool for this session and let the agent fall back to text.
+    let mcp_config_path = if provider.id() == "anthropic" {
+        match write_mcp_config_file(rt.mcp_self.as_ref(), &paths.home_dir, &session_key) {
+            Ok(path) => path,
+            Err(e) => {
+                tracing::warn!("[sessions] mcp_config write failed for {session_key}: {e}");
+                None
+            }
+        }
+    } else {
+        None
+    };
+    let mcp_config_for_cleanup = mcp_config_path.clone();
+
     let events_for_end = events.clone();
     let working_dir_for_end = working_dir.clone();
     let handle = session_runner::spawn_and_monitor(
@@ -332,6 +374,7 @@ async fn run_start(
         provider,
         model,
         effort,
+        mcp_config_path,
     );
 
     // Own the end-of-session activity flip engine-side. Before this, the
@@ -438,7 +481,84 @@ async fn run_start(
     }
     rt.control.finish(&identity).await;
 
+    // Clean up the per-session MCP config file. Best-effort — leaving it on
+    // disk would leak token material in a world-readable file path, so we
+    // log on failure but don't fail the session for it.
+    if let Some(path) = mcp_config_for_cleanup {
+        if let Err(e) = std::fs::remove_file(&path) {
+            if e.kind() != std::io::ErrorKind::NotFound {
+                tracing::warn!(
+                    "[sessions] failed to remove mcp_config at {}: {e}",
+                    path.display()
+                );
+            }
+        }
+    }
+
     Ok(())
+}
+
+/// Write a per-session MCP config JSON pointing claude at this engine's
+/// in-process MCP server. Returns the file path (or `None` if `mcp_self`
+/// isn't set yet — caller falls back to no MCP for the session).
+///
+/// File layout (matches the `--mcp-config` format Claude Code accepts):
+/// ```json
+/// {
+///   "mcpServers": {
+///     "houston": {
+///       "type": "http",
+///       "url": "http://127.0.0.1:31338/v1/mcp/<session_key>/",
+///       "headers": { "Authorization": "Bearer <token>" }
+///     }
+///   }
+/// }
+/// ```
+fn write_mcp_config_file(
+    mcp_self: Option<&crate::state::McpSelf>,
+    home_dir: &Path,
+    session_key: &str,
+) -> std::io::Result<Option<PathBuf>> {
+    let Some(mcp) = mcp_self else {
+        return Ok(None);
+    };
+    let dir = home_dir.join("tmp").join("mcp");
+    std::fs::create_dir_all(&dir)?;
+    // session_key already comes from the frontend so it's a stable id; but
+    // file-system-safety still demands we strip anything that isn't a
+    // file-name-safe character. The caller's session_key is opaque to the
+    // CLI — only this engine reads the path back to delete it.
+    let safe_key: String = session_key
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() || c == '-' || c == '_' { c } else { '_' })
+        .collect();
+    let path = dir.join(format!("{safe_key}.json"));
+    let url = format!("{}/v1/mcp/{}/", mcp.base_url.trim_end_matches('/'), session_key);
+    let body = serde_json::json!({
+        "mcpServers": {
+            "houston": {
+                "type": "http",
+                "url": url,
+                "headers": {
+                    "Authorization": format!("Bearer {}", mcp.token),
+                }
+            }
+        }
+    });
+    std::fs::write(&path, body.to_string())?;
+    // Best-effort tighten permissions to owner-only (mode 0600). This file
+    // holds the engine token. Failure to chmod is a warning, not an error —
+    // the parent ~/.houston is already owner-only by convention.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(metadata) = std::fs::metadata(&path) {
+            let mut perms = metadata.permissions();
+            perms.set_mode(0o600);
+            let _ = std::fs::set_permissions(&path, perms);
+        }
+    }
+    Ok(Some(path))
 }
 
 /// Cancel a running or queued session. On Unix sends `SIGTERM` to the
@@ -456,6 +576,11 @@ pub async fn cancel(
     let identity = SessionIdentity::new(agent_path.to_string(), session_key.to_string());
     let had_queued = rt.control.cancel(&identity).await;
     let pid = rt.pid_map.remove(session_key).await;
+
+    // Drop any pending AskUserQuestion state so an in-flight MCP handler
+    // doesn't hang forever waiting on a user answer that will never come.
+    // mcp_await_answer resolves with Err the moment we drop the senders.
+    rt.ask_user.cancel(session_key).await;
 
     if let Some(pid) = pid {
         tracing::info!("[sessions] cancel session_key={session_key} pid={pid}");
@@ -542,6 +667,7 @@ pub async fn start_onboarding(
     db: Database,
     app_system_prompt: &str,
     app_onboarding_prompt: &str,
+    paths: &EnginePaths,
     agent_dir: PathBuf,
     session_key: String,
 ) -> Result<String, crate::CoreError> {
@@ -558,6 +684,7 @@ pub async fn start_onboarding(
         events,
         db,
         app_system_prompt,
+        paths,
         StartParams {
             agent_dir: agent_dir.clone(),
             working_dir: agent_dir,
@@ -617,6 +744,10 @@ mod tests {
         let guard = rt.acquire_turn(&identity).await;
         let db = Database::connect_in_memory().await.unwrap();
         let events: DynEventSink = Arc::new(NoopEventSink);
+        let paths = EnginePaths {
+            docs_dir: dir.path().to_path_buf(),
+            home_dir: dir.path().to_path_buf(),
+        };
 
         let accepted = timeout(
             Duration::from_millis(100),
@@ -625,6 +756,7 @@ mod tests {
                 events.clone(),
                 db,
                 "",
+                &paths,
                 StartParams {
                     agent_dir: dir.path().to_path_buf(),
                     working_dir: dir.path().to_path_buf(),

--- a/engine/houston-engine-core/src/state.rs
+++ b/engine/houston-engine-core/src/state.rs
@@ -11,7 +11,8 @@ pub struct EngineState {
     pub paths: EnginePaths,
     pub events: DynEventSink,
     pub db: Database,
-    /// Per-engine session state (Claude-session-ID tracker, pid map).
+    /// Per-engine session state (Claude-session-ID tracker, pid map,
+    /// MCP self-loopback identity).
     pub sessions: SessionRuntime,
     /// Product-layer prompt prefix supplied by the embedding app (e.g. the
     /// Houston desktop app) via env. Prepended to caller-less sessions.
@@ -20,6 +21,17 @@ pub struct EngineState {
     /// Product-layer onboarding suffix supplied by the embedding app.
     /// Appended on first-run sessions.
     pub app_onboarding_prompt: String,
+}
+
+/// Self-referential connection details for the in-engine MCP server.
+/// Stored on [`SessionRuntime`] (not here) because it's only read during
+/// session start; defining the type here keeps it grouped with `EngineState`.
+#[derive(Clone)]
+pub struct McpSelf {
+    /// `http://127.0.0.1:<port>` — no trailing slash, no path.
+    pub base_url: String,
+    /// Bearer token clients send. Same value the rest of `/v1/*` checks.
+    pub token: String,
 }
 
 impl EngineState {
@@ -42,6 +54,14 @@ impl EngineState {
     ) -> Self {
         self.app_system_prompt = app_system_prompt;
         self.app_onboarding_prompt = app_onboarding_prompt;
+        self
+    }
+
+    /// Chainable setter the server binary calls once it knows its own bind
+    /// address and token. The MCP self-loopback identity lives on
+    /// `SessionRuntime` (read during session start), not on this struct.
+    pub fn with_mcp_self(mut self, base_url: String, token: String) -> Self {
+        self.sessions.mcp_self = Some(McpSelf { base_url, token });
         self
     }
 }

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -25,6 +25,7 @@ sha2 = "0.10"
 base64 = "0.22"
 rand = "0.8"
 futures-util = "0.3"
+async-stream = "0.3"
 houston-engine-protocol = { version = "0.4.0", path = "../houston-engine-protocol" }
 houston-engine-core = { version = "0.4.0", path = "../houston-engine-core" }
 houston-composio = { workspace = true }

--- a/engine/houston-engine-server/src/lib.rs
+++ b/engine/houston-engine-server/src/lib.rs
@@ -42,6 +42,7 @@ pub fn build_router(state: Arc<ServerState>) -> Router {
         .merge(routes::tunnel::router())
         .merge(routes::watcher::router())
         .merge(routes::portable::router())
+        .merge(routes::mcp::router())
         .layer(middleware::from_fn_with_state(
             state.clone(),
             auth::require_bearer,

--- a/engine/houston-engine-server/src/main.rs
+++ b/engine/houston-engine-server/src/main.rs
@@ -126,9 +126,20 @@ async fn main() {
         }
     };
 
-    let state = ServerState::new(cfg, tunnel_identity)
+    let mut state = ServerState::new(cfg, tunnel_identity)
         .await
         .expect("engine state init failed");
+
+    // Now that we know our own bind port + token, stamp the self-loopback
+    // identity onto SessionRuntime so future sessions can generate a
+    // per-session `--mcp-config` JSON pointing claude at our in-engine
+    // `/v1/mcp/<session_key>/` endpoint. Without this, the ask-user MCP
+    // tool stays unwired and agents fall back to plain-text questions.
+    let mcp_base = format!("http://127.0.0.1:{}", actual.port());
+    state.engine.sessions.mcp_self = Some(houston_engine_core::McpSelf {
+        base_url: mcp_base,
+        token: state.config.token.clone(),
+    });
 
     let state = Arc::new(state);
 

--- a/engine/houston-engine-server/src/routes/mcp.rs
+++ b/engine/houston-engine-server/src/routes/mcp.rs
@@ -72,7 +72,8 @@ const PROTOCOL_VERSION: &str = "2025-06-18";
 /// is enforced by the client, not us).
 const TOOL_NAME: &str = "AskUserQuestion";
 
-const TOOL_DESCRIPTION: &str = "Use this tool when you need to ask the user questions during execution. \
+const TOOL_DESCRIPTION: &str =
+    "Use this tool when you need to ask the user questions during execution. \
 This allows you to gather user preferences, clarify ambiguous instructions, get \
 decisions on implementation choices, or offer choices about what direction to \
 take. An 'Other' option that allows free-form input is automatically provided \
@@ -199,8 +200,13 @@ async fn handle_post(
             // first-byte fetch budget. Return SSE so we can flush keepalive
             // bytes during the wait; the spec allows it (section "Sending
             // Messages to the Server" in the Streamable HTTP transport).
-            return handle_tools_call_sse(st.clone(), session_key.clone(), id_for_dispatch, req.params)
-                .await;
+            return handle_tools_call_sse(
+                st.clone(),
+                session_key.clone(),
+                id_for_dispatch,
+                req.params,
+            )
+            .await;
         }
         other => rpc_error(
             id_for_dispatch,
@@ -498,7 +504,10 @@ mod tests {
         .await;
         assert_eq!(resp.status(), StatusCode::ACCEPTED);
         let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
-        assert!(bytes.is_empty(), "notification response must have empty body");
+        assert!(
+            bytes.is_empty(),
+            "notification response must have empty body"
+        );
     }
 
     #[tokio::test]
@@ -514,10 +523,7 @@ mod tests {
         let tools = value["result"]["tools"].as_array().expect("tools array");
         assert_eq!(tools.len(), 1);
         assert_eq!(tools[0]["name"], TOOL_NAME);
-        assert!(tools[0]["description"]
-            .as_str()
-            .unwrap()
-            .contains("Other"));
+        assert!(tools[0]["description"].as_str().unwrap().contains("Other"));
         // Schema must require questions array and forbid missing fields.
         assert_eq!(tools[0]["inputSchema"]["required"][0], "questions");
     }
@@ -589,7 +595,10 @@ mod tests {
             "a"
         );
         let txt = value["result"]["content"][0]["text"].as_str().unwrap();
-        assert!(txt.contains("\"a\""), "text payload should include the answer");
+        assert!(
+            txt.contains("\"a\""),
+            "text payload should include the answer"
+        );
     }
 
     #[tokio::test]

--- a/engine/houston-engine-server/src/routes/mcp.rs
+++ b/engine/houston-engine-server/src/routes/mcp.rs
@@ -1,0 +1,709 @@
+//! `/v1/mcp/:session_key/` — in-engine MCP server.
+//!
+//! Hand-rolled minimal Streamable-HTTP MCP server. Just enough surface to host
+//! a single tool, `AskUserQuestion`, that the Claude CLI subprocess can call
+//! over loopback HTTP. We hand-roll (rather than depend on `rmcp`) because
+//! every rmcp release tracking the current MCP spec pulls in axum 0.8 while
+//! the rest of `houston-engine-server` is on axum 0.7.
+//!
+//! ## Wire shape
+//!
+//! Per the [Streamable HTTP transport][mcp-transport]:
+//!
+//! - POST `/v1/mcp/:session_key/` with a JSON-RPC 2.0 request → JSON response
+//!   (we don't open SSE — single-shot JSON is allowed and simpler).
+//! - POST with a notification (no `id`) → 202 Accepted, empty body.
+//! - GET `/v1/mcp/:session_key/` → 405 Method Not Allowed (no server-to-
+//!   client push needed; we never originate messages).
+//! - DELETE → 405 Method Not Allowed.
+//!
+//! [mcp-transport]: https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http
+//!
+//! ## Methods we implement
+//!
+//! - `initialize` — handshake. Returns protocol version, server info,
+//!   capabilities (`tools` only).
+//! - `notifications/initialized` — client signals it's ready; 202 + no-op.
+//! - `notifications/cancelled` — client aborts a request; we currently no-op
+//!   because our only blocking call (`tools/call` on `AskUserQuestion`) is
+//!   cancelled via `SessionRuntime::ask_user.cancel(session_key)` from the
+//!   sessions::cancel path. Adding per-request cancellation here is phase 2.
+//! - `tools/list` — returns the AskUserQuestion definition.
+//! - `tools/call` — blocks on the [`PendingAskUserRegistry`] until the user
+//!   answers, returns the answer as the tool result.
+//! - `ping` — heartbeat. Returns empty result.
+//!
+//! Other methods get `-32601` Method Not Found.
+//!
+//! ## Session scoping
+//!
+//! The `session_key` path parameter is how Houston (not MCP) identifies the
+//! agent conversation. It's baked into the per-session mcp_config the engine
+//! writes when spawning claude; the URL therefore arrives pre-correlated.
+//! We do not use the MCP-spec `Mcp-Session-Id` header.
+
+use crate::routes::error::ApiError;
+use crate::state::ServerState;
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse, Response,
+    },
+    routing::post,
+    Json, Router,
+};
+use houston_engine_core::CoreError;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use std::convert::Infallible;
+use std::sync::Arc;
+use std::time::Duration;
+
+/// MCP protocol version we speak. The spec calls for clients to send back
+/// whatever the server returned during `initialize`; sticking with a known
+/// stable version (rather than echoing the client's request) lets us avoid
+/// surprises if a future Claude CLI starts requesting a newer spec.
+const PROTOCOL_VERSION: &str = "2025-06-18";
+
+/// The MCP tool we register. The agent calls it as
+/// `mcp__houston__AskUserQuestion` (the `mcp__<server>__<tool>` convention
+/// is enforced by the client, not us).
+const TOOL_NAME: &str = "AskUserQuestion";
+
+const TOOL_DESCRIPTION: &str = "Use this tool when you need to ask the user questions during execution. \
+This allows you to gather user preferences, clarify ambiguous instructions, get \
+decisions on implementation choices, or offer choices about what direction to \
+take. An 'Other' option that allows free-form input is automatically provided \
+to the user, so do NOT include 'Other' or similar options in your options \
+array. If you want to ask a question referring to work you did (e.g., a plan \
+you wrote), you must write that work as an assistant message AND end your turn \
+(give them a chance to read and respond) BEFORE using this tool.";
+
+pub fn router() -> Router<Arc<ServerState>> {
+    Router::new()
+        .route("/mcp/:session_key", post(handle_post).get(handle_get))
+        .route("/mcp/:session_key/", post(handle_post).get(handle_get))
+}
+
+// ---------------------------------------------------------------------------
+// JSON-RPC 2.0 envelope
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcRequest {
+    #[allow(dead_code)] // serde_json::from_value rejects unknown fields without this
+    jsonrpc: Option<String>,
+    #[serde(default)]
+    id: Option<Value>,
+    method: String,
+    #[serde(default)]
+    params: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcSuccess {
+    jsonrpc: &'static str,
+    id: Value,
+    result: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcError {
+    jsonrpc: &'static str,
+    id: Value,
+    error: JsonRpcErrorBody,
+}
+
+#[derive(Debug, Serialize)]
+struct JsonRpcErrorBody {
+    code: i32,
+    message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<Value>,
+}
+
+const ERR_PARSE: i32 = -32700;
+const ERR_METHOD_NOT_FOUND: i32 = -32601;
+const ERR_INVALID_PARAMS: i32 = -32602;
+const ERR_INTERNAL: i32 = -32603;
+
+fn success(id: Value, result: Value) -> Response {
+    Json(JsonRpcSuccess {
+        jsonrpc: "2.0",
+        id,
+        result,
+    })
+    .into_response()
+}
+
+fn rpc_error(id: Value, code: i32, message: impl Into<String>) -> Response {
+    Json(JsonRpcError {
+        jsonrpc: "2.0",
+        id,
+        error: JsonRpcErrorBody {
+            code,
+            message: message.into(),
+            data: None,
+        },
+    })
+    .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handlers
+// ---------------------------------------------------------------------------
+
+/// GET on the MCP endpoint is for opening an optional server-to-client SSE
+/// stream. We don't push to the client, so we decline.
+async fn handle_get() -> Response {
+    StatusCode::METHOD_NOT_ALLOWED.into_response()
+}
+
+/// POST is the workhorse — every JSON-RPC request, notification, and response
+/// from the client lands here. Returns either a `JsonRpcSuccess` /
+/// `JsonRpcError` JSON body for requests, or `202 Accepted` for notifications.
+async fn handle_post(
+    State(st): State<Arc<ServerState>>,
+    Path(session_key): Path<String>,
+    body: Json<Value>,
+) -> Response {
+    // Parse the envelope ourselves (rather than via the typed extractor) so
+    // we can return a spec-conformant JSON-RPC error for malformed bodies
+    // instead of an axum 400.
+    let raw: Value = body.0;
+    let req: JsonRpcRequest = match serde_json::from_value(raw) {
+        Ok(r) => r,
+        Err(e) => {
+            return rpc_error(Value::Null, ERR_PARSE, format!("parse error: {e}"));
+        }
+    };
+
+    let id = req.id.clone();
+    let is_request = id.is_some();
+    let id_for_dispatch = id.clone().unwrap_or(Value::Null);
+
+    let response = match req.method.as_str() {
+        "initialize" => handle_initialize(id_for_dispatch, req.params),
+        "notifications/initialized" | "notifications/cancelled" => {
+            // Notifications: no body, no response. The client doesn't
+            // expect anything except the 202.
+            return StatusCode::ACCEPTED.into_response();
+        }
+        "ping" => success(id_for_dispatch, json!({})),
+        "tools/list" => handle_tools_list(id_for_dispatch),
+        "tools/call" => {
+            // Special-case: this handler may block for minutes waiting on a
+            // user answer. Plain JSON would hit Claude CLI's 60-second
+            // first-byte fetch budget. Return SSE so we can flush keepalive
+            // bytes during the wait; the spec allows it (section "Sending
+            // Messages to the Server" in the Streamable HTTP transport).
+            return handle_tools_call_sse(st.clone(), session_key.clone(), id_for_dispatch, req.params)
+                .await;
+        }
+        other => rpc_error(
+            id_for_dispatch,
+            ERR_METHOD_NOT_FOUND,
+            format!("method not found: {other}"),
+        ),
+    };
+
+    // For a notification we already returned 202 above; this branch is for
+    // requests that produced a JsonRpc envelope.
+    if !is_request {
+        // Defensive: a method handler somehow returned a body for what looks
+        // like a notification. Spec says we MUST 202 a notification with no
+        // body. Drop whatever the handler made.
+        return StatusCode::ACCEPTED.into_response();
+    }
+    response
+}
+
+// ---------------------------------------------------------------------------
+// Method handlers
+// ---------------------------------------------------------------------------
+
+fn handle_initialize(id: Value, _params: Value) -> Response {
+    success(
+        id,
+        json!({
+            "protocolVersion": PROTOCOL_VERSION,
+            "capabilities": {
+                "tools": { "listChanged": false }
+            },
+            "serverInfo": {
+                "name": "houston",
+                "version": env!("CARGO_PKG_VERSION"),
+            }
+        }),
+    )
+}
+
+fn handle_tools_list(id: Value) -> Response {
+    success(
+        id,
+        json!({
+            "tools": [
+                {
+                    "name": TOOL_NAME,
+                    "description": TOOL_DESCRIPTION,
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "questions": {
+                                "type": "array",
+                                "description": "One or more questions to put to the user. Render order is preserved.",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "question": {
+                                            "type": "string",
+                                            "description": "The text of the question."
+                                        },
+                                        "options": {
+                                            "type": "array",
+                                            "description": "Discrete answer choices. Do NOT include 'Other' — the UI adds it automatically.",
+                                            "items": { "type": "string" }
+                                        },
+                                        "multiSelect": {
+                                            "type": "boolean",
+                                            "description": "True if the user may pick more than one option. Defaults to false."
+                                        }
+                                    },
+                                    "required": ["question", "options"]
+                                }
+                            }
+                        },
+                        "required": ["questions"]
+                    }
+                }
+            ]
+        }),
+    )
+}
+
+/// Resolve a `tools/call` against the registry. Used by tests (synchronous
+/// API surface) and by the SSE handler (which wraps it inside a stream).
+async fn resolve_tools_call(
+    st: &ServerState,
+    session_key: &str,
+    id: Value,
+    params: Value,
+) -> Result<Value, CoreError> {
+    let name = params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| CoreError::BadRequest("tools/call: missing 'name'".into()))?;
+
+    if name != TOOL_NAME {
+        // Encode "unknown tool" as a JSON-RPC error wrapped in a Value so
+        // the caller can choose how to deliver it (plain JSON vs SSE).
+        return Ok(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": {
+                "code": ERR_METHOD_NOT_FOUND,
+                "message": format!("unknown tool: {name}")
+            }
+        }));
+    }
+
+    // (1) Wait until the NDJSON parser sees the matching `tool_use_id` for
+    // this session. In practice the parser pushes within milliseconds —
+    // sometimes BEFORE this handler is even invoked.
+    let tool_use_id = st.engine.sessions.ask_user.mcp_invoked(session_key).await?;
+
+    // (2) Block until the user POSTs an answer to `/user_input`. This is
+    // where the wall-clock latency lives — the agent's turn is paused on
+    // this single await. SSE keepalives at the transport layer prevent
+    // claude's first-byte timeout from firing during this wait.
+    let answer = st
+        .engine
+        .sessions
+        .ask_user
+        .mcp_await_answer(session_key, &tool_use_id)
+        .await?;
+
+    // (3) Build the tool result envelope. We serialize the typed answer
+    // to JSON text — claude surfaces this as the tool_result block on the
+    // next NDJSON frame, which the parser then emits as
+    // `FeedItem::ToolResult` to the UI (closing the card).
+    let answer_text = serde_json::to_string(&answer)
+        .map_err(|e| CoreError::Internal(format!("ask_user answer serialize: {e}")))?;
+
+    Ok(json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": {
+            "content": [
+                { "type": "text", "text": answer_text }
+            ],
+            "isError": false,
+            // Also include the structured form so future clients that
+            // understand it don't have to re-parse the text.
+            "structuredContent": answer
+        }
+    }))
+}
+
+/// Test-only helper that returns the legacy plain-JSON shape for `tools/call`.
+/// Production traffic goes through [`handle_tools_call_sse`].
+#[cfg(test)]
+async fn handle_tools_call(
+    st: &ServerState,
+    session_key: &str,
+    id: Value,
+    params: Value,
+) -> Result<Response, CoreError> {
+    let envelope = resolve_tools_call(st, session_key, id, params).await?;
+    Ok(Json(envelope).into_response())
+}
+
+/// SSE-wrapped `tools/call`. Streams keepalive bytes to satisfy claude
+/// CLI's 60-second first-byte fetch budget, then a single SSE event
+/// carrying the JSON-RPC envelope, then closes the stream.
+///
+/// MCP Streamable HTTP spec allows the server to return either a plain
+/// JSON body or `Content-Type: text/event-stream`. We use SSE here
+/// specifically because this is the one handler whose response time
+/// depends on a human clicking a button.
+async fn handle_tools_call_sse(
+    st: Arc<ServerState>,
+    session_key: String,
+    id: Value,
+    params: Value,
+) -> Response {
+    // The resolver future is spawned into a single-item stream. The SSE
+    // wrapper layers a 15-second keepalive on top, so claude sees bytes
+    // periodically while we wait on the user.
+    let stream = async_stream::stream! {
+        let envelope = match resolve_tools_call(&st, &session_key, id.clone(), params).await {
+            Ok(v) => v,
+            Err(e) => {
+                let code = match &e {
+                    CoreError::BadRequest(_) => ERR_INVALID_PARAMS,
+                    CoreError::NotFound(_) => ERR_METHOD_NOT_FOUND,
+                    _ => ERR_INTERNAL,
+                };
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": { "code": code, "message": e.to_string() }
+                })
+            }
+        };
+        // Serializing must succeed for any JSON value we constructed.
+        let payload = serde_json::to_string(&envelope)
+            .unwrap_or_else(|_| String::from("{\"jsonrpc\":\"2.0\",\"error\":{\"code\":-32603,\"message\":\"serialize failure\"}}"));
+        yield Ok::<Event, Infallible>(Event::default().data(payload));
+    };
+    Sse::new(stream)
+        .keep_alive(
+            KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text(": keepalive"),
+        )
+        .into_response()
+}
+
+fn map_core_error(id: Value, e: CoreError) -> Response {
+    let code = match &e {
+        CoreError::BadRequest(_) => ERR_INVALID_PARAMS,
+        CoreError::NotFound(_) => ERR_METHOD_NOT_FOUND,
+        _ => ERR_INTERNAL,
+    };
+    rpc_error(id, code, e.to_string())
+}
+
+// Quiet ApiError import warning. The MCP layer doesn't return ApiError
+// (every code path here either produces a JsonRpc envelope or HTTP status),
+// but keeping the import documents that we considered it.
+#[allow(dead_code)]
+type _ApiErrorPlaceholder = ApiError;
+
+// ---------------------------------------------------------------------------
+// Tests — exercise the JSON-RPC dispatch against a real ServerState.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::ServerConfig;
+    use axum::body::to_bytes;
+    use std::time::Duration;
+    use tempfile::TempDir;
+
+    async fn test_state() -> (Arc<ServerState>, TempDir) {
+        // Test ServerState rooted at a TempDir so the engine.json write
+        // and any other side effects don't escape the test sandbox.
+        let dir = TempDir::new().unwrap();
+        let cfg = ServerConfig {
+            bind: "127.0.0.1:0".parse().unwrap(),
+            token: "test-token".into(),
+            home_dir: dir.path().to_path_buf(),
+            docs_dir: dir.path().to_path_buf(),
+            app_system_prompt: String::new(),
+            app_onboarding_prompt: String::new(),
+            tunnel_url: "https://tunnel.test".into(),
+        };
+        let state = ServerState::new(cfg, None)
+            .await
+            .expect("ServerState::new should succeed in tests");
+        (Arc::new(state), dir)
+    }
+
+    async fn body_to_value(resp: Response) -> Value {
+        let body = to_bytes(resp.into_body(), 1024 * 1024).await.unwrap();
+        serde_json::from_slice(&body).unwrap()
+    }
+
+    #[tokio::test]
+    async fn initialize_returns_protocol_version_and_server_info() {
+        let (state, _dir) = test_state().await;
+        let resp = handle_post(
+            State(state),
+            Path("test-session".into()),
+            Json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": PROTOCOL_VERSION,
+                    "capabilities": {},
+                    "clientInfo": { "name": "test-client", "version": "0.0.1" }
+                }
+            })),
+        )
+        .await;
+        let value = body_to_value(resp).await;
+        assert_eq!(value["jsonrpc"], "2.0");
+        assert_eq!(value["id"], 1);
+        assert_eq!(value["result"]["protocolVersion"], PROTOCOL_VERSION);
+        assert_eq!(value["result"]["serverInfo"]["name"], "houston");
+        assert!(value["result"]["capabilities"]["tools"].is_object());
+    }
+
+    #[tokio::test]
+    async fn notifications_initialized_returns_202_with_no_body() {
+        let (state, _dir) = test_state().await;
+        let resp = handle_post(
+            State(state),
+            Path("test-session".into()),
+            Json(json!({
+                "jsonrpc": "2.0",
+                "method": "notifications/initialized"
+            })),
+        )
+        .await;
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+        let bytes = to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert!(bytes.is_empty(), "notification response must have empty body");
+    }
+
+    #[tokio::test]
+    async fn tools_list_returns_ask_user_question() {
+        let (state, _dir) = test_state().await;
+        let resp = handle_post(
+            State(state),
+            Path("sk".into()),
+            Json(json!({"jsonrpc":"2.0","id":2,"method":"tools/list"})),
+        )
+        .await;
+        let value = body_to_value(resp).await;
+        let tools = value["result"]["tools"].as_array().expect("tools array");
+        assert_eq!(tools.len(), 1);
+        assert_eq!(tools[0]["name"], TOOL_NAME);
+        assert!(tools[0]["description"]
+            .as_str()
+            .unwrap()
+            .contains("Other"));
+        // Schema must require questions array and forbid missing fields.
+        assert_eq!(tools[0]["inputSchema"]["required"][0], "questions");
+    }
+
+    #[tokio::test]
+    async fn unknown_method_returns_method_not_found() {
+        let (state, _dir) = test_state().await;
+        let resp = handle_post(
+            State(state),
+            Path("sk".into()),
+            Json(json!({"jsonrpc":"2.0","id":3,"method":"nonsense"})),
+        )
+        .await;
+        let value = body_to_value(resp).await;
+        assert_eq!(value["error"]["code"], ERR_METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn tools_call_blocks_then_returns_user_answer() {
+        // Full happy path through the synchronous legacy helper. The SSE
+        // path is covered by `tools_call_sse_streams_answer_after_submit`
+        // — exercising both shapes ensures `resolve_tools_call` stays the
+        // single source of truth for the answer-resolution logic.
+        let (state, _dir) = test_state().await;
+        let session = "sk-happy";
+
+        state
+            .engine
+            .sessions
+            .ask_user
+            .parser_saw_tool_use(session, "tu_42".into())
+            .await;
+
+        let state_for_task = state.clone();
+        let session_for_task = session.to_string();
+        let mcp_handle = tokio::spawn(async move {
+            handle_tools_call(
+                &state_for_task,
+                &session_for_task,
+                json!(7),
+                json!({
+                    "name": TOOL_NAME,
+                    "arguments": { "questions": [{"question":"pick","options":["a","b"],"multiSelect":false}] }
+                }),
+            )
+            .await
+            .expect("resolve_tools_call should succeed")
+        });
+
+        tokio::time::sleep(Duration::from_millis(20)).await;
+
+        state
+            .engine
+            .sessions
+            .ask_user
+            .submit_answer(session, "tu_42", json!({"answers":[{"selected":["a"]}]}))
+            .await
+            .unwrap();
+
+        let resp = tokio::time::timeout(Duration::from_millis(200), mcp_handle)
+            .await
+            .expect("MCP call should return after submit_answer")
+            .unwrap();
+        let value = body_to_value(resp).await;
+        assert_eq!(value["id"], 7);
+        assert!(value["result"]["isError"] == false);
+        assert_eq!(
+            value["result"]["structuredContent"]["answers"][0]["selected"][0],
+            "a"
+        );
+        let txt = value["result"]["content"][0]["text"].as_str().unwrap();
+        assert!(txt.contains("\"a\""), "text payload should include the answer");
+    }
+
+    #[tokio::test]
+    async fn tools_call_sse_streams_answer_after_submit() {
+        // Verifies the production SSE shape that `handle_post` selects for
+        // tools/call. claude needs the response Content-Type to be
+        // `text/event-stream` and the body to start with `data: ` lines.
+        let (state, _dir) = test_state().await;
+        let session = "sk-sse";
+
+        state
+            .engine
+            .sessions
+            .ask_user
+            .parser_saw_tool_use(session, "tu_99".into())
+            .await;
+
+        let state_for_task = state.clone();
+        let session_for_task = session.to_string();
+        let resp_handle = tokio::spawn(async move {
+            handle_post(
+                State(state_for_task),
+                Path(session_for_task),
+                Json(json!({
+                    "jsonrpc": "2.0",
+                    "id": 11,
+                    "method": "tools/call",
+                    "params": {
+                        "name": TOOL_NAME,
+                        "arguments": { "questions": [] }
+                    }
+                })),
+            )
+            .await
+        });
+
+        // handle_post for tools/call returns immediately with an SSE
+        // wrapper whose body is lazy. Concurrently: submit the answer
+        // (which unblocks the inner resolver) and drain the body.
+        let resp = resp_handle
+            .await
+            .expect("handle_post should return SSE wrapper");
+        assert_eq!(
+            resp.headers()
+                .get(axum::http::header::CONTENT_TYPE)
+                .and_then(|v| v.to_str().ok())
+                .unwrap_or(""),
+            "text/event-stream"
+        );
+
+        let state_for_submit = state.clone();
+        let session_for_submit = session.to_string();
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            state_for_submit
+                .engine
+                .sessions
+                .ask_user
+                .submit_answer(&session_for_submit, "tu_99", json!({"chosen": "yes"}))
+                .await
+                .unwrap();
+        });
+
+        let bytes = tokio::time::timeout(
+            Duration::from_secs(2),
+            to_bytes(resp.into_body(), 64 * 1024),
+        )
+        .await
+        .expect("SSE stream should resolve once submit_answer fires")
+        .expect("body bytes");
+        let body = String::from_utf8_lossy(&bytes);
+        assert!(body.contains("data: "), "missing SSE data prefix: {body}");
+        // Extract the JSON-RPC payload from the first data line.
+        let payload_line = body
+            .lines()
+            .find(|l| l.starts_with("data: "))
+            .expect("a data: line");
+        let payload: Value =
+            serde_json::from_str(payload_line.trim_start_matches("data: ").trim()).unwrap();
+        assert_eq!(payload["id"], 11);
+        assert_eq!(payload["result"]["isError"], false);
+        assert_eq!(payload["result"]["structuredContent"]["chosen"], "yes");
+    }
+
+    #[tokio::test]
+    async fn tools_call_with_unknown_tool_name_returns_method_not_found() {
+        // Unknown-tool error rides the same SSE channel — verify the
+        // JSON-RPC error envelope is what arrives in the SSE data event.
+        let (state, _dir) = test_state().await;
+        let resp = handle_post(
+            State(state),
+            Path("sk".into()),
+            Json(json!({
+                "jsonrpc": "2.0",
+                "id": 9,
+                "method": "tools/call",
+                "params": { "name": "not_a_real_tool", "arguments": {} }
+            })),
+        )
+        .await;
+        let bytes = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let body = String::from_utf8_lossy(&bytes);
+        let payload_line = body
+            .lines()
+            .find(|l| l.starts_with("data: "))
+            .expect("a data: line carrying the JSON-RPC error");
+        let payload: Value =
+            serde_json::from_str(payload_line.trim_start_matches("data: ").trim()).unwrap();
+        assert_eq!(payload["error"]["code"], ERR_METHOD_NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn get_returns_method_not_allowed() {
+        let resp = handle_get().await;
+        assert_eq!(resp.status(), StatusCode::METHOD_NOT_ALLOWED);
+    }
+}

--- a/engine/houston-engine-server/src/routes/mod.rs
+++ b/engine/houston-engine-server/src/routes/mod.rs
@@ -9,6 +9,7 @@ pub mod composio;
 pub mod conversations;
 pub mod error;
 pub mod health;
+pub mod mcp;
 pub mod portable;
 pub mod preferences;
 pub mod providers;

--- a/engine/houston-engine-server/src/routes/sessions.rs
+++ b/engine/houston-engine-server/src/routes/sessions.rs
@@ -123,7 +123,15 @@ async fn start_session(
     let rt = SessionRuntime::clone(&st.engine.sessions);
     let sink = st.engine.events.clone();
     let db = st.engine.db.clone();
-    let key = sessions::start(&rt, sink, db, &st.engine.app_system_prompt, params).await?;
+    let key = sessions::start(
+        &rt,
+        sink,
+        db,
+        &st.engine.app_system_prompt,
+        &st.engine.paths,
+        params,
+    )
+    .await?;
 
     Ok(Json(StartResponse { session_key: key }))
 }
@@ -155,6 +163,7 @@ async fn start_onboarding(
         db,
         &st.engine.app_system_prompt,
         &st.engine.app_onboarding_prompt,
+        &st.engine.paths,
         agent_dir,
         req.session_key,
     )

--- a/engine/houston-engine-server/src/routes/sessions.rs
+++ b/engine/houston-engine-server/src/routes/sessions.rs
@@ -49,6 +49,10 @@ pub fn router() -> Router<Arc<ServerState>> {
             "/agents/:agent_path/sessions/:key/history",
             get(load_history),
         )
+        .route(
+            "/agents/:agent_path/sessions/:key/user_input",
+            post(submit_user_input),
+        )
         .route("/sessions/summarize", post(summarize_activity))
         .route(
             "/sessions/generate-instructions",
@@ -177,6 +181,40 @@ async fn load_history(
 ) -> Result<Json<Vec<history::ChatHistoryEntry>>, ApiError> {
     let agent_dir = resolve_agent_dir(&st.engine.paths, &agent_path);
     Ok(Json(history::load(&st.engine.db, &agent_dir, &key).await?))
+}
+
+/// POST `/v1/agents/:agent_path/sessions/:key/user_input` — frontend submits
+/// the user's answer to a pending `mcp__houston__AskUserQuestion`. The MCP
+/// handler in `routes/mcp.rs` is currently blocked awaiting this exact
+/// `tool_use_id`; we resolve its oneshot and return 204.
+///
+/// Errors:
+/// - `404 NOT_FOUND` if no pending question matches (already answered, wrong
+///   id, session cancelled).
+/// - `409 CONFLICT` if the MCP handler was cancelled in the same tick.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UserInputRequest {
+    /// The Anthropic-emitted `tool_use_id` echoed back from the frontend's
+    /// `FeedItem::ToolCall` row. The MCP handler is keyed on this id.
+    pub tool_use_id: String,
+    /// The structured answer payload, shape decided by the frontend.
+    /// Typically `{ answers: [{ selected: string[], other?: string }] }`
+    /// but treated opaquely here — handed verbatim to the MCP tool result.
+    pub answer: serde_json::Value,
+}
+
+async fn submit_user_input(
+    State(st): State<Arc<ServerState>>,
+    Path((_agent_path, key)): Path<(String, String)>,
+    Json(req): Json<UserInputRequest>,
+) -> Result<axum::http::StatusCode, ApiError> {
+    st.engine
+        .sessions
+        .ask_user
+        .submit_answer(&key, &req.tool_use_id, req.answer)
+        .await?;
+    Ok(axum::http::StatusCode::NO_CONTENT)
 }
 
 #[derive(Debug, Deserialize)]

--- a/engine/houston-terminal-manager/src/codex_parser.rs
+++ b/engine/houston-terminal-manager/src/codex_parser.rs
@@ -481,7 +481,9 @@ mod tests {
         let _ = parse_codex_event(r#"{"type":"turn.started"}"#, &mut a);
         let items = parse_codex_event(r#"{"type":"turn.completed"}"#, &mut a);
         assert!(
-            items.iter().any(|i| matches!(i, FeedItem::Thinking(t) if t.is_empty())),
+            items
+                .iter()
+                .any(|i| matches!(i, FeedItem::Thinking(t) if t.is_empty())),
             "expected an empty Thinking() to close the placeholder, got {items:?}"
         );
     }
@@ -546,7 +548,9 @@ mod tests {
         let items = parse_codex_event(completed, &mut a);
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::ToolResult { content, is_error, .. } => {
+            FeedItem::ToolResult {
+                content, is_error, ..
+            } => {
                 assert!(content.contains("src/"));
                 assert!(!is_error);
             }
@@ -571,7 +575,9 @@ mod tests {
         let items = parse_codex_event(line, &mut acc());
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::ToolResult { content, is_error, .. } => {
+            FeedItem::ToolResult {
+                content, is_error, ..
+            } => {
                 assert!(content.contains("update: src/main.rs"));
                 assert!(!is_error);
             }

--- a/engine/houston-terminal-manager/src/codex_parser.rs
+++ b/engine/houston-terminal-manager/src/codex_parser.rs
@@ -286,6 +286,7 @@ fn parse_item_streaming(event: &CodexEvent, acc: &mut CodexAccumulator) -> Vec<F
                 return vec![FeedItem::ToolCall {
                     name: "Bash".into(),
                     input: serde_json::json!({ "command": cmd }),
+                    tool_use_id: None,
                 }];
             }
             vec![]
@@ -295,6 +296,7 @@ fn parse_item_streaming(event: &CodexEvent, acc: &mut CodexAccumulator) -> Vec<F
             vec![FeedItem::ToolCall {
                 name: "Edit".into(),
                 input: serde_json::json!({ "description": desc }),
+                tool_use_id: None,
             }]
         }
         "mcp_tool_call" => {
@@ -306,6 +308,7 @@ fn parse_item_streaming(event: &CodexEvent, acc: &mut CodexAccumulator) -> Vec<F
             vec![FeedItem::ToolCall {
                 name,
                 input: serde_json::Value::Null,
+                tool_use_id: None,
             }]
         }
         "web_search" => {
@@ -313,6 +316,7 @@ fn parse_item_streaming(event: &CodexEvent, acc: &mut CodexAccumulator) -> Vec<F
             vec![FeedItem::ToolCall {
                 name: "WebSearch".into(),
                 input: serde_json::json!({ "query": query }),
+                tool_use_id: None,
             }]
         }
         _ => vec![],
@@ -353,7 +357,11 @@ fn parse_item_completed(event: &CodexEvent, acc: &mut CodexAccumulator) -> Vec<F
             } else {
                 output.to_string()
             };
-            vec![FeedItem::ToolResult { content, is_error }]
+            vec![FeedItem::ToolResult {
+                content,
+                is_error,
+                tool_use_id: None,
+            }]
         }
         "file_change" => {
             let desc = describe_file_changes(item);
@@ -361,6 +369,7 @@ fn parse_item_completed(event: &CodexEvent, acc: &mut CodexAccumulator) -> Vec<F
             vec![FeedItem::ToolResult {
                 content: desc,
                 is_error,
+                tool_use_id: None,
             }]
         }
         "mcp_tool_call" => {
@@ -373,6 +382,7 @@ fn parse_item_completed(event: &CodexEvent, acc: &mut CodexAccumulator) -> Vec<F
             vec![FeedItem::ToolResult {
                 content: format!("{name} completed"),
                 is_error,
+                tool_use_id: None,
             }]
         }
         "error" => {
@@ -525,7 +535,7 @@ mod tests {
         let items = parse_codex_event(started, &mut a);
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::ToolCall { name, input } => {
+            FeedItem::ToolCall { name, input, .. } => {
                 assert_eq!(name, "Bash");
                 assert_eq!(input["command"], "bash -lc ls");
             }
@@ -536,7 +546,7 @@ mod tests {
         let items = parse_codex_event(completed, &mut a);
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::ToolResult { content, is_error } => {
+            FeedItem::ToolResult { content, is_error, .. } => {
                 assert!(content.contains("src/"));
                 assert!(!is_error);
             }
@@ -561,7 +571,7 @@ mod tests {
         let items = parse_codex_event(line, &mut acc());
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::ToolResult { content, is_error } => {
+            FeedItem::ToolResult { content, is_error, .. } => {
                 assert!(content.contains("update: src/main.rs"));
                 assert!(!is_error);
             }

--- a/engine/houston-terminal-manager/src/gemini_parser_state.rs
+++ b/engine/houston-terminal-manager/src/gemini_parser_state.rs
@@ -80,16 +80,20 @@ fn handle_event(event: GeminiEvent, acc: &mut GeminiAccumulator) -> Vec<FeedItem
         }
         GeminiEvent::ToolUse { tool_name, tool_id, parameters, .. } => {
             let mut items = flush_assistant_buffer(acc);
-            acc.tool_names_by_id.insert(tool_id, tool_name.clone());
+            acc.tool_names_by_id.insert(tool_id.clone(), tool_name.clone());
             let input =
                 serde_json::to_value(&parameters).unwrap_or(serde_json::Value::Null);
-            items.push(FeedItem::ToolCall { name: tool_name, input });
+            items.push(FeedItem::ToolCall {
+                name: tool_name,
+                input,
+                tool_use_id: Some(tool_id),
+            });
             items
         }
         GeminiEvent::ToolResult { tool_id, status, output, error, .. } => {
             let mut items = flush_assistant_buffer(acc);
             acc.tool_names_by_id.remove(&tool_id);
-            items.push(tool_result_item(status, output, error));
+            items.push(tool_result_item(status, output, error, Some(tool_id)));
             items
         }
         GeminiEvent::Error { message, .. } => {
@@ -188,11 +192,13 @@ fn tool_result_item(
     status: GeminiStatus,
     output: Option<String>,
     error: Option<GeminiErrorPayload>,
+    tool_use_id: Option<String>,
 ) -> FeedItem {
     match status {
         GeminiStatus::Success => FeedItem::ToolResult {
             content: output.unwrap_or_else(|| "(non-text result)".to_string()),
             is_error: false,
+            tool_use_id,
         },
         GeminiStatus::Error => {
             let msg = error
@@ -205,7 +211,11 @@ fn tool_result_item(
                 })
                 .or(output)
                 .unwrap_or_else(|| "tool failed".to_string());
-            FeedItem::ToolResult { content: msg, is_error: true }
+            FeedItem::ToolResult {
+                content: msg,
+                is_error: true,
+                tool_use_id,
+            }
         }
     }
 }
@@ -284,9 +294,14 @@ mod tests {
         let use_items = parse_gemini_event(TOOL_USE_LINE, &mut a);
         assert_eq!(use_items.len(), 1);
         match &use_items[0] {
-            FeedItem::ToolCall { name, input } => {
+            FeedItem::ToolCall {
+                name,
+                input,
+                tool_use_id,
+            } => {
                 assert_eq!(name, "Read");
                 assert_eq!(input["file_path"], "/path/to/file.txt");
+                assert_eq!(tool_use_id.as_deref(), Some("read-123"));
             }
             other => panic!("expected ToolCall, got {other:?}"),
         }
@@ -295,9 +310,14 @@ mod tests {
         let res_items = parse_gemini_event(TOOL_RESULT_OK, &mut a);
         assert_eq!(res_items.len(), 1);
         match &res_items[0] {
-            FeedItem::ToolResult { content, is_error } => {
+            FeedItem::ToolResult {
+                content,
+                is_error,
+                tool_use_id,
+            } => {
                 assert_eq!(content, "File contents here");
                 assert!(!is_error);
+                assert_eq!(tool_use_id.as_deref(), Some("read-123"));
             }
             other => panic!("expected ToolResult, got {other:?}"),
         }
@@ -310,7 +330,11 @@ mod tests {
         let items = parse_gemini_event(TOOL_RESULT_ERR, &mut acc());
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::ToolResult { content, is_error } => {
+            FeedItem::ToolResult {
+                content,
+                is_error,
+                ..
+            } => {
                 assert!(*is_error);
                 assert!(content.contains("FILE_NOT_FOUND"));
                 assert!(content.contains("File not found"));

--- a/engine/houston-terminal-manager/src/gemini_parser_state.rs
+++ b/engine/houston-terminal-manager/src/gemini_parser_state.rs
@@ -68,21 +68,31 @@ pub fn parse_gemini_event(line: &str, acc: &mut GeminiAccumulator) -> Vec<FeedIt
 
 fn handle_event(event: GeminiEvent, acc: &mut GeminiAccumulator) -> Vec<FeedItem> {
     match event {
-        GeminiEvent::Init { session_id, model, .. } => {
+        GeminiEvent::Init {
+            session_id, model, ..
+        } => {
             acc.session_id = Some(session_id);
             if !model.is_empty() {
                 acc.model = Some(model);
             }
             vec![]
         }
-        GeminiEvent::Message { role, content, delta, .. } => {
-            handle_message(role, content, delta, acc)
-        }
-        GeminiEvent::ToolUse { tool_name, tool_id, parameters, .. } => {
+        GeminiEvent::Message {
+            role,
+            content,
+            delta,
+            ..
+        } => handle_message(role, content, delta, acc),
+        GeminiEvent::ToolUse {
+            tool_name,
+            tool_id,
+            parameters,
+            ..
+        } => {
             let mut items = flush_assistant_buffer(acc);
-            acc.tool_names_by_id.insert(tool_id.clone(), tool_name.clone());
-            let input =
-                serde_json::to_value(&parameters).unwrap_or(serde_json::Value::Null);
+            acc.tool_names_by_id
+                .insert(tool_id.clone(), tool_name.clone());
+            let input = serde_json::to_value(&parameters).unwrap_or(serde_json::Value::Null);
             items.push(FeedItem::ToolCall {
                 name: tool_name,
                 input,
@@ -90,7 +100,13 @@ fn handle_event(event: GeminiEvent, acc: &mut GeminiAccumulator) -> Vec<FeedItem
             });
             items
         }
-        GeminiEvent::ToolResult { tool_id, status, output, error, .. } => {
+        GeminiEvent::ToolResult {
+            tool_id,
+            status,
+            output,
+            error,
+            ..
+        } => {
             let mut items = flush_assistant_buffer(acc);
             acc.tool_names_by_id.remove(&tool_id);
             items.push(tool_result_item(status, output, error, Some(tool_id)));
@@ -103,9 +119,12 @@ fn handle_event(event: GeminiEvent, acc: &mut GeminiAccumulator) -> Vec<FeedItem
             items.push(FeedItem::SystemMessage(message));
             items
         }
-        GeminiEvent::Result { status, error, stats, .. } => {
-            handle_result(status, error, stats, acc)
-        }
+        GeminiEvent::Result {
+            status,
+            error,
+            stats,
+            ..
+        } => handle_result(status, error, stats, acc),
         GeminiEvent::Unknown => {
             tracing::debug!("[gemini] unknown event variant — ignoring");
             vec![]
@@ -126,7 +145,9 @@ fn handle_message(
         GeminiMessageRole::Assistant if content.is_empty() => vec![],
         GeminiMessageRole::Assistant if delta => {
             acc.assistant_buffer.push_str(&content);
-            vec![FeedItem::AssistantTextStreaming(acc.assistant_buffer.clone())]
+            vec![FeedItem::AssistantTextStreaming(
+                acc.assistant_buffer.clone(),
+            )]
         }
         GeminiMessageRole::Assistant => {
             // Non-delta assistant message — treat as a final block.
@@ -167,17 +188,19 @@ fn classify_result_error(error: Option<&GeminiErrorPayload>) -> FeedItem {
         Some(e) => (e.kind.as_str(), e.message.as_str()),
         None => ("", "gemini reported an error with no detail"),
     };
-    let typed = provider.classify_result_error(kind, message).unwrap_or_else(|| {
-        let raw = if kind.is_empty() {
-            message.to_string()
-        } else {
-            format!("{kind}: {message}")
-        };
-        ProviderError::Unknown {
-            provider: "gemini".into(),
-            raw_excerpt: truncate_excerpt(&raw),
-        }
-    });
+    let typed = provider
+        .classify_result_error(kind, message)
+        .unwrap_or_else(|| {
+            let raw = if kind.is_empty() {
+                message.to_string()
+            } else {
+                format!("{kind}: {message}")
+            };
+            ProviderError::Unknown {
+                provider: "gemini".into(),
+                raw_excerpt: truncate_excerpt(&raw),
+            }
+        });
     FeedItem::ProviderError(typed)
 }
 
@@ -224,7 +247,9 @@ fn flush_assistant_buffer(acc: &mut GeminiAccumulator) -> Vec<FeedItem> {
     if acc.assistant_buffer.is_empty() {
         return vec![];
     }
-    vec![FeedItem::AssistantText(std::mem::take(&mut acc.assistant_buffer))]
+    vec![FeedItem::AssistantText(std::mem::take(
+        &mut acc.assistant_buffer,
+    ))]
 }
 
 #[cfg(test)]
@@ -255,7 +280,10 @@ mod tests {
         assert!(items.is_empty());
         assert_eq!(a.session_id.as_deref(), Some("test-session-123"));
         assert_eq!(a.model.as_deref(), Some("gemini-2.0-flash-exp"));
-        assert_eq!(extract_session_id(INIT_LINE).as_deref(), Some("test-session-123"));
+        assert_eq!(
+            extract_session_id(INIT_LINE).as_deref(),
+            Some("test-session-123")
+        );
     }
 
     #[test]
@@ -268,7 +296,10 @@ mod tests {
     fn user_message_is_dropped() {
         let mut a = acc();
         let items = parse_gemini_event(USER_MSG_LINE, &mut a);
-        assert!(items.is_empty(), "user echo dropped to avoid dup with prompt");
+        assert!(
+            items.is_empty(),
+            "user echo dropped to avoid dup with prompt"
+        );
     }
 
     #[test]
@@ -285,7 +316,10 @@ mod tests {
         // Result line should flush the buffer to a final AssistantText.
         let items3 = parse_gemini_event(RESULT_OK, &mut a);
         assert!(matches!(&items3[0], FeedItem::AssistantText(t) if t == "4!"));
-        assert!(matches!(items3.last().unwrap(), FeedItem::FinalResult { .. }));
+        assert!(matches!(
+            items3.last().unwrap(),
+            FeedItem::FinalResult { .. }
+        ));
     }
 
     #[test]
@@ -305,7 +339,10 @@ mod tests {
             }
             other => panic!("expected ToolCall, got {other:?}"),
         }
-        assert_eq!(a.tool_names_by_id.get("read-123").map(|s| s.as_str()), Some("Read"));
+        assert_eq!(
+            a.tool_names_by_id.get("read-123").map(|s| s.as_str()),
+            Some("Read")
+        );
 
         let res_items = parse_gemini_event(TOOL_RESULT_OK, &mut a);
         assert_eq!(res_items.len(), 1);
@@ -331,9 +368,7 @@ mod tests {
         assert_eq!(items.len(), 1);
         match &items[0] {
             FeedItem::ToolResult {
-                content,
-                is_error,
-                ..
+                content, is_error, ..
             } => {
                 assert!(*is_error);
                 assert!(content.contains("FILE_NOT_FOUND"));
@@ -368,7 +403,11 @@ mod tests {
         let items = parse_gemini_event(RESULT_OK, &mut acc());
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::FinalResult { result, cost_usd, duration_ms } => {
+            FeedItem::FinalResult {
+                result,
+                cost_usd,
+                duration_ms,
+            } => {
                 assert_eq!(*duration_ms, Some(1200));
                 assert!(cost_usd.is_none(), "gemini emits no cost field");
                 assert!(result.contains("100 tokens"));
@@ -429,6 +468,12 @@ mod tests {
         // strict ordering), it still produces a sensible FeedItem.
         let items = parse_gemini_event(TOOL_RESULT_OK, &mut acc());
         assert_eq!(items.len(), 1);
-        assert!(matches!(&items[0], FeedItem::ToolResult { is_error: false, .. }));
+        assert!(matches!(
+            &items[0],
+            FeedItem::ToolResult {
+                is_error: false,
+                ..
+            }
+        ));
     }
 }

--- a/engine/houston-terminal-manager/src/parser.rs
+++ b/engine/houston-terminal-manager/src/parser.rs
@@ -227,9 +227,7 @@ fn parse_rate_limit_event(extra: serde_json::Value) -> Vec<FeedItem> {
         .get("message")
         .and_then(|v| v.as_str())
         .map(truncate_excerpt)
-        .unwrap_or_else(|| {
-            format!("Anthropic rate-limit signal: {status}")
-        });
+        .unwrap_or_else(|| format!("Anthropic rate-limit signal: {status}"));
     vec![FeedItem::ProviderError(ProviderError::RateLimited {
         provider: ANTHROPIC.into(),
         model: None,
@@ -417,9 +415,7 @@ mod tests {
         assert_eq!(items.len(), 1);
         match &items[0] {
             FeedItem::ToolCall {
-                name,
-                tool_use_id,
-                ..
+                name, tool_use_id, ..
             } => {
                 assert_eq!(name, "Read");
                 assert_eq!(tool_use_id.as_deref(), Some("t1"));
@@ -461,7 +457,11 @@ mod tests {
         let stop = r#"{"type":"stream_event","event":{"type":"content_block_stop","index":0}}"#;
 
         let started = parse_event(start, &mut a);
-        assert_eq!(started.len(), 1, "expected immediate ToolCall on block_start");
+        assert_eq!(
+            started.len(),
+            1,
+            "expected immediate ToolCall on block_start"
+        );
         match &started[0] {
             FeedItem::ToolCall {
                 name,

--- a/engine/houston-terminal-manager/src/parser.rs
+++ b/engine/houston-terminal-manager/src/parser.rs
@@ -22,6 +22,10 @@ pub struct StreamAccumulator {
 #[derive(Debug)]
 struct InProgressTool {
     name: String,
+    /// `tool_use.id` from the Anthropic stream-json. Carried through from
+    /// `content_block_start` to `content_block_stop` so the final
+    /// [`FeedItem::ToolCall`] can be stamped with it.
+    tool_use_id: Option<String>,
     json_parts: Vec<String>,
 }
 
@@ -41,7 +45,9 @@ impl StreamAccumulator {
         match inner.event_type.as_str() {
             "content_block_start" => {
                 if let Some(ContentBlock::ToolUse {
-                    name: Some(name), ..
+                    id,
+                    name: Some(name),
+                    ..
                 }) = inner.content_block
                 {
                     // Emit an immediate ToolCall so the UI shows activity right away.
@@ -49,11 +55,13 @@ impl StreamAccumulator {
                     let item = FeedItem::ToolCall {
                         name: name.clone(),
                         input: serde_json::Value::Null,
+                        tool_use_id: id.clone(),
                     };
                     self.tools.insert(
                         index,
                         InProgressTool {
                             name,
+                            tool_use_id: id,
                             json_parts: Vec::new(),
                         },
                     );
@@ -112,6 +120,7 @@ impl StreamAccumulator {
                     return vec![FeedItem::ToolCall {
                         name: tool.name,
                         input,
+                        tool_use_id: tool.tool_use_id,
                     }];
                 }
                 // Finalize a thinking block.
@@ -264,14 +273,20 @@ fn parse_assistant_event(
                     }
                 }
             }
-            ContentBlock::ToolUse { name, input, .. } => {
+            ContentBlock::ToolUse {
+                id, name, input, ..
+            } => {
                 items.push(FeedItem::ToolCall {
                     name: name.unwrap_or_else(|| "unknown".into()),
                     input: input.unwrap_or(serde_json::Value::Null),
+                    tool_use_id: id,
                 });
             }
             ContentBlock::ToolResult {
-                content, is_error, ..
+                tool_use_id,
+                content,
+                is_error,
+                ..
             } => {
                 let text = match content {
                     Some(serde_json::Value::String(s)) => s,
@@ -281,6 +296,7 @@ fn parse_assistant_event(
                 items.push(FeedItem::ToolResult {
                     content: text,
                     is_error: is_error.unwrap_or(false),
+                    tool_use_id,
                 });
             }
             ContentBlock::Unknown => {}
@@ -311,7 +327,10 @@ fn parse_user_event(message: Option<UserMessage>) -> Vec<FeedItem> {
     let mut items = Vec::new();
     for block in blocks {
         if let ContentBlock::ToolResult {
-            content, is_error, ..
+            tool_use_id,
+            content,
+            is_error,
+            ..
         } = block
         {
             let text = match content {
@@ -322,6 +341,7 @@ fn parse_user_event(message: Option<UserMessage>) -> Vec<FeedItem> {
             items.push(FeedItem::ToolResult {
                 content: text,
                 is_error: is_error.unwrap_or(false),
+                tool_use_id,
             });
         }
     }
@@ -396,7 +416,14 @@ mod tests {
         let items = parse_event(line, &mut acc());
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::ToolCall { name, .. } => assert_eq!(name, "Read"),
+            FeedItem::ToolCall {
+                name,
+                tool_use_id,
+                ..
+            } => {
+                assert_eq!(name, "Read");
+                assert_eq!(tool_use_id.as_deref(), Some("t1"));
+            }
             other => panic!("expected ToolCall, got {other:?}"),
         }
     }
@@ -407,11 +434,67 @@ mod tests {
         let items = parse_event(line, &mut acc());
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::ToolResult { content, is_error } => {
+            FeedItem::ToolResult {
+                content,
+                is_error,
+                tool_use_id,
+            } => {
                 assert_eq!(content, "file contents");
                 assert!(!is_error);
+                assert_eq!(tool_use_id.as_deref(), Some("t1"));
             }
             other => panic!("expected ToolResult, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_streaming_tool_use_carries_id() {
+        // Real Claude `-p --output-format stream-json --include-partial-messages`
+        // splits a tool_use across stream events: content_block_start carries the
+        // id+name, input_json_delta accumulates the arguments, content_block_stop
+        // finalizes. Both the immediate ToolCall (null input) and the final
+        // ToolCall (with input) must carry the tool_use_id so the UI can pair
+        // them with the eventual tool_result.
+        let mut a = acc();
+        let start = r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu_abc","name":"mcp__houston__AskUserQuestion","input":{}}}}"#;
+        let delta = r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"questions\":[]}"}}}"#;
+        let stop = r#"{"type":"stream_event","event":{"type":"content_block_stop","index":0}}"#;
+
+        let started = parse_event(start, &mut a);
+        assert_eq!(started.len(), 1, "expected immediate ToolCall on block_start");
+        match &started[0] {
+            FeedItem::ToolCall {
+                name,
+                input,
+                tool_use_id,
+            } => {
+                assert_eq!(name, "mcp__houston__AskUserQuestion");
+                assert!(input.is_null(), "early ToolCall has null input");
+                assert_eq!(tool_use_id.as_deref(), Some("tu_abc"));
+            }
+            other => panic!("expected ToolCall, got {other:?}"),
+        }
+
+        let mid = parse_event(delta, &mut a);
+        assert!(mid.is_empty(), "input_json_delta emits no FeedItem");
+
+        let finished = parse_event(stop, &mut a);
+        assert_eq!(finished.len(), 1);
+        match &finished[0] {
+            FeedItem::ToolCall {
+                name,
+                input,
+                tool_use_id,
+            } => {
+                assert_eq!(name, "mcp__houston__AskUserQuestion");
+                assert_eq!(input["questions"], serde_json::json!([]));
+                assert_eq!(
+                    tool_use_id.as_deref(),
+                    Some("tu_abc"),
+                    "tool_use_id from block_start must survive to block_stop"
+                );
+            }
+            other => panic!("expected final ToolCall, got {other:?}"),
         }
     }
 
@@ -421,9 +504,14 @@ mod tests {
         let items = parse_event(line, &mut acc());
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::ToolResult { content, is_error } => {
+            FeedItem::ToolResult {
+                content,
+                is_error,
+                tool_use_id,
+            } => {
                 assert!(content.contains("(id: abc-123)"));
                 assert!(!is_error);
+                assert_eq!(tool_use_id.as_deref(), Some("t1"));
             }
             other => panic!("expected ToolResult, got {other:?}"),
         }
@@ -503,7 +591,7 @@ mod tests {
         let start_items = parse_event(start, &mut a);
         assert_eq!(start_items.len(), 1);
         match &start_items[0] {
-            FeedItem::ToolCall { name, input } => {
+            FeedItem::ToolCall { name, input, .. } => {
                 assert_eq!(name, "complete_job");
                 assert!(input.is_null());
             }
@@ -521,7 +609,7 @@ mod tests {
         let items = parse_event(stop, &mut a);
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::ToolCall { name, input } => {
+            FeedItem::ToolCall { name, input, .. } => {
                 assert_eq!(name, "complete_job");
                 assert_eq!(input.get("summary").unwrap().as_str().unwrap(), "Done!");
             }

--- a/engine/houston-terminal-manager/src/session_pump.rs
+++ b/engine/houston-terminal-manager/src/session_pump.rs
@@ -23,7 +23,7 @@ pub async fn pump_session(
         match update {
             SessionUpdate::Feed(item) => {
                 // Detect output files from Write/Edit tool calls.
-                if let FeedItem::ToolCall { ref name, ref input } = item {
+                if let FeedItem::ToolCall { ref name, ref input, .. } = item {
                     if let Some(path) = extract_output_file(name, input) {
                         on_output_file(path);
                     }
@@ -149,6 +149,7 @@ mod tests {
         tx.send(SessionUpdate::Feed(FeedItem::ToolCall {
             name: "Write".into(),
             input: serde_json::json!({"file_path": "/tmp/out.txt"}),
+            tool_use_id: None,
         }))
         .unwrap();
         tx.send(SessionUpdate::Status(SessionStatus::Completed))

--- a/engine/houston-terminal-manager/src/types.rs
+++ b/engine/houston-terminal-manager/src/types.rs
@@ -172,12 +172,28 @@ pub enum FeedItem {
     /// and CTAs.
     ProviderError(ProviderError),
     /// Tool call made by the assistant.
+    ///
+    /// `tool_use_id` is the LLM-provided identifier from the Anthropic API
+    /// (`tool_use.id` in stream-json). Optional only for backward
+    /// compatibility with previously-persisted feed rows that predate the
+    /// field; live parsing always stamps it. The UI uses it to (a) pair
+    /// tool_call with the matching tool_result deterministically and
+    /// (b) key interactive-question answers back to the right call via
+    /// `POST /v1/agents/.../sessions/.../user_input`.
     ToolCall {
         name: String,
         input: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_use_id: Option<String>,
     },
-    /// Result of a tool call.
-    ToolResult { content: String, is_error: bool },
+    /// Result of a tool call. `tool_use_id` matches the originating
+    /// [`Self::ToolCall`] when available; see that variant's docs.
+    ToolResult {
+        content: String,
+        is_error: bool,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_use_id: Option<String>,
+    },
     /// System message (session start, etc.).
     SystemMessage(String),
     /// Session completed — cost/duration summary.

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -81,6 +81,9 @@ export interface AIBoardProps {
   isSpecialTool?: ToolsAndCardsProps["isSpecialTool"]
   /** Custom renderer for special tool results. */
   renderToolResult?: ToolsAndCardsProps["renderToolResult"]
+  /** Custom renderer for special tools still awaiting a result (e.g.
+   *  interactive question cards that drive the result themselves). */
+  renderPendingTool?: ToolsAndCardsProps["renderPendingTool"]
   /** Translated labels for the collapsed process/details block. */
   processLabels?: ChatPanelProps["processLabels"]
   /** Translated reasoning text inside the process/details block. */
@@ -214,6 +217,7 @@ export function AIBoard({
   onDraftChange,
   isSpecialTool,
   renderToolResult,
+  renderPendingTool,
   processLabels,
   getThinkingMessage,
   toolLabels,
@@ -518,6 +522,7 @@ export function AIBoard({
           }
           isSpecialTool={isSpecialTool}
           renderToolResult={renderToolResult}
+          renderPendingTool={renderPendingTool}
           processLabels={processLabels}
           getThinkingMessage={getThinkingMessage}
           toolLabels={toolLabels}

--- a/ui/chat/src/ask-user-question-card.tsx
+++ b/ui/chat/src/ask-user-question-card.tsx
@@ -1,0 +1,435 @@
+/**
+ * `<AskUserQuestionCard>` — interactive UI for the `mcp__houston__AskUserQuestion`
+ * tool. Renders the agent's structured question(s) as radio chips
+ * (`multiSelect: false`) or checkboxes (`multiSelect: true`), plus an "Other"
+ * free-text input that's always present (matches Conductor convention — the
+ * tool docstring tells the LLM not to include "Other" in its options).
+ *
+ * Library-pure: no engine-client import, no i18n hook, no app-state coupling.
+ * The app passes `onSubmit` (which POSTs to `/v1/agents/.../user_input`) and
+ * a `labels` object built from `t(...)`. English defaults render correctly
+ * if labels is omitted, so the component is also usable standalone.
+ *
+ * Keyboard:
+ * - `Tab` / `Shift+Tab` between questions and the submit button (browser default).
+ * - `↑` / `↓` between options within a question.
+ * - `Space` / `Enter` toggles the focused option.
+ * - `⌘↩` / `Ctrl+↩` submits if at least one answer is filled.
+ * - `Esc` clears the form (does NOT cancel the underlying tool call —
+ *    the engine's MCP handler stays blocked until a real answer arrives).
+ */
+
+"use client";
+
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import type { KeyboardEvent } from "react";
+import { cn } from "@houston-ai/core";
+
+/**
+ * One question in the tool's input. Mirrors the Rust shape in
+ * `engine/houston-engine-server/src/routes/mcp.rs::handle_tools_list`.
+ */
+export interface AskUserQuestion {
+  question: string;
+  options: string[];
+  multiSelect?: boolean;
+}
+
+/**
+ * The answer shape posted back to the engine. The engine wraps this verbatim
+ * as the MCP tool result, so the LLM sees it in tool_result. One entry per
+ * question in the same order.
+ */
+export interface AskUserQuestionAnswer {
+  answers: Array<{
+    /** Selected option labels (or [] if only "Other" was filled). */
+    selected: string[];
+    /** Free-text "Other" content, or undefined if the user didn't fill it. */
+    other?: string;
+  }>;
+}
+
+export interface AskUserQuestionLabels {
+  /** Button text in idle state. */
+  submit?: string;
+  /** Button text while the POST is in flight. */
+  submitting?: string;
+  /** Label on the trailing free-text input. */
+  other?: string;
+  /** Placeholder on the trailing free-text input. */
+  otherPlaceholder?: string;
+  /** Helper text above a single-select question's options. */
+  selectOne?: string;
+  /** Helper text above a multi-select question's options. */
+  selectMany?: string;
+  /** Heading on the read-only "answered" view. */
+  answered?: string;
+}
+
+const DEFAULT_LABELS: Required<AskUserQuestionLabels> = {
+  submit: "Submit",
+  submitting: "Submitting...",
+  other: "Other",
+  otherPlaceholder: "Type your answer",
+  selectOne: "Choose one",
+  selectMany: "Choose one or more",
+  answered: "Answered",
+};
+
+export interface AskUserQuestionCardProps {
+  /** The LLM-emitted id we POST back as `tool_use_id`. */
+  toolUseId: string;
+  /** Questions from the tool_use input payload. */
+  questions: AskUserQuestion[];
+  /**
+   * Called when the user clicks submit. The promise resolves once the
+   * POST has been accepted (the answer then flows back to the agent
+   * out-of-band through the MCP HTTP response). Errors are surfaced
+   * inline on the card.
+   */
+  onSubmit: (answer: AskUserQuestionAnswer) => Promise<void>;
+  /**
+   * If set, the card renders read-only — used when displaying a
+   * previously-answered question from chat history.
+   */
+  answered?: AskUserQuestionAnswer;
+  labels?: AskUserQuestionLabels;
+}
+
+interface QuestionState {
+  selected: Set<string>;
+  other: string;
+}
+
+function freshState(questions: AskUserQuestion[]): QuestionState[] {
+  return questions.map(() => ({ selected: new Set<string>(), other: "" }));
+}
+
+export const AskUserQuestionCard = memo(function AskUserQuestionCard({
+  toolUseId,
+  questions,
+  onSubmit,
+  answered,
+  labels,
+}: AskUserQuestionCardProps) {
+  const l = useMemo(() => ({ ...DEFAULT_LABELS, ...labels }), [labels]);
+
+  if (answered) {
+    return <AnsweredView questions={questions} answered={answered} label={l.answered} />;
+  }
+
+  return (
+    <PendingForm
+      toolUseId={toolUseId}
+      questions={questions}
+      onSubmit={onSubmit}
+      labels={l}
+    />
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Pending — interactive form
+// ---------------------------------------------------------------------------
+
+function PendingForm({
+  toolUseId,
+  questions,
+  onSubmit,
+  labels,
+}: {
+  toolUseId: string;
+  questions: AskUserQuestion[];
+  onSubmit: AskUserQuestionCardProps["onSubmit"];
+  labels: Required<AskUserQuestionLabels>;
+}) {
+  const [state, setState] = useState<QuestionState[]>(() => freshState(questions));
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const cardRef = useRef<HTMLFormElement | null>(null);
+
+  // Reset internal state if the agent re-uses the card with a new tool_use_id
+  // (a new question came in for the same session).
+  useEffect(() => {
+    setState(freshState(questions));
+    setSubmitting(false);
+    setError(null);
+  }, [toolUseId, questions]);
+
+  const hasAtLeastOneAnswer = state.some(
+    (q) => q.selected.size > 0 || q.other.trim().length > 0,
+  );
+
+  const toggleOption = useCallback(
+    (qIdx: number, option: string, multiSelect: boolean | undefined) => {
+      setState((prev) => {
+        const next = prev.map((q) => ({ selected: new Set(q.selected), other: q.other }));
+        const slot = next[qIdx];
+        if (multiSelect) {
+          if (slot.selected.has(option)) slot.selected.delete(option);
+          else slot.selected.add(option);
+        } else {
+          if (slot.selected.has(option)) {
+            slot.selected.clear();
+          } else {
+            slot.selected.clear();
+            slot.selected.add(option);
+          }
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const setOther = useCallback((qIdx: number, value: string) => {
+    setState((prev) => prev.map((q, i) => (i === qIdx ? { ...q, other: value } : q)));
+  }, []);
+
+  const submit = useCallback(async () => {
+    if (submitting || !hasAtLeastOneAnswer) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await onSubmit({
+        answers: state.map((q) => {
+          const selected = Array.from(q.selected);
+          const other = q.other.trim();
+          return other ? { selected, other } : { selected };
+        }),
+      });
+      // On success the engine will emit a tool_result FeedItem and the parent
+      // re-renders with `answered` set. We don't reset state here — the
+      // re-render replaces this component with `AnsweredView`.
+    } catch (err) {
+      setSubmitting(false);
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  }, [submitting, hasAtLeastOneAnswer, onSubmit, state]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLFormElement>) => {
+      // ⌘↩ / Ctrl+↩ → submit (anywhere in the form, including inside textboxes).
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        void submit();
+        return;
+      }
+      // Esc → clear the form (a stale-state escape valve for keyboard users).
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setState(freshState(questions));
+        setError(null);
+      }
+    },
+    [questions, submit],
+  );
+
+  return (
+    <form
+      ref={cardRef}
+      onSubmit={(e) => {
+        e.preventDefault();
+        void submit();
+      }}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        "rounded-xl border border-border bg-card text-card-foreground",
+        "p-4 space-y-4 not-prose",
+      )}
+      aria-label="Agent question"
+    >
+      {questions.map((q, qIdx) => (
+        <QuestionBlock
+          key={qIdx}
+          question={q}
+          state={state[qIdx]}
+          onToggle={(option) => toggleOption(qIdx, option, q.multiSelect)}
+          onOtherChange={(v) => setOther(qIdx, v)}
+          labels={labels}
+        />
+      ))}
+
+      {error && (
+        <p role="alert" className="text-xs text-destructive">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center justify-end gap-2 pt-1">
+        <button
+          type="submit"
+          disabled={!hasAtLeastOneAnswer || submitting}
+          className={cn(
+            "rounded-md px-3 py-1.5 text-sm font-medium",
+            "bg-primary text-primary-foreground",
+            "transition-opacity",
+            "disabled:opacity-50 disabled:cursor-not-allowed",
+            "hover:opacity-90",
+          )}
+        >
+          {submitting ? labels.submitting : labels.submit}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function QuestionBlock({
+  question,
+  state,
+  onToggle,
+  onOtherChange,
+  labels,
+}: {
+  question: AskUserQuestion;
+  state: QuestionState;
+  onToggle: (option: string) => void;
+  onOtherChange: (value: string) => void;
+  labels: Required<AskUserQuestionLabels>;
+}) {
+  const groupRef = useRef<HTMLDivElement | null>(null);
+  const multiSelect = !!question.multiSelect;
+  const groupRole = multiSelect ? undefined : "radiogroup";
+  const helperText = multiSelect ? labels.selectMany : labels.selectOne;
+
+  // ↑ / ↓ keyboard navigation between options within the same question.
+  const handleArrowKeys = useCallback((e: KeyboardEvent<HTMLDivElement>) => {
+    if (e.key !== "ArrowUp" && e.key !== "ArrowDown") return;
+    const buttons = Array.from(
+      groupRef.current?.querySelectorAll<HTMLButtonElement>("button[data-option]") ?? [],
+    );
+    if (buttons.length === 0) return;
+    const current = buttons.findIndex((b) => b === document.activeElement);
+    const dir = e.key === "ArrowDown" ? 1 : -1;
+    const next = current < 0 ? 0 : (current + dir + buttons.length) % buttons.length;
+    buttons[next]?.focus();
+    e.preventDefault();
+  }, []);
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm font-medium text-foreground">{question.question}</p>
+      <p className="text-xs text-muted-foreground">{helperText}</p>
+      <div
+        ref={groupRef}
+        role={groupRole}
+        onKeyDown={handleArrowKeys}
+        className="space-y-1.5"
+      >
+        {question.options.map((option) => {
+          const checked = state.selected.has(option);
+          return (
+            <button
+              key={option}
+              type="button"
+              data-option
+              role={multiSelect ? "checkbox" : "radio"}
+              aria-checked={checked}
+              onClick={() => onToggle(option)}
+              className={cn(
+                "flex w-full items-center gap-2.5 rounded-md border px-3 py-2",
+                "text-sm text-left transition-colors",
+                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                checked
+                  ? "border-primary bg-primary/10 text-foreground"
+                  : "border-border bg-background hover:bg-muted/50",
+              )}
+            >
+              <span
+                aria-hidden
+                className={cn(
+                  "shrink-0 size-4 border flex items-center justify-center",
+                  multiSelect ? "rounded-sm" : "rounded-full",
+                  checked
+                    ? "border-primary bg-primary text-primary-foreground"
+                    : "border-muted-foreground/40 bg-transparent",
+                )}
+              >
+                {checked && (multiSelect ? <CheckGlyph /> : <DotGlyph />)}
+              </span>
+              <span className="min-w-0 flex-1">{option}</span>
+            </button>
+          );
+        })}
+      </div>
+      <label className="block space-y-1.5 pt-1">
+        <span className="text-xs text-muted-foreground">{labels.other}</span>
+        <input
+          type="text"
+          value={state.other}
+          onChange={(e) => onOtherChange(e.target.value)}
+          placeholder={labels.otherPlaceholder}
+          className={cn(
+            "w-full rounded-md border border-border bg-background",
+            "px-3 py-2 text-sm",
+            "placeholder:text-muted-foreground",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+          )}
+        />
+      </label>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Answered — read-only view (history reload, or moments after submit)
+// ---------------------------------------------------------------------------
+
+function AnsweredView({
+  questions,
+  answered,
+  label,
+}: {
+  questions: AskUserQuestion[];
+  answered: AskUserQuestionAnswer;
+  label: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-xl border border-border/60 bg-card/60 text-card-foreground",
+        "p-4 space-y-3 not-prose",
+      )}
+      aria-label="Answered question"
+    >
+      <p className="text-xs uppercase tracking-wide text-muted-foreground/70">{label}</p>
+      {questions.map((q, qIdx) => {
+        const slot = answered.answers[qIdx];
+        const picks = slot?.selected ?? [];
+        const other = slot?.other ?? "";
+        const summary = [...picks, ...(other ? [other] : [])].join(", ");
+        return (
+          <div key={qIdx} className="space-y-1">
+            <p className="text-sm font-medium text-foreground">{q.question}</p>
+            <p className="text-sm text-muted-foreground">
+              {summary || "(no answer)"}
+            </p>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Glyphs
+// ---------------------------------------------------------------------------
+
+function CheckGlyph() {
+  return (
+    <svg viewBox="0 0 16 16" className="size-3" fill="none">
+      <path
+        d="M3.5 8.5l3 3 6-6.5"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+function DotGlyph() {
+  return <span className="size-1.5 rounded-full bg-current" aria-hidden />;
+}

--- a/ui/chat/src/ask-user-question-card.tsx
+++ b/ui/chat/src/ask-user-question-card.tsx
@@ -148,13 +148,17 @@ function PendingForm({
   const [error, setError] = useState<string | null>(null);
   const cardRef = useRef<HTMLFormElement | null>(null);
 
-  // Reset internal state if the agent re-uses the card with a new tool_use_id
-  // (a new question came in for the same session).
+  // Reset internal state if the agent re-uses the card with a new
+  // tool_use_id (a new question came in for the same session). We key
+  // ONLY on tool_use_id — depending on `questions` would refire on every
+  // render because the parent re-parses `tool.input` into a new array
+  // identity each time, which would clobber in-progress user selections.
   useEffect(() => {
     setState(freshState(questions));
     setSubmitting(false);
     setError(null);
-  }, [toolUseId, questions]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toolUseId]);
 
   const hasAtLeastOneAnswer = state.some(
     (q) => q.selected.size > 0 || q.other.trim().length > 0,
@@ -239,16 +243,27 @@ function PendingForm({
       )}
       aria-label="Agent question"
     >
-      {questions.map((q, qIdx) => (
-        <QuestionBlock
-          key={qIdx}
-          question={q}
-          state={state[qIdx]}
-          onToggle={(option) => toggleOption(qIdx, option, q.multiSelect)}
-          onOtherChange={(v) => setOther(qIdx, v)}
-          labels={labels}
-        />
-      ))}
+      {questions.map((q, qIdx) => {
+        // `state` is reset via useEffect when `questions` changes (new
+        // tool_use_id), but the very next render runs BEFORE setState
+        // commits, so `state[qIdx]` can transiently be undefined for an
+        // index that exists in the new questions array. Fall back to an
+        // empty slot so the child never crashes on `state.selected.has`.
+        const slot: QuestionState = state[qIdx] ?? {
+          selected: new Set<string>(),
+          other: "",
+        };
+        return (
+          <QuestionBlock
+            key={qIdx}
+            question={q}
+            state={slot}
+            onToggle={(option) => toggleOption(qIdx, option, q.multiSelect)}
+            onOtherChange={(v) => setOther(qIdx, v)}
+            labels={labels}
+          />
+        );
+      })}
 
       {error && (
         <p role="alert" className="text-xs text-destructive">

--- a/ui/chat/src/chat-helpers.tsx
+++ b/ui/chat/src/chat-helpers.tsx
@@ -28,15 +28,29 @@ export interface ToolsAndCardsProps {
   toolLabels?: Record<string, string>;
   /**
    * Predicate to identify "special" tools that should be rendered via
-   * renderToolResult instead of the default ToolBlock.
+   * `renderToolResult` / `renderPendingTool` instead of the default ToolBlock.
    * Defaults to returning false (all tools shown as ToolBlocks).
    */
   isSpecialTool?: (toolName: string) => boolean;
   /**
    * Render prop for special tool results. Called for each tool where
-   * isSpecialTool returns true and the tool has a result.
+   * `isSpecialTool` returns true AND the tool has a result.
    */
   renderToolResult?: (tool: ToolEntry, index: number) => ReactNode;
+  /**
+   * Render prop for special tools that are STILL PENDING — the LLM has
+   * emitted the tool_use but no tool_result has arrived yet. Called for
+   * each tool where `isSpecialTool` returns true AND `tool.result` is
+   * undefined. Used to show interactive cards that DRIVE the result
+   * (e.g. `mcp__houston__AskUserQuestion` — the user picks an option,
+   * the app POSTs to `/user_input`, the engine routes the answer back to
+   * the LLM as the tool_result).
+   *
+   * When this prop is omitted, pending special tools fall back to the
+   * default ToolBlock rendering — which is fine, the user just sees a
+   * "running" tool block until the result lands.
+   */
+  renderPendingTool?: (tool: ToolEntry, index: number) => ReactNode;
 }
 
 export function ToolsAndCards({
@@ -45,19 +59,29 @@ export function ToolsAndCards({
   toolLabels,
   isSpecialTool,
   renderToolResult,
+  renderPendingTool,
 }: ToolsAndCardsProps) {
   const allDone = isStreaming && tools.length > 0 && tools.every((t) => t.result);
 
   return (
     <div className="space-y-2 mb-4">
       {tools.map((tool, i) => {
-        // Special tools get custom rendering
-        if (isSpecialTool?.(tool.name) && tool.result && renderToolResult) {
-          return (
-            <div key={`special-${i}`} className="py-1">
-              {renderToolResult(tool, i)}
-            </div>
-          );
+        // Special tools get custom rendering — branch on result state.
+        if (isSpecialTool?.(tool.name)) {
+          if (tool.result && renderToolResult) {
+            return (
+              <div key={`special-${i}`} className="py-1">
+                {renderToolResult(tool, i)}
+              </div>
+            );
+          }
+          if (!tool.result && renderPendingTool) {
+            return (
+              <div key={`special-pending-${i}`} className="py-1">
+                {renderPendingTool(tool, i)}
+              </div>
+            );
+          }
         }
 
         const isLastTool = i === tools.length - 1;

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -38,6 +38,7 @@ export interface ChatMessagesProps {
   toolLabels?: ToolsAndCardsProps["toolLabels"];
   isSpecialTool?: ToolsAndCardsProps["isSpecialTool"];
   renderToolResult?: ToolsAndCardsProps["renderToolResult"];
+  renderPendingTool?: ToolsAndCardsProps["renderPendingTool"];
   processLabels?: ChatProcessLabels;
   getThinkingMessage?: ReasoningTriggerProps["getThinkingMessage"];
   renderMessageAvatar?: (msg: ChatMessage) => ReactNode | undefined;
@@ -69,6 +70,7 @@ export function ChatMessages({
   toolLabels,
   isSpecialTool,
   renderToolResult,
+  renderPendingTool,
   processLabels,
   getThinkingMessage,
   renderMessageAvatar,
@@ -108,6 +110,7 @@ export function ChatMessages({
                     toolLabels={toolLabels}
                     isSpecialTool={isSpecialTool}
                     renderToolResult={renderToolResult}
+                    renderPendingTool={renderPendingTool}
                     getThinkingMessage={getThinkingMessage}
                   />
                   {(() => {

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -65,6 +65,7 @@ export interface ChatPanelProps {
   toolLabels?: ToolsAndCardsProps["toolLabels"];
   isSpecialTool?: ToolsAndCardsProps["isSpecialTool"];
   renderToolResult?: ToolsAndCardsProps["renderToolResult"];
+  renderPendingTool?: ToolsAndCardsProps["renderPendingTool"];
   processLabels?: ChatMessagesProps["processLabels"];
   getThinkingMessage?: ChatMessagesProps["getThinkingMessage"];
   renderMessageAvatar?: (msg: ChatMessage) => ReactNode | undefined;

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -36,6 +36,7 @@ export function ChatPanel({
   toolLabels,
   isSpecialTool,
   renderToolResult,
+  renderPendingTool,
   processLabels,
   getThinkingMessage,
   renderMessageAvatar,
@@ -134,6 +135,7 @@ export function ChatPanel({
           toolLabels={toolLabels}
           isSpecialTool={isSpecialTool}
           renderToolResult={renderToolResult}
+          renderPendingTool={renderPendingTool}
           processLabels={processLabels}
           getThinkingMessage={getThinkingMessage}
           renderMessageAvatar={renderMessageAvatar}

--- a/ui/chat/src/chat-process-block.tsx
+++ b/ui/chat/src/chat-process-block.tsx
@@ -30,6 +30,7 @@ export interface ChatProcessBlockProps {
   toolLabels?: ToolsAndCardsProps["toolLabels"];
   isSpecialTool?: ToolsAndCardsProps["isSpecialTool"];
   renderToolResult?: ToolsAndCardsProps["renderToolResult"];
+  renderPendingTool?: ToolsAndCardsProps["renderPendingTool"];
   getThinkingMessage?: ReasoningTriggerProps["getThinkingMessage"];
 }
 
@@ -45,6 +46,7 @@ export function ChatProcessBlock({
   toolLabels,
   isSpecialTool,
   renderToolResult,
+  renderPendingTool,
   getThinkingMessage,
 }: ChatProcessBlockProps) {
   const l = useMemo(() => ({ ...DEFAULT_LABELS, ...labels }), [labels]);
@@ -109,6 +111,7 @@ export function ChatProcessBlock({
                   toolLabels={toolLabels}
                   isSpecialTool={isSpecialTool}
                   renderToolResult={renderToolResult}
+                  renderPendingTool={renderPendingTool}
                 />
               )}
             </div>

--- a/ui/chat/src/feed-to-messages.ts
+++ b/ui/chat/src/feed-to-messages.ts
@@ -12,6 +12,15 @@ export interface ToolEntry {
   name: string;
   input?: unknown;
   result?: { content: string; is_error: boolean };
+  /**
+   * LLM-provided id from Anthropic's stream-json (and the matching field
+   * on Gemini's tool events). When present we can pair `tool_call` rows
+   * with their `tool_result` row deterministically, instead of relying on
+   * the legacy "last unmatched tool" sequential heuristic. Optional only
+   * because legacy `chat_feed` rows persisted before this field landed
+   * have no id — those still fall back to sequential pairing.
+   */
+  tool_use_id?: string;
 }
 
 export interface FileChangeEntry {
@@ -135,27 +144,53 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
 
       case "tool_call": {
         const msg = ensureAssistant();
+        const incomingId = item.data.tool_use_id;
         // Deduplicate: the parser emits two tool_calls per tool (null input
         // on block start, real input on block stop). Replace the placeholder.
+        // When tool_use_id is present, pair by id; otherwise fall back to
+        // the legacy "last tool with matching name and null input" heuristic.
         const lastTool = msg.tools[msg.tools.length - 1];
-        if (lastTool && lastTool.name === item.data.name && lastTool.input == null) {
+        const isFollowupForLast =
+          !!lastTool &&
+          ((incomingId && lastTool.tool_use_id === incomingId) ||
+            (!incomingId && lastTool.name === item.data.name && lastTool.input == null));
+        if (isFollowupForLast) {
           lastTool.input = item.data.input;
+          // Stamp the id on first arrival (block_start may emit it before
+          // block_stop on some parsers).
+          if (!lastTool.tool_use_id && incomingId) {
+            lastTool.tool_use_id = incomingId;
+          }
         } else {
-          msg.tools.push({ name: item.data.name, input: item.data.input });
+          msg.tools.push({
+            name: item.data.name,
+            input: item.data.input,
+            tool_use_id: incomingId,
+          });
         }
         if (!msg.content) msg.isStreaming = true;
         break;
       }
 
       case "tool_result": {
-        // Find the most recent unmatched tool_call — it might be in the
-        // current message OR in an already-flushed one (thinking blocks
-        // can cause flushes between tool_call and tool_result).
+        const incomingId = item.data.tool_use_id;
+        // Preferred: pair by tool_use_id. Falls back to sequential matching
+        // (oldest unmatched tool) when the id is absent — true for legacy
+        // chat_feed rows persisted before the field was added.
+        const matchTool = (entry: ToolEntry): boolean => {
+          if (entry.result) return false;
+          if (incomingId && entry.tool_use_id) {
+            return entry.tool_use_id === incomingId;
+          }
+          // Either side lacks an id — fall back to "any unresulted tool".
+          return !incomingId || !entry.tool_use_id;
+        };
+
         let matched = false;
         const active = getCur();
         if (active && active.from === "assistant") {
           for (let j = active.tools.length - 1; j >= 0; j--) {
-            if (!active.tools[j].result) {
+            if (matchTool(active.tools[j])) {
               active.tools[j].result = {
                 content: item.data.content,
                 is_error: item.data.is_error,
@@ -166,12 +201,12 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
           }
         }
         if (!matched) {
-          // Search flushed messages backwards
+          // Search flushed messages backwards.
           for (let m = messages.length - 1; m >= 0 && !matched; m--) {
             const msg = messages[m];
             if (msg.from !== "assistant") continue;
             for (let j = msg.tools.length - 1; j >= 0; j--) {
-              if (!msg.tools[j].result) {
+              if (matchTool(msg.tools[j])) {
                 msg.tools[j].result = {
                   content: item.data.content,
                   is_error: item.data.is_error,

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -179,6 +179,14 @@ export type {
 } from "./chat-panel-types";
 export type { ChatProcessLabels } from "./chat-process-block";
 
+export { AskUserQuestionCard } from "./ask-user-question-card";
+export type {
+  AskUserQuestion,
+  AskUserQuestionAnswer,
+  AskUserQuestionCardProps,
+  AskUserQuestionLabels,
+} from "./ask-user-question-card";
+
 export { ChatInput } from "./chat-input";
 export type { ChatInputProps, ChatComposerLabels } from "./chat-input";
 export type { AttachMenuItem } from "./chat-input-parts";

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -9,8 +9,18 @@ export type FeedItem =
   | { feed_type: "user_message"; data: string }
   | { feed_type: "tool_runtime_error"; data: ToolRuntimeErrorEntry }
   | { feed_type: "provider_error"; data: ProviderError }
-  | { feed_type: "tool_call"; data: { name: string; input: unknown } }
-  | { feed_type: "tool_result"; data: { content: string; is_error: boolean } }
+  | {
+      feed_type: "tool_call";
+      data: { name: string; input: unknown; tool_use_id?: string };
+    }
+  | {
+      feed_type: "tool_result";
+      data: {
+        content: string;
+        is_error: boolean;
+        tool_use_id?: string;
+      };
+    }
   | { feed_type: "system_message"; data: string }
   | {
       feed_type: "file_changes";

--- a/ui/chat/test/feed-to-messages.test.mjs
+++ b/ui/chat/test/feed-to-messages.test.mjs
@@ -25,3 +25,87 @@ test("attaches file changes to the previous assistant message after final result
     { path: "/tmp/notes.txt", status: "modified" },
   ]);
 });
+
+test("pairs tool_call with tool_result by tool_use_id and propagates the id onto ToolEntry", () => {
+  const messages = feedItemsToMessages([
+    { feed_type: "user_message", data: "do two things" },
+    {
+      feed_type: "tool_call",
+      data: { name: "Bash", input: null, tool_use_id: "tu_a" },
+    },
+    {
+      feed_type: "tool_call",
+      data: {
+        name: "Bash",
+        input: { command: "ls" },
+        tool_use_id: "tu_a",
+      },
+    },
+    {
+      feed_type: "tool_call",
+      data: { name: "Read", input: null, tool_use_id: "tu_b" },
+    },
+    {
+      feed_type: "tool_call",
+      data: {
+        name: "Read",
+        input: { path: "/etc/hosts" },
+        tool_use_id: "tu_b",
+      },
+    },
+    // tool_results arrive OUT OF ORDER on purpose — sequential pairing
+    // would attach them to the wrong calls.
+    {
+      feed_type: "tool_result",
+      data: { content: "127.0.0.1 localhost", is_error: false, tool_use_id: "tu_b" },
+    },
+    {
+      feed_type: "tool_result",
+      data: { content: "src/\npackage.json\n", is_error: false, tool_use_id: "tu_a" },
+    },
+    {
+      feed_type: "assistant_text",
+      data: "done both",
+    },
+  ]);
+
+  // user + assistant (which holds both tool entries)
+  assert.equal(messages.length, 2);
+  const assistant = messages[1];
+  assert.equal(assistant.tools.length, 2);
+
+  const [bashEntry, readEntry] = assistant.tools;
+  assert.equal(bashEntry.name, "Bash");
+  assert.equal(bashEntry.tool_use_id, "tu_a");
+  assert.deepEqual(bashEntry.input, { command: "ls" });
+  assert.equal(bashEntry.result.content, "src/\npackage.json\n");
+
+  assert.equal(readEntry.name, "Read");
+  assert.equal(readEntry.tool_use_id, "tu_b");
+  assert.deepEqual(readEntry.input, { path: "/etc/hosts" });
+  assert.equal(readEntry.result.content, "127.0.0.1 localhost");
+});
+
+test("falls back to sequential tool pairing when tool_use_id is absent on legacy rows", () => {
+  // Pre-tool_use_id chat_feed rows lacked the field. New `feed-to-messages`
+  // logic must still pair them in insertion order so existing chat history
+  // renders correctly.
+  const messages = feedItemsToMessages([
+    { feed_type: "user_message", data: "legacy turn" },
+    { feed_type: "tool_call", data: { name: "Bash", input: null } },
+    {
+      feed_type: "tool_call",
+      data: { name: "Bash", input: { command: "echo hi" } },
+    },
+    {
+      feed_type: "tool_result",
+      data: { content: "hi", is_error: false },
+    },
+  ]);
+
+  assert.equal(messages.length, 2);
+  const tool = messages[1].tools[0];
+  assert.equal(tool.name, "Bash");
+  assert.equal(tool.tool_use_id, undefined);
+  assert.equal(tool.result.content, "hi");
+});

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -637,6 +637,31 @@ export class HoustonClient {
       `/agents/${this.seg(agentPath)}/sessions/${this.seg(sessionKey)}/history`,
     );
   }
+  /**
+   * Submit the user's answer to a pending
+   * `mcp__houston__AskUserQuestion` tool call. The engine's MCP handler is
+   * blocked awaiting this; on success it returns the answer to the agent
+   * as the tool_result. 204 No Content on success; 404 if the question
+   * was already answered or never existed; 409 if the MCP handler was
+   * cancelled in the same tick.
+   *
+   * The `answer` shape is opaque to the engine — typically
+   * `{ answers: [{ selected: string[], other?: string }] }` per the UI
+   * convention, but the engine just forwards it verbatim as the tool
+   * result so the agent can interpret it however it wants.
+   */
+  submitUserInput(
+    agentPath: string,
+    sessionKey: string,
+    toolUseId: string,
+    answer: unknown,
+  ): Promise<void> {
+    return this.request(
+      "POST",
+      `/agents/${this.seg(agentPath)}/sessions/${this.seg(sessionKey)}/user_input`,
+      { toolUseId, answer },
+    );
+  }
   summarizeActivity(message: string, opts: SummarizeOptions = {}): Promise<SummarizeResult> {
     return this.request("POST", "/sessions/summarize", {
       message,


### PR DESCRIPTION
Fork-side companion: [broomva/houston#38](https://github.com/broomva/houston/pull/38).

Ships interactive `AskUserQuestion` end-to-end. When a Claude agent calls `mcp__houston__AskUserQuestion`, the chat now renders a real interactive card (radio chips / checkboxes / "Other" textbox) instead of falling back to plain text. The user clicks, the answer flows back to the agent as the tool_result via a new REST endpoint + an in-engine MCP HTTP server, agent continues the turn.

Modeled after Conductor's `mcp__conductor__AskUserQuestion` ([blog](https://www.conductor.build/blog/ask-user-question-tool)) — same schema shape so LLMs prompted in either ecosystem use the tool with zero retraining.

## Summary

- **New in-engine MCP server**: hand-rolled minimal Streamable-HTTP MCP server in `routes/mcp.rs` (axum 0.7-compatible; rmcp pulls axum 0.8 so we can't use it). Hosts a single tool, `AskUserQuestion`. `tools/call` returns SSE with `KeepAlive::new().interval(15s)` to beat Claude CLI's 60-second first-byte fetch budget while waiting on the human. Per-server `timeout: 3_600_000` raises the watchdog to 1h.
- **`PendingAskUserRegistry`** (`engine-core/src/sessions/ask_user.rs`) brokers the parser↔MCP↔REST flow via fifo queue + waiters; tolerates either ordering, propagates cancellation by dropping oneshots. 10 unit tests.
- **`tool_use_id` propagation**: parser stamps it from Anthropic stream-json; Gemini's `tool_id` uses the same field; persisted into `chat_feed`. Backward-compatible (optional field).
- **`mcp_config` plumbed** through `SessionRuntime → run_start → spawn_and_monitor → claude_runner`. `run_start` writes `~/.houston/tmp/mcp/<session_key>.json` per session.
- **New REST**: `POST /v1/agents/:agent_path/sessions/:key/user_input { toolUseId, answer }` → 204 on success / 404 / 409.
- **`<AskUserQuestionCard>`** (`ui/chat/src/ask-user-question-card.tsx`): library-pure, English label defaults, app passes localized `labels` from `t()`. Keyboard nav (↑/↓, Space/Enter, ⌘↩, Esc).
- **New `renderPendingTool` render-prop** through `ToolsAndCards → ChatProcessBlock → ChatMessages → ChatPanel → AIBoard`, parallel to existing `renderToolResult`.
- **App-side hooks** `useAskUserQuestionRenderer` + `useComposedSpecialToolRenderers` plug the card into both chat-tab and the board/dashboard mission view.
- i18n in en / es / pt.

## Tests + Verification

- 267 tests pass in `houston-engine-core`, 8 new in `routes::mcp::tests`, 10 new in `sessions::ask_user::tests`, 1 new parser test.
- `pnpm typecheck` clean across `ui/chat`, `ui/engine-client`, `ui/board`, `app`.
- `pnpm check-locales` clean.
- **Live dogfood via Interceptor**: three complete tool-call round-trips in a single real Claude session (statement → setup mode → company-name onboarding step). Screenshots in `/tmp/dogfood-ask-user-ui/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)