### PR TITLE
style(website): add breathing room above early-access headline

### DIFF
--- a/website/src/_includes/early-access/styles.njk
+++ b/website/src/_includes/early-access/styles.njk
@@ -46,7 +46,7 @@
       radial-gradient(ellipse 60% 40% at 85% 25%, rgba(249,115,22,0.07), transparent),
       radial-gradient(ellipse 60% 40% at 15% 75%, rgba(129,140,248,0.06), transparent); }
 
-  .wrap { max-width:600px; margin:0 auto; padding:96px 24px 56px; text-align:center; }
+  .wrap { max-width:600px; margin:0 auto; padding:124px 24px 56px; text-align:center; }
 
   h1 { font-family:'General Sans',sans-serif; font-size:54px; font-weight:600; letter-spacing:-0.03em; line-height:1.04; color:var(--gray-950); margin-bottom:18px; }
   h1 .grad { background:linear-gradient(90deg,#3b82f6,#818cf8 40%,#f97316 85%); -webkit-background-clip:text; background-clip:text; color:transparent; }
@@ -73,7 +73,7 @@
 
   @media (max-width:600px) {
     nav { padding:12px 18px; }
-    .wrap { padding:58px 18px 24px; }
+    .wrap { padding:78px 18px 24px; }
     h1 { font-size:33px; margin-bottom:9px; }
     .lede { font-size:15px; line-height:1.45; margin-bottom:16px; }
     .card { padding:20px 18px; }


### PR DESCRIPTION
## What

Adds a bit more vertical space between the fixed top nav and the **"Skip the line."** headline on the early-access download pages, so the title has room to breathe instead of sitting right under the header.

- `.wrap` top padding: desktop **96px → 124px**, mobile **58px → 78px**.
- Single change in the shared `early-access/styles.njk`, so it applies to all three localized pages: **EN** (`/early-access/`), **ES** (`/early-access/es/`), **PT** (`/early-access/pt/`).

## Why

The headline felt cramped against the header. Purely cosmetic spacing.

## Scope

CSS-only. No copy, logic, data, or behavior changes. No secrets or migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
