### PR TITLE
fix(engine): recover corrupt routines.json instead of bricking list (HOU-436)

### DIFF
--- a/engine/houston-engine-core/src/agents/store.rs
+++ b/engine/houston-engine-core/src/agents/store.rs
@@ -58,23 +58,34 @@ pub fn with_json_file_lock<T>(
 }
 
 /// Read and deserialize `.houston/<name>/<name>.json`.
-/// Returns `T::default()` if the file does not exist or is empty.
+///
+/// Resilient by design — a corrupt `.houston` data file must never
+/// permanently brick the surface that reads it (HOU-436: a malformed
+/// `routines.json` made every `list_routines` call 500 with `json error:
+/// expected value at line 1 column 1`). Recovery, least-lossy first:
+/// - missing, empty, or whitespace-only file → `T::default()`
+/// - a leading UTF-8 BOM (U+FEFF) is stripped before parsing; serde_json
+///   does not skip one, so a BOM-prefixed file otherwise fails at line 1
+///   column 1 (editors, cloud-sync, and Windows writers all emit BOMs)
+/// - one valid value followed by trailing junk → keep the first value
+/// - otherwise unparseable → reset to `T::default()`
+///
+/// Every recovery that mutates the file first preserves the original bytes
+/// as a timestamped `.bak` and logs a warning, so nothing is lost silently.
 pub fn read_json<T: DeserializeOwned + Serialize + Default>(
     root: &Path,
     name: &str,
 ) -> CoreResult<T> {
     let rel = rel_path(name);
-    let contents = files::read_file(root, &rel)
+    let raw = files::read_file(root, &rel)
         .map_err(|e| CoreError::Internal(format!("failed to read {rel}: {e}")))?;
-    if contents.is_empty() {
+    let contents = raw.strip_prefix('\u{feff}').unwrap_or(&raw);
+    if contents.trim().is_empty() {
         return Ok(T::default());
     }
-    match serde_json::from_str(&contents) {
+    match serde_json::from_str(contents) {
         Ok(value) => Ok(value),
-        Err(err) => match repair_json(root, name, &rel, &contents, &err)? {
-            Some(value) => Ok(value),
-            None => Err(err.into()),
-        },
+        Err(err) => repair_json(root, name, &rel, contents, &err),
     }
 }
 
@@ -86,35 +97,37 @@ pub fn write_json<T: Serialize>(root: &Path, name: &str, data: &T) -> CoreResult
         .map_err(|e| CoreError::Internal(format!("failed to write {rel}: {e}")))
 }
 
+/// Recover a `.houston` JSON file that failed to parse. Least-lossy salvage
+/// first (one valid value + trailing junk → keep the value), then reset to
+/// `T::default()`. Either way the original bytes are preserved as a `.bak`
+/// and a warning logged, so a corrupt data file degrades to an empty surface
+/// rather than hard-erroring the read (HOU-436). A backup-write failure still
+/// surfaces — that's a real, actionable error, not a recoverable one.
 fn repair_json<T: DeserializeOwned + Serialize + Default>(
     root: &Path,
     name: &str,
     rel: &str,
     contents: &str,
     err: &serde_json::Error,
-) -> CoreResult<Option<T>> {
-    if let Some(value) = parse_first_json_value(contents) {
+) -> CoreResult<T> {
+    if let Some(value) = parse_first_json_value::<T>(contents) {
         backup_and_write(root, name, contents, &value)?;
         tracing::warn!(
             file = rel,
             error = %err,
             "repaired JSON file by removing trailing data"
         );
-        return Ok(Some(value));
+        return Ok(value);
     }
 
-    if name == "routine_runs" {
-        let value = T::default();
-        backup_and_write(root, name, contents, &value)?;
-        tracing::warn!(
-            file = rel,
-            error = %err,
-            "reset corrupt routine run history after preserving backup"
-        );
-        return Ok(Some(value));
-    }
-
-    Ok(None)
+    let value = T::default();
+    backup_and_write(root, name, contents, &value)?;
+    tracing::warn!(
+        file = rel,
+        error = %err,
+        "reset corrupt JSON file to default after preserving backup"
+    );
+    Ok(value)
 }
 
 fn parse_first_json_value<T: DeserializeOwned>(contents: &str) -> Option<T> {
@@ -142,4 +155,78 @@ fn backup_and_write<T: Serialize>(
         .map_err(|e| CoreError::Internal(format!("failed to back up corrupt JSON: {e}")))?;
     write_json(root, name, value)?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    const NAME: &str = "routines";
+
+    fn write_raw(root: &Path, name: &str, body: &str) {
+        let dir = houston_dir(root).join(name);
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join(format!("{name}.json")), body).unwrap();
+    }
+
+    fn has_backup(root: &Path, name: &str) -> bool {
+        std::fs::read_dir(houston_dir(root).join(name))
+            .map(|rd| {
+                rd.filter_map(Result::ok)
+                    .any(|e| e.file_name().to_string_lossy().contains(".corrupt-"))
+            })
+            .unwrap_or(false)
+    }
+
+    #[test]
+    fn missing_file_reads_as_default() {
+        let d = TempDir::new().unwrap();
+        let v: Vec<i64> = read_json(d.path(), NAME).unwrap();
+        assert!(v.is_empty());
+        assert!(!has_backup(d.path(), NAME));
+    }
+
+    #[test]
+    fn whitespace_only_reads_as_default_without_backup() {
+        let d = TempDir::new().unwrap();
+        write_raw(d.path(), NAME, "  \n\t  ");
+        let v: Vec<i64> = read_json(d.path(), NAME).unwrap();
+        assert!(v.is_empty());
+        assert!(!has_backup(d.path(), NAME), "blank file is not a corruption");
+    }
+
+    #[test]
+    fn bom_prefixed_json_parses_losslessly() {
+        // A leading UTF-8 BOM is the textbook `expected value at line 1
+        // column 1` serde failure (HOU-436). It must parse, not reset.
+        let d = TempDir::new().unwrap();
+        write_raw(d.path(), NAME, "\u{feff}[1, 2, 3]");
+        let v: Vec<i64> = read_json(d.path(), NAME).unwrap();
+        assert_eq!(v, vec![1, 2, 3]);
+        assert!(!has_backup(d.path(), NAME), "BOM strip is lossless, no backup");
+    }
+
+    #[test]
+    fn unparseable_resets_to_default_and_backs_up() {
+        // Reaches the generalized reset path for a non-`routine_runs` file —
+        // the bug was that this hard-errored instead of recovering.
+        let d = TempDir::new().unwrap();
+        write_raw(d.path(), NAME, "this is not json at all");
+        let v: Vec<i64> = read_json(d.path(), NAME).unwrap();
+        assert!(v.is_empty());
+        assert!(has_backup(d.path(), NAME), "corrupt bytes preserved in .bak");
+        // File now holds the reset default, so a re-read is clean.
+        let again: Vec<i64> = read_json(d.path(), NAME).unwrap();
+        assert!(again.is_empty());
+    }
+
+    #[test]
+    fn trailing_junk_keeps_first_value_and_backs_up() {
+        let d = TempDir::new().unwrap();
+        write_raw(d.path(), NAME, "[1, 2, 3]\n[4, 5]");
+        let v: Vec<i64> = read_json(d.path(), NAME).unwrap();
+        assert_eq!(v, vec![1, 2, 3], "first value salvaged, trailing dropped");
+        assert!(has_backup(d.path(), NAME));
+    }
 }

--- a/engine/houston-engine-core/src/routines/mod.rs
+++ b/engine/houston-engine-core/src/routines/mod.rs
@@ -361,4 +361,41 @@ mod tests {
         delete(d.path(), &r.id).unwrap();
         assert!(list(d.path()).unwrap().is_empty());
     }
+
+    #[test]
+    fn bom_prefixed_routines_file_still_lists() {
+        // HOU-436: a tool (editor, cloud-sync, Windows writer) rewrote
+        // routines.json with a leading UTF-8 BOM. serde rejects it with
+        // `expected value at line 1 column 1`; the BOM must be stripped so
+        // the user's routines load losslessly instead of 500-ing list.
+        let d = TempDir::new().unwrap();
+        let r = create(d.path(), sample()).unwrap();
+        let path = d.path().join(".houston/routines/routines.json");
+        let body = std::fs::read_to_string(&path).unwrap();
+        std::fs::write(&path, format!("\u{feff}{body}")).unwrap();
+
+        let all = list(d.path()).unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id, r.id);
+    }
+
+    #[test]
+    fn corrupt_routines_file_recovers_instead_of_erroring() {
+        // HOU-436: before this fix, an unparseable routines.json made every
+        // list_routines call return `json error: expected value at line 1
+        // column 1`, bricking the routines screen (and create, which lists
+        // first). It must degrade to an empty list and stay usable.
+        let d = TempDir::new().unwrap();
+        let dir = d.path().join(".houston/routines");
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("routines.json"), "\0\0not json\0").unwrap();
+
+        assert!(list(d.path()).unwrap().is_empty(), "recovers, does not error");
+
+        // Surface is not bricked: creating a routine works and persists.
+        let r = create(d.path(), sample()).unwrap();
+        let all = list(d.path()).unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id, r.id);
+    }
 }

