### PR TITLE
feat(app): add Claude Sonnet 5 model support (HOU-614)

### DIFF
--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -2,7 +2,7 @@
  * Reasoning-effort levels, ordered low→high. The set a given model accepts
  * is model-specific (see `ModelOption.effortLevels`):
  * - Codex `model_reasoning_effort`: low/medium/high/xhigh (no `max`).
- * - Claude `--effort`: Opus 4.7 and 4.8 = all five; Sonnet 4.6 =
+ * - Claude `--effort`: Opus 4.7/4.8 and Sonnet 5 = all five; Sonnet 4.6 =
  *   low/medium/high/max (no `xhigh`). Claude self-clamps an unsupported
  *   value; Codex does not.
  */
@@ -123,9 +123,22 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     cost: "Your Claude subscription",
     models: [
       {
+        id: "claude-sonnet-5",
+        label: "Sonnet 5",
+        description: "Latest Sonnet. Best balance of speed and quality.",
+        // Sonnet 5 accepts the full effort range, INCLUDING `xhigh` (unlike
+        // Sonnet 4.6, which has `max` but not `xhigh`). API default is `high`.
+        effortLevels: ["low", "medium", "high", "xhigh", "max"],
+        // Same window story as Sonnet 4.6: Claude Code starts at 200k on every
+        // plan and the 1M window is opt-in via usage credits, so start at 200k
+        // and snap to 1M once observed usage proves the larger window is active.
+        contextWindow: 200_000,
+        contextWindowMax: 1_000_000,
+      },
+      {
         id: "claude-sonnet-4-6",
         label: "Sonnet 4.6",
-        description: "Best balance of speed and quality.",
+        description: "Previous Sonnet. Strong balance of speed and quality.",
         // Sonnet 4.6: has `max`, no `xhigh`.
         effortLevels: ["low", "medium", "high", "max"],
         // Sonnet 4.6 in Claude Code defaults to 200k on EVERY plan; the
@@ -161,7 +174,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         contextWindow: 1_000_000,
       },
     ],
-    defaultModel: "claude-sonnet-4-6",
+    defaultModel: "claude-sonnet-5",
   },
 ] as const;
 
@@ -177,7 +190,7 @@ export function getModel(providerId: string, modelId: string): ModelOption | und
 
 /** Get the default provider + model for a provider id. */
 export function getDefaultModel(providerId: string): string {
-  return getProvider(providerId)?.defaultModel ?? "claude-sonnet-4-6";
+  return getProvider(providerId)?.defaultModel ?? "claude-sonnet-5";
 }
 
 /** Default + snap-up ceiling for a model's context window (tokens). */

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -125,7 +125,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
       {
         id: "claude-sonnet-5",
         label: "Sonnet 5",
-        description: "Latest Sonnet. Best balance of speed and quality.",
+        description: "Newest Sonnet. Stronger agentic coding and tool use.",
         // Sonnet 5 accepts the full effort range, INCLUDING `xhigh` (unlike
         // Sonnet 4.6, which has `max` but not `xhigh`). API default is `high`.
         effortLevels: ["low", "medium", "high", "xhigh", "max"],
@@ -138,7 +138,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
       {
         id: "claude-sonnet-4-6",
         label: "Sonnet 4.6",
-        description: "Previous Sonnet. Strong balance of speed and quality.",
+        description: "Best balance of speed and quality.",
         // Sonnet 4.6: has `max`, no `xhigh`.
         effortLevels: ["low", "medium", "high", "max"],
         // Sonnet 4.6 in Claude Code defaults to 200k on EVERY plan; the
@@ -174,7 +174,7 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         contextWindow: 1_000_000,
       },
     ],
-    defaultModel: "claude-sonnet-5",
+    defaultModel: "claude-sonnet-4-6",
   },
 ] as const;
 
