### PR TITLE
release: v0.4.22

### DIFF
--- a/.github/release-notes/0.4.22.es.md
+++ b/.github/release-notes/0.4.22.es.md
@@ -1,6 +1,6 @@
 ## Houston 0.4.22
 
-Una versión sobre elegir y recuperarte. Cambia la IA detrás de un chat sin empezar de nuevo, dale a cada tarea programada su propio cerebro y recibe avisos más claros cuando un proveedor necesita que vuelvas a conectarte. Se instala sobre 0.4.21, sin cambios que rompan nada.
+Más control sobre la IA y mejor recuperación cuando algo falla. Cambia de proveedor en medio de un chat sin empezar de cero, deja que cada tarea programada elija su propio proveedor, modelo y nivel de esfuerzo, y recibe avisos más claros cuando un proveedor te pide volver a conectarte. Se instala sobre 0.4.21, sin cambios que rompan nada.
 
 ### Agregado
 

--- a/.github/release-notes/0.4.22.es.md
+++ b/.github/release-notes/0.4.22.es.md
@@ -1,0 +1,22 @@
+## Houston 0.4.22
+
+Una versión sobre elegir y recuperarte. Cambia la IA detrás de un chat sin empezar de nuevo, dale a cada tarea programada su propio cerebro y recibe avisos más claros cuando un proveedor necesita que vuelvas a conectarte. Se instala sobre 0.4.21, sin cambios que rompan nada.
+
+### Agregado
+
+- **Cambia la IA a mitad de la conversación.** Puedes mover un chat en curso a otro proveedor de IA en cualquier momento sin perder el hilo. Houston lleva tu conversación al nuevo proveedor: el historial completo cuando cabe, o un resumen corto (con tu permiso) cuando no. Útil cuando un proveedor se queda sin crédito, o simplemente quieres una segunda opinión a mitad de camino.
+- **Cada tarea programada puede elegir su propia IA.** Las rutinas ahora pueden elegir su propio proveedor, modelo y nivel de esfuerzo en lugar de heredar siempre el predeterminado del agente. Fija un modelo más rápido y económico para un chequeo de rutina, o uno de mayor esfuerzo para el trabajo semanal pesado. Si no lo tocas, sigue al agente.
+
+### Corregido
+
+- **Houston elige la IA que de verdad usas.** Los agentes sin proveedor configurado solían recurrir a Claude, lo que fallaba si solo usas OpenAI. Ahora Houston recurre a tu proveedor más reciente o al único que tienes conectado, así los agentes de la Tienda, las tareas programadas y los envíos rápidos arrancan con la IA correcta.
+- **Un aviso claro para volver a conectar en OpenAI.** Cuando OpenAI termina tu sesión desde su lado, el chat mostraba un borde rojo pero sin forma de arreglarlo, y cualquier pista desaparecía al recargar. Ahora tienes el mismo botón de reconexión integrado que Claude ya tenía, y se queda hasta que vuelves a conectarte.
+- **Mensajes más claros cuando Claude tiene el límite de solicitudes.** Una respuesta de "demasiadas solicitudes" de Claude solía aparecer como un error desconocido con un botón de "Reportar error", a veces duplicado. Ahora se lee correctamente como un límite temporal, mostrado una sola vez.
+- **Tu propio mensaje aparece en la tarjeta de misión.** Iniciar una tarea desde una habilidad solía mostrar un marcador interno en bruto en lugar de lo que escribiste. La tarjeta de misión ahora muestra tu mensaje.
+- **Los pasos de herramientas ya no acaparan el chat.** Una lista larga de los pasos de herramientas de un agente podía expandirse y desplazar la conversación. Ese panel ahora tiene un límite, así el chat sigue siendo legible.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza una app en ejecución de forma limpia. Si tienes dudas, elimina `/Applications/Houston.app` y arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde la 0.4.7 o posterior te lleva adelante sola. El MSI aún no está firmado a nivel del sistema operativo (la integración con SignPath sigue pendiente), por lo que Windows SmartScreen puede mostrar una advertencia en una instalación nueva.
+- **Windows ARM64:** no hay actualización automática desde una instalación x64 emulada. Descarga el MSI ARM64 manualmente, desinstala primero la versión x64 y luego instala la ARM64.

