### PR TITLE
ci: build desktop app with the TypeScript host sidecar (HOU-628)

### DIFF
--- a/.github/workflows/engine-release.yml
+++ b/.github/workflows/engine-release.yml
@@ -1,10 +1,30 @@
-name: Engine Release
+name: Host Engine Release
+
+# Builds the standalone Houston HOST binary — the bun-compiled TypeScript engine —
+# for bare-metal / self-host use. This is the SAME self-contained binary the
+# desktop app embeds as its sidecar (scripts/build-host-sidecar.sh) and the one a
+# `selfhost/` operator can run directly instead of the Docker image. Replaces the
+# legacy Rust `houston-engine` build. Fires on an `engine-v*` tag or manually.
+#
+# ONE binary, TWO roles (packages/host/src/sidecar-entry.ts): it runs as the
+# local HOST by default, or as a pi RUNTIME when HOUSTON_SIDECAR_ROLE=runtime (the
+# host spawns itself in runtime mode). `bun build --compile` embeds the Bun
+# runtime, so the binary needs no bun/node installed to run. No provider CLIs are
+# bundled — pi talks to providers in-process.
 
 on:
   push:
     tags:
       - "engine-v*"
   workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  # Same Bun pin the desktop release + cli-deps.json use, so every compiled host
+  # binary is byte-reproducible regardless of which workflow built it.
+  BUN_VERSION: "1.3.10"
 
 jobs:
   build:
@@ -14,35 +34,60 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - target: x86_64-unknown-linux-musl
+          # Native legs — `--verify` boots the binary and curls /v1/capabilities.
+          - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: aarch64-unknown-linux-musl
-            os: ubuntu-latest
+            verify: "--verify"
           - target: aarch64-apple-darwin
             os: macos-latest
+            verify: "--verify"
+          # Cross legs — Bun links its own libc, so same-OS cross-arch compiles,
+          # but the binary can't boot on this runner, so no `--verify`.
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            verify: ""
           - target: x86_64-apple-darwin
             os: macos-latest
+            verify: ""
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
         with:
-          targets: ${{ matrix.target }}
-      - name: Install musl tooling
-        if: contains(matrix.target, 'musl')
-        run: sudo apt-get update && sudo apt-get install -y musl-tools
-      - name: Build houston-engine
+          node-version: 20
+          cache: pnpm
+
+      # build-host-sidecar.sh bun-bundles packages/host/src/sidecar-entry.ts,
+      # which imports across the workspace — so node_modules must exist first.
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Compile Houston host binary (${{ matrix.target }})
         run: |
-          cargo build --release --target ${{ matrix.target }} \
-            -p houston-engine-server --bin houston-engine
+          set -euo pipefail
+          scripts/build-host-sidecar.sh ${{ matrix.target }} ${{ matrix.verify }}
+
       - name: Package
         run: |
+          set -euo pipefail
           mkdir -p dist
-          cp target/${{ matrix.target }}/release/houston-engine \
-            dist/houston-engine-${{ matrix.target }}
-          chmod +x dist/houston-engine-${{ matrix.target }}
+          cp "target/host-sidecar/houston-host-${{ matrix.target }}" \
+            "dist/houston-host-${{ matrix.target }}"
+          chmod +x "dist/houston-host-${{ matrix.target }}"
+          ls -lah dist/
+
       - uses: actions/upload-artifact@v7
         with:
-          name: houston-engine-${{ matrix.target }}
+          name: houston-host-${{ matrix.target }}
           path: dist/*
 
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@
 # `--features host-sidecar` + `VITE_NEW_ENGINE=1` (the frontend aliases to the v3
 # host adapter). No provider CLIs are bundled — pi runs providers in-process — so
 # the codex/composio/git-bash staging the Rust path needed is gone. Ships macOS
-# (universal DMG) + Windows (x64/arm64 MSI) + Linux (x64 AppImage + .deb).
+# (universal DMG) + Windows (x64/arm64 MSI) + Linux (x64 AppImage).
 #
 # Signing chain (macOS):
 #   1. tauri-action builds, signs, notarizes, and staples the .app
@@ -1059,12 +1059,14 @@ jobs:
           echo "::warning::This MSI is UNSIGNED (code-signing wise) — Windows SmartScreen will warn on first install. The updater minisign signature above is separate; it covers in-app auto-update verification, not OS code-signing. SignPath integration lands in a follow-up PR."
 
   # ============================================================================
-  # Linux desktop build — x86_64 AppImage + .deb. Runs IN PARALLEL with the mac
-  # and Windows jobs, uploading into the same draft. NEW with the TS engine: the
+  # Linux desktop build — x86_64 AppImage. Runs IN PARALLEL with the mac and
+  # Windows jobs, uploading into the same draft. NEW with the TS engine: the
   # CLI-free host makes a Linux desktop build viable for the first time (the Rust
   # path bundled per-arch provider CLIs that never had Linux builds). The
-  # tauri.conf.json bundle.targets stay app/dmg/msi — Linux bundles are requested
-  # on the CLI via `--bundles deb,appimage`, so the default config is untouched.
+  # tauri.conf.json bundle.targets stay app/dmg/msi — the AppImage bundle is
+  # requested on the CLI via `--bundles appimage`, so the default config is
+  # untouched. (.deb intentionally not built — AppImage is the single Linux
+  # artifact; a .deb would need its own apt/repo + GPG story to be worth it.)
   #
   # UNSIGNED + NOT wired into the auto-updater (latest.json is macOS + Windows
   # only; `finalize` doesn't add a Linux entry). Download-only, for testing.
@@ -1144,11 +1146,11 @@ jobs:
           chmod +x "$SHIM_DIR/ldd"
           echo "$SHIM_DIR" >> "$GITHUB_PATH"
 
-      - name: Build Tauri app (Linux AppImage + deb)
+      - name: Build Tauri app (Linux AppImage)
         uses: tauri-apps/tauri-action@v0
         with:
           projectPath: app
-          args: --target x86_64-unknown-linux-gnu --features host-sidecar --bundles deb,appimage
+          args: --target x86_64-unknown-linux-gnu --features host-sidecar --bundles appimage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
@@ -1159,28 +1161,22 @@ jobs:
           LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
           SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
 
-      - name: Locate Linux artifacts
+      - name: Locate Linux artifact
         id: artifacts-linux
         run: |
           set -euo pipefail
           BUNDLE="target/x86_64-unknown-linux-gnu/release/bundle"
           APPIMAGE=$(ls -t "$BUNDLE/appimage/"*.AppImage 2>/dev/null | head -1 || true)
-          DEB=$(ls -t "$BUNDLE/deb/"*.deb 2>/dev/null | head -1 || true)
 
-          missing=()
-          [ -f "$APPIMAGE" ] || missing+=("AppImage")
-          [ -f "$DEB" ] || missing+=(".deb")
-          if [ ${#missing[@]} -gt 0 ]; then
-            echo "::error::Missing Linux build artifacts: ${missing[*]}"
+          if [ ! -f "$APPIMAGE" ]; then
+            echo "::error::Missing Linux build artifact: AppImage"
             ls -laR "$BUNDLE" 2>&1 | head -50 || true
             exit 1
           fi
 
           echo "appimage=$APPIMAGE" >> "$GITHUB_OUTPUT"
-          echo "deb=$DEB" >> "$GITHUB_OUTPUT"
-          echo "Artifacts:"
+          echo "Artifact:"
           echo "  AppImage: $APPIMAGE ($(du -sh "$APPIMAGE" | cut -f1))"
-          echo "  .deb:     $DEB ($(du -sh "$DEB" | cut -f1))"
 
       - name: Upload source maps + Rust debug symbols to Sentry (linux x64)
         if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
@@ -1217,7 +1213,6 @@ jobs:
         run: |
           sha256sum \
             "${{ steps.artifacts-linux.outputs.appimage }}" \
-            "${{ steps.artifacts-linux.outputs.deb }}" \
             > checksums-linux-sha256.txt
           cat checksums-linux-sha256.txt
 
@@ -1227,11 +1222,10 @@ jobs:
         run: |
           gh release upload "$GITHUB_REF_NAME" \
             "${{ steps.artifacts-linux.outputs.appimage }}" \
-            "${{ steps.artifacts-linux.outputs.deb }}" \
             checksums-linux-sha256.txt \
             --clobber
 
-          echo "::notice::Linux artifacts uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
+          echo "::notice::Linux AppImage uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
 
   # ============================================================================
   # Stitch the parallel mac + win builds into one finished draft release.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,16 @@
-# Houston macOS Release Workflow
+# Houston Desktop Release Workflow (TypeScript engine)
 #
 # Triggered by pushing a version tag (e.g. `git tag v0.3.0 && git push --tags`).
 #
-# Signing chain:
+# Builds the desktop app around the Bun-compiled Houston HOST sidecar (the single
+# TypeScript engine), NOT the legacy Rust `houston-engine`. Each platform job
+# bun-compiles the host via `scripts/build-host-sidecar.sh` and builds Tauri with
+# `--features host-sidecar` + `VITE_NEW_ENGINE=1` (the frontend aliases to the v3
+# host adapter). No provider CLIs are bundled — pi runs providers in-process — so
+# the codex/composio/git-bash staging the Rust path needed is gone. Ships macOS
+# (universal DMG) + Windows (x64/arm64 MSI) + Linux (x64 AppImage + .deb).
+#
+# Signing chain (macOS):
 #   1. tauri-action builds, signs, notarizes, and staples the .app
 #   2. tauri-action creates and signs the DMG (but does NOT notarize it — known Tauri gap)
 #   3. This workflow notarizes and staples the DMG (with retry)
@@ -40,6 +48,12 @@ on:
 
 permissions:
   contents: write
+
+# Bun version used to compile the Houston host sidecar (the TS engine), shared by
+# every platform job so the compiled binary is reproducible. Matches the version
+# the repo already pins elsewhere (cli-deps.json).
+env:
+  BUN_VERSION: "1.3.10"
 
 jobs:
   # Lightweight orchestration job that runs before the heavy builds. It
@@ -264,6 +278,11 @@ jobs:
     # without the secret, so forks keep skipping the upload.
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      # Frontend build flag: aliases @houston-ai/engine-client to the v3 host
+      # adapter (app/vite.config.ts `useHost`) so the packaged app talks to the
+      # bun-compiled host sidecar, not the legacy Rust wire. Job-level so every
+      # step — including tauri-action's beforeBuildCommand child — sees it.
+      VITE_NEW_ENGINE: "1"
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -307,70 +326,23 @@ jobs:
           mkdir -p ~/.appstoreconnect/private_keys
           echo "${{ secrets.APPLE_API_KEY_CONTENT }}" | base64 --decode > ~/.appstoreconnect/private_keys/AuthKey_${{ secrets.APPLE_API_KEY }}.p8
 
-      # Stage bundled CLI binaries (codex universal, composio per-arch)
-      # into `app/src-tauri/resources/bin/` so Tauri's `bundle.resources`
-      # picks them up. The fetch script:
-      #   - Downloads each CLI for both arches from URLs pinned in
-      #     cli-deps.json
-      #   - Verifies SHA-256 against pinned checksums (any mismatch
-      #     fails the release — release artifacts must be reproducible)
-      #   - lipos codex into a single universal Mach-O binary
-      #   - Prunes cross-platform composio acp-adapters that the
-      #     resolved arch can never execute (saves ~580 MB)
-      #   - Stages cli-deps.json itself so the runtime claude-code
-      #     installer can read pinned URLs + checksums offline
-      #
-      # macos-latest comes with curl + unzip + jq + lipo preinstalled.
-      # If a future runner image drops jq, install it explicitly
-      # rather than rewriting the script in a dep-free language; jq is
-      # the right tool for cli-deps.json.
-      - name: Stage bundled CLI dependencies (codex, composio)
-        run: |
-          set -euo pipefail
-          if ! command -v jq >/dev/null 2>&1; then
-            echo "::group::Installing jq (missing on runner)"
-            brew install jq
-            echo "::endgroup::"
-          fi
-          ./scripts/fetch-cli-deps.sh both
+      # The TS engine bundles NO provider CLIs (pi runs providers in-process), so
+      # the codex/composio staging + SHA-verify the Rust path did is gone. All we
+      # need is Bun to compile the host sidecar in the next steps.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
 
-          echo "=== Staged bundle ==="
-          ls -lah app/src-tauri/resources/bin/
-          echo "=== Sizes ==="
-          du -sh app/src-tauri/resources/bin/*
-
-          # Sanity: every shippable artifact must be present and the
-          # codex binary must be a fat (universal) Mach-O.
-          test -x app/src-tauri/resources/bin/codex
-          test -x app/src-tauri/resources/bin/composio-aarch64/composio
-          test -x app/src-tauri/resources/bin/composio-x86_64/composio
-          test -f app/src-tauri/resources/bin/cli-deps.json
-
-          LIPO_INFO=$(lipo -info app/src-tauri/resources/bin/codex)
-          echo "$LIPO_INFO"
-          echo "$LIPO_INFO" | grep -q 'arm64' \
-            || { echo "::error::bundled codex missing arm64 slice"; exit 1; }
-          echo "$LIPO_INFO" | grep -q 'x86_64' \
-            || { echo "::error::bundled codex missing x86_64 slice"; exit 1; }
-
-      # Import the Developer ID certificate into a temporary keychain so
-      # we can pre-sign the bundled CLI binaries (codex + composio) BEFORE
-      # tauri-action runs.
-      #
-      # Why pre-sign here:
-      #   tauri-action calls `codesign --force --deep` on the .app bundle,
-      #   which signs the main app + frameworks + helpers but does NOT
-      #   recurse into nested directories under `Resources/`. Result:
-      #   `Resources/bin/composio-aarch64/composio` (one level deeper than
-      #   `Resources/bin/codex`) ships UNSIGNED, and Apple notary rejects
-      #   the .app with "signature invalid / no secure timestamp / hardened
-      #   runtime not enabled" on those nested binaries.
-      #
-      # Pre-signing each Mach-O at stage time with Developer ID + hardened
-      # runtime + secure timestamp leaves a valid signature in place that
-      # tauri-action's deep sign won't disturb (it skips files inside
-      # nested Resources/ subdirs entirely).
-      - name: Import Apple Developer ID for pre-signing bundled CLIs
+      # Import the Developer ID certificate into a temporary keychain and add it
+      # to the user search list. tauri-action imports its OWN cert for the .app
+      # sign, but the later "Re-sign DMG after volume rename" step runs a bare
+      # `codesign --sign "$APPLE_SIGNING_IDENTITY"` and needs the identity
+      # resolvable in a keychain — this step is what keeps it there. (The Rust
+      # path also used this keychain to pre-sign nested CLI binaries; the TS host
+      # sidecar sits directly in Contents/MacOS/, so tauri-action's deep sign
+      # reaches it and no pre-signing is needed.)
+      - name: Import Apple Developer ID (keychain for DMG re-signing)
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -400,72 +372,41 @@ jobs:
 
           rm -f "$CERT_FILE"
 
-      - name: Pre-sign bundled CLI binaries (Developer ID + hardened runtime + timestamp)
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
-        run: |
-          set -euo pipefail
-          BIN=app/src-tauri/resources/bin
-          for f in "$BIN/codex" \
-                   "$BIN/composio-aarch64/composio" \
-                   "$BIN/composio-x86_64/composio" \
-                   "$BIN/gemini-aarch64/gemini" \
-                   "$BIN/gemini-x86_64/gemini"; do
-            echo "=== Signing $f ==="
-            codesign --force --options runtime --timestamp \
-              --sign "$APPLE_SIGNING_IDENTITY" "$f"
-            codesign -dvv "$f" 2>&1 | grep -E '^(Authority|TeamIdentifier|Timestamp|CodeDirectory)' || true
-          done
-
-      # Build the engine sidecar for BOTH macOS architectures BEFORE the
-      # Tauri app build.
+      # Compile the Houston HOST sidecar (the TS engine) for BOTH macOS arches,
+      # then lipo them into the single universal binary Tauri's
+      # `--target universal-apple-darwin` bundler expects at
+      # `binaries/houston-engine-universal-apple-darwin`.
       #
-      # Tauri's universal-apple-darwin build invokes cargo once per real
-      # triple (aarch64 + x86_64) and expects per-triple sidecars at
-      # `src-tauri/binaries/houston-engine-<triple>`. `build.rs` copies them
-      # there, but it needs the underlying binary to exist for the triple
-      # cargo is currently compiling for. So we build BOTH up front.
-      #
-      # Shipping an Intel-only or arm64-only engine would break half of our
-      # Mac users — so a missing triple fails hard here rather than producing
-      # a silently-broken DMG.
-      - name: Build houston-engine sidecar (aarch64 + x86_64) + lipo universal
+      # `scripts/build-host-sidecar.sh <triple>` bun-compiles a self-contained
+      # binary (embeds the Bun runtime — no `bun`/node needed at runtime) to
+      # `target/host-sidecar/houston-host-<triple>`. Bun links its own libc, so
+      # one macOS runner cross-compiles both arches. `build.rs::stage_host_sidecar`
+      # (the `host-sidecar` cargo feature) also stages per-triple copies to
+      # `binaries/houston-engine-<triple>` during tauri's per-arch cargo runs;
+      # the fat binary we lipo here is what the universal bundle actually ships.
+      # A missing arch would break half of our Mac users, so fail hard.
+      - name: Compile Houston host sidecar (aarch64 + x86_64) + lipo universal
         run: |
           set -euo pipefail
           for TRIPLE in aarch64-apple-darwin x86_64-apple-darwin; do
-            echo "=== Building houston-engine for $TRIPLE ==="
-            cargo build --release --target "$TRIPLE" -p houston-engine-server
-            test -x "target/$TRIPLE/release/houston-engine" \
-              || { echo "::error::engine binary missing for $TRIPLE"; exit 1; }
-            # Pack DWARF into a .dSYM right after the build, while the per-object
-            # (.o) files the debug map points at are still on disk and unmoved.
-            # `debug = "line-tables-only"` keeps line tables in the .o, not in
-            # the linked Mach-O, so without this Sentry can only show function
-            # names (no file:line) for engine panics. Uploaded in the Sentry
-            # step below.
-            dsymutil "target/$TRIPLE/release/houston-engine" \
-              -o "target/$TRIPLE/release/houston-engine.dSYM"
+            echo "=== Bun-compiling host sidecar for $TRIPLE ==="
+            scripts/build-host-sidecar.sh "$TRIPLE"
+            test -x "target/host-sidecar/houston-host-$TRIPLE" \
+              || { echo "::error::host sidecar missing for $TRIPLE"; exit 1; }
           done
 
-          # Tauri's `--target universal-apple-darwin` bundler looks for a
-          # SINGLE fat binary at `binaries/houston-engine-universal-apple-darwin`.
-          # `build.rs` stages per-triple binaries during the per-arch cargo
-          # invocations (aarch64 + x86_64), but there's no cargo target for
-          # "universal-apple-darwin" — so nothing stages the fat one.
-          # We lipo the two per-arch outputs manually here, before tauri-action
-          # runs, so the bundler finds it.
           echo "=== Lipo universal sidecar ==="
           mkdir -p app/src-tauri/binaries
           lipo -create \
-            target/aarch64-apple-darwin/release/houston-engine \
-            target/x86_64-apple-darwin/release/houston-engine \
+            target/host-sidecar/houston-host-aarch64-apple-darwin \
+            target/host-sidecar/houston-host-x86_64-apple-darwin \
             -output app/src-tauri/binaries/houston-engine-universal-apple-darwin
           chmod +x app/src-tauri/binaries/houston-engine-universal-apple-darwin
           lipo -info app/src-tauri/binaries/houston-engine-universal-apple-darwin
 
           ls -la \
-            target/aarch64-apple-darwin/release/houston-engine \
-            target/x86_64-apple-darwin/release/houston-engine \
+            target/host-sidecar/houston-host-aarch64-apple-darwin \
+            target/host-sidecar/houston-host-x86_64-apple-darwin \
             app/src-tauri/binaries/houston-engine-universal-apple-darwin
 
       # Build only — no release creation (no tagName).
@@ -481,7 +422,7 @@ jobs:
         uses: tauri-apps/tauri-action@v0
         with:
           projectPath: app
-          args: --target universal-apple-darwin
+          args: --target universal-apple-darwin --features host-sidecar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -546,82 +487,12 @@ jobs:
           echo "=== Notarization staple ==="
           xcrun stapler validate "${{ steps.artifacts.outputs.app }}"
 
-      # Explicit assertions on the bundled `houston-engine` sidecar.
-      # `--deep` above validates all embedded binaries, but a regression in
-      # tauri-action could silently ship an ad-hoc-signed or
-      # hardened-runtime-less sidecar — Gatekeeper would then quarantine-kill
-      # it on first launch for upgraders and the app hangs at splash.
-      # Fail the release if any of these invariants drifts.
-      # Bundled CLI invariants — codex, composio per-arch + the
-      # cli-deps.json manifest must all be present inside the
-      # `.app/Contents/Resources/bin/` tree, and every Mach-O must be
-      # signed with Developer ID + hardened runtime so Gatekeeper +
-      # subprocess execution work post-notarization.
-      #
-      # We assert every check that, if violated, would visibly break
-      # the user experience: missing files, ad-hoc signatures (Gatekeeper
-      # quarantine), missing arch slices, and broken codex universal
-      # layout. Any failure is fatal — a release where the bundled CLI
-      # works for half of users is worse than no release.
-      - name: Verify bundled CLI invariants
-        run: |
-          set -euo pipefail
-          APP="${{ steps.artifacts.outputs.app }}"
-          BIN="$APP/Contents/Resources/bin"
-
-          echo "=== 1. Bundle layout ==="
-          test -d "$BIN" || { echo "::error::Resources/bin/ missing"; exit 1; }
-          test -x "$BIN/codex" || { echo "::error::Resources/bin/codex missing or not executable"; exit 1; }
-          test -x "$BIN/composio-aarch64/composio" || { echo "::error::composio-aarch64/composio missing"; exit 1; }
-          test -x "$BIN/composio-x86_64/composio"  || { echo "::error::composio-x86_64/composio missing"; exit 1; }
-          test -x "$BIN/gemini-aarch64/gemini"     || { echo "::error::gemini-aarch64/gemini missing"; exit 1; }
-          test -x "$BIN/gemini-x86_64/gemini"      || { echo "::error::gemini-x86_64/gemini missing"; exit 1; }
-          test -f "$BIN/cli-deps.json" || { echo "::error::cli-deps.json manifest missing"; exit 1; }
-          ls -lah "$BIN"
-
-          echo "=== 2. codex is universal (arm64 + x86_64) ==="
-          LIPO=$(lipo -info "$BIN/codex")
-          echo "$LIPO"
-          echo "$LIPO" | grep -q 'arm64'  || { echo "::error::codex missing arm64 slice"; exit 1; }
-          echo "$LIPO" | grep -q 'x86_64' || { echo "::error::codex missing x86_64 slice"; exit 1; }
-
-          echo "=== 3. Mach-O binaries have Developer ID + hardened runtime ==="
-          # Walk every executable file under Resources/bin/ and assert
-          # signing invariants. We only care about Mach-O — `.mjs` /
-          # `services/` / json files don't need signatures.
-          fail=0
-          while IFS= read -r f; do
-            if file "$f" | grep -q 'Mach-O'; then
-              echo ""
-              echo "Checking: $f"
-              if ! codesign -vvv "$f" 2>&1; then
-                echo "::error::codesign verify failed: $f"
-                fail=1
-                continue
-              fi
-              AUTH=$(codesign -dvv "$f" 2>&1 | grep '^Authority=' | head -1 || echo "")
-              echo "  $AUTH"
-              if ! echo "$AUTH" | grep -q 'Developer ID Application'; then
-                echo "::error::Bundled binary not signed with Developer ID: $f"
-                codesign -dvv "$f" 2>&1 | sed 's/^/  /' || true
-                fail=1
-              fi
-              FLAGS=$(codesign -dv "$f" 2>&1 | grep -E '^CodeDirectory.*flags=' | head -1 || echo "")
-              echo "  $FLAGS"
-              if ! echo "$FLAGS" | grep -q 'runtime'; then
-                echo "::error::Bundled binary missing hardened runtime: $f"
-                fail=1
-              fi
-            fi
-          done < <(find "$BIN" -type f -perm -u+x)
-
-          if [ "$fail" -ne 0 ]; then
-            echo "::error::One or more bundled CLI binaries failed signing checks"
-            exit 1
-          fi
-          echo "=== Bundled CLI checks passed ==="
-
-      - name: Verify engine sidecar signing
+      # The host sidecar is a single universal Mach-O in Contents/MacOS/ (same
+      # externalBin name the Rust engine used). tauri-action's deep sign reaches
+      # it there, so assert the invariants that would otherwise break launch:
+      # valid signature, Developer ID (not ad-hoc → Gatekeeper), hardened runtime,
+      # and both arch slices.
+      - name: Verify host sidecar signing
         run: |
           APP="${{ steps.artifacts.outputs.app }}"
 
@@ -723,19 +594,17 @@ jobs:
           # symbolicate (Sentry error `js_invalid_sourcemap_location`).
           "$SENTRY_CLI" sourcemaps upload --release "$RELEASE" app/dist
 
-          echo "=== 3. Upload Rust debug info (app + engine, dSYM) ==="
-          # macOS gotcha: `debug = "line-tables-only"` keeps DWARF line tables
-          # in the per-object (.o) files, NOT in the linked Mach-O. Uploading
-          # just the executable gives Sentry function names but never file:line.
-          # `dsymutil` walks the binary's debug map (OSO stabs) and packs the
-          # DWARF into a standalone .dSYM, which is the DIF Sentry symbolicates
-          # against. The engine .dSYMs are produced in the sidecar-build step;
-          # we dsymutil the universal app binary here (its per-arch .o still
-          # live under target/{aarch64,x86_64}-apple-darwin/release/deps).
+          echo "=== 3. Upload Rust debug info (Tauri app binary, dSYM) ==="
+          # Only the Tauri app SHELL is native now — the engine is the
+          # bun-compiled host sidecar (a self-contained binary with no Rust
+          # debug info to upload). macOS gotcha: `debug = "line-tables-only"`
+          # keeps DWARF line tables in the per-object (.o) files, NOT in the
+          # linked Mach-O, so `dsymutil` packs them into a standalone .dSYM (the
+          # DIF Sentry symbolicates against). The app's per-arch .o still live
+          # under target/{aarch64,x86_64}-apple-darwin/release/deps.
           APP="${{ steps.artifacts.outputs.app }}"
           # The bundled executable is named after the Cargo binary
-          # (`houston-app`), NOT the productName ("Houston"). The sidecar
-          # alongside it is `houston-engine`.
+          # (`houston-app`), NOT the productName ("Houston").
           APP_EXE="$APP/Contents/MacOS/houston-app"
           if [ ! -x "$APP_EXE" ]; then
             echo "::error::Tauri app executable missing at $APP_EXE"
@@ -747,26 +616,17 @@ jobs:
           # than the pre-dSYM behavior).
           dsymutil "$APP_EXE" -o "$APP_EXE.dSYM" \
             || echo "::warning::dsymutil failed for the app binary — native app frames may stay unresolved"
-          # Executables (code-id) always upload. dSYMs (DWARF) join the upload
-          # only when present, each checked + warned individually so one bad
-          # dSYM can't fail the whole release.
-          UPLOAD=(
-            "$APP_EXE"
-            target/aarch64-apple-darwin/release/houston-engine
-            target/x86_64-apple-darwin/release/houston-engine
-          )
-          for D in "$APP_EXE.dSYM" \
-                   target/aarch64-apple-darwin/release/houston-engine.dSYM \
-                   target/x86_64-apple-darwin/release/houston-engine.dSYM; do
-            if [ -d "$D" ]; then
-              "$SENTRY_CLI" debug-files check "$D" \
-                || echo "::warning::debug-files check failed for $D — native frames from it may not resolve to file:line"
-              UPLOAD+=( "$D" )
-            else
-              echo "::warning::missing dSYM $D — native frames from it may stay unresolved"
-            fi
-          done
-          # sentry-cli recurses into the .dSYM bundles. --include-sources bundles
+          # Executable (code-id) always uploads. The dSYM (DWARF) joins only
+          # when present, checked + warned so a bad dSYM can't fail the release.
+          UPLOAD=( "$APP_EXE" )
+          if [ -d "$APP_EXE.dSYM" ]; then
+            "$SENTRY_CLI" debug-files check "$APP_EXE.dSYM" \
+              || echo "::warning::debug-files check failed for $APP_EXE.dSYM — native frames may not resolve to file:line"
+            UPLOAD+=( "$APP_EXE.dSYM" )
+          else
+            echo "::warning::missing dSYM $APP_EXE.dSYM — native app frames may stay unresolved"
+          fi
+          # sentry-cli recurses into the .dSYM bundle. --include-sources bundles
           # the referenced source files (Houston's own Rust + cargo-registry
           # crates present in this checkout) so native stack traces show inline
           # CODE context, not just file:line. The repo is open source, so there's
@@ -951,8 +811,8 @@ jobs:
   # `latest.json` together (Windows entry added to the macOS-only base
   # uploaded by build-macos).
   #
-  # Scope (v1, weekend test build):
-  #   * Windows x64 only — no ARM64 build, no NSIS installer.
+  # Scope:
+  #   * Windows x86_64 + aarch64 (matrix), MSI installers.
   #   * No SignPath signing — the MSI ships UNSIGNED. Windows users will see
   #     a SmartScreen warning ("Don't run / More info → Run anyway") on
   #     first install. This is acceptable for personal testing; before we
@@ -960,24 +820,16 @@ jobs:
   #     a `sign-windows` job between this and the upload step.
   #
   # Build pipeline (runs once per matrix arch, x86_64 + aarch64):
-  #   1. Stage CLI deps via `scripts/fetch-cli-deps.sh windows-<arch>`.
-  #      Codex is downloaded + zstd-decompressed; composio is BUILT FROM
-  #      SOURCE on this Windows runner using a pinned commit on the
-  #      gethouston/composio fork (windows-x64 = houston-windows-support
-  #      branch, windows-arm64 = houston-windows-arm64 branch with the
-  #      bun:ffi fallback patch) — see `cli-deps.json`'s
-  #      `composio.build."windows-<arch>"` block for the pin and the
-  #      `$build_comment` for why upstream can't ship Windows yet.
-  #      git-bash-<arch>.7z.exe (PortableGit SFX) is also staged so the
-  #      first-launch extractor in houston-engine-core::git_bash gives
-  #      Claude Code its bash.exe dependency without user setup.
-  #   2. Build the houston-engine sidecar for the matrix target.
-  #      Tauri's externalBin picks it up at `binaries/houston-engine.exe`
-  #      (build.rs::stage_engine_sidecar names it
-  #      `houston-engine-<target>.exe` per Tauri's per-target convention).
-  #   3. Run `pnpm tauri build --target <matrix.target>` to produce the
-  #      MSI under `target/<matrix.target>/release/bundle/msi/*.msi`.
-  #   4. Upload the per-arch MSI + .sig to the draft release. `finalize`
+  #   1. Bun-compile the Houston HOST sidecar for the matrix target via
+  #      `scripts/build-host-sidecar.sh <target>` → a self-contained
+  #      `target/host-sidecar/houston-host-<target>.exe`. NO provider-CLI
+  #      staging (no codex/composio/git-bash) — pi runs providers in-process.
+  #      `build.rs::stage_host_sidecar` copies it to the externalBin name
+  #      `binaries/houston-engine-<target>.exe` (same name the Rust engine used,
+  #      so tauri.conf.json needs no per-feature branch).
+  #   2. Run `tauri build --target <matrix.target> --features host-sidecar` to
+  #      produce the MSI under `target/<matrix.target>/release/bundle/msi/*.msi`.
+  #   3. Upload the per-arch MSI + .sig to the draft release. `finalize`
   #      then merges both into a single latest.json with separate
   #      `windows-x86_64` and `windows-aarch64` entries the in-app
   #      updater consumes.
@@ -989,6 +841,9 @@ jobs:
     # can see it — same step-`if`-can't-read-step-env footgun as build-macos.
     env:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      # See build-macos: aliases the frontend to the v3 host adapter so the
+      # packaged app runs on the bun-compiled host sidecar.
+      VITE_NEW_ENGINE: "1"
     strategy:
       # Both arches build in parallel. fail-fast=false so a transient
       # ARM-runner outage doesn't kill the x64 release that 90%+ of
@@ -997,26 +852,18 @@ jobs:
       matrix:
         include:
           - arch: x86_64
-            bun_arch: x64
-            fetch_mode: windows-x64
             target: x86_64-pc-windows-msvc
             runner: windows-latest
           - arch: aarch64
-            bun_arch: arm64
-            fetch_mode: windows-arm64
             target: aarch64-pc-windows-msvc
-            # GitHub-hosted Windows-on-ARM runner. Goes through the
-            # same VS 2022 toolchain as the x64 runner; the only
-            # practical difference is the host arch + which Bun /
-            # composio variants we pull. See:
-            # https://github.com/actions/partner-runner-images/issues/61
-            # If this label ever disappears, fall back by changing
-            # `runner: windows-latest` + adding
-            # `rustup target add aarch64-pc-windows-msvc` and the
-            # ARM64 component of VS Build Tools — but that path
-            # requires running the linker via /arm64 cross-toolchain
-            # which has subtle issues with mingw-w64-linked C deps in
-            # libsql, so prefer the native runner whenever it's up.
+            # GitHub-hosted Windows-on-ARM runner. Native arm64 keeps two things
+            # simple: the Tauri app shell links for aarch64 without a cross
+            # toolchain, and setup-bun compiles the host sidecar for windows-arm64
+            # natively (avoiding the flakier cross-target compile). See
+            # https://github.com/actions/partner-runner-images/issues/61 — if this
+            # label ever disappears, fall back to `runner: windows-latest` plus
+            # `rustup target add aarch64-pc-windows-msvc` and the ARM64 VS Build
+            # Tools component, but prefer the native runner whenever it's up.
             runner: windows-11-arm
     steps:
       - name: Checkout
@@ -1053,126 +900,33 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ matrix.arch }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-${{ matrix.arch }}-
 
-      # Bun + jq + zstd are required by `scripts/fetch-cli-deps.sh`. Bun
-      # is needed because the composio Windows binary is built FROM
-      # SOURCE on this runner via `bun build:binary:cross
-      # --target=bun-windows-<arch>`. The version MUST match the pin
-      # in `cli-deps.json#composio.build."windows-<arch>".bun_version` —
-      # mismatched Bun produces a binary with subtle behavioral
-      # differences that bite at runtime, so we install via direct
-      # GitHub release download (deterministic) rather than the
-      # web-installer (which can drift if oven-sh changes the env-var
-      # contract on `install.ps1`).
-      - name: Install Bun (pinned to cli-deps.json)
-        shell: pwsh
-        run: |
-          $platformKey = "windows-${{ matrix.bun_arch }}"
-          if ("${{ matrix.bun_arch }}" -eq "x64") {
-            $bunVersion = (Get-Content cli-deps.json | ConvertFrom-Json).composio.build.'windows-x64'.bun_version
-            $bunBundle = "bun-windows-x64"
-          } else {
-            $bunVersion = (Get-Content cli-deps.json | ConvertFrom-Json).composio.build.'windows-arm64'.bun_version
-            # Bun's GitHub release artifact for Windows ARM64 is published
-            # as `bun-windows-aarch64.zip` (asymmetric with the
-            # `--target=bun-windows-arm64` CLI flag in cli-deps.json,
-            # which still uses `arm64`). Both the URL stem and the zip's
-            # inner folder use `aarch64`.
-            $bunBundle = "bun-windows-aarch64"
-          }
-          Write-Host "Installing Bun $bunVersion ($bunBundle, direct GitHub release download)"
-          $bunDir = "$HOME\.bun\bin"
-          New-Item -ItemType Directory -Force -Path $bunDir | Out-Null
-          $url = "https://github.com/oven-sh/bun/releases/download/bun-v$bunVersion/$bunBundle.zip"
-          $zipPath = "$env:TEMP\$bunBundle.zip"
-          Invoke-WebRequest -Uri $url -OutFile $zipPath
-          Expand-Archive -Force -Path $zipPath -DestinationPath "$env:TEMP\bun-extract"
-          Copy-Item -Force "$env:TEMP\bun-extract\$bunBundle\bun.exe" "$bunDir\bun.exe"
-          Remove-Item -Recurse -Force "$env:TEMP\bun-extract", $zipPath
-          # Add bun to PATH for subsequent steps.
-          echo "$bunDir" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-          $actual = & "$bunDir\bun.exe" --version
-          if ($actual.Trim() -ne $bunVersion) {
-            Write-Error "Bun version mismatch after install: got '$actual', expected '$bunVersion'"
-            exit 1
-          }
-          Write-Host "Pinned Bun OK: $actual"
+      # Bun compiles the host sidecar. setup-bun resolves the right build for the
+      # x64 and arm64 Windows runners.
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
 
-      # jq is preinstalled on the GitHub Windows runners. zstd is NOT, and the
-      # Chocolatey community feed (community.chocolatey.org) 504s intermittently
-      # — it failed the ARM64 release leg repeatedly. Pull zstd straight from
-      # its GitHub release instead (pinned), which is far more reliable. The
-      # x64 binary runs natively on x64 and under emulation on the ARM64 runner;
-      # it's only used to decompress the codex archive in fetch-cli-deps.sh.
-      - name: Install jq + zstd
-        shell: pwsh
-        run: |
-          $ErrorActionPreference = "Stop"
-          jq --version
-
-          $ZSTD = "1.5.6"
-          $zip = "zstd-v$ZSTD-win64.zip"
-          $url = "https://github.com/facebook/zstd/releases/download/v$ZSTD/$zip"
-          $tmp = Join-Path $env:RUNNER_TEMP $zip
-          $out = Join-Path $env:RUNNER_TEMP "zstd"
-          Write-Host "Downloading $url"
-          for ($i = 1; $i -le 3; $i++) {
-            try { Invoke-WebRequest -Uri $url -OutFile $tmp; break }
-            catch { if ($i -eq 3) { throw }; Write-Host "retry $i…"; Start-Sleep 5 }
-          }
-          Expand-Archive -Force -Path $tmp -DestinationPath $out
-          # Zip extracts to a single `zstd-v<ver>-win64\` folder containing zstd.exe.
-          $dir = (Get-ChildItem -Path $out -Directory | Select-Object -First 1).FullName
-          if (-not $dir) { $dir = $out }
-          echo "$dir" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
-          & "$dir\zstd.exe" --version
-
-      # Stage bundled CLI binaries: codex.exe (downloaded + zstd),
-      # composio-<arch>/composio.exe (built from gethouston/composio
-      # fork — windows-x64 from branch houston-windows-support,
-      # windows-arm64 from branch houston-windows-arm64 with the
-      # bun:ffi fallback patch), and git-bash-<arch>.7z.exe (PortableGit
-      # SFX, extracted on first launch by houston-engine-core::git_bash).
-      # The fetch script handles `pnpm install` + `tsdown` +
-      # `bun build:binary:cross` for the composio fork; full build is
-      # ~3-5 minutes on a warm runner.
-      - name: Stage bundled CLI dependencies (codex, composio, git-bash)
+      # Bun-compile the Houston HOST sidecar for the matrix target BEFORE
+      # `tauri build`. build.rs::stage_host_sidecar copies
+      # `target/host-sidecar/houston-host-<target>.exe` to the externalBin name
+      # `app/src-tauri/binaries/houston-engine-<target>.exe` (the same name the
+      # Rust engine used). Self-contained — no provider CLIs, jq, or zstd needed.
+      - name: Compile Houston host sidecar (${{ matrix.target }})
         shell: bash
         run: |
           set -euo pipefail
-          ./scripts/fetch-cli-deps.sh ${{ matrix.fetch_mode }}
-
-          echo "=== Staged bundle ==="
-          ls -lah app/src-tauri/resources/bin/
-          echo "=== Sizes ==="
-          du -sh app/src-tauri/resources/bin/*
-
-          # Sanity: every Windows artifact must be present.
-          test -f app/src-tauri/resources/bin/codex.exe
-          test -f app/src-tauri/resources/bin/composio-${{ matrix.arch }}/composio.exe
-          test -f app/src-tauri/resources/bin/composio-${{ matrix.arch }}/run-helpers-runtime.mjs
-          test -f app/src-tauri/resources/bin/composio-${{ matrix.arch }}/acp-adapters/codex/win32-${{ matrix.bun_arch }}/codex-acp.exe
-          test -f app/src-tauri/resources/bin/git-bash-${{ matrix.arch }}.7z.exe
-          test -f app/src-tauri/resources/bin/cli-deps.json
-
-      # Build the engine sidecar for the matrix target BEFORE
-      # `tauri build`. build.rs::stage_engine_sidecar copies it to
-      # `app/src-tauri/binaries/houston-engine-<target>.exe` which is
-      # what Tauri's externalBin pattern expects.
-      - name: Build houston-engine sidecar (${{ matrix.target }})
-        shell: bash
-        run: |
-          set -euo pipefail
-          cargo build --release --target ${{ matrix.target }} -p houston-engine-server
-          test -x "target/${{ matrix.target }}/release/houston-engine.exe" \
-            || { echo "::error::engine binary missing for ${{ matrix.target }}"; exit 1; }
+          scripts/build-host-sidecar.sh ${{ matrix.target }}
+          test -x "target/host-sidecar/houston-host-${{ matrix.target }}.exe" \
+            || { echo "::error::host sidecar missing for ${{ matrix.target }}"; exit 1; }
           echo "Sidecar size:"
-          ls -lah target/${{ matrix.target }}/release/houston-engine.exe
+          ls -lah target/host-sidecar/houston-host-${{ matrix.target }}.exe
 
       - name: Build Tauri app (Windows MSI)
         uses: tauri-apps/tauri-action@v0
         with:
           projectPath: app
-          args: --target ${{ matrix.target }}
+          args: --target ${{ matrix.target }} --features host-sidecar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # The Tauri updater key signs the MSI for the auto-updater
@@ -1270,22 +1024,19 @@ jobs:
           "$SENTRY_CLI" sourcemaps upload --release "$RELEASE" app/dist
 
           echo "=== Upload ${{ matrix.target }} debug symbols ==="
-          # Rust converts `-` to `_` for PDB stems
-          # (houston-app.exe -> houston_app.pdb, houston-engine.exe ->
-          # houston_engine.pdb). Upload exe + PDB pairs so Sentry can index by
-          # the executable debug-id and resolve through the PDB line tables.
+          # Only the Tauri app SHELL is native now (the engine is the
+          # bun-compiled host sidecar — no PDB). Rust converts `-` to `_` for
+          # PDB stems (houston-app.exe -> houston_app.pdb). Upload exe + PDB so
+          # Sentry indexes by the executable debug-id and resolves through the
+          # PDB line tables.
           test -f "target/${{ matrix.target }}/release/houston-app.exe"
           test -f "target/${{ matrix.target }}/release/houston_app.pdb"
-          test -f "target/${{ matrix.target }}/release/houston-engine.exe"
-          test -f "target/${{ matrix.target }}/release/houston_engine.pdb"
           # --include-sources bundles the referenced source (Houston's Rust +
           # cargo crates in this checkout) so native frames show inline CODE,
           # not just file:line. Open-source repo → no exposure concern.
           "$SENTRY_CLI" debug-files upload --include-sources \
             "target/${{ matrix.target }}/release/houston-app.exe" \
-            "target/${{ matrix.target }}/release/houston_app.pdb" \
-            "target/${{ matrix.target }}/release/houston-engine.exe" \
-            "target/${{ matrix.target }}/release/houston_engine.pdb"
+            "target/${{ matrix.target }}/release/houston_app.pdb"
 
       - name: Upload Windows MSI + updater signature to draft release
         env:
@@ -1306,6 +1057,181 @@ jobs:
 
           echo "::notice::Windows MSI + .sig uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
           echo "::warning::This MSI is UNSIGNED (code-signing wise) — Windows SmartScreen will warn on first install. The updater minisign signature above is separate; it covers in-app auto-update verification, not OS code-signing. SignPath integration lands in a follow-up PR."
+
+  # ============================================================================
+  # Linux desktop build — x86_64 AppImage + .deb. Runs IN PARALLEL with the mac
+  # and Windows jobs, uploading into the same draft. NEW with the TS engine: the
+  # CLI-free host makes a Linux desktop build viable for the first time (the Rust
+  # path bundled per-arch provider CLIs that never had Linux builds). The
+  # tauri.conf.json bundle.targets stay app/dmg/msi — Linux bundles are requested
+  # on the CLI via `--bundles deb,appimage`, so the default config is untouched.
+  #
+  # UNSIGNED + NOT wired into the auto-updater (latest.json is macOS + Windows
+  # only; `finalize` doesn't add a Linux entry). Download-only, for testing.
+  build-linux:
+    needs: prep
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      # See build-macos: aliases the frontend to the v3 host adapter.
+      VITE_NEW_ENGINE: "1"
+      # AppImage packaging on headless CI: don't strip (keeps the bundled
+      # sidecar intact) and extract-and-run the AppImage tooling (no FUSE on
+      # GitHub runners).
+      NO_STRIP: "true"
+      APPIMAGE_EXTRACT_AND_RUN: "1"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Setup Rust (linux target)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-gnu
+
+      - name: Cache Rust artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            app/src-tauri/target
+            target
+          key: ${{ runner.os }}-cargo-linux-x64-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: ${{ runner.os }}-cargo-linux-x64-
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+
+      - name: Install Tauri Linux system dependencies
+        run: ./scripts/ci/install-tauri-linux-deps.sh
+
+      - name: Compile Houston host sidecar (x86_64-unknown-linux-gnu)
+        run: |
+          set -euo pipefail
+          scripts/build-host-sidecar.sh x86_64-unknown-linux-gnu --verify
+          test -x target/host-sidecar/houston-host-x86_64-unknown-linux-gnu \
+            || { echo "::error::host sidecar missing for x86_64-unknown-linux-gnu"; exit 1; }
+
+      # linuxdeploy runs `ldd` on every ELF to discover libraries to bundle. The
+      # bun-compiled sidecar is self-contained and `ldd` can't trace it, aborting
+      # the AppImage build. A front-of-PATH shim reports it as "not a dynamic
+      # executable" and defers to the real ldd for everything else.
+      - name: Install AppImage ldd shim
+        run: |
+          set -euo pipefail
+          SHIM_DIR="$RUNNER_TEMP/ldd-shim"
+          mkdir -p "$SHIM_DIR"
+          cp scripts/ci/appimage-ldd-shim.sh "$SHIM_DIR/ldd"
+          chmod +x "$SHIM_DIR/ldd"
+          echo "$SHIM_DIR" >> "$GITHUB_PATH"
+
+      - name: Build Tauri app (Linux AppImage + deb)
+        uses: tauri-apps/tauri-action@v0
+        with:
+          projectPath: app
+          args: --target x86_64-unknown-linux-gnu --features host-sidecar --bundles deb,appimage
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+          SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
+          LINEAR_API_KEY: ${{ secrets.LINEAR_API_KEY }}
+          LINEAR_TEAM_ID: ${{ secrets.LINEAR_TEAM_ID }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+
+      - name: Locate Linux artifacts
+        id: artifacts-linux
+        run: |
+          set -euo pipefail
+          BUNDLE="target/x86_64-unknown-linux-gnu/release/bundle"
+          APPIMAGE=$(ls -t "$BUNDLE/appimage/"*.AppImage 2>/dev/null | head -1 || true)
+          DEB=$(ls -t "$BUNDLE/deb/"*.deb 2>/dev/null | head -1 || true)
+
+          missing=()
+          [ -f "$APPIMAGE" ] || missing+=("AppImage")
+          [ -f "$DEB" ] || missing+=(".deb")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing Linux build artifacts: ${missing[*]}"
+            ls -laR "$BUNDLE" 2>&1 | head -50 || true
+            exit 1
+          fi
+
+          echo "appimage=$APPIMAGE" >> "$GITHUB_OUTPUT"
+          echo "deb=$DEB" >> "$GITHUB_OUTPUT"
+          echo "Artifacts:"
+          echo "  AppImage: $APPIMAGE ($(du -sh "$APPIMAGE" | cut -f1))"
+          echo "  .deb:     $DEB ($(du -sh "$DEB" | cut -f1))"
+
+      - name: Upload source maps + Rust debug symbols to Sentry (linux x64)
+        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
+        env:
+          SENTRY_ORG: houston-cd
+          SENTRY_PROJECT: houston-app
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          RELEASE="houston-app@${VERSION}"
+          SENTRY_CLI="app/node_modules/.bin/sentry-cli"
+          "$SENTRY_CLI" --version
+
+          echo "=== Upload Linux Vite source maps ==="
+          # Linux ships its own Vite content-hashed bundle, so its maps must be
+          # uploaded under the shared release or Linux JS frames stay minified.
+          # `releases new` is idempotent and guards the race with the mac/win jobs.
+          "$SENTRY_CLI" releases new "$RELEASE"
+          "$SENTRY_CLI" sourcemaps upload --release "$RELEASE" app/dist
+
+          echo "=== Upload Linux app debug symbols ==="
+          # Only the Tauri app SHELL is native (the engine is the bun-compiled
+          # host sidecar — no debug info). The ELF carries DWARF inline in release
+          # with debug = "line-tables-only", so upload the executable directly.
+          APP_EXE="target/x86_64-unknown-linux-gnu/release/houston-app"
+          if [ -f "$APP_EXE" ]; then
+            "$SENTRY_CLI" debug-files upload --include-sources "$APP_EXE" \
+              || echo "::warning::debug-files upload failed for $APP_EXE"
+          else
+            echo "::warning::app executable missing at $APP_EXE — native Linux frames may stay unresolved"
+          fi
+
+      - name: Generate checksums
+        run: |
+          sha256sum \
+            "${{ steps.artifacts-linux.outputs.appimage }}" \
+            "${{ steps.artifacts-linux.outputs.deb }}" \
+            > checksums-linux-sha256.txt
+          cat checksums-linux-sha256.txt
+
+      - name: Upload Linux artifacts to draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" \
+            "${{ steps.artifacts-linux.outputs.appimage }}" \
+            "${{ steps.artifacts-linux.outputs.deb }}" \
+            checksums-linux-sha256.txt \
+            --clobber
+
+          echo "::notice::Linux artifacts uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
 
   # ============================================================================
   # Stitch the parallel mac + win builds into one finished draft release.

--- a/convergence/README.md
+++ b/convergence/README.md
@@ -102,35 +102,43 @@ points at the gateway with a static bearer for service-token smoke tests) — se
 
 ## Host-sidecar release CI
 
-The Rust `release.yml` pipeline is untouched — it still builds the Rust engine on
-a `v*` tag. The host-sidecar release builds live in a SEPARATE, committed
-workflow, `.github/workflows/host-sidecar-release.yml`, so they can never perturb
-the releasable Rust path. It fires only off the critical path: a manual
-`workflow_dispatch` or a `host-v*` tag push (NOT `v*`), producing a draft release
-tagged `host-v<version>` (distinct namespace, no artifact collision).
+**Updated (HOU-628): the desktop release now builds the TS engine directly.**
+`.github/workflows/release.yml` (tag `v*`) was rewritten to bun-compile the host
+sidecar and build Tauri with `--features host-sidecar` + `VITE_NEW_ENGINE=1`,
+replacing the Rust `houston-engine` build + the codex/composio/git-bash CLI
+staging. `.github/workflows/engine-release.yml` (tag `engine-v*`) likewise now
+bun-compiles the **standalone** host binary (`houston-host-<triple>`) instead of
+the Rust engine. (The earlier plan kept `release.yml` on Rust and put the TS build
+in a separate `host-sidecar-release.yml` / `ts-engine-desktop-artifacts.yml`;
+those were never committed — the build logic they described now lives directly in
+`release.yml` + `engine-release.yml`.)
 
-For QA artifact pulls that should NOT create a release, use
-`.github/workflows/ts-engine-desktop-artifacts.yml`. It is manual-only,
-builds the same host-sidecar desktop path for macOS universal, Windows x64/arm64,
-and Linux x64, and uploads GitHub Actions artifacts (DMG/tar/sig, MSI/sig,
-AppImage, and `.deb`) without touching any release draft.
+This is a CI-only cutover: it flips what the RELEASE ships to the TS engine, but
+the app's build DEFAULTS are untouched (a plain `pnpm tauri build` still builds the
+Rust engine; the `app/vite.config.ts` + `app/src-tauri/Cargo.toml` defaults are
+unchanged), so `engine/` stays as the instant-rollback oracle. Flipping the
+defaults + deleting `engine/` remain the gated final cutover
+(`convergence/final-cutover.md`). A manual-only QA-artifacts workflow — the
+`.github/actions/build-ts-engine-desktop-artifact` composite action + `scripts/ci/`
+prepare helpers already exist for it — can upload GitHub Actions artifacts without
+cutting a release; it is not wired into a top-level workflow yet.
 
-Three platform jobs, all bun-compiling the host via the one parameterized
+The platform jobs all bun-compile the host via the one parameterized
 `scripts/build-host-sidecar.sh <triple>` (no second compile path to drift):
 
 - **macOS** — universal (arm64 + x86_64, lipo'd from two per-arch bun-compiles),
-  signed + notarized + stapled with the SAME Apple secrets + steps as
-  `release.yml::build-macos` (DMG re-sign, notarize-with-retry, full signing-chain
-  verification, sidecar Developer-ID + hardened-runtime asserts), uploaded.
+  signed + notarized + stapled with the SAME Apple secrets + steps as before (DMG
+  re-sign, notarize-with-retry, full signing-chain verification, sidecar
+  Developer-ID + hardened-runtime asserts), uploaded to the draft release.
 - **Windows** — MSI per arch (x86_64 + aarch64 matrix), updater-key signed (`.sig`
-  emitted), uploaded. None of `release.yml`'s codex/composio/git-bash CLI staging:
-  pi runs providers in-process, so the host carries no CLIs.
-- **Linux** — the platform `release.yml` never builds (its `tauri.conf.json`
-  `bundle.targets` are app/dmg/msi only). The CLI-free host makes a Linux DESKTOP
-  build viable for the first time: x86_64 AppImage + `.deb` via tauri-action's
-  `--bundles deb,appimage` (passed on the CLI, so the default config stays
-  untouched), uploaded. The job also boots the bare host binary (`--verify` →
-  curls `/v1/capabilities`), which is the same binary the `selfhost/` server runs.
+  emitted), uploaded. None of the old codex/composio/git-bash CLI staging: pi runs
+  providers in-process, so the host carries no CLIs.
+- **Linux** — NEW: the CLI-free host makes a Linux DESKTOP build viable for the
+  first time. x86_64 AppImage + `.deb` via tauri-action's `--bundles deb,appimage`
+  (passed on the CLI, so `tauri.conf.json`'s app/dmg/msi targets stay untouched),
+  uploaded to the draft (UNSIGNED, download-only — not in `latest.json`). The job
+  also boots the bare host binary (`--verify` → curls `/v1/capabilities`), which is
+  the same binary the `selfhost/` server runs.
 
 `build.rs::stage_host_sidecar` (the `host-sidecar` cargo feature) stages the
 compiled host at the SAME `binaries/houston-engine-<triple>` externalBin name the

--- a/convergence/README.md
+++ b/convergence/README.md
@@ -134,11 +134,11 @@ The platform jobs all bun-compile the host via the one parameterized
   emitted), uploaded. None of the old codex/composio/git-bash CLI staging: pi runs
   providers in-process, so the host carries no CLIs.
 - **Linux** — NEW: the CLI-free host makes a Linux DESKTOP build viable for the
-  first time. x86_64 AppImage + `.deb` via tauri-action's `--bundles deb,appimage`
-  (passed on the CLI, so `tauri.conf.json`'s app/dmg/msi targets stay untouched),
-  uploaded to the draft (UNSIGNED, download-only — not in `latest.json`). The job
-  also boots the bare host binary (`--verify` → curls `/v1/capabilities`), which is
-  the same binary the `selfhost/` server runs.
+  first time. x86_64 AppImage via tauri-action's `--bundles appimage` (passed on
+  the CLI, so `tauri.conf.json`'s app/dmg/msi targets stay untouched), uploaded to
+  the draft (UNSIGNED, download-only — not in `latest.json`; `.deb` intentionally
+  not built). The job also boots the bare host binary (`--verify` → curls
+  `/v1/capabilities`), which is the same binary the `selfhost/` server runs.
 
 `build.rs::stage_host_sidecar` (the `host-sidecar` cargo feature) stages the
 compiled host at the SAME `binaries/houston-engine-<triple>` externalBin name the

--- a/convergence/final-cutover.md
+++ b/convergence/final-cutover.md
@@ -17,7 +17,7 @@ we will not take.
    **notarized packaged `.app`** (see `convergence/packaged-app-launch.md`), with a real
    provider, including the migrated-conversation recall rows and the force-quit/no-orphan row.
 2. The host-sidecar release builds are produced + launched on macOS, Windows, and Linux
-   (`.github/workflows/host-sidecar-release.yml`).
+   (`.github/workflows/release.yml` — since HOU-628 it builds the TS host sidecar directly on `v*`).
 3. The migration gate is confirmed on the real `~/.houston` (already verified on a copy —
    `convergence/migration-gate.md`; re-confirm on the live machine).
 
@@ -37,8 +37,11 @@ Make `VITE_NEW_ENGINE` / the host-sidecar the DEFAULT (not flag-gated):
   host path is behind the flag — `app/vite.config.ts`, `app/src/lib/engine.ts`).
 - `app/src-tauri`: make `host-sidecar` the default cargo feature (today it is opt-in;
   `app/src-tauri/Cargo.toml`), and the supervisor spawns the host sidecar unconditionally.
-- `release.yml`: build the app with the host sidecar (as `host-sidecar-release.yml` does),
-  retire the Rust-engine sidecar staging.
+- `release.yml`: **DONE (HOU-628)** — it already builds the app with the host sidecar
+  (`--features host-sidecar` + `VITE_NEW_ENGINE=1`), and the Rust-engine + codex/composio/
+  git-bash CLI staging is retired. `engine-release.yml` bun-compiles the standalone TS host
+  too. What remains here are the two DEFAULT flips above, so that a plain `pnpm tauri build`
+  (no flags) also builds the host.
 
 ## Step 3 — delete the legacy Rust + CLI surface
 
@@ -47,7 +50,9 @@ Only after Steps 1–2 and a green build:
 - The CLI-bundling pipeline: `scripts/fetch-cli-deps.sh`, the `build.rs` engine/CLI staging,
   `cli-deps.json`, the claude-installer + per-arch Composio CLI fetch.
 - Gemini legacy (only in `engine/` + the legacy `ui/engine-client` v1 client — both go here).
-- `.github/workflows/engine-release.yml` (the standalone Rust engine release).
+- `.github/workflows/engine-release.yml` — no longer builds the Rust engine (HOU-628 rewired
+  it to bun-compile the standalone TS host binary `houston-host-<triple>`). Keep it if you
+  still want a bare-host release artifact; drop it only if nothing consumes it.
 - The legacy `ui/engine-client` v1 transport (the app's v3 path uses the QA'd adapter; once
   the Rust default is gone, the v1 client has no consumer — see `convergence/follow-ups.md`
   for the cleaner consolidation).

--- a/convergence/packaged-app-launch.md
+++ b/convergence/packaged-app-launch.md
@@ -38,7 +38,7 @@ Output: a DRAFT GitHub Release tagged `v<version>` with, per platform:
 | macOS | `Houston_<v>_universal.dmg` + `.app.tar.gz` + `.sig` | Developer ID, notarized, stapled |
 | Windows x64 | `Houston_<v>_x64_en-US.msi` + `.msi.sig` | updater-key only (no OS code-sign yet) |
 | Windows arm64 | `Houston_<v>_arm64_en-US.msi` + `.msi.sig` | updater-key only |
-| Linux x64 | `*.AppImage` + `*.deb` | unsigned |
+| Linux x64 | `*.AppImage` | unsigned |
 
 Download the macOS DMG from the draft release, then go to **"Run the gate"** below.
 

--- a/convergence/packaged-app-launch.md
+++ b/convergence/packaged-app-launch.md
@@ -16,31 +16,22 @@ There are two ways to get the packaged app. Pick one.
 
 ## Option A — build it in CI (preferred: produces the real signed/notarized artifact)
 
-The committed workflow `.github/workflows/host-sidecar-release.yml` builds all
-three platforms. It is OFF the Rust `release.yml` critical path — it never runs
-on a `v*` tag.
+Since HOU-628, `.github/workflows/release.yml` (tag `v*`) builds the desktop app
+around the host sidecar — so a **normal release IS the host-sidecar build**. There
+is no separate `host-sidecar-release.yml` (it was planned but never committed; the
+build logic lives in `release.yml`).
 
-Trigger it one of two ways:
+Trigger it with a version tag (drives the full signed + notarized chain — the Apple
+secrets are already on the repo):
 
-1. **GitHub UI / `gh`** — Actions → "Host-sidecar Release" → Run workflow:
+```bash
+# Bump app/package.json + app/src-tauri/Cargo.toml to <version> first — the `prep`
+# job fails the release if the tag and the two manifests disagree.
+git tag v0.4.19
+git push origin v0.4.19
+```
 
-   ```bash
-   # default inputs: sign_macos = true (full notarized chain)
-   gh workflow run host-sidecar-release.yml --ref main
-
-   # or build mac unsigned (e.g. no Apple secrets on the runner):
-   gh workflow run host-sidecar-release.yml --ref main -f sign_macos=false
-   ```
-
-2. **`host-v*` tag push** (always signs mac):
-
-   ```bash
-   git tag host-v0.4.19
-   git push origin host-v0.4.19
-   ```
-
-Output: a DRAFT GitHub Release tagged `host-v<version>` (distinct from the Rust
-`v<version>` releases — no collision) with, per platform:
+Output: a DRAFT GitHub Release tagged `v<version>` with, per platform:
 
 | Platform | Artifact | Signed |
 |---|---|---|

--- a/knowledge-base/cli-bundling.md
+++ b/knowledge-base/cli-bundling.md
@@ -2,6 +2,8 @@
 
 > **⚠️ LEGACY — Rust engine, being retired at P6.** This whole CLI-bundling scheme exists because the Rust `engine/` drives agents by spawning provider **CLI subprocesses**. The target TS engine (**pi runtime**) talks to providers **in-process** — there are NO bundled provider CLIs. This doc is accurate for the current default Rust build only. See `convergence/README.md` + `selfhost/`.
 >
+> **⚠️ No longer wired into CI (HOU-628).** `.github/workflows/release.yml` was rewritten to build the desktop app around the bun-compiled TS host sidecar, so it NO LONGER runs `fetch-cli-deps.sh`, the "Pre-sign bundled CLI binaries" step, or the bundled-CLI invariant checks. Every "CI / `release.yml` calls `fetch-cli-deps.sh` …" reference below is HISTORICAL — the script + this bundling scheme survive only for a manual/local Rust-engine build until `engine/` is deleted at P6.
+>
 > **Two corrections that matter even today:**
 > - **Composio is NO LONGER a bundled CLI.** The earlier "cut" was reversed and Composio was **re-wired as an in-process REST tool** (each user's own free "Composio for you" account, no binary) behind the `IntegrationProvider` port — `packages/host/src/integrations/`. Ignore every "bundle the composio CLI" instruction below; that path is gone. `houston-composio` (Rust) + the per-arch composio binary fetch are deleted with `engine/`.
 > - **Gemini CLI is dropped, not Google Gemini as a provider.** The TS engine keeps Google Gemini as an API-key pi provider. Ignore the legacy gemini CLI bundle rows/sections below.

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -205,7 +205,7 @@ CI also needs as Secrets:
 - **Workflow:** `.github/workflows/release.yml`
 - **Trigger:** Push tag matching `v*`
 - **Engine:** builds the desktop app around the **bun-compiled Houston host sidecar** (the TS engine) via `--features host-sidecar` + `VITE_NEW_ENGINE=1` — NOT the legacy Rust `houston-engine`. No provider CLIs are bundled (pi runs providers in-process). The app's build DEFAULTS stay Rust (a plain `pnpm tauri build` still builds the Rust engine); only the release workflow passes the host-sidecar flags, so `engine/` remains the instant-rollback oracle until the gated final cutover (`convergence/final-cutover.md`).
-- **Output:** Draft GitHub Release w/ signed+notarized universal DMG + signed Windows MSI (x64 + arm64) + Linux AppImage + `.deb` + `latest.json`
+- **Output:** Draft GitHub Release w/ signed+notarized universal DMG + signed Windows MSI (x64 + arm64) + Linux AppImage + `latest.json`
 - **Duration:** ~25-30 min wall-clock (mac + win + linux run in parallel; mac is the long pole at ~25 min including Apple notarization).
 - **Draft = QA gate.** Users don't see until published on GitHub.
 
@@ -214,7 +214,7 @@ CI also needs as Secrets:
 prep (ubuntu, ~30s)               creates empty draft + release-notes.md artifact
   ├── build-macos (mac, ~25m)     bun-compiles host sidecar (both arches) → signs, notarizes, uploads DMG/tar/sig/latest.json
   ├── build-windows (win, ~15m)   bun-compiles host sidecar per arch → uploads MSI + .sig (x64 + arm64)
-  └── build-linux (ubuntu, ~15m)  bun-compiles host sidecar → uploads AppImage + .deb (download-only, not in latest.json)
+  └── build-linux (ubuntu, ~15m)  bun-compiles host sidecar → uploads AppImage (download-only, not in latest.json)
         └── finalize (ubuntu, ~30s) [needs mac + win] extends latest.json with windows entries, posts Slack
 ```
 Mac, Windows, and Linux run in parallel because they only need the empty draft `prep` creates, not each other's output. `finalize` stitches `latest.json` together (the macOS-only base from build-macos plus the Windows entries assembled from the MSI .sig in the draft) and posts the team Slack notification — it needs only mac + win, so a flaky new Linux leg never blocks the updater manifest or the mac/win artifacts already on the draft. Linux is UNSIGNED + download-only (no auto-update entry). Slack lives in `finalize` (not Windows) because it needs `release-notes.md` and the file is published as a workflow artifact by `prep`.

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -125,7 +125,7 @@ PostHog → BigQuery plugin → target GCP project (burns credits). SQL-queryabl
   - **Source CODE context (both platforms):** symbolication gives function + file:line, but Sentry shows the actual source LINES inline only if a source bundle is uploaded too. CI passes `--include-sources` to `debug-files upload`, which bundles the referenced source (Houston's own Rust + cargo-registry crates present in the build checkout; NOT the Rust stdlib unless `rust-src` is installed) into Sentry. The repo is open source so there's no exposure concern, and it brings native to parity with JS (whose maps already inline `sourcesContent`). Without the flag you still get file:line, just no code snippet.
 - **JS source maps:** Vite emits `*.js.map` next to bundled JS via `build.sourcemap: "hidden"` (no `//# sourceMappingURL=` comment — production users can't view source via DevTools). With a hidden map, Sentry can only link `.js`→`.map` via a **Debug ID baked into the shipped bundle**, so the ID must be injected BEFORE Tauri embeds the frontend.
 - **Build-time Debug ID injection:** `app/src-tauri/tauri.conf.json` → `beforeBuildCommand: "pnpm build && node scripts/sentry-inject.mjs"`. The script (`app/scripts/sentry-inject.mjs`, using the `@sentry/cli` devDep) runs `sentry-cli sourcemaps inject app/dist` after the Vite build but before cargo embeds the assets, so the shipped bundle and the uploaded map share identical byte offsets + Debug ID. No-op unless `SENTRY_DSN` is baked in (dev/forks skip it). **Why here, not in CI:** injecting after Tauri packaged `app/dist` (the pre-2026-06 behavior) shifted offsets and every in-app JS frame failed to symbolicate (`js_invalid_sourcemap_location`) even though the map uploaded fine. `beforeBundleCommand` is too late — assets embed during cargo build. Do NOT add `@sentry/vite-plugin` (getsentry #916 risk); the CLI inject achieves the same result. `@sentry/cli` needs an `onlyBuiltDependencies` allowlist in `pnpm-workspace.yaml` (pnpm 10 blocks its postinstall otherwise — without it the native `sentry-cli` binary never downloads and the inject fails). This setting lives in `pnpm-workspace.yaml`, NOT the `package.json` `pnpm` field: recent pnpm stopped reading that field ("The pnpm field in package.json is no longer read").
-- **Release.yml uploads:** After Tauri build (which has already injected the bundle), the macOS job runs `sentry-cli releases new + set-commits + sourcemaps upload + debug-files upload` against the signed Tauri app executable + its `.dSYM` plus both `target/{aarch64,x86_64}-apple-darwin/release/houston-engine` + their `.dSYM`s. Each Windows matrix arch uploads its own `app/dist` maps (Vite content-hashes differ per arch) + `houston-app.exe` + `houston_app.pdb` + `houston-engine.exe` + `houston_engine.pdb` (PDB filename has underscore — Rust convention). `releases finalize` runs ONCE in the dedicated `finalize` job (after both build jobs upload), not per-build. The CI steps **upload only** (no `inject` — that happens at build time). sentry-cli is the lockfile-pinned `app/node_modules/.bin/sentry-cli` (via the `@sentry/cli` devDep), not an unpinned `get-cli` download.
+- **Release.yml uploads:** After Tauri build (which has already injected the bundle), the macOS job runs `sentry-cli releases new + set-commits + sourcemaps upload + debug-files upload` against the signed Tauri app executable + its `.dSYM`. Only the Tauri app SHELL is native now — the engine is the bun-compiled host sidecar (a self-contained binary with no Rust debug info), so there are no engine `.dSYM`/`.pdb` uploads. Each Windows matrix arch uploads its own `app/dist` maps (Vite content-hashes differ per arch) + `houston-app.exe` + `houston_app.pdb` (PDB filename has underscore — Rust convention); the Linux job uploads its own maps + the `houston-app` ELF. `releases finalize` runs ONCE in the dedicated `finalize` job (after both build jobs upload), not per-build. The CI steps **upload only** (no `inject` — that happens at build time). sentry-cli is the lockfile-pinned `app/node_modules/.bin/sentry-cli` (via the `@sentry/cli` devDep), not an unpinned `get-cli` download.
   - **⚠️ The gate that must never regress:** the upload steps gate on `if: ${{ env.SENTRY_AUTH_TOKEN != '' }}`, and `SENTRY_AUTH_TOKEN` is defined at **job level** on `build-macos` / `build-windows` (and `finalize`). It MUST stay job-level: a step's own `env:` block is NOT visible to that same step's `if:` (GitHub evaluates `if:` before step env), so defining it only in the step made the gate read empty and **silently skipped every upload on every run, official builds included** — the bug that left production stack traces minified/hex despite the maps existing. Same footgun fixed on the PostHog annotation step. Forks without the secret still resolve to `''` and skip.
   - **Version guard:** the `prep` job fails the release if the git tag ≠ `app/package.json` version ≠ `app/src-tauri/Cargo.toml` version (all three feed the one `houston-app@<version>` release identity).
 - **Sentry smoke shortcuts (DEV-ONLY):** `Ctrl+Alt+Shift+J` throws a JS error from `app/src/lib/error-toast.ts` (source-map frame resolution check); `Ctrl+Alt+Shift+N` invokes a native Tauri command that panics with `sentry-native-stack-smoke-test` (app binary/PDB symbolication check); in DevTools the same hooks are `window.__HOUSTON_SENTRY_SMOKE__.javascript()` / `.native()`. Because dev builds now suppress Sentry by default (Dev suppression above), these only actually transmit when `SENTRY_SEND_IN_DEV` is set — run `pnpm tauri dev` with both that flag and a `SENTRY_DSN` to verify delivery; without the flag BOTH triggers show the dev "no issue sent" toast and nothing leaves the machine (the native trigger checks `sentrySuppressedInDev` too, so it never tells you to "Check Sentry" when the client was never initialized). **These are compiled OUT of release builds** — the JS triggers are gated behind `import.meta.env.DEV` in `main.tsx` (tree-shaken in prod) and the native command's panic path behind `#[cfg(debug_assertions)]` in `commands/diagnostics.rs` (no-op in release). Reason: Houston is open source and official release binaries bake the prod `SENTRY_DSN`, so shipping reachable error-injectors would let anyone flood the prod Sentry project. **To verify symbolication on a SIGNED build** (rare — only when the build/upload setup changes), temporarily drop the `import.meta.env.DEV` guard + the `debug_assertions` cfg and cut a one-off tagged build (the disposable-version + `gh release delete --cleanup-tag` flow). Note: the native smoke panics the **app** process — there is no dedicated engine-process smoke trigger; verify engine (`runtime=engine`) symbolication against a real engine crash.
@@ -204,40 +204,47 @@ CI also needs as Secrets:
 
 - **Workflow:** `.github/workflows/release.yml`
 - **Trigger:** Push tag matching `v*`
-- **Output:** Draft GitHub Release w/ signed+notarized DMG + signed MSI + `latest.json`
-- **Duration:** ~25-30 min wall-clock (mac + win run in parallel; mac is the long pole at ~25 min including Apple notarization).
+- **Engine:** builds the desktop app around the **bun-compiled Houston host sidecar** (the TS engine) via `--features host-sidecar` + `VITE_NEW_ENGINE=1` — NOT the legacy Rust `houston-engine`. No provider CLIs are bundled (pi runs providers in-process). The app's build DEFAULTS stay Rust (a plain `pnpm tauri build` still builds the Rust engine); only the release workflow passes the host-sidecar flags, so `engine/` remains the instant-rollback oracle until the gated final cutover (`convergence/final-cutover.md`).
+- **Output:** Draft GitHub Release w/ signed+notarized universal DMG + signed Windows MSI (x64 + arm64) + Linux AppImage + `.deb` + `latest.json`
+- **Duration:** ~25-30 min wall-clock (mac + win + linux run in parallel; mac is the long pole at ~25 min including Apple notarization).
 - **Draft = QA gate.** Users don't see until published on GitHub.
 
 ### Job graph
 ```
 prep (ubuntu, ~30s)               creates empty draft + release-notes.md artifact
-  ├── build-macos (mac, ~25m)     builds, signs, notarizes, uploads DMG/tar/sig/latest.json
-  └── build-windows (win, ~20m)   builds, uploads MSI + .sig
-        └── finalize (ubuntu, ~30s) extends latest.json with windows-x86_64 entry, posts Slack
+  ├── build-macos (mac, ~25m)     bun-compiles host sidecar (both arches) → signs, notarizes, uploads DMG/tar/sig/latest.json
+  ├── build-windows (win, ~15m)   bun-compiles host sidecar per arch → uploads MSI + .sig (x64 + arm64)
+  └── build-linux (ubuntu, ~15m)  bun-compiles host sidecar → uploads AppImage + .deb (download-only, not in latest.json)
+        └── finalize (ubuntu, ~30s) [needs mac + win] extends latest.json with windows entries, posts Slack
 ```
-Mac and Windows run in parallel because they only need the empty draft `prep` creates, not each other's output. `finalize` stitches `latest.json` together (the macOS-only base from build-macos plus the Windows entry assembled from the MSI .sig in the draft) and posts the team Slack notification. Slack lives in `finalize` (not Windows) because it needs `release-notes.md` and the file is published as a workflow artifact by `prep`.
+Mac, Windows, and Linux run in parallel because they only need the empty draft `prep` creates, not each other's output. `finalize` stitches `latest.json` together (the macOS-only base from build-macos plus the Windows entries assembled from the MSI .sig in the draft) and posts the team Slack notification — it needs only mac + win, so a flaky new Linux leg never blocks the updater manifest or the mac/win artifacts already on the draft. Linux is UNSIGNED + download-only (no auto-update entry). Slack lives in `finalize` (not Windows) because it needs `release-notes.md` and the file is published as a workflow artifact by `prep`.
 
 ## macOS Universal (arm64 + Intel)
 
 Houston ships ONE DMG that runs natively on Apple Silicon AND Intel. Same app, same download, same update channel.
 
 ### How it works
-- `release.yml` builds `houston-engine` TWICE — once per real triple (`aarch64-apple-darwin`, `x86_64-apple-darwin`).
-- `build.rs` stages both as per-triple sidecars: `src-tauri/binaries/houston-engine-aarch64-apple-darwin` + `-x86_64-apple-darwin`. Tauri universal build requires per-triple sidecars (NOT a pre-lipo'd fat binary).
-- `tauri-action` invoked with `--target universal-apple-darwin`. It runs cargo twice, then `lipo`s the outputs into one fat `.app`. Bundle lands at `target/universal-apple-darwin/release/bundle/`.
-- Verification step runs `lipo -info` on the embedded engine sidecar and fails the release if either slice is missing.
+- `release.yml` bun-compiles the **host sidecar** TWICE — once per real triple (`aarch64-apple-darwin`, `x86_64-apple-darwin`) via `scripts/build-host-sidecar.sh <triple>` — then `lipo`s the two `target/host-sidecar/houston-host-<triple>` outputs into one fat `binaries/houston-engine-universal-apple-darwin` (the universal bundle's externalBin).
+- `build.rs::stage_host_sidecar` (the `host-sidecar` cargo feature) also stages per-triple copies to `src-tauri/binaries/houston-engine-<triple>` during tauri's per-arch cargo runs; the manually-lipo'd fat binary is what the `--target universal-apple-darwin` bundle actually ships. It reuses the SAME externalBin name the Rust engine used, so `tauri.conf.json` never branches on the feature.
+- `tauri-action` invoked with `--target universal-apple-darwin --features host-sidecar`. Bundle lands at `target/universal-apple-darwin/release/bundle/`.
+- Verification step runs `lipo -info` on the embedded host sidecar and fails the release if either slice is missing.
 - `latest.json` ships FOUR platform keys (`darwin-aarch64`, `darwin-aarch64-app`, `darwin-x86_64`, `darwin-x86_64-app`) all pointing at the same tarball + signature. Intel users on older Houston installs check `darwin-x86_64` — if that key is absent they NEVER see the update prompt.
 - `bundle.macOS.minimumSystemVersion = 10.15` in `tauri.conf.json` — required for Intel Macs old enough to matter.
 
-### Engine-only release
-`.github/workflows/engine-release.yml` (tag `engine-v*`) builds `houston-engine` standalone for Linux (arm64 + x86_64 musl) and macOS (arm64 + Intel). Four artifacts total.
+### Standalone host binary release
+`.github/workflows/engine-release.yml` (tag `engine-v*`) bun-compiles the **standalone Houston host binary** (`houston-host-<triple>` — the same self-contained binary the desktop embeds as its sidecar, and the one a `selfhost/` operator can run directly instead of the Docker image) for Linux (arm64 + x86_64 gnu) and macOS (arm64 + Intel). Four artifacts total. Replaced the legacy standalone Rust `houston-engine` build; needs no Rust toolchain (bun only).
 
 ### Local universal build
 ```bash
 rustup target add aarch64-apple-darwin x86_64-apple-darwin
-cargo build --release --target aarch64-apple-darwin -p houston-engine-server
-cargo build --release --target x86_64-apple-darwin -p houston-engine-server
-cd app && pnpm tauri build --target universal-apple-darwin
+# bun-compile the host sidecar for both arches, then lipo into the universal externalBin
+scripts/build-host-sidecar.sh aarch64-apple-darwin
+scripts/build-host-sidecar.sh x86_64-apple-darwin
+lipo -create \
+  target/host-sidecar/houston-host-aarch64-apple-darwin \
+  target/host-sidecar/houston-host-x86_64-apple-darwin \
+  -output app/src-tauri/binaries/houston-engine-universal-apple-darwin
+cd app && VITE_NEW_ENGINE=1 pnpm tauri build --target universal-apple-darwin --features host-sidecar
 ```
 Output: `target/universal-apple-darwin/release/bundle/{macos,dmg}/`.
 


### PR DESCRIPTION
## What

Closes **HOU-628** — update the GitHub Actions to build the desktop app with the new TypeScript engine.

The release workflows were rewired off the legacy Rust `houston-engine` and onto the bun-compiled **Houston host sidecar** (the single TS engine), reusing the *exact* signing / notarization / updater / Slack machinery and the secrets already on the repo (the "almost the same workflow, same signin" ask).

## Changes

### `.github/workflows/release.yml` (tag `v*`) — rewritten in place
- **build-macos / build-windows:** removed the codex/composio/git-bash CLI staging, the CLI pre-sign step, and `cargo build -p houston-engine-server`. Swapped in `oven-sh/setup-bun` → `scripts/build-host-sidecar.sh` (mac: both arches + `lipo`) → `tauri build --features host-sidecar` with `VITE_NEW_ENGINE=1`. Kept **verbatim**: Apple cert import, `.app` notarize/staple, DMG rename/re-sign/notarize/verify, updater manifest, MSI updater signing, upload-to-draft.
- **build-linux (NEW):** x86_64 AppImage + `.deb`, viable for the first time now the host bundles no CLIs (uses the existing `scripts/ci/{install-tauri-linux-deps,appimage-ldd-shim}.sh`). Unsigned, download-only — **not** wired into the auto-updater.
- **finalize:** unchanged (latest.json stitch + PostHog + Slack; still `needs: [build-macos, build-windows]` so a flaky Linux leg never blocks the updater).
- Sentry uploads slimmed to the Tauri app shell (the host sidecar is a self-contained bun binary — no dSYM/PDB).

### `.github/workflows/engine-release.yml` (tag `engine-v*`) — replaced
Now bun-compiles the **standalone** `houston-host-<triple>` binary (macOS arm64/x64 + Linux arm64/x64 gnu) — the same self-contained binary the desktop embeds and a `selfhost/` operator can run directly. No Rust toolchain / musl.

### Shared
- Workflow-level `BUN_VERSION: "1.3.10"` (matches the repo's existing pin in `cli-deps.json`).

## Safety / rollback

This is a **CI-only** cutover. The app build **defaults are untouched** (`app/src-tauri/Cargo.toml` `host-sidecar` stays opt-in; `app/vite.config.ts` stays Rust-default) — a plain `pnpm tauri build` still builds the Rust engine, so `engine/` remains the instant-rollback oracle. Only the release workflows ship the TS engine. Flipping the defaults + deleting `engine/` remain the gated final cutover (`convergence/final-cutover.md`). Rollback = revert this PR.

## Verification

**Load-bearing new command, proven locally end-to-end** (this Mac, arm64):
```
$ scripts/build-host-sidecar.sh aarch64-apple-darwin --verify
Built host sidecar: target/host-sidecar/houston-host-aarch64-apple-darwin (73M)
Banner: HOUSTON_HOST_LISTENING port=8090 token=t1
GET /v1/capabilities → {"profile":"local", ...}
VERIFIED: host served /v1/capabilities (profile=local)
```
- Both workflow YAMLs parse; job/step graph confirmed (`prep → build-{macos,windows,linux} → finalize`).
- No `houston-engine-server` / `cargo build ... engine` / `fetch-cli-deps.sh` invocations remain in either workflow.
- The signing / notarization steps are preserved verbatim from the proven Rust pipeline (they need Apple secrets + GitHub runners, so they run only in CI).

**Before:** on `main`, `release.yml` runs `cargo build -p houston-engine-server` + `fetch-cli-deps.sh both` and a `v*` tag ships the Rust engine.
**After:** a `v*` tag bun-compiles the host sidecar and ships the TS engine (universal DMG + Windows x64/arm64 MSI + Linux AppImage/deb), signed/notarized exactly as before. First real end-to-end confirmation of the packaged `.app` is the one manual step in `convergence/packaged-app-launch.md` (now updated to point at `release.yml`).

**Watch items:** Windows-arm64 host-sidecar compile is the least battle-tested leg (`fail-fast: false` isolates it from x64); Linux is unsigned + not auto-updating.

## Docs updated
`knowledge-base/production-infra.md`, `convergence/README.md`, `convergence/final-cutover.md`, `convergence/packaged-app-launch.md`, `knowledge-base/cli-bundling.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
