### PR TITLE
fix(chat): show only the square in the stop button (no spinner)

### DIFF
--- a/ui/chat/src/ai-elements/prompt-input.tsx
+++ b/ui/chat/src/ai-elements/prompt-input.tsx
@@ -35,7 +35,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@houston-ai/core";
-import { Spinner } from "@houston-ai/core";
 import {
   Tooltip,
   TooltipContent,
@@ -1273,16 +1272,11 @@ export const PromptInputSubmit = ({
   let Icon = <ArrowUpIcon className="size-4" />;
 
   if (isGenerating) {
-    // Stop square + activity ring: the spinner keeps signalling that the
-    // agent is working while the square makes the stop affordance
-    // explicit the whole time (issue #469 — a bare spinner didn't read
-    // as stoppable, and a bare square didn't read as "working").
-    Icon = (
-      <span className="relative flex items-center justify-center">
-        <Spinner className="size-[26px]" />
-        <SquareIcon className="absolute size-2.5 fill-current" />
-      </span>
-    );
+    // Stop square: a solid square is the whole stop affordance while the
+    // agent is working. (It was previously paired with a spinner ring per
+    // issue #469; the ring was dropped — the square alone reads as
+    // stoppable.)
+    Icon = <SquareIcon className="size-3.5 fill-current" />;
   } else if (status === "error") {
     Icon = <XIcon className="size-4" />;
   }


### PR DESCRIPTION
## What

The chat stop button (shown while the agent is streaming/submitting) rendered an animated `Spinner` ring with a small `SquareIcon` overlaid in the center. This removes the spinner ring and shows **only the square**.

## Why

Requested: only the static square should signal the stop affordance, no animated loading spinner.

## Changes

- `ui/chat/src/ai-elements/prompt-input.tsx` — `PromptInputSubmit` generating state now renders a bare `<SquareIcon className="size-3.5 fill-current" />` instead of the `Spinner` + overlaid square.
- Resized the square from `size-2.5` → `size-3.5`. The old size was tuned to sit inside the 26px spinner ring; standalone it would look too small in the 36px button, so it's bumped to a proper standalone icon size (matches the routines stop-square precedent).
- Removed the now-unused `Spinner` import.

Reverts the visual half of issue #469 (the spinner ring); the square-as-stop affordance and all click/`onStop` behavior are unchanged.

## Test

- `pnpm typecheck` — green across the workspace (incl. `ui/chat`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)