### PR TITLE
release: v0.4.24

### DIFF
--- a/.github/release-notes/0.4.24.es.md
+++ b/.github/release-notes/0.4.24.es.md
@@ -1,9 +1,9 @@
 ## Houston 0.4.24
 
-Una versión de pulido y confiabilidad. El chat se siente más tranquilo, las
-rutinas programadas son más fáciles de configurar, las conexiones con apps se
-recuperan mejor y el límite de sesión de Claude ahora muestra el mensaje
-correcto en vez de parecer un límite de uso genérico.
+Una versión de pulido y confiabilidad. Ahora puedes iniciar sesión en Houston
+sin salir de la app, el chat se siente más tranquilo, las rutinas programadas son
+más fáciles de configurar y ya no desaparecen, y los límites de Claude y OpenAI
+Codex ahora muestran el mensaje correcto en vez de un error genérico.
 Puedes instalarla encima de 0.4.23, sin cambios incompatibles.
 
 ### Agregado
@@ -14,6 +14,15 @@ Puedes instalarla encima de 0.4.23, sin cambios incompatibles.
 - **Contexto más claro en el chat.** El indicador de contexto ahora es un anillo
   más discreto al pasar el cursor, para ver la señal cuando la necesitas sin
   meter más ruido en la pantalla de chat.
+- **Inicia sesión sin salir de Houston.** Ahora puedes iniciar sesión dentro de
+  la app con Google, un código de un solo uso por correo o tu cuenta de
+  Microsoft, en vez de salir al navegador para terminar.
+- **Configuración del agente en un solo lugar.** La pestaña de configuración del
+  agente ahora tiene una sección de Configuración donde puedes renombrar un
+  agente y llegar a las acciones de su tarjeta, en vez de buscar en un menú.
+- **Encuentra una zona horaria escribiendo.** El control de zona horaria de las
+  rutinas ahora es un selector con búsqueda. Escribe una ciudad o región en vez
+  de recorrer una lista larga.
 
 ### Mejorado
 
@@ -34,6 +43,15 @@ Puedes instalarla encima de 0.4.23, sin cambios incompatibles.
 - **Los límites de sesión de Claude se etiquetan bien.** Si Claude llega a su
   límite de sesión de 5 horas, Houston ahora muestra una tarjeta de límite de
   sesión en vez de un mensaje engañoso de límite de uso.
+- **Los límites de uso de OpenAI Codex se etiquetan bien.** Cuando Codex agota su
+  uso disponible, Houston ahora muestra una tarjeta de cuota clara, con la fecha
+  en que se reinicia, en vez de un error genérico.
+- **Las rutinas ya no desaparecen.** Una sola rutina con un carácter inusual
+  hacía que toda la lista no cargara. Houston ahora recupera tus rutinas y las
+  conserva en vez de borrar la lista.
+- **El selector de modelos solo muestra modelos que puedes usar.** Un modelo que
+  no estaba disponible para seleccionar ya no aparece en el selector de modelos
+  del chat ni en el de bienvenida.
 - **Las conexiones de apps se actualizan al instante.** Cuando una app conectada
   ya estaba vinculada, Houston ahora cambia Connect a conectado en vez de dejar
   la pantalla desactualizada.

--- a/.github/release-notes/0.4.24.md
+++ b/.github/release-notes/0.4.24.md
@@ -1,8 +1,9 @@
 ## Houston 0.4.24
 
-A polish and reliability release. Chat feels calmer, scheduled routines are easier
-to set up, app connections recover more reliably, and Claude's session limit now
-shows the right message instead of looking like a generic rate limit.
+A polish and reliability release. You can now sign in to Houston without leaving
+the app, chat feels calmer, scheduled routines are easier to set up and no longer
+go missing, and provider limits from Claude and OpenAI Codex now show the right
+message instead of a generic error.
 Drop-in on top of 0.4.23, no breaking changes.
 
 ### Added
@@ -13,6 +14,14 @@ Drop-in on top of 0.4.23, no breaking changes.
 - **Clearer context in chat.** The context indicator is now a quieter hover ring,
   so you can see the signal when you need it without adding more noise to the
   chat screen.
+- **Sign in without leaving Houston.** You can now sign in right inside the app
+  with Google, a one-time email code, or your Microsoft account, instead of
+  bouncing out to a browser to finish.
+- **Agent Settings in one place.** The agent's settings tab now has a Settings
+  section where you can rename an agent and reach its card actions, instead of
+  hunting through a menu.
+- **Find a timezone by typing.** The routines timezone control is now a
+  searchable picker. Type a city or region instead of scrolling a long list.
 
 ### Improved
 
@@ -32,6 +41,14 @@ Drop-in on top of 0.4.23, no breaking changes.
 - **Claude session limits are labeled correctly.** If Claude hits its 5-hour
   session limit, Houston now shows a session-limit card instead of a misleading
   rate-limit message.
