### PR TITLE
fix(host): cloud pods claimed connected apps weren't connected

### DIFF
--- a/packages/host/src/integrations/composio.test.ts
+++ b/packages/host/src/integrations/composio.test.ts
@@ -342,6 +342,36 @@ test("search scopes to the user's connected toolkits and maps tools", async () =
   );
 });
 
+test("a zero-hit scoped query degrades to listing the connected toolkits' actions", async () => {
+  // Composio's full-text match is naive: "read my latest 5 emails" scores zero
+  // against GMAIL_FETCH_EMAILS. The scoped retry (no query) must surface the
+  // toolkit's real actions instead of a dead "no results".
+  const { provider, calls } = harness((url) => {
+    if (url.pathname === "/api/v3/connected_accounts") {
+      return {
+        body: { items: [{ toolkit: { slug: "gmail" }, status: "ACTIVE" }] },
+      };
+    }
+    // First tools call carries the query → no hits; the fallback (no query)
+    // returns the toolkit listing.
+    if (url.searchParams.has("query")) return { body: { items: [] } };
+    return {
+      body: {
+        items: [
+          {
+            slug: "GMAIL_FETCH_EMAILS",
+            toolkit: { slug: "gmail" },
+            description: "Fetch emails",
+          },
+        ],
+      },
+    };
+  });
+  const found = await provider.search(USER, "read my latest 5 emails");
+  expect(found.map((t) => t.action)).toEqual(["GMAIL_FETCH_EMAILS"]);
+  expect(calls[2]?.path).toBe("/api/v3/tools?limit=50&toolkit_slug=gmail");
+});
+
 test("search falls back to the global catalog when nothing is connected", async () => {
   const { provider, calls } = harness((url) => {
     if (url.pathname === "/api/v3/connected_accounts")

--- a/packages/host/src/integrations/composio.ts
+++ b/packages/host/src/integrations/composio.ts
@@ -186,7 +186,17 @@ export class ComposioProvider implements IntegrationProvider {
         ...(slugs.length ? { toolkit_slug: slugs.join(",") } : {}),
       },
     });
-    return (body?.items ?? []).map(mapTool);
+    const matched = (body?.items ?? []).map(mapTool);
+    if (matched.length > 0 || slugs.length === 0) return matched;
+    // Composio's full-text match is naive AND-ish: an everyday phrasing like
+    // "read my latest 5 emails" scores ZERO against GMAIL_FETCH_EMAILS
+    // (verified live). Scoped to connected toolkits the catalog is small, so
+    // degrade to listing their actions instead of returning nothing — the
+    // agent picks the right slug from the list.
+    const all = await this.http.call<{ items?: RawTool[] }>("/api/v3/tools", {
+      query: { limit: "50", toolkit_slug: slugs.join(",") },
+    });
+    return (all?.items ?? []).map(mapTool);
   }
 
   async execute(

--- a/packages/host/src/local/host.test.ts
+++ b/packages/host/src/local/host.test.ts
@@ -1,4 +1,5 @@
 import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { createServer as createHttpServer } from "node:http";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -36,6 +37,8 @@ async function setup(opts?: {
   chatHistoryDbPath?: string;
   capabilities?: Capabilities;
   integrations?: { gatewayUrl?: string; composioApiKey?: string };
+  gatewayFronted?: boolean;
+  spawner?: RuntimeSpawner;
 }) {
   const workspacesRoot = mkdtempSync(join(tmpdir(), "houston-localhost-"));
   mkdirSync(join(workspacesRoot, "Work", "Sales"), { recursive: true });
@@ -49,10 +52,11 @@ async function setup(opts?: {
     port,
     token: "boot-secret",
     runtimeCommand: ["true"],
-    spawner: fakeSpawner,
+    spawner: opts?.spawner ?? fakeSpawner,
     chatHistoryDbPath: opts?.chatHistoryDbPath,
     capabilities: opts?.capabilities,
     integrations: opts?.integrations,
+    gatewayFronted: opts?.gatewayFronted,
   });
   await host.start();
   return { host, base: `http://127.0.0.1:${port}`, workspacesRoot };
@@ -211,6 +215,74 @@ test("a slash-bearing agent id round-trips through the URL (encode → decode)",
   } finally {
     host.stop();
   }
+});
+
+// ── acting-as relay (C2): the managed pod is gateway-fronted ─────────────────
+
+/**
+ * A fake runtime: a live HTTP server whose port the spawner hands to the
+ * launcher. /health satisfies the launcher's readiness probe; every other
+ * request records its headers so the test can see what the proxy relayed.
+ */
+function fakeRuntime() {
+  const seen: Record<string, string | string[] | undefined>[] = [];
+  const server = createHttpServer((req, res) => {
+    if (req.url === "/health") {
+      res.writeHead(200);
+      res.end("ok");
+      return;
+    }
+    seen.push({ ...req.headers });
+    res.writeHead(202, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true }));
+  });
+  const spawner: RuntimeSpawner = {
+    spawn: () => ({
+      port: (server.address() as { port: number }).port,
+      kill: () => {},
+    }),
+  };
+  return {
+    seen,
+    spawner,
+    listen: () =>
+      new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r())),
+    close: () => server.close(),
+  };
+}
+
+async function relayActingHeader(gatewayFronted: boolean | undefined) {
+  const rt = fakeRuntime();
+  await rt.listen();
+  const { host, base } = await setup({ spawner: rt.spawner, gatewayFronted });
+  try {
+    const r = await fetch(
+      `${base}/agents/${encodeURIComponent("Work/Sales")}/conversations/c1/messages`,
+      {
+        method: "POST",
+        headers: { ...auth, "x-houston-acting-as": "acting-v1.payload.sig" },
+        body: JSON.stringify({ text: "hi" }),
+      },
+    );
+    expect(r.status).toBe(202);
+    return rt.seen[0] ?? {};
+  } finally {
+    host.stop();
+    rt.close();
+  }
+}
+
+test("managed pod (gatewayFronted): the gateway-minted acting-as header reaches the runtime", async () => {
+  // The bug this locks down: the pod profile dropping the header meant the
+  // runtime had no acting identity, so every integration call in a cloud chat
+  // died signin-required and agents claimed connected apps weren't connected.
+  const headers = await relayActingHeader(true);
+  expect(headers["x-houston-acting-as"]).toBe("acting-v1.payload.sig");
+});
+
+test("desktop (default): a client-supplied acting-as header is dropped", async () => {
+  const headers = await relayActingHeader(undefined);
+  expect(headers["x-houston-acting-as"]).toBeUndefined();
 });
 
 test("preferences persist via the vfs under the workspace", async () => {

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -86,6 +86,15 @@ export interface LocalHostOptions {
     composioApiKey?: string;
     podToken?: string;
   };
+  /**
+   * True only when a trusted gateway fronts EVERY request to this host (the
+   * managed cloud pod: the gateway enforces the pod token and mints/strips
+   * `x-houston-acting-as` itself). Relays that header to the runtime so a
+   * turn's integration calls authenticate as the driving user (C2). On the
+   * desktop clients reach this host directly, so an inbound acting header is
+   * untrusted client input — leave this false (the default) and it is dropped.
+   */
+  gatewayFronted?: boolean;
 }
 
 export interface LocalHost {
@@ -152,9 +161,11 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     credentials,
     // Desktop: clients talk to this host DIRECTLY (no gateway in front to mint
     // or strip identity headers), so an inbound x-houston-acting-as is
-    // untrusted client input — never relay it to the runtime. Identity here is
-    // always the single local owner.
-    forwardActingHeader: false,
+    // untrusted client input — never relay it to the runtime; identity is the
+    // single local owner. Managed pods (gatewayFronted) ARE gateway-fronted:
+    // the gateway minted the header, so relaying it is what lets the runtime's
+    // integration calls act as the driving user (C2).
+    forwardActingHeader: opts.gatewayFronted ?? false,
   });
 
   // Integrations (platform model): the desktop holds NO provider key — the

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -81,6 +81,10 @@ const host = buildLocalHost({
     process.env.HOUSTON_MANAGED_CLOUD === "1"
       ? MANAGED_CLOUD_CAPABILITIES
       : LOCAL_CAPABILITIES,
+  // Managed pods sit behind the gateway (it enforces the pod token and mints
+  // x-houston-acting-as); relay that header to the runtime so integration
+  // calls act as the driving user. Desktop/self-host stay direct → false.
+  gatewayFronted: process.env.HOUSTON_MANAGED_CLOUD === "1",
   // Platform-mode integrations: desktops get HOUSTON_INTEGRATIONS_URL (the
   // cloud gateway holding Houston's Composio key); self-host + the managed pod
   // set their own COMPOSIO_API_KEY and go direct. Neither → integrations off.


### PR DESCRIPTION
## Problem

In cloud, the agent refuses to use integrations ("Gmail isn't connected") even when the Integrations UI shows Gmail connected.

## Diagnosis (confirmed live in prod)

The agent's `integration_search` tool call dies inside the agent pod: `POST /sandbox/integrations/search` returns `503 {"error":"integrations not configured"}`, and no search request ever reaches the gateway. Two wiring gaps in the managed-pod profile:

1. **Acting identity was dropped.** `buildLocalHost` hardcoded `forwardActingHeader: false`. Correct on desktop (clients hit the host directly, an inbound header is untrusted), wrong in the managed pod where the gateway fronts every request and mints `x-houston-acting-as`. Without it the runtime has no acting identity, so integration calls fall through to the (absent) frontend session token and die signin-required. New `gatewayFronted` option on `buildLocalHost`, set from `HOUSTON_MANAGED_CLOUD=1`.

2. **Composio full-text search is naive AND-ish.** "read my latest 5 emails" scores ZERO against `GMAIL_FETCH_EMAILS` (verified against the live API). A zero-hit scoped query now degrades to listing the scoped toolkits' actions (limit 50) so the agent can pick the right slug instead of getting a dead "no results".

Companion PR in the cloud repo injects `HOUSTON_INTEGRATIONS_URL` (the gateway's public URL) into every agent pod — without it the pod builds no integration provider at all, which is the 503 above.

## Tests

- `host.test.ts`: gatewayFronted relays the acting-as header to the runtime; default (desktop) still drops it. Verified red against the old code.
- `composio.test.ts`: zero-hit scoped query falls back to the toolkit listing; zero-hit unscoped query stays empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)