### PR TITLE
fix(skills): disable + spin a skill card while its detail loads (HOU-464)

### DIFF
--- a/app/src/components/skill-card.tsx
+++ b/app/src/components/skill-card.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { cn } from "@houston-ai/core";
+import { cn, Spinner } from "@houston-ai/core";
 import { SkillIcon } from "./skill-icon";
 import { IntegrationLogos } from "./integration-logos";
 
@@ -69,6 +69,9 @@ export function SkillCard({
           <IntegrationLogos toolkits={visibleIntegrations} />
         )}
       </div>
+      {busy && (
+        <Spinner className="size-4 shrink-0 self-center text-muted-foreground" />
+      )}
     </button>
   );
 }

--- a/app/src/components/tabs/job-description-tab.tsx
+++ b/app/src/components/tabs/job-description-tab.tsx
@@ -89,6 +89,7 @@ export default function JobDescriptionTab({ agent }: TabProps) {
             <SkillsContent
               skills={surface.skills}
               loading={surface.skillsLoading}
+              loadingSkillName={surface.loadingSkillName}
               onSkillClick={surface.selectSkill}
               onSearch={surface.handleSearch}
               onPopular={surface.handlePopular}

--- a/app/src/components/tabs/skill-loading-model.ts
+++ b/app/src/components/tabs/skill-loading-model.ts
@@ -1,0 +1,22 @@
+/**
+ * Which skill card, if any, should show a busy + disabled state.
+ *
+ * Clicking a skill card pins `selectedSkillName` and kicks off the async
+ * `load_skill` detail fetch. Until that fetch resolves the grid stays
+ * mounted, so a slow load (or one that 404s on a renamed/deleted skill)
+ * leaves the card live with no feedback. Users read that as "nothing
+ * happened" and rage-click, firing the fetch again and again. Returning the
+ * in-flight skill name lets the caller disable + spin that one card so the
+ * extra clicks are swallowed. See HOU-464.
+ *
+ * Gated on `!hasDetail` so a background refetch of an already-open skill
+ * (detail already on screen) doesn't re-flag its card as loading.
+ */
+export function resolveLoadingSkillName(
+  selectedSkillName: string | null,
+  detailFetching: boolean,
+  hasDetail: boolean,
+): string | null {
+  if (!selectedSkillName || !detailFetching || hasDetail) return null;
+  return selectedSkillName;
+}

--- a/app/src/components/tabs/skills-content.tsx
+++ b/app/src/components/tabs/skills-content.tsx
@@ -18,6 +18,7 @@ import { useSkillDialogLabels } from "./use-skill-surface-labels";
 export function SkillsContent({
   skills,
   loading,
+  loadingSkillName,
   onSkillClick,
   onSearch,
   onPopular,
@@ -29,6 +30,8 @@ export function SkillsContent({
 }: {
   skills: SkillSummary[];
   loading: boolean;
+  /** Name of the skill whose detail is loading; its card spins + disables. */
+  loadingSkillName?: string | null;
   onSkillClick: (name: string) => void;
   onSearch?: (query: string, signal?: AbortSignal) => Promise<CommunitySkill[]>;
   onPopular?: (signal?: AbortSignal) => Promise<CommunitySkill[]>;
@@ -123,6 +126,8 @@ export function SkillsContent({
             description={skill.description}
             integrations={skill.integrations}
             onClick={() => onSkillClick(skill.name)}
+            busy={loadingSkillName === skill.name}
+            disabled={loadingSkillName === skill.name}
           />
         ))}
       </div>

--- a/app/src/components/tabs/use-skill-surface.ts
+++ b/app/src/components/tabs/use-skill-surface.ts
@@ -17,6 +17,7 @@ import { tauriSkills } from "../../lib/tauri";
 import { isMissingSkillError } from "../../lib/missing-skill";
 import { useUIStore } from "../../stores/ui";
 import { useSkillSurfaceLabels } from "./use-skill-surface-labels";
+import { resolveLoadingSkillName } from "./skill-loading-model";
 
 export function useSkillSurface(agentPath: string) {
   const { t } = useTranslation("skills");
@@ -32,9 +33,19 @@ export function useSkillSurface(agentPath: string) {
     setPrevAgentPath(agentPath);
     setSelectedSkillName(null);
   }
-  const { data: skillDetail, error: skillDetailError } = useSkillDetail(
-    agentPath,
-    selectedSkillName ?? undefined,
+  const {
+    data: skillDetail,
+    error: skillDetailError,
+    isFetching: skillDetailFetching,
+  } = useSkillDetail(agentPath, selectedSkillName ?? undefined);
+
+  // The skill whose `load_skill` fetch is in flight, so the grid can disable
+  // and spin just that card instead of letting a slow/failed load get
+  // rage-clicked into duplicate fetches (HOU-464).
+  const loadingSkillName = resolveLoadingSkillName(
+    selectedSkillName,
+    skillDetailFetching,
+    !!skillDetail,
   );
 
   // A selected skill that no longer resolves (renamed, deleted, or never
@@ -144,6 +155,7 @@ export function useSkillSurface(agentPath: string) {
     skills: summaries ?? [],
     skillsLoading,
     selectedSkill,
+    loadingSkillName,
     selectSkill: setSelectedSkillName,
     clearSelectedSkill,
     handleSkillSave,

--- a/app/tests/skill-loading-model.test.ts
+++ b/app/tests/skill-loading-model.test.ts
@@ -1,0 +1,27 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { resolveLoadingSkillName } from "../src/components/tabs/skill-loading-model.ts";
+
+describe("resolveLoadingSkillName", () => {
+  it("returns null when no skill is selected", () => {
+    strictEqual(resolveLoadingSkillName(null, true, false), null);
+    strictEqual(resolveLoadingSkillName(null, false, false), null);
+  });
+
+  it("flags the selected skill while its first detail fetch is in flight", () => {
+    strictEqual(resolveLoadingSkillName("research", true, false), "research");
+  });
+
+  it("clears once the detail resolves (fetch settled)", () => {
+    strictEqual(resolveLoadingSkillName("research", false, true), null);
+  });
+
+  it("clears on a failed/settled fetch with no detail (toast path owns it)", () => {
+    strictEqual(resolveLoadingSkillName("missing-skill", false, false), null);
+  });
+
+  it("does not re-flag a card during a background refetch of an open skill", () => {
+    // Detail already on screen, React Query is revalidating: not a rage window.
+    strictEqual(resolveLoadingSkillName("research", true, true), null);
+  });
+});


### PR DESCRIPTION
## HOU-464 — Rage click: undebounced skill card

### Root cause
Sentry **HOUSTON-APP-75** (`Rage Click`) fired on a `SkillCard` button. The captured selector (`...hover:bg-accent.disabled:opacity-50.disabled:cursor-not-allowed.w-full`) matches `app/src/components/skill-card.tsx`, and the privacy-masked Session Replay (`fd4e537b…`) correlates it with **HOUSTON-APP-74** `load_skill: Skill not found: buscar eventos y agendar` in the same session.

So the real culprit is the agent's **Skills surface**, not "agent/board creation" as the triage note guessed:

1. Clicking a card calls `selectSkill(name)` → pins `selectedSkillName`.
2. `useSkillDetail` fires the async `load_skill` fetch.
3. The grid stays mounted during the fetch (the detail page only renders once the detail resolves). The card stays live with **no busy/disabled state**.
4. On a slow load — or one that 404s on a renamed/deleted skill — the user sees nothing happen, reads it as a dead click, and **rage-clicks**, re-firing `load_skill`.

`SkillCard` already accepts `busy` + `disabled`, but the Skills grid never wired them, and `busy` was a11y-only (`aria-busy`, no visible spinner).

### Fix
- **`skill-loading-model.ts`** (new, pure + unit-tested): `resolveLoadingSkillName(selected, fetching, hasDetail)` returns the skill whose first detail fetch is in flight.
- **`use-skill-surface.ts`**: read `isFetching` from `useSkillDetail` and expose `loadingSkillName`.
- **`job-description-tab.tsx` → `skills-content.tsx`**: pass it down; the matching card gets `busy` + `disabled`.
- **`skill-card.tsx`**: render a `Spinner` when `busy` (shared component, so every future async caller gets the affordance).

While the fetch is in flight the clicked card spins and ignores clicks, so the extra clicks are swallowed; when it settles, the card re-enables (and the existing HOU-441 toast handles the not-found case). Other `SkillCard` call sites — chat empty state, mission picker, agent store — select/navigate **synchronously**, so they have no rage window and are intentionally untouched.

Chose query-driven `busy`/`disabled` over a generic `<AsyncButton>` (the triage's suggestion) because the async here is a React Query side-effect of a state change, not a promise returned by `onClick` — wrapping the click would fight the reactive query architecture.

### Reproduce (before)
1. Open an agent → **Skills**.
2. Rename or delete a skill's folder on disk so the list is briefly stale (or pick any skill while the engine is under load).
3. Click that skill card repeatedly. Before this change the card gives no feedback during `load_skill`, so the clicks land again and again → Sentry rage click + duplicate `load_skill` calls.

### Verify (after)
1. Same setup.
2. Click a skill card: it immediately shows a spinner and becomes non-interactive while `load_skill` runs.
3. Hammer it: the extra clicks are ignored (no duplicate fetches). On success the detail opens; on a missing skill the existing "unavailable" toast shows and the card re-enables.

### Tests
- `app/tests/skill-loading-model.test.ts` (new, 5 cases) — green.
- Full app suite: **302 pass**. `tsc --noEmit`: clean. `check-locales`: in sync (no new strings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)