### PR TITLE
feat(routines): user-friendly clock time picker in schedule config (HOU-456)

### DIFF
--- a/app/src/locales/en/routines.json
+++ b/app/src/locales/en/routines.json
@@ -78,6 +78,11 @@
     "shortcuts": { "everyDay": "Every day", "weekdays": "Weekdays", "weekends": "Weekends" },
     "decrease": "Decrease",
     "increase": "Increase",
+    "timePicker": {
+      "hour": "Hour",
+      "minute": "Minute",
+      "period": "AM/PM"
+    },
     "summary": {
       "noSchedule": "No schedule set",
       "custom": "Custom schedule",

--- a/app/src/locales/es/routines.json
+++ b/app/src/locales/es/routines.json
@@ -78,6 +78,11 @@
     "shortcuts": { "everyDay": "Todos los días", "weekdays": "Días laborables", "weekends": "Fines de semana" },
     "decrease": "Disminuir",
     "increase": "Aumentar",
+    "timePicker": {
+      "hour": "Hora",
+      "minute": "Minuto",
+      "period": "a. m./p. m."
+    },
     "summary": {
       "noSchedule": "Sin horario definido",
       "custom": "Horario personalizado",

--- a/app/src/locales/pt/routines.json
+++ b/app/src/locales/pt/routines.json
@@ -78,6 +78,11 @@
     "shortcuts": { "everyDay": "Todos os dias", "weekdays": "Dias úteis", "weekends": "Fins de semana" },
     "decrease": "Diminuir",
     "increase": "Aumentar",
+    "timePicker": {
+      "hour": "Hora",
+      "minute": "Minuto",
+      "period": "AM/PM"
+    },
     "summary": {
       "noSchedule": "Nenhum agendamento definido",
       "custom": "Agendamento personalizado",

--- a/ui/routines/src/labels-default.ts
+++ b/ui/routines/src/labels-default.ts
@@ -82,6 +82,7 @@ export const DEFAULT_SCHEDULE_LABELS: ScheduleLabels = {
   shortcuts: { everyDay: "Every day", weekdays: "Weekdays", weekends: "Weekends" },
   decrease: "Decrease",
   increase: "Increase",
+  timePicker: { hour: "Hour", minute: "Minute", period: "AM/PM" },
   summary: DEFAULT_SCHEDULE_SUMMARY_LABELS,
 }
 

--- a/ui/routines/src/labels.ts
+++ b/ui/routines/src/labels.ts
@@ -102,6 +102,8 @@ export interface ScheduleLabels {
   /** aria-labels for the count stepper's − / + buttons. */
   decrease: string
   increase: string
+  /** Accessible names for the time picker's hour / minute / AM-PM columns. */
+  timePicker: { hour: string; minute: string; period: string }
   summary: ScheduleSummaryLabels
 }
 

--- a/ui/routines/src/schedule-builder.tsx
+++ b/ui/routines/src/schedule-builder.tsx
@@ -18,11 +18,8 @@ import { AnimatePresence, motion } from "framer-motion"
 import { cn } from "@houston-ai/core"
 import type { SchedulePreset } from "./types"
 import { DEFAULT_SCHEDULE_LABELS, type ScheduleLabels } from "./labels"
-import {
-  TimePicker,
-  DayOfMonthPicker,
-  WeekdaysPicker,
-} from "./schedule-picker-fields"
+import { DayOfMonthPicker, WeekdaysPicker } from "./schedule-picker-fields"
+import { TimePicker } from "./time-picker"
 import { IntervalPicker } from "./schedule-interval-picker"
 import { useScheduleBuilder } from "./use-schedule-builder"
 
@@ -116,6 +113,8 @@ export function ScheduleBuilder({
                 label={labels.timeLabel}
                 value={options.time}
                 onChange={(time) => updateOption({ time })}
+                locale={locale}
+                labels={labels.timePicker}
               />
             </Reveal>
           )}
@@ -174,6 +173,8 @@ export function ScheduleBuilder({
                 label={labels.timeLabel}
                 value={options.time}
                 onChange={(time) => updateOption({ time })}
+                locale={locale}
+                labels={labels.timePicker}
               />
             </Reveal>
           )}

--- a/ui/routines/src/schedule-picker-fields.tsx
+++ b/ui/routines/src/schedule-picker-fields.tsx
@@ -1,7 +1,8 @@
 /**
- * Picker fields used by ScheduleBuilder — time, day-of-month, and the "On these
- * days" weekday multi-select. The "Repeat every N [unit]" control lives in
- * schedule-interval-picker.tsx and reuses labelClass exported here.
+ * Picker fields used by ScheduleBuilder — day-of-month and the "On these days"
+ * weekday multi-select. The friendly clock-button time picker lives in
+ * time-picker.tsx and the "Repeat every N [unit]" control in
+ * schedule-interval-picker.tsx; both reuse `labelClass` exported here.
  *
  * All visible text arrives via props so the package stays i18n-agnostic;
  * weekday names come from `Intl` in the given `locale`.
@@ -16,28 +17,6 @@ const inputClass = cn(
 )
 
 export const labelClass = "text-xs font-medium text-muted-foreground mb-1.5 block"
-
-export function TimePicker({
-  label,
-  value,
-  onChange,
-}: {
-  label: string
-  value: string
-  onChange: (time: string) => void
-}) {
-  return (
-    <div>
-      <label className={labelClass}>{label}</label>
-      <input
-        type="time"
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className={cn(inputClass, "w-full")}
-      />
-    </div>
-  )
-}
 
 export function DayOfMonthPicker({
   label,

--- a/ui/routines/src/time-picker-columns.tsx
+++ b/ui/routines/src/time-picker-columns.tsx
@@ -1,0 +1,107 @@
+/**
+ * The scrollable columns inside the TimePicker popover. Kept apart from
+ * time-picker.tsx so each file stays small; these are presentational and own no
+ * time logic — the parent computes values and hands selection callbacks down.
+ */
+import { useEffect, useRef } from "react"
+import { cn } from "@houston-ai/core"
+import { pad2, type Period } from "./time-picker-utils.ts"
+
+/**
+ * One scrollable column of zero-padded numbers. On mount (the popover opens) the
+ * selected value is centered so the user lands on the current time, not the top
+ * of the list. We set `scrollTop` directly rather than `scrollIntoView` so only
+ * the column scrolls — never the surrounding page or popover.
+ */
+export function TimeColumn({
+  ariaLabel,
+  options,
+  selected,
+  onSelect,
+}: {
+  ariaLabel: string
+  options: number[]
+  selected: number
+  onSelect: (n: number) => void
+}) {
+  const containerRef = useRef<HTMLDivElement>(null)
+  const selectedRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    const c = containerRef.current
+    const el = selectedRef.current
+    if (c && el) c.scrollTop = el.offsetTop - c.clientHeight / 2 + el.clientHeight / 2
+  }, [])
+
+  return (
+    <div
+      ref={containerRef}
+      role="group"
+      aria-label={ariaLabel}
+      className="relative flex h-48 w-14 flex-col gap-0.5 overflow-y-auto scroll-smooth"
+    >
+      {options.map((n) => {
+        const on = n === selected
+        return (
+          <button
+            key={n}
+            ref={on ? selectedRef : undefined}
+            type="button"
+            aria-label={`${ariaLabel} ${n}`}
+            aria-pressed={on}
+            onClick={() => onSelect(n)}
+            className={cn(
+              "shrink-0 rounded-md py-1.5 text-center text-sm tabular-nums transition-colors",
+              on
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            {pad2(n)}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
+/** The AM/PM column, shown only for 12-hour locales. */
+export function PeriodColumn({
+  ariaLabel,
+  periods,
+  selected,
+  onSelect,
+}: {
+  ariaLabel: string
+  periods: { am: string; pm: string }
+  selected: Period
+  onSelect: (p: Period) => void
+}) {
+  const items: { key: Period; label: string }[] = [
+    { key: "am", label: periods.am },
+    { key: "pm", label: periods.pm },
+  ]
+  return (
+    <div role="group" aria-label={ariaLabel} className="flex w-14 flex-col gap-0.5">
+      {items.map((it) => {
+        const on = it.key === selected
+        return (
+          <button
+            key={it.key}
+            type="button"
+            aria-pressed={on}
+            onClick={() => onSelect(it.key)}
+            className={cn(
+              "shrink-0 rounded-md py-1.5 text-center text-sm uppercase transition-colors",
+              on
+                ? "bg-primary text-primary-foreground"
+                : "text-muted-foreground hover:bg-muted hover:text-foreground",
+            )}
+          >
+            {it.label}
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/ui/routines/src/time-picker-columns.tsx
+++ b/ui/routines/src/time-picker-columns.tsx
@@ -8,10 +8,11 @@ import { cn } from "@houston-ai/core"
 import { pad2, type Period } from "./time-picker-utils.ts"
 
 /**
- * One scrollable column of zero-padded numbers. On mount (the popover opens) the
- * selected value is centered so the user lands on the current time, not the top
- * of the list. We set `scrollTop` directly rather than `scrollIntoView` so only
- * the column scrolls — never the surrounding page or popover.
+ * One scrollable column of zero-padded numbers. The selected value is kept
+ * centered: the column is padded at both ends so even the first/last number can
+ * sit dead-center, and `scrollTop` is re-set whenever the selection changes so
+ * the current value never drifts off-center. We set `scrollTop` directly rather
+ * than `scrollIntoView` so only the column scrolls — never the page or popover.
  */
 export function TimeColumn({
   ariaLabel,
@@ -30,8 +31,12 @@ export function TimeColumn({
   useEffect(() => {
     const c = containerRef.current
     const el = selectedRef.current
-    if (c && el) c.scrollTop = el.offsetTop - c.clientHeight / 2 + el.clientHeight / 2
-  }, [])
+    if (!c || !el) return
+    // Pad the ends to half the viewport so the extreme values can also center,
+    // then bring the current selection to the middle.
+    c.style.paddingBlock = `${Math.max(0, (c.clientHeight - el.clientHeight) / 2)}px`
+    c.scrollTop = el.offsetTop - c.clientHeight / 2 + el.clientHeight / 2
+  }, [selected])
 
   return (
     <div
@@ -82,7 +87,11 @@ export function PeriodColumn({
     { key: "pm", label: periods.pm },
   ]
   return (
-    <div role="group" aria-label={ariaLabel} className="flex w-14 flex-col gap-0.5">
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      className="flex w-14 flex-col justify-center gap-0.5"
+    >
       {items.map((it) => {
         const on = it.key === selected
         return (

--- a/ui/routines/src/time-picker-columns.tsx
+++ b/ui/routines/src/time-picker-columns.tsx
@@ -38,7 +38,7 @@ export function TimeColumn({
       ref={containerRef}
       role="group"
       aria-label={ariaLabel}
-      className="relative flex h-48 w-14 flex-col gap-0.5 overflow-y-auto scroll-smooth"
+      className="relative flex h-28 w-14 flex-col gap-0.5 overflow-y-auto scroll-smooth"
     >
       {options.map((n) => {
         const on = n === selected

--- a/ui/routines/src/time-picker-columns.tsx
+++ b/ui/routines/src/time-picker-columns.tsx
@@ -5,7 +5,7 @@
  */
 import { useEffect, useRef } from "react"
 import { cn } from "@houston-ai/core"
-import { pad2, type Period } from "./time-picker-utils.ts"
+import { pad2, centerPadding, centerScrollTop, type Period } from "./time-picker-utils.ts"
 
 /**
  * One scrollable column of zero-padded numbers. The selected value is kept
@@ -32,10 +32,10 @@ export function TimeColumn({
     const c = containerRef.current
     const el = selectedRef.current
     if (!c || !el) return
-    // Pad the ends to half the viewport so the extreme values can also center,
-    // then bring the current selection to the middle.
-    c.style.paddingBlock = `${Math.max(0, (c.clientHeight - el.clientHeight) / 2)}px`
-    c.scrollTop = el.offsetTop - c.clientHeight / 2 + el.clientHeight / 2
+    // Pad the ends so the extreme values can also center, then bring the current
+    // selection to the middle. (offsetTop reflects the padding once it's set.)
+    c.style.paddingBlock = `${centerPadding(c.clientHeight, el.clientHeight)}px`
+    c.scrollTop = centerScrollTop(el.offsetTop, c.clientHeight, el.clientHeight)
   }, [selected])
 
   return (

--- a/ui/routines/src/time-picker-utils.ts
+++ b/ui/routines/src/time-picker-utils.ts
@@ -64,3 +64,25 @@ export function hourOptions(twelveHour: boolean): number[] {
 export function minuteOptions(): number[] {
   return Array.from({ length: 60 }, (_, i) => i)
 }
+
+/**
+ * Padding for each end of a short picker column so the first and last values can
+ * still scroll to the vertical center. Half the leftover viewport, never < 0.
+ */
+export function centerPadding(viewportHeight: number, itemHeight: number): number {
+  return Math.max(0, (viewportHeight - itemHeight) / 2)
+}
+
+/**
+ * The `scrollTop` that places an item — at `offsetTop` within the (end-padded)
+ * scroll content, `itemHeight` tall — at the vertical center of `viewportHeight`.
+ * The browser clamps to the scroll range, which is exactly why the end padding
+ * is needed for the first/last items to truly center.
+ */
+export function centerScrollTop(
+  offsetTop: number,
+  viewportHeight: number,
+  itemHeight: number,
+): number {
+  return offsetTop - viewportHeight / 2 + itemHeight / 2
+}

--- a/ui/routines/src/time-picker-utils.ts
+++ b/ui/routines/src/time-picker-utils.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure helpers for the friendly TimePicker — locale-aware 12h/24h detection,
+ * AM/PM markers, and conversion between the stored "HH:MM" (24-hour) value and
+ * the hour/minute/period a column picker shows.
+ *
+ * All localization flows through `Intl` so the package stays i18n-agnostic, and
+ * everything here is side-effect free (no React, no DOM) so it can be unit-tested
+ * directly. The component in `time-picker.tsx` is the only consumer.
+ */
+
+/** A half of the 12-hour clock. */
+export type Period = "am" | "pm"
+
+/** Whether `locale` formats clock time as 12-hour (en) vs 24-hour (es/pt). */
+export function is12HourLocale(locale = "en-US"): boolean {
+  // Asking for an hour part without forcing `hourCycle` lets the locale's own
+  // default clock surface through `resolvedOptions().hour12`.
+  return (
+    new Intl.DateTimeFormat(locale, { hour: "numeric" }).resolvedOptions()
+      .hour12 ?? false
+  )
+}
+
+/** Localized AM/PM markers for `locale` (e.g. "AM"/"PM", "a. m."/"p. m."). */
+export function periodLabels(locale = "en-US"): { am: string; pm: string } {
+  const mark = (hour: number) =>
+    new Intl.DateTimeFormat(locale, { hour: "numeric", hour12: true })
+      .formatToParts(new Date(2000, 0, 1, hour))
+      .find((p) => p.type === "dayPeriod")?.value ?? (hour < 12 ? "AM" : "PM")
+  return { am: mark(9), pm: mark(21) }
+}
+
+/** 24-hour hour (0–23) → 12-hour display hour (1–12) + period. */
+export function to12Hour(hour24: number): { hour: number; period: Period } {
+  const period: Period = hour24 < 12 ? "am" : "pm"
+  const hour = hour24 % 12 === 0 ? 12 : hour24 % 12
+  return { hour, period }
+}
+
+/** 12-hour display hour (1–12) + period → 24-hour hour (0–23). */
+export function from12Hour(hour12: number, period: Period): number {
+  const base = hour12 % 12 // 12 o'clock maps to 0 within its half
+  return period === "pm" ? base + 12 : base
+}
+
+/** Two-digit zero-padded string ("9" → "09"). */
+export function pad2(n: number): string {
+  return String(n).padStart(2, "0")
+}
+
+/** Compose a stored "HH:MM" (24-hour) value from its parts. */
+export function buildTime(hour24: number, minute: number): string {
+  return `${pad2(hour24)}:${pad2(minute)}`
+}
+
+/** Hour options for a column: 1–12 (12h locales) or 0–23 (24h locales). */
+export function hourOptions(twelveHour: boolean): number[] {
+  return twelveHour
+    ? Array.from({ length: 12 }, (_, i) => i + 1)
+    : Array.from({ length: 24 }, (_, i) => i)
+}
+
+/** Minute options 0–59. */
+export function minuteOptions(): number[] {
+  return Array.from({ length: 60 }, (_, i) => i)
+}

--- a/ui/routines/src/time-picker.tsx
+++ b/ui/routines/src/time-picker.tsx
@@ -1,0 +1,111 @@
+/**
+ * TimePicker — a friendly clock-button time picker for the schedule builder.
+ *
+ * The trigger shows the time in the user's locale (12h for en, 24h for es/pt)
+ * next to an always-visible clock icon; clicking opens a popover with scrollable
+ * hour / minute (and AM/PM, for 12h locales) columns. The stored value stays
+ * "HH:MM" 24-hour regardless of how it's displayed, so the cron logic upstream
+ * is unaffected.
+ *
+ * Replaces the bare `<input type="time">`, which in the app's macOS webview
+ * renders as a digit-only spinner with no pop-up picker — the user could only
+ * type or nudge with arrow keys (HOU-456).
+ *
+ * i18n-agnostic per the library boundary: the field label + column names arrive
+ * via props; AM/PM markers and the 12h-vs-24h choice come from `Intl` in the
+ * given `locale`. The scroll columns live in time-picker-columns.tsx.
+ */
+import { Clock } from "lucide-react"
+import { cn, Popover, PopoverContent, PopoverTrigger } from "@houston-ai/core"
+import { parseTime, formatTime } from "./schedule-format.ts"
+import { labelClass } from "./schedule-picker-fields.tsx"
+import { TimeColumn, PeriodColumn } from "./time-picker-columns.tsx"
+import {
+  is12HourLocale,
+  periodLabels,
+  to12Hour,
+  from12Hour,
+  buildTime,
+  hourOptions,
+  minuteOptions,
+  type Period,
+} from "./time-picker-utils.ts"
+
+/** Accessible names for the picker's columns. */
+export interface TimePickerLabels {
+  hour: string
+  minute: string
+  period: string
+}
+
+export function TimePicker({
+  label,
+  value,
+  onChange,
+  locale = "en-US",
+  labels,
+}: {
+  label: string
+  value: string
+  onChange: (time: string) => void
+  locale?: string
+  labels: TimePickerLabels
+}) {
+  const twelveHour = is12HourLocale(locale)
+  const { hour: hour24, minute } = parseTime(value)
+  const { hour: hour12, period } = to12Hour(hour24)
+  const periods = periodLabels(locale)
+
+  const selectHour = (h: number) =>
+    onChange(buildTime(twelveHour ? from12Hour(h, period) : h, minute))
+  const selectMinute = (m: number) => onChange(buildTime(hour24, m))
+  const selectPeriod = (p: Period) =>
+    onChange(buildTime(from12Hour(hour12, p), minute))
+
+  return (
+    <div>
+      <label className={labelClass}>{label}</label>
+      <Popover>
+        <PopoverTrigger asChild>
+          <button
+            type="button"
+            aria-label={`${label}: ${formatTime(value, locale)}`}
+            className={cn(
+              "flex w-full items-center justify-between gap-2 px-3 py-2",
+              "rounded-lg border border-border/20 bg-background",
+              "text-sm text-foreground transition-shadow",
+              "focus:outline-none focus:shadow-sm",
+            )}
+          >
+            <span>{formatTime(value, locale)}</span>
+            <Clock className="size-4 text-muted-foreground" aria-hidden />
+          </button>
+        </PopoverTrigger>
+        <PopoverContent align="start" className="w-auto p-2">
+          <div className="flex gap-1" role="group" aria-label={label}>
+            <TimeColumn
+              ariaLabel={labels.hour}
+              options={hourOptions(twelveHour)}
+              selected={twelveHour ? hour12 : hour24}
+              onSelect={selectHour}
+            />
+            <TimeColumn
+              ariaLabel={labels.minute}
+              options={minuteOptions()}
+              selected={minute}
+              onSelect={selectMinute}
+            />
+            {twelveHour && (
+              <PeriodColumn
+                ariaLabel={labels.period}
+                periods={periods}
+                selected={period}
+                onSelect={selectPeriod}
+              />
+            )}
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  )
+}

--- a/ui/routines/src/time-picker.tsx
+++ b/ui/routines/src/time-picker.tsx
@@ -81,7 +81,7 @@ export function TimePicker({
             <Clock className="size-4 text-muted-foreground" aria-hidden />
           </button>
         </PopoverTrigger>
-        <PopoverContent align="start" className="w-auto p-2">
+        <PopoverContent align="start" className="w-auto rounded-2xl p-2">
           <div className="flex gap-1" role="group" aria-label={label}>
             <TimeColumn
               ariaLabel={labels.hour}

--- a/ui/routines/tests/time-picker-utils.test.ts
+++ b/ui/routines/tests/time-picker-utils.test.ts
@@ -1,0 +1,81 @@
+import { strict as assert } from "node:assert"
+import { describe, it } from "node:test"
+import {
+  is12HourLocale,
+  periodLabels,
+  to12Hour,
+  from12Hour,
+  buildTime,
+  pad2,
+  hourOptions,
+  minuteOptions,
+  type Period,
+} from "../src/time-picker-utils.ts"
+
+describe("is12HourLocale", () => {
+  it("is true for en, false for es/pt", () => {
+    assert.equal(is12HourLocale("en-US"), true)
+    assert.equal(is12HourLocale("es"), false)
+    assert.equal(is12HourLocale("pt-BR"), false)
+  })
+})
+
+describe("periodLabels", () => {
+  it("returns the locale's AM/PM markers", () => {
+    assert.deepEqual(periodLabels("en-US"), { am: "AM", pm: "PM" })
+  })
+})
+
+describe("to12Hour", () => {
+  it("maps 24-hour to display hour + period", () => {
+    assert.deepEqual(to12Hour(0), { hour: 12, period: "am" })
+    assert.deepEqual(to12Hour(9), { hour: 9, period: "am" })
+    assert.deepEqual(to12Hour(12), { hour: 12, period: "pm" })
+    assert.deepEqual(to12Hour(13), { hour: 1, period: "pm" })
+    assert.deepEqual(to12Hour(23), { hour: 11, period: "pm" })
+  })
+})
+
+describe("from12Hour", () => {
+  it("maps display hour + period back to 24-hour", () => {
+    assert.equal(from12Hour(12, "am"), 0)
+    assert.equal(from12Hour(9, "am"), 9)
+    assert.equal(from12Hour(12, "pm"), 12)
+    assert.equal(from12Hour(1, "pm"), 13)
+    assert.equal(from12Hour(11, "pm"), 23)
+  })
+
+  it("round-trips with to12Hour for every hour", () => {
+    for (let h = 0; h < 24; h++) {
+      const { hour, period } = to12Hour(h)
+      assert.equal(from12Hour(hour, period as Period), h)
+    }
+  })
+})
+
+describe("pad2 + buildTime", () => {
+  it("zero-pads each part", () => {
+    assert.equal(pad2(0), "00")
+    assert.equal(pad2(9), "09")
+    assert.equal(pad2(23), "23")
+    assert.equal(buildTime(9, 0), "09:00")
+    assert.equal(buildTime(13, 5), "13:05")
+    assert.equal(buildTime(0, 30), "00:30")
+  })
+})
+
+describe("option builders", () => {
+  it("hourOptions: 1–12 for 12h, 0–23 for 24h", () => {
+    assert.deepEqual(hourOptions(true), [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12])
+    assert.equal(hourOptions(false).length, 24)
+    assert.equal(hourOptions(false)[0], 0)
+    assert.equal(hourOptions(false)[23], 23)
+  })
+
+  it("minuteOptions: 0–59", () => {
+    const mins = minuteOptions()
+    assert.equal(mins.length, 60)
+    assert.equal(mins[0], 0)
+    assert.equal(mins[59], 59)
+  })
+})

--- a/ui/routines/tests/time-picker-utils.test.ts
+++ b/ui/routines/tests/time-picker-utils.test.ts
@@ -9,6 +9,8 @@ import {
   pad2,
   hourOptions,
   minuteOptions,
+  centerPadding,
+  centerScrollTop,
   type Period,
 } from "../src/time-picker-utils.ts"
 
@@ -77,5 +79,40 @@ describe("option builders", () => {
     assert.equal(mins.length, 60)
     assert.equal(mins[0], 0)
     assert.equal(mins[59], 59)
+  })
+})
+
+describe("centerPadding", () => {
+  it("is half the leftover viewport", () => {
+    assert.equal(centerPadding(112, 32), 40)
+  })
+
+  it("clamps at 0 when the item is as tall or taller than the viewport", () => {
+    assert.equal(centerPadding(32, 32), 0)
+    assert.equal(centerPadding(20, 32), 0)
+  })
+})
+
+describe("centerScrollTop", () => {
+  it("lands the first (end-padded) item at scrollTop 0", () => {
+    // With centerPadding(112, 32) = 40px of top padding, the first item sits at
+    // offsetTop 40 — and centering it must require no scroll.
+    assert.equal(centerScrollTop(40, 112, 32), 0)
+  })
+
+  it("scrolls a mid-list item to the middle", () => {
+    assert.equal(centerScrollTop(400, 112, 32), 360)
+  })
+
+  it("puts the item's center on the viewport's center, for any inputs", () => {
+    for (const [offsetTop, vh, ih] of [
+      [40, 112, 32],
+      [400, 112, 32],
+      [1060, 128, 34],
+    ]) {
+      const scrollTop = centerScrollTop(offsetTop, vh, ih)
+      // item center, measured from the scrolled viewport's top, is the midpoint
+      assert.equal(offsetTop + ih / 2 - scrollTop, vh / 2)
+    }
   })
 })


### PR DESCRIPTION
## HOU-456 — Show user-friendly time picker in routine config

### Root cause
The routine schedule builder set the run time with a bare `<input type="time">`
(`ui/routines/src/schedule-picker-fields.tsx`). In the desktop app's macOS
WKWebView, `type="time"` renders as a digit-only spinner with **no pop-up
clock** (unlike Chrome). The only way to change the time was typing digits or
nudging the up/down arrow keys, which is exactly what the issue reports.

### Fix
Replace the input with a real picker:

- **Trigger**: a clock-button showing the time in the user's locale (12h for
  en, 24h for es/pt) with an always-visible `Clock` icon (no hover-gated
  affordance).
- **Popover**: scrollable **hour** and **minute** columns, plus an **AM/PM**
  column for 12-hour locales. The current value is centered on open. Selected
  state uses the standard primary pill, matching `WeekdaysPicker`.
- The stored value stays `"HH:MM"` 24-hour, so cron derivation is unchanged.
- 12h-vs-24h and the AM/PM markers come from `Intl` in the active locale; the
  column names are i18n `labels` (added to `ScheduleLabels` + en/es/pt
  `routines.json`), keeping `ui/` i18n-agnostic per the library boundary.
- Pure conversion logic split into `time-picker-utils.ts` (unit-tested) and the
  columns into `time-picker-columns.tsx` to keep every file under 200 lines.

### Affected files
- `ui/routines/src/time-picker.tsx` (new) — picker component
- `ui/routines/src/time-picker-columns.tsx` (new) — scroll columns
- `ui/routines/src/time-picker-utils.ts` (new) — pure 12h/24h + Intl helpers
- `ui/routines/tests/time-picker-utils.test.ts` (new) — unit tests
- `ui/routines/src/schedule-builder.tsx` — wire in new picker (pass locale + labels)
- `ui/routines/src/schedule-picker-fields.tsx` — drop the bare input
- `ui/routines/src/labels.ts`, `labels-default.ts` — `timePicker` labels
- `app/src/locales/{en,es,pt}/routines.json` — `schedule.timePicker` strings

### Verification
**Before:** Open an agent → Routines → New/edit routine → schedule = Daily (or
Weekly/Monthly/Custom-days). The Time field is a plain digit box; clicking it
gives no calendar/clock popup on macOS — you can only type or arrow-key.

**After:** The Time field is a button showing e.g. `9:00 AM` with a clock icon.
Clicking opens a popover with hour/minute (and AM/PM) columns; picking values
updates the time and the schedule summary, and Save persists the same cron as
before.

### Checks
- `pnpm --filter @houston-ai/routines test` — 46 pass
- `pnpm --filter @houston-ai/routines typecheck` — clean
- `cd app && pnpm tsc --noEmit` — clean
- `cd app && pnpm check-locales` — all locales in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)