### PR TITLE
style(chat): round the context card to match app cards (HOU-450)

### DIFF
--- a/app/src/components/context-indicator.tsx
+++ b/app/src/components/context-indicator.tsx
@@ -106,7 +106,7 @@ export function ContextIndicator({
           <ContextRing percent={percent} />
         </button>
       </HoverCardTrigger>
-      <HoverCardContent align="end" className="flex w-64 flex-col gap-2">
+      <HoverCardContent align="end" className="flex w-64 flex-col gap-2 rounded-2xl">
         <p className="text-sm font-medium leading-none">{t("card.title")}</p>
 
         {!usage ? (


### PR DESCRIPTION
Follow-up polish to #519 (HOU-450).

The context hover card inherited the popover primitive's `rounded-md` (6px) corners. Bump it to **`rounded-2xl`** (16px) so it matches the app's card slabs — the same radius used by the provider-error cards (`provider-error-cards/shared.tsx`) and other panels.

### Change
- `app/src/components/context-indicator.tsx` — add `rounded-2xl` to the `HoverCardContent` className (tailwind-merge overrides the primitive's `rounded-md`).

### Verify
1. `cd app && pnpm tauri dev`, open an agent, send a message.
2. Hover the footer context ring → the card now has noticeably rounder (16px) corners, consistent with the rate-limit / error cards.

`pnpm typecheck` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)