### PR TITLE
fix(routines): run both routines scheduled for the same time (#362)

### DIFF
--- a/engine/houston-engine-core/src/routines/engine_dispatcher.rs
+++ b/engine/houston-engine-core/src/routines/engine_dispatcher.rs
@@ -38,15 +38,19 @@ pub struct EngineRoutineDispatcher {
 #[async_trait]
 impl RoutineDispatcher for EngineRoutineDispatcher {
     async fn dispatch(&self, ctx: DispatchContext<'_>) -> DispatchOutcome {
-        let _workdir_guard = match self.rt.try_acquire_workdir(ctx.working_dir).await {
-            Ok(guard) => guard,
-            Err(e) => {
-                return DispatchOutcome {
-                    response_text: String::new(),
-                    error: Some(e.to_string()),
-                };
-            }
-        };
+        // Serialize sessions that share a working directory: wait for any
+        // earlier routine run in this folder to finish before starting ours.
+        // Two routines scheduled for the same time both run, one after the
+        // other (issue #362), instead of the second failing on a busy folder.
+        let _workdir_guard = self.rt.acquire_workdir(ctx.working_dir).await;
+
+        // We may have waited on the lock. If the user cancelled this run while
+        // it sat queued, the row is already terminal — skip spawning a session
+        // (and burning provider tokens) for work that's been called off.
+        // `finish_run` sees the `cancelled` status and discards this outcome.
+        if cancelled_while_queued(ctx.working_dir, &ctx.run.id) {
+            return DispatchOutcome::default();
+        }
 
         if let Err(e) = agent_prompt::seed_agent(ctx.working_dir) {
             return DispatchOutcome {
@@ -118,6 +122,27 @@ impl RoutineDispatcher for EngineRoutineDispatcher {
                 response_text: String::new(),
                 error: Some(format!("session task failed: {e}")),
             },
+        }
+    }
+}
+
+/// After acquiring the workdir lock, a run that sat queued behind another
+/// routine may have been cancelled. Returns `true` if the on-disk row is
+/// already terminal (`cancelled`) and the dispatcher should skip spawning a
+/// session for it.
+///
+/// A failed re-read is treated as "not cancelled" (proceed): `finish_run`
+/// still drives the run to a terminal status from the dispatch outcome, so
+/// proceeding can't strand the row, whereas wrongly skipping on a transient
+/// read error would.
+fn cancelled_while_queued(working_dir: &Path, run_id: &str) -> bool {
+    match routine_runs::find_by_id(working_dir, run_id) {
+        Ok(run) => run.status == "cancelled",
+        Err(e) => {
+            tracing::warn!(
+                "[routines] failed to re-read run {run_id} after acquiring workdir lock: {e}"
+            );
+            false
         }
     }
 }
@@ -236,6 +261,32 @@ mod lifecycle_tests {
 
         let after = routine_runs::find_by_id(d.path(), &run.id).unwrap();
         assert_eq!(after.paused_until.as_deref(), Some("soon"));
+    }
+
+    #[test]
+    fn cancelled_while_queued_detects_terminal_cancel_and_tolerates_missing() {
+        let d = TempDir::new().unwrap();
+        let r = create(d.path(), mk_routine()).unwrap();
+        let run = routine_runs::create(d.path(), &r.id).unwrap();
+
+        // Freshly created run is still `running` → not cancelled → proceed.
+        assert!(!cancelled_while_queued(d.path(), &run.id));
+
+        // Cancelled while queued → skip dispatch.
+        routine_runs::update(
+            d.path(),
+            &run.id,
+            RoutineRunUpdate {
+                status: Some("cancelled".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert!(cancelled_while_queued(d.path(), &run.id));
+
+        // Unreadable / missing row → treat as live (proceed); finish_run still
+        // drives a terminal status, so this must never strand the run.
+        assert!(!cancelled_while_queued(d.path(), "nonexistent-run-id"));
     }
 }
 

--- a/engine/houston-engine-core/src/routines/runner.rs
+++ b/engine/houston-engine-core/src/routines/runner.rs
@@ -67,20 +67,38 @@ pub trait ActivitySurface: Send + Sync {
     ) -> Result<String, String>;
 }
 
-/// Full execution of one routine. Mirrors the original behaviour of
-/// `run_routine()` in the desktop adapter:
+/// Phase 1 output: the loaded routine and the freshly-created `running` row,
+/// ready to hand to [`finish_run`].
+pub struct BegunRun {
+    pub working_dir: PathBuf,
+    pub routine: Routine,
+    pub run: RoutineRun,
+    /// Prompt with the suppression instruction already appended when
+    /// `routine.suppress_when_silent` is set.
+    pub prompt: String,
+}
+
+/// Phase 1 of a routine run: load the routine, enforce the per-routine
+/// in-flight gate, create the `running` row, and announce it.
 ///
-/// 1. Load routine + create run (status=`running`)
-/// 2. Dispatch session (via trait)
-/// 3. Evaluate: silent → update run; error → update run; surfaced → create
-///    activity, link both sides, emit events.
-pub async fn run_routine(
-    events: DynEventSink,
-    dispatcher: Arc<dyn RoutineDispatcher>,
-    surface: Arc<dyn ActivitySurface>,
+/// Synchronous and fast — callers run it in the request path so `NotFound`
+/// (routine gone) and `Conflict` (this routine already running) surface to the
+/// user as an HTTP error, then hand the [`BegunRun`] to [`finish_run`] (inline
+/// for the cron loop, or on a detached task for `run-now`).
+///
+/// The gate is per-routine, not per-agent: a *different* routine that happens
+/// to be running on the same agent must NOT block this one (issue #362).
+/// Repeated runs of the *same* routine are still rejected so spam-clicked
+/// `run-now` (or a cron fire landing on a still-running previous run) doesn't
+/// queue duplicate work. Serializing the sessions themselves — so two runs
+/// don't write the same folder at once — is the dispatcher's job via the
+/// workdir lock, which waits rather than failing. Orphan `running` rows from a
+/// crashed engine are swept by `sweep_orphan_running` at agent-scheduler start.
+pub fn begin_run(
+    events: &DynEventSink,
     agent_path: &str,
     routine_id: &str,
-) -> CoreResult<()> {
+) -> CoreResult<BegunRun> {
     let working_dir = expand_tilde(Path::new(agent_path));
 
     let routines = routines::list(&working_dir)?;
@@ -92,21 +110,7 @@ pub async fn run_routine(
 
     ensure_houston_dir(&working_dir)?;
 
-    // Reject early if a run is already in flight for this agent. Without
-    // this, repeated `run-now` clicks (a) pollute the on-disk history
-    // with `status="error", summary="conflict: another mission..."` rows
-    // from the workdir-lock failure inside the dispatcher, and (b) leave
-    // the UI unable to pick out the "real" running run vs. the noise
-    // since `lastRuns` keys by latest `started_at`. Fail fast at the
-    // route level instead — frontend gets a 409 and surfaces a toast.
-    //
-    // We treat "in flight" as "status=running on disk". The workdir lock
-    // would be a more precise signal, but it lives on `SessionRuntime`
-    // and isn't reachable from this transport-neutral runner. Disk state
-    // is reliable for the common case (one run completes, status flips
-    // terminal); orphan `running` rows from a crashed engine are swept
-    // by `sweep_orphan_running` at agent-scheduler start.
-    let run = routine_runs::create_if_no_running(&working_dir, routine_id)?;
+    let run = routine_runs::create_if_routine_idle(&working_dir, routine_id)?;
     events.emit(HoustonEvent::RoutineRunsChanged {
         agent_path: agent_path.to_string(),
     });
@@ -116,6 +120,36 @@ pub async fn run_routine(
     } else {
         routine.prompt.clone()
     };
+
+    Ok(BegunRun {
+        working_dir,
+        routine,
+        run,
+        prompt,
+    })
+}
+
+/// Phase 2 of a routine run: dispatch the session, then evaluate the outcome
+/// (silent → update run; error → update run; surfaced → create activity, link
+/// both sides, emit events).
+///
+/// Always drives the run to a terminal status before returning — a dispatch
+/// error, a cancellation, or a failure to surface the result can never leave
+/// the row stuck on `running`. Safe to run on a detached task: it owns its
+/// inputs and reaches a terminal write regardless of the caller's lifetime.
+pub async fn finish_run(
+    events: DynEventSink,
+    dispatcher: Arc<dyn RoutineDispatcher>,
+    surface: Arc<dyn ActivitySurface>,
+    agent_path: &str,
+    begun: BegunRun,
+) -> CoreResult<()> {
+    let BegunRun {
+        working_dir,
+        routine,
+        run,
+        prompt,
+    } = begun;
 
     let outcome = dispatcher
         .dispatch(DispatchContext {
@@ -132,11 +166,27 @@ pub async fn run_routine(
     let is_silent = routine.suppress_when_silent && response_is_silent(&response);
 
     // Cancellation race: the cancel handler may have written status="cancelled"
-    // (and SIGTERM'd the PID) while we were awaiting dispatch. In that case the
-    // disk record is already terminal — don't overwrite it with `error`/`silent`/
-    // `surfaced`, and don't create an activity for a cancelled run.
-    let current = routine_runs::find_by_id(&working_dir, &run.id)?;
-    if current.status == "cancelled" {
+    // (and SIGTERM'd the PID) while we were awaiting dispatch — or while this
+    // run sat queued on the workdir lock waiting for an earlier routine to
+    // finish. In that case the disk record is already terminal — don't
+    // overwrite it with `error`/`silent`/`surfaced`, and don't create an
+    // activity for a cancelled run.
+    //
+    // A failed re-read must NOT bail with `?` here: that would skip every
+    // terminal write below and strand the row on `running` forever — the very
+    // failure this runner exists to prevent. Treat an unreadable record as
+    // "not cancelled" and fall through to a terminal status update.
+    let cancelled = match routine_runs::find_by_id(&working_dir, &run.id) {
+        Ok(current) => current.status == "cancelled",
+        Err(e) => {
+            tracing::warn!(
+                "[routines] failed to re-read run {} after dispatch: {e}; treating as live",
+                run.id
+            );
+            false
+        }
+    };
+    if cancelled {
         events.emit(HoustonEvent::RoutineRunsChanged {
             agent_path: agent_path.to_string(),
         });
@@ -171,35 +221,52 @@ pub async fn run_routine(
             routine.name,
             first_line(&response).unwrap_or("Needs attention")
         );
-        let activity_id = surface
-            .surface(
-                &working_dir,
-                &title,
-                &routine.description,
-                &run.session_key,
-                &routine.id,
-                &run.id,
-            )
-            .map_err(CoreError::Internal)?;
-
-        routine_runs::update(
+        match surface.surface(
             &working_dir,
+            &title,
+            &routine.description,
+            &run.session_key,
+            &routine.id,
             &run.id,
-            RoutineRunUpdate {
-                status: Some("surfaced".into()),
-                activity_id: Some(activity_id),
-                completed_at: Some(now),
-                ..Default::default()
-            },
-        )?;
-
-        events.emit(HoustonEvent::ActivityChanged {
-            agent_path: agent_path.to_string(),
-        });
-        events.emit(HoustonEvent::CompletionToast {
-            title: format!("{} found something", routine.name),
-            issue_id: None,
-        });
+        ) {
+            Ok(activity_id) => {
+                routine_runs::update(
+                    &working_dir,
+                    &run.id,
+                    RoutineRunUpdate {
+                        status: Some("surfaced".into()),
+                        activity_id: Some(activity_id),
+                        completed_at: Some(now),
+                        ..Default::default()
+                    },
+                )?;
+                events.emit(HoustonEvent::ActivityChanged {
+                    agent_path: agent_path.to_string(),
+                });
+                events.emit(HoustonEvent::CompletionToast {
+                    title: format!("{} found something", routine.name),
+                    issue_id: None,
+                });
+            }
+            Err(e) => {
+                // Surfacing failed. Flip the run to `error` so it doesn't sit
+                // on `running` forever, then propagate so the caller logs it.
+                routine_runs::update(
+                    &working_dir,
+                    &run.id,
+                    RoutineRunUpdate {
+                        status: Some("error".into()),
+                        summary: Some(format!("failed to surface result: {e}")),
+                        completed_at: Some(now),
+                        ..Default::default()
+                    },
+                )?;
+                events.emit(HoustonEvent::RoutineRunsChanged {
+                    agent_path: agent_path.to_string(),
+                });
+                return Err(CoreError::Internal(e));
+            }
+        }
     }
 
     events.emit(HoustonEvent::RoutineRunsChanged {
@@ -207,6 +274,24 @@ pub async fn run_routine(
     });
 
     Ok(())
+}
+
+/// Full execution of one routine: [`begin_run`] then [`finish_run`]. Used by
+/// the cron scheduler, which already runs on its own task per routine.
+///
+/// 1. Load routine + create run (status=`running`)
+/// 2. Dispatch session (via trait)
+/// 3. Evaluate: silent → update run; error → update run; surfaced → create
+///    activity, link both sides, emit events.
+pub async fn run_routine(
+    events: DynEventSink,
+    dispatcher: Arc<dyn RoutineDispatcher>,
+    surface: Arc<dyn ActivitySurface>,
+    agent_path: &str,
+    routine_id: &str,
+) -> CoreResult<()> {
+    let begun = begin_run(&events, agent_path, routine_id)?;
+    finish_run(events, dispatcher, surface, agent_path, begun).await
 }
 
 /// Cancel an in-flight routine run end-to-end.
@@ -472,6 +557,148 @@ mod tests {
         let runs = routine_runs::list(d.path()).unwrap();
         assert_eq!(runs.len(), 1);
         assert_eq!(runs[0].id, in_flight.id);
+    }
+
+    #[tokio::test]
+    async fn two_different_routines_on_same_agent_both_run() {
+        // Issue #362: two routines scheduled for the same time on the same
+        // agent must BOTH run — the per-routine gate must not let one drop the
+        // other. (The workdir lock that serializes the real sessions is
+        // exercised separately in `sessions` + `workdir_locks` tests; the fake
+        // dispatcher here doesn't take it, so this isolates the gate fix.)
+        let d = TempDir::new().unwrap();
+        let agent_path = d.path().to_string_lossy().to_string();
+        let a = create(d.path(), sample_routine()).unwrap();
+        let b = create(d.path(), sample_routine()).unwrap();
+
+        let dispatcher = Arc::new(FakeDispatcher(DispatchOutcome {
+            response_text: "all quiet\nROUTINE_OK".into(),
+            error: None,
+        }));
+        let surface = Arc::new(RecordingSurface::default());
+        let events: DynEventSink = Arc::new(NoopEventSink);
+
+        let (ra, rb) = tokio::join!(
+            run_routine(events.clone(), dispatcher.clone(), surface.clone(), &agent_path, &a.id),
+            run_routine(events.clone(), dispatcher.clone(), surface.clone(), &agent_path, &b.id),
+        );
+        ra.unwrap();
+        rb.unwrap();
+
+        let runs = routine_runs::list(d.path()).unwrap();
+        assert_eq!(runs.len(), 2, "both routines created a run");
+        assert!(
+            runs.iter().all(|r| r.status == "silent"),
+            "both runs reached a terminal status: {:?}",
+            runs.iter().map(|r| (&r.routine_id, &r.status)).collect::<Vec<_>>()
+        );
+        // One run per routine id.
+        assert!(runs.iter().any(|r| r.routine_id == a.id));
+        assert!(runs.iter().any(|r| r.routine_id == b.id));
+    }
+
+    #[tokio::test]
+    async fn two_routines_same_folder_serialize_via_workdir_lock() {
+        // Issue #362 end-to-end: two routines on the same agent both run, but
+        // their sessions SERIALIZE on the shared folder (never overlap) — using
+        // the real `SessionRuntime::acquire_workdir` the engine dispatcher uses.
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let d = TempDir::new().unwrap();
+        let agent_path = d.path().to_string_lossy().to_string();
+        let a = create(d.path(), sample_routine()).unwrap();
+        let b = create(d.path(), sample_routine()).unwrap();
+
+        struct SerializingDispatcher {
+            rt: crate::sessions::SessionRuntime,
+            active: Arc<AtomicUsize>,
+            peak: Arc<AtomicUsize>,
+        }
+        #[async_trait]
+        impl RoutineDispatcher for SerializingDispatcher {
+            async fn dispatch(&self, ctx: DispatchContext<'_>) -> DispatchOutcome {
+                let _guard = self.rt.acquire_workdir(ctx.working_dir).await;
+                let n = self.active.fetch_add(1, Ordering::SeqCst) + 1;
+                self.peak.fetch_max(n, Ordering::SeqCst);
+                tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+                self.active.fetch_sub(1, Ordering::SeqCst);
+                DispatchOutcome {
+                    response_text: "all quiet\nROUTINE_OK".into(),
+                    error: None,
+                }
+            }
+        }
+
+        let peak = Arc::new(AtomicUsize::new(0));
+        let dispatcher = Arc::new(SerializingDispatcher {
+            rt: crate::sessions::SessionRuntime::default(),
+            active: Arc::new(AtomicUsize::new(0)),
+            peak: peak.clone(),
+        });
+        let surface = Arc::new(RecordingSurface::default());
+        let events: DynEventSink = Arc::new(NoopEventSink);
+
+        let (ra, rb) = tokio::join!(
+            run_routine(events.clone(), dispatcher.clone(), surface.clone(), &agent_path, &a.id),
+            run_routine(events.clone(), dispatcher.clone(), surface.clone(), &agent_path, &b.id),
+        );
+        ra.unwrap();
+        rb.unwrap();
+
+        let runs = routine_runs::list(d.path()).unwrap();
+        assert_eq!(runs.len(), 2, "both routines ran");
+        assert!(runs.iter().all(|r| r.status == "silent"), "both reached terminal");
+        assert_eq!(
+            peak.load(Ordering::SeqCst),
+            1,
+            "the two sessions must serialize on the shared workdir lock"
+        );
+    }
+
+    #[tokio::test]
+    async fn finish_run_marks_error_when_surface_fails() {
+        // A surfacing failure must not strand the run on `running`.
+        let d = TempDir::new().unwrap();
+        let agent_path = d.path().to_string_lossy().to_string();
+        let r = create(d.path(), sample_routine()).unwrap();
+
+        struct FailingSurface;
+        impl ActivitySurface for FailingSurface {
+            fn surface(
+                &self,
+                _wd: &Path,
+                _t: &str,
+                _d: &str,
+                _s: &str,
+                _r: &str,
+                _rr: &str,
+            ) -> Result<String, String> {
+                Err("disk full".into())
+            }
+        }
+
+        // Non-silent response → runner tries to surface → surface fails.
+        let dispatcher = Arc::new(FakeDispatcher(DispatchOutcome {
+            response_text: "Found something".into(),
+            error: None,
+        }));
+
+        let err = run_routine(
+            Arc::new(NoopEventSink),
+            dispatcher,
+            Arc::new(FailingSurface),
+            &agent_path,
+            &r.id,
+        )
+        .await
+        .unwrap_err();
+        assert!(matches!(err, CoreError::Internal(_)));
+
+        let runs = routine_runs::list(d.path()).unwrap();
+        assert_eq!(runs.len(), 1);
+        assert_eq!(runs[0].status, "error");
+        assert!(runs[0].completed_at.is_some());
+        assert!(runs[0].summary.as_deref().unwrap().contains("disk full"));
     }
 
     #[tokio::test]

--- a/engine/houston-engine-core/src/routines/runs.rs
+++ b/engine/houston-engine-core/src/routines/runs.rs
@@ -36,9 +36,9 @@ pub fn find_by_id(root: &Path, id: &str) -> CoreResult<RoutineRun> {
 /// because there's no way to distinguish a row from a still-alive
 /// subprocess vs. one that's been orphaned by a previous engine crash
 /// (the row is written before the dispatch awaits, and the dispatch
-/// process is gone after a hard restart). Without this sweep, an
-/// orphan would permanently block every future `run-now` for that
-/// agent via the precondition in [`crate::routines::runner::run_routine`].
+/// process is gone after a hard restart). Without this sweep, an orphan
+/// would permanently block every future run of that routine via the
+/// per-routine gate in [`create_if_routine_idle`].
 ///
 /// Returns the number of rows reaped. Safe to call when there are no
 /// orphan rows — it's a no-op.
@@ -68,12 +68,27 @@ fn sweep_orphan_running_unlocked(root: &Path) -> CoreResult<usize> {
     Ok(reaped)
 }
 
-pub fn create_if_no_running(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
+/// Create a run for `routine_id`, unless that *same* routine already has a
+/// run in `running` status.
+///
+/// The gate is scoped to the routine, NOT the agent: two different routines
+/// on the same agent that fire at the same time both get a run created, so
+/// neither is silently dropped (issue #362). Serializing the actual sessions
+/// — so two runs don't write the same folder at once — is the dispatcher's
+/// job via the workdir lock, which now *waits* instead of failing.
+///
+/// Same-routine concurrency is still rejected so repeated `run-now` clicks
+/// (or a cron fire that lands while the previous run is still in flight)
+/// don't queue duplicate work or pollute history.
+pub fn create_if_routine_idle(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
     with_runs_lock(root, || {
         let existing = list(root)?;
-        if let Some(busy) = existing.iter().find(|r| r.status == "running") {
+        if let Some(busy) = existing
+            .iter()
+            .find(|r| r.routine_id == routine_id && r.status == "running")
+        {
             return Err(CoreError::Conflict(format!(
-                "another routine run is already in progress (run {})",
+                "routine {routine_id} already has a run in progress (run {})",
                 busy.id
             )));
         }
@@ -290,13 +305,15 @@ mod tests {
     }
 
     #[test]
-    fn concurrent_create_if_no_running_allows_one_run() {
+    fn create_if_routine_idle_serializes_same_routine() {
+        // Spam-click protection: many concurrent attempts to run the SAME
+        // routine collapse to a single in-flight run.
         let d = TempDir::new().unwrap();
         let root = d.path().to_path_buf();
         let handles = (0..8)
-            .map(|i| {
+            .map(|_| {
                 let root = root.clone();
-                thread::spawn(move || create_if_no_running(&root, &format!("rid-{i}")))
+                thread::spawn(move || create_if_routine_idle(&root, "same-rid"))
             })
             .collect::<Vec<_>>();
 
@@ -314,6 +331,51 @@ mod tests {
         assert_eq!(conflicts, 7);
         let runs = list(&root).unwrap();
         assert_eq!(runs.len(), 1);
+    }
+
+    #[test]
+    fn create_if_routine_idle_allows_a_different_routine_while_one_runs() {
+        // Issue #362: a second routine on the same agent must NOT be blocked
+        // by an unrelated routine that happens to be running.
+        let d = TempDir::new().unwrap();
+        let root = d.path();
+
+        let a = create_if_routine_idle(root, "routine-a").unwrap();
+        assert_eq!(a.status, "running");
+
+        // Different routine — allowed even though A is still running.
+        let b = create_if_routine_idle(root, "routine-b").unwrap();
+        assert_eq!(b.status, "running");
+
+        // Same routine as the in-flight A — rejected.
+        assert!(matches!(
+            create_if_routine_idle(root, "routine-a").unwrap_err(),
+            CoreError::Conflict(_)
+        ));
+
+        let runs = list(root).unwrap();
+        assert_eq!(runs.len(), 2);
+    }
+
+    #[test]
+    fn concurrent_create_if_routine_idle_allows_distinct_routines() {
+        // Distinct routine ids racing concurrently each get their own run —
+        // none are dropped.
+        let d = TempDir::new().unwrap();
+        let root = d.path().to_path_buf();
+        let handles = (0..8)
+            .map(|i| {
+                let root = root.clone();
+                thread::spawn(move || create_if_routine_idle(&root, &format!("rid-{i}")))
+            })
+            .collect::<Vec<_>>();
+
+        for handle in handles {
+            handle.join().unwrap().unwrap();
+        }
+
+        let runs = list(&root).unwrap();
+        assert_eq!(runs.len(), 8);
     }
 
     #[test]

--- a/engine/houston-engine-core/src/routines/scheduler.rs
+++ b/engine/houston-engine-core/src/routines/scheduler.rs
@@ -172,7 +172,7 @@ impl AgentScheduler {
                     Utc::now().to_rfc3339()
                 );
 
-                if let Err(e) = run_routine(
+                match run_routine(
                     events.clone(),
                     dispatcher.clone(),
                     surface.clone(),
@@ -181,9 +181,19 @@ impl AgentScheduler {
                 )
                 .await
                 {
-                    tracing::error!(
-                        "[routines] Error running routine {routine_id}: {e}"
-                    );
+                    Ok(()) => {}
+                    // The previous run of THIS routine is still in flight when
+                    // the next tick landed — expected dedup, not an error.
+                    Err(crate::CoreError::Conflict(msg)) => {
+                        tracing::info!(
+                            "[routines] skipped cron fire for {routine_id}: {msg}"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::error!(
+                            "[routines] Error running routine {routine_id}: {e}"
+                        );
+                    }
                 }
             }
         }))

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -30,7 +30,7 @@ mod workdir_locks;
 
 use crate::agents::prompt as agent_prompt;
 use crate::paths::EnginePaths;
-use crate::{CoreError, CoreResult};
+use crate::CoreResult;
 use control::{
     SessionControl, SessionIdentity, SessionTurnGuard, SessionTurnLocks, WorkdirActivity,
 };
@@ -57,16 +57,13 @@ pub struct SessionRuntime {
 }
 
 impl SessionRuntime {
-    pub(crate) async fn try_acquire_workdir(
-        &self,
-        working_dir: &Path,
-    ) -> CoreResult<WorkdirSessionGuard> {
-        self.workdir_locks
-            .try_acquire(working_dir)
-            .await
-            .ok_or_else(|| {
-                CoreError::Conflict("another mission is already running in this folder".to_string())
-            })
+    /// Acquire the per-folder session lock, waiting if another session is
+    /// already running in that folder. Routines use this to serialize runs
+    /// that share a working directory — two routines scheduled for the same
+    /// time both run, one after the other, instead of the second being
+    /// dropped (issue #362). The guard releases on drop.
+    pub(crate) async fn acquire_workdir(&self, working_dir: &Path) -> WorkdirSessionGuard {
+        self.workdir_locks.acquire(working_dir).await
     }
 
     async fn acquire_turn(&self, id: &SessionIdentity) -> SessionTurnGuard {
@@ -727,6 +724,45 @@ mod tests {
         assert_eq!(accepted, "chat-test");
         assert!(cancel(&rt, &events, &dir.path().to_string_lossy(), "chat-test",).await);
         drop(guard);
+    }
+
+    #[tokio::test]
+    async fn acquire_workdir_serializes_same_folder() {
+        // The primitive behind serial routine execution (issue #362): two
+        // acquisitions of the same folder queue — the second only proceeds
+        // after the first guard drops.
+        let rt = SessionRuntime::default();
+        let dir = TempDir::new().unwrap();
+
+        let first = rt.acquire_workdir(dir.path()).await;
+        assert!(
+            timeout(Duration::from_millis(20), rt.acquire_workdir(dir.path()))
+                .await
+                .is_err(),
+            "second acquire on a busy folder must wait"
+        );
+        drop(first);
+        assert!(
+            timeout(Duration::from_millis(50), rt.acquire_workdir(dir.path()))
+                .await
+                .is_ok(),
+            "second acquire proceeds once the folder frees"
+        );
+    }
+
+    #[tokio::test]
+    async fn acquire_workdir_allows_distinct_folders_concurrently() {
+        let rt = SessionRuntime::default();
+        let one = TempDir::new().unwrap();
+        let two = TempDir::new().unwrap();
+
+        let _a = rt.acquire_workdir(one.path()).await;
+        // Different folder — no contention even while the first is held.
+        assert!(
+            timeout(Duration::from_millis(50), rt.acquire_workdir(two.path()))
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]

--- a/engine/houston-engine-core/src/sessions/workdir_locks.rs
+++ b/engine/houston-engine-core/src/sessions/workdir_locks.rs
@@ -11,7 +11,9 @@ pub struct WorkdirLocks {
 }
 
 impl WorkdirLocks {
-    #[cfg(test)]
+    /// Acquire the per-folder session lock, waiting if another session holds
+    /// it. Callers that want two sessions in the same folder to *queue*
+    /// (routines — issue #362) await this; the guard releases on drop.
     pub async fn acquire(&self, working_dir: &Path) -> WorkdirSessionGuard {
         let key = normalize_key(working_dir);
         let lock = {
@@ -22,18 +24,6 @@ impl WorkdirLocks {
                 .clone()
         };
         lock.lock_owned().await
-    }
-
-    pub async fn try_acquire(&self, working_dir: &Path) -> Option<WorkdirSessionGuard> {
-        let key = normalize_key(working_dir);
-        let lock = {
-            let mut locks = self.inner.lock().await;
-            locks
-                .entry(key)
-                .or_insert_with(|| Arc::new(Mutex::new(())))
-                .clone()
-        };
-        lock.try_lock_owned().ok()
     }
 }
 
@@ -47,16 +37,26 @@ mod tests {
     use tempfile::TempDir;
 
     #[tokio::test]
-    async fn rejects_same_workdir_until_guard_drops() {
+    async fn second_acquire_blocks_until_guard_drops() {
         let dir = TempDir::new().unwrap();
         let locks = WorkdirLocks::default();
 
-        let first = locks.try_acquire(dir.path()).await;
-        assert!(first.is_some());
-        assert!(locks.try_acquire(dir.path()).await.is_none());
+        let first = locks.acquire(dir.path()).await;
 
+        // A second acquire on the held folder must not resolve immediately…
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), locks.acquire(dir.path()))
+                .await
+                .is_err()
+        );
+
+        // …but does once the first guard drops.
         drop(first);
-        assert!(locks.try_acquire(dir.path()).await.is_some());
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(50), locks.acquire(dir.path()))
+                .await
+                .is_ok()
+        );
     }
 
     #[tokio::test]
@@ -87,11 +87,13 @@ mod tests {
         let two = TempDir::new().unwrap();
         let locks = WorkdirLocks::default();
 
-        let first = locks.try_acquire(one.path()).await;
-        let second = locks.try_acquire(two.path()).await;
-
-        assert!(first.is_some());
-        assert!(second.is_some());
+        // Distinct folders never contend — both acquire without waiting.
+        let _first = tokio::time::timeout(std::time::Duration::from_millis(50), locks.acquire(one.path()))
+            .await
+            .expect("first folder acquires immediately");
+        let _second = tokio::time::timeout(std::time::Duration::from_millis(50), locks.acquire(two.path()))
+            .await
+            .expect("second folder acquires immediately");
     }
 
     #[tokio::test]
@@ -100,8 +102,12 @@ mod tests {
         let locks = WorkdirLocks::default();
         let equivalent = dir.path().join(".");
 
-        let first = locks.try_acquire(dir.path()).await;
-        assert!(first.is_some());
-        assert!(locks.try_acquire(&equivalent).await.is_none());
+        let _first = locks.acquire(dir.path()).await;
+        // `dir` and `dir/.` canonicalize to the same key → the second waits.
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(20), locks.acquire(&equivalent))
+                .await
+                .is_err()
+        );
     }
 }

--- a/engine/houston-engine-server/src/routes/routines.rs
+++ b/engine/houston-engine-server/src/routes/routines.rs
@@ -15,7 +15,7 @@ use houston_engine_core::preferences;
 use houston_engine_core::routines::{
     self,
     engine_dispatcher::{EngineActivitySurface, EngineRoutineDispatcher},
-    runner::{cancel_run, run_routine},
+    runner::cancel_run,
     runs as routine_runs,
     types::{NewRoutine, Routine, RoutineRun, RoutineUpdate},
 };
@@ -162,14 +162,29 @@ async fn run_now(
     let dispatcher: Arc<dyn routines::runner::RoutineDispatcher> =
         Arc::new(make_dispatcher(&st));
     let surface: Arc<dyn routines::runner::ActivitySurface> = Arc::new(EngineActivitySurface);
-    run_routine(
-        st.engine.events.clone(),
-        dispatcher,
-        surface,
-        &q.agent_path,
-        &id,
-    )
-    .await?;
+    let events = st.engine.events.clone();
+
+    // Phase 1 runs in the request path so a missing routine (404) or an
+    // already-in-flight run of THIS routine (409) surfaces to the caller as a
+    // toast.
+    let begun = routines::runner::begin_run(&events, &q.agent_path, &id)?;
+
+    // Phase 2 — the actual session — runs on a detached task. A routine can
+    // take minutes, and may wait on the workdir lock behind another routine
+    // that's already running in the folder; we must not pin the HTTP request
+    // open for that. Critically, if we awaited it here and the client
+    // disconnected (navigate away / timeout), the dropped future would strand
+    // the run on `running` forever. The UI follows progress via
+    // `RoutineRunsChanged` events + query invalidation, not this response.
+    let agent_path = q.agent_path.clone();
+    tokio::spawn(async move {
+        if let Err(e) =
+            routines::runner::finish_run(events, dispatcher, surface, &agent_path, begun).await
+        {
+            tracing::error!("[routines] run-now dispatch failed for routine {id}: {e}");
+        }
+    });
+
     Ok(())
 }
 

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -170,7 +170,7 @@ not user-facing copy.
 | PATCH/DELETE | `/v1/routines/:id` | Update/delete |
 | POST | `/v1/routines/:id/runs` | Create run |
 | POST | `/v1/routines/:id/runs/:run_id:cancel` | Stop an in-flight run (kills the provider PID, marks status `cancelled`). 409 if the run is already terminal. Deleting a routine cascades to this for any `running` runs. |
-| POST | `/v1/routines/:id/run-now` | Manual trigger |
+| POST | `/v1/routines/:id/run-now` | Manual trigger. Returns once the run row is created (404 if the routine is gone, 409 if *this* routine already has a run in flight); the session runs on a detached task — follow it via `RoutineRunsChanged`. Different routines on one agent both run, serialized on the folder; the same routine can't double-run. |
 | GET | `/v1/routine-runs` | List (optional `?routineId`) |
 | PATCH | `/v1/routine-runs/:id` | Update run |
 | POST | `/v1/routines/scheduler/start` | Start per-agent cron |


### PR DESCRIPTION
Fixes #362.

## Problem

Two routines on the **same agent** scheduled for the **same time** only ran one of them — the other was silently dropped (neither auto nor manual), and a manually-triggered run could get stuck on `running` forever.

## Root cause — three stacked serialization bugs

1. **Per-agent in-flight gate.** `routine_runs::create_if_no_running` (called by every routine run) rejected if *any* run on the agent was `running`, ignoring the routine id. Routine A creates its `running` row → routine B hits the gate → `Conflict` → B's run is never created (cron logs an error; `run-now` returns 409).

2. **Fail-fast workdir lock.** The routine dispatcher is the *only* caller of the per-folder workdir lock (interactive chat sessions deliberately run concurrently in a folder). It used `try_acquire` (fail-fast), so even if both runs existed, the second errored with *"another mission is already running in this folder"* instead of waiting its turn.

3. **Blocking `run-now` → orphaned run.** `run-now` awaited the entire session inline. If the client disconnected (navigate away / timeout), axum dropped the handler future while the detached session task kept running — so the status-update code never ran and the row was stranded on `running` (only swept on the next engine restart). Same trap if `surface()` failed mid-run.

## Fix

- **Per-routine gate** — `create_if_no_running` → `create_if_routine_idle`: blocks only a second run of the *same* routine (keeps spam-click protection); a *different* routine on the same agent is allowed.
- **Waiting workdir lock** — `SessionRuntime::acquire_workdir` (was `try_acquire_workdir`) now *queues* on a busy folder. Two same-agent routines run **serially** (safe: no concurrent writes to the same folder); different agents still parallelize. Removed the now-dead fail-fast path.
- **Non-blocking `run-now`** — `run_routine` is split into `begin_run` (sync: validate + per-routine gate + create row; `404`/`409` still surface in the request path) and `finish_run` (async: dispatch + evaluate). `run-now` runs phase 1 inline and phase 2 on a detached task. `finish_run` **always** drives the run to a terminal status — including when `surface()` fails *or* the post-dispatch re-read fails — so a run can never be stranded on `running`.
- **Cancel-while-queued** — after acquiring the lock, a run cancelled while it sat queued skips spawning a session (no wasted provider tokens).
- Cron logs an expected per-routine conflict at `info`, not `error`.

## Behaviour after

| Scenario | Before | After |
|---|---|---|
| 2 routines, same agent, same time | only 1 runs | both run, serialized on the folder |
| 2 routines, different agents | (gated) | both run in parallel |
| same routine double-fired | dropped/errored | deduped (one in flight) |
| `run-now` + client disconnects | run stuck on `running` | run completes on detached task |

## Tests

Engine unit tests added/updated: per-routine gate (same vs different routine, concurrent), two routines on one agent both run **and** serialize on the real workdir lock (peak concurrency asserted == 1), surface-failure flips the run to `error`, cancel-while-queued helper, and the waiting-lock primitives. No protocol/TS changes — the frontend already tracks runs reactively via `RoutineRunsChanged`.

## Verify locally

```
cargo test -p houston-engine-core routines
cargo test -p houston-engine-core sessions
cargo build --workspace
```

## Files

- `engine/houston-engine-core/src/routines/runs.rs` — per-routine gate
- `engine/houston-engine-core/src/routines/runner.rs` — `begin_run`/`finish_run` split, always-terminal
- `engine/houston-engine-core/src/routines/engine_dispatcher.rs` — waiting lock + cancel-while-queued
- `engine/houston-engine-core/src/routines/scheduler.rs` — conflict log level
- `engine/houston-engine-core/src/sessions/mod.rs` — `acquire_workdir`
- `engine/houston-engine-core/src/sessions/workdir_locks.rs` — `acquire` is the API
- `engine/houston-engine-server/src/routes/routines.rs` — non-blocking `run-now`
- `knowledge-base/engine-protocol.md` — documented new `run-now` semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)