--- a/.github/release-notes/0.4.22.md
+++ b/.github/release-notes/0.4.22.md
@@ -1,0 +1,22 @@
+## Houston 0.4.22
+
+A release about choice and recovery. Switch the AI behind a chat without starting over, give each scheduled task its own brain, and get clearer prompts when a provider needs you to reconnect. Drop-in on top of 0.4.21, no breaking changes.
+
+### Added
+
+- **Switch the AI mid-conversation.** You can move a live chat to a different AI provider at any time without losing the thread. Houston carries your conversation over to the new provider: the full history when it fits, or a short summary (with your go-ahead) when it does not. Handy when one provider runs out of credit, or you just want a second opinion partway through.
+- **Each scheduled task can pick its own AI.** Routines can now choose their own provider, model, and effort level instead of always inheriting the agent's default. Pin a faster, cheaper model for a routine check-in, or a higher-effort one for the heavy weekly job. Leave it untouched and it keeps following the agent.
+
+### Fixed
+
+- **Houston picks the AI you actually use.** Agents with no provider set used to fall back to Claude, which failed if you only use OpenAI. Houston now falls back to your last-used or only connected provider, so agents from the Store, scheduled tasks, and quick sends all start on the right AI.
+- **A clear reconnect prompt for OpenAI.** When OpenAI ends your login session on their side, the chat showed a red border but no way to fix it, and any hint vanished on reload. Now you get the same inline reconnect button Claude already had, and it sticks around until you reconnect.
+- **Clearer messages when Claude is rate-limited.** A Claude "too many requests" response used to show up as an unknown error with a "Report bug" button, sometimes doubled. It now reads correctly as a temporary rate limit, shown just once.
+- **Your own message shows in the mission card.** Starting a task from a skill used to show a raw behind-the-scenes marker instead of what you wrote. The mission card now shows your message.
+- **Tool steps no longer take over the chat.** A long list of an agent's tool steps could expand and crowd out the conversation. That panel is now capped, so the chat stays readable.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward automatically. The MSI is still not OS-code-signed (SignPath integration still pending), so Windows SmartScreen may warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install. Download the ARM64 MSI manually, uninstall the x64 build first, then install the ARM64 one.

