### PR TITLE
fix(routines): reset editor state on agent switch

### DIFF
--- a/app/src/components/tabs/routines-tab-model.ts
+++ b/app/src/components/tabs/routines-tab-model.ts
@@ -1,0 +1,83 @@
+import type { Routine, RoutineFormData, RoutineRun } from "@houston-ai/routines";
+
+/** Editor view state for the Routines tab. */
+export type View = { type: "grid" } | { type: "editor"; editId?: string };
+
+/** Most recent run per routine id, keyed by `routine_id`. */
+export function latestRunByRoutine(
+  runs: RoutineRun[] | undefined,
+): Record<string, RoutineRun> {
+  if (!runs) return {};
+  const map: Record<string, RoutineRun> = {};
+  for (const run of runs) {
+    const existing = map[run.routine_id];
+    if (!existing || new Date(run.started_at) > new Date(existing.started_at)) {
+      map[run.routine_id] = run;
+    }
+  }
+  return map;
+}
+
+/** Blank form for "create new routine" and the reset target on agent switch. */
+export const EMPTY_FORM: RoutineFormData = {
+  name: "",
+  description: "",
+  prompt: "",
+  schedule: "0 9 * * *",
+  suppress_when_silent: true,
+  timezone: null,
+  integrations: [],
+};
+
+function sameStringList(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+}
+
+/** True when `form` has no edits relative to `source`. Gates the Save button. */
+export function formMatchesRoutine(
+  form: RoutineFormData,
+  source: RoutineFormData,
+): boolean {
+  return (
+    form.name === source.name &&
+    form.description === source.description &&
+    form.prompt === source.prompt &&
+    form.schedule === source.schedule &&
+    form.suppress_when_silent === source.suppress_when_silent &&
+    (form.timezone ?? null) === (source.timezone ?? null) &&
+    sameStringList(form.integrations, source.integrations)
+  );
+}
+
+/** Project a stored routine onto the editor's form shape. */
+export function routineToFormData(routine: Routine): RoutineFormData {
+  return {
+    name: routine.name,
+    description: routine.description,
+    prompt: routine.prompt,
+    schedule: routine.schedule,
+    suppress_when_silent: routine.suppress_when_silent,
+    timezone: routine.timezone ?? null,
+    integrations: routine.integrations ?? [],
+  };
+}
+
+/**
+ * Fresh Routines-tab state: grid view, blank form + baseline.
+ *
+ * Used both for the initial mount and when the active agent changes. The tab
+ * instance is reused across agents — it's keyed by tab, not agent (see
+ * experience-renderer.tsx + workspace-shell.tsx; board-tab.tsx resets its own
+ * per-agent selection the same way). So a routine being edited under one agent
+ * must NOT bleed into the next agent's Routines tab: switching agents drops any
+ * in-progress edit and returns to that agent's grid.
+ */
+export function freshRoutinesState(): {
+  view: View;
+  form: RoutineFormData;
+  baseline: RoutineFormData;
+} {
+  return { view: { type: "grid" }, form: EMPTY_FORM, baseline: EMPTY_FORM };
+}

--- a/app/src/components/tabs/routines-tab.tsx
+++ b/app/src/components/tabs/routines-tab.tsx
@@ -1,7 +1,15 @@
 import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { RoutinesGrid, RoutineEditor } from "@houston-ai/routines";
