### PR TITLE
fix(skills): resolve skills by directory slug so drifted/missing skills load (HOU-441)

### DIFF
--- a/app/src/components/tabs/use-skill-surface.ts
+++ b/app/src/components/tabs/use-skill-surface.ts
@@ -1,4 +1,6 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
 import type { CommunitySkill, RepoSkill, Skill } from "@houston-ai/skills";
 import {
   useCreateSkill,
@@ -10,10 +12,16 @@ import {
   useSkillDetail,
   useSkills,
 } from "../../hooks/queries";
+import { queryKeys } from "../../lib/query-keys";
 import { tauriSkills } from "../../lib/tauri";
+import { isMissingSkillError } from "../../lib/missing-skill";
+import { useUIStore } from "../../stores/ui";
 import { useSkillSurfaceLabels } from "./use-skill-surface-labels";
 
 export function useSkillSurface(agentPath: string) {
+  const { t } = useTranslation("skills");
+  const queryClient = useQueryClient();
+  const addToast = useUIStore((s) => s.addToast);
   const { skillDetailLabels } = useSkillSurfaceLabels();
   const { data: summaries, isLoading: skillsLoading } = useSkills(agentPath);
   const [selectedSkillName, setSelectedSkillName] = useState<string | null>(null);
@@ -24,10 +32,26 @@ export function useSkillSurface(agentPath: string) {
     setPrevAgentPath(agentPath);
     setSelectedSkillName(null);
   }
-  const { data: skillDetail } = useSkillDetail(
+  const { data: skillDetail, error: skillDetailError } = useSkillDetail(
     agentPath,
     selectedSkillName ?? undefined,
   );
+
+  // A selected skill that no longer resolves (renamed, deleted, or never
+  // installed) returns `skill_not_found`. `tauriSkills.load` keeps that off the
+  // red bug-toast / Sentry path, so surface it plainly here: a friendly note,
+  // drop the stale selection, and refetch the list so the dead card vanishes.
+  // (HOU-441)
+  useEffect(() => {
+    if (!selectedSkillName || !isMissingSkillError(skillDetailError)) return;
+    addToast({
+      title: t("detail.unavailableToast.title"),
+      description: t("detail.unavailableToast.description"),
+      variant: "info",
+    });
+    setSelectedSkillName(null);
+    queryClient.invalidateQueries({ queryKey: queryKeys.skills(agentPath) });
+  }, [skillDetailError, selectedSkillName, agentPath, addToast, queryClient, t]);
   const saveSkill = useSaveSkill(agentPath);
   const deleteSkill = useDeleteSkill(agentPath);
   const createSkill = useCreateSkill(agentPath);

--- a/app/src/lib/missing-skill.ts
+++ b/app/src/lib/missing-skill.ts
@@ -1,0 +1,26 @@
+/**
+ * A skill the user opened can no longer be resolved on disk — renamed,
+ * deleted, or never installed. The engine reports this with a stable
+ * `skill_not_found` error kind (see `SkillError::NotFound` ->
+ * `CoreError::Labeled` in `engine/houston-engine-core/src/skills.rs`).
+ *
+ * This is an expected, explainable state, NOT a Houston bug: the Skills view
+ * surfaces it inline and refreshes the list. We use it to keep the red
+ * "we have a problem" bug toast + Sentry report off the missing-skill path
+ * (HOU-441) while still surfacing a clear message.
+ */
+export const MISSING_SKILL_KIND = "skill_not_found";
+
+/**
+ * True when a thrown engine error means the referenced skill is gone. Reads
+ * the typed `.kind` exposed by `HoustonEngineError` (and tolerates a plain
+ * `{ kind }` object), so it never depends on parsing message strings.
+ */
+export function isMissingSkillError(err: unknown): boolean {
+  return (
+    !!err &&
+    typeof err === "object" &&
+    "kind" in err &&
+    (err as { kind?: unknown }).kind === MISSING_SKILL_KIND
+  );
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -32,6 +32,7 @@ import type {
 import { getEngine } from "./engine";
 import { osPickDirectory } from "./os-bridge";
 import { logger } from "./logger";
+import { MISSING_SKILL_KIND } from "./missing-skill";
 import { normalizeLegacyModel } from "./providers";
 import { shouldAutocompactForSession } from "./autocompact";
 import { useProviderSwitchStore } from "../stores/provider-switch";
@@ -45,6 +46,12 @@ interface EngineCallOptions {
    *  user-initiated failures always reach crash reporting; set false only for
    *  genuinely fire-and-forget calls or ones with their own report path. */
   capture?: boolean;
+  /** Engine error `kind`s that are expected + explainable (not Houston bugs).
+   *  Matching errors are logged but get NO red bug toast and NO Sentry report;
+   *  the caller surfaces them inline. Use sparingly, only for kinds a user can
+   *  understand and act on (e.g. `skill_not_found` — the skill was renamed or
+   *  removed). */
+  silenceKinds?: string[];
 }
 
 /** Wrap an engine call and surface errors as toasts unless caller handles them inline. */
@@ -75,6 +82,14 @@ async function surfaceError(
   // Aborted requests (user typed again, navigated away, cancelled a sign-in)
   // are expected, not failures — never toast or report them.
   if (err instanceof Error && err.name === "AbortError") return;
+
+  // Expected, explainable engine errors the caller surfaces inline. Logged
+  // above for the local log tail, but no red bug toast and no Sentry report.
+  const kind =
+    err && typeof err === "object" && "kind" in err
+      ? (err as { kind?: unknown }).kind
+      : undefined;
+  if (typeof kind === "string" && options?.silenceKinds?.includes(kind)) return;
 
   const shouldToast = options?.toast !== false;
   const shouldCapture = options?.capture !== false;
@@ -320,7 +335,15 @@ export const tauriSkills = {
       })),
     ),
   load: (agentPath: string, name: string) =>
-    call<SkillDetail>("load_skill", () => getEngine().loadSkill(agentPath, name)),
+    call<SkillDetail>(
+      "load_skill",
+      () => getEngine().loadSkill(agentPath, name),
+      undefined,
+      // The skill the user opened may have been renamed, deleted, or never
+      // installed. That's expected — the Skills view surfaces it inline and
+      // refreshes the list — so don't fire the red bug toast or report it.
+      { silenceKinds: [MISSING_SKILL_KIND] },
+    ),
   create: (agentPath: string, name: string, description: string, content: string) =>
     call<void>("create_skill", () =>
       getEngine().createSkill({ workspacePath: agentPath, name, description, content }),

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -78,6 +78,10 @@
   },
   "detail": {
     "notFound": "Skill not found",
+    "unavailableToast": {
+      "title": "Skill unavailable",
+      "description": "This skill is no longer available. It may have been renamed or removed."
+    },
     "backAria": "Back to skills",
     "moreOptions": "More options",
     "saveChanges": "Save changes",

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -78,6 +78,10 @@
   },
   "detail": {
     "notFound": "Skill no encontrado",
+    "unavailableToast": {
+      "title": "Skill no disponible",
+      "description": "Este skill ya no está disponible. Es posible que lo hayan renombrado o eliminado."
+    },
     "backAria": "Volver a skills",
     "moreOptions": "Más opciones",
     "saveChanges": "Guardar cambios",

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -78,6 +78,10 @@
   },
   "detail": {
     "notFound": "Skill não encontrado",
+    "unavailableToast": {
+      "title": "Skill indisponível",
+      "description": "Este skill não está mais disponível. Ele pode ter sido renomeado ou removido."
+    },
     "backAria": "Voltar para skills",
     "moreOptions": "Mais opções",
     "saveChanges": "Salvar alterações",

--- a/app/tests/missing-skill.test.ts
+++ b/app/tests/missing-skill.test.ts
@@ -1,0 +1,35 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { MISSING_SKILL_KIND, isMissingSkillError } from "../src/lib/missing-skill.ts";
+
+describe("missing-skill classifier (HOU-441)", () => {
+  it("matches the stable engine error kind", () => {
+    // Mirrors SkillError::NotFound -> kind "skill_not_found" in
+    // engine/houston-engine-core/src/skills.rs.
+    strictEqual(MISSING_SKILL_KIND, "skill_not_found");
+  });
+
+  it("recognizes a plain { kind } error body", () => {
+    strictEqual(isMissingSkillError({ kind: "skill_not_found" }), true);
+  });
+
+  it("recognizes an error exposing kind via a getter (HoustonEngineError shape)", () => {
+    const err = new Error("Skill not found: Redactar Outreach ESG");
+    Object.defineProperty(err, "kind", { get: () => "skill_not_found" });
+    strictEqual(isMissingSkillError(err), true);
+  });
+
+  it("does NOT match other engine error kinds (they still bug-toast + report)", () => {
+    strictEqual(isMissingSkillError({ kind: "validation" }), false);
+    strictEqual(isMissingSkillError({ kind: "rate_limited" }), false);
+    strictEqual(isMissingSkillError({ kind: "parse_failed" }), false);
+  });
+
+  it("does NOT match untyped errors — a real crash must keep surfacing", () => {
+    strictEqual(isMissingSkillError(new Error("boom")), false);
+    strictEqual(isMissingSkillError("Skill not found"), false);
+    strictEqual(isMissingSkillError(null), false);
+    strictEqual(isMissingSkillError(undefined), false);
+    strictEqual(isMissingSkillError({ message: "no kind here" }), false);
+  });
+});

--- a/engine/houston-skills/src/index.rs
+++ b/engine/houston-skills/src/index.rs
@@ -66,7 +66,15 @@ fn list_summaries(skills_dir: &Path) -> Result<Vec<SkillSummary>, crate::SkillEr
             continue;
         }
         match format::parse_file(&skill_md) {
-            Ok((summary, _body)) => summaries.push(summary),
+            Ok((mut summary, _body)) => {
+                // Identity = directory slug, matching `list_skills` and what
+                // `load_skill` resolves by. Keeps the system-prompt index in
+                // step even when frontmatter `name:` drifted. (HOU-441)
+                if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
+                    summary.name = dir_name.to_string();
+                }
+                summaries.push(summary);
+            }
             Err(e) => tracing::warn!("[houston-skills] skipping {}: {e}", path.display()),
         }
     }

--- a/engine/houston-skills/src/lib.rs
+++ b/engine/houston-skills/src/lib.rs
@@ -182,7 +182,19 @@ pub fn list_skills(skills_dir: &Path) -> Result<Vec<SkillSummary>, SkillError> {
             continue;
         }
         match format::parse_file(&skill_md) {
-            Ok((summary, _body)) => summaries.push(summary),
+            Ok((mut summary, _body)) => {
+                // Identity = the on-disk directory slug. `load_skill`, `save`,
+                // `delete`, and the `.claude` discovery mirror all resolve by
+                // directory, so the name we hand back here is the one a caller
+                // will pass to `load_skill`. A SKILL.md whose frontmatter `name:`
+                // drifted from its directory (common for agent-authored skills
+                // that carry a display phrase) must still round-trip — trust the
+                // directory, not the frontmatter. (HOU-441)
+                if let Some(dir_name) = path.file_name().and_then(|n| n.to_str()) {
+                    summary.name = dir_name.to_string();
+                }
+                summaries.push(summary);
+            }
             Err(e) => tracing::warn!("[houston-skills] skipping {}: {e}", path.display()),
         }
     }
