### PR TITLE
fix(routines): load one routine chat in Mission Control

### DIFF
--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -53,7 +53,16 @@ export function useMissionControl(agents: Agent[]) {
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [loading, setLoading] = useState<Record<string, boolean>>({});
+  // activityId → agentPath. Keyed by the activity id (the KanbanItem id), used
+  // by the card-level handlers (delete/approve/rename) that operate on item.id.
   const pathMapRef = useRef<Record<string, string>>({});
+  // session_key → { agentPath, activityId }. A routine chat's key is
+  // `routine-{rid}`, NOT `activity-{id}`, so stripping an "activity-" prefix to
+  // recover the agent fails for routines and the chat loads empty. Resolve by
+  // the stored session_key directly instead (#381).
+  const sessionMapRef = useRef<
+    Record<string, { agentPath: string; activityId: string }>
+  >({});
 
   const paths = useMemo(
     () => agents.map((a) => a.folderPath),
@@ -71,12 +80,14 @@ export function useMissionControl(agents: Agent[]) {
   const items: KanbanItem[] = useMemo(() => {
     if (!convos) return [];
     const map: Record<string, string> = {};
+    const sessionMap: Record<string, { agentPath: string; activityId: string }> = {};
     const result = convos
       // Archived missions live in the per-agent Archived tab — keep them off
       // the cross-agent active board.
       .filter((c) => c.type === "activity" && c.status && c.status !== "archived")
       .map((c) => {
         map[c.id] = c.agent_path;
+        sessionMap[c.session_key] = { agentPath: c.agent_path, activityId: c.id };
         return {
           id: c.id,
           title: c.title,
@@ -89,13 +100,13 @@ export function useMissionControl(agents: Agent[]) {
         };
       });
     pathMapRef.current = map;
+    sessionMapRef.current = sessionMap;
     return result;
   }, [convos, agentColorMap]);
 
   const loadHistory = useCallback(
     async (sessionKey: string): Promise<FeedItem[]> => {
-      const activityId = sessionKey.replace("activity-", "");
-      const agentPath = pathMapRef.current[activityId];
+      const agentPath = sessionMapRef.current[sessionKey]?.agentPath;
       if (!agentPath) return [];
       const history = await tauriChat.loadHistory(agentPath, sessionKey);
       return history as FeedItem[];
@@ -141,8 +152,7 @@ export function useMissionControl(agents: Agent[]) {
       // the ChatPanel renders it. Without this Mission Control would
       // open a conversation and show an empty chat (history was loaded
       // but had nowhere to land).
-      const activityId = sessionKey.replace("activity-", "");
-      const agentPath = pathMapRef.current[activityId];
+      const agentPath = sessionMapRef.current[sessionKey]?.agentPath;
       if (!agentPath) return;
       // Server history is authoritative for what's persisted; reconcile it with
       // anything already in the live bucket (optimistic overlay or a WS event
@@ -156,9 +166,9 @@ export function useMissionControl(agents: Agent[]) {
 
   const handleSendMessage = useCallback(
     async (sessionKey: string, text: string, files: File[]) => {
-      const activityId = sessionKey.replace("activity-", "");
-      const agentPath = pathMapRef.current[activityId];
-      if (!agentPath) return;
+      const entry = sessionMapRef.current[sessionKey];
+      if (!entry) return;
+      const { agentPath, activityId } = entry;
       try {
         const paths = await tauriAttachments.save(`activity-${activityId}`, files);
         const prompt = buildAttachmentPrompt(text, files, paths);
@@ -279,8 +289,7 @@ export function useMissionControl(agents: Agent[]) {
     }
     for (const [sessionKey, value] of Object.entries(loading)) {
       if (!value) continue;
-      const activityId = sessionKey.replace("activity-", "");
-      const agentPath = pathMapRef.current[activityId];
+      const agentPath = sessionMapRef.current[sessionKey]?.agentPath;
       const status = agentPath
         ? sessionStatuses[getSessionStatusKey(agentPath, sessionKey)]
         : undefined;

--- a/engine/houston-engine-core/src/conversations.rs
+++ b/engine/houston-engine-core/src/conversations.rs
@@ -1,7 +1,12 @@
 //! Conversation listing — derived view over `.houston/activity/activity.json`.
 //!
-//! Every conversation is an activity with a UUID-scoped session key
-//! (`activity-{id}`). This module reads the JSON file directly via
+//! A conversation is addressed by its activity's stored `session_key`. Normal
+//! missions use the `activity-{id}` convention; routine chats use a stable
+//! `routine-{routine_id}` key shared by every run (#381), so all of a
+//! routine's runs collapse into one conversation. We surface the row's stored
+//! key verbatim — falling back to `activity-{id}` only for legacy rows written
+//! before the field existed — so Mission Control loads the same history the
+//! per-agent board does. This module reads the JSON file directly via
 //! `houston_agent_files` so it does not depend on the full agent_store
 //! layer. Phase 2 slice 4 will move the activity writer here too and
 //! collapse the duplication with `app/houston-tauri/src/agent_store/`.
@@ -21,6 +26,11 @@ struct ActivityRow {
     description: String,
     #[serde(default)]
     status: String,
+    /// The conversation address this activity persisted. Routine chats store
+    /// `routine-{routine_id}`; normal missions store `activity-{id}`. Legacy
+    /// rows written before this field existed leave it `None`.
+    #[serde(default)]
+    session_key: Option<String>,
     #[serde(default)]
     updated_at: Option<String>,
 }
@@ -36,7 +46,10 @@ pub struct ConversationEntry {
     /// Always `"activity"` today. Field kept for forward compatibility.
     #[serde(rename = "type")]
     pub entry_type: String,
-    /// Session key used to address this conversation (`activity-{id}`).
+    /// Key used to address this conversation. `activity-{id}` for normal
+    /// missions, `routine-{routine_id}` for routine chats (shared by every run
+    /// of the routine). The frontend must NOT re-derive this from `id` — a
+    /// routine's conversation lives under its routine key, not `activity-{id}`.
     pub session_key: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub updated_at: Option<String>,
@@ -73,7 +86,14 @@ pub fn list(root: &Path) -> CoreResult<Vec<ConversationEntry>> {
     Ok(rows
         .into_iter()
         .map(|row| ConversationEntry {
-            session_key: format!("activity-{}", row.id),
+            // Use the activity's stored key verbatim so routine chats resolve
+            // to `routine-{rid}` (where every run's feed aggregates), not a
+            // per-activity key that would load an empty history. Legacy rows
+            // with no stored key fall back to the `activity-{id}` convention.
+            session_key: row
+                .session_key
+                .filter(|key| !key.is_empty())
+                .unwrap_or_else(|| format!("activity-{}", row.id)),
             id: row.id,
             title: row.title,
             description: Some(row.description).filter(|d| !d.is_empty()),
@@ -145,6 +165,58 @@ mod tests {
         assert_eq!(entries[0].entry_type, "activity");
         assert_eq!(entries[0].description.as_deref(), Some("d"));
         assert_eq!(entries[1].description, None); // empty description → None
+    }
+
+    #[test]
+    fn routine_activity_keeps_its_stored_session_key() {
+        // A routine chat persists `routine-{rid}` (shared by every run). The
+        // conversation list MUST surface that key, not rewrite it to
+        // `activity-{id}` — otherwise Mission Control addresses the wrong
+        // conversation and the routine's history loads empty (#381).
+        let d = TempDir::new().unwrap();
+        seed(
+            d.path(),
+            serde_json::json!([
+                { "id": "act-uuid", "title": "Morning digest", "description": "",
+                  "status": "needs_you", "session_key": "routine-abc",
+                  "routine_id": "abc", "updated_at": "2026-02-02T00:00:00Z" },
+            ]),
+        );
+        let entries = list(d.path()).unwrap();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].id, "act-uuid");
+        assert_eq!(
+            entries[0].session_key, "routine-abc",
+            "routine chats keep their stable per-routine key"
+        );
+    }
+
+    #[test]
+    fn missing_or_empty_session_key_falls_back_to_activity_convention() {
+        // Legacy rows (written before session_key was persisted) and rows that
+        // stored an empty string both fall back to `activity-{id}` so normal
+        // missions still resolve.
+        let d = TempDir::new().unwrap();
+        seed(
+            d.path(),
+            serde_json::json!([
+                { "id": "legacy", "title": "Old", "description": "", "status": "done",
+                  "updated_at": "2026-01-02T00:00:00Z" },
+                { "id": "blank", "title": "Blank", "description": "", "status": "done",
+                  "session_key": "", "updated_at": "2026-01-01T00:00:00Z" },
+            ]),
+        );
+        let entries = list(d.path()).unwrap();
+        let by_id = |id: &str| {
+            entries
+                .iter()
+                .find(|e| e.id == id)
+                .unwrap_or_else(|| panic!("entry {id}"))
+                .session_key
+                .clone()
+        };
+        assert_eq!(by_id("legacy"), "activity-legacy");
+        assert_eq!(by_id("blank"), "activity-blank");
     }
 
     #[test]


### PR DESCRIPTION
Follow-up to #386 ("one chat per routine, not one per run").

## Background
While verifying #386, the reporter saw "a new chat per run" in `pnpm tauri dev`. That turned out to be a **stale engine sidecar** (Tauri does not rebuild the engine on `tauri dev`, so a pre-#386 binary was running). A fresh release build behaves correctly: the per-agent board shows one chat per routine with all runs aggregated. So #386 itself is sound.

## The real bug this fixes
#386 made the engine aggregate every run under a stable `session_key = routine-{rid}` and reuse one activity per routine. The **per-agent board** honors that (it reads the activity's stored `session_key`). But the **cross-agent Mission Control** list did not, so routine chats opened **empty there**:

1. `engine/houston-engine-core/src/conversations.rs` hardcoded `session_key = format!("activity-{}", row.id)`, discarding the activity's stored key (`ActivityRow` didn't even deserialize it). A routine card was addressed as `activity-{aid}`, but its feed lives under `routine-{rid}` → `history::load` resolved an empty `.history`.
2. `app/src/components/use-mission-control.ts` recovered the agent path by stripping an `"activity-"` prefix. For `routine-{rid}` keys that strip is a no-op and the lookup missed → empty chat / no-op send.

## Fix
- **Engine:** read and surface the stored `session_key` verbatim; fall back to `activity-{id}` only for legacy rows with no stored key. New tests cover the routine passthrough and the legacy fallback.
- **Frontend:** build a `session_key → { agentPath, activityId }` map from the conversation list and resolve by `session_key` directly (no prefix-stripping). Covers `loadHistory`, history hydration, send, and the loading indicator.

No protocol/wire shape change: `ConversationEntry.session_key` already flowed through `conversationToRaw` unchanged.

## Test plan
- `cargo test -p houston-engine-core conversations` (new + existing pass)
- `cd app && pnpm tsc --noEmit`
- Manual: in Mission Control, run a routine twice → one card, opening it shows both runs aggregated (previously empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)