### PR TITLE
fix(chat): separate integration connection status from reconnect action

### DIFF
--- a/app/src-tauri/src/houston_prompt/integrations.rs
+++ b/app/src-tauri/src/houston_prompt/integrations.rs
@@ -36,5 +36,12 @@ to go to the Integrations tab. Instead:\n\n\
    output exactly: \
    `[Connect Gmail](https://connect.composio.dev/link/lk_abc#houston_toolkit=gmail)`. \
    The card renders the app name/logo and handles the click for you.\n\
-4. After they tell you they've approved in the browser, retry the \
-   original request.";
+4. Do NOT ask the user to tell you when they're done, and do NOT promise \
+   to \"check\" or \"confirm\" the connection yourself. Houston detects the \
+   moment the connection goes live and automatically sends you a short \
+   message (e.g. \"I've connected Gmail. Please continue.\") so you can \
+   resume the task on your own. Phrase your message to set that \
+   expectation instead of asking them to report back, e.g. \"Once you \
+   approve access in the browser, I'll keep going from here \
+   automatically.\" Then stop and wait. When Houston's confirmation \
+   arrives, retry the original request.";

--- a/app/src/components/composio-card-state.ts
+++ b/app/src/components/composio-card-state.ts
@@ -12,6 +12,27 @@
  * auth flow.
  */
 
+import { normalizeToolkitSlug } from "../lib/composio-toolkits.ts";
+
+/**
+ * Is `toolkit` present in the connected set?
+ *
+ * `connected` is already normalized (lowercased) by the
+ * `useConnectedToolkits` query, but `toolkit` arrives raw from the
+ * agent-authored `#houston_toolkit=<slug>` fragment — so it can carry any
+ * casing or stray whitespace. Comparing the two directly silently misses a
+ * real connection (e.g. fragment `GoogleDrive` vs probe `googledrive`),
+ * leaving the card stuck on "Connecting…" forever even after the engine
+ * watcher has detected the landing. Normalize the lookup so the card
+ * reflects the same truth the engine already computed.
+ */
+export function isToolkitConnected(
+  connected: ReadonlySet<string>,
+  toolkit: string,
+): boolean {
+  return connected.has(normalizeToolkitSlug(toolkit));
+}
+
 /**
  * Local interaction state owned by the card. The real connection status
  * (`isConnected`, resolved from the shared probe query) is tracked

--- a/app/src/components/composio-card-state.ts
+++ b/app/src/components/composio-card-state.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure presentation logic for the inline Composio connection card
+ * (`ComposioLinkCard`). Extracted so the three-way visual state and the
+ * "should we nudge the agent" decision are unit-testable without a DOM —
+ * the component stays a thin shell over these functions.
+ *
+ * Background (issue #379): the old card folded *status* and *action* into
+ * one button that read "I've connected" while also showing reconnect
+ * arrows, so it looked like it was simultaneously claiming a connection and
+ * offering to redo it. The new model keeps them separate: a status badge
+ * (connecting / connected) plus a distinct arrows button to (re)open the
+ * auth flow.
+ */
+
+/**
+ * Local interaction state owned by the card. The real connection status
+ * (`isConnected`, resolved from the shared probe query) is tracked
+ * separately and always wins over this phase.
+ *
+ *   - "idle"       — the user has not started a connect from this card.
+ *   - "connecting" — the user clicked Connect / Reconnect and we are
+ *                    waiting for the connection to land. Detection is
+ *                    automatic via the connection watchers, so there is no
+ *                    manual "I've connected" step anymore.
+ */
+export type ComposioCardPhase = "idle" | "connecting";
+
+/**
+ * What the card actually renders, derived from the real connection status
+ * and the local phase.
+ *
+ *   - "connected"  — green "Connected" badge + arrows reconnect button.
+ *   - "connecting" — "Connecting…" loading badge + arrows reconnect button.
+ *   - "idle"       — single "Connect" call-to-action button.
+ */
+export type ComposioCardView = "idle" | "connecting" | "connected";
+
+/**
+ * Map (real status, local phase) → the rendered view. A confirmed
+ * connection always wins: once the probe says connected we show the
+ * connected badge regardless of where the local phase sits, so a stale
+ * "connecting" can never mask a live connection.
+ */
+export function deriveComposioCardView(
+  isConnected: boolean,
+  phase: ComposioCardPhase,
+): ComposioCardView {
+  if (isConnected) return "connected";
+  if (phase === "connecting") return "connecting";
+  return "idle";
+}
+
+export interface ConnectedFollowupInput {
+  /** The card's previous `isConnected` snapshot. */
+  wasConnected: boolean;
+  /** The card's current `isConnected` value. */
+  isConnected: boolean;
+  /** Did the user start a connect / reconnect from THIS card? */
+  hasInitiated: boolean;
+  /** Have we already sent the follow-up for this connection? */
+  alreadyFired: boolean;
+}
+
+/**
+ * Decide whether to send the proactive "I've connected X, please continue"
+ * follow-up to the agent.
+ *
+ * Fires exactly once, only on a real not-connected → connected transition,
+ * and only when the user drove the connect from this card. That is what
+ * keeps the nudge honest:
+ *
+ *   - A card that mounts already-connected (the agent linked an app the
+ *     user had connected earlier) never nudges — there was no transition
+ *     and no user action here.
+ *   - A connection that lands because another card, the Integrations tab,
+ *     or the CLI did the work never nudges from this card (`hasInitiated`
+ *     is false), so two cards for two apps each only speak for their own.
+ *   - `alreadyFired` dedupes against re-renders and status flaps.
+ */
+export function shouldSendConnectedFollowup({
+  wasConnected,
+  isConnected,
+  hasInitiated,
+  alreadyFired,
+}: ConnectedFollowupInput): boolean {
+  return isConnected && !wasConnected && hasInitiated && !alreadyFired;
+}
+
+/**
+ * Parse a Composio redirect URL for the `#houston_toolkit=<slug>` fragment
+ * that agents append per the system prompt. Returns the slug, or `null` if
+ * the URL doesn't carry one — which is the chat link renderer's signal to
+ * fall back to a plain markdown link instead of rendering the card.
+ */
+export function parseComposioToolkitFromHref(href: string): string | null {
+  try {
+    const url = new URL(href);
+    const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+    if (!hash) return null;
+    const params = new URLSearchParams(hash);
+    const slug = params.get("houston_toolkit");
+    return slug && slug.length > 0 ? slug : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort logo when Composio's catalog doesn't supply one: Google's
+ * favicon service, keyed off the toolkit slug as a domain guess.
+ */
+export function fallbackLogo(toolkit: string): string {
+  return `https://www.google.com/s2/favicons?domain=${toolkit}.com&sz=128`;
+}

--- a/app/src/components/composio-card-visuals.tsx
+++ b/app/src/components/composio-card-visuals.tsx
@@ -1,0 +1,100 @@
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Check, ExternalLink, Loader2, RefreshCw } from "lucide-react";
+import type { ComposioCardView } from "./composio-card-state";
+
+/**
+ * Presentational right-slot for the Composio card. Keeps connection
+ * *status* (a badge) visually distinct from the connect *action* (the
+ * arrows button), which is the core of the issue #379 fix — the old card
+ * fused them into one ambiguous "I've connected" control.
+ *
+ *   - connected  → green "Connected" badge + arrows reconnect button
+ *   - connecting → "Connecting…" loading badge + arrows reconnect button
+ *   - idle       → single "Connect" call-to-action
+ *
+ * `onConnect` drives every path: the Connect CTA and the arrows button both
+ * (re)open the auth flow.
+ */
+export function ComposioStatusSlot({
+  view,
+  onConnect,
+}: {
+  view: ComposioCardView;
+  onConnect: () => void;
+}) {
+  const { t } = useTranslation("chat");
+
+  const reconnectButton = (
+    <button
+      type="button"
+      onClick={onConnect}
+      aria-label={t("composio.reconnect")}
+      title={t("composio.reconnect")}
+      className="inline-flex items-center justify-center size-7 rounded-full border border-border text-muted-foreground hover:text-foreground hover:bg-accent transition-colors duration-200 shrink-0"
+    >
+      <RefreshCw className="size-3.5" />
+    </button>
+  );
+
+  if (view === "connected") {
+    return (
+      <span className="inline-flex items-center gap-1.5 shrink-0">
+        <span className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full bg-emerald-50 text-emerald-700 text-xs font-medium">
+          <Check className="size-3" />
+          {t("composio.connected")}
+        </span>
+        {reconnectButton}
+      </span>
+    );
+  }
+
+  if (view === "connecting") {
+    return (
+      <span className="inline-flex items-center gap-1.5 shrink-0">
+        <span className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full bg-secondary text-muted-foreground text-xs font-medium">
+          <Loader2 className="size-3 animate-spin" />
+          {t("composio.connecting")}
+        </span>
+        {reconnectButton}
+      </span>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onConnect}
+      className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full border border-border bg-foreground text-background text-xs font-medium hover:opacity-90 transition-opacity duration-200 shrink-0"
+    >
+      {t("composio.connect")}
+      <ExternalLink className="size-3" />
+    </button>
+  );
+}
+
+/**
+ * App logo with an initial-letter fallback when the catalog image fails to
+ * load (broken/expired logo URL, offline favicon service).
+ */
+export function AppLogo({ app }: { app: { name: string; logoUrl: string } }) {
+  const [imgError, setImgError] = useState(false);
+  const initial = app.name.charAt(0).toUpperCase();
+  if (imgError) {
+    return (
+      <span className="size-8 rounded-lg bg-accent flex items-center justify-center shrink-0">
+        <span className="text-xs font-semibold text-muted-foreground">
+          {initial}
+        </span>
+      </span>
+    );
+  }
+  return (
+    <img
+      src={app.logoUrl}
+      alt={app.name}
+      className="size-8 rounded-lg object-contain shrink-0"
+      onError={() => setImgError(true)}
+    />
+  );
+}

--- a/app/src/components/composio-link-card.tsx
+++ b/app/src/components/composio-link-card.tsx
@@ -1,6 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useComposioApps } from "../hooks/queries";
+import {
+  useComposioApps,
+  useConnectedToolkits,
+  useConnections,
+} from "../hooks/queries";
 import { useComposioConnectionWatcher } from "../hooks/use-composio-connection-watcher";
 import { useComposioRefetchOnReturn } from "../hooks/use-composio-refetch-on-return";
 import { normalizeToolkitSlug } from "../lib/composio-toolkits";