--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -53,12 +53,16 @@ REST routes (`/v1/agents/:path/files/:kind`, etc.), which call into
 matching `HoustonEvent` over the WS. No typed CRUD — per-type folder +
 schema + a generic read/write pair covers everything.
 
-Typed JSON readers preserve corrupt files as
-`.houston/<type>/<type>.json.corrupt-<timestamp>-<uuid>.bak` before
-repairing. If a file has trailing JSON data, Houston keeps the first valid
-value and rewrites the file. If `routine_runs.json` is otherwise
-unreadable, Houston resets only the run history to `[]` after backing up
-the original so routine definitions can load and run again.
+Typed JSON readers never let a corrupt data file brick the surface that
+reads it (HOU-436: a malformed `routines.json` used to make every
+`list_routines` call 500 with `json error: expected value at line 1 column
+1`). Recovery is least-lossy first: a leading UTF-8 BOM is stripped before
+parsing (serde rejects one); a whitespace-only file reads as the type
+default; a file with one valid value plus trailing junk keeps the first
+value; any other unparseable file resets to the type default (`[]`, `{}`,
+…). Every recovery that rewrites the file first copies the original bytes to
+`.houston/<type>/<type>.json.corrupt-<timestamp>-<uuid>.bak` and logs a
+warning, so nothing is lost silently.
 
 ## Schemas
 Authoritative. Live in `ui/agent-schemas/src/*.schema.json`. Embedded in Rust via `include_str!` in `houston-agent-files::schemas`. Seeded into each agent's `.houston/<type>/<type>.schema.json` on first launch. Prompts instruct model to read schema before writing data file.


