### PR TITLE
fix(composio): parse `login --no-wait` prose output (HOU-468)

### DIFF
--- a/app/src/hooks/use-composio-auth.ts
+++ b/app/src/hooks/use-composio-auth.ts
@@ -94,8 +94,17 @@ export function useComposioAuth(onSuccess: () => void | Promise<void>) {
       setState({ open: false, phase: "idle", loginUrl: null, error: null });
       await onSuccess();
     } catch (e) {
-      logger.error("[composio-auth] flow error:", String(e));
       if (!mountedRef.current || genRef.current !== myGen) return;
+      // Already signed in (the CLI no-ops when creds exist, e.g. signed in
+      // elsewhere or a stale status). Not an error: close and refresh so the
+      // UI snaps to the connected state.
+      if (isHoustonEngineError(e) && e.kind === "composio_already_signed_in") {
+        logger.info("[composio-auth] already signed in, refreshing");
+        setState({ open: false, phase: "idle", loginUrl: null, error: null });
+        await onSuccess();
+        return;
+      }
+      logger.error("[composio-auth] flow error:", String(e));
       // Localize for the user. A `composio_login_timeout` is the expected
       // "you didn't finish approving in the browser" case; everything
       // else collapses to a generic retry prompt so we never surface a

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -498,10 +498,18 @@ export const tauriConnections = {
       { toast: false, capture: false },
     ),
   startOAuth: () =>
-    call<StartLoginResponse>("start_composio_oauth", async () => {
-      const r = await getEngine().composioStartLogin();
-      return { login_url: r.login_url, cli_key: r.cli_key };
-    }),
+    call<StartLoginResponse>(
+      "start_composio_oauth",
+      async () => {
+        const r = await getEngine().composioStartLogin();
+        return { login_url: r.login_url, cli_key: r.cli_key };
+      },
+      undefined,
+      // "Already signed in" is a benign no-op (the CLI prints nothing when
+      // creds already exist); the dialog handles that kind as success, so no
+      // red bug toast and no Sentry report.
+      { silenceKinds: ["composio_already_signed_in"] },
+    ),
   completeLogin: (cliKey: string) =>
     call<void>(
       "complete_composio_login",

--- a/engine/houston-composio/src/cli.rs
+++ b/engine/houston-composio/src/cli.rs
@@ -101,12 +101,17 @@ pub async fn start_login() -> Result<StartLoginResponse, String> {
     let home = crate::install::home_dir().to_string_lossy().to_string();
     let path = std::env::var("PATH").unwrap_or_default();
 
-    let result = tokio::time::timeout(
+    let (stdout, stderr) = tokio::time::timeout(
         std::time::Duration::from_secs(30),
         tokio::task::spawn_blocking(move || {
-            let tmp = std::env::temp_dir().join("houston-composio-login.json");
+            let tmp_out = std::env::temp_dir().join("houston-composio-login.out");
+            let tmp_err = std::env::temp_dir().join("houston-composio-login.err");
 
-            let stdout_file = std::fs::File::create(&tmp)
+            let stdout_file = std::fs::File::create(&tmp_out)
+                .map_err(|e| format!("Failed to create temp file: {e}"))?;
+            // Capture stderr too so an unrecognized/empty stdout can surface the
+            // CLI's own diagnostics instead of a bare parse error.
+            let stderr_file = std::fs::File::create(&tmp_err)
                 .map_err(|e| format!("Failed to create temp file: {e}"))?;
 
             let mut cmd = std::process::Command::new(&bin);
@@ -117,58 +122,117 @@ pub async fn start_login() -> Result<StartLoginResponse, String> {
                 .env("PATH", &path)
                 .stdin(std::process::Stdio::null())
                 .stdout(stdout_file)
-                .stderr(std::process::Stdio::null());
+                .stderr(stderr_file);
             crate::install::set_home_env(&mut cmd, &home);
             let status = cmd
                 .status()
                 .map_err(|e| format!("Failed to spawn composio login: {e}"))?;
 
+            let stdout = std::fs::read_to_string(&tmp_out)
+                .map_err(|e| format!("Failed to read login output: {e}"))?;
+            let stderr = std::fs::read_to_string(&tmp_err)
+                .map_err(|e| format!("Failed to read login stderr: {e}"))?;
+            let _ = std::fs::remove_file(&tmp_out);
+            let _ = std::fs::remove_file(&tmp_err);
+
             if !status.success() {
+                let stderr = stderr.trim();
                 return Err(decorate_windows_exit(
                     "composio login --no-wait",
-                    &format!("{status}"),
+                    &format!(
+                        "{status}{}",
+                        if stderr.is_empty() {
+                            String::new()
+                        } else {
+                            format!(": {stderr}")
+                        }
+                    ),
                     status.code(),
                 ));
             }
 
-            let stdout = std::fs::read_to_string(&tmp)
-                .map_err(|e| format!("Failed to read login output: {e}"))?;
-            let _ = std::fs::remove_file(&tmp);
-
-            // Do NOT log the raw stdout: it is the `{login_url, cli_key}`
-            // JSON, and `cli_key` is the login-session credential that
-            // `complete_login` later passes as `--key` (HOU-431). Log only
-            // its size so "CLI returned something" is still distinguishable
-            // from "CLI returned nothing".
+            // Do NOT log the raw stdout: it embeds the login-session secret
+            // (`cli_key`, carried as `?cliKey=`) that `complete_login` later
+            // passes as `--key` (HOU-431). Log only its size so "CLI returned
+            // something" stays distinguishable from "CLI returned nothing".
             tracing::info!(
                 "[composio:cli] start_login returned {} bytes",
                 stdout.trim().len()
             );
-            Ok(stdout)
+            Ok((stdout, stderr))
         }),
     )
     .await
     .map_err(|_| "composio login --no-wait timed out after 30s".to_string())?
     .map_err(|e| format!("spawn_blocking failed: {e}"))??;
 
-    #[derive(Deserialize)]
-    struct Payload {
-        login_url: String,
-        cli_key: String,
+    interpret_login_output(&stdout, &stderr)
+}
+
+/// Interpret the stdout of a successful `composio login --no-wait`.
+///
+/// The CLI no longer prints a JSON object. A successful `--no-wait` run prints
+/// human/agent-readable prose that contains the dashboard login URL, with the
+/// session key carried as the `cliKey` query parameter:
+///
+/// ```text
+/// Open this URL in your browser to log in:
+///
+///   https://dashboard.composio.dev/?cliKey=<uuid>
+///
+/// Then run this command to complete login:
+///   composio login --poll
+/// ```
+///
+/// Feeding that prose to serde was the HOU-468 crash (`Unexpected composio
+/// login --no-wait output: expected value at line 1 column 1`). The URL is
+/// exactly what the frontend opens, and its `cliKey` is the session key
+/// `complete_login` passes as `--key` (verified identical to the `key` the CLI
+/// caches in `~/.composio/pending-login-session.json`).
+fn interpret_login_output(stdout: &str, stderr: &str) -> Result<StartLoginResponse, String> {
+    let stdout = stdout.trim();
+    let stderr = stderr.trim();
+
+    // Empty stdout: the CLI produced nothing (e.g. the EOF case in HOUSTON-APP-51).
+    if stdout.is_empty() {
+        return Err(format!(
+            "composio login --no-wait produced no output{}",
+            if stderr.is_empty() {
+                String::new()
+            } else {
+                format!(" (stderr: {stderr})")
+            }
+        ));
     }
 
-    let payload: Payload = serde_json::from_str(result.trim()).map_err(|e| {
-        // Do NOT echo the raw stdout: it is the `{login_url, cli_key}` payload
-        // and both fields carry the login-session secret (`login_url` embeds
-        // it as `?cliKey=`). The serde message names the failing field/offset
-        // without dumping the blob (HOU-431).
-        format!("Unexpected composio login --no-wait output: {e}")
-    })?;
+    if let Some((login_url, cli_key)) = extract_login_url_and_key(stdout) {
+        return Ok(StartLoginResponse { login_url, cli_key });
+    }
 
-    Ok(StartLoginResponse {
-        login_url: payload.login_url,
-        cli_key: payload.cli_key,
-    })
+    // No usable login URL. Surface the CLI's stderr (NOT stdout — it carries
+    // the session secret) so the bug report shows what actually happened.
+    Err(format!(
+        "composio login --no-wait produced unrecognized output (no login URL found){}",
+        if stderr.is_empty() {
+            String::new()
+        } else {
+            format!("; stderr: {stderr}")
+        }
+    ))
+}
+
+/// `Some((login_url, cli_key))` when `stdout` contains a single `http(s)://`
+/// login URL whose `cliKey` query parameter is the session key. Both come from
+/// the one URL so they can never disagree.
+fn extract_login_url_and_key(stdout: &str) -> Option<(String, String)> {
+    let url = stdout
+        .split_whitespace()
+        .find(|t| t.starts_with("https://") || t.starts_with("http://"))?;
+    let cli_key = url.split_once("cliKey=")?.1.split(['&', '#']).next()?;
+    if cli_key.is_empty() {
+        return None;
+    }
+    Some((url.to_string(), cli_key.to_string()))
 }
 
 /// How long `complete_login` waits for the user to approve the sign-in
@@ -1141,5 +1205,51 @@ mod tests {
         assert!(bare_url("see https://docs.composio.dev/errors for help").is_none());
         assert!(bare_url("https://dashboard.composio.dev/x?open=true").is_some());
         assert!(bare_url("not-a-url").is_none());
+    }
+
+    // Representative `composio login --no-wait` stdout (HOU-468 prose shape).
+    // The cliKey is a synthetic placeholder, never a real session key.
+    const LOGIN_NO_WAIT_STDOUT: &str = "Open this URL in your browser to log in:\n\n  https://dashboard.composio.dev/?cliKey=00000000-0000-0000-0000-000000000000\n\nThen run this command to complete login:\n\n  composio login --poll\n\nhint: For agents: Show the URL above to the user to click, then run the command above. The command uses the cached login key, polls for up to 10 minutes, and exits once credentials are saved. Do not ask the user whether to poll — they already requested login.\n";
+
+    #[test]
+    fn login_output_parses_prose() {
+        let r = interpret_login_output(LOGIN_NO_WAIT_STDOUT, "").unwrap();
+        assert_eq!(
+            r.login_url,
+            "https://dashboard.composio.dev/?cliKey=00000000-0000-0000-0000-000000000000"
+        );
+        assert_eq!(r.cli_key, "00000000-0000-0000-0000-000000000000");
+    }
+
+    #[test]
+    fn login_output_empty_is_error_not_panic() {
+        for s in ["", "   ", "\n\t"] {
+            let err = interpret_login_output(s, "session expired").unwrap_err();
+            assert!(err.contains("no output"), "got: {err}");
+            assert!(err.contains("session expired"), "got: {err}");
+            // Must NOT leak a raw serde message.
+            assert!(!err.contains("expected value"), "got: {err}");
+        }
+    }
+
+    #[test]
+    fn login_output_unrecognized_surfaces_stderr() {
+        let err = interpret_login_output("totally not a url", "boom from cli").unwrap_err();
+        assert!(err.contains("boom from cli"), "got: {err}");
+        assert!(!err.contains("expected value"), "got: {err}");
+    }
+
+    #[test]
+    fn extract_login_url_and_key_handles_extra_params_and_misses() {
+        let (url, key) =
+            extract_login_url_and_key("  https://dashboard.composio.dev/?cliKey=abc-123&x=1#f")
+                .unwrap();
+        assert_eq!(url, "https://dashboard.composio.dev/?cliKey=abc-123&x=1#f");
+        assert_eq!(key, "abc-123");
+
+        // URL present but no session key, or no URL at all -> None.
+        assert!(extract_login_url_and_key("https://dashboard.composio.dev/?foo=1").is_none());
+        assert!(extract_login_url_and_key("https://dashboard.composio.dev/?cliKey=").is_none());
+        assert!(extract_login_url_and_key("no url here").is_none());
     }
 }

--- a/engine/houston-composio/src/cli.rs
+++ b/engine/houston-composio/src/cli.rs
@@ -86,6 +86,28 @@ pub async fn status() -> ComposioStatus {
     }
 }
 
+/// Why `start_login` failed, so the engine server can tell a benign
+/// "you're already signed in" no-op apart from a genuine CLI fault.
+#[derive(Debug)]
+pub enum StartLoginError {
+    /// `login --no-wait` printed nothing because the user is already
+    /// authenticated (e.g. signed in elsewhere, or a stale status). Not a
+    /// bug: the UI treats it as success and refreshes.
+    AlreadySignedIn,
+    /// Spawn failure, non-zero exit, or unparseable output. Carries internal
+    /// detail for logs / the bug report; never shown verbatim to the user.
+    Failed(String),
+}
+
+impl std::fmt::Display for StartLoginError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::AlreadySignedIn => write!(f, "already signed in to composio"),
+            Self::Failed(detail) => write!(f, "{detail}"),
+        }
+    }
+}
+
 /// Begin the login flow. Returns a URL for the user to open in their
 /// browser and a `cli_key` that `complete_login` will use to finalize.
 ///
