### PR TITLE
fix(ci): re-sign DMG after volume rename before notarization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -605,6 +605,22 @@ jobs:
         run: |
           ./scripts/rename-dmg-volume.sh "${{ steps.artifacts.outputs.dmg }}" "Houston Installer"
 
+      # rename-dmg-volume.sh rebuilds the DMG (hdiutil convert), which strips
+      # the Developer ID signature tauri-action applied to the original .dmg.
+      # Notarization staples a ticket but does NOT code-sign, so without this
+      # the DMG reaches "Verify complete signing chain" unsigned ("code object
+      # is not signed at all"). Re-sign with Developer ID here, before
+      # notarization, so the notarized + stapled DMG carries a valid signature.
+      # The identity is already in the keychain from the pre-sign import step.
+      - name: Re-sign DMG after volume rename
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          DMG="${{ steps.artifacts.outputs.dmg }}"
+          codesign --force --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$DMG"
+          echo "=== Re-signed DMG with Developer ID ==="
+          codesign -vvv "$DMG"
+
       - name: Notarize DMG
         timeout-minutes: 25
         run: |


### PR DESCRIPTION
## What

Add a step to the `build-macos` job that re-`codesign`s the DMG with Developer ID right after the volume rename and before notarization.

## Why

The macOS release build failed at **"Verify complete signing chain"**:

```
=== 1. DMG code signature ===
target/.../Houston_0.4.14_universal.dmg: code object is not signed at all
Error: Process completed with exit code 1.
```

`rename-dmg-volume.sh` rebuilds the DMG via `hdiutil convert` to relabel the volume to "Houston Installer", which **discards the Developer ID signature** tauri-action applied to the original `.dmg`. The rename script's comment assumed the later Notarize step would "re-sign implicitly" — but notarization only **staples a ticket**; it does not `codesign`. So the DMG reached the verify step unsigned.

This is the third issue this release surfaced in the new (#326) DMG-rename path; the earlier two attempts died before reaching this check (the detach race fixed in #333, then the Windows sentry-cli path in #334), so this signing gap is only now exposed.

## Fix

```yaml
- name: Re-sign DMG after volume rename
  env:
    APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
  run: |
    DMG="${{ steps.artifacts.outputs.dmg }}"
    codesign --force --timestamp --sign "$APPLE_SIGNING_IDENTITY" "$DMG"
    codesign -vvv "$DMG"
```

- Runs **before** notarization, so the notarized + stapled DMG carries a valid signature.
- The signing identity is already in the keychain from the earlier "Import Apple Developer ID for pre-signing bundled CLIs" step.
- The inner `.app` keeps its own signature + notarization staple (`hdiutil convert` preserves DMG contents), so only the outer DMG container needed re-signing — the verify step's check #4 (`.app inside DMG`) was already passing.

## Validation

macOS-only signing step; can't run locally. Needs a release CI run on macOS to confirm. Windows (x64 + arm64) is already green on this tag.
