### PR TITLE
feat(chat): show "Waiting for you to connect" on integration cards

### DIFF
--- a/app/src/components/composio-card-state.ts
+++ b/app/src/components/composio-card-state.ts
@@ -76,14 +76,16 @@ export function deriveComposioCardView(
  * Should the card show the "Waiting for you to connect" status line (issue
  * #412)?
  *
- * Only in the "idle" view: the agent has linked an app and paused, but the
- * user has not started the connect yet, so the line makes the hand-off
- * explicit ("the agent is waiting on you"). Once the user clicks Connect the
- * "Connecting…" badge already communicates progress, and "Connected" speaks
- * for itself, so the line would be redundant in those views.
+ * In every view except "connected": the line stays up the whole time the
+ * agent is blocked on the integration, from the idle hand-off through the
+ * "Connecting…" auth round-trip, and only clears once the connection is
+ * truly established (at which point the agent resumes via the auto-continue
+ * nudge). Keeping it through "connecting" matters because the auth flow can
+ * stall, get abandoned, or time back out to idle, so the agent is still
+ * waiting until the connection actually lands.
  */
 export function shouldShowWaitingToConnect(view: ComposioCardView): boolean {
-  return view === "idle";
+  return view !== "connected";
 }
 
 export interface ConnectedFollowupInput {

--- a/app/src/components/composio-card-state.ts
+++ b/app/src/components/composio-card-state.ts
@@ -13,6 +13,7 @@
  */
 
 import { normalizeToolkitSlug } from "../lib/composio-toolkits.ts";
+import type { ComposioAppEntry } from "../lib/tauri.ts";
 
 /**
  * Is `toolkit` present in the connected set?
@@ -69,6 +70,20 @@ export function deriveComposioCardView(
   if (isConnected) return "connected";
   if (phase === "connecting") return "connecting";
   return "idle";
+}
+
+/**
+ * Should the card show the "Waiting for you to connect" status line (issue
+ * #412)?
+ *
+ * Only in the "idle" view: the agent has linked an app and paused, but the
+ * user has not started the connect yet, so the line makes the hand-off
+ * explicit ("the agent is waiting on you"). Once the user clicks Connect the
+ * "Connecting…" badge already communicates progress, and "Connected" speaks
+ * for itself, so the line would be redundant in those views.
+ */
+export function shouldShowWaitingToConnect(view: ComposioCardView): boolean {
+  return view === "idle";
 }
 
 export interface ConnectedFollowupInput {
@@ -132,4 +147,46 @@ export function parseComposioToolkitFromHref(href: string): string | null {
  */
 export function fallbackLogo(toolkit: string): string {
   return `https://www.google.com/s2/favicons?domain=${toolkit}.com&sz=128`;
+}
+
+/** The card's resolved app identity: real catalog entry when we have one,
+ *  else a best-effort fallback from the raw toolkit slug. */
+export interface ComposioCardApp {
+  toolkit: string;
+  name: string;
+  description: string;
+  logoUrl: string;
+}
+
+/**
+ * Resolve the display identity (name, description, logo) for a connect card
+ * from the Composio catalog. The catalog reports canonical (lowercased)
+ * slugs while `toolkit` is the raw `#houston_toolkit=<slug>` fragment, so we
+ * normalize both sides — otherwise a mis-cased slug falls back to the bare
+ * name + favicon guess instead of the real name/logo. `fallbackDescription`
+ * is supplied by the caller so this stays i18n-agnostic and unit-testable.
+ */
+export function resolveComposioApp(
+  toolkit: string,
+  apiApps: ComposioAppEntry[] | undefined,
+  fallbackDescription: string,
+): ComposioCardApp {
+  const normalizedToolkit = normalizeToolkitSlug(toolkit);
+  const fromApi = apiApps?.find(
+    (a) => normalizeToolkitSlug(a.toolkit) === normalizedToolkit,
+  );
+  if (fromApi) {
+    return {
+      toolkit: fromApi.toolkit,
+      name: fromApi.name,
+      description: fromApi.description,
+      logoUrl: fromApi.logo_url || fallbackLogo(fromApi.toolkit),
+    };
+  }
+  return {
+    toolkit,
+    name: toolkit,
+    description: fallbackDescription,
+    logoUrl: fallbackLogo(toolkit),
+  };
 }

--- a/app/src/components/composio-link-card.tsx
+++ b/app/src/components/composio-link-card.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { ChatStatusLine } from "@houston-ai/chat";
 import {
   useComposioApps,
   useConnectedToolkits,
@@ -12,9 +13,10 @@ import { useUIStore } from "../stores/ui";
 import { analytics } from "../lib/analytics";
 import {
   deriveComposioCardView,
-  fallbackLogo,
   isToolkitConnected,
+  resolveComposioApp,
   shouldSendConnectedFollowup,
+  shouldShowWaitingToConnect,
   type ComposioCardPhase,
 } from "./composio-card-state";
 import { AppLogo, ComposioStatusSlot } from "./composio-card-visuals";
@@ -107,29 +109,7 @@ export function ComposioLinkCard({
   // another agent, CLI, stale cache from a prior session).
   useComposioConnectionWatcher(isConnected);
 
-  const app = (() => {
-    // The catalog reports canonical (lowercased) slugs; `toolkit` is the
-    // raw fragment slug, so normalize both sides or a mis-cased slug falls
-    // back to the bare name + favicon guess instead of the real name/logo.
-    const normalizedToolkit = normalizeToolkitSlug(toolkit);
-    const fromApi = apiApps?.find(
-      (a) => normalizeToolkitSlug(a.toolkit) === normalizedToolkit,
-    );
-    if (fromApi) {
-      return {
-        toolkit: fromApi.toolkit,
-        name: fromApi.name,
-        description: fromApi.description,
-        logoUrl: fromApi.logo_url || fallbackLogo(fromApi.toolkit),
-      };
-    }
-    return {
-      toolkit,
-      name: toolkit,
-      description: t("composio.integration"),
-      logoUrl: fallbackLogo(toolkit),
-    };
-  })();
+  const app = resolveComposioApp(toolkit, apiApps, t("composio.integration"));
   const appName = app.name;
 
   // Watch the real connection status. On the not-connected → connected edge
@@ -196,7 +176,7 @@ export function ComposioLinkCard({
   const view = deriveComposioCardView(isConnected, phase);
 
   return (
-    <span className="not-prose inline-flex my-1 max-w-full align-middle">
+    <span className="not-prose inline-flex flex-col gap-1.5 my-1 max-w-full align-middle">
       <span className="inline-flex items-center gap-3 px-3 py-2.5 rounded-xl border border-black/5 bg-background min-w-0">
         <AppLogo app={app} />
         <span className="flex-1 min-w-0 flex flex-col">
@@ -209,6 +189,13 @@ export function ComposioLinkCard({
         </span>
         <ComposioStatusSlot view={view} onConnect={startConnect} />
       </span>
+      {shouldShowWaitingToConnect(view) && (
+        <ChatStatusLine
+          label={t("composio.waitingToConnect")}
+          active
+          className="px-1 text-muted-foreground/65"
+        />
+      )}
     </span>
   );
 }

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -44,6 +44,7 @@
     "connected": "Connected",
     "connecting": "Connecting...",
     "connect": "Connect",
+    "waitingToConnect": "Waiting for you to connect",
     "reconnect": "Reconnect",
     "verifiedToast": "{{name}} is connected",
     "connectedFollowup": "I've connected {{name}}. Please continue.",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -44,6 +44,7 @@
     "connected": "Conectado",
     "connecting": "Conectando...",
     "connect": "Conectar",
+    "waitingToConnect": "Esperando a que te conectes",
     "reconnect": "Reconectar",
     "verifiedToast": "{{name}} está conectado",
     "connectedFollowup": "Ya conecté {{name}}. Por favor continúa.",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -44,6 +44,7 @@
     "connected": "Conectado",
     "connecting": "Conectando...",
     "connect": "Conectar",
+    "waitingToConnect": "Aguardando você conectar",
     "reconnect": "Reconectar",
     "verifiedToast": "{{name}} está conectado",
     "connectedFollowup": "Já conectei {{name}}. Pode continuar.",

--- a/app/tests/composio-card-state.test.ts
+++ b/app/tests/composio-card-state.test.ts
@@ -5,9 +5,21 @@ import {
   fallbackLogo,
   isToolkitConnected,
   parseComposioToolkitFromHref,
+  resolveComposioApp,
   shouldSendConnectedFollowup,
+  shouldShowWaitingToConnect,
   type ConnectedFollowupInput,
 } from "../src/components/composio-card-state.ts";
+import type { ComposioAppEntry } from "../src/lib/tauri.ts";
+
+const appEntry = (over: Partial<ComposioAppEntry> = {}): ComposioAppEntry => ({
+  toolkit: "gmail",
+  name: "Gmail",
+  description: "Email",
+  logo_url: "https://logos.example/gmail.png",
+  categories: [],
+  ...over,
+});
 
 describe("deriveComposioCardView (issue #379: status badge vs action)", () => {
   it("shows the Connect CTA when not connected and idle", () => {
@@ -27,6 +39,61 @@ describe("deriveComposioCardView (issue #379: status badge vs action)", () => {
     // mid-flight; the card must show Connected, never a spinner that masks
     // a live connection.
     strictEqual(deriveComposioCardView(true, "connecting"), "connected");
+  });
+});
+
+describe("resolveComposioApp (card display identity)", () => {
+  it("uses the catalog entry's name, description, and logo when found", () => {
+    const app = resolveComposioApp("gmail", [appEntry()], "App integration");
+    strictEqual(app.name, "Gmail");
+    strictEqual(app.description, "Email");
+    strictEqual(app.logoUrl, "https://logos.example/gmail.png");
+  });
+
+  it("matches the catalog across casing (raw fragment vs canonical slug)", () => {
+    const app = resolveComposioApp(
+      "GoogleDrive",
+      [appEntry({ toolkit: "googledrive", name: "Google Drive" })],
+      "App integration",
+    );
+    strictEqual(app.name, "Google Drive");
+  });
+
+  it("falls back to the favicon when the catalog entry has no logo", () => {
+    const app = resolveComposioApp(
+      "gmail",
+      [appEntry({ logo_url: "" })],
+      "App integration",
+    );
+    strictEqual(app.logoUrl, fallbackLogo("gmail"));
+  });
+
+  it("builds a fallback identity when the toolkit is not in the catalog", () => {
+    const app = resolveComposioApp("obscureapp", [appEntry()], "App integration");
+    strictEqual(app.name, "obscureapp");
+    strictEqual(app.description, "App integration");
+    strictEqual(app.logoUrl, fallbackLogo("obscureapp"));
+  });
+
+  it("falls back when the catalog has not loaded yet (undefined)", () => {
+    const app = resolveComposioApp("gmail", undefined, "App integration");
+    strictEqual(app.name, "gmail");
+    strictEqual(app.description, "App integration");
+  });
+});
+
+describe("shouldShowWaitingToConnect (issue #412: explicit hand-off line)", () => {
+  it("shows the waiting line while idle, before the user acts", () => {
+    // The agent linked an app and paused; make the hand-off explicit.
+    strictEqual(shouldShowWaitingToConnect("idle"), true);
+  });
+
+  it("hides it once connecting (the Connecting badge already speaks)", () => {
+    strictEqual(shouldShowWaitingToConnect("connecting"), false);
+  });
+
+  it("hides it once connected (nothing left to wait on)", () => {
+    strictEqual(shouldShowWaitingToConnect("connected"), false);
   });
 });
 

--- a/app/tests/composio-card-state.test.ts
+++ b/app/tests/composio-card-state.test.ts
@@ -88,11 +88,13 @@ describe("shouldShowWaitingToConnect (issue #412: explicit hand-off line)", () =
     strictEqual(shouldShowWaitingToConnect("idle"), true);
   });
 
-  it("hides it once connecting (the Connecting badge already speaks)", () => {
-    strictEqual(shouldShowWaitingToConnect("connecting"), false);
+  it("keeps the line up while connecting, until the connection lands", () => {
+    // The auth round-trip can stall, get abandoned, or time back out to
+    // idle, so the agent is still waiting; the message must not vanish.
+    strictEqual(shouldShowWaitingToConnect("connecting"), true);
   });
 
-  it("hides it once connected (nothing left to wait on)", () => {
+  it("hides it only once connected (the agent can resume)", () => {
     strictEqual(shouldShowWaitingToConnect("connected"), false);
   });
 });

--- a/ui/chat/src/chat-process-block.tsx
+++ b/ui/chat/src/chat-process-block.tsx
@@ -3,11 +3,10 @@ import {
   Collapsible,
   CollapsibleContent,
   CollapsibleTrigger,
-  HoustonHelmet,
   cn,
 } from "@houston-ai/core";
 import { ChevronDownIcon } from "lucide-react";
-import { Shimmer } from "./ai-elements/shimmer";
+import { ChatStatusLine } from "./chat-status-line";
 import {
   Reasoning,
   ReasoningContent,
@@ -67,12 +66,9 @@ export function ChatProcessBlock({
       onOpenChange={setIsOpen}
     >
       <CollapsibleTrigger
-        className="inline-flex max-w-full items-center gap-1.5 text-xs text-muted-foreground/65 transition-colors hover:text-muted-foreground"
+        className="inline-flex max-w-full items-center gap-1.5 text-muted-foreground/65 transition-colors hover:text-muted-foreground"
       >
-        <HoustonHelmet color="currentColor" size={13} />
-        <span className="min-w-0 truncate text-left">
-          {isActive ? <Shimmer duration={1}>{l.active}</Shimmer> : l.complete}
-        </span>
+        <ChatStatusLine label={isActive ? l.active : l.complete} active={isActive} />
         <ChevronDownIcon
           className={cn(
             "size-3.5 shrink-0 transition-transform",

--- a/ui/chat/src/chat-status-line.tsx
+++ b/ui/chat/src/chat-status-line.tsx
@@ -1,0 +1,50 @@
+import { HoustonHelmet, cn } from "@houston-ai/core";
+import { Shimmer } from "./ai-elements/shimmer";
+
+export interface ChatStatusLineProps {
+  /** The status text shown next to the Houston helmet glyph. */
+  label: string;
+  /**
+   * When true the label shimmers to signal an ongoing / pending state —
+   * the same treatment the "Mission in progress..." line uses. Leave it
+   * off for a settled, static status.
+   */
+  active?: boolean;
+  /** Helmet glyph size in px. Defaults to 13 to match the Mission log line. */
+  iconSize?: number;
+  /** Extra classes for the root span (e.g. the muted text color the
+   *  consumer wants). Color is inherited so callers control it. */
+  className?: string;
+}
+
+/**
+ * The little Houston-helmet + muted-label status line. It is the visual
+ * identity of the chat's "Mission log" / "Mission in progress..." row, lifted
+ * out of `ChatProcessBlock` so the exact same line can stand alone elsewhere
+ * (e.g. a "Waiting for you to connect" prompt on a Composio card) without
+ * duplicating the glyph + shimmer wiring.
+ *
+ * Renders as an inline-level element (spans only) so it stays valid nested
+ * inside markdown prose. Text color is inherited from the parent; pass it via
+ * `className` or set it on an ancestor.
+ */
+export function ChatStatusLine({
+  label,
+  active,
+  iconSize = 13,
+  className,
+}: ChatStatusLineProps) {
+  return (
+    <span
+      className={cn(
+        "inline-flex min-w-0 max-w-full items-center gap-1.5 text-xs",
+        className,
+      )}
+    >
+      <HoustonHelmet color="currentColor" size={iconSize} />
+      <span className="min-w-0 truncate text-left">
+        {active ? <Shimmer duration={1}>{label}</Shimmer> : label}
+      </span>
+    </span>
+  );
+}

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -179,6 +179,8 @@ export type {
   PrepareAttachments,
 } from "./chat-panel-types";
 export type { ChatProcessLabels } from "./chat-process-block";
+export { ChatStatusLine } from "./chat-status-line";
+export type { ChatStatusLineProps } from "./chat-status-line";
 
 export { ChatInput } from "./chat-input";
 export type { ChatInputProps, ChatComposerLabels } from "./chat-input";


### PR DESCRIPTION
## What

When an agent links an integration and pauses for the user to connect it, the connect card was visually indistinguishable from a finished turn, so users didn't realize the agent was blocked on *them*. This adds a Mission-log-style status line **"Waiting for you to connect"** under the connect card, making the hand-off explicit.

Per the issue, it **reuses the same component that renders the chat's "Mission log" line** — the Houston-helmet glyph + shimmering muted label — rather than reimplementing the look.

The line stays visible the **whole time the agent is blocked** — from the idle hand-off, through the "Connecting…" auth round-trip — and only clears once the connection is **truly established** (at which point the agent resumes via the existing auto-continue nudge). It never vanishes mid-flow, since the auth flow can stall, be abandoned, or time back out to idle.

## How

- **`[ui/chat]` Extract `ChatStatusLine`** (`ui/chat/src/chat-status-line.tsx`): the helmet + (optionally shimmering) label line, lifted out of `ChatProcessBlock`. `ChatProcessBlock` now renders its "Mission log" / "Mission in progress…" trigger *through* `ChatStatusLine`, so the connect-card line and the Mission log line are literally the same component. Exported from `@houston-ai/chat`.
- **`[app]` Connect card** (`composio-link-card.tsx`): renders a shimmering `ChatStatusLine` with `composio.waitingToConnect` in every view **except `connected`** (i.e. idle + connecting). A card that mounts already-connected never shows it.
- **`[app]` Pure logic + tests** (`composio-card-state.ts`): `shouldShowWaitingToConnect(view)` returns `view !== "connected"`. Also extracts the card's app-identity resolution into a pure, unit-tested `resolveComposioApp(...)` (keeps `composio-link-card.tsx` under the file-size budget — 214 → 201 lines).
- **`[app]` i18n**: `composio.waitingToConnect` added to en/es/pt.

## Affected files

- `ui/chat/src/chat-status-line.tsx` (new)
- `ui/chat/src/chat-process-block.tsx`
- `ui/chat/src/index.ts`
- `app/src/components/composio-link-card.tsx`
- `app/src/components/composio-card-state.ts`
- `app/src/locales/{en,es,pt}/chat.json`
- `app/tests/composio-card-state.test.ts`

## Test plan

- `pnpm typecheck` (ui/)
- `cd app && pnpm tsc --noEmit`
- `cd app && pnpm check-locales`
- `cd app && node --experimental-strip-types --test tests/composio-card-state.test.ts`
- Manual: ask an agent to use a skill that needs an unconnected integration → connect card shows a shimmering "Waiting for you to connect" line beneath it. Click Connect → the line **stays** while the "Connecting…" badge shows. Finish auth → green "Connected", the line disappears, and the agent resumes.

Closes #412

🤖 Generated with [Claude Code](https://claude.com/claude-code)