### PR TITLE
feat(design): cross-surface component inventory + parity manifests + CI check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,26 @@ Closes #
 
 -
 
+## Surface impact
+
+<!-- A UI/UX change must not silently skip a surface. Tick what this PR touches.
+     Procedure: knowledge-base/client-architecture.md -->
+
+Change type:
+
+- [ ] Behavior (shared SDK view-model — `packages/sdk`)
+- [ ] Look (design tokens — `packages/design-tokens`)
+- [ ] Structure (a component added/changed → bump `design/inventory/inventory.yaml` + CHANGELOG + update enforced manifests)
+- [ ] n-a (no user-facing surface change)
+
+Surfaces updated:
+
+- [ ] Web / desktop
+- [ ] iOS
+- [ ] Android
+
+<!-- Structural change? `pnpm check:parity` must pass. See design/inventory/README.md. -->
+
 ## Checklist
 
 - [ ] I read the diff myself before opening this PR (AI-assisted is fine, AI-unreviewed is not)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Boundary check
         run: pnpm check:boundaries
 
+      - name: Parity check (cross-surface component inventory)
+        run: pnpm check:parity
+
       - name: Typecheck (pnpm workspace)
         run: pnpm -r typecheck
 
@@ -60,6 +63,7 @@ jobs:
           pnpm --filter @houston/host-cloud test
           pnpm --filter @houston/runtime test
           pnpm --filter @houston/code-sandbox test
+          pnpm exec vitest run scripts/check-parity.test.mjs
 
   web:
     name: Web (typecheck + unit + UI tests)

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Inventory changelog
+
+Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
+`pnpm check:parity`). Newest first. Use `## vN` headings.
+
+## v1 - 2026-07-03
+
+Initial cross-surface component inventory. 22 components derived from an audit of
+the `ui/` packages, scoped to pieces that are genuinely cross-surface (will exist
+on native iOS/Android). Establishes the structural-parity contract and the three
+surface manifests.
+
+Components: agent-avatar, agent-list-item, conversation-feed, assistant-message,
+user-message, thinking-indicator, tool-call-chip, provider-error-card,
+system-message, skill-invocation-message, composer, turn-status, progress-panel,
+approval-surface, deliverable-card, mission-card, mission-board,
+mission-status-chip, routine-row, skill-row, empty-state, toast.
+
+Surfaces: web (enforced, inventoryVersion 1), ios + android (unenforced,
+inventoryVersion 0, all not-started).

