### PR TITLE
fix(engine): surface codex usage limit as a quota card, not a generic runtime error (HOU-495)

### DIFF
--- a/app/src/components/shell/provider-error-cards/quota.tsx
+++ b/app/src/components/shell/provider-error-cards/quota.tsx
@@ -1,16 +1,14 @@
 /**
- * Quota / model-availability variants — these are the "pay or switch"
- * outcomes. QuotaExhausted mounts an Upgrade CTA (via `tauriSystem.openUrl`)
- * that drops the user into the right provider console; ModelUnavailable is
- * informational. Both render on the unified `RowCard` (HOU-467).
+ * Quota / model-availability variants — the "pay or switch" outcomes. Both are
+ * informational: the body tells the user to upgrade or switch provider, and
+ * QuotaExhausted names the reset time when the provider gives one. Rendered on
+ * the unified `RowCard` (HOU-467).
  */
 
 import { useTranslation } from "react-i18next";
 import { AlertTriangleIcon, XCircleIcon } from "lucide-react";
 import type { ProviderError } from "@houston-ai/chat";
-import { tauriSystem } from "../../../lib/tauri";
 import { RowCard } from "../../cards/row-card";
-import { RowCardButton } from "../../cards/row-card-button";
 import { providerLabel } from "./shared";
 
 export function QuotaExhaustedCard({
@@ -32,14 +30,6 @@ export function QuotaExhaustedCard({
                 time: error.resets_at,
               })
             : t("providerError.quotaExhausted.body", { provider })
-        }
-        action={
-          error.upgrade_url && (
-            <RowCardButton
-              label={t("providerError.quotaExhausted.upgrade")}
-              onClick={() => tauriSystem.openUrl(error.upgrade_url!)}
-            />
-          )
         }
       />
     </div>

--- a/app/src/components/shell/provider-error-cards/quota.tsx
+++ b/app/src/components/shell/provider-error-cards/quota.tsx
@@ -25,7 +25,14 @@ export function QuotaExhaustedCard({
       <RowCard
         media={<XCircleIcon className="size-5" />}
         title={t("providerError.quotaExhausted.title")}
-        description={t("providerError.quotaExhausted.body", { provider })}
+        description={
+          error.resets_at
+            ? t("providerError.quotaExhausted.bodyWithReset", {
+                provider,
+                time: error.resets_at,
+              })
+            : t("providerError.quotaExhausted.body", { provider })
+        }
         action={
           error.upgrade_url && (
             <RowCardButton

--- a/app/src/components/shell/provider-error-cards/quota.tsx
+++ b/app/src/components/shell/provider-error-cards/quota.tsx
@@ -1,15 +1,17 @@
 /**
  * Quota / model-availability variants — these are the "pay or switch"
- * outcomes. CTAs lean on `tauriSystem.openUrl` to drop the user into
- * the right provider console.
+ * outcomes. QuotaExhausted mounts an Upgrade CTA (via `tauriSystem.openUrl`)
+ * that drops the user into the right provider console; ModelUnavailable is
+ * informational. Both render on the unified `RowCard` (HOU-467).
  */
 
 import { useTranslation } from "react-i18next";
 import { AlertTriangleIcon, XCircleIcon } from "lucide-react";
-import { Button } from "@houston-ai/core";
 import type { ProviderError } from "@houston-ai/chat";
 import { tauriSystem } from "../../../lib/tauri";
-import { ErrorCard, providerLabel } from "./shared";
+import { RowCard } from "../../cards/row-card";
+import { RowCardButton } from "../../cards/row-card-button";
+import { providerLabel } from "./shared";
 
 export function QuotaExhaustedCard({
   error,
@@ -19,21 +21,21 @@ export function QuotaExhaustedCard({
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
   return (
-    <ErrorCard
-      icon={<XCircleIcon className="size-5" />}
-      title={t("providerError.quotaExhausted.title")}
-      body={t("providerError.quotaExhausted.body", { provider })}
-    >
-      {error.upgrade_url && (
-        <Button
-          size="sm"
-          className="h-8 gap-2 rounded-full px-3 text-xs"
-          onClick={() => void tauriSystem.openUrl(error.upgrade_url!)}
-        >
-          {t("providerError.quotaExhausted.upgrade")}
-        </Button>
-      )}
-    </ErrorCard>
+    <div className="w-full px-1 py-2">
+      <RowCard
+        media={<XCircleIcon className="size-5" />}
+        title={t("providerError.quotaExhausted.title")}
+        description={t("providerError.quotaExhausted.body", { provider })}
+        action={
+          error.upgrade_url && (
+            <RowCardButton
+              label={t("providerError.quotaExhausted.upgrade")}
+              onClick={() => tauriSystem.openUrl(error.upgrade_url!)}
+            />
+          )
+        }
+      />
+    </div>
   );
 }
 
@@ -45,10 +47,15 @@ export function ModelUnavailableCard({
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
   return (
-    <ErrorCard
-      icon={<AlertTriangleIcon className="size-5" />}
-      title={t("providerError.modelUnavailable.title")}
-      body={t("providerError.modelUnavailable.body", { provider, model: error.model })}
-    />
+    <div className="w-full px-1 py-2">
+      <RowCard
+        media={<AlertTriangleIcon className="size-5" />}
+        title={t("providerError.modelUnavailable.title")}
+        description={t("providerError.modelUnavailable.body", {
+          provider,
+          model: error.model,
+        })}
+      />
+    </div>
   );
 }

--- a/app/src/components/shell/provider-error-cards/shared.tsx
+++ b/app/src/components/shell/provider-error-cards/shared.tsx
@@ -1,51 +1,23 @@
 /**
- * Shared layout + CTA primitives for typed-provider-error cards.
+ * Shared CTA primitives + helpers for typed-provider-error cards.
  *
- * All variants share the same secondary-tinted slab (icon + title +
- * body + button row), the same retry button shape, and the same
- * report-bug + status-page helpers. Centralising them keeps the
- * per-variant files small (each renderer = copy + which CTAs to mount).
+ * Every variant renders on the unified `RowCard` (HOU-467); these are the
+ * stateful pills that sit in its `action` slot — retry (with spinner),
+ * status-page link, and report-bug (the `reportBug` call + toast). All three
+ * are thin wrappers over `RowCardButton` so the error cards match the
+ * reconnect / integration cards exactly. The per-variant files own only the
+ * copy + which CTAs to mount.
  */
 
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
-import { BugIcon, RotateCcwIcon } from "lucide-react";
-import { Button, Spinner } from "@houston-ai/core";
 import { reportBug } from "../../../lib/bug-report";
 import { getCurrentUserEmail } from "../../../lib/current-user";
 import { tauriSystem } from "../../../lib/tauri";
 import { getProvider } from "../../../lib/providers";
 import { useUIStore } from "../../../stores/ui";
 import { useWorkspaceStore } from "../../../stores/workspaces";
-
-export function ErrorCard({
-  icon,
-  title,
-  body,
-  children,
-}: {
-  icon: React.ReactNode;
-  title: string;
-  body: string;
-  children?: React.ReactNode;
-}) {
-  return (
-    <div className="w-full px-1 py-2">
-      <div className="flex items-start gap-4 rounded-2xl bg-secondary p-4 text-left">
-        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-border bg-background text-muted-foreground">
-          {icon}
-        </div>
-        <div className="flex min-w-0 flex-1 flex-col gap-1">
-          <p className="text-sm font-semibold text-foreground">{title}</p>
-          <p className="text-xs leading-relaxed text-muted-foreground">{body}</p>
-          {children && (
-            <div className="mt-2 flex flex-wrap items-center gap-2">{children}</div>
-          )}
-        </div>
-      </div>
-    </div>
-  );
-}
+import { RowCardButton } from "../../cards/row-card-button";
 
 export function providerLabel(id: string): string {
   return getProvider(id)?.name ?? id;
@@ -68,17 +40,7 @@ export function RetryButton({
       setRunning(false);
     }
   };
-  return (
-    <Button
-      size="sm"
-      className="h-8 gap-2 rounded-full px-3 text-xs"
-      disabled={running}
-      onClick={() => void handle()}
-    >
-      {running ? <Spinner className="size-3.5" /> : <RotateCcwIcon className="size-3.5" />}
-      {label}
-    </Button>
-  );
+  return <RowCardButton label={label} onClick={handle} loading={running} />;
 }
 
 export function StatusPageButton({
@@ -91,14 +53,11 @@ export function StatusPageButton({
   const url = statusPageUrl(provider);
   if (!url) return null;
   return (
-    <Button
+    <RowCardButton
+      label={label}
       variant="outline"
-      size="sm"
-      className="h-8 gap-2 rounded-full px-3 text-xs"
-      onClick={() => void tauriSystem.openUrl(url)}
-    >
-      {label}
-    </Button>
+      onClick={() => tauriSystem.openUrl(url)}
+    />
   );
 }
 
@@ -143,16 +102,12 @@ export function ReportBugButton({
     }
   };
   return (
-    <Button
+    <RowCardButton
+      label={label}
       variant="outline"
-      size="sm"
-      className="h-8 gap-2 rounded-full px-3 text-xs"
-      disabled={sending}
-      onClick={() => void send()}
-    >
-      {sending ? <Spinner className="size-3.5" /> : <BugIcon className="size-3.5" />}
-      {label}
-    </Button>
+      onClick={send}
+      loading={sending}
+    />
   );
 }
 

--- a/app/src/components/shell/provider-error-cards/shared.tsx
+++ b/app/src/components/shell/provider-error-cards/shared.tsx
@@ -13,7 +13,6 @@ import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { reportBug } from "../../../lib/bug-report";
 import { getCurrentUserEmail } from "../../../lib/current-user";
-import { tauriSystem } from "../../../lib/tauri";
 import { getProvider } from "../../../lib/providers";
 import { useUIStore } from "../../../stores/ui";
 import { useWorkspaceStore } from "../../../stores/workspaces";
@@ -41,24 +40,6 @@ export function RetryButton({
     }
   };
   return <RowCardButton label={label} onClick={handle} loading={running} />;
-}
-
-export function StatusPageButton({
-  provider,
-  label,
-}: {
-  provider: string;
-  label: string;
-}) {
-  const url = statusPageUrl(provider);
-  if (!url) return null;
-  return (
-    <RowCardButton
-      label={label}
-      variant="outline"
-      onClick={() => tauriSystem.openUrl(url)}
-    />
-  );
 }
 
 export function ReportBugButton({
@@ -109,17 +90,4 @@ export function ReportBugButton({
       loading={sending}
     />
   );
-}
-
-export function statusPageUrl(provider: string): string | null {
-  switch (provider) {
-    case "anthropic":
-      return "https://status.anthropic.com/";
-    case "openai":
-      return "https://status.openai.com/";
-    case "gemini":
-      return "https://status.cloud.google.com/";
-    default:
-      return null;
-  }
 }

--- a/app/src/components/shell/provider-error-cards/terminal.tsx
+++ b/app/src/components/shell/provider-error-cards/terminal.tsx
@@ -2,12 +2,14 @@
  * Terminal variants — session-resume failure, spawn failure, and the
  * Unknown catch-all. The unifying theme: the user can't simply "wait
  * and retry"; they need a fresh start, a reinstall, or to file a bug.
+ * All render on the unified `RowCard` (HOU-467).
  */
 
 import { useTranslation } from "react-i18next";
 import { CloudOffIcon, RefreshCwIcon, WrenchIcon } from "lucide-react";
 import type { ProviderError } from "@houston-ai/chat";
-import { ErrorCard, ReportBugButton, RetryButton, providerLabel } from "./shared";
+import { RowCard } from "../../cards/row-card";
+import { ReportBugButton, RetryButton, providerLabel } from "./shared";
 
 interface BaseProps {
   onRetry?: () => Promise<void> | void;
@@ -22,18 +24,21 @@ export function SessionResumeMissingCard({
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
   return (
-    <ErrorCard
-      icon={<RefreshCwIcon className="size-5" />}
-      title={t("providerError.sessionResumeMissing.title")}
-      body={t("providerError.sessionResumeMissing.body", { provider })}
-    >
-      {onRetry && (
-        <RetryButton
-          onRetry={onRetry}
-          label={t("providerError.sessionResumeMissing.tryAgain")}
-        />
-      )}
-    </ErrorCard>
+    <div className="w-full px-1 py-2">
+      <RowCard
+        media={<RefreshCwIcon className="size-5" />}
+        title={t("providerError.sessionResumeMissing.title")}
+        description={t("providerError.sessionResumeMissing.body", { provider })}
+        action={
+          onRetry && (
+            <RetryButton
+              onRetry={onRetry}
+              label={t("providerError.sessionResumeMissing.tryAgain")}
+            />
+          )
+        }
+      />
+    </div>
   );
 }
 
@@ -45,17 +50,20 @@ export function SpawnFailedCard({
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
   return (
-    <ErrorCard
-      icon={<WrenchIcon className="size-5" />}
-      title={t("providerError.spawnFailed.title", { provider })}
-      body={t("providerError.spawnFailed.body", { provider })}
-    >
-      <ReportBugButton
-        command={`provider_error:spawn_failed:${error.provider}`}
-        details={error.message}
-        label={t("providerError.spawnFailed.reportBug")}
+    <div className="w-full px-1 py-2">
+      <RowCard
+        media={<WrenchIcon className="size-5" />}
+        title={t("providerError.spawnFailed.title", { provider })}
+        description={t("providerError.spawnFailed.body", { provider })}
+        action={
+          <ReportBugButton
+            command={`provider_error:spawn_failed:${error.provider}`}
+            details={error.message}
+            label={t("providerError.spawnFailed.reportBug")}
+          />
+        }
       />
-    </ErrorCard>
+    </div>
   );
 }
 
@@ -67,16 +75,19 @@ export function UnknownErrorCard({
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
   return (
-    <ErrorCard
-      icon={<CloudOffIcon className="size-5" />}
-      title={t("providerError.unknown.title")}
-      body={t("providerError.unknown.body", { provider })}
-    >
-      <ReportBugButton
-        command={`provider_error:unknown:${error.provider}`}
-        details={error.raw_excerpt}
-        label={t("providerError.unknown.reportBug")}
+    <div className="w-full px-1 py-2">
+      <RowCard
+        media={<CloudOffIcon className="size-5" />}
+        title={t("providerError.unknown.title")}
+        description={t("providerError.unknown.body", { provider })}
+        action={
+          <ReportBugButton
+            command={`provider_error:unknown:${error.provider}`}
+            details={error.raw_excerpt}
+            label={t("providerError.unknown.reportBug")}
+          />
+        }
       />
-    </ErrorCard>
+    </div>
   );
 }

--- a/app/src/components/shell/provider-error-cards/transient.tsx
+++ b/app/src/components/shell/provider-error-cards/transient.tsx
@@ -17,7 +17,7 @@ import {
 } from "lucide-react";
 import type { ProviderError } from "@houston-ai/chat";
 import { RowCard } from "../../cards/row-card";
-import { RetryButton, StatusPageButton, providerLabel } from "./shared";
+import { RetryButton, providerLabel } from "./shared";
 
 interface BaseProps {
   onRetry?: () => Promise<void> | void;
@@ -97,18 +97,12 @@ export function NetworkUnreachableCard({
         title={t("providerError.networkUnreachable.title", { provider })}
         description={t("providerError.networkUnreachable.body", { provider })}
         action={
-          <>
-            {onRetry && (
-              <RetryButton
-                onRetry={onRetry}
-                label={t("providerError.networkUnreachable.retry")}
-              />
-            )}
-            <StatusPageButton
-              provider={error.provider}
-              label={t("providerError.networkUnreachable.checkStatus")}
+          onRetry && (
+            <RetryButton
+              onRetry={onRetry}
+              label={t("providerError.networkUnreachable.retry")}
             />
-          </>
+          )
         }
       />
     </div>
@@ -130,18 +124,12 @@ export function ProviderInternalCard({
         title={t("providerError.providerInternal.title", { provider })}
         description={t("providerError.providerInternal.body", { provider })}
         action={
-          <>
-            {onRetry && (
-              <RetryButton
-                onRetry={onRetry}
-                label={t("providerError.providerInternal.retry")}
-              />
-            )}
-            <StatusPageButton
-              provider={error.provider}
-              label={t("providerError.providerInternal.checkStatus")}
+          onRetry && (
+            <RetryButton
+              onRetry={onRetry}
+              label={t("providerError.providerInternal.retry")}
             />
-          </>
+          )
         }
       />
     </div>

--- a/app/src/components/shell/provider-error-cards/transient.tsx
+++ b/app/src/components/shell/provider-error-cards/transient.tsx
@@ -3,10 +3,10 @@
  * network, provider-internal, malformed-response. They share the "wait"
  * recovery shape; rate-limited/network/internal offer a retry (and the
  * network/internal ones a status-page link), while usage-limit-paused is
- * informational — the user waits for the plan window to reset.
+ * informational — the user waits for the plan window to reset. All render on
+ * the unified `RowCard` (HOU-467).
  */
 
-import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   AlertTriangleIcon,
@@ -17,13 +17,7 @@ import {
 } from "lucide-react";
 import type { ProviderError } from "@houston-ai/chat";
 import { RowCard } from "../../cards/row-card";
-import { RowCardButton } from "../../cards/row-card-button";
-import {
-  ErrorCard,
-  RetryButton,
-  StatusPageButton,
-  providerLabel,
-} from "./shared";
+import { RetryButton, StatusPageButton, providerLabel } from "./shared";
 
 interface BaseProps {
   onRetry?: () => Promise<void> | void;
@@ -37,22 +31,12 @@ export function RateLimitedCard({
 }) {
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
-  const [retrying, setRetrying] = useState(false);
   const body = error.retry_after_seconds
     ? t("providerError.rateLimited.bodyWithRetry", {
         provider,
         seconds: error.retry_after_seconds,
       })
     : t("providerError.rateLimited.body", { provider });
-  const retry = async () => {
-    if (!onRetry || retrying) return;
-    setRetrying(true);
-    try {
-      await onRetry();
-    } finally {
-      setRetrying(false);
-    }
-  };
   return (
     <div className="w-full px-1 py-2">
       <RowCard
@@ -61,10 +45,9 @@ export function RateLimitedCard({
         description={body}
         action={
           onRetry && (
-            <RowCardButton
+            <RetryButton
+              onRetry={onRetry}
               label={t("providerError.rateLimited.retry")}
-              onClick={retry}
-              loading={retrying}
             />
           )
         }
@@ -108,22 +91,27 @@ export function NetworkUnreachableCard({
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
   return (
-    <ErrorCard
-      icon={<WifiOffIcon className="size-5" />}
-      title={t("providerError.networkUnreachable.title", { provider })}
-      body={t("providerError.networkUnreachable.body", { provider })}
-    >
-      {onRetry && (
-        <RetryButton
-          onRetry={onRetry}
-          label={t("providerError.networkUnreachable.retry")}
-        />
-      )}
-      <StatusPageButton
-        provider={error.provider}
-        label={t("providerError.networkUnreachable.checkStatus")}
+    <div className="w-full px-1 py-2">
+      <RowCard
+        media={<WifiOffIcon className="size-5" />}
+        title={t("providerError.networkUnreachable.title", { provider })}
+        description={t("providerError.networkUnreachable.body", { provider })}
+        action={
+          <>
+            {onRetry && (
+              <RetryButton
+                onRetry={onRetry}
+                label={t("providerError.networkUnreachable.retry")}
+              />
+            )}
+            <StatusPageButton
+              provider={error.provider}
+              label={t("providerError.networkUnreachable.checkStatus")}
+            />
+          </>
+        }
       />
-    </ErrorCard>
+    </div>
   );
 }
 
@@ -136,22 +124,27 @@ export function ProviderInternalCard({
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
   return (
-    <ErrorCard
-      icon={<ServerCrashIcon className="size-5" />}
-      title={t("providerError.providerInternal.title", { provider })}
-      body={t("providerError.providerInternal.body", { provider })}
-    >
-      {onRetry && (
-        <RetryButton
-          onRetry={onRetry}
-          label={t("providerError.providerInternal.retry")}
-        />
-      )}
-      <StatusPageButton
-        provider={error.provider}
-        label={t("providerError.providerInternal.checkStatus")}
+    <div className="w-full px-1 py-2">
+      <RowCard
+        media={<ServerCrashIcon className="size-5" />}
+        title={t("providerError.providerInternal.title", { provider })}
+        description={t("providerError.providerInternal.body", { provider })}
+        action={
+          <>
+            {onRetry && (
+              <RetryButton
+                onRetry={onRetry}
+                label={t("providerError.providerInternal.retry")}
+              />
+            )}
+            <StatusPageButton
+              provider={error.provider}
+              label={t("providerError.providerInternal.checkStatus")}
+            />
+          </>
+        }
       />
-    </ErrorCard>
+    </div>
   );
 }
 
@@ -164,17 +157,20 @@ export function MalformedResponseCard({
   const { t } = useTranslation("shell");
   const provider = providerLabel(error.provider);
   return (
-    <ErrorCard
-      icon={<AlertTriangleIcon className="size-5" />}
-      title={t("providerError.malformedResponse.title")}
-      body={t("providerError.malformedResponse.body", { provider })}
-    >
-      {onRetry && (
-        <RetryButton
-          onRetry={onRetry}
-          label={t("providerError.malformedResponse.retry")}
-        />
-      )}
-    </ErrorCard>
+    <div className="w-full px-1 py-2">
+      <RowCard
+        media={<AlertTriangleIcon className="size-5" />}
+        title={t("providerError.malformedResponse.title")}
+        description={t("providerError.malformedResponse.body", { provider })}
+        action={
+          onRetry && (
+            <RetryButton
+              onRetry={onRetry}
+              label={t("providerError.malformedResponse.retry")}
+            />
+          )
+        }
+      />
+    </div>
   );
 }

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -290,6 +290,7 @@
     "quotaExhausted": {
       "title": "Out of capacity",
       "body": "Your {{provider}} plan reached its quota. Upgrade or switch to a different provider to keep going.",
+      "bodyWithReset": "Your {{provider}} plan reached its quota. It resets {{time}}, or upgrade to keep going.",
       "upgrade": "Upgrade plan",
       "useApiKey": "Use API key instead"
     },

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -291,7 +291,6 @@
       "title": "Out of capacity",
       "body": "Your {{provider}} plan reached its quota. Upgrade or switch to a different provider to keep going.",
       "bodyWithReset": "Your {{provider}} plan reached its quota. It resets {{time}}, or upgrade to keep going.",
-      "upgrade": "Upgrade plan",
       "useApiKey": "Use API key instead"
     },
     "modelUnavailable": {
@@ -315,14 +314,12 @@
     "networkUnreachable": {
       "title": "Cannot reach {{provider}}",
       "body": "Houston could not reach the {{provider}} API. Check your internet, then try again.",
-      "retry": "Try again",
-      "checkStatus": "Check status page"
+      "retry": "Try again"
     },
     "providerInternal": {
       "title": "{{provider}} is having a problem",
       "body": "The {{provider}} API returned an error on its side. Try again in a moment.",
-      "retry": "Try again",
-      "checkStatus": "Check status page"
+      "retry": "Try again"
     },
     "sessionResumeMissing": {
       "title": "Session restarted",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -291,7 +291,6 @@
       "title": "Sin capacidad disponible",
       "body": "Tu plan de {{provider}} llegó al límite. Mejora tu plan o cambia de proveedor para continuar.",
       "bodyWithReset": "Tu plan de {{provider}} llegó al límite. Se restablece {{time}}, o mejora tu plan para continuar.",
-      "upgrade": "Mejorar plan",
       "useApiKey": "Usar clave de API en su lugar"
     },
     "modelUnavailable": {
@@ -315,14 +314,12 @@
     "networkUnreachable": {
       "title": "No se puede conectar con {{provider}}",
       "body": "Houston no pudo conectarse a la API de {{provider}}. Verifica tu conexión y vuelve a intentar.",
-      "retry": "Reintentar",
-      "checkStatus": "Ver página de estado"
+      "retry": "Reintentar"
     },
     "providerInternal": {
       "title": "{{provider}} está teniendo un problema",
       "body": "La API de {{provider}} devolvió un error desde su lado. Inténtalo de nuevo en unos minutos.",
-      "retry": "Reintentar",
-      "checkStatus": "Ver página de estado"
+      "retry": "Reintentar"
     },
     "sessionResumeMissing": {
       "title": "Sesión reiniciada",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -290,6 +290,7 @@
     "quotaExhausted": {
       "title": "Sin capacidad disponible",
       "body": "Tu plan de {{provider}} llegó al límite. Mejora tu plan o cambia de proveedor para continuar.",
+      "bodyWithReset": "Tu plan de {{provider}} llegó al límite. Se restablece {{time}}, o mejora tu plan para continuar.",
       "upgrade": "Mejorar plan",
       "useApiKey": "Usar clave de API en su lugar"
     },

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -291,7 +291,6 @@
       "title": "Sem capacidade disponível",
       "body": "Seu plano do {{provider}} chegou ao limite. Faça upgrade ou troque de provedor para continuar.",
       "bodyWithReset": "Seu plano do {{provider}} chegou ao limite. Ele reinicia {{time}}, ou faça upgrade para continuar.",
-      "upgrade": "Fazer upgrade",
       "useApiKey": "Usar chave de API no lugar"
     },
     "modelUnavailable": {
@@ -315,14 +314,12 @@
     "networkUnreachable": {
       "title": "Não foi possível alcançar o {{provider}}",
       "body": "O Houston não conseguiu acessar a API do {{provider}}. Verifique sua internet e tente de novo.",
-      "retry": "Tentar de novo",
-      "checkStatus": "Ver página de status"
+      "retry": "Tentar de novo"
     },
     "providerInternal": {
       "title": "{{provider}} está com um problema",
       "body": "A API do {{provider}} retornou um erro do lado deles. Tente de novo em alguns minutos.",
-      "retry": "Tentar de novo",
-      "checkStatus": "Ver página de status"
+      "retry": "Tentar de novo"
     },
     "sessionResumeMissing": {
       "title": "Sessão reiniciada",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -290,6 +290,7 @@
     "quotaExhausted": {
       "title": "Sem capacidade disponível",
       "body": "Seu plano do {{provider}} chegou ao limite. Faça upgrade ou troque de provedor para continuar.",
+      "bodyWithReset": "Seu plano do {{provider}} chegou ao limite. Ele reinicia {{time}}, ou faça upgrade para continuar.",
       "upgrade": "Fazer upgrade",
       "useApiKey": "Usar chave de API no lugar"
     },

--- a/engine/houston-terminal-manager/src/codex_parser.rs
+++ b/engine/houston-terminal-manager/src/codex_parser.rs
@@ -200,6 +200,12 @@ pub struct CodexAccumulator {
     /// banner up to 5× and then restarts the whole turn, so without this the
     /// feed would stack a reconnect card per retry. One per session is enough.
     auth_card_emitted: bool,
+    /// True once a NON-auth terminal error (typed `ProviderError` card or the
+    /// raw `Error: …` fallback) has been surfaced for this run. codex emits the
+    /// same failure as BOTH an `error` and a `turn.failed` event back-to-back
+    /// (e.g. the usage-limit banner, HOU-495), so without this the feed would
+    /// stack two identical cards. Auth keeps its own dedup above.
+    terminal_error_emitted: bool,
 }
 
 impl CodexAccumulator {
@@ -337,10 +343,14 @@ pub fn parse_codex_event(line: &str, acc: &mut CodexAccumulator) -> Vec<FeedItem
                         tracing::info!("[codex] auth failure — emitting Unauthenticated reconnect card");
                         items.push(FeedItem::ProviderError(typed));
                     }
-                } else {
+                } else if !acc.terminal_error_emitted {
+                    // codex repeats the same failure across its `error` +
+                    // `turn.failed` pair; surface the typed card once per run.
+                    acc.terminal_error_emitted = true;
                     items.push(FeedItem::ProviderError(typed));
                 }
-            } else {
+            } else if !acc.terminal_error_emitted {
+                acc.terminal_error_emitted = true;
                 items.push(FeedItem::SystemMessage(format!("Error: {msg}")));
             }
             items
@@ -825,6 +835,51 @@ mod tests {
         let items = parse_codex_event(line, &mut acc());
         assert_eq!(items.len(), 1);
         assert!(matches!(&items[0], FeedItem::SystemMessage(m) if m.contains("Context window")));
+    }
+
+    #[test]
+    fn codex_usage_limit_emits_single_quota_card_across_error_and_turn_failed() {
+        // HOU-495: a spent ChatGPT-account Codex allowance fails every turn
+        // with this banner, emitted as BOTH an `error` and a `turn.failed`
+        // event. The parser must surface ONE QuotaExhausted card (Upgrade CTA)
+        // — not the old generic "runtime error" text, and not two cards.
+        use crate::provider_error_kind::{ProviderError, QuotaScope};
+        let mut a = acc();
+        let _ = parse_codex_event(r#"{"type":"turn.started"}"#, &mut a);
+
+        let banner = "You've hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), or try again at Jul 1st, 2026 1:16 PM.";
+        let err = format!(r#"{{"type":"error","message":"{banner}"}}"#);
+        let first = parse_codex_event(&err, &mut a);
+        let cards: Vec<_> = first
+            .iter()
+            .filter(|i| matches!(i, FeedItem::ProviderError(_)))
+            .collect();
+        assert_eq!(cards.len(), 1, "expected exactly one card, got {first:?}");
+        match cards[0] {
+            FeedItem::ProviderError(ProviderError::QuotaExhausted {
+                provider, scope, ..
+            }) => {
+                assert_eq!(provider, "openai");
+                assert_eq!(*scope, QuotaScope::FreeTier);
+            }
+            other => panic!("expected QuotaExhausted card, got {other:?}"),
+        }
+        // No raw "Error: ..." text alongside the card.
+        assert!(
+            !first
+                .iter()
+                .any(|i| matches!(i, FeedItem::SystemMessage(m) if m.starts_with("Error:"))),
+            "usage limit must not also render as raw text, got {first:?}"
+        );
+
+        // The duplicate `turn.failed` carrying the same banner must not stack a
+        // second card.
+        let failed = format!(r#"{{"type":"turn.failed","error":{{"message":"{banner}"}}}}"#);
+        let second = parse_codex_event(&failed, &mut a);
+        assert!(
+            !second.iter().any(|i| matches!(i, FeedItem::ProviderError(_))),
+            "duplicate usage-limit event must not emit a second card, got {second:?}"
+        );
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/provider/anthropic_classify.rs
+++ b/engine/houston-terminal-manager/src/provider/anthropic_classify.rs
@@ -111,7 +111,6 @@ pub(crate) fn classify_stderr(line: &str) -> Option<ProviderError> {
             // above; this terminal-quota path names no reset.
             resets_at: None,
             message: truncate_excerpt(line.trim()),
-            upgrade_url: Some("https://www.anthropic.com/pricing".into()),
         });
     }
 
@@ -443,14 +442,12 @@ mod tests {
     }
 
     #[test]
-    fn quota_exhausted_includes_upgrade_url() {
+    fn monthly_limit_classified_as_quota_exhausted() {
         let line = "Monthly limit exhausted for plan";
-        match classify_stderr(line).unwrap() {
-            ProviderError::QuotaExhausted { upgrade_url, .. } => {
-                assert!(upgrade_url.unwrap().contains("anthropic.com"));
-            }
-            other => panic!("expected QuotaExhausted, got {other:?}"),
-        }
+        assert!(matches!(
+            classify_stderr(line),
+            Some(ProviderError::QuotaExhausted { .. })
+        ));
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/provider/anthropic_classify.rs
+++ b/engine/houston-terminal-manager/src/provider/anthropic_classify.rs
@@ -107,6 +107,9 @@ pub(crate) fn classify_stderr(line: &str) -> Option<ProviderError> {
             provider: PROVIDER.into(),
             model: None,
             scope: QuotaScope::Unknown,
+            // The "usage limit ... reset at" banner routes to UsageLimitPaused
+            // above; this terminal-quota path names no reset.
+            resets_at: None,
             message: truncate_excerpt(line.trim()),
             upgrade_url: Some("https://www.anthropic.com/pricing".into()),
         });

--- a/engine/houston-terminal-manager/src/provider/gemini/classify.rs
+++ b/engine/houston-terminal-manager/src/provider/gemini/classify.rs
@@ -11,11 +11,6 @@ use crate::provider_error_kind::{
 };
 
 const PROVIDER: &str = "gemini";
-/// Plan-upgrade target for QuotaExhausted. The "Use API key instead"
-/// CTA target (`https://aistudio.google.com/app/apikey`) is driven by
-/// the frontend, not embedded in the wire shape, because it depends on
-/// the user's chosen auth mode.
-pub const UPGRADE_URL: &str = "https://ai.google.dev/pricing";
 
 pub(crate) fn classify_stderr(line: &str) -> Option<ProviderError> {
     let trimmed = line.trim();
@@ -40,7 +35,6 @@ pub(crate) fn classify_stderr(line: &str) -> Option<ProviderError> {
                 scope: QuotaScope::Unknown,
                 resets_at: None,
                 message: truncate_excerpt(trimmed),
-                upgrade_url: Some(UPGRADE_URL.into()),
             });
         }
 
@@ -98,7 +92,6 @@ pub(crate) fn classify_result_error(
             scope: QuotaScope::Unknown,
             resets_at: None,
             message: truncate_excerpt(error_message),
-            upgrade_url: Some(UPGRADE_URL.into()),
         }),
         // Auth class names emitted by gemini-cli's error handler.
         "FatalAuthenticationError" => Some(ProviderError::Unauthenticated {
@@ -206,9 +199,8 @@ mod tests {
     #[test]
     fn attempt_max_reached_is_quota_exhausted() {
         match classify_stderr(ATTEMPT_MAX_REACHED).unwrap() {
-            ProviderError::QuotaExhausted { provider, upgrade_url, .. } => {
+            ProviderError::QuotaExhausted { provider, .. } => {
                 assert_eq!(provider, "gemini");
-                assert_eq!(upgrade_url.as_deref(), Some(UPGRADE_URL));
             }
             other => panic!("expected QuotaExhausted, got {other:?}"),
         }
@@ -240,9 +232,7 @@ mod tests {
         )
         .unwrap()
         {
-            ProviderError::QuotaExhausted { upgrade_url, .. } => {
-                assert_eq!(upgrade_url.as_deref(), Some(UPGRADE_URL));
-            }
+            ProviderError::QuotaExhausted { .. } => {}
             other => panic!("expected QuotaExhausted, got {other:?}"),
         }
     }

--- a/engine/houston-terminal-manager/src/provider/gemini/classify.rs
+++ b/engine/houston-terminal-manager/src/provider/gemini/classify.rs
@@ -38,6 +38,7 @@ pub(crate) fn classify_stderr(line: &str) -> Option<ProviderError> {
                 provider: PROVIDER.into(),
                 model: None,
                 scope: QuotaScope::Unknown,
+                resets_at: None,
                 message: truncate_excerpt(trimmed),
                 upgrade_url: Some(UPGRADE_URL.into()),
             });
@@ -95,6 +96,7 @@ pub(crate) fn classify_result_error(
             provider: PROVIDER.into(),
             model: None,
             scope: QuotaScope::Unknown,
+            resets_at: None,
             message: truncate_excerpt(error_message),
             upgrade_url: Some(UPGRADE_URL.into()),
         }),

--- a/engine/houston-terminal-manager/src/provider/openai_classify.rs
+++ b/engine/houston-terminal-manager/src/provider/openai_classify.rs
@@ -113,10 +113,6 @@ pub(crate) fn classify_stderr(line: &str) -> Option<ProviderError> {
             // so the card reads "resets <when>" instead of a bare upgrade nag.
             resets_at: extract_reset_hint(line),
             message: truncate_excerpt(line.trim()),
-            // Prefer the exact upgrade link codex embeds in the banner; fall
-            // back to the ChatGPT plan page if a future banner drops it.
-            upgrade_url: extract_first_url(line)
-                .or_else(|| Some("https://chatgpt.com/explore/plus".into())),
         });
     }
 
@@ -128,7 +124,6 @@ pub(crate) fn classify_stderr(line: &str) -> Option<ProviderError> {
             scope: QuotaScope::Unknown,
             resets_at: None,
             message: truncate_excerpt(line.trim()),
-            upgrade_url: Some("https://platform.openai.com/account/billing".into()),
         });
     }
 
@@ -197,26 +192,6 @@ fn extract_quoted_model(line: &str) -> Option<String> {
         None
     } else {
         Some(model.to_string())
-    }
-}
-
-/// Pull the first `http(s)://…` token out of a CLI message. Codex's
-/// usage-limit banner embeds the exact upgrade URL (e.g.
-/// `…(https://chatgpt.com/explore/plus)…`); reusing it keeps the Upgrade CTA
-/// correct across plan tiers instead of hard-coding a single target. Stops at
-/// the first whitespace or closing bracket/quote so trailing punctuation
-/// (the `)` after the URL) is not captured.
-fn extract_first_url(line: &str) -> Option<String> {
-    let start = line.find("http")?;
-    let rest = &line[start..];
-    let end = rest
-        .find(|c: char| c.is_whitespace() || matches!(c, ')' | ']' | '"' | '>' | '<'))
-        .unwrap_or(rest.len());
-    let url = &rest[..end];
-    if url.starts_with("http://") || url.starts_with("https://") {
-        Some(url.to_string())
-    } else {
-        None
     }
 }
 
@@ -318,14 +293,12 @@ mod tests {
     }
 
     #[test]
-    fn quota_exhausted_includes_billing_url() {
+    fn quota_exceeded_classified_as_quota_exhausted() {
         let line = "Quota exceeded for this account";
-        match classify_stderr(line).unwrap() {
-            ProviderError::QuotaExhausted { upgrade_url, .. } => {
-                assert!(upgrade_url.unwrap().contains("openai.com"));
-            }
-            other => panic!("expected QuotaExhausted, got {other:?}"),
-        }
+        assert!(matches!(
+            classify_stderr(line),
+            Some(ProviderError::QuotaExhausted { .. })
+        ));
     }
 
     #[test]
@@ -333,23 +306,18 @@ mod tests {
         // The exact codex banner a ChatGPT free-tier user hits once their
         // Codex allowance is spent (HOU-495). Previously matched nothing and
         // showed a generic "codex hit a runtime error"; now a QuotaExhausted
-        // card with a Plus upgrade CTA pulled straight from the banner.
+        // card carrying the reset hint parsed from the banner.
         let line = "You've hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), or try again at Jul 1st, 2026 1:16 PM.";
         match classify_stderr(line).unwrap() {
             ProviderError::QuotaExhausted {
                 provider,
                 scope,
                 resets_at,
-                upgrade_url,
                 ..
             } => {
                 assert_eq!(provider, "openai");
                 assert_eq!(scope, QuotaScope::FreeTier);
                 assert_eq!(resets_at.as_deref(), Some("Jul 1st, 2026 1:16 PM"));
-                assert_eq!(
-                    upgrade_url.as_deref(),
-                    Some("https://chatgpt.com/explore/plus")
-                );
             }
             other => panic!("expected QuotaExhausted, got {other:?}"),
         }
@@ -375,16 +343,6 @@ mod tests {
             classify_stderr(line),
             Some(ProviderError::QuotaExhausted { .. })
         ));
-    }
-
-    #[test]
-    fn extract_first_url_pulls_banner_link_without_trailing_paren() {
-        let line = "limit (https://chatgpt.com/explore/plus), or try again";
-        assert_eq!(
-            extract_first_url(line).as_deref(),
-            Some("https://chatgpt.com/explore/plus")
-        );
-        assert!(extract_first_url("no link here").is_none());
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/provider/openai_classify.rs
+++ b/engine/houston-terminal-manager/src/provider/openai_classify.rs
@@ -87,6 +87,36 @@ pub(crate) fn classify_stderr(line: &str) -> Option<ProviderError> {
         });
     }
 
+    // ChatGPT-account Codex usage limit. When a ChatGPT plan's Codex
+    // allowance for the billing window is spent, codex fails EVERY turn with
+    // "You've hit your usage limit. Upgrade to Plus to continue using Codex
+    // (<url>), or try again at <date>." It is NOT a per-minute 429 throttle
+    // (waiting a minute won't help) and NOT the API-key "quota exceeded"
+    // billing error below — it's the plan allowance. Without this branch it
+    // matched nothing and surfaced as a generic "codex hit a runtime error"
+    // (HOU-495). Map it to a QuotaExhausted card whose Upgrade CTA points at
+    // the plan page codex itself names (free → Plus, Plus → Pro), so the user
+    // gets an actionable next step. Must precede the `quota`-keyword branch.
+    if lower.contains("usage limit") {
+        let scope = if lower.contains("upgrade to plus") {
+            QuotaScope::FreeTier
+        } else if lower.contains("upgrade to pro") {
+            QuotaScope::PaidPlan
+        } else {
+            QuotaScope::Unknown
+        };
+        return Some(ProviderError::QuotaExhausted {
+            provider: PROVIDER.into(),
+            model: None,
+            scope,
+            message: truncate_excerpt(line.trim()),
+            // Prefer the exact upgrade link codex embeds in the banner; fall
+            // back to the ChatGPT plan page if a future banner drops it.
+            upgrade_url: extract_first_url(line)
+                .or_else(|| Some("https://chatgpt.com/explore/plus".into())),
+        });
+    }
+
     // Quota exhausted — paid plan / org quota.
     if lower.contains("quota") && (lower.contains("exceed") || lower.contains("exhaust")) {
         return Some(ProviderError::QuotaExhausted {
@@ -163,6 +193,26 @@ fn extract_quoted_model(line: &str) -> Option<String> {
         None
     } else {
         Some(model.to_string())
+    }
+}
+
+/// Pull the first `http(s)://…` token out of a CLI message. Codex's
+/// usage-limit banner embeds the exact upgrade URL (e.g.
+/// `…(https://chatgpt.com/explore/plus)…`); reusing it keeps the Upgrade CTA
+/// correct across plan tiers instead of hard-coding a single target. Stops at
+/// the first whitespace or closing bracket/quote so trailing punctuation
+/// (the `)` after the URL) is not captured.
+fn extract_first_url(line: &str) -> Option<String> {
+    let start = line.find("http")?;
+    let rest = &line[start..];
+    let end = rest
+        .find(|c: char| c.is_whitespace() || matches!(c, ')' | ']' | '"' | '>' | '<'))
+        .unwrap_or(rest.len());
+    let url = &rest[..end];
+    if url.starts_with("http://") || url.starts_with("https://") {
+        Some(url.to_string())
+    } else {
+        None
     }
 }
 
@@ -256,6 +306,52 @@ mod tests {
             }
             other => panic!("expected QuotaExhausted, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn codex_usage_limit_classified_as_quota_exhausted_free_tier() {
+        // The exact codex banner a ChatGPT free-tier user hits once their
+        // Codex allowance is spent (HOU-495). Previously matched nothing and
+        // showed a generic "codex hit a runtime error"; now a QuotaExhausted
+        // card with a Plus upgrade CTA pulled straight from the banner.
+        let line = "You've hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), or try again at Jul 1st, 2026 1:16 PM.";
+        match classify_stderr(line).unwrap() {
+            ProviderError::QuotaExhausted {
+                provider,
+                scope,
+                upgrade_url,
+                ..
+            } => {
+                assert_eq!(provider, "openai");
+                assert_eq!(scope, QuotaScope::FreeTier);
+                assert_eq!(
+                    upgrade_url.as_deref(),
+                    Some("https://chatgpt.com/explore/plus")
+                );
+            }
+            other => panic!("expected QuotaExhausted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn codex_usage_limit_is_not_misfiled_as_rate_limited() {
+        // "usage limit" is a billing-window cap, not a 429 throttle — a wait
+        // won't clear it. Must NOT fall into the RateLimited branch.
+        let line = "You've hit your usage limit. Upgrade to Plus to continue using Codex.";
+        assert!(matches!(
+            classify_stderr(line),
+            Some(ProviderError::QuotaExhausted { .. })
+        ));
+    }
+
+    #[test]
+    fn extract_first_url_pulls_banner_link_without_trailing_paren() {
+        let line = "limit (https://chatgpt.com/explore/plus), or try again";
+        assert_eq!(
+            extract_first_url(line).as_deref(),
+            Some("https://chatgpt.com/explore/plus")
+        );
+        assert!(extract_first_url("no link here").is_none());
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/provider/openai_classify.rs
+++ b/engine/houston-terminal-manager/src/provider/openai_classify.rs
@@ -109,6 +109,9 @@ pub(crate) fn classify_stderr(line: &str) -> Option<ProviderError> {
             provider: PROVIDER.into(),
             model: None,
             scope,
+            // codex names the absolute time the allowance frees up; surface it
+            // so the card reads "resets <when>" instead of a bare upgrade nag.
+            resets_at: extract_reset_hint(line),
             message: truncate_excerpt(line.trim()),
             // Prefer the exact upgrade link codex embeds in the banner; fall
             // back to the ChatGPT plan page if a future banner drops it.
@@ -123,6 +126,7 @@ pub(crate) fn classify_stderr(line: &str) -> Option<ProviderError> {
             provider: PROVIDER.into(),
             model: None,
             scope: QuotaScope::Unknown,
+            resets_at: None,
             message: truncate_excerpt(line.trim()),
             upgrade_url: Some("https://platform.openai.com/account/billing".into()),
         });
@@ -213,6 +217,22 @@ fn extract_first_url(line: &str) -> Option<String> {
         Some(url.to_string())
     } else {
         None
+    }
+}
+
+/// Lift the reset hint out of codex's "…, or try again at <when>." tail.
+/// The banner names an absolute time the Codex allowance frees up
+/// (e.g. `Jul 1st, 2026 1:16 PM`); we surface it verbatim on the quota card.
+/// Returns `None` when the banner names no reset (open-ended limit). The
+/// marker is ASCII, so the lowercase byte offset is valid in the original.
+fn extract_reset_hint(line: &str) -> Option<String> {
+    const MARKER: &str = "try again at ";
+    let idx = line.to_lowercase().find(MARKER)?;
+    let hint = line[idx + MARKER.len()..].trim().trim_end_matches('.').trim();
+    if hint.is_empty() {
+        None
+    } else {
+        Some(hint.to_string())
     }
 }
 
@@ -319,11 +339,13 @@ mod tests {
             ProviderError::QuotaExhausted {
                 provider,
                 scope,
+                resets_at,
                 upgrade_url,
                 ..
             } => {
                 assert_eq!(provider, "openai");
                 assert_eq!(scope, QuotaScope::FreeTier);
+                assert_eq!(resets_at.as_deref(), Some("Jul 1st, 2026 1:16 PM"));
                 assert_eq!(
                     upgrade_url.as_deref(),
                     Some("https://chatgpt.com/explore/plus")
@@ -331,6 +353,17 @@ mod tests {
             }
             other => panic!("expected QuotaExhausted, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn extract_reset_hint_pulls_date_without_trailing_period() {
+        let line = "You've hit your usage limit. ..., or try again at Jul 1st, 2026 1:16 PM.";
+        assert_eq!(
+            extract_reset_hint(line).as_deref(),
+            Some("Jul 1st, 2026 1:16 PM")
+        );
+        // No reset named → None (open-ended limit).
+        assert!(extract_reset_hint("Quota exceeded for this account").is_none());
     }
 
     #[test]

--- a/engine/houston-terminal-manager/src/provider_error_kind.rs
+++ b/engine/houston-terminal-manager/src/provider_error_kind.rs
@@ -103,7 +103,6 @@ pub enum ProviderError {
         /// `None` for open-ended limits where upgrading is the only path.
         resets_at: Option<String>,
         message: String,
-        upgrade_url: Option<String>,
     },
     /// Plan-window usage limit the CLI auto-recovers from by sleeping
     /// internally until the reset window. The CLI subprocess is still
@@ -237,14 +236,13 @@ mod tests {
     }
 
     #[test]
-    fn round_trip_quota_exhausted_with_url() {
+    fn round_trip_quota_exhausted() {
         let e = ProviderError::QuotaExhausted {
             provider: "gemini".into(),
             model: None,
             scope: QuotaScope::FreeTier,
             resets_at: Some("Jul 1st, 2026 1:16 PM".into()),
             message: "Max attempts reached".into(),
-            upgrade_url: Some("https://ai.google.dev/pricing".into()),
         };
         let json = serde_json::to_string(&e).unwrap();
         assert!(json.contains(r#""kind":"quota_exhausted""#));

--- a/engine/houston-terminal-manager/src/provider_error_kind.rs
+++ b/engine/houston-terminal-manager/src/provider_error_kind.rs
@@ -98,6 +98,10 @@ pub enum ProviderError {
         provider: String,
         model: Option<String>,
         scope: QuotaScope,
+        /// Human-readable reset hint when the provider names one (e.g. codex's
+        /// "try again at Jul 1st, 2026 1:16 PM" → `"Jul 1st, 2026 1:16 PM"`).
+        /// `None` for open-ended limits where upgrading is the only path.
+        resets_at: Option<String>,
         message: String,
         upgrade_url: Option<String>,
     },
@@ -238,12 +242,14 @@ mod tests {
             provider: "gemini".into(),
             model: None,
             scope: QuotaScope::FreeTier,
+            resets_at: Some("Jul 1st, 2026 1:16 PM".into()),
             message: "Max attempts reached".into(),
             upgrade_url: Some("https://ai.google.dev/pricing".into()),
         };
         let json = serde_json::to_string(&e).unwrap();
         assert!(json.contains(r#""kind":"quota_exhausted""#));
         assert!(json.contains(r#""scope":"free_tier""#));
+        assert!(json.contains(r#""resets_at":"Jul 1st, 2026 1:16 PM""#));
         let back: ProviderError = serde_json::from_str(&json).unwrap();
         assert_eq!(e, back);
     }

--- a/knowledge-base/provider-errors.md
+++ b/knowledge-base/provider-errors.md
@@ -126,6 +126,23 @@ plain — now funnels to a single `auth_card_emitted`-deduped
 `Unauthenticated` card; before, the plain refresh-failure fell through to a
 raw `Error: …` SystemMessage shown twice.
 
+**Codex usage limit → `QuotaExhausted` (HOU-495).** A spent ChatGPT-account
+Codex allowance fails every turn with `You've hit your usage limit. Upgrade to
+Plus to continue using Codex (<url>), or try again at <date>.`, emitted on
+stdout as BOTH an `error` and a `turn.failed` event. It is not a 429 throttle
+and not the API-key `quota exceeded` billing error, so it matched no
+`openai_classify::classify_stderr` branch and fell through to a raw `Error: …`
+SystemMessage (shown twice) + a generic `codex hit a runtime error` status +
+a `SpawnFailed` fallback card — the user saw no actionable next step, just
+noise (the symptom behind "unable to use codex"). `classify_stderr` now maps
+any `usage limit` line to `QuotaExhausted` (scope inferred from
+`upgrade to plus` → `FreeTier` / `upgrade to pro` → `PaidPlan`; `upgrade_url`
+lifted from the banner via `extract_first_url`, falling back to the ChatGPT
+plan page). `CodexAccumulator::terminal_error_emitted` dedupes the
+`error`+`turn.failed` pair to one card (the auth path keeps its separate
+`auth_card_emitted` guard). The card is `QuotaExhaustedCard` — same "Upgrade
+plan" CTA Anthropic/Gemini quota errors get.
+
 **Auth cards: prefer the persisted inline card over the store card.** The
 store-driven `ProviderReconnectCard` (anchored to the `authRequired` flag,
 rendered in `ChatPanel.afterMessages`) AUTO-DISMISSES for codex: its 3s

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -98,7 +98,6 @@ export type ProviderError =
       /** Human-readable reset hint (e.g. "Jul 1st, 2026 1:16 PM"); null when open-ended. */
       resets_at: string | null;
       message: string;
-      upgrade_url: string | null;
     }
   | {
       kind: "usage_limit_paused";

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -95,6 +95,8 @@ export type ProviderError =
       provider: string;
       model: string | null;
       scope: QuotaScope;
+      /** Human-readable reset hint (e.g. "Jul 1st, 2026 1:16 PM"); null when open-ended. */
+      resets_at: string | null;
       message: string;
       upgrade_url: string | null;
     }


### PR DESCRIPTION
## Root cause

A user reported being unable to use the Codex model "since v0.4.23, even with session limit available." The engine logs tell the real story:

- **06-11**: codex `turn.completed` succeeded (10.4M input tokens — heavy use).
- **06-12 22:22 onward** (06-12, 06-14, 06-16): every codex turn fails with:
  > `You've hit your usage limit. Upgrade to Plus to continue using Codex (https://chatgpt.com/explore/plus), or try again at Jul 1st, 2026 1:16 PM.`

The user genuinely exhausted their monthly ChatGPT-account **Codex allowance** (resets Jul 1; OpenAI-side, Houston can't lift it). The model (`gpt-5.5`) and auth are unchanged across the success and failure days, so the "since v0.4.23" framing is coincidental — **the actual Houston bug is how the limit is surfaced.**

That banner contains no `quota` / `429` / `rate limit` token, so it matched **no branch** in `openai_classify::classify_stderr`. It fell through to:
1. a raw `Error: …` `SystemMessage` — emitted **twice** (codex sends both an `error` and a `turn.failed` event),
2. a generic `codex hit a runtime error` status, and
3. a `SpawnFailed("no stderr output captured")` fallback card (the SystemMessage path never set `saw_provider_error`).

Net: confusing noise, no actionable next step.

## Fix

- **`openai_classify::classify_stderr`** now maps any `usage limit` line to `ProviderError::QuotaExhausted`:
  - `scope` inferred from the banner (`upgrade to plus` → `FreeTier`, `upgrade to pro` → `PaidPlan`),
  - `upgrade_url` lifted from the banner via a new `extract_first_url` helper (falls back to the ChatGPT plan page),
  - renders the existing `QuotaExhaustedCard` ("Out of capacity" + **Upgrade plan** CTA) — parity with the Anthropic/Gemini quota path. Emitting a typed `ProviderError` also trips `saw_provider_error`, which suppresses the bogus `SpawnFailed` fallback.
- **`CodexAccumulator::terminal_error_emitted`** dedupes the back-to-back `error`+`turn.failed` pair so the card (and the raw-text fallback for genuinely-unclassified errors) surfaces once per run. The auth path keeps its separate `auth_card_emitted` guard.

This does **not** make codex usable again — the limit is real and OpenAI-side. It makes the failure legible: the user now sees a clear "you're out of Codex capacity, upgrade or switch provider" card instead of a generic runtime error.

Scope note: the exact reset date ("Jul 1st") lives in the error `message` but is intentionally not surfaced on the card — the `QuotaExhausted` variant has no `resets_at` field and the established card pattern (shared with Anthropic/Gemini) leads with the upgrade CTA. Kept consistent rather than widening the wire type for one provider.

## Files
- `engine/houston-terminal-manager/src/provider/openai_classify.rs` — `usage limit` → `QuotaExhausted`, `extract_first_url`, tests
- `engine/houston-terminal-manager/src/codex_parser.rs` — per-run `terminal_error_emitted` dedup, test
- `knowledge-base/provider-errors.md` — documents the mapping

## Verification

**Before** (reproduce): exhaust a ChatGPT-account Codex allowance (or feed codex a `turn.failed` with the usage-limit banner). Engine log shows:
```
[codex] error/turn.failed: You've hit your usage limit. Upgrade to Plus ...
[session_runner] session error: "codex hit a runtime error" | saw_auth_error=false | is_auth_error=false | provider=openai
```
Chat renders raw `Error: …` text (twice) + a generic error — no card.

**After**: the same banner produces one `ProviderError::QuotaExhausted` card ("Out of capacity / Your OpenAI plan reached its quota. Upgrade or switch to a different provider to keep going." + **Upgrade plan** button → `https://chatgpt.com/explore/plus`), no duplicate, no `SpawnFailed`.

```
cargo test -p houston-terminal-manager   # 269 + 4 new, all pass
cargo check --workspace                  # clean
```

New tests:
- `openai_classify::codex_usage_limit_classified_as_quota_exhausted_free_tier`
- `openai_classify::codex_usage_limit_is_not_misfiled_as_rate_limited`
- `openai_classify::extract_first_url_pulls_banner_link_without_trailing_paren`
- `codex_parser::codex_usage_limit_emits_single_quota_card_across_error_and_turn_failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up commit: finish the RowCard migration

While confirming the new codex card matched the rest of chat, I found HOU-467's `RowCard` unification was only half-applied to the provider-error cards: `auth` + `rate-limited`/`usage-limit-paused` had moved, but **`quota` (where this PR's QuotaExhausted card lives), `terminal`, and the network/internal/malformed transient cards were still on the legacy `ErrorCard` slab** — so the codex usage-limit card would have rendered visually inconsistent with the reconnect/rate-limit cards beside it.

Finished it in `729996c`:
- `provider-error-cards/shared.tsx`: deleted `ErrorCard`; rebuilt `RetryButton` / `StatusPageButton` / `ReportBugButton` as thin `RowCardButton` wrappers (retry + report-bug keep their spinner via `loading`; report-bug keeps its `reportBug` call + toast).
- `quota.tsx`, `terminal.tsx`, and the `transient.tsx` remainder now render on `RowCard`; `RateLimited` drops its inline button for the shared `RetryButton` so every retry pill is identical.

Net: one card primitive across every typed provider error (codex + claude + gemini), legacy `ErrorCard` deleted, −31 lines. No wire/i18n changes. `pnpm tsc --noEmit` + `pnpm check-locales` green.

> ⚠️ Visual pass still wanted: I verified structurally (clean typecheck under `noUnusedLocals`, exact parity with the already-shipped `auth`/`RateLimited` RowCard pattern) but did not render the cards on screen.


---

## Follow-up commit: surface codex's reset date (`ed262fd`)

The codex banner names the exact reset (`…, or try again at Jul 1st, 2026 1:16 PM.`). We carried it verbatim in `QuotaExhausted.message`, but the card ignored `message` → the reset was invisible (the gap behind "I still have usage left"). Added a structured `resets_at: Option<String>` to `QuotaExhausted` (parsed from the banner via `extract_reset_hint` — real codex data, not hardcoded; `None` at the other 4 producers), mirrored on the TS type, and a `quotaExhausted.bodyWithReset` card variant (en/es/pt).

Card now reads: **"Your OpenAI plan reached its quota. It resets Jul 1st, 2026 1:16 PM, or upgrade to keep going."** + Upgrade CTA.

Gates: engine `cargo test` 270 ✓, `pnpm tsc --noEmit` ✓, `pnpm check-locales` ✓.


---

## Follow-up commits: button removal + upgrade_url strip

`455a1b6` — removed the **Upgrade plan** CTA (QuotaExhausted) and **Check status page** CTA (NetworkUnreachable / ProviderInternal). QuotaExhausted is now button-free; the network/server cards keep only "Try again". Deleted the orphaned `StatusPageButton` / `statusPageUrl` and the dead `quotaExhausted.upgrade` / `*.checkStatus` i18n keys.

`802f14b` — with no renderer left for it, **removed `upgrade_url` from the `QuotaExhausted` taxonomy** entirely: the struct field, both OpenAI sites + the `extract_first_url` helper, the Anthropic/Gemini sites + gemini's `UPGRADE_URL` const, the TS `quota_exhausted` shape, and the URL-only test assertions. `resets_at` stays (it's what the card shows).

Gates after both: engine `cargo test` 269 ✓ · `cargo check --workspace` ✓ · `pnpm tsc --noEmit` ✓ · `pnpm check-locales` ✓.
