### PR TITLE
fix(engine): recover routines with unescaped control chars instead of wiping them (HOU-494)

### DIFF
--- a/engine/houston-engine-core/src/agents/store.rs
+++ b/engine/houston-engine-core/src/agents/store.rs
@@ -67,6 +67,12 @@ pub fn with_json_file_lock<T>(
 /// - a leading UTF-8 BOM (U+FEFF) is stripped before parsing; serde_json
 ///   does not skip one, so a BOM-prefixed file otherwise fails at line 1
 ///   column 1 (editors, cloud-sync, and Windows writers all emit BOMs)
+/// - unescaped control characters inside a string literal (a raw newline or
+///   tab an external editor, sync client, or agent wrote into a multi-line
+///   value) are escaped in place and the document re-parsed — lossless, so
+///   every record survives (HOU-494: a routine `prompt` carried a literal
+///   newline, making routines.json unparseable, and the reset path below then
+///   wiped every routine)
 /// - one valid value followed by trailing junk → keep the first value
 /// - otherwise unparseable → reset to `T::default()`
 ///
@@ -97,12 +103,15 @@ pub fn write_json<T: Serialize>(root: &Path, name: &str, data: &T) -> CoreResult
         .map_err(|e| CoreError::Internal(format!("failed to write {rel}: {e}")))
 }
 
