### PR TITLE
feat(chat): remove the blinking loading helmet (HOU-471)

### DIFF
--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -6,7 +6,6 @@ import { useUIStore } from "../../stores/ui";
 import { openAgentHref } from "../../lib/open-href";
 import { buildMissionBoardColumns } from "../mission-board-columns";
 import { useDetailPanelContainer } from "../shell/detail-panel-context";
-import { HoustonThinkingIndicator } from "../shell/experience-card";
 import { AgentPanelAvatar } from "../shell/agent-panel-avatar";
 import { useQueuedMessageLabels } from "../use-queued-message-labels";
 import { useAgentChatPanel } from "../use-agent-chat-panel";
@@ -160,7 +159,7 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           actions={cardActions}
           panelActions={panelActions}
           cardAvatar={source.cardAvatar}
-          thinkingIndicator={<HoustonThinkingIndicator />}
+          thinkingIndicator={panel.thinkingIndicator}
           panelAgentName={source.panelAgentName}
           panelAvatar={
             <AgentPanelAvatar
@@ -186,6 +185,7 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           renderToolResult={panel.renderToolResult}
           processLabels={panel.processLabels}
           getThinkingMessage={panel.getThinkingMessage}
+          renderMessageAvatar={panel.renderMessageAvatar}
           renderTurnSummary={panel.renderTurnSummary}
           renderLink={panel.renderLink}
           transformContent={panel.transformContent}

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -185,7 +185,7 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           renderToolResult={panel.renderToolResult}
           processLabels={panel.processLabels}
           getThinkingMessage={panel.getThinkingMessage}
-          renderMessageAvatar={panel.renderMessageAvatar}
+          endOfTurnIndicator={panel.endOfTurnIndicator}
           renderTurnSummary={panel.renderTurnSummary}
           renderLink={panel.renderLink}
           transformContent={panel.transformContent}

--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -6,7 +6,6 @@ import { useUIStore } from "../../stores/ui";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { openAgentHref } from "../../lib/open-href";
 import { useDetailPanelContainer } from "../shell/detail-panel-context";
-import { HoustonThinkingIndicator } from "../shell/experience-card";
 import { AgentPanelAvatar } from "../shell/agent-panel-avatar";
 import { useAgentChatPanel } from "../use-agent-chat-panel";
 import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
@@ -134,7 +133,7 @@ export function MissionControlArchived({
           onOpenLink={(url) => activeAgent && openAgentHref(url, activeAgent.folderPath)}
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
-          thinkingIndicator={<HoustonThinkingIndicator />}
+          thinkingIndicator={panel.thinkingIndicator}
           panelAgentName={activeAgent?.name ?? selectedItem?.subtitle}
           panelAvatar={<AgentPanelAvatar color={activeAgent?.color} running={false} />}
           cardLabels={{
@@ -155,6 +154,7 @@ export function MissionControlArchived({
           renderToolResult={panel.renderToolResult}
           processLabels={panel.processLabels}
           getThinkingMessage={panel.getThinkingMessage}
+          renderMessageAvatar={panel.renderMessageAvatar}
           renderTurnSummary={panel.renderTurnSummary}
           renderLink={panel.renderLink}
           transformContent={panel.transformContent}

--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -154,7 +154,7 @@ export function MissionControlArchived({
           renderToolResult={panel.renderToolResult}
           processLabels={panel.processLabels}
           getThinkingMessage={panel.getThinkingMessage}
-          renderMessageAvatar={panel.renderMessageAvatar}
+          endOfTurnIndicator={panel.endOfTurnIndicator}
           renderTurnSummary={panel.renderTurnSummary}
           renderLink={panel.renderLink}
           transformContent={panel.transformContent}

--- a/app/src/components/shell/agent-avatar.tsx
+++ b/app/src/components/shell/agent-avatar.tsx
@@ -132,12 +132,3 @@ export function HoustonLogo({ size = 20, className = "" }: { size?: number; clas
     </svg>
   );
 }
-
-/** Pulsing Houston logo — universal loading indicator for all agents */
-export function HoustonThinkingIndicator() {
-  return (
-    <div className="py-2 flex items-center gap-2">
-      <HoustonLogo size={20} className="animate-pulse" />
-    </div>
-  );
-}

--- a/app/src/components/shell/experience-card.tsx
+++ b/app/src/components/shell/experience-card.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import type { AgentConfig, StoreListing } from "../../lib/types";
 import { SkillCard } from "../skill-card";
 import { AgentAvatar } from "./agent-avatar";
-export { AgentAvatar, HoustonLogo, HoustonThinkingIndicator, getAgentIcon, getAgentIconColor, getHoustonLogo, isLightColor } from "./agent-avatar";
+export { AgentAvatar, HoustonLogo, getAgentIcon, getAgentIconColor, getHoustonLogo, isLightColor } from "./agent-avatar";
 
 interface AgentCardProps {
   config: AgentConfig;

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -13,7 +13,6 @@ import { openAgentHref } from "../../lib/open-href";
 import { selectArchived } from "../../lib/mission-selection";
 import type { TabProps } from "../../lib/types";
 import { useDetailPanelContainer } from "../shell/detail-panel-context";
-import { HoustonThinkingIndicator } from "../shell/experience-card";
 import { AgentCardAvatar } from "../shell/agent-card-avatar";
 import { AgentPanelAvatar } from "../shell/agent-panel-avatar";
 import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
@@ -152,7 +151,7 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           cardAvatar={<AgentCardAvatar color={agent.color} />}
-          thinkingIndicator={<HoustonThinkingIndicator />}
+          thinkingIndicator={panel.thinkingIndicator}
           panelAgentName={agent.name}
           panelAvatar={<AgentPanelAvatar color={agent.color} running={false} />}
           cardLabels={{
@@ -173,6 +172,7 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
           renderToolResult={panel.renderToolResult}
           processLabels={panel.processLabels}
           getThinkingMessage={panel.getThinkingMessage}
+          renderMessageAvatar={panel.renderMessageAvatar}
           renderTurnSummary={panel.renderTurnSummary}
           renderLink={panel.renderLink}
           transformContent={panel.transformContent}

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -172,7 +172,7 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
           renderToolResult={panel.renderToolResult}
           processLabels={panel.processLabels}
           getThinkingMessage={panel.getThinkingMessage}
-          renderMessageAvatar={panel.renderMessageAvatar}
+          endOfTurnIndicator={panel.endOfTurnIndicator}
           renderTurnSummary={panel.renderTurnSummary}
           renderLink={panel.renderLink}
           transformContent={panel.transformContent}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -145,6 +145,10 @@ interface AgentChatPanelProps {
   renderToolResult: ChatPanelProps["renderToolResult"];
   processLabels: ChatPanelProps["processLabels"];
   getThinkingMessage: ChatPanelProps["getThinkingMessage"];
+  /** Calm "Mission in progress..." line shown while a turn is in flight. */
+  thinkingIndicator: ChatPanelProps["thinkingIndicator"];
+  /** Static Houston helmet rendered at the end of each agent reply. */
+  renderMessageAvatar: ChatPanelProps["renderMessageAvatar"];
   renderTurnSummary: ChatPanelProps["renderTurnSummary"];
   renderSystemMessage: AIBoardProps["renderSystemMessage"];
   mapFeedItems: AIBoardProps["mapFeedItems"];
@@ -167,7 +171,8 @@ export function useAgentChatPanel({
   onSelectSession,
 }: UseAgentChatPanelArgs): AgentChatPanelProps {
   const { t } = useTranslation(["board", "chat"]);
-  const { processLabels, getThinkingMessage } = useChatDisplayLabels();
+  const { processLabels, getThinkingMessage, thinkingIndicator, renderMessageAvatar } =
+    useChatDisplayLabels();
   const queryClient = useQueryClient();
   const addToast = useUIStore((s) => s.addToast);
   const pushFeedItem = useFeedStore((s) => s.pushFeedItem);
@@ -937,6 +942,8 @@ export function useAgentChatPanel({
     renderToolResult,
     processLabels,
     getThinkingMessage,
+    thinkingIndicator,
+    renderMessageAvatar,
     renderTurnSummary,
     renderSystemMessage,
     mapFeedItems,

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -147,8 +147,8 @@ interface AgentChatPanelProps {
   getThinkingMessage: ChatPanelProps["getThinkingMessage"];
   /** Calm "Mission in progress..." line shown while a turn is in flight. */
   thinkingIndicator: ChatPanelProps["thinkingIndicator"];
-  /** Static Houston helmet rendered at the end of each agent reply. */
-  renderMessageAvatar: ChatPanelProps["renderMessageAvatar"];
+  /** Static Houston helmet shown after the agent's reply when it settles. */
+  endOfTurnIndicator: ChatPanelProps["endOfTurnIndicator"];
   renderTurnSummary: ChatPanelProps["renderTurnSummary"];
   renderSystemMessage: AIBoardProps["renderSystemMessage"];
   mapFeedItems: AIBoardProps["mapFeedItems"];
@@ -171,7 +171,7 @@ export function useAgentChatPanel({
   onSelectSession,
 }: UseAgentChatPanelArgs): AgentChatPanelProps {
   const { t } = useTranslation(["board", "chat"]);
-  const { processLabels, getThinkingMessage, thinkingIndicator, renderMessageAvatar } =
+  const { processLabels, getThinkingMessage, thinkingIndicator, endOfTurnIndicator } =
     useChatDisplayLabels();
   const queryClient = useQueryClient();
   const addToast = useUIStore((s) => s.addToast);
@@ -943,7 +943,7 @@ export function useAgentChatPanel({
     processLabels,
     getThinkingMessage,
     thinkingIndicator,
-    renderMessageAvatar,
+    endOfTurnIndicator,
     renderTurnSummary,
     renderSystemMessage,
     mapFeedItems,

--- a/app/src/components/use-chat-display-labels.tsx
+++ b/app/src/components/use-chat-display-labels.tsx
@@ -1,11 +1,15 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Shimmer } from "@houston-ai/chat";
-import type { ChatPanelProps } from "@houston-ai/chat";
+import type { ChatMessage, ChatPanelProps } from "@houston-ai/chat";
+import { HoustonLogo } from "./shell/experience-card";
 
 export function useChatDisplayLabels(): Pick<
   ChatPanelProps,
-  "processLabels" | "getThinkingMessage"
+  | "processLabels"
+  | "getThinkingMessage"
+  | "thinkingIndicator"
+  | "renderMessageAvatar"
 > {
   const { t } = useTranslation("chat");
   const processLabels = useMemo(
@@ -29,5 +33,32 @@ export function useChatDisplayLabels(): Pick<
     [t],
   );
 
-  return { processLabels, getThinkingMessage };
+  // HOU-471: while a turn is in flight, show only the calm "Mission in
+  // progress..." line. The pulsing helmet that used to load here is gone; the
+  // helmet now appears static at the END of the agent's reply (below).
+  const thinkingIndicator = useMemo(
+    () => (
+      <div className="py-1">
+        <Shimmer duration={2}>{t("process.active")}</Shimmer>
+      </div>
+    ),
+    [t],
+  );
+
+  // HOU-471: a static (never-blinking) Houston helmet tucked at the end of each
+  // agent reply, so the helmet reads as a signature rather than a loader.
+  const renderMessageAvatar = useCallback(
+    (msg: ChatMessage) =>
+      msg.from === "assistant" ? (
+        <HoustonLogo size={16} className="text-muted-foreground/70" />
+      ) : undefined,
+    [],
+  );
+
+  return {
+    processLabels,
+    getThinkingMessage,
+    thinkingIndicator,
+    renderMessageAvatar,
+  };
 }

--- a/app/src/components/use-chat-display-labels.tsx
+++ b/app/src/components/use-chat-display-labels.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
-import { Shimmer } from "@houston-ai/chat";
-import type { ChatMessage, ChatPanelProps } from "@houston-ai/chat";
+import { ChatStatusLine, Shimmer } from "@houston-ai/chat";
+import type { ChatPanelProps } from "@houston-ai/chat";
 import { HoustonLogo } from "./shell/experience-card";
 
 export function useChatDisplayLabels(): Pick<
@@ -9,7 +9,7 @@ export function useChatDisplayLabels(): Pick<
   | "processLabels"
   | "getThinkingMessage"
   | "thinkingIndicator"
-  | "renderMessageAvatar"
+  | "endOfTurnIndicator"
 > {
   const { t } = useTranslation("chat");
   const processLabels = useMemo(
@@ -33,25 +33,27 @@ export function useChatDisplayLabels(): Pick<
     [t],
   );
 
-  // HOU-471: while a turn is in flight, show only the calm "Mission in
-  // progress..." line. The pulsing helmet that used to load here is gone; the
-  // helmet now appears static at the END of the agent's reply (below).
+  // HOU-471: while a turn is in flight, show the calm "Mission in progress..."
+  // line, keeping the small helmet to its left (same identity as the
+  // mission-log header). The pulsing helmet loader that used to sit here is gone.
   const thinkingIndicator = useMemo(
     () => (
-      <div className="py-1">
-        <Shimmer duration={2}>{t("process.active")}</Shimmer>
+      <div className="py-1 text-muted-foreground/65">
+        <ChatStatusLine label={t("process.active")} active />
       </div>
     ),
     [t],
   );
 
-  // HOU-471: a static (never-blinking) Houston helmet tucked at the end of each
-  // agent reply, so the helmet reads as a signature rather than a loader.
-  const renderMessageAvatar = useCallback(
-    (msg: ChatMessage) =>
-      msg.from === "assistant" ? (
-        <HoustonLogo size={16} className="text-muted-foreground/70" />
-      ) : undefined,
+  // HOU-471: once the turn settles, the agent's reply ends with a static
+  // (never-blinking) Houston helmet, in the same size and spot the old loader
+  // used; only the animation is gone.
+  const endOfTurnIndicator = useMemo(
+    () => (
+      <div className="py-2 flex items-center">
+        <HoustonLogo size={20} />
+      </div>
+    ),
     [],
   );
 
@@ -59,6 +61,6 @@ export function useChatDisplayLabels(): Pick<
     processLabels,
     getThinkingMessage,
     thinkingIndicator,
-    renderMessageAvatar,
+    endOfTurnIndicator,
   };
 }

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -94,9 +94,9 @@ export interface AIBoardProps {
   renderTurnSummary?: import("@houston-ai/chat").ChatPanelProps["renderTurnSummary"]
   /** Custom renderer for system messages. Forwarded to ChatPanel. */
   renderSystemMessage?: import("@houston-ai/chat").ChatPanelProps["renderSystemMessage"]
-  /** Avatar shown at the end of each chat message (e.g. a static Houston
-   *  helmet on agent replies). Forwarded to ChatPanel. */
-  renderMessageAvatar?: import("@houston-ai/chat").ChatPanelProps["renderMessageAvatar"]
+  /** Static glyph shown after the agent's reply once the turn settles
+   *  (e.g. a non-blinking Houston helmet). Forwarded to ChatPanel. */
+  endOfTurnIndicator?: import("@houston-ai/chat").ChatPanelProps["endOfTurnIndicator"]
   /** Map active feed items before rendering. */
   mapFeedItems?: (ctx: { sessionKey: string; items: FeedItem[] }) => FeedItem[]
   /** Node rendered after the last chat message. */
@@ -265,7 +265,7 @@ export function AIBoard({
   toolLabels,
   renderTurnSummary,
   renderSystemMessage,
-  renderMessageAvatar,
+  endOfTurnIndicator,
   mapFeedItems,
   afterMessages,
   renderUserMessage,
@@ -615,7 +615,7 @@ export function AIBoard({
           toolLabels={toolLabels}
           renderTurnSummary={renderTurnSummary}
           renderSystemMessage={renderSystemMessage}
-          renderMessageAvatar={renderMessageAvatar}
+          endOfTurnIndicator={endOfTurnIndicator}
           renderUserMessage={renderUserMessage}
           afterMessages={renderedAfterMessages}
           onNotice={onNotice}

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -94,6 +94,9 @@ export interface AIBoardProps {
   renderTurnSummary?: import("@houston-ai/chat").ChatPanelProps["renderTurnSummary"]
   /** Custom renderer for system messages. Forwarded to ChatPanel. */
   renderSystemMessage?: import("@houston-ai/chat").ChatPanelProps["renderSystemMessage"]
+  /** Avatar shown at the end of each chat message (e.g. a static Houston
+   *  helmet on agent replies). Forwarded to ChatPanel. */
+  renderMessageAvatar?: import("@houston-ai/chat").ChatPanelProps["renderMessageAvatar"]
   /** Map active feed items before rendering. */
   mapFeedItems?: (ctx: { sessionKey: string; items: FeedItem[] }) => FeedItem[]
   /** Node rendered after the last chat message. */
@@ -262,6 +265,7 @@ export function AIBoard({
   toolLabels,
   renderTurnSummary,
   renderSystemMessage,
+  renderMessageAvatar,
   mapFeedItems,
   afterMessages,
   renderUserMessage,
@@ -611,6 +615,7 @@ export function AIBoard({
           toolLabels={toolLabels}
           renderTurnSummary={renderTurnSummary}
           renderSystemMessage={renderSystemMessage}
+          renderMessageAvatar={renderMessageAvatar}
           renderUserMessage={renderUserMessage}
           afterMessages={renderedAfterMessages}
           onNotice={onNotice}

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -31,6 +31,9 @@ export interface ChatMessagesProps {
   messages: ChatMessage[];
   status: "ready" | "streaming" | "submitted";
   thinkingIndicator: ReactNode;
+  /** Static glyph rendered after the agent's reply once the turn settles
+   *  (e.g. a non-blinking Houston helmet). Omitted → nothing renders. */
+  endOfTurnIndicator?: ReactNode;
   transformContent?: (content: string) => {
     content: string;
     extra?: ReactNode;
@@ -68,6 +71,7 @@ export function ChatMessages({
   messages,
   status,
   thinkingIndicator,
+  endOfTurnIndicator,
   transformContent,
   toolLabels,
   isSpecialTool,
@@ -95,6 +99,14 @@ export function ChatMessages({
   // active process block is already surfacing it (see the helper) — otherwise
   // the two would duplicate while the agent runs tools.
   const showThinkingIndicator = shouldShowThinkingIndicator(displayItems, status);
+  // HOU-471: once the turn settles, the agent's reply ends with a static
+  // (never-blinking) helmet — same slot the loader used. The consumer supplies
+  // the glyph, so it stays opt-in per surface.
+  const lastMessage = messages[messages.length - 1];
+  const showEndOfTurnIndicator =
+    status === "ready" &&
+    lastMessage?.from === "assistant" &&
+    Boolean(endOfTurnIndicator);
   return (
     <Conversation className="flex-1 min-h-0">
       <ConversationAutoScroll status={status} />
@@ -198,6 +210,13 @@ export function ChatMessages({
           <Message from="assistant">
             <MessageContent>
               {thinkingIndicator}
+            </MessageContent>
+          </Message>
+        )}
+        {showEndOfTurnIndicator && (
+          <Message from="assistant">
+            <MessageContent>
+              {endOfTurnIndicator}
             </MessageContent>
           </Message>
         )}

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -22,7 +22,7 @@ import type { ReasoningTriggerProps } from "./ai-elements/reasoning";
 import type { ToolsAndCardsProps } from "./chat-helpers";
 import { ChatProcessBlock } from "./chat-process-block";
 import type { ChatProcessLabels } from "./chat-process-block";
-import { getChatDisplayItems } from "./chat-process-groups";
+import { getChatDisplayItems, shouldShowThinkingIndicator } from "./chat-process-groups";
 import { computeTurnEndSummary } from "./turn-tools";
 import type { TurnEndSummary } from "./turn-tools";
 import type { ChatMessage } from "./feed-to-messages";
@@ -91,6 +91,10 @@ export function ChatMessages({
     () => getChatDisplayItems(messages, status),
     [messages, status],
   );
+  // HOU-471: show the standalone "Mission in progress..." line only when no
+  // active process block is already surfacing it (see the helper) — otherwise
+  // the two would duplicate while the agent runs tools.
+  const showThinkingIndicator = shouldShowThinkingIndicator(displayItems, status);
   return (
     <Conversation className="flex-1 min-h-0">
       <ConversationAutoScroll status={status} />
@@ -190,7 +194,7 @@ export function ChatMessages({
             </Message>
           );
         })}
-        {status === "submitted" && (
+        {showThinkingIndicator && (
           <Message from="assistant">
             <MessageContent>
               {thinkingIndicator}

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -61,6 +61,9 @@ export interface ChatPanelProps {
   canSendEmpty?: boolean;
   status?: ChatStatus;
   thinkingIndicator?: ReactNode;
+  /** Static glyph shown after the agent's reply once the turn settles
+   *  (e.g. a non-blinking Houston helmet). Opt-in per surface. */
+  endOfTurnIndicator?: ReactNode;
   transformContent?: (content: string) => { content: string; extra?: ReactNode };
   toolLabels?: ToolsAndCardsProps["toolLabels"];
   isSpecialTool?: ToolsAndCardsProps["isSpecialTool"];

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -33,6 +33,7 @@ export function ChatPanel({
   emptyState,
   status: statusProp,
   thinkingIndicator,
+  endOfTurnIndicator,
   transformContent,
   toolLabels,
   isSpecialTool,
@@ -144,6 +145,7 @@ export function ChatPanel({
           messages={messages}
           status={status}
           thinkingIndicator={thinkingIndicator ?? <DefaultThinkingIndicator />}
+          endOfTurnIndicator={endOfTurnIndicator}
           transformContent={transformContent}
           toolLabels={toolLabels}
           isSpecialTool={isSpecialTool}

--- a/ui/chat/src/chat-process-groups.ts
+++ b/ui/chat/src/chat-process-groups.ts
@@ -99,3 +99,19 @@ export function getChatDisplayItems(
   flushProcess(status !== "ready", true);
   return items;
 }
+
+/**
+ * HOU-471: the standalone "Mission in progress..." indicator is the only
+ * in-flight signal during the gap before the agent's first output. Once an
+ * active process block is on screen it ALREADY surfaces "Mission in progress:
+ * <action>", so the standalone line would duplicate it. Show the indicator
+ * only while a turn is `submitted` AND no active process block is trailing.
+ */
+export function shouldShowThinkingIndicator(
+  items: ChatDisplayItem[],
+  status: ChatStatus,
+): boolean {
+  if (status !== "submitted") return false;
+  const last = items[items.length - 1];
+  return !(last?.kind === "process" && last.isActive);
+}

--- a/ui/chat/tests/chat-thinking-indicator.test.ts
+++ b/ui/chat/tests/chat-thinking-indicator.test.ts
@@ -1,0 +1,68 @@
+import { equal } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  shouldShowThinkingIndicator,
+  type ChatDisplayItem,
+} from "../src/chat-process-groups.ts";
+import type { ChatMessage } from "../src/feed-to-messages.ts";
+
+function message(from: ChatMessage["from"]): ChatDisplayItem {
+  return {
+    kind: "message",
+    sourceIndex: 0,
+    message: {
+      key: "m",
+      from,
+      content: "",
+      isStreaming: false,
+      tools: [],
+      fileChanges: [],
+    },
+  };
+}
+
+function process(isActive: boolean): ChatDisplayItem {
+  return {
+    kind: "process",
+    key: "p",
+    segments: [],
+    isActive,
+    isTrailing: true,
+    sourceIndex: 0,
+  };
+}
+
+describe("shouldShowThinkingIndicator (HOU-471)", () => {
+  it("hides the indicator when the turn is settled", () => {
+    equal(shouldShowThinkingIndicator([message("assistant")], "ready"), false);
+  });
+
+  it("hides the indicator while the answer streams (the text is the signal)", () => {
+    equal(shouldShowThinkingIndicator([message("assistant")], "streaming"), false);
+  });
+
+  it("shows the indicator in the gap after sending, before any output", () => {
+    // Just the user's message on the feed, waiting on the first token.
+    equal(shouldShowThinkingIndicator([message("user")], "submitted"), true);
+  });
+
+  it("shows the indicator on a brand-new chat with no items yet", () => {
+    equal(shouldShowThinkingIndicator([], "submitted"), true);
+  });
+
+  it("suppresses the indicator while an active process block surfaces progress", () => {
+    // The mission-log header already reads "Mission in progress: <action>", so
+    // a second standalone line would duplicate it.
+    equal(
+      shouldShowThinkingIndicator([message("user"), process(true)], "submitted"),
+      false,
+    );
+  });
+
+  it("shows the indicator again once the trailing process block has settled", () => {
+    equal(
+      shouldShowThinkingIndicator([process(false)], "submitted"),
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## HOU-471 — Remove loading helmet

Closes HOU-471.

### What the issue asked
- [x] While a turn is in flight, show only the "Mission in progress..." message (keep its small helmet), without the big blinking helmet.
- [x] Show the helmet at the end of the agent's message, static (no blink).

### Before
The chat loading state rendered `HoustonThinkingIndicator` — a 20px Houston helmet with `animate-pulse` (the big "blinking loading helmet") shown below the agent's message while a turn was submitted. It vanished once the reply landed.

### After
- **In-flight line:** the loader is replaced by the calm "Mission in progress..." line, rendered through `ChatStatusLine` so it keeps the small helmet to its left (same identity as the mission-log header). No blinking.
- **End-of-turn helmet:** once the turn settles, the agent's reply ends with a *static* 20px Houston helmet, rendered in the same row/size/spot the old loader used (just without the pulse). It is wired through a new opt-in `endOfTurnIndicator` prop, so only the desktop chat surfaces show it (mobile and the onboarding demos already used plain "Thinking..." text and never had the loader).
- **No duplicate line:** while the agent runs tools the mission-log header already reads "Mission in progress: <action>", so the standalone line is suppressed then (new `shouldShowThinkingIndicator` helper, unit-tested). It still shows in the gap right after sending and on a fresh chat.
- Deleted the now-unused `HoustonThinkingIndicator`.

> Note: the static end-of-turn helmet shows once, below the latest settled agent reply (matching where the single blinking loader used to sit), not after every historical reply. Easy to switch to per-message if preferred.

### Verify the fix
1. `cargo build -p houston-engine-server` then `pnpm tauri dev` (frontend-only change; keep the sidecar fresh).
2. Pick an agent and send a message:
   - Right after sending / while running tools: the "Mission in progress..." line shows with its small helmet, no blinking, no big helmet.
   - When the reply lands: a static 20px Houston helmet sits in its own row below the reply, never blinking.
3. Automated: `pnpm typecheck`, `cd app && pnpm check-locales`, `cd ui/chat && pnpm test` (28 passing, incl. 6 new `shouldShowThinkingIndicator` cases).

### Affected files
- `ui/chat/src/chat-process-groups.ts` — `shouldShowThinkingIndicator` helper
- `ui/chat/src/chat-messages.tsx` — gate the in-flight line; render `endOfTurnIndicator` when settled
- `ui/chat/src/chat-panel.tsx`, `chat-panel-types.ts` — new `endOfTurnIndicator` prop
- `ui/chat/tests/chat-thinking-indicator.test.ts` — unit tests
- `ui/board/src/ai-board.tsx` — forward `endOfTurnIndicator`
- `app/src/components/use-chat-display-labels.tsx` — "Mission in progress..." via ChatStatusLine + static helmet
- `app/src/components/use-agent-chat-panel.tsx` — thread both through the panel bundle
- `app/src/components/board/mission-board.tsx`, `board/mission-control-archived.tsx`, `tabs/archived-tab.tsx` — consume them, drop the blinking indicator
- `app/src/components/shell/agent-avatar.tsx`, `shell/experience-card.tsx` — delete dead `HoustonThinkingIndicator`

🤖 Generated with [Claude Code](https://claude.com/claude-code)