### PR TITLE
fix(release): bump cross-crate houston pins + regen Cargo.lock in version.sh

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "futures-util",
  "hex",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.26"
+version = "0.5.0"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -35,8 +35,8 @@ base64 = "0.22"
 urlencoding = "2"
 rand = "0.8"
 futures-util = "0.3"
-houston-engine-protocol = { version = "0.4.0", path = "../houston-engine-protocol" }
-houston-engine-core = { version = "0.4.0", path = "../houston-engine-core" }
+houston-engine-protocol = { version = "0.5.0", path = "../houston-engine-protocol" }
+houston-engine-core = { version = "0.5.0", path = "../houston-engine-core" }
 houston-composio = { workspace = true }
 houston-claude-installer = { workspace = true }
 houston-cli-bundle = { workspace = true }

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -53,11 +53,34 @@ for toml in engine/*/Cargo.toml app/houston-tauri/Cargo.toml app/src-tauri/Cargo
   perl -i -pe 'BEGIN{$d=0} if(!$d && /^version = "[^"]+"$/){s/^version = "[^"]+"$/version = "'"$VERSION"'"/; $d=1}' "$toml"
 done
 
+# --- Cross-crate houston-* dep pins in member Cargo.tomls --------------------
+# A member crate may pin a sibling like
+#   houston-engine-core = { version = "0.4.0", path = "../houston-engine-core" }
+# Scoped on `path = "` exactly like the root pass below, so third-party pins
+# stay untouched. Without this, a caret pin silently tolerates patch bumps and
+# then breaks the release on the first MINOR bump (bit us at 0.4.26 -> 0.5.0:
+# houston-engine-server pinned ^0.4.0 while the crates moved to 0.5.0).
+for toml in engine/*/Cargo.toml app/houston-tauri/Cargo.toml app/src-tauri/Cargo.toml; do
+  perl -i -pe 's/version = "[0-9]+\.[0-9]+\.[0-9]+"/version = "'"$VERSION"'"/ if /path = "/' "$toml"
+done
+
 # --- Root Cargo.toml workspace deps -----------------------------------------
 # Bump only the houston-* path deps: every workspace member line carries
 # `path = "…"`, while third-party pins like serde `version = "1"` do not, so
 # scoping on `path = "` leaves them untouched. perl (not BSD `sed -i ''`) so
 # the bump runs on Linux + Windows git-bash, not just macOS.
 perl -i -pe 's/version = "[0-9]+\.[0-9]+\.[0-9]+"/version = "'"$VERSION"'"/ if /path = "/' Cargo.toml
+
+# --- Cargo.lock ---------------------------------------------------------------
+# The lock pins workspace-member versions too; without a regen the release
+# build fails on the toml/lock mismatch (prior releases regenerated it by
+# hand — now it's part of the bump). `cargo update --workspace` refreshes only
+# the workspace members' entries.
+if command -v cargo >/dev/null 2>&1; then
+  cargo update --workspace --quiet
+  echo "Cargo.lock regenerated for workspace members"
+else
+  echo "WARNING: cargo not found — Cargo.lock NOT regenerated; the release build will fail until it is" >&2
+fi
 
 echo "All packages bumped to v$VERSION"


### PR DESCRIPTION
The `cloud-v0.5.0` release build failed on a Cargo resolution error: `houston-engine-server` pinned `houston-engine-{protocol,core}` at `^0.4.0` — tolerated every 0.4.x patch release, broke on the first minor bump — and `Cargo.lock` wasn't regenerated with the bump (previous releases did it manually).

`scripts/version.sh` now rewrites cross-crate houston pins in member Cargo.tomls (path-scoped, same rule as the root pass) and regenerates the lock's workspace entries (`cargo update --workspace`), warning loudly if cargo is absent. Applied here: all pins + lock at 0.5.0, `cargo metadata` resolution verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)