@@ -96,8 +118,8 @@ pub async fn status() -> ComposioStatus {
 /// command returned in ~500 ms from a plain shell but hung indefinitely
 /// through tokio's async pipe handling. The sync+file approach has zero
 /// tokio pipe involvement.
-pub async fn start_login() -> Result<StartLoginResponse, String> {
-    let bin = cli_binary()?;
+pub async fn start_login() -> Result<StartLoginResponse, StartLoginError> {
+    let bin = cli_binary().map_err(StartLoginError::Failed)?;
     let home = crate::install::home_dir().to_string_lossy().to_string();
     let path = std::env::var("PATH").unwrap_or_default();
 
@@ -163,10 +185,32 @@ pub async fn start_login() -> Result<StartLoginResponse, String> {
         }),
     )
     .await
-    .map_err(|_| "composio login --no-wait timed out after 30s".to_string())?
-    .map_err(|e| format!("spawn_blocking failed: {e}"))??;
+    .map_err(|_| StartLoginError::Failed("composio login --no-wait timed out after 30s".into()))?
+    .map_err(|e| StartLoginError::Failed(format!("spawn_blocking failed: {e}")))?
+    .map_err(StartLoginError::Failed)?;
 
-    interpret_login_output(&stdout, &stderr)
+    // Empty stdout: the CLI had nothing to print. That is the EOF case
+    // (HOUSTON-APP-51) AND what `--no-wait` does when the user is already
+    // signed in. Disambiguate by auth state so we never bug-toast a benign
+    // "already connected".
+    if stdout.trim().is_empty() {
+        return match whoami().await {
+            Ok(Some(_)) => Err(StartLoginError::AlreadySignedIn),
+            _ => {
+                let stderr = stderr.trim();
+                Err(StartLoginError::Failed(format!(
+                    "composio login --no-wait produced no output{}",
+                    if stderr.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" (stderr: {stderr})")
+                    }
+                )))
+            }
+        };
+    }
+
+    interpret_login_output(&stdout, &stderr).map_err(StartLoginError::Failed)
 }
 
 /// Interpret the stdout of a successful `composio login --no-wait`.
