### PR TITLE
fix(app): swallow benign Web Locks steal rejections (HOU-435)

### DIFF
--- a/app/src/lib/benign-rejections.ts
+++ b/app/src/lib/benign-rejections.ts
@@ -1,0 +1,48 @@
+/**
+ * Supabase auth-js coordinates token refresh across browser contexts (tabs,
+ * webviews, Houston's multi-window shell) with the Web Locks API. When one
+ * context's lock acquire times out, auth-js recovers by *stealing* the lock
+ * (`navigator.locks.request(name, { steal: true }, …)`). Per the Web Locks
+ * spec the displaced holder's request promise then rejects. Depending on the
+ * browser build and the bundled auth-js version that surfaces as either:
+ *
+ *   - a raw DOMException — "Lock was stolen by another request" or
+ *     "Lock broken by another request with the 'steal' option", or
+ *   - auth-js's typed `NavigatorLockAcquireTimeoutError`, which carries
+ *     `isAcquireTimeout === true` (the `ProcessLock` variant sets it too).
+ *
+ * None of these are real failures: the steal *is* the recovery and the auto
+ * refresh simply retries on its next tick. Supabase fires that refresh from an
+ * internal timer we can't attach a `.catch` to, so when it rejects it reaches
+ * our global `onunhandledrejection` handler. Without this guard it became a
+ * scary "we have a problem" toast for non-technical users plus unactionable
+ * Sentry noise (HOU-435 / HOUSTON-APP-8Y, dup APP-6Q).
+ *
+ * Treat it as background lock contention: swallow it, don't surface it. This is
+ * NOT a banned silent-failure — the rejection comes from a background timer, is
+ * not a user-initiated action, and is recovered automatically. User-initiated
+ * auth calls (sign-in, code exchange) are awaited with their own try/catch in
+ * `auth.ts`, so those rejections are *handled* and never reach this predicate.
+ */
+export function isBenignLockRejection(reason: unknown): boolean {
+  if (!reason || typeof reason !== "object") return false;
+
+  // auth-js's typed acquire-timeout / steal errors flag themselves. Filtering
+  // on this is exactly auth-js's documented intent ("convert to a typed error
+  // so callers can handle/filter it without it leaking to Sentry as a raw
+  // AbortError").
+  if ((reason as { isAcquireTimeout?: unknown }).isAcquireTimeout === true) {
+    return true;
+  }
+
+  const message = (reason as { message?: unknown }).message;
+  if (typeof message !== "string") return false;
+  const normalized = message.toLowerCase();
+  // Raw Web Locks DOMException phrasings (they vary by browser build) plus
+  // auth-js's own wrapped message. All describe the same steal event.
+  return (
+    normalized.includes("stolen by another request") ||
+    normalized.includes("broken by another request") ||
+    normalized.includes("another request stole it")
+  );
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -17,6 +17,7 @@ import i18n from "./lib/i18n";
 import { DisclaimerGate } from "./components/shell/disclaimer-gate";
 import { LanguageGate } from "./components/shell/language-gate";
 import { showErrorToast } from "./lib/error-toast";
+import { isBenignLockRejection } from "./lib/benign-rejections";
 import { analytics, classifyAnalyticsError } from "./lib/analytics";
 import { initSentry } from "./lib/sentry";
 import { installSentrySmokeShortcuts } from "./lib/sentry-smoke";
@@ -53,6 +54,16 @@ window.onerror = (_event, _source, _line, _col, error) => {
 
 window.onunhandledrejection = (event: PromiseRejectionEvent) => {
   const message = event.reason?.message ?? String(event.reason);
+  // Supabase's cross-context auth-refresh lock gets stolen as a normal part of
+  // its own recovery; the displaced promise rejects from a timer we can't
+  // catch. Not a real error — swallow it instead of toasting + reporting
+  // (HOU-435). console.debug only (not the patched console.error) so it never
+  // reaches the log file as an error or the user as a toast.
+  if (isBenignLockRejection(event.reason)) {
+    event.preventDefault();
+    console.debug("[global:unhandledrejection] ignored benign Web Locks contention:", message);
+    return;
+  }
   console.error("[global:unhandledrejection]", message, event.reason);
   analytics.captureException(event.reason, {
     source: "unhandled_rejection",

--- a/app/tests/benign-rejections.test.ts
+++ b/app/tests/benign-rejections.test.ts
@@ -1,0 +1,85 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { isBenignLockRejection } from "../src/lib/benign-rejections.ts";
+
+/**
+ * auth-js's typed acquire-timeout error, reduced to the shape our predicate
+ * reads: an Error subclass carrying `isAcquireTimeout === true`.
+ */
+function acquireTimeoutError(message: string): Error {
+  return Object.assign(new Error(message), { isAcquireTimeout: true });
+}
+
+describe("isBenignLockRejection", () => {
+  it("matches the raw Web Locks 'stolen' DOMException (HOUSTON-APP-8Y)", () => {
+    strictEqual(
+      isBenignLockRejection(new Error("Lock was stolen by another request")),
+      true,
+    );
+  });
+
+  it("matches the raw Web Locks 'broken … steal' DOMException (dup APP-6Q)", () => {
+    strictEqual(
+      isBenignLockRejection(
+        new Error("Lock broken by another request with the 'steal' option"),
+      ),
+      true,
+    );
+  });
+
+  it("matches auth-js's wrapped 'another request stole it' message", () => {
+    strictEqual(
+      isBenignLockRejection(
+        new Error('Lock "sb-auth-token" was released because another request stole it'),
+      ),
+      true,
+    );
+  });
+
+  it("matches any auth-js error flagged isAcquireTimeout, regardless of message", () => {
+    strictEqual(
+      isBenignLockRejection(acquireTimeoutError("Acquiring an exclusive lock timed out")),
+      true,
+    );
+  });
+
+  it("is case-insensitive on the message", () => {
+    strictEqual(
+      isBenignLockRejection(new Error("LOCK WAS STOLEN BY ANOTHER REQUEST")),
+      true,
+    );
+  });
+
+  it("does NOT match an unrelated error that merely mentions a lock", () => {
+    strictEqual(
+      isBenignLockRejection(new Error("Failed to lock the keychain item")),
+      false,
+    );
+  });
+
+  it("does NOT match a generic application error", () => {
+    strictEqual(
+      isBenignLockRejection(new Error("Network request failed")),
+      false,
+    );
+  });
+
+  it("does NOT match isAcquireTimeout when it is not strictly true", () => {
+    strictEqual(
+      isBenignLockRejection(Object.assign(new Error("x"), { isAcquireTimeout: "yes" })),
+      false,
+    );
+  });
+
+  it("handles non-object reasons safely", () => {
+    strictEqual(isBenignLockRejection(null), false);
+    strictEqual(isBenignLockRejection(undefined), false);
+    strictEqual(isBenignLockRejection("Lock was stolen by another request"), false);
+    strictEqual(isBenignLockRejection(42), false);
+  });
+
+  it("handles an object with no message", () => {
+    strictEqual(isBenignLockRejection({}), false);
+    strictEqual(isBenignLockRejection({ message: 123 }), false);
+  });
+});


### PR DESCRIPTION
## Linear
[HOU-435 — Web Locks "Lock was stolen by another request" unhandled rejection](https://linear.app/houston-ai/issue/HOU-435/web-locks-lock-was-stolen-by-another-request-unhandled-rejection)

## Root cause
Supabase **auth-js** coordinates token refresh across browser contexts (tabs, webviews, Houston's multi-window shell) with the **Web Locks API**. When a lock acquire times out, auth-js recovers by *stealing* the lock — `navigator.locks.request(name, { steal: true }, …)` (`@supabase/auth-js` `src/lib/locks.ts`). Per the Web Locks spec, the displaced holder's `request` promise then **rejects**, surfacing as either:

- a raw `DOMException` — `Lock was stolen by another request` / `Lock broken by another request with the 'steal' option`, or
- auth-js's typed `NavigatorLockAcquireTimeoutError` (carries `isAcquireTimeout === true`).

The refresh fires from an **internal timer we can't attach a `.catch` to**, so the rejection went **unhandled** and hit our global `window.onunhandledrejection` handler in `app/src/main.tsx`, which reports to Sentry **and** shows a red "we have a problem" toast. For our non-technical users this is a scary, unactionable error — but the steal *is* auth-js's recovery and the refresh just retries on its next tick. Sentry: `HOUSTON-APP-8Y` (dup `APP-6Q`), 6 users, releases 0.4.18–0.4.21. The reported culprit `createSentryReportError` is a red herring — it's just where our reporting path constructs the `Error`.

## Fix
- New pure predicate `app/src/lib/benign-rejections.ts` → `isBenignLockRejection(reason)`. Matches the typed flag (`isAcquireTimeout === true`) and the raw browser phrasings (`stolen by another request`, `broken by another request`, `another request stole it`).
- `main.tsx` `onunhandledrejection` short-circuits when benign: `event.preventDefault()` + a `console.debug` breadcrumb, **no toast, no Sentry capture**.

This is **not** a banned silent-failure: the rejection comes from a background timer (not a user-initiated action) and is auto-recovered. User-initiated auth calls (sign-in, code exchange) are awaited with their own `try/catch` in `auth.ts`, so those rejections are *handled* and never reach this predicate — they still surface as before.

## Tests
- `app/tests/benign-rejections.test.ts` — 10 cases over verbatim Sentry messages, the auth-js typed shape, case-insensitivity, and negatives (generic "lock" errors, non-objects, `isAcquireTimeout` not strictly `true`).
- Full app suite green: **267 pass / 0 fail**. `tsc --noEmit` clean.

## Verify
**Before:** with releases 0.4.18–0.4.21, when auth-js stole a refresh lock across two app windows, a red error toast appeared (`unhandled_rejection: Lock was stolen by another request`) and an event landed in Sentry.

**After:** the rejection is recognized as benign background lock contention, `preventDefault`'d, and logged at `console.debug` only — no toast, no Sentry event. Auth keeps working (refresh retries next tick).

## Files
- `app/src/lib/benign-rejections.ts` (new)
- `app/src/main.tsx`
- `app/tests/benign-rejections.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)