### PR TITLE
feat(app): add Settings to Job Description with sidebar card actions (HOU-492)

### DIFF
--- a/app/src/agents/standard-tabs.ts
+++ b/app/src/agents/standard-tabs.ts
@@ -22,7 +22,7 @@ export const STANDARD_TABS: AgentTab[] = [
   { id: "activity", label: "Activity", builtIn: "board", badge: "activity" },
   { id: "routines", label: "Routines", builtIn: "routines" },
   { id: "files", label: "Files", builtIn: "files" },
-  { id: "job-description", label: "Job Description", builtIn: "job-description" },
+  { id: "job-description", label: "Agent Settings", builtIn: "job-description" },
   { id: "integrations", label: "Integrations", builtIn: "integrations" },
   { id: "archived", label: "Archived", builtIn: "archived" },
 ];

--- a/app/src/components/shell/agent-sidebar-color-menu.tsx
+++ b/app/src/components/shell/agent-sidebar-color-menu.tsx
@@ -6,10 +6,11 @@ import {
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
+  agentColorId,
   colorHex,
 } from "@houston-ai/core";
 
-const AGENT_COLOR_LABEL_KEYS: Record<string, AgentColorLabelKey> = {
+export const AGENT_COLOR_LABEL_KEYS: Record<string, AgentColorLabelKey> = {
   charcoal: "shell:sidebar.colorLabels.charcoal",
   forest: "shell:sidebar.colorLabels.forest",
   navy: "shell:sidebar.colorLabels.navy",
@@ -19,7 +20,7 @@ const AGENT_COLOR_LABEL_KEYS: Record<string, AgentColorLabelKey> = {
   golden: "shell:sidebar.colorLabels.golden",
 };
 
-type AgentColorLabelKey =
+export type AgentColorLabelKey =
   | "shell:sidebar.colorLabels.charcoal"
   | "shell:sidebar.colorLabels.forest"
   | "shell:sidebar.colorLabels.navy"
@@ -44,7 +45,7 @@ export function AgentSidebarColorMenu({
       <DropdownMenuSubTrigger>{t("sidebar.changeColor")}</DropdownMenuSubTrigger>
       <DropdownMenuSubContent>
         <DropdownMenuRadioGroup
-          value={agentColorValue(color)}
+          value={agentColorId(color)}
           onValueChange={onChange}
         >
           {AGENT_COLORS.map((entry) => (
@@ -64,12 +65,4 @@ export function AgentSidebarColorMenu({
       </DropdownMenuSubContent>
     </DropdownMenuSub>
   );
-}
-
-function agentColorValue(color: string | undefined): string {
-  const match = AGENT_COLORS.find(
-    (entry) =>
-      entry.id === color || entry.light === color || entry.dark === color,
-  );
-  return match?.id ?? AGENT_COLORS[0].id;
 }

--- a/app/src/components/tabs/agent-settings-content.tsx
+++ b/app/src/components/tabs/agent-settings-content.tsx
@@ -13,9 +13,10 @@ import { AGENT_COLOR_LABEL_KEYS } from "../shell/agent-sidebar-color-menu";
 import { canSaveName } from "./agent-settings-model";
 
 /**
- * The "Settings" sub-tab of an agent's Job Description. Surfaces the same
- * actions as the sidebar card's three-dots menu (rename, color, share, delete)
- * as a full settings panel instead of a dropdown.
+ * The "Settings" sub-tab of an agent's Agent Settings tab (tab id
+ * `job-description`). Surfaces the same actions as the sidebar card's
+ * three-dots menu (rename, color, share, delete) as a full settings panel
+ * instead of a dropdown.
  */
 export function AgentSettingsContent({
   name,

--- a/app/src/components/tabs/agent-settings-content.tsx
+++ b/app/src/components/tabs/agent-settings-content.tsx
@@ -13,7 +13,7 @@ import { AGENT_COLOR_LABEL_KEYS } from "../shell/agent-sidebar-color-menu";
 import { canSaveName } from "./agent-settings-model";
 
 /**
- * The "Settings" sub-tab of an agent's Agent Settings tab (tab id
+ * The "General" sub-tab of an agent's Agent Settings tab (tab id
  * `job-description`). Surfaces the same actions as the sidebar card's
  * three-dots menu (rename, color, share, delete) as a full settings panel
  * instead of a dropdown.

--- a/app/src/components/tabs/agent-settings-content.tsx
+++ b/app/src/components/tabs/agent-settings-content.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  AGENT_COLORS,
+  Button,
+  ConfirmDialog,
+  agentColorId,
+  colorHex,
+  cn,
+} from "@houston-ai/core";
+import { Share2 } from "lucide-react";
+import { AGENT_COLOR_LABEL_KEYS } from "../shell/agent-sidebar-color-menu";
+import { canSaveName } from "./agent-settings-model";
+
+/**
+ * The "Settings" sub-tab of an agent's Job Description. Surfaces the same
+ * actions as the sidebar card's three-dots menu (rename, color, share, delete)
+ * as a full settings panel instead of a dropdown.
+ */
+export function AgentSettingsContent({
+  name,
+  color,
+  onRename,
+  onChangeColor,
+  onShare,
+  onDelete,
+}: {
+  name: string;
+  color: string | undefined;
+  onRename: (name: string) => Promise<unknown>;
+  onChangeColor: (color: string) => Promise<unknown>;
+  onShare: () => void;
+  onDelete: () => Promise<unknown>;
+}) {
+  const { t } = useTranslation(["agents", "shell", "common", "portable"]);
+  const [draftName, setDraftName] = useState(name);
+  const [showConfirm, setShowConfirm] = useState(false);
+  const selectedColor = agentColorId(color);
+
+  // Keep the field in sync when the rename lands (the store re-selects the
+  // agent with its new, on-disk name) or the user switches agents.
+  useEffect(() => {
+    setDraftName(name);
+  }, [name]);
+
+  const handleRename = async () => {
+    if (!canSaveName(name, draftName)) {
+      setDraftName(name);
+      return;
+    }
+    try {
+      await onRename(draftName.trim());
+    } catch {
+      // The store/tauri layer already surfaced the reason as a toast (e.g. a
+      // name clash). Restore the field to the agent's real name so the input
+      // doesn't keep showing the rejected text.
+      setDraftName(name);
+    }
+  };
+
+  const handleConfirmDelete = async () => {
+    setShowConfirm(false);
+    await onDelete();
+  };
+
+  return (
+    <div className="mx-auto max-w-xl px-8 py-10 space-y-10">
+      <section>
+        <h2 className="text-lg font-semibold mb-4">
+          {t("agents:agentSettings.nameTitle")}
+        </h2>
+        <label
+          htmlFor="agent-settings-name"
+          className="text-xs text-muted-foreground block mb-1.5"
+        >
+          {t("agents:agentSettings.nameLabel")}
+        </label>
+        <input
+          id="agent-settings-name"
+          type="text"
+          value={draftName}
+          onChange={(e) => setDraftName(e.target.value)}
+          onBlur={() => void handleRename()}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") void handleRename();
+          }}
+          placeholder={t("agents:agentSettings.namePlaceholder")}
+          className="w-full rounded-xl border border-border bg-card px-4 py-2.5 text-sm outline-none focus:ring-1 focus:ring-ring transition-all"
+        />
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold mb-1">
+          {t("agents:agentSettings.colorTitle")}
+        </h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          {t("agents:agentSettings.colorHelper")}
+        </p>
+        <div className="flex flex-wrap gap-2.5">
+          {AGENT_COLORS.map((entry) => {
+            const isActive = entry.id === selectedColor;
+            const label = t(
+              AGENT_COLOR_LABEL_KEYS[entry.id] ??
+                "shell:sidebar.colorLabels.charcoal",
+            );
+            return (
+              <button
+                key={entry.id}
+                type="button"
+                aria-label={label}
+                aria-pressed={isActive}
+                title={label}
+                onClick={() => void onChangeColor(entry.id)}
+                className={cn(
+                  "size-7 rounded-full transition-transform hover:scale-110",
+                  "ring-offset-2 ring-offset-background",
+                  isActive && "ring-2 ring-ring",
+                )}
+                style={{ backgroundColor: colorHex(entry) }}
+              />
+            );
+          })}
+        </div>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold mb-1">
+          {t("agents:agentSettings.shareTitle")}
+        </h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          {t("agents:agentSettings.shareHelper")}
+        </p>
+        <Button variant="secondary" className="rounded-full" onClick={onShare}>
+          <Share2 className="size-4" />
+          {t("portable:shareMenu")}
+        </Button>
+      </section>
+
+      <section>
+        <h2 className="text-lg font-semibold text-destructive mb-1">
+          {t("agents:agentSettings.dangerTitle")}
+        </h2>
+        <p className="text-sm text-muted-foreground mb-4">
+          {t("agents:agentSettings.dangerHelper")}
+        </p>
+        <Button
+          variant="destructive"
+          className="rounded-full"
+          onClick={() => setShowConfirm(true)}
+        >
+          {t("common:actions.delete")}
+        </Button>
+      </section>
+
+      <ConfirmDialog
+        open={showConfirm}
+        onOpenChange={setShowConfirm}
+        title={t("shell:agentDelete.title")}
+        description={t("shell:agentDelete.description")}
+        confirmLabel={t("common:actions.delete")}
+        onConfirm={() => void handleConfirmDelete()}
+      />
+    </div>
+  );
+}

--- a/app/src/components/tabs/agent-settings-model.ts
+++ b/app/src/components/tabs/agent-settings-model.ts
@@ -1,0 +1,14 @@
+/**
+ * Pure helpers for the agent Settings sub-tab. Kept dependency-free so they can
+ * be unit-tested without a DOM.
+ */
+
+/**
+ * Whether a pending name edit should be committed: non-empty after trimming and
+ * different from the current name. Gates the on-blur / Enter rename so an empty
+ * or no-op edit doesn't fire a pointless rename.
+ */
+export function canSaveName(current: string, draft: string): boolean {
+  const trimmed = draft.trim();
+  return trimmed.length > 0 && trimmed !== current;
+}

--- a/app/src/components/tabs/job-description-parts.tsx
+++ b/app/src/components/tabs/job-description-parts.tsx
@@ -9,7 +9,7 @@ import {
 } from "@houston-ai/core";
 import { FileText } from "lucide-react";
 
-export type SubTab = "instructions" | "skills" | "learnings" | "settings";
+export type SubTab = "instructions" | "skills" | "learnings" | "general";
 
 type SaveState = "idle" | "saving" | "saved";
 

--- a/app/src/components/tabs/job-description-parts.tsx
+++ b/app/src/components/tabs/job-description-parts.tsx
@@ -9,7 +9,7 @@ import {
 } from "@houston-ai/core";
 import { FileText } from "lucide-react";
 
-export type SubTab = "instructions" | "skills" | "learnings";
+export type SubTab = "instructions" | "skills" | "learnings" | "settings";
 
 type SaveState = "idle" | "saving" | "saved";
 

--- a/app/src/components/tabs/job-description-tab.tsx
+++ b/app/src/components/tabs/job-description-tab.tsx
@@ -57,7 +57,7 @@ export default function JobDescriptionTab({ agent }: TabProps) {
       { id: "instructions", label: t("subTabs.instructions"), icon: FileText },
       { id: "skills", label: t("subTabs.skills"), icon: LibraryBig },
       { id: "learnings", label: t("subTabs.learnings"), icon: Brain },
-      { id: "settings", label: t("subTabs.settings"), icon: Settings },
+      { id: "general", label: t("subTabs.general"), icon: Settings },
     ],
     [t],
   );
@@ -120,7 +120,7 @@ export default function JobDescriptionTab({ agent }: TabProps) {
           />
         )}
 
-        {activeTab === "settings" && (
+        {activeTab === "general" && (
           <AgentSettingsContent
             name={agent.name}
             color={agent.color}

--- a/app/src/components/tabs/job-description-tab.tsx
+++ b/app/src/components/tabs/job-description-tab.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { FileText, LibraryBig, Brain } from "lucide-react";
+import { FileText, LibraryBig, Brain, Settings } from "lucide-react";
 import { SkillDetailPage } from "@houston-ai/skills";
 import {
   useInstructions,
@@ -12,8 +12,11 @@ import {
 } from "../../hooks/queries";
 import type { TabProps } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
+import { useWorkspaceStore } from "../../stores/workspaces";
+import { useAgentStore } from "../../stores/agents";
 import { LearningsContent } from "./learnings-content";
 import { InstructionsContent, type SubTab } from "./job-description-parts";
+import { AgentSettingsContent } from "./agent-settings-content";
 import { SkillsContent } from "./skills-content";
 import { useSkillSurface } from "./use-skill-surface";
 import {
@@ -28,6 +31,11 @@ export default function JobDescriptionTab({ agent }: TabProps) {
   const [activeTab, setActiveTab] = useState<SubTab>("instructions");
   const targetTab = useUIStore((s) => s.jobDescriptionTarget);
   const setTargetTab = useUIStore((s) => s.setJobDescriptionTarget);
+  const setShareAgentId = useUIStore((s) => s.setShareAgentId);
+  const currentWorkspace = useWorkspaceStore((s) => s.current);
+  const renameAgent = useAgentStore((s) => s.rename);
+  const deleteAgent = useAgentStore((s) => s.delete);
+  const updateAgentColor = useAgentStore((s) => s.updateColor);
 
   const { data: instructions } = useInstructions(path);
   const saveInstructions = useSaveInstructions(path);
@@ -49,6 +57,7 @@ export default function JobDescriptionTab({ agent }: TabProps) {
       { id: "instructions", label: t("subTabs.instructions"), icon: FileText },
       { id: "skills", label: t("subTabs.skills"), icon: LibraryBig },
       { id: "learnings", label: t("subTabs.learnings"), icon: Brain },
+      { id: "settings", label: t("subTabs.settings"), icon: Settings },
     ],
     [t],
   );
@@ -108,6 +117,29 @@ export default function JobDescriptionTab({ agent }: TabProps) {
             onAdd={(text) => addLearning.mutateAsync(text)}
             onRemove={(index) => removeLearning.mutateAsync(index)}
             onUpdate={(id, text) => updateLearning.mutateAsync({ id, text })}
+          />
+        )}
+
+        {activeTab === "settings" && (
+          <AgentSettingsContent
+            name={agent.name}
+            color={agent.color}
+            onRename={(newName) =>
+              currentWorkspace
+                ? renameAgent(currentWorkspace.id, agent.id, newName)
+                : Promise.resolve()
+            }
+            onChangeColor={(color) =>
+              currentWorkspace
+                ? updateAgentColor(currentWorkspace.id, agent.id, color)
+                : Promise.resolve()
+            }
+            onShare={() => setShareAgentId(agent.id)}
+            onDelete={() =>
+              currentWorkspace
+                ? deleteAgent(currentWorkspace.id, agent.id)
+                : Promise.resolve()
+            }
           />
         )}
       </div>

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -35,7 +35,19 @@
   "subTabs": {
     "instructions": "Instructions",
     "skills": "Skills",
-    "learnings": "Learnings"
+    "learnings": "Learnings",
+    "settings": "Settings"
+  },
+  "agentSettings": {
+    "nameTitle": "Name",
+    "nameLabel": "What your agent is called",
+    "namePlaceholder": "Name your agent",
+    "colorTitle": "Color",
+    "colorHelper": "Pick a color for your agent's avatar.",
+    "shareTitle": "Share",
+    "shareHelper": "Send a copy of this agent to a friend.",
+    "dangerTitle": "Delete agent",
+    "dangerHelper": "Permanently remove this agent and everything it has done. This cannot be undone."
   },
   "tabLabels": {
     "activity": "Activity",

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -36,7 +36,7 @@
     "instructions": "Instructions",
     "skills": "Skills",
     "learnings": "Learnings",
-    "settings": "Settings"
+    "general": "General"
   },
   "agentSettings": {
     "nameTitle": "Name",

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -54,7 +54,7 @@
     "archived": "Archived",
     "routines": "Routines",
     "files": "Files",
-    "job-description": "Job Description",
+    "job-description": "Agent Settings",
     "integrations": "Integrations",
     "chat": "Chat",
     "board": "Board",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -83,8 +83,8 @@
         "body": "Docs your assistant can read or share with you. Drop anything here for context."
       },
       "tabJobDescription": {
-        "title": "Job Description",
-        "body": "Your assistant's standing instructions. Edit any time to change how it behaves."
+        "title": "Agent Settings",
+        "body": "Shape how your assistant works: its instructions, skills, and settings. Update them any time."
       },
       "missionControl": {
         "title": "Mission Control",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -54,7 +54,7 @@
     "archived": "Archivadas",
     "routines": "Rutinas",
     "files": "Archivos",
-    "job-description": "Descripción del rol",
+    "job-description": "Configuración del agente",
     "integrations": "Integraciones",
     "chat": "Chat",
     "board": "Tablero",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -36,7 +36,7 @@
     "instructions": "Instrucciones",
     "skills": "Skills",
     "learnings": "Aprendizajes",
-    "settings": "Configuración"
+    "general": "General"
   },
   "agentSettings": {
     "nameTitle": "Nombre",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -35,7 +35,19 @@
   "subTabs": {
     "instructions": "Instrucciones",
     "skills": "Skills",
-    "learnings": "Aprendizajes"
+    "learnings": "Aprendizajes",
+    "settings": "Configuración"
+  },
+  "agentSettings": {
+    "nameTitle": "Nombre",
+    "nameLabel": "Cómo se llama tu agente",
+    "namePlaceholder": "Nombra a tu agente",
+    "colorTitle": "Color",
+    "colorHelper": "Elige un color para el avatar de tu agente.",
+    "shareTitle": "Compartir",
+    "shareHelper": "Envía una copia de este agente a un amigo.",
+    "dangerTitle": "Eliminar agente",
+    "dangerHelper": "Elimina este agente y todo lo que ha hecho de forma permanente. Esto no se puede deshacer."
   },
   "tabLabels": {
     "activity": "Actividad",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -83,8 +83,8 @@
         "body": "Documentos que tu asistente puede leer o compartir contigo. Arrastra lo que quieras para dar contexto."
       },
       "tabJobDescription": {
-        "title": "Descripción del Puesto",
-        "body": "Las instrucciones permanentes de tu asistente. Edítalas cuando quieras para cambiar cómo se comporta."
+        "title": "Configuración del agente",
+        "body": "Define cómo trabaja tu asistente: sus instrucciones, skills y configuración. Actualízalo cuando quieras."
       },
       "missionControl": {
         "title": "Centro de Misión",

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -35,7 +35,19 @@
   "subTabs": {
     "instructions": "Instruções",
     "skills": "Skills",
-    "learnings": "Aprendizados"
+    "learnings": "Aprendizados",
+    "settings": "Configurações"
+  },
+  "agentSettings": {
+    "nameTitle": "Nome",
+    "nameLabel": "Como o seu agente se chama",
+    "namePlaceholder": "Dê um nome ao seu agente",
+    "colorTitle": "Cor",
+    "colorHelper": "Escolha uma cor para o avatar do seu agente.",
+    "shareTitle": "Compartilhar",
+    "shareHelper": "Envie uma cópia deste agente para um amigo.",
+    "dangerTitle": "Excluir agente",
+    "dangerHelper": "Remova este agente e tudo o que ele fez permanentemente. Isso não pode ser desfeito."
   },
   "tabLabels": {
     "activity": "Atividade",

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -54,7 +54,7 @@
     "archived": "Arquivadas",
     "routines": "Rotinas",
     "files": "Arquivos",
-    "job-description": "Descrição do papel",
+    "job-description": "Configurações do agente",
     "integrations": "Integrações",
     "chat": "Chat",
     "board": "Quadro",

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -36,7 +36,7 @@
     "instructions": "Instruções",
     "skills": "Skills",
     "learnings": "Aprendizados",
-    "settings": "Configurações"
+    "general": "Geral"
   },
   "agentSettings": {
     "nameTitle": "Nome",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -83,8 +83,8 @@
         "body": "Documentos que seu assistente pode ler ou compartilhar com você. Solte qualquer coisa aqui para dar contexto."
       },
       "tabJobDescription": {
-        "title": "Descrição do Cargo",
-        "body": "As instruções permanentes do seu assistente. Edite quando quiser para mudar como ele se comporta."
+        "title": "Configurações do agente",
+        "body": "Defina como o seu assistente trabalha: suas instruções, skills e configurações. Atualize quando quiser."
       },
       "missionControl": {
         "title": "Central de Missão",

--- a/app/tests/agent-settings-model.test.ts
+++ b/app/tests/agent-settings-model.test.ts
@@ -1,0 +1,26 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { canSaveName } from "../src/components/tabs/agent-settings-model.ts";
+
+describe("agent settings model — canSaveName", () => {
+  it("allows saving a changed, non-empty name", () => {
+    strictEqual(canSaveName("Ada", "Grace"), true);
+  });
+
+  it("trims before comparing, so re-spacing the same name is a no-op", () => {
+    strictEqual(canSaveName("Ada", "  Ada  "), false);
+  });
+
+  it("rejects an unchanged name", () => {
+    strictEqual(canSaveName("Ada", "Ada"), false);
+  });
+
+  it("rejects an empty or whitespace-only name", () => {
+    strictEqual(canSaveName("Ada", ""), false);
+    strictEqual(canSaveName("Ada", "   "), false);
+  });
+
+  it("allows saving a trimmed variant that differs from current", () => {
+    strictEqual(canSaveName("Ada", "  Grace  "), true);
+  });
+});

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -30,7 +30,7 @@ interface AgentManifest {
 ## Tabs
 
 Every agent renders the same five tabs in the shell:
-`Activity` (board) / `Routines` / `Files` / `Job Description` / `Integrations`.
+`Activity` (board) / `Routines` / `Files` / `Agent Settings` (tab id `job-description`) / `Integrations`.
 
 This used to be configurable per agent via a `tabs: AgentTab[]` field in `houston.json`, plus an optional `customComponent` pointing at a per-agent `bundle.js`. The flexibility was never used in practice (zero shipped agents had a custom React tab) and caused drift between installed agents and fresh ones whenever the default set changed. The set is now hardcoded in `app/src/agents/standard-tabs.ts` (`STANDARD_TABS`, `DEFAULT_TAB_ID`). Old `tabs` / `defaultTab` fields on installed manifests are ignored by the loader.
 

--- a/ui/core/src/agent-colors.ts
+++ b/ui/core/src/agent-colors.ts
@@ -24,6 +24,19 @@ export function resolveAgentColor(stored: string | undefined): string {
   return stored;
 }
 
+/**
+ * Resolve a stored color value (id, light hex, or dark hex) to its canonical
+ * palette id, defaulting to the first color when nothing matches. Used to mark
+ * the active swatch in color pickers.
+ */
+export function agentColorId(stored: string | undefined): string {
+  const match = AGENT_COLORS.find(
+    (entry) =>
+      entry.id === stored || entry.light === stored || entry.dark === stored,
+  );
+  return match?.id ?? AGENT_COLORS[0].id;
+}
+
 export function colorHex(color: AgentColor): string {
   return isDark() ? color.dark : color.light;
 }


### PR DESCRIPTION
## What

HOU-492 asks for **agent settings at the bottom of the Job Description menu** and (per the title) to call that surface **Agent Settings**. This PR does both:

1. **Renames the tab** "Job Description" → **"Agent Settings"** (en/es/pt + the onboarding-tour step). The internal tab id/slug stays `job-description` so persisted last-tab state, the built-in resolver key, and the sub-tab deep-links keep working.
2. **Adds a Settings entry** at the bottom of that tab's left nav (Instructions / Skills / Learnings / **Settings**), surfacing the four sidebar agent-card three-dots actions as a panel instead of a dropdown:
   - **Name** — rename the agent (commits on blur / Enter; reverts on failure)
   - **Color** — pick the avatar color from the 7-color palette
   - **Share** — "Share with a friend" (opens the existing export wizard)
   - **Delete agent** — destructive, gated behind the existing confirm dialog

## How

- New `AgentSettingsContent` panel that follows the existing settings-section visual idiom (`app/src/components/settings/sections/*`). Wired into `JobDescriptionTab` using the same store actions the sidebar uses (`useAgentStore` rename/delete/updateColor, `setShareAgentId`).
- Promoted the private `agentColorValue` helper to a shared `agentColorId` in `@houston-ai/core` and reuse it in both the sidebar color menu and the new panel — removes the duplication rather than copying it.
- Extracted a pure `canSaveName` guard and unit-tested it.
- `en` / `es` / `pt` strings for the renamed tab, the new sub-tab label, and the panel; tour copy broadened to cover instructions + skills + settings.

## Review

Ran an adversarial multi-agent review (correctness / boundaries / i18n+a11y). Confirmed findings were all fixed: label↔input association for the name field, name-field revert on rename failure, and a stale doc comment.

## Affected files

- `ui/core/src/agent-colors.ts` — new `agentColorId`
- `app/src/components/shell/agent-sidebar-color-menu.tsx` — use shared helper
- `app/src/components/tabs/agent-settings-content.tsx` — new panel
- `app/src/components/tabs/agent-settings-model.ts` + test — `canSaveName`
- `app/src/components/tabs/job-description-tab.tsx`, `job-description-parts.tsx` — nav item + wiring
- `app/src/agents/standard-tabs.ts` — tab label
- `app/src/locales/{en,es,pt}/agents.json`, `.../shell.json` — strings + tour
- `knowledge-base/agent-manifest.md` — tab list

## Verification

- `cd app && pnpm tsc --noEmit` ✅
- `pnpm typecheck` (all ui/ packages incl. core) ✅
- `cd app && pnpm check-locales` ✅ (en/es/pt in sync)
- `cd app && pnpm test` ✅ 325 pass (incl. new `agent-settings-model` test)

**Before:** the tab is "Job Description" with Instructions / Skills / Learnings; rename/recolor/share/delete live only in the sidebar card's `…` menu.
**After:** the tab is "Agent Settings" with a 4th **Settings** entry; from it you can rename, change color, share, and delete the agent. The sidebar `…` menu still works (shared color helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)