### PR TITLE
ci: auto-deploy website to Cloudflare Pages

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,0 +1,52 @@
+name: Website Deploy
+
+# Builds the Eleventy site in website/ and deploys it to Cloudflare Pages
+# (project: houston-site). Runs automatically when website/ changes land on
+# main; can also be triggered manually from the Actions tab.
+#
+# Required repo secrets:
+#   CLOUDFLARE_API_TOKEN  - token with "Cloudflare Pages: Edit" permission
+#   CLOUDFLARE_ACCOUNT_ID - account id from the Cloudflare dashboard
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'website/**'
+      - '.github/workflows/website-deploy.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: website-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build & deploy to Cloudflare Pages
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: website/package-lock.json
+
+      - name: Install dependencies
+        working-directory: website
+        run: npm ci
+
+      - name: Build site
+        working-directory: website
+        run: npx @11ty/eleventy
+
+      - name: Deploy to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: website
+          command: pages deploy _site --project-name=houston-site --branch=main


### PR DESCRIPTION
## Summary

Replaces the manual \`cd website && npm run deploy\` step with a GitHub Actions workflow that builds + deploys on every push to \`main\` that touches \`website/\`.

- Trigger: push to \`main\` with path filter on \`website/**\` (plus the workflow file itself); also \`workflow_dispatch\` for manual reruns
- Concurrency group \`website-deploy\` with \`cancel-in-progress\` so the latest commit always wins if two land back-to-back
- Steps: checkout → setup-node 20 with npm cache → \`npm ci\` → \`npx @11ty/eleventy\` → \`cloudflare/wrangler-action@v3\` running \`pages deploy _site --project-name=houston-site --branch=main\`

## One-time setup before this works

Add two repo secrets in **Settings → Secrets and variables → Actions**:

- \`CLOUDFLARE_API_TOKEN\` — Cloudflare dashboard → My Profile → API Tokens → "Create Token" → use the **Edit Cloudflare Workers** template (it covers Pages too), or build a custom token with \`Account → Cloudflare Pages: Edit\`
- \`CLOUDFLARE_ACCOUNT_ID\` — visible in the Cloudflare dashboard URL or right-hand sidebar of any zone

Once those are set, the next \`website/\` change merged to main will deploy automatically. Manual \`npm run deploy\` still works as a fallback.

## Test plan

- [ ] Add the two secrets in repo settings
- [ ] Trigger via Actions tab → "Website Deploy" → "Run workflow" once to validate end-to-end
- [ ] Confirm the deploy lands on houston-site and gethouston.ai serves the new \`/privacy/\` text from #307