### PR TITLE
Fix agent empty state selection

### DIFF
--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -47,6 +47,8 @@ interface WorkspaceShellProps {
 export function WorkspaceShell({ toasts, onDismissToast }: WorkspaceShellProps) {
   const { t } = useTranslation(["agents", "shell", "board"]);
   const currentAgent = useAgentStore((s) => s.current);
+  const agents = useAgentStore((s) => s.agents);
+  const setCurrentAgent = useAgentStore((s) => s.setCurrent);
   const getById = useAgentCatalogStore((s) => s.getById);
   const viewMode = useUIStore((s) => s.viewMode);
   const setViewMode = useUIStore((s) => s.setViewMode);
@@ -76,6 +78,12 @@ export function WorkspaceShell({ toasts, onDismissToast }: WorkspaceShellProps) 
       setViewMode(DEFAULT_TAB_ID);
     }
   }, [isAgentView, setViewMode, viewMode]);
+
+  useEffect(() => {
+    if (!currentAgent && agents.length > 0) {
+      setCurrentAgent(agents[0]);
+    }
+  }, [agents, currentAgent, setCurrentAgent]);
 
   // Single tab_opened analytics point — watches viewMode regardless of which
   // path triggered the change (TabBar click, sidebar nav, keyboard shortcut,
@@ -220,7 +228,7 @@ export function WorkspaceShell({ toasts, onDismissToast }: WorkspaceShellProps) 
                     />
                   </main>
                 </>
-              ) : (
+              ) : agents.length === 0 ? (
                 <div className="flex flex-1 flex-col items-center justify-center">
                   <Empty className="border-0">
                     <EmptyHeader>
@@ -235,6 +243,10 @@ export function WorkspaceShell({ toasts, onDismissToast }: WorkspaceShellProps) 
                       {t("shell:newAgent.dialogTitle")}
                     </Button>
                   </Empty>
+                </div>
+              ) : (
+                <div className="flex flex-1 flex-col items-center justify-center">
+                  <p className="text-muted-foreground text-sm">{t("shell:engineGate.starting")}</p>
                 </div>
               )}
             </main>

--- a/app/src/lib/agent-selection.ts
+++ b/app/src/lib/agent-selection.ts
@@ -1,0 +1,12 @@
+import type { Agent } from "./types";
+
+/**
+ * Keep an existing selection only when it still belongs to the loaded agent
+ * list. Otherwise pick the first available agent so the shell never renders the
+ * no-agent empty state for a workspace that already has agents.
+ */
+export function selectCurrentAgent(agents: Agent[], current: Agent | null): Agent | null {
+  if (agents.length === 0) return null;
+  if (!current) return agents[0];
+  return agents.find((a) => a.id === current.id) ?? agents[0];
+}