@@ -244,6 +256,13 @@ pub fn load_skill(skills_dir: &Path, name: &str) -> Result<Skill, SkillError> {
         return Err(SkillError::NotFound(name.to_string()));
     }
     let (mut summary, body) = format::parse_file(&skill_md)?;
+    // Pin identity to the directory slug we were asked for. If the frontmatter
+    // `name:` drifted from the directory (agent-authored skills often store a
+    // display phrase here), heal it on open so the file, the `.claude` mirror,
+    // and Claude Code's native tool name all agree with the slug everything
+    // else loads by. `load_skill` already rewrites the file for `last_used`, so
+    // this is free. (HOU-441)
+    summary.name = name.to_string();
     let today = chrono::Local::now().format("%Y-%m-%d").to_string();
     summary.last_used = Some(today);
     let updated = format::serialize(&summary, &body);
@@ -484,6 +503,45 @@ mod tests {
         let skill = load_skill(dir, "loader-test").unwrap();
         assert_eq!(skill.summary.name, "loader-test");
         assert!(skill.content.contains("Test body"));
+    }
+
+    #[test]
+    fn list_and_load_use_directory_slug_when_frontmatter_name_drifts() {
+        // HOU-441: an agent-authored SKILL.md can carry a display phrase in its
+        // frontmatter `name:` while living in a kebab-slug directory. `list_skills`
+        // must report the *directory* slug — the id `load_skill` resolves by — or
+        // the UI round-trip (list -> click -> load) hard-errors "Skill not found".
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path();
+        let slug = "redactar-outreach-esg";
+        let skill_dir = dir.join(slug);
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        std::fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: Redactar Outreach ESG\ndescription: Draft ESG outreach\n---\n\n## Procedure\nDraft it.\n",
+        )
+        .unwrap();
+
+        // list reports the directory slug, not the drifted frontmatter phrase.
+        let skills = list_skills(dir).unwrap();
+        assert_eq!(skills.len(), 1);
+        assert_eq!(skills[0].name, slug);
+
+        // The id `list_skills` handed back round-trips cleanly through `load_skill`.
+        let loaded = load_skill(dir, &skills[0].name).unwrap();
+        assert_eq!(loaded.summary.name, slug);
+        assert!(loaded.content.contains("Draft it."));
+
+        // Opening the skill heals the on-disk frontmatter name to the slug.
+        let healed = std::fs::read_to_string(skill_dir.join("SKILL.md")).unwrap();
+        assert!(healed.contains(&format!("name: {slug}")));
+        assert!(!healed.contains("Redactar Outreach ESG"));
+
+        // The drifted phrase never named a real directory — still NotFound.
+        assert!(matches!(
+            load_skill(dir, "Redactar Outreach ESG"),
+            Err(SkillError::NotFound(_))
+        ));
     }
 
     #[test]

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -199,6 +199,33 @@ Format:
 
 The engine applies the rename per workspace on the next sync. If only the old slug exists, it's renamed in place — body content preserved, `name:` field fixed, rest of the frontmatter refreshed from the new package. If both old and new slugs already exist (because a prior sync without migrations copied the new one alongside the old), the **old one is deleted**: the bundled package no longer ships it, every cross-reference points to the new slug, so keeping it would just leave a duplicate in the picker. See `store/README.md` for the full mechanism, including the recipe for shipping a follow-up migration step when the rename was published before the migration mechanism existed.
 
