### PR TITLE
feat(client): write-through invalidation echo + redact pod boot-token banner

### DIFF
--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -4,6 +4,7 @@ export * from "./layout";
 export * from "./portable";
 export * from "./preferences";
 export * from "./provider-model";
+export * from "./reactivity";
 export * from "./routines";
 export * from "./schedule";
 export * from "./skills";

--- a/packages/domain/src/reactivity.ts
+++ b/packages/domain/src/reactivity.ts
@@ -1,0 +1,49 @@
+import type { HoustonEvent } from "@houston/protocol";
+
+/**
+ * Map an agent-relative path (the part AFTER `<Workspace>/<Agent>/`, e.g.
+ * `.houston/config/config.json` or `CLAUDE.md`) to the reactivity event a
+ * mutation of that path should raise.
+ *
+ * This is the ONE classification shared by the cloud/local host's file watcher
+ * (`packages/host/src/watch/classify.ts`, which prepends the agent prefix) and
+ * the web engine-adapter's write-through echo
+ * (`packages/web/src/engine-adapter/client.ts`). Keeping it in the shared domain
+ * means the watcher and the echo can never drift into disagreeing about which
+ * file raises which event.
+ *
+ * Order matters: `routine_runs` must be tested before `routines` (prefix
+ * overlap). Returns null for paths not worth an event (`.git/**`, `.DS_Store`).
+ */
+export function agentFileEventType(
+  relPath: string,
+): HoustonEvent["type"] | null {
+  if (relPath.startsWith(".houston/routine_runs")) return "RoutineRunsChanged";
+  if (relPath.startsWith(".houston/routines")) return "RoutinesChanged";
+  if (relPath.startsWith(".houston/activity")) return "ActivityChanged";
+  if (relPath.startsWith(".houston/config")) return "ConfigChanged";
+  if (relPath.startsWith(".houston/learnings")) return "LearningsChanged";
+  if (
+    relPath.startsWith(".houston/conversations") ||
+    relPath.startsWith(".houston/sessions")
+  ) {
+    return "ConversationsChanged";
+  }
+  if (
+    relPath.startsWith(".agents/skills") ||
+    relPath.startsWith(".houston/skills") ||
+    relPath.startsWith(".claude/skills")
+  ) {
+    return "SkillsChanged";
+  }
+  if (
+    relPath === "CLAUDE.md" ||
+    relPath === "AGENTS.md" ||
+    relPath === "GEMINI.md"
+  )
+    return "ContextChanged";
+  // Internal bookkeeping we never surface.
+  if (relPath.startsWith(".git/") || relPath === ".DS_Store") return null;
+  // Any other file in the agent's working tree.
+  return "FilesChanged";
+}

--- a/packages/host/src/local/banner.test.ts
+++ b/packages/host/src/local/banner.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+import { formatHostListeningBanner } from "./banner";
+
+const TOKEN =
+  "deadbeefcafef00d0123456789abcdef0123456789abcdef0123456789abcdef";
+
+test("desktop sidecar (generated token) prints the full token for the handshake", () => {
+  // The Tauri supervisor parses `token=<value>` back out of this line, so the
+  // full token MUST be present when we are NOT redacting.
+  const line = formatHostListeningBanner({
+    port: 4318,
+    token: TOKEN,
+    redactToken: false,
+  });
+  expect(line).toBe(`HOUSTON_HOST_LISTENING port=4318 token=${TOKEN}`);
+  // parse_banner's grammar: a whitespace-delimited `token=` field is present.
+  expect(line).toMatch(/(^|\s)token=deadbeef/);
+});
+
+test("managed pod / self-host (env token) redacts to a non-reversible fingerprint", () => {
+  const line = formatHostListeningBanner({
+    port: 4318,
+    token: TOKEN,
+    redactToken: true,
+  });
+  // Readiness greps still match on the prefix.
+  expect(line.startsWith("HOUSTON_HOST_LISTENING port=4318")).toBe(true);
+  // The full token never appears.
+  expect(line).not.toContain(TOKEN);
+  // A fingerprint (first 8 chars) + length is surfaced for log correlation, and
+  // deliberately uses `token_fp=`/`token_len=` so nothing parses it as a token.
+  expect(line).toContain(`token_fp=${TOKEN.slice(0, 8)}`);
+  expect(line).toContain(`token_len=${TOKEN.length}`);
+  expect(line).not.toMatch(/(^|\s)token=/);
+});

