### PR TITLE
docs(privacy): marketing-email consent + unsubscribe paths

### DIFF
--- a/website/src/_includes/footer-landing.njk
+++ b/website/src/_includes/footer-landing.njk
@@ -40,6 +40,7 @@
     <span style="font-size: 12px; color: var(--gray-400); display: flex; gap: 16px;">
       <a href="/privacy/" style="color: var(--gray-500);">Privacy Policy</a>
       <a href="/terms/" style="color: var(--gray-500);">Terms of Service</a>
+      <a href="mailto:hello@gethouston.ai?subject=Unsubscribe&amp;body=Please%20remove%20this%20email%20address%20from%20Houston%20marketing." style="color: var(--gray-500);">Unsubscribe</a>
     </span>
   </div>
 </footer>

--- a/website/src/index.html
+++ b/website/src/index.html
@@ -2225,6 +2225,7 @@ visionPath: "vision/index.html"
       <a id="dl-btn" class="btn btn-primary btn-lg btn-disabled"><svg viewBox="0 0 384 512" fill="currentColor" width="16" height="16"><path d="M318.7 268.7c-.2-36.7 16.4-64.4 50-84.8-18.8-26.9-47.2-41.7-84.7-44.6-35.5-2.8-74.3 20.7-88.5 20.7-15 0-49.4-19.7-76.4-19.7C63.3 141.2 4 184.8 4 273.5q0 39.3 14.4 81.2c12.8 36.7 59 126.7 107.2 125.2 25.2-.6 43-17.9 75.8-17.9 31.8 0 48.3 17.9 76.4 17.9 48.6-.7 90.4-82.5 102.6-119.3-65.2-30.7-61.7-90-61.7-91.9zm-56.6-164.2c27.3-32.4 24.8-61.9 24-72.5-24.1 1.4-52 16.4-67.9 34.9-17.5 19.8-27.8 44.3-25.6 71.9 26.1 2 49.9-11.4 69.5-34.3z"/></svg> Download for Mac</a>
       <span class="dl-divider">or join our waiting list to get access</span>
       <a id="dl-waitlist" href="https://forms.gle/ac24qrKSufYvfudt8" target="_blank" rel="noopener noreferrer" class="btn btn-secondary btn-lg">Join the waiting list</a>
+      <p style="font-size: 11px; color: var(--gray-500); line-height: 1.5; margin: 10px 0 0; text-align: center;">By joining you agree to receive product updates from Houston. Unsubscribe anytime. See our <a href="/privacy/" style="color: var(--gray-600); text-decoration: underline;">Privacy Policy</a>.</p>
     </div>
     <details class="dl-skip" id="dl-skip">
       <summary>Want to skip the waitlist?</summary>
@@ -2250,6 +2251,7 @@ visionPath: "vision/index.html"
       <a id="dl-windows-arm64-btn" class="btn btn-secondary btn-lg btn-disabled"><svg viewBox="0 0 448 512" fill="currentColor" width="16" height="16"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg> Windows (ARM64 / Surface, Snapdragon)</a>
       <span class="dl-divider">or join our waiting list to get access</span>
       <a id="dl-windows-waitlist" href="https://forms.gle/ac24qrKSufYvfudt8" target="_blank" rel="noopener noreferrer" class="btn btn-secondary btn-lg">Join the waiting list</a>
+      <p style="font-size: 11px; color: var(--gray-500); line-height: 1.5; margin: 10px 0 0; text-align: center;">By joining you agree to receive product updates from Houston. Unsubscribe anytime. See our <a href="/privacy/" style="color: var(--gray-600); text-decoration: underline;">Privacy Policy</a>.</p>
     </div>
     <details class="dl-skip" id="dl-windows-skip">
       <summary>Not sure which one to pick?</summary>

--- a/website/src/privacy/index.html
+++ b/website/src/privacy/index.html
@@ -149,7 +149,7 @@ visionPath: "../vision/index.html"
   <div class="eyebrow">Legal</div>
   <h1>Privacy Policy</h1>
   <div class="meta-row">
-    Effective April 25, 2026 · Last updated April 25, 2026
+    Effective April 25, 2026 · Last updated May 26, 2026
   </div>
 
   <p class="lead">
