### PR TITLE
fix(composio): stop --key credential leaking into logs and Sentry (HOU-431)

### DIFF
--- a/app/src/hooks/use-composio-auth.ts
+++ b/app/src/hooks/use-composio-auth.ts
@@ -55,7 +55,10 @@ export function useComposioAuth(onSuccess: () => void | Promise<void>) {
       // 1. Get the login URL from the backend.
       logger.info("[composio-auth] calling startOAuth...");
       const { login_url, cli_key } = await tauriConnections.startOAuth();
-      logger.info(`[composio-auth] startOAuth returned: url=${login_url} key=${cli_key}`);
+      // Never log `cli_key`: it is the login-session credential later passed
+      // to the engine as `--key`, and frontend.log is bundled into bug
+      // reports (HOU-431).
+      logger.info(`[composio-auth] startOAuth returned: url=${login_url}`);
 
       // 2. ALWAYS surface the URL and open the browser — no stale-gen
       //    check here. Even if the component re-rendered during the

--- a/app/src/hooks/use-composio-auth.ts
+++ b/app/src/hooks/use-composio-auth.ts
@@ -58,10 +58,13 @@ export function useComposioAuth(onSuccess: () => void | Promise<void>) {
       // 1. Get the login URL from the backend.
       logger.info("[composio-auth] calling startOAuth...");
       const { login_url, cli_key } = await tauriConnections.startOAuth();
-      // Never log `cli_key`: it is the login-session credential later passed
-      // to the engine as `--key`, and frontend.log is bundled into bug
-      // reports (HOU-431).
-      logger.info(`[composio-auth] startOAuth returned: url=${login_url}`);
+      // Never log `cli_key` OR the raw `login_url`: the URL embeds the same
+      // secret as a `?cliKey=<cli_key>` query param. Strip the query string so
+      // only host + path is logged; frontend.log is bundled into bug reports
+      // (HOU-431).
+      logger.info(
+        `[composio-auth] startOAuth returned: url=${login_url.replace(/[?#].*$/, "")}`,
+      );
 
       // 2. ALWAYS surface the URL and open the browser — no stale-gen
       //    check here. Even if the component re-rendered during the

--- a/engine/houston-composio/src/cli.rs
+++ b/engine/houston-composio/src/cli.rs
@@ -135,7 +135,15 @@ pub async fn start_login() -> Result<StartLoginResponse, String> {
                 .map_err(|e| format!("Failed to read login output: {e}"))?;
             let _ = std::fs::remove_file(&tmp);
 
-            tracing::info!("[composio:cli] start_login stdout: {}", stdout.trim());
+            // Do NOT log the raw stdout: it is the `{login_url, cli_key}`
+            // JSON, and `cli_key` is the login-session credential that
+            // `complete_login` later passes as `--key` (HOU-431). Log only
+            // its size so "CLI returned something" is still distinguishable
+            // from "CLI returned nothing".
+            tracing::info!(
+                "[composio:cli] start_login returned {} bytes",
+                stdout.trim().len()
+            );
             Ok(stdout)
         }),
     )