--- a/design/inventory/README.md
+++ b/design/inventory/README.md
@@ -1,0 +1,112 @@
+# Cross-surface component inventory
+
+Houston runs on three surfaces: **web/desktop** (React, shipping today), and the
+coming native **iOS** (SwiftUI) and **Android** (Kotlin Compose) apps. A UI/UX
+change made on one surface must not silently skip the others. Three layers keep
+them in step:
+
+| Layer | Owns | Source of truth |
+| --- | --- | --- |
+| **Behavior** | what a component does | the shared SDK view-models (`packages/sdk`) |
+| **Look** | color / type / spacing / motion | design tokens (`packages/design-tokens`) |
+| **Structure** | which components exist, their anatomy/states/semantics, and who implements which | **this directory** |
+
+This directory is the **structural** layer. It answers: *does this component
+exist on each surface, with the same parts, states, and semantics?* It is a
+versioned engineering contract, CI-checked, not remembered.
+
+## Files
+
+```
+design/inventory/
+  inventory.yaml        the versioned cross-surface component spec (source of truth)
+  CHANGELOG.md          one entry per version bump
+  manifests/
+    web.yaml            web/desktop  — enforced
+    ios.yaml            iOS          — unenforced (not built yet)
+    android.yaml        Android      — unenforced (not built yet)
+  README.md             this file
+```
+
+The checker lives at `scripts/check-parity.mjs` (`pnpm check:parity`), factored
+into `scripts/parity/*` with tests at `scripts/check-parity.test.mjs`.
+
+## Schema
+
+### `inventory.yaml`
+
+- `version` — integer, bumped on every add/modify of a component.
+- `components` — a list; each entry (all fields required):
+
+  | field | meaning |
+  | --- | --- |
+  | `id` | kebab-case, stable — never reuse or rename without a version bump |
+  | `title` | human name |
+  | `purpose` | one line: what it is / when it appears |
+  | `anatomy` | named structural parts (non-empty list) |
+  | `states` | distinct render states incl. loading/empty/error/streaming where real (non-empty list) |
+  | `variants` | shape/context variants that are the *same* component |
+  | `behavior` | semantic notes — what the SDK view-model drives (not styling) |
+  | `a11y` | roles / labels / focus expectations |
+  | `since` | inventory version the component first appeared in (`1 <= since <= version`) |
+
+Only genuinely cross-surface components belong here (see *Scope* below).
+
+### `manifests/<surface>.yaml`
+
+- `surface` — must equal the filename base.
+- `enforced` — `true` blocks the build on a lag; `false` only reports it.
+- `inventoryVersion` — the inventory version this surface fully implements
+  (`0` = nothing yet). May not exceed the inventory's own `version`.
+- `components` — map of `component-id → { status, notes?, ref? }`:
+  - `status` — `implemented` | `partial` | `not-started`.
+  - `notes` — optional; explain a `partial`.
+  - `ref` — optional; where the component lives (e.g. the `ui/` package).
+
+`partial` is honest shorthand for "ships but has a real structural gap" — most
+often the reusable, view-model-driven piece is still app/-locked rather than in a
+shared `ui/` package, so a native surface can't yet reuse its structure.
+
+## Scope — what is and isn't inventoried
+
+**In:** components that will exist on native mobile — the conversation feed and
+its item types (assistant text, streaming, thinking, tool chip, provider-error
+card, system message), the composer, turn status, the board and its mission
+cards/status chips, the approval/needs-you surface, agent list items and avatars,
+progress, deliverables, routines and skills rows, empty states and toasts.
+
+**Out (deliberately):** desktop-only chrome and power-user surfaces that mobile
+won't ship — menu bars, resizable split panes, the file-tree browser, the
+schedule/cron editor, skill-authoring dialogs, drag-and-drop machinery, and the
+design-system *primitives* (buttons, dialogs, popovers, menus) that are owned by
+the token/primitive layer rather than tracked as product structure.
+
+## How a change flows
+
+1. **Add or modify a cross-surface component** → edit `inventory.yaml`.
+2. **Bump `version`.**
+3. **Add a matching `## vN` entry to `CHANGELOG.md`.**
+4. **Update every *enforced* surface manifest in the SAME PR** — an enforced
+   surface may not leave a component with `since <= inventoryVersion`
+   `not-started`. Use `partial` (with a `notes`) if it only half-lands.
+5. **Unenforced surfaces (iOS/Android) update later.** As a native app
+   implements components, flip their statuses and raise its manifest's
+   `inventoryVersion` as it fully catches up.
+6. **Flip `enforced: true`** for a surface only when its app *ships* at that
+   inventory version.
+
+## What `pnpm check:parity` does
+
+Runs in CI alongside `pnpm check:boundaries`. It **fails the build** when:
+
+- `inventory.yaml` or a manifest doesn't parse or violates the schema — unknown
+  keys and typo'd statuses are hard fails, not silent passes;
+- a manifest references a component that isn't in the inventory;
+- an inventory component is missing an entry in any manifest;
+- an **enforced** surface at `inventoryVersion N` leaves a component with
+  `since <= N` `not-started` (or missing);
+- a manifest claims an `inventoryVersion` beyond the inventory's `version`;
+- `version` was bumped without a matching `CHANGELOG.md` entry.
+
+It **never fails** on the unenforced surfaces; instead it prints a lag table so
+iOS/Android progress is visible in every CI run.

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -1,0 +1,302 @@
+# Houston cross-surface component inventory
+#
+# THE CONTRACT
+# ------------
+# This file is the single source of truth for WHICH product components exist
+# across Houston's surfaces and WHAT each one is (anatomy, states, semantics,
+# a11y). It handles STRUCTURAL parity only:
+#
+#   - BEHAVIOR parity  -> owned by the shared SDK view-models (packages/sdk).
+#   - LOOK parity      -> owned by design tokens (packages/design-tokens).
+#   - STRUCTURE parity -> owned by THIS inventory: does the component exist on
+#                         each surface, with the same anatomy/states/semantics?
+#
+# Every entry here is surface-AGNOSTIC. It describes the component once; each
+# surface (web/desktop, iOS, Android) then declares in its own manifest under
+# manifests/ whether it implements that component (implemented|partial|
+# not-started). scripts/check-parity.mjs (pnpm check:parity) enforces the
+# contract in CI: an enforced surface may not lag its declared inventoryVersion.
+#
+# SCOPE: only components that are genuinely cross-surface (will exist on native
+# mobile) belong here. Desktop-only chrome (menu bars, resizable panes, the file
+# tree, the schedule/cron editor, skill-authoring dialogs) is deliberately
+# excluded -- see design/inventory/README.md for the exclusion rationale.
+#
+# CHANGE FLOW: add/modify a component -> bump `version` -> add a CHANGELOG.md
+# entry -> update every ENFORCED surface manifest in the SAME PR. Unenforced
+# surfaces catch up later and bump their manifest's inventoryVersion when they do.
+#
+# Field reference (all fields required per component):
+#   id       kebab-case stable identifier (never reused/renamed without a bump)
+#   title    human name
+#   purpose  one line: what it is / when it appears
+#   anatomy  named structural parts
+#   states   distinct render states (incl. loading/empty/error/streaming where real)
+#   variants shape/context variants that are the SAME component
+#   behavior semantic notes: what the SDK view-model drives (not styling)
+#   a11y     roles / labels / focus expectations the surface must honor
+#   since    inventory version this component first appeared in
+
+version: 1
+
+components:
+  - id: agent-avatar
+    title: Agent avatar
+    purpose: Identity badge for an agent -- colored helmet glyph, resting vs running.
+    anatomy: [glyph, color-fill, running-glow-ring]
+    states: [resting, running]
+    variants: [sizes-xs-to-xl, channel-source-avatar]
+    behavior: >-
+      Stored semantic color id resolves to a palette entry (resolveAgentColor);
+      running state is driven by the agent's live run status, not local hover.
+    a11y: Decorative when paired with a text label; else img role with the agent name as label.
+    since: 1
+
+  - id: agent-list-item
+    title: Agent list item
+    purpose: A single agent row/card in the agent list or sidebar.
+    anatomy: [avatar, name, status-chip, unread-or-count-slot, trailing-actions]
+    states: [idle, running, needs-you, selected, focused]
+    variants: [sidebar-rail-collapsed, list-row, grid-card]
+    behavior: >-
+      Selection and run status come from the view-model; the row reflects the
+      agent's aggregate mission state, not a single conversation.
+    a11y: button/listitem role, name as accessible label, aria-current when selected.
+    since: 1
+
+  - id: conversation-feed
+    title: Conversation feed
+    purpose: The scrolling transcript that hosts every message/tool/system item.
+    anatomy: [scroll-viewport, item-list, stick-to-bottom-anchor, scroll-to-bottom-button]
+    states: [empty, loading-history, streaming, idle, error]
+    variants: [single-player, multiplayer]
+    behavior: >-
+      Renders an ordered FeedItem stream; auto-sticks to bottom while streaming
+      unless the user scrolled up. Item ordering/merge is view-model driven.
+    a11y: log role with aria-live=polite for appended items; preserves scroll on prepend.
+    since: 1
+
+  - id: assistant-message
+    title: Assistant message
+    purpose: A model turn's prose -- markdown, no bubble, left aligned.
+    anatomy: [markdown-body, code-block, inline-links, copy-action]
+    states: [streaming, complete]
+    variants: [with-code, plain-prose]
+    behavior: >-
+      assistant_text vs assistant_text_streaming decide whether the body grows
+      token-by-token; copy acts on the resolved markdown source.
+    a11y: article/group role; code blocks keyboard-selectable; copy button labeled.
+    since: 1
+
+  - id: user-message
+    title: User message
+    purpose: A message the user (or a teammate) sent, right-aligned bubble.
+    anatomy: [bubble, author-label, attachment-chips]
+    states: [default, with-attachments]
+    variants: [single-player, multiplayer-authored]
+    behavior: >-
+      In multiplayer the author field labels a teammate's bubble; single-player
+      omits it. Attachment/skill markers are decoded to a clean preview.
+    a11y: group role; author announced in multiplayer; attachments labeled.
+    since: 1
+
+  - id: thinking-indicator
+    title: Thinking / reasoning indicator
+    purpose: Signals the model is working -- reasoning block or the pre-token wait.
+    anatomy: [helmet-glyph, shimmer-label, collapsible-reasoning-body]
+    states: [submitted-waiting, streaming-thoughts, collapsed, expanded]
+    variants: [typing-bounce-dots, reasoning-collapsible]
+    behavior: >-
+      Shown while a turn is in flight with no visible stream (deriveStatus =
+      submitted); yields to the stream once tokens appear. Reasoning content is
+      thinking / thinking_streaming feed items.
+    a11y: aria-live=polite status text; expand/collapse is a labeled toggle button.
+    since: 1
+
+  - id: tool-call-chip
+    title: Tool call chip
+    purpose: Collapsible display of one tool invocation and its result.
+    anatomy: [tool-icon, action-label, chevron, collapsible-output, result-status]
+    states: [running, success, error, collapsed, expanded]
+    variants: [default-auto-collapse, bash-collapsed-by-default]
+    behavior: >-
+      Auto-opens while running, auto-collapses shortly after the result; Bash
+      stays collapsed. Label derives from tool name + input via tool-labels.
+    a11y: toggle button with tool action as label; error state announced.
+    since: 1
+
+  - id: provider-error-card
+    title: Provider error card
+    purpose: Actionable card for a provider failure in the feed (auth, quota, rate-limit).
+    anatomy: [icon-bubble, title, reason, primary-action, secondary-action]
+    states: [unauthenticated, quota-exhausted, rate-limited, model-unavailable, transient]
+    variants: [single-action-row-card, multi-action-error-card]
+    behavior: >-
+      provider_error feed items carry a typed ProviderError (cause/scope). The
+      card maps each taxonomy variant to its reconnect/upgrade/retry affordance.
+    a11y: alert role; each action a labeled button; status-page link where relevant.
+    since: 1
+
+  - id: system-message
+    title: System message / boundary
+    purpose: Non-message feed events -- system notes and context/provider boundaries.
+    anatomy: [divider-rule, centered-italic-label]
+    states: [system-note, context-compacted, provider-switched]
+    variants: [plain-note, divider-boundary]
+    behavior: >-
+      system_message renders a centered note; context_compacted and
+      provider_switched render subtle dividers that keep the full chat visible.
+    a11y: separator role for boundaries; note text exposed to the a11y tree.
+    since: 1
+
+  - id: skill-invocation-message
+    title: Skill invocation message
+    purpose: Shows that the user ran a Skill, as a decoded card in the feed.
+    anatomy: [skill-image, skill-title, field-summary]
+    states: [default]
+    variants: [with-image, initial-fallback]
+    behavior: >-
+      A user-message marker (decodeSkillMessage) is decoded to a structured
+      payload so every surface renders the same card instead of the raw marker.
+    a11y: group role labeled with the skill name; image is decorative.
+    since: 1
+
+  - id: composer
+    title: Composer
+    purpose: The signature message-input surface -- text, attachments, send/stop.
+    anatomy: [leading-attach, textarea, footer-slot, queued-list, trailing-send-stop]
+    states: [ready, submitted, streaming, has-attachments, drag-over, disabled]
+    variants: [single-line, multiline-expanded]
+    behavior: >-
+      Send is gated on non-empty text/attachments; while streaming the trailing
+      button becomes Stop. Queued messages show when sending mid-turn.
+    a11y: labeled textarea; send/stop button state-labeled; drop zone announced.
+    since: 1
+
+  - id: turn-status
+    title: Turn status line
+    purpose: The helmet + muted label line reporting the current turn state.
+    anatomy: [helmet-glyph, status-label, shimmer]
+    states: [idle, active-shimmer]
+    variants: [inline-in-feed, standalone-on-card]
+    behavior: >-
+      Label + active flag come from deriveStatus over the feed; shimmer marks an
+      ongoing/pending state. Inline-safe so it can sit inside markdown prose.
+    a11y: status role; label announced politely; shimmer is presentational only.
+    since: 1
+
+  - id: progress-panel
+    title: Progress panel
+    purpose: Agent-declared step checklist for a running mission.
+    anatomy: [header-count, step-row, step-status-icon]
+    states: [pending, active, done, empty]
+    variants: [side-panel, sidebar-card]
+    behavior: >-
+      Steps come from the agent's update_progress calls (or are derived from
+      tool activity); header shows "X of Y complete".
+    a11y: list role; each step's status conveyed as text, not color alone.
+    since: 1
+
+  - id: approval-surface
+    title: Approval / needs-you surface
+    purpose: Where a mission awaiting the user is reviewed and approved.
+    anatomy: [item-title, status-indicator, deliverable-preview, approve-action, feedback-input]
+    states: [needs-you, running, approved, error, empty]
+    variants: [list-item, detail-panel]
+    behavior: >-
+      needs_you items are surfaced for the user to review; approve advances the
+      mission, feedback returns it to the agent. Status drives the indicator.
+    a11y: needs-you item announced; approve is a labeled primary button; live status.
+    since: 1
+
+  - id: deliverable-card
+    title: Deliverable card
+    purpose: A rendered mission deliverable (markdown output) for review.
+    anatomy: [card-frame, markdown-body]
+    states: [default]
+    variants: [deliverable, user-feedback-bubble]
+    behavior: Renders the deliverable markdown; feedback variant echoes the user's reply.
+    a11y: article role; headings preserved from source markdown.
+    since: 1
+
+  - id: mission-card
+    title: Mission card
+    purpose: A board card representing one mission/conversation.
+    anatomy: [avatar, title, status-chip, actions, drag-handle, select-checkbox]
+    states: [resting, running, needs-you, error, selected, focused, dragging]
+    variants: [board-card, archived-list-row]
+    behavior: >-
+      Running state shows the comet glow; approve moves to done. Drag/multi-select
+      are surface-capability gated (pointer drag on desktop).
+    a11y: article/button role; title as label; checkbox labeled; status not color-only.
+    since: 1
+
+  - id: mission-board
+    title: Mission board
+    purpose: The columned board that groups mission cards by status.
+    anatomy: [column, column-header, card-list, empty-column-state, bulk-action-bar]
+    states: [populated, empty, loading, dragging]
+    variants: [multi-column-board, single-column-list]
+    behavior: >-
+      Columns map to mission statuses; cards move between columns on approve/drag.
+      Bulk-action bar appears when cards are multi-selected.
+    a11y: list/grid semantics per column; column headers labeled; DnD has non-pointer fallback.
+    since: 1
+
+  - id: mission-status-chip
+    title: Mission status chip
+    purpose: The shared status token (running / needs-you / done / error) used across surfaces.
+    anatomy: [status-dot-or-icon, status-label]
+    states: [running, needs-you, done, error, cancelled]
+    variants: [dot-only, dot-with-label, badge]
+    behavior: >-
+      One canonical mapping from a mission RunStatus to indicator + label, reused
+      by board cards, the approval list, and conversation rows.
+    a11y: status conveyed as text/label, never color alone; running is announced.
+    since: 1
+
+  - id: routine-row
+    title: Routine row
+    purpose: A scheduled routine in the routines list -- schedule summary + next run.
+    anatomy: [name, schedule-summary, next-fire, enabled-toggle, run-status]
+    states: [enabled, disabled, running, last-run-failed]
+    variants: [list-row, grid-card]
+    behavior: >-
+      Shows a humanized schedule summary and the next fire time; the toggle
+      enables/disables the routine. Authoring the schedule is a separate surface.
+    a11y: listitem role; toggle labeled with the routine name; next-run as text.
+    since: 1
+
+  - id: skill-row
+    title: Skill row
+    purpose: A skill in the skills list -- icon, name, description, install/run action.
+    anatomy: [icon, name, description, trailing-action]
+    states: [available, installed, installing, error]
+    variants: [list-row, grid-card, community-row]
+    behavior: >-
+      Reflects install state; the trailing action installs or runs the skill.
+      Full skill detail/authoring lives on a separate surface.
+    a11y: listitem role; action button labeled; install state conveyed as text.
+    since: 1
+
+  - id: empty-state
+    title: Empty state
+    purpose: The shared "nothing here yet" surface -- title, description, optional action.
+    anatomy: [title, description, optional-action]
+    states: [default]
+    variants: [with-action, text-only]
+    behavior: Big title + description with one optional primary action; no icon-in-box.
+    a11y: region labeled by the title; action is a labeled button.
+    since: 1
+
+  - id: toast
+    title: Toast / notice
+    purpose: Transient surfacing of an action's result or error (with report-bug affordance).
+    anatomy: [message, optional-action, dismiss]
+    states: [info, success, error, loading]
+    variants: [plain, with-report-bug-action]
+    behavior: >-
+      Every user-initiated error must reach a toast carrying the real reason and
+      a Report-bug action (beta no-silent-failure policy).
+    a11y: status/alert role by severity; auto-dismiss pauses on focus/hover.
+    since: 1

