### PR TITLE
chore(cargo): sync Cargo.lock to 0.4.20 workspace versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "futures-util",
  "hex",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "serde",
  "serde_json",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2593,7 +2593,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2605,7 +2605,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2645,7 +2645,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2684,7 +2684,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2700,7 +2700,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "dirs 5.0.1",
  "houston-cli-bundle",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2752,7 +2752,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.19"
+version = "0.4.20"
 dependencies = [
  "houston-terminal-manager",
  "serde",


### PR DESCRIPTION
Closes #458

`Cargo.lock` still pinned the workspace crates at `0.4.19` after the v0.4.20 release bumped their `Cargo.toml` versions. Running `cargo build -p houston-engine-server` regenerated the lockfile; this PR commits only the resulting version updates.

## Changes
- `Cargo.lock` — workspace crate versions `0.4.19` → `0.4.20` (19 entries)

No source changes. Build verified green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)