### PR TITLE
fix(app): generic startup crash gate so white screen becomes a copyable error

### DIFF
--- a/app/public/compat-gate.js
+++ b/app/public/compat-gate.js
@@ -9,23 +9,35 @@
 // public/ so Vite copies it verbatim and never bundles it — keeping it free of
 // the modern syntax that the app bundle ships.
 //
-// Why it exists: Tauri renders through the *system* WKWebView. macOS Monterey
-// commonly ships WebKit < 16.4, which predates regex lookbehind. Our markdown
-// stack (streamdown -> remark-gfm -> mdast-util-gfm-autolink-literal) contains a
-// top-level lookbehind regex *literal*, so the engine throws
-// "SyntaxError: invalid group specifier name" while *evaluating* the app bundle,
-// before React mounts. Nothing renders and no error boundary can run, so the
-// user just sees a white screen (issue #102).
+// Two jobs:
 //
-// Lookbehind can't be transpiled away (esbuild emits regex literals verbatim)
-// and the rest of the stack (Tailwind v4's modern CSS included) also needs a
-// recent engine, so instead of a silent white screen we detect the unsupported
-// engine up front and replace it with a clear, localized message.
+// 1. Old-WebKit detection. macOS Monterey commonly ships WebKit < 16.4, which
+//    predates regex lookbehind. Our markdown stack contains a top-level
+//    lookbehind regex *literal*, so the engine throws "SyntaxError: invalid
+//    group specifier name" while *evaluating* the app bundle, before React
+//    mounts. Nothing renders and no error boundary can run, so the user just
+//    sees a white screen (issue #102). We feature-test lookbehind via the
+//    RegExp constructor and paint a localized "update macOS" message.
+//
+// 2. Generic crash safety net for modern engines. The Monterey gate only
+//    catches one specific cause of white screen. Anything else (a Tahoe-only
+//    WebKit regression, a CSP block, a third-party script failing to load, a
+//    synchronous throw inside React.render) still produced a silent blank
+//    screen with nothing in the user-visible UI. Install a window error and
+//    unhandledrejection listener up front, plus a watchdog timer: if #root
+//    is still empty after MOUNT_TIMEOUT_MS, paint a localized "couldn't start"
+//    message with the captured error + diagnostics and a Copy button so the
+//    user has something to send to support@gethouston.ai instead of a blank.
 //
 // Written in conservative ES2015 (no optional chaining / nullish coalescing)
 // because this file is shipped as-authored, never run through esbuild.
 (function () {
   "use strict";
+
+  // How long to wait for React to mount into #root before declaring a silent
+  // crash. Cold start with HMR off is typically well under 2s; 8s leaves slack
+  // for slow disks without making the user stare at white for a minute.
+  var MOUNT_TIMEOUT_MS = 8000;
 
   // Mirrors the app's shipped locales (en / es / pt). This runs before
   // react-i18next exists, so the strings live here. Keep them in the product
@@ -42,6 +54,31 @@
     pt: {
       title: "O Houston precisa de uma versão mais recente do macOS",
       body: "Atualize seu Mac para o macOS Ventura (13) ou mais recente e abra o Houston novamente.",
+    },
+  };
+
+  // Used when the watchdog or an early error fires. Same language matrix.
+  var CRASH_MESSAGES = {
+    en: {
+      title: "Houston couldn't start",
+      body: "Try opening Houston again. If this keeps happening, copy the details below and send them to hello@gethouston.ai so we can fix it.",
+      reload: "Reopen Houston",
+      copy: "Copy details",
+      copied: "Copied",
+    },
+    es: {
+      title: "Houston no pudo iniciar",
+      body: "Intenta abrir Houston de nuevo. Si el problema continúa, copia los detalles y envíalos a hello@gethouston.ai para que podamos resolverlo.",
+      reload: "Volver a abrir Houston",
+      copy: "Copiar detalles",
+      copied: "Copiado",
+    },
+    pt: {
+      title: "O Houston não conseguiu iniciar",
+      body: "Tente abrir o Houston novamente. Se o problema continuar, copie os detalhes e envie para hello@gethouston.ai para que possamos resolver.",
+      reload: "Reabrir o Houston",
+      copy: "Copiar detalhes",
+      copied: "Copiado",
     },
   };
 
@@ -80,23 +117,205 @@
       "</p></div></div>";
   }
 