@@ -341,7 +349,7 @@ async fn run_cli_with_timeout(
     tracing::debug!(
         "[composio:cli] → spawn {:?} {:?} (timeout={:?})",
         bin,
-        args,
+        redact_secret_args(args),
         timeout
     );
 
@@ -372,7 +380,8 @@ async fn run_cli_with_timeout(
         Ok(Err(e)) => Err(format!("Failed to spawn composio CLI: {e}")),
         Err(_) => Err(format!(
             "composio CLI timed out after {:?}: args={:?}",
-            timeout, args
+            timeout,
+            redact_secret_args(args)
         )),
     };
 
@@ -387,7 +396,7 @@ async fn run_cli_with_timeout(
                 stdout_len,
                 stderr_len,
                 elapsed,
-                args
+                redact_secret_args(args)
             );
             if stdout_len > 0 && stdout_len < 2048 {
                 tracing::debug!(
@@ -411,6 +420,31 @@ async fn run_cli_with_timeout(
         }
     }
     result
+}
+
+/// Mask secret-bearing argv values before an arg list is formatted into a
+/// log line or a returned error string. `composio login --key <cli_key>`
+/// puts a login-session credential on argv; without this it rode into
+/// `backend.log`, the timeout error string, and from there into Sentry
+/// (HOU-431). Returns owned `String`s safe to `{:?}`-format. Handles both
+/// the separated (`--key`, `<value>`) and joined (`--key=<value>`) forms.
+fn redact_secret_args(args: &[&str]) -> Vec<String> {
+    let mut out = Vec::with_capacity(args.len());
+    let mut redact_next = false;
+    for &arg in args {
+        if redact_next {
+            out.push("<redacted>".to_string());
+            redact_next = false;
+        } else if arg == "--key" {
+            out.push(arg.to_string());
+            redact_next = true;
+        } else if arg.starts_with("--key=") {
+            out.push("--key=<redacted>".to_string());
+        } else {
+            out.push(arg.to_string());
+        }
+    }
+    out
 }
 
 fn cli_binary() -> Result<PathBuf, String> {
@@ -795,6 +829,39 @@ fn decorate_windows_exit(command: &str, status_display: &str, exit_code: Option<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn redact_secret_args_masks_separated_key() {
+        let args = [
+            "login",
+            "--key",
+            "cf7f2461-f693-4f65-95bf-6d110f1d4344",
+            "--no-skill-install",
+            "-y",
+        ];
+        let red = redact_secret_args(&args);
+        assert_eq!(
+            red,
+            vec!["login", "--key", "<redacted>", "--no-skill-install", "-y"]
+        );
+        // The Debug-formatted form is what reached Sentry — it must be clean.
+        assert!(!format!("{red:?}").contains("cf7f2461"));
+    }
+
+    #[test]
+    fn redact_secret_args_masks_joined_key() {
+        let args = ["login", "--key=super-secret", "-y"];
+        assert_eq!(
+            redact_secret_args(&args),
+            vec!["login", "--key=<redacted>", "-y"]
+        );
+    }
+
+    #[test]
+    fn redact_secret_args_passes_through_non_key() {
+        assert_eq!(redact_secret_args(&["whoami"]), vec!["whoami"]);
+        assert_eq!(redact_secret_args(&["logout"]), vec!["logout"]);
+    }
 
     #[test]
     fn decorates_illegal_instruction() {

--- a/engine/houston-composio/src/cli.rs
+++ b/engine/houston-composio/src/cli.rs
@@ -158,10 +158,11 @@ pub async fn start_login() -> Result<StartLoginResponse, String> {
     }
 
     let payload: Payload = serde_json::from_str(result.trim()).map_err(|e| {
-        format!(
-            "Unexpected composio login --no-wait output: {e}\nstdout: {}",
-            result.trim()
-        )
+        // Do NOT echo the raw stdout: it is the `{login_url, cli_key}` payload
+        // and both fields carry the login-session secret (`login_url` embeds
+        // it as `?cliKey=`). The serde message names the failing field/offset
+        // without dumping the blob (HOU-431).
+        format!("Unexpected composio login --no-wait output: {e}")
     })?;
 
     Ok(StartLoginResponse {

--- a/engine/houston-engine-server/src/main.rs
+++ b/engine/houston-engine-server/src/main.rs
@@ -15,6 +15,8 @@ use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::net::TcpListener;
 
+mod sentry_scrub;
+
 #[derive(Serialize)]
 struct EngineManifest<'a> {
     version: &'a str,
@@ -276,6 +278,11 @@ fn init_sentry() -> Option<sentry::ClientInitGuard> {
         sentry::ClientOptions {
             release: Some(release),
             environment: Some(environment),
+            // Defense-in-depth: strip `--key <value>` composio credentials from
+            // any outbound event/breadcrumb in case a future code path formats
+            // one into a tracing error (HOU-431). The real fix is redaction at
+            // the source in `houston_composio::cli`; this is the safety net.
+            before_send: Some(Arc::new(sentry_scrub::scrub_event)),
             // No `auto_session_tracking` field: the engine's Cargo.toml leaves
             // the `release-health` feature OFF (default-features = false), which
             // cfg-gates that field out entirely. That is intentional — the

--- a/engine/houston-engine-server/src/sentry_scrub.rs
+++ b/engine/houston-engine-server/src/sentry_scrub.rs
@@ -15,32 +15,52 @@ use sentry::protocol::{Event, Value};
 
 const REDACTED: &str = "<redacted>";
 
-/// Redact the value that follows any `--key` token in `input`.
+/// Tokens that introduce a composio login-session secret. The same value
+/// surfaces three ways: the `--key` argv flag, the `cliKey` query param
+/// embedded in `login_url`, and the `cli_key` JSON field of the CLI's
+/// start-login output (HOU-431).
+const SECRET_MARKERS: [&str; 3] = ["--key", "cliKey", "cli_key"];
+
+/// Redact the value that follows any [`SECRET_MARKERS`] token in `input`.
 ///
-/// Handles the three shapes a composio key can take inside a captured string:
+/// Handles every shape the secret takes inside a captured string:
 ///   - shell:        `--key cf7f2461-...`
 ///   - joined:       `--key=cf7f2461-...`
 ///   - Rust `{:?}`:  `"--key", "cf7f2461-..."`
+///   - URL param:    `?cliKey=cf7f2461-...`
+///   - JSON field:   `"cli_key":"cf7f2461-..."`
 ///
-/// Anything that is not a `--key` value passes through untouched. UTF-8 safe:
+/// Anything not following a marker passes through untouched. UTF-8 safe:
 /// only ever slices on `char_indices` boundaries.
 pub fn scrub_key_secrets(input: &str) -> String {
-    if !input.contains("--key") {
+    if !SECRET_MARKERS.iter().any(|m| input.contains(m)) {
         return input.to_string();
     }
 
+    // Separators between a marker and its value: quote / comma / `=` / `:` /
+    // whitespace — covers `--key `, `--key=`, the Debug form `"--key", "`,
+    // the URL `cliKey=`, and the JSON `"cli_key":"`.
+    let is_sep = |c: char| matches!(c, '"' | '\'' | ',' | '=' | ':') || c.is_whitespace();
+    // The value ends at the first quote / comma / bracket / brace / ampersand
+    // (argv-Debug, JSON, and URL-query delimiters) or whitespace.
+    let is_boundary = |c: char| matches!(c, '"' | '\'' | ',' | ']' | '}' | '&') || c.is_whitespace();
+
     let mut out = String::with_capacity(input.len());
     let mut rest = input;
-    while let Some(pos) = rest.find("--key") {
-        // Emit everything up to and including the `--key` flag.
+    loop {
+        // Earliest marker remaining in `rest`.
+        let Some((pos, marker)) = SECRET_MARKERS
+            .iter()
+            .filter_map(|m| rest.find(m).map(|p| (p, *m)))
+            .min_by_key(|&(p, _)| p)
+        else {
+            break;
+        };
         out.push_str(&rest[..pos]);
-        out.push_str("--key");
-        rest = &rest[pos + "--key".len()..];
+        out.push_str(marker);
+        rest = &rest[pos + marker.len()..];
 
-        // Copy the separators between the flag and its value verbatim
-        // (quote / comma / whitespace / `=` — covers `--key=`, `--key `, and
-        // the Debug form `"--key", "`).
-        let is_sep = |c: char| c == '"' || c == '\'' || c == ',' || c == '=' || c.is_whitespace();
+        // Copy the separators between the marker and its value verbatim.
         let sep_end = rest
             .char_indices()
             .find(|&(_, c)| !is_sep(c))
@@ -49,10 +69,7 @@ pub fn scrub_key_secrets(input: &str) -> String {
         out.push_str(&rest[..sep_end]);
         rest = &rest[sep_end..];
 
-        // Replace the value run (until the next quote / comma / whitespace /
-        // closing bracket) with a single placeholder.
-        let is_boundary =
-            |c: char| c == '"' || c == '\'' || c == ',' || c == ']' || c.is_whitespace();
+        // Replace the value run with a single placeholder.
         let val_end = rest
             .char_indices()
             .find(|&(_, c)| is_boundary(c))
@@ -124,6 +141,28 @@ mod tests {
     #[test]
     fn scrubs_joined_form() {
         assert_eq!(scrub_key_secrets("--key=secret-uuid"), "--key=<redacted>");
+    }
+
+    #[test]
+    fn scrubs_url_query_clikey() {
+        // `login_url` embeds the secret as `?cliKey=<cli_key>` (HOU-431).
+        let input =
+            "url=https://dashboard.composio.dev/?cliKey=6490d0eb-66c6-4a50-ae7f-28b3ac147ef9";
+        let out = scrub_key_secrets(input);
+        assert!(!out.contains("6490d0eb"), "secret leaked: {out}");
+        assert!(out.contains("cliKey=<redacted>"), "got: {out}");
+        assert!(out.contains("https://dashboard.composio.dev/"));
+    }
+
+    #[test]
+    fn scrubs_json_cli_key_field() {
+        // The CLI's start-login stdout carries the secret twice: in the
+        // `login_url` query and in the `cli_key` field. Both must go.
+        let input = r#"{"login_url":"https://x/?cliKey=abc-123","cli_key":"abc-123"}"#;
+        let out = scrub_key_secrets(input);
+        assert!(!out.contains("abc-123"), "secret leaked: {out}");
+        assert!(out.contains("cliKey=<redacted>"), "got: {out}");
+        assert!(out.contains(r#""cli_key":"<redacted>""#), "got: {out}");
     }
 
     #[test]

--- a/engine/houston-engine-server/src/sentry_scrub.rs
+++ b/engine/houston-engine-server/src/sentry_scrub.rs
@@ -1,0 +1,160 @@
+//! Defense-in-depth secret scrubbing for outbound Sentry events (HOU-431).
+//!
+//! The primary fix for the composio `--key` credential leak is redaction at
+//! the source: `houston_composio::cli` no longer formats the raw key into any
+//! log line or error string. This `before_send` hook is the safety net — if
+//! any *future* code path ever formats a `--key <value>` secret into a
+//! `tracing::error!`, a breadcrumb, or an exception value, this strips it
+//! before the event leaves the process.
+//!
+//! Scope is deliberately narrow: it only touches the `--key <value>` shape, so
+//! legitimate UUIDs (agent ids, workspace ids) that are useful for triage are
+//! never redacted.
+
+use sentry::protocol::{Event, Value};
+
+const REDACTED: &str = "<redacted>";
+
+/// Redact the value that follows any `--key` token in `input`.
+///
+/// Handles the three shapes a composio key can take inside a captured string:
+///   - shell:        `--key cf7f2461-...`
+///   - joined:       `--key=cf7f2461-...`
+///   - Rust `{:?}`:  `"--key", "cf7f2461-..."`
+///
+/// Anything that is not a `--key` value passes through untouched. UTF-8 safe:
+/// only ever slices on `char_indices` boundaries.
+pub fn scrub_key_secrets(input: &str) -> String {
+    if !input.contains("--key") {
+        return input.to_string();
+    }
+
+    let mut out = String::with_capacity(input.len());
+    let mut rest = input;
+    while let Some(pos) = rest.find("--key") {
+        // Emit everything up to and including the `--key` flag.
+        out.push_str(&rest[..pos]);
+        out.push_str("--key");
+        rest = &rest[pos + "--key".len()..];
+
+        // Copy the separators between the flag and its value verbatim
+        // (quote / comma / whitespace / `=` — covers `--key=`, `--key `, and
+        // the Debug form `"--key", "`).
+        let is_sep = |c: char| c == '"' || c == '\'' || c == ',' || c == '=' || c.is_whitespace();
+        let sep_end = rest
+            .char_indices()
+            .find(|&(_, c)| !is_sep(c))
+            .map(|(idx, _)| idx)
+            .unwrap_or(rest.len());
+        out.push_str(&rest[..sep_end]);
+        rest = &rest[sep_end..];
+
+        // Replace the value run (until the next quote / comma / whitespace /
+        // closing bracket) with a single placeholder.
+        let is_boundary =
+            |c: char| c == '"' || c == '\'' || c == ',' || c == ']' || c.is_whitespace();
+        let val_end = rest
+            .char_indices()
+            .find(|&(_, c)| is_boundary(c))
+            .map(|(idx, _)| idx)
+            .unwrap_or(rest.len());
+        if val_end > 0 {
+            out.push_str(REDACTED);
+            rest = &rest[val_end..];
+        }
+    }
+    out.push_str(rest);
+    out
+}
+
+/// Sentry `before_send` hook: scrub every string-bearing field of an event so
+/// a `--key` secret can never leave the process, regardless of which field
+/// `sentry-tracing` happened to populate. Never drops events.
+pub fn scrub_event(mut event: Event<'static>) -> Option<Event<'static>> {
+    if let Some(msg) = event.message.take() {
+        event.message = Some(scrub_key_secrets(&msg));
+    }
+    if let Some(mut entry) = event.logentry.take() {
+        entry.message = scrub_key_secrets(&entry.message);
+        event.logentry = Some(entry);
+    }
+    for exc in &mut event.exception.values {
+        if let Some(v) = exc.value.take() {
+            exc.value = Some(scrub_key_secrets(&v));
+        }
+    }
+    for bc in &mut event.breadcrumbs.values {
+        if let Some(m) = bc.message.take() {
+            bc.message = Some(scrub_key_secrets(&m));
+        }
+    }
+    for v in event.extra.values_mut() {
+        if let Value::String(s) = v {
+            *s = scrub_key_secrets(s);
+        }
+    }
+    Some(event)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sentry::protocol::{Breadcrumb, Event};
+
+    #[test]
+    fn scrubs_debug_formatted_args() {
+        let input = r#"composio CLI timed out after 330s: args=["login", "--key", "cf7f2461-f693-4f65-95bf-6d110f1d4344", "--no-skill-install", "-y"]"#;
+        let out = scrub_key_secrets(input);
+        assert!(!out.contains("cf7f2461"), "secret leaked: {out}");
+        assert!(out.contains("--key"));
+        assert!(out.contains("<redacted>"));
+        // Surrounding non-secret args survive.
+        assert!(out.contains("--no-skill-install"));
+        assert!(out.contains("\"-y\""));
+    }
+
+    #[test]
+    fn scrubs_shell_form() {
+        assert_eq!(
+            scrub_key_secrets("composio login --key abc-123 --no-skill-install"),
+            "composio login --key <redacted> --no-skill-install"
+        );
+    }
+
+    #[test]
+    fn scrubs_joined_form() {
+        assert_eq!(scrub_key_secrets("--key=secret-uuid"), "--key=<redacted>");
+    }
+
+    #[test]
+    fn leaves_unrelated_uuids_untouched() {
+        let s = "agent 7f3a-2b1c started in workspace pr_99abc";
+        assert_eq!(scrub_key_secrets(s), s);
+    }
+
+    #[test]
+    fn noop_without_key_flag() {
+        let s = "nothing to redact here";
+        assert_eq!(scrub_key_secrets(s), s);
+    }
+
+    #[test]
+    fn scrubs_event_message_and_breadcrumb() {
+        let mut event = Event {
+            message: Some(r#"args=["--key", "leaked-key-123"]"#.to_string()),
+            ..Default::default()
+        };
+        event.breadcrumbs.values.push(Breadcrumb {
+            message: Some("login --key leaked-key-456 done".to_string()),
+            ..Default::default()
+        });
+
+        let out = scrub_event(event).expect("event is never dropped");
+        assert!(!out.message.as_ref().unwrap().contains("leaked-key-123"));
+        assert!(!out.breadcrumbs.values[0]
+            .message
+            .as_ref()
+            .unwrap()
+            .contains("leaked-key-456"));
+    }
+}


### PR DESCRIPTION
## Problem

Composio `login --key <cli_key>` puts the login-session credential on argv. The CLI wrapper's timeout branch formatted the raw `args` into the **returned error string**, which the engine's `tracing::error!` shipped to Sentry (`runtime=engine`, shared `houston-app` project) — exactly the evidence in **HOU-431** (`HOUSTON-APP-66`, `HOUSTON-APP-13`).

The same key also reached:
- `backend.log` (debug spawn/exit logs)
- `start_login`'s info log (its stdout JSON carries `cli_key`)
- `frontend.log` (`use-composio-auth.ts`)
- the **user-facing error toast** (engine error string flowed over HTTP into the UI)

All of which get bundled into "Report bug" log tails.

## Fix

**Root cause — redact at the source** (kills the Sentry event, every log, and the toast at once):
- `engine/houston-composio/src/cli.rs` — new `redact_secret_args()` masks `--key <value>` / `--key=<value>` → `<redacted>` at all three arg-format sites (timeout error + both debug logs). `start_login` now logs a byte count instead of the `cli_key`-bearing JSON.
- `app/src/hooks/use-composio-auth.ts` — drops `key=${cli_key}` from the frontend log.

**Defense-in-depth — Sentry `before_send` scrubber:**
- `engine/houston-engine-server/src/sentry_scrub.rs` (new) strips `--key` secrets from any outbound event message / logentry / exception / breadcrumb / extra. Narrow scope so legitimate UUIDs (agent/workspace ids) are untouched.
- Wired into the engine Sentry init in `main.rs`.

## Tests

9 new unit tests (3 redaction + 6 scrubber). `cargo test -p houston-composio -p houston-engine-server` and `pnpm tsc --noEmit` both green.

## Severity note

The `--key` value is the **`cli_key`, a 5-minute pending-login nonce**, not the persistent Composio API key (which is written to `~/.composio/user_data.json` *after* login and is never on argv). The two exposed UUIDs are already expired and aren't independently rotatable — recommend just **deleting Sentry issues HOUSTON-APP-66 & -13** to purge stored values.

## Files
- `engine/houston-composio/src/cli.rs`
- `engine/houston-engine-server/src/sentry_scrub.rs` (new)
- `engine/houston-engine-server/src/main.rs`
- `app/src/hooks/use-composio-auth.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)