### PR TITLE
fix(app): gate phone-access reset on tunnel readiness (HOU-443)

### DIFF
--- a/app/src/components/settings/sections/connect-phone-state.ts
+++ b/app/src/components/settings/sections/connect-phone-state.ts
@@ -1,0 +1,24 @@
+/**
+ * Pure gating logic for the Connect-phone settings section, split out so the
+ * decision is unit-testable without rendering React (see
+ * `app/tests/connect-phone-state.test.ts`).
+ */
+
+export interface TunnelReadiness {
+  /** True only once the tunnel has allocated AND we're connected to the relay. */
+  connected: boolean;
+}
+
+/**
+ * Whether "Disconnect all phones" (reset access) may be invoked.
+ *
+ * Resetting rotates the QR and revokes paired phones via a relay round-trip,
+ * which only succeeds once the tunnel has finished allocating and is connected.
+ * Firing it earlier produced the raw `unavailable: Tunnel allocation hasn't
+ * completed yet` error and an unhandled rejection (HOU-443). The frontend only
+ * has `connected` to go on — when the tunnel is still allocating or the machine
+ * is offline, `connected` is false — so we gate the action on it.
+ */
+export function canResetPhoneAccess(info: TunnelReadiness | null): boolean {
+  return info?.connected === true;
+}

--- a/app/src/components/settings/sections/connect-phone.tsx
+++ b/app/src/components/settings/sections/connect-phone.tsx
@@ -6,6 +6,7 @@ import { tauriTunnel } from "../../../lib/tauri";
 import { analytics } from "../../../lib/analytics";
 import { logger } from "../../../lib/logger";
 import { useUIStore } from "../../../stores/ui";