@@ -217,10 +217,31 @@ visionPath: "../vision/index.html"
     <li>Diagnose problems, fix bugs, and improve performance and reliability.</li>
     <li>Understand how the product is used in aggregate so we can prioritize what to build.</li>
     <li>Communicate with you about updates, security alerts, and support requests.</li>
+    <li>Send you product announcements, release notes, tips, and other marketing messages if you have given us your email (see <a href="#marketing">section 3.1</a>). You can opt out at any time.</li>
     <li>Comply with legal obligations and enforce our <a href="/terms/">Terms of Service</a>.</li>
   </ul>
   <p>
     We do not sell your personal information. We do not use the contents of your agent files, prompts, or messages to train our own models.
+  </p>
+
+  <h3 id="marketing">3.1 Marketing and product updates</h3>
+  <p>
+    If you join the Houston waiting list, sign up for an account, or otherwise share your email with us, we may send you product announcements, release notes, tips on getting more out of Houston, occasional case studies, and other product-related communications. We treat the act of giving us your email through one of these channels as your consent to receive these messages (GDPR Art. 6(1)(a), LGPD Art. 7(I), CASL implied consent through inquiry, CAN-SPAM commercial messaging).
+  </p>
+  <p>
+    What we will not do:
+  </p>
+  <ul>
+    <li>Sell, rent, or trade your email address.</li>
+    <li>Share it with partners for their own marketing.</li>
+    <li>Send you messages on behalf of a third party.</li>
+    <li>Hide the unsubscribe link or make you log in to opt out.</li>
+  </ul>
+  <p>
+    <strong>How to unsubscribe.</strong> Every marketing email contains a one-click unsubscribe link in the footer. You can also reply with the word "unsubscribe" or email <a href="mailto:hello@gethouston.ai?subject=Unsubscribe">hello@gethouston.ai</a> at any time and we will remove you within a few days. Unsubscribing from marketing does not affect transactional messages you need in order to use Houston (security alerts, billing receipts, account notices, replies to your support requests).
+  </p>
+  <p>
+    <strong>Legal basis (EEA / UK / Brazil users).</strong> We process your email for marketing on the basis of your consent. You can withdraw consent at any time as described above; withdrawal does not affect the lawfulness of processing carried out before the withdrawal.
   </p>
 
   <h2 id="share">4. When we share information</h2>
@@ -273,6 +294,7 @@ visionPath: "../vision/index.html"
     <li><strong>Port</strong> your information to another service in a structured, machine-readable format.</li>
     <li><strong>Object</strong> to or <strong>restrict</strong> certain processing.</li>
     <li><strong>Withdraw consent</strong> where we rely on consent as the basis for processing.</li>
+    <li><strong>Opt out of marketing email</strong> at any time, via the unsubscribe link in any message, by replying "unsubscribe", or by emailing us. See <a href="#marketing">section 3.1</a>.</li>
     <li><strong>Lodge a complaint</strong> with your local data-protection authority.</li>
   </ul>
   <p>


### PR DESCRIPTION
## Summary

Adds the legal scaffolding needed to run real marketing email without friction or legal exposure.

- **Privacy policy** — new section 3.1 covering marketing/product updates. Names the consent basis (GDPR Art. 6(1)(a), LGPD Art. 7(I), CASL implied consent, CAN-SPAM); lists what we will not do (sell/rent/share/hide opt-out); spells out three unsubscribe paths (one-click link, reply "unsubscribe", email). Adds a matching bullet in Use of Data (§3) and in Rights (§9). "Last updated" bumped to May 26, 2026.
- **Footer** — Unsubscribe mailto added next to Privacy / Terms on every landing page.
- **Waitlist CTAs** — small disclosure under the Join button in both Mac and Windows modals. The click itself is now informed affirmative consent, with link to the privacy policy.

Deliberately skipped (would add friction without legal upgrade): cookie banner, checkbox on the Google Form, double opt-in.

## Files

- `website/src/privacy/index.html`
- `website/src/_includes/footer-landing.njk`
- `website/src/index.html`

## Test plan

- [x] `npx @11ty/eleventy` builds cleanly (14 files written, 0 errors)
- [ ] Visual check `/privacy/` renders the new 3.1 block and TOC unchanged
- [ ] Footer Unsubscribe link opens the user's mail client with subject + body prefilled
- [ ] Waitlist modal disclosure copy renders on Mac + Windows variants