--- a/packages/host/src/local/banner.ts
+++ b/packages/host/src/local/banner.ts
@@ -1,0 +1,37 @@
+/**
+ * The `HOUSTON_HOST_LISTENING` startup banner.
+ *
+ * This ONE line serves two very different deployments of the same local host:
+ *
+ *  - **Desktop sidecar** — the host mints a random per-boot token and the Tauri
+ *    supervisor parses the token back out of this banner
+ *    (`app/src-tauri/src/engine_supervisor.rs::parse_banner`). Here the full
+ *    `token=<value>` field is a real handshake channel and MUST be printed.
+ *
+ *  - **Managed cloud pod / self-host** — the token is injected via env
+ *    (`HOUSTON_HOST_TOKEN`) by an orchestrator that already knows it. Nothing
+ *    in-cluster reads it back from the log (readiness is an HTTP `/health`
+ *    probe), so echoing the full credential just leaks it into plaintext pod
+ *    logs. We redact it to a short, non-reversible fingerprint instead.
+ *
+ * Both forms keep the `HOUSTON_HOST_LISTENING port=<p>` prefix intact, which is
+ * all the readiness greps (build-host-sidecar.sh, the parent-watchdog test, the
+ * parity checklist) match on. The redacted form deliberately uses `token_fp=` /
+ * `token_len=` field names — NOT `token=` — so no consumer can mistake the
+ * fingerprint for a usable token.
+ */
+export function formatHostListeningBanner(args: {
+  port: number;
+  token: string;
+  /** Redact the token to a fingerprint (env/orchestrator-supplied token). */
+  redactToken: boolean;
+}): string {
+  const base = `HOUSTON_HOST_LISTENING port=${args.port}`;
+  if (!args.redactToken) return `${base} token=${args.token}`;
+  return `${base} token_fp=${tokenFingerprint(args.token)} token_len=${args.token.length}`;
+}
+
+/** First 8 chars of the token — enough to correlate logs, useless as a credential. */
+function tokenFingerprint(token: string): string {
+  return token.slice(0, 8);
+}

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -22,6 +22,7 @@ import { LocalWorkspaceStore } from "../store/local";
 import { MemoryTurnBus } from "../turn/bus";
 import { FsVfs } from "../vfs";
 import { FsWatcher } from "../watch/watcher";
+import { formatHostListeningBanner } from "./banner";
 
 /** The single local user every request resolves to. */
 export const LOCAL_USER = "local-owner";
