### PR TITLE
fix(design-tokens): POSIX-normalize source globs so the build works on Windows

### DIFF
--- a/packages/design-tokens/build/collect.mjs
+++ b/packages/design-tokens/build/collect.mjs
@@ -8,6 +8,21 @@ import StyleDictionary from "style-dictionary";
 // cwd the build is invoked from (pnpm filter, the sync test, CI).
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
 
+/**
+ * Join path segments into a Style Dictionary `source` glob with POSIX separators.
+ *
+ * Style Dictionary globs `source` with fast-glob, which requires forward-slash
+ * separators on EVERY platform. `node:path.join` emits BACKSLASHES on Windows,
+ * and fast-glob reads a backslash as an escape character — so a Windows-joined
+ * glob (`C:\…\tokens\primitive\**\*.json`) silently matches nothing, the
+ * primitive/scale token files never load, and every cross-file reference fails
+ * ("Some token references could not be found"). This broke both windows-msvc
+ * release jobs at `pnpm install` (the design-tokens `prepare` build). Join for
+ * correct resolution, then force forward slashes. No-op on macOS/Linux.
+ */
+export const posixGlob = (...segments) =>
+  join(...segments).replaceAll("\\", "/");
+
 const FLAT_FORMAT = "houston/flat-json";
 let registered = false;
 
@@ -44,9 +59,9 @@ export async function collect(theme) {
   try {
     const sd = new StyleDictionary({
       source: [
-        join(ROOT, "tokens/primitive/**/*.json"),
-        join(ROOT, "tokens/scale/**/*.json"),
-        join(ROOT, `tokens/semantic/color.${theme}.json`),
+        posixGlob(ROOT, "tokens/primitive/**/*.json"),
+        posixGlob(ROOT, "tokens/scale/**/*.json"),
+        posixGlob(ROOT, `tokens/semantic/color.${theme}.json`),
       ],
       platforms: {
         flat: {
@@ -59,7 +74,12 @@ export async function collect(theme) {
     });
     await sd.buildAllPlatforms();
     const tokens = JSON.parse(readFileSync(join(out, "flat.json"), "utf8"));
-    return tokens.filter((t) => !t.filePath.includes("/primitive/"));
+    // fast-glob returns forward-slash filePaths, but normalise defensively so the
+    // primitive filter can't silently misfire on Windows (which would leak
+    // primitives into the emitted tokens instead of failing loudly).
+    return tokens.filter(
+      (t) => !t.filePath.replaceAll("\\", "/").includes("/primitive/"),
+    );
   } finally {
     rmSync(out, { recursive: true, force: true });
   }

--- a/packages/design-tokens/test/windows-glob.test.mjs
+++ b/packages/design-tokens/test/windows-glob.test.mjs
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { posixGlob } from "../build/collect.mjs";
+
+/**
+ * Regression for the Windows CI break: both windows-msvc release jobs failed at
+ * `pnpm install` → the design-tokens `prepare` build with "Some token references
+ * could not be found". Style Dictionary globs its `source` files with fast-glob,
+ * which requires forward-slash separators on every platform. On Windows
+ * `node:path.join` emits backslashes, which fast-glob reads as escapes, so the
+ * primitive/scale globs matched nothing and every cross-file reference dangled.
+ *
+ * These assert the transform on a Windows-style root, so they hold on any OS
+ * (macOS/Linux `path.join` never introduces backslashes, so the bug can't
+ * reproduce there — the input has to be simulated). This file is .mjs so it can
+ * import the .mjs build helper without tripping the package's TS typecheck.
+ */
+describe("posixGlob (Windows source-glob normalisation)", () => {
+  it("strips the backslashes a Windows path.join introduces", () => {
+    const glob = posixGlob(
+      "C:\\repo\\design-tokens",
+      "tokens/primitive/**/*.json",
+    );
+    expect(glob.includes("\\")).toBe(false);
+    expect(glob).toBe("C:/repo/design-tokens/tokens/primitive/**/*.json");
+  });
+
+  it("normalises an already-backslashed relative segment too", () => {
+    expect(posixGlob("C:\\a", "tokens\\scale\\**\\*.json")).toBe(
+      "C:/a/tokens/scale/**/*.json",
+    );
+  });
+
+  it("leaves a POSIX glob unchanged (no-op on macOS/Linux)", () => {
+    const glob = "/repo/design-tokens/tokens/semantic/color.dark.json";
+    expect(posixGlob(glob)).toBe(glob);
+  });
+});


### PR DESCRIPTION
## What

Fixes the design-tokens build so it works on Windows. Both `windows-msvc` release
jobs were failing at **`pnpm install`** with:

```
packages/design-tokens prepare$ node build/index.mjs
Reference Errors: Some token references (33) could not be found.
  at async collect (packages/design-tokens/build/collect.mjs:60)
```

(Example failing job: run 28670761311 → `build-windows`.)

## Root cause

Since #597, `@houston/design-tokens` builds its `dist/` in a `prepare` script on
every `pnpm install`. That build globs its Style Dictionary `source` files with
`node:path.join(ROOT, "tokens/**/*.json")`. On Windows `path.join` emits
**backslashes** (`C:\…\tokens\primitive\**\*.json`), and Style Dictionary's
globber (fast-glob) reads a backslash as an **escape character** — so the
primitive/scale globs match nothing, the primitives never load, and the 33
references in the semantic color file dangle. It works on macOS/Linux only
because `path.join` emits forward slashes there.

## Fix

- Normalize the `source` globs to POSIX separators before handing them to Style
  Dictionary (`collect.mjs` → `posixGlob`). No-op on macOS/Linux.
- Defensively normalize the primitive filter's `filePath` check so it can't
  silently misfire on Windows either.
- Add `test/windows-glob.test.mjs` — an OS-independent regression test for the
  normalization (asserts a Windows-style `path.join` result becomes a
  forward-slash glob). It's `.mjs` so it can import the `.mjs` build helper
  without the package's tsgo typecheck flagging an untyped import.

## Verification

- **Reproduced the exact failure on macOS**: feeding Style Dictionary
  backslashed globs (with a loadable semantic file, mirroring the Windows shape)
  reproduces `references (33) could not be found` — the same "33" as CI. The
  POSIX globs resolve all **112** tokens.
- **No regression**: `zero-diff` (68) + `sync` (4) tests pass, i.e. the emitted
  `dist/` is byte-identical on POSIX. Full suite: **78 passed**.
- Note: PR CI (typecheck/biome/vitest on Linux) can't run a real Windows tokens
  build, so final confirmation is the next Windows release build — but the failure
  mode is reproduced and fixed above.

## Context

Surfaced while smoke-testing the new `cloud-v*` desktop build channel (#594): the
first full release build since #595/#597 hit this. Independent of that channel —
it breaks local `v*` Windows releases identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
