### PR TITLE
chore: gitignore local .codex/ tool dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ target/
 !/store/agents/*/.agents/**
 .claude/skills/
 .windsurf/
+.codex/
 skills-lock.json
 .playwright-mcp/
 .wrangler/


### PR DESCRIPTION
Ignores the machine-local `.codex/` directory (Codex environments config), same category as `.windsurf/`, `.playwright-mcp/`, and `.claude/worktrees/` already in `.gitignore`.

**File:** `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)