### PR TITLE
feat(analytics): track normalized install OS

### DIFF
--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -1,5 +1,6 @@
 import posthog from "posthog-js";
 import { getInstallId } from "./install-id";
+import { currentPlatformOs } from "./platform";
 import { tauriPreferences } from "./tauri";
 
 // __POSTHOG_KEY__, __POSTHOG_HOST__, __APP_VERSION__ declared in vite-env.d.ts,
@@ -115,6 +116,21 @@ const ALLOWED_PROPS = new Set<AnalyticsProperty>([
 // Bootstrap PostHog at module load so a configured build can capture errors
 // before `analytics.init()` resolves. Product events are fired after init.
 let bootstrapped = false;
+
+function rawNavigatorPlatform() {
+  return typeof navigator !== "undefined" ? navigator.platform : "unknown";
+}
+
+function baseSuperProps() {
+  return {
+    app_version: APP_VERSION,
+    app_os: currentPlatformOs,
+    os: rawNavigatorPlatform(),
+    is_debug: import.meta.env.DEV,
+    session_id: SESSION_ID,
+  };
+}
+
 function bootstrap() {
   if (bootstrapped || !KEY) return;
   bootstrapped = true;
@@ -132,10 +148,7 @@ function bootstrap() {
     advanced_disable_flags: true,
     loaded: (ph) => {
       ph.register({
-        app_version: APP_VERSION,
-        os: typeof navigator !== "undefined" ? navigator.platform : "unknown",
-        is_debug: import.meta.env.DEV,
-        session_id: SESSION_ID,
+        ...baseSuperProps(),
         auth_status: "anonymous",
       });
     },
@@ -248,8 +261,10 @@ export const analytics = {
       posthog.identify(id, {
         first_install_version: firstInstallVersion,
         first_install_date: firstInstallDate,
+        install_os: currentPlatformOs,
       });
       posthog.register({
+        ...baseSuperProps(),
         install_id: id,
         days_since_install: daysBetween(firstInstallDate, activeDate()),
       });
@@ -294,7 +309,7 @@ export const analytics = {
     try {
       posthog.alias(userId);
       posthog.identify(userId, personProps(profile));
-      posthog.register({ auth_status: "authenticated" });
+      posthog.register({ ...baseSuperProps(), auth_status: "authenticated" });
     } catch {
       // Analytics unavailable
     }
@@ -315,7 +330,7 @@ export const analytics = {
     if (!KEY) return;
     try {
       posthog.reset();
-      posthog.register({ auth_status: "anonymous" });
+      posthog.register({ ...baseSuperProps(), auth_status: "anonymous" });
     } catch {
       // Analytics unavailable
     }

--- a/app/src/lib/platform.ts
+++ b/app/src/lib/platform.ts
@@ -2,23 +2,39 @@
  * Lightweight client-side OS detection.
  *
  * Houston doesn't bundle `@tauri-apps/plugin-os`, and the webview's
- * `navigator` is enough to tell macOS apart from Linux/Windows — which is all
- * the frontend needs (e.g. ⌘ vs Ctrl shortcut hints, and routing native
- * notifications through the JS plugin on macOS vs. the Rust command on
- * Linux/Windows). Anything finer-grained belongs in Rust behind `#[cfg]`.
+ * `navigator` is enough for coarse OS detection: shortcut hints,
+ * notification routing, and analytics OS breakdowns. Anything finer-grained
+ * belongs in Rust behind `#[cfg]`.
  */
+export type PlatformOs = "macos" | "windows" | "linux" | "unknown";
+
 /**
- * Pure macOS check over raw `navigator` fields, exported for tests. Prefers
+ * Pure OS classifier over raw `navigator` fields, exported for tests. Prefers
  * `platform` and falls back to `userAgent` (some webviews leave `platform`
- * empty). The runtime `isMac` const below is the only production caller.
+ * empty) so a spoofed/fallback UA cannot override a concrete platform value.
  */
+export function detectPlatformOs(
+  platform: string | undefined | null,
+  userAgent: string | undefined | null,
+): PlatformOs {
+  const source = (platform?.trim() || userAgent?.trim() || "").toLowerCase();
+  if (/mac|darwin/.test(source)) return "macos";
+  if (/win/.test(source)) return "windows";
+  if (/linux|x11/.test(source)) return "linux";
+  return "unknown";
+}
+
+/** Pure macOS check over raw `navigator` fields, exported for tests. */
 export function isMacPlatform(
   platform: string | undefined | null,
   userAgent: string | undefined | null,
 ): boolean {
-  return /mac/i.test(platform || userAgent || "");
+  return detectPlatformOs(platform, userAgent) === "macos";
 }
 
-export const isMac =
-  typeof navigator !== "undefined" &&
-  isMacPlatform(navigator.platform, navigator.userAgent);
+export const currentPlatformOs: PlatformOs =
+  typeof navigator !== "undefined"
+    ? detectPlatformOs(navigator.platform, navigator.userAgent)
+    : "unknown";
+
+export const isMac = currentPlatformOs === "macos";

--- a/app/tests/platform-detection.test.ts
+++ b/app/tests/platform-detection.test.ts
@@ -1,6 +1,6 @@
 import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import { isMacPlatform } from "../src/lib/platform.ts";
+import { detectPlatformOs, isMacPlatform } from "../src/lib/platform.ts";
 
 // `isMacPlatform` gates the whole notification fix: macOS keeps the JS
 // notification plugin, every other OS routes through the Rust command. A
@@ -34,5 +34,42 @@ describe("isMacPlatform", () => {
     strictEqual(isMacPlatform(undefined, undefined), false);
     strictEqual(isMacPlatform(null, null), false);
     strictEqual(isMacPlatform("", ""), false);
+  });
+});
+
+describe("detectPlatformOs", () => {
+  it("normalizes macOS", () => {
+    strictEqual(detectPlatformOs("MacIntel", "Mozilla/5.0 (Macintosh)"), "macos");
+  });
+
+  it("normalizes Windows", () => {
+    strictEqual(
+      detectPlatformOs("Win32", "Mozilla/5.0 (Windows NT 10.0; Win64)"),
+      "windows",
+    );
+  });
+
+  it("normalizes Linux", () => {
+    strictEqual(
+      detectPlatformOs("Linux x86_64", "Mozilla/5.0 (X11; Linux x86_64)"),
+      "linux",
+    );
+  });
+
+  it("falls back to userAgent when platform is empty", () => {
+    strictEqual(
+      detectPlatformOs("", "Mozilla/5.0 (Windows NT 10.0; Win64)"),
+      "windows",
+    );
+  });
+
+  it("prefers platform over userAgent", () => {
+    strictEqual(detectPlatformOs("Win32", "Mozilla/5.0 (Macintosh)"), "windows");
+  });
+
+  it("returns unknown when navigator fields are missing or empty", () => {
+    strictEqual(detectPlatformOs(undefined, undefined), "unknown");
+    strictEqual(detectPlatformOs(null, null), "unknown");
+    strictEqual(detectPlatformOs("", ""), "unknown");
   });
 });

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -22,7 +22,7 @@ Four prod systems. All **dormant by default** — activate only when env vars se
 - **Install identity:** `app/src/lib/install-id.ts` — mints a UUID on first launch, persists via `tauriPreferences` (`install_id` key). Used as anonymous PostHog `distinct_id` until sign-in, then `analytics.alias/identify` merges history to the Supabase user.
 - **User identity:** `distinct_id` is the stable Supabase user id. `email` and `email_domain` are PostHog person properties only, used for lookup, company-domain filtering, and B2B usage checks.
 - **Debug/Release:** `import.meta.env.DEV` → `is_debug` super property. Filter it out in dashboards to exclude dev activity.
-- **Super properties:** `app_version`, `os`, `install_id`, `is_debug`.
+- **Super properties:** `app_version`, `app_os` (normalized: `macos` / `windows` / `linux` / `unknown`), `os` (raw legacy `navigator.platform`), `install_id`, `is_debug`.
 - **Privacy:** no workspace names, agent names, raw prompts, raw message text, file paths, session keys, or raw error text in PostHog event props. Email is allowed only as a person property after auth, never as an event property.
 
 ### Event surface
@@ -46,7 +46,7 @@ Event names + props are allowlisted in `AnalyticsEventName` / `AnalyticsProperty
 
 8 themed dashboards, each opens with one question. Numeric prefix sets the sidebar order to match daily reading flow:
 
-1. **Houston / 1. Acquisition** (id 1631626) — where users come from. Installs over time + UTM-campaign + OS breakdown
+1. **Houston / 1. Acquisition** (id 1631626) — where users come from. Installs over time + UTM-campaign + normalized `app_os` breakdown
 2. **Houston / 2. Activation** (id 1631629) — where the funnel leaks. Install → activation funnel, time-to-activation, onboarding completion
 3. **Houston / 3. Engagement** (id 1631631) — DAU/WAU/MAU, stickiness, messages-per-active-day
 4. **Houston / 4. Retention** (id 1631635) — weekly cohort retention, growth accounting, attribution-cohorted retention
@@ -70,7 +70,7 @@ The dashboard tile shows COUNTS. To actually reach people on old versions, use P
 1. Persons → "New cohort" (or ad-hoc filter)
 2. Filter: `app_version` (super property, type **Event property**) `is not` `<latest version>` (e.g. `0.4.3`). Repeat with `is_set` to exclude any persons missing the property.
 3. Optionally also filter `email is_set` — only signed-in users have an email; anonymous installs cannot be emailed.
-4. Export the cohort as CSV. Columns of interest: `email`, `email_domain`, `app_version`, `os`.
+4. Export the cohort as CSV. Columns of interest: `email`, `email_domain`, `app_version`, `install_os`.
 
 Caveats:
 - `app_version` is a SUPER property attached to events, not a person property. So filtering by it on Persons works only if PostHog has seen that person fire an event recently in that version. Long-dormant users may not show up.


### PR DESCRIPTION
## Summary
- Add normalized app OS detection (`macos`, `windows`, `linux`, `unknown`) for analytics.
- Register `app_os` on PostHog events and `install_os` on the install person profile while preserving raw legacy `os`.
- Document how to use the normalized OS fields for acquisition/install reporting.

Closes #350

## Tests
- node --test --experimental-strip-types app/tests/platform-detection.test.ts
- pnpm --filter houston-app typecheck