### PR TITLE
fix(engine): silence git_bash dead-code warnings on non-Windows builds

### DIFF
--- a/engine/houston-engine-core/src/git_bash.rs
+++ b/engine/houston-engine-core/src/git_bash.rs
@@ -37,11 +37,16 @@
 /// 7z file-format magic. Always at the start of a valid 7z archive —
 /// appears in the SFX after the PE stub. Public to the module so the
 /// cross-platform unit tests below can reference it.
+///
+/// Compiled only where referenced — the Windows extractor and any test
+/// build — so non-Windows release builds don't flag it as dead code.
+#[cfg(any(target_os = "windows", test))]
 const SEVENZ_MAGIC: &[u8] = &[0x37, 0x7A, 0xBC, 0xAF, 0x27, 0x1C];
 
 /// Maximum bytes to scan for the 7z magic. PortableGit's SFX stub is
 /// consistently ~245 KB; 2 MB is generous headroom for future SFX
 /// builds without slurping the whole 57 MB file.
+#[cfg(any(target_os = "windows", test))]
 const MAGIC_SCAN_LIMIT: usize = 2 * 1024 * 1024;
 
 /// Scan a file for the 7z file-format magic and return its byte
@@ -51,7 +56,9 @@ const MAGIC_SCAN_LIMIT: usize = 2 * 1024 * 1024;
 ///
 /// Kept outside the Windows-only `imp` module so it can be unit-
 /// tested on any host. The full extraction path (which needs
-/// `sevenz-rust2`) stays Windows-only.
+/// `sevenz-rust2`) stays Windows-only. Compiled only for Windows and
+/// test builds so it isn't dead code in non-Windows release builds.
+#[cfg(any(target_os = "windows", test))]
 fn find_magic_offset(path: &std::path::Path) -> std::io::Result<Option<u64>> {
     use std::io::Read;
     let mut f = std::fs::File::open(path)?;
@@ -72,7 +79,8 @@ fn find_magic_offset(path: &std::path::Path) -> std::io::Result<Option<u64>> {
 /// by construction.
 ///
 /// Kept outside `imp` for the same cross-platform test reason as
-/// `find_magic_offset`.
+/// `find_magic_offset`. Compiled only for Windows and test builds.
+#[cfg(any(target_os = "windows", test))]
 fn sanitize_entry_path(name: &str) -> Option<std::path::PathBuf> {
     use std::path::{Component, Path, PathBuf};
     let p = Path::new(name);


### PR DESCRIPTION
## Problem (HOU-417)

Compiling `houston-engine-server` on macOS/Linux emits 4 `dead_code` warnings, all from `engine/houston-engine-core/src/git_bash.rs`:

```
warning: constant `SEVENZ_MAGIC` is never used
warning: constant `MAGIC_SCAN_LIMIT` is never used
warning: function `find_magic_offset` is never used
warning: function `sanitize_entry_path` is never used
warning: `houston-engine-core` (lib) generated 4 warnings
```

## Root cause

These four helpers power the in-process PortableGit 7z-SFX extraction, which only runs on **Windows** (`#[cfg(target_os = "windows")] mod imp`). They are deliberately kept *outside* `imp` so the cross-platform unit tests can exercise them on any host. But they lived unconditionally in the module, so on a **non-Windows, non-test** build — exactly what `houston-engine-server` triggers on macOS/Linux — nothing references them and rustc flags them as dead code.

Deleting them would break the Windows extractor and the tests, so that's not an option.

## Fix

Gate each item behind `#[cfg(any(target_os = "windows", test))]` so it compiles only where it's actually used. This is strictly better than `#[allow(dead_code)]`: it expresses the real condition and keeps the unused bytes out of non-Windows release binaries. It also matches the file's existing `#[cfg(target_os = "windows")]` / `#[cfg(test)]` style.

## Verification

- **macOS `cargo build -p houston-engine-server`** → CLEAN, 0 warnings (was 4)
- **`cargo test -p houston-engine-core git_bash`** → 8/8 pass (cfg(test) keeps the items)
- **`cargo check --target x86_64-pc-windows-gnu -p houston-engine-core`** → compiles clean (cfg windows keeps the items; `imp`'s `use super::{...}` still resolves)

## Files

- `engine/houston-engine-core/src/git_bash.rs` — 4 `#[cfg(...)]` gates + doc notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)