### PR TITLE
fix(provider): supersede stale login on relaunch so retry isn't blocked (HOU-438)

### DIFF
--- a/engine/houston-engine-core/src/provider/login_relay.rs
+++ b/engine/houston-engine-core/src/provider/login_relay.rs
@@ -35,7 +35,7 @@ use houston_ui_events::{DynEventSink, HoustonEvent};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
@@ -76,15 +76,23 @@ struct LoginSession {
     /// Fired by [`cancel_login`] to abort an in-flight browser sign-in.
     /// The relay task holds its own `Arc` clone and selects on it.
     cancel: Arc<Notify>,
+    /// Set by [`supersede_session`] immediately before it fires `cancel`,
+    /// marking this teardown as "a fresh launch is replacing me." The relay
+    /// reads it on the cancel path and stays silent (no
+    /// `ProviderLoginComplete`) so it can't clear the replacement login's
+    /// spinner on the frontend (HOU-438). A user-driven [`cancel_login`]
+    /// leaves it false, preserving the benign completion that re-arms the card.
+    superseded: Arc<AtomicBool>,
     /// Identifies which relay owns this map entry (see [`SESSION_SEQ`]).
     token: u64,
 }
 
 /// Handed back by [`insert_session`] to the spawn site so the relay
-/// task gets the same cancel handle + token stored in the map.
+/// task gets the same cancel handle + supersede flag + token stored in the map.
 #[derive(Debug)]
 pub(super) struct RelayRegistration {
     cancel: Arc<Notify>,
+    superseded: Arc<AtomicBool>,
     token: u64,
 }
 
@@ -94,6 +102,10 @@ pub(super) struct RelayRegistration {
 enum RelayOutcome {
     Exited(std::io::Result<std::process::ExitStatus>),
     Cancelled,
+    /// A fresh launch tore this session down to take its slot. Behaves like
+    /// `Cancelled` (kill + reap the child) but the relay emits no
+    /// `ProviderLoginComplete` — see [`supersede_session`].
+    Superseded,
 }
 
 /// Regex over a single line of CLI stdout, looking for an HTTPS URL
@@ -183,16 +195,22 @@ pub(super) async fn insert_session(
         )));
     }
     let cancel = Arc::new(Notify::new());
+    let superseded = Arc::new(AtomicBool::new(false));
     let token = SESSION_SEQ.fetch_add(1, Ordering::Relaxed);
     sessions.insert(
         provider_id.to_string(),
         LoginSession {
             stdin: Arc::new(Mutex::new(stdin)),
             cancel: Arc::clone(&cancel),
+            superseded: Arc::clone(&superseded),
             token,
         },
     );
-    Ok(RelayRegistration { cancel, token })
+    Ok(RelayRegistration {
+        cancel,
+        superseded,
+        token,
+    })
 }
 
 /// Cancel an in-flight OAuth login. Removes the map entry **eagerly**
@@ -226,6 +244,39 @@ async fn cancel_login_inner(provider_id: &str, cli_name: &str) -> CoreResult<()>
         }
     }
     Ok(())
+}
+
+/// Silently tear down a stale pending session for `provider_id` because a
+/// FRESH login is about to take its slot. Like [`cancel_login_inner`] it
+/// removes the map entry under the lock and signals the relay to kill the
+/// subprocess, but it first sets the session's `superseded` flag so the relay
+/// SKIPS its `ProviderLoginComplete` emit. Without that suppression the benign
+/// completion would race the replacement login and clear the new attempt's
+/// spinner on the frontend (HOU-438). Idempotent: a no-op when nothing is
+/// pending. Infallible — there is nothing to surface; the caller proceeds to
+/// spawn its own session regardless.
+pub(super) async fn supersede_session(provider_id: &str, cli_name: &str) {
+    let session = {
+        let mut sessions = LOGIN_SESSIONS.lock().await;
+        sessions.remove(provider_id)
+    };
+    match session {
+        Some(session) => {
+            // Ordering matters: store the flag BEFORE notifying so the relay
+            // is guaranteed to observe it when it wakes. `Notify` holds a
+            // permit if no waiter is parked yet, so the wakeup is never lost.
+            session.superseded.store(true, Ordering::SeqCst);
+            session.cancel.notify_one();
+            tracing::info!(
+                "[houston:provider] {cli_name} stale login superseded by a fresh launch"
+            );
+        }
+        None => {
+            tracing::debug!(
+                "[houston:provider] supersede_session: no pending {cli_name} session"
+            );
+        }
+    }
 }
 
 /// Spawn the background task that drives a single login session:
