### PR TITLE
fix(dmg): detach renamed volume by device node, not /Volumes path

### DIFF
--- a/scripts/rename-dmg-volume.sh
+++ b/scripts/rename-dmg-volume.sh
@@ -6,10 +6,9 @@
 # Finder and the macOS dock. We want the disk to read "Houston Installer"
 # so non-technical users don't think the mounted volume IS the app.
 #
-# Approach: convert the read-only .dmg → temporary read/write .sparseimage,
-# rename the volume with `hdiutil resize`'s sibling tool isn't reliable, so
-# we instead mount, rename via `diskutil`, detach, then convert back to a
-# compressed read-only UDZO image at the original path.
+# Approach: convert the read-only .dmg into a temporary read/write
+# .sparseimage, mount it, rename the volume via `diskutil`, detach, then
+# convert back to a compressed read-only UDZO image at the original path.
 #
 # Usage:
 #   ./scripts/rename-dmg-volume.sh path/to/Houston_x.y.z_aarch64.dmg "Houston Installer"
@@ -20,7 +19,7 @@
 #     tauri-bundler injected).
 #   - Resulting DMG is unsigned (the rename invalidates the original
 #     code-signature). On CI the existing `Notarize DMG` step re-notarizes
-#     and staples after rename — that re-signs implicitly. For local runs
+#     and staples after rename, which re-signs implicitly. For local runs
 #     you can skip signing; Gatekeeper will warn on first open.
 
 set -euo pipefail
@@ -39,36 +38,72 @@ if [ ! -f "$DMG" ]; then
 fi
 
 WORK_DIR=$(mktemp -d)
-trap 'rm -rf "$WORK_DIR"; hdiutil detach "$MOUNT_POINT" -force -quiet 2>/dev/null || true' EXIT
-
 SPARSE="$WORK_DIR/work.sparseimage"
 MOUNT_POINT="$WORK_DIR/mnt"
+# Device node (e.g. /dev/disk6) from `hdiutil attach`, captured after mount.
+# We detach by device, NOT by mountpoint: renaming a mounted volume can make
+# macOS expose it at /Volumes/<new-name> while the original -mountpoint goes
+# stale, so the device node is the only handle that stays valid across the
+# rename. Empty until attached so the EXIT trap can guard on it.
+DEV_NODE=""
 mkdir -p "$MOUNT_POINT"
+
+# Detach (by device) BEFORE removing the temp dir. Reversing that order is
+# what produced the "Resource busy" / "Directory not empty" rm failures: the
+# volume was still mounted under $WORK_DIR when rm ran.
+cleanup() {
+    if [ -n "$DEV_NODE" ]; then
+        hdiutil detach "$DEV_NODE" -force -quiet 2>/dev/null || true
+    fi
+    rm -rf "$WORK_DIR" 2>/dev/null || true
+}
+trap cleanup EXIT
 
 echo "=== Converting $(basename "$DMG") to writable sparse image ==="
 hdiutil convert "$DMG" -format UDSP -o "${SPARSE%.sparseimage}" -quiet
 
 echo "=== Mounting sparse image ==="
-hdiutil attach "$SPARSE" -mountpoint "$MOUNT_POINT" -nobrowse -quiet
+# Not -quiet: we need the attach table to extract the device node.
+ATTACH_OUT=$(hdiutil attach "$SPARSE" -mountpoint "$MOUNT_POINT" -nobrowse)
+DEV_NODE=$(printf '%s\n' "$ATTACH_OUT" | awk '/^\/dev\// { print $1; exit }')
+if [ -z "$DEV_NODE" ]; then
+    echo "::error::could not determine device node from hdiutil attach" >&2
+    printf '%s\n' "$ATTACH_OUT" >&2
+    exit 1
+fi
+echo "mounted $DEV_NODE at $MOUNT_POINT"
+
+# Hide the dot-prefixed helper folders so users with "show hidden files"
+# enabled in Finder (Cmd+Shift+.) don't see `.background` and `.fseventsd`
+# overlapping the styled background art. Done BEFORE the rename, while the
+# volume is unambiguously at $MOUNT_POINT.
+for dotdir in .background .fseventsd; do
+    if [ -d "$MOUNT_POINT/$dotdir" ]; then
+        chflags hidden "$MOUNT_POINT/$dotdir" || true
+    fi
+done
 
 echo "=== Renaming volume to '$NEW_NAME' ==="
 # `diskutil rename <mount-point>` works on the mounted HFS+/APFS volume.
 diskutil rename "$MOUNT_POINT" "$NEW_NAME"
 
