### PR TITLE
fix(ci): point Sentry symbol upload at houston-app binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -596,7 +596,10 @@ jobs:
 
           echo "=== 3. Upload Rust debug symbols (app + engine) ==="
           APP="${{ steps.artifacts.outputs.app }}"
-          APP_EXE="$APP/Contents/MacOS/Houston"
+          # The bundled executable is named after the Cargo binary
+          # (`houston-app`), NOT the productName ("Houston"). The sidecar
+          # alongside it is `houston-engine`.
+          APP_EXE="$APP/Contents/MacOS/houston-app"
           if [ ! -x "$APP_EXE" ]; then
             echo "::error::Tauri app executable missing at $APP_EXE"
             find "$APP/Contents/MacOS" -maxdepth 1 -type f -print || true


### PR DESCRIPTION
The v0.4.17 release build failed at **Upload source maps + Rust debug symbols to Sentry** ([run](https://github.com/gethouston/houston/actions/runs/26885787012/job/79297529383)):

```
::error::Tauri app executable missing at target/universal-apple-darwin/release/bundle/macos/Houston.app/Contents/MacOS/Houston
target/universal-apple-darwin/release/bundle/macos/Houston.app/Contents/MacOS/houston-engine
target/universal-apple-darwin/release/bundle/macos/Houston.app/Contents/MacOS/houston-app
```

## Cause
The verification added in #403 hardcoded `Contents/MacOS/Houston` (the `productName`). But the bundled executable is named after the Cargo package, `houston-app`, with `houston-engine` as the sidecar. `Houston` never exists, so `[ ! -x "$APP_EXE" ]` always fails. #403 merged after v0.4.16, so v0.4.17 is the first release to hit it.

## Fix
Point `APP_EXE` at `Contents/MacOS/houston-app`. One line + a clarifying comment. No other step references that path.

After merge: re-tag `v0.4.17` on the new commit to re-trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)