### PR TITLE
fix(chat): refresh assistant reply when switching between routine missions (#364)

### DIFF
--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -23,6 +23,7 @@ const DefaultThinkingIndicator = () => (
 );
 
 export function ChatPanel({
+  sessionKey,
   feedItems,
   onSend,
   onStop,
@@ -127,6 +128,18 @@ export function ChatPanel({
       )}
       {hasMessages || status !== "ready" ? (
         <ChatMessages
+          // Remount the whole message list when the conversation changes.
+          // Assistant text renders through Streamdown, a *streaming* markdown
+          // renderer that appends incrementally and holds internal parse/DOM
+          // state. Message keys are position-based ("assistant-1"), so they
+          // collide across conversations and React reuses those Streamdown
+          // instances on a session switch — swapping to a different mission's
+          // final answer leaves the previous reply on screen (the user message,
+          // plain text, updates; the assistant reply does not). Keying the list
+          // by sessionKey resets the subtree so each conversation renders fresh
+          // (#364). sessionKey is stable within a conversation, so live
+          // streaming is unaffected.
+          key={sessionKey}
           messages={messages}
           status={status}
           thinkingIndicator={thinkingIndicator ?? <DefaultThinkingIndicator />}


### PR DESCRIPTION
Fixes #364 

## Problem

Issue #364: In an agent's **Activity** tab, with two missions spawned by routines, clicking from the first to the second updated the **user message** but left the **previous mission's assistant reply** on screen. The only way to see the real content was to click a non-routine mission, which forced a refresh.

## Root cause

Assistant text renders through **Streamdown**, a *streaming* markdown renderer that appends incrementally and holds internal parse/DOM state. `feedItemsToMessages` keys messages by **position** (`assistant-1`, `user-0`), so those keys **collide across conversations**. On a session switch React reconciles the same-keyed nodes and **reuses the Streamdown instances** — the plain-text user bubble updates from props, but the streaming-markdown assistant reply keeps its stale internal state.

Routine missions hit this most visibly because two of them sit next to each other on the board with structurally identical message lists (same colliding keys); switching to a non-routine mission with a different shape forced a remount, which is why that "fixed" it.

## Fix

Key the `ChatMessages` subtree by `sessionKey` so each conversation renders a fresh subtree (the canonical React "reset state with `key`" pattern). `sessionKey` is stable within a conversation, so live streaming is unaffected. `ChatPanelProps.sessionKey` was already declared (required) and `AIBoard` already passed it — it was simply unused until now.

One file, +13 lines (11 are an explanatory comment).

## Scope

Targets **#364 only** (the switch-staleness). The separate surfaced-routine duplication (#363) is intentionally out of scope.

## Testing

- `pnpm --filter @houston-ai/chat typecheck` ✅
- `pnpm --filter @houston-ai/board typecheck` ✅
- `app` `tsc --noEmit` ✅
- Chat package logic tests pass (the one failing `chat-status` test is pre-existing on `main` and unrelated — it asserts `deriveStatus` behavior this PR does not touch).

This is a render-identity fix; `ui/chat` has no React-render test harness (its tests are pure-logic `node:test`), and the bug only reproduces with a stateful client re-render reusing Streamdown instances. Recommend a quick manual check: run two routines, then click between their missions in Activity and confirm each shows its own reply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)