-/// Recover a `.houston` JSON file that failed to parse. Least-lossy salvage
-/// first (one valid value + trailing junk → keep the value), then reset to
-/// `T::default()`. Either way the original bytes are preserved as a `.bak`
-/// and a warning logged, so a corrupt data file degrades to an empty surface
-/// rather than hard-erroring the read (HOU-436). A backup-write failure still
-/// surfaces — that's a real, actionable error, not a recoverable one.
+/// Recover a `.houston` JSON file that failed to parse. Least-lossy first:
+/// 1. escape unescaped control characters inside string literals and re-parse
+///    — lossless, recovers every record (HOU-494);
+/// 2. one valid value + trailing junk → keep the first value (drops the junk);
+/// 3. reset to `T::default()` (last resort, drops everything).
+/// Either way the original bytes are preserved as a `.bak` and a warning
+/// logged, so a corrupt data file degrades gracefully rather than
+/// hard-erroring the read (HOU-436). A backup-write failure still surfaces —
+/// that's a real, actionable error, not a recoverable one.
 fn repair_json<T: DeserializeOwned + Serialize + Default>(
     root: &Path,
     name: &str,
@@ -110,7 +119,29 @@ fn repair_json<T: DeserializeOwned + Serialize + Default>(
     contents: &str,
     err: &serde_json::Error,
 ) -> CoreResult<T> {
-    if let Some(value) = parse_first_json_value::<T>(contents) {
+    // The most common external-writer corruption: a literal control char (a
+    // raw newline/tab a sync client, editor, or agent dropped into a
+    // multi-line value) inside a JSON string. serde rejects it with "control
+    // character (\u0000-\u001F) found while parsing a string". Escaping it in
+    // place is lossless — the string's logical content is identical — so once
+    // it parses, every record is recovered. Compose with the trailing-junk
+    // salvage below by running both against the escaped text.
+    let escaped = escape_control_chars_in_strings(contents);
+    let effective = escaped.as_deref().unwrap_or(contents);
+
+    if escaped.is_some() {
+        if let Ok(value) = serde_json::from_str::<T>(effective) {
+            backup_and_write(root, name, contents, &value)?;
+            tracing::warn!(
+                file = rel,
+                error = %err,
+                "repaired JSON file by escaping unescaped control characters"
+            );
+            return Ok(value);
+        }
+    }
+
+    if let Some(value) = parse_first_json_value::<T>(effective) {
         backup_and_write(root, name, contents, &value)?;
         tracing::warn!(
             file = rel,
@@ -128,6 +159,65 @@ fn repair_json<T: DeserializeOwned + Serialize + Default>(
         "reset corrupt JSON file to default after preserving backup"
     );
     Ok(value)
+}
+
+/// Escape literal control characters (U+0000–U+001F) that appear *inside* JSON
+/// string literals, leaving structural whitespace between tokens untouched.
+///
+/// JSON forbids raw control chars in strings, so serde fails the whole parse on
+/// the first one ("control character (\u0000-\u001F) found while parsing a
+/// string"). An external editor, sync client, or agent that rewrites a
+/// `.houston` file and splices a raw newline/tab into a multi-line value
+/// produces exactly this (HOU-494). Re-encoding each offender to its escape
+/// (`\n`, `\r`, `\t`, else `\u00xx`) preserves the value byte-for-byte once
+/// decoded.
+///
+/// Returns `None` when nothing needed escaping, so a file that failed to parse
+/// for some other reason is not pointlessly rewritten.
+fn escape_control_chars_in_strings(contents: &str) -> Option<String> {
+    let mut out = String::with_capacity(contents.len());
+    let mut in_string = false;
+    // Whether the previous char inside a string was a lone backslash, so the
+    // current char is part of an escape sequence and must pass through verbatim.
+    let mut after_backslash = false;
+    let mut changed = false;
+
+    for ch in contents.chars() {
+        if !in_string {
+            if ch == '"' {
+                in_string = true;
+            }
+            out.push(ch);
+            continue;
+        }
+        if after_backslash {
+            out.push(ch);
+            after_backslash = false;
+            continue;
+        }
+        match ch {
+            '\\' => {
+                out.push(ch);
+                after_backslash = true;
+            }
+            '"' => {
+                out.push(ch);
+                in_string = false;
+            }
+            c if (c as u32) < 0x20 => {
+                match c {
+                    '\n' => out.push_str("\\n"),
+                    '\r' => out.push_str("\\r"),
+                    '\t' => out.push_str("\\t"),
+                    other => out.push_str(&format!("\\u{:04x}", other as u32)),
+                }
+                changed = true;
+            }
+            _ => out.push(ch),
+        }
+    }
+
+    changed.then_some(out)
 }
 
 fn parse_first_json_value<T: DeserializeOwned>(contents: &str) -> Option<T> {
@@ -228,5 +318,69 @@ mod tests {
         let v: Vec<i64> = read_json(d.path(), NAME).unwrap();
         assert_eq!(v, vec![1, 2, 3], "first value salvaged, trailing dropped");
         assert!(has_backup(d.path(), NAME));
+    }
+
+    #[test]
+    fn unescaped_newline_in_string_recovers_every_record_losslessly() {
+        // HOU-494: an external writer (sync client / editor / agent) spliced a
+        // raw newline into a multi-line string value, so serde failed the whole
+        // parse with "control character (\u0000-\u001F) found while parsing a
+        // string". The old reset path then wiped EVERY record. The repair must
+        // escape the stray newline and recover all values, newline intact.
+        let d = TempDir::new().unwrap();
+        // The `\n` between "line1" and "line2" is a real newline byte sitting
+        // INSIDE the JSON string — exactly the corruption seen on disk.
+        write_raw(d.path(), NAME, "[\"keep me\", \"line1\nline2\"]");
+
+        let v: Vec<String> = read_json(d.path(), NAME).unwrap();
+        assert_eq!(v, vec!["keep me".to_string(), "line1\nline2".to_string()]);
+        assert!(has_backup(d.path(), NAME), "original bytes preserved in .bak");
+
+        // File was rewritten as valid JSON, so a re-read is clean and does NOT
+        // produce a second backup (no repeated corruption every poll).
+        let again: Vec<String> = read_json(d.path(), NAME).unwrap();
+        assert_eq!(again, v);
+        let backups = std::fs::read_dir(houston_dir(d.path()).join(NAME))
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|e| e.file_name().to_string_lossy().contains(".corrupt-"))
+            .count();
+        assert_eq!(backups, 1, "recovery is one-shot, not re-triggered on re-read");
+    }
+
+    #[test]
+    fn escapes_tab_and_carriage_return_inside_strings() {
+        let d = TempDir::new().unwrap();
+        // Raw TAB and CR bytes inside the string value.
+        write_raw(d.path(), NAME, "[\"a\tb\rc\"]");
+        let v: Vec<String> = read_json(d.path(), NAME).unwrap();
+        assert_eq!(v, vec!["a\tb\rc".to_string()]);
+        assert!(has_backup(d.path(), NAME));
+    }
+
+    #[test]
+    fn control_char_repair_composes_with_trailing_junk_salvage() {
+        // Compound corruption: a raw newline inside a string AND trailing junk.
+        // Escaping runs first, then the first-value salvage drops the junk.
+        let d = TempDir::new().unwrap();
+        write_raw(d.path(), NAME, "[\"a\nb\"]\n[\"junk\"]");
+        let v: Vec<String> = read_json(d.path(), NAME).unwrap();
+        assert_eq!(v, vec!["a\nb".to_string()], "newline escaped, trailing dropped");
+        assert!(has_backup(d.path(), NAME));
+    }
+
+    #[test]
+    fn escape_control_chars_leaves_structural_whitespace_and_valid_strings_alone() {
+        // A newline BETWEEN tokens is structural JSON whitespace, not a string
+        // control char — it must not be touched (else we'd rewrite files that
+        // failed to parse for unrelated reasons).
+        assert!(escape_control_chars_in_strings("[1,\n2]").is_none());
+        // Already-escaped content is untouched too.
+        assert!(escape_control_chars_in_strings("[\"a\\nb\"]").is_none());
+        // A raw newline inside a string IS rewritten to the `\n` escape.
+        assert_eq!(
+            escape_control_chars_in_strings("[\"a\nb\"]").as_deref(),
+            Some("[\"a\\nb\"]"),
+        );
     }
 }

--- a/engine/houston-engine-core/src/routines/mod.rs
+++ b/engine/houston-engine-core/src/routines/mod.rs
@@ -428,4 +428,44 @@ mod tests {
         assert_eq!(all.len(), 1);
         assert_eq!(all[0].id, r.id);
     }
+
+    #[test]
+    fn unescaped_newline_in_prompt_recovers_routines_instead_of_wiping_them() {
+        // HOU-494 end to end: a routine's `prompt` held a LITERAL newline (an
+        // external editor / sync client / the agent wrote it raw instead of
+        // `\n`), making routines.json unparseable. v0.4.23's recovery then
+        // reset the file to `[]` and every routine vanished. The fix escapes
+        // the stray control char and recovers all routines, prompt intact.
+        let d = TempDir::new().unwrap();
+        let dir = d.path().join(".houston/routines");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        // `@@` marks where a RAW newline byte sits inside the prompt string —
+        // the exact shape of the `.corrupt-*.bak` files attached to the issue.
+        let template = r#"[
+          {"id":"a","name":"Keep me","description":"","prompt":"single line",
+           "schedule":"0 9 * * 1-5","enabled":true,"suppress_when_silent":true,
+           "integrations":[],"created_at":"2026-05-01T00:00:00Z","updated_at":"2026-05-01T00:00:00Z"},
+          {"id":"b","name":"Multi line","description":"","prompt":"first line@@second line",
+           "schedule":"0 * * * *","enabled":true,"suppress_when_silent":true,
+           "integrations":[],"created_at":"2026-05-01T00:00:00Z","updated_at":"2026-05-01T00:00:00Z"}
+        ]"#;
+        std::fs::write(dir.join("routines.json"), template.replace("@@", "\n")).unwrap();
+
+        let loaded = list(d.path()).unwrap();
+        assert_eq!(loaded.len(), 2, "both routines recovered, none wiped");
+        assert_eq!(loaded[0].id, "a");
+        assert_eq!(loaded[1].id, "b");
+        assert_eq!(loaded[1].prompt, "first line\nsecond line", "newline preserved");
+
+        // Original corrupt bytes are preserved as a sibling `.corrupt-*.bak`.
+        let has_bak = std::fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(Result::ok)
+            .any(|e| e.file_name().to_string_lossy().contains(".corrupt-"));
+        assert!(has_bak, "original bytes preserved in a .corrupt-*.bak");
+
+        // The live file is valid JSON again: a re-read is clean and stable.
+        assert_eq!(list(d.path()).unwrap().len(), 2);
+    }
 }

--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -58,11 +58,22 @@ reads it (HOU-436: a malformed `routines.json` used to make every
 `list_routines` call 500 with `json error: expected value at line 1 column
 1`). Recovery is least-lossy first: a leading UTF-8 BOM is stripped before
 parsing (serde rejects one); a whitespace-only file reads as the type
-default; a file with one valid value plus trailing junk keeps the first
+default; **unescaped control characters inside a string** (a raw newline/tab
+an external editor, sync client, or agent spliced into a multi-line value)
+are escaped in place and the document re-parsed — lossless, so every record
+survives; a file with one valid value plus trailing junk keeps the first
 value; any other unparseable file resets to the type default (`[]`, `{}`,
 …). Every recovery that rewrites the file first copies the original bytes to
 `.houston/<type>/<type>.json.corrupt-<timestamp>-<uuid>.bak` and logs a
 warning, so nothing is lost silently.
+
+The control-char step is load-bearing (HOU-494): these files are explicitly
+multi-writer, so a non-Houston process (a `routines.json.tmp.<pid>.<hex>`
+temp file unlike Houston's own `.<name>.<uuid>.tmp`) can leave a literal
+newline inside a `prompt`. Without the lossless escape, that hit the reset
+path and the recovery itself *wiped* every routine — exactly the data loss it
+was meant to prevent. Reset is the last resort, for genuinely unrecoverable
+bytes only.
 
 ## Schemas
 Authoritative. Live in `ui/agent-schemas/src/*.schema.json`. Embedded in Rust via `include_str!` in `houston-agent-files::schemas`. Seeded into each agent's `.houston/<type>/<type>.schema.json` on first launch. Prompts instruct model to read schema before writing data file.


### PR DESCRIPTION
## Summary

A user reported that **all their routines disappeared after updating from v0.4.22 to v0.4.23**.

**Root cause.** `~/.houston/<agent>/.houston/routines/routines.json` contained an **unescaped control character — a literal newline byte inside a routine's `prompt` string** (the rest of the prompt used proper `\n` escapes). That makes the file invalid JSON, so serde fails the whole parse with `control character (\u0000-\u001F) found while parsing a string`.

v0.4.23 shipped the HOU-436 recovery (`store::read_json` → `repair_json`). On an unsalvageable parse error it **resets to `T::default()` (empty `[]`) and overwrites the live file** (after a `.corrupt-*.bak` backup). So the *recovery itself wiped every routine* the moment the user opened the app on 0.4.23 — confirmed in their logs:

```
WARN reset corrupt JSON file to default after preserving backup
     file=".houston/routines/routines.json"
     error=control character (\u0000-\u001F) found while parsing a string at line 19 column 0
...
INFO [routines] Stopped cron for routine knowledge-base-update
INFO [routines] Stopped cron for routine inbox-cleanup
```

The bad bytes did **not** come from Houston: its atomic writer is `serde_json::to_string_pretty` (always escapes) writing `.<name>.<uuid>.tmp`. The log shows a foreign `routines.json.tmp.<pid>.<hex>` temp file — a non-Houston writer (sync client / external editor / the routine agent's own file tool, which runs in that exact dir). `.houston/*` files are explicitly multi-writer, so the reader has to be robust to this.

## Fix

`store::read_json` / `repair_json` gets a new **lossless** recovery step that runs **before** the lossy salvage/reset paths: escape unescaped control chars that appear *inside* JSON string literals (structural whitespace between tokens is left alone) and re-parse. The string's logical content is identical once decoded, so **every record is recovered**. Only genuinely unrecoverable bytes still reach the reset path — HOU-436 behavior preserved.

The fix is in the shared typed-JSON helper, so `routine_runs` / `activity` / `config` / `learnings` get the same protection.

## Verification

**Ground truth** — ran the new repair against the two real `.corrupt-*.bak` files from the report: each recovers **both** routines (`knowledge-base-update`, `inbox-cleanup`) with prompts fully intact (59 / 56-57 newlines preserved).

Tests (all green): `cargo test --workspace`, `cargo build -p houston-engine-server`. New tests:
- `agents::store`: unescaped newline recovers every record losslessly + one-shot backup; tab/CR escaped; composes with trailing-junk salvage; structural whitespace / already-escaped content untouched.
- `routines`: `unescaped_newline_in_prompt_recovers_routines_instead_of_wiping_them` (HOU-494 end-to-end).

### Reproduce the bug (before this change)
1. In an agent's `.houston/routines/routines.json`, put a routine whose `prompt` contains a **raw** newline byte (not `\n`).
2. Open the routines screen / let the scheduler read it.
3. **Before:** `routines.json` is reset to `[]`, routines vanish, crons stop (a `.corrupt-*.bak` is left behind).

### Verify the fix (after)
1. Same corrupt file.
2. `list()` returns **all** routines with the newline intact; `routines.json` is rewritten as valid JSON; the original is preserved as `.corrupt-*.bak`; a re-read is clean (no repeated backup).

> Note for the already-affected user: their live `routines.json` is now valid `[]`, so recovery-on-read won't re-fire. Their routines are intact in the `routines.json.corrupt-*.bak` files and can be restored from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
