### PR TITLE
fix(engine): auto-recover from corrupted claude resume transcripts

### DIFF
--- a/app/src/components/shell/provider-error-cards/terminal.tsx
+++ b/app/src/components/shell/provider-error-cards/terminal.tsx
@@ -30,7 +30,7 @@ export function SessionResumeMissingCard({
       {onRetry && (
         <RetryButton
           onRetry={onRetry}
-          label={t("providerError.sessionResumeMissing.startFresh")}
+          label={t("providerError.sessionResumeMissing.tryAgain")}
         />
       )}
     </ErrorCard>

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -306,9 +306,9 @@
       "checkStatus": "Check status page"
     },
     "sessionResumeMissing": {
-      "title": "Cannot resume this session",
-      "body": "The previous {{provider}} session is gone. Start a fresh mission to continue.",
-      "startFresh": "Start fresh"
+      "title": "Session restarted",
+      "body": "The previous {{provider}} conversation could not be reopened, so Houston restarted it. Your message was sent again and the assistant is responding below.",
+      "tryAgain": "Try again"
     },
     "malformedResponse": {
       "title": "Got a broken response",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -306,9 +306,9 @@
       "checkStatus": "Ver página de estado"
     },
     "sessionResumeMissing": {
-      "title": "No se puede retomar esta sesión",
-      "body": "La sesión anterior de {{provider}} ya no existe. Inicia una misión nueva para continuar.",
-      "startFresh": "Empezar de nuevo"
+      "title": "Sesión reiniciada",
+      "body": "La conversación anterior de {{provider}} no se pudo reabrir, así que Houston la reinició. Tu mensaje se envió de nuevo y el asistente está respondiendo abajo.",
+      "tryAgain": "Reintentar"
     },
     "malformedResponse": {
       "title": "Respuesta dañada",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -306,9 +306,9 @@
       "checkStatus": "Ver página de status"
     },
     "sessionResumeMissing": {
-      "title": "Não dá para retomar esta sessão",
-      "body": "A sessão anterior do {{provider}} não existe mais. Comece uma missão nova para continuar.",
-      "startFresh": "Recomeçar"
+      "title": "Sessão reiniciada",
+      "body": "A conversa anterior do {{provider}} não pôde ser reaberta, então o Houston a reiniciou. Sua mensagem foi enviada novamente e o assistente está respondendo abaixo.",
+      "tryAgain": "Tentar de novo"
     },
     "malformedResponse": {
       "title": "Resposta corrompida",

--- a/engine/houston-terminal-manager/src/claude_runner.rs
+++ b/engine/houston-terminal-manager/src/claude_runner.rs
@@ -1,7 +1,8 @@
-use super::types::SessionStatus;
+use super::types::{FeedItem, SessionStatus};
 use crate::claude_install_path;
 use crate::cli_process::{run_cli_process, CliRunOutcome};
 use crate::provider_error::MALFORMED_PROVIDER_JSON_MESSAGE;
+use crate::provider_error_kind::ProviderError;
 use crate::session_update::SessionUpdate;
 use crate::Provider;
 use std::ffi::OsString;
@@ -74,9 +75,9 @@ pub(crate) async fn spawn_claude(
         disable_all_tools,
     );
     let outcome = run_cli_process(tx, &mut cmd, &prompt, provider).await;
-    if should_retry_malformed_provider_json(outcome, resume_session_id.as_deref()) {
+    if should_retry_fresh_after_resume_failure(outcome, resume_session_id.as_deref()) {
         tracing::warn!(
-            "[houston:session] claude resume failed with malformed provider JSON; retrying fresh"
+            "[houston:session] claude resume failed ({outcome:?}); retrying fresh"
         );
         let _ = tx.send(SessionUpdate::ResumeInvalid);
         retry_fresh(
@@ -93,7 +94,24 @@ pub(crate) async fn spawn_claude(
         )
         .await;
     } else if outcome == CliRunOutcome::ProviderRequestMalformedJson {
+        // Malformed-JSON without a resume to clear: tell the user
+        // explicitly so they can edit the prompt and try again.
         send_malformed_provider_json_status(tx);
+    } else if outcome == CliRunOutcome::ClaudeResumeCorrupted {
+        // Corrupted-resume signature fired but we had no `--resume` to
+        // strip. That means claude itself bombed at startup for some
+        // unrelated reason — surface a typed `SpawnFailed` so the user
+        // sees a "Report bug" card instead of a silent hang.
+        let _ = tx.send(SessionUpdate::Feed(FeedItem::ProviderError(
+            ProviderError::SpawnFailed {
+                provider: provider.id().to_string(),
+                cli_name: provider.cli_name().to_string(),
+                message: "claude exited at startup with error_during_execution".to_string(),
+            },
+        )));
+        let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(
+            "claude failed to start".to_string(),
+        )));
     }
 }
 
@@ -125,6 +143,23 @@ async fn retry_fresh(
     let retry_outcome = run_cli_process(tx, &mut fresh_cmd, prompt, provider).await;
     if retry_outcome == CliRunOutcome::ProviderRequestMalformedJson {
         send_malformed_provider_json_status(tx);
+    } else if retry_outcome == CliRunOutcome::ClaudeResumeCorrupted {
+        // Defensive: the fresh retry has no `--resume`, so the
+        // corrupted-resume signature firing here means claude is
+        // crashing at startup for an unrelated reason. cli_process
+        // skipped its normal failed-exit emission, so surface the
+        // failure ourselves rather than leaving the user staring at a
+        // spinner.
+        let _ = tx.send(SessionUpdate::Feed(FeedItem::ProviderError(
+            ProviderError::SpawnFailed {
+                provider: provider.id().to_string(),
+                cli_name: provider.cli_name().to_string(),
+                message: "claude exited at startup with error_during_execution".to_string(),
+            },
+        )));
+        let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(
+            "claude failed to start".to_string(),
+        )));
     }
 }
 
