### PR TITLE
fix(notifications): open the routine's chat when its completion notification is clicked

### DIFF
--- a/app/src/hooks/session-notifications.ts
+++ b/app/src/hooks/session-notifications.ts
@@ -2,15 +2,18 @@ import { getCurrentWindow } from "@tauri-apps/api/window";
 
 import { logger } from "../lib/logger";
 import { isMac } from "../lib/platform";
-import { shouldArmNotificationNav, shouldNavigateOnAppActivation } from "../lib/notification-nav";
+import {
+  activityIdForSessionKey,
+  shouldArmNotificationNav,
+  shouldNavigateOnAppActivation,
+  type NotificationNav,
+} from "../lib/notification-nav";
 import { osShowSessionNotification } from "../lib/os-bridge";
+import { queryClient } from "../lib/query-client";
+import { queryKeys } from "../lib/query-keys";
+import { tauriActivity } from "../lib/tauri";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
-
-interface NotificationNav {
-  agentId: string;
-  activityId: string;
-}
 
 let pendingNotificationNav: NotificationNav | null = null;
 let pendingNavTimer: ReturnType<typeof setTimeout> | null = null;
@@ -19,9 +22,35 @@ export function describePendingNotificationNav() {
   return JSON.stringify(pendingNotificationNav);
 }
 