@@ -48,6 +49,15 @@ export interface LocalHostOptions {
   bind?: string;
   /** Random per-boot token the shell presents on every request (SingleUserVerifier). */
   token: string;
+  /**
+   * Redact the token in the `HOUSTON_HOST_LISTENING` startup banner to a short
+   * fingerprint instead of printing it in full. Set when the token was supplied
+   * by an orchestrator (env `HOUSTON_HOST_TOKEN`) or in managed cloud — where the
+   * banner would otherwise leak the credential into plaintext pod logs and no one
+   * reads it back. Left false for the desktop sidecar, whose supervisor parses the
+   * per-boot token out of this line (`engine_supervisor.rs::parse_banner`).
+   */
+  redactBannerToken?: boolean;
   /** argv to launch a pi-runtime: dev `node --import tsx .../runtime/src/main.ts`, prod the sidecar. */
   runtimeCommand: string[];
   /** Product system prompt the app injects into every runtime (voice rules). */
@@ -288,8 +298,14 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
       watcher.start();
       scheduler.start();
       // The banner the Tauri supervisor parses (mirrors the runtime's contract).
+      // The full token rides ONLY for the desktop sidecar; a pod/self-host token
+      // is env-supplied and redacted so it never lands in plaintext logs.
       console.log(
-        `HOUSTON_HOST_LISTENING port=${opts.port} token=${opts.token}`,
+        formatHostListeningBanner({
+          port: opts.port,
+          token: opts.token,
+          redactToken: opts.redactBannerToken ?? false,
+        }),
       );
     },
     stop() {

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -73,6 +73,15 @@ const host = buildLocalHost({
   // Loopback by default (desktop). Self-host sets HOUSTON_HOST_BIND=0.0.0.0.
   bind: process.env.HOUSTON_HOST_BIND || undefined,
   token: process.env.HOUSTON_HOST_TOKEN || randomBytes(32).toString("hex"),
+  // Redact the token in the startup banner whenever it came from the
+  // environment (a pod/self-host token an orchestrator already knows) or we are
+  // a managed cloud pod — echoing it there just leaks a credential into
+  // plaintext logs. The desktop sidecar mints a random per-boot token (no
+  // HOUSTON_HOST_TOKEN) and its supervisor reads it back from this line, so
+  // that case keeps the full token.
+  redactBannerToken:
+    !!process.env.HOUSTON_HOST_TOKEN ||
+    process.env.HOUSTON_MANAGED_CLOUD === "1",
   runtimeCommand: runtimeCommand(),
   // The real Tauri app hands over its own product prompt; this is the built-in
   // default so the agent knows how to create Skills/Routines/learnings.

--- a/packages/host/src/watch/classify.ts
+++ b/packages/host/src/watch/classify.ts
@@ -1,3 +1,4 @@
+import { agentFileEventType } from "@houston/domain";
 import type { HoustonEvent } from "@houston/protocol";
 
 /**
@@ -6,6 +7,9 @@ import type { HoustonEvent } from "@houston/protocol";
  * engine/houston-file-watcher's classification. The agentPath is the
  * `<Workspace>/<Agent>` prefix (the agent's opaque key locally).
  *
+ * The path→event decision lives in `@houston/domain` (`agentFileEventType`) so
+ * this watcher and the web adapter's write-through echo classify identically.
+ *
  * Returns null for paths not inside an agent or not worth an event.
  */
 export function classifyChange(relPath: string): HoustonEvent | null {
@@ -13,34 +17,6 @@ export function classifyChange(relPath: string): HoustonEvent | null {
   if (parts.length < 3) return null; // need <Workspace>/<Agent>/<something>
   const agentPath = `${parts[0]}/${parts[1]}`;
   const rest = parts.slice(2).join("/");
-  const type = eventTypeFor(rest);
+  const type = agentFileEventType(rest);
   return type ? ({ type, agentPath } as HoustonEvent) : null;
-}
-
-function eventTypeFor(rest: string): HoustonEvent["type"] | null {
-  // Order matters: routine_runs must be tested before routines (prefix overlap).
-  if (rest.startsWith(".houston/routine_runs")) return "RoutineRunsChanged";
-  if (rest.startsWith(".houston/routines")) return "RoutinesChanged";
-  if (rest.startsWith(".houston/activity")) return "ActivityChanged";
-  if (rest.startsWith(".houston/config")) return "ConfigChanged";
-  if (rest.startsWith(".houston/learnings")) return "LearningsChanged";
-  if (
-    rest.startsWith(".houston/conversations") ||
-    rest.startsWith(".houston/sessions")
-  ) {
-    return "ConversationsChanged";
-  }
-  if (
-    rest.startsWith(".agents/skills") ||
-    rest.startsWith(".houston/skills") ||
-    rest.startsWith(".claude/skills")
-  ) {
-    return "SkillsChanged";
-  }
-  if (rest === "CLAUDE.md" || rest === "AGENTS.md" || rest === "GEMINI.md")
-    return "ContextChanged";
-  // Internal bookkeeping we never surface.
-  if (rest.startsWith(".git/") || rest === ".DS_Store") return null;
-  // Any other file in the agent's working tree.
-  return "FilesChanged";
 }

--- a/packages/web/src/engine-adapter/bus.ts
+++ b/packages/web/src/engine-adapter/bus.ts
@@ -31,3 +31,37 @@ export const bus = new EventBus();
 export function emitEvent(type: string, data: unknown): void {
   bus.emit({ type, data });
 }
+
+/**
+ * Write-through invalidation echo — adapter-synthesizer behavior, app-bus
+ * specific (NOT SDK core; see knowledge-base/client-architecture.md, procedure
+ * a).
+ *
+ * The hosted UI's TanStack caches (board status, config, routines, skills,
+ * learnings, …) invalidate ONLY on events from the host's global `/v1/events`
+ * stream. But after the adapter ITSELF performs a domain write it already KNOWS
+ * the matching cache is stale — and waiting for the server round trip (which the
+ * gateway historically never even forwarded for pod events) leaves e.g. a board
+ * card stuck on "running" after the reply already rendered.
+ *
+ * So we synthesize the SAME invalidation event locally, in the EXACT shape a real
+ * server frame takes after `control-plane.toInvalidationEvent` translation
+ * (`{ type, data: { agent_path, workspace_id } }`), and push it onto the SAME bus
+ * the server stream feeds → the EngineWebSocket shim (`ws.ts`) →
+ * `app/src/hooks/use-agent-invalidation.ts`. Idempotent by construction:
+ * invalidation is only a refetch trigger, so the real event arriving later (once
+ * the gateway forwards pod events) is a harmless no-op.
+ *
+ * Call ONLY after a successful domain WRITE — never for reads or turn frames
+ * (those flow on the turn stream and are folded once by the SDK). SDK-embedding
+ * surfaces need no echo: their VM consumers update directly.
+ */
+export function emitLocalEcho(
+  type: string,
+  keys: { agentPath?: string; workspaceId?: string },
+): void {
+  bus.emit({
+    type,
+    data: { agent_path: keys.agentPath, workspace_id: keys.workspaceId },
+  });
+}

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -1,4 +1,4 @@
-import { migrateProviderModel } from "@houston/domain";
+import { agentFileEventType, migrateProviderModel } from "@houston/domain";
 import {
   type CustomEndpoint,
   HoustonEngineClient,
@@ -34,7 +34,7 @@ import {
   writeAgentFile as writeAgentFileStore,
 } from "./agent-files";
 import * as agents from "./agents";
-import { bus, emitEvent } from "./bus";
+import { bus, emitEvent, emitLocalEcho } from "./bus";
 import type { ControlPlaneConfig } from "./control-plane";
 import * as controlPlane from "./control-plane";
 import {
@@ -335,6 +335,9 @@ export class HoustonClient {
         : this.engine;
       await engine.setSettings({ activeProvider: provider, model });
     }
+    // Write-through echo: the config query keys on agentPath, so the picker
+    // flips without waiting for a server round trip. See bus.emitLocalEcho.
+    emitLocalEcho("ConfigChanged", { agentPath });
     return config;
   }
   async listInstalledConfigs() {
@@ -352,21 +355,27 @@ export class HoustonClient {
     agentPath: string,
     input: NewActivity,
   ): Promise<Activity> {
-    if (this.cp) return controlPlane.createActivity(this.cp, agentPath, input);
-    return activities.createActivity(agentPath, input);
+    const activity = this.cp
+      ? await controlPlane.createActivity(this.cp, agentPath, input)
+      : activities.createActivity(agentPath, input);
+    emitLocalEcho("ActivityChanged", { agentPath });
+    return activity;
   }
   async updateActivity(
     agentPath: string,
     id: string,
     updates: ActivityUpdate,
   ): Promise<Activity> {
-    if (this.cp)
-      return controlPlane.updateActivity(this.cp, agentPath, id, updates);
-    return activities.updateActivity(agentPath, id, updates);
+    const activity = this.cp
+      ? await controlPlane.updateActivity(this.cp, agentPath, id, updates)
+      : activities.updateActivity(agentPath, id, updates);
+    emitLocalEcho("ActivityChanged", { agentPath });
+    return activity;
   }
   async deleteActivity(agentPath: string, id: string): Promise<void> {
-    if (this.cp) return controlPlane.deleteActivity(this.cp, agentPath, id);
-    activities.deleteActivity(agentPath, id);
+    if (this.cp) await controlPlane.deleteActivity(this.cp, agentPath, id);
+    else activities.deleteActivity(agentPath, id);
+    emitLocalEcho("ActivityChanged", { agentPath });
   }
 
   /**
@@ -384,6 +393,10 @@ export class HoustonClient {
   ): Promise<void> {
     if (!this.cp) {
       activities.setStatusBySessionKey(agentPath, sessionKey, status);
+      // Write-through echo: this is the settle path (a turn finishing PATCHes
+      // its board status). Without it the card sticks on "running" until a
+      // server event that, in hosted mode, historically never comes.
+      emitLocalEcho("ActivityChanged", { agentPath });
       return;
     }
     const list = await controlPlane.listActivities(this.cp, agentPath);
@@ -392,6 +405,7 @@ export class HoustonClient {
     );
     if (!match) return; // transient session with no board card — nothing to update
     await controlPlane.updateActivity(this.cp, agentPath, match.id, { status });
+    emitLocalEcho("ActivityChanged", { agentPath });
   }
 
   // ---- agent data files (.houston/**) ----
@@ -418,6 +432,11 @@ export class HoustonClient {
     // (e.g. a non-default OpenCode Go model) updates the doc but every turn keeps
     // running the provider's default. Bridge the config write into the engine.
     await this.syncConfigToSettings(agentPath, relPath, content);
+    // Write-through echo: files-first writes (learnings, context, config doc, …)
+    // have no dedicated event, so classify the path exactly as the host watcher
+    // does and invalidate the matching cache locally. Null (e.g. `.git/**`) skips.
+    const echoType = agentFileEventType(relPath);
+    if (echoType) emitLocalEcho(echoType, { agentPath });
   }
 
   /**
@@ -608,46 +627,55 @@ export class HoustonClient {
   // Routine + skill mutations route to the host (cloud); standalone web has no
   // routine/skill backend, so they no-op there (the UI still navigates).
   async createRoutine(agentPath: string, input: NewRoutine): Promise<Routine> {
-    if (this.cp) return controlPlane.createRoutine(this.cp, agentPath, input);
-    return {} as Routine;
+    if (!this.cp) return {} as Routine;
+    const routine = await controlPlane.createRoutine(this.cp, agentPath, input);
+    emitLocalEcho("RoutinesChanged", { agentPath });
+    return routine;
   }
   async updateRoutine(
     agentPath: string,
     id: string,
     updates: RoutineUpdate,
   ): Promise<Routine> {
-    if (this.cp)
-      return controlPlane.updateRoutine(this.cp, agentPath, id, updates);
-    return {} as Routine;
+    if (!this.cp) return {} as Routine;
+    const routine = await controlPlane.updateRoutine(
+      this.cp,
+      agentPath,
+      id,
+      updates,
+    );
+    emitLocalEcho("RoutinesChanged", { agentPath });
+    return routine;
   }
   async deleteRoutine(agentPath: string, id: string): Promise<void> {
-    if (this.cp) return controlPlane.deleteRoutine(this.cp, agentPath, id);
+    if (!this.cp) return;
+    await controlPlane.deleteRoutine(this.cp, agentPath, id);
+    emitLocalEcho("RoutinesChanged", { agentPath });
   }
   /** Fire a routine on demand: the host records a routine_run and starts the turn now. */
   async runRoutineNow(agentPath: string, routineId: string): Promise<void> {
-    if (this.cp)
-      return controlPlane.runRoutineNow(this.cp, agentPath, routineId);
-    throw new Error("Running a routine needs a cloud workspace.");
+    if (!this.cp) throw new Error("Running a routine needs a cloud workspace.");
+    await controlPlane.runRoutineNow(this.cp, agentPath, routineId);
+    emitLocalEcho("RoutineRunsChanged", { agentPath });
   }
   async createSkill(req: CreateSkillRequest): Promise<void> {
-    if (this.cp)
-      return controlPlane.createSkill(this.cp, req.workspacePath, {
-        name: req.name,
-        description: req.description,
-        content: req.content,
-      });
+    if (!this.cp) return;
+    await controlPlane.createSkill(this.cp, req.workspacePath, {
+      name: req.name,
+      description: req.description,
+      content: req.content,
+    });
+    emitLocalEcho("SkillsChanged", { agentPath: req.workspacePath });
   }
   async saveSkill(name: string, req: SaveSkillRequest): Promise<void> {
-    if (this.cp)
-      return controlPlane.saveSkill(
-        this.cp,
-        req.workspacePath,
-        name,
-        req.content,
-      );
+    if (!this.cp) return;
+    await controlPlane.saveSkill(this.cp, req.workspacePath, name, req.content);
+    emitLocalEcho("SkillsChanged", { agentPath: req.workspacePath });
   }
   async deleteSkill(workspacePath: string, name: string): Promise<void> {
-    if (this.cp) return controlPlane.deleteSkill(this.cp, workspacePath, name);
+    if (!this.cp) return;
+    await controlPlane.deleteSkill(this.cp, workspacePath, name);
+    emitLocalEcho("SkillsChanged", { agentPath: workspacePath });
   }
 
   // ---- providers (auth) ----

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -630,19 +630,36 @@ export function subscribeEvents(
       `${cfg.baseUrl}/v1/events?token=${encodeURIComponent(liveToken(cfg.token))}`,
     fetch,
     signal: ac.signal,
-    onEvent: (data) => {
-      const ev = data as {
-        type: string;
-        agentPath?: string;
-        workspaceId?: string;
-      };
-      onEvent({
-        type: ev.type,
-        data: { agent_path: ev.agentPath, workspace_id: ev.workspaceId },
-      });
-    },
+    onEvent: (data) =>
+      onEvent(
+        toInvalidationEvent(
+          data as { type: string; agentPath?: string; workspaceId?: string },
+        ),
+      ),
   });
   return () => ac.abort();
+}
+
+/**
+ * Translate a host global-events frame (`{ type, agentPath, workspaceId }`) into
+ * the shape the app's invalidation map reads
+ * (`{ type, data: { agent_path, workspace_id } }`, see
+ * `app/src/hooks/use-agent-invalidation.ts`).
+ *
+ * Exported as the ONE source of that shape so the adapter's write-through echo
+ * (`bus.emitLocalEcho`) can be verified to produce byte-identical events — a
+ * locally synthesized echo and a real server frame must be indistinguishable to
+ * the invalidation hook, or one of them silently no-ops.
+ */
+export function toInvalidationEvent(frame: {
+  type: string;
+  agentPath?: string;
+  workspaceId?: string;
+}): { type: string; data: { agent_path?: string; workspace_id?: string } } {
+  return {
+    type: frame.type,
+    data: { agent_path: frame.agentPath, workspace_id: frame.workspaceId },
+  };
 }
 
 // ── integrations (Composio, platform mode) ───────────────────────────────────

--- a/packages/web/tests/write-echo.test.ts
+++ b/packages/web/tests/write-echo.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, expect, test, vi } from "vitest";
+
+/**
+ * Write-through invalidation echo (the hosted "instant status flip" fix).
+ *
+ * In hosted (control-plane) mode the board/config/routine/skill/learnings caches
+ * invalidate ONLY on events from the host's global `/v1/events` stream, which the
+ * gateway historically never forwarded for pod events — so after the adapter's
+ * OWN write the UI stuck (a settled turn's card hung on "running"). The adapter
+ * now echoes the matching invalidation event locally, in the EXACT shape a real
+ * server frame produces (`control-plane.toInvalidationEvent`). These tests assert
+ * the echo fires on the settle path and on other writes, with the correct keys,
+ * and that its shape is byte-identical to a server frame's.
+ *
+ * The control-plane module is mocked so cp-mode writes resolve without a network,
+ * letting us observe the echo the client pushes onto the in-process bus.
+ */
+vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../src/engine-adapter/control-plane")
+    >();
+  return {
+    ...actual,
+    runtimeClientFor: vi.fn(() => ({
+      cancel: vi.fn(async () => ({ cancelled: false })),
+      setSettings: vi.fn(async () => {}),
+    })),
+    subscribeEvents: vi.fn(() => () => {}),
+    listActivities: vi.fn(async () => [
+      {
+        id: "a1",
+        title: "t",
+        description: "",
+        status: "running",
+        session_key: "sk-1",
+        updated_at: 0,
+      },
+    ]),
+    updateActivity: vi.fn(async () => ({})),
+    createRoutine: vi.fn(async () => ({ id: "r1" })),
+    writeAgentFile: vi.fn(async () => {}),
+  };
+});
+
+import { bus, emitLocalEcho } from "../src/engine-adapter/bus";
+import { HoustonClient } from "../src/engine-adapter/client";
+import { toInvalidationEvent } from "../src/engine-adapter/control-plane";
+
+type BusEvent = { type: string; data: { agent_path?: string } };
+
+function capture() {
+  const events: BusEvent[] = [];
+  const off = bus.on((e) => events.push(e as BusEvent));
+  return { events, off };
+}
+
+function hostedClient() {
+  return new HoustonClient({
+    baseUrl: "http://host",
+    token: "t",
+    controlPlane: true,
+  });
+}
+
+afterEach(() => vi.clearAllMocks());
+
+test("the settle path echoes ActivityChanged with the agent key", async () => {
+  // cancelSession is a settle-and-PATCH: the runtime reports no live turn
+  // (`cancelled: false`), so the client writes the board status itself — the
+  // same setActivityStatus write a turn's own settle performs.
+  const client = hostedClient();
+  const { events, off } = capture();
+  await client.cancelSession("Home/Ada", "sk-1");
+  off();
+
+  const echoes = events.filter((e) => e.type === "ActivityChanged");
+  expect(echoes).toEqual([
+    toInvalidationEvent({ type: "ActivityChanged", agentPath: "Home/Ada" }),
+  ]);
+});
+
+test("routine CRUD echoes RoutinesChanged with the agent key", async () => {
+  const client = hostedClient();
+  const { events, off } = capture();
+  await client.createRoutine("Home/Ada", {
+    name: "Daily",
+  } as Parameters<HoustonClient["createRoutine"]>[1]);
+  off();
+
+  expect(events.filter((e) => e.type === "RoutinesChanged")).toEqual([
+    toInvalidationEvent({ type: "RoutinesChanged", agentPath: "Home/Ada" }),
+  ]);
+});
+
+test("a files-first write echoes its classified event (learnings)", async () => {
+  const client = hostedClient();
+  const { events, off } = capture();
+  await client.writeAgentFile(
+    "Home/Ada",
+    ".houston/learnings/learnings.json",
+    "[]",
+  );
+  off();
+
+  expect(events.filter((e) => e.type === "LearningsChanged")).toEqual([
+    toInvalidationEvent({ type: "LearningsChanged", agentPath: "Home/Ada" }),
+  ]);
+});
+
+test("emitLocalEcho is byte-identical to the server frame the gateway will send", () => {
+  // Shape parity: the invalidation hook keys off `data.agent_path`; a locally
+  // synthesized echo and a real `/v1/events` frame must be indistinguishable, or
+  // one silently no-ops. Assert the echo the client emits equals what the ONE
+  // server-frame translator produces for the same event.
+  const { events, off } = capture();
+  emitLocalEcho("ActivityChanged", { agentPath: "W/A" });
+  off();
+
+  expect(events).toEqual([
+    toInvalidationEvent({ type: "ActivityChanged", agentPath: "W/A" }),
+  ]);
+});

--- a/selfhost/README.md
+++ b/selfhost/README.md
@@ -296,4 +296,7 @@ All state lives in the Docker volume mounted at `/data`: workspaces, agents,
 skills, routines, and provider credentials.
 
 Security: token gates every route except `/engine/health`; treat it like a
-password. On a VPS, expose Caddy only, never port `4318` directly.
+password. On a VPS, expose Caddy only, never port `4318` directly. Because you
+supply `HOUSTON_HOST_TOKEN` via env, the host redacts it in its
+`HOUSTON_HOST_LISTENING` boot banner (you see `token_fp=…` + `token_len=…`, not
+the value) so the credential never lands in `docker compose logs`.


### PR DESCRIPTION
Sibling of gethouston/cloud#27 (gateway pod-event fan-in) — together they fix the hosted-mode staleness (reply arrives, card stuck on 'running'; everything updating late).

## Write-through echo
After every adapter-initiated domain write succeeds (turn-settle activity PATCH, activity/routine/skill CRUD, config + files-first writes), the adapter emits the matching invalidation event locally through the same bus the server stream feeds — the UI flips instantly, no network round-trip. `toInvalidationEvent` is the single source of the event shape (server stream + echo, byte-parity tested); the path→event classifier moved to `@houston/domain` so the host FS watcher and the echo share one mapping. Idempotent when the real event also arrives (post cloud#27).

## Token banner redaction
`HOUSTON_HOST_LISTENING … token=<full bearer>` was in every pod's logs. The line is a genuine handshake only for the desktop sidecar (Tauri parses it; token random per boot). When the token is env-supplied or `HOUSTON_MANAGED_CLOUD=1`, the banner now prints `token_fp=`/`token_len=` — readiness-grep prefix intact, credential gone. Verified every consumer of the line in both repos before changing it.

## Verification
web 27 (4 new echo/parity) · host 408 (banner 2) · domain 60 · e2e 15/15 (double-render guard) · typecheck/biome/boundaries/parity clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)