-import type { RoutineFormData, RoutineRun } from "@houston-ai/routines";
+import type { RoutineFormData } from "@houston-ai/routines";
+import {
+  EMPTY_FORM,
+  formMatchesRoutine,
+  freshRoutinesState,
+  latestRunByRoutine,
+  routineToFormData,
+  type View,
+} from "./routines-tab-model";
 import {
   useRoutines,
   useRoutineRuns,
@@ -14,39 +22,6 @@ import {
 import { useTimezonePreference } from "../../hooks/use-timezone-preference";
 import { analytics } from "../../lib/analytics";
 import type { TabProps } from "../../lib/types";
-
-type View = { type: "grid" } | { type: "editor"; editId?: string };
-
-const EMPTY_FORM: RoutineFormData = {
-  name: "",
-  description: "",
-  prompt: "",
-  schedule: "0 9 * * *",
-  suppress_when_silent: true,
-  timezone: null,
-  integrations: [],
-};
-
-function sameStringList(a: string[], b: string[]): boolean {
-  if (a.length !== b.length) return false;
-  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
-  return true;
-}
-
-function formMatchesRoutine(
-  form: RoutineFormData,
-  source: RoutineFormData,
-): boolean {
-  return (
-    form.name === source.name &&
-    form.description === source.description &&
-    form.prompt === source.prompt &&
-    form.schedule === source.schedule &&
-    form.suppress_when_silent === source.suppress_when_silent &&
-    (form.timezone ?? null) === (source.timezone ?? null) &&
-    sameStringList(form.integrations, source.integrations)
-  );
-}
 
 export default function RoutinesTab({ agent }: TabProps) {
   const { t } = useTranslation("routines");
@@ -61,22 +36,31 @@ export default function RoutinesTab({ agent }: TabProps) {
   const runNow = useRunRoutineNow(path);
   const cancelRun = useCancelRoutineRun(path);
 
-  const [view, setView] = useState<View>({ type: "grid" });
-  const [form, setForm] = useState<RoutineFormData>(EMPTY_FORM);
-  const [baseline, setBaseline] = useState<RoutineFormData>(EMPTY_FORM);
+  const [view, setView] = useState<View>(() => freshRoutinesState().view);
+  const [form, setForm] = useState<RoutineFormData>(() => freshRoutinesState().form);
+  const [baseline, setBaseline] = useState<RoutineFormData>(
+    () => freshRoutinesState().baseline,
+  );
 
-  // Compute last run per routine
-  const lastRuns = useMemo(() => {
-    if (!allRuns) return {};
-    const map: Record<string, RoutineRun> = {};
-    for (const run of allRuns) {
-      const existing = map[run.routine_id];
-      if (!existing || new Date(run.started_at) > new Date(existing.started_at)) {
-        map[run.routine_id] = run;
-      }
-    }
-    return map;
-  }, [allRuns]);
+  // `view`/`form`/`baseline` describe a routine belonging to ONE agent, but
+  // this RoutinesTab instance is reused across agents — it's keyed by tab, not
+  // agent (see experience-renderer.tsx + workspace-shell.tsx; board-tab.tsx
+  // reconciles its own per-agent selection the same way). When the active agent
+  // changes we reset to that agent's grid during render (React's "adjust state
+  // on prop change" pattern: the render-phase setState re-renders before the
+  // stale editor ever paints), so an edit started under one agent never bleeds
+  // into another agent's Routines tab.
+  const [trackedAgentId, setTrackedAgentId] = useState(agent.id);
+  if (trackedAgentId !== agent.id) {
+    setTrackedAgentId(agent.id);
+    const fresh = freshRoutinesState();
+    setView(fresh.view);
+    setForm(fresh.form);
+    setBaseline(fresh.baseline);
+  }
+
+  // Most recent run per routine, for the grid's "last run" badges.
+  const lastRuns = useMemo(() => latestRunByRoutine(allRuns), [allRuns]);
 
   const handleCreate = useCallback(() => {
     setForm(EMPTY_FORM);
@@ -88,15 +72,7 @@ export default function RoutinesTab({ agent }: TabProps) {
     (routineId: string) => {
       const r = routines?.find((x) => x.id === routineId);
       if (!r) return;
-      const next: RoutineFormData = {
-        name: r.name,
-        description: r.description,
-        prompt: r.prompt,
-        schedule: r.schedule,
-        suppress_when_silent: r.suppress_when_silent,
-        timezone: r.timezone ?? null,
-        integrations: r.integrations ?? [],
-      };
+      const next = routineToFormData(r);
       setForm(next);
       setBaseline(next);
       setView({ type: "editor", editId: routineId });
@@ -112,15 +88,7 @@ export default function RoutinesTab({ agent }: TabProps) {
         updates: form,
       });
       // Reset baseline so the Save button disables until the next edit.
-      setBaseline({
-        name: updated.name,
-        description: updated.description,
-        prompt: updated.prompt,
-        schedule: updated.schedule,
-        suppress_when_silent: updated.suppress_when_silent,
-        timezone: updated.timezone ?? null,
-        integrations: updated.integrations ?? [],
-      });
+      setBaseline(routineToFormData(updated));
     } else {
       const created = await createRoutine.mutateAsync(form);
       analytics.track("routine_scheduled", { routine_id: created.id });

--- a/app/tests/routines-tab-model.test.ts
+++ b/app/tests/routines-tab-model.test.ts
@@ -1,0 +1,137 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { Routine, RoutineRun } from "@houston-ai/routines";
+import {
+  EMPTY_FORM,
+  formMatchesRoutine,
+  freshRoutinesState,
+  latestRunByRoutine,
+  routineToFormData,
+} from "../src/components/tabs/routines-tab-model.ts";
+
+function routine(overrides: Partial<Routine> = {}): Routine {
+  return {
+    id: "r1",
+    name: "Morning digest",
+    description: "Summarize overnight email",
+    prompt: "Summarize my inbox.",
+    schedule: "0 9 * * 1-5",
+    enabled: true,
+    suppress_when_silent: false,
+    timezone: "America/Los_Angeles",
+    integrations: ["gmail", "slack"],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-02T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("routines tab model — fresh state", () => {
+  // This is the regression guard for issue #400: editing a routine under one
+  // agent, switching agents, then opening the Routines tab must NOT show the
+  // previous agent's edit. The tab resets to `freshRoutinesState()` on agent
+  // change, so that state must be the closed grid with a blank, clean form.
+  it("resets to the grid view", () => {
+    deepStrictEqual(freshRoutinesState().view, { type: "grid" });
+  });
+
+  it("resets the form and baseline to blank", () => {
+    const fresh = freshRoutinesState();
+    deepStrictEqual(fresh.form, EMPTY_FORM);
+    deepStrictEqual(fresh.baseline, EMPTY_FORM);
+  });
+
+  it("reports no unsaved changes (Save disabled) right after a reset", () => {
+    const fresh = freshRoutinesState();
+    strictEqual(formMatchesRoutine(fresh.form, fresh.baseline), true);
+  });
+});
+
+describe("routines tab model — routineToFormData", () => {
+  it("projects every editable field off the stored routine", () => {
+    deepStrictEqual(routineToFormData(routine()), {
+      name: "Morning digest",
+      description: "Summarize overnight email",
+      prompt: "Summarize my inbox.",
+      schedule: "0 9 * * 1-5",
+      suppress_when_silent: false,
+      timezone: "America/Los_Angeles",
+      integrations: ["gmail", "slack"],
+    });
+  });
+
+  it("normalizes an absent timezone to null", () => {
+    strictEqual(routineToFormData(routine({ timezone: undefined })).timezone, null);
+  });
+});
+
+describe("routines tab model — formMatchesRoutine", () => {
+  it("treats an unedited form as matching", () => {
+    const form = routineToFormData(routine());
+    strictEqual(formMatchesRoutine(form, routineToFormData(routine())), true);
+  });
+
+  it("detects edits to a scalar field", () => {
+    const baseline = routineToFormData(routine());
+    strictEqual(
+      formMatchesRoutine({ ...baseline, name: "Evening digest" }, baseline),
+      false,
+    );
+  });
+
+  it("detects a reordered or resized integrations list", () => {
+    const baseline = routineToFormData(routine());
+    strictEqual(
+      formMatchesRoutine({ ...baseline, integrations: ["slack", "gmail"] }, baseline),
+      false,
+    );
+    strictEqual(
+      formMatchesRoutine({ ...baseline, integrations: ["gmail"] }, baseline),
+      false,
+    );
+  });
+
+  it("treats null and undefined timezone as equal", () => {
+    const baseline = routineToFormData(routine({ timezone: null }));
+    strictEqual(
+      formMatchesRoutine({ ...baseline, timezone: undefined }, baseline),
+      true,
+    );
+  });
+});
+
+describe("routines tab model — latestRunByRoutine", () => {
+  function run(overrides: Partial<RoutineRun>): RoutineRun {
+    return {
+      id: "run1",
+      routine_id: "r1",
+      status: "surfaced",
+      session_key: "s1",
+      started_at: "2026-01-01T00:00:00Z",
+      ...overrides,
+    };
+  }
+
+  it("returns an empty map when runs are absent", () => {
+    deepStrictEqual(latestRunByRoutine(undefined), {});
+  });
+
+  it("keeps the newest run per routine", () => {
+    const older = run({ id: "a", routine_id: "r1", started_at: "2026-01-01T00:00:00Z" });
+    const newer = run({ id: "b", routine_id: "r1", started_at: "2026-01-03T00:00:00Z" });
+    const other = run({ id: "c", routine_id: "r2", started_at: "2026-01-02T00:00:00Z" });
+
+    const map = latestRunByRoutine([older, newer, other]);
+
+    strictEqual(map.r1.id, "b");
+    strictEqual(map.r2.id, "c");
+  });
+
+  it("ignores ordering of the input", () => {
+    const older = run({ id: "a", started_at: "2026-01-01T00:00:00Z" });
+    const newer = run({ id: "b", started_at: "2026-01-03T00:00:00Z" });
+
+    strictEqual(latestRunByRoutine([newer, older]).r1.id, "b");
+    strictEqual(latestRunByRoutine([older, newer]).r1.id, "b");
+  });
+});


### PR DESCRIPTION
## Problem

Closes #400.

Editing a routine for one agent, switching to another agent, then opening that agent's **Routines** tab showed the *previous* agent's in-progress routine config.

## Root cause

`RoutinesTab` keeps the editor's `view` / `form` / `baseline` in local `useState`. But the tab component instance is **reused across agents** — `experience-renderer.tsx` keys tabs by `tab.id`, not by agent (this is deliberate; `board-tab.tsx` documents why: cross-agent navigation from notifications / command palette / Mission Control must switch agent *and* set a pending selection in the same update, which a remount would break). So on an agent switch only the `agent` prop changes; the stale editor state survives and bleeds into the next agent's tab.

## Fix

Reset to the grid view with a blank form **during render** when the active agent changes, using the same render-phase "adjust state on prop change" pattern `board-tab.tsx` already uses (`trackedAgentId`). The render-phase `setState` re-renders before the stale editor ever paints, so switching agents now drops any in-progress edit and returns to that agent's own grid.

While here, the tab's pure logic is extracted into a testable model module (matching the repo's `*-model.ts` + node `--test` convention), which also brought `routines-tab.tsx` back under the 200-line limit.

## Affected files

- `app/src/components/tabs/routines-tab.tsx` — render-phase agent-change reset; consume the extracted helpers; drop now-unused `RoutineRun` import.
- `app/src/components/tabs/routines-tab-model.ts` *(new)* — `EMPTY_FORM`, `formMatchesRoutine`, `routineToFormData`, `latestRunByRoutine`, `freshRoutinesState` (single source of truth for the reset target).
- `app/tests/routines-tab-model.test.ts` *(new)* — pins the regression invariant (after an agent switch the editor is closed + blank, Save disabled) plus dirty-check / projection / last-run coverage.

## Notes

- No new user-facing strings, so no i18n changes.
- Library boundary respected: all changes are app-side; `ui/@houston-ai/routines` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)