### PR TITLE
fix(ci): upload JS source maps from Windows release jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1019,13 +1019,16 @@ jobs:
       # Sentry upload (Windows): Rust debug symbols for the matrix-arch
       # houston-engine.exe + its .pdb (MSVC emits PDBs alongside the binary
        # in release mode with debug = "line-tables-only" in workspace Cargo).
-      # Source maps are uploaded once by the macOS job — same JS bundle ships
-      # to both platforms, so we don't duplicate the upload here.
+      # Source maps are uploaded per-arch (NOT once from the macOS job): Vite
+      # content-hashes the bundle on every build, so the Windows x64 / arm64 /
+      # macOS bundles ship distinct filenames (e.g. index-<hash>.js). Uploading
+      # only from macOS left every Windows JS frame unmatchable; each arch must
+      # upload its own app/dist to the shared release.
       #
       # x86_64 + aarch64 each run this in parallel via the matrix; both
       # contribute their debug symbols to the same `houston-app@<version>`
       # release. Skips silently when SENTRY_AUTH_TOKEN is unset.
-      - name: Upload Rust debug symbols to Sentry (${{ matrix.arch }})
+      - name: Upload source maps + Rust debug symbols to Sentry (${{ matrix.arch }})
         if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
         shell: bash
         env:
@@ -1055,6 +1058,15 @@ jobs:
             exit 1
           fi
           "$SENTRY_CLI" --version
+
+          echo "=== Inject + upload ${{ matrix.target }} Vite source maps ==="
+          # This arch's bundle carries its own Vite content-hashes, so its maps
+          # must be uploaded under the shared release or Windows JS frames stay
+          # minified in Sentry. `releases new` is idempotent and guards the
+          # parallel race with the macOS job, which also creates this release.
+          "$SENTRY_CLI" releases new "$RELEASE"
+          "$SENTRY_CLI" sourcemaps inject app/dist
+          "$SENTRY_CLI" sourcemaps upload --release "$RELEASE" app/dist
 
           echo "=== Upload ${{ matrix.target }} debug symbols ==="
           # MSVC emits the PDB next to the .exe; Rust converts the binary's


### PR DESCRIPTION
## Problem

Windows users' JS stack traces never symbolicate in Sentry — they arrive as minified soup. The Windows release jobs upload only Rust `.pdb` debug symbols; JS source maps are uploaded **only** by the macOS job, on the assumption (stated in the old comment) that "the same JS bundle ships to both platforms."

That assumption is false. Vite content-hashes the bundle on every build, so each platform/arch ships **distinct** filenames. From the `v0.4.14` release logs:

- Windows **x64**: `assets/index-BxLaTYo9.js`
- Windows **arm64**: `assets/index-gI8aakjG.js`
- macOS: a third hash (the only one whose maps were uploaded)

Sentry matches JS frames to maps by filename/path (and debug id where present). With only the macOS-hashed maps uploaded, every Windows JS frame is unmatchable.

## Fix

Mirror the macOS sourcemaps step into the per-arch Windows Sentry job:

```bash
sentry-cli releases new "$RELEASE"            # idempotent; guards the parallel race with macOS
sentry-cli sourcemaps inject app/dist
sentry-cli sourcemaps upload --release "$RELEASE" app/dist
```

Each arch uploads its own bundle's maps to the shared `houston-app@<version>` release (additive). No `@sentry/vite-plugin`, so no exposure to getsentry/sentry-javascript#916 (silent capture-drop with `tauri-plugin-sentry` on `@sentry/browser` v10).

## Files

- `.github/workflows/release.yml` — Windows Sentry step now uploads source maps in addition to Rust debug symbols; corrected the stale "same JS bundle" comment.

## Verification

After merge, cut a release and confirm a Windows JS error resolves to real `file:line` under `houston-app@<version>`. Already-collected `v0.4.14` Windows events can be recovered separately by rebuilding `v0.4.14` on Windows and uploading those maps under the same release (works if the bundle hash reproduces).

## Follow-up (out of scope)

`sentry-cli sourcemaps inject` runs *after* tauri-action packages the bundle, so debug ids don't ship in the app and matching relies on the legacy release+path mechanism (same as macOS today). Moving `inject` before packaging would make matching debug-id-based and more robust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Closes #354