+  function rootHasMounted(doc) {
+    var root = doc.getElementById("root");
+    return !!root && root.childElementCount > 0;
+  }
+
+  // Builds a plain-text diagnostics blob the user can copy. No structured
+  // payload — the goal is something a non-technical user can paste into an
+  // email. Stays robust when `error` is null (silent stall) or partial.
+  function captureDiagnostics(error, info) {
+    var lines = [];
+    lines.push("Time: " + new Date().toISOString());
+    if (info && info.userAgent) lines.push("User agent: " + info.userAgent);
+    if (info && info.url) lines.push("URL: " + info.url);
+    if (error) {
+      if (error.message) lines.push("Error: " + error.message);
+      if (error.filename) {
+        lines.push(
+          "Where: " +
+            error.filename +
+            ":" +
+            (error.lineno || "?") +
+            ":" +
+            (error.colno || "?"),
+        );
+      }
+      if (error.stack) lines.push("Stack:\n" + error.stack);
+    } else {
+      lines.push("Error: app did not mount within " + MOUNT_TIMEOUT_MS + "ms");
+    }
+    return lines.join("\n");
+  }
+
+  function escapeHtml(value) {
+    return String(value)
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;");
+  }
+
+  function renderCrashScreen(root, message, diagnostics) {
+    root.innerHTML =
+      '<div style="position:fixed;inset:0;display:flex;align-items:center;justify-content:center;padding:24px;background:#0d0d0f;color:#e8e8ea;font-family:system-ui,-apple-system,sans-serif;-webkit-font-smoothing:antialiased;overflow:auto;">' +
+      '<div style="max-width:36rem;width:100%;">' +
+      '<h1 style="margin:0 0 12px;font-size:20px;font-weight:600;line-height:1.3;text-align:center;">' +
+      escapeHtml(message.title) +
+      "</h1>" +
+      '<p style="margin:0 0 20px;font-size:15px;line-height:1.5;color:#a1a1aa;text-align:center;">' +
+      escapeHtml(message.body) +
+      "</p>" +
+      '<div style="display:flex;gap:8px;justify-content:center;margin-bottom:20px;flex-wrap:wrap;">' +
+      '<button id="houston-gate-reload" type="button" style="padding:8px 16px;font:inherit;font-size:14px;background:#3b82f6;color:#fff;border:0;border-radius:6px;cursor:pointer;">' +
+      escapeHtml(message.reload) +
+      "</button>" +
+      '<button id="houston-gate-copy" type="button" style="padding:8px 16px;font:inherit;font-size:14px;background:#1f1f23;color:#e8e8ea;border:1px solid #2e2e33;border-radius:6px;cursor:pointer;">' +
+      escapeHtml(message.copy) +
+      "</button>" +
+      "</div>" +
+      '<pre id="houston-gate-diagnostics" style="margin:0;padding:12px;background:#1a1a1c;color:#a1a1aa;border:1px solid #2e2e33;border-radius:6px;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:12px;line-height:1.5;white-space:pre-wrap;word-break:break-word;max-height:240px;overflow:auto;">' +
+      escapeHtml(diagnostics) +
+      "</pre>" +
+      "</div></div>";
+
+    var reloadBtn = root.querySelector("#houston-gate-reload");
+    var copyBtn = root.querySelector("#houston-gate-copy");
+    if (reloadBtn) {
+      reloadBtn.addEventListener("click", function () {
+        try {
+          window.location.reload();
+        } catch (e) {
+          /* nothing better we can do from inside the crash screen */
+        }
+      });
+    }
+    if (copyBtn) {
+      copyBtn.addEventListener("click", function () {
+        var done = function () {
+          copyBtn.textContent = message.copied;
+        };
+        try {
+          if (navigator.clipboard && navigator.clipboard.writeText) {
+            navigator.clipboard.writeText(diagnostics).then(done, done);
+            return;
+          }
+        } catch (e) {
+          /* fall through to selection fallback */
+        }
+        var pre = root.querySelector("#houston-gate-diagnostics");
+        if (pre && typeof getSelection === "function" && typeof document.createRange === "function") {
+          var range = document.createRange();
+          range.selectNodeContents(pre);
+          var sel = getSelection();
+          sel.removeAllRanges();
+          sel.addRange(range);
+        }
+      });
+    }
+  }
+
+  // Normalizes the two browser error shapes (`ErrorEvent`, `PromiseRejectionEvent`)
+  // into a flat record the diagnostics formatter consumes. Returns null when the
+  // event carries nothing useful so callers can ignore it.
+  function errorFromErrorEvent(event) {
+    if (!event) return null;
+    var nested = event.error;
+    if (nested && (nested.message || nested.stack)) {
+      return {
+        message: nested.message || String(nested),
+        stack: nested.stack,
+        filename: event.filename,
+        lineno: event.lineno,
+        colno: event.colno,
+      };
+    }
+    if (event.message || event.filename) {
+      return {
+        message: event.message || "Script error",
+        filename: event.filename,
+        lineno: event.lineno,
+        colno: event.colno,
+      };
+    }
+    return null;
+  }
+
+  function errorFromRejectionEvent(event) {
+    if (!event) return null;
+    var reason = event.reason;
+    if (reason && (reason.message || reason.stack)) {
+      return { message: reason.message || String(reason), stack: reason.stack };
+    }
+    if (typeof reason !== "undefined" && reason !== null) {
+      return { message: String(reason) };
+    }
+    return { message: "Unhandled promise rejection" };
+  }
+
   // Expose the pure helpers when loaded by the unit test (Node passes a
   // `module` object). In the browser `module` is undefined, so we skip this and
   // run the gate.
   if (typeof module !== "undefined" && module.exports) {
     module.exports = {
+      MOUNT_TIMEOUT_MS: MOUNT_TIMEOUT_MS,
       MESSAGES: MESSAGES,
+      CRASH_MESSAGES: CRASH_MESSAGES,
       pickLanguage: pickLanguage,
       isModernEngineSupported: isModernEngineSupported,
       renderUnsupportedScreen: renderUnsupportedScreen,
+      rootHasMounted: rootHasMounted,
+      captureDiagnostics: captureDiagnostics,
+      renderCrashScreen: renderCrashScreen,
+      errorFromErrorEvent: errorFromErrorEvent,
+      errorFromRejectionEvent: errorFromRejectionEvent,
     };
     return;
   }
 
