### PR TITLE
fix(engine): carry system prompts to provider CLIs via files, not argv (Windows os error 206)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2727,6 +2727,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
+ "toml 0.8.2",
  "tracing",
 ]
 

--- a/cli-deps.json
+++ b/cli-deps.json
@@ -23,7 +23,7 @@
     }
   },
   "codex": {
-    "version": "0.130.0",
+    "version": "0.137.0",
     "bundled": true,
     "binary_name": "codex",
     "license": "Apache-2.0",
@@ -36,10 +36,10 @@
       "windows-arm64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-aarch64-pc-windows-msvc.exe.zst"
     },
     "checksums": {
-      "darwin-arm64": "bc50a4b7f9a0c8ca99179189e4659b601107830770e21547dc0c246bce733577",
-      "darwin-x64": "feddb116bd96d7d83f8bb19b34fbabe6843cc64461baf2e49c017e1206ad5e67",
-      "windows-x64": "b941e5d2f3d59ef38d7b31885be1596566640f1c3b6c5d086bfdeade6c8ff9cd",
-      "windows-arm64": "087f12e44d6da8a6378e39e1448470db6b40836c9775f704de95cd9c84bfce0f"
+      "darwin-arm64": "628d2278b1fa2a467452635f2fd5aaeee98de4a94f2af06031e4790da6844046",
+      "darwin-x64": "32206ff8e4edb3422832b24d25a521246e4478b67bab2ec63bee632fdf94b306",
+      "windows-x64": "327e93f43d039734353d2ba7feb8ecffd8a0f90c068c5370ac2ae4f80436aa7a",
+      "windows-arm64": "1a24ce2d34a2b9e62a22c2a20626a78bab83250f148ce87b73c67b1b0923b1e7"
     }
   },
   "composio": {

--- a/engine/houston-engine-core/src/workspace_context.rs
+++ b/engine/houston-engine-core/src/workspace_context.rs
@@ -23,6 +23,17 @@ use std::path::{Path, PathBuf};
 pub const WORKSPACE_MD: &str = "WORKSPACE.md";
 pub const USER_MD: &str = "USER.md";
 
+/// Prompt-injection budget per file. Agents append to these files forever
+/// (the prompt section below tells them to), so the on-disk text grows
+/// without bound — a real workspace hit ~19 KB and, combined with the rest
+/// of the system prompt, broke codex spawns on Windows (32,767-char command
+/// line limit, os error 206). The argv side is fixed separately
+/// (`houston-terminal-manager::prompt_scratch`); this cap keeps the prompt
+/// share bounded the same way `learnings_context` bounds learnings. The
+/// files on disk are never trimmed — only what gets injected per session.
+const WORKSPACE_PROMPT_LIMIT: usize = 12_000;
+const USER_PROMPT_LIMIT: usize = 4_000;
+
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct WorkspaceContext {
@@ -93,14 +104,14 @@ pub fn build_prompt_section(ws_dir: &Path) -> Option<String> {
          path below.)"
             .to_string()
     } else {
-        workspace.trim_end().to_string()
+        cap_for_prompt(workspace.trim_end(), WORKSPACE_PROMPT_LIMIT)
     };
     let user_body = if user.trim().is_empty() {
         "(empty so far. When the user tells you about their role, goals, or \
          how they like to work, write it to the file path below.)"
             .to_string()
     } else {
-        user.trim_end().to_string()
+        cap_for_prompt(user.trim_end(), USER_PROMPT_LIMIT)
     };
 
     let mut out = String::new();
@@ -123,6 +134,29 @@ pub fn build_prompt_section(ws_dir: &Path) -> Option<String> {
         user_md_path.display(),
     ));
     Some(out)
+}
+
+/// Keep the END of an oversized body (agents append new facts at the
+/// bottom, so the tail is the most recent), cut at a line boundary, and say
+/// so explicitly — silent truncation would read as "this is everything".
+fn cap_for_prompt(body: &str, limit: usize) -> String {
+    if body.len() <= limit {
+        return body.to_string();
+    }
+    let mut cut = body.len() - limit;
+    while !body.is_char_boundary(cut) {
+        cut += 1;
+    }
+    let tail = &body[cut..];
+    // Drop the (likely partial) first line of the tail for a clean start.
+    let tail = match tail.split_once('\n') {
+        Some((_, rest)) => rest,
+        None => tail,
+    };
+    format!(
+        "(beginning omitted from this prompt to keep it bounded; the full \
+         text remains in the file below. Most recent entries follow.)\n{tail}"
+    )
 }
 
 #[cfg(test)]
