### PR TITLE
fix(app): keep agent folderPath fresh after rename (#298)

### DIFF
--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -144,9 +144,9 @@ export const tauriAgents = {
   delete: (workspaceId: string, id: string) =>
     call<void>("delete_agent", () => getEngine().deleteAgent(workspaceId, id)),
   rename: (workspaceId: string, id: string, newName: string) =>
-    call<void>("rename_agent", async () => {
-      await getEngine().renameAgent(workspaceId, id, newName);
-    }),
+    call<Agent>("rename_agent", async () =>
+      toAgent(await getEngine().renameAgent(workspaceId, id, newName)),
+    ),
   updateColor: (workspaceId: string, id: string, color: string) =>
     call<Agent>("update_agent_color", async () =>
       toAgent(await getEngine().updateAgent(workspaceId, id, { color })),

--- a/app/src/stores/agents.ts
+++ b/app/src/stores/agents.ts
@@ -93,14 +93,19 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   },
 
   rename: async (workspaceId, id, newName) => {
-    await tauriAgents.rename(workspaceId, id, newName);
+    // The engine renames the folder on disk, so folderPath changes too. Use
+    // the returned record instead of patching only `name`, or the stale path
+    // later reaches tauriWatcher.start and the watch fails with a "neither a
+    // file nor a directory" error toast (#298).
+    const updated = await tauriAgents.rename(workspaceId, id, newName);
     set((s) => ({
-      agents: s.agents.map((a) =>
-        a.id === id ? { ...a, name: newName } : a,
-      ),
-      current:
-        s.current?.id === id ? { ...s.current, name: newName } : s.current,
+      agents: s.agents.map((a) => (a.id === id ? updated : a)),
     }));
+    // If we renamed the agent we're viewing, re-select it so the file watcher
+    // and routine scheduler repoint at the new folder (the old one is gone).
+    if (get().current?.id === id) {
+      get().setCurrent(updated);
+    }
   },
 
   updateColor: async (workspaceId, id, color) => {

--- a/engine/houston-engine-core/src/agents_crud.rs
+++ b/engine/houston-engine-core/src/agents_crud.rs
@@ -448,6 +448,20 @@ mod tests {
         .unwrap();
         let renamed = rename(d.path(), &ws_id, &res.agent.id, "m").unwrap();
         assert_eq!(renamed.name, "m");
+        // The folder moves on disk, so the returned record must carry the NEW
+        // path. The desktop store relies on this to repoint its file watcher;
+        // a stale path makes the watch fail with an error toast (#298).
+        assert_eq!(
+            Path::new(&renamed.folder_path)
+                .file_name()
+                .and_then(|n| n.to_str()),
+            Some("m"),
+        );
+        assert!(
+            !d.path().join("alpha/n").exists(),
+            "old agent folder should no longer exist after rename"
+        );
+        assert!(d.path().join("alpha/m/.houston/agent.json").exists());
         delete(d.path(), &ws_id, &res.agent.id).unwrap();
         assert!(list(d.path(), &ws_id).unwrap().is_empty());
     }


### PR DESCRIPTION
## Problem

Fixes #298. After renaming an agent, navigating away and back surfaced a scary toast:

> Houston, we have a problem! internal: Failed to start watching `\\?\C:\Users\…\.houston\workspaces\Personal\per`: Input watch path is neither a file nor a directory.

The error is harmless (chat/history keep working) but alarming for a non-technical user.

## Root cause

The engine's `agents_crud::rename` does `fs::rename(old_folder → new_folder)`, so an agent's **`folderPath` changes on rename**. But the desktop layer ignored that:

- `tauriAgents.rename` (`app/src/lib/tauri.ts`) was typed `call<void>` and **discarded** the renamed `Agent` the engine returns.
- The store's `rename` (`app/src/stores/agents.ts`) patched only `name`, leaving the **old `folderPath`** in `agents[]` and `current`.

On the next agent selection, `setCurrent` handed that stale path to `tauriWatcher.start`. The folder no longer exists at the old path → the engine watch fails → `call()` surfaces it as an error toast (its `.catch(console.error)` only adds a log; the toast already fired). The `\\?\` prefix is just Windows canonicalization of the now-stale path.

## Fix (root cause, not the symptom)

- **`app/src/lib/tauri.ts`** — `tauriAgents.rename` returns the engine's `Agent` (mirrors `updateColor`), so the new `folderPath` isn't thrown away.
- **`app/src/stores/agents.ts`** — `rename` uses that record to refresh `agents[]` + `current`, and re-selects the agent when it's the active one so the **file watcher and routine scheduler repoint at the new folder**. This also fixes a latent bug: before, the active agent's `current.folderPath` stayed stale after rename, so subsequent file reads / chat sends used the old path.
- **`engine/houston-engine-core/src/agents_crud.rs`** — strengthened the existing `rename_and_delete` test to assert the returned `folder_path` reflects the new name and the old folder is gone — the contract the frontend now relies on.

I deliberately did **not** silence the watcher-start toast: per the beta "no silent failures" policy, a *genuine* watch failure should still surface. Fixing the stale path removes the *false* alarm while keeping real ones.

## Affected files
- `app/src/lib/tauri.ts`
- `app/src/stores/agents.ts`
- `engine/houston-engine-core/src/agents_crud.rs` (test)

## Testing
- `pnpm typecheck` — clean across all 15 workspace projects (incl. `app`).
- `pnpm check-locales` — in sync (no user-facing strings changed).
- Engine `rename_and_delete` test strengthened; **runs in CI** (no local Rust toolchain on this machine).

### Note
Workspace rename (`app/src/stores/workspaces.ts`) has the same latent shape — renaming a workspace moves every agent folder under it, invalidating their paths. Out of scope for this fix; flagging as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
