### PR TITLE
fix(chat): make bare URLs in chat clickable to open in browser (#358)

### DIFF
--- a/ui/chat/src/ai-elements/message.tsx
+++ b/ui/chat/src/ai-elements/message.tsx
@@ -30,6 +30,7 @@ import {
 } from "react";
 import { Streamdown } from "streamdown";
 import { MarkdownCodeBlock } from "../markdown-code-block";
+import { classifyMarkdownLink } from "../markdown-link";
 
 const MessageAvatarContext = createContext<React.ReactNode | undefined>(undefined);
 
@@ -380,22 +381,44 @@ export const MessageResponse = memo(
       return {
         ...sharedComponents,
         a: ({ href, children, node: _node }: AnchorHTMLAttributes<HTMLAnchorElement> & { node?: unknown }) => {
-          // Raw auto-linked URL: children text equals href → plain text, no button
-          if (!href || children === href) {
+          const kind = classifyMarkdownLink(href, children);
+          // No href → nothing to open.
+          if (kind === "plain") {
             return <span>{children}</span>;
           }
-          const onOpen = () => fn?.(href);
-          // If a custom renderer is provided and returns something, use
-          // it. If it returns undefined/null, fall through to the
-          // default button so the app can selectively override only
-          // specific URL patterns.
+          const url = href as string;
+          const onOpen = () => fn?.(url);
+          // The app's custom renderer gets first say on every link (its
+          // contract). When it returns undefined/null we fall through to
+          // the defaults below, so the app can override only specific URL
+          // patterns (e.g. Composio connect cards) and leave the rest alone.
           if (renderLink) {
-            const custom = renderLink({ href, children, onOpen });
+            const custom = renderLink({ href: url, children, onOpen });
             if (custom != null) {
               return <>{custom}</>;
             }
           }
-          // Markdown link with custom text → default button with text + icon
+          // Bare URL the agent dropped in chat → inline, clickable link that
+          // opens in the system browser (issue #358), not dead text. Only
+          // render it interactive when there's an open handler; otherwise it
+          // would look clickable but do nothing.
+          if (kind === "autolink") {
+            if (!fn) return <span>{children}</span>;
+            return (
+              <a
+                href={url}
+                rel="noreferrer"
+                onClick={(e) => {
+                  e.preventDefault();
+                  onOpen();
+                }}
+                className="text-primary underline-offset-4 hover:underline [overflow-wrap:anywhere]"
+              >
+                {children}
+              </a>
+            );
+          }
+          // Labeled link (text distinct from URL) → button with text + icon.
           return (
             <Button
               type="button"

--- a/ui/chat/src/markdown-link.ts
+++ b/ui/chat/src/markdown-link.ts
@@ -1,0 +1,29 @@
+/**
+ * How a markdown `<a>` rendered by Streamdown should behave in chat.
+ *
+ * - `plain`    — no href, nothing to open. Render inert text.
+ * - `autolink` — the visible text IS the URL. GFM auto-linked a bare URL the
+ *                agent dropped into a message (`https://example.com`). Render
+ *                it inline AND clickable so it opens in the system browser
+ *                (issue #358) instead of sitting there as dead text.
+ * - `labeled`  — the link has descriptive text distinct from the URL
+ *                (`[Open report](https://…)`). Render the labeled button.
+ */
+export type MarkdownLinkKind = "plain" | "autolink" | "labeled";
+
+/**
+ * Classify a markdown link by its href and rendered children.
+ *
+ * `children` is a React node in practice, but the only thing that matters for
+ * classification is strict equality with the href string — Streamdown emits a
+ * bare auto-linked URL as `<a href="X">X</a>`, so `children === href` exactly
+ * when the user never gave the link a label. Typed as `unknown` so this helper
+ * stays free of React (and therefore unit-testable without a DOM).
+ */
+export function classifyMarkdownLink(
+  href: string | null | undefined,
+  children: unknown,
+): MarkdownLinkKind {
+  if (!href) return "plain";
+  return children === href ? "autolink" : "labeled";
+}

--- a/ui/chat/test/markdown-link.test.mjs
+++ b/ui/chat/test/markdown-link.test.mjs
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { classifyMarkdownLink } from "../src/markdown-link.ts";
+
+test("bare auto-linked URL is an autolink (issue #358 — must stay clickable)", () => {
+  assert.equal(
+    classifyMarkdownLink("https://example.com", "https://example.com"),
+    "autolink",
+  );
+});
+
+test("labeled markdown link is labeled", () => {
+  assert.equal(
+    classifyMarkdownLink("https://example.com/report.pdf", "Open report"),
+    "labeled",
+  );
+});
+
+test("missing href is plain (nothing to open)", () => {
+  assert.equal(classifyMarkdownLink(undefined, "text"), "plain");
+  assert.equal(classifyMarkdownLink("", "text"), "plain");
+  assert.equal(classifyMarkdownLink(null, "text"), "plain");
+});
+
+test("non-string children (React nodes) never match a string href → labeled", () => {
+  // Streamdown can hand us an array/element for labeled links; only a bare
+  // auto-linked URL yields children strictly equal to the href string.
+  assert.equal(
+    classifyMarkdownLink("https://example.com", ["https://example.com"]),
+    "labeled",
+  );
+  assert.equal(classifyMarkdownLink("https://example.com", { href: "x" }), "labeled");
+});
+
+test("relative path the agent dropped (perfil.md) classifies as autolink when shown bare", () => {
+  // openAgentHref resolves non-URL hrefs against the agent dir; classification
+  // only cares whether the visible text equals the href.
+  assert.equal(classifyMarkdownLink("perfil.md", "perfil.md"), "autolink");
+});


### PR DESCRIPTION
Closes #358.

## Problem
When an agent drops a raw URL in chat, GFM auto-links it — so the rendered `<a>`'s visible text equals its `href`. The chat link handler treated that case as "not a real link" and rendered a dead `<span>`. Only markdown links with *custom label text* (`[Open report](…)`) got a clickable button, so bare URLs the agent emits were inert. The reporter wanted to click (or ctrl/cmd+click) a link to open it in the browser.

## Fix
`ui/chat/src/ai-elements/message.tsx` — the markdown `<a>` renderer now:
- Renders an **auto-linked bare URL as an inline, clickable link** styled with the design system's link tokens (`text-primary` / `underline-offset-4` / `hover:underline`). Click (and ctrl/cmd+click) opens the system browser through the existing `onOpenLink` → `openAgentHref` → `tauriSystem.openUrl` path; `preventDefault` stops the WebView from navigating away. It only becomes interactive when an open handler is present, so it never *looks* clickable while being dead.
- Promotes the app's `renderLink` override to run for **every** `<a>` (raw or labeled). This matches the override's documented JSDoc contract — previously raw URLs short-circuited before `renderLink` was ever consulted. No behavior change for the existing Composio cards (those links are labeled and both `renderLink` impls return `undefined` for ordinary URLs).
- Keeps labeled links rendering as the existing button-with-icon.

The link-kind decision is extracted into a pure, dependency-free `classifyMarkdownLink` helper (`plain` / `autolink` / `labeled`) so it's unit-testable without a DOM.

No app-side change was needed — `openAgentHref` already routes URLs to the system browser (and bare relative paths to the agent's file opener).

## Files
- `ui/chat/src/ai-elements/message.tsx` — clickable auto-links; `renderLink` applies to all links
- `ui/chat/src/markdown-link.ts` — new pure `classifyMarkdownLink` helper (new)
- `ui/chat/test/markdown-link.test.mjs` — unit tests (new)

## Testing
- `node --test ui/chat/test/markdown-link.test.mjs` — 5/5 pass
- `pnpm typecheck` clean in `@houston-ai/chat`, `@houston-ai/board`, and the app (`pnpm tsc --noEmit`)
- Interactive/visual confirmation in the running app is recommended (bare URL renders as an inline link; clicking opens the default browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)