### PR TITLE
fix: recover corrupt routine run history

### DIFF
--- a/engine/houston-agent-files/src/lib.rs
+++ b/engine/houston-agent-files/src/lib.rs
@@ -90,7 +90,7 @@ pub fn write_file_atomic(agent_root: &Path, rel: &str, content: &str) -> Result<
     if let Some(parent) = path.parent() {
         fs::create_dir_all(parent)?;
     }
-    let tmp = path.with_extension("tmp");
+    let tmp = unique_tmp_path(&path);
     {
         let mut f = fs::File::create(&tmp)?;
         f.write_all(content.as_bytes())?;
@@ -98,6 +98,11 @@ pub fn write_file_atomic(agent_root: &Path, rel: &str, content: &str) -> Result<
     }
     fs::rename(&tmp, &path)?;
     Ok(())
+}
+
+fn unique_tmp_path(path: &Path) -> PathBuf {
+    let file_name = path.file_name().and_then(|s| s.to_str()).unwrap_or("file");
+    path.with_file_name(format!(".{file_name}.{}.tmp", uuid::Uuid::new_v4()))
 }
 
 /// Classify a relative path to the matching event type name.

--- a/engine/houston-engine-core/src/agents/routine_runs.rs
+++ b/engine/houston-engine-core/src/agents/routine_runs.rs
@@ -22,6 +22,10 @@ pub fn list_for_routine(root: &Path, routine_id: &str) -> CoreResult<Vec<Routine
 }
 
 pub fn create(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
+    with_runs_lock(root, || create_unlocked(root, routine_id))
+}
+
+fn create_unlocked(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
     let mut runs = list(root)?;
     let id = Uuid::new_v4().to_string();
     let session_key = format!("routine-{routine_id}-run-{id}");
@@ -42,6 +46,10 @@ pub fn create(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
 }
 
 pub fn update(root: &Path, id: &str, updates: RoutineRunUpdate) -> CoreResult<RoutineRun> {
+    with_runs_lock(root, || update_unlocked(root, id, updates))
+}
+
+fn update_unlocked(root: &Path, id: &str, updates: RoutineRunUpdate) -> CoreResult<RoutineRun> {
     let mut runs = list(root)?;
     let run = runs
         .iter_mut()
@@ -64,6 +72,10 @@ pub fn update(root: &Path, id: &str, updates: RoutineRunUpdate) -> CoreResult<Ro
     let result = run.clone();
     write_json(root, FILE, &runs)?;
     Ok(result)
+}
+
+fn with_runs_lock<T>(root: &Path, f: impl FnOnce() -> CoreResult<T>) -> CoreResult<T> {
+    super::store::with_json_file_lock(root, FILE, f)
 }
 
 /// Keep only the most recent `MAX_RUNS_PER_ROUTINE` runs per routine.

--- a/engine/houston-engine-core/src/agents/store.rs
+++ b/engine/houston-engine-core/src/agents/store.rs
@@ -3,10 +3,18 @@
 //! Delegates atomic writes + path-traversal safety to `houston-agent-files`.
 
 use crate::error::{CoreError, CoreResult};
+use chrono::Utc;
 use houston_agent_files as files;
+use once_cell::sync::Lazy;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use uuid::Uuid;
+
+static JSON_FILE_LOCKS: Lazy<Mutex<HashMap<PathBuf, Arc<Mutex<()>>>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
 
 /// Returns the `.houston/` directory inside an agent root.
 pub fn houston_dir(root: &Path) -> PathBuf {
@@ -27,16 +35,47 @@ fn rel_path(name: &str) -> String {
     format!(".houston/{name}/{name}.json")
 }
 
+pub fn with_json_file_lock<T>(
+    root: &Path,
+    name: &str,
+    f: impl FnOnce() -> CoreResult<T>,
+) -> CoreResult<T> {
+    let rel = rel_path(name);
+    let key = root.join(&rel);
+    let lock = {
+        let mut locks = JSON_FILE_LOCKS
+            .lock()
+            .map_err(|_| CoreError::Internal(format!("{rel} lock registry poisoned")))?;
+        locks
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    };
+    let _guard = lock
+        .lock()
+        .map_err(|_| CoreError::Internal(format!("{rel} lock poisoned")))?;
+    f()
+}
+
 /// Read and deserialize `.houston/<name>/<name>.json`.
 /// Returns `T::default()` if the file does not exist or is empty.
-pub fn read_json<T: DeserializeOwned + Default>(root: &Path, name: &str) -> CoreResult<T> {
+pub fn read_json<T: DeserializeOwned + Serialize + Default>(
+    root: &Path,
+    name: &str,
+) -> CoreResult<T> {
     let rel = rel_path(name);
     let contents = files::read_file(root, &rel)
         .map_err(|e| CoreError::Internal(format!("failed to read {rel}: {e}")))?;
     if contents.is_empty() {
         return Ok(T::default());
     }
-    serde_json::from_str(&contents).map_err(Into::into)
+    match serde_json::from_str(&contents) {
+        Ok(value) => Ok(value),
+        Err(err) => match repair_json(root, name, &rel, &contents, &err)? {
+            Some(value) => Ok(value),
+            None => Err(err.into()),
+        },
+    }
 }
 
 /// Atomically write a typed value as `.houston/<name>/<name>.json`.
@@ -45,4 +84,62 @@ pub fn write_json<T: Serialize>(root: &Path, name: &str, data: &T) -> CoreResult
     let body = serde_json::to_string_pretty(data)?;
     files::write_file_atomic(root, &rel, &body)
         .map_err(|e| CoreError::Internal(format!("failed to write {rel}: {e}")))
+}
+
+fn repair_json<T: DeserializeOwned + Serialize + Default>(
+    root: &Path,
+    name: &str,
+    rel: &str,
+    contents: &str,
+    err: &serde_json::Error,
+) -> CoreResult<Option<T>> {
+    if let Some(value) = parse_first_json_value(contents) {
+        backup_and_write(root, name, contents, &value)?;
+        tracing::warn!(
+            file = rel,
+            error = %err,
+            "repaired JSON file by removing trailing data"
+        );
+        return Ok(Some(value));
+    }
+
+    if name == "routine_runs" {
+        let value = T::default();
+        backup_and_write(root, name, contents, &value)?;
+        tracing::warn!(
+            file = rel,
+            error = %err,
+            "reset corrupt routine run history after preserving backup"
+        );
+        return Ok(Some(value));
+    }
+
+    Ok(None)
+}
+
+fn parse_first_json_value<T: DeserializeOwned>(contents: &str) -> Option<T> {
+    let mut stream = serde_json::Deserializer::from_str(contents).into_iter::<T>();
+    let first = stream.next()?.ok()?;
+    let trailing = &contents[stream.byte_offset()..];
+    if trailing.trim().is_empty() {
+        return None;
+    }
+    Some(first)
+}
+
+fn backup_and_write<T: Serialize>(
+    root: &Path,
+    name: &str,
+    contents: &str,
+    value: &T,
+) -> CoreResult<()> {
+    let backup_rel = format!(
+        ".houston/{name}/{name}.json.corrupt-{}-{}.bak",
+        Utc::now().format("%Y%m%dT%H%M%S%3fZ"),
+        Uuid::new_v4()
+    );
+    files::write_file_atomic(root, &backup_rel, contents)
+        .map_err(|e| CoreError::Internal(format!("failed to back up corrupt JSON: {e}")))?;
+    write_json(root, name, value)?;
+    Ok(())
 }

--- a/engine/houston-engine-core/src/routines/mod.rs
+++ b/engine/houston-engine-core/src/routines/mod.rs
@@ -12,7 +12,6 @@ pub mod types;
 
 use crate::error::{CoreError, CoreResult};
 use chrono::Utc;
-use houston_agent_files as files;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use std::path::Path;
@@ -22,27 +21,17 @@ pub use types::{NewRoutine, Routine, RoutineUpdate};
 
 const FILE: &str = "routines";
 
-// -- Typed JSON I/O helpers (mirrors agent_store::helpers) --
+// -- Typed JSON I/O helpers --
 
-fn rel_path(name: &str) -> String {
-    format!(".houston/{name}/{name}.json")
-}
-
-pub(crate) fn read_json<T: DeserializeOwned + Default>(root: &Path, name: &str) -> CoreResult<T> {
-    let rel = rel_path(name);
-    let contents = files::read_file(root, &rel)
-        .map_err(|e| CoreError::Internal(format!("read {rel}: {e}")))?;
-    if contents.is_empty() {
-        return Ok(T::default());
-    }
-    serde_json::from_str(&contents).map_err(Into::into)
+pub(crate) fn read_json<T: DeserializeOwned + Serialize + Default>(
+    root: &Path,
+    name: &str,
+) -> CoreResult<T> {
+    crate::agents::store::read_json(root, name)
 }
 
 pub(crate) fn write_json<T: Serialize>(root: &Path, name: &str, data: &T) -> CoreResult<()> {
-    let rel = rel_path(name);
-    let body = serde_json::to_string_pretty(data)?;
-    files::write_file_atomic(root, &rel, &body)
-        .map_err(|e| CoreError::Internal(format!("write {rel}: {e}")))
+    crate::agents::store::write_json(root, name, data)
 }
 
 pub(crate) fn ensure_houston_dir(root: &Path) -> CoreResult<()> {

--- a/engine/houston-engine-core/src/routines/runner.rs
+++ b/engine/houston-engine-core/src/routines/runner.rs
@@ -106,15 +106,7 @@ pub async fn run_routine(
     // is reliable for the common case (one run completes, status flips
     // terminal); orphan `running` rows from a crashed engine are swept
     // by `sweep_orphan_running` at agent-scheduler start.
-    let existing = routine_runs::list(&working_dir)?;
-    if let Some(busy) = existing.iter().find(|r| r.status == "running") {
-        return Err(CoreError::Conflict(format!(
-            "another routine run is already in progress (run {})",
-            busy.id
-        )));
-    }
-
-    let run = routine_runs::create(&working_dir, routine_id)?;
+    let run = routine_runs::create_if_no_running(&working_dir, routine_id)?;
     events.emit(HoustonEvent::RoutineRunsChanged {
         agent_path: agent_path.to_string(),
     });

--- a/engine/houston-engine-core/src/routines/runs.rs
+++ b/engine/houston-engine-core/src/routines/runs.rs
@@ -43,6 +43,10 @@ pub fn find_by_id(root: &Path, id: &str) -> CoreResult<RoutineRun> {
 /// Returns the number of rows reaped. Safe to call when there are no
 /// orphan rows — it's a no-op.
 pub fn sweep_orphan_running(root: &Path) -> CoreResult<usize> {
+    with_runs_lock(root, || sweep_orphan_running_unlocked(root))
+}
+
+fn sweep_orphan_running_unlocked(root: &Path) -> CoreResult<usize> {
     let mut runs = list(root)?;
     if runs.is_empty() {
         return Ok(0);
@@ -64,7 +68,24 @@ pub fn sweep_orphan_running(root: &Path) -> CoreResult<usize> {
     Ok(reaped)
 }
 
+pub fn create_if_no_running(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
+    with_runs_lock(root, || {
+        let existing = list(root)?;
+        if let Some(busy) = existing.iter().find(|r| r.status == "running") {
+            return Err(CoreError::Conflict(format!(
+                "another routine run is already in progress (run {})",
+                busy.id
+            )));
+        }
+        create_unlocked(root, routine_id)
+    })
+}
+
 pub fn create(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
+    with_runs_lock(root, || create_unlocked(root, routine_id))
+}
+
+fn create_unlocked(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
     ensure_houston_dir(root)?;
     let mut runs = list(root)?;
     let id = Uuid::new_v4().to_string();
@@ -87,6 +108,10 @@ pub fn create(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
 }
 
 pub fn update(root: &Path, id: &str, updates: RoutineRunUpdate) -> CoreResult<RoutineRun> {
+    with_runs_lock(root, || update_unlocked(root, id, updates))
+}
+
+fn update_unlocked(root: &Path, id: &str, updates: RoutineRunUpdate) -> CoreResult<RoutineRun> {
     let mut runs = list(root)?;
     let run = runs
         .iter_mut()
@@ -112,6 +137,10 @@ pub fn update(root: &Path, id: &str, updates: RoutineRunUpdate) -> CoreResult<Ro
     let result = run.clone();
     write_json(root, FILE, &runs)?;
     Ok(result)
+}
+
+fn with_runs_lock<T>(root: &Path, f: impl FnOnce() -> CoreResult<T>) -> CoreResult<T> {
+    crate::agents::store::with_json_file_lock(root, FILE, f)
 }
 
 /// Keep at most `MAX_RUNS_PER_ROUTINE` runs per routine; drop oldest entries
@@ -144,7 +173,26 @@ fn prune(runs: &mut Vec<RoutineRun>) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
+    use std::thread;
     use tempfile::TempDir;
+
+    fn write_raw_runs(root: &Path, body: &str) {
+        let dir = root.join(".houston/routine_runs");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("routine_runs.json"), body).unwrap();
+    }
+
+    fn backups(root: &Path) -> Vec<std::path::PathBuf> {
+        fs::read_dir(root.join(".houston/routine_runs"))
+            .unwrap()
+            .filter_map(|entry| {
+                let path = entry.unwrap().path();
+                let name = path.file_name()?.to_str()?;
+                name.contains(".corrupt-").then_some(path)
+            })
+            .collect()
+    }
 
     #[test]
     fn empty_list() {
@@ -173,6 +221,99 @@ mod tests {
         .unwrap();
         assert_eq!(done.status, "silent");
         assert!(done.completed_at.is_some());
+    }
+
+    #[test]
+    fn list_repairs_trailing_json_and_preserves_backup() {
+        let d = TempDir::new().unwrap();
+        let valid = r#"[
+          {
+            "id": "run-1",
+            "routine_id": "rid",
+            "status": "silent",
+            "session_key": "routine-rid-run-run-1",
+            "started_at": "2026-05-18T22:00:00Z",
+            "completed_at": "2026-05-18T22:01:00Z"
+          }
+        ]"#;
+        let corrupt = format!("{valid}\n[]");
+        write_raw_runs(d.path(), &corrupt);
+
+        let runs = list(d.path()).unwrap();
+
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].id, "run-1");
+        let repaired =
+            fs::read_to_string(d.path().join(".houston/routine_runs/routine_runs.json")).unwrap();
+        assert!(serde_json::from_str::<Vec<RoutineRun>>(&repaired).is_ok());
+        assert!(!repaired.trim_end().ends_with("[]"));
+
+        let backups = backups(d.path());
+        assert_eq!(backups.len(), 1);
+        assert_eq!(fs::read_to_string(&backups[0]).unwrap(), corrupt);
+    }
+
+    #[test]
+    fn list_resets_unsalvageable_run_history_after_backup() {
+        let d = TempDir::new().unwrap();
+        let corrupt = "[{\"id\":";
+        write_raw_runs(d.path(), corrupt);
+
+        let runs = list(d.path()).unwrap();
+
+        assert!(runs.is_empty());
+        let repaired =
+            fs::read_to_string(d.path().join(".houston/routine_runs/routine_runs.json")).unwrap();
+        assert_eq!(repaired.trim(), "[]");
+        let backups = backups(d.path());
+        assert_eq!(backups.len(), 1);
+        assert_eq!(fs::read_to_string(&backups[0]).unwrap(), corrupt);
+    }
+
+    #[test]
+    fn concurrent_create_preserves_each_run() {
+        let d = TempDir::new().unwrap();
+        let root = d.path().to_path_buf();
+        let handles = (0..12)
+            .map(|i| {
+                let root = root.clone();
+                thread::spawn(move || create(&root, &format!("rid-{i}")).unwrap())
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.join().unwrap();
+        }
+
+        let runs = list(&root).unwrap();
+        assert_eq!(runs.len(), 12);
+    }
+
+    #[test]
+    fn concurrent_create_if_no_running_allows_one_run() {
+        let d = TempDir::new().unwrap();
+        let root = d.path().to_path_buf();
+        let handles = (0..8)
+            .map(|i| {
+                let root = root.clone();
+                thread::spawn(move || create_if_no_running(&root, &format!("rid-{i}")))
+            })
+            .collect::<Vec<_>>();
+
+        let mut created = 0;
+        let mut conflicts = 0;
+        for handle in handles {
+            match handle.join().unwrap() {
+                Ok(_) => created += 1,
+                Err(CoreError::Conflict(_)) => conflicts += 1,
+                Err(err) => panic!("unexpected error: {err}"),
+            }
+        }
+
+        assert_eq!(created, 1);
+        assert_eq!(conflicts, 7);
+        let runs = list(&root).unwrap();
+        assert_eq!(runs.len(), 1);
     }
 
     #[test]

--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -47,9 +47,16 @@ If app-specific → `.houston/`.
 Frontend never touches the filesystem directly. All `.houston/` reads
 and writes flow through `@houston-ai/engine-client` → `houston-engine`
 REST routes (`/v1/agents/:path/files/:kind`, etc.), which call into
-`houston-agent-files`. Writes are atomic (temp + rename) and emit a
+`houston-agent-files`. Writes are atomic (unique temp + rename) and emit a
 matching `HoustonEvent` over the WS. No typed CRUD — per-type folder +
 schema + a generic read/write pair covers everything.
+
+Typed JSON readers preserve corrupt files as
+`.houston/<type>/<type>.json.corrupt-<timestamp>-<uuid>.bak` before
+repairing. If a file has trailing JSON data, Houston keeps the first valid
+value and rewrites the file. If `routine_runs.json` is otherwise
+unreadable, Houston resets only the run history to `[]` after backing up
+the original so routine definitions can load and run again.
 
 ## Schemas
 Authoritative. Live in `ui/agent-schemas/src/*.schema.json`. Embedded in Rust via `include_str!` in `houston-agent-files::schemas`. Seeded into each agent's `.houston/<type>/<type>.schema.json` on first launch. Prompts instruct model to read schema before writing data file.
@@ -74,7 +81,7 @@ session key. Provider-scoped `.invalid` files stop a rejected legacy ID
 from being retried by the provider that rejected it.
 
 ## Atomic writes
-All writes: temp file + rename. Path-traversal safe via `houston-agent-files::safe_relative`.
+All writes: unique temp file + rename. Path-traversal safe via `houston-agent-files::safe_relative`.
 
 ## Activity statuses
 `running` · `needs_you` · `done` · `error`


### PR DESCRIPTION
Fixes #320

## Summary
- repair corrupted typed JSON by preserving a `.corrupt-<timestamp>-<uuid>.bak` backup before rewriting
- recover `routine_runs.json` with trailing data, and reset only run history to `[]` when it is otherwise unreadable so saved routines can run again
- serialize routine-run read/modify/write paths and use unique atomic-write temp files to prevent concurrent writes from corrupting JSON
- document the `.houston/` recovery behavior

## Tests
- `cargo test -p houston-agent-files`
- `cargo test -p houston-engine-core routines::runs --lib`
- `cargo test -p houston-engine-core routines --lib`
- `cargo test -p houston-engine-core agents::tests::routine --lib`
- `cargo test -p houston-engine-server --test routines`
- `cargo test -p houston-engine-core --lib` fails on this Windows environment with 253 passed / 7 unrelated failures: path separator assertion, missing `sleep`, symlink metadata assertions, and shell program lookup