@@ -188,5 +222,56 @@ mod tests {
         let d = TempDir::new().unwrap();
         // No `.houston/` => not a real workspace; skip injection.
         assert!(build_prompt_section(d.path()).is_none());
+    }
+
+    #[test]
+    fn cap_keeps_small_bodies_untouched() {
+        assert_eq!(cap_for_prompt("Acme Corp.", WORKSPACE_PROMPT_LIMIT), "Acme Corp.");
+    }
+
+    #[test]
+    fn cap_keeps_most_recent_lines_and_says_so() {
+        let body = (0..2_000)
+            .map(|i| format!("- fact number {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert!(body.len() > WORKSPACE_PROMPT_LIMIT);
+
+        let capped = cap_for_prompt(&body, WORKSPACE_PROMPT_LIMIT);
+
+        assert!(capped.len() <= WORKSPACE_PROMPT_LIMIT + 200, "marker overhead only");
+        assert!(capped.contains("- fact number 1999"), "newest entries must survive");
+        assert!(!capped.contains("- fact number 0\n"), "oldest entries are dropped");
+        assert!(
+            capped.starts_with("(beginning omitted"),
+            "truncation must be explicit, never silent"
+        );
+    }
+
+    #[test]
+    fn cap_respects_utf8_boundaries() {
+        let body = "🚀".repeat(5_000); // 4 bytes each, no newlines
+        let capped = cap_for_prompt(&body, 1_000);
+        assert!(capped.contains('🚀'));
+        assert!(capped.starts_with("(beginning omitted"));
+    }
+
+    #[test]
+    fn oversized_workspace_file_is_capped_in_prompt_but_not_on_disk() {
+        let d = TempDir::new().unwrap();
+        fs::create_dir_all(d.path().join(".houston")).unwrap();
+        let big = (0..2_000)
+            .map(|i| format!("- workspace fact {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        fs::write(d.path().join(WORKSPACE_MD), &big).unwrap();
+
+        let out = build_prompt_section(d.path()).unwrap();
+
+        assert!(out.len() < big.len(), "prompt section must be bounded");
+        assert!(out.contains("- workspace fact 1999"));
+        assert!(out.contains("(beginning omitted"));
+        // The file itself is never trimmed.
+        assert_eq!(fs::read_to_string(d.path().join(WORKSPACE_MD)).unwrap(), big);
     }
 }

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -11,6 +11,10 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+# TOML encoding for the per-session codex profile file that carries
+# `developer_instructions` off the command line (Windows 32,767-char
+# `CreateProcessW` limit — see `prompt_scratch`).
+toml = "0.8"
 # Cross-platform home-directory resolution (HOME on Unix, USERPROFILE on
 # Windows). Used by `claude_path` to expand `~/...` entries in the common
 # install-dir list.

--- a/engine/houston-terminal-manager/src/claude_command.rs
+++ b/engine/houston-terminal-manager/src/claude_command.rs
@@ -1,0 +1,207 @@
+//! Claude CLI command assembly — counterpart of `codex_command` for the
+//! Anthropic provider: binary resolution, argv construction, and the
+//! retry-policy predicates the runner consults.
+
+use crate::cli_process::CliRunOutcome;
+use std::ffi::OsString;
+use tokio::process::Command;
+
+/// Absolute path to the Houston-managed `claude` if the runtime installer
+/// dropped it (`~/.local/bin/claude` on Unix,
+/// `%LOCALAPPDATA%\Programs\claude\claude.exe` on Windows). Falls back to
+/// the bare name `"claude"` (PATH lookup) only when the installer hasn't
+/// run yet, e.g. dev checkouts without `cli-deps.json`.
+///
+/// Spawning the absolute path matters: we pin a specific claude-code
+/// version in `cli-deps.json` and pass flags
+/// (`--include-partial-messages`, `--dangerously-skip-permissions`, ...)
+/// that only newer versions support. PATH lookup can hit an older
+/// `claude` from npm-global, homebrew, or a prior install, which then
+/// rejects the flag with `error: unknown option '--include-partial-messages'`
+/// and the session dies before producing any output.
+pub(crate) fn claude_command_name() -> OsString {
+    if crate::claude_install_path::is_installed() {
+        crate::claude_install_path::cli_path().into_os_string()
+    } else {
+        OsString::from("claude")
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn configure_claude_command(
+    cmd: &mut Command,
+    resume_session_id: Option<&str>,
+    working_dir: Option<&std::path::Path>,
+    model: Option<&str>,
+    effort: Option<&str>,
+    system_prompt_file: Option<&std::path::Path>,
+    mcp_config: Option<&std::path::Path>,
+    disable_builtin_tools: bool,
+    disable_all_tools: bool,
+) {
+    cmd.env("PATH", crate::claude_path::shell_path());
+    cmd.arg("-p")
+        .arg("--output-format")
+        .arg("stream-json")
+        .arg("--verbose")
+        .arg("--include-partial-messages");
+
+    if disable_all_tools {
+        cmd.arg("--allowedTools").arg("");
+    } else {
+        cmd.arg("--dangerously-skip-permissions");
+        if disable_builtin_tools {
+            cmd.arg("--disallowedTools")
+                .arg("Edit")
+                .arg("Write")
+                .arg("NotebookEdit");
+        }
+    }
+
+    if let Some(m) = model {
+        cmd.arg("--model").arg(m);
+    }
+    if let Some(e) = effort {
+        cmd.arg("--effort").arg(e);
+    }
+    if let Some(path) = system_prompt_file {
+        // File, not inline text: inline `--system-prompt <text>` puts the
+        // whole prompt on the command line, which exceeds Windows'
+        // 32,767-char limit for agents with large accumulated context.
+        cmd.arg("--system-prompt-file").arg(path);
+    }
+    if let Some(mcp) = mcp_config {
+        cmd.arg("--mcp-config").arg(mcp);
+    }
+    if let Some(session_id) = resume_session_id {
+        cmd.arg("--resume").arg(session_id);
+    }
+
+    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
+    cmd.env_remove("CLAUDECODE");
+
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
+}
+
+/// Two failure modes share the "retry without `--resume`" recovery path:
+/// 1. `ProviderRequestMalformedJson` — Anthropic API rejected the resumed
+///    transcript as having an unpaired UTF-16 surrogate (a single bad
+///    emoji or pasted character anywhere in history poisons it forever).
+/// 2. `ClaudeResumeCorrupted` — the on-disk transcript JSONL at
+///    `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` is structurally
+///    broken (truncated trailing line, dangling tool_use without
+///    tool_result). The CLI crashes before contacting the API.
+///
+/// In both cases the cure is the same: clear the persisted session id,
+/// re-spawn `claude -p` without `--resume`, and let the user continue.
+/// Without a resume id there is nothing to strip — fall through to the
+/// outer error-surfacing branches so the user still gets feedback.
+pub(crate) fn should_retry_fresh_after_resume_failure(
+    outcome: CliRunOutcome,
+    resume_session_id: Option<&str>,
+) -> bool {
+    matches!(
+        outcome,
+        CliRunOutcome::ProviderRequestMalformedJson | CliRunOutcome::ClaudeResumeCorrupted
+    ) && resume_session_id.is_some()
+}
+
+pub(crate) fn fresh_retry_prompt<'a>(
+    prompt: &'a str,
+    resume_fallback_prompt: Option<&'a str>,
+) -> &'a str {
+    resume_fallback_prompt.unwrap_or(prompt)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn retries_malformed_provider_json_only_for_resume() {
+        assert!(should_retry_fresh_after_resume_failure(
+            CliRunOutcome::ProviderRequestMalformedJson,
+            Some("claude-session-id"),
+        ));
+        assert!(!should_retry_fresh_after_resume_failure(
+            CliRunOutcome::ProviderRequestMalformedJson,
+            None,
+        ));
+    }
+
+    #[test]
+    fn retries_corrupted_resume_only_when_resume_id_present() {
+        assert!(should_retry_fresh_after_resume_failure(
+            CliRunOutcome::ClaudeResumeCorrupted,
+            Some("claude-session-id"),
+        ));
+        // No resume to strip — the runner surfaces a SpawnFailed card instead.
+        assert!(!should_retry_fresh_after_resume_failure(
+            CliRunOutcome::ClaudeResumeCorrupted,
+            None,
+        ));
+    }
+
+    #[test]
+    fn does_not_retry_other_outcomes() {
+        assert!(!should_retry_fresh_after_resume_failure(
+            CliRunOutcome::Failed,
+            Some("claude-session-id"),
+        ));
+        assert!(!should_retry_fresh_after_resume_failure(
+            CliRunOutcome::Completed,
+            Some("claude-session-id"),
+        ));
+        assert!(!should_retry_fresh_after_resume_failure(
+            CliRunOutcome::CodexResumeMissing,
+            Some("claude-session-id"),
+        ));
+    }
+
+    #[test]
+    fn fresh_retry_uses_recovery_prompt_when_available() {
+        assert_eq!(
+            fresh_retry_prompt("latest", Some("recovered history + latest")),
+            "recovered history + latest"
+        );
+        assert_eq!(fresh_retry_prompt("latest", None), "latest");
+    }
+
+    /// Mirror of `codex_command::argv_length_is_independent_of_prompt_size`:
+    /// the system prompt reaches claude via `--system-prompt-file <path>`,
+    /// so argv stays small and constant regardless of prompt size and the
+    /// Windows 32,767-char command-line limit can never kill the spawn.
+    #[test]
+    fn argv_carries_a_file_path_not_the_prompt_text() {
+        let mut cmd = Command::new("claude");
+        let sp_file = std::path::Path::new("/tmp/houston-claude-sp-1-1.md");
+        configure_claude_command(
+            &mut cmd,
+            Some("session-id"),
+            None,
+            Some("claude-opus-4-8"),
+            Some("high"),
+            Some(sp_file),
+            None,
+            false,
+            false,
+        );
+
+        let args: Vec<String> = cmd
+            .as_std()
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        let total: usize = args.iter().map(|a| a.len() + 1).sum();
+        assert!(total < 1_000, "claude argv must stay tiny, got {total}: {args:?}");
+
+        let flag_pos = args.iter().position(|a| a == "--system-prompt-file").unwrap();
+        assert_eq!(args[flag_pos + 1], sp_file.to_string_lossy());
+        assert!(
+            !args.iter().any(|a| a == "--system-prompt"),
+            "inline --system-prompt must never be used"
+        );
+    }
+}

--- a/engine/houston-terminal-manager/src/claude_runner.rs
+++ b/engine/houston-terminal-manager/src/claude_runner.rs
@@ -1,34 +1,16 @@
 use super::types::{FeedItem, SessionStatus};
-use crate::claude_install_path;
+use crate::claude_command::{
+    claude_command_name, configure_claude_command, fresh_retry_prompt,
+    should_retry_fresh_after_resume_failure,
+};
 use crate::cli_process::{run_cli_process, CliRunOutcome};
+use crate::prompt_scratch;
 use crate::provider_error::MALFORMED_PROVIDER_JSON_MESSAGE;
 use crate::provider_error_kind::ProviderError;
 use crate::session_update::SessionUpdate;
 use crate::Provider;
-use std::ffi::OsString;
 use tokio::process::Command;
 use tokio::sync::mpsc;
-
-/// Absolute path to the Houston-managed `claude` if the runtime installer
-/// dropped it (`~/.local/bin/claude` on Unix,
-/// `%LOCALAPPDATA%\Programs\claude\claude.exe` on Windows). Falls back to
-/// the bare name `"claude"` (PATH lookup) only when the installer hasn't
-/// run yet, e.g. dev checkouts without `cli-deps.json`.
-///
-/// Spawning the absolute path matters: we pin a specific claude-code
-/// version in `cli-deps.json` and pass flags
-/// (`--include-partial-messages`, `--dangerously-skip-permissions`, ...)
-/// that only newer versions support. PATH lookup can hit an older
-/// `claude` from npm-global, homebrew, or a prior install, which then
-/// rejects the flag with `error: unknown option '--include-partial-messages'`
-/// and the session dies before producing any output.
-fn claude_command_name() -> OsString {
-    if claude_install_path::is_installed() {
-        claude_install_path::cli_path().into_os_string()
-    } else {
-        OsString::from("claude")
-    }
-}
 
 /// Spawn a Claude CLI session (`claude -p --output-format stream-json`).
 #[allow(clippy::too_many_arguments)]
@@ -63,6 +45,23 @@ pub(crate) async fn spawn_claude(
         }
     }
 
+    // The system prompt travels via `--system-prompt-file`, never as an argv
+    // token (`--system-prompt <text>` broke `CreateProcessW` on Windows once
+    // the prompt outgrew the 32,767-char command-line limit). The scratch
+    // value owns the temp file; it is deleted when this fn returns.
+    let system_prompt_file = match system_prompt.as_deref() {
+        None => None,
+        Some(sp) => match prompt_scratch::claude_system_prompt_file(sp) {
+            Ok(f) => Some(f),
+            Err(e) => {
+                let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(format!(
+                    "Failed to prepare claude instructions: {e}"
+                ))));
+                return;
+            }
+        },
+    };
+
     let mut cmd = Command::new(claude_command_name());
     configure_claude_command(
         &mut cmd,
@@ -70,7 +69,7 @@ pub(crate) async fn spawn_claude(
         working_dir.as_deref(),
         model.as_deref(),
         effort.as_deref(),
-        system_prompt.as_deref(),
+        system_prompt_file.as_ref().map(|f| f.path()),
         mcp_config.as_deref(),
         disable_builtin_tools,
         disable_all_tools,
@@ -89,7 +88,7 @@ pub(crate) async fn spawn_claude(
             working_dir.as_deref(),
             model.as_deref(),
             effort.as_deref(),
-            system_prompt.as_deref(),
+            system_prompt_file.as_ref().map(|f| f.path()),
             mcp_config.as_deref(),
             disable_builtin_tools,
             disable_all_tools,
@@ -125,7 +124,7 @@ async fn retry_fresh(
     working_dir: Option<&std::path::Path>,
     model: Option<&str>,
     effort: Option<&str>,
-    system_prompt: Option<&str>,
+    system_prompt_file: Option<&std::path::Path>,
     mcp_config: Option<&std::path::Path>,
     disable_builtin_tools: bool,
     disable_all_tools: bool,
@@ -137,7 +136,7 @@ async fn retry_fresh(
         working_dir,
         model,
         effort,
-        system_prompt,
+        system_prompt_file,
         mcp_config,
         disable_builtin_tools,
         disable_all_tools,
@@ -165,145 +164,8 @@ async fn retry_fresh(
     }
 }
 
-#[allow(clippy::too_many_arguments)]
-fn configure_claude_command(
-    cmd: &mut Command,
-    resume_session_id: Option<&str>,
-    working_dir: Option<&std::path::Path>,
-    model: Option<&str>,
-    effort: Option<&str>,
-    system_prompt: Option<&str>,
-    mcp_config: Option<&std::path::Path>,
-    disable_builtin_tools: bool,
-    disable_all_tools: bool,
-) {
-    cmd.env("PATH", super::claude_path::shell_path());
-    cmd.arg("-p")
-        .arg("--output-format")
-        .arg("stream-json")
-        .arg("--verbose")
-        .arg("--include-partial-messages");
-
-    if disable_all_tools {
-        cmd.arg("--allowedTools").arg("");
-    } else {
-        cmd.arg("--dangerously-skip-permissions");
-        if disable_builtin_tools {
-            cmd.arg("--disallowedTools")
-                .arg("Edit")
-                .arg("Write")
-                .arg("NotebookEdit");
-        }
-    }
-
-    if let Some(m) = model {
-        cmd.arg("--model").arg(m);
-    }
-    if let Some(e) = effort {
-        cmd.arg("--effort").arg(e);
-    }
-    if let Some(sp) = system_prompt {
-        cmd.arg("--system-prompt").arg(sp);
-    }
-    if let Some(mcp) = mcp_config {
-        cmd.arg("--mcp-config").arg(mcp);
-    }
-    if let Some(session_id) = resume_session_id {
-        cmd.arg("--resume").arg(session_id);
-    }
-
-    cmd.env_remove("CLAUDE_CODE_ENTRYPOINT");
-    cmd.env_remove("CLAUDECODE");
-
-    if let Some(dir) = working_dir {
-        cmd.current_dir(dir);
-    }
-}
-
-/// Two failure modes share the "retry without `--resume`" recovery path:
-/// 1. `ProviderRequestMalformedJson` — Anthropic API rejected the resumed
-///    transcript as having an unpaired UTF-16 surrogate (a single bad
-///    emoji or pasted character anywhere in history poisons it forever).
-/// 2. `ClaudeResumeCorrupted` — the on-disk transcript JSONL at
-///    `~/.claude/projects/<encoded-cwd>/<session-id>.jsonl` is structurally
-///    broken (truncated trailing line, dangling tool_use without
-///    tool_result). The CLI crashes before contacting the API.
-///
-/// In both cases the cure is the same: clear the persisted session id,
-/// re-spawn `claude -p` without `--resume`, and let the user continue.
-/// Without a resume id there is nothing to strip — fall through to the
-/// outer error-surfacing branches so the user still gets feedback.
-fn should_retry_fresh_after_resume_failure(
-    outcome: CliRunOutcome,
-    resume_session_id: Option<&str>,
-) -> bool {
-    matches!(
-        outcome,
-        CliRunOutcome::ProviderRequestMalformedJson | CliRunOutcome::ClaudeResumeCorrupted
-    ) && resume_session_id.is_some()
-}
-
-fn fresh_retry_prompt<'a>(prompt: &'a str, resume_fallback_prompt: Option<&'a str>) -> &'a str {
-    resume_fallback_prompt.unwrap_or(prompt)
-}
-
 fn send_malformed_provider_json_status(tx: &mpsc::UnboundedSender<SessionUpdate>) {
     let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(
         MALFORMED_PROVIDER_JSON_MESSAGE.to_string(),
     )));
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn retries_malformed_provider_json_only_for_resume() {
-        assert!(should_retry_fresh_after_resume_failure(
-            CliRunOutcome::ProviderRequestMalformedJson,
-            Some("claude-session-id"),
-        ));
-        assert!(!should_retry_fresh_after_resume_failure(
-            CliRunOutcome::ProviderRequestMalformedJson,
-            None,
-        ));
-    }
-
-    #[test]
-    fn retries_corrupted_resume_only_when_resume_id_present() {
-        assert!(should_retry_fresh_after_resume_failure(
-            CliRunOutcome::ClaudeResumeCorrupted,
-            Some("claude-session-id"),
-        ));
-        // No resume to strip — the runner surfaces a SpawnFailed card instead.
-        assert!(!should_retry_fresh_after_resume_failure(
-            CliRunOutcome::ClaudeResumeCorrupted,
-            None,
-        ));
-    }
-
-    #[test]
-    fn does_not_retry_other_outcomes() {
-        assert!(!should_retry_fresh_after_resume_failure(
-            CliRunOutcome::Failed,
-            Some("claude-session-id"),
-        ));
-        assert!(!should_retry_fresh_after_resume_failure(
-            CliRunOutcome::Completed,
-            Some("claude-session-id"),
-        ));
-        assert!(!should_retry_fresh_after_resume_failure(
-            CliRunOutcome::CodexResumeMissing,
-            Some("claude-session-id"),
-        ));
-    }
-
-    #[test]
-    fn fresh_retry_uses_recovery_prompt_when_available() {
-        assert_eq!(
-            fresh_retry_prompt("latest", Some("recovered history + latest")),
-            "recovered history + latest"
-        );
-        assert_eq!(fresh_retry_prompt("latest", None), "latest");
-    }
 }

--- a/engine/houston-terminal-manager/src/cli_process.rs
+++ b/engine/houston-terminal-manager/src/cli_process.rs
@@ -49,7 +49,8 @@ pub(crate) async fn run_cli_process(
         Ok(c) => c,
         Err(e) => {
             let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(format!(
-                "Failed to spawn {cli_name}: {e}"
+                "Failed to spawn {cli_name}: {e}{}",
+                spawn_error_hint(e.raw_os_error())
             ))));
             return CliRunOutcome::Failed;
         }
@@ -288,6 +289,24 @@ extern "C" {
     fn setpgid(pid: i32, pgid: i32) -> i32;
 }
 
+/// Decorate a raw spawn errno with an actionable hint. 206 is Windows'
+/// `ERROR_FILENAME_EXCED_RANGE`: `CreateProcessW` rejected the command line
+/// for exceeding 32,767 chars before the CLI ever started. The localized OS
+/// string ("El nombre del archivo o la extensión es demasiado largo") gives
+/// the user no path forward, so spell out what actually happened. 206 is not
+/// a spawn errno on Unix, so the match needs no platform gate.
+fn spawn_error_hint(raw_os_error: Option<i32>) -> &'static str {
+    match raw_os_error {
+        Some(206) => {
+            " — the command line passed to the provider exceeded Windows' \
+             32,767-character limit. This is a Houston bug (the agent's \
+             instructions should never ride on the command line); please \
+             report it from the menu."
+        }
+        _ => "",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -355,5 +374,12 @@ mod tests {
             SessionUpdate::Feed(FeedItem::ProviderError(ProviderError::SpawnFailed { message, .. }))
                 if message == "no stderr output captured"
         )));
