### PR TITLE
release: v0.4.24

### DIFF
--- a/.github/release-notes/0.4.24.es.md
+++ b/.github/release-notes/0.4.24.es.md
@@ -1,0 +1,79 @@
+## Houston 0.4.24
+
+Una versión de pulido y confiabilidad. El chat se siente más tranquilo, las
+rutinas programadas son más fáciles de configurar, las conexiones con apps se
+recuperan mejor y el límite de sesión de Claude ahora muestra el mensaje
+correcto en vez de parecer un límite de uso genérico.
+Puedes instalarla encima de 0.4.23, sin cambios incompatibles.
+
+### Agregado
+
+- **Programar rutinas es más fácil.** Los horarios semanales ahora son un preset
+  simple de varios días, y el formulario usa un selector de reloj amigable en
+  vez de pedirte escribir la hora a mano.
+- **Contexto más claro en el chat.** El indicador de contexto ahora es un anillo
+  más discreto al pasar el cursor, para ver la señal cuando la necesitas sin
+  meter más ruido en la pantalla de chat.
+
+### Mejorado
+
+- **Menos ruido visual mientras Houston trabaja.** Quitamos el casco de carga
+  parpadeante, el registro de misión empieza cerrado y Houston muestra solo la
+  acción actual salvo que quieras ver más detalle.
+- **Tarjetas más consistentes.** Las tarjetas de chat, integraciones y contexto
+  ahora comparten la misma forma y comportamiento, así que las acciones se
+  sienten más predecibles en toda la app.
+- **Control de esfuerzo más simple.** El botón de esfuerzo ahora recorre los
+  niveles con un ícono que coincide con el nivel seleccionado.
+- **Una zona horaria para rutinas.** Las rutinas ahora usan una zona horaria
+  global de la cuenta en vez de ajustes por rutina, lo que hace más fácil
+  entender cuándo se ejecutarán.
+
+### Corregido
+
+- **Los límites de sesión de Claude se etiquetan bien.** Si Claude llega a su
+  límite de sesión de 5 horas, Houston ahora muestra una tarjeta de límite de
+  sesión en vez de un mensaje engañoso de límite de uso.
+- **Las conexiones de apps se actualizan al instante.** Cuando una app conectada
+  ya estaba vinculada, Houston ahora cambia Connect a conectado en vez de dejar
+  la pantalla desactualizada.
+- **Se entiende más salida de inicio de sesión.** Houston ahora maneja el texto
+  de `login --no-wait`, así que más flujos de conexión terminan sin limpieza
+  manual.
+- **Los errores del chat se quedan donde ocurrieron.** Un error ya no salta al
+  final de la conversación ni se separa del mensaje al que pertenece.
+- **La actividad de herramientas ya no se repite en snapshots.** Las llamadas de
+  herramientas de Claude que ya se enviaron por streaming ya no vuelven a salir
+  desde el snapshot del motor.
+- **Las rutinas mantienen sus tareas sincronizadas.** Editar el horario o la
+  zona horaria de una rutina ahora recrea correctamente la tarea programada
+  interna.
+- **Los botones resisten clics repetidos.** Los botones que envían acciones
+  asíncronas ahora se protegen contra clics repetidos mientras el trabajo sigue
+  en curso.
+- **Borrar actividad es seguro de reintentar.** Un doble borrado ya no se vuelve
+  una falla visible.
+- **Cargar detalles de skills es más claro.** Las tarjetas de skills se
+  desactivan y muestran progreso mientras carga la vista de detalle.
+- **Los reportes de errores en desarrollo son más silenciosos.** Sentry se
+  mantiene apagado en desarrollo salvo que se active explícitamente con
+  `SENTRY_SEND_IN_DEV`.
+- **El reinicio de acceso del teléfono espera a que todo esté listo.** Houston ya
+  no reinicia el acceso del teléfono antes de que el túnel esté preparado.
+- **Se ignoran traspasos benignos de bloqueo del navegador.** Rechazos inofensivos
+  de Web Locks ya no aparecen como errores preocupantes.
+- **Instalar skills es idempotente.** Instalar una skill que ya existe ya no falla
+  sin necesidad.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza bien una
+  app que sigue abierta. Si tienes dudas, elimina `/Applications/Houston.app` y
+  arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde 0.4.7 o posterior te lleva
+  a esta versión automáticamente. El MSI todavía no está firmado a nivel de
+  sistema operativo, así que Windows SmartScreen puede mostrar una advertencia en
+  una instalación nueva.
+- **Windows ARM64:** no hay ruta de actualización automática desde una instalación
+  x64 emulada. Descarga el MSI ARM64 manualmente, desinstala primero la versión
+  x64 y luego instala la ARM64.

