### PR TITLE
feat(chat): refactor context indicator to hover gauge (HOU-450)

### DIFF
--- a/app/src/components/context-indicator.tsx
+++ b/app/src/components/context-indicator.tsx
@@ -1,30 +1,22 @@
 /**
  * Composer context-usage indicator.
  *
- * A small footer pill that shows how full the model's context window is for
- * the current conversation, opening a dialog with the detail. The caller
+ * A small footer control showing how full the model's context window is for
+ * the current conversation. The trigger is a ring gauge (a
+ * donut whose arc fills with the occupied fraction and turns red near the
+ * limit) plus the bare percentage; hovering reveals the detail. The caller
  * resolves `usage` (latest turn) and `contextWindow` (a self-correcting
  * estimate; see `sessionContextUsage` + `effectiveContextWindow` in
  * `lib/context-usage.ts` and `getContextWindowConfig` in `lib/providers.ts`).
- * The window is plan/credit-gated and not reported by `claude -p`, so the
- * dialog labels the figure "estimated". When no window is known for a model
- * it degrades to a raw token count rather than a misleading percentage.
+ * When no window is known for a model it degrades to a raw token count rather
+ * than a misleading percentage.
  *
  * App-side (not in `ui/`) because it depends on the app's model catalog and
  * i18n; it uses `t()` directly per the library-boundary rule.
  */
 
 import { useTranslation } from "react-i18next";
-import { Gauge } from "lucide-react";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-  Progress,
-} from "@houston-ai/core";
+import { HoverCard, HoverCardContent, HoverCardTrigger, Progress } from "@houston-ai/core";
 import type { TokenUsage } from "@houston-ai/chat";
 import { contextFillPercent } from "../lib/context-usage";
 
@@ -33,17 +25,52 @@ interface ContextIndicatorProps {
   usage: TokenUsage | null;
   /** Active model's max context window in tokens, if catalogued. */
   contextWindow?: number;
-  /** Human-readable model label (e.g. "Sonnet 4.6"). */
-  modelLabel?: string;
 }
 
 /** Threshold at which the indicator warns the window is nearly full. */
 const WARN_PERCENT = 90;
 
