### PR TITLE
feat(settings): move Commands into Settings as Keyboard shortcuts

### DIFF
--- a/app/src/components/settings/sections/shortcuts.tsx
+++ b/app/src/components/settings/sections/shortcuts.tsx
@@ -1,0 +1,101 @@
+import { useTranslation } from "react-i18next";
+import { Kbd, KbdGroup } from "@houston-ai/core";
+import { shortcutParts, type ShortcutAction } from "../../../lib/shortcuts";
+
+interface Row {
+  action?: ShortcutAction;
+  /** Used for groups of glyphs that don't map to a single action (e.g. arrows). */
+  parts?: string[][];
+  labelKey: string;
+}
+
+const NAV_ROWS: Row[] = [
+  { action: "palette", labelKey: "shell:cheatsheet.rows.palette" },
+  { action: "missionControl", labelKey: "shell:cheatsheet.rows.missionControl" },
+  { action: "newMission", labelKey: "shell:cheatsheet.rows.newMission" },
+];
+
+const CYCLE_ROWS: Row[] = [
+  { action: "prevAgent", labelKey: "shell:cheatsheet.rows.prevAgent" },
+  { action: "nextAgent", labelKey: "shell:cheatsheet.rows.nextAgent" },
+  {
+    parts: [
+      shortcutParts("boardUp"),
+      shortcutParts("boardDown"),
+      shortcutParts("boardLeft"),
+      shortcutParts("boardRight"),
+    ],
+    labelKey: "shell:cheatsheet.rows.boardNavigate",
+  },
+  { action: "boardOpen", labelKey: "shell:cheatsheet.rows.boardOpen" },
+  { parts: [["Esc"]], labelKey: "shell:cheatsheet.rows.panelEscape" },
+];
+
+const HELP_ROWS: Row[] = [
+  { action: "cheatsheet", labelKey: "shell:cheatsheet.rows.cheatsheet" },
+];
+
+function RowKbd({ row }: { row: Row }) {
+  const groups = row.action
+    ? [shortcutParts(row.action)]
+    : (row.parts ?? []);
+  return (
+    <div className="flex items-center gap-1">
+      {groups.map((parts, i) => (
+        <KbdGroup key={i}>
+          {parts.map((p) => (
+            <Kbd key={p}>{p}</Kbd>
+          ))}
+        </KbdGroup>
+      ))}
+    </div>
+  );
+}
+
+function Section({
+  title,
+  rows,
+  t,
+}: {
+  title: string;
+  rows: Row[];
+  t: (k: string) => string;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        {title}
+      </div>
+      <div className="flex flex-col">
+        {rows.map((r) => (
+          <div
+            key={r.labelKey}
+            className="flex items-center justify-between rounded-md py-2"
+          >
+            <span className="text-sm text-foreground">{t(r.labelKey)}</span>
+            <RowKbd row={r} />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function ShortcutsSection() {
+  const { t } = useTranslation(["settings", "shell"]);
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-1">
+        {t("settings:shortcuts.title")}
+      </h2>
+      <p className="text-sm text-muted-foreground mb-6">
+        {t("settings:shortcuts.description")}
+      </p>
+      <div className="flex flex-col gap-6">
+        <Section title={t("shell:cheatsheet.sections.navigation")} rows={NAV_ROWS} t={t} />
+        <Section title={t("shell:cheatsheet.sections.cycle")} rows={CYCLE_ROWS} t={t} />
+        <Section title={t("shell:cheatsheet.sections.help")} rows={HELP_ROWS} t={t} />
+      </div>
+    </section>
+  );
+}

--- a/app/src/components/settings/settings-view.tsx
+++ b/app/src/components/settings/settings-view.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Spinner } from "@houston-ai/core";
-import { User, Smartphone, Folder, Bot, Bug, FileText, UserCircle } from "lucide-react";
+import { User, Smartphone, Folder, Bot, Bug, FileText, Keyboard, UserCircle } from "lucide-react";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { useUIStore } from "../../stores/ui";
 import {
@@ -16,6 +16,7 @@ type SettingsSectionId =
   | "userContext"
   | "provider"
   | "phone"
+  | "shortcuts"
   | "reportBug";
 import { AccountSection, useAccountAvailable } from "./sections/account";
 import { ConnectPhoneSection } from "./sections/connect-phone";
@@ -30,6 +31,7 @@ import { LanguageSection } from "./sections/language";
 import { AppearanceSection } from "./sections/appearance";
 import { DangerSection } from "./sections/danger";
 import { ReportBugSection } from "./sections/report-bug";
+import { ShortcutsSection } from "./sections/shortcuts";
 
 export function SettingsView() {
   const { t } = useTranslation(["settings", "common"]);
@@ -69,6 +71,7 @@ export function SettingsView() {
       },
       { id: "provider", label: t("settings:nav.provider"), icon: Bot },
       { id: "phone", label: t("settings:nav.phone"), icon: Smartphone, beta: true },
+      { id: "shortcuts", label: t("settings:nav.shortcuts"), icon: Keyboard },
       { id: "reportBug", label: t("settings:nav.reportBug"), icon: Bug },
     );
     return list;
@@ -125,6 +128,7 @@ export function SettingsView() {
             )}
             {activeVisible === "provider" && <ProviderSection />}
             {activeVisible === "phone" && <ConnectPhoneSection />}
+            {activeVisible === "shortcuts" && <ShortcutsSection />}
             {activeVisible === "reportBug" && <ReportBugSection />}
           </div>
         )}

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -1,7 +1,7 @@
 import { useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
-import { LayoutDashboard, Blend, Command, Settings } from "lucide-react";
-import { ConfirmDialog, Kbd, KbdGroup } from "@houston-ai/core";
+import { LayoutDashboard, Blend, Settings } from "lucide-react";
+import { ConfirmDialog } from "@houston-ai/core";
 import { AppSidebar, WorkspaceSwitcher } from "@houston-ai/layout";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { useAgentStore } from "../../stores/agents";
@@ -12,7 +12,6 @@ import { CreateWorkspaceDialog } from "./workspace-dialog";
 import { useAgentActivitySummaries } from "./use-agent-activity-summaries";
 import { buildAgentSidebarItems } from "./agent-sidebar-items";
 import { orderAgents } from "../../lib/agent-order";
-import { shortcutParts } from "../../lib/shortcuts";
 import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
 
 export function Sidebar({ children }: { children: ReactNode }) {
@@ -129,19 +128,6 @@ export function Sidebar({ children }: { children: ReactNode }) {
             icon: <Blend className="h-4 w-4" />,
             onClick: () => setViewMode("connections"),
             dataAttrs: { "data-tour-target": "nav-connections" },
-          },
-          {
-            id: "commands",
-            label: t("shell:sidebar.commands"),
-            icon: <Command className="h-4 w-4" />,
-            onClick: () => useUIStore.getState().setPaletteOpen(true),
-            trailing: (
-              <KbdGroup>
-                {shortcutParts("palette").map((p) => (
-                  <Kbd key={p}>{p}</Kbd>
-                ))}
-              </KbdGroup>
-            ),
           },
           {
             id: "settings",

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -7,6 +7,7 @@
     "userContext": "User context",
     "provider": "AI provider",
     "phone": "Connect phone",
+    "shortcuts": "Keyboard shortcuts",
     "reportBug": "Report bug"
   },
   "account": {
@@ -81,6 +82,10 @@
     "confirmTitle": "Delete \"{{name}}\"?",
     "confirmDescription": "This will permanently delete this workspace and all its agents. This cannot be undone.",
     "confirmLabel": "Delete"
+  },
+  "shortcuts": {
+    "title": "Keyboard shortcuts",
+    "description": "Run Houston without touching the mouse."
   },
   "reportBug": {
     "title": "Report bug",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -2,7 +2,6 @@
   "sidebar": {
     "missionControl": "Mission Control",
     "integrations": "Integrations",
-    "commands": "Commands",
     "settings": "Settings",
     "yourAgents": "Your Agents",
     "selectWorkspace": "Select workspace",

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -7,6 +7,7 @@
     "userContext": "Contexto del usuario",
     "provider": "Proveedor de IA",
     "phone": "Conectar celular",
+    "shortcuts": "Atajos de teclado",
     "reportBug": "Reportar bug"
   },
   "account": {
@@ -81,6 +82,10 @@
     "confirmTitle": "¿Eliminar \"{{name}}\"?",
     "confirmDescription": "Esto eliminará de forma permanente este espacio de trabajo y todos sus agentes. No se puede deshacer.",
     "confirmLabel": "Eliminar"
+  },
+  "shortcuts": {
+    "title": "Atajos de teclado",
+    "description": "Usa Houston sin tocar el mouse."
   },
   "reportBug": {
     "title": "Reportar bug",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -2,7 +2,6 @@
   "sidebar": {
     "missionControl": "Centro de misiones",
     "integrations": "Integraciones",
-    "commands": "Comandos",
     "settings": "Configuración",
     "yourAgents": "Tus agentes",
     "selectWorkspace": "Elige un espacio de trabajo",

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -7,6 +7,7 @@
     "userContext": "Contexto do usuário",
     "provider": "Provedor de IA",
     "phone": "Conectar celular",
+    "shortcuts": "Atalhos de teclado",
     "reportBug": "Reportar bug"
   },
   "account": {
@@ -81,6 +82,10 @@
     "confirmTitle": "Excluir \"{{name}}\"?",
     "confirmDescription": "Isso exclui este espaço de trabalho e todos os seus agentes de forma permanente. Não dá para desfazer.",
     "confirmLabel": "Excluir"
+  },
+  "shortcuts": {
+    "title": "Atalhos de teclado",
+    "description": "Use o Houston sem tocar no mouse."
   },
   "reportBug": {
     "title": "Reportar bug",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -2,7 +2,6 @@
   "sidebar": {
     "missionControl": "Central de missões",
     "integrations": "Integrações",
-    "commands": "Comandos",
     "settings": "Configurações",
     "yourAgents": "Seus agentes",
     "selectWorkspace": "Escolha um espaço de trabalho",


### PR DESCRIPTION
## Summary
- Removes the **Commands** entry from the main sidebar.
- Adds a **Keyboard shortcuts** item under Settings that renders the shortcut list inline in the right pane (label on the left, kbd chips on the right), grouped Navigation / Cycle / Help.
- Same data the ⌘K cheatsheet dialog uses, just promoted to a settings page so it behaves like every other settings item (no modal).
- en / es / pt locales updated (added \`settings:shortcuts.title\` + \`description\`, removed dead \`shell:sidebar.commands\`).

## Test plan
- [ ] Open Settings → "Keyboard shortcuts" row highlights, right pane shows the grouped shortcut list with kbd chips.
- [ ] Main sidebar no longer shows "Commands".
- [ ] ⌘K still opens the command palette (handled by the global shortcut, unaffected).
- [ ] \`pnpm tsc --noEmit\` clean, \`pnpm check-locales\` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)