### PR TITLE
feat(chat): auto-compact context when the window fills up (#313)

### DIFF
--- a/app/src/components/context-compacted-divider.tsx
+++ b/app/src/components/context-compacted-divider.tsx
@@ -1,0 +1,21 @@
+import { useTranslation } from "react-i18next";
+
+/**
+ * Subtle divider shown where a conversation's context was compacted (the
+ * provider auto-compacted, or Houston proactively summarized + reseeded). The
+ * full chat above and below stays visible; this just marks the boundary.
+ * Rendered by the app's `renderSystemMessage` for `msg.compaction` items so
+ * the label is localized (the `ui/chat` library keeps an English default).
+ */
+export function ContextCompactedDivider() {
+  const { t } = useTranslation("chat");
+  return (
+    <div className="flex items-center gap-3 max-w-3xl mx-auto px-4 py-3 text-muted-foreground/70">
+      <div className="h-px flex-1 bg-border/60" />
+      <span className="text-xs italic whitespace-nowrap">
+        {t("contextCompacted")}
+      </span>
+      <div className="h-px flex-1 bg-border/60" />
+    </div>
+  );
+}

--- a/app/src/components/context-indicator.tsx
+++ b/app/src/components/context-indicator.tsx
@@ -26,6 +26,7 @@ import {
   Progress,
 } from "@houston-ai/core";
 import type { TokenUsage } from "@houston-ai/chat";
+import { contextFillPercent } from "../lib/context-usage";
 
 interface ContextIndicatorProps {
   /** Latest turn's usage, or null when no turn has reported it yet. */
@@ -53,13 +54,7 @@ export function ContextIndicator({
     typeof contextWindow === "number" && contextWindow > 0
       ? contextWindow
       : null;
-  const percent =
-    usage && windowTokens != null
-      ? Math.min(
-          100,
-          Math.max(0, Math.round((usage.context_tokens / windowTokens) * 100)),
-        )
-      : null;
+  const percent = contextFillPercent(usage, windowTokens);
   const warn = percent != null && percent >= WARN_PERCENT;
 
   const fmt = (n: number) => n.toLocaleString(i18n.language);

--- a/app/src/components/settings/sections/autocompact.tsx
+++ b/app/src/components/settings/sections/autocompact.tsx
@@ -1,21 +1,16 @@
 import { useTranslation } from "react-i18next";
-import {
-  useAutocompactSettings,
-  MIN_AUTOCOMPACT_THRESHOLD,
-  MAX_AUTOCOMPACT_THRESHOLD,
-} from "../../../stores/autocompact-settings";
+import { useAutocompactSettings } from "../../../stores/autocompact-settings";
 
 /**
  * Autocompact settings. When on, Houston summarizes a conversation and
- * continues on a fresh session once its context reaches the chosen fullness,
- * so long chats keep working. The user still sees the full history.
+ * continues on a fresh session once its context gets full, so long chats keep
+ * working. The user still sees the full history. The fullness threshold is a
+ * build-time constant (`VITE_AUTOCOMPACT_THRESHOLD`), not exposed here.
  */
 export function AutocompactSection() {
   const { t } = useTranslation("settings");
   const enabled = useAutocompactSettings((s) => s.enabled);
-  const threshold = useAutocompactSettings((s) => s.threshold);
   const setEnabled = useAutocompactSettings((s) => s.setEnabled);
-  const setThreshold = useAutocompactSettings((s) => s.setThreshold);
 
   const pill = (selected: boolean) =>
     `flex items-center gap-2 px-4 py-2.5 rounded-full text-sm transition-colors ${
@@ -42,23 +37,6 @@ export function AutocompactSection() {
           {t("autocompact.off")}
         </button>
       </div>
-      {enabled && (
-        <div className="mt-4 flex items-center gap-3 text-sm max-w-sm">
-          <span className="text-muted-foreground whitespace-nowrap">
-            {t("autocompact.thresholdLabel")}
-          </span>
-          <input
-            type="range"
-            min={MIN_AUTOCOMPACT_THRESHOLD}
-            max={MAX_AUTOCOMPACT_THRESHOLD}
-            value={threshold}
-            onChange={(e) => setThreshold(Number(e.target.value))}
-            className="flex-1 accent-primary"
-            aria-label={t("autocompact.thresholdLabel")}
-          />
-          <span className="tabular-nums w-10 text-right">{threshold}%</span>
-        </div>
-      )}
     </section>
   );
 }

--- a/app/src/components/settings/sections/autocompact.tsx
+++ b/app/src/components/settings/sections/autocompact.tsx
@@ -1,0 +1,64 @@
+import { useTranslation } from "react-i18next";
+import {
+  useAutocompactSettings,
+  MIN_AUTOCOMPACT_THRESHOLD,
+  MAX_AUTOCOMPACT_THRESHOLD,
+} from "../../../stores/autocompact-settings";
+
+/**
+ * Autocompact settings. When on, Houston summarizes a conversation and
+ * continues on a fresh session once its context reaches the chosen fullness,
+ * so long chats keep working. The user still sees the full history.
+ */
+export function AutocompactSection() {
+  const { t } = useTranslation("settings");
+  const enabled = useAutocompactSettings((s) => s.enabled);
+  const threshold = useAutocompactSettings((s) => s.threshold);
+  const setEnabled = useAutocompactSettings((s) => s.setEnabled);
+  const setThreshold = useAutocompactSettings((s) => s.setThreshold);
+
+  const pill = (selected: boolean) =>
+    `flex items-center gap-2 px-4 py-2.5 rounded-full text-sm transition-colors ${
+      selected
+        ? "bg-primary text-primary-foreground"
+        : "bg-secondary text-foreground hover:bg-accent"
+    }`;
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold mb-1">{t("autocompact.title")}</h2>
+      <p className="text-sm text-muted-foreground mb-4">
+        {t("autocompact.description")}
+      </p>
+      <div className="flex gap-2">
+        <button type="button" onClick={() => setEnabled(true)} className={pill(enabled)}>
+          {t("autocompact.on")}
+        </button>
+        <button
+          type="button"
+          onClick={() => setEnabled(false)}
+          className={pill(!enabled)}
+        >
+          {t("autocompact.off")}
+        </button>
+      </div>
+      {enabled && (
+        <div className="mt-4 flex items-center gap-3 text-sm max-w-sm">
+          <span className="text-muted-foreground whitespace-nowrap">
+            {t("autocompact.thresholdLabel")}
+          </span>
+          <input
+            type="range"
+            min={MIN_AUTOCOMPACT_THRESHOLD}
+            max={MAX_AUTOCOMPACT_THRESHOLD}
+            value={threshold}
+            onChange={(e) => setThreshold(Number(e.target.value))}
+            className="flex-1 accent-primary"
+            aria-label={t("autocompact.thresholdLabel")}
+          />
+          <span className="tabular-nums w-10 text-right">{threshold}%</span>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/src/components/settings/settings-view.tsx
+++ b/app/src/components/settings/settings-view.tsx
@@ -29,6 +29,7 @@ import { ProviderSection } from "./sections/provider";
 import { TimezoneSection } from "./sections/timezone";
 import { LanguageSection } from "./sections/language";
 import { AppearanceSection } from "./sections/appearance";
+import { AutocompactSection } from "./sections/autocompact";
 import { DangerSection } from "./sections/danger";
 import { ReportBugSection } from "./sections/report-bug";
 import { ShortcutsSection } from "./sections/shortcuts";
@@ -123,6 +124,7 @@ export function SettingsView() {
                 <LanguageSection />
                 <TimezoneSection />
                 <AppearanceSection />
+                <AutocompactSection />
                 <DangerSection />
               </div>
             )}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -67,6 +67,7 @@ import {
 } from "./composio-signin-card";
 import { ChatModelSelector } from "./chat-model-selector";
 import { ChatEffortSelector } from "./chat-effort-selector";
+import { ContextCompactedDivider } from "./context-compacted-divider";
 import {
   getContextWindowConfig,
   getDefaultModel,
@@ -514,6 +515,7 @@ export function useAgentChatPanel({
   );
   const renderSystemMessage = useCallback(
     (msg: ChatMessage) => {
+      if (msg.compaction) return <ContextCompactedDivider />;
       if (isToolRuntimeErrorMessage(msg)) {
         const isModelUnsupported =
           msg.runtimeError.kind === "provider_model_unsupported";

--- a/app/src/lib/autocompact.ts
+++ b/app/src/lib/autocompact.ts
@@ -5,9 +5,10 @@
  * board chat, mission control, skill sends, retries — gets autocompact for
  * free, rather than each call site re-deriving the flag and one being missed.
  *
- * Reads the live feed store + the user's autocompact settings synchronously
- * (both are Zustand stores). New conversations have no reported usage yet, so
- * this returns `false` and the engine runs a normal first turn.
+ * Reads the live feed store + the user's on/off setting synchronously (both
+ * Zustand stores); the threshold is a build-time constant. New conversations
+ * have no reported usage yet, so this returns `false` and the engine runs a
+ * normal first turn.
  */
 import { useFeedStore } from "../stores/feeds";
 import { useAutocompactSettings } from "../stores/autocompact-settings";
@@ -15,9 +16,20 @@ import { getContextWindowConfig } from "./providers";
 import {
   contextFillPercent,
   effectiveContextWindow,
+  resolveThreshold,
   sessionContextUsage,
   shouldAutocompact,
 } from "./context-usage";
+
+/**
+ * Percent-full at which a turn proactively compacts. A tuning constant, not a
+ * user setting: defaults to 93, optionally overridden at build time via
+ * `VITE_AUTOCOMPACT_THRESHOLD` (e.g. set it low to force compaction while
+ * testing). Resolved once at module load.
+ */
+const AUTOCOMPACT_THRESHOLD = resolveThreshold(
+  import.meta.env.VITE_AUTOCOMPACT_THRESHOLD,
+);
 
 export function shouldAutocompactForSession(
   agentPath: string,
@@ -25,7 +37,7 @@ export function shouldAutocompactForSession(
   provider: string | undefined,
   model: string | undefined,
 ): boolean {
-  const { enabled, threshold } = useAutocompactSettings.getState();
+  const enabled = useAutocompactSettings.getState().enabled;
   if (!enabled) return false;
 
   const items = useFeedStore.getState().items[agentPath]?.[sessionKey];
@@ -34,5 +46,9 @@ export function shouldAutocompactForSession(
   const window = effectiveContextWindow(cfg, peakContextTokens);
   const percent = contextFillPercent(latest, window);
 
-  return shouldAutocompact({ percent, enabled, threshold });
+  return shouldAutocompact({
+    percent,
+    enabled,
+    threshold: AUTOCOMPACT_THRESHOLD,
+  });
 }

--- a/app/src/lib/autocompact.ts
+++ b/app/src/lib/autocompact.ts
@@ -1,0 +1,38 @@
+/**
+ * Decide whether a given send should ask the engine to compact first.
+ *
+ * Centralized here (and called from `tauriChat.send`) so EVERY send path —
+ * board chat, mission control, skill sends, retries — gets autocompact for
+ * free, rather than each call site re-deriving the flag and one being missed.
+ *
+ * Reads the live feed store + the user's autocompact settings synchronously
+ * (both are Zustand stores). New conversations have no reported usage yet, so
+ * this returns `false` and the engine runs a normal first turn.
+ */
+import { useFeedStore } from "../stores/feeds";
+import { useAutocompactSettings } from "../stores/autocompact-settings";
+import { getContextWindowConfig } from "./providers";
+import {
+  contextFillPercent,
+  effectiveContextWindow,
+  sessionContextUsage,
+  shouldAutocompact,
+} from "./context-usage";
+
+export function shouldAutocompactForSession(
+  agentPath: string,
+  sessionKey: string,
+  provider: string | undefined,
+  model: string | undefined,
+): boolean {
+  const { enabled, threshold } = useAutocompactSettings.getState();
+  if (!enabled) return false;
+
+  const items = useFeedStore.getState().items[agentPath]?.[sessionKey];
+  const { latest, peakContextTokens } = sessionContextUsage(items);
+  const cfg = getContextWindowConfig(provider, model);
+  const window = effectiveContextWindow(cfg, peakContextTokens);
+  const percent = contextFillPercent(latest, window);
+
+  return shouldAutocompact({ percent, enabled, threshold });
+}

--- a/app/src/lib/context-usage.ts
+++ b/app/src/lib/context-usage.ts
@@ -88,3 +88,30 @@ export function shouldAutocompact(opts: {
   if (!opts.enabled || opts.percent == null) return false;
   return opts.percent >= opts.threshold;
 }
+
+/**
+ * Autocompact threshold (percent-full at which the next turn proactively
+ * compacts). Not a user setting — a tuning constant with an optional
+ * build-time override via `VITE_AUTOCOMPACT_THRESHOLD` (read in
+ * `lib/autocompact.ts`). Defaults to 93, just below the provider CLIs' own
+ * ~95% auto-compaction so Houston compacts cleanly at a turn boundary first.
+ */
+export const DEFAULT_AUTOCOMPACT_THRESHOLD = 93;
+export const MIN_AUTOCOMPACT_THRESHOLD = 1;
+export const MAX_AUTOCOMPACT_THRESHOLD = 99;
+
+/**
+ * Parse + clamp the `VITE_AUTOCOMPACT_THRESHOLD` build-time env value. Empty,
+ * missing, or non-numeric falls back to the default; valid values are rounded
+ * and clamped to [1, 99]. Pure (takes the raw string, not `import.meta.env`)
+ * so it's unit-testable without a Vite environment.
+ */
+export function resolveThreshold(raw: string | undefined): number {
+  if (raw == null || raw === "") return DEFAULT_AUTOCOMPACT_THRESHOLD;
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return DEFAULT_AUTOCOMPACT_THRESHOLD;
+  return Math.min(
+    MAX_AUTOCOMPACT_THRESHOLD,
+    Math.max(MIN_AUTOCOMPACT_THRESHOLD, Math.round(n)),
+  );
+}

--- a/app/src/lib/context-usage.ts
+++ b/app/src/lib/context-usage.ts
@@ -55,3 +55,36 @@ export function effectiveContextWindow(
   const estimate = peakContextTokens > cfg.default ? cfg.max : cfg.default;
   return Math.max(estimate, peakContextTokens);
 }
+
+/**
+ * How full the context window is, 0-100, or `null` when usage or the window
+ * isn't known. Rounded and clamped so the displayed gauge and the autocompact
+ * trigger agree on the same number. Shared by `ContextIndicator` (display) and
+ * `shouldAutocompactForSession` (the trigger decision).
+ */
+export function contextFillPercent(
+  usage: TokenUsage | null,
+  windowTokens: number | null | undefined,
+): number | null {
+  if (!usage || windowTokens == null || windowTokens <= 0) return null;
+  return Math.min(
+    100,
+    Math.max(0, Math.round((usage.context_tokens / windowTokens) * 100)),
+  );
+}
+
+/**
+ * Whether to proactively compact this turn: autocompact is enabled and the
+ * context is at/over the user's threshold. `percent` null (unknown usage or
+ * window) means we can't tell, so we don't compact. Self-limiting: after a
+ * compaction the next turn's fill is small, so this won't re-fire until the
+ * window fills again.
+ */
+export function shouldAutocompact(opts: {
+  percent: number | null;
+  enabled: boolean;
+  threshold: number;
+}): boolean {
+  if (!opts.enabled || opts.percent == null) return false;
+  return opts.percent >= opts.threshold;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -33,6 +33,7 @@ import { getEngine } from "./engine";
 import { osPickDirectory } from "./os-bridge";
 import { logger } from "./logger";
 import { normalizeLegacyModel } from "./providers";
+import { shouldAutocompactForSession } from "./autocompact";
 export { withAttachmentPaths } from "./attachment-message";
 
 interface EngineCallOptions {
@@ -181,6 +182,16 @@ export const tauriChat = {
     },
   ) =>
     call<string>("send_message", async () => {
+      // Centralized autocompact decision: when this session's context is
+      // nearly full, ask the engine to summarize + reseed before this turn.
+      // Computed here so every send path gets it; new conversations have no
+      // usage yet and resolve to `false`.
+      const compact = shouldAutocompactForSession(
+        agentPath,
+        sessionKey,
+        opts?.providerOverride,
+        opts?.modelOverride,
+      );
       const res = await getEngine().startSession(agentPath, {
         sessionKey,
         prompt,
@@ -189,6 +200,7 @@ export const tauriChat = {
         provider: opts?.providerOverride,
         model: opts?.modelOverride,
         effort: opts?.effortOverride,
+        compact,
       });
       return res.sessionKey;
     }),

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -94,5 +94,6 @@
     "learningsUpdated": "Learnings updated"
   },
   "filesUpdated_one": "1 file updated",
-  "filesUpdated_other": "{{count}} files updated"
+  "filesUpdated_other": "{{count}} files updated",
+  "contextCompacted": "Earlier conversation summarized so the chat can keep going"
 }

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -75,7 +75,7 @@
     "dark": "Dark"
   },
   "autocompact": {
-    "title": "Long conversations",
+    "title": "Summarize long conversations",
     "description": "When a chat gets very long, automatically summarize the earlier part so the assistant can keep going. You'll still see the full conversation.",
     "on": "On",
     "off": "Off"

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -78,8 +78,7 @@
     "title": "Long conversations",
     "description": "When a chat gets very long, automatically summarize the earlier part so the assistant can keep going. You'll still see the full conversation.",
     "on": "On",
-    "off": "Off",
-    "thresholdLabel": "Summarize at"
+    "off": "Off"
   },
   "dangerZone": {
     "title": "Danger zone",

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -74,6 +74,13 @@
     "light": "Light",
     "dark": "Dark"
   },
+  "autocompact": {
+    "title": "Long conversations",
+    "description": "When a chat gets very long, automatically summarize the earlier part so the assistant can keep going. You'll still see the full conversation.",
+    "on": "On",
+    "off": "Off",
+    "thresholdLabel": "Summarize at"
+  },
   "dangerZone": {
     "title": "Danger zone",
     "description": "Permanently delete this workspace and all its agents.",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -94,5 +94,6 @@
     "learningsUpdated": "Aprendizajes actualizados"
   },
   "filesUpdated_one": "1 archivo actualizado",
-  "filesUpdated_other": "{{count}} archivos actualizados"
+  "filesUpdated_other": "{{count}} archivos actualizados",
+  "contextCompacted": "Resumimos la conversación anterior para que el chat pueda continuar"
 }

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -78,8 +78,7 @@
     "title": "Conversaciones largas",
     "description": "Cuando un chat se hace muy largo, resume automáticamente la parte anterior para que el asistente pueda continuar. Seguirás viendo la conversación completa.",
     "on": "Activado",
-    "off": "Desactivado",
-    "thresholdLabel": "Resumir al"
+    "off": "Desactivado"
   },
   "dangerZone": {
     "title": "Zona de peligro",

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -75,7 +75,7 @@
     "dark": "Oscuro"
   },
   "autocompact": {
-    "title": "Conversaciones largas",
+    "title": "Resumir conversaciones largas",
     "description": "Cuando un chat se hace muy largo, resume automáticamente la parte anterior para que el asistente pueda continuar. Seguirás viendo la conversación completa.",
     "on": "Activado",
     "off": "Desactivado"

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -74,6 +74,13 @@
     "light": "Claro",
     "dark": "Oscuro"
   },
+  "autocompact": {
+    "title": "Conversaciones largas",
+    "description": "Cuando un chat se hace muy largo, resume automáticamente la parte anterior para que el asistente pueda continuar. Seguirás viendo la conversación completa.",
+    "on": "Activado",
+    "off": "Desactivado",
+    "thresholdLabel": "Resumir al"
+  },
   "dangerZone": {
     "title": "Zona de peligro",
     "description": "Elimina este espacio de trabajo y todos sus agentes de forma permanente.",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -94,5 +94,6 @@
     "learningsUpdated": "Aprendizados atualizados"
   },
   "filesUpdated_one": "1 arquivo atualizado",
-  "filesUpdated_other": "{{count}} arquivos atualizados"
+  "filesUpdated_other": "{{count}} arquivos atualizados",
+  "contextCompacted": "Resumimos a conversa anterior para o chat poder continuar"
 }

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -78,8 +78,7 @@
     "title": "Conversas longas",
     "description": "Quando uma conversa fica muito longa, resume automaticamente a parte anterior para o assistente poder continuar. Você ainda verá a conversa completa.",
     "on": "Ativado",
-    "off": "Desativado",
-    "thresholdLabel": "Resumir em"
+    "off": "Desativado"
   },
   "dangerZone": {
     "title": "Zona de perigo",

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -75,7 +75,7 @@
     "dark": "Escuro"
   },
   "autocompact": {
-    "title": "Conversas longas",
+    "title": "Resumir conversas longas",
     "description": "Quando uma conversa fica muito longa, resume automaticamente a parte anterior para o assistente poder continuar. Você ainda verá a conversa completa.",
     "on": "Ativado",
     "off": "Desativado"

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -74,6 +74,13 @@
     "light": "Claro",
     "dark": "Escuro"
   },
+  "autocompact": {
+    "title": "Conversas longas",
+    "description": "Quando uma conversa fica muito longa, resume automaticamente a parte anterior para o assistente poder continuar. Você ainda verá a conversa completa.",
+    "on": "Ativado",
+    "off": "Desativado",
+    "thresholdLabel": "Resumir em"
+  },
   "dangerZone": {
     "title": "Zona de perigo",
     "description": "Exclui este espaço de trabalho e todos os seus agentes de forma permanente.",

--- a/app/src/stores/autocompact-settings.ts
+++ b/app/src/stores/autocompact-settings.ts
@@ -2,41 +2,26 @@ import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
 /**
- * Autocompact settings — a client-side UI behavior preference, persisted to
+ * Autocompact on/off — a client-side UI behavior preference, persisted to
  * localStorage. Kept out of the engine `preferences` table on purpose: it
  * governs how the desktop client drives sessions, reads synchronously at send
  * time (see `lib/autocompact.ts`), and doesn't need cross-device sync.
  *
- * When enabled (default), once a conversation's context fill reaches
- * `threshold` percent the next turn runs on a freshly-compacted session. The
- * threshold sits just below the provider CLIs' own ~95% auto-compaction so
- * Houston compacts cleanly at a turn boundary first.
+ * When enabled (default), once a conversation's context fill reaches the
+ * threshold the next turn runs on a freshly-compacted session. The threshold
+ * is a build-time tuning constant (`VITE_AUTOCOMPACT_THRESHOLD`, default 93),
+ * not a user setting — see `lib/context-usage.ts`.
  */
-export const DEFAULT_AUTOCOMPACT_THRESHOLD = 93;
-export const MIN_AUTOCOMPACT_THRESHOLD = 50;
-export const MAX_AUTOCOMPACT_THRESHOLD = 99;
-
 interface AutocompactSettings {
   enabled: boolean;
-  /** Percent-full at which to compact (clamped to [50, 99]). */
-  threshold: number;
   setEnabled: (enabled: boolean) => void;
-  setThreshold: (threshold: number) => void;
 }
-
-const clampThreshold = (n: number): number =>
-  Math.min(
-    MAX_AUTOCOMPACT_THRESHOLD,
-    Math.max(MIN_AUTOCOMPACT_THRESHOLD, Math.round(n)),
-  );
 
 export const useAutocompactSettings = create<AutocompactSettings>()(
   persist(
     (set) => ({
       enabled: true,
-      threshold: DEFAULT_AUTOCOMPACT_THRESHOLD,
       setEnabled: (enabled) => set({ enabled }),
-      setThreshold: (threshold) => set({ threshold: clampThreshold(threshold) }),
     }),
     { name: "houston.autocompact" },
   ),

--- a/app/src/stores/autocompact-settings.ts
+++ b/app/src/stores/autocompact-settings.ts
@@ -1,0 +1,43 @@
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+/**
+ * Autocompact settings — a client-side UI behavior preference, persisted to
+ * localStorage. Kept out of the engine `preferences` table on purpose: it
+ * governs how the desktop client drives sessions, reads synchronously at send
+ * time (see `lib/autocompact.ts`), and doesn't need cross-device sync.
+ *
+ * When enabled (default), once a conversation's context fill reaches
+ * `threshold` percent the next turn runs on a freshly-compacted session. The
+ * threshold sits just below the provider CLIs' own ~95% auto-compaction so
+ * Houston compacts cleanly at a turn boundary first.
+ */
+export const DEFAULT_AUTOCOMPACT_THRESHOLD = 93;
+export const MIN_AUTOCOMPACT_THRESHOLD = 50;
+export const MAX_AUTOCOMPACT_THRESHOLD = 99;
+
+interface AutocompactSettings {
+  enabled: boolean;
+  /** Percent-full at which to compact (clamped to [50, 99]). */
+  threshold: number;
+  setEnabled: (enabled: boolean) => void;
+  setThreshold: (threshold: number) => void;
+}
+
+const clampThreshold = (n: number): number =>
+  Math.min(
+    MAX_AUTOCOMPACT_THRESHOLD,
+    Math.max(MIN_AUTOCOMPACT_THRESHOLD, Math.round(n)),
+  );
+
+export const useAutocompactSettings = create<AutocompactSettings>()(
+  persist(
+    (set) => ({
+      enabled: true,
+      threshold: DEFAULT_AUTOCOMPACT_THRESHOLD,
+      setEnabled: (enabled) => set({ enabled }),
+      setThreshold: (threshold) => set({ threshold: clampThreshold(threshold) }),
+    }),
+    { name: "houston.autocompact" },
+  ),
+);

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -8,3 +8,13 @@ declare const __SUPABASE_ANON_KEY__: string;
 declare const __HOUSTON_AUTH_STORAGE_MODE__: string;
 declare const __HOUSTON_AUTH_STORAGE_SCOPE__: string;
 declare const __SENTRY_DSN__: string;
+
+interface ImportMetaEnv {
+  /**
+   * Percent-full at which Houston proactively compacts a conversation's
+   * context (default 93). Optional build-time tuning knob; parsed + clamped
+   * to [1, 99] by `resolveThreshold` in `lib/context-usage.ts`. Set it low
+   * (e.g. 5) to force compaction while testing.
+   */
+  readonly VITE_AUTOCOMPACT_THRESHOLD?: string;
+}

--- a/app/tests/autocompact.test.ts
+++ b/app/tests/autocompact.test.ts
@@ -2,6 +2,7 @@ import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
   contextFillPercent,
+  resolveThreshold,
   shouldAutocompact,
 } from "../src/lib/context-usage.ts";
 
@@ -38,5 +39,21 @@ describe("shouldAutocompact", () => {
   it("never fires when disabled or usage unknown", () => {
     strictEqual(shouldAutocompact({ percent: 99, enabled: false, threshold: 93 }), false);
     strictEqual(shouldAutocompact({ percent: null, enabled: true, threshold: 93 }), false);
+  });
+});
+
+describe("resolveThreshold", () => {
+  it("defaults to 93 when unset, empty, or non-numeric", () => {
+    strictEqual(resolveThreshold(undefined), 93);
+    strictEqual(resolveThreshold(""), 93);
+    strictEqual(resolveThreshold("abc"), 93);
+  });
+
+  it("rounds and clamps to [1, 99]", () => {
+    strictEqual(resolveThreshold("80"), 80);
+    strictEqual(resolveThreshold("85.6"), 86); // round
+    strictEqual(resolveThreshold("0"), 1); // clamp floor
+    strictEqual(resolveThreshold("-20"), 1); // clamp floor
+    strictEqual(resolveThreshold("150"), 99); // clamp ceil
   });
 });

--- a/app/tests/autocompact.test.ts
+++ b/app/tests/autocompact.test.ts
@@ -1,0 +1,42 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  contextFillPercent,
+  shouldAutocompact,
+} from "../src/lib/context-usage.ts";
+
+const usage = (context_tokens: number) => ({
+  context_tokens,
+  output_tokens: 0,
+  cached_tokens: 0,
+});
+
+describe("contextFillPercent", () => {
+  it("rounds and clamps to 0-100", () => {
+    strictEqual(contextFillPercent(usage(93_000), 100_000), 93);
+    strictEqual(contextFillPercent(usage(925), 1000), 93); // 92.5 -> 93
+    strictEqual(contextFillPercent(usage(250_000), 100_000), 100); // clamp
+  });
+
+  it("returns null when usage or window is missing", () => {
+    strictEqual(contextFillPercent(null, 100_000), null);
+    strictEqual(contextFillPercent(usage(1000), null), null);
+    strictEqual(contextFillPercent(usage(1000), 0), null);
+  });
+});
+
+describe("shouldAutocompact", () => {
+  it("fires at or above the threshold when enabled", () => {
+    strictEqual(shouldAutocompact({ percent: 93, enabled: true, threshold: 93 }), true);
+    strictEqual(shouldAutocompact({ percent: 99, enabled: true, threshold: 93 }), true);
+  });
+
+  it("does not fire below the threshold", () => {
+    strictEqual(shouldAutocompact({ percent: 92, enabled: true, threshold: 93 }), false);
+  });
+
+  it("never fires when disabled or usage unknown", () => {
+    strictEqual(shouldAutocompact({ percent: 99, enabled: false, threshold: 93 }), false);
+    strictEqual(shouldAutocompact({ percent: null, enabled: true, threshold: 93 }), false);
+  });
+});

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -447,6 +447,16 @@ fn serialize_for_persist(item: &FeedItem) -> Option<(String, String)> {
             let data = serde_json::to_string(err).unwrap_or_else(|_| "null".into());
             Some(("provider_error".into(), data))
         }
+        FeedItem::ContextCompacted {
+            trigger,
+            pre_tokens,
+        } => {
+            // Persist the compaction divider so it survives a history reload,
+            // matching the live FeedItem wire shape (`data` = the variant
+            // fields). `trigger` serializes to "native"/"proactive".
+            let data = serde_json::json!({ "trigger": trigger, "pre_tokens": pre_tokens });
+            Some(("context_compacted".into(), data.to_string()))
+        }
         // Skip streaming items — they get replaced by finals.
         FeedItem::AssistantTextStreaming(_) | FeedItem::ThinkingStreaming(_) => None,
     }
@@ -698,6 +708,38 @@ mod tests {
         assert_eq!(parsed["usage"]["context_tokens"], 151_500);
         assert_eq!(parsed["usage"]["cached_tokens"], 150_000);
         assert_eq!(parsed["usage"]["output_tokens"], 420);
+    }
+
+    #[test]
+    fn context_compacted_persists_for_history() {
+        // The compaction divider must survive a history reload, so it
+        // serializes to its wire shape (`trigger` + `pre_tokens`).
+        let item = FeedItem::ContextCompacted {
+            trigger: houston_terminal_manager::CompactTrigger::Proactive,
+            pre_tokens: Some(185_000),
+        };
+
+        let (feed_type, data) = serialize_for_persist(&item).expect("serializes");
+
+        assert_eq!(feed_type, "context_compacted");
+        let parsed: serde_json::Value = serde_json::from_str(&data).unwrap();
+        assert_eq!(parsed["trigger"], "proactive");
+        assert_eq!(parsed["pre_tokens"], 185_000);
+    }
+
+    #[test]
+    fn context_compacted_native_without_pre_tokens_persists_null() {
+        let item = FeedItem::ContextCompacted {
+            trigger: houston_terminal_manager::CompactTrigger::Native,
+            pre_tokens: None,
+        };
+
+        let (feed_type, data) = serialize_for_persist(&item).expect("serializes");
+
+        assert_eq!(feed_type, "context_compacted");
+        let parsed: serde_json::Value = serde_json::from_str(&data).unwrap();
+        assert_eq!(parsed["trigger"], "native");
+        assert!(parsed["pre_tokens"].is_null());
     }
 
     #[test]

--- a/engine/houston-engine-core/src/sessions/compaction.rs
+++ b/engine/houston-engine-core/src/sessions/compaction.rs
@@ -1,0 +1,209 @@
+//! Proactive context compaction — the forced "summarize-and-reseed" path.
+//!
+//! When the frontend sees a conversation's context fill cross the user's
+//! threshold, it sets `compact: true` on the next turn (see
+//! `StartParams::compact`). The engine then summarizes the visible chat
+//! history into a compact handoff, abandons the current provider resume id
+//! (kept in `.history` so the chat stays visible), and runs the turn on a
+//! FRESH provider session seeded with the summary.
+//!
+//! The user's `chat_feed` is never mutated — they still see every message;
+//! only the agent's working context shrinks. This is provider-agnostic: it
+//! works the same for Claude, Codex, and Gemini, and is the reliable path for
+//! Codex (whose own auto-compaction is unreliable in `exec` mode).
+
+use super::{history, provider_oneshot};
+use crate::error::{CoreError, CoreResult};
+use houston_db::Database;
+use houston_terminal_manager::Provider;
+use std::path::Path;
+use std::time::Duration;
+
+/// Cap on how much rendered history we feed the summarizer. Mirrors the
+/// resume-recovery cap; keeps the summary call itself from blowing context.
+const MAX_HISTORY_BYTES: usize = 120_000;
+
+/// Generous bound — summarizing a long conversation with a capable model takes
+/// longer than a title. Still bounded so a hung CLI can't wedge the turn.
+const SUMMARY_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Cheap, always-available fallback summary model per provider, used only when
+/// the conversation's own model is unknown. Mirrors `summarize`'s title tiers.
+fn fallback_summary_model(provider: Provider) -> Option<&'static str> {
+    match provider.id() {
+        "anthropic" => Some("haiku"),
+        "openai" => Some("gpt-5.5-mini"),
+        "gemini" => Some("gemini-3.1-flash-lite"),
+        _ => None,
+    }
+}
+
+/// Outcome of preparing a compaction: the seeded prompt to send to the fresh
+/// session, plus the context size just before compaction (for the marker).
+pub struct CompactionSeed {
+    pub prompt: String,
+    pub pre_tokens: Option<u64>,
+}
+
+/// Build the seed for a forced compaction, or `Ok(None)` when there is nothing
+/// to summarize (no visible history yet). Returns `Err` only when the
+/// summarizer call itself fails — the caller degrades to a normal resume in
+/// that case (the provider's own auto-compaction is the backstop).
+pub async fn build_compaction_seed(
+    db: &Database,
+    working_dir: &Path,
+    agent_dir: &Path,
+    session_key: &str,
+    latest_user_prompt: &str,
+    provider: Provider,
+    model: Option<&str>,
+) -> CoreResult<Option<CompactionSeed>> {
+    let mut entries = history::load(db, working_dir, session_key).await?;
+    if entries.is_empty() && agent_dir != working_dir {
+        entries = history::load(db, agent_dir, session_key).await?;
+    }
+
+    let rendered = history::render_visible_entries(&entries).join("\n\n");
+    if rendered.trim().is_empty() {
+        return Ok(None);
+    }
+    let pre_tokens = latest_context_tokens(&entries);
+    let capped = history::truncate_history_tail(rendered, MAX_HISTORY_BYTES);
+
+    let summary_model = model.or_else(|| fallback_summary_model(provider)).ok_or_else(|| {
+        CoreError::Internal(format!(
+            "no summary model available for provider {:?}",
+            provider.id()
+        ))
+    })?;
+
+    let summary = provider_oneshot::run_provider_oneshot(
+        &summary_request_prompt(&capped),
+        provider,
+        summary_model,
+        SUMMARY_TIMEOUT,
+    )
+    .await
+    .map_err(CoreError::Internal)?;
+
+    let summary = summary.trim();
+    if summary.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(CompactionSeed {
+        prompt: seeded_prompt(summary, latest_user_prompt),
+        pre_tokens,
+    }))
+}
+
+/// The prompt sent to the summarizer CLI. Asks for a handoff brief that lets a
+/// fresh agent continue the SAME work without the full transcript.
+fn summary_request_prompt(history: &str) -> String {
+    format!(
+        "You are compacting a conversation so a fresh assistant session can continue the SAME work without the full transcript. Write a dense handoff summary that preserves: the user's goal and any constraints, decisions already made, key facts and file paths, what has been done so far, and the immediate next step. Omit small talk. Use compact prose or bullet points. Do not address the user; these are notes for the next assistant.\n\n<conversation>\n{history}\n</conversation>"
+    )
+}
+
+/// Wrap the summary + the user's actual latest message into the prompt the
+/// fresh session receives. The summary is established context; the latest
+/// message is the task. Mirrors the resume-recovery framing.
+fn seeded_prompt(summary: &str, latest_user_prompt: &str) -> String {
+    format!(
+        "This conversation continues from earlier work that was summarized to save space. Treat the summary as established context, not as a new task.\n\n<conversation_summary>\n{summary}\n</conversation_summary>\n\nLatest user message:\n<latest_user_message>\n{latest_user_prompt}\n</latest_user_message>"
+    )
+}
+
+/// Pull the most recent reported context size from the visible history so the
+/// compaction marker can show how full things were. Best-effort.
+fn latest_context_tokens(entries: &[history::ChatHistoryEntry]) -> Option<u64> {
+    entries
+        .iter()
+        .rev()
+        .find(|e| e.feed_type == "final_result")
+        .and_then(|e| e.data.get("usage"))
+        .and_then(|u| u.get("context_tokens"))
+        .and_then(serde_json::Value::as_u64)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn entry(feed_type: &str, data: serde_json::Value) -> history::ChatHistoryEntry {
+        history::ChatHistoryEntry {
+            feed_type: feed_type.to_string(),
+            data,
+        }
+    }
+
+    #[test]
+    fn summary_prompt_wraps_history_and_states_intent() {
+        let p = summary_request_prompt("User: do X\n\nAssistant: did Y");
+        assert!(p.contains("<conversation>"));
+        assert!(p.contains("do X"));
+        assert!(p.contains("did Y"));
+        assert!(p.contains("handoff summary"));
+        // No em dashes in any generated text (project copy rule, even for
+        // model-facing prompts we keep it clean).
+        assert!(!p.contains('\u{2014}'));
+    }
+
+    #[test]
+    fn seeded_prompt_keeps_summary_as_context_and_latest_as_task() {
+        let p = seeded_prompt("Goal: ship feature", "now write the tests");
+        assert!(p.contains("<conversation_summary>"));
+        assert!(p.contains("Goal: ship feature"));
+        assert!(p.contains("<latest_user_message>"));
+        assert!(p.contains("now write the tests"));
+        // The original user message must be present verbatim so the fresh
+        // session answers the real ask, not the summary.
+        assert!(p.contains("now write the tests"));
+    }
+
+    #[test]
+    fn latest_context_tokens_reads_most_recent_final_result_usage() {
+        let entries = vec![
+            entry("user_message", json!("hi")),
+            entry(
+                "final_result",
+                json!({ "result": "a", "usage": { "context_tokens": 1000 } }),
+            ),
+            entry("assistant_text", json!("ok")),
+            entry(
+                "final_result",
+                json!({ "result": "b", "usage": { "context_tokens": 185000 } }),
+            ),
+        ];
+        assert_eq!(latest_context_tokens(&entries), Some(185_000));
+    }
+
+    #[test]
+    fn latest_context_tokens_none_when_usage_missing_or_null() {
+        let entries = vec![
+            entry("user_message", json!("hi")),
+            entry("final_result", json!({ "result": "a", "usage": null })),
+        ];
+        assert_eq!(latest_context_tokens(&entries), None);
+
+        let no_final = vec![entry("user_message", json!("hi"))];
+        assert_eq!(latest_context_tokens(&no_final), None);
+    }
+
+    #[test]
+    fn fallback_summary_model_is_wired_per_provider() {
+        assert_eq!(
+            fallback_summary_model("anthropic".parse().unwrap()),
+            Some("haiku")
+        );
+        assert_eq!(
+            fallback_summary_model("openai".parse().unwrap()),
+            Some("gpt-5.5-mini")
+        );
+        assert_eq!(
+            fallback_summary_model("gemini".parse().unwrap()),
+            Some("gemini-3.1-flash-lite")
+        );
+    }
+}

--- a/engine/houston-engine-core/src/sessions/history.rs
+++ b/engine/houston-engine-core/src/sessions/history.rs
@@ -80,8 +80,7 @@ pub(crate) fn build_resume_recovery_prompt(
     latest_user_prompt: &str,
     activity_hint: Option<&str>,
 ) -> Option<String> {
-    let mut rendered_entries: Vec<String> =
-        entries.iter().filter_map(render_recovery_entry).collect();
+    let mut rendered_entries: Vec<String> = render_visible_entries(entries);
 
     if rendered_entries.is_empty() {
         if let Some(hint) = activity_hint
@@ -96,10 +95,19 @@ pub(crate) fn build_resume_recovery_prompt(
         return None;
     }
 
-    let recovered_history = truncate_recovered_history(rendered_entries.join("\n\n"));
+    let recovered_history =
+        truncate_history_tail(rendered_entries.join("\n\n"), MAX_RECOVERY_HISTORY_BYTES);
     Some(format!(
         "The previous provider transcript could not be resumed. Continue this conversation using the recovered visible chat history below. Do not treat this as a new conversation.\n\n<recovered_chat_history>\n{recovered_history}\n</recovered_chat_history>\n\nLatest user message:\n<latest_user_message>\n{latest_user_prompt}\n</latest_user_message>"
     ))
+}
+
+/// Render the user/assistant turns of a conversation to plain text lines,
+/// dropping tool calls/results and other non-conversational feed items. Shared
+/// by resume-recovery and proactive compaction so both reconstruct the visible
+/// chat the same way.
+pub(crate) fn render_visible_entries(entries: &[ChatHistoryEntry]) -> Vec<String> {
+    entries.iter().filter_map(render_recovery_entry).collect()
 }
 
 fn render_recovery_entry(entry: &ChatHistoryEntry) -> Option<String> {
@@ -121,17 +129,20 @@ fn text_from_json(value: &serde_json::Value) -> Option<String> {
     (!trimmed.is_empty()).then(|| trimmed.to_string())
 }
 
-fn truncate_recovered_history(history: String) -> String {
-    if history.len() <= MAX_RECOVERY_HISTORY_BYTES {
+/// Keep the most-recent `max_bytes` of a rendered history, prefixing a note
+/// when earlier content was dropped. Splits on a UTF-8 char boundary. Shared
+/// by resume-recovery and compaction (each passes its own cap).
+pub(crate) fn truncate_history_tail(history: String, max_bytes: usize) -> String {
+    if history.len() <= max_bytes {
         return history;
     }
 
-    let mut start = history.len() - MAX_RECOVERY_HISTORY_BYTES;
+    let mut start = history.len() - max_bytes;
     while !history.is_char_boundary(start) {
         start += 1;
     }
     format!(
-        "[Earlier recovered history omitted because it was too long.]\n\n{}",
+        "[Earlier history omitted because it was too long.]\n\n{}",
         &history[start..]
     )
 }

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -17,6 +17,7 @@
 //! lives in the adapter today; it will move into `engine-core` in a later
 //! phase once `agent_store` is ported.
 
+mod compaction;
 mod control;
 pub mod file_changes;
 pub mod generate_instructions;
@@ -38,7 +39,7 @@ use houston_agents_conversations::session_id_tracker::SessionIdTracker;
 use houston_agents_conversations::session_pids::SessionPidMap;
 use houston_agents_conversations::session_runner::{self, PersistOptions};
 use houston_db::Database;
-use houston_terminal_manager::{FeedItem, Provider};
+use houston_terminal_manager::{CompactTrigger, FeedItem, Provider};
 use houston_ui_events::{DynEventSink, HoustonEvent};
 use std::path::{Path, PathBuf};
 use workdir_locks::{WorkdirLocks, WorkdirSessionGuard};
@@ -98,6 +99,11 @@ pub struct StartParams {
     /// `--effort <value>`. Accepted values vary per provider; the caller is
     /// responsible for passing something each CLI understands (e.g. "medium").
     pub effort: Option<String>,
+    /// When `true`, the frontend has detected the context window is nearly
+    /// full and wants this turn to run on a freshly-compacted session.
+    /// Honored only when there's an existing session to compact; ignored on
+    /// the first turn. See [`compaction`].
+    pub compact: bool,
 }
 
 /// Start a session turn. The request is accepted immediately. Turns with the
@@ -192,6 +198,7 @@ async fn run_start(
         provider,
         model,
         effort,
+        compact,
     } = params;
 
     if !agent_dir.exists() {
@@ -271,7 +278,80 @@ async fn run_start(
         .session_ids
         .get_for_session(&agent_key, &working_dir, &session_key, provider)
         .await;
-    let resume_id = sid_handle.get().await;
+    let agent_path = agent_dir.to_string_lossy().to_string();
+    let mut resume_id = sid_handle.get().await;
+    // What the CLI actually receives this turn. Normally the user's prompt;
+    // for a forced compaction it becomes the summary-seeded prompt, while the
+    // persisted/displayed user message stays the original (see `persist`).
+    let mut cli_prompt = prompt.clone();
+
+    // Forced autocompact (mechanism B): the frontend flagged this turn because
+    // the context window is nearly full. Summarize the visible history,
+    // abandon the current resume id (kept in `.history` so the chat stays
+    // visible), and run this turn on a FRESH provider session seeded with the
+    // summary. The user's chat_feed is never mutated.
+    if compact {
+        if let Some(old_id) = resume_id.clone() {
+            match compaction::build_compaction_seed(
+                &db,
+                &working_dir,
+                &agent_dir,
+                &session_key,
+                &prompt,
+                provider,
+                model.as_deref(),
+            )
+            .await
+            {
+                Ok(Some(seed)) => {
+                    cli_prompt = seed.prompt;
+                    // Emit the marker live so the divider appears immediately,
+                    // and persist it under the OLD session id so it sits at the
+                    // boundary between the prior turns and the fresh session.
+                    events.emit(HoustonEvent::FeedItem {
+                        agent_path: agent_path.clone(),
+                        session_key: session_key.clone(),
+                        item: FeedItem::ContextCompacted {
+                            trigger: CompactTrigger::Proactive,
+                            pre_tokens: seed.pre_tokens,
+                        },
+                    });
+                    let data = serde_json::json!({
+                        "trigger": "proactive",
+                        "pre_tokens": seed.pre_tokens,
+                    })
+                    .to_string();
+                    if let Err(e) = db
+                        .add_chat_feed_item_by_session(&old_id, "context_compacted", &data, &source)
+                        .await
+                    {
+                        tracing::warn!(
+                            "[sessions] failed to persist compaction marker: {e} (session_key={session_key})"
+                        );
+                    }
+                    sid_handle.clear_current_preserving_history().await;
+                    resume_id = None;
+                    tracing::info!(
+                        "[sessions] proactively compacted context for session_key={session_key} (abandoned resume_id={old_id})"
+                    );
+                }
+                Ok(None) => {
+                    tracing::info!(
+                        "[sessions] compaction requested but no visible history to summarize (session_key={session_key})"
+                    );
+                }
+                Err(e) => {
+                    // Non-fatal: fall back to a normal resume. The provider's
+                    // own auto-compaction is the backstop, and the context
+                    // indicator still shows the high fill so it stays visible.
+                    tracing::warn!(
+                        "[sessions] context compaction failed, continuing with normal resume: {e} (session_key={session_key})"
+                    );
+                }
+            }
+        }
+    }
+
     let resume_recovery_prompt = if resume_id.is_some() {
         let activity_hint = match activity_hint_for_session_key(&agent_dir, &session_key) {
             Ok(hint) => hint,
@@ -312,8 +392,6 @@ async fn run_start(
         provider,
     );
 
-    let agent_path = agent_dir.to_string_lossy().to_string();
-
     // Flip the matching board activity to "running" synchronously, before
     // the CLI subprocess spawns. Desktop UI pre-wrote this from the send
     // handler; moving it here means mobile (and any other client that
@@ -350,7 +428,7 @@ async fn run_start(
         events,
         agent_path.clone(),
         session_key.clone(),
-        prompt,
+        cli_prompt,
         resume_id,
         resume_recovery_prompt,
         working_dir,
@@ -647,6 +725,7 @@ pub async fn start_onboarding(
             provider: resolved.provider,
             model: resolved.model,
             effort,
+            compact: false,
         },
     )
     .await
@@ -714,6 +793,7 @@ mod tests {
                     provider: "openai".parse().unwrap(),
                     model: None,
                     effort: None,
+                    compact: false,
                 },
             ),
         )

--- a/engine/houston-engine-server/src/routes/sessions.rs
+++ b/engine/houston-engine-server/src/routes/sessions.rs
@@ -84,6 +84,12 @@ pub struct StartRequest {
     /// in `~/.codex/config.toml`.
     #[serde(default)]
     pub effort: Option<String>,
+    /// When `true`, compact the conversation (summarize + reseed a fresh
+    /// provider session) before running this turn. The frontend sets this
+    /// once the context window is nearly full. Defaults to `false` so older
+    /// clients deserialize unchanged.
+    #[serde(default)]
+    pub compact: bool,
 }
 
 #[derive(Debug, Serialize)]
@@ -125,6 +131,7 @@ async fn start_session(
         provider,
         model,
         effort,
+        compact: req.compact,
     };
 
     let rt = SessionRuntime::clone(&st.engine.sessions);

--- a/engine/houston-terminal-manager/src/lib.rs
+++ b/engine/houston-terminal-manager/src/lib.rs
@@ -42,6 +42,6 @@ pub use provider_error_kind::{
 };
 pub use session_update::SessionUpdate;
 pub use types::{
-    ClaudeEvent, ContentBlock, FeedItem, FileChanges, SessionFeedBuffer, SessionStatus,
-    TokenUsage, ToolRuntimeErrorKind,
+    ClaudeEvent, CompactTrigger, ContentBlock, FeedItem, FileChanges, SessionFeedBuffer,
+    SessionStatus, TokenUsage, ToolRuntimeErrorKind,
 };

--- a/engine/houston-terminal-manager/src/parser.rs
+++ b/engine/houston-terminal-manager/src/parser.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use super::provider::anthropic_classify;
 use super::provider_error_kind::{truncate_excerpt, ProviderError};
 use super::types::{
-    AssistantMessage, ClaudeEvent, ContentBlock, FeedItem, TokenUsage, UserMessage,
+    AssistantMessage, ClaudeEvent, CompactTrigger, ContentBlock, FeedItem, TokenUsage, UserMessage,
 };
 
 const ANTHROPIC: &str = "anthropic";
@@ -156,7 +156,9 @@ pub fn parse_event(line: &str, acc: &mut StreamAccumulator) -> Vec<FeedItem> {
     };
 
     match event {
-        ClaudeEvent::System { .. } => vec![],
+        ClaudeEvent::System { subtype, extra, .. } => {
+            parse_system_event(subtype.as_deref(), &extra)
+        }
         ClaudeEvent::Assistant {
             subtype, message, ..
         } => {
@@ -255,6 +257,45 @@ fn parse_rate_limit_event(extra: serde_json::Value) -> Vec<FeedItem> {
         retry_after_seconds,
         message,
     })]
+}
+
+/// Parse Claude's `system` events. Most are internal (`init`, `api_retry`,
+/// `plugin_install`) and produce nothing. The one we surface is
+/// `compact_boundary`: Claude Code auto-compacts its own transcript as it
+/// nears the context window and emits this marker. We lift it to a
+/// [`FeedItem::ContextCompacted`] (trigger `Native`) so the UI can show a
+/// subtle divider — the user's visible chat is untouched; only the agent's
+/// working context shrank.
+///
+/// Verified against Claude Code 2.1.160: the wire line is a top-level
+/// `{"type":"system","subtype":"compact_boundary","session_id":...,"uuid":...,
+/// "compact_metadata":{"trigger":"auto"|"manual","pre_tokens":N,...}}`.
+/// `compact_metadata` lands in the flattened `extra`. We read leniently
+/// (number-or-string `pre_tokens`) so a casing/format shift doesn't crash.
+fn parse_system_event(subtype: Option<&str>, extra: &serde_json::Value) -> Vec<FeedItem> {
+    if subtype != Some("compact_boundary") {
+        return vec![];
+    }
+    let pre_tokens = extra
+        .get("compact_metadata")
+        .and_then(|m| m.get("pre_tokens").or_else(|| m.get("preTokens")))
+        .and_then(json_u64)
+        .or_else(|| {
+            extra
+                .get("pre_tokens")
+                .or_else(|| extra.get("preTokens"))
+                .and_then(json_u64)
+        });
+    vec![FeedItem::ContextCompacted {
+        trigger: CompactTrigger::Native,
+        pre_tokens,
+    }]
+}
+
+/// Read a JSON value as a `u64`, tolerating a numeric string (some Claude
+/// telemetry paths stringify token counts).
+fn json_u64(v: &serde_json::Value) -> Option<u64> {
+    v.as_u64().or_else(|| v.as_str().and_then(|s| s.parse().ok()))
 }
 
 fn parse_assistant_event(
@@ -399,6 +440,42 @@ mod tests {
             }
             other => panic!("expected Unauthenticated, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn parse_compact_boundary_emits_context_compacted() {
+        // Verbatim shape from Claude Code 2.1.160's stream-json output: a
+        // top-level `system` event whose `compact_metadata` carries the
+        // pre-compaction token count. We surface it as a Native marker.
+        let line = r#"{"type":"system","subtype":"compact_boundary","session_id":"s1","uuid":"u1","compact_metadata":{"trigger":"auto","pre_tokens":185000,"post_tokens":42000,"duration_ms":1200}}"#;
+        let items = parse_event(line, &mut acc());
+        assert_eq!(items.len(), 1);
+        match &items[0] {
+            FeedItem::ContextCompacted {
+                trigger,
+                pre_tokens,
+            } => {
+                assert_eq!(*trigger, CompactTrigger::Native);
+                assert_eq!(*pre_tokens, Some(185_000));
+            }
+            other => panic!("expected ContextCompacted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_compact_boundary_tolerates_missing_metadata() {
+        // A future/variant shape without compact_metadata still produces the
+        // marker (pre_tokens unknown) rather than crashing or going silent.
+        let line = r#"{"type":"system","subtype":"compact_boundary","session_id":"s1","uuid":"u1"}"#;
+        let items = parse_event(line, &mut acc());
+        assert_eq!(items.len(), 1);
+        assert!(matches!(
+            &items[0],
+            FeedItem::ContextCompacted {
+                trigger: CompactTrigger::Native,
+                pre_tokens: None,
+            }
+        ));
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/types.rs
+++ b/engine/houston-terminal-manager/src/types.rs
@@ -198,6 +198,21 @@ pub enum ToolRuntimeErrorKind {
     ProviderModelUnsupported,
 }
 
+/// Why a context-compaction boundary was recorded.
+///
+/// `Native` — the provider CLI compacted its own transcript on its own
+/// schedule (Claude Code's `compact_boundary` system event as it nears the
+/// context window). `Proactive` — Houston forced a summarize-and-reseed at the
+/// user's configured threshold, before the CLI would have. In both cases the
+/// user's visible `chat_feed` is untouched; only the agent's working context
+/// shrinks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CompactTrigger {
+    Native,
+    Proactive,
+}
+
 /// Processed feed items for rendering in the UI.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "feed_type", content = "data", rename_all = "snake_case")]
@@ -237,6 +252,21 @@ pub enum FeedItem {
     ToolResult { content: String, is_error: bool },
     /// System message (session start, etc.).
     SystemMessage(String),
+    /// A context-compaction boundary. The conversation's earlier turns were
+    /// summarized to free context — either by the provider CLI itself
+    /// (`Native`) or by Houston's proactive reseed (`Proactive`). Rendered as
+    /// a subtle divider; the full chat history above and below stays visible.
+    /// `pre_tokens` is how full the context was just before compaction, when
+    /// the provider reports it.
+    ContextCompacted {
+        trigger: CompactTrigger,
+        // Plain `Option` (serializes as `null` when absent), matching the
+        // `FinalResult { usage }` convention so the live event and the
+        // persisted `chat_feed` row share one shape. `default` keeps an older
+        // row that predates the field deserializable.
+        #[serde(default)]
+        pre_tokens: Option<u64>,
+    },
     /// Session completed — cost/duration summary.
     FinalResult {
         result: String,

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -451,8 +451,9 @@ rendered as a subtle divider — the full history above and below stays visible.
   `ContextCompacted { trigger: Native }`. Claude-only today: Codex's `exec`
   auto-compaction is unreliable, which is exactly why the forced path exists.
 - **Proactive** — the desktop client watches the context-usage % and, once it
-  crosses the user's threshold (default 93%, *Settings → Long conversations*),
-  sets `compact: true` on the next `startSession`. The engine
+  crosses the threshold (default 93%, overridable at build time via
+  `VITE_AUTOCOMPACT_THRESHOLD`), sets `compact: true` on the next
+  `startSession`. The engine
   (`sessions::compaction`) summarizes the visible chat via a one-shot provider
   call, abandons the current resume id with
   `SessionIdHandle::clear_current_preserving_history()` (the id stays in
@@ -462,10 +463,13 @@ rendered as a subtle divider — the full history above and below stays visible.
   persisted/displayed user message stays the original; only the agent's working
   context shrank. Provider-agnostic — the reliable path for Codex.
 
-The threshold + on/off live in a client-side store (`localStorage`,
+The on/off toggle lives in a client-side store (`localStorage`,
 `houston.autocompact`), not the engine `preferences` table: it governs how the
 desktop client drives sessions and is read synchronously at send time
 (`lib/autocompact.ts`, called from `tauriChat.send` so every send path gets it).
+*Settings → Long conversations* is just that toggle. The threshold itself is a
+build-time constant (`VITE_AUTOCOMPACT_THRESHOLD`, default 93), not a user
+setting.
 `compact` is honored only when a resume id exists (ignored on turn 1). On
 summary failure the engine logs and falls back to a normal resume (the CLI's own
 auto-compaction is the backstop), so a turn never fails because compaction

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -467,7 +467,7 @@ The on/off toggle lives in a client-side store (`localStorage`,
 `houston.autocompact`), not the engine `preferences` table: it governs how the
 desktop client drives sessions and is read synchronously at send time
 (`lib/autocompact.ts`, called from `tauriChat.send` so every send path gets it).
-*Settings → Long conversations* is just that toggle. The threshold itself is a
+*Settings → Summarize long conversations* is just that toggle. The threshold itself is a
 build-time constant (`VITE_AUTOCOMPACT_THRESHOLD`, default 93), not a user
 setting.
 `compact` is honored only when a resume id exists (ignored on turn 1). On

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -436,6 +436,41 @@ can't self-correct downward, so the dialog labels the figure "estimated".
 If a future CLI release exposes the window in `system init` /
 `thread.started`, prefer that live value over the estimate.
 
+### Autocompact (`context_compacted`)
+
+When a conversation nears the context window, Houston frees space without
+touching the user's visible chat. Both paths surface as one
+`feed_type: "context_compacted"` item (`data: { trigger: "native" |
+"proactive", pre_tokens?: number }`, Rust `FeedItem::ContextCompacted`),
+rendered as a subtle divider — the full history above and below stays visible.
+
+- **Native** — Claude Code auto-compacts its own transcript as it nears the
+  window (~95%) and emits a top-level stream-json `system` event
+  `{"subtype":"compact_boundary","compact_metadata":{"trigger","pre_tokens",…}}`
+  (verified against Claude Code 2.1.160). `parser.rs` lifts it into
+  `ContextCompacted { trigger: Native }`. Claude-only today: Codex's `exec`
+  auto-compaction is unreliable, which is exactly why the forced path exists.
+- **Proactive** — the desktop client watches the context-usage % and, once it
+  crosses the user's threshold (default 93%, *Settings → Long conversations*),
+  sets `compact: true` on the next `startSession`. The engine
+  (`sessions::compaction`) summarizes the visible chat via a one-shot provider
+  call, abandons the current resume id with
+  `SessionIdHandle::clear_current_preserving_history()` (the id stays in
+  `.history` so `session_ids_for_history` still loads the full `chat_feed`),
+  emits + persists a `Proactive` marker under the old id, then runs the turn on
+  a FRESH provider session seeded with `[summary + the user's message]`. The
+  persisted/displayed user message stays the original; only the agent's working
+  context shrank. Provider-agnostic — the reliable path for Codex.
+
+The threshold + on/off live in a client-side store (`localStorage`,
+`houston.autocompact`), not the engine `preferences` table: it governs how the
+desktop client drives sessions and is read synchronously at send time
+(`lib/autocompact.ts`, called from `tauriChat.send` so every send path gets it).
+`compact` is honored only when a resume id exists (ignored on turn 1). On
+summary failure the engine logs and falls back to a normal resume (the CLI's own
+auto-compaction is the backstop), so a turn never fails because compaction
+couldn't run.
+
 ### Binary file downloads
 
 The `read-project` route returns text only. For xlsx, pdf, images,

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -45,6 +45,9 @@ export interface ChatMessagesProps {
   /** Custom renderer for system messages. Return a node to replace the default,
    *  or undefined to use the default italic text. */
   renderSystemMessage?: (msg: ChatMessage) => ReactNode | undefined;
+  /** Localized label for the context-compaction divider. The library ships an
+   *  English default; the app passes a `t()` string (i18n stays out of `ui/`). */
+  contextCompactedLabel?: string;
   /**
    * Custom renderer for user messages. Return a node to replace the
    * default user bubble (e.g. to render a structured action-invocation
@@ -74,6 +77,7 @@ export function ChatMessages({
   renderMessageAvatar,
   renderTurnSummary,
   renderSystemMessage,
+  contextCompactedLabel,
   renderUserMessage,
   afterMessages,
   onOpenLink,
@@ -126,6 +130,21 @@ export function ChatMessages({
           if (msg.from === "system") {
             const custom = renderSystemMessage?.(msg);
             if (custom !== undefined) return <div key={msg.key}>{custom}</div>;
+            if (msg.compaction) {
+              return (
+                <div
+                  key={msg.key}
+                  className="flex items-center gap-3 max-w-3xl mx-auto px-4 py-3 text-muted-foreground/70"
+                >
+                  <div className="h-px flex-1 bg-border/60" />
+                  <span className="text-xs italic whitespace-nowrap">
+                    {contextCompactedLabel ??
+                      "Earlier conversation summarized to free up space"}
+                  </span>
+                  <div className="h-px flex-1 bg-border/60" />
+                </div>
+              );
+            }
             return (
               <div key={msg.key} className="flex justify-center py-2">
                 <span className="text-xs text-muted-foreground/60 italic">

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -69,6 +69,9 @@ export interface ChatPanelProps {
   getThinkingMessage?: ChatMessagesProps["getThinkingMessage"];
   renderMessageAvatar?: (msg: ChatMessage) => ReactNode | undefined;
   renderSystemMessage?: (msg: ChatMessage) => ReactNode | undefined;
+  /** Localized label for the context-compaction divider. English default in
+   *  the component; the app passes a `t()` string. */
+  contextCompactedLabel?: string;
   renderUserMessage?: (msg: ChatMessage) => ReactNode | undefined;
   afterMessages?: ReactNode;
   renderTurnSummary?: ChatMessagesProps["renderTurnSummary"];

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -41,6 +41,7 @@ export function ChatPanel({
   getThinkingMessage,
   renderMessageAvatar,
   renderSystemMessage,
+  contextCompactedLabel,
   renderUserMessage,
   afterMessages,
   renderTurnSummary,
@@ -151,6 +152,7 @@ export function ChatPanel({
           getThinkingMessage={getThinkingMessage}
           renderMessageAvatar={renderMessageAvatar}
           renderSystemMessage={renderSystemMessage}
+          contextCompactedLabel={contextCompactedLabel}
           renderUserMessage={renderUserMessage}
           afterMessages={afterMessages}
           renderTurnSummary={renderTurnSummary}

--- a/ui/chat/src/feed-to-messages.ts
+++ b/ui/chat/src/feed-to-messages.ts
@@ -19,6 +19,12 @@ export interface FileChangeEntry {
   status: "created" | "modified";
 }
 
+/** Marks a `from: "system"` message as a context-compaction divider. */
+export interface ChatCompactionInfo {
+  trigger: "native" | "proactive";
+  preTokens?: number;
+}
+
 export interface ChatMessage {
   key: string;
   from: "user" | "assistant" | "system";
@@ -36,6 +42,11 @@ export interface ChatMessage {
   fileChanges: FileChangeEntry[];
   /** Source channel if the message came from an external channel. */
   source?: string;
+  /**
+   * Set on `from: "system"` messages that mark a context-compaction boundary.
+   * The renderer shows a subtle divider instead of plain system text.
+   */
+  compaction?: ChatCompactionInfo;
 }
 
 export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
@@ -229,6 +240,25 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
           isStreaming: false,
           tools: [],
           fileChanges: [],
+        });
+        break;
+      }
+
+      case "context_compacted": {
+        flush();
+        messages.push({
+          key: `context-compacted-${messages.length}`,
+          from: "system",
+          // Empty content — the renderer shows a localized divider keyed off
+          // `compaction`, not this string.
+          content: "",
+          isStreaming: false,
+          tools: [],
+          fileChanges: [],
+          compaction: {
+            trigger: item.data.trigger,
+            preTokens: item.data.pre_tokens ?? undefined,
+          },
         });
         break;
       }

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -13,6 +13,17 @@ export type FeedItem =
   | { feed_type: "tool_result"; data: { content: string; is_error: boolean } }
   | { feed_type: "system_message"; data: string }
   | {
+      /**
+       * A context-compaction boundary. Earlier turns were summarized to free
+       * context, either by the provider CLI itself (`native`) or by Houston's
+       * proactive reseed (`proactive`). Rendered as a subtle divider; the full
+       * chat above and below stays visible. `pre_tokens` is how full the
+       * context was just before compaction, when reported.
+       */
+      feed_type: "context_compacted";
+      data: { trigger: "native" | "proactive"; pre_tokens?: number | null };
+    }
+  | {
       feed_type: "file_changes";
       data: { created: string[]; modified: string[] };
     }

--- a/ui/chat/test/feed-to-messages.test.mjs
+++ b/ui/chat/test/feed-to-messages.test.mjs
@@ -25,3 +25,39 @@ test("attaches file changes to the previous assistant message after final result
     { path: "/tmp/notes.txt", status: "modified" },
   ]);
 });
+
+test("context_compacted becomes a system divider carrying compaction info", () => {
+  const messages = feedItemsToMessages([
+    { feed_type: "user_message", data: "keep going" },
+    { feed_type: "assistant_text", data: "Sure." },
+    {
+      feed_type: "context_compacted",
+      data: { trigger: "proactive", pre_tokens: 185000 },
+    },
+    { feed_type: "assistant_text", data: "Continuing from the summary." },
+  ]);
+
+  const divider = messages.find((m) => m.compaction);
+  assert.ok(divider, "a divider message is produced");
+  assert.equal(divider.from, "system");
+  assert.equal(divider.content, "");
+  assert.equal(divider.compaction.trigger, "proactive");
+  assert.equal(divider.compaction.preTokens, 185000);
+  // The surrounding turns are preserved (full history stays visible).
+  assert.ok(messages.some((m) => m.from === "user" && m.content === "keep going"));
+  assert.ok(
+    messages.some(
+      (m) => m.from === "assistant" && m.content === "Continuing from the summary.",
+    ),
+  );
+});
+
+test("context_compacted tolerates a null pre_tokens", () => {
+  const messages = feedItemsToMessages([
+    { feed_type: "context_compacted", data: { trigger: "native", pre_tokens: null } },
+  ]);
+  const divider = messages.find((m) => m.compaction);
+  assert.ok(divider);
+  assert.equal(divider.compaction.trigger, "native");
+  assert.equal(divider.compaction.preTokens, undefined);
+});

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -512,6 +512,13 @@ export interface SessionStartRequest {
    * blow up the session.
    */
   effort?: string;
+  /**
+   * When `true`, the engine compacts the conversation (summarize the visible
+   * history + reseed a fresh provider session) before running this turn. Set
+   * by the desktop client once the context window is nearly full. Honored only
+   * when there's an existing session to compact; ignored on the first turn.
+   */
+  compact?: boolean;
 }
 
 export interface SessionStartResponse {


### PR DESCRIPTION
Closes #313.

## What

When a conversation nears the model's context window, Houston now frees space **without changing what the user sees**. The full chat history stays visible and scrollable; only the agent's underlying working context is compacted.

Two coordinated mechanisms, both surfaced as one subtle divider (new `feed_type: "context_compacted"`):

### 1. Native (Claude) — detect & surface
Claude Code already auto-compacts its own transcript as it nears ~95% and emits a stream-json `system` event `subtype: "compact_boundary"` (verified against the installed Claude Code 2.1.160 binary). Houston was **dropping** all `system` events, so this was invisible. The parser now lifts it into a `FeedItem::ContextCompacted { trigger: native }`.

### 2. Proactive reseed — the guarantee (esp. Codex)
Codex's `exec`-mode auto-compaction is unreliable (openai/codex#16033 + community reports of running straight into the context wall). So Houston proactively compacts at a turn boundary:

- The desktop client watches the existing context-usage indicator and, once fill crosses the user's threshold (default **93%**), sets `compact: true` on the next `startSession`.
- The engine summarizes the visible chat via a one-shot provider call, abandons the current resume id with `SessionIdHandle::clear_current_preserving_history()` (the id stays in `.history`, so `session_ids_for_history` still loads the full `chat_feed`), persists + emits a `proactive` marker under the old id, then runs the turn on a **fresh** provider session seeded with `[summary + the user's message]`.
- The persisted/displayed user message stays the original — the seed only goes to the CLI.

Provider-agnostic. The decision is centralized in `tauriChat.send`, so every send path (board chat, mission control, skill sends, retries) gets it for free; new conversations have no usage yet and resolve to `false`.

## UX
- Subtle "Earlier conversation summarized so the chat can keep going" divider at the boundary (localized en/es/pt; library keeps an English default).
- **Settings → Long conversations**: on/off + threshold slider (50–99%, default 93). Client-side preference (localStorage), since it governs how the desktop client drives sessions.

## Why 93%
Compacting at a turn boundary (not mid-task) avoids the quality degradation people hit when the CLI compacts mid-turn near the limit, and reseeding to a small summary leaves full headroom for the next turn. Native detection stays as a backstop/observability for Claude.

## Files
- **engine**: `FeedItem::ContextCompacted` + `CompactTrigger` (`types.rs`), native `compact_boundary` parse arm (`parser.rs`), exhaustive-match persist arm (`session_runner.rs`), `sessions/compaction.rs` (summarize-and-reseed), `compact` plumbed through `StartParams` + the `/sessions` route, shared history render/truncate helpers.
- **ui/chat**: `context_compacted` union member + divider render (`contextCompactedLabel` prop, English default).
- **engine-client**: `SessionStartRequest.compact`.
- **app**: `shouldAutocompact`/`contextFillPercent` helpers, `lib/autocompact.ts`, persisted settings store, settings section, localized divider, i18n.
- **docs**: `knowledge-base/engine-protocol.md`.

## Verification
- All **15 TS packages** typecheck clean; `check-locales` in sync (en/es/pt, no em dashes); app tests **113/113**, ui/chat tests pass — including new tests for the parser, persistence, feed→divider conversion, and the threshold helpers.
- ⚠️ **Engine (Rust) was verified by review only** — there is no local Rust toolchain in this environment. A 5-lens adversarial review (compile/exhaustiveness ×2, serde/wire, borrow/async/Send, logic) found **0 blockers**. Please run `cargo build --workspace && cargo test --workspace` in CI before merging — the exhaustive `serialize_for_persist` match and the new module are the spots that only a real build can fully confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)