### PR TITLE
release: v0.4.20

### DIFF
--- a/.github/release-notes/0.4.20.es.md
+++ b/.github/release-notes/0.4.20.es.md
@@ -25,4 +25,3 @@ Claude Fable 5, el modelo más capaz de Anthropic, ya es una opción para tus ag
 ### Limitaciones conocidas
 
 - **Fable 5 consume más créditos.** Usa alrededor del doble de créditos que Opus 4.8 por ejecución. El selector de modelos lo indica, pero conviene saberlo antes de cambiar todos tus agentes.
-- **El compañero móvil sigue en beta.** Espera algún tropiezo ocasional de reconexión. Mantén tu Mac despierta mientras lo usas.

--- a/.github/release-notes/0.4.20.es.md
+++ b/.github/release-notes/0.4.20.es.md
@@ -1,0 +1,28 @@
+## Houston 0.4.20
+
+Claude Fable 5, el modelo más capaz de Anthropic, ya es una opción para tus agentes. Además, una forma más simple de crear horarios personalizados para las rutinas y un par de correcciones en el chat. Se instala sobre 0.4.19, sin cambios que rompan nada.
+
+### Agregado
+
+- **Claude Fable 5.** Fable 5 es el modelo más capaz de Anthropic, y ahora puedes elegirlo para cualquier agente desde el selector de modelos. Es la mejor opción para trabajos difíciles de varios pasos. Algo que conviene saber sobre el costo: Fable 5 usa alrededor del doble de créditos que Opus 4.8 por ejecución, así que úsalo cuando la tarea realmente lo amerite y deja Opus 4.8 o Sonnet 4.6 para el trabajo diario.
+- **Horarios de rutinas personalizados más simples.** Crear un horario personalizado ahora es un selector sencillo de "Repetir cada N minutos, horas, días, semanas o meses", sin nada parecido a cron. Si eliges semanas, aparece un selector de días con atajos para Todos los días, Días laborables y Fines de semana. Si eliges meses, eliges el día del mes. El resumen en lenguaje claro se actualiza mientras avanzas, para que siempre veas cuándo se ejecutará la rutina.
+
+### Cambiado
+
+- **Descripciones de modelos más claras.** Cada modelo de Claude en el selector ahora tiene una descripción de una línea actualizada, para que la diferencia entre velocidad, capacidad y costo se entienda de un vistazo.
+
+### Corregido
+
+- **Los enlaces en el chat se pueden abrir.** Una dirección web que un agente escriba en el chat ahora se abre en tu navegador con un solo clic, sin copiar y pegar.
+- **Codex ya no se interrumpe durante una búsqueda web.** Se corrigió un error que podía cortar un chat de Codex mientras buscaba en la web.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza una app en ejecución de forma limpia. Si tienes dudas, elimina `/Applications/Houston.app` y arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde la 0.4.7 o posterior te lleva adelante sola. El MSI aún no está firmado a nivel del sistema operativo (la integración con SignPath sigue pendiente), por lo que Windows SmartScreen puede mostrar una advertencia en una instalación nueva.
+- **Windows ARM64:** no hay actualización automática desde una instalación x64 emulada. Descarga el MSI ARM64 manualmente, desinstala primero la versión x64 y luego instala la ARM64.
+
+### Limitaciones conocidas
+
+- **Fable 5 consume más créditos.** Usa alrededor del doble de créditos que Opus 4.8 por ejecución. El selector de modelos lo indica, pero conviene saberlo antes de cambiar todos tus agentes.
+- **El compañero móvil sigue en beta.** Espera algún tropiezo ocasional de reconexión. Mantén tu Mac despierta mientras lo usas.

--- a/.github/release-notes/0.4.20.md
+++ b/.github/release-notes/0.4.20.md
@@ -1,0 +1,28 @@
+## Houston 0.4.20
+
+Claude Fable 5, Anthropic's most capable model, is now a pick for your agents. Plus a simpler way to set custom routine schedules and a couple of chat fixes. Drop-in on top of 0.4.19, no breaking changes.
+
+### Added
+
+- **Claude Fable 5.** Fable 5 is Anthropic's most capable model, and you can now choose it for any agent from the model picker. It is the strongest option for hard, multi-step work. One thing to know about cost: Fable 5 uses about twice the credits of Opus 4.8 per run, so reach for it when a task really calls for it and keep Opus 4.8 or Sonnet 4.6 for everyday work.
+- **Simpler custom routine schedules.** Setting a custom schedule is now a plain "Repeat every N minutes, hours, days, weeks, or months" picker instead of anything cron-shaped. Choose weeks and you get a day-of-week selector with Every day, Weekdays, and Weekends shortcuts. Choose months and you pick the day of the month. The plain-language summary updates as you go, so you always see exactly when the routine will run.
+
+### Changed
+
+- **Clearer model descriptions.** Every Claude model in the picker now has a refreshed one-line description, so the trade-off between speed, capability, and cost reads at a glance.
+
+### Fixed
+
+- **Links in chat are clickable.** A plain web address an agent writes in chat now opens in your browser with a single click, no copy and paste.
+- **Codex no longer interrupts during a web search.** Fixed an error that could break a Codex chat while it was searching the web.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward automatically. The MSI is still not OS-code-signed (SignPath integration still pending), so Windows SmartScreen may warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install. Download the ARM64 MSI manually, uninstall the x64 build first, then install the ARM64 one.
+
+### Known limitations
+
+- **Fable 5 costs more credits.** It uses roughly twice the credits of Opus 4.8 per run. The model picker flags this, but it is worth knowing before you switch every agent over.
+- **Mobile companion is still beta.** Expect occasional reconnect hiccups. Keep your Mac awake while using it.

