### PR TITLE
fix(updater): render release notes as markdown in update dialog

### DIFF
--- a/app/src/components/shell/update-checker.tsx
+++ b/app/src/components/shell/update-checker.tsx
@@ -2,6 +2,7 @@ import { AlertCircle, DownloadCloud, Loader2, RotateCw, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useUpdateChecker } from "../../hooks/use-update-checker";
 import { normalizeUpdateNotes } from "../../lib/update-details";
+import { UpdateNotes } from "./update-notes";
 import houstonBlack from "../../assets/houston-black.svg";
 import houstonWhite from "../../assets/houston-icon-white.svg";
 
@@ -87,9 +88,9 @@ export function UpdateChecker() {
         <p className="text-xs font-medium text-foreground">
           {t("updateChecker.detailsHeading")}
         </p>
-        <p className="mt-1 max-h-28 overflow-auto whitespace-pre-wrap text-xs leading-relaxed text-muted-foreground">
-          {notes ?? t("updateChecker.noDetails")}
-        </p>
+        <div className="mt-1 max-h-28 overflow-y-auto break-words text-xs leading-relaxed text-muted-foreground">
+          {notes ? <UpdateNotes notes={notes} /> : <p>{t("updateChecker.noDetails")}</p>}
+        </div>
       </div>
 
       {downloading && (

--- a/app/src/components/shell/update-notes.tsx
+++ b/app/src/components/shell/update-notes.tsx
@@ -1,0 +1,32 @@
+import { MessageResponse } from "@houston-ai/chat";
+
+// Renders the updater's "What's new" release notes as markdown. Reuses the
+// app's shared Streamdown renderer (the same `MessageResponse` already used for
+// standalone markdown in try-done-screen.tsx) rather than pulling in a separate
+// markdown library. Links need no onClick: the app-wide interceptor in App.tsx
+// catches `<a href>` clicks and opens them in the system browser, and
+// MessageResponse degrades to raw text if a render-time failure escapes.
+//
+// The class scope keeps the output compact and muted for the small card:
+// headings shrink to body size and structural margins tighten so the notes
+// read as a tight changelog, not a full chat message. Descendant selectors
+// (specificity 0,1,1) reliably win over Streamdown's own element utilities
+// (0,1,0).
+//
+// Verification: this render path is covered by `pnpm tsc --noEmit` (types) and
+// manual visual check. The app's `node --test` harness strips TS types but does
+// NOT transform JSX, so a React component cannot be rendered there; only pure
+// `.ts` logic is unit-testable. The input contract (what reaches this component)
+// is guarded by the `normalizeUpdateNotes` tests in update-details.test.ts.
+const COMPACT = [
+  "text-xs leading-relaxed text-muted-foreground",
+  "[&_:is(h1,h2,h3,h4,h5,h6)]:mb-1 [&_:is(h1,h2,h3,h4,h5,h6)]:mt-2",
+  "[&_:is(h1,h2,h3,h4,h5,h6)]:text-xs [&_:is(h1,h2,h3,h4,h5,h6)]:font-semibold",
+  "[&_:is(h1,h2,h3,h4,h5,h6)]:text-foreground",
+  "[&_p]:my-1 [&_ul]:my-1 [&_ol]:my-1 [&_li]:my-0.5",
+  "[&_a]:font-medium [&_a]:text-foreground",
+].join(" ");
+
+export function UpdateNotes({ notes }: { notes: string }) {
+  return <MessageResponse className={COMPACT}>{notes}</MessageResponse>;
+}

--- a/app/tests/update-details.test.ts
+++ b/app/tests/update-details.test.ts
@@ -1,0 +1,34 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { normalizeUpdateNotes } from "../src/lib/update-details.ts";
+
+describe("normalizeUpdateNotes", () => {
+  it("returns null for empty, whitespace, null, and undefined bodies", () => {
+    strictEqual(normalizeUpdateNotes(null), null);
+    strictEqual(normalizeUpdateNotes(undefined), null);
+    strictEqual(normalizeUpdateNotes(""), null);
+    strictEqual(normalizeUpdateNotes("   \n  \t "), null);
+  });
+
+  it("suppresses the generic Tauri placeholder so the card shows the fallback", () => {
+    strictEqual(
+      normalizeUpdateNotes("See the assets to download and install this version."),
+      null,
+    );
+  });
+
+  it("normalizes CRLF to LF so markdown blocks parse consistently", () => {
+    strictEqual(
+      normalizeUpdateNotes("## Houston 0.4.16\r\n\r\nArchive missions."),
+      "## Houston 0.4.16\n\nArchive missions.",
+    );
+  });
+
+  it("trims surrounding whitespace but preserves the markdown body", () => {
+    const body = "\n\n## Houston 0.4.16\n\n- Archive missions\n- Manage apps\n\n";
+    strictEqual(
+      normalizeUpdateNotes(body),
+      "## Houston 0.4.16\n\n- Archive missions\n- Manage apps",
+    );
+  });
+});

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -9,7 +9,7 @@ Four prod systems. All **dormant by default** — activate only when env vars se
 - **UI:** `app/src/components/shell/update-checker.tsx` → update card w/ download, progress, details, relaunch
 - **How:** Checks `latest.json` on GitHub Releases. Newer version? Downloads `.app.tar.gz`, verifies Ed25519 sig, replaces binary, relaunches.
 - **Relaunch:** frontend captures the original app bundle path before install and calls `relaunch_app_from_path` after install. Do not use generic process relaunch after macOS updater install; it can resolve to the moved backup bundle and reopen the old version.
-- **Notes:** release CI writes `release-notes.md` into `latest.json.notes`; the update card shows those details.
+- **Notes:** release CI writes `release-notes.md` into `latest.json.notes`; the update card renders those details as markdown via `update-notes.tsx`, which reuses the shared `MessageResponse` (Streamdown) renderer from `@houston-ai/chat` (no extra markdown dep) scoped compact for the small card.
 - **Critical:** Update signing (Ed25519 via `TAURI_SIGNING_PRIVATE_KEY`) is SEPARATE from Apple code signing. Both needed.
 - **Critical:** Users who install version WITHOUT updater can never auto-update. Ship updater in EVERY release.
 


### PR DESCRIPTION
## What

The auto-updater's **"What's new"** card rendered release notes as **raw markdown text** (e.g. `## Houston 0.4.16` showed literally, see issue screenshot). This renders the notes as actual markdown.

## How

- **New `app/src/components/shell/update-notes.tsx`** — `UpdateNotes` reuses the app's shared **`MessageResponse`** (Streamdown) renderer from `@houston-ai/chat` — the same component already used for standalone markdown in `app/src/components/onboarding/try-done-screen.tsx`. **No new markdown dependency**: it is already bundled, and it ships an `ErrorBoundary` that degrades to raw text if a render-time failure escapes. A class scope keeps the output compact and muted for the small card (headings shrink to body size, margins tighten; descendant selectors reliably win over Streamdown's element utilities).
- **`update-checker.tsx`** — swapped the raw `<p whitespace-pre-wrap>` for `<UpdateNotes/>`; container is `overflow-y-auto break-words` so long inline tokens (PR URLs, paths) wrap instead of horizontally scrolling the card.
- **Links** rely on the existing global `<a href>` click interceptor in `App.tsx` (opens in the system browser).
- **i18n:** no new user-facing strings (release-note content isn't translatable); `detailsHeading` / `noDetails` unchanged.

## Tests

- `app/tests/update-details.test.ts` — unit tests for `normalizeUpdateNotes` (the input contract feeding the renderer: CRLF normalize, trim, generic-placeholder suppression, null cases).
- The `node --test` harness strips TS types but can't transform JSX, so the React render path is covered by `tsc` + manual visual check (documented in the component header).

## Affected files

- `app/src/components/shell/update-notes.tsx` (new)
- `app/src/components/shell/update-checker.tsx`
- `app/tests/update-details.test.ts` (new)
- `knowledge-base/production-infra.md`

No dependency or lockfile changes.

Closes #395