-export function consumePendingNav() {
+/**
+ * Map the armed session key to the board activity id to open, fetching the
+ * finished agent's activities fresh. A routine's chat is created right *after*
+ * its session completes (#401), so the cache can be a beat behind at click
+ * time; `fetchQuery` re-reads through the same key the board uses, so it both
+ * resolves the routine chat and warms the cache for the agent we switch to.
+ */
+async function resolveActivityId(
+  agentPath: string,
+  sessionKey: string,
+): Promise<string | null> {
+  try {
+    const activities = await queryClient.fetchQuery({
+      queryKey: queryKeys.activity(agentPath),
+      queryFn: () => tauriActivity.list(agentPath),
+    });
+    return activityIdForSessionKey(activities, sessionKey);
+  } catch (e) {
+    // Log-only (no toast): nav is best-effort and this same path fires on a
+    // bare macOS refocus, where a toast would be noise. A standard mission key
+    // still encodes its id, so it can navigate even if the list fetch failed.
+    logger.error(`[notification] failed to list activities for nav (${sessionKey}): ${e}`);
+    return activityIdForSessionKey([], sessionKey);
+  }
+}
+
+export async function consumePendingNav() {
   if (!pendingNotificationNav) return;
-  const { agentId, activityId } = pendingNotificationNav;
+  const { agentId, sessionKey } = pendingNotificationNav;
   pendingNotificationNav = null;
   if (pendingNavTimer) {
     clearTimeout(pendingNavTimer);
@@ -29,14 +58,20 @@ export function consumePendingNav() {
   }
 
   const agents = useAgentStore.getState().agents;
-  logger.debug(`[notification] consuming nav: agentId=${agentId} activityId=${activityId} agents=[${agents.map(a => a.id).join(",")}]`);
+  logger.debug(`[notification] consuming nav: agentId=${agentId} sessionKey=${sessionKey} agents=[${agents.map(a => a.id).join(",")}]`);
   const agent = agents.find((a) => a.id === agentId);
   if (!agent) {
     logger.debug("[notification] agent not found, cannot navigate");
     return;
   }
 
-  logger.debug(`[notification] navigating to agent=${agent.name} activity=${activityId}`);
+  const activityId = await resolveActivityId(agent.folderPath, sessionKey);
+  if (!activityId) {
+    logger.debug(`[notification] no activity matches sessionKey=${sessionKey}, cannot navigate`);
+    return;
+  }
+
+  logger.debug(`[notification] navigating to agent=${agent.name} activity=${activityId} (sessionKey=${sessionKey})`);
   useUIStore.getState().setViewMode("activity");
   useAgentStore.getState().setCurrent(agent);
   useUIStore.getState().setActivityPanelId(activityId, { forceOpen: true });
@@ -87,7 +122,7 @@ export async function sendSessionNotification(
     pendingNavTimer = setTimeout(() => {
       pendingNotificationNav = null;
     }, 5 * 60 * 1000);
-    logger.debug(`[notification] pending nav set: agentId=${nav.agentId} activityId=${nav.activityId}`);
+    logger.debug(`[notification] pending nav set: agentId=${nav.agentId} sessionKey=${nav.sessionKey}`);
   } catch (e) {
     logger.error(`[notification] Failed: ${e}`);
   }
@@ -104,7 +139,9 @@ export function listenForNotificationFocus(): Promise<() => void> | undefined {
     return getCurrentWindow().onFocusChanged(({ payload: focused }) => {
       if (!focused || !pendingNotificationNav) return;
       logger.debug(`[notification] onFocusChanged fired: focused=${focused} pendingNav=${JSON.stringify(pendingNotificationNav)}`);
-      consumePendingNav();
+      consumePendingNav().catch((e) => {
+        logger.error(`[notification] consumePendingNav (focus) failed: ${e}`);
+      });
     });
   } catch (e) {
     logger.debug(`[notification] Tauri focus listener unavailable: ${e}`);

--- a/app/src/hooks/use-session-events.ts
+++ b/app/src/hooks/use-session-events.ts
@@ -128,8 +128,13 @@ export function useSessionEvents() {
               session_key,
               h.getAgent()?.name ?? "Agent",
             );
-            if (!nav && session_key.startsWith("activity-") && !session_key.startsWith("routine-")) {
-              logger.debug(`[notification] completed agent not in loaded list: agent_path=${agent_path}`);
+            if (
+              !nav &&
+              (session_key.startsWith("activity-") || session_key.startsWith("routine-"))
+            ) {
+              logger.debug(
+                `[notification] completed chat not navigable (agent not in loaded list?): agent_path=${agent_path} session_key=${session_key}`,
+              );
             }
 
             sendSessionNotification(
@@ -193,7 +198,9 @@ export function useSessionEvents() {
     import("@tauri-apps/plugin-notification").then(({ onAction }) => {
       onAction((action) => {
         logger.debug(`[notification] onAction fired: ${JSON.stringify(action)} pendingNav=${describePendingNotificationNav()}`);
-        consumePendingNav();
+        consumePendingNav().catch((e) => {
+          logger.error(`[notification] consumePendingNav (onAction) failed: ${e}`);
+        });
       }).then((unlisten) => {
         unlistenNotificationAction = () => { unlisten.unregister(); };
       }).catch((e) => {
@@ -215,7 +222,11 @@ export function useSessionEvents() {
     //    are picked up when the window comes forward.
     const unlistenActivated = listenOsEvent<unknown>("app-activated", () => {
       logger.debug(`[notification] app-activated event fired: pendingNav=${describePendingNotificationNav()}`);
-      if (shouldNavigateOnAppActivation(isMac)) consumePendingNav();
+      if (shouldNavigateOnAppActivation(isMac)) {
+        consumePendingNav().catch((e) => {
+          logger.error(`[notification] consumePendingNav (app-activated) failed: ${e}`);
+        });
+      }
       const ws = useWorkspaceStore.getState().current;
       if (ws) {
         // Silent refresh — don't flip loading:true, which would unmount the
@@ -229,7 +240,9 @@ export function useSessionEvents() {
     // mission on those platforms. macOS never emits it (uses the focus path).
     const unlistenNotifClick = listenOsEvent<unknown>("notification-clicked", () => {
       logger.debug(`[notification] notification-clicked event fired: pendingNav=${describePendingNotificationNav()}`);
-      consumePendingNav();
+      consumePendingNav().catch((e) => {
+        logger.error(`[notification] consumePendingNav (notification-clicked) failed: ${e}`);
+      });
     });
 
     // Fallback: Tauri window focus event (macOS only — see listenForNotificationFocus).

--- a/app/src/lib/notification-nav.ts
+++ b/app/src/lib/notification-nav.ts
@@ -14,22 +14,29 @@ export interface NavAgent {
 
 export interface NotificationNav {
   agentId: string;
-  activityId: string;
+  /**
+   * Session key of the finished chat — `activity-{id}` for a standard mission,
+   * `routine-{routine_id}` for a routine (#401). Resolved to a board activity
+   * id at click time (`consumePendingNav` → `activityIdForSessionKey`) rather
+   * than here, because a routine's chat is created right *after* its session
+   * completes, so the activity may not exist yet when the notification fires.
+   */
+  sessionKey: string;
 }
 
 export interface NotificationTarget {
   /** Agent name for the notification title (the agent that finished). */
   agentName: string;
-  /** Click target, set only when the finished session maps to an activity. */
+  /** Click target, set only when the finished session maps to a chat. */
   nav?: NotificationNav;
 }
 
 /**
  * Match the finished session to its agent by **folder path**, not by whichever
  * agent the user currently has open. This is what lets a notification click
- * jump to the agent + activity that completed even after the user switched
- * agents or closed the chat — `consumePendingNav()` switches the active agent
- * for us, so the only thing missing was a target that survives the switch.
+ * jump to the agent + chat that completed even after the user switched agents
+ * or closed the chat — `consumePendingNav()` switches the active agent for us,
+ * so the only thing missing was a target that survives the switch.
  *
  * `fallbackAgentName` is used for the title only when the finished agent isn't
  * in the loaded list (e.g. it lives in another workspace).
@@ -43,22 +50,49 @@ export function resolveNotificationTarget(
   const finishedAgent = agents.find((a) => a.folderPath === agentPath);
   const agentName = finishedAgent?.name ?? fallbackAgentName;
 
-  // Activity sessions are keyed `activity-<id>`. Routine runs are excluded:
-  // they have no mission chat to open.
-  const isActivitySession =
-    sessionKey.startsWith("activity-") && !sessionKey.startsWith("routine-");
+  // Any finished chat is navigable: standard missions (`activity-{id}`) and
+  // routine chats (`routine-{routine_id}`, #401). The key is resolved to a
+  // board activity id at click time. Non-chat sessions (e.g. the bare `main`
+  // key) carry no board card and simply don't arm a target.
+  const opensAChat =
+    sessionKey.startsWith("activity-") || sessionKey.startsWith("routine-");
 
-  if (finishedAgent && isActivitySession) {
+  if (finishedAgent && opensAChat) {
     return {
       agentName,
-      nav: {
-        agentId: finishedAgent.id,
-        activityId: sessionKey.replace("activity-", ""),
-      },
+      nav: { agentId: finishedAgent.id, sessionKey },
     };
   }
 
   return { agentName };
+}
+
+/**
+ * Resolve a finished session's key to the board activity id to open.
+ *
+ * Standard mission chats are keyed `activity-{id}`; the row usually has no
+ * explicit `session_key`, so the board derives `activity-{id}` from the id.
+ * Routine chats use the routine's stable `routine-{routine_id}` key (#381),
+ * stored explicitly as `session_key` on an activity whose own id is unrelated.
+ * Mirror the board's exact derivation (`session_key ?? activity-{id}`) so the
+ * lookup round-trips for both. The `activity-` prefix fallback covers the case
+ * where the matching row isn't in `activities` (preserving the prior
+ * strip-and-trust behavior for standard missions).
+ *
+ * Pure + store-free so it's unit-testable; the caller fetches the list.
+ */
+export function activityIdForSessionKey(
+  activities: { id: string; session_key?: string }[],
+  sessionKey: string,
+): string | null {
+  const match = activities.find(
+    (a) => (a.session_key ?? `activity-${a.id}`) === sessionKey,
+  );
+  if (match) return match.id;
+  if (sessionKey.startsWith("activity-")) {
+    return sessionKey.slice("activity-".length);
+  }
+  return null;
 }
 
 export interface PendingActivityArgs {

--- a/app/tests/notification-nav.test.ts
+++ b/app/tests/notification-nav.test.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
+  activityIdForSessionKey,
   resolveNotificationTarget,
   resolvePendingActivitySelection,
   shouldArmNotificationNav,
@@ -17,17 +18,17 @@ describe("resolveNotificationTarget", () => {
   it("targets the agent that finished, matched by folder path", () => {
     deepStrictEqual(
       resolveNotificationTarget(agents, "/ws/Writer", "activity-act99", "Writer"),
-      { agentName: "Writer", nav: { agentId: "a2", activityId: "act99" } },
+      { agentName: "Writer", nav: { agentId: "a2", sessionKey: "activity-act99" } },
     );
   });
 
   // Regression for the cross-agent bug: user is on "Researcher" (the fallback)
   // when "Writer" finishes in the background. The click target must still point
-  // at Writer + its activity, not stay on the open agent / go nowhere.
+  // at Writer + its chat, not stay on the open agent / go nowhere.
   it("targets the finished agent even when a different agent is open", () => {
     deepStrictEqual(
       resolveNotificationTarget(agents, "/ws/Writer", "activity-act99", "Researcher"),
-      { agentName: "Writer", nav: { agentId: "a2", activityId: "act99" } },
+      { agentName: "Writer", nav: { agentId: "a2", sessionKey: "activity-act99" } },
     );
   });
 
@@ -38,18 +39,49 @@ describe("resolveNotificationTarget", () => {
     );
   });
 
-  it("sets no nav for routine sessions (no mission chat to open)", () => {
+  // Regression for #401: a routine that finishes with a chat result must arm a
+  // click target so the notification opens the routine's chat (it used to be
+  // excluded, so the click stayed on the last non-routine chat). The routine's
+  // stable key is carried through and resolved to its activity id at click time.
+  it("arms the routine chat's session key for navigation", () => {
     deepStrictEqual(
       resolveNotificationTarget(agents, "/ws/Writer", "routine-r1", "Researcher"),
-      { agentName: "Writer" },
+      { agentName: "Writer", nav: { agentId: "a2", sessionKey: "routine-r1" } },
     );
   });
 
-  it("sets no nav for non-activity session keys", () => {
+  it("sets no nav for non-chat session keys", () => {
     deepStrictEqual(
       resolveNotificationTarget(agents, "/ws/Writer", "main", "Researcher"),
       { agentName: "Writer" },
     );
+  });
+});
+
+describe("activityIdForSessionKey", () => {
+  it("resolves a routine key to the activity id stored on the row", () => {
+    // The routine chat's activity id is unrelated to its `routine-{id}` key —
+    // only the stored `session_key` links them (#381/#401).
+    const activities = [
+      { id: "act-1", session_key: "activity-act-1" },
+      { id: "act-routine", session_key: "routine-r1" },
+    ];
+    strictEqual(activityIdForSessionKey(activities, "routine-r1"), "act-routine");
+  });
+
+  it("resolves a standard mission key whose row has no explicit session_key", () => {
+    // Normal activities omit `session_key`; the board derives `activity-{id}`,
+    // and so must this lookup.
+    const activities = [{ id: "act99" }];
+    strictEqual(activityIdForSessionKey(activities, "activity-act99"), "act99");
+  });
+
+  it("falls back to the encoded id when the activity row isn't in the list", () => {
+    strictEqual(activityIdForSessionKey([], "activity-act99"), "act99");
+  });
+
+  it("returns null for a routine key with no matching activity", () => {
+    strictEqual(activityIdForSessionKey([], "routine-r1"), null);
   });
 });
 


### PR DESCRIPTION
## What

Clicking a routine-finished notification did nothing useful: it left whatever non-routine chat was last open on screen instead of opening the routine's chat.

Root cause: `resolveNotificationTarget` (app/src/lib/notification-nav.ts) explicitly excluded `routine-` session keys with the comment *"no mission chat to open"*. That assumption is wrong — a surfaced routine reuses one board activity per routine, keyed by its stable `routine-{routine_id}` session_key (#381). So no click target was ever armed for routines, and the notification click just foregrounded the window on the previously-open chat.

## Fix

Make notification navigation work for **any** chat kind, mission or routine:

- **Arm a target for `activity-` and `routine-` sessions alike.** The nav target now carries the **session key** rather than a pre-stripped activity id.
- **Resolve the session key → board activity id at _click_ time** (`consumePendingNav`), fetching the finished agent's activities fresh via the shared `queryClient`. This is deliberate: a routine's chat activity is created *right after* its session completes (the `SessionStatus: completed` event that fires the notification precedes the surface step), so resolving at notification-send time would race the activity into existence. A click-time fetch reliably finds it and also warms the cache for the agent we switch to.
- New pure, unit-tested helper `activityIdForSessionKey` mirrors the board's exact `session_key ?? activity-{id}` derivation, so the lookup round-trips for both normal activities (no stored key) and routines (explicit `routine-` key).

Standard mission notifications are unchanged in behavior — same end target, now produced through the shared resolver. `consumePendingNav` became `async`, so its fire-and-forget call sites get a `.catch` (no-silent-failures policy).

## Affected files

- `app/src/lib/notification-nav.ts` — nav carries `sessionKey`; arm for `activity-` + `routine-`; new `activityIdForSessionKey` pure helper.
- `app/src/hooks/session-notifications.ts` — `consumePendingNav` resolves the session key to an activity id via `fetchQuery`; imports the shared `NotificationNav` type (removed the local duplicate).
- `app/src/hooks/use-session-events.ts` — updated debug-log condition; `.catch` on the now-async `consumePendingNav` calls.
- `app/tests/notification-nav.test.ts` — nav-shape update, routine-navigates regression test, `activityIdForSessionKey` cases.

## Test plan

- TS: `cd app && pnpm tsc --noEmit`
- Unit: `cd app && node --test tests/notification-nav.test.ts` (or the repo's app test runner)
- Manual: run a routine that surfaces a result while focused on a different (non-routine) chat → click the completion notification → the routine's chat opens. Verify a normal mission notification still opens its chat, and cross-agent + backgrounded (macOS focus / Linux-Windows native click) paths still work.

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)