+## Skill identity = directory slug (drift-resilient)
+
+The **directory slug is the one canonical identity** for a skill. `load_skill`,
+`save`, `delete`, and the `.claude/skills/<slug>` mirror all resolve by
+`skills_dir.join(<name>)` — the directory, never the frontmatter. So the name a
+caller hands `load_skill` MUST be a directory slug.
+
+Therefore `list_skills` (and the system-prompt `index::build`) report each
+skill's **directory name** as `name`, overriding whatever the frontmatter `name:`
+says. Agent-authored SKILL.md files sometimes carry a display phrase in `name:`
+(e.g. dir `redactar-outreach-esg`, frontmatter `name: Redactar Outreach ESG`).
+Before HOU-441 the list handed the UI the phrase, the user clicked it, and
+`load_skill("Redactar Outreach ESG")` found no such directory → a hard
+`skill_not_found` (red bug toast + Sentry). Reporting the directory slug makes
+the list → click → load round-trip consistent and gives the `.claude` mirror a
+real target. `load_skill` also **heals** the frontmatter `name:` to the slug on
+open (it already rewrites the file for `last_used`), so Claude Code's native
+tool name stops drifting too. No bulk migration — identity is fixed at read
+time and self-heals on access.
+
+Genuinely missing skills still happen (deleted, never installed, a stale
+selection). `skill_not_found` is an expected, explainable state, **not** a
+Houston bug: `tauriSkills.load` tags it via `silenceKinds: ["skill_not_found"]`
+(see `app/src/lib/missing-skill.ts`) so it skips the red bug toast + Sentry
+report, and `useSkillSurface` surfaces it inline (a friendly info toast, clears
+the selection, refetches the list so the dead card vanishes).
+
 ## Files of interest
 
 | What | Where |


