### PR TITLE
fix(chat): dedupe hydrated feed items

### DIFF
--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { useQueryClient } from "@tanstack/react-query";
 import { AIBoard } from "@houston-ai/board";
 import type { KanbanItem, NewPanelOpener } from "@houston-ai/board";
-import type { FeedItem } from "@houston-ai/chat";
+import { mergeFeedHistory, type FeedItem } from "@houston-ai/chat";
 import { Terminal, GitBranch } from "lucide-react";
 
 import { useFeedStore } from "../../stores/feeds";
@@ -239,17 +239,9 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
       // truth — live WS events append cleanly and no "liveFeed wins if
       // non-empty" hack is needed. Any items already in the bucket
       // from WS events that arrived between activity creation and
-      // selection are preserved by merging the server history with
-      // the current bucket and dropping exact duplicates by position.
+      // selection are preserved by the shared history merge.
       const current = useFeedStore.getState().items[path]?.[sessionKey] ?? [];
-      // Server history is authoritative for everything persisted up to
-      // load time. Anything currently in `current` that isn't in the
-      // server history must be either an optimistic overlay we pushed
-      // or an event that landed mid-load. Append those after the
-      // server slice.
-      const serverIds = new Set(items.map((it) => JSON.stringify(it)));
-      const tail = current.filter((it) => !serverIds.has(JSON.stringify(it)));
-      setFeed(path, sessionKey, [...items, ...tail]);
+      setFeed(path, sessionKey, mergeFeedHistory(items, current));
     },
     [path, setFeed],
   );

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type { KanbanItem } from "@houston-ai/board";
-import type { FeedItem } from "@houston-ai/chat";
+import { mergeFeedHistory, type FeedItem } from "@houston-ai/chat";
 import { useFeedStore } from "../stores/feeds";
 import {
   getSessionStatusKey,
@@ -141,13 +141,7 @@ export function useMissionControl(agents: Agent[]) {
       const agentPath = pathMapRef.current[activityId];
       if (!agentPath) return;
       const current = useFeedStore.getState().items[agentPath]?.[sessionKey] ?? [];
-      // Server history is authoritative for what's persisted; anything
-      // currently in `current` that isn't on the server is either an
-      // optimistic overlay we pushed or a WS event that landed
-      // mid-load. Append those after the server slice.
-      const serverIds = new Set(history.map((it) => JSON.stringify(it)));
-      const tail = current.filter((it) => !serverIds.has(JSON.stringify(it)));
-      setFeed(agentPath, sessionKey, [...history, ...tail]);
+      setFeed(agentPath, sessionKey, mergeFeedHistory(history, current));
     },
     [setFeed],
   );

--- a/app/tests/mission-board-columns.test.ts
+++ b/app/tests/mission-board-columns.test.ts
@@ -23,7 +23,7 @@ describe("mission board columns", () => {
       })),
       [
         { id: "running", label: "Running", statuses: ["running"] },
-        { id: "needs_you", label: "Needs you", statuses: ["needs_you"] },
+        { id: "needs_you", label: "Needs you", statuses: ["needs_you", "error"] },
         { id: "done", label: "Done", statuses: ["done", "cancelled"] },
       ],
     );

