### PR TITLE
fix(providers): hide Claude Code sign-in dialog on desktop

### DIFF
--- a/app/src/components/shell/provider-login-dialog.tsx
+++ b/app/src/components/shell/provider-login-dialog.tsx
@@ -31,8 +31,10 @@ import { ProviderDeviceCode } from "./provider-device-code";
  *    dialog waits for `ProviderLoginComplete` (handled by the parent) to
  *    auto-close.
  *
- * On desktop the dialog still pops (claude prints the URL unconditionally)
- * but auto-dismisses once the CLI's own localhost callback completes.
+ * Desktop never reaches here: the picker / settings drop `ProviderLoginUrl`
+ * when `osIsTauri()` (issue #453). The co-located CLI opens the user's own
+ * browser and completes via its localhost OAuth callback, so the URL relay
+ * is purely for clients that can't see that browser (webapp / mobile PWA).
  */
 interface Props {
   provider: ProviderInfo | null;

--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -96,7 +96,8 @@ export function ProviderPicker({ onSelect }: Props) {
 
   // Sign-in lifecycle events. `ProviderLoginUrl` surfaces the OAuth URL
   // for remote/headless engines (the CLI can't open the local browser),
-  // shown via <ProviderLoginDialog>. `ProviderLoginComplete` is the
+  // shown via <ProviderLoginDialog> — remote clients only (see the
+  // osIsTauri guard below). `ProviderLoginComplete` is the
   // authoritative end of an attempt: the status poll only ever flips a
   // card to Connected on SUCCESS, so without reacting to a failed or
   // cancelled completion the card would spin forever (the #237 bug this
@@ -106,6 +107,14 @@ export function ProviderPicker({ onSelect }: Props) {
   useEffect(() => {
     const off = subscribeHoustonEvents((ev: HoustonEvent) => {
       if (ev.type === "ProviderLoginUrl") {
+        // The sign-in URL / paste-back dialog is a REMOTE-only affordance.
+        // On desktop the engine is the co-located sidecar: the provider CLI
+        // opens the user's own browser and finishes via its localhost OAuth
+        // callback, so surfacing the URL would only flash a dialog that
+        // immediately auto-dismisses on ProviderLoginComplete (issue #453).
+        // Skip it — same osIsTauri signal that sets `deviceAuth: !osIsTauri()`
+        // on connect.
+        if (osIsTauri()) return;
         const prov = PROVIDERS.find((p) => p.id === ev.data.provider);
         if (prov) {
           // The relay can emit twice for codex's device flow: URL-only,

--- a/app/src/components/shell/provider-settings.tsx
+++ b/app/src/components/shell/provider-settings.tsx
@@ -140,7 +140,8 @@ export function ProviderSettings() {
   // Always-On VPS). When the engine spawns claude/codex login and the
   // CLI can't open the user's browser, it surfaces the fallback URL
   // via `ProviderLoginUrl`. We show <ProviderLoginDialog> with the
-  // URL + a paste-code field. `ProviderLoginComplete` closes the
+  // URL + a paste-code field — remote clients only (see the osIsTauri
+  // guard below). `ProviderLoginComplete` closes the
   // dialog and refreshes provider status. The status-poll effect
   // above flips the chip to Connected once the CLI's credential file
   // lands. Functional setState avoids stale-closure reads on
@@ -150,6 +151,14 @@ export function ProviderSettings() {
   useEffect(() => {
     const off = subscribeHoustonEvents((ev: HoustonEvent) => {
       if (ev.type === "ProviderLoginUrl") {
+        // The sign-in URL / paste-back dialog is a REMOTE-only affordance.
+        // On desktop the engine is the co-located sidecar: the provider CLI
+        // opens the user's own browser and finishes via its localhost OAuth
+        // callback, so surfacing the URL would only flash a dialog that
+        // immediately auto-dismisses on ProviderLoginComplete (issue #453).
+        // Skip it — same osIsTauri signal that sets `deviceAuth: !osIsTauri()`
+        // on connect.
+        if (osIsTauri()) return;
         const prov = PROVIDERS.find((p) => p.id === ev.data.provider);
         if (prov) {
           // The relay can emit twice for codex's device flow: URL-only,

--- a/engine/houston-engine-core/src/provider/login_relay.rs
+++ b/engine/houston-engine-core/src/provider/login_relay.rs
@@ -21,10 +21,13 @@
 //! the relay task emits [`HoustonEvent::ProviderLoginComplete`] so the
 //! frontend can close the sign-in dialog and refresh `providerStatus`.
 //!
-//! Same machinery handles desktop too: claude prints the URL
-//! unconditionally, but completes via its own local callback before
-//! the user needs to interact with the Houston dialog. The dialog
-//! pops, then auto-dismisses on `ProviderLoginComplete`.
+//! The same machinery runs for a co-located desktop client too — claude
+//! prints the URL unconditionally — but there the CLI opens the user's own
+//! browser and finishes via its localhost callback, so the desktop frontend
+//! drops `ProviderLoginUrl` (`osIsTauri()`, issue #453) and shows no dialog;
+//! it just waits for `ProviderLoginComplete`. The URL relay is frontend-
+//! agnostic: the engine always emits it, and each client decides whether it
+//! can reach a local browser.
 
 use crate::error::{CoreError, CoreResult};
 use houston_terminal_manager::Provider;

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -114,6 +114,18 @@ expired OAuth/API-key messages) and `houston-agents-conversations` emits
 `codex login` through `/v1/providers/:name/login` and polls provider status
 until the CLI reports authenticated.
 
+**`ProviderLoginDialog` is a remote-only affordance.** On desktop the engine
+is the co-located sidecar: the provider CLI opens the user's own browser and
+finishes through its `localhost` OAuth callback, so the connect surfaces
+(`ProviderPicker`, `ProviderSettings`) **drop `ProviderLoginUrl` when
+`osIsTauri()`** and show no dialog — they just wait for `ProviderLoginComplete`
+to flip the card (issue #453). Without that guard claude (which prints its
+`https://claude.com/…` URL unconditionally) flashed a paste-back dialog that
+instantly auto-dismissed; codex never did, because its desktop fallback URL is
+`http://localhost:1455/…`, which the relay's `https://`-only regex skips. The
+engine still emits `ProviderLoginUrl` either way — it's frontend-agnostic; the
+client decides whether it can reach a local browser.
+
 **Headless connect uses two completion shapes.** A remote client (the webapp
 or mobile PWA pointed at a hosted engine) can't receive the CLI's `localhost`
 OAuth callback, so the connect surfaces that render `ProviderLoginDialog`


### PR DESCRIPTION
## What

On desktop, clicking **Connect** for Claude Code briefly flashed the OAuth sign-in dialog (the URL + paste-back-code modal) before it auto-dismissed. This hides it, matching how Codex already behaves on desktop.

Closes #453.

## Why

`ProviderLoginDialog` is a **remote-only affordance**. It exists for webapp / mobile PWA clients whose engine runs on another machine, where the provider CLI can't open the user's browser — so the engine surfaces the sign-in URL over the `ProviderLoginUrl` WS event and the client renders a dialog (paste-back for Claude, device-code for Codex).

On **desktop** the engine is the co-located sidecar: the CLI opens the user's *own* browser and finishes through its `localhost` OAuth callback. The dialog is never actionable there — it just pops and auto-dismisses on `ProviderLoginComplete`. This is exactly the distinction the `osIsTauri()` docstring already calls "load-bearing" for provider sign-in.

Claude exposed the bug because `claude auth login --claudeai` prints its `https://claude.com/…` URL unconditionally, which the relay surfaces. Codex only *looked* clean because its desktop fallback URL is `http://localhost:1455/…`, which the relay's `https://`-only regex skips.

## How

Fix lives in the frontend so the **engine stays frontend-agnostic** — it still emits `ProviderLoginUrl`; each client decides whether it can reach a local browser. `ProviderPicker` and `ProviderSettings` now drop `ProviderLoginUrl` when `osIsTauri()`, the same signal that already drives `deviceAuth: !osIsTauri()` on connect. The guard is provider-agnostic (not a Claude-only hack), so Claude now behaves like Codex on desktop, and remote/headless clients are unaffected.

## Affected files

- `app/src/components/shell/provider-picker.tsx` — desktop guard in the `ProviderLoginUrl` handler
- `app/src/components/shell/provider-settings.tsx` — same guard
- `app/src/components/shell/provider-login-dialog.tsx` — refreshed now-stale docstring
- `engine/houston-engine-core/src/provider/login_relay.rs` — refreshed now-stale module docstring (behavior unchanged)
- `knowledge-base/auth.md` — documented the remote-only-dialog rule

## Testing

- `cd app && pnpm tsc --noEmit` — types
- No engine behavior change (doc comment only); `cargo build --workspace` still applies if engine is rebuilt.
- Manual: in the desktop app, Settings → connect Claude Code → no sign-in dialog flashes; the card spins, then flips to **Connected** after the browser handshake. Repeat in the webapp/PWA against a remote engine → the dialog still appears (unchanged).

> Note: `app/` has no JS unit-test harness (build is `tsc --noEmit && vite build`), so this guard is covered by typecheck + manual verification rather than a new unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)