### PR TITLE
fix(providers): cache + reactive provider status in model picker (#342)

### DIFF
--- a/app/src/components/chat-model-selector-parts.tsx
+++ b/app/src/components/chat-model-selector-parts.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenuSeparator,
 } from "@houston-ai/core";
 import { type ProviderInfo } from "../lib/providers";
+import { type ProviderPickerState } from "../lib/model-picker";
 import { ClaudeLogo, OpenAILogo } from "./shell/provider-logos";
 
 /**
@@ -16,27 +17,31 @@ import { ClaudeLogo, OpenAILogo } from "./shell/provider-logos";
 
 export function ProviderModelGroup({
   provider,
-  connected,
+  state,
   isActiveProvider,
   activeModel,
   onSelect,
   showSeparator,
 }: {
   provider: ProviderInfo;
-  connected: boolean;
+  state: ProviderPickerState;
   isActiveProvider: boolean;
   activeModel: string | null;
   onSelect: (provider: string, model: string) => void;
   showSeparator: boolean;
 }) {
   const { t } = useTranslation("chat");
+  const connected = state === "connected";
   return (
     <>
       {showSeparator && <DropdownMenuSeparator />}
       <DropdownMenuLabel className="flex items-center gap-1.5 text-xs text-muted-foreground font-normal">
         <ProviderIcon providerId={provider.id} className="size-3.5" />
         {provider.name}
-        {!connected && (
+        {state === "checking" && (
+          <span className="text-[10px] text-muted-foreground/60 ml-auto">{t("modelSelector.checking")}</span>
+        )}
+        {state === "disconnected" && (
           <span className="text-[10px] text-muted-foreground/60 ml-auto">{t("modelSelector.notConnected")}</span>
         )}
       </DropdownMenuLabel>

--- a/app/src/components/chat-model-selector.tsx
+++ b/app/src/components/chat-model-selector.tsx
@@ -1,4 +1,3 @@
-import { useState, useEffect, useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { ChevronDown } from "lucide-react";
 import {
@@ -6,8 +5,12 @@ import {
   DropdownMenuTrigger,
   DropdownMenuContent,
 } from "@houston-ai/core";
-import { tauriProvider, type ProviderStatus } from "../lib/tauri";
 import { PROVIDERS, getProvider, getModel } from "../lib/providers";
+import {
+  providerPickerState,
+  shouldShowProviderInPicker,
+} from "../lib/model-picker";
+import { useProviderStatuses } from "../hooks/use-provider-statuses";
 import {
   ProviderModelGroup,
   ProviderIcon,
@@ -35,18 +38,7 @@ export function ChatModelSelector({
   lockedProvider,
 }: ChatModelSelectorProps) {
   const { t } = useTranslation("chat");
-  const [statuses, setStatuses] = useState<Record<string, ProviderStatus>>({});
-
-  const loadStatuses = useCallback(async () => {
-    const entries = await Promise.all(
-      PROVIDERS.map(async (p) => [p.id, await tauriProvider.checkStatus(p.id)] as const),
-    );
-    setStatuses(Object.fromEntries(entries));
-  }, []);
-
-  useEffect(() => {
-    loadStatuses();
-  }, [loadStatuses]);
+  const { statuses, isLoading } = useProviderStatuses();
 
   const currentProvider = getProvider(provider);
   const currentModel = getModel(provider, model);
@@ -95,22 +87,30 @@ export function ChatModelSelector({
           onCloseAutoFocus={(e) => e.preventDefault()}
         >
           {PROVIDERS.map((prov, idx) => {
-            const status = statuses[prov.id];
-            const connected = (status?.cli_installed && status?.authenticated) ?? false;
-            // Hide disconnected providers that aren't active
-            if (!connected && prov.id !== provider) return null;
-            // When provider is locked AND still installed, only show the
-            // locked provider's models. When the locked provider is
-            // uninstalled, `effectiveLock` is null so other connected
-            // providers stay visible — see the lock-override comment above.
-            if (effectiveLock && prov.id !== effectiveLock) return null;
+            const state = providerPickerState(statuses[prov.id], isLoading);
+            const isActiveProvider = prov.id === provider;
+            // Keep every provider visible while statuses are still loading so
+            // the list doesn't collapse to a single "Not connected" entry
+            // (issue #342); once known, hide disconnected non-active
+            // providers. A lock (conversation already started) still shows
+            // only the locked provider — see the lock-override comment above.
+            if (
+              !shouldShowProviderInPicker({
+                providerId: prov.id,
+                state,
+                isActiveProvider,
+                effectiveLock,
+              })
+            ) {
+              return null;
+            }
             return (
               <ProviderModelGroup
                 key={prov.id}
                 provider={prov}
-                connected={connected}
-                isActiveProvider={prov.id === provider}
-                activeModel={prov.id === provider ? model : null}
+                state={state}
+                isActiveProvider={isActiveProvider}
+                activeModel={isActiveProvider ? model : null}
                 onSelect={onSelect}
                 showSeparator={idx > 0 && !effectiveLock}
               />

--- a/app/src/hooks/use-agent-invalidation.ts
+++ b/app/src/hooks/use-agent-invalidation.ts
@@ -65,6 +65,12 @@ export function useAgentInvalidation() {
         case "ComposioConnectionAdded":
           qc.invalidateQueries({ queryKey: queryKeys.connectedToolkits() });
           break;
+        // A provider OAuth sign-in (or sign-out) finished — refresh the
+        // cached provider statuses so the chat model picker reflects the new
+        // connection without waiting for the next mount (issue #342).
+        case "ProviderLoginComplete":
+          qc.invalidateQueries({ queryKey: queryKeys.providerStatuses() });
+          break;
       }
     });
 

--- a/app/src/hooks/use-provider-statuses.ts
+++ b/app/src/hooks/use-provider-statuses.ts
@@ -1,0 +1,48 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { tauriProvider, type ProviderStatus } from "../lib/tauri";
+import { PROVIDERS } from "../lib/providers";
+import { queryKeys } from "../lib/query-keys";
+
+export interface ProviderStatusesState {
+  /** Status by provider id. Empty until the first fetch resolves. */
+  statuses: Record<string, ProviderStatus>;
+  /**
+   * True only on the FIRST load with no cached data, so the picker can show a
+   * neutral "checking" state instead of a false "Not connected". Background
+   * refetches with cached data keep this false, so reopening the picker never
+   * flickers back to "checking".
+   */
+  isLoading: boolean;
+  isError: boolean;
+}
+
+/**
+ * Shared provider connection statuses, cached + reactive via TanStack Query.
+ *
+ * Replaces the per-mount `Promise.all(checkStatus)` the chat model picker ran
+ * on every open (issue #342): the load-on-mount-only pattern showed every
+ * provider as "Not connected" for the few seconds the engine spent probing the
+ * provider CLIs. Keyed under `queryKeys.providerStatuses()` so it is
+ * invalidated when a provider login completes (see use-agent-invalidation.ts);
+ * `staleTime` keeps repeat opens instant, and the default window-focus refetch
+ * picks up out-of-band auth changes.
+ */
+export function useProviderStatuses(): ProviderStatusesState {
+  const query = useQuery({
+    queryKey: queryKeys.providerStatuses(),
+    queryFn: async (): Promise<Record<string, ProviderStatus>> => {
+      const entries = await Promise.all(
+        PROVIDERS.map(async (p) => [p.id, await tauriProvider.checkStatus(p.id)] as const),
+      );
+      return Object.fromEntries(entries);
+    },
+    staleTime: 30_000,
+  });
+
+  return {
+    statuses: query.data ?? {},
+    isLoading: query.isLoading,
+    isError: query.isError,
+  };
+}

