### PR TITLE
fix(app): set Sonnet 5 context window to 1M, keep max effort, restore Fable 5 (HOU-618)

### DIFF
--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -160,11 +160,12 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         // Sonnet 5 accepts the full effort range, INCLUDING `xhigh` (unlike
         // Sonnet 4.6, which has `max` but not `xhigh`). API default is `high`.
         effortLevels: ["low", "medium", "high", "xhigh", "max"],
-        // Same window story as Sonnet 4.6: Claude Code starts at 200k on every
-        // plan and the 1M window is opt-in via usage credits, so start at 200k
-        // and snap to 1M once observed usage proves the larger window is active.
-        contextWindow: 200_000,
-        contextWindowMax: 1_000_000,
+        // Unlike Sonnet 4.6 (whose 1M is a credit-gated opt-in over a 200k
+        // default), Sonnet 5's 1M window is the default AND the only variant:
+        // per Anthropic, "1M tokens is both the default and the maximum; there
+        // is no smaller context variant," and it's the Claude Code default on
+        // Pro and up. So a flat 1M denominator with no snap-up, like Opus 4.8.
+        contextWindow: 1_000_000,
       },
       {
         id: "claude-sonnet-4-6",
@@ -192,10 +193,15 @@ export const PROVIDERS: readonly ProviderInfo[] = [
         // it can't self-correct downward, so the dialog flags it as estimated.
         contextWindow: 1_000_000,
       },
-      // Fable 5 (`claude-fable-5`) is intentionally absent from the picker for
-      // now — pulled per HOU-476. Engine support and its `modelDescriptions`
-      // copy in the chat locales are retained so re-adding a ModelOption here
-      // (full effort range, 1M window, 2x Opus 4.8 credits) re-enables it.
+      {
+        id: "claude-fable-5",
+        label: "Fable 5",
+        description: "Most capable model. Costs 2x more credits than Opus 4.8.",
+        // Fable 5: full range like Opus 4.8. ultracode is a harness mode, not
+        // an effort level — it is intentionally excluded for this model.
+        effortLevels: ["low", "medium", "high", "xhigh", "max"],
+        contextWindow: 1_000_000,
+      },
       {
         id: "claude-opus-4-7",
         label: "Opus 4.7",

--- a/app/tests/anthropic-model-catalog.test.ts
+++ b/app/tests/anthropic-model-catalog.test.ts
@@ -1,0 +1,69 @@
+import { strictEqual, deepStrictEqual, ok } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  getModel,
+  getContextWindowConfig,
+  getEffortLevels,
+} from "../src/lib/providers.ts";
+
+// Regression guards for HOU-618 (Sonnet 5 context window) plus the Fable 5
+// picker restore. The Anthropic catalog is plain data, so these lock in the
+// exact per-model context-window and effort facts that were wrong / absent.
+
+describe("Sonnet 5 catalog (HOU-618)", () => {
+  it("has a flat 1M context window — no 200k snap-up (unlike Sonnet 4.6)", () => {
+    // Sonnet 5's 1M is the default AND only variant (no credit-gated 200k),
+    // so default === max === 1M. The bug started the estimate at 200k by
+    // copying Sonnet 4.6's credit-gated snap-up, which doesn't apply here.
+    deepStrictEqual(getContextWindowConfig("anthropic", "claude-sonnet-5"), {
+      default: 1_000_000,
+      max: 1_000_000,
+    });
+  });
+
+  it("keeps all five effort levels including max", () => {
+    // Anthropic's effort docs list Sonnet 5 for both `xhigh` and `max`, so
+    // `max` stays in the picker (it is not an Opus-only level).
+    deepStrictEqual(getEffortLevels("anthropic", "claude-sonnet-5"), [
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+  });
+});
+
+describe("Sonnet 4.6 still credit-gates its 1M window", () => {
+  it("starts at 200k and snaps up to 1M (unchanged by HOU-618)", () => {
+    deepStrictEqual(getContextWindowConfig("anthropic", "claude-sonnet-4-6"), {
+      default: 200_000,
+      max: 1_000_000,
+    });
+  });
+});
+
+describe("Fable 5 restored to the picker", () => {
+  it("is present as the flagship model", () => {
+    const fable = getModel("anthropic", "claude-fable-5");
+    ok(fable, "claude-fable-5 should be in the Anthropic catalog");
+    strictEqual(fable?.label, "Fable 5");
+  });
+
+  it("has a flat 1M context window like Opus 4.8", () => {
+    deepStrictEqual(getContextWindowConfig("anthropic", "claude-fable-5"), {
+      default: 1_000_000,
+      max: 1_000_000,
+    });
+  });
+
+  it("accepts all five effort levels", () => {
+    deepStrictEqual(getEffortLevels("anthropic", "claude-fable-5"), [
+      "low",
+      "medium",
+      "high",
+      "xhigh",
+      "max",
+    ]);
+  });
+});

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -293,6 +293,7 @@ shows only the levels the active model accepts.
 
 | Provider | Model | Effort levels offered | CLI flag |
 |---|---|---|---|
+| `anthropic` | `claude-fable-5` (Fable 5) | low, medium, high, xhigh, max | `--effort <v>` |
 | `anthropic` | `claude-opus-4-8` (Opus 4.8) | low, medium, high, xhigh, max | `--effort <v>` |
 | `anthropic` | `claude-opus-4-7` (Opus 4.7) | low, medium, high, xhigh, max | `--effort <v>` |
 | `anthropic` | `claude-sonnet-5` (Sonnet 5) | low, medium, high, xhigh, max | `--effort <v>` |


### PR DESCRIPTION
## HOU-618

### Root cause
`app/src/lib/providers.ts` gave Claude **Sonnet 5** the same context-window treatment as Sonnet 4.6 — a 200k default that snaps up to 1M (`contextWindow: 200_000` / `contextWindowMax: 1_000_000`). That is wrong for Sonnet 5. Per Anthropic's docs, Sonnet 5's **1M window is both the default and the only variant** ("there is no smaller context variant"), and it is the Claude Code default on Pro and up. Sonnet 4.6's 1M, by contrast, is a **credit-gated opt-in** over a 200k default — which is exactly why the snap-up exists there and must not be applied to Sonnet 5.

### What changed
1. **Sonnet 5 → flat 1M context window** (`contextWindow: 1_000_000`, drop the `contextWindowMax` snap-up), matching Opus 4.8. Rewrote the misleading comment.
2. **Kept `max` effort on Sonnet 5.** The issue asked to remove it, but research into Anthropic's current effort docs shows Sonnet 5 supports **both `xhigh` and `max`** (all five levels) — `max` is no longer Opus-only. Removing it would make Houston wrong, so it stays. (Confirmed direction with the issue author.)
3. **Restored the Fable 5 model option** to the picker (pulled per HOU-476). Restored its exact prior config — all-five effort, flat 1M window — which still matches current docs. Locale keys and engine support were already retained, so no other wiring was needed.
4. Added a catalog regression test and a Fable 5 row to the agent-manifest effort table.

### Sources
Anthropic docs (models overview, effort, context-windows, "what's new in Sonnet 5") all confirm Sonnet 5 = 1M context (default and only) and effort levels low/medium/high/xhigh/max.

### Files
- `app/src/lib/providers.ts` — Sonnet 5 context window; restore Fable 5 option
- `knowledge-base/agent-manifest.md` — Fable 5 effort-table row
- `app/tests/anthropic-model-catalog.test.ts` — new regression test

### Verify

**Before (on `main`):**
- Model picker → Anthropic **Sonnet 5**: the context-usage indicator denominator starts at **200k** (only snaps to 1M after a session exceeds 200k observed tokens) — under-reporting the real 1M window.
- **Fable 5** is absent from the picker.

**After (this branch):**
- `cd app && pnpm test` → 350 passing, including the new `anthropic-model-catalog.test.ts` (Sonnet 5 = flat 1M, `max` retained, Fable 5 present at 1M / all-five; Sonnet 4.6's 200k→1M snap-up unchanged).
- `cd app && pnpm tsc --noEmit` and `pnpm check-locales` both clean.
- Model picker: **Sonnet 5** shows a 1M context denominator from the start; **Fable 5** appears again with the full effort range.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
