### PR TITLE
fix(engine): make codex login-server failure recoverable (HOU-446)

### DIFF
--- a/app/src/components/shell/gemini-connect-dialog.tsx
+++ b/app/src/components/shell/gemini-connect-dialog.tsx
@@ -91,7 +91,9 @@ export function GeminiConnectDialog({
       // `oauth-personal` method, gemini-cli opens the user's browser.
       // The call returns once gemini-cli has acknowledged the request
       // (it's then waiting on the browser flow externally).
-      await tauriProvider.launchLogin(provider.id);
+      // `toast: false`: the catch below renders its own failure toast, so
+      // `call` must not also toast the same message (it showed twice).
+      await tauriProvider.launchLogin(provider.id, { toast: false });
       // Hand off to the picker's polling loop — it watches
       // `checkStatus("gemini")` every 1.5-2s and flips to Connected
       // when gemini-cli writes its credential files. Close the dialog

--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -169,7 +169,9 @@ export function ProviderPicker({ onSelect }: Props) {
       // engine) can't receive the CLI's localhost OAuth callback, so ask
       // for the headless device-code flow. The engine ignores the flag for
       // providers without a device variant (Claude keeps its paste-back).
-      await tauriProvider.launchLogin(provider.id, { deviceAuth: !osIsTauri() });
+      // `toast: false`: the catch below renders the provider-specific failure
+      // toast, so `call` must not also toast the same message (it showed twice).
+      await tauriProvider.launchLogin(provider.id, { deviceAuth: !osIsTauri(), toast: false });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[provider-picker] launchLogin(${provider.id}) failed:`, msg);

--- a/app/src/components/shell/provider-settings.tsx
+++ b/app/src/components/shell/provider-settings.tsx
@@ -216,7 +216,9 @@ export function ProviderSettings() {
       // engine) can't receive the CLI's localhost OAuth callback, so ask
       // for the headless device-code flow. The engine ignores the flag for
       // providers without a device variant (Claude keeps its paste-back).
-      await tauriProvider.launchLogin(provider.id, { deviceAuth: !osIsTauri() });
+      // `toast: false`: the catch below renders the provider-specific failure
+      // toast, so `call` must not also toast the same message (it showed twice).
+      await tauriProvider.launchLogin(provider.id, { deviceAuth: !osIsTauri(), toast: false });
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err);
       console.error(`[provider-settings] launchLogin(${provider.id}) failed:`, msg);

--- a/app/src/lib/engine-call-policy.ts
+++ b/app/src/lib/engine-call-policy.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure decision for how an engine-call failure should be surfaced. Extracted
+ * from `tauri.ts`'s `surfaceError` so it can be unit-tested without importing
+ * the Tauri runtime.
+ *
+ * Two independent switches:
+ *  - `toast`  — show the red error toast to the user.
+ *  - `capture` — report the failure to Sentry.
+ *
+ * The no-silent-failures policy lives here: a caller that renders its OWN
+ * failure UI passes `toast: false` (so `call`'s generic toast doesn't fire on
+ * top of theirs), but the failure is STILL captured to Sentry. Suppressing the
+ * toast must never suppress the report.
+ */
+export interface EngineCallSurface {
+  toast: boolean;
+  capture: boolean;
+}
+
+export interface EngineCallSurfaceOptions {
+  /** Show a red error toast on failure. Default true. */
+  toast?: boolean;
+  /** Report the failure to Sentry. Default true. */
+  capture?: boolean;
+}
+
+/**
+ * Decide whether a failed engine call should toast and/or capture.
+ *
+ * @param errorName `err.name` of the caught error (`undefined` for non-Error
+ *   throws). `"AbortError"` is treated as an expected cancellation (the user
+ *   typed again, navigated away, or cancelled a sign-in) — never toasted, never
+ *   captured.
+ */
+export function engineCallSurface(
+  errorName: string | undefined,
+  options?: EngineCallSurfaceOptions,
+): EngineCallSurface {
+  if (errorName === "AbortError") {
+    return { toast: false, capture: false };
+  }
+  return {
+    toast: options?.toast !== false,
+    capture: options?.capture !== false,
+  };
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -32,6 +32,7 @@ import type {
 import { getEngine } from "./engine";
 import { osPickDirectory } from "./os-bridge";
 import { logger } from "./logger";
+import { engineCallSurface } from "./engine-call-policy";
 import { normalizeLegacyModel } from "./providers";
 import { shouldAutocompactForSession } from "./autocompact";
 import { useProviderSwitchStore } from "../stores/provider-switch";
@@ -72,12 +73,12 @@ async function surfaceError(
     err instanceof Error ? err.message : typeof err === "string" ? err : String(err);
   logger.error(`[engine:${label}] ${message}`, context ? JSON.stringify(context) : undefined);
 
-  // Aborted requests (user typed again, navigated away, cancelled a sign-in)
-  // are expected, not failures — never toast or report them.
-  if (err instanceof Error && err.name === "AbortError") return;
-
-  const shouldToast = options?.toast !== false;
-  const shouldCapture = options?.capture !== false;
+  // Aborted requests are expected; `toast: false` callers render their own
+  // failure UI but the error is still captured. See `engineCallSurface`.
+  const { toast: shouldToast, capture: shouldCapture } = engineCallSurface(
+    err instanceof Error ? err.name : undefined,
+    options,
+  );
   if (!shouldToast && !shouldCapture) return;
 
   const { showErrorToast, reportError } = await import("./error-toast");
@@ -799,8 +800,18 @@ export const tauriProvider = {
       await eng.setPreference(DEFAULT_PROVIDER_PREF_KEY, provider);
       await eng.setPreference(DEFAULT_MODEL_PREF_KEY, model);
     }),
-  launchLogin: (provider: string, opts?: { deviceAuth?: boolean }) =>
-    call<void>("launch_provider_login", () => getEngine().providerLogin(provider, opts)),
+  launchLogin: (provider: string, opts?: { deviceAuth?: boolean; toast?: boolean }) =>
+    call<void>(
+      "launch_provider_login",
+      () => getEngine().providerLogin(provider, opts),
+      undefined,
+      // Callers that render their OWN failure toast (the picker, settings, and
+      // the Gemini dialog) pass `toast: false` so `call`'s generic toast does
+      // not fire on top of theirs — the engine error message showed twice
+      // otherwise. Sentry capture still happens. Callers that surface the
+      // failure inline (reconnect cards / banner) omit it and keep this toast.
+      opts?.toast === false ? { toast: false } : undefined,
+    ),
   launchLogout: (provider: string) =>
     call<void>("launch_provider_logout", () => getEngine().providerLogout(provider)),
   /**

--- a/app/tests/engine-call-policy.test.ts
+++ b/app/tests/engine-call-policy.test.ts
@@ -1,0 +1,44 @@
+import { deepStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { engineCallSurface } from "../src/lib/engine-call-policy.ts";
+
+describe("engineCallSurface", () => {
+  it("toasts and captures by default", () => {
+    deepStrictEqual(engineCallSurface(undefined), { toast: true, capture: true });
+    deepStrictEqual(engineCallSurface("HoustonEngineError"), { toast: true, capture: true });
+  });
+
+  it("suppresses the toast but STILL captures when toast:false", () => {
+    // The contract behind the provider-login double-toast fix: the picker /
+    // settings / Gemini dialog render their own failure toast, so `call` must
+    // not toast on top — but the failure must still reach Sentry. Suppressing
+    // the toast must never become a silent failure.
+    deepStrictEqual(engineCallSurface(undefined, { toast: false }), {
+      toast: false,
+      capture: true,
+    });
+  });
+
+  it("suppresses capture independently when capture:false", () => {
+    deepStrictEqual(engineCallSurface(undefined, { capture: false }), {
+      toast: true,
+      capture: false,
+    });
+  });
+
+  it("does nothing when both are suppressed", () => {
+    deepStrictEqual(engineCallSurface(undefined, { toast: false, capture: false }), {
+      toast: false,
+      capture: false,
+    });
+  });
+
+  it("treats AbortError as expected — never toasts or captures, ignoring options", () => {
+    deepStrictEqual(engineCallSurface("AbortError"), { toast: false, capture: false });
+    // Even if a caller asked to toast, an abort stays silent.
+    deepStrictEqual(engineCallSurface("AbortError", { toast: true, capture: true }), {
+      toast: false,
+      capture: false,
+    });
+  });
+});

--- a/engine/houston-engine-core/src/provider/login_relay.rs
+++ b/engine/houston-engine-core/src/provider/login_relay.rs
@@ -35,6 +35,7 @@ use houston_ui_events::{DynEventSink, HoustonEvent};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashMap;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -48,6 +49,12 @@ use tokio::sync::{Mutex, Notify};
 /// `ProviderLoginComplete` with a timeout error and the session is
 /// removed so the next Connect click can spawn a fresh subprocess.
 const LOGIN_SESSION_TIMEOUT: Duration = Duration::from_secs(600);
+
+/// How many leading stdout lines the relay retains for failure diagnosis
+/// (e.g. codex's "Starting local login server" banner — HOU-446). Bounded so a
+/// chatty CLI can't grow this without limit; the signatures we look for are
+/// printed at startup, well within this head.
+const RELAY_STDOUT_DIAG_LINES: usize = 64;
 
 /// In-flight OAuth login sessions, keyed by provider id (e.g.
 /// `"anthropic"`, `"openai"`). Single-entry-per-provider by design:
@@ -295,6 +302,10 @@ async fn relay_login_output(
     // re-emit can carry both.
     let mut login_url: Option<String> = None;
     let mut code_emitted = false;
+    // Bounded head of stdout, retained for the failure path so the diagnoser
+    // can see a login-server startup banner the CLI printed to stdout (the
+    // companion to the drained stderr). See [`make_login_error`].
+    let mut stdout_tail: Vec<String> = Vec::new();
     let mut reader = BufReader::new(stdout).lines();
 
     // Outer timeout protects against a CLI that keeps stdout open
@@ -305,6 +316,14 @@ async fn relay_login_output(
     let work = async {
         loop {
             tokio::select! {
+                // Biased so the branches are polled top-to-bottom: a pending
+                // user cancel always wins, then we drain a ready stdout line
+                // BEFORE observing the child's exit. Without this, an unbiased
+                // select randomly picks `child.wait()` over `reader.next_line()`
+                // when a fast-exiting CLI has both ready — dropping the login
+                // URL (and the device code) it already printed. stdout EOF
+                // (`Ok(None)`) then falls through to the exit branch below.
+                biased;
                 _ = cancel.notified() => {
                     tracing::info!(
                         "[houston:provider] {cli_name} login cancelled — killing subprocess"
@@ -325,6 +344,10 @@ async fn relay_login_output(
                             // never surfaced. See `strip_ansi`.
                             let clean = strip_ansi(&line);
                             let clean = clean.as_ref();
+                            // Retain a bounded head for the failure diagnoser.
+                            if stdout_tail.len() < RELAY_STDOUT_DIAG_LINES {
+                                stdout_tail.push(clean.to_string());
+                            }
                             if !url_emitted {
                                 if let Some(url) = extract_login_url(clean) {
                                     tracing::info!(
@@ -382,7 +405,13 @@ async fn relay_login_output(
         RelayOutcome::Exited(child.wait().await)
     };
 
-    let (success, error) = match tokio::time::timeout(LOGIN_SESSION_TIMEOUT, work).await {
+    let outcome = tokio::time::timeout(LOGIN_SESSION_TIMEOUT, work).await;
+    // `work` has completed and been dropped, releasing its borrow of
+    // `stdout_tail` — safe to read it now for the failure diagnoser.
+    let stdout_diag = stdout_tail.join("\n");
+    let provider = Provider::from_str(&provider_id).ok();
+
+    let (success, error) = match outcome {
         Ok(RelayOutcome::Exited(Ok(status))) => {
             tracing::info!("[houston:provider] {cli_name} login exited: {status}");
             let stderr_text = drain_stderr(stderr_handle).await;
@@ -391,7 +420,13 @@ async fn relay_login_output(
                 if status.success() {
                     None
                 } else {
-                    Some(format_exit_error(&cli_name, &format!("{status}"), &stderr_text))
+                    Some(make_login_error(
+                        provider,
+                        &cli_name,
+                        &stdout_diag,
+                        &format!("{status}"),
+                        &stderr_text,
+                    ))
                 },
             )
         }
@@ -400,7 +435,13 @@ async fn relay_login_output(
             let stderr_text = drain_stderr(stderr_handle).await;
             (
                 false,
-                Some(format_exit_error(&cli_name, &format!("wait failed: {e}"), &stderr_text)),
+                Some(make_login_error(
+                    provider,
+                    &cli_name,
+                    &stdout_diag,
+                    &format!("wait failed: {e}"),
+                    &stderr_text,
+                )),
             )
         }
         Ok(RelayOutcome::Cancelled) => {
@@ -420,8 +461,10 @@ async fn relay_login_output(
             let stderr_text = drain_stderr(stderr_handle).await;
             (
                 false,
-                Some(format_exit_error(
+                Some(make_login_error(
+                    provider,
                     &cli_name,
+                    &stdout_diag,
                     &format!("timed out after {}s", LOGIN_SESSION_TIMEOUT.as_secs()),
                     &stderr_text,
                 )),
@@ -460,6 +503,26 @@ fn format_exit_error(cli_name: &str, status: &str, stderr: &str) -> String {
     } else {
         format!("{cli_name} {status}: {stderr}")
     }
+}
+
+/// Pick the user-facing error message for a login subprocess the relay saw
+/// fail. A provider-specific recoverable diagnosis wins (e.g. codex's loopback
+/// login server failing to start — HOU-446), so the user gets an actionable
+/// message instead of codex's benign "Starting local login server" banner;
+/// otherwise we fall back to [`format_exit_error`] (raw stderr is the real,
+/// actionable detail for a genuine login error). Mirrors
+/// `super::login_early_exit_error`, which guards the sub-3s probe path.
+fn make_login_error(
+    provider: Option<Provider>,
+    cli_name: &str,
+    stdout_diag: &str,
+    status: &str,
+    stderr: &str,
+) -> String {
+    provider
+        .and_then(|p| p.diagnose_login_failure(stdout_diag, stderr))
+        .map(|hint| hint.message)
+        .unwrap_or_else(|| format_exit_error(cli_name, status, stderr))
 }
 
 /// Submit the OAuth verification code the user pasted from their
@@ -889,6 +952,106 @@ mod tests {
         // The relay removes the session on child exit (token-guarded); clear
         // it explicitly too so a slow exit can't leak into sibling tests that
         // share the global LOGIN_SESSIONS map.
+        LOGIN_SESSIONS.lock().await.remove(provider_id);
+    }
+
+    #[test]
+    fn make_login_error_prefers_diagnosis_then_falls_back() {
+        let codex = parse("openai").unwrap();
+        // codex login-server banner on stderr → recoverable diagnosis, not the
+        // raw "codex exit status: 1: <banner>" string.
+        let diagnosed = make_login_error(
+            Some(codex),
+            "codex",
+            "",
+            "exit status: 1",
+            "Starting local login server on http://localhost:1455.",
+        );
+        assert!(diagnosed.contains("1455"), "got: {diagnosed}");
+        assert!(!diagnosed.contains("Starting local login server"), "got: {diagnosed}");
+
+        // A genuine codex error has no login-server signature → raw stderr
+        // (the actionable detail) flows through format_exit_error.
+        let raw = make_login_error(
+            Some(codex),
+            "codex",
+            "",
+            "exit status: 1",
+            "Error loading configuration: bad value",
+        );
+        assert_eq!(raw, "codex exit status: 1: Error loading configuration: bad value");
+
+        // No provider resolved → always the raw fallback.
+        let none = make_login_error(None, "codex", "", "exit status: 1", "boom");
+        assert_eq!(none, "codex exit status: 1: boom");
+    }
+
+    /// End-to-end relay proof: a `codex login` stand-in whose loopback server
+    /// can't start prints codex's benign banner to stderr and exits non-zero.
+    /// The relay must emit a `ProviderLoginComplete` carrying the recoverable
+    /// diagnosis, NOT the raw banner (HOU-446). Unix-only: it shells out to
+    /// `sh -c` to write stderr + exit 1; the cross-platform logic is covered by
+    /// `make_login_error_prefers_diagnosis_then_falls_back` and the OpenAI
+    /// adapter's own `openai_login` unit tests.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn relay_diagnoses_codex_login_server_failure_instead_of_raw_banner() {
+        use houston_ui_events::BroadcastEventSink;
+
+        let mut cmd = tokio::process::Command::new("sh");
+        cmd.arg("-c")
+            .arg("echo 'Starting local login server on http://localhost:1455.' 1>&2; exit 1")
+            .stdin(std::process::Stdio::piped())
+            .stdout(std::process::Stdio::piped())
+            .stderr(std::process::Stdio::piped())
+            .kill_on_drop(true);
+        let mut child = cmd.spawn().expect("spawn codex stand-in");
+        let stdin = child.stdin.take().expect("stdin piped");
+        let stdout = child.stdout.take().expect("stdout piped");
+        let stderr = child.stderr.take();
+
+        // Real provider id so the relay resolves the OpenAI adapter + diagnoser.
+        let provider_id = "openai";
+        let cli_name = "codex";
+        let sink = Arc::new(BroadcastEventSink::new(16));
+        let mut rx = sink.subscribe();
+
+        let registration = insert_session(provider_id, cli_name, stdin)
+            .await
+            .expect("insert succeeds");
+        spawn_relay(
+            provider_id.to_string(),
+            cli_name.to_string(),
+            child,
+            stdout,
+            stderr,
+            sink.clone(),
+            registration,
+            false,
+        );
+
+        let ev = tokio::time::timeout(Duration::from_secs(5), rx.recv())
+            .await
+            .expect("relay emits within 5s")
+            .expect("event received");
+        match ev {
+            HoustonEvent::ProviderLoginComplete {
+                provider,
+                success,
+                error,
+            } => {
+                assert_eq!(provider, provider_id);
+                assert!(!success, "a failed login did not complete");
+                let error = error.expect("a failed sign-in surfaces an error");
+                assert!(error.contains("1455"), "recoverable message names the port: {error}");
+                assert!(
+                    !error.contains("Starting local login server"),
+                    "the benign banner must not leak: {error}"
+                );
+            }
+            other => panic!("expected ProviderLoginComplete, got {other:?}"),
+        }
+
         LOGIN_SESSIONS.lock().await.remove(provider_id);
     }
 }

--- a/engine/houston-engine-core/src/provider/mod.rs
+++ b/engine/houston-engine-core/src/provider/mod.rs
@@ -20,6 +20,7 @@ pub use gemini_disconnect::disconnect_gemini;
 pub use login_relay::{cancel_login, submit_login_code};
 
 use crate::error::{CoreError, CoreResult};
+use houston_engine_protocol::ErrorCode;
 use houston_terminal_manager::provider_auth::ProviderAuthState;
 use houston_terminal_manager::{claude_path, InstallSource, Provider};
 use houston_ui_events::DynEventSink;
@@ -203,14 +204,14 @@ pub async fn launch_login(
             tracing::warn!(
                 "[houston:provider] {cli_name} login exited early: {status} stdout={stdout:?} stderr={stderr:?}"
             );
-            let detail = if !stderr.is_empty() {
-                stderr.to_string()
-            } else if !stdout.is_empty() {
-                stdout.to_string()
-            } else {
-                decorate_windows_exit(cli_name, &format!("{status}"), status.code())
-            };
-            Err(CoreError::Internal(format!("{cli_name} login: {detail}")))
+            Err(login_early_exit_error(
+                provider,
+                cli_name,
+                stdout,
+                stderr,
+                status.code(),
+                &format!("{status}"),
+            ))
         }
         Ok(Ok(status)) => {
             // Exited cleanly within 3s — unusual but possible if the CLI
@@ -523,6 +524,42 @@ fn decorate_windows_exit(command: &str, status_display: &str, exit_code: Option<
     }
 }
 
+/// Build the error for a login subprocess that exited non-zero inside the
+/// probe window. A provider-specific recoverable diagnosis wins (e.g. codex's
+/// loopback login server failing to bind port 1455, HOU-446): it surfaces as a
+/// clean [`CoreError::Labeled`] — no `internal:` prefix, with a machine-
+/// readable `kind` — so the user sees an actionable message instead of codex's
+/// benign "Starting local login server" banner. With no diagnosis we fall back
+/// to the raw stderr (then stdout, then the decorated exit status), which for a
+/// genuine login error is already the actionable detail.
+///
+/// Pure (no process handles) so the stream-handling branches stay unit-testable
+/// without spawning a CLI.
+fn login_early_exit_error(
+    provider: Provider,
+    cli_name: &str,
+    stdout: &str,
+    stderr: &str,
+    status_code: Option<i32>,
+    status_display: &str,
+) -> CoreError {
+    if let Some(hint) = provider.diagnose_login_failure(stdout, stderr) {
+        return CoreError::Labeled {
+            code: ErrorCode::Unavailable,
+            kind: hint.kind,
+            message: hint.message,
+        };
+    }
+    let detail = if !stderr.is_empty() {
+        stderr.to_string()
+    } else if !stdout.is_empty() {
+        stdout.to_string()
+    } else {
+        decorate_windows_exit(cli_name, status_display, status_code)
+    };
+    CoreError::Internal(format!("{cli_name} login: {detail}"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -532,6 +569,90 @@ mod tests {
         assert!(parse("nonexistent-provider").is_err());
         assert!(parse("anthropic").is_ok());
         assert!(parse("openai").is_ok());
+    }
+
+    #[test]
+    fn login_early_exit_diagnoses_codex_login_server_banner() {
+        // HOU-446: codex printed only its benign "Starting local login server"
+        // banner before exiting non-zero. The probe must turn that into a
+        // clean, recoverable Labeled error — NOT echo the banner, and NOT wrap
+        // it with the `internal:` prefix.
+        let codex = parse("openai").unwrap();
+        let err = login_early_exit_error(
+            codex,
+            "codex",
+            "",
+            "Starting local login server on http://localhost:1455.",
+            Some(1),
+            "exit status: 1",
+        );
+        match &err {
+            CoreError::Labeled { code, kind, message } => {
+                assert_eq!(*code, ErrorCode::Unavailable);
+                assert_eq!(*kind, "codex_login_server_unavailable");
+                assert!(message.contains("1455"), "got: {message}");
+            }
+            other => panic!("expected Labeled, got {other:?}"),
+        }
+        // Display (the on-the-wire `error.message` / toast description) is the
+        // clean sentence: no `internal:` prefix, no raw banner.
+        let shown = err.to_string();
+        assert!(!shown.contains("internal:"), "no internal prefix: {shown}");
+        assert!(
+            !shown.contains("Starting local login server"),
+            "benign banner must not leak: {shown}"
+        );
+        assert!(shown.starts_with("Codex could not start"), "got: {shown}");
+    }
+
+    #[test]
+    fn login_early_exit_passes_through_a_real_codex_error() {
+        // A genuine, already-actionable codex error has no login-server
+        // signature, so it falls through to the raw stderr (still actionable)
+        // rather than being mislabeled as a port problem.
+        let codex = parse("openai").unwrap();
+        let err = login_early_exit_error(
+            codex,
+            "codex",
+            "",
+            "Error loading configuration: unknown variant `max`",
+            Some(1),
+            "exit status: 1",
+        );
+        match err {
+            CoreError::Internal(msg) => {
+                assert_eq!(msg, "codex login: Error loading configuration: unknown variant `max`");
+            }
+            other => panic!("expected Internal pass-through, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn login_early_exit_does_not_diagnose_for_other_providers() {
+        // Only codex runs the loopback login server. The same banner from
+        // another provider stays a raw Internal error (default diagnosis).
+        let claude = parse("anthropic").unwrap();
+        let err = login_early_exit_error(
+            claude,
+            "claude",
+            "",
+            "Starting local login server on http://localhost:1455.",
+            Some(1),
+            "exit status: 1",
+        );
+        assert!(matches!(err, CoreError::Internal(_)), "got: {err:?}");
+    }
+
+    #[test]
+    fn login_early_exit_with_no_output_decorates_status() {
+        // Nothing on either stream — surface the (possibly decorated) exit
+        // status so the user still gets *something* actionable.
+        let codex = parse("openai").unwrap();
+        let err = login_early_exit_error(codex, "codex", "", "", Some(1), "exit status: 1");
+        match err {
+            CoreError::Internal(msg) => assert!(msg.contains("exit status: 1"), "got: {msg}"),
+            other => panic!("expected Internal, got {other:?}"),
+        }
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/lib.rs
+++ b/engine/houston-terminal-manager/src/lib.rs
@@ -37,7 +37,7 @@ pub use codex_parser::{extract_thread_id, parse_codex_event, CodexAccumulator};
 pub use gemini_parser::{parse_gemini_event, GeminiAccumulator};
 pub use manager::{SessionHandle, SessionManager};
 pub use parser::{extract_session_id, parse_event, StreamAccumulator};
-pub use provider::{InstallSource, Provider, ProviderAdapter};
+pub use provider::{InstallSource, LoginFailureHint, Provider, ProviderAdapter};
 pub use provider_auth::ProviderAuthState;
 pub use provider_error_kind::{
     AuthFailureCause, ModelUnavailableReason, ProviderError, QuotaScope,

--- a/engine/houston-terminal-manager/src/provider/mod.rs
+++ b/engine/houston-terminal-manager/src/provider/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod anthropic_classify;
 mod gemini;
 mod openai;
 mod openai_classify;
+pub(crate) mod openai_login;
 mod resolve;
 
 pub(crate) use anthropic_classify::detect_malformed_provider_json;
@@ -45,6 +46,26 @@ pub use resolve::{which_on_path, InstallSource};
 /// trait stays object-safe without the `async-trait` macro (which would
 /// allocate a `Pin<Box<dyn Future>>` on every call anyway).
 pub type ProbeFuture<'a> = Pin<Box<dyn Future<Output = ProviderAuthState> + Send + 'a>>;
+
+/// An actionable, recoverable diagnosis of a provider *login* subprocess that
+/// exited non-zero. Produced by [`ProviderAdapter::diagnose_login_failure`].
+///
+/// Login failures are surfaced as plain strings (a toast description over the
+/// REST login call, or the `error` field of a `ProviderLoginComplete` WS
+/// event) — NOT as the session-level [`ProviderError`] card taxonomy
+/// ([`ProviderAdapter::classify_stderr`] et al.), which only applies to a
+/// *running* chat session. So this carries a ready-to-show `message` plus a
+/// stable `kind` the frontend can later match for localized copy.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoginFailureHint {
+    /// Stable machine-readable tag (e.g. `"codex_login_server_unavailable"`).
+    /// Surfaces as `CoreError::Labeled.kind` → `error.details.kind`.
+    pub kind: &'static str,
+    /// User-facing, recoverable English message. Shown as the toast
+    /// description; the engine is i18n-agnostic, so this is English like every
+    /// other login-error detail.
+    pub message: String,
+}
 
 /// One AI provider's CLI integration. Every method is intended to be
 /// cheap to call repeatedly — the registry hands out shared `&'static`
@@ -158,6 +179,20 @@ pub trait ProviderAdapter: Send + Sync + 'static {
             cli_name: self.cli_name().into(),
             message: truncate_excerpt(stderr_excerpt),
         }
+    }
+
+    /// Diagnose a *login* subprocess that exited non-zero, from its captured
+    /// `stdout` + `stderr`. Returns [`Some`] with an actionable, recoverable
+    /// [`LoginFailureHint`] when the adapter recognizes a known startup-failure
+    /// signature, otherwise [`None`] so the caller surfaces the raw CLI output.
+    ///
+    /// Default is `None` (no special diagnosis). OpenAI overrides it because
+    /// plain `codex login` runs a fixed-port `localhost:1455` loopback server
+    /// whose benign startup banner used to leak as the error string when the
+    /// server failed to start (HOU-446). Unlike [`Self::classify_stderr`], this
+    /// is NOT on a hot path — it runs once, only when a login attempt fails.
+    fn diagnose_login_failure(&self, _stdout: &str, _stderr: &str) -> Option<LoginFailureHint> {
+        None
     }
 
     // -------------------------------------------------------------------
@@ -307,6 +342,12 @@ impl Provider {
         stderr_excerpt: &str,
     ) -> ProviderError {
         self.0.classify_spawn_failure(exit_code, stderr_excerpt)
+    }
+
+    /// Diagnose a non-zero login-subprocess exit. See
+    /// [`ProviderAdapter::diagnose_login_failure`].
+    pub fn diagnose_login_failure(self, stdout: &str, stderr: &str) -> Option<LoginFailureHint> {
+        self.0.diagnose_login_failure(stdout, stderr)
     }
 
     /// Reasoning-effort levels this provider accepts. See
@@ -487,6 +528,30 @@ mod tests {
             );
         }
         assert!(gemini.default_effort().is_none());
