### PR TITLE
fix(i18n): localize agent-finished notification

### DIFF
--- a/app/src/hooks/use-session-events.ts
+++ b/app/src/hooks/use-session-events.ts
@@ -128,7 +128,14 @@ export function useSessionEvents() {
               logger.debug(`[notification] completed agent not in loaded list: agent_path=${agent_path}`);
             }
 
-            sendSessionNotification(`${workspaceName} — ${agentName}`, "Your agent has finished working.", nav);
+            sendSessionNotification(
+              h.t("common:notifications.sessionComplete.title", {
+                workspace: workspaceName,
+                agent: agentName,
+              }),
+              h.t("common:notifications.sessionComplete.body"),
+              nav,
+            );
           }
           break;
         }

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -35,5 +35,11 @@
     "description": "Choose the language Houston uses in its interface.",
     "label": "Interface language",
     "toastChanged": "Language changed"
+  },
+  "notifications": {
+    "sessionComplete": {
+      "title": "{{workspace}} · {{agent}}",
+      "body": "Your agent has finished working."
+    }
   }
 }

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -35,5 +35,11 @@
     "description": "Elige el idioma que Houston usa en su interfaz.",
     "label": "Idioma de la interfaz",
     "toastChanged": "Idioma cambiado"
+  },
+  "notifications": {
+    "sessionComplete": {
+      "title": "{{workspace}} · {{agent}}",
+      "body": "Tu agente terminó de trabajar."
+    }
   }
 }

--- a/app/src/locales/pt/common.json
+++ b/app/src/locales/pt/common.json
@@ -35,5 +35,11 @@
     "description": "Escolha o idioma que o Houston usa na interface.",
     "label": "Idioma da interface",
     "toastChanged": "Idioma alterado"
+  },
+  "notifications": {
+    "sessionComplete": {
+      "title": "{{workspace}} · {{agent}}",
+      "body": "Seu agente terminou de trabalhar."
+    }
   }
 }


### PR DESCRIPTION
## What

The session-completed OS notification (the "your agent finished working" toast) had its text hardcoded in English, so `es`/`pt` users saw English regardless of their interface language.

`app/src/hooks/use-session-events.ts` built the notification as:

```js
sendSessionNotification(`${workspaceName} — ${agentName}`, "Your agent has finished working.", nav);
```

Both the body and the title separator were literals.

## Changes

- **`app/src/hooks/use-session-events.ts`** — route the notification title and body through `t()` (`common:notifications.sessionComplete.{title,body}`), interpolating `workspace` + `agent`. `t` is read from `handlersRef.current` at event time, so a locale switch is reflected without re-subscribing.
- **`app/src/locales/{en,es,pt}/common.json`** — add the `notifications.sessionComplete` group with `title` + `body` for all three shipped locales.
- Dropped the em dash from the title separator (banned in user-facing copy by the i18n rule + `check-locales`) in favor of a middot `·`, keeping the `workspace · agent` format.

## Verification

- `pnpm check-locales` → all locales in sync (parity, placeholder, em-dash checks pass).
- `pnpm tsc --noEmit` → clean (the new key path type-resolves via the `react-i18next.d.ts` augmentation).

No new namespace, so no i18n wiring changes. No engine/Rust changes.

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)