+/**
+ * Context gauge: a ring whose arc fills clockwise from 12
+ * o'clock in proportion to `percent` (0-100), over a faint full-circle track.
+ * The arc follows `currentColor`, so the caller turns it red by setting
+ * `text-destructive`. A `null` percent (unknown window or no usage yet) shows
+ * the bare track.
+ */
+function ContextRing({ percent }: { percent: number | null }) {
+  const pct = percent == null ? 0 : Math.min(100, Math.max(0, percent));
+  const radius = 12;
+  const circumference = 2 * Math.PI * radius;
+  return (
+    <svg viewBox="0 0 32 32" className="size-4 -rotate-90" aria-hidden="true">
+      <circle
+        cx="16"
+        cy="16"
+        r={radius}
+        fill="none"
+        strokeWidth="5"
+        className="stroke-muted-foreground/25"
+      />
+      {pct > 0 && (
+        <circle
+          cx="16"
+          cy="16"
+          r={radius}
+          fill="none"
+          strokeWidth="5"
+          strokeLinecap="round"
+          className="stroke-current"
+          strokeDasharray={circumference}
+          strokeDashoffset={circumference * (1 - pct / 100)}
+        />
+      )}
+    </svg>
+  );
+}
+
 export function ContextIndicator({
   usage,
   contextWindow,
-  modelLabel,
 }: ContextIndicatorProps) {
   const { t, i18n } = useTranslation("context");
 
@@ -57,96 +84,63 @@ export function ContextIndicator({
   const percent = contextFillPercent(usage, windowTokens);
   const warn = percent != null && percent >= WARN_PERCENT;
 
-  const fmt = (n: number) => n.toLocaleString(i18n.language);
+  // Compact, rounded token counts (e.g. "100K", "10.5K", "1M") — locale-aware.
+  const fmt = (n: number) =>
+    new Intl.NumberFormat(i18n.language, {
+      notation: "compact",
+      maximumFractionDigits: 1,
+    }).format(n);
 
   return (
-    <Dialog>
-      <DialogTrigger asChild>
+    <HoverCard openDelay={150} closeDelay={100}>
+      <HoverCardTrigger asChild>
         <button
           type="button"
           aria-label={t("button.aria")}
-          title={percent != null ? t("dialog.estimated") : undefined}
-          className={`inline-flex items-center gap-1.5 h-7 px-2.5 rounded-full text-xs font-medium transition-colors hover:bg-accent ${
+          className={`inline-flex items-center justify-center size-7 rounded-full transition-colors hover:bg-accent ${
             warn
               ? "text-destructive"
               : "text-muted-foreground hover:text-foreground"
           }`}
         >
-          <Gauge className="size-3.5" />
-          {percent != null ? `${percent}%` : t("button.label")}
+          <ContextRing percent={percent} />
         </button>
-      </DialogTrigger>
-      <DialogContent className="sm:max-w-md" closeLabel={t("dialog.close")}>
-        <DialogHeader>
-          <DialogTitle>{t("dialog.title")}</DialogTitle>
-          <DialogDescription>
-            {modelLabel
-              ? t("dialog.subtitle", { model: modelLabel })
-              : t("dialog.subtitleNoModel")}
-          </DialogDescription>
-        </DialogHeader>
+      </HoverCardTrigger>
+      <HoverCardContent align="end" className="flex w-64 flex-col gap-2">
+        <p className="text-sm font-medium leading-none">{t("card.title")}</p>
 
         {!usage ? (
-          <p className="text-sm text-muted-foreground">{t("dialog.empty")}</p>
+          <p className="text-sm text-muted-foreground">{t("card.empty")}</p>
+        ) : windowTokens != null ? (
+          <>
+            <div className="flex items-baseline justify-between gap-3">
+              <span
+                className={`text-2xl font-semibold tabular-nums ${
+                  warn ? "text-destructive" : ""
+                }`}
+              >
+                {t("card.percent", { percent: percent ?? 0 })}
+              </span>
+              <span className="text-xs text-muted-foreground tabular-nums">
+                {t("card.usedOfTotal", {
+                  used: fmt(usage.context_tokens),
+                  total: fmt(windowTokens),
+                })}
+              </span>
+            </div>
+            <Progress value={percent ?? 0} aria-label={t("card.title")} />
+          </>
         ) : (
-          <div className="flex flex-col gap-3">
-            {windowTokens != null ? (
-              <>
-                <div className="flex items-baseline justify-between gap-3">
-                  <span className="text-2xl font-semibold tabular-nums">
-                    {t("dialog.percentFull", { percent: percent ?? 0 })}
-                  </span>
-                  <span className="text-xs text-muted-foreground tabular-nums">
-                    {t("dialog.usedOfTotal", {
-                      used: fmt(usage.context_tokens),
-                      total: fmt(windowTokens),
-                    })}
-                  </span>
-                </div>
-                <Progress value={percent ?? 0} aria-label={t("dialog.title")} />
-                <p className="text-xs text-muted-foreground tabular-nums">
-                  {t("dialog.free", {
-                    free: fmt(Math.max(0, windowTokens - usage.context_tokens)),
-                  })}
-                </p>
-                <p className="text-[11px] text-muted-foreground/80">
-                  {t("dialog.estimated")}
-                </p>
-              </>
-            ) : (
-              <>
-                <span className="text-lg font-semibold tabular-nums">
-                  {t("dialog.tokensUsed", { used: fmt(usage.context_tokens) })}
-                </span>
-                <p className="text-xs text-muted-foreground">
-                  {t("dialog.unknownWindow")}
-                </p>
-              </>
-            )}
-
-            {(usage.cached_tokens > 0 || usage.output_tokens > 0) && (
-              <dl className="flex flex-col gap-1 border-t border-border/50 pt-3 text-xs">
-                {usage.cached_tokens > 0 && (
-                  <div className="flex items-center justify-between gap-3">
-                    <dt className="text-muted-foreground">
-                      {t("dialog.cached")}
-                    </dt>
-                    <dd className="tabular-nums">{fmt(usage.cached_tokens)}</dd>
-                  </div>
-                )}
-                {usage.output_tokens > 0 && (
-                  <div className="flex items-center justify-between gap-3">
-                    <dt className="text-muted-foreground">
-                      {t("dialog.lastReply")}
-                    </dt>
-                    <dd className="tabular-nums">{fmt(usage.output_tokens)}</dd>
-                  </div>
-                )}
-              </dl>
-            )}
-          </div>
+          <>
+            <span className="text-lg font-semibold tabular-nums">
+              {t("card.tokensUsed", { used: fmt(usage.context_tokens) })}
+            </span>
+            <p className="text-xs text-muted-foreground">
+              {t("card.unknownWindow")}
+            </p>
+          </>
         )}
-      </DialogContent>
-    </Dialog>
+      </HoverCardContent>
+    </HoverCard>
   );
 }

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -66,7 +66,6 @@ import { ContextCompactedDivider } from "./context-compacted-divider";
 import {
   getContextWindowConfig,
   getDefaultModel,
-  getModel,
   getProvider,
   validModelOrNull,
   validEffortOrDefault,
@@ -295,7 +294,6 @@ export function useAgentChatPanel({
         effectiveContextWindow(cfg, peakContextTokens) ?? undefined,
     };
   }, [sessionFeedItems, effectiveProvider, effectiveModel]);
-  const modelLabel = getModel(effectiveProvider, effectiveModel)?.label;
 
   // Whether the current conversation has produced provider output already, so a
   // provider session exists to hand off FROM. A switch only matters once it has.
@@ -851,12 +849,11 @@ export function useAgentChatPanel({
           <ContextIndicator
             usage={contextUsage}
             contextWindow={contextWindow}
-            modelLabel={modelLabel}
           />
         </div>
       </div>
     );
-  }, [agent, t, effectiveProvider, effectiveModel, effectiveEffort, handleModelSelect, handleEffortSelect, contextUsage, contextWindow, modelLabel]);
+  }, [agent, t, effectiveProvider, effectiveModel, effectiveEffort, handleModelSelect, handleEffortSelect, contextUsage, contextWindow]);
 
   const attachMenu = useMemo<AIBoardProps["attachMenu"]>(() => {
     if (!agent) return undefined;

--- a/app/src/locales/en/context.json
+++ b/app/src/locales/en/context.json
@@ -1,21 +1,13 @@
 {
   "button": {
-    "aria": "Open context usage",
-    "label": "Context"
+    "aria": "Context usage"
   },
-  "dialog": {
-    "title": "Context usage",
-    "subtitle": "How full {{model}}'s memory is for this conversation.",
-    "subtitleNoModel": "How full the memory is for this conversation.",
-    "percentFull": "{{percent}}% full",
+  "card": {
+    "title": "Context",
+    "percent": "{{percent}}%",
     "usedOfTotal": "{{used}} of {{total}} tokens",
     "tokensUsed": "{{used}} tokens used",
-    "free": "{{free}} free",
-    "estimated": "Estimated. Your plan's actual context window may differ.",
-    "cached": "Reused from cache",
-    "lastReply": "Last reply",
     "empty": "Send a message and the context usage will show up here.",
-    "unknownWindow": "The context size for this model is not known yet, so the amount used is shown without a percentage.",
-    "close": "Close"
+    "unknownWindow": "The context size for this model is not known yet, so the amount used is shown without a percentage."
   }
 }

--- a/app/src/locales/es/context.json
+++ b/app/src/locales/es/context.json
@@ -1,21 +1,13 @@
 {
   "button": {
-    "aria": "Abrir uso del contexto",
-    "label": "Contexto"
+    "aria": "Uso del contexto"
   },
-  "dialog": {
-    "title": "Uso del contexto",
-    "subtitle": "Qué tan llena está la memoria de {{model}} para esta conversación.",
-    "subtitleNoModel": "Qué tan llena está la memoria para esta conversación.",
-    "percentFull": "{{percent}}% lleno",
+  "card": {
+    "title": "Contexto",
+    "percent": "{{percent}}%",
     "usedOfTotal": "{{used}} de {{total}} tokens",
     "tokensUsed": "{{used}} tokens usados",
-    "free": "{{free}} libres",
-    "estimated": "Estimado. La ventana de contexto real de tu plan puede variar.",
-    "cached": "Reutilizado de la caché",
-    "lastReply": "Última respuesta",
     "empty": "Envía un mensaje y el uso del contexto aparecerá aquí.",
-    "unknownWindow": "Todavía no se conoce el tamaño del contexto de este modelo, así que la cantidad usada se muestra sin porcentaje.",
-    "close": "Cerrar"
+    "unknownWindow": "Todavía no se conoce el tamaño del contexto de este modelo, así que la cantidad usada se muestra sin porcentaje."
   }
 }

--- a/app/src/locales/pt/context.json
+++ b/app/src/locales/pt/context.json
@@ -1,21 +1,13 @@
 {
   "button": {
-    "aria": "Abrir uso do contexto",
-    "label": "Contexto"
+    "aria": "Uso do contexto"
   },
-  "dialog": {
-    "title": "Uso do contexto",
-    "subtitle": "O quão cheia está a memória do {{model}} para esta conversa.",
-    "subtitleNoModel": "O quão cheia está a memória para esta conversa.",
-    "percentFull": "{{percent}}% cheio",
+  "card": {
+    "title": "Contexto",
+    "percent": "{{percent}}%",
     "usedOfTotal": "{{used}} de {{total}} tokens",
     "tokensUsed": "{{used}} tokens usados",
-    "free": "{{free}} livres",
-    "estimated": "Estimado. A janela de contexto real do seu plano pode variar.",
-    "cached": "Reaproveitado do cache",
-    "lastReply": "Última resposta",
     "empty": "Envie uma mensagem e o uso do contexto vai aparecer aqui.",
-    "unknownWindow": "O tamanho do contexto deste modelo ainda não é conhecido, então a quantidade usada aparece sem porcentagem.",
-    "close": "Fechar"
+    "unknownWindow": "O tamanho do contexto deste modelo ainda não é conhecido, então a quantidade usada aparece sem porcentagem."
   }
 }

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -442,7 +442,9 @@ request, i.e. how much of the context window is in use.
 
 The desktop composer's context-usage indicator (`app/src/components/context-
 indicator.tsx`) divides the latest turn's `context_tokens` by a window
-estimate for a "% full" gauge; it reads usage via `sessionContextUsage`
+estimate to drive a ring gauge (a donut whose arc fills with the occupied
+fraction and turns red near the limit; the percentage, a progress bar, and
+rounded token counts surface on hover); it reads usage via `sessionContextUsage`
 (`app/src/lib/context-usage.ts`) so it works both live and after a history
 reload (the field is persisted in `chat_feed.data_json`). `/context` (the
 interactive Claude Code slash command) is unavailable here because the


### PR DESCRIPTION
## HOU-450 — Refactor context indicator

Reworks the composer's context-usage indicator per the issue.

### What changed
- **Hover, not click** — the click-to-open dialog is now a hover card; detail surfaces on hover (and keyboard focus).
- **Ring gauge** — an icon-only ring whose arc fills with the occupied context fraction and turns **red** near/at the limit (>=90%). Built as a local `ContextRing` SVG (stroke-dash arc, fill follows `currentColor`).
- **Less noise** — dropped the cached-token and last-reply rows, the model subtitle, and the estimated caveat; kept the bare percentage, a status bar, and rounded compact token counts (e.g. `100K`, `10.5K`, `1M`) via locale-aware `Intl.NumberFormat`.
- Hover-card title trimmed to **"Context"**. Removed the now-dead `modelLabel` prop and `getModel` lookup.

### Files
- `app/src/components/context-indicator.tsx` — rewrite
- `app/src/components/use-agent-chat-panel.tsx` — drop dead modelLabel/getModel
- `app/src/locales/{en,es,pt}/context.json` — keys trimmed, title becomes "Context"
- `knowledge-base/engine-protocol.md` — updated indicator description

### Verification
**Before:** clicking the footer pill opened a dialog listing percent-full, used/total, free, cached, and last-reply rows.

**After:**
1. `cd app && pnpm tauri dev`, open an agent, send a couple messages.
2. Footer shows an icon-only **ring** that fills as the conversation grows.
3. **Hover** -> card shows the percentage, a status bar, and `used of total` in compact units. No cached / last-reply / subtitle rows.
4. Past 90% -> ring + percentage turn **red**.
5. Switch language (en/es/pt) -> strings + numbers localize.

Checks: `pnpm typecheck` OK, `pnpm check-locales` OK, `pnpm test` (284) OK, `node --test src/lib/context-usage.test.mjs` (8) OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)