### PR TITLE
fix(providers): probe real claude-code version, disable its self-updater

### DIFF
--- a/engine/houston-claude-installer/src/lib.rs
+++ b/engine/houston-claude-installer/src/lib.rs
@@ -117,27 +117,50 @@ pub async fn ensure_and_upgrade(sink: DynEventSink, db: Database) {
 
     let pinned_version = entry.version.clone();
 
-    // Already installed at the pinned version? Skip the download.
-    let last_version = db
+    // Authoritative check: ask the binary ON DISK what version it is,
+    // instead of trusting the DB marker. The marker only records what we
+    // last installed; the binary can change out from under it — claude-code
+    // ships its own self-updater, and a user can reinstall claude-code by
+    // hand into the same path. Trusting the marker alone let a 2.1.92
+    // binary sit under a "2.1.158" marker and skip every upgrade, which is
+    // the exact drift this probe closes (2.1.92 rejects `--effort xhigh`).
+    // The marker is still read — but only for a friendlier install log and
+    // to keep `/v1/claude/status` honest.
+    let marker_version = db
         .get_preference(PREF_INSTALLED_VERSION)
         .await
         .ok()
         .flatten()
         .unwrap_or_default();
+    let on_disk_version = installed_cli_version().await;
 
-    if is_installed() && last_version == pinned_version {
+    if on_disk_version.as_deref() == Some(pinned_version.as_str()) {
         tracing::info!(
             "[claude-installer] already at pinned version {}, skipping",
             pinned_version
         );
+        // Heal a lagging marker (a prior drift we just confirmed gone, or a
+        // manual reinstall to the pinned version) so the status route stops
+        // reporting a stale value.
+        if marker_version != pinned_version {
+            if let Err(e) = db.set_preference(PREF_INSTALLED_VERSION, &pinned_version).await {
+                tracing::warn!("[claude-installer] failed to reconcile version marker: {e}");
+            }
+        }
         sink.emit(HoustonEvent::ClaudeCliReady);
         return;
     }
 
+    // Prefer the real on-disk version for the "from" label; fall back to
+    // the marker, then to "none" on a fresh install.
+    let from_label = on_disk_version
+        .as_deref()
+        .or_else(|| (!marker_version.is_empty()).then_some(marker_version.as_str()))
+        .unwrap_or("none");
     tracing::info!(
         "[claude-installer] installing claude-code v{} ({} → {})",
         pinned_version,
-        if last_version.is_empty() { "none" } else { &last_version },
+        from_label,
         pinned_version
     );
 
@@ -210,6 +233,49 @@ pub async fn install_pinned(
     let version = entry.version.clone();
     let path = install(&entry, progress).await?;
     Ok((version, path))
+}
+
+/// Probe the version of the claude binary actually on disk by running
+/// `<cli_path> --version`. Returns `None` when the binary is missing or
+/// the probe fails for any reason (spawn error, non-zero exit, timeout,
+/// unparseable output) — each of those means "we can't confirm the pinned
+/// version is installed", so the caller treats `None` as needs-install and
+/// re-downloads.
+///
+/// This is the authoritative source of truth for "what version is on
+/// disk", replacing blind trust in the DB marker (`PREF_INSTALLED_VERSION`),
+/// which silently drifts when claude-code's self-updater or a manual
+/// reinstall swaps the binary. claude-code prints `2.1.158 (Claude Code)`
+/// to stdout; we keep the leading token.
+async fn installed_cli_version() -> Option<String> {
+    if !is_installed() {
+        return None;
+    }
+    // claude-code prints its version to stdout and exits immediately, but a
+    // cold spawn of the ~240 MB binary on Windows isn't free — bound it so a
+    // wedged binary can never hang the boot-time CLI lifecycle task.
+    let output = tokio::time::timeout(
+        std::time::Duration::from_secs(10),
+        tokio::process::Command::new(cli_path())
+            .arg("--version")
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .ok()? // timed out
+    .ok()?; // spawn / IO error
+    if !output.status.success() {
+        return None;
+    }
+    parse_cli_version(&String::from_utf8_lossy(&output.stdout))
+}
+
+/// Extract the semver from `claude --version` output, e.g.
+/// `"2.1.158 (Claude Code)\n"` → `"2.1.158"`. Returns `None` for empty or
+/// whitespace-only output so a garbled probe degrades to needs-install
+/// rather than matching nothing.
+fn parse_cli_version(raw: &str) -> Option<String> {
+    raw.split_whitespace().next().map(str::to_string)
 }
 
 /// Resolve the `cli-deps.json` manifest. Prefers the bundled copy
@@ -455,6 +521,34 @@ mod tests {
         assert!(checksum_matches("DEADBEEF", "deadbeef"));
         assert!(checksum_matches("abc123", "abc123"));
         assert!(!checksum_matches("abc", "abd"));
+    }
+
+    #[test]
+    fn parse_cli_version_extracts_leading_semver() {
+        // The real `claude --version` shape — the drift check compares the
+        // leading token to the pinned version, so it must drop the suffix.
+        assert_eq!(
+            parse_cli_version("2.1.158 (Claude Code)\n").as_deref(),
+            Some("2.1.158")
+        );
+        assert_eq!(
+            parse_cli_version("2.1.92 (Claude Code)").as_deref(),
+            Some("2.1.92")
+        );
+        // Leading/trailing whitespace must not leak into the token, or the
+        // `== pinned_version` compare would spuriously fail and re-download.
+        assert_eq!(
+            parse_cli_version("  2.1.158  \n").as_deref(),
+            Some("2.1.158")
+        );
+    }
+
+    #[test]
+    fn parse_cli_version_rejects_empty_output() {
+        // A garbled / empty probe must be None so the caller re-installs,
+        // never treats "" as a version that could match the pin.
+        assert_eq!(parse_cli_version(""), None);
+        assert_eq!(parse_cli_version("   \n\t "), None);
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/claude_runner.rs
+++ b/engine/houston-terminal-manager/src/claude_runner.rs
@@ -178,6 +178,19 @@ fn configure_claude_command(
     disable_all_tools: bool,
 ) {
     cmd.env("PATH", super::claude_path::shell_path());
+
+    // Houston pins an exact claude-code version in `cli-deps.json` and
+    // manages the managed binary itself (download + sha256-verify +
+    // atomic install via `houston-claude-installer`). claude-code's own
+    // self-updater fights that: left enabled, it swaps the binary out
+    // from under our pin on its own schedule, leaving a stale/mismatched
+    // version on disk (and `.bak` files in the install dir). That drift
+    // is exactly how a 2.1.92 binary ended up under a "2.1.158" install
+    // marker, breaking `--effort xhigh` (only added after 2.1.92). Houston
+    // must be the sole manager of the pinned binary, so disable the
+    // updater on every spawn.
+    cmd.env("DISABLE_AUTOUPDATER", "1");
+
     cmd.arg("-p")
         .arg("--output-format")
         .arg("stream-json")

--- a/knowledge-base/cli-bundling.md
+++ b/knowledge-base/cli-bundling.md
@@ -236,11 +236,29 @@ boot:
 
 2. `houston_claude_installer::ensure_and_upgrade` — reads
    `cli-deps.json` for the pinned `claude-code` version and:
-   - If installed at the pinned version → emit `ClaudeCliReady`.
+   - Probes the **actual on-disk** version by running
+     `<cli_path> --version` (`installed_cli_version()`), and compares the
+     leading token to the pinned version. This is the source of truth —
+     **not** the DB marker. If they match → emit `ClaudeCliReady` (and
+     reconcile a lagging marker so `/v1/claude/status` stays honest).
    - Else → stream-download with sha256 verification, atomic rename
-     into `~/.local/bin/claude`, persist version marker, emit
+     into `~/.local/bin/claude` (Win: `%LOCALAPPDATA%\Programs\claude\
+     claude.exe`), persist version marker, emit
      `ClaudeCliInstalling { progress_pct }` then `ClaudeCliReady`.
    - On failure → `ClaudeCliFailed { message }`.
+
+   **Why probe instead of trusting `claude_code_installed_version`?** The
+   marker only records what Houston *last installed*; the binary drifts
+   out from under it (claude-code's own self-updater swapping it, a manual
+   reinstall, a `.bak` rollback). A drifted 2.1.92 binary once sat under a
+   "2.1.158" marker and `--effort xhigh` died on every session because the
+   marker-trust skip never re-downloaded (PR #359 pinned 2.1.158, but it
+   never landed on disk). The probe self-heals that on the next boot.
+
+   **Houston is the sole manager of the pinned binary.** `claude_runner`
+   sets `DISABLE_AUTOUPDATER=1` on every spawn so claude-code's own updater
+   can't swap the pinned binary out from under `cli-deps.json`. Without it,
+   the updater mutates the binary on its schedule and the version drifts.
 
 Both run on independent tasks so a slow claude download never blocks
 composio readiness.


### PR DESCRIPTION
## Problem

Opus 4.7/4.8 with `--effort xhigh` die with `Session error: claude hit a runtime error` in **prod and dev** — the same failure #359 fixed, regressed.

Root cause: the managed claude-code binary is **2.1.92** (which rejects `xhigh`), but the engine-DB marker `claude_code_installed_version` says **2.1.158**. `ensure_and_upgrade` trusted the marker (`is_installed() && marker == pinned`) and skipped the upgrade **every boot**, so the pin from #359 never landed on disk. The binary drifts because Houston spawns claude-code **without disabling its self-updater**, which swaps the binary out-of-band (leaving `.bak` files in the install dir).

Verified on a Windows host:

- `…\Programs\claude\claude.exe --version` → `2.1.92` (size 240482464 = the 2.1.92 dist manifest exactly)
- engine log, every boot: `[claude-installer] already at pinned version 2.1.158, skipping`
- `cli-deps.json` pin + checksums for 2.1.158 are correct (match the dist `manifest.json` byte-for-byte) — **the pin was never the problem**, the upgrade just never ran.

## Fix

- **`houston-claude-installer`** — `ensure_and_upgrade` now probes the **actual** on-disk version (`installed_cli_version()` runs `claude --version`) and compares the leading token to the pin. The DB marker is demoted to a hint and reconciled when it lags. Drift self-heals: a mismatched or absent binary re-downloads the pinned version on next boot.
- **`houston-terminal-manager` (`claude_runner`)** — set `DISABLE_AUTOUPDATER=1` on every spawn so claude-code's updater can no longer mutate the pinned binary. Houston becomes the sole manager of the managed install.
- **`knowledge-base/cli-bundling.md`** — documented both, with the drift story.

> Note: `DISABLE_AUTOUPDATER=1` is the known claude-code env var; worth a quick confirm against 2.1.158's docs before release. Even if the name were stale, Fix A re-pins every boot, so `xhigh` stays fixed regardless.

## Affected files

- `engine/houston-claude-installer/src/lib.rs` — on-disk version probe + marker reconcile + 2 unit tests
- `engine/houston-terminal-manager/src/claude_runner.rs` — `DISABLE_AUTOUPDATER=1` on spawn
- `knowledge-base/cli-bundling.md` — lifecycle docs

## Test plan

- `cargo test -p houston-claude-installer` — 10 pass, incl. new `parse_cli_version_*` tests
- `cargo test -p houston-terminal-manager` — 218 pass
- `cargo build -p houston-engine-server` — clean
- Manual: delete the drifted managed binary → next boot probes `None`/mismatch → re-installs 2.1.158 → Opus 4.8 + `xhigh` runs without the runtime error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
