### PR TITLE
fix(rename): handle no-op and case-only agent/workspace renames

### DIFF
--- a/engine/houston-engine-core/src/agents_crud.rs
+++ b/engine/houston-engine-core/src/agents_crud.rs
@@ -9,7 +9,7 @@
 //! consume this module.
 
 use crate::error::{CoreError, CoreResult};
-use crate::paths::expand_tilde;
+use crate::paths::{expand_tilde, rename_path, same_fs_entity};
 use crate::workspaces;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
@@ -316,10 +316,21 @@ pub fn rename(root: &Path, workspace_id: &str, id: &str, new_name: &str) -> Core
     let old_folder = find_agent_by_id(&ws_dir, id)?;
     let new_link = ws_dir.join(new_name);
 
-    if new_link.exists() {
+    // A genuine conflict is a *different* agent already holding `new_name`.
+    // A case-only rename of the agent's own folder ("PERA" -> "PERa") resolves
+    // to the same entity on case-insensitive filesystems, so `new_link.exists()`
+    // is true even though there is no collision — allow it.
+    if new_link.exists() && !same_fs_entity(&old_folder, &new_link) {
         return Err(CoreError::Conflict(format!(
             "An agent named \"{new_name}\" already exists"
         )));
+    }
+
+    // Exact no-op (same path, same case): nothing to move. Defends the engine
+    // even when a client fires a rename with the unchanged name.
+    if old_folder == new_link {
+        let meta = read_agent_meta(&old_folder)?;
+        return Ok(meta_to_agent(&old_folder, &meta));
     }
 
     if old_folder.is_symlink() {
@@ -334,7 +345,7 @@ pub fn rename(root: &Path, workspace_id: &str, id: &str, new_name: &str) -> Core
         write_agent_meta(&new_link, &meta)?;
         Ok(meta_to_agent(&new_link, &meta))
     } else {
-        fs::rename(&old_folder, &new_link)?;
+        rename_path(&old_folder, &new_link)?;
         let meta = read_agent_meta(&new_link)?;
         Ok(meta_to_agent(&new_link, &meta))
     }
@@ -484,5 +495,72 @@ mod tests {
         assert_eq!(updated.color.as_deref(), Some("forest"));
         let all = list(d.path(), &ws_id).unwrap();
         assert_eq!(all[0].color.as_deref(), Some("forest"));
+    }
+
+    fn create_named(root: &Path, ws_id: &str, name: &str) -> Agent {
+        create(
+            root,
+            ws_id,
+            CreateAgent {
+                name: name.into(),
+                config_id: "blank".into(),
+                color: None,
+                claude_md: None,
+                installed_path: None,
+                seeds: None,
+                existing_path: None,
+            },
+        )
+        .unwrap()
+        .agent
+    }
+
+    /// Renaming to the unchanged name is a no-op, not a conflict. Guards #325 at
+    /// the engine level regardless of which client fires it. FS-independent.
+    #[test]
+    fn rename_to_same_name_is_noop() {
+        let d = TempDir::new().unwrap();
+        let ws_id = setup_ws(d.path());
+        let agent = create_named(d.path(), &ws_id, "PERA");
+
+        let renamed = rename(d.path(), &ws_id, &agent.id, "PERA").unwrap();
+
+        assert_eq!(renamed.id, agent.id);
+        assert_eq!(renamed.name, "PERA");
+        assert_eq!(list(d.path(), &ws_id).unwrap().len(), 1);
+    }
+
+    /// A case-only change ("PERA" -> "PERa") must succeed and leave exactly one
+    /// agent under the new spelling. On case-insensitive filesystems (Windows,
+    /// default macOS) this is the bug from PR #339's testing: the destination
+    /// resolves to the agent's own folder, so the old `new_link.exists()` guard
+    /// wrongly reported "already exists".
+    #[test]
+    fn rename_case_only_change() {
+        let d = TempDir::new().unwrap();
+        let ws_id = setup_ws(d.path());
+        let agent = create_named(d.path(), &ws_id, "PERA");
+
+        let renamed = rename(d.path(), &ws_id, &agent.id, "PERa").unwrap();
+
+        assert_eq!(renamed.id, agent.id);
+        assert_eq!(renamed.name, "PERa");
+        let all = list(d.path(), &ws_id).unwrap();
+        assert_eq!(all.len(), 1, "case-only rename must not duplicate the agent");
+        assert_eq!(all[0].name, "PERa");
+    }
+
+    /// Renaming onto a *different* agent's name is still a real conflict.
+    #[test]
+    fn rename_conflicts_with_other_agent() {
+        let d = TempDir::new().unwrap();
+        let ws_id = setup_ws(d.path());
+        create_named(d.path(), &ws_id, "PERA");
+        let zed = create_named(d.path(), &ws_id, "ZED");
+
+        let err = rename(d.path(), &ws_id, &zed.id, "PERA").unwrap_err();
+
+        assert!(matches!(err, CoreError::Conflict(_)));
+        assert_eq!(list(d.path(), &ws_id).unwrap().len(), 2);
     }
 }

