### PR TITLE
fix(chat): scope provider reconnect card to the chat's own provider (HOU-410)

### DIFF
--- a/app/src/components/shell/provider-reconnect-card.tsx
+++ b/app/src/components/shell/provider-reconnect-card.tsx
@@ -7,6 +7,7 @@ import { getProvider } from "../../lib/providers";
 import {
   providerIsAuthenticated,
   providerReconnectSignalState,
+  reconnectProviderForChat,
 } from "./provider-reconnect-state";
 
 interface ProviderReconnectCardProps {
@@ -26,9 +27,19 @@ export function ProviderReconnectCard({
   const [resolvedSignal, setResolvedSignal] = useState<string | null>(null);
   const [signalNeedsAuth, setSignalNeedsAuth] = useState(false);
 
+  // `authRequired` is a single global flag (set by whichever session last hit
+  // an auth error). Only let it drive THIS card when it names this chat's
+  // provider; otherwise fall back to this chat's own feed signal. This is what
+  // keeps a Claude logout from leaking a "Connect Claude" button into an
+  // OpenAI chat (HOU-410).
+  const authMatchesChat = !!authRequired && authRequired === providerId;
   const shouldCheckSignal =
-    !authRequired && !!providerId && !!signalKey && signalKey !== resolvedSignal;
-  const activeProviderId = authRequired ?? (signalNeedsAuth ? providerId : null);
+    !authMatchesChat && !!providerId && !!signalKey && signalKey !== resolvedSignal;
+  const activeProviderId = reconnectProviderForChat({
+    authRequired,
+    chatProvider: providerId ?? null,
+    signalNeedsAuth,
+  });
   const provider = activeProviderId ? getProvider(activeProviderId) : null;
 
   useEffect(() => {
@@ -65,7 +76,10 @@ export function ProviderReconnectCard({
         const status = await tauriProvider.checkStatus(activeProviderId);
         if (cancelled) return;
         if (providerIsAuthenticated(status)) {
-          setAuthRequired(null);
+          // Only clear the global flag if it belongs to the provider we just
+          // confirmed — otherwise an OpenAI chat re-auth would wipe a pending
+          // Claude reconnect (or vice-versa).
+          if (authRequired === activeProviderId) setAuthRequired(null);
           if (signalKey) setResolvedSignal(signalKey);
           setLoginLaunched(false);
         }
@@ -79,7 +93,7 @@ export function ProviderReconnectCard({
       cancelled = true;
       clearInterval(interval);
     };
-  }, [activeProviderId, signalKey, setAuthRequired]);
+  }, [activeProviderId, authRequired, signalKey, setAuthRequired]);
 
   const handleSignIn = useCallback(async () => {
     if (!activeProviderId) return;

--- a/app/src/components/shell/provider-reconnect-state.ts
+++ b/app/src/components/shell/provider-reconnect-state.ts
@@ -34,3 +34,32 @@ export function providerIsAuthenticated(status: ProviderReconnectStatus): boolea
 export function providerAppearsConnected(status: ProviderReconnectStatus): boolean {
   return status.cli_installed && status.auth_state !== "unauthenticated";
 }
+
+/**
+ * Which provider (if any) the in-chat reconnect card should prompt to
+ * reconnect, for a chat whose session runs `chatProvider`.
+ *
+ * Invariant: a chat's reconnect card may ONLY ever ask the user to reconnect
+ * the provider THAT chat uses. The global `authRequired` flag is set by
+ * whichever session last hit an auth error — possibly a different provider in
+ * a different agent or routine. Before HOU-410 the card read `authRequired`
+ * directly, so a Claude logout (from e.g. a routine or another agent) leaked a
+ * "Connect Claude" button into unrelated OpenAI chats and never cleared while
+ * the user kept using OpenAI.
+ *
+ * So `authRequired` is honored only when it names this chat's provider;
+ * otherwise we fall back to this chat's own feed auth signal (which the card
+ * confirms with a provider-scoped status probe). Either way the result is
+ * always `chatProvider` or `null` — never a foreign provider.
+ */
+export function reconnectProviderForChat(args: {
+  authRequired: string | null;
+  chatProvider: string | null;
+  signalNeedsAuth: boolean;
+}): string | null {
+  const { authRequired, chatProvider, signalNeedsAuth } = args;
+  if (!chatProvider) return null;
+  if (authRequired === chatProvider) return chatProvider;
+  if (signalNeedsAuth) return chatProvider;
+  return null;
+}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -585,9 +585,13 @@ export function useAgentChatPanel({
   const afterMessages = useCallback(
     ({ feedItems }: { sessionKey: string; feedItems: FeedItem[] }) => {
       const signalKey = providerAuthSignalKey(feedItems);
+      // Always hand the card THIS chat's provider so it can match the global
+      // `authRequired` flag against the provider this chat actually uses — a
+      // Claude logout must never surface a reconnect button in an OpenAI chat
+      // (HOU-410). The card stays hidden unless that provider truly needs auth.
       return (
         <ProviderReconnectCard
-          providerId={signalKey ? effectiveProvider : undefined}
+          providerId={effectiveProvider}
           signalKey={signalKey ?? undefined}
         />
       );

--- a/app/tests/provider-reconnect-state.test.ts
+++ b/app/tests/provider-reconnect-state.test.ts
@@ -4,6 +4,7 @@ import {
   providerAppearsConnected,
   providerIsAuthenticated,
   providerReconnectSignalState,
+  reconnectProviderForChat,
 } from "../src/components/shell/provider-reconnect-state.ts";
 
 describe("provider reconnect signal state", () => {
@@ -85,6 +86,85 @@ describe("provider appears connected (settings card)", () => {
     strictEqual(
       providerAppearsConnected({ cli_installed: false, auth_state: "authenticated" }),
       false,
+    );
+  });
+});
+
+describe("reconnect provider for a chat (HOU-410 scoping)", () => {
+  it("does NOT show a Claude reconnect in an OpenAI chat when Claude is logged out elsewhere", () => {
+    // The exact bug: a Claude session (another agent / routine) set the global
+    // authRequired to "anthropic"; the user is in an OpenAI chat with no auth
+    // problem of its own. The card must stay hidden.
+    strictEqual(
+      reconnectProviderForChat({
+        authRequired: "anthropic",
+        chatProvider: "openai",
+        signalNeedsAuth: false,
+      }),
+      null,
+    );
+  });
+
+  it("shows the chat's own provider when the global flag names it", () => {
+    strictEqual(
+      reconnectProviderForChat({
+        authRequired: "anthropic",
+        chatProvider: "anthropic",
+        signalNeedsAuth: false,
+      }),
+      "anthropic",
+    );
+    strictEqual(
+      reconnectProviderForChat({
+        authRequired: "openai",
+        chatProvider: "openai",
+        signalNeedsAuth: false,
+      }),
+      "openai",
+    );
+  });
+
+  it("falls back to this chat's own feed signal when the global flag is unset or foreign", () => {
+    // No global flag, but this chat's feed carried an auth signal and the
+    // status probe confirmed it needs auth.
+    strictEqual(
+      reconnectProviderForChat({
+        authRequired: null,
+        chatProvider: "openai",
+        signalNeedsAuth: true,
+      }),
+      "openai",
+    );
+    // Foreign global flag must not suppress this chat's own confirmed signal.
+    strictEqual(
+      reconnectProviderForChat({
+        authRequired: "anthropic",
+        chatProvider: "openai",
+        signalNeedsAuth: true,
+      }),
+      "openai",
+    );
+  });
+
+  it("shows nothing when neither the flag matches nor the feed signals auth", () => {
+    strictEqual(
+      reconnectProviderForChat({
+        authRequired: null,
+        chatProvider: "openai",
+        signalNeedsAuth: false,
+      }),
+      null,
+    );
+  });
+
+  it("shows nothing when the chat has no resolved provider", () => {
+    strictEqual(
+      reconnectProviderForChat({
+        authRequired: "anthropic",
+        chatProvider: null,
+        signalNeedsAuth: true,
+      }),
+      null,
     );
   });
 });


### PR DESCRIPTION
## HOU-410 — User is asked to connect to Claude when using OpenAI

### Root cause
The in-chat reconnect login button (`ProviderReconnectCard`, rendered in every chat via `afterMessages`) read a single **global, sticky** `authRequired` flag that isn't tied to the chat you're looking at.

- Engine `session_runner.rs` emits `AuthRequired { provider }` on any session's auth failure — the event carries **no agent/session**, just the provider string.
- `use-session-events.ts` stores it in one global `useUIStore.authRequired`.
- The card did `activeProviderId = authRequired ?? …`, so the global flag won and **ignored which provider the open chat uses**.
- It's sticky — only clears when *that* provider re-auths. Logged out of Claude + using OpenAI → never clears.

Net: any Claude auth failure (a Claude-configured agent, a routine, an old Claude conversation, a Mission-Control send that dropped its override) pinned a **"Connect Claude"** button into **OpenAI** chats, indefinitely.

The provider-scoped `signalNeedsAuth` path was already correct; only the global short-circuit leaked.

### Fix
Enforce one invariant: **an in-chat reconnect card can only ever prompt for the provider that chat actually uses.**

- `provider-reconnect-state.ts` — new pure `reconnectProviderForChat({ authRequired, chatProvider, signalNeedsAuth })`. Honors the global flag only when it names this chat's provider; otherwise falls back to this chat's own (provider-scoped, status-probed) feed signal. Result is always `chatProvider` or `null` — never a foreign provider.
- `provider-reconnect-card.tsx` — uses it; signal probe runs only when the global flag doesn't already cover this chat; the clear-poll only nulls `authRequired` when it matches the confirmed provider (so an OpenAI re-auth can't wipe a genuine pending Claude prompt, and vice-versa).
- `use-agent-chat-panel.tsx` — `afterMessages` now always passes `effectiveProvider` so the match works even with no feed signal.

### Tests
- `provider-reconnect-state.test.ts` — +6 cases incl. the exact bug: Claude logged out elsewhere → **no** card in an OpenAI chat.
- `pnpm test` → 251/251 pass · `pnpm typecheck` → clean.

### Behavior after
- Claude logout → reconnect shows only in Claude chats.
- OpenAI chats are untouched by a Claude logout; OpenAI's own logout still shows an OpenAI reconnect.

### Follow-up (separate)
While tracing this I confirmed the engine defaults to Anthropic in every no-override path (`resolve_provider` → `Provider::default()`, plus the summarize / generate-instructions / routines-dispatcher / onboarding callers, and the frontend `effectiveProvider ?? "anthropic"`). Harmless for a properly-configured foreground chat, but an agent/activity/routine with **no provider set** will try Claude even for an OpenAI-only user. Tracked separately.

### Files
- `app/src/components/shell/provider-reconnect-state.ts`
- `app/src/components/shell/provider-reconnect-card.tsx`
- `app/src/components/use-agent-chat-panel.tsx`
- `app/tests/provider-reconnect-state.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)