+import { canResetPhoneAccess } from "./connect-phone-state";
 
 interface TunnelInfo {
   connected: boolean;
@@ -80,16 +81,23 @@ export function ConnectPhoneSection() {
       ? `${info.publicHost.startsWith("localhost") ? "http" : "https"}://${info.publicHost}/pair/${pairingCode}`
       : null;
 
+  const canReset = canResetPhoneAccess(info);
+
   const handleReset = async () => {
     if (resetting) return;
     setResetting(true);
     try {
       await tauriTunnel.resetAccess();
-      setConfirmOpen(false);
       setPairingCode(null);
       void loadStatus();
       addToast({ title: t("settings:connectPhone.reset.toast") });
+    } catch {
+      // `tauriTunnel.resetAccess` routes through `call`, which already
+      // surfaced the failure (toast + Sentry capture). Swallow here only so a
+      // rejected reset can't escape as an unhandled rejection — the bug behind
+      // HOU-443, where reset fired before the tunnel had finished allocating.
     } finally {
+      setConfirmOpen(false);
       setResetting(false);
     }
   };
@@ -160,11 +168,16 @@ export function ConnectPhoneSection() {
         <Button
           variant="outline"
           className="rounded-full"
-          disabled={resetting}
+          disabled={resetting || !canReset}
           onClick={() => setConfirmOpen(true)}
         >
           {t("settings:connectPhone.reset.button")}
         </Button>
+        {!canReset && (
+          <p className="mt-2 text-[11px] text-muted-foreground leading-relaxed">
+            {t("settings:connectPhone.reset.unavailable")}
+          </p>
+        )}
       </div>
 
       <ConfirmDialog

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -59,7 +59,8 @@
       "confirmTitle": "Disconnect all phones?",
       "confirmDescription": "This resets the QR and signs out every phone currently connected to this computer. Scan the new QR to connect again.",
       "confirmLabel": "Disconnect",
-      "toast": "Phone access reset"
+      "toast": "Phone access reset",
+      "unavailable": "Available once your phone connection is ready."
     }
   },
   "timezone": {

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -59,7 +59,8 @@
       "confirmTitle": "¿Desconectar todos los celulares?",
       "confirmDescription": "Esto restablece el QR y cierra la sesión de todos los celulares conectados a esta computadora. Escanea el nuevo QR para conectarte otra vez.",
       "confirmLabel": "Desconectar",
-      "toast": "Acceso desde el celular restablecido"
+      "toast": "Acceso desde el celular restablecido",
+      "unavailable": "Disponible cuando la conexión con tu celular esté lista."
     }
   },
   "timezone": {

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -59,7 +59,8 @@
       "confirmTitle": "Desconectar todos os celulares?",
       "confirmDescription": "Isso redefine o QR e sai de todos os celulares conectados a este computador. Escaneie o novo QR para conectar de novo.",
       "confirmLabel": "Desconectar",
-      "toast": "Acesso pelo celular redefinido"
+      "toast": "Acesso pelo celular redefinido",
+      "unavailable": "Disponível quando a conexão com seu celular estiver pronta."
     }
   },
   "timezone": {

--- a/app/tests/connect-phone-state.test.ts
+++ b/app/tests/connect-phone-state.test.ts
@@ -1,0 +1,19 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { canResetPhoneAccess } from "../src/components/settings/sections/connect-phone-state.ts";
+
+describe("canResetPhoneAccess (HOU-443 gating)", () => {
+  it("allows reset only when the tunnel is connected", () => {
+    strictEqual(canResetPhoneAccess({ connected: true }), true);
+  });
+
+  it("blocks reset while the tunnel is still allocating or offline", () => {
+    // The exact bug: reset fired before allocation completed (connected:false),
+    // surfacing `unavailable: Tunnel allocation hasn't completed yet`.
+    strictEqual(canResetPhoneAccess({ connected: false }), false);
+  });
+
+  it("blocks reset before status has loaded (no info yet)", () => {
+    strictEqual(canResetPhoneAccess(null), false);
+  });
+});


### PR DESCRIPTION
## Root cause

**Linear:** [HOU-443](https://linear.app/houston-ai/issue/HOU-443/tunnel-reset-access-called-before-tunnel-allocation-completes) — `tunnel_reset_access` called before tunnel allocation completes (Sentry `HOUSTON-APP-88`, collapsed dup `APP-AH unhandled_rejection`; houston-app 0.4.18–0.4.21).

In **Settings → Connect phone**, the "Disconnect all phones" button was only disabled while a reset was in flight (`disabled={resetting}`) — it was **not** gated on tunnel readiness, unlike the pairing-code mint which gates on `info.connected`. So a user could trigger reset before the tunnel finished allocating (first boot) or while offline. The engine's `POST /v1/tunnel/reset-access` then returns `CoreError::Unavailable("Tunnel allocation hasn't completed yet…")`.

Two failures resulted:
1. The raw `unavailable` engine message was surfaced verbatim to the user (via `call` → `surfaceError`), built in `HoustonClient.toError`.
2. `handleReset` was `try { … } finally { … }` with **no `catch`**. `ConfirmDialog` binds `onConfirm` as a plain `onClick` (`() => void`), so the rejected promise was neither awaited nor caught → **unhandled rejection** (`APP-AH`).

## Fix (frontend only — engine already returns a structured error)

- **Gate the action on tunnel readiness.** New pure helper `canResetPhoneAccess(info)` (`= info?.connected === true`); the reset button is now `disabled={resetting || !canReset}`.
- **Clear copy instead of the raw error.** When not ready, show "Available once your phone connection is ready." under the button (en/es/pt).
- **Stop the unhandled rejection.** `handleReset` now `catch`es; `call`/`surfaceError` already toasts + reports genuine failures (e.g. relay error mid-reset), so the catch only prevents the rejection escaping. `setConfirmOpen(false)` moved to `finally`.
- Extracted the gate to a co-located `connect-phone-state.ts` with a unit test, mirroring the `provider-reconnect-state.ts` convention.

## Files
- `app/src/components/settings/sections/connect-phone.tsx` — gate button + hint, add `catch`
- `app/src/components/settings/sections/connect-phone-state.ts` — new pure `canResetPhoneAccess` helper
- `app/tests/connect-phone-state.test.ts` — new unit test (3 cases)
- `app/src/locales/{en,es,pt}/settings.json` — `connectPhone.reset.unavailable`

## Verification

**Before:** Open Settings → Connect phone on first launch (or with no internet) before the tunnel connects, and click **Disconnect all phones**. Result: raw toast `tunnel_reset_access: unavailable: Tunnel allocation hasn't completed yet` + an unhandled-rejection report in Sentry.

**After:** While the tunnel is still allocating / offline, the **Disconnect all phones** button is disabled with the hint "Available once your phone connection is ready." Once the tunnel reports `connected`, the button enables and reset works. No raw `unavailable` toast, no unhandled rejection.

Checks run: `pnpm tsc --noEmit` ✅ · `pnpm check-locales` ✅ (es/pt in sync) · `node --test tests/connect-phone-state.test.ts` ✅ (3/3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)