### PR TITLE
fix(composio): force-logout migration + manual sign-out button

### DIFF
--- a/app/src/components/tabs/integrations-view.tsx
+++ b/app/src/components/tabs/integrations-view.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { ConfirmDialog } from "@houston-ai/core";
 import {
   useConnections,
   useConnectedToolkits,
@@ -23,11 +25,14 @@ interface IntegrationsViewProps {
 }
 
 export function IntegrationsView({ title }: IntegrationsViewProps) {
+  const { t } = useTranslation("integrations");
   const { data: result, isLoading: loading, refetch } = useConnections();
   const reset = useResetConnections();
   const auth = useComposioAuth(() => reset());
   const [installing, setInstalling] = useState(false);
   const [installError, setInstallError] = useState<string | null>(null);
+  const [signOutOpen, setSignOutOpen] = useState(false);
+  const [signingOut, setSigningOut] = useState(false);
 
   const isSignedIn = result?.status === "ok";
   const { data: connectedList } = useConnectedToolkits(isSignedIn);
@@ -53,13 +58,40 @@ export function IntegrationsView({ title }: IntegrationsViewProps) {
     }
   }, [reset]);
 
+  const handleSignOut = useCallback(async () => {
+    setSigningOut(true);
+    try {
+      await tauriConnections.logout();
+      await reset();
+      setSignOutOpen(false);
+    } finally {
+      setSigningOut(false);
+    }
+  }, [reset]);
+
   return (
     <div className="h-full overflow-auto">
       <div className="max-w-3xl mx-auto w-full px-6 py-6">
-        {title && (
-          <h1 className="text-[28px] font-normal text-foreground mb-6">
-            {title}
-          </h1>
+        {(title || isSignedIn) && (
+          <div className="flex items-center justify-between mb-6 min-h-[36px]">
+            {title ? (
+              <h1 className="text-[28px] font-normal text-foreground">
+                {title}
+              </h1>
+            ) : (
+              <span />
+            )}
+            {isSignedIn && (
+              <button
+                type="button"
+                onClick={() => setSignOutOpen(true)}
+                disabled={signingOut}
+                className="text-xs text-muted-foreground hover:text-foreground underline underline-offset-4 disabled:opacity-50 disabled:no-underline"
+              >
+                {signingOut ? t("signOut.loading") : t("signOut.button")}
+              </button>
+            )}
+          </div>
         )}
 
         {loading && <LoadingState />}
@@ -98,6 +130,19 @@ export function IntegrationsView({ title }: IntegrationsViewProps) {
         state={auth.state}
         onClose={auth.close}
         onReopenBrowser={auth.reopenBrowser}
+      />
+
+      <ConfirmDialog
+        open={signOutOpen}
+        onOpenChange={(open) => {
+          if (!signingOut) setSignOutOpen(open);
+        }}
+        title={t("signOut.confirmTitle")}
+        description={t("signOut.confirmBody")}
+        confirmLabel={t("signOut.confirmAction")}
+        cancelLabel={t("signOut.cancel")}
+        variant="destructive"
+        onConfirm={handleSignOut}
       />
     </div>
   );

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -404,6 +404,7 @@ export const tauriConnections = {
     }),
   completeLogin: (cliKey: string) =>
     call<void>("complete_composio_login", () => getEngine().composioCompleteLogin(cliKey)),
+  logout: () => call<void>("logout_composio", () => getEngine().composioLogout()),
   isCliInstalled: () =>
     call<boolean>("is_composio_cli_installed", () => getEngine().composioCliInstalled()),
   installCli: () => call<void>("install_composio_cli", () => getEngine().composioInstallCli()),

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -27,6 +27,14 @@
     "manageOn": "Manage {{name}}",
     "dotAria": "Connected"
   },
+  "signOut": {
+    "button": "Sign out",
+    "loading": "Signing out…",
+    "confirmTitle": "Sign out of Composio?",
+    "confirmBody": "You'll need to sign in again and reconnect any apps you use. This won't uninstall the provider.",
+    "confirmAction": "Sign out",
+    "cancel": "Cancel"
+  },
   "browse": {
     "title": "Browse all apps",
     "count_one": "{{count}} app",

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -27,6 +27,14 @@
     "manageOn": "Gestionar {{name}}",
     "dotAria": "Conectado"
   },
+  "signOut": {
+    "button": "Cerrar sesión",
+    "loading": "Cerrando sesión…",
+    "confirmTitle": "¿Cerrar sesión de Composio?",
+    "confirmBody": "Tendrás que iniciar sesión de nuevo y reconectar las apps que uses. Esto no desinstala el proveedor.",
+    "confirmAction": "Cerrar sesión",
+    "cancel": "Cancelar"
+  },
   "browse": {
     "title": "Explorar todas las apps",
     "count_one": "{{count}} app",

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -27,6 +27,14 @@
     "manageOn": "Gerenciar {{name}}",
     "dotAria": "Conectado"
   },
+  "signOut": {
+    "button": "Sair",
+    "loading": "Saindo…",
+    "confirmTitle": "Sair do Composio?",
+    "confirmBody": "Você vai precisar entrar de novo e reconectar os apps que usa. Isso não desinstala o provedor.",
+    "confirmAction": "Sair",
+    "cancel": "Cancelar"
+  },
   "browse": {
     "title": "Ver todos os apps",
     "count_one": "{{count}} app",

--- a/engine/houston-composio/src/cli.rs
+++ b/engine/houston-composio/src/cli.rs
@@ -191,9 +191,20 @@ pub async fn complete_login(cli_key: &str) -> Result<(), String> {
     }
 }
 
-/// Log out of Composio. Best-effort; silently ignores CLI errors.
+/// Log out of Composio. Shells out to `composio logout` (no flags —
+/// the subcommand takes none and rejects `-y` with exit 1 + usage
+/// text). Errors surface to the caller so the UI can toast on failure
+/// instead of falsely reporting success.
 pub async fn logout() -> Result<(), String> {
-    let _ = run_cli(&["logout", "-y"]).await?;
+    let output = run_cli(&["logout"]).await?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(format!(
+            "composio logout failed (exit {}): {}",
+            output.status,
+            if stderr.is_empty() { "<no stderr>" } else { &stderr }
+        ));
+    }
     Ok(())
 }
 