@@ -190,7 +190,7 @@ export function getModel(providerId: string, modelId: string): ModelOption | und
 
 /** Get the default provider + model for a provider id. */
 export function getDefaultModel(providerId: string): string {
-  return getProvider(providerId)?.defaultModel ?? "claude-sonnet-5";
+  return getProvider(providerId)?.defaultModel ?? "claude-sonnet-4-6";
 }
 
 /** Default + snap-up ceiling for a model's context window (tokens). */

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -80,7 +80,8 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "OpenAI's frontier model.",
-      "claude-sonnet-4-6": "Best balance of speed and quality.",
+      "claude-sonnet-5": "Latest Sonnet. Best balance of speed and quality.",
+      "claude-sonnet-4-6": "Previous Sonnet. Strong balance of speed and quality.",
       "claude-opus-4-8": "Latest Opus. Better alignment and agentic coding than 4.7.",
       "claude-fable-5": "Most capable model. Costs 2x more credits than Opus 4.8.",
       "claude-opus-4-7": "Previous flagship. Strong coding autonomy and complex reasoning."

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -80,8 +80,8 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "OpenAI's frontier model.",
-      "claude-sonnet-5": "Latest Sonnet. Best balance of speed and quality.",
-      "claude-sonnet-4-6": "Previous Sonnet. Strong balance of speed and quality.",
+      "claude-sonnet-5": "Newest Sonnet. Stronger agentic coding and tool use.",
+      "claude-sonnet-4-6": "Best balance of speed and quality.",
       "claude-opus-4-8": "Latest Opus. Better alignment and agentic coding than 4.7.",
       "claude-fable-5": "Most capable model. Costs 2x more credits than Opus 4.8.",
       "claude-opus-4-7": "Previous flagship. Strong coding autonomy and complex reasoning."

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -80,7 +80,8 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "El modelo más avanzado de OpenAI.",
-      "claude-sonnet-4-6": "Mejor equilibrio entre velocidad y calidad.",
+      "claude-sonnet-5": "Sonnet mas reciente. Mejor equilibrio entre velocidad y calidad.",
+      "claude-sonnet-4-6": "Sonnet anterior. Buen equilibrio entre velocidad y calidad.",
       "claude-opus-4-8": "Opus mas reciente. Mejor alineamiento y codigo agente que 4.7.",
       "claude-fable-5": "El modelo mas capaz. Consume el doble de creditos que Opus 4.8.",
       "claude-opus-4-7": "Modelo anterior. Autonomia de codigo y razonamiento complejo."

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -80,8 +80,8 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "El modelo más avanzado de OpenAI.",
-      "claude-sonnet-5": "Sonnet mas reciente. Mejor equilibrio entre velocidad y calidad.",
-      "claude-sonnet-4-6": "Sonnet anterior. Buen equilibrio entre velocidad y calidad.",
+      "claude-sonnet-5": "Sonnet mas reciente. Mejor para codigo con agentes y herramientas.",
+      "claude-sonnet-4-6": "Mejor equilibrio entre velocidad y calidad.",
       "claude-opus-4-8": "Opus mas reciente. Mejor alineamiento y codigo agente que 4.7.",
       "claude-fable-5": "El modelo mas capaz. Consume el doble de creditos que Opus 4.8.",
       "claude-opus-4-7": "Modelo anterior. Autonomia de codigo y razonamiento complejo."

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -80,7 +80,8 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "O modelo mais avançado da OpenAI.",
-      "claude-sonnet-4-6": "Melhor equilibrio entre velocidade e qualidade.",
+      "claude-sonnet-5": "Sonnet mais recente. Melhor equilibrio entre velocidade e qualidade.",
+      "claude-sonnet-4-6": "Sonnet anterior. Bom equilibrio entre velocidade e qualidade.",
       "claude-opus-4-8": "Opus mais recente. Melhor alinhamento e codigo agente que 4.7.",
       "claude-fable-5": "O modelo mais capaz. Consome o dobro de creditos que Opus 4.8.",
       "claude-opus-4-7": "Modelo anterior. Autonomia de codigo e raciocinio complexo."

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -80,8 +80,8 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "O modelo mais avançado da OpenAI.",
-      "claude-sonnet-5": "Sonnet mais recente. Melhor equilibrio entre velocidade e qualidade.",
-      "claude-sonnet-4-6": "Sonnet anterior. Bom equilibrio entre velocidade e qualidade.",
+      "claude-sonnet-5": "Sonnet mais recente. Melhor para codigo com agentes e ferramentas.",
+      "claude-sonnet-4-6": "Melhor equilibrio entre velocidade e qualidade.",
       "claude-opus-4-8": "Opus mais recente. Melhor alinhamento e codigo agente que 4.7.",
       "claude-fable-5": "O modelo mais capaz. Consome o dobro de creditos que Opus 4.8.",
       "claude-opus-4-7": "Modelo anterior. Autonomia de codigo e raciocinio complexo."

