### PR TITLE
feat(website): simplify early-access hero (remove pill, raise title)

### DIFF
--- a/website/src/_includes/early-access/styles.njk
+++ b/website/src/_includes/early-access/styles.njk
@@ -46,10 +46,7 @@
       radial-gradient(ellipse 60% 40% at 85% 25%, rgba(249,115,22,0.07), transparent),
       radial-gradient(ellipse 60% 40% at 15% 75%, rgba(129,140,248,0.06), transparent); }
 
-  .wrap { max-width:600px; margin:0 auto; padding:128px 24px 64px; text-align:center; }
-
-  .eyebrow { display:inline-flex; align-items:center; gap:9px; font-size:12.5px; font-weight:600; letter-spacing:.05em; text-transform:uppercase; color:var(--gray-950); background:#fff; border:1px solid var(--gray-200); border-radius:9999px; padding:8px 16px; margin-bottom:22px; box-shadow:0 1px 2px rgba(0,0,0,0.04); }
-  .eyebrow .dot { width:8px; height:8px; border-radius:50%; background:linear-gradient(90deg,#3b82f6,#f97316); box-shadow:0 0 0 3px rgba(59,130,246,0.12); }
+  .wrap { max-width:600px; margin:0 auto; padding:96px 24px 56px; text-align:center; }
 
   h1 { font-family:'General Sans',sans-serif; font-size:54px; font-weight:600; letter-spacing:-0.03em; line-height:1.04; color:var(--gray-950); margin-bottom:18px; }
   h1 .grad { background:linear-gradient(90deg,#3b82f6,#818cf8 40%,#f97316 85%); -webkit-background-clip:text; background-clip:text; color:transparent; }
@@ -76,8 +73,7 @@
 
   @media (max-width:600px) {
     nav { padding:12px 18px; }
-    .wrap { padding:78px 18px 24px; }
-    .eyebrow { margin-bottom:12px; padding:6px 13px; font-size:11.5px; }
+    .wrap { padding:58px 18px 24px; }
     h1 { font-size:33px; margin-bottom:9px; }
     .lede { font-size:15px; line-height:1.45; margin-bottom:16px; }
     .card { padding:20px 18px; }

--- a/website/src/early-access/es/index.html
+++ b/website/src/early-access/es/index.html
@@ -14,7 +14,6 @@
 </nav>
 
 <div class="wrap">
-  <span class="eyebrow"><span class="dot"></span> Uno de los primeros 1,000</span>
   <h1>Sáltate la <span class="grad">fila.</span></h1>
   <p class="lede">Eres una de las primeras 1,000 personas en usar Houston, y eso te hace un constructor, no solo un usuario. Responde una pregunta y descarga la app.</p>
 

--- a/website/src/early-access/index.html
+++ b/website/src/early-access/index.html
@@ -14,7 +14,6 @@
 </nav>
 
 <div class="wrap">
-  <span class="eyebrow"><span class="dot"></span> One of the first 1,000</span>
   <h1>Skip the <span class="grad">line.</span></h1>
   <p class="lede">You're one of the first 1,000 people to ever use Houston, which makes you a builder, not just a user. Answer one question, download the app.</p>
 

--- a/website/src/early-access/pt/index.html
+++ b/website/src/early-access/pt/index.html
@@ -14,7 +14,6 @@
 </nav>
 
 <div class="wrap">
-  <span class="eyebrow"><span class="dot"></span> Um dos primeiros 1,000</span>
   <h1>Fure a <span class="grad">fila.</span></h1>
   <p class="lede">Você é uma das primeiras 1,000 pessoas a usar a Houston, e isso faz de você um construtor, não só um usuário. Responda uma pergunta e baixe o app.</p>
 


### PR DESCRIPTION
## What
Simplifies the early-access hero across en / es / pt:
- Removes the **"One of the first 1,000" pill** (eyebrow badge).
- Moves the **title + subtext higher** (reduced top padding: desktop 128->96, mobile 78->58).
- Drops the now-dead `.eyebrow` CSS.

Still fits one mobile screen (verified, local Eleventy build). Files: `website/src/_includes/early-access/styles.njk` + `website/src/early-access/{,es,pt}/index.html`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
