### PR TITLE
docs(contributing): post the bar for incoming PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+<!--
+Read CONTRIBUTING.md "Before you open a PR" first. PRs that don't fit get closed.
+-->
+
+## What this scratches for you
+
+<!-- Required. A bug you hit, or a feature you'll use in Houston. "Thought it would be nice" is not an answer. -->
+
+## Linked issue
+
+<!-- Required for anything >50 LOC or any new tooling/docs/governance. Bug fixes under 50 LOC can skip. -->
+
+Closes #
+
+## Summary
+
+<!-- 1-3 bullets on what changed. -->
+
+-
+
+## Checklist
+
+- [ ] I read the diff myself before opening this PR (AI-assisted is fine, AI-unreviewed is not)
+- [ ] I have no other open PRs on this repo
+- [ ] `pnpm typecheck` passes
+- [ ] `cargo check --workspace` passes (if Rust touched)
+- [ ] `cargo test --workspace` passes (if Rust touched)
+- [ ] No external frameworks/methodology imported into `knowledge-base/` or `docs/`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,19 @@
 # Contributing to Houston
 
-Thanks for your interest in contributing to Houston!
+Houston is a small team shipping fast. We're glad you want to help, and we have a posted bar so review stays sustainable.
+
+## Before you open a PR
+
+Read this section. If your PR doesn't fit, we'll close it without arguing.
+
+1. **Open an issue first** for anything that isn't a bug fix under ~50 LOC. No surprise PRs for refactors, new tooling, governance, or docs about how to contribute. If we haven't agreed it's worth building, don't build it.
+2. **One open PR at a time** per contributor. Open the next one only after the previous merges or closes.
+3. **Scratch your own itch.** The PR must fix a bug you hit or add a feature you actually use in Houston. "I thought the repo could use X" isn't a reason. Speculative improvements are work for us, not value.
+4. **AI-generated is fine, you reviewing the diff isn't optional.** Use Claude Code, Cursor, whatever. But you read the diff first. If the PR body has to justify why to ship it ("not really an upgrade but…"), don't ship it. PRs that read as raw autonomous-loop output get closed.
+5. **No importing external frameworks.** Don't add your own methodology, RFCs, or doctrine to Houston's `knowledge-base/` or `docs/`. Link from your repo to ours, not the other way around.
+6. **Stacked PRs get one shot.** If the base PR doesn't land, the stack is dead. Don't chain four deep.
+
+If you're unsure whether something fits, open an issue and ask. Cheaper than a closed PR for both of us.
 
 ## Getting Started
 
@@ -43,10 +56,11 @@ cargo test --workspace
 
 ## Pull Requests
 
-1. Create a feature branch from `main`
-2. Make your changes
-3. Run `pnpm typecheck` and `cargo check --workspace`
-4. Open a PR to `main`
+1. Confirm your change fits the bar in [Before you open a PR](#before-you-open-a-pr)
+2. Create a feature branch from `main`
+3. Make your changes
+4. Run `pnpm typecheck` and `cargo check --workspace`
+5. Open a PR to `main`, fill out the template honestly
 
 ## Commit Messages
 


### PR DESCRIPTION
## Summary

- Adds a **Before you open a PR** section to `CONTRIBUTING.md` with 6 rules
- Adds `.github/PULL_REQUEST_TEMPLATE.md` so the bar is in writing before a PR is even opened

## Why

Houston has been getting volume PRs from autonomous-loop contributors who haven't read the diff themselves. No posted bar = contributor sets their own. This puts the rules in writing so closing off-spec PRs becomes a one-liner pointing at the doc.

## The 6 rules

1. **Open an issue first** for anything that isn't a bug fix under ~50 LOC
2. **One open PR at a time** per contributor
3. **Scratch your own itch** (real bug you hit or feature you use)
4. **AI is fine, reviewing the diff isn't optional**
5. **No importing external frameworks** into our knowledge-base/docs
6. **Stacked PRs get one shot**

## PR template

Two required free-text fields (*what this scratches for you*, *linked issue*) plus an explicit checkbox attesting the author read the diff. Empty templates = trivial close.

## Test plan

- [x] Markdown renders cleanly
- [x] Anchor link `#before-you-open-a-pr` resolves
- [ ] First inbound PR uses the new template