### PR TITLE
fix(analytics): identify every user in PostHog by Supabase user id

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -74,17 +74,19 @@ export default function App() {
 
   const { data: session, isLoading: sessionLoading } = useSession();
 
-  // Identify / alias the user in PostHog AND Sentry on sign-in; reset on
-  // sign-out. Runs AFTER analytics.init() has claimed the install_id as
-  // distinct_id, so `alias(userId, profile)` correctly merges prior
-  // anonymous history. Sentry gets the same identity so crashes are
+  // Tag the user in PostHog AND Sentry on sign-in; reset on sign-out. The
+  // install_id stays PostHog's distinct_id (the website UTM bridge + onboarding
+  // funnel depend on it); `identifyUser` attaches supabase_user_id / email /
+  // signup date as person properties so every authenticated person joins back
+  // to a Supabase account. Sentry gets the same identity so crashes are
   // attributable to a user when triaging.
   const prevUserIdRef = useRef<string | null>(null);
   useEffect(() => {
     const userId = session?.user?.id ?? null;
     const userEmail = session?.user?.email ?? null;
+    const signupDate = session?.user?.created_at?.slice(0, 10) ?? null;
     if (userId && userId !== prevUserIdRef.current) {
-      analytics.alias(userId, { email: userEmail });
+      analytics.identifyUser(userId, { email: userEmail, signupDate });
       setSentryUser({ id: userId, email: userEmail });
       prevUserIdRef.current = userId;
     } else if (!userId && prevUserIdRef.current) {

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -101,11 +101,10 @@ type AnalyticsProperty =
   | "locale";
 
 type Props = Partial<Record<AnalyticsProperty, string | number | boolean>>;
-type UserProfile = {
+type UserIdentity = {
   email?: string | null;
-};
-type PersonProps = {
-  email?: string;
+  /** ISO date (YYYY-MM-DD) from auth.users.created_at — acquisition cohort. */
+  signupDate?: string | null;
 };
 
 const ALLOWED_PROPS = new Set<AnalyticsProperty>([
@@ -190,11 +189,6 @@ function cleanEmail(email?: string | null): string | undefined {
   const value = email?.trim().toLowerCase();
   const at = value?.lastIndexOf("@") ?? -1;
   return value && at > 0 && at < value.length - 1 ? value : undefined;
-}
-
-function personProps(profile?: UserProfile): PersonProps | undefined {
-  const email = cleanEmail(profile?.email);
-  return email ? { email } : undefined;
 }
 
 function daysBetween(fromISO: string, toISO: string): number {
@@ -304,10 +298,11 @@ export const analytics = {
     if (!KEY) return;
     try {
       posthog.capture(event, cleanProps(props));
-      // Maintain the `is_activated` person property — flips to true on
-      // first `chat_message_received` and stays true forever. Lets cohort
-      // filters say "activated users" without a complex insight.
-      if (event === "chat_message_received") {
+      // Maintain the `is_activated` person property — flips to true on the
+      // user's first `chat_message_sent` (activation = the user sends a
+      // message) and stays true forever. Lets cohort filters say "activated
+      // users" without a complex insight.
+      if (event === "chat_message_sent") {
         posthog.people.set({ is_activated: true });
       }
     } catch {
@@ -316,16 +311,34 @@ export const analytics = {
   },
 
   /**
-   * Merge anonymous install_id history into an identified user. Call on sign-in.
-   * Email is a person property for lookup/filtering, never an event prop.
-   * Flips the auth_status super property so every event going forward is
-   * tagged as authenticated.
+   * Stamp the signed-in user's Supabase identity onto the current person.
+   * Call on sign-in.
+   *
+   * We deliberately KEEP the install_id as PostHog's distinct_id — it is the
+   * spine the website `/welcome` UTM bridge and the sequential onboarding
+   * funnel both depend on. (PostHog ignores a second `identify()` with a new
+   * distinct_id once a person is identified, so re-pointing it is a silent
+   * no-op anyway.) Instead we attach `supabase_user_id` — plus email and signup
+   * date — as PERSON PROPERTIES, so every authenticated person carries a
+   * reliable, queryable join key to Supabase with pre-login attribution
+   * untouched. Email is a person property for lookup/filtering, never an event
+   * prop. Flips `auth_status` so every event going forward is authenticated.
+   *
+   * NOTE: join user-level metrics on `supabase_user_id` (not distinct_id) so a
+   * user signing in on two devices — two install_ids, one supabase_user_id —
+   * dedupes correctly.
    */
-  alias: (userId: string, profile?: UserProfile) => {
+  identifyUser: (userId: string, identity?: UserIdentity) => {
     if (!KEY) return;
     try {
-      posthog.alias(userId);
-      posthog.identify(userId, personProps(profile));
+      const email = cleanEmail(identity?.email);
+      posthog.setPersonProperties(
+        {
+          supabase_user_id: userId,
+          ...(email ? { email } : {}),
+        },
+        identity?.signupDate ? { signup_date: identity.signupDate } : undefined,
+      );
       posthog.register({ ...baseSuperProps(), auth_status: "authenticated" });
     } catch {
       // Analytics unavailable


### PR DESCRIPTION
## Problem

PostHog identifies the **device** (`install_id`), not the **user**, so events can't be joined to Supabase and one human across devices/reinstalls counts as multiple people. Verified against the live DB: signed-in users' PostHog `distinct_id`s do **not** match their `auth.users.id` (e.g. `juanframartzz@gmail.com` → PostHog `13aa0e33…` vs Supabase `73c26eb8…`).

### Root cause
1. `analytics.init()` calls `posthog.identify(install_id)` on every launch → locks `distinct_id` to the device.
2. The sign-in path called `analytics.alias(userId)` → `posthog.identify(userId)`, but PostHog **silently ignores** re-identifying an already-identified person, so the Supabase id never landed anywhere queryable. Only `email` got `$set`, which masked the gap.

## Fix

Keep `install_id` as the `distinct_id` — the website `/welcome` UTM bridge and the sequential onboarding funnel both depend on it — and attach the Supabase identity as **person properties** at sign-in. Every authenticated person now carries a reliable, queryable join key to Supabase, with pre-login attribution untouched.

- `analytics.ts`: replace the misleading `alias()` with `identifyUser()`, which sets `supabase_user_id` + `email` (`$set`) and `signup_date` (`$set_once`) via `posthog.setPersonProperties`, and flips `auth_status` to `authenticated`.
- `App.tsx`: call `analytics.identifyUser(userId, { email, signupDate })` on sign-in (signup date from `session.user.created_at`).
- Removed the now-unused `alias()`, `personProps`, and related types.

### Also: activation definition
`is_activated` now flips on the user's first **`chat_message_sent`** (agreed definition: activation = the user sends a message) instead of `chat_message_received` (agent reply).

## Why person property, not re-identify

Re-pointing the `distinct_id` to the user id would require dropping the `install_id` identify in `init()`, which would strand the website's UTM attribution (the `/welcome` bridge merges the anonymous website person into `install_id`). The person-property approach achieves a reliable Supabase join without that risk.

> **Analysis note:** join user-level metrics on `supabase_user_id`, not `distinct_id`, so a user on two devices (two `install_id`s, one `supabase_user_id`) dedupes correctly.

## Scope / follow-ups (not in this PR)
- Enrich the person with `signup_country` (from the geo-ip work) and `profile_complete` — needs the profiles row at sign-in.
- Reliable internal/test-user exclusion (`is_internal`) — needs the team email list.
- Optional: native cross-device person merge (would require a coordinated website + identify change).
- Event dedup/definitions (`app_error_shown` vs `error_shown`, `session_*`, `app_active`/`app_launched`/`user_returned`).

## Test plan
- [ ] `pnpm`/`bun` typecheck + lint pass.
- [ ] Local with empty `POSTHOG_KEY` → no-ops, no throws.
- [ ] Staging: fresh install → onboarding → sign in → PostHog person shows `supabase_user_id` = the Supabase `auth.users.id`, `email`, `signup_date`, `auth_status = authenticated`; pre-login funnel still connects.
- [ ] Sign out → `reset()` to anonymous.
- [ ] Spot-check 10 recent signed-in emails: PostHog `supabase_user_id` matches Supabase `id`.

Full context: `posthog-identity-unification.md` / `product-metrics-definitions.md` (product specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)