--- a/app/src/lib/model-picker.test.mjs
+++ b/app/src/lib/model-picker.test.mjs
@@ -1,0 +1,113 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  providerPickerState,
+  shouldShowProviderInPicker,
+} from "./model-picker.ts";
+
+const CONNECTED = { cli_installed: true, authenticated: true };
+const INSTALLED_UNAUTH = { cli_installed: true, authenticated: false };
+const MISSING = { cli_installed: false, authenticated: false };
+
+test("providerPickerState: known statuses map to connected / disconnected", () => {
+  assert.equal(providerPickerState(CONNECTED, false), "connected");
+  // A connected status wins even if a background refetch is in flight.
+  assert.equal(providerPickerState(CONNECTED, true), "connected");
+  assert.equal(providerPickerState(INSTALLED_UNAUTH, false), "disconnected");
+  assert.equal(providerPickerState(MISSING, false), "disconnected");
+});
+
+test("providerPickerState: missing status is 'checking' only while loading", () => {
+  // The #342 fix: before statuses resolve, providers read as 'checking', NOT
+  // 'disconnected', so the picker never shows a false "Not connected".
+  assert.equal(providerPickerState(undefined, true), "checking");
+  // Not loading + no status (e.g. the fetch failed) degrades to disconnected
+  // rather than spinning forever.
+  assert.equal(providerPickerState(undefined, false), "disconnected");
+});
+
+test("shouldShowProviderInPicker: 'checking' keeps every provider visible (#342)", () => {
+  // Before resolution a non-active provider must stay visible so the list does
+  // not collapse to a single "Not connected" entry — the reported bug.
+  assert.equal(
+    shouldShowProviderInPicker({
+      providerId: "openai",
+      state: "checking",
+      isActiveProvider: false,
+      effectiveLock: null,
+    }),
+    true,
+  );
+});
+
+test("shouldShowProviderInPicker: known-disconnected non-active providers are hidden", () => {
+  assert.equal(
+    shouldShowProviderInPicker({
+      providerId: "openai",
+      state: "disconnected",
+      isActiveProvider: false,
+      effectiveLock: null,
+    }),
+    false,
+  );
+});
+
+test("shouldShowProviderInPicker: connected non-active providers are shown", () => {
+  assert.equal(
+    shouldShowProviderInPicker({
+      providerId: "openai",
+      state: "connected",
+      isActiveProvider: false,
+      effectiveLock: null,
+    }),
+    true,
+  );
+});
+
+test("shouldShowProviderInPicker: the active provider is always shown", () => {
+  for (const state of ["connected", "disconnected", "checking"]) {
+    assert.equal(
+      shouldShowProviderInPicker({
+        providerId: "anthropic",
+        state,
+        isActiveProvider: true,
+        effectiveLock: null,
+      }),
+      true,
+      `active provider should show while ${state}`,
+    );
+  }
+});
+
+test("shouldShowProviderInPicker: a lock hides every other provider", () => {
+  // Non-locked provider hidden even when connected.
+  assert.equal(
+    shouldShowProviderInPicker({
+      providerId: "openai",
+      state: "connected",
+      isActiveProvider: false,
+      effectiveLock: "anthropic",
+    }),
+    false,
+  );
+  // The locked provider shows.
+  assert.equal(
+    shouldShowProviderInPicker({
+      providerId: "anthropic",
+      state: "connected",
+      isActiveProvider: true,
+      effectiveLock: "anthropic",
+    }),
+    true,
+  );
+  // A still-checking locked provider shows too (only it).
+  assert.equal(
+    shouldShowProviderInPicker({
+      providerId: "anthropic",
+      state: "checking",
+      isActiveProvider: true,
+      effectiveLock: "anthropic",
+    }),
+    true,
+  );
+});

