### PR TITLE
fix(chat): cap the open tool-call accordion so it doesn't take over the chat (HOU-426)

### DIFF
--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -29,6 +29,7 @@
     "nanoid": "^5.1.7"
   },
   "scripts": {
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "node --experimental-strip-types --test tests/*.test.ts"
   }
 }

--- a/ui/chat/src/chat-process-block.tsx
+++ b/ui/chat/src/chat-process-block.tsx
@@ -6,7 +6,9 @@ import {
   cn,
 } from "@houston-ai/core";
 import { ChevronDownIcon } from "lucide-react";
+import { useStickToBottom } from "use-stick-to-bottom";
 import { ChatStatusLine } from "./chat-status-line";
+import { processScrollPaneClass } from "./chat-process-classes";
 import {
   Reasoning,
   ReasoningContent,
@@ -59,6 +61,16 @@ export function ChatProcessBlock({
     wasActiveRef.current = isActive;
   }, [isActive]);
 
+  // While the agent works, tool calls stream into this one open accordion.
+  // Pin the latest one into view inside the height-capped pane so the user
+  // sees live progress without the list swallowing the conversation. The hook
+  // releases the lock the moment the user scrolls up to read an earlier step,
+  // and on a settled (re-opened) log it starts at the top instead of jumping.
+  const { scrollRef, contentRef } = useStickToBottom({
+    initial: isActive ? "instant" : false,
+    resize: "smooth",
+  });
+
   return (
     <Collapsible
       className="not-prose"
@@ -78,38 +90,42 @@ export function ChatProcessBlock({
       </CollapsibleTrigger>
       <CollapsibleContent
         className={cn(
-          "mt-3 space-y-3 text-sm text-muted-foreground outline-none",
+          "mt-3 text-sm text-muted-foreground outline-none",
           "data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2",
           "data-[state=open]:slide-in-from-top-2",
           "data-[state=closed]:animate-out data-[state=open]:animate-in",
         )}
       >
-        {segments.map((segment, index) => {
-          const isLastSegment = index === segments.length - 1;
-          const segmentActive = isActive && isLastSegment;
-          return (
-            <div key={segment.key} className="space-y-3">
-              {segment.reasoning && (
-                <Reasoning
-                  isStreaming={segmentActive && segment.reasoning.isStreaming}
-                  defaultOpen={segmentActive && segment.reasoning.isStreaming}
-                >
-                  <ReasoningTrigger getThinkingMessage={getThinkingMessage} />
-                  <ReasoningContent>{segment.reasoning.content}</ReasoningContent>
-                </Reasoning>
-              )}
-              {segment.tools.length > 0 && (
-                <ToolsAndCards
-                  tools={segment.tools}
-                  isStreaming={segmentActive}
-                  toolLabels={toolLabels}
-                  isSpecialTool={isSpecialTool}
-                  renderToolResult={renderToolResult}
-                />
-              )}
-            </div>
-          );
-        })}
+        <div ref={scrollRef} className={processScrollPaneClass}>
+          <div ref={contentRef} className="space-y-3">
+            {segments.map((segment, index) => {
+              const isLastSegment = index === segments.length - 1;
+              const segmentActive = isActive && isLastSegment;
+              return (
+                <div key={segment.key} className="space-y-3">
+                  {segment.reasoning && (
+                    <Reasoning
+                      isStreaming={segmentActive && segment.reasoning.isStreaming}
+                      defaultOpen={segmentActive && segment.reasoning.isStreaming}
+                    >
+                      <ReasoningTrigger getThinkingMessage={getThinkingMessage} />
+                      <ReasoningContent>{segment.reasoning.content}</ReasoningContent>
+                    </Reasoning>
+                  )}
+                  {segment.tools.length > 0 && (
+                    <ToolsAndCards
+                      tools={segment.tools}
+                      isStreaming={segmentActive}
+                      toolLabels={toolLabels}
+                      isSpecialTool={isSpecialTool}
+                      renderToolResult={renderToolResult}
+                    />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </div>
       </CollapsibleContent>
     </Collapsible>
   );

--- a/ui/chat/src/chat-process-classes.ts
+++ b/ui/chat/src/chat-process-classes.ts
@@ -1,0 +1,23 @@
+/**
+ * Pure class-name constants for the chat "process" block (reasoning + tool
+ * calls). Kept dependency-free (no React, no CSS imports) so the layout
+ * decisions can be asserted in a `node:test` unit test the same way
+ * `sidebar-classes.ts` is — see `tests/chat-process-pane.test.ts`.
+ */
+
+/**
+ * The scroll pane that wraps an *open* process block's content.
+ *
+ * Why a cap: while the agent is working its tool calls stream into one open
+ * accordion. Without a height cap that list grows unbounded and pushes the
+ * whole conversation off-screen (HOU-426 — "the tool calls take all the
+ * chat"). `max-h-80` bounds it and `overflow-y-auto` scrolls the overflow in
+ * place. Scroll-chaining is left on (no `overscroll-contain`): this is inline,
+ * in-flow content, so a wheel that reaches the pane's edge should keep
+ * scrolling the conversation rather than dead-end. `pr-1` keeps content clear
+ * of the scrollbar gutter (matters on Windows, where the bar takes space).
+ *
+ * Stick-to-bottom (the active tool stays in view) is wired separately via
+ * `useStickToBottom` in `chat-process-block.tsx`.
+ */
+export const processScrollPaneClass = "max-h-80 overflow-y-auto pr-1";

--- a/ui/chat/tests/chat-process-pane.test.ts
+++ b/ui/chat/tests/chat-process-pane.test.ts
@@ -1,0 +1,25 @@
+import { ok } from "node:assert";
+import { describe, it } from "node:test";
+import { processScrollPaneClass } from "../src/chat-process-classes.ts";
+
+function tokens(className: string): Set<string> {
+  return new Set(className.split(/\s+/).filter(Boolean));
+}
+
+function includes(className: string, token: string): boolean {
+  return tokens(className).has(token);
+}
+
+describe("chat process scroll pane", () => {
+  // HOU-426: while the agent works, tool calls stream into one open accordion.
+  // These tokens are what stop that list from growing unbounded and taking the
+  // whole conversation. If a refactor drops one, the bug comes back — so guard
+  // them explicitly.
+  it("caps the height so the open tool log cannot swallow the chat", () => {
+    ok(includes(processScrollPaneClass, "max-h-80"));
+  });
+
+  it("scrolls the overflow in place instead of growing the page", () => {
+    ok(includes(processScrollPaneClass, "overflow-y-auto"));
+  });
+});


### PR DESCRIPTION
## HOU-426 — tool calls take all the chat

### The ask
> Use an accordion to hold all the tool calls — open by default, but it shouldn't take all the chat, the user can easily hide it, and they still know the agent is working.

### What I found
The accordion **already exists**: `ChatProcessBlock` groups a turn's reasoning + tool calls into one collapsible that opens while the agent works (**"Mission in progress…"** with a shimmer), collapses to **"Mission log"** when the turn ends, and toggles via a chevron. Every tool call already routes through it.

The real gap: the **open** pane had **no height bound**. A long tool run grew an unbounded vertical list that pushed the whole conversation off-screen — that's the "takes all the chat" the issue describes. The collapse-when-done and hide-via-chevron parts already worked.

### The fix
Wrap the open content in a height-capped, scroll-in-place pane and pin the latest tool into view with `useStickToBottom` (the same library the outer conversation already uses).

- ✅ **Opened by default** — unchanged; opens while active.
- ✅ **Doesn't take all the chat** — `max-h-80` (320px) cap + internal scroll.
- ✅ **Still knows the agent is working** — the latest tool stays pinned in view; the "Mission in progress…" shimmer is untouched.
- ✅ **Easily hide it** — chevron toggle, unchanged.

Stick-to-bottom releases the lock the moment the user scrolls up to read an earlier step, and a settled (re-opened) "Mission log" starts at the top instead of jumping. Scroll-chaining is left on — this is inline content, not an overlay, so a wheel that reaches the pane's edge keeps scrolling the conversation.

### Files
- `ui/chat/src/chat-process-classes.ts` *(new)* — pure, dependency-free module holding the capped scroll-pane class, so the layout decision is unit-testable the same way `sidebar-classes.ts` is.
- `ui/chat/src/chat-process-block.tsx` — wire `useStickToBottom` + the capped pane around the segment list.
- `ui/chat/tests/chat-process-pane.test.ts` *(new)* — `node:test` token guard so a future refactor can't silently drop the cap and regress HOU-426; adds the package `test` script.

### Verification
- `pnpm --filter @houston-ai/chat test` → 2 passing.
- `pnpm --filter @houston-ai/chat typecheck` → clean.
- `app` `pnpm tsc --noEmit` → clean (consumer; `ChatProcessBlock` props unchanged).
- Visual check still recommended in the running app (active long-tool-run + reviewing a completed Mission log).

🤖 Generated with [Claude Code](https://claude.com/claude-code)