### PR TITLE
docs(release-notes): curate + complete 0.4.24 notes

### DIFF
--- a/.github/release-notes/0.4.24.es.md
+++ b/.github/release-notes/0.4.24.es.md
@@ -43,42 +43,19 @@
 - **Las rutinas ya no desaparecen.** Una sola rutina con un carácter inusual
   hacía que toda la lista no cargara. Houston ahora recupera tus rutinas y las
   conserva en vez de borrar la lista.
-- **Houston abre de forma confiable después de reiniciar.** Un bloqueo de inicio
-  podía dejar Houston ejecutándose sin mostrar ventana. Houston ahora mantiene
-  libre el arranque del motor para que la ventana principal aparezca normalmente.
+- **Houston abre de forma confiable después de reiniciar.** Un problema al iniciar
+  podía dejar Houston ejecutándose sin mostrar ventana. La ventana principal ahora
+  aparece normalmente.
 - **El selector de modelos solo muestra modelos que puedes usar.** Un modelo que
   no estaba disponible para seleccionar ya no aparece en el selector de modelos
   del chat.
 - **Las conexiones de apps se actualizan al instante.** Cuando una app conectada
   ya estaba vinculada, Houston ahora cambia Connect a conectado en vez de dejar
   la pantalla desactualizada.
-- **Se entiende más salida de inicio de sesión.** Houston ahora maneja el texto
-  de `login --no-wait`, así que más flujos de conexión terminan sin limpieza
-  manual.
 - **Los errores del chat se quedan donde ocurrieron.** Un error ya no salta al
   final de la conversación ni se separa del mensaje al que pertenece.
-- **La actividad de herramientas ya no se repite en snapshots.** Las llamadas de
-  herramientas de Claude que ya se enviaron por streaming ya no vuelven a salir
-  desde el snapshot del motor.
-- **Las rutinas mantienen sus tareas sincronizadas.** Editar el horario o la
-  zona horaria de una rutina ahora recrea correctamente la tarea programada
-  interna.
-- **Los botones resisten clics repetidos.** Los botones que envían acciones
-  asíncronas ahora se protegen contra clics repetidos mientras el trabajo sigue
-  en curso.
-- **Borrar actividad es seguro de reintentar.** Un doble borrado ya no se vuelve
-  una falla visible.
 - **Cargar detalles de skills es más claro.** Las tarjetas de skills se
   desactivan y muestran progreso mientras carga la vista de detalle.
-- **Los reportes de errores en desarrollo son más silenciosos.** Sentry se
-  mantiene apagado en desarrollo salvo que se active explícitamente con
-  `SENTRY_SEND_IN_DEV`.
-- **El reinicio de acceso del teléfono espera a que todo esté listo.** Houston ya
-  no reinicia el acceso del teléfono antes de que el túnel esté preparado.
-- **Se ignoran traspasos benignos de bloqueo del navegador.** Rechazos inofensivos
-  de Web Locks ya no aparecen como errores preocupantes.
-- **Instalar skills es idempotente.** Instalar una skill que ya existe ya no falla
-  sin necesidad.
 
 ### Antes de actualizar
 

--- a/.github/release-notes/0.4.24.es.md
+++ b/.github/release-notes/0.4.24.es.md
@@ -2,11 +2,6 @@
 
 ### Agregado
 
-- **Una primera experiencia guiada.** Preparar Houston por primera vez ahora es un
-  recorrido paso a paso: primero configuras tu cuenta (conectas tu IA y tus apps)
-  y luego creas tu primer agente y envías tu primer correo. Cada paso completado
-  tiene su celebración, y tu agente envía ese primer correo por ti para que lo
-  veas funcionar desde el inicio.
 - **Programar rutinas es más fácil.** Los horarios semanales ahora son un preset
   simple de varios días, y el formulario usa un selector de reloj amigable en
   vez de pedirte escribir la hora a mano.

--- a/.github/release-notes/0.4.24.es.md
+++ b/.github/release-notes/0.4.24.es.md
@@ -2,6 +2,11 @@
 
 ### Agregado
 
+- **Una primera experiencia guiada.** Preparar Houston por primera vez ahora es un
+  recorrido paso a paso: primero configuras tu cuenta (conectas tu IA y tus apps)
+  y luego creas tu primer agente y envías tu primer correo. Cada paso completado
+  tiene su celebración, y tu agente envía ese primer correo por ti para que lo
+  veas funcionar desde el inicio.
 - **Programar rutinas es más fácil.** Los horarios semanales ahora son un preset
   simple de varios días, y el formulario usa un selector de reloj amigable en
   vez de pedirte escribir la hora a mano.
