### PR TITLE
ci: install zstd from GitHub release, not the flaky Chocolatey feed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1013,12 +1013,34 @@ jobs:
           }
           Write-Host "Pinned Bun OK: $actual"
 
-      - name: Install jq + zstd (Chocolatey)
+      # jq is preinstalled on the GitHub Windows runners. zstd is NOT, and the
+      # Chocolatey community feed (community.chocolatey.org) 504s intermittently
+      # — it failed the ARM64 release leg repeatedly. Pull zstd straight from
+      # its GitHub release instead (pinned), which is far more reliable. The
+      # x64 binary runs natively on x64 and under emulation on the ARM64 runner;
+      # it's only used to decompress the codex archive in fetch-cli-deps.sh.
+      - name: Install jq + zstd
         shell: pwsh
         run: |
-          choco install -y jq zstandard --no-progress
+          $ErrorActionPreference = "Stop"
           jq --version
-          zstd --version
+
+          $ZSTD = "1.5.6"
+          $zip = "zstd-v$ZSTD-win64.zip"
+          $url = "https://github.com/facebook/zstd/releases/download/v$ZSTD/$zip"
+          $tmp = Join-Path $env:RUNNER_TEMP $zip
+          $out = Join-Path $env:RUNNER_TEMP "zstd"
+          Write-Host "Downloading $url"
+          for ($i = 1; $i -le 3; $i++) {
+            try { Invoke-WebRequest -Uri $url -OutFile $tmp; break }
+            catch { if ($i -eq 3) { throw }; Write-Host "retry $i…"; Start-Sleep 5 }
+          }
+          Expand-Archive -Force -Path $tmp -DestinationPath $out
+          # Zip extracts to a single `zstd-v<ver>-win64\` folder containing zstd.exe.
+          $dir = (Get-ChildItem -Path $out -Directory | Select-Object -First 1).FullName
+          if (-not $dir) { $dir = $out }
+          echo "$dir" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+          & "$dir\zstd.exe" --version
 
       # Stage bundled CLI binaries: codex.exe (downloaded + zstd),
       # composio-<arch>/composio.exe (built from gethouston/composio


### PR DESCRIPTION
## Problem
The Windows release jobs install `jq` + `zstd` via `choco install -y jq zstandard`. The Chocolatey **community feed** (`community.chocolatey.org`) returns `504 Gateway Timeout` intermittently, which has repeatedly failed the **Windows ARM64** release leg (and skipped `finalize` with it):

```
[NuGet] Error downloading 'zstandard.1.5.7…': 504 (Gateway Timeout)
The install of zstandard was NOT successful.
…
'zstd' is not recognized as a name of a cmdlet…
```

`jq` is already preinstalled on the runner (the log even says `jq v1.8.1 already installed`), so only `zstd` actually needs installing.

## Fix
Drop Chocolatey for this step. Pull the `zstd` Windows binary straight from **facebook/zstd's pinned GitHub release** (`v1.5.6`, asset `zstd-v1.5.6-win64.zip`, verified to exist) with a small 3× retry, and add it to `PATH`. GitHub release downloads are far more reliable than the choco community feed.

- The x64 zstd binary runs natively on x64 and under emulation on the ARM64 runner — it's only used to decompress the codex archive in `fetch-cli-deps.sh`.
- `jq` is now just verified (already on the runner), not reinstalled.

Unrelated to the in-flight Sentry work; this is purely a CI-reliability fix for the release pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)