### PR TITLE
feat(providers): add Claude Opus 4.8 and pin explicit Claude model versions

### DIFF
--- a/app/src/components/mission-control-send.ts
+++ b/app/src/components/mission-control-send.ts
@@ -15,7 +15,11 @@
  * normalization is unit-testable and shared with whatever Mission Control's
  * future send paths grow into.
  */
-import { normalizeLegacyModel } from "../lib/providers";
+// Explicit `.ts` extension so this module is also resolvable when loaded
+// directly by `node --test --experimental-strip-types` (Node ESM requires
+// the extension for runtime-value imports). Vite/TSC accept it because
+// `allowImportingTsExtensions: true` is set in `app/tsconfig.json`.
+import { normalizeLegacyModel } from "../lib/providers.ts";
 
 /** Minimal shape needed for override resolution; mirrors `ActivityItem`. */
 export interface ActivityOverrideSource {

--- a/app/src/components/mission-control-send.ts
+++ b/app/src/components/mission-control-send.ts
@@ -1,0 +1,55 @@
+/**
+ * Pure activity-override resolution for a Mission Control follow-up send.
+ *
+ * Mission Control is cross-agent: an existing activity's stored provider+model
+ * is the per-activity override and is often different from the agent's default
+ * (e.g. agent default is GPT-5.5 but the activity was created with Opus). The
+ * engine's session router never reads activity records — it falls back to the
+ * agent's `config.json` when no override is passed. So the frontend must look
+ * up the activity and forward its provider+model on every send; otherwise the
+ * picker shows one model while the wire ships another, surfacing as a silent
+ * model swap when both CLIs are installed, or as `Failed to spawn <cli>:
+ * program not found` when they aren't.
+ *
+ * Kept pure (no React, no Tauri, no async) so the lookup + legacy-alias
+ * normalization is unit-testable and shared with whatever Mission Control's
+ * future send paths grow into.
+ */
+import { normalizeLegacyModel } from "../lib/providers";
+
+/** Minimal shape needed for override resolution; mirrors `ActivityItem`. */
+export interface ActivityOverrideSource {
+  id: string;
+  provider?: string;
+  model?: string;
+}
+
+/** Override pair passed to `tauriChat.send`. */
+export interface SendOverrides {
+  providerOverride?: string;
+  modelOverride?: string;
+}
+
+/**
+ * Look the activity up by the id encoded in `sessionKey` and project its
+ * stored provider/model as the engine override pair. Legacy CLI aliases
+ * (`"opus"`/`"sonnet"`) are normalized to their explicit version IDs so the
+ * frontend mirrors the engine's `migrate_config_model_aliases` map for any
+ * activity record that predates the version-pinning catalog.
+ *
+ * Returns an empty object when the activity is not found (e.g. it was deleted
+ * between render and send); the engine then falls back to the agent config,
+ * which is the only sane default with no override information available.
+ */
+export function resolveActivityOverride(
+  sessionKey: string,
+  activities: ActivityOverrideSource[] | undefined,
+): SendOverrides {
+  const activityId = sessionKey.replace(/^activity-/, "");
+  const activity = activities?.find((a) => a.id === activityId);
+  if (!activity) return {};
+  return {
+    providerOverride: activity.provider,
+    modelOverride: normalizeLegacyModel(activity.model ?? null) ?? undefined,
+  };
+}

--- a/app/src/components/onboarding/personal-assistant-onboarding.tsx
+++ b/app/src/components/onboarding/personal-assistant-onboarding.tsx
@@ -6,6 +6,7 @@ import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { useAgentStore } from "../../stores/agents";
 import { tauriProvider, tauriWorkspaces } from "../../lib/tauri";
+import { getDefaultModel } from "../../lib/providers";
 import type { Agent } from "../../lib/types";
 import { MissionFrame } from "./mission-frame";
 import { MeetMission } from "./missions/meet";
@@ -116,7 +117,7 @@ export function PersonalAssistantOnboarding({
     setTutorialActive(true);
     try {
       const fallbackProvider = provider ?? "anthropic";
-      const fallbackModel = model ?? "sonnet";
+      const fallbackModel = model ?? getDefaultModel(fallbackProvider);
       await createWorkspaceAndAssistant(fallbackProvider, fallbackModel);
       analytics.track("onboarding_completed", {
         mission: TUTORIAL_MISSION.id,
@@ -152,6 +153,12 @@ export function PersonalAssistantOnboarding({
     setUiTourActive(true);
     setTutorialActive(false);
   };
+
+  // Provider/model the back-half missions (Try, Routine) run against. The
+  // user picks these in the Brain mission; fall back to the platform default
+  // model for the chosen provider if a mission renders before a pick.
+  const missionProvider = provider ?? "anthropic";
+  const missionModel = model ?? getDefaultModel(missionProvider);
 
   return (
     <>
@@ -213,8 +220,8 @@ export function PersonalAssistantOnboarding({
           frame={frame}
           agent={agent}
           assistantColor={assistantColor}
-          provider={provider ?? "anthropic"}
-          model={model ?? "sonnet"}
+          provider={missionProvider}
+          model={missionModel}
           onSessionKey={setMissionSessionKey}
           onContinue={handleTryComplete}
           onSkip={finishOnboarding}
@@ -237,8 +244,8 @@ export function PersonalAssistantOnboarding({
           frame={frame}
           agent={agent}
           assistantColor={assistantColor}
-          provider={provider ?? "anthropic"}
-          model={model ?? "sonnet"}
+          provider={missionProvider}
+          model={missionModel}
           sessionKey={missionSessionKey}
           onContinue={handleRoutineComplete}
           onSkip={finishOnboarding}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -71,6 +71,7 @@ import {
   getDefaultModel,
   validModelOrNull,
   validEffortOrDefault,
+  normalizeLegacyModel,
   type EffortLevel,
 } from "../lib/providers";
 import { analytics } from "../lib/analytics";
@@ -158,8 +159,12 @@ export function useAgentChatPanel({
 
   // ── Activity / agent tier model resolution ─────────────────────────────
   // Activity is the per-mission override; agent config is the per-agent
-  // default. Workspace-level defaults were retired; existing values were
-  // migrated into agent configs at engine boot.
+  // default. Workspace-level defaults were retired and pushed into agent
+  // configs. Legacy Claude model aliases ("opus"/"sonnet") are normalized to
+  // their explicit version IDs on read (mirrors the engine migration) so a
+  // stored alias never falls through to the default model and silently
+  // downgrades an Opus agent to Sonnet — activity records in particular are
+  // never migrated on disk, so this read-side guard is what covers them.
   const [agentProvider, setAgentProvider] = useState<string | null>(null);
   const [agentModel, setAgentModel] = useState<string | null>(null);
   const [agentEffort, setAgentEffort] = useState<string | null>(null);
@@ -174,7 +179,7 @@ export function useAgentChatPanel({
       .read(path)
       .then((cfg) => {
         setAgentProvider((cfg.provider as string) ?? null);
-        setAgentModel((cfg.model as string) ?? null);
+        setAgentModel(normalizeLegacyModel((cfg.model as string) ?? null));
         setAgentEffort((cfg.effort as string) ?? null);
       })
       .catch(() => {});
@@ -188,7 +193,7 @@ export function useAgentChatPanel({
     ) ?? null;
   }, [activities, selectedSessionKey]);
   const activityProvider = selectedActivity?.provider ?? null;
-  const activityModel = selectedActivity?.model ?? null;
+  const activityModel = normalizeLegacyModel(selectedActivity?.model ?? null);
   const selectedActivityId = selectedActivity?.id ?? null;
 
   const effectiveProvider = activityProvider ?? agentProvider ?? "anthropic";

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -20,6 +20,7 @@ import {
 } from "../lib/tauri";
 import { buildAttachmentPrompt } from "../lib/attachment-message";
 import { createMission } from "../lib/create-mission";
+import { resolveActivityOverride } from "./mission-control-send";
 import { formatVisibleMessageText } from "../lib/queued-chat";
 import { queryKeys } from "../lib/query-keys";
 import { useUIStore } from "../stores/ui";
@@ -160,7 +161,17 @@ export function useMissionControl(agents: Agent[]) {
       try {
         const paths = await tauriAttachments.save(`activity-${activityId}`, files);
         const prompt = buildAttachmentPrompt(text, files, paths);
-        await tauriChat.send(agentPath, prompt, sessionKey);
+        // Mission Control is cross-agent: the activity's stored provider/model
+        // is the per-activity override that the chat picker is showing. The
+        // engine session router only reads agent config when no override is
+        // sent, so dropping the activity's choice here routes the message to
+        // whatever CLI the agent defaults to (e.g. agent=openai but activity
+        // was created with Opus -> spawns codex instead of claude). Look the
+        // activity up and forward its override pair to keep picker and wire
+        // in agreement.
+        const list = await tauriActivity.list(agentPath);
+        const overrides = resolveActivityOverride(sessionKey, list);
+        await tauriChat.send(agentPath, prompt, sessionKey, overrides);
         pushFeedItem(agentPath, sessionKey, { feed_type: "user_message", data: prompt });
         setLoading((prev) => ({ ...prev, [sessionKey]: true }));
       } catch (err) {

--- a/app/src/lib/providers.test.mjs
+++ b/app/src/lib/providers.test.mjs
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { getEffortLevels, validEffortOrDefault } from "./providers.ts";
+import {
+  getEffortLevels,
+  validEffortOrDefault,
+  validModelOrNull,
+  normalizeLegacyModel,
+} from "./providers.ts";
 
 test("effort levels are per model", () => {
   // Codex: has xhigh, no max.
@@ -67,4 +72,41 @@ test("validEffortOrDefault falls back to default when unset or garbage", () => {
 
 test("validEffortOrDefault is undefined for models without effort control", () => {
   assert.equal(validEffortOrDefault("gemini", "gemini-2.5-pro", "high"), undefined);
+});
+
+test("validModelOrNull rejects retired aliases and accepts catalog IDs", () => {
+  assert.equal(validModelOrNull("anthropic", "opus"), null);
+  assert.equal(validModelOrNull("anthropic", "sonnet"), null);
+  assert.equal(validModelOrNull("anthropic", "claude-opus-4-8"), "claude-opus-4-8");
+  assert.equal(validModelOrNull("anthropic", "claude-opus-4-7"), "claude-opus-4-7");
+  assert.equal(validModelOrNull("anthropic", "claude-sonnet-4-6"), "claude-sonnet-4-6");
+});
+
+test("normalizeLegacyModel maps retired aliases, passes everything else through", () => {
+  assert.equal(normalizeLegacyModel("opus"), "claude-opus-4-7");
+  assert.equal(normalizeLegacyModel("sonnet"), "claude-sonnet-4-6");
+  // Already-explicit IDs and other providers' models are untouched.
+  assert.equal(normalizeLegacyModel("claude-opus-4-8"), "claude-opus-4-8");
+  assert.equal(normalizeLegacyModel("gpt-5.5"), "gpt-5.5");
+  // null/undefined return null so it composes in `??` chains.
+  assert.equal(normalizeLegacyModel(null), null);
+  assert.equal(normalizeLegacyModel(undefined), null);
+  // Object-prototype keys are not aliases: a hand-edited config must pass
+  // through, never resolve to an Object.prototype member.
+  assert.equal(normalizeLegacyModel("constructor"), "constructor");
+  assert.equal(normalizeLegacyModel("__proto__"), "__proto__");
+  assert.equal(normalizeLegacyModel("toString"), "toString");
+});
+
+test("normalized legacy model resolves through validModelOrNull (no Opus->Sonnet downgrade)", () => {
+  // The chat panel normalizes a stored model before validModelOrNull: a legacy
+  // "opus" must resolve to Opus 4.7, never fall through to the Sonnet default.
+  assert.equal(
+    validModelOrNull("anthropic", normalizeLegacyModel("opus")),
+    "claude-opus-4-7",
+  );
+  assert.equal(
+    validModelOrNull("anthropic", normalizeLegacyModel("sonnet")),
+    "claude-sonnet-4-6",
+  );
 });

--- a/app/src/lib/providers.test.mjs
+++ b/app/src/lib/providers.test.mjs
@@ -11,14 +11,23 @@ test("effort levels are per model", () => {
     "xhigh",
   ]);
   // Sonnet 4.6: has max, no xhigh.
-  assert.deepEqual(getEffortLevels("anthropic", "sonnet"), [
+  assert.deepEqual(getEffortLevels("anthropic", "claude-sonnet-4-6"), [
     "low",
     "medium",
     "high",
     "max",
   ]);
   // Opus 4.7: full range.
-  assert.deepEqual(getEffortLevels("anthropic", "opus"), [
+  assert.deepEqual(getEffortLevels("anthropic", "claude-opus-4-7"), [
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+  ]);
+  // Opus 4.8: full range, identical to 4.7. `ultracode` is a Claude Code
+  // harness mode, not an effort level — it must never appear here.
+  assert.deepEqual(getEffortLevels("anthropic", "claude-opus-4-8"), [
     "low",
     "medium",
     "high",
@@ -31,23 +40,29 @@ test("effort levels empty for unknown / effort-less models", () => {
   assert.deepEqual(getEffortLevels("gemini", "gemini-2.5-pro"), []);
   assert.deepEqual(getEffortLevels(null, null), []);
   assert.deepEqual(getEffortLevels("anthropic", "no-such-model"), []);
+  // Legacy CLI aliases were retired in favor of explicit version IDs; the
+  // engine migrates stored configs (see houston-agent-files), so they are no
+  // longer catalog entries.
+  assert.deepEqual(getEffortLevels("anthropic", "opus"), []);
+  assert.deepEqual(getEffortLevels("anthropic", "sonnet"), []);
 });
 
 test("validEffortOrDefault keeps a value the model accepts", () => {
-  assert.equal(validEffortOrDefault("anthropic", "sonnet", "max"), "max");
+  assert.equal(validEffortOrDefault("anthropic", "claude-sonnet-4-6", "max"), "max");
   assert.equal(validEffortOrDefault("openai", "gpt-5.5", "xhigh"), "xhigh");
-  assert.equal(validEffortOrDefault("anthropic", "opus", "high"), "high");
+  assert.equal(validEffortOrDefault("anthropic", "claude-opus-4-7", "high"), "high");
+  assert.equal(validEffortOrDefault("anthropic", "claude-opus-4-8", "xhigh"), "xhigh");
 });
 
 test("validEffortOrDefault clamps a value the model rejects to the default", () => {
   // Sonnet has no xhigh; codex has no max — both fall back to medium.
-  assert.equal(validEffortOrDefault("anthropic", "sonnet", "xhigh"), "medium");
+  assert.equal(validEffortOrDefault("anthropic", "claude-sonnet-4-6", "xhigh"), "medium");
   assert.equal(validEffortOrDefault("openai", "gpt-5.5", "max"), "medium");
 });
 
 test("validEffortOrDefault falls back to default when unset or garbage", () => {
-  assert.equal(validEffortOrDefault("anthropic", "sonnet", null), "medium");
-  assert.equal(validEffortOrDefault("anthropic", "sonnet", "ultra"), "medium");
+  assert.equal(validEffortOrDefault("anthropic", "claude-sonnet-4-6", null), "medium");
+  assert.equal(validEffortOrDefault("anthropic", "claude-sonnet-4-6", "ultra"), "medium");
 });
 
 test("validEffortOrDefault is undefined for models without effort control", () => {

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -156,6 +156,36 @@ export function validModelOrNull(
   return providerId && modelId && getModel(providerId, modelId) ? modelId : null;
 }
 
+/**
+ * Retired Claude CLI aliases → the explicit catalog ID that replaced them.
+ * Mirrors the engine map in `houston-agent-files/src/lib.rs`
+ * (`LEGACY_MODEL_ALIASES`) — keep both in sync.
+ */
+const LEGACY_MODEL_ALIASES: Readonly<Record<string, string>> = {
+  opus: "claude-opus-4-7",
+  sonnet: "claude-sonnet-4-6",
+};
+
+/**
+ * Interpret a model value that may have been persisted by an older Houston
+ * build. The catalog pins explicit versions now, so a stored `"opus"`/`"sonnet"`
+ * (an agent config the engine has not migrated yet, or an activity record —
+ * those are never migrated) must be read as the version it denoted rather than
+ * treated as unknown. Without this, `validModelOrNull` would null a legacy
+ * `"opus"` and the effective-model chain would fall through to the default,
+ * silently downgrading an Opus agent to Sonnet. Already-explicit IDs and other
+ * providers' models pass through unchanged; null/undefined returns null so it
+ * composes in `??` chains.
+ */
+export function normalizeLegacyModel(model: string | null | undefined): string | null {
+  if (!model) return null;
+  // `hasOwnProperty` guard so a hand-edited config with a model like
+  // "constructor"/"__proto__" resolves to itself, not an Object.prototype member.
+  return Object.prototype.hasOwnProperty.call(LEGACY_MODEL_ALIASES, model)
+    ? LEGACY_MODEL_ALIASES[model]
+    : model;
+}
+
 /** Reasoning-effort levels the given provider+model accepts (low→high). */
 export function getEffortLevels(
   providerId: string | null | undefined,

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -2,8 +2,9 @@
  * Reasoning-effort levels, ordered low→high. The set a given model accepts
  * is model-specific (see `ModelOption.effortLevels`):
  * - Codex `model_reasoning_effort`: low/medium/high/xhigh (no `max`).
- * - Claude `--effort`: Opus 4.7 = all five; Sonnet 4.6 = low/medium/high/max
- *   (no `xhigh`). Claude self-clamps an unsupported value; Codex does not.
+ * - Claude `--effort`: Opus 4.7 and 4.8 = all five; Sonnet 4.6 =
+ *   low/medium/high/max (no `xhigh`). Claude self-clamps an unsupported
+ *   value; Codex does not.
  */
 export type EffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
 
@@ -87,21 +88,29 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     cost: "Your Claude subscription",
     models: [
       {
-        id: "sonnet",
-        label: "Sonnet",
+        id: "claude-sonnet-4-6",
+        label: "Sonnet 4.6",
         description: "Best balance of speed and quality.",
         // Sonnet 4.6: has `max`, no `xhigh`.
         effortLevels: ["low", "medium", "high", "max"],
       },
       {
-        id: "opus",
-        label: "Opus",
-        description: "Most capable. Slower, more tokens.",
+        id: "claude-opus-4-8",
+        label: "Opus 4.8",
+        description: "Newest flagship. Most capable, slower.",
+        // Opus 4.8: full range (same as 4.7). NOTE: `ultracode` is a Claude
+        // Code harness mode, NOT an effort level — never add it here.
+        effortLevels: ["low", "medium", "high", "xhigh", "max"],
+      },
+      {
+        id: "claude-opus-4-7",
+        label: "Opus 4.7",
+        description: "Previous flagship. Very capable, slower.",
         // Opus 4.7: full range.
         effortLevels: ["low", "medium", "high", "xhigh", "max"],
       },
     ],
-    defaultModel: "sonnet",
+    defaultModel: "claude-sonnet-4-6",
   },
 ] as const;
 
@@ -117,7 +126,7 @@ export function getModel(providerId: string, modelId: string): ModelOption | und
 
 /** Get the default provider + model for a provider id. */
 export function getDefaultModel(providerId: string): string {
-  return getProvider(providerId)?.defaultModel ?? "sonnet";
+  return getProvider(providerId)?.defaultModel ?? "claude-sonnet-4-6";
 }
 
 /**

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -32,6 +32,7 @@ import type {
 import { getEngine } from "./engine";
 import { osPickDirectory } from "./os-bridge";
 import { logger } from "./logger";
+import { normalizeLegacyModel } from "./providers";
 export { withAttachmentPaths } from "./attachment-message";
 
 interface EngineCallOptions {
@@ -687,6 +688,12 @@ export const tauriProvider = {
    * migration step. The companion model key is new (no upgrade path needed
    * because a missing value just falls back to the provider's
    * `defaultModel`).
+   *
+   * The stored model is normalized through `normalizeLegacyModel` on the way
+   * out: an install that last picked a model before the catalog pinned
+   * versions has a bare `"opus"`/`"sonnet"` in this preference, and creation
+   * dialogs seed a new agent's config from this value. Normalizing here means
+   * they never write a retired alias into a fresh config.
    */
   getLastUsed: () =>
     call<{ provider: string | null; model: string | null }>(
@@ -697,7 +704,7 @@ export const tauriProvider = {
           eng.getPreference(DEFAULT_PROVIDER_PREF_KEY),
           eng.getPreference(DEFAULT_MODEL_PREF_KEY),
         ]);
-        return { provider: provider ?? null, model: model ?? null };
+        return { provider: provider ?? null, model: normalizeLegacyModel(model) };
       },
     ),
   setLastUsed: (provider: string, model: string) =>

--- a/app/tests/mission-control-create.test.ts
+++ b/app/tests/mission-control-create.test.ts
@@ -30,7 +30,7 @@ describe("planNewMission (issue #328)", () => {
       activeAgent: agent,
       activeAgentDef: agentDefWithModes,
       providerOverride: "anthropic",
-      modelOverride: "sonnet",
+      modelOverride: "claude-sonnet-4-6",
     });
     deepStrictEqual(plan, {
       kind: "create",
@@ -38,7 +38,7 @@ describe("planNewMission (issue #328)", () => {
       agentMode: "default",
       promptFile: "default",
       providerOverride: "anthropic",
-      modelOverride: "sonnet",
+      modelOverride: "claude-sonnet-4-6",
     });
   });
 
@@ -64,7 +64,7 @@ describe("planNewMission (issue #328)", () => {
       activeAgent: null,
       activeAgentDef: null,
       providerOverride: "anthropic",
-      modelOverride: "sonnet",
+      modelOverride: "claude-sonnet-4-6",
     });
     deepStrictEqual(plan, { kind: "no-agent" });
   });

--- a/app/tests/mission-control-send.test.ts
+++ b/app/tests/mission-control-send.test.ts
@@ -1,0 +1,104 @@
+import { deepStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  resolveActivityOverride,
+  type ActivityOverrideSource,
+} from "../src/components/mission-control-send.ts";
+
+const opus47Activity: ActivityOverrideSource = {
+  id: "2792471e-1cca-4c75-addb-1259f3dd638b",
+  provider: "anthropic",
+  model: "claude-opus-4-7",
+};
+
+const legacyOpusActivity: ActivityOverrideSource = {
+  id: "abc",
+  provider: "anthropic",
+  model: "opus",
+};
+
+const legacySonnetActivity: ActivityOverrideSource = {
+  id: "def",
+  provider: "anthropic",
+  model: "sonnet",
+};
+
+const codexActivity: ActivityOverrideSource = {
+  id: "ghi",
+  provider: "openai",
+  model: "gpt-5.5",
+};
+
+describe("resolveActivityOverride (Mission Control send-path override drop fix)", () => {
+  it("returns the activity's provider+model when the activity is found", () => {
+    const overrides = resolveActivityOverride(
+      `activity-${opus47Activity.id}`,
+      [opus47Activity, codexActivity],
+    );
+    deepStrictEqual(overrides, {
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-7",
+    });
+  });
+
+  it("normalizes the legacy 'opus' alias to claude-opus-4-7", () => {
+    // Activity records created before catalog version-pinning hold bare
+    // aliases on disk and are NOT migrated by the engine (only config.json
+    // is). The frontend must normalize on read so the send doesn't ship
+    // "opus" to a CLI that no longer accepts it.
+    const overrides = resolveActivityOverride(`activity-${legacyOpusActivity.id}`, [
+      legacyOpusActivity,
+    ]);
+    deepStrictEqual(overrides, {
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-7",
+    });
+  });
+
+  it("normalizes the legacy 'sonnet' alias to claude-sonnet-4-6", () => {
+    const overrides = resolveActivityOverride(`activity-${legacySonnetActivity.id}`, [
+      legacySonnetActivity,
+    ]);
+    deepStrictEqual(overrides, {
+      providerOverride: "anthropic",
+      modelOverride: "claude-sonnet-4-6",
+    });
+  });
+
+  it("returns an empty object when the activity is not in the list", () => {
+    // Activity deleted between render and send, or sessionKey for a different
+    // agent's activity. Empty override lets the engine fall back to the agent
+    // config — the only safe default with no activity context.
+    deepStrictEqual(resolveActivityOverride("activity-missing", [opus47Activity]), {});
+  });
+
+  it("returns an empty object when the activities list is undefined", () => {
+    deepStrictEqual(resolveActivityOverride("activity-anything", undefined), {});
+  });
+
+  it("returns model=undefined (not null) when the activity has no model", () => {
+    // tauriChat.send opts type uses string | undefined; null would type-error.
+    const overrides = resolveActivityOverride("activity-x", [
+      { id: "x", provider: "anthropic" },
+    ]);
+    deepStrictEqual(overrides, {
+      providerOverride: "anthropic",
+      modelOverride: undefined,
+    });
+  });
+
+  it("treats the leading 'activity-' as a literal prefix only", () => {
+    // The activity id itself might start with characters that look like the
+    // prefix; the helper must only strip the FIRST occurrence at position 0.
+    const weird: ActivityOverrideSource = {
+      id: "activity-inside-id",
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+    };
+    const overrides = resolveActivityOverride(`activity-${weird.id}`, [weird]);
+    deepStrictEqual(overrides, {
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-8",
+    });
+  });
+});

--- a/engine/houston-agent-files/src/lib.rs
+++ b/engine/houston-agent-files/src/lib.rs
@@ -327,11 +327,25 @@ fn migrate_config_model_aliases(agent_root: &Path) -> Result<()> {
     }
 
     if changed {
+        // Downgrade safety net: save the pre-migration content as a sibling
+        // backup BEFORE the atomic overwrite. The catalog now pins explicit
+        // version IDs (claude-opus-4-7 / claude-sonnet-4-6), so a user who
+        // rolls back to an older Houston build that only knows the bare
+        // aliases can restore the original config with
+        // `mv config.json.pre-opus48 config.json`. Only the FIRST rewrite
+        // writes a backup; idempotent re-runs (or any later migration that
+        // touches the model field again) find the backup already present
+        // and leave the original pre-opus48 content intact, so the rollback
+        // target never drifts forward over time.
+        let backup_rel = ".houston/config/config.json.pre-opus48";
+        if !agent_root.join(backup_rel).exists() {
+            write_file_atomic(agent_root, backup_rel, &raw)?;
+        }
         let body = serde_json::to_string_pretty(&serde_json::Value::Object(obj))?;
         write_file_atomic(agent_root, rel, &body)?;
         tracing::info!(
             agent_root = %agent_root.display(),
-            "migrated legacy Claude model alias → explicit version id"
+            "migrated legacy Claude model alias → explicit version id (backup: config.json.pre-opus48)"
         );
     }
     Ok(())
@@ -451,6 +465,87 @@ mod tests {
         let raw =
             fs::read_to_string(dir.path().join(".houston/config/config.json")).unwrap();
         assert_eq!(raw, "not json at all");
+    }
+
+    // --- Pre-migration backup (downgrade safety net) ---
+
+    fn backup_path(agent_root: &Path) -> std::path::PathBuf {
+        agent_root.join(".houston/config/config.json.pre-opus48")
+    }
+
+    #[test]
+    fn first_alias_rewrite_writes_pre_opus48_backup_with_original_content() {
+        let dir = TempDir::new().unwrap();
+        let original = r#"{"provider":"anthropic","model":"opus","effort":"high"}"#;
+        write_config(dir.path(), original);
+
+        migrate_config_model_aliases(dir.path()).unwrap();
+
+        let backup = fs::read_to_string(backup_path(dir.path())).unwrap();
+        assert_eq!(backup, original);
+        // The live file is the rewritten one.
+        assert_eq!(read_config(dir.path())["model"], "claude-opus-4-7");
+    }
+
+    #[test]
+    fn second_run_preserves_the_original_backup() {
+        // Rollback target must NEVER drift forward. After the first rewrite, any
+        // subsequent migration that touches the model field again (idempotent
+        // re-run, or a later migration extending LEGACY_MODEL_ALIASES) must not
+        // overwrite the existing backup, or the user's path back to the pre-
+        // opus48 build is lost.
+        let dir = TempDir::new().unwrap();
+        let original = r#"{"model":"opus"}"#;
+        write_config(dir.path(), original);
+
+        migrate_config_model_aliases(dir.path()).unwrap();
+        let first_backup = fs::read_to_string(backup_path(dir.path())).unwrap();
+
+        // Simulate a later mutation that triggers another rewrite path: rewrite
+        // the live config back to a bare alias and re-run. The backup must
+        // still reflect the very first pre-migration content, not this newer
+        // intermediate state.
+        fs::write(
+            dir.path().join(".houston/config/config.json"),
+            r#"{"model":"sonnet"}"#,
+        )
+        .unwrap();
+        migrate_config_model_aliases(dir.path()).unwrap();
+
+        let second_backup = fs::read_to_string(backup_path(dir.path())).unwrap();
+        assert_eq!(second_backup, first_backup);
+        assert_eq!(second_backup, original);
+    }
+
+    #[test]
+    fn no_op_migration_does_not_create_backup() {
+        // No legacy alias present → nothing rewritten → backup must not appear
+        // (we only want backups for agents the migration actually touched).
+        let dir = TempDir::new().unwrap();
+        write_config(dir.path(), r#"{"model":"claude-opus-4-8"}"#);
+
+        migrate_config_model_aliases(dir.path()).unwrap();
+
+        assert!(!backup_path(dir.path()).exists());
+    }
+
+    #[test]
+    fn missing_or_non_object_config_does_not_create_backup() {
+        // Empty/missing/non-object configs bail before the rewrite branch, so
+        // they must NOT leave a backup turd behind.
+        let dir1 = TempDir::new().unwrap();
+        migrate_config_model_aliases(dir1.path()).unwrap();
+        assert!(!backup_path(dir1.path()).exists());
+
+        let dir2 = TempDir::new().unwrap();
+        write_config(dir2.path(), "");
+        migrate_config_model_aliases(dir2.path()).unwrap();
+        assert!(!backup_path(dir2.path()).exists());
+
+        let dir3 = TempDir::new().unwrap();
+        write_config(dir3.path(), "not json at all");
+        migrate_config_model_aliases(dir3.path()).unwrap();
+        assert!(!backup_path(dir3.path()).exists());
     }
 
     #[test]

--- a/engine/houston-agent-files/src/lib.rs
+++ b/engine/houston-agent-files/src/lib.rs
@@ -513,6 +513,72 @@ mod tests {
         assert_eq!(fs::read_to_string(&new).unwrap(), "[{\"id\":\"a\"}]");
     }
 
+    // --- Full upgrade-path coverage through migrate_agent_data ---
+    // The alias unit tests above call migrate_config_model_aliases directly on a
+    // pre-seeded FOLDER config. These drive the REAL upgrade sequence a user
+    // hits: a legacy FLAT `.houston/config.json` that the layout step copies to
+    // the per-type folder, which the alias rewrite then runs against. This also
+    // pins the load-bearing ordering (layout copy BEFORE alias rewrite).
+
+    fn write_flat_config(agent_root: &Path, body: &str) {
+        let flat = agent_root.join(".houston/config.json");
+        fs::create_dir_all(flat.parent().unwrap()).unwrap();
+        fs::write(&flat, body).unwrap();
+    }
+
+    #[test]
+    fn migrate_agent_data_rewrites_alias_via_flat_to_folder_and_preserves_siblings() {
+        let dir = TempDir::new().unwrap();
+        write_flat_config(
+            dir.path(),
+            r#"{"provider":"anthropic","model":"opus","effort":"high","worktreeMode":true}"#,
+        );
+
+        migrate_agent_data(dir.path()).unwrap();
+
+        let cfg = read_config(dir.path());
+        assert_eq!(cfg["model"], "claude-opus-4-7");
+        assert_eq!(cfg["provider"], "anthropic");
+        assert_eq!(cfg["effort"], "high");
+        // An unknown sibling key survives the raw-Object rewrite.
+        assert_eq!(cfg["worktreeMode"], true);
+    }
+
+    #[test]
+    fn migrate_agent_data_leaves_stale_flat_config_untouched() {
+        // The flat file is a deliberate rollback safety net; no step rewrites it.
+        let dir = TempDir::new().unwrap();
+        write_flat_config(dir.path(), r#"{"model":"opus"}"#);
+
+        migrate_agent_data(dir.path()).unwrap();
+
+        let flat = fs::read_to_string(dir.path().join(".houston/config.json")).unwrap();
+        assert!(flat.contains("opus"), "flat config must stay as a rollback net: {flat}");
+    }
+
+    #[test]
+    fn migrate_agent_data_rewrites_both_keys_via_full_path() {
+        let dir = TempDir::new().unwrap();
+        write_flat_config(dir.path(), r#"{"model":"opus","claude_model":"sonnet"}"#);
+
+        migrate_agent_data(dir.path()).unwrap();
+
+        let cfg = read_config(dir.path());
+        assert_eq!(cfg["model"], "claude-opus-4-7");
+        assert_eq!(cfg["claude_model"], "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn migrate_agent_data_is_idempotent_on_config_alias() {
+        let dir = TempDir::new().unwrap();
+        write_flat_config(dir.path(), r#"{"model":"opus"}"#);
+
+        migrate_agent_data(dir.path()).unwrap();
+        migrate_agent_data(dir.path()).unwrap();
+
+        assert_eq!(read_config(dir.path())["model"], "claude-opus-4-7");
+    }
+
     #[test]
     fn migrate_removes_legacy_product_prompts() {
         let dir = TempDir::new().unwrap();

--- a/engine/houston-agent-files/src/lib.rs
+++ b/engine/houston-agent-files/src/lib.rs
@@ -169,6 +169,13 @@ pub fn migrate_agent_data(agent_root: &Path) -> Result<()> {
         }
     }
 
+    // Rewrite legacy Claude model aliases (`opus`/`sonnet`) stored in the
+    // per-agent config to explicit version IDs, now that the model catalog
+    // pins versions (see `app/src/lib/providers.ts`). Runs after the layout
+    // migration above so the config has reached its
+    // `.houston/config/config.json` home.
+    migrate_config_model_aliases(agent_root)?;
+
     // learnings.md → learnings.json (parse markdown bullet list into JSON objects).
     let learnings_md = agent_root.join(".houston/memory/learnings.md");
     let learnings_new = agent_root.join(".houston/learnings/learnings.json");
@@ -267,6 +274,69 @@ pub fn migrate_agent_data(agent_root: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Legacy Claude model aliases → explicit version IDs.
+///
+/// Houston used to store the Claude CLI shorthand (`"opus"`, `"sonnet"`) as an
+/// agent's model. The shorthand resolves to *whatever the CLI calls latest*, so
+/// it can't distinguish Opus 4.7 from 4.8 once both ship. The model catalog
+/// (`app/src/lib/providers.ts`) now pins explicit version IDs, so each alias is
+/// rewritten to the version it denoted at the time of the switch. Mapping
+/// `"opus"` → 4.7 is deliberate: it preserves the exact model existing users
+/// were implicitly running rather than silently bumping them to the new
+/// flagship (they can opt into 4.8 from the picker).
+const LEGACY_MODEL_ALIASES: &[(&str, &str)] = &[
+    ("opus", "claude-opus-4-7"),
+    ("sonnet", "claude-sonnet-4-6"),
+];
+
+/// Rewrite a legacy Claude model alias in `.houston/config/config.json` to its
+/// explicit version ID. Idempotent: explicit IDs and unknown values pass
+/// through untouched, and a missing / empty / non-object config is a no-op so
+/// hand-edited or foreign-format files are never clobbered.
+///
+/// The model has historically lived under `"model"` (current) or
+/// `"claude_model"` (pre-multi-provider, still read via a serde alias), so both
+/// keys are normalized in place.
+fn migrate_config_model_aliases(agent_root: &Path) -> Result<()> {
+    let rel = ".houston/config/config.json";
+    let path = agent_root.join(rel);
+    let Ok(raw) = fs::read_to_string(&path) else {
+        return Ok(()); // no per-agent config — nothing to rewrite
+    };
+    if raw.trim().is_empty() {
+        return Ok(());
+    }
+    let Ok(serde_json::Value::Object(mut obj)) = serde_json::from_str::<serde_json::Value>(&raw)
+    else {
+        return Ok(()); // not a JSON object — leave it untouched
+    };
+
+    let mut changed = false;
+    for key in ["model", "claude_model"] {
+        let replacement = match obj.get(key) {
+            Some(serde_json::Value::String(current)) => LEGACY_MODEL_ALIASES
+                .iter()
+                .find(|(alias, _)| *alias == current.as_str())
+                .map(|(_, repl)| (*repl).to_string()),
+            _ => None,
+        };
+        if let Some(repl) = replacement {
+            obj.insert(key.to_string(), serde_json::Value::String(repl));
+            changed = true;
+        }
+    }
+
+    if changed {
+        let body = serde_json::to_string_pretty(&serde_json::Value::Object(obj))?;
+        write_file_atomic(agent_root, rel, &body)?;
+        tracing::info!(
+            agent_root = %agent_root.display(),
+            "migrated legacy Claude model alias → explicit version id"
+        );
+    }
+    Ok(())
+}
+
 /// Outcome of [`link_or_copy_role_file`]: which path the OS accepted.
 /// Reported back to the caller so it can log the right line — copies
 /// drift if `CLAUDE.md` is edited later, symlinks don't.
@@ -303,6 +373,85 @@ fn link_or_copy_role_file(target_path: &Path, link_path: &Path) -> std::io::Resu
 mod tests {
     use super::*;
     use tempfile::TempDir;
+
+    fn write_config(agent_root: &Path, body: &str) {
+        let dir = agent_root.join(".houston/config");
+        fs::create_dir_all(&dir).unwrap();
+        fs::write(dir.join("config.json"), body).unwrap();
+    }
+
+    fn read_config(agent_root: &Path) -> serde_json::Value {
+        let raw = fs::read_to_string(agent_root.join(".houston/config/config.json")).unwrap();
+        serde_json::from_str(&raw).unwrap()
+    }
+
+    #[test]
+    fn migrates_opus_alias_to_4_7_and_preserves_siblings() {
+        let dir = TempDir::new().unwrap();
+        write_config(
+            dir.path(),
+            r#"{"provider":"anthropic","model":"opus","effort":"high"}"#,
+        );
+        migrate_config_model_aliases(dir.path()).unwrap();
+        let cfg = read_config(dir.path());
+        assert_eq!(cfg["model"], "claude-opus-4-7");
+        assert_eq!(cfg["provider"], "anthropic");
+        assert_eq!(cfg["effort"], "high");
+    }
+
+    #[test]
+    fn migrates_sonnet_alias_to_4_6() {
+        let dir = TempDir::new().unwrap();
+        write_config(dir.path(), r#"{"model":"sonnet"}"#);
+        migrate_config_model_aliases(dir.path()).unwrap();
+        assert_eq!(read_config(dir.path())["model"], "claude-sonnet-4-6");
+    }
+
+    #[test]
+    fn migrates_legacy_claude_model_key() {
+        let dir = TempDir::new().unwrap();
+        write_config(dir.path(), r#"{"claude_model":"opus"}"#);
+        migrate_config_model_aliases(dir.path()).unwrap();
+        assert_eq!(read_config(dir.path())["claude_model"], "claude-opus-4-7");
+    }
+
+    #[test]
+    fn leaves_explicit_ids_and_unknown_values_untouched() {
+        let dir = TempDir::new().unwrap();
+        write_config(dir.path(), r#"{"model":"claude-opus-4-8"}"#);
+        migrate_config_model_aliases(dir.path()).unwrap();
+        assert_eq!(read_config(dir.path())["model"], "claude-opus-4-8");
+
+        let dir2 = TempDir::new().unwrap();
+        write_config(dir2.path(), r#"{"provider":"openai","model":"gpt-5.5"}"#);
+        migrate_config_model_aliases(dir2.path()).unwrap();
+        assert_eq!(read_config(dir2.path())["model"], "gpt-5.5");
+    }
+
+    #[test]
+    fn migration_is_idempotent_and_noop_without_config() {
+        // No config file at all — must not error or create one.
+        let dir = TempDir::new().unwrap();
+        migrate_config_model_aliases(dir.path()).unwrap();
+        assert!(!dir.path().join(".houston/config/config.json").exists());
+
+        // Running twice over an alias config is stable.
+        let dir2 = TempDir::new().unwrap();
+        write_config(dir2.path(), r#"{"model":"opus"}"#);
+        migrate_config_model_aliases(dir2.path()).unwrap();
+        migrate_config_model_aliases(dir2.path()).unwrap();
+        assert_eq!(read_config(dir2.path())["model"], "claude-opus-4-7");
+    }
+
+    #[test]
+    fn migration_does_not_clobber_non_object_config() {
+        let dir = TempDir::new().unwrap();
+        write_config(dir.path(), "not json at all");
+        migrate_config_model_aliases(dir.path()).unwrap();
+        let raw =
+            fs::read_to_string(dir.path().join(".houston/config/config.json")).unwrap();
+        assert_eq!(raw, "not json at all");
+    }
 
     #[test]
     fn rejects_parent_dir() {

--- a/engine/houston-engine-core/src/sessions/provider.rs
+++ b/engine/houston-engine-core/src/sessions/provider.rs
@@ -162,6 +162,23 @@ mod tests {
         assert_eq!(r.model.as_deref(), Some("sonnet"));
     }
 
+    #[test]
+    fn reads_folder_config_not_stale_flat() {
+        // After the per-type-folder migration the authoritative model lives in
+        // `.houston/config/config.json`. A stale legacy FLAT `.houston/config.json`
+        // left behind as a rollback net (still holding the pre-migration alias)
+        // must never be read, so the migrated explicit ID always wins.
+        let d = TempDir::new().unwrap();
+        let agent = d.path().join("ws").join("agent");
+        write_json(&agent.join(".houston/config.json"), r#"{"model":"opus"}"#);
+        write_json(
+            &agent.join(".houston/config/config.json"),
+            r#"{"model":"claude-opus-4-7"}"#,
+        );
+        let r = resolve_provider(&agent);
+        assert_eq!(r.model.as_deref(), Some("claude-opus-4-7"));
+    }
+
     fn agent_with(body: &str) -> (TempDir, std::path::PathBuf) {
         let d = TempDir::new().unwrap();
         let agent = d.path().join("ws").join("agent");

--- a/engine/houston-terminal-manager/src/provider/anthropic.rs
+++ b/engine/houston-terminal-manager/src/provider/anthropic.rs
@@ -56,7 +56,7 @@ impl ProviderAdapter for AnthropicAdapter {
 
     fn effort_levels(&self) -> &'static [&'static str] {
         // `claude --effort` accepts low/medium/high/xhigh/max. The model
-        // gates which are *honored* (Opus 4.7 = all; Sonnet 4.6 = no
+        // gates which are *honored* (Opus 4.7/4.8 = all; Sonnet 4.6 = no
         // `xhigh`), but Claude self-clamps an unsupported value to its
         // highest, so the engine carries the full union and lets the
         // frontend picker present the per-model subset.

--- a/engine/houston-terminal-manager/src/provider/mod.rs
+++ b/engine/houston-terminal-manager/src/provider/mod.rs
@@ -462,7 +462,7 @@ mod tests {
         let openai = Provider::from_str("openai").unwrap();
         let gemini = Provider::from_str("gemini").unwrap();
 
-        // Claude `--effort` accepts the full range (Opus 4.7); Claude
+        // Claude `--effort` accepts the full range (Opus 4.7/4.8); Claude
         // self-clamps unsupported values per model.
         assert_eq!(
             anthropic.effort_levels().to_vec(),

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -219,7 +219,7 @@ adapter, see `knowledge-base/architecture.md`).
 
 | Provider id | CLI | Default model | Premium model | Login flow |
 |---|---|---|---|---|
-| `anthropic` (alias `claude`) | `claude` (runtime download) | `claude-sonnet-4-5` | `claude-opus-4-1` | OAuth via `claude auth login --claudeai` |
+| `anthropic` (alias `claude`) | `claude` (runtime download) | `claude-sonnet-4-6` | `claude-opus-4-8` | OAuth via `claude auth login --claudeai` |
 | `openai` (alias `codex`) | `codex` (bundled) | `gpt-5` | `gpt-5-codex` | OAuth via `codex login` |
 | `gemini` (alias `google`) | `gemini` (bundled, macOS only) | `gemini-2.5-flash` | `gemini-2.5-pro` | API key, no CLI login (see `knowledge-base/auth.md`) |
 
@@ -253,8 +253,9 @@ shows only the levels the active model accepts.
 
 | Provider | Model | Effort levels offered | CLI flag |
 |---|---|---|---|
-| `anthropic` | `opus` (Opus 4.7) | low, medium, high, xhigh, max | `--effort <v>` |
-| `anthropic` | `sonnet` (Sonnet 4.6) | low, medium, high, max (no `xhigh`) | `--effort <v>` |
+| `anthropic` | `claude-opus-4-8` (Opus 4.8) | low, medium, high, xhigh, max | `--effort <v>` |
+| `anthropic` | `claude-opus-4-7` (Opus 4.7) | low, medium, high, xhigh, max | `--effort <v>` |
+| `anthropic` | `claude-sonnet-4-6` (Sonnet 4.6) | low, medium, high, max (no `xhigh`) | `--effort <v>` |
 | `openai` | `gpt-5.5` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
 | `gemini` | any | none | (no flag) |
 


### PR DESCRIPTION
Closes #343 

## What

Adds **Claude Opus 4.8** (`claude-opus-4-8`, released 2026-05-28) and pins explicit, version-pinned IDs for every Claude model, so the model picker shows **Sonnet 4.6**, **Opus 4.7**, and the new **Opus 4.8** instead of just "Sonnet"/"Opus".

Houston previously stored the bare Claude CLI aliases `"opus"`/`"sonnet"`, which resolve to whatever the CLI calls "latest" — so 4.7 and 4.8 could not be offered as distinct, selectable models.

## Changes

**Frontend (`app/`)**
- `app/src/lib/providers.ts` — Anthropic catalog now lists `claude-sonnet-4-6` ("Sonnet 4.6"), `claude-opus-4-8` ("Opus 4.8"), and `claude-opus-4-7` ("Opus 4.7"). Default stays Sonnet 4.6; `getDefaultModel` fallback updated.
- `app/src/components/onboarding/personal-assistant-onboarding.tsx` — Try/Routine/skip fallbacks use `getDefaultModel()` instead of a bare `"sonnet"`.

**Engine (`engine/`)**
- `houston-agent-files/src/lib.rs` — `migrate_agent_data` gains an idempotent step that rewrites legacy aliases stored in `.houston/config/config.json`: `opus -> claude-opus-4-7`, `sonnet -> claude-sonnet-4-6` (also normalizes the legacy `claude_model` key). Missing/empty/non-object configs are a no-op. Runs on app boot and every session start, so existing agents keep their exact model with no user action.
- `houston-terminal-manager` adapter + test comment accuracy.

**Effort levels** — Opus 4.8 keeps the standard five (`low/medium/high/xhigh/max`), identical to 4.7. `ultracode` is a Claude Code **harness mode**, not a model effort level, and is deliberately excluded (the `EffortLevel` union is untouched).

**i18n** — none. Model names are brand identifiers rendered from the catalog `label` (like "GPT-5.5"), per the i18n KB ("brand names do not translate"), so no locale strings change. `check-locales` still runs as a guard.

## Decisions
- Legacy `"opus"` migrates to **4.7** (preserve the exact model users were implicitly running) rather than auto-bumping to 4.8; users opt into 4.8 from the picker.
- All Claude models versioned (not just Opus) for a consistent catalog shape.
- Engine passthrough/round-trip tests intentionally keep arbitrary `"opus"/"sonnet"` strings — they verify model-agnostic handling, not catalog membership.

## Tests
Added 6 unit tests for the alias migration (`houston-agent-files`) and Opus 4.8 / explicit-id / retired-alias cases in `providers.test.mjs`.

Suggested checks:
- `cd app && pnpm tsc --noEmit && pnpm check-locales`
- `cargo test -p houston-agent-files`
- `cargo test --workspace`

🤖 Generated with [Claude Code](https://claude.com/claude-code)