### PR TITLE
ci(release): add cloud desktop build channel (cloud-v* tags)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,15 @@
 # Houston Desktop Release Workflow (TypeScript engine)
 #
-# Triggered by pushing a version tag (e.g. `git tag v0.3.0 && git push --tags`).
+# Triggered by pushing a version tag. Two channels, one pipeline:
+#   - `v*`        → LOCAL build (e.g. `git tag v0.3.0`). The user connects on
+#                   their own machine (host sidecar) or types a remote URL.
+#   - `cloud-v*`  → CLOUD build (e.g. `git tag cloud-v0.3.0`). The managed
+#                   Houston Cloud gateway URL is baked in from a secret, so the
+#                   user just signs in with Google — no URL to enter. Everything
+#                   cloud-specific is gated on the tag prefix, so a `v*` build
+#                   behaves exactly as it did before this channel existed (the
+#                   cloud env vars resolve to '' there, which the app reads as
+#                   unset — see app/src/lib/engine-mode.ts).
 #
 # Builds the desktop app around the Bun-compiled Houston HOST sidecar (the single
 # TypeScript engine), NOT the legacy Rust `houston-engine`. Each platform job
@@ -31,6 +40,11 @@
 #   POSTHOG_HOST                       — PostHog ingest host (e.g. https://us.i.posthog.com)
 #   SUPABASE_URL                       — Supabase project URL
 #   SUPABASE_ANON_KEY                  — Supabase anon key (client-side, RLS-gated)
+#   HOSTED_ENGINE_URL                  — (CLOUD channel only, tag `cloud-v*`) Base URL of the
+#                                        managed Houston Cloud gateway the desktop app connects to.
+#                                        Baked in as VITE_HOSTED_ENGINE_URL so cloud users just sign
+#                                        in with Google — no URL to enter. Kept as a secret; never a
+#                                        literal in this file. Empty/unused on the local `v*` channel.
 #   LINEAR_API_KEY                     — Linear API key for in-app "Report bug" issue creation
 #   LINEAR_TEAM_ID                     — Linear team UUID for in-app "Report bug" issues
 #   SLACK_RELEASE_WEBHOOK_URL          — Slack incoming-webhook to ping the team when a draft release is built
@@ -45,6 +59,7 @@ on:
   push:
     tags:
       - "v*"
+      - "cloud-v*"
 
 permissions:
   contents: write
@@ -83,7 +98,7 @@ jobs:
       - name: Verify tag matches manifest versions
         run: |
           set -euo pipefail
-          TAG="${GITHUB_REF_NAME#v}"
+          TAG="${GITHUB_REF_NAME#cloud-}"; TAG="${TAG#v}"
           PKG_V=$(jq -r .version app/package.json)
           CARGO_V=$(grep -m1 '^version = ' app/src-tauri/Cargo.toml | sed -E 's/version = "(.*)"/\1/')
           echo "tag=$TAG package.json=$PKG_V Cargo.toml=$CARGO_V"
@@ -91,6 +106,21 @@ jobs:
             echo "::error::Version mismatch — tag '$TAG', app/package.json '$PKG_V', app/src-tauri/Cargo.toml '$CARGO_V' must all match. Bump them together before tagging."
             exit 1
           fi
+
+      # A `cloud-v*` tag promises a build with the managed gateway baked in. If
+      # the secret is empty the build would silently fall back to the local
+      # connection chooser (no gateway), shipping a "cloud" app that isn't one.
+      # Fail loudly here (no-silent-failures) rather than at a confused user.
+      - name: Verify cloud gateway secret is set (cloud channel)
+        if: ${{ startsWith(github.ref_name, 'cloud-') }}
+        env:
+          HOSTED_ENGINE_URL: ${{ secrets.HOSTED_ENGINE_URL }}
+        run: |
+          if [ -z "${HOSTED_ENGINE_URL}" ]; then
+            echo "::error::A cloud-v* tag was pushed but the HOSTED_ENGINE_URL secret is empty. Set it (repo → Settings → Secrets) or push a plain v* tag for a local build."
+            exit 1
+          fi
+          echo "HOSTED_ENGINE_URL secret is present — cloud gateway will be baked in."
 
       # Resolve `release-notes.md`. Two paths:
       #