-  if (typeof document !== "undefined" && !isModernEngineSupported(RegExp)) {
-    var root = document.getElementById("root");
-    if (root) {
-      renderUnsupportedScreen(root, MESSAGES[pickLanguage(navigator.language)]);
+  if (typeof document === "undefined") return;
+
+  // 1) Monterey path — paint and stop. Skips the crash watchdog because #root
+  //    is already painted (rootHasMounted would short-circuit anyway, but this
+  //    also saves the listeners and timer).
+  if (!isModernEngineSupported(RegExp)) {
+    var unsupportedRoot = document.getElementById("root");
+    if (unsupportedRoot) {
+      renderUnsupportedScreen(unsupportedRoot, MESSAGES[pickLanguage(navigator.language)]);
     }
+    return;
   }
+
+  // 2) Modern engine — install the crash safety net. window/setTimeout may not
+  //    exist in non-browser hosts (Node SSR test harness); degrade silently.
+  if (typeof window === "undefined" || typeof setTimeout === "undefined") return;
+
+  var firstError = null;
+  function rememberError(err) {
+    if (firstError || !err) return;
+    firstError = err;
+  }
+  window.addEventListener(
+    "error",
+    function (event) {
+      rememberError(errorFromErrorEvent(event));
+    },
+    true, // capture, so we see errors from inline scripts even if they stopPropagation
+  );
+  window.addEventListener("unhandledrejection", function (event) {
+    rememberError(errorFromRejectionEvent(event));
+  });
+
+  setTimeout(function () {
+    if (rootHasMounted(document)) return;
+    var crashRoot = document.getElementById("root");
+    if (!crashRoot) return;
+    var lang = pickLanguage(navigator.language);
+    var diagnostics = captureDiagnostics(firstError, {
+      userAgent: navigator.userAgent,
+      url: typeof location !== "undefined" ? location.href : "",
+    });
+    renderCrashScreen(crashRoot, CRASH_MESSAGES[lang], diagnostics);
+  }, MOUNT_TIMEOUT_MS);
 })();

