### PR TITLE
fix(routines): suspend-safe scheduler — fire on a capped wall-clock tick, not one long sleep (HOU-541)

### DIFF
--- a/engine/houston-engine-core/src/routines/scheduler.rs
+++ b/engine/houston-engine-core/src/routines/scheduler.rs
@@ -10,7 +10,7 @@ use crate::routines::{
     runner::{run_routine, ActivitySurface, RoutineDispatcher},
     types::Routine,
 };
-use chrono::Utc;
+use chrono::{DateTime, Utc};
 use chrono_tz::Tz;
 use cron::Schedule;
 use houston_ui_events::{DynEventSink, HoustonEvent};
@@ -18,7 +18,45 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::{watch, Mutex};
+
+/// Upper bound on a single sleep in the cron wait loop.
+///
+/// A scheduled fire can be a whole day out, but we must never wait for it in one
+/// long sleep. `tokio::time::sleep` runs on the monotonic clock, and on macOS
+/// that clock *stops while the machine is asleep* (App Nap, a closed lid, idle
+/// suspend). One multi-hour sleep therefore undercounts wall-clock time by the
+/// suspend duration: the routine fires late by however long the Mac napped, and
+/// across an overnight suspend it can miss the day entirely with no run ever
+/// recorded (HOU-541). Capping each sleep forces the loop to re-read the wall
+/// clock at least this often, so after a wake an overdue fire is noticed within
+/// `MAX_TICK` and caught up.
+const MAX_TICK: Duration = Duration::from_secs(30);
+
+/// One decision of the cron wait loop, split out so the suspend-safe timing can
+/// be unit-tested without real clocks or real time passing.
+#[derive(Debug, PartialEq, Eq)]
+enum Tick {
+    /// `now` has reached or passed the scheduled instant — fire the routine.
+    Fire,
+    /// Not due yet — sleep this long (never more than `MAX_TICK`) and re-check.
+    Sleep(Duration),
+}
+
+/// Decide what the wait loop should do given the current wall-clock `now` and
+/// the `next` scheduled instant. Fires when due *or overdue* (the overdue branch
+/// is the catch-up after a suspend that slept past the instant); otherwise naps
+/// until `next`, capped at `max` so a single wait can never outlast a system
+/// suspend.
+fn tick(now: DateTime<Utc>, next: DateTime<Utc>, max: Duration) -> Tick {
+    match next.signed_duration_since(now).to_std() {
+        // Strictly in the future: nap until it, but no longer than `max`.
+        Ok(remaining) if !remaining.is_zero() => Tick::Sleep(remaining.min(max)),
+        // Zero (`to_std` -> Ok(0)) or negative (`to_std` -> Err): due / overdue.
+        _ => Tick::Fire,
+    }
+}
 
 /// A spawned cron task plus the signature it was spawned for. The signature
 /// captures everything that determines *when* the job fires — the schedule and