--- a/app/src/lib/model-picker.ts
+++ b/app/src/lib/model-picker.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure decision helpers for the chat model picker (ChatModelSelector).
+ *
+ * Split out from the component so the visibility / connection logic is
+ * unit-testable without a React renderer (the app has no component test
+ * runner — see the sibling *.test.mjs files for the node:test pattern) and so
+ * the container stays under the file-size budget.
+ *
+ * Background (issue #342): provider connection status is fetched
+ * asynchronously. Before it resolves, the picker must NOT collapse to a single
+ * "Not connected" provider — it shows every provider in a neutral "checking"
+ * state until the real status arrives. These helpers encode exactly that.
+ */
+
+/** Minimal shape of a provider status these helpers need. */
+export interface ProviderConnection {
+  cli_installed: boolean;
+  authenticated: boolean;
+}
+
+/**
+ * Per-provider state the picker renders:
+ * - `connected`    — CLI installed AND authenticated; models selectable.
+ * - `disconnected` — status known but not usable; hidden unless it's the
+ *                    active provider, where it shows a "Not connected" hint.
+ * - `checking`     — status not yet known and a fetch is in flight; shown with
+ *                    a neutral "Checking..." hint, models disabled. This is the
+ *                    state that prevents the #342 flicker.
+ */
+export type ProviderPickerState = "connected" | "disconnected" | "checking";
+
+/**
+ * Resolve a provider's picker state from its (possibly missing) status and
+ * whether the status query is still loading. An absent status while loading is
+ * `checking`; an absent status when NOT loading (e.g. the fetch failed) is
+ * treated as `disconnected` so the picker degrades to the same safe view it had
+ * before — never stuck spinning.
+ */
+export function providerPickerState(
+  status: ProviderConnection | undefined,
+  isLoading: boolean,
+): ProviderPickerState {
+  if (status) {
+    return status.cli_installed && status.authenticated ? "connected" : "disconnected";
+  }
+  return isLoading ? "checking" : "disconnected";
+}
+
+/**
+ * Whether a provider group should render in the picker.
+ *
+ * Rules, in order:
+ *  1. A lock hides every provider except the locked one (the conversation has
+ *     already started on that provider).
+ *  2. The active provider is always shown, so the user can see and re-pick the
+ *     current selection even when it is disconnected.
+ *  3. While `checking`, every provider stays visible — this is the #342 fix:
+ *     the list must not collapse to just the active provider before statuses
+ *     load.
+ *  4. Otherwise show only providers known to be connected; hide the rest.
+ */
+export function shouldShowProviderInPicker(opts: {
+  providerId: string;
+  state: ProviderPickerState;
+  isActiveProvider: boolean;
+  effectiveLock: string | null;
+}): boolean {
+  const { providerId, state, isActiveProvider, effectiveLock } = opts;
+  if (effectiveLock) return providerId === effectiveLock;
+  if (isActiveProvider) return true;
+  if (state === "checking") return true;
+  return state === "connected";
+}

--- a/app/src/lib/query-keys.ts
+++ b/app/src/lib/query-keys.ts
@@ -32,4 +32,10 @@ export const queryKeys = {
   connections: () => ["connections"] as const,
   composioApps: () => ["composio-apps"] as const,
   connectedToolkits: () => ["connected-toolkits"] as const,
+  /**
+   * Provider connection statuses for the chat model picker. Invalidated on
+   * `ProviderLoginComplete` so a fresh sign-in flips the picker live instead
+   * of waiting for the next mount (issue #342).
+   */
+  providerStatuses: () => ["provider-statuses"] as const,
 };

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -59,6 +59,7 @@
     "selectModel": "Select model",
     "model": "Model",
     "notConnected": "Not connected",
+    "checking": "Checking...",
     "effort": "Reasoning effort",
     "effortLevels": {
       "low": "Low",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -59,6 +59,7 @@
     "selectModel": "Elige un modelo",
     "model": "Modelo",
     "notConnected": "Sin conexión",
+    "checking": "Verificando...",
     "effort": "Esfuerzo de razonamiento",
     "effortLevels": {
       "low": "Bajo",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -59,6 +59,7 @@
     "selectModel": "Escolha um modelo",
     "model": "Modelo",
     "notConnected": "Sem conexão",
+    "checking": "Verificando...",
     "effort": "Esforço de raciocínio",
     "effortLevels": {
       "low": "Baixo",


### PR DESCRIPTION
## What & why

Fixes #342 ("Delay in model picker"). When opening the model picker on a new
chat, only one provider showed, marked "not connected"; a few seconds later
the other providers appeared and their models became selectable.

### Root cause

`app/src/components/chat-model-selector.tsx` fetched provider connection
statuses **load-on-mount-only**: `statuses` started as `{}` and a `useEffect`
fired `tauriProvider.checkStatus()` for each provider. Each call hits
`GET /providers/:name/status`, which on the engine spawns the provider CLI
(`claude auth status` / `codex login status`) with up to a **5s timeout and no
caching**. During that window the render collapsed the list:

```
const connected = (status?.cli_installed && status?.authenticated) ?? false;
if (!connected && prov.id !== provider) return null;   // hides all but active
```

so only the active provider showed, as "Not connected", with models disabled —
until the probes resolved and `setStatuses` re-rendered. This is also a
violation of the repo's AI-native reactivity rule (no load-on-mount-only).

## Changes (frontend reactivity layer)

- **`app/src/hooks/use-provider-statuses.ts`** (new) — shared TanStack Query
  hook for provider statuses, keyed under `queryKeys.providerStatuses()` with a
  stale time. Cached + deduped; repeat opens don't re-probe.
- **`app/src/lib/model-picker.ts`** (new) — pure decision helpers
  `providerPickerState` and `shouldShowProviderInPicker`, encoding the
  connected / disconnected / **checking** states.
- **`chat-model-selector.tsx`** — consumes the hook; while loading, providers
  stay visible in a neutral "checking" state instead of collapsing to a single
  "Not connected" entry. Cached opens skip the checking state entirely.
- **`chat-model-selector-parts.tsx`** — `ProviderModelGroup` now takes a
  `state` prop and shows "Checking..." vs "Not connected" appropriately.
- **`use-agent-invalidation.ts`** + **`query-keys.ts`** — invalidate provider
  statuses on the `ProviderLoginComplete` WS event so a fresh sign-in/out
  updates the picker live.
- **locales en/es/pt** — add `modelSelector.checking`.

## Tests

- `app/src/lib/model-picker.test.mjs` (new) — unit tests for
  `providerPickerState` (checking only while loading; known statuses map to
  connected/disconnected) and `shouldShowProviderInPicker` (checking keeps all
  providers visible — the #342 fix; disconnected non-active hidden; active
  always shown; lock hides others).

## Verification

- `cd app && pnpm tsc --noEmit`
- `cd app && pnpm check-locales`
- `node --test app/src/lib/model-picker.test.mjs` (via the repo's TS-aware test
  runner)

## Out of scope / follow-up

The engine still probes the provider CLI on every `/providers/:name/status`
call with no server-side cache. The React Query cache eliminates repeated
probes from the picker's perspective; a server-side status cache (invalidated
on login/logout) would be a separate optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
