### PR TITLE
fix(missions): start new mission from Mission Control

### DIFF
--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -30,6 +30,7 @@ import { MissionBoardEmptyState } from "./mission-board-empty-state";
 import { useMissionSearch } from "./use-mission-search";
 import { buildMissionBoardColumns } from "./mission-board-columns";
 import { navigateBoard } from "../lib/board-navigate";
+import { planNewMission } from "./mission-control-create";
 
 export function Dashboard() {
   const { t } = useTranslation(["dashboard", "board", "common"]);
@@ -319,6 +320,36 @@ export function Dashboard() {
     },
     [selectedSessionKey, selectedSessionActive, messageQueue.queueMessage, panel.onComposerSubmit],
   );
+  // Blank "New mission" submit. The new-mission panel only opens after an
+  // agent is picked, so `activeAgent` drives the create; the planner keeps
+  // the agent/default-mode resolution pure (and unit-tested). Wiring this
+  // into AIBoard is the issue #328 fix — Mission Control previously passed
+  // no `onCreateConversation`, so a blank submit cleared the composer and
+  // did nothing.
+  const handleCreateConversation = useCallback(
+    async (text: string, files: File[]): Promise<string> => {
+      const plan = planNewMission({
+        activeAgent,
+        activeAgentDef,
+        providerOverride: panel.effectiveProvider,
+        modelOverride: panel.effectiveModel,
+      });
+      if (plan.kind === "no-agent") {
+        addToast({
+          title: t("dashboard:errors.noAgentForMission"),
+          variant: "error",
+        });
+        throw new Error("New mission submitted with no active agent");
+      }
+      return mc.handleCreateConversation(plan.agent, text, files, {
+        agentMode: plan.agentMode,
+        promptFile: plan.promptFile,
+        providerOverride: plan.providerOverride,
+        modelOverride: plan.modelOverride,
+      });
+    },
+    [activeAgent, activeAgentDef, panel.effectiveProvider, panel.effectiveModel, mc.handleCreateConversation, addToast, t],
+  );
   const queuedMessages = useMemo(
     () => selectedSessionKey ? { [selectedSessionKey]: messageQueue.queuedMessages } : {},
     [selectedSessionKey, messageQueue.queuedMessages],
@@ -393,6 +424,7 @@ export function Dashboard() {
           onDelete={mc.handleDelete}
           onApprove={mc.handleApprove}
           onRename={mc.handleRename}
+          onCreateConversation={handleCreateConversation}
           onSendMessage={handleSendMessage}
           queuedMessages={queuedMessages}
           onRemoveQueuedMessage={(_, id) => messageQueue.removeQueuedMessage(id)}

--- a/app/src/components/mission-control-create.ts
+++ b/app/src/components/mission-control-create.ts
@@ -1,0 +1,43 @@
+/**
+ * Pure planning for a Mission Control "new mission" submit.
+ *
+ * Mission Control creates conversations across agents, so the active agent
+ * and its default mode must be resolved before delegating to
+ * `useMissionControl.handleCreateConversation`. Kept pure (no React, no
+ * Tauri) so the routing that issue #328 regressed — a blank submit MUST
+ * produce a create request whenever an agent is active — is unit-testable.
+ */
+
+import type { Agent, AgentDefinition } from "../lib/types";
+
+export type NewMissionPlan =
+  | {
+      kind: "create";
+      agent: Agent;
+      agentMode?: string;
+      promptFile?: string;
+      providerOverride: string;
+      modelOverride: string;
+    }
+  | { kind: "no-agent" };
+
+export function planNewMission(args: {
+  activeAgent: Agent | null;
+  activeAgentDef: AgentDefinition | null;
+  providerOverride: string;
+  modelOverride: string;
+}): NewMissionPlan {
+  const { activeAgent, activeAgentDef, providerOverride, modelOverride } = args;
+  if (!activeAgent) return { kind: "no-agent" };
+  // A blank Mission Control mission runs the agent's default mode (the
+  // first entry), mirroring the per-agent BoardTab "New mission" button.
+  const defaultMode = activeAgentDef?.config.agents?.[0];
+  return {
+    kind: "create",
+    agent: activeAgent,
+    agentMode: defaultMode?.id,
+    promptFile: defaultMode?.promptFile,
+    providerOverride,
+    modelOverride,
+  };
+}

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -8,15 +8,29 @@ import {
   isActiveSessionStatus,
   useSessionStatusStore,
 } from "../stores/session-status";
+import { useQueryClient } from "@tanstack/react-query";
 import { useAllConversations } from "../hooks/queries";
-import { tauriActivity, tauriChat, tauriAttachments } from "../lib/tauri";
+import {
+  tauriActivity,
+  tauriChat,
+  tauriAttachments,
+  tauriConfig,
+  tauriWorktree,
+  tauriShell,
+} from "../lib/tauri";
 import { buildAttachmentPrompt } from "../lib/attachment-message";
+import { createMission } from "../lib/create-mission";
+import { formatVisibleMessageText } from "../lib/queued-chat";
+import { queryKeys } from "../lib/query-keys";
+import { useUIStore } from "../stores/ui";
 import type { Agent } from "../lib/types";
 import { createElement } from "react";
 import { AgentCardAvatar } from "./shell/agent-card-avatar";
 
 export function useMissionControl(agents: Agent[]) {
   const { t } = useTranslation("chat");
+  const queryClient = useQueryClient();
+  const addToast = useUIStore((s) => s.addToast);
   // Mission control is cross-agent. Flatten the nested feed store into a
   // single sessionKey → items map, filtered to the agents on this view.
   const allItems = useFeedStore((s) => s.items);
@@ -161,18 +175,87 @@ export function useMissionControl(agents: Agent[]) {
     [pushFeedItem, t],
   );
 
-  const handleCreate = useCallback(
-    async (agentPath: string, text: string) => {
-      const title = text.length > 80 ? text.slice(0, 77) + "..." : text;
-      const item = await tauriActivity.create(agentPath, title, text);
-      const sessionKey = `activity-${item.id}`;
-      pushFeedItem(agentPath, sessionKey, { feed_type: "user_message", data: text });
-      setLoading((prev) => ({ ...prev, [sessionKey]: true }));
-      await tauriActivity.update(agentPath, item.id, { status: "running" });
-      tauriChat.send(agentPath, text, sessionKey);
-      setSelectedId(item.id);
+  // Blank "New mission" create path for Mission Control. Mirrors the
+  // per-agent BoardTab `handleCreateConversation` (it routes through the
+  // same `createMission` source of truth) but takes the agent explicitly
+  // because this view is cross-agent. Wired into AIBoard via
+  // `onCreateConversation`; without it a blank submit had no handler and
+  // the composer silently cleared (issue #328). AIBoard selects the
+  // returned activity id, so we don't call setSelectedId here.
+  const handleCreateConversation = useCallback(
+    async (
+      agent: Agent,
+      text: string,
+      files: File[],
+      opts?: {
+        agentMode?: string;
+        promptFile?: string;
+        providerOverride?: string;
+        modelOverride?: string;
+      },
+    ): Promise<string> => {
+      const agentPath = agent.folderPath;
+
+      // Honour worktree mode when the agent's config opts in — same
+      // bootstrap as the BoardTab create path.
+      let worktreePath: string | undefined;
+      try {
+        const cfg = await tauriConfig.read(agentPath);
+        if (cfg.worktreeMode) {
+          const slug = crypto.randomUUID().slice(0, 8);
+          const wt = await tauriWorktree.create(agentPath, slug);
+          worktreePath = wt.path;
+          const installCmd = cfg.installCommand as string | undefined;
+          if (installCmd && worktreePath) {
+            tauriShell.run(worktreePath, installCmd).catch(console.error);
+          }
+        }
+      } catch {
+        /* config may not exist yet */
+      }
+
+      const visible = formatVisibleMessageText(
+        text,
+        files,
+        (names) => t("queue.attached", { names }),
+      );
+      let userMessage = text;
+      try {
+        const { conversationId, sessionKey } = await createMission(
+          { id: agent.id, name: agent.name, color: agent.color, folderPath: agentPath },
+          text,
+          {
+            agentMode: opts?.agentMode,
+            worktreePath,
+            promptFile: opts?.promptFile,
+            providerOverride: opts?.providerOverride,
+            modelOverride: opts?.modelOverride,
+            titleText: visible,
+            buildPrompt: async (activityId) => {
+              const saved = await tauriAttachments.save(`activity-${activityId}`, files);
+              userMessage = buildAttachmentPrompt(text, files, saved);
+              return userMessage;
+            },
+          },
+        );
+        pushFeedItem(agentPath, sessionKey, { feed_type: "user_message", data: userMessage });
+        setLoading((prev) => ({ ...prev, [sessionKey]: true }));
+        // createMission bypasses the activity mutation hooks, so refresh
+        // the cross-agent conversation list manually.
+        queryClient.invalidateQueries({ queryKey: queryKeys.allConversations(paths) });
+        return conversationId;
+      } catch (err) {
+        // No silent failures: createMission already rolled back the
+        // half-created activity. Surface why the mission did not start so
+        // the user can retry or report it.
+        addToast({
+          title: t("errors.sessionStart", { error: String(err) }),
+          variant: "error",
+        });
+        throw err;
+      }
     },
-    [pushFeedItem],
+    [t, pushFeedItem, queryClient, paths, addToast],
   );
 
   const effectiveLoading = useMemo(() => {
@@ -214,6 +297,6 @@ export function useMissionControl(agents: Agent[]) {
     handleApprove,
     handleRename,
     handleSendMessage,
-    handleCreate,
+    handleCreateConversation,
   };
 }

--- a/app/src/locales/en/dashboard.json
+++ b/app/src/locales/en/dashboard.json
@@ -30,6 +30,9 @@
     "description": "Build your AI team and ship the impossible.",
     "cta": "New Agent"
   },
+  "errors": {
+    "noAgentForMission": "Pick an agent before starting a mission."
+  },
   "agentPicker": {
     "title": "Which agent should run this?",
     "description": "Pick an agent to open a fresh conversation."

--- a/app/src/locales/es/dashboard.json
+++ b/app/src/locales/es/dashboard.json
@@ -30,6 +30,9 @@
     "description": "Arma tu equipo de IA y haz lo imposible.",
     "cta": "Nuevo agente"
   },
+  "errors": {
+    "noAgentForMission": "Elige un agente antes de iniciar una misión."
+  },
   "agentPicker": {
     "title": "¿Qué agente debería ejecutar esto?",
     "description": "Elige un agente para abrir una nueva conversación."

--- a/app/src/locales/pt/dashboard.json
+++ b/app/src/locales/pt/dashboard.json
@@ -30,6 +30,9 @@
     "description": "Monte seu time de IA e realize o impossível.",
     "cta": "Novo agente"
   },
+  "errors": {
+    "noAgentForMission": "Escolha um agente antes de iniciar uma missão."
+  },
   "agentPicker": {
     "title": "Qual agente deve fazer isso?",
     "description": "Escolha um agente para abrir uma nova conversa."

--- a/app/tests/mission-control-create.test.ts
+++ b/app/tests/mission-control-create.test.ts
@@ -1,0 +1,71 @@
+import { deepStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { planNewMission } from "../src/components/mission-control-create.ts";
+import type { Agent, AgentDefinition } from "../src/lib/types.ts";
+
+const agent: Agent = {
+  id: "a1",
+  name: "Ada",
+  folderPath: "/ws/Personal/Ada",
+  configId: "cfg",
+  color: "#abcdef",
+  createdAt: "2026-01-01T00:00:00.000Z",
+};
+
+const agentDefWithModes = {
+  config: {
+    agents: [
+      { id: "default", name: "Default", promptFile: "default", createLabel: "New mission" },
+      { id: "research", name: "Research", promptFile: "research", createLabel: "Research" },
+    ],
+  },
+  source: "builtin",
+} as unknown as AgentDefinition;
+
+const agentDefNoModes = { config: {}, source: "builtin" } as unknown as AgentDefinition;
+
+describe("planNewMission (issue #328)", () => {
+  it("plans a create from a blank submit when an agent is active", () => {
+    const plan = planNewMission({
+      activeAgent: agent,
+      activeAgentDef: agentDefWithModes,
+      providerOverride: "anthropic",
+      modelOverride: "sonnet",
+    });
+    deepStrictEqual(plan, {
+      kind: "create",
+      agent,
+      agentMode: "default",
+      promptFile: "default",
+      providerOverride: "anthropic",
+      modelOverride: "sonnet",
+    });
+  });
+
+  it("creates with no mode when the agent declares none", () => {
+    const plan = planNewMission({
+      activeAgent: agent,
+      activeAgentDef: agentDefNoModes,
+      providerOverride: "openai",
+      modelOverride: "gpt-5.5",
+    });
+    deepStrictEqual(plan, {
+      kind: "create",
+      agent,
+      agentMode: undefined,
+      promptFile: undefined,
+      providerOverride: "openai",
+      modelOverride: "gpt-5.5",
+    });
+  });
+
+  it("refuses to create when no agent is active (caller surfaces a toast)", () => {
+    const plan = planNewMission({
+      activeAgent: null,
+      activeAgentDef: null,
+      providerOverride: "anthropic",
+      modelOverride: "sonnet",
+    });
+    deepStrictEqual(plan, { kind: "no-agent" });
+  });
+});


### PR DESCRIPTION
## Problem
On **Mission Control**, clicking **+**, typing a message, and pressing Enter cleared the composer and did nothing — no mission started and nothing reached the engine. Per-agent mission creation worked fine. Fixes #328.

## Root cause
`Dashboard` (Mission Control) never passed `onCreateConversation` to `AIBoard`. For a blank new-mission submit, `AIBoard.handleSend` runs:
1. `onComposerSubmit` (skill path) returns `false` (no skill) → not handled
2. no card selected → `onSendMessage` skipped
3. `newPanelOpen && onCreateConversation` → **`onCreateConversation` is undefined → skipped**

`handleSend` (async) then resolves with `undefined`, so the composer treats it as a successful send and clears the text. The per-agent `BoardTab` passed `onCreateConversation`, which is why only Mission Control was broken. `useMissionControl.handleCreate` existed but was incomplete and wired to nothing.

## Fix
- **`use-mission-control.ts`** — replace the dead `handleCreate` with `handleCreateConversation(agent, text, files, opts)` routing through the shared `createMission` (attachments, worktree mode, provider/model overrides, auto-title, optimistic feed + loading, conversation-list invalidation). Failures surface via toast then rethrow (no silent failure).
- **`dashboard.tsx`** — wire `onCreateConversation` into `AIBoard`, scoped to the active agent.
- **`mission-control-create.ts`** (new) — pure `planNewMission(...)` resolving active agent + default mode + guard; keeps the logic unit-testable without React.
- **`mission-control-create.test.ts`** (new) — create-with-mode, create-without-mode, and the no-agent guard.
- **`locales/{en,es,pt}/dashboard.json`** — `errors.noAgentForMission` guard string.

## Test plan
- [x] `node --test app/tests/mission-control-create.test.ts` — 3/3 pass (Node 22.6+ strips TS natively; no extra deps)
- [x] `cd app && pnpm typecheck`
- [x] `cd app && pnpm check-locales`
- [x] Manual: Mission Control → + → pick agent → type → Enter → mission starts (card appears, reply streams)

## Out of scope
`ui/chat/.../prompt-input.tsx` swallows submit errors in a `catch {}` with no toast (affects BoardTab create too). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
