### PR TITLE
fix(engine): pass the workspace test suite on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2700,6 +2700,7 @@ dependencies = [
 name = "houston-tauri"
 version = "0.4.15"
 dependencies = [
+ "dirs 5.0.1",
  "houston-agent-files",
  "houston-agents-conversations",
  "houston-db",

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -19,3 +19,4 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tauri = { version = "2", features = ["tray-icon"] }
 tracing = { workspace = true }
+dirs = "5"

--- a/app/houston-tauri/src/paths.rs
+++ b/app/houston-tauri/src/paths.rs
@@ -4,16 +4,17 @@ use std::path::{Path, PathBuf};
 ///
 /// Shell tilde expansion doesn't happen in Rust's `PathBuf`.
 /// Use this when accepting user-facing paths like `~/Documents/MyApp`.
+///
+/// Cross-platform: uses `dirs::home_dir()` rather than `$HOME` so Windows
+/// (which sets `%USERPROFILE%`, not `HOME`) resolves correctly. Mirrors
+/// `houston_engine_core::paths::expand_tilde`.
 pub fn expand_tilde(path: &Path) -> PathBuf {
     if path.starts_with("~") {
-        if let Ok(home) = std::env::var("HOME") {
-            PathBuf::from(home).join(path.strip_prefix("~").unwrap_or(path))
-        } else {
-            path.to_path_buf()
+        if let Some(home) = dirs::home_dir() {
+            return home.join(path.strip_prefix("~").unwrap_or(path));
         }
-    } else {
-        path.to_path_buf()
     }
+    path.to_path_buf()
 }
 
 #[cfg(test)]
@@ -24,7 +25,9 @@ mod tests {
     fn expands_tilde() {
         let result = expand_tilde(Path::new("~/Documents/Test"));
         assert!(!result.starts_with("~"));
-        assert!(result.to_string_lossy().ends_with("Documents/Test"));
+        // `Path::ends_with` matches components, so it is separator-agnostic
+        // (the joined path uses `\` on Windows, `/` elsewhere).
+        assert!(result.ends_with("Documents/Test"));
     }
 
     #[test]

--- a/engine/houston-composio/src/install.rs
+++ b/engine/houston-composio/src/install.rs
@@ -207,12 +207,20 @@ pub async fn install() -> Result<PathBuf, String> {
     Ok(resolved)
 }
 
-/// Cross-platform home directory. macOS/Linux set `HOME`; Windows sets
-/// `USERPROFILE`. The `dirs` crate papers over both. Public so the
-/// rest of `houston-composio` doesn't read `$HOME` directly — that env
-/// var is unset on Windows and produces "HOME not set" failures when
-/// reading `~/.composio/user_data.json` (see apps.rs).
+/// Cross-platform home directory, used to locate `~/.composio`. Public so the
+/// rest of `houston-composio` never reads `$HOME` directly (that var is unset
+/// on Windows and produces "HOME not set" failures, e.g. in apps.rs).
+///
+/// On Windows we check `USERPROFILE` first: `dirs 5` resolves the home there
+/// via the known-folder API and ignores the env var, so honoring it explicitly
+/// gives callers and tests a seam to redirect resolution. It equals the
+/// known-folder profile in normal use, so production behavior is unchanged.
+/// Unix `dirs::home_dir()` already honors `$HOME`.
 pub fn home_dir() -> PathBuf {
+    #[cfg(windows)]
+    if let Some(p) = std::env::var_os("USERPROFILE").filter(|v| !v.is_empty()) {
+        return PathBuf::from(p);
+    }
     dirs::home_dir().unwrap_or_default()
 }
 

--- a/engine/houston-engine-core/src/attachments/tests.rs
+++ b/engine/houston-engine-core/src/attachments/tests.rs
@@ -80,8 +80,20 @@ fn commit_upload_writes_manifest_and_prompt_path() {
         "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824".into(),
     )
     .unwrap();
-    assert!(out.path.contains("activity-1/files/"));
-    assert!(!out.path.contains("/../"));
+    // `path` is a real filesystem path, so its separator is platform-specific
+    // (`\` on Windows). Assert structure with `MAIN_SEPARATOR`, not a literal
+    // `/`, or the check spuriously fails on Windows.
+    let sep = std::path::MAIN_SEPARATOR;
+    assert!(
+        out.path.contains(&format!("activity-1{sep}files{sep}")),
+        "committed file must live under the scope's files dir: {}",
+        out.path
+    );
+    assert!(
+        !out.path.contains(&format!("{sep}..{sep}")),
+        "committed path must not contain a parent-traversal segment: {}",
+        out.path
+    );
     assert_eq!(std::fs::read(&out.path).unwrap(), b"hello");
     let manifests = list(home.path(), "activity-1").unwrap();
     assert_eq!(manifests.len(), 1);

--- a/engine/houston-engine-core/src/provider/login_relay.rs
+++ b/engine/houston-engine-core/src/provider/login_relay.rs
@@ -502,6 +502,47 @@ mod tests {
     use super::*;
     use crate::provider::parse;
 
+    /// A child that blocks without writing stdout, standing in for a provider
+    /// CLI waiting on the user. Cross-platform: `cat` (Unix) and `findstr`
+    /// (Windows, always in System32) both block reading the piped stdin we hold
+    /// open; neither writes stdout while no input arrives (these tests never
+    /// write the child's stdin). Replaces a Unix-only `sleep 60`, which fails
+    /// with "program not found" on Windows.
+    fn idle_child_command() -> tokio::process::Command {
+        #[cfg(windows)]
+        {
+            let mut c = tokio::process::Command::new("findstr");
+            c.arg("HoustonIdleNoMatch");
+            c
+        }
+        #[cfg(not(windows))]
+        {
+            tokio::process::Command::new("cat")
+        }
+    }
+
+    /// A child that emits the bytes of `file_name` (resolved in `dir`) verbatim
+    /// then exits: `cat` (Unix) / `cmd /C type` (Windows). Routing the canned
+    /// output through a file preserves the SGR/ESC bytes and newlines a portable
+    /// `echo` cannot emit, and a bare filename with `cwd = dir` sidesteps path
+    /// quoting. Replaces a Unix-only `printf`.
+    fn emit_file_command(dir: &std::path::Path, file_name: &str) -> tokio::process::Command {
+        #[cfg(windows)]
+        let mut cmd = {
+            let mut c = tokio::process::Command::new("cmd");
+            c.args(["/C", "type", file_name]);
+            c
+        };
+        #[cfg(not(windows))]
+        let mut cmd = {
+            let mut c = tokio::process::Command::new("cat");
+            c.arg(file_name);
+            c
+        };
+        cmd.current_dir(dir);
+        cmd
+    }
+
     #[test]
     fn extract_url_from_claude_oauth_line() {
         let line = "If the browser didn't open, visit: \
@@ -634,17 +675,16 @@ mod tests {
 
     #[tokio::test]
     async fn insert_session_rejects_duplicate() {
-        // Spawn a long-running subprocess to grab a real ChildStdin —
-        // `sleep` blocks until killed, so its stdin handle stays alive
-        // long enough for both insert attempts.
+        // Spawn a long-running subprocess to grab a real ChildStdin. The idle
+        // child blocks until killed, so its stdin handle stays alive long
+        // enough for both insert attempts.
         async fn make_stdin() -> ChildStdin {
-            let mut cmd = tokio::process::Command::new("sleep");
-            cmd.arg("60")
-                .stdin(std::process::Stdio::piped())
+            let mut cmd = idle_child_command();
+            cmd.stdin(std::process::Stdio::piped())
                 .stdout(std::process::Stdio::null())
                 .stderr(std::process::Stdio::null())
                 .kill_on_drop(true);
-            let mut child = cmd.spawn().expect("spawn sleep");
+            let mut child = cmd.spawn().expect("spawn idle child");
             child.stdin.take().expect("stdin piped")
         }
         // Use a unique provider id so this test doesn't collide with
@@ -665,17 +705,16 @@ mod tests {
         LOGIN_SESSIONS.lock().await.remove(provider_id);
     }
 
-    /// Spawn a long-lived child with piped stdio so the relay has a
-    /// real subprocess to kill. `sleep 60` never writes stdout, so the
-    /// relay only ever emits on cancel/exit — no spurious URL event.
+    /// Spawn a long-lived child with piped stdio so the relay has a real
+    /// subprocess to kill. The idle child never writes stdout, so the relay
+    /// only ever emits on cancel/exit, with no spurious URL event.
     async fn spawn_idle_child() -> Child {
-        let mut cmd = tokio::process::Command::new("sleep");
-        cmd.arg("60")
-            .stdin(std::process::Stdio::piped())
+        let mut cmd = idle_child_command();
+        cmd.stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true);
-        cmd.spawn().expect("spawn sleep")
+        cmd.spawn().expect("spawn idle child")
     }
 
     #[tokio::test]
@@ -754,29 +793,37 @@ mod tests {
     async fn device_auth_relay_emits_url_then_code() {
         use houston_ui_events::BroadcastEventSink;
 
-        // Stand-in for `codex login --device-auth`: `printf` emits the
-        // verbatim multi-line output (prose, the verification URL, then the
-        // one-time code on its own line) and exits. The relay should surface
-        // the URL the moment it streams, then re-emit with the code.
+        // Stand-in for `codex login --device-auth`: emit the verbatim
+        // multi-line output (prose, the verification URL, then the one-time
+        // code on its own line) and exit. The relay should surface the URL the
+        // moment it streams, then re-emit with the code.
         //
         // The URL and code lines carry the SGR colour wrappers codex prints
-        // even over a pipe (`\x1b[94m…\x1b[0m`) — the exact byte shape
-        // captured from codex 0.133. This is the regression case: the
-        // opening `\x1b[94m` ends in `m`, flush against the code, so the
-        // relay MUST strip ANSI before matching or the second emit (the
-        // code) never fires and the dialog falls back to paste-back.
-        let mut cmd = tokio::process::Command::new("printf");
-        cmd.arg("%s\\n")
-            .arg("Follow these steps to sign in with ChatGPT using device code authorization:")
-            .arg("1. Open this link in your browser and sign in to your account")
-            .arg("   \u{1b}[94mhttps://auth.openai.com/codex/device\u{1b}[0m")
-            .arg("2. Enter this one-time code \u{1b}[90m(expires in 15 minutes)\u{1b}[0m")
-            .arg("   \u{1b}[94mABCD-EFGHI\u{1b}[0m")
-            .stdin(std::process::Stdio::piped())
+        // even over a pipe (`\x1b[94m...\x1b[0m`), the exact byte shape captured
+        // from codex 0.133. This is the regression case: the opening `\x1b[94m`
+        // ends in `m`, flush against the code, so the relay MUST strip ANSI
+        // before matching or the second emit (the code) never fires and the
+        // dialog falls back to paste-back. Route the bytes through a file read
+        // by `cat`/`type` (not Unix-only `printf`) so ESC survives everywhere.
+        let dir = tempfile::TempDir::new().unwrap();
+        let canned = format!(
+            "{}\n",
+            [
+                "Follow these steps to sign in with ChatGPT using device code authorization:",
+                "1. Open this link in your browser and sign in to your account",
+                "   \u{1b}[94mhttps://auth.openai.com/codex/device\u{1b}[0m",
+                "2. Enter this one-time code \u{1b}[90m(expires in 15 minutes)\u{1b}[0m",
+                "   \u{1b}[94mABCD-EFGHI\u{1b}[0m",
+            ]
+            .join("\n")
+        );
+        std::fs::write(dir.path().join("device.txt"), canned).unwrap();
+        let mut cmd = emit_file_command(dir.path(), "device.txt");
+        cmd.stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true);
-        let mut child = cmd.spawn().expect("spawn printf");
+        let mut child = cmd.spawn().expect("spawn device-auth stand-in");
         let stdin = child.stdin.take().expect("stdin piped");
         let stdout = child.stdout.take().expect("stdout piped");
         let stderr = child.stderr.take();

--- a/engine/houston-engine-core/src/skills.rs
+++ b/engine/houston-engine-core/src/skills.rs
@@ -197,29 +197,88 @@ fn skills_dir(workspace_path: &str) -> PathBuf {
     expand_tilde(&PathBuf::from(workspace_path)).join(".agents/skills")
 }
 
-/// Create `.claude/skills/{name}` → `../../.agents/skills/{name}` symlink
-/// so Claude Code discovers skills natively. Idempotent.
+/// Create `.claude/skills/{name}` so Claude Code discovers the skill natively.
+///
+/// On Unix this is a relative symlink to `../../.agents/skills/{name}`. On
+/// Windows, symlink creation needs Developer Mode or admin (os error 1314), so
+/// we try a directory symlink and, failing that, copy the skill directory —
+/// the same "symlink, else copy" fallback the engine uses for agent role
+/// files. The copy is kept current by [`refresh_claude_mirror`] on edit.
+/// Idempotent: skips when the node already exists.
 fn ensure_claude_symlink(workspace_path: &str, skill_name: &str) {
     let root = expand_tilde(&PathBuf::from(workspace_path));
     let claude_skills = root.join(".claude/skills");
-    let _ = std::fs::create_dir_all(&claude_skills);
+    if let Err(e) = std::fs::create_dir_all(&claude_skills) {
+        tracing::warn!("[skills] could not create .claude/skills dir: {e}");
+        return;
+    }
     let link = claude_skills.join(skill_name);
-    if !link.exists() {
+    if link.exists() {
+        return;
+    }
+    #[cfg(unix)]
+    {
         let target = Path::new("../../.agents/skills").join(skill_name);
-        #[cfg(unix)]
-        let _ = std::os::unix::fs::symlink(&target, &link);
-        #[cfg(not(unix))]
-        let _ = target;
+        if let Err(e) = std::os::unix::fs::symlink(&target, &link) {
+            tracing::warn!("[skills] could not symlink {skill_name} into .claude: {e}");
+        }
+    }
+    #[cfg(windows)]
+    {
+        let target = Path::new("..\\..\\.agents\\skills").join(skill_name);
+        if std::os::windows::fs::symlink_dir(&target, &link).is_err() {
+            // No symlink privilege: copy so Claude Code still finds the skill.
+            let source = skills_dir(workspace_path).join(skill_name);
+            if let Err(e) = crate::store::copy_dir_all(&source, &link) {
+                tracing::warn!("[skills] could not mirror {skill_name} into .claude: {e}");
+            }
+        }
     }
 }
 
+/// Remove the `.claude/skills/{name}` discovery node, whether it is a symlink
+/// (Unix, or Windows with Developer Mode) or a copied directory (the Windows
+/// fallback). Routes by node type because a Windows directory symlink must be
+/// removed with `remove_dir`, not `remove_file`.
 fn remove_claude_symlink(workspace_path: &str, skill_name: &str) {
     let root = expand_tilde(&PathBuf::from(workspace_path));
     let link = root.join(".claude/skills").join(skill_name);
-    if link.symlink_metadata().is_ok() {
-        let _ = std::fs::remove_file(&link);
+    let Ok(meta) = link.symlink_metadata() else {
+        return;
+    };
+    let ft = meta.file_type();
+    let res = if ft.is_symlink() {
+        remove_symlink_node(&link)
+    } else if ft.is_dir() {
+        std::fs::remove_dir_all(&link)
+    } else {
+        std::fs::remove_file(&link)
+    };
+    if let Err(e) = res {
+        tracing::warn!("[skills] could not remove {skill_name} from .claude: {e}");
     }
 }
+
+/// Remove a symlink node. Windows directory symlinks need `remove_dir`;
+/// everywhere else `remove_file` handles both file and directory symlinks.
+fn remove_symlink_node(link: &Path) -> std::io::Result<()> {
+    #[cfg(windows)]
+    let r = std::fs::remove_dir(link);
+    #[cfg(not(windows))]
+    let r = std::fs::remove_file(link);
+    r
+}
+
+/// Keep the Claude Code discovery mirror current after a skill's content
+/// changes. On Unix the mirror is a live symlink, so there is nothing to do; on
+/// Windows it may be a copy, so rebuild it.
+#[cfg(windows)]
+fn refresh_claude_mirror(workspace_path: &str, skill_name: &str) {
+    remove_claude_symlink(workspace_path, skill_name);
+    ensure_claude_symlink(workspace_path, skill_name);
+}
+#[cfg(not(windows))]
+fn refresh_claude_mirror(_workspace_path: &str, _skill_name: &str) {}
 
 fn emit_skills_changed(events: &DynEventSink, workspace_path: &str) {
     events.emit(HoustonEvent::SkillsChanged {
@@ -309,6 +368,7 @@ pub fn delete(events: &DynEventSink, workspace_path: &str, name: &str) -> CoreRe
 pub fn save(events: &DynEventSink, name: &str, req: SaveSkillRequest) -> CoreResult<()> {
     let dir = skills_dir(&req.workspace_path);
     houston_skills::edit_skill(&dir, name, &req.content)?;
+    refresh_claude_mirror(&req.workspace_path, name);
     emit_skills_changed(events, &req.workspace_path);
     Ok(())
 }

--- a/engine/houston-engine-core/src/worktree.rs
+++ b/engine/houston-engine-core/src/worktree.rs
@@ -197,8 +197,22 @@ pub async fn run_shell(req: RunShellRequest) -> CoreResult<String> {
         )));
     }
 
-    let output = Command::new("sh")
-        .args(["-c", &req.command])
+    // Run through the platform shell so pipes, globs, and builtins work. There
+    // is no `sh` on Windows, so use `cmd /C`; everywhere else use `sh -c`.
+    #[cfg(windows)]
+    let mut command = {
+        let mut c = Command::new("cmd");
+        c.args(["/C", &req.command]);
+        c
+    };
+    #[cfg(not(windows))]
+    let mut command = {
+        let mut c = Command::new("sh");
+        c.args(["-c", &req.command]);
+        c
+    };
+
+    let output = command
         .current_dir(&dir)
         .env(
             "PATH",

--- a/engine/houston-engine-server/tests/composio.rs
+++ b/engine/houston-engine-server/tests/composio.rs
@@ -16,8 +16,12 @@ async fn spawn() -> (SocketAddr, String, tempfile::TempDir, tempfile::TempDir) {
     let token = "ctest".to_string();
     let docs = tempfile::TempDir::new().unwrap();
     let home = tempfile::TempDir::new().unwrap();
-    // Point composio resolution at the empty tempdir so `is_installed()` is false.
+    // Point composio resolution at the empty tempdir so `is_installed()` is
+    // false. Set both home vars: `dirs` reads `HOME` on Unix and `USERPROFILE`
+    // on Windows (via `houston_composio::install::home_dir`), so sandboxing
+    // only `HOME` would leak the real profile on Windows.
     std::env::set_var("HOME", home.path());
+    std::env::set_var("USERPROFILE", home.path());
     let cfg = ServerConfig {
         bind: "127.0.0.1:0".parse().unwrap(),
         token: token.clone(),

--- a/knowledge-base/platform-matrix.md
+++ b/knowledge-base/platform-matrix.md
@@ -20,8 +20,13 @@ both.
 
 ## Cross-platform primitives — in use
 
-- **Home dir**: `dirs::home_dir()` (HOME on Unix, USERPROFILE on
-  Windows). `std::env::var("HOME")` is banned in engine code.
+- **Home dir**: `dirs::home_dir()` (HOME on Unix; on Windows `dirs 5`
+  resolves via the known-folder API and ignores `USERPROFILE`).
+  `std::env::var("HOME")` is banned in engine code.
+  `houston-composio::install::home_dir` checks `USERPROFILE` first on
+  Windows so callers and tests can redirect `~/.composio` resolution
+  (it equals the known-folder profile in normal use, so production
+  behavior is unchanged).
 - **PATH manipulation**: `std::env::split_paths` / `std::env::join_paths`
   — never hand-roll the separator.
 - **Symlinks**: `std::os::unix::fs::symlink` on Unix,
@@ -30,10 +35,12 @@ both.
   `skills.rs`. Windows symlink creation needs Developer Mode or
   admin; stock installs fail with os error 1314 ("A required
   privilege is not held by the client"). Call sites that expose
-  agent-role content to a sibling CLI (AGENTS.md/GEMINI.md in
-  `agents/prompt.rs` and `houston-agent-files::migrate_agent_data`)
-  fall back to `fs::copy` so non-admin Windows users still see the
-  role file. The gemini runtime-home staging
+  content to a sibling CLI fall back to `fs::copy` so non-admin
+  Windows users still get it: AGENTS.md/GEMINI.md in
+  `agents/prompt.rs` and `houston-agent-files::migrate_agent_data`,
+  and the `.claude/skills/<name>` discovery mirror in `skills.rs`
+  (copies the whole skill dir when `symlink_dir` is denied, and
+  re-copies on `save` so edits don't go stale). The gemini runtime-home staging
   (`houston-terminal-manager::gemini_home::ensure_symlink`) also
   tolerates a missing source on the copy fallback so first-time
   gemini users without `~/.gemini/.env` or OAuth files do not hit
@@ -63,6 +70,7 @@ both.
 | Area | File | Unix | Windows |
 |------|------|------|---------|
 | Session cancel | `engine-core/src/sessions/mod.rs::cancel` | `kill -TERM <pid>` | `taskkill /PID <pid> /T /F` |
+| Worktree shell (`run_shell`) | `engine-core/src/worktree.rs::run_shell` | `sh -c <command>` | `cmd /C <command>` (no `sh` on Windows) |
 | `engine.json` perms | `engine-server/src/main.rs::write_manifest` | `chmod 0o600` | inherits NTFS ACL from parent (sufficient; user dir is per-user) |
 | Composio installer | `houston-composio/src/install.rs::install` | `bash -c "curl \| bash"` | returns a clear error — auto-install not wired (see **gaps** below) |
 | Composio executable check | `houston-composio/src/install.rs::is_installed` | file + `+x` bit | file existence only (NTFS has no POSIX +x; Composio installer drops `composio.exe`) |


### PR DESCRIPTION
## What

Issue #375 ("workspace tests failing on windows") refers to the cargo **workspace** test suite, not the `workspaces` module (which was already green). This makes the engine test suite pass on Windows and also fixes the one app-crate (`houston-tauri`) failure that a literal `cargo test --workspace` surfaces.

Causes were a mix of genuine Windows production bugs and Unix-only test scaffolding.

## Production fixes

- **`worktree::run_shell`** spawned `sh -c`, which does not exist on Windows, so `/v1/shell` was unusable there. Now uses `cmd /C` on Windows, `sh -c` elsewhere.
- **Skills discovery mirror** (`.claude/skills/<name>`) was a **no-op on Windows** (it only ever created a Unix symlink), so an agent skills were invisible to the Claude Code CLI on Windows. Now tries a directory symlink and falls back to copying the skill dir (the same "symlink, else copy" pattern the engine already uses for agent role files), refreshing the copy on `save` so edits do not go stale. Removal handles both a copied directory and a Windows directory symlink (`remove_dir`, not `remove_file`).
- **`composio::install::home_dir`** now honors `USERPROFILE` on Windows. `dirs 5` resolves the Windows home via the known-folder API and ignores the env var, so the composio test could not sandbox `~/.composio` and reported the real, installed CLI. `USERPROFILE` equals the known-folder profile in normal use, so production behavior is unchanged.
- **`houston-tauri::paths::expand_tilde`** read `$HOME`, which is unset on Windows, so `~/...` paths passed to the `os` and `terminal` Tauri commands never expanded. Now uses `dirs::home_dir()`, mirroring the engine already-correct `expand_tilde`.

## Test-only fixes

- **attachments** test asserted a `/`-separated path; now uses `MAIN_SEPARATOR` (the committed `path` is a real filesystem path, backslash-separated on Windows).
- **login_relay** tests spawned `sleep`/`printf` (Unix-only) as stand-in subprocesses; now use `cat`/`findstr` (idle child that blocks silently) and `cat`/`type` over a temp file (canned device-auth output) so the SGR/ESC bytes survive on every platform.
- **composio** test also sets `USERPROFILE` for a hermetic "not installed" check.
- **houston-tauri** tilde test now asserts with component-based `Path::ends_with` instead of a separator-sensitive `to_string_lossy().ends_with(...)`.

## Affected files

- `engine/houston-engine-core/src/worktree.rs` - cross-platform `run_shell`
- `engine/houston-engine-core/src/skills.rs` - Windows symlink-or-copy mirror + dir-aware removal + save refresh
- `engine/houston-engine-core/src/attachments/tests.rs` - `MAIN_SEPARATOR` assertion
- `engine/houston-engine-core/src/provider/login_relay.rs` - cross-platform stand-in subprocesses
- `engine/houston-composio/src/install.rs` - `home_dir` honors `USERPROFILE` on Windows
- `engine/houston-engine-server/tests/composio.rs` - set `USERPROFILE` for hermetic check
- `app/houston-tauri/src/paths.rs` + `app/houston-tauri/Cargo.toml` (+ `Cargo.lock`) - `expand_tilde` via `dirs::home_dir()`
- `knowledge-base/platform-matrix.md` - document the above

## Verification (Windows, `x86_64-pc-windows-msvc`)

Engine suite (the documented command):

```
cargo test --workspace --exclude houston-app --exclude houston-tauri
```

**808 passed, 0 failed.**

App adapter crate:

```
cargo test -p houston-tauri --lib
```

**3 passed, 0 failed** (was 1 passed / 2 failed).

`houston-app` (the full Tauri binary crate, which needs a built frontend + WebView2) is intentionally **not** included; it is a separate, heavier scope. Note: no CI workflow runs `cargo test` in any form, so the Rust suite is verified manually.

## Note: pre-existing flake (not addressed here)

`houston-engine-server --test tunnel` intermittently crashes its test process at teardown with `STATUS_ACCESS_VIOLATION (0xc0000005)` on Windows, a native-teardown flake unrelated to these changes (it passes on every re-run, and this branch does not touch the tunnel/networking code).

Closes #375

🤖 Generated with [Claude Code](https://claude.com/claude-code)