### PR TITLE
fix(files): show agent-created markdown in Files tab (#294)

### DIFF
--- a/engine/houston-engine-core/src/agents/files.rs
+++ b/engine/houston-engine-core/src/agents/files.rs
@@ -89,11 +89,34 @@ fn file_err(e: files::AgentFilesError) -> CoreError {
 // ---------------------------------------------------------------------------
 
 /// User-facing file extensions shown in the browser.
-/// Technical files (json, py, md) are excluded — they confuse non-technical users.
+///
+/// Markdown is included: it is the document format agents most often
+/// produce (reports, plans, notes), so a non-technical user MUST see it
+/// (issue #294). Genuinely technical files (`json`, `py`, `ts`, …) stay
+/// excluded — they only confuse the non-technical audience.
 const USER_EXTENSIONS: &[&str] = &[
     "docx", "doc", "xlsx", "xls", "pptx", "ppt", "pdf", "png", "jpg", "jpeg", "svg", "gif", "txt",
-    "rtf", "csv",
+    "rtf", "csv", "md", "markdown",
 ];
+
+/// Agent-role instruction files seeded at the agent root. They are
+/// markdown, but they are the agent's "brain" (its job description), not
+/// user documents: `CLAUDE.md` is canonical and `AGENTS.md` / `GEMINI.md`
+/// are symlink/copy mirrors of it for codex / gemini-cli (see
+/// `agents::prompt::seed_agent`). Now that markdown is user-facing they
+/// would otherwise surface in the file browser AND in chat file-change
+/// summaries (the snapshot in `sessions::file_changes` shares this
+/// filter), so they are hidden by name.
+const HIDDEN_ROLE_FILES: &[&str] = &["CLAUDE.md", "AGENTS.md", "GEMINI.md"];
+
+/// True if `name` is an agent-role instruction file that must never
+/// appear as a user document. Compared case-insensitively: the canonical
+/// casing is fixed but filesystems (and user-typed copies) vary.
+fn is_hidden_role_file(name: &str) -> bool {
+    HIDDEN_ROLE_FILES
+        .iter()
+        .any(|role| role.eq_ignore_ascii_case(name))
+}
 
 fn should_skip_dir(name: &str) -> bool {
     matches!(
@@ -372,6 +395,12 @@ fn collect_files(root: &Path, dir: &Path, out: &mut Vec<ProjectFile>) {
         if !USER_EXTENSIONS.contains(&ext.as_str()) {
             continue;
         }
+        // Markdown passes the extension gate, so filter the seeded agent
+        // role files (CLAUDE.md / AGENTS.md / GEMINI.md) here — they are
+        // instructions, not user documents (issue #294).
+        if is_hidden_role_file(&name) {
+            continue;
+        }
         let relative = relative_path_string(root, &path);
         let metadata = entry.metadata().ok();
         let size = metadata.as_ref().map(|m| m.len()).unwrap_or(0);
@@ -455,6 +484,45 @@ mod tests {
         assert!(names.contains(&"notes.txt"));
         assert!(!names.contains(&"script.py"));
         assert!(!names.iter().any(|n| n.starts_with('.')));
+    }
+
+    #[test]
+    fn markdown_files_are_visible() {
+        // Issue #294: agents emit markdown deliverables (reports, plans);
+        // a non-technical user must see them in the browser. Genuinely
+        // technical files (json, py) stay hidden.
+        let d = tmp();
+        std::fs::write(d.path().join("report.md"), "# Report").unwrap();
+        std::fs::write(d.path().join("notes.markdown"), "notes").unwrap();
+        std::fs::write(d.path().join("data.json"), "{}").unwrap();
+        std::fs::write(d.path().join("script.py"), "x").unwrap();
+
+        let files = list_project_files(d.path()).unwrap();
+        let names: Vec<&str> = files.iter().map(|f| f.name.as_str()).collect();
+        assert!(names.contains(&"report.md"));
+        assert!(names.contains(&"notes.markdown"));
+        assert!(!names.contains(&"data.json"));
+        assert!(!names.contains(&"script.py"));
+    }
+
+    #[test]
+    fn agent_role_files_stay_hidden_despite_markdown() {
+        // CLAUDE.md and its AGENTS.md / GEMINI.md mirrors are the agent's
+        // instructions, not user documents — they must never appear even
+        // though markdown is now visible (issue #294). A real markdown
+        // deliverable alongside them still shows.
+        let d = tmp();
+        std::fs::write(d.path().join("CLAUDE.md"), "role").unwrap();
+        std::fs::write(d.path().join("AGENTS.md"), "role").unwrap();
+        std::fs::write(d.path().join("GEMINI.md"), "role").unwrap();
+        std::fs::write(d.path().join("deliverable.md"), "# Real doc").unwrap();
+
+        let files = list_project_files(d.path()).unwrap();
+        let names: Vec<&str> = files.iter().map(|f| f.name.as_str()).collect();
+        assert!(names.contains(&"deliverable.md"));
+        assert!(!names.contains(&"CLAUDE.md"));
+        assert!(!names.contains(&"AGENTS.md"));
+        assert!(!names.contains(&"GEMINI.md"));
     }
 
     #[test]

--- a/engine/houston-engine-core/src/sessions/file_changes.rs
+++ b/engine/houston-engine-core/src/sessions/file_changes.rs
@@ -81,6 +81,31 @@ mod tests {
     }
 
     #[test]
+    fn markdown_deliverables_tracked_but_role_files_ignored() {
+        // Markdown reports are user deliverables and must appear in the
+        // chat file-change summary (issue #294). The seeded role files
+        // (CLAUDE.md, AGENTS.md, GEMINI.md), created on first run, must
+        // NOT — otherwise every agent's first session would falsely
+        // report creating its own instructions.
+        let dir = TempDir::new().unwrap();
+        let before = snapshot(dir.path()).unwrap();
+
+        std::fs::write(dir.path().join("CLAUDE.md"), "role").unwrap();
+        std::fs::write(dir.path().join("AGENTS.md"), "role").unwrap();
+        std::fs::write(dir.path().join("GEMINI.md"), "role").unwrap();
+        std::fs::write(dir.path().join("summary.md"), "# Summary").unwrap();
+
+        let after = snapshot(dir.path()).unwrap();
+        let changes = diff(&before, &after);
+
+        assert_eq!(
+            changes.created,
+            vec![dir.path().join("summary.md").to_string_lossy()]
+        );
+        assert!(changes.modified.is_empty());
+    }
+
+    #[test]
     fn detects_modified_visible_files() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("brief.txt");

--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -105,8 +105,13 @@ Chat sessions snapshot user-visible project files before and after the
 CLI run. The engine diffs those snapshots and persists a `file_changes`
 feed item with `created` and `modified` absolute paths. The visible-file
 filter is shared with the project file browser, so helper files such as
-Python scripts, JSON, Markdown, `.houston/`, `.agents/`, and dotdirs stay
-out of non-technical chat summaries.
+Python scripts, JSON, the agent role files (`CLAUDE.md` / `AGENTS.md` /
+`GEMINI.md`), `.houston/`, `.agents/`, and dotdirs stay out of
+non-technical chat summaries. Markdown deliverables the agent writes
+(reports, plans, notes) DO surface — they are documents, not config
+(issue #294). The allowlist + role-file denylist live in
+`USER_EXTENSIONS` / `HIDDEN_ROLE_FILES` in
+`engine/houston-engine-core/src/agents/files.rs`.
 
 Attribution is strict only when one session owns a working directory. The
 engine enforces that by holding a per-`working_dir` guard for chat and


### PR DESCRIPTION
Fixes #294.

## Problem
Agents frequently write markdown deliverables (reports, plans, notes), but the file browser's `USER_EXTENSIONS` allowlist treated `md` as a "technical" file and hid it, so those files never appeared in the Files tab. As @franko-c diagnosed, the gate is `USER_EXTENSIONS` in `engine/houston-engine-core/src/agents/files.rs`.

## Fix
- Add `md` + `markdown` to `USER_EXTENSIONS`. Markdown is a document format, not config like `.json`/`.py`/`.ts` (those stay hidden).
- Add a `HIDDEN_ROLE_FILES` denylist (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`), skipped in `collect_files`. The agent root seeds those role files (`AGENTS.md`/`GEMINI.md` are symlink/copy mirrors of `CLAUDE.md` for codex/gemini, see `agents::prompt::seed_agent`), so naively allowing `md` would surface the agent's instructions as user documents, and make the first session falsely report "Created CLAUDE.md".
- The change lives in `collect_files`, used by both `list_project_files` (Files tab) and `sessions::file_changes::snapshot` (chat created/modified summaries), so both surfaces stay consistent.

## Tests
- `agents/files.rs`: `markdown_files_are_visible`, `agent_role_files_stay_hidden_despite_markdown`
- `sessions/file_changes.rs`: `markdown_deliverables_tracked_but_role_files_ignored`

## Files
- `engine/houston-engine-core/src/agents/files.rs`
- `engine/houston-engine-core/src/sessions/file_changes.rs`
- `knowledge-base/files-first.md` (doc: markdown now visible, role files hidden)

## Screenshots

<img width="1158" height="431" alt="image" src="https://github.com/user-attachments/assets/b510b5da-2275-4170-810f-73c80089d3e1" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)