### PR DESCRIPTION
## Linear
HOU-436 

## Root cause
Sentry (`HOUSTON-APP-9V`, 3 users / 18 events, app 0.4.18–0.4.21) reported `list_routines: json error: expected value at line 1 column 1`. That message is decisive: `json error:` is the `Display` of `CoreError::Json` and `expected value at line 1 column 1` is serde_json's message for parsing junk at byte 0 — so the failure originates **in the engine**, not in a JS `JSON.parse` (a JS `SyntaxError` reads "Unexpected end of JSON input", different text). The TS `HoustonClient.toError` was faithfully surfacing an engine error envelope.

`store::read_json` returned `T::default()` only for a *missing or byte-empty* file. A file that is **non-empty but unparseable** went to `repair_json`, which recovered just two cases — "one valid value + trailing junk", and a hard-coded `name == "routine_runs"` reset. For `routines` any other corruption fell through to `Err(serde_json::Error)` → `CoreError::Json` → 500. Because the routines screen calls `list_routines` on mount (and `create_routine` lists first), the surface was **permanently bricked** until someone hand-fixed the file.

The textbook trigger for "expected value at line 1 column 1" on a valid-UTF-8, non-empty file is a **leading UTF-8 BOM** (U+FEFF) — serde_json does not skip it. Editors, cloud-sync tools, and Windows writers all emit BOMs. Truncated/partial legacy writes and null/garbage bytes hit the same dead end.

## Fix
`store::read_json` (`engine/houston-engine-core/src/agents/store.rs`) now recovers **any** corrupt typed `.houston` JSON file, least-lossy first:
1. strip a leading UTF-8 BOM before parsing (lossless — fixes the most likely real cause),
2. whitespace-only → type default,
3. one valid value + trailing junk → keep the first value (unchanged),
4. otherwise → reset to the type default.

The reset path is no longer gated to `routine_runs`; it applies to every typed file. Each mutating recovery still backs the original bytes up to `.houston/<type>/<type>.json.corrupt-<ts>-<uuid>.bak` and logs a `tracing::warn!`, so nothing is lost silently, and a backup-write failure still surfaces as a real error.

No TS change: the engine is the root cause, and adding a silent empty-body guard in `request()` would violate the no-silent-failures policy.

## Tests
- `agents::store::tests`: BOM round-trip (lossless, no backup), whitespace-only (default, no backup), unparseable (reset + `.bak`), trailing-junk salvage.
- `routines::tests`: `bom_prefixed_routines_file_still_lists` (user's routines survive a BOM losslessly through the public API) and `corrupt_routines_file_recovers_instead_of_erroring` (list degrades to `[]` and `create` still works — surface not bricked).
- Existing `routine_runs` corrupt-recovery tests still pass (generalized path is behavior-compatible). Server `--test routines` integration suite green.

## Verify
Before (on `main`): write a BOM or junk into `~/.houston/workspaces/<ws>/<agent>/.houston/routines/routines.json`, open that agent's routines → screen errors with `json error: expected value at line 1 column 1`; creating a routine fails the same way.
After: the screen loads (routines intact if it was just a BOM; empty list otherwise), a `.corrupt-*.bak` holds the original bytes, and creating a routine works.

## Notes
The issue speculated this might share the engine-sidecar-drop root cause (HOUSTON-APP-65, the 127.0.0.1 fetch failures). It does not — that path is a *failed* fetch; this is a *successful* fetch returning an engine error envelope from a corrupt file. The sidecar-drop failures remain tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)