### PR TITLE
fix: align Mission Control chats with agent board

### DIFF
--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AIBoard } from "@houston-ai/board";
-import type { KanbanColumnConfig, NewPanelOpener } from "@houston-ai/board";
+import type { KanbanColumnConfig, KanbanItem, NewPanelOpener } from "@houston-ai/board";
 import {
   Empty,
   EmptyHeader,
@@ -12,8 +12,11 @@ import {
 import { Plus } from "lucide-react";
 import { useAgentStore } from "../stores/agents";
 import { useAgentCatalogStore } from "../stores/agent-catalog";
+import { useDraftStore } from "../stores/drafts";
 import { useUIStore } from "../stores/ui";
 import { tauriChat } from "../lib/tauri";
+import { openAgentHref } from "../lib/open-href";
+import { openMissionWorktreeTerminal } from "../lib/mission-worktree";
 import { useMissionControl } from "./use-mission-control";
 import { useSessionMessageQueue } from "../hooks/use-session-message-queue";
 import { AgentPickerDialog } from "./agent-picker-dialog";
@@ -35,9 +38,13 @@ import {
   missionControlAgentPathForSession,
   missionControlSessionKeyForId,
 } from "./mission-control-session";
+import {
+  MissionWorktreeCardAction,
+  MissionWorktreePanelActions,
+} from "./mission-worktree-actions";
 
 export function Dashboard() {
-  const { t } = useTranslation(["dashboard", "board", "common"]);
+  const { t } = useTranslation(["dashboard", "board", "common", "chat"]);
   const queuedLabels = useQueuedMessageLabels();
   // Card-action tooltips (Approve / Rename / Delete) — shared with the
   // per-agent board tab so the affordance reads the same everywhere.
@@ -60,6 +67,7 @@ export function Dashboard() {
   const setOnBoardOpen = useUIStore((s) => s.setOnBoardOpen);
   const setOnPanelClose = useUIStore((s) => s.setOnPanelClose);
   const addToast = useUIStore((s) => s.addToast);
+  const rawDrafts = useDraftStore((s) => s.drafts);
 
   const [filterPath, setFilterPath] = useState("");
   const [missionSearchQuery, setMissionSearchQuery] = useState("");
@@ -221,6 +229,10 @@ export function Dashboard() {
       variant: "error",
     });
   }, [addToast, t]);
+  const handleNotice = useCallback(
+    (message: string) => addToast({ title: message }),
+    [addToast],
+  );
   const missionSearch = useMissionSearch({
     items: agentFilteredItems,
     query: missionSearchQuery,
@@ -275,6 +287,13 @@ export function Dashboard() {
     }
     return pendingAgent;
   }, [selectedItem, pendingAgent, agents]);
+  const handleOpenLink = useCallback(
+    (url: string) => {
+      if (!activeAgent) return;
+      openAgentHref(url, activeAgent.folderPath);
+    },
+    [activeAgent],
+  );
   const activeAgentDef = activeAgent ? getAgentDef(activeAgent.configId) ?? null : null;
   const selectedSessionKey = selectedItem
     ? (selectedItem.metadata?.sessionKey as string | undefined) ?? `activity-${selectedItem.id}`
@@ -365,6 +384,58 @@ export function Dashboard() {
     () => selectedSessionKey ? { [selectedSessionKey]: messageQueue.queuedMessages } : {},
     [selectedSessionKey, messageQueue.queuedMessages],
   );
+  const boardDrafts = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(rawDrafts)) {
+      if (value.text) out[key] = value.text;
+    }
+    return out;
+  }, [rawDrafts]);
+  const handleDraftChange = useCallback((sessionKey: string, text: string) => {
+    useDraftStore.getState().setDraftText(sessionKey, text);
+  }, []);
+  const handleRunInTerminal = useCallback(
+    async (item: KanbanItem) => {
+      const wtPath = item.metadata?.worktreePath as string | undefined;
+      const agentPath = item.metadata?.agentPath as string | undefined;
+      if (!wtPath || !agentPath) return;
+      try {
+        await openMissionWorktreeTerminal(agentPath, wtPath);
+      } catch (err) {
+        addToast({
+          title: t("board:cardActions.openTerminalFailed", { error: String(err) }),
+          variant: "error",
+        });
+      }
+    },
+    [addToast, t],
+  );
+  const cardActions = useCallback(
+    (item: KanbanItem) => (
+      <MissionWorktreeCardAction
+        item={item}
+        labels={{
+          openTerminal: t("board:cardActions.openTerminal"),
+          run: t("board:cardActions.run"),
+        }}
+        onRun={handleRunInTerminal}
+      />
+    ),
+    [handleRunInTerminal, t],
+  );
+  const panelActions = useCallback(
+    (item: KanbanItem) => (
+      <MissionWorktreePanelActions
+        item={item}
+        labels={{
+          openTerminal: t("board:cardActions.openTerminal"),
+          run: t("board:cardActions.run"),
+        }}
+        onRun={handleRunInTerminal}
+      />
+    ),
+    [handleRunInTerminal, t],
+  );
 
   if (agents.length === 0) {
     return (
@@ -449,8 +520,20 @@ export function Dashboard() {
           panelContainer={panelContainer}
           onPanelOpenChange={setMissionPanelOpen}
           onStopSession={handleStopSession}
+          drafts={boardDrafts}
+          onDraftChange={handleDraftChange}
+          onNotice={handleNotice}
+          composerLabels={{
+            fileAlreadyInChat: t("chat:composer.fileAlreadyInChat"),
+            dropTitle: t("chat:composer.dropTitle"),
+            dropDescription: t("chat:composer.dropDescription"),
+            imagePasteUnavailable: t("chat:composer.imagePasteUnavailable"),
+          }}
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
+          onOpenLink={handleOpenLink}
+          actions={cardActions}
+          panelActions={panelActions}
           panelAgentName={activeAgent?.name ?? selectedItem?.subtitle}
           panelAvatar={
             <AgentPanelAvatar

--- a/app/src/components/dashboard.tsx
+++ b/app/src/components/dashboard.tsx
@@ -31,6 +31,10 @@ import { useMissionSearch } from "./use-mission-search";
 import { buildMissionBoardColumns } from "./mission-board-columns";
 import { navigateBoard } from "../lib/board-navigate";
 import { planNewMission } from "./mission-control-create";
+import {
+  missionControlAgentPathForSession,
+  missionControlSessionKeyForId,
+} from "./mission-control-session";
 
 export function Dashboard() {
   const { t } = useTranslation(["dashboard", "board", "common"]);
@@ -176,13 +180,16 @@ export function Dashboard() {
 
   const handleStopSession = useCallback(
     (sessionKey: string) => {
-      const activityId = sessionKey.replace("activity-", "");
-      const item = mc.items.find((i) => i.id === activityId);
-      const agentPath = item?.metadata?.agentPath as string | undefined;
+      const agentPath = missionControlAgentPathForSession(mc.items, sessionKey);
       if (!agentPath) return;
-      tauriChat.stop(agentPath, sessionKey).catch(console.error);
+      tauriChat.stop(agentPath, sessionKey).catch((err) => {
+        addToast({
+          title: t("dashboard:errors.stopSession", { error: String(err) }),
+          variant: "error",
+        });
+      });
     },
-    [mc.items],
+    [mc.items, addToast, t],
   );
 
   // Build agentPath → color lookup from agent instances
@@ -310,6 +317,10 @@ export function Dashboard() {
     },
     [mc.handleSendMessage, selectedSessionKey, messageQueue.sendOrQueue],
   );
+  const sessionKeyFor = useCallback(
+    (activityId: string) => missionControlSessionKeyForId(mc.items, activityId),
+    [mc.items],
+  );
   const handleComposerSubmit = useCallback<NonNullable<typeof panel.onComposerSubmit>>(
     async (ctx) => {
       if (ctx.sessionKey && ctx.sessionKey === selectedSessionKey && selectedSessionActive) {
@@ -426,6 +437,7 @@ export function Dashboard() {
           onRename={mc.handleRename}
           onCreateConversation={handleCreateConversation}
           onSendMessage={handleSendMessage}
+          sessionKeyFor={sessionKeyFor}
           queuedMessages={queuedMessages}
           onRemoveQueuedMessage={(_, id) => messageQueue.removeQueuedMessage(id)}
           queuedLabels={queuedLabels}

--- a/app/src/components/mission-control-send.ts
+++ b/app/src/components/mission-control-send.ts
@@ -24,6 +24,7 @@ import { normalizeLegacyModel } from "../lib/providers.ts";
 /** Minimal shape needed for override resolution; mirrors `ActivityItem`. */
 export interface ActivityOverrideSource {
   id: string;
+  session_key?: string;
   provider?: string;
   model?: string;
 }
@@ -50,7 +51,10 @@ export function resolveActivityOverride(
   activities: ActivityOverrideSource[] | undefined,
 ): SendOverrides {
   const activityId = sessionKey.replace(/^activity-/, "");
-  const activity = activities?.find((a) => a.id === activityId);
+  const activity = activities?.find((a) => {
+    if (a.session_key && a.session_key === sessionKey) return true;
+    return sessionKey.startsWith("activity-") && a.id === activityId;
+  });
   if (!activity) return {};
   return {
     providerOverride: activity.provider,

--- a/app/src/components/mission-control-session.ts
+++ b/app/src/components/mission-control-session.ts
@@ -1,0 +1,30 @@
+import type { KanbanItem } from "@houston-ai/board";
+
+type MissionControlSessionItem = Pick<KanbanItem, "id" | "metadata">;
+
+function metadataString(item: MissionControlSessionItem, key: string): string | undefined {
+  const value = item.metadata?.[key];
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function missionControlSessionKey(item: MissionControlSessionItem): string {
+  return metadataString(item, "sessionKey") ?? `activity-${item.id}`;
+}
+
+export function missionControlSessionKeyForId(
+  items: MissionControlSessionItem[],
+  activityId: string,
+): string {
+  const item = items.find((candidate) => candidate.id === activityId);
+  return item ? missionControlSessionKey(item) : `activity-${activityId}`;
+}
+
+export function missionControlAgentPathForSession(
+  items: MissionControlSessionItem[],
+  sessionKey: string,
+): string | undefined {
+  const item = items.find(
+    (candidate) => missionControlSessionKey(candidate) === sessionKey,
+  );
+  return item ? metadataString(item, "agentPath") : undefined;
+}

--- a/app/src/components/mission-worktree-actions.tsx
+++ b/app/src/components/mission-worktree-actions.tsx
@@ -1,0 +1,70 @@
+import type { KanbanItem } from "@houston-ai/board";
+import { GitBranch, Terminal } from "lucide-react";
+
+interface MissionWorktreeActionLabels {
+  openTerminal: string;
+  run: string;
+}
+
+function worktreePath(item: KanbanItem): string | undefined {
+  const value = item.metadata?.worktreePath;
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+export function MissionWorktreeCardAction({
+  item,
+  labels,
+  onRun,
+}: {
+  item: KanbanItem;
+  labels: MissionWorktreeActionLabels;
+  onRun: (item: KanbanItem) => void;
+}) {
+  if (!worktreePath(item)) return null;
+  return (
+    <button
+      onClick={(e) => {
+        e.stopPropagation();
+        onRun(item);
+      }}
+      className="flex items-center gap-0.5 h-5 px-1.5 rounded-full bg-secondary text-foreground text-[10px] font-medium hover:bg-accent transition-colors duration-200"
+      title={labels.openTerminal}
+    >
+      <Terminal className="size-2.5" />
+      {labels.run}
+    </button>
+  );
+}
+
+export function MissionWorktreePanelActions({
+  item,
+  labels,
+  onRun,
+}: {
+  item: KanbanItem;
+  labels: MissionWorktreeActionLabels;
+  onRun: (item: KanbanItem) => void;
+}) {
+  const path = worktreePath(item);
+  if (!path) return null;
+  const label = path.split("/").pop() ?? path;
+  return (
+    <div className="flex items-center gap-1.5">
+      <span
+        className="flex items-center gap-1 h-5 px-1.5 rounded-full bg-secondary text-muted-foreground text-[10px] font-medium truncate max-w-[160px]"
+        title={path}
+      >
+        <GitBranch className="size-2.5 shrink-0" />
+        {label}
+      </span>
+      <button
+        onClick={() => onRun(item)}
+        className="flex items-center gap-0.5 h-5 px-1.5 rounded-full bg-secondary text-foreground text-[10px] font-medium hover:bg-accent transition-colors duration-200"
+        title={labels.openTerminal}
+      >
+        <Terminal className="size-2.5" />
+        {labels.run}
+      </button>
+    </div>
+  );
+}

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -22,9 +22,10 @@ import {
   useUpdateActivity,
 } from "../../hooks/queries";
 import { useAgentChatPanel } from "../use-agent-chat-panel";
-import { tauriActivity, tauriChat, tauriAttachments, tauriWorktree, tauriShell, tauriTerminal, tauriConfig, tauriPreferences } from "../../lib/tauri";
+import { tauriActivity, tauriChat, tauriAttachments, tauriTerminal, tauriConfig, tauriPreferences } from "../../lib/tauri";
 import { openAgentHref } from "../../lib/open-href";
 import { createMission } from "../../lib/create-mission";
+import { createMissionWorktreeIfEnabled } from "../../lib/mission-worktree";
 import { formatVisibleMessageText } from "../../lib/queued-chat";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { queryKeys } from "../../lib/query-keys";
@@ -639,21 +640,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
       const agentMode = pendingAgentMode ?? agentModes?.[0]?.id;
       const mode = agentModes?.find((m) => m.id === agentMode);
 
-      // Check if worktree mode is enabled
-      let worktreePath: string | undefined;
-      try {
-        const cfg = await tauriConfig.read(path);
-        if (cfg.worktreeMode) {
-          const slug = crypto.randomUUID().slice(0, 8);
-          const wt = await tauriWorktree.create(path, slug);
-          worktreePath = wt.path;
-          // Run install command in the new worktree
-          const installCmd = cfg.installCommand as string | undefined;
-          if (installCmd && worktreePath) {
-            tauriShell.run(worktreePath, installCmd).catch(console.error);
-          }
-        }
-      } catch { /* config may not exist yet */ }
+      const worktreePath = await createMissionWorktreeIfEnabled(path);
 
       // Single source of truth for activity creation + session start. The
       // buildPrompt callback fires after the activity row exists so we can

--- a/app/src/components/tabs/board-tab.tsx
+++ b/app/src/components/tabs/board-tab.tsx
@@ -5,7 +5,6 @@ import { AIBoard } from "@houston-ai/board";
 import type { KanbanItem, NewPanelOpener } from "@houston-ai/board";
 import { mergeFeedHistory } from "@houston-ai/chat";
 import type { FeedItem } from "@houston-ai/chat";
-import { Terminal, GitBranch } from "lucide-react";
 
 import { useFeedStore } from "../../stores/feeds";
 import { useUIStore } from "../../stores/ui";
@@ -22,10 +21,13 @@ import {
   useUpdateActivity,
 } from "../../hooks/queries";
 import { useAgentChatPanel } from "../use-agent-chat-panel";
-import { tauriActivity, tauriChat, tauriAttachments, tauriTerminal, tauriConfig, tauriPreferences } from "../../lib/tauri";
+import { tauriActivity, tauriChat, tauriAttachments } from "../../lib/tauri";
 import { openAgentHref } from "../../lib/open-href";
 import { createMission } from "../../lib/create-mission";
-import { createMissionWorktreeIfEnabled } from "../../lib/mission-worktree";
+import {
+  createMissionWorktreeIfEnabled,
+  openMissionWorktreeTerminal,
+} from "../../lib/mission-worktree";
 import { formatVisibleMessageText } from "../../lib/queued-chat";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { queryKeys } from "../../lib/query-keys";
@@ -47,6 +49,11 @@ import { SelectAllButton } from "../select-all-button";
 import { selectActive, moveTargetsForSection, areAllSelected } from "../../lib/mission-selection";
 import { navigateBoard } from "../../lib/board-navigate";
 import { resolvePendingActivitySelection } from "../../lib/notification-nav";
+import { missionCardTags } from "../../lib/mission-card";
+import {
+  MissionWorktreeCardAction,
+  MissionWorktreePanelActions,
+} from "../mission-worktree-actions";
 
 // Stable empty reference so the feed store selector doesn't return a new
 // object every render when this agent has no feeds yet (which would otherwise
@@ -226,25 +233,29 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
   );
 
   const items: KanbanItem[] = useMemo(
-    () => activeRaw.map((t) => {
-      const mode = agentModes?.find((m) => m.id === t.agent);
+    () => activeRaw.map((activity) => {
       return {
-        id: t.id,
-        title: t.title,
-        description: t.description,
-        status: t.status,
-        updatedAt: t.updated_at ?? new Date().toISOString(),
+        id: activity.id,
+        title: activity.title,
+        description: activity.description,
+        status: activity.status,
+        updatedAt: activity.updated_at ?? new Date().toISOString(),
         group: agent.name,
-        tags: mode ? [mode.name] : (t.routine_id ? ["Routine"] : undefined),
+        tags: missionCardTags({
+          agent: activity.agent,
+          agentModes,
+          routineId: activity.routine_id,
+          routineLabel: t("board:tags.routine"),
+        }),
         metadata: {
-          ...(t.session_key ? { sessionKey: t.session_key } : {}),
-          ...(t.routine_id ? { routineId: t.routine_id } : {}),
-          ...(t.agent ? { agent: t.agent } : {}),
-          ...(t.worktree_path ? { worktreePath: t.worktree_path } : {}),
+          ...(activity.session_key ? { sessionKey: activity.session_key } : {}),
+          ...(activity.routine_id ? { routineId: activity.routine_id } : {}),
+          ...(activity.agent ? { agent: activity.agent } : {}),
+          ...(activity.worktree_path ? { worktreePath: activity.worktree_path } : {}),
         },
       };
     }),
-    [agent.name, agentModes, activeRaw],
+    [agent.name, agentModes, activeRaw, t],
   );
 
   // Read and consume pending selection from Mission Control
@@ -787,60 +798,43 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
     async (item: KanbanItem) => {
       const wtPath = item.metadata?.worktreePath as string | undefined;
       if (!wtPath) return;
-      let devCmd: string | undefined;
       try {
-        const cfg = await tauriConfig.read(path);
-        devCmd = cfg.devCommand as string | undefined;
-      } catch { /* ignore */ }
-      const terminal = await tauriPreferences.get("terminal") ?? undefined;
-      tauriTerminal.open(wtPath, devCmd, terminal).catch(console.error);
+        await openMissionWorktreeTerminal(path, wtPath);
+      } catch (err) {
+        addToast({
+          title: t("board:cardActions.openTerminalFailed", { error: String(err) }),
+          variant: "error",
+        });
+      }
     },
-    [path],
+    [path, addToast, t],
   );
 
   const cardActions = useCallback(
-    (item: KanbanItem) => {
-      const wtPath = item.metadata?.worktreePath as string | undefined;
-      if (!wtPath) return undefined;
-      return (
-        <button
-          onClick={(e) => { e.stopPropagation(); handleRunInTerminal(item); }}
-          className="flex items-center gap-0.5 h-5 px-1.5 rounded-full bg-secondary text-foreground text-[10px] font-medium hover:bg-accent transition-colors duration-200"
-          title={t("cardActions.openTerminal")}
-        >
-          <Terminal className="size-2.5" />
-          {t("cardActions.run")}
-        </button>
-      );
-    },
+    (item: KanbanItem) => (
+      <MissionWorktreeCardAction
+        item={item}
+        labels={{
+          openTerminal: t("board:cardActions.openTerminal"),
+          run: t("board:cardActions.run"),
+        }}
+        onRun={handleRunInTerminal}
+      />
+    ),
     [handleRunInTerminal, t],
   );
 
   const panelActions = useCallback(
-    (item: KanbanItem) => {
-      const wtPath = item.metadata?.worktreePath as string | undefined;
-      if (!wtPath) return undefined;
-      const label = wtPath.split("/").pop() ?? wtPath;
-      return (
-        <div className="flex items-center gap-1.5">
-          <span
-            className="flex items-center gap-1 h-5 px-1.5 rounded-full bg-secondary text-muted-foreground text-[10px] font-medium truncate max-w-[160px]"
-            title={wtPath}
-          >
-            <GitBranch className="size-2.5 shrink-0" />
-            {label}
-          </span>
-          <button
-            onClick={() => handleRunInTerminal(item)}
-            className="flex items-center gap-0.5 h-5 px-1.5 rounded-full bg-secondary text-foreground text-[10px] font-medium hover:bg-accent transition-colors duration-200"
-            title={t("cardActions.openTerminal")}
-          >
-            <Terminal className="size-2.5" />
-            {t("cardActions.run")}
-          </button>
-        </div>
-      );
-    },
+    (item: KanbanItem) => (
+      <MissionWorktreePanelActions
+        item={item}
+        labels={{
+          openTerminal: t("board:cardActions.openTerminal"),
+          run: t("board:cardActions.run"),
+        }}
+        onRun={handleRunInTerminal}
+      />
+    ),
     [handleRunInTerminal, t],
   );
 
@@ -917,7 +911,7 @@ export default function BoardTab({ agent, agentDef }: TabProps) {
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           onOpenLink={handleOpenLink}
-          actions={agentModes ? cardActions : undefined}
+          actions={cardActions}
           panelActions={panelActions}
           cardAvatar={<AgentCardAvatar color={agent.color} />}
           thinkingIndicator={<HoustonThinkingIndicator />}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -44,11 +44,10 @@ import {
   tauriChat,
   tauriConfig,
   tauriProvider,
-  tauriShell,
-  tauriWorktree,
   withAttachmentPaths,
 } from "../lib/tauri";
 import { createMission } from "../lib/create-mission";
+import { createMissionWorktreeIfEnabled } from "../lib/mission-worktree";
 import { queryKeys } from "../lib/query-keys";
 import { humanizeSkillName } from "../lib/humanize-skill-name";
 import { useFileToolRenderer } from "../hooks/use-file-tool-renderer";
@@ -440,23 +439,7 @@ export function useAgentChatPanel({
         const mode = agentModes?.find((m) => m.id === agentMode);
         let encodedUserMessage = encoded;
 
-        // Honour worktree mode if the agent's config opts in. Same
-        // bootstrap as BoardTab's text-send path.
-        let worktreePath: string | undefined;
-        try {
-          const cfg = await tauriConfig.read(path);
-          if (cfg.worktreeMode) {
-            const slug = crypto.randomUUID().slice(0, 8);
-            const wt = await tauriWorktree.create(path, slug);
-            worktreePath = wt.path;
-            const installCmd = cfg.installCommand as string | undefined;
-            if (installCmd && worktreePath) {
-              tauriShell.run(worktreePath, installCmd).catch(console.error);
-            }
-          }
-        } catch {
-          /* config may not exist yet */
-        }
+        const worktreePath = await createMissionWorktreeIfEnabled(path);
 
         const { conversationId, sessionKey } = await createMission(
           {

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -15,12 +15,10 @@ import {
   tauriActivity,
   tauriChat,
   tauriAttachments,
-  tauriConfig,
-  tauriWorktree,
-  tauriShell,
 } from "../lib/tauri";
 import { buildAttachmentPrompt } from "../lib/attachment-message";
 import { createMission } from "../lib/create-mission";
+import { createMissionWorktreeIfEnabled } from "../lib/mission-worktree";
 import { resolveActivityOverride } from "./mission-control-send";
 import { formatVisibleMessageText } from "../lib/queued-chat";
 import { queryKeys } from "../lib/query-keys";
@@ -218,31 +216,14 @@ export function useMissionControl(agents: Agent[]) {
     ): Promise<string> => {
       const agentPath = agent.folderPath;
 
-      // Honour worktree mode when the agent's config opts in — same
-      // bootstrap as the BoardTab create path.
-      let worktreePath: string | undefined;
       try {
-        const cfg = await tauriConfig.read(agentPath);
-        if (cfg.worktreeMode) {
-          const slug = crypto.randomUUID().slice(0, 8);
-          const wt = await tauriWorktree.create(agentPath, slug);
-          worktreePath = wt.path;
-          const installCmd = cfg.installCommand as string | undefined;
-          if (installCmd && worktreePath) {
-            tauriShell.run(worktreePath, installCmd).catch(console.error);
-          }
-        }
-      } catch {
-        /* config may not exist yet */
-      }
-
-      const visible = formatVisibleMessageText(
-        text,
-        files,
-        (names) => t("queue.attached", { names }),
-      );
-      let userMessage = text;
-      try {
+        const worktreePath = await createMissionWorktreeIfEnabled(agentPath);
+        const visible = formatVisibleMessageText(
+          text,
+          files,
+          (names) => t("queue.attached", { names }),
+        );
+        let userMessage = text;
         const { conversationId, sessionKey } = await createMission(
           { id: agent.id, name: agent.name, color: agent.color, folderPath: agentPath },
           text,

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -11,6 +11,7 @@ import {
 } from "../stores/session-status";
 import { useQueryClient } from "@tanstack/react-query";
 import { useAllConversations } from "../hooks/queries";
+import { useAgentCatalogStore } from "../stores/agent-catalog";
 import {
   tauriActivity,
   tauriChat,
@@ -22,15 +23,17 @@ import { createMissionWorktreeIfEnabled } from "../lib/mission-worktree";
 import { resolveActivityOverride } from "./mission-control-send";
 import { formatVisibleMessageText } from "../lib/queued-chat";
 import { queryKeys } from "../lib/query-keys";
+import { missionCardTags } from "../lib/mission-card";
 import { useUIStore } from "../stores/ui";
 import type { Agent } from "../lib/types";
 import { createElement } from "react";
 import { AgentCardAvatar } from "./shell/agent-card-avatar";
 
 export function useMissionControl(agents: Agent[]) {
-  const { t } = useTranslation("chat");
+  const { t } = useTranslation(["chat", "board"]);
   const queryClient = useQueryClient();
   const addToast = useUIStore((s) => s.addToast);
+  const getAgentDef = useAgentCatalogStore((s) => s.getById);
   // Mission control is cross-agent. Flatten the nested feed store into a
   // single sessionKey → items map, filtered to the agents on this view.
   const allItems = useFeedStore((s) => s.items);
@@ -74,6 +77,11 @@ export function useMissionControl(agents: Agent[]) {
     for (const a of agents) m[a.folderPath] = a.color;
     return m;
   }, [agents]);
+  const agentMap = useMemo(() => {
+    const m: Record<string, Agent> = {};
+    for (const a of agents) m[a.folderPath] = a;
+    return m;
+  }, [agents]);
 
   const items: KanbanItem[] = useMemo(() => {
     if (!convos) return [];
@@ -84,6 +92,8 @@ export function useMissionControl(agents: Agent[]) {
       // the cross-agent active board.
       .filter((c) => c.type === "activity" && c.status && c.status !== "archived")
       .map((c) => {
+        const agent = agentMap[c.agent_path];
+        const agentModes = agent ? getAgentDef(agent.configId)?.config.agents : undefined;
         map[c.id] = c.agent_path;
         sessionMap[c.session_key] = { agentPath: c.agent_path, activityId: c.id };
         return {
@@ -94,13 +104,25 @@ export function useMissionControl(agents: Agent[]) {
           icon: createElement(AgentCardAvatar, { color: agentColorMap[c.agent_path] }),
           status: c.status!,
           updatedAt: c.updated_at ?? new Date().toISOString(),
-          metadata: { agentPath: c.agent_path, sessionKey: c.session_key },
+          tags: missionCardTags({
+            agent: c.agent,
+            agentModes,
+            routineId: c.routine_id,
+            routineLabel: t("board:tags.routine"),
+          }),
+          metadata: {
+            agentPath: c.agent_path,
+            sessionKey: c.session_key,
+            ...(c.agent ? { agent: c.agent } : {}),
+            ...(c.routine_id ? { routineId: c.routine_id } : {}),
+            ...(c.worktree_path ? { worktreePath: c.worktree_path } : {}),
+          },
         };
       });
     pathMapRef.current = map;
     sessionMapRef.current = sessionMap;
     return result;
-  }, [convos, agentColorMap]);
+  }, [convos, agentColorMap, agentMap, getAgentDef, t]);
 
   const loadHistory = useCallback(
     async (sessionKey: string): Promise<FeedItem[]> => {

--- a/app/src/lib/mission-card.ts
+++ b/app/src/lib/mission-card.ts
@@ -1,0 +1,18 @@
+import type { AgentMode } from "./types";
+
+export function missionCardTags({
+  agent,
+  agentModes,
+  routineId,
+  routineLabel,
+}: {
+  agent?: string | null;
+  agentModes?: Pick<AgentMode, "id" | "name">[];
+  routineId?: string | null;
+  routineLabel: string;
+}): string[] | undefined {
+  const mode = agentModes?.find((candidate) => candidate.id === agent);
+  if (mode) return [mode.name];
+  if (routineId) return [routineLabel];
+  return undefined;
+}

--- a/app/src/lib/mission-worktree.ts
+++ b/app/src/lib/mission-worktree.ts
@@ -1,4 +1,10 @@
-import { tauriConfig, tauriShell, tauriWorktree } from "./tauri";
+import {
+  tauriConfig,
+  tauriPreferences,
+  tauriShell,
+  tauriTerminal,
+  tauriWorktree,
+} from "./tauri";
 
 export async function createMissionWorktreeIfEnabled(
   agentPath: string,
@@ -14,4 +20,14 @@ export async function createMissionWorktreeIfEnabled(
       : undefined;
   if (installCmd) await tauriShell.run(worktree.path, installCmd);
   return worktree.path;
+}
+
+export async function openMissionWorktreeTerminal(
+  agentPath: string,
+  worktreePath: string,
+): Promise<void> {
+  const cfg = await tauriConfig.read(agentPath);
+  const devCmd = typeof cfg.devCommand === "string" ? cfg.devCommand : undefined;
+  const terminal = (await tauriPreferences.get("terminal")) ?? undefined;
+  await tauriTerminal.open(worktreePath, devCmd, terminal);
 }

--- a/app/src/lib/mission-worktree.ts
+++ b/app/src/lib/mission-worktree.ts
@@ -1,0 +1,17 @@
+import { tauriConfig, tauriShell, tauriWorktree } from "./tauri";
+
+export async function createMissionWorktreeIfEnabled(
+  agentPath: string,
+): Promise<string | undefined> {
+  const cfg = await tauriConfig.read(agentPath);
+  if (!cfg.worktreeMode) return undefined;
+
+  const slug = crypto.randomUUID().slice(0, 8);
+  const worktree = await tauriWorktree.create(agentPath, slug);
+  const installCmd =
+    typeof cfg.installCommand === "string" && cfg.installCommand.trim().length > 0
+      ? cfg.installCommand
+      : undefined;
+  if (installCmd) await tauriShell.run(worktree.path, installCmd);
+  return worktree.path;
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -522,6 +522,9 @@ interface RawConversation {
   updated_at?: string;
   agent_path: string;
   agent_name: string;
+  agent?: string;
+  routine_id?: string;
+  worktree_path?: string | null;
 }
 
 export const tauriConversations = {
@@ -548,6 +551,9 @@ function conversationToRaw(
     updated_at: c.updated_at,
     agent_path: c.agent_path,
     agent_name: c.agent_name,
+    agent: c.agent,
+    routine_id: c.routine_id,
+    worktree_path: c.worktree_path,
   };
 }
 

--- a/app/src/locales/en/board.json
+++ b/app/src/locales/en/board.json
@@ -6,11 +6,15 @@
     "approveTooltip": "Move to done",
     "renameTooltip": "Change title",
     "deleteTooltip": "Delete",
-    "select": "Select mission"
+    "select": "Select mission",
+    "openTerminalFailed": "Couldn't open the terminal: {{error}}"
   },
   "deleteCard": {
     "titleWithName": "Delete \"{{name}}\"?",
     "description": "This item and its history will be permanently removed."
+  },
+  "tags": {
+    "routine": "Routine"
   },
   "empty": {
     "title": "No conversations yet",

--- a/app/src/locales/en/dashboard.json
+++ b/app/src/locales/en/dashboard.json
@@ -31,7 +31,8 @@
     "cta": "New Agent"
   },
   "errors": {
-    "noAgentForMission": "Pick an agent before starting a mission."
+    "noAgentForMission": "Pick an agent before starting a mission.",
+    "stopSession": "Couldn't stop the mission: {{error}}"
   },
   "agentPicker": {
     "title": "Which agent should run this?",

--- a/app/src/locales/es/board.json
+++ b/app/src/locales/es/board.json
@@ -6,11 +6,15 @@
     "approveTooltip": "Mover a Listo",
     "renameTooltip": "Cambiar título",
     "deleteTooltip": "Eliminar",
-    "select": "Seleccionar misión"
+    "select": "Seleccionar misión",
+    "openTerminalFailed": "No se pudo abrir la terminal: {{error}}"
   },
   "deleteCard": {
     "titleWithName": "¿Eliminar \"{{name}}\"?",
     "description": "Este elemento y su historial se eliminarán de forma permanente."
+  },
+  "tags": {
+    "routine": "Rutina"
   },
   "empty": {
     "title": "Aún no hay conversaciones",

--- a/app/src/locales/es/dashboard.json
+++ b/app/src/locales/es/dashboard.json
@@ -31,7 +31,8 @@
     "cta": "Nuevo agente"
   },
   "errors": {
-    "noAgentForMission": "Elige un agente antes de iniciar una misión."
+    "noAgentForMission": "Elige un agente antes de iniciar una misión.",
+    "stopSession": "No se pudo detener la misión: {{error}}"
   },
   "agentPicker": {
     "title": "¿Qué agente debería ejecutar esto?",

--- a/app/src/locales/pt/board.json
+++ b/app/src/locales/pt/board.json
@@ -6,11 +6,15 @@
     "approveTooltip": "Mover para Pronto",
     "renameTooltip": "Mudar título",
     "deleteTooltip": "Excluir",
-    "select": "Selecionar missão"
+    "select": "Selecionar missão",
+    "openTerminalFailed": "Não foi possível abrir o terminal: {{error}}"
   },
   "deleteCard": {
     "titleWithName": "Excluir \"{{name}}\"?",
     "description": "Este item e seu histórico serão removidos de forma permanente."
+  },
+  "tags": {
+    "routine": "Rotina"
   },
   "empty": {
     "title": "Ainda sem conversas",

--- a/app/src/locales/pt/dashboard.json
+++ b/app/src/locales/pt/dashboard.json
@@ -31,7 +31,8 @@
     "cta": "Novo agente"
   },
   "errors": {
-    "noAgentForMission": "Escolha um agente antes de iniciar uma missão."
+    "noAgentForMission": "Escolha um agente antes de iniciar uma missão.",
+    "stopSession": "Não foi possível parar a missão: {{error}}"
   },
   "agentPicker": {
     "title": "Qual agente deve fazer isso?",

--- a/app/tests/mission-card.test.ts
+++ b/app/tests/mission-card.test.ts
@@ -1,0 +1,42 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { missionCardTags } from "../src/lib/mission-card.ts";
+
+const modes = [
+  { id: "default", name: "Default" },
+  { id: "research", name: "Research" },
+];
+
+describe("missionCardTags", () => {
+  it("uses the agent mode label when the mission has a mode", () => {
+    deepStrictEqual(
+      missionCardTags({
+        agent: "research",
+        agentModes: modes,
+        routineLabel: "Routine",
+      }),
+      ["Research"],
+    );
+  });
+
+  it("uses the routine label when the mission is a routine chat with no mode", () => {
+    deepStrictEqual(
+      missionCardTags({
+        routineId: "routine-id",
+        agentModes: modes,
+        routineLabel: "Routine",
+      }),
+      ["Routine"],
+    );
+  });
+
+  it("keeps normal blank missions untagged", () => {
+    strictEqual(
+      missionCardTags({
+        agentModes: modes,
+        routineLabel: "Routine",
+      }),
+      undefined,
+    );
+  });
+});

--- a/app/tests/mission-control-send.test.ts
+++ b/app/tests/mission-control-send.test.ts
@@ -29,12 +29,34 @@ const codexActivity: ActivityOverrideSource = {
   model: "gpt-5.5",
 };
 
+const routineActivity: ActivityOverrideSource = {
+  id: "activity-row-for-routine",
+  session_key: "routine-routine-id",
+  provider: "anthropic",
+  model: "claude-opus-4-7",
+};
+
 describe("resolveActivityOverride (Mission Control send-path override drop fix)", () => {
   it("returns the activity's provider+model when the activity is found", () => {
     const overrides = resolveActivityOverride(
       `activity-${opus47Activity.id}`,
       [opus47Activity, codexActivity],
     );
+    deepStrictEqual(overrides, {
+      providerOverride: "anthropic",
+      modelOverride: "claude-opus-4-7",
+    });
+  });
+
+  it("matches routine chats by their stored session key", () => {
+    // Mission Control card ids are activity ids, but routine chat history and
+    // follow-up sends address the stable `routine-{id}` session. Matching only
+    // `activity-{id}` makes Mission Control silently drop the routine's model
+    // override even though the per-agent board sends correctly.
+    const overrides = resolveActivityOverride("routine-routine-id", [
+      opus47Activity,
+      routineActivity,
+    ]);
     deepStrictEqual(overrides, {
       providerOverride: "anthropic",
       modelOverride: "claude-opus-4-7",

--- a/app/tests/mission-control-session.test.ts
+++ b/app/tests/mission-control-session.test.ts
@@ -1,0 +1,67 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  missionControlAgentPathForSession,
+  missionControlSessionKey,
+  missionControlSessionKeyForId,
+} from "../src/components/mission-control-session.ts";
+
+const items = [
+  {
+    id: "normal",
+    metadata: {
+      agentPath: "/agents/Ada",
+      sessionKey: "activity-normal",
+    },
+  },
+  {
+    id: "routine-activity-row",
+    metadata: {
+      agentPath: "/agents/Grace",
+      sessionKey: "routine-morning-digest",
+    },
+  },
+  {
+    id: "legacy",
+    metadata: {
+      agentPath: "/agents/Legacy",
+    },
+  },
+];
+
+describe("Mission Control session key resolution", () => {
+  it("uses the stored session key for routine activity rows", () => {
+    strictEqual(
+      missionControlSessionKey(items[1]),
+      "routine-morning-digest",
+    );
+    strictEqual(
+      missionControlSessionKeyForId(items, "routine-activity-row"),
+      "routine-morning-digest",
+    );
+  });
+
+  it("falls back to activity-{id} for legacy rows", () => {
+    strictEqual(missionControlSessionKey(items[2]), "activity-legacy");
+    strictEqual(missionControlSessionKeyForId(items, "missing"), "activity-missing");
+  });
+
+  it("resolves the agent path from the active chat session key", () => {
+    strictEqual(
+      missionControlAgentPathForSession(items, "routine-morning-digest"),
+      "/agents/Grace",
+    );
+    strictEqual(
+      missionControlAgentPathForSession(items, "activity-normal"),
+      "/agents/Ada",
+    );
+    strictEqual(
+      missionControlAgentPathForSession(items, "activity-legacy"),
+      "/agents/Legacy",
+    );
+    strictEqual(
+      missionControlAgentPathForSession(items, "activity-missing"),
+      undefined,
+    );
+  });
+});

--- a/engine/houston-engine-core/src/conversations.rs
+++ b/engine/houston-engine-core/src/conversations.rs
@@ -32,6 +32,12 @@ struct ActivityRow {
     #[serde(default)]
     session_key: Option<String>,
     #[serde(default)]
+    agent: Option<String>,
+    #[serde(default)]
+    routine_id: Option<String>,
+    #[serde(default)]
+    worktree_path: Option<String>,
+    #[serde(default)]
     updated_at: Option<String>,
 }
 
@@ -57,6 +63,12 @@ pub struct ConversationEntry {
     pub agent_path: String,
     /// Human-readable agent name.
     pub agent_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub routine_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub worktree_path: Option<String>,
 }
 
 fn read_activities(root: &Path) -> CoreResult<Vec<ActivityRow>> {
@@ -102,6 +114,9 @@ pub fn list(root: &Path) -> CoreResult<Vec<ConversationEntry>> {
             updated_at: row.updated_at,
             agent_path: agent_path_str.clone(),
             agent_name: agent_name_str.clone(),
+            agent: row.agent,
+            routine_id: row.routine_id,
+            worktree_path: row.worktree_path,
         })
         .collect())
 }
@@ -185,10 +200,28 @@ mod tests {
         let entries = list(d.path()).unwrap();
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].id, "act-uuid");
+        assert_eq!(entries[0].routine_id.as_deref(), Some("abc"));
         assert_eq!(
             entries[0].session_key, "routine-abc",
             "routine chats keep their stable per-routine key"
         );
+    }
+
+    #[test]
+    fn preserves_activity_card_metadata() {
+        let d = TempDir::new().unwrap();
+        seed(
+            d.path(),
+            serde_json::json!([
+                { "id": "act", "title": "Work", "description": "", "status": "running",
+                  "session_key": "activity-act", "agent": "research",
+                  "worktree_path": "/tmp/worktree",
+                  "updated_at": "2026-02-02T00:00:00Z" },
+            ]),
+        );
+        let entries = list(d.path()).unwrap();
+        assert_eq!(entries[0].agent.as_deref(), Some("research"));
+        assert_eq!(entries[0].worktree_path.as_deref(), Some("/tmp/worktree"));
     }
 
     #[test]

--- a/engine/houston-engine-server/tests/conversations.rs
+++ b/engine/houston-engine-server/tests/conversations.rs
@@ -89,6 +89,38 @@ async fn list_returns_sorted_entries() {
 }
 
 #[tokio::test]
+async fn list_returns_activity_card_metadata() {
+    let (addr, tok) = spawn().await;
+    let agent = tempfile::TempDir::new().unwrap();
+    seed_activity(
+        agent.path(),
+        serde_json::json!([
+            { "id": "routine-card", "title": "Digest", "description": "",
+              "status": "needs_you", "session_key": "routine-r1",
+              "routine_id": "r1", "agent": "research",
+              "worktree_path": "/tmp/wt",
+              "updated_at": "2026-02-02T00:00:00Z" }
+        ]),
+    );
+    let c = reqwest::Client::new();
+    let body: serde_json::Value = c
+        .post(format!("http://{addr}/v1/conversations/list"))
+        .bearer_auth(&tok)
+        .json(&serde_json::json!({ "agentPath": agent.path().to_string_lossy() }))
+        .send()
+        .await
+        .unwrap()
+        .json()
+        .await
+        .unwrap();
+    let row = &body.as_array().unwrap()[0];
+    assert_eq!(row["session_key"], "routine-r1");
+    assert_eq!(row["routine_id"], "r1");
+    assert_eq!(row["agent"], "research");
+    assert_eq!(row["worktree_path"], "/tmp/wt");
+}
+
+#[tokio::test]
 async fn list_all_aggregates_across_agents() {
     let (addr, tok) = spawn().await;
     let a = tempfile::TempDir::new().unwrap();

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -184,6 +184,10 @@ not user-facing copy.
 | POST | `/v1/conversations/list` | List conversations for one agent |
 | POST | `/v1/conversations/list-all` | List across many agents |
 
+Conversation entries include the activity's stored `session_key` plus the
+card metadata the agent board needs to render the same mission card in
+cross-agent surfaces: `agent`, `routine_id`, and `worktree_path` when present.
+
 **Skills**
 | Method | Path | Description |
 |---|---|---|

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -272,6 +272,9 @@ export interface ConversationEntry {
   updated_at?: string;
   agent_path: string;
   agent_name: string;
+  agent?: string;
+  routine_id?: string;
+  worktree_path?: string | null;
 }
 
 // ---------- Skills ----------


### PR DESCRIPTION
## Summary

- Pass Mission Control's stored `session_key` into `AIBoard` so routine chats use `routine-{id}` instead of re-derived `activity-{cardId}`.
- Preserve conversation card metadata across `/v1/conversations/list-all`: `agent`, `routine_id`, and `worktree_path` now reach Mission Control.
- Render Mission Control card tags with the same helper as the agent board: mode cards show the mode label, routine chats show the localized Routine tag.
- Wire Mission Control's `AIBoard` to the same chat props the agent board uses: persisted drafts, duplicate-file notices, translated composer drop labels, attachment rejection handling, agent-scoped link opening, shared panel rendering, and worktree card/panel actions.
- Resolve Mission Control follow-up provider/model overrides by stored `session_key` first, with legacy `activity-{id}` fallback.
- Route Mission Control stop actions by active session key and surface stop failures as a visible toast.
- Extract shared mission worktree bootstrap/open-terminal helpers so worktree/config/install/open-terminal failures surface instead of silently falling back or logging only.
- Document the expanded conversation payload in `knowledge-base/engine-protocol.md`.

## Bugs Found And How To Reproduce Before

1. Routine chat transcript missing in Mission Control:
   - Trigger a routine that creates an activity row with `session_key: "routine-{routineId}"`.
   - Open the routine chat from the agent Activity section. The transcript appears.
   - Open the same card from Mission Control. Before this PR, Mission Control asked `AIBoard` for `activity-{activityRowId}`, so history/feed lookup missed and the chat appeared empty.

2. Routine tag missing in Mission Control:
   - Trigger a routine card.
   - Open the agent board and confirm the card shows the Routine tag.
   - Open Mission Control. Before this PR, `/v1/conversations/list-all` dropped `routine_id`, so Mission Control could not render the same tag.

3. Agent mode tag missing in Mission Control:
   - Create a mission with a configured sub-agent/mode.
   - Open the agent board and confirm the card shows that mode label.
   - Open Mission Control. Before this PR, the cross-agent conversation payload dropped `agent`, so Mission Control could not map the card to the mode label.

4. Worktree actions missing in Mission Control:
   - Enable mission worktrees for an agent and create a mission with a worktree.
   - Open the agent board. The card and detail panel show the Run/worktree controls.
   - Open Mission Control. Before this PR, `worktree_path` was dropped from conversation entries, and Mission Control did not pass the shared card/panel action renderers.

5. Mission Control composer behavior diverged from agent chats:
   - Type a draft in a Mission Control chat, switch away, then return.
   - Drop a duplicate/unsupported attachment or click an inline link in Mission Control.
   - Before this PR, Mission Control did not pass the same draft persistence, notice, translated composer labels, attachment rejection, or agent-scoped link-opening props as the agent board.

6. Mission Control follow-up/stop routing could target the wrong session:
   - Open a routine chat from Mission Control and send a follow-up or press Stop.
   - Before this PR, lookup paths relied on `activity-{id}` in several places, so routine chats could miss provider/model overrides or stop the wrong/no session.

7. Worktree setup failures were too quiet:
   - Enable mission worktrees, then break worktree creation/config/install command and start a mission.
   - Before this PR, Mission Control could swallow that setup failure and continue without the prepared worktree.

## Reproduce After

1. Trigger the same routine and open it from Mission Control.
2. The panel uses the stored `routine-{routineId}` session key, so the same transcript shown in the agent Activity section appears in Mission Control.
3. The same routine card shows the same localized Routine tag in the agent board and Mission Control.
4. A mode/sub-agent mission shows the same mode label in the agent board and Mission Control.
5. A worktree mission shows the same Run/worktree controls on the card and panel in both views. Open-terminal errors surface as a toast.
6. Mission Control drafts, duplicate-file notices, attachment rejection dialogs, composer drop labels, and inline-link opening follow the same behavior as agent chats.
7. Follow-up sends, queued messages, loading state, Stop, and provider/model overrides all address the stored session key.
8. Worktree setup failures abort mission creation and surface through the existing error-toast path instead of silently running in the original folder.

## Tests Run

- `pnpm --dir app test`
- `pnpm --dir app typecheck`
- `pnpm --dir app check-locales`
- `git diff --check`

## Additional Checks To Run In CI/Local Rust Setup

These engine tests cover the conversation payload changes:

- `cargo test -p houston-engine-core conversations::tests`
- `cargo test -p houston-engine-server --test conversations`

Closes #383.