--- a/.github/release-notes/0.4.22.pt.md
+++ b/.github/release-notes/0.4.22.pt.md
@@ -1,0 +1,22 @@
+## Houston 0.4.22
+
+Uma versão sobre escolha e recuperação. Troque a IA por trás de um chat sem começar do zero, dê a cada tarefa agendada o próprio cérebro e receba avisos mais claros quando um provedor precisa que você reconecte. Instala por cima da 0.4.21, sem mudanças que quebrem nada.
+
+### Adicionado
+
+- **Troque a IA no meio da conversa.** Você pode mover um chat em andamento para outro provedor de IA a qualquer momento sem perder o fio. O Houston leva sua conversa para o novo provedor: o histórico completo quando cabe, ou um resumo curto (com a sua autorização) quando não cabe. Útil quando um provedor fica sem crédito, ou você só quer uma segunda opinião no meio do caminho.
+- **Cada tarefa agendada pode escolher a própria IA.** As rotinas agora podem escolher o próprio provedor, modelo e nível de esforço em vez de sempre herdar o padrão do agente. Fixe um modelo mais rápido e econômico para uma checagem de rotina, ou um de maior esforço para o trabalho semanal pesado. Se você não mexer, ela continua seguindo o agente.
+
+### Corrigido
+
+- **O Houston escolhe a IA que você realmente usa.** Agentes sem provedor configurado costumavam recorrer ao Claude, o que falhava se você só usa o OpenAI. Agora o Houston recorre ao seu provedor mais recente ou ao único que você tem conectado, então os agentes da Loja, as tarefas agendadas e os envios rápidos começam com a IA certa.
+- **Um aviso claro para reconectar no OpenAI.** Quando o OpenAI encerra a sua sessão do lado deles, o chat mostrava uma borda vermelha mas sem como resolver, e qualquer dica sumia ao recarregar. Agora você tem o mesmo botão de reconexão embutido que o Claude já tinha, e ele fica ali até você reconectar.
+- **Mensagens mais claras quando o Claude está com limite de solicitações.** Uma resposta de "muitas solicitações" do Claude costumava aparecer como um erro desconhecido com um botão de "Relatar erro", às vezes duplicado. Agora ela aparece corretamente como um limite temporário, mostrado uma única vez.
+- **Sua própria mensagem aparece no cartão de missão.** Iniciar uma tarefa a partir de uma habilidade costumava mostrar um marcador interno em vez do que você escreveu. O cartão de missão agora mostra a sua mensagem.
+- **Os passos de ferramentas não dominam mais o chat.** Uma lista longa dos passos de ferramentas de um agente podia expandir e empurrar a conversa para fora. Esse painel agora tem um limite, então o chat continua legível.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui um app em execução de forma limpa. Na dúvida, remova `/Applications/Houston.app` e arraste a cópia nova.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou posterior te leva adiante sozinha. O MSI ainda não é assinado no nível do sistema operacional (a integração com o SignPath segue pendente), então o Windows SmartScreen pode avisar em uma instalação nova.
+- **Windows ARM64:** não há atualização automática a partir de uma instalação x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a versão x64 e depois instale a ARM64.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.21", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.21", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.21", path = "app/houston-tauri" }
-houston-events = { version = "0.4.21", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.21", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.21", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.21", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.21", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.21", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.21", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.21", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.21", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.21", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.21", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.21", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.21", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.21", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.21", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.22", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.22", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.22", path = "app/houston-tauri" }
+houston-events = { version = "0.4.22", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.22", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.22", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.22", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.22", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.22", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.22", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.22", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.22", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.22", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.22", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.22", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.22", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.22", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.22", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.21"
+version = "0.4.22"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.21",
+  "version": "0.4.22",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Release v0.4.22

Version bump (all packages `0.4.21` → `0.4.22`) plus hand-written release notes in EN/ES/PT. No code changes; this is the release cut for the six PRs already merged to `main` since `v0.4.21`.

### What ships (since v0.4.21)
- **Switch AI provider mid-conversation** (#493, HOU-424)
- **Per-routine provider + model + effort selection; unified routine surface** (#492, HOU-418)
- **Authenticated provider fallback for no-config agents; honor explicit provider** (#484, #483)
- **OpenAI session-ended reconnect card; classify Claude 429s** (#490)
- **Mission card shows user message, not raw skill marker** (#495, HOU-425)
- **Cap open tool-call accordion so it doesn't take over the chat** (#494, HOU-426)

### Changed files
- Version bump: root `Cargo.toml` (houston-* path deps), all `engine/*/Cargo.toml`, `app/{src-tauri,houston-tauri}/Cargo.toml`, `package.json`, `app/package.json`, all bumped `ui/*/package.json` (via `./scripts/version.sh 0.4.22`).
- New notes: `.github/release-notes/0.4.22.md` (+ `.es.md`, `.pt.md`).

### Review notes / how to ship
- Notes are user-facing copy: plain language, no em dashes, ES = neutral Latin-American, PT = Brazilian. Polish here before merge if needed.
- **This PR does not tag.** Per the `/release` flow, after you merge to `main`, push the tag (`git tag v0.4.22 && git push origin v0.4.22`) to kick off the build/sign/notarize CI, which creates a **draft** GitHub Release using `0.4.22.md` verbatim. The release stays a draft until you click Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)