### PR TITLE
fix(routines): respawn cron job when schedule or timezone is edited (HOU-455)

### DIFF
--- a/engine/houston-engine-core/src/routines/cron_compat.rs
+++ b/engine/houston-engine-core/src/routines/cron_compat.rs
@@ -161,6 +161,39 @@ mod tests {
     }
 
     #[test]
+    fn today_plus_one_minute_fires_today_for_every_preset() {
+        // HOU-455 at the cron layer: a routine set for "today, one minute from
+        // now" must fire *today* for the weekly and monthly presets — not slip
+        // to next week / next month. Mirrors the scheduler's evaluation
+        // (`schedule.upcoming(tz)` == `after(&now_in_tz)`) in a non-UTC zone
+        // with nonzero seconds, exactly the real environment.
+        use chrono::{Datelike, Duration, TimeZone as _, Timelike};
+        use chrono_tz::America::Bogota; // UTC-5
+        let now = Bogota.with_ymd_and_hms(2026, 6, 12, 14, 30, 37).unwrap(); // a Friday
+        let fire = now + Duration::minutes(1); // 14:31 today, Bogota wall-clock
+        let (min, hour, dom) = (fire.minute(), fire.hour(), fire.day());
+        // The UI emits JS getDay()-style dow: Sunday=0..Saturday=6.
+        let dow = fire.weekday().num_days_from_sunday();
+
+        for cron5 in [
+            format!("{min} {hour} * * *"),     // daily
+            format!("{min} {hour} * * {dow}"), // weekly, on today's weekday
+            format!("{min} {hour} {dom} * *"), // monthly, on today's day-of-month
+        ] {
+            let schedule = Schedule::from_str(&to_engine_cron(&cron5))
+                .unwrap_or_else(|e| panic!("'{cron5}' should parse: {e}"));
+            let next = schedule.after(&now).next().expect("an upcoming fire");
+            let delta = next.signed_duration_since(now);
+            assert!(
+                delta > Duration::zero() && delta <= Duration::seconds(90),
+                "'{cron5}' should fire ~1 min out, got {next} ({}s away)",
+                delta.num_seconds(),
+            );
+            assert_eq!(next.day(), 12, "'{cron5}' should fire today, got {next}");
+        }
+    }
+
+    #[test]
     fn weekly_monday_actually_fires_on_monday() {
         assert_eq!(next_weekday("0 9 * * 1"), Weekday::Mon);
     }

--- a/engine/houston-engine-core/src/routines/scheduler.rs
+++ b/engine/houston-engine-core/src/routines/scheduler.rs
@@ -20,11 +20,22 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::{watch, Mutex};
 
