### PR TITLE
fix(onboarding): idempotent default-workspace creation (HOU-444)

### DIFF
--- a/app/src/components/onboarding/ensure-default-assistant.ts
+++ b/app/src/components/onboarding/ensure-default-assistant.ts
@@ -1,0 +1,72 @@
+/**
+ * Idempotent get-or-create for the first-run default workspace and its
+ * assistant — the fix for HOU-444.
+ *
+ * The onboarding orchestrator can invoke workspace creation more than once
+ * for a single install: a double-clicked "Continue", the welcome-screen
+ * "Skip" racing a mission, a retry after a step failed partway, or an
+ * orchestrator remount when `tutorialActive` toggles. Calling the engine's
+ * `createWorkspace` blindly each time made the second call hit the dup-name
+ * guard and reject with `conflict: workspace named "Personal" already
+ * exists`, which then surfaced as an unhandled rejection (Sentry
+ * HOUSTON-APP-7D).
+ *
+ * Reusing the existing workspace — and any assistant already inside it (the
+ * engine rejects a duplicate AGENT name too) — makes the whole step safe to
+ * run repeatedly. Pure + dependency-injected so it unit-tests without the
+ * React / store / tauri graph.
+ */
+
+export interface WorkspaceLike {
+  id: string;
+  name: string;
+}
+
+export interface EnsureWorkspaceDeps<W extends WorkspaceLike, A> {
+  /** All existing workspaces (engine `list_workspaces`). */
+  listWorkspaces: () => Promise<W[]>;
+  /** Create a brand-new workspace with this name. */
+  createWorkspace: (name: string) => Promise<W>;
+  /** Agents already inside the workspace (engine `list_agents`). */
+  listAgents: (workspaceId: string) => Promise<A[]>;
+  /** Create the default assistant inside the workspace. */
+  createAssistant: (workspaceId: string) => Promise<A>;
+}
+
+export interface EnsuredWorkspace<W, A> {
+  workspace: W;
+  assistant: A;
+  /**
+   * True only when this call actually created the workspace (vs. reused an
+   * existing one). Lets the caller fire `workspace_created` analytics exactly
+   * once per install rather than on every retry.
+   */
+  createdWorkspace: boolean;
+}
+
+/**
+ * Get-or-create the named workspace and ensure it has an assistant. Safe to
+ * call repeatedly: an existing workspace (and its first assistant) is reused
+ * instead of re-created, so a retried / double-fired first-run never hits the
+ * engine's dup-name conflict.
+ */
+export async function ensureWorkspaceWithAssistant<W extends WorkspaceLike, A>(
+  workspaceName: string,
+  deps: EnsureWorkspaceDeps<W, A>,
+): Promise<EnsuredWorkspace<W, A>> {
+  const name = workspaceName.trim();
+  const existing = (await deps.listWorkspaces()).find((w) => w.name === name);
+  const workspace = existing ?? (await deps.createWorkspace(name));
+  const createdWorkspace = existing === undefined;
+
+  // A freshly created workspace has no agents; only an already-existing one
+  // could carry an assistant from a prior partial run. Reuse it rather than
+  // creating a second (which the engine would reject as a duplicate name).
+  const existingAssistant = createdWorkspace
+    ? undefined
+    : (await deps.listAgents(workspace.id))[0];
+  const assistant =
+    existingAssistant ?? (await deps.createAssistant(workspace.id));
+
+  return { workspace, assistant, createdWorkspace };
+}

--- a/app/src/components/onboarding/personal-assistant-onboarding.tsx
+++ b/app/src/components/onboarding/personal-assistant-onboarding.tsx
@@ -1,11 +1,11 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { ToastContainer, type Toast } from "@houston-ai/core";
 import { analytics } from "../../lib/analytics";
 import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { useAgentStore } from "../../stores/agents";
-import { tauriProvider, tauriWorkspaces } from "../../lib/tauri";
+import { tauriAgents, tauriProvider, tauriWorkspaces } from "../../lib/tauri";
 import { getDefaultModel } from "../../lib/providers";
 import type { Agent } from "../../lib/types";
 import { MissionFrame } from "./mission-frame";
