### PR TITLE
fix(providers): pin claude-code 2.1.158 for Opus 4.8 xhigh effort

### DIFF
--- a/cli-deps.json
+++ b/cli-deps.json
@@ -2,7 +2,7 @@
   "$schema": "./cli-deps.schema.json",
   "$comment": "Pinned versions for every CLI Houston ships or runtime-installs. Bundled (codex, composio) ride inside the .app / .msi under resources/bin. claude-code cannot be bundled (proprietary license) so the runtime installer downloads it on first launch via houston-claude-installer using the URLs + sha256 below. Bumping a version: run `./scripts/bump-cli.sh <name> <version>`, then `./scripts/fetch-cli-deps.sh both` to refresh the staged copies + print the new checksums; pin the printed sha256 back into this file. For Windows, composio is built from source (see `build` block) because upstream does not yet ship a Windows artifact.",
   "claude-code": {
-    "version": "2.1.92",
+    "version": "2.1.158",
     "bundled": false,
     "binary_name": "claude",
     "license": "PROPRIETARY",
@@ -16,10 +16,10 @@
       "manifest": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/manifest.json"
     },
     "checksums": {
-      "darwin-arm64": "6d1b9657727dce81332b3cda11bfe0a8c83e2392e3c062a31022e10b0e71cdd1",
-      "darwin-x64": "d422b5cc974b3bc4b28f698144fd0316f3e17774babe0bc1eb76c2bb0858d0aa",
-      "windows-x64": "ebd9007c464d912593418f133a61d9f24866428530a81e88e910a24823066415",
-      "windows-arm64": "c258bce79aefac609f909e5abde92d1653bcef47d3577656d299d1d56f1604bb"
+      "darwin-arm64": "536a0517fa64d48ddcbc8eb511a3d08027d47e06d148872332a8041d72c22768",
+      "darwin-x64": "b7b33293702fb8e0a119b795d5af5178bd346fb46d4d7f161336d521f62d1451",
+      "windows-x64": "10fa305545b20baf6e074a086762bd252b89dfe7035848a5d41385503b1a6c74",
+      "windows-arm64": "9e0e303015eb3c9aba782b366b35194073ab8130ac6c091c2c46870798a20bdc"
     }
   },
   "codex": {

--- a/engine/houston-terminal-manager/src/provider/anthropic.rs
+++ b/engine/houston-terminal-manager/src/provider/anthropic.rs
@@ -55,11 +55,18 @@ impl ProviderAdapter for AnthropicAdapter {
     }
 
     fn effort_levels(&self) -> &'static [&'static str] {
-        // `claude --effort` accepts low/medium/high/xhigh/max. The model
-        // gates which are *honored* (Opus 4.7/4.8 = all; Sonnet 4.6 = no
-        // `xhigh`), but Claude self-clamps an unsupported value to its
-        // highest, so the engine carries the full union and lets the
-        // frontend picker present the per-model subset.
+        // These MUST be a subset of the `--effort` choices accepted by the
+        // claude-code version pinned in `cli-deps.json`. `claude --effort`
+        // validates via a commander `.choices()` allow-list and HARD-REJECTS
+        // (exit 1, `argument '<v>' is invalid`) anything outside it — it does
+        // NOT self-clamp to its highest level. Passing a value an older
+        // installed CLI doesn't know kills the session with a generic
+        // "claude hit a runtime error" (this is exactly how `xhigh` broke on
+        // the previously-pinned 2.1.92, which only knew low/medium/high/max).
+        // The pinned CLI (>= 2.1.158) accepts all five below; the model gates
+        // which are *honored* (Opus 4.7/4.8 = all; Sonnet 4.6 = no `xhigh`),
+        // so the engine carries the full union and the frontend picker
+        // presents the per-model subset.
         &["low", "medium", "high", "xhigh", "max"]
     }
 


### PR DESCRIPTION
Fixes #357

## Problem

Opus 4.8 agents with **`xhigh`** effort die with a generic `Session error: claude hit a runtime error`. The engine log shows the real cause:

```
spawning claude -p (model=Some("claude-opus-4-8"), effort=Some("xhigh"))
cli stderr: error: option '--effort <level>' argument 'xhigh' is invalid. It must be one of: low, medium, high, max
process exited with exit code: 1
session error: "claude hit a runtime error"
```

The **managed** claude-code (the one the engine spawns — `~/.local/bin/claude` / `%LOCALAPPDATA%\Programs\claude\claude.exe`) is pinned at **2.1.92**, which only accepts `--effort low|medium|high|max`. PR #344 added Opus 4.8 + the `xhigh` effort level to the catalog/UI, but never bumped the pinned CLI — so the spawned binary hard-rejects what the UI offers. Confirmed by running the pinned binary directly:

```
$ claude.exe --help | grep effort
  --effort <level>   Effort level for the current session (low, medium, high, max)   # no xhigh
```

This affects **every** production user who selects Opus 4.8 + `xhigh` (default effort is `medium`, so only explicit `xhigh` pickers break). It looks fine when testing in a terminal because the developer's PATH `claude` is a newer build.

## Fix

- **`cli-deps.json`**: bump `claude-code` `2.1.92` → `2.1.158` (current npm `latest`, verified to accept `low/medium/high/xhigh/max`). Checksums are taken from the dist `manifest.json` and verified against the previous 2.1.92 pins — all four platform hashes matched the manifest exactly, so the manifest is the authoritative source. `houston_claude_installer::ensure_and_upgrade` auto-upgrades existing installs on next launch (installed-vs-pinned compare).
- **`anthropic.rs`**: correct the false `effort_levels` comment. It claimed *"Claude self-clamps an unsupported value to its highest"* — it does **not**; `claude --effort` validates via a commander `.choices()` allow-list and exits 1 on an unknown value. That wrong assumption is exactly why the union carried `xhigh` regardless of the pinned CLI version. The comment now documents that the union must stay a subset of the pinned CLI's accepted `--effort` choices.

## Affected files

- `cli-deps.json` — version + 4 checksums (darwin arm64/x64, win32 x64/arm64)
- `engine/houston-terminal-manager/src/provider/anthropic.rs` — comment only

## Test plan

- `cargo test -p houston-terminal-manager` (effort-resolution + classifier tests; union is unchanged so they stay green)
- Release CI `fetch-cli-deps.sh` re-downloads + sha256-verifies the new checksums
- Manual: Opus 4.8 agent with `xhigh` effort runs a session without the runtime error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