--- a/engine/houston-composio/src/commands.rs
+++ b/engine/houston-composio/src/commands.rs
@@ -37,6 +37,14 @@ pub async fn complete_composio_login(cli_key: String) -> Result<(), String> {
     cli::complete_login(&cli_key).await
 }
 
+/// Log the user out of Composio. Shells out to `composio logout -y`,
+/// which clears `~/.composio/user_data.json`. After this the next
+/// `status()` returns `NeedsAuth` and the UI snaps back to the sign-in
+/// empty state.
+pub async fn logout_composio() -> Result<(), String> {
+    cli::logout().await
+}
+
 /// Start the flow to link an external app to the currently-signed-in account.
 pub async fn connect_composio_app(toolkit: String) -> Result<StartLinkResponse, String> {
     cli::start_link(&toolkit).await

--- a/engine/houston-composio/src/lifecycle.rs
+++ b/engine/houston-composio/src/lifecycle.rs
@@ -18,7 +18,7 @@
 //! Emits `HoustonEvent::ComposioCliReady` on success so the frontend
 //! invalidates the connections query and the integrations tab refreshes.
 
-use crate::install;
+use crate::{cli, install};
 use houston_db::db::Database;
 use houston_ui_events::{DynEventSink, HoustonEvent};
 
@@ -26,12 +26,29 @@ use houston_ui_events::{DynEventSink, HoustonEvent};
 /// ensured the standalone CLI. Skipped entirely for bundled builds.
 const PREF_CLI_VERSION: &str = "composio_cli_houston_version";
 
+/// Marker preference set the first time the forced-logout migration
+/// ran successfully. Existence of this key means "we already kicked
+/// every user out once on this version of the migration, don't do it
+/// again." Bump the suffix (`_v3`, `_v4`, …) for any future incident
+/// that requires another mass logout — reusing the same key would
+/// silently skip everyone.
+///
+/// `_v2` because the first cut shipped with `composio logout -y`,
+/// which the CLI rejects with exit 1 + usage text. Old wrapper
+/// swallowed the exit code so the migration reported success without
+/// actually logging anyone out. Bumping to `_v2` re-triggers the
+/// migration with the fixed wrapper on any machine that still has
+/// the poisoned `_v1` marker.
+const PREF_FORCED_LOGOUT_V2: &str = "composio_forced_logout_v2";
+
 /// Current Houston version (read from Cargo.toml at compile time).
 const APP_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// Run the full lifecycle check: install if missing, upgrade if Houston
 /// version changed. Emits events so the frontend reacts.
 pub async fn ensure_and_upgrade(sink: DynEventSink, db: Database) {
+    forced_logout(&db).await;
+
     if install::is_bundled() {
         tracing::info!(
             "[composio:lifecycle] bundled CLI detected at {} — skipping install/upgrade",
@@ -95,6 +112,56 @@ pub async fn ensure_and_upgrade(sink: DynEventSink, db: Database) {
     }
 
     sink.emit(HoustonEvent::ComposioCliReady);
+}
+
+/// One-time forced logout, gated by [`PREF_FORCED_LOGOUT_V2`].
+///
+/// Runs before the bundled / standalone branches so every existing
+/// user gets signed out exactly once on the first launch of the
+/// release that ships this migration. If the logout shell-out fails
+/// we leave the marker unset so the next launch retries — better to
+/// re-run the (idempotent) `composio logout` once more than to leave
+/// a user still signed in believing they're not.
+async fn forced_logout(db: &Database) {
+    let already_done = db
+        .get_preference(PREF_FORCED_LOGOUT_V2)
+        .await
+        .ok()
+        .flatten()
+        .is_some();
+    if already_done {
+        return;
+    }
+
+    if !install::is_installed() {
+        tracing::info!(
+            "[composio:lifecycle] forced logout: CLI not installed, nothing to clear"
+        );
+        if let Err(e) = db.set_preference(PREF_FORCED_LOGOUT_V2, "1").await {
+            tracing::warn!(
+                "[composio:lifecycle] failed to persist forced-logout marker: {e}"
+            );
+        }
+        return;
+    }
+
+    tracing::info!("[composio:lifecycle] running forced logout (one-time migration)");
+    match cli::logout().await {
+        Ok(()) => {
+            tracing::info!("[composio:lifecycle] forced logout succeeded");
+            if let Err(e) = db.set_preference(PREF_FORCED_LOGOUT_V2, "1").await {
+                tracing::warn!(
+                    "[composio:lifecycle] failed to persist forced-logout marker: {e} \
+                     (migration will retry next launch)"
+                );
+            }
+        }
+        Err(e) => {
+            tracing::warn!(
+                "[composio:lifecycle] forced logout failed: {e} — will retry next launch"
+            );
+        }
+    }
 }
 
 /// Run `composio upgrade` via the same sync-Command + spawn_blocking

--- a/engine/houston-engine-server/src/routes/composio.rs
+++ b/engine/houston-engine-server/src/routes/composio.rs
@@ -26,6 +26,7 @@ pub fn router() -> Router<Arc<ServerState>> {
         .route("/composio/cli", post(install_cli))
         .route("/composio/login", post(start_login))
         .route("/composio/login/complete", post(complete_login))
+        .route("/composio/logout", post(logout))
         .route("/composio/apps", get(list_apps))
         .route(
             "/composio/connections",
@@ -86,6 +87,10 @@ async fn complete_login(
     inner::complete_composio_login(req.cli_key)
         .await
         .map_err(lift)
+}
+
+async fn logout(State(_st): State<Arc<ServerState>>) -> Result<(), ApiError> {
+    inner::logout_composio().await.map_err(lift)
 }
 
 async fn list_apps(State(_st): State<Arc<ServerState>>) -> Json<Vec<ComposioAppEntry>> {

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -753,6 +753,9 @@ export class HoustonClient {
   composioCompleteLogin(cliKey: string): Promise<void> {
     return this.request("POST", "/composio/login/complete", { cliKey });
   }
+  composioLogout(): Promise<void> {
+    return this.request("POST", "/composio/logout");
+  }
   composioListApps(): Promise<ComposioAppEntry[]> {
     return this.request("GET", "/composio/apps");
   }


### PR DESCRIPTION
## Summary
- One-shot startup migration (`composio_forced_logout_v2` preference key) runs `composio logout` so every existing user gets signed out exactly once on first launch of this release. Future incidents bump the suffix; reusing the key would silently skip everyone.
- New Sign-out button in the top-right of the Integrations view, with a destructive confirm dialog. On confirm → `POST /v1/composio/logout` → query reset → UI snaps to the "Sign in" empty state.
- Fixed `cli::logout()` — previously called `composio logout -y` (the CLI rejects `-y` with exit 1 + usage text) AND discarded the exit code with `let _ = run_cli(...)`, so non-zero exits silently reported success. Now drops `-y`, checks `output.status`, surfaces real errors.

## Files touched
- `engine/houston-composio/src/{cli,commands,lifecycle}.rs`
- `engine/houston-engine-server/src/routes/composio.rs` — `POST /composio/logout`
- `ui/engine-client/src/client.ts` — `composioLogout()`
- `app/src/lib/tauri.ts` — `tauriConnections.logout()`
- `app/src/components/tabs/integrations-view.tsx` — header button + confirm dialog
- `app/src/locales/{en,es,pt}/integrations.json` — `signOut.*` keys

## Test plan
- [x] `cargo test -p houston-composio` — 14 passed
- [x] `cargo build -p houston-engine-server` — clean
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm check-locales` — en/es/pt in sync
- [x] Real-CLI sanity check: bare `composio logout` exits 0 (with `-y` exits 1 + usage). Verified against the bundled `~/.composio/composio`.