### PR TITLE
feat(routines): choose one chat per routine or a new chat each run

### DIFF
--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -138,6 +138,7 @@ export function CreateAgentDialog() {
             schedule: routineForm.schedule,
             enabled: true,
             suppress_when_silent: routineForm.suppress_when_silent,
+            chat_mode: routineForm.chat_mode,
             timezone: routineForm.timezone,
           });
           await tauriRoutines.startScheduler(agent.folderPath);
@@ -243,6 +244,7 @@ export function CreateAgentDialog() {
                         prompt: routine.prompt,
                         schedule: routine.schedule,
                         suppress_when_silent: true,
+                        chat_mode: "shared",
                         timezone: null,
                         integrations: [],
                       }

--- a/app/src/components/tabs/routines-tab-model.ts
+++ b/app/src/components/tabs/routines-tab-model.ts
@@ -25,6 +25,7 @@ export const EMPTY_FORM: RoutineFormData = {
   prompt: "",
   schedule: "0 9 * * *",
   suppress_when_silent: true,
+  chat_mode: "shared",
   timezone: null,
   integrations: [],
 };
@@ -46,6 +47,7 @@ export function formMatchesRoutine(
     form.prompt === source.prompt &&
     form.schedule === source.schedule &&
     form.suppress_when_silent === source.suppress_when_silent &&
+    form.chat_mode === source.chat_mode &&
     (form.timezone ?? null) === (source.timezone ?? null) &&
     sameStringList(form.integrations, source.integrations)
   );
@@ -59,6 +61,7 @@ export function routineToFormData(routine: Routine): RoutineFormData {
     prompt: routine.prompt,
     schedule: routine.schedule,
     suppress_when_silent: routine.suppress_when_silent,
+    chat_mode: routine.chat_mode ?? "shared",
     timezone: routine.timezone ?? null,
     integrations: routine.integrations ?? [],
   };

--- a/app/tests/routines-tab-model.test.ts
+++ b/app/tests/routines-tab-model.test.ts
@@ -18,6 +18,7 @@ function routine(overrides: Partial<Routine> = {}): Routine {
     schedule: "0 9 * * 1-5",
     enabled: true,
     suppress_when_silent: false,
+    chat_mode: "shared",
     timezone: "America/Los_Angeles",
     integrations: ["gmail", "slack"],
     created_at: "2026-01-01T00:00:00Z",
@@ -55,6 +56,7 @@ describe("routines tab model — routineToFormData", () => {
       prompt: "Summarize my inbox.",
       schedule: "0 9 * * 1-5",
       suppress_when_silent: false,
+      chat_mode: "shared",
       timezone: "America/Los_Angeles",
       integrations: ["gmail", "slack"],
     });
@@ -75,6 +77,14 @@ describe("routines tab model — formMatchesRoutine", () => {
     const baseline = routineToFormData(routine());
     strictEqual(
       formMatchesRoutine({ ...baseline, name: "Evening digest" }, baseline),
+      false,
+    );
+  });
+
+  it("detects a chat_mode toggle", () => {
+    const baseline = routineToFormData(routine());
+    strictEqual(
+      formMatchesRoutine({ ...baseline, chat_mode: "per_run" }, baseline),
       false,
     );
   });

--- a/engine/houston-engine-core/src/agents/mod.rs
+++ b/engine/houston-engine-core/src/agents/mod.rs
@@ -203,6 +203,7 @@ mod tests {
                 schedule: "0 9 * * *".into(),
                 enabled: true,
                 suppress_when_silent: true,
+                chat_mode: crate::routines::RoutineChatMode::Shared,
                 integrations: vec![],
             })
             .unwrap();

--- a/engine/houston-engine-core/src/agents/routine_runs.rs
+++ b/engine/houston-engine-core/src/agents/routine_runs.rs
@@ -25,12 +25,23 @@ pub fn create(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
     with_runs_lock(root, || create_unlocked(root, routine_id))
 }
 
