### PR TITLE
fix(chat): keep chat errors in place instead of carrying them to the bottom (HOU-457)

### DIFF
--- a/ui/chat/src/feed-merge.ts
+++ b/ui/chat/src/feed-merge.ts
@@ -117,17 +117,27 @@ export function mergeFeedItem(items: FeedItem[], item: FeedItem): FeedItem[] {
  * in the live feed bucket (`current`) for the same session: optimistic pushes
  * plus WS events that landed before or during the history fetch.
  *
- * Server history is authoritative for everything persisted up to load time, so
- * it is returned verbatim and only the `current` items it does NOT already
- * account for are appended after it. The match is by TURN IDENTITY, not by
- * byte-exact JSON: a live `assistant_text_streaming` (or `thinking_streaming`)
- * is the same turn as the persisted `assistant_text` (`thinking`) final and
- * must not re-append. That byte-exact mismatch was the bug behind issue #363,
- * where a routine-surfaced conversation rendered its first user prompt and AI
- * reply twice. Matching is count-based (a turn persisted once cancels exactly
- * one live copy) so a user who legitimately repeated a message keeps every
- * copy, and runs in O(history + current) via a Map rather than re-stringifying
- * on every compare.
+ * Server history is authoritative for everything it persisted, so persisted
+ * turns are taken from `history` in `history` order (a live
+ * `assistant_text_streaming` / `thinking_streaming` collapses to the persisted
+ * `assistant_text` / `thinking` final — issue #363 — and a count-based match
+ * keeps deliberate repeats, issue #381). The job is to weave back in the
+ * `current` items history does NOT account for, at the position they hold in
+ * `current` rather than dumping them at the end:
+ *
+ *   - A CLIENT-ONLY item sandwiched between two persisted turns keeps its slot.
+ *     This matters for synthetic, never-persisted feed items — chiefly the
+ *     `"Session error: …"` system message the desktop pushes on a failed turn
+ *     (and any pre-session-id `provider_error`): the engine has no row for them,
+ *     so the old tail-append re-pinned them to the bottom of the chat on every
+ *     reload, dragging a stale error below turns that came after it (HOU-457).
+ *   - A client-only item with NO persisted successor is genuine live tail (an
+ *     optimistic send still awaiting its echo, a stream mid-flight) and appends
+ *     after history, where it belongs.
+ *
+ * Persisted turns share the same chronological order in `current` and
+ * `history`, so a single forward walk of each is enough — O(history + current),
+ * Map-based, no per-compare re-stringify.
  */
 export function mergeFeedHistory(
   history: FeedItem[],
@@ -135,25 +145,48 @@ export function mergeFeedHistory(
 ): FeedItem[] {
   if (current.length === 0) return history;
 
-  const persisted = new Map<string, number>();
+  // Remaining match budget per key, drawn down as we consume `history`. Lets us
+  // tell a persisted `current` item (take it from history) from a client-only
+  // one (keep it inline), count-based so duplicates stay distinct.
+  const remaining = new Map<string, number>();
   for (const item of history) {
     const key = feedTurnKey(item);
-    persisted.set(key, (persisted.get(key) ?? 0) + 1);
+    remaining.set(key, (remaining.get(key) ?? 0) + 1);
   }
 
-  const tail: FeedItem[] = [];
+  const merged: FeedItem[] = [];
+  let hi = 0; // forward cursor into `history`
+  // Client-only items seen since the last persisted anchor, held until we know
+  // whether a persisted successor follows (→ splice in here) or not (→ tail).
+  let pendingClientOnly: FeedItem[] = [];
+
   for (const item of current) {
     const key = feedTurnKey(item);
-    const remaining = persisted.get(key) ?? 0;
-    if (remaining > 0) {
-      // Already represented by a persisted item: consume one and skip.
-      persisted.set(key, remaining - 1);
+    if ((remaining.get(key) ?? 0) > 0) {
+      // Persisted: the held client-only items had a persisted successor (this
+      // one), so they belong right before it. Then advance `history` to and
+      // including this item's match, emitting any history-only turns in between
+      // (e.g. a background routine run the live bucket never saw).
+      merged.push(...pendingClientOnly);
+      pendingClientOnly = [];
+      while (hi < history.length) {
+        const h = history[hi++];
+        merged.push(h);
+        const hk = feedTurnKey(h);
+        remaining.set(hk, (remaining.get(hk) ?? 0) - 1);
+        if (hk === key) break;
+      }
     } else {
-      tail.push(item);
+      // Client-only (or a repeat beyond history's count): hold its position.
+      pendingClientOnly.push(item);
     }
   }
 
-  return tail.length === 0 ? history : [...history, ...tail];
+  // Trailing history-only turns, then trailing client-only items (live tail).
+  while (hi < history.length) merged.push(history[hi++]);
+  merged.push(...pendingClientOnly);
+
+  return merged;
 }
 
 /**

--- a/ui/chat/test/chat-status.test.mjs
+++ b/ui/chat/test/chat-status.test.mjs
@@ -2,10 +2,15 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { deriveStatus } from "../src/chat-status.ts";
 
-test("active session stays streaming after non-streaming feed item", () => {
+test("active session shows the thinking indicator after a non-streaming feed item", () => {
+  // Mid-turn (isLoading) with a settled, non-streaming last item: the indicator
+  // is the only progress signal during silent stretches (e.g. Gemini batching
+  // its whole response after a quiet gap), so deriveStatus yields "submitted",
+  // not "streaming". See chat-status.ts. This assertion was left on the old
+  // contract when deriveStatus changed in f5ecd33.
   assert.equal(
     deriveStatus([{ feed_type: "assistant_text", data: "done so far" }], true),
-    "streaming",
+    "submitted",
   );
 });
 

--- a/ui/chat/test/feed-merge.test.mjs
+++ b/ui/chat/test/feed-merge.test.mjs
@@ -223,3 +223,88 @@ test("history reconcile: distinct turns of the same type stay distinct", () => {
     { feed_type: "assistant_text", data: "three" },
   ]);
 });
+
+// ── mergeFeedHistory: client-only items keep their position (HOU-457) ───────
+
+test("history reconcile: a client-only error stays where it first appeared", () => {
+  // The desktop pushes a synthetic `Session error: …` system_message on a
+  // failed turn; the engine never persists it. After the user retries, the new
+  // turn is persisted ABOVE nothing — the error must stay between the failed
+  // prompt and the retry, not get re-pinned to the bottom of the chat.
+  const history = [
+    { feed_type: "user_message", data: "do the thing" },
+    { feed_type: "user_message", data: "retry" },
+    { feed_type: "assistant_text", data: "done" },
+  ];
+  const current = [
+    { feed_type: "user_message", data: "do the thing" },
+    { feed_type: "system_message", data: "Session error: boom" },
+    { feed_type: "user_message", data: "retry" },
+    { feed_type: "assistant_text", data: "done" },
+  ];
+
+  assert.deepEqual(mergeFeedHistory(history, current), [
+    { feed_type: "user_message", data: "do the thing" },
+    { feed_type: "system_message", data: "Session error: boom" },
+    { feed_type: "user_message", data: "retry" },
+    { feed_type: "assistant_text", data: "done" },
+  ]);
+});
+
+test("history reconcile: a trailing client-only error appends after history", () => {
+  // The failed turn has no successor yet: the error is the latest event, so it
+  // belongs at the end — and below the persisted prompt, never above it.
+  const history = [{ feed_type: "user_message", data: "do the thing" }];
+  const current = [
+    { feed_type: "user_message", data: "do the thing" },
+    { feed_type: "system_message", data: "Session error: boom" },
+  ];
+
+  assert.deepEqual(mergeFeedHistory(history, current), [
+    { feed_type: "user_message", data: "do the thing" },
+    { feed_type: "system_message", data: "Session error: boom" },
+  ]);
+});
+
+test("history reconcile: consecutive client-only items keep their order", () => {
+  const history = [
+    { feed_type: "user_message", data: "go" },
+    { feed_type: "assistant_text", data: "ok" },
+  ];
+  const current = [
+    { feed_type: "user_message", data: "go" },
+    { feed_type: "system_message", data: "Session error: one" },
+    { feed_type: "system_message", data: "Session error: two" },
+    { feed_type: "assistant_text", data: "ok" },
+  ];
+
+  assert.deepEqual(mergeFeedHistory(history, current), [
+    { feed_type: "user_message", data: "go" },
+    { feed_type: "system_message", data: "Session error: one" },
+    { feed_type: "system_message", data: "Session error: two" },
+    { feed_type: "assistant_text", data: "ok" },
+  ]);
+});
+
+test("history reconcile: a history-only background turn weaves in around a client-only error", () => {
+  // History gained a turn the live bucket never saw (another client / a
+  // background run). The persisted turn stays in history order; the client-only
+  // error keeps its slot after its anchor.
+  const history = [
+    { feed_type: "user_message", data: "first" },
+    { feed_type: "assistant_text", data: "reply" },
+    { feed_type: "user_message", data: "second" },
+  ];
+  const current = [
+    { feed_type: "user_message", data: "first" },
+    { feed_type: "system_message", data: "Session error: boom" },
+    { feed_type: "user_message", data: "second" },
+  ];
+
+  assert.deepEqual(mergeFeedHistory(history, current), [
+    { feed_type: "user_message", data: "first" },
+    { feed_type: "system_message", data: "Session error: boom" },
+    { feed_type: "assistant_text", data: "reply" },
+    { feed_type: "user_message", data: "second" },
+  ]);
+});


### PR DESCRIPTION
## HOU-457 — Stop carrying over claudecode runtime errors

### Root cause
A failed turn surfaces a synthetic `Session error: …` system_message that the desktop pushes directly into the live feed buffer (`use-session-events.ts`). The engine never persists it — the `run_start`-bail path has no provider session id to key a `chat_feed` row on — so it is a **permanent client-only feed item**.

`mergeFeedHistory(history, current)` returned `[...history, ...unmatchedCurrentTail]`: every `current` item absent from server `history` was appended to the **tail**. On each history reload — which grows as later turns persist — the client-only error got re-appended at the very bottom, dragging a stale error **below** turns that chronologically came after it. The path is provider-agnostic, which is why it affected *every* error surfaced this way, not just claudecode runtime errors ("this also happens with other errors displayed in the chat").

### Fix
Make `mergeFeedHistory` **position-preserving**:
- A client-only item **sandwiched between persisted turns keeps its slot** (anchored after its persisted predecessor / before its persisted successor) — the issue's preferred "stays where it first appeared" behavior.
- A client-only item with **no persisted successor** is genuine live tail (optimistic send awaiting echo, stream mid-flight) and appends after history, as before.
- Persisted turns are still taken from `history` in history order, streaming variants still collapse to their persisted final, and repeats stay count-distinct — invariants from #363 / #381 preserved.

Single forward walk of each list: O(history + current), Map-based.

### Files
- `ui/chat/src/feed-merge.ts` — rewrite `mergeFeedHistory` to splice client-only items at position instead of tail-appending; updated docstring.
- `ui/chat/test/feed-merge.test.mjs` — 4 new cases (error stays in place after a retry; trailing error appends; consecutive client-only items keep order; history-only background turn weaves around a client-only error). All 15 prior cases unchanged and passing.

### Verification
**Before:** trigger a session error (e.g. a failed claudecode start), then send another message / let history reload → the `Session error: …` line jumps to the bottom of the chat, beneath newer turns.

**After:** the error stays at the turn where it occurred; new turns render below it. If it is the latest event (no later turn), it sits at the bottom as expected and never moves above the prompt.

- `ui/chat` unit suite: 19/19 pass (`node --experimental-strip-types --test test/feed-merge.test.mjs`).
- `ui/chat` typecheck: clean. `app` typecheck: clean.
- Adversarial multi-agent review (break-the-merge / client-only-source sweep / consumer-impact): 0 confirmed findings.

Also included (separate commit `165a3bc`): updated a stale `chat-status.test.mjs` assertion that asserted the old `deriveStatus` contract and failed on `main` since f5ecd33. Unrelated to the merge fix; folded in to leave the `ui/chat` suite green (63/63).

🤖 Generated with [Claude Code](https://claude.com/claude-code)