### PR TITLE
fix(credentials): one OpenCode key connects both Zen and Go gateways

### DIFF
--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -270,6 +270,15 @@ Notes:
   directly) — the model picked selects the gateway; opencode.ai enforces
   Go-subscription vs Zen-credit entitlement per request (surfaced as a
   provider-error card), so Houston never has to detect the plan from the key.
+  The **cloud/web path has no Tauri adapter**, so the client-side fan-out above
+  doesn't run there — the same sharing is enforced BACKEND-side instead:
+  `credentialSiblings` (`@houston/domain`, byte-mirrored in the runtime at
+  `packages/runtime/src/auth/credential-siblings.ts`) makes the host serve either
+  gateway from the one stored opencode key (`resolveSharedCredential`) and the
+  runtime write/clear both gateways' `auth.json` entries together
+  (`applyServedCredential`, `setApiKey`, `logout`). So a single saved key connects
+  both gateways with or without a client fan-out; without it a Go turn hit
+  `opencode-go`'s empty credential and surfaced a spurious "sign in to OpenCode Go".
 - _[NEW ENGINE only]_ The TS engine also adds **GitHub Copilot**
   (`github-copilot`) as a **subscription OAuth** provider — pi-ai ships it
   built-in (no adapter, no CLI), so it's registry entries only across the same

--- a/packages/domain/src/credential-siblings.test.ts
+++ b/packages/domain/src/credential-siblings.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+import { credentialSiblings } from "./credential-siblings";
+
+test("opencode and opencode-go share a credential, both directions", () => {
+  // The two OpenCode gateways authenticate with the same opencode.ai key.
+  expect(credentialSiblings("opencode")).toEqual(["opencode-go"]);
+  expect(credentialSiblings("opencode-go")).toEqual(["opencode"]);
+});
+
+test("a provider is never listed as its own sibling", () => {
+  expect(credentialSiblings("opencode")).not.toContain("opencode");
+  expect(credentialSiblings("opencode-go")).not.toContain("opencode-go");
+});
+
+test("providers with no shared credential have no siblings", () => {
+  for (const id of [
+    "anthropic",
+    "openai-codex",
+    "github-copilot",
+    "openrouter",
+    "deepseek",
+    "google",
+    "amazon-bedrock",
+    "minimax",
+    "openai-compatible",
+    "totally-unknown",
+  ]) {
+    expect(credentialSiblings(id)).toEqual([]);
+  }
+});

--- a/packages/domain/src/credential-siblings.ts
+++ b/packages/domain/src/credential-siblings.ts
@@ -1,0 +1,24 @@
+/**
+ * Providers that share ONE upstream credential.
+ *
+ * OpenCode Zen (`opencode`) and OpenCode Go (`opencode-go`) are two distinct pi
+ * gateways — `opencode.ai/zen/v1` vs `opencode.ai/zen/go/v1`, with disjoint
+ * model catalogs — but they authenticate with the SAME opencode.ai key: pi reads
+ * `OPENCODE_API_KEY` for both. So a credential connected for either gateway
+ * connects both; there is NO separate "OpenCode Go" sign-in. The frontend
+ * already models this as one account with `gatewayIds: ["opencode","opencode-go"]`
+ * (app/src/lib/providers.ts) — this is the backend half of that contract.
+ *
+ * The runtime keeps a byte-identical copy at
+ * `packages/runtime/src/auth/credential-siblings.ts` (it can't import
+ * `@houston/domain`, the same reason it mirrors `ProviderId`). Keep them in sync.
+ */
+const CREDENTIAL_SIBLING_GROUPS: readonly (readonly string[])[] = [
+  ["opencode", "opencode-go"],
+];
+
+/** The other provider ids that share `id`'s stored credential (excludes `id`). */
+export function credentialSiblings(id: string): string[] {
+  const group = CREDENTIAL_SIBLING_GROUPS.find((g) => g.includes(id));
+  return group ? group.filter((p) => p !== id) : [];
+}

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./activities";
 export * from "./config";
+export * from "./credential-siblings";
 export * from "./layout";
 export * from "./portable";
 export * from "./preferences";

