### PR TITLE
feat(chat): switch AI provider mid-conversation (HOU-424)

### DIFF
--- a/app/src/components/chat-model-selector.tsx
+++ b/app/src/components/chat-model-selector.tsx
@@ -17,25 +17,23 @@ import {
 } from "./chat-model-selector-parts";
 
 interface ChatModelSelectorProps {
-  /** Current provider id (from workspace/agent config). */
+  /** Current provider id (from agent config / per-mission override). */
   provider: string;
   /** Current model id. */
   model: string;
-  /** Called when user picks a provider + model. */
-  onSelect: (provider: string, model: string) => void;
   /**
-   * When set, the provider is locked (conversation already started).
-   * The user can still switch models within this provider, but not
-   * change to a different provider.
+   * Called when the user picks a provider + model. The provider is never
+   * locked: picking a different provider mid-conversation is supported, and
+   * the consumer (`use-agent-chat-panel`) stages the handoff so the engine
+   * carries context across.
    */
-  lockedProvider?: string | null;
+  onSelect: (provider: string, model: string) => void;
 }
 
 export function ChatModelSelector({
   provider,
   model,
   onSelect,
-  lockedProvider,
 }: ChatModelSelectorProps) {
   const { t } = useTranslation("chat");
   const { statuses, isLoading } = useProviderStatuses();
@@ -43,28 +41,6 @@ export function ChatModelSelector({
   const currentProvider = getProvider(provider);
   const currentModel = getModel(provider, model);
   const displayLabel = currentModel?.label ?? currentProvider?.subtitle ?? t("modelSelector.selectModel");
-
-  // Honour `lockedProvider` only when it points at a currently-active
-  // provider that the engine reports as installed. Two cases drop the
-  // lock so the user can switch instead of being stuck:
-  //
-  //   * The locked provider is in `COMING_SOON_PROVIDERS` (or unknown),
-  //     so `getProvider` returns undefined. This happens when Gemini is
-  //     paused in the catalog but a stored activity still references
-  //     it.
-  //   * The locked provider is in `PROVIDERS` but the engine reports
-  //     `cli_installed=false` (binary missing on this platform).
-  //
-  // In both cases every send would route to a provider the user cannot
-  // currently invoke, so the dropdown must expose installed
-  // alternatives instead of pinning the broken choice.
-  const lockedProviderEntry = lockedProvider ? getProvider(lockedProvider) : undefined;
-  const lockedStatus = lockedProvider ? statuses[lockedProvider] : undefined;
-  const lockedProviderInstalled = lockedStatus?.cli_installed ?? true;
-  const effectiveLock =
-    lockedProvider && lockedProviderEntry && lockedProviderInstalled
-      ? lockedProvider
-      : null;
 
   return (
     // Stop pointer events from bubbling — prevents the board detail panel
@@ -92,14 +68,13 @@ export function ChatModelSelector({
             // Keep every provider visible while statuses are still loading so
             // the list doesn't collapse to a single "Not connected" entry
             // (issue #342); once known, hide disconnected non-active
-            // providers. A lock (conversation already started) still shows
-            // only the locked provider — see the lock-override comment above.
+            // providers. Every connected provider stays selectable — switching
+            // provider mid-conversation is supported.
             if (
               !shouldShowProviderInPicker({
                 providerId: prov.id,
                 state,
                 isActiveProvider,
-                effectiveLock,
               })
             ) {
               return null;
@@ -112,7 +87,7 @@ export function ChatModelSelector({
                 isActiveProvider={isActiveProvider}
                 activeModel={isActiveProvider ? model : null}
                 onSelect={onSelect}
-                showSeparator={idx > 0 && !effectiveLock}
+                showSeparator={idx > 0}
               />
             );
           })}

--- a/app/src/components/context-compacted-divider.tsx
+++ b/app/src/components/context-compacted-divider.tsx
@@ -1,20 +1,44 @@
 import { useTranslation } from "react-i18next";
+import type { ChatCompactionInfo } from "@houston-ai/chat";
+import { getProvider } from "../lib/providers";
+
+interface ContextCompactedDividerProps {
+  info: ChatCompactionInfo;
+}
 
 /**
- * Subtle divider shown where a conversation's context was compacted (the
- * provider auto-compacted, or Houston proactively summarized + reseeded). The
- * full chat above and below stays visible; this just marks the boundary.
- * Rendered by the app's `renderSystemMessage` for `msg.compaction` items so
- * the label is localized (the `ui/chat` library keeps an English default).
+ * Subtle divider marking a conversation boundary. Two kinds:
+ *
+ *  - `compacted` — the context was compacted (the provider auto-compacted, or
+ *    Houston proactively summarized + reseeded to free space).
+ *  - `provider_switch` — the user switched the conversation to a different
+ *    provider; the new provider continued with the full conversation carried
+ *    over (`summarized: false`) or a summary of it (`summarized: true`).
+ *
+ * The full chat above and below stays visible; this just marks the boundary.
+ * Rendered by the app's `renderSystemMessage` for `msg.compaction` items so the
+ * label is localized (the `ui/chat` library keeps an English default).
  */
-export function ContextCompactedDivider() {
+export function ContextCompactedDivider({ info }: ContextCompactedDividerProps) {
   const { t } = useTranslation("chat");
+
+  let label: string;
+  if (info.kind === "provider_switch") {
+    const provider = getProvider(info.provider ?? "")?.name ?? info.provider ?? "";
+    label = t(
+      info.summarized
+        ? "providerSwitch.dividerSummary"
+        : "providerSwitch.dividerFull",
+      { provider },
+    );
+  } else {
+    label = t("contextCompacted");
+  }
+
   return (
     <div className="flex items-center gap-3 max-w-3xl mx-auto px-4 py-3 text-muted-foreground/70">
       <div className="h-px flex-1 bg-border/60" />
-      <span className="text-xs italic whitespace-nowrap">
-        {t("contextCompacted")}
-      </span>
+      <span className="text-xs italic whitespace-nowrap">{label}</span>
       <div className="h-px flex-1 bg-border/60" />
     </div>
   );

--- a/app/src/components/provider-switch-dialog.tsx
+++ b/app/src/components/provider-switch-dialog.tsx
@@ -1,0 +1,63 @@
+import { useTranslation } from "react-i18next";
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@houston-ai/core";
+import { Sparkles } from "lucide-react";
+
+interface ProviderSwitchDialogProps {
+  open: boolean;
+  /** Display name of the provider being switched TO. */
+  providerName: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+/**
+ * Consent dialog shown when switching a conversation to a provider whose
+ * context window is too small to hold the whole conversation. Carrying it over
+ * then means summarizing the conversation so far — lossy, and it spends tokens
+ * on the summary — so we ask first. When the conversation already fits the new
+ * provider there is no dialog: the full conversation is carried over verbatim
+ * (decision in `use-agent-chat-panel`).
+ */
+export function ProviderSwitchDialog({
+  open,
+  providerName,
+  onConfirm,
+  onCancel,
+}: ProviderSwitchDialogProps) {
+  const { t } = useTranslation("chat");
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && onCancel()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <div className="flex items-start gap-3">
+            <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+              <Sparkles className="size-5" />
+            </span>
+            <div>
+              <DialogTitle>
+                {t("providerSwitch.dialogTitle", { provider: providerName })}
+              </DialogTitle>
+              <DialogDescription className="mt-1">
+                {t("providerSwitch.dialogBody", { provider: providerName })}
+              </DialogDescription>
+            </div>
+          </div>
+        </DialogHeader>
+        <DialogFooter>
+          <Button variant="ghost" onClick={onCancel}>
+            {t("providerSwitch.cancel")}
+          </Button>
+          <Button onClick={onConfirm}>{t("providerSwitch.confirm")}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/provider-switch-dialog.tsx
+++ b/app/src/components/provider-switch-dialog.tsx
@@ -9,30 +9,38 @@ import {
   DialogTitle,
 } from "@houston-ai/core";
 import { Sparkles } from "lucide-react";
+import type { ProviderHandoffMode } from "../lib/provider-switch";
 
 interface ProviderSwitchDialogProps {
   open: boolean;
   /** Display name of the provider being switched TO. */
   providerName: string;
+  /** How prior context will be carried over, which drives the copy. */
+  mode: ProviderHandoffMode;
   onConfirm: () => void;
   onCancel: () => void;
 }
 
 /**
- * Consent dialog shown when switching a conversation to a provider whose
- * context window is too small to hold the whole conversation. Carrying it over
- * then means summarizing the conversation so far — lossy, and it spends tokens
- * on the summary — so we ask first. When the conversation already fits the new
- * provider there is no dialog: the full conversation is carried over verbatim
- * (decision in `use-agent-chat-panel`).
+ * Consent dialog shown before switching a live conversation to a different
+ * provider. Both handoff modes ask first, because both spend tokens:
+ *
+ *  - `replay`    — the whole conversation is reloaded into the new provider
+ *    verbatim, so the cost scales with the current conversation size.
+ *  - `summarize` — the conversation is too big for the new provider's window, so
+ *    it's summarized to fit (still spends tokens, and may lose some detail).
+ *
+ * The user must acknowledge the token/usage cost before the switch is staged.
  */
 export function ProviderSwitchDialog({
   open,
   providerName,
+  mode,
   onConfirm,
   onCancel,
 }: ProviderSwitchDialogProps) {
   const { t } = useTranslation("chat");
+  const isSummary = mode === "summarize";
   return (
     <Dialog open={open} onOpenChange={(next) => !next && onCancel()}>
       <DialogContent className="sm:max-w-md">
@@ -43,10 +51,15 @@ export function ProviderSwitchDialog({
             </span>
             <div>
               <DialogTitle>
-                {t("providerSwitch.dialogTitle", { provider: providerName })}
+                {t("providerSwitch.title", { provider: providerName })}
               </DialogTitle>
               <DialogDescription className="mt-1">
-                {t("providerSwitch.dialogBody", { provider: providerName })}
+                {t(
+                  isSummary
+                    ? "providerSwitch.summaryBody"
+                    : "providerSwitch.replayBody",
+                  { provider: providerName },
+                )}
               </DialogDescription>
             </div>
           </div>
@@ -55,7 +68,13 @@ export function ProviderSwitchDialog({
           <Button variant="ghost" onClick={onCancel}>
             {t("providerSwitch.cancel")}
           </Button>
-          <Button onClick={onConfirm}>{t("providerSwitch.confirm")}</Button>
+          <Button onClick={onConfirm}>
+            {t(
+              isSummary
+                ? "providerSwitch.summaryConfirm"
+                : "providerSwitch.replayConfirm",
+            )}
+          </Button>
         </DialogFooter>
       </DialogContent>
     </Dialog>

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -74,6 +74,7 @@ import {
 import {
   decideHandoffMode,
   estimateConversationTokens,
+  type ProviderHandoffMode,
 } from "../lib/provider-switch";
 import { useProviderSwitchStore } from "../stores/provider-switch";
 import { ProviderSwitchDialog } from "./provider-switch-dialog";
@@ -183,11 +184,12 @@ export function useAgentChatPanel({
   const [agentProvider, setAgentProvider] = useState<string | null>(null);
   const [agentModel, setAgentModel] = useState<string | null>(null);
   const [agentEffort, setAgentEffort] = useState<string | null>(null);
-  // A summarize-and-switch awaiting the user's consent (lossy + spends tokens).
+  // A provider switch awaiting the user's consent (both modes spend tokens).
   const [switchDialog, setSwitchDialog] = useState<{
     toProvider: string;
     toModel: string;
     fromProvider: string;
+    mode: ProviderHandoffMode;
   } | null>(null);
   useEffect(() => {
     if (!path) {
@@ -333,6 +335,11 @@ export function useAgentChatPanel({
       const fromProvider =
         useProviderSwitchStore.getState().peekPending(path, selectedSessionKey)
           ?.fromProvider ?? effectiveProvider;
+      // Both handoff modes spend tokens — `replay` reloads the whole
+      // conversation into the new provider; `summarize` (when it won't fit) is
+      // also lossy — so ALWAYS ask first. The size only decides which mode the
+      // dialog explains and which handoff we stage on confirm. The
+      // provider/model change is applied only in `confirmProviderSwitch`.
       const mode = decideHandoffMode({
         currentContextTokens: contextUsage?.context_tokens ?? null,
         estimatedTokens: estimateConversationTokens(sessionFeedItems),
@@ -340,25 +347,7 @@ export function useAgentChatPanel({
         // DEFAULT window, not a snapped-up estimate.
         targetWindowTokens: getContextWindowConfig(prov, mod)?.default ?? null,
       });
-      if (mode === "summarize") {
-        // Lossy + spends a summarizer call: get explicit consent first. The
-        // provider/model change is applied only when the user confirms.
-        setSwitchDialog({ toProvider: prov, toModel: mod, fromProvider });
-        return;
-      }
-      // Fits the new window: carry the full conversation over verbatim, no
-      // dialog. Stage the handoff for the next send (consumed in
-      // `tauriChat.send`), then persist the new provider/model.
-      useProviderSwitchStore.getState().setPending(path, selectedSessionKey, {
-        mode: "replay",
-        fromProvider,
-      });
-      await applyProviderModel(prov, mod);
-      addToast({
-        title: t("chat:providerSwitch.replayToast", {
-          provider: getProvider(prov)?.name ?? prov,
-        }),
-      });
+      setSwitchDialog({ toProvider: prov, toModel: mod, fromProvider, mode });
     },
     [
       conversationStarted,
@@ -368,19 +357,18 @@ export function useAgentChatPanel({
       contextUsage,
       sessionFeedItems,
       applyProviderModel,
-      addToast,
-      t,
     ],
   );
 
-  // The user confirmed the summarize-and-switch dialog: stage the summarize
-  // handoff for the next send, then persist the new provider/model.
+  // The user confirmed the switch dialog: stage the handoff (replay or
+  // summarize, as decided when the dialog opened) for the next send, then
+  // persist the new provider/model.
   const confirmProviderSwitch = useCallback(async () => {
     const pending = switchDialog;
     setSwitchDialog(null);
     if (!pending || !path || !selectedSessionKey) return;
     useProviderSwitchStore.getState().setPending(path, selectedSessionKey, {
-      mode: "summarize",
+      mode: pending.mode,
       fromProvider: pending.fromProvider,
     });
     await applyProviderModel(pending.toProvider, pending.toModel);
@@ -857,6 +845,7 @@ export function useAgentChatPanel({
             ? getProvider(switchDialog.toProvider)?.name ?? switchDialog.toProvider
             : ""
         }
+        mode={switchDialog?.mode ?? "replay"}
         onConfirm={confirmProviderSwitch}
         onCancel={() => setSwitchDialog(null)}
       />

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -65,11 +65,18 @@ import {
   getContextWindowConfig,
   getDefaultModel,
   getModel,
+  getProvider,
   validModelOrNull,
   validEffortOrDefault,
   normalizeLegacyModel,
   type EffortLevel,
 } from "../lib/providers";
+import {
+  decideHandoffMode,
+  estimateConversationTokens,
+} from "../lib/provider-switch";
+import { useProviderSwitchStore } from "../stores/provider-switch";
+import { ProviderSwitchDialog } from "./provider-switch-dialog";
 import {
   sessionContextUsage,
   effectiveContextWindow,
@@ -176,6 +183,12 @@ export function useAgentChatPanel({
   const [agentProvider, setAgentProvider] = useState<string | null>(null);
   const [agentModel, setAgentModel] = useState<string | null>(null);
   const [agentEffort, setAgentEffort] = useState<string | null>(null);
+  // A summarize-and-switch awaiting the user's consent (lossy + spends tokens).
+  const [switchDialog, setSwitchDialog] = useState<{
+    toProvider: string;
+    toModel: string;
+    fromProvider: string;
+  } | null>(null);
   useEffect(() => {
     if (!path) {
       setAgentProvider(null);
@@ -231,10 +244,13 @@ export function useAgentChatPanel({
   const { contextUsage, contextWindow } = useMemo(() => {
     const { latest, peakContextTokens } = sessionContextUsage(sessionFeedItems);
     // `peakContextTokens` is session-wide while `cfg` is the currently-selected
-    // model's. Safe today because all same-provider models share a snap ceiling
-    // (every Anthropic model maxes at 1M; provider is locked after turn one so
-    // openai/anthropic never mix in one session). Revisit if a provider ever
-    // adds a model whose ceiling is below a sibling's realistic peak.
+    // model's. Providers CAN now differ across one conversation (a mid-session
+    // switch reseeds onto a new provider), so a peak observed under the old
+    // provider may snap the new model's window up. That only ever OVER-states
+    // the window (it can never read above 100% — `effectiveContextWindow`
+    // floors at the peak), and the figure is already labeled an estimate, so
+    // it's acceptable for the post-switch turns until the new provider reports
+    // its own usage and the indicator re-settles.
     const cfg = getContextWindowConfig(effectiveProvider, effectiveModel);
     return {
       contextUsage: latest,
@@ -244,9 +260,24 @@ export function useAgentChatPanel({
   }, [sessionFeedItems, effectiveProvider, effectiveModel]);
   const modelLabel = getModel(effectiveProvider, effectiveModel)?.label;
 
-  const handleModelSelect = useCallback(
+  // Whether the current conversation has produced provider output already, so a
+  // provider session exists to hand off FROM. A switch only matters once it has.
+  const conversationStarted = useMemo(
+    () =>
+      (sessionFeedItems ?? []).some(
+        (i) =>
+          i.feed_type === "final_result" ||
+          i.feed_type === "assistant_text" ||
+          i.feed_type === "assistant_text_streaming",
+      ),
+    [sessionFeedItems],
+  );
+
+  // Persist a provider/model choice: agent config (the per-agent default), the
+  // per-mission activity override, and the last-used preference, with an
+  // optimistic picker flip. Shared by the plain pick and the switch-confirm path.
+  const applyProviderModel = useCallback(
     async (prov: string, mod: string) => {
-      // Optimistic UI: the picker flips instantly while the writes fan out.
       setAgentProvider(prov);
       setAgentModel(mod);
       try {
@@ -275,6 +306,85 @@ export function useAgentChatPanel({
     },
     [path, selectedActivityId, addToast, t],
   );
+
+  // Picking a provider/model from the dropdown. Switching to a DIFFERENT
+  // provider mid-conversation can't resume the old CLI session (provider
+  // sessions aren't portable), so the engine reseeds a fresh session with prior
+  // context. We size the conversation against the new model's window: if it
+  // fits, carry the full transcript verbatim (`replay`); if not, summarizing is
+  // lossy and spends tokens, so we ask first via the dialog. A model change
+  // within the same provider, or any pick before the first turn, just persists.
+  const handleModelSelect = useCallback(
+    async (prov: string, mod: string) => {
+      const isProviderSwitch =
+        conversationStarted &&
+        !!selectedSessionKey &&
+        !!path &&
+        prov !== effectiveProvider;
+      if (!isProviderSwitch) {
+        await applyProviderModel(prov, mod);
+        return;
+      }
+      // The provider the LIVE engine session actually runs on. On the first
+      // pick that's `effectiveProvider`; on a re-pick before any send,
+      // `effectiveProvider` has already optimistically flipped, so reuse the
+      // `fromProvider` the first staged handoff captured (the engine session
+      // hasn't moved until a send lands).
+      const fromProvider =
+        useProviderSwitchStore.getState().peekPending(path, selectedSessionKey)
+          ?.fromProvider ?? effectiveProvider;
+      const mode = decideHandoffMode({
+        currentContextTokens: contextUsage?.context_tokens ?? null,
+        estimatedTokens: estimateConversationTokens(sessionFeedItems),
+        // The new provider hasn't been observed yet, so use its catalogued
+        // DEFAULT window, not a snapped-up estimate.
+        targetWindowTokens: getContextWindowConfig(prov, mod)?.default ?? null,
+      });
+      if (mode === "summarize") {
+        // Lossy + spends a summarizer call: get explicit consent first. The
+        // provider/model change is applied only when the user confirms.
+        setSwitchDialog({ toProvider: prov, toModel: mod, fromProvider });
+        return;
+      }
+      // Fits the new window: carry the full conversation over verbatim, no
+      // dialog. Stage the handoff for the next send (consumed in
+      // `tauriChat.send`), then persist the new provider/model.
+      useProviderSwitchStore.getState().setPending(path, selectedSessionKey, {
+        mode: "replay",
+        fromProvider,
+      });
+      await applyProviderModel(prov, mod);
+      addToast({
+        title: t("chat:providerSwitch.replayToast", {
+          provider: getProvider(prov)?.name ?? prov,
+        }),
+      });
+    },
+    [
+      conversationStarted,
+      selectedSessionKey,
+      path,
+      effectiveProvider,
+      contextUsage,
+      sessionFeedItems,
+      applyProviderModel,
+      addToast,
+      t,
+    ],
+  );
+
+  // The user confirmed the summarize-and-switch dialog: stage the summarize
+  // handoff for the next send, then persist the new provider/model.
+  const confirmProviderSwitch = useCallback(async () => {
+    const pending = switchDialog;
+    setSwitchDialog(null);
+    if (!pending || !path || !selectedSessionKey) return;
+    useProviderSwitchStore.getState().setPending(path, selectedSessionKey, {
+      mode: "summarize",
+      fromProvider: pending.fromProvider,
+    });
+    await applyProviderModel(pending.toProvider, pending.toModel);
+  }, [switchDialog, path, selectedSessionKey, applyProviderModel]);
   const handleEffortSelect = useCallback(
     async (effort: EffortLevel) => {
       // Effort is per-agent (not per-activity): persist to the agent config
@@ -542,7 +652,7 @@ export function useAgentChatPanel({
   );
   const renderSystemMessage = useCallback(
     (msg: ChatMessage) => {
-      if (msg.compaction) return <ContextCompactedDivider />;
+      if (msg.compaction) return <ContextCompactedDivider info={msg.compaction} />;
       if (isToolRuntimeErrorMessage(msg)) {
         const isModelUnsupported =
           msg.runtimeError.kind === "provider_model_unsupported";
@@ -651,7 +761,7 @@ export function useAgentChatPanel({
 
   const footer = useMemo<AIBoardProps["footer"]>(() => {
     if (!agent) return undefined;
-    return ({ hasMessages }) => (
+    return () => (
       <div className="flex items-center gap-2 w-full">
         <button
           type="button"
@@ -666,7 +776,6 @@ export function useAgentChatPanel({
           provider={effectiveProvider}
           model={effectiveModel}
           onSelect={handleModelSelect}
-          lockedProvider={hasMessages ? effectiveProvider : null}
         />
         <ChatEffortSelector
           provider={effectiveProvider}
@@ -687,7 +796,7 @@ export function useAgentChatPanel({
 
   const attachMenu = useMemo<AIBoardProps["attachMenu"]>(() => {
     if (!agent) return undefined;
-    return ({ hasMessages, openFilePicker, close }) => (
+    return ({ openFilePicker, close }) => (
       <div className="flex flex-col gap-0.5">
         <button
           type="button"
@@ -715,7 +824,6 @@ export function useAgentChatPanel({
             provider={effectiveProvider}
             model={effectiveModel}
             onSelect={handleModelSelect}
-            lockedProvider={hasMessages ? effectiveProvider : null}
           />
         </div>
         <div className="px-2 py-1">
@@ -731,16 +839,28 @@ export function useAgentChatPanel({
   }, [agent, t, effectiveProvider, effectiveModel, effectiveEffort, handleModelSelect, handleEffortSelect]);
 
   const pickerDialog = agent ? (
-    <NewMissionPickerDialog
-      open={pickerOpen}
-      onOpenChange={setPickerOpen}
-      lockedAgent={agent}
-      hideBlank
-      onSkill={(_agentPath, skillName) => {
-        const skill = (allSkills ?? []).find((s) => s.name === skillName);
-        if (skill) applySkill(skill);
-      }}
-    />
+    <>
+      <NewMissionPickerDialog
+        open={pickerOpen}
+        onOpenChange={setPickerOpen}
+        lockedAgent={agent}
+        hideBlank
+        onSkill={(_agentPath, skillName) => {
+          const skill = (allSkills ?? []).find((s) => s.name === skillName);
+          if (skill) applySkill(skill);
+        }}
+      />
+      <ProviderSwitchDialog
+        open={switchDialog !== null}
+        providerName={
+          switchDialog
+            ? getProvider(switchDialog.toProvider)?.name ?? switchDialog.toProvider
+            : ""
+        }
+        onConfirm={confirmProviderSwitch}
+        onCancel={() => setSwitchDialog(null)}
+      />
+    </>
   ) : null;
 
   return {

--- a/app/src/hooks/use-session-events.ts
+++ b/app/src/hooks/use-session-events.ts
@@ -7,6 +7,7 @@ import { useUIStore } from "../stores/ui";
 import { useWorkspaceStore } from "../stores/workspaces";
 import { useAgentStore } from "../stores/agents";
 import { useSessionStatusStore } from "../stores/session-status";
+import { useProviderSwitchStore } from "../stores/provider-switch";
 import { subscribeHoustonEvents, listenOsEvent } from "../lib/events";
 import { logger } from "../lib/logger";
 import { isMac } from "../lib/platform";
@@ -65,17 +66,28 @@ export function useSessionEvents() {
       const h = handlersRef.current;
 
       switch (payload.type) {
-        case "FeedItem":
+        case "FeedItem": {
+          const item = payload.data.item as FeedItem;
           // Mark WS-delivered so a re-broadcast user_message echo (the engine
           // emits one at session-id time for cross-client sync) dedupes against
           // a turn the feed already shows instead of duplicating it (#363).
           h.pushFeedItem(
             payload.data.agent_path,
             payload.data.session_key,
-            payload.data.item as FeedItem,
+            item,
             { fromWs: true },
           );
+          // The engine confirmed a mid-session provider switch by emitting the
+          // boundary divider — clear the staged handoff so later normal turns
+          // don't re-trigger a reseed. A failed seed never emits this, so the
+          // handoff stays staged and the next send retries the switch.
+          if (item.feed_type === "provider_switched") {
+            useProviderSwitchStore
+              .getState()
+              .clearPending(payload.data.agent_path, payload.data.session_key);
+          }
           break;
+        }
         case "SessionStatus": {
           const { status, error, session_key, agent_path } = payload.data;
           if (

--- a/app/src/lib/context-usage.test.mjs
+++ b/app/src/lib/context-usage.test.mjs
@@ -1,0 +1,81 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  sessionContextUsage,
+  effectiveContextWindow,
+  contextFillPercent,
+} from "./context-usage.ts";
+
+function finalResult(contextTokens) {
+  return {
+    feed_type: "final_result",
+    data: {
+      result: "x",
+      cost_usd: null,
+      duration_ms: null,
+      usage: {
+        context_tokens: contextTokens,
+        output_tokens: 0,
+        cached_tokens: 0,
+      },
+    },
+  };
+}
+const providerSwitched = {
+  feed_type: "provider_switched",
+  data: { provider: "openai", summarized: true },
+};
+
+test("sessionContextUsage: tracks latest + peak within one provider segment", () => {
+  const r = sessionContextUsage([
+    finalResult(50_000),
+    finalResult(120_000),
+    finalResult(90_000),
+  ]);
+  assert.equal(r.latest.context_tokens, 90_000);
+  assert.equal(r.peakContextTokens, 120_000);
+});
+
+test("sessionContextUsage: provider_switched resets peak + latest to the new provider's segment", () => {
+  // Big Opus turns, then a switch, then a small GPT-5.5 turn. The Opus peak must
+  // NOT bleed across the boundary.
+  const r = sessionContextUsage([
+    finalResult(280_000),
+    finalResult(300_000),
+    providerSwitched,
+    finalResult(19_197),
+  ]);
+  assert.equal(r.latest.context_tokens, 19_197);
+  assert.equal(r.peakContextTokens, 19_197);
+});
+
+test("sessionContextUsage: latest is null right after a switch, before the new provider reports", () => {
+  const r = sessionContextUsage([finalResult(280_000), providerSwitched]);
+  assert.equal(r.latest, null);
+  assert.equal(r.peakContextTokens, 0);
+});
+
+test("effectiveContextWindow: a cross-provider peak no longer snaps the new window up (the reported bug)", () => {
+  const gpt = { default: 258_400, max: 950_000 };
+  // Pre-fix: the 300k Opus peak snapped GPT-5.5 to 950k, so 19_197 read as ~2%.
+  // Post-fix: the reset means peak is the post-switch value, so the window stays
+  // at GPT-5.5's 258_400 default.
+  const { latest, peakContextTokens } = sessionContextUsage([
+    finalResult(300_000),
+    providerSwitched,
+    finalResult(19_197),
+  ]);
+  const window = effectiveContextWindow(gpt, peakContextTokens);
+  assert.equal(window, 258_400);
+  assert.equal(contextFillPercent(latest, window), 7); // 19_197 / 258_400 ≈ 7%
+});
+
+test("effectiveContextWindow: still snaps up within the SAME provider when its own usage proves a larger window", () => {
+  const sonnet = { default: 200_000, max: 1_000_000 };
+  // No switch: a 240k peak proves the credit-gated 1M window is active.
+  const { peakContextTokens } = sessionContextUsage([
+    finalResult(120_000),
+    finalResult(240_000),
+  ]);
+  assert.equal(effectiveContextWindow(sonnet, peakContextTokens), 1_000_000);
+});

--- a/app/src/lib/context-usage.ts
+++ b/app/src/lib/context-usage.ts
@@ -16,6 +16,16 @@ export interface SessionContextUsage {
  * Fold a session's feed into the current fill + observed peak. `final_result`
  * items are persisted and replayed into the feed store, so this is stable
  * across a history reload. Scans forward so `latest` ends as the last turn.
+ *
+ * A `provider_switched` divider RESETS both the fill and the peak: a mid-session
+ * provider switch starts a fresh context window on a DIFFERENT provider, and
+ * usage observed under the previous provider says nothing about the new one's
+ * window. Without the reset, a large peak under one provider (e.g. an Opus 1M
+ * conversation) bleeds into the next provider's window estimate and wrongly
+ * snaps it up (e.g. GPT-5.5's 258k default jumping to its opt-in-1M 950k
+ * ceiling), so the indicator reads a wrong window and a tiny percentage.
+ * `context_compacted` is NOT a reset: it's the same provider, so the
+ * pre-compaction peak still proves that provider's window.
  */
 export function sessionContextUsage(
   items: FeedItem[] | undefined,
@@ -24,6 +34,11 @@ export function sessionContextUsage(
   let peakContextTokens = 0;
   if (!items) return { latest, peakContextTokens };
   for (const item of items) {
+    if (item.feed_type === "provider_switched") {
+      latest = null;
+      peakContextTokens = 0;
+      continue;
+    }
     if (item.feed_type === "final_result" && item.data.usage) {
       latest = item.data.usage;
       peakContextTokens = Math.max(

--- a/app/src/lib/model-picker.test.mjs
+++ b/app/src/lib/model-picker.test.mjs
@@ -34,7 +34,6 @@ test("shouldShowProviderInPicker: 'checking' keeps every provider visible (#342)
       providerId: "openai",
       state: "checking",
       isActiveProvider: false,
-      effectiveLock: null,
     }),
     true,
   );
@@ -46,7 +45,6 @@ test("shouldShowProviderInPicker: known-disconnected non-active providers are hi
       providerId: "openai",
       state: "disconnected",
       isActiveProvider: false,
-      effectiveLock: null,
     }),
     false,
   );
@@ -58,7 +56,6 @@ test("shouldShowProviderInPicker: connected non-active providers are shown", () 
       providerId: "openai",
       state: "connected",
       isActiveProvider: false,
-      effectiveLock: null,
     }),
     true,
   );
@@ -71,7 +68,6 @@ test("shouldShowProviderInPicker: the active provider is always shown", () => {
         providerId: "anthropic",
         state,
         isActiveProvider: true,
-        effectiveLock: null,
       }),
       true,
       `active provider should show while ${state}`,
@@ -79,35 +75,17 @@ test("shouldShowProviderInPicker: the active provider is always shown", () => {
   }
 });
 
-test("shouldShowProviderInPicker: a lock hides every other provider", () => {
-  // Non-locked provider hidden even when connected.
-  assert.equal(
-    shouldShowProviderInPicker({
-      providerId: "openai",
-      state: "connected",
-      isActiveProvider: false,
-      effectiveLock: "anthropic",
-    }),
-    false,
-  );
-  // The locked provider shows.
-  assert.equal(
-    shouldShowProviderInPicker({
-      providerId: "anthropic",
-      state: "connected",
-      isActiveProvider: true,
-      effectiveLock: "anthropic",
-    }),
-    true,
-  );
-  // A still-checking locked provider shows too (only it).
-  assert.equal(
-    shouldShowProviderInPicker({
-      providerId: "anthropic",
-      state: "checking",
-      isActiveProvider: true,
-      effectiveLock: "anthropic",
-    }),
-    true,
-  );
+test("shouldShowProviderInPicker: every connected provider stays selectable (no mid-conversation lock)", () => {
+  // The provider is never locked once a conversation starts — switching
+  // providers mid-stream is supported (the engine carries context across).
+  for (const providerId of ["openai", "anthropic"]) {
+    assert.equal(
+      shouldShowProviderInPicker({
+        providerId,
+        state: "connected",
+        isActiveProvider: false,
+      }),
+      true,
+    );
+  }
 });

--- a/app/src/lib/model-picker.ts
+++ b/app/src/lib/model-picker.ts
@@ -49,24 +49,22 @@ export function providerPickerState(
 /**
  * Whether a provider group should render in the picker.
  *
- * Rules, in order:
- *  1. A lock hides every provider except the locked one (the conversation has
- *     already started on that provider).
- *  2. The active provider is always shown, so the user can see and re-pick the
+ * The user may switch providers any time — including mid-conversation (the
+ * engine carries context across, see `lib/provider-switch.ts`) — so the picker
+ * never locks to one provider. Rules, in order:
+ *  1. The active provider is always shown, so the user can see and re-pick the
  *     current selection even when it is disconnected.
- *  3. While `checking`, every provider stays visible — this is the #342 fix:
+ *  2. While `checking`, every provider stays visible — this is the #342 fix:
  *     the list must not collapse to just the active provider before statuses
  *     load.
- *  4. Otherwise show only providers known to be connected; hide the rest.
+ *  3. Otherwise show only providers known to be connected; hide the rest.
  */
 export function shouldShowProviderInPicker(opts: {
   providerId: string;
   state: ProviderPickerState;
   isActiveProvider: boolean;
-  effectiveLock: string | null;
 }): boolean {
-  const { providerId, state, isActiveProvider, effectiveLock } = opts;
-  if (effectiveLock) return providerId === effectiveLock;
+  const { state, isActiveProvider } = opts;
   if (isActiveProvider) return true;
   if (state === "checking") return true;
   return state === "connected";

--- a/app/src/lib/provider-switch.test.mjs
+++ b/app/src/lib/provider-switch.test.mjs
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  decideHandoffMode,
+  estimateConversationTokens,
+  REPLAY_FIT_FRACTION,
+} from "./provider-switch.ts";
+
+// With REPLAY_FIT_FRACTION = 0.8, a 258_400-token window has a 206_720 cutoff.
+const GPT_WINDOW = 258_400;
+const SONNET_WINDOW = 200_000;
+
+test("decideHandoffMode: replays a small conversation that fits the target window", () => {
+  assert.equal(
+    decideHandoffMode({
+      currentContextTokens: 10_000,
+      estimatedTokens: 0,
+      targetWindowTokens: GPT_WINDOW,
+    }),
+    "replay",
+  );
+});
+
+test("decideHandoffMode: summarizes when the conversation exceeds the fit fraction", () => {
+  assert.equal(
+    decideHandoffMode({
+      currentContextTokens: 250_000,
+      estimatedTokens: 0,
+      targetWindowTokens: GPT_WINDOW,
+    }),
+    "summarize",
+  );
+});
+
+test("decideHandoffMode: respects the exact fit boundary", () => {
+  const cutoff = SONNET_WINDOW * REPLAY_FIT_FRACTION; // 160_000
+  assert.equal(
+    decideHandoffMode({
+      currentContextTokens: cutoff,
+      estimatedTokens: 0,
+      targetWindowTokens: SONNET_WINDOW,
+    }),
+    "replay",
+  );
+  assert.equal(
+    decideHandoffMode({
+      currentContextTokens: cutoff + 1,
+      estimatedTokens: 0,
+      targetWindowTokens: SONNET_WINDOW,
+    }),
+    "summarize",
+  );
+});
+
+test("decideHandoffMode: uses the larger of reported vs estimated size", () => {
+  // Reported usage is tiny but the text estimate proves it's big → summarize.
+  assert.equal(
+    decideHandoffMode({
+      currentContextTokens: 1_000,
+      estimatedTokens: 240_000,
+      targetWindowTokens: GPT_WINDOW,
+    }),
+    "summarize",
+  );
+});
+
+test("decideHandoffMode: summarizes (safe default) when the target window is unknown", () => {
+  for (const targetWindowTokens of [null, undefined]) {
+    assert.equal(
+      decideHandoffMode({
+        currentContextTokens: 10,
+        estimatedTokens: 0,
+        targetWindowTokens,
+      }),
+      "summarize",
+    );
+  }
+});
+
+test("estimateConversationTokens: ~4 chars/token over user + assistant text only", () => {
+  const items = [
+    { feed_type: "user_message", data: "a".repeat(400) },
+    { feed_type: "assistant_text", data: "b".repeat(400) },
+    // tool noise is excluded (the engine drops it from the replay too).
+    { feed_type: "tool_call", data: { name: "x", input: {} } },
+    { feed_type: "final_result", data: { result: "ok" } },
+  ];
+  assert.equal(estimateConversationTokens(items), 200); // 800 chars / 4
+  assert.equal(estimateConversationTokens(undefined), 0);
+});

--- a/app/src/lib/provider-switch.ts
+++ b/app/src/lib/provider-switch.ts
@@ -1,0 +1,84 @@
+/**
+ * Mid-session provider switch — the pure decision layer.
+ *
+ * Provider CLI sessions are not portable across providers (Claude's resume id
+ * means nothing to Codex), so switching a live conversation to a different
+ * provider runs a FRESH session on the new provider, seeded with prior context.
+ * Two ways to carry that context over:
+ *
+ *   - `replay`    — re-send the full transcript verbatim. Lossless. Chosen when
+ *                   the conversation comfortably fits the new model's window.
+ *   - `summarize` — AI-summarize the conversation to fit. Lossy and spends a
+ *                   summarizer call, so the UI gates it behind explicit consent.
+ *
+ * The size check lives here (frontend) because the context-window catalog
+ * (`providers.ts`) is frontend-only — the engine has no per-model window table.
+ */
+
+import type { FeedItem } from "@houston-ai/chat";
+
+export type ProviderHandoffMode = "replay" | "summarize";
+
+/**
+ * Headroom kept free when deciding whether a conversation can be REPLAYED
+ * verbatim into the new provider. The replayed transcript re-tokenizes
+ * differently under the new model, and the new turn plus provider overhead need
+ * room, so we only replay when the estimated size is under this fraction of the
+ * target window. Below the fraction → `replay`; at/above → `summarize`.
+ */
+export const REPLAY_FIT_FRACTION = 0.8;
+
+/**
+ * Rough token estimate for a conversation from its visible text. Used only when
+ * the leaving provider never reported usage (e.g. Gemini). ~4 chars per token,
+ * counting the user/assistant text the engine would replay — tool calls and
+ * results are dropped by the engine's `render_visible_entries`, so they are
+ * excluded here too.
+ */
+export function estimateConversationTokens(
+  items: FeedItem[] | undefined,
+): number {
+  if (!items) return 0;
+  let chars = 0;
+  for (const item of items) {
+    if (
+      (item.feed_type === "user_message" ||
+        item.feed_type === "assistant_text") &&
+      typeof item.data === "string"
+    ) {
+      chars += item.data.length;
+    }
+  }
+  return Math.ceil(chars / 4);
+}
+
+/**
+ * Decide how to carry a conversation across a mid-session provider switch.
+ *
+ * Verbatim `replay` when the conversation fits the target window with headroom.
+ * Otherwise `summarize`. When the target window is unknown (`null`) we cannot
+ * prove a fit, so we summarize to be safe (the consent dialog still gives the
+ * user the final say).
+ *
+ * `targetWindowTokens` is the new model's DEFAULT context window — pass the
+ * catalogued default (`getContextWindowConfig(provider, model)?.default`), never
+ * a snapped-up estimate, since the new provider hasn't been observed yet.
+ * `currentContextTokens` is the most accurate size (the leaving provider's last
+ * reported context fill, or `null` when it never reported one).
+ * `estimatedTokens` is the text-derived fallback. The larger of the two is used
+ * so a switch away from a usage-reporting provider never under-counts.
+ *
+ * Pure (the window is passed in, not looked up) so it unit-tests without the
+ * provider catalog module.
+ */
+export function decideHandoffMode(args: {
+  currentContextTokens: number | null;
+  estimatedTokens: number;
+  targetWindowTokens: number | null | undefined;
+}): ProviderHandoffMode {
+  if (args.targetWindowTokens == null) return "summarize";
+  const size = Math.max(args.currentContextTokens ?? 0, args.estimatedTokens);
+  return size <= args.targetWindowTokens * REPLAY_FIT_FRACTION
+    ? "replay"
+    : "summarize";
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -34,6 +34,7 @@ import { osPickDirectory } from "./os-bridge";
 import { logger } from "./logger";
 import { normalizeLegacyModel } from "./providers";
 import { shouldAutocompactForSession } from "./autocompact";
+import { useProviderSwitchStore } from "../stores/provider-switch";
 export { withAttachmentPaths } from "./attachment-message";
 
 interface EngineCallOptions {
@@ -208,16 +209,27 @@ export const tauriChat = {
     },
   ) =>
     call<string>("send_message", async () => {
+      // A staged provider switch (the user changed providers mid-conversation)
+      // takes precedence over autocompact: the engine reseeds a fresh session
+      // on the new provider, so same-provider context-full compaction doesn't
+      // apply. PEEK, don't clear — the handoff is cleared only when the engine
+      // confirms the switch with a `provider_switched` event, so a failed seed
+      // is retried on the next send instead of silently continuing blank.
+      const handoff = useProviderSwitchStore
+        .getState()
+        .peekPending(agentPath, sessionKey);
       // Centralized autocompact decision: when this session's context is
       // nearly full, ask the engine to summarize + reseed before this turn.
       // Computed here so every send path gets it; new conversations have no
       // usage yet and resolve to `false`.
-      const compact = shouldAutocompactForSession(
-        agentPath,
-        sessionKey,
-        opts?.providerOverride,
-        opts?.modelOverride,
-      );
+      const compact = handoff
+        ? false
+        : shouldAutocompactForSession(
+            agentPath,
+            sessionKey,
+            opts?.providerOverride,
+            opts?.modelOverride,
+          );
       const res = await getEngine().startSession(agentPath, {
         sessionKey,
         prompt,
@@ -227,6 +239,9 @@ export const tauriChat = {
         model: opts?.modelOverride,
         effort: opts?.effortOverride,
         compact,
+        providerSwitch: handoff
+          ? { mode: handoff.mode, fromProvider: handoff.fromProvider }
+          : undefined,
       });
       return res.sessionKey;
     }),

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -104,5 +104,14 @@
   },
   "filesUpdated_one": "1 file updated",
   "filesUpdated_other": "{{count}} files updated",
-  "contextCompacted": "Earlier conversation summarized so the chat can keep going"
+  "contextCompacted": "Earlier conversation summarized so the chat can keep going",
+  "providerSwitch": {
+    "dialogTitle": "Switch to {{provider}}?",
+    "dialogBody": "{{provider}} has a smaller context window, so we'll summarize this conversation so it fits. That uses some tokens and may lose a little detail. Continue?",
+    "confirm": "Summarize and switch",
+    "cancel": "Cancel",
+    "replayToast": "Continuing with {{provider}}. Your full conversation was carried over.",
+    "dividerFull": "Continued with {{provider}}",
+    "dividerSummary": "Continued with {{provider}}, summarized to fit"
+  }
 }

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -106,11 +106,12 @@
   "filesUpdated_other": "{{count}} files updated",
   "contextCompacted": "Earlier conversation summarized so the chat can keep going",
   "providerSwitch": {
-    "dialogTitle": "Switch to {{provider}}?",
-    "dialogBody": "{{provider}} has a smaller context window, so we'll summarize this conversation so it fits. That uses some tokens and may lose a little detail. Continue?",
-    "confirm": "Summarize and switch",
+    "title": "Switch to {{provider}}?",
+    "replayBody": "Switching brings this whole conversation over to {{provider}} so it can continue with full context. Reloading the conversation uses a considerable amount of tokens, and more the larger the conversation is right now. Continue?",
+    "replayConfirm": "Reload and switch",
+    "summaryBody": "{{provider}} has a smaller context window, so the whole conversation won't fit. We'll summarize it so {{provider}} can continue. Summarizing uses tokens and may lose some detail. Continue?",
+    "summaryConfirm": "Summarize and switch",
     "cancel": "Cancel",
-    "replayToast": "Continuing with {{provider}}. Your full conversation was carried over.",
     "dividerFull": "Continued with {{provider}}",
     "dividerSummary": "Continued with {{provider}}, summarized to fit"
   }

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -104,5 +104,14 @@
   },
   "filesUpdated_one": "1 archivo actualizado",
   "filesUpdated_other": "{{count}} archivos actualizados",
-  "contextCompacted": "Resumimos la conversación anterior para que el chat pueda continuar"
+  "contextCompacted": "Resumimos la conversación anterior para que el chat pueda continuar",
+  "providerSwitch": {
+    "dialogTitle": "¿Cambiar a {{provider}}?",
+    "dialogBody": "{{provider}} tiene una ventana de contexto más pequeña, así que resumiremos esta conversación para que quepa. Eso usa algunos tokens y puede perder un poco de detalle. ¿Continuar?",
+    "confirm": "Resumir y cambiar",
+    "cancel": "Cancelar",
+    "replayToast": "Continuando con {{provider}}. Tu conversación completa se mantuvo.",
+    "dividerFull": "Se continuó con {{provider}}",
+    "dividerSummary": "Se continuó con {{provider}}, resumido para que quepa"
+  }
 }

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -106,11 +106,12 @@
   "filesUpdated_other": "{{count}} archivos actualizados",
   "contextCompacted": "Resumimos la conversación anterior para que el chat pueda continuar",
   "providerSwitch": {
-    "dialogTitle": "¿Cambiar a {{provider}}?",
-    "dialogBody": "{{provider}} tiene una ventana de contexto más pequeña, así que resumiremos esta conversación para que quepa. Eso usa algunos tokens y puede perder un poco de detalle. ¿Continuar?",
-    "confirm": "Resumir y cambiar",
+    "title": "¿Cambiar a {{provider}}?",
+    "replayBody": "Cambiar lleva toda esta conversación a {{provider}} para que pueda continuar con todo el contexto. Recargar la conversación usa una cantidad considerable de tokens, y más cuanto más larga sea la conversación en este momento. ¿Continuar?",
+    "replayConfirm": "Recargar y cambiar",
+    "summaryBody": "{{provider}} tiene una ventana de contexto más pequeña, así que la conversación completa no cabe. La resumiremos para que {{provider}} pueda continuar. Resumir usa tokens y puede perder algún detalle. ¿Continuar?",
+    "summaryConfirm": "Resumir y cambiar",
     "cancel": "Cancelar",
-    "replayToast": "Continuando con {{provider}}. Tu conversación completa se mantuvo.",
     "dividerFull": "Se continuó con {{provider}}",
     "dividerSummary": "Se continuó con {{provider}}, resumido para que quepa"
   }

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -106,11 +106,12 @@
   "filesUpdated_other": "{{count}} arquivos atualizados",
   "contextCompacted": "Resumimos a conversa anterior para o chat poder continuar",
   "providerSwitch": {
-    "dialogTitle": "Mudar para {{provider}}?",
-    "dialogBody": "O {{provider}} tem uma janela de contexto menor, então vamos resumir esta conversa para ela caber. Isso usa alguns tokens e pode perder um pouco de detalhe. Continuar?",
-    "confirm": "Resumir e mudar",
+    "title": "Mudar para {{provider}}?",
+    "replayBody": "Mudar leva toda esta conversa para o {{provider}} continuar com todo o contexto. Recarregar a conversa usa uma quantidade considerável de tokens, e mais quanto maior a conversa estiver agora. Continuar?",
+    "replayConfirm": "Recarregar e mudar",
+    "summaryBody": "O {{provider}} tem uma janela de contexto menor, então a conversa inteira não cabe. Vamos resumi-la para o {{provider}} continuar. Resumir usa tokens e pode perder algum detalhe. Continuar?",
+    "summaryConfirm": "Resumir e mudar",
     "cancel": "Cancelar",
-    "replayToast": "Continuando com {{provider}}. Sua conversa completa foi mantida.",
     "dividerFull": "Continuou com {{provider}}",
     "dividerSummary": "Continuou com {{provider}}, resumido para caber"
   }

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -104,5 +104,14 @@
   },
   "filesUpdated_one": "1 arquivo atualizado",
   "filesUpdated_other": "{{count}} arquivos atualizados",
-  "contextCompacted": "Resumimos a conversa anterior para o chat poder continuar"
+  "contextCompacted": "Resumimos a conversa anterior para o chat poder continuar",
+  "providerSwitch": {
+    "dialogTitle": "Mudar para {{provider}}?",
+    "dialogBody": "O {{provider}} tem uma janela de contexto menor, então vamos resumir esta conversa para ela caber. Isso usa alguns tokens e pode perder um pouco de detalhe. Continuar?",
+    "confirm": "Resumir e mudar",
+    "cancel": "Cancelar",
+    "replayToast": "Continuando com {{provider}}. Sua conversa completa foi mantida.",
+    "dividerFull": "Continuou com {{provider}}",
+    "dividerSummary": "Continuou com {{provider}}, resumido para caber"
+  }
 }

--- a/app/src/stores/provider-switch.ts
+++ b/app/src/stores/provider-switch.ts
@@ -1,0 +1,62 @@
+/**
+ * Staged provider-switch handoffs, keyed by conversation.
+ *
+ * When the user switches a live conversation to a different provider, the
+ * model picker stages a handoff here (the chosen `mode` + the provider being
+ * left). The next send for that conversation reads it (`peekPending`) and
+ * forwards it to the engine as `providerSwitch`. It is cleared (`clearPending`)
+ * only when the engine confirms the switch by emitting the `provider_switched`
+ * boundary divider — so a switch whose seed FAILS stays staged and the next
+ * send retries it, rather than silently continuing on a blank/stale session.
+ *
+ * This mirrors how autocompact is centralized in `tauriChat.send`: a
+ * cross-cutting send concern read from a store so every send path inherits it.
+ */
+import { create } from "zustand";
+import type { ProviderHandoffMode } from "../lib/provider-switch";
+
+export interface PendingHandoff {
+  mode: ProviderHandoffMode;
+  /** Provider id the conversation is being switched away FROM. */
+  fromProvider: string;
+}
+
+interface ProviderSwitchState {
+  pending: Record<string, PendingHandoff>;
+  setPending: (
+    agentPath: string,
+    sessionKey: string,
+    handoff: PendingHandoff,
+  ) => void;
+  /** Read the staged handoff without clearing it. */
+  peekPending: (
+    agentPath: string,
+    sessionKey: string,
+  ) => PendingHandoff | undefined;
+  /** Clear the staged handoff once the switch has landed (or been abandoned). */
+  clearPending: (agentPath: string, sessionKey: string) => void;
+}
+
+function handoffKey(agentPath: string, sessionKey: string): string {
+  return `${agentPath}::${sessionKey}`;
+}
+
+export const useProviderSwitchStore = create<ProviderSwitchState>(
+  (set, get) => ({
+    pending: {},
+    setPending: (agentPath, sessionKey, handoff) =>
+      set((s) => ({
+        pending: { ...s.pending, [handoffKey(agentPath, sessionKey)]: handoff },
+      })),
+    peekPending: (agentPath, sessionKey) =>
+      get().pending[handoffKey(agentPath, sessionKey)],
+    clearPending: (agentPath, sessionKey) =>
+      set((s) => {
+        const k = handoffKey(agentPath, sessionKey);
+        if (!(k in s.pending)) return s;
+        const next = { ...s.pending };
+        delete next[k];
+        return { pending: next };
+      }),
+  }),
+);

--- a/engine/houston-agents-conversations/src/session_runner.rs
+++ b/engine/houston-agents-conversations/src/session_runner.rs
@@ -470,6 +470,23 @@ fn serialize_for_persist(item: &FeedItem) -> Option<(String, String)> {
             let data = serde_json::json!({ "trigger": trigger, "pre_tokens": pre_tokens });
             Some(("context_compacted".into(), data.to_string()))
         }
+        FeedItem::ProviderSwitched {
+            provider,
+            summarized,
+            pre_tokens,
+        } => {
+            // Persist the provider-switch divider so it survives a history
+            // reload, matching the live FeedItem wire shape (`data` = the
+            // variant fields). Engine-core emits + persists this directly at the
+            // switch boundary (see `sessions::run_start`); this arm keeps the
+            // FeedItem → feed_type mapping total for any future emitter.
+            let data = serde_json::json!({
+                "provider": provider,
+                "summarized": summarized,
+                "pre_tokens": pre_tokens,
+            });
+            Some(("provider_switched".into(), data.to_string()))
+        }
         // Skip streaming items — they get replaced by finals.
         FeedItem::AssistantTextStreaming(_) | FeedItem::ThinkingStreaming(_) => None,
     }

--- a/engine/houston-engine-core/src/sessions/compaction.rs
+++ b/engine/houston-engine-core/src/sessions/compaction.rs
@@ -23,6 +23,15 @@ use std::time::Duration;
 /// resume-recovery cap; keeps the summary call itself from blowing context.
 const MAX_HISTORY_BYTES: usize = 120_000;
 
+/// Cap on a verbatim provider-switch replay. Far larger than the summarizer cap
+/// because the whole point is to carry the FULL conversation across when it
+/// fits the new provider's window (the frontend only chooses `Replay` after
+/// confirming it fits). `render_visible_entries` already drops tool noise, so
+/// this is conversation text, not raw turns; ~3 MB ≈ 750k tokens stays under
+/// every catalogued window ceiling. `truncate_history_tail` keeps the most
+/// recent text and marks any omission rather than failing.
+const REPLAY_MAX_BYTES: usize = 3_000_000;
+
 /// Generous bound — summarizing a long conversation with a capable model takes
 /// longer than a title. Still bounded so a hung CLI can't wedge the turn.
 const SUMMARY_TIMEOUT: Duration = Duration::from_secs(90);
@@ -45,10 +54,13 @@ pub struct CompactionSeed {
     pub pre_tokens: Option<u64>,
 }
 
-/// Build the seed for a forced compaction, or `Ok(None)` when there is nothing
-/// to summarize (no visible history yet). Returns `Err` only when the
-/// summarizer call itself fails — the caller degrades to a normal resume in
-/// that case (the provider's own auto-compaction is the backstop).
+/// Build the seed for a forced compaction. `Ok(None)` means there is genuinely
+/// nothing to summarize (no visible history yet). `Err` means the summarize
+/// step failed — either the summarizer call errored, or it returned empty text
+/// despite real history existing (an unusable summary). Callers must treat the
+/// two differently: a provider switch surfaces the `Err` (the user consented to
+/// the summary), while autocompact degrades to a normal resume (the provider's
+/// own auto-compaction is the backstop).
 pub async fn build_compaction_seed(
     db: &Database,
     working_dir: &Path,
@@ -88,13 +100,72 @@ pub async fn build_compaction_seed(
 
     let summary = summary.trim();
     if summary.is_empty() {
-        return Ok(None);
+        // History WAS non-empty (checked above), but the summarizer returned
+        // nothing usable. That's a real failure, not a "nothing to summarize" —
+        // distinct from the `Ok(None)` above so callers can tell them apart. The
+        // provider-switch path surfaces this (the user consented to + paid for a
+        // summary); autocompact degrades to a normal resume in its `Err` arm.
+        return Err(CoreError::Internal(
+            "summarizer returned empty output".to_string(),
+        ));
     }
 
     Ok(Some(CompactionSeed {
         prompt: seeded_prompt(summary, latest_user_prompt),
         pre_tokens,
     }))
+}
+
+/// Outcome of preparing a verbatim replay: the full rendered transcript framed
+/// as the seed prompt for a fresh session on the new provider, plus the context
+/// size just before the switch (for the divider marker).
+pub struct ReplaySeed {
+    pub prompt: String,
+    pub pre_tokens: Option<u64>,
+}
+
+/// Build a verbatim-replay seed for a provider switch: render the FULL visible
+/// transcript and frame it as established context for a fresh session on the
+/// new provider. Unlike [`build_compaction_seed`] this makes NO provider call,
+/// so it never depends on the leaving provider (the transcript comes from our
+/// `chat_feed`) — the reliable path when the user is switching precisely
+/// because the old provider hit a wall (out of credits, rate limited).
+///
+/// Returns `Ok(None)` when there is no visible history to carry. Returns `Err`
+/// only on a DB read failure; the caller surfaces that rather than silently
+/// starting the new provider blank, because a provider switch was explicit.
+pub async fn build_replay_seed(
+    db: &Database,
+    working_dir: &Path,
+    agent_dir: &Path,
+    session_key: &str,
+    latest_user_prompt: &str,
+) -> CoreResult<Option<ReplaySeed>> {
+    let mut entries = history::load(db, working_dir, session_key).await?;
+    if entries.is_empty() && agent_dir != working_dir {
+        entries = history::load(db, agent_dir, session_key).await?;
+    }
+
+    let rendered = history::render_visible_entries(&entries).join("\n\n");
+    if rendered.trim().is_empty() {
+        return Ok(None);
+    }
+    let pre_tokens = latest_context_tokens(&entries);
+    let capped = history::truncate_history_tail(rendered, REPLAY_MAX_BYTES);
+
+    Ok(Some(ReplaySeed {
+        prompt: replay_seeded_prompt(&capped, latest_user_prompt),
+        pre_tokens,
+    }))
+}
+
+/// Wrap the verbatim transcript + the user's latest message into the prompt the
+/// fresh session receives after a provider switch. The transcript is the
+/// ongoing conversation (established context); the latest message is the task.
+fn replay_seeded_prompt(history: &str, latest_user_prompt: &str) -> String {
+    format!(
+        "This conversation continues from earlier work that a different assistant handled. The full prior conversation is below. Treat it as the ongoing conversation you are part of, not a new task or a document to react to.\n\n<conversation_history>\n{history}\n</conversation_history>\n\nLatest user message:\n<latest_user_message>\n{latest_user_prompt}\n</latest_user_message>"
+    )
 }
 
 /// The prompt sent to the summarizer CLI. Asks for a handoff brief that lets a
@@ -148,6 +219,68 @@ mod tests {
         // No em dashes in any generated text (project copy rule, even for
         // model-facing prompts we keep it clean).
         assert!(!p.contains('\u{2014}'));
+    }
+
+    #[test]
+    fn replay_prompt_carries_verbatim_history_and_keeps_latest_as_task() {
+        let p = replay_seeded_prompt(
+            "User:\nrefactor the parser\n\nAssistant:\ndone, split into modules",
+            "now add tests",
+        );
+        assert!(p.contains("<conversation_history>"));
+        assert!(p.contains("refactor the parser"));
+        assert!(p.contains("split into modules"));
+        assert!(p.contains("<latest_user_message>"));
+        assert!(p.contains("now add tests"));
+        // Verbatim, not summarized: the original assistant text is present.
+        assert!(p.contains("done, split into modules"));
+        // No em dashes in generated text (project copy rule).
+        assert!(!p.contains('\u{2014}'));
+    }
+
+    #[tokio::test]
+    async fn replay_seed_renders_full_visible_history() {
+        let db = houston_db::Database::connect_in_memory().await.unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        let provider: Provider = "anthropic".parse().unwrap();
+        let sid_path = houston_agents_conversations::session_id_tracker::session_id_path(
+            dir.path(),
+            provider,
+            "chat",
+        );
+        std::fs::create_dir_all(sid_path.parent().unwrap()).unwrap();
+        std::fs::write(&sid_path, "claude-session").unwrap();
+        for (ft, text) in [
+            ("user_message", "plan the launch"),
+            ("assistant_text", "step one: pick a date"),
+        ] {
+            db.add_chat_feed_item_by_session(
+                "claude-session",
+                ft,
+                &serde_json::Value::String(text.into()).to_string(),
+                "test",
+            )
+            .await
+            .unwrap();
+        }
+
+        let seed = build_replay_seed(&db, dir.path(), dir.path(), "chat", "now draft the invite")
+            .await
+            .unwrap()
+            .expect("replay seed");
+        assert!(seed.prompt.contains("plan the launch"));
+        assert!(seed.prompt.contains("step one: pick a date"));
+        assert!(seed.prompt.contains("now draft the invite"));
+    }
+
+    #[tokio::test]
+    async fn replay_seed_is_none_without_visible_history() {
+        let db = houston_db::Database::connect_in_memory().await.unwrap();
+        let dir = tempfile::TempDir::new().unwrap();
+        let seed = build_replay_seed(&db, dir.path(), dir.path(), "chat", "hi")
+            .await
+            .unwrap();
+        assert!(seed.is_none());
     }
 
     #[test]

--- a/engine/houston-engine-core/src/sessions/mod.rs
+++ b/engine/houston-engine-core/src/sessions/mod.rs
@@ -37,7 +37,9 @@ use crate::CoreResult;
 use control::{
     SessionControl, SessionIdentity, SessionTurnGuard, SessionTurnLocks, WorkdirActivity,
 };
-use houston_agents_conversations::session_id_tracker::SessionIdTracker;
+use houston_agents_conversations::session_id_tracker::{
+    session_ids_for_history, SessionIdTracker,
+};
 use houston_agents_conversations::session_pids::SessionPidMap;
 use houston_agents_conversations::session_runner::{self, PersistOptions};
 use houston_db::Database;
@@ -108,6 +110,60 @@ pub struct StartParams {
     /// Honored only when there's an existing session to compact; ignored on
     /// the first turn. See [`compaction`].
     pub compact: bool,
+    /// Set when the user moved this conversation to a DIFFERENT provider
+    /// mid-stream. The new provider has no resume session, so the turn reseeds
+    /// fresh with prior context — verbatim or summarized, see [`SeedMode`] —
+    /// and any stale resume id for the resolved provider is cleared so a
+    /// switch-back never resumes a session missing the other provider's turns.
+    /// Takes precedence over `compact`. See [`compaction`].
+    pub handoff: Option<ProviderHandoff>,
+}
+
+/// How prior context is carried over when a conversation is handed to a
+/// different provider. Provider CLI sessions aren't portable, so the new
+/// provider always starts fresh; this picks the seed strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SeedMode {
+    /// Re-send the full visible transcript verbatim. Lossless; chosen by the
+    /// client when the conversation fits the new provider's context window.
+    Replay,
+    /// Summarize the conversation with the TARGET provider, then seed the fresh
+    /// session with the summary. Lossy; chosen when a verbatim replay would not
+    /// fit. Costs one summarizer call on the target provider (never the one
+    /// being left, so it works even when the old provider is out of credits).
+    Summarize,
+}
+
+impl std::fmt::Display for SeedMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            SeedMode::Replay => "replay",
+            SeedMode::Summarize => "summarize",
+        })
+    }
+}
+
+impl std::str::FromStr for SeedMode {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "replay" => Ok(SeedMode::Replay),
+            "summarize" => Ok(SeedMode::Summarize),
+            other => Err(format!(
+                "unknown seed mode {other:?} (expected \"replay\" or \"summarize\")"
+            )),
+        }
+    }
+}
+
+/// A mid-session provider switch requested by the client. The provider being
+/// switched TO is the session's resolved provider; `from_provider` is the one
+/// being left — used only to anchor the boundary divider at the right place in
+/// the persisted history.
+#[derive(Debug, Clone, Copy)]
+pub struct ProviderHandoff {
+    pub mode: SeedMode,
+    pub from_provider: Provider,
 }
 
 /// Start a session turn. The request is accepted immediately. Turns with the
@@ -203,6 +259,7 @@ async fn run_start(
         model,
         effort,
         compact,
+        handoff,
     } = params;
 
     if !agent_dir.exists() {
@@ -263,12 +320,146 @@ async fn run_start(
     // persisted/displayed user message stays the original (see `persist`).
     let mut cli_prompt = prompt.clone();
 
-    // Forced autocompact (mechanism B): the frontend flagged this turn because
-    // the context window is nearly full. Summarize the visible history,
-    // abandon the current resume id (kept in `.history` so the chat stays
-    // visible), and run this turn on a FRESH provider session seeded with the
-    // summary. The user's chat_feed is never mutated.
-    if compact {
+    // Provider switch (takes precedence over autocompact): the user moved this
+    // conversation to a different provider. The new provider has no portable
+    // resume session, so reseed a FRESH session with prior context — the full
+    // transcript verbatim (`Replay`, when it fits the new window) or an
+    // AI-generated summary (`Summarize`, when it doesn't). Both read our
+    // `chat_feed`, never the leaving provider's CLI, so a switch away from an
+    // out-of-credits provider still works. The summarizer (when used) runs on
+    // the TARGET provider. Always clears any current resume id for the resolved
+    // provider so a switch-BACK never resumes a session missing the other
+    // provider's turns.
+    if let Some(handoff) = handoff {
+        let seed = match handoff.mode {
+            SeedMode::Replay => compaction::build_replay_seed(
+                &db,
+                &working_dir,
+                &agent_dir,
+                &session_key,
+                &prompt,
+            )
+            .await
+            .map(|opt| opt.map(|s| (s.prompt, s.pre_tokens))),
+            SeedMode::Summarize => compaction::build_compaction_seed(
+                &db,
+                &working_dir,
+                &agent_dir,
+                &session_key,
+                &prompt,
+                provider,
+                model.as_deref(),
+            )
+            .await
+            .map(|opt| opt.map(|s| (s.prompt, s.pre_tokens))),
+        };
+        match seed {
+            Ok(maybe_seed) => {
+                // The switch SUCCEEDED whether or not there was prior context to
+                // carry. `Some` carries a seed; `None` means the engine saw no
+                // visible history (e.g. the frontend's streaming-feed
+                // `conversationStarted` ran ahead of the persisted `chat_feed`),
+                // so the new provider just starts fresh. EITHER WAY we emit +
+                // persist the divider: it's the success signal the frontend uses
+                // to clear the staged handoff, so a switch that emitted nothing
+                // would re-fire on every later send. Only a true seed FAILURE
+                // (Err) keeps the handoff staged for retry.
+                let pre_tokens = maybe_seed.as_ref().and_then(|(_, pt)| *pt);
+                let seeded = maybe_seed.is_some();
+                if let Some((seed_prompt, _)) = maybe_seed {
+                    cli_prompt = seed_prompt;
+                }
+                let summarized = matches!(handoff.mode, SeedMode::Summarize);
+                // Live divider so the boundary shows immediately.
+                events.emit(HoustonEvent::FeedItem {
+                    agent_path: agent_path.clone(),
+                    session_key: session_key.clone(),
+                    item: FeedItem::ProviderSwitched {
+                        provider: provider.id().to_string(),
+                        summarized,
+                        pre_tokens,
+                    },
+                });
+                // Persist the divider under an id in THIS conversation's id set
+                // so a history reload loads it. `chat_feed` sorts by timestamp,
+                // so any anchor places the marker at the boundary (after the old
+                // turns, before the new). Prefer the leaving provider's current
+                // id, then the resolved provider's (a switch-back's stale id),
+                // then any id from the full history set — the last guarantees
+                // persistence even when neither provider holds a current sid
+                // (e.g. the leaving provider only ever errored), as long as the
+                // seed read non-empty history.
+                let leaving_agent_key = format!(
+                    "{}:{}:{}",
+                    working_dir.to_string_lossy(),
+                    handoff.from_provider,
+                    session_key
+                );
+                let leaving_id = rt
+                    .session_ids
+                    .get_for_session(
+                        &leaving_agent_key,
+                        &working_dir,
+                        &session_key,
+                        handoff.from_provider,
+                    )
+                    .await
+                    .get()
+                    .await
+                    .or_else(|| resume_id.clone())
+                    .or_else(|| {
+                        session_ids_for_history(&working_dir, &session_key)
+                            .into_iter()
+                            .next_back()
+                    });
+                if let Some(leaving_id) = leaving_id {
+                    let data = serde_json::json!({
+                        "provider": provider.id(),
+                        "summarized": summarized,
+                        "pre_tokens": pre_tokens,
+                    })
+                    .to_string();
+                    if let Err(e) = db
+                        .add_chat_feed_item_by_session(
+                            &leaving_id,
+                            "provider_switched",
+                            &data,
+                            &source,
+                        )
+                        .await
+                    {
+                        tracing::warn!(
+                            "[sessions] failed to persist provider-switch marker: {e} (session_key={session_key})"
+                        );
+                    }
+                }
+                sid_handle.clear_current_preserving_history().await;
+                resume_id = None;
+                tracing::info!(
+                    "[sessions] provider switch to {provider} (mode={}, summarized={summarized}, seeded={seeded}) for session_key={session_key}",
+                    handoff.mode
+                );
+            }
+            Err(e) => {
+                // The user explicitly switched (and for Summarize consented to
+                // the token cost). There is NO safe fallback here — a normal
+                // resume would be blank (new provider) or a stale cross-provider
+                // session, and an unusable/empty summary is a failure too. Surface
+                // it rather than silently degrade (beta no-silent-failure policy);
+                // the start wrapper flips the activity to `error` and emits a
+                // SessionStatus error. The frontend keeps the handoff staged, so
+                // the next send retries the switch.
+                return Err(crate::CoreError::Internal(format!(
+                    "couldn't switch to {provider}: {e}"
+                )));
+            }
+        }
+    } else if compact {
+        // Forced autocompact (mechanism B): the frontend flagged this turn
+        // because the context window is nearly full. Summarize the visible
+        // history, abandon the current resume id (kept in `.history` so the
+        // chat stays visible), and run this turn on a FRESH provider session
+        // seeded with the summary. The user's chat_feed is never mutated.
         if let Some(old_id) = resume_id.clone() {
             match compaction::build_compaction_seed(
                 &db,
@@ -641,6 +832,7 @@ pub async fn start_onboarding(
             model: resolved.model,
             effort,
             compact: false,
+            handoff: None,
         },
     )
     .await
@@ -709,6 +901,7 @@ mod tests {
                     model: None,
                     effort: None,
                     compact: false,
+                    handoff: None,
                 },
             ),
         )

--- a/engine/houston-engine-server/src/routes/sessions.rs
+++ b/engine/houston-engine-server/src/routes/sessions.rs
@@ -90,6 +90,23 @@ pub struct StartRequest {
     /// clients deserialize unchanged.
     #[serde(default)]
     pub compact: bool,
+    /// Set when the user switched this conversation to a DIFFERENT provider
+    /// mid-stream. Reseeds a fresh session on the new provider with prior
+    /// context (verbatim or summarized — see [`ProviderSwitchRequest`]). Takes
+    /// precedence over `compact`. Absent for normal turns.
+    #[serde(default)]
+    pub provider_switch: Option<ProviderSwitchRequest>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProviderSwitchRequest {
+    /// `"replay"` (carry the full transcript verbatim) or `"summarize"`
+    /// (AI-summarize to fit the new provider's smaller window).
+    pub mode: String,
+    /// Provider id being LEFT (e.g. `"anthropic"`). The provider being switched
+    /// TO is `provider`. Used to anchor the boundary divider in history.
+    pub from_provider: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -121,6 +138,24 @@ async fn start_session(
         .effort
         .or_else(|| sessions::resolve_effort(&agent_dir, provider));
 
+    // Parse the optional provider-switch handoff. Invalid mode / provider is a
+    // client error, not a silent drop.
+    let handoff = match req.provider_switch {
+        Some(sw) => {
+            let mode: sessions::SeedMode =
+                sw.mode.parse().map_err(|e: String| CoreError::BadRequest(e))?;
+            let from_provider: Provider = sw
+                .from_provider
+                .parse()
+                .map_err(|e: String| CoreError::BadRequest(e))?;
+            Some(sessions::ProviderHandoff {
+                mode,
+                from_provider,
+            })
+        }
+        None => None,
+    };
+
     let params = StartParams {
         agent_dir,
         working_dir,
@@ -132,6 +167,7 @@ async fn start_session(
         model,
         effort,
         compact: req.compact,
+        handoff,
     };
 
     let rt = SessionRuntime::clone(&st.engine.sessions);

--- a/engine/houston-engine-server/tests/sessions.rs
+++ b/engine/houston-engine-server/tests/sessions.rs
@@ -370,3 +370,27 @@ async fn rest_cancel_requires_colon_cancel_suffix() {
         .unwrap();
     assert_eq!(res.status(), 400);
 }
+
+#[tokio::test]
+async fn rest_start_session_rejects_invalid_provider_switch_mode() {
+    // A bad `providerSwitch.mode` is a client error surfaced as 400 (not
+    // swallowed, not a 500). This fails BEFORE any session task spawns, so it
+    // has no filesystem side effects. Mirrors HOU-424's wire contract:
+    // `providerSwitch: { mode: "replay" | "summarize", fromProvider }`.
+    let (addr, token, _state) = spawn_engine().await;
+    let encoded_path = urlencoding::encode("/tmp/houston-switch-agent");
+    let url = format!("http://{addr}/v1/agents/{encoded_path}/sessions");
+    let res = reqwest::Client::new()
+        .post(&url)
+        .bearer_auth(&token)
+        .json(&serde_json::json!({
+            "sessionKey": "switch-bad-mode",
+            "prompt": "hi",
+            "provider": "openai",
+            "providerSwitch": { "mode": "bogus", "fromProvider": "anthropic" }
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(res.status(), 400);
+}

--- a/engine/houston-terminal-manager/src/types.rs
+++ b/engine/houston-terminal-manager/src/types.rs
@@ -279,6 +279,25 @@ pub enum FeedItem {
     },
     /// Visible files created or changed during the session.
     FileChanges(FileChanges),
+    /// The conversation was handed off to a DIFFERENT provider mid-session.
+    ///
+    /// Provider CLI sessions are not portable across providers (Claude's
+    /// resume id means nothing to Codex), so the new provider runs a FRESH
+    /// session seeded with prior context — the full transcript verbatim when
+    /// it fits the new model's window (`summarized = false`), or an
+    /// AI-generated summary when it does not (`summarized = true`). The user's
+    /// visible `chat_feed` is never mutated; this is a boundary divider, like
+    /// [`Self::ContextCompacted`]. `pre_tokens` is how full the leaving
+    /// provider's context was just before the switch, when known.
+    ProviderSwitched {
+        /// Provider id the conversation was handed off TO (e.g. "openai").
+        provider: String,
+        /// Whether prior context was summarized to fit (`true`) or carried
+        /// over verbatim (`false`).
+        summarized: bool,
+        #[serde(default)]
+        pre_tokens: Option<u64>,
+    },
 }
 
 /// In-memory buffer for a live session's feed items.

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -234,6 +234,33 @@ Notes:
   three dispatch arms (runner, parser, summarizer). See "Engine boundary"
   in `CLAUDE.md`.
 
+### Switching provider mid-conversation
+
+The picker is **never locked** — the user can switch a live conversation to a
+different provider at any time (HOU-424). Provider CLI sessions are not portable
+(Claude's resume id means nothing to Codex), so the engine runs a FRESH session
+on the new provider seeded with prior context, reusing the compaction machinery:
+
+- **Fits the new model's window** → carry the full transcript over verbatim
+  (`replay`). Lossless.
+- **Doesn't fit** → summarize with the TARGET provider to fit, behind an
+  explicit consent dialog (lossy + spends a summarizer call).
+
+The size decision is frontend-only — the context-window catalog lives in
+`app/src/lib/providers.ts` (`app/src/lib/provider-switch.ts::decideHandoffMode`).
+The choice is staged in `app/src/stores/provider-switch.ts`, forwarded on the
+next send as `POST .../sessions { providerSwitch: { mode, fromProvider } }`, and
+the engine reseeds in `houston_engine_core::sessions::run_start`: it clears the
+resolved provider's current resume id (so a switch-**back** never resumes a
+session missing the other provider's turns), builds the seed
+(`compaction::build_replay_seed` or `build_compaction_seed`, both reading the DB
+`chat_feed`, the summary running on the TARGET provider), and emits a
+`provider_switched` boundary divider. Because the handoff never touches the
+provider being LEFT, switching away from one that is out of credits or rate
+limited works. A seed failure surfaces as a session error (no silent
+blank-start); the staged handoff is cleared only on the `provider_switched`
+event, so a failed switch is retried on the next send.
+
 ### Reasoning effort
 
 Effort is **per-agent and model-gated**. Stored as `effort` in the agent's

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -242,9 +242,13 @@ different provider at any time (HOU-424). Provider CLI sessions are not portable
 on the new provider seeded with prior context, reusing the compaction machinery:
 
 - **Fits the new model's window** → carry the full transcript over verbatim
-  (`replay`). Lossless.
-- **Doesn't fit** → summarize with the TARGET provider to fit, behind an
-  explicit consent dialog (lossy + spends a summarizer call).
+  (`replay`). Lossless, but reloading the whole conversation costs tokens.
+- **Doesn't fit** → summarize with the TARGET provider to fit (`summarize`).
+  Lossy + spends a summarizer call.
+
+**Both** modes ask for confirmation first via `ProviderSwitchDialog` (they both
+spend tokens, scaling with the current conversation size), with mode-specific
+copy. The switch is staged only on confirm.
 
 The size decision is frontend-only — the context-window catalog lives in
 `app/src/lib/providers.ts` (`app/src/lib/provider-switch.ts::decideHandoffMode`).

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -502,6 +502,27 @@ summary failure the engine logs and falls back to a normal resume (the CLI's own
 auto-compaction is the backstop), so a turn never fails because compaction
 couldn't run.
 
+### Provider switch (`provider_switched`)
+
+`POST .../sessions` accepts an optional `providerSwitch: { mode: "replay" |
+"summarize", fromProvider }` (HOU-424). It is set by the client when the user
+moves a live conversation to a DIFFERENT provider mid-stream. Provider CLI
+sessions aren't portable, so the engine reseeds a FRESH session on the resolved
+(new) provider with prior context — the full transcript verbatim (`replay`) or
+an AI summary (`summarize`) — and clears any current resume id for the resolved
+provider so a switch-back never resumes a stale cross-provider session. It takes
+precedence over `compact`. The seed is built from the DB `chat_feed`, and the
+summary (for `summarize`) runs on the TARGET provider, so a switch away from an
+out-of-credits provider still works. Unlike `compact`, a switch seed failure is
+NOT swallowed: it surfaces as a `SessionStatus` error (beta no-silent-failure
+policy).
+
+The boundary is recorded as a `feed_type: "provider_switched"` item (`data: {
+provider, summarized, pre_tokens? }`, Rust `FeedItem::ProviderSwitched`),
+rendered as a subtle divider like `context_compacted`. `provider` is the
+provider switched TO; `summarized` distinguishes the verbatim carry from the
+summarized one. The full `chat_feed` above and below stays visible.
+
 ### Binary file downloads
 
 The `read-project` route returns text only. For xlsx, pdf, images,

--- a/ui/chat/src/feed-to-messages.ts
+++ b/ui/chat/src/feed-to-messages.ts
@@ -19,9 +19,18 @@ export interface FileChangeEntry {
   status: "created" | "modified";
 }
 
-/** Marks a `from: "system"` message as a context-compaction divider. */
+/** Marks a `from: "system"` message as a boundary divider — either a
+ *  context compaction or a mid-session provider switch. */
 export interface ChatCompactionInfo {
-  trigger: "native" | "proactive";
+  /** What produced this divider. */
+  kind: "compacted" | "provider_switch";
+  /** Compaction trigger. Set only when `kind === "compacted"`. */
+  trigger?: "native" | "proactive";
+  /** Provider switched TO. Set only when `kind === "provider_switch"`. */
+  provider?: string;
+  /** Whether a switch summarized prior context (`true`) or carried the full
+   *  conversation verbatim (`false`). Set only when `kind === "provider_switch"`. */
+  summarized?: boolean;
   preTokens?: number;
 }
 
@@ -256,7 +265,29 @@ export function feedItemsToMessages(items: FeedItem[]): ChatMessage[] {
           tools: [],
           fileChanges: [],
           compaction: {
+            kind: "compacted",
             trigger: item.data.trigger,
+            preTokens: item.data.pre_tokens ?? undefined,
+          },
+        });
+        break;
+      }
+
+      case "provider_switched": {
+        flush();
+        messages.push({
+          key: `provider-switched-${messages.length}`,
+          from: "system",
+          // Empty content — the renderer shows a localized divider keyed off
+          // `compaction`, not this string.
+          content: "",
+          isStreaming: false,
+          tools: [],
+          fileChanges: [],
+          compaction: {
+            kind: "provider_switch",
+            provider: item.data.provider,
+            summarized: item.data.summarized,
             preTokens: item.data.pre_tokens ?? undefined,
           },
         });

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -12,6 +12,7 @@ export type {
 export type {
   ToolEntry,
   ChatMessage,
+  ChatCompactionInfo,
   FileChangeEntry,
 } from "./feed-to-messages";
 export type { TurnEndSummary } from "./turn-tools";

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -24,6 +24,23 @@ export type FeedItem =
       data: { trigger: "native" | "proactive"; pre_tokens?: number | null };
     }
   | {
+      /**
+       * A provider-switch boundary. The conversation was handed to a different
+       * provider mid-session; the new provider ran a fresh session seeded with
+       * prior context — the full transcript (`summarized: false`) or an AI
+       * summary (`summarized: true`). Rendered as a subtle divider; the full
+       * chat above and below stays visible. `provider` is the provider switched
+       * TO. `pre_tokens` is how full the leaving provider's context was, when
+       * reported.
+       */
+      feed_type: "provider_switched";
+      data: {
+        provider: string;
+        summarized: boolean;
+        pre_tokens?: number | null;
+      };
+    }
+  | {
       feed_type: "file_changes";
       data: { created: string[]; modified: string[] };
     }

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -539,6 +539,19 @@ export interface SessionStartRequest {
    * when there's an existing session to compact; ignored on the first turn.
    */
   compact?: boolean;
+  /**
+   * Set when the user switches this conversation to a DIFFERENT provider
+   * mid-stream. Provider CLI sessions are not portable, so the engine reseeds
+   * a fresh session on the new provider with prior context: the full
+   * transcript verbatim (`mode: "replay"`) when it fits the new model's
+   * window, or an AI summary (`mode: "summarize"`) when it does not.
+   * `fromProvider` is the provider being left. Takes precedence over
+   * `compact`; absent for normal turns.
+   */
+  providerSwitch?: {
+    mode: "replay" | "summarize";
+    fromProvider: string;
+  };
 }
 
 export interface SessionStartResponse {


### PR DESCRIPTION
Closes #491. Linear: HOU-424.

## What

Lets users switch a **live** conversation to a different AI provider at any time. Until now the provider/model picker locked to the conversation's provider once it started.

Provider CLI sessions aren't portable (Claude's resume id means nothing to Codex), so the engine reseeds a **fresh** session on the new provider with prior context, sized against the new model's window:

- **Fits** → carry the full transcript over **verbatim** (lossless), one-time cost toast.
- **Doesn't fit** → **summarize** to fit, behind an explicit **consent dialog** (lossy + spends a summarizer call).

Both read Houston's own `chat_feed`, and the summary runs on the **target** provider — so switching away from an out-of-credits / rate-limited provider works (the handoff never touches the provider being left). Switching **back** to a provider whose session went stale reseeds rather than resuming a session missing the other provider's turns. A `provider_switched` divider marks the boundary; the full history stays visible.

## How

**Engine**
- `StartRequest.providerSwitch { mode: "replay" | "summarize", fromProvider }`, typed `SeedMode` parsing (bad mode → 400).
- `sessions::run_start` handoff block: reseeds fresh, **clears the resolved provider's stale resume id**, persists the divider anchored to a chat_feed id (timestamp-ordered), and emits `FeedItem::ProviderSwitched`.
- `compaction::build_replay_seed` (verbatim, no LLM) next to `build_compaction_seed` (summary).
- No silent blank-start: a seed failure — **including an empty summary** — returns `Err` and surfaces as a session error; a *successful* switch (even with no carryable history) always emits the divider.

**Frontend**
- Picker unlocked (removed the dead `lockedProvider` / `effectiveLock` plumbing).
- Size-aware decision (`provider-switch.ts`) + consent dialog (`provider-switch-dialog.tsx`).
- Staged handoff (`stores/provider-switch.ts`) is **peeked** on send and **cleared only on the `provider_switched` event**, so a failed switch retries on the next send; `fromProvider` stays the true leaving provider across re-picks.
- `provider_switched` divider (full-history vs summarized copy), en/es/pt strings.

## Review

Hardened against a 6-dimension adversarial multi-agent review (correctness, the out-of-credits case, frontend handoff lifecycle, no-silent-failure, Rust↔TS wire contract, quality/boundary). All 4 confirmed findings fixed: empty-summary now surfaces instead of silently dropping context; a successful switch always emits the divider so the handoff can't re-fire forever; the divider persists via a robust id fallback; `fromProvider` is stable across re-picks.

## Tests

`cargo test --workspace`, `pnpm typecheck` (all packages incl. app), `check-locales`, and the new unit/route tests all pass. (One pre-existing intermittent flake, `provider::login_relay::tests::device_auth_relay_emits_url_then_code`, is unrelated — a shared-global-state race in a module this PR doesn't touch.)

## Affected files

Engine: `houston-terminal-manager/src/types.rs`, `houston-agents-conversations/src/session_runner.rs`, `houston-engine-core/src/sessions/{mod,compaction}.rs`, `houston-engine-server/src/routes/sessions.rs` (+ test).
Frontend: `app/src/{lib/provider-switch.ts, stores/provider-switch.ts, lib/tauri.ts, hooks/use-session-events.ts, components/{use-agent-chat-panel,provider-switch-dialog,context-compacted-divider,chat-model-selector}.tsx, lib/model-picker.ts}`, `ui/chat/src/{types,feed-to-messages,index}.ts`, `ui/engine-client/src/types.ts`, locales en/es/pt.
Docs: `knowledge-base/{agent-manifest,engine-protocol}.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)