--- a/ui/chat/src/feed-merge.ts
+++ b/ui/chat/src/feed-merge.ts
@@ -16,27 +16,43 @@ export function mergeFeedItem(items: FeedItem[], item: FeedItem): FeedItem[] {
   const last = items[items.length - 1];
 
   if (item.feed_type === "thinking_streaming") {
-    return replaceLast(items, item, (existing) => existing.feed_type === "thinking_streaming");
+    if (hasEquivalentSinceLastUser(items, item)) return items;
+    return replaceLast(
+      items,
+      item,
+      (existing) => existing.feed_type === "thinking_streaming",
+    ) ?? [...items, item];
   }
 
   if (item.feed_type === "thinking") {
-    return replaceLast(items, item, (existing) => existing.feed_type === "thinking_streaming");
+    const next = replaceLast(
+      items,
+      item,
+      (existing) => existing.feed_type === "thinking_streaming",
+    );
+    if (next) return next;
+    if (hasEquivalentSinceLastUser(items, item)) return items;
+    return [...items, item];
   }
 
   if (item.feed_type === "assistant_text_streaming") {
+    if (hasEquivalentSinceLastUser(items, item)) return items;
     return replaceLast(
       items,
       item,
       (existing) => existing.feed_type === "assistant_text_streaming",
-    );
+    ) ?? [...items, item];
   }
 
   if (item.feed_type === "assistant_text") {
-    return replaceLast(
+    const next = replaceLast(
       items,
       item,
       (existing) => existing.feed_type === "assistant_text_streaming",
     );
+    if (next) return next;
+    if (hasEquivalentSinceLastUser(items, item)) return items;
+    return [...items, item];
   }
 
   // tool_call with real input replaces the immediate null-input notification
@@ -61,14 +77,40 @@ export function mergeFeedItem(items: FeedItem[], item: FeedItem): FeedItem[] {
     }
   }
 
+  if (item.feed_type !== "user_message" && hasExactSinceLastUser(items, item)) {
+    return items;
+  }
+
   return [...items, item];