@@ -110,7 +140,7 @@ jobs:
       # polish before publishing.
       - name: Build release notes
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
           AUTHORED=".github/release-notes/${VERSION}.md"
 
           if [ -f "$AUTHORED" ]; then
@@ -180,7 +210,7 @@ jobs:
       - name: Build localized updater notes
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
           DIR=".github/release-notes"
           EN="$DIR/${VERSION}.md"
           ES="$DIR/${VERSION}.es.md"
@@ -233,13 +263,33 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
+          # Distinguish the two channels in the GitHub Releases list so a cloud
+          # draft is never mistaken for the local one (they carry the same
+          # underlying version, only the tag prefix + connection target differ).
+          #
+          # Cloud releases are marked PRERELEASE. This is load-bearing, not
+          # cosmetic: existing LOCAL apps have `…/releases/latest/download/latest.json`
+          # baked in, and GitHub's "latest release" is the newest NON-prerelease,
+          # non-draft release. If a cloud release could become "latest" it would
+          # shadow that URL (a cloud release ships latest-cloud.json, not
+          # latest.json) and every installed local app's auto-updater would 404.
+          # Keeping cloud releases as prereleases means they never become "latest",
+          # so the local updater feed is unaffected. (Consequence: cloud auto-update
+          # via the /latest/ endpoint is a documented follow-up — see the PR /
+          # convergence/README.md; contamination is already prevented by the
+          # channel-specific manifest name.)
+          case "$GITHUB_REF_NAME" in
+            cloud-*) TITLE="Houston Cloud v$VERSION"; PRERELEASE=(--prerelease) ;;
+            *)       TITLE="Houston v$VERSION";       PRERELEASE=() ;;
+          esac
           gh release create "$GITHUB_REF_NAME" \
-            --title "Houston v$VERSION" \
+            --title "$TITLE" \
             --notes-file release-notes.md \
-            --draft
+            --draft \
+            "${PRERELEASE[@]}"
 
-          echo "::notice::Empty draft release created at https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME — macOS + Windows builds will upload artifacts in parallel."
+          echo "::notice::Empty draft release \"$TITLE\" created at https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME — macOS + Windows builds will upload artifacts in parallel."
 
       # Hand release-notes.md to downstream jobs (Slack notifier in
       # finalize, updater-manifest builder in build-macos) without each of
@@ -283,6 +333,17 @@ jobs:
       # bun-compiled host sidecar, not the legacy Rust wire. Job-level so every
       # step — including tauri-action's beforeBuildCommand child — sees it.
       VITE_NEW_ENGINE: "1"