+/// Derive a run's `session_key` from its routine's `chat_mode` (#423). Mirrors
+/// `routines::runs::session_key_for` so both run-creation paths agree: `Shared`
+/// keeps one chat per routine (#381), `PerRun` gives each run a fresh chat. A
+/// missing routine falls back to `Shared` so a stray run never fails here.
+fn session_key_for(root: &Path, routine_id: &str, run_id: &str) -> CoreResult<String> {
+    let chat_mode = super::routines::list(root)?
+        .into_iter()
+        .find(|r| r.id == routine_id)
+        .map(|r| r.chat_mode)
+        .unwrap_or_default();
+    Ok(chat_mode.session_key(routine_id, run_id))
+}
+
 fn create_unlocked(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
     let mut runs = list(root)?;
     let id = Uuid::new_v4().to_string();
-    // Stable per routine, NOT per run, so all of a routine's runs share one
-    // chat (#381). Kept in lockstep with `routines::runs::create_unlocked`.
-    let session_key = format!("routine-{routine_id}");
+    let session_key = session_key_for(root, routine_id, &id)?;
     let run = RoutineRun {
         id,
         routine_id: routine_id.to_string(),

--- a/engine/houston-engine-core/src/agents/routines.rs
+++ b/engine/houston-engine-core/src/agents/routines.rs
@@ -24,6 +24,7 @@ pub fn create(root: &Path, input: NewRoutine) -> CoreResult<Routine> {
         schedule: input.schedule,
         enabled: input.enabled,
         suppress_when_silent: input.suppress_when_silent,
+        chat_mode: input.chat_mode,
         integrations: input.integrations,
         created_at: now.clone(),
         updated_at: now,
@@ -57,6 +58,9 @@ pub fn update(root: &Path, id: &str, updates: RoutineUpdate) -> CoreResult<Routi
     }
     if let Some(suppress) = updates.suppress_when_silent {
         routine.suppress_when_silent = suppress;
+    }
+    if let Some(chat_mode) = updates.chat_mode {
+        routine.chat_mode = chat_mode;
     }
     if let Some(integrations) = updates.integrations {
         routine.integrations = integrations;

--- a/engine/houston-engine-core/src/agents/types.rs
+++ b/engine/houston-engine-core/src/agents/types.rs
@@ -3,6 +3,7 @@
 //! Relocated from `app/houston-tauri/src/agent_store/types.rs`. Wire-compatible
 //! with existing on-disk JSON.
 
+use crate::routines::types::RoutineChatMode;
 use serde::{Deserialize, Serialize};
 
 // -- Activity --
@@ -88,6 +89,10 @@ pub struct Routine {
     /// silently (no activity created on the board).
     #[serde(default = "default_true")]
     pub suppress_when_silent: bool,
+    /// Whether each run reuses one chat or starts a fresh one (#423). Defaults
+    /// to `Shared` so existing routines keep one chat per routine (#381).
+    #[serde(default)]
+    pub chat_mode: RoutineChatMode,
     /// Composio toolkit slugs this routine uses (e.g. `["gmail", "slack"]`).
     /// Mirrors the same field on Skills; surfaced by the share/import flow so
     /// the recipient can wire up the integrations before enabling the routine.
@@ -109,6 +114,7 @@ pub struct RoutineUpdate {
     pub schedule: Option<String>,
     pub enabled: Option<bool>,
     pub suppress_when_silent: Option<bool>,
+    pub chat_mode: Option<RoutineChatMode>,
     pub integrations: Option<Vec<String>>,
 }
 
@@ -124,6 +130,8 @@ pub struct NewRoutine {
     pub enabled: bool,
     #[serde(default = "default_true")]
     pub suppress_when_silent: bool,
+    #[serde(default)]
+    pub chat_mode: RoutineChatMode,
     #[serde(default)]
     pub integrations: Vec<String>,
 }

--- a/engine/houston-engine-core/src/routines/engine_dispatcher.rs
+++ b/engine/houston-engine-core/src/routines/engine_dispatcher.rs
@@ -208,7 +208,10 @@ impl SessionLifecycle for RoutineRunLifecycle {
 #[cfg(test)]
 mod lifecycle_tests {
     use super::*;
-    use crate::routines::{create, types::NewRoutine};
+    use crate::routines::{
+        create,
+        types::{NewRoutine, RoutineChatMode},
+    };
     use houston_ui_events::NoopEventSink;
     use tempfile::TempDir;
 
@@ -220,6 +223,7 @@ mod lifecycle_tests {
             schedule: "0 9 * * *".into(),
             enabled: true,
             suppress_when_silent: true,
+            chat_mode: RoutineChatMode::Shared,
             timezone: None,
             integrations: vec![],
         }

--- a/engine/houston-engine-core/src/routines/mod.rs
+++ b/engine/houston-engine-core/src/routines/mod.rs
@@ -18,7 +18,7 @@ use serde::Serialize;
 use std::path::Path;
 use uuid::Uuid;
 
-pub use types::{NewRoutine, Routine, RoutineUpdate};
+pub use types::{NewRoutine, Routine, RoutineChatMode, RoutineUpdate};
 
 const FILE: &str = "routines";
 
@@ -59,6 +59,7 @@ pub fn create(root: &Path, input: NewRoutine) -> CoreResult<Routine> {
         schedule: input.schedule,
         enabled: input.enabled,
         suppress_when_silent: input.suppress_when_silent,
+        chat_mode: input.chat_mode,
         timezone: input.timezone,
         integrations: input.integrations,
         created_at: now.clone(),
@@ -93,6 +94,9 @@ pub fn update(root: &Path, id: &str, updates: RoutineUpdate) -> CoreResult<Routi
     }
     if let Some(suppress) = updates.suppress_when_silent {
         routine.suppress_when_silent = suppress;
+    }
+    if let Some(chat_mode) = updates.chat_mode {
+        routine.chat_mode = chat_mode;
     }
     if let Some(tz) = updates.timezone {
         routine.timezone = tz;
@@ -130,6 +134,7 @@ mod tests {
             schedule: "0 9 * * 1-5".into(),
             enabled: true,
             suppress_when_silent: true,
+            chat_mode: RoutineChatMode::Shared,
             timezone: None,
             integrations: vec![],
         }
@@ -176,6 +181,56 @@ mod tests {
         let d = TempDir::new().unwrap();
         let err = update(d.path(), "nope", RoutineUpdate::default()).unwrap_err();
         assert!(matches!(err, CoreError::NotFound(_)));
+    }
+
+    #[test]
+    fn chat_mode_defaults_to_shared_and_round_trips() {
+        // New routines default to one shared chat (#381); the option flips to a
+        // fresh chat per run (#423) and persists across read-back.
+        let d = TempDir::new().unwrap();
+        let r = create(d.path(), sample()).unwrap();
+        assert_eq!(r.chat_mode, RoutineChatMode::Shared, "default is one shared chat");
+
+        let upd = update(
+            d.path(),
+            &r.id,
+            RoutineUpdate {
+                chat_mode: Some(RoutineChatMode::PerRun),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        assert_eq!(upd.chat_mode, RoutineChatMode::PerRun);
+        // Re-read from disk to prove it serialized, not just mutated in memory.
+        let reloaded = list(d.path()).unwrap();
+        assert_eq!(reloaded[0].chat_mode, RoutineChatMode::PerRun);
+    }
+
+    #[test]
+    fn chat_mode_absent_on_disk_reads_as_shared() {
+        // A routine written before this option (no `chat_mode` key) must read
+        // back as Shared so existing routines keep one chat with no migration.
+        let d = TempDir::new().unwrap();
+        let dir = d.path().join(".houston/routines");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(
+            dir.join("routines.json"),
+            r#"[{
+              "id": "legacy",
+              "name": "Old",
+              "description": "",
+              "prompt": "p",
+              "schedule": "0 9 * * *",
+              "enabled": true,
+              "suppress_when_silent": true,
+              "integrations": [],
+              "created_at": "2026-05-01T00:00:00Z",
+              "updated_at": "2026-05-01T00:00:00Z"
+            }]"#,
+        )
+        .unwrap();
+        let loaded = list(d.path()).unwrap();
+        assert_eq!(loaded[0].chat_mode, RoutineChatMode::Shared);
     }
 
     #[test]

--- a/engine/houston-engine-core/src/routines/runner.rs
+++ b/engine/houston-engine-core/src/routines/runner.rs
@@ -383,7 +383,10 @@ fn truncate(s: &str, max: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::routines::{create, types::NewRoutine};
+    use crate::routines::{
+        create,
+        types::{NewRoutine, RoutineChatMode},
+    };
     use houston_ui_events::NoopEventSink;
     use std::sync::Mutex;
     use tempfile::TempDir;
@@ -428,6 +431,7 @@ mod tests {
             schedule: "0 9 * * *".into(),
             enabled: true,
             suppress_when_silent: true,
+            chat_mode: RoutineChatMode::Shared,
             timezone: None,
             integrations: vec![],
         }
@@ -520,6 +524,81 @@ mod tests {
         let runs = routine_runs::list(d.path()).unwrap();
         assert_eq!(runs[0].status, "surfaced");
         assert_eq!(runs[0].activity_id.as_deref(), Some("act-1"));
+    }
+
+    #[tokio::test]
+    async fn per_run_chat_mode_surfaces_a_fresh_chat_each_run() {
+        // #423: a routine set to PerRun must create a NEW chat per surfaced run.
+        // Drive two runs through the REAL activity surface and assert two
+        // distinct activities — the Shared default would collapse to one.
+        use crate::agents::activity;
+        use crate::routines::engine_dispatcher::EngineActivitySurface;
+
+        let d = TempDir::new().unwrap();
+        let agent_path = d.path().to_string_lossy().to_string();
+        let mut per_run = sample_routine();
+        per_run.chat_mode = RoutineChatMode::PerRun;
+        // Non-silent every run so both surface.
+        per_run.suppress_when_silent = false;
+        let r = create(d.path(), per_run).unwrap();
+
+        let dispatcher = Arc::new(FakeDispatcher(DispatchOutcome {
+            response_text: "Found something".into(),
+            error: None,
+        }));
+        let surface: Arc<dyn ActivitySurface> = Arc::new(EngineActivitySurface);
+        let events: DynEventSink = Arc::new(NoopEventSink);
+
+        run_routine(events.clone(), dispatcher.clone(), surface.clone(), &agent_path, &r.id)
+            .await
+            .unwrap();
+        run_routine(events.clone(), dispatcher, surface, &agent_path, &r.id)
+            .await
+            .unwrap();
+
+        let acts = activity::list(d.path()).unwrap();
+        assert_eq!(acts.len(), 2, "per-run mode creates a chat per run");
+
+        let runs = routine_runs::list(d.path()).unwrap();
+        assert_eq!(runs.len(), 2);
+        assert_ne!(
+            runs[0].session_key, runs[1].session_key,
+            "each per-run run carries a unique session key"
+        );
+    }
+
+    #[tokio::test]
+    async fn shared_chat_mode_reuses_one_chat_across_runs() {
+        // Contrast to the per-run case: the Shared default collapses two
+        // surfaced runs into a single chat (#381 behavior, preserved).
+        use crate::agents::activity;
+        use crate::routines::engine_dispatcher::EngineActivitySurface;
+
+        let d = TempDir::new().unwrap();
+        let agent_path = d.path().to_string_lossy().to_string();
+        let mut shared = sample_routine();
+        shared.suppress_when_silent = false; // surface every run
+        let r = create(d.path(), shared).unwrap();
+
+        let dispatcher = Arc::new(FakeDispatcher(DispatchOutcome {
+            response_text: "Found something".into(),
+            error: None,
+        }));
+        let surface: Arc<dyn ActivitySurface> = Arc::new(EngineActivitySurface);
+        let events: DynEventSink = Arc::new(NoopEventSink);
+
+        run_routine(events.clone(), dispatcher.clone(), surface.clone(), &agent_path, &r.id)
+            .await
+            .unwrap();
+        run_routine(events.clone(), dispatcher, surface, &agent_path, &r.id)
+            .await
+            .unwrap();
+
+        let acts = activity::list(d.path()).unwrap();
+        assert_eq!(acts.len(), 1, "shared mode keeps one chat for all runs");
+
+        let runs = routine_runs::list(d.path()).unwrap();
+        assert_eq!(runs[0].session_key, runs[1].session_key);
     }
 
     #[tokio::test]

--- a/engine/houston-engine-core/src/routines/runs.rs
+++ b/engine/houston-engine-core/src/routines/runs.rs
@@ -100,17 +100,30 @@ pub fn create(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
     with_runs_lock(root, || create_unlocked(root, routine_id))
 }
 
+/// Derive a run's `session_key` from its routine's `chat_mode` (#423). Reads
+/// the routine config to pick `Shared` (`routine-{id}`) vs. `PerRun`
+/// (`routine-{id}-run-{run_id}`). A routine that can't be found falls back to
+/// `Shared` — the #381 default — so a stray run never fails on key derivation.
+fn session_key_for(root: &Path, routine_id: &str, run_id: &str) -> CoreResult<String> {
+    let chat_mode = crate::routines::list(root)?
+        .into_iter()
+        .find(|r| r.id == routine_id)
+        .map(|r| r.chat_mode)
+        .unwrap_or_default();
+    Ok(chat_mode.session_key(routine_id, run_id))
+}
+
 fn create_unlocked(root: &Path, routine_id: &str) -> CoreResult<RoutineRun> {
     ensure_houston_dir(root)?;
     let mut runs = list(root)?;
     let id = Uuid::new_v4().to_string();
-    // One chat per routine (#381): the session key is stable per routine, NOT
-    // per run, so every run of a routine streams + persists into the same
-    // conversation. The shared key's `.history` file aggregates each run's
-    // provider session id, so opening the routine's chat shows a running log of
-    // all its reports instead of a fresh chat per surfaced run. Runs stay
-    // independent (the dispatcher never resumes) — only the *view* is unified.
-    let session_key = format!("routine-{routine_id}");
+    // The session key is the single lever for how a routine's runs map onto
+    // chats: the activity surface + session history both find-or-create on it.
+    // `Shared` (the #381 default) keeps a stable `routine-{id}` key so every run
+    // streams into one conversation; `PerRun` (#423) makes it unique per run so
+    // each surfaces in a fresh chat. Runs stay independent either way (the
+    // dispatcher never resumes) — only the *view* changes.
+    let session_key = session_key_for(root, routine_id, &id)?;
     let run = RoutineRun {
         id,
         routine_id: routine_id.to_string(),
@@ -258,6 +271,55 @@ mod tests {
 
         let other = create(d.path(), "other").unwrap();
         assert_eq!(other.session_key, "routine-other");
+    }
+
+    #[test]
+    fn session_key_follows_routine_chat_mode() {
+        use crate::routines::types::{NewRoutine, RoutineChatMode};
+
+        let d = TempDir::new().unwrap();
+
+        // Shared routine → stable per-routine key, every run collapses to one.
+        let shared = crate::routines::create(
+            d.path(),
+            NewRoutine {
+                name: "Shared".into(),
+                description: String::new(),
+                prompt: "p".into(),
+                schedule: "0 9 * * *".into(),
+                enabled: true,
+                suppress_when_silent: true,
+                chat_mode: RoutineChatMode::Shared,
+                timezone: None,
+                integrations: vec![],
+            },
+        )
+        .unwrap();
+        let r1 = create(d.path(), &shared.id).unwrap();
+        let r2 = create(d.path(), &shared.id).unwrap();
+        assert_eq!(r1.session_key, format!("routine-{}", shared.id));
+        assert_eq!(r2.session_key, r1.session_key, "shared mode reuses one key");
+
+        // Per-run routine → unique key per run, each run a fresh chat.
+        let per_run = crate::routines::create(
+            d.path(),
+            NewRoutine {
+                name: "PerRun".into(),
+                description: String::new(),
+                prompt: "p".into(),
+                schedule: "0 9 * * *".into(),
+                enabled: true,
+                suppress_when_silent: true,
+                chat_mode: RoutineChatMode::PerRun,
+                timezone: None,
+                integrations: vec![],
+            },
+        )
+        .unwrap();
+        let p1 = create(d.path(), &per_run.id).unwrap();
+        let p2 = create(d.path(), &per_run.id).unwrap();
+        assert_eq!(p1.session_key, format!("routine-{}-run-{}", per_run.id, p1.id));
+        assert_ne!(p1.session_key, p2.session_key, "per-run mode keys are unique");
     }
 
     #[test]

--- a/engine/houston-engine-core/src/routines/scheduler.rs
+++ b/engine/houston-engine-core/src/routines/scheduler.rs
@@ -298,7 +298,7 @@ mod tests {
     use super::*;
     use crate::routines::create;
     use crate::routines::runner::{DispatchContext, DispatchOutcome};
-    use crate::routines::types::NewRoutine;
+    use crate::routines::types::{NewRoutine, RoutineChatMode};
     use async_trait::async_trait;
     use houston_ui_events::NoopEventSink;
     use std::path::Path;
@@ -334,6 +334,7 @@ mod tests {
             schedule: "0 9 * * *".into(),
             enabled,
             suppress_when_silent: true,
+            chat_mode: RoutineChatMode::Shared,
             timezone: tz.map(str::to_string),
             integrations: vec![],
         }
@@ -400,6 +401,7 @@ mod tests {
                 schedule: "not a cron".into(),
                 enabled: true,
                 suppress_when_silent: true,
+                chat_mode: RoutineChatMode::Shared,
                 timezone: None,
                 integrations: vec![],
             },

--- a/engine/houston-engine-core/src/routines/types.rs
+++ b/engine/houston-engine-core/src/routines/types.rs
@@ -6,6 +6,38 @@ fn default_true() -> bool {
     true
 }
 
+// -- Chat mode --
+
+/// Whether a routine's runs share one chat or each surface in a fresh one.
+///
+/// The single lever behind the run's `session_key`: the activity surface +
+/// session history both find-or-create on that key, so the key shape is what
+/// decides how many chats a routine's runs collapse into.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RoutineChatMode {
+    /// Every run streams into one persistent chat (`routine-{id}`). The
+    /// behavior shipped in #381 and the default for every routine that
+    /// predates this option, so existing routines keep one chat untouched.
+    #[default]
+    Shared,
+    /// Each run surfaces in its own fresh chat (`routine-{id}-run-{run_id}`) —
+    /// the pre-#381 per-run keying, now opt-in (#423).
+    PerRun,
+}
+
+impl RoutineChatMode {
+    /// Build the run's `session_key` for this mode. Shared collapses every run
+    /// into one chat; per-run gives each run a unique key so the surface +
+    /// session history create a new chat for it.
+    pub fn session_key(self, routine_id: &str, run_id: &str) -> String {
+        match self {
+            RoutineChatMode::Shared => format!("routine-{routine_id}"),
+            RoutineChatMode::PerRun => format!("routine-{routine_id}-run-{run_id}"),
+        }
+    }
+}
+
 // -- Routine --
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -23,6 +55,11 @@ pub struct Routine {
     /// (no activity surfaces on the board).
     #[serde(default = "default_true")]
     pub suppress_when_silent: bool,
+    /// Whether each run reuses one chat or starts a fresh one. Defaults to
+    /// `Shared` so every existing routine keeps the one-chat-per-routine
+    /// behavior (#381) until the user opts into a new chat per run (#423).
+    #[serde(default)]
+    pub chat_mode: RoutineChatMode,
     /// IANA timezone override (e.g. `"America/Bogota"`). When `None`, the
     /// scheduler falls back to the user's `timezone` preference, then UTC.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -49,6 +86,8 @@ pub struct NewRoutine {
     #[serde(default = "default_true")]
     pub suppress_when_silent: bool,
     #[serde(default)]
+    pub chat_mode: RoutineChatMode,
+    #[serde(default)]
     pub timezone: Option<String>,
     #[serde(default)]
     pub integrations: Vec<String>,
@@ -62,6 +101,7 @@ pub struct RoutineUpdate {
     pub schedule: Option<String>,
     pub enabled: Option<bool>,
     pub suppress_when_silent: Option<bool>,
+    pub chat_mode: Option<RoutineChatMode>,
     /// `Some(Some("..."))` sets a tz override, `Some(None)` clears it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub timezone: Option<Option<String>>,

--- a/ui/agent-schemas/src/routines.schema.json
+++ b/ui/agent-schemas/src/routines.schema.json
@@ -14,6 +14,12 @@
       "schedule": { "type": "string", "description": "Cron expression (e.g. '0 9 * * 1-5')." },
       "enabled": { "type": "boolean" },
       "suppress_when_silent": { "type": "boolean", "description": "If true, runs that respond ROUTINE_OK are silent." },
+      "chat_mode": {
+        "type": "string",
+        "enum": ["shared", "per_run"],
+        "default": "shared",
+        "description": "Whether each run reuses one chat ('shared', the default) or starts a fresh chat per run ('per_run')."
+      },
       "integrations": {
         "type": "array",
         "items": { "type": "string" },

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -165,6 +165,13 @@ export interface NewActivity {
   model?: string;
 }
 
+/**
+ * Whether a routine's runs share one chat or each start a fresh one.
+ * `"shared"` (the default) keeps one chat per routine; `"per_run"` surfaces
+ * each run in its own chat.
+ */
+export type RoutineChatMode = "shared" | "per_run";
+
 export interface Routine {
   id: string;
   name: string;
@@ -173,6 +180,8 @@ export interface Routine {
   schedule: string;
   enabled: boolean;
   suppress_when_silent: boolean;
+  /** Whether each run reuses one chat or starts a fresh one. */
+  chat_mode: RoutineChatMode;
   /** IANA timezone override; absent means use the user's preference. */
   timezone?: string | null;
   /** Composio toolkit slugs this routine uses (e.g. ["gmail", "slack"]). */
@@ -188,6 +197,8 @@ export interface NewRoutine {
   schedule: string;
   enabled?: boolean;
   suppress_when_silent?: boolean;
+  /** Defaults to `"shared"` (one chat per routine) when omitted. */
+  chat_mode?: RoutineChatMode;
   /** IANA timezone override (e.g. "America/Bogota"). Falls back to user pref. */
   timezone?: string | null;
   /** Composio toolkit slugs this routine uses. */
@@ -201,6 +212,7 @@ export interface RoutineUpdate {
   schedule?: string;
   enabled?: boolean;
   suppress_when_silent?: boolean;
+  chat_mode?: RoutineChatMode;
   /** Set to a string to override, `null` to clear, omit to leave unchanged. */
   timezone?: string | null;
   integrations?: string[];

--- a/ui/routines/src/index.ts
+++ b/ui/routines/src/index.ts
@@ -1,6 +1,7 @@
 // Types
 export type {
   Routine,
+  RoutineChatMode,
   RoutineRun,
   RunStatus,
   SchedulePreset,

--- a/ui/routines/src/routine-editor.tsx
+++ b/ui/routines/src/routine-editor.tsx
@@ -27,7 +27,7 @@ import {
   CalendarClock,
   MoreHorizontal,
 } from "lucide-react"
-import type { Routine, RoutineRun } from "./types"
+import type { Routine, RoutineChatMode, RoutineRun } from "./types"
 import { ScheduleBuilder } from "./schedule-builder"
 import { RunHistory } from "./run-history"
 import { nextFire, describeNextFire } from "./next-fire"
@@ -39,6 +39,8 @@ export interface RoutineFormData {
   prompt: string
   schedule: string
   suppress_when_silent: boolean
+  /** Whether each run reuses one chat (`"shared"`) or starts a fresh one. */
+  chat_mode: RoutineChatMode
   /** IANA timezone override. `null`/empty means use the account default. */
   timezone?: string | null
   /** Composio toolkit slugs this routine uses. */
@@ -407,6 +409,25 @@ export function RoutineEditor({
                   onChange({ suppress_when_silent: checked })
                 }
                 aria-label="Only notify when relevant"
+              />
+            </div>
+
+            <div className="flex items-center justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-sm text-foreground">
+                  Keep results in one chat
+                </p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Every run adds to the same chat. Turn this off to start a new
+                  chat each time this routine runs.
+                </p>
+              </div>
+              <Switch
+                checked={value.chat_mode === "shared"}
+                onCheckedChange={(checked) =>
+                  onChange({ chat_mode: checked ? "shared" : "per_run" })
+                }
+                aria-label="Keep results in one chat"
               />
             </div>
           </SectionCard>

--- a/ui/routines/src/types.ts
+++ b/ui/routines/src/types.ts
@@ -1,5 +1,12 @@
 // Routine types — mirrors Houston's new file-backed Routine model.
 
+/**
+ * Whether a routine's runs share one chat or each start a fresh one.
+ * `"shared"` (the default) keeps one chat per routine; `"per_run"` surfaces
+ * each run in its own chat.
+ */
+export type RoutineChatMode = "shared" | "per_run"
+
 export interface Routine {
   id: string
   name: string
@@ -11,6 +18,8 @@ export interface Routine {
   enabled: boolean
   /** When true, runs where Claude responds with ROUTINE_OK are auto-completed silently. */
   suppress_when_silent: boolean
+  /** Whether each run reuses one chat or starts a fresh one. */
+  chat_mode: RoutineChatMode
   /** IANA timezone override; absent means use the user's account timezone. */
   timezone?: string | null
   /** Composio toolkit slugs this routine uses (e.g. ["gmail", "slack"]). */


### PR DESCRIPTION
Closes #423.

## What
Adds a **"Keep results in one chat"** toggle to the routine editor's **Behavior** section:

- **On (default)** — every run streams into one chat per routine (the behavior shipped in #381).
- **Off** — each run surfaces in its own fresh chat, and (because silent runs never surface) a run only spawns a chat when it actually has something to report, so it composes with **"Only notify when relevant"** for free.

## How it works
The whole feature rides on a run's `session_key` — the activity surface *and* the session history both find-or-create on it. A new `RoutineChatMode` enum derives the key:

| mode | session_key | result |
|------|-------------|--------|
| `Shared` (default) | `routine-{id}` | one chat, all runs |
| `PerRun` | `routine-{id}-run-{run_id}` | a fresh chat per run (the pre-#381 keying) |

Key derivation is centralized in `session_key_for` at the single point of run creation, so the cron scheduler, "Run now", and the REST create-run routes all pick it up.

## Migration (issue's two cases)
`chat_mode` is `#[serde(default)]` → **Shared**, so **no data rewrite is needed**:
- **Routines created after #381** (currently one shared chat) read back as `Shared` → behavior unchanged. Toggling the option off makes future runs create a new chat each run.
- **Routines created before #381** also read back as `Shared`; their old per-run "dead" chats are deliberately left untouched (the surface only matches the exact `session_key`).

## Two routine type trees
This repo carries two parallel routine implementations writing the same `routines.json`: `crate::routines::*` (scheduler/runner + `/routines`) and `crate::agents::*` (the live UI CRUD path behind `/agents/routines`). I added `chat_mode` to **both** so the field round-trips no matter which path reads/writes it — mirroring how #381 touched both. Two things worth a follow-up (pre-existing, **not** changed here):
- The duplication itself is ripe for consolidation.
- `crate::agents::types::Routine` has no `timezone` field, so the UI CRUD path already drops a per-routine timezone override on write. `chat_mode` is safe (it lives in both trees); flagging the timezone drift separately.

## i18n note
The routine **editor** (`ui/routines/routine-editor.tsx`) is currently hardcoded English with no `labels` prop (e.g. the sibling "Only notify when relevant"). I matched that convention for the new strings rather than retrofit a labels system for two strings while a dozen others stay hardcoded — the editor's i18n is a separate cleanup.

## Tests
- `routines/types` — `RoutineChatMode::session_key` shapes.
- `routines/runs` + `agents/routine_runs` — session_key follows the routine's `chat_mode`; absent field reads as Shared.
- `routines/mod` — create/update round-trip; legacy-JSON-without-`chat_mode` reads as Shared.
- `routines/runner` — end-to-end through the real `EngineActivitySurface`: PerRun → 2 distinct chats across 2 runs; Shared → 1 chat.
- `app/tests/routines-tab-model` — form projection + `chat_mode` change detection.

## Affected files
**Engine:** `routines/{types,mod,runs,runner,scheduler,engine_dispatcher}.rs`, `agents/{types,routines,routine_runs,mod}.rs`
**Schema:** `ui/agent-schemas/src/routines.schema.json`
**TS/UI:** `ui/engine-client/src/types.ts`, `ui/routines/src/{types,index,routine-editor}.tsx`, `app/src/components/tabs/routines-tab-model.ts`, `app/src/components/shell/create-workspace-dialog.tsx`, `app/tests/routines-tab-model.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)