+- **OpenAI Codex usage limits are labeled correctly.** When Codex runs out of its
+  usage allowance, Houston now shows a clear quota card, including when it resets,
+  instead of a generic error.
+- **Routines no longer disappear.** A single routine with an unusual character
+  used to make the whole list fail to load. Houston now recovers your routines and
+  keeps them instead of clearing the list.
+- **The model picker only lists models you can use.** A model that was not
+  available to select no longer appears in the chat or onboarding model pickers.
 - **App connections update immediately.** When a connected app is already linked,
   Houston now flips Connect to connected instead of leaving the screen stale.
 - **More sign-in output is understood.** Houston now handles the prose output from

--- a/.github/release-notes/0.4.24.pt.md
+++ b/.github/release-notes/0.4.24.pt.md
@@ -1,9 +1,9 @@
 ## Houston 0.4.24
 
-Uma versão de polimento e confiabilidade. O chat fica mais tranquilo, as rotinas
-agendadas ficam mais fáceis de configurar, as conexões com apps se recuperam
-melhor e o limite de sessão do Claude agora mostra a mensagem correta em vez de
-parecer um limite genérico de uso.
+Uma versão de polimento e confiabilidade. Agora você pode entrar no Houston sem
+sair da app, o chat fica mais tranquilo, as rotinas agendadas ficam mais fáceis
+de configurar e não somem mais, e os limites do Claude e do OpenAI Codex agora
+mostram a mensagem correta em vez de um erro genérico.
 Pode instalar por cima da 0.4.23, sem mudanças incompatíveis.
 
 ### Adicionado
@@ -14,6 +14,15 @@ Pode instalar por cima da 0.4.23, sem mudanças incompatíveis.
 - **Contexto mais claro no chat.** O indicador de contexto agora é um anel mais
   discreto ao passar o cursor, para você ver o sinal quando precisar sem colocar
   mais ruído na tela do chat.
+- **Entre sem sair do Houston.** Agora você pode entrar dentro da app com o
+  Google, um código de uso único por e-mail ou sua conta Microsoft, em vez de ir
+  para o navegador para terminar.
+- **Configurações do agente em um só lugar.** A aba de configurações do agente
+  agora tem uma seção de Configurações onde você pode renomear um agente e chegar
+  às ações do cartão, em vez de procurar em um menu.
+- **Encontre um fuso horário digitando.** O controle de fuso horário das rotinas
+  agora é um seletor com busca. Digite uma cidade ou região em vez de percorrer
+  uma lista longa.
 
 ### Melhorado
 
@@ -34,6 +43,15 @@ Pode instalar por cima da 0.4.23, sem mudanças incompatíveis.
 - **Os limites de sessão do Claude são identificados corretamente.** Se o Claude
   atingir o limite de sessão de 5 horas, o Houston agora mostra um cartão de
   limite de sessão em vez de uma mensagem enganosa de limite de uso.
+- **Os limites de uso do OpenAI Codex são identificados corretamente.** Quando o
+  Codex esgota o uso disponível, o Houston agora mostra um cartão de cota claro,
+  com a data em que reinicia, em vez de um erro genérico.
+- **As rotinas não somem mais.** Uma única rotina com um caractere incomum fazia
+  a lista inteira não carregar. O Houston agora recupera as suas rotinas e as
+  mantém em vez de apagar a lista.
+- **O seletor de modelos só mostra modelos que você pode usar.** Um modelo que
+  não estava disponível para seleção não aparece mais no seletor de modelos do
+  chat nem no de boas-vindas.
 - **Conexões de apps atualizam na hora.** Quando uma app conectada já estava
   vinculada, o Houston agora muda Connect para conectado em vez de deixar a tela
   desatualizada.


### PR DESCRIPTION
Re-cut of **v0.4.24** from the current `main`.

The first `v0.4.24` tag (PR #544) was cut before six fixes landed on `main`, and the resulting build is still an unpublished draft GitHub Release. This PR re-cuts v0.4.24 from current `main` so those fixes ship in the release, and refreshes the release notes to cover them. The version number stays `0.4.24` (already on `main`; never published), so this PR is **release-notes only** — no version bump diff.

## Folded into v0.4.24 (landed after the original tag)

- Codex usage limit surfaced as a quota card, not a generic runtime error (HOU-495, #548)
- In-app sign-in: loopback OAuth + email code + Microsoft (#447)
- Recover routines with unescaped control chars instead of wiping them (HOU-494, #547)
- Searchable timezone picker for routines (HOU-496, #549)
- Agent Settings section + sidebar card actions (HOU-492, #546)
- Remove unavailable model from the model picker (HOU-476, #545)

## Files

- `.github/release-notes/0.4.24.md` (en)
- `.github/release-notes/0.4.24.es.md` (es)
- `.github/release-notes/0.4.24.pt.md` (pt)

## Release steps after merge

1. Delete the stale draft GitHub Release **Houston v0.4.24** (built from the premature tag).
2. Move tag `v0.4.24` to this merge commit (delete + re-push), triggering a fresh CI build.
3. CI builds, signs, notarizes → new **draft** GH Release. Handed off to the user to publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)