--- a/.github/release-notes/0.4.24.md
+++ b/.github/release-notes/0.4.24.md
@@ -1,0 +1,70 @@
+## Houston 0.4.24
+
+A polish and reliability release. Chat feels calmer, scheduled routines are easier
+to set up, app connections recover more reliably, and Claude's session limit now
+shows the right message instead of looking like a generic rate limit.
+Drop-in on top of 0.4.23, no breaking changes.
+
+### Added
+
+- **Easier routine scheduling.** Weekly schedules are now a simple multi-day
+  preset, and the schedule form uses a friendly clock picker instead of making
+  you type time values by hand.
+- **Clearer context in chat.** The context indicator is now a quieter hover ring,
+  so you can see the signal when you need it without adding more noise to the
+  chat screen.
+
+### Improved
+
+- **Less visual noise while Houston works.** The blinking loading helmet is gone,
+  mission logs start collapsed, and Houston surfaces only the live action unless
+  you want more detail.
+- **More consistent cards.** Chat, integration, and context cards now share the
+  same shape and behavior, so actions feel more predictable across the app.
+- **Simpler effort control.** The effort button now cycles through levels with an
+  icon that matches the selected level.
+- **One timezone for routines.** Routine schedules now use one account-wide
+  timezone instead of per-routine overrides, which makes scheduled behavior
+  easier to reason about.
+
+### Fixed
+
+- **Claude session limits are labeled correctly.** If Claude hits its 5-hour
+  session limit, Houston now shows a session-limit card instead of a misleading
+  rate-limit message.
+- **App connections update immediately.** When a connected app is already linked,
+  Houston now flips Connect to connected instead of leaving the screen stale.
+- **More sign-in output is understood.** Houston now handles the prose output from
+  `login --no-wait`, so more connection flows finish without manual cleanup.
+- **Chat errors stay where they happened.** An error no longer jumps to the bottom
+  of the conversation and separates itself from the message it belongs to.
+- **Tool activity no longer repeats in snapshots.** Claude tool calls that were
+  already streamed are no longer re-emitted from the engine snapshot.
+- **Routines keep their jobs in sync.** Editing a routine's schedule or timezone
+  now respawns the underlying scheduled job correctly.
+- **Buttons resist rage clicks.** Async-submit buttons now guard against repeated
+  clicks while work is still in progress.
+- **Deleting activity is safe to retry.** A double-delete no longer turns into a
+  visible failure.
+- **Skill detail loading is clearer.** Skill cards disable and show progress while
+  their detail view is loading.
+- **Developer crash reporting is quieter.** Sentry stays off in dev unless it is
+  explicitly enabled with `SENTRY_SEND_IN_DEV`.
+- **Phone access reset waits for readiness.** Houston no longer resets phone
+  access before the tunnel is ready.
+- **Benign browser lock handoffs are ignored.** Harmless Web Locks rejections no
+  longer bubble up as scary errors.
+- **Skill installs are idempotent.** Installing a skill that is already present no
+  longer fails unnecessarily.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a
+  running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag
+  the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward
+  automatically. The MSI is still not OS-code-signed, so Windows SmartScreen may
+  warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install.
+  Download the ARM64 MSI manually, uninstall the x64 build first, then install
+  the ARM64 one.