-# Hide the dot-prefixed helper folders so users with "show hidden files"
-# enabled in Finder (Cmd+Shift+.) don't see `.background` and
-# `.fseventsd` overlapping the styled background art. The Tauri DMG
-# bundler doesn't set the UF_HIDDEN flag by default; do it here while
-# we've already got the volume mounted read-write.
-NEW_MOUNT="/Volumes/$NEW_NAME"
-for dotdir in .background .fseventsd; do
-    if [ -d "$NEW_MOUNT/$dotdir" ]; then
-        chflags hidden "$NEW_MOUNT/$dotdir" || true
-    fi
-done
-
 echo "=== Detaching ==="
-hdiutil detach "$NEW_MOUNT" -quiet
+# A freshly renamed volume can briefly report busy (fseventsd, Spotlight
+# indexing), so retry the detach before giving up.
+detached=0
+for attempt in 1 2 3 4 5; do
+    if hdiutil detach "$DEV_NODE" -force -quiet 2>/dev/null; then
+        detached=1
+        break
+    fi
+    echo "detach attempt $attempt: $DEV_NODE busy, retrying in 2s..."
+    sleep 2
+done
+if [ "$detached" -ne 1 ]; then
+    echo "::error::failed to detach $DEV_NODE after 5 attempts" >&2
+    exit 1
+fi
+DEV_NODE=""  # detached cleanly; stop the EXIT trap from re-detaching
 
 echo "=== Re-compressing back to read-only UDZO at original path ==="
 TMP_OUT="$WORK_DIR/out.dmg"


### PR DESCRIPTION
## What

`scripts/rename-dmg-volume.sh` now detaches the mounted sparse image by its **device node** (e.g. `/dev/disk6`) instead of by `/Volumes/$NEW_NAME`.

## Why

The macOS release build for v0.4.14 failed at the **"Rename DMG volume"** step:

```
=== Detaching ===
rm: .../tmp.RhFSZg5KPE/mnt: Resource busy
rm: .../tmp.RhFSZg5KPE: Directory not empty
Error: Process completed with exit code 1.
```

The script mounts the sparse image at an explicit `$WORK_DIR/mnt` mountpoint, but then ran `chflags` + `hdiutil detach` against `/Volumes/$NEW_NAME`. After `diskutil rename` the volume is still mounted at `$WORK_DIR/mnt`, so the detach targeted a path with nothing mounted, failed under `set -e`, and the EXIT trap's `rm -rf "$WORK_DIR"` then tripped over the still-mounted (busy) `mnt`.

It passed for v0.4.13 only because macOS *sometimes* also surfaces a renamed volume under `/Volumes` — luck, not correctness.

## Fix

- Capture the device node from `hdiutil attach` and detach by device, which stays valid no matter where the renamed volume ends up mounted.
- `chflags` the helper dot-dirs **before** the rename, while the volume is unambiguously at `$MOUNT_POINT`.
- Retry the detach (transient `fseventsd`/Spotlight busy) and fail loudly if it never releases.
- Reorder the EXIT trap to detach the device **before** `rm` so cleanup can't trip over a live mount.

`bash -n` clean. The `hdiutil`/`diskutil` flow is macOS-only and can't run on the PR author's machine, so it needs a CI run on macOS to fully validate.

## Heads-up: v0.4.14 needs re-cutting after this merges

The `v0.4.14` tag currently points at `f672233`, which predates this fix, and a partial draft release already exists. After merging, to ship a working v0.4.14:

```
gh run cancel <failed-run-id> --repo gethouston/houston      # the in-flight build of the old commit
gh release delete v0.4.14 --repo gethouston/houston --cleanup-tag --yes
git fetch upstream && git tag -a v0.4.14 upstream/main -m "Houston v0.4.14"
git push upstream v0.4.14
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