@@ -189,21 +233,13 @@ pub async fn start_login() -> Result<StartLoginResponse, String> {
 /// exactly what the frontend opens, and its `cliKey` is the session key
 /// `complete_login` passes as `--key` (verified identical to the `key` the CLI
 /// caches in `~/.composio/pending-login-session.json`).
+///
+/// Empty stdout is handled by the caller (`start_login`), which checks auth
+/// state to tell "already signed in" from a real failure; here a blank or
+/// URL-less input simply falls through to the unrecognized-output error.
 fn interpret_login_output(stdout: &str, stderr: &str) -> Result<StartLoginResponse, String> {
     let stdout = stdout.trim();
     let stderr = stderr.trim();
-
-    // Empty stdout: the CLI produced nothing (e.g. the EOF case in HOUSTON-APP-51).
-    if stdout.is_empty() {
-        return Err(format!(
-            "composio login --no-wait produced no output{}",
-            if stderr.is_empty() {
-                String::new()
-            } else {
-                format!(" (stderr: {stderr})")
-            }
-        ));
-    }
 
     if let Some((login_url, cli_key)) = extract_login_url_and_key(stdout) {
         return Ok(StartLoginResponse { login_url, cli_key });
@@ -1222,12 +1258,12 @@ mod tests {
     }
 
     #[test]
-    fn login_output_empty_is_error_not_panic() {
-        for s in ["", "   ", "\n\t"] {
+    fn login_output_blank_or_urlless_is_error_not_panic() {
+        // `start_login` intercepts empty stdout (auth-state check); the pure
+        // parser just must not panic and must surface stderr, never serde.
+        for s in ["", "   ", "\n\t", "no url here"] {
             let err = interpret_login_output(s, "session expired").unwrap_err();
-            assert!(err.contains("no output"), "got: {err}");
             assert!(err.contains("session expired"), "got: {err}");
-            // Must NOT leak a raw serde message.
             assert!(!err.contains("expected value"), "got: {err}");
         }
     }
@@ -1252,4 +1288,5 @@ mod tests {
         assert!(extract_login_url_and_key("https://dashboard.composio.dev/?cliKey=").is_none());
         assert!(extract_login_url_and_key("no url here").is_none());
     }
+
 }

--- a/engine/houston-composio/src/cli.rs
+++ b/engine/houston-composio/src/cli.rs
@@ -215,38 +215,55 @@ pub async fn start_login() -> Result<StartLoginResponse, StartLoginError> {
 
 /// Interpret the stdout of a successful `composio login --no-wait`.
 ///
-/// The CLI no longer prints a JSON object. A successful `--no-wait` run prints
-/// human/agent-readable prose that contains the dashboard login URL, with the
-/// session key carried as the `cliKey` query parameter:
+/// `--no-wait` stdout is NOT one stable shape: it varies by CLI version, and
+/// which version runs varies by user (the per-arch CLI bundled in the `.app`
+/// vs. a standalone `~/.composio` install). Both forms seen in the wild carry
+/// the same two fields, so accept either:
 ///
-/// ```text
-/// Open this URL in your browser to log in:
+/// 1. **JSON** (e.g. composio 0.2.24, the version Houston currently bundles):
+///    `{"status":"pending","login_url":"…?cliKey=<uuid>","cli_key":"<uuid>",…}`.
+/// 2. **Prose** (e.g. composio 0.2.31): human/agent text with the dashboard
+///    URL, the session key carried as its `cliKey` query param:
+///    ```text
+///    Open this URL in your browser to log in:
+///      https://dashboard.composio.dev/?cliKey=<uuid>
+///    ```
 ///
-///   https://dashboard.composio.dev/?cliKey=<uuid>
-///
-/// Then run this command to complete login:
-///   composio login --poll
-/// ```
-///
-/// Feeding that prose to serde was the HOU-468 crash (`Unexpected composio
-/// login --no-wait output: expected value at line 1 column 1`). The URL is
-/// exactly what the frontend opens, and its `cliKey` is the session key
-/// `complete_login` passes as `--key` (verified identical to the `key` the CLI
-/// caches in `~/.composio/pending-login-session.json`).
+/// Feeding prose to a JSON-only parser was the HOU-468 crash (`expected value
+/// at line 1 column 1`); a prose-only parser would symmetrically break the
+/// JSON-emitting bundled CLI on prod. The URL is what the frontend opens and
+/// its `cliKey` is the session key `complete_login` passes as `--key` (verified
+/// identical to the `key` the CLI caches in `pending-login-session.json`).
 ///
 /// Empty stdout is handled by the caller (`start_login`), which checks auth
 /// state to tell "already signed in" from a real failure; here a blank or
-/// URL-less input simply falls through to the unrecognized-output error.
+/// unrecognized input falls through to the unrecognized-output error.
 fn interpret_login_output(stdout: &str, stderr: &str) -> Result<StartLoginResponse, String> {
     let stdout = stdout.trim();
     let stderr = stderr.trim();
 
+    // Form 1: JSON object. Extra fields (status/message/expires_at) are ignored.
+    #[derive(Deserialize)]
+    struct JsonPayload {
+        login_url: String,
+        cli_key: String,
+    }
+    if let Ok(p) = serde_json::from_str::<JsonPayload>(stdout) {
+        if !p.login_url.is_empty() && !p.cli_key.is_empty() {
+            return Ok(StartLoginResponse {
+                login_url: p.login_url,
+                cli_key: p.cli_key,
+            });
+        }
+    }
+
+    // Form 2: prose containing the login URL.
     if let Some((login_url, cli_key)) = extract_login_url_and_key(stdout) {
         return Ok(StartLoginResponse { login_url, cli_key });
     }
 
-    // No usable login URL. Surface the CLI's stderr (NOT stdout — it carries
-    // the session secret) so the bug report shows what actually happened.
+    // Neither. Surface the CLI's stderr (NOT stdout — it carries the session
+    // secret) so the bug report shows what actually happened.
     Err(format!(
         "composio login --no-wait produced unrecognized output (no login URL found){}",
         if stderr.is_empty() {
@@ -1258,6 +1275,25 @@ mod tests {
     }
 
     #[test]
+    fn login_output_parses_bundled_json() {
+        // Shape emitted by composio 0.2.24 (the version Houston bundles); the
+        // key is a synthetic placeholder. Extra fields must be tolerated.
+        let json = r#"{
+            "status": "pending",
+            "message": "Complete login by opening the URL",
+            "login_url": "https://dashboard.composio.dev/?cliKey=00000000-0000-0000-0000-000000000000",
+            "cli_key": "00000000-0000-0000-0000-000000000000",
+            "expires_at": "2026-06-15T18:42:48.969Z"
+        }"#;
+        let r = interpret_login_output(json, "").unwrap();
+        assert_eq!(
+            r.login_url,
+            "https://dashboard.composio.dev/?cliKey=00000000-0000-0000-0000-000000000000"
+        );
+        assert_eq!(r.cli_key, "00000000-0000-0000-0000-000000000000");
+    }
+
+    #[test]
     fn login_output_blank_or_urlless_is_error_not_panic() {
         // `start_login` intercepts empty stdout (auth-state check); the pure
         // parser just must not panic and must surface stderr, never serde.
@@ -1288,5 +1324,4 @@ mod tests {
         assert!(extract_login_url_and_key("https://dashboard.composio.dev/?cliKey=").is_none());
         assert!(extract_login_url_and_key("no url here").is_none());
     }
-
 }

--- a/engine/houston-composio/src/commands.rs
+++ b/engine/houston-composio/src/commands.rs
@@ -7,7 +7,10 @@
 //! Tauri command decorators live in the adapter crate (`houston-tauri`),
 //! keeping this crate frontend-agnostic.
 
-use crate::cli::{self, ComposioStatus, CompleteLoginError, StartLinkResponse, StartLoginResponse};
+use crate::cli::{
+    self, ComposioStatus, CompleteLoginError, StartLinkResponse, StartLoginError,
+    StartLoginResponse,
+};
 use crate::install;
 use crate::toolkits::normalize_toolkit_slugs;
 
@@ -27,8 +30,10 @@ pub async fn install_composio_cli() -> Result<(), String> {
     install::install().await.map(|_| ())
 }
 
-/// Start the composio login flow. Returns `{login_url, cli_key}`.
-pub async fn start_composio_oauth() -> Result<StartLoginResponse, String> {
+/// Start the composio login flow. Returns `{login_url, cli_key}`, or a typed
+/// `StartLoginError` so the server can render "already signed in" as a benign
+/// success instead of a bug toast.
+pub async fn start_composio_oauth() -> Result<StartLoginResponse, StartLoginError> {
     cli::start_login().await
 }
 

--- a/engine/houston-engine-server/src/routes/composio.rs
+++ b/engine/houston-engine-server/src/routes/composio.rs
@@ -13,7 +13,7 @@ use axum::{
 };
 use houston_composio::apps::ComposioAppEntry;
 use houston_composio::cli::{
-    ComposioStatus, CompleteLoginError, StartLinkResponse, StartLoginResponse,
+    ComposioStatus, CompleteLoginError, StartLinkResponse, StartLoginError, StartLoginResponse,
 };
 use houston_composio::commands as inner;
 use houston_composio::connection_watcher;
@@ -94,6 +94,23 @@ fn map_complete_login_err(e: CompleteLoginError) -> ApiError {
     }
 }
 
+/// Map a login-start failure to the wire error.
+///
+/// `AlreadySignedIn` is benign: `login --no-wait` prints nothing when creds
+/// already exist, so it surfaces as a typed `composio_already_signed_in` the
+/// frontend treats as success (close the dialog, refresh status) with no toast
+/// or crash report. Anything else is an internal fault worth a bug report.
+fn map_start_login_err(e: StartLoginError) -> ApiError {
+    match e {
+        StartLoginError::AlreadySignedIn => ApiError(CoreError::Labeled {
+            code: ErrorCode::Conflict,
+            kind: "composio_already_signed_in",
+            message: "You're already signed in to Composio.".to_string(),
+        }),
+        StartLoginError::Failed(detail) => ApiError(CoreError::Internal(detail)),
+    }
+}
+
 async fn status(State(_st): State<Arc<ServerState>>) -> Json<ComposioStatus> {
     Json(inner::list_composio_connections().await)
 }
@@ -111,7 +128,10 @@ async fn install_cli(State(_st): State<Arc<ServerState>>) -> Result<(), ApiError
 async fn start_login(
     State(_st): State<Arc<ServerState>>,
 ) -> Result<Json<StartLoginResponse>, ApiError> {
-    inner::start_composio_oauth().await.map(Json).map_err(lift)
+    inner::start_composio_oauth()
+        .await
+        .map(Json)
+        .map_err(map_start_login_err)
 }
 
 async fn complete_login(


### PR DESCRIPTION
Makes Composio sign-in work for **all users, prod and dev**. `start_login` had two defects, and a third surfaced only when checking prod-parity (different CLI version than dev).

## The output format depends on the composio version — and which version a user runs varies

`composio login --no-wait` does not have one stable output shape:

| composio version | who runs it | logged-out stdout | logged-in stdout |
|---|---|---|---|
| **0.2.24** | **prod** (per-arch CLI bundled in the `.app`, pinned in `cli-deps.json`) | **JSON** `{status, login_url, cli_key, expires_at}` | empty |
| 0.2.31 | dev / standalone `~/.composio` / auto-upgraded | **prose** with the login URL | empty |

So the parser must accept **JSON and prose**, and must treat empty as "already signed in" (not a crash).

## Root cause 1 — prose crashes the JSON-only parser (HOU-468)

The original `start_login` did `serde_json::from_str::<{login_url, cli_key}>(stdout)`. On a prose-emitting CLI that is `Unexpected composio login --no-wait output: expected value at line 1 column 1` (Sentry HOUSTON-APP-51 / -21 / -66).

## Root cause 2 — a prose-only fix would have broken prod

The first cut parsed prose only. Prod's bundled **0.2.24 emits JSON**, so that cut would have broken sign-in for prod users (`unrecognized output`). Caught by downloading the exact prod-pinned binary (sha256 matches `cli-deps.json`) and running it.

**Fix (1+2):** `interpret_login_output` accepts either form: try JSON `{login_url, cli_key}` (extra fields ignored), else pull the URL + `cliKey` from prose. The `cliKey` is byte-identical to the `key` cached in `pending-login-session.json` and is what `complete_login` passes as `--key` (unchanged, still supported).

## Root cause 3 — already-signed-in toast (the EOF case)

When already signed in, the CLI prints nothing (empty stdout). The naive handling reported a bug toast. Now `start_login` checks `whoami` on empty output and returns a typed `StartLoginError::AlreadySignedIn`, mapped to `composio_already_signed_in` (`ErrorCode::Conflict`); the sign-in dialog treats that kind as success (close + refresh) with no toast and no Sentry.

## Verification — against the real binaries, through the real `start_login()`

| binary | logged out | logged in |
|---|---|---|
| **0.2.24** (prod bundle, sha256-verified) | `Ok(Started)`, valid URL + 36-char key | `AlreadySignedIn` |
| 0.2.31 (prose) | `Ok(Started)`, valid URL + 36-char key | `AlreadySignedIn` |

Isolated `~/.composio` clones, real credentials untouched. `cargo test -p houston-composio` → 35 pass (JSON form, prose form, unrecognized, extract-key, blank). `cargo build -p houston-engine-server` clean. `app pnpm tsc` + `check-locales` clean.

## Reproduce before
```
CI=1 TERM=dumb NO_COLOR=1 HOME=$(mktemp -d) ~/.composio/composio login --no-wait --no-skill-install -y
```
0.2.31 prints prose; pre-fix the "Sign in to Composio" click toasts `expected value at line 1 column 1`.

## Verify after
`cargo build -p houston-engine-server`, restart `pnpm tauri dev`. Logged out → sign-in opens `https://dashboard.composio.dev/?cliKey=…`, finishing in-browser completes login. Already signed in → clicking sign-in quietly refreshes to connected (no toast).

## Affected files
- `engine/houston-composio/src/cli.rs`, `commands.rs`
- `engine/houston-engine-server/src/routes/composio.rs`
- `app/src/hooks/use-composio-auth.ts`, `app/src/lib/tauri.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)