### PR TITLE
release: v0.4.14

### DIFF
--- a/.github/release-notes/0.4.14.md
+++ b/.github/release-notes/0.4.14.md
@@ -1,0 +1,27 @@
+## Houston 0.4.14
+
+Builds on v0.4.13 with a round of reliability fixes (Windows sign-in, setup errors, starting missions, and a friendlier crash screen) plus a cleaner macOS installer.
+
+### Fixed
+
+- **Codex sign-in on Windows.** Signing in to Codex on Windows now works. A previous build could fail the Codex login step with a cryptic error.
+- **Start a new mission from Mission Control.** The "new mission" action works again from Mission Control.
+- **Automatic recovery from a corrupted conversation history.** If a saved conversation gets corrupted, Houston now repairs it on its own instead of getting stuck when you resume.
+- **Clearer, translated setup errors.** When Claude Code can't finish setting up, Houston now shows the real reason, in your language, instead of a generic failure.
+- **Readable startup errors instead of a white screen.** If Houston hits a problem while launching, you now get a clear, copyable error with a way to report it, rather than a blank window. On older macOS versions you get an update prompt instead.
+- **Agent-created notes show up in Files.** Markdown that an agent writes now appears in the Files tab right away.
+- **Notification clicks open the mission (Windows and Linux).** Clicking a finished-session notification now takes you straight to that mission.
+- **No leftover background process after quitting (Windows and Linux).** Closing Houston now fully shuts down its background engine.
+
+### Changed
+
+- **Cleaner macOS installer.** The install window has a clear drag-to-Applications layout, and if you open Houston directly from the disk image it offers to move itself into Applications for you.
+- **Keyboard shortcuts live in Settings.** The Commands list moved into Settings as a "Keyboard shortcuts" section.
+- **Reasoning effort is per agent.** You can set reasoning effort per agent now, and it only shows for models that support it.
+- **Tidier sign-in dialog.** The provider sign-in link is tucked behind a "reveal" toggle so the dialog stays clean.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward automatically. The MSI is still not OS-code-signed (SignPath integration still pending).
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install. Download the ARM64 MSI manually, uninstall the x64 build first, then install the ARM64 one.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "futures-util",
  "hex",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "serde",
  "serde_json",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2643,7 +2643,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2657,7 +2657,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2668,7 +2668,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2682,7 +2682,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2698,7 +2698,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "houston-agent-files",
  "houston-agents-conversations",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "dirs 5.0.1",
  "houston-cli-bundle",
@@ -2729,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2749,7 +2749,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.13"
+version = "0.4.14"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.13", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.13", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.13", path = "app/houston-tauri" }
-houston-events = { version = "0.4.13", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.13", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.13", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.13", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.13", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.13", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.13", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.13", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.13", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.13", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.13", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.13", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.13", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.13", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.13", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.14", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.14", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.14", path = "app/houston-tauri" }
+houston-events = { version = "0.4.14", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.14", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.14", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.14", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.14", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.14", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.14", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.14", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.14", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.14", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.14", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.14", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.14", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.14", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.14", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.13"
+version = "0.4.14"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.13",
+  "version": "0.4.14",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## What

Workspace version bump **0.4.13 → 0.4.14** plus authored release notes.

- Root `Cargo.toml` internal dependency pins (18 `houston-*` entries)
- All 17 engine crates + both app crates (`houston-app`, `houston-tauri`)
- Root + app `package.json` and the 8 published `ui/*` packages
- The 19 `houston-*` entries in `Cargo.lock` (the external `h2` and `tower` crates are coincidentally also at `0.4.13` and are intentionally left untouched)
- New `.github/release-notes/0.4.14.md`

30 manifests + `Cargo.lock` + 1 notes file = 32 files.

## Release notes

`.github/release-notes/0.4.14.md` is included so the release workflow uses it verbatim instead of the auto-generated changelog. It is a **draft starting point** — please curate/polish before publishing the GitHub release. It summarizes the user-facing work since v0.4.13: Windows Codex sign-in fix, new-mission-from-Mission-Control fix, corrupted-transcript auto-recovery, localized setup errors, copyable startup-crash screen, Files-tab markdown, notification-click routing, orphan-engine cleanup, the branded macOS installer, keyboard shortcuts in Settings, and per-agent reasoning effort.

## How to ship after merge

This PR only lands the bump on `main`. To cut the release:

```
git checkout main && git pull upstream main
git tag v0.4.14
git push upstream v0.4.14
```

The tag push triggers `release.yml`, which builds + signs + notarizes macOS and Windows, then creates a **draft** GitHub release using the notes above. Smoke-test, then click Publish.

## Notes

- No code changes — version strings only. CI typecheck/build validates the bump.
- Includes the Windows build fix from #330 (already on `main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
