### PR TITLE
fix(sessions): make Stop reliably kill the provider process tree

### DIFF
--- a/engine/houston-agents-conversations/src/lib.rs
+++ b/engine/houston-agents-conversations/src/lib.rs
@@ -8,11 +8,15 @@
 //!   ID.
 //! - `session_id_tracker` — per-conversation provider resume ID registry with
 //!   disk persistence (`.houston/sessions/{provider}/{key}.sid`).
-//! - `session_pids` — map of `session_key → pid` so stop requests can kill
-//!   the right subprocess.
+//! - `session_pids` — map of `session_key → pid` (with cancel tombstones)
+//!   so stop requests can kill the right subprocess, even one that spawns
+//!   after Stop was pressed.
+//! - `process_kill` — escalating, verified termination of a provider
+//!   process tree (TERM → KILL on Unix, `taskkill /T /F` on Windows).
 //! - `supervisor` — panic-isolating wrapper so one session crashing doesn't
 //!   unwind the whole app.
 
+pub mod process_kill;
 pub mod session_id_tracker;
 pub mod session_pids;
 pub mod session_runner;

--- a/engine/houston-agents-conversations/src/process_kill/mod.rs
+++ b/engine/houston-agents-conversations/src/process_kill/mod.rs
@@ -1,0 +1,108 @@
+//! Escalating, verified termination of a provider CLI process tree.
+//!
+//! `sessions::cancel` (engine-core) and the late-PID guard in
+//! `session_runner` both need the same guarantee: after Stop, the
+//! claude/codex/gemini process AND everything it spawned (shell tools,
+//! MCP servers, subagent helpers) are actually gone. Sending one SIGTERM
+//! and hoping is not enough — Node CLIs trap TERM, children can ignore
+//! it, and `kill`'s exit status only proves the signal was *sent*.
+//!
+//! Platform strategies live in the submodules: [`unix`] (TERM the
+//! process group + descendant snapshot, poll, escalate to KILL) and
+//! [`windows`] (`taskkill /T /F`, verify via `tasklist`, retry).
+
+use std::time::Duration;
+
+#[cfg(unix)]
+mod unix;
+#[cfg(unix)]
+use unix as imp;
+
+#[cfg(windows)]
+mod windows;
+#[cfg(windows)]
+use windows as imp;
+
+#[cfg(not(any(unix, windows)))]
+mod imp {
+    use super::Duration;
+
+    pub(super) async fn terminate(root: u32, _term: Duration, _kill: Duration) -> bool {
+        tracing::error!("[process_kill] unsupported platform — cannot terminate pid {root}");
+        false
+    }
+}
+
+const TERM_GRACE: Duration = Duration::from_millis(1500);
+const KILL_GRACE: Duration = Duration::from_millis(1000);
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// Terminate `pid` and its whole process tree. Returns `true` only when
+/// every tracked process is confirmed dead; failures are logged inside.
+pub async fn terminate_process_tree(pid: u32) -> bool {
+    imp::terminate(pid, TERM_GRACE, KILL_GRACE).await
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use std::process::Stdio;
+
+    async fn spawn_sh(script: &str) -> u32 {
+        let child = tokio::process::Command::new("sh")
+            .arg("-c")
+            .arg(script)
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("spawn test process");
+        let pid = child.id().expect("child pid");
+        // Detach: the reaper task waits so the pid can't linger as a
+        // zombie; tests only check liveness via signal 0.
+        tokio::spawn(async move {
+            let mut child = child;
+            let _ = child.wait().await;
+        });
+        // Give the shell a beat to exec / fork its children.
+        tokio::time::sleep(Duration::from_millis(150)).await;
+        pid
+    }
+
+    fn alive(pid: u32) -> bool {
+        extern "C" {
+            fn kill(pid: i32, sig: i32) -> i32;
+        }
+        unsafe { kill(pid as i32, 0) == 0 }
+    }
+
+    #[tokio::test]
+    async fn terminates_simple_process() {
+        let pid = spawn_sh("sleep 30").await;
+        assert!(alive(pid));
+        assert!(terminate_process_tree(pid).await);
+        assert!(!alive(pid));
+    }
+
+    #[tokio::test]
+    async fn escalates_to_sigkill_when_term_is_trapped() {
+        let pid = spawn_sh("trap '' TERM; sleep 30").await;
+        assert!(alive(pid));
+        // Short grace so the test exercises the KILL phase quickly.
+        assert!(imp::terminate(pid, Duration::from_millis(200), KILL_GRACE).await);
+        assert!(!alive(pid));
+    }
+
+    #[tokio::test]
+    async fn kills_descendants_too() {
+        let pid = spawn_sh("sleep 30 & sleep 30 & wait").await;
+        assert!(alive(pid));
+        assert!(terminate_process_tree(pid).await);
+        assert!(!alive(pid));
+    }
+
+    #[tokio::test]
+    async fn already_dead_pid_confirms_quickly() {
+        // PID far above any real process on test machines.
+        assert!(terminate_process_tree(3_999_999).await);
+    }
+}