@@ -273,7 +324,11 @@ async fn relay_login_output(
     registration: RelayRegistration,
     device_auth: bool,
 ) {
-    let RelayRegistration { cancel, token } = registration;
+    let RelayRegistration {
+        cancel,
+        superseded,
+        token,
+    } = registration;
     // Drain stderr in a sibling task so a verbose CLI can't fill the
     // 64KB stderr pipe buffer and deadlock the child on write.
     // Captured stderr is appended to the `ProviderLoginComplete`
@@ -305,14 +360,36 @@ async fn relay_login_output(
     let work = async {
         loop {
             tokio::select! {
+                // Poll in declared order, not at random: a user cancel is
+                // honored first, then we DRAIN stdout before observing the
+                // child's exit. Without the bias, a CLI that prints its URL
+                // (or device code) and exits promptly races `reader.next_line`
+                // against `child.wait` — when exit wins, the URL line is left
+                // unread and `ProviderLoginUrl` never fires. Reader-before-exit
+                // guarantees every buffered line is surfaced before we treat
+                // the process as done (also de-flakes the device-auth relay
+                // test, whose stand-in emits then exits immediately).
+                biased;
                 _ = cancel.notified() => {
+                    // A fresh launch that superseded this session set the flag
+                    // before signalling cancel. Distinguish the two: a
+                    // superseded relay must stay silent (the replacement login
+                    // owns the slot now), whereas a user cancel emits a benign
+                    // completion to re-arm the card. The flag is false for a
+                    // plain `cancel_login`.
+                    let superseded = superseded.load(Ordering::SeqCst);
                     tracing::info!(
-                        "[houston:provider] {cli_name} login cancelled — killing subprocess"
+                        "[houston:provider] {cli_name} login {} — killing subprocess",
+                        if superseded { "superseded" } else { "cancelled" }
                     );
                     let _ = child.kill().await;
                     // Reap so the OS doesn't keep a zombie around.
                     let _ = child.wait().await;
-                    return RelayOutcome::Cancelled;
+                    return if superseded {
+                        RelayOutcome::Superseded
+                    } else {
+                        RelayOutcome::Cancelled
+                    };
                 }
                 line = reader.next_line() => {
                     match line {
@@ -382,56 +459,68 @@ async fn relay_login_output(
         RelayOutcome::Exited(child.wait().await)
     };
 
-    let (success, error) = match tokio::time::timeout(LOGIN_SESSION_TIMEOUT, work).await {
-        Ok(RelayOutcome::Exited(Ok(status))) => {
-            tracing::info!("[houston:provider] {cli_name} login exited: {status}");
-            let stderr_text = drain_stderr(stderr_handle).await;
-            (
-                status.success(),
-                if status.success() {
-                    None
-                } else {
-                    Some(format_exit_error(&cli_name, &format!("{status}"), &stderr_text))
-                },
-            )
-        }
-        Ok(RelayOutcome::Exited(Err(e))) => {
-            tracing::warn!("[houston:provider] {cli_name} login wait failed: {e}");
-            let stderr_text = drain_stderr(stderr_handle).await;
-            (
-                false,
-                Some(format_exit_error(&cli_name, &format!("wait failed: {e}"), &stderr_text)),
-            )
-        }
-        Ok(RelayOutcome::Cancelled) => {
-            // User abandoned the sign-in. Drain stderr so the sibling
-            // task joins, but DON'T surface it — a deliberate cancel
-            // isn't an error, so `error: None` keeps the frontend from
-            // toasting. The spinner just clears and the card re-arms.
-            drain_stderr(stderr_handle).await;
-            (false, None)
-        }
-        Err(_) => {
-            tracing::warn!(
-                "[houston:provider] {cli_name} login timed out after {}s — killing subprocess",
-                LOGIN_SESSION_TIMEOUT.as_secs()
-            );
-            let _ = child.kill().await;
-            let stderr_text = drain_stderr(stderr_handle).await;
-            (
-                false,
-                Some(format_exit_error(
-                    &cli_name,
-                    &format!("timed out after {}s", LOGIN_SESSION_TIMEOUT.as_secs()),
-                    &stderr_text,
-                )),
-            )
-        }
-    };
+    // `None` == superseded: emit nothing. Every other outcome carries the
+    // exactly-one `ProviderLoginComplete` payload `(success, error)`.
+    let result: Option<(bool, Option<String>)> =
+        match tokio::time::timeout(LOGIN_SESSION_TIMEOUT, work).await {
+            Ok(RelayOutcome::Exited(Ok(status))) => {
+                tracing::info!("[houston:provider] {cli_name} login exited: {status}");
+                let stderr_text = drain_stderr(stderr_handle).await;
+                Some((
+                    status.success(),
+                    if status.success() {
+                        None
+                    } else {
+                        Some(format_exit_error(&cli_name, &format!("{status}"), &stderr_text))
+                    },
+                ))
+            }
+            Ok(RelayOutcome::Exited(Err(e))) => {
+                tracing::warn!("[houston:provider] {cli_name} login wait failed: {e}");
+                let stderr_text = drain_stderr(stderr_handle).await;
+                Some((
+                    false,
+                    Some(format_exit_error(&cli_name, &format!("wait failed: {e}"), &stderr_text)),
+                ))
+            }
+            Ok(RelayOutcome::Cancelled) => {
+                // User abandoned the sign-in. Drain stderr so the sibling
+                // task joins, but DON'T surface it — a deliberate cancel
+                // isn't an error, so `error: None` keeps the frontend from
+                // toasting. The spinner just clears and the card re-arms.
+                drain_stderr(stderr_handle).await;
+                Some((false, None))
+            }
+            Ok(RelayOutcome::Superseded) => {
+                // A fresh launch already tore this session down and took its
+                // slot (see `supersede_session`). Drain stderr so the sibling
+                // task joins, then emit NOTHING: a benign ProviderLoginComplete
+                // would race the replacement login and clear its spinner. The
+                // map entry is already gone, so the cleanup below is a no-op.
+                drain_stderr(stderr_handle).await;
+                None
+            }
+            Err(_) => {
+                tracing::warn!(
+                    "[houston:provider] {cli_name} login timed out after {}s — killing subprocess",
+                    LOGIN_SESSION_TIMEOUT.as_secs()
+                );
+                let _ = child.kill().await;
+                let stderr_text = drain_stderr(stderr_handle).await;
+                Some((
+                    false,
+                    Some(format_exit_error(
+                        &cli_name,
+                        &format!("timed out after {}s", LOGIN_SESSION_TIMEOUT.as_secs()),
+                        &stderr_text,
+                    )),
+                ))
+            }
+        };
 
-    // Remove the map entry only if it's still *ours*. A `cancel_login`
-    // already removed it eagerly, and a fresh `Connect` may have
-    // inserted a brand-new session under the same provider id — token
+    // Remove the map entry only if it's still *ours*. A `cancel_login` or
+    // `supersede_session` already removed it eagerly, and a fresh `Connect`
+    // may have inserted a brand-new session under the same provider id — token
     // equality stops us from evicting that newcomer.
     {
         let mut sessions = LOGIN_SESSIONS.lock().await;
@@ -439,11 +528,13 @@ async fn relay_login_output(
             sessions.remove(&provider_id);
         }
     }
-    sink.emit(HoustonEvent::ProviderLoginComplete {
-        provider: provider_id,
-        success,
-        error,
-    });
+    if let Some((success, error)) = result {
+        sink.emit(HoustonEvent::ProviderLoginComplete {
+            provider: provider_id,
+            success,
+            error,
+        });
+    }
 }
 
 async fn drain_stderr(handle: Option<tokio::task::JoinHandle<String>>) -> String {
@@ -889,6 +980,108 @@ mod tests {
         // The relay removes the session on child exit (token-guarded); clear
         // it explicitly too so a slow exit can't leak into sibling tests that
         // share the global LOGIN_SESSIONS map.
+        LOGIN_SESSIONS.lock().await.remove(provider_id);
+    }
+
+    #[tokio::test]
+    async fn supersede_session_frees_slot_without_emitting() {
+        // A fresh launch supersedes a stale pending session. Unlike a user
+        // cancel, the relay must tear the subprocess down SILENTLY — no
+        // ProviderLoginComplete — because the replacement login already owns
+        // the slot and a benign completion would clear its spinner (HOU-438).
+        use houston_ui_events::BroadcastEventSink;
+
+        let provider_id = "test-supersede-silent";
+        let cli_name = "test-cli";
+
+        let mut child = spawn_idle_child().await;
+        let stdin = child.stdin.take().expect("stdin piped");
+        let stdout = child.stdout.take().expect("stdout piped");
+        let stderr = child.stderr.take();
+
+        let sink = Arc::new(BroadcastEventSink::new(16));
+        let mut rx = sink.subscribe();
+
+        let registration = insert_session(provider_id, cli_name, stdin)
+            .await
+            .expect("insert succeeds");
+        spawn_relay(
+            provider_id.to_string(),
+            cli_name.to_string(),
+            child,
+            stdout,
+            stderr,
+            sink.clone(),
+            registration,
+            false,
+        );
+
+        assert!(
+            LOGIN_SESSIONS.lock().await.contains_key(provider_id),
+            "session pending right after spawn"
+        );
+
+        supersede_session(provider_id, cli_name).await;
+
+        // The slot frees eagerly so a retry can spawn at once...
+        assert!(
+            !LOGIN_SESSIONS.lock().await.contains_key(provider_id),
+            "supersede frees the slot"
+        );
+
+        // ...and the relay stays SILENT — no event may arrive. (A user cancel,
+        // by contrast, emits a benign ProviderLoginComplete; see
+        // `cancel_login_kills_session_and_emits_benign_completion`.)
+        let quiet = tokio::time::timeout(Duration::from_secs(1), rx.recv()).await;
+        assert!(
+            quiet.is_err(),
+            "a superseded relay must not emit any event, got {quiet:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn supersede_unblocks_a_fresh_insert() {
+        // Regression for HOU-438: a stale pending session must not wedge the
+        // next sign-in. After supersede frees the slot, a fresh insert for the
+        // same provider succeeds instead of being rejected as "already pending"
+        // (cf. `insert_session_rejects_duplicate`, which has no supersede).
+        use houston_ui_events::BroadcastEventSink;
+
+        let provider_id = "test-supersede-unblocks";
+        let cli_name = "test-cli";
+
+        let mut stale = spawn_idle_child().await;
+        let stale_stdin = stale.stdin.take().expect("stdin piped");
+        let stale_stdout = stale.stdout.take().expect("stdout piped");
+        let stale_stderr = stale.stderr.take();
+
+        let sink = Arc::new(BroadcastEventSink::new(16));
+
+        let registration = insert_session(provider_id, cli_name, stale_stdin)
+            .await
+            .expect("first insert succeeds");
+        spawn_relay(
+            provider_id.to_string(),
+            cli_name.to_string(),
+            stale,
+            stale_stdout,
+            stale_stderr,
+            sink.clone(),
+            registration,
+            false,
+        );
+
+        // A fresh launch supersedes the stale session, then retries the insert.
+        supersede_session(provider_id, cli_name).await;
+
+        let mut fresh = spawn_idle_child().await;
+        let fresh_stdin = fresh.stdin.take().expect("stdin piped");
+        insert_session(provider_id, cli_name, fresh_stdin)
+            .await
+            .expect("insert after supersede succeeds — the slot was freed");
+
+        // Cleanup: drop the fresh session so sibling tests see an empty map.
+        // (`fresh` is kill_on_drop, so its subprocess dies at scope end.)
         LOGIN_SESSIONS.lock().await.remove(provider_id);
     }
 }

--- a/engine/houston-engine-core/src/provider/mod.rs
+++ b/engine/houston-engine-core/src/provider/mod.rs
@@ -122,16 +122,23 @@ pub async fn launch_login(
     }
 
     // A previous sign-in for this provider may still be pending: the user
-    // abandoned the OAuth tab, lost the browser window, or the app restarted
-    // while the relay's 10-minute timeout was still counting down. Left as-is,
-    // the `insert_session` guard below would reject this fresh attempt as
-    // "already pending" and the user would be stuck with no way to retry
-    // (HOU-438) — worse on desktop, where the sign-in dialog and its Cancel
-    // button are hidden (#453). A fresh Connect must win: silently tear the
-    // stale session down (kill its subprocess, free the slot) before we spawn.
-    // Silent — no `ProviderLoginComplete` — because THIS launch immediately
-    // takes the slot's place, so a benign completion would only clear the new
-    // attempt's spinner. Idempotent no-op when nothing is pending.
+    // abandoned the OAuth tab, or — on a remote/persistent engine (Always-On,
+    // container, mobile against a hosted engine) that outlives the client — a
+    // reconnect landed while the relay's 10-minute timeout was still counting
+    // down. (On the co-located desktop sidecar an app restart kills the engine
+    // and wipes LOGIN_SESSIONS, so there the window is one engine lifetime.)
+    // Left as-is, the `insert_session` guard below would reject this fresh
+    // attempt as "already pending" and the user would be stuck (HOU-438). The
+    // frontend's cancel-before-retry recovery is applied inconsistently — the
+    // in-chat reconnect surfaces (`provider-reconnect-card`) call `launchLogin`
+    // with no cancel and expose no Cancel button, and the Settings/Picker
+    // Cancel button is bound to local `pendingId` that the error path clears
+    // and that a fresh mount resets (no endpoint resyncs in-flight sessions) —
+    // so UI recovery can't be guaranteed. A fresh Connect must win: silently
+    // tear the stale session down (kill its subprocess, free the slot) before
+    // we spawn. Silent — no `ProviderLoginComplete` — because THIS launch
+    // immediately takes the slot's place, so a benign completion would only
+    // clear the new attempt's spinner. Idempotent no-op when nothing is pending.
     login_relay::supersede_session(provider.id(), provider.cli_name()).await;
 
     let ProviderCliCommand {

--- a/engine/houston-engine-core/src/provider/mod.rs
+++ b/engine/houston-engine-core/src/provider/mod.rs
@@ -120,6 +120,19 @@ pub async fn launch_login(
         return gemini_login::launch_login(path).await;
     }
 
+    // A previous sign-in for this provider may still be pending: the user
+    // abandoned the OAuth tab, lost the browser window, or the app restarted
+    // while the relay's 10-minute timeout was still counting down. Left as-is,
+    // the `insert_session` guard below would reject this fresh attempt as
+    // "already pending" and the user would be stuck with no way to retry
+    // (HOU-438) — worse on desktop, where the sign-in dialog and its Cancel
+    // button are hidden (#453). A fresh Connect must win: silently tear the
+    // stale session down (kill its subprocess, free the slot) before we spawn.
+    // Silent — no `ProviderLoginComplete` — because THIS launch immediately
+    // takes the slot's place, so a benign completion would only clear the new
+    // attempt's spinner. Idempotent no-op when nothing is pending.
+    login_relay::supersede_session(provider.id(), provider.cli_name()).await;
+
     let ProviderCliCommand {
         cli_name,
         path,
@@ -256,7 +269,21 @@ pub async fn launch_login(
             })?;
             let stderr = child.stderr.take();
 
-            let registration = login_relay::insert_session(&provider_id, cli_name, stdin).await?;
+            // The supersede at the top of `launch_login` frees any stale slot,
+            // so this normally succeeds. It can still reject if a genuinely
+            // concurrent Connect for the same provider grabbed the slot inside
+            // our 3s probe window — in that case kill the child we just spawned
+            // so it doesn't orphan (`kill_on_drop` is false on the login
+            // command) before surfacing the conflict.
+            let registration =
+                match login_relay::insert_session(&provider_id, cli_name, stdin).await {
+                    Ok(reg) => reg,
+                    Err(e) => {
+                        let _ = child.kill().await;
+                        let _ = child.wait().await;
+                        return Err(e);
+                    }
+                };
             login_relay::spawn_relay(
                 provider_id,
                 cli_name_owned,


### PR DESCRIPTION
## Linear

**HOU-438** — https://linear.app/houston-ai/issue/HOU-438/launch-provider-login-claude-sign-in-already-pending-blocks-retry

## Root cause

The engine keeps **one OAuth login slot per provider** (`login_relay::insert_session`). If a prior Claude/codex sign-in never finished or was cancelled, the slot stays occupied (up to the 10-minute relay timeout, or for the whole abandoned-tab window), so the next `launch_login` is rejected with `BadRequest("… sign-in is already pending")` — surfaced as the Sentry `HoustonEngineError`.

The frontend's intended recovery is to call `cancelLogin` before `launchLogin`, but it is applied **inconsistently across surfaces**, and the Cancel affordance is bound to ephemeral local React state that desyncs from the engine's session map:

- **In-chat reconnect (the surface token-expiry actually renders): `provider-reconnect-card.tsx`** calls `launchLogin` with **no** `cancelLogin` first, and its only buttons are "Sign in" / "Try Again" — both re-call the same cancel-less path. There is **no Cancel button** on this card, so an "already pending" rejection has no in-UI recovery (it loops on the same error). `auth-reconnect-banner.tsx` is worse — it swallows the error in an empty catch.
- **Settings / Picker** *do* show a Cancel button, but it is gated on local `pendingId`: the `handleConnect` catch clears `pendingId` the instant "already pending" fires (removing the button), and a fresh mount starts at `pendingId = null`. There is **no engine endpoint to resync in-flight login sessions**, so after an unmount/reopen the UI can't know a slot is held.
- Only `provider-error-cards/auth.tsx` does `cancelLogin → launchLogin`.

**Desktop vs remote.** On the desktop sidecar, an app restart kills the engine and wipes the in-memory `LOGIN_SESSIONS`, so the stale-slot window there is **one engine lifetime** (abandon a tab, retry within 600s). The durable case is **remote/persistent engines** (Always-On, container, mobile against a hosted engine) that outlive the client tab/app — closing and returning leaves the slot held. That is the primary HOU-438 scenario.

> Note: an adversarial audit corrected two claims from an earlier draft of this description — #453 hides only the `ProviderLoginUrl` dialog (not the card Cancel button), and desktop app-restart self-heals (sidecar dies). The corrected rationale is in the `mod.rs` comment.

## Fix

Make `launch_login` **idempotent** at the engine layer: it silently supersedes any stale pending session for that provider before spawning the fresh one (latest-launch-wins). This fixes **every** surface at once — including the cancel-less `provider-reconnect-card` / `auth-reconnect-banner` — instead of depending on each frontend to cancel-first.

- **Silent supersede** (`supersede_session` + a `superseded` flag): tears the stale subprocess down like a cancel, but emits **no** `ProviderLoginComplete` — a benign completion would otherwise race the replacement login and clear its spinner.
- **Orphan guard**: if `insert_session` still rejects (a genuinely concurrent Connect inside the 3s probe window), kill the just-spawned child instead of dropping it unkilled (`kill_on_drop` is `false`).
- **`biased;` relay select**: drain buffered stdout before observing the child's exit, so a fast-exiting CLI no longer drops `ProviderLoginUrl`. (Convergent with HOU-446, which added the same `biased;` on `main` — reconciled in the merge.)

## Files changed

- `engine/houston-engine-core/src/provider/login_relay.rs` — `supersede_session`, the `superseded` flag, the silent `Superseded` outcome, `biased;` select, 2 new tests.
- `engine/houston-engine-core/src/provider/mod.rs` — `launch_login` pre-supersede + insert-reject orphan kill.

No frontend changes. (Follow-up worth considering, but not required by this fix: add cancel-before-retry to `provider-reconnect-card` and stop the silent catch in `auth-reconnect-banner`.)

## Tests

- `supersede_session_frees_slot_without_emitting` — supersede frees the slot **and** the relay stays silent.
- `supersede_unblocks_a_fresh_insert` — regression: after supersede, a fresh insert succeeds instead of "already pending".
- Full `houston-engine-core`: **370 passed**; relay tests 18/18 across repeated runs (no flake).

## Reproduce the bug BEFORE this fix

Easiest on a persistent/remote engine (or within the 600s window on desktop):

1. Start a Claude sign-in but do **not** complete the browser flow:
   `curl -X POST http://127.0.0.1:<port>/v1/providers/anthropic/login`
2. Without cancelling, start it again:
   `curl -X POST http://127.0.0.1:<port>/v1/providers/anthropic/login`
3. **Before:** the second call returns `400 … claude sign-in is already pending`. In-app, a chat whose provider needs re-auth renders `provider-reconnect-card`, whose "Sign in" / "Try Again" both hit this rejection with no Cancel button to free the slot — stuck until the 600s timeout or (desktop) an app restart.

## Verify the fix AFTER

1. Same steps: `POST …/login`, abandon, then `POST …/login` again.
2. **After:** the second call returns `200` — the stale subprocess is killed and a fresh sign-in spawns. Connect / Sign in / Try Again is retryable immediately from **any** surface (Settings, picker, onboarding, in-chat reconnect card), desktop and remote, with no restart.
3. The superseded teardown emits no `ProviderLoginComplete`, so the new attempt's spinner is not cleared.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