--- a/.github/release-notes/0.4.20.md
+++ b/.github/release-notes/0.4.20.md
@@ -25,4 +25,3 @@ Claude Fable 5, Anthropic's most capable model, is now a pick for your agents. P
 ### Known limitations
 
 - **Fable 5 costs more credits.** It uses roughly twice the credits of Opus 4.8 per run. The model picker flags this, but it is worth knowing before you switch every agent over.
-- **Mobile companion is still beta.** Expect occasional reconnect hiccups. Keep your Mac awake while using it.

--- a/.github/release-notes/0.4.20.pt.md
+++ b/.github/release-notes/0.4.20.pt.md
@@ -25,4 +25,3 @@ O Claude Fable 5, o modelo mais capaz da Anthropic, agora é uma opção para se
 ### Limitações conhecidas
 
 - **O Fable 5 consome mais créditos.** Usa cerca do dobro de créditos do Opus 4.8 por execução. O seletor de modelos avisa, mas vale saber antes de trocar todos os seus agentes.
-- **O companheiro móvel ainda está em beta.** Espere algum tropeço ocasional de reconexão. Mantenha seu Mac acordado enquanto o usa.

--- a/.github/release-notes/0.4.20.pt.md
+++ b/.github/release-notes/0.4.20.pt.md
@@ -1,0 +1,28 @@
+## Houston 0.4.20
+
+O Claude Fable 5, o modelo mais capaz da Anthropic, agora é uma opção para seus agentes. Além disso, uma forma mais simples de criar agendamentos personalizados para as rotinas e algumas correções no chat. Instala por cima da 0.4.19, sem mudanças que quebrem nada.
+
+### Adicionado
+
+- **Claude Fable 5.** O Fable 5 é o modelo mais capaz da Anthropic, e agora você pode escolhê-lo para qualquer agente no seletor de modelos. É a opção mais forte para trabalhos difíceis de várias etapas. Algo que vale saber sobre o custo: o Fable 5 usa cerca do dobro de créditos do Opus 4.8 por execução, então use-o quando a tarefa realmente pedir e deixe o Opus 4.8 ou o Sonnet 4.6 para o trabalho do dia a dia.
+- **Agendamentos de rotina personalizados mais simples.** Criar um agendamento personalizado agora é um seletor simples de "Repetir a cada N minutos, horas, dias, semanas ou meses", sem nada parecido com cron. Se você escolher semanas, aparece um seletor de dias com atalhos para Todos os dias, Dias úteis e Fins de semana. Se escolher meses, você escolhe o dia do mês. O resumo em linguagem clara se atualiza conforme você avança, então você sempre vê quando a rotina vai rodar.
+
+### Alterado
+
+- **Descrições de modelos mais claras.** Cada modelo do Claude no seletor agora tem uma descrição de uma linha atualizada, para que a diferença entre velocidade, capacidade e custo fique clara num relance.
+
+### Corrigido
+
+- **Os links no chat podem ser abertos.** Um endereço web que um agente escreve no chat agora abre no seu navegador com um clique, sem copiar e colar.
+- **O Codex não interrompe mais durante uma busca na web.** Corrigimos um erro que podia cortar um chat do Codex enquanto ele buscava na web.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui um app em execução de forma limpa. Na dúvida, remova `/Applications/Houston.app` e arraste a cópia nova.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou posterior te leva adiante sozinha. O MSI ainda não é assinado no nível do sistema operacional (a integração com o SignPath segue pendente), então o Windows SmartScreen pode avisar em uma instalação nova.
+- **Windows ARM64:** não há atualização automática a partir de uma instalação x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a versão x64 e depois instale a ARM64.
+
+### Limitações conhecidas
+
+- **O Fable 5 consome mais créditos.** Usa cerca do dobro de créditos do Opus 4.8 por execução. O seletor de modelos avisa, mas vale saber antes de trocar todos os seus agentes.
+- **O companheiro móvel ainda está em beta.** Espere algum tropeço ocasional de reconexão. Mantenha seu Mac acordado enquanto o usa.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.19", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.19", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.19", path = "app/houston-tauri" }
-houston-events = { version = "0.4.19", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.19", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.19", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.19", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.19", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.19", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.19", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.19", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.19", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.19", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.19", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.19", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.19", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.19", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.19", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.20", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.20", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.20", path = "app/houston-tauri" }
+houston-events = { version = "0.4.20", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.20", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.20", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.20", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.20", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.20", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.20", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.20", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.20", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.20", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.20", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.20", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.20", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.20", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.20", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.19"
+version = "0.4.20"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Version bump to **v0.4.20** + release notes (en/es/pt). Cut from `main` (does **not** include the open routine-i18n PR #456).

## Headline
- **Claude Fable 5** is selectable in the model picker (#476), with refreshed Anthropic model descriptions.

## Also in this release (since v0.4.19)
- Custom routine schedules: "Repeat every N [unit]" + weekly day picker (#445)
- Bare URLs in chat are clickable (#457)
- Codex: tolerate duplicate `id` in web_search events (#472)

## Changes in this PR
- `./scripts/version.sh 0.4.20` — bumps all `package.json` + `Cargo.toml` (30 manifests)
- `.github/release-notes/0.4.20.md` + `.es.md` + `.pt.md` — in-app updater notes, Fable 5 as the lead item

## Verified
- `cargo metadata` clean (all manifests parse, versions consistent), no `0.4.19` leftovers
- Release notes pass copy rules (no em dashes, no `-->`)

## After merge
Tag `v0.4.20` on the squashed commit and push it to upstream to trigger the signed/notarized draft build. Release CI stops at a **draft** for manual QA + publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)