### PR TITLE
fix(app): don't let the boot LanguageGate hang the window on a stalled workspace fetch (#439)

### DIFF
--- a/app/src/hooks/use-locale-preference.ts
+++ b/app/src/hooks/use-locale-preference.ts
@@ -10,6 +10,7 @@ import {
   applyEngineLocale,
   changeLocale,
   isSupported,
+  localeGateIsLoading,
   resolveEffectiveLocale,
   type SupportedLocale,
 } from "../lib/i18n";
@@ -25,7 +26,11 @@ export interface LocalePreferenceState {
    * picker). Per-workspace overrides do NOT affect first-run.
    */
   locale: SupportedLocale | null;
-  /** True until every source has resolved AND the resolved locale is applied. */
+  /**
+   * True until the GLOBAL preference has resolved AND been applied. The
+   * per-workspace override is applied on arrival and NEVER holds the first
+   * paint — blocking on it hung the app on launch (gethouston/houston#439).
+   */
   isLoading: boolean;
   /**
    * First-run picker write: persist the GLOBAL default (no workspace exists
@@ -62,11 +67,14 @@ export function useLocalePreference(): LocalePreferenceState {
   });
 
   // Boot-time active-workspace override, resolved INDEPENDENTLY of <App/> —
-  // which mounts below <LanguageGate> and only then loads workspaces. Without
-  // this the gate would apply the global default on the first paint and then
-  // flash to the workspace override once <App/> loads. Best-effort: a failure
-  // logs and resolves null (the real error surfaces via the store's
-  // loadWorkspaces), so boot falls back to the global default, never blocks.
+  // which mounts below <LanguageGate> and only then loads workspaces. When this
+  // resolves quickly the first paint already reflects the override (no flash);
+  // when it is slow or never settles it is applied on arrival instead. It is
+  // best-effort and MUST NOT gate the paint: see `localeGateIsLoading` and the
+  // apply effect below. Blocking the gate on this query hung the app on launch
+  // (a non-settling GET /workspaces never released the gate, gethouston/houston#439).
+  // A rejecting fetch logs and resolves null (the real error surfaces via the
+  // store's loadWorkspaces), so boot falls back to the global default.
   const bootWorkspaceQuery = useQuery({
     queryKey: bootWorkspaceKey,
     queryFn: async (): Promise<string | null> => {
@@ -96,13 +104,17 @@ export function useLocalePreference(): LocalePreferenceState {
     : bootWorkspaceQuery.data ?? null;
   const effective = resolveEffectiveLocale(workspaceLocale, globalLocale);
 
-  // Apply the engine-resolved locale to the live i18n instance, and re-apply
-  // when it changes (e.g. switching into a workspace that pins a different
-  // language). Applying is best-effort — the i18next detector already picked a
-  // valid language — so a failure must NOT hold the gate: always un-gate in
+  // Apply the engine-resolved locale to the live i18n instance once the GLOBAL
+  // preference has resolved, and re-apply whenever `effective` changes — which
+  // includes the boot workspace override landing LATER (apply-on-arrival) and
+  // the user switching into a workspace that pins a different language. We do
+  // NOT wait on `bootWorkspaceQuery` here: gating the first paint on it hung
+  // the app when GET /workspaces never settled (gethouston/houston#439).
+  // Applying is best-effort — the i18next detector already picked a valid
+  // language — so a failure must NOT hold the gate: always un-gate in
   // `finally`, and log (never silently swallow) on error.
   useEffect(() => {
-    if (globalQuery.isLoading || bootWorkspaceQuery.isLoading) return;
+    if (globalQuery.isLoading) return;
     let cancelled = false;
     void (async () => {
       try {
@@ -119,7 +131,7 @@ export function useLocalePreference(): LocalePreferenceState {
     return () => {
       cancelled = true;
     };
-  }, [globalQuery.isLoading, bootWorkspaceQuery.isLoading, effective]);
+  }, [globalQuery.isLoading, effective]);
 
   const mutation = useMutation({
     mutationFn: async (locale: SupportedLocale) => {
@@ -141,7 +153,7 @@ export function useLocalePreference(): LocalePreferenceState {
 
   return {
     locale: globalLocale,
-    isLoading: globalQuery.isLoading || bootWorkspaceQuery.isLoading || !applied,
+    isLoading: localeGateIsLoading(globalQuery.isLoading, applied),
     setLocale,
   };
 }

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -20,6 +20,7 @@ import {
   resolveEffectiveLocale,
   localeToApply,
   activeWorkspaceLocale,
+  localeGateIsLoading,
   type SupportedLocale,
 } from "./locale";
 
@@ -85,6 +86,7 @@ export {
   resolveEffectiveLocale,
   localeToApply,
   activeWorkspaceLocale,
+  localeGateIsLoading,
 };
 export type { SupportedLocale };
 

--- a/app/src/lib/locale.ts
+++ b/app/src/lib/locale.ts
@@ -91,3 +91,22 @@ export function activeWorkspaceLocale(
     workspaces[0];
   return active.locale ?? null;
 }
+
+/**
+ * Whether the first-run `LanguageGate` must keep blocking the first paint.
+ *
+ * ONLY the global locale preference gates the paint: it decides the language
+ * (and whether to show the first-run picker) and is a tiny KV read. The
+ * per-workspace override (`bootWorkspaceQuery`) is best-effort and applied on
+ * arrival, so it MUST NOT be a factor here — it takes no parameter by design.
+ *
+ * Blocking the gate on that override is what hung the whole app on launch: a
+ * non-settling `GET /workspaces` left the gate loading forever, so `<App/>`
+ * never mounted and the window stayed blank (gethouston/houston#439).
+ */
+export function localeGateIsLoading(
+  globalQueryLoading: boolean,
+  applied: boolean,
+): boolean {
+  return globalQueryLoading || !applied;
+}