--- a/design/inventory/manifests/android.yaml
+++ b/design/inventory/manifests/android.yaml
@@ -1,0 +1,57 @@
+# android surface parity manifest.
+#
+# The native Kotlin Compose Android app (not started). This surface is UNENFORCED: check-parity reports its lag in
+# every CI run (visible progress) but never fails the build on it. When the
+# app begins implementing components, flip statuses to partial/implemented and
+# raise inventoryVersion as it fully catches up; flip enforced: true only when
+# the app SHIPS at that inventory version.
+
+surface: android
+enforced: false
+inventoryVersion: 0
+
+components:
+  agent-avatar:
+    status: not-started
+  agent-list-item:
+    status: not-started
+  conversation-feed:
+    status: not-started
+  assistant-message:
+    status: not-started
+  user-message:
+    status: not-started
+  thinking-indicator:
+    status: not-started
+  tool-call-chip:
+    status: not-started
+  provider-error-card:
+    status: not-started
+  system-message:
+    status: not-started
+  skill-invocation-message:
+    status: not-started
+  composer:
+    status: not-started
+  turn-status:
+    status: not-started
+  progress-panel:
+    status: not-started
+  approval-surface:
+    status: not-started
+  deliverable-card:
+    status: not-started
+  mission-card:
+    status: not-started
+  mission-board:
+    status: not-started
+  mission-status-chip:
+    status: not-started
+  routine-row:
+    status: not-started
+  skill-row:
+    status: not-started
+  empty-state:
+    status: not-started
+  toast:
+    status: not-started