--- a/cli-deps.json
+++ b/cli-deps.json
@@ -2,7 +2,7 @@
   "$schema": "./cli-deps.schema.json",
   "$comment": "Pinned versions for every CLI Houston ships or runtime-installs. Bundled (codex, composio) ride inside the .app / .msi under resources/bin. claude-code cannot be bundled (proprietary license) so the runtime installer downloads it on first launch via houston-claude-installer using the URLs + sha256 below. Bumping a version: run `./scripts/bump-cli.sh <name> <version>`, then `./scripts/fetch-cli-deps.sh both` to refresh the staged copies + print the new checksums; pin the printed sha256 back into this file. For Windows, composio is built from source (see `build` block) because upstream does not yet ship a Windows artifact.",
   "claude-code": {
-    "version": "2.1.170",
+    "version": "2.1.197",
     "bundled": false,
     "binary_name": "claude",
     "license": "PROPRIETARY",
@@ -16,10 +16,10 @@
       "manifest": "https://storage.googleapis.com/claude-code-dist-86c565f3-f756-42ad-8dfa-d59b1c096819/claude-code-releases/{version}/manifest.json"
     },
     "checksums": {
-      "darwin-arm64": "e903646d8b7a31882a80ecd27569a27d8ac57b3708745f349709632c84117fdf",
-      "darwin-x64": "914f23a70bbed5d9ae567e3e04b86206ed9971b371bc9baca3f79c8885bfddb4",
-      "windows-x64": "193061508fe619abf534b2c9d48151f26971d1d5b8460ad75c0af4be3d3525fb",
-      "windows-arm64": "9abd330bcc191aecc877a8ee9da2b448852cfe3bda15e5e4608385ea1d9d1709"
+      "darwin-arm64": "8cc0c4d1e4eb1dca3b0cc92ab02ee3505de764e023f8c901761c167b72041fb8",
+      "darwin-x64": "5e8a57cc7a92377f0744fa4c79191cf93d4b26c79cb919b07a407511fed1be26",
+      "windows-x64": "038bd9fe90c60304601e19751269a50d62925c541dd6a2b3da5274549e9416ee",
+      "windows-arm64": "8d2baeaf77b0e79ea33cf5ce78a37e64804c3a26d63d35355a830fda404a4f61"
     }
   },
   "codex": {

--- a/engine/houston-terminal-manager/src/prompt_scratch.rs
+++ b/engine/houston-terminal-manager/src/prompt_scratch.rs
@@ -15,7 +15,7 @@
 //!   `cli-deps.json` is kept new enough (older codex `-p` only reads
 //!   `[profiles.*]` tables out of the user's own `config.toml`).
 //! - **claude**: a plain temp file passed via `--system-prompt-file`
-//!   (supported by the pinned claude-code 2.1.170).
+//!   (supported by the pinned claude-code 2.1.197).
 //!
 //! Files are unique per spawn (pid + counter), removed on [`Drop`], and any
 //! leftovers from crashes are swept on the first spawn of each engine

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -219,7 +219,7 @@ adapter, see `knowledge-base/architecture.md`).
 
 | Provider id | CLI | Default model | Premium model | Login flow |
 |---|---|---|---|---|
-| `anthropic` (alias `claude`) | `claude` (runtime download) | `claude-sonnet-5` | `claude-opus-4-8` | OAuth via `claude auth login --claudeai` |
+| `anthropic` (alias `claude`) | `claude` (runtime download) | `claude-sonnet-4-6` | `claude-opus-4-8` | OAuth via `claude auth login --claudeai` |
 | `openai` (alias `codex`) | `codex` (bundled) | `gpt-5` | `gpt-5-codex` | OAuth via `codex login` |
 | `gemini` (alias `google`) | `gemini` (bundled, macOS only) | `gemini-2.5-flash` | `gemini-2.5-pro` | API key, no CLI login (see `knowledge-base/auth.md`) |
 

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -219,7 +219,7 @@ adapter, see `knowledge-base/architecture.md`).
 
 | Provider id | CLI | Default model | Premium model | Login flow |
 |---|---|---|---|---|
-| `anthropic` (alias `claude`) | `claude` (runtime download) | `claude-sonnet-4-6` | `claude-opus-4-8` | OAuth via `claude auth login --claudeai` |
+| `anthropic` (alias `claude`) | `claude` (runtime download) | `claude-sonnet-5` | `claude-opus-4-8` | OAuth via `claude auth login --claudeai` |
 | `openai` (alias `codex`) | `codex` (bundled) | `gpt-5` | `gpt-5-codex` | OAuth via `codex login` |
 | `gemini` (alias `google`) | `gemini` (bundled, macOS only) | `gemini-2.5-flash` | `gemini-2.5-pro` | API key, no CLI login (see `knowledge-base/auth.md`) |
 