--- a/engine/houston-engine-core/src/paths.rs
+++ b/engine/houston-engine-core/src/paths.rs
@@ -1,6 +1,9 @@
 //! Filesystem path resolution for the engine.
 
+use std::fs;
+use std::io;
 use std::path::{Path, PathBuf};
+use uuid::Uuid;
 
 /// Expand a leading `~` to the user's home directory. Mirrors the Tauri-side
 /// helper so REST callers can submit `~/Documents/Houston/...` paths verbatim.
@@ -14,6 +17,47 @@ pub fn expand_tilde(path: &Path) -> PathBuf {
         }
     }
     path.to_path_buf()
+}
+
+/// True when `a` and `b` resolve to the same filesystem entity.
+///
+/// Canonicalizing both sides collapses case differences on case-insensitive
+/// filesystems (Windows, default macOS) — where a case-only rename target like
+/// `PERa` already "exists" because it resolves to the existing `PERA` — and
+/// resolves symlinks to their target. On case-sensitive filesystems the two
+/// paths stay distinct, so genuine name collisions are still reported.
+///
+/// Falls back to a literal comparison when either path cannot be canonicalized
+/// (e.g. the destination does not exist yet, which is the common no-collision
+/// case).
+pub fn same_fs_entity(a: &Path, b: &Path) -> bool {
+    match (fs::canonicalize(a), fs::canonicalize(b)) {
+        (Ok(ca), Ok(cb)) => ca == cb,
+        _ => a == b,
+    }
+}
+
+/// Rename `from` to `to`, tolerating a case-only change on case-insensitive
+/// filesystems.
+///
+/// A direct `fs::rename("PERA", "PERa")` can be rejected on Windows because the
+/// destination resolves to the source, so the OS reports it as already
+/// existing. When `from` and `to` are the same entity spelled differently, hop
+/// through a unique temporary name in the destination's parent so the move
+/// always lands. Everything else is a plain `fs::rename`.
+pub fn rename_path(from: &Path, to: &Path) -> io::Result<()> {
+    if from == to {
+        return Ok(());
+    }
+    if same_fs_entity(from, to) {
+        let parent = to.parent().unwrap_or_else(|| Path::new("."));
+        let tmp = parent.join(format!(".houston-rename-{}", Uuid::new_v4()));
+        fs::rename(from, &tmp)?;
+        fs::rename(&tmp, to)?;
+        Ok(())
+    } else {
+        fs::rename(from, to)
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -40,5 +84,84 @@ impl EnginePaths {
     /// Installed-agent definitions: `<home>/agents`.
     pub fn agents_dir(&self) -> PathBuf {
         self.home_dir.join("agents")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn same_fs_entity_identical_path() {
+        let d = TempDir::new().unwrap();
+        let p = d.path().join("agent");
+        fs::create_dir(&p).unwrap();
+        assert!(same_fs_entity(&p, &p));
+    }
+
+    #[test]
+    fn same_fs_entity_distinct_dirs() {
+        let d = TempDir::new().unwrap();
+        let a = d.path().join("a");
+        let b = d.path().join("b");
+        fs::create_dir(&a).unwrap();
+        fs::create_dir(&b).unwrap();
+        assert!(!same_fs_entity(&a, &b));
+    }
+
+    #[test]
+    fn same_fs_entity_missing_destination_is_not_same() {
+        let d = TempDir::new().unwrap();
+        let a = d.path().join("a");
+        let b = d.path().join("b"); // never created
+        fs::create_dir(&a).unwrap();
+        assert!(!same_fs_entity(&a, &b));
+    }
+
+    #[test]
+    fn rename_path_plain_move() {
+        let d = TempDir::new().unwrap();
+        let from = d.path().join("alpha");
+        let to = d.path().join("beta");
+        fs::create_dir(&from).unwrap();
+        rename_path(&from, &to).unwrap();
+        assert!(to.exists());
+        let names: Vec<String> = fs::read_dir(d.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["beta".to_string()]);
+    }
+
+    /// Case-only rename must succeed on every filesystem and leave exactly one
+    /// directory under the new spelling — no leftover temp dir, no duplicate.
+    /// On case-insensitive filesystems this exercises the temp-hop path; on
+    /// case-sensitive ones it is a plain move. Both must converge to `case`.
+    #[test]
+    fn rename_path_case_only_change() {
+        let d = TempDir::new().unwrap();
+        let from = d.path().join("CASE");
+        let to = d.path().join("case");
+        fs::create_dir(&from).unwrap();
+        fs::write(from.join("marker"), "x").unwrap();
+
+        rename_path(&from, &to).unwrap();
+
+        let names: Vec<String> = fs::read_dir(d.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["case".to_string()]);
+        assert!(to.join("marker").exists(), "contents must survive the move");
+    }
+
+    #[test]
+    fn rename_path_identical_is_noop() {
+        let d = TempDir::new().unwrap();
+        let p = d.path().join("agent");
+        fs::create_dir(&p).unwrap();
+        rename_path(&p, &p).unwrap();
+        assert!(p.exists());
     }
 }

--- a/engine/houston-engine-core/src/workspaces/mod.rs
+++ b/engine/houston-engine-core/src/workspaces/mod.rs
@@ -12,6 +12,7 @@ pub use io::read_all;
 pub use migrate::migrate_workspace_provider_into_agents;
 
 use crate::error::{CoreError, CoreResult};
+use crate::paths::{rename_path, same_fs_entity};
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::Path;
@@ -97,14 +98,18 @@ pub fn rename(root: &Path, id: &str, req: RenameWorkspace) -> CoreResult<Workspa
         .ok_or_else(|| CoreError::NotFound(format!("workspace {id}")))?;
     let old_dir = root.join(&ws.name);
     let new_dir = root.join(&req.new_name);
-    if new_dir.exists() && old_dir != new_dir {
+    // Same entity = renaming the workspace's own folder (including a case-only
+    // change like "Acme" -> "ACME" on a case-insensitive filesystem, where
+    // `new_dir.exists()` is true because it resolves to `old_dir`). Only a
+    // *different* directory occupying `new_name` is a real conflict.
+    if new_dir.exists() && !same_fs_entity(&old_dir, &new_dir) {
         return Err(CoreError::Conflict(format!(
             "directory named {:?} already exists",
             req.new_name
         )));
     }
     if old_dir.exists() {
-        fs::rename(&old_dir, &new_dir)?;
+        rename_path(&old_dir, &new_dir)?;
     }
     ws.name = req.new_name;
     let updated = ws.clone();
@@ -173,6 +178,45 @@ mod tests {
         assert_eq!(renamed.name, "b");
         delete(d.path(), &ws.id).unwrap();
         assert!(list(d.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn rename_to_same_name_is_noop() {
+        let d = tmp();
+        let ws = create(d.path(), CreateWorkspace { name: "alpha".into() }).unwrap();
+        let renamed = rename(
+            d.path(),
+            &ws.id,
+            RenameWorkspace {
+                new_name: "alpha".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(renamed.name, "alpha");
+        assert_eq!(list(d.path()).unwrap().len(), 1);
+        assert!(d.path().join("alpha").is_dir());
+    }
+
+    /// Case-only workspace rename ("Acme" -> "ACME"). On case-insensitive
+    /// filesystems the new folder resolves to the old one, so the previous
+    /// `old_dir != new_dir` string compare reported a spurious conflict.
+    #[test]
+    fn rename_case_only_change() {
+        let d = tmp();
+        let ws = create(d.path(), CreateWorkspace { name: "Acme".into() }).unwrap();
+        let renamed = rename(
+            d.path(),
+            &ws.id,
+            RenameWorkspace {
+                new_name: "ACME".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(renamed.name, "ACME");
+        let all = list(d.path()).unwrap();
+        assert_eq!(all.len(), 1, "case-only rename must not duplicate workspace");
+        assert_eq!(all[0].name, "ACME");
+        assert!(d.path().join("ACME").is_dir());
     }
 
     /// Concurrent writers must not corrupt `workspaces.json`. Mirrors the

--- a/ui/layout/src/sidebar.tsx
+++ b/ui/layout/src/sidebar.tsx
@@ -91,7 +91,10 @@ export function AppSidebar({
 
   const commitRename = (id: string) => {
     const trimmed = editValue.trim();
-    if (trimmed && onRename) onRename(id, trimmed);
+    const originalName = items.find((it) => it.id === id)?.name;
+    if (trimmed && trimmed !== originalName && onRename) {
+      onRename(id, trimmed);
+    }
     setEditingId(null);
   };
 


### PR DESCRIPTION
## Problem

Two related bugs in agent / workspace rename:

1. **(#325)** Clicking **Rename** in the sidebar and clicking away without changing the name fired the rename with the unchanged value. The engine rejected it because a folder with that name already exists (the agent's own folder), so the user saw a spurious `An agent named X already exists` toast.

2. **(found while testing the fix above)** Renaming to a **case-only variant** — e.g. `PERA` → `PERa`, or workspace `Acme` → `ACME` — still failed with the same error on Windows and macOS. On case-insensitive filesystems the destination path resolves to the entity's own folder, so `new_link.exists()` was `true` even though there was no real collision. The guard in `workspaces::rename` (`old_dir != new_dir`, a case-sensitive string compare) had the identical flaw.

## Fix

**Sidebar** (`ui/layout/src/sidebar.tsx`) — only fire `onRename` when the trimmed value is non-empty and differs from the original name.

**Engine** (`engine/houston-engine-core`):
- New `paths::same_fs_entity(a, b)` — canonicalizes both paths so a case-only destination on a case-insensitive FS is recognized as the entity's own folder (and symlinks resolve to their target), while genuine collisions on case-sensitive filesystems are still reported.
- New `paths::rename_path(from, to)` — case-only-safe directory rename that hops through a unique temp name, so a case-only move is not rejected by Windows `MoveFileEx` (which sees the destination as already existing).
- `agents_crud::rename` and `workspaces::rename` now report a conflict only when a *different* entity occupies the name, short-circuit an exact no-op, and use `rename_path` for the move.

## Tests

`cargo test -p houston-engine-core` — same-name no-op, case-only change (no duplicate folder), and genuine conflict still rejected, for both agents and workspaces, plus unit tests for the `paths` helpers.

## Files
- `ui/layout/src/sidebar.tsx`
- `engine/houston-engine-core/src/paths.rs`
- `engine/houston-engine-core/src/agents_crud.rs`
- `engine/houston-engine-core/src/workspaces/mod.rs`

Closes #325

🤖 Generated with [Claude Code](https://claude.com/claude-code)