### PR TITLE
refactor(app): level-aware effort switch icon (HOU-451)

### DIFF
--- a/app/src/components/chat-effort-selector.tsx
+++ b/app/src/components/chat-effort-selector.tsx
@@ -1,12 +1,7 @@
 import { useTranslation } from "react-i18next";
-import { ChevronDown, Check, Gauge } from "lucide-react";
-import {
-  DropdownMenu,
-  DropdownMenuTrigger,
-  DropdownMenuContent,
-  DropdownMenuItem,
-} from "@houston-ai/core";
 import { getEffortLevels, type EffortLevel } from "../lib/providers";
+import { nextEffort } from "../lib/effort-cycle";
+import { EffortIcon } from "./effort-icon";
 
 interface ChatEffortSelectorProps {
   /** Active provider id — used to look up the model's effort levels. */
@@ -15,95 +10,67 @@ interface ChatEffortSelectorProps {
   model: string;
   /** Current effective effort for the active model. */
   effort?: string;
-  /** Called when the user picks a level. */
+  /** Called when the user advances to the next level. */
   onSelect: (effort: EffortLevel) => void;
 }
 
 /**
- * Standalone reasoning-effort picker, rendered beside {@link ChatModelSelector}
- * in the composer. Shows only the levels the active model accepts (Sonnet
- * never offers `xhigh`, Codex never `max`) and renders nothing when the model
- * has no effort control (e.g. Gemini), so the composer row collapses cleanly.
+ * Reasoning-effort cycle button, rendered beside {@link ChatModelSelector} in
+ * the composer. One click advances to the next level the active model accepts,
+ * wrapping after the last (low → … → max → low). The icon's filled bars and
+ * the label both track the level, so the control reads at a glance without a
+ * menu. Renders nothing when the model has no effort control (e.g. Gemini), so
+ * the composer row collapses cleanly.
  */
 export function ChatEffortSelector({ provider, model, effort, onSelect }: ChatEffortSelectorProps) {
   const { t } = useTranslation("chat");
   const levels = getEffortLevels(provider, model);
   if (levels.length === 0) return null;
 
-  const labels: Record<EffortLevel, { label: string; description: string }> = {
-    low: {
-      label: t("modelSelector.effortLevels.low"),
-      description: t("modelSelector.effortDescriptions.low"),
-    },
-    medium: {
-      label: t("modelSelector.effortLevels.medium"),
-      description: t("modelSelector.effortDescriptions.medium"),
-    },
-    high: {
-      label: t("modelSelector.effortLevels.high"),
-      description: t("modelSelector.effortDescriptions.high"),
-    },
-    xhigh: {
-      label: t("modelSelector.effortLevels.xhigh"),
-      description: t("modelSelector.effortDescriptions.xhigh"),
-    },
-    max: {
-      label: t("modelSelector.effortLevels.max"),
-      description: t("modelSelector.effortDescriptions.max"),
-    },
+  const labels: Record<EffortLevel, string> = {
+    low: t("modelSelector.effortLevels.low"),
+    medium: t("modelSelector.effortLevels.medium"),
+    high: t("modelSelector.effortLevels.high"),
+    xhigh: t("modelSelector.effortLevels.xhigh"),
+    max: t("modelSelector.effortLevels.max"),
   };
-  const activeLabel =
-    effort && labels[effort as EffortLevel]
-      ? labels[effort as EffortLevel].label
-      : t("modelSelector.effort");
+  const descriptions: Record<EffortLevel, string> = {
+    low: t("modelSelector.effortDescriptions.low"),
+    medium: t("modelSelector.effortDescriptions.medium"),
+    high: t("modelSelector.effortDescriptions.high"),
+    xhigh: t("modelSelector.effortDescriptions.xhigh"),
+    max: t("modelSelector.effortDescriptions.max"),
+  };
+
+  // The current level (only when the stored value is one this model accepts)
+  // and the level a click advances to, wrapping past the last back to the first.
+  const activeLevel =
+    effort && levels.includes(effort as EffortLevel) ? (effort as EffortLevel) : undefined;
+  const nextLevel = nextEffort(levels, effort);
+
+  const activeLabel = activeLevel ? labels[activeLevel] : t("modelSelector.effort");
 
   return (
-    // Stop pointer events from bubbling — keeps the board detail panel from
-    // reading dropdown clicks as "click outside → close panel".
-    <div onPointerDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()}>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <button
-            type="button"
-            aria-label={t("modelSelector.effort")}
-            className="flex items-center gap-1.5 h-7 px-2 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring"
-          >
-            <Gauge className="size-3.5" />
-            <span>{activeLabel}</span>
-            <ChevronDown className="size-3 opacity-60" />
-          </button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent
-          align="start"
-          className="w-56"
-          onCloseAutoFocus={(e) => e.preventDefault()}
-        >
-          {levels.map((level) => {
-            const isActive = level === effort;
-            return (
-              <DropdownMenuItem
-                key={level}
-                onPointerDown={(e) => e.stopPropagation()}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  onSelect(level);
-                }}
-                className="flex items-start gap-2.5 py-1.5"
-              >
-                <div className="w-4 shrink-0 mt-0.5 flex justify-center">
-                  {isActive && <Check className="h-3.5 w-3.5 text-foreground" />}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="text-sm">{labels[level].label}</div>
-                  <div className="text-xs text-muted-foreground leading-snug">
-                    {labels[level].description}
-                  </div>
-                </div>
-              </DropdownMenuItem>
-            );
-          })}
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+    <button
+      type="button"
+      // Announce the value (the visible label alone reads as a bare "High").
+      aria-label={
+        activeLevel
+          ? t("modelSelector.effortValue", { level: activeLabel })
+          : t("modelSelector.effort")
+      }
+      title={activeLevel ? descriptions[activeLevel] : t("modelSelector.effort")}
+      // Stop pointer events from bubbling — keeps the board detail panel from
+      // reading the click as "click outside → close panel".
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (nextLevel) onSelect(nextLevel);
+      }}
+      className="flex items-center gap-1.5 h-7 px-2 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring"
+    >
+      <EffortIcon levels={levels} active={effort} className="size-3.5" />
+      <span>{activeLabel}</span>
+    </button>
   );
 }