@@ -174,26 +212,34 @@ impl AgentScheduler {
         let mut shutdown_rx = self.shutdown_tx.subscribe();
 
         Ok(tokio::spawn(async move {
+            // The instant we're currently waiting to fire. Re-armed from the
+            // schedule after every fire. `upcoming` is "strictly after now", so
+            // once a fire has happened (now has passed the old instant) it
+            // yields the next *future* instant — which collapses every instant
+            // skipped during a long suspend into a single catch-up rather than
+            // replaying the whole backlog on wake. It is computed once and held:
+            // recomputing it mid-wait would step past the very instant we are
+            // waiting for the moment `now` reaches it.
+            let mut next = match schedule.upcoming(tz).next() {
+                Some(t) => t,
+                None => return,
+            };
+
             loop {
-                let next = match schedule.upcoming(tz).next() {
-                    Some(t) => t,
-                    None => return,
-                };
-
-                let delay = next.with_timezone(&Utc).signed_duration_since(Utc::now());
-                let sleep_dur = if delay.num_milliseconds() > 0 {
-                    std::time::Duration::from_millis(delay.num_milliseconds() as u64)
-                } else {
-                    std::time::Duration::from_millis(0)
-                };
-
-                tokio::select! {
-                    _ = tokio::time::sleep(sleep_dur) => {}
-                    _ = shutdown_rx.changed() => {
-                        if *shutdown_rx.borrow() {
-                            return;
+                // Sleep toward `next` in capped chunks (see `MAX_TICK`) so the
+                // wait re-reads the wall clock often enough to survive a system
+                // suspend; fall through to fire as soon as the clock has reached
+                // or passed the instant.
+                if let Tick::Sleep(nap) = tick(Utc::now(), next.with_timezone(&Utc), MAX_TICK) {
+                    tokio::select! {
+                        _ = tokio::time::sleep(nap) => {}
+                        _ = shutdown_rx.changed() => {
+                            if *shutdown_rx.borrow() {
+                                return;
+                            }
                         }
                     }
+                    continue;
                 }
 
                 tracing::info!(
@@ -224,6 +270,13 @@ impl AgentScheduler {
                         );
                     }
                 }
+
+                // Re-arm for the next future instant. Done after the run so an
+                // overrunning routine can't immediately re-fire its own slot.
+                next = match schedule.upcoming(tz).next() {
+                    Some(t) => t,
+                    None => return,
+                };
             }
         }))
     }
@@ -323,6 +376,7 @@ impl RoutineSchedulerState {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::TimeZone;
     use crate::routines::create;
     use crate::routines::runner::{DispatchContext, DispatchOutcome};
     use crate::routines::types::{NewRoutine, RoutineChatMode};
@@ -638,5 +692,46 @@ mod tests {
         }
         state.stop_all().await;
         assert!(state.0.lock().await.is_empty());
+    }
+
+    // ---- suspend-safe wait loop (HOU-541) ----------------------------------
+    // These drive `tick` with synthetic clocks: no real time passes, so the
+    // timing policy is asserted deterministically. The bug was a single
+    // multi-hour `tokio::time::sleep` whose monotonic timer macOS freezes
+    // during system sleep, so the routine fired late or — across an overnight
+    // suspend — never that day, with no run recorded.
+
+    #[test]
+    fn tick_far_future_fire_is_capped_to_max_tick() {
+        // A fire ~23h out must become a short capped nap, never one 23h sleep:
+        // that single monotonic sleep is exactly what a suspend freezes.
+        let now = Utc.with_ymd_and_hms(2026, 6, 19, 1, 0, 0).unwrap();
+        let next = now + chrono::Duration::hours(23);
+        assert_eq!(tick(now, next, MAX_TICK), Tick::Sleep(MAX_TICK));
+    }
+
+    #[test]
+    fn tick_within_cap_sleeps_the_exact_remainder() {
+        // Closer than the cap: wait precisely the remainder, don't fire early.
+        let now = Utc.with_ymd_and_hms(2026, 6, 19, 12, 59, 55).unwrap();
+        let next = Utc.with_ymd_and_hms(2026, 6, 19, 13, 0, 0).unwrap();
+        assert_eq!(tick(now, next, MAX_TICK), Tick::Sleep(Duration::from_secs(5)));
+    }
+
+    #[test]
+    fn tick_due_now_fires() {
+        let now = Utc.with_ymd_and_hms(2026, 6, 19, 13, 0, 0).unwrap();
+        assert_eq!(tick(now, now, MAX_TICK), Tick::Fire);
+    }
+
+    #[test]
+    fn tick_overdue_after_suspend_fires_immediately() {
+        // The HOU-541 case: the Mac slept past 08:00 Bogota (13:00 UTC) and the
+        // loop only re-reads the clock on wake, hours later. The overdue instant
+        // must fire (catch up), not be skipped — skipping is why no run was ever
+        // recorded that morning.
+        let next = Utc.with_ymd_and_hms(2026, 6, 19, 13, 0, 0).unwrap();
+        let woke = next + chrono::Duration::hours(9);
+        assert_eq!(tick(woke, next, MAX_TICK), Tick::Fire);
     }
 }

--- a/engine/houston-scheduler/src/cron_job.rs
+++ b/engine/houston-scheduler/src/cron_job.rs
@@ -1,4 +1,5 @@
 use std::str::FromStr;
+use std::time::Duration;
 
 use chrono::Utc;
 use cron::Schedule;
@@ -6,6 +7,30 @@ use houston_events::{EventQueueHandle, HoustonInput};
 use serde::{Deserialize, Serialize};
 use tokio::sync::watch;
 use tracing::{debug, error, info, warn};
+
+/// Upper bound on a single sleep in the cron wait loop. `tokio::time::sleep`
+/// waits on the monotonic clock, which macOS freezes while the machine is
+/// asleep, so one long sleep undercounts wall-clock time by the suspend
+/// duration and the job fires late or misses the day (HOU-541). Capping each
+/// sleep makes the loop re-read the wall clock often enough to catch up within
+/// `MAX_TICK` of a wake.
+const MAX_TICK: Duration = Duration::from_secs(30);
+
+/// How long to nap before re-checking a scheduled instant, or `None` when the
+/// instant is due (`now`) or overdue (a suspend slept past it) and the job
+/// should fire. The nap is capped at `max` so the wait loop re-reads the wall
+/// clock often enough to survive a system suspend. Pure in `now`, so the timing
+/// is unit-testable without real time passing.
+fn wait_until(
+    now: chrono::DateTime<Utc>,
+    next: chrono::DateTime<Utc>,
+    max: Duration,
+) -> Option<Duration> {
+    match next.signed_duration_since(now).to_std() {
+        Ok(remaining) if !remaining.is_zero() => Some(remaining.min(max)),
+        _ => None,
+    }
+}
 
 /// Configuration for a single cron job.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -73,38 +98,33 @@ impl CronRunner {
             "Cron runner started"
         );
 
