### PR TITLE
fix(app): make root mount idempotent to stop removeChild crash (HOU-459)

### DIFF
--- a/app/src/lib/react-root.ts
+++ b/app/src/lib/react-root.ts
@@ -1,0 +1,33 @@
+import { createRoot, type Root } from "react-dom/client";
+
+/**
+ * A React root container that remembers the {@link Root} we mounted into it.
+ *
+ * React keys its root bookkeeping off the container node, so handing the same
+ * container to {@link createRoot} a second time spins up a *competing* root.
+ * The two roots then both try to own the container's children and desync during
+ * the commit phase, which surfaces as
+ * `Failed to execute 'removeChild' on 'Node': The node to be removed is not a
+ * child of this node` (HOU-459).
+ */
+type RootContainer = (Element | DocumentFragment) & { __houstonRoot?: Root };
+
+/**
+ * Idempotently obtain the React root for `container`.
+ *
+ * The first call mounts a root and caches it on the node; every later call
+ * returns that same root so the caller re-renders through `root.render(...)`
+ * instead of minting a second root. In production the entry module runs exactly
+ * once, so this is a plain `createRoot`. In dev, Vite / React Fast Refresh can
+ * re-evaluate the entry module against the still-live document; without this
+ * guard that re-evaluation calls `createRoot` twice on `#root` and crashes the
+ * app with a `removeChild` reconciliation error (HOU-459).
+ *
+ * `create` is injectable purely so the guard can be unit-tested without a DOM.
+ */
+export function getOrCreateRoot(
+  container: RootContainer,
+  create: (node: Element | DocumentFragment) => Root = createRoot,
+): Root {
+  return (container.__houstonRoot ??= create(container));
+}

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -4,7 +4,7 @@ import {
   useState,
   type ReactNode,
 } from "react";
-import { createRoot } from "react-dom/client";
+import { getOrCreateRoot } from "./lib/react-root";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { I18nextProvider } from "react-i18next";
 import { TooltipProvider } from "@houston-ai/core";