--- a/.github/release-notes/0.4.24.pt.md
+++ b/.github/release-notes/0.4.24.pt.md
@@ -1,0 +1,77 @@
+## Houston 0.4.24
+
+Uma versão de polimento e confiabilidade. O chat fica mais tranquilo, as rotinas
+agendadas ficam mais fáceis de configurar, as conexões com apps se recuperam
+melhor e o limite de sessão do Claude agora mostra a mensagem correta em vez de
+parecer um limite genérico de uso.
+Pode instalar por cima da 0.4.23, sem mudanças incompatíveis.
+
+### Adicionado
+
+- **Agendar rotinas ficou mais fácil.** Os horários semanais agora são um preset
+  simples de vários dias, e o formulário usa um seletor de relógio amigável em
+  vez de pedir que você digite a hora manualmente.
+- **Contexto mais claro no chat.** O indicador de contexto agora é um anel mais
+  discreto ao passar o cursor, para você ver o sinal quando precisar sem colocar
+  mais ruído na tela do chat.
+
+### Melhorado
+
+- **Menos ruído visual enquanto o Houston trabalha.** O capacete de carregamento
+  piscando saiu, o registro de missão começa recolhido e o Houston mostra só a
+  ação atual, a menos que você queira mais detalhes.
+- **Cartões mais consistentes.** Os cartões de chat, integrações e contexto agora
+  compartilham a mesma forma e comportamento, então as ações ficam mais
+  previsíveis em toda a app.
+- **Controle de esforço mais simples.** O botão de esforço agora alterna entre os
+  níveis com um ícone que combina com o nível selecionado.
+- **Um fuso horário para rotinas.** As rotinas agora usam um único fuso horário
+  da conta em vez de ajustes por rotina, o que deixa mais fácil entender quando
+  elas vão rodar.
+
+### Corrigido
+
+- **Os limites de sessão do Claude são identificados corretamente.** Se o Claude
+  atingir o limite de sessão de 5 horas, o Houston agora mostra um cartão de
+  limite de sessão em vez de uma mensagem enganosa de limite de uso.
+- **Conexões de apps atualizam na hora.** Quando uma app conectada já estava
+  vinculada, o Houston agora muda Connect para conectado em vez de deixar a tela
+  desatualizada.
+- **Mais saídas de login são entendidas.** O Houston agora lida com o texto de
+  `login --no-wait`, então mais fluxos de conexão terminam sem limpeza manual.
+- **Erros do chat ficam onde aconteceram.** Um erro não pula mais para o fim da
+  conversa nem se separa da mensagem a que pertence.
+- **A atividade de ferramentas não se repete em snapshots.** Chamadas de
+  ferramentas do Claude que já foram transmitidas não são mais reemitidas pelo
+  snapshot do motor.
+- **Rotinas mantêm seus jobs sincronizados.** Editar o horário ou o fuso horário
+  de uma rotina agora recria corretamente o job agendado interno.
+- **Botões resistem a cliques repetidos.** Botões que enviam ações assíncronas
+  agora se protegem contra cliques repetidos enquanto o trabalho ainda está em
+  andamento.
+- **Excluir atividade é seguro de tentar de novo.** Um duplo delete não vira mais
+  uma falha visível.
+- **Carregar detalhes de skills ficou mais claro.** Cartões de skills ficam
+  desativados e mostram progresso enquanto a tela de detalhes carrega.
+- **Relatórios de erro em desenvolvimento ficam mais silenciosos.** O Sentry fica
+  desligado em dev, a menos que seja ativado explicitamente com
+  `SENTRY_SEND_IN_DEV`.
+- **A redefinição de acesso do telefone espera tudo ficar pronto.** O Houston não
+  redefine mais o acesso do telefone antes de o túnel estar pronto.
+- **Passagens benignas de bloqueio do navegador são ignoradas.** Rejeições
+  inofensivas de Web Locks não aparecem mais como erros assustadores.
+- **Instalar skills é idempotente.** Instalar uma skill que já está presente não
+  falha mais sem necessidade.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui bem uma
+  app que ainda está aberta. Na dúvida, remova `/Applications/Houston.app` e
+  arraste a nova cópia.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou mais recente
+  leva você para esta versão automaticamente. O MSI ainda não é assinado no nível
+  do sistema operacional, então o Windows SmartScreen pode mostrar um aviso em
+  uma instalação nova.
+- **Windows ARM64:** não há caminho de atualização automática a partir de uma
+  instalação x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a
+  versão x64 e depois instale a ARM64.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2496,7 +2496,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "futures-util",
  "hex",
@@ -2516,7 +2516,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "serde",
  "serde_json",
@@ -2526,7 +2526,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2544,7 +2544,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2557,7 +2557,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2594,7 +2594,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2606,7 +2606,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2646,7 +2646,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2660,7 +2660,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2685,7 +2685,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2701,7 +2701,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2735,7 +2735,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.23"
+version = "0.4.24"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.23", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.23", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.23", path = "app/houston-tauri" }
-houston-events = { version = "0.4.23", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.23", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.23", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.23", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.23", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.23", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.23", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.23", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.23", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.23", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.23", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.23", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.23", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.23", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.23", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.24", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.24", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.24", path = "app/houston-tauri" }
+houston-events = { version = "0.4.24", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.24", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.24", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.24", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.24", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.24", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.24", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.24", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.24", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.24", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.24", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.24", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.24", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.24", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.24", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.23"
+version = "0.4.24"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.23",
+  "version": "0.4.24",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Summary
- Bump Houston packages and workspace versions to `0.4.24`
- Add 0.4.24 release notes for English, Latin-American Spanish, and Brazilian Portuguese
- Prepare release branch for the draft-release flow. Do not merge until release notes look good.

## Test Plan
- [x] `./scripts/test/release-scripts.test.sh`
- [x] `pnpm install --frozen-lockfile`
- [x] `cd app && pnpm typecheck`
- [ ] `cargo check --workspace` was not run because `cargo` is not installed in this environment

## Release notes
This PR does not create or push the `v0.4.24` tag. After merge, tag `v0.4.24` from `main` to let CI build artifacts and create the draft GitHub Release.