--- a/app/src/components/effort-icon.tsx
+++ b/app/src/components/effort-icon.tsx
@@ -1,0 +1,41 @@
+import { effortBars, EFFORT_ICON_VIEWBOX } from "../lib/effort-bars";
+
+interface EffortIconProps {
+  /** Levels the active model accepts, ordered low→high. One bar each. */
+  levels: readonly string[];
+  /** Current level; bars fill up to and including it. */
+  active?: string | null;
+  className?: string;
+}
+
+/**
+ * Reasoning-effort glyph: ascending signal bars filled to the active level (see
+ * {@link effortBars} for the geometry). Replaces the static gauge so the icon
+ * itself changes with the effort. Color is inherited via `currentColor` so the
+ * same component reads correctly on the muted composer trigger and the menu
+ * rows; unfilled bars drop to a low opacity instead of disappearing.
+ */
+export function EffortIcon({ levels, active, className }: EffortIconProps) {
+  const bars = effortBars(levels, active);
+  return (
+    <svg
+      viewBox={`0 0 ${EFFORT_ICON_VIEWBOX} ${EFFORT_ICON_VIEWBOX}`}
+      className={className}
+      fill="none"
+      aria-hidden="true"
+    >
+      {bars.map((bar, i) => (
+        <rect
+          key={i}
+          x={bar.x}
+          y={bar.y}
+          width={bar.width}
+          height={bar.height}
+          rx={1}
+          fill="currentColor"
+          fillOpacity={bar.filled ? 1 : 0.3}
+        />
+      ))}
+    </svg>
+  );
+}