+      # CLOUD channel (tag `cloud-v*`): bake the managed gateway URL so the
+      # packaged app talks to Houston Cloud and the user just signs in with
+      # Google — no URL to enter (resolveEngine → hosted-oauth, chooser skipped).
+      # The URL is a SECRET, never a literal. On the local `v*` channel these
+      # resolve to '' (a missing secret is also ''), so that build is unchanged.
+      # VITE_HOSTED_ENGINE_AUTH=oauth is the managed-cloud default anyway; set it
+      # explicitly so the Google-login gate is unambiguous. Baked as VITE_* build
+      # constants (consumed by app/vite.config.ts), so job-level like the flag above.
+      IS_CLOUD: ${{ startsWith(github.ref_name, 'cloud-') }}
+      VITE_HOSTED_ENGINE_URL: ${{ startsWith(github.ref_name, 'cloud-') && secrets.HOSTED_ENGINE_URL || '' }}
+      VITE_HOSTED_ENGINE_AUTH: ${{ startsWith(github.ref_name, 'cloud-') && 'oauth' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -418,6 +479,16 @@ jobs:
       # sidecar is handled the same way via the per-triple
       # `binaries/houston-engine-<triple>` files staged by `build.rs`.
       # Bundle output lands under `target/universal-apple-darwin/release/bundle/`.
+      # CLOUD channel only: repoint the in-app updater at `latest-cloud.json`
+      # BEFORE the build bakes tauri.conf.json in, so a Houston Cloud app never
+      # reads the local channel's `latest.json` (which would auto-update it into
+      # a local build and drop the baked gateway). Local `v*` builds skip this
+      # and keep the default `latest.json` endpoint untouched. Edits only the
+      # runner's checkout — never committed.
+      - name: Point updater at cloud manifest (cloud channel)
+        if: ${{ env.IS_CLOUD == 'true' }}
+        run: bash scripts/ci/point-updater-at-cloud-manifest.sh
+
       - name: Build Tauri app (universal)
         uses: tauri-apps/tauri-action@v0
         with:
@@ -565,7 +636,7 @@ jobs:
           SENTRY_PROJECT: houston-app
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
           RELEASE="houston-app@${VERSION}"
 
           # Use the sentry-cli pinned in app/package.json (devDep @sentry/cli)
@@ -736,7 +807,16 @@ jobs:
 
       - name: Generate updater manifest
         run: |
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
+          # Channel-specific updater manifest name so the cloud + local feeds
+          # stay distinct release assets (the cloud app's baked endpoint points
+          # at latest-cloud.json — see point-updater-at-cloud-manifest.sh).
+          # Exported so the upload + finalize steps agree on the filename.
+          case "$GITHUB_REF_NAME" in
+            cloud-*) MANIFEST="latest-cloud.json" ;;
+            *)       MANIFEST="latest.json" ;;
+          esac
+          echo "MANIFEST=$MANIFEST" >> "$GITHUB_ENV"
           TAR_NAME=$(basename "${{ steps.artifacts.outputs.tar }}")
           SIG=$(cat "${{ steps.artifacts.outputs.sig }}")
           URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/$TAR_NAME"
@@ -777,10 +857,10 @@ jobs:
                   url: $url
                 }
               }
-            }' > latest.json
+            }' > "$MANIFEST"
 
-          echo "latest.json:"
-          cat latest.json
+          echo "$MANIFEST:"
+          cat "$MANIFEST"
 
       # Draft release was already created in the `prep` job. We only need
       # to upload the macOS-specific artifacts to it. `--clobber` makes
@@ -798,7 +878,7 @@ jobs:
             "${{ steps.artifacts.outputs.dmg }}" \
             "${{ steps.artifacts.outputs.tar }}" \
             "${{ steps.artifacts.outputs.sig }}" \
-            latest.json \
+            "$MANIFEST" \
             checksums-sha256.txt \
             --clobber
 
@@ -844,6 +924,11 @@ jobs:
       # See build-macos: aliases the frontend to the v3 host adapter so the
       # packaged app runs on the bun-compiled host sidecar.
       VITE_NEW_ENGINE: "1"
+      # See build-macos: cloud channel bakes the managed gateway URL (a secret)
+      # so cloud users just sign in with Google. Empty on the local `v*` channel.
+      IS_CLOUD: ${{ startsWith(github.ref_name, 'cloud-') }}
+      VITE_HOSTED_ENGINE_URL: ${{ startsWith(github.ref_name, 'cloud-') && secrets.HOSTED_ENGINE_URL || '' }}
+      VITE_HOSTED_ENGINE_AUTH: ${{ startsWith(github.ref_name, 'cloud-') && 'oauth' || '' }}
     strategy:
       # Both arches build in parallel. fail-fast=false so a transient
       # ARM-runner outage doesn't kill the x64 release that 90%+ of
@@ -922,6 +1007,14 @@ jobs:
           echo "Sidecar size:"
           ls -lah target/host-sidecar/houston-host-${{ matrix.target }}.exe
 
+      # CLOUD channel only: repoint the updater at `latest-cloud.json` before the
+      # build bakes tauri.conf.json in (see build-macos for the why). The script
+      # is Node-based so it also runs on windows-11-arm, where jq is absent.
+      - name: Point updater at cloud manifest (cloud channel)
+        if: ${{ env.IS_CLOUD == 'true' }}
+        shell: bash
+        run: bash scripts/ci/point-updater-at-cloud-manifest.sh
+
       - name: Build Tauri app (Windows MSI)
         uses: tauri-apps/tauri-action@v0
         with:
@@ -997,7 +1090,7 @@ jobs:
           SENTRY_PROJECT: houston-app
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
           RELEASE="houston-app@${VERSION}"
 
           # Use the lockfile-pinned sentry-cli from app/package.json via the
@@ -1078,6 +1171,12 @@ jobs:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
       # See build-macos: aliases the frontend to the v3 host adapter.
       VITE_NEW_ENGINE: "1"
+      # See build-macos: cloud channel bakes the managed gateway URL (a secret).
+      # Linux is download-only / not wired into the auto-updater, so it needs no
+      # endpoint rewrite — only the baked URL so the app reaches the gateway.
+      IS_CLOUD: ${{ startsWith(github.ref_name, 'cloud-') }}
+      VITE_HOSTED_ENGINE_URL: ${{ startsWith(github.ref_name, 'cloud-') && secrets.HOSTED_ENGINE_URL || '' }}
+      VITE_HOSTED_ENGINE_AUTH: ${{ startsWith(github.ref_name, 'cloud-') && 'oauth' || '' }}
       # AppImage packaging on headless CI: don't strip (keeps the bundled
       # sidecar intact) and extract-and-run the AppImage tooling (no FUSE on
       # GitHub runners).
@@ -1195,7 +1294,7 @@ jobs:
           SENTRY_PROJECT: houston-app
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
           RELEASE="houston-app@${VERSION}"
           SENTRY_CLI="app/node_modules/.bin/sentry-cli"
           "$SENTRY_CLI" --version
@@ -1290,7 +1389,7 @@ jobs:
           SENTRY_PROJECT: houston-app
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
           RELEASE="houston-app@${VERSION}"
           # This job has no source tree / node_modules, so use the standalone
           # CLI. Pin it to the same major the app's @sentry/cli devDep tracks.
@@ -1310,14 +1409,21 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
+          # Match the channel-specific manifest build-macos uploaded (the cloud
+          # app's baked updater endpoint reads latest-cloud.json). finalize has
+          # no checkout, so derive the name from the tag, not a shared file.
+          case "$GITHUB_REF_NAME" in
+            cloud-*) MANIFEST="latest-cloud.json" ;;
+            *)       MANIFEST="latest.json" ;;
+          esac
           tmpdir=$(mktemp -d)
           gh release download "$GITHUB_REF_NAME" \
-            --pattern 'latest.json' \
+            --pattern "$MANIFEST" \
             --pattern '*.msi.sig' \
             --dir "$tmpdir"
 
-          if [ ! -s "$tmpdir/latest.json" ]; then
-            echo "::error::latest.json not found in draft release; build-macos must have failed to upload it"
+          if [ ! -s "$tmpdir/$MANIFEST" ]; then
+            echo "::error::$MANIFEST not found in draft release; build-macos must have failed to upload it"
             exit 1
           fi
 
@@ -1333,7 +1439,7 @@ jobs:
             exit 1
           fi
 
-          cp "$tmpdir/latest.json" "$tmpdir/latest.next.json"
+          cp "$tmpdir/$MANIFEST" "$tmpdir/latest.next.json"
           for SIG_FILE in "${sigs[@]}"; do
             MSI_NAME=$(basename "$SIG_FILE" .sig)
             MSI_URL="https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/$MSI_NAME"
@@ -1354,12 +1460,12 @@ jobs:
             mv "$tmpdir/latest.merged.json" "$tmpdir/latest.next.json"
           done
 
-          echo "Updated latest.json:"
+          echo "Updated $MANIFEST:"
           cat "$tmpdir/latest.next.json"
 
