### PR TITLE
feat(website): add Google Analytics 4 alongside PostHog

### DIFF
--- a/website/src/_data/env.js
+++ b/website/src/_data/env.js
@@ -3,5 +3,6 @@ export default function () {
     downloadCode: process.env.DOWNLOAD_CODE || "getsh*tdone",
     posthogKey: process.env.POSTHOG_KEY || "",
     posthogHost: process.env.POSTHOG_HOST || "https://us.i.posthog.com",
+    gaMeasurementId: process.env.GA_MEASUREMENT_ID || "G-GZRKCBT0D0",
   };
 }

--- a/website/src/_includes/base.njk
+++ b/website/src/_includes/base.njk
@@ -41,6 +41,33 @@
   });
 </script>
 {% endif %}
+{% if env.gaMeasurementId %}
+<!-- Google Analytics 4 (gtag.js) — loaded once site-wide via this base layout.
+     Static multi-page site: every navigation is a full load, so gtag's config
+     call emits page_view on each page. No SPA route tracking needed; GA4
+     enhanced measurement (configured in the GA UI) covers scroll, outbound
+     clicks and file downloads. Conversion events are forwarded from the
+     existing track() helper, so PostHog and GA stay in sync with no duplicate
+     pageviews and no second Google tag. -->
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  // Consent Mode v2. This site runs no advertising, so all ad signals are
+  // denied by default. Analytics mirrors the existing PostHog posture: on by
+  // default but disabled when the visitor has Do Not Track enabled
+  // (PostHog uses respect_dnt: true above).
+  var __houstonDNT = (navigator.doNotTrack == '1' || window.doNotTrack == '1' || navigator.msDoNotTrack == '1');
+  gtag('consent', 'default', {
+    ad_storage: 'denied',
+    ad_user_data: 'denied',
+    ad_personalization: 'denied',
+    analytics_storage: __houstonDNT ? 'denied' : 'granted'
+  });
+  gtag('js', new Date());
+  gtag('config', '{{ env.gaMeasurementId }}');
+</script>
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ env.gaMeasurementId }}"></script>
+{% endif %}
 </head>
 <body>
 {% block body %}{% endblock %}

--- a/website/src/index.html
+++ b/website/src/index.html
@@ -2560,10 +2560,21 @@ visionPath: "vision/index.html"
     });
   });
 
-  // Analytics helper — no-op when PostHog snippet not loaded
+  // Analytics helper — forwards each conversion event to both PostHog and
+  // Google Analytics 4. Each sink is independent: if one snippet is absent
+  // (no key, blocked, or Do Not Track) the other still fires. Event names are
+  // snake_case and props carry no personal information, so they map cleanly to
+  // GA4 events. Pageviews are NOT sent here — PostHog and gtag config each
+  // capture their own, so there are no duplicate pageviews.
   function track(name, props) {
-    if (typeof window === 'undefined' || !window.posthog || !window.posthog.capture) return;
-    try { window.posthog.capture(name, props || {}); } catch (e) {}
+    if (typeof window === 'undefined') return;
+    var payload = props || {};
+    if (window.posthog && window.posthog.capture) {
+      try { window.posthog.capture(name, payload); } catch (e) {}
+    }
+    if (typeof window.gtag === 'function') {
+      try { window.gtag('event', name, payload); } catch (e) {}
+    }
   }
 
   // OS-aware Download button: visitors on Windows kept clicking "Download for

--- a/website/src/privacy/index.html
+++ b/website/src/privacy/index.html
@@ -311,7 +311,7 @@ visionPath: "../vision/index.html"
 
   <h2 id="cookies">11. Cookies and similar technologies</h2>
   <p>
-    The gethouston.ai website uses a small number of cookies and local-storage entries for essential functionality (for example, remembering whether you have dismissed a banner) and for analytics through PostHog. The desktop app does not use cookies in the traditional web sense, but stores local preferences in your operating system's standard application-data location.
+    The gethouston.ai website uses a small number of cookies and local-storage entries for essential functionality (for example, remembering whether you have dismissed a banner) and for analytics through PostHog and Google Analytics 4. We use these analytics tools to understand aggregate, non-identifying usage of the website (such as page views and download interest); we do not use them for advertising. The desktop app does not use cookies in the traditional web sense, but stores local preferences in your operating system's standard application-data location.
   </p>
   <p>
     You can clear cookies and local storage through your browser settings. Blocking analytics may not affect your ability to use the Services.


### PR DESCRIPTION
## Summary
Adds **Google Analytics 4** (`G-GZRKCBT0D0`) to the gethouston.ai website (the `website/` 11ty project) so analytics data starts flowing. PostHog is fully preserved and untouched in behavior — GA4 runs alongside it.

The GA tag is injected **once** in the shared `src/_includes/base.njk` layout, so it loads on every templated page with a single Google tag and a single `page_view` per navigation. This is a static multi-page site (Eleventy), so each route is a full page load — GA4 enhanced measurement + the per-page `config` call cover pageviews; no SPA route tracking is required.

## Changes
- **`src/_data/env.js`** — new `gaMeasurementId` from `GA_MEASUREMENT_ID` env var, falling back to the public `G-GZRKCBT0D0` (same pattern as `posthogKey`/`posthogHost`).
- **`src/_includes/base.njk`** — gtag.js snippet with **Consent Mode v2**:
  - all advertising signals (`ad_storage`, `ad_user_data`, `ad_personalization`) **denied** (the site runs no ads);
  - `analytics_storage` **granted by default but denied under Do Not Track**, mirroring PostHog's existing `respect_dnt: true` posture.
- **`src/index.html`** — the existing `track()` helper now **dual-sends** every conversion event to PostHog **and** GA4 (`gtag('event', …)`). No duplicate pageviews; pageviews are handled by each SDK's own config, not by `track()`.
- **`src/privacy/index.html`** — cookies section updated to disclose Google Analytics alongside PostHog (factual disclosure; non-advertising use).

## Conversion events forwarded to GA4
All existing landing-page events, already snake_case and free of PII: `app_download_clicked`, `download_clicked`, `download_unlocked`, `download_started`, `waitlist_clicked`, `x_follow_clicked`, `skip_waitlist_expanded`, plus the Windows variants (`windows_modal_opened`, `windows_download_unlocked`, `windows_download_started`, `windows_waitlist_clicked`, `windows_arch_help_expanded`).

## Verification
- `npm run build` (Eleventy) passes.
- Built `_site` output: **exactly one** `G-GZRKCBT0D0` tag on each of the 13 templated pages; no GTM container, no second/duplicate Google tag, no other GA property.
- Consent Mode `default` present before the `config` call.
- `track()` dual-send compiled into `index.html`.

## Privacy decision still open (needs product/legal sign-off)
The site has **no cookie consent banner today** — PostHog already runs by default, disclosed in the privacy policy. This PR keeps GA4 consistent with that existing posture (Consent Mode v2 wired, ad signals denied, DNT respected) but does **not** add a region-gated (EU/UK/EEA GDPR) consent banner, because that is a legal/product decision. If you want opt-in consent for those regions, that's a follow-up: a CMP would flip the Consent Mode signals already in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)