--- a/app/src/lib/effort-bars.ts
+++ b/app/src/lib/effort-bars.ts
@@ -1,0 +1,72 @@
+/**
+ * Geometry + fill state for the reasoning-effort "signal bars" icon
+ * ({@link EffortIcon}). Pure so the bar math is unit-tested without a DOM — the
+ * .tsx component is a thin `<rect>` map over {@link effortBars}.
+ *
+ * One ascending bar per level the active model accepts, solid up to (and
+ * including) the current level and dimmed beyond it, so the glyph itself
+ * encodes the effort. Bar count tracks the model's own level set (Codex = 4,
+ * Opus/Fable = 5), keeping the provider > model > effort cascade legible at a
+ * glance.
+ */
+
+/** Square viewBox the bars are laid out in (bottom-aligned). */
+export const EFFORT_ICON_VIEWBOX = 24;
+
+const BASELINE = 21;
+const MIN_HEIGHT = 5;
+const MAX_HEIGHT = 19;
+const BAR_WIDTH = 3;
+const BAR_GAP = 1.6;
+
+export interface EffortBar {
+  /** Left edge (viewBox units). */
+  x: number;
+  /** Top edge (viewBox units); bars share a fixed bottom baseline. */
+  y: number;
+  width: number;
+  height: number;
+  /** True when this bar is at or below the active level (drawn solid). */
+  filled: boolean;
+}
+
+/**
+ * 1-based position of `active` within `levels` (ordered low→high), i.e. how
+ * many bars are solid. 0 when `active` is unset or not a member, so the icon
+ * reads "nothing selected" rather than guessing a level.
+ */
+export function effortFillCount(
+  levels: readonly string[],
+  active: string | null | undefined,
+): number {
+  if (!active) return 0;
+  const index = levels.indexOf(active);
+  return index < 0 ? 0 : index + 1;
+}
+
+/**
+ * Ascending bar specs for `levels`, the first {@link effortFillCount} of them
+ * solid. The group is centered horizontally in the viewBox so the icon stays
+ * balanced whether the model offers 4 levels or 5.
+ */
+export function effortBars(
+  levels: readonly string[],
+  active: string | null | undefined,
+): EffortBar[] {
+  const count = levels.length;
+  if (count === 0) return [];
+  const filled = effortFillCount(levels, active);
+  const totalWidth = count * BAR_WIDTH + (count - 1) * BAR_GAP;
+  const startX = (EFFORT_ICON_VIEWBOX - totalWidth) / 2;
+  const step = count > 1 ? (MAX_HEIGHT - MIN_HEIGHT) / (count - 1) : 0;
+  return Array.from({ length: count }, (_, i) => {
+    const height = MIN_HEIGHT + i * step;
+    return {
+      x: startX + i * (BAR_WIDTH + BAR_GAP),
+      y: BASELINE - height,
+      width: BAR_WIDTH,
+      height,
+      filled: i < filled,
+    };
+  });
+}

--- a/app/src/lib/effort-cycle.ts
+++ b/app/src/lib/effort-cycle.ts
@@ -1,0 +1,17 @@
+import type { EffortLevel } from "./providers";
+
+/**
+ * The level a cycle-button click should select: the one after `current` in
+ * `levels` (ordered low→high), wrapping past the last back to the first. When
+ * `current` is unset or isn't a member of this model's set, cycling starts at
+ * the first level. Returns `undefined` only when `levels` is empty (the model
+ * has no effort control), so the caller can no-op.
+ */
+export function nextEffort(
+  levels: readonly EffortLevel[],
+  current: string | null | undefined,
+): EffortLevel | undefined {
+  if (levels.length === 0) return undefined;
+  const index = current ? levels.indexOf(current as EffortLevel) : -1;
+  return levels[(index + 1) % levels.length];
+}

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -63,6 +63,7 @@
     "notConnected": "Not connected",
     "checking": "Checking...",
     "effort": "Reasoning effort",
