### PR TITLE
fix(app): silence unsupported-engine crash reports in compat gate (HOU-460)

### DIFF
--- a/app/public/compat-gate.js
+++ b/app/public/compat-gate.js
@@ -103,6 +103,37 @@
     }
   }
 
+  // On an unsupported engine the deferred app bundle is doomed: its markdown
+  // stack ships a top-level regex *lookbehind* literal this engine can't parse
+  // ("SyntaxError: invalid group specifier name"), and the partial teardown
+  // that follows trips a null-ref cascade ("TypeError: null is not an object
+  // (evaluating 'el.dispatchEvent')", HOU-460). The Sentry SDK is injected by
+  // tauri-plugin-sentry and runs even though our bundle never evaluates, so
+  // without intervention it ships both crashes as reports for a user we are
+  // already, clearly, telling to update macOS. That is pure noise. Record ONE
+  // intentional event so we keep visibility into how many users hit an
+  // unsupported engine, then shut the SDK down so the doomed bundle stays
+  // silent. inject.js exposes the SDK as `window.Sentry`; close() flushes the
+  // event above and then disables the client, dropping every later capture.
+  // All best-effort: telemetry must never block the update message.
+  function quietTelemetryForUnsupportedEngine(win) {
+    var sentry = win && win.Sentry;
+    if (!sentry) return;
+    try {
+      if (typeof sentry.captureMessage === "function") {
+        sentry.captureMessage(
+          "Unsupported WebView engine (no regex lookbehind); showed update-macOS prompt",
+          "info",
+        );
+      }
+      if (typeof sentry.close === "function") {
+        sentry.close();
+      }
+    } catch (e) {
+      /* telemetry shutdown is best-effort; never block the update screen */
+    }
+  }
+
   function renderUnsupportedScreen(root, message) {
     // Inline styles only — the app stylesheet may not parse on the unsupported
     // engine, and explicit colors cover the viewport regardless.
@@ -264,6 +295,7 @@
       CRASH_MESSAGES: CRASH_MESSAGES,
       pickLanguage: pickLanguage,
       isModernEngineSupported: isModernEngineSupported,
+      quietTelemetryForUnsupportedEngine: quietTelemetryForUnsupportedEngine,
       renderUnsupportedScreen: renderUnsupportedScreen,
       rootHasMounted: rootHasMounted,
       captureDiagnostics: captureDiagnostics,
@@ -280,6 +312,9 @@
   //    is already painted (rootHasMounted would short-circuit anyway, but this
   //    also saves the listeners and timer).
   if (!isModernEngineSupported(RegExp)) {
+    // Silence the doomed app bundle's crash reports before it even loads (this
+    // runs ahead of the deferred bundle). HOU-460.
+    quietTelemetryForUnsupportedEngine(typeof window === "undefined" ? null : window);
     var unsupportedRoot = document.getElementById("root");
     if (unsupportedRoot) {
       renderUnsupportedScreen(unsupportedRoot, MESSAGES[pickLanguage(navigator.language)]);

--- a/app/src/lib/compat-gate.test.mjs
+++ b/app/src/lib/compat-gate.test.mjs
@@ -20,7 +20,7 @@ function loadHelpers() {
 
 // Runs the gate's browser side effect with injected globals. `module` is
 // undefined here, so the IIFE skips the export branch and executes the gate.
-function runGate({ navigatorLanguage, lookbehindThrows, hasWindow = false }) {
+function runGate({ navigatorLanguage, lookbehindThrows, sentry }) {
   const root = { innerHTML: "", childElementCount: 0, querySelector: () => null };
   const fakeDocument = {
     getElementById: (id) => (id === "root" ? root : null),
@@ -31,10 +31,11 @@ function runGate({ navigatorLanguage, lookbehindThrows, hasWindow = false }) {
         throw new SyntaxError("invalid group specifier name");
       }
     : RegExp;
-  // For tests of the Monterey path we deliberately leave `window`/`setTimeout`
-  // undefined: the gate's modern-engine branch guards on `typeof window` and
-  // bails, so we exercise the lookbehind branch in isolation.
-  const fakeWindow = hasWindow ? undefined : undefined;
+  // The lookbehind branch runs ahead of the modern-engine `typeof window`
+  // guard, so `window` can be a real object there. Pass a fake `window.Sentry`
+  // to exercise the telemetry-shutdown path; leaving it undefined matches the
+  // Monterey path where the gate bails before touching window/setTimeout.
+  const fakeWindow = sentry ? { Sentry: sentry } : undefined;
   new Function("module", "document", "navigator", "RegExp", "window", gateSource)(
     undefined,
     fakeDocument,
@@ -45,9 +46,29 @@ function runGate({ navigatorLanguage, lookbehindThrows, hasWindow = false }) {
   return root.innerHTML;
 }
 
+// Minimal stand-in for the injected `@sentry/browser` namespace. Records calls
+// so tests can assert the gate quiets telemetry, and can be told to throw so we
+// can prove the gate swallows SDK failures rather than blocking the screen.
+function makeSentrySpy({ throwOn } = {}) {
+  const calls = { captureMessage: [], close: 0 };
+  return {
+    calls,
+    captureMessage: (message, level) => {
+      if (throwOn === "captureMessage") throw new Error("captureMessage failed");
+      calls.captureMessage.push({ message, level });
+    },
+    close: () => {
+      if (throwOn === "close") throw new Error("close failed");
+      calls.close += 1;
+      return Promise.resolve(true);
+    },
+  };
+}
+
 const {
   pickLanguage,
   isModernEngineSupported,
+  quietTelemetryForUnsupportedEngine,
   MESSAGES,
   CRASH_MESSAGES,
   rootHasMounted,
@@ -128,6 +149,46 @@ test("an old engine renders a localized message into the root", () => {
 
   const en = runGate({ navigatorLanguage: "fr-FR", lookbehindThrows: true });
   assert.ok(en.includes(MESSAGES.en.title), "unknown locale falls back to English");
+});
+
+// ---- Telemetry shutdown on unsupported engines (HOU-460) --------------------
+// On macOS < 13 the app bundle fails to parse (markdown lookbehind regex) and
+// the injected Sentry SDK reports that SyntaxError plus a null-ref cascade
+// ("el.dispatchEvent") for a user we already tell to update macOS. The gate
+// shuts the SDK down so that noise never ships.
+
+test("quietTelemetryForUnsupportedEngine records one info event then closes Sentry", () => {
+  const spy = makeSentrySpy();
+  quietTelemetryForUnsupportedEngine({ Sentry: spy });
+  assert.equal(spy.calls.captureMessage.length, 1, "exactly one intentional event");
+  assert.equal(spy.calls.captureMessage[0].level, "info");
+  assert.match(spy.calls.captureMessage[0].message, /unsupported/i);
+  assert.equal(spy.calls.close, 1, "must close the client to drop the doomed bundle's crashes");
+});
+
+test("quietTelemetryForUnsupportedEngine is a safe no-op without window or Sentry", () => {
+  assert.doesNotThrow(() => quietTelemetryForUnsupportedEngine(undefined));
+  assert.doesNotThrow(() => quietTelemetryForUnsupportedEngine(null));
+  assert.doesNotThrow(() => quietTelemetryForUnsupportedEngine({}));
+  // SDK present but missing the methods (older/newer shape): still no throw.
+  assert.doesNotThrow(() => quietTelemetryForUnsupportedEngine({ Sentry: {} }));
+});
+
+test("quietTelemetryForUnsupportedEngine swallows SDK errors so the update screen still paints", () => {
+  assert.doesNotThrow(() =>
+    quietTelemetryForUnsupportedEngine({ Sentry: makeSentrySpy({ throwOn: "captureMessage" }) }),
+  );
+  assert.doesNotThrow(() =>
+    quietTelemetryForUnsupportedEngine({ Sentry: makeSentrySpy({ throwOn: "close" }) }),
+  );
+});
+
+test("the old-engine branch quiets telemetry AND still paints the update message", () => {
+  const spy = makeSentrySpy();
+  const html = runGate({ navigatorLanguage: "en-US", lookbehindThrows: true, sentry: spy });
+  assert.equal(spy.calls.close, 1, "old-engine path must close Sentry to silence the doomed bundle");
+  assert.equal(spy.calls.captureMessage.length, 1, "and record one intentional event");
+  assert.ok(html.includes(MESSAGES.en.title), "while still showing the update-macOS prompt");
 });
 
 // Guards the load order, which runGate can't model: the gate paints into #root,

--- a/knowledge-base/architecture.md
+++ b/knowledge-base/architecture.md
@@ -112,6 +112,19 @@ detects. It feature-tests lookbehind via the `RegExp` *constructor* (a literal
 would fail to parse on the very engines it targets) and, when unsupported, paints
 a localized "update macOS" message instead of a white screen.
 
+On the unsupported path the gate also shuts Sentry down. `tauri-plugin-sentry`
+injects `@sentry/browser` (exposed as `window.Sentry`) ahead of our bundle and
+forwards every envelope to the Rust SDK over IPC, so it keeps reporting even
+though our bundle never evaluates. Left alone it ships the bundle's
+`SyntaxError` *plus* the null-ref cascade it triggers
+(`TypeError: null is not an object (evaluating 'el.dispatchEvent')`, HOU-460) as
+crashes — for a user we are already, clearly, telling to update macOS. So before
+the doomed bundle loads, the gate records one intentional `info` event (to keep
+visibility into how many users land on an unsupported engine) and then calls
+`window.Sentry.close()`, which flushes that event and disables the client so the
+cascade is dropped. This runs only on the unsupported branch, so supported
+engines keep full reporting.
+
 Invariants: keep it a classic `<script defer>` (not `type=module`, never
 parser-blocking), dependency-free, and never author a lookbehind / `v`-flag
 regex *literal* in it. Defense in depth:


### PR DESCRIPTION
## Root cause

Sentry issue [HOUSTON-APP-1RD](https://houston-cd.sentry.io/issues/7543314081/) — `TypeError: null is not an object (evaluating 'el.dispatchEvent')`. Single user, **macOS 12.7.6**, release 0.4.21.

There is no `dispatchEvent` call anywhere in our source — the triage note's "null-guard the element" suggestion does not apply. The real chain is an **old-WebKit** one:

1. macOS < 13 runs WebKit < 16.4, which has no regex **lookbehind**. Our markdown stack ships a top-level lookbehind literal (`mdast-util-gfm-autolink-literal` → `streamdown`, statically imported by `@houston-ai/chat`), so the app bundle throws `SyntaxError: invalid group specifier name` at module-eval and never runs. (This is exactly what `app/public/compat-gate.js` exists to handle — it paints a localized "update macOS" screen.)
2. `tauri-plugin-sentry` injects `@sentry/browser` (as `window.Sentry`) **ahead of** our bundle and forwards every envelope to the Rust SDK over IPC. So Sentry keeps reporting even though our bundle never evaluates.
3. Result: for a user we already, clearly, tell to update macOS, Sentry still ships the bundle's `SyntaxError` **plus** the null-ref cascade it triggers (`el.dispatchEvent`). Both are pure noise. The only event on this issue is that exact case.

## Fix

In the compat gate's unsupported-engine branch — which runs **before** the doomed bundle loads and only on engines we can't support — shut the injected SDK down:

- Record **one** intentional `info` event so we keep visibility into how many users land on an unsupported engine (signal instead of noise).
- Then call `window.Sentry.close()`, which flushes that event and disables the client (`enabled = false`), so the imminent `SyntaxError` + `el.dispatchEvent` cascade are dropped instead of reported.

Everything is best-effort (feature-checked + `try/catch`) so telemetry can never block the update message. Scoped strictly to the unsupported branch — **supported engines keep full reporting**, so no real bug can be hidden.

Why not the alternatives: patching the dependency's lookbehind would let the app *run* on an engine it isn't built for (defeating the gate); a Rust `before_send` message filter would suppress `el.dispatchEvent` on *all* engines, risking hiding a genuine future bug. Closing the SDK in the gate is the precise, root-cause fix.

## Files

- `app/public/compat-gate.js` — new `quietTelemetryForUnsupportedEngine(win)` helper, called first in the unsupported branch; exported for tests.
- `app/src/lib/compat-gate.test.mjs` — tests: records one info event + closes; safe no-op without `window`/`Sentry`; swallows SDK errors; gate branch quiets telemetry while still painting the prompt. (23/23 pass.)
- `knowledge-base/architecture.md` — documents the telemetry-shutdown behavior.

## Verification

**Before (reproduce the noise):** launch release 0.4.21 on macOS 12.7.x (WebKit < 16.4). The "update macOS" screen shows, but Sentry receives two crash events: the lookbehind `SyntaxError` and `TypeError: null is not an object (evaluating 'el.dispatchEvent')`.

**After:** same launch shows the same "update macOS" screen, Sentry receives a single `info` event ("Unsupported WebView engine ...") and the client is closed, so neither the `SyntaxError` nor the `el.dispatchEvent` cascade is reported.

Run the tests:
```
cd app && node --test src/lib/compat-gate.test.mjs   # 23/23 pass
cd app && pnpm tsc --noEmit                            # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
