### PR TITLE
docs(vite): clarify sentry sourcemap release matching

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -50,8 +50,12 @@ export default defineConfig(({ mode }) => {
     build: {
       // "hidden" emits .map files next to bundled JS but skips the
       // //# sourceMappingURL= comment, so production users can't reconstruct
-      // source via DevTools. release.yml uploads the maps to Sentry, which
-      // matches them to events by filename + content hash for symbolication.
+      // source via DevTools. The release.yml CI step uploads these maps to
+      // Sentry tagged `houston-app@<version>` (the same release reported at
+      // runtime by sentry::release_name!() in lib.rs and the JS RELEASE in
+      // lib/sentry.ts); Sentry resolves frames to source by release + file
+      // path. Maps are uploaded ONLY by that CI release step — local builds
+      // emit maps but never upload them.
       sourcemap: "hidden",
     },
     clearScreen: false,


### PR DESCRIPTION
## Summary
- Replaces inaccurate comment in `app/vite.config.ts` near `build.sourcemap: "hidden"`.
- Old comment claimed Sentry matched maps to events by filename + content hash. Actual mechanism: maps are tagged `houston-app@<version>` by `release.yml` and resolved by release + file path, matching the runtime release reported by `sentry::release_name!()` (lib.rs) and the JS `RELEASE` constant (lib/sentry.ts).
- Also clarifies that maps are uploaded only by the CI release step, never by local builds.

## Test plan
- [x] Comment-only change in `app/vite.config.ts`; no runtime behavior touched.
- [x] No source-map config keys changed (`sourcemap: "hidden"` unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)