@@ -18,6 +18,7 @@ import { RoutineMission } from "./missions/routine";
 import { SummaryScreen } from "./summary-screen";
 import { WelcomeScreen } from "./welcome-screen";
 import { createPersonalAssistantForWorkspace } from "./create-personal-assistant";
+import { ensureWorkspaceWithAssistant } from "./ensure-default-assistant";
 import {
   buildAssistantInstructions,
   defaultAssistantSetup,
@@ -42,6 +43,7 @@ export function PersonalAssistantOnboarding({
   const { t } = useTranslation(["setup", "common"]);
   const setTutorialActive = useUIStore((s) => s.setTutorialActive);
   const setUiTourActive = useUIStore((s) => s.setUiTourActive);
+  const addToast = useUIStore((s) => s.addToast);
   const [step, setStep] = useState<OnboardingStep>("welcome");
   const [agent, setAgent] = useState<Agent | null>(null);
   const [provider, setProvider] = useState<string | null>(null);
@@ -59,6 +61,10 @@ export function PersonalAssistantOnboarding({
     t("setup:tutorial.defaults.assistantName"),
   );
   const [assistantColor, setAssistantColor] = useState("navy");
+  // Collapses concurrent / repeated default-workspace creation onto a single
+  // in-flight operation so first-run can never fire `createWorkspace` twice
+  // (a double-clicked Continue, Skip racing a mission) — HOU-444.
+  const creationRef = useRef<Promise<Agent> | null>(null);
 
   const missionTitle = t("setup:tutorial.missions.try.skill.title");
 
@@ -77,37 +83,73 @@ export function PersonalAssistantOnboarding({
     setStep("meet");
   };
 
-  const createWorkspaceAndAssistant = async (
+  const createWorkspaceAndAssistant = (
     pickedProvider: string,
     pickedModel: string,
   ): Promise<Agent> => {
-    const setup = defaultAssistantSetup({
-      workspaceName: t("setup:tutorial.defaults.workspaceName"),
-      assistantName: assistantName.trim() || t("setup:tutorial.defaults.assistantName"),
-      focus: t("setup:tutorial.defaults.focus"),
-      approvalRule: t("setup:tutorial.defaults.approvalRule"),
+    // Reuse an in-flight creation rather than starting a second one, so a
+    // double-clicked Continue (or a Skip racing a mission) can't fire two
+    // `createWorkspace("Personal")` calls and trip the engine's dup-name
+    // conflict (HOU-444).
+    if (creationRef.current) return creationRef.current;
+
+    const op = (async (): Promise<Agent> => {
+      const setup = defaultAssistantSetup({
+        workspaceName: t("setup:tutorial.defaults.workspaceName"),
+        assistantName:
+          assistantName.trim() || t("setup:tutorial.defaults.assistantName"),
+        focus: t("setup:tutorial.defaults.focus"),
+        approvalRule: t("setup:tutorial.defaults.approvalRule"),
+      });
+      setup.color = assistantColor;
+
+      // Get-or-create: a prior partial run (or an orchestrator remount) may
+      // have already created "Personal" and/or its assistant. Reuse them
+      // instead of re-creating, which the engine rejects as a duplicate.
+      const { workspace: ws, assistant: created, createdWorkspace } =
+        await ensureWorkspaceWithAssistant(setup.workspaceName, {
+          listWorkspaces: () => tauriWorkspaces.list(),
+          createWorkspace: (name) => tauriWorkspaces.create(name),
+          listAgents: (workspaceId) => tauriAgents.list(workspaceId),
+          createAssistant: (workspaceId) =>
+            createPersonalAssistantForWorkspace(workspaceId, {
+              name: setup.assistantName.trim(),
+              instructions: buildAssistantInstructions(setup, missionTitle),
+              color: setup.color,
+              provider: pickedProvider,
+              model: pickedModel,
+            }),
+        });
+
+      // Persist the picked pair as the new global default so the next new
+      // agent starts from the same place the user just chose during onboarding.
+      await tauriProvider.setLastUsed(pickedProvider, pickedModel);
+      // Count activation only for a genuinely new workspace — a reused one
+      // (retry / remount) must not double-fire the event.
+      if (createdWorkspace) {
+        analytics.track("workspace_created", {
+          provider: pickedProvider,
+          source: "onboarding",
+        });
+      }
+      await useWorkspaceStore.getState().loadWorkspaces();
+      useWorkspaceStore.getState().setCurrent(ws);
+      await useAgentStore.getState().loadAgents(ws.id);
+      const refreshed =
+        useAgentStore.getState().agents.find((a) => a.id === created.id) ??
+        created;
+      useAgentStore.getState().setCurrent(refreshed);
+      setAgent(refreshed);
+      return refreshed;
+    })();
+
+    creationRef.current = op;
+    // If it fails partway, drop the memo so a retry re-runs the (now
+    // idempotent) get-or-create instead of being stuck on a rejected promise.
+    op.catch(() => {
+      creationRef.current = null;
     });
-    setup.color = assistantColor;
-    const ws = await tauriWorkspaces.create(setup.workspaceName.trim());
-    // Persist the picked pair as the new global default so the next new agent
-    // starts from the same place the user just chose during onboarding.
-    await tauriProvider.setLastUsed(pickedProvider, pickedModel);
-    analytics.track("workspace_created", { provider: pickedProvider, source: "onboarding" });
-    const created = await createPersonalAssistantForWorkspace(ws.id, {
-      name: setup.assistantName.trim(),
-      instructions: buildAssistantInstructions(setup, missionTitle),
-      color: setup.color,
-      provider: pickedProvider,
-      model: pickedModel,
-    });
-    await useWorkspaceStore.getState().loadWorkspaces();
-    useWorkspaceStore.getState().setCurrent(ws);
-    await useAgentStore.getState().loadAgents(ws.id);
-    const refreshed =
-      useAgentStore.getState().agents.find((a) => a.id === created.id) ?? created;
-    useAgentStore.getState().setCurrent(refreshed);
-    setAgent(refreshed);
-    return refreshed;
+    return op;
   };
 
   const handleSkip = async () => {
@@ -123,6 +165,15 @@ export function PersonalAssistantOnboarding({
         mission: TUTORIAL_MISSION.id,
         integrations_skipped: true,
         tutorial_run: false,
+      });
+    } catch (err) {
+      // No silent failures: surface why setup failed (and drop back to the
+      // welcome screen via the finally) so the user can retry instead of
+      // crashing to an unhandled rejection — HOU-444.
+      addToast({
+        title: t("setup:tutorial.errors.setupFailed"),
+        description: String(err),
+        variant: "error",
       });
     } finally {
       setTutorialActive(false);
@@ -203,8 +254,18 @@ export function PersonalAssistantOnboarding({
             }}
             onContinue={async () => {
               if (!provider || !model) return;
-              await createWorkspaceAndAssistant(provider, model);
-              setStep("tools");
+              try {
+                await createWorkspaceAndAssistant(provider, model);
+                setStep("tools");
+              } catch (err) {
+                // Surface the failure as a toast and stay on this step so the
+                // user can retry — never an unhandled rejection (HOU-444).
+                addToast({
+                  title: t("setup:tutorial.errors.setupFailed"),
+                  description: String(err),
+                  variant: "error",
+                });
+              }
             }}
           />
         </MissionFrame>

--- a/app/src/components/shell/workspace-dialog.tsx
+++ b/app/src/components/shell/workspace-dialog.tsx
@@ -14,6 +14,7 @@ import { tauriProvider, tauriStore } from "../../lib/tauri";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { useAgentStore } from "../../stores/agents";
 import { useWorkspaceStore } from "../../stores/workspaces";
+import { useUIStore } from "../../stores/ui";
 import { WorkspaceSetupFlow } from "./workspace-setup-flow";
 import { createPersonalAssistantForWorkspace } from "../onboarding/create-personal-assistant";
 import {
@@ -34,6 +35,7 @@ export function CreateWorkspaceDialog({
   const loadWorkspaces = useWorkspaceStore((s) => s.loadWorkspaces);
   const loadAgents = useAgentStore((s) => s.loadAgents);
   const loadConfigs = useAgentCatalogStore((s) => s.loadConfigs);
+  const addToast = useUIStore((s) => s.addToast);
   const [tab, setTab] = useState<"new" | "github">("new");
   const [importing, setImporting] = useState(false);
   const [importError, setImportError] = useState("");
@@ -99,26 +101,37 @@ export function CreateWorkspaceDialog({
           <WorkspaceSetupFlow
             mode="dialog"
             onComplete={async (name, provider, model) => {
-              const ws = await createWorkspace(name);
-              const setup = defaultAssistantSetup({
-                workspaceName: name,
-                assistantName: t("setup:tutorial.defaults.assistantName"),
-                focus: t("setup:tutorial.defaults.focus"),
-                approvalRule: t("setup:tutorial.defaults.approvalRule"),
-              });
-              await createPersonalAssistantForWorkspace(ws.id, {
-                name: setup.assistantName,
-                instructions: buildAssistantInstructions(
-                  setup,
-                  t("setup:tutorial.defaults.firstWorkflow"),
-                ),
-                provider,
-                model,
-              });
-              await tauriProvider.setLastUsed(provider, model);
-              setCurrentWorkspace(ws);
-              await loadAgents(ws.id);
-              handleClose();
+              try {
+                const ws = await createWorkspace(name);
+                const setup = defaultAssistantSetup({
+                  workspaceName: name,
+                  assistantName: t("setup:tutorial.defaults.assistantName"),
+                  focus: t("setup:tutorial.defaults.focus"),
+                  approvalRule: t("setup:tutorial.defaults.approvalRule"),
+                });
+                await createPersonalAssistantForWorkspace(ws.id, {
+                  name: setup.assistantName,
+                  instructions: buildAssistantInstructions(
+                    setup,
+                    t("setup:tutorial.defaults.firstWorkflow"),
+                  ),
+                  provider,
+                  model,
+                });
+                await tauriProvider.setLastUsed(provider, model);
+                setCurrentWorkspace(ws);
+                await loadAgents(ws.id);
+                handleClose();
+              } catch (err) {
+                // Don't let a create failure (e.g. a name that's already
+                // taken) escape as an unhandled rejection — surface it and
+                // keep the dialog open so the user can pick another name.
+                addToast({
+                  title: t("shell:workspaceDialog.createFailed"),
+                  description: String(err),
+                  variant: "error",
+                });
+              }
             }}
           />
         ) : (

--- a/app/src/locales/en/setup.json
+++ b/app/src/locales/en/setup.json
@@ -21,6 +21,9 @@
     "eyebrow": "Mission {{number}}",
     "missionLabel": "Mission: {{title}}",
     "upNext": "Up next",
+    "errors": {
+      "setupFailed": "We couldn't finish setting up your workspace. Please try again."
+    },
     "welcome": {
       "title": "Welcome to Houston",
       "tagline": "Houston is where you build Agents that work with the same tools you use to work.",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -48,7 +48,8 @@
     "githubDescription": "Import a workspace template from GitHub. This creates a workspace with all its agents ready to use.",
     "githubPlaceholder": "owner/repo",
     "githubImport": "Import",
-    "githubImporting": "Importing workspace and agents..."
+    "githubImporting": "Importing workspace and agents...",
+    "createFailed": "We couldn't create the workspace. Please try again."
   },
   "uiTour": {
     "counter": "Tour {{current}} of {{total}}",

--- a/app/src/locales/es/setup.json
+++ b/app/src/locales/es/setup.json
@@ -21,6 +21,9 @@
     "eyebrow": "Misión {{number}}",
     "missionLabel": "Misión: {{title}}",
     "upNext": "Sigue",
+    "errors": {
+      "setupFailed": "No pudimos terminar de configurar tu espacio de trabajo. Inténtalo de nuevo."
+    },
     "welcome": {
       "title": "Bienvenido a Houston",
       "tagline": "Houston es donde construyes Agentes que funcionan con las mismas herramientas que usas para trabajar.",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -48,7 +48,8 @@
     "githubDescription": "Importa una plantilla de espacio de trabajo desde GitHub. Crea un espacio con todos sus agentes listos para usar.",
     "githubPlaceholder": "usuario/repo",
     "githubImport": "Importar",
-    "githubImporting": "Importando espacio de trabajo y agentes..."
+    "githubImporting": "Importando espacio de trabajo y agentes...",
+    "createFailed": "No pudimos crear el espacio de trabajo. Inténtalo de nuevo."
   },
   "uiTour": {
     "counter": "Tour {{current}} de {{total}}",

--- a/app/src/locales/pt/setup.json
+++ b/app/src/locales/pt/setup.json
@@ -21,6 +21,9 @@
     "eyebrow": "Missão {{number}}",
     "missionLabel": "Missão: {{title}}",
     "upNext": "A seguir",
+    "errors": {
+      "setupFailed": "Não conseguimos terminar de configurar seu espaço de trabalho. Tente novamente."
+    },
     "welcome": {
       "title": "Bem-vindo ao Houston",
       "tagline": "O Houston é onde você constrói Agentes que funcionam com as mesmas ferramentas que você usa para trabalhar.",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -48,7 +48,8 @@
     "githubDescription": "Importe um modelo de espaço de trabalho do GitHub. Isso cria um espaço com todos os agentes prontos para usar.",
     "githubPlaceholder": "usuario/repo",
     "githubImport": "Importar",
-    "githubImporting": "Importando espaço de trabalho e agentes..."
+    "githubImporting": "Importando espaço de trabalho e agentes...",
+    "createFailed": "Não conseguimos criar o espaço de trabalho. Tente novamente."
   },
   "uiTour": {
     "counter": "Tour {{current}} de {{total}}",

--- a/app/tests/ensure-default-assistant.test.ts
+++ b/app/tests/ensure-default-assistant.test.ts
@@ -1,0 +1,94 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  ensureWorkspaceWithAssistant,
+  type WorkspaceLike,
+} from "../src/components/onboarding/ensure-default-assistant.ts";
+
+type W = WorkspaceLike;
+interface A {
+  id: string;
+}
+
+/**
+ * A fake engine that mimics the real dup-name guards: creating a workspace
+ * or an agent whose name already exists throws a Conflict, exactly like
+ * `houston-engine-core::workspaces::create` / `agents_crud::create`. If the
+ * idempotency logic regresses, these fakes throw the same way prod does.
+ */
+function fakeEngine() {
+  const workspaces: W[] = [];
+  const agentsByWs: Record<string, A[]> = {};
+  let wsSeq = 0;
+  let agentSeq = 0;
+  return {
+    workspaces,
+    agentsByWs,
+    listWorkspaces: async () => workspaces.slice(),
+    createWorkspace: async (name: string) => {
+      if (workspaces.some((w) => w.name === name)) {
+        throw new Error(`conflict: workspace named "${name}" already exists`);
+      }
+      const ws: W = { id: `ws-${++wsSeq}`, name };
+      workspaces.push(ws);
+      agentsByWs[ws.id] = [];
+      return ws;
+    },
+    listAgents: async (workspaceId: string) =>
+      (agentsByWs[workspaceId] ?? []).slice(),
+    createAssistant: async (workspaceId: string) => {
+      const a: A = { id: `agent-${++agentSeq}` };
+      (agentsByWs[workspaceId] ??= []).push(a);
+      return a;
+    },
+  };
+}
+
+describe("ensureWorkspaceWithAssistant (HOU-444)", () => {
+  it("creates the workspace + assistant on first run", async () => {
+    const e = fakeEngine();
+    const r = await ensureWorkspaceWithAssistant("Personal", e);
+    strictEqual(r.createdWorkspace, true);
+    strictEqual(r.workspace.name, "Personal");
+    strictEqual(e.workspaces.length, 1);
+    strictEqual(e.agentsByWs[r.workspace.id].length, 1);
+    strictEqual(r.assistant.id, e.agentsByWs[r.workspace.id][0].id);
+  });
+
+  it("is idempotent: a second run reuses the workspace + assistant, no conflict", async () => {
+    const e = fakeEngine();
+    const first = await ensureWorkspaceWithAssistant("Personal", e);
+    // Re-running (double-fire / retry / remount) must NOT throw the dup-name
+    // conflict and must NOT create a second workspace or assistant.
+    const second = await ensureWorkspaceWithAssistant("Personal", e);
+    strictEqual(second.createdWorkspace, false);
+    strictEqual(second.workspace.id, first.workspace.id);
+    strictEqual(second.assistant.id, first.assistant.id);
+    strictEqual(e.workspaces.length, 1);
+    strictEqual(e.agentsByWs[first.workspace.id].length, 1);
+  });
+
+  it("reuses a workspace left without an assistant by a partial prior run", async () => {
+    const e = fakeEngine();
+    // Simulate a first attempt that created the workspace but rejected before
+    // the assistant was created.
+    await e.createWorkspace("Personal");
+    const r = await ensureWorkspaceWithAssistant("Personal", e);
+    strictEqual(r.createdWorkspace, false);
+    strictEqual(e.workspaces.length, 1);
+    // The missing assistant is created on the retry.
+    strictEqual(e.agentsByWs[r.workspace.id].length, 1);
+    strictEqual(r.assistant.id, e.agentsByWs[r.workspace.id][0].id);
+  });
+
+  it("trims the workspace name before matching / creating", async () => {
+    const e = fakeEngine();
+    const r = await ensureWorkspaceWithAssistant("  Personal  ", e);
+    strictEqual(r.workspace.name, "Personal");
+    // A padded re-run resolves to the same workspace, not a second one.
+    const again = await ensureWorkspaceWithAssistant("Personal ", e);
+    strictEqual(again.createdWorkspace, false);
+    strictEqual(again.workspace.id, r.workspace.id);
+    strictEqual(e.workspaces.length, 1);
+  });
+});


### PR DESCRIPTION
HOU-444 — Duplicate default workspace · "Personal already exists" conflict

Source: Sentry (auto-triaged), `unhandled_rejection: conflict: workspace named "Personal" already exists` — 2 users / 8 events, app 0.4.18–0.4.21. Representative: HOUSTON-APP-7D.

## Root cause
First-run onboarding (`PersonalAssistantOnboarding`) created the default **Personal** workspace by calling the engine's `createWorkspace` unconditionally. When that step fired **more than once for one install** — a double-clicked "Continue" in the Brain mission, the welcome-screen "Skip" racing a mission, or a **retry after a later step failed partway** (the workspace was already created) — the second `create` hit the engine's dup-name guard (`workspaces::create`) and rejected with `conflict: workspace named "Personal" already exists`.

Both onboarding call sites invoke creation from a button handler via `void` / no-catch (`onClick={() => void handleContinue()}`, `onSkip={() => void handleSkip()}`), so the rejection escaped as an **unhandled rejection** → Sentry via `HoustonClient.toError`.

## Fix
- **Idempotent get-or-create.** New pure helper `ensureWorkspaceWithAssistant` (`app/src/components/onboarding/ensure-default-assistant.ts`): reuses an existing workspace — and any assistant already inside it (the engine rejects duplicate **agent** names too) — instead of re-creating. Dependency-injected, so it unit-tests without the store/tauri graph.
- **In-flight guard.** A `useRef` memo collapses concurrent/repeat invocations onto one operation so first-run can never fire two creates; cleared on failure so retries work.
- **No more unhandled rejections.** Both onboarding call sites and the manual **New workspace** dialog now `try/catch` and surface failures as an error toast (with `String(err)`), per the repo's no-silent-failures policy.
- **Analytics.** `workspace_created` fires only for a genuinely new workspace, not a reused one.
- **i18n.** Added `setup:tutorial.errors.setupFailed` and `shell:workspaceDialog.createFailed` in en / es / pt.

## Tests
- `app/tests/ensure-default-assistant.test.ts` — first-run creates; a second run reuses with **no conflict**; a workspace left without an assistant by a partial run gets one on retry; name is trimmed before matching.
- `pnpm test` → 261 pass · `pnpm tsc --noEmit` → clean · `pnpm check-locales` → all in sync.

## Reproduce (before)
1. Fresh install (no workspaces) → onboarding.
2. In the Brain mission, get a provider connected, then trigger creation twice for the install — e.g. let the first attempt create **Personal** but throw on a later step (assistant create / `setLastUsed`), then click **Continue** again; or double-fire Continue/Skip.
3. Second attempt calls `createWorkspace("Personal")` → engine `Conflict` → **unhandled rejection** `workspace named "Personal" already exists` (Sentry).

## Verify (after)
1. Same setup. The retried/second creation **reuses** the existing Personal workspace + assistant — no conflict, onboarding advances to Tools.
2. Force a create failure (e.g. engine offline): instead of a crash you get an **error toast** ("We couldn't finish setting up your workspace. Please try again."); the user can retry.
3. Manual **New workspace** dialog with a name that already exists → error toast instead of an unhandled rejection.
4. `cd app && pnpm test && pnpm tsc --noEmit && pnpm check-locales` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)