### PR TITLE
feat(app): add Codex gpt-5.4 / 5.4-mini / 5.3-codex-spark models (HOU-589)

### DIFF
--- a/app/src/lib/providers.test.mjs
+++ b/app/src/lib/providers.test.mjs
@@ -8,13 +8,15 @@ import {
 } from "./providers.ts";
 
 test("effort levels are per model", () => {
-  // Codex: has xhigh, no max.
-  assert.deepEqual(getEffortLevels("openai", "gpt-5.5"), [
-    "low",
-    "medium",
-    "high",
-    "xhigh",
-  ]);
+  // Codex: has xhigh, no max. Every catalogued GPT model shares this set
+  // (verified against Codex's models_cache.json supported_reasoning_levels).
+  for (const id of ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"]) {
+    assert.deepEqual(
+      getEffortLevels("openai", id),
+      ["low", "medium", "high", "xhigh"],
+      id,
+    );
+  }
   // Sonnet 4.6: has max, no xhigh.
   assert.deepEqual(getEffortLevels("anthropic", "claude-sonnet-4-6"), [
     "low",
@@ -80,6 +82,12 @@ test("validModelOrNull rejects retired aliases and accepts catalog IDs", () => {
   assert.equal(validModelOrNull("anthropic", "claude-opus-4-8"), "claude-opus-4-8");
   assert.equal(validModelOrNull("anthropic", "claude-opus-4-7"), "claude-opus-4-7");
   assert.equal(validModelOrNull("anthropic", "claude-sonnet-4-6"), "claude-sonnet-4-6");
+  // Full Codex lineup is catalogued (gpt-5.5 + the gpt-5.4 / mini / spark
+  // models added in HOU-589); the phantom gpt-5.5-codex never shipped.
+  for (const id of ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"]) {
+    assert.equal(validModelOrNull("openai", id), id);
+  }
+  assert.equal(validModelOrNull("openai", "gpt-5.5-codex"), null);
 });
 
 test("normalizeLegacyModel maps retired aliases, passes everything else through", () => {

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -110,6 +110,37 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         contextWindow: 258_400,
         contextWindowMax: 950_000,
       },
+      {
+        id: "gpt-5.4",
+        label: "GPT-5.4",
+        description: "Strong model for everyday coding.",
+        effortLevels: ["low", "medium", "high", "xhigh"],
+        // Same window math as gpt-5.5: raw context_window 272k × 95%
+        // effective = 258_400 default. gpt-5.4 also exposes the opt-in 1M
+        // variant (max_context_window 1_000_000 in Codex's models_cache.json),
+        // so the snap-up ceiling is 1_000_000 × 95% = 950_000, reached only
+        // once observed usage exceeds the default.
+        contextWindow: 258_400,
+        contextWindowMax: 950_000,
+      },
+      {
+        id: "gpt-5.4-mini",
+        label: "GPT-5.4-Mini",
+        description: "Small, fast, and cost-efficient for simpler tasks.",
+        effortLevels: ["low", "medium", "high", "xhigh"],
+        // 272k raw × 95% = 258_400. No 1M opt-in (max_context_window == base in
+        // models_cache.json), so no snap-up ceiling.
+        contextWindow: 258_400,
+      },
+      {
+        id: "gpt-5.3-codex-spark",
+        label: "GPT-5.3-Codex-Spark",
+        description: "Ultra-fast coding model.",
+        effortLevels: ["low", "medium", "high", "xhigh"],
+        // Smaller window than the 5.4/5.5 line: 128k raw × 95% = 121_600. No
+        // upward gating (max_context_window == base in models_cache.json).
+        contextWindow: 121_600,
+      },
     ],
     defaultModel: "gpt-5.5",
   },

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -80,6 +80,9 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "OpenAI's frontier model.",
+      "gpt-5_4": "Strong model for everyday coding.",
+      "gpt-5_4-mini": "Small, fast, and cost-efficient for simpler tasks.",
+      "gpt-5_3-codex-spark": "Ultra-fast coding model.",
       "claude-sonnet-4-6": "Best balance of speed and quality.",
       "claude-opus-4-8": "Latest Opus. Better alignment and agentic coding than 4.7.",
       "claude-fable-5": "Most capable model. Costs 2x more credits than Opus 4.8.",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -80,6 +80,9 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "El modelo más avanzado de OpenAI.",
+      "gpt-5_4": "Modelo potente para programar a diario.",
+      "gpt-5_4-mini": "Pequeño, rápido y económico para tareas más simples.",
+      "gpt-5_3-codex-spark": "Modelo de programación ultrarrápido.",
       "claude-sonnet-4-6": "Mejor equilibrio entre velocidad y calidad.",
       "claude-opus-4-8": "Opus mas reciente. Mejor alineamiento y codigo agente que 4.7.",
       "claude-fable-5": "El modelo mas capaz. Consume el doble de creditos que Opus 4.8.",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -80,6 +80,9 @@
     },
     "modelDescriptions": {
       "gpt-5_5": "O modelo mais avançado da OpenAI.",
+      "gpt-5_4": "Modelo forte para programação do dia a dia.",
+      "gpt-5_4-mini": "Pequeno, rápido e econômico para tarefas mais simples.",
+      "gpt-5_3-codex-spark": "Modelo de programação ultrarrápido.",
       "claude-sonnet-4-6": "Melhor equilibrio entre velocidade e qualidade.",
       "claude-opus-4-8": "Opus mais recente. Melhor alinhamento e codigo agente que 4.7.",
       "claude-fable-5": "O modelo mais capaz. Consome o dobro de creditos que Opus 4.8.",

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -220,10 +220,19 @@ adapter, see `knowledge-base/architecture.md`).
 | Provider id | CLI | Default model | Premium model | Login flow |
 |---|---|---|---|---|
 | `anthropic` (alias `claude`) | `claude` (runtime download) | `claude-sonnet-4-6` | `claude-opus-4-8` | OAuth via `claude auth login --claudeai` |
-| `openai` (alias `codex`) | `codex` (bundled) | `gpt-5` | `gpt-5-codex` | OAuth via `codex login` |
+| `openai` (alias `codex`) | `codex` (bundled) | `gpt-5.5` | `gpt-5.5` (frontier; no separate tier) | OAuth via `codex login` |
 | `gemini` (alias `google`) | `gemini` (bundled, macOS only) | `gemini-2.5-flash` | `gemini-2.5-pro` | API key, no CLI login (see `knowledge-base/auth.md`) |
 
 Notes:
+- OpenAI ships four models in the picker: `gpt-5.5` (default, frontier),
+  `gpt-5.4` (everyday coding), `gpt-5.4-mini` (small/fast/cheap), and
+  `gpt-5.3-codex-spark` (ultra-fast). gpt-5.5 is both default and frontier, so
+  the "Premium model" column repeats it. The full catalog (labels, per-model
+  context windows, effort levels) lives in `app/src/lib/providers.ts`; codex
+  itself enumerates them in `~/.codex/models_cache.json`. The model string is
+  passed verbatim to `codex --model`, so the engine never validates against a
+  fixed list. The phantom `gpt-5.5-codex` / `gpt-5-codex` coding SKUs are NOT
+  selectable (ChatGPT accounts reject them; see `openai_classify.rs`).
 - Gemini has no `gemini login`. The picker short-circuits on
   `loginKind === "apiKey"` and opens the Connect-API-Key dialog
   (`app/src/components/shell/api-key-connect-dialog.tsx`). Calling
@@ -288,6 +297,9 @@ shows only the levels the active model accepts.
 | `anthropic` | `claude-opus-4-7` (Opus 4.7) | low, medium, high, xhigh, max | `--effort <v>` |
 | `anthropic` | `claude-sonnet-4-6` (Sonnet 4.6) | low, medium, high, max (no `xhigh`) | `--effort <v>` |
 | `openai` | `gpt-5.5` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
+| `openai` | `gpt-5.4` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
+| `openai` | `gpt-5.4-mini` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
+| `openai` | `gpt-5.3-codex-spark` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
 | `gemini` | any | none | (no flag) |
 
 Claude self-clamps an unsupported `--effort` down to its highest supported


### PR DESCRIPTION
## HOU-589 — Add support for more Codex GPT models

### Root cause / gap
Houston's OpenAI provider catalog (`app/src/lib/providers.ts`) only exposed **`gpt-5.5`**, but Codex now lists four selectable models in its own picker (per the issue screenshot, Codex v0.141.0):

1. `gpt-5.5` (already present)
2. `gpt-5.4`
3. `gpt-5.4-mini`
4. `gpt-5.3-codex-spark`

So users couldn't pick the three lighter/faster models even though the bundled Codex CLI accepts them.

### Fix
Frontend-only — the engine passes the model string verbatim to `codex --model` with **no allowlist** (`codex_command.rs`), so adding picker entries is sufficient. Every attribute is sourced from Codex's authoritative `~/.codex/models_cache.json`, not guessed:

| model | effort levels | context window (default / snap-up) |
|---|---|---|
| `gpt-5.4` | low/medium/high/xhigh | 258,400 / 950,000 (opt-in 1M variant) |
| `gpt-5.4-mini` | low/medium/high/xhigh | 258,400 (no gating) |
| `gpt-5.3-codex-spark` | low/medium/high/xhigh | 121,600 (128k window, no gating) |

Context windows = raw `context_window` × 95% effective, mirroring the existing `gpt-5.5` math.

### Changed files
- `app/src/lib/providers.ts` — three new `ModelOption` entries (ordered to match Codex's picker).
- `app/src/locales/{en,es,pt}/chat.json` — localized `modelDescriptions` for each new model.
- `app/src/lib/providers.test.mjs` — extended effort-level + `validModelOrNull` coverage for the full Codex lineup.
- `knowledge-base/agent-manifest.md` — fixed the stale openai row (`gpt-5` / `gpt-5-codex`), added the new models to the effort table, and documented the lineup.

### Verification
**Before:** model picker (OpenAI section) shows only **GPT-5.5**.

**After:**
- `cd app && pnpm typecheck` → exit 0
- `cd app && pnpm check-locales` → all locales in sync
- `node --experimental-strip-types --test app/src/lib/providers.test.mjs` → 9/9 pass
- `cd app && pnpm test` → 344/344 pass
- Picker (OpenAI) now lists **GPT-5.5, GPT-5.4, GPT-5.4-Mini, GPT-5.3-Codex-Spark**, each selectable per agent / per mission with its effort row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)