### PR TITLE
release: v0.4.24

### DIFF
--- a/.github/release-notes/0.4.24.es.md
+++ b/.github/release-notes/0.4.24.es.md
@@ -1,11 +1,5 @@
 ## Houston 0.4.24
 
-Una versión de pulido y confiabilidad. Ahora puedes iniciar sesión en Houston
-sin salir de la app, el chat se siente más tranquilo, las rutinas programadas son
-más fáciles de configurar y ya no desaparecen, y los límites de Claude y OpenAI
-Codex ahora muestran el mensaje correcto en vez de un error genérico.
-Puedes instalarla encima de 0.4.23, sin cambios incompatibles.
-
 ### Agregado
 
 - **Programar rutinas es más fácil.** Los horarios semanales ahora son un preset
@@ -49,9 +43,12 @@ Puedes instalarla encima de 0.4.23, sin cambios incompatibles.
 - **Las rutinas ya no desaparecen.** Una sola rutina con un carácter inusual
   hacía que toda la lista no cargara. Houston ahora recupera tus rutinas y las
   conserva en vez de borrar la lista.
+- **Houston abre de forma confiable después de reiniciar.** Un bloqueo de inicio
+  podía dejar Houston ejecutándose sin mostrar ventana. Houston ahora mantiene
+  libre el arranque del motor para que la ventana principal aparezca normalmente.
 - **El selector de modelos solo muestra modelos que puedes usar.** Un modelo que
   no estaba disponible para seleccionar ya no aparece en el selector de modelos
-  del chat ni en el de bienvenida.
+  del chat.
 - **Las conexiones de apps se actualizan al instante.** Cuando una app conectada
   ya estaba vinculada, Houston ahora cambia Connect a conectado en vez de dejar
   la pantalla desactualizada.

--- a/.github/release-notes/0.4.24.md
+++ b/.github/release-notes/0.4.24.md
@@ -1,11 +1,5 @@
 ## Houston 0.4.24
 
-A polish and reliability release. You can now sign in to Houston without leaving
-the app, chat feels calmer, scheduled routines are easier to set up and no longer
-go missing, and provider limits from Claude and OpenAI Codex now show the right
-message instead of a generic error.
-Drop-in on top of 0.4.23, no breaking changes.
-
 ### Added
 
 - **Easier routine scheduling.** Weekly schedules are now a simple multi-day
@@ -47,8 +41,11 @@ Drop-in on top of 0.4.23, no breaking changes.
 - **Routines no longer disappear.** A single routine with an unusual character
   used to make the whole list fail to load. Houston now recovers your routines and
   keeps them instead of clearing the list.
+- **Houston opens reliably after relaunching.** A startup deadlock could leave
+  Houston running with no window. Houston now keeps the engine startup path free
+  so the main window appears normally.
 - **The model picker only lists models you can use.** A model that was not
-  available to select no longer appears in the chat or onboarding model pickers.
+  available to select no longer appears in the chat model picker.
 - **App connections update immediately.** When a connected app is already linked,
   Houston now flips Connect to connected instead of leaving the screen stale.
 - **More sign-in output is understood.** Houston now handles the prose output from

--- a/.github/release-notes/0.4.24.pt.md
+++ b/.github/release-notes/0.4.24.pt.md
@@ -1,11 +1,5 @@
 ## Houston 0.4.24
 
-Uma versão de polimento e confiabilidade. Agora você pode entrar no Houston sem
-sair da app, o chat fica mais tranquilo, as rotinas agendadas ficam mais fáceis
-de configurar e não somem mais, e os limites do Claude e do OpenAI Codex agora
-mostram a mensagem correta em vez de um erro genérico.
-Pode instalar por cima da 0.4.23, sem mudanças incompatíveis.
-
 ### Adicionado
 
 - **Agendar rotinas ficou mais fácil.** Os horários semanais agora são um preset
@@ -49,9 +43,13 @@ Pode instalar por cima da 0.4.23, sem mudanças incompatíveis.
 - **As rotinas não somem mais.** Uma única rotina com um caractere incomum fazia
   a lista inteira não carregar. O Houston agora recupera as suas rotinas e as
   mantém em vez de apagar a lista.
+- **O Houston abre de forma confiável depois de reiniciar.** Um bloqueio na
+  inicialização podia deixar o Houston rodando sem mostrar janela. O Houston agora
+  mantém o caminho de inicialização do motor livre para a janela principal aparecer
+  normalmente.
 - **O seletor de modelos só mostra modelos que você pode usar.** Um modelo que
   não estava disponível para seleção não aparece mais no seletor de modelos do
-  chat nem no de boas-vindas.
+  chat.
 - **Conexões de apps atualizam na hora.** Quando uma app conectada já estava
   vinculada, o Houston agora muda Connect para conectado em vez de deixar a tela
   desatualizada.


### PR DESCRIPTION
## Summary
- Re-cuts the v0.4.24 release branch from the latest `main`.
- Deletes the previous draft GitHub Release and tag so CI can create a fresh draft after this PR lands.
- Refreshes the user-facing release notes in English, Spanish, and Portuguese.
- Keeps onboarding analytics/internal funnel updates out of the user changelog.

## Changelog summary

### Added
- Easier routine scheduling.
- Clearer context in chat.
- Sign in without leaving Houston.
- Agent Settings in one place.
- Find a timezone by typing.

### Improved
- Less visual noise while Houston works.
- More consistent cards.
- Simpler effort control.
- One timezone for routines.

### Fixed
- Claude session limits are labeled correctly.
- OpenAI Codex usage limits are labeled correctly.
- Routines no longer disappear.
- Houston opens reliably after relaunching.
- The model picker only lists models you can use.
- App connections update immediately.
- More sign-in output is understood.
- Chat errors stay where they happened.
- Tool activity no longer repeats in snapshots.
- Routines keep their jobs in sync.
- Buttons resist repeated clicks.
- Deleting activity is safe to retry.
- Skill detail loading is clearer.
- Developer crash reporting is quieter.
- Phone access reset waits for readiness.
- Benign browser lock handoffs are ignored.
- Skill installs are idempotent.

## Verification
- `./scripts/test/release-scripts.test.sh` → PASS 26 / FAIL 0
- Checked v0.4.24 release notes for onboarding/funnel/internal analytics wording → no matches
- Checked v0.4.24 release notes for `-->` i18n-comment terminators → no matches