+    "effortValue": "Reasoning effort: {{level}}",
     "effortLevels": {
       "low": "Low",
       "medium": "Medium",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -63,6 +63,7 @@
     "notConnected": "Sin conexión",
     "checking": "Verificando...",
     "effort": "Esfuerzo de razonamiento",
+    "effortValue": "Esfuerzo de razonamiento: {{level}}",
     "effortLevels": {
       "low": "Bajo",
       "medium": "Medio",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -63,6 +63,7 @@
     "notConnected": "Sem conexão",
     "checking": "Verificando...",
     "effort": "Esforço de raciocínio",
+    "effortValue": "Esforço de raciocínio: {{level}}",
     "effortLevels": {
       "low": "Baixo",
       "medium": "Médio",

--- a/app/tests/effort-bars.test.ts
+++ b/app/tests/effort-bars.test.ts
@@ -1,0 +1,79 @@
+import { strictEqual, deepStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  effortFillCount,
+  effortBars,
+  EFFORT_ICON_VIEWBOX,
+} from "../src/lib/effort-bars.ts";
+
+// Opus/Fable accept all five; Codex stops at xhigh (no max).
+const FIVE = ["low", "medium", "high", "xhigh", "max"] as const;
+const FOUR = ["low", "medium", "high", "xhigh"] as const;
+
+describe("effortFillCount", () => {
+  it("is the 1-based position of the active level", () => {
+    strictEqual(effortFillCount(FIVE, "low"), 1);
+    strictEqual(effortFillCount(FIVE, "high"), 3);
+    strictEqual(effortFillCount(FIVE, "max"), 5);
+    strictEqual(effortFillCount(FOUR, "xhigh"), 4);
+  });
+
+  it("is 0 when the level is absent, unset, or the set is empty", () => {
+    strictEqual(effortFillCount(FOUR, "max"), 0); // Codex has no max
+    strictEqual(effortFillCount(FIVE, undefined), 0);
+    strictEqual(effortFillCount(FIVE, null), 0);
+    strictEqual(effortFillCount([], "low"), 0);
+  });
+});
+
+describe("effortBars", () => {
+  it("emits one bar per level", () => {
+    strictEqual(effortBars(FIVE, "high").length, 5);
+    strictEqual(effortBars(FOUR, "high").length, 4);
+    deepStrictEqual(effortBars([], "low"), []);
+  });
+
+  it("fills bars up to and including the active level", () => {
+    deepStrictEqual(
+      effortBars(FIVE, "high").map((b) => b.filled),
+      [true, true, true, false, false],
+    );
+    deepStrictEqual(
+      effortBars(FOUR, "xhigh").map((b) => b.filled),
+      [true, true, true, true],
+    );
+  });
+
+  it("leaves every bar dimmed when nothing is selected", () => {
+    deepStrictEqual(
+      effortBars(FIVE, undefined).map((b) => b.filled),
+      [false, false, false, false, false],
+    );
+  });
+
+  it("ascends in height from left to right", () => {
+    const bars = effortBars(FIVE, "max");
+    for (let i = 1; i < bars.length; i++) {
+      strictEqual(bars[i].height > bars[i - 1].height, true);
+    }
+  });
+
+  it("centers the bar group within the viewBox", () => {
+    const bars = effortBars(FOUR, "low");
+    const left = bars[0].x;
+    const last = bars[bars.length - 1];
+    const right = EFFORT_ICON_VIEWBOX - (last.x + last.width);
+    strictEqual(Math.abs(left - right) < 1e-9, true);
+  });
+
+  it("keeps every bar inside the viewBox", () => {
+    for (const levels of [FOUR, FIVE]) {
+      for (const bar of effortBars(levels, "high")) {
+        strictEqual(bar.x >= 0, true);
+        strictEqual(bar.x + bar.width <= EFFORT_ICON_VIEWBOX, true);
+        strictEqual(bar.y >= 0, true);
+        strictEqual(bar.y + bar.height <= EFFORT_ICON_VIEWBOX, true);
+      }
+    }
+  });
+});

--- a/app/tests/effort-cycle.test.ts
+++ b/app/tests/effort-cycle.test.ts
@@ -1,0 +1,37 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { nextEffort } from "../src/lib/effort-cycle.ts";
+
+// Opus/Fable accept all five; Codex stops at xhigh (no max).
+const FIVE = ["low", "medium", "high", "xhigh", "max"] as const;
+const FOUR = ["low", "medium", "high", "xhigh"] as const;
+
+describe("nextEffort", () => {
+  it("advances to the next level low → … → max", () => {
+    strictEqual(nextEffort(FIVE, "low"), "medium");
+    strictEqual(nextEffort(FIVE, "medium"), "high");
+    strictEqual(nextEffort(FIVE, "high"), "xhigh");
+    strictEqual(nextEffort(FIVE, "xhigh"), "max");
+  });
+
+  it("wraps past the last level back to the first", () => {
+    strictEqual(nextEffort(FIVE, "max"), "low");
+    strictEqual(nextEffort(FOUR, "xhigh"), "low"); // Codex tops out at xhigh
+  });
+
+  it("starts at the first level when current is unset", () => {
+    strictEqual(nextEffort(FIVE, undefined), "low");
+    strictEqual(nextEffort(FIVE, null), "low");
+    strictEqual(nextEffort(FIVE, ""), "low");
+  });
+
+  it("starts at the first level when current isn't in this model's set", () => {
+    // e.g. an agent carrying `max` after switching to a Codex model.
+    strictEqual(nextEffort(FOUR, "max"), "low");
+  });
+
+  it("returns undefined when the model has no effort control", () => {
+    strictEqual(nextEffort([], "low"), undefined);
+    strictEqual(nextEffort([], undefined), undefined);
+  });
+});


### PR DESCRIPTION
## HOU-451 — Refactor effort switch

Turn the reasoning-effort control into a **single cycle button**: each click advances to the next level, and the icon **changes with the current effort** instead of a static gauge.

### Request
The composer's `ChatEffortSelector` showed a static `Gauge` and opened a dropdown. HOU-451 asks for an ascending **signal-bars** icon that encodes the level, and a button that cycles the effort on click — no menu. Keep the existing `provider > model > effort` cascade and do **not** add the `ultracode` harness mode as an effort.

### Behavior
- One button: `[bars icon] [label]`. Click → next level, wrapping `low → medium → high → xhigh → max → low` **within the active model's accepted set** (Codex wraps `xhigh → low`; it has no `max`).
- The bar icon fills to the current level (Codex shows 4 bars, Opus/Fable 5), so the glyph alone reads the effort.
- If the agent carries a level the new model doesn't accept (e.g. `max` after switching to Codex), the next click resets to the first level.
- Models without effort control (Gemini/Haiku) still render nothing — the composer row collapses.

### What changed `[app]`
- **`app/src/lib/effort-bars.ts`** — pure bar geometry + fill (`effortFillCount`, `effortBars`). One ascending bar per accepted level, solid up to the active level, dimmed beyond.
- **`app/src/components/effort-icon.tsx`** — thin SVG renderer over `effortBars`; inherits color via `currentColor`.
- **`app/src/lib/effort-cycle.ts`** — `nextEffort(levels, current)`: the wrap-around selection logic, pure so it's unit-tested.
- **`app/src/components/chat-effort-selector.tsx`** — dropdown → cycle button; icon + label track the level; `aria-label` announces the value.
- **`app/src/locales/{en,es,pt}/chat.json`** — `effortValue: "Reasoning effort: {{level}}"` for the accessible label.
- **`app/tests/effort-bars.test.ts`**, **`app/tests/effort-cycle.test.ts`** — node:test coverage.

No backend/data change. Propagates automatically to `routine-model-controls`. `ultracode` is intentionally **not** added (stays a harness mode per `providers.ts`).

### Verify
**Before:** the effort control is a static gauge that opens a dropdown menu.

**After:**
1. `cd app && pnpm tsc --noEmit && pnpm test && pnpm check-locales` — all green (297 tests).
2. Run the app, open an agent composer. The effort pill shows bars filled to the current level + the label.
3. Click it repeatedly → it cycles low → medium → high → xhigh → max → low; the bar fill and label update each click. No menu opens.
4. Switch model to Codex (GPT-5.5) → 4 bars, cycles `xhigh → low`; Opus/Fable → 5 bars through `max`. Gemini/Haiku hide the control.

🤖 Generated with [Claude Code](https://claude.com/claude-code)