--- a/design/inventory/manifests/ios.yaml
+++ b/design/inventory/manifests/ios.yaml
@@ -1,0 +1,57 @@
+# ios surface parity manifest.
+#
+# The native SwiftUI iOS app (not started). This surface is UNENFORCED: check-parity reports its lag in
+# every CI run (visible progress) but never fails the build on it. When the
+# app begins implementing components, flip statuses to partial/implemented and
+# raise inventoryVersion as it fully catches up; flip enforced: true only when
+# the app SHIPS at that inventory version.
+
+surface: ios
+enforced: false
+inventoryVersion: 0
+
+components:
+  agent-avatar:
+    status: not-started
+  agent-list-item:
+    status: not-started
+  conversation-feed:
+    status: not-started
+  assistant-message:
+    status: not-started
+  user-message:
+    status: not-started
+  thinking-indicator:
+    status: not-started
+  tool-call-chip:
+    status: not-started
+  provider-error-card:
+    status: not-started
+  system-message:
+    status: not-started
+  skill-invocation-message:
+    status: not-started
+  composer:
+    status: not-started
+  turn-status:
+    status: not-started
+  progress-panel:
+    status: not-started
+  approval-surface:
+    status: not-started
+  deliverable-card:
+    status: not-started
+  mission-card:
+    status: not-started
+  mission-board:
+    status: not-started
+  mission-status-chip:
+    status: not-started
+  routine-row:
+    status: not-started
+  skill-row:
+    status: not-started
+  empty-state:
+    status: not-started
+  toast:
+    status: not-started

--- a/design/inventory/manifests/web.yaml
+++ b/design/inventory/manifests/web.yaml
@@ -1,0 +1,115 @@
+# Web / desktop surface parity manifest.
+#
+# The React frontend in `app/src` (also shipped verbatim as `packages/web`),
+# built on the `@houston-ai/*` ui packages. This surface is ENFORCED: it must
+# implement (implemented or partial, never not-started/missing) every inventory
+# component whose `since <= inventoryVersion`. `pnpm check:parity` fails the
+# build otherwise. `ref` points at where the component lives today.
+#
+# Honesty note: `partial` flags a real structural gap even when the component
+# ships and works -- typically because the reusable, view-model-driven piece is
+# not yet in a shared `ui/` package (it is app/-locked), so a native surface
+# cannot reuse its structure. Those are the extract-before-mobile items.
+
+surface: web
+enforced: true
+inventoryVersion: 1
+
+components:
+  agent-avatar:
+    status: implemented
+    ref: "@houston-ai/core HoustonAvatar / AgentAvatar (resolveAgentColor)"
+
+  agent-list-item:
+    status: partial
+    ref: "@houston-ai/layout SidebarNavItem + @houston-ai/core HoustonAvatar"
+    notes: >-
+      No single shared agent-list-item component; the row is composed in app/
+      from generic nav + avatar primitives. Aggregate status is app-side.
+
+  conversation-feed:
+    status: implemented
+    ref: "@houston-ai/chat ChatPanel / ChatMessages / Conversation"
+
+  assistant-message:
+    status: implemented
+    ref: "@houston-ai/chat ai-elements/message + markdown-code-block"
+
+  user-message:
+    status: implemented
+    ref: "@houston-ai/chat user-attachment-message + author-label"
+
+  thinking-indicator:
+    status: implemented
+    ref: "@houston-ai/chat ai-elements/reasoning + chat-status (deriveStatus)"
+
+  tool-call-chip:
+    status: implemented
+    ref: "@houston-ai/chat ai-elements/tool-block + tool-formatters"
+
+  provider-error-card:
+    status: partial
+    ref: "app/src/components/shell/provider-error-cards/* (types in @houston-ai/chat)"
+    notes: >-
+      Feed types + ProviderError taxonomy live in @houston-ai/chat, but the
+      rendered cards are app/-locked. Extract into ui/ before mobile can reuse.
+
+  system-message:
+    status: implemented
+    ref: "@houston-ai/chat chat-system-message"
+
+  skill-invocation-message:
+    status: partial
+    ref: "@houston-ai/chat skill-message (decode) rendered in app/"
+    notes: Marker decode is shared; the card render is composed in app/.
+
+  composer:
+    status: implemented
+    ref: "@houston-ai/chat ChatInput / ai-elements/prompt-input"
+
+  turn-status:
+    status: implemented
+    ref: "@houston-ai/chat ChatStatusLine + chat-status"
+
+  progress-panel:
+    status: implemented
+    ref: "@houston-ai/chat ProgressPanel / useProgressSteps"
+
+  approval-surface:
+    status: implemented
+    ref: "@houston-ai/review ReviewItem / ReviewDetailPanel / DeliverableCard"
+
+  deliverable-card:
+    status: implemented
+    ref: "@houston-ai/review DeliverableCard / UserFeedback"
+
+  mission-card:
+    status: implemented
+    ref: "@houston-ai/board KanbanCard / KanbanListItem"
+
+  mission-board:
+    status: implemented
+    ref: "@houston-ai/board KanbanBoard / AIBoard / KanbanColumn"
+
+  mission-status-chip:
+    status: partial
+    ref: "@houston-ai/board + @houston-ai/review (per-package)"
+    notes: >-
+      Status rendering is duplicated across kanban-card, conversation-list and
+      review-item with divergent RunStatus enums. No shared status chip yet.
+
+  routine-row:
+    status: implemented
+    ref: "@houston-ai/routines RoutineRow / RoutinesGrid"
+
+  skill-row:
+    status: implemented
+    ref: "@houston-ai/skills SkillRow / SkillsGrid"
+
+  empty-state:
+    status: implemented
+    ref: "@houston-ai/core Empty"
+
+  toast:
+    status: implemented
+    ref: "@houston-ai/core sonner / toast-container"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "check": "biome check --error-on-warnings",
     "check:fix": "biome check --write --error-on-warnings",
     "check:boundaries": "node scripts/check-boundaries.mjs",
+    "check:parity": "node scripts/check-parity.mjs",
     "prepare": "husky || true",
     "test": "pnpm -r --if-present --no-bail test",
     "dev": "mprocs",

