### PR TITLE
fix(composio): actionable login timeout, kill 330s hang + Sentry noise (HOU-434)

### DIFF
--- a/app/src/components/composio-auth-dialog.tsx
+++ b/app/src/components/composio-auth-dialog.tsx
@@ -9,17 +9,22 @@ interface ComposioAuthDialogProps {
   state: ComposioAuthState;
   onClose: () => void;
   onReopenBrowser: () => void;
+  /** Restart the whole sign-in flow. Shown in the error state because a
+   *  timed-out login session is dead — reopening the old URL is useless,
+   *  the user needs a fresh attempt. */
+  onRetry: () => void;
 }
 
 /**
- * Sign-in dialog for Composio. Always shows the login URL as a
- * clickable button as soon as `state.loginUrl` is set, so the user
- * can always manually open it even if the auto-open failed.
+ * Sign-in dialog for Composio. While waiting, shows the login URL as a
+ * clickable button (in case auto-open failed). On failure it swaps to an
+ * actionable "Try again" that mints a fresh session.
  */
 export function ComposioAuthDialog({
   state,
   onClose,
   onReopenBrowser,
+  onRetry,
 }: ComposioAuthDialogProps) {
   const { t } = useTranslation("integrations");
   return (
@@ -52,13 +57,24 @@ export function ComposioAuthDialog({
           </p>
         )}
 
-        {state.loginUrl && (
+        {/* While waiting, let the user re-open the live login URL if the
+            auto-open failed. Hidden once we error: that session is dead. */}
+        {state.phase === "waiting" && state.loginUrl && (
           <button
             onClick={onReopenBrowser}
             className="inline-flex items-center gap-1.5 h-9 px-4 rounded-full border border-border bg-background text-foreground text-sm font-medium hover:bg-secondary transition-colors duration-200 self-start"
           >
             {t("authDialog.openInBrowser")}
             <ExternalLink className="size-3.5" />
+          </button>
+        )}
+
+        {state.phase === "error" && (
+          <button
+            onClick={onRetry}
+            className="inline-flex items-center justify-center h-9 px-4 rounded-full bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors duration-200 self-start"
+          >
+            {t("authDialog.tryAgain")}
           </button>
         )}
       </DialogContent>

--- a/app/src/components/composio-signin-card.tsx
+++ b/app/src/components/composio-signin-card.tsx
@@ -74,6 +74,7 @@ export function ComposioSigninCard() {
         state={auth.state}
         onClose={auth.close}
         onReopenBrowser={auth.reopenBrowser}
+        onRetry={auth.startAuth}
       />
     </span>
   );

--- a/app/src/components/onboarding/missions/tools.tsx
+++ b/app/src/components/onboarding/missions/tools.tsx
@@ -91,6 +91,7 @@ export function ToolsMission({ onContinue }: ToolsMissionProps) {
         state={auth.state}
         onClose={auth.close}
         onReopenBrowser={auth.reopenBrowser}
+        onRetry={auth.startAuth}
       />
     </div>
   );

--- a/app/src/components/shell/ai-integrations-step.tsx
+++ b/app/src/components/shell/ai-integrations-step.tsx
@@ -135,6 +135,7 @@ export function AiIntegrationsStep({
         state={auth.state}
         onClose={auth.close}
         onReopenBrowser={auth.reopenBrowser}
+        onRetry={auth.startAuth}
       />
     </div>
   );

--- a/app/src/components/tabs/integrations-view.tsx
+++ b/app/src/components/tabs/integrations-view.tsx
@@ -135,6 +135,7 @@ export function IntegrationsView({ title }: IntegrationsViewProps) {
         state={auth.state}
         onClose={auth.close}
         onReopenBrowser={auth.reopenBrowser}
+        onRetry={auth.startAuth}
       />
 
       <ConfirmDialog

--- a/app/src/hooks/use-composio-auth.ts
+++ b/app/src/hooks/use-composio-auth.ts
@@ -1,4 +1,6 @@
 import { useState, useCallback, useRef, useEffect } from "react";
+import { useTranslation } from "react-i18next";
+import { isHoustonEngineError } from "@houston-ai/engine-client";
 import { tauriConnections, tauriSystem } from "../lib/tauri";
 import { logger } from "../lib/logger";
 
@@ -28,6 +30,7 @@ export interface ComposioAuthState {
 }
 
 export function useComposioAuth(onSuccess: () => void | Promise<void>) {
+  const { t } = useTranslation("integrations");
   const [state, setState] = useState<ComposioAuthState>({
     open: false,
     phase: "idle",
@@ -87,13 +90,18 @@ export function useComposioAuth(onSuccess: () => void | Promise<void>) {
     } catch (e) {
       logger.error("[composio-auth] flow error:", String(e));
       if (!mountedRef.current || genRef.current !== myGen) return;
-      setState((s) => ({
-        ...s,
-        phase: "error",
-        error: String(e),
-      }));
+      // Localize for the user. A `composio_login_timeout` is the expected
+      // "you didn't finish approving in the browser" case; everything
+      // else collapses to a generic retry prompt so we never surface a
+      // raw engine string. The real detail is logged above and (for
+      // genuine faults) captured to Sentry by the engine-call wrapper.
+      const message =
+        isHoustonEngineError(e) && e.kind === "composio_login_timeout"
+          ? t("authDialog.errorTimeout")
+          : t("authDialog.errorGeneric");
+      setState((s) => ({ ...s, phase: "error", error: message }));
     }
-  }, [onSuccess]);
+  }, [onSuccess, t]);
 
   const reopenBrowser = useCallback(() => {
     if (state.loginUrl) {
@@ -105,7 +113,7 @@ export function useComposioAuth(onSuccess: () => void | Promise<void>) {
     // Cancel the in-flight flow by bumping the generation: any
     // pending completeLogin resolution from this generation will be
     // discarded when it finally returns. The Rust subprocess will
-    // still run to completion (its own 5 min timeout), but the UI
+    // still run to completion (the engine's 3 min cap), but the UI
     // won't react to it. A proper backend cancel is a follow-up.
     genRef.current += 1;
     setState({ open: false, phase: "idle", loginUrl: null, error: null });

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -29,6 +29,7 @@ import type {
   ProviderStatus as EngineProviderStatus,
   GenerateInstructionsResult,
 } from "@houston-ai/engine-client";
+import { isHoustonEngineError } from "@houston-ai/engine-client";
 import { getEngine } from "./engine";
 import { osPickDirectory } from "./os-bridge";
 import { logger } from "./logger";
@@ -46,6 +47,11 @@ interface EngineCallOptions {
    *  genuinely fire-and-forget calls or ones with their own report path. */
   capture?: boolean;
 }
+
+/** Typed engine error `kind`s that are expected user-flow outcomes, fully
+ *  surfaced by their own inline UI. Never toasted, never sent to Sentry —
+ *  the same treatment as an aborted request. */
+const EXPECTED_INLINE_KINDS = new Set<string>(["composio_login_timeout"]);
 
 /** Wrap an engine call and surface errors as toasts unless caller handles them inline. */
 async function call<T>(
@@ -75,6 +81,12 @@ async function surfaceError(
   // Aborted requests (user typed again, navigated away, cancelled a sign-in)
   // are expected, not failures — never toast or report them.
   if (err instanceof Error && err.name === "AbortError") return;
+
+  // Typed engine errors that are expected user-flow outcomes (e.g. the
+  // user closed the Composio sign-in tab so the login poll timed out) own
+  // their inline UI — never toast or report them. Reporting these is
+  // exactly the Sentry noise HOU-434 surfaced.
+  if (isHoustonEngineError(err) && err.kind && EXPECTED_INLINE_KINDS.has(err.kind)) return;
 
   const shouldToast = options?.toast !== false;
   const shouldCapture = options?.capture !== false;
@@ -477,7 +489,15 @@ export const tauriConnections = {
       return { login_url: r.login_url, cli_key: r.cli_key };
     }),
   completeLogin: (cliKey: string) =>
-    call<void>("complete_composio_login", () => getEngine().composioCompleteLogin(cliKey)),
+    call<void>(
+      "complete_composio_login",
+      () => getEngine().composioCompleteLogin(cliKey),
+      undefined,
+      // The sign-in dialog renders failures inline; don't double-surface
+      // as a toast. Genuine faults still capture to Sentry; the expected
+      // timeout is carved out in surfaceError (EXPECTED_INLINE_KINDS).
+      { toast: false },
+    ),
   logout: () => call<void>("logout_composio", () => getEngine().composioLogout()),
   isCliInstalled: () =>
     call<boolean>("is_composio_cli_installed", () => getEngine().composioCliInstalled()),

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -68,7 +68,10 @@
     "title": "Connecting your integrations provider",
     "description": "Complete the sign-in in your browser, then return here.",
     "waiting": "Waiting for you to approve in the browser…",
-    "openInBrowser": "Open link in browser"
+    "openInBrowser": "Open link in browser",
+    "errorTimeout": "Sign-in timed out. Make sure you finished approving in the browser, then try again.",
+    "errorGeneric": "Something went wrong while connecting. Please try again.",
+    "tryAgain": "Try again"
   },
   "linkCard": {
     "integration": "App integration",

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -68,7 +68,10 @@
     "title": "Conectando tu proveedor de integraciones",
     "description": "Completa el inicio de sesión en tu navegador y vuelve aquí.",
     "waiting": "Esperando tu aprobación en el navegador…",
-    "openInBrowser": "Abrir enlace en el navegador"
+    "openInBrowser": "Abrir enlace en el navegador",
+    "errorTimeout": "Se agotó el tiempo de inicio de sesión. Asegúrate de completar la aprobación en el navegador y vuelve a intentarlo.",
+    "errorGeneric": "Algo salió mal al conectar. Inténtalo de nuevo.",
+    "tryAgain": "Volver a intentar"
   },
   "linkCard": {
     "integration": "Integración de app",

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -68,7 +68,10 @@
     "title": "Conectando seu provedor de integrações",
     "description": "Conclua o login no navegador e volte para cá.",
     "waiting": "Aguardando sua aprovação no navegador…",
-    "openInBrowser": "Abrir link no navegador"
+    "openInBrowser": "Abrir link no navegador",
+    "errorTimeout": "O tempo de login se esgotou. Conclua a aprovação no navegador e tente novamente.",
+    "errorGeneric": "Algo deu errado ao conectar. Tente novamente.",
+    "tryAgain": "Tentar novamente"
   },
   "linkCard": {
     "integration": "Integração de app",

--- a/engine/houston-composio/src/cli.rs
+++ b/engine/houston-composio/src/cli.rs
@@ -162,33 +162,83 @@ pub async fn start_login() -> Result<StartLoginResponse, String> {
     })
 }
 
+/// How long `complete_login` waits for the user to approve the sign-in
+/// in their browser before giving up.
+///
+/// The composio CLI's `login --key` polls the pending-login session for
+/// up to **10 minutes** — the session's own lifetime (`expiresAt -
+/// cachedAt` in `~/.composio/pending-login-session.json` is exactly
+/// 600s). Crucially the CLI stays completely silent the whole time (no
+/// stdout, no stderr) even for an invalid or already-expired key
+/// (verified by probing the bundled binary), so there is no early
+/// failure signal to surface — this wall-clock cap is the de-facto
+/// outcome for any login the user does not approve.
+///
+/// 180s comfortably covers a real browser OAuth (the happy path returns
+/// within seconds of the user approving) while surfacing an actionable,
+/// retryable error ~2.5 minutes sooner than the previous 330s. That 330s
+/// rested on a wrong "5 minute session" assumption AND was shorter than
+/// the CLI's real 10-minute poll, so it cut still-valid sessions off
+/// mid-flight and handed the user a raw internal timeout string (HOU-434).
+const LOGIN_POLL_TIMEOUT_SECS: u64 = 180;
+
+/// Why `complete_login` failed, so the caller can tell an expected "user
+/// never finished in the browser" timeout apart from a genuine CLI fault.
+/// The engine server maps `TimedOut` to a typed, localized, user-
+/// actionable error (`kind = "composio_login_timeout"`) and leaves
+/// `Failed` as an internal error worth a bug report.
+#[derive(Debug)]
+pub enum CompleteLoginError {
+    /// We hit `LOGIN_POLL_TIMEOUT_SECS` before the CLI completed — the
+    /// user almost certainly closed the tab or walked away. Not a bug.
+    TimedOut,
+    /// Spawn failure or a non-zero CLI exit. Carries internal detail for
+    /// logs / the bug report; never shown verbatim to the user.
+    Failed(String),
+}
+
+impl std::fmt::Display for CompleteLoginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::TimedOut => write!(
+                f,
+                "composio login timed out after {LOGIN_POLL_TIMEOUT_SECS}s waiting for browser approval"
+            ),
+            Self::Failed(detail) => write!(f, "{detail}"),
+        }
+    }
+}
+
 /// Complete the login flow started by `start_login`. Shells out to
-/// `composio login --key <cli_key>` which internally polls Composio's
-/// backend for the user's approval and exits once the credentials are
+/// `composio login --key <cli_key>`, which polls Composio's backend for
+/// the user's browser approval and exits once the credentials are
 /// written to `~/.composio/user_data.json`.
 ///
-/// Wrapped in a 330s timeout so a stuck subprocess can't hang the
-/// Houston UI forever — the CLI's own session expiry is 5 minutes, so
-/// 330s gives it ~30s of slack before Houston gives up and returns an
-/// error. `kill_on_drop` on the Command ensures the subprocess is
-/// terminated if we time out.
-pub async fn complete_login(cli_key: &str) -> Result<(), String> {
+/// Bounded by `LOGIN_POLL_TIMEOUT_SECS`; `kill_on_drop` on the Command
+/// (see `run_cli_with_timeout`) terminates the subprocess if we time out
+/// so it can't leak.
+pub async fn complete_login(cli_key: &str) -> Result<(), CompleteLoginError> {
     let args = ["login", "--key", cli_key, "--no-skill-install", "-y"];
-    let result = run_cli_with_timeout(&args, std::time::Duration::from_secs(330)).await;
+    let timeout = std::time::Duration::from_secs(LOGIN_POLL_TIMEOUT_SECS);
 
-    match result {
+    match run_cli_with_timeout(&args, timeout).await {
         Ok(output) if output.status.success() => {
             tracing::info!("[composio:cli] login completed via cli_key");
             Ok(())
         }
         Ok(output) => {
+            // CLI exited non-zero before our cap. Rare — the CLI polls
+            // silently for invalid/expired keys rather than failing fast
+            // — so a fast non-zero exit is a genuine fault. No argv here,
+            // so the `--key` secret can't leak into the message.
             let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-            Err(format!(
+            Err(CompleteLoginError::Failed(format!(
                 "composio login --key failed (exit {}): {}",
                 output.status, stderr
-            ))
+            )))
         }
-        Err(e) => Err(e),
+        Err(CliError::TimedOut) => Err(CompleteLoginError::TimedOut),
+        Err(CliError::Spawn(detail)) => Err(CompleteLoginError::Failed(detail)),
     }
 }
 
@@ -318,9 +368,34 @@ async fn whoami() -> Result<Option<WhoamiResponse>, String> {
 /// `login --key` call uses a custom, much larger timeout.
 const DEFAULT_CLI_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
-/// Short alias for the common 30s timeout case.
+/// Short alias for the common 30s timeout case. Flattens the typed
+/// `CliError` to a string — only `complete_login` needs to tell a
+/// timeout apart from a spawn failure.
 async fn run_cli(args: &[&str]) -> Result<std::process::Output, String> {
-    run_cli_with_timeout(args, DEFAULT_CLI_TIMEOUT).await
+    run_cli_with_timeout(args, DEFAULT_CLI_TIMEOUT)
+        .await
+        .map_err(|e| e.to_string())
+}
+
+/// Failure modes of a CLI invocation. Kept distinct so `complete_login`
+/// can map a wall-clock timeout to a user-actionable message while every
+/// other caller flattens both arms to a string via `run_cli`.
+enum CliError {
+    /// The process did not exit before the caller's timeout elapsed.
+    TimedOut,
+    /// Failed to spawn or wait on the process.
+    Spawn(String),
+}
+
+impl std::fmt::Display for CliError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // No argv in the message: a `login --key` timeout must never
+            // surface the secret cli_key (HOU-431 / HOU-434).
+            Self::TimedOut => write!(f, "composio CLI timed out"),
+            Self::Spawn(detail) => write!(f, "{detail}"),
+        }
+    }
 }
 
 /// Spawn the `composio` CLI with stdout/stderr captured, a hard
@@ -335,8 +410,9 @@ async fn run_cli(args: &[&str]) -> Result<std::process::Output, String> {
 async fn run_cli_with_timeout(
     args: &[&str],
     timeout: std::time::Duration,
-) -> Result<std::process::Output, String> {
-    let bin = cli_binary()?;
+) -> Result<std::process::Output, CliError> {
+    // A missing binary is a spawn precondition failure, not a timeout.
+    let bin = cli_binary().map_err(CliError::Spawn)?;
     let start = std::time::Instant::now();
     tracing::debug!(
         "[composio:cli] → spawn {:?} {:?} (timeout={:?})",
@@ -369,11 +445,8 @@ async fn run_cli_with_timeout(
     let fut = cmd.output();
     let result = match tokio::time::timeout(timeout, fut).await {
         Ok(Ok(out)) => Ok(out),
-        Ok(Err(e)) => Err(format!("Failed to spawn composio CLI: {e}")),
-        Err(_) => Err(format!(
-            "composio CLI timed out after {:?}: args={:?}",
-            timeout, args
-        )),
+        Ok(Err(e)) => Err(CliError::Spawn(format!("Failed to spawn composio CLI: {e}"))),
+        Err(_) => Err(CliError::TimedOut),
     };
 
     let elapsed = start.elapsed();
@@ -402,12 +475,21 @@ async fn run_cli_with_timeout(
                 );
             }
         }
-        Err(e) => {
-            tracing::error!(
-                "[composio:cli] ← error in {:?}: {}",
-                elapsed,
-                e
+        Err(CliError::TimedOut) => {
+            // A timeout is transient/expected — most often the user never
+            // approved a `login` in the browser. Log at warn! (a Sentry
+            // breadcrumb, NOT an event) so an abandoned sign-in stops
+            // spamming crash reporting (HOU-434); `sentry_tracing` would
+            // ship an error! here as a full event. Log only the
+            // subcommand, never argv — `login` carries the secret key.
+            tracing::warn!(
+                "[composio:cli] ← `{}` timed out after {:?}",
+                args.first().copied().unwrap_or("?"),
+                elapsed
             );
+        }
+        Err(CliError::Spawn(detail)) => {
+            tracing::error!("[composio:cli] ← error in {:?}: {detail}", elapsed);
         }
     }
     result
@@ -795,6 +877,30 @@ fn decorate_windows_exit(command: &str, status_display: &str, exit_code: Option<
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn complete_login_timeout_message_has_no_secret_argv() {
+        let msg = CompleteLoginError::TimedOut.to_string();
+        assert!(msg.contains("timed out"), "msg: {msg}");
+        assert!(msg.contains("180"), "should name the cap: {msg}");
+        // The login argv carries the secret `--key`; it must never reach
+        // a message we hand back to the user / logs (HOU-431 / HOU-434).
+        assert!(!msg.contains("--key"), "leaked argv: {msg}");
+        assert!(!msg.contains("args"), "leaked argv: {msg}");
+    }
+
+    #[test]
+    fn complete_login_failed_passes_detail_through() {
+        let msg = CompleteLoginError::Failed("exit 1: boom".into()).to_string();
+        assert_eq!(msg, "exit 1: boom");
+    }
+
+    #[test]
+    fn cli_timeout_message_has_no_secret_argv() {
+        let msg = CliError::TimedOut.to_string();
+        assert!(msg.contains("timed out"), "msg: {msg}");
+        assert!(!msg.contains("--key"), "leaked argv: {msg}");
+    }
 
     #[test]
     fn decorates_illegal_instruction() {

--- a/engine/houston-composio/src/commands.rs
+++ b/engine/houston-composio/src/commands.rs
@@ -7,7 +7,7 @@
 //! Tauri command decorators live in the adapter crate (`houston-tauri`),
 //! keeping this crate frontend-agnostic.
 
-use crate::cli::{self, ComposioStatus, StartLinkResponse, StartLoginResponse};
+use crate::cli::{self, ComposioStatus, CompleteLoginError, StartLinkResponse, StartLoginResponse};
 use crate::install;
 use crate::toolkits::normalize_toolkit_slugs;
 
@@ -32,8 +32,10 @@ pub async fn start_composio_oauth() -> Result<StartLoginResponse, String> {
     cli::start_login().await
 }
 
-/// Finish the login flow started by `start_composio_oauth`.
-pub async fn complete_composio_login(cli_key: String) -> Result<(), String> {
+/// Finish the login flow started by `start_composio_oauth`. The typed
+/// error lets the engine server distinguish an expected "user never
+/// approved" timeout from a genuine CLI fault (see `cli::complete_login`).
+pub async fn complete_composio_login(cli_key: String) -> Result<(), CompleteLoginError> {
     cli::complete_login(&cli_key).await
 }
 

--- a/engine/houston-engine-server/src/routes/composio.rs
+++ b/engine/houston-engine-server/src/routes/composio.rs
@@ -12,10 +12,13 @@ use axum::{
     Json, Router,
 };
 use houston_composio::apps::ComposioAppEntry;
-use houston_composio::cli::{ComposioStatus, StartLinkResponse, StartLoginResponse};
+use houston_composio::cli::{
+    ComposioStatus, CompleteLoginError, StartLinkResponse, StartLoginResponse,
+};
 use houston_composio::commands as inner;
 use houston_composio::connection_watcher;
 use houston_engine_core::CoreError;
+use houston_engine_protocol::ErrorCode;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -73,6 +76,24 @@ fn lift(e: String) -> ApiError {
     ApiError(CoreError::Internal(e))
 }
 
+/// Map a login-completion failure to the wire error.
+///
+/// A `TimedOut` is an expected outcome — the user closed the sign-in tab
+/// or never approved — so it surfaces as a typed `composio_login_timeout`
+/// the frontend renders as localized, retryable copy (and deliberately
+/// does NOT report to crash tracking; that reporting was the HOU-434
+/// Sentry noise). Anything else is an internal fault worth a bug report.
+fn map_complete_login_err(e: CompleteLoginError) -> ApiError {
+    match e {
+        CompleteLoginError::TimedOut => ApiError(CoreError::Labeled {
+            code: ErrorCode::Unavailable,
+            kind: "composio_login_timeout",
+            message: "Sign-in timed out waiting for browser approval.".to_string(),
+        }),
+        CompleteLoginError::Failed(detail) => ApiError(CoreError::Internal(detail)),
+    }
+}
+
 async fn status(State(_st): State<Arc<ServerState>>) -> Json<ComposioStatus> {
     Json(inner::list_composio_connections().await)
 }
@@ -99,7 +120,7 @@ async fn complete_login(
 ) -> Result<(), ApiError> {
     inner::complete_composio_login(req.cli_key)
         .await
-        .map_err(lift)
+        .map_err(map_complete_login_err)
 }
 
 async fn logout(State(_st): State<Arc<ServerState>>) -> Result<(), ApiError> {
@@ -164,4 +185,27 @@ async fn watch_connection(
     }
     connection_watcher::watch(toolkit, Arc::new(st.events.clone()));
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn timeout_maps_to_typed_login_timeout() {
+        let err = map_complete_login_err(CompleteLoginError::TimedOut).0;
+        // Frontend matches on `kind` to render localized, retryable copy.
+        assert_eq!(err.kind(), Some("composio_login_timeout"));
+        assert_eq!(err.code(), ErrorCode::Unavailable);
+        // The wire message must not carry the secret `--key` argv.
+        assert!(!err.to_string().contains("--key"));
+    }
+
+    #[test]
+    fn cli_failure_maps_to_internal_bug() {
+        let err = map_complete_login_err(CompleteLoginError::Failed("boom".into())).0;
+        assert_eq!(err.kind(), None);
+        assert_eq!(err.code(), ErrorCode::Internal);
+        assert_eq!(err.to_string(), "internal: boom");
+    }
 }


### PR DESCRIPTION
## Linear
HOU-434 — Composio login CLI times out after 330s

## Root cause
`complete_login` shells out to `composio login --key <cli_key>` — a blocking poll — wrapped in a **330s** timeout. The doc comment justified 330s as "CLI session expiry is 5 minutes + slack," but that premise is wrong:

- The pending-login session actually lives **10 minutes** (`expiresAt - cachedAt` in `~/.composio/pending-login-session.json` = exactly 600s; `login --key` / `--poll` "poll for up to 10 minutes").
- The CLI stays **completely silent** the entire time (no stdout, no stderr) even for an invalid or already-expired key (verified by probing the bundled binary).

So when a user doesn't finish the browser approval, the request blocks for 5.5 minutes and then returns a raw internal string — `composio CLI timed out after 330s: args=[...]` — which the sign-in dialog rendered **verbatim** in red, and which was reported to Sentry from **both**:
- the frontend (`HoustonClient.toError`, the HOU-434 culprit), and
- the engine (`sentry_tracing` maps `tracing::error!` → a Sentry event).

That is the 9 users / 12 events in HOU-434 (and the same `--key`-on-argv exposure HOU-431 tracks).

## Fix
**Engine** (`houston-composio`, `houston-engine-server`)
- Cap lowered to **180s** (`LOGIN_POLL_TIMEOUT_SECS`). Covers a real browser OAuth — the happy path returns within seconds of approval — while failing an abandon ~2.5 min sooner.
- Typed errors: new `CompleteLoginError { TimedOut, Failed }` + an internal `CliError { TimedOut, Spawn }` so a wall-clock timeout is distinguishable from a spawn/exit fault. The route maps `TimedOut` → `CoreError::Labeled { kind: "composio_login_timeout", code: Unavailable }`; genuine faults stay `Internal` (still captured as bugs).
- Timeout now logged at `warn!` (a Sentry **breadcrumb**, not an event), and the message/log **never** include argv — the `login --key` value is the secret `cli_key`. The warn log names only the subcommand.

**Frontend** (`app/`)
- `surfaceError` carve-out (`EXPECTED_INLINE_KINDS`): the expected `composio_login_timeout` is never toasted or sent to Sentry — same treatment as an `AbortError`. `completeLogin` passes `{ toast: false }` since the dialog renders failures inline; genuine faults still capture.
- `useComposioAuth` renders **localized, actionable** copy by `kind` (`errorTimeout` / `errorGeneric`) instead of the raw engine string.
- The dialog hides the now-dead "open browser" button in the error state (that session is expired) and shows a **"Try again"** that mints a fresh session.
- New i18n keys in `en` / `es` / `pt`.

## Tests
5 new unit tests + existing suites:
- typed-error messages carry no `--key` / `args`; `TimedOut` names the 180s cap.
- route maps `TimedOut` → kind `composio_login_timeout` / `Unavailable`, `Failed` → `Internal`.
- `cargo test -p houston-composio -p houston-engine-server` ✅, `cargo build --workspace` ✅, `pnpm tsc --noEmit` ✅, `pnpm check-locales` ✅.

## Verify
**Before:** start a Composio sign-in, then don't approve in the browser. The dialog spins ~5.5 min, then shows a raw `composio CLI timed out after 330s: args=[...]` string and fires a Sentry event.
**After:** same flow fails at ~3 min with "Sign-in timed out. Make sure you finished approving in the browser, then try again." + a **Try again** button; no Sentry event (frontend carve-out + engine `warn!`). A real approval within the window still completes in seconds.

## Note on overlap with #500 (HOU-431)
#500 redacts `--key` from logs/Sentry. This PR removes argv from the timeout path entirely (the `TimedOut` arm carries no args), so the two touch the same `cli.rs` timeout site and will conflict trivially on merge — resolution is "no argv in the timeout message," which both PRs want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)