@@ -166,7 +166,19 @@ function EngineGate({ children }: { children: ReactNode }) {
 // WKWebView that double-mount collides with portal DOM + Tauri event
 // listeners and throws NotFoundError on removeChild. Skipping it for now;
 // revisit once the underlying portal/listener churn is fixed.
-createRoot(document.getElementById("root")!).render(
+const container = document.getElementById("root");
+if (!container) {
+  // index.html always ships <div id="root">, so a missing node means the
+  // document failed to parse. Surface it instead of silently no-op mounting;
+  // compat-gate.js's watchdog still paints a friendly fallback (no silent
+  // failures).
+  throw new Error("Houston UI cannot start: #root is missing from the document");
+}
+// getOrCreateRoot (not a bare createRoot) so a dev-time re-evaluation of this
+// entry module reuses the existing root instead of minting a second one on the
+// same #root node — two roots desync the container and crash React with a
+// removeChild reconciliation error (HOU-459).
+getOrCreateRoot(container).render(
   <QueryClientProvider client={queryClient}>
     <ErrorBoundary>
       <TooltipProvider>

--- a/app/tests/react-root.test.ts
+++ b/app/tests/react-root.test.ts
@@ -1,0 +1,60 @@
+import { strictEqual, notStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { Root } from "react-dom/client";
+import { getOrCreateRoot } from "../src/lib/react-root.ts";
+
+// getOrCreateRoot only ever reads/writes the __houstonRoot property and never
+// touches real DOM, so a bare object is a faithful stand-in for the container
+// node — letting us exercise the guard under node:test without a DOM.
+type Container = Parameters<typeof getOrCreateRoot>[0];
+function fakeContainer(): Container {
+  return {} as unknown as Container;
+}
+
+// A factory that hands back a fresh sentinel "root" and counts its own calls,
+// standing in for react-dom's createRoot so the test never mounts React.
+function countingFactory() {
+  let calls = 0;
+  const create = () => {
+    calls += 1;
+    return { id: calls } as unknown as Root;
+  };
+  return { create, calls: () => calls };
+}
+
+describe("getOrCreateRoot (HOU-459 double-createRoot guard)", () => {
+  it("creates the root once per container and reuses it on repeat calls", () => {
+    const container = fakeContainer();
+    const factory = countingFactory();
+
+    const first = getOrCreateRoot(container, factory.create);
+    const second = getOrCreateRoot(container, factory.create);
+    const third = getOrCreateRoot(container, factory.create);
+
+    // The whole point: a second/third evaluation of the entry module must NOT
+    // mint a competing root on the same node (that is what desyncs #root and
+    // throws "Failed to execute 'removeChild' on 'Node'").
+    strictEqual(factory.calls(), 1, "createRoot must run exactly once per container");
+    strictEqual(first, second);
+    strictEqual(second, third);
+  });
+
+  it("caches the root on the container node", () => {
+    const container = fakeContainer();
+    const factory = countingFactory();
+
+    const root = getOrCreateRoot(container, factory.create);
+
+    strictEqual((container as { __houstonRoot?: Root }).__houstonRoot, root);
+  });
+
+  it("mints a distinct root for each distinct container", () => {
+    const factory = countingFactory();
+
+    const a = getOrCreateRoot(fakeContainer(), factory.create);
+    const b = getOrCreateRoot(fakeContainer(), factory.create);
+
+    strictEqual(factory.calls(), 2);
+    notStrictEqual(a, b);
+  });
+});


### PR DESCRIPTION
## HOU-459 — React crash: `removeChild` DOM reconciliation error

Sentry: `HOUSTON-APP-2W` — `react_crash: Failed to execute 'removeChild' on 'Node': The node to be removed is not a child of this node.` · culprit `removeChildFromContainer`.

### Root cause
The Linear description guessed an external-DOM-mutation cause (translate extensions). The Sentry breadcrumbs say otherwise — immediately before the crash:

> `You are calling ReactDOMClient.createRoot() on a container that has already been passed to createRoot() before. Instead, call root.render().` (logged **twice**)

`app/src/main.tsx` called `createRoot(document.getElementById("root")!)` at module top level (the only `createRoot` in the codebase). When Vite / React Fast Refresh re-evaluates the entry module against the still-live document in dev, `createRoot()` runs a **second time on the same `#root` node**, creating a competing React root. The two roots both manage `#root`'s children and desync during the commit phase, throwing the `removeChild` `NotFoundError`. Event env: `development`, Windows WebView2, `http://localhost:1420/`. Same bug family as the StrictMode note already in `main.tsx`.

### Fix
- New `app/src/lib/react-root.ts` → `getOrCreateRoot(container)`: caches the `Root` on the container node and returns it on every later call, so a re-eval re-renders via `root.render(...)` instead of minting a second root. Production runs the entry once, so it's a plain `createRoot` there.
- `main.tsx` mounts through `getOrCreateRoot`, and now throws a clear error if `#root` is missing instead of silently no-op mounting (no silent failures; `compat-gate.js` still paints the friendly fallback).
- Extracted as a pure, factory-injectable helper so it's unit-testable under `node:test` without a DOM.

### Tests
`app/tests/react-root.test.ts` — asserts the factory runs exactly once per container, the same root is reused across repeated calls, the root is cached on the node, and distinct containers get distinct roots.

- `node --test` (full app suite): **300 pass / 0 fail**
- `pnpm tsc --noEmit`: clean

### Verify the bug (before)
1. `cd app && pnpm tauri dev` (or `pnpm dev`) on the pre-fix entry.
2. With the app mounted, force the entry module to re-evaluate in the live document (a Fast-Refresh hot update that re-runs `main.tsx` / a flaky HMR reconnect on Windows WebView2). React logs `createRoot() on a container that has already been passed to createRoot()` and then crashes with `Failed to execute 'removeChild' on 'Node'`.

### Verify the fix (after)
1. Same dev run on this branch — the re-eval now hits `getOrCreateRoot`, reuses the existing root, and re-renders cleanly: no `createRoot`-twice warning, no `removeChild` crash.
2. `cd app && node --experimental-strip-types --test tests/react-root.test.ts` → 3 pass (guard proven without a DOM).
3. `cd app && pnpm test` → 300 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)