### PR TITLE
fix(ci): resolve sentry-cli path on Windows debug-symbol upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1023,12 +1023,29 @@ jobs:
 
           curl -sL https://sentry.io/get-cli/ | bash
 
+          # get-cli installs to /usr/local/bin, which is on PATH on the macOS
+          # runner but NOT on the Windows git-bash runner (the upload there
+          # failed with "sentry-cli: command not found", exit 127). Resolve the
+          # binary explicitly so it works regardless of PATH or the .exe suffix
+          # the Windows download lands with.
+          SENTRY_CLI=$(command -v sentry-cli || true)
+          if [ -z "$SENTRY_CLI" ]; then
+            for candidate in /usr/local/bin/sentry-cli /usr/local/bin/sentry-cli.exe; do
+              if [ -x "$candidate" ]; then SENTRY_CLI="$candidate"; break; fi
+            done
+          fi
+          if [ -z "$SENTRY_CLI" ]; then
+            echo "::error::sentry-cli not found after install" >&2
+            exit 1
+          fi
+          "$SENTRY_CLI" --version
+
           echo "=== Upload ${{ matrix.target }} debug symbols ==="
           # MSVC emits the PDB next to the .exe; Rust converts the binary's
           # `-` to `_` for the PDB stem (houston-engine.exe → houston_engine.pdb).
           # Upload both — Sentry needs the PDB for symbolication but indexes
           # by the .exe's debug-id.
-          sentry-cli debug-files upload \
+          "$SENTRY_CLI" debug-files upload \
             "target/${{ matrix.target }}/release/houston-engine.exe" \
             "target/${{ matrix.target }}/release/houston_engine.pdb"
 


### PR DESCRIPTION
## What

In the `build-windows` job's **"Upload Rust debug symbols to Sentry"** step, resolve the `sentry-cli` binary explicitly instead of relying on a bare `sentry-cli` being on PATH.

## Why

The step failed the Windows release build with exit code 127:

```
Sucessfully installed sentry-cli 3.4.3
Installation path: /usr/local/bin/sentry-cli
=== Upload x86_64-pc-windows-msvc debug symbols ===
...sh: line 12: sentry-cli: command not found
```

`curl -sL https://sentry.io/get-cli/ | bash` installs `sentry-cli` into `/usr/local/bin`. That directory is on PATH on the macOS runner (where the identical pattern works), but **not** on the Windows git-bash runner, so the subsequent bare `sentry-cli` invocation is `command not found`.

## Fix

After install, resolve the binary into `$SENTRY_CLI`:
1. `command -v sentry-cli` (the macOS path, unchanged),
2. else fall back to `/usr/local/bin/sentry-cli` / `…/sentry-cli.exe`,
3. else `::error::` + exit 1 (no silent skip).

Then invoke `"$SENTRY_CLI" --version` and the `debug-files upload` through that resolved path. Same get-cli installer on both platforms; macOS behavior is unchanged (it hits branch 1).

Affects both Windows matrix arches (x86_64 + aarch64), since they share this step.

## Validation

YAML/script change only; the real check is a Windows CI run. Without it, Sentry symbol upload silently degrades Windows crash reports to unsymbolicated addresses — this restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
