### PR TITLE
feat(website): optimize early-access pages for mobile

### DIFF
--- a/website/src/_includes/early-access/app.njk
+++ b/website/src/_includes/early-access/app.njk
@@ -66,27 +66,15 @@
     else { asPrimary(macBtn); asAlt(winBtn); }
   })();
 
-  // Gate: the download unlocks only once the question is answered AND the pledge taken.
-  var pledge = document.getElementById('pledge');
-  var pledged = false;
+  // Gate: the download unlocks once the question is answered.
   function answered() { return answer.value.trim().length >= 2; }
   function update() {
-    var ok = answered() && pledged;
+    var ok = answered();
     group.classList.toggle('locked', !ok);
     saved.classList.toggle('show', ok);
-    if (ok) {
-      lockNote.style.display = 'none';
-    } else {
-      lockNote.style.display = 'block';
-      lockNote.textContent = !answered() ? '{{ eaLockAnswer }}' : '{{ eaLockPledge }}';
-    }
+    lockNote.style.display = ok ? 'none' : 'block';
   }
   answer.addEventListener('input', update);
-  pledge.addEventListener('click', function () {
-    pledged = !pledged;
-    pledge.classList.toggle('checked', pledged);
-    update();
-  });
   update();
 
   var submitted = false;
@@ -94,7 +82,8 @@
     if (group.classList.contains('locked')) return;
     if (!submitted) {
       submitted = true;
-      rpc('submit_early_access', { p_token: token, p_answer: answer.value.trim().slice(0, 2000), p_pledged: pledged });
+      // Pledge UI removed; anyone who answers + downloads is recorded as an early adopter.
+      rpc('submit_early_access', { p_token: token, p_answer: answer.value.trim().slice(0, 2000), p_pledged: true });
     }
     rpc('mark_download', { p_token: token, p_os: os });
     if (url) window.location.href = url;

--- a/website/src/_includes/early-access/styles.njk
+++ b/website/src/_includes/early-access/styles.njk
@@ -69,25 +69,24 @@
   .saved { display:none; align-items:center; justify-content:center; gap:7px; font-size:13.5px; color:var(--success); font-weight:600; margin:18px 0 2px; text-align:center; }
   .saved.show { display:flex; }
 
