### PR TITLE
fix(activity): idempotent delete, no unhandled rejection on double-delete (HOU-462)

### DIFF
--- a/app/src/data/activity-bulk.ts
+++ b/app/src/data/activity-bulk.ts
@@ -27,3 +27,12 @@ export function applyBulkRemove(
 ): Activity[] {
   return items.filter((item) => !ids.has(item.id));
 }
+
+/**
+ * Drop the single item with `id`. Returns the same-length list (an idempotent
+ * no-op) when `id` isn't present, so `data/activity.ts` `remove()` can skip the
+ * write and treat "already gone" as success rather than throwing.
+ */
+export function applyRemove(items: Activity[], id: string): Activity[] {
+  return items.filter((item) => item.id !== id);
+}

--- a/app/src/data/activity.ts
+++ b/app/src/data/activity.ts
@@ -7,7 +7,7 @@
 
 import schema from "@houston-ai/agent-schemas/activity.schema.json";
 import { newId, now, readAgentJson, writeAgentJson } from "./agent-file";
-import { applyBulkPatch, applyBulkRemove } from "./activity-bulk";
+import { applyBulkPatch, applyBulkRemove, applyRemove } from "./activity-bulk";
 
 /** Every status a mission can have. Mirrors the `status` enum in
  *  `activity.schema.json` (the on-disk source of truth). */
@@ -102,10 +102,18 @@ export async function update(
   return merged;
 }
 
+/**
+ * Delete an activity. Idempotent: removing an id that's already gone is a
+ * no-op success — the desired end state (row absent) already holds, so there's
+ * nothing to write. Mirrors `bulkRemove`'s "unknown ids are silently no-ops"
+ * semantics and stops a double-delete (a UI click racing an agent / file-watcher
+ * write that already removed the row) from rejecting as an unhandled rejection.
+ * Genuine write failures still propagate.
+ */
 export async function remove(agentPath: string, id: string): Promise<void> {
   const items = await list(agentPath);
-  const next = items.filter((a) => a.id !== id);
-  if (next.length === items.length) throw new Error(`Activity not found: ${id}`);
+  const next = applyRemove(items, id);
+  if (next.length === items.length) return; // already gone — nothing to write
   await writeAgentJson(agentPath, NAME, s, next);
 }
 

--- a/app/tests/activity-bulk.test.ts
+++ b/app/tests/activity-bulk.test.ts
@@ -1,6 +1,10 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import { applyBulkPatch, applyBulkRemove } from "../src/data/activity-bulk.ts";
+import {
+  applyBulkPatch,
+  applyBulkRemove,
+  applyRemove,
+} from "../src/data/activity-bulk.ts";
 import type { Activity } from "../src/data/activity.ts";
 
 const item = (id: string, status: string): Activity => ({
@@ -46,5 +50,26 @@ describe("activity bulk helpers", () => {
   it("removing an unknown id leaves the list unchanged", () => {
     const items = [item("a", "done")];
     deepStrictEqual(applyBulkRemove(items, new Set(["zzz"])), items);
+  });
+
+  it("removes a single matching id and preserves order", () => {
+    const items = [item("a", "done"), item("b", "done"), item("c", "running")];
+    const next = applyRemove(items, "b");
+    deepStrictEqual(
+      next.map((i) => i.id),
+      ["a", "c"],
+    );
+  });
+
+  it("removing a single unknown id is an idempotent no-op", () => {
+    // Same length back signals "already gone" so `remove()` skips the write
+    // and resolves instead of throwing — the HOU-462 unhandled-rejection fix.
+    const items = [item("a", "done")];
+    const next = applyRemove(items, "zzz");
+    strictEqual(next.length, items.length);
+    deepStrictEqual(
+      next.map((i) => i.id),
+      ["a"],
+    );
   });
 });


### PR DESCRIPTION
## Root cause

`app/src/data/activity.ts` `remove()` threw `Activity not found: <id>` when the row was already gone. The delete callers `handleDelete` in `use-mission-control.ts` and `use-mission-control-archived.ts` bare-`await` the delete with no `.catch`, so a **double-delete** — a UI delete click racing an agent / file-watcher write that already removed the row — bubbled up as an **unhandled rejection** (Sentry `HOUSTON-APP-8W`, `unhandled_rejection: Activity not found: <id>`).

This was also inconsistent with the rest of the delete flow, which is already built to be idempotent: `bulkRemove` treats unknown ids as silent no-ops, and every caller's attachment/draft cleanup is `.catch(() => {})` "Idempotent".

## Fix

Treat "already gone" as success at the data layer — removing an absent id is a no-op (skips the write, so no spurious file write / query invalidation), instead of throwing. This fixes every current and future caller in one place rather than wrapping each call site in try/catch.

- Extract the single-item filter into a tested `applyRemove` pure helper in `activity-bulk.ts` (mirrors `applyBulkRemove`).
- `remove()` returns early when nothing changed.
- Genuine write failures still propagate — only the "desired state already holds" non-error stops throwing, so the no-silent-failures policy is preserved.
- `update()` is intentionally left throwing: patching a missing row is a real, unfulfilled intent.

The issue also flagged `app/src/lib/tauri.ts` — no change needed there; `tauriActivity.delete` just forwards to the data layer, which is now idempotent.

## Tests

`app/tests/activity-bulk.test.ts` — two new cases for `applyRemove`: removes a single matching id (order preserved), and a single unknown id is an idempotent no-op (same-length list, the signal `remove()` uses to skip the write). Full suite: 299 pass, 0 fail. `tsc --noEmit` clean.

## Verify

**Before (reproduces the bug):** open the board, delete a mission, then delete the same mission again before the list refreshes (or have an agent/routine delete a conversation already open for delete in the UI, then click delete). `remove()` rejects → DevTools console shows an uncaught `Activity not found: <id>` and it reports to Sentry as an unhandled rejection.

**After:** the second delete resolves silently — the row is already gone, which is the desired end state. No console error, no Sentry event, list stays correct.

Closes HOU-462