### PR TITLE
fix(engine): stop claude-code snapshot re-emitting streamed tool calls (HOU-472)

### DIFF
--- a/engine/houston-terminal-manager/src/parser.rs
+++ b/engine/houston-terminal-manager/src/parser.rs
@@ -335,23 +335,19 @@ fn parse_assistant_event(
                     }
                 }
             }
-            ContentBlock::Thinking { thinking } => {
-                if let Some(t) = thinking {
-                    if !t.is_empty() {
-                        if is_partial {
-                            items.push(FeedItem::ThinkingStreaming(t));
-                        } else {
-                            items.push(FeedItem::Thinking(t));
-                        }
-                    }
-                }
-            }
-            ContentBlock::ToolUse { name, input, .. } => {
-                items.push(FeedItem::ToolCall {
-                    name: name.unwrap_or_else(|| "unknown".into()),
-                    input: input.unwrap_or(serde_json::Value::Null),
-                });
-            }
+            // Thinking and tool_use are already delivered live by the streaming
+            // path (`StreamAccumulator::handle`): with `--include-partial-messages`
+            // always on (see `claude_command.rs`), every tool_use streams as a
+            // content_block_start (null input) + content_block_stop (full input)
+            // pair, and every thinking block is finalized at content_block_stop.
+            // This non-partial `assistant` event is a COMPLETE SNAPSHOT of the
+            // turn, so re-emitting those blocks here duplicated every tool call
+            // (and would duplicate every thinking block) in the feed — HOU-472.
+            // The committed final text (handled above) is the one thing the
+            // streaming path never emits, so it stays. tool_result keeps its own
+            // arm below: it is not a streamed content_block — Anthropic delivers
+            // tool results as separate user-role events (`parse_user_event`).
+            ContentBlock::Thinking { .. } | ContentBlock::ToolUse { .. } => {}
             ContentBlock::ToolResult {
                 content, is_error, ..
             } => {
@@ -509,14 +505,73 @@ mod tests {
     }
 
     #[test]
-    fn parse_tool_use() {
-        let line = r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Read","input":{"path":"/foo"}}]}}"#;
+    fn assistant_snapshot_does_not_re_emit_tool_use() {
+        // A non-partial `assistant` message is a complete snapshot of a turn
+        // whose tool calls already streamed as content_block_start/stop pairs.
+        // It must NOT re-emit the tool_use, or every tool call doubles in the
+        // feed (HOU-472). Text in the same snapshot is still committed.
+        let line = r#"{"type":"assistant","message":{"content":[{"type":"text","text":"reading"},{"type":"tool_use","id":"t1","name":"Read","input":{"path":"/foo"}}]}}"#;
         let items = parse_event(line, &mut acc());
-        assert_eq!(items.len(), 1);
-        match &items[0] {
-            FeedItem::ToolCall { name, .. } => assert_eq!(name, "Read"),
-            other => panic!("expected ToolCall, got {other:?}"),
+        assert_eq!(
+            items.len(),
+            1,
+            "snapshot should emit only its text, not the tool_use"
+        );
+        assert!(matches!(&items[0], FeedItem::AssistantText(t) if t == "reading"));
+    }
+
+    #[test]
+    fn streamed_tool_then_snapshot_yields_single_tool_call() {
+        // Regression for HOU-472: claude-code (`--include-partial-messages`)
+        // emits each tool use THREE times — content_block_start (null input),
+        // content_block_stop (full input), and again inside the final non-partial
+        // `assistant` snapshot. The snapshot copy must be dropped so the feed
+        // carries exactly the start(null) + stop(real) pair the frontend dedups
+        // into one row (instead of a third tool_call that renders a duplicate).
+        let mut a = acc();
+        let mut tool_calls = 0;
+        let lines = [
+            r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"t1","name":"Read","input":{}}},"session_id":"s1","uuid":"u1"}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"file_path\":\"/foo\"}"}},"session_id":"s1","uuid":"u2"}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"s1","uuid":"u3"}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Read","input":{"file_path":"/foo"}}]}}"#,
+        ];
+        for line in lines {
+            for item in parse_event(line, &mut a) {
+                if matches!(item, FeedItem::ToolCall { .. }) {
+                    tool_calls += 1;
+                }
+            }
         }