### PR DESCRIPTION
Fixes **[HOU-441](https://linear.app/houston-ai/issue/HOU-441/load-skill-skill-not-found-for-referenced-skill)** — `load_skill`: "Skill not found" for a referenced skill.

## Root cause — skill identity drift

A skill on disk is a **folder** plus a `SKILL.md` whose frontmatter carries a `name:`. The engine read these two names from different places, and they could disagree:

| Operation | Keyed off |
|-----------|-----------|
| `list` (`GET /skills`, fills the Skills tab) | frontmatter `name:` |
| `load` / `save` / `delete` + the `.claude` mirror | **directory slug** (`skills_dir.join(name)`) |

Skills made via the UI or install keep folder == frontmatter `name` (both validated kebab). But agent-authored `SKILL.md` files (the model writes the file directly) sometimes put a display phrase in `name:` while the folder is a different slug — e.g. dir `redactar-outreach-esg`, `name: Redactar Outreach ESG`. `list` then handed the UI the phrase, the user clicked it, and `load_skill("Redactar Outreach ESG")` found no such directory → hard `skill_not_found` (red bug toast + Sentry). The Spanish phrase-names in the Sentry events are the fingerprint.

## Fix

1. **Directory slug is the single source of identity** (engine). `list_skills` and the system-prompt index now report each skill's directory name; `load_skill` pins the returned identity to the requested slug and **heals** the drifted frontmatter `name:` on open (it already rewrites the file for `last_used`). This makes list → click → load consistent and also repairs the broken `.claude` discovery mirror. No bulk migration — identity is fixed at read time and self-heals on access.
2. **Graceful missing-skill handling** (app). A genuinely gone skill (renamed/deleted/never installed) is expected, not a Houston bug: `tauriSkills.load` tags `skill_not_found` via a new `silenceKinds` option (no red bug toast, no Sentry report), and `useSkillSurface` surfaces it inline — a calm "Skill unavailable" info toast, clears the stale selection, refetches the list so the dead card vanishes. No fake "reinstall" button: we have no source for an arbitrary missing skill.

## Reproduce (before / after)

Unit:
```
cargo test -p houston-skills list_and_load_use_directory_slug_when_frontmatter_name_drifts
```
- Before: fails (list returns the phrase, `load_skill(phrase)` → `NotFound`).
- After: passes (list returns the dir slug, load round-trips, frontmatter healed).

App: create `…/.agents/skills/redactar-outreach-esg/SKILL.md` with `name: Redactar Outreach ESG`, open the agent → Skills → click the card.
- Before: red "We have a problem — Skill not found: Redactar Outreach ESG".
- After: opens fine; frontmatter `name:` rewritten to `redactar-outreach-esg`. Deleting the folder and clicking a stale card shows the calm "Skill unavailable" toast.

## Tests & verification

- `cargo test -p houston-skills` → 51/51 (incl. new drift regression test).
- `app/tests/missing-skill.test.ts` → 5/5 (the `skill_not_found` classifier).
- `pnpm tsc --noEmit` clean · `pnpm check-locales` in sync (en/es/pt) · `houston-engine-server` builds.
- Note: a pre-existing unrelated failure `houston-engine-core … device_auth_relay_emits_url_then_code` (in `provider/login_relay`, untouched) fails on the base branch too.

## Affected files

- `engine/houston-skills/src/lib.rs`, `engine/houston-skills/src/index.rs`
- `app/src/lib/tauri.ts`, `app/src/lib/missing-skill.ts` (new)
- `app/src/components/tabs/use-skill-surface.ts`
- `app/src/locales/{en,es,pt}/skills.json`
- `app/tests/missing-skill.test.ts` (new)
- `knowledge-base/skills.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