--- a/scripts/check-parity.mjs
+++ b/scripts/check-parity.mjs
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+/**
+ * Cross-surface component parity gate. Mirrors scripts/check-boundaries.mjs: a
+ * secret-free, dependency-light node script that collects every violation and
+ * fails the build (exit 1) if any survive. Wired as `pnpm check:parity` and run
+ * in CI alongside `pnpm check:boundaries`.
+ *
+ * WHAT IT GUARDS (see design/inventory/README.md for the full contract):
+ *
+ *   design/inventory/inventory.yaml   -- the versioned cross-surface spec
+ *   design/inventory/CHANGELOG.md     -- one entry per version bump
+ *   design/inventory/manifests/*.yaml -- per-surface implementation status
+ *
+ * HARD FAILS (exit 1):
+ *   - inventory.yaml / manifests must parse and match the schema precisely
+ *     (unknown keys and typo'd statuses fail, not pass silently);
+ *   - a manifest may only reference components that exist in the inventory;
+ *   - every inventory component must have an entry in every manifest;
+ *   - an ENFORCED surface at inventoryVersion N may not leave any component
+ *     with since <= N `not-started` (or missing);
+ *   - a manifest may not claim an inventoryVersion beyond the inventory's;
+ *   - a `version` bump must be accompanied by a matching CHANGELOG.md entry.
+ *
+ * REPORT (never fails): the lag of the UNENFORCED surfaces (native apps) so
+ * their progress is visible in every CI run.
+ *
+ * The validation logic is factored into scripts/parity/* and exported here as
+ * `checkParity(dir)` so it is unit-testable against fixtures
+ * (scripts/check-parity.test.mjs) without shelling out.
+ */
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadChangelog, loadInventory, loadManifests } from "./parity/load.mjs";
+import { validateManifest } from "./parity/manifest.mjs";
+import { buildReport } from "./parity/report.mjs";
+import { validateChangelog, validateInventory } from "./parity/validate.mjs";
+
+/**
+ * Run every check against an inventory directory (containing inventory.yaml,
+ * CHANGELOG.md and manifests/). Returns { violations, report } and never throws
+ * on bad content -- malformed files become violations.
+ */
+export function checkParity(dir) {
+  const violations = [];
+
+  const inv = loadInventory(dir);
+  if (inv.problem) violations.push(`[inventory] ${inv.problem}`);
+
+  const {
+    violations: invViolations,
+    version,
+    sinceById,
+  } = inv.value
+    ? validateInventory(inv.value)
+    : { violations: [], version: null, sinceById: new Map() };
+  violations.push(...invViolations);
+
+  const changelog = loadChangelog(dir);
+  if (changelog.problem) violations.push(`[changelog] ${changelog.problem}`);
+  else violations.push(...validateChangelog(changelog.value, version));
+
+  const manifests = loadManifests(dir);
+  for (const m of manifests) {
+    if (m.problem) violations.push(`[${m.label ?? m.name}] ${m.problem}`);
+    else violations.push(...validateManifest(m, sinceById, version));
+  }
+
+  const parsed = manifests.filter(
+    (m) => m.value && typeof m.value === "object",
+  );
+  const report = buildReport(parsed, sinceById, version);
+  return { violations, report };
+}
+
+function main() {
+  const root = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const dir = join(root, "design", "inventory");
+  const { violations, report } = checkParity(dir);
+
+  if (report) console.log(`${report}\n`);
+
+  if (violations.length > 0) {
+    console.error(
+      "Parity check FAILED — the component inventory and manifests are out of sync:\n",
+    );
+    for (const v of violations.sort()) console.error(`  ${v}`);
+    console.error(
+      `\n${violations.length} violation(s). See design/inventory/README.md for the contract.\n` +
+        "A cross-surface component change must bump inventory.yaml, add a CHANGELOG entry, and update every enforced manifest in the same PR.",
+    );
+    process.exit(1);
+  }
+
+  console.log(
+    "Parity OK — inventory, changelog and all surface manifests are consistent.",
+  );
+}
+
+if (fileURLToPath(import.meta.url) === process.argv[1]) main();

