### PR TITLE
fix(supabase): stop anon from reading profiles.email

### DIFF
--- a/supabase/migrations/20260628000000_profiles_anon_column_scope.sql
+++ b/supabase/migrations/20260628000000_profiles_anon_column_scope.sql
@@ -1,0 +1,32 @@
+-- Harden public.profiles against email exposure to the anonymous web role.
+--
+-- Problem: `anon` holds a blanket table-level SELECT on public.profiles, and
+-- the "read public profile by handle" RLS policy (USING handle IS NOT NULL)
+-- makes any handled profile row visible to everyone. RLS gates ROWS, not
+-- COLUMNS, so the moment a profile sets a handle, its `email` (and other
+-- non-public fields) become readable by anyone holding the public anon key.
+-- Today 0 of ~900 profiles have a handle, so nothing is exposed yet; this is a
+-- latent leak that opens the day public handles ship.
+--
+-- Fix: replace anon's blanket SELECT with a column-scoped SELECT limited to
+-- public-safe display fields. Row visibility (own profile / public-by-handle)
+-- is unchanged; anon simply can no longer read email, last_seen_at, or socials.
+-- `authenticated` keeps full SELECT, so a signed-in user still reads their own
+-- email via the "read own profile" policy. service_role is untouched.
+
+revoke select on public.profiles from anon;
+
+grant select (
+  user_id,
+  handle,
+  name,
+  avatar_url,
+  cover_url,
+  bio,
+  created_at
+) on public.profiles to anon;
+
+-- Verify after applying:
+--   select has_column_privilege('anon','public.profiles','email','SELECT')  as anon_email;   -- expect false
+--   select has_column_privilege('anon','public.profiles','handle','SELECT') as anon_handle;  -- expect true
+--   select has_column_privilege('authenticated','public.profiles','email','SELECT') as auth_email; -- expect true


### PR DESCRIPTION
## Security finding

`anon` (the public web role, whose key ships in the client) holds a **blanket table-level SELECT** on `public.profiles`. The `profiles` SELECT policies are:
- `read own profile` — `auth.uid() = user_id`
- **`read public profile by handle` — `handle IS NOT NULL`** (visible to everyone)

RLS gates **rows, not columns**. So any profile that sets a `handle` becomes fully readable by anyone holding the public anon key, **including its `email`** (and `last_seen_at`, `socials`).

**Exposure today: 0** — none of the ~900 profiles have a handle set yet. This is a **latent** leak that opens the moment public handles ship.

## Fix

Replace anon's blanket SELECT with a **column-scoped** grant limited to public-safe display fields:

```sql
revoke select on public.profiles from anon;
grant select (user_id, handle, name, avatar_url, cover_url, bio, created_at)
  on public.profiles to anon;
```

- Row visibility is unchanged (own-profile / public-by-handle still work).
- `anon` can no longer read `email`, `last_seen_at`, or `socials`.
- `authenticated` keeps full SELECT, so a signed-in user still reads their own email.
- `service_role` untouched.

## Before merging / applying
- [ ] **Not yet applied to `houston-prod`** — this touches production auth/data; apply deliberately after review (and confirm with the team).
- [ ] Confirm no anon-context client query requests `email`/`socials`/`last_seen_at` from `profiles` (the app reads its own profile as `authenticated`, which is unaffected). If a future public-profile page needs `socials`, add it to the grant list explicitly.
- [ ] After applying, verify:
  ```sql
  select has_column_privilege('anon','public.profiles','email','SELECT')  as anon_email;   -- expect false
  select has_column_privilege('anon','public.profiles','handle','SELECT') as anon_handle;  -- expect true
  select has_column_privilege('authenticated','public.profiles','email','SELECT') as auth_email; -- expect true
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