@@ -9,6 +13,7 @@ import { analytics } from "../lib/analytics";
 import {
   deriveComposioCardView,
   fallbackLogo,
+  isToolkitConnected,
   shouldSendConnectedFollowup,
   type ComposioCardPhase,
 } from "./composio-card-state";
@@ -26,12 +31,6 @@ const CONNECTING_TIMEOUT_MS = 90_000;
 
 interface ComposioLinkCardProps {
   toolkit: string;
-  /**
-   * True if this toolkit is currently connected in the user's Composio
-   * account. Resolved from the shared `useConnectedToolkits` query in
-   * the parent (chat-tab / board-tab).
-   */
-  isConnected: boolean;
   /**
    * Default open-URL handler from the chat's link renderer. Called when
    * the user clicks Connect — opens the authorization URL in the
@@ -66,11 +65,28 @@ interface ComposioLinkCardProps {
  */
 export function ComposioLinkCard({
   toolkit,
-  isConnected,
   onOpen,
   onConnected,
 }: ComposioLinkCardProps) {
   const { t } = useTranslation("chat");
+
+  // Own the connection status instead of taking it as a prop. The card
+  // renders inside Streamdown, which memoizes a completed markdown block by
+  // its source text and stops re-invoking the custom link renderer once the
+  // message has finished streaming. A parent-computed `isConnected` prop
+  // therefore freezes at the card's first render and never reflects a
+  // connection that lands afterwards — the eternal "Connecting…" bug. By
+  // subscribing to the query here, the card re-renders itself the moment the
+  // status changes, independent of Streamdown's block memoization. TanStack
+  // dedupes the fetch, so N cards still issue one request per tick.
+  const { data: composioStatus } = useConnections();
+  const isSignedIn = composioStatus?.status === "ok";
+  const { data: connectedList } = useConnectedToolkits(isSignedIn);
+  const isConnected = useMemo(
+    () => isToolkitConnected(new Set(connectedList ?? []), toolkit),
+    [connectedList, toolkit],
+  );
+
   const [phase, setPhase] = useState<ComposioCardPhase>("idle");
   const graceTimer = useRef<number | null>(null);
   // Whether the user started a connect/reconnect from this card. Gates the
@@ -92,7 +108,13 @@ export function ComposioLinkCard({
   useComposioConnectionWatcher(isConnected);
 
   const app = (() => {
-    const fromApi = apiApps?.find((a) => a.toolkit === toolkit);
+    // The catalog reports canonical (lowercased) slugs; `toolkit` is the
+    // raw fragment slug, so normalize both sides or a mis-cased slug falls
+    // back to the bare name + favicon guess instead of the real name/logo.
+    const normalizedToolkit = normalizeToolkitSlug(toolkit);
+    const fromApi = apiApps?.find(
+      (a) => normalizeToolkitSlug(a.toolkit) === normalizedToolkit,
+    );
     if (fromApi) {
       return {
         toolkit: fromApi.toolkit,

--- a/app/src/components/composio-link-card.tsx
+++ b/app/src/components/composio-link-card.tsx
@@ -1,29 +1,28 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { useQueryClient } from "@tanstack/react-query";
-import { Check, ExternalLink, Loader2, RefreshCw } from "lucide-react";
 import { useComposioApps } from "../hooks/queries";
 import { useComposioConnectionWatcher } from "../hooks/use-composio-connection-watcher";
 import { useComposioRefetchOnReturn } from "../hooks/use-composio-refetch-on-return";
-import {
-  normalizeToolkitSlug,
-  normalizeToolkitSlugs,
-} from "../lib/composio-toolkits";
-import { queryKeys } from "../lib/query-keys";
+import { normalizeToolkitSlug } from "../lib/composio-toolkits";
 import { useUIStore } from "../stores/ui";
 import { analytics } from "../lib/analytics";
+import {
+  deriveComposioCardView,
+  fallbackLogo,
+  shouldSendConnectedFollowup,
+  type ComposioCardPhase,
+} from "./composio-card-state";
+import { AppLogo, ComposioStatusSlot } from "./composio-card-visuals";
 
 /**
- * After clicking Connect, the user goes to the browser to authorize.
- * This is how long we leave the spinner up before flipping to a
- * manual "I've connected" button. Short enough that a stuck card
- * recovers quickly; long enough to cover the typical OAuth round-trip
- * + Composio backend propagation when the engine-side watcher catches
- * the event for us.
+ * After clicking Connect, the user leaves for the browser to authorize. If
+ * nothing has landed within this window we drop the "Connecting…" badge and
+ * restore the Connect call-to-action, so the card never shows an eternal
+ * spinner for an abandoned or failed flow. The engine-side watch and the
+ * ambient connection watcher keep running regardless, so a late connection
+ * still flips the card to Connected (and nudges the agent) on its own.
  */
-const OPENING_GRACE_MS = 6_000;
-
-type Phase = "idle" | "opening" | "verify" | "verifying";
+const CONNECTING_TIMEOUT_MS = 90_000;
 
 interface ComposioLinkCardProps {
   toolkit: string;
@@ -39,31 +38,50 @@ interface ComposioLinkCardProps {
    * system browser.
    */
   onOpen: () => void;
+  /**
+   * Fired once when a connection the user started from THIS card actually
+   * lands. The chat panel uses it to proactively nudge the agent ("I've
+   * connected X, please continue") so the task resumes without the user
+   * having to type. Optional: surfaces (like onboarding) that don't want a
+   * follow-up simply omit it.
+   */
+  onConnected?: (toolkit: string, appName: string) => void;
 }
 
 /**
  * Rich inline card rendered in place of plain markdown links when the
  * agent outputs a Composio connect URL tagged with
- * `#houston_toolkit=<slug>`. Shows the app's logo + name and reflects
- * live connection state:
+ * `#houston_toolkit=<slug>`. Shows the app's logo + name and keeps the
+ * connection *status* visually separate from the *action* (issue #379):
  *
- *   - Connected → green "Connected" pill, click is a no-op
- *   - Not connected → "Connect" button that opens the OAuth URL and,
- *     when the Houston window regains focus (user returned from the
- *     browser), invalidates the probe query so the card flips to
- *     Connected. OAuth flows vary from 5s to 60s+ so a fixed timeout
- *     would always be wrong — focus-driven invalidation updates
- *     precisely when the user looks at the card.
+ *   - Not connected, idle → a single "Connect" button that opens the OAuth
+ *     URL.
+ *   - Connecting → a "Connecting…" loading badge plus a distinct arrows
+ *     button to re-open the auth flow. Detection is automatic: the engine
+ *     watch + ambient watcher invalidate the shared probe query the moment
+ *     the connection appears (this card, the Integrations tab, another
+ *     agent, the CLI), so there is no manual "I've connected" step.
+ *   - Connected → a green "Connected" badge plus the same arrows button to
+ *     reconnect.
  */
 export function ComposioLinkCard({
   toolkit,
   isConnected,
   onOpen,
+  onConnected,
 }: ComposioLinkCardProps) {
   const { t } = useTranslation("chat");
-  const [phase, setPhase] = useState<Phase>("idle");
+  const [phase, setPhase] = useState<ComposioCardPhase>("idle");
   const graceTimer = useRef<number | null>(null);
-  const qc = useQueryClient();
+  // Whether the user started a connect/reconnect from this card. Gates the
+  // proactive agent nudge so the card only speaks for connections it drove.
+  const hasInitiated = useRef(false);
+  // Dedupe guard so the nudge fires at most once per landed connection.
+  const followupFired = useRef(false);
+  // Previous `isConnected` snapshot, to detect the not-connected → connected
+  // edge. Seeded with the mount value so a card that mounts already-connected
+  // registers no transition (and therefore no nudge).
+  const prevConnected = useRef(isConnected);
   const addToast = useUIStore((s) => s.addToast);
   const { data: apiApps } = useComposioApps();
   const markWaitingForAuth = useComposioRefetchOnReturn();
@@ -72,29 +90,6 @@ export function ComposioLinkCard({
   // connection lands via any path (this Connect, Integrations tab,
   // another agent, CLI, stale cache from a prior session).
   useComposioConnectionWatcher(isConnected);
-
-  // Once the probe comes back connected, drop any local intermediate
-  // state — the parent owns the visual now.
-  useEffect(() => {
-    if (isConnected) {
-      setPhase("idle");
-      if (graceTimer.current !== null) {
-        window.clearTimeout(graceTimer.current);
-        graceTimer.current = null;
-      }
-    }
-  }, [isConnected]);
-
-  // Always clean up the grace timer on unmount so it never fires
-  // against a dead component.
-  useEffect(() => {
-    return () => {
-      if (graceTimer.current !== null) {
-        window.clearTimeout(graceTimer.current);
-        graceTimer.current = null;
-      }
-    };
-  }, []);
 
   const app = (() => {
     const fromApi = apiApps?.find((a) => a.toolkit === toolkit);
@@ -113,110 +108,70 @@ export function ComposioLinkCard({
       logoUrl: fallbackLogo(toolkit),
     };
   })();
+  const appName = app.name;
 
-  const handleConnect = useCallback(() => {
-    setPhase("opening");
-    markWaitingForAuth(toolkit);
-    onOpen();
-    // After the grace window, hand control to the user. The engine
-    // watcher and the ambient connection watcher are both still
-    // running; if a connection lands while we're in `verify` state,
-    // the parent's `isConnected` will flip and the effect above
-    // resets the phase.
-    if (graceTimer.current !== null) window.clearTimeout(graceTimer.current);
-    graceTimer.current = window.setTimeout(() => {
-      setPhase((p) => (p === "opening" ? "verify" : p));
-      graceTimer.current = null;
-    }, OPENING_GRACE_MS);
-  }, [onOpen, markWaitingForAuth, toolkit]);
+  // Watch the real connection status. On the not-connected → connected edge
+  // for a connection this card started, nudge the agent and confirm to the
+  // user. Always clear the in-flight "connecting" UI once truly connected.
+  useEffect(() => {
+    const wasConnected = prevConnected.current;
+    prevConnected.current = isConnected;
 
-  const handleVerify = useCallback(async () => {
-    setPhase("verifying");
-    // Hard refresh: cancel anything in flight so a stale "[]" can't
-    // race past us, force the registered query to refetch, then read
-    // the freshly-written cache. We don't trust the cached
-    // `isConnected` prop here — the user explicitly asked us to
-    // re-check.
-    await qc.cancelQueries({ queryKey: queryKeys.connectedToolkits() });
-    await qc.refetchQueries({
-      queryKey: queryKeys.connectedToolkits(),
-      type: "active",
-    });
-    const target = normalizeToolkitSlug(toolkit);
-    const fresh = normalizeToolkitSlugs(
-      qc.getQueryData<string[]>(queryKeys.connectedToolkits()) ?? [],
-    );
-    const connected = fresh.includes(target);
-    if (connected) {
-      analytics.track("integration_connected", { integration_slug: target });
+    if (isConnected) {
+      if (graceTimer.current !== null) {
+        window.clearTimeout(graceTimer.current);
+        graceTimer.current = null;
+      }
+      setPhase("idle");
+    }
+
+    if (
+      shouldSendConnectedFollowup({
+        wasConnected,
+        isConnected,
+        hasInitiated: hasInitiated.current,
+        alreadyFired: followupFired.current,
+      })
+    ) {
+      followupFired.current = true;
+      analytics.track("integration_connected", {
+        integration_slug: normalizeToolkitSlug(toolkit),
+      });
+      onConnected?.(toolkit, appName);
       addToast({
-        title: t("composio.verifiedToast", { name: app.name }),
+        title: t("composio.verifiedToast", { name: appName }),
         variant: "success",
       });
-      // Parent's isConnected will flip on the next render; effect
-      // above resets phase to idle.
-    } else {
-      addToast({
-        title: t("composio.notVerified"),
-        variant: "info",
-      });
-      setPhase("verify");
     }
-  }, [qc, toolkit, addToast, t, app.name]);
+  }, [isConnected, toolkit, appName, onConnected, addToast, t]);
 
-  const renderRightSlot = () => {
-    if (isConnected) {
-      return (
-        <span className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full bg-emerald-50 text-emerald-700 text-xs font-medium shrink-0">
-          <Check className="size-3" />
-          {t("composio.connected")}
-        </span>
-      );
-    }
-    if (phase === "opening") {
-      return (
-        <button
-          type="button"
-          disabled
-          className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full border border-border bg-foreground text-background text-xs font-medium opacity-50 shrink-0"
-        >
-          <Loader2 className="size-3 animate-spin" />
-        </button>
-      );
-    }
-    if (phase === "verify" || phase === "verifying") {
-      return (
-        <button
-          type="button"
-          onClick={phase === "verifying" ? undefined : handleVerify}
-          disabled={phase === "verifying"}
-          className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full border border-border bg-secondary text-foreground text-xs font-medium hover:bg-black/[0.05] transition-colors duration-200 disabled:opacity-50 shrink-0"
-        >
-          {phase === "verifying" ? (
-            <>
-              <Loader2 className="size-3 animate-spin" />
-              {t("composio.verifying")}
-            </>
-          ) : (
-            <>
-              <RefreshCw className="size-3" />
-              {t("composio.verify")}
-            </>
-          )}
-        </button>
-      );
-    }
-    return (
-      <button
-        type="button"
-        onClick={handleConnect}
-        className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full border border-border bg-foreground text-background text-xs font-medium hover:opacity-90 transition-opacity duration-200 shrink-0"
-      >
-        {t("composio.connect")}
-        <ExternalLink className="size-3" />
-      </button>
-    );
-  };
+  // Always clean up the grace timer on unmount so it never fires
+  // against a dead component.
+  useEffect(() => {
+    return () => {
+      if (graceTimer.current !== null) {
+        window.clearTimeout(graceTimer.current);
+        graceTimer.current = null;
+      }
+    };
+  }, []);
+
+  // Single entry point for both the Connect CTA and the arrows reconnect
+  // button: open the auth URL, arm the watchers, and show "Connecting…"
+  // while we wait for detection.
+  const startConnect = useCallback(() => {
+    hasInitiated.current = true;
+    setPhase("connecting");
+    markWaitingForAuth(toolkit);
+    onOpen();
+    if (graceTimer.current !== null) window.clearTimeout(graceTimer.current);
+    graceTimer.current = window.setTimeout(() => {
+      setPhase((p) => (p === "connecting" ? "idle" : p));
+      graceTimer.current = null;
+    }, CONNECTING_TIMEOUT_MS);
+  }, [onOpen, markWaitingForAuth, toolkit]);
+
+  const view = deriveComposioCardView(isConnected, phase);
 
   return (
     <span className="not-prose inline-flex my-1 max-w-full align-middle">
@@ -230,52 +185,8 @@ export function ComposioLinkCard({
             {isConnected ? t("composio.alreadyConnected") : app.description}
           </span>
         </span>
-        {renderRightSlot()}
+        <ComposioStatusSlot view={view} onConnect={startConnect} />
       </span>
     </span>
   );
-}
-
-function AppLogo({ app }: { app: { name: string; logoUrl: string } }) {
-  const [imgError, setImgError] = useState(false);
-  const initial = app.name.charAt(0).toUpperCase();
-  if (imgError) {
-    return (
-      <span className="size-8 rounded-lg bg-accent flex items-center justify-center shrink-0">
-        <span className="text-xs font-semibold text-muted-foreground">
-          {initial}
-        </span>
-      </span>
-    );
-  }
-  return (
-    <img
-      src={app.logoUrl}
-      alt={app.name}
-      className="size-8 rounded-lg object-contain shrink-0"
-      onError={() => setImgError(true)}
-    />
-  );
-}
-
-/**
- * Parse a Composio redirect URL for the `#houston_toolkit=<slug>`
- * fragment that agents append per the system prompt. Returns the slug
- * or `null` if the URL doesn't carry one.
- */
-export function parseComposioToolkitFromHref(href: string): string | null {
-  try {
-    const url = new URL(href);
-    const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
-    if (!hash) return null;
-    const params = new URLSearchParams(hash);
-    const slug = params.get("houston_toolkit");
-    return slug && slug.length > 0 ? slug : null;
-  } catch {
-    return null;
-  }
-}
-
-function fallbackLogo(toolkit: string): string {
-  return `https://www.google.com/s2/favicons?domain=${toolkit}.com&sz=128`;
 }

--- a/app/src/components/onboarding/missions/try.tsx
+++ b/app/src/components/onboarding/missions/try.tsx
@@ -21,10 +21,8 @@ import {
   isActiveSessionStatus,
 } from "../../../stores/session-status";
 import { useChatDisplayLabels } from "../../use-chat-display-labels";
-import {
-  ComposioLinkCard,
-  parseComposioToolkitFromHref,
-} from "../../composio-link-card";
+import { ComposioLinkCard } from "../../composio-link-card";
+import { parseComposioToolkitFromHref } from "../../composio-card-state";
 import {
   ComposioSigninCard,
   isComposioSigninHref,

--- a/app/src/components/onboarding/missions/try.tsx
+++ b/app/src/components/onboarding/missions/try.tsx
@@ -2,10 +2,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ChatPanel, type FeedItem } from "@houston-ai/chat";
 import { HoustonAvatar, cn, resolveAgentColor } from "@houston-ai/core";
-import {
-  useConnectedToolkits,
-  useConnections,
-} from "../../../hooks/queries";
 import { tauriAgent, tauriChat, tauriSystem } from "../../../lib/tauri";
 import { logger } from "../../../lib/logger";
 import { createMission } from "../../../lib/create-mission";
@@ -127,14 +123,6 @@ export function TryMission({
   const [pickedAny, setPickedAny] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const { data: composioStatus } = useConnections();
-  const isSignedIn = composioStatus?.status === "ok";
-  const { data: connectedList } = useConnectedToolkits(isSignedIn);
-  const connectedSet = useMemo(
-    () => new Set(connectedList ?? []),
-    [connectedList],
-  );
-
   // Append the tutorial directive to CLAUDE.md while this mission is
   // mounted; strip on unmount. Agent reads the augmented file at session
   // start so the directive lives in the system context, not in any
@@ -202,14 +190,10 @@ export function TryMission({
       const toolkit = parseComposioToolkitFromHref(href);
       if (!toolkit) return undefined;
       return (
-        <ComposioLinkCard
-          toolkit={toolkit}
-          isConnected={connectedSet.has(toolkit)}
-          onOpen={onOpen}
-        />
+        <ComposioLinkCard toolkit={toolkit} onOpen={onOpen} />
       );
     },
-    [connectedSet],
+    [],
   );
 
   const transformContent = useCallback((content: string) => {

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -57,10 +57,8 @@ import { createMission } from "../lib/create-mission";
 import { queryKeys } from "../lib/query-keys";
 import { humanizeSkillName } from "../lib/humanize-skill-name";
 import { useFileToolRenderer } from "../hooks/use-file-tool-renderer";
-import {
-  ComposioLinkCard,
-  parseComposioToolkitFromHref,
-} from "./composio-link-card";
+import { ComposioLinkCard } from "./composio-link-card";
+import { parseComposioToolkitFromHref } from "./composio-card-state";
 import {
   ComposioSigninCard,
   isComposioSigninHref,
@@ -160,6 +158,7 @@ export function useAgentChatPanel({
   const { processLabels, getThinkingMessage } = useChatDisplayLabels();
   const queryClient = useQueryClient();
   const addToast = useUIStore((s) => s.addToast);
+  const pushFeedItem = useFeedStore((s) => s.pushFeedItem);
 
   const path = agent?.folderPath ?? null;
   const agentModes = agentDef?.config.agents;
@@ -303,6 +302,45 @@ export function useAgentChatPanel({
     () => new Set(connectedList ?? []),
     [connectedList],
   );
+  // When a connection the user started from a chat card actually lands,
+  // proactively nudge the agent so it resumes the task without the user
+  // having to retype. Mirrors the retry send-path: send first, then push the
+  // optimistic feed item; surface a toast if the send fails (no silent drop).
+  const handleIntegrationConnected = useCallback(
+    (_toolkit: string, appName: string) => {
+      if (!path || !selectedSessionKey) return;
+      const text = t("chat:composio.connectedFollowup", { name: appName });
+      tauriChat
+        .send(path, text, selectedSessionKey, {
+          providerOverride: effectiveProvider,
+          modelOverride: effectiveModel,
+          effortOverride: effectiveEffort,
+        })
+        .then(() => {
+          pushFeedItem(path, selectedSessionKey, {
+            feed_type: "user_message",
+            data: text,
+          });
+        })
+        .catch((err) => {
+          addToast({
+            title: t("chat:composio.followupFailed", { name: appName }),
+            description: String(err),
+            variant: "error",
+          });
+        });
+    },
+    [
+      path,
+      selectedSessionKey,
+      effectiveProvider,
+      effectiveModel,
+      effectiveEffort,
+      pushFeedItem,
+      addToast,
+      t,
+    ],
+  );
   const renderLink = useCallback(
     ({ href, onOpen }: { href: string; onOpen: () => void }) => {
       if (isComposioSigninHref(href)) {
@@ -315,10 +353,11 @@ export function useAgentChatPanel({
           toolkit={toolkit}
           isConnected={connectedSet.has(toolkit)}
           onOpen={onOpen}
+          onConnected={handleIntegrationConnected}
         />
       );
     },
-    [connectedSet],
+    [connectedSet, handleIntegrationConnected],
   );
 
   // ── File-tool rendering (per-agent path) ──────────────────────────────
@@ -350,7 +389,6 @@ export function useAgentChatPanel({
     onSelectSessionRef.current = onSelectSession;
   }, [onSelectSession]);
 
-  const pushFeedItem = useFeedStore((s) => s.pushFeedItem);
   const attachmentLabels = useMemo<UserAttachmentMessageLabels>(
     () => ({
       attachmentCount: (count) => t("attachmentMessage.count", { count }),

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -37,12 +37,7 @@ import {
 
 import { useFeedStore } from "../stores/feeds";
 import { useUIStore } from "../stores/ui";
-import {
-  useActivity,
-  useConnectedToolkits,
-  useConnections,
-  useSkills,
-} from "../hooks/queries";
+import { useActivity, useSkills } from "../hooks/queries";
 import {
   tauriActivity,
   tauriAttachments,
@@ -86,6 +81,10 @@ import {
   encodeSkillMessage,
 } from "../lib/skill-message";
 import { attachmentReferences } from "../lib/attachment-message";
+import {
+  encodeAutoContinueMessage,
+  filterAutoContinueFeedItems,
+} from "../lib/auto-continue-message";
 import { SkillCard } from "./skill-card";
 import { NewMissionPickerDialog } from "./new-mission-picker-dialog";
 import { UserSkillMessage } from "./user-skill-message";
@@ -295,13 +294,10 @@ export function useAgentChatPanel({
   );
 
   // ── Composio link card support ────────────────────────────────────────
-  const { data: composioStatus } = useConnections();
-  const isSignedIn = composioStatus?.status === "ok";
-  const { data: connectedList } = useConnectedToolkits(isSignedIn);
-  const connectedSet = useMemo(
-    () => new Set(connectedList ?? []),
-    [connectedList],
-  );
+  // The card owns its own connection status (it subscribes to the
+  // connectedToolkits query directly so it stays reactive inside Streamdown's
+  // memoized markdown blocks). The panel only supplies the agent nudge.
+  //
   // When a connection the user started from a chat card actually lands,
   // proactively nudge the agent so it resumes the task without the user
   // having to retype. Mirrors the retry send-path: send first, then push the
@@ -309,18 +305,19 @@ export function useAgentChatPanel({
   const handleIntegrationConnected = useCallback(
     (_toolkit: string, appName: string) => {
       if (!path || !selectedSessionKey) return;
-      const text = t("chat:composio.connectedFollowup", { name: appName });
+      // The agent needs a user turn to resume, but the user didn't type one.
+      // Tag it with the auto-continue marker so the agent still receives the
+      // instruction while the transcript hides the bubble (see
+      // `mapFeedItems`). No optimistic push: we never want it shown, and the
+      // engine-persisted copy is filtered the same way on reload.
+      const message = encodeAutoContinueMessage(
+        t("chat:composio.connectedFollowup", { name: appName }),
+      );
       tauriChat
-        .send(path, text, selectedSessionKey, {
+        .send(path, message, selectedSessionKey, {
           providerOverride: effectiveProvider,
           modelOverride: effectiveModel,
           effortOverride: effectiveEffort,
-        })
-        .then(() => {
-          pushFeedItem(path, selectedSessionKey, {
-            feed_type: "user_message",
-            data: text,
-          });
         })
         .catch((err) => {
           addToast({
@@ -336,7 +333,6 @@ export function useAgentChatPanel({
       effectiveProvider,
       effectiveModel,
       effectiveEffort,
-      pushFeedItem,
       addToast,
       t,
     ],
@@ -351,13 +347,12 @@ export function useAgentChatPanel({
       return (
         <ComposioLinkCard
           toolkit={toolkit}
-          isConnected={connectedSet.has(toolkit)}
           onOpen={onOpen}
           onConnected={handleIntegrationConnected}
         />
       );
     },
-    [connectedSet, handleIntegrationConnected],
+    [handleIntegrationConnected],
   );
 
   // ── File-tool rendering (per-agent path) ──────────────────────────────
@@ -588,7 +583,7 @@ export function useAgentChatPanel({
   );
   const mapFeedItems = useCallback(
     ({ items }: { sessionKey: string; items: FeedItem[] }) =>
-      filterProviderAuthFeedItems(items),
+      filterAutoContinueFeedItems(filterProviderAuthFeedItems(items)),
     [],
   );
   const afterMessages = useCallback(

--- a/app/src/lib/auto-continue-message.ts
+++ b/app/src/lib/auto-continue-message.ts
@@ -1,0 +1,41 @@
+/**
+ * A "continue the task" message Houston sends to the agent on the user's
+ * behalf — e.g. when a Composio integration the user started from a chat
+ * card finishes connecting.
+ *
+ * The provider has no "resume without a prompt" concept, so the agent needs
+ * a user turn to continue. But the user never typed it, and showing a fake
+ * "I've connected X. Please continue." bubble reads as if they did. So we
+ * tag the message with a marker: the agent still receives the instruction
+ * (it ignores the leading HTML comment, exactly like the Skill marker in
+ * `lib/skill-message.ts`), while the transcript filters the bubble out.
+ *
+ * The marker rides inside the persisted message, which the engine preserves
+ * verbatim (that is how Skill cards survive a reload), so the same filter
+ * applies to the optimistic path AND to the message replayed on reload.
+ */
+import type { FeedItem } from "@houston-ai/chat";
+
+const AUTO_CONTINUE_MARKER = "<!--houston:auto_continue-->";
+
+/** Wrap agent-bound text so the transcript can recognize and hide it. */
+export function encodeAutoContinueMessage(text: string): string {
+  return `${AUTO_CONTINUE_MARKER}\n\n${text}`;
+}
+
+/** True for a message Houston auto-sent to resume a task. */
+export function isAutoContinueMessage(content: string): boolean {
+  return content.startsWith(AUTO_CONTINUE_MARKER);
+}
+
+/**
+ * Drop auto-continue user messages from a feed before it is rendered. Only
+ * `user_message` turns qualify — an assistant/tool item is never an
+ * auto-continue, even if its content somehow started with the marker.
+ */
+export function filterAutoContinueFeedItems(items: FeedItem[]): FeedItem[] {
+  return items.filter(
+    (item) =>
+      !(item.feed_type === "user_message" && isAutoContinueMessage(item.data)),
+  );
+}

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -42,11 +42,12 @@
     "integration": "App integration",
     "alreadyConnected": "Already connected",
     "connected": "Connected",
+    "connecting": "Connecting...",
     "connect": "Connect",
-    "verify": "I've connected",
-    "verifying": "Checking...",
-    "notVerified": "Couldn't verify yet, try again",
-    "verifiedToast": "{{name}} is connected"
+    "reconnect": "Reconnect",
+    "verifiedToast": "{{name}} is connected",
+    "connectedFollowup": "I've connected {{name}}. Please continue.",
+    "followupFailed": "Couldn't tell the assistant that {{name}} is connected"
   },
   "composioSignin": {
     "appName": "Integrations provider",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -42,11 +42,12 @@
     "integration": "Integración de app",
     "alreadyConnected": "Ya está conectado",
     "connected": "Conectado",
+    "connecting": "Conectando...",
     "connect": "Conectar",
-    "verify": "Ya me conecté",
-    "verifying": "Comprobando...",
-    "notVerified": "Aún no podemos verificar, intenta de nuevo",
-    "verifiedToast": "{{name}} está conectado"
+    "reconnect": "Reconectar",
+    "verifiedToast": "{{name}} está conectado",
+    "connectedFollowup": "Ya conecté {{name}}. Por favor continúa.",
+    "followupFailed": "No pudimos avisar al asistente que {{name}} está conectado"
   },
   "composioSignin": {
     "appName": "Proveedor de integraciones",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -42,11 +42,12 @@
     "integration": "Integração de app",
     "alreadyConnected": "Já conectado",
     "connected": "Conectado",
+    "connecting": "Conectando...",
     "connect": "Conectar",
-    "verify": "Já me conectei",
-    "verifying": "Verificando...",
-    "notVerified": "Ainda não consigo verificar, tente de novo",
-    "verifiedToast": "{{name}} está conectado"
+    "reconnect": "Reconectar",
+    "verifiedToast": "{{name}} está conectado",
+    "connectedFollowup": "Já conectei {{name}}. Pode continuar.",
+    "followupFailed": "Não consegui avisar o assistente que {{name}} está conectado"
   },
   "composioSignin": {
     "appName": "Provedor de integrações",

--- a/app/tests/auto-continue-message.test.ts
+++ b/app/tests/auto-continue-message.test.ts
@@ -1,0 +1,65 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { FeedItem } from "@houston-ai/chat";
+import {
+  encodeAutoContinueMessage,
+  filterAutoContinueFeedItems,
+  isAutoContinueMessage,
+} from "../src/lib/auto-continue-message.ts";
+
+describe("auto-continue message encoding", () => {
+  it("round-trips: an encoded message is recognized", () => {
+    const encoded = encodeAutoContinueMessage(
+      "I've connected Google Drive. Please continue.",
+    );
+    strictEqual(isAutoContinueMessage(encoded), true);
+  });
+
+  it("keeps the agent-facing instruction in the payload", () => {
+    const encoded = encodeAutoContinueMessage("please continue");
+    strictEqual(encoded.includes("please continue"), true);
+  });
+
+  it("does not flag an ordinary user message", () => {
+    strictEqual(
+      isAutoContinueMessage("I've connected Google Drive. Please continue."),
+      false,
+    );
+  });
+});
+
+describe("filterAutoContinueFeedItems", () => {
+  it("drops only the auto-continue user message, preserving order", () => {
+    const items: FeedItem[] = [
+      { feed_type: "user_message", data: "real question" },
+      { feed_type: "user_message", data: encodeAutoContinueMessage("auto") },
+      { feed_type: "assistant_text", data: "answer" },
+    ];
+    const filtered = filterAutoContinueFeedItems(items);
+    deepStrictEqual(
+      filtered.map((i) => i.feed_type),
+      ["user_message", "assistant_text"],
+    );
+    strictEqual(
+      filtered[0].feed_type === "user_message" && filtered[0].data,
+      "real question",
+    );
+  });
+
+  it("only hides user_message turns, never assistant/tool items", () => {
+    // Defensive: an assistant message that happens to start with the marker
+    // is still a real assistant turn and must survive.
+    const items: FeedItem[] = [
+      { feed_type: "assistant_text", data: encodeAutoContinueMessage("x") },
+    ];
+    strictEqual(filterAutoContinueFeedItems(items).length, 1);
+  });
+
+  it("is a no-op for a feed without auto-continue messages", () => {
+    const items: FeedItem[] = [
+      { feed_type: "user_message", data: "hello" },
+      { feed_type: "assistant_text", data: "hi" },
+    ];
+    strictEqual(filterAutoContinueFeedItems(items).length, 2);
+  });
+});

--- a/app/tests/composio-card-state.test.ts
+++ b/app/tests/composio-card-state.test.ts
@@ -1,0 +1,165 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  deriveComposioCardView,
+  fallbackLogo,
+  parseComposioToolkitFromHref,
+  shouldSendConnectedFollowup,
+  type ConnectedFollowupInput,
+} from "../src/components/composio-card-state.ts";
+
+describe("deriveComposioCardView (issue #379: status badge vs action)", () => {
+  it("shows the Connect CTA when not connected and idle", () => {
+    strictEqual(deriveComposioCardView(false, "idle"), "idle");
+  });
+
+  it("shows the Connecting badge once the user has started a connect", () => {
+    strictEqual(deriveComposioCardView(false, "connecting"), "connecting");
+  });
+
+  it("shows the Connected badge when the probe confirms a connection", () => {
+    strictEqual(deriveComposioCardView(true, "idle"), "connected");
+  });
+
+  it("lets a confirmed connection win over a stale connecting phase", () => {
+    // The watcher landed the connection while the local phase was still
+    // mid-flight; the card must show Connected, never a spinner that masks
+    // a live connection.
+    strictEqual(deriveComposioCardView(true, "connecting"), "connected");
+  });
+});
+
+describe("shouldSendConnectedFollowup (proactive agent nudge)", () => {
+  const base: ConnectedFollowupInput = {
+    wasConnected: false,
+    isConnected: true,
+    hasInitiated: true,
+    alreadyFired: false,
+  };
+
+  it("fires once on a user-driven not-connected → connected transition", () => {
+    strictEqual(shouldSendConnectedFollowup(base), true);
+  });
+
+  it("stays silent when the card mounted already connected (no transition)", () => {
+    // Agent linked an app the user had connected earlier: was===is===true.
+    strictEqual(
+      shouldSendConnectedFollowup({ ...base, wasConnected: true }),
+      false,
+    );
+  });
+
+  it("stays silent when this card never initiated the connect", () => {
+    // Connection landed via the Integrations tab / CLI / another agent.
+    strictEqual(
+      shouldSendConnectedFollowup({ ...base, hasInitiated: false }),
+      false,
+    );
+  });
+
+  it("never double-fires for the same connection", () => {
+    strictEqual(
+      shouldSendConnectedFollowup({ ...base, alreadyFired: true }),
+      false,
+    );
+  });
+
+  it("stays silent on a disconnect (connected → not connected)", () => {
+    strictEqual(
+      shouldSendConnectedFollowup({
+        wasConnected: true,
+        isConnected: false,
+        hasInitiated: true,
+        alreadyFired: false,
+      }),
+      false,
+    );
+  });
+
+  it("keeps two integrations independent: each speaks only for itself", () => {
+    // Two cards (e.g. Gmail + Google Sheets) in the same conversation. The
+    // user connects Gmail first; Sheets is still connecting. Only Gmail
+    // should nudge — Sheets has not transitioned yet.
+    const gmail = { wasConnected: false, hasInitiated: true, alreadyFired: false };
+    const sheets = { wasConnected: false, hasInitiated: true, alreadyFired: false };
+
+    strictEqual(
+      shouldSendConnectedFollowup({ ...gmail, isConnected: true }),
+      true,
+    );
+    strictEqual(
+      shouldSendConnectedFollowup({ ...sheets, isConnected: false }),
+      false,
+    );
+
+    // Sheets connects on a later tick — it fires its own (single) nudge,
+    // and Gmail, already fired, does not speak again.
+    strictEqual(
+      shouldSendConnectedFollowup({ ...sheets, isConnected: true }),
+      true,
+    );
+    strictEqual(
+      shouldSendConnectedFollowup({
+        wasConnected: true,
+        isConnected: true,
+        hasInitiated: true,
+        alreadyFired: true,
+      }),
+      false,
+    );
+  });
+});
+
+describe("parseComposioToolkitFromHref (card-vs-plain-link decision)", () => {
+  it("extracts the slug from the #houston_toolkit fragment", () => {
+    strictEqual(
+      parseComposioToolkitFromHref(
+        "https://composio.dev/connect?x=1#houston_toolkit=gmail",
+      ),
+      "gmail",
+    );
+  });
+
+  it("reads the slug even when the fragment carries other params", () => {
+    strictEqual(
+      parseComposioToolkitFromHref(
+        "https://composio.dev/c#foo=bar&houston_toolkit=googlesheets",
+      ),
+      "googlesheets",
+    );
+  });
+
+  it("returns null when there is no fragment", () => {
+    strictEqual(
+      parseComposioToolkitFromHref("https://composio.dev/connect"),
+      null,
+    );
+  });
+
+  it("returns null when the fragment lacks the toolkit param", () => {
+    strictEqual(
+      parseComposioToolkitFromHref("https://composio.dev/c#state=abc"),
+      null,
+    );
+  });
+
+  it("returns null for an empty toolkit value", () => {
+    strictEqual(
+      parseComposioToolkitFromHref("https://composio.dev/c#houston_toolkit="),
+      null,
+    );
+  });
+
+  it("returns null for a non-URL string instead of throwing", () => {
+    strictEqual(parseComposioToolkitFromHref("not a url"), null);
+  });
+});
+
+describe("fallbackLogo", () => {
+  it("builds a favicon URL keyed off the toolkit slug", () => {
+    strictEqual(
+      fallbackLogo("gmail"),
+      "https://www.google.com/s2/favicons?domain=gmail.com&sz=128",
+    );
+  });
+});

--- a/app/tests/composio-card-state.test.ts
+++ b/app/tests/composio-card-state.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   deriveComposioCardView,
   fallbackLogo,
+  isToolkitConnected,
   parseComposioToolkitFromHref,
   shouldSendConnectedFollowup,
   type ConnectedFollowupInput,
@@ -152,6 +153,33 @@ describe("parseComposioToolkitFromHref (card-vs-plain-link decision)", () => {
 
   it("returns null for a non-URL string instead of throwing", () => {
     strictEqual(parseComposioToolkitFromHref("not a url"), null);
+  });
+});
+
+describe("isToolkitConnected (normalized membership)", () => {
+  it("matches when the fragment slug and probe slug agree exactly", () => {
+    strictEqual(isToolkitConnected(new Set(["gmail"]), "gmail"), true);
+  });
+
+  it("matches across casing: raw fragment vs lowercased probe set", () => {
+    // The engine watcher detected `googledrive`; the agent authored the
+    // fragment as `GoogleDrive`. Without normalization the card would stay
+    // stuck on "Connecting..." forever — this is the #385 fix.
+    strictEqual(isToolkitConnected(new Set(["googledrive"]), "GoogleDrive"), true);
+  });
+
+  it("matches despite stray whitespace in the fragment slug", () => {
+    strictEqual(isToolkitConnected(new Set(["slack"]), "  slack "), true);
+  });
+
+  it("does not match a structurally different slug", () => {
+    // Normalization only trims + lowercases; an underscore variant is a
+    // genuine authoring mismatch, not something the card should paper over.
+    strictEqual(isToolkitConnected(new Set(["googledrive"]), "google_drive"), false);
+  });
+
+  it("is false against an empty connected set", () => {
+    strictEqual(isToolkitConnected(new Set(), "gmail"), false);
   });
 });
 


### PR DESCRIPTION
Fixes #379

## Problem

The inline integration card in chat fused **status** and **action** into one button that read **"I've connected"** while also showing reconnect arrows. It looked like the card was simultaneously *claiming* a connection and *offering to redo* it, and it never actually reflected whether the connection had really landed.

![before](https://github.com/user-attachments/assets/456194d8-9396-42d7-8a47-e91d462eb557)

## Fix

Track the real connection status and render status separately from the action, per the issue's mockup:

| State | Status badge | Action |
|-------|--------------|--------|
| not connected (idle) | — | **Connect** CTA |
| connecting | **Connecting…** (spinner) | arrows reconnect button |
| connected | **Connected** (green check) | arrows reconnect button |

- **Automatic detection.** The manual "I've connected" verify step is gone. The card flips to *Connected* on its own via the existing engine watch + ambient connection watcher (also catches connections made from the Integrations tab / CLI / another agent). If nothing lands within 90s the spinner falls back to the Connect CTA so it's never eternal.
- **Proactive agent nudge.** When a connection the user *started from the card* lands, the chat panel sends a follow-up message ("I've connected X. Please continue.") so the agent resumes the task without the user retyping. Fires once, only on a real not-connected → connected transition the card drove — so a card that mounts already-connected, or a sibling card for a different app, never speaks out of turn. Send failures surface a toast (no silent drop).

## Structure / tests

- New `composio-card-state.ts` — pure view-derivation + follow-up-gating + href parsing (the card is now a thin shell over it).
- New `composio-card-visuals.tsx` — props-driven status slot + logo (container/presentational split brings the card from 282 → 192 lines, back under the 200-line limit).
- New `app/tests/composio-card-state.test.ts` — 17 cases: the three view states (incl. real-status-wins), follow-up gating, **two-integration independence** (issue asked to check 2+ integrations), and href parsing.
- Locales: drop the unused `verify`/`verifying`/`notVerified`; add `connecting`/`reconnect`/`connectedFollowup`/`followupFailed` across en/es/pt.

### Checks
- `pnpm tsc --noEmit` ✅
- `pnpm test` ✅ (125 app tests, incl. the new 17)
- `pnpm check-locales` ✅ (en/es/pt in sync)

> **Remaining manual step:** live verification with 2+ real integrations (OAuth round-trip) — can't be exercised headless.

## Files
- `app/src/components/composio-link-card.tsx` (rewrite)
- `app/src/components/composio-card-state.ts` (new)
- `app/src/components/composio-card-visuals.tsx` (new)
- `app/src/components/use-agent-chat-panel.tsx` (proactive nudge wiring)
- `app/src/components/onboarding/missions/try.tsx` (import update)
- `app/src/locales/{en,es,pt}/chat.json`
- `app/tests/composio-card-state.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
