### PR TITLE
fix(claude-installer): localize install failures via a typed error taxonomy

### DIFF
--- a/app/src/components/shell/claude-install-hint.tsx
+++ b/app/src/components/shell/claude-install-hint.tsx
@@ -1,7 +1,10 @@
 import { useTranslation } from "react-i18next";
 import { AlertTriangle, Download, Loader2, RefreshCw } from "lucide-react";
 import { Button } from "@houston-ai/core";
-import type { ClaudeInstallState } from "../../hooks/use-claude-install";
+import {
+  useClaudeInstallErrorText,
+  type ClaudeInstallState,
+} from "../../hooks/use-claude-install";
 
 /**
  * Replacement for the generic "install the CLI yourself" hint when the
@@ -12,6 +15,7 @@ import type { ClaudeInstallState } from "../../hooks/use-claude-install";
  */
 export function ClaudeInstallHint({ state }: { state: ClaudeInstallState }) {
   const { t } = useTranslation("providers");
+  const errorText = useClaudeInstallErrorText();
 
   if (state.installing) {
     const label =
@@ -28,14 +32,14 @@ export function ClaudeInstallHint({ state }: { state: ClaudeInstallState }) {
     );
   }
 
-  if (state.errorMessage) {
+  if (state.error) {
     return (
       <div className="flex flex-col gap-2">
         <div className="flex items-start gap-2 text-xs text-foreground">
           <AlertTriangle className="mt-0.5 size-3.5 shrink-0 text-amber-600" />
           <div className="flex flex-col gap-0.5">
             <span className="font-medium">{t("claudeInstall.failedTitle")}</span>
-            <span className="text-muted-foreground">{state.errorMessage}</span>
+            <span className="text-muted-foreground">{errorText(state.error)}</span>
           </div>
         </div>
         <Button

--- a/app/src/hooks/use-claude-install.ts
+++ b/app/src/hooks/use-claude-install.ts
@@ -1,8 +1,53 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import type { HoustonEvent } from "@houston-ai/core";
+import type { ClaudeInstallError } from "@houston-ai/engine-client";
 import { subscribeHoustonEvents } from "../lib/events";
 import { tauriClaude } from "../lib/tauri";
 import { logger } from "../lib/logger";
+
+/**
+ * Localize a typed install failure. The engine is i18n-agnostic — it
+ * emits a stable `kind` slug (`ClaudeInstallError`) and we map it to the
+ * app's en/es/pt copy here. `detail` is deliberately NOT shown to the
+ * user; it rides along on the error for the Report-bug bundle / logs.
+ *
+ * Exposed as a hook (not a plain fn) so callers don't have to thread a
+ * `t` through — both consumers (the inline hint + the global
+ * `ClaudeCliFailed` toast) already run inside React.
+ */
+export function useClaudeInstallErrorText(): (error: ClaudeInstallError) => string {
+  const { t } = useTranslation("providers");
+  return (error: ClaudeInstallError): string => {
+    switch (error.kind) {
+      case "timeout":
+        return t("claudeInstall.errors.timeout");
+      case "network_unreachable":
+        return t("claudeInstall.errors.networkUnreachable");
+      case "download_interrupted":
+        return t("claudeInstall.errors.downloadInterrupted");
+      case "http_error":
+        return t("claudeInstall.errors.httpError", { status: error.status ?? 0 });
+      case "checksum_mismatch":
+        return t("claudeInstall.errors.checksumMismatch");
+      case "platform_unsupported":
+        return t("claudeInstall.errors.platformUnsupported");
+      case "write_failed":
+        return t("claudeInstall.errors.writeFailed");
+      // Dev-only manifest problems collapse to a generic "couldn't
+      // start" so we never leak the internal manifest hint to users.
+      case "manifest_missing":
+      case "manifest_entry_missing":
+        return t("claudeInstall.errors.unavailable");
+      case "unknown":
+        return t("claudeInstall.errors.unknown");
+      default:
+        // Wire drift: a newer engine sent a kind this build doesn't
+        // know. Degrade to the generic message rather than render blank.
+        return t("claudeInstall.errors.unknown");
+    }
+  };
+}
 
 /**
  * Live state of the Anthropic Claude Code runtime install — the install
@@ -18,8 +63,9 @@ export interface ClaudeInstallState {
   installing: boolean;
   /** `0..=100`, or `null` if the engine never sent a progress event yet. */
   progressPct: number | null;
-  /** User-readable failure reason from the engine. `null` after a clean install. */
-  errorMessage: string | null;
+  /** Typed failure from the engine, or `null` after a clean install.
+   *  Localize for display with {@link useClaudeInstallErrorText}. */
+  error: ClaudeInstallError | null;
   /**
    * Trigger a fresh install. The HTTP call returns immediately; the
    * state in this hook flips on the resulting WS events.
@@ -36,13 +82,13 @@ interface UseClaudeInstallOpts {
    *  Separate from the in-component error display to keep concerns
    *  decoupled (the inline card always shows; the toast is a global
    *  affordance). */
-  onFailed?: (message: string) => void;
+  onFailed?: (error: ClaudeInstallError) => void;
 }
 
 export function useClaudeInstall(opts: UseClaudeInstallOpts = {}): ClaudeInstallState {
   const [installing, setInstalling] = useState(false);
   const [progressPct, setProgressPct] = useState<number | null>(null);
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [error, setError] = useState<ClaudeInstallError | null>(null);
 
   // Stable refs so the subscription effect doesn't tear down whenever
   // the parent re-renders with a new lambda.
@@ -61,10 +107,10 @@ export function useClaudeInstall(opts: UseClaudeInstallOpts = {}): ClaudeInstall
       .then((s) => {
         if (cancelled) return;
         if (s.installed) {
-          setErrorMessage(null);
+          setError(null);
           return;
         }
-        if (s.lastInstallError) setErrorMessage(s.lastInstallError);
+        if (s.lastInstallError) setError(s.lastInstallError);
       })
       .catch((err: unknown) => {
         logger.warn(`[claude-install] status fetch failed: ${String(err)}`);
@@ -80,19 +126,19 @@ export function useClaudeInstall(opts: UseClaudeInstallOpts = {}): ClaudeInstall
         case "ClaudeCliInstalling":
           setInstalling(true);
           setProgressPct(event.data.progress_pct);
-          setErrorMessage(null);
+          setError(null);
           break;
         case "ClaudeCliReady":
           setInstalling(false);
           setProgressPct(null);
-          setErrorMessage(null);
+          setError(null);
           callbacksRef.current.onReady?.();
           break;
         case "ClaudeCliFailed":
           setInstalling(false);
           setProgressPct(null);
-          setErrorMessage(event.data.message);
-          callbacksRef.current.onFailed?.(event.data.message);
+          setError(event.data.error);
+          callbacksRef.current.onFailed?.(event.data.error);
           break;
       }
     });
@@ -100,21 +146,22 @@ export function useClaudeInstall(opts: UseClaudeInstallOpts = {}): ClaudeInstall
   }, []);
 
   const retry = useCallback(async () => {
-    setErrorMessage(null);
+    setError(null);
     setInstalling(true);
     setProgressPct(0);
     try {
       await tauriClaude.install();
     } catch (err) {
-      // The HTTP request itself rejected (engine route surfaced a
-      // synchronous error, e.g. manifest missing in a degraded dev
-      // build). Roll the state back so the UI doesn't get stuck at
-      // 0% forever.
+      // The install route returns 202 immediately and reports the real
+      // outcome over the WS firehose, so this only fires when the HTTP
+      // request itself couldn't be made (engine unreachable). Roll the
+      // state back so the UI doesn't get stuck at 0% forever, and carry
+      // the transport detail for the bug report.
       setInstalling(false);
       setProgressPct(null);
-      setErrorMessage(err instanceof Error ? err.message : String(err));
+      setError({ kind: "unknown", detail: err instanceof Error ? err.message : String(err) });
     }
   }, []);
 
-  return { installing, progressPct, errorMessage, retry };
+  return { installing, progressPct, error, retry };
 }

