### PR TITLE
release: v0.4.19

### DIFF
--- a/.github/release-notes/0.4.19.es.md
+++ b/.github/release-notes/0.4.19.es.md
@@ -1,0 +1,26 @@
+## Houston 0.4.19
+
+Más control sobre cómo tus rutinas usan los chats, notas de actualización en tu propio idioma y una mejora de estabilidad para que Houston abra sin problemas y cada cosa te lleve al lugar correcto.
+
+### Agregado
+
+- **Elige cómo usa los chats cada rutina.** Al configurar una rutina, decide si cada ejecución continúa en un mismo chat o inicia un chat nuevo cada vez, para que el historial coincida con cómo piensas esa tarea.
+- **Notas de actualización en tu idioma.** La tarjeta de "actualización disponible" ahora muestra las novedades en español, inglés o portugués, según el idioma con el que usas Houston.
+
+### Cambiado
+
+- **Mission Control coincide con tus tableros.** Mission Control ahora usa las mismas tarjetas y el mismo comportamiento que el tablero de cada agente, así lo que ves es igual en todas partes.
+
+### Corregido
+
+- **Houston abre aunque un espacio de trabajo tarde en cargar.** La app ya no se queda en una ventana en blanco al iniciar si un espacio de trabajo demora en responder.
+- **Las notificaciones de rutinas te llevan al chat correcto.** Al tocar la notificación de "finalizada" de una rutina, ahora se abre el chat de esa rutina en lugar de una vista genérica.
+- **Arrastrar misiones es más fluido.** Al arrastrar las tarjetas de misión ahora se ve el mismo cursor en todos los sistemas y ya no se subraya el título de la tarjeta mientras la mueves.
+- **Aviso de "conectar" más claro.** El aviso "Esperando que te conectes" de una integración ahora aparece al final del mensaje del agente, justo donde estás mirando.
+- **Los reportes de problemas capturan más (en segundo plano).** Algunos errores de la pantalla de Houston se perdían antes de llegarnos. Ahora se reportan para que podamos corregirlos más rápido. No tienes que hacer nada.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza una app en ejecución de forma limpia. Si tienes dudas, elimina `/Applications/Houston.app` y arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde la 0.4.7 o posterior te lleva adelante sola. El MSI aún no está firmado a nivel del sistema operativo (la integración con SignPath sigue pendiente), por lo que Windows SmartScreen puede mostrar una advertencia en una instalación nueva.
+- **Windows ARM64:** no hay actualización automática desde una instalación x64 emulada. Descarga el MSI ARM64 manualmente, desinstala primero la versión x64 y luego instala la ARM64.

--- a/.github/release-notes/0.4.19.md
+++ b/.github/release-notes/0.4.19.md
@@ -1,0 +1,26 @@
+## Houston 0.4.19
+
+More control over how your routines use chats, update notes in your own language, and a reliability pass so Houston opens cleanly and the right things take you to the right place.
+
+### Added
+
+- **Choose how each routine uses chats.** When you set up a routine, pick whether every run keeps going in one ongoing chat or starts a fresh chat each time, so the history matches how you think about that task.
+- **Update notes in your language.** The "update available" card now shows what is new in English, Spanish, or Portuguese, matching the language you use Houston in.
+
+### Changed
+
+- **Mission Control matches your boards exactly.** Mission Control now uses the same cards and behavior as each agent's board, so what you see lines up everywhere.
+
+### Fixed
+
+- **Houston opens even when a workspace is slow to load.** The app no longer gets stuck on a blank window at startup if one workspace takes a while to respond.
+- **Routine notifications take you to the right chat.** Clicking a routine's "finished" notification now opens that routine's chat instead of a generic view.
+- **Smoother mission dragging.** Dragging mission cards now shows the same cursor on every system and no longer underlines the card title mid-drag.
+- **Clearer "connect" prompt.** The "Waiting for you to connect" note for an integration now appears at the end of the agent's message, where you are already looking.
+- **Problem reports catch more (behind the scenes).** Some errors from Houston's screen were being dropped before they reached us. They now get reported so we can fix them faster. Nothing for you to do.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward automatically. The MSI is still not OS-code-signed (SignPath integration still pending), so Windows SmartScreen may warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install. Download the ARM64 MSI manually, uninstall the x64 build first, then install the ARM64 one.