--- a/scripts/check-parity.test.mjs
+++ b/scripts/check-parity.test.mjs
@@ -1,0 +1,54 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { checkParity } from "./check-parity.mjs";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixtures = join(here, "parity", "__fixtures__");
+const realInventory = join(here, "..", "design", "inventory");
+
+const run = (name) => checkParity(join(fixtures, name));
+
+describe("check-parity", () => {
+  it("passes on the real design/inventory files", () => {
+    const { violations } = checkParity(realInventory);
+    expect(violations).toEqual([]);
+  });
+
+  it("passes a well-formed fixture (implemented + partial + not-started)", () => {
+    const { violations, report } = run("valid");
+    expect(violations).toEqual([]);
+    // Unenforced ios surface still shows up in the non-blocking lag report.
+    expect(report).toMatch(/ios/);
+  });
+
+  it("FAILS when a manifest references a component absent from the inventory", () => {
+    const { violations } = run("unknown-component");
+    expect(violations.length).toBeGreaterThan(0);
+    expect(
+      violations.some((v) => /unknown component "ghost-component"/.test(v)),
+    ).toBe(true);
+  });
+
+  it("FAILS when an enforced surface lags its declared inventoryVersion", () => {
+    const { violations } = run("enforced-lagging");
+    expect(violations.length).toBeGreaterThan(0);
+    expect(
+      violations.some((v) =>
+        /enforced surface at inventoryVersion 1 has "comp-b".*not-started/.test(
+          v,
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("FAILS on a typo'd status value", () => {
+    const { violations } = run("bad-status");
+    expect(violations.some((v) => /status must be one of/.test(v))).toBe(true);
+  });
+
+  it("FAILS when the version is bumped without a matching CHANGELOG entry", () => {
+    const { violations } = run("changelog-missing");
+    expect(violations.some((v) => /no "## v2" entry/.test(v))).toBe(true);
+  });
+});

--- a/scripts/parity/__fixtures__/bad-status/CHANGELOG.md
+++ b/scripts/parity/__fixtures__/bad-status/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1 - test
+
+Initial.

--- a/scripts/parity/__fixtures__/bad-status/inventory.yaml
+++ b/scripts/parity/__fixtures__/bad-status/inventory.yaml
@@ -1,0 +1,20 @@
+version: 1
+components:
+  - id: comp-a
+    title: Component A
+    purpose: First test component.
+    anatomy: [part-a]
+    states: [default]
+    variants: [only]
+    behavior: Driven by the view-model.
+    a11y: button role.
+    since: 1
+  - id: comp-b
+    title: Component B
+    purpose: Second test component.
+    anatomy: [part-b]
+    states: [default]
+    variants: [only]
+    behavior: Driven by the view-model.
+    a11y: list role.
+    since: 1

--- a/scripts/parity/__fixtures__/bad-status/manifests/ios.yaml
+++ b/scripts/parity/__fixtures__/bad-status/manifests/ios.yaml
@@ -1,0 +1,8 @@
+surface: ios
+enforced: false
+inventoryVersion: 0
+components:
+  comp-a:
+    status: not-started
+  comp-b:
+    status: not-started

--- a/scripts/parity/__fixtures__/bad-status/manifests/web.yaml
+++ b/scripts/parity/__fixtures__/bad-status/manifests/web.yaml
@@ -1,0 +1,8 @@
+surface: web
+enforced: true
+inventoryVersion: 1
+components:
+  comp-a:
+    status: done
+  comp-b:
+    status: implemented

--- a/scripts/parity/__fixtures__/changelog-missing/CHANGELOG.md
+++ b/scripts/parity/__fixtures__/changelog-missing/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1 - test
+
+Initial.

--- a/scripts/parity/__fixtures__/changelog-missing/inventory.yaml
+++ b/scripts/parity/__fixtures__/changelog-missing/inventory.yaml
@@ -1,0 +1,20 @@
+version: 2
+components:
+  - id: comp-a
+    title: Component A
+    purpose: First test component.
+    anatomy: [part-a]
+    states: [default]
+    variants: [only]
+    behavior: Driven by the view-model.
+    a11y: button role.
+    since: 1
+  - id: comp-b
+    title: Component B
+    purpose: Second test component.
+    anatomy: [part-b]
+    states: [default]
+    variants: [only]
+    behavior: Driven by the view-model.
+    a11y: list role.
+    since: 1

--- a/scripts/parity/__fixtures__/changelog-missing/manifests/ios.yaml
+++ b/scripts/parity/__fixtures__/changelog-missing/manifests/ios.yaml
@@ -1,0 +1,8 @@
+surface: ios
+enforced: false
+inventoryVersion: 0
+components:
+  comp-a:
+    status: not-started
+  comp-b:
+    status: not-started

--- a/scripts/parity/__fixtures__/changelog-missing/manifests/web.yaml
+++ b/scripts/parity/__fixtures__/changelog-missing/manifests/web.yaml
@@ -1,0 +1,8 @@
+surface: web
+enforced: true
+inventoryVersion: 2
+components:
+  comp-a:
+    status: implemented
+  comp-b:
+    status: implemented

--- a/scripts/parity/__fixtures__/enforced-lagging/CHANGELOG.md
+++ b/scripts/parity/__fixtures__/enforced-lagging/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1 - test
+
+Initial.

--- a/scripts/parity/__fixtures__/enforced-lagging/inventory.yaml
+++ b/scripts/parity/__fixtures__/enforced-lagging/inventory.yaml
@@ -1,0 +1,20 @@
+version: 1
+components:
+  - id: comp-a
+    title: Component A
+    purpose: First test component.
+    anatomy: [part-a]
+    states: [default]
+    variants: [only]
+    behavior: Driven by the view-model.
+    a11y: button role.
+    since: 1
+  - id: comp-b
+    title: Component B
+    purpose: Second test component.
+    anatomy: [part-b]
+    states: [default]
+    variants: [only]
+    behavior: Driven by the view-model.
+    a11y: list role.
+    since: 1

--- a/scripts/parity/__fixtures__/enforced-lagging/manifests/ios.yaml
+++ b/scripts/parity/__fixtures__/enforced-lagging/manifests/ios.yaml
@@ -1,0 +1,8 @@
+surface: ios
+enforced: false
+inventoryVersion: 0
+components:
+  comp-a:
+    status: not-started
+  comp-b:
+    status: not-started

--- a/scripts/parity/__fixtures__/enforced-lagging/manifests/web.yaml
+++ b/scripts/parity/__fixtures__/enforced-lagging/manifests/web.yaml
@@ -1,0 +1,8 @@
+surface: web
+enforced: true
+inventoryVersion: 1
+components:
+  comp-a:
+    status: implemented
+  comp-b:
+    status: not-started

--- a/scripts/parity/__fixtures__/unknown-component/CHANGELOG.md
+++ b/scripts/parity/__fixtures__/unknown-component/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1 - test
+
+Initial.

--- a/scripts/parity/__fixtures__/unknown-component/inventory.yaml
+++ b/scripts/parity/__fixtures__/unknown-component/inventory.yaml
@@ -1,0 +1,20 @@
+version: 1
+components:
+  - id: comp-a
+    title: Component A
+    purpose: First test component.
+    anatomy: [part-a]
+    states: [default]
+    variants: [only]
+    behavior: Driven by the view-model.
+    a11y: button role.
+    since: 1
+  - id: comp-b
+    title: Component B
+    purpose: Second test component.
+    anatomy: [part-b]
+    states: [default]
+    variants: [only]
+    behavior: Driven by the view-model.
+    a11y: list role.
+    since: 1

--- a/scripts/parity/__fixtures__/unknown-component/manifests/ios.yaml
+++ b/scripts/parity/__fixtures__/unknown-component/manifests/ios.yaml
@@ -1,0 +1,8 @@
+surface: ios
+enforced: false
+inventoryVersion: 0
+components:
+  comp-a:
+    status: not-started
+  comp-b:
+    status: not-started

--- a/scripts/parity/__fixtures__/unknown-component/manifests/web.yaml
+++ b/scripts/parity/__fixtures__/unknown-component/manifests/web.yaml
@@ -1,0 +1,10 @@
+surface: web
+enforced: true
+inventoryVersion: 1
+components:
+  comp-a:
+    status: implemented
+  comp-b:
+    status: implemented
+  ghost-component:
+    status: implemented

--- a/scripts/parity/__fixtures__/valid/CHANGELOG.md
+++ b/scripts/parity/__fixtures__/valid/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v1 - test
+
+Initial.

--- a/scripts/parity/__fixtures__/valid/inventory.yaml
+++ b/scripts/parity/__fixtures__/valid/inventory.yaml
@@ -1,0 +1,20 @@
+version: 1
+components:
+  - id: comp-a
+    title: Component A
+    purpose: First test component.
+    anatomy: [part-a]
+    states: [default]
+    variants: [only]
+    behavior: Driven by the view-model.
+    a11y: button role.
+    since: 1
+  - id: comp-b
+    title: Component B
+    purpose: Second test component.
+    anatomy: [part-b]
+    states: [default]
+    variants: [only]
+    behavior: Driven by the view-model.
+    a11y: list role.
+    since: 1

--- a/scripts/parity/__fixtures__/valid/manifests/ios.yaml
+++ b/scripts/parity/__fixtures__/valid/manifests/ios.yaml
@@ -1,0 +1,8 @@
+surface: ios
+enforced: false
+inventoryVersion: 0
+components:
+  comp-a:
+    status: not-started
+  comp-b:
+    status: not-started

--- a/scripts/parity/__fixtures__/valid/manifests/web.yaml
+++ b/scripts/parity/__fixtures__/valid/manifests/web.yaml
@@ -1,0 +1,9 @@
+surface: web
+enforced: true
+inventoryVersion: 1
+components:
+  comp-a:
+    status: implemented
+  comp-b:
+    status: partial
+    notes: half done

--- a/scripts/parity/load.mjs
+++ b/scripts/parity/load.mjs
@@ -1,0 +1,78 @@
+/**
+ * Filesystem + YAML loading for the parity checker. Every loader is total: a
+ * missing file or a parse error becomes a structured problem string rather than
+ * a thrown exception, so the checker can report ALL problems in one run (the
+ * same "collect, don't throw" shape as scripts/check-boundaries.mjs).
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+import { parse } from "yaml";
+
+/** Parse a YAML file. Returns { value } or { problem } (never throws). */
+function loadYaml(path, label) {
+  if (!existsSync(path))
+    return { problem: `${label}: file not found (${path})` };
+  let text;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch (err) {
+    return { problem: `${label}: unreadable (${err.message})` };
+  }
+  try {
+    return { value: parse(text) };
+  } catch (err) {
+    return { problem: `${label}: invalid YAML (${err.message})` };
+  }
+}
+
+/** Load design/inventory/inventory.yaml as a raw parsed object. */
+export function loadInventory(dir) {
+  return loadYaml(join(dir, "inventory.yaml"), "inventory.yaml");
+}
+
+/** Load the CHANGELOG.md text, or a problem if it is missing. */
+export function loadChangelog(dir) {
+  const path = join(dir, "CHANGELOG.md");
+  if (!existsSync(path)) return { problem: "CHANGELOG.md: file not found" };
+  try {
+    return { value: readFileSync(path, "utf8") };
+  } catch (err) {
+    return { problem: `CHANGELOG.md: unreadable (${err.message})` };
+  }
+}
+
+/**
+ * Load every manifest under manifests/*.yaml. Returns an array of
+ * { name, path, value?, problem? }, sorted by filename for stable reporting.
+ * `name` is the filename base (the expected `surface` value).
+ */
+export function loadManifests(dir) {
+  const manifestDir = join(dir, "manifests");
+  if (!existsSync(manifestDir)) {
+    return [
+      {
+        name: "manifests",
+        path: manifestDir,
+        problem: "manifests/: directory not found",
+      },
+    ];
+  }
+  const files = readdirSync(manifestDir)
+    .filter((f) => f.endsWith(".yaml") || f.endsWith(".yml"))
+    .sort();
+  if (files.length === 0) {
+    return [
+      {
+        name: "manifests",
+        path: manifestDir,
+        problem: "manifests/: no *.yaml manifests found",
+      },
+    ];
+  }
+  return files.map((file) => {
+    const path = join(manifestDir, file);
+    const name = basename(file).replace(/\.ya?ml$/, "");
+    const parsed = loadYaml(path, `manifests/${file}`);
+    return { name, path, label: `manifests/${file}`, ...parsed };
+  });
+}

--- a/scripts/parity/manifest.mjs
+++ b/scripts/parity/manifest.mjs
@@ -1,0 +1,99 @@
+/**
+ * Per-surface manifest validation for the parity contract. Pure function over an
+ * already-loaded manifest, returning violation strings (empty == clean).
+ */
+import {
+  ENTRY_KEYS,
+  isInt,
+  isNonEmptyString,
+  isObject,
+  MANIFEST_KEYS,
+  STATUSES,
+} from "./schema.mjs";
+
+/**
+ * Validate one manifest against the inventory. `sinceById` maps id -> since for
+ * the components that passed inventory validation; `invVersion` is the spec's
+ * own version (a manifest may not claim to implement beyond it).
+ */
+export function validateManifest(m, sinceById, invVersion) {
+  const violations = [];
+  const tag = m.label ?? m.name;
+  if (!isObject(m.value)) return [`[${tag}] top-level must be a mapping`];
+  const man = m.value;
+
+  for (const key of Object.keys(man)) {
+    if (!MANIFEST_KEYS.includes(key))
+      violations.push(`[${tag}] unknown top-level key "${key}"`);
+  }
+  if (man.surface !== m.name) {
+    violations.push(
+      `[${tag}] surface "${man.surface}" must match filename "${m.name}"`,
+    );
+  }
+  if (typeof man.enforced !== "boolean") {
+    violations.push(`[${tag}] enforced must be a boolean`);
+  }
+  const iv = man.inventoryVersion;
+  if (!isInt(iv) || iv < 0) {
+    violations.push(`[${tag}] inventoryVersion must be an integer >= 0`);
+  } else if (isInt(invVersion) && iv > invVersion) {
+    violations.push(
+      `[${tag}] inventoryVersion ${iv} exceeds the inventory's version ${invVersion}`,
+    );
+  }
+  if (!isObject(man.components)) {
+    violations.push(
+      `[${tag}] components must be a mapping of component-id -> entry`,
+    );
+    return violations;
+  }
+
+  for (const [id, entry] of Object.entries(man.components)) {
+    violations.push(...validateEntry(tag, id, entry, sinceById));
+  }
+
+  const enforced = man.enforced === true;
+  for (const [id, since] of sinceById) {
+    const entry = man.components[id];
+    if (!entry) {
+      violations.push(`[${tag}] missing entry for component "${id}"`);
+      continue;
+    }
+    if (
+      enforced &&
+      isInt(iv) &&
+      since <= iv &&
+      entry.status === "not-started"
+    ) {
+      violations.push(
+        `[${tag}] enforced surface at inventoryVersion ${iv} has "${id}" (since ${since}) still not-started`,
+      );
+    }
+  }
+
+  return violations;
+}
+
+/** Validate a single component entry's shape + status. */
+function validateEntry(tag, id, entry, sinceById) {
+  if (!sinceById.has(id)) {
+    return [`[${tag}] references unknown component "${id}" (not in inventory)`];
+  }
+  if (!isObject(entry)) return [`[${tag}] "${id}": entry must be a mapping`];
+  const out = [];
+  for (const key of Object.keys(entry)) {
+    if (!ENTRY_KEYS.has(key))
+      out.push(`[${tag}] "${id}": unknown key "${key}"`);
+  }
+  if (!STATUSES.has(entry.status)) {
+    out.push(
+      `[${tag}] "${id}": status must be one of implemented|partial|not-started (got ${JSON.stringify(entry.status)})`,
+    );
+  }
+  for (const f of ["notes", "ref"]) {
+    if (f in entry && !isNonEmptyString(entry[f]))
+      out.push(`[${tag}] "${id}": ${f} must be a non-empty string`);
+  }
+  return out;
+}

--- a/scripts/parity/report.mjs
+++ b/scripts/parity/report.mjs
@@ -1,0 +1,74 @@
+/**
+ * Non-failing progress report: how far the UNENFORCED surfaces (the native apps)
+ * lag the inventory. Printed on every run so mobile progress is visible in CI
+ * without blocking the build. Enforced surfaces are gated by validation instead.
+ */
+
+/**
+ * Build the lag table string. `manifests` are the loaded+parsed manifests;
+ * `sinceById` maps component id -> since; `version` is the inventory version.
+ * A component "counts as behind" for a surface if its since <= the inventory
+ * version and its status is anything other than "implemented" (not-started,
+ * partial, or a missing entry).
+ */
+export function buildReport(manifests, sinceById, version) {
+  const total = sinceById.size;
+  const rows = [];
+  for (const m of manifests) {
+    const man = m.value;
+    if (!man || typeof man !== "object" || man.enforced === true) continue;
+    const comps = man.components ?? {};
+    let implemented = 0;
+    let partial = 0;
+    let notStarted = 0;
+    for (const id of sinceById.keys()) {
+      const status = comps[id]?.status;
+      if (status === "implemented") implemented++;
+      else if (status === "partial") partial++;
+      else notStarted++;
+    }
+    const behind = total - implemented;
+    rows.push({
+      surface: man.surface ?? m.name,
+      at: `v${man.inventoryVersion ?? "?"}`,
+      spec: `v${version ?? "?"}`,
+      implemented,
+      partial,
+      notStarted,
+      behind,
+    });
+  }
+
+  if (rows.length === 0) return "";
+
+  const header = [
+    "Surface",
+    "At",
+    "Spec",
+    "Impl",
+    "Partial",
+    "Not-started",
+    "Behind",
+  ];
+  const cells = rows.map((r) => [
+    r.surface,
+    r.at,
+    r.spec,
+    String(r.implemented),
+    String(r.partial),
+    String(r.notStarted),
+    `${r.behind}/${total}`,
+  ]);
+  const widths = header.map((h, i) =>
+    Math.max(h.length, ...cells.map((c) => c[i].length)),
+  );
+  const line = (c) => c.map((v, i) => v.padEnd(widths[i])).join("  ");
+
+  const out = [
+    "Unenforced surface lag (report only, non-blocking):",
+    "",
+    `  ${line(header)}`,
+  ];
+  for (const c of cells) out.push(`  ${line(c)}`);
+  return out.join("\n");
+}

--- a/scripts/parity/schema.mjs
+++ b/scripts/parity/schema.mjs
@@ -1,0 +1,35 @@
+/**
+ * Shared predicates + schema constants for the parity validators
+ * (validate.mjs for the inventory, manifest.mjs for the surface manifests).
+ */
+
+export const KEBAB = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export const COMPONENT_KEYS = [
+  "id",
+  "title",
+  "purpose",
+  "anatomy",
+  "states",
+  "variants",
+  "behavior",
+  "a11y",
+  "since",
+];
+export const STRING_FIELDS = ["title", "purpose", "behavior", "a11y"];
+export const NONEMPTY_ARRAYS = ["anatomy", "states"];
+export const STATUSES = new Set(["implemented", "partial", "not-started"]);
+export const ENTRY_KEYS = new Set(["status", "notes", "ref"]);
+export const MANIFEST_KEYS = [
+  "surface",
+  "enforced",
+  "inventoryVersion",
+  "components",
+];
+
+export const isObject = (v) =>
+  v !== null && typeof v === "object" && !Array.isArray(v);
+export const isInt = (v) => typeof v === "number" && Number.isInteger(v);
+export const isNonEmptyString = (v) =>
+  typeof v === "string" && v.trim().length > 0;
+export const isStringArray = (v) =>
+  Array.isArray(v) && v.every(isNonEmptyString);

--- a/scripts/parity/validate.mjs
+++ b/scripts/parity/validate.mjs
@@ -1,0 +1,122 @@
+/**
+ * Inventory + changelog validation for the parity contract. Pure functions over
+ * already-parsed objects; each returns an array of violation strings (empty ==
+ * clean). Precise by design: an unknown key or a bad shape is a hard fail,
+ * because a silently-ignored field would let the contract rot. Manifest
+ * validation lives in ./manifest.mjs.
+ */
+import {
+  COMPONENT_KEYS,
+  isInt,
+  isNonEmptyString,
+  isObject,
+  isStringArray,
+  KEBAB,
+  NONEMPTY_ARRAYS,
+  STRING_FIELDS,
+} from "./schema.mjs";
+
+/**
+ * Validate inventory.yaml. Returns { violations, version, sinceById } so callers
+ * can cross-check manifests even when some components are malformed (sinceById
+ * holds only the components that passed).
+ */
+export function validateInventory(inv) {
+  const violations = [];
+  const sinceById = new Map();
+  if (!isObject(inv)) {
+    return {
+      violations: ["[inventory] top-level must be a mapping"],
+      version: null,
+      sinceById,
+    };
+  }
+  for (const key of Object.keys(inv)) {
+    if (key !== "version" && key !== "components") {
+      violations.push(
+        `[inventory] unknown top-level key "${key}" (allowed: version, components)`,
+      );
+    }
+  }
+  const version = inv.version;
+  if (!isInt(version) || version < 1) {
+    violations.push(
+      `[inventory] version must be an integer >= 1 (got ${JSON.stringify(version)})`,
+    );
+  }
+  if (!Array.isArray(inv.components) || inv.components.length === 0) {
+    violations.push("[inventory] components must be a non-empty list");
+    return { violations, version: isInt(version) ? version : null, sinceById };
+  }
+
+  const seen = new Set();
+  inv.components.forEach((comp, i) => {
+    violations.push(...validateComponent(comp, i, version, seen, sinceById));
+  });
+
+  return { violations, version: isInt(version) ? version : null, sinceById };
+}
+
+/** Validate one inventory component; records a valid id->since into sinceById. */
+function validateComponent(comp, i, version, seen, sinceById) {
+  const at = `[inventory] components[${i}]`;
+  if (!isObject(comp)) return [`${at} must be a mapping`];
+  const out = [];
+  const id = comp.id;
+  const label = isNonEmptyString(id) ? `component "${id}"` : at;
+
+  for (const key of Object.keys(comp)) {
+    if (!COMPONENT_KEYS.includes(key))
+      out.push(`[inventory] ${label}: unknown key "${key}"`);
+  }
+  for (const key of COMPONENT_KEYS) {
+    if (!(key in comp))
+      out.push(`[inventory] ${label}: missing required field "${key}"`);
+  }
+  if (!isNonEmptyString(id) || !KEBAB.test(id)) {
+    out.push(
+      `[inventory] ${at}: id must be a kebab-case string (got ${JSON.stringify(id)})`,
+    );
+  } else if (seen.has(id)) {
+    out.push(`[inventory] duplicate component id "${id}"`);
+  } else {
+    seen.add(id);
+  }
+  for (const f of STRING_FIELDS) {
+    if (f in comp && !isNonEmptyString(comp[f]))
+      out.push(`[inventory] ${label}: ${f} must be a non-empty string`);
+  }
+  if ("variants" in comp && !isStringArray(comp.variants)) {
+    out.push(`[inventory] ${label}: variants must be a list of strings`);
+  }
+  for (const f of NONEMPTY_ARRAYS) {
+    if (f in comp && !(isStringArray(comp[f]) && comp[f].length > 0)) {
+      out.push(
+        `[inventory] ${label}: ${f} must be a non-empty list of strings`,
+      );
+    }
+  }
+  if ("since" in comp) {
+    if (!isInt(comp.since) || comp.since < 1) {
+      out.push(`[inventory] ${label}: since must be an integer >= 1`);
+    } else if (isInt(version) && comp.since > version) {
+      out.push(
+        `[inventory] ${label}: since ${comp.since} exceeds inventory version ${version}`,
+      );
+    } else if (isNonEmptyString(id)) {
+      sinceById.set(id, comp.since);
+    }
+  }
+  return out;
+}
+
+/** version bumped => CHANGELOG.md must carry a matching `## vN` heading. */
+export function validateChangelog(text, version) {
+  if (!isInt(version)) return [];
+  const re = new RegExp(`^##\\s+v?${version}\\b`, "m");
+  return re.test(text)
+    ? []
+    : [
+        `[changelog] no "## v${version}" entry for inventory version ${version}`,
+      ];
+}


### PR DESCRIPTION
Element 3 of the mobile-parity prerequisites (headless SDK / design tokens / **component inventory** / procedures).

Structural parity, tracked instead of remembered: when the native apps exist, a UI change that touches a cross-surface component cannot silently skip mobile.

## What
- **`design/inventory/inventory.yaml`** — versioned spec of the 22 genuinely cross-surface components (mobile-core set + board/routines/skills/primitives), each with anatomy, states, variants, behavior semantics, and a11y expectations. Desktop-only chrome and power-user surfaces deliberately excluded (documented).
- **Manifests** — `web` enforced at v1 with an honest audit (18 implemented, **4 partial**: no shared agent-list-item; provider-error cards app/-locked despite the shared taxonomy; skill-invocation card app-composed; mission-status rendering triplicated with divergent enums). `ios`/`android` tracked at v0, unenforced until they ship.
- **`pnpm check:parity`** (CI-wired, style-matched to check-boundaries) — hard-fails on schema errors, unknown components, missing entries, enforced-surface lag, or version bumps without CHANGELOG; prints a lag table for unenforced surfaces. 6 tests incl. both required failure modes.
- **PR template** — Surface-impact checklist (behavior → SDK / look → tokens / structure → inventory / per-surface).

The 4 web partials + the triplicated status rendering are the consolidation backlog the inventory now makes visible.

## Verification
`pnpm check` clean, workspace typecheck clean, `check:parity` OK on the real files, 6/6 checker tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)