### PR TITLE
fix(provider): stop Windows codex login spawning a non-PE (os error 193)

### DIFF
--- a/engine/houston-engine-core/src/provider/mod.rs
+++ b/engine/houston-engine-core/src/provider/mod.rs
@@ -155,9 +155,12 @@ pub async fn launch_login(provider: Provider, sink: DynEventSink) -> CoreResult<
         }
     }
 
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| CoreError::Internal(format!("failed to spawn {cli_name} login: {e}")))?;
+    let mut child = cmd.spawn().map_err(|e| {
+        CoreError::Internal(
+            windows_bad_exe_message(cli_name, "login", &path, &e)
+                .unwrap_or_else(|| format!("failed to spawn {cli_name} login: {e}")),
+        )
+    })?;
 
     // Take stdin BEFORE the probe. `tokio::process::Child::wait` calls
     // `drop(self.stdin.take())` internally to avoid the classic
@@ -315,7 +318,10 @@ pub async fn launch_logout(provider: Provider) -> CoreResult<()> {
                 "[houston:provider] {cli_name} logout failed at {}: {e}",
                 path.display()
             );
-            Err(CoreError::Internal(format!("{cli_name} logout failed: {e}")))
+            Err(CoreError::Internal(
+                windows_bad_exe_message(cli_name, "logout", &path, &e)
+                    .unwrap_or_else(|| format!("{cli_name} logout failed: {e}")),
+            ))
         }
         Err(_) => {
             tracing::warn!("[houston:provider] {cli_name} logout timed out after 10s");
@@ -424,6 +430,41 @@ fn find_git_bash_windows() -> Option<PathBuf> {
     None
 }
 
+/// Map a Windows `CreateProcess` *spawn* failure to an actionable message
+/// when the resolved binary isn't a valid executable for this machine
+/// (os error 193, `ERROR_BAD_EXE_FORMAT`). Returns `None` for every other
+/// error code and on non-Windows so callers keep their own wording.
+///
+/// Distinct from [`decorate_windows_exit`], which explains NT status codes
+/// from a process that *did* spawn and then exited. 193 happens before the
+/// process ever starts — the file is a wrong-architecture PE, a corrupted
+/// binary, or a non-PE script the CLI resolver let through. Without this the
+/// user only sees the raw "%1 is not a valid Win32 application" string with
+/// no path and no next step (issue #213).
+fn windows_bad_exe_message(
+    cli_name: &str,
+    action: &str,
+    path: &std::path::Path,
+    e: &std::io::Error,
+) -> Option<String> {
+    #[cfg(target_os = "windows")]
+    {
+        if e.raw_os_error() == Some(193) {
+            return Some(format!(
+                "{cli_name} {action}: {} is not a valid application for this PC \
+                 (os error 193). It may have been built for a different processor \
+                 or be damaged. Reinstall Houston to restore the bundled {cli_name}.",
+                path.display()
+            ));
+        }
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = (cli_name, action, path, e);
+    }
+    None
+}
+
 /// Turn a cryptic Windows process exit (e.g. `0xc000001d`) into a
 /// human-actionable error message. On non-Windows or unrecognized
 /// codes we return the original status verbatim. Kept in sync with
@@ -466,6 +507,28 @@ mod tests {
         assert!(parse("nonexistent-provider").is_err());
         assert!(parse("anthropic").is_ok());
         assert!(parse("openai").is_ok());
+    }
+
+    #[test]
+    fn bad_exe_message_is_none_for_non_193_errors() {
+        // os error 2 (ENOENT) must keep the caller's own wording, on any
+        // platform — only 193 gets the actionable rewrite.
+        let e = std::io::Error::from_raw_os_error(2);
+        let path = PathBuf::from("/install/bin/codex.exe");
+        assert!(windows_bad_exe_message("codex", "login", &path, &e).is_none());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn bad_exe_message_decorates_193() {
+        let e = std::io::Error::from_raw_os_error(193);
+        let path = PathBuf::from(r"C:\Program Files\Houston\bin\codex.exe");
+        let msg = windows_bad_exe_message("codex", "login", &path, &e)
+            .expect("os error 193 should be decorated");
+        assert!(msg.contains("os error 193"), "got: {msg}");
+        assert!(msg.contains("codex"), "got: {msg}");
+        assert!(msg.contains("not a valid application"), "got: {msg}");
+        assert!(msg.contains("codex.exe"), "should name the binary path: {msg}");
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/provider/resolve.rs
+++ b/engine/houston-terminal-manager/src/provider/resolve.rs
@@ -27,8 +27,8 @@ pub enum InstallSource {
 }
 
 /// Walk the resolved shell PATH and return the first matching binary.
-/// On Windows we check the standard `PATHEXT` extensions FIRST so
-/// `codex.cmd` / `claude.exe` / etc. resolve before the bare name.
+/// On Windows we check executable extensions FIRST so `codex.cmd` /
+/// `claude.exe` / etc. resolve before the bare name.
 ///
 /// **Order matters on Windows.** npm-global (the dominant Windows
 /// install path for `@google/gemini-cli`, `@anthropic-ai/claude-code`,
@@ -40,6 +40,17 @@ pub enum InstallSource {
 /// application"). Returning the `.cmd` shim makes Rust's spawn route
 /// through `cmd.exe` (per the CVE-2024-24576 mitigation) and the
 /// script runs as intended.
+///
+/// Two Windows guards keep this fn from ever handing a caller a path
+/// that is guaranteed to fail with os error 193:
+///   - `.ps1` is NOT in the extension list. Rust's `Command` launches a
+///     PE directly and wraps `.bat`/`.cmd` through cmd.exe, but it does
+///     NOT route `.ps1` through PowerShell — `CreateProcess` on a `.ps1`
+///     always fails with 193. npm ships a `.cmd` shim next to the `.ps1`,
+///     so dropping `.ps1` loses nothing real.
+///   - The bare (extensionless) fallback only accepts a file that is a
+///     real PE image (`MZ` magic). A bare file on PATH is almost always a
+///     Unix shim script, which would also spawn-fail with 193.
 ///
 /// Returns `None` if nothing matches.
 pub fn which_on_path(command: &str) -> Option<PathBuf> {
@@ -58,19 +69,48 @@ where
     for dir in dirs {
         #[cfg(windows)]
         {
-            for ext in ["exe", "cmd", "bat", "ps1"] {
+            // `.ps1` intentionally absent — `CreateProcess` cannot launch a
+            // PowerShell script directly, so returning one guarantees a later
+            // os error 193. `.cmd`/`.bat` are fine (Rust wraps them via
+            // cmd.exe).
+            for ext in ["exe", "cmd", "bat"] {
                 let candidate = dir.join(format!("{command}.{ext}"));
                 if candidate.is_file() {
                     return Some(candidate);
                 }
             }
+            // Bare, extensionless name: accept only a real PE image. A bare
+            // file is almost always a Unix shim script (npm ships `codex`
+            // next to `codex.cmd`) and spawning it fails with os error 193.
+            let bare = dir.join(command);
+            if bare.is_file() && is_windows_pe(&bare) {
+                return Some(bare);
+            }
+            continue;
         }
-        let candidate = dir.join(command);
-        if candidate.is_file() {
-            return Some(candidate);
+        #[cfg(not(windows))]
+        {
+            let candidate = dir.join(command);
+            if candidate.is_file() {
+                return Some(candidate);
+            }
         }
     }
     None
+}
+
+/// Whether `path` begins with the `MZ` DOS/PE signature. Used on Windows so
+/// [`which_in_dirs`] never returns a bare Unix shim script (which would later
+/// fail to spawn with os error 193) when probing the extensionless command
+/// name. Legitimate extensionless PE binaries still resolve.
+#[cfg(windows)]
+fn is_windows_pe(path: &std::path::Path) -> bool {
+    use std::io::Read;
+    let mut magic = [0u8; 2];
+    std::fs::File::open(path)
+        .and_then(|mut f| f.read_exact(&mut magic))
+        .map(|()| &magic == b"MZ")
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -164,16 +204,40 @@ mod tests {
 
     #[cfg(windows)]
     #[test]
-    fn which_in_dirs_falls_back_to_bare_on_windows() {
+    fn which_in_dirs_falls_back_to_bare_pe_on_windows() {
         // Bare PE files (no `.exe` extension) are rare but legal on
-        // Windows — Windows will execute them as long as the PE
-        // signature is present. When no extensioned variant exists,
-        // the bare filename must still resolve.
+        // Windows — `CreateProcess` runs them as long as the `MZ` PE
+        // signature is present. When no extensioned variant exists, a
+        // bare PE must still resolve.
         let tmp = tempfile::TempDir::new().unwrap();
         let bare = tmp.path().join("toolx");
-        std::fs::write(&bare, b"").unwrap();
+        std::fs::write(&bare, b"MZ\x90\x00").unwrap();
         let resolved = which_in_dirs("toolx", vec![tmp.path().to_path_buf()]).unwrap();
         assert_eq!(resolved, bare);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn which_in_dirs_skips_bare_unix_script_on_windows() {
+        // The npm-global trap: a bare `codex` shim is a Node shebang
+        // script, not a PE. Returning it means `Command::spawn` later
+        // fails with os error 193 ("%1 is not a valid Win32 application").
+        // It must be skipped so resolution falls through (here: to None).
+        let tmp = tempfile::TempDir::new().unwrap();
+        let bare = tmp.path().join("toolx");
+        std::fs::write(&bare, b"#!/usr/bin/env node\nconsole.log(1)\n").unwrap();
+        assert!(which_in_dirs("toolx", vec![tmp.path().to_path_buf()]).is_none());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn which_in_dirs_ignores_ps1_on_windows() {
+        // `.ps1` is not directly launchable by `CreateProcess`, so it must
+        // not be returned even when it's the only candidate — otherwise the
+        // caller spawns it and hits os error 193.
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("toolx.ps1"), b"Write-Output hi\n").unwrap();
+        assert!(which_in_dirs("toolx", vec![tmp.path().to_path_buf()]).is_none());
     }
 
     fn bare_executable_name() -> String {

--- a/knowledge-base/platform-matrix.md
+++ b/knowledge-base/platform-matrix.md
@@ -39,15 +39,20 @@ both.
   gemini users without `~/.gemini/.env` or OAuth files do not hit
   "Failed to prepare gemini runtime home".
 - **PATH lookup**: `houston-terminal-manager::provider::which_on_path`
-  walks each PATH directory. On Windows it checks
-  `.exe` / `.cmd` / `.bat` / `.ps1` variants BEFORE the bare filename
-  in each directory so npm-global CLIs (which ship both `<name>` —
-  Unix script — and `<name>.cmd` — Windows shim — in the same dir)
-  resolve to the executable shim instead of the unexecutable script.
-  Without that, `Command::new(...)` later fails with os error 193
-  ("%1 is not a valid Win32 application"). Inner pure helper
-  `which_in_dirs(command, iter)` is exposed for tests so the
-  per-platform priority can be verified without mutating
+  walks each PATH directory. On Windows it checks `.exe` / `.cmd` /
+  `.bat` variants BEFORE the bare filename in each directory so
+  npm-global CLIs (which ship both `<name>` — Unix script — and
+  `<name>.cmd` — Windows shim — in the same dir) resolve to the
+  executable shim instead of the unexecutable script. Without that,
+  `Command::new(...)` later fails with os error 193 ("%1 is not a valid
+  Win32 application"). Two guards keep the resolver from ever returning a
+  guaranteed-193 path (regression from issue #213): `.ps1` is NOT probed
+  (`CreateProcess` can't launch a PowerShell script directly, and Rust's
+  `Command` only wraps `.bat`/`.cmd` through cmd.exe), and the bare,
+  extensionless fallback is accepted only when the file is a real PE
+  image (`MZ` magic) — a bare file is almost always a Unix shim script.
+  Inner pure helper `which_in_dirs(command, iter)` is exposed for tests
+  so the per-platform priority can be verified without mutating
   process-global PATH.
 - **PTY**: `portable-pty` (used in `houston-terminal-manager::manager`)
   — ConPTY-backed on Windows 10+, no code change needed.
@@ -65,7 +70,7 @@ both.
 | Login-shell PATH probe | `houston-terminal-manager/src/claude_path.rs` | `/bin/zsh -l -c 'echo $PATH'`, fallback `/bin/bash -l`, `-i` | skipped — inherited process PATH is already the user PATH |
 | Common-install-dir probe | same | `~/.local/bin`, `/opt/homebrew/bin`, `/usr/local/bin`, `~/.cargo/bin`, `~/.composio`, nvm node dirs | `~\.cargo\bin`, `~\.composio`, `~\AppData\Roaming\npm`, `~\AppData\Local\Programs\claude` |
 | Command-exists check | same `is_command_available` | bare filename | bare + `.exe`/`.cmd`/`.bat`/`.ps1` variants |
-| Gemini CLI spawn | `houston-terminal-manager/src/gemini_runner.rs` + `houston-engine-core/src/sessions/provider_oneshot.rs::run_gemini` | bundled SEA per arch (`Resources/bin/gemini-<arch>/gemini`) | bundled binary not shipped in v1; falls back to user-installed gemini-cli on PATH (e.g. `npm i -g @google/gemini-cli`). Two Windows-specific quirks make this work: (a) `which_on_path` prefers `.exe`/`.cmd`/`.bat`/`.ps1` variants over the bare filename so the npm-global `.cmd` shim wins over the unexecutable Unix script that ships in the same dir (avoids os error 193, "%1 is not a valid Win32 application"); (b) `gemini_compatible_path` strips the `\\?\` extended-length prefix from canonicalized agent paths before they hit `--include-directories` because gemini-cli's Node-based `fs.realpathSync` parses each component and crashes with `EISDIR: illegal operation on a directory, lstat 'C:'`. If neither bundled nor PATH-installed, both call sites short-circuit with a platform-aware "not available yet" toast. UI also unlocks the chat-model dropdown when the locked provider has `cli_installed=false` (`chat-model-selector.tsx`). |
+| Gemini CLI spawn | `houston-terminal-manager/src/gemini_runner.rs` + `houston-engine-core/src/sessions/provider_oneshot.rs::run_gemini` | bundled SEA per arch (`Resources/bin/gemini-<arch>/gemini`) | bundled binary not shipped in v1; falls back to user-installed gemini-cli on PATH (e.g. `npm i -g @google/gemini-cli`). Two Windows-specific quirks make this work: (a) `which_on_path` prefers `.exe`/`.cmd`/`.bat` variants over the bare filename so the npm-global `.cmd` shim wins over the unexecutable Unix script that ships in the same dir (avoids os error 193, "%1 is not a valid Win32 application"; `.ps1` is not probed and a bare extensionless match must be a real PE — see the PATH-lookup note above); (b) `gemini_compatible_path` strips the `\\?\` extended-length prefix from canonicalized agent paths before they hit `--include-directories` because gemini-cli's Node-based `fs.realpathSync` parses each component and crashes with `EISDIR: illegal operation on a directory, lstat 'C:'`. If neither bundled nor PATH-installed, both call sites short-circuit with a platform-aware "not available yet" toast. UI also unlocks the chat-model dropdown when the locked provider has `cli_installed=false` (`chat-model-selector.tsx`). |
 
 ## Known gaps — Windows needs a follow-up
 


### PR DESCRIPTION
Fixes #213 — "Codex not working on Windows": clicking **Connect** on the OpenAI/Codex provider failed with

> `failed to spawn codex login: %1 is not a valid Win32 application. (os error 193)`

## Root cause (it's the PATH fallback, not the bundled binary)

I pulled the shipped v0.4.11 MSIs and verified the bundled codex is healthy:

| MSI | `bin\codex.exe` machine | runs? |
|-----|------------------------|-------|
| `Houston_0.4.11_x64_en-US.msi`   | `0x8664` (x64)   | ✅ `codex-cli 0.130.0`, exit 0 |
| `Houston_0.4.11_arm64_en-US.msi` | `0xAA64` (ARM64) | ✅ valid PE |

Both sit at `<install>\bin\codex.exe`, and the engine (run from the install root) resolves them via `bundled_codex_path()`. So a standard install does **not** hit 193 from the bundled binary.

`os error 193` (`ERROR_BAD_EXE_FORMAT`) comes from the fallback: when `bundled_codex_path()` is `None` (pre-v0.4.10 build — codex Win bundling landed in v0.4.10, x64 MSI jumped 174MB→246MB — or the unsigned exe was removed by AV), `provider::resolve()` calls `which_on_path("codex")`, which could return:

- a `.ps1` (Rust's `Command` launches PEs directly and wraps `.bat`/`.cmd` via cmd.exe, but **never** routes `.ps1` through PowerShell), or
- a bare extensionless Unix shim script (npm ships `codex` next to `codex.cmd`).

Both spawn-fail with exactly os error 193. Confirmed empirically via `CreateProcess`:

```
bare 'codex' (Unix script): Win32Exception native=193  ... not a valid application for this OS
'codex.ps1':                Win32Exception native=193
'codex.cmd':                OK exit=0
```

## Fix

- **`provider/resolve.rs`** — drop `.ps1` from the Windows extension probe (returning it is a guaranteed 193) and guard the bare-name fallback with an `MZ` PE-magic check, so the resolver never hands a caller a path that can't spawn. Real bare PEs still resolve; Unix shim scripts are skipped.
- **`provider/mod.rs`** — when a login/logout spawn fails with os error 193, surface an actionable message (names the binary, points at wrong-arch / corruption, suggests reinstall) instead of the raw Win32 string, so any future 193 is diagnosable from the Report-bug log.

## Tests

New unit tests, all in the two files this PR changes:

**`resolve.rs`** (`houston-terminal-manager`):
- `which_in_dirs_falls_back_to_bare_pe_on_windows` — a bare (extensionless) file with `MZ` magic still resolves.
- `which_in_dirs_skips_bare_unix_script_on_windows` — a bare npm `#!/usr/bin/env node` shim is skipped (would otherwise 193).
- `which_in_dirs_ignores_ps1_on_windows` — a `.ps1`-only candidate resolves to `None`.

**`provider/mod.rs`** (`houston-engine-core`):
- `bad_exe_message_decorates_193` — os error 193 gets the actionable, path-naming message.
- `bad_exe_message_is_none_for_non_193_errors` — every other error keeps the caller's existing wording.

Run just this PR's tests:

```
cargo test -p houston-terminal-manager which_in_dirs
cargo test -p houston-engine-core bad_exe_message
```

### Pre-existing Windows-host test failures (NOT from this PR)

Running the full `houston-engine-core` suite on a **Windows dev box** fails 7 tests that have nothing to do with this change. They assume a Unix dev environment, predate this branch, and fail identically on `main`. None touch the two files this PR changes, and none are this PR's own tests:

| Test | Unix assumption |
|------|-----------------|
| `worktree::run_shell_echo`, `worktree::run_shell_nonzero_exits_as_bad_request` | `run_shell` spawns `Command::new("sh")` with `echo` / `false` — no `sh` on the Windows PATH |
| `provider::login_relay::insert_session_rejects_duplicate`, `provider::login_relay::cancel_login_kills_session_and_emits_benign_completion` | spawn `Command::new("sleep")` to hold a live `ChildStdin` — no `sleep.exe` on Windows |
| `skills::create_then_list_and_load`, `skills::delete_removes_symlink_and_dir` | `ensure_claude_symlink` uses `std::os::unix::fs::symlink`; the symlink isn't created on Windows so the `symlink_metadata()` assert fails |
| `attachments::commit_upload_writes_manifest_and_prompt_path` | path-separator assertion (`\` vs `/`) |

These are a Windows-CI gap, tracked separately (gate with `#[cfg(unix)]`, or detect/skip when `sh`/`sleep` are absent). Not a regression from this PR.

## Reproduce / verify the fix

### Fastest — unit tests on a Windows host
The fix's resolution logic has `#[cfg(windows)]` tests that exercise the real code path; on a Windows host they run for real:

```
cargo test -p houston-terminal-manager which_in_dirs
cargo test -p houston-engine-core bad_exe_message
```

Green = the resolver never returns a non-PE, and a genuine 193 is decorated.

### Optional — prove a non-PE really 193s
Confirm the failure mode the tests model is real:

```powershell
Set-Content -Path "$env:TEMP\codex" -Value "#!/usr/bin/env node`nconsole.log(1)" -NoNewline
$p = New-Object System.Diagnostics.ProcessStartInfo
$p.FileName = "$env:TEMP\codex"; $p.UseShellExecute = $false
try { [System.Diagnostics.Process]::Start($p) } catch { $_.Exception.Message }
# expect: "...is not a valid Win32 application" (os error 193)
```

### End-to-end — the real #213 path
1. Use a Houston build with **no** bundled codex (a pre-v0.4.10 build, or delete `<install>\bin\codex.exe` from a current install).
2. Put a non-`.exe`/`.cmd` `codex` **early** on PATH — a bare Unix shim, or a lone `codex.ps1`. (An npm-global codex install creates exactly this.)
3. Open the OpenAI/Codex provider → click **Connect**.

- **Before this fix:** `failed to spawn codex login: %1 is not a valid Win32 application. (os error 193)`.
- **After this fix:** the resolver skips the non-PE and falls through to the clean "not installed" path instead of 193. If a genuinely wrong-arch / corrupt `codex.exe` is present, you instead get the new actionable message that names the binary path and suggests a reinstall.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