--- a/engine/houston-agents-conversations/src/process_kill/unix.rs
+++ b/engine/houston-agents-conversations/src/process_kill/unix.rs
@@ -1,0 +1,123 @@
+//! Unix termination: SIGTERM the process group + a descendant snapshot,
+//! poll for death, escalate to SIGKILL, poll again.
+//!
+//! Provider CLIs are spawned with `setpgid(0, 0)` (see
+//! `houston-terminal-manager::cli_process`), so group id == root pid and
+//! one group signal reaches every in-group child. The `pgrep -P` BFS
+//! additionally catches processes that left the group (setsid daemons,
+//! double-forked MCP servers).
+
+use super::{Duration, POLL_INTERVAL};
+
+const SIGTERM: i32 = 15;
+const SIGKILL: i32 = 9;
+
+extern "C" {
+    fn kill(pid: i32, sig: i32) -> i32;
+}
+
+fn send_signal(pid: i32, sig: i32) -> bool {
+    unsafe { kill(pid, sig) == 0 }
+}
+
+fn alive(pid: u32) -> bool {
+    // Signal 0 = liveness probe. Provider processes run as the same
+    // user, so EPERM (alive but not ours) does not apply here.
+    unsafe { kill(pid as i32, 0) == 0 }
+}
+
+/// BFS over `pgrep -P` to find every descendant of `root`. Best effort:
+/// a missing `pgrep` just yields fewer pids (the group signal still
+/// covers in-group children). Bounded to keep a pathological tree from
+/// looping forever.
+async fn collect_descendants(root: u32) -> Vec<u32> {
+    const MAX_PIDS: usize = 256;
+    let mut all: Vec<u32> = Vec::new();
+    let mut frontier = vec![root];
+    while let Some(parent) = frontier.pop() {
+        let output = tokio::process::Command::new("pgrep")
+            .arg("-P")
+            .arg(parent.to_string())
+            .output()
+            .await;
+        let output = match output {
+            Ok(o) => o,
+            Err(e) => {
+                tracing::warn!(
+                    "[process_kill] pgrep unavailable, descendant sweep limited to the process group: {e}"
+                );
+                return all;
+            }
+        };
+        for line in String::from_utf8_lossy(&output.stdout).lines() {
+            if let Ok(child) = line.trim().parse::<u32>() {
+                if child != root && !all.contains(&child) {
+                    all.push(child);
+                    frontier.push(child);
+                }
+            }
+        }
+        if all.len() >= MAX_PIDS {
+            tracing::warn!(
+                "[process_kill] descendant sweep hit the {MAX_PIDS}-pid bound for root {root}"
+            );
+            break;
+        }
+    }
+    all
+}
+
+async fn wait_dead(root: u32, descendants: &[u32], grace: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + grace;
+    loop {
+        let any_alive = alive(root) || descendants.iter().any(|&d| alive(d));
+        if !any_alive {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+pub(super) async fn terminate(root: u32, term_grace: Duration, kill_grace: Duration) -> bool {
+    let descendants = collect_descendants(root).await;
+    let group = -(root as i32);
+
+    // Phase 1: graceful TERM — group first, root as fallback, snapshot
+    // pids for anything that escaped the group.
+    if !send_signal(group, SIGTERM) {
+        send_signal(root as i32, SIGTERM);
+    }
+    for &d in &descendants {
+        send_signal(d as i32, SIGTERM);
+    }
+    if wait_dead(root, &descendants, term_grace).await {
+        return true;
+    }
+
+    // Phase 2: forced KILL. Re-snapshot to catch children spawned
+    // between the first sweep and now.
+    tracing::warn!(
+        "[process_kill] SIGTERM did not stop pid {root} (or a descendant) — escalating to SIGKILL"
+    );
+    send_signal(group, SIGKILL);
+    send_signal(root as i32, SIGKILL);
+    for &d in &descendants {
+        if alive(d) {
+            send_signal(d as i32, SIGKILL);
+        }
+    }
+    let late = collect_descendants(root).await;
+    for &d in &late {
+        send_signal(d as i32, SIGKILL);
+    }
+    if wait_dead(root, &descendants, kill_grace).await {
+        return true;
+    }
+    tracing::error!(
+        "[process_kill] process tree for pid {root} survived SIGKILL — manual cleanup may be required"
+    );
+    false
+}

--- a/engine/houston-agents-conversations/src/process_kill/windows.rs
+++ b/engine/houston-agents-conversations/src/process_kill/windows.rs
@@ -1,0 +1,62 @@
+//! Windows termination: `taskkill /T /F` (already forced, walks the
+//! tree), verified via `tasklist`, retried once — a child spawned while
+//! taskkill walks the tree can escape the first traversal.
+
+use super::{Duration, POLL_INTERVAL};
+
+/// `tasklist /FI "PID eq <pid>"` prints a table row containing the pid
+/// when the process exists, or an INFO banner when it doesn't.
+async fn alive(pid: u32) -> bool {
+    let output = tokio::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/NH"])
+        .output()
+        .await;
+    match output {
+        Ok(o) => String::from_utf8_lossy(&o.stdout).contains(&format!(" {pid} ")),
+        Err(e) => {
+            tracing::warn!("[process_kill] tasklist probe failed for pid {pid}: {e}");
+            false
+        }
+    }
+}
+
+async fn wait_gone(pid: u32, grace: Duration) -> bool {
+    let deadline = tokio::time::Instant::now() + grace;
+    loop {
+        if !alive(pid).await {
+            return true;
+        }
+        if tokio::time::Instant::now() >= deadline {
+            return false;
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+}
+
+pub(super) async fn terminate(root: u32, term_grace: Duration, kill_grace: Duration) -> bool {
+    for (attempt, grace) in [(1u8, term_grace), (2, kill_grace)] {
+        let status = tokio::process::Command::new("taskkill")
+            .args(["/PID", &root.to_string(), "/T", "/F"])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .await;
+        match status {
+            // 128 = "process not found" — already dead, verify below.
+            Ok(s) if s.success() || s.code() == Some(128) => {}
+            Ok(s) => tracing::warn!(
+                "[process_kill] taskkill attempt {attempt} for pid {root} exited with {s}"
+            ),
+            Err(e) => tracing::warn!(
+                "[process_kill] taskkill attempt {attempt} for pid {root} failed to run: {e}"
+            ),
+        }
+        if wait_gone(root, grace).await {
+            return true;
+        }
+    }
+    tracing::error!(
+        "[process_kill] process tree for pid {root} survived taskkill /T /F — manual cleanup may be required"
+    );
+    false
+}

--- a/engine/houston-agents-conversations/src/session_pids.rs
+++ b/engine/houston-agents-conversations/src/session_pids.rs
@@ -1,23 +1,125 @@
-//! Shared map of session keys to running process PIDs.
+//! Shared map of session keys to running provider process PIDs.
 //!
-//! Allows `stop_session` to look up and kill a running Claude CLI process by
-//! its session key.
+//! Beyond plain pid lookup, this map closes the cancel-before-spawn race
+//! (issue #469): pressing Stop while a turn is still in prep (compaction,
+//! resume-recovery, provider retry respawn) used to leave nothing to
+//! kill — the CLI spawned moments later and ran to completion behind a
+//! "Stopped by user" message. Cancelling now leaves a `Cancelled`
+//! tombstone; a PID that arrives afterwards is reported back to the
+//! caller (`PidInsert::AlreadyCancelled`) so it can be killed on the
+//! spot. The tombstone is cleared when the turn finishes (`remove`).
 
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-/// Thread-safe map of session_key → process PID for running sessions.
-/// Register as Tauri managed state in your app setup.
+/// Outcome of registering a freshly spawned PID.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PidInsert {
+    /// PID recorded; the session runs normally.
+    Tracked,
+    /// The session was cancelled before this PID arrived — the caller
+    /// must terminate the process tree immediately.
+    AlreadyCancelled,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum Slot {
+    Running(u32),
+    /// Stop was pressed while a turn was active but no PID existed yet
+    /// (or a retry respawn is possible). Late PIDs must not survive.
+    Cancelled,
+}
+
+/// Thread-safe map of session_key → process state for running sessions.
 #[derive(Default, Clone)]
-pub struct SessionPidMap(Arc<Mutex<HashMap<String, u32>>>);
+pub struct SessionPidMap(Arc<Mutex<HashMap<String, Slot>>>);
 
 impl SessionPidMap {
-    pub async fn insert(&self, session_key: String, pid: u32) {
-        self.0.lock().await.insert(session_key, pid);
+    /// Register the PID of a freshly spawned provider process. Returns
+    /// [`PidInsert::AlreadyCancelled`] when the session was cancelled
+    /// first — the caller must kill `pid`'s tree right away.
+    #[must_use]
+    pub async fn insert(&self, session_key: String, pid: u32) -> PidInsert {
+        let mut map = self.0.lock().await;
+        match map.get(&session_key) {
+            Some(Slot::Cancelled) => PidInsert::AlreadyCancelled,
+            _ => {
+                map.insert(session_key, Slot::Running(pid));
+                PidInsert::Tracked
+            }
+        }
     }
 
+    /// Drop tracking for a finished turn. Clears a cancel tombstone too,
+    /// so the next turn for this key starts clean.
     pub async fn remove(&self, session_key: &str) -> Option<u32> {
-        self.0.lock().await.remove(session_key)
+        match self.0.lock().await.remove(session_key) {
+            Some(Slot::Running(pid)) => Some(pid),
+            _ => None,
+        }
+    }
+
+    /// Begin cancelling a session: takes the running PID (if any) for
+    /// the caller to kill. With `tombstone` set (a turn is still active
+    /// or queued), leaves a `Cancelled` marker so late-arriving PIDs get
+    /// flagged by [`Self::insert`]; without it, the entry is simply
+    /// cleared.
+    pub async fn begin_cancel(&self, session_key: &str, tombstone: bool) -> Option<u32> {
+        let mut map = self.0.lock().await;
+        let pid = match map.get(session_key) {
+            Some(Slot::Running(pid)) => Some(*pid),
+            _ => None,
+        };
+        if tombstone {
+            map.insert(session_key.to_string(), Slot::Cancelled);
+        } else {
+            map.remove(session_key);
+        }
+        pid
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn insert_then_begin_cancel_returns_pid() {
+        let map = SessionPidMap::default();
+        assert_eq!(map.insert("k".into(), 42).await, PidInsert::Tracked);
+        assert_eq!(map.begin_cancel("k", true).await, Some(42));
+    }
+
+    #[tokio::test]
+    async fn pid_arriving_after_cancel_is_flagged() {
+        let map = SessionPidMap::default();
+        assert_eq!(map.begin_cancel("k", true).await, None);
+        assert_eq!(map.insert("k".into(), 42).await, PidInsert::AlreadyCancelled);
+        // Tombstone persists across retry respawns within the turn.
+        assert_eq!(map.insert("k".into(), 43).await, PidInsert::AlreadyCancelled);
+    }
+
+    #[tokio::test]
+    async fn remove_clears_tombstone_for_next_turn() {
+        let map = SessionPidMap::default();
+        assert_eq!(map.begin_cancel("k", true).await, None);
+        assert_eq!(map.remove("k").await, None);
+        assert_eq!(map.insert("k".into(), 7).await, PidInsert::Tracked);
+    }
+
+    #[tokio::test]
+    async fn cancel_without_active_turn_leaves_no_tombstone() {
+        let map = SessionPidMap::default();
+        assert_eq!(map.begin_cancel("k", false).await, None);
+        assert_eq!(map.insert("k".into(), 7).await, PidInsert::Tracked);
+    }
+
+    #[tokio::test]
+    async fn cancel_without_tombstone_still_takes_pid() {
+        let map = SessionPidMap::default();
+        assert_eq!(map.insert("k".into(), 42).await, PidInsert::Tracked);
+        assert_eq!(map.begin_cancel("k", false).await, Some(42));
+        assert_eq!(map.insert("k".into(), 7).await, PidInsert::Tracked);
     }
 }

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -4,7 +4,7 @@
 //! that apps previously implemented manually.
 
 use crate::session_id_tracker::SessionIdHandle;
-use crate::session_pids::SessionPidMap;
+use crate::session_pids::{PidInsert, SessionPidMap};
 use houston_db::Database;
 use houston_terminal_manager::auth_error::{is_auth_error, is_auth_retry_marker};
 use houston_terminal_manager::provider_auth::ProviderAuthState;
@@ -141,7 +141,20 @@ pub fn spawn_and_monitor(
             match update {
                 SessionUpdate::ProcessPid(pid) => {
                     if let Some(ref pm) = pid_map {
-                        pm.insert(key.clone(), pid).await;
+                        if pm.insert(key.clone(), pid).await == PidInsert::AlreadyCancelled {
+                            // Stop was pressed before this PID existed
+                            // (slow prep or a provider retry respawn).
+                            // Kill it now or it runs to completion behind
+                            // the "Stopped by user" message (issue #469).
+                            tracing::info!(
+                                "[session_runner] pid {pid} arrived for cancelled session {key} — terminating"
+                            );
+                            if !crate::process_kill::terminate_process_tree(pid).await {
+                                tracing::error!(
+                                    "[session_runner] could not confirm late-spawn kill for cancelled session {key} (pid {pid})"
+                                );
+                            }
+                        }
                     }
                     continue;
                 }

--- a/engine/houston-engine-core/src/sessions/cancel.rs
+++ b/engine/houston-engine-core/src/sessions/cancel.rs
@@ -1,0 +1,89 @@
+//! User-initiated session cancellation.
+//!
+//! Kills the provider CLI process tree (verified, with SIGKILL
+//! escalation — see `houston_agents_conversations::process_kill`),
+//! dequeues pending turns, and leaves a tombstone in the pid map so a
+//! process that spawns AFTER Stop was pressed still gets killed the
+//! moment its PID is reported (issue #469).
+
+use super::control::SessionIdentity;
+use super::SessionRuntime;
+use houston_agents_conversations::process_kill::terminate_process_tree;
+use houston_terminal_manager::FeedItem;
+use houston_ui_events::{DynEventSink, HoustonEvent};
+use std::path::Path;
+
+/// Cancel a running or queued session. Terminates the provider process
+/// tree (TERM → KILL on Unix, `taskkill /T /F` on Windows) and verifies
+/// it actually died. Emits a `Stopped by user` feed item + `completed`
+/// session status so the UI can reconcile.
+///
+/// Returns `true` if a process or queued turn was found, `false` otherwise.
+pub async fn cancel(
+    rt: &SessionRuntime,
+    events: &DynEventSink,
+    agent_path: &str,
+    session_key: &str,
+) -> bool {
+    let identity = SessionIdentity::new(agent_path.to_string(), session_key.to_string());
+    // `had_active` also decides whether `begin_cancel` leaves a tombstone:
+    // only an active/queued turn can still produce a late PID, and only an
+    // active turn's end clears the tombstone again.
+    let had_active = rt.control.cancel(&identity).await;
+    let pid = rt.pid_map.begin_cancel(session_key, had_active).await;
+
+    if let Some(pid) = pid {
+        tracing::info!("[sessions] cancel session_key={session_key} pid={pid}");
+        use tokio::time::{timeout, Duration};
+        // terminate_process_tree is internally bounded (~2.5s worst case);
+        // the outer timeout is a belt-and-braces guard against a wedged
+        // pgrep/tasklist subprocess.
+        match timeout(Duration::from_secs(5), terminate_process_tree(pid)).await {
+            Ok(true) => {}
+            Ok(false) => {
+                tracing::error!(
+                    "[sessions] could not confirm provider process tree exit for session_key={session_key} pid={pid}"
+                );
+            }
+            Err(_) => {
+                tracing::error!(
+                    "[sessions] terminate timed out for session_key={session_key} pid={pid}"
+                );
+            }
+        }
+    } else if !had_active {
+        match crate::agents::activity::clear_stale_running_by_session_key(
+            Path::new(agent_path),
+            session_key,
+        ) {
+            Ok(Some(_)) => {
+                tracing::info!(
+                    "[sessions] cleared stale running activity on cancel session_key={session_key}"
+                );
+                events.emit(HoustonEvent::ActivityChanged {
+                    agent_path: agent_path.to_string(),
+                });
+            }
+            Ok(None) => return false,
+            Err(e) => {
+                tracing::warn!(
+                    "[sessions] failed to clear stale running activity on cancel: {e} (session_key={session_key})"
+                );
+                return false;
+            }
+        }
+    }
+
+    events.emit(HoustonEvent::FeedItem {
+        agent_path: agent_path.to_string(),
+        session_key: session_key.to_string(),
+        item: FeedItem::SystemMessage("Stopped by user".into()),
+    });
+    events.emit(HoustonEvent::SessionStatus {
+        agent_path: agent_path.to_string(),
+        session_key: session_key.to_string(),
+        status: "completed".into(),
+        error: None,
+    });
+    true
+}

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -8,8 +8,9 @@
 //! - [`start`] — spawn + monitor a session via
 //!   `houston-agents-conversations`, streaming updates to the engine's event
 //!   sink (which WS clients subscribe to via `session:{key}` topics).
-//! - [`cancel`] — SIGTERM the running CLI for a given session_key and emit
-//!   a "Stopped by user" feed item + `completed` status.
+//! - [`cancel`] — kill the running CLI process tree for a given session_key
+//!   (verified, with SIGKILL escalation) and emit a "Stopped by user" feed
+//!   item + `completed` status. See [`cancel`] (module `cancel.rs`).
 //! - [`resolve_provider`] — agent-config → Anthropic default fallback.
 //!
 //! Callers (REST handlers, Tauri adapter) supply the already-resolved
@@ -17,6 +18,7 @@
 //! lives in the adapter today; it will move into `engine-core` in a later
 //! phase once `agent_store` is ported.
 
+mod cancel;
 mod compaction;
 mod control;
 pub mod file_changes;
@@ -44,6 +46,8 @@ use houston_ui_events::{DynEventSink, HoustonEvent};
 use std::path::{Path, PathBuf};
 use workdir_locks::{WorkdirLocks, WorkdirSessionGuard};
 
+pub use cancel::cancel;
+pub use houston_agents_conversations::session_pids::PidInsert;
 pub use provider::{resolve_effort, resolve_provider, ResolvedProvider};
 
 /// Engine-owned session state. Cheap to clone.
@@ -207,33 +211,7 @@ async fn run_start(
 
     let _turn_guard = rt.acquire_turn(&identity).await;
     if rt.control.is_stale(&identity, generation).await {
-        tracing::info!("[sessions] skipping cancelled queued turn session_key={session_key}");
-        // The desktop UI optimistically wrote `running` to the activity
-        // row when the user pressed send (see the comment at the
-        // `set_status_by_session_key("running")` call below). If we exit
-        // here without resetting, the row stays stuck on `running`
-        // forever — the kanban "running" column shows a permanently
-        // spinning mission for work that never actually started, because
-        // `cancel()` only kills the process / dequeues the turn and
-        // doesn't touch the activity file. Flip to `needs_you` so the
-        // user can retry, edit, or move to done.
-        let agent_path = agent_dir.to_string_lossy().to_string();
-        match crate::agents::activity::set_status_by_session_key(
-            &agent_dir,
-            &session_key,
-            "needs_you",
-        ) {
-            Ok(Some(_)) => {
-                events.emit(HoustonEvent::ActivityChanged { agent_path });
-            }
-            Ok(None) => { /* ad-hoc session, no board row to flip */ }
-            Err(e) => {
-                tracing::warn!(
-                    "[sessions] failed to flip cancelled queued activity: {e} (session_key={session_key})"
-                );
-            }
-        }
-        rt.control.finish(&identity).await;
+        bail_cancelled_turn(rt, &events, &agent_dir, &session_key, &identity).await;
         return Ok(());
     }
 
@@ -392,6 +370,18 @@ async fn run_start(
         provider,
     );
 
+    // Re-check staleness right before spawning: the prep work above
+    // (compaction summarize, resume-recovery prompt) can take seconds,
+    // and a Stop pressed in that window already bumped the generation.
+    // Without this check the CLI would spawn AFTER the user cancelled
+    // and run to completion behind a "Stopped by user" message
+    // (issue #469). The pid-map tombstone covers the remaining
+    // instants between this check and PID registration.
+    if rt.control.is_stale(&identity, generation).await {
+        bail_cancelled_turn(rt, &events, &agent_dir, &session_key, &identity).await;
+        return Ok(());
+    }
+
     // Flip the matching board activity to "running" synchronously, before
     // the CLI subprocess spawns. Desktop UI pre-wrote this from the send
     // handler; moving it here means mobile (and any other client that
@@ -548,6 +538,39 @@ async fn run_start(
     Ok(())
 }
 
+/// A queued or prepped turn discovered it was cancelled before its CLI
+/// spawned. The desktop UI optimistically wrote `running` to the activity
+/// row when the user pressed send; without resetting, the row stays stuck
+/// on `running` forever — the kanban "running" column shows a permanently
+/// spinning mission for work that never actually started, because
+/// `cancel()` only kills the process / dequeues the turn and doesn't touch
+/// the activity file. Flip to `needs_you` so the user can retry, edit, or
+/// move to done. Also clears the pid-map cancel tombstone (no process will
+/// ever register for this turn) and releases the control slot.
+async fn bail_cancelled_turn(
+    rt: &SessionRuntime,
+    events: &DynEventSink,
+    agent_dir: &Path,
+    session_key: &str,
+    identity: &SessionIdentity,
+) {
+    tracing::info!("[sessions] skipping cancelled turn session_key={session_key}");
+    let agent_path = agent_dir.to_string_lossy().to_string();
+    match crate::agents::activity::set_status_by_session_key(agent_dir, session_key, "needs_you") {
+        Ok(Some(_)) => {
+            events.emit(HoustonEvent::ActivityChanged { agent_path });
+        }
+        Ok(None) => { /* ad-hoc session, no board row to flip */ }
+        Err(e) => {
+            tracing::warn!(
+                "[sessions] failed to flip cancelled queued activity: {e} (session_key={session_key})"
+            );
+        }
+    }
+    let _stale_pid = rt.pid_map.remove(session_key).await;
+    rt.control.finish(identity).await;
+}
+
 fn activity_hint_for_session_key(
     agent_dir: &Path,
     session_key: &str,
@@ -576,114 +599,6 @@ fn activity_hint_for_session_key(
         (false, false, false) => Some(format!("{title}\n\n{description}")),
     };
     Ok(hint)
-}
-
-/// Cancel a running or queued session. On Unix sends `SIGTERM` to the
-/// provider process group; on Windows issues `taskkill /PID <pid> /T /F`
-/// (terminates the process tree). Emits a `Stopped by user` feed item +
-/// `completed` session status so the UI can reconcile.
-///
-/// Returns `true` if a process or queued turn was found, `false` otherwise.
-pub async fn cancel(
-    rt: &SessionRuntime,
-    events: &DynEventSink,
-    agent_path: &str,
-    session_key: &str,
-) -> bool {
-    let identity = SessionIdentity::new(agent_path.to_string(), session_key.to_string());
-    let had_queued = rt.control.cancel(&identity).await;
-    let pid = rt.pid_map.remove(session_key).await;
-
-    if let Some(pid) = pid {
-        tracing::info!("[sessions] cancel session_key={session_key} pid={pid}");
-        use tokio::time::{timeout, Duration};
-        match timeout(Duration::from_millis(750), terminate_process_tree(pid)).await {
-            Ok(Ok(status)) if status.success() => {}
-            Ok(Ok(status)) => {
-                tracing::warn!(
-                    "[sessions] terminate command exited with {status} for session_key={session_key} pid={pid}"
-                );
-            }
-            Ok(Err(e)) => {
-                tracing::warn!(
-                    "[sessions] failed to run terminate command for session_key={session_key} pid={pid}: {e}"
-                );
-            }
-            Err(_) => {
-                tracing::warn!(
-                    "[sessions] terminate command timed out for session_key={session_key} pid={pid}"
-                );
-            }
-        }
-    } else if !had_queued {
-        match crate::agents::activity::clear_stale_running_by_session_key(
-            Path::new(agent_path),
-            session_key,
-        ) {
-            Ok(Some(_)) => {
-                tracing::info!(
-                    "[sessions] cleared stale running activity on cancel session_key={session_key}"
-                );
-                events.emit(HoustonEvent::ActivityChanged {
-                    agent_path: agent_path.to_string(),
-                });
-            }
-            Ok(None) => return false,
-            Err(e) => {
-                tracing::warn!(
-                    "[sessions] failed to clear stale running activity on cancel: {e} (session_key={session_key})"
-                );
-                return false;
-            }
-        }
-    }
-
-    events.emit(HoustonEvent::FeedItem {
-        agent_path: agent_path.to_string(),
-        session_key: session_key.to_string(),
-        item: FeedItem::SystemMessage("Stopped by user".into()),
-    });
-    events.emit(HoustonEvent::SessionStatus {
-        agent_path: agent_path.to_string(),
-        session_key: session_key.to_string(),
-        status: "completed".into(),
-        error: None,
-    });
-    true
-}
-
-#[cfg(unix)]
-async fn terminate_process_tree(pid: u32) -> std::io::Result<std::process::ExitStatus> {
-    let group_status = tokio::process::Command::new("kill")
-        .arg("-TERM")
-        .arg(format!("-{pid}"))
-        .stderr(std::process::Stdio::null())
-        .kill_on_drop(true)
-        .status()
-        .await?;
-    if group_status.success() {
-        return Ok(group_status);
-    }
-    tokio::process::Command::new("kill")
-        .arg("-TERM")
-        .arg(pid.to_string())
-        .stderr(std::process::Stdio::null())
-        .kill_on_drop(true)
-        .status()
-        .await
-}
-
-#[cfg(windows)]
-async fn terminate_process_tree(pid: u32) -> std::io::Result<std::process::ExitStatus> {
-    tokio::process::Command::new("taskkill")
-        .arg("/PID")
-        .arg(pid.to_string())
-        .arg("/T")
-        .arg("/F")
-        .stderr(std::process::Stdio::null())
-        .kill_on_drop(true)
-        .status()
-        .await
 }
 
 /// Start an onboarding session: seeds the agent and runs the first turn with
@@ -843,6 +758,30 @@ mod tests {
                 .await
                 .is_ok()
         );
+    }
+
+    #[tokio::test]
+    async fn cancel_before_pid_leaves_tombstone_for_late_spawn() {
+        // Issue #469: Stop pressed while the turn is still in prep — no
+        // PID exists yet. The cancel must poison the pid map so the CLI
+        // that spawns moments later is flagged and killed on arrival.
+        use houston_agents_conversations::session_pids::PidInsert;
+        let rt = SessionRuntime::default();
+        let dir = TempDir::new().unwrap();
+        let identity = SessionIdentity::new(
+            dir.path().to_string_lossy().to_string(),
+            "chat-race".into(),
+        );
+        let _generation = rt.control.register(&identity).await;
+        let events: DynEventSink = Arc::new(NoopEventSink);
+
+        assert!(cancel(&rt, &events, &dir.path().to_string_lossy(), "chat-race").await);
+
+        assert_eq!(
+            rt.pid_map.insert("chat-race".into(), 12_345).await,
+            PidInsert::AlreadyCancelled
+        );
+        rt.control.finish(&identity).await;
     }
 
     #[tokio::test]

--- a/engine/houston-engine-server/tests/sessions.rs
+++ b/engine/houston-engine-server/tests/sessions.rs
@@ -317,12 +317,13 @@ async fn rest_cancel_existing_session_emits_events() {
     // side-effect is tolerated (no real process) — we just verify the
     // emitted events land on the `session:{key}` WS topic.
     let (addr, token, state) = spawn_engine().await;
-    state
+    let tracked = state
         .engine
         .sessions
         .pid_map
         .insert("k1".into(), 999_999)
         .await;
+    assert_eq!(tracked, houston_engine_core::sessions::PidInsert::Tracked);
 
     let mut ws = ws_connect(addr, &token).await;
     ws.send(Message::Text(sub_frame(&["session:k1"]))).await.unwrap();

--- a/engine/houston-terminal-manager/src/cli_process.rs
+++ b/engine/houston-terminal-manager/src/cli_process.rs
@@ -109,7 +109,7 @@ pub(crate) async fn run_cli_process(
     match child.wait().await {
         Ok(status) => {
             tracing::info!("[houston:session] process exited with {status}");
-            let is_sigterm = status.code() == Some(143);
+            let is_stop_signal = exited_by_stop_signal(&status);
             // On Windows, `sessions::cancel` calls `taskkill /F /T /PID` to
             // tear down the codex / claude process tree when the user
             // clicks Stop. TerminateProcess sets the killed process's exit
@@ -145,22 +145,22 @@ pub(crate) async fn run_cli_process(
             } else if malformed_provider_json {
                 tracing::warn!("[houston:session] claude failed with malformed provider JSON");
                 CliRunOutcome::ProviderRequestMalformedJson
-            } else if status.success() || is_sigterm || likely_user_stop_windows {
+            } else if status.success() || is_stop_signal || likely_user_stop_windows {
                 if likely_user_stop_windows {
                     tracing::info!(
                         "[houston:session] {cli_name} exited with code 1 + empty stderr — treating as user-initiated stop"
                     );
                 }
-                // SIGTERM (143) and the Windows-stop heuristic both
-                // indicate user-initiated cancellation. Emit a typed
-                // `Cancelled` feed item BEFORE Completed so the chat
-                // history carries the structured marker (the dispatcher
-                // intentionally renders nothing for `Cancelled`, but
-                // analytics / debug surfaces / future "show stopped
-                // sessions" filters all key off the typed variant).
-                // A clean exit (`status.success()`) is NOT cancellation,
-                // so we only emit when one of the stop signals fired.
-                if is_sigterm || likely_user_stop_windows {
+                // Stop signals (SIGTERM/SIGKILL) and the Windows-stop
+                // heuristic both indicate user-initiated cancellation.
+                // Emit a typed `Cancelled` feed item BEFORE Completed so
+                // the chat history carries the structured marker (the
+                // dispatcher intentionally renders nothing for
+                // `Cancelled`, but analytics / debug surfaces / future
+                // "show stopped sessions" filters all key off the typed
+                // variant). A clean exit (`status.success()`) is NOT
+                // cancellation, so we only emit when a stop signal fired.
+                if is_stop_signal || likely_user_stop_windows {
                     let _ = tx.send(SessionUpdate::Feed(FeedItem::ProviderError(
                         ProviderError::Cancelled {
                             provider: provider.id().to_string(),
@@ -265,6 +265,29 @@ fn handle_failed_exit(
     CliRunOutcome::Failed
 }
 
+/// Did the process die from a user-initiated stop? `sessions::cancel`
+/// SIGTERMs the provider process group and escalates to SIGKILL when the
+/// CLI (or a child) traps/ignores TERM. On Unix a signal death reports
+/// `code() == None` with `signal()` set — checking `code() == Some(143)`
+/// alone misses every direct signal kill and misfiles it as a runtime
+/// error next to the "Stopped by user" message. The 143/137 codes cover
+/// CLIs that catch the signal and re-exit with the shell convention.
+/// (An OOM-killer SIGKILL is indistinguishable and also lands here —
+/// acceptable: rare, and the session status still resolves.)
+#[cfg(unix)]
+fn exited_by_stop_signal(status: &std::process::ExitStatus) -> bool {
+    use std::os::unix::process::ExitStatusExt;
+    const SIGKILL: i32 = 9;
+    const SIGTERM: i32 = 15;
+    matches!(status.signal(), Some(SIGTERM) | Some(SIGKILL))
+        || matches!(status.code(), Some(143) | Some(137))
+}
+
+#[cfg(not(unix))]
+fn exited_by_stop_signal(status: &std::process::ExitStatus) -> bool {
+    matches!(status.code(), Some(143) | Some(137))
+}
+
 #[cfg(unix)]
 fn configure_process_group(cmd: &mut Command) {
     unsafe {
@@ -299,6 +322,21 @@ mod tests {
             out.push(u);
         }
         out
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stop_signal_classification_covers_signal_and_code_forms() {
+        use std::os::unix::process::ExitStatusExt;
+        use std::process::ExitStatus;
+        // Raw wait status: low byte = signal, exit code = code << 8.
+        assert!(exited_by_stop_signal(&ExitStatus::from_raw(15))); // SIGTERM
+        assert!(exited_by_stop_signal(&ExitStatus::from_raw(9))); // SIGKILL
+        assert!(exited_by_stop_signal(&ExitStatus::from_raw(143 << 8))); // shell convention
+        assert!(exited_by_stop_signal(&ExitStatus::from_raw(137 << 8)));
+        assert!(!exited_by_stop_signal(&ExitStatus::from_raw(0))); // clean exit
+        assert!(!exited_by_stop_signal(&ExitStatus::from_raw(1 << 8))); // real failure
+        assert!(!exited_by_stop_signal(&ExitStatus::from_raw(2))); // SIGINT — not ours
     }
 
     #[test]

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -110,7 +110,7 @@ module.
 |---|---|---|
 | POST | `/v1/agents/:agent_path/sessions` | Start turn |
 | POST | `/v1/agents/:agent_path/sessions/onboarding` | Start onboarding turn |
-| POST | `/v1/agents/:agent_path/sessions/:key:cancel` | SIGTERM CLI |
+| POST | `/v1/agents/:agent_path/sessions/:key:cancel` | Kill CLI process tree (verified, SIGKILL escalation); a tombstone catches a CLI that spawns after Stop |
 | GET | `/v1/agents/:agent_path/sessions/:key/history` | Load chat history |
 | POST | `/v1/sessions/summarize` | Activity title/description |
 

--- a/knowledge-base/platform-matrix.md
+++ b/knowledge-base/platform-matrix.md
@@ -69,7 +69,7 @@ both.
 
 | Area | File | Unix | Windows |
 |------|------|------|---------|
-| Session cancel | `engine-core/src/sessions/mod.rs::cancel` | `kill -TERM <pid>` | `taskkill /PID <pid> /T /F` |
+| Session cancel | `engine-core/src/sessions/cancel.rs` → `houston-agents-conversations/src/process_kill/` | SIGTERM process group + `pgrep -P` descendant snapshot → poll → SIGKILL escalation, death verified | `taskkill /PID <pid> /T /F`, verified via `tasklist`, retried once |
 | Worktree shell (`run_shell`) | `engine-core/src/worktree.rs::run_shell` | `sh -c <command>` | `cmd /C <command>` (no `sh` on Windows) |
 | `engine.json` perms | `engine-server/src/main.rs::write_manifest` | `chmod 0o600` | inherits NTFS ACL from parent (sufficient; user dir is per-user) |
 | Composio installer | `houston-composio/src/install.rs::install` | `bash -c "curl \| bash"` | returns a clear error — auto-install not wired (see **gaps** below) |
@@ -94,12 +94,15 @@ both.
    `%APPDATA%\nvm\v<ver>\` with a different shape than nvm.sh — not
    yet probed; Node tools installed via nvm-windows won't be picked up
    unless they're on PATH already.
-4. **Process-group kill**: on Unix we `kill -TERM` the single PID we
-   tracked; Windows uses `taskkill /T` which walks the child tree.
-   Semantics differ — Windows is forceful (`/F`) because Console
-   applications don't respond to clean-shutdown signals unless they're
-   in our console group. If this becomes a problem (e.g. sessions that
-   need graceful Claude shutdown to flush token caches), switch to
+4. **Process-group kill**: on Unix we SIGTERM the process group (+ a
+   `pgrep -P` descendant snapshot), verify death, and escalate to
+   SIGKILL; Windows uses `taskkill /T /F` which walks the child tree,
+   verified via `tasklist` and retried once
+   (`houston-agents-conversations/src/process_kill/`). Windows is
+   forceful (`/F`) from the start because Console applications don't
+   respond to clean-shutdown signals unless they're in our console
+   group. If this becomes a problem (e.g. sessions that need graceful
+   Claude shutdown to flush token caches), switch to
    `GenerateConsoleCtrlEvent` via a detached child console.
 5. **MSVC target build**: not verified on the macOS host. CI on Windows
    runners (E₂'s scope) is the authoritative check. Cross-compile from

--- a/ui/chat/src/ai-elements/prompt-input.tsx
+++ b/ui/chat/src/ai-elements/prompt-input.tsx
@@ -1272,10 +1272,17 @@ export const PromptInputSubmit = ({
 
   let Icon = <ArrowUpIcon className="size-4" />;
 
-  if (status === "submitted") {
-    Icon = <Spinner />;
-  } else if (status === "streaming") {
-    Icon = <SquareIcon className="size-3.5 fill-current" />;
+  if (isGenerating) {
+    // Stop square + activity ring: the spinner keeps signalling that the
+    // agent is working while the square makes the stop affordance
+    // explicit the whole time (issue #469 — a bare spinner didn't read
+    // as stoppable, and a bare square didn't read as "working").
+    Icon = (
+      <span className="relative flex items-center justify-center">
+        <Spinner className="size-[26px]" />
+        <SquareIcon className="absolute size-2.5 fill-current" />
+      </span>
+    );
   } else if (status === "error") {
     Icon = <XIcon className="size-4" />;
   }


### PR DESCRIPTION
Fixes #469 — "Stopped by user" appeared but the agent kept working; some users had to quit the app to stop it. Affected every provider.

## Root causes + fixes

1. **Cancel-before-PID race (main bug).** `run_start` does seconds of async prep (compaction summarize, resume-recovery prompt) after its single staleness check. Stop in that window found no PID to kill; the CLI spawned afterwards and ran to completion. Provider retry respawns (`claude` resume-corrupted retry, codex rollout-missing retry) had the same hole.
   → Second staleness check immediately before spawn, plus a `Cancelled` tombstone in `SessionPidMap`: any PID registered after Stop is flagged (`PidInsert::AlreadyCancelled`) and its tree is killed on arrival by `session_runner`.

2. **SIGTERM was fire-and-forget.** `kill -TERM` exit 0 only proves delivery; Node CLIs trap TERM and children (MCP servers, shell tools, subagent helpers) can ignore it. No verification, no escalation.
   → New `houston-agents-conversations/src/process_kill/`: SIGTERM the process group + a `pgrep -P` descendant snapshot (catches setsid escapees), poll for actual death, escalate to SIGKILL, verify again. Windows: `taskkill /T /F` verified via `tasklist`, retried once. Routine-run cancel inherits the fix through `sessions::cancel`.

3. **Signal exits misclassified.** `cli_process` checked `code() == Some(143)`, but signal-killed children report `code() == None` + `signal() == Some(15)` — successful kills could surface a spurious "runtime error" card next to "Stopped by user".
   → Classified via `ExitStatusExt::signal()` (TERM/KILL) plus 143/137 shell conventions.

## UI

`PromptInputSubmit` now shows a square stop icon inside the spinning activity ring during both `submitted` and `streaming` — the user sees the agent is working AND has an explicit stop affordance the whole time (was: bare spinner during `submitted`, bare square during `streaming`).

## Files

- `engine/houston-agents-conversations/src/process_kill/{mod,unix,windows}.rs` (new)
- `engine/houston-agents-conversations/src/{session_pids,session_runner,lib}.rs`
- `engine/houston-engine-core/src/sessions/{mod,cancel}.rs` (cancel extracted to its own module)
- `engine/houston-terminal-manager/src/cli_process.rs`
- `engine/houston-engine-server/tests/sessions.rs`
- `ui/chat/src/ai-elements/prompt-input.tsx`
- `knowledge-base/{engine-protocol,platform-matrix}.md`

## Tests

- `cargo test --workspace` green (incl. new: tombstone unit tests, process-tree kill integration tests — simple, TERM-trapping, multi-child — signal-classification table, cancel-race regression test).
- `pnpm typecheck` (ui + app + mobile) green.
- `cargo check --target x86_64-pc-windows-gnu -p houston-engine-server` green.

> Note: `provider::login_relay::tests::device_auth_relay_emits_url_then_code` is flaky on a clean checkout of this branch's base (~50% failure, verified with stashed changes) — unrelated to this PR; deserves its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)