### PR TITLE
feat(i18n): persist UI language per workspace in the engine

### DIFF
--- a/app/src/components/settings/sections/language.tsx
+++ b/app/src/components/settings/sections/language.tsx
@@ -6,15 +6,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@houston-ai/core";
-import { tauriPreferences } from "../../../lib/tauri";
 import {
   changeLocale,
   isSupported,
-  LOCALE_PREF_KEY,
   SUPPORTED_LOCALES,
   type SupportedLocale,
 } from "../../../lib/i18n";
 import { useUIStore } from "../../../stores/ui";
+import { useWorkspaceStore } from "../../../stores/workspaces";
 
 const LOCALE_LABELS: Record<SupportedLocale, string> = {
   en: "English",
@@ -25,14 +24,21 @@ const LOCALE_LABELS: Record<SupportedLocale, string> = {
 export function LanguageSection() {
   const { t, i18n } = useTranslation("common");
   const addToast = useUIStore((s) => s.addToast);
+  const current = useWorkspaceStore((s) => s.current);
+  const setWorkspaceLocale = useWorkspaceStore((s) => s.setLocale);
   const currentLocale: SupportedLocale = isSupported(i18n.resolvedLanguage)
     ? (i18n.resolvedLanguage as SupportedLocale)
     : "en";
 
   const handleLocaleChange = async (value: string) => {
-    if (!isSupported(value)) return;
+    // This picker lives under the Workspace settings tab, which SettingsView
+    // only renders once a workspace is active — so `current` is guaranteed; the
+    // guard just defends the rare unmount race. Persist the override FIRST so
+    // the engine is the source of truth; if it fails the error surfaces and the
+    // UI never switches to an unsaved language.
+    if (!isSupported(value) || !current) return;
+    await setWorkspaceLocale(current.id, value);
     await changeLocale(value);
-    await tauriPreferences.set(LOCALE_PREF_KEY, value);
     addToast({ title: t("language.toastChanged") });
   };
 

--- a/app/src/hooks/use-locale-preference.ts
+++ b/app/src/hooks/use-locale-preference.ts
@@ -1,42 +1,125 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
-import { tauriPreferences } from "../lib/tauri";
+import { tauriPreferences, tauriWorkspaces } from "../lib/tauri";
+import { logger } from "../lib/logger";
+import { useWorkspaceStore } from "../stores/workspaces";
 import {
   LOCALE_PREF_KEY,
+  activeWorkspaceLocale,
+  applyEngineLocale,
   changeLocale,
   isSupported,
+  resolveEffectiveLocale,
   type SupportedLocale,
 } from "../lib/i18n";
 
-const queryKey = ["locale-preference"] as const;
+const globalKey = ["locale-preference"] as const;
+const bootWorkspaceKey = ["boot-workspace-locale"] as const;
+const LAST_WORKSPACE_KEY = "last_workspace_id";
 
 export interface LocalePreferenceState {
-  /** Persisted locale the user explicitly chose, or null if they never picked. */
+  /**
+   * The GLOBAL default locale the user explicitly chose, or null if they never
+   * picked. The first-run language gate keys off this (null → show the
+   * picker). Per-workspace overrides do NOT affect first-run.
+   */
   locale: SupportedLocale | null;
-  /** True while the initial preference fetch is in flight. */
+  /** True until every source has resolved AND the resolved locale is applied. */
   isLoading: boolean;
-  /** Write the locale to engine prefs AND swap the live i18n language. */
+  /**
+   * First-run picker write: persist the GLOBAL default (no workspace exists
+   * yet) and swap the live i18n language. Later, per-workspace changes go
+   * through the workspace store's `setLocale`, not this.
+   */
   setLocale: (locale: SupportedLocale) => Promise<void>;
 }
 
 /**
- * Reads and writes the user's explicit UI-locale preference via the
- * engine's preferences KV. A null result means "never picked" — the
- * first-run language gate uses that to decide whether to show the
- * picker. Once set, the value survives across launches.
+ * Owns the full locale story for boot: it resolves the user's effective UI
+ * locale from the engine — the active workspace's `locale` override winning
+ * over the global `locale` preference — and applies it to the live i18n
+ * instance. The engine, NOT the browser's localStorage cache, is the source of
+ * truth, so a fresh browser pointed at a headless engine still shows the
+ * stored language. localStorage stays a boot-time flash cache only.
+ *
+ * Consumed by the first-run `LanguageGate`; because that gate wraps the whole
+ * app it also keeps the live language in sync as the active workspace changes.
  */
 export function useLocalePreference(): LocalePreferenceState {
   const qc = useQueryClient();
+  const storeCurrent = useWorkspaceStore((s) => s.current);
+  const [applied, setApplied] = useState(false);
 
-  const query = useQuery({
-    queryKey,
+  // Global default locale preference (engine-owned).
+  const globalQuery = useQuery({
+    queryKey: globalKey,
     queryFn: async (): Promise<SupportedLocale | null> => {
       const raw = await tauriPreferences.get(LOCALE_PREF_KEY);
       return isSupported(raw) ? raw : null;
     },
     staleTime: 30_000,
   });
+
+  // Boot-time active-workspace override, resolved INDEPENDENTLY of <App/> —
+  // which mounts below <LanguageGate> and only then loads workspaces. Without
+  // this the gate would apply the global default on the first paint and then
+  // flash to the workspace override once <App/> loads. Best-effort: a failure
+  // logs and resolves null (the real error surfaces via the store's
+  // loadWorkspaces), so boot falls back to the global default, never blocks.
+  const bootWorkspaceQuery = useQuery({
+    queryKey: bootWorkspaceKey,
+    queryFn: async (): Promise<string | null> => {
+      try {
+        const [workspaces, lastId] = await Promise.all([
+          tauriWorkspaces.list(),
+          tauriPreferences.get(LAST_WORKSPACE_KEY),
+        ]);
+        return activeWorkspaceLocale(workspaces, lastId);
+      } catch (err) {
+        logger.error(
+          "[locale] boot workspace resolve failed",
+          err instanceof Error ? err.message : String(err),
+        );
+        return null;
+      }
+    },
+    staleTime: 30_000,
+  });
+
+  const globalLocale = globalQuery.data ?? null;
+  // Once <App/> has set an active workspace it is authoritative (it reacts to
+  // the user switching workspaces); before that, the boot query stands in so
+  // the first paint already reflects the active workspace's override.
+  const workspaceLocale = storeCurrent
+    ? storeCurrent.locale ?? null
+    : bootWorkspaceQuery.data ?? null;
+  const effective = resolveEffectiveLocale(workspaceLocale, globalLocale);
+
+  // Apply the engine-resolved locale to the live i18n instance, and re-apply
+  // when it changes (e.g. switching into a workspace that pins a different
+  // language). Applying is best-effort — the i18next detector already picked a
+  // valid language — so a failure must NOT hold the gate: always un-gate in
+  // `finally`, and log (never silently swallow) on error.
+  useEffect(() => {
+    if (globalQuery.isLoading || bootWorkspaceQuery.isLoading) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        await applyEngineLocale(effective);
+      } catch (err) {
+        logger.error(
+          "[locale] applyEngineLocale failed",
+          err instanceof Error ? err.message : String(err),
+        );
+      } finally {
+        if (!cancelled) setApplied(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [globalQuery.isLoading, bootWorkspaceQuery.isLoading, effective]);
 
   const mutation = useMutation({
     mutationFn: async (locale: SupportedLocale) => {
@@ -45,7 +128,7 @@ export function useLocalePreference(): LocalePreferenceState {
       return locale;
     },
     onSuccess: (locale) => {
-      qc.setQueryData<SupportedLocale | null>(queryKey, locale);
+      qc.setQueryData<SupportedLocale | null>(globalKey, locale);
     },
   });
 
@@ -57,8 +140,8 @@ export function useLocalePreference(): LocalePreferenceState {
   );
 
   return {
-    locale: query.data ?? null,
-    isLoading: query.isLoading,
+    locale: globalLocale,
+    isLoading: globalQuery.isLoading || bootWorkspaceQuery.isLoading || !applied,
     setLocale,
   };
 }

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -12,6 +12,17 @@ import i18n from "i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 
+import {
+  SUPPORTED_LOCALES,
+  LOCALE_PREF_KEY,
+  isSupported,
+  normalizeLocale,
+  resolveEffectiveLocale,
+  localeToApply,
+  activeWorkspaceLocale,
+  type SupportedLocale,
+} from "./locale";
+
 import commonEn from "../locales/en/common.json";
 import setupEn from "../locales/en/setup.json";
 import legalEn from "../locales/en/legal.json";
@@ -64,11 +75,18 @@ import eventsPt from "../locales/pt/events.json";
 import portablePt from "../locales/pt/portable.json";
 import contextPt from "../locales/pt/context.json";
 
-export const SUPPORTED_LOCALES = ["en", "es", "pt"] as const;
-export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
-
-/** Engine preference key for the user's chosen UI locale. */
-export const LOCALE_PREF_KEY = "locale";
+// Pure locale value-logic lives in ./locale (DOM/JSON-free, unit-tested).
+// Re-exported here so existing `from "../lib/i18n"` imports keep working.
+export {
+  SUPPORTED_LOCALES,
+  LOCALE_PREF_KEY,
+  isSupported,
+  normalizeLocale,
+  resolveEffectiveLocale,
+  localeToApply,
+  activeWorkspaceLocale,
+};
+export type { SupportedLocale };
 
 /**
  * Boot-time cache key in localStorage. Used ONLY to avoid flash-of-wrong-
@@ -91,20 +109,6 @@ export function setCachedLocale(locale: SupportedLocale): void {
   } catch {
     /* ignore quota / disabled storage */
   }
-}
-
-export function isSupported(value: unknown): value is SupportedLocale {
-  return (
-    typeof value === "string" &&
-    (SUPPORTED_LOCALES as readonly string[]).includes(value)
-  );
-}
-
-/** Normalize a BCP-47 tag (`pt-BR`) to a supported locale (`pt`), or null. */
-export function normalizeLocale(value: string | null | undefined): SupportedLocale | null {
-  if (!value) return null;
-  const base = value.toLowerCase().split(/[-_]/)[0];
-  return isSupported(base) ? base : null;
 }
 
 const resources = {
@@ -216,15 +220,16 @@ void i18n
   });
 
 /**
- * Apply a locale coming from the engine preference. Pass `null` if the
- * preference is unset and the detector-picked value should stand.
+ * Apply the engine-resolved locale to the live i18n instance and refresh the
+ * boot cache, making the engine the source of truth. Pass `null` if neither
+ * the workspace override nor the global preference is set — the detector pick
+ * then stands. No-ops when the target already matches the active language.
  */
 export async function applyEngineLocale(raw: string | null): Promise<void> {
-  const locale = normalizeLocale(raw);
-  if (!locale) return;
-  if (i18n.language === locale) return;
-  await i18n.changeLanguage(locale);
-  setCachedLocale(locale);
+  const target = localeToApply(raw, i18n.language);
+  if (!target) return;
+  await i18n.changeLanguage(target);
+  setCachedLocale(target);
 }
 
 /** Change the active locale AND remember it in the boot cache. */

--- a/app/src/lib/locale.ts
+++ b/app/src/lib/locale.ts
@@ -1,0 +1,93 @@
+/**
+ * Pure locale value-logic for the Houston desktop app — no i18next, no DOM, no
+ * JSON-module imports, so it loads under the bare Node test runner and stays
+ * unit-testable. The i18next runtime wiring (init, changeLanguage, the
+ * localStorage flash-cache, applying the engine value) lives in `./i18n`, which
+ * re-exports everything here so existing `from "../lib/i18n"` imports keep
+ * working.
+ */
+
+export const SUPPORTED_LOCALES = ["en", "es", "pt"] as const;
+export type SupportedLocale = (typeof SUPPORTED_LOCALES)[number];
+
+/** Engine preference key for the user's chosen UI locale (global default). */
+export const LOCALE_PREF_KEY = "locale";
+
+export function isSupported(value: unknown): value is SupportedLocale {
+  return (
+    typeof value === "string" &&
+    (SUPPORTED_LOCALES as readonly string[]).includes(value)
+  );
+}
+
+/** Normalize a BCP-47 tag (`pt-BR`) to a supported locale (`pt`), or null. */
+export function normalizeLocale(
+  value: string | null | undefined,
+): SupportedLocale | null {
+  if (!value) return null;
+  const base = value.toLowerCase().split(/[-_]/)[0];
+  return isSupported(base) ? base : null;
+}
+
+/**
+ * Resolve the effective UI locale from the engine's two sources of truth: the
+ * active workspace's override wins, otherwise the global `locale` preference.
+ * Returns null when neither is set/valid (caller then keeps the detector pick).
+ *
+ * The engine, never the browser's localStorage cache, owns both, so a fresh
+ * browser pointed at a headless engine resolves the right language.
+ */
+export function resolveEffectiveLocale(
+  workspaceLocale: string | null | undefined,
+  globalLocale: string | null | undefined,
+): SupportedLocale | null {
+  return normalizeLocale(workspaceLocale) ?? normalizeLocale(globalLocale);
+}
+
+/**
+ * Decide which locale (if any) the live UI should switch to, given an
+ * engine-resolved value and the currently active language. Returns null to
+ * leave the language untouched: the value is unset/invalid, or already active.
+ * Pure, so it's unit-testable without an i18next instance; `applyEngineLocale`
+ * in `./i18n` wraps it with the actual `changeLanguage` call.
+ */
+export function localeToApply(
+  raw: string | null,
+  current: string | undefined,
+): SupportedLocale | null {
+  const locale = normalizeLocale(raw);
+  if (!locale) return null;
+  if (locale === current) return null;
+  return locale;
+}
+
+/** Minimal workspace shape needed to resolve the boot-time active locale. */
+export interface WorkspaceLocaleInput {
+  id: string;
+  isDefault: boolean;
+  locale?: string | null;
+}
+
+/**
+ * Pick the boot-time active workspace's locale override. Mirrors how the app
+ * restores the active workspace at startup (see `useHoustonInit`): the
+ * last-used workspace wins, else the default, else the first. Returns that
+ * workspace's override — which may be null (inherit the global default) — or
+ * null when there are no workspaces.
+ *
+ * Lets the locale gate resolve the override on the FIRST paint, independently
+ * of `<App/>` (which mounts below the gate and only then loads workspaces).
+ */
+export function activeWorkspaceLocale(
+  workspaces: WorkspaceLocaleInput[],
+  lastWorkspaceId: string | null | undefined,
+): string | null {
+  if (workspaces.length === 0) return null;
+  const active =
+    (lastWorkspaceId
+      ? workspaces.find((w) => w.id === lastWorkspaceId)
+      : undefined) ??
+    workspaces.find((w) => w.isDefault) ??
+    workspaces[0];
+  return active.locale ?? null;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -79,6 +79,10 @@ export const tauriWorkspaces = {
     call<void>("rename_workspace", async () => {
       await getEngine().renameWorkspace(id, { newName });
     }),
+  setLocale: (id: string, locale: string | null) =>
+    call<Workspace>("set_workspace_locale", () =>
+      getEngine().setWorkspaceLocale(id, locale),
+    ),
   getContext: (id: string) =>
     call<import("@houston-ai/engine-client").WorkspaceContext>(
       "get_workspace_context",

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -11,6 +11,11 @@ export interface Workspace {
   name: string;
   isDefault: boolean;
   createdAt: string;
+  /**
+   * Optional per-workspace UI-locale override (BCP-47 base tag: `en`/`es`/`pt`).
+   * Absent/null means the workspace inherits the global `locale` preference.
+   */
+  locale?: string | null;
 }
 
 /** Agent category for Houston Store filtering */

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -32,7 +32,7 @@
   },
   "language": {
     "title": "Language",
-    "description": "Choose the language Houston uses in its interface.",
+    "description": "Choose the language Houston uses for this workspace.",
     "label": "Interface language",
     "toastChanged": "Language changed"
   },

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -32,7 +32,7 @@
   },
   "language": {
     "title": "Idioma",
-    "description": "Elige el idioma que Houston usa en su interfaz.",
+    "description": "Elige el idioma que Houston usa para este espacio de trabajo.",
     "label": "Idioma de la interfaz",
     "toastChanged": "Idioma cambiado"
   },

--- a/app/src/locales/pt/common.json
+++ b/app/src/locales/pt/common.json
@@ -32,7 +32,7 @@
   },
   "language": {
     "title": "Idioma",
-    "description": "Escolha o idioma que o Houston usa na interface.",
+    "description": "Escolha o idioma que o Houston usa para este espaço de trabalho.",
     "label": "Idioma da interface",
     "toastChanged": "Idioma alterado"
   },

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -115,9 +115,11 @@ function EngineGate({ children }: { children: ReactNode }) {
     };
   }, [ready]);
 
-  // Locale resolution moved to <LanguageGate>, which both reads the
-  // persisted pref and handles the first-run picker. That gate sits
-  // inside <I18nextProvider> and owns the full locale story.
+  // Locale resolution lives in <LanguageGate>: it resolves the effective
+  // locale from the engine (active workspace override → global preference),
+  // applies it to the live i18n instance, and handles the first-run picker.
+  // That gate sits inside <I18nextProvider> and owns the full locale story —
+  // the engine, not localStorage, is the source of truth.
 
   if (!ready) {
     // Use the i18n singleton directly — this renders OUTSIDE

--- a/app/src/stores/workspaces.ts
+++ b/app/src/stores/workspaces.ts
@@ -12,6 +12,8 @@ interface WorkspaceState {
   create: (name: string) => Promise<Workspace>;
   delete: (id: string) => Promise<void>;
   rename: (id: string, newName: string) => Promise<void>;
+  /** Set (or clear, with null) the workspace's UI-locale override. */
+  setLocale: (id: string, locale: string | null) => Promise<void>;
 }
 
 export const useWorkspaceStore = create<WorkspaceState>((set) => ({
@@ -71,6 +73,14 @@ export const useWorkspaceStore = create<WorkspaceState>((set) => ({
       ),
       current:
         s.current?.id === id ? { ...s.current, name: newName } : s.current,
+    }));
+  },
+
+  setLocale: async (id, locale) => {
+    const updated = await tauriWorkspaces.setLocale(id, locale);
+    set((s) => ({
+      workspaces: s.workspaces.map((w) => (w.id === id ? updated : w)),
+      current: s.current?.id === id ? updated : s.current,
     }));
   },
 }));

--- a/app/tests/locale.test.ts
+++ b/app/tests/locale.test.ts
@@ -1,0 +1,113 @@
+import { strictEqual, ok } from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  isSupported,
+  normalizeLocale,
+  resolveEffectiveLocale,
+  localeToApply,
+  activeWorkspaceLocale,
+} from "../src/lib/locale.ts";
+
+describe("isSupported", () => {
+  it("accepts the three shipped locales only", () => {
+    ok(isSupported("en"));
+    ok(isSupported("es"));
+    ok(isSupported("pt"));
+    ok(!isSupported("fr"));
+    ok(!isSupported("EN")); // case-sensitive: normalization is a separate step
+    ok(!isSupported(null));
+    ok(!isSupported(undefined));
+    ok(!isSupported(123));
+  });
+});
+
+describe("normalizeLocale", () => {
+  it("maps BCP-47 tags to a supported base tag", () => {
+    strictEqual(normalizeLocale("en"), "en");
+    strictEqual(normalizeLocale("pt-BR"), "pt");
+    strictEqual(normalizeLocale("es-ES"), "es");
+    strictEqual(normalizeLocale("es_419"), "es");
+    strictEqual(normalizeLocale("EN"), "en");
+    strictEqual(normalizeLocale("PT-br"), "pt");
+  });
+
+  it("returns null for unsupported / empty / missing values", () => {
+    strictEqual(normalizeLocale("fr"), null);
+    strictEqual(normalizeLocale("english"), null);
+    strictEqual(normalizeLocale(""), null);
+    strictEqual(normalizeLocale(null), null);
+    strictEqual(normalizeLocale(undefined), null);
+  });
+});
+
+describe("resolveEffectiveLocale", () => {
+  it("prefers a valid workspace override over the global default", () => {
+    strictEqual(resolveEffectiveLocale("es", "en"), "es");
+    strictEqual(resolveEffectiveLocale("pt-BR", "en"), "pt");
+  });
+
+  it("falls back to the global default when the workspace has no valid override", () => {
+    strictEqual(resolveEffectiveLocale(null, "pt"), "pt");
+    strictEqual(resolveEffectiveLocale(undefined, "en"), "en");
+    strictEqual(resolveEffectiveLocale("fr", "es"), "es"); // invalid override ignored
+    strictEqual(resolveEffectiveLocale("", "es"), "es");
+  });
+
+  it("returns null when neither source is set/valid (keep detector pick)", () => {
+    strictEqual(resolveEffectiveLocale(null, null), null);
+    strictEqual(resolveEffectiveLocale(undefined, undefined), null);
+    strictEqual(resolveEffectiveLocale("fr", "de"), null);
+  });
+});
+
+describe("localeToApply", () => {
+  it("returns the normalized target when it differs from the active language", () => {
+    strictEqual(localeToApply("es", "en"), "es");
+    strictEqual(localeToApply("pt-BR", "en"), "pt");
+    strictEqual(localeToApply("es", undefined), "es");
+    strictEqual(localeToApply("en", "es"), "en");
+  });
+
+  it("returns null to leave the language untouched", () => {
+    strictEqual(localeToApply("en", "en"), null); // already active
+    strictEqual(localeToApply("pt-BR", "pt"), null); // already active after normalize
+    strictEqual(localeToApply(null, "en"), null); // unset
+    strictEqual(localeToApply("fr", "en"), null); // unsupported
+    strictEqual(localeToApply("", "en"), null); // empty
+  });
+});
+
+describe("activeWorkspaceLocale", () => {
+  const ws = (id: string, isDefault: boolean, locale?: string | null) => ({
+    id,
+    isDefault,
+    locale,
+  });
+
+  it("returns null when there are no workspaces", () => {
+    strictEqual(activeWorkspaceLocale([], null), null);
+    strictEqual(activeWorkspaceLocale([], "anything"), null);
+  });
+
+  it("prefers the last-used workspace's override", () => {
+    const list = [ws("a", true, "en"), ws("b", false, "pt")];
+    strictEqual(activeWorkspaceLocale(list, "b"), "pt");
+  });
+
+  it("falls back to the default workspace when last-used is unknown/absent", () => {
+    const list = [ws("a", false, "en"), ws("b", true, "pt")];
+    strictEqual(activeWorkspaceLocale(list, null), "pt"); // default wins
+    strictEqual(activeWorkspaceLocale(list, "ghost"), "pt"); // stale id -> default
+  });
+
+  it("falls back to the first workspace when none is default", () => {
+    const list = [ws("a", false, "es"), ws("b", false, "pt")];
+    strictEqual(activeWorkspaceLocale(list, null), "es");
+  });
+
+  it("returns null when the active workspace has no override (inherit global)", () => {
+    const list = [ws("a", true), ws("b", false, "pt")];
+    strictEqual(activeWorkspaceLocale(list, null), null); // default has no override
+    strictEqual(activeWorkspaceLocale(list, "a"), null);
+  });
+});

--- a/engine/houston-engine-core/src/workspaces/mod.rs
+++ b/engine/houston-engine-core/src/workspaces/mod.rs
@@ -25,6 +25,14 @@ pub struct Workspace {
     pub name: String,
     pub is_default: bool,
     pub created_at: String,
+    /// Optional per-workspace UI locale override (BCP-47 base tag: `"en"`,
+    /// `"es"`, `"pt"`). When set, frontends prefer it over the global
+    /// `preferences::locale` value; when `None` the workspace inherits that
+    /// global default. Additive + `skip_serializing_if` so pre-existing
+    /// `workspaces.json` files (which lack the key) parse unchanged and a
+    /// workspace that never picked a language never grows a `locale` key.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub locale: Option<String>,
     // Legacy fields. They're still parsed here so the migration can read
     // pre-0.5 workspace files; once `migrate_workspace_provider_into_agents`
     // runs they're stripped from disk and the resolver no longer consults
@@ -70,6 +78,7 @@ pub fn create(root: &Path, req: CreateWorkspace) -> CoreResult<Workspace> {
         name: req.name.clone(),
         is_default: false,
         created_at: now_iso(),
+        locale: None,
         provider: None,
         model: None,
     };
@@ -112,6 +121,23 @@ pub fn rename(root: &Path, id: &str, req: RenameWorkspace) -> CoreResult<Workspa
         rename_path(&old_dir, &new_dir)?;
     }
     ws.name = req.new_name;
+    let updated = ws.clone();
+    io::write_all(root, &workspaces)?;
+    Ok(updated)
+}
+
+/// Set (or clear) a workspace's UI-locale override. An empty / whitespace
+/// value clears it — mirroring how `preferences::locale` treats blanks — so
+/// the workspace falls back to the global `locale` preference. The value is
+/// stored verbatim (frontends normalize BCP-47 tags); the engine stays
+/// locale-agnostic.
+pub fn set_locale(root: &Path, id: &str, locale: Option<String>) -> CoreResult<Workspace> {
+    let mut workspaces = read_all(root)?;
+    let ws = workspaces
+        .iter_mut()
+        .find(|w| w.id == id)
+        .ok_or_else(|| CoreError::NotFound(format!("workspace {id}")))?;
+    ws.locale = locale.filter(|s| !s.trim().is_empty());
     let updated = ws.clone();
     io::write_all(root, &workspaces)?;
     Ok(updated)
@@ -178,6 +204,68 @@ mod tests {
         assert_eq!(renamed.name, "b");
         delete(d.path(), &ws.id).unwrap();
         assert!(list(d.path()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn set_locale_roundtrip_and_clear() {
+        let d = tmp();
+        let ws = create(d.path(), CreateWorkspace { name: "alpha".into() }).unwrap();
+        assert!(ws.locale.is_none(), "new workspace has no locale override");
+
+        let updated = set_locale(d.path(), &ws.id, Some("es".into())).unwrap();
+        assert_eq!(updated.locale.as_deref(), Some("es"));
+        assert_eq!(list(d.path()).unwrap()[0].locale.as_deref(), Some("es"));
+
+        // Whitespace-only clears the override (falls back to the global default),
+        // mirroring preferences::locale.
+        let cleared = set_locale(d.path(), &ws.id, Some("   ".into())).unwrap();
+        assert!(cleared.locale.is_none());
+        assert!(list(d.path()).unwrap()[0].locale.is_none());
+
+        // Explicit None also clears.
+        set_locale(d.path(), &ws.id, Some("pt".into())).unwrap();
+        let cleared_again = set_locale(d.path(), &ws.id, None).unwrap();
+        assert!(cleared_again.locale.is_none());
+    }
+
+    #[test]
+    fn set_locale_unknown_id_errors() {
+        let d = tmp();
+        let err = set_locale(d.path(), "nope", Some("es".into())).unwrap_err();
+        assert!(matches!(err, CoreError::NotFound(_)));
+    }
+
+    #[test]
+    fn locale_survives_rename() {
+        let d = tmp();
+        let ws = create(d.path(), CreateWorkspace { name: "alpha".into() }).unwrap();
+        set_locale(d.path(), &ws.id, Some("pt".into())).unwrap();
+        rename(
+            d.path(),
+            &ws.id,
+            RenameWorkspace { new_name: "beta".into() },
+        )
+        .unwrap();
+        let all = list(d.path()).unwrap();
+        assert_eq!(all[0].name, "beta");
+        assert_eq!(all[0].locale.as_deref(), Some("pt"));
+    }
+
+    /// A pre-`locale` `workspaces.json` (no `locale` key) must deserialize with
+    /// `locale: None` — the field is additive, so existing users need no
+    /// migration. And a workspace without an override must not serialize the key.
+    #[test]
+    fn workspace_json_without_locale_parses_and_omits_when_unset() {
+        let json = r#"[{"id":"w1","name":"Personal","isDefault":true,"createdAt":"t"}]"#;
+        let parsed: Vec<Workspace> = serde_json::from_str(json).unwrap();
+        assert_eq!(parsed.len(), 1);
+        assert!(parsed[0].locale.is_none());
+
+        let out = serde_json::to_string(&parsed).unwrap();
+        assert!(
+            !out.contains("locale"),
+            "an unset locale override must not be written to disk, got: {out}"
+        );
     }
 
     #[test]

--- a/engine/houston-engine-server/src/routes/workspaces.rs
+++ b/engine/houston-engine-server/src/routes/workspaces.rs
@@ -18,6 +18,7 @@ pub fn router() -> Router<Arc<ServerState>> {
         .route("/workspaces", get(list).post(create))
         .route("/workspaces/:id", delete(remove))
         .route("/workspaces/:id/rename", post(rename))
+        .route("/workspaces/:id/locale", patch(set_locale))
         .route(
             "/workspaces/:id/context",
             get(get_context).put(put_context),
@@ -62,6 +63,26 @@ async fn rename(
     Json(req): Json<RenameWorkspace>,
 ) -> Result<Json<Workspace>, ApiError> {
     Ok(Json(workspaces::rename(st.engine.paths.docs(), &id, req)?))
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SetWorkspaceLocale {
+    /// BCP-47 base tag (`"en"` / `"es"` / `"pt"`). `null` or empty clears the
+    /// per-workspace override so the workspace inherits the global `locale`.
+    locale: Option<String>,
+}
+
+async fn set_locale(
+    State(st): State<Arc<ServerState>>,
+    Path(id): Path<String>,
+    Json(req): Json<SetWorkspaceLocale>,
+) -> Result<Json<Workspace>, ApiError> {
+    Ok(Json(workspaces::set_locale(
+        st.engine.paths.docs(),
+        &id,
+        req.locale,
+    )?))
 }
 
 async fn get_context(

--- a/engine/houston-engine-server/tests/workspaces.rs
+++ b/engine/houston-engine-server/tests/workspaces.rs
@@ -95,6 +95,64 @@ async fn create_list_rename_delete_workspace() {
 }
 
 #[tokio::test]
+async fn set_workspace_locale_roundtrip() {
+    let (addr, tok, _docs) = spawn().await;
+    let c = reqwest::Client::new();
+
+    // Create — no locale override on a fresh workspace.
+    let ws: serde_json::Value = c
+        .post(format!("http://{addr}/v1/workspaces"))
+        .bearer_auth(&tok)
+        .json(&serde_json::json!({ "name": "alpha" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let id = ws["id"].as_str().unwrap().to_string();
+    assert!(ws.get("locale").is_none() || ws["locale"].is_null());
+
+    // Set the per-workspace locale override.
+    let updated: serde_json::Value = c
+        .patch(format!("http://{addr}/v1/workspaces/{id}/locale"))
+        .bearer_auth(&tok)
+        .json(&serde_json::json!({ "locale": "es" }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(updated["locale"], "es");
+
+    // It survives a fresh list (persisted to workspaces.json).
+    let list: serde_json::Value = c
+        .get(format!("http://{addr}/v1/workspaces"))
+        .bearer_auth(&tok)
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert_eq!(list[0]["locale"], "es");
+
+    // Clearing with null removes the override.
+    let cleared: serde_json::Value = c
+        .patch(format!("http://{addr}/v1/workspaces/{id}/locale"))
+        .bearer_auth(&tok)
+        .json(&serde_json::json!({ "locale": null }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    assert!(cleared.get("locale").is_none() || cleared["locale"].is_null());
+}
+
+#[tokio::test]
 async fn update_workspace_agent_color() {
     let (addr, tok, _docs) = spawn().await;
     let c = reqwest::Client::new();

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -94,6 +94,7 @@ module.
 | POST | `/v1/workspaces` | Create |
 | DELETE | `/v1/workspaces/:id` | Delete |
 | POST | `/v1/workspaces/:id/rename` | Rename |
+| PATCH | `/v1/workspaces/:id/locale` | Set/clear the per-workspace UI-locale override (`{ locale: "es" \| null }`) |
 | PATCH | `/v1/workspaces/:id/provider` | Set provider/model |
 | GET | `/v1/workspaces/:id/context` | Read shared `WORKSPACE.md` + `USER.md` |
 | PUT | `/v1/workspaces/:id/context` | Write shared `WORKSPACE.md` + `USER.md` |

--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -9,6 +9,8 @@ If app-specific → `.houston/`.
 ## Layout
 
 ```
+~/.houston/workspaces/workspaces.json   Workspace[] index: id, name, isDefault, createdAt, locale?
+                                          (locale = optional per-workspace UI-locale override; absent = inherit global `locale` pref)
 ~/.houston/workspaces/{Workspace}/{Agent}/
   .houston/
     agent.json                  AgentMeta (id, manifest_id, created_at, last_opened_at)

--- a/knowledge-base/i18n.md
+++ b/knowledge-base/i18n.md
@@ -101,11 +101,17 @@ label: t(`agents:tabLabels.${tab.id}`, { defaultValue: tab.label })
 | settings | configuración | configurações |
 
 ## Locale source of truth
-- Engine preference key `locale` (BCP-47 base tag: `en` / `es` / `pt`)
-- First-run picker: [LanguageGate](../app/src/components/shell/language-gate.tsx) writes the pref before disclaimer
-- Settings has the same picker for later changes
-- localStorage cache `houston.locale.cache` is **boot-time only**, never the source of truth
-- Engine itself is locale-agnostic — surfaces the value verbatim
+
+Two **engine-owned** sources, resolved as: **active-workspace `locale` override → global `locale` preference → `navigator` → `en`**. The engine, never the browser, owns both — so a fresh browser pointed at a headless engine (the `houston webapp` against a container) shows the stored language instead of whatever happens to be in that browser's localStorage.
+
+- **Global default** = engine preference `locale` (BCP-47 base tag `en`/`es`/`pt`), the value the first-run picker writes. Also the fallback for any workspace without an override.
+- **Per-workspace override** = `locale` field on the workspace record in `workspaces.json`, set via `PATCH /v1/workspaces/:id/locale`. A workspace that never picked a language has no key (inherits the global default); clearing with `null`/empty reverts to it.
+- **Boot-apply (the part that was missing):** [`useLocalePreference`](../app/src/hooks/use-locale-preference.ts), consumed by [LanguageGate](../app/src/components/shell/language-gate.tsx), resolves the effective locale and calls `applyEngineLocale` so the engine value is actually *applied* to the live i18n instance — not just read. Re-applies when the active workspace changes. The gate holds its blank screen until the first apply lands (no flash of the wrong language).
+- **First-run picker** ([LanguageGate](../app/src/components/shell/language-gate.tsx)) writes the **global default** (no workspace exists yet) before the disclaimer.
+- **Settings → Workspace language picker** ([language.tsx](../app/src/components/settings/sections/language.tsx)) writes the **active workspace's** override (it lives under the Workspace settings tab).
+- localStorage cache `houston.locale.cache` is **boot-time flash-avoidance only**, never the source of truth.
+- Pure value-logic (`isSupported`, `normalizeLocale`, `resolveEffectiveLocale`, `localeToApply`) lives in [`app/src/lib/locale.ts`](../app/src/lib/locale.ts) — DOM/JSON-free so it unit-tests under bare Node (`app/tests/locale.test.ts`); `i18n.ts` re-exports it.
+- Engine itself is locale-agnostic — surfaces both values verbatim.
 
 ## What does NOT translate
 - Brand names: Houston, Claude, OpenAI, Anthropic, GitHub, Google, Gemini

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -190,6 +190,14 @@ export class HoustonClient {
   deleteWorkspace(id: string): Promise<void> {
     return this.request("DELETE", `/workspaces/${this.seg(id)}`);
   }
+  /**
+   * Set (or clear) a workspace's UI-locale override. Pass `null` to clear it
+   * so the workspace falls back to the global `locale` preference. Persisted on
+   * the workspace record, so every client of this engine shares the value.
+   */
+  setWorkspaceLocale(id: string, locale: string | null): Promise<Workspace> {
+    return this.request("PATCH", `/workspaces/${this.seg(id)}/locale`, { locale });
+  }
   setWorkspaceProvider(id: string, req: UpdateProvider): Promise<Workspace> {
     return this.request("PATCH", `/workspaces/${this.seg(id)}/provider`, req);
   }

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -65,6 +65,11 @@ export interface Workspace {
   name: string;
   isDefault: boolean;
   createdAt: string;
+  /**
+   * Optional per-workspace UI-locale override (BCP-47 base tag: `en`/`es`/`pt`).
+   * Absent/null means the workspace inherits the global `locale` preference.
+   */
+  locale?: string | null;
   provider?: string;
   model?: string;
 }


### PR DESCRIPTION
Closes #293.

## The bug
The UI language was effectively driven by **browser localStorage**. `applyEngineLocale()` existed but was **never called**, so at boot i18next only resolved `localStorage(houston.locale.cache) → navigator → en`. On the same browser it looked fine (the cache happened to match), but a **fresh browser pointed at a headless engine** (e.g. the webapp against a container) ignored the engine's stored locale entirely. The language lived in the browser, not the engine.

## The fix
The engine is now the source of truth, with a **per-workspace override** (as discussed: workspaces should carry their own config):

> **effective locale = active-workspace `locale` override → global `locale` preference → navigator → `en`**

localStorage is demoted to a pure boot-time flash cache. The first-run picker still writes the global default (no workspace exists yet); the Settings → Workspace language picker writes the **active workspace's** override.

### Changes
- **engine** (`houston-engine-core`, `houston-engine-server`)
  - `Workspace.locale: Option<String>` on the `workspaces.json` record — additive with `#[serde(default)]` + `skip_serializing_if`, so existing files parse unchanged and **no migration** is needed.
  - `workspaces::set_locale()` + `PATCH /v1/workspaces/:id/locale` with `{ locale: string | null }` (null/empty clears the override → inherit the global default).
- **engine-client** — `Workspace.locale?`, `setWorkspaceLocale(id, locale)`.
- **app**
  - `use-locale-preference` now **resolves and applies** the effective locale at boot. It resolves the active workspace's override via an independent boot query (the gate sits above `<App/>`, which is what loads workspaces), so the override lands on the **first paint** with no flash; it always un-gates even if applying fails (no blank-screen hang) and logs rather than swallows.
  - Settings language picker writes the active workspace's override.
  - Pure, DOM/JSON-free locale logic extracted to `app/src/lib/locale.ts` so it unit-tests under the bare Node runner.

### Other config worth storing there?
Audited: **theme** is already engine-backed and applied on boot correctly (it was the reference pattern); timezone, legal acceptance, and default provider/model already live engine-side too. The only remaining `localStorage` use is Supabase auth PKCE, which must stay client-side. So **locale was the only setting still effectively stuck in the browser** — nothing else needed moving. The new `Workspace.locale` field is the foundation for further per-workspace config.

## Tests
- Rust: unit tests for `set_locale` (set / clear-on-blank / clear-on-null / unknown-id / survives-rename / pre-`locale` JSON parses + omits when unset) and an HTTP round-trip test for the new route.
- App: unit tests for the pure resolvers (`normalizeLocale`, `resolveEffectiveLocale`, `localeToApply`, `activeWorkspaceLocale`).
- `pnpm -r typecheck`, `pnpm check-locales`, and `pnpm test` (121 pass) all green. (Rust is verified by review + the new tests; this environment has no local cargo toolchain.)

## Reviewed
Ran a multi-agent adversarial review (incl. redundant Rust compile-correctness checkers and a frontend boot-flow pass). Findings fixed: the boot-apply could hang the app on a `changeLanguage` rejection (now always un-gates + logs), and the per-workspace override lost the first-paint race (now resolved via the independent boot query). Verdict: GO.

## Follow-up (deliberately out of scope)
The `PATCH .../locale` endpoint + client/store already support clearing an override (`null` → inherit global), but the Settings picker doesn't yet expose an explicit "Use global default" option — overrides are currently one-way from the UI. Small enhancement for a later PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
