### PR TITLE
release: v0.4.18

### DIFF
--- a/.github/release-notes/0.4.18.md
+++ b/.github/release-notes/0.4.18.md
@@ -1,0 +1,17 @@
+## Houston 0.4.18
+
+A reliability release. When something goes wrong, Houston now reports it more dependably and gives you a short reference code you can share with us.
+
+### Changed
+
+- **Clearer problem reports.** When Houston hits an error, the follow-up message now says "report sent" with a short reference code. Tap Copy to grab it and send it our way, and we can pin down exactly what happened on your machine.
+
+### Fixed
+
+- **Reports now carry the real details.** We fixed our build pipeline so crash reports point at the actual place a problem happened instead of unreadable scrambled code, and so problems in Houston's background engine get reported too (they were previously invisible to us). This is all behind the scenes, so there is nothing for you to do.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward automatically. The MSI is still not OS-code-signed (SignPath integration still pending), so Windows SmartScreen may warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install. Download the ARM64 MSI manually, uninstall the x64 build first, then install the ARM64 one.

--- a/.github/release-notes/0.4.18.md
+++ b/.github/release-notes/0.4.18.md
@@ -1,14 +1,26 @@
 ## Houston 0.4.18
 
-A reliability release. When something goes wrong, Houston now reports it more dependably and gives you a short reference code you can share with us.
+New ways to organize your missions, clearer scheduling and integrations, and a reliability pass so problems actually get reported when something goes wrong.
+
+### Added
+
+- **Drag and drop missions between columns.** Rearrange mission cards across your board columns by dragging them, so the board matches how you actually work.
+- **Friendlier schedule picker.** Setting a custom schedule for a routine now uses a simple interval picker instead of raw cron-style entry.
+- **Search highlights in archived missions.** When you search archived missions, the matching words are now highlighted so the result is easy to spot.
 
 ### Changed
 
-- **Clearer problem reports.** When Houston hits an error, the follow-up message now says "report sent" with a short reference code. Tap Copy to grab it and send it our way, and we can pin down exactly what happened on your machine.
+- **Clearer integration cards.** An integration that still needs you to sign in now says "Waiting for you to connect," so the next step is obvious.
+- **Formatted update notes.** The "update available" dialog now renders these release notes with proper formatting instead of raw text.
+- **Clearer problem reports.** When Houston hits an error, the follow-up message now says "report sent" with a short reference code. Tap Copy to grab it and send it our way so we can pin down exactly what happened.
 
 ### Fixed
 
-- **Reports now carry the real details.** We fixed our build pipeline so crash reports point at the actual place a problem happened instead of unreadable scrambled code, and so problems in Houston's background engine get reported too (they were previously invisible to us). This is all behind the scenes, so there is nothing for you to do.
+- **Routines run on the day you picked.** A weekly routine now fires on the correct day of the week instead of being off by a day.
+- **Mission Control matches your boards.** The chats and missions shown in Mission Control now line up with what is on each agent's board.
+- **Routine editor stays correct when you switch agents.** Opening the routine editor after switching agents no longer shows leftover settings from the previous agent.
+- **Archived mission search lines up.** The archived-mission search now sits and behaves consistently with the rest of the board.
+- **Problem reports carry the real details (behind the scenes).** We fixed our build pipeline so crash reports point at the actual place a problem happened instead of unreadable scrambled code, and so problems in Houston's background engine get reported too. Nothing for you to do.
 
 ### Before you upgrade
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.17", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.17", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.17", path = "app/houston-tauri" }
-houston-events = { version = "0.4.17", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.17", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.17", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.17", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.17", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.17", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.17", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.17", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.17", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.17", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.17", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.17", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.17", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.17", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.17", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.18", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.18", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.18", path = "app/houston-tauri" }
+houston-events = { version = "0.4.18", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.18", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.18", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.18", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.18", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.18", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.18", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.18", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.18", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.18", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.18", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.18", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.18", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.18", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.18", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.17"
+version = "0.4.18"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.17",
+  "version": "0.4.18",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Version bump to **0.4.18** to ship the Sentry observability work merged in #426.

## What ships in 0.4.18
- CI Sentry upload gate fixed (source maps + debug symbols now actually upload).
- macOS dSYM + Windows PDB symbolication → real `file:line`, not minified soup.
- Engine-process crash reporting (engine self-inits Sentry; supervisor captures abnormal exits).
- Honest "report sent" toast with a copyable event id.

Full detail in #426. User-facing notes: `.github/release-notes/0.4.18.md`.

## Bump scope
All Houston packages bumped 0.4.17 → 0.4.18 (mirrors `scripts/version.sh`): 8 `@houston-ai/*` UI packages, root + app `package.json`, every workspace Cargo crate `[package]` version, and the root `Cargo.toml` workspace-dependency versions. The new `prep` version-guard requires tag == `app/package.json` == `app/src-tauri/Cargo.toml`, all now `0.4.18`.

## Before merging (needs the toolchain I don't have here)
Please run on this branch — this is both the lockfile sync and the compile gate for the merged #426:
```
cargo check --workspace        # syncs Cargo.lock (workspace member versions) + compiles
cd app && pnpm install && pnpm tsc --noEmit && pnpm test && pnpm check-locales
```
Commit any `Cargo.lock` change. (A stale `Cargo.lock` won't block the release CI — its `cargo build` isn't `--locked` — but committing the synced lock keeps the tree clean.)

## Release flow
Merge this → tag `v0.4.18` on main → `release.yml` runs the **fixed** pipeline → **draft** GitHub release. Verify the run shows the Sentry upload steps **executed, not skipped**, then install the draft MSI on Win11 and smoke-test (`Ctrl+Alt+Shift+J` / `N`) before publishing.

Heads up: `scripts/version.sh` line 32 uses the macOS-only `sed -i ''`, so it can't run on Linux/Windows git-bash (I bumped via a portable `perl` equivalent here). Worth a one-line follow-up to make `/release` runnable off-Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)