### PR TITLE
release: v0.4.25

### DIFF
--- a/.github/release-notes/0.4.25.es.md
+++ b/.github/release-notes/0.4.25.es.md
@@ -1,0 +1,25 @@
+## Houston 0.4.25
+
+### Nuevos modelos
+
+- **Claude Sonnet 5.** El Sonnet más reciente de Anthropic ya está en el selector
+  de modelos del chat. Ofrece mejor programación con agentes y uso de
+  herramientas. Puedes elegirlo por agente o por misión.
+- **Más modelos de OpenAI Codex.** El selector de Codex ahora incluye tres
+  modelos más para que elijas el adecuado según la tarea:
+  - **GPT-5.4**, un modelo potente para programar a diario.
+  - **GPT-5.4-Mini**, pequeño, rápido y económico para tareas más simples.
+  - **GPT-5.3-Codex-Spark**, un modelo de programación ultrarrápido.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza bien una
+  app que sigue abierta. Si tienes dudas, elimina `/Applications/Houston.app` y
+  arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde 0.4.7 o posterior te lleva
+  a esta versión automáticamente. El MSI todavía no está firmado a nivel de
+  sistema operativo, así que Windows SmartScreen puede mostrar una advertencia en
+  una instalación nueva.
+- **Windows ARM64:** no hay ruta de actualización automática desde una instalación
+  x64 emulada. Descarga el MSI ARM64 manualmente, desinstala primero la versión
+  x64 y luego instala la ARM64.

--- a/.github/release-notes/0.4.25.md
+++ b/.github/release-notes/0.4.25.md
@@ -1,0 +1,24 @@
+## Houston 0.4.25
+
+### New models
+
+- **Claude Sonnet 5.** Anthropic's newest Sonnet is now in the chat model
+  picker. It brings stronger agentic coding and tool use. Pick it per agent or
+  per mission.
+- **More OpenAI Codex models.** The Codex picker now lists three more models so
+  you can match the model to the job:
+  - **GPT-5.4**, a strong model for everyday coding.
+  - **GPT-5.4-Mini**, small, fast, and cost-efficient for simpler tasks.
+  - **GPT-5.3-Codex-Spark**, an ultra-fast coding model.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a
+  running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag
+  the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward
+  automatically. The MSI is still not OS-code-signed, so Windows SmartScreen may
+  warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install.
+  Download the ARM64 MSI manually, uninstall the x64 build first, then install
+  the ARM64 one.

--- a/.github/release-notes/0.4.25.pt.md
+++ b/.github/release-notes/0.4.25.pt.md
@@ -1,0 +1,25 @@
+## Houston 0.4.25
+
+### Novos modelos
+
+- **Claude Sonnet 5.** O Sonnet mais recente da Anthropic já está no seletor de
+  modelos do chat. Ele traz programação com agentes e uso de ferramentas mais
+  fortes. Você pode escolhê-lo por agente ou por missão.
+- **Mais modelos do OpenAI Codex.** O seletor do Codex agora lista três modelos a
+  mais para você escolher o ideal para cada tarefa:
+  - **GPT-5.4**, um modelo forte para programação do dia a dia.
+  - **GPT-5.4-Mini**, pequeno, rápido e econômico para tarefas mais simples.
+  - **GPT-5.3-Codex-Spark**, um modelo de programação ultrarrápido.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui bem uma
+  app que ainda está aberta. Na dúvida, remova `/Applications/Houston.app` e
+  arraste a nova cópia.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou mais recente
+  leva você para esta versão automaticamente. O MSI ainda não é assinado no nível
+  do sistema operacional, então o Windows SmartScreen pode mostrar um aviso em
+  uma instalação nova.
+- **Windows ARM64:** não há caminho de atualização automática a partir de uma
+  instalação x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a
+  versão x64 e depois instale a ARM64.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "futures-util",
  "hex",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "serde",
  "serde_json",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.24"
+version = "0.4.25"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.24", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.24", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.24", path = "app/houston-tauri" }
-houston-events = { version = "0.4.24", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.24", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.24", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.24", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.24", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.24", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.24", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.24", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.24", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.24", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.24", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.24", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.24", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.24", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.24", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.25", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.25", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.25", path = "app/houston-tauri" }
+houston-events = { version = "0.4.25", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.25", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.25", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.25", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.25", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.25", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.25", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.25", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.25", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.25", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.25", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.25", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.25", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.25", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.25", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.24"
+version = "0.4.25"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.24",
+  "version": "0.4.25",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Houston 0.4.25 — release prep

Version bump across all packages (0.4.24 → 0.4.25) plus hand-written release notes (en/es/pt).

### What ships for users
Only new models this cut. Release notes deliberately omit website work and internal plumbing.

- **Claude Sonnet 5** added to the chat model picker (selectable per agent / per mission).
- **OpenAI Codex** picker gains three models:
  - **GPT-5.4** — everyday coding
  - **GPT-5.4-Mini** — small, fast, cost-efficient
  - **GPT-5.3-Codex-Spark** — ultra-fast coding

(Both model PRs — #578, #579 — already landed on `main`. This PR only bumps the version and writes the user-facing notes.)

### Files
- `.github/release-notes/0.4.25.md` + `.es.md` + `.pt.md` — user-facing notes (model changes + standard before-you-upgrade caveats)
- 19 `Cargo.toml` + `Cargo.lock` (regenerated) + 9 `package.json` — version bumped to 0.4.25 via `scripts/version.sh`

### Verification
- `cargo check --workspace --exclude houston-app` — clean
- `cd app && pnpm tsc --noEmit` — clean

### After merge
Tag `v0.4.25` on `main` to trigger the signed/notarized build. CI creates a **draft** GitHub Release using these notes verbatim; publishing stays the maintainer's call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)