### PR TITLE
release: v0.4.23

### DIFF
--- a/.github/release-notes/0.4.23.es.md
+++ b/.github/release-notes/0.4.23.es.md
@@ -1,0 +1,23 @@
+## Houston 0.4.23
+
+Una versión sobre estabilidad. Conectar apps ya no se queda colgado, las habilidades siguen funcionando después de moverlas o cambiarles el nombre, y varias cosas que antes se rompían ahora se recuperan solas. Además, una forma rápida de actuar sobre toda una columna del tablero a la vez. Se instala sobre 0.4.22, sin cambios que rompan nada.
+
+### Agregado
+
+- **Actúa sobre toda una columna a la vez.** El encabezado de cada columna del tablero ahora tiene un menú con "Seleccionar todo en la columna", así puedes mover o actualizar cada tarjeta de una etapa sin hacer clic una por una.
+
+### Corregido
+
+- **Conectar una app ya no se queda colgado.** Iniciar sesión en una app conectada podía quedarse trabado más de cinco minutos sin dar señales de vida. Ahora termina rápido o te dice con claridad qué hacer, en lugar de congelarse.
+- **Más enlaces de conexión funcionan sin más.** Algunas apps devuelven una dirección web simple cuando las conectas. Houston ahora la acepta y continúa.
+- **Agregar una habilidad desde un comando o enlace pegado.** Pega un comando completo o una dirección web y Houston averigua qué habilidad agregar, y rechaza con claridad lo que de verdad no tiene sentido en lugar de fallar de forma confusa.
+- **Las habilidades renombradas o movidas siguen funcionando.** Una habilidad que cambió de nombre o de lugar solía desaparecer sin aviso. Houston ahora la encuentra por su carpeta, así sigue apareciendo.
+- **Una lista de tareas programadas dañada se repara sola.** Una sola entrada en mal estado solía romper toda tu lista de tareas programadas. Houston ahora la arregla y conserva el resto.
+- **Un pequeño tropiezo ya no corta tu chat.** Un parpadeo momentáneo entre Houston y su motor podía mostrar "Load failed". Ahora reintenta en silencio y se recupera.
+- **Configuración inicial más estable.** Crear tu espacio de trabajo predeterminado en el primer arranque ahora se puede reintentar sin problema, así un tropiezo durante la configuración no te deja atascado ni duplicado.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza una app en ejecución de forma limpia. Si tienes dudas, elimina `/Applications/Houston.app` y arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde la 0.4.7 o posterior te lleva adelante sola. El MSI aún no está firmado a nivel del sistema operativo (la integración con SignPath sigue pendiente), por lo que Windows SmartScreen puede mostrar una advertencia en una instalación nueva.
+- **Windows ARM64:** no hay actualización automática desde una instalación x64 emulada. Descarga el MSI ARM64 manualmente, desinstala primero la versión x64 y luego instala la ARM64.

--- a/.github/release-notes/0.4.23.md
+++ b/.github/release-notes/0.4.23.md
@@ -1,0 +1,45 @@
+## Houston 0.4.23
+
+A reliability release. Connecting apps no longer hangs, skills keep working
+after they move or get renamed, and a few things that used to break now
+recover on their own. Plus a quick way to act on a whole board column at once.
+Drop-in on top of 0.4.22, no breaking changes.
+
+### Added
+
+- **Act on a whole column at once.** Each board column header now has a menu
+  with "Select all in column," so you can move or update every card in a stage
+  without clicking them one by one.
+
+### Fixed
+
+- **Connecting an app no longer hangs.** Signing in to a connected app could
+  stall for over five minutes with no sign of life. It now finishes quickly or
+  tells you clearly what to do, instead of freezing.
+- **More connection links just work.** Some apps hand back a plain web address
+  when you connect them. Houston now accepts that and carries on.
+- **Adding a skill from a pasted command or link.** Paste a full command or a
+  web address and Houston works out the right skill to add, and clearly refuses
+  genuine nonsense instead of failing in a confusing way.
+- **Renamed or moved skills keep working.** A skill that was renamed or moved
+  used to quietly disappear. Houston now finds it by its folder, so it keeps
+  showing up.
+- **A damaged scheduled-tasks list repairs itself.** One bad entry used to break
+  your whole list of scheduled tasks. Houston now fixes it and keeps the rest.
+- **A brief hiccup no longer drops your chat.** A momentary blip between Houston
+  and its engine could show "Load failed." It now retries quietly and recovers.
+- **Steadier first-run setup.** Creating your default workspace on first launch
+  is now safe to retry, so a hiccup during setup can't leave you stuck or
+  duplicated.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a
+  running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag
+  the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward
+  automatically. The MSI is still not OS-code-signed, so Windows SmartScreen may
+  warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install.
+  Download the ARM64 MSI manually, uninstall the x64 build first, then install
+  the ARM64 one.