-          mv "$tmpdir/latest.next.json" "$tmpdir/latest.json"
-          gh release upload "$GITHUB_REF_NAME" "$tmpdir/latest.json" --clobber
-          echo "::notice::latest.json now advertises macOS + Windows (x64 + arm64) for the in-app updater"
+          mv "$tmpdir/latest.next.json" "$tmpdir/$MANIFEST"
+          gh release upload "$GITHUB_REF_NAME" "$tmpdir/$MANIFEST" --clobber
+          echo "::notice::$MANIFEST now advertises macOS + Windows (x64 + arm64) for the in-app updater"
 
       # Drop a PostHog annotation marking this release. Every PostHog
       # insight chart shows a vertical line at this timestamp, so any
@@ -1375,7 +1481,7 @@ jobs:
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
         run: |
           set -euo pipefail
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
           HOST="${POSTHOG_HOST:-https://us.posthog.com}"
           # Strip the i. ingestion subdomain if someone configured POSTHOG_HOST
           # for client ingest (us.i.posthog.com). The annotation REST API
@@ -1412,7 +1518,7 @@ jobs:
             exit 0
           fi
 
-          VERSION="${GITHUB_REF_NAME#v}"
+          VERSION="${GITHUB_REF_NAME#cloud-}"; VERSION="${VERSION#v}"
           RELEASE_URL="https://github.com/${{ github.repository }}/releases/tag/${GITHUB_REF_NAME}"
           DMG_URL=$(gh release view "$GITHUB_REF_NAME" --json assets --jq '[.assets[] | select(.name | endswith(".dmg")) | .url] | first // empty')
 

--- a/convergence/README.md
+++ b/convergence/README.md
@@ -115,6 +115,32 @@ in a separate `host-sidecar-release.yml` / `ts-engine-desktop-artifacts.yml`;
 those were never committed — the build logic they described now lives directly in
 `release.yml` + `engine-release.yml`.)
 
