### PR TITLE
fix(design-tokens): build dist on install so CI and consumers can resolve it

### DIFF
--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -21,6 +21,7 @@
   ],
   "scripts": {
     "build": "node build/index.mjs",
+    "prepare": "node build/index.mjs",
     "test": "vitest run",
     "typecheck": "tsgo -p tsconfig.json --noEmit"
   },


### PR DESCRIPTION
## Problem

#595 introduced `@houston/design-tokens`, whose `dist/` output is gitignored and never built in CI. The PR gate on `main` broke two ways ([failing run](https://github.com/gethouston/houston/actions/runs/28669913139/job/85030576919)):

- **TS checks**: `pnpm -r typecheck` failed — `test/outputs.test.ts` imports `../dist/ts/tokens.ts`, which doesn't exist on a fresh checkout.
- **Web UI tests**: the Playwright job's vite dev server couldn't resolve `@houston/design-tokens/css` (imported by `ui/core/src/globals.css`), so the app never rendered and global setup timed out.

Release builds would have hit the same wall at `vite build` time.

## Fix

Add a `prepare` script to the package so `pnpm install` compiles the tokens into `dist/`. This makes the package self-sufficient — every consumer (both CI jobs, release workflows, fresh clones) gets the built output with no workflow changes.

## Verification

- Deleted `dist/`, ran `pnpm install --frozen-lockfile`: `prepare` runs and regenerates `dist/{css,ts,swift,kotlin}`.
- `pnpm -r typecheck` passes across all 21 workspace packages.
- `pnpm --filter @houston/design-tokens test`: 75 tests pass.
- `pnpm --filter houston-web build` resolves `@houston/design-tokens/css` and builds clean.
- `pnpm check` (Biome) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)