--- a/.github/release-notes/0.4.23.pt.md
+++ b/.github/release-notes/0.4.23.pt.md
@@ -1,0 +1,23 @@
+## Houston 0.4.23
+
+Uma versão sobre estabilidade. Conectar apps não trava mais, as habilidades continuam funcionando depois de movê-las ou renomeá-las, e várias coisas que antes quebravam agora se recuperam sozinhas. Além disso, um jeito rápido de agir sobre uma coluna inteira do quadro de uma vez. Instala por cima da 0.4.22, sem mudanças que quebrem nada.
+
+### Adicionado
+
+- **Aja sobre uma coluna inteira de uma vez.** O cabeçalho de cada coluna do quadro agora tem um menu com "Selecionar tudo na coluna", então você pode mover ou atualizar cada cartão de uma etapa sem clicar um por um.
+
+### Corrigido
+
+- **Conectar um app não trava mais.** Entrar em um app conectado podia ficar travado por mais de cinco minutos sem dar sinal de vida. Agora termina rápido ou te diz com clareza o que fazer, em vez de congelar.
+- **Mais links de conexão simplesmente funcionam.** Alguns apps devolvem um endereço web simples quando você os conecta. O Houston agora aceita isso e segue em frente.
+- **Adicionar uma habilidade a partir de um comando ou link colado.** Cole um comando completo ou um endereço web e o Houston descobre qual habilidade adicionar, e recusa com clareza o que de fato não faz sentido em vez de falhar de um jeito confuso.
+- **Habilidades renomeadas ou movidas continuam funcionando.** Uma habilidade que mudou de nome ou de lugar costumava desaparecer sem aviso. O Houston agora a encontra pela pasta, então ela continua aparecendo.
+- **Uma lista de tarefas agendadas danificada se conserta sozinha.** Uma única entrada com problema costumava quebrar toda a sua lista de tarefas agendadas. O Houston agora a conserta e mantém o resto.
+- **Um tropeço rápido não derruba mais o seu chat.** Uma piscada momentânea entre o Houston e o motor dele podia mostrar "Load failed". Agora ele tenta de novo em silêncio e se recupera.
+- **Configuração inicial mais estável.** Criar o seu espaço de trabalho padrão na primeira inicialização agora pode ser repetido sem problema, então um tropeço durante a configuração não te deixa travado nem duplicado.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui um app em execução de forma limpa. Na dúvida, remova `/Applications/Houston.app` e arraste a cópia nova.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou posterior te leva adiante sozinha. O MSI ainda não é assinado no nível do sistema operacional (a integração com o SignPath segue pendente), então o Windows SmartScreen pode avisar em uma instalação nova.
+- **Windows ARM64:** não há atualização automática a partir de uma instalação x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a versão x64 e depois instale a ARM64.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "futures-util",
  "hex",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "serde",
  "serde_json",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "dirs 5.0.1",
  "houston-cli-bundle",
@@ -2734,7 +2734,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2754,7 +2754,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.22"
+version = "0.4.23"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.22", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.22", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.22", path = "app/houston-tauri" }
-houston-events = { version = "0.4.22", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.22", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.22", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.22", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.22", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.22", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.22", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.22", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.22", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.22", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.22", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.22", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.22", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.22", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.22", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.23", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.23", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.23", path = "app/houston-tauri" }
+houston-events = { version = "0.4.23", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.23", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.23", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.23", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.23", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.23", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.23", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.23", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.23", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.23", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.23", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.23", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.23", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.23", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.23", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.22"
+version = "0.4.23"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Release v0.4.23

Version cut off `main` (was at `v0.4.22`, df18d8c). Patch bump.

### Changes
- Bump all shared-version packages 0.4.22 → 0.4.23 (`version.sh`): 30 `package.json` + `Cargo.toml` files.
- Regenerated `Cargo.lock` (19 houston-* crate versions; no dependency churn).
- Release notes: `.github/release-notes/0.4.23.md` (en) + `.es.md` + `.pt.md`.

### Notes content
One board convenience (`Select all in column`, HOU-429) plus a reliability pass: connection login no longer hangs (HOU-434), bare-URL connect links accepted (HOU-433), skill install from pasted command/URL (HOU-440), skills resolve by directory slug (HOU-441), corrupt routines.json recovers (HOU-436), codex login-server failure recoverable (HOU-446), engine-client transient-drop retry (HOU-432), idempotent default-workspace onboarding (HOU-444). The composio `--key` log-leak fix (HOU-431) ships but is intentionally omitted from user notes.

### After merge
Tag `v0.4.23` on the squashed main commit + push → release CI builds, signs, notarizes, and creates a **draft** GH Release. Publish is manual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)