### PR TITLE
fix(chat): show user message, not raw skill marker, in mission card (HOU-425)

### DIFF
--- a/app/src/components/board/use-agent-board-data.ts
+++ b/app/src/components/board/use-agent-board-data.ts
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { KanbanItem } from "@houston-ai/board";
-import { mergeFeedHistory } from "@houston-ai/chat";
+import { mergeFeedHistory, messagePreviewText } from "@houston-ai/chat";
 import type { FeedItem } from "@houston-ai/chat";
 
 import { useFeedStore } from "../../stores/feeds";
@@ -54,7 +54,9 @@ export function useAgentBoardData({
       activeRaw.map((activity) => ({
         id: activity.id,
         title: activity.title,
-        description: activity.description,
+        // A Skill / attachment first message persists as a marker; show the
+        // user's words on the card, never the raw `<!--houston:...-->` (HOU-425).
+        description: messagePreviewText(activity.description),
         status: activity.status,
         updatedAt: activity.updated_at ?? new Date().toISOString(),
         group: agent.name,

--- a/app/src/components/board/use-mission-control-archived.ts
+++ b/app/src/components/board/use-mission-control-archived.ts
@@ -1,7 +1,7 @@
 import { createElement, useCallback, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { KanbanItem } from "@houston-ai/board";
-import { mergeFeedHistory } from "@houston-ai/chat";
+import { mergeFeedHistory, messagePreviewText } from "@houston-ai/chat";
 import type { FeedItem } from "@houston-ai/chat";
 import { useFeedStore } from "../../stores/feeds";
 import { useAllConversations } from "../../hooks/queries";
@@ -68,7 +68,9 @@ export function useMissionControlArchived(agents: Agent[]) {
         return {
           id: c.id,
           title: c.title,
-          description: c.description,
+          // Decode a Skill / attachment first-message marker to the user's
+          // words; never echo the raw `<!--houston:...-->` on the card (HOU-425).
+          description: messagePreviewText(c.description),
           group: c.agent_name,
           icon: createElement(AgentCardAvatar, { color: agentColorMap[c.agent_path] }),
           status: c.status!,

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { AIBoard } from "@houston-ai/board";
 import type { KanbanItem } from "@houston-ai/board";
-import { mergeFeedHistory } from "@houston-ai/chat";
+import { mergeFeedHistory, messagePreviewText } from "@houston-ai/chat";
 import type { FeedItem } from "@houston-ai/chat";
 
 import { useFeedStore } from "../../stores/feeds";
@@ -49,7 +49,9 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
       archived.map((a) => ({
         id: a.id,
         title: a.title,
-        description: a.description,
+        // Decode a Skill / attachment first-message marker to the user's words;
+        // never echo the raw `<!--houston:...-->` on the card (HOU-425).
+        description: messagePreviewText(a.description),
         status: a.status,
         updatedAt: a.updated_at ?? new Date().toISOString(),
         group: agent.name,

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -1,7 +1,7 @@
 import { useState, useCallback, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import type { KanbanItem } from "@houston-ai/board";
-import { mergeFeedHistory } from "@houston-ai/chat";
+import { mergeFeedHistory, messagePreviewText } from "@houston-ai/chat";
 import type { FeedItem } from "@houston-ai/chat";
 import { useFeedStore } from "../stores/feeds";
 import {
@@ -99,7 +99,9 @@ export function useMissionControl(agents: Agent[]) {
         return {
           id: c.id,
           title: c.title,
-          description: c.description,
+          // Decode a Skill / attachment first-message marker to the user's
+          // words; never echo the raw `<!--houston:...-->` on the card (HOU-425).
+          description: messagePreviewText(c.description),
           group: c.agent_name,
           icon: createElement(AgentCardAvatar, { color: agentColorMap[c.agent_path] }),
           status: c.status!,

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -127,6 +127,7 @@ Focus on pricing.
 - If files were uploaded with the Skill, `attachments` carries `{name,path}` entries. The renderer shows only the count badge; the Claude-facing body still contains the `[User attached these files...]` path block.
 - Decoder lives in `@houston-ai/chat`'s `skill-message.ts` so desktop AND mobile render the same card from the same payload. The decoder also accepts a legacy `<!--houston:action ...-->` prefix so chat history persisted before the rename keeps rendering as a card.
 - Encoder (`encodeSkillMessage`) + Claude-prompt assembler (`buildSkillClaudePrompt`) live in `app/src/lib/skill-message.ts` — only the desktop sends Skills today.
+- The persisted body is also the activity's `description`, which surfaces as the **mission-card / archived-list subtitle**. Those mapping sites run it through `@houston-ai/chat`'s `messagePreviewText` so the card shows the user's words (or the Skill's one-line description when sent on its own), never the raw `<!--houston:skill ...-->` marker. This was HOU-425: a Skill sent as the first message rendered the marker JSON as the card subtitle.
 
 ## Attachment message marker (chat persistence)
 
@@ -210,4 +211,5 @@ The engine applies the rename per workspace on the next sync. If only the old sl
 | Selected Skill chip | [`app/src/components/selected-skill-chip.tsx`](../app/src/components/selected-skill-chip.tsx) |
 | Card on user message | [`app/src/components/user-skill-message.tsx`](../app/src/components/user-skill-message.tsx) (desktop) and [`mobile/src/components/user-skill-message.tsx`](../mobile/src/components/user-skill-message.tsx) |
 | Marker codec | [`ui/chat/src/skill-message.ts`](../ui/chat/src/skill-message.ts) (decode) and [`app/src/lib/skill-message.ts`](../app/src/lib/skill-message.ts) (encode) |
+| Card/list preview text | [`ui/chat/src/message-preview.ts`](../ui/chat/src/message-preview.ts) — `messagePreviewText` decodes a marker → mission-card subtitle (HOU-425) |
 | System prompt template | [`app/src-tauri/src/houston_prompt/skills_memory.rs`](../app/src-tauri/src/houston_prompt/skills_memory.rs) (`SELF_IMPROVEMENT_GUIDANCE`) |

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -29,6 +29,7 @@
     "nanoid": "^5.1.7"
   },
   "scripts": {
+    "test": "node --experimental-strip-types --test tests/*.test.ts",
     "typecheck": "tsc --noEmit"
   }
 }

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -209,6 +209,9 @@ export { decodeSkillMessage, resolveSkillImage } from "./skill-message";
 export type { SkillInvocation, SkillInvocationField } from "./skill-message";
 export { decodeAttachmentMessage, normalizeAttachmentReferences } from "./attachment-message";
 export type { AttachmentInvocation, AttachmentReference } from "./attachment-message";
+// Clean, human-readable preview of a persisted user-message body: decodes the
+// Skill / attachment markers so cards and lists never show the raw marker.
+export { messagePreviewText } from "./message-preview";
 export {
   UserAttachmentBadge,
   UserAttachmentMessage,

--- a/ui/chat/src/message-preview.ts
+++ b/ui/chat/src/message-preview.ts
@@ -1,0 +1,42 @@
+/**
+ * Short, human-readable preview of a persisted user-message body.
+ *
+ * Skill and attachment invocations persist a leading HTML-comment marker
+ * (`<!--houston:skill ...-->` / `<!--houston:attachments ...-->`) followed by
+ * the model-facing prompt. Rendering that body verbatim on a card or list
+ * leaks the raw marker JSON to the user — e.g. a mission card whose first
+ * message ran a Skill showed `<!--houston:skill {"skill":"set-up-my-...`
+ * instead of what the user actually asked for (HOU-425).
+ *
+ * This decodes the body the same way the chat does and returns clean text:
+ *  - Skill: the text the user typed; when they sent the Skill on its own,
+ *    the Skill's one-line description (never the slug/marker). Falls through
+ *    to "" so the surface can hide an empty subtitle rather than echo the
+ *    card title.
+ *  - Attachment: the text the user typed (absolute paths stay hidden).
+ *  - Plain text: returned unchanged.
+ *
+ * Lives next to the marker decoders so every consumer (mission cards,
+ * archived lists, future embedded chats) derives the same preview.
+ */
+
+import { decodeSkillMessage } from "./skill-message.ts";
+import { decodeAttachmentMessage } from "./attachment-message.ts";
+
+export function messagePreviewText(body: string | null | undefined): string {
+  if (!body) return "";
+
+  const skill = decodeSkillMessage(body);
+  if (skill) {
+    const message = skill.message.trim();
+    if (message) return message;
+    // Skill sent with no composer text: the one-line description reads as a
+    // human subtitle. "" when absent → the card simply hides the line.
+    return skill.description.trim();
+  }
+
+  const attachment = decodeAttachmentMessage(body);
+  if (attachment) return attachment.message.trim();
+
+  return body;
+}

--- a/ui/chat/tests/message-preview.test.ts
+++ b/ui/chat/tests/message-preview.test.ts
@@ -1,0 +1,88 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "node:test"
+import { messagePreviewText } from "../src/message-preview.ts"
+
+const skillBody = (payload: Record<string, unknown>, prompt: string): string =>
+  `<!--houston:skill ${JSON.stringify(payload)}-->\n\n${prompt}`
+
+const attachmentBody = (payload: Record<string, unknown>, prompt: string): string =>
+  `<!--houston:attachments ${JSON.stringify(payload)}-->\n\n${prompt}`
+
+describe("messagePreviewText", () => {
+  it("returns the user's composer text for a Skill run with a message", () => {
+    const body = skillBody(
+      {
+        skill: "set-up-my-books",
+        displayName: "Set up my books",
+        description: "Get your bookkeeping organized",
+        message: "Use last quarter's statements",
+      },
+      "Use the set-up-my-books skill.\n\nUse last quarter's statements",
+    )
+    assert.equal(messagePreviewText(body), "Use last quarter's statements")
+  })
+
+  it("falls back to the Skill description when sent on its own", () => {
+    // The exact regression from HOU-425: a Skill sent without composer text
+    // must never surface the raw `<!--houston:skill ...-->` marker.
+    const body = skillBody(
+      {
+        skill: "set-up-my-books",
+        displayName: "Set up my books",
+        description: "Get your bookkeeping organized",
+        message: "",
+      },
+      "Use the set-up-my-books skill.",
+    )
+    const preview = messagePreviewText(body)
+    assert.equal(preview, "Get your bookkeeping organized")
+    assert.ok(!preview.includes("houston:skill"))
+  })
+
+  it("returns empty string when a Skill has neither message nor description", () => {
+    const body = skillBody(
+      { skill: "set-up-my-books", displayName: "Set up my books" },
+      "Use the set-up-my-books skill.",
+    )
+    assert.equal(messagePreviewText(body), "")
+  })
+
+  it("trims surrounding whitespace from the Skill message", () => {
+    const body = skillBody(
+      { skill: "draft-an-nda", message: "   focus on mutual terms  " },
+      "Use the draft-an-nda skill.",
+    )
+    assert.equal(messagePreviewText(body), "focus on mutual terms")
+  })
+
+  it("returns the user's text for an attachment message, never the file paths", () => {
+    const body = attachmentBody(
+      {
+        message: "Summarize this",
+        files: [{ name: "brief.pdf", path: "/Users/x/brief.pdf" }],
+      },
+      "Summarize this\n\n[User attached these files...]",
+    )
+    const preview = messagePreviewText(body)
+    assert.equal(preview, "Summarize this")
+    assert.ok(!preview.includes("/Users/"))
+  })
+
+  it("returns empty string for files sent with no text", () => {
+    const body = attachmentBody(
+      { message: "", files: [{ name: "brief.pdf", path: "/Users/x/brief.pdf" }] },
+      "[User attached these files...]",
+    )
+    assert.equal(messagePreviewText(body), "")
+  })
+
+  it("returns plain message bodies unchanged", () => {
+    assert.equal(messagePreviewText("Review my Q3 numbers"), "Review my Q3 numbers")
+  })
+
+  it("treats empty / null / undefined as empty", () => {
+    assert.equal(messagePreviewText(""), "")
+    assert.equal(messagePreviewText(null), "")
+    assert.equal(messagePreviewText(undefined), "")
+  })
+})


### PR DESCRIPTION
## HOU-425

A mission whose **first message** ran a Skill showed the raw marker JSON as its card subtitle instead of what the user asked for:

> `<!--houston:skill {"skill":"set-up-my-books","displayName":"Set up my...`

## Root cause

A Skill / attachment invocation persists as a `<!--houston:skill ...-->` (or `…attachments…`) marker body. That body is also stored as the activity's `description`, and four app sites map `activity.description` straight onto a `KanbanItem` → rendered verbatim as the card / list subtitle (`kanban-card.tsx`). The card **title** was already overridden clean (the friendly Skill name); only the subtitle leaked the marker. The chat itself was always fine — `renderUserMessage` decodes the marker to a card.

## Fix

Add `messagePreviewText` to `@houston-ai/chat`, next to the existing marker decoders. It turns a stored body into clean preview text:

- **Skill** → the user's composer text; when the Skill was sent on its own, the Skill's one-line description (never the slug/marker).
- **Attachment** → the user's typed text (absolute paths stay hidden).
- **Plain text** → unchanged.

Applied at the four mapping sites. Render-layer fix, so **existing** missions render cleanly with no data migration.

## Affected files

- `ui/chat/src/message-preview.ts` — new helper
- `ui/chat/src/index.ts` — export it
- `ui/chat/package.json` — add the `test` script (package had none)
- `ui/chat/tests/message-preview.test.ts` — 8 unit tests
- `app/src/components/board/use-agent-board-data.ts` — per-agent board (the screenshot's surface)
- `app/src/components/use-mission-control.ts` — cross-agent board
- `app/src/components/board/use-mission-control-archived.ts` — cross-agent archived
- `app/src/components/tabs/archived-tab.tsx` — per-agent archived
- `knowledge-base/skills.md` — document the preview helper

## Tests

- `ui/chat` unit tests: 8 pass (`node --experimental-strip-types --test`)
- `ui/chat` typecheck: clean
- `app` typecheck (`pnpm tsc --noEmit`): clean

Mobile mission cards show only the title, so no mobile change was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)