### PR TITLE
fix(chat): remove Fable 5 from the model picker (HOU-476)

### DIFF
--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -148,15 +148,10 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         // it can't self-correct downward, so the dialog flags it as estimated.
         contextWindow: 1_000_000,
       },
-      {
-        id: "claude-fable-5",
-        label: "Fable 5",
-        description: "Most capable model. Costs 2x more credits than Opus 4.8.",
-        // Fable 5: full range like Opus 4.8. ultracode is a harness mode, not
-        // an effort level — it is intentionally excluded for this model.
-        effortLevels: ["low", "medium", "high", "xhigh", "max"],
-        contextWindow: 1_000_000,
-      },
+      // Fable 5 (`claude-fable-5`) is intentionally absent from the picker for
+      // now — pulled per HOU-476. Engine support and its `modelDescriptions`
+      // copy in the chat locales are retained so re-adding a ModelOption here
+      // (full effort range, 1M window, 2x Opus 4.8 credits) re-enables it.
       {
         id: "claude-opus-4-7",
         label: "Opus 4.7",


### PR DESCRIPTION
## HOU-476 — Remove Fable 5

Removes the **Fable 5** option from the chat model picker (and the onboarding model picker) without ripping out the rest of the Fable 5 plumbing — we expect to re-enable it soon.

### Root cause / change
The picker is driven entirely by the `models` array in `app/src/lib/providers.ts` (mapped in both `chat-model-selector-parts.tsx` and `naming-step.tsx`). Removing the `claude-fable-5` `ModelOption` drops it from every picker surface in one place.

**Intentionally retained as references for re-enabling:**
- `modelDescriptions.claude-fable-5` copy in `app/src/locales/{en,es,pt}/chat.json`
- Effort-level prose/comments in `effort-bars.ts` and the effort tests
- Engine: no Fable-specific code exists (the model id is a pass-through string), so nothing engine-side to touch

A note comment at the removal site documents what was pulled and how to bring it back (full effort range, 1M window, 2x Opus 4.8 credits).

### Behavior
Any existing config still set to `claude-fable-5` falls back to the default model (Sonnet 4.6) via `validModelOrNull` — the same fallback path already used for retired SKUs. No crash, no silent breakage.

### Verification
**Before:** open the chat model picker (Anthropic provider) → "Fable 5" listed between Opus 4.8 and Opus 4.7.

**After:** open the picker → Anthropic shows **Sonnet 4.6 / Opus 4.8 / Opus 4.7** only; no Fable 5. Same in the onboarding naming-step picker.

### Gates
- `pnpm tsc --noEmit` — clean
- `pnpm check-locales` — all locales in sync (retained keys keep en/es/pt parity)
- effort test suites — 13/13 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)