### PR TITLE
fix: recover stale Claude resumes

### DIFF
--- a/engine/houston-agents-conversations/src/session_id_tracker.rs
+++ b/engine/houston-agents-conversations/src/session_id_tracker.rs
@@ -52,6 +52,90 @@ fn session_invalid_path(agent_dir: &Path, provider: Provider, session_key: &str)
         .join(format!("{session_key}.invalid"))
 }
 
+/// Invalidate current provider resume IDs when an agent's filesystem path is
+/// about to change. Provider CLIs can bind resumed conversations to their
+/// original working directory; after a path rename, retrying the old current
+/// ID can produce a permanent immediate runtime error. History remains
+/// readable, but the next turn starts a fresh provider session.
+pub fn invalidate_current_session_ids_for_path_change(agent_dir: &Path) -> io::Result<usize> {
+    let base = sessions_dir(agent_dir);
+    if !base.exists() {
+        return Ok(0);
+    }
+
+    let mut invalidated = 0usize;
+    for provider in all_providers() {
+        let provider_dir = base.join(provider.to_string());
+        if !provider_dir.exists() {
+            continue;
+        }
+        for entry in fs::read_dir(&provider_dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if !entry.file_type()?.is_file()
+                || path.extension().and_then(|v| v.to_str()) != Some("sid")
+            {
+                continue;
+            }
+            let Some(session_key) = path
+                .file_stem()
+                .and_then(|name| name.to_str())
+                .map(str::to_string)
+            else {
+                continue;
+            };
+            if invalidate_provider_sid(agent_dir, provider, &session_key, &path)? {
+                invalidated += 1;
+            }
+        }
+    }
+
+    for entry in fs::read_dir(&base)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !entry.file_type()?.is_file() || path.extension().and_then(|v| v.to_str()) != Some("sid")
+        {
+            continue;
+        }
+        let Some(session_key) = path
+            .file_stem()
+            .and_then(|name| name.to_str())
+            .map(str::to_string)
+        else {
+            continue;
+        };
+        if let Some(id) = read_trimmed_file_checked(&path)? {
+            for provider in all_providers() {
+                append_history_id_checked(
+                    &session_invalid_path(agent_dir, provider, &session_key),
+                    &id,
+                )?;
+            }
+            invalidated += 1;
+        }
+    }
+
+    Ok(invalidated)
+}
+
+fn invalidate_provider_sid(
+    agent_dir: &Path,
+    provider: Provider,
+    session_key: &str,
+    sid_path: &Path,
+) -> io::Result<bool> {
+    if let Some(id) = read_trimmed_file_checked(sid_path)? {
+        append_history_id_checked(&session_history_path(agent_dir, provider, session_key), &id)?;
+        append_history_id_checked(&session_invalid_path(agent_dir, provider, session_key), &id)?;
+    }
+
+    match fs::remove_file(sid_path) {
+        Ok(()) => Ok(true),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(false),
+        Err(e) => Err(e),
+    }
+}
+
 /// Return every known resume ID for a session key, across legacy and
 /// provider-scoped current/history files. Used for DB-backed chat history.
 pub fn session_ids_for_history(agent_dir: &Path, session_key: &str) -> Vec<String> {
@@ -215,11 +299,8 @@ fn push_unique_id(ids: &mut Vec<String>, seen: &mut HashSet<String>, id: String)
 }
 
 fn read_trimmed_file(path: &Path) -> Option<String> {
-    match fs::read_to_string(path) {
-        Ok(body) => {
-            let value = body.trim().to_string();
-            (!value.is_empty()).then_some(value)
-        }
+    match read_trimmed_file_checked(path) {
+        Ok(value) => value,
         Err(e) if e.kind() == io::ErrorKind::NotFound => None,
         Err(e) => {
             tracing::warn!(
@@ -232,16 +313,20 @@ fn read_trimmed_file(path: &Path) -> Option<String> {
     }
 }
 
-fn read_history_ids(path: &Path) -> Vec<String> {
+fn read_trimmed_file_checked(path: &Path) -> io::Result<Option<String>> {
     match fs::read_to_string(path) {
         Ok(body) => {
-            let mut ids = Vec::new();
-            let mut seen = HashSet::new();
-            for line in body.lines() {
-                push_unique_id(&mut ids, &mut seen, line.to_string());
-            }
-            ids
+            let value = body.trim().to_string();
+            Ok((!value.is_empty()).then_some(value))
         }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(e),
+    }
+}
+
+fn read_history_ids(path: &Path) -> Vec<String> {
+    match read_history_ids_checked(path) {
+        Ok(ids) => ids,
         Err(e) if e.kind() == io::ErrorKind::NotFound => Vec::new(),
         Err(e) => {
             tracing::warn!(
@@ -254,27 +339,45 @@ fn read_history_ids(path: &Path) -> Vec<String> {
     }
 }
 
+fn read_history_ids_checked(path: &Path) -> io::Result<Vec<String>> {
+    let body = match fs::read_to_string(path) {
+        Ok(body) => body,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+    let mut ids = Vec::new();
+    let mut seen = HashSet::new();
+    for line in body.lines() {
+        push_unique_id(&mut ids, &mut seen, line.to_string());
+    }
+    Ok(ids)
+}
+
 fn append_history_id(path: &Path, id: &str) {
-    let id = id.trim();
-    if id.is_empty() {
-        return;
-    }
-
-    let mut ids = read_history_ids(path);
-    if ids.iter().any(|existing| existing == id) {
-        return;
-    }
-    ids.push(id.to_string());
-
-    let mut body = ids.join("\n");
-    body.push('\n');
-    if let Err(e) = write_atomic(path, &body) {
+    if let Err(e) = append_history_id_checked(path, id) {
         tracing::warn!(
             path = %path.display(),
             error = %e,
             "failed to persist session history"
         );
     }
+}
+
+fn append_history_id_checked(path: &Path, id: &str) -> io::Result<()> {
+    let id = id.trim();
+    if id.is_empty() {
+        return Ok(());
+    }
+
+    let mut ids = read_history_ids_checked(path)?;
+    if ids.iter().any(|existing| existing == id) {
+        return Ok(());
+    }
+    ids.push(id.to_string());
+
+    let mut body = ids.join("\n");
+    body.push('\n');
+    write_atomic(path, &body)
 }
 
 fn write_atomic(path: &Path, content: &str) -> io::Result<()> {
@@ -397,6 +500,44 @@ mod tests {
 
         assert_eq!(openai_handle.get().await, None);
         assert_eq!(anthropic_handle.get().await, Some("legacy-id".to_string()));
+    }
+
+    #[tokio::test]
+    async fn path_change_invalidation_clears_current_ids_and_blocks_legacy_fallback() {
+        let dir = TempDir::new().unwrap();
+        write_file(
+            &session_id_path(dir.path(), anthropic(), "chat"),
+            "claude-current\n",
+        );
+        write_file(&legacy_session_id_path(dir.path(), "chat"), "legacy-id\n");
+
+        let count = invalidate_current_session_ids_for_path_change(dir.path()).unwrap();
+
+        assert_eq!(count, 2);
+        assert!(!session_id_path(dir.path(), anthropic(), "chat").exists());
+        assert_eq!(
+            fs::read_to_string(session_history_path(dir.path(), anthropic(), "chat")).unwrap(),
+            "claude-current\n"
+        );
+        assert_eq!(
+            fs::read_to_string(session_invalid_path(dir.path(), anthropic(), "chat")).unwrap(),
+            "claude-current\nlegacy-id\n"
+        );
+        assert_eq!(
+            fs::read_to_string(session_invalid_path(dir.path(), openai(), "chat")).unwrap(),
+            "legacy-id\n"
+        );
+
+        let restarted_tracker = SessionIdTracker::default();
+        let anthropic_handle = restarted_tracker
+            .get_for_session("agent:anthropic:chat", dir.path(), "chat", anthropic())
+            .await;
+        let openai_handle = restarted_tracker
+            .get_for_session("agent:openai:chat", dir.path(), "chat", openai())
+            .await;
+
+        assert_eq!(anthropic_handle.get().await, None);
+        assert_eq!(openai_handle.get().await, None);
     }
 
     #[test]

--- a/engine/houston-engine-core/src/agents_crud.rs
+++ b/engine/houston-engine-core/src/agents_crud.rs
@@ -12,6 +12,7 @@ use crate::error::{CoreError, CoreResult};
 use crate::paths::expand_tilde;
 use crate::workspaces;
 use chrono::Utc;
+use houston_agents_conversations::session_id_tracker::invalidate_current_session_ids_for_path_change;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -334,6 +335,13 @@ pub fn rename(root: &Path, workspace_id: &str, id: &str, new_name: &str) -> Core
         write_agent_meta(&new_link, &meta)?;
         Ok(meta_to_agent(&new_link, &meta))
     } else {
+        let invalidated = invalidate_current_session_ids_for_path_change(&old_folder)?;
+        if invalidated > 0 {
+            tracing::info!(
+                "[agents] invalidated {invalidated} current session ids before path rename: {}",
+                old_folder.display()
+            );
+        }
         fs::rename(&old_folder, &new_link)?;
         let meta = read_agent_meta(&new_link)?;
         Ok(meta_to_agent(&new_link, &meta))
@@ -361,10 +369,7 @@ mod tests {
     use tempfile::TempDir;
 
     fn setup_ws(root: &Path) -> String {
-        workspaces::create(
-            root,
-            CreateWorkspace { name: "alpha".into() },
-        )
+        workspaces::create(root, CreateWorkspace { name: "alpha".into() })
         .unwrap()
         .id
     }
@@ -450,6 +455,44 @@ mod tests {
         assert_eq!(renamed.name, "m");
         delete(d.path(), &ws_id, &res.agent.id).unwrap();
         assert!(list(d.path(), &ws_id).unwrap().is_empty());
+    }
+
+    #[test]
+    fn rename_invalidates_current_session_ids() {
+        use houston_agents_conversations::session_id_tracker::{
+            session_history_path, session_id_path,
+        };
+
+        let d = TempDir::new().unwrap();
+        let ws_id = setup_ws(d.path());
+        let res = create(
+            d.path(),
+            &ws_id,
+            CreateAgent {
+                name: "before".into(),
+                config_id: "gmail".into(),
+                color: None,
+                claude_md: None,
+                installed_path: None,
+                seeds: None,
+                existing_path: None,
+            },
+        )
+        .unwrap();
+        let agent_dir = d.path().join("alpha/before");
+        let provider = "anthropic".parse().unwrap();
+        let sid_path = session_id_path(&agent_dir, provider, "activity-1");
+        fs::create_dir_all(sid_path.parent().unwrap()).unwrap();
+        fs::write(&sid_path, "claude-session\n").unwrap();
+
+        rename(d.path(), &ws_id, &res.agent.id, "after").unwrap();
+
+        let renamed_dir = d.path().join("alpha/after");
+        assert!(!session_id_path(&renamed_dir, provider, "activity-1").exists());
+        assert_eq!(
+            fs::read_to_string(session_history_path(&renamed_dir, provider, "activity-1")).unwrap(),
+            "claude-session\n"
+        );
     }
 
     #[test]

--- a/engine/houston-engine-core/src/workspaces/mod.rs
+++ b/engine/houston-engine-core/src/workspaces/mod.rs
@@ -12,6 +12,7 @@ pub use io::read_all;
 pub use migrate::migrate_workspace_provider_into_agents;
 
 use crate::error::{CoreError, CoreResult};
+use houston_agents_conversations::session_id_tracker::invalidate_current_session_ids_for_path_change;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
@@ -104,12 +105,32 @@ pub fn rename(root: &Path, id: &str, req: RenameWorkspace) -> CoreResult<Workspa
         )));
     }
     if old_dir.exists() {
+        invalidate_workspace_session_ids_for_path_change(&old_dir)?;
         fs::rename(&old_dir, &new_dir)?;
     }
     ws.name = req.new_name;
     let updated = ws.clone();
     io::write_all(root, &workspaces)?;
     Ok(updated)
+}
+
+fn invalidate_workspace_session_ids_for_path_change(ws_dir: &Path) -> CoreResult<()> {
+    for entry in fs::read_dir(ws_dir)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        if !file_type.is_dir() {
+            continue;
+        }
+        let agent_dir = entry.path();
+        let invalidated = invalidate_current_session_ids_for_path_change(&agent_dir)?;
+        if invalidated > 0 {
+            tracing::info!(
+                "[workspaces] invalidated {invalidated} current session ids before path rename: {}",
+                agent_dir.display()
+            );
+        }
+    }
+    Ok(())
 }
 
 pub fn delete(root: &Path, id: &str) -> CoreResult<()> {
@@ -173,6 +194,42 @@ mod tests {
         assert_eq!(renamed.name, "b");
         delete(d.path(), &ws.id).unwrap();
         assert!(list(d.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn rename_invalidates_child_agent_session_ids() {
+        use houston_agents_conversations::session_id_tracker::{
+            session_history_path, session_id_path,
+        };
+
+        let d = tmp();
+        let ws = create(d.path(), CreateWorkspace { name: "a".into() }).unwrap();
+        let agent_dir = d.path().join("a/agent");
+        let provider = "anthropic".parse().unwrap();
+        let sid_path = session_id_path(&agent_dir, provider, "activity-1");
+        fs::create_dir_all(sid_path.parent().unwrap()).unwrap();
+        fs::write(&sid_path, "claude-session\n").unwrap();
+
+        rename(
+            d.path(),
+            &ws.id,
+            RenameWorkspace {
+                new_name: "b".into(),
+            },
+        )
+        .unwrap();
+
+        let renamed_agent_dir = d.path().join("b/agent");
+        assert!(!session_id_path(&renamed_agent_dir, provider, "activity-1").exists());
+        assert_eq!(
+            fs::read_to_string(session_history_path(
+                &renamed_agent_dir,
+                provider,
+                "activity-1"
+            ))
+            .unwrap(),
+            "claude-session\n"
+        );
     }
 
     /// Concurrent writers must not corrupt `workspaces.json`. Mirrors the

--- a/engine/houston-terminal-manager/src/claude_runner.rs
+++ b/engine/houston-terminal-manager/src/claude_runner.rs
@@ -73,7 +73,8 @@ pub(crate) async fn spawn_claude(
         disable_builtin_tools,
         disable_all_tools,
     );
-    let outcome = run_cli_process(tx, &mut cmd, &prompt, provider).await;
+    let outcome =
+        run_cli_process(tx, &mut cmd, &prompt, provider, resume_session_id.is_some()).await;
     if should_retry_malformed_provider_json(outcome, resume_session_id.as_deref()) {
         tracing::warn!(
             "[houston:session] claude resume failed with malformed provider JSON; retrying fresh"
@@ -92,8 +93,28 @@ pub(crate) async fn spawn_claude(
             disable_all_tools,
         )
         .await;
+    } else if should_retry_resume_rejected(outcome, resume_session_id.as_deref()) {
+        tracing::warn!("[houston:session] claude resume rejected by provider; retrying fresh");
+        let _ = tx.send(SessionUpdate::ResumeInvalid);
+        retry_fresh(
+            tx,
+            provider,
+            &prompt,
+            working_dir.as_deref(),
+            model.as_deref(),
+            effort.as_deref(),
+            system_prompt.as_deref(),
+            mcp_config.as_deref(),
+            disable_builtin_tools,
+            disable_all_tools,
+        )
+        .await;
     } else if outcome == CliRunOutcome::ProviderRequestMalformedJson {
         send_malformed_provider_json_status(tx);
+    } else if outcome == CliRunOutcome::ProviderResumeRejected {
+        let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(
+            "Claude hit a runtime error".to_string(),
+        )));
     }
 }
 
@@ -122,7 +143,7 @@ async fn retry_fresh(
         disable_builtin_tools,
         disable_all_tools,
     );
-    let retry_outcome = run_cli_process(tx, &mut fresh_cmd, prompt, provider).await;
+    let retry_outcome = run_cli_process(tx, &mut fresh_cmd, prompt, provider, false).await;
     if retry_outcome == CliRunOutcome::ProviderRequestMalformedJson {
         send_malformed_provider_json_status(tx);
     }
@@ -190,6 +211,10 @@ fn should_retry_malformed_provider_json(
     outcome == CliRunOutcome::ProviderRequestMalformedJson && resume_session_id.is_some()
 }
 
+fn should_retry_resume_rejected(outcome: CliRunOutcome, resume_session_id: Option<&str>) -> bool {
+    outcome == CliRunOutcome::ProviderResumeRejected && resume_session_id.is_some()
+}
+
 fn send_malformed_provider_json_status(tx: &mpsc::UnboundedSender<SessionUpdate>) {
     let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(
         MALFORMED_PROVIDER_JSON_MESSAGE.to_string(),
@@ -208,6 +233,18 @@ mod tests {
         ));
         assert!(!should_retry_malformed_provider_json(
             CliRunOutcome::ProviderRequestMalformedJson,
+            None,
+        ));
+    }
+
+    #[test]
+    fn retries_resume_rejected_only_for_resume() {
+        assert!(should_retry_resume_rejected(
+            CliRunOutcome::ProviderResumeRejected,
+            Some("claude-session-id"),
+        ));
+        assert!(!should_retry_resume_rejected(
+            CliRunOutcome::ProviderResumeRejected,
             None,
         ));
     }

--- a/engine/houston-terminal-manager/src/cli_process.rs
+++ b/engine/houston-terminal-manager/src/cli_process.rs
@@ -2,7 +2,7 @@ use super::session_io;
 use super::types::{FeedItem, SessionStatus};
 use crate::codex_command;
 use crate::provider::detect_malformed_provider_json;
-use crate::provider_error_kind::ProviderError;
+use crate::provider_error_kind::{truncate_excerpt, ProviderError};
 use crate::session_update::SessionUpdate;
 use crate::Provider;
 use std::process::Stdio;
@@ -16,6 +16,7 @@ pub(crate) enum CliRunOutcome {
     Completed,
     Failed,
     CodexResumeMissing,
+    ProviderResumeRejected,
     ProviderRequestMalformedJson,
 }
 
@@ -30,6 +31,7 @@ pub(crate) async fn run_cli_process(
     cmd: &mut Command,
     prompt: &str,
     provider: Provider,
+    resume_requested: bool,
 ) -> CliRunOutcome {
     let cli_name = provider.cli_name();
 
@@ -153,6 +155,12 @@ pub(crate) async fn run_cli_process(
                 }
                 let _ = tx.send(SessionUpdate::Status(SessionStatus::Completed));
                 CliRunOutcome::Completed
+            } else if is_resume_rejected(provider, resume_requested, &stderr_lines, &stdout_report)
+            {
+                tracing::warn!(
+                    "[houston:session] {cli_name} rejected resume without progress; retrying fresh"
+                );
+                CliRunOutcome::ProviderResumeRejected
             } else {
                 handle_failed_exit(tx, cli_name, provider, &stderr_lines, &stdout_report)
             }
@@ -164,6 +172,20 @@ pub(crate) async fn run_cli_process(
             CliRunOutcome::Failed
         }
     }
+}
+
+fn is_resume_rejected(
+    provider: Provider,
+    resume_requested: bool,
+    stderr_lines: &[String],
+    stdout_report: &session_io::StdoutReadReport,
+) -> bool {
+    resume_requested
+        && provider.id() == "anthropic"
+        && stderr_lines.is_empty()
+        && stdout_report
+            .claude_error_during_execution_without_progress
+            .is_some()
 }
 
 fn handle_failed_exit(
@@ -228,7 +250,8 @@ fn handle_failed_exit(
     let is_tool_runtime = stderr_lines
         .iter()
         .any(|line| crate::stderr_filter::is_tool_runtime_stderr(line));
-    if !already_emitted_typed && !is_tool_runtime {
+    let emitted_deferred_stdout_error = emit_deferred_stdout_error(tx, provider, stdout_report);
+    if !emitted_deferred_stdout_error && !already_emitted_typed && !is_tool_runtime {
         let stderr_summary = if stderr_lines.is_empty() {
             "no stderr output captured".to_string()
         } else {
@@ -247,6 +270,26 @@ fn handle_failed_exit(
         "{cli_name} hit a runtime error"
     ))));
     CliRunOutcome::Failed
+}
+
+fn emit_deferred_stdout_error(
+    tx: &mpsc::UnboundedSender<SessionUpdate>,
+    provider: Provider,
+    stdout_report: &session_io::StdoutReadReport,
+) -> bool {
+    let Some(message) = stdout_report
+        .claude_error_during_execution_without_progress
+        .as_deref()
+    else {
+        return false;
+    };
+    let _ = tx.send(SessionUpdate::Feed(FeedItem::ProviderError(
+        ProviderError::Unknown {
+            provider: provider.id().to_string(),
+            raw_excerpt: truncate_excerpt(message),
+        },
+    )));
+    true
 }
 
 #[cfg(unix)]
@@ -293,18 +336,17 @@ mod tests {
             malformed_provider_json: false,
             saw_auth_error: true,
             saw_model_unsupported_error: false,
+            claude_error_during_execution_without_progress: None,
         };
 
-        let outcome =
-            handle_failed_exit(&tx, "claude", Provider::default(), &[], &stdout_report);
+        let outcome = handle_failed_exit(&tx, "claude", Provider::default(), &[], &stdout_report);
         assert_eq!(outcome, CliRunOutcome::Failed);
 
         let updates = drain(&mut rx);
         assert!(
-            !updates.iter().any(|u| matches!(
-                u,
-                SessionUpdate::Feed(FeedItem::ToolRuntimeError { .. })
-            )),
+            !updates
+                .iter()
+                .any(|u| matches!(u, SessionUpdate::Feed(FeedItem::ToolRuntimeError { .. }))),
             "should not emit ToolRuntimeError when auth was seen on stdout: {updates:?}"
         );
         assert!(
@@ -328,8 +370,7 @@ mod tests {
         let (tx, mut rx) = mpsc::unbounded_channel();
         let stdout_report = session_io::StdoutReadReport::default();
 
-        let outcome =
-            handle_failed_exit(&tx, "claude", Provider::default(), &[], &stdout_report);
+        let outcome = handle_failed_exit(&tx, "claude", Provider::default(), &[], &stdout_report);
         assert_eq!(outcome, CliRunOutcome::Failed);
 
         let updates = drain(&mut rx);
@@ -338,5 +379,26 @@ mod tests {
             SessionUpdate::Feed(FeedItem::ProviderError(ProviderError::SpawnFailed { message, .. }))
                 if message == "no stderr output captured"
         )));
+    }
+
+    #[test]
+    fn claude_immediate_execution_error_with_resume_is_resume_rejected() {
+        let stdout_report = session_io::StdoutReadReport {
+            claude_error_during_execution_without_progress: Some("Unknown error".into()),
+            ..Default::default()
+        };
+
+        assert!(is_resume_rejected(
+            Provider::default(),
+            true,
+            &[],
+            &stdout_report
+        ));
+        assert!(!is_resume_rejected(
+            Provider::default(),
+            false,
+            &[],
+            &stdout_report
+        ));
     }
 }

--- a/engine/houston-terminal-manager/src/codex_runner.rs
+++ b/engine/houston-terminal-manager/src/codex_runner.rs
@@ -51,7 +51,8 @@ pub(crate) async fn spawn_codex(
         system_prompt.as_deref(),
     );
 
-    let outcome = run_cli_process(tx, &mut cmd, &prompt, provider).await;
+    let outcome =
+        run_cli_process(tx, &mut cmd, &prompt, provider, resume_session_id.is_some()).await;
     if outcome == CliRunOutcome::CodexResumeMissing && resume_session_id.is_some() {
         tracing::warn!("[houston:session] codex resume rollout missing; retrying with fresh thread");
         let _ = tx.send(SessionUpdate::ResumeInvalid);
@@ -62,7 +63,7 @@ pub(crate) async fn spawn_codex(
             effort.as_deref(),
             system_prompt.as_deref(),
         );
-        run_cli_process(tx, &mut fresh_cmd, &prompt, provider).await;
+        run_cli_process(tx, &mut fresh_cmd, &prompt, provider, false).await;
     }
 }
 

--- a/engine/houston-terminal-manager/src/gemini_runner.rs
+++ b/engine/houston-terminal-manager/src/gemini_runner.rs
@@ -119,7 +119,14 @@ pub(crate) async fn spawn_gemini(
     }
 
     let composed = compose_gemini_prompt(system_prompt.as_deref(), &prompt);
-    run_cli_process(tx, &mut cmd, &composed, provider).await;
+    run_cli_process(
+        tx,
+        &mut cmd,
+        &composed,
+        provider,
+        resume_session_id.is_some(),
+    )
+    .await;
 }
 
 fn build_gemini_command(

--- a/engine/houston-terminal-manager/src/parser.rs
+++ b/engine/houston-terminal-manager/src/parser.rs
@@ -333,8 +333,37 @@ pub fn extract_session_id(line: &str) -> Option<String> {
     let event: ClaudeEvent = serde_json::from_str(line.trim()).ok()?;
     match event {
         ClaudeEvent::System { session_id, .. } => session_id,
-        ClaudeEvent::Result { session_id, .. } => session_id,
+        ClaudeEvent::Result {
+            subtype,
+            is_error,
+            session_id,
+            ..
+        } => {
+            if is_error == Some(true) || subtype.as_deref().is_some_and(|s| s.starts_with("error"))
+            {
+                None
+            } else {
+                session_id
+            }
+        }
         ClaudeEvent::StreamEvent { session_id, .. } => session_id,
+        _ => None,
+    }
+}
+
+/// Return the message from Claude's immediate `result/error_during_execution`
+/// shape. The caller decides whether to surface it or retry without `--resume`.
+pub fn claude_execution_error_message(line: &str) -> Option<String> {
+    let event: ClaudeEvent = serde_json::from_str(line.trim()).ok()?;
+    match event {
+        ClaudeEvent::Result {
+            subtype,
+            is_error,
+            result,
+            ..
+        } if subtype.as_deref() == Some("error_during_execution") && is_error != Some(false) => {
+            Some(result.unwrap_or_else(|| "Unknown error".to_string()))
+        }
         _ => None,
     }
 }
@@ -452,6 +481,23 @@ mod tests {
             other => panic!("expected FinalResult, got {other:?}"),
         }
         assert_eq!(extract_session_id(line), Some("s1".to_string()));
+    }
+
+    #[test]
+    fn extract_session_id_ignores_error_result() {
+        let line = r#"{"type":"result","subtype":"error_during_execution","is_error":true,"result":"stale","session_id":"bad"}"#;
+
+        assert_eq!(extract_session_id(line), None);
+    }
+
+    #[test]
+    fn claude_execution_error_message_reads_immediate_error() {
+        let line = r#"{"type":"result","subtype":"error_during_execution","is_error":true,"result":"resume failed","session_id":"bad"}"#;
+
+        assert_eq!(
+            claude_execution_error_message(line).as_deref(),
+            Some("resume failed")
+        );
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/session_io.rs
+++ b/engine/houston-terminal-manager/src/session_io.rs
@@ -11,9 +11,15 @@ use crate::Provider;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc;
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct StdoutReadReport {
     pub malformed_provider_json: bool,
+    /// Claude can emit a one-line `result/error_during_execution` immediately
+    /// when `--resume <id>` points at a conversation that no longer works from
+    /// this working directory. The runner handles this as stale resume state and
+    /// retries fresh. We defer the Unknown provider card until the runner knows
+    /// whether a retry is possible, so users don't see a false permanent error.
+    pub claude_error_during_execution_without_progress: Option<String>,
     /// True when the provider CLI surfaced an auth failure on stdout (e.g.
     /// claude's `{"type":"result","is_error":true,"result":"... 401 ..."}`
     /// event). stderr is empty in that case, so without this flag the
@@ -117,6 +123,7 @@ async fn read_claude_stdout(
     let mut line_count = 0u64;
     let mut item_count = 0u64;
     let mut report = StdoutReadReport::default();
+    let mut saw_progress = false;
     while let Ok(Some(line)) = lines.next_line().await {
         line_count += 1;
         let line_type = line.trim().chars().take(80).collect::<String>();
@@ -130,14 +137,45 @@ async fn read_claude_stdout(
             tracing::warn!("[houston:stdout:claude] suppressed malformed provider JSON error");
             continue;
         }
+        let maybe_immediate_execution_error = (!saw_progress)
+            .then(|| parser::claude_execution_error_message(&line))
+            .flatten();
         let items = parser::parse_event(&line, &mut acc);
+        if let Some(message) = maybe_immediate_execution_error {
+            let only_unknown_provider_error = matches!(
+                items.as_slice(),
+                [FeedItem::ProviderError(ProviderError::Unknown { .. })]
+            );
+            if only_unknown_provider_error {
+                report.claude_error_during_execution_without_progress = Some(message);
+                tracing::warn!(
+                    "[houston:stdout:claude] deferred immediate error_during_execution for runner retry"
+                );
+                continue;
+            }
+        }
         mark_auth_error(&items, &mut report);
+        mark_progress(&items, &mut saw_progress);
         item_count += log_and_send(&tx, items);
     }
     tracing::debug!(
         "[houston:stdout:claude] stream ended. {line_count} lines, {item_count} feed items"
     );
     report
+}
+
+fn mark_progress(items: &[FeedItem], saw_progress: &mut bool) {
+    if *saw_progress {
+        return;
+    }
+    if items.iter().any(|item| {
+        !matches!(
+            item,
+            FeedItem::ProviderError(_) | FeedItem::SystemMessage(_)
+        )
+    }) {
+        *saw_progress = true;
+    }
 }
 
 async fn read_codex_stdout(

--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -73,6 +73,11 @@ loads the legacy ID plus every provider current/history ID for the same
 session key. Provider-scoped `.invalid` files stop a rejected legacy ID
 from being retried by the provider that rejected it.
 
+Agent and workspace renames invalidate current provider-scoped resume IDs before
+the filesystem path changes. The IDs are preserved in `.history` for chat replay
+and copied to `.invalid` so the next turn starts a fresh provider session instead
+of retrying a resume bound to the old working directory.
+
 ## Atomic writes
 All writes: temp file + rename. Path-traversal safe via `houston-agent-files::safe_relative`.
 


### PR DESCRIPTION
## Summary
- Detect Claude immediate `result/error_during_execution` on resume before any conversation progress and retry once with a fresh session instead of flipping the mission card to permanent error.
- Avoid persisting Claude error-result session IDs as current resume IDs.
- Invalidate current provider resume IDs before agent/workspace path renames while preserving history for chat replay.
- Document rename/session invalidation behavior.

## Tests
- `cargo test -p houston-terminal-manager`
- `cargo test -p houston-agents-conversations`
- `cargo test -p houston-engine-core agents_crud::tests::rename_invalidates_current_session_ids`
- `cargo test -p houston-engine-core workspaces::tests::rename_invalidates_child_agent_session_ids`
- `cargo build -p houston-engine-server --bin houston-engine`
- `cargo test --workspace` fails on existing Windows/environment-sensitive `houston-engine-core` tests: attachment path separator assertion, `sleep` program not found in login relay tests, symlink metadata assertions, and shell command tests with command program not found.

Fixes HOU-393. Related: HOU-362, HOU-353, #316.