### PR TITLE
release: v0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.26", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.26", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.26", path = "app/houston-tauri" }
-houston-events = { version = "0.4.26", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.26", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.26", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.26", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.26", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.26", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.26", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.26", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.26", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.26", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.26", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.26", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.26", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.26", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.26", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.5.0", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.5.0", path = "engine/houston-db" }
+houston-tauri = { version = "0.5.0", path = "app/houston-tauri" }
+houston-events = { version = "0.5.0", path = "engine/houston-events" }
+houston-scheduler = { version = "0.5.0", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.5.0", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.5.0", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.5.0", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.5.0", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.5.0", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.5.0", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.5.0", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.5.0", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.5.0", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.5.0", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.5.0", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.5.0", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.5.0", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.26",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 
 [lib]

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.26"
+version = "0.5.0"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.26",
+  "version": "0.5.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.26",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.26",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.26",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.26",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.26",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.26",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.26",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.26",
+  "version": "0.5.0",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Version bump via `scripts/version.sh 0.5.0` for the rolling `cloud-v0.5.0` test release (hosted desktop channel). Contains: resumable streams (#592), design tokens (#595), inventory (#596), @houston/sdk (#599), procedures (#600), hosted write-through echo + banner redaction (#601).

🤖 Generated with [Claude Code](https://claude.com/claude-code)