-  /* Pledge, the early adopter commitment */
-  .pledge { display:flex; gap:13px; align-items:flex-start; margin:18px 0 0; padding:16px 18px; border:1px solid var(--border); border-radius:14px; background:var(--gray-50); cursor:pointer; transition:border-color .15s, background .15s, box-shadow .15s; }
-  .pledge:hover { border-color:var(--gray-300); }
-  .pledge.checked { border-color:var(--gray-950); background:#fff; box-shadow:0 0 0 3px rgba(13,13,13,0.05); }
-  .pledge .box { flex:0 0 22px; width:22px; height:22px; border-radius:7px; border:1.5px solid var(--gray-300); background:#fff; display:inline-flex; align-items:center; justify-content:center; margin-top:1px; transition:all .15s; }
-  .pledge.checked .box { background:var(--gray-950); border-color:var(--gray-950); }
-  .pledge .box svg { width:13px; height:13px; color:#fff; opacity:0; transition:opacity .15s; }
-  .pledge.checked .box svg { opacity:1; }
-  .pledge .ptxt { font-size:14.5px; line-height:1.5; color:var(--gray-700); }
-  .pledge .ptxt b { color:var(--gray-950); font-weight:600; }
-
   footer { max-width:600px; margin:48px auto 0; padding:24px; text-align:center; border-top:1px solid var(--border); }
   footer .fl { font-size:13px; color:var(--gray-500); margin-bottom:10px; }
   footer .links a { font-size:13px; color:var(--gray-600); text-decoration:none; margin:0 8px; }
   footer .links a:hover { color:var(--gray-950); }
 
   @media (max-width:600px) {
-    .wrap { padding:108px 18px 48px; }
-    h1 { font-size:40px; }
-    nav { padding:14px 20px; }
+    nav { padding:12px 18px; }
+    .wrap { padding:78px 18px 24px; }
+    .eyebrow { margin-bottom:12px; padding:6px 13px; font-size:11.5px; }
+    h1 { font-size:33px; margin-bottom:9px; }
+    .lede { font-size:15px; line-height:1.45; margin-bottom:16px; }
+    .card { padding:20px 18px; }
+    .card .step { margin-bottom:7px; }
+    .card h2 { font-size:20px; }
+    .card .hint { margin-bottom:11px; }
+    textarea { min-height:84px; }
+    .dl-actions { margin-top:18px; }
+    .lock-note { margin-top:11px; }
+    footer { margin-top:22px; padding:16px; }
   }
 </style>

--- a/website/src/early-access/es/index.html
+++ b/website/src/early-access/es/index.html
@@ -1,9 +1,7 @@
 {% extends "base.njk" %}
-{% set eaLockAnswer = "Responde la pregunta de arriba para continuar." %}
-{% set eaLockPledge = "Asume el compromiso para desbloquear tu descarga." %}
 {% block title %}Sáltate la fila | Houston{% endblock %}
 {% block meta %}
-<meta name="description" content="Acceso anticipado a Houston: responde una pregunta, asume el compromiso y descarga la app hoy.">
+<meta name="description" content="Acceso anticipado a Houston: responde una pregunta y descarga la app hoy.">
 {% endblock %}
 {% block headScripts %}{% include "early-access/scrub.njk" %}{% endblock %}
 {% block inlineStyles %}{% include "early-access/styles.njk" %}{% endblock %}
@@ -18,19 +16,14 @@
 <div class="wrap">
   <span class="eyebrow"><span class="dot"></span> Uno de los primeros 1,000</span>
   <h1>Sáltate la <span class="grad">fila.</span></h1>
-  <p class="lede">Eres una de las primeras 1,000 personas en usar Houston, y eso te hace un constructor, no solo un usuario. Tu feedback moldea de verdad lo que creamos. Responde una pregunta, asume el compromiso y la app es tuya.</p>
+  <p class="lede">Eres una de las primeras 1,000 personas en usar Houston, y eso te hace un constructor, no solo un usuario. Responde una pregunta y descarga la app.</p>
 
   <div class="comet-card">
     <div class="card">
       <p class="step">UNA PREGUNTA Y ES TUYA</p>
-      <h2>¿Qué tarea haces una y otra vez que te encantaría pasarle a Houston?</h2>
-      <p class="hint">Eres una de las primeras 1,000 personas, así que tu respuesta pesa de verdad: moldea lo que construimos a continuación y cómo llegas a tu primer logro. Con una tarea real basta.</p>
+      <h2>¿Qué tarea repetitiva te gustaría automatizar con IA?</h2>
+      <p class="hint">Cuanto más específico, mejor: la tarea, las herramientas que usas y cada cuánto la haces.</p>
       <textarea id="answer" placeholder="ej. Cada lunes concilio las facturas de la semana con el estado de cuenta del banco…"></textarea>
-
-      <div class="pledge" id="pledge">
-        <span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span>
-        <span class="ptxt"><b>Me sumo como uno de los primeros 1,000.</b> Compartiré feedback honesto e ideas para ayudar a moldear Houston a medida que crece.</span>
-      </div>
 
       <div class="saved" id="saved">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
@@ -45,7 +38,7 @@
           <svg viewBox="0 0 448 512" fill="currentColor" width="16" height="16"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg> Descargar para Windows
         </button>
       </div>
-      <p class="lock-note" id="lockNote">Responde la pregunta y asume el compromiso para desbloquear tu descarga.</p>
+      <p class="lock-note" id="lockNote">Responde la pregunta para desbloquear tu descarga.</p>
     </div>
   </div>
 </div>

--- a/website/src/early-access/index.html
+++ b/website/src/early-access/index.html
@@ -1,9 +1,7 @@
 {% extends "base.njk" %}
-{% set eaLockAnswer = "Answer the question above to continue." %}
-{% set eaLockPledge = "Take the pledge to unlock your download." %}
 {% block title %}Skip the line | Houston{% endblock %}
 {% block meta %}
-<meta name="description" content="Houston early access: answer one question, take the pledge, and download the app today.">
+<meta name="description" content="Houston early access: answer one question and download the app today.">
 {% endblock %}
 {% block headScripts %}{% include "early-access/scrub.njk" %}{% endblock %}
 {% block inlineStyles %}{% include "early-access/styles.njk" %}{% endblock %}
@@ -18,19 +16,14 @@
 <div class="wrap">
   <span class="eyebrow"><span class="dot"></span> One of the first 1,000</span>
   <h1>Skip the <span class="grad">line.</span></h1>
-  <p class="lede">You're one of the first 1,000 people to ever use Houston, which makes you a builder, not just a user. Your feedback genuinely shapes what we make. Answer one question, take the pledge, and the app is yours.</p>
+  <p class="lede">You're one of the first 1,000 people to ever use Houston, which makes you a builder, not just a user. Answer one question, download the app.</p>
 
   <div class="comet-card">
     <div class="card">
       <p class="step">ONE QUESTION, THEN IT'S YOURS</p>
-      <h2>What's a task you do over and over that you'd love to just hand to Houston?</h2>
-      <p class="hint">You're one of the first 1,000, so your answer carries real weight, it shapes what we build next and how we get you to your first win. One real task is plenty.</p>
+      <h2>What's a repetitive task you'd like to automate with AI?</h2>
+      <p class="hint">The more specific the better: the task, the tools you use, and how often you do it.</p>
       <textarea id="answer" placeholder="e.g. Every Monday I reconcile last week's invoices against the bank statement…"></textarea>
-
-      <div class="pledge" id="pledge">
-        <span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span>
-        <span class="ptxt"><b>I'm in as one of the first 1,000.</b> I'll share honest feedback and ideas to help shape Houston as it grows.</span>
-      </div>
 
       <div class="saved" id="saved">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
@@ -45,7 +38,7 @@
           <svg viewBox="0 0 448 512" fill="currentColor" width="16" height="16"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg> Download for Windows
         </button>
       </div>
-      <p class="lock-note" id="lockNote">Answer the question and take the pledge to unlock your download.</p>
+      <p class="lock-note" id="lockNote">Answer the question to unlock your download.</p>
     </div>
   </div>
 </div>

--- a/website/src/early-access/pt/index.html
+++ b/website/src/early-access/pt/index.html
@@ -1,9 +1,7 @@
 {% extends "base.njk" %}
-{% set eaLockAnswer = "Responda a pergunta acima para continuar." %}
-{% set eaLockPledge = "Assuma o compromisso para liberar seu download." %}
 {% block title %}Fure a fila | Houston{% endblock %}
 {% block meta %}
-<meta name="description" content="Acesso antecipado à Houston: responda uma pergunta, assuma o compromisso e baixe o app hoje.">
+<meta name="description" content="Acesso antecipado à Houston: responda uma pergunta e baixe o app hoje.">
 {% endblock %}
 {% block headScripts %}{% include "early-access/scrub.njk" %}{% endblock %}
 {% block inlineStyles %}{% include "early-access/styles.njk" %}{% endblock %}
@@ -18,19 +16,14 @@
 <div class="wrap">
   <span class="eyebrow"><span class="dot"></span> Um dos primeiros 1,000</span>
   <h1>Fure a <span class="grad">fila.</span></h1>
-  <p class="lede">Você é uma das primeiras 1,000 pessoas a usar a Houston, e isso faz de você um construtor, não só um usuário. Seu feedback molda de verdade o que criamos. Responda uma pergunta, assuma o compromisso e o app é seu.</p>
+  <p class="lede">Você é uma das primeiras 1,000 pessoas a usar a Houston, e isso faz de você um construtor, não só um usuário. Responda uma pergunta e baixe o app.</p>
 
   <div class="comet-card">
     <div class="card">
       <p class="step">UMA PERGUNTA E ELE É SEU</p>
-      <h2>Qual tarefa você faz repetidas vezes que adoraria passar para a Houston?</h2>
-      <p class="hint">Você é uma das primeiras 1,000 pessoas, então sua resposta tem peso de verdade: ela molda o que construímos a seguir e como você chega à sua primeira vitória. Uma tarefa real já basta.</p>
+      <h2>Qual tarefa repetitiva você gostaria de automatizar com IA?</h2>
+      <p class="hint">Quanto mais específico, melhor: a tarefa, as ferramentas que você usa e com que frequência.</p>
       <textarea id="answer" placeholder="ex. Toda segunda eu concilio as notas fiscais da semana com o extrato bancário…"></textarea>
-
-      <div class="pledge" id="pledge">
-        <span class="box"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg></span>
-        <span class="ptxt"><b>Estou dentro, como um dos primeiros 1,000.</b> Vou compartilhar feedback honesto e ideias para ajudar a moldar a Houston conforme ela cresce.</span>
-      </div>
 
       <div class="saved" id="saved">
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>
@@ -45,7 +38,7 @@
           <svg viewBox="0 0 448 512" fill="currentColor" width="16" height="16"><path d="M0 93.7l183.6-25.3v177.4H0V93.7zm0 324.6l183.6 25.3V268.4H0v149.9zm203.8 28L448 480V268.4H203.8v177.9zm0-380.6v180.1H448V32L203.8 65.7z"/></svg> Baixar para Windows
         </button>
       </div>
-      <p class="lock-note" id="lockNote">Responda a pergunta e assuma o compromisso para liberar seu download.</p>
+      <p class="lock-note" id="lockNote">Responda a pergunta para liberar seu download.</p>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## What

Tightens the three early-access landing pages so the whole flow fits **one mobile screen, no scrolling** (verified down to iPhone SE 375x667), and simplifies the copy. Applied across en / es / pt.

- **Shorter lede.**
- **Simplified question:** "What's a repetitive task you'd like to automate with AI?" (localized).
- **More descriptive hint** that prompts specificity (task + tools + frequency).
- **Removed the pledge + checkbox.** The download now unlocks on the **answer alone** — cleaner, and frees room for a larger answer box. Dead `.pledge` CSS and the pledge JS branch are removed; the lock-note is now a single state.
- **Tighter mobile spacing** (top gap, headline, card padding, taller textarea) in the `@media (max-width:600px)` block of `styles.njk`.

Files: `website/src/_includes/early-access/{styles,app}.njk` and `website/src/early-access/{,es,pt}/index.html`.

## Notes
- Data: with the pledge gone, `submit_early_access` now sends `p_pledged: true` for anyone who answers + downloads (treated as an engaged early adopter).
- Verified with a local Eleventy build: all three routes render and fit one mobile screen; no em dashes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