--- a/app/tests/locale.test.ts
+++ b/app/tests/locale.test.ts
@@ -6,6 +6,7 @@ import {
   resolveEffectiveLocale,
   localeToApply,
   activeWorkspaceLocale,
+  localeGateIsLoading,
 } from "../src/lib/locale.ts";
 
 describe("isSupported", () => {
@@ -109,5 +110,23 @@ describe("activeWorkspaceLocale", () => {
     const list = [ws("a", true), ws("b", false, "pt")];
     strictEqual(activeWorkspaceLocale(list, null), null); // default has no override
     strictEqual(activeWorkspaceLocale(list, "a"), null);
+  });
+});
+
+describe("localeGateIsLoading", () => {
+  it("blocks the first paint until the global preference is loaded and applied", () => {
+    ok(localeGateIsLoading(true, false)); // global still loading
+    ok(localeGateIsLoading(true, true)); // global loading wins regardless of applied
+    ok(localeGateIsLoading(false, false)); // loaded but not yet applied
+    strictEqual(localeGateIsLoading(false, true), false); // loaded + applied -> paint
+  });
+
+  it("does NOT depend on the best-effort workspace override query (gethouston/houston#439)", () => {
+    // The predicate takes no workspace-query argument by design: a non-settling
+    // GET /workspaces must never hold the gate. Once the global preference is
+    // loaded and applied, the gate releases — there is no third input that a
+    // stalled override query could keep true. This is the regression guard for
+    // the v0.4.17 launch hang.
+    strictEqual(localeGateIsLoading(false, true), false);
   });
 });