+}
+
+/**
+ * Merge persisted history with the current in-memory feed.
+ *
+ * History is authoritative, but the current feed can hold optimistic user
+ * messages or live WS events that arrived while history was loading. Treat
+ * streaming/final assistant pairs with the same text as duplicates so a stale
+ * in-memory stream cannot render below its persisted final answer.
+ */
+export function mergeFeedHistory(history: FeedItem[], current: FeedItem[]): FeedItem[] {
+  const exactCounts = countBy(history, feedItemKey);
+  const finalCounts = countBy(history, finalEquivalentKey);
+  let merged = [...history];
+
+  for (const item of current) {
+    if (consumeCount(exactCounts, feedItemKey(item))) continue;
+    if (consumeCount(finalCounts, finalEquivalentKey(item))) continue;
+    merged = mergeFeedItem(merged, item);
+  }
+
+  return merged;
 }
 
 function replaceLast(
   items: FeedItem[],
   item: FeedItem,
   predicate: (item: FeedItem) => boolean,
-): FeedItem[] {
+): FeedItem[] | null {
   for (let index = items.length - 1; index >= 0; index -= 1) {
     if (predicate(items[index])) {
       return [
@@ -78,5 +120,65 @@ function replaceLast(
       ];
     }
   }
-  return [...items, item];
+  return null;
+}
+
+function hasExactSinceLastUser(items: FeedItem[], item: FeedItem): boolean {
+  const key = feedItemKey(item);
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const existing = items[index];
+    if (existing.feed_type === "user_message") return false;
+    if (feedItemKey(existing) === key) return true;
+  }
+  return false;
+}
+
+function hasEquivalentSinceLastUser(items: FeedItem[], item: FeedItem): boolean {
+  const key = finalEquivalentKey(item);
+  if (!key) return false;
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const existing = items[index];
+    if (existing.feed_type === "user_message") return false;
+    if (finalEquivalentKey(existing) === key) return true;
+  }
+  return false;
+}
+
+function feedItemKey(item: FeedItem): string {
+  return JSON.stringify(item);
+}
+
+function finalEquivalentKey(item: FeedItem): string | null {
+  switch (item.feed_type) {
+    case "assistant_text":
+    case "assistant_text_streaming":
+      return `assistant:${item.data}`;
+    case "thinking":
+    case "thinking_streaming":
+      return `thinking:${item.data}`;
+    default:
+      return null;
+  }
+}
+
+function countBy(
+  items: FeedItem[],
+  keyFor: (item: FeedItem) => string | null,
+): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const item of items) {
+    const key = keyFor(item);
+    if (!key) continue;
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function consumeCount(counts: Map<string, number>, key: string | null): boolean {
+  if (!key) return false;
+  const count = counts.get(key) ?? 0;
+  if (count <= 0) return false;
+  if (count === 1) counts.delete(key);
+  else counts.set(key, count - 1);
+  return true;
 }

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -214,7 +214,7 @@ export type { UserAttachmentMessageLabels } from "./user-attachment-message";
 
 // === Utilities ===
 export { Typewriter } from "./typewriter";
-export { mergeFeedItem } from "./feed-merge";
+export { mergeFeedItem, mergeFeedHistory } from "./feed-merge";
 export { ChannelAvatar } from "./channel-avatar";
 export type { ChannelSource } from "./channel-avatar";
 

--- a/ui/chat/tests/feed-merge.test.ts
+++ b/ui/chat/tests/feed-merge.test.ts
@@ -1,0 +1,82 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { mergeFeedHistory, mergeFeedItem } from "../src/feed-merge.ts";
+import type { FeedItem } from "../src/types.ts";
+
+const user = (text: string): FeedItem => ({ feed_type: "user_message", data: text });
+const assistant = (text: string): FeedItem => ({ feed_type: "assistant_text", data: text });
+const stream = (text: string): FeedItem => ({
+  feed_type: "assistant_text_streaming",
+  data: text,
+});
+const finalResult = (text: string): FeedItem => ({
+  feed_type: "final_result",
+  data: {
+    result: text,
+    cost_usd: null,
+    duration_ms: null,
+  },
+});
+
+describe("mergeFeedItem", () => {
+  it("replaces a streaming assistant item with the final item", () => {
+    const items = [user("ping?"), stream("Pong")];
+
+    deepStrictEqual(
+      mergeFeedItem(items, assistant("Pong. What can I help you with?")),
+      [user("ping?"), assistant("Pong. What can I help you with?")],
+    );
+  });
+
+  it("drops a duplicate final assistant item after final_result", () => {
+    const items = [
+      user("ping?"),
+      assistant("Pong. What can I help you with?"),
+      finalResult("Pong. What can I help you with?"),
+    ];
+
+    const next = mergeFeedItem(items, assistant("Pong. What can I help you with?"));
+
+    strictEqual(next, items);
+  });
+});
+
+describe("mergeFeedHistory", () => {
+  it("drops stale streaming text when history already has the final answer", () => {
+    const history = [
+      user("ping?"),
+      assistant("Pong. What can I help you with?"),
+      finalResult("Pong. What can I help you with?"),
+    ];
+    const current = [
+      user("ping?"),
+      stream("Pong. What can I help you with?"),
+    ];
+
+    deepStrictEqual(mergeFeedHistory(history, current), history);
+  });
+
+  it("keeps live tail items that are not in persisted history", () => {
+    const history = [
+      user("ping?"),
+      assistant("Pong. What can I help you with?"),
+      finalResult("Pong. What can I help you with?"),
+    ];
+    const current = [
+      user("ping?"),
+      assistant("Pong. What can I help you with?"),
+      finalResult("Pong. What can I help you with?"),
+      user("now say it shorter"),
+      stream("Pong."),
+    ];
+
+    deepStrictEqual(
+      mergeFeedHistory(history, current),
+      [
+        ...history,
+        user("now say it shorter"),
+        stream("Pong."),
+      ],
+    );
+  });
+});


### PR DESCRIPTION
Summary:
- Add shared feed-history merge that treats persisted final assistant/thinking items as equivalent to stale streaming copies.
- Use it in per-agent board and Mission Control hydration so notification navigation and agent switching do not show duplicate responses.
- Add regression coverage for stale streaming/final hydration and refresh stale mission-board column expectation.

Tests:
- pnpm typecheck
- pnpm check-locales (app)
- node --test app\tests\*.test.ts ui\chat\tests\*.test.ts

Closes #303