@@ -183,11 +218,27 @@ fn configure_claude_command(
     }
 }
 
-fn should_retry_malformed_provider_json(
+/// Two failure modes share the "retry without `--resume`" recovery path:
+/// 1. `ProviderRequestMalformedJson` — Anthropic API rejected the resumed
+///    transcript as having an unpaired UTF-16 surrogate (a single bad
+///    emoji or pasted character anywhere in history poisons it forever).
+/// 2. `ClaudeResumeCorrupted` — the on-disk transcript JSONL at
+///    `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` is structurally
+///    broken (truncated trailing line, dangling tool_use without
+///    tool_result). The CLI crashes before contacting the API.
+///
+/// In both cases the cure is the same: clear the persisted session id,
+/// re-spawn `claude -p` without `--resume`, and let the user continue.
+/// Without a resume id there is nothing to strip — fall through to the
+/// outer error-surfacing branches so the user still gets feedback.
+fn should_retry_fresh_after_resume_failure(
     outcome: CliRunOutcome,
     resume_session_id: Option<&str>,
 ) -> bool {
-    outcome == CliRunOutcome::ProviderRequestMalformedJson && resume_session_id.is_some()
+    matches!(
+        outcome,
+        CliRunOutcome::ProviderRequestMalformedJson | CliRunOutcome::ClaudeResumeCorrupted
+    ) && resume_session_id.is_some()
 }
 
 fn send_malformed_provider_json_status(tx: &mpsc::UnboundedSender<SessionUpdate>) {
@@ -202,24 +253,41 @@ mod tests {
 
     #[test]
     fn retries_malformed_provider_json_only_for_resume() {
-        assert!(should_retry_malformed_provider_json(
+        assert!(should_retry_fresh_after_resume_failure(
             CliRunOutcome::ProviderRequestMalformedJson,
             Some("claude-session-id"),
         ));
-        assert!(!should_retry_malformed_provider_json(
+        assert!(!should_retry_fresh_after_resume_failure(
             CliRunOutcome::ProviderRequestMalformedJson,
             None,
         ));
     }
 
     #[test]
+    fn retries_corrupted_resume_only_when_resume_id_present() {
+        assert!(should_retry_fresh_after_resume_failure(
+            CliRunOutcome::ClaudeResumeCorrupted,
+            Some("claude-session-id"),
+        ));
+        // No resume to strip — the runner surfaces a SpawnFailed card instead.
+        assert!(!should_retry_fresh_after_resume_failure(
+            CliRunOutcome::ClaudeResumeCorrupted,
+            None,
+        ));
+    }
+
+    #[test]
     fn does_not_retry_other_outcomes() {
-        assert!(!should_retry_malformed_provider_json(
+        assert!(!should_retry_fresh_after_resume_failure(
             CliRunOutcome::Failed,
             Some("claude-session-id"),
         ));
-        assert!(!should_retry_malformed_provider_json(
+        assert!(!should_retry_fresh_after_resume_failure(
             CliRunOutcome::Completed,
+            Some("claude-session-id"),
+        ));
+        assert!(!should_retry_fresh_after_resume_failure(
+            CliRunOutcome::CodexResumeMissing,
             Some("claude-session-id"),
         ));
     }

--- a/engine/houston-terminal-manager/src/cli_process.rs
+++ b/engine/houston-terminal-manager/src/cli_process.rs
@@ -17,6 +17,13 @@ pub(crate) enum CliRunOutcome {
     Failed,
     CodexResumeMissing,
     ProviderRequestMalformedJson,
+    /// Claude's first stdout line was a `result/error_during_execution`
+    /// with `duration_ms == 0` — the on-disk transcript pointed at by
+    /// `--resume <id>` is unrecoverable. The runner uses this outcome to
+    /// silently retry the spawn without `--resume`. See
+    /// `session_io::StdoutReadReport::saw_resume_corrupted` for the full
+    /// rationale.
+    ClaudeResumeCorrupted,
 }
 
 enum CliIoReport {
@@ -126,7 +133,16 @@ pub(crate) async fn run_cli_process(
                 || stderr_lines
                     .iter()
                     .any(|line| detect_malformed_provider_json(line));
-            if malformed_provider_json {
+            // Claude resume-corrupted: must precede `status.success()`
+            // and the generic failure path so the runner can retry
+            // silently without the user seeing a flicker of "claude hit
+            // a runtime error".
+            if stdout_report.saw_resume_corrupted {
+                tracing::warn!(
+                    "[houston:session] claude failed with corrupted-resume signature"
+                );
+                CliRunOutcome::ClaudeResumeCorrupted
+            } else if malformed_provider_json {
                 tracing::warn!("[houston:session] claude failed with malformed provider JSON");
                 CliRunOutcome::ProviderRequestMalformedJson
             } else if status.success() || is_sigterm || likely_user_stop_windows {
@@ -293,6 +309,7 @@ mod tests {
             malformed_provider_json: false,
             saw_auth_error: true,
             saw_model_unsupported_error: false,
+            saw_resume_corrupted: false,
         };
 
         let outcome =

--- a/engine/houston-terminal-manager/src/session_io.rs
+++ b/engine/houston-terminal-manager/src/session_io.rs
@@ -26,6 +26,22 @@ pub struct StdoutReadReport {
     /// card, so `handle_failed_exit` must NOT also emit the generic
     /// `ProviderProcess` card on top of it.
     pub saw_model_unsupported_error: bool,
+    /// True when claude's very first stdout line is a `result` event with
+    /// `subtype:"error_during_execution"` and `duration_ms == 0`. That
+    /// combination is the runtime signature of a corrupted resume — the
+    /// CLI tries to replay the on-disk transcript at
+    /// `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl`, finds an
+    /// unrecoverable shape (dangling tool_use without tool_result,
+    /// truncated trailing line, etc.) and bombs out before issuing any
+    /// API call. The runner uses this flag to silently retry the spawn
+    /// without `--resume` rather than surfacing a useless "claude hit a
+    /// runtime error" status to the user. See the production logs for
+    /// 2026-05-22 (Luisa Postres / Chef - Checho) where 11 successive
+    /// turns hit this state for the same session_key with rotating
+    /// resume_ids — each retry from the UI re-pinned the same broken
+    /// transcript, and the user perceived it as the conversation being
+    /// frozen and her history vanishing.
+    pub saw_resume_corrupted: bool,
 }
 
 /// Read all stderr lines, emitting only user-actionable feed items.
@@ -130,6 +146,28 @@ async fn read_claude_stdout(
             tracing::warn!("[houston:stdout:claude] suppressed malformed provider JSON error");
             continue;
         }
+        // First-line `result` with `subtype:"error_during_execution"` +
+        // `duration_ms == 0` is the corrupted-resume signature. Replace
+        // the useless "Unknown error" parse result with a typed
+        // `SessionResumeMissing` card so the user sees a clear "we had
+        // to restart this session" message in the feed — then mark the
+        // report so the runner can silently retry without `--resume`.
+        // The card stays in the feed as historical context for why the
+        // assistant's next response will not remember prior turns.
+        if line_count == 1 && detect_claude_resume_corrupted(&line) {
+            report.saw_resume_corrupted = true;
+            tracing::warn!(
+                "[houston:stdout:claude] corrupted-resume signature (line 1) — emitting SessionResumeMissing card + flagging for retry-fresh"
+            );
+            let session_id = parser::extract_session_id(&line).unwrap_or_default();
+            let _ = tx.send(SessionUpdate::Feed(FeedItem::ProviderError(
+                ProviderError::SessionResumeMissing {
+                    provider: "anthropic".to_string(),
+                    session_id,
+                },
+            )));
+            continue;
+        }
         let items = parser::parse_event(&line, &mut acc);
         mark_auth_error(&items, &mut report);
         item_count += log_and_send(&tx, items);
@@ -138,6 +176,33 @@ async fn read_claude_stdout(
         "[houston:stdout:claude] stream ended. {line_count} lines, {item_count} feed items"
     );
     report
+}
+
+/// Detect the on-the-wire shape of a claude `--resume` failure: the very
+/// first stdout line is `{"type":"result","subtype":"error_during_execution","duration_ms":0,...}`.
+///
+/// `duration_ms == 0` plus `error_during_execution` on the first event
+/// means the CLI failed before issuing any API call — in practice, the
+/// `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` transcript the
+/// `--resume <id>` flag points to is unrecoverable (dangling tool_use,
+/// truncated trailing line). Any non-zero duration would mean the API
+/// was actually contacted, and any non-`result` first line (`system
+/// init`, `assistant`, `stream_event`, etc.) means claude was already in
+/// flight and the failure is mid-stream — neither case is a resume bug,
+/// so we deliberately keep the matcher narrow.
+fn detect_claude_resume_corrupted(line: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(line.trim()) else {
+        return false;
+    };
+    let obj = match value.as_object() {
+        Some(o) => o,
+        None => return false,
+    };
+    let is_result = obj.get("type").and_then(|v| v.as_str()) == Some("result");
+    let is_corrupt_subtype =
+        obj.get("subtype").and_then(|v| v.as_str()) == Some("error_during_execution");
+    let zero_duration = obj.get("duration_ms").and_then(|v| v.as_u64()) == Some(0);
+    is_result && is_corrupt_subtype && zero_duration
 }
 
 async fn read_codex_stdout(
@@ -303,5 +368,73 @@ mod tests {
             report.saw_auth_error,
             "claude 401 result event should set saw_auth_error"
         );
+    }
+
+    #[test]
+    fn detect_resume_corrupted_matches_production_signature() {
+        // Verbatim shape from backend.log.2026-05-22 line 856 (Luisa
+        // Postres / Chef - Checho activity-409b0b45). The session was
+        // pinned to a broken transcript; claude exited at duration_ms=0
+        // after 11 successive turns.
+        let line = r#"{"type":"result","subtype":"error_during_execution","duration_ms":0,"duration_api_ms":0,"is_error":true,"num_turns":0,"session_id":"5f394669-2db7-4be2-b939-ce92176f6002"}"#;
+        assert!(detect_claude_resume_corrupted(line));
+    }
+
+    #[test]
+    fn detect_resume_corrupted_rejects_post_api_error() {
+        // Same subtype but the API was actually contacted (non-zero
+        // duration_ms). That's a legitimate mid-flight failure, not a
+        // resume bug — must NOT auto-retry, or we'd hide real issues.
+        let line = r#"{"type":"result","subtype":"error_during_execution","duration_ms":4200,"is_error":true}"#;
+        assert!(!detect_claude_resume_corrupted(line));
+    }
+
+    #[test]
+    fn detect_resume_corrupted_rejects_other_subtypes() {
+        // A zero-duration `result` with a different subtype (e.g.
+        // `success`, `error_max_turns`, plain `error`) does not match
+        // the corrupted-resume signature.
+        let cases = [
+            r#"{"type":"result","subtype":"success","duration_ms":0,"is_error":false}"#,
+            r#"{"type":"result","subtype":"error","duration_ms":0,"is_error":true}"#,
+            r#"{"type":"result","subtype":"error_max_turns","duration_ms":0,"is_error":true}"#,
+        ];
+        for line in cases {
+            assert!(
+                !detect_claude_resume_corrupted(line),
+                "expected no match for: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn detect_resume_corrupted_rejects_non_result_events() {
+        // `system init`, `assistant`, `stream_event` all happen BEFORE a
+        // legitimate result event. Matching them would be a category
+        // error — they aren't end-of-stream signals.
+        let cases = [
+            r#"{"type":"system","subtype":"init","session_id":"abc","cwd":"/tmp"}"#,
+            r#"{"type":"assistant","message":{"id":"m1","content":[]}}"#,
+            r#"{"type":"stream_event","event":{"type":"message_start"}}"#,
+        ];
+        for line in cases {
+            assert!(
+                !detect_claude_resume_corrupted(line),
+                "expected no match for: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn detect_resume_corrupted_rejects_invalid_json() {
+        // Truncated / partial lines must not match — claude's first
+        // stdout event is always a complete NDJSON object, so a bad
+        // parse means the line is corrupted on our end, not a resume
+        // signature.
+        assert!(!detect_claude_resume_corrupted(""));
+        assert!(!detect_claude_resume_corrupted("not json"));
+        assert!(!detect_claude_resume_corrupted(
+            r#"{"type":"result","subtype":"error_during_execution","duration_ms":"#
+        ));
     }
 }

--- a/knowledge-base/provider-errors.md
+++ b/knowledge-base/provider-errors.md
@@ -30,7 +30,7 @@ and mirrored in `ui/chat/src/types.ts`. The two MUST stay in sync.
 | `Unauthenticated`          | Auth missing/expired/invalid. `cause` narrows the body copy.                            | Reconnect (drives `tauriProvider.launchLogin`).      |
 | `NetworkUnreachable`       | Cannot reach the provider's API (DNS, connect refused, ECONNRESET).                     | Retry, Check status page.                            |
 | `ProviderInternal`         | 5xx from upstream, transient infra failure.                                             | Retry, Check status page.                            |
-| `SessionResumeMissing`     | Resume target doesn't exist (Codex `no rollout found`).                                 | Start fresh.                                         |
+| `SessionResumeMissing`     | Resume target is gone or unrecoverable. Codex: `no rollout found`. Anthropic: claude exits with `result/error_during_execution/duration_ms:0` on the very first stdout line — the `~/.claude/projects/<encoded-cwd>/<id>.jsonl` transcript is corrupt. Both runners auto-restart fresh; the card is informational. | Try again (re-sends after the auto-restart in case the fresh attempt also failed). |
 | `MalformedResponse`        | CLI emitted unparseable JSON mid-stream.                                                 | Retry.                                               |
 | `SpawnFailed`              | CLI couldn't even spawn (binary missing, killed by OS).                                  | Report bug.                                          |
 | `Cancelled`                | User pressed Stop. Distinct so the UI shows nothing (no toast, no retry).                | none (rendered as `null`).                           |


### PR DESCRIPTION
## Summary

- Detect the claude-CLI signature for a corrupted `~/.claude/projects/<encoded-cwd>/<id>.jsonl` transcript (first stdout line is `{type:result, subtype:error_during_execution, duration_ms:0}`) and short-circuit to `CliRunOutcome::ClaudeResumeCorrupted` before the generic failure path runs.
- Mirror the existing `ProviderRequestMalformedJson` recovery on the new outcome: when a `--resume` was passed, emit `SessionUpdate::ResumeInvalid` (clears the persisted session id) and silently respawn `claude -p` without `--resume`; when no `--resume` was passed, surface a typed `SpawnFailed` card.
- Emit a typed `FeedItem::ProviderError(SessionResumeMissing)` before the silent retry so the user sees a single "Session restarted" card in the feed instead of a useless `Unknown` blob, with copy reworded across en/es/pt to reflect that the restart already happened.

## Why

Production logs from Luisa Postres (2026-05-22) showed 11+ successive turns in the same activity (`Chef - Checho`) bombing at `duration_ms=0` because the engine kept pinning the same corrupted transcript on every retry. From the user's side it looked like the conversation kept freezing and her history vanishing, costing us the account.

## Test plan

- [x] `cargo test --workspace` (748 passed, 0 failed) — covers the new `detect_claude_resume_corrupted` matcher, the `should_retry_fresh_after_resume_failure` helper, and existing flows.
- [x] `pnpm tsc --noEmit` in `app/` — clean.
- [x] `pnpm check-locales` — en/es/pt in sync, no em dashes.
- [ ] Manual: corrupt a session transcript locally, send a message in the agent, verify the "Sesión reiniciada" card appears once and the fresh assistant response streams in below without the user clicking anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)