### PR TITLE
chore(engine): stop auto-connecting to the mobile tunnel on boot (HOU-474)

### DIFF
--- a/engine/houston-engine-server/src/main.rs
+++ b/engine/houston-engine-server/src/main.rs
@@ -118,38 +118,21 @@ async fn main() {
         actual
     );
 
-    // Tunnel identity: cached in `<home>/tunnel.json`, or allocated on
-    // first boot via `POST {relay}/allocate`. Failure is non-fatal — the
-    // engine keeps serving local traffic; mobile companion + push stay
-    // dormant until the next boot succeeds.
-    let tunnel_identity = match houston_tunnel::ensure(&cfg.home_dir, &cfg.tunnel_url).await {
-        Ok(identity) => {
-            tracing::info!(
-                target: "houston_tunnel",
-                tunnel_id = %identity.tunnel_id,
-                host = %identity.public_host,
-                "tunnel identity loaded"
-            );
-            Some(identity)
-        }
-        Err(e) => {
-            tracing::warn!(
-                target: "houston_tunnel",
-                error = %e,
-                "tunnel allocation failed — running local-only, pairing disabled until next boot"
-            );
-            None
-        }
-    };
-
-    let state = ServerState::new(cfg, tunnel_identity)
+    // Mobile companion tunnel is intentionally disabled (HOU-474). We skip
+    // `houston_tunnel::ensure` so the engine never POSTs `{relay}/allocate`
+    // and never dials the Cloudflare relay. With no identity the tunnel
+    // runtime stays `None`, so `spawn_tunnel_if_allocated` below is inert.
+    // The `houston-tunnel` crate, the `/v1/tunnel/*` routes, and the settings
+    // section are all kept; restore the `ensure` call here to re-enable phone
+    // pairing.
+    let state = ServerState::new(cfg, None)
         .await
         .expect("engine state init failed");
 
     let state = Arc::new(state);
 
-    // Spawn the tunnel client if identity allocated. Needs the engine
-    // port, which we know now.
+    // No-op while the tunnel is disabled (identity is `None`); kept wired so
+    // restoring `ensure` above brings the connection back with no other edits.
     spawn_tunnel_if_allocated(state.clone(), actual.port());
 
     // Bundled-/runtime-CLI lifecycles. Fire-and-forget — both publish


### PR DESCRIPTION
## HOU-474 — stop the engine dialing the Cloudflare relay on boot

Follow-up to HOU-473 / #536 (removed the **Connect phone** settings entry).

### Problem
The tunnel is **not** driven by the UI. On every engine boot, regardless of whether a user ever opened Connect phone:
- `houston_tunnel::ensure()` runs — first boot POSTs `{relay}/allocate` and caches `tunnel.json`;
- `spawn_tunnel_if_allocated()` dials `wss://tunnel.gethouston.ai/e/<id>/register` and holds it open with heartbeats + auto-reconnect.

So removing the button only stopped minting **new** QR codes — the persistent Cloudflare connection and any already-paired phone kept working.

### Change
Skip `houston_tunnel::ensure` in `main.rs` so the engine never POSTs `/allocate` and never dials the relay. A `None` identity leaves the tunnel runtime unset, so `spawn_tunnel_if_allocated` stays inert (kept wired with a comment). 

**Kept intact** — this disables the boot trigger, it doesn't delete the feature:
- the `houston-tunnel` crate and the `/v1/tunnel/*` routes
- the (dormant) settings section from #536

Re-enable = restore the one `ensure` call.

### ⚠️ Impact (intended)
- **Already-paired phones lose access** and phone push stops. Deliberate as part of pulling the mobile companion, but a behavior change for current mobile users.
- `tunnel.json` is left in place (harmless); re-enabling resumes the same identity.
- Relay / Cloudflare decommission is a separate ops task (`docs/relay-operations.md`).

### Verification
- `cargo build -p houston-engine-server` — clean, no warnings.
- `cargo test -p houston-engine-server` — all green (21 binaries, 0 failed; `tests/tunnel.rs` 7/7 still pass since the routes are unchanged).
- Behavior: on boot the engine no longer logs `tunnel identity loaded` / `tunnel connected` and makes no outbound relay connection. `GET /v1/tunnel/status` reports disconnected; mint returns 503 (section is unreachable anyway).

Diff: one file (`main.rs`), allocation block removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)