### PR TITLE
feat(chat): context-window usage indicator in composer (#312)

### DIFF
--- a/app/src/components/context-indicator.tsx
+++ b/app/src/components/context-indicator.tsx
@@ -2,11 +2,13 @@
  * Composer context-usage indicator.
  *
  * A small footer pill that shows how full the model's context window is for
- * the current conversation, opening a dialog with the detail. Reads the
- * latest turn's normalized `TokenUsage` (see `latestContextUsage`) and the
- * active model's context window (`getContextWindow`). When the window is
- * unknown for a model it degrades to a raw token count rather than showing a
- * misleading percentage.
+ * the current conversation, opening a dialog with the detail. The caller
+ * resolves `usage` (latest turn) and `contextWindow` (a self-correcting
+ * estimate; see `sessionContextUsage` + `effectiveContextWindow` in
+ * `lib/context-usage.ts` and `getContextWindowConfig` in `lib/providers.ts`).
+ * The window is plan/credit-gated and not reported by `claude -p`, so the
+ * dialog labels the figure "estimated". When no window is known for a model
+ * it degrades to a raw token count rather than a misleading percentage.
  *
  * App-side (not in `ui/`) because it depends on the app's model catalog and
  * i18n; it uses `t()` directly per the library-boundary rule.
@@ -68,6 +70,7 @@ export function ContextIndicator({
         <button
           type="button"
           aria-label={t("button.aria")}
+          title={percent != null ? t("dialog.estimated") : undefined}
           className={`inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full text-xs font-medium transition-colors hover:bg-accent ${
             warn
               ? "text-destructive"
@@ -110,6 +113,9 @@ export function ContextIndicator({
                   {t("dialog.free", {
                     free: fmt(Math.max(0, windowTokens - usage.context_tokens)),
                   })}
+                </p>
+                <p className="text-[11px] text-muted-foreground/80">
+                  {t("dialog.estimated")}
                 </p>
               </>
             ) : (

--- a/app/src/components/context-indicator.tsx
+++ b/app/src/components/context-indicator.tsx
@@ -1,0 +1,151 @@
+/**
+ * Composer context-usage indicator.
+ *
+ * A small footer pill that shows how full the model's context window is for
+ * the current conversation, opening a dialog with the detail. Reads the
+ * latest turn's normalized `TokenUsage` (see `latestContextUsage`) and the
+ * active model's context window (`getContextWindow`). When the window is
+ * unknown for a model it degrades to a raw token count rather than showing a
+ * misleading percentage.
+ *
+ * App-side (not in `ui/`) because it depends on the app's model catalog and
+ * i18n; it uses `t()` directly per the library-boundary rule.
+ */
+
+import { useTranslation } from "react-i18next";
+import { Gauge } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+  Progress,
+} from "@houston-ai/core";
+import type { TokenUsage } from "@houston-ai/chat";
+
+interface ContextIndicatorProps {
+  /** Latest turn's usage, or null when no turn has reported it yet. */
+  usage: TokenUsage | null;
+  /** Active model's max context window in tokens, if catalogued. */
+  contextWindow?: number;
+  /** Human-readable model label (e.g. "Sonnet 4.6"). */
+  modelLabel?: string;
+}
+
+/** Threshold at which the indicator warns the window is nearly full. */
+const WARN_PERCENT = 90;
+
+export function ContextIndicator({
+  usage,
+  contextWindow,
+  modelLabel,
+}: ContextIndicatorProps) {
+  const { t, i18n } = useTranslation("context");
+
+  // A directly-narrowable `number | null` — TypeScript won't carry a boolean
+  // alias's narrowing of `contextWindow` across the JSX branches below, so we
+  // branch on this value itself and read it where it's already proven non-null.
+  const windowTokens =
+    typeof contextWindow === "number" && contextWindow > 0
+      ? contextWindow
+      : null;
+  const percent =
+    usage && windowTokens != null
+      ? Math.min(
+          100,
+          Math.max(0, Math.round((usage.context_tokens / windowTokens) * 100)),
+        )
+      : null;
+  const warn = percent != null && percent >= WARN_PERCENT;
+
+  const fmt = (n: number) => n.toLocaleString(i18n.language);
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          aria-label={t("button.aria")}
+          className={`inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full text-xs font-medium transition-colors hover:bg-accent ${
+            warn
+              ? "text-destructive"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          <Gauge className="size-3.5" />
+          {percent != null ? `${percent}%` : t("button.label")}
+        </button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-md" closeLabel={t("dialog.close")}>
+        <DialogHeader>
+          <DialogTitle>{t("dialog.title")}</DialogTitle>
+          <DialogDescription>
+            {modelLabel
+              ? t("dialog.subtitle", { model: modelLabel })
+              : t("dialog.subtitleNoModel")}
+          </DialogDescription>
+        </DialogHeader>
+
+        {!usage ? (
+          <p className="text-sm text-muted-foreground">{t("dialog.empty")}</p>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {windowTokens != null ? (
+              <>
+                <div className="flex items-baseline justify-between gap-3">
+                  <span className="text-2xl font-semibold tabular-nums">
+                    {t("dialog.percentFull", { percent: percent ?? 0 })}
+                  </span>
+                  <span className="text-xs text-muted-foreground tabular-nums">
+                    {t("dialog.usedOfTotal", {
+                      used: fmt(usage.context_tokens),
+                      total: fmt(windowTokens),
+                    })}
+                  </span>
+                </div>
+                <Progress value={percent ?? 0} aria-label={t("dialog.title")} />
+                <p className="text-xs text-muted-foreground tabular-nums">
+                  {t("dialog.free", {
+                    free: fmt(Math.max(0, windowTokens - usage.context_tokens)),
+                  })}
+                </p>
+              </>
+            ) : (
+              <>
+                <span className="text-lg font-semibold tabular-nums">
+                  {t("dialog.tokensUsed", { used: fmt(usage.context_tokens) })}
+                </span>
+                <p className="text-xs text-muted-foreground">
+                  {t("dialog.unknownWindow")}
+                </p>
+              </>
+            )}
+
+            {(usage.cached_tokens > 0 || usage.output_tokens > 0) && (
+              <dl className="flex flex-col gap-1 border-t border-border/50 pt-3 text-xs">
+                {usage.cached_tokens > 0 && (
+                  <div className="flex items-center justify-between gap-3">
+                    <dt className="text-muted-foreground">
+                      {t("dialog.cached")}
+                    </dt>
+                    <dd className="tabular-nums">{fmt(usage.cached_tokens)}</dd>
+                  </div>
+                )}
+                {usage.output_tokens > 0 && (
+                  <div className="flex items-center justify-between gap-3">
+                    <dt className="text-muted-foreground">
+                      {t("dialog.lastReply")}
+                    </dt>
+                    <dd className="tabular-nums">{fmt(usage.output_tokens)}</dd>
+                  </div>
+                )}
+              </dl>
+            )}
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -68,7 +68,7 @@ import {
 import { ChatModelSelector } from "./chat-model-selector";
 import { ChatEffortSelector } from "./chat-effort-selector";
 import {
-  getContextWindow,
+  getContextWindowConfig,
   getDefaultModel,
   getModel,
   validModelOrNull,
@@ -76,7 +76,10 @@ import {
   normalizeLegacyModel,
   type EffortLevel,
 } from "../lib/providers";
-import { latestContextUsage } from "../lib/context-usage";
+import {
+  sessionContextUsage,
+  effectiveContextWindow,
+} from "../lib/context-usage";
 import { ContextIndicator } from "./context-indicator";
 import { analytics } from "../lib/analytics";
 import {
@@ -215,18 +218,29 @@ export function useAgentChatPanel({
   );
 
   // ── Context-usage indicator ───────────────────────────────────────────
-  // Latest turn's normalized usage from this session's feed, plus the active
-  // model's context-window size. Drive the composer footer pill + dialog.
+  // Latest turn's normalized usage from this session's feed, divided by a
+  // self-correcting window estimate: the active model's catalogued default,
+  // snapped up once the session's observed peak proves a larger (plan/credit-
+  // gated) window. Drives the composer footer pill + dialog.
   const sessionFeedItems = useFeedStore((s) =>
     path && selectedSessionKey
       ? s.items[path]?.[selectedSessionKey]
       : undefined,
   );
-  const contextUsage = useMemo(
-    () => latestContextUsage(sessionFeedItems),
-    [sessionFeedItems],
-  );
-  const contextWindow = getContextWindow(effectiveProvider, effectiveModel);
+  const { contextUsage, contextWindow } = useMemo(() => {
+    const { latest, peakContextTokens } = sessionContextUsage(sessionFeedItems);
+    // `peakContextTokens` is session-wide while `cfg` is the currently-selected
+    // model's. Safe today because all same-provider models share a snap ceiling
+    // (every Anthropic model maxes at 1M; provider is locked after turn one so
+    // openai/anthropic never mix in one session). Revisit if a provider ever
+    // adds a model whose ceiling is below a sibling's realistic peak.
+    const cfg = getContextWindowConfig(effectiveProvider, effectiveModel);
+    return {
+      contextUsage: latest,
+      contextWindow:
+        effectiveContextWindow(cfg, peakContextTokens) ?? undefined,
+    };
+  }, [sessionFeedItems, effectiveProvider, effectiveModel]);
   const modelLabel = getModel(effectiveProvider, effectiveModel)?.label;
 
   const handleModelSelect = useCallback(

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -68,12 +68,16 @@ import {
 import { ChatModelSelector } from "./chat-model-selector";
 import { ChatEffortSelector } from "./chat-effort-selector";
 import {
+  getContextWindow,
   getDefaultModel,
+  getModel,
   validModelOrNull,
   validEffortOrDefault,
   normalizeLegacyModel,
   type EffortLevel,
 } from "../lib/providers";
+import { latestContextUsage } from "../lib/context-usage";
+import { ContextIndicator } from "./context-indicator";
 import { analytics } from "../lib/analytics";
 import {
   buildSkillClaudePrompt,
@@ -209,6 +213,22 @@ export function useAgentChatPanel({
     effectiveModel,
     agentEffort,
   );
+
+  // ── Context-usage indicator ───────────────────────────────────────────
+  // Latest turn's normalized usage from this session's feed, plus the active
+  // model's context-window size. Drive the composer footer pill + dialog.
+  const sessionFeedItems = useFeedStore((s) =>
+    path && selectedSessionKey
+      ? s.items[path]?.[selectedSessionKey]
+      : undefined,
+  );
+  const contextUsage = useMemo(
+    () => latestContextUsage(sessionFeedItems),
+    [sessionFeedItems],
+  );
+  const contextWindow = getContextWindow(effectiveProvider, effectiveModel);
+  const modelLabel = getModel(effectiveProvider, effectiveModel)?.label;
+
   const handleModelSelect = useCallback(
     async (prov: string, mod: string) => {
       // Optimistic UI: the picker flips instantly while the writes fan out.
@@ -607,9 +627,16 @@ export function useAgentChatPanel({
           effort={effectiveEffort}
           onSelect={handleEffortSelect}
         />
+        <div className="ml-auto">
+          <ContextIndicator
+            usage={contextUsage}
+            contextWindow={contextWindow}
+            modelLabel={modelLabel}
+          />
+        </div>
       </div>
     );
-  }, [agent, t, effectiveProvider, effectiveModel, effectiveEffort, handleModelSelect, handleEffortSelect]);
+  }, [agent, t, effectiveProvider, effectiveModel, effectiveEffort, handleModelSelect, handleEffortSelect, contextUsage, contextWindow, modelLabel]);
 
   const attachMenu = useMemo<AIBoardProps["attachMenu"]>(() => {
     if (!agent) return undefined;

--- a/app/src/lib/context-usage.ts
+++ b/app/src/lib/context-usage.ts
@@ -1,21 +1,57 @@
 import type { FeedItem, TokenUsage } from "@houston-ai/chat";
+import type { ContextWindowConfig } from "./providers";
+
+export interface SessionContextUsage {
+  /** Current fill: usage from the most recent completed turn, or null when no
+   *  turn has reported usage yet. */
+  latest: TokenUsage | null;
+  /** Session high-water mark of `context_tokens`. Proves a LOWER BOUND on the
+   *  real context window: Claude Code / Codex auto-compact before the limit,
+   *  so observed usage can never exceed the true window. Used to snap the
+   *  estimated window up when a plan/credit-gated larger window is in play. */
+  peakContextTokens: number;
+}
 
 /**
- * The most recent turn's token usage in a session's feed, or `null` when no
- * completed turn has reported usage yet (a fresh conversation, or a provider
- * that doesn't surface usage). Scans from the end so the result reflects the
- * current state of the context window, and survives a history reload because
- * `final_result` items are persisted and replayed into the feed store.
+ * Fold a session's feed into the current fill + observed peak. `final_result`
+ * items are persisted and replayed into the feed store, so this is stable
+ * across a history reload. Scans forward so `latest` ends as the last turn.
  */
-export function latestContextUsage(
+export function sessionContextUsage(
   items: FeedItem[] | undefined,
-): TokenUsage | null {
-  if (!items) return null;
-  for (let i = items.length - 1; i >= 0; i -= 1) {
-    const item = items[i];
+): SessionContextUsage {
+  let latest: TokenUsage | null = null;
+  let peakContextTokens = 0;
+  if (!items) return { latest, peakContextTokens };
+  for (const item of items) {
     if (item.feed_type === "final_result" && item.data.usage) {
-      return item.data.usage;
+      latest = item.data.usage;
+      peakContextTokens = Math.max(
+        peakContextTokens,
+        item.data.usage.context_tokens,
+      );
     }
   }
-  return null;
+  return { latest, peakContextTokens };
+}
+
+/**
+ * The window to divide by, given the model's catalogued config and the
+ * session's observed peak. Self-correcting: starts at the per-model default
+ * and snaps UP to the ceiling once observed usage exceeds the default, which
+ * proves the real (plan/credit-gated) window is the larger one. Returns null
+ * when the model has no catalogued window, so the caller falls back to a raw
+ * token count.
+ *
+ * The result is floored at the observed peak, so even a mis-catalogued ceiling
+ * can't make the indicator read over 100% — that guarantee lives here in the
+ * data layer, with the component's clamp as defense in depth.
+ */
+export function effectiveContextWindow(
+  cfg: ContextWindowConfig | undefined,
+  peakContextTokens: number,
+): number | null {
+  if (!cfg) return null;
+  const estimate = peakContextTokens > cfg.default ? cfg.max : cfg.default;
+  return Math.max(estimate, peakContextTokens);
 }

--- a/app/src/lib/context-usage.ts
+++ b/app/src/lib/context-usage.ts
@@ -1,0 +1,21 @@
+import type { FeedItem, TokenUsage } from "@houston-ai/chat";
+
+/**
+ * The most recent turn's token usage in a session's feed, or `null` when no
+ * completed turn has reported usage yet (a fresh conversation, or a provider
+ * that doesn't surface usage). Scans from the end so the result reflects the
+ * current state of the context window, and survives a history reload because
+ * `final_result` items are persisted and replayed into the feed store.
+ */
+export function latestContextUsage(
+  items: FeedItem[] | undefined,
+): TokenUsage | null {
+  if (!items) return null;
+  for (let i = items.length - 1; i >= 0; i -= 1) {
+    const item = items[i];
+    if (item.feed_type === "final_result" && item.data.usage) {
+      return item.data.usage;
+    }
+  }
+  return null;
+}

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -28,6 +28,7 @@ import providersEn from "../locales/en/providers.json";
 import errorsEn from "../locales/en/errors.json";
 import eventsEn from "../locales/en/events.json";
 import portableEn from "../locales/en/portable.json";
+import contextEn from "../locales/en/context.json";
 import commonEs from "../locales/es/common.json";
 import setupEs from "../locales/es/setup.json";
 import legalEs from "../locales/es/legal.json";
@@ -44,6 +45,7 @@ import providersEs from "../locales/es/providers.json";
 import errorsEs from "../locales/es/errors.json";
 import eventsEs from "../locales/es/events.json";
 import portableEs from "../locales/es/portable.json";
+import contextEs from "../locales/es/context.json";
 import commonPt from "../locales/pt/common.json";
 import setupPt from "../locales/pt/setup.json";
 import legalPt from "../locales/pt/legal.json";
@@ -60,6 +62,7 @@ import providersPt from "../locales/pt/providers.json";
 import errorsPt from "../locales/pt/errors.json";
 import eventsPt from "../locales/pt/events.json";
 import portablePt from "../locales/pt/portable.json";
+import contextPt from "../locales/pt/context.json";
 
 export const SUPPORTED_LOCALES = ["en", "es", "pt"] as const;
 export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
@@ -122,6 +125,7 @@ const resources = {
     errors: errorsEn,
     events: eventsEn,
     portable: portableEn,
+    context: contextEn,
   },
   es: {
     common: commonEs,
@@ -140,6 +144,7 @@ const resources = {
     errors: errorsEs,
     events: eventsEs,
     portable: portableEs,
+    context: contextEs,
   },
   pt: {
     common: commonPt,
@@ -158,6 +163,7 @@ const resources = {
     errors: errorsPt,
     events: eventsPt,
     portable: portablePt,
+    context: contextPt,
   },
 } as const;
 
@@ -196,6 +202,7 @@ void i18n
       "errors",
       "events",
       "portable",
+      "context",
     ],
     interpolation: { escapeValue: false }, // react already escapes
     detection: {

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -22,13 +22,17 @@ export interface ModelOption {
    */
   effortLevels?: readonly EffortLevel[];
   /**
-   * Maximum context-window size in tokens, as it behaves inside the model's
-   * CLI. Drives the composer context-usage indicator (used tokens ÷ window).
-   * Omit when the window isn't known for a model so the indicator degrades to
-   * a raw token count instead of showing a misleading percentage.
+   * Maximum context-window size in tokens, as the model's CLI actually
+   * behaves at runtime (i.e. the number to divide live `usage.context_tokens`
+   * by). Drives the composer context-usage indicator. Omit when unknown so
+   * the indicator falls back to a raw token count instead of a misleading %.
    *
-   * Houston runs Claude at the standard 200k window (not the 1M beta). Codex
-   * caps gpt-5.5 at 400k even though the raw API offers 1M.
+   * The model's CLI is the source of truth, not the raw API: the same model
+   * id can have different effective windows depending on which client speaks
+   * to it (Claude Code defaults to 1M; Microsoft Foundry routes still see
+   * 200k; Codex caps gpt-5.5 well below the 1M raw API offer). The values
+   * here mirror what each CLI reports back to the user in its own usage UI,
+   * so Houston's % matches what users see when they run the bare CLI.
    */
   contextWindow?: number;
 }
@@ -84,9 +88,12 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         label: "GPT-5.5",
         description: "OpenAI's frontier model.",
         effortLevels: ["low", "medium", "high", "xhigh"],
-        // Codex caps gpt-5.5 at 400k total context (272k input + 128k
-        // reserved output) even though the raw API exposes 1M.
-        contextWindow: 400_000,
+        // Codex CLI's enforced cap is 272k input — the input portion of a
+        // 400k total split (272k input + 128k reserved output). The raw
+        // OpenAI API offers 1M but Codex never serves that. Matches the
+        // ceiling Codex's own UI reports back (~258k post-95% safety
+        // multiplier, but the hard limit IS 272k).
+        contextWindow: 272_000,
       },
     ],
     defaultModel: "gpt-5.5",
@@ -106,7 +113,15 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         description: "Best balance of speed and quality.",
         // Sonnet 4.6: has `max`, no `xhigh`.
         effortLevels: ["low", "medium", "high", "max"],
-        contextWindow: 200_000,
+        // Claude Code 2.1+ defaults Sonnet 4.6 / Opus 4.7 / Opus 4.8 to the
+        // 1M-token window on the Anthropic API + Bedrock + Vertex routes
+        // (the routes the bundled Claude CLI uses for OAuth + ANTHROPIC_API_KEY
+        // auth, i.e. every Houston user we ship to today). Microsoft Foundry
+        // routes still cap at 200k, but `claude -p` never speaks to Foundry
+        // and the stream-json `system init` event carries no window field,
+        // so we encode the Claude-Code-default 1M. Houston's % indicator
+        // matches what `/context` shows in the bare CLI.
+        contextWindow: 1_000_000,
       },
       {
         id: "claude-opus-4-8",
@@ -115,7 +130,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         // Opus 4.8: full range (same as 4.7). NOTE: `ultracode` is a Claude
         // Code harness mode, NOT an effort level — never add it here.
         effortLevels: ["low", "medium", "high", "xhigh", "max"],
-        contextWindow: 200_000,
+        contextWindow: 1_000_000,
       },
       {
         id: "claude-opus-4-7",
@@ -123,7 +138,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         description: "Previous flagship. Very capable, slower.",
         // Opus 4.7: full range.
         effortLevels: ["low", "medium", "high", "xhigh", "max"],
-        contextWindow: 200_000,
+        contextWindow: 1_000_000,
       },
     ],
     defaultModel: "claude-sonnet-4-6",

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -22,19 +22,29 @@ export interface ModelOption {
    */
   effortLevels?: readonly EffortLevel[];
   /**
-   * Maximum context-window size in tokens, as the model's CLI actually
-   * behaves at runtime (i.e. the number to divide live `usage.context_tokens`
-   * by). Drives the composer context-usage indicator. Omit when unknown so
-   * the indicator falls back to a raw token count instead of a misleading %.
-   *
-   * The model's CLI is the source of truth, not the raw API: the same model
-   * id can have different effective windows depending on which client speaks
-   * to it (Claude Code defaults to 1M; Microsoft Foundry routes still see
-   * 200k; Codex caps gpt-5.5 well below the 1M raw API offer). The values
-   * here mirror what each CLI reports back to the user in its own usage UI,
-   * so Houston's % matches what users see when they run the bare CLI.
+   * Default assumed context window (tokens) — the denominator the composer's
+   * context-usage indicator STARTS with. The real window is plan/credit-gated
+   * and is NOT reported by `claude -p` (verified: the stream's `system init`
+   * event carries only `model`, no window; no flag, no env var). Specifically:
+   *   - Opus 4.x: 1M only on Max/Team/Enterprise (automatic) or with usage
+   *     credits; 200k on Pro without credits.
+   *   - Sonnet 4.6: 200k unless usage credits are enabled (on every plan).
+   *   - Codex caps gpt-5.5 at ~272k regardless of the 1M raw API offer.
+   * So this is an estimate. The indicator snaps UP to `contextWindowMax` once
+   * a session's observed usage exceeds this default, which PROVES the real
+   * window is larger (Claude Code auto-compacts before the limit, so observed
+   * usage can never exceed the true window). Omit to hide the % and show a raw
+   * token count instead.
    */
   contextWindow?: number;
+  /**
+   * Snap-up ceiling (tokens) for the self-correcting estimate. When a
+   * session's observed usage exceeds `contextWindow`, the indicator switches
+   * the denominator to this value. Defaults to `contextWindow` when omitted
+   * (no snapping). Set above `contextWindow` only for models whose window is
+   * gated upward at runtime — e.g. Sonnet 4.6 (200k default → 1M with credits).
+   */
+  contextWindowMax?: number;
 }
 
 /**
@@ -90,9 +100,8 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         effortLevels: ["low", "medium", "high", "xhigh"],
         // Codex CLI's enforced cap is 272k input — the input portion of a
         // 400k total split (272k input + 128k reserved output). The raw
-        // OpenAI API offers 1M but Codex never serves that. Matches the
-        // ceiling Codex's own UI reports back (~258k post-95% safety
-        // multiplier, but the hard limit IS 272k).
+        // OpenAI API offers 1M but Codex never serves that. Not plan-laddered
+        // like Claude, so no snap-up ceiling.
         contextWindow: 272_000,
       },
     ],
@@ -113,15 +122,12 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         description: "Best balance of speed and quality.",
         // Sonnet 4.6: has `max`, no `xhigh`.
         effortLevels: ["low", "medium", "high", "max"],
-        // Claude Code 2.1+ defaults Sonnet 4.6 / Opus 4.7 / Opus 4.8 to the
-        // 1M-token window on the Anthropic API + Bedrock + Vertex routes
-        // (the routes the bundled Claude CLI uses for OAuth + ANTHROPIC_API_KEY
-        // auth, i.e. every Houston user we ship to today). Microsoft Foundry
-        // routes still cap at 200k, but `claude -p` never speaks to Foundry
-        // and the stream-json `system init` event carries no window field,
-        // so we encode the Claude-Code-default 1M. Houston's % indicator
-        // matches what `/context` shows in the bare CLI.
-        contextWindow: 1_000_000,
+        // Sonnet 4.6 in Claude Code defaults to 200k on EVERY plan; the
+        // 1M window is opt-in via usage credits (`/extra-usage`) and is NOT
+        // part of any automatic upgrade. So start at 200k and snap to 1M only
+        // once observed usage proves the credits-enabled window is active.
+        contextWindow: 200_000,
+        contextWindowMax: 1_000_000,
       },
       {
         id: "claude-opus-4-8",
@@ -130,13 +136,17 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         // Opus 4.8: full range (same as 4.7). NOTE: `ultracode` is a Claude
         // Code harness mode, NOT an effort level — never add it here.
         effortLevels: ["low", "medium", "high", "xhigh", "max"],
+        // Opus 4.x auto-upgrades to 1M on Max/Team/Enterprise (the power-user
+        // default; matches what `/context` shows there). Pro WITHOUT usage
+        // credits actually runs 200k — the one case this over-estimates, and
+        // it can't self-correct downward, so the dialog flags it as estimated.
         contextWindow: 1_000_000,
       },
       {
         id: "claude-opus-4-7",
         label: "Opus 4.7",
         description: "Previous flagship. Very capable, slower.",
-        // Opus 4.7: full range.
+        // Opus 4.7: full range. Same 1M-on-Max default as Opus 4.8 above.
         effortLevels: ["low", "medium", "high", "xhigh", "max"],
         contextWindow: 1_000_000,
       },
@@ -160,18 +170,32 @@ export function getDefaultModel(providerId: string): string {
   return getProvider(providerId)?.defaultModel ?? "claude-sonnet-4-6";
 }
 
+/** Default + snap-up ceiling for a model's context window (tokens). */
+export interface ContextWindowConfig {
+  /** Starting denominator for the usage indicator (the estimate). */
+  default: number;
+  /** Snap-up ceiling once observed usage proves a larger window. */
+  max: number;
+}
+
 /**
- * Max context-window size (tokens) for a provider+model, or `undefined` when
- * the model is unknown or its window isn't catalogued. Drives the composer
- * context-usage indicator: the caller shows a percentage when a window is
- * known and falls back to a raw token count otherwise.
+ * Context-window config for a provider+model, or `undefined` when the model is
+ * unknown or its window isn't catalogued (the indicator then shows a raw token
+ * count instead of a %). `max` falls back to `default` when the model has no
+ * upward gating. See `effectiveContextWindow` for how the two combine with a
+ * session's observed usage.
  */
-export function getContextWindow(
+export function getContextWindowConfig(
   providerId: string | null | undefined,
   modelId: string | null | undefined,
-): number | undefined {
+): ContextWindowConfig | undefined {
   if (!providerId || !modelId) return undefined;
-  return getModel(providerId, modelId)?.contextWindow;
+  const model = getModel(providerId, modelId);
+  if (model?.contextWindow == null) return undefined;
+  return {
+    default: model.contextWindow,
+    max: model.contextWindowMax ?? model.contextWindow,
+  };
 }
 
 /**

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -98,11 +98,17 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         label: "GPT-5.5",
         description: "OpenAI's frontier model.",
         effortLevels: ["low", "medium", "high", "xhigh"],
-        // Codex CLI's enforced cap is 272k input — the input portion of a
-        // 400k total split (272k input + 128k reserved output). The raw
-        // OpenAI API offers 1M but Codex never serves that. Not plan-laddered
-        // like Claude, so no snap-up ceiling.
-        contextWindow: 272_000,
+        // Codex's EFFECTIVE window = raw context_window (272k) x
+        // effective_context_window_percent (95%) = 258_400. Confirmed in
+        // Codex's own models_cache.json and the rollout's `model_context_window`
+        // — it's the number Codex `/status` shows, so it's what we divide by.
+        // The opt-in 1M gpt-5.5 variant maxes at 1_000_000 x 95% = 950_000, the
+        // snap-up ceiling reached only when observed usage exceeds 258_400
+        // (analogous to Claude's credit-gated 1M). The numerator comes from the
+        // rollout's last_token_usage (see engine `codex_rollout`), not the
+        // cumulative `turn.completed.usage`.
+        contextWindow: 258_400,
+        contextWindowMax: 950_000,
       },
     ],
     defaultModel: "gpt-5.5",

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -21,6 +21,16 @@ export interface ModelOption {
    * effort row (e.g. Gemini, Haiku).
    */
   effortLevels?: readonly EffortLevel[];
+  /**
+   * Maximum context-window size in tokens, as it behaves inside the model's
+   * CLI. Drives the composer context-usage indicator (used tokens ÷ window).
+   * Omit when the window isn't known for a model so the indicator degrades to
+   * a raw token count instead of showing a misleading percentage.
+   *
+   * Houston runs Claude at the standard 200k window (not the 1M beta). Codex
+   * caps gpt-5.5 at 400k even though the raw API offers 1M.
+   */
+  contextWindow?: number;
 }
 
 /**
@@ -74,6 +84,9 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         label: "GPT-5.5",
         description: "OpenAI's frontier model.",
         effortLevels: ["low", "medium", "high", "xhigh"],
+        // Codex caps gpt-5.5 at 400k total context (272k input + 128k
+        // reserved output) even though the raw API exposes 1M.
+        contextWindow: 400_000,
       },
     ],
     defaultModel: "gpt-5.5",
@@ -93,6 +106,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         description: "Best balance of speed and quality.",
         // Sonnet 4.6: has `max`, no `xhigh`.
         effortLevels: ["low", "medium", "high", "max"],
+        contextWindow: 200_000,
       },
       {
         id: "claude-opus-4-8",
@@ -101,6 +115,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         // Opus 4.8: full range (same as 4.7). NOTE: `ultracode` is a Claude
         // Code harness mode, NOT an effort level — never add it here.
         effortLevels: ["low", "medium", "high", "xhigh", "max"],
+        contextWindow: 200_000,
       },
       {
         id: "claude-opus-4-7",
@@ -108,6 +123,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         description: "Previous flagship. Very capable, slower.",
         // Opus 4.7: full range.
         effortLevels: ["low", "medium", "high", "xhigh", "max"],
+        contextWindow: 200_000,
       },
     ],
     defaultModel: "claude-sonnet-4-6",
@@ -127,6 +143,20 @@ export function getModel(providerId: string, modelId: string): ModelOption | und
 /** Get the default provider + model for a provider id. */
 export function getDefaultModel(providerId: string): string {
   return getProvider(providerId)?.defaultModel ?? "claude-sonnet-4-6";
+}
+
+/**
+ * Max context-window size (tokens) for a provider+model, or `undefined` when
+ * the model is unknown or its window isn't catalogued. Drives the composer
+ * context-usage indicator: the caller shows a percentage when a window is
+ * known and falls back to a raw token count otherwise.
+ */
+export function getContextWindow(
+  providerId: string | null | undefined,
+  modelId: string | null | undefined,
+): number | undefined {
+  if (!providerId || !modelId) return undefined;
+  return getModel(providerId, modelId)?.contextWindow;
 }
 
 /**

--- a/app/src/locales/en/context.json
+++ b/app/src/locales/en/context.json
@@ -11,6 +11,7 @@
     "usedOfTotal": "{{used}} of {{total}} tokens",
     "tokensUsed": "{{used}} tokens used",
     "free": "{{free}} free",
+    "estimated": "Estimated. Your plan's actual context window may differ.",
     "cached": "Reused from cache",
     "lastReply": "Last reply",
     "empty": "Send a message and the context usage will show up here.",

--- a/app/src/locales/en/context.json
+++ b/app/src/locales/en/context.json
@@ -1,0 +1,20 @@
+{
+  "button": {
+    "aria": "Open context usage",
+    "label": "Context"
+  },
+  "dialog": {
+    "title": "Context usage",
+    "subtitle": "How full {{model}}'s memory is for this conversation.",
+    "subtitleNoModel": "How full the memory is for this conversation.",
+    "percentFull": "{{percent}}% full",
+    "usedOfTotal": "{{used}} of {{total}} tokens",
+    "tokensUsed": "{{used}} tokens used",
+    "free": "{{free}} free",
+    "cached": "Reused from cache",
+    "lastReply": "Last reply",
+    "empty": "Send a message and the context usage will show up here.",
+    "unknownWindow": "The context size for this model is not known yet, so the amount used is shown without a percentage.",
+    "close": "Close"
+  }
+}

--- a/app/src/locales/es/context.json
+++ b/app/src/locales/es/context.json
@@ -11,6 +11,7 @@
     "usedOfTotal": "{{used}} de {{total}} tokens",
     "tokensUsed": "{{used}} tokens usados",
     "free": "{{free}} libres",
+    "estimated": "Estimado. La ventana de contexto real de tu plan puede variar.",
     "cached": "Reutilizado de la caché",
     "lastReply": "Última respuesta",
     "empty": "Envía un mensaje y el uso del contexto aparecerá aquí.",

--- a/app/src/locales/es/context.json
+++ b/app/src/locales/es/context.json
@@ -1,0 +1,20 @@
+{
+  "button": {
+    "aria": "Abrir uso del contexto",
+    "label": "Contexto"
+  },
+  "dialog": {
+    "title": "Uso del contexto",
+    "subtitle": "Qué tan llena está la memoria de {{model}} para esta conversación.",
+    "subtitleNoModel": "Qué tan llena está la memoria para esta conversación.",
+    "percentFull": "{{percent}}% lleno",
+    "usedOfTotal": "{{used}} de {{total}} tokens",
+    "tokensUsed": "{{used}} tokens usados",
+    "free": "{{free}} libres",
+    "cached": "Reutilizado de la caché",
+    "lastReply": "Última respuesta",
+    "empty": "Envía un mensaje y el uso del contexto aparecerá aquí.",
+    "unknownWindow": "Todavía no se conoce el tamaño del contexto de este modelo, así que la cantidad usada se muestra sin porcentaje.",
+    "close": "Cerrar"
+  }
+}

--- a/app/src/locales/pt/context.json
+++ b/app/src/locales/pt/context.json
@@ -11,6 +11,7 @@
     "usedOfTotal": "{{used}} de {{total}} tokens",
     "tokensUsed": "{{used}} tokens usados",
     "free": "{{free}} livres",
+    "estimated": "Estimado. A janela de contexto real do seu plano pode variar.",
     "cached": "Reaproveitado do cache",
     "lastReply": "Última resposta",
     "empty": "Envie uma mensagem e o uso do contexto vai aparecer aqui.",

--- a/app/src/locales/pt/context.json
+++ b/app/src/locales/pt/context.json
@@ -1,0 +1,20 @@
+{
+  "button": {
+    "aria": "Abrir uso do contexto",
+    "label": "Contexto"
+  },
+  "dialog": {
+    "title": "Uso do contexto",
+    "subtitle": "O quão cheia está a memória do {{model}} para esta conversa.",
+    "subtitleNoModel": "O quão cheia está a memória para esta conversa.",
+    "percentFull": "{{percent}}% cheio",
+    "usedOfTotal": "{{used}} de {{total}} tokens",
+    "tokensUsed": "{{used}} tokens usados",
+    "free": "{{free}} livres",
+    "cached": "Reaproveitado do cache",
+    "lastReply": "Última resposta",
+    "empty": "Envie uma mensagem e o uso do contexto vai aparecer aqui.",
+    "unknownWindow": "O tamanho do contexto deste modelo ainda não é conhecido, então a quantidade usada aparece sem porcentagem.",
+    "close": "Fechar"
+  }
+}

--- a/app/src/types/react-i18next.d.ts
+++ b/app/src/types/react-i18next.d.ts
@@ -23,6 +23,7 @@ import type providers from "../locales/en/providers.json";
 import type errors from "../locales/en/errors.json";
 import type events from "../locales/en/events.json";
 import type portable from "../locales/en/portable.json";
+import type context from "../locales/en/context.json";
 
 declare module "react-i18next" {
   interface CustomTypeOptions {
@@ -44,6 +45,7 @@ declare module "react-i18next" {
       errors: typeof errors;
       events: typeof events;
       portable: typeof portable;
+      context: typeof context;
     };
   }
 }

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -421,9 +421,13 @@ fn serialize_for_persist(item: &FeedItem) -> Option<(String, String)> {
             result,
             cost_usd,
             duration_ms,
+            usage,
         } => {
+            // `usage` serializes to its TokenUsage object (or null) so the
+            // context-usage indicator survives a history reload, same as the
+            // live FeedItem event.
             let data = serde_json::json!({
-                "result": result, "cost_usd": cost_usd, "duration_ms": duration_ms
+                "result": result, "cost_usd": cost_usd, "duration_ms": duration_ms, "usage": usage
             });
             Some(("final_result".into(), data.to_string()))
         }
@@ -668,5 +672,43 @@ mod tests {
 
         assert_eq!(feed_type, "tool_runtime_error");
         assert_eq!(data, r#"{"details":"exec failed","kind":"local_tool"}"#);
+    }
+
+    #[test]
+    fn final_result_persists_token_usage_for_history() {
+        // The context-usage indicator reads usage back from history on reload,
+        // so the persisted JSON must carry the TokenUsage object.
+        let item = FeedItem::FinalResult {
+            result: "Done".to_string(),
+            cost_usd: Some(0.01),
+            duration_ms: Some(1200),
+            usage: Some(houston_terminal_manager::TokenUsage {
+                context_tokens: 151_500,
+                output_tokens: 420,
+                cached_tokens: 150_000,
+            }),
+        };
+
+        let (feed_type, data) = serialize_for_persist(&item).expect("serializes");
+
+        assert_eq!(feed_type, "final_result");
+        let parsed: serde_json::Value = serde_json::from_str(&data).unwrap();
+        assert_eq!(parsed["usage"]["context_tokens"], 151_500);
+        assert_eq!(parsed["usage"]["cached_tokens"], 150_000);
+        assert_eq!(parsed["usage"]["output_tokens"], 420);
+    }
+
+    #[test]
+    fn final_result_without_usage_persists_null() {
+        let item = FeedItem::FinalResult {
+            result: "Done".to_string(),
+            cost_usd: None,
+            duration_ms: None,
+            usage: None,
+        };
+
+        let (_, data) = serialize_for_persist(&item).expect("serializes");
+        let parsed: serde_json::Value = serde_json::from_str(&data).unwrap();
+        assert!(parsed["usage"].is_null());
     }
 }

--- a/engine/houston-terminal-manager/src/codex_parser.rs
+++ b/engine/houston-terminal-manager/src/codex_parser.rs
@@ -6,7 +6,7 @@
 use super::auth_error::{is_auth_retry_noise, AUTH_RETRY_MARKER};
 use super::provider::Provider;
 use super::provider_error_kind::ProviderError;
-use super::types::{FeedItem, TokenUsage};
+use super::types::FeedItem;
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -75,21 +75,6 @@ pub struct CodexUsage {
     pub input_tokens: Option<u64>,
     pub output_tokens: Option<u64>,
     pub cached_input_tokens: Option<u64>,
-}
-
-impl CodexUsage {
-    /// Normalize into the shared [`TokenUsage`]. Codex (like the OpenAI API)
-    /// reports `input_tokens` as the cache-INCLUSIVE prompt total, with
-    /// `cached_input_tokens` the cached subset — so the context-window size
-    /// is just `input_tokens`. (Contrast Anthropic, which splits the prompt
-    /// across three fields that must be summed.)
-    fn normalize(&self) -> TokenUsage {
-        TokenUsage {
-            context_tokens: self.input_tokens.unwrap_or(0),
-            output_tokens: self.output_tokens.unwrap_or(0),
-            cached_tokens: self.cached_input_tokens.unwrap_or(0),
-        }
-    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -191,11 +176,18 @@ pub fn parse_codex_event(line: &str, acc: &mut CodexAccumulator) -> Vec<FeedItem
             // Emit usage as FinalResult
             if let Some(usage) = &event.usage {
                 let total = usage.input_tokens.unwrap_or(0) + usage.output_tokens.unwrap_or(0);
+                // `turn.completed.usage` is the CUMULATIVE sum of every model
+                // request in the turn, NOT the context-window fill (a turn
+                // with N tool round-trips reports ~N× the real size). Leave
+                // `usage` None here; `session_io::read_codex_stdout` patches in
+                // the accurate last-request usage from the rollout once codex
+                // has exited and flushed it (see `codex_rollout`). The `result`
+                // text keeps the cumulative total for the (non-rendered) record.
                 items.push(FeedItem::FinalResult {
                     result: format!("{total} tokens used"),
                     cost_usd: None,
                     duration_ms: None,
-                    usage: Some(usage.normalize()),
+                    usage: None,
                 });
             }
             items
@@ -592,13 +584,13 @@ mod tests {
         assert_eq!(items.len(), 1);
         match &items[0] {
             FeedItem::FinalResult { result, usage, .. } => {
+                // `result` keeps the cumulative total for the record, but
+                // `usage` is intentionally None: the parser can't get the true
+                // context fill from the cumulative `turn.completed.usage`. The
+                // accurate value is patched in from the rollout by
+                // `session_io::read_codex_stdout` (see codex_rollout).
                 assert!(result.contains("24885"));
-                // Codex `input_tokens` is the cache-inclusive prompt total, so
-                // it maps straight to context_tokens (no summing).
-                let usage = usage.expect("codex turn carries usage");
-                assert_eq!(usage.context_tokens, 24763);
-                assert_eq!(usage.cached_tokens, 24448);
-                assert_eq!(usage.output_tokens, 122);
+                assert!(usage.is_none(), "cumulative turn usage must not be trusted as context fill");
             }
             other => panic!("expected FinalResult, got {other:?}"),
         }

--- a/engine/houston-terminal-manager/src/codex_parser.rs
+++ b/engine/houston-terminal-manager/src/codex_parser.rs
@@ -6,7 +6,7 @@
 use super::auth_error::{is_auth_retry_noise, AUTH_RETRY_MARKER};
 use super::provider::Provider;
 use super::provider_error_kind::ProviderError;
-use super::types::FeedItem;
+use super::types::{FeedItem, TokenUsage};
 use serde::Deserialize;
 use std::str::FromStr;
 
@@ -75,6 +75,21 @@ pub struct CodexUsage {
     pub input_tokens: Option<u64>,
     pub output_tokens: Option<u64>,
     pub cached_input_tokens: Option<u64>,
+}
+
+impl CodexUsage {
+    /// Normalize into the shared [`TokenUsage`]. Codex (like the OpenAI API)
+    /// reports `input_tokens` as the cache-INCLUSIVE prompt total, with
+    /// `cached_input_tokens` the cached subset — so the context-window size
+    /// is just `input_tokens`. (Contrast Anthropic, which splits the prompt
+    /// across three fields that must be summed.)
+    fn normalize(&self) -> TokenUsage {
+        TokenUsage {
+            context_tokens: self.input_tokens.unwrap_or(0),
+            output_tokens: self.output_tokens.unwrap_or(0),
+            cached_tokens: self.cached_input_tokens.unwrap_or(0),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -180,6 +195,7 @@ pub fn parse_codex_event(line: &str, acc: &mut CodexAccumulator) -> Vec<FeedItem
                     result: format!("{total} tokens used"),
                     cost_usd: None,
                     duration_ms: None,
+                    usage: Some(usage.normalize()),
                 });
             }
             items
@@ -575,8 +591,14 @@ mod tests {
         let items = parse_codex_event(line, &mut acc());
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::FinalResult { result, .. } => {
+            FeedItem::FinalResult { result, usage, .. } => {
                 assert!(result.contains("24885"));
+                // Codex `input_tokens` is the cache-inclusive prompt total, so
+                // it maps straight to context_tokens (no summing).
+                let usage = usage.expect("codex turn carries usage");
+                assert_eq!(usage.context_tokens, 24763);
+                assert_eq!(usage.cached_tokens, 24448);
+                assert_eq!(usage.output_tokens, 122);
             }
             other => panic!("expected FinalResult, got {other:?}"),
         }

--- a/engine/houston-terminal-manager/src/codex_rollout.rs
+++ b/engine/houston-terminal-manager/src/codex_rollout.rs
@@ -1,0 +1,194 @@
+//! Read accurate Codex context usage from the on-disk session rollout.
+//!
+//! `codex exec --json` only emits `turn.completed.usage`, which is the
+//! CUMULATIVE sum of every model request in the turn (a turn with N tool
+//! round-trips reports ~N× the real context size). The actual "current
+//! context fill" — the input size of the LAST model request — and the
+//! effective context window live only in the rollout's `token_count` events,
+//! never in the exec stdout stream.
+//!
+//! Codex writes a rollout per session at
+//! `$CODEX_HOME/sessions/<YYYY>/<MM>/<DD>/rollout-<ISO8601>-<thread_id>.jsonl`
+//! (CODEX_HOME defaults to `~/.codex`). Each `token_count` event carries
+//! `info.last_token_usage` (the last request) and `info.model_context_window`.
+//! We locate the newest rollout for the thread and read its last
+//! `token_count`, giving the same number Codex's own `/status` shows.
+//!
+//! This couples Houston to Codex's rollout format. It degrades gracefully:
+//! any failure (file missing, format change, parse error) returns `None`, and
+//! the caller leaves the Codex `FinalResult` usage unset rather than showing a
+//! wrong (summed) number.
+
+use crate::types::TokenUsage;
+use std::path::{Path, PathBuf};
+use std::time::SystemTime;
+
+/// The newest rollout for `thread_id`, parsed for its last `token_count`'s
+/// `last_token_usage` → normalized [`TokenUsage`]. `None` when the rollout
+/// can't be found, read, or parsed. Runs the blocking filesystem work on a
+/// blocking thread so it never stalls the async stream reader.
+pub async fn latest_usage(thread_id: &str) -> Option<TokenUsage> {
+    let thread_id = thread_id.to_string();
+    tokio::task::spawn_blocking(move || latest_usage_blocking(&thread_id))
+        .await
+        .ok()
+        .flatten()
+}
+
+fn latest_usage_blocking(thread_id: &str) -> Option<TokenUsage> {
+    let sessions = codex_sessions_dir()?;
+    let path = newest_rollout_for_thread(&sessions, thread_id)?;
+    let tail = read_rollout_tail(&path)?;
+    parse_last_token_count(&tail)
+}
+
+/// Bytes of the rollout tail to scan. `token_count` events are a few hundred
+/// bytes each and cluster at the end, so this covers the final turn's events
+/// without reading a long-lived thread's multi-MB rollout on every turn.
+const TAIL_BYTES: u64 = 64 * 1024;
+
+/// Read the last [`TAIL_BYTES`] of the file as lossy UTF-8. A truncated leading
+/// line is harmless — `parse_last_token_count` skips unparseable lines.
+fn read_rollout_tail(path: &Path) -> Option<String> {
+    use std::io::{Read, Seek, SeekFrom};
+    let mut file = std::fs::File::open(path).ok()?;
+    let len = file.metadata().ok()?.len();
+    let start = len.saturating_sub(TAIL_BYTES);
+    if start > 0 {
+        file.seek(SeekFrom::Start(start)).ok()?;
+    }
+    let mut buf = Vec::new();
+    file.read_to_end(&mut buf).ok()?;
+    Some(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// `$CODEX_HOME/sessions`, falling back to `~/.codex/sessions`. Houston spawns
+/// codex without overriding `CODEX_HOME`, so codex uses whatever the engine
+/// inherited (the user's env) or its default — mirror that here.
+fn codex_sessions_dir() -> Option<PathBuf> {
+    let home = std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".codex")))?;
+    Some(home.join("sessions"))
+}
+
+/// Walk the sessions tree for the newest rollout belonging to `thread_id`. A
+/// resumed thread may have several rollout files (one per `codex exec resume`
+/// invocation); the newest holds the most recent turn's usage.
+///
+/// Matches the exact filename grammar `rollout-<ISO8601>-<thread_id>.jsonl` by
+/// the trailing `-<thread_id>.jsonl` token, NOT a substring — UUIDv7 thread ids
+/// share timestamp prefixes, and Houston can run several codex agents against
+/// the one `~/.codex/sessions` tree, so a substring match could pick a
+/// concurrent session's rollout. Equal mtimes (coarse-granularity filesystems)
+/// break deterministically by filename: the leading ISO8601 timestamp sorts
+/// lexically by recency, so the genuinely-newest turn always wins.
+fn newest_rollout_for_thread(sessions_dir: &Path, thread_id: &str) -> Option<PathBuf> {
+    let suffix = format!("-{thread_id}.jsonl");
+    let mut best: Option<(SystemTime, String, PathBuf)> = None;
+    let mut stack = vec![sessions_dir.to_path_buf()];
+    while let Some(dir) = stack.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            if file_type.is_dir() {
+                stack.push(entry.path());
+                continue;
+            }
+            let name = entry.file_name();
+            let Some(name) = name.to_str() else { continue };
+            if !name.ends_with(&suffix) {
+                continue;
+            }
+            let mtime = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(SystemTime::UNIX_EPOCH);
+            let is_newer = match &best {
+                Some((best_mtime, best_name, _)) => {
+                    mtime > *best_mtime || (mtime == *best_mtime && name > best_name.as_str())
+                }
+                None => true,
+            };
+            if is_newer {
+                best = Some((mtime, name.to_string(), entry.path()));
+            }
+        }
+    }
+    best.map(|(_, _, path)| path)
+}
+
+/// Find the last `token_count` event in the rollout and read its
+/// `last_token_usage`. Scans from the end because token_count events cluster
+/// near the tail. `input_tokens` is the cache-inclusive prompt size of the
+/// last request, i.e. the context-window fill — same as Codex `/status`.
+fn parse_last_token_count(content: &str) -> Option<TokenUsage> {
+    for line in content.lines().rev() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        let payload = value.get("payload")?;
+        if payload.get("type").and_then(|t| t.as_str()) != Some("token_count") {
+            continue;
+        }
+        let last = payload.get("info")?.get("last_token_usage")?;
+        let field = |key: &str| last.get(key).and_then(|v| v.as_u64()).unwrap_or(0);
+        return Some(TokenUsage {
+            context_tokens: field("input_tokens"),
+            output_tokens: field("output_tokens"),
+            cached_tokens: field("cached_input_tokens"),
+        });
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Verbatim shapes from a real rollout (codex 0.130/0.135,
+    // ~/.codex/sessions/.../rollout-*.jsonl).
+    const TOKEN_COUNT_1: &str = r#"{"timestamp":"2026-06-01T19:07:19.451Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":75279,"cached_input_tokens":49664,"output_tokens":336,"reasoning_output_tokens":108,"total_tokens":75615},"last_token_usage":{"input_tokens":18954,"cached_input_tokens":6528,"output_tokens":198,"reasoning_output_tokens":73,"total_tokens":19152},"model_context_window":258400}}}"#;
+    const TOKEN_COUNT_2: &str = r#"{"timestamp":"2026-06-01T19:07:24.291Z","type":"event_msg","payload":{"type":"token_count","info":{"total_token_usage":{"input_tokens":94673,"cached_input_tokens":68480,"output_tokens":435,"reasoning_output_tokens":108,"total_tokens":95108},"last_token_usage":{"input_tokens":19394,"cached_input_tokens":18816,"output_tokens":99,"reasoning_output_tokens":0,"total_tokens":19493},"model_context_window":258400}}}"#;
+    const OTHER: &str = r#"{"timestamp":"2026-06-01T19:07:12.986Z","type":"event_msg","payload":{"type":"task_started","turn_id":"t1","model_context_window":258400}}"#;
+
+    #[test]
+    fn reads_last_token_count_not_cumulative() {
+        let content = format!("{OTHER}\n{TOKEN_COUNT_1}\n{TOKEN_COUNT_2}\n");
+        let usage = parse_last_token_count(&content).expect("parses");
+        // The LAST token_count's last_token_usage — the real context fill —
+        // NOT the cumulative total (94673) the exec stream reports.
+        assert_eq!(usage.context_tokens, 19394);
+        assert_eq!(usage.cached_tokens, 18816);
+        assert_eq!(usage.output_tokens, 99);
+    }
+
+    #[test]
+    fn picks_final_token_count_when_trailing_non_token_lines() {
+        // A trailing task_complete line after the last token_count must not
+        // hide the usage — reverse scan skips non-token_count lines.
+        let content = format!("{TOKEN_COUNT_1}\n{TOKEN_COUNT_2}\n{OTHER}\n");
+        let usage = parse_last_token_count(&content).expect("parses");
+        assert_eq!(usage.context_tokens, 19394);
+    }
+
+    #[test]
+    fn none_when_no_token_count() {
+        let content = format!("{OTHER}\n{OTHER}\n");
+        assert!(parse_last_token_count(&content).is_none());
+    }
+
+    #[test]
+    fn none_on_garbage() {
+        assert!(parse_last_token_count("not json\n\n").is_none());
+        assert!(parse_last_token_count("").is_none());
+    }
+}

--- a/engine/houston-terminal-manager/src/gemini_parser_state.rs
+++ b/engine/houston-terminal-manager/src/gemini_parser_state.rs
@@ -149,6 +149,11 @@ fn handle_result(
         // Gemini emits no cost field — see schema findings §3.
         cost_usd: None,
         duration_ms,
+        // Context-usage indicator covers Anthropic + Codex for now. Gemini is
+        // a "coming soon" provider with no published context-window size in
+        // the model catalog, so we leave usage unset until it ships (the token
+        // stats are already in `stats` and can be normalized then).
+        usage: None,
     });
     items
 }
@@ -344,9 +349,10 @@ mod tests {
         let items = parse_gemini_event(RESULT_OK, &mut acc());
         assert_eq!(items.len(), 1);
         match &items[0] {
-            FeedItem::FinalResult { result, cost_usd, duration_ms } => {
+            FeedItem::FinalResult { result, cost_usd, duration_ms, usage } => {
                 assert_eq!(*duration_ms, Some(1200));
                 assert!(cost_usd.is_none(), "gemini emits no cost field");
+                assert!(usage.is_none(), "gemini usage not wired yet");
                 assert!(result.contains("100 tokens"));
             }
             other => panic!("expected FinalResult, got {other:?}"),

--- a/engine/houston-terminal-manager/src/lib.rs
+++ b/engine/houston-terminal-manager/src/lib.rs
@@ -10,6 +10,7 @@ mod claude_runner;
 mod cli_process;
 mod codex_command;
 pub mod codex_parser;
+pub mod codex_rollout;
 mod codex_runner;
 pub mod concurrency;
 pub mod gemini_home;

--- a/engine/houston-terminal-manager/src/lib.rs
+++ b/engine/houston-terminal-manager/src/lib.rs
@@ -42,5 +42,5 @@ pub use provider_error_kind::{
 pub use session_update::SessionUpdate;
 pub use types::{
     ClaudeEvent, ContentBlock, FeedItem, FileChanges, SessionFeedBuffer, SessionStatus,
-    ToolRuntimeErrorKind,
+    TokenUsage, ToolRuntimeErrorKind,
 };

--- a/engine/houston-terminal-manager/src/parser.rs
+++ b/engine/houston-terminal-manager/src/parser.rs
@@ -2,7 +2,9 @@ use std::collections::HashMap;
 
 use super::provider::anthropic_classify;
 use super::provider_error_kind::{truncate_excerpt, ProviderError};
-use super::types::{AssistantMessage, ClaudeEvent, ContentBlock, FeedItem, UserMessage};
+use super::types::{
+    AssistantMessage, ClaudeEvent, ContentBlock, FeedItem, TokenUsage, UserMessage,
+};
 
 const ANTHROPIC: &str = "anthropic";
 
@@ -17,6 +19,16 @@ pub struct StreamAccumulator {
     text_buffer: String,
     /// Accumulated thinking across all thinking content blocks.
     thinking_buffer: String,
+    /// Token usage from the most recent (non-partial) assistant message.
+    /// The last assistant message of a turn carries the full prompt size of
+    /// the final API request, so this is the authoritative context-window
+    /// reading. Attached to `FinalResult` when the turn's `result` arrives.
+    ///
+    /// A `StreamAccumulator` is recreated per subprocess (see
+    /// `session_io::read_claude_stdout`), and Claude runs one process per
+    /// turn, so this never carries a stale reading into a later turn — the
+    /// success path also `.take()`s it for hygiene.
+    last_usage: Option<TokenUsage>,
 }
 
 #[derive(Debug)]
@@ -154,6 +166,12 @@ pub fn parse_event(line: &str, acc: &mut StreamAccumulator) -> Vec<FeedItem> {
             if subtype.as_deref() != Some("partial") {
                 acc.text_buffer.clear();
                 acc.thinking_buffer.clear();
+                // Capture this request's usage. Later assistant messages in
+                // the same turn overwrite it, so the final one wins —
+                // exactly the context-window size we want to report.
+                if let Some(usage) = message.as_ref().and_then(|m| m.usage) {
+                    acc.last_usage = Some(usage.normalize());
+                }
             }
             parse_assistant_event(subtype.as_deref(), message)
         }
@@ -164,6 +182,7 @@ pub fn parse_event(line: &str, acc: &mut StreamAccumulator) -> Vec<FeedItem> {
             is_error,
             cost_usd,
             duration_ms,
+            usage: result_usage,
             ..
         } => {
             if subtype.as_deref() == Some("error") || is_error == Some(true) {
@@ -183,10 +202,19 @@ pub fn parse_event(line: &str, acc: &mut StreamAccumulator) -> Vec<FeedItem> {
                     });
                 return vec![FeedItem::ProviderError(typed)];
             }
+            // Prefer the per-request usage captured from the last assistant
+            // message (the true context-window size); fall back to the
+            // terminal event's own usage block when no assistant message
+            // carried one.
+            let usage = acc
+                .last_usage
+                .take()
+                .or_else(|| result_usage.map(|u| u.normalize()));
             vec![FeedItem::FinalResult {
                 result: result.unwrap_or_default(),
                 cost_usd,
                 duration_ms,
+                usage,
             }]
         }
         ClaudeEvent::StreamEvent { event: inner, .. } => acc.handle(inner),
@@ -578,5 +606,62 @@ mod tests {
             FeedItem::ProviderError(_) => {}
             other => panic!("expected ProviderError, got {other:?}"),
         }
+    }
+
+    fn final_result_usage(items: &[FeedItem]) -> Option<TokenUsage> {
+        items.iter().find_map(|i| match i {
+            FeedItem::FinalResult { usage, .. } => *usage,
+            _ => None,
+        })
+    }
+
+    #[test]
+    fn assistant_usage_is_attached_to_final_result() {
+        let mut a = acc();
+        // Final assistant message carrying Anthropic's four-way usage block.
+        let assistant = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":1200,"cache_creation_input_tokens":300,"cache_read_input_tokens":150000,"output_tokens":420}}}"#;
+        let _ = parse_event(assistant, &mut a);
+        let result = r#"{"type":"result","result":"Done","session_id":"s1"}"#;
+        let usage =
+            final_result_usage(&parse_event(result, &mut a)).expect("final result carries usage");
+        // context = input + cache_creation + cache_read (all occupy the window).
+        assert_eq!(usage.context_tokens, 1200 + 300 + 150_000);
+        assert_eq!(usage.cached_tokens, 150_000);
+        assert_eq!(usage.output_tokens, 420);
+    }
+
+    #[test]
+    fn last_assistant_usage_wins_within_a_turn() {
+        let mut a = acc();
+        // Two assistant messages (e.g. a tool round-trip): the second has the
+        // larger, more complete context and must be the one reported.
+        let first = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"step"}],"usage":{"input_tokens":1000,"cache_read_input_tokens":0,"output_tokens":10}}}"#;
+        let second = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"done"}],"usage":{"input_tokens":50,"cache_read_input_tokens":2000,"output_tokens":80}}}"#;
+        let _ = parse_event(first, &mut a);
+        let _ = parse_event(second, &mut a);
+        let usage = final_result_usage(&parse_event(
+            r#"{"type":"result","result":"Done"}"#,
+            &mut a,
+        ))
+        .expect("usage present");
+        assert_eq!(usage.context_tokens, 50 + 2000);
+    }
+
+    #[test]
+    fn result_usage_used_when_no_assistant_usage() {
+        // No assistant message this turn — fall back to the terminal event's
+        // own usage block so the indicator still updates.
+        let line = r#"{"type":"result","result":"Done","usage":{"input_tokens":10,"cache_read_input_tokens":90000,"output_tokens":50}}"#;
+        let usage = final_result_usage(&parse_event(line, &mut acc()))
+            .expect("usage from result event");
+        assert_eq!(usage.context_tokens, 10 + 90_000);
+        assert_eq!(usage.cached_tokens, 90_000);
+        assert_eq!(usage.output_tokens, 50);
+    }
+
+    #[test]
+    fn final_result_without_any_usage_is_none() {
+        let line = r#"{"type":"result","result":"Done","session_id":"s1"}"#;
+        assert!(final_result_usage(&parse_event(line, &mut acc())).is_none());
     }
 }

--- a/engine/houston-terminal-manager/src/session_io.rs
+++ b/engine/houston-terminal-manager/src/session_io.rs
@@ -215,19 +215,51 @@ async fn read_codex_stdout(
     let mut line_count = 0u64;
     let mut item_count = 0u64;
     let mut report = StdoutReadReport::default();
+    // Codex thread id (from `thread.started`) — used to locate the rollout for
+    // accurate context usage once the stream ends.
+    let mut thread_id: Option<String> = None;
+    // The terminal FinalResult is held back until the stream ends: its accurate
+    // context usage lives in the rollout, which codex only fully flushes when
+    // it exits (stdout EOF → this loop breaks). codex exec emits exactly one
+    // turn.completed, so keeping the last one is sufficient.
+    let mut final_result: Option<FeedItem> = None;
     while let Ok(Some(line)) = lines.next_line().await {
         line_count += 1;
         let line_type = line.trim().chars().take(80).collect::<String>();
         tracing::debug!("[houston:stdout:codex] line {line_count}: {line_type}");
 
         if let Some(tid) = codex_parser::extract_thread_id(&line) {
+            thread_id = Some(tid.clone());
             let _ = tx.send(SessionUpdate::SessionId(tid));
         }
-        let items = codex_parser::parse_codex_event(&line, &mut acc);
+        let mut items = codex_parser::parse_codex_event(&line, &mut acc);
         mark_auth_error(&items, &mut report);
         mark_model_unsupported(&items, &mut report);
+        if let Some(pos) = items
+            .iter()
+            .position(|item| matches!(item, FeedItem::FinalResult { .. }))
+        {
+            final_result = Some(items.remove(pos));
+        }
         item_count += log_and_send(&tx, items);
     }
+
+    // Stream ended → codex has exited and flushed its rollout. Patch the held
+    // FinalResult with the accurate last-request usage, then emit it. On any
+    // failure the usage stays None (indicator shows no %, never a wrong summed
+    // number). See `codex_rollout` for why the exec stream alone can't give us
+    // this.
+    if let Some(mut fr) = final_result {
+        if let FeedItem::FinalResult { usage, .. } = &mut fr {
+            if let Some(tid) = thread_id.as_deref() {
+                if let Some(accurate) = crate::codex_rollout::latest_usage(tid).await {
+                    *usage = Some(accurate);
+                }
+            }
+        }
+        item_count += log_and_send(&tx, vec![fr]);
+    }
+
     tracing::debug!(
         "[houston:stdout:codex] stream ended. {line_count} lines, {item_count} feed items"
     );

--- a/engine/houston-terminal-manager/src/types.rs
+++ b/engine/houston-terminal-manager/src/types.rs
@@ -34,6 +34,9 @@ pub enum ClaudeEvent {
         cost_usd: Option<f64>,
         duration_ms: Option<u64>,
         session_id: Option<String>,
+        /// Cumulative-turn token usage on the terminal event. Used as a
+        /// fallback when no assistant message carried per-request usage.
+        usage: Option<ClaudeUsageRaw>,
         #[serde(flatten)]
         extra: serde_json::Value,
     },
@@ -81,8 +84,47 @@ pub struct StreamDelta {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AssistantMessage {
     pub content: Option<Vec<ContentBlock>>,
+    /// Per-request token usage Anthropic attaches to each assistant message.
+    /// The final assistant message of a turn reports the full prompt size of
+    /// the last API request — i.e. how much of the context window was used.
+    pub usage: Option<ClaudeUsageRaw>,
     #[serde(flatten)]
     pub extra: serde_json::Value,
+}
+
+/// Raw Anthropic `usage` block, as it appears on `assistant` messages and
+/// the terminal `result` event. Fields default to 0 when absent so an older
+/// CLI that omits a key (e.g. no cache fields) still deserializes. Normalized
+/// into the provider-agnostic [`TokenUsage`] before it reaches the feed.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
+pub struct ClaudeUsageRaw {
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_input_tokens: u64,
+    #[serde(default)]
+    pub cache_read_input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+}
+
+impl ClaudeUsageRaw {
+    /// Collapse Anthropic's four-way split into the shared [`TokenUsage`].
+    ///
+    /// Anthropic reports `input_tokens` as the NON-cached fresh input only;
+    /// `cache_read_input_tokens` and `cache_creation_input_tokens` are the
+    /// cached-reuse and cache-write portions. All three occupy the context
+    /// window, so the prompt size = their sum. (Contrast Codex, whose
+    /// `input_tokens` is already the cache-inclusive total.)
+    pub fn normalize(&self) -> TokenUsage {
+        TokenUsage {
+            context_tokens: self.input_tokens
+                + self.cache_creation_input_tokens
+                + self.cache_read_input_tokens,
+            output_tokens: self.output_tokens,
+            cached_tokens: self.cache_read_input_tokens,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -113,6 +155,21 @@ pub enum ContentBlock {
     },
     #[serde(other)]
     Unknown,
+}
+
+/// Provider-agnostic token usage for a completed turn, normalized from each
+/// provider's native `usage` shape (Anthropic's four-way cache split, Codex's
+/// cache-inclusive totals, ...). Drives the chat context-usage indicator.
+///
+/// `context_tokens` is the headline number: the size of the prompt on the
+/// most recent model request, i.e. how much of the context window is in use.
+/// `cached_tokens` (a subset of `context_tokens`) and `output_tokens` are
+/// informational detail for the dialog.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct TokenUsage {
+    pub context_tokens: u64,
+    pub output_tokens: u64,
+    pub cached_tokens: u64,
 }
 
 /// Visible files created or modified during a session.
@@ -185,6 +242,10 @@ pub enum FeedItem {
         result: String,
         cost_usd: Option<f64>,
         duration_ms: Option<u64>,
+        /// Normalized token usage for the turn, when the provider reported it.
+        /// Feeds the chat context-usage indicator; `None` for providers that
+        /// don't surface usage yet.
+        usage: Option<TokenUsage>,
     },
     /// Visible files created or changed during the session.
     FileChanges(FileChanges),

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -385,13 +385,30 @@ sums its three-way split (`input + cache_creation + cache_read`), Codex's
 `input_tokens` is already cache-inclusive so it maps straight through. The
 desktop composer's context-usage indicator (`app/src/components/context-
 indicator.tsx`) divides `context_tokens` by the model's `contextWindow`
-(`app/src/lib/providers.ts`, Claude 200k / gpt-5.5 400k) for a "% full"
-gauge; it reads the latest such item via `latestContextUsage` so it works
-both live and after a history reload (the field is persisted in
-`chat_feed.data_json`). `/context` (the interactive Claude Code slash
-command) is unavailable here because the engine drives `claude -p` in
-non-interactive print mode — the data comes from the stream's `usage`
-blocks, not a REPL command.
+(`app/src/lib/providers.ts`) for a "% full" gauge; it reads the latest such
+item via `latestContextUsage` so it works both live and after a history
+reload (the field is persisted in `chat_feed.data_json`). `/context` (the
+interactive Claude Code slash command) is unavailable here because the
+engine drives `claude -p` in non-interactive print mode — the data comes
+from the stream's `usage` blocks, not a REPL command.
+
+**Window values.** Claude Code's stream-json `system init` event does NOT
+carry a context-window field (verified against Claude Code 2.1.159: only
+`model`, `tools`, `mcp_servers`, etc. — no `max_tokens` / `context_window`),
+and Codex's `thread.started` doesn't either. The catalog therefore encodes
+per-model CLI-reported windows:
+
+- `claude-sonnet-4-6` / `claude-opus-4-7` / `claude-opus-4-8` → **1M**
+  (Claude Code default on Anthropic/Bedrock/Vertex routes — i.e. every
+  Houston user; Microsoft Foundry capping at 200k is undetectable from the
+  stream but doesn't apply to the bundled `claude` CLI's auth flow).
+- `gpt-5.5` → **272k** (Codex CLI's enforced input cap, the input portion
+  of its 400k total split; the raw OpenAI API offers 1M but Codex never
+  serves that).
+
+If a future Claude/Codex release exposes the window in `system init` /
+`thread.started`, prefer the live value over the catalog and treat the
+catalog as a fallback.
 
 ### Binary file downloads
 

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -384,31 +384,38 @@ request, i.e. how much of the context window is in use — Anthropic's parser
 sums its three-way split (`input + cache_creation + cache_read`), Codex's
 `input_tokens` is already cache-inclusive so it maps straight through. The
 desktop composer's context-usage indicator (`app/src/components/context-
-indicator.tsx`) divides `context_tokens` by the model's `contextWindow`
-(`app/src/lib/providers.ts`) for a "% full" gauge; it reads the latest such
-item via `latestContextUsage` so it works both live and after a history
+indicator.tsx`) divides the latest turn's `context_tokens` by a window
+estimate for a "% full" gauge; it reads usage via `sessionContextUsage`
+(`app/src/lib/context-usage.ts`) so it works both live and after a history
 reload (the field is persisted in `chat_feed.data_json`). `/context` (the
 interactive Claude Code slash command) is unavailable here because the
 engine drives `claude -p` in non-interactive print mode — the data comes
 from the stream's `usage` blocks, not a REPL command.
 
-**Window values.** Claude Code's stream-json `system init` event does NOT
-carry a context-window field (verified against Claude Code 2.1.159: only
-`model`, `tools`, `mcp_servers`, etc. — no `max_tokens` / `context_window`),
-and Codex's `thread.started` doesn't either. The catalog therefore encodes
-per-model CLI-reported windows:
+**The window is an estimate, by necessity.** The real context window is
+plan/credit-gated and is NOT reported anywhere `claude -p` can see (verified
+against Claude Code 2.1.159: `system init` carries only `model`, `tools`,
+`mcp_servers`, ... — no window field; no flag; no env var; Codex's
+`thread.started` likewise). The gating:
 
-- `claude-sonnet-4-6` / `claude-opus-4-7` / `claude-opus-4-8` → **1M**
-  (Claude Code default on Anthropic/Bedrock/Vertex routes — i.e. every
-  Houston user; Microsoft Foundry capping at 200k is undetectable from the
-  stream but doesn't apply to the bundled `claude` CLI's auth flow).
-- `gpt-5.5` → **272k** (Codex CLI's enforced input cap, the input portion
-  of its 400k total split; the raw OpenAI API offers 1M but Codex never
-  serves that).
+- Opus 4.x → 1M automatic on Max/Team/Enterprise, else 200k (1M needs
+  `/extra-usage` credits on Pro).
+- Sonnet 4.6 → 200k on every plan; 1M only with usage credits.
+- Codex gpt-5.5 → ~272k enforced input cap (input portion of a 400k split;
+  raw API offers 1M but Codex never serves it).
 
-If a future Claude/Codex release exposes the window in `system init` /
-`thread.started`, prefer the live value over the catalog and treat the
-catalog as a fallback.
+So the indicator uses a **self-correcting estimate** (`providers.ts`
+`contextWindow` = default assumption, `contextWindowMax` = snap-up ceiling;
+`context-usage.ts` `effectiveContextWindow`): start from the per-model
+default (Opus 1M, Sonnet 200k, gpt-5.5 272k), then snap UP to the ceiling
+once the session's observed PEAK `context_tokens` exceeds the default —
+which proves the real window is larger, because both CLIs auto-compact
+before the limit so observed usage can never exceed the true window. This
+auto-fixes Sonnet-with-credits and never reads over 100%. The one case it
+over-estimates is Opus on Pro WITHOUT credits (shows 1M, really 200k); it
+can't self-correct downward, so the dialog labels the figure "estimated".
+If a future CLI release exposes the window in `system init` /
+`thread.started`, prefer that live value over the estimate.
 
 ### Binary file downloads
 

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -372,6 +372,27 @@ Don't append every streaming delta as a new message row. Same
 pattern for `thinking_streaming` / `thinking`. See
 `examples/smartbooks/src/lib/feed.ts::appendFeedItem`.
 
+### Context-usage lives on `final_result`
+
+The terminal `feed_type: "final_result"` item carries `data: { result,
+cost_usd, duration_ms, usage }`. `usage` is the normalized `TokenUsage`
+`{ context_tokens, output_tokens, cached_tokens }` (Rust
+`houston-terminal-manager::TokenUsage`, TS `@houston-ai/chat` `TokenUsage`)
+or `null` for providers that don't report it (Anthropic + Codex do; Gemini
+doesn't yet). `context_tokens` is the prompt size of the most recent model
+request, i.e. how much of the context window is in use — Anthropic's parser
+sums its three-way split (`input + cache_creation + cache_read`), Codex's
+`input_tokens` is already cache-inclusive so it maps straight through. The
+desktop composer's context-usage indicator (`app/src/components/context-
+indicator.tsx`) divides `context_tokens` by the model's `contextWindow`
+(`app/src/lib/providers.ts`, Claude 200k / gpt-5.5 400k) for a "% full"
+gauge; it reads the latest such item via `latestContextUsage` so it works
+both live and after a history reload (the field is persisted in
+`chat_feed.data_json`). `/context` (the interactive Claude Code slash
+command) is unavailable here because the engine drives `claude -p` in
+non-interactive print mode — the data comes from the stream's `usage`
+blocks, not a REPL command.
+
 ### Binary file downloads
 
 The `read-project` route returns text only. For xlsx, pdf, images,

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -380,10 +380,27 @@ cost_usd, duration_ms, usage }`. `usage` is the normalized `TokenUsage`
 `houston-terminal-manager::TokenUsage`, TS `@houston-ai/chat` `TokenUsage`)
 or `null` for providers that don't report it (Anthropic + Codex do; Gemini
 doesn't yet). `context_tokens` is the prompt size of the most recent model
-request, i.e. how much of the context window is in use — Anthropic's parser
-sums its three-way split (`input + cache_creation + cache_read`), Codex's
-`input_tokens` is already cache-inclusive so it maps straight through. The
-desktop composer's context-usage indicator (`app/src/components/context-
+request, i.e. how much of the context window is in use.
+
+- **Anthropic:** the parser sums the last assistant message's three-way split
+  (`input + cache_creation + cache_read`). The per-message usage IS the last
+  request, so this is the live fill.
+- **Codex:** trickier. `codex exec --json` only emits `turn.completed.usage`,
+  which is the CUMULATIVE sum of every model request in the turn (a turn with
+  N tool round-trips reports ~N× the real size — this is the
+  94k-instead-of-19k bug). The real last-request fill + the effective window
+  live ONLY in Codex's on-disk rollout
+  (`$CODEX_HOME/sessions/**/rollout-*-<thread_id>.jsonl`, default
+  `~/.codex`), in `token_count.info.last_token_usage` /
+  `model_context_window`. So `engine codex_rollout::latest_usage(thread_id)`
+  reads the newest rollout's last `token_count` and `session_io` patches it
+  onto the `FinalResult` after the stream flushes (codex only writes the
+  rollout fully on exit, so the held-back FinalResult is emitted post-loop).
+  The parser leaves `usage` None; on any rollout failure it stays None (no %
+  beats a wrong %). Bumping the bundled codex won't help — neither 0.130 nor
+  0.135 `exec --json` exposes the per-request data in stdout.
+
+The desktop composer's context-usage indicator (`app/src/components/context-
 indicator.tsx`) divides the latest turn's `context_tokens` by a window
 estimate for a "% full" gauge; it reads usage via `sessionContextUsage`
 (`app/src/lib/context-usage.ts`) so it works both live and after a history
@@ -401,13 +418,15 @@ against Claude Code 2.1.159: `system init` carries only `model`, `tools`,
 - Opus 4.x → 1M automatic on Max/Team/Enterprise, else 200k (1M needs
   `/extra-usage` credits on Pro).
 - Sonnet 4.6 → 200k on every plan; 1M only with usage credits.
-- Codex gpt-5.5 → ~272k enforced input cap (input portion of a 400k split;
-  raw API offers 1M but Codex never serves it).
+- Codex gpt-5.5 → **258,400** effective = raw `context_window` 272k ×
+  `effective_context_window_percent` 95% (both from Codex's `models_cache.json`,
+  and the rollout's `model_context_window` confirms 258400). The opt-in 1M
+  variant maxes at 1M × 95% = 950k.
 
 So the indicator uses a **self-correcting estimate** (`providers.ts`
 `contextWindow` = default assumption, `contextWindowMax` = snap-up ceiling;
 `context-usage.ts` `effectiveContextWindow`): start from the per-model
-default (Opus 1M, Sonnet 200k, gpt-5.5 272k), then snap UP to the ceiling
+default (Opus 1M, Sonnet 200k, gpt-5.5 258.4k), then snap UP to the ceiling
 once the session's observed PEAK `context_tokens` exceeds the default —
 which proves the real window is larger, because both CLIs auto-compact
 before the limit so observed usage can never exceed the true window. This

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -1,6 +1,7 @@
 // === Types ===
 export type {
   FeedItem,
+  TokenUsage,
   RunStatus,
   ToolRuntimeErrorEntry,
   ProviderError,

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -22,8 +22,26 @@ export type FeedItem =
         result: string;
         cost_usd: number | null;
         duration_ms: number | null;
+        /**
+         * Normalized token usage for the turn. Present for providers that
+         * report it (Anthropic, Codex); `null`/absent otherwise. Drives the
+         * composer context-usage indicator.
+         */
+        usage?: TokenUsage | null;
       };
     };
+
+/**
+ * Provider-agnostic token usage for one turn. Mirrors the Rust `TokenUsage`
+ * in `houston-terminal-manager`. `context_tokens` is the prompt size of the
+ * most recent model request, i.e. how much of the context window is in use;
+ * `cached_tokens` (a subset) and `output_tokens` are informational detail.
+ */
+export interface TokenUsage {
+  context_tokens: number;
+  output_tokens: number;
+  cached_tokens: number;
+}
 
 export interface ToolRuntimeErrorEntry {
   kind: "local_tool" | "provider_process" | "provider_model_unsupported";


### PR DESCRIPTION
Closes #312 — users can now see how much of the model's context window a conversation is using.

## Why not `/context`?
`/context` is an **interactive** slash command (both Claude Code and Codex). Houston drives the CLIs in non-interactive print mode (`claude -p`, `codex exec --json`): one prompt in, NDJSON out, process exits — no stdin for slash commands. So the indicator parses the token data the CLIs already emit, instead.

## What it does
A small **gauge pill in the composer footer** (trailing, next to the model/effort controls) shows `N% full`; clicking it opens a dialog with a progress bar, used/total tokens, free remaining, cached, and last-reply tokens, plus an "estimated" note. Updates after each turn and **survives a history reload**.

## How it works
- **engine** — `FeedItem::FinalResult` gains a normalized `TokenUsage { context_tokens, output_tokens, cached_tokens }`.
  - **Anthropic:** captured from the **last assistant message** of a turn (the true context-window size = `input + cache_creation + cache_read`), with the terminal `result` event's `usage` as fallback.
  - **Codex:** the exec stream's `turn.completed.usage` is the **cumulative SUM of every model request in the turn** (a turn with N tool round-trips reports ~N× the real size), so it is NOT used. The accurate last-request fill + effective window live only in Codex's on-disk rollout (`~/.codex/sessions/**/rollout-*-<thread_id>.jsonl`, `token_count.info.last_token_usage` / `model_context_window`). `codex_rollout::latest_usage(thread_id)` reads the newest rollout's last `token_count`, and `session_io` patches it onto the held-back `FinalResult` after the stream flushes. On any failure usage stays `None` (no % beats a wrong %).
  - **Gemini:** left unset (coming-soon provider, no catalogued window).
  - Persisted in `chat_feed.data_json`, so it replays on reload.
- **ui/chat** — `TokenUsage` wire type + optional `usage` on the `final_result` feed item.
- **app** — `ContextIndicator` reads usage via `sessionContextUsage` and divides by a **self-correcting window estimate** (`getContextWindowConfig` + `effectiveContextWindow`). New `context` i18n namespace (en/es/pt).

## The window is plan/credit-gated and not in the stream
Verified: Claude's `system init` and Codex's `thread.started` carry only `model`, no window field; no flag, no env var. Gating:

| Model | Pro | Max / Team / Enterprise |
|---|---|---|
| Opus 4.x | 200k (1M with usage credits) | **1M automatic** |
| Sonnet 4.6 | 200k (1M with usage credits) | 200k (1M with usage credits) |
| gpt-5.5 (Codex) | **258,400** (272k raw × 95% effective) | 258,400 (1M variant → 950k) |

So the indicator uses a **self-correcting estimate**:
- per-model **default** (`contextWindow`: Opus 1M, Sonnet 200k, gpt-5.5 258.4k),
- **snaps up** to a **ceiling** (`contextWindowMax`) once a session's observed *peak* `context_tokens` exceeds the default — which *proves* the real window is larger (both CLIs auto-compact before the limit, so observed usage can never exceed the true window),
- floors the denominator at the observed peak, so the gauge **cannot read over 100%**,
- labels the figure **"estimated"** (dialog + pill tooltip).

For Codex the gpt-5.5 window (258,400) comes straight from Codex's own `models_cache.json` (`context_window` 272000 × `effective_context_window_percent` 95) and is confirmed by the rollout's `model_context_window`. Result: Houston matches Codex `/status` (~19k / 258k). The only over-estimate is **Opus on Pro without credits** (shows 1M, really 200k); it can't self-correct downward.

## Behavior notes (known, accepted)
- **Pre-existing chats:** turns from before this feature have no `usage` recorded, so an old conversation's pill reads a neutral "Context" (no %) until its **next message**, then populates and is immediately accurate (`--resume` re-sends the whole history, so that turn reflects the full context). No backfill is possible or done. New chats populate from turn one.
- **Codex rollout coupling:** the Codex numerator depends on Codex's on-disk rollout format (`token_count` / `last_token_usage` / `model_context_window`). Stable across codex 0.130–0.135; if a future codex changes it, the read fails gracefully → Codex pill shows no % rather than a wrong one. Bumping the bundled codex does NOT help (neither 0.130 nor 0.135 exec `--json` exposes the per-request data in stdout).
- **Snap "jump":** a credits-enabled session crossing its default window snaps the denominator up (e.g. Sonnet 200k → 1M), so the % drops at that moment. Inherent to a self-correcting estimate; not a bug.
- **Cross-model peak:** observed peak is session-wide while the window config is per current model. Safe today (same-provider models share a ceiling; providers can't mix in one session); commented at the call site.

## Scope
Claude + Codex. Gemini is a follow-up once it leaves coming-soon and gets a catalogued window.

## Tests
- engine: Anthropic usage capture (last-message-wins / result fallback / none), `codex_rollout` parse (last vs cumulative, trailing non-token lines, garbage), codex parser leaves usage None, `serialize_for_persist` round-trip, Gemini still `None`.
- frontend: `tsc` + `check-locales` (no unit-test runner in `app/`/`ui/`; pure helpers adversarially reviewed).

## Affected files
**engine:** `houston-terminal-manager/src/{types,parser,codex_parser,codex_rollout,gemini_parser_state,session_io,lib}.rs`, `houston-agents-conversations/src/session_runner.rs`
**ui:** `ui/chat/src/{types,index}.ts`
**app:** `lib/{providers,context-usage,i18n}.ts`, `types/react-i18next.d.ts`, `components/{context-indicator,use-agent-chat-panel}.tsx`, `locales/{en,es,pt}/context.json`
**docs:** `knowledge-base/engine-protocol.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)