### PR TITLE
fix(sentry): define own name property to dodge getter-only throw (HOU-461)

### DIFF
--- a/app/src/lib/sentry-report-error.ts
+++ b/app/src/lib/sentry-report-error.ts
@@ -4,7 +4,19 @@ export function createSentryReportError(
   originalError?: unknown,
 ): Error {
   const error = new Error(message);
-  error.name = command;
+  // Some runtimes (and Sentry/polyfill-patched globals) expose
+  // `Error.prototype.name` as a getter-only accessor, so a plain
+  // `error.name = command` assignment throws ("Cannot set property name … which
+  // has only a getter") — inside the error reporter itself. Define an own data
+  // property instead: it shadows any inherited accessor and never throws on a
+  // fresh Error, while keeping `name` as the Sentry exception type used for
+  // grouping/triage.
+  Object.defineProperty(error, "name", {
+    value: command,
+    writable: true,
+    configurable: true,
+    enumerable: false,
+  });
   if (originalError instanceof Error && originalError.stack) {
     error.stack = originalError.stack;
   }

--- a/app/tests/sentry-report-error.test.ts
+++ b/app/tests/sentry-report-error.test.ts
@@ -32,4 +32,29 @@ describe("createSentryReportError", () => {
     assert.equal(error.name, "react_crash");
     assert.equal(error.stack, original.stack);
   });
+
+  it("does not throw when Error.prototype.name is a getter-only accessor", () => {
+    // Reproduces HOU-461: in runtimes where `name` is exposed as a getter-only
+    // accessor on the prototype, a plain `error.name = command` assignment
+    // throws "Cannot set property name … which has only a getter" — inside the
+    // reporter. The fix defines an own data property, which must still win.
+    const descriptor = Object.getOwnPropertyDescriptor(Error.prototype, "name");
+    Object.defineProperty(Error.prototype, "name", {
+      configurable: true,
+      get: () => "Error",
+    });
+
+    try {
+      let error: Error | undefined;
+      assert.doesNotThrow(() => {
+        error = createSentryReportError("uncaught_error", "boom");
+      });
+      assert.equal(error?.name, "uncaught_error");
+      assert.equal(error?.message, "boom");
+    } finally {
+      if (descriptor) {
+        Object.defineProperty(Error.prototype, "name", descriptor);
+      }
+    }
+  });
 });


### PR DESCRIPTION
Closes HOU-461.

## Root cause
`createSentryReportError` (`app/src/lib/sentry-report-error.ts`) set the Sentry exception type with a plain assignment:

```ts
const error = new Error(message);
error.name = command;
```

In runtimes where `Error.prototype.name` is exposed as a **getter-only accessor** (no setter) — seen in prod via Sentry `HOUSTON-APP-2V`, patched/polyfilled globals — assigning to `error.name` throws:

```
TypeError: Cannot set property name of … which has only a getter
```

The throw happens **inside the error reporter itself**, so the report it was trying to capture never reached Sentry.

## Fix
Use `Object.defineProperty` to set `name` as an **own data property**. It shadows any inherited getter-only accessor and never throws on a fresh `Error`, while still keeping `name` as the Sentry exception type used for grouping/triage.

```ts
Object.defineProperty(error, "name", {
  value: command,
  writable: true,
  configurable: true,
  enumerable: false,
});
```

`stack` is untouched (only `name` is implicated in prod).

## Affected files
- `app/src/lib/sentry-report-error.ts` — `error.name = command` → `Object.defineProperty(...)`
- `app/tests/sentry-report-error.test.ts` — regression test that patches `Error.prototype.name` to getter-only and asserts the helper does not throw and still sets the command as `name`

## Verify
**Before the fix** (reproduce the throw):
```js
const d = Object.getOwnPropertyDescriptor(Error.prototype, "name");
Object.defineProperty(Error.prototype, "name", { configurable: true, get: () => "Error" });
const e = new Error("boom");
e.name = "uncaught_error"; // TypeError: Cannot set property name … which has only a getter
Object.defineProperty(Error.prototype, "name", d);
```

**After the fix:**
```
cd app && node --experimental-strip-types --test tests/sentry-report-error.test.ts
# 4 pass / 0 fail — incl. "does not throw when Error.prototype.name is a getter-only accessor"
cd app && pnpm tsc --noEmit   # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)