--- a/.github/release-notes/0.4.19.pt.md
+++ b/.github/release-notes/0.4.19.pt.md
@@ -1,0 +1,26 @@
+## Houston 0.4.19
+
+Mais controle sobre como suas rotinas usam os chats, notas de atualização no seu próprio idioma e uma rodada de estabilidade para o Houston abrir direitinho e cada coisa levar você ao lugar certo.
+
+### Adicionado
+
+- **Escolha como cada rotina usa os chats.** Ao configurar uma rotina, decida se cada execução continua em um mesmo chat ou começa um chat novo a cada vez, para que o histórico combine com a forma como você pensa naquela tarefa.
+- **Notas de atualização no seu idioma.** O cartão de "atualização disponível" agora mostra as novidades em português, inglês ou espanhol, conforme o idioma em que você usa o Houston.
+
+### Alterado
+
+- **O Mission Control combina com seus quadros.** O Mission Control agora usa os mesmos cartões e o mesmo comportamento do quadro de cada agente, então o que você vê fica igual em todo lugar.
+
+### Corrigido
+
+- **O Houston abre mesmo quando um espaço de trabalho demora a carregar.** O app não fica mais travado em uma janela em branco ao iniciar se um espaço de trabalho demora a responder.
+- **As notificações de rotinas levam você ao chat certo.** Ao tocar na notificação de "concluída" de uma rotina, agora o chat dessa rotina abre, em vez de uma tela genérica.
+- **Arrastar missões ficou mais suave.** Ao arrastar os cartões de missão agora aparece o mesmo cursor em todos os sistemas e o título do cartão não fica mais sublinhado durante o movimento.
+- **Aviso de "conectar" mais claro.** O aviso "Esperando você se conectar" de uma integração agora aparece no fim da mensagem do agente, bem onde você está olhando.
+- **Os relatórios de problemas capturam mais (nos bastidores).** Alguns erros da tela do Houston eram perdidos antes de chegarem até nós. Agora eles são reportados para corrigirmos mais rápido. Você não precisa fazer nada.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui um app em execução de forma limpa. Na dúvida, remova `/Applications/Houston.app` e arraste a cópia nova.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou posterior leva você adiante sozinha. O MSI ainda não é assinado no nível do sistema operacional (a integração com o SignPath continua pendente), então o Windows SmartScreen pode exibir um aviso em uma instalação nova.
+- **Windows ARM64:** não há atualização automática a partir de uma instalação x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a versão x64 e depois instale a ARM64.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "futures-util",
  "hex",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "serde",
  "serde_json",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2627,6 +2627,8 @@ dependencies = [
  "houston-ui-events",
  "rand 0.8.5",
  "reqwest 0.12.28",
+ "sentry",
+ "sentry-tracing",
  "serde",
  "serde_json",
  "sha2",
@@ -2643,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2657,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2668,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2682,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2698,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2717,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "dirs 5.0.1",
  "houston-cli-bundle",
@@ -2730,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2750,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.17"
+version = "0.4.19"
 dependencies = [
  "houston-terminal-manager",
  "serde",
@@ -5520,6 +5522,7 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -5826,6 +5829,7 @@ dependencies = [
  "httpdate",
  "native-tls",
  "reqwest 0.12.28",
+ "rustls 0.23.37",
  "sentry-actix",
  "sentry-backtrace",
  "sentry-contexts",
@@ -7647,10 +7651,12 @@ dependencies = [
  "log",
  "native-tls",
  "percent-encoding",
+ "rustls 0.23.37",
  "rustls-pki-types",
  "ureq-proto",
  "utf8-zero",
  "webpki-root-certs",
+ "webpki-roots 1.0.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.18", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.18", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.18", path = "app/houston-tauri" }
-houston-events = { version = "0.4.18", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.18", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.18", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.18", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.18", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.18", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.18", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.18", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.18", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.18", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.18", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.18", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.18", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.18", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.18", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.19", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.19", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.19", path = "app/houston-tauri" }
+houston-events = { version = "0.4.19", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.19", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.19", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.19", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.19", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.19", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.19", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.19", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.19", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.19", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.19", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.19", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.19", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.19", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.19", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.18"
+version = "0.4.19"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.18",
+  "version": "0.4.19",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Release v0.4.19

Patch bump across all shared-version packages, plus hand-written release notes (en/es/pt) for the in-app updater and the GitHub release body.

### What ships (user-facing)
**Added**
- Routines: choose one ongoing chat per routine, or a fresh chat each run (#423, #436)
- Localized update notes in the "update available" card, en/es/pt (#434)

**Changed**
- Mission Control now uses the same shared board component as agent boards (#442)

**Fixed**
- Boot no longer hangs on a stalled workspace fetch (#439, #443)
- Routine completion notification opens that routine's chat (#432)
- Consistent cross-OS drag cursor + pointer-at-rest, no title underline (#433)
- Composio "Waiting for you to connect" shown at the end of the agent message (#435)
- Sentry: renderer JS errors delivered over direct HTTP, no longer silently dropped (#437)

Plus internal hardening (#450), CI (#444), and chore (#449) commits not surfaced to users.

### Files
- Version bump: all `Cargo.toml` + workspace `package.json` files + `Cargo.lock` (via `scripts/version.sh 0.4.19`)
- Notes: `.github/release-notes/0.4.19.md`, `0.4.19.es.md`, `0.4.19.pt.md`

### Verification
- `cargo check --workspace` — pass (only pre-existing dead-code warnings)
- `cd app && pnpm tsc --noEmit` — pass

### Release process
This PR only lands the bump + notes on `main`. The draft GitHub Release is created by CI **after** `v0.4.19` is tagged and pushed (~15-20 min signed/notarized universal build). CI stops at a **draft** — publishing is the user's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)