### PR TITLE
fix(app): restore cross-platform deps wrongly scoped to macOS target

### DIFF
--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -32,6 +32,12 @@ sentry = "0.42"
 # unconditionally in logging.rs even when SENTRY_DSN is empty.
 sentry-tracing = "0.42"
 keyring = { version = "3", features = ["apple-native", "windows-native"] }
+houston-ui-events = { path = "../../engine/houston-ui-events" }
+reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"], default-features = false }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-appender = { workspace = true }
+
 # macOS-only: native blocking dialog used by the first-launch DMG guard
 # (`dmg_guard.rs`). Must fire BEFORE the Tauri builder runs because once
 # the webview boots we've already committed to launching from the DMG.
@@ -39,11 +45,6 @@ keyring = { version = "3", features = ["apple-native", "windows-native"] }
 # can pop a dialog at the very top of `run()`.
 [target."cfg(target_os = \"macos\")".dependencies]
 rfd = "0.15"
-houston-ui-events = { path = "../../engine/houston-ui-events" }
-reqwest = { version = "0.12", features = ["json", "rustls-tls", "blocking"], default-features = false }
-tracing = { workspace = true }
-tracing-subscriber = { workspace = true }
-tracing-appender = { workspace = true }
 
 # Windows + Linux only: the OS protocol handler launches a fresh
 # `houston-app.exe` for every `houston://` URL it receives (Start-menu


### PR DESCRIPTION
## What

Move `reqwest`, `tracing`, `tracing-subscriber`, `tracing-appender`, and `houston-ui-events` out of the macOS-only `[target."cfg(target_os = "macos")".dependencies]` table in `app/src-tauri/Cargo.toml` and back into the main `[dependencies]` table. Only `rfd` stays macOS-scoped.

## Why

PR #326 (branded DMG installer) added the macOS `[target...]` dependency table for `rfd`, but the table header landed **in the middle of `[dependencies]`**, immediately after `keyring`. In TOML a table header captures every key below it until the next header — so the five crates that followed were silently reassigned to macOS-only:

```toml
[target."cfg(target_os = "macos")".dependencies]
rfd = "0.15"
houston-ui-events = { ... }   # ← meant to be cross-platform
reqwest = { ... }             # ← meant to be cross-platform
tracing = { workspace = true }
tracing-subscriber = { workspace = true }
tracing-appender = { workspace = true }
```

macOS builds and CI kept compiling (the target table is active there), so the regression was invisible on the mac toolchain. The first `cargo check --workspace` on Windows/Linux fails with **42 unresolved-crate errors** (`E0432`/`E0433`) across `logging.rs`, `lib.rs`, `notification.rs`, `engine_supervisor.rs`, `auth.rs`, and `bug_report/`.

## Fix

The five crates go back into `[dependencies]`; `rfd` keeps its macOS target table (now correctly holding only `rfd`).

## Verification

- `cargo check --workspace` — passes on Windows (previously 42 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
