### PR TITLE
fix(routines): flatten plural unit labels that crashed the schedule builder

### DIFF
--- a/app/src/locales/en/routines.json
+++ b/app/src/locales/en/routines.json
@@ -66,10 +66,10 @@
       "custom": "Custom"
     },
     "units": {
-      "minutes": { "one": "minute", "other": "minutes" },
-      "hours": { "one": "hour", "other": "hours" },
-      "days": { "one": "day", "other": "days" },
-      "months": { "one": "month", "other": "months" }
+      "minutes": "minutes",
+      "hours": "hours",
+      "days": "days",
+      "months": "months"
     },
     "unitsSingular": {
       "minutes": "minute",

--- a/app/src/locales/es/routines.json
+++ b/app/src/locales/es/routines.json
@@ -66,10 +66,10 @@
       "custom": "Personalizado"
     },
     "units": {
-      "minutes": { "one": "minuto", "other": "minutos" },
-      "hours": { "one": "hora", "other": "horas" },
-      "days": { "one": "día", "other": "días" },
-      "months": { "one": "mes", "other": "meses" }
+      "minutes": "minutos",
+      "hours": "horas",
+      "days": "días",
+      "months": "meses"
     },
     "unitsSingular": {
       "minutes": "minuto",

--- a/app/src/locales/pt/routines.json
+++ b/app/src/locales/pt/routines.json
@@ -66,10 +66,10 @@
       "custom": "Personalizado"
     },
     "units": {
-      "minutes": { "one": "minuto", "other": "minutos" },
-      "hours": { "one": "hora", "other": "horas" },
-      "days": { "one": "dia", "other": "dias" },
-      "months": { "one": "mês", "other": "meses" }
+      "minutes": "minutos",
+      "hours": "horas",
+      "days": "dias",
+      "months": "meses"
     },
     "unitsSingular": {
       "minutes": "minuto",

--- a/app/tests/routines-locale-shape.test.ts
+++ b/app/tests/routines-locale-shape.test.ts
@@ -1,0 +1,39 @@
+import { ok, strictEqual } from "node:assert/strict";
+import { describe, it } from "node:test";
+import en from "../src/locales/en/routines.json" with { type: "json" };
+import es from "../src/locales/es/routines.json" with { type: "json" };
+import pt from "../src/locales/pt/routines.json" with { type: "json" };
+
+// The `ui/routines` IntervalPicker types `units` / `unitsSingular` as
+// Record<IntervalUnit, string> and renders `plural ? units[u] : unitsSingular[u]`
+// straight into JSX. The app sources these labels via
+// `t("schedule", { returnObjects: true })`, so a value authored as an OBJECT
+// (e.g. an i18next `{ one, other }` plural) instead of a flat string is handed
+// to React as a child and crashes the whole app:
+//   "Objects are not valid as a React child (found: object with keys
+//    {one, other})."
+// (regression guard — the plural-object crash in the custom schedule builder.)
+// Keep the unit labels flat strings; per-count wording is chosen in `ui/` by
+// switching between `unitsSingular` (count 1) and `units` (count > 1).
+
+const INTERVAL_UNITS = ["minutes", "hours", "days", "months"] as const;
+const LOCALES = { en, es, pt } as const;
+
+describe("routines schedule unit labels are flat strings, not plural objects", () => {
+  for (const [lang, bundle] of Object.entries(LOCALES)) {
+    const schedule = (bundle as { schedule: Record<string, unknown> }).schedule;
+    for (const group of ["units", "unitsSingular"] as const) {
+      it(`${lang}: schedule.${group} maps every interval unit to a string`, () => {
+        const record = schedule[group] as Record<string, unknown>;
+        for (const unit of INTERVAL_UNITS) {
+          ok(unit in record, `${lang}: schedule.${group}.${unit} is missing`);
+          strictEqual(
+            typeof record[unit],
+            "string",
+            `${lang}: schedule.${group}.${unit} must be a string, got ${JSON.stringify(record[unit])}`,
+          );
+        }
+      });
+    }
+  }
+});


### PR DESCRIPTION
## What

Fixes an app crash in the routines **custom schedule builder**:

```
Objects are not valid as a React child (found: object with keys {one, other})
```

It fires whenever the custom interval count is greater than 1 (e.g. "Repeat every 2 days"). Reported while using the dev desktop app against the cloud gateway, but the gateway is incidental — it reproduces for any client.

## Root cause

- `ui/routines`' `IntervalPicker` is i18n-agnostic: it types `units` as `Record<IntervalUnit, string>` and renders `plural ? units[u] : unitsSingular[u]` straight into JSX, choosing singular vs plural by count itself (`ui/routines/src/schedule-interval-picker.tsx:122`, defaults at `labels-default.ts:70-75`).
- But the locale JSON authored `schedule.units` as i18next-style `{ one, other }` **objects**. The app sources them via `t("schedule", { returnObjects: true }) as ScheduleLabels` in `use-routine-labels.ts` — and that `as` cast hid the shape mismatch from typecheck.
- So on the plural branch, `units.minutes` was `{ one, other }`, handed to React as a child → crash. A count of 1 used `unitsSingular` (a real string), which is why it only surfaced above 1.
- These three `units` blocks were the only nested `{ one, other }` objects in the entire locale tree, so this closes the whole class.

## Fix

Flatten `schedule.units` to plain plural strings in en/es/pt to match the `Record<IntervalUnit, string>` contract. `unitsSingular` already carries the singular forms, and `ui/` picks between them by count.

## Test

`app/tests/routines-locale-shape.test.ts` asserts every `schedule.units` / `unitsSingular` value is a string across all shipped locales. Proven red/green — on the old shape it fails with:

```
schedule.units.minutes must be a string, got {"one":"minute","other":"minutes"}
```

and passes with the fix. Runs in CI via `pnpm --filter houston-app test`.

## Verification

- `tsgo --noEmit` clean, Biome clean.
- Follow-up worth scoping separately: the underlying weakness is the `as ScheduleLabels` cast in `use-routine-labels.ts` swallowing shape mismatches — tightening that typing would catch this class at compile time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