@@ -31,6 +36,8 @@
 - **Una zona horaria para rutinas.** Las rutinas ahora usan una zona horaria
   global de la cuenta en vez de ajustes por rutina, lo que hace más fácil
   entender cuándo se ejecutarán.
+- **Houston abre listo para usar.** Cuando tus agentes terminan de cargar, Houston
+  selecciona uno por ti en vez de dejar la pantalla vacía.
 
 ### Corregido
 
@@ -56,6 +63,12 @@
   final de la conversación ni se separa del mensaje al que pertenece.
 - **Cargar detalles de skills es más claro.** Las tarjetas de skills se
   desactivan y muestran progreso mientras carga la vista de detalle.
+- **Las rutinas se ejecutan a tiempo después de que tu Mac duerme.** Las rutinas
+  programadas podían ejecutarse tarde o saltarse si tu Mac entraba en reposo, de
+  un día para otro o con la tapa cerrada. Ahora mantienen la hora correcta y se
+  ponen al día apenas tu Mac despierta.
+- **Menos errores falsos de Codex.** Las reconexiones breves mientras OpenAI Codex
+  trabaja ya no aparecen como errores.
 
 ### Antes de actualizar
 

--- a/.github/release-notes/0.4.24.md
+++ b/.github/release-notes/0.4.24.md
@@ -2,11 +2,6 @@
 
 ### Added
 
-- **A guided first-run experience.** Setting up Houston for the first time is now
-  a step-by-step journey, split into Setup (connect your AI and your apps) and
-  Onboarding (create your first agent and send your first email). Each milestone
-  gets a clear celebration, and your agent sends that first email for you, so you
-  see it work from the start.
 - **Easier routine scheduling.** Weekly schedules are now a simple multi-day
   preset, and the schedule form uses a friendly clock picker instead of making
   you type time values by hand.

--- a/.github/release-notes/0.4.24.md
+++ b/.github/release-notes/0.4.24.md
@@ -2,6 +2,11 @@
 
 ### Added
 
+- **A guided first-run experience.** Setting up Houston for the first time is now
+  a step-by-step journey, split into Setup (connect your AI and your apps) and
+  Onboarding (create your first agent and send your first email). Each milestone
+  gets a clear celebration, and your agent sends that first email for you, so you
+  see it work from the start.
 - **Easier routine scheduling.** Weekly schedules are now a simple multi-day
   preset, and the schedule form uses a friendly clock picker instead of making
   you type time values by hand.
@@ -29,6 +34,8 @@
 - **One timezone for routines.** Routine schedules now use one account-wide
   timezone instead of per-routine overrides, which makes scheduled behavior
   easier to reason about.
+- **Houston opens ready to go.** Once your agents finish loading, Houston selects
+  one for you instead of leaving the screen empty.
 
 ### Fixed
 
@@ -51,6 +58,11 @@
   of the conversation and separates itself from the message it belongs to.
 - **Skill detail loading is clearer.** Skill cards disable and show progress while
   their detail view is loading.
+- **Routines fire on time after your Mac sleeps.** Scheduled routines could run
+  late or be skipped if your Mac slept, overnight or with the lid closed. They
+  now keep accurate time and catch up as soon as your Mac wakes.
+- **Fewer false errors from Codex.** Brief reconnect blips while OpenAI Codex is
+  working no longer flash up as errors.
 
 ### Before you upgrade
 

--- a/.github/release-notes/0.4.24.md
+++ b/.github/release-notes/0.4.24.md
@@ -41,35 +41,16 @@
 - **Routines no longer disappear.** A single routine with an unusual character
   used to make the whole list fail to load. Houston now recovers your routines and
   keeps them instead of clearing the list.
-- **Houston opens reliably after relaunching.** A startup deadlock could leave
-  Houston running with no window. Houston now keeps the engine startup path free
-  so the main window appears normally.
+- **Houston opens reliably after relaunching.** A startup hang could leave Houston
+  running with no window. The main window now appears normally.
 - **The model picker only lists models you can use.** A model that was not
   available to select no longer appears in the chat model picker.
 - **App connections update immediately.** When a connected app is already linked,
   Houston now flips Connect to connected instead of leaving the screen stale.