--- a/packages/host/src/credentials/resolve.test.ts
+++ b/packages/host/src/credentials/resolve.test.ts
@@ -1,0 +1,56 @@
+import { expect, test } from "vitest";
+import { resolveSharedCredential } from "./resolve";
+import { MemoryCredentialStore } from "./store";
+
+test("returns the provider's own credential when it has one", async () => {
+  const s = new MemoryCredentialStore();
+  await s.put({
+    workspaceId: "w1",
+    provider: "opencode-go",
+    accessToken: "sk-go",
+    refreshToken: "",
+    expiresAt: 0,
+    kind: "api_key",
+  });
+  const c = await resolveSharedCredential(s, "w1", "opencode-go");
+  expect(c).toMatchObject({ provider: "opencode-go", accessToken: "sk-go" });
+});
+
+test("falls back to a sibling's credential, relabeled to the requested provider", async () => {
+  const s = new MemoryCredentialStore();
+  // The user connected OpenCode Zen only; Go shares the same opencode.ai key.
+  await s.put({
+    workspaceId: "w1",
+    provider: "opencode",
+    accessToken: "sk-shared",
+    refreshToken: "",
+    expiresAt: 0,
+    kind: "api_key",
+  });
+  const c = await resolveSharedCredential(s, "w1", "opencode-go");
+  // The shared key resolves, RELABELED to the gateway the turn runs on.
+  expect(c).toMatchObject({
+    provider: "opencode-go",
+    accessToken: "sk-shared",
+    kind: "api_key",
+  });
+});
+
+test("null when neither the provider nor a sibling is connected", async () => {
+  const s = new MemoryCredentialStore();
+  expect(await resolveSharedCredential(s, "w1", "opencode-go")).toBeNull();
+});
+
+test("does not cross-wire a provider that has no siblings", async () => {
+  const s = new MemoryCredentialStore();
+  await s.put({
+    workspaceId: "w1",
+    provider: "opencode",
+    accessToken: "sk",
+    refreshToken: "",
+    expiresAt: 0,
+    kind: "api_key",
+  });
+  // openrouter shares nothing with opencode — no accidental fallback.
+  expect(await resolveSharedCredential(s, "w1", "openrouter")).toBeNull();
+});

--- a/packages/host/src/credentials/resolve.ts
+++ b/packages/host/src/credentials/resolve.ts
@@ -1,0 +1,29 @@
+import { credentialSiblings } from "@houston/domain";
+import type { CredentialStore, WorkspaceCredential } from "../ports";
+
+/**
+ * Fetch a workspace's stored credential for `provider`, falling back to a
+ * credential-sibling's when the provider has none of its own.
+ *
+ * OpenCode Zen (`opencode`) and OpenCode Go (`opencode-go`) share one
+ * opencode.ai key, so a turn on the gateway the user did NOT explicitly connect
+ * still resolves the shared key. The returned credential is RELABELED to the
+ * requested `provider` so every downstream consumer (the sandbox serve response,
+ * the per-turn POST body) writes the runtime's auth.json entry under the id the
+ * turn actually runs on — not the sibling it was borrowed from.
+ *
+ * Returns null only when neither the provider nor any sibling is connected.
+ */
+export async function resolveSharedCredential(
+  store: Pick<CredentialStore, "get">,
+  workspaceId: string,
+  provider: string,
+): Promise<WorkspaceCredential | null> {
+  const direct = await store.get(workspaceId, provider);
+  if (direct) return direct;
+  for (const sibling of credentialSiblings(provider)) {
+    const shared = await store.get(workspaceId, sibling);
+    if (shared) return { ...shared, provider };
+  }
+  return null;
+}

--- a/packages/host/src/routes/credential.test.ts
+++ b/packages/host/src/routes/credential.test.ts
@@ -109,3 +109,25 @@ test("404 when the workspace has not connected the provider", async () => {
   expect(await call(credentials, "anthropic", r)).toBe(true);
   expect(r.out.status).toBe(404);
 });
