### PR TITLE
release: v0.4.21

### DIFF
--- a/.github/release-notes/0.4.21.es.md
+++ b/.github/release-notes/0.4.21.es.md
@@ -1,0 +1,20 @@
+## Houston 0.4.21
+
+Una versión centrada en la confiabilidad. Un botón Detener más confiable, las habilidades que instalas aparecen y desaparecen algunas molestias con los proveedores. Se instala sobre 0.4.20, sin cambios que rompan nada.
+
+### Cambiado
+
+- **La última versión de Claude Code por dentro.** Houston ahora incluye la versión más reciente de Claude Code que impulsa a tus agentes de Claude, así que funcionan con las correcciones y mejoras más nuevas de Anthropic.
+
+### Corregido
+
+- **Botón Detener más confiable.** El botón Detener ya funcionaba, pero en algunos casos un agente podía seguir trabajando en segundo plano, sobre todo cuando había iniciado subagentes u otras tareas de apoyo. Ahora Detener detiene de forma confiable al agente y todo lo que haya iniciado, incluso a mitad de una idea o justo después de que envías un mensaje. Mientras un agente trabaja, el botón de enviar también muestra un ícono claro de detener, así siempre sabes cómo pararlo.
+- **Los agentes con mucho contexto vuelven a iniciar en Windows.** Un agente muy usado que había acumulado mucha memoria y notas podía fallar al iniciar en Windows. Eso quedó corregido, así que incluso tus agentes más usados se abren con normalidad.
+- **Las habilidades instaladas aparecen.** Una habilidad que instalas ahora aparece para tu agente de inmediato y se mantiene sincronizada si el agente la actualiza más tarde. Esto se notaba sobre todo en Windows, donde las habilidades instaladas podían quedar ocultas.
+- **El aviso para conectar solo aparece donde corresponde.** Un botón de "Conectar Claude" solía aparecer en chats que no usan Claude, como un chat de OpenAI, y se quedaba ahí. Ahora un aviso de reconexión solo aparece para el proveedor que ese chat realmente usa.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza una app en ejecución de forma limpia. Si tienes dudas, elimina `/Applications/Houston.app` y arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde la 0.4.7 o posterior te lleva adelante sola. El MSI aún no está firmado a nivel del sistema operativo (la integración con SignPath sigue pendiente), por lo que Windows SmartScreen puede mostrar una advertencia en una instalación nueva.
+- **Windows ARM64:** no hay actualización automática desde una instalación x64 emulada. Descarga el MSI ARM64 manualmente, desinstala primero la versión x64 y luego instala la ARM64.

--- a/.github/release-notes/0.4.21.md
+++ b/.github/release-notes/0.4.21.md
@@ -1,0 +1,20 @@
+## Houston 0.4.21
+
+A reliability release. A more reliable Stop button, installed skills show up, and a few provider papercuts are gone. Drop-in on top of 0.4.20, no breaking changes.
+
+### Changed
+
+- **Latest Claude Code under the hood.** Houston now bundles the newest version of Claude Code that powers your Claude agents, so they run on Anthropic's most recent fixes and improvements.
+
+### Fixed
+
+- **More reliable Stop button.** The Stop button already worked, but in some cases an agent could keep going in the background, especially when it had started subagents or other helper tasks. Stop now reliably halts the agent and everything it started, even mid-thought or right after you send a message. While an agent is working, the send button also shows a clear stop icon, so you always know how to halt it.
+- **Agents with a lot of context start again on Windows.** A busy agent that had built up a large amount of memory and notes could fail to start on Windows. That is fixed, so even your most-used agents launch normally.
+- **Installed skills show up.** A skill you install now appears for your agent right away and stays in sync if the agent later updates it. This was most noticeable on Windows, where installed skills could stay hidden.
+- **The Connect prompt only shows where it belongs.** A "Connect Claude" button used to appear in chats that do not use Claude, like an OpenAI chat, and stick around. Now a reconnect prompt only ever shows for the provider that chat actually uses.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward automatically. The MSI is still not OS-code-signed (SignPath integration still pending), so Windows SmartScreen may warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install. Download the ARM64 MSI manually, uninstall the x64 build first, then install the ARM64 one.