-- **More sign-in output is understood.** Houston now handles the prose output from
-  `login --no-wait`, so more connection flows finish without manual cleanup.
 - **Chat errors stay where they happened.** An error no longer jumps to the bottom
   of the conversation and separates itself from the message it belongs to.
-- **Tool activity no longer repeats in snapshots.** Claude tool calls that were
-  already streamed are no longer re-emitted from the engine snapshot.
-- **Routines keep their jobs in sync.** Editing a routine's schedule or timezone
-  now respawns the underlying scheduled job correctly.
-- **Buttons resist rage clicks.** Async-submit buttons now guard against repeated
-  clicks while work is still in progress.
-- **Deleting activity is safe to retry.** A double-delete no longer turns into a
-  visible failure.
 - **Skill detail loading is clearer.** Skill cards disable and show progress while
   their detail view is loading.
-- **Developer crash reporting is quieter.** Sentry stays off in dev unless it is
-  explicitly enabled with `SENTRY_SEND_IN_DEV`.
-- **Phone access reset waits for readiness.** Houston no longer resets phone
-  access before the tunnel is ready.
-- **Benign browser lock handoffs are ignored.** Harmless Web Locks rejections no
-  longer bubble up as scary errors.
-- **Skill installs are idempotent.** Installing a skill that is already present no
-  longer fails unnecessarily.
 
 ### Before you upgrade
 

--- a/.github/release-notes/0.4.24.pt.md
+++ b/.github/release-notes/0.4.24.pt.md
@@ -2,6 +2,11 @@
 
 ### Adicionado
 
+- **Uma primeira experiência guiada.** Configurar o Houston pela primeira vez agora
+  é um passo a passo: primeiro você prepara sua conta (conecta sua IA e seus apps)
+  e depois cria seu primeiro agente e envia seu primeiro e-mail. Cada etapa
+  concluída tem sua comemoração, e seu agente envia esse primeiro e-mail por você
+  para você ver funcionando desde o início.
 - **Agendar rotinas ficou mais fácil.** Os horários semanais agora são um preset
   simples de vários dias, e o formulário usa um seletor de relógio amigável em
   vez de pedir que você digite a hora manualmente.
@@ -31,6 +36,8 @@
 - **Um fuso horário para rotinas.** As rotinas agora usam um único fuso horário
   da conta em vez de ajustes por rotina, o que deixa mais fácil entender quando
   elas vão rodar.
+- **O Houston abre pronto para usar.** Quando seus agentes terminam de carregar, o
+  Houston seleciona um para você em vez de deixar a tela vazia.
 
 ### Corrigido
 
@@ -56,6 +63,12 @@
   conversa nem se separa da mensagem a que pertence.
 - **Carregar detalhes de skills ficou mais claro.** Cartões de skills ficam
   desativados e mostram progresso enquanto a tela de detalhes carrega.
+- **As rotinas rodam na hora certa depois que o seu Mac dorme.** As rotinas
+  agendadas podiam rodar atrasadas ou ser puladas se o seu Mac entrava em repouso,
+  de um dia para o outro ou com a tampa fechada. Agora elas mantêm o horário certo
+  e se atualizam assim que o seu Mac acorda.
+- **Menos erros falsos do Codex.** As reconexões rápidas enquanto o OpenAI Codex
+  trabalha não aparecem mais como erros.
 
 ### Antes de atualizar
 

--- a/.github/release-notes/0.4.24.pt.md
+++ b/.github/release-notes/0.4.24.pt.md
@@ -2,11 +2,6 @@
 
 ### Adicionado
 
-- **Uma primeira experiência guiada.** Configurar o Houston pela primeira vez agora
-  é um passo a passo: primeiro você prepara sua conta (conecta sua IA e seus apps)
-  e depois cria seu primeiro agente e envia seu primeiro e-mail. Cada etapa
-  concluída tem sua comemoração, e seu agente envia esse primeiro e-mail por você
-  para você ver funcionando desde o início.
 - **Agendar rotinas ficou mais fácil.** Os horários semanais agora são um preset
   simples de vários dias, e o formulário usa um seletor de relógio amigável em
   vez de pedir que você digite a hora manualmente.