--- a/app/src/stores/agents.ts
+++ b/app/src/stores/agents.ts
@@ -3,10 +3,23 @@ import { tauriAgents, tauriAttachments, tauriPreferences, tauriRoutines, tauriWa
 import { useFeedStore } from "./feeds";
 import { useDraftStore } from "./drafts";
 import { analytics } from "../lib/analytics";
+import { selectCurrentAgent } from "../lib/agent-selection";
 import type { Agent } from "../lib/types";
 
 export interface CreatedAgent {
   agent: Agent;
+}
+
+function startAgentSideEffects(agent: Agent) {
+  tauriPreferences.set("last_agent_id", agent.id);
+  // Start file watcher for AI-native reactivity
+  tauriWatcher.start(agent.folderPath).catch((e) =>
+    console.error("[watcher] Failed to start:", e),
+  );
+  // Start routine scheduler for this agent
+  tauriRoutines.startScheduler(agent.folderPath).catch((e) =>
+    console.error("[routines] Failed to start scheduler:", e),
+  );
 }
 
 interface AgentState {
@@ -32,9 +45,11 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     try {
       const agents = await tauriAgents.list(workspaceId);
       const current = get().current;
-      const selected =
-        agents.find((a) => a.id === current?.id) ?? current;
+      const selected = selectCurrentAgent(agents, current);
       set({ agents, current: selected, loading: false });
+      if (selected && selected.id !== current?.id) {
+        startAgentSideEffects(selected);
+      }
     } catch (e) {
       console.error("[agents] Failed to load:", e);
       set({ loading: false });
@@ -43,15 +58,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
 
   setCurrent: (agent) => {
     set({ current: agent });
-    tauriPreferences.set("last_agent_id", agent.id);
-    // Start file watcher for AI-native reactivity
-    tauriWatcher.start(agent.folderPath).catch((e) =>
-      console.error("[watcher] Failed to start:", e),
-    );
-    // Start routine scheduler for this agent
-    tauriRoutines.startScheduler(agent.folderPath).catch((e) =>
-      console.error("[routines] Failed to start scheduler:", e),
-    );
+    startAgentSideEffects(agent);
   },
 
   create: async (workspaceId: string, name: string, configId: string, color?: string, claudeMd?: string, installedPath?: string, seeds?: Record<string, string>, existingPath?: string) => {
@@ -62,17 +69,14 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       agents: [...s.agents, agent],
       current: agent,
     }));
-    tauriPreferences.set("last_agent_id", agent.id);
-    // Start file watcher so agent writes (CLAUDE.md, skills) trigger query invalidation
-    tauriWatcher.start(agent.folderPath).catch((e) =>
-      console.error("[watcher] Failed to start:", e),
-    );
+    startAgentSideEffects(agent);
     return { agent };
   },
 
   delete: async (workspaceId, id) => {
     // Resolve the agent path before deleting so we can clear its feed bucket.
     const agentPath = get().agents.find((a) => a.id === id)?.folderPath;
+    const wasCurrent = get().current?.id === id;
     await tauriAgents.delete(workspaceId, id);
     // Wipe any chat composer attachments scoped to this agent's chat.
     // Per-activity attachments are wiped via useDeleteActivity / handleDelete.
@@ -84,12 +88,16 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     }
     // Clear the free-form chat draft for this agent.
     useDraftStore.getState().clearDraft(`chat-${id}`);
+    let nextCurrent: Agent | null = null;
     set((s) => {
       const agents = s.agents.filter((a) => a.id !== id);
-      const current =
-        s.current?.id === id ? agents[0] ?? null : s.current;
+      const current = wasCurrent ? agents[0] ?? null : s.current;
+      nextCurrent = current;
       return { agents, current };
     });
+    if (wasCurrent && nextCurrent) {
+      startAgentSideEffects(nextCurrent);
+    }
   },
 
   rename: async (workspaceId, id, newName) => {

--- a/app/tests/agent-selection.test.ts
+++ b/app/tests/agent-selection.test.ts
@@ -1,0 +1,46 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { selectCurrentAgent } from "../src/lib/agent-selection.ts";
+import type { Agent } from "../src/lib/types.ts";
+
+function agent(id: string, name = id): Agent {
+  return {
+    id,
+    name,
+    folderPath: `/agents/${name}`,
+    configId: "personal-assistant",
+    color: "orange",
+    createdAt: "2026-01-01T00:00:00Z",
+    lastOpenedAt: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("agent selection", () => {
+  it("auto-selects the first agent when none is selected", () => {
+    const first = agent("a1", "Ada");
+    const selected = selectCurrentAgent([first, agent("a2", "Grace")], null);
+
+    strictEqual(selected, first);
+  });
+
+  it("keeps the matching loaded agent when the current selection still exists", () => {
+    const previous = agent("a2", "Old Grace");
+    const refreshed = agent("a2", "Grace");
+    const selected = selectCurrentAgent([agent("a1", "Ada"), refreshed], previous);
+
+    strictEqual(selected, refreshed);
+  });
+
+  it("replaces a stale selection with the first loaded agent", () => {
+    const first = agent("a1", "Ada");
+    const selected = selectCurrentAgent([first], agent("missing", "Deleted"));
+
+    strictEqual(selected, first);
+  });
+
+  it("clears the selection when the workspace has no agents", () => {
+    const selected = selectCurrentAgent([], agent("missing", "Deleted"));
+
+    strictEqual(selected, null);
+  });
+});


### PR DESCRIPTION
## Summary
- Auto-select the first loaded agent whenever a workspace has agents but no current selection.
- Replace stale selections with a loaded agent instead of letting the shell fall through to the no-agent empty state.
- Guard the workspace shell so the "No agents yet" empty state only renders when the loaded agent list is actually empty.
- Add regression coverage for missing, stale, preserved, and genuinely empty selections.

## Verification
- `node --experimental-strip-types --test app/tests/agent-selection.test.ts`
- `pnpm --dir app typecheck`
- `pnpm --dir app test`
- `pnpm --dir app build`