+        // The instant we're waiting to fire, re-armed after each fire. Held
+        // across the wait (not recomputed mid-loop): `upcoming` is "strictly
+        // after now", so recomputing once `now` reaches it would step right
+        // over the instant we mean to fire.
+        let mut next = match schedule.upcoming(Utc).next() {
+            Some(t) => t,
+            None => {
+                warn!(cron_id = %config.id, "No future occurrences, stopping");
+                return;
+            }
+        };
+
         loop {
-            let next = match schedule.upcoming(Utc).next() {
-                Some(t) => t,
-                None => {
-                    warn!(cron_id = %config.id, "No future occurrences, stopping");
-                    return;
-                }
-            };
-
-            let now = Utc::now();
-            let delay = next.signed_duration_since(now);
-            let sleep_duration = if delay.num_milliseconds() > 0 {
-                std::time::Duration::from_millis(delay.num_milliseconds() as u64)
-            } else {
-                std::time::Duration::from_millis(0)
-            };
-
-            debug!(
-                cron_id = %config.id,
-                next = %next,
-                sleep_ms = sleep_duration.as_millis() as u64,
-                "Sleeping until next cron trigger"
-            );
-
-            tokio::select! {
-                _ = tokio::time::sleep(sleep_duration) => {}
-                _ = shutdown.changed() => {
-                    if *shutdown.borrow() {
-                        info!(cron_id = %config.id, "Cron runner shutting down");
-                        return;
+            // Sleep toward `next` in capped chunks so a long wait can't outlast
+            // a system suspend (see `MAX_TICK`); fire as soon as the wall clock
+            // has reached or passed the instant.
+            if let Some(nap) = wait_until(Utc::now(), next, MAX_TICK) {
+                tokio::select! {
+                    _ = tokio::time::sleep(nap) => {}
+                    _ = shutdown.changed() => {
+                        if *shutdown.borrow() {
+                            info!(cron_id = %config.id, "Cron runner shutting down");
+                            return;
+                        }
                     }
                 }
+                continue;
             }
 
             let mut input = HoustonInput::cron(&config.name, &config.prompt);
@@ -122,6 +142,54 @@ impl CronRunner {
             }
 
             debug!(cron_id = %config.id, "Cron job fired");
+
+            // Re-arm for the next future instant (see the comment above the
+            // initial computation).
+            next = match schedule.upcoming(Utc).next() {
+                Some(t) => t,
+                None => {
+                    warn!(cron_id = %config.id, "No future occurrences, stopping");
+                    return;
+                }
+            };
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    // `wait_until` is the suspend-safe core of the cron wait loop (HOU-541):
+    // a fire that is a whole day out must still be waited for in capped naps,
+    // and an instant the machine slept past must fire rather than be skipped.
+
+    #[test]
+    fn wait_until_caps_a_far_future_nap() {
+        let now = Utc.with_ymd_and_hms(2026, 6, 19, 1, 0, 0).unwrap();
+        let next = now + chrono::Duration::hours(23);
+        assert_eq!(wait_until(now, next, MAX_TICK), Some(MAX_TICK));
+    }
+
+    #[test]
+    fn wait_until_returns_exact_remainder_within_cap() {
+        let now = Utc.with_ymd_and_hms(2026, 6, 19, 12, 59, 50).unwrap();
+        let next = Utc.with_ymd_and_hms(2026, 6, 19, 13, 0, 0).unwrap();
+        assert_eq!(wait_until(now, next, MAX_TICK), Some(Duration::from_secs(10)));
+    }
+
+    #[test]
+    fn wait_until_fires_when_due() {
+        let now = Utc.with_ymd_and_hms(2026, 6, 19, 13, 0, 0).unwrap();
+        assert_eq!(wait_until(now, now, MAX_TICK), None);
+    }
+
+    #[test]
+    fn wait_until_fires_when_overdue_after_suspend() {
+        // Woke hours after the instant: catch up, don't skip.
+        let next = Utc.with_ymd_and_hms(2026, 6, 19, 13, 0, 0).unwrap();
+        let woke = next + chrono::Duration::hours(9);
+        assert_eq!(wait_until(woke, next, MAX_TICK), None);
     }
 }

--- a/knowledge-base/engine-protocol.md
+++ b/knowledge-base/engine-protocol.md
@@ -199,6 +199,20 @@ every weekly routine fired a day early and Sunday routines never scheduled
 (issue #389). Keep cron generation/parsing on the standard convention; never
 hand a raw `schedule` to `Schedule::from_str`.
 
+**Suspend-safe waiting (HOU-541).** The cron task must NOT wait for its next
+fire in one long `tokio::time::sleep`. That timer runs on the monotonic clock,
+which macOS *freezes while the machine is asleep* (App Nap, closed lid, idle
+suspend) — so a single multi-hour sleep undercounts wall-clock time by the nap
+duration and the routine fires late, or across an overnight suspend never that
+day, with no run row ever written (the run row is only created when the timer
+actually fires). The loop instead re-reads the wall clock in capped chunks
+(`MAX_TICK`, 30s) and fires the moment `now` has reached *or passed* the
+instant, so a wake catches up an overdue fire within `MAX_TICK`. After firing it
+re-arms with `upcoming().next()` (strictly-after-now), which collapses every
+instant skipped during a long suspend into a single catch-up instead of
+replaying the backlog. Same pattern in `houston-scheduler::cron_job`. Never
+reintroduce a single unbounded sleep for a wall-clock deadline.
+
 **Conversations** (cross-agent read)
 | Method | Path | Description |
 |---|---|---|


### PR DESCRIPTION
## HOU-541 — Routine execution not working

A user's routines (8:00 / 8:45 / 9:00 AM `America/Bogota`) stopped firing. The app was open on his Mac the whole time, the routines were enabled, they ran the previous day — but the morning they failed, **no run was recorded at all, not even an attempt**. The in-app agent could only read `.houston/` JSON, so it guessed "the scheduler didn't wake." This is the real cause.

## Root cause

`routines::scheduler::spawn_cron` armed **one** `tokio::time::sleep` for the entire gap until the next fire (~23h):

```rust
let next  = schedule.upcoming(tz).next();
let delay = next.with_timezone(&Utc).signed_duration_since(Utc::now()); // ~23h
tokio::time::sleep(sleep_dur).await; // single long monotonic-clock sleep
```

tokio's timer is **monotonic**, and on macOS the monotonic clock **stops while the machine is asleep** (App Nap, closed lid, idle suspend). A single multi-hour sleep therefore undercounts wall-clock time by the suspend duration:

- short nap → fires hours late
- laptop closed overnight (8–14h) → the fire is pushed so far it hasn't elapsed by morning → **the day's run never happens**

The run row is written only inside `begin_run` *when the timer fires*, so a missed/deferred fire leaves **no record** — exactly the reported symptom. Normal Mac sleep is the trigger; a correct scheduler (cron/launchd/systemd) must tolerate it. "App open" ≠ "machine awake".

### Evidence (engine logs, a different affected user)

Bogota = UTC−5, so `0 8`→13:00Z, `45 8`→13:45Z, `0 9`→14:00Z. After a ~2h suspend, all three fired late by the **same** offset:

| Routine | Scheduled (Z) | Fired (Z) | Late |
|---|---|---|---|
| `0 8 * * *` | 13:00 | 14:57:51 | +1h58m |
| `45 8 * * *` | 13:45 | 15:42:51 | +1h57m |
| `0 9 * * *` | 14:00 | 15:57:51 | +1h57m |

A uniform lateness across three different scheduled times is the fingerprint of one suspend block frozen out of the monotonic timer. On mornings the Mac was awake before 08:00, fires were on time — proving the cron/timezone logic is correct; only the wait mechanism was broken.

## Fix

Wait toward the next instant in **capped chunks** (`MAX_TICK` = 30s), re-reading the wall clock each tick, and fire as soon as `now` has reached **or passed** the instant — so a wake catches up an overdue fire within 30s. After firing, re-arm with `upcoming().next()` (strictly-after-now), which collapses every instant skipped during a long suspend into a **single** catch-up rather than replaying the backlog. Wall-clock comparison (not accumulated monotonic delta) also makes it robust to NTP/DST jumps.

The timing decision is factored into a pure `tick` / `wait_until` helper and unit-tested with synthetic clocks (no real time passes): far-future is capped, near-future sleeps the exact remainder, due fires, and **overdue-after-suspend fires immediately**. The same flaw + fix is applied to `houston-scheduler::cron_job` (reachable via `houston-tauri`).

Out of scope (noted for follow-up): cross-*restart* catch-up — if the engine is killed during sleep and relaunched after the slot, the missed fire is still skipped (needs a persisted `last_fired` + startup catch-up). This PR fixes the in-process suspend case (engine alive across the nap), which is the reported scenario.

## Files
- `engine/houston-engine-core/src/routines/scheduler.rs` — capped-tick wait loop + `tick` helper + 4 unit tests
- `engine/houston-scheduler/src/cron_job.rs` — same pattern + `wait_until` helper + 4 unit tests
- `knowledge-base/engine-protocol.md` — "Suspend-safe waiting (HOU-541)" gotcha note

## Verify
**Before (bug):** with the old single-sleep loop, arm a daily routine, let the Mac sleep across the scheduled time (close the lid past the slot), reopen → no run is recorded for that slot; the fire only lands after the suspend duration of awake-time elapses.

**After (fix):**
- `cargo test -p houston-engine-core -p houston-scheduler` → 4 `tick::*` + 4 `wait_until::*` timing tests pass (incl. `*_overdue_after_suspend_*`).
- `cargo build --workspace` clean (engine-server + houston-tauri compile).
- Manual: arm a routine, sleep the Mac across the slot, wake → the routine fires within ~30s of wake and a run row appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)