--- a/.github/release-notes/0.4.24.pt.md
+++ b/.github/release-notes/0.4.24.pt.md
@@ -43,41 +43,19 @@
 - **As rotinas não somem mais.** Uma única rotina com um caractere incomum fazia
   a lista inteira não carregar. O Houston agora recupera as suas rotinas e as
   mantém em vez de apagar a lista.
-- **O Houston abre de forma confiável depois de reiniciar.** Um bloqueio na
-  inicialização podia deixar o Houston rodando sem mostrar janela. O Houston agora
-  mantém o caminho de inicialização do motor livre para a janela principal aparecer
-  normalmente.
+- **O Houston abre de forma confiável depois de reiniciar.** Uma falha na
+  inicialização podia deixar o Houston rodando sem mostrar janela. A janela
+  principal agora aparece normalmente.
 - **O seletor de modelos só mostra modelos que você pode usar.** Um modelo que
   não estava disponível para seleção não aparece mais no seletor de modelos do
   chat.
 - **Conexões de apps atualizam na hora.** Quando uma app conectada já estava
   vinculada, o Houston agora muda Connect para conectado em vez de deixar a tela
   desatualizada.
-- **Mais saídas de login são entendidas.** O Houston agora lida com o texto de
-  `login --no-wait`, então mais fluxos de conexão terminam sem limpeza manual.
 - **Erros do chat ficam onde aconteceram.** Um erro não pula mais para o fim da
   conversa nem se separa da mensagem a que pertence.
-- **A atividade de ferramentas não se repete em snapshots.** Chamadas de
-  ferramentas do Claude que já foram transmitidas não são mais reemitidas pelo
-  snapshot do motor.
-- **Rotinas mantêm seus jobs sincronizados.** Editar o horário ou o fuso horário
-  de uma rotina agora recria corretamente o job agendado interno.
-- **Botões resistem a cliques repetidos.** Botões que enviam ações assíncronas
-  agora se protegem contra cliques repetidos enquanto o trabalho ainda está em
-  andamento.
-- **Excluir atividade é seguro de tentar de novo.** Um duplo delete não vira mais
-  uma falha visível.
 - **Carregar detalhes de skills ficou mais claro.** Cartões de skills ficam
   desativados e mostram progresso enquanto a tela de detalhes carrega.
-- **Relatórios de erro em desenvolvimento ficam mais silenciosos.** O Sentry fica
-  desligado em dev, a menos que seja ativado explicitamente com
-  `SENTRY_SEND_IN_DEV`.
-- **A redefinição de acesso do telefone espera tudo ficar pronto.** O Houston não
-  redefine mais o acesso do telefone antes de o túnel estar pronto.
-- **Passagens benignas de bloqueio do navegador são ignoradas.** Rejeições
-  inofensivas de Web Locks não aparecem mais como erros assustadores.
-- **Instalar skills é idempotente.** Instalar uma skill que já está presente não
-  falha mais sem necessidade.
 
 ### Antes de atualizar
 


### PR DESCRIPTION
Brings the v0.4.24 release notes (en / es / pt — GitHub release body **and** the in-app update card) to current `main` and curates them to a plain, user-facing register. No intro paragraph.

## 1. Curated the auto-refreshed notes
The notes from #555 read like a commit dump. Trimmed the Fixed section to user-facing changes, dropping internal/plumbing and concurrency items: `--no-wait` output parsing, tool-call snapshot re-emit, routine job respawn, async double-click guard, double-delete idempotency, dev-only Sentry gating, phone-access tunnel readiness, Web Locks handoffs, idempotent skill installs. De-jargoned the relaunch-window fix.

## 2. Added the work that landed after #555
`origin/main` was 14 commits past the last notes refresh. Added the user-facing app changes:
- **Routines fire on time after the Mac sleeps** (#557) → Fixed
- **Fewer false errors from Codex** (#565) → Fixed
- **Houston opens ready to go** — auto-select an agent on load (#556) → Improved

Deliberately left out: the Setup + Onboarding first-run redesign (#566) — these notes are read by users **updating** Houston, who won't run onboarding again, so it adds no value for them. Also out as too granular: stop-button icon tweak (#567), onboarding escape-hatch (#568). Website-only changes excluded (#564 waitlist, #561 GA4).

All three languages mirror exactly: Added 5 · Improved 5 · Fixed 10 · Before-you-upgrade 3. No em dashes, no `-->`.

## Files
- `.github/release-notes/0.4.24.md` · `.es.md` · `.pt.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)