### PR TITLE
fix(scripts): make version bump portable and EOL-safe on Windows

### DIFF
--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -8,13 +8,17 @@ echo "Bumping all packages to v$VERSION..."
 # NPM packages — only the ones that share the Houston version line.
 # ui/agent, ui/agent-schemas, ui/engine-client, ui/sync-protocol are
 # versioned independently and are intentionally excluded.
-for pkg in core chat board layout skills events routines review; do
-  jq --arg v "$VERSION" '.version = $v' "ui/$pkg/package.json" > tmp.json && mv tmp.json "ui/$pkg/package.json"
-done
-
-# Root + app
-for f in package.json app/package.json; do
-  jq --arg v "$VERSION" '.version = $v' "$f" > tmp.json && mv tmp.json "$f"
+for f in package.json app/package.json \
+         ui/core/package.json ui/chat/package.json ui/board/package.json \
+         ui/layout/package.json ui/skills/package.json ui/events/package.json \
+         ui/routines/package.json ui/review/package.json; do
+  # Surgical, EOL-preserving bump of ONLY the top-level "version" key.
+  # Dependencies are keyed by package name (never literal "version"), so
+  # the first `"version":` line is always the package's own. We do NOT
+  # pipe through jq: the Windows jq build rewrites the file to CRLF and
+  # reserializes the whole document, turning a 1-line bump into a 16-line
+  # EOL-churn diff. perl edits one line in place and keeps LF.
+  perl -i -pe 'if (!$d && s/("version":\s*")[0-9]+\.[0-9]+\.[0-9]+(")/${1}'"$VERSION"'${2}/) { $d=1 }' "$f"
 done
 
 # Rust crates — replace ONLY the first `^version = ...` line (the
@@ -28,7 +32,11 @@ for toml in engine/*/Cargo.toml app/houston-tauri/Cargo.toml app/src-tauri/Cargo
   perl -i -pe 'BEGIN{$d=0} if(!$d && /^version = "[^"]+"$/){s/^version = "[^"]+"$/version = "'"$VERSION"'"/; $d=1}' "$toml"
 done
 
-# Root Cargo.toml workspace dependencies
-sed -i '' "s/version = \"[0-9]*\.[0-9]*\.[0-9]*\"/version = \"$VERSION\"/g" Cargo.toml
+# Root Cargo.toml workspace dependencies. Match only the houston-* path
+# deps (every workspace member line carries `path = "…"`); third-party
+# pins like `version = "1"` lack a path and are left untouched. Uses perl
+# instead of BSD `sed -i ''` so the bump runs on Linux + Windows git-bash,
+# not just macOS.
+perl -i -pe 's/version = "[0-9]+\.[0-9]+\.[0-9]+"/version = "'"$VERSION"'"/ if /path = "/' Cargo.toml
 
 echo "All packages bumped to v$VERSION"


### PR DESCRIPTION
## Problem

`scripts/version.sh` (the release version-bump) had two macOS-only assumptions that break a release cut from Windows git-bash:

- **`sed -i ''`** (BSD syntax) — GNU sed in git-bash mis-parses the empty `''` argument and the script aborts mid-run under `set -e`.
- **`jq` per `package.json`** — the Windows `jq` build emits **CRLF** and reserializes the whole document, turning a 1-line version bump into a ~16-line EOL-churn diff (and violating the repo's LF-only rule).

## Fix

Switch both to in-place `perl` edits:

- `package.json` bump rewrites only the top-level `"version"` key, preserving LF.
- Root `Cargo.toml` workspace bump matches only houston path deps (`path = "…"`), leaving third-party pins like `version = "1"` untouched.

Output is now byte-identical on macOS, Linux, and Windows git-bash. This is what let `v0.4.16` bump cleanly from Windows (one-line-per-file diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)