### PR TITLE
docs(cloud-design): Houston Cloud architecture guide

### DIFF
--- a/cloud-design/01-the-plan.html
+++ b/cloud-design/01-the-plan.html
@@ -1,0 +1,197 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The plan — Houston Cloud Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html" class="active"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 01
+      <span class="status progress">The plan</span>
+    </div>
+    <h1>One agent, one tiny computer.</h1>
+    <p class="lead">
+      That is the whole architecture. Every agent in Houston Cloud gets
+      its own miniature Linux machine, sealed off from everything else,
+      asleep until someone talks to it. This chapter is the one page
+      version. Every chapter after this zooms in on one piece.
+    </p>
+
+    <h2>The core decision</h2>
+    <p>
+      Each agent runs in its own <strong>Kata container</strong>, which
+      is a fancy way of saying its own little virtual computer powered
+      by <strong>Firecracker</strong>. Those little computers run on a
+      cluster managed by <strong>Kubernetes</strong>. When an agent
+      isn't being used, its computer is turned off and costs zero.
+      When you send a message, the computer boots in under a second,
+      does the work, then turns off again.
+    </p>
+    <p>
+      Everything else in this guide flows from that one decision.
+    </p>
+
+    <h2>The pieces</h2>
+
+    <h3>Frontend</h3>
+    <ul>
+      <li>One React web app at <code>app.houston.ai</code>, served from a CDN.</li>
+      <li>The existing desktop app can also point at the cloud engine instead of a local one. Same wire protocol. Same code, two doors.</li>
+    </ul>
+
+    <h3>Control plane</h3>
+    <p>The brain in front of every agent. About 3 to 5 copies running at all times.</p>
+    <ul>
+      <li>Handles login (Supabase does the actual heavy lifting).</li>
+      <li>Stores who-owns-what in Postgres: workspaces, users, agents, permissions, billing.</li>
+      <li>Holds the live chat session state in Redis (short term memory).</li>
+      <li>Decides which agent a message goes to, checks if the user is allowed, then forwards it.</li>
+      <li>Wakes the agent's pod if it's asleep.</li>
+    </ul>
+
+    <h3>Agent pods (the meat)</h3>
+    <ul>
+      <li>One Kata + Firecracker microVM per agent.</li>
+      <li>Inside each one: the <code>houston-engine</code> binary plus the bundled CLIs (Claude Code, Codex, Composio).</li>
+      <li><strong>Knative</strong> turns them off when idle, boots them when needed.</li>
+      <li>Each agent's pod lives inside its team's K8s namespace.</li>
+    </ul>
+
+    <h3>Per team isolation</h3>
+    <ul>
+      <li>Each workspace gets its own Kubernetes namespace.</li>
+      <li>A <strong>NetworkPolicy</strong> stops different teams' agents from ever talking to each other.</li>
+      <li>Big enterprise customers can pay for their own dedicated machines.</li>
+    </ul>
+
+    <h3>Per agent isolation</h3>
+    <p>The pod boundary <em>is</em> the agent boundary.</p>
+    <ul>
+      <li>Each pod has its own filesystem, its own OAuth tokens, its own data.</li>
+      <li>Juan asks the HR agent to peek at Sales files. The HR agent's pod literally cannot see the Sales pod's disk. No clever sandboxing inside a shared pod required.</li>
+    </ul>
+
+    <h3>State</h3>
+    <ul>
+      <li>Each agent gets a small persistent volume that holds its <code>.houston/</code> directory.</li>
+      <li>Survives pod restarts and scale to zero.</li>
+      <li>Storage is cheap (a few cents per GB per month). Compute is the expensive part, and that's zero when idle.</li>
+    </ul>
+
+    <h3>Permissions</h3>
+    <ul>
+      <li>Admin sets, in the UI: "Juan can talk to HR agent. Cannot talk to Sales agent."</li>
+      <li>Enforced at the control plane. The only path to an agent's pod goes through the control plane, so RBAC is final.</li>
+    </ul>
+
+    <h2>The stack at a glance</h2>
+    <table>
+      <thead>
+        <tr><th>Layer</th><th>What we use</th><th>Plain English</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>Cluster</td><td>EKS or GKE</td><td>Rented Kubernetes from Amazon or Google.</td></tr>
+        <tr><td>Runtime isolation</td><td>Kata Containers with Firecracker</td><td>Tiny VMs that wrap each pod with a real hardware wall.</td></tr>
+        <tr><td>Scale to zero</td><td>Knative Serving</td><td>Turns pods off when idle, boots on demand.</td></tr>
+        <tr><td>Network policy</td><td>Cilium or Calico</td><td>Decides who is allowed to talk to whom.</td></tr>
+        <tr><td>Auth</td><td>Supabase</td><td>Handles login, sessions, SSO.</td></tr>
+        <tr><td>Metadata DB</td><td>Postgres</td><td>Long term memory. Users, agents, permissions, billing.</td></tr>
+        <tr><td>Session cache</td><td>Redis</td><td>Short term memory. Live chat state.</td></tr>
+        <tr><td>Object storage</td><td>S3 or GCS</td><td>Files, attachments, backups.</td></tr>
+        <tr><td>Analytics</td><td>PostHog</td><td>Who clicked what.</td></tr>
+        <tr><td>Errors</td><td>Sentry</td><td>What broke and where.</td></tr>
+        <tr><td>Frontend</td><td>React (<code>@houston-ai/*</code>)</td><td>The same components the desktop already uses.</td></tr>
+        <tr><td>Agent runtime</td><td><code>houston-engine</code> + CLIs</td><td>The same Rust binary that runs on the desktop today.</td></tr>
+      </tbody>
+    </table>
+
+    <h2>Why this shape</h2>
+
+    <div class="fail-grid">
+      <div class="fail-card">
+        <div class="label">Problem 1</div>
+        <p><strong>Agents can read each other's stuff.</strong> If two agents share a machine and one of them is told "read the other guy's files," it can. Solution: each agent gets its own machine. Done.</p>
+      </div>
+      <div class="fail-card">
+        <div class="label">Problem 2</div>
+        <p><strong>Idle agents cost money.</strong> A sales bot used once a day shouldn't cost the same as one running 24 by 7. Solution: turn off the box when nobody's talking. Knative does it for us.</p>
+      </div>
+      <div class="fail-card">
+        <div class="label">Problem 3</div>
+        <p><strong>Different teams can't share a machine.</strong> Acme's HR agent should never accidentally route to Globex. Solution: each team in its own Kubernetes namespace, walled off with NetworkPolicy.</p>
+      </div>
+      <div class="fail-card">
+        <div class="label">Problem 4</div>
+        <p><strong>Agent state has to survive a restart.</strong> The agent's notes, memory, OAuth tokens. Solution: per agent persistent volume. Disk lives even when the pod doesn't.</p>
+      </div>
+    </div>
+
+    <h2>What we are not doing</h2>
+    <p>Three architectural rejects, so we don't relitigate them later.</p>
+    <ul>
+      <li><strong>Pod per user, agents share a pod.</strong> Cheaper, simpler, fewer pods to schedule, but loses the per agent trust boundary. Requires <code>bubblewrap</code> or similar sandboxes inside the pod. Rejected: the pod boundary is free, why fight it.</li>
+      <li><strong>Throw away our engine, run Hermes or OpenClaw.</strong> Their engines are great. They are also competitors with funded teams and fast moving APIs. Rejected: stay on <code>houston-engine</code>, freeze it at "good enough," invest hours into the moat layer (UX, Composio, deployment) instead.</li>
+      <li><strong>Bubblewrap inside the pod.</strong> Was Plan A when we thought one pod served a whole team. With pod per agent, the pod itself is the wall. Bwrap becomes redundant complexity.</li>
+    </ul>
+
+    <h2>What this buys us</h2>
+    <ul>
+      <li><strong>Clean trust boundary.</strong> Pod equals agent equals isolation. No clever sandboxing.</li>
+      <li><strong>Scale to zero.</strong> A customer with 10,000 agents pays only for the ones currently in a conversation.</li>
+      <li><strong>Real team isolation.</strong> Workspace boundary is enforced by Kubernetes, not aspiration.</li>
+      <li><strong>Reuses the engine.</strong> No rewrite. Container image is just <code>houston-engine</code> plus the CLIs.</li>
+      <li><strong>Multi engine optional later.</strong> The pod can hold any runtime that speaks our supervisor protocol. We don't decide now.</li>
+    </ul>
+
+    <div class="callout callout-info">
+      <div class="callout-label">How to read the rest of this guide</div>
+      <p>Chapters 2 through 9 explain each piece of the stack from the ground up. Chapter 10 walks through a single message end to end. Chapter 11 is the build order with gates. If you only have ten minutes, you just read the most important chapter.</p>
+    </div>
+
+    <div class="pager">
+      <a href="index.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Overview</div>
+      </a>
+      <a href="02-kubernetes.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Kubernetes</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/02-kubernetes.html
+++ b/cloud-design/02-kubernetes.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Kubernetes — Houston Cloud Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html" class="active"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 02
+      <span class="status planned">Planned</span>
+    </div>
+    <h1>Kubernetes is a robot landlord.</h1>
+    <p class="lead">
+      Houston runs ten thousand tiny programs. Something has to decide
+      where each one lives, restart them when they crash, and move them
+      around when a machine dies. That thing is Kubernetes. It is a
+      robot landlord for software.
+    </p>
+
+    <h2>The 30 second version</h2>
+    <p>
+      You have a bunch of computers in a datacenter. You have a bunch
+      of programs you want to run. You don't want to log into each
+      computer and start each program by hand. So you tell Kubernetes
+      "here are 50 servers, here are 5,000 programs, figure it out."
+      Kubernetes figures it out. When a program crashes, Kubernetes
+      restarts it. When a server dies, Kubernetes moves the programs
+      to a different server. When you need more programs, Kubernetes
+      finds room.
+    </p>
+    <p>
+      That's the whole pitch. Everything else is jargon.
+    </p>
+
+    <h2>The words</h2>
+
+    <h3>Pod</h3>
+    <p>
+      A pod is one running program. In our case, one pod equals one
+      agent. If we have 10,000 agents online, we have 10,000 pods.
+      A pod is the smallest thing Kubernetes manages.
+    </p>
+
+    <h3>Node</h3>
+    <p>
+      A node is one physical computer (or one rented virtual computer
+      from Amazon). Many pods live on one node. Think of a node as an
+      apartment building and pods as the tenants.
+    </p>
+
+    <h3>Cluster</h3>
+    <p>
+      A cluster is the whole set of nodes managed together. One
+      cluster might have 50 nodes running 5,000 pods. The cluster is
+      the city the robot landlord runs.
+    </p>
+
+    <h3>Namespace</h3>
+    <p>
+      A namespace is a fence inside the cluster. Pods in different
+      namespaces can be told to ignore each other entirely. Houston
+      uses one namespace per team workspace. So Acme's pods and
+      Globex's pods can run on the same physical machines but never
+      see each other.
+    </p>
+
+    <h3>Service</h3>
+    <p>
+      A pod's address changes every time it restarts. A service is a
+      permanent doorbell that points to whichever pod is currently
+      alive. "Always knock here, I'll forward you to the right pod."
+    </p>
+
+    <h3>Deployment</h3>
+    <p>
+      A wish. "I want 3 copies of this program running at all times."
+      Kubernetes keeps that wish true. If a copy dies, it makes a new
+      one. If you change the wish to 5 copies, it spawns 2 more. If
+      you change the program version, it rolls out the new one a few
+      pods at a time.
+    </p>
+
+    <h2>GKE? EKS? What are those?</h2>
+    <p>
+      Running Kubernetes yourself is a part time job. You'd need
+      people to update it, secure it, fix it when it breaks. Nobody
+      wants that. So Amazon and Google rent it to you.
+    </p>
+    <ul>
+      <li><strong>GKE</strong> is Google's rented Kubernetes. "Google Kubernetes Engine." You give them a credit card, they give you a cluster.</li>
+      <li><strong>EKS</strong> is Amazon's version. "Elastic Kubernetes Service." Same idea.</li>
+      <li><strong>AKS</strong> is Microsoft's. Same again.</li>
+    </ul>
+    <p>
+      Pick one based on which cloud's invoices you already hate. We're
+      planning on GKE because Houston already has Google Cloud credits
+      from BigQuery and hosting.
+    </p>
+
+    <h2>What Kubernetes gives us specifically</h2>
+    <ul>
+      <li><strong>Restart for free.</strong> If <code>houston-engine</code> crashes inside an agent pod, Kubernetes restarts it without anyone noticing.</li>
+      <li><strong>Move for free.</strong> If a node dies in the middle of the night, Kubernetes spreads its pods across the surviving nodes. The on-call engineer's pager doesn't go off.</li>
+      <li><strong>Scale for free.</strong> When 1,000 new customers sign up tomorrow, we ask the cluster to add more nodes. New pods land on them. No code changes.</li>
+      <li><strong>Walls for free.</strong> Namespaces and NetworkPolicy keep Acme and Globex apart without us writing any code.</li>
+      <li><strong>Ecosystem for free.</strong> Knative (auto sleep), Kata (microVMs), Cilium (network), Helm (packages), cert-manager (TLS), Prometheus (metrics). Every piece of cloud infra plugs into K8s.</li>
+    </ul>
+
+    <h2>What Kubernetes does not give us</h2>
+    <ul>
+      <li><strong>Isolation between pods on the same node.</strong> Two pods on the same physical machine share the kernel. If one of them escapes, it can attack its neighbor. We fix this with Kata + Firecracker (Chapter 3).</li>
+      <li><strong>Scale to zero.</strong> Default Kubernetes keeps your pods running even when nobody uses them. We fix this with Knative (Chapter 4).</li>
+      <li><strong>An opinion about your code.</strong> K8s is dumb on purpose. It runs whatever you put in a container. We have to bring our own engine, our own control plane, our own everything.</li>
+    </ul>
+
+    <h2>What our cluster will roughly look like</h2>
+
+    <div class="diagram">
+      <div class="deploy-grid">
+        <div class="deploy-col">
+          <div class="deploy-head">Cluster</div>
+          <div class="deploy-layer">EKS / GKE</div>
+          <div class="deploy-arrow">↓</div>
+          <div class="deploy-layer">~50 nodes (autoscaling)</div>
+        </div>
+        <div class="deploy-col">
+          <div class="deploy-head">Shared namespace</div>
+          <div class="deploy-layer">Control plane (3-5 pods)</div>
+          <div class="deploy-layer">Postgres + Redis</div>
+          <div class="deploy-layer">Knative system pods</div>
+        </div>
+        <div class="deploy-col">
+          <div class="deploy-head">Per team namespace</div>
+          <div class="deploy-layer">Acme: agent pods</div>
+          <div class="deploy-layer">Globex: agent pods</div>
+          <div class="deploy-layer">... thousands</div>
+        </div>
+      </div>
+      <div class="caption">The cluster runs everything. Namespaces are the team walls.</div>
+    </div>
+
+    <div class="callout callout-info">
+      <div class="callout-label">Why not Docker Compose / Fly Machines / something simpler?</div>
+      <p>For a 10-pod side project, Docker Compose wins. For 10,000-pod multi tenant with per agent isolation, audit logging, RBAC, and the ecosystem of every tool we want to use (Kata, Knative, Cilium), Kubernetes is the boring answer. Boring wins enterprise sales calls.</p>
+    </div>
+
+    <div class="tech-box">
+      <div class="label">Cost shape</div>
+      <p>EKS control plane is ~$72/month. GKE is comparable. Node cost is whatever VMs we use — likely a mix of small always-on nodes for the control plane and bigger autoscaling nodes for agents. Real cost lives in the nodes, not the cluster fee.</p>
+    </div>
+
+    <div class="pager">
+      <a href="01-the-plan.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">The plan</div>
+      </a>
+      <a href="03-kata-firecracker.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Kata + Firecracker</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/03-kata-firecracker.html
+++ b/cloud-design/03-kata-firecracker.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Kata + Firecracker — Houston Cloud Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html" class="active"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 03
+      <span class="status planned">Planned</span>
+    </div>
+    <h1>Each agent gets a tiny fortress.</h1>
+    <p class="lead">
+      Normal containers share a kernel. If one container is told "go
+      read the other guy's files," it can probably find a way. We
+      can't have that. Firecracker is a tool that wraps each pod in
+      a real virtual machine, so the wall between agents is the same
+      wall between two laptops on the same desk.
+    </p>
+
+    <h2>The problem we are solving</h2>
+    <p>
+      A normal Docker container is not a real machine. It's a process
+      with some fences around it. Linux uses tricks (namespaces,
+      cgroups, seccomp) to make the process <em>feel</em> isolated.
+      But it's still sharing the Linux kernel with every other
+      container on the same node. One nasty bug in the kernel
+      and one container can read every other container's memory.
+    </p>
+    <p>
+      This is fine if you trust everything running on your node. It
+      is not fine if your business is "run code on behalf of strangers
+      and customers who don't want their data to leak."
+    </p>
+
+    <div class="fail-grid">
+      <div class="fail-card">
+        <div class="label">The exact attack we don't want</div>
+        <p>Juan (sales) is told he can only use the HR agent. The HR agent is just a process running Claude Code. Juan says: "read /workspaces/sales/.houston/sessions and summarize." If the HR agent's process can reach those files, Juan just bypassed his permissions. The auth layer can't stop this — the agent literally has filesystem access. The only fix is to make sure HR's process can't even see Sales' disk.</p>
+      </div>
+    </div>
+
+    <h2>Firecracker, in one paragraph</h2>
+    <p>
+      Firecracker is a tool from AWS. They invented it to run AWS
+      Lambda. It boots a real virtual machine in about 125
+      milliseconds, with a real Linux kernel inside, completely
+      separated from the host. Each Firecracker VM is called a
+      "microVM" because it's stripped down to almost nothing: no
+      drivers you don't need, no boot screens, no nonsense. Just
+      enough Linux to run your process.
+    </p>
+    <p>
+      The wall between two Firecracker microVMs is the same kind of
+      wall between your MacBook and the Windows laptop next to it.
+      Hardware level. To get from one to the other, you need a bug in
+      the CPU, not a bug in some Linux feature.
+    </p>
+
+    <h2>Kata Containers, in one paragraph</h2>
+    <p>
+      Kubernetes doesn't know what Firecracker is. It only knows how
+      to start containers. Kata Containers is the translator. It
+      pretends to be a normal container runtime to Kubernetes, but
+      under the hood, each "container" it starts is actually a
+      Firecracker microVM. You add one config line to your pod
+      (<code>runtimeClassName: kata-fc</code>) and Kubernetes is
+      happy. Your pod gets a real VM.
+    </p>
+
+    <div class="diagram">
+      <div class="stack">
+        <div class="stack-layer top">
+          <div class="name">Your pod spec</div>
+          <div class="desc">Says <code>runtimeClassName: kata-fc</code>. Everything else is normal Kubernetes.</div>
+        </div>
+        <div class="stack-layer mid">
+          <div class="name">Kata Containers (the translator)</div>
+          <div class="desc">Kubernetes thinks it's starting a container. Kata starts a Firecracker microVM instead.</div>
+        </div>
+        <div class="stack-layer bot">
+          <div class="name">Firecracker microVM</div>
+          <div class="desc">Real virtual machine. Real Linux kernel. Hardware-level wall. Boots in ~125 ms.</div>
+        </div>
+      </div>
+      <div class="caption">Kubernetes on top, Firecracker on the bottom, Kata gluing them together.</div>
+    </div>
+
+    <h2>Why not gVisor?</h2>
+    <p>
+      <strong>gVisor</strong> is the competitor. Google built it. Same
+      idea (better isolation than regular containers) but it works by
+      intercepting system calls instead of running a real VM. Cheaper
+      to run. Weaker wall.
+    </p>
+    <ul>
+      <li><strong>gVisor</strong>: catches every syscall, simulates it in user space. Lower overhead, no real VM. Used by Google Cloud Run. Solid against most attacks.</li>
+      <li><strong>Firecracker</strong>: actual hardware-level virtualization. Stronger wall. Used by AWS Lambda and Fly.io.</li>
+    </ul>
+    <p>
+      For Houston specifically: we are running customer code (agents)
+      on shared infrastructure, with an open marketplace where some
+      agents will be community contributed. That means we should
+      assume some agent code is hostile or buggy. Firecracker is the
+      right answer for that threat model. We can switch to gVisor as
+      an option later if the cost story demands it.
+    </p>
+
+    <h2>The performance question</h2>
+    <p>
+      "Doesn't booting a VM per agent make everything slow?" Used to
+      be true. Not anymore.
+    </p>
+    <ul>
+      <li>Firecracker cold start: ~125 ms to boot the VM itself.</li>
+      <li>Add Houston engine startup: another few hundred ms.</li>
+      <li>Total user-facing delay on first message after idle: roughly half a second.</li>
+      <li>Subsequent messages: zero overhead. The VM is already running.</li>
+    </ul>
+    <p>
+      Half a second of "agent waking up" is a feature, not a bug.
+      It maps perfectly to scale to zero (Chapter 4), which means
+      idle agents cost nothing.
+    </p>
+
+    <h2>What this gets us</h2>
+    <ul>
+      <li><strong>Hardware-level isolation.</strong> The HR agent literally cannot reach the Sales agent's files because it's a different VM with a different kernel.</li>
+      <li><strong>Per agent OAuth tokens are safe.</strong> Each pod has its own credentials. Compromise one, you compromise one. Not all.</li>
+      <li><strong>Compliance answers write themselves.</strong> "How are agents isolated?" "Each one runs in its own Firecracker microVM." Conversation over.</li>
+      <li><strong>Community agents are safe to host.</strong> Someone publishes a malicious agent? Worst case it owns its own pod. Can't escape.</li>
+    </ul>
+
+    <div class="callout callout-warning">
+      <div class="callout-label">The catch</div>
+      <p>Kata + Firecracker is operationally heavier than vanilla containers. You need bare metal nodes (or nested virtualization), proper RuntimeClass setup, and you can't use every K8s feature out of the box (some networking plugins don't play nice with microVMs). This is real engineering, not a flag flip. Budget several weeks for the platform team to get it production-ready the first time.</p>
+    </div>
+
+    <div class="tech-box">
+      <div class="label">What we install on the cluster</div>
+      <p>Kata Containers operator from their official charts. Register a RuntimeClass called <code>kata-fc</code>. Configure node pools to support nested virtualization (or use bare metal nodes — most clouds offer them). Every agent pod manifest sets <code>spec.runtimeClassName: kata-fc</code>. Control plane pods, Postgres, Redis, the boring stuff stays on regular <code>runc</code>.</p>
+    </div>
+
+    <div class="pager">
+      <a href="02-kubernetes.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Kubernetes</div>
+      </a>
+      <a href="04-knative.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Knative</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/04-knative.html
+++ b/cloud-design/04-knative.html
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Knative — Houston Cloud Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html" class="active"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 04
+      <span class="status planned">Planned</span>
+    </div>
+    <h1>Idle agents pay zero.</h1>
+    <p class="lead">
+      The economics of Houston Cloud only work if a sleeping agent
+      costs nothing. Most users have a Sales bot they touch twice a
+      day and a recruiter bot they touch once a week. If those pods
+      run 24 hours a day, our bill scales linearly with seats and
+      we lose money on every customer. Knative is the trick that
+      makes idle agents free.
+    </p>
+
+    <h2>The economic problem</h2>
+    <p>
+      Imagine an enterprise with 100 employees and 10 agents per
+      employee. That's 1,000 agents. If we charge $20 per seat per
+      month and each agent's pod costs us $5 a month to run idle,
+      our gross margin is negative before the agent does any work.
+    </p>
+    <p>
+      We need: pods that exist only when a human is actually talking
+      to them. Pods that take less than a second to wake up. Pods
+      that automatically die when nobody's around.
+    </p>
+    <p>
+      That is exactly what Knative does.
+    </p>
+
+    <h2>Knative, in one paragraph</h2>
+    <p>
+      Knative is a layer on top of Kubernetes that adds three superpowers:
+      "scale to zero," "scale on demand," and "scale based on traffic."
+      You hand Knative a container image and say "this is a service."
+      Knative figures out the rest. When traffic arrives, it boots
+      pods. When traffic stops, it kills them. When traffic spikes,
+      it boots more. You never run <code>kubectl scale</code> by hand.
+    </p>
+    <p>
+      Built by Google. Same team that made Kubernetes. Used in
+      production by tons of teams. It's the open source guts of
+      Google Cloud Run.
+    </p>
+
+    <h2>How it works for one agent</h2>
+
+    <div class="flow-list">
+      <div class="flow-step">
+        <div class="num">01</div>
+        <div>
+          <div class="from-to"><span class="actor">Admin</span> <span class="arrow">→</span> <span class="actor">Knative</span></div>
+          <div class="action">"Here's the agent image. Treat it as a service called <code>agent-hr-acme</code>."</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">02</div>
+        <div>
+          <div class="from-to"><span class="actor">Knative</span></div>
+          <div class="action">Creates the service. Zero pods running. Nothing to bill.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">03</div>
+        <div>
+          <div class="from-to"><span class="actor">Juan sends a message</span> <span class="arrow">→</span> <span class="actor">Knative</span></div>
+          <div class="action">First request arrives. No pod to handle it. Knative boots one (Kata + Firecracker, ~500 ms total).</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">04</div>
+        <div>
+          <div class="from-to"><span class="actor">Pod</span> <span class="arrow">→</span> <span class="actor">Juan</span></div>
+          <div class="action">Pod handles the message, streams the response back over WebSocket.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">05</div>
+        <div>
+          <div class="from-to"><span class="actor">Juan</span></div>
+          <div class="action">Stops chatting. Closes the tab. Goes for lunch.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">06</div>
+        <div>
+          <div class="from-to"><span class="actor">Knative</span></div>
+          <div class="action">Waits a couple of minutes of zero traffic. Kills the pod. Back to zero. Storage lives on (Chapter 7).</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Cold start, the only real downside</h2>
+    <p>
+      First message after idle takes longer because the pod has to
+      boot. With Firecracker we're talking ~500 ms total, which is
+      shorter than the user's expectation of "agent is thinking."
+      Subsequent messages have zero overhead.
+    </p>
+    <p>
+      For agents the user expects to be instant (a daily-use agent),
+      we can configure Knative to keep one pod always warm. Costs a
+      tiny bit, hides the cold start. The default for any new agent
+      is "scale to zero" because most agents are touched rarely.
+    </p>
+
+    <h2>What about KEDA?</h2>
+    <p>
+      <strong>KEDA</strong> is the other big "scale based on events"
+      project. Knative scales based on HTTP traffic. KEDA scales based
+      on anything (queue depth, message count, custom metrics). For
+      Houston, HTTP/WebSocket traffic is the signal that matters, so
+      Knative fits more naturally. We can add KEDA later if we need
+      to scale based on, say, "number of inbound Slack messages
+      waiting for an agent."
+    </p>
+
+    <h2>Why this matters for the pitch</h2>
+    <p>
+      "A customer with 10,000 agents pays only for the ones actively
+      in a conversation" is a real cost story, not marketing. It's
+      what makes per agent isolation affordable. Without scale to
+      zero, pod per agent is expensive theater. With scale to zero,
+      it's a structural cost advantage we can't easily lose.
+    </p>
+
+    <div class="callout callout-success">
+      <div class="callout-label">The combo</div>
+      <p>Kubernetes (the platform) + Kata Containers (the runtime) + Firecracker (the VM) + Knative (the autoscaler) is the full hand. Each one fixes a problem the others can't. Together they give us "pod per agent, isolated by VM, billed only when active." Nothing else gets us all three at once.</p>
+    </div>
+
+    <div class="tech-box">
+      <div class="label">What we install on the cluster</div>
+      <p>Knative Serving from the official YAML. Configure it to use Kata's RuntimeClass for our agent services. Each agent becomes a <code>Service</code> resource with a unique URL. Scale-to-zero idle time defaults to ~30 seconds; can tune per agent. The control plane points at the agent's Knative URL when routing messages.</p>
+    </div>
+
+    <div class="pager">
+      <a href="03-kata-firecracker.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Kata + Firecracker</div>
+      </a>
+      <a href="05-control-plane.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">The control plane</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/05-control-plane.html
+++ b/cloud-design/05-control-plane.html
@@ -1,0 +1,198 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The control plane — Houston Cloud Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html" class="active"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 05
+      <span class="status planned">Planned</span>
+    </div>
+    <h1>The control plane is the doorman.</h1>
+    <p class="lead">
+      Every message in Houston Cloud passes through one small service
+      called the control plane. It checks your ID, decides which
+      agent you're allowed to talk to, wakes that agent up if it's
+      asleep, and forwards your message. That's it. It has no opinions
+      about what the agent does next.
+    </p>
+
+    <h2>The job, in three lines</h2>
+    <ol>
+      <li>Authenticate the user (is this really Juan?).</li>
+      <li>Authorize the request (is Juan allowed to talk to the HR agent?).</li>
+      <li>Route the message (forward it to the HR agent's pod and stream the reply back).</li>
+    </ol>
+    <p>
+      Nothing else. The agent does the actual work. The control plane
+      is a doorman, not a chef.
+    </p>
+
+    <h2>Why it has to exist</h2>
+    <p>
+      Without a control plane, the frontend would have to know:
+    </p>
+    <ul>
+      <li>which Kubernetes namespace each agent lives in</li>
+      <li>which pod URL is currently alive</li>
+      <li>which credentials to send</li>
+      <li>which agents this user is allowed to see</li>
+      <li>how to wake a sleeping pod</li>
+    </ul>
+    <p>
+      That's a lot of trust to put in a React app. So we put a small
+      stateless service between the frontend and the cluster. The
+      frontend talks to one address. The control plane does the
+      thinking.
+    </p>
+
+    <h2>Stateless? What does that mean?</h2>
+    <p>
+      "Stateless" means the control plane remembers nothing between
+      requests. Every request is fresh. Every answer comes from
+      asking the database. The control plane itself can be killed
+      and restarted whenever, and nobody notices.
+    </p>
+    <p>
+      This is huge for reliability. If one copy crashes, the other
+      4 keep running. If we deploy a new version, we roll it out
+      pod by pod with zero downtime. The data lives in Postgres
+      and Redis (Chapter 6), not in the control plane.
+    </p>
+
+    <h2>What's inside</h2>
+
+    <div class="diagram">
+      <div class="deploy-grid">
+        <div class="deploy-col">
+          <div class="deploy-head">HTTP routes</div>
+          <div class="deploy-layer"><code>POST /login</code></div>
+          <div class="deploy-layer"><code>GET /workspaces</code></div>
+          <div class="deploy-layer"><code>GET /agents</code></div>
+          <div class="deploy-layer"><code>POST /chat</code></div>
+          <div class="deploy-layer"><code>WS /v1/ws</code></div>
+        </div>
+        <div class="deploy-col">
+          <div class="deploy-head">Talks to</div>
+          <div class="deploy-layer">Supabase (auth)</div>
+          <div class="deploy-layer">Postgres (metadata)</div>
+          <div class="deploy-layer">Redis (sessions)</div>
+          <div class="deploy-layer">Kubernetes API</div>
+          <div class="deploy-layer">Agent pods (via Knative)</div>
+        </div>
+        <div class="deploy-col">
+          <div class="deploy-head">Does not talk to</div>
+          <div class="deploy-layer">Claude / OpenAI</div>
+          <div class="deploy-layer">Composio</div>
+          <div class="deploy-layer">User's tools</div>
+          <div class="deploy-layer">Anything LLM</div>
+        </div>
+      </div>
+      <div class="caption">The control plane routes. It doesn't think. The agent's pod does that.</div>
+    </div>
+
+    <h2>The handoff to an agent</h2>
+    <p>
+      When a message arrives:
+    </p>
+    <ol>
+      <li>Check the user's token (Supabase verifies it).</li>
+      <li>Look up: "is this user allowed to talk to this agent?" (one Postgres query, cached).</li>
+      <li>Get the agent's Knative URL (one Redis lookup, or fall back to Postgres).</li>
+      <li>Open a WebSocket to that URL. Forward the message. Stream the response back to the user.</li>
+    </ol>
+    <p>
+      If the agent's pod is asleep, step 4 takes ~500 ms because
+      Knative boots it. If the pod is warm, step 4 is instant. The
+      user sees a tiny lag the first time, then nothing.
+    </p>
+
+    <h2>Multi tenancy in one place</h2>
+    <p>
+      Every multi-tenant decision lives in the control plane:
+    </p>
+    <ul>
+      <li><strong>Tenant isolation</strong>: the control plane never lets a request from Acme reach a Globex agent. Even if Acme's frontend sent a Globex agent ID by accident, the auth check refuses it.</li>
+      <li><strong>Billing</strong>: the control plane logs every message and every agent wake-up. The billing job reads those logs.</li>
+      <li><strong>Audit</strong>: who talked to which agent when, with what content (or just metadata, depending on the tenant's compliance settings).</li>
+      <li><strong>Rate limiting</strong>: per user, per workspace, per agent. The agent's pod doesn't have to think about it.</li>
+    </ul>
+
+    <h2>What language is it written in?</h2>
+    <p>
+      Honest answer: probably Rust. We already write Rust well, the
+      <code>houston-engine</code> is Rust, and a low-latency router with
+      lots of concurrent WebSockets is exactly what Rust is good at.
+      Could also be Go (designed for this) or Node (familiar). The
+      choice doesn't change the architecture.
+    </p>
+    <p>
+      Size estimate: 3 to 5 thousand lines of code. Not a huge project.
+      Most of it is HTTP routes, auth glue, and forwarding logic.
+    </p>
+
+    <h2>How many copies do we run?</h2>
+    <p>
+      Three to five replicas at all times. Load balanced. Add more
+      automatically when CPU climbs. Kubernetes handles the autoscale.
+      Because it's stateless, adding capacity is just running more pods.
+    </p>
+
+    <div class="callout callout-info">
+      <div class="callout-label">The mental model</div>
+      <p>Frontend says "I want to chat with HR." Control plane says "let me check… ok, you can. Here's HR." Control plane wires the user's WebSocket directly to HR's pod and gets out of the way. Bytes flow agent ↔ user with the control plane only watching for billing and abuse. No middleman slowing down the conversation.</p>
+    </div>
+
+    <div class="tech-box">
+      <div class="label">Concrete tech stack</div>
+      <p>Rust (axum or actix), Tokio for async, sqlx for Postgres, fred for Redis, kube-rs for K8s API calls, jsonwebtoken for verifying Supabase JWTs. Built as a Docker image, deployed as a regular K8s Deployment (no Kata, no Knative — these are always-on services, not scaled-per-agent).</p>
+    </div>
+
+    <div class="pager">
+      <a href="04-knative.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Knative</div>
+      </a>
+      <a href="06-postgres-redis.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Postgres + Redis</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/06-postgres-redis.html
+++ b/cloud-design/06-postgres-redis.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Postgres + Redis — Houston Cloud Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html" class="active"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 06
+      <span class="status planned">Planned</span>
+    </div>
+    <h1>Two memories. One slow and forever, one fast and forgetful.</h1>
+    <p class="lead">
+      Houston Cloud has two databases that work as a team. Postgres
+      is the boring permanent record: workspaces, users, agents,
+      who can talk to whom. Redis is the fast scratchpad: who's
+      online right now, which session is open, where the
+      WebSocket is. Both matter. They do completely different jobs.
+    </p>
+
+    <h2>Postgres, the long term memory</h2>
+    <p>
+      Postgres is the most boring, most reliable database in
+      existence. Tables, rows, SQL. It's what your bank's bank uses.
+      When data has to be there next Tuesday, it goes in Postgres.
+    </p>
+    <p>
+      In Houston Cloud, Postgres holds:
+    </p>
+    <ul>
+      <li><strong>Workspaces</strong>: "Acme Corp" has these settings, these billing details, this namespace.</li>
+      <li><strong>Users</strong>: Juan is in Acme, his email is juan@acme.com, his Supabase ID is xyz.</li>
+      <li><strong>Agents</strong>: "HR agent" belongs to Acme, lives at this Knative URL, costs this much.</li>
+      <li><strong>Permissions</strong>: Juan can talk to HR. Cannot talk to Sales. Map of (user, agent, can_use).</li>
+      <li><strong>Billing</strong>: how many messages this month, how many tokens, how much owed.</li>
+      <li><strong>Audit log</strong>: who did what when. For compliance.</li>
+    </ul>
+    <p>
+      None of this changes fast. Permissions get set once and read a
+      thousand times. Postgres is perfect.
+    </p>
+
+    <h2>Why Supabase</h2>
+    <p>
+      Supabase is "Postgres in a box, plus auth, plus realtime, plus
+      file storage, plus a Node.js library." You get a managed
+      Postgres database and a bunch of helpful extras around it. We
+      already chose Supabase for auth, so we get the database for
+      free (well, for cheap).
+    </p>
+    <p>
+      The alternative is hosting Postgres ourselves on AWS RDS or
+      Google Cloud SQL. We could. Supabase is faster because we don't
+      have to wire up auth separately. Honest tradeoff: Supabase has
+      ops headroom limits if we grow huge. We can migrate to dedicated
+      Postgres when it actually hurts.
+    </p>
+
+    <h2>Redis, the short term memory</h2>
+    <p>
+      Redis is a different shape of database. Postgres stores
+      everything on disk. Redis stores everything in RAM. That makes
+      it stupid fast (microseconds per query) and stupid forgetful
+      (if it restarts, things you didn't explicitly save can vanish).
+    </p>
+    <p>
+      Trade-off: speed for permanence. For some data, that's the
+      right trade.
+    </p>
+    <p>
+      In Houston Cloud, Redis holds:
+    </p>
+    <ul>
+      <li><strong>Active WebSocket sessions</strong>: which user is currently chatting with which agent, on which control plane pod.</li>
+      <li><strong>Routing cache</strong>: "agent HR-Acme is at this Knative URL." Avoids hitting Postgres for every message.</li>
+      <li><strong>Rate limits</strong>: "Juan has sent 47 messages this hour." Resets every hour. Lives in RAM.</li>
+      <li><strong>Permission cache</strong>: "Juan → HR: allowed." Avoids re-checking Postgres on every message in a chat.</li>
+      <li><strong>Pub/sub</strong>: when an agent's pod emits an event, Redis fans it out to all the control plane pods that have subscribers.</li>
+    </ul>
+    <p>
+      Notice the pattern: anything we'd be sad about losing goes in
+      Postgres. Anything we can rebuild from Postgres in a second
+      goes in Redis.
+    </p>
+
+    <h2>The four tables you actually need to remember</h2>
+    <p>The first version of the schema is roughly four tables in Postgres.</p>
+
+    <table>
+      <thead>
+        <tr><th>Table</th><th>What's in it</th><th>How often it changes</th></tr>
+      </thead>
+      <tbody>
+        <tr><td><code>workspaces</code></td><td>Tenant ID, name, billing plan, K8s namespace</td><td>Rarely (new customer signs up)</td></tr>
+        <tr><td><code>users</code></td><td>User ID, Supabase ID, email, workspace, role</td><td>Sometimes (invites, removals)</td></tr>
+        <tr><td><code>agents</code></td><td>Agent ID, workspace, name, Knative URL, settings</td><td>Sometimes (new agent published)</td></tr>
+        <tr><td><code>permissions</code></td><td>User ID + Agent ID + can_use bool</td><td>Sometimes (admin grants/revokes)</td></tr>
+      </tbody>
+    </table>
+
+    <p>
+      Plus an audit log table and a billing-events table. That's it
+      for v1. Grow from there.
+    </p>
+
+    <h2>How they work together</h2>
+
+    <div class="diagram">
+      <div class="flow-list">
+        <div class="flow-step">
+          <div class="num">01</div>
+          <div>
+            <div class="from-to"><span class="actor">Juan opens Houston</span></div>
+            <div class="action">Frontend calls control plane: "give me my agents."</div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="num">02</div>
+          <div>
+            <div class="from-to"><span class="actor">Control plane</span> <span class="arrow">→</span> <span class="actor">Postgres</span></div>
+            <div class="action">Look up Juan's permissions. Returns: [HR, Recruiter]. Caches in Redis for 5 minutes.</div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="num">03</div>
+          <div>
+            <div class="from-to"><span class="actor">Juan clicks HR</span></div>
+            <div class="action">Frontend opens WebSocket to control plane.</div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="num">04</div>
+          <div>
+            <div class="from-to"><span class="actor">Control plane</span> <span class="arrow">→</span> <span class="actor">Redis</span></div>
+            <div class="action">Lookup HR's Knative URL. Cached. Microseconds.</div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="num">05</div>
+          <div>
+            <div class="from-to"><span class="actor">Control plane</span> <span class="arrow">→</span> <span class="actor">HR pod</span></div>
+            <div class="action">Open WebSocket to HR. Stream the conversation.</div>
+          </div>
+        </div>
+        <div class="flow-step db-write">
+          <div class="num">06</div>
+          <div>
+            <div class="from-to"><span class="actor db">Postgres</span> <span class="arrow">←</span> <span class="actor">Control plane</span></div>
+            <div class="action">After the turn ends, write an audit entry: "Juan asked HR a question at 10:42."</div>
+          </div>
+        </div>
+      </div>
+      <div class="caption">Postgres is the source of truth. Redis is the speed layer in front of it.</div>
+    </div>
+
+    <h2>Why we don't just use Postgres for everything</h2>
+    <p>
+      We could. Postgres can do rate limiting (with row locks), can
+      do pub/sub (with LISTEN/NOTIFY). It would just be slower and
+      more expensive.
+    </p>
+    <p>
+      Adding Redis is a 30-minute decision that buys us 100x
+      throughput on the hot path. Cheap insurance against scale
+      problems we don't want to debug at 3am.
+    </p>
+
+    <h2>Where the agent's own memory lives</h2>
+    <p>
+      Important distinction. <strong>The agent's own memory</strong>
+      (its conversations with the user, its CLAUDE.md, its skills) is
+      not in Postgres. That lives in the agent's pod, on its
+      persistent volume, in the <code>.houston/</code> directory.
+      Postgres only holds the platform metadata around the agent.
+    </p>
+    <p>
+      The pod is the agent. Postgres is the registry of which pods
+      exist and who's allowed to talk to them.
+    </p>
+
+    <div class="callout callout-info">
+      <div class="callout-label">Two databases, one rule</div>
+      <p>Lose Redis: site is slow for a few minutes, no data lost. Lose Postgres: catastrophe, everyone's locked out, payments break, this is what backups are for. Treat them accordingly: Postgres gets daily backups + read replicas + point-in-time recovery. Redis gets a restart script and a shrug.</p>
+    </div>
+
+    <div class="tech-box">
+      <div class="label">Concrete services</div>
+      <p>Postgres via Supabase (managed). Redis via Upstash (managed, serverless, cheap) or a small self-hosted instance on the cluster for v1. Connection pooling via PgBouncer in front of Postgres to keep connection counts sane as the control plane scales.</p>
+    </div>
+
+    <div class="pager">
+      <a href="05-control-plane.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">The control plane</div>
+      </a>
+      <a href="07-storage.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Storage</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/07-storage.html
+++ b/cloud-design/07-storage.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Storage — Houston Cloud Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html" class="active"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 07
+      <span class="status planned">Planned</span>
+    </div>
+    <h1>The agent's brain lives on a disk that outlives the pod.</h1>
+    <p class="lead">
+      When Knative kills an idle agent pod, the agent's notes, memory,
+      and OAuth tokens can't die with it. The pod gets thrown away.
+      The disk doesn't. This chapter is about that disk and the
+      handful of decisions around it.
+    </p>
+
+    <h2>The problem</h2>
+    <p>
+      A Houston agent stores everything in a folder called
+      <code>.houston/</code>. Inside: chat history, memory, learned
+      skills, OAuth tokens for connected tools, files the user has
+      shared. On the desktop, that folder lives in
+      <code>~/.houston/workspaces/...</code> on the user's hard drive.
+      It survives reboots, app crashes, anything short of the user
+      deleting it.
+    </p>
+    <p>
+      In the cloud, the agent's pod is ephemeral. Knative kills it
+      after a few minutes of idle. If the <code>.houston/</code>
+      folder lived inside the pod, every nap would amnesia the agent.
+      Bad. So the folder has to live somewhere outside the pod.
+    </p>
+
+    <h2>The fix: a persistent volume per agent</h2>
+    <p>
+      Kubernetes calls disks "persistent volumes." A persistent volume
+      is a chunk of cloud storage that gets attached to a pod when the
+      pod boots and detached when the pod dies. The data on it
+      survives.
+    </p>
+    <p>
+      Every agent gets one. ~1 GB to start, grows as needed. Mounted
+      inside the pod at <code>/data/.houston/</code>. The engine
+      doesn't know it's running in the cloud; it sees a normal
+      folder.
+    </p>
+
+    <div class="diagram">
+      <div class="deploy-grid">
+        <div class="deploy-col">
+          <div class="deploy-head">When the agent is awake</div>
+          <div class="deploy-layer">Agent pod (Knative)</div>
+          <div class="deploy-arrow">↓ mounted at</div>
+          <div class="deploy-layer">/data/.houston/</div>
+          <div class="deploy-arrow">↓ stored on</div>
+          <div class="deploy-layer">PersistentVolume (cloud disk)</div>
+        </div>
+        <div class="deploy-col">
+          <div class="deploy-head">When the agent is asleep</div>
+          <div class="deploy-layer" style="opacity: 0.4">Agent pod (deleted)</div>
+          <div class="deploy-arrow" style="opacity: 0.4">↓</div>
+          <div class="deploy-layer" style="opacity: 0.4">/data/.houston/</div>
+          <div class="deploy-arrow">↓ still here</div>
+          <div class="deploy-layer">PersistentVolume (cloud disk)</div>
+        </div>
+      </div>
+      <div class="caption">Pod dies, disk lives. Wake up, mount disk, exactly where you left off.</div>
+    </div>
+
+    <h2>How big is the disk?</h2>
+    <ul>
+      <li>Sessions and memory text: a few MB even for heavy users. Text compresses well.</li>
+      <li>OAuth tokens, settings: kilobytes.</li>
+      <li>Files the user uploads: this is the wild card. Could be tens of MB to GB.</li>
+    </ul>
+    <p>
+      Start at 1 GB per agent. Costs about 10 cents per month on GCP.
+      Auto-grow when 80% full. We're not optimizing storage cost
+      ever — even 10,000 agents at 1 GB is $1,000 a month total. Real
+      money is compute, not disk.
+    </p>
+
+    <h2>What about big files?</h2>
+    <p>
+      If an agent handles huge files (videos, datasets), the
+      persistent volume is the wrong place. Two reasons: it's
+      attached only when the pod is alive, and it's a more
+      expensive kind of storage than necessary.
+    </p>
+    <p>
+      For big files, the agent writes to <strong>object storage</strong>
+      (S3 on AWS, GCS on Google Cloud). Object storage is dirt cheap,
+      designed for huge blobs, and accessible from anywhere. The
+      agent keeps only a reference (a URL) on its persistent volume.
+    </p>
+    <p>
+      Same pattern as your desktop app having a shortcut to a video
+      on Dropbox. The shortcut is small, the video lives somewhere
+      cheap and shared.
+    </p>
+
+    <h2>Backups</h2>
+    <p>
+      Two layers:
+    </p>
+    <ul>
+      <li><strong>Volume snapshots</strong>: Kubernetes can snapshot a persistent volume nightly. Costs a fraction of the volume itself.</li>
+      <li><strong>Export to object storage</strong>: weekly tar of the <code>.houston/</code> folder uploaded to S3, keyed by agent + date. Old snapshots cycle out.</li>
+    </ul>
+    <p>
+      Restore process: if an agent's volume gets corrupted, we mount
+      the last snapshot, copy in the latest <code>.houston/</code> from
+      S3, the agent's next message wakes the pod with restored state.
+      User notices nothing.
+    </p>
+
+    <h2>Sticky scheduling</h2>
+    <p>
+      There's a subtle issue: a persistent volume is usually tied to
+      one cloud region or even one zone. If we have nodes in
+      <code>us-east-1a</code> and <code>us-east-1b</code>, an agent's
+      volume that was created in <code>1a</code> can only mount to
+      pods in <code>1a</code>.
+    </p>
+    <p>
+      Kubernetes handles this automatically with
+      <strong>topology aware scheduling</strong>. When the pod boots,
+      K8s asks "where does your volume live?" and only schedules the
+      pod onto matching nodes. We don't have to think about it once
+      it's set up.
+    </p>
+
+    <h2>The cold start optimization (for later)</h2>
+    <p>
+      Attaching a persistent volume on cold start adds a few hundred
+      milliseconds. For 99% of agents this is fine. If we ever need
+      sub-100ms cold start for some always-on agent, we'd switch to
+      <strong>image preloaded with state</strong> or
+      <strong>state sync from object storage</strong> instead of mount.
+      Not v1.
+    </p>
+
+    <h2>What this gives us</h2>
+    <ul>
+      <li><strong>Agents have real memory.</strong> Their <code>.houston/</code> survives sleep, restart, even cluster failures (with backups).</li>
+      <li><strong>Compute scales to zero, storage costs pennies.</strong> An agent untouched for a year still has its memory waiting, for less than a dollar in storage.</li>
+      <li><strong>The engine doesn't have to change.</strong> From the engine's perspective, <code>/data/.houston/</code> is just a folder. Same logic as the desktop app's <code>~/.houston/</code>.</li>
+    </ul>
+
+    <div class="callout callout-warning">
+      <div class="callout-label">The one footgun</div>
+      <p>Persistent volumes don't shrink. If an agent writes 5 GB of crap once and then cleans up, you're paying for 5 GB forever (until you migrate the volume). For Houston this probably doesn't matter — agent data should stay small if we're disciplined about big-file offload to object storage. Worth a periodic "agent volume size audit" cron once we're live.</p>
+    </div>
+
+    <div class="tech-box">
+      <div class="label">Concrete setup</div>
+      <p>StorageClass <code>standard-ssd-zonal</code> on GKE (cheap SSD per AZ). PersistentVolumeClaim per agent, name pattern <code>pvc-agent-{agent-id}</code>. Created by the control plane when the agent is provisioned. Snapshots scheduled via Velero or native VolumeSnapshot controllers. Object storage: GCS bucket per workspace for tenant data, with lifecycle rules archiving old files to colder/cheaper tiers.</p>
+    </div>
+
+    <div class="pager">
+      <a href="06-postgres-redis.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Postgres + Redis</div>
+      </a>
+      <a href="08-networking.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Networking</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/08-networking.html
+++ b/cloud-design/08-networking.html
@@ -1,0 +1,226 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Networking — Houston Cloud Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html" class="active"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 08
+      <span class="status planned">Planned</span>
+    </div>
+    <h1>Build the walls before someone needs them.</h1>
+    <p class="lead">
+      By default, every pod in a Kubernetes cluster can talk to
+      every other pod. That's an open building with no doors. For
+      multi tenant Houston, we add doors. Lots of them. This chapter
+      is about who is allowed to talk to whom.
+    </p>
+
+    <h2>The default is dangerous</h2>
+    <p>
+      Out of the box, K8s networking is one big party. Every pod can
+      reach every other pod by IP. The thinking is "you decide your
+      rules; we give you the primitives." Which is fine for one team,
+      one product. Dangerous for "Acme's agents and Globex's agents
+      on the same cluster."
+    </p>
+    <p>
+      Acme should not be able to reach Globex's agents even by
+      accident. Even with a bug in the control plane that sent a
+      request to the wrong place. The network itself should refuse.
+    </p>
+
+    <h2>NetworkPolicy, the K8s firewall</h2>
+    <p>
+      Kubernetes has a resource called <code>NetworkPolicy</code>.
+      It's a tiny YAML file that says "pods labeled X can talk to
+      pods labeled Y on these ports. Nothing else allowed."
+    </p>
+    <p>
+      Our shape:
+    </p>
+    <ul>
+      <li>Default deny in every per-team namespace. Agents can't initiate connections to anything.</li>
+      <li>Allow: agent → control plane (so the agent can stream responses back).</li>
+      <li>Allow: agent → public internet on port 443 (so the agent can call Claude, OpenAI, Composio).</li>
+      <li>Deny everything else. Especially: agent → other tenants' anything.</li>
+    </ul>
+
+    <h2>Cilium, the upgraded firewall</h2>
+    <p>
+      Raw Kubernetes NetworkPolicy is fine but limited. You can't
+      say "allow this agent to call api.slack.com but not the rest of
+      the internet."
+    </p>
+    <p>
+      <strong>Cilium</strong> is a replacement for the default K8s
+      networking plugin. It uses eBPF (a Linux feature that lets
+      programs run inside the kernel safely) to enforce richer rules:
+    </p>
+    <ul>
+      <li>Per pod allowlists by hostname (not just IP).</li>
+      <li>Per pod observability: which pod called which API, when.</li>
+      <li>Encryption between pods automatically.</li>
+      <li>Faster than the default plugin because it skips iptables.</li>
+    </ul>
+    <p>
+      Cilium is the boring industry standard for serious multi tenant
+      K8s. GKE has a managed Cilium option. We'd turn it on at
+      cluster creation.
+    </p>
+    <p>
+      The alternative is <strong>Calico</strong>. Older, also good,
+      simpler. If Cilium feels like overkill in year one, Calico is
+      the fallback.
+    </p>
+
+    <h2>Per workspace namespaces</h2>
+    <p>
+      The unit of tenant isolation is a Kubernetes namespace.
+    </p>
+    <ul>
+      <li>One namespace per workspace. Naming pattern: <code>ws-acme-corp</code>, <code>ws-globex</code>, etc.</li>
+      <li>All of that workspace's agent pods, persistent volumes, secrets, and configs live in their namespace.</li>
+      <li>NetworkPolicy says: pods in <code>ws-acme-corp</code> cannot reach anything in <code>ws-globex</code> and vice versa. Period.</li>
+      <li>RBAC says: only the control plane service account can read across namespaces. Tenant admins can't even look at other namespaces.</li>
+    </ul>
+
+    <div class="walls">
+      <div class="agent-col">
+        <h4>ws-acme-corp</h4>
+        <ul>
+          <li>HR agent pod</li>
+          <li>Sales agent pod</li>
+          <li>Recruiter agent pod</li>
+          <li>Agent volumes</li>
+          <li>Agent secrets</li>
+        </ul>
+      </div>
+      <div class="wall">NETWORK<br>POLICY</div>
+      <div class="agent-col">
+        <h4>ws-globex</h4>
+        <ul>
+          <li>Marketing agent pod</li>
+          <li>Engineering agent pod</li>
+          <li>Agent volumes</li>
+          <li>Agent secrets</li>
+        </ul>
+      </div>
+    </div>
+
+    <h2>Inbound traffic (how users reach us)</h2>
+    <p>
+      Users connect to <code>app.houston.ai</code> over HTTPS. That
+      hits a load balancer (managed by GKE), which routes to the
+      control plane. The control plane is the only door from the
+      outside world into the cluster.
+    </p>
+    <p>
+      Agent pods are never reachable directly from the internet. They
+      live inside the cluster, behind Knative, behind the control
+      plane. There is no public URL like <code>agent-hr-acme.houston.ai</code>.
+      Even if there were, NetworkPolicy would block external traffic
+      to it.
+    </p>
+
+    <h2>Outbound traffic (how agents reach tools)</h2>
+    <p>
+      Agents need to call out: Claude API, OpenAI API, Composio
+      (which calls Slack, Gmail, etc on the agent's behalf). This is
+      a hole we have to leave open.
+    </p>
+    <p>
+      Default: allow outbound on port 443 (HTTPS) only, with an
+      allowlist of hostnames. That way an agent can call
+      <code>api.anthropic.com</code> but not, say, exfiltrate to
+      <code>random-attacker.com</code>.
+    </p>
+    <p>
+      An enterprise customer can tighten this further. "Our agents
+      may only call Anthropic, Slack, and Gmail. Block everything
+      else." Cilium policy, two lines of YAML.
+    </p>
+
+    <h2>The dedicated node pool option</h2>
+    <p>
+      Most workspaces share nodes. Acme's HR agent pod might run on
+      the same physical machine as Globex's marketing agent pod. The
+      Firecracker wall keeps them apart (Chapter 3).
+    </p>
+    <p>
+      For an enterprise customer that doesn't like that even with
+      Firecracker, we can offer a <strong>dedicated node pool</strong>:
+      "Acme's agents only schedule onto these specific machines. No
+      one else's agents will ever land there." Costs more, sells
+      easier to security teams. Trivial to set up with K8s node
+      selectors and taints.
+    </p>
+
+    <h2>The mental model</h2>
+    <ul>
+      <li><strong>NetworkPolicy</strong> = walls between workspaces.</li>
+      <li><strong>Cilium</strong> = better walls, with hostname-aware rules and visibility.</li>
+      <li><strong>Namespaces</strong> = labeled rooms inside the building.</li>
+      <li><strong>Load balancer</strong> = the front door.</li>
+      <li><strong>Control plane</strong> = the only path from front door to any agent.</li>
+      <li><strong>Dedicated node pool</strong> = own floor of the building (enterprise tier).</li>
+    </ul>
+
+    <div class="callout callout-info">
+      <div class="callout-label">Where the agents' permission story ends</div>
+      <p>Network + Firecracker + namespaces handle the platform isolation. <em>Who can talk to which agent</em> is enforced at the control plane (auth + RBAC). Network policy stops cross-tenant bugs from becoming cross-tenant breaches. The two layers fail safely in different ways.</p>
+    </div>
+
+    <div class="tech-box">
+      <div class="label">Concrete setup</div>
+      <p>GKE with Cilium dataplane enabled at cluster creation. NetworkPolicies templated by the control plane when provisioning a new workspace (the namespace + default-deny policy + allow-control-plane policy are created together). Service mesh (Istio/Linkerd) <em>not</em> required for v1 — Cilium does enough. Add a mesh only if we need fancy traffic shaping or zero-trust mTLS between every pod, which is overkill at our scale.</p>
+    </div>
+
+    <div class="pager">
+      <a href="07-storage.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Storage</div>
+      </a>
+      <a href="09-auth.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Auth</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/09-auth.html
+++ b/cloud-design/09-auth.html
@@ -1,0 +1,216 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Auth — Houston Cloud Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html" class="active"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 09
+      <span class="status partial">Partial</span>
+    </div>
+    <h1>Login is solved. Supabase does it.</h1>
+    <p class="lead">
+      Auth is the kind of thing that sounds simple ("just log people
+      in") and ends with a six month rewrite. We don't write auth.
+      We use Supabase, which handles email login, Google SSO, magic
+      links, password resets, multi factor, and the rest of the
+      checklist. Our job is to consume the result.
+    </p>
+
+    <h2>What "auth" actually means</h2>
+    <p>
+      Three different jobs people confuse:
+    </p>
+    <ol>
+      <li><strong>Authentication</strong>: who are you? (Login, sessions, password reset.)</li>
+      <li><strong>Authorization</strong>: what are you allowed to do? (Can Juan talk to HR agent?)</li>
+      <li><strong>Connection</strong>: which third party tools is this agent allowed to act on? (Has Juan's Slack been linked?)</li>
+    </ol>
+    <p>
+      We use Supabase for #1. We do #2 ourselves in the control plane.
+      #3 is mostly Composio (with help from us for the OAuth flow).
+    </p>
+
+    <h2>Supabase, the parts we use</h2>
+    <ul>
+      <li><strong>Email + password</strong>: standard login. Supabase stores hashed passwords. We never see plaintext.</li>
+      <li><strong>Google SSO</strong>: "Continue with Google." Maps Google accounts to Houston accounts.</li>
+      <li><strong>SAML / OIDC for enterprise</strong>: "log in with your Okta/Azure AD." Supabase has this for the paid tier. Enterprise customers will demand it.</li>
+      <li><strong>Magic links</strong>: emailed login link. Useful for non-tech users who forget passwords.</li>
+      <li><strong>Multi factor</strong>: TOTP (authenticator app). Optional for individuals, mandatory for admin roles on enterprise tenants.</li>
+      <li><strong>JWT tokens</strong>: after login, Supabase issues a JWT. The frontend sends it on every request. The control plane verifies it.</li>
+    </ul>
+
+    <h2>How the JWT flows</h2>
+
+    <div class="flow-list">
+      <div class="flow-step">
+        <div class="num">01</div>
+        <div>
+          <div class="from-to"><span class="actor">User</span> <span class="arrow">→</span> <span class="actor">app.houston.ai</span></div>
+          <div class="action">Clicks "log in." Frontend redirects to Supabase login UI.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">02</div>
+        <div>
+          <div class="from-to"><span class="actor">User</span> <span class="arrow">→</span> <span class="actor">Supabase</span></div>
+          <div class="action">Enters credentials (or clicks Google). Supabase authenticates.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">03</div>
+        <div>
+          <div class="from-to"><span class="actor">Supabase</span> <span class="arrow">→</span> <span class="actor">User</span></div>
+          <div class="action">Returns a JWT containing user ID, email, expiry. Frontend stores it (cookie or local storage).</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">04</div>
+        <div>
+          <div class="from-to"><span class="actor">Frontend</span> <span class="arrow">→</span> <span class="actor">Control plane</span></div>
+          <div class="action">Every request includes the JWT in the <code>Authorization</code> header.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">05</div>
+        <div>
+          <div class="from-to"><span class="actor">Control plane</span></div>
+          <div class="action">Verifies the JWT's signature with Supabase's public key. Locally. No network call. Microseconds.</div>
+        </div>
+      </div>
+      <div class="flow-step">
+        <div class="num">06</div>
+        <div>
+          <div class="from-to"><span class="actor">Control plane</span> <span class="arrow">→</span> <span class="actor">Postgres</span></div>
+          <div class="action">Look up: which workspace + which permissions for this user ID? Cache the answer in Redis.</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Authorization: who can do what</h2>
+    <p>
+      JWT only proves "you are Juan." Whether Juan can talk to the
+      HR agent is a Houston question, answered from our
+      <code>permissions</code> table in Postgres.
+    </p>
+    <p>
+      The rule is simple:
+    </p>
+    <ul>
+      <li>Workspace admin grants per agent access to each user.</li>
+      <li>Control plane checks <code>permissions(user_id, agent_id, can_use)</code> on every request.</li>
+      <li>If the row doesn't exist or is <code>false</code>, return 403. Don't even tell the user the agent exists.</li>
+    </ul>
+    <p>
+      We considered fancier models (roles, groups, ABAC). For v1, a
+      simple grant table covers 95% of needs. Add complexity when a
+      customer asks.
+    </p>
+
+    <h2>OAuth for tools (Composio's job)</h2>
+    <p>
+      The third kind of auth: when the HR agent needs to read Juan's
+      Slack messages, Slack has to grant permission. That's OAuth.
+      <strong>Composio</strong> handles all the OAuth flows for the
+      1,000+ tools we integrate.
+    </p>
+    <p>
+      Flow:
+    </p>
+    <ol>
+      <li>Juan asks HR agent to do something Slack related.</li>
+      <li>Agent says "you haven't connected Slack yet, click here."</li>
+      <li>Juan clicks. Composio opens Slack's OAuth dialog.</li>
+      <li>Juan approves. Slack sends OAuth tokens back to Composio.</li>
+      <li>Composio stores the tokens, keyed by (user, tool).</li>
+      <li>Agent calls Composio with "send a message to Slack as Juan." Composio uses the stored tokens.</li>
+    </ol>
+    <p>
+      Composio tokens live in Composio's secure storage, not ours. We
+      ask Composio to do things on a user's behalf using a Composio
+      API key per workspace.
+    </p>
+
+    <h2>Sessions, in plain English</h2>
+    <p>
+      A "session" is the unbroken span from login to logout. Supabase
+      manages it: when the JWT expires (default 1 hour), the frontend
+      silently refreshes it using a longer-lived refresh token (30
+      days). User stays logged in for weeks unless they explicitly
+      log out or the security policy says re-auth.
+    </p>
+    <p>
+      Enterprise tenants can tighten this: "force re-login every 8
+      hours" or "require MFA on each session." All handled by
+      Supabase config per tenant.
+    </p>
+
+    <h2>What "partial" means in the status pill</h2>
+    <p>
+      We already use Supabase for the desktop app's "sign in to use a
+      remote Houston engine" flow (it shipped in commit
+      <code>c9affe3f</code>). That gives us the OAuth foundation. What
+      we don't have yet: the multi-tenant permissions table, the
+      enterprise SSO flow, the audit log of who-did-what. All
+      additive on top of what exists.
+    </p>
+
+    <div class="callout callout-success">
+      <div class="callout-label">Why we don't write our own auth</div>
+      <p>Auth is the bottomless pit. Password hashing edge cases, OAuth provider quirks, session fixation attacks, MFA bypass bugs, GDPR-compliant deletion. Supabase has a security team that does nothing but this. Our team gets to ship Houston instead of becoming part-time identity engineers.</p>
+    </div>
+
+    <div class="tech-box">
+      <div class="label">Concrete pieces</div>
+      <p>Supabase project for the cloud (separate from the desktop auth project). JWT validation in the control plane using the project's JWKS URL. <code>users</code> table in our Postgres mirrors a subset of Supabase user data (email, workspace, role) for fast lookup. RLS not used directly — control plane enforces all authz in code so we keep Supabase as a pure identity provider.</p>
+    </div>
+
+    <div class="pager">
+      <a href="08-networking.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Networking</div>
+      </a>
+      <a href="10-message-flow.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">End-to-end flow</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/10-message-flow.html
+++ b/cloud-design/10-message-flow.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>End-to-end flow — Houston Cloud Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html" class="active"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 10
+      <span class="status planned">Planned</span>
+    </div>
+    <h1>One message, all the way through.</h1>
+    <p class="lead">
+      Time to stop talking about boxes and watch one actually run.
+      Juan from sales is going to ask his HR agent for the company
+      vacation policy. We follow that single message from his
+      keystroke to the agent's reply. Every chapter so far shows up
+      in this one walkthrough.
+    </p>
+
+    <h2>Setup</h2>
+    <ul>
+      <li>Juan is an Acme Corp employee. Logged in. Has permission for the HR agent.</li>
+      <li>The HR agent's pod is asleep. Nobody talked to HR since yesterday.</li>
+      <li>HR's persistent volume holds 3 months of conversation history.</li>
+      <li>Juan opens <code>app.houston.ai</code>, clicks the HR tile, types "what's our vacation policy?", hits send.</li>
+    </ul>
+
+    <h2>The full flow</h2>
+
+    <div class="flow-list">
+      <div class="flow-step">
+        <div class="num">01</div>
+        <div>
+          <div class="from-to"><span class="actor">Juan's browser</span> <span class="arrow">→</span> <span class="actor">Load balancer</span></div>
+          <div class="action">HTTPS POST to <code>app.houston.ai/v1/chat</code>. Carries the JWT in the Authorization header and the message text in the body.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">02</div>
+        <div>
+          <div class="from-to"><span class="actor">Load balancer</span> <span class="arrow">→</span> <span class="actor">Control plane pod</span></div>
+          <div class="action">Routes to one of the 5 control plane replicas. Round robin.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">03</div>
+        <div>
+          <div class="from-to"><span class="actor">Control plane</span></div>
+          <div class="action">Verifies JWT signature locally using Supabase's public key. <strong>~1 ms.</strong></div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">04</div>
+        <div>
+          <div class="from-to"><span class="actor">Control plane</span> <span class="arrow">→</span> <span class="actor">Redis</span></div>
+          <div class="action">"Can user juan-id-123 talk to agent hr-acme-456?" Cached from a previous lookup. <strong>~0.1 ms.</strong> Yes.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">05</div>
+        <div>
+          <div class="from-to"><span class="actor">Control plane</span> <span class="arrow">→</span> <span class="actor">Redis</span></div>
+          <div class="action">"Where is hr-acme-456's pod?" Cached. Returns Knative URL <code>http://hr-acme.ws-acme.svc.cluster.local</code>.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">06</div>
+        <div>
+          <div class="from-to"><span class="actor">Control plane</span> <span class="arrow">→</span> <span class="actor">Knative</span></div>
+          <div class="action">Opens a WebSocket to the agent's URL. Knative sees no pod is running. <strong>This is the cold start.</strong></div>
+        </div>
+      </div>
+
+      <div class="flow-loop">
+        <div class="flow-loop-label">Cold start (~500 ms total)</div>
+        <div class="flow-step">
+          <div class="num">06a</div>
+          <div>
+            <div class="from-to"><span class="actor">Knative</span></div>
+            <div class="action">Asks Kubernetes to schedule a new pod for hr-acme. K8s picks a node in <code>ws-acme</code>'s namespace.</div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="num">06b</div>
+          <div>
+            <div class="from-to"><span class="actor">Kata Containers</span></div>
+            <div class="action">Boots a Firecracker microVM with the houston-engine image. <strong>~125 ms.</strong></div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="num">06c</div>
+          <div>
+            <div class="from-to"><span class="actor">Kubernetes</span></div>
+            <div class="action">Mounts the persistent volume holding HR's <code>.houston/</code> directory at <code>/data/.houston</code>. <strong>~100 ms.</strong></div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="num">06d</div>
+          <div>
+            <div class="from-to"><span class="actor">houston-engine</span></div>
+            <div class="action">Starts inside the VM. Reads agent manifest. Opens its HTTP + WS server. <strong>~200 ms.</strong></div>
+          </div>
+        </div>
+        <div class="flow-step">
+          <div class="num">06e</div>
+          <div>
+            <div class="from-to"><span class="actor">Knative</span> <span class="arrow">→</span> <span class="actor">Control plane</span></div>
+            <div class="action">"Pod is ready." WebSocket connects.</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">07</div>
+        <div>
+          <div class="from-to"><span class="actor">Control plane</span> <span class="arrow">→</span> <span class="actor">Agent pod</span></div>
+          <div class="action">Forwards Juan's message: "what's our vacation policy?"</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">08</div>
+        <div>
+          <div class="from-to"><span class="actor">houston-engine</span></div>
+          <div class="action">Reads the agent's CLAUDE.md (HR persona). Loads recent session history from <code>/data/.houston/sessions/</code>.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">09</div>
+        <div>
+          <div class="from-to"><span class="actor">houston-engine</span> <span class="arrow">→</span> <span class="actor">Claude API</span></div>
+          <div class="action">Spawns the claude-code CLI as a subprocess. Streams Juan's message + the agent's system prompt + history. Outbound traffic allowed by Cilium policy (api.anthropic.com is on the allowlist).</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">10</div>
+        <div>
+          <div class="from-to"><span class="actor">Claude</span> <span class="arrow">→</span> <span class="actor">houston-engine</span></div>
+          <div class="action">Streams tokens back. Houston-engine emits each token over its WebSocket as it arrives.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">11</div>
+        <div>
+          <div class="from-to"><span class="actor">Agent pod</span> <span class="arrow">→</span> <span class="actor">Control plane</span> <span class="arrow">→</span> <span class="actor">Juan's browser</span></div>
+          <div class="action">Token by token, the answer streams back to Juan. He starts reading before Claude has finished generating. Feels instant.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">12</div>
+        <div>
+          <div class="from-to"><span class="actor">houston-engine</span></div>
+          <div class="action">Writes the full turn (Juan's message + agent's reply) to <code>/data/.houston/sessions/...</code>. Saved on the persistent volume. Survives sleep.</div>
+        </div>
+      </div>
+
+      <div class="flow-step db-write">
+        <div class="num">13</div>
+        <div>
+          <div class="from-to"><span class="actor db">Postgres</span> <span class="arrow">←</span> <span class="actor">Control plane</span></div>
+          <div class="action">Audit log entry: "juan-id-123 sent a message to hr-acme-456 at 14:22:07." Billing event: "+1 message, +N tokens for ws-acme."</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">14</div>
+        <div>
+          <div class="from-to"><span class="actor">Juan</span></div>
+          <div class="action">Reads the answer. Closes the tab.</div>
+        </div>
+      </div>
+
+      <div class="flow-step">
+        <div class="num">15</div>
+        <div>
+          <div class="from-to"><span class="actor">Knative</span></div>
+          <div class="action">2 minutes of no traffic to hr-acme. Kills the pod. Persistent volume detaches but persists. Back to zero compute cost.</div>
+        </div>
+      </div>
+    </div>
+
+    <h2>Numbers that matter</h2>
+    <ul>
+      <li><strong>Cold start:</strong> ~500 ms (Firecracker + engine + volume mount).</li>
+      <li><strong>Warm hop:</strong> ~10 ms (control plane → agent pod is in-cluster).</li>
+      <li><strong>Token streaming latency:</strong> ~50 ms first token (limited by Claude API itself, not by Houston).</li>
+      <li><strong>Idle compute cost:</strong> zero.</li>
+      <li><strong>Idle storage cost:</strong> ~10 cents/month for the persistent volume.</li>
+    </ul>
+
+    <h2>What if Juan sends a second message?</h2>
+    <p>
+      Pod is still warm. Steps 1–5 are the same (with everything
+      cached). Step 6 reuses the existing WebSocket. No cold start.
+      Total latency to first token: maybe 60 ms plus Claude's
+      thinking time. Indistinguishable from a desktop app.
+    </p>
+
+    <h2>What if the agent has to call a tool?</h2>
+    <p>
+      Same flow plus a step at #9.5: the agent decides to call Slack
+      via Composio. houston-engine calls
+      <code>api.composio.dev</code> (on the Cilium allowlist).
+      Composio uses Juan's stored Slack OAuth token to do the thing.
+      Returns a result. houston-engine feeds it back into Claude, the
+      conversation continues. The user sees a "calling Slack…" status
+      then the result.
+    </p>
+
+    <h2>What if Juan tries to read Sales' data via HR?</h2>
+    <p>
+      Juan: "HR agent, please read /data/sales/.houston/sessions/."
+    </p>
+    <p>
+      HR's pod is a Firecracker microVM with one mounted volume:
+      <code>/data/.houston</code> (HR's own). There is no
+      <code>/data/sales/</code> visible inside the VM. Even the
+      claude-code subprocess running inside the pod can't reach what
+      isn't mounted. The file doesn't exist for it. The attack fails
+      at the kernel level, not at the application level.
+    </p>
+    <p>
+      This is why pod-per-agent matters. Auth + RBAC keep Juan from
+      <em>asking</em> the Sales agent for things. Kata + Firecracker
+      keep him from <em>tricking</em> the HR agent into reading Sales
+      data. Two locks. Different keys.
+    </p>
+
+    <div class="callout callout-success">
+      <div class="callout-label">The whole guide in one walkthrough</div>
+      <p>Every chapter shows up here. Auth (Ch9), control plane (Ch5), Postgres + Redis (Ch6), Knative (Ch4), Kata + Firecracker (Ch3), Kubernetes (Ch2), storage (Ch7), networking (Ch8). The flow above is the whole product running. Build that flow and you've built Houston Cloud.</p>
+    </div>
+
+    <div class="pager">
+      <a href="09-auth.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">Auth</div>
+      </a>
+      <a href="11-roadmap.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">The roadmap</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/11-roadmap.html
+++ b/cloud-design/11-roadmap.html
@@ -1,0 +1,266 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>The roadmap — Houston Cloud Design</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html" class="active"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content">
+    <div class="content-label">
+      Chapter 11
+      <span class="status progress">Gate plan</span>
+    </div>
+    <h1>Build order. Honest sizing. Real gates.</h1>
+    <p class="lead">
+      The architecture is settled. The question is sequence. Some
+      pieces unlock others; some are independent. This is the order
+      we build, the gate each milestone has to pass before the next
+      starts, and the rough time it takes.
+    </p>
+
+    <div class="callout callout-info">
+      <div class="callout-label">How to read this</div>
+      <p>Every milestone has a goal, a list of deliverables, a gate, and a size. Sizes are honest engineering estimates, not commitments to investors. Gates are the conditions that say "we're done with this, on to the next." If a gate fails, we don't skip, we fix.</p>
+    </div>
+
+    <h2>Milestone C1 — Container the engine (2 weeks)</h2>
+    <p>
+      Take the existing <code>houston-engine</code> binary and put it
+      in a Docker image. Verify it boots, serves the HTTP API, and
+      can run a Claude Code session inside the container exactly
+      like it does on the desktop.
+    </p>
+    <ul>
+      <li>Dockerfile based on a slim Linux base.</li>
+      <li>Bundles the engine binary + Claude Code CLI + Codex CLI + Composio CLI (already produced by <code>scripts/fetch-cli-deps.sh</code>).</li>
+      <li>Mounts <code>/data/.houston</code> for state.</li>
+      <li>Tested by running locally with <code>docker run</code> and pointing the desktop app at it.</li>
+    </ul>
+    <p><strong>Gate:</strong> A developer can run a full chat session against the containerized engine, locally, with zero functional regressions vs the desktop sidecar.</p>
+
+    <h2>Milestone C2 — One cluster, one agent (3-4 weeks)</h2>
+    <p>
+      Stand up a Kubernetes cluster on GKE. Deploy the engine
+      container as a regular pod. Connect to it from a dev machine.
+      No multi-tenant. No Knative. Just: cloud-hosted engine working.
+    </p>
+    <ul>
+      <li>GKE cluster, 2-3 nodes, no special runtime.</li>
+      <li>One agent pod with a persistent volume.</li>
+      <li>Ingress (load balancer + cert-manager TLS).</li>
+      <li>Desktop app updated to point at the cloud engine via the existing remote-engine OAuth flow.</li>
+    </ul>
+    <p><strong>Gate:</strong> Engineer logs into the cloud engine from the desktop app, runs an agent, sessions persist across pod restart.</p>
+
+    <h2>Milestone C3 — Kata + Firecracker (3 weeks)</h2>
+    <p>
+      Switch the agent pod from regular runc to Kata Containers with
+      Firecracker. Measure cold start, throughput, and any feature
+      regressions.
+    </p>
+    <ul>
+      <li>Install Kata operator on the cluster.</li>
+      <li>Provision node pool with nested virtualization (or bare metal).</li>
+      <li>Add <code>runtimeClassName: kata-fc</code> to the agent pod manifest.</li>
+      <li>Benchmark cold start, message latency, memory overhead.</li>
+    </ul>
+    <p><strong>Gate:</strong> Cold start ≤ 1 second end-to-end. Message latency within 50 ms of pre-Kata baseline. No feature breaks.</p>
+
+    <h2>Milestone C4 — Knative scale-to-zero (2 weeks)</h2>
+    <p>
+      Replace the always-on agent Deployment with a Knative Service.
+      Watch it sleep when idle and wake when a message arrives.
+    </p>
+    <ul>
+      <li>Install Knative Serving.</li>
+      <li>Knative <code>Service</code> per agent (initially: one test agent).</li>
+      <li>Tune scale-to-zero grace period (default ~30s, probably keep).</li>
+      <li>Verify the persistent volume re-attaches correctly on wake.</li>
+    </ul>
+    <p><strong>Gate:</strong> Agent pod is gone after idle, persistent volume survives, first message after idle wakes it in ≤ 1 second with no data loss.</p>
+
+    <h2>Milestone C5 — Control plane v0 (4-6 weeks)</h2>
+    <p>
+      Write the routing service that sits between the frontend and
+      the agent pods. v0 is single tenant (one workspace, one user).
+      Multi-tenant comes in C6.
+    </p>
+    <ul>
+      <li>Rust axum service. JWT verification (Supabase). Postgres for users + agents + permissions. Redis for routing cache + sessions.</li>
+      <li>HTTP routes: list agents, send message, stream response. WebSocket for live chat.</li>
+      <li>Routes messages to the right Knative URL.</li>
+      <li>Audit log for every request.</li>
+    </ul>
+    <p><strong>Gate:</strong> Frontend → control plane → agent pod works end-to-end for one workspace. Sessions survive control plane pod restart.</p>
+
+    <h2>Milestone C6 — Multi-tenancy + permissions (3-4 weeks)</h2>
+    <p>
+      Add workspaces, per-workspace namespaces, and per-agent
+      permissions. Make sure Acme can never see Globex.
+    </p>
+    <ul>
+      <li>Workspace provisioning: when an admin creates a workspace, the control plane creates a K8s namespace + default NetworkPolicy + Postgres rows.</li>
+      <li>User invite flow.</li>
+      <li>Admin UI: grant / revoke agent access per user.</li>
+      <li>Cilium installed and configured. Cross-namespace traffic denied by default.</li>
+      <li>Penetration test: try to make Acme reach Globex. Should fail at every layer.</li>
+    </ul>
+    <p><strong>Gate:</strong> Two test workspaces can run on the same cluster, share no data, and a deliberate attempt by one to reach the other is blocked by the control plane, by Cilium, and by Firecracker independently.</p>
+
+    <h2>Milestone C7 — Web app (4-8 weeks, parallel)</h2>
+    <p>
+      Build <code>app.houston.ai</code> as a webapp using the existing
+      <code>@houston-ai/*</code> React packages. Or: defer this and
+      ship "desktop app + cloud engine" for v1.
+    </p>
+    <ul>
+      <li>Next.js or Vite frontend.</li>
+      <li>Reuses chat, board, layout packages.</li>
+      <li>Login via Supabase. Workspace switcher. Agent list. Chat UI.</li>
+      <li>Admin UI for managing users + permissions.</li>
+    </ul>
+    <p><strong>Gate:</strong> Non-technical user can sign up, get invited to a workspace, see their agents, chat with one, all without installing anything.</p>
+
+    <h2>Milestone C8 — Production hardening (4-6 weeks)</h2>
+    <p>
+      Everything works. Now make it stay working at 3am on a Sunday
+      with paying customers.
+    </p>
+    <ul>
+      <li>Monitoring: Prometheus + Grafana. Alerts on every SLO.</li>
+      <li>Sentry wired into control plane and agent pods.</li>
+      <li>Backups: Postgres point-in-time recovery, volume snapshots, S3 exports.</li>
+      <li>Runbooks for: pod stuck, control plane down, Postgres failover, region outage.</li>
+      <li>Load test: 1,000 concurrent agents, measure cost.</li>
+      <li>Security review: external pentest.</li>
+    </ul>
+    <p><strong>Gate:</strong> Stack survives a load test of 10x expected v1 traffic. Pentest finds no high-severity issues.</p>
+
+    <h2>Milestone C9 — First paying customer (gated by previous)</h2>
+    <p>
+      Onboard a friendly design-partner. Get them through real usage.
+      Fix what breaks.
+    </p>
+    <ul>
+      <li>White-glove onboarding.</li>
+      <li>Slack channel with their team.</li>
+      <li>Daily check-ins for the first 2 weeks.</li>
+    </ul>
+    <p><strong>Gate:</strong> Customer renews / signs annual contract. We've earned the right to scale to ten more like them.</p>
+
+    <h2>The size totals</h2>
+    <table>
+      <thead>
+        <tr><th>Milestone</th><th>Size</th><th>Cumulative</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>C1 Container the engine</td><td>2 weeks</td><td>2 weeks</td></tr>
+        <tr><td>C2 One cluster, one agent</td><td>3-4 weeks</td><td>5-6 weeks</td></tr>
+        <tr><td>C3 Kata + Firecracker</td><td>3 weeks</td><td>8-9 weeks</td></tr>
+        <tr><td>C4 Knative scale-to-zero</td><td>2 weeks</td><td>10-11 weeks</td></tr>
+        <tr><td>C5 Control plane v0</td><td>4-6 weeks</td><td>14-17 weeks</td></tr>
+        <tr><td>C6 Multi-tenancy</td><td>3-4 weeks</td><td>17-21 weeks</td></tr>
+        <tr><td>C7 Web app (parallel)</td><td>4-8 weeks</td><td>same window</td></tr>
+        <tr><td>C8 Production hardening</td><td>4-6 weeks</td><td>21-27 weeks</td></tr>
+        <tr><td>C9 First paying customer</td><td>2-4 weeks</td><td>23-31 weeks</td></tr>
+      </tbody>
+    </table>
+
+    <p>
+      Roughly <strong>6 to 8 months</strong> from start to first
+      paying enterprise customer, assuming 1-2 engineers dedicated.
+      Faster with more people, but the gates aren't always
+      parallelizable (you can't tune Kata before the engine is
+      containerized).
+    </p>
+
+    <h2>What we don't build in v1</h2>
+    <p>Listed so we don't forget we said no.</p>
+    <ul>
+      <li><strong>Multi-engine support.</strong> Pluggable runtime adapter. Defer until a customer asks for Hermes or OpenClaw specifically.</li>
+      <li><strong>Multi-region.</strong> Single region, single cluster for v1. Add EU region when EU customers sign.</li>
+      <li><strong>Self-hosted on-prem.</strong> Separate product story. We ship the SaaS first.</li>
+      <li><strong>BYO Kubernetes.</strong> "Run Houston on our cluster." Maybe never. Definitely not v1.</li>
+      <li><strong>Custom node pools per tenant.</strong> Enterprise tier feature. Add once an enterprise demands it and is willing to pay the premium.</li>
+      <li><strong>Per-region data residency.</strong> Compliance feature, separate workstream.</li>
+    </ul>
+
+    <h2>The biggest risks</h2>
+    <div class="fail-grid">
+      <div class="fail-card">
+        <div class="label">Risk 1</div>
+        <p><strong>Kata cold start is too slow in practice.</strong> Mitigation: keep one warm pod per "popular" agent. If still too slow, fall back to gVisor for less paranoid tenants and reserve Kata for compliance-sensitive ones.</p>
+      </div>
+      <div class="fail-card">
+        <div class="label">Risk 2</div>
+        <p><strong>Persistent volume attach is slow or flaky.</strong> Mitigation: snapshot-based fast restore from object storage. Topology-aware scheduling. Tested as part of C4 gate.</p>
+      </div>
+      <div class="fail-card">
+        <div class="label">Risk 3</div>
+        <p><strong>Per-agent pod count explodes.</strong> 10,000 customers × 5 agents = 50,000 K8s services. Knative handles a lot but not infinite. Mitigation: shard across multiple clusters by tenant once we hit ~10k active services per cluster.</p>
+      </div>
+      <div class="fail-card">
+        <div class="label">Risk 4</div>
+        <p><strong>Engine bugs in production are hard to debug.</strong> Logs from a Firecracker microVM aren't as easy to grab as from a process on a laptop. Mitigation: structured logging streamed to Loki, per-agent log retention, "support session" mode that lets us shell into a pod with consent.</p>
+      </div>
+    </div>
+
+    <h2>What this guide does not cover (and where to look)</h2>
+    <ul>
+      <li><strong>What the engine actually does inside the pod</strong> → see the <a href="../engine-design/index.html">engine-design</a> guide.</li>
+      <li><strong>Marketplace, agent publishing</strong> → separate product spec, not written yet.</li>
+      <li><strong>Mobile PWA in the cloud world</strong> → see <code>docs/mobile-architecture.md</code> and <code>docs/relay-operations.md</code>.</li>
+      <li><strong>Billing model + pricing</strong> → business doc, not engineering.</li>
+    </ul>
+
+    <div class="callout callout-success">
+      <div class="callout-label">Where to start tomorrow</div>
+      <p>Milestone C1. Two weeks to containerize the engine, locally testable end-to-end. Doesn't need a cluster, doesn't need approvals, just a Dockerfile and a developer. Everything else compounds on that working artifact.</p>
+    </div>
+
+    <div class="pager">
+      <a href="10-message-flow.html">
+        <div class="pager-label">← Previous</div>
+        <div class="pager-title">End-to-end flow</div>
+      </a>
+      <a href="index.html" class="next">
+        <div class="pager-label">Next →</div>
+        <div class="pager-title">Back to overview</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/README.md
+++ b/cloud-design/README.md
@@ -1,0 +1,9 @@
+## Houston Cloud Design Guide
+
+How we ship Houston to teams in the cloud, plain English.
+
+Open `index.html` in any browser. Self-contained. Each chapter has a status pill: shipped, partial, planned, or gated.
+
+This is the working design for the multi-tenant cloud deployment. The engine-design guide explains what Houston is today; this guide explains how Houston runs in a datacenter for thousands of users with per-agent isolation.
+
+If you're new and want the one-page version, start at Chapter 1 (The plan). The rest of the chapters explain each piece of the stack from the ground up.

--- a/cloud-design/index.html
+++ b/cloud-design/index.html
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Houston Cloud Design — The Guide</title>
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+
+<nav>
+  <a href="index.html" class="nav-logo">Houston<span class="nav-sub">· Cloud Design</span></a>
+</nav>
+
+<div class="layout">
+  <aside class="sidebar">
+    <div class="sidebar-label">Cloud Design</div>
+    <ul class="sidebar-nav">
+      <li><a href="index.html" class="active"><span class="num">—</span>Overview</a></li>
+      <li><a href="01-the-plan.html"><span class="num">01</span>The plan<span class="sb-status progress"></span></a></li>
+      <li><a href="02-kubernetes.html"><span class="num">02</span>Kubernetes<span class="sb-status planned"></span></a></li>
+      <li><a href="03-kata-firecracker.html"><span class="num">03</span>Kata + Firecracker<span class="sb-status planned"></span></a></li>
+      <li><a href="04-knative.html"><span class="num">04</span>Knative<span class="sb-status planned"></span></a></li>
+      <li><a href="05-control-plane.html"><span class="num">05</span>The control plane<span class="sb-status planned"></span></a></li>
+      <li><a href="06-postgres-redis.html"><span class="num">06</span>Postgres + Redis<span class="sb-status planned"></span></a></li>
+      <li><a href="07-storage.html"><span class="num">07</span>Storage<span class="sb-status planned"></span></a></li>
+      <li><a href="08-networking.html"><span class="num">08</span>Networking<span class="sb-status planned"></span></a></li>
+      <li><a href="09-auth.html"><span class="num">09</span>Auth<span class="sb-status partial"></span></a></li>
+      <li><a href="10-message-flow.html"><span class="num">10</span>End-to-end flow<span class="sb-status planned"></span></a></li>
+      <li><a href="11-roadmap.html"><span class="num">11</span>The roadmap<span class="sb-status progress"></span></a></li>
+    </ul>
+  </aside>
+
+  <main class="content hero">
+    <div class="content-label">Houston · Cloud Design Guide</div>
+    <h1>How Houston runs in the cloud.</h1>
+    <p class="lead">
+      The Houston desktop app puts one agent on your machine. Houston
+      Cloud puts ten thousand agents on a cluster, each one in its own
+      sealed box, woken on demand, billed only when it works. This is
+      how every piece of that stack fits together, written so a non
+      engineer can follow it.
+    </p>
+
+    <div class="hero-actions">
+      <a class="btn btn-primary" href="01-the-plan.html">Start reading</a>
+      <a class="btn btn-secondary" href="11-roadmap.html">Jump to roadmap</a>
+    </div>
+
+    <h2 style="margin-top: 80px">Reading legend</h2>
+    <p>Each chapter has a status pill. Four states.</p>
+    <ul>
+      <li><span class="status shipped">Shipped</span> already in the codebase today.</li>
+      <li><span class="status partial">Partial</span> some of it works, the rest is on the plan.</li>
+      <li><span class="status planned">Planned</span> proposed design, not built yet.</li>
+      <li><span class="status progress">Gate plan</span> sequencing, decisions, and what triggers the build.</li>
+    </ul>
+
+    <h2>The big idea, in one paragraph</h2>
+    <p>
+      Houston Cloud is the same <code>houston-engine</code> from the
+      desktop, packaged in a tiny Linux box, and run one box per agent
+      on Kubernetes. Each box is sealed off from the others using
+      Firecracker microVMs. When nobody is talking to an agent, the
+      box sleeps and costs nothing. When a message arrives, the box
+      wakes up in under a second, does the work, and goes back to
+      sleep. A small control plane in front of it all handles login,
+      permissions, and routing messages to the right box. That's
+      it. The whole guide is just zooming into each of those words.
+    </p>
+
+    <h2>The chapters</h2>
+
+    <div class="chapter-grid">
+      <a class="chapter-card" href="01-the-plan.html">
+        <div class="chapter-num">01 <span class="status progress">Plan</span></div>
+        <div class="chapter-title">The plan</div>
+        <div class="chapter-desc">The whole thing on one page. The summary of every chapter that comes after.</div>
+      </a>
+
+      <a class="chapter-card" href="02-kubernetes.html">
+        <div class="chapter-num">02 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">Kubernetes</div>
+        <div class="chapter-desc">The thing that runs all the boxes. Explained without the buzzwords.</div>
+      </a>
+
+      <a class="chapter-card" href="03-kata-firecracker.html">
+        <div class="chapter-num">03 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">Kata + Firecracker</div>
+        <div class="chapter-desc">How we make each agent's box bulletproof. Tiny VMs, big walls.</div>
+      </a>
+
+      <a class="chapter-card" href="04-knative.html">
+        <div class="chapter-num">04 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">Knative</div>
+        <div class="chapter-desc">The reason sleeping agents cost zero. Wake on demand, fall asleep on idle.</div>
+      </a>
+
+      <a class="chapter-card" href="05-control-plane.html">
+        <div class="chapter-num">05 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">The control plane</div>
+        <div class="chapter-desc">The doorman. Routes messages, checks permissions, wakes the right box.</div>
+      </a>
+
+      <a class="chapter-card" href="06-postgres-redis.html">
+        <div class="chapter-num">06 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">Postgres + Redis</div>
+        <div class="chapter-desc">Where the long term memory lives and where the short term memory lives.</div>
+      </a>
+
+      <a class="chapter-card" href="07-storage.html">
+        <div class="chapter-num">07 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">Storage</div>
+        <div class="chapter-desc">Where each agent's files survive when its box is sleeping.</div>
+      </a>
+
+      <a class="chapter-card" href="08-networking.html">
+        <div class="chapter-num">08 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">Networking</div>
+        <div class="chapter-desc">Walls between teams. The HR agent and the Sales agent can't see each other.</div>
+      </a>
+
+      <a class="chapter-card" href="09-auth.html">
+        <div class="chapter-num">09 <span class="status partial">Partial</span></div>
+        <div class="chapter-title">Auth</div>
+        <div class="chapter-desc">Login, sessions, who-can-talk-to-which-agent. Supabase doing the heavy lifting.</div>
+      </a>
+
+      <a class="chapter-card" href="10-message-flow.html">
+        <div class="chapter-num">10 <span class="status planned">Planned</span></div>
+        <div class="chapter-title">End-to-end flow</div>
+        <div class="chapter-desc">User clicks Send. What happens, in order, all the way to the agent's reply.</div>
+      </a>
+
+      <a class="chapter-card" href="11-roadmap.html">
+        <div class="chapter-num">11 <span class="status progress">Gate plan</span></div>
+        <div class="chapter-title">The roadmap</div>
+        <div class="chapter-desc">What gets built first, what waits, what the gates are.</div>
+      </a>
+    </div>
+  </main>
+</div>
+
+<footer class="footer">
+  <div>Houston Cloud Design Guide · Living document · Edit as decisions get made.</div>
+</footer>
+
+</body>
+</html>

--- a/cloud-design/style.css
+++ b/cloud-design/style.css
@@ -1,0 +1,883 @@
+/* ═══════════════════════════════════════════
+   Houston Engine Design — Mirrors learn/style.css
+   ═══════════════════════════════════════════ */
+
+:root {
+  --background: #ffffff;
+  --foreground: #0d0d0d;
+  --secondary: #f9f9f9;
+  --muted-foreground: #5d5d5d;
+  --border: #e5e5e5;
+  --gray-50: #f9f9f9;
+  --gray-100: #ececec;
+  --gray-200: #e3e3e3;
+  --gray-300: #cdcdcd;
+  --gray-400: #b4b4b4;
+  --gray-500: #9b9b9b;
+  --gray-600: #676767;
+  --gray-700: #424242;
+  --gray-900: #1a1a1a;
+  --gray-950: #0d0d0d;
+  --success: #00a240;
+  --info: #2964aa;
+  --warning: #e0ac00;
+  --danger: #e02e2a;
+  --border-light: rgba(13, 13, 13, 0.05);
+  --border-medium: rgba(0, 0, 0, 0.12);
+  --border-heavy: rgba(13, 13, 13, 0.15);
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+@media (prefers-reduced-motion: no-preference) {
+  html { scroll-behavior: smooth; }
+}
+
+body {
+  font-family: ui-sans-serif, -apple-system, system-ui, "Segoe UI", Helvetica, Arial, sans-serif;
+  color: var(--foreground);
+  background: var(--background);
+  -webkit-font-smoothing: antialiased;
+  font-size: 16px;
+  line-height: 1.6;
+  padding-top: 65px;
+}
+
+code, .mono {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+}
+
+a { color: inherit; text-decoration: none; }
+
+/* ─── Top nav ─── */
+nav {
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  z-index: 100;
+  padding: 16px 40px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  border-bottom: 1px solid var(--border-light);
+}
+
+.nav-logo {
+  font-family: 'General Sans', sans-serif;
+  font-size: 22px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--gray-950);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.nav-logo .nav-sub {
+  font-size: 14px;
+  color: var(--gray-500);
+  font-weight: 400;
+  margin-left: 4px;
+}
+
+.nav-right {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  font-size: 14px;
+  color: var(--gray-600);
+}
+
+@media (max-width: 700px) {
+  nav { padding: 16px 20px; }
+  .nav-logo .nav-sub { display: none; }
+}
+
+/* ─── Layout ─── */
+.layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  max-width: 1280px;
+  margin: 0 auto;
+  gap: 48px;
+  padding: 48px 32px 120px;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+    gap: 0;
+    padding: 32px 24px 80px;
+  }
+}
+
+/* ─── Sidebar ─── */
+.sidebar {
+  position: sticky;
+  top: 88px;
+  align-self: start;
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+@media (max-width: 900px) {
+  .sidebar {
+    position: static;
+    max-height: none;
+    margin-bottom: 32px;
+    padding-right: 0;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--border-light);
+  }
+}
+
+.sidebar-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-500);
+  margin-bottom: 12px;
+  padding: 0 10px;
+}
+
+.sidebar-nav {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebar-nav a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 14px;
+  color: var(--gray-700);
+  transition: background 0.15s, color 0.15s;
+  position: relative;
+}
+
+.sidebar-nav a:hover {
+  background: var(--gray-50);
+  color: var(--gray-950);
+}
+
+.sidebar-nav a.active {
+  background: var(--gray-100);
+  color: var(--gray-950);
+  font-weight: 500;
+}
+
+.sidebar-nav .num {
+  color: var(--gray-400);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  min-width: 18px;
+}
+
+.sidebar-nav a.active .num {
+  color: var(--gray-600);
+}
+
+.sidebar-nav .sb-status {
+  margin-left: auto;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+.sidebar-nav .sb-status.shipped { background: var(--success); }
+.sidebar-nav .sb-status.partial { background: var(--warning); }
+.sidebar-nav .sb-status.progress { background: var(--info); }
+.sidebar-nav .sb-status.planned { background: var(--gray-300); }
+
+/* ─── Content ─── */
+.content {
+  max-width: 880px;
+  min-width: 0;
+}
+
+.content-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gray-500);
+  margin-bottom: 16px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.content h1 {
+  font-size: clamp(32px, 4vw, 44px);
+  font-weight: 400;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: var(--gray-950);
+  margin-bottom: 20px;
+}
+
+.content .lead {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--muted-foreground);
+  margin-bottom: 48px;
+  max-width: 640px;
+}
+
+.content h2 {
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
+  color: var(--gray-950);
+  margin-top: 56px;
+  margin-bottom: 16px;
+  scroll-margin-top: 88px;
+}
+.content h2:first-of-type { margin-top: 0; }
+
+.content h3 {
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--gray-950);
+  margin-top: 32px;
+  margin-bottom: 10px;
+}
+
+.content p {
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--gray-700);
+  margin-bottom: 16px;
+}
+.content p strong { color: var(--gray-950); font-weight: 600; }
+
+.content ul, .content ol {
+  margin-bottom: 20px;
+  padding-left: 22px;
+  color: var(--gray-700);
+}
+
+.content li { margin-bottom: 8px; line-height: 1.65; }
+.content li::marker { color: var(--gray-400); }
+
+.content code {
+  background: var(--gray-100);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 14px;
+  color: var(--gray-950);
+}
+
+.content pre {
+  background: var(--gray-950);
+  color: #f0f0f0;
+  padding: 20px 24px;
+  border-radius: 12px;
+  overflow-x: auto;
+  margin-bottom: 24px;
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+.content pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-size: 14px;
+}
+
+/* ─── Status pills ─── */
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 10px;
+  border-radius: 9999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.status::before {
+  content: '';
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+.status.shipped {
+  background: color-mix(in oklch, var(--success) 12%, white);
+  color: var(--success);
+}
+.status.shipped::before { background: var(--success); }
+.status.partial {
+  background: color-mix(in oklch, var(--warning) 14%, white);
+  color: #a07b00;
+}
+.status.partial::before { background: var(--warning); }
+.status.progress {
+  background: color-mix(in oklch, var(--info) 12%, white);
+  color: var(--info);
+}
+.status.progress::before { background: var(--info); }
+.status.planned {
+  background: var(--gray-100);
+  color: var(--gray-600);
+}
+.status.planned::before { background: var(--gray-400); }
+
+/* ─── On-this-page TOC ─── */
+.toc {
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin-bottom: 48px;
+}
+
+.toc-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-500);
+  margin-bottom: 12px;
+}
+
+.toc ol { list-style: none; padding: 0; counter-reset: toc; margin: 0; }
+.toc li {
+  counter-increment: toc;
+  margin-bottom: 6px;
+  font-size: 14px;
+  padding-left: 0;
+}
+.toc li::marker { color: transparent; }
+.toc li::before {
+  content: counter(toc) ".";
+  color: var(--gray-400);
+  margin-right: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.toc a { color: var(--gray-700); transition: color 0.15s; }
+.toc a:hover { color: var(--gray-950); text-decoration: underline; text-underline-offset: 3px; }
+
+/* ─── Callouts ─── */
+.callout {
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 16px 20px;
+  margin: 24px 0;
+  background: var(--gray-50);
+}
+.callout-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--gray-600);
+  margin-bottom: 6px;
+}
+.callout p { margin-bottom: 0; font-size: 15px; color: var(--gray-700); }
+.callout p + p { margin-top: 10px; }
+
+.callout-info {
+  background: color-mix(in oklch, var(--info) 6%, white);
+  border-color: color-mix(in oklch, var(--info) 20%, transparent);
+}
+.callout-info .callout-label { color: var(--info); }
+
+.callout-warning {
+  background: color-mix(in oklch, var(--warning) 6%, white);
+  border-color: color-mix(in oklch, var(--warning) 20%, transparent);
+}
+.callout-warning .callout-label { color: var(--warning); }
+
+.callout-success {
+  background: color-mix(in oklch, var(--success) 6%, white);
+  border-color: color-mix(in oklch, var(--success) 20%, transparent);
+}
+.callout-success .callout-label { color: var(--success); }
+
+.callout-danger {
+  background: color-mix(in oklch, var(--danger) 6%, white);
+  border-color: color-mix(in oklch, var(--danger) 20%, transparent);
+}
+.callout-danger .callout-label { color: var(--danger); }
+
+/* ─── Diagrams ─── */
+.diagram {
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 28px 24px 24px;
+  margin: 32px 0;
+  overflow-x: auto;
+}
+.diagram .caption {
+  color: var(--gray-500);
+  font-size: 13px;
+  margin-top: 18px;
+  text-align: center;
+}
+
+/* Host-runtime grid (Ch3) */
+.host-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 14px;
+}
+.host-card {
+  background: white;
+  border: 1px solid var(--border-medium);
+  border-radius: 12px;
+  padding: 18px 18px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.host-card .host-name {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--gray-500);
+}
+.host-card .runtime-pill {
+  font-size: 13px;
+  color: var(--gray-700);
+  padding: 7px 12px;
+  background: var(--gray-50);
+  border-radius: 8px;
+  border: 1px dashed var(--border-medium);
+  text-align: center;
+}
+.host-card .engine-pill {
+  background: var(--gray-950);
+  color: white;
+  padding: 10px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  text-align: center;
+  letter-spacing: -0.005em;
+}
+.host-card .engine-pill .engine-sub {
+  font-size: 11px;
+  color: var(--gray-400);
+  margin-top: 2px;
+  font-weight: 400;
+}
+
+/* Deployment grid (Ch10) — vertical flow per column */
+.deploy-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 14px;
+}
+.deploy-col {
+  background: white;
+  border: 1px solid var(--border-medium);
+  border-radius: 12px;
+  padding: 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.deploy-col .deploy-head {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--gray-500);
+  margin-bottom: 6px;
+}
+.deploy-col .deploy-layer {
+  padding: 9px 12px;
+  border-radius: 8px;
+  font-size: 13px;
+  text-align: center;
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  color: var(--gray-700);
+}
+.deploy-col .deploy-layer.engine {
+  background: var(--gray-950);
+  border-color: var(--gray-950);
+  color: white;
+  font-weight: 600;
+}
+.deploy-col .deploy-arrow {
+  text-align: center;
+  color: var(--gray-300);
+  font-size: 14px;
+  line-height: 1;
+}
+
+/* Flow steps (replaces sequence diagram) */
+.flow-list {
+  margin: 32px 0;
+  display: grid;
+  gap: 8px;
+}
+.flow-step {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  gap: 16px;
+  padding: 14px 18px;
+  background: white;
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  align-items: start;
+}
+.flow-step .num {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--gray-400);
+  font-variant-numeric: tabular-nums;
+  padding-top: 4px;
+}
+.flow-step .from-to {
+  font-size: 12px;
+  color: var(--gray-500);
+  margin-bottom: 4px;
+  letter-spacing: 0.01em;
+}
+.flow-step .from-to .actor {
+  font-weight: 600;
+  color: var(--gray-700);
+}
+.flow-step .from-to .arrow {
+  margin: 0 6px;
+  color: var(--gray-400);
+}
+.flow-step .action {
+  font-size: 14.5px;
+  color: var(--gray-950);
+  line-height: 1.5;
+}
+.flow-step .action code { font-size: 13px; }
+.flow-step.db-write {
+  background: color-mix(in oklch, var(--success) 5%, white);
+  border-color: color-mix(in oklch, var(--success) 18%, transparent);
+}
+.flow-step.db-write .num { color: var(--success); }
+.flow-step.db-write .from-to .actor.db { color: var(--success); }
+.flow-loop {
+  border: 1.5px dashed var(--border-medium);
+  border-radius: 12px;
+  padding: 14px;
+  background: var(--gray-50);
+  display: grid;
+  gap: 8px;
+}
+.flow-loop-label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--gray-600);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  margin-bottom: 2px;
+  padding-left: 4px;
+}
+
+/* HTML/CSS stack diagram */
+.stack {
+  display: grid;
+  gap: 12px;
+  max-width: 460px;
+  margin: 32px auto;
+}
+.stack-layer {
+  padding: 22px 24px;
+  border-radius: 10px;
+  text-align: left;
+  background: white;
+  border: 1px solid var(--border-medium);
+}
+.stack-layer .name {
+  font-weight: 700;
+  font-size: 17px;
+  margin-bottom: 4px;
+  color: var(--gray-950);
+}
+.stack-layer .desc {
+  font-size: 14px;
+  color: var(--gray-600);
+}
+.stack-layer.top { border-top: 3px solid var(--info); }
+.stack-layer.mid { border-top: 3px solid var(--success); }
+.stack-layer.bot { border-top: 3px solid var(--warning); }
+
+/* Walls (isolation diagram) */
+.walls {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  gap: 0;
+  margin: 32px 0;
+  align-items: stretch;
+}
+.agent-col {
+  background: white;
+  border: 1px solid var(--border-medium);
+  border-radius: 12px;
+  padding: 24px;
+}
+.agent-col h4 {
+  margin: 0 0 12px;
+  font-size: 15px;
+  color: var(--gray-950);
+  font-weight: 600;
+}
+.agent-col ul {
+  margin: 0;
+  padding-left: 18px;
+  font-size: 13px;
+  color: var(--gray-600);
+}
+.agent-col ul li { margin-bottom: 4px; }
+.wall {
+  position: relative;
+  width: 60px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--danger);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+.wall::before, .wall::after {
+  content: '';
+  position: absolute;
+  width: 3px;
+  background: repeating-linear-gradient(0deg, var(--danger) 0 8px, transparent 8px 14px);
+  top: 0;
+  bottom: 0;
+}
+.wall::before { left: 22px; }
+.wall::after { right: 22px; }
+@media (max-width: 700px) {
+  .walls { grid-template-columns: 1fr; gap: 12px; }
+  .wall { width: 100%; height: 36px; }
+  .wall::before, .wall::after { width: auto; height: 3px; left: 0; right: 0; bottom: auto; }
+  .wall::before { top: 16px; background: repeating-linear-gradient(90deg, var(--danger) 0 8px, transparent 8px 14px); }
+  .wall::after { top: 22px; background: repeating-linear-gradient(90deg, var(--danger) 0 8px, transparent 8px 14px); }
+}
+
+/* Failure cards (a row of small problem callouts) */
+.fail-grid {
+  display: grid;
+  gap: 12px;
+  margin: 24px 0;
+}
+.fail-card {
+  background: color-mix(in oklch, var(--danger) 5%, white);
+  border: 1px solid color-mix(in oklch, var(--danger) 18%, transparent);
+  border-left: 3px solid var(--danger);
+  border-radius: 10px;
+  padding: 16px 20px;
+}
+.fail-card .label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--danger);
+  letter-spacing: 0.05em;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+.fail-card p { margin: 0; font-size: 14px; color: var(--gray-700); }
+.fail-card strong { color: var(--gray-950); }
+
+/* Tech detail box */
+.tech-box {
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  border-left: 3px solid var(--gray-400);
+  border-radius: 10px;
+  padding: 14px 18px;
+  margin: 24px 0;
+  font-size: 13.5px;
+  color: var(--gray-600);
+}
+.tech-box .label {
+  font-size: 11px;
+  font-weight: 700;
+  color: var(--gray-500);
+  letter-spacing: 0.05em;
+  margin-bottom: 6px;
+  text-transform: uppercase;
+}
+.tech-box code { font-size: 12.5px; background: white; }
+
+/* ─── Tables ─── */
+.content table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 24px 0;
+  background: white;
+  border-radius: 12px;
+  overflow: hidden;
+  border: 1px solid var(--border-light);
+  font-size: 14px;
+}
+.content th {
+  text-align: left;
+  padding: 12px 16px;
+  background: var(--gray-50);
+  color: var(--gray-600);
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--border-light);
+}
+.content td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--border-light);
+  vertical-align: top;
+  color: var(--gray-700);
+}
+.content tr:last-child td { border-bottom: none; }
+.content td code { font-size: 12.5px; }
+
+/* ─── Index page bits ─── */
+.chapter-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 16px;
+  margin-top: 48px;
+}
+@media (max-width: 700px) { .chapter-grid { grid-template-columns: 1fr; } }
+
+.chapter-card {
+  display: block;
+  padding: 22px 24px;
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  background: white;
+  transition: border-color 0.15s, box-shadow 0.2s, transform 0.15s;
+}
+.chapter-card:hover {
+  border-color: var(--border-medium);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03), 0 8px 24px rgba(0, 0, 0, 0.04);
+  transform: translateY(-1px);
+}
+.chapter-card .chapter-num {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-400);
+  margin-bottom: 6px;
+  font-variant-numeric: tabular-nums;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.chapter-card .chapter-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--gray-950);
+  letter-spacing: -0.01em;
+  margin-bottom: 8px;
+}
+.chapter-card .chapter-desc {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--muted-foreground);
+}
+
+.hero { padding-top: 24px; padding-bottom: 24px; }
+.hero h1 {
+  font-size: clamp(36px, 5vw, 52px);
+  font-weight: 400;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  margin-bottom: 24px;
+}
+.hero .lead { font-size: 20px; margin-bottom: 36px; }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 44px;
+  padding: 0 22px;
+  border-radius: 9999px;
+  font-size: 15px;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+.btn-primary { background: var(--gray-950); color: white; }
+.btn-primary:hover { background: var(--gray-700); }
+.btn-secondary { background: white; color: var(--gray-950); border: 1px solid var(--border-medium); }
+.btn-secondary:hover { background: var(--gray-50); }
+
+.hero-actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  margin-bottom: 24px;
+}
+
+/* ─── Pager ─── */
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 72px;
+  padding-top: 32px;
+  border-top: 1px solid var(--border-light);
+}
+.pager a {
+  display: flex;
+  flex-direction: column;
+  padding: 18px 22px;
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  transition: border-color 0.15s, background 0.15s;
+}
+.pager a:hover { border-color: var(--border-medium); background: var(--gray-50); }
+.pager .pager-label {
+  font-size: 12px;
+  color: var(--gray-500);
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+.pager .pager-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--gray-950);
+}
+.pager .next { text-align: right; }
+.pager .spacer { border: none; background: transparent; cursor: default; }
+.pager .spacer:hover { background: transparent; border: none; }
+
+/* ─── File tree ─── */
+.tree {
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin: 24px 0;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font-size: 13.5px;
+  color: var(--gray-700);
+  line-height: 1.75;
+  white-space: pre;
+  overflow-x: auto;
+}
+.tree .dir { color: var(--gray-950); font-weight: 600; }
+.tree .comment { color: var(--gray-500); }
+
+/* ─── Footer ─── */
+.footer {
+  border-top: 1px solid var(--border-light);
+  padding: 32px;
+  text-align: center;
+  color: var(--gray-500);
+  font-size: 13px;
+}


### PR DESCRIPTION
## Summary

Adds `cloud-design/`, an 11-chapter HTML guide to the planned multi-tenant cloud deployment. Mirrors the layout and style of `engine-design/` so the two read as a pair.

Core architecture: pod-per-agent on Kubernetes, Kata Containers + Firecracker for VM-level isolation, Knative for scale-to-zero, a stateless control plane in front, per-team namespaces with NetworkPolicy. Written for non-technical readers (every stack piece explained from scratch).

## Chapters

1. The plan — one-page summary and the core decision
2. Kubernetes — what it is, why we use it
3. Kata + Firecracker — agent-level isolation
4. Knative — scale-to-zero economics
5. The control plane — auth, routing, RBAC
6. Postgres + Redis — long and short term memory
7. Storage — per-agent persistent volumes
8. Networking — namespaces, Cilium, walls between tenants
9. Auth — Supabase and per-agent permissions
10. End-to-end message flow — one message all the way through
11. Roadmap — build order, gates, honest sizing

## Test plan

- [ ] Open `cloud-design/index.html` in a browser
- [ ] Click "Start reading" → chapter 1 loads
- [ ] Navigate through all 11 chapters via sidebar and next/prev pagers
- [ ] Confirm style matches `engine-design/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)