--- a/app/src/lib/compat-gate.test.mjs
+++ b/app/src/lib/compat-gate.test.mjs
@@ -20,8 +20,8 @@ function loadHelpers() {
 
 // Runs the gate's browser side effect with injected globals. `module` is
 // undefined here, so the IIFE skips the export branch and executes the gate.
-function runGate({ navigatorLanguage, lookbehindThrows }) {
-  const root = { innerHTML: "" };
+function runGate({ navigatorLanguage, lookbehindThrows, hasWindow = false }) {
+  const root = { innerHTML: "", childElementCount: 0, querySelector: () => null };
   const fakeDocument = {
     getElementById: (id) => (id === "root" ? root : null),
   };
@@ -31,16 +31,32 @@ function runGate({ navigatorLanguage, lookbehindThrows }) {
         throw new SyntaxError("invalid group specifier name");
       }
     : RegExp;
-  new Function("module", "document", "navigator", "RegExp", gateSource)(
+  // For tests of the Monterey path we deliberately leave `window`/`setTimeout`
+  // undefined: the gate's modern-engine branch guards on `typeof window` and
+  // bails, so we exercise the lookbehind branch in isolation.
+  const fakeWindow = hasWindow ? undefined : undefined;
+  new Function("module", "document", "navigator", "RegExp", "window", gateSource)(
     undefined,
     fakeDocument,
     fakeNavigator,
     FakeRegExp,
+    fakeWindow,
   );
   return root.innerHTML;
 }
 
-const { pickLanguage, isModernEngineSupported, MESSAGES } = loadHelpers();
+const {
+  pickLanguage,
+  isModernEngineSupported,
+  MESSAGES,
+  CRASH_MESSAGES,
+  rootHasMounted,
+  captureDiagnostics,
+  renderCrashScreen,
+  errorFromErrorEvent,
+  errorFromRejectionEvent,
+  MOUNT_TIMEOUT_MS,
+} = loadHelpers();
 
 test("pickLanguage maps navigator locales to a shipped language", () => {
   assert.equal(pickLanguage("es-ES"), "es");
@@ -55,7 +71,7 @@ test("pickLanguage falls back to English for unknown or missing locales", () => 
   assert.equal(pickLanguage(undefined), "en");
 });
 
-test("every shipped language has a non-empty title and body", () => {
+test("every shipped language has a non-empty Monterey title and body", () => {
   for (const lang of ["en", "es", "pt"]) {
     const message = MESSAGES[lang];
     assert.ok(message, `missing message for ${lang}`);
@@ -64,11 +80,28 @@ test("every shipped language has a non-empty title and body", () => {
   }
 });
 
+test("every shipped language has full crash-screen copy", () => {
+  for (const lang of ["en", "es", "pt"]) {
+    const message = CRASH_MESSAGES[lang];
+    assert.ok(message, `missing crash message for ${lang}`);
+    for (const key of ["title", "body", "reload", "copy", "copied"]) {
+      assert.ok(
+        typeof message[key] === "string" && message[key].length > 0,
+        `${lang}.${key} must be a non-empty string`,
+      );
+    }
+  }
+});
+
 test("gate copy contains no em dashes (i18n validator rule)", () => {
   for (const lang of ["en", "es", "pt"]) {
-    const { title, body } = MESSAGES[lang];
-    assert.ok(!title.includes("—"), `em dash in ${lang} title`);
-    assert.ok(!body.includes("—"), `em dash in ${lang} body`);
+    const monterey = MESSAGES[lang];
+    assert.ok(!monterey.title.includes("—"), `em dash in Monterey ${lang} title`);
+    assert.ok(!monterey.body.includes("—"), `em dash in Monterey ${lang} body`);
+    const crash = CRASH_MESSAGES[lang];
+    for (const key of ["title", "body", "reload", "copy", "copied"]) {
+      assert.ok(!crash[key].includes("—"), `em dash in crash ${lang}.${key}`);
+    }
   }
 });
 
@@ -119,4 +152,229 @@ test("index.html loads the gate as a deferred (not parser-blocking) script", () 
     /\btype="module"\b/,
     "gate must stay a classic script so it parses on the engines it detects",
   );
+});
+
+// ---- Generic crash safety net (watchdog + error handlers) -------------------
+
+test("rootHasMounted is true exactly when #root has child elements", () => {
+  const empty = { getElementById: () => ({ childElementCount: 0 }) };
+  const full = { getElementById: () => ({ childElementCount: 3 }) };
+  const missing = { getElementById: () => null };
+  assert.equal(rootHasMounted(empty), false);
+  assert.equal(rootHasMounted(full), true);
+  assert.equal(rootHasMounted(missing), false);
+});
+
+test("captureDiagnostics formats an error event into a copyable blob", () => {
+  const out = captureDiagnostics(
+    {
+      message: "Boom",
+      stack: "Error: Boom\n    at app.js:1:1",
+      filename: "app.js",
+      lineno: 1,
+      colno: 5,
+    },
+    { userAgent: "TestAgent/1.0", url: "tauri://app/index.html" },
+  );
+  assert.match(out, /User agent: TestAgent\/1\.0/);
+  assert.match(out, /URL: tauri:\/\/app\/index\.html/);
+  assert.match(out, /Error: Boom/);
+  assert.match(out, /Where: app\.js:1:5/);
+  assert.match(out, /Stack:\nError: Boom/);
+  assert.match(out, /^Time: \d{4}-\d{2}-\d{2}T/m);
+});
+
+test("captureDiagnostics names the silent-stall case when no error fired", () => {
+  const out = captureDiagnostics(null, { userAgent: "UA", url: "u" });
+  assert.match(out, new RegExp(`did not mount within ${MOUNT_TIMEOUT_MS}ms`));
+});
+
+test("errorFromErrorEvent prefers the nested Error then falls back to the event", () => {
+  assert.deepEqual(
+    errorFromErrorEvent({
+      error: { message: "nested", stack: "S" },
+      filename: "a.js",
+      lineno: 2,
+      colno: 3,
+    }),
+    { message: "nested", stack: "S", filename: "a.js", lineno: 2, colno: 3 },
+  );
+  assert.deepEqual(
+    errorFromErrorEvent({
+      message: "Script error",
+      filename: "x.js",
+      lineno: 1,
+      colno: 1,
+    }),
+    { message: "Script error", filename: "x.js", lineno: 1, colno: 1 },
+  );
+  assert.equal(errorFromErrorEvent(null), null);
+  assert.equal(errorFromErrorEvent({}), null);
+});
+
+test("errorFromRejectionEvent unwraps Error reasons and stringifies plain values", () => {
+  assert.deepEqual(
+    errorFromRejectionEvent({ reason: { message: "nope", stack: "T" } }),
+    { message: "nope", stack: "T" },
+  );
+  assert.deepEqual(errorFromRejectionEvent({ reason: "weird string" }), {
+    message: "weird string",
+  });
+  assert.deepEqual(errorFromRejectionEvent({ reason: undefined }), {
+    message: "Unhandled promise rejection",
+  });
+});
+
+test("renderCrashScreen embeds title, body, buttons, diagnostics, and wires Reload/Copy", () => {
+  // Minimal fake root that records the painted HTML and captures the click
+  // handlers the gate attaches.
+  const handlers = { reload: null, copy: null };
+  const reloadBtn = {
+    addEventListener: (type, fn) => {
+      if (type === "click") handlers.reload = fn;
+    },
+  };
+  const copyBtn = {
+    addEventListener: (type, fn) => {
+      if (type === "click") handlers.copy = fn;
+    },
+    textContent: "",
+  };
+  const root = {
+    innerHTML: "",
+    querySelector: (sel) => {
+      if (sel === "#houston-gate-reload") return reloadBtn;
+      if (sel === "#houston-gate-copy") return copyBtn;
+      return null;
+    },
+  };
+
+  renderCrashScreen(root, CRASH_MESSAGES.en, "Time: ...\nError: Boom");
+
+  assert.ok(root.innerHTML.includes(CRASH_MESSAGES.en.title));
+  assert.ok(root.innerHTML.includes(CRASH_MESSAGES.en.body));
+  assert.ok(root.innerHTML.includes(CRASH_MESSAGES.en.reload));
+  assert.ok(root.innerHTML.includes(CRASH_MESSAGES.en.copy));
+  assert.ok(root.innerHTML.includes("Error: Boom"), "diagnostics body must be embedded");
+  assert.ok(root.innerHTML.includes('id="houston-gate-diagnostics"'));
+  assert.ok(root.innerHTML.includes("position:fixed"), "must use self-contained inline styles");
+  assert.equal(typeof handlers.reload, "function", "Reload button must have a click handler");
+  assert.equal(typeof handlers.copy, "function", "Copy button must have a click handler");
+  // The copy click swallows any clipboard / selection error so it never
+  // throws past the user. We can't mutate globalThis.navigator under Node 20+
+  // (it's read-only), so just assert that invoking the handler in a hostile
+  // environment doesn't escape.
+  assert.doesNotThrow(() => handlers.copy());
+});
+
+test("renderCrashScreen escapes HTML in the diagnostics so an error message can't break out", () => {
+  const root = {
+    innerHTML: "",
+    querySelector: () => ({ addEventListener: () => {}, textContent: "" }),
+  };
+  renderCrashScreen(root, CRASH_MESSAGES.en, '<script>alert("x")</script>');
+  assert.ok(
+    !root.innerHTML.includes('<script>alert("x")</script>'),
+    "diagnostics must be HTML-escaped before being embedded",
+  );
+  assert.ok(root.innerHTML.includes("&lt;script&gt;"));
+});
+
+// Watchdog integration: run the gate in a minimal browser harness, force the
+// 'modern engine' branch, and fast-forward setTimeout. With #root empty when
+// the watchdog fires, the crash screen must be painted; with #root populated
+// (React mounted in real life), the watchdog must leave the page alone.
+function runGateWithWatchdog({ rootChildren, fireError, navigatorLanguage }) {
+  const eventListeners = {};
+  const root = {
+    innerHTML: "",
+    childElementCount: rootChildren,
+    querySelector: () => ({ addEventListener: () => {}, textContent: "" }),
+  };
+  const fakeDocument = { getElementById: (id) => (id === "root" ? root : null) };
+  const fakeNavigator = { language: navigatorLanguage, userAgent: "Watchdog/1.0" };
+  let scheduled = null;
+  const fakeWindow = {
+    addEventListener: (type, fn) => {
+      eventListeners[type] = fn;
+    },
+    location: { href: "tauri://app", reload: () => {} },
+  };
+  const fakeSetTimeout = (fn, _ms) => {
+    scheduled = fn;
+    return 1;
+  };
+  new Function(
+    "module",
+    "document",
+    "navigator",
+    "RegExp",
+    "window",
+    "setTimeout",
+    "location",
+    gateSource,
+  )(
+    undefined,
+    fakeDocument,
+    fakeNavigator,
+    RegExp,
+    fakeWindow,
+    fakeSetTimeout,
+    fakeWindow.location,
+  );
+
+  if (fireError && eventListeners.error) {
+    eventListeners.error({
+      error: { message: "Bundle blew up", stack: "stack here" },
+      filename: "main.tsx",
+      lineno: 42,
+      colno: 7,
+    });
+  }
+  if (scheduled) scheduled();
+  return root.innerHTML;
+}
+
+test("watchdog stays quiet when React has mounted into #root", () => {
+  const html = runGateWithWatchdog({
+    rootChildren: 1,
+    fireError: false,
+    navigatorLanguage: "en-US",
+  });
+  assert.equal(html, "", "must not repaint over a successfully mounted app");
+});
+
+test("watchdog paints a localized crash screen when #root is still empty", () => {
+  const en = runGateWithWatchdog({
+    rootChildren: 0,
+    fireError: false,
+    navigatorLanguage: "en-US",
+  });
+  assert.ok(en.includes(CRASH_MESSAGES.en.title));
+  assert.ok(en.includes(`did not mount within ${MOUNT_TIMEOUT_MS}ms`));
+
+  const es = runGateWithWatchdog({
+    rootChildren: 0,
+    fireError: false,
+    navigatorLanguage: "es-ES",
+  });
+  assert.ok(es.includes(CRASH_MESSAGES.es.title));
+
+  const pt = runGateWithWatchdog({
+    rootChildren: 0,
+    fireError: false,
+    navigatorLanguage: "pt-BR",
+  });
+  assert.ok(pt.includes(CRASH_MESSAGES.pt.title));
+});
+
+test("watchdog surfaces the first captured error in the diagnostics blob", () => {
+  const html = runGateWithWatchdog({
+    rootChildren: 0,
+    fireError: true,
+    navigatorLanguage: "en-US",
+  });
+  assert.ok(html.includes("Error: Bundle blew up"));
+  assert.ok(html.includes("Where: main.tsx:42:7"));
+  assert.ok(html.includes("User agent: Watchdog/1.0"));
 });


### PR DESCRIPTION
## Summary

- Extend `app/public/compat-gate.js` beyond the Monterey lookbehind detector with a generic startup crash safety net: window error + unhandledrejection listeners installed before the bundle evaluates, plus an 8s watchdog that paints a localized "Houston couldn't start" screen with the captured error, Reload, and Copy details buttons whenever `#root` is still empty.
- Triggered by a Tahoe (macOS 26) user reporting white screen on first launch of 0.4.13. Backend + engine logs from her `.houston/` were clean (engine spawns, window receives Focused), so the failure is renderer-side, before React mounts, where no error boundary can catch it. The Monterey gate paints a "update macOS" message only for missing regex lookbehind; everything else fell through to blank.
- The shipped gate now turns any future "white screen" report into a copyable diagnostics blob (error, stack, file:line:col, timestamp, user agent, URL) the user can paste into a support email, so we can actually identify the Tahoe-specific cause instead of guessing from clean backend logs.

## Test plan

- [x] `node --test app/src/lib/compat-gate.test.mjs` (19 tests pass): all three locales for both Monterey and crash messages, em-dash check, diagnostics formatting (error and silent-stall variants), error-event / promise-rejection unwrapping, HTML escaping so a malicious error message cannot break out, watchdog quiet when React mounts, watchdog paints when `#root` stays empty, captured error surfacing in diagnostics blob.
- [x] `pnpm tsc --noEmit` passes.
- [x] `pnpm check-locales` passes (all 16 namespaces in sync; em-dash rule respected).
- [ ] Manual: ship a build to the Tahoe reporter, confirm the new screen replaces white and that Copy details produces a real error string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)