@@ -286,6 +286,7 @@ shows only the levels the active model accepts.
 |---|---|---|---|
 | `anthropic` | `claude-opus-4-8` (Opus 4.8) | low, medium, high, xhigh, max | `--effort <v>` |
 | `anthropic` | `claude-opus-4-7` (Opus 4.7) | low, medium, high, xhigh, max | `--effort <v>` |
+| `anthropic` | `claude-sonnet-5` (Sonnet 5) | low, medium, high, xhigh, max | `--effort <v>` |
 | `anthropic` | `claude-sonnet-4-6` (Sonnet 4.6) | low, medium, high, max (no `xhigh`) | `--effort <v>` |
 | `openai` | `gpt-5.5` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
 | `gemini` | any | none | (no flag) |

--- a/knowledge-base/cli-bundling.md
+++ b/knowledge-base/cli-bundling.md
@@ -114,7 +114,7 @@ session's system prompt as a file-based profile
 `houston-terminal-manager::prompt_scratch`); older codex `-p` only reads
 `[profiles.*]` tables inside the user's own `config.toml` and would fail
 with "config profile not found". claude-code must stay ≥ a version with
-`--system-prompt-file` (the pinned 2.1.170 has it). Both exist because
+`--system-prompt-file` (the pinned 2.1.197 has it). Both exist because
 inline prompts on argv exceed Windows' 32,767-char `CreateProcessW`
 limit (os error 206) for agents with large accumulated context.
 


### PR DESCRIPTION
## HOU-614 — Add support for Sonnet 5

Adds Anthropic's **Claude Sonnet 5** (`claude-sonnet-5`) to Houston's model picker and bumps the runtime-installed Claude Code CLI to the version that supports it.

### Verified facts (Anthropic live docs + Claude Code changelog)
- **Model id / alias:** `claude-sonnet-5` (Bedrock `anthropic.claude-sonnet-5`, Google Cloud `claude-sonnet-5`)
- 1M context, 128k max output, adaptive thinking, **full effort range incl. `xhigh`** (default `high`)
- Released June 2026; "best combination of speed and intelligence"
- **Requires Claude Code >= 2.1.197** — the release that added the model. Houston pinned **2.1.170**, which does not know `claude-sonnet-5`, so the model would fail to launch until the CLI is bumped.

### Changes
- **`app/src/lib/providers.ts`** — new `claude-sonnet-5` `ModelOption` (effort `low/medium/high/xhigh/max`, 200k→1M self-correcting context window). **Default stays `claude-sonnet-4-6`** (per review) — Sonnet 5 is selectable, not the default. Sonnet 4.6 unchanged.
- **`cli-deps.json`** — claude-code `2.1.170` → `2.1.197`, with refreshed darwin-arm64 / darwin-x64 / win32-x64 / win32-arm64 sha256 checksums. Checksums were taken from the release `manifest.json` and the source was validated byte-for-byte against the known-good 2.1.170 pins before trusting it for 2.1.197.
- **`app/src/locales/{en,es,pt}/chat.json`** — picker description for Sonnet 5 (distinct from 4.6).
- **`knowledge-base/{agent-manifest,cli-bundling}.md`, `prompt_scratch.rs`** — provider + effort tables, pinned-version references.

### Why the engine code is otherwise untouched
The engine treats the model id as an **opaque pass-through** to `claude --model`; there is no model enum to extend. The effort union in `engine/houston-terminal-manager/src/provider/anthropic.rs` already carries all five levels, and per-model gating is a frontend-picker concern. The only engine-dir change is a stale-version reference in a doc comment.

### Verification
- `cd app && pnpm tsc --noEmit` → exit 0
- `cd app && pnpm check-locales` → "All locales in sync."
- `cd app && pnpm test` → 344/344 pass
- `cargo check -p houston-terminal-manager` → clean
- `cli-deps.json` parses; claude-code pinned to 2.1.197 with the four manifest-verified checksums

**Before:** picker had no Sonnet 5; Houston shipped Claude Code 2.1.170 (no `claude-sonnet-5`).
**After:** Sonnet 5 selectable under Anthropic (full effort menu incl. `xhigh`); default remains Sonnet 4.6; the runtime installer fetches Claude Code 2.1.197, which recognizes the model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)