### PR TITLE
release: v0.4.26

### DIFF
--- a/.github/release-notes/0.4.26.es.md
+++ b/.github/release-notes/0.4.26.es.md
@@ -1,0 +1,30 @@
+## Houston 0.4.26
+
+### Correcciones en el selector de modelos
+
+- **Claude Sonnet 5 ahora usa su ventana de contexto completa de 1M.** Una
+  versión anterior le mostraba un límite más pequeño por error, así que las
+  misiones largas se llenaban muy rápido. Sonnet 5 ahora mantiene un millón
+  completo de tokens de contexto en cada mensaje.
+- **Fable 5 vuelve al selector.** Se quitó por error en una versión reciente.
+  Puedes elegirlo otra vez por agente o por misión.
+
+### Ahora en tu idioma
+
+- **La tienda de nuevos agentes habla español y portugués.** Los agentes
+  integrados y el selector de modelos dentro de la tienda estaban en inglés.
+  Ahora siguen el idioma de tu app, así que toda la tienda se lee en español o
+  portugués.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza bien una
+  app que sigue abierta. Si tienes dudas, elimina `/Applications/Houston.app` y
+  arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde 0.4.7 o posterior te lleva
+  a esta versión automáticamente. El MSI todavía no está firmado a nivel de
+  sistema operativo, así que Windows SmartScreen puede mostrar una advertencia en
+  una instalación nueva.
+- **Windows ARM64:** no hay ruta de actualización automática desde una instalación
+  x64 emulada. Descarga el MSI ARM64 manualmente, desinstala primero la versión
+  x64 y luego instala la ARM64.

--- a/.github/release-notes/0.4.26.es.md
+++ b/.github/release-notes/0.4.26.es.md
@@ -1,20 +1,18 @@
 ## Houston 0.4.26
 
-### Correcciones en el selector de modelos
+### Modelos
 
-- **Claude Sonnet 5 ahora usa su ventana de contexto completa de 1M.** Una
-  versión anterior le mostraba un límite más pequeño por error, así que las
-  misiones largas se llenaban muy rápido. Sonnet 5 ahora mantiene un millón
-  completo de tokens de contexto en cada mensaje.
-- **Fable 5 vuelve al selector.** Se quitó por error en una versión reciente.
-  Puedes elegirlo otra vez por agente o por misión.
+- **Claude Sonnet 5 funciona con una ventana de contexto completa de 1M.** Es un
+  millón completo de tokens de contexto en cada mensaje, así que las misiones
+  largas conservan mucho más de su historial.
+- **Fable 5 está en el selector de modelos.** Puedes elegirlo por agente o por
+  misión.
 
 ### Ahora en tu idioma
 
 - **La tienda de nuevos agentes habla español y portugués.** Los agentes
-  integrados y el selector de modelos dentro de la tienda estaban en inglés.
-  Ahora siguen el idioma de tu app, así que toda la tienda se lee en español o
-  portugués.
+  integrados y el selector de modelos dentro de la tienda ahora siguen el idioma
+  de tu app, así que toda la tienda se lee en español o portugués.
 
 ### Antes de actualizar
 

--- a/.github/release-notes/0.4.26.md
+++ b/.github/release-notes/0.4.26.md
@@ -1,18 +1,17 @@
 ## Houston 0.4.26
 
-### Model picker fixes
+### Models
 
-- **Claude Sonnet 5 now uses its full 1M context window.** An earlier build
-  showed it a smaller limit by mistake, so long missions filled up too fast.
-  Sonnet 5 now keeps a full million tokens of context on every message.
-- **Fable 5 is back in the picker.** It was pulled by mistake in a recent build.
-  You can pick it per agent or per mission again.
+- **Claude Sonnet 5 runs with a full 1M context window.** That is a full million
+  tokens of context on every message, so long missions hold much more of their
+  history.
+- **Fable 5 is in the model picker.** Pick it per agent or per mission.
 
 ### Now in your language
 
 - **The new-agent store speaks Spanish and Portuguese.** The built-in agents and
-  the model picker inside the store were stuck in English. They now follow your
-  app language, so the whole store reads in Spanish or Portuguese.
+  the model picker inside the store now follow your app language, so the whole
+  store reads in Spanish or Portuguese.
 
 ### Before you upgrade
 

--- a/.github/release-notes/0.4.26.md
+++ b/.github/release-notes/0.4.26.md
@@ -1,0 +1,27 @@
+## Houston 0.4.26
+
+### Model picker fixes
+
+- **Claude Sonnet 5 now uses its full 1M context window.** An earlier build
+  showed it a smaller limit by mistake, so long missions filled up too fast.
+  Sonnet 5 now keeps a full million tokens of context on every message.
+- **Fable 5 is back in the picker.** It was pulled by mistake in a recent build.
+  You can pick it per agent or per mission again.
+
+### Now in your language
+
+- **The new-agent store speaks Spanish and Portuguese.** The built-in agents and
+  the model picker inside the store were stuck in English. They now follow your
+  app language, so the whole store reads in Spanish or Portuguese.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a
+  running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag
+  the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward
+  automatically. The MSI is still not OS-code-signed, so Windows SmartScreen may
+  warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install.
+  Download the ARM64 MSI manually, uninstall the x64 build first, then install
+  the ARM64 one.

