### PR TITLE
fix(app): i18n the new-agent store (builtin catalog + model picker) (HOU-587)

### DIFF
--- a/app/src/agents/builtin/default-experience.ts
+++ b/app/src/agents/builtin/default-experience.ts
@@ -3,7 +3,7 @@ import type { AgentConfig } from "../../lib/types";
 export const blankAgent: AgentConfig = {
   id: "blank",
   name: "Start from scratch",
-  description: "A blank agent with no pre-configured actions, instructions, or learnings — build it your way",
+  description: "A blank agent with no pre-configured actions, instructions, or learnings. Build it your way.",
   icon: "Plus",
   category: "productivity",
   author: "Houston",

--- a/app/src/agents/catalog-labels.ts
+++ b/app/src/agents/catalog-labels.ts
@@ -1,30 +1,43 @@
 import type { TFunction } from "i18next";
-import type { AgentDefinition } from "../lib/types";
+
+export interface CatalogCopy {
+  name: string;
+  description: string;
+}
 
 /**
- * Localized display name + description for a catalog agent shown in the
- * new-agent store.
- *
- * Houston's first-party (builtin) agents ship translations under
- * `agents:catalog.<id>`, so the store renders them in the user's language.
- * Installed / remote store agents keep their author's language (the App Store
- * model), so anything that isn't builtin falls back to the raw config strings.
- *
- * The `defaultValue` guard also covers a builtin agent that doesn't yet have a
- * `catalog.<id>` entry: it renders the in-code English rather than a raw key.
+ * The minimal shape both an `AgentConfig` (builtin / installed agents) and a
+ * `StoreListing` (remote store catalog) satisfy — enough to localize a card.
  */
-export function localizeCatalogEntry(
-  def: AgentDefinition,
-  t: TFunction,
-): { name: string; description: string } {
-  const { config } = def;
-  if (def.source !== "builtin") {
-    return { name: config.name, description: config.description };
+interface CatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  author?: string;
+}
+
+/**
+ * Localized display name + description for a new-agent store card.
+ *
+ * Houston's own first-party agents (`author === "Houston"`) — whether the
+ * builtin `personal-assistant` / `blank` or a bundled store listing
+ * (bookkeeping, legal, sales, …) — ship translations under
+ * `agents:catalog.<id>`, so the store renders them in the user's language.
+ *
+ * Third-party / community agents keep their author's language (the App Store
+ * model), so anything not authored by Houston falls back to the raw strings.
+ * The `defaultValue` guard also covers a first-party agent that doesn't yet
+ * have a `catalog.<id>` entry: it renders the in-catalog English rather than a
+ * raw key.
+ */
+export function localizeCatalogCopy(entry: CatalogEntry, t: TFunction): CatalogCopy {
+  if (entry.author !== "Houston") {
+    return { name: entry.name, description: entry.description };
   }
   return {
-    name: t(`agents:catalog.${config.id}.name`, { defaultValue: config.name }),
-    description: t(`agents:catalog.${config.id}.description`, {
-      defaultValue: config.description,
+    name: t(`agents:catalog.${entry.id}.name`, { defaultValue: entry.name }),
+    description: t(`agents:catalog.${entry.id}.description`, {
+      defaultValue: entry.description,
     }),
   };
 }

--- a/app/src/agents/catalog-labels.ts
+++ b/app/src/agents/catalog-labels.ts
@@ -1,0 +1,30 @@
+import type { TFunction } from "i18next";
+import type { AgentDefinition } from "../lib/types";
+
+/**
+ * Localized display name + description for a catalog agent shown in the
+ * new-agent store.
+ *
+ * Houston's first-party (builtin) agents ship translations under
+ * `agents:catalog.<id>`, so the store renders them in the user's language.
+ * Installed / remote store agents keep their author's language (the App Store
+ * model), so anything that isn't builtin falls back to the raw config strings.
+ *
+ * The `defaultValue` guard also covers a builtin agent that doesn't yet have a
+ * `catalog.<id>` entry: it renders the in-code English rather than a raw key.
+ */
+export function localizeCatalogEntry(
+  def: AgentDefinition,
+  t: TFunction,
+): { name: string; description: string } {
+  const { config } = def;
+  if (def.source !== "builtin") {
+    return { name: config.name, description: config.description };
+  }
+  return {
+    name: t(`agents:catalog.${config.id}.name`, { defaultValue: config.name }),
+    description: t(`agents:catalog.${config.id}.description`, {
+      defaultValue: config.description,
+    }),
+  };
+}

--- a/app/src/components/shell/experience-card.tsx
+++ b/app/src/components/shell/experience-card.tsx
@@ -32,12 +32,18 @@ export function AgentCard({ config, title, description, onSelect }: AgentCardPro
 
 interface StoreAgentCardProps {
   listing: StoreListing;
+  /** Localized display name (falls back to `listing.name`). */
+  title?: string;
+  /** Localized display description (falls back to `listing.description`). */
+  description?: string;
   onInstall: (listing: StoreListing) => Promise<void>;
   onSelect: (id: string) => void;
 }
 
 export function StoreAgentCard({
   listing,
+  title,
+  description,
   onInstall,
   onSelect,
 }: StoreAgentCardProps) {
@@ -55,8 +61,8 @@ export function StoreAgentCard({
 
   return (
     <SkillCard
-      title={listing.name}
-      description={listing.description}
+      title={title ?? listing.name}
+      description={description ?? listing.description}
       image={listing.icon_url}
       integrations={listing.integrations}
       maxIntegrations={8}

--- a/app/src/components/shell/experience-card.tsx
+++ b/app/src/components/shell/experience-card.tsx
@@ -6,18 +6,22 @@ export { AgentAvatar, HoustonLogo, getAgentIcon, getAgentIconColor, getHoustonLo
 
 interface AgentCardProps {
   config: AgentConfig;
+  /** Localized display name (falls back to `config.name`). */
+  title?: string;
+  /** Localized display description (falls back to `config.description`). */
+  description?: string;
   onSelect: (id: string) => void;
 }
 
-export function AgentCard({ config, onSelect }: AgentCardProps) {
+export function AgentCard({ config, title, description, onSelect }: AgentCardProps) {
   return (
     <SkillCard
       image={config.image}
       media={
         config.image ? undefined : <AgentAvatar config={config} size="md" />
       }
-      title={config.name}
-      description={config.description}
+      title={title ?? config.name}
+      description={description ?? config.description}
       integrations={config.integrations}
       maxIntegrations={8}
       className="min-h-[132px]"

--- a/app/src/components/shell/naming-step.tsx
+++ b/app/src/components/shell/naming-step.tsx
@@ -15,7 +15,7 @@ import { ArrowLeft, Check, FolderOpen, ChevronDown } from "lucide-react";
 import type { AgentDefinition } from "../../lib/types";
 import { tauriProvider, type ProviderStatus } from "../../lib/tauri";
 import { PROVIDERS, getProvider, getModel } from "../../lib/providers";
-import { localizeCatalogEntry } from "../../agents/catalog-labels";
+import { localizeCatalogCopy } from "../../agents/catalog-labels";
 
 interface NamingStepProps {
   selectedAgent: AgentDefinition | undefined;
@@ -55,7 +55,7 @@ export function NamingStep({
   // Default to white on mount if none selected
   const resolvedColor = resolveAgentColor(color);
   const selectedName = selectedAgent
-    ? localizeCatalogEntry(selectedAgent, t).name
+    ? localizeCatalogCopy(selectedAgent.config, t).name
     : t("naming.newAgentFallback");
 
   useEffect(() => {

--- a/app/src/components/shell/naming-step.tsx
+++ b/app/src/components/shell/naming-step.tsx
@@ -15,6 +15,7 @@ import { ArrowLeft, Check, FolderOpen, ChevronDown } from "lucide-react";
 import type { AgentDefinition } from "../../lib/types";
 import { tauriProvider, type ProviderStatus } from "../../lib/tauri";
 import { PROVIDERS, getProvider, getModel } from "../../lib/providers";
+import { localizeCatalogEntry } from "../../agents/catalog-labels";
 
 interface NamingStepProps {
   selectedAgent: AgentDefinition | undefined;
@@ -50,9 +51,12 @@ export function NamingStep({
   onBack,
   onSubmit,
 }: NamingStepProps) {
-  const { t } = useTranslation("shell");
+  const { t } = useTranslation(["shell", "agents"]);
   // Default to white on mount if none selected
   const resolvedColor = resolveAgentColor(color);
+  const selectedName = selectedAgent
+    ? localizeCatalogEntry(selectedAgent, t).name
+    : t("naming.newAgentFallback");
 
   useEffect(() => {
     if (!color) {
@@ -77,7 +81,7 @@ export function NamingStep({
 
         <div className="text-center">
           <p className="text-lg font-semibold">
-            {selectedAgent?.config.name ?? t("naming.newAgentFallback")}
+            {selectedName}
           </p>
           <p className="text-sm text-muted-foreground mt-1">
             {t("naming.tagline")}
@@ -190,7 +194,7 @@ export function InlineModelSelector({
   model: string;
   onSelect: (provider: string, model: string) => void;
 }) {
-  const { t } = useTranslation("providers");
+  const { t } = useTranslation(["providers", "chat"]);
   const [statuses, setStatuses] = useState<Record<string, ProviderStatus>>({});
   const [open, setOpen] = useState(false);
 
@@ -265,7 +269,9 @@ export function InlineModelSelector({
                       </div>
                       <div className="min-w-0 flex-1">
                         <div className="text-sm">{m.label}</div>
-                        <div className="text-xs text-muted-foreground leading-snug">{m.description}</div>
+                        <div className="text-xs text-muted-foreground leading-snug">
+                          {t(`chat:modelSelector.modelDescriptions.${m.id.replace(/\./g, "_")}`, { defaultValue: m.description })}
+                        </div>
                       </div>
                     </button>
                   );

--- a/app/src/components/shell/store-step.tsx
+++ b/app/src/components/shell/store-step.tsx
@@ -5,10 +5,8 @@ import { useTranslation } from "react-i18next";
 import type { AgentDefinition, StoreListing } from "../../lib/types";
 import { SkillCard } from "../skill-card";
 import { AgentCard, StoreAgentCard } from "./experience-card";
-import { localizeCatalogEntry } from "../../agents/catalog-labels";
+import { localizeCatalogCopy, type CatalogCopy } from "../../agents/catalog-labels";
 import { useUIStore } from "../../stores/ui";
-
-type CatalogDisplay = { name: string; description: string };
 
 interface StoreStepProps {
   search: string;
@@ -39,17 +37,27 @@ export function StoreStep({
   );
   const query = search.trim().toLowerCase();
 
-  // First-party (builtin) agents render in the user's language; installed /
-  // remote agents keep their author's language. Recompute when the active
-  // language changes so switching locales relabels the store live.
-  const localized = useMemo(() => {
-    const map = new Map<string, CatalogDisplay>();
+  // Houston's first-party agents (builtin + bundled store listings) render in
+  // the user's language; third-party agents keep their author's language.
+  // Recompute when the active language changes so switching locales relabels
+  // the store live.
+  const localizedAgents = useMemo(() => {
+    const map = new Map<string, CatalogCopy>();
     for (const def of agents) {
-      map.set(def.config.id, localizeCatalogEntry(def, t));
+      map.set(def.config.id, localizeCatalogCopy(def.config, t));
     }
     return map;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agents, t, i18n.language]);
+
+  const localizedStore = useMemo(() => {
+    const map = new Map<string, CatalogCopy>();
+    for (const listing of storeCatalog) {
+      map.set(listing.id, localizeCatalogCopy(listing, t));
+    }
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [storeCatalog, t, i18n.language]);
 
   const filteredAgents = useMemo(
     () =>
@@ -59,18 +67,18 @@ export function StoreStep({
         }
         if (storeIds.has(d.config.id)) return false;
         if (!query) return true;
-        return matchesAgent(d, localized.get(d.config.id), query);
+        return matchesAgent(d, localizedAgents.get(d.config.id), query);
       }),
-    [agents, query, storeIds, localized],
+    [agents, query, storeIds, localizedAgents],
   );
 
   const filteredStore = useMemo(
     () =>
       storeCatalog.filter((listing) => {
         if (!query) return true;
-        return matchesListing(listing, query);
+        return matchesListing(listing, localizedStore.get(listing.id), query);
       }),
-    [query, storeCatalog],
+    [query, storeCatalog, localizedStore],
   );
 
   const reorderedAgents = useMemo(() => {
@@ -138,7 +146,7 @@ export function StoreStep({
               />
             )}
             {reorderedAgents.map((def) => {
-              const display = localized.get(def.config.id);
+              const display = localizedAgents.get(def.config.id);
               return (
                 <AgentCard
                   key={def.config.id}
@@ -149,14 +157,19 @@ export function StoreStep({
                 />
               );
             })}
-            {filteredStore.map((listing) => (
-              <StoreAgentCard
-                key={listing.id}
-                listing={listing}
-                onInstall={onInstall}
-                onSelect={onSelect}
-              />
-            ))}
+            {filteredStore.map((listing) => {
+              const display = localizedStore.get(listing.id);
+              return (
+                <StoreAgentCard
+                  key={listing.id}
+                  listing={listing}
+                  title={display?.name}
+                  description={display?.description}
+                  onInstall={onInstall}
+                  onSelect={onSelect}
+                />
+              );
+            })}
           </div>
         ) : (
           <div className="flex items-center justify-center py-16">
@@ -172,7 +185,7 @@ export function StoreStep({
 
 function matchesAgent(
   def: AgentDefinition,
-  display: CatalogDisplay | undefined,
+  display: CatalogCopy | undefined,
   query: string,
 ): boolean {
   const config = def.config;
@@ -189,10 +202,16 @@ function matchesAgent(
   );
 }
 
-function matchesListing(listing: StoreListing, query: string): boolean {
+function matchesListing(
+  listing: StoreListing,
+  display: CatalogCopy | undefined,
+  query: string,
+): boolean {
+  const name = display?.name ?? listing.name;
+  const description = display?.description ?? listing.description;
   return (
-    listing.name.toLowerCase().includes(query) ||
-    listing.description.toLowerCase().includes(query) ||
+    name.toLowerCase().includes(query) ||
+    description.toLowerCase().includes(query) ||
     listing.tags.some((tag) => tag.toLowerCase().includes(query)) ||
     listing.integrations?.some((toolkit) =>
       toolkit.toLowerCase().includes(query),

--- a/app/src/components/shell/store-step.tsx
+++ b/app/src/components/shell/store-step.tsx
@@ -5,7 +5,10 @@ import { useTranslation } from "react-i18next";
 import type { AgentDefinition, StoreListing } from "../../lib/types";
 import { SkillCard } from "../skill-card";
 import { AgentCard, StoreAgentCard } from "./experience-card";
+import { localizeCatalogEntry } from "../../agents/catalog-labels";
 import { useUIStore } from "../../stores/ui";
+
+type CatalogDisplay = { name: string; description: string };
 
 interface StoreStepProps {
   search: string;
@@ -26,7 +29,7 @@ export function StoreStep({
   onInstall,
   onCreateWithAi,
 }: StoreStepProps) {
-  const { t } = useTranslation(["shell", "portable"]);
+  const { t, i18n } = useTranslation(["shell", "portable", "agents"]);
   const setImportOpen = useUIStore((s) => s.setImportFromFriendOpen);
   const setCreateOpen = useUIStore((s) => s.setCreateAgentDialogOpen);
 
@@ -36,6 +39,18 @@ export function StoreStep({
   );
   const query = search.trim().toLowerCase();
 
+  // First-party (builtin) agents render in the user's language; installed /
+  // remote agents keep their author's language. Recompute when the active
+  // language changes so switching locales relabels the store live.
+  const localized = useMemo(() => {
+    const map = new Map<string, CatalogDisplay>();
+    for (const def of agents) {
+      map.set(def.config.id, localizeCatalogEntry(def, t));
+    }
+    return map;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agents, t, i18n.language]);
+
   const filteredAgents = useMemo(
     () =>
       agents.filter((d) => {
@@ -44,9 +59,9 @@ export function StoreStep({
         }
         if (storeIds.has(d.config.id)) return false;
         if (!query) return true;
-        return matchesAgent(d, query);
+        return matchesAgent(d, localized.get(d.config.id), query);
       }),
-    [agents, query, storeIds],
+    [agents, query, storeIds, localized],
   );
 
   const filteredStore = useMemo(
@@ -122,13 +137,18 @@ export function StoreStep({
                 onClick={onCreateWithAi}
               />
             )}
-            {reorderedAgents.map((def) => (
-              <AgentCard
-                key={def.config.id}
-                config={def.config}
-                onSelect={onSelect}
-              />
-            ))}
+            {reorderedAgents.map((def) => {
+              const display = localized.get(def.config.id);
+              return (
+                <AgentCard
+                  key={def.config.id}
+                  config={def.config}
+                  title={display?.name}
+                  description={display?.description}
+                  onSelect={onSelect}
+                />
+              );
+            })}
             {filteredStore.map((listing) => (
               <StoreAgentCard
                 key={listing.id}
@@ -150,11 +170,17 @@ export function StoreStep({
   );
 }
 
-function matchesAgent(def: AgentDefinition, query: string): boolean {
+function matchesAgent(
+  def: AgentDefinition,
+  display: CatalogDisplay | undefined,
+  query: string,
+): boolean {
   const config = def.config;
+  const name = display?.name ?? config.name;
+  const description = display?.description ?? config.description;
   return (
-    config.name.toLowerCase().includes(query) ||
-    config.description.toLowerCase().includes(query) ||
+    name.toLowerCase().includes(query) ||
+    description.toLowerCase().includes(query) ||
     config.tags?.some((tag) => tag.toLowerCase().includes(query)) ||
     config.integrations?.some((toolkit) =>
       toolkit.toLowerCase().includes(query),

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -7,6 +7,38 @@
     "blank": {
       "name": "Start from scratch",
       "description": "A blank agent with no pre-configured actions, instructions, or learnings. Build it your way."
+    },
+    "bookkeeping": {
+      "name": "Bookkeeping",
+      "description": "Categorize transactions, reconcile accounts, close the books every month, and generate investor-ready financials. Connects to QuickBooks, Xero, Stripe, and your bank feeds. Drafts journal entries and statements, never posts to your ledger or moves money."
+    },
+    "legal": {
+      "name": "Legal",
+      "description": "Review contracts, audit privacy compliance, prep Delaware filings, run trademark searches, and answer legal questions on the spot. Drafts NDAs, policies, and escalation briefs, never files, signs, or sends anything on your behalf."
+    },
+    "marketing": {
+      "name": "Marketing",
+      "description": "Build positioning, plan campaigns, write blog posts and landing pages, audit SEO and AI-search visibility, and draft email sequences. Strategy through execution across content, paid, social, and conversion copy, all drafts, never published."
+    },
+    "operations": {
+      "name": "Operations",
+      "description": "Triage your inbox, prep meetings, track goals, manage vendor renewals, audit SaaS spend, and run data queries. Covers planning, scheduling, finance hygiene, and reporting, drafts only, never sends or commits."
+    },
+    "people": {
+      "name": "People",
+      "description": "Source and evaluate candidates, coordinate interview loops, draft offer letters, run review cycles, and track compliance deadlines. Covers hiring through retention, drafts only, never sends or modifies your HR systems."
+    },
+    "sales": {
+      "name": "Sales",
+      "description": "Find leads, research accounts, prep calls, draft outreach, manage your CRM, and forecast pipeline. Covers prospecting through expansion, drafts only, never sends or changes deal stages without your approval."
+    },
+    "support": {
+      "name": "Support",
+      "description": "Triage tickets, draft replies, write help-center articles, score customer health, and build churn-save playbooks. Covers inbox through customer success, drafts only, never sends."
+    },
+    "outbound": {
+      "name": "Outbound",
+      "description": "Turn a single LinkedIn post into a paused cold email campaign in Instantly. I scrape the commenters or reactors, store them in Airtable, find verified emails through Apollo, co-write a 3-email sequence with you, then load it all into Instantly. The campaign always stays paused for your review, I never auto-launch."
     }
   },
   "toasts": {

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -1,4 +1,14 @@
 {
+  "catalog": {
+    "personal-assistant": {
+      "name": "Personal assistant",
+      "description": "A general-purpose assistant for your day, inbox, calendar, follow-ups, and recurring work."
+    },
+    "blank": {
+      "name": "Start from scratch",
+      "description": "A blank agent with no pre-configured actions, instructions, or learnings. Build it your way."
+    }
+  },
   "toasts": {
     "renamed": "Workspace renamed",
     "deleted": "Workspace deleted",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -1,4 +1,14 @@
 {
+  "catalog": {
+    "personal-assistant": {
+      "name": "Asistente personal",
+      "description": "Un asistente de uso general para tu día, tu bandeja de entrada, tu calendario, tus seguimientos y tu trabajo recurrente."
+    },
+    "blank": {
+      "name": "Empezar desde cero",
+      "description": "Un agente en blanco, sin acciones, instrucciones ni aprendizajes preconfigurados. Constrúyelo a tu manera."
+    }
+  },
   "toasts": {
     "renamed": "Espacio de trabajo renombrado",
     "deleted": "Espacio de trabajo eliminado",

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -7,6 +7,38 @@
     "blank": {
       "name": "Empezar desde cero",
       "description": "Un agente en blanco, sin acciones, instrucciones ni aprendizajes preconfigurados. Constrúyelo a tu manera."
+    },
+    "bookkeeping": {
+      "name": "Contabilidad",
+      "description": "Categoriza transacciones, concilia cuentas, cierra los libros cada mes y genera estados financieros listos para inversionistas. Se conecta con QuickBooks, Xero, Stripe y tus conexiones bancarias. Redacta asientos contables y estados, pero nunca registra en tu libro mayor ni mueve dinero."
+    },
+    "legal": {
+      "name": "Legal",
+      "description": "Revisa contratos, audita el cumplimiento de privacidad, prepara presentaciones ante Delaware, hace búsquedas de marcas registradas y responde dudas legales al instante. Redacta acuerdos de confidencialidad, políticas y resúmenes de escalamiento, pero nunca presenta, firma ni envía nada en tu nombre."
+    },
+    "marketing": {
+      "name": "Marketing",
+      "description": "Define el posicionamiento, planifica campañas, escribe artículos de blog y páginas de aterrizaje, audita el SEO y la visibilidad en búsquedas con IA, y redacta secuencias de correo. De la estrategia a la ejecución en contenido, medios pagados, redes sociales y textos de conversión, todo en borradores, nunca publicado."
+    },
+    "operations": {
+      "name": "Operaciones",
+      "description": "Prioriza tu bandeja de entrada, prepara reuniones, da seguimiento a objetivos, gestiona renovaciones con proveedores, audita el gasto en SaaS y ejecuta consultas de datos. Abarca planificación, agenda, orden financiero y reportes, solo borradores, nunca envía ni confirma nada."
+    },
+    "people": {
+      "name": "Personas",
+      "description": "Busca y evalúa candidatos, coordina rondas de entrevistas, redacta cartas de oferta, gestiona ciclos de evaluación y da seguimiento a plazos de cumplimiento. Abarca desde la contratación hasta la retención, solo borradores, nunca envía ni modifica tus sistemas de recursos humanos."
+    },
+    "sales": {
+      "name": "Ventas",
+      "description": "Encuentra prospectos, investiga cuentas, prepara llamadas, redacta mensajes de contacto, gestiona tu CRM y proyecta el pipeline. Abarca desde la prospección hasta la expansión, solo borradores, nunca envía ni cambia la etapa de un trato sin tu aprobación."
+    },
+    "support": {
+      "name": "Soporte",
+      "description": "Prioriza tickets, redacta respuestas, escribe artículos del centro de ayuda, evalúa la salud de los clientes y crea planes para evitar cancelaciones. Abarca desde la bandeja de entrada hasta el éxito del cliente, solo borradores, nunca envía."
+    },
+    "outbound": {
+      "name": "Prospección",
+      "description": "Convierte una sola publicación de LinkedIn en una campaña de correo en frío pausada en Instantly. Extraigo a quienes comentan o reaccionan, los guardo en Airtable, busco correos verificados con Apollo, escribo contigo una secuencia de 3 correos y luego cargo todo en Instantly. La campaña siempre queda en pausa para que la revises, nunca la lanzo sola."
     }
   },
   "toasts": {

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -7,6 +7,38 @@
     "blank": {
       "name": "Começar do zero",
       "description": "Um agente em branco, sem ações, instruções ou aprendizados pré-configurados. Monte do seu jeito."
+    },
+    "bookkeeping": {
+      "name": "Contabilidade",
+      "description": "Categoriza transações, concilia contas, fecha os livros todo mês e gera demonstrações financeiras prontas para investidores. Conecta com QuickBooks, Xero, Stripe e os feeds do seu banco. Prepara lançamentos contábeis e demonstrações, mas nunca registra no seu livro-razão nem movimenta dinheiro."
+    },
+    "legal": {
+      "name": "Jurídico",
+      "description": "Revisa contratos, audita a conformidade de privacidade, prepara registros em Delaware, faz buscas de marcas registradas e responde dúvidas jurídicas na hora. Prepara acordos de confidencialidade, políticas e resumos de escalonamento, mas nunca protocola, assina nem envia nada em seu nome."
+    },
+    "marketing": {
+      "name": "Marketing",
+      "description": "Define o posicionamento, planeja campanhas, escreve posts de blog e páginas de destino, audita o SEO e a visibilidade em buscas com IA, e redige sequências de e-mail. Da estratégia à execução em conteúdo, mídia paga, redes sociais e textos de conversão, tudo em rascunhos, nunca publicado."
+    },
+    "operations": {
+      "name": "Operações",
+      "description": "Prioriza sua caixa de entrada, prepara reuniões, acompanha metas, gerencia renovações com fornecedores, audita os gastos com SaaS e executa consultas de dados. Abrange planejamento, agenda, organização financeira e relatórios, apenas rascunhos, nunca envia nem confirma nada."
+    },
+    "people": {
+      "name": "Pessoas",
+      "description": "Busca e avalia candidatos, coordena rodadas de entrevistas, redige cartas de oferta, conduz ciclos de avaliação e acompanha prazos de conformidade. Abrange da contratação à retenção, apenas rascunhos, nunca envia nem modifica seus sistemas de RH."
+    },
+    "sales": {
+      "name": "Vendas",
+      "description": "Encontra leads, pesquisa contas, prepara ligações, redige mensagens de contato, gerencia seu CRM e projeta o pipeline. Abrange da prospecção à expansão, apenas rascunhos, nunca envia nem muda o estágio de uma negociação sem a sua aprovação."
+    },
+    "support": {
+      "name": "Suporte",
+      "description": "Prioriza tickets, redige respostas, escreve artigos da central de ajuda, avalia a saúde dos clientes e cria planos para evitar cancelamentos. Abrange da caixa de entrada ao sucesso do cliente, apenas rascunhos, nunca envia."
+    },
+    "outbound": {
+      "name": "Prospecção",
+      "description": "Transforma uma única publicação do LinkedIn em uma campanha de e-mail frio pausada no Instantly. Extraio quem comenta ou reage, guardo essas pessoas no Airtable, busco e-mails verificados com o Apollo, escrevo com você uma sequência de 3 e-mails e depois carrego tudo no Instantly. A campanha sempre fica pausada para você revisar, nunca disparo sozinho."
     }
   },
   "toasts": {

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -1,4 +1,14 @@
 {
+  "catalog": {
+    "personal-assistant": {
+      "name": "Assistente pessoal",
+      "description": "Um assistente de uso geral para o seu dia, sua caixa de entrada, seu calendário, seus acompanhamentos e seu trabalho recorrente."
+    },
+    "blank": {
+      "name": "Começar do zero",
+      "description": "Um agente em branco, sem ações, instruções ou aprendizados pré-configurados. Monte do seu jeito."
+    }
+  },
   "toasts": {
     "renamed": "Espaço de trabalho renomeado",
     "deleted": "Espaço de trabalho excluído",

--- a/app/tests/catalog-labels.test.ts
+++ b/app/tests/catalog-labels.test.ts
@@ -1,8 +1,7 @@
 import { strictEqual } from "node:assert/strict";
 import { describe, it } from "node:test";
 import type { TFunction } from "i18next";
-import { localizeCatalogEntry } from "../src/agents/catalog-labels.ts";
-import type { AgentDefinition } from "../src/lib/types.ts";
+import { localizeCatalogCopy } from "../src/agents/catalog-labels.ts";
 
 /**
  * Minimal i18next stub: returns the value in `table` for a known key,
@@ -14,56 +13,64 @@ function fakeT(table: Record<string, string>): TFunction {
   return t as unknown as TFunction;
 }
 
-function def(
-  source: AgentDefinition["source"],
-  config: Partial<AgentDefinition["config"]> & { id: string },
-): AgentDefinition {
-  return {
-    source,
-    config: {
-      name: "English name",
-      description: "English description",
-      ...config,
-    },
-  };
-}
-
-describe("localizeCatalogEntry", () => {
-  it("translates a builtin agent that has catalog entries", () => {
+describe("localizeCatalogCopy", () => {
+  it("translates a first-party (Houston) agent that has catalog entries", () => {
     const t = fakeT({
       "agents:catalog.personal-assistant.name": "Asistente personal",
       "agents:catalog.personal-assistant.description": "Descripción en español",
     });
-    const result = localizeCatalogEntry(def("builtin", { id: "personal-assistant" }), t);
+    const result = localizeCatalogCopy(
+      { id: "personal-assistant", name: "Personal assistant", description: "English", author: "Houston" },
+      t,
+    );
     strictEqual(result.name, "Asistente personal");
     strictEqual(result.description, "Descripción en español");
   });
 
-  it("falls back to the config strings when a builtin has no catalog entry", () => {
+  it("translates a bundled Houston store listing by id", () => {
+    const t = fakeT({
+      "agents:catalog.bookkeeping.name": "Contabilidad",
+      "agents:catalog.bookkeeping.description": "Categoriza transacciones...",
+    });
+    const result = localizeCatalogCopy(
+      { id: "bookkeeping", name: "Bookkeeping", description: "Categorize transactions...", author: "Houston" },
+      t,
+    );
+    strictEqual(result.name, "Contabilidad");
+    strictEqual(result.description, "Categoriza transacciones...");
+  });
+
+  it("falls back to the raw strings when a Houston agent has no catalog entry", () => {
     const t = fakeT({});
-    const result = localizeCatalogEntry(
-      def("builtin", { id: "future-agent", name: "Future", description: "Later" }),
+    const result = localizeCatalogCopy(
+      { id: "future-agent", name: "Future", description: "Later", author: "Houston" },
       t,
     );
     strictEqual(result.name, "Future");
     strictEqual(result.description, "Later");
   });
 
-  it("keeps an installed agent in its author's language, ignoring catalog keys", () => {
-    // Even if a catalog key collides by id, an installed (non-builtin) agent
-    // must never be relabeled — author's language wins (App Store model).
+  it("keeps a third-party agent in its author's language, ignoring catalog keys", () => {
+    // Even if a catalog key collides by id, a non-Houston agent must never be
+    // relabeled: author's language wins (App Store model).
     const t = fakeT({
-      "agents:catalog.personal-assistant.name": "SHOULD NOT APPLY",
+      "agents:catalog.bookkeeping.name": "SHOULD NOT APPLY",
     });
-    const result = localizeCatalogEntry(
-      def("installed", {
-        id: "personal-assistant",
-        name: "Community Agent",
-        description: "By some author",
-      }),
+    const result = localizeCatalogCopy(
+      { id: "bookkeeping", name: "Community Bookkeeper", description: "By some author", author: "Jane Dev" },
       t,
     );
-    strictEqual(result.name, "Community Agent");
+    strictEqual(result.name, "Community Bookkeeper");
     strictEqual(result.description, "By some author");
+  });
+
+  it("treats a missing author as third-party (no translation)", () => {
+    const t = fakeT({ "agents:catalog.sales.name": "Ventas" });
+    const result = localizeCatalogCopy(
+      { id: "sales", name: "Sales", description: "Find leads" },
+      t,
+    );
+    strictEqual(result.name, "Sales");
+    strictEqual(result.description, "Find leads");
   });
 });

--- a/app/tests/catalog-labels.test.ts
+++ b/app/tests/catalog-labels.test.ts
@@ -1,0 +1,69 @@
+import { strictEqual } from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { TFunction } from "i18next";
+import { localizeCatalogEntry } from "../src/agents/catalog-labels.ts";
+import type { AgentDefinition } from "../src/lib/types.ts";
+
+/**
+ * Minimal i18next stub: returns the value in `table` for a known key,
+ * otherwise the `defaultValue` (mirrors i18next's fallback contract).
+ */
+function fakeT(table: Record<string, string>): TFunction {
+  const t = (key: string, opts?: { defaultValue?: string }) =>
+    table[key] ?? opts?.defaultValue ?? key;
+  return t as unknown as TFunction;
+}
+
+function def(
+  source: AgentDefinition["source"],
+  config: Partial<AgentDefinition["config"]> & { id: string },
+): AgentDefinition {
+  return {
+    source,
+    config: {
+      name: "English name",
+      description: "English description",
+      ...config,
+    },
+  };
+}
+
+describe("localizeCatalogEntry", () => {
+  it("translates a builtin agent that has catalog entries", () => {
+    const t = fakeT({
+      "agents:catalog.personal-assistant.name": "Asistente personal",
+      "agents:catalog.personal-assistant.description": "Descripción en español",
+    });
+    const result = localizeCatalogEntry(def("builtin", { id: "personal-assistant" }), t);
+    strictEqual(result.name, "Asistente personal");
+    strictEqual(result.description, "Descripción en español");
+  });
+
+  it("falls back to the config strings when a builtin has no catalog entry", () => {
+    const t = fakeT({});
+    const result = localizeCatalogEntry(
+      def("builtin", { id: "future-agent", name: "Future", description: "Later" }),
+      t,
+    );
+    strictEqual(result.name, "Future");
+    strictEqual(result.description, "Later");
+  });
+
+  it("keeps an installed agent in its author's language, ignoring catalog keys", () => {
+    // Even if a catalog key collides by id, an installed (non-builtin) agent
+    // must never be relabeled — author's language wins (App Store model).
+    const t = fakeT({
+      "agents:catalog.personal-assistant.name": "SHOULD NOT APPLY",
+    });
+    const result = localizeCatalogEntry(
+      def("installed", {
+        id: "personal-assistant",
+        name: "Community Agent",
+        description: "By some author",
+      }),
+      t,
+    );
+    strictEqual(result.name, "Community Agent");
+    strictEqual(result.description, "By some author");
+  });
+});

--- a/knowledge-base/i18n.md
+++ b/knowledge-base/i18n.md
@@ -84,6 +84,12 @@ The shell renders the five `STANDARD_TABS` from `app/src/agents/standard-tabs.ts
 label: t(`agents:tabLabels.${tab.id}`, { defaultValue: tab.label })
 ```
 
+## Builtin agent catalog (new-agent store cards)
+The new-agent store (`app/src/components/shell/store-step.tsx` → `experience-card.tsx`, plus the `naming-step.tsx` header) renders one card per catalog agent. The card's `name`/`description` come from the agent's `AgentConfig`, which for third-party (`installed`) and remote store listings is authored English/whatever and must stay in the author's language.
+
+Houston's own **builtin** agents (`app/src/agents/builtin/*` — currently `personal-assistant`, `blank`) are first-party product copy and DO translate. Same id-keyed pattern as the tab labels: keys live under `agents:catalog.<id>.{name,description}` and the config strings are the English fallback. The gate lives in `localizeCatalogEntry(def, t)` (`app/src/agents/catalog-labels.ts`), which only looks up a translation when `def.source === "builtin"` — so an installed agent that happens to share a builtin id is never relabeled. Store search matches the localized strings too. Adding a new builtin agent = add its `catalog.<id>` block to en/es/pt.
+
+
 ## Style rules
 - **No em dashes (`—`, U+2014)** in user-facing copy. Use commas or sentence breaks. Validator enforces this.
 - Spanish: Latin-American neutral (computador, tú; not vos).
@@ -120,7 +126,7 @@ The "update available" card shows the release notes in the user's language. Auth
 ## What does NOT translate
 - Brand names: Houston, Claude, OpenAI, Anthropic, GitHub, Google, Gemini
 - Code identifiers, file paths, CLI commands, env var names (e.g. `GEMINI_API_KEY`)
-- Agent catalog content (store listings) — author's language wins; treated like App Store listings
+- Installed / remote agent store listings — author's language wins; treated like App Store listings. (Houston's own **builtin** agents in the new-agent store ARE translated — see "Builtin agent catalog" below.)
 - Engine-side error strings (currently English; future work: error code → i18n key map)
 - Console / log messages
 - The WebView compatibility gate ([app/public/compat-gate.js](../app/public/compat-gate.js)) — it runs before the bundle (and thus before i18next) to catch engines too old to load the app, so its en/es/pt strings live inline and are picked by `navigator.language`. Keep them in sync with the product voice (no em dashes).

--- a/knowledge-base/i18n.md
+++ b/knowledge-base/i18n.md
@@ -84,10 +84,14 @@ The shell renders the five `STANDARD_TABS` from `app/src/agents/standard-tabs.ts
 label: t(`agents:tabLabels.${tab.id}`, { defaultValue: tab.label })
 ```
 
-## Builtin agent catalog (new-agent store cards)
-The new-agent store (`app/src/components/shell/store-step.tsx` → `experience-card.tsx`, plus the `naming-step.tsx` header) renders one card per catalog agent. The card's `name`/`description` come from the agent's `AgentConfig`, which for third-party (`installed`) and remote store listings is authored English/whatever and must stay in the author's language.
+## First-party agent catalog (new-agent store cards)
+The new-agent store (`app/src/components/shell/store-step.tsx` → `experience-card.tsx`, plus the `naming-step.tsx` header) renders one card per catalog agent. Two feeds land here:
+- **builtin** agents (`app/src/agents/builtin/*` — `personal-assistant`, `blank`), rendered as `AgentCard`;
+- the **bundled store catalog** (`store/catalog.json` → engine `store/bundled.rs` → `fetch_store_catalog`), e.g. `bookkeeping`, `legal`, `marketing`, `operations`, `people`, `sales`, `support`, `outbound`, rendered as `StoreAgentCard`.
 
-Houston's own **builtin** agents (`app/src/agents/builtin/*` — currently `personal-assistant`, `blank`) are first-party product copy and DO translate. Same id-keyed pattern as the tab labels: keys live under `agents:catalog.<id>.{name,description}` and the config strings are the English fallback. The gate lives in `localizeCatalogEntry(def, t)` (`app/src/agents/catalog-labels.ts`), which only looks up a translation when `def.source === "builtin"` — so an installed agent that happens to share a builtin id is never relabeled. Store search matches the localized strings too. Adding a new builtin agent = add its `catalog.<id>` block to en/es/pt.
+Both feeds are authored by Houston (`author: "Houston"`) and are first-party product copy, so they DO translate. Same id-keyed pattern as the tab labels: keys live under `agents:catalog.<id>.{name,description}` and the catalog's own strings are the English fallback. The gate lives in `localizeCatalogCopy(entry, t)` (`app/src/agents/catalog-labels.ts`), which localizes only when `entry.author === "Houston"` — so a third-party / community agent that happens to share a first-party id is never relabeled (author's language wins). It takes the minimal `{ id, name, description, author }` shape, so both `AgentConfig` and `StoreListing` pass straight in. Store search matches the localized strings too.
+
+**Adding a new first-party agent** (builtin or a new `store/catalog.json` entry) = add its `catalog.<id>.{name,description}` block to en/es/pt `agents.json`. English mirrors the catalog copy (source of truth stays in `store/catalog.json` / the builtin config); es/pt are the real translations. `pnpm check-locales` enforces that all three locales carry the same `catalog.<id>` keys.
 
 
 ## Style rules
@@ -126,7 +130,7 @@ The "update available" card shows the release notes in the user's language. Auth
 ## What does NOT translate
 - Brand names: Houston, Claude, OpenAI, Anthropic, GitHub, Google, Gemini
 - Code identifiers, file paths, CLI commands, env var names (e.g. `GEMINI_API_KEY`)
-- Installed / remote agent store listings — author's language wins; treated like App Store listings. (Houston's own **builtin** agents in the new-agent store ARE translated — see "Builtin agent catalog" below.)
+- **Third-party / community** agent store listings — author's language wins; treated like App Store listings. (Houston's own **first-party** agents in the new-agent store ARE translated — see "First-party agent catalog" below.)
 - Engine-side error strings (currently English; future work: error code → i18n key map)
 - Console / log messages
 - The WebView compatibility gate ([app/public/compat-gate.js](../app/public/compat-gate.js)) — it runs before the bundle (and thus before i18next) to catch engines too old to load the app, so its en/es/pt strings live inline and are picked by `navigator.language`. Keep them in sync with the product voice (no em dashes).


### PR DESCRIPTION
## Root cause

Opening the new-agent store showed everything in English even with the app language set to Spanish/Portuguese:

- The two **first-party builtin** agents (`personal-assistant`, `blank`) render their `name`/`description` straight from `AgentConfig`, which is hardcoded English. The store cards (`experience-card.tsx`) and the naming-step header (`naming-step.tsx`) both surfaced it untranslated.
- The in-store model picker (`InlineModelSelector`) rendered raw `m.description` (per-model help copy from `PROVIDERS`) in English, while the chat model selector already translates the same strings.

Remote/installed store listings were already correct (author's language wins, App Store model) — those are untouched.

## Fix

- New helper `localizeCatalogEntry(def, t)` (`app/src/agents/catalog-labels.ts`) that localizes **only** builtin agents via `agents:catalog.<id>.{name,description}`, with the in-code config strings as the English fallback. Gated on `def.source === "builtin"`, so an installed agent that happens to share a builtin id is never relabeled.
- Wired into `store-step.tsx` (cards + search matching) and `naming-step.tsx` (header). Cards relabel live on language switch (`useMemo` keyed on `i18n.language`).
- `AgentCard` gains optional `title`/`description` overrides (default to config), keeping it i18n-agnostic.
- `InlineModelSelector` now reads model help copy from the existing, already-translated `chat:modelSelector.modelDescriptions.<id>` keys instead of raw `m.description` — no new copy needed.
- Added `catalog` subtree to `en/es/pt` `agents.json` (es = LatAm neutral, pt = Brazilian, no em dashes). Also dropped a stray em dash from the `blank` fallback description.
- Documented the builtin-vs-remote catalog translation rule in `knowledge-base/i18n.md`.

## Tests / gates

- `app/tests/catalog-labels.test.ts` — 3 cases: builtin translates, builtin-without-key falls back, installed stays author-language.
- `pnpm typecheck` ✓ · `pnpm check-locales` ✓ (es/pt in sync) · `pnpm test` ✓ (353/353).
- Adversarially verified via a multi-agent sweep of the whole wizard: only the model-description gap surfaced (now fixed); es/pt copy reviewed clean; diff reviewed for regressions (persisted agent name unaffected, reorder-pin intact, search correct).

## Verify

**Before:** Set the app language to Spanish (Settings → language), open **New agent**. The "Personal assistant" / "Start from scratch" cards, the naming-step header, and the model-picker descriptions all show English.

**After:** Same steps show "Asistente personal" / "Empezar desde cero" (and Portuguese equivalents), a translated naming header, and translated model descriptions. Switching language live relabels the store. Installed/remote store agents still show in their author's language.

Closes HOU-587.