--- a/app/src/hooks/use-session-events.ts
+++ b/app/src/hooks/use-session-events.ts
@@ -10,6 +10,7 @@ import { useSessionStatusStore } from "../stores/session-status";
 import { subscribeHoustonEvents, listenOsEvent } from "../lib/events";
 import { logger } from "../lib/logger";
 import { tauriClaude } from "../lib/tauri";
+import { useClaudeInstallErrorText } from "./use-claude-install";
 import { hasToolRuntimeError } from "../components/tool-runtime-feed";
 import {
   consumePendingNav,
@@ -30,6 +31,7 @@ export function useSessionEvents() {
   const addToast = useUIStore((s) => s.addToast);
   const setAuthRequired = useUIStore((s) => s.setAuthRequired);
   const { t } = useTranslation(["providers", "common"]);
+  const claudeErrorText = useClaudeInstallErrorText();
 
   const handlersRef = useRef({
     pushFeedItem,
@@ -39,6 +41,7 @@ export function useSessionEvents() {
     getWorkspace: () => useWorkspaceStore.getState().current,
     getAgent: () => useAgentStore.getState().current,
     t,
+    claudeErrorText,
   });
   handlersRef.current = {
     pushFeedItem,
@@ -48,6 +51,7 @@ export function useSessionEvents() {
     getWorkspace: () => useWorkspaceStore.getState().current,
     getAgent: () => useAgentStore.getState().current,
     t,
+    claudeErrorText,
   };
 
   useEffect(() => {
@@ -133,19 +137,23 @@ export function useSessionEvents() {
           logger.info(`[auth] AuthRequired received: provider=${payload.data.provider}`);
           h.setAuthRequired(payload.data.provider);
           break;
-        case "ClaudeCliFailed":
+        case "ClaudeCliFailed": {
           // Per the beta-stage "no silent failures" rule, every install
           // failure must reach the user somewhere — the onboarding card
           // shows it inline but a user already past onboarding (e.g. on
           // a Houston upgrade that re-downloads claude-code) would
-          // otherwise never know. Toast carries the engine's classified
-          // message verbatim because it's already user-readable (see
-          // `houston_claude_installer::classify_reqwest_error`).
-          logger.warn(`[claude-install] ClaudeCliFailed: ${payload.data.message}`);
+          // otherwise never know. The engine emits a typed `kind`; we
+          // localize it here and keep `detail` in the log for the bug
+          // report.
+          const installError = payload.data.error;
+          logger.warn(
+            `[claude-install] ClaudeCliFailed: kind=${installError.kind}` +
+              (installError.detail ? ` detail=${installError.detail}` : ""),
+          );
           h.addToast({
             variant: "error",
             title: h.t("providers:claudeInstall.failedTitle"),
-            description: payload.data.message,
+            description: h.claudeErrorText(installError),
             action: {
               label: h.t("providers:claudeInstall.retry"),
               onClick: () => {
@@ -156,6 +164,7 @@ export function useSessionEvents() {
             },
           });
           break;
+        }
       }
     });
 

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -27,7 +27,18 @@
     "installingWithProgress": "Downloading Claude Code... {{progress}}%",
     "failedTitle": "Houston couldn't download Claude Code",
     "preparing": "Houston is downloading Claude Code in the background. If it doesn't start, try again below.",
-    "retry": "Retry download"
+    "retry": "Retry download",
+    "errors": {
+      "timeout": "The download took too long. Check your internet connection and try again.",
+      "networkUnreachable": "Couldn't reach Anthropic. Check your internet connection and try again.",
+      "downloadInterrupted": "The download was interrupted. Check your internet connection and try again.",
+      "httpError": "Anthropic's servers had a problem (error {{status}}). Try again in a few minutes.",
+      "checksumMismatch": "The download didn't arrive intact. Check your connection and try again.",
+      "platformUnsupported": "Claude Code isn't available for this device yet.",
+      "writeFailed": "Houston couldn't save Claude Code to your computer. Make sure there's enough space and try again.",
+      "unavailable": "Houston couldn't start the download. Try again in a moment.",
+      "unknown": "Something went wrong while downloading Claude Code. Try again."
+    }
   },
   "signOutConfirm": {
     "title": "Sign out of {{provider}}?",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -27,7 +27,18 @@
     "installingWithProgress": "Descargando Claude Code... {{progress}}%",
     "failedTitle": "Houston no pudo descargar Claude Code",
     "preparing": "Houston está descargando Claude Code en segundo plano. Si no inicia, reintenta abajo.",
-    "retry": "Reintentar descarga"
+    "retry": "Reintentar descarga",
+    "errors": {
+      "timeout": "La descarga tardó demasiado. Revisa tu conexión a internet e inténtalo de nuevo.",
+      "networkUnreachable": "No se pudo conectar con Anthropic. Revisa tu conexión a internet e inténtalo de nuevo.",
+      "downloadInterrupted": "La descarga se interrumpió. Revisa tu conexión a internet e inténtalo de nuevo.",
+      "httpError": "Los servidores de Anthropic tuvieron un problema (error {{status}}). Inténtalo de nuevo en unos minutos.",
+      "checksumMismatch": "La descarga no llegó completa. Revisa tu conexión e inténtalo de nuevo.",
+      "platformUnsupported": "Claude Code todavía no está disponible para este dispositivo.",
+      "writeFailed": "Houston no pudo guardar Claude Code en tu computador. Asegúrate de tener espacio suficiente e inténtalo de nuevo.",
+      "unavailable": "Houston no pudo iniciar la descarga. Inténtalo de nuevo en un momento.",
+      "unknown": "Algo salió mal al descargar Claude Code. Inténtalo de nuevo."
+    }
   },
   "signOutConfirm": {
     "title": "¿Cerrar sesión de {{provider}}?",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -27,7 +27,18 @@
     "installingWithProgress": "Baixando Claude Code... {{progress}}%",
     "failedTitle": "Houston não conseguiu baixar Claude Code",
     "preparing": "Houston está baixando Claude Code em segundo plano. Se não começar, tente novamente abaixo.",
-    "retry": "Tentar baixar de novo"
+    "retry": "Tentar baixar de novo",
+    "errors": {
+      "timeout": "O download demorou demais. Verifique sua conexão com a internet e tente novamente.",
+      "networkUnreachable": "Não foi possível conectar à Anthropic. Verifique sua conexão com a internet e tente novamente.",
+      "downloadInterrupted": "O download foi interrompido. Verifique sua conexão com a internet e tente novamente.",
+      "httpError": "Os servidores da Anthropic tiveram um problema (erro {{status}}). Tente novamente em alguns minutos.",
+      "checksumMismatch": "O download não chegou completo. Verifique sua conexão e tente novamente.",
+      "platformUnsupported": "O Claude Code ainda não está disponível para este dispositivo.",
+      "writeFailed": "O Houston não conseguiu salvar o Claude Code no seu computador. Verifique se há espaço suficiente e tente novamente.",
+      "unavailable": "O Houston não conseguiu iniciar o download. Tente novamente em instantes.",
+      "unknown": "Algo deu errado ao baixar o Claude Code. Tente novamente."
+    }
   },
   "signOutConfirm": {
     "title": "Sair de {{provider}}?",

--- a/engine/houston-claude-installer/src/lib.rs
+++ b/engine/houston-claude-installer/src/lib.rs
@@ -43,7 +43,7 @@
 
 use futures_util::StreamExt;
 use houston_db::db::Database;
-use houston_ui_events::{DynEventSink, HoustonEvent};
+use houston_ui_events::{ClaudeInstallError, DynEventSink, HoustonEvent};
 use sha2::{Digest, Sha256};
 use std::path::PathBuf;
 use tokio::io::AsyncWriteExt;
@@ -83,8 +83,8 @@ const CLI_KEY: &str = "claude-code";
 /// - Already installed at the pinned version → emit `ClaudeCliReady`.
 /// - Not installed, or installed at a different version →
 ///   download/verify/install, then emit `ClaudeCliReady`.
-/// - Download/verify failure → emit `ClaudeCliFailed { message }` with
-///   actionable hint.
+/// - Download/verify failure → emit `ClaudeCliFailed { error }` with a
+///   typed, localizable reason.
 pub async fn ensure_and_upgrade(sink: DynEventSink, db: Database) {
     // Resolve the manifest. In dev (no bundle), we fall back to the
     // checkout's `cli-deps.json` so engineers get the same auto-install
@@ -160,7 +160,7 @@ pub async fn finalize_install(
     db: &Database,
     pinned_version: &str,
     sink: &DynEventSink,
-    result: Result<PathBuf, String>,
+    result: Result<PathBuf, ClaudeInstallError>,
 ) {
     match result {
         Ok(path) => {
@@ -169,21 +169,47 @@ pub async fn finalize_install(
                 tracing::warn!("[claude-installer] failed to persist version marker: {e}");
             }
             // Clear the last-error marker so the UI stops surfacing a
-            // stale "couldn't reach Anthropic" message after a successful
-            // retry.
+            // stale failure after a successful retry.
             if let Err(e) = db.set_preference(PREF_LAST_INSTALL_ERROR, "").await {
                 tracing::warn!("[claude-installer] failed to clear last-error marker: {e}");
             }
             sink.emit(HoustonEvent::ClaudeCliReady);
         }
-        Err(e) => {
-            tracing::error!("[claude-installer] install failed: {e}");
-            if let Err(persist_err) = db.set_preference(PREF_LAST_INSTALL_ERROR, &e).await {
-                tracing::warn!("[claude-installer] failed to persist last-error marker: {persist_err}");
+        Err(error) => {
+            // English `Display` is for the engine log + bug-report
+            // bundle only; the typed `kind` is what the UI localizes.
+            tracing::error!("[claude-installer] install failed: {error}");
+            if let Err(persist_err) = db
+                .set_preference(PREF_LAST_INSTALL_ERROR, &error.to_pref_json())
+                .await
+            {
+                tracing::warn!(
+                    "[claude-installer] failed to persist last-error marker: {persist_err}"
+                );
             }
-            sink.emit(HoustonEvent::ClaudeCliFailed { message: e });
+            sink.emit(HoustonEvent::ClaudeCliFailed { error });
         }
     }
+}
+
+/// Resolve the pinned manifest, look up the `claude-code` entry, and run
+/// the install for the host platform. Used by the `POST /v1/claude/install`
+/// route so manifest / entry problems surface as a typed
+/// [`ClaudeInstallError`] through the normal `ClaudeCliFailed` path
+/// instead of a synchronous internal error the UI can't localize.
+///
+/// Returns the pinned version alongside the path on success so the
+/// caller can write the installed-version marker via [`finalize_install`].
+pub async fn install_pinned(
+    progress: impl FnMut(u8) + Send + 'static,
+) -> Result<(String, PathBuf), ClaudeInstallError> {
+    let manifest = resolve_manifest().ok_or(ClaudeInstallError::ManifestMissing)?;
+    let entry = manifest
+        .entry(CLI_KEY)
+        .ok_or(ClaudeInstallError::ManifestEntryMissing)?;
+    let version = entry.version.clone();
+    let path = install(&entry, progress).await?;
+    Ok((version, path))
 }
 
 /// Resolve the `cli-deps.json` manifest. Prefers the bundled copy
@@ -218,7 +244,7 @@ fn resolve_manifest() -> Option<houston_cli_bundle::CliDepsManifest> {
 pub async fn install(
     entry: &houston_cli_bundle::CliEntry,
     progress: impl FnMut(u8) + Send + 'static,
-) -> Result<PathBuf, String> {
+) -> Result<PathBuf, ClaudeInstallError> {
     install_to(entry, &install_dir(), binary_name(), progress).await
 }
 
@@ -231,21 +257,27 @@ pub async fn install_to(
     install_dir: &std::path::Path,
     binary_name: &str,
     mut progress: impl FnMut(u8) + Send + 'static,
-) -> Result<PathBuf, String> {
+) -> Result<PathBuf, ClaudeInstallError> {
     let platform = houston_cli_bundle::host_platform_key();
     let url = entry
         .url_for(platform)
-        .ok_or_else(|| format!("no claude-code URL for platform '{platform}'"))?;
+        .ok_or_else(|| ClaudeInstallError::PlatformUnsupported {
+            platform: platform.to_string(),
+        })?;
     let expected_checksum = entry
         .checksum_for(platform)
-        .ok_or_else(|| format!("no claude-code checksum for platform '{platform}'"))?
+        .ok_or_else(|| ClaudeInstallError::PlatformUnsupported {
+            platform: platform.to_string(),
+        })?
         .to_string();
 
     tracing::info!("[claude-installer] GET {url}");
 
     tokio::fs::create_dir_all(install_dir)
         .await
-        .map_err(|e| format!("failed to create install dir {}: {e}", install_dir.display()))?;
+        .map_err(|e| ClaudeInstallError::WriteFailed {
+            detail: format!("failed to create install dir {}: {e}", install_dir.display()),
+        })?;
 
     let final_path = install_dir.join(binary_name);
     // Temp path on the same filesystem so the final rename is atomic
@@ -258,19 +290,20 @@ pub async fn install_to(
     let client = reqwest::Client::builder()
         .connect_timeout(std::time::Duration::from_secs(15))
         .build()
-        .map_err(|e| format!("failed to build HTTP client: {e}"))?;
+        .map_err(|e| ClaudeInstallError::Unknown {
+            detail: format!("failed to build HTTP client: {e}"),
+        })?;
 
     let resp = client
         .get(&url)
         .send()
         .await
-        .map_err(|e| classify_reqwest_error(&e, &url))?;
+        .map_err(|e| classify_reqwest_error(&e))?;
 
     if !resp.status().is_success() {
-        return Err(format!(
-            "Anthropic's download server returned HTTP {}. Try again in a few minutes; if it keeps happening, report it.",
-            resp.status()
-        ));
+        return Err(ClaudeInstallError::HttpError {
+            status: resp.status().as_u16(),
+        });
     }
 
     let total = resp.content_length();
@@ -281,15 +314,19 @@ pub async fn install_to(
 
     let mut tmp_file = tokio::fs::File::create(&tmp_path)
         .await
-        .map_err(|e| format!("failed to open temp file {}: {e}", tmp_path.display()))?;
+        .map_err(|e| ClaudeInstallError::WriteFailed {
+            detail: format!("failed to open temp file {}: {e}", tmp_path.display()),
+        })?;
 
     while let Some(chunk) = stream.next().await {
-        let chunk = chunk.map_err(|e| classify_reqwest_error(&e, &url))?;
+        let chunk = chunk.map_err(|e| classify_reqwest_error(&e))?;
         hasher.update(&chunk);
         tmp_file
             .write_all(&chunk)
             .await
-            .map_err(|e| format!("failed to write chunk: {e}"))?;
+            .map_err(|e| ClaudeInstallError::WriteFailed {
+                detail: format!("failed to write chunk: {e}"),
+            })?;
         downloaded = downloaded.saturating_add(chunk.len() as u64);
 
         // Throttle progress events so we don't flood the WebSocket.
@@ -309,7 +346,9 @@ pub async fn install_to(
     tmp_file
         .flush()
         .await
-        .map_err(|e| format!("flush failed: {e}"))?;
+        .map_err(|e| ClaudeInstallError::WriteFailed {
+            detail: format!("flush failed: {e}"),
+        })?;
     drop(tmp_file);
 
     // Always emit a final 100% so the UI can transition out of
@@ -320,12 +359,11 @@ pub async fn install_to(
     let actual_checksum = hex::encode(hasher.finalize());
     if !checksum_matches(&actual_checksum, &expected_checksum) {
         let _ = tokio::fs::remove_file(&tmp_path).await;
-        // Surface a user-readable summary and keep the technical detail
-        // appended so the engine logs / bug reports stay diagnosable.
-        return Err(format!(
-            "The downloaded Claude Code file looks corrupted. Check your internet connection and try again. \
-             (checksum mismatch: expected {expected_checksum}, got {actual_checksum})"
-        ));
+        // The localized user copy comes from the `kind`; the expected /
+        // actual digests ride along in `detail` for the bug report.
+        return Err(ClaudeInstallError::ChecksumMismatch {
+            detail: format!("checksum mismatch: expected {expected_checksum}, got {actual_checksum}"),
+        });
     }
 
     // Make the binary executable BEFORE the rename so a racing reader
@@ -334,8 +372,9 @@ pub async fn install_to(
     {
         use std::os::unix::fs::PermissionsExt;
         let perms = std::fs::Permissions::from_mode(0o755);
-        std::fs::set_permissions(&tmp_path, perms)
-            .map_err(|e| format!("failed to chmod +x: {e}"))?;
+        std::fs::set_permissions(&tmp_path, perms).map_err(|e| ClaudeInstallError::WriteFailed {
+            detail: format!("failed to chmod +x: {e}"),
+        })?;
     }
 
     // Atomic rename within the same dir. On Unix this is a syscall;
@@ -347,11 +386,11 @@ pub async fn install_to(
             let _ = std::fs::remove_file(&final_path);
         }
     }
-    std::fs::rename(&tmp_path, &final_path).map_err(|e| {
-        format!(
-            "failed to install to {}: {e} — check the directory is writable",
+    std::fs::rename(&tmp_path, &final_path).map_err(|e| ClaudeInstallError::WriteFailed {
+        detail: format!(
+            "failed to install to {}: {e} (check the directory is writable)",
             final_path.display()
-        )
+        ),
     })?;
 
     Ok(final_path)
@@ -377,29 +416,29 @@ fn checksum_matches(actual: &str, expected: &str) -> bool {
 /// (laptop on a flaky cafe wifi, captive portal). The other branches
 /// (HTTP 5xx, response body decode) get their own user-readable
 /// wording.
-fn classify_reqwest_error(err: &reqwest::Error, url: &str) -> String {
+fn classify_reqwest_error(err: &reqwest::Error) -> ClaudeInstallError {
     if err.is_timeout() {
-        return "Timed out while downloading Claude Code. Check your internet connection and try again.".to_string();
+        return ClaudeInstallError::Timeout;
     }
     if err.is_connect() {
-        return "Couldn't reach Anthropic to download Claude Code. Check your internet connection and try again.".to_string();
+        return ClaudeInstallError::NetworkUnreachable;
     }
     if err.is_body() || err.is_decode() {
-        return "Download interrupted while fetching Claude Code. Check your internet connection and try again.".to_string();
+        return ClaudeInstallError::DownloadInterrupted;
     }
     if err.is_request() {
         // `is_request` catches the catch-all "request-level" failures
         // (DNS lookup failure at the resolver layer, TLS handshake
         // failure, etc.) that don't surface through the more specific
         // predicates above. From the user's perspective these all mean
-        // "the network didn't cooperate", so collapse to the same
-        // wording rather than leaking the chain.
-        return "Couldn't reach Anthropic to download Claude Code. Check your internet connection and try again.".to_string();
+        // "the network didn't cooperate", so collapse to the same kind.
+        return ClaudeInstallError::NetworkUnreachable;
     }
     // Unknown shape — keep the technical detail so bug reports stay
-    // actionable. Drops the URL because users don't need it inline.
-    let _ = url;
-    format!("Download failed: {err}")
+    // actionable.
+    ClaudeInstallError::Unknown {
+        detail: err.to_string(),
+    }
 }
 
 #[cfg(test)]
@@ -536,9 +575,13 @@ mod tests {
         let result = install_to(&entry, dest_dir.path(), "claude", |_| {}).await;
 
         let err = result.expect_err("checksum mismatch must error");
+        let detail = match err {
+            ClaudeInstallError::ChecksumMismatch { detail } => detail,
+            other => panic!("expected ChecksumMismatch, got {other:?}"),
+        };
         assert!(
-            err.contains("checksum mismatch"),
-            "unexpected error: {err}"
+            detail.contains("checksum mismatch"),
+            "detail must keep the technical digests for the bug report: {detail}"
         );
         // Both the partial and the final must be absent — we never want
         // a tampered binary on disk after a verification failure.
@@ -560,13 +603,10 @@ mod tests {
         let result = install_to(&entry, dest_dir.path(), "claude", |_| {}).await;
 
         let err = result.expect_err("server 500 must error");
-        assert!(
-            err.contains("500"),
-            "unexpected error (must mention status code): {err}"
-        );
-        assert!(
-            err.contains("Anthropic"),
-            "must name the upstream so users know who to blame: {err}"
+        assert_eq!(
+            err,
+            ClaudeInstallError::HttpError { status: 500 },
+            "5xx must classify as HttpError carrying the status code"
         );
     }
 
@@ -603,52 +643,81 @@ mod tests {
         let result = install_to(&entry, dest_dir.path(), "claude", |_| {}).await;
 
         let err = result.expect_err("bad host must error");
-        // The legacy message started with `download request failed:
-        // error sending request for url (...): error trying to connect:
-        // dns error: ...`. The new message is human-readable.
-        assert!(
-            err.contains("internet connection"),
-            "must coach user on internet connection: {err}"
-        );
-        assert!(
-            !err.contains("error sending request"),
-            "must not leak the reqwest error chain: {err}"
+        // A DNS/connect failure used to dump the raw reqwest chain at the
+        // user (issue #231). It must now collapse to the typed
+        // NetworkUnreachable kind so the frontend can localize it — no
+        // English prose, no leaked transport chain.
+        assert_eq!(
+            err,
+            ClaudeInstallError::NetworkUnreachable,
+            "DNS/connect failure must classify as NetworkUnreachable"
         );
     }
 
     #[tokio::test]
     async fn install_surfaces_stream_interruption() {
-        // Server promises 1 KB but closes the socket after a few bytes.
-        // Without classify_reqwest_error the user would see the raw
-        // `hyper::Error(IncompleteMessage)` chain.
-        let server = MockServer::start().await;
-        Mock::given(method("GET"))
-            .and(path("/claude"))
-            .respond_with(
-                ResponseTemplate::new(200)
-                    .insert_header("content-length", "1024")
-                    .set_body_bytes(b"short".to_vec()),
-            )
-            .mount(&server)
-            .await;
+        // A genuinely truncated download: the server declares a 1 KB body
+        // in Content-Length but writes a handful of bytes and slams the
+        // socket shut, so reqwest fails mid-stream with a body/decode
+        // error. Without classify_reqwest_error the user would see the raw
+        // `hyper::Error(IncompleteMessage)` chain (issue #231).
+        //
+        // wiremock can't express this — it recomputes Content-Length from
+        // the body, so a hand-rolled one-shot TCP server is the only way
+        // to put a header/body length mismatch on the wire.
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        use tokio::net::TcpListener;
 
-        let entry = entry_for(&server.uri(), b"unused");
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            if let Ok((mut socket, _)) = listener.accept().await {
+                // Drain the request head enough to start replying; the
+                // exact bytes don't matter, only that we then send a
+                // short, truncated response body.
+                let mut buf = [0u8; 1024];
+                let _ = socket.read(&mut buf).await;
+                let _ = socket
+                    .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 1024\r\n\r\nshort")
+                    .await;
+                // Dropping `socket` here closes the connection mid-body.
+            }
+        });
+
+        let entry = entry_for(&format!("http://{addr}"), b"unused");
         let dest_dir = tempfile::tempdir().unwrap();
         let result = install_to(&entry, dest_dir.path(), "claude", |_| {}).await;
 
-        // The mock may complete the body OR cut the stream depending on
-        // wiremock internals. Both paths must produce a user-readable
-        // error, never the raw reqwest chain. If the stream completes
-        // cleanly the checksum mismatch fires instead — also acceptable
-        // and also user-readable.
-        let err = result.expect_err("undersized response must error somewhere");
-        assert!(
-            err.contains("internet connection") || err.contains("corrupted"),
-            "must collapse to a user-readable error: {err}"
+        let err = result.expect_err("a truncated download must error");
+        // The connection succeeded — only the body was cut — so this must
+        // collapse to the typed DownloadInterrupted kind, never the raw
+        // hyper chain and never NetworkUnreachable.
+        assert_eq!(
+            err,
+            ClaudeInstallError::DownloadInterrupted,
+            "truncated stream must classify as DownloadInterrupted, got {err:?}"
         );
-        assert!(
-            !err.contains("hyper::") && !err.contains("IncompleteMessage"),
-            "must not leak hyper internals: {err}"
+    }
+
+    #[test]
+    fn error_kinds_serialize_with_snake_case_discriminant() {
+        // The wire contract the TS union mirrors: a `kind` discriminant
+        // in snake_case, per-variant fields alongside.
+        assert_eq!(
+            serde_json::to_string(&ClaudeInstallError::NetworkUnreachable).unwrap(),
+            r#"{"kind":"network_unreachable"}"#
         );
+        assert_eq!(
+            serde_json::to_string(&ClaudeInstallError::HttpError { status: 503 }).unwrap(),
+            r#"{"kind":"http_error","status":503}"#
+        );
+        // The preference JSON form the status route reads back must
+        // round-trip losslessly.
+        let original = ClaudeInstallError::ChecksumMismatch {
+            detail: "expected a, got b".into(),
+        };
+        let restored: ClaudeInstallError =
+            serde_json::from_str(&original.to_pref_json()).unwrap();
+        assert_eq!(restored, original);
     }
 }

--- a/engine/houston-engine-server/src/routes/claude.rs
+++ b/engine/houston-engine-server/src/routes/claude.rs
@@ -15,14 +15,14 @@
 //!   "Retry"). Returns 202-style — the install runs in the background
 //!   and progress events stream over the WS firehose.
 
-use crate::routes::error::ApiError;
 use crate::state::ServerState;
 use axum::{
     extract::State,
+    http::StatusCode,
     routing::{get, post},
     Json, Router,
 };
-use houston_engine_core::CoreError;
+use houston_ui_events::{ClaudeInstallError, HoustonEvent};
 use serde::Serialize;
 use std::sync::Arc;
 
@@ -53,17 +53,13 @@ struct ClaudeStatus {
     /// Used by the lifecycle to decide whether to re-download on a
     /// Houston upgrade that bumps the pinned version.
     installed_version: Option<String>,
-    /// Last install failure reason, classified for end users (see
-    /// `houston_claude_installer::classify_reqwest_error`). `None` when
-    /// install has never failed, or when the most recent attempt
-    /// succeeded. The onboarding "Sign in with Anthropic" card reads
-    /// this so it can distinguish "Houston tried but the network was
-    /// down" from "the user hasn't connected yet" — issue #231.
-    last_install_error: Option<String>,
-}
-
-fn lift(e: String) -> ApiError {
-    ApiError(CoreError::Internal(e))
+    /// Last install failure, as a typed [`ClaudeInstallError`] (`kind` +
+    /// optional `detail`). `None` when install has never failed, or when
+    /// the most recent attempt succeeded. The onboarding "Sign in with
+    /// Anthropic" card reads this so it can distinguish "Houston tried
+    /// but the network was down" from "the user hasn't connected yet"
+    /// (issue #231); the frontend localizes `kind` (en/es/pt).
+    last_install_error: Option<ClaudeInstallError>,
 }
 
 async fn cli_installed(State(_st): State<Arc<ServerState>>) -> Json<CliInstalled> {
@@ -91,8 +87,12 @@ async fn status(State(st): State<Arc<ServerState>>) -> Json<ClaudeStatus> {
 
     // Empty string is the cleared sentinel — the installer writes "" on
     // a successful retry rather than deleting the row, so we filter it
-    // here so the UI doesn't render an empty-string error card.
-    let last_install_error = st
+    // here so the UI doesn't render an empty-string error card. The
+    // stored value is the JSON form of a `ClaudeInstallError`; a value
+    // that doesn't parse is a legacy/corrupt marker from an older build,
+    // so we log it and degrade to "no error" rather than 500 the status
+    // call.
+    let raw_last_error = st
         .engine
         .db
         .get_preference(houston_claude_installer::PREF_LAST_INSTALL_ERROR)
@@ -100,6 +100,18 @@ async fn status(State(st): State<Arc<ServerState>>) -> Json<ClaudeStatus> {
         .ok()
         .flatten()
         .filter(|s| !s.is_empty());
+    let last_install_error = match raw_last_error {
+        Some(s) => match serde_json::from_str::<ClaudeInstallError>(&s) {
+            Ok(error) => Some(error),
+            Err(parse_err) => {
+                tracing::warn!(
+                    "[claude] ignoring legacy/corrupt last-install-error preference: {parse_err}"
+                );
+                None
+            }
+        },
+        None => None,
+    };
 
     Json(ClaudeStatus {
         installed,
@@ -111,41 +123,38 @@ async fn status(State(st): State<Arc<ServerState>>) -> Json<ClaudeStatus> {
 }
 
 /// Trigger a fresh install in the background. The request returns
-/// immediately; install progress + completion are emitted as
-/// `HoustonEvent::ClaudeCliInstalling` / `ClaudeCliReady` /
+/// `202 Accepted` immediately; install progress + completion are emitted
+/// as `HoustonEvent::ClaudeCliInstalling` / `ClaudeCliReady` /
 /// `ClaudeCliFailed` over the WebSocket firehose.
-async fn install(State(st): State<Arc<ServerState>>) -> Result<(), ApiError> {
-    let manifest = houston_cli_bundle::load_bundled_manifest()
-        .ok_or_else(|| lift("cli-deps.json manifest not available — install pinned manifest first".into()))?;
-    let entry = manifest
-        .entry("claude-code")
-        .ok_or_else(|| lift("cli-deps.json missing 'claude-code' entry".into()))?;
-    let pinned_version = entry.version.clone();
-
-    // Run the actual install on a background task so the HTTP request
-    // returns immediately. The lifecycle entry would emit the same
-    // events, but going through `install()` directly lets us run the
-    // install even when the version marker already matches (manual
-    // "reinstall" from the UI).
+///
+/// Manifest resolution runs INSIDE the spawned task (via
+/// `install_pinned`) so a missing or malformed manifest surfaces as a
+/// typed `ClaudeCliFailed { ManifestMissing }` the UI can localize,
+/// rather than a synchronous internal error string the frontend would
+/// have shown verbatim (untranslated) on Retry.
+async fn install(State(st): State<Arc<ServerState>>) -> StatusCode {
     let sink = st.engine.events.clone();
     let db = st.engine.db.clone();
     tokio::spawn(async move {
-        sink.emit(houston_ui_events::HoustonEvent::ClaudeCliInstalling { progress_pct: 0 });
+        sink.emit(HoustonEvent::ClaudeCliInstalling { progress_pct: 0 });
         let sink_for_progress = sink.clone();
-        let result =
-            houston_claude_installer::install(&entry, move |pct| {
-                sink_for_progress
-                    .emit(houston_ui_events::HoustonEvent::ClaudeCliInstalling { progress_pct: pct });
-            })
-            .await;
+        let outcome = houston_claude_installer::install_pinned(move |pct| {
+            sink_for_progress.emit(HoustonEvent::ClaudeCliInstalling { progress_pct: pct });
+        })
+        .await;
         // Delegate to the shared finalizer so we write the same DB
-        // markers as the boot-time `ensure_and_upgrade` path. The
-        // alternative (in-lining the writes here) drifted in the past:
-        // the success branch persisted the version but neither branch
-        // touched `claude_code_last_install_error`, so a successful
-        // retry left a stale failure marker on disk.
-        houston_claude_installer::finalize_install(&db, &pinned_version, &sink, result).await;
+        // markers (version + cleared/updated last-error) as the
+        // boot-time `ensure_and_upgrade` path. The version is only used
+        // on the success branch, so the error branch passes "".
+        match outcome {
+            Ok((version, path)) => {
+                houston_claude_installer::finalize_install(&db, &version, &sink, Ok(path)).await;
+            }
+            Err(error) => {
+                houston_claude_installer::finalize_install(&db, "", &sink, Err(error)).await;
+            }
+        }
     });
 
-    Ok(())
+    StatusCode::ACCEPTED
 }

--- a/engine/houston-ui-events/src/lib.rs
+++ b/engine/houston-ui-events/src/lib.rs
@@ -9,9 +9,99 @@
 //! injected at the top of the app. No Tauri dep here by design.
 
 use houston_terminal_manager::FeedItem;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tokio::sync::broadcast;
+
+/// Typed reason a Claude Code install attempt failed.
+///
+/// Mirrors the `ProviderError` taxonomy (see
+/// `knowledge-base/provider-errors.md`): the engine is i18n-agnostic, so
+/// instead of shipping an English sentence to the UI we emit a stable
+/// `kind` slug and let the frontend localize it (en/es/pt). The
+/// `Display` impl is the English wording, kept ONLY for engine logs and
+/// the Report-bug bundle — never shown to a user verbatim. `detail`
+/// carries the technical specifics (digest values, filesystem error,
+/// raw transport error) for those diagnostics.
+///
+/// Serializes with a `kind` discriminant (snake_case) so the same JSON
+/// flows over the WS `ClaudeCliFailed` event AND into the
+/// `claude_code_last_install_error` preference the status route reads
+/// back. Lives in this crate (not `houston-claude-installer`) because
+/// the installer depends on this crate for `HoustonEvent` — putting the
+/// type here keeps the dependency edge one-way.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ClaudeInstallError {
+    /// Download timed out.
+    Timeout,
+    /// Couldn't reach Anthropic at all (DNS, refused connection, TLS, or
+    /// any other request-level transport failure).
+    NetworkUnreachable,
+    /// The connection dropped mid-stream (truncated body / decode error).
+    DownloadInterrupted,
+    /// Anthropic's download server answered with a non-success status.
+    HttpError { status: u16 },
+    /// The downloaded bytes didn't match the pinned SHA-256.
+    ChecksumMismatch { detail: String },
+    /// No URL / checksum is pinned for the host platform.
+    PlatformUnsupported { platform: String },
+    /// A filesystem step failed (mkdir, temp file, write, flush, chmod,
+    /// rename).
+    WriteFailed { detail: String },
+    /// `cli-deps.json` couldn't be resolved. Dev-only in practice —
+    /// production bundles the manifest. Surfaced to the user as a
+    /// generic "couldn't start the download" so we never leak the
+    /// internal manifest hint.
+    ManifestMissing,
+    /// Manifest resolved but has no `claude-code` entry.
+    ManifestEntryMissing,
+    /// No classifier matched. `detail` carries the raw error so the bug
+    /// report stays actionable.
+    Unknown { detail: String },
+}
+
+impl std::fmt::Display for ClaudeInstallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Timeout => write!(f, "Timed out while downloading Claude Code."),
+            Self::NetworkUnreachable => {
+                write!(f, "Couldn't reach Anthropic to download Claude Code.")
+            }
+            Self::DownloadInterrupted => {
+                write!(f, "Download interrupted while fetching Claude Code.")
+            }
+            Self::HttpError { status } => {
+                write!(f, "Anthropic's download server returned HTTP {status}.")
+            }
+            Self::ChecksumMismatch { detail } => {
+                write!(f, "Downloaded Claude Code failed checksum verification ({detail}).")
+            }
+            Self::PlatformUnsupported { platform } => {
+                write!(f, "No Claude Code download is pinned for platform '{platform}'.")
+            }
+            Self::WriteFailed { detail } => {
+                write!(f, "Failed to write Claude Code to disk: {detail}")
+            }
+            Self::ManifestMissing => {
+                write!(f, "cli-deps.json manifest not available; install the pinned manifest first.")
+            }
+            Self::ManifestEntryMissing => write!(f, "cli-deps.json has no 'claude-code' entry."),
+            Self::Unknown { detail } => write!(f, "Claude Code install failed: {detail}"),
+        }
+    }
+}
+
+impl ClaudeInstallError {
+    /// JSON form persisted to the `claude_code_last_install_error`
+    /// preference and read back by the status route. Falls back to a
+    /// valid `unknown` document if serialization ever fails so the
+    /// stored value always round-trips.
+    pub fn to_pref_json(&self) -> String {
+        serde_json::to_string(self)
+            .unwrap_or_else(|_| r#"{"kind":"unknown","detail":""}"#.to_string())
+    }
+}
 
 #[derive(Clone, Debug, Serialize)]
 #[serde(tag = "type", content = "data")]
@@ -154,9 +244,10 @@ pub enum HoustonEvent {
     /// already at the pinned version). Frontend invalidates the
     /// `provider_status` query so the Anthropic provider chip updates.
     ClaudeCliReady,
-    /// Claude Code CLI install or upgrade failed. `message` is intended
-    /// to be user-readable (network/region/permissions/disk-space hints).
-    ClaudeCliFailed { message: String },
+    /// Claude Code CLI install or upgrade failed. Carries a typed
+    /// [`ClaudeInstallError`] (`kind` + optional `detail`); the frontend
+    /// localizes `kind` and the engine logs the English `Display`.
+    ClaudeCliFailed { error: ClaudeInstallError },
 
     // ----- Provider OAuth login (URL relay) -----
     //

--- a/ui/core/src/types.ts
+++ b/ui/core/src/types.ts
@@ -1,4 +1,38 @@
 /**
+ * Stable failure `kind` for a Claude Code install attempt. Mirror of the
+ * Rust `ClaudeInstallError` enum in
+ * `engine/houston-ui-events/src/lib.rs` (serde `tag = "kind"`,
+ * snake_case). The engine emits the slug; the frontend localizes it. The
+ * two MUST stay in sync.
+ */
+export type ClaudeInstallErrorKind =
+  | "timeout"
+  | "network_unreachable"
+  | "download_interrupted"
+  | "http_error"
+  | "checksum_mismatch"
+  | "platform_unsupported"
+  | "write_failed"
+  | "manifest_missing"
+  | "manifest_entry_missing"
+  | "unknown";
+
+/**
+ * Typed install failure carried by `ClaudeCliFailed`. `kind` is
+ * localized by the frontend; `detail` is technical text for the bug
+ * report, never shown verbatim.
+ */
+export interface ClaudeInstallError {
+  kind: ClaudeInstallErrorKind;
+  /** Present on `http_error`. */
+  status?: number;
+  /** Present on `platform_unsupported`. */
+  platform?: string;
+  /** Present on `checksum_mismatch` / `write_failed` / `unknown`. */
+  detail?: string;
+}
+
+/**
  * Events emitted from the Rust backend via houston-tauri.
  *
  * Mirrors the Rust `HoustonEvent` enum in `houston-tauri/src/events.rs`.
@@ -130,7 +164,7 @@ export type HoustonEvent =
     }
   | {
       type: "ClaudeCliFailed";
-      data: { message: string };
+      data: { error: ClaudeInstallError };
     }
   | {
       type: "ProviderLoginUrl";

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -600,6 +600,40 @@ export interface AttachmentManifest extends AttachmentUploadResult {
 // ---------- Claude Code installer ----------
 
 /**
+ * Stable failure `kind` for a Claude Code install attempt. Mirror of the
+ * Rust `ClaudeInstallError` enum in
+ * `engine/houston-ui-events/src/lib.rs` (serde `tag = "kind"`,
+ * snake_case). The engine is i18n-agnostic, so it emits the slug and the
+ * frontend localizes it. The two MUST stay in sync.
+ */
+export type ClaudeInstallErrorKind =
+  | "timeout"
+  | "network_unreachable"
+  | "download_interrupted"
+  | "http_error"
+  | "checksum_mismatch"
+  | "platform_unsupported"
+  | "write_failed"
+  | "manifest_missing"
+  | "manifest_entry_missing"
+  | "unknown";
+
+/**
+ * Typed install failure. `kind` is localized by the frontend; the
+ * optional fields carry per-kind data. `detail` is technical text for
+ * the bug report — never shown to a user verbatim.
+ */
+export interface ClaudeInstallError {
+  kind: ClaudeInstallErrorKind;
+  /** Present on `http_error`. */
+  status?: number;
+  /** Present on `platform_unsupported`. */
+  platform?: string;
+  /** Present on `checksum_mismatch` / `write_failed` / `unknown`. */
+  detail?: string;
+}
+
+/**
  * Snapshot of the runtime Claude Code install. Returned by
  * `GET /v1/claude/status`.
  *
@@ -614,7 +648,7 @@ export interface ClaudeStatus {
   installPath: string;
   pinnedVersion: string | null;
   installedVersion: string | null;
-  lastInstallError: string | null;
+  lastInstallError: ClaudeInstallError | null;
 }
 
 // ---------- Composio ----------


### PR DESCRIPTION
Closes #322

## Problem

Claude Code install failures showed **hardcoded English** to the user (e.g. _"Couldn't reach Anthropic to download Claude Code..."_), ignoring the app's en/es/pt support. Worse, clicking **Retry** leaked an internal string (`cli-deps.json manifest not available — install pinned manifest first`) **raw** to the user, because manifest resolution ran synchronously in the HTTP handler before the background task started.

Follow-up to #270 (which added the real-reason error but as a free-form English string).

## Fix

Replace the free-form message with a typed `ClaudeInstallError` enum (serde-tagged `kind` discriminant), mirroring the existing `ProviderError` pattern:

- The **engine stays i18n-agnostic** and emits a stable slug (`network_unreachable`, `timeout`, `http_error`, `checksum_mismatch`, `manifest_missing`, …).
- The **app maps `kind` → `t()`** in en/es/pt.
- `detail` rides along for logs and the bug-report bundle but is **never shown** to the user.

Manifest resolution moves **into the background install task** (`install_pinned`), so a missing/malformed manifest surfaces as a typed `manifest_missing` (localized to a generic "unavailable") instead of a synchronous internal error the frontend rendered verbatim on Retry.

## Changes by layer

**Engine**
- `houston-ui-events` — new `ClaudeInstallError` (+ `Display` + `to_pref_json`); `ClaudeCliFailed` now carries `{ error }` instead of `{ message }`. (Lives here, not the installer, so the dependency edge stays one-way.)
- `houston-claude-installer` — `install`/`install_to`/`finalize_install` return the typed error; `classify_reqwest_error` maps reqwest failures to kinds; new `install_pinned` resolves the manifest in-task.
- `routes/claude.rs` — `install` returns `202` and finalizes in the spawned task; `status` reads the error back as JSON, degrading gracefully on legacy/corrupt values.

**UI types (hand-mirrored, both packages)**
- `ui/core`, `ui/engine-client` — `ClaudeInstallErrorKind` union + `ClaudeInstallError`; `ClaudeStatus.lastInstallError` typed.

**App**
- `use-claude-install.ts` — state carries typed `error`; new `useClaudeInstallErrorText()` maps `kind` → localized copy.
- `claude-install-hint.tsx`, `use-session-events.ts` — inline hint + `ClaudeCliFailed` toast both localized.
- `locales/{en,es,pt}/providers.json` — `claudeInstall.errors.*` for every kind (no em dashes; es = LatAm neutral, pt = Brazilian).

## Tests

- Unit tests assert on `kind`/`detail` rather than English prose.
- New wire-contract test pins the snake_case `kind` discriminant the TS union mirrors.
- `install_surfaces_stream_interruption` now drives a **real truncated download** via a hand-rolled one-shot TCP server (wiremock can't emit a Content-Length/body-length mismatch), exercising the `DownloadInterrupted` path deterministically.

## Affected files

- `engine/houston-ui-events/src/lib.rs`
- `engine/houston-claude-installer/src/lib.rs`
- `engine/houston-engine-server/src/routes/claude.rs`
- `ui/core/src/types.ts`
- `ui/engine-client/src/types.ts`
- `app/src/hooks/use-claude-install.ts`
- `app/src/hooks/use-session-events.ts`
- `app/src/components/shell/claude-install-hint.tsx`
- `app/src/locales/{en,es,pt}/providers.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