--- a/.github/release-notes/0.4.21.pt.md
+++ b/.github/release-notes/0.4.21.pt.md
@@ -1,0 +1,20 @@
+## Houston 0.4.21
+
+Uma versão focada em confiabilidade. Um botão Parar mais confiável, as habilidades que você instala aparecem e somem alguns incômodos com os provedores. Instala por cima da 0.4.20, sem mudanças que quebrem nada.
+
+### Alterado
+
+- **A versão mais recente do Claude Code por dentro.** O Houston agora inclui a versão mais nova do Claude Code que move seus agentes do Claude, então eles rodam com as correções e melhorias mais recentes da Anthropic.
+
+### Corrigido
+
+- **Botão Parar mais confiável.** O botão Parar já funcionava, mas em alguns casos um agente podia continuar trabalhando em segundo plano, principalmente quando tinha iniciado subagentes ou outras tarefas de apoio. Agora Parar interrompe de forma confiável o agente e tudo o que ele iniciou, mesmo no meio de uma ideia ou logo depois de você enviar uma mensagem. Enquanto um agente trabalha, o botão de enviar também mostra um ícone claro de parar, então você sempre sabe como interrompê-lo.
+- **Agentes com muito contexto voltam a iniciar no Windows.** Um agente muito usado que tinha acumulado bastante memória e anotações podia falhar ao iniciar no Windows. Isso foi corrigido, então até os seus agentes mais usados abrem normalmente.
+- **As habilidades instaladas aparecem.** Uma habilidade que você instala agora aparece para o seu agente na hora e fica sincronizada se o agente atualizá-la depois. Isso era mais perceptível no Windows, onde as habilidades instaladas podiam ficar ocultas.
+- **O aviso para conectar só aparece onde deve.** Um botão de "Conectar Claude" costumava aparecer em chats que não usam o Claude, como um chat do OpenAI, e ficava por lá. Agora um aviso de reconexão só aparece para o provedor que aquele chat realmente usa.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui um app em execução de forma limpa. Na dúvida, remova `/Applications/Houston.app` e arraste a cópia nova.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou posterior te leva adiante sozinha. O MSI ainda não é assinado no nível do sistema operacional (a integração com o SignPath segue pendente), então o Windows SmartScreen pode avisar em uma instalação nova.
+- **Windows ARM64:** não há atualização automática a partir de uma instalação x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a versão x64 e depois instale a ARM64.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "futures-util",
  "hex",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "serde",
  "serde_json",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "dirs 5.0.1",
  "houston-cli-bundle",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.20"
+version = "0.4.21"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.20", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.20", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.20", path = "app/houston-tauri" }
-houston-events = { version = "0.4.20", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.20", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.20", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.20", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.20", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.20", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.20", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.20", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.20", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.20", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.20", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.20", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.20", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.20", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.20", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.21", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.21", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.21", path = "app/houston-tauri" }
+houston-events = { version = "0.4.21", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.21", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.21", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.21", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.21", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.21", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.21", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.21", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.21", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.21", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.21", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.21", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.21", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.21", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.21", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.20",
+  "version": "0.4.21",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.20"
+version = "0.4.21"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.20",
+  "version": "0.4.21",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## v0.4.21 draft release

Bumps every Houston package `0.4.20 → 0.4.21` and adds hand-written release notes in en/es/pt. Drop-in on top of 0.4.20, no breaking changes.

After this merges, tag `v0.4.21` on `main` to kick off the release workflow (builds, signs, notarizes, creates the **draft** GitHub release using these notes verbatim). The draft is then hand-off to the user to review and Publish.

### What's in 0.4.21 (a reliability release)
- **Stop reliably stops the agent.** Kills the full provider process tree, closes the cancel-before-PID race, classifies signal exits correctly, and adds an explicit stop icon while working. (#480)
- **Agents with large context start again on Windows.** System prompts are carried to provider CLIs via files instead of argv, fixing `os error 206` once accumulated context outgrew the 32,767-char Windows command-line cap. (#478)
- **Installed skills appear and stay in sync.** Live Windows junction mirror + frontmatter preservation. (#479)
- **In-chat reconnect card scoped to the chat's own provider.** No more "Connect Claude" button leaking into OpenAI chats. (#482)
- **Bundled claude-code pinned to 2.1.170.** (#488)

### Files
- Version bump across all `package.json` + `Cargo.toml` (via `scripts/version.sh 0.4.21`)
- `Cargo.lock` regenerated to 0.4.21 workspace versions (no stale-lock follow-up needed)
- `.github/release-notes/0.4.21.md` + `.es.md` + `.pt.md`

### Verification
- `cargo check --workspace` — green (all crates report v0.4.21)
- Release-notes guards: no em dashes, no literal `-->` in any notes file

🤖 Generated with [Claude Code](https://claude.com/claude-code)