### PR TITLE
fix(routines): one chat per routine, not one per run (#381)

### DIFF
--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -116,8 +116,8 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
   const handleSendMessage = useCallback(
     async (sessionKey: string, text: string, files: File[]) => {
       // Use the selected activity id (not a derived session key): routine
-      // missions carry a `routine-{id}-run-{run}` session key, so stripping
-      // `activity-` would yield the wrong id for attachments + the handoff.
+      // missions carry a `routine-{id}` session key, so stripping `activity-`
+      // would yield the wrong id for attachments + the handoff.
       const missionId = selectedId ?? sessionKey.replace(/^activity-/, "");
       const activity = archived.find((a) => a.id === missionId);
       const mode = agentDef.config.agents?.find((m) => m.id === activity?.agent);

--- a/app/src/stores/feeds.ts
+++ b/app/src/stores/feeds.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
-import { mergeFeedItem } from "@houston-ai/chat";
-import type { FeedItem, MergeFeedOptions } from "@houston-ai/chat";
+import { mergeFeedItem, reconcileUserMessageEcho } from "@houston-ai/chat";
+import type { FeedItem, MergeFeedOptions, PendingUserEcho } from "@houston-ai/chat";
 
 /**
  * Feed store — nested by agent path, then by session key.
@@ -13,10 +13,19 @@ import type { FeedItem, MergeFeedOptions } from "@houston-ai/chat";
 interface FeedState {
   items: Record<string, Record<string, FeedItem[]>>;
   /**
+   * Optimistic `user_message` pushes still awaiting their WS echo, nested by
+   * agent path then session key. Lets `pushFeedItem` drop the engine's echo of
+   * a prompt this client already showed without collapsing distinct turns that
+   * happen to share text — e.g. every run of a routine, which now share one
+   * chat (#381). See `reconcileUserMessageEcho`.
+   */
+  pendingEcho: Record<string, Record<string, PendingUserEcho>>;
+  /**
    * Merge one item into a session's feed. Pass `{ fromWs: true }` for items
    * delivered over the engine WebSocket so a re-broadcast `user_message` echo
-   * is deduped against the turn already shown (see `mergeFeedItem`). Optimistic
-   * local pushes omit it so a deliberate repeat still appends.
+   * is deduped against the matching optimistic push. Optimistic local pushes
+   * omit it so a deliberate repeat (and every routine run's prompt) still
+   * appends.
    */
   pushFeedItem: (
     agentPath: string,
@@ -31,12 +40,25 @@ interface FeedState {
 
 export const useFeedStore = create<FeedState>((set) => ({
   items: {},
+  pendingEcho: {},
 
   pushFeedItem: (agentPath, sessionKey, item, opts) => {
     return set((s) => {
+      const agentPending = s.pendingEcho[agentPath] ?? {};
+      const sessionPending = { ...(agentPending[sessionKey] ?? {}) };
+      const keep = reconcileUserMessageEcho(sessionPending, item, opts?.fromWs ?? false);
+      const pendingEcho = {
+        ...s.pendingEcho,
+        [agentPath]: { ...agentPending, [sessionKey]: sessionPending },
+      };
+      // Drop the WS echo of a prompt already shown optimistically, but keep the
+      // decremented pending tally so a later identical send still matches.
+      if (!keep) return { pendingEcho };
+
       const agentBucket = s.items[agentPath] ?? {};
-      const nextSession = mergeFeedItem(agentBucket[sessionKey] ?? [], item, opts);
+      const nextSession = mergeFeedItem(agentBucket[sessionKey] ?? [], item);
       return {
+        pendingEcho,
         items: {
           ...s.items,
           [agentPath]: {
@@ -64,10 +86,16 @@ export const useFeedStore = create<FeedState>((set) => ({
       const agentBucket = s.items[agentPath];
       if (!agentBucket) return s;
       const { [sessionKey]: _, ...rest } = agentBucket;
+      const agentPending = s.pendingEcho[agentPath];
+      const { [sessionKey]: __, ...restPending } = agentPending ?? {};
       return {
         items: {
           ...s.items,
           [agentPath]: rest,
+        },
+        pendingEcho: {
+          ...s.pendingEcho,
+          [agentPath]: restPending,
         },
       };
     }),
@@ -75,6 +103,7 @@ export const useFeedStore = create<FeedState>((set) => ({
   clearAgent: (agentPath) =>
     set((s) => {
       const { [agentPath]: _, ...rest } = s.items;
-      return { items: rest };
+      const { [agentPath]: __, ...restPending } = s.pendingEcho;
+      return { items: rest, pendingEcho: restPending };
     }),
 }));

--- a/engine/houston-engine-core/src/agents/mod.rs
+++ b/engine/houston-engine-core/src/agents/mod.rs
@@ -210,7 +210,7 @@ mod tests {
 
         let run = s.create_routine_run(&r.id).unwrap();
         assert_eq!(run.routine_id, r.id);
-        assert!(run.session_key.starts_with(&format!("routine-{}-run-", r.id)));
+        assert_eq!(run.session_key, format!("routine-{}", r.id));
         assert_eq!(s.list_routine_runs_for(&r.id).unwrap().len(), 1);
 
         let upd = s

--- a/engine/houston-engine-core/src/agents/routine_runs.rs
+++ b/engine/houston-engine-core/src/agents/routine_runs.rs
@@ -28,7 +28,9 @@ pub fn create(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
 fn create_unlocked(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
     let mut runs = list(root)?;
     let id = Uuid::new_v4().to_string();
-    let session_key = format!("routine-{routine_id}-run-{id}");
+    // Stable per routine, NOT per run, so all of a routine's runs share one
+    // chat (#381). Kept in lockstep with `routines::runs::create_unlocked`.
+    let session_key = format!("routine-{routine_id}");
     let run = RoutineRun {
         id,
         routine_id: routine_id.to_string(),

--- a/engine/houston-engine-core/src/agents/types.rs
+++ b/engine/houston-engine-core/src/agents/types.rs
@@ -136,7 +136,9 @@ pub struct RoutineRun {
     pub routine_id: String,
     /// "running" | "silent" | "surfaced" | "error"
     pub status: String,
-    /// Session key for chat history lookup (e.g. "routine-{routine_id}-run-{id}").
+    /// Session key for chat history lookup. Stable per routine
+    /// ("routine-{routine_id}"), shared by every run — one chat per routine,
+    /// not per run (#381).
     pub session_key: String,
     /// If surfaced, the activity ID created on the board.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/engine/houston-engine-core/src/routines/engine_dispatcher.rs
+++ b/engine/houston-engine-core/src/routines/engine_dispatcher.rs
@@ -83,7 +83,13 @@ impl RoutineDispatcher for EngineRoutineDispatcher {
                 resolved.provider,
             )
             .await;
-        let resume_id = sid_handle.get().await;
+        // One chat per routine (#381): all runs share a stable session_key, so
+        // resuming here would carry the PREVIOUS run's full context into this
+        // one — unbounded growth and drift that would change what a routine
+        // does. Force a fresh session every run. The handle is still passed
+        // below so the new provider session id is appended to the shared key's
+        // `.history`, and THAT is what merges every run into the single chat.
+        let resume_id: Option<String> = None;
 
         let join_handle = session_runner::spawn_and_monitor(
             self.events.clone(),
@@ -304,21 +310,42 @@ impl ActivitySurface for EngineActivitySurface {
         routine_run_id: &str,
     ) -> Result<String, String> {
         ensure_houston_dir(working_dir).map_err(|e| e.to_string())?;
-        let activity = agents::activity::create(
-            working_dir,
-            NewActivity {
-                title: title.to_string(),
-                description: description.to_string(),
-                agent: None,
-                worktree_path: None,
-                provider: None,
-                model: None,
-            },
-        )
-        .map_err(|e| e.to_string())?;
+
+        // One chat per routine (#381): reuse the activity already bound to this
+        // routine's stable session_key instead of spawning a fresh chat for
+        // every surfaced run. The match is on the exact session_key, so older
+        // per-run routine chats (which carry the legacy `routine-{id}-run-{run}`
+        // key) are left untouched as history while new runs collapse into one.
+        let existing = agents::activity::list(working_dir)
+            .map_err(|e| e.to_string())?
+            .into_iter()
+            .find(|a| a.session_key.as_deref() == Some(session_key));
+
+        let activity_id = match existing {
+            Some(activity) => activity.id,
+            None => {
+                agents::activity::create(
+                    working_dir,
+                    NewActivity {
+                        title: title.to_string(),
+                        description: description.to_string(),
+                        agent: None,
+                        worktree_path: None,
+                        provider: None,
+                        model: None,
+                    },
+                )
+                .map_err(|e| e.to_string())?
+                .id
+            }
+        };
+
+        // Flip the chat back to "needs you" and re-link the latest run. Title +
+        // description are deliberately set only on create (above), so a user's
+        // rename of the routine chat survives later surfaces.
         agents::activity::update(
             working_dir,
-            &activity.id,
+            &activity_id,
             ActivityUpdate {
                 status: Some("needs_you".into()),
                 session_key: Some(session_key.to_string()),
@@ -328,6 +355,107 @@ impl ActivitySurface for EngineActivitySurface {
             },
         )
         .map_err(|e| e.to_string())?;
-        Ok(activity.id)
+        Ok(activity_id)
+    }
+}
+
+#[cfg(test)]
+mod surface_tests {
+    use super::*;
+    use crate::agents::activity;
+    use tempfile::TempDir;
+
+    #[test]
+    fn reuses_one_activity_per_routine_session_key() {
+        // Two surfaced runs of the same routine collapse into one chat (#381).
+        let d = TempDir::new().unwrap();
+        let surface = EngineActivitySurface;
+        let key = "routine-abc";
+
+        let id1 = surface
+            .surface(d.path(), "Morning", "desc", key, "abc", "run-1")
+            .unwrap();
+        let id2 = surface
+            .surface(d.path(), "Morning", "desc", key, "abc", "run-2")
+            .unwrap();
+
+        assert_eq!(id1, id2, "second surface reuses the same activity");
+        let acts = activity::list(d.path()).unwrap();
+        assert_eq!(acts.len(), 1, "only one activity for the routine");
+        let a = &acts[0];
+        assert_eq!(a.status, "needs_you");
+        assert_eq!(a.session_key.as_deref(), Some(key));
+        assert_eq!(a.routine_id.as_deref(), Some("abc"));
+        assert_eq!(
+            a.routine_run_id.as_deref(),
+            Some("run-2"),
+            "the reused chat links the latest run"
+        );
+    }
+
+    #[test]
+    fn distinct_routines_get_distinct_chats() {
+        let d = TempDir::new().unwrap();
+        let surface = EngineActivitySurface;
+
+        let id_a = surface
+            .surface(d.path(), "A", "", "routine-a", "a", "run-1")
+            .unwrap();
+        let id_b = surface
+            .surface(d.path(), "B", "", "routine-b", "b", "run-1")
+            .unwrap();
+
+        assert_ne!(id_a, id_b);
+        assert_eq!(activity::list(d.path()).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn reuse_preserves_a_user_renamed_chat_title() {
+        let d = TempDir::new().unwrap();
+        let surface = EngineActivitySurface;
+        let key = "routine-abc";
+
+        let id = surface
+            .surface(d.path(), "Morning", "desc", key, "abc", "run-1")
+            .unwrap();
+        activity::update(
+            d.path(),
+            &id,
+            ActivityUpdate {
+                title: Some("My renamed chat".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+
+        surface
+            .surface(d.path(), "Morning", "desc", key, "abc", "run-2")
+            .unwrap();
+
+        let acts = activity::list(d.path()).unwrap();
+        assert_eq!(acts.len(), 1);
+        assert_eq!(
+            acts[0].title, "My renamed chat",
+            "a later surface must not clobber the user's rename"
+        );
+    }
+
+    #[test]
+    fn legacy_per_run_chats_are_left_intact() {
+        // A pre-#381 routine chat carries the old per-run key. A new surface on
+        // the stable key must create a fresh canonical chat, not adopt the old
+        // one (whose feed lives under a different key).
+        let d = TempDir::new().unwrap();
+        let surface = EngineActivitySurface;
+
+        let legacy = surface
+            .surface(d.path(), "Old", "", "routine-abc-run-xyz", "abc", "run-xyz")
+            .unwrap();
+        let canonical = surface
+            .surface(d.path(), "Morning", "", "routine-abc", "abc", "run-1")
+            .unwrap();
+
+        assert_ne!(legacy, canonical);
+        assert_eq!(activity::list(d.path()).unwrap().len(), 2);
     }
 }

--- a/engine/houston-engine-core/src/routines/engine_dispatcher.rs
+++ b/engine/houston-engine-core/src/routines/engine_dispatcher.rs
@@ -104,7 +104,13 @@ impl RoutineDispatcher for EngineRoutineDispatcher {
             Some(PersistOptions {
                 db: self.db.clone(),
                 source: "routine".into(),
-                user_message: Some(ctx.prompt.to_string()),
+                // Persist + echo the routine's own prompt as the per-run user
+                // message, NOT `ctx.prompt` — the latter has the internal
+                // "end with ROUTINE_OK" suppression instruction appended, which
+                // is scaffolding the user should never see (#381). The model
+                // still receives the full `ctx.prompt` above; only the
+                // displayed/saved message is the clean one.
+                user_message: Some(ctx.routine.prompt.clone()),
                 claude_session_id: None,
                 lifecycle: Some(Arc::new(RoutineRunLifecycle {
                     root: ctx.working_dir.to_path_buf(),

--- a/engine/houston-engine-core/src/routines/runner.rs
+++ b/engine/houston-engine-core/src/routines/runner.rs
@@ -52,9 +52,11 @@ pub trait RoutineDispatcher: Send + Sync {
     async fn dispatch(&self, ctx: DispatchContext<'_>) -> DispatchOutcome;
 }
 
-/// Surface for creating + linking activities when a routine run needs
-/// attention. Activity CRUD currently lives in the desktop adapter; this
-/// trait lets the runner stay engine-side without pulling it in.
+/// Surface for the chat that shows a routine's results when a run needs
+/// attention. Implementations reuse one chat per routine — keyed by the
+/// stable `session_key` — rather than creating a new one per run (#381), so
+/// the engine impl is a find-or-create on `session_key`. Activity CRUD lives
+/// in the agent store; this trait lets the runner stay decoupled from it.
 pub trait ActivitySurface: Send + Sync {
     fn surface(
         &self,
@@ -216,11 +218,10 @@ pub async fn finish_run(
             },
         )?;
     } else {
-        let title = format!(
-            "{} — {}",
-            routine.name,
-            first_line(&response).unwrap_or("Needs attention")
-        );
+        // One chat per routine (#381): the chat is reused across runs, so its
+        // title is the stable routine name rather than the latest finding's
+        // first line. The finding itself lands in the conversation feed.
+        let title = routine.name.clone();
         match surface.surface(
             &working_dir,
             &title,
@@ -371,10 +372,6 @@ fn extract_summary(response: &str) -> String {
     }
 }
 
-fn first_line(text: &str) -> Option<&str> {
-    text.lines().map(|l| l.trim()).find(|l| !l.is_empty())
-}
-
 fn truncate(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
         return s.to_string();
@@ -516,8 +513,9 @@ mod tests {
 
         let calls = surface.calls.lock().unwrap();
         assert_eq!(calls.len(), 1);
-        assert!(calls[0].0.contains("Morning"));
-        assert!(calls[0].0.contains("Two PRs need review"));
+        // Title is the stable routine name, not the finding (#381) — the
+        // finding shows up in the conversation feed, not the chat title.
+        assert_eq!(calls[0].0, "Morning");
 
         let runs = routine_runs::list(d.path()).unwrap();
         assert_eq!(runs[0].status, "surfaced");

--- a/engine/houston-engine-core/src/routines/runs.rs
+++ b/engine/houston-engine-core/src/routines/runs.rs
@@ -104,7 +104,13 @@ fn create_unlocked(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
     ensure_houston_dir(root)?;
     let mut runs = list(root)?;
     let id = Uuid::new_v4().to_string();
-    let session_key = format!("routine-{routine_id}-run-{id}");
+    // One chat per routine (#381): the session key is stable per routine, NOT
+    // per run, so every run of a routine streams + persists into the same
+    // conversation. The shared key's `.history` file aggregates each run's
+    // provider session id, so opening the routine's chat shows a running log of
+    // all its reports instead of a fresh chat per surfaced run. Runs stay
+    // independent (the dispatcher never resumes) — only the *view* is unified.
+    let session_key = format!("routine-{routine_id}");
     let run = RoutineRun {
         id,
         routine_id: routine_id.to_string(),
@@ -221,7 +227,7 @@ mod tests {
         let run = create(d.path(), "rid").unwrap();
         assert_eq!(run.routine_id, "rid");
         assert_eq!(run.status, "running");
-        assert!(run.session_key.contains("routine-rid-run-"));
+        assert_eq!(run.session_key, "routine-rid");
 
         let done = update(
             d.path(),
@@ -236,6 +242,22 @@ mod tests {
         .unwrap();
         assert_eq!(done.status, "silent");
         assert!(done.completed_at.is_some());
+    }
+
+    #[test]
+    fn session_key_is_stable_per_routine() {
+        // One chat per routine (#381): every run of a routine shares the same
+        // session_key so their feeds aggregate into a single conversation,
+        // while different routines keep their own chats.
+        let d = TempDir::new().unwrap();
+        let r1 = create(d.path(), "rid").unwrap();
+        let r2 = create(d.path(), "rid").unwrap();
+        assert_eq!(r1.session_key, "routine-rid");
+        assert_eq!(r2.session_key, "routine-rid");
+        assert_ne!(r1.id, r2.id, "runs are still distinct rows");
+
+        let other = create(d.path(), "other").unwrap();
+        assert_eq!(other.session_key, "routine-other");
     }
 
     #[test]

--- a/engine/houston-engine-core/src/routines/types.rs
+++ b/engine/houston-engine-core/src/routines/types.rs
@@ -80,7 +80,9 @@ pub struct RoutineRun {
     /// `POST /v1/routines/:id/runs/:run_id:cancel` or when the parent
     /// routine is deleted while a run is still in flight.
     pub status: String,
-    /// Session key for chat history lookup (`"routine-{rid}-run-{id}"`).
+    /// Session key for chat history lookup. Stable per routine
+    /// (`"routine-{rid}"`), shared by every run so they aggregate into one
+    /// chat — one chat per routine, not per run (#381).
     pub session_key: String,
     /// If surfaced, the activity ID created on the board.
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/ui/chat/src/feed-merge.ts
+++ b/ui/chat/src/feed-merge.ts
@@ -4,15 +4,56 @@ import type { FeedItem } from "./types";
 export interface MergeFeedOptions {
   /**
    * The item arrived over the engine WebSocket (a push event), not from an
-   * optimistic local push. The engine re-broadcasts a turn's `user_message`
-   * over the `session:{key}` topic (so other clients echo it) AFTER streaming
-   * has begun, so that echo can land non-consecutively: on top of the
-   * assistant reply or on top of hydrated history. A WS-sourced `user_message`
-   * the feed already shows is a re-delivery and is dropped; optimistic/local
-   * pushes leave this unset so a deliberate repeat of the same text always
-   * appends.
+   * optimistic local push. Used by {@link reconcileUserMessageEcho} to drop the
+   * engine's re-broadcast of a prompt this client already pushed optimistically.
    */
   fromWs?: boolean;
+}
+
+/**
+ * Per-session tally of optimistic (locally-pushed) user messages still awaiting
+ * their engine WS echo, keyed by message text.
+ */
+export type PendingUserEcho = Record<string, number>;
+
+/**
+ * Decide whether a `user_message` should be appended to a session feed, given
+ * the optimistic pushes still awaiting their WS echo.
+ *
+ * The engine re-broadcasts every turn's prompt over the `session:{key}` WS topic
+ * so other clients echo it. The client that SENT the turn already pushed the
+ * prompt optimistically, so that echo is a duplicate — but only for that one
+ * turn. The earlier fix (#363) dropped any WS `user_message` whose TEXT already
+ * appeared in the feed, which wrongly collapsed DISTINCT turns that share text:
+ * once a routine reuses a single chat across runs (#381), every run carries the
+ * identical prompt, so a new run's prompt got swallowed by an earlier run's
+ * (and prior runs sitting in hydrated history swallowed it too).
+ *
+ * Correlating echo→optimistic by a pending count fixes both: the sender's own
+ * echo is dropped, while a background routine run (which never pushes
+ * optimistically) and cross-client deliveries append. Mutates `pending`.
+ *
+ * @returns `true` to append the item, `false` to drop it as a duplicate echo.
+ */
+export function reconcileUserMessageEcho(
+  pending: PendingUserEcho,
+  item: FeedItem,
+  fromWs: boolean,
+): boolean {
+  if (item.feed_type !== "user_message") return true;
+  if (!fromWs) {
+    // Optimistic local push: remember it so its echo can be matched + dropped.
+    pending[item.data] = (pending[item.data] ?? 0) + 1;
+    return true;
+  }
+  const awaiting = pending[item.data] ?? 0;
+  if (awaiting > 0) {
+    pending[item.data] = awaiting - 1;
+    return false;
+  }
+  // No optimistic push is waiting: a routine run's prompt, or a turn from
+  // another client. Append it — there is nothing to dedupe against.
+  return true;
 }
 
 /**
@@ -23,16 +64,16 @@ export interface MergeFeedOptions {
  * - `thinking` (final) replaces last `thinking_streaming`
  * - `assistant_text_streaming` replaces previous `assistant_text_streaming`
  * - `assistant_text` (final) replaces last `assistant_text_streaming`
- * - a WebSocket-echoed `user_message` already present is dropped
+ * - a null-input `tool_call` is replaced by the real-input one
  * - everything else is appended.
+ *
+ * `user_message` echo de-duplication is handled separately by
+ * {@link reconcileUserMessageEcho} BEFORE this is called, because it needs
+ * per-session provenance state this pure function does not carry.
  *
  * Use this in your Zustand/Redux store to avoid duplicating merge logic.
  */
-export function mergeFeedItem(
-  items: FeedItem[],
-  item: FeedItem,
-  opts?: MergeFeedOptions,
-): FeedItem[] {
+export function mergeFeedItem(items: FeedItem[], item: FeedItem): FeedItem[] {
   const last = items[items.length - 1];
 
   if (item.feed_type === "thinking_streaming") {
@@ -65,20 +106,6 @@ export function mergeFeedItem(
   if (item.feed_type === "tool_call" && last?.feed_type === "tool_call") {
     if (last.data.name === item.data.name && last.data.input == null) {
       return [...items.slice(0, -1), item];
-    }
-  }
-
-  // Drop a WebSocket-echoed user_message the feed already shows. The engine
-  // re-broadcasts the turn's prompt over the session topic for cross-client
-  // echo AFTER streaming has begun, so the echo can arrive non-consecutively:
-  // on top of the assistant reply, or on top of hydrated history. Matching only
-  // the immediately-previous item (the old behaviour) let routine-surfaced
-  // turns render their first user prompt twice (issue #363). Provenance, not
-  // shape, decides: only WS deliveries dedupe, so a user who deliberately
-  // repeats the same text locally still sees both copies.
-  if (item.feed_type === "user_message" && opts?.fromWs) {
-    if (items.some((it) => it.feed_type === "user_message" && it.data === item.data)) {
-      return items;
     }
   }
 

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -215,8 +215,8 @@ export type { UserAttachmentMessageLabels } from "./user-attachment-message";
 
 // === Utilities ===
 export { Typewriter } from "./typewriter";
-export { mergeFeedItem, mergeFeedHistory } from "./feed-merge";
-export type { MergeFeedOptions } from "./feed-merge";
+export { mergeFeedItem, mergeFeedHistory, reconcileUserMessageEcho } from "./feed-merge";
+export type { MergeFeedOptions, PendingUserEcho } from "./feed-merge";
 export { ChannelAvatar } from "./channel-avatar";
 export type { ChannelSource } from "./channel-avatar";
 

--- a/ui/chat/test/feed-merge.test.mjs
+++ b/ui/chat/test/feed-merge.test.mjs
@@ -1,6 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mergeFeedItem, mergeFeedHistory } from "../src/feed-merge.ts";
+import {
+  mergeFeedItem,
+  mergeFeedHistory,
+  reconcileUserMessageEcho,
+} from "../src/feed-merge.ts";
 
 test("assistant final replaces streaming text before queued user message", () => {
   const queued = [
@@ -40,63 +44,81 @@ test("streaming updates replace existing stream before queued user message", () 
   ]);
 });
 
-// ── mergeFeedItem: WS user_message echo dedup (issue #363) ─────────────────
+// ── reconcileUserMessageEcho: optimistic↔echo dedup (issues #363 + #381) ───
 
-test("WS user_message echo dropped when it duplicates a non-consecutive turn", () => {
-  // The engine re-broadcasts the prompt over the session topic AFTER the
-  // assistant has started replying, so the echo lands after the reply — not
-  // consecutively. Old code only collapsed consecutive user_messages, so this
-  // duplicated the user's first message.
-  const feed = [
-    { feed_type: "user_message", data: "ping" },
-    { feed_type: "assistant_text", data: "pong" },
-  ];
-
-  const merged = mergeFeedItem(
-    feed,
-    { feed_type: "user_message", data: "ping" },
-    { fromWs: true },
+test("echo of an optimistic push is dropped (issue #363)", () => {
+  const pending = {};
+  // The local client pushed the prompt optimistically first.
+  assert.equal(
+    reconcileUserMessageEcho(pending, { feed_type: "user_message", data: "ping" }, false),
+    true,
   );
-
-  assert.deepEqual(merged, feed);
+  assert.deepEqual(pending, { ping: 1 });
+  // The engine's WS echo of that same prompt is the duplicate — drop it.
+  assert.equal(
+    reconcileUserMessageEcho(pending, { feed_type: "user_message", data: "ping" }, true),
+    false,
+  );
+  assert.deepEqual(pending, { ping: 0 });
 });
 
-test("WS user_message echo dropped when it duplicates the previous turn", () => {
+test("an echo with no pending optimistic push appends (routine run / cross-client)", () => {
+  // A background routine run never pushes optimistically, so its prompt arrives
+  // only as a WS echo and must append.
+  const pending = {};
+  assert.equal(
+    reconcileUserMessageEcho(pending, { feed_type: "user_message", data: "check email" }, true),
+    true,
+  );
+  assert.deepEqual(pending, {});
+});
+
+test("repeated routine runs with the identical prompt all append (issue #381)", () => {
+  // One chat per routine: every run carries the same prompt and arrives as a WS
+  // echo with nothing pending. Each must append — no run's prompt is swallowed.
+  const pending = {};
+  for (let i = 0; i < 3; i += 1) {
+    assert.equal(
+      reconcileUserMessageEcho(pending, { feed_type: "user_message", data: "check email" }, true),
+      true,
+      `run ${i} appends`,
+    );
+  }
+});
+
+test("deliberate local repeat keeps both; both echoes drop", () => {
+  const pending = {};
+  reconcileUserMessageEcho(pending, { feed_type: "user_message", data: "again" }, false);
+  reconcileUserMessageEcho(pending, { feed_type: "user_message", data: "again" }, false);
+  assert.deepEqual(pending, { again: 2 });
+  assert.equal(
+    reconcileUserMessageEcho(pending, { feed_type: "user_message", data: "again" }, true),
+    false,
+  );
+  assert.equal(
+    reconcileUserMessageEcho(pending, { feed_type: "user_message", data: "again" }, true),
+    false,
+  );
+  assert.deepEqual(pending, { again: 0 });
+});
+
+test("non-user_message items are never gated by the echo tally", () => {
+  const pending = {};
+  assert.equal(
+    reconcileUserMessageEcho(pending, { feed_type: "assistant_text", data: "hi" }, true),
+    true,
+  );
+  assert.deepEqual(pending, {});
+});
+
+// ── mergeFeedItem: streaming/tool merges leave user_messages alone ──────────
+
+test("mergeFeedItem appends user_messages verbatim (dedup moved out)", () => {
   const feed = [{ feed_type: "user_message", data: "ping" }];
-  const merged = mergeFeedItem(
-    feed,
-    { feed_type: "user_message", data: "ping" },
-    { fromWs: true },
-  );
-  assert.deepEqual(merged, feed);
-});
-
-test("local user_message repeat always appends (deliberate repeat preserved)", () => {
-  // No fromWs => optimistic/local push. A user sending the same text twice
-  // keeps both copies; provenance, not shape, gates the dedup.
-  const feed = [
-    { feed_type: "user_message", data: "again" },
-    { feed_type: "assistant_text", data: "ok" },
-  ];
-
-  const merged = mergeFeedItem(feed, { feed_type: "user_message", data: "again" });
-
-  assert.deepEqual(merged, [
-    ...feed,
-    { feed_type: "user_message", data: "again" },
-  ]);
-});
-
-test("WS user_message with new text still appends", () => {
-  const feed = [{ feed_type: "user_message", data: "ping" }];
-  const merged = mergeFeedItem(
-    feed,
-    { feed_type: "user_message", data: "different" },
-    { fromWs: true },
-  );
+  const merged = mergeFeedItem(feed, { feed_type: "user_message", data: "ping" });
   assert.deepEqual(merged, [
     { feed_type: "user_message", data: "ping" },
-    { feed_type: "user_message", data: "different" },
+    { feed_type: "user_message", data: "ping" },
   ]);
 });
 


### PR DESCRIPTION
## What

Routines surfaced **one new chat per run**, so a daily routine cluttered the sidebar with a fresh chat every day. Now there is **one chat per routine** that accumulates every run as a clean `prompt → reply` log, flipping to "needs you" only when a run actually surfaces something.

Closes #381.

## How

**One chat per routine (commit 1)**

- **Stable session key per routine.** `routine_runs::create` (and the `AgentStore` copy) now mints `routine-{id}` instead of `routine-{id}-run-{run}`. Chat history already aggregates every provider session id recorded under a key's `.history` file, so all of a routine's runs naturally collapse into a single conversation.
- **One activity per routine.** `EngineActivitySurface::surface` is now find-or-create on the stable key: the first surfaced run creates the chat, later runs reuse it (flip to `needs_you`, re-link the latest run). Title + description are written only on create, so a user's rename survives.
- **Runs stay independent.** The dispatcher forces `resume_id = None`, so each automated run is a fresh session and never carries the previous run's context — only the *view* is unified. The session-id handle is still passed so each run's id lands in the shared `.history` that merges the feed.
- **Stable chat title** = the routine name.

**Each run's prompt shows in the log (commit 2)**

- **Clean per-run prompt.** The displayed/persisted `user_message` is now the routine's own prompt, not `ctx.prompt` (which has the internal "end with ROUTINE_OK" suppression instruction appended). The model still receives the full prompt; only the saved/shown copy is clean.
- **Turn-aware echo de-dup.** The #363 fix dropped any WS-echoed prompt whose *text* already appeared in the feed. Since a routine's runs now share one chat and an identical prompt, a new run's prompt was being swallowed by an earlier run's (live and in hydrated history). The de-dup now correlates each WS echo with a *pending optimistic local push* (by count, per session) via `reconcileUserMessageEcho`: the sender's own echo is dropped, while a background routine run (no optimistic push) and cross-client deliveries append. `mergeFeedItem` is now append-only for user messages.

## Behavior notes

- The chat is a chronological `prompt → reply` log of all of a routine's runs. For `suppress_when_silent` routines, "nothing to report" runs also appear in the log once the chat exists (they simply don't flip it to "needs you") — matching the agreed design.
- **No migration:** older per-run routine chats keep their legacy `routine-{id}-run-{run}` keys and are left untouched as history. New runs collapse into one chat going forward.

## Tests

- `routines/runs.rs`: session key is stable per routine.
- `routines/engine_dispatcher.rs`: activity reuse across runs, distinct routines get distinct chats, user rename preserved, legacy per-run chats left intact.
- `routines/runner.rs`: chat title is the stable routine name.
- `ui/chat/test/feed-merge.test.mjs`: `reconcileUserMessageEcho` covers optimistic→echo drop, routine-run / cross-client append, repeated identical routine prompts all appending, and deliberate local repeats.

## Verification

- `pnpm typecheck` (full `ui` workspace) + `app` `pnpm tsc --noEmit`: pass.
- `ui/chat` feed-merge tests: 15/15 pass.
- Engine: verified by review (no local Rust toolchain); the new unit tests are there for CI / the maintainer to run.

## Files changed

- `engine/houston-engine-core/src/routines/runs.rs`, `agents/routine_runs.rs`
- `engine/houston-engine-core/src/routines/engine_dispatcher.rs`
- `engine/houston-engine-core/src/routines/runner.rs`
- `engine/houston-engine-core/src/routines/types.rs`, `agents/types.rs`, `agents/mod.rs`
- `ui/chat/src/feed-merge.ts`, `ui/chat/src/index.ts`, `ui/chat/test/feed-merge.test.mjs`
- `app/src/stores/feeds.ts`
- `app/src/components/tabs/archived-tab.tsx` (comment)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
