### PR TITLE
fix(routines): preserve custom cron schedules instead of resetting to Daily

### DIFF
--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -17,6 +17,7 @@
     "framer-motion": "^12.38.0"
   },
   "scripts": {
+    "test": "node --experimental-strip-types --test tests/*.test.ts",
     "typecheck": "tsc --noEmit"
   }
 }

--- a/ui/routines/src/routine-row.tsx
+++ b/ui/routines/src/routine-row.tsx
@@ -7,7 +7,7 @@
  */
 import { cn, Switch } from "@houston-ai/core"
 import type { Routine, RoutineRun } from "./types"
-import { cronToPreset, presetSummary, cronToOptions } from "./schedule-cron-utils"
+import { cronSummary } from "./schedule-cron-utils"
 import { nextFire, describeNextFire } from "./next-fire"
 import { useNow } from "./use-now"
 
@@ -18,17 +18,6 @@ export interface RoutineRowProps {
   accountTimezone: string
   onClick?: () => void
   onToggle?: (enabled: boolean) => void
-}
-
-function scheduleSummary(cron: string): string {
-  const preset = cronToPreset(cron)
-  if (!preset) return cron
-  const options = cronToOptions(cron)
-  return presetSummary(preset, {
-    time: options.time ?? "09:00",
-    dayOfWeek: options.dayOfWeek ?? 1,
-    dayOfMonth: options.dayOfMonth ?? 1,
-  })
 }
 
 const STATUS_DOT: Record<string, string> = {
@@ -107,7 +96,7 @@ export function RoutineRow({
           {routine.name || "Untitled"}
         </p>
         <p className="text-xs text-muted-foreground truncate mt-0.5">
-          {scheduleSummary(routine.schedule)}
+          {cronSummary(routine.schedule)}
           {routine.timezone && (
             <span className="text-muted-foreground/60"> · {routine.timezone}</span>
           )}

--- a/ui/routines/src/schedule-builder.tsx
+++ b/ui/routines/src/schedule-builder.tsx
@@ -12,6 +12,7 @@ import {
   presetSummary,
   cronToPreset,
   cronToOptions,
+  cronSummary,
   type ScheduleOptions,
 } from "./schedule-cron-utils"
 
@@ -50,7 +51,7 @@ export function ScheduleBuilder({
     ...detectedOptions,
   })
   const [customCron, setCustomCron] = useState(
-    detectedPreset === null ? value : "",
+    detectedPreset === "custom" ? value : "",
   )
 
   // Stable ref for onChange to avoid infinite effect loops
@@ -73,7 +74,7 @@ export function ScheduleBuilder({
 
   const showTime = NEEDS_TIME.includes(activePreset)
   const summary = activePreset === "custom"
-    ? (customCron.trim() ? "Custom cron schedule" : "Enter a cron expression")
+    ? (customCron.trim() ? cronSummary(customCron) : "Enter a cron expression")
     : presetSummary(activePreset, options)
   const cronDisplay = activePreset === "custom"
     ? customCron

--- a/ui/routines/src/schedule-cron-utils.ts
+++ b/ui/routines/src/schedule-cron-utils.ts
@@ -83,16 +83,28 @@ function ordinal(n: number): string {
   return n + (s[(v - 20) % 10] || s[v] || s[0])
 }
 
-/** Detect a preset from a cron expression (best-effort) */
+/**
+ * Classify a cron expression for the schedule builder. Three-way result, and
+ * the distinction is load-bearing:
+ *   - a known preset slug  → the matching preset UI is shown
+ *   - `"custom"`           → a valid-but-non-preset cron (e.g. `*​/5 * * * *`);
+ *                            the raw-cron input is shown, seeded with the value
+ *   - `null`               → no schedule at all (empty string)
+ *
+ * Returning `null` for a *non-empty* custom cron was the source of issue #374:
+ * the builder treated "unrecognized" the same as "empty" and silently fell
+ * back to the Daily preset, clobbering every-N-minutes schedules on reopen.
+ */
 export function cronToPreset(cron: string): SchedulePreset | null {
   const trimmed = cron.trim()
+  if (!trimmed) return null
   if (trimmed === "*/30 * * * *") return "every_30min"
   if (trimmed === "0 * * * *") return "hourly"
   if (/^\d+ \d+ \* \* \*$/.test(trimmed)) return "daily"
   if (/^\d+ \d+ \* \* 1-5$/.test(trimmed)) return "weekdays"
   if (/^\d+ \d+ \* \* [0-6]$/.test(trimmed)) return "weekly"
   if (/^\d+ \d+ \d+ \* \*$/.test(trimmed)) return "monthly"
-  return null
+  return "custom"
 }
 
 /** Extract time/day options from a cron expression (best-effort) */
@@ -119,4 +131,47 @@ export function cronToOptions(cron: string): Partial<ScheduleOptions> {
   }
 
   return result
+}
+
+/**
+ * Human-readable summary of any cron expression, written for non-technical
+ * users. Recognizes the presets and the common interval patterns (every N
+ * minutes / hours) so a `*​/5 * * * *` reads as "Runs every 5 minutes" instead
+ * of raw cron, and otherwise falls back to a generic label.
+ */
+export function cronSummary(cron: string): string {
+  const trimmed = cron.trim()
+  if (!trimmed) return "No schedule set"
+
+  const preset = cronToPreset(trimmed)
+  if (preset && preset !== "custom") {
+    const o = cronToOptions(trimmed)
+    return presetSummary(preset, {
+      time: o.time ?? "09:00",
+      dayOfWeek: o.dayOfWeek ?? 1,
+      dayOfMonth: o.dayOfMonth ?? 1,
+    })
+  }
+
+  const parts = trimmed.split(/\s+/)
+  if (parts.length === 5) {
+    const [min, hour, dom, month, dow] = parts
+    const everyDay = dom === "*" && month === "*" && dow === "*"
+    if (everyDay) {
+      // Every N minutes: "*/N * * * *" (and "* * * * *" = every minute).
+      const minStep = min.match(/^\*\/(\d+)$/)
+      if (hour === "*" && (min === "*" || minStep)) {
+        const n = minStep ? Number(minStep[1]) : 1
+        return n === 1 ? "Runs every minute" : `Runs every ${n} minutes`
+      }
+      // Every N hours on the hour: "M */N * * *".
+      const hourStep = hour.match(/^\*\/(\d+)$/)
+      if (/^\d+$/.test(min) && hourStep) {
+        const n = Number(hourStep[1])
+        return n === 1 ? "Runs every hour" : `Runs every ${n} hours`
+      }
+    }
+  }
+
+  return "Custom schedule"
 }

--- a/ui/routines/tests/schedule-cron-utils.test.ts
+++ b/ui/routines/tests/schedule-cron-utils.test.ts
@@ -1,0 +1,98 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "node:test"
+import {
+  presetToCron,
+  presetSummary,
+  cronToPreset,
+  cronToOptions,
+  cronSummary,
+  type ScheduleOptions,
+} from "../src/schedule-cron-utils.ts"
+
+const OPTS: ScheduleOptions = { time: "09:00", dayOfWeek: 3, dayOfMonth: 15 }
+
+describe("cronToPreset", () => {
+  it("detects the built-in presets", () => {
+    assert.equal(cronToPreset("*/30 * * * *"), "every_30min")
+    assert.equal(cronToPreset("0 * * * *"), "hourly")
+    assert.equal(cronToPreset("0 9 * * *"), "daily")
+    assert.equal(cronToPreset("30 8 * * *"), "daily")
+    assert.equal(cronToPreset("0 9 * * 1-5"), "weekdays")
+    assert.equal(cronToPreset("0 9 * * 3"), "weekly")
+    assert.equal(cronToPreset("0 9 15 * *"), "monthly")
+  })
+
+  // The crux of issue #374: an every-N-minutes cron must classify as "custom",
+  // not null. Previously null was treated as "empty" and the builder fell back
+  // to the Daily preset, silently overwriting the schedule on reopen.
+  it("classifies a non-empty, non-preset cron as custom", () => {
+    assert.equal(cronToPreset("*/5 * * * *"), "custom")
+    assert.equal(cronToPreset("*/1 * * * *"), "custom")
+    assert.equal(cronToPreset("* * * * *"), "custom")
+    assert.equal(cronToPreset("0 */2 * * *"), "custom")
+    assert.equal(cronToPreset("0 9 * * 1-3"), "custom")
+    assert.equal(cronToPreset("not a cron"), "custom")
+  })
+
+  it("returns null only for an empty schedule", () => {
+    assert.equal(cronToPreset(""), null)
+    assert.equal(cronToPreset("   "), null)
+  })
+})
+
+describe("presetToCron / cronToPreset round-trip", () => {
+  it("round-trips every detectable preset", () => {
+    const presets = [
+      "every_30min",
+      "hourly",
+      "daily",
+      "weekdays",
+      "weekly",
+      "monthly",
+    ] as const
+    for (const preset of presets) {
+      const cron = presetToCron(preset, OPTS)
+      assert.equal(cronToPreset(cron), preset, `${preset} -> ${cron}`)
+    }
+  })
+})
+
+describe("cronToOptions", () => {
+  it("extracts the time from a daily cron", () => {
+    assert.equal(cronToOptions("30 8 * * *").time, "08:30")
+  })
+  it("extracts the day of week", () => {
+    assert.equal(cronToOptions("0 9 * * 4").dayOfWeek, 4)
+  })
+  it("extracts the day of month", () => {
+    assert.equal(cronToOptions("0 9 15 * *").dayOfMonth, 15)
+  })
+  it("returns no spurious options for interval crons", () => {
+    assert.deepEqual(cronToOptions("*/5 * * * *"), {})
+  })
+})
+
+describe("cronSummary", () => {
+  it("describes every-N-minute schedules in plain words", () => {
+    assert.equal(cronSummary("* * * * *"), "Runs every minute")
+    assert.equal(cronSummary("*/1 * * * *"), "Runs every minute")
+    assert.equal(cronSummary("*/5 * * * *"), "Runs every 5 minutes")
+    assert.equal(cronSummary("*/10 * * * *"), "Runs every 10 minutes")
+  })
+  it("describes every-N-hour schedules", () => {
+    assert.equal(cronSummary("0 */1 * * *"), "Runs every hour")
+    assert.equal(cronSummary("0 */2 * * *"), "Runs every 2 hours")
+  })
+  it("describes the presets", () => {
+    assert.equal(cronSummary("*/30 * * * *"), "Runs every 30 minutes")
+    assert.equal(cronSummary("0 9 * * *"), "Runs every day at 9:00 AM")
+    assert.equal(
+      cronSummary("0 9 * * 1-5"),
+      "Runs Monday through Friday at 9:00 AM",
+    )
+  })
+  it("falls back gracefully for irregular crons and empty input", () => {
+    assert.equal(cronSummary("0 9 1-3 * *"), "Custom schedule")
+    assert.equal(cronSummary(""), "No schedule set")
+  })
+})


### PR DESCRIPTION
Fixes #374

## Problem

Custom routine schedules (e.g. "every 1 to 10 minutes") didn't work, and reopening a routine that used one showed **Daily** instead of the custom schedule.

Both symptoms had a single root cause in `@houston-ai/routines`:

`cronToPreset()` returned `null` for **any** cron that wasn't one of the six built-in presets, conflating *"valid custom schedule"* with *"no schedule"*. `ScheduleBuilder` then:

1. fell back to the Daily preset (`detectedPreset ?? "daily"`), so a custom cron like `*/5 * * * *` rendered as **Daily**; and
2. its mount `useEffect` immediately emitted `presetToCron("daily", …)` = `0 9 * * *`, **silently overwriting** the custom schedule in form state. On the next save the every-5-minutes routine became a daily-9am routine, so short intervals never fired.

The **engine scheduler already fires these crons correctly** (`engine/houston-engine-core/src/routines/scheduler.rs` uses event-driven `Schedule::upcoming().next()` then sleeps; there is no minimum-interval floor, and `*/5 * * * *` is already covered by an engine test). The bug was entirely frontend.

## Fix

- **`cronToPreset`** — three-way classification now: a known preset / `"custom"` (non-empty, non-preset) / `null` (empty only). `"custom"` is a real `SchedulePreset`, so this just stops lying about it.
- **`ScheduleBuilder`** — seed the raw-cron input when the detected preset is `"custom"` so the value round-trips instead of being clobbered; the preset chip now correctly highlights **Custom (cron)** on reopen.
- **`cronSummary`** — plain-language summaries for interval crons (`*/5 * * * *` → "Runs every 5 minutes", `0 */2 * * *` → "Runs every 2 hours") used by the routine row and the editor summary instead of vague "Custom cron schedule" / raw cron. Friendlier for the non-technical target user.

No engine changes; no public API change to the package (the new helper is internal).

## Tests

New `ui/routines/tests/schedule-cron-utils.test.ts` (12 cases, `node:test`) covering the three-way `cronToPreset` classification, `presetToCron` ↔ `cronToPreset` round-trips, `cronToOptions` extraction, and `cronSummary` rendering. Added a `test` script to the package.

```
ℹ tests 12   ℹ pass 12   ℹ fail 0
```

`pnpm typecheck` (`@houston-ai/routines`) passes.

## Affected files

- `ui/routines/src/schedule-cron-utils.ts` — `cronToPreset` fix + new `cronSummary`
- `ui/routines/src/schedule-builder.tsx` — seed custom input from `"custom"`; use `cronSummary` for the live summary
- `ui/routines/src/routine-row.tsx` — use `cronSummary` for the row's schedule label
- `ui/routines/tests/schedule-cron-utils.test.ts` — new tests
- `ui/routines/package.json` — `test` script

## Follow-up (not in this PR)

The routine editor/schedule summaries are hardcoded English (pre-existing — `presetSummary` etc. were already not routed through `labels` props). Threading these through the `ui/` `labels` i18n pattern is a separate, larger refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