+    }
+
+    #[test]
+    fn spawn_error_hint_explains_windows_cmdline_overflow() {
+        assert!(spawn_error_hint(Some(206)).contains("32,767"));
+        assert_eq!(spawn_error_hint(Some(2)), "");
+        assert_eq!(spawn_error_hint(None), "");
     }
 }

--- a/engine/houston-terminal-manager/src/codex_command.rs
+++ b/engine/houston-terminal-manager/src/codex_command.rs
@@ -4,12 +4,19 @@ use std::path::Path;
 /// Build `codex exec` args with exec-level flags before the optional
 /// `resume` subcommand. Older Codex CLIs reject global flags placed after
 /// `resume <id>`.
+///
+/// The system prompt is deliberately NOT an argv token. It used to ride as
+/// `-c developer_instructions=<json>`, which put the whole prompt on the
+/// command line and blew past Windows' 32,767-char `CreateProcessW` limit
+/// (os error 206) for agents with large accumulated context. It now lives
+/// in a profile file (`prompt_scratch::codex_profile`) selected here by
+/// name via `-p`.
 pub(crate) fn build_args(
     resume_session_id: Option<&str>,
     working_dir: Option<&Path>,
     model: Option<&str>,
     effort: Option<&str>,
-    system_prompt: Option<&str>,
+    profile: Option<&str>,
 ) -> Vec<OsString> {
     let mut args = vec![
         OsString::from("exec"),
@@ -18,17 +25,18 @@ pub(crate) fn build_args(
         OsString::from("--skip-git-repo-check"),
     ];
 
-    if let Some(sp) = system_prompt {
-        let json_val = serde_json::to_string(sp).unwrap_or_else(|_| format!("\"{sp}\""));
-        args.push(OsString::from("-c"));
-        args.push(OsString::from(format!("developer_instructions={json_val}")));
+    if let Some(name) = profile {
+        args.push(OsString::from("-p"));
+        args.push(OsString::from(name));
     }
 
     // Always emit `model_reasoning_effort` so a stale global
     // `~/.codex/config.toml` value can't silently change the effort the
     // engine resolved (or, if it's a variant this codex build can't parse,
     // break the session). The value itself is chosen upstream by
-    // `sessions::resolve_effort`.
+    // `sessions::resolve_effort`. It stays a `-c` override (not part of the
+    // profile file) because `-c` has the highest config precedence — it
+    // wins even over the profile layer.
     if let Some(e) = effort {
         args.push(OsString::from("-c"));
         args.push(OsString::from(format!("model_reasoning_effort=\"{e}\"")));
@@ -79,17 +87,43 @@ mod tests {
             Some(&dir),
             Some("gpt-5.5"),
             Some("medium"),
-            Some("system"),
+            Some("houston-tmp-1-1"),
         ));
 
         let resume_pos = args.iter().position(|arg| arg == "resume").unwrap();
         let json_pos = args.iter().position(|arg| arg == "--json").unwrap();
         let cd_pos = args.iter().position(|arg| arg == "--cd").unwrap();
+        let profile_pos = args.iter().position(|arg| arg == "-p").unwrap();
 
         assert!(json_pos < resume_pos);
         assert!(cd_pos < resume_pos);
+        assert!(profile_pos < resume_pos);
+        assert_eq!(args[profile_pos + 1], "houston-tmp-1-1");
         assert_eq!(args[resume_pos + 1], "019dd59b-5e8c-7f63-a8c6-18fb825874ad");
         assert_eq!(args[resume_pos + 2], "-");
+    }
+
+    /// The whole point of the profile indirection: argv stays small and
+    /// constant no matter how large the agent's system prompt grows, so the
+    /// Windows 32,767-char command-line limit can never kill the spawn again.
+    #[test]
+    fn argv_length_is_independent_of_prompt_size() {
+        let args = strings(build_args(
+            None,
+            None,
+            Some("gpt-5.5"),
+            Some("high"),
+            Some("houston-tmp-9999-9999"),
+        ));
+        let total: usize = args.iter().map(|a| a.len() + 1).sum();
+        assert!(
+            total < 1_000,
+            "codex argv must stay tiny, got {total} chars: {args:?}"
+        );
+        assert!(
+            !args.iter().any(|a| a.contains("developer_instructions")),
+            "system prompt must never ride on argv"
+        );
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/codex_rollout.rs
+++ b/engine/houston-terminal-manager/src/codex_rollout.rs
@@ -66,10 +66,7 @@ fn read_rollout_tail(path: &Path) -> Option<String> {
 /// codex without overriding `CODEX_HOME`, so codex uses whatever the engine
 /// inherited (the user's env) or its default — mirror that here.
 fn codex_sessions_dir() -> Option<PathBuf> {
-    let home = std::env::var_os("CODEX_HOME")
-        .map(PathBuf::from)
-        .or_else(|| dirs::home_dir().map(|h| h.join(".codex")))?;
-    Some(home.join("sessions"))
+    Some(crate::prompt_scratch::codex_home()?.join("sessions"))
 }
 
 /// Walk the sessions tree for the newest rollout belonging to `thread_id`. A

--- a/engine/houston-terminal-manager/src/codex_runner.rs
+++ b/engine/houston-terminal-manager/src/codex_runner.rs
@@ -3,6 +3,7 @@
 
 use crate::cli_process::{run_cli_process, CliRunOutcome};
 use crate::codex_command;
+use crate::prompt_scratch;
 use crate::session_update::SessionUpdate;
 use crate::types::SessionStatus;
 use crate::Provider;
@@ -44,12 +45,29 @@ pub(crate) async fn spawn_codex(
         }
     }
 
+    // The system prompt travels as a codex profile file, never as argv (the
+    // old `-c developer_instructions=…` token broke `CreateProcessW` on
+    // Windows once the prompt outgrew the 32,767-char command-line limit).
+    // The profile value owns the file; it is deleted when this fn returns.
+    let profile = match system_prompt.as_deref() {
+        None => None,
+        Some(sp) => match prompt_scratch::codex_profile(sp) {
+            Ok(p) => Some(p),
+            Err(e) => {
+                let _ = tx.send(SessionUpdate::Status(SessionStatus::Error(format!(
+                    "Failed to prepare codex instructions: {e}"
+                ))));
+                return;
+            }
+        },
+    };
+
     let mut cmd = build_codex_command(
         resume_session_id.as_deref(),
         working_dir.as_deref(),
         model.as_deref(),
         effort.as_deref(),
-        system_prompt.as_deref(),
+        profile.as_ref().map(|p| p.name()),
     );
 
     let outcome = run_cli_process(tx, &mut cmd, &prompt, provider).await;
@@ -61,7 +79,7 @@ pub(crate) async fn spawn_codex(
             working_dir.as_deref(),
             model.as_deref(),
             effort.as_deref(),
-            system_prompt.as_deref(),
+            profile.as_ref().map(|p| p.name()),
         );
         run_cli_process(
             tx,
@@ -82,7 +100,7 @@ fn build_codex_command(
     working_dir: Option<&std::path::Path>,
     model: Option<&str>,
     effort: Option<&str>,
-    system_prompt: Option<&str>,
+    profile: Option<&str>,
 ) -> Command {
     // Always prefer the bundled codex over whatever happens to be on the
     // user's PATH. The user's PATH might point at a stale `nvm` codex that
@@ -101,7 +119,7 @@ fn build_codex_command(
         working_dir,
         model,
         effort,
-        system_prompt,
+        profile,
     ));
     if let Some(dir) = working_dir {
         cmd.current_dir(dir);

--- a/engine/houston-terminal-manager/src/lib.rs
+++ b/engine/houston-terminal-manager/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod auth_error;
 pub mod claude_install_path;
 pub mod claude_path;
+mod claude_command;
 mod claude_runner;
 mod cli_process;
 mod codex_command;
@@ -18,6 +19,7 @@ pub mod gemini_parser;
 mod gemini_parser_state;
 mod gemini_runner;
 pub mod manager;
+mod prompt_scratch;
 pub mod parser;
 pub mod provider;
 pub mod provider_auth;

--- a/engine/houston-terminal-manager/src/prompt_scratch.rs
+++ b/engine/houston-terminal-manager/src/prompt_scratch.rs
@@ -1,0 +1,276 @@
+//! Scratch files that carry the per-session system prompt to provider CLIs
+//! without putting it on the command line.
+//!
+//! Windows `CreateProcessW` caps the whole command line at 32,767 chars.
+//! Passing the system prompt as an argv token (`-c developer_instructions=…`
+//! for codex, `--system-prompt …` for claude) kills the spawn with
+//! `ERROR_FILENAME_EXCED_RANGE` (os error 206) once an agent's accumulated
+//! context (workspace files, skills index, learnings) crosses that limit —
+//! real Windows users hit this (2026-06). The prompt now travels via files
+//! each CLI reads natively:
+//!
+//! - **codex**: a profile config layer at `$CODEX_HOME/<name>.config.toml`
+//!   holding `developer_instructions`, selected with `-p <name>`. Requires
+//!   the file-based profiles shipped in newer codex CLIs; the bundled pin in
+//!   `cli-deps.json` is kept new enough (older codex `-p` only reads
+//!   `[profiles.*]` tables out of the user's own `config.toml`).
+//! - **claude**: a plain temp file passed via `--system-prompt-file`
+//!   (supported by the pinned claude-code 2.1.158).
+//!
+//! Files are unique per spawn (pid + counter), removed on [`Drop`], and any
+//! leftovers from crashes are swept on the first spawn of each engine
+//! process. The sweep only touches Houston-named files older than 24 hours
+//! so a concurrently running second engine instance never loses live files.
+
+use serde::Serialize;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::Duration;
+
+const SWEEP_MAX_AGE: Duration = Duration::from_secs(24 * 60 * 60);
+const CODEX_PROFILE_PREFIX: &str = "houston-tmp-";
+const CODEX_PROFILE_SUFFIX: &str = ".config.toml";
+const CLAUDE_PROMPT_PREFIX: &str = "houston-claude-sp-";
+const CLAUDE_PROMPT_SUFFIX: &str = ".md";
+
+/// A file deleted when the value drops (i.e. when the CLI process is done).
+pub(crate) struct ScratchFile {
+    path: PathBuf,
+}
+
+impl ScratchFile {
+    pub(crate) fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for ScratchFile {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            // No UI thread to surface this on; the boot sweep is the backstop.
+            tracing::warn!(
+                "[prompt-scratch] could not remove {}: {e}",
+                self.path.display()
+            );
+        }
+    }
+}
+
+/// A codex profile config layer: `$CODEX_HOME/<name>.config.toml`,
+/// selected on the codex command line with `-p <name>`.
+pub(crate) struct CodexProfile {
+    name: String,
+    _file: ScratchFile,
+}
+
+impl CodexProfile {
+    pub(crate) fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+/// `$CODEX_HOME`, falling back to `~/.codex` — the same resolution codex
+/// itself uses. Shared with `codex_rollout`'s session scanning.
+pub(crate) fn codex_home() -> Option<PathBuf> {
+    std::env::var_os("CODEX_HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".codex")))
+}
+
+/// Write the system prompt as a codex profile file under `$CODEX_HOME`.
+pub(crate) fn codex_profile(system_prompt: &str) -> Result<CodexProfile, String> {
+    sweep_once();
+    let home = codex_home().ok_or("could not resolve the codex home directory")?;
+    codex_profile_in(&home, system_prompt)
+}
+
+fn codex_profile_in(home: &Path, system_prompt: &str) -> Result<CodexProfile, String> {
+    #[derive(Serialize)]
+    struct ProfileBody<'a> {
+        developer_instructions: &'a str,
+    }
+
+    std::fs::create_dir_all(home)
+        .map_err(|e| format!("could not create {}: {e}", home.display()))?;
+    let name = format!("{CODEX_PROFILE_PREFIX}{}", unique_suffix());
+    let path = home.join(format!("{name}{CODEX_PROFILE_SUFFIX}"));
+    let body = toml::to_string(&ProfileBody {
+        developer_instructions: system_prompt,
+    })
+    .map_err(|e| format!("could not encode instructions as TOML: {e}"))?;
+    std::fs::write(&path, body).map_err(|e| format!("could not write {}: {e}", path.display()))?;
+    Ok(CodexProfile {
+        name,
+        _file: ScratchFile { path },
+    })
+}
+
+/// Write the system prompt to a temp file for `claude --system-prompt-file`.
+pub(crate) fn claude_system_prompt_file(system_prompt: &str) -> Result<ScratchFile, String> {
+    sweep_once();
+    claude_system_prompt_file_in(&std::env::temp_dir(), system_prompt)
+}
+
+fn claude_system_prompt_file_in(dir: &Path, system_prompt: &str) -> Result<ScratchFile, String> {
+    let path = dir.join(format!(
+        "{CLAUDE_PROMPT_PREFIX}{}{CLAUDE_PROMPT_SUFFIX}",
+        unique_suffix()
+    ));
+    std::fs::write(&path, system_prompt)
+        .map_err(|e| format!("could not write {}: {e}", path.display()))?;
+    Ok(ScratchFile { path })
+}
+
+/// Unique per spawn within this machine: engine pid + process-local counter.
+fn unique_suffix() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    format!(
+        "{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+/// Remove crash leftovers, once per engine process.
+fn sweep_once() {
+    static ONCE: std::sync::Once = std::sync::Once::new();
+    ONCE.call_once(|| {
+        if let Some(home) = codex_home() {
+            sweep_dir(&home, CODEX_PROFILE_PREFIX, CODEX_PROFILE_SUFFIX, SWEEP_MAX_AGE);
+        }
+        sweep_dir(
+            &std::env::temp_dir(),
+            CLAUDE_PROMPT_PREFIX,
+            CLAUDE_PROMPT_SUFFIX,
+            SWEEP_MAX_AGE,
+        );
+    });
+}
+
+fn sweep_dir(dir: &Path, prefix: &str, suffix: &str, max_age: Duration) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(name) = file_name.to_str() else {
+            continue;
+        };
+        if !name.starts_with(prefix) || !name.ends_with(suffix) {
+            continue;
+        }
+        let stale = entry
+            .metadata()
+            .and_then(|m| m.modified())
+            .ok()
+            .and_then(|t| t.elapsed().ok())
+            .is_some_and(|age| age >= max_age);
+        if stale {
+            if let Err(e) = std::fs::remove_file(entry.path()) {
+                tracing::warn!(
+                    "[prompt-scratch] sweep could not remove {}: {e}",
+                    entry.path().display()
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Deserialize;
+    use tempfile::TempDir;
+
+    #[derive(Deserialize)]
+    struct ProfileRead {
+        developer_instructions: String,
+    }
+
+    const NASTY: &str =
+        "Line \"one\"\nLine two with 'quotes', a backslash \\, emoji 🚀, tab\there\nand [toml] = trip-ups";
+
+    #[test]
+    fn codex_profile_roundtrips_arbitrary_prompt_content() {
+        let home = TempDir::new().unwrap();
+        let profile = codex_profile_in(home.path(), NASTY).unwrap();
+
+        let path = home
+            .path()
+            .join(format!("{}{CODEX_PROFILE_SUFFIX}", profile.name()));
+        let parsed: ProfileRead = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(parsed.developer_instructions, NASTY);
+        assert!(profile.name().starts_with(CODEX_PROFILE_PREFIX));
+    }
+
+    #[test]
+    fn codex_profile_handles_large_prompts() {
+        let home = TempDir::new().unwrap();
+        let big = "x".repeat(100_000);
+        let profile = codex_profile_in(home.path(), &big).unwrap();
+        let path = home
+            .path()
+            .join(format!("{}{CODEX_PROFILE_SUFFIX}", profile.name()));
+        let parsed: ProfileRead = toml::from_str(&std::fs::read_to_string(&path).unwrap()).unwrap();
+        assert_eq!(parsed.developer_instructions.len(), 100_000);
+    }
+
+    #[test]
+    fn claude_file_roundtrips_and_drop_removes_it() {
+        let dir = TempDir::new().unwrap();
+        let scratch = claude_system_prompt_file_in(dir.path(), NASTY).unwrap();
+        let path = scratch.path().to_path_buf();
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), NASTY);
+
+        drop(scratch);
+        assert!(!path.exists(), "Drop must delete the scratch file");
+    }
+
+    #[test]
+    fn drop_removes_codex_profile_file() {
+        let home = TempDir::new().unwrap();
+        let profile = codex_profile_in(home.path(), "hello").unwrap();
+        let path = home
+            .path()
+            .join(format!("{}{CODEX_PROFILE_SUFFIX}", profile.name()));
+        assert!(path.exists());
+        drop(profile);
+        assert!(!path.exists());
+    }
+
+    #[test]
+    fn unique_suffix_never_repeats() {
+        let a = unique_suffix();
+        let b = unique_suffix();
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn sweep_removes_only_matching_stale_files() {
+        let dir = TempDir::new().unwrap();
+        let matching = dir.path().join("houston-tmp-1-1.config.toml");
+        let foreign = dir.path().join("my-own-profile.config.toml");
+        let wrong_suffix = dir.path().join("houston-tmp-1-2.txt");
+        for p in [&matching, &foreign, &wrong_suffix] {
+            std::fs::write(p, "x").unwrap();
+        }
+
+        // max_age zero: every matching file counts as stale.
+        sweep_dir(dir.path(), CODEX_PROFILE_PREFIX, CODEX_PROFILE_SUFFIX, Duration::ZERO);
+
+        assert!(!matching.exists(), "stale houston profile must be swept");
+        assert!(foreign.exists(), "user's own profiles must never be touched");
+        assert!(wrong_suffix.exists(), "non-profile files must never be touched");
+    }
+
+    #[test]
+    fn sweep_keeps_fresh_files() {
+        let dir = TempDir::new().unwrap();
+        let fresh = dir.path().join("houston-tmp-2-1.config.toml");
+        std::fs::write(&fresh, "x").unwrap();
+
+        sweep_dir(dir.path(), CODEX_PROFILE_PREFIX, CODEX_PROFILE_SUFFIX, SWEEP_MAX_AGE);
+
+        assert!(fresh.exists(), "files younger than max_age must survive");
+    }
+}

--- a/knowledge-base/cli-bundling.md
+++ b/knowledge-base/cli-bundling.md
@@ -108,6 +108,16 @@ The manifest is staged into the .app at
 `Resources/bin/cli-deps.json` so the runtime claude-code installer can
 read pinned URLs + checksums without a separate network round-trip.
 
+**Version floors:** codex must stay ≥ 0.137 — the engine passes each
+session's system prompt as a file-based profile
+(`$CODEX_HOME/houston-tmp-*.config.toml` + `-p`, see
+`houston-terminal-manager::prompt_scratch`); older codex `-p` only reads
+`[profiles.*]` tables inside the user's own `config.toml` and would fail
+with "config profile not found". claude-code must stay ≥ a version with
+`--system-prompt-file` (the pinned 2.1.158 has it). Both exist because
+inline prompts on argv exceed Windows' 32,767-char `CreateProcessW`
+limit (os error 206) for agents with large accumulated context.
+
 ## Build pipeline
 
 The same `scripts/fetch-cli-deps.sh` handles both macOS and Windows; the

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -378,6 +378,20 @@ skills index, integrations). Final prompt =
 `<product_prompt>\n\n---\n\n<agent_context>`. Onboarding sessions use
 `HOUSTON_APP_ONBOARDING_PROMPT` as an additional suffix.
 
+The assembled prompt reaches the provider CLIs via **scratch files,
+never argv** (`houston-terminal-manager::prompt_scratch`): codex gets a
+per-session profile at `$CODEX_HOME/houston-tmp-*.config.toml` selected
+with `-p` (requires the file-based profiles in codex ≥ 0.137 — keep the
+`cli-deps.json` pin at or above that), claude gets a temp file via
+`--system-prompt-file`. Argv tokens are capped at 32,767 chars total by
+Windows `CreateProcessW`; carrying the prompt inline (`-c
+developer_instructions=…` / `--system-prompt <text>`) broke every spawn
+with os error 206 once an agent's accumulated context outgrew the limit.
+Growth is also bounded at the source: `workspace_context` caps the
+`WORKSPACE.md`/`USER.md` prompt share (12 KB / 4 KB, newest-first, with
+an explicit omission marker) the same way `learnings_context` caps
+learnings — files on disk are never trimmed.
+
 ### Feed-item streaming needs a reducer
 
 `assistant_text_streaming` deltas should REPLACE the in-progress


### PR DESCRIPTION
## Problem

Windows `CreateProcessW` rejects command lines over **32,767 chars** with os error 206 (`ERROR_FILENAME_EXCED_RANGE`). Houston passed each session's **entire system prompt as an argv token**:

- codex: `-c developer_instructions=<full JSON-escaped prompt>` (`codex_command.rs`)
- claude: `--system-prompt <full text>` (`claude_runner.rs`)

Once an agent's accumulated context outgrew the limit, **every spawn failed** — even a fresh "hola" — and never recovered. Reported by a Windows user on 0.4.19: all agents in his workspace turned red with `Failed to spawn codex: El nombre del archivo o la extensión es demasiado largo. (os error 206)`.

Root cause of the growth: the **shared, agent-written `WORKSPACE.md`** at the workspace root (the cross-agent memory feature, injected into *every* agent's prompt, uncapped) reached ~19 KB; with the ~8 KB product prompt + headers + learnings the argv hit ~32.7 K. Being per-workspace explains why all agents (including brand-new blank ones) failed at once while a new workspace worked.

## Fix

1. **New `prompt_scratch` module** — system prompts travel via files the CLIs read natively, never argv:
   - **codex**: per-session profile `$CODEX_HOME/houston-tmp-<pid>-<n>.config.toml` holding `developer_instructions`, selected with `-p <name>`. `model_reasoning_effort` stays a `-c` override (highest config precedence, same stale-global-config guard as before).
   - **claude**: temp file + `--system-prompt-file` (supported by the pinned 2.1.158 — verified).
   - Unique per spawn, deleted on `Drop`, crash leftovers swept on first spawn (only Houston-named files older than 24 h, so concurrent engine instances are safe). Write failures surface as session errors — no silent fallback.
2. **Bundled codex 0.130.0 → 0.137.0** (`cli-deps.json` + verified sha256s). 0.130's `-p` only reads `[profiles.*]` from the user's own `config.toml`; file-based profiles ship in newer codex. Live-probed on 0.137: profile `developer_instructions` reach the model (ack round-trip) and the `exec --json` event schema is unchanged.
3. **os error 206 mapped to an actionable message** in `cli_process.rs` instead of the raw localized OS string.
4. **`WORKSPACE.md`/`USER.md` prompt injection capped** (12 KB / 4 KB, newest entries kept, explicit "(beginning omitted…)" marker — mirrors `learnings_context`). Files on disk are never trimmed; gemini (stdin-composed) benefits too since the same assembled prompt shrinks.
5. **Refactor**: extracted `claude_command.rs` from `claude_runner.rs` (mirrors `codex_command.rs`), restoring the 200-line rule.

## Verification

- `cargo test --workspace` — all green (new tests: argv-size invariants for both CLIs, TOML round-trip incl. emoji/quotes/newlines, Drop cleanup, sweep selectivity, workspace-cap behavior incl. disk-untouched)
- `cargo check --target x86_64-pc-windows-gnu -p houston-engine-server` — green
- Live probes: codex 0.137 `-p` profile + `--json` (ack round-trip), claude `--system-prompt-file` + `stream-json` (ack round-trip), codex 0.130 negative probe (proves the pin floor)
- All four 0.137 artifact URLs HTTP 200, checksums match `cli-deps.json`

## Files

- `engine/houston-terminal-manager/src/prompt_scratch.rs` (new), `codex_command.rs`, `codex_runner.rs`, `claude_command.rs` (new), `claude_runner.rs`, `cli_process.rs`, `codex_rollout.rs`, `lib.rs`, `Cargo.toml`
- `engine/houston-engine-core/src/workspace_context.rs`
- `cli-deps.json`, `Cargo.lock`
- `knowledge-base/engine-protocol.md`, `knowledge-base/cli-bundling.md`

## User-side note

Affected users can recover **today** (pre-release) by trimming Settings → Workspace context, or renaming `~/.houston/workspaces/<WS>/WORKSPACE.md`; after this ships neither is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)