+        // start(null) + stop(real) = 2; the snapshot must add nothing.
+        assert_eq!(tool_calls, 2, "snapshot re-emit must not add a third tool_call");
+    }
+
+    #[test]
+    fn streamed_thinking_then_snapshot_yields_single_thinking() {
+        // Same snapshot redundancy as tool calls: a thinking block streams via
+        // thinking_delta and is finalized at content_block_stop, then reappears
+        // in the non-partial `assistant` snapshot. The snapshot copy is dropped
+        // so reasoning is not duplicated in the mission log (HOU-472).
+        let mut a = acc();
+        let mut thinking = 0;
+        let lines = [
+            r#"{"type":"stream_event","event":{"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}},"session_id":"s1","uuid":"u1"}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"hmm"}},"session_id":"s1","uuid":"u2"}"#,
+            r#"{"type":"stream_event","event":{"type":"content_block_stop","index":0},"session_id":"s1","uuid":"u3"}"#,
+            r#"{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"hmm"}]}}"#,
+        ];
+        for line in lines {
+            for item in parse_event(line, &mut a) {
+                if matches!(item, FeedItem::Thinking(_)) {
+                    thinking += 1;
+                }
+            }
+        }
+        assert_eq!(
+            thinking, 1,
+            "snapshot re-emit must not add a second thinking block"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## HOU-472 — duplicated tool calls in mission log

Every tool call in the mission log rendered **twice** — once as "Reading file" (active, no result) and once as "Read file" (done). Confirmed in the dev DB: the persisted `chat_feed` carries each Anthropic tool call as `null, real, real` instead of `null, real`.

### Root cause

claude-code's `stream-json` output (`--include-partial-messages`, always passed in `claude_command.rs`) delivers each tool use to the feed **three** times:

| source | parser path | emits |
|---|---|---|
| `content_block_start` | `StreamAccumulator::handle` | `tool_call(null)` |
| `content_block_stop` | `StreamAccumulator::handle` | `tool_call(real)` |
| final non-partial `assistant` message | `parse_assistant_event` | `tool_call(real)` ← **duplicate** |

The final `assistant` event is a *complete snapshot* of the turn. The frontend dedup (`feed-to-messages` / `feed-merge`) only collapses the `null → real` pair, so the snapshot's third copy becomes a second row. (Thinking blocks have the identical latent bug: they are finalized at `content_block_stop` and then restated in the snapshot.)

### Fix

`parse_assistant_event` no longer re-emits the snapshot's `tool_use` or `thinking` blocks — both are already delivered live by the streaming path. It keeps:
- the **committed final text** (the one thing `content_block_stop` never emits), and
- `tool_result` (not a streamed content_block — Anthropic delivers tool results as separate user-role events via `parse_user_event`).

`parse_event` has a single caller (`session_io.rs`, the streaming NDJSON loop), and the `--include-partial-messages` flag is always on, so the streamed pair is guaranteed — dropping the snapshot copy cannot lose a tool call.

### Files
- `engine/houston-terminal-manager/src/parser.rs` — drop snapshot tool_use/thinking re-emit; 3 new regression tests.

### Tests
- `streamed_tool_then_snapshot_yields_single_tool_call` — full `content_block_start/stop` + snapshot sequence ⇒ exactly 2 `tool_call`s (null+real), snapshot adds none.
- `streamed_thinking_then_snapshot_yields_single_thinking` — same for thinking.
- `assistant_snapshot_does_not_re_emit_tool_use` — snapshot with text+tool_use ⇒ only the text.
- `cargo test -p houston-terminal-manager` → 259 passed; `cargo build --workspace` clean.

### Verify

**Before (reproduce):** in a dev build on `main`, open an agent on the Anthropic provider and have it read a few files / run commands. The mission log shows each action twice ("Reading file …" + "Read file …"). Or inspect the DB:
```
sqlite3 ~/.dev-houston/db/houston.db \
  "SELECT a.id FROM chat_feed a JOIN chat_feed b ON b.id=a.id+1 \
   AND b.feed_type=a.feed_type AND b.data_json=a.data_json WHERE a.feed_type='tool_call';"
```
returns adjacent duplicate rows.

**After (fix):** rebuild the engine (`cargo build -p houston-engine-server`, restart `pnpm tauri dev`) and start a **new** conversation. Each tool call appears once, transitioning in place from "Reading file" → "Read file". The duplicate-detection query above returns no rows for the new turns.

> Scope note: this fixes new turns at the source. Conversations already recorded before the fix keep their pre-fix duplicate rows in history (cosmetic; the persisted feed is append-only and not rewritten).

🤖 Generated with [Claude Code](https://claude.com/claude-code)