### PR TITLE
feat: visible git-backed workspace root + developer mode (agentic-workspace F1)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2487,6 +2487,7 @@ dependencies = [
  "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-winrt-notification",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -2496,7 +2497,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "futures-util",
  "hex",
@@ -2516,7 +2517,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "serde",
  "serde_json",
@@ -2526,7 +2527,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2544,7 +2545,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2557,7 +2558,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2593,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2605,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2627,6 +2628,8 @@ dependencies = [
  "houston-ui-events",
  "rand 0.8.5",
  "reqwest 0.12.28",
+ "sentry",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "sha2",
@@ -2643,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2657,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2668,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2682,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2698,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2717,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "dirs 5.0.1",
  "houston-cli-bundle",
@@ -2730,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2750,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.17"
+version = "0.4.18"
 dependencies = [
  "houston-terminal-manager",
  "serde",
@@ -5520,6 +5523,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5826,6 +5830,7 @@ dependencies = [
  "httpdate",
  "native-tls",
  "reqwest 0.12.28",
+ "rustls 0.23.37",
  "sentry-actix",
  "sentry-backtrace",
  "sentry-contexts",
@@ -7647,10 +7652,12 @@ dependencies = [
  "log",
  "native-tls",
  "percent-encoding",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
  "webpki-root-certs",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -77,6 +77,9 @@ notify-rust = "4.11"
 # file under `%LOCALAPPDATA%\com.houston.app\auth\<key>.dpapi` instead.
 # DPAPI binds the ciphertext to the Windows user account so a copied
 # file is useless to another user. See `src/auth.rs` storage module.
+[dev-dependencies]
+tempfile = "3"
+
 [target."cfg(target_os = \"windows\")".dependencies]
 windows-sys = { version = "0.59", features = ["Win32_Foundation", "Win32_Security_Cryptography", "Win32_System_JobObjects", "Win32_System_Threading"] }
 # Same reason as notify-rust on Linux, but notify-rust's action handling is

--- a/app/src-tauri/src/app_config.rs
+++ b/app/src-tauri/src/app_config.rs
@@ -5,35 +5,44 @@
 //! `HOUSTON_DOCS`. Absent or empty `docsRoot` keeps the historical default
 //! (`<home>/workspaces`, i.e. `~/.houston/workspaces/`), so existing installs
 //! behave exactly as before until the user opts into a visible, git-backed
-//! root via onboarding.
+//! root via Settings.
+//!
+//! A workspace-location *change* is staged here (`migrateFrom`) and applied at
+//! the next boot, BEFORE the engine starts — so the move never races a live
+//! engine that is still reading/writing the old root.
 
 use serde::{Deserialize, Serialize};
+use std::ffi::OsStr;
 use std::io;
 use std::path::{Path, PathBuf};
 
 const FILE_NAME: &str = "app-config.json";
+const MANIFEST: &str = "workspaces.json";
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct AppConfig {
-    /// Absolute (or `~`-prefixed) path the user chose as their visible,
-    /// git-backed Houston root. `None`/empty → default `<home>/workspaces`.
+    /// Absolute path the user chose as their visible, git-backed Houston root.
+    /// `None`/empty → default `<home>/workspaces`. Stored already-resolved
+    /// (absolute) so the app (migrate) and engine (resolve) never disagree.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub docs_root: Option<String>,
+    /// Set by `set_docs_root` when the user changes the location. The next boot
+    /// moves the tree FROM this path INTO `docs_root` before the engine starts,
+    /// then clears it. Absolute path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub migrate_from: Option<String>,
 }
 
 fn config_path(houston: &Path) -> PathBuf {
     houston.join(FILE_NAME)
 }
 
-fn expand_tilde(path: &str) -> PathBuf {
-    if let Some(rest) = path.strip_prefix('~') {
-        if let Some(home) = dirs::home_dir() {
-            let rest = rest.strip_prefix('/').unwrap_or(rest);
-            return if rest.is_empty() { home } else { home.join(rest) };
-        }
-    }
-    PathBuf::from(path)
+/// The one tilde-expander used on the docs-root path. Delegates to the shared
+/// `houston_tauri::paths::expand_tilde` so the app (migrate) and the engine
+/// (resolve) never diverge on what a stored `docsRoot` means.
+pub fn expand_path(path: &str) -> PathBuf {
+    houston_tauri::paths::expand_tilde(&PathBuf::from(path))
 }
 
 /// Load app config. A missing file is the normal first-run case → default.
@@ -85,38 +94,123 @@ pub fn resolve_docs_dir(houston: &Path, cfg: &AppConfig) -> PathBuf {
         .map(str::trim)
         .filter(|s| !s.is_empty())
     {
-        Some(root) => expand_tilde(root),
+        Some(root) => expand_path(root),
         None => houston.join("workspaces"),
     }
 }
 
-/// Move an existing workspace tree from `old_root` to `new_root` when a user
-/// opts into a visible, git-backed root. Idempotent + non-destructive: it only
-/// moves when `new_root` has no `workspaces.json` yet, and never overwrites an
-/// entry that already exists in the target. Mirrors the legacy-docs migration
-/// (`migrate_legacy_docs_dir`). Returns `Ok(true)` when a move happened.
+/// True when two paths resolve to the same location (canonicalizing when both
+/// exist; lexical fallback otherwise).
+pub fn paths_equal(a: &Path, b: &Path) -> bool {
+    match (std::fs::canonicalize(a), std::fs::canonicalize(b)) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => a == b,
+    }
+}
+
+/// True when either path is an ancestor of (or equal to) the other —
+/// moving a tree into a location nested within itself would tear it.
+pub fn paths_overlap(a: &Path, b: &Path) -> bool {
+    let ca = std::fs::canonicalize(a).unwrap_or_else(|_| a.to_path_buf());
+    let cb = std::fs::canonicalize(b).unwrap_or_else(|_| b.to_path_buf());
+    ca.starts_with(&cb) || cb.starts_with(&ca)
+}
+
+/// Move an existing workspace tree from `old_root` to `new_root`.
 ///
-/// `old_root` and `new_root` are expected to live on the same filesystem (both
-/// under `$HOME`), so per-entry `rename` is atomic and cheap.
+/// EXDEV-safe, no-loss, and resumable:
+/// - per-entry `rename`, falling back to recursive copy across filesystems
+///   (external drive, network mount, iCloud) — `rename` fails `EXDEV` there;
+/// - a source entry is removed only AFTER it is fully written to the
+///   destination, so a crash can tear the tree but never lose data;
+/// - the index `workspaces.json` is moved LAST, so an interrupted run leaves
+///   the source still "migratable" and a retry resumes where it left off.
+///
+/// Idempotent + non-clobbering: no-op when `old_root` has no manifest or when
+/// `new_root` already has one. Returns `Ok(true)` when anything moved.
 pub fn migrate_docs_root(old_root: &Path, new_root: &Path) -> io::Result<bool> {
-    if !old_root.join("workspaces.json").is_file() {
+    if paths_equal(old_root, new_root) {
+        return Ok(false);
+    }
+    if !old_root.join(MANIFEST).is_file() {
         return Ok(false); // nothing to migrate
     }
-    if new_root.join("workspaces.json").is_file() {
+    if new_root.join(MANIFEST).is_file() {
         return Ok(false); // target already populated — never clobber
     }
     std::fs::create_dir_all(new_root)?;
+
+    // Move the manifest LAST so the "source still has a manifest" guard above
+    // stays true across a partial run, making retries resume cleanly.
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(old_root)?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .collect();
+    entries.sort_by_key(|p| p.file_name() == Some(OsStr::new(MANIFEST)));
+
     let mut moved = false;
-    for entry in std::fs::read_dir(old_root)? {
-        let entry = entry?;
-        let dst = new_root.join(entry.file_name());
+    for src in entries {
+        let name = match src.file_name() {
+            Some(n) => n.to_owned(),
+            None => continue,
+        };
+        let dst = new_root.join(&name);
         if dst.exists() {
-            continue; // never overwrite an existing entry in the target
+            tracing::warn!(
+                "[migrate] left {:?} in place: already exists at destination",
+                name
+            );
+            continue;
         }
-        std::fs::rename(entry.path(), &dst)?;
+        move_entry(&src, &dst)?;
         moved = true;
     }
     Ok(moved)
+}
+
+/// Move one entry, falling back to copy+remove across filesystems. The source
+/// is removed only after the destination is fully written, so a failure leaves
+/// the source intact (any partial destination copy is cleaned up).
+fn move_entry(src: &Path, dst: &Path) -> io::Result<()> {
+    match std::fs::rename(src, dst) {
+        Ok(()) => Ok(()),
+        Err(e) if is_cross_device(&e) => {
+            if let Err(copy_err) = copy_recursive(src, dst) {
+                // Best-effort cleanup of the partial copy; source stays intact.
+                let _ = std::fs::remove_dir_all(dst);
+                let _ = std::fs::remove_file(dst);
+                return Err(copy_err);
+            }
+            if src.is_dir() {
+                std::fs::remove_dir_all(src)
+            } else {
+                std::fs::remove_file(src)
+            }
+        }
+        Err(e) => Err(e),
+    }
+}
+
+/// EXDEV on Unix is raw errno 18; Windows `ERROR_NOT_SAME_DEVICE` is 17.
+/// Matching the raw code avoids depending on the unstable
+/// `io::ErrorKind::CrossesDevices`.
+fn is_cross_device(e: &io::Error) -> bool {
+    matches!(e.raw_os_error(), Some(18) | Some(17))
+}
+
+fn copy_recursive(src: &Path, dst: &Path) -> io::Result<()> {
+    if src.is_dir() {
+        std::fs::create_dir_all(dst)?;
+        for entry in std::fs::read_dir(src)? {
+            let entry = entry?;
+            copy_recursive(&entry.path(), &dst.join(entry.file_name()))?;
+        }
+        Ok(())
+    } else {
+        if let Some(parent) = dst.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        std::fs::copy(src, dst).map(|_| ())
+    }
 }
 
 #[cfg(test)]
@@ -137,6 +231,7 @@ mod tests {
         let d = TempDir::new().unwrap();
         let cfg = AppConfig {
             docs_root: Some("/abs/Houston".into()),
+            migrate_from: None,
         };
         save(d.path(), &cfg).unwrap();
         let got = load(d.path());
@@ -152,6 +247,7 @@ mod tests {
         let d = TempDir::new().unwrap();
         let cfg = AppConfig {
             docs_root: Some("   ".into()),
+            migrate_from: None,
         };
         assert_eq!(resolve_docs_dir(d.path(), &cfg), d.path().join("workspaces"));
     }
@@ -160,46 +256,23 @@ mod tests {
     fn corrupt_config_is_default_not_panic() {
         let d = TempDir::new().unwrap();
         std::fs::write(d.path().join(FILE_NAME), "{not json").unwrap();
-        let cfg = load(d.path());
-        assert_eq!(cfg, AppConfig::default());
+        assert_eq!(load(d.path()), AppConfig::default());
     }
 
     #[test]
-    fn tilde_expands_to_home() {
+    fn migrate_from_roundtrips_and_skips_when_none() {
         let d = TempDir::new().unwrap();
-        let cfg = AppConfig {
-            docs_root: Some("~/Houston".into()),
-        };
-        if let Some(home) = dirs::home_dir() {
-            assert_eq!(resolve_docs_dir(d.path(), &cfg), home.join("Houston"));
-        }
-    }
-
-    #[test]
-    fn save_is_atomic_and_overwrites() {
-        let d = TempDir::new().unwrap();
+        // `migrate_from` absent → not serialized (additive, no key churn).
+        save(d.path(), &AppConfig { docs_root: Some("/x".into()), migrate_from: None }).unwrap();
+        let raw = std::fs::read_to_string(d.path().join(FILE_NAME)).unwrap();
+        assert!(!raw.contains("migrateFrom"));
+        // present → roundtrips.
         save(
             d.path(),
-            &AppConfig {
-                docs_root: Some("/one".into()),
-            },
+            &AppConfig { docs_root: Some("/x".into()), migrate_from: Some("/old".into()) },
         )
         .unwrap();
-        save(
-            d.path(),
-            &AppConfig {
-                docs_root: Some("/two".into()),
-            },
-        )
-        .unwrap();
-        assert_eq!(load(d.path()).docs_root.as_deref(), Some("/two"));
-        // No leftover temp files.
-        let leftovers: Vec<_> = std::fs::read_dir(d.path())
-            .unwrap()
-            .flatten()
-            .filter(|e| e.file_name().to_string_lossy().contains(".tmp-"))
-            .collect();
-        assert!(leftovers.is_empty(), "temp files leaked: {leftovers:?}");
+        assert_eq!(load(d.path()).migrate_from.as_deref(), Some("/old"));
     }
 
     #[test]
@@ -208,12 +281,14 @@ mod tests {
         let old = tmp.path().join("old");
         let new = tmp.path().join("Houston");
         std::fs::create_dir_all(old.join("Work/Agent")).unwrap();
-        std::fs::write(old.join("workspaces.json"), "[]").unwrap();
+        std::fs::write(old.join(MANIFEST), "[]").unwrap();
         std::fs::write(old.join("Work/Agent/CLAUDE.md"), "x").unwrap();
 
         assert!(migrate_docs_root(&old, &new).unwrap());
-        assert!(new.join("workspaces.json").is_file());
+        assert!(new.join(MANIFEST).is_file());
         assert!(new.join("Work/Agent/CLAUDE.md").is_file());
+        // Source fully drained.
+        assert!(!old.join(MANIFEST).exists());
         // Second call is a no-op (old no longer has a manifest).
         assert!(!migrate_docs_root(&old, &new).unwrap());
     }
@@ -233,12 +308,53 @@ mod tests {
         let new = tmp.path().join("new");
         std::fs::create_dir_all(&old).unwrap();
         std::fs::create_dir_all(&new).unwrap();
-        std::fs::write(old.join("workspaces.json"), "[\"old\"]").unwrap();
-        std::fs::write(new.join("workspaces.json"), "[\"new\"]").unwrap();
+        std::fs::write(old.join(MANIFEST), "[\"old\"]").unwrap();
+        std::fs::write(new.join(MANIFEST), "[\"new\"]").unwrap();
         assert!(!migrate_docs_root(&old, &new).unwrap());
         assert_eq!(
-            std::fs::read_to_string(new.join("workspaces.json")).unwrap(),
+            std::fs::read_to_string(new.join(MANIFEST)).unwrap(),
             "[\"new\"]"
         );
+    }
+
+    #[test]
+    fn migrate_noop_when_equal() {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path().join("Houston");
+        std::fs::create_dir_all(&root).unwrap();
+        std::fs::write(root.join(MANIFEST), "[]").unwrap();
+        assert!(!migrate_docs_root(&root, &root).unwrap());
+        assert!(root.join(MANIFEST).is_file());
+    }
+
+    #[test]
+    fn migrate_resumes_after_partial() {
+        // Simulate an interrupted run: one agent dir already at the destination,
+        // manifest still at source. A re-run must finish without clobbering and
+        // without losing the already-moved dir.
+        let tmp = TempDir::new().unwrap();
+        let old = tmp.path().join("old");
+        let new = tmp.path().join("new");
+        std::fs::create_dir_all(old.join("A")).unwrap();
+        std::fs::create_dir_all(old.join("B")).unwrap();
+        std::fs::write(old.join(MANIFEST), "[]").unwrap();
+        std::fs::create_dir_all(new.join("A")).unwrap(); // already moved
+        std::fs::write(new.join("A/keep"), "1").unwrap();
+
+        assert!(migrate_docs_root(&old, &new).unwrap());
+        assert!(new.join("A/keep").is_file()); // pre-moved dir untouched
+        assert!(new.join("B").is_dir()); // B finished
+        assert!(new.join(MANIFEST).is_file());
+    }
+
+    #[test]
+    fn paths_overlap_detects_nesting() {
+        let tmp = TempDir::new().unwrap();
+        let a = tmp.path().join("root");
+        let b = a.join("inner");
+        std::fs::create_dir_all(&b).unwrap();
+        assert!(paths_overlap(&a, &b));
+        assert!(paths_overlap(&b, &a));
+        assert!(!paths_overlap(&a, &tmp.path().join("sibling")));
     }
 }

--- a/app/src-tauri/src/app_config.rs
+++ b/app/src-tauri/src/app_config.rs
@@ -1,0 +1,244 @@
+//! Houston app-level configuration persisted at `~/.houston/app-config.json`.
+//!
+//! Read by the Tauri boot BEFORE the engine subprocess is spawned, so the
+//! user's chosen workspace-root location (`docsRoot`) can be injected as
+//! `HOUSTON_DOCS`. Absent or empty `docsRoot` keeps the historical default
+//! (`<home>/workspaces`, i.e. `~/.houston/workspaces/`), so existing installs
+//! behave exactly as before until the user opts into a visible, git-backed
+//! root via onboarding.
+
+use serde::{Deserialize, Serialize};
+use std::io;
+use std::path::{Path, PathBuf};
+
+const FILE_NAME: &str = "app-config.json";
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AppConfig {
+    /// Absolute (or `~`-prefixed) path the user chose as their visible,
+    /// git-backed Houston root. `None`/empty → default `<home>/workspaces`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub docs_root: Option<String>,
+}
+
+fn config_path(houston: &Path) -> PathBuf {
+    houston.join(FILE_NAME)
+}
+
+fn expand_tilde(path: &str) -> PathBuf {
+    if let Some(rest) = path.strip_prefix('~') {
+        if let Some(home) = dirs::home_dir() {
+            let rest = rest.strip_prefix('/').unwrap_or(rest);
+            return if rest.is_empty() { home } else { home.join(rest) };
+        }
+    }
+    PathBuf::from(path)
+}
+
+/// Load app config. A missing file is the normal first-run case → default.
+/// A corrupt file is logged and treated as default rather than crashing boot:
+/// there is no UI thread to toast on this early, and a broken config must never
+/// wedge startup.
+pub fn load(houston: &Path) -> AppConfig {
+    let path = config_path(houston);
+    let contents = match std::fs::read_to_string(&path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == io::ErrorKind::NotFound => return AppConfig::default(),
+        Err(e) => {
+            tracing::warn!("[app-config] read {} failed: {e}", path.display());
+            return AppConfig::default();
+        }
+    };
+    match serde_json::from_str(&contents) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            tracing::warn!(
+                "[app-config] parse {} failed: {e}; using defaults",
+                path.display()
+            );
+            AppConfig::default()
+        }
+    }
+}
+
+/// Persist app config atomically (temp + rename), matching the Houston
+/// file-write convention.
+pub fn save(houston: &Path, cfg: &AppConfig) -> io::Result<()> {
+    std::fs::create_dir_all(houston)?;
+    let path = config_path(houston);
+    let json = serde_json::to_string_pretty(cfg)
+        .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+    let tmp = path.with_extension(format!("json.tmp-{}", std::process::id()));
+    std::fs::write(&tmp, json.as_bytes())?;
+    std::fs::rename(&tmp, &path)?;
+    Ok(())
+}
+
+/// Resolve the workspace-root (`docs`) directory the engine should use.
+/// `docsRoot` from config when set + non-empty (tilde-expanded), else the
+/// historical default `<home>/workspaces`.
+pub fn resolve_docs_dir(houston: &Path, cfg: &AppConfig) -> PathBuf {
+    match cfg
+        .docs_root
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(root) => expand_tilde(root),
+        None => houston.join("workspaces"),
+    }
+}
+
+/// Move an existing workspace tree from `old_root` to `new_root` when a user
+/// opts into a visible, git-backed root. Idempotent + non-destructive: it only
+/// moves when `new_root` has no `workspaces.json` yet, and never overwrites an
+/// entry that already exists in the target. Mirrors the legacy-docs migration
+/// (`migrate_legacy_docs_dir`). Returns `Ok(true)` when a move happened.
+///
+/// `old_root` and `new_root` are expected to live on the same filesystem (both
+/// under `$HOME`), so per-entry `rename` is atomic and cheap.
+pub fn migrate_docs_root(old_root: &Path, new_root: &Path) -> io::Result<bool> {
+    if !old_root.join("workspaces.json").is_file() {
+        return Ok(false); // nothing to migrate
+    }
+    if new_root.join("workspaces.json").is_file() {
+        return Ok(false); // target already populated — never clobber
+    }
+    std::fs::create_dir_all(new_root)?;
+    let mut moved = false;
+    for entry in std::fs::read_dir(old_root)? {
+        let entry = entry?;
+        let dst = new_root.join(entry.file_name());
+        if dst.exists() {
+            continue; // never overwrite an existing entry in the target
+        }
+        std::fs::rename(entry.path(), &dst)?;
+        moved = true;
+    }
+    Ok(moved)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn absent_config_resolves_to_default() {
+        let d = TempDir::new().unwrap();
+        let cfg = load(d.path());
+        assert!(cfg.docs_root.is_none());
+        assert_eq!(resolve_docs_dir(d.path(), &cfg), d.path().join("workspaces"));
+    }
+
+    #[test]
+    fn save_then_load_roundtrip() {
+        let d = TempDir::new().unwrap();
+        let cfg = AppConfig {
+            docs_root: Some("/abs/Houston".into()),
+        };
+        save(d.path(), &cfg).unwrap();
+        let got = load(d.path());
+        assert_eq!(got, cfg);
+        assert_eq!(
+            resolve_docs_dir(d.path(), &got),
+            PathBuf::from("/abs/Houston")
+        );
+    }
+
+    #[test]
+    fn empty_or_whitespace_docs_root_falls_back_to_default() {
+        let d = TempDir::new().unwrap();
+        let cfg = AppConfig {
+            docs_root: Some("   ".into()),
+        };
+        assert_eq!(resolve_docs_dir(d.path(), &cfg), d.path().join("workspaces"));
+    }
+
+    #[test]
+    fn corrupt_config_is_default_not_panic() {
+        let d = TempDir::new().unwrap();
+        std::fs::write(d.path().join(FILE_NAME), "{not json").unwrap();
+        let cfg = load(d.path());
+        assert_eq!(cfg, AppConfig::default());
+    }
+
+    #[test]
+    fn tilde_expands_to_home() {
+        let d = TempDir::new().unwrap();
+        let cfg = AppConfig {
+            docs_root: Some("~/Houston".into()),
+        };
+        if let Some(home) = dirs::home_dir() {
+            assert_eq!(resolve_docs_dir(d.path(), &cfg), home.join("Houston"));
+        }
+    }
+
+    #[test]
+    fn save_is_atomic_and_overwrites() {
+        let d = TempDir::new().unwrap();
+        save(
+            d.path(),
+            &AppConfig {
+                docs_root: Some("/one".into()),
+            },
+        )
+        .unwrap();
+        save(
+            d.path(),
+            &AppConfig {
+                docs_root: Some("/two".into()),
+            },
+        )
+        .unwrap();
+        assert_eq!(load(d.path()).docs_root.as_deref(), Some("/two"));
+        // No leftover temp files.
+        let leftovers: Vec<_> = std::fs::read_dir(d.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp-"))
+            .collect();
+        assert!(leftovers.is_empty(), "temp files leaked: {leftovers:?}");
+    }
+
+    #[test]
+    fn migrate_moves_tree_when_target_empty() {
+        let tmp = TempDir::new().unwrap();
+        let old = tmp.path().join("old");
+        let new = tmp.path().join("Houston");
+        std::fs::create_dir_all(old.join("Work/Agent")).unwrap();
+        std::fs::write(old.join("workspaces.json"), "[]").unwrap();
+        std::fs::write(old.join("Work/Agent/CLAUDE.md"), "x").unwrap();
+
+        assert!(migrate_docs_root(&old, &new).unwrap());
+        assert!(new.join("workspaces.json").is_file());
+        assert!(new.join("Work/Agent/CLAUDE.md").is_file());
+        // Second call is a no-op (old no longer has a manifest).
+        assert!(!migrate_docs_root(&old, &new).unwrap());
+    }
+
+    #[test]
+    fn migrate_noop_without_source_manifest() {
+        let tmp = TempDir::new().unwrap();
+        let old = tmp.path().join("old");
+        std::fs::create_dir_all(&old).unwrap();
+        assert!(!migrate_docs_root(&old, &tmp.path().join("new")).unwrap());
+    }
+
+    #[test]
+    fn migrate_never_clobbers_populated_target() {
+        let tmp = TempDir::new().unwrap();
+        let old = tmp.path().join("old");
+        let new = tmp.path().join("new");
+        std::fs::create_dir_all(&old).unwrap();
+        std::fs::create_dir_all(&new).unwrap();
+        std::fs::write(old.join("workspaces.json"), "[\"old\"]").unwrap();
+        std::fs::write(new.join("workspaces.json"), "[\"new\"]").unwrap();
+        assert!(!migrate_docs_root(&old, &new).unwrap());
+        assert_eq!(
+            std::fs::read_to_string(new.join("workspaces.json")).unwrap(),
+            "[\"new\"]"
+        );
+    }
+}

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -5,3 +5,4 @@ pub mod diagnostics;
 pub mod portable;
 pub mod terminal;
 pub mod update;
+pub mod workspace_root;

--- a/app/src-tauri/src/commands/workspace_root.rs
+++ b/app/src-tauri/src/commands/workspace_root.rs
@@ -1,10 +1,12 @@
 //! Workspace-root selection — view + change the user-visible, git-backed
 //! Houston root (`docsRoot`).
 //!
-//! The chosen root is persisted in `~/.houston/app-config.json` and injected
-//! as `HOUSTON_DOCS` at the next boot, so a change takes effect on the next
-//! launch (the engine binds the root once at spawn). The caller prompts the
-//! user to restart Houston after a successful change.
+//! Changing the location does NOT move data inline — migrating a tree while the
+//! engine is live (file watcher, scheduler, in-flight sessions all reading the
+//! old root) would tear it. Instead `set_docs_root` validates + persists the
+//! new absolute path and stages a `migrateFrom`; the next boot performs the
+//! move BEFORE the engine starts and clears the flag. The caller prompts the
+//! user to restart.
 
 use std::path::PathBuf;
 
@@ -23,28 +25,46 @@ pub fn get_docs_root() -> Result<String, String> {
         .into_owned())
 }
 
-/// Persist a new workspace root and migrate any existing tree into it. The new
-/// location takes effect on the next launch, so the caller must prompt the user
-/// to restart Houston. Migration is idempotent + non-clobbering (see
-/// `app_config::migrate_docs_root`).
+/// Validate + persist a new workspace root and stage a boot-time migration.
+/// The new location takes effect on the next launch, so the caller must prompt
+/// the user to restart Houston.
 #[tauri::command(rename_all = "snake_case")]
 pub fn set_docs_root(new_root: String) -> Result<(), String> {
     let trimmed = new_root.trim();
     if trimmed.is_empty() {
         return Err("Workspace location cannot be empty".into());
     }
+
     let h = houston();
-    let cfg = crate::app_config::load(&h);
+    let mut cfg = crate::app_config::load(&h);
     let old = crate::app_config::resolve_docs_dir(&h, &cfg);
-    let new = houston_tauri::paths::expand_tilde(&PathBuf::from(trimmed));
-    if new != old {
-        crate::app_config::migrate_docs_root(&old, &new).map_err(|e| e.to_string())?;
+
+    // Resolve to a single absolute path NOW and persist that, so the engine's
+    // resolver and the migrator never re-expand the string differently.
+    let new = crate::app_config::expand_path(trimmed);
+    if !new.is_absolute() {
+        return Err("Workspace location must be an absolute path".into());
     }
-    crate::app_config::save(
-        &h,
-        &crate::app_config::AppConfig {
-            docs_root: Some(trimmed.to_string()),
-        },
-    )
-    .map_err(|e| e.to_string())
+    if new.is_file() {
+        return Err("Workspace location must be a folder, not a file".into());
+    }
+
+    let new_abs = new.to_string_lossy().into_owned();
+
+    // No change → persist the explicit (absolute) choice, clear any stale
+    // migration, and stop.
+    if crate::app_config::paths_equal(&new, &old) {
+        cfg.docs_root = Some(new_abs);
+        cfg.migrate_from = None;
+        return crate::app_config::save(&h, &cfg).map_err(|e| e.to_string());
+    }
+
+    // A move between nested locations would move a tree into itself.
+    if crate::app_config::paths_overlap(&new, &old) {
+        return Err("New location cannot be inside the current one (or vice versa)".into());
+    }
+
+    cfg.docs_root = Some(new_abs);
+    cfg.migrate_from = Some(old.to_string_lossy().into_owned());
+    crate::app_config::save(&h, &cfg).map_err(|e| e.to_string())
 }

--- a/app/src-tauri/src/commands/workspace_root.rs
+++ b/app/src-tauri/src/commands/workspace_root.rs
@@ -1,0 +1,50 @@
+//! Workspace-root selection — view + change the user-visible, git-backed
+//! Houston root (`docsRoot`).
+//!
+//! The chosen root is persisted in `~/.houston/app-config.json` and injected
+//! as `HOUSTON_DOCS` at the next boot, so a change takes effect on the next
+//! launch (the engine binds the root once at spawn). The caller prompts the
+//! user to restart Houston after a successful change.
+
+use std::path::PathBuf;
+
+fn houston() -> PathBuf {
+    houston_tauri::houston_db::db::houston_dir()
+}
+
+/// The workspace-root directory currently in effect — resolved from app-config,
+/// defaulting to `~/.houston/workspaces` when the user has not chosen a root.
+#[tauri::command(rename_all = "snake_case")]
+pub fn get_docs_root() -> Result<String, String> {
+    let h = houston();
+    let cfg = crate::app_config::load(&h);
+    Ok(crate::app_config::resolve_docs_dir(&h, &cfg)
+        .to_string_lossy()
+        .into_owned())
+}
+
+/// Persist a new workspace root and migrate any existing tree into it. The new
+/// location takes effect on the next launch, so the caller must prompt the user
+/// to restart Houston. Migration is idempotent + non-clobbering (see
+/// `app_config::migrate_docs_root`).
+#[tauri::command(rename_all = "snake_case")]
+pub fn set_docs_root(new_root: String) -> Result<(), String> {
+    let trimmed = new_root.trim();
+    if trimmed.is_empty() {
+        return Err("Workspace location cannot be empty".into());
+    }
+    let h = houston();
+    let cfg = crate::app_config::load(&h);
+    let old = crate::app_config::resolve_docs_dir(&h, &cfg);
+    let new = houston_tauri::paths::expand_tilde(&PathBuf::from(trimmed));
+    if new != old {
+        crate::app_config::migrate_docs_root(&old, &new).map_err(|e| e.to_string())?;
+    }
+    crate::app_config::save(
+        &h,
+        &crate::app_config::AppConfig {
+            docs_root: Some(trimmed.to_string()),
+        },
+    )
+    .map_err(|e| e.to_string())
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -387,6 +387,8 @@ pub fn run() {
             commands::os::reveal_path,
             commands::terminal::open_terminal,
             commands::os::check_claude_cli,
+            commands::workspace_root::get_docs_root,
+            commands::workspace_root::set_docs_root,
             commands::portable::save_portable_agent,
             commands::portable::open_portable_agent,
             commands::update::current_app_bundle_path,

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,3 +1,4 @@
+mod app_config;
 mod auth;
 mod bug_report;
 mod commands;
@@ -191,6 +192,12 @@ pub fn run() {
             houston_tauri::houston_terminal_manager::claude_path::init();
 
             let houston = houston_tauri::houston_db::db::houston_dir();
+            // Resolve the workspace-root (`docs`) directory before anything
+            // reads it. From `~/.houston/app-config.json` (`docsRoot`) when the
+            // user picked a visible, git-backed root, else the historical
+            // `$HOUSTON_HOME/workspaces/` default.
+            let app_cfg = app_config::load(&houston);
+            let docs_dir = app_config::resolve_docs_dir(&houston, &app_cfg);
             let db_path = houston.join("db").join("houston.db");
             let db = tauri::async_runtime::block_on(async {
                 Database::connect(&db_path)
@@ -212,7 +219,7 @@ pub fn run() {
             // empty board even though their `.houston/activity.json` was
             // sitting next to it. Walk the workspaces dir here so existing
             // activities, routines, learnings show up immediately.
-            migrate_all_agents(&houston.join("workspaces"));
+            migrate_all_agents(&docs_dir);
 
             // AppState keeps a DB handle for any OS-native lookup (log
             // reading, session search). Domain state now lives in the
@@ -240,12 +247,10 @@ pub fn run() {
             // exported to the engine via env vars. The engine treats these
             // as opaque strings — it has no hardcoded Houston copy.
             //
-            // Also pin HOUSTON_HOME + HOUSTON_DOCS so the engine uses the
-            // same data roots as the app. Workspaces live under
-            // `$HOUSTON_HOME/workspaces/` in both debug (`~/.dev-houston/`)
-            // and release (`~/.houston/`) — everything Houston writes is
-            // rooted at a single discoverable location.
-            let docs_dir = houston.join("workspaces");
+            // Also pin HOUSTON_HOME + HOUSTON_DOCS so the engine uses the same
+            // data roots as the app. `docs_dir` was resolved above from
+            // app-config (`docsRoot`); it defaults to `$HOUSTON_HOME/workspaces/`
+            // until the user opts into a visible root via onboarding.
             let mut engine_env: Vec<(String, String)> = vec![
                 (
                     "HOUSTON_APP_SYSTEM_PROMPT".into(),

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -196,8 +196,34 @@ pub fn run() {
             // reads it. From `~/.houston/app-config.json` (`docsRoot`) when the
             // user picked a visible, git-backed root, else the historical
             // `$HOUSTON_HOME/workspaces/` default.
-            let app_cfg = app_config::load(&houston);
+            let mut app_cfg = app_config::load(&houston);
             let docs_dir = app_config::resolve_docs_dir(&houston, &app_cfg);
+
+            // Apply a pending workspace-location change BEFORE the engine
+            // starts, so the move never races a live engine (file watcher,
+            // scheduler, in-flight sessions) still reading the old root. On
+            // failure `migrateFrom` stays set to retry next launch; the
+            // migrator leaves the source intact, so no data is lost.
+            if let Some(from) = app_cfg.migrate_from.clone() {
+                let from_path = app_config::expand_path(&from);
+                match app_config::migrate_docs_root(&from_path, &docs_dir) {
+                    Ok(moved) => {
+                        tracing::info!(
+                            "[migrate] docs-root {} -> {} (moved={moved})",
+                            from_path.display(),
+                            docs_dir.display()
+                        );
+                        app_cfg.migrate_from = None;
+                        if let Err(e) = app_config::save(&houston, &app_cfg) {
+                            tracing::warn!("[migrate] failed to clear migrateFrom: {e}");
+                        }
+                    }
+                    Err(e) => tracing::error!(
+                        "[migrate] docs-root move failed (retrying next launch): {e}"
+                    ),
+                }
+            }
+
             let db_path = houston.join("db").join("houston.db");
             let db = tauri::async_runtime::block_on(async {
                 Database::connect(&db_path)
@@ -210,7 +236,7 @@ pub fn run() {
             // so everything Houston owns is under a single discoverable root.
             // Move the legacy directory if it exists and the new location is
             // empty. Idempotent on subsequent launches.
-            migrate_legacy_docs_dir(&houston);
+            migrate_legacy_docs_dir(&docs_dir);
 
             // Eagerly run the intra-agent data-layout migration on every
             // agent the user already has. Previously this only fired the
@@ -511,13 +537,12 @@ fn migrate_all_agents(workspaces_root: &std::path::Path) {
 /// first v0.4.2+ boot for anyone who previously ran v0.3.x/v0.4.0–v0.4.1.
 /// On any error we log + bail; the engine will still run against the new
 /// empty path. Original legacy dir is left in place as manual rollback.
-fn migrate_legacy_docs_dir(houston: &std::path::Path) {
+fn migrate_legacy_docs_dir(new_root: &std::path::Path) {
     let home = match dirs::home_dir() {
         Some(h) => h,
         None => return,
     };
     let legacy = home.join("Documents").join("Houston");
-    let new_root = houston.join("workspaces");
 
     let legacy_manifest = legacy.join("workspaces.json");
     if !legacy_manifest.is_file() {

--- a/app/src/components/settings/sections/advanced.tsx
+++ b/app/src/components/settings/sections/advanced.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Code2, FolderOpen } from "lucide-react";
+import { Button } from "@houston-ai/core";
+import { useUIStore } from "../../../stores/ui";
+import { useDeveloperMode } from "../../../hooks/use-developer-mode";
+import {
+  osGetDocsRoot,
+  osPickDirectory,
+  osRevealPath,
+  osSetDocsRoot,
+} from "../../../lib/os-bridge";
+
+/**
+ * Advanced settings. Houston is invisible-substrate by default; the developer
+ * mode toggle reveals the technical surfaces (files, git, the workspace-root
+ * location) for power users. Lives in the Workspace settings tab.
+ */
+export function AdvancedSection() {
+  const { t } = useTranslation("settings");
+  const addToast = useUIStore((s) => s.addToast);
+  const { enabled, setEnabled } = useDeveloperMode();
+  const [docsRoot, setDocsRoot] = useState<string>("");
+
+  useEffect(() => {
+    osGetDocsRoot()
+      .then(setDocsRoot)
+      .catch(() => {});
+  }, []);
+
+  const handleToggle = async () => {
+    try {
+      await setEnabled(!enabled);
+    } catch (err) {
+      addToast({
+        title: t("advanced.toggleFailed"),
+        description: err instanceof Error ? err.message : String(err),
+        variant: "error",
+      });
+    }
+  };
+
+  const handleChangeLocation = async () => {
+    try {
+      const picked = await osPickDirectory();
+      if (!picked) return;
+      await osSetDocsRoot(picked);
+      setDocsRoot(picked);
+      addToast({
+        title: t("advanced.workspaceLocation.changed"),
+        description: t("advanced.workspaceLocation.restartHint"),
+      });
+    } catch (err) {
+      addToast({
+        title: t("advanced.workspaceLocation.changeFailed"),
+        description: err instanceof Error ? err.message : String(err),
+        variant: "error",
+      });
+    }
+  };
+
+  return (
+    <section className="space-y-6">
+      <h2 className="text-lg font-semibold">{t("advanced.title")}</h2>
+
+      {/* Developer mode toggle */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <Code2 className="size-4" />
+            {t("advanced.developerMode.label")}
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t("advanced.developerMode.description")}
+          </p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={enabled}
+          aria-label={t("advanced.developerMode.label")}
+          onClick={handleToggle}
+          className={`mt-1 h-6 w-10 shrink-0 rounded-full transition-colors ${
+            enabled ? "bg-primary" : "bg-secondary"
+          }`}
+        >
+          <span
+            className={`block size-5 rounded-full bg-white shadow transition-transform ${
+              enabled ? "translate-x-[18px]" : "translate-x-0.5"
+            }`}
+          />
+        </button>
+      </div>
+
+      {/* Workspace location — only meaningful in developer mode */}
+      {enabled && (
+        <div>
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <FolderOpen className="size-4" />
+            {t("advanced.workspaceLocation.label")}
+          </div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {t("advanced.workspaceLocation.description")}
+          </p>
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => docsRoot && void osRevealPath(docsRoot)}
+              title={docsRoot}
+              className="min-w-0 flex-1 truncate rounded-lg border border-border bg-secondary/50 px-3 py-2 text-left font-mono text-xs text-muted-foreground transition-colors hover:text-foreground"
+            >
+              {docsRoot || "…"}
+            </button>
+            <Button
+              className="shrink-0 rounded-full"
+              onClick={handleChangeLocation}
+            >
+              {t("advanced.workspaceLocation.change")}
+            </Button>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/src/components/settings/sections/advanced.tsx
+++ b/app/src/components/settings/sections/advanced.tsx
@@ -25,7 +25,13 @@ export function AdvancedSection() {
   useEffect(() => {
     osGetDocsRoot()
       .then(setDocsRoot)
-      .catch(() => {});
+      .catch((err) =>
+        addToast({
+          title: t("advanced.workspaceLocation.loadFailed"),
+          description: err instanceof Error ? err.message : String(err),
+          variant: "error",
+        }),
+      );
   }, []);
 
   const handleToggle = async () => {

--- a/app/src/components/settings/settings-view.tsx
+++ b/app/src/components/settings/settings-view.tsx
@@ -32,6 +32,7 @@ import { AppearanceSection } from "./sections/appearance";
 import { DangerSection } from "./sections/danger";
 import { ReportBugSection } from "./sections/report-bug";
 import { ShortcutsSection } from "./sections/shortcuts";
+import { AdvancedSection } from "./sections/advanced";
 
 export function SettingsView() {
   const { t } = useTranslation(["settings", "common"]);
@@ -123,6 +124,7 @@ export function SettingsView() {
                 <LanguageSection />
                 <TimezoneSection />
                 <AppearanceSection />
+                <AdvancedSection />
                 <DangerSection />
               </div>
             )}

--- a/app/src/hooks/use-developer-mode.ts
+++ b/app/src/hooks/use-developer-mode.ts
@@ -1,0 +1,44 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { tauriPreferences } from "../lib/tauri";
+
+/**
+ * Developer mode — the master "advanced" toggle. Off by default, so the
+ * non-technical product is unchanged. When on, technical surfaces (files,
+ * folders, git history, the workspace-root location, …) become visible.
+ *
+ * Persisted as the engine preference `developer_mode` (string `"true"`/
+ * `"false"`), the same KV channel `theme` / `locale` use.
+ */
+const DEVELOPER_MODE_KEY = "developer_mode";
+const queryKey = ["preference", DEVELOPER_MODE_KEY] as const;
+
+export interface DeveloperModeState {
+  enabled: boolean;
+  isLoading: boolean;
+  setEnabled: (enabled: boolean) => Promise<boolean>;
+}
+
+export function useDeveloperMode(): DeveloperModeState {
+  const qc = useQueryClient();
+
+  const query = useQuery({
+    queryKey,
+    queryFn: async () => (await tauriPreferences.get(DEVELOPER_MODE_KEY)) === "true",
+    staleTime: 30_000,
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (enabled: boolean) => {
+      await tauriPreferences.set(DEVELOPER_MODE_KEY, enabled ? "true" : "false");
+      return enabled;
+    },
+    onSuccess: (enabled) => qc.setQueryData(queryKey, enabled),
+  });
+
+  return {
+    enabled: query.data ?? false,
+    isLoading: query.isLoading,
+    setEnabled: (enabled: boolean) => mutation.mutateAsync(enabled),
+  };
+}

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -58,6 +58,16 @@ export function osPickDirectory(): Promise<string | null> {
   return invoke<string | null>("pick_directory");
 }
 
+/** The workspace-root directory currently in effect (resolved `docsRoot`). */
+export function osGetDocsRoot(): Promise<string> {
+  return invoke<string>("get_docs_root");
+}
+
+/** Persist a new workspace-root location. Takes effect on the next launch. */
+export function osSetDocsRoot(newRoot: string): Promise<void> {
+  return invoke<void>("set_docs_root", { new_root: newRoot });
+}
+
 /** Open a URL in the user's default browser. */
 export function osOpenUrl(url: string): Promise<void> {
   return invoke<void>("open_url", { url });

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -74,6 +74,22 @@
     "light": "Light",
     "dark": "Dark"
   },
+  "advanced": {
+    "title": "Advanced",
+    "toggleFailed": "Could not change developer mode.",
+    "developerMode": {
+      "label": "Developer mode",
+      "description": "Show files, folders, version history, and other technical details. Off by default."
+    },
+    "workspaceLocation": {
+      "label": "Workspace location",
+      "description": "Where Houston keeps everything you and your agents create.",
+      "change": "Change",
+      "changed": "Workspace location updated.",
+      "restartHint": "Restart Houston to apply the new location.",
+      "changeFailed": "Could not change the workspace location."
+    }
+  },
   "dangerZone": {
     "title": "Danger zone",
     "description": "Permanently delete this workspace and all its agents.",

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -87,7 +87,8 @@
       "change": "Change",
       "changed": "Workspace location updated.",
       "restartHint": "Restart Houston to apply the new location.",
-      "changeFailed": "Could not change the workspace location."
+      "changeFailed": "Could not change the workspace location.",
+      "loadFailed": "Could not read the workspace location."
     }
   },
   "dangerZone": {

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -74,6 +74,22 @@
     "light": "Claro",
     "dark": "Oscuro"
   },
+  "advanced": {
+    "title": "Avanzado",
+    "toggleFailed": "No se pudo cambiar el modo de desarrollador.",
+    "developerMode": {
+      "label": "Modo de desarrollador",
+      "description": "Muestra archivos, carpetas, historial de versiones y otros detalles técnicos. Desactivado por defecto."
+    },
+    "workspaceLocation": {
+      "label": "Ubicación del espacio de trabajo",
+      "description": "Donde Houston guarda todo lo que tú y tus agentes crean.",
+      "change": "Cambiar",
+      "changed": "Se actualizó la ubicación del espacio de trabajo.",
+      "restartHint": "Reinicia Houston para aplicar la nueva ubicación.",
+      "changeFailed": "No se pudo cambiar la ubicación del espacio de trabajo."
+    }
+  },
   "dangerZone": {
     "title": "Zona de peligro",
     "description": "Elimina este espacio de trabajo y todos sus agentes de forma permanente.",

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -87,7 +87,8 @@
       "change": "Cambiar",
       "changed": "Se actualizó la ubicación del espacio de trabajo.",
       "restartHint": "Reinicia Houston para aplicar la nueva ubicación.",
-      "changeFailed": "No se pudo cambiar la ubicación del espacio de trabajo."
+      "changeFailed": "No se pudo cambiar la ubicación del espacio de trabajo.",
+      "loadFailed": "No se pudo leer la ubicación del espacio de trabajo."
     }
   },
   "dangerZone": {

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -87,7 +87,8 @@
       "change": "Alterar",
       "changed": "Local do espaço de trabalho atualizado.",
       "restartHint": "Reinicie o Houston para aplicar o novo local.",
-      "changeFailed": "Não foi possível alterar o local do espaço de trabalho."
+      "changeFailed": "Não foi possível alterar o local do espaço de trabalho.",
+      "loadFailed": "Não foi possível ler o local do espaço de trabalho."
     }
   },
   "dangerZone": {

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -74,6 +74,22 @@
     "light": "Claro",
     "dark": "Escuro"
   },
+  "advanced": {
+    "title": "Avançado",
+    "toggleFailed": "Não foi possível alterar o modo de desenvolvedor.",
+    "developerMode": {
+      "label": "Modo de desenvolvedor",
+      "description": "Mostra arquivos, pastas, histórico de versões e outros detalhes técnicos. Desativado por padrão."
+    },
+    "workspaceLocation": {
+      "label": "Local do espaço de trabalho",
+      "description": "Onde o Houston guarda tudo o que você e seus agentes criam.",
+      "change": "Alterar",
+      "changed": "Local do espaço de trabalho atualizado.",
+      "restartHint": "Reinicie o Houston para aplicar o novo local.",
+      "changeFailed": "Não foi possível alterar o local do espaço de trabalho."
+    }
+  },
   "dangerZone": {
     "title": "Zona de perigo",
     "description": "Exclui este espaço de trabalho e todos os seus agentes de forma permanente.",

--- a/docs/agentic-workspace-substrate.html
+++ b/docs/agentic-workspace-substrate.html
@@ -1,0 +1,423 @@
+<!doctype html>
+<!--
+---
+type: spec
+slug: agentic-workspace-substrate
+status: candidate
+core_claim: Houston becomes a user-visible, git-backed, bstack-governed agentic workspace by providing the environment and installing skills, not by building engine features.
+related: [[concept/llm-as-index]] [[pattern/capabilities-via-skills]] [[concept/two-root-split]]
+sources: [wf_55e0d214-f5e]
+tags: [houston, bstack, substrate, knowledge-graph, worktrees, governance]
+created: 2026-06-04
+updated: 2026-06-04
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Houston — Agentic Workspace Substrate</title>
+<style>
+  :root{
+    --bg:#0b0d12; --panel:#12151c; --panel2:#161a23; --border:#232838;
+    --text:#e7eaf0; --muted:#98a2b3; --faint:#6b7488;
+    --blue:#6ea8fe; --teal:#3ddc97; --amber:#f4b740; --red:#ff6b6b; --violet:#b794f6;
+    --mono:ui-monospace,SFMono-Regular,Menlo,Consolas,monospace;
+    --sans:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Roboto,Helvetica,Arial,sans-serif;
+  }
+  *{box-sizing:border-box}
+  html{scroll-behavior:smooth}
+  body{margin:0;background:var(--bg);color:var(--text);font-family:var(--sans);
+    line-height:1.6;font-size:15.5px;-webkit-font-smoothing:antialiased}
+  .wrap{max-width:1080px;margin:0 auto;padding:0 28px 120px}
+  header.hero{padding:64px 28px 40px;max-width:1080px;margin:0 auto}
+  .eyebrow{font:600 12px/1 var(--mono);letter-spacing:.16em;text-transform:uppercase;color:var(--blue)}
+  h1{font-size:40px;line-height:1.1;margin:16px 0 10px;letter-spacing:-.02em;font-weight:700}
+  .thesis{font-size:19px;color:var(--muted);max-width:760px}
+  .thesis b{color:var(--text);font-weight:600}
+  .meta{display:flex;gap:10px;flex-wrap:wrap;margin-top:22px}
+  .badge{font:600 11.5px/1 var(--mono);padding:6px 10px;border-radius:999px;border:1px solid var(--border);
+    background:var(--panel);color:var(--muted)}
+  .badge.warn{color:var(--amber);border-color:#3a3320}
+  .badge.ok{color:var(--teal);border-color:#1e3a30}
+  h2{font-size:13px;letter-spacing:.14em;text-transform:uppercase;color:var(--faint);
+    margin:64px 0 18px;font-weight:700;font-family:var(--mono)}
+  h3{font-size:21px;margin:30px 0 8px;letter-spacing:-.01em}
+  p{margin:10px 0}
+  a{color:var(--blue);text-decoration:none}
+  a:hover{text-decoration:underline}
+  code{font-family:var(--mono);font-size:.86em;background:var(--panel2);border:1px solid var(--border);
+    padding:1px 6px;border-radius:6px;color:#cdd6e6}
+  .lead{font-size:17px;color:var(--muted)}
+  .card{background:var(--panel);border:1px solid var(--border);border-radius:14px;padding:20px 22px;margin:14px 0}
+  .grid{display:grid;gap:14px}
+  .g2{grid-template-columns:1fr 1fr}
+  .g3{grid-template-columns:repeat(3,1fr)}
+  @media(max-width:820px){.g2,.g3{grid-template-columns:1fr}}
+  .chip{display:inline-flex;align-items:center;gap:7px;font:600 13px/1 var(--sans);
+    padding:9px 13px;border-radius:10px;background:var(--panel2);border:1px solid var(--border);margin:4px 6px 4px 0}
+  .chip .n{font:700 11px/1 var(--mono);color:var(--blue)}
+  figure{margin:24px 0;background:var(--panel);border:1px solid var(--border);border-radius:16px;padding:10px}
+  figure svg{display:block;width:100%;height:auto}
+  figcaption{color:var(--faint);font-size:13px;text-align:center;padding:8px 12px 6px}
+  table{width:100%;border-collapse:collapse;margin:16px 0;font-size:14px}
+  th,td{text-align:left;padding:11px 13px;border-bottom:1px solid var(--border);vertical-align:top}
+  th{color:var(--faint);font:600 11.5px/1.3 var(--mono);letter-spacing:.06em;text-transform:uppercase}
+  tbody tr:hover{background:#0e1117}
+  td code{white-space:nowrap}
+  .callout{border-radius:14px;padding:16px 18px;margin:14px 0;border:1px solid;display:flex;gap:14px}
+  .callout .tag{font:700 11px/1 var(--mono);padding:5px 8px;border-radius:6px;height:fit-content;white-space:nowrap}
+  .callout.red{background:#1a0f12;border-color:#3a2024}
+  .callout.red .tag{background:#3a2024;color:var(--red)}
+  .callout.amber{background:#19150c;border-color:#3a3320}
+  .callout.amber .tag{background:#3a3320;color:var(--amber)}
+  .callout.blue{background:#0e1422;border-color:#1f2d4a}
+  .callout.blue .tag{background:#1f2d4a;color:var(--blue)}
+  .callout b{color:var(--text)}
+  ul{margin:8px 0;padding-left:20px}
+  li{margin:5px 0}
+  .muted{color:var(--muted)}
+  .phase{border-left:3px solid var(--border);padding:4px 0 4px 18px;margin:18px 0}
+  .phase.f{border-color:var(--violet)}
+  .phase.c{border-color:var(--teal)}
+  .phase h4{margin:0 0 4px;font-size:16px}
+  .phase .area{font:600 11px/1 var(--mono);color:var(--faint)}
+  .kv{font-family:var(--mono);font-size:12.5px;color:var(--muted)}
+  hr{border:0;border-top:1px solid var(--border);margin:40px 0}
+  .foot{color:var(--faint);font-size:13px;margin-top:40px;text-align:center}
+  .pill{display:inline-block;font:700 10.5px/1 var(--mono);padding:4px 7px;border-radius:5px;margin-right:6px}
+  .pill.p{background:#241a33;color:var(--violet)}
+  .pill.b{background:#0e2a22;color:var(--teal)}
+  .pill.a{background:#102036;color:var(--blue)}
+</style>
+</head>
+<body>
+
+<header class="hero">
+  <div class="eyebrow">Houston · Design Arc</div>
+  <h1>Agentic Workspace Substrate</h1>
+  <p class="thesis">Turn Houston's hidden bag-of-agents into a <b>user-visible, git-backed, bstack-governed</b> workspace that orchestrates multiple projects, runs agents in worktrees, and shares one second-brain knowledge graph — by <b>providing the environment and installing skills</b>, not by building engine features.</p>
+  <div class="meta">
+    <span class="badge warn">status: proposed — under review</span>
+    <span class="badge">2026-06-04</span>
+    <span class="badge ok">grounded · 5-agent sweep · wf_55e0d214-f5e</span>
+    <span class="badge">canonical spec: agentic-workspace-substrate.md</span>
+  </div>
+</header>
+
+<div class="wrap">
+
+  <h2>The shift</h2>
+  <p class="lead">Today a Houston "workspace" is a bag of agents hidden under <code>~/.houston/workspaces/</code> — no git, no visibility, no shared context. This arc pulls the workspace out into a named, visible, version-controlled root and makes it <b>autonomous-agentic natively</b> — while the non-technical product stays exactly as it is by default. The substrate (git, worktrees, governance, knowledge graph) runs underneath; an advanced mode reveals it.</p>
+
+  <figure>
+    <!-- SVG 1: two roots -->
+    <svg viewBox="0 0 960 360" role="img" aria-label="Two-root model">
+      <defs>
+        <style>
+          .t{fill:#e7eaf0;font-family:var(--sans),sans-serif}
+          .m{fill:#98a2b3;font-family:ui-monospace,monospace;font-size:12px}
+          .h{fill:#e7eaf0;font-weight:700;font-size:15px;font-family:ui-monospace,monospace}
+          .lbl{fill:#6b7488;font:700 11px ui-monospace,monospace;letter-spacing:.1em}
+        </style>
+      </defs>
+      <!-- system root -->
+      <rect x="24" y="60" width="430" height="270" rx="16" fill="#12151c" stroke="#232838"/>
+      <text x="44" y="92" class="lbl">SYSTEM ROOT · HIDDEN · NO GIT</text>
+      <text x="44" y="120" class="h" fill="#ff8a8a">~/.houston/</text>
+      <text x="44" y="142" class="m">how Houston runs · disposable</text>
+      <g class="m" fill="#9aa3b2">
+        <text x="44" y="178">engine.json · houston.db (chat_feed, prefs)</text>
+        <text x="44" y="200">logs/ · installed agent definitions (agents/)</text>
+        <text x="44" y="222">bundled CLIs · tunnel id</text>
+        <text x="44" y="244" fill="#6ea8fe">app-config.json  ← new: root path the boot reads</text>
+      </g>
+      <text x="44" y="296" class="m" fill="#6b7488">never shown to the user · regenerated on reinstall</text>
+
+      <!-- workspace root -->
+      <rect x="506" y="60" width="430" height="270" rx="16" fill="#12151c" stroke="#1e3a30"/>
+      <text x="526" y="92" class="lbl" fill="#3ddc97">WORKSPACE ROOT · VISIBLE · GIT</text>
+      <text x="526" y="120" class="h" fill="#7ef0c0">~/Houston/</text>
+      <text x="526" y="142" class="m">what you + your agents make · precious</text>
+      <g class="m" fill="#9aa3b2">
+        <text x="526" y="178">CLAUDE.md · AGENTS.md · .control/ (governance)</text>
+        <text x="526" y="200">research/entities/ · docs/ (the second brain)</text>
+        <text x="526" y="222">&lt;Workspace&gt;/&lt;Agent&gt;/ · &lt;Project&gt;/ + worktrees</text>
+        <text x="526" y="244">WORKSPACE.md · USER.md · all deliverables</text>
+      </g>
+      <text x="526" y="296" class="m" fill="#6b7488">in Finder · git-tracked · backup-able · portable</text>
+
+      <!-- boot arrow -->
+      <text x="480" y="24" class="lbl" text-anchor="middle">boot</text>
+      <path d="M300 60 C 300 36, 470 36, 470 30" fill="none" stroke="#6ea8fe" stroke-width="1.5" stroke-dasharray="4 3"/>
+      <path d="M470 30 C 470 36, 640 36, 640 60" fill="none" stroke="#6ea8fe" stroke-width="1.5" stroke-dasharray="4 3"/>
+      <text x="470" y="48" class="m" fill="#6ea8fe" text-anchor="middle">reads app-config → HOUSTON_DOCS → spawns engine</text>
+    </svg>
+    <figcaption>Two roots, one rule: <code>~/.houston/</code> = how Houston runs · <code>~/Houston/</code> = what you and your agents make.</figcaption>
+  </figure>
+
+  <h2>Locked decisions</h2>
+  <div>
+    <span class="chip"><span class="n">1</span> Invisible by default + advanced toggle</span>
+    <span class="chip"><span class="n">2</span> Onboarding names the root (<code>~/Houston</code>)</span>
+    <span class="chip"><span class="n">3</span> Project is first-class now</span>
+    <span class="chip"><span class="n">4</span> Full bstack — as environment, not code</span>
+    <span class="chip"><span class="n">5</span> Sessions are addressable graph nodes</span>
+    <span class="chip"><span class="n">6</span> Bookkeeping + PM are agent jobs</span>
+    <span class="chip"><span class="n">7</span> Opinionated, autonomous-native</span>
+    <span class="chip"><span class="n">8</span> Root + per-workspace shared context</span>
+    <span class="chip"><span class="n">9</span> Rich HTML for plans &amp; deep work</span>
+  </div>
+
+  <h2>The reframe — environment, not build</h2>
+  <p class="lead">The load-bearing decision. The grounding sweep confirmed every capability the arc needs is <b>already a shipped bstack skill that runs in-session</b>. Houston's job is to make each workspace root <i>look like</i> a bstack workspace and <b>install the skill roster through the rail it already owns</b> — then get out of the way.</p>
+
+  <figure>
+    <!-- SVG 2: provides / builds / agents -->
+    <svg viewBox="0 0 960 392" role="img" aria-label="Environment, glue, agents">
+      <defs><style>
+        .lane{font:700 12px ui-monospace,monospace;letter-spacing:.08em}
+        .it{fill:#c9d2e3;font-size:12.5px;font-family:var(--sans),sans-serif}
+        .cap{fill:#e7eaf0;font-weight:700;font-size:14px}
+      </style></defs>
+
+      <!-- agents (top) -->
+      <rect x="24" y="24" width="912" height="92" rx="14" fill="#0e1422" stroke="#1f2d4a"/>
+      <text x="44" y="48" class="lane" fill="#6ea8fe">AGENTS DO — in-session, via skills</text>
+      <g class="it">
+        <text x="44" y="74">/autonomous (21-reflex mode)</text>
+        <text x="250" y="74">/kg load · bookkeeping run</text>
+        <text x="470" y="74">/persist · /role-x · /cross-review</text>
+        <text x="720" y="74">/p9 watch · git · gh · Linear</text>
+        <text x="44" y="98" fill="#98a2b3">curate the graph · bridge sessions · run the PR pipeline — themselves</text>
+      </g>
+
+      <!-- glue (middle, thin) -->
+      <rect x="24" y="132" width="912" height="84" rx="14" fill="#0e2a22" stroke="#1e3a30"/>
+      <text x="44" y="156" class="lane" fill="#3ddc97">HOUSTON BUILDS — thin irreducible glue</text>
+      <g class="it">
+        <text x="44" y="182">idempotent governance scaffold</text>
+        <text x="290" y="182">skill provisioning (existing Store rail)</text>
+        <text x="600" y="182">worktree lifecycle + janitor</text>
+        <text x="44" y="204" fill="#7ef0c0">addressable session URI (the one net-new wire contract)</text>
+        <text x="470" y="204">reactivity (mostly free) · per-session runtime env</text>
+      </g>
+
+      <!-- environment (bottom, foundation) -->
+      <rect x="24" y="232" width="912" height="92" rx="14" fill="#12151c" stroke="#232838"/>
+      <text x="44" y="256" class="lane" fill="#b794f6">HOUSTON PROVIDES — the environment</text>
+      <g class="it">
+        <text x="44" y="282">governance tree (CLAUDE/AGENTS/METALAYER/.control)</text>
+        <text x="470" y="282">research/entities/ + catalog + frontmatter</text>
+        <text x="44" y="304">bstack skill roster installed per agent</text>
+        <text x="350" y="304">BROOMVA_ROOT + git/gh/python3 on PATH</text>
+        <text x="700" y="304">git init + worktrees real</text>
+      </g>
+
+      <!-- do not build bar -->
+      <rect x="24" y="344" width="912" height="36" rx="10" fill="#1a0f12" stroke="#3a2024"/>
+      <text x="44" y="367" style="fill:#ff6b6b;font:700 12px ui-monospace,monospace;letter-spacing:.06em">DO NOT BUILD</text>
+      <text x="200" y="367" class="it" fill="#d6a0a0">bookkeeping pipeline · kg loader · persist loop · role-x router · p9 watcher · cross-review · graph DB · embeddings · hook engine · autonomous orchestrator</text>
+    </svg>
+    <figcaption>Houston provides the floor and installs the skills; agents do the work on top. The glue layer is deliberately thin.</figcaption>
+  </figure>
+
+  <table>
+    <thead><tr><th>Houston provides (environment)</th><th>Houston builds (glue)</th><th>Agents do (in-session)</th></tr></thead>
+    <tbody>
+      <tr>
+        <td>Governance tree seeded at create: <code>CLAUDE.md</code>/<code>AGENTS.md</code>/<code>METALAYER.md</code> + <code>.control/*</code> + <code>roles/</code></td>
+        <td>Idempotent <b>scaffold</b> (keep-if-exists) in <code>houston-agent-files</code> + <code>agents_crud.rs::create</code></td>
+        <td><code>/autonomous</code> — the 21-reflex operating mode = "autonomous by default"</td>
+      </tr>
+      <tr>
+        <td><code>research/entities/</code> + <code>docs/</code> + <code>knowledge-index.md</code> stub at the <b>workspace root</b> (not under <code>.houston/</code>)</td>
+        <td><b>Skill provisioning</b> = ship the roster as a bundled package on the existing Store <code>.agents/skills/*</code> rail</td>
+        <td><code>/kg load</code> + <code>bookkeeping</code> — LLM-as-index over the entities tree</td>
+      </tr>
+      <tr>
+        <td>The bstack <b>roster</b> installed per agent + per-session <code>BROOMVA_ROOT</code> + <code>git/gh/python3</code> on PATH</td>
+        <td><b>Worktree lifecycle</b> + janitor · <b>addressable session URI</b> · reactivity</td>
+        <td><code>/persist</code> · <code>/role-x</code> · <code>/cross-review</code> · <code>/p9</code> · <code>git</code>/<code>gh</code>/Linear directly</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <h2>The make-or-break risks</h2>
+  <p class="lead">The sweep surfaced three things that quietly decide whether the whole arc works.</p>
+
+  <div class="callout red">
+    <span class="tag">CRUX</span>
+    <div><b>Path-assumption mismatch.</b> Every bstack skill hard-codes <code>~/broomva/research/entities</code>, <code>~/.config/broomva</code>, <code>~/.claude/…</code>. Installed as-is they read/write the <b>wrong</b> root. Houston spawns the provider subprocess, so it sets <code>BROOMVA_ROOT=&lt;agent workspace&gt;</code> + CWD per session — <code>kg.py</code>/<code>bookkeeping.py</code> honor it — but skill bodies still need light adaptation to the workspace-relative layout. <span class="muted">This is the single make-or-break wiring detail of the arc.</span></div>
+  </div>
+  <div class="callout amber">
+    <span class="tag">SILENT NO-OP</span>
+    <div><b>Workspace-side hook scripts gap.</b> <code>settings.json</code> references <code>$WORKSPACE/scripts/*-hook.sh</code> that are emitted by <code>control-metalayer-loop</code>'s bootstrap — <b>not shipped in bstack/scripts/</b>. Seed <code>settings.json</code> without seeding these and every hook 404s, so the P1/P2/P6/P7 reflex layer silently no-ops. Houston must seed the scripts.</div>
+  </div>
+  <div class="callout amber">
+    <span class="tag">RUNTIME</span>
+    <div><b>Bundled at install — resolved.</b> <code>python3</code> 3.11+ (tomllib + PyYAML), <code>git</code>, <code>gh</code>, <code>bash</code> 4+, <code>node</code>/<code>npx</code>. Houston <b>bundles + installs them at install time</b> so a bare fresh setup is ready; agents install more on demand. New foundation <b>F0</b> — extends the <code>houston-cli-bundle</code> infra + notarization.</div>
+  </div>
+  <div class="callout blue">
+    <span class="tag">VOICE</span>
+    <div><b>Firewall the jargon.</b> Governance language, <code>Pn</code> primitives, URIs and paths must never leak into non-technical chat — the governance is agent-facing, the user sees outcomes only. <code>advanced.developer_mode</code> relaxes the voice. Skill-picker slugs (<code>kg</code>, <code>role-x</code>) stay out of the prominent surface (no <code>display_name</code> override — RULE 0).</div>
+  </div>
+
+  <h2>Sessions ↔ the knowledge graph</h2>
+  <p class="lead">A Houston session is <b>already addressable</b> — <code>(agent_path, session_key)</code>, resume ids on disk, transcript in <code>chat_feed</code> with an existing FTS5 index. The arc makes that address a first-class URI the graph links to, both directions.</p>
+
+  <figure>
+    <!-- SVG 3: session <-> KG loop -->
+    <svg viewBox="0 0 960 250" role="img" aria-label="Session to knowledge graph loop">
+      <defs>
+        <marker id="ar" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#6ea8fe"/></marker>
+        <marker id="ar2" markerWidth="9" markerHeight="9" refX="7" refY="3" orient="auto"><path d="M0,0 L7,3 L0,6 Z" fill="#3ddc97"/></marker>
+        <style>.nx{fill:#e7eaf0;font-weight:600;font-size:13px;font-family:var(--sans),sans-serif}.sub{fill:#98a2b3;font-size:11px;font-family:ui-monospace,monospace}.edge{fill:#6b7488;font:600 11px var(--sans),sans-serif}</style>
+      </defs>
+      <!-- session -->
+      <rect x="30" y="92" width="180" height="66" rx="12" fill="#0e1422" stroke="#1f2d4a"/>
+      <text x="120" y="120" text-anchor="middle" class="nx">Session</text>
+      <text x="120" y="140" text-anchor="middle" class="sub">houston://…/session/&lt;key&gt;</text>
+      <!-- bridge -->
+      <rect x="290" y="30" width="180" height="60" rx="12" fill="#12151c" stroke="#232838"/>
+      <text x="380" y="55" text-anchor="middle" class="nx">docs/conversations/</text>
+      <text x="380" y="74" text-anchor="middle" class="sub">bridge skill (P1)</text>
+      <!-- entities -->
+      <rect x="560" y="92" width="180" height="66" rx="12" fill="#0e2a22" stroke="#1e3a30"/>
+      <text x="650" y="120" text-anchor="middle" class="nx">research/entities/</text>
+      <text x="650" y="140" text-anchor="middle" class="sub">bookkeeping (P6)</text>
+      <!-- kg load -->
+      <rect x="290" y="170" width="180" height="60" rx="12" fill="#12151c" stroke="#232838"/>
+      <text x="380" y="195" text-anchor="middle" class="nx">/kg load &lt;topic&gt;</text>
+      <text x="380" y="214" text-anchor="middle" class="sub">LLM-as-index</text>
+
+      <path d="M210 110 C 250 80, 270 65, 288 60" fill="none" stroke="#6ea8fe" stroke-width="1.6" marker-end="url(#ar)"/>
+      <text x="245" y="74" class="edge">writes node</text>
+      <path d="M470 60 C 510 70, 530 90, 558 108" fill="none" stroke="#6ea8fe" stroke-width="1.6" marker-end="url(#ar)"/>
+      <text x="505" y="78" class="edge">promotes</text>
+      <path d="M650 158 C 650 195, 540 205, 472 202" fill="none" stroke="#3ddc97" stroke-width="1.6" marker-end="url(#ar2)"/>
+      <text x="556" y="196" class="edge">surfaces bodies</text>
+      <path d="M310 178 C 240 165, 200 150, 188 158" fill="none" stroke="#3ddc97" stroke-width="1.6" marker-end="url(#ar2)"/>
+      <text x="214" y="182" class="edge">cross-session memory</text>
+
+      <!-- join key -->
+      <text x="380" y="130" text-anchor="middle" style="fill:#b794f6;font:700 12px ui-monospace,monospace">URI = join key</text>
+      <text x="380" y="148" text-anchor="middle" class="sub">frontmatter = edge store · agent = query engine</text>
+    </svg>
+    <figcaption>Entity → session (<code>sessions:&nbsp;[houston://…]</code>) and session → entity (<code>entities:&nbsp;[[slug]]</code>). No DB, no embeddings — markdown frontmatter is the edge store.</figcaption>
+  </figure>
+
+  <h2>The arc</h2>
+  <p class="lead">Two foundations enable five capabilities. Each ships + is tested independently.</p>
+
+  <figure>
+    <!-- SVG 4: dependency graph -->
+    <svg viewBox="0 0 960 300" role="img" aria-label="Arc dependency graph">
+      <defs><marker id="d" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L6,3 L0,6 Z" fill="#3a4258"/></marker>
+      <style>.node{font-weight:700;font-size:13px;font-family:ui-monospace,monospace}.cap{fill:#c9d2e3;font-size:11.5px;font-family:var(--sans),sans-serif}</style></defs>
+      <!-- edges -->
+      <g stroke="#2a3145" stroke-width="1.5" fill="none" marker-end="url(#d)">
+        <path d="M170 215 L 250 150"/><path d="M170 215 L 250 90"/>
+        <path d="M430 215 L 480 150"/><path d="M430 215 L 510 150"/><path d="M430 215 L 540 150"/>
+        <path d="M170 215 L 250 215"/>
+      </g>
+      <!-- foundations -->
+      <rect x="40" y="196" width="130" height="56" rx="11" fill="#1a1430" stroke="#3a2d5a"/>
+      <text x="105" y="220" text-anchor="middle" class="node" fill="#b794f6">F1 · Root</text>
+      <text x="105" y="238" text-anchor="middle" class="cap">visible · git</text>
+      <rect x="300" y="196" width="130" height="56" rx="11" fill="#1a1430" stroke="#3a2d5a"/>
+      <text x="365" y="220" text-anchor="middle" class="node" fill="#b794f6">F2 · Env</text>
+      <text x="365" y="238" text-anchor="middle" class="cap">skills · runtime</text>
+
+      <!-- capabilities -->
+      <rect x="250" y="120" width="120" height="50" rx="10" fill="#0e2a22" stroke="#1e3a30"/>
+      <text x="310" y="140" text-anchor="middle" class="node" fill="#3ddc97">C1 Projects</text>
+      <text x="310" y="158" text-anchor="middle" class="cap">open folder</text>
+      <rect x="250" y="60" width="120" height="50" rx="10" fill="#0e2a22" stroke="#1e3a30"/>
+      <text x="310" y="80" text-anchor="middle" class="node" fill="#3ddc97">C2 Worktrees</text>
+      <text x="310" y="98" text-anchor="middle" class="cap">parallel + janitor</text>
+      <rect x="450" y="120" width="120" height="50" rx="10" fill="#0e2a22" stroke="#1e3a30"/>
+      <text x="510" y="140" text-anchor="middle" class="node" fill="#3ddc97">C3 Governance</text>
+      <text x="510" y="158" text-anchor="middle" class="cap">opinionated</text>
+      <rect x="590" y="120" width="120" height="50" rx="10" fill="#0e2a22" stroke="#1e3a30"/>
+      <text x="650" y="140" text-anchor="middle" class="node" fill="#3ddc97">C4 Second brain</text>
+      <text x="650" y="158" text-anchor="middle" class="cap">LLM-as-index</text>
+      <rect x="730" y="120" width="120" height="50" rx="10" fill="#0e2a22" stroke="#1e3a30"/>
+      <text x="790" y="140" text-anchor="middle" class="node" fill="#3ddc97">C5 Session↔KG</text>
+      <text x="790" y="158" text-anchor="middle" class="cap">URI contract</text>
+
+      <!-- cross-cutting -->
+      <rect x="250" y="20" width="600" height="30" rx="9" fill="#0e1422" stroke="#1f2d4a"/>
+      <text x="550" y="40" text-anchor="middle" style="fill:#6ea8fe;font:700 12px ui-monospace,monospace">cross-cutting · voice firewall + advanced mode + i18n + tests</text>
+    </svg>
+    <figcaption>F0 (runtime bundling, install-time) + F1/F2 are the floor; C1–C5 stand on them; the voice firewall + advanced toggle wrap everything.</figcaption>
+  </figure>
+
+  <div class="phase f"><div class="area">FOUNDATION · [build][app] · prereq for F2</div><h4>F0 — Runtime bundling</h4>
+    <p class="muted">Bundle + install <code>python3</code>/<code>git</code>/<code>gh</code>/<code>bash</code>/<code>node</code> at Houston install time so a bare fresh setup is ready; agents extend on demand. Extends <code>houston-cli-bundle</code> + <code>fetch-cli-deps.sh</code>; notarize bundled binaries; per-arch.</p></div>
+  <div class="phase f"><div class="area">FOUNDATION · [engine][app]</div><h4>F1 — Visible git-backed root</h4>
+    <p class="muted"><code>docs_root</code> pref + <code>app-config.json</code> + boot wiring (<code>HOUSTON_DOCS</code> from pref, engine restart); onboarding root-pick (default <code>~/Houston</code>); <code>git init</code> + <code>.gitignore</code>; existing-user migration offer (reuse <code>migrate_legacy_docs_dir</code>).</p></div>
+
+  <div class="phase f"><div class="area">FOUNDATION · [engine][app] · the make-or-break</div><h4>F2 — Agent environment + skill rail</h4>
+    <p class="muted">Guarantee runtime (<code>python3</code>/<code>git</code>/<code>gh</code>); set <code>BROOMVA_ROOT</code> + CWD per session; vendor + provision the bstack roster via the Store <code>.agents/skills/*</code> rail + <code>copy_missing_skill_dirs</code>; seed the hook scripts; adapt skill bodies to workspace-relative roots; voice firewall + <code>advanced.developer_mode</code>.</p></div>
+
+  <div class="phase c"><div class="area">CAPABILITY · [engine][ui][app]</div><h4>C1 — Projects first-class</h4>
+    <p class="muted"><code>Project</code> entity + <code>projects.json</code> + <code>projects.rs</code> + routes; "Open existing folder" / "New project" in the switcher (the original ask); agent↔project via <code>workingDirOverride</code>.</p></div>
+  <div class="phase c"><div class="area">CAPABILITY · [engine][app]</div><h4>C2 — Worktrees + janitor</h4>
+    <p class="muted">Worktree-per-mission; parallel missions; P8 squash-merge cleanup; reactive UI. Reuses <code>worktree.rs</code> wholesale.</p></div>
+  <div class="phase c"><div class="area">CAPABILITY · [engine][app]</div><h4>C3 — Governance scaffold (autonomous-native)</h4>
+    <p class="muted">Idempotent seed of the governance tree (keep-if-exists) + <code>prompt.rs</code> root context layer; <code>/autonomous</code> as the default stance; profile=autonomous with L3 paths still <code>require_human</code>.</p></div>
+  <div class="phase c"><div class="area">CAPABILITY · [engine][app]</div><h4>C4 — Second brain (LLM-as-index)</h4>
+    <p class="muted">Seed <code>research/entities/</code> + catalog stub + frontmatter + hand-authored starter entities; <code>kg</code>/<code>bookkeeping</code> provisioned in F2; reactivity free via the file-watcher catch-all.</p></div>
+  <div class="phase c"><div class="area">CAPABILITY · [engine][app]</div><h4>C5 — Session ↔ KG</h4>
+    <p class="muted">The <code>houston://</code> URI wire contract + history-route exposure + prompt injection; bridge writes session nodes; entity↔session backlinks; session→artifact edges from <code>file_changes.rs</code>.</p></div>
+
+  <h2>Reuse map — wire what exists (RULE 0)</h2>
+  <table>
+    <thead><tr><th>Need</th><th>Existing surface</th></tr></thead>
+    <tbody>
+      <tr><td>Skill provisioning</td><td><code>houston-skills/src/lib.rs</code> (CRUD, <code>build_skills_index</code>), <code>engine-core/skills.rs</code> (<code>ensure_claude_symlink</code>, <code>install_from_repo</code>)</td></tr>
+      <tr><td>Ship roster to existing agents</td><td><code>store/bundled.rs</code> (<code>sync_bundled_agent_instances</code>, <code>copy_missing_skill_dirs</code>, <code>.migrations.json</code>)</td></tr>
+      <tr><td>Scaffold seam</td><td><code>agents_crud.rs::create</code> (packaged-skill copy + seeds map), <code>houston-agent-files/{lib,schemas}.rs</code></td></tr>
+      <tr><td>Context injection</td><td><code>agents/prompt.rs</code> (<code>seed_agent</code>, <code>build_agent_context</code>)</td></tr>
+      <tr><td>Frontmatter tolerance</td><td><code>houston-skills/src/format.rs</code> — serde_yml, unknown-key tolerant (bstack frontmatter parses as-is)</td></tr>
+      <tr><td>Session identity / search</td><td><code>conversations.rs</code> (<code>session_key</code>), <code>sessions/history.rs</code>, <code>houston-db/repo_search.rs</code> (FTS5), <code>file_changes.rs</code></td></tr>
+      <tr><td>Worktrees</td><td><code>engine-core/src/worktree.rs</code> (<code>houston/{name}</code> branches, <code>run_shell</code>)</td></tr>
+      <tr><td>Folder linking / run elsewhere</td><td><code>agents_crud.rs</code> symlink + <code>pickDirectory</code> (dormant <code>link-project</code>) · <code>workingDirOverride</code></td></tr>
+      <tr><td>Root relocation + migration</td><td><code>docs_dir</code>/<code>HOUSTON_DOCS</code> + <code>migrate_legacy_docs_dir</code></td></tr>
+      <tr><td>Reactivity</td><td><code>houston-file-watcher</code> FilesChanged catch-all + <code>use-agent-invalidation.ts</code></td></tr>
+      <tr><td>Advanced flags</td><td><code>advanced.*</code> substrate (FLAG_REGISTRY → KV → FeatureGate → enforcement → KB → tests)</td></tr>
+    </tbody>
+  </table>
+
+  <h2>Decisions — all resolved</h2>
+  <div class="grid g2">
+    <div class="card">
+      <h3 style="margin-top:4px">Resolved</h3>
+      <ul class="muted">
+        <li><b>Sessions</b> → first-class addressable nodes, referenceable both ways.</li>
+        <li><b>Bookkeeping/PM</b> → agent jobs in-session, never a user chore.</li>
+        <li><b>KG/index</b> → LLM-as-index + frontmatter core; no engine pipeline.</li>
+        <li><b>Governance</b> → seed the bstack tree as environment, opinionated.</li>
+        <li><b>Autonomous</b> → profile=autonomous; <code>/autonomous</code> default; L3 <code>require_human</code>.</li>
+        <li><b>Format</b> → bstack conventions; rich HTML for the user.</li>
+      </ul>
+    </div>
+    <div class="card">
+      <h3 style="margin-top:4px">Closed (this round)</h3>
+      <ul class="muted">
+        <li>Path fix: <b><code>BROOMVA_ROOT</code> per session + minimal body adaptation</b>.</li>
+        <li>Hooks: <b>seed Houston-authored equivalents</b> (offline, deterministic).</li>
+        <li>Runtime: <b>bundle + install all deps at install time</b> → new foundation F0.</li>
+        <li>Roster: install for every agent, <b>suppressed from the picker</b>.</li>
+        <li>Templates: <b>Houston-tuned, voice-firewalled</b>.</li>
+      </ul>
+    </div>
+  </div>
+
+  <hr>
+  <p class="foot">Arc approved. Next step: execute <b>F1 — Visible git-backed root</b> (numbered chunk plan in chat). Nothing is built yet.<br>
+  Canonical spec: <code>docs/agentic-workspace-substrate.md</code> · grounded by run <code>wf_55e0d214-f5e</code>.</p>
+
+</div>
+</body>
+</html>

--- a/docs/agentic-workspace-substrate.md
+++ b/docs/agentic-workspace-substrate.md
@@ -1,0 +1,243 @@
+# Agentic Workspace Substrate — design arc
+
+Status: **proposed** (design under review, nothing built). Owner: Carlos.
+Rich presentation: [`agentic-workspace-substrate.html`](./agentic-workspace-substrate.html) (P18 — read this for diagrams).
+Grounded by a 5-agent sweep over the bstack skills + Houston reuse surfaces (run `wf_55e0d214-f5e`).
+
+Turns Houston's hidden bag-of-agents into a **user-visible, git-backed, bstack-governed**
+workspace root that orchestrates multiple projects, runs agents in worktrees, and shares one
+second-brain knowledge graph — by **providing the environment and installing skills**, not by
+building engine features. Non-technical product stays intact by default; an advanced mode reveals
+the substrate.
+
+---
+
+## 0. Locked decisions
+
+1. **Invisible by default + advanced toggle.** Substrate runs underneath; non-technical voice +
+   UI stay default. `advanced.developer_mode` reveals the raw substrate.
+2. **Onboarding picks + names the root** (default `~/Houston`). `.houston` vs root split is §2.
+3. **Project is first-class now.** Workspace → { Agents, Projects }, many-to-many.
+4. **Full bstack — as environment + skills, NOT engine code** (§1, the reframe).
+5. **Sessions are addressable nodes** the knowledge graph references both directions (§5).
+6. **Bookkeeping + project management are agent jobs in-session**, never user chores.
+7. **Opinionated governance** so Houston workspaces are autonomous-agentic natively.
+8. Root-level + per-workspace shared context (both).
+9. **Rich HTML** for presenting plans/deep work (this arc ships an `.html` companion).
+
+---
+
+## 1. The reframe — environment, not build (load-bearing)
+
+> Houston provides the **environment**; **agents** do the work **in-session via skills**.
+
+The grounding sweep confirmed: every capability the arc needs is already a shipped bstack skill
+that runs entirely in-session. Houston's job is to make each agent's workspace root *look like a
+bstack workspace* and **install the skill roster through the rail Houston already owns**. It must
+NOT reimplement any of it.
+
+| Houston PROVIDES (environment) | Houston BUILDS (irreducible glue) | AGENTS DO (in-session via skill) |
+|---|---|---|
+| Governance tree seeded at create: `CLAUDE.md`/`AGENTS.md`/`METALAYER.md` + `.control/{policy.yaml,rcs-parameters.toml,audit/}` + `roles/` | Idempotent **scaffold** step (keep-if-exists) in `houston-agent-files` + `agents_crud.rs::create` | `/autonomous` — the 21-reflex operating mode (the meaning of "autonomous by default") |
+| `research/entities/` + `docs/{conversations,specs,handoffs}/` + `docs/knowledge-index.md` catalog stub, at the **workspace root** (not under `.houston/`) | **Skill provisioning** = ship the bstack roster as a bundled package on the existing Store `.agents/skills/*` rail | `/kg load` + `bookkeeping run\|index` (P6) — LLM-as-index over `research/entities/` |
+| The bstack **skill roster** installed per agent (`.agents/skills/<name>/SKILL.md` + `.claude/skills` symlink + prompt roster) | **Worktree lifecycle** ops + janitor (`worktree.rs` exists; add cleanup + reactive surface) | `/persist` (P12), `/role-x` (P17), `/cross-review` (P20), `/p9` (P9), `/handoff`, `/dogfood` |
+| Per-session **runtime env**: `BROOMVA_ROOT=<agent workspace>`, `git`/`gh`/`python3` on PATH, the hook scripts | **Addressable session URI** (the one net-new wire contract, §5) | `git`/`gh`/Linear-MCP calls directly for P3/P4/P5/P8/P10 |
+| `git init` + `.gitignore` per workspace; worktrees real | **Reactivity** for new agent-written surfaces (mostly free — FilesChanged catch-all) | curate the graph, bridge sessions, run the PR pipeline — themselves |
+
+**Do NOT build** (consensus across all 5 findings): no Rust/TS port of the bookkeeping pipeline,
+kg loader, persist loop, role-x router, p9 watcher, or cross-review; no graph DB / embeddings /
+typed-edge store / query DSL (LLM-as-index is the design); no engine hook-engine (it's Claude Code
+`settings.json` + shell scripts); no bespoke autonomous orchestrator (`/autonomous` IS it); no
+engine CI-watcher (that's not `houston-scheduler`); don't bundle the full 60-skill roster (only the
+~16 required-compliance set + `autonomous`).
+
+---
+
+## 2. Two roots — the `.houston` vs user-root split
+
+> **`~/.houston/` = how Houston runs. `~/Houston/` = what you + your agents make.**
+
+| | System root `~/.houston/` (`home_dir`) | Workspace root `~/Houston/` (`docs_dir`) |
+|---|---|---|
+| Visibility / git | Hidden, never git | Visible in Finder, **git repo** |
+| Holds | `engine.json`, `houston.db` (chat_feed + prefs), `logs/`, installed agent **definitions** (`agents/`), bundled CLIs, tunnel id, **new** `app-config.json` (root path + flags the boot reads) | Root governance, `research/entities/` second brain, `WORKSPACE.md`/`USER.md`, every `<Workspace>/<Agent>/`, every `<Project>/`, all deliverables + the skills/governance the agent runs |
+| Rule | machine state, disposable | the user's work, precious, backup-able |
+
+`research/entities/`, governance, and `docs/conversations/` live at the **workspace root**
+(user-visible, git-trackable) — **never under `.houston/`** (that would hide them from the user and
+from git, defeating the arc). Each `<Agent>/.houston/` stays a hidden data dir; volatile parts
+(`sessions/`, `*.sid`, `*.invalid`, schemas) are git-ignored, meaningful parts (activity/routines/
+learnings/config) committed.
+
+---
+
+## 3. Data model
+
+### 3.1 Project (first-class, NEW)
+```ts
+interface Project { id: string; name: string; path: string;
+  kind: "created" | "linked"; git: { enabled: boolean; remote?: string }; createdAt: string }
+```
+- Index: `<Workspace>/.houston/projects.json` (beside the existing `connections.json`), files-first + reactive.
+- `created` = `git init` a subdir; `linked` = symlink an external repo in (reuse the dormant agent link-folder mechanism, lifted to project scope).
+- Engine: `projects.rs` + routes `/v1/workspaces/:id/projects`. Git/worktree ops reuse `worktree.rs`.
+- **Agent ↔ Project (many-to-many):** agent identity stays its own dir; *where it works per mission* is a project (or worktree), resolved via the **existing** `session.workingDirOverride`.
+
+### 3.2 Governance scaffold (NEW, opinionated)
+Idempotent seed at root + workspace create, from embedded bstack templates with `{{WORKSPACE_NAME}}`
+substituted, **keep-if-exists** (user-data-shaped, follows `migrate_agent_data` contract):
+`CLAUDE.md`, `AGENTS.md`, `METALAYER.md`, `.control/policy.yaml` (profile=autonomous; governance
+paths stay `require_human` until L3 trust gates are CI-wired — no silent L3 auto-merge),
+`.control/rcs-parameters.toml`, `.control/audit/`, `roles/_meta.md`, `.claude/settings.json` (hooks),
+`.githooks/pre-commit` + `core.hooksPath`. **Plus the workspace-side hook scripts** (§6 risk).
+
+### 3.3 Second brain (LLM-as-index)
+Seed `research/entities/<type>/` (10-type taxonomy) + `docs/knowledge-index.md` stub (empty-but-valid
+— `kg.py` errors if absent) + the uniform **frontmatter schema** carried across `.md` *and* `.html`
+*and* sidecars (P18) + a handful of hand-authored starter entities. `kg` + `bookkeeping` skills
+provisioned per agent. Agents query/curate in-session; Houston builds no pipeline.
+
+### 3.4 Session URI (the one net-new contract)
+`houston://workspace/<W>/agent/<A>/session/<session_key>` — keyed on stable `(session_key,
+working_dir)`, NOT the volatile resume id. Minted from `conversations.rs`'s existing `session_key`,
+exposed on the history route, injected into the session prompt via `build_agent_context`. §5.
+
+### 3.5 Root context layer
+`build_agent_context` gains a top layer, broad → narrow:
+`product prompt → ROOT (governance + KG digest) → WORKSPACE (WORKSPACE.md/USER.md) → AGENT (CLAUDE.md/learnings/skills)`.
+
+---
+
+## 4. Git + worktrees
+- **Per workspace:** `git --version` check → `git init` + seed `.gitignore` + initial commit. Git
+  absent → degrade to no-git mode + a **toast** (no silent failure), never block.
+- **Commit cadence:** mission boundaries (hook the existing `file_changes` before/after snapshot) +
+  explicit "save a version." Not per-write. Presented invisibly as "Houston saved a version."
+- **Worktrees:** mission on a git project optionally runs in `{project}-worktrees/houston/{mission}`
+  via `workingDirOverride` (reuse `worktree.rs`); the engine already permits parallel worktrees,
+  conflicts same-folder. **Janitor** (P8 squash-merge detection) prunes — mandatory for
+  non-technical users or `*-worktrees/` orphans pile up.
+- `.gitignore` seeds: `**/.houston/sessions/`, `**/*.sid`, `**/*.invalid`,
+  `**/.houston/**/*.schema.json`, `*-worktrees/`, `logs/`, `.DS_Store`.
+
+---
+
+## 5. Session ↔ knowledge-graph referenceability (decision #1)
+
+A Houston session is **already addressable**: `(agent_path, session_key)` (`conversations.rs`),
+resume ids on disk (`.houston/sessions/<provider>/<session_key>.sid`), transcript in `chat_feed` with
+an **existing FTS5 index** (`repo_search.rs`). So:
+- **FORWARD (session is addressable):** Houston mints the `houston://` URI, exposes it on the history
+  route, injects it into the session's own prompt → the agent knows its address. The conversation
+  bridge skill writes `docs/conversations/<session_key>.md` carrying that URI in frontmatter → the
+  session becomes a node.
+- **BACKWARD (graph references session):** entities promoted in-session carry `sessions: [houston://…]`
+  (entity→session); the session node lists `entities: [[slug]]` (session→entity). `/kg`'s catalog
+  already turns these into `→`/`←` links; `chat_feed` FTS makes the body queryable. Session→artifact
+  edges come free from `file_changes.rs`.
+
+No DB graph layer, no embeddings — the URI is the join key, markdown frontmatter is the edge store,
+the agent is the query engine. **Caveats:** routine sessions share one `session_key` across runs →
+need a run discriminator; URI must survive resume/compaction; PII redaction stays on in the bridge.
+
+---
+
+## 6. The make-or-break risks (surfaced by the sweep)
+
+1. **Path-assumption mismatch (the crux).** bstack skills hard-code `~/broomva/research/entities`,
+   `~/.config/broomva`, `~/.claude/...`. Installed as-is they target the *wrong* root. Houston spawns
+   the provider subprocess, so it sets `BROOMVA_ROOT=<agent workspace>` (+ CWD) per session —
+   `kg.py`/`bookkeeping.py` honor it. Skill bodies still need light adaptation to the workspace-
+   relative + `.agents/`/`.houston/` layout. **This is the make-or-break of the whole arc.**
+2. **Workspace-side hook scripts gap.** `settings.json` references `$WORKSPACE/scripts/*-hook.sh` that
+   are emitted by `control-metalayer-loop`'s bootstrap, **not shipped in bstack/scripts/**. Seed
+   settings.json without seeding these → every hook 404s → the P1/P2/P6/P7 reflex layer silently
+   no-ops. Houston must seed the scripts (or run the bootstrap).
+3. **Runtime deps — bundled at install (resolved).** `python3` 3.11+ (tomllib + PyYAML), `git`,
+   `gh`, `bash` 4+, `node`/`npx`. Houston **bundles + installs these at install time** so a bare
+   fresh setup is ready; agents install further tools on demand. Touches `houston-cli-bundle` +
+   `scripts/fetch-cli-deps.sh` + notarization + bundle size → foundation **F0**.
+4. **Voice firewall.** Governance jargon / `Pn` / URIs / paths must never leak into non-technical
+   chat. Governance is agent-facing; the user sees outcomes only. `developer_mode` relaxes the voice.
+5. **Skill-picker naming.** bstack slugs (`kg`, `role-x`, `persist`) + em-dash descriptions read badly
+   and violate i18n rules. Don't use `display_name` override (RULE 0 / schema forbids) — mark them
+   non-`featured`/no-`category` so they stay out of the prominent picker, or humanize at packaging.
+6. **Bundle vs fetch.** Companion skills are "checked, not bundled" (`npx skills add`). Houston is
+   offline-first → **vendor the chosen SKILL.md bodies into `store/` at release** (deterministic),
+   not runtime `install_from_repo` (network → violates no-silent-failure).
+7. **Governance ownership / L3 churn.** Houston-seeded governance vs agent self-evolution (P16) can
+   fight; the L3 churn budget + pre-commit rate gate could block early-setup edits. Idempotent
+   keep-if-exists re-seed; treat governance as user-data-shaped.
+
+---
+
+## 7. The arc (foundations → capabilities → cross-cutting)
+
+**Foundations** (enable everything):
+- **F0 — Runtime bundling.** Bundle + install `python3`/`git`/`gh`/`bash`/`node` at Houston install
+  time (fresh setup ready; agents extend on demand). Extends `houston-cli-bundle` +
+  `fetch-cli-deps.sh`; notarize bundled binaries; per-arch. Prereq for F2. `[build][app]`
+- **F1 — Visible git-backed root.** `docs_root` pref + `app-config.json` + boot wiring
+  (`HOUSTON_DOCS` from pref, engine restart); onboarding root-pick (default `~/Houston`); `git init`
+  + `.gitignore`; existing-user migration offer (reuse `migrate_legacy_docs_dir`). `[engine][app]`
+- **F2 — Agent environment + skill rail (the make-or-break).** Guarantee runtime (`python3`/`git`/
+  `gh`); set `BROOMVA_ROOT` + CWD per session; vendor + provision the bstack roster via the Store
+  `.agents/skills/*` rail + `copy_missing_skill_dirs` to existing agents; seed hook scripts; adapt
+  skill bodies to workspace-relative roots; voice firewall + `advanced.developer_mode`. `[engine][app]`
+
+**Capabilities** (each shippable + tested):
+- **C1 — Projects first-class.** `Project` entity + `projects.json` + `projects.rs` + routes;
+  "Open existing folder"/"New project" in the switcher (the original ask); agent↔project via
+  `workingDirOverride`. `[engine][ui][app]`
+- **C2 — Worktrees + janitor.** worktree-per-mission; parallel missions; P8 cleanup; reactive UI. `[engine][app]`
+- **C3 — Governance scaffold (opinionated, autonomous-native).** Idempotent seed of the governance
+  tree + `prompt.rs` root layer; `/autonomous` as the default stance. `[engine][app]`
+- **C4 — Second brain (LLM-as-index).** Seed `research/entities/` + catalog + frontmatter + starter
+  entities; `kg`/`bookkeeping` provisioned (F2); reactivity free. `[engine][app]`
+- **C5 — Session ↔ KG.** The `houston://` URI wire contract + history-route exposure + prompt
+  injection; bridge writes session nodes; entity↔session backlinks. `[engine][app]`
+
+**Cross-cutting:** voice firewall + `developer_mode` reveal; humanized skill picker; KB docs + i18n
+(en/es/pt); per-surface advanced toggles; tests + dogfood receipts each phase.
+
+---
+
+## 8. Reuse map (precise — per RULE 0, wire what exists)
+
+| Need | Existing surface |
+|---|---|
+| Skill provisioning | `engine/houston-skills/src/lib.rs` (CRUD, `build_skills_index`, `migrate_flat_files`), `engine-core/src/skills.rs` (`ensure_claude_symlink`, `install_from_repo`, `SkillsChanged`) |
+| Ship roster to existing agents | `store/bundled.rs` (`sync_bundled_agent_instances`, `copy_missing_skill_dirs`, `.migrations.json`) |
+| Governance/entities scaffold seam | `agents_crud.rs::create` (241-247 packaged-skill copy + seeds map ~277), `houston-agent-files/src/{lib,schemas}.rs` (embedded-asset seed) |
+| Context injection | `agents/prompt.rs` (`seed_agent` role-file fan-out, `build_agent_context`) |
+| Frontmatter tolerance | `houston-skills/src/format.rs` (serde_yml, unknown-key tolerant — bstack frontmatter parses as-is) |
+| Session identity / transcript / search | `conversations.rs` (`session_key`), `sessions/history.rs`, `houston-db/repo_search.rs` (FTS5), `sessions/file_changes.rs` (session→artifact) |
+| Worktrees | `engine/houston-engine-core/src/worktree.rs` (`houston/{name}` branches, `run_shell`) |
+| Folder linking | `agents_crud.rs` symlink + `pickDirectory` (dormant `link-project`) |
+| Run elsewhere | `session.workingDirOverride` (`tauriChat.send`) |
+| Root relocation + migration | `docs_dir`/`HOUSTON_DOCS` knob + `migrate_legacy_docs_dir` |
+| Reactivity | `houston-file-watcher` FilesChanged catch-all (already covers `research/entities/**` + catalog), `use-agent-invalidation.ts` |
+| Advanced flags | `advanced.*` substrate (FLAG_REGISTRY → KV → FeatureGate → enforcement → KB → tests) |
+
+---
+
+## 9. Decisions — resolved (this round)
+
+| # | Resolution |
+|---|---|
+| 1 Sessions | First-class addressable nodes; bridge → KG; URI referenceable both ways (§5). |
+| 2 Bookkeeping/PM | Agent jobs in-session via skills; never a user chore. |
+| 3 KG/index | LLM-as-index + filesystem/frontmatter core from day 1; **no engine pipeline**. |
+| 4 Governance | Best practice — seed bstack governance tree as environment. |
+| 5 Opinionated | profile=autonomous; `/autonomous` default; governance L3 stays `require_human`. |
+| 6 Shared context | Root global + per-workspace local (both). |
+| 7 Format | `/bstack` conventions; rich HTML for presenting to the user. |
+
+## 10. Decisions — closed (this round)
+1. Path fix: **`BROOMVA_ROOT` per session + minimal per-skill body adaptation** to workspace-relative roots.
+2. Hook scripts: **seed Houston-authored equivalents** (deterministic, offline) — don't depend on `control-metalayer-loop` bootstrap.
+3. Runtime: **bundle + install all needed deps at Houston install time** (fresh setup ready); agents install more on demand → foundation **F0**.
+4. Roster: **install for every agent, suppress from the picker surface** (non-`featured`/no-`category`).
+5. Templates: **Houston-tuned, voice-firewalled**.
+
+All arc-level decisions are closed. Next: execute **F1** (numbered chunk plan tracked in chat / the worktree branch).

--- a/docs/handoffs/2026-06-04-agentic-workspace-f1.md
+++ b/docs/handoffs/2026-06-04-agentic-workspace-f1.md
@@ -1,0 +1,59 @@
+# Agentic Workspace Substrate — F1 (visible git-backed root + developer mode)
+
+**TL;DR.** F1 of the agentic-workspace arc is implemented, fully unit-validated, adversarially reviewed (P20) and fixed, and pushed as **PR gethouston/houston#446** — but it is **not merged** (the `broomva` token lacks write access to `gethouston/houston`) and has **not had a real-app runtime check**; **FIRST ACTION: run `cd app && pnpm tauri dev`, exercise Settings → Advanced → Developer mode → Workspace location → pick a folder → restart → confirm the tree migrated, then have a gethouston maintainer merge #446.**
+
+## State of the world (P15 snapshot 2026-06-04)
+
+- **Houston** (`gethouston/houston`) — working branch `open-existing-workspace-folder`, tracking `fork/open-existing-workspace-folder` (remote `fork` = `broomva/houston`; remote `origin` = `gethouston/houston`, **broomva has no push/merge access → 403**). **4 ahead / 0 behind** `origin/main` (`e8919db`). Tree clean.
+- **PR #446** — `OPEN`, `mergeable: MERGEABLE`, `mergeStateStatus: CLEAN`, no CI checks reported (gethouston runs Actions only after maintainer approval on fork PRs). Blocked solely on merge permission.
+- **Daemons** — none running. No dev server / engine was started this session (validation was unit-tests + typecheck only). To run: `cd app && pnpm tauri dev` (rebuild the engine first if `engine/**` changed: `cargo build -p houston-engine-server`).
+- **Deps** — this worktree had **no `node_modules`** until `pnpm install` was run this session; if you re-clone, run `pnpm install` before `pnpm tsc`.
+
+## What F1 delivered (one PR, 4 commits — so the next agent doesn't redo it)
+
+| Commit | Files | What it gave |
+|---|---|---|
+| `8bfcc50` | `docs/agentic-workspace-substrate.{md,html}` | The whole-arc design (env-not-build reframe, two-root split, F0–F2 + C1–C5, session↔KG). Canonical spec + rich HTML. |
+| `0c45df5` | `app_config.rs` (new), `git_repo.rs` (new), `state.rs`, `lib.rs`, engine `lib.rs`, `Cargo.toml` | **C1** docsRoot resolution at boot (default unchanged); **C4** `ensure_docs_root_git` (idempotent git-init, skips hidden root, degrades w/o git); **C5** `migrate_docs_root`. |
+| `d011e6d` | `commands/workspace_root.rs` (new), `use-developer-mode.ts` (new), `advanced.tsx` (new), `os-bridge.ts`, `settings-view.tsx`, `commands/mod.rs`, `lib.rs`, `locales/*/settings.json`, `agent-manifest.md` | **C2** developer-mode toggle (off by default); **C3** `get/set_docs_root` + Settings → Advanced → Workspace location. |
+| `ae2e626` | `app_config.rs`, `git_repo.rs`, `workspace_root.rs`, `lib.rs`, `advanced.tsx`, `locales/*/settings.json` | **P20 fixes:** boot-time (pre-engine) migration; EXDEV-safe + resumable move; `.gitignore`-only initial commit + broadened ignore; canonicalized home-skip; absolute-path persistence + input validation; legacy→docs_dir; no silent catch. |
+
+**Default behavior is unchanged** — `docsRoot` unset → `~/.houston/workspaces/`. The visible-root path only activates when a user opts in via Settings.
+
+## E2E proof (re-runnable any time)
+
+```bash
+# Rust (engine + app crates) — from repo root:
+cargo test -p houston-engine-core git_repo     # 6 passed
+cargo test -p houston-app app_config           # 11 passed (incl. EXDEV-resume, nesting/equal guards)
+
+# TypeScript + locales — from app/ (run `pnpm install` first if node_modules absent):
+cd app && pnpm tsc --noEmit                     # 0 errors
+pnpm check-locales                              # en/es/pt in sync
+```
+
+## First action
+
+```bash
+cd /Users/broomva/conductor/workspaces/houston/lansing
+cargo build -p houston-engine-server   # stage the sidecar (engine changed)
+cd app && pnpm tauri dev
+# Then, in the app: Settings → Advanced → toggle "Developer mode" on →
+#   "Workspace location" → Change → pick e.g. ~/Houston → restart Houston →
+#   confirm: ~/Houston exists, is a git repo (`git -C ~/Houston log`),
+#   workspaces moved out of ~/.houston/workspaces, agents still load.
+```
+This is the **P11 gate** I could not close headlessly; it must pass before #446 merges (it's a data-migration feature). If it passes, ping a `gethouston/houston` maintainer to merge #446 (squash).
+
+## Pickup state (what's open)
+
+- [ ] **Merge #446** — needs a maintainer with write to `gethouston/houston` (broomva is 403). PR is CLEAN/MERGEABLE.
+- [ ] **Runtime-verify the migration** (the First action above) — the only validation gap.
+- [ ] **First-run onboarding root-pick screen** — deferred from C3. Capability ships via Settings; the tutorial-flow placement (`personal-assistant-onboarding.tsx` / welcome gate) needs the same `pnpm tauri dev` verification.
+- [ ] **Next arc foundations:** **F0** runtime bundling (python3/git/gh/bash/node into the installer) and **F2** agent environment + skill rail (`BROOMVA_ROOT` per session, vendor the bstack roster via the Store `.agents/skills/*` rail) — see the design doc §7.
+
+## Related context
+
+- Design (canonical + rich): `docs/agentic-workspace-substrate.md` / `.html`
+- Memory: `agentic-workspace-substrate-arc.md` (the arc), `advanced-settings-feature-shape.md` (now annotated STALE — no FLAG_REGISTRY exists; use the `tauriPreferences`+settings pattern from `use-developer-mode.ts`)
+- The P20 cross-review findings + their fixes are spelled out in commit `ae2e626`'s body.

--- a/engine/houston-engine-core/src/git_repo.rs
+++ b/engine/houston-engine-core/src/git_repo.rs
@@ -1,0 +1,177 @@
+//! Git-init the user-visible Houston workspace root.
+//!
+//! The visible, user-named root (`docs_dir`, e.g. `~/Houston`) is a git
+//! repository so the user gets version history of everything they and their
+//! agents create. The hidden system root (`~/.houston`, `~/.dev-houston`) is
+//! never a repo — it holds machine state, not user work — so git-init is
+//! skipped whenever `docs_dir` lives inside `home_dir` (which also covers the
+//! legacy `~/.houston/workspaces` default).
+//!
+//! Idempotent + boot-safe: a missing `git` degrades to a logged skip rather
+//! than failing engine startup. The app's onboarding surfaces git availability
+//! to the user; there is no UI thread at engine boot.
+
+use crate::error::{CoreError, CoreResult};
+use std::path::Path;
+use std::process::Command;
+
+/// Seeded `.gitignore` — keep volatile / machine state out of history.
+const GITIGNORE: &str = "\
+# Houston — volatile / machine state (never committed)
+**/.houston/sessions/
+**/*.sid
+**/*.invalid
+**/.houston/**/*.schema.json
+*-worktrees/
+logs/
+.DS_Store
+";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GitInitOutcome {
+    /// Freshly initialized a repo + seeded `.gitignore` + initial commit.
+    Initialized,
+    /// `docs_dir` already contained a `.git` — nothing to do.
+    AlreadyRepo,
+    /// `docs_dir` is inside the hidden system root — intentionally not a repo.
+    SkippedSystemRoot,
+    /// `git` is not on PATH — degraded gracefully.
+    SkippedNoGit,
+}
+
+fn git_available() -> bool {
+    Command::new("git")
+        .arg("--version")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+fn run_git(dir: &Path, args: &[&str]) -> CoreResult<()> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .map_err(|e| CoreError::Internal(format!("git {args:?} failed to spawn: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(CoreError::Internal(format!("git {args:?} failed: {stderr}")));
+    }
+    Ok(())
+}
+
+/// Ensure the visible workspace root is a git repo. See module docs.
+pub fn ensure_docs_root_git(docs_dir: &Path, home_dir: &Path) -> CoreResult<GitInitOutcome> {
+    // The hidden system root (and the legacy `~/.houston/workspaces` default,
+    // plus the `~/.dev-houston` debug root) all live under `home_dir`. Those
+    // are machine state, never git-backed.
+    if docs_dir.starts_with(home_dir) {
+        return Ok(GitInitOutcome::SkippedSystemRoot);
+    }
+    std::fs::create_dir_all(docs_dir).map_err(|e| {
+        CoreError::Internal(format!("create_dir_all({}) failed: {e}", docs_dir.display()))
+    })?;
+    if docs_dir.join(".git").exists() {
+        return Ok(GitInitOutcome::AlreadyRepo);
+    }
+    if !git_available() {
+        tracing::warn!(
+            "[git] git not found on PATH — {} will not be version-controlled until git is installed",
+            docs_dir.display()
+        );
+        return Ok(GitInitOutcome::SkippedNoGit);
+    }
+
+    run_git(docs_dir, &["init", "-b", "main"])?;
+
+    let gitignore = docs_dir.join(".gitignore");
+    if !gitignore.exists() {
+        std::fs::write(&gitignore, GITIGNORE)
+            .map_err(|e| CoreError::Internal(format!("write .gitignore failed: {e}")))?;
+    }
+
+    run_git(docs_dir, &["add", "-A"])?;
+    // Per-invocation identity + no signing so the initial commit succeeds on a
+    // machine with no global git config (CI, a fresh non-technical Mac). The
+    // `-c` flags do not touch the user's global config.
+    run_git(
+        docs_dir,
+        &[
+            "-c",
+            "user.name=Houston",
+            "-c",
+            "user.email=houston@localhost",
+            "-c",
+            "commit.gpgsign=false",
+            "commit",
+            "-m",
+            "Initial Houston workspace",
+        ],
+    )?;
+
+    Ok(GitInitOutcome::Initialized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn is_git_repo(dir: &Path) -> bool {
+        dir.join(".git").is_dir()
+    }
+
+    #[test]
+    fn visible_root_is_initialized() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path().join("home");
+        let docs = tmp.path().join("Houston");
+        std::fs::create_dir_all(&home).unwrap();
+        let outcome = ensure_docs_root_git(&docs, &home).unwrap();
+        assert_eq!(outcome, GitInitOutcome::Initialized);
+        assert!(is_git_repo(&docs));
+        assert!(docs.join(".gitignore").is_file());
+    }
+
+    #[test]
+    fn second_call_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path().join("home");
+        let docs = tmp.path().join("Houston");
+        std::fs::create_dir_all(&home).unwrap();
+        assert_eq!(
+            ensure_docs_root_git(&docs, &home).unwrap(),
+            GitInitOutcome::Initialized
+        );
+        assert_eq!(
+            ensure_docs_root_git(&docs, &home).unwrap(),
+            GitInitOutcome::AlreadyRepo
+        );
+    }
+
+    #[test]
+    fn system_root_is_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path().join(".houston");
+        let docs = home.join("workspaces");
+        std::fs::create_dir_all(&docs).unwrap();
+        let outcome = ensure_docs_root_git(&docs, &home).unwrap();
+        assert_eq!(outcome, GitInitOutcome::SkippedSystemRoot);
+        assert!(!is_git_repo(&docs));
+    }
+
+    #[test]
+    fn initial_commit_establishes_head() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path().join("home");
+        let docs = tmp.path().join("Houston");
+        std::fs::create_dir_all(&home).unwrap();
+        ensure_docs_root_git(&docs, &home).unwrap();
+        let out = Command::new("git")
+            .args(["rev-parse", "HEAD"])
+            .current_dir(&docs)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "HEAD should resolve after initial commit");
+    }
+}

--- a/engine/houston-engine-core/src/git_repo.rs
+++ b/engine/houston-engine-core/src/git_repo.rs
@@ -15,7 +15,11 @@ use crate::error::{CoreError, CoreResult};
 use std::path::Path;
 use std::process::Command;
 
-/// Seeded `.gitignore` — keep volatile / machine state out of history.
+/// Seeded `.gitignore`. Keeps volatile machine state, heavy build output, and
+/// credentials out of history. Only the `.gitignore` itself is committed at
+/// init (see below), but seeding the full set means later mission-boundary
+/// commits never sweep in `node_modules/`, `target/`, or a stray `.env` an
+/// agent wrote into a project.
 const GITIGNORE: &str = "\
 # Houston — volatile / machine state (never committed)
 **/.houston/sessions/
@@ -25,6 +29,24 @@ const GITIGNORE: &str = "\
 *-worktrees/
 logs/
 .DS_Store
+
+# Dependencies, build output, virtualenvs — agents clone + build inside projects
+**/node_modules/
+**/target/
+**/dist/
+**/build/
+**/.next/
+**/.turbo/
+**/.venv/
+**/venv/
+**/__pycache__/
+
+# Secrets — never version-control credentials an agent may write into a project
+**/.env
+**/.env.*
+!**/.env.example
+**/*.pem
+**/*.key
 ";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -60,17 +82,30 @@ fn run_git(dir: &Path, args: &[&str]) -> CoreResult<()> {
     Ok(())
 }
 
+/// True when `child` resolves to a path inside (or equal to) `ancestor`.
+/// Canonicalizes both so a symlinked or case-only-different home (macOS
+/// `/var` vs `/private/var`, case-insensitive filesystems) is matched
+/// correctly; falls back to a lexical check only when canonicalization fails.
+fn is_inside(child: &Path, ancestor: &Path) -> bool {
+    match (std::fs::canonicalize(child), std::fs::canonicalize(ancestor)) {
+        (Ok(c), Ok(a)) => c.starts_with(a),
+        _ => child.starts_with(ancestor),
+    }
+}
+
 /// Ensure the visible workspace root is a git repo. See module docs.
 pub fn ensure_docs_root_git(docs_dir: &Path, home_dir: &Path) -> CoreResult<GitInitOutcome> {
-    // The hidden system root (and the legacy `~/.houston/workspaces` default,
-    // plus the `~/.dev-houston` debug root) all live under `home_dir`. Those
-    // are machine state, never git-backed.
-    if docs_dir.starts_with(home_dir) {
-        return Ok(GitInitOutcome::SkippedSystemRoot);
-    }
+    // Create first so the system-root check can canonicalize a real path.
     std::fs::create_dir_all(docs_dir).map_err(|e| {
         CoreError::Internal(format!("create_dir_all({}) failed: {e}", docs_dir.display()))
     })?;
+
+    // The hidden system root (and the legacy `~/.houston/workspaces` default,
+    // plus the `~/.dev-houston` debug root) all live under `home_dir`. Those
+    // are machine state, never git-backed.
+    if is_inside(docs_dir, home_dir) {
+        return Ok(GitInitOutcome::SkippedSystemRoot);
+    }
     if docs_dir.join(".git").exists() {
         return Ok(GitInitOutcome::AlreadyRepo);
     }
@@ -90,10 +125,15 @@ pub fn ensure_docs_root_git(docs_dir: &Path, home_dir: &Path) -> CoreResult<GitI
             .map_err(|e| CoreError::Internal(format!("write .gitignore failed: {e}")))?;
     }
 
-    run_git(docs_dir, &["add", "-A"])?;
-    // Per-invocation identity + no signing so the initial commit succeeds on a
-    // machine with no global git config (CI, a fresh non-technical Mac). The
-    // `-c` flags do not touch the user's global config.
+    // Commit ONLY the `.gitignore`. Never `git add -A` the user's workspace at
+    // init: it may hold gigabytes of agent build output or a `.env` an agent
+    // wrote into a project, and sweeping all of that into a first commit is
+    // both slow and a credential-leak risk. The repo just needs a HEAD; real
+    // content is committed later at mission boundaries.
+    run_git(docs_dir, &["add", ".gitignore"])?;
+    // Per-invocation identity + no signing so the commit succeeds on a machine
+    // with no global git config (CI, a fresh non-technical Mac). The `-c` flags
+    // do not touch the user's global config.
     run_git(
         docs_dir,
         &[
@@ -105,7 +145,7 @@ pub fn ensure_docs_root_git(docs_dir: &Path, home_dir: &Path) -> CoreResult<GitI
             "commit.gpgsign=false",
             "commit",
             "-m",
-            "Initial Houston workspace",
+            "Initialize Houston workspace",
         ],
     )?;
 
@@ -121,6 +161,15 @@ mod tests {
         dir.join(".git").is_dir()
     }
 
+    fn tracked_files(dir: &Path) -> String {
+        let out = Command::new("git")
+            .args(["ls-files"])
+            .current_dir(dir)
+            .output()
+            .unwrap();
+        String::from_utf8_lossy(&out.stdout).to_string()
+    }
+
     #[test]
     fn visible_root_is_initialized() {
         let tmp = TempDir::new().unwrap();
@@ -131,6 +180,24 @@ mod tests {
         assert_eq!(outcome, GitInitOutcome::Initialized);
         assert!(is_git_repo(&docs));
         assert!(docs.join(".gitignore").is_file());
+    }
+
+    #[test]
+    fn only_gitignore_is_committed_not_user_content() {
+        let tmp = TempDir::new().unwrap();
+        let home = tmp.path().join("home");
+        let docs = tmp.path().join("Houston");
+        std::fs::create_dir_all(&home).unwrap();
+        // Pre-existing user content (incl. a secret) must NOT be swept in.
+        std::fs::create_dir_all(docs.join("Project")).unwrap();
+        std::fs::write(docs.join("Project/.env"), "API_KEY=secret").unwrap();
+        std::fs::write(docs.join("Project/huge.bin"), vec![0u8; 1024]).unwrap();
+
+        ensure_docs_root_git(&docs, &home).unwrap();
+        let tracked = tracked_files(&docs);
+        assert_eq!(tracked.trim(), ".gitignore");
+        assert!(!tracked.contains(".env"));
+        assert!(!tracked.contains("huge.bin"));
     }
 
     #[test]
@@ -156,6 +223,24 @@ mod tests {
         let docs = home.join("workspaces");
         std::fs::create_dir_all(&docs).unwrap();
         let outcome = ensure_docs_root_git(&docs, &home).unwrap();
+        assert_eq!(outcome, GitInitOutcome::SkippedSystemRoot);
+        assert!(!is_git_repo(&docs));
+    }
+
+    /// The home-skip must survive a symlinked home (the macOS `/var` vs
+    /// `/private/var` class of bug), which a lexical `starts_with` would miss.
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_home_is_skipped() {
+        let tmp = TempDir::new().unwrap();
+        let real_home = tmp.path().join("real_home");
+        let docs = real_home.join(".houston").join("workspaces");
+        std::fs::create_dir_all(&docs).unwrap();
+        let link_home = tmp.path().join("link_home");
+        std::os::unix::fs::symlink(&real_home, &link_home).unwrap();
+
+        // home passed as the symlink, docs spelled via the real path.
+        let outcome = ensure_docs_root_git(&docs, &link_home).unwrap();
         assert_eq!(outcome, GitInitOutcome::SkippedSystemRoot);
         assert!(!is_git_repo(&docs));
     }

--- a/engine/houston-engine-core/src/lib.rs
+++ b/engine/houston-engine-core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod attachments;
 pub mod conversations;
 pub mod error;
 pub mod git_bash;
+pub mod git_repo;
 pub mod paths;
 pub mod portable;
 pub mod preferences;

--- a/engine/houston-engine-server/src/state.rs
+++ b/engine/houston-engine-server/src/state.rs
@@ -84,6 +84,16 @@ impl ServerState {
             tracing::info!("[boot] repaired {repaired_activities} orphan running activity row(s)");
         }
 
+        // Make the visible workspace root a git repo so the user gets version
+        // history of everything they + their agents create. No-op for the
+        // hidden system root and when git is unavailable. Logged-and-swallowed
+        // because a git-init hiccup must not fail engine boot; onboarding
+        // surfaces git availability to the user, and there is no UI thread here.
+        match houston_engine_core::git_repo::ensure_docs_root_git(paths.docs(), paths.home()) {
+            Ok(outcome) => tracing::info!("[boot] docs-root git: {outcome:?}"),
+            Err(e) => tracing::warn!("[boot] docs-root git-init failed: {e}"),
+        }
+
         let engine = EngineState::new(paths, Arc::new(events.clone()), db.clone())
             .with_app_prompts(
                 config.app_system_prompt.clone(),

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -264,7 +264,7 @@ level; codex has no such fallback, so `max` (an unknown variant to codex) is
 never offered for OpenAI. Default for every effort-capable provider is `medium`.
 
 ## Workspace
-- Storage: `~/.houston/workspaces/workspaces.json` (index) + one dir per workspace `~/.houston/workspaces/{Name}/`. `HOUSTON_DOCS` env var overrides the root.
+- Storage: index `workspaces.json` + one dir per workspace `<docs-root>/{Name}/`. The **docs root** resolves at app boot from `~/.houston/app-config.json` (`docsRoot`), falling back to `~/.houston/workspaces/`; the app passes it to the engine as `HOUSTON_DOCS`. A user-visible root (e.g. `~/Houston`) is git-initialised at engine boot (`houston_engine_core::git_repo::ensure_docs_root_git` — seeds `.gitignore` + initial commit, skips the hidden system root, degrades when git is absent); the hidden default is never a repo. App-side resolution + idempotent migration live in `app/src-tauri/src/app_config.rs`; users change the location via Settings → Advanced (developer mode) → Workspace location (`commands::workspace_root::{get_docs_root,set_docs_root}`, applied on next launch).
 - First launch: welcome screen, create first workspace
 - Engine routes: `GET /v1/workspaces`, `POST /v1/workspaces`, `POST /v1/workspaces/:id/rename`, `DELETE /v1/workspaces/:id`, `PATCH /v1/workspaces/:id/provider`, `GET|PUT /v1/workspaces/:id/context` (`engine/houston-engine-server/src/routes/workspaces.rs`). Frontend reaches them via `@houston-ai/engine-client` — no Tauri commands in the path.
 - Store: `useWorkspaceStore` — `loadWorkspaces()`, `setCurrent()`, `create()`, `rename()`, `delete()`


### PR DESCRIPTION
## Summary
F1 of the agentic-workspace substrate arc (design in `docs/agentic-workspace-substrate.{md,html}`). Lets Houston workspaces live in a **user-visible, git-backed root** instead of only `~/.houston/`, behind an invisible-by-default **developer mode**. **Default behavior is unchanged** — `docsRoot` unset → `~/.houston/workspaces/`, so existing installs are untouched until a user opts in.

## What's included
- **C1 — docs_root resolution** (`app/src-tauri/src/app_config.rs`): `docsRoot` in `~/.houston/app-config.json`, read at boot, injected as `HOUSTON_DOCS`. Defaults to today's path.
- **C4 — git-init the root** (`engine/houston-engine-core/src/git_repo.rs`): idempotently git-inits the *visible* root + seeds `.gitignore` + a `.gitignore`-only initial commit; skips the hidden system root (canonicalized); degrades gracefully when git is absent. Wired into engine boot (`state.rs`).
- **C5 — migration** (`app_config::migrate_docs_root`): EXDEV-safe, no-loss, resumable move of an existing tree into a chosen root.
- **C2 — developer mode** (`use-developer-mode.ts` + Settings → Advanced): opt-in toggle; off by default keeps the non-technical product.
- **C3 — workspace location** (`commands/workspace_root.rs` + Settings control): view/reveal/change the root; the change is staged and applied at the next boot (before the engine starts), then the app prompts to restart.

## Adversarial review (P20)
A cross-model review flagged data-loss paths (live-engine migration, EXDEV tears, `git add -A` committing secrets, lexical home-skip, dual tilde-expanders, missing input validation). All addressed in `ae2e626`: migration runs at boot before the engine spawns, is EXDEV-safe + resumable, commits only `.gitignore`, canonicalizes the home-skip, persists an absolute path, and validates inputs.

## Validation
- Rust: `git_repo` 6 tests, `app_config` 11 tests (incl. EXDEV-resume + nesting/equal guards) — all green.
- `cargo check` (app) clean; `pnpm tsc --noEmit` 0 errors; `pnpm check-locales` OK (en/es/pt).

## NOT done / please verify before merge
- **Runtime verification (P11):** unit-tested + type-clean, but I could not run the Tauri app headlessly. Before merge, `pnpm tauri dev` and exercise: Settings → Advanced → Developer mode → Workspace location → pick a folder → restart → confirm the tree migrated and the engine uses the new root. This gate I cannot close from here, and it guards a data-migration feature.
- **First-run onboarding root-pick screen** is deferred — the capability ships via Settings; the tutorial-flow placement needs the same runtime verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)