--- a/.github/release-notes/0.4.26.pt.md
+++ b/.github/release-notes/0.4.26.pt.md
@@ -1,19 +1,18 @@
 ## Houston 0.4.26
 
-### Correções no seletor de modelos
+### Modelos
 
-- **O Claude Sonnet 5 agora usa a janela de contexto completa de 1M.** Uma versão
-  anterior mostrava um limite menor por engano, então as missões longas enchiam
-  rápido demais. O Sonnet 5 agora mantém um milhão completo de tokens de contexto
-  em cada mensagem.
-- **O Fable 5 voltou ao seletor.** Ele foi removido por engano em uma versão
-  recente. Você pode escolhê-lo de novo por agente ou por missão.
+- **O Claude Sonnet 5 funciona com uma janela de contexto completa de 1M.** É um
+  milhão completo de tokens de contexto em cada mensagem, então as missões longas
+  guardam muito mais do seu histórico.
+- **O Fable 5 está no seletor de modelos.** Você pode escolhê-lo por agente ou por
+  missão.
 
 ### Agora no seu idioma
 
 - **A loja de novos agentes fala espanhol e português.** Os agentes integrados e
-  o seletor de modelos dentro da loja estavam em inglês. Agora eles seguem o
-  idioma do seu app, então a loja inteira aparece em espanhol ou português.
+  o seletor de modelos dentro da loja agora seguem o idioma do seu app, então a
+  loja inteira aparece em espanhol ou português.
 
 ### Antes de atualizar
 

--- a/.github/release-notes/0.4.26.pt.md
+++ b/.github/release-notes/0.4.26.pt.md
@@ -1,0 +1,29 @@
+## Houston 0.4.26
+
+### Correções no seletor de modelos
+
+- **O Claude Sonnet 5 agora usa a janela de contexto completa de 1M.** Uma versão
+  anterior mostrava um limite menor por engano, então as missões longas enchiam
+  rápido demais. O Sonnet 5 agora mantém um milhão completo de tokens de contexto
+  em cada mensagem.
+- **O Fable 5 voltou ao seletor.** Ele foi removido por engano em uma versão
+  recente. Você pode escolhê-lo de novo por agente ou por missão.
+
+### Agora no seu idioma
+
+- **A loja de novos agentes fala espanhol e português.** Os agentes integrados e
+  o seletor de modelos dentro da loja estavam em inglês. Agora eles seguem o
+  idioma do seu app, então a loja inteira aparece em espanhol ou português.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui bem uma
+  app que ainda está aberta. Na dúvida, remova `/Applications/Houston.app` e
+  arraste a nova cópia.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou mais recente
+  leva você para esta versão automaticamente. O MSI ainda não é assinado no nível
+  do sistema operacional, então o Windows SmartScreen pode mostrar um aviso em
+  uma instalação nova.
+- **Windows ARM64:** não há caminho de atualização automática a partir de uma
+  instalação x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a
+  versão x64 e depois instale a ARM64.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "futures-util",
  "hex",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "serde",
  "serde_json",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.25"
+version = "0.4.26"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.25", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.25", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.25", path = "app/houston-tauri" }
-houston-events = { version = "0.4.25", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.25", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.25", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.25", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.25", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.25", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.25", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.25", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.25", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.25", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.25", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.25", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.25", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.25", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.25", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.26", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.26", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.26", path = "app/houston-tauri" }
+houston-events = { version = "0.4.26", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.26", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.26", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.26", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.26", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.26", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.26", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.26", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.26", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.26", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.26", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.26", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.26", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.26", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.26", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.25",
+  "version": "0.4.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.25"
+version = "0.4.26"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.25",
+  "version": "0.4.26",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Cuts Houston **v0.4.26** (patch). Bumps every shared-version package 0.4.25 → 0.4.26, regenerates `Cargo.lock`, and adds hand-written release notes in en/es/pt.

## What ships (two app fixes landed since v0.4.25)

- **Sonnet 5 context window fix + Fable 5 restored** (HOU-618, #581). Sonnet 5 now uses its full flat 1M context window instead of the wrong credit-gated 200k→1M snap it inherited from Sonnet 4.6; `max` effort stays; Fable 5 is back in the model picker.
- **New-agent store localized** (HOU-587, #582). The built-in agent catalog and the in-store model picker now follow the app language (Spanish / Portuguese) instead of showing English on every install.

## Release notes

- `.github/release-notes/0.4.26.md` (English base, GitHub release body)
- `.github/release-notes/0.4.26.es.md` (Latin-American Spanish, in-app update card)
- `.github/release-notes/0.4.26.pt.md` (Brazilian Portuguese, in-app update card)

Audience is updating users: Sonnet 5 fix, Fable 5 return, store now in your language. No em dashes; boilerplate upgrade caveats carried over from 0.4.25.

## Verification

- `cargo check --workspace` — pass (regenerated `Cargo.lock` to 0.4.26)
- `cd app && pnpm tsc --noEmit` — pass (exit 0)
- Notes guarded: no `—`, no `-->`
- Diff is version-lines-only; independently-versioned UI packages (agent, agent-schemas, engine-client, sync-protocol) correctly untouched

## After merge

Tag `v0.4.26` on `main` and push the tag. CI (`release.yml`) builds the 2-arch universal `.app`, signs + notarizes, and creates a **draft** GH Release using `0.4.26.md` verbatim. Publishing the draft stays a manual human step.

**Do not merge yet** per request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)