+**Cloud desktop channel (tag `cloud-v*`).** `release.yml` now drives TWO channels
+from one pipeline: `v*` = the LOCAL build (host sidecar / connection chooser,
+unchanged) and `cloud-v*` = a CLOUD build that bakes the managed gateway URL in
+from the `HOSTED_ENGINE_URL` **secret** (never a literal) as
+`VITE_HOSTED_ENGINE_URL` + `VITE_HOSTED_ENGINE_AUTH=oauth`, so `resolveEngine` →
+`hosted-oauth` and the user just signs in with Google — no URL to enter. Every
+cloud-specific line is gated on `startsWith(github.ref_name, 'cloud-')`, so a `v*`
+build is byte-identical to before. The cloud channel repoints the in-app updater
+at a distinct `latest-cloud.json` manifest (`scripts/ci/point-updater-at-cloud-manifest.sh`,
+Node-based so it runs on windows-11-arm too) so a cloud app can never auto-update
+into a local build (dropping the baked gateway) or vice-versa. Cloud releases are
+also created as **prereleases** so they can never become GitHub's "latest release"
+(which is the newest NON-prerelease) and shadow the local channel's baked
+`…/releases/latest/download/latest.json` endpoint — otherwise the first published
+cloud release would 404 every installed local app's auto-updater. The desktop
+hosted path itself is unchanged app code (`app/src/lib/engine-mode.ts`,
+`knowledge-base/auth.md`); this is purely the CI that ships it. Known non-blocking
+follow-ups: the packaged app still spawns an idle host sidecar in hosted mode
+(`lib.rs` `host_mode` reads runtime env, which is empty in a packaged app — an
+`option_env!` check would let it skip the spawn); and cloud auto-update itself is
+not wired up yet — because cloud releases are prereleases, the cloud app's
+`…/releases/latest/download/latest-cloud.json` endpoint resolves to the latest
+non-prerelease (a local release) and 404s, so cloud is effectively download-only
+until a fixed-tag / channel-pinned updater endpoint exists (the manifest isolation
+here is the foundation for that).
+
 This is a CI-only cutover: it flips what the RELEASE ships to the TS engine, but
 the app's build DEFAULTS are untouched (a plain `pnpm tauri build` still builds the
 Rust engine; the `app/vite.config.ts` + `app/src-tauri/Cargo.toml` defaults are

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -73,6 +73,15 @@ bakes Supabase, the app-wide sign-in (`App.tsx`'s `isAuthConfigured()` gate) sti
 applies, so the no-login path is meant for service-token smoke builds that bake no
 Supabase creds.
 
+**Shipping a cloud desktop build.** The signed, all-platform CI for this mode is
+the `cloud-v*` channel of `.github/workflows/release.yml`: tag `cloud-v<version>`
+and it builds mac/win/linux with `VITE_HOSTED_ENGINE_URL` baked from the
+`HOSTED_ENGINE_URL` **secret** (the gateway URL is never a literal) plus
+`VITE_HOSTED_ENGINE_AUTH=oauth`, so users just sign in with Google — no URL to
+enter. The plain `v*` channel is the unchanged local build. See
+`convergence/README.md` → "Host-sidecar release CI" for the channel details and
+the updater-isolation note.
+
 ### Testing Google login against the local kind gateway
 
 To exercise the real Google-login flow against the `gethouston/cloud` local kind

--- a/scripts/ci/point-updater-at-cloud-manifest.sh
+++ b/scripts/ci/point-updater-at-cloud-manifest.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Point the in-app updater at the CLOUD release channel's manifest.
+#
+# The desktop app ships two channels from this repo's releases:
+#   - local build  (tag `v*`)       → updater manifest `latest.json`
+#   - cloud build  (tag `cloud-v*`) → updater manifest `latest-cloud.json`
+#
+# A cloud app must NEVER read the local channel's `latest.json`: doing so would
+# auto-update it into a LOCAL build, dropping the baked gateway URL and dumping
+# the user back on the connection chooser (and symmetrically a local app must
+# not read a cloud manifest). Repointing the cloud build's updater endpoint at
+# `latest-cloud.json` keeps the two channels' manifests as distinct release
+# assets, so neither can ever feed the other — the worst case is "no update
+# found", never a wrong-channel update.
+#
+# Edits ONLY the runner's checkout of tauri.conf.json — never committed. Uses
+# Node (present on every GitHub runner, including windows-11-arm where jq is
+# not), mirroring configure-ts-engine-unsigned.sh.
+set -euo pipefail
+
+CONF="app/src-tauri/tauri.conf.json"
+[ -f "$CONF" ] || { echo "::error::$CONF not found (run this from the repo root)"; exit 1; }
+
+node -e '
+const fs = require("fs");
+const p = process.argv[1];
+const c = JSON.parse(fs.readFileSync(p, "utf8"));
+const eps = c && c.plugins && c.plugins.updater && c.plugins.updater.endpoints;
+if (!Array.isArray(eps) || eps.length === 0) {
+  console.error("::error::plugins.updater.endpoints missing — cannot repoint the cloud updater");
+  process.exit(1);
+}
+const next = eps.map((u) => u.replace(/latest\.json$/, "latest-cloud.json"));
+if (next.every((u, i) => u === eps[i])) {
+  console.error("::error::no endpoint ended in latest.json — refusing to ship a cloud build on the local updater feed");
+  process.exit(1);
+}
+c.plugins.updater.endpoints = next;
+fs.writeFileSync(p, JSON.stringify(c, null, 2) + "\n");
+console.log("Cloud updater endpoints: " + next.join(", "));
+' "$CONF"


### PR DESCRIPTION
## What

Adds a **cloud desktop build channel** to `release.yml` so we can ship a desktop
app that's pre-wired to the managed Houston Cloud gateway: the user just downloads,
signs in with Google, and uses it — **no URL to enter**. The existing local build
is untouched.

One workflow, two channels, selected by tag prefix:

| Tag | Channel | Engine target |
|---|---|---|
| `v0.4.9` | **local** (unchanged) | host sidecar on this machine, or a remote URL the user types |
| `cloud-v0.4.9` | **cloud** (new) | managed gateway, baked in; Google sign-in |

## How

- **Gateway URL is a secret, never a literal.** The cloud channel bakes
  `VITE_HOSTED_ENGINE_URL` from the new **`HOSTED_ENGINE_URL`** secret (+
  `VITE_HOSTED_ENGINE_AUTH=oauth`). The app already supports this exact mode
  (`app/src/lib/engine-mode.ts` `resolveEngine` → `hosted-oauth` →
  `HostedEngineGate` + Google sign-in); this PR is only the CI that ships it.
- **Everything cloud-specific is gated on `startsWith(github.ref_name, 'cloud-')`,**
  so a plain `v*` build behaves exactly as before (the cloud env vars resolve to
  `''`, which the app reads as unset). All three platforms build the cloud variant:
  macOS universal DMG, Windows x64/arm64 MSI, Linux x64 AppImage — same signing +
  notarization as today.
- **Updater channel isolation + local protection.** The cloud build repoints the
  in-app updater at a distinct `latest-cloud.json` manifest
  (`scripts/ci/point-updater-at-cloud-manifest.sh`, Node-based so it also runs on
  windows-11-arm where `jq` is absent) so the two channels' manifests are separate
  release assets and can never cross-update. **Cloud releases are also created as
  prereleases** — this is load-bearing: GitHub's "latest release" is the newest
  *non-prerelease*, and existing local apps have `…/releases/latest/download/latest.json`
  baked in. Without prerelease, the first published cloud release would become
  "latest" (it ships `latest-cloud.json`, not `latest.json`) and **404 every
  installed local app's auto-updater**. Prerelease keeps cloud off the "latest"
  pointer, so the local updater feed is untouched.
- **Fails loud, not silent.** A `cloud-v*` tag pushed without `HOSTED_ENGINE_URL`
  set aborts in `prep` with a clear message, instead of shipping a "cloud" app that
  quietly has no gateway.
- Version extraction (`prep` version-match, Sentry release, notes, updater manifest)
  now strips an optional `cloud-` prefix, so `cloud-v0.4.9` → `0.4.9` and the
  tag/manifest version check still passes.

## New secret

`HOSTED_ENGINE_URL` — base URL of the managed gateway. **Cloud channel only**;
empty/unused for `v*`. Not documented as a literal anywhere in the repo.

## Verification

- `actionlint` clean — **0 new findings vs. baseline, 0 native errors** (only the
  same pre-existing shellcheck `info` notes on untouched `ls`/`find` steps).
- `scripts/ci/point-updater-at-cloud-manifest.sh` shellcheck-clean and tested
  against a copy of `tauri.conf.json` (rewrites the endpoint, leaves the real file
  untouched).
- Traced the full chain CI job-env → vite `import.meta.env` → `engine.ts`
  `resolveEngine` → `hosted-oauth`. Confirmed the local `v*` path is behaviorally
  unchanged (every cloud line is a no-op when the tag doesn't start with `cloud-`).

## How to cut a cloud build

1. Set the `HOSTED_ENGINE_URL` repo secret (Settings → Secrets → Actions).
2. `git tag cloud-v<version> && git push origin cloud-v<version>` (version must
   match `app/package.json` + `app/src-tauri/Cargo.toml`, same rule as `v*`).
3. A draft "Houston Cloud v<version>" release appears with signed all-platform
   artifacts + `latest-cloud.json`; publish after QA.

## Known follow-ups (non-blocking, out of scope here)

- **Idle sidecar in the packaged cloud app.** `lib.rs` decides `host_mode` from
  *runtime* env (`std::env::var`), which is empty in a packaged app, so the cloud
  build still spawns an unused host sidecar (already the accepted behavior for the
  remote-chooser path). An `option_env!("VITE_HOSTED_ENGINE_URL")` compile-time
  check would let it skip the spawn. The app still connects to the gateway
  correctly; the sidecar is just dead weight.
- **Cloud auto-update isn't wired up yet.** Because cloud releases are prereleases
  (to protect the local feed, above), the cloud app's
  `…/releases/latest/download/latest-cloud.json` endpoint resolves to the latest
  *non-prerelease* (a local release) and 404s — so cloud is effectively
  download-only for now. Reliable cloud auto-update needs a fixed-tag /
  channel-pinned endpoint; the manifest isolation in this PR is the foundation for
  that. (This PR does not regress anything: there was no cloud channel before.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