+/// A spawned cron task plus the signature it was spawned for. The signature
+/// captures everything that determines *when* the job fires — the schedule and
+/// the resolved timezone — so [`AgentScheduler::sync`] can tell a real timing
+/// change from a no-op and re-spawn only when needed. Without it, an edited
+/// schedule was silently ignored: the job stayed keyed by routine id alone and
+/// the spawn loop skipped it because a job already existed (HOU-455).
+struct CronJob {
+    handle: tokio::task::JoinHandle<()>,
+    signature: String,
+}
+
 /// Per-agent bundle of cron tasks.
 pub struct AgentScheduler {
     agent_path: String,
     default_tz: String,
-    jobs: HashMap<String, tokio::task::JoinHandle<()>>,
+    jobs: HashMap<String, CronJob>,
     shutdown_tx: watch::Sender<bool>,
     events: DynEventSink,
     dispatcher: Arc<dyn RoutineDispatcher>,
@@ -56,42 +67,49 @@ impl AgentScheduler {
     }
 
     pub fn set_default_tz(&mut self, tz: &str) {
-        if self.default_tz != tz {
-            self.default_tz = tz.to_string();
-            // Respawn all jobs so new TZ takes effect.
-            for (_, handle) in self.jobs.drain() {
-                handle.abort();
-            }
-        }
+        // Just record it; the next `sync()` re-spawns every job whose resolved
+        // timezone actually changed (via the job signature). Routines pinned to
+        // their own timezone are left running untouched.
+        self.default_tz = tz.to_string();
     }
 
-    /// Read routines from disk and reconcile cron tasks: spawn for newly
-    /// enabled ones, abort for removed or disabled ones.
+    /// Read routines from disk and reconcile cron tasks: spawn newly enabled
+    /// ones, abort removed or disabled ones, and re-spawn any whose schedule or
+    /// timezone changed since it was started.
     pub fn sync(&mut self) {
         let dir = crate::routines::runner::expand_tilde(&PathBuf::from(&self.agent_path));
         let routines = routines::list(&dir).unwrap_or_default();
 
-        let active_ids: HashMap<String, String> = routines
+        // Desired job signatures, keyed by routine id, for every enabled
+        // routine. The signature folds in the schedule and the resolved
+        // timezone so an edit to either is detected as a change.
+        let desired: HashMap<String, String> = routines
             .iter()
             .filter(|r| r.enabled)
-            .map(|r| (r.id.clone(), r.schedule.clone()))
+            .map(|r| (r.id.clone(), self.job_signature(r)))
             .collect();
 
+        // Drop jobs that are gone, disabled, OR whose signature changed (edited
+        // schedule / timezone). The signature mismatch is the HOU-455 fix: a
+        // live job for an edited routine must be torn down so the spawn loop
+        // below re-creates it with the new timing.
         let to_remove: Vec<String> = self
             .jobs
-            .keys()
-            .filter(|id| !active_ids.contains_key(*id))
-            .cloned()
+            .iter()
+            .filter(|(id, job)| desired.get(*id).map_or(true, |sig| sig != &job.signature))
+            .map(|(id, _)| id.clone())
             .collect();
         for id in to_remove {
-            if let Some(handle) = self.jobs.remove(&id) {
-                handle.abort();
+            if let Some(job) = self.jobs.remove(&id) {
+                job.handle.abort();
                 tracing::info!("[routines] Stopped cron for routine {id}");
             }
         }
 
-        for routine in &routines {
-            if !routine.enabled || self.jobs.contains_key(&routine.id) {
+        for routine in routines.iter().filter(|r| r.enabled) {
+            // Anything still present here has a matching signature (changed ones
+            // were removed above); skip it so we don't churn the task.
+            if self.jobs.contains_key(&routine.id) {
                 continue;
             }
             match self.spawn_cron(routine) {
@@ -102,7 +120,12 @@ impl AgentScheduler {
                         routine.schedule,
                         self.resolve_tz(routine).name(),
                     );
-                    self.jobs.insert(routine.id.clone(), handle);
+                    let signature = desired
+                        .get(&routine.id)
+                        .cloned()
+                        .unwrap_or_else(|| self.job_signature(routine));
+                    self.jobs
+                        .insert(routine.id.clone(), CronJob { handle, signature });
                 }
                 Err(e) => tracing::error!(
                     "[routines] Failed to start cron for '{}': {e}",
@@ -110,6 +133,13 @@ impl AgentScheduler {
                 ),
             }
         }
+    }
+
+    /// Signature that determines when a routine's cron task fires: its schedule
+    /// plus the resolved timezone. Two routines with the same signature fire at
+    /// the same instants, so `sync` only re-spawns when this string changes.
+    fn job_signature(&self, routine: &Routine) -> String {
+        format!("{}|{}", routine.schedule, self.resolve_tz(routine).name())
     }
 
     fn resolve_tz(&self, routine: &Routine) -> Tz {
@@ -203,8 +233,8 @@ impl AgentScheduler {
 
     pub fn shutdown(&mut self) {
         let _ = self.shutdown_tx.send(true);
-        for (id, handle) in self.jobs.drain() {
-            handle.abort();
+        for (id, job) in self.jobs.drain() {
+            job.handle.abort();
             tracing::info!("[routines] Stopped cron for routine {id}");
         }
     }
@@ -365,6 +395,121 @@ mod tests {
         );
         sched.sync();
         assert_eq!(sched.jobs.len(), 1);
+        sched.shutdown();
+    }
+
+    #[tokio::test]
+    async fn editing_schedule_respawns_the_cron_job() {
+        // HOU-455: a routine's schedule was being changed on disk but the live
+        // cron job kept firing on the OLD schedule (or never, if the old time
+        // had passed) because `sync` keyed jobs by id alone and skipped any
+        // routine that already had a job. Editing the schedule must re-spawn the
+        // job so the new timing takes effect.
+        use crate::routines::{types::RoutineUpdate, update};
+
+        let d = TempDir::new().unwrap();
+        let agent = d.path().to_string_lossy().to_string();
+        let r = create(d.path(), mk("editable", true, None)).unwrap(); // "0 9 * * *"
+
+        let mut sched = AgentScheduler::new(
+            &agent,
+            "UTC",
+            Arc::new(NoopEventSink),
+            Arc::new(NoopDispatch),
+            Arc::new(NoopSurface),
+        );
+        sched.sync();
+        let before = sched.jobs.get(&r.id).expect("job spawned").signature.clone();
+        assert_eq!(before, "0 9 * * *|UTC");
+
+        // Edit the schedule on disk, then re-sync as the route handler does.
+        update(
+            d.path(),
+            &r.id,
+            RoutineUpdate {
+                schedule: Some("30 14 * * 5".into()),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        sched.sync();
+
+        assert_eq!(sched.jobs.len(), 1, "still exactly one job after the edit");
+        let after = sched.jobs.get(&r.id).expect("job still present").signature.clone();
+        assert_eq!(
+            after, "30 14 * * 5|UTC",
+            "the live job now carries the edited schedule",
+        );
+        assert_ne!(before, after, "schedule edit must change the job signature");
+        sched.shutdown();
+    }
+
+    #[tokio::test]
+    async fn editing_timezone_respawns_the_cron_job() {
+        // Sibling of the schedule-edit case: pinning a routine to a different
+        // timezone changes *when* it fires, so the job must re-spawn even though
+        // the cron string is untouched.
+        use crate::routines::{types::RoutineUpdate, update};
+
+        let d = TempDir::new().unwrap();
+        let agent = d.path().to_string_lossy().to_string();
+        let r = create(d.path(), mk("tz-edit", true, None)).unwrap();
+
+        let mut sched = AgentScheduler::new(
+            &agent,
+            "UTC",
+            Arc::new(NoopEventSink),
+            Arc::new(NoopDispatch),
+            Arc::new(NoopSurface),
+        );
+        sched.sync();
+        let before = sched.jobs.get(&r.id).unwrap().signature.clone();
+        assert_eq!(before, "0 9 * * *|UTC");
+
+        update(
+            d.path(),
+            &r.id,
+            RoutineUpdate {
+                timezone: Some(Some("America/Bogota".into())),
+                ..Default::default()
+            },
+        )
+        .unwrap();
+        sched.sync();
+
+        let after = sched.jobs.get(&r.id).unwrap().signature.clone();
+        assert_eq!(after, "0 9 * * *|America/Bogota");
+        assert_ne!(before, after);
+        sched.shutdown();
+    }
+
+    #[tokio::test]
+    async fn unchanged_routine_keeps_its_job_across_syncs() {
+        // The flip side of the respawn fix: a no-op sync (nothing edited) must
+        // NOT churn the job, or every periodic re-sync would needlessly tear
+        // down and re-create live cron tasks.
+        let d = TempDir::new().unwrap();
+        let agent = d.path().to_string_lossy().to_string();
+        let r = create(d.path(), mk("steady", true, None)).unwrap();
+
+        let mut sched = AgentScheduler::new(
+            &agent,
+            "UTC",
+            Arc::new(NoopEventSink),
+            Arc::new(NoopDispatch),
+            Arc::new(NoopSurface),
+        );
+        sched.sync();
+        let first_id = sched.jobs.get(&r.id).unwrap().handle.id();
+
+        sched.sync(); // no changes on disk
+
+        assert_eq!(sched.jobs.len(), 1);
+        assert_eq!(
+            sched.jobs.get(&r.id).unwrap().handle.id(),
+            first_id,
+            "an unchanged routine must keep the very same task, not be re-spawned",
+        );
         sched.shutdown();
     }
 


### PR DESCRIPTION
## Problem

Weekly and monthly routines appeared to never trigger when tested with **today + 1 minute** (HOU-455).

The engine fires *fresh* routines correctly — verified with a test that mirrors the exact repro (today + 1 min, in a real UTC-5 zone with nonzero seconds): daily, weekly-on-today's-weekday, and monthly-on-today's-day all return a fire ~23s out, **same day**. No bug in the cron translation, day-of-week numbering, or timezone resolution.

The real bug was in the **edit path**. `AgentScheduler::sync()` keyed each cron job by routine **id alone**: it captured the schedule but never compared it, and the spawn loop skipped any routine that already had a live job. So **editing a routine's schedule / time / timezone did nothing** — the old job kept firing on the stale schedule, or never fired at all once its picked minute had passed.

This matches the testing workflow precisely: create a routine → its picked minute passes while you finish → edit the time to "1 min from now" → the edit is silently dropped → it never fires.

## Fix

`engine/houston-engine-core/src/routines/scheduler.rs`:

- Each job now stores a **signature** = `schedule | resolved-timezone`.
- `sync()` tears down and re-spawns a job when its signature changes, leaves unchanged jobs running (no churn), and removes disabled/deleted ones.
- `set_default_tz` no longer blanket-drains every job — the signature handles timezone changes, and routines pinned to their own timezone are left untouched.

## Tests (372 engine-core tests pass)

- `editing_schedule_respawns_the_cron_job` — the HOU-455 regression
- `editing_timezone_respawns_the_cron_job` — per-routine tz edit takes effect
- `unchanged_routine_keeps_its_job_across_syncs` — no needless re-spawn (asserts same task id)
- `today_plus_one_minute_fires_today_for_every_preset` — engine fires fresh weekly/monthly today

## Files

- `engine/houston-engine-core/src/routines/scheduler.rs` — the fix + 3 scheduler tests
- `engine/houston-engine-core/src/routines/cron_compat.rs` — HOU-455 cron-layer test

## Dev note

This is an `engine/**` change. Run `cargo build -p houston-engine-server` and restart `pnpm tauri dev` before testing — Tauri does not rebuild the engine sidecar on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)