+    }
+
+    #[test]
+    fn diagnose_login_failure_only_for_openai() {
+        // The codex loopback login-server banner / port-1455 failure is
+        // diagnosed for OpenAI and surfaced as a recoverable hint...
+        let openai = Provider::from_str("openai").unwrap();
+        let hint = openai
+            .diagnose_login_failure("", "Starting local login server on http://localhost:1455.")
+            .expect("openai diagnoses the codex login-server failure");
+        assert_eq!(hint.kind, "codex_login_server_unavailable");
+        assert!(hint.message.contains("1455"));
+
+        // ...while providers that don't run a loopback login server keep the
+        // trait default (None) and let their raw stderr surface.
+        for id in ["anthropic", "gemini"] {
+            assert!(
+                Provider::from_str(id)
+                    .unwrap()
+                    .diagnose_login_failure("", "Starting local login server on http://localhost:1455.")
+                    .is_none(),
+                "{id} must not borrow codex's login-server diagnosis"
+            );
+        }
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/provider/openai.rs
+++ b/engine/houston-terminal-manager/src/provider/openai.rs
@@ -104,4 +104,12 @@ impl ProviderAdapter for OpenAiAdapter {
     ) -> Option<ProviderError> {
         openai_classify::classify_result_error(error_type, error_message)
     }
+
+    fn diagnose_login_failure(&self, stdout: &str, stderr: &str) -> Option<super::LoginFailureHint> {
+        // Recognize the `codex login` loopback server failing to start on its
+        // fixed port 1455 (HOU-446) and return a recoverable message instead
+        // of leaking codex's benign "Starting local login server" banner as
+        // the error. See `openai_login::diagnose`.
+        super::openai_login::diagnose(stdout, stderr)
+    }
 }

--- a/engine/houston-terminal-manager/src/provider/openai_login.rs
+++ b/engine/houston-terminal-manager/src/provider/openai_login.rs
@@ -1,0 +1,168 @@
+//! Codex login-subprocess failure diagnosis.
+//!
+//! Distinct from [`super::openai_classify`], which maps a *running* codex
+//! session's stderr / result errors onto the session-level
+//! [`crate::provider_error_kind::ProviderError`] card taxonomy. This module
+//! diagnoses a `codex login` subprocess that exits non-zero, turning a
+//! confusing raw-CLI-output toast into an actionable, recoverable message.
+//!
+//! ## The bug this fixes (HOU-446)
+//!
+//! Plain `codex login` (the desktop loopback flow) starts a local HTTP
+//! callback server on a **fixed** port (1455) and prints the informational
+//! banner `Starting local login server on http://localhost:1455.` before it
+//! waits for the browser redirect. When that helper can't start — the port is
+//! already held by an orphaned prior `codex login`, or it's blocked by a
+//! firewall / VPN / security tool — codex exits non-zero within a second of
+//! printing that banner.
+//!
+//! Houston's login probe ([`crate::provider`] caller in
+//! `houston-engine-core`) surfaced the first non-empty output stream verbatim
+//! as the failure detail, so the user saw
+//! `internal: codex login: Starting local login server on http://localhost:1455.`
+//! — codex's benign startup line dressed up as an internal error, with no
+//! cause and no path to recover.
+//!
+//! [`diagnose`] recognizes that startup-failure signature (the banner, the
+//! fixed port, or an explicit address-in-use / bind error on any platform)
+//! and returns a [`super::LoginFailureHint`] the caller renders as a clear,
+//! recoverable message. Anything it doesn't recognize returns `None`, so a
+//! genuine codex login error (bad config, auth failure, ...) still surfaces
+//! its real stderr.
+
+use super::LoginFailureHint;
+
+/// Machine-readable tag attached to the diagnosed error
+/// (`CoreError::Labeled.kind` → `error.details.kind` on the wire). The
+/// frontend may match on it to render localized copy; until it does, the
+/// English [`SERVER_UNAVAILABLE_MESSAGE`] is shown as the toast description.
+pub const SERVER_UNAVAILABLE_KIND: &str = "codex_login_server_unavailable";
+
+/// User-facing, recoverable message for the codex loopback login-server
+/// startup failure. Desktop-appropriate: the desktop app has no device-code
+/// fallback button (that flow is remote-only), so the guidance is "close the
+/// other sign-in, wait, retry" rather than "use a one-time code". No em dash
+/// per the copy rules.
+pub const SERVER_UNAVAILABLE_MESSAGE: &str = "Codex could not start its local sign-in helper on port 1455. Another Codex sign-in may still be running, or the port is blocked by other software. Close any other sign-in window, wait a few seconds, then try Connect again.";
+
+/// Lowercased substrings that mark a codex loopback login-server startup
+/// failure. Any one match is enough. Kept deliberately specific to the
+/// login-server / fixed port so a different codex login failure (bad config,
+/// auth error) falls through to its real stderr instead of being mislabeled.
+const SERVER_FAILURE_SIGNATURES: &[&str] = &[
+    // codex's own informational banner — present even when the bind then
+    // fails, which is exactly the line that used to leak as "the error".
+    "local login server",
+    // The fixed loopback port codex always uses for this flow.
+    "localhost:1455",
+    "127.0.0.1:1455",
+    ":1455",
+    // Explicit bind failures, across platforms:
+    "address already in use", // generic
+    "address in use",
+    "eaddrinuse",                            // Node-style / some wrappers
+    "os error 48",                           // macOS EADDRINUSE
+    "os error 98",                           // Linux EADDRINUSE
+    "only one usage of each socket address", // Windows WSAEADDRINUSE
+    "failed to bind",
+    "could not bind",
+    "error binding",
+];
+
+/// Diagnose a non-zero `codex login` exit from its captured `stdout` +
+/// `stderr`. Returns [`Some`] with a recoverable hint when the output carries
+/// a loopback login-server startup-failure signature, otherwise [`None`].
+///
+/// Both streams are inspected because codex has printed the banner to stderr
+/// in shipped versions while a bind error can land on either stream; matching
+/// the union avoids depending on which stream a given codex build uses.
+pub fn diagnose(stdout: &str, stderr: &str) -> Option<LoginFailureHint> {
+    let haystack = format!("{stdout}\n{stderr}").to_lowercase();
+    SERVER_FAILURE_SIGNATURES
+        .iter()
+        .any(|sig| haystack.contains(sig))
+        .then(|| LoginFailureHint {
+            kind: SERVER_UNAVAILABLE_KIND,
+            message: SERVER_UNAVAILABLE_MESSAGE.to_string(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn diagnoses_the_benign_banner_on_stderr() {
+        // The exact Sentry case (HOU-446): codex printed only its
+        // informational startup banner and exited non-zero. It must become
+        // the recoverable hint, never leak verbatim as "the error".
+        let hint = diagnose("", "Starting local login server on http://localhost:1455.")
+            .expect("banner is a login-server startup failure");
+        assert_eq!(hint.kind, SERVER_UNAVAILABLE_KIND);
+        assert!(hint.message.contains("1455"), "message names the port: {}", hint.message);
+        assert!(
+            hint.message.to_lowercase().contains("try connect again"),
+            "message tells the user how to recover: {}",
+            hint.message
+        );
+    }
+
+    #[test]
+    fn diagnoses_the_banner_on_stdout_too() {
+        // Some codex builds print the banner to stdout; the caller prefers
+        // stderr but falls back to stdout, so we must catch either stream.
+        assert!(diagnose("Starting local login server on http://localhost:1455.", "").is_some());
+    }
+
+    #[test]
+    fn diagnoses_explicit_bind_errors_each_platform() {
+        // macOS / Linux / Windows address-in-use phrasings, plus the generic.
+        for stderr in [
+            "Error: Address already in use (os error 48)",
+            "thread 'main' panicked: address already in use (os error 98)",
+            "only one usage of each socket address is normally permitted",
+            "EADDRINUSE: address already in use 127.0.0.1:1455",
+            "failed to bind TcpListener",
+        ] {
+            assert!(
+                diagnose("", stderr).is_some(),
+                "should diagnose bind failure: {stderr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_case_insensitive() {
+        assert!(diagnose("", "STARTING LOCAL LOGIN SERVER ON HTTP://LOCALHOST:1455.").is_some());
+    }
+
+    #[test]
+    fn ignores_unrelated_codex_login_errors() {
+        // A genuine, already-actionable codex error must fall through to its
+        // real stderr (return None) instead of being mislabeled as a port
+        // problem. These are the false-positive guards.
+        for stderr in [
+            "Error loading configuration: unknown variant `max`",
+            "error: unexpected argument '--nope'",
+            "Your access token could not be refreshed. Please log out and sign in again.",
+            "could not connect to https://chatgpt.com",
+        ] {
+            assert!(
+                diagnose("", stderr).is_none(),
+                "must NOT hijack a real error: {stderr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn empty_output_is_none() {
+        assert!(diagnose("", "").is_none());
+        assert!(diagnose("   \n  ", "  ").is_none());
+    }
+
+    #[test]
+    fn message_has_no_em_dash() {
+        // Copy rule: no em dashes in user-facing strings.
+        assert!(!SERVER_UNAVAILABLE_MESSAGE.contains('\u{2014}'));
+    }
+}

--- a/knowledge-base/provider-errors.md
+++ b/knowledge-base/provider-errors.md
@@ -171,6 +171,42 @@ Resist if `Unknown` covers it. If you must:
 7. `cargo test --workspace`, `pnpm tsc --noEmit`, `pnpm check-locales`,
    `pnpm vite build` — every gate green before committing.
 
+## Login-flow failures (separate from session classification)
+
+Everything above is about a **running session** — stderr / result events from a
+spawned chat run, classified into the `ProviderError` card taxonomy. The
+**login** flow (`provider::launch_login` in `houston-engine-core`) is a
+different surface, and its failures are plain strings, not cards:
+
+- sub-3s probe exit → `CoreError` → REST → toast description.
+- >3s relay exit → `ProviderLoginComplete.error` (string) → toast description.
+
+The login probe used to surface the CLI's first non-empty output stream
+verbatim as the error. For codex that leaked its benign startup banner
+`Starting local login server on http://localhost:1455.` as
+`internal: codex login: <banner>` — no cause, no recovery (HOU-446). Plain
+`codex login` runs a **fixed-port (1455)** loopback callback server; when it
+can't start (port held by an orphaned prior login, or blocked by a firewall /
+VPN / security tool) codex dies right after printing that banner.
+
+The adapter now owns login diagnosis:
+`ProviderAdapter::diagnose_login_failure(stdout, stderr) -> Option<LoginFailureHint>`
+(default `None`). OpenAI overrides it (`provider/openai_login.rs`) to recognize
+the login-server / port-1455 / address-in-use signature and return a clean,
+recoverable message plus a stable `kind`. Both failure paths
+(`login_early_exit_error` in `provider/mod.rs`, `make_login_error` in
+`provider/login_relay.rs`) prefer the diagnosis; with none they fall back to the
+raw stderr — still the actionable detail for a genuine login error. The
+diagnosed error surfaces as
+`CoreError::Labeled { code: Unavailable, kind, message }`: clean (no `internal:`
+prefix), with `kind` reaching `error.details.kind` for future localized copy.
+
+This is NOT a new `ProviderError` variant — login failures never render as
+session cards, so they stay out of the taxonomy table above.
+
+(Same fix biased the relay's stdout/exit `select!` so a fast-exiting CLI's
+login URL is always drained before its exit is observed — see `login_relay.rs`.)
+
 ## File map
 
 | Layer        | Path                                                                              |
@@ -179,6 +215,7 @@ Resist if `Unknown` covers it. If you must:
 | Trait        | `engine/houston-terminal-manager/src/provider/mod.rs`                             |
 | Anthropic    | `engine/houston-terminal-manager/src/provider/anthropic_classify.rs`              |
 | OpenAI       | `engine/houston-terminal-manager/src/provider/openai_classify.rs`                 |
+| Codex login  | `engine/houston-terminal-manager/src/provider/openai_login.rs` (login-flow diag)  |
 | Gemini       | `engine/houston-terminal-manager/src/provider/gemini/classify.rs`                 |
 | Stderr wire  | `engine/houston-terminal-manager/src/session_io.rs::read_stderr_lines`            |
 | Result wire  | `engine/houston-terminal-manager/src/gemini_parser_state.rs::handle_result`       |


### PR DESCRIPTION
## Linear
Fixes **[HOU-446](https://linear.app/houston-ai/issue/HOU-446/launch-provider-login-codex-local-login-server-error)** — `launch_provider_login`: codex local login server error.

(Branch `fix-hou-446-codex-login` carries the issue id, so Linear ↔ PR link both ways.)

## Problem
From Sentry (`HOUSTON-APP-6E`, app 0.4.18–0.4.21): clicking **Connect** for Codex could toast

> `internal: codex login: Starting local login server on http://localhost:1455.`

That string is **codex's benign informational startup banner**, not an error. `launch_login`'s 3-second probe (`provider/mod.rs`), on an early non-zero CLI exit, surfaced the CLI's **first non-empty output stream verbatim** as the failure detail — so codex's banner got dressed up as an internal error with **no cause and no recovery path**. The `>3s` relay path (`login_relay.rs`) had the same flaw via `format_exit_error`.

Plain `codex login` runs a **fixed-port (1455)** loopback callback server. When it can't start — port held by an orphaned prior `codex login`, or blocked by a firewall / VPN / security tool — codex dies right after printing the banner. (Confirmed: the banner is codex's literal startup line; the bundled codex at the affected releases printed it to a pipe.)

## Fix
- New adapter hook `ProviderAdapter::diagnose_login_failure(stdout, stderr) -> Option<LoginFailureHint>` (default `None`). Login failures are plain strings (toast description / `ProviderLoginComplete.error`), **not** the session `ProviderError` card taxonomy — so this is a separate, honest surface.
- **OpenAI** overrides it (`provider/openai_login.rs`, pure + unit-tested): recognizes the login-server / `localhost:1455` / address-in-use signature across platforms and returns a clean, **recoverable** message:
  > Codex could not start its local sign-in helper on port 1455. Another Codex sign-in may still be running, or the port is blocked by other software. Close any other sign-in window, wait a few seconds, then try Connect again.
- Wired into **both** failure paths: the sub-3s probe (`login_early_exit_error`) and the relay (`make_login_error`). The diagnosed error surfaces as `CoreError::Labeled { code: Unavailable, kind: "codex_login_server_unavailable", message }` — **no `internal:` prefix**, and `kind` reaches `error.details.kind` for future localized copy. With no diagnosis we fall back to the raw stderr (still the actionable detail for a genuine codex login error).
- **Bonus latent bug:** biased the relay's stdout/exit `select!` so a fast-exiting CLI's login URL is always drained before its exit is observed. This fixes a pre-existing **flaky** relay test (`device_auth_relay_emits_url_then_code`, ~80% fail in isolation) and a real dropped-URL race.

## i18n note
The toast **title** is already `t()`-localized; the **description** is the engine message, which is English for every login error today (the boundary keeps the engine i18n-agnostic). This change improves that English and attaches a stable `kind` as the hook for app-side localized copy later — it does not introduce a new untranslated frontend string.

## Tests
`cargo test --workspace` green. Added:
- `openai_login::diagnose` units — banner on stderr/stdout, per-platform bind errors, case-insensitivity, **false-positive guards** (real config/auth errors fall through), empty, no-em-dash.
- `provider/mod.rs` (terminal-manager): adapter forwarding (openai diagnoses; claude/gemini keep default `None`).
- `provider/mod.rs` (core): `login_early_exit_error` → `Labeled`/clean message, real-error pass-through, other-provider default, no-output status.
- `login_relay.rs`: `make_login_error` precedence + a `#[cfg(unix)]` end-to-end relay test.

## Files
- `engine/houston-terminal-manager/src/provider/openai_login.rs` (new) — pure diagnoser + tests
- `engine/houston-terminal-manager/src/provider/{mod.rs,openai.rs}`, `src/lib.rs` — trait hook, `LoginFailureHint`, OpenAI override, re-export
- `engine/houston-engine-core/src/provider/{mod.rs,login_relay.rs}` — wiring + biased select
- `knowledge-base/provider-errors.md` — login-flow-diagnosis section + file map

🤖 Generated with [Claude Code](https://claude.com/claude-code)