### PR TITLE
chore(cli): bump pinned claude-code to 2.1.170 (HOU-419)

### DIFF
--- a/cli-deps.json
+++ b/cli-deps.json
@@ -2,7 +2,7 @@
   "$schema": "./cli-deps.schema.json",
   "$comment": "Pinned versions for every CLI Houston ships or runtime-installs. Bundled (codex, composio) ride inside the .app / .msi under resources/bin. claude-code cannot be bundled (proprietary license) so the runtime installer downloads it on first launch via houston-claude-installer using the URLs + sha256 below. Bumping a version: run `./scripts/bump-cli.sh <name> <version>`, then `./scripts/fetch-cli-deps.sh both` to refresh the staged copies + print the new checksums; pin the printed sha256 back into this file. For Windows, composio is built from source (see `build` block) because upstream does not yet ship a Windows artifact.",
   "claude-code": {
-    "version": "2.1.158",
+    "version": "2.1.170",
     "bundled": false,
     "binary_name": "claude",
     "license": "PROPRIETARY",
@@ -16,10 +16,10 @@
       "manifest": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/manifest.json"
     },
     "checksums": {
-      "darwin-arm64": "536a0517fa64d48ddcbc8eb511a3d08027d47e06d148872332a8041d72c22768",
-      "darwin-x64": "b7b33293702fb8e0a119b795d5af5178bd346fb46d4d7f161336d521f62d1451",
-      "windows-x64": "10fa305545b20baf6e074a086762bd252b89dfe7035848a5d41385503b1a6c74",
-      "windows-arm64": "9e0e303015eb3c9aba782b366b35194073ab8130ac6c091c2c46870798a20bdc"
+      "darwin-arm64": "e903646d8b7a31882a80ecd27569a27d8ac57b3708745f349709632c84117fdf",
+      "darwin-x64": "914f23a70bbed5d9ae567e3e04b86206ed9971b371bc9baca3f79c8885bfddb4",
+      "windows-x64": "193061508fe619abf534b2c9d48151f26971d1d5b8460ad75c0af4be3d3525fb",
+      "windows-arm64": "9abd330bcc191aecc877a8ee9da2b448852cfe3bda15e5e4608385ea1d9d1709"
     }
   },
   "codex": {

--- a/engine/houston-terminal-manager/src/prompt_scratch.rs
+++ b/engine/houston-terminal-manager/src/prompt_scratch.rs
@@ -15,7 +15,7 @@
 //!   `cli-deps.json` is kept new enough (older codex `-p` only reads
 //!   `[profiles.*]` tables out of the user's own `config.toml`).
 //! - **claude**: a plain temp file passed via `--system-prompt-file`
-//!   (supported by the pinned claude-code 2.1.158).
+//!   (supported by the pinned claude-code 2.1.170).
 //!
 //! Files are unique per spawn (pid + counter), removed on [`Drop`], and any
 //! leftovers from crashes are swept on the first spawn of each engine

--- a/knowledge-base/cli-bundling.md
+++ b/knowledge-base/cli-bundling.md
@@ -114,7 +114,7 @@ session's system prompt as a file-based profile
 `houston-terminal-manager::prompt_scratch`); older codex `-p` only reads
 `[profiles.*]` tables inside the user's own `config.toml` and would fail
 with "config profile not found". claude-code must stay ≥ a version with
-`--system-prompt-file` (the pinned 2.1.158 has it). Both exist because
+`--system-prompt-file` (the pinned 2.1.170 has it). Both exist because
 inline prompts on argv exceed Windows' 32,767-char `CreateProcessW`
 limit (os error 206) for agents with large accumulated context.
 


### PR DESCRIPTION
## What
Bump the pinned, runtime-installed claude-code CLI from 2.1.158 → 2.1.170.

## Why
claude-code ships under a proprietary license, so it isn't bundled —
`houston-claude-installer` downloads it on first launch and verifies the
bytes against the SHA-256 pinned in `cli-deps.json`. A version bump must
carry fresh per-platform checksums or every install fails with
`ChecksumMismatch`.

## Changes
- `cli-deps.json` — `claude-code.version` → `2.1.170` and all four
  checksums (darwin-arm64, darwin-x64, windows-x64, windows-arm64)
  refreshed from Anthropic's published `2.1.170/manifest.json`.
- `prompt_scratch.rs`, `cli-bundling.md` — update the two comments that
  name the current pin. Left `anthropic.rs`'s `>= 2.1.158` effort-level
  floor untouched (it documents a minimum, not the pin).

## Verification
- The 2.1.158 manifest reproduces the existing pinned checksums
  byte-for-byte, confirming the manifest is the canonical source.
- Downloaded the real darwin-arm64 2.1.170 binary; its SHA-256 matches
  the pinned value (`e903646d…`).
- `cargo check -p houston-terminal-manager` — clean.

Linear: HOU-419

🤖 Generated with [Claude Code](https://claude.com/claude-code)