--- a/engine/houston-engine-server/src/routes/workspaces.rs
+++ b/engine/houston-engine-server/src/routes/workspaces.rs
@@ -10,6 +10,7 @@ use axum::{
 use houston_engine_core::agents_crud::{self, Agent, CreateAgent, CreateAgentResult, UpdateAgent};
 use houston_engine_core::workspace_context::{self, WorkspaceContext};
 use houston_engine_core::workspaces::{self, CreateWorkspace, RenameWorkspace, Workspace};
+use houston_engine_core::CoreError;
 use serde::Deserialize;
 use std::sync::Arc;
 
@@ -39,7 +40,16 @@ pub fn router() -> Router<Arc<ServerState>> {
 }
 
 async fn list(State(st): State<Arc<ServerState>>) -> Result<Json<Vec<Workspace>>, ApiError> {
-    Ok(Json(workspaces::list(st.engine.paths.docs())?))
+    // `workspaces::list` does synchronous filesystem work (create_dir_all +
+    // read the workspaces dir). This is the call the frontend's boot
+    // `LanguageGate` makes on every launch, so a slow or contended disk read
+    // must not block a tokio worker and starve other requests. Run it on a
+    // blocking thread (gethouston/houston#439).
+    let docs = st.engine.paths.docs().to_path_buf();
+    let workspaces = tokio::task::spawn_blocking(move || workspaces::list(&docs))
+        .await
+        .map_err(|e| CoreError::Internal(format!("workspaces list task failed: {e}")))??;
+    Ok(Json(workspaces))
 }
 
 async fn create(

--- a/knowledge-base/architecture.md
+++ b/knowledge-base/architecture.md
@@ -121,6 +121,26 @@ than blanking the chat. `minimumSystemVersion` in `tauri.conf.json` stays at
 `10.15` (install-time native-binary floor) — the capability gate, not the OS
 version, decides whether the UI can actually run.
 
+## App boot — gate chain must never hang on the engine
+
+After the compat gate, the React tree mounts behind a chain of gates that each
+withhold the first paint until something resolves: `EngineGate` (waits for
+`houston-engine-ready`) → `LanguageGate` (waits for the locale preference) →
+`DisclaimerGate` → `<App/>` (`app/src/main.tsx`). A gate that blocks on an
+engine call with no bound turns a single slow/stalled request into a permanently
+blank window — the engine can be healthy in 50ms and the user still never sees
+a UI. That was issue #439: v0.4.17 (#390) made `LanguageGate` block on a
+best-effort `GET /workspaces` (`use-locale-preference.ts`); when that request
+never settled, `<App/>` never mounted, `frontend.log` went silent, and users
+force-quit (which then triggered macOS's "reopen windows" dialog).
+
+Invariant: **a boot gate may only block on what it strictly needs, and that
+call must be bounded.** Best-effort enrichment (per-workspace locale override,
+etc.) is applied on arrival, never gated on — see `localeGateIsLoading` in
+`app/src/lib/locale.ts`. Engine handlers on the boot path must not run
+synchronous filesystem work directly on the async runtime (`workspaces::list`
+now uses `spawn_blocking`) so a slow disk read can't wedge a tokio worker.
+
 ## UI packages (`ui/`)
 
 11 packages under `@houston-ai/`: `core, chat, board, layout, events,


### PR DESCRIPTION
## Root cause of #439

After updating to **v0.4.17**, some macOS users saw Houston hang on launch — the window never appeared. They force-quit (which is what makes macOS show the *"force quit while reopening windows"* dialog on the next launch), and a relaunch worked.

The user logs are decisive. In the hung launch:
- the engine printed `HOUSTON_ENGINE_LISTENING` **50ms** after spawn (fast), and `/v1/health` is a constant handler that can't stall;
- yet there was **no `WindowEvent::Focused` for ~27s** and `frontend.log` was **totally silent** (no `[auth] onAuthStateChange listener attached`, no composio/routines/watcher activity);
- the supervisor **auto-restarted the engine on its own thread mid-hang** — proving the main thread / event loop were alive.

So it is **not** slow engine bring-up and **not** a `setup()` main-thread block. It is a **frontend boot gate** that never released.

`#390` (`903b271f`, *"persist UI language per workspace in the engine"*, Jun 2) added a second engine call — `GET /workspaces` via `bootWorkspaceQuery` — into the `LanguageGate` boot gate, which sits **above `<App/>`** (`EngineGate → LanguageGate → DisclaimerGate → App`, `app/src/main.tsx`). `LanguageGate` renders a blank `bg-background` div and **withholds `<App/>` while `isLoading`** (`language-gate.tsx:20-29`), and `#390` made `isLoading` depend on that workspace fetch (`use-locale-preference.ts`). The call passes **no `AbortSignal`**, the `QueryClient` is `retry:false` with **no timeout** (`query-client.ts`), and the engine handler runs **synchronous filesystem work on the async runtime** (`workspaces.rs` → `workspaces::list`, no `spawn_blocking`). When `GET /workspaces` never settles, the gate stays loading forever → `<App/>` never mounts → blank window, silent frontend.

`git tag --contains 903b271f` → **`v0.4.17`, `v0.4.18` only** (absent from v0.4.16 and earlier), matching the "started in the last 2 days" report exactly.

## Fix

- **The per-workspace override must never hold the first paint.** It's best-effort (its own comment says "never blocks"). Gate only on the global locale preference + `applied`, via a new pure `localeGateIsLoading`; the override is applied **on arrival** (the apply effect already re-runs when `effective` changes). So even if `GET /workspaces` never settles, the gate releases as soon as the tiny locale-pref read resolves. — `app/src/lib/locale.ts`, `app/src/lib/i18n.ts`, `app/src/hooks/use-locale-preference.ts`
- **Engine defense-in-depth:** run `workspaces::list`'s sync fs read on `spawn_blocking` so a slow/contended disk read can't wedge a tokio worker. — `engine/houston-engine-server/src/routes/workspaces.rs`
- **Regression test** for `localeGateIsLoading` (the gate has no workspace-query input by design). — `app/tests/locale.test.ts`
- **Docs:** the boot-gate-must-not-hang invariant. — `knowledge-base/architecture.md`

## Relationship to #440

#440 (move engine bring-up off the Tauri main thread) is **separate launch hardening** and does **not** fix #439 — its target code is from v0.4.10 and the logs show the engine was fast and the main thread alive. This PR is the actual fix; #440 should not close #439.

## Follow-up (not in this PR)

A default timeout on `ui/engine-client` `request()` so *any* boot/gate engine call rejects instead of hanging forever (would also bound the global locale-pref read). Deferred because it changes shared engine-client behavior for all consumers (incl. mobile) and deserves its own review.

## Test plan

- `cd app && pnpm test` — runs `tests/locale.test.ts` incl. the new `localeGateIsLoading` cases.
- `cd app && pnpm tsc --noEmit`
- `cd app && pnpm check-locales`
- `cargo test -p houston-engine-server --test workspaces` (list handler behavior unchanged by `spawn_blocking`).
- Manual (macOS): launch repeatedly; the window should paint the language/app within ~1s even if a workspace fetch is slow. To exercise the path, throttle/stall `GET /workspaces` and confirm the app still paints (falling back to the global locale) instead of a blank window.

Closes #439

🤖 Generated with [Claude Code](https://claude.com/claude-code)