### PR TITLE
fix(engine): unbreak 0.4.22 build — import Provider in sessions route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "futures-util",
  "hex",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "serde",
  "serde_json",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "dirs 5.0.1",
  "houston-cli-bundle",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.21"
+version = "0.4.22"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/engine/houston-engine-server/src/routes/sessions.rs
+++ b/engine/houston-engine-server/src/routes/sessions.rs
@@ -27,6 +27,7 @@ use houston_engine_core::sessions::{
     summarize, SessionRuntime, StartParams,
 };
 use houston_engine_core::CoreError;
+use houston_terminal_manager::Provider;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 


### PR DESCRIPTION
## Hotfix: 0.4.22 release build failed to compile

The `v0.4.22` release run failed on the macOS engine compile:

```
error[E0425]: cannot find type `Provider` in this scope
  --> engine/houston-engine-server/src/routes/sessions.rs:154:32
```

### Cause
`routes/sessions.rs` parses the provider-switch handoff (`let from_provider: Provider = sw.from_provider.parse()...`, added in #493) but never imports `Provider`. Two provider PRs (#493, #490/#484) merged green independently; their combined merge on `main` left the type unimported — the classic "both PRs pass, main is red." The version bump (#496) forced the first full release compile, which surfaced it.

### Fix
- Add `use houston_terminal_manager::Provider;` to `routes/sessions.rs` (keeps the documented type annotation on the parse).
- Regenerate `Cargo.lock` to the 0.4.22 workspace versions. The release bump (#496) missed this because `scripts/version.sh` only rewrites `Cargo.toml`; this matches the `v0.4.21` release commit pattern and removes the `Cargo.toml`/`Cargo.lock` version skew on `main`.

### Verification
- `cargo check --workspace --exclude houston-app` → green (`houston-app` only fails on the dev-only missing staged sidecar resource, unrelated).
- `cargo check -p houston-engine-server` → green.
- `cargo test -p houston-engine-server` → all suites pass.

After merge, the `v0.4.22` tag is moved to the new `main` tip to re-trigger the release build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)