+
+test("serves an OpenCode Go turn the shared opencode.ai key (sibling fallback)", async () => {
+  const credentials = new MemoryCredentialStore();
+  // The user connected OpenCode Zen (`opencode`) only; Go shares the same key,
+  // so a Go turn must still be served — relabeled to the gateway it runs on.
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "opencode",
+    accessToken: "sk-shared",
+    refreshToken: "",
+    expiresAt: 0,
+    kind: "api_key",
+  });
+  const r = mockRes();
+  expect(await call(credentials, "opencode-go", r)).toBe(true);
+  expect(r.out.status).toBe(200);
+  expect(r.out.body).toMatchObject({
+    provider: "opencode-go",
+    access: "sk-shared",
+    kind: "api_key",
+  });
+});

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { isExpiring, refreshCredential } from "../credentials/refresh";
+import { resolveSharedCredential } from "../credentials/resolve";
 import {
   type CredentialStore,
   type CredentialVault,
@@ -32,7 +33,14 @@ export async function handleSandboxCredential(
     return true;
   }
   const provider = url.searchParams.get("provider") || "openai-codex";
-  let cred = await deps.credentials.get(claim.workspaceId, provider);
+  // OpenCode Zen + Go share one opencode.ai key: when the requested gateway has
+  // no credential of its own, fall back to its sibling's (relabeled to the
+  // requested provider) so a turn on either gateway resolves the shared key.
+  let cred = await resolveSharedCredential(
+    deps.credentials,
+    claim.workspaceId,
+    provider,
+  );
   if (!cred) {
     json(res, 404, { error: "workspace not connected" });
     return true;

--- a/packages/host/src/turn/start-turn.ts
+++ b/packages/host/src/turn/start-turn.ts
@@ -1,6 +1,7 @@
 import type { ServerResponse } from "node:http";
 import { readEventStream } from "@houston/runtime-client";
 import { isExpiring } from "../credentials/refresh";
+import { resolveSharedCredential } from "../credentials/resolve";
 import type { Agent, Workspace } from "../domain/types";
 import {
   isApiKeyCredential,
@@ -28,7 +29,7 @@ export async function freshCredential(
   wsId: string,
   provider: string,
 ): Promise<WorkspaceCredential | null> {
-  let cred = await deps.credentials.get(wsId, provider);
+  let cred = await resolveSharedCredential(deps.credentials, wsId, provider);
   if (!cred) return null;
   if (isExpiring(cred)) {
     cred = await deps.refresh(cred);

--- a/packages/runtime/src/auth/auth-file.test.ts
+++ b/packages/runtime/src/auth/auth-file.test.ts
@@ -53,3 +53,57 @@ test("applyServedCredential omits enterpriseUrl for individual Copilot", () => {
     expect(cred.enterpriseUrl).toBeUndefined();
   }
 });
+
+/**
+ * OpenCode Zen (`opencode`) and OpenCode Go (`opencode-go`) authenticate with the
+ * same opencode.ai key. A credential served for either gateway must materialize
+ * an auth.json entry for BOTH, so the gateway it wasn't served under still reads
+ * as connected (pi's `has()`) and its turns authenticate (pi's `getApiKey()`) —
+ * otherwise it surfaces a spurious "sign in again" card.
+ */
+test("applyServedCredential mirrors an OpenCode key onto its sibling gateway", () => {
+  const path = scratch();
+  applyServedCredential(path, {
+    provider: "opencode",
+    access: "sk-zen",
+    expires: 0,
+    accountId: null,
+    kind: "api_key",
+  });
+  const auth = readAuthFile(path);
+  rmSync(path, { force: true });
+  for (const id of ["opencode", "opencode-go"]) {
+    const cred = auth[id];
+    expect(cred?.type).toBe("api_key");
+    if (cred?.type === "api_key") expect(cred.key).toBe("sk-zen");
+  }
+});
+
+test("applyServedCredential mirrors symmetrically from opencode-go to opencode", () => {
+  const path = scratch();
+  applyServedCredential(path, {
+    provider: "opencode-go",
+    access: "sk-go",
+    expires: 0,
+    accountId: null,
+    kind: "api_key",
+  });
+  const opencode = readAuthFile(path).opencode;
+  rmSync(path, { force: true });
+  expect(opencode?.type).toBe("api_key");
+  if (opencode?.type === "api_key") expect(opencode.key).toBe("sk-go");
+});
+
+test("applyServedCredential does not mirror a provider with no shared credential", () => {
+  const path = scratch();
+  applyServedCredential(path, {
+    provider: "openrouter",
+    access: "sk-or",
+    expires: 0,
+    accountId: null,
+    kind: "api_key",
+  });
+  const auth = readAuthFile(path);
+  rmSync(path, { force: true });
+  expect(Object.keys(auth)).toEqual(["openrouter"]);
+});

--- a/packages/runtime/src/auth/auth-file.ts
+++ b/packages/runtime/src/auth/auth-file.ts
@@ -1,4 +1,5 @@
 import { existsSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { credentialSiblings } from "./credential-siblings";
 
 /**
  * Pure auth.json file logic (no config import — tests drive it with explicit
@@ -85,6 +86,11 @@ export function applyServedCredential(path: string, c: ServedCredential): void {
         };
   const merged = readAuthFile(path);
   merged[c.provider] = entry;
+  // OpenCode Zen + Go share one opencode.ai key (pi reads OPENCODE_API_KEY for
+  // both gateways). Mirror the served entry onto its sibling(s) so the gateway
+  // this credential wasn't served under still reads as connected AND its turns
+  // authenticate — otherwise it surfaces a spurious "sign in again" card.
+  for (const sibling of credentialSiblings(c.provider)) merged[sibling] = entry;
   writeAuthFile(path, merged);
 }
 

--- a/packages/runtime/src/auth/credential-siblings.test.ts
+++ b/packages/runtime/src/auth/credential-siblings.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+import { credentialSiblings } from "./credential-siblings";
+
+test("opencode and opencode-go share a credential, both directions", () => {
+  // The two OpenCode gateways authenticate with the same opencode.ai key, so
+  // connecting either must connect both.
+  expect(credentialSiblings("opencode")).toEqual(["opencode-go"]);
+  expect(credentialSiblings("opencode-go")).toEqual(["opencode"]);
+});
+
+test("a provider is never listed as its own sibling", () => {
+  expect(credentialSiblings("opencode")).not.toContain("opencode");
+  expect(credentialSiblings("opencode-go")).not.toContain("opencode-go");
+});
+
+test("providers with no shared credential have no siblings", () => {
+  for (const id of [
+    "anthropic",
+    "openai-codex",
+    "github-copilot",
+    "openrouter",
+    "deepseek",
+    "google",
+    "amazon-bedrock",
+    "minimax",
+    "openai-compatible",
+    "totally-unknown",
+  ]) {
+    expect(credentialSiblings(id)).toEqual([]);
+  }
+});

--- a/packages/runtime/src/auth/credential-siblings.ts
+++ b/packages/runtime/src/auth/credential-siblings.ts
@@ -1,0 +1,22 @@
+/**
+ * Providers that share ONE upstream credential.
+ *
+ * OpenCode Zen (`opencode`) and OpenCode Go (`opencode-go`) are two distinct pi
+ * gateways — `opencode.ai/zen/v1` vs `opencode.ai/zen/go/v1`, with disjoint
+ * model catalogs — but they authenticate with the SAME opencode.ai key: pi reads
+ * `OPENCODE_API_KEY` for both. So a credential connected for either gateway
+ * connects both; there is NO separate "OpenCode Go" sign-in.
+ *
+ * This is a byte-identical mirror of `@houston/domain`'s `credentialSiblings`
+ * (the runtime can't import `@houston/domain`, the same reason `@houston/domain`
+ * mirrors this package's `ProviderId`). Keep the two in sync.
+ */
+const CREDENTIAL_SIBLING_GROUPS: readonly (readonly string[])[] = [
+  ["opencode", "opencode-go"],
+];
+
+/** The other provider ids that share `id`'s stored credential (excludes `id`). */
+export function credentialSiblings(id: string): string[] {
+  const group = CREDENTIAL_SIBLING_GROUPS.find((g) => g.includes(id));
+  return group ? group.filter((p) => p !== id) : [];
+}

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -18,6 +18,7 @@ import {
   providerAuthMethod,
 } from "../ai/providers";
 import { config } from "../config";
+import { credentialSiblings } from "./credential-siblings";
 import { authStorage, providerConnected } from "./storage";
 
 /**
@@ -210,6 +211,12 @@ export function setApiKey(providerId: string, key: string): void {
   const trimmed = key.trim();
   if (!trimmed) throw new Error("missing API key");
   authStorage.set(providerId, { type: "api_key", key: trimmed });
+  // OpenCode Zen + Go authenticate with the same opencode.ai key, so connecting
+  // one connects both — mirror the key onto its sibling gateway(s). Without this
+  // the gateway the user didn't paste under reads as a spurious "sign in again".
+  for (const sibling of credentialSiblings(providerId)) {
+    authStorage.set(sibling, { type: "api_key", key: trimmed });
+  }
   active.delete(providerId as ProviderId);
 }
 
@@ -247,6 +254,12 @@ export function logout(providerId: string): void {
   if (!known(providerId)) throw new Error(`unknown provider: ${providerId}`);
   authStorage.logout(providerId);
   active.delete(providerId);
+  // Siblings share this stored credential (OpenCode Zen ↔ Go), so disconnect
+  // them together — else the sibling lingers "connected" with the same key.
+  for (const sibling of credentialSiblings(providerId)) {
+    authStorage.logout(sibling);
+    active.delete(sibling as ProviderId);
+  }
   // Disconnecting the local provider also forgets its endpoint, else the next
   // turn would re-resolve a base URL with no (real) key behind it.
   if (providerId === OPENAI_COMPATIBLE) clearCustomEndpointConfig();


### PR DESCRIPTION
## What & why

Connecting **OpenCode** with an API key in the cloud left **OpenCode Go** unusable: sending a first message on a Go model showed a **"Sign in to OpenCode Go again"** card even though the key was saved.

Root cause (from prod logs + the code): `opencode` (Zen) and `opencode-go` (Go) are two pi gateways — `opencode.ai/zen/v1` vs `opencode.ai/zen/go/v1` — but they authenticate with the **same opencode.ai key** (pi reads `OPENCODE_API_KEY` for both). Houston's cloud/web path treated them as independent credentials, so the saved key only credentialed `opencode`; a Go turn hit `opencode-go`'s empty credential and surfaced the reconnect card.

The desktop Tauri adapter already fans the key across both gateway ids (HOU-577, `synthetic.ts`/`client.ts`), but **the cloud/web path has no such adapter** — so nothing shared the key there. This PR enforces the sharing **backend-side**, so one saved key connects both gateways regardless of client.

## Change

- **`@houston/domain` `credentialSiblings`** — the single source of the Zen↔Go pairing (byte-mirrored in the runtime at `packages/runtime/src/auth/credential-siblings.ts`, which can't import `@houston/domain`, the same reason domain mirrors `ProviderId`).
- **host `resolveSharedCredential`** — the sandbox serve endpoint (`/sandbox/credential`) and the per-turn credential fetch (`freshCredential`) fall back to a sibling's stored credential, **relabeled** to the requested gateway.
- **runtime** — `applyServedCredential` / `setApiKey` / `logout` now write and clear **both** gateways' `auth.json` entries together, so pi's `has()` (connected status) and `getApiKey()` (the turn) both resolve the shared key.

Composes with the existing desktop fan-out (idempotent); makes it unnecessary but harmless.

## Tests

New/extended, all green:
- `credentialSiblings` mapping — domain + runtime
- `applyServedCredential` mirrors Zen↔Go, and does **not** mirror a provider with no sibling
- `resolveSharedCredential` — own-credential, sibling fallback + relabel, null-when-neither, no cross-wiring
- serve endpoint serves a Go turn the shared key via sibling fallback

`domain` + `runtime` + `host` suites pass (706 tests); `typecheck` (all three) and `pnpm check:boundaries` clean; Biome clean.

## Verification note

Logic is covered by unit/integration tests. End-to-end confirmation (paste an OpenCode key → run an OpenCode Go model like `kimi-k2.6` and get a normal reply, no reconnect card) needs this built into the cloud engine-pod image + rolled out — do that after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
