### PR TITLE
feat(sdk): native bridge runtime + mobile domain modules

### DIFF
--- a/mobile/PARITY.md
+++ b/mobile/PARITY.md
@@ -1,0 +1,135 @@
+# iOS Parity Spec — Mission Control & Missions (mirrors desktop exactly)
+
+> Extracted from the desktop app 2026-07-03 (all claims cited file:line at extraction time).
+> HARD REQUIREMENT (founder): mobile uses exactly the same statuses, names, and affordances
+> as desktop. This file is the enforceable contract for the iOS surfaces; update it via the
+> normal inventory/procedures flow (knowledge-base/client-architecture.md) when desktop changes.
+> Locale strings come from app/src/locales/en/*.json; es/pt mirror the same keys.
+
+## 1. Status vocabulary
+
+### Canonical wire statuses (the activity `status` field)
+`packages/domain/src/activities.ts:11-17`, `ui/agent-schemas/src/activity.schema.json:15`:
+`running · needs_you · done · error · archived`
+Unknown statuses are preserved and rendered neutrally. New activities are created `status:"running"`.
+
+### Live-turn status unions (SDK — `packages/sdk/src/modules/turns/feed-output.ts`)
+| Type | Values | Meaning |
+|---|---|---|
+| `SessionStatusValue` | `starting` \| `running` \| `completed` \| `error` | Drives spinner (`running`), settle (`completed`), failure (`error`). `starting` is legacy — TS machinery never emits it. |
+| `BoardStatus` | `running` \| `needs_you` \| `error` | Persisted board-card status once a turn settles. |
+
+### THE critical needs_you-vs-error rule
+`packages/sdk/src/modules/turns/vm-output.ts:36-47`: a user **Stop** (and a logged-out provider)
+settles `sessionStatus === "error"` **but** `boardStatus === "needs_you"`. **Read the pair, never
+`sessionStatus` alone** — keying off sessionStatus renders a normal Stop as red.
+`boardStatus:"needs_you"` = handled / your attention; `boardStatus:"error"` = genuine failure.
+`ConversationVM` exposes `{ feed, running, sessionStatus, boardStatus }`.
+
+### Board columns (kanban) — `app/src/components/mission-board-columns.ts`
+Left-to-right order and status→column mapping (single source of truth):
+| Order | Column id | Label (`dashboard.json:columns`) | Statuses mapped | Extras |
+|---|---|---|---|---|
+| 1 | `running` | **Running** | `running` | has `+` New-mission add button |
+| 2 | `needs_you` | **Needs you** | `needs_you`, `error` | — |
+| 3 | `done` | **Done** | `done`, `cancelled` | — |
+| — | (none) | — | `archived` → never on the active board | |
+
+`cancelled` is a tolerant alias folded into Done, not a canonical activity status.
+**There is no backlog/todo column. Three columns only.**
+
+### Card color/glow semantics — `ui/board/src/kanban-card.tsx`
+- `running` → `card-running-glow` animated conic border + blue shadow `rgba(59,130,246,0.12)`.
+- `error` → `border-destructive/60`.
+- `needs_you` → renders the Approve check button ("Move to done").
+- selected/highlighted → `bg-accent`.
+
+## 2. Archive semantics
+- Archiving = the activity `status` field set to `"archived"` (`ARCHIVED_STATUS`, `app/src/lib/mission-selection.ts:9`). No separate flag.
+- Desktop affordance: multi-select → bulk bar "Archive" (`board.json:bulk.archive`); confirm dialog
+  `bulk.confirmArchive`: title "Archive missions?", body "Archive {{count}} mission? You can reopen
+  it from the Archived tab." No per-card archive icon on desktop (per-card icons: Approve / Rename / Delete).
+  iOS uses explicit per-item actions instead of multi-select (see §7).
+- Drag-and-drop does NOT archive; drop targets are only `done`/`needs_you`.
+- Archived is visible in the **Archived** view (toolbar toggle, label "Archived",
+  `dashboard.json:archived.button`) — cross-agent list layout, and per-agent tab.
+- **Reversible by replying**: sending in an archived chat re-activates it (engine flips
+  `archived → running` on session start). Empty state: "Archived missions appear here.
+  Reply to one to bring it back." (`board.json:archived.emptyDescription`).
+- Active lists exclude `archived`; the archived list includes only `archived`. Search runs identically over both.
+
+## 3. Mission Control layout & card anatomy
+`KanbanItem` shape: `ui/board/src/types.ts`. Card build: `app/src/components/use-mission-control.ts:105-130`.
+| Card field | Source | Notes |
+|---|---|---|
+| title | activity title | AI-generated async after create; fallback = truncated first message. Rename via pencil. `line-clamp-2`. |
+| description | `messagePreviewText(description)` | User's first message; `<!--houston:...-->` markers decoded. `line-clamp-2`. |
+| group (above title) | `agent_name` | muted |
+| icon | `AgentCardAvatar{color}` | colored Houston helmet |
+| tags | `missionCardTags(...)` | e.g. "Routine" (`board.json:tags.routine`), agent-mode pill |
+| updatedAt | `updated_at` | |
+| metadata | `agentPath, sessionKey, agent?, routineId?` | routing/session addressing |
+
+- Agent filter: default "All agents" (`dashboard.json:filter.allAgents`); filters `metadata.agentPath`.
+- Header: "Mission Control" (`dashboard.json:title`); archived view header "Archived".
+- **Search** (`app/src/components/mission-search.ts` + `use-mission-search.ts`): matches title,
+  then description, then lazily-loaded chat history content (per feed item: `user_message` text,
+  `tool_call` name+input, `tool_result` content, `file_changes` paths, `final_result` result).
+  History loaded only for missions not already matching, with `observe:false`.
+  Placeholder "Search missions"; matches show a highlighted snippet under the title.
+- Empty states: board "No conversations yet" / "Start a new conversation to delegate work to an
+  agent." + "New mission" CTA; search-empty "No matching missions" / "Try a different search or
+  clear the current one."; searching "Searching mission text" / "Looking through older messages
+  now."; history-load error toast "Couldn't search every mission" / "Some older mission text could
+  not be loaded."; no-agents "No agents yet" / "Build your AI team and ship the impossible."
+
+## 4. Agent presentation
+- Avatar = `HoustonAvatar` (`ui/core/src/components/houston-avatar.tsx`): colored circle
+  (`color-mix secondary 82% + agentColor 18%`) with the Houston helmet SVG glyph (~65% size).
+  **No initials, no photos** — always the helmet tinted by `agent.color` (fallback `#9b9b9b`).
+  `running` → comet-glow halo wrap.
+- Per-agent status aggregation (`app/src/components/shell/agent-activity-summary-model.ts`):
+  counts of that agent's conversations by status → `{ needsYouCount, runningCount }`.
+  Rendering: runningCount>0 → avatar running-glow; needsYouCount>0 → outline `NeedsYouChip`
+  badge with the count (caps "99+"). Labels (`shell.json`): "{{count}} issue running" /
+  "{{count}} issue needs you" (+ plurals).
+- Busy rule: a session is busy if activity `status==="running"` OR live sessionStatus active OR
+  optimistically started — externally-started sessions (routines, other surfaces) count as busy.
+
+## 5. Mission chat feed catalog
+`FeedItem` union: `ui/chat/src/types.ts`. Fold: `ui/chat/src/feed-to-messages.ts`.
+| feed_type | Renders as | Copy / notes |
+|---|---|---|
+| `assistant_text` / `_streaming` | assistant bubble | streaming carries cumulative full text → updates ONE bubble in place; final flushes the same bubble |
+| `thinking` / `_streaming` | reasoning block | "Thinking..." while active; "Thought for {{count}} seconds" / "Thought for a few seconds" (`chat.json:reasoning`) |
+| `user_message` | user bubble | author label only when ≥2 distinct authors |
+| `tool_call` | tool chip (name + input) | deduped (placeholder null-input replaced) |
+| `tool_result` | attached to its tool chip | `{content, is_error}` |
+| `tool_runtime_error` | system message | "A local tool failed to start." + typed detail; retry "Try again." |
+| `provider_error` | typed ProviderErrorCard | 12 kinds (`ui/chat/src/types.ts:105-163`); `kind:"cancelled"` is DROPPED (no UI); duplicates collapsed per turn |
+| `system_message` | system line | suppressed when a typed card already covered the same `Session error:` |
+| `context_compacted` | subtle divider | "Earlier conversation summarized so the chat can keep going" |
+| `provider_switched` | subtle divider | "Continued with {{provider}}" / "Continued with {{provider}}, summarized to fit" |
+| `file_changes` | file-change list on the assistant msg | "Updates made", "1 new file"/"{{count}} new files", "1 file updated"/"{{count}} files updated" |
+| `final_result` | flush → turn summary "Mission log" | `{result, cost_usd, duration_ms, usage}` |
+
+Status lines (`chat.json:process`): active = "Mission in progress..."; with action =
+"Mission in progress: {{action}}"; settled = "Mission log". Shimmer while active.
+**There is NO "Stopped by user" string** — a Stop moves the card to Needs you silently
+(the `cancelled` provider_error is dropped).
+
+## 6. New-mission flow (wire) — `app/src/lib/create-mission.ts`
+1. Create activity (`status:"running"`), id → session key `activity-{id}`.
+2. Send the first message — creation IS activity+first send; no separate create-conversation call.
+3. Title: `fallbackMissionTitle(text)` immediately (trim, ~40-char word-boundary truncate,
+   "New mission" if empty); async AI title refresh afterwards unless an explicit title was given.
+4. On send failure → rollback deletes the activity (no fake running card).
+- Agent picker copy: "Which agent should run this?" / "Pick an agent to open a fresh conversation."
+
+## 7. Desktop-only — iOS must NOT replicate
+- Drag-and-drop between columns → iOS uses explicit move/approve actions.
+- Multi-select + floating bulk bar + "Select all in column" + hover-reveal checkboxes.
+- Keyboard navigation.
+- Run-in-terminal / worktree affordances.
+- Model selector, reasoning-effort picker, provider-switch dialogs (desktop chrome).
+- Bulk move targets deliberately exclude `running` (you enter running by sending), `error`, `archived`.

--- a/packages/sdk/BRIDGE.md
+++ b/packages/sdk/BRIDGE.md
@@ -8,9 +8,10 @@ versioning discipline. Everything here is plain JSON; nothing crosses the bridge
 that is not JSON-serializable.
 
 This is the contract. The thin JS-side **dispatcher** that implements it (wraps
-`HoustonSdk.dispatch` / `subscribe` / `on` and marshals strings over the pipe)
-is on the roadmap — this document is the interface it will satisfy, and the
-native side may be written against it before that code lands.
+`HoustonSdk.dispatch` / `subscribe` / `on`, marshals strings over the pipe, and
+backs `fetch`/`storage` natively) has **shipped** in `packages/sdk/src/bridge/`,
+along with the embeddable IIFE bundle (`build:bridge`). §2.1, §9, and §10 are the
+normative additions that landed with it; the base envelopes are unchanged.
 
 ---
 
@@ -47,15 +48,22 @@ Every message is a JSON object with a `kind` discriminator. Types below reuse
 the kernel contract verbatim:
 
 ```ts
-// packages/sdk/src/bridge.ts (roadmap) — the wire union this doc specifies
+// packages/sdk/src/bridge/wire.ts — the wire union this doc specifies (SHIPPED)
 import type { CommandEnvelope, CommandResult } from "../commands";
 import type { SdkEvent } from "../store";
 
 // host → SDK
 export type BridgeInbound =
+  | { kind: "configure"; baseUrl: string; native?: NativePorts } // §2.1
   | { kind: "command"; envelope: CommandEnvelope }
   | { kind: "subscribe"; sub: string; scope: string }
-  | { kind: "unsubscribe"; sub: string };
+  | { kind: "unsubscribe"; sub: string }
+  // native port replies (correlated to an SDK-minted `id`) — §9
+  | { kind: "fetch/response"; id: string; status: number; ok: boolean }
+  | { kind: "fetch/chunk"; id: string; bytesBase64: string }
+  | { kind: "fetch/done"; id: string }
+  | { kind: "fetch/error"; id: string; message: string }
+  | { kind: "storage/result"; id: string; value?: string | null };
 
 // SDK → host
 export type BridgeOutbound =
@@ -64,8 +72,60 @@ export type BridgeOutbound =
   | { kind: "subscribed"; sub: string; scope: string; snapshot?: unknown }
   | { kind: "snapshot"; sub: string; scope: string; snapshot: unknown }
   | { kind: "event"; event: SdkEvent }
-  | { kind: "fatal"; reason: string; message: string };
+  | { kind: "fatal"; reason: string; message: string }
+  | { kind: "error"; message: string; detail?: unknown } // §5, protocol-level
+  // native port requests (host replies correlated by `id`) — §9
+  | { kind: "fetch/start"; id: string; url: string; method: string;
+      headers: Record<string, string>; body?: string }
+  | { kind: "fetch/abort"; id: string }
+  | { kind: "storage/get"; id: string; key: string }
+  | { kind: "storage/set"; id: string; key: string; value: string }
+  | { kind: "storage/delete"; id: string; key: string }
+  | { kind: "log"; level: "debug" | "info" | "warn" | "error";
+      message: string; fields?: Record<string, unknown> };
+
+/** Which capability ports the host services natively over the pipe (§9). */
+export interface NativePorts { storage?: boolean; fetch?: boolean }
 ```
+
+> **Status.** This union is SHIPPED in `packages/sdk/src/bridge/` (the dispatcher
+> `createBridge`, the native-port marshalling, and the embeddable-bundle entry).
+> The four base envelopes above match the original contract verbatim; the
+> `configure` / `error` / `fetch/*` / `storage/*` / `log` members and the
+> `NativePorts` shape were added additively when the dispatcher landed — all
+> optional-by-construction, so a host built against the base four is unaffected
+> (§4). §2.1 (configure), §9 (native ports), and §10 (host polyfills) below are
+> the new normative sections.
+
+### 2.1 Configure — the first inbound message
+
+The dispatcher constructs nothing until the host declares where the engine
+lives. `configure` is therefore the **first** message the host sends, before
+any command or subscription:
+
+```json
+→ { "kind": "configure", "baseUrl": "http://127.0.0.1:4317",
+    "native": { "storage": true } }
+← { "kind": "ready", "v": 1 }
+```
+
+- `baseUrl` (required) roots every engine request.
+- `native` (optional) declares which ports the host backs over the pipe.
+  `storage` defaults `true` (host-backed via `storage/*`); `false` makes the
+  bridge use an in-memory store (tokens do not survive a restart). `fetch` is
+  always native — an embedded engine has no HTTP stack — and a `false` is
+  ignored.
+- The dispatcher builds the ports, constructs the SDK, wires the event channel,
+  and replies `ready` **once**. A second `configure` is refused with an `error`.
+- **Ordering note.** Constructing the SDK hydrates the persisted token, so the
+  first `storage/get` (§9) may go out *before* `ready`. A host must be ready to
+  service port requests as soon as it has sent `configure`.
+
+> **Deviation from the original §2 handshake.** The roadmap draft posted `ready`
+> "on construction," before any inbound message. Reality: the dispatcher needs
+> `baseUrl` to construct the SDK, so `ready` is the **reply to `configure`**, not
+> an unprompted greeting. Everything else about `ready` (posted exactly once,
+> `v` is the compatibility gate) is unchanged.
 
 ### Commands (request / reply, correlated by `id`)
 
@@ -91,9 +151,17 @@ modules register; the flows in §6 use the representative names below.
 - SDK replies **once, immediately**, with
   `{ kind: "subscribed", sub, scope, snapshot? }`. `snapshot` carries the
   current `getSnapshot(scope)`; it is **omitted** when that is `undefined`
-  (nothing published yet). Subscribing is also what *activates* a lazy scope —
-  e.g. the first subscriber on `conversation/<id>` starts that conversation's
-  live stream underneath (§7).
+  (nothing published yet).
+
+  > **Deviation — subscribing does NOT activate a lazy scope.** The roadmap
+  > draft said the first subscriber on `conversation/<id>` starts that
+  > conversation's stream underneath. In the shipped SDK `subscribe` is a
+  > *passive* read attachment: it delivers the initial snapshot and forwards
+  > later publishes, but it starts no stream. To make a conversation stream, the
+  > host issues a command — `turns/send` (start a turn) or `turns/observe`
+  > (attach to a turn started elsewhere); those publish to the scope and the
+  > subscriber then receives the pushes. Subscribe first so the initial frames
+  > are not missed, then send the activating command (see §6.3/§6.4).
 - Thereafter, every `publish(scope, snapshot)` the SDK makes for that scope is
   pushed as `{ kind: "snapshot", sub, scope, snapshot }` — one message **per
   matching subscription**. `snapshot` here always carries a value (publish
@@ -168,7 +236,21 @@ no in-band renegotiation — `v` is a compatibility gate, not a handshake dialog
 
 ## 5. Error surfaces
 
-Three distinct surfaces. Keep them separate in host code.
+Four distinct surfaces. Keep them separate in host code. (The fourth,
+**protocol errors**, is new — added with the dispatcher.)
+
+**0. Protocol errors** — an inbound message the dispatcher could not act on and
+could not correlate to a command or subscription. Delivered as
+`{ kind: "error", message, detail? }`. Causes: a non-JSON string, an object with
+no string `kind`, `subscribe` missing `sub`/`scope`, `unsubscribe` missing
+`sub`, `subscribe`/`command` before `configure`, or a second `configure`. It is
+**never fatal** and correlates to nothing — it just reports that one message was
+rejected. A **malformed command** does *not* use this surface: it still gets a
+`result` (`ok:false`, `"invalid command envelope"`) correlated by whatever `id`
+was extractable (§2), so command replies stay uniform. An **unknown `kind`** is
+*not* an error either — it is inert per §4 (ignored, no reply), so a newer host
+speaking a future member never trips the old dispatcher.
+
 
 **1. Command errors** — a single command failed. Delivered as the command's own
 `{ kind: "result", result: { id, ok: false, error: { message, status? } } }`.
@@ -195,6 +277,13 @@ host must stop issuing commands, obtain a fresh session token, and re-attach
 (§6.6). The SDK also flips the `connection` scope snapshot to unauthenticated,
 so a host subscribed there sees it both ways. A `fatal` is **not** correlated to
 any command; it can arrive at any time.
+
+> **Mechanism.** Inside the SDK, token expiry is an `SdkEvent`
+> (`type: "session/tokenExpired"`) on the event channel. The dispatcher
+> translates that ONE event type into `{ kind: "fatal", reason: "tokenExpired" }`
+> and forwards every other event verbatim as `{ kind: "event", event }`. A host
+> therefore never sees a `session/tokenExpired` `event` — it always arrives as a
+> `fatal`.
 
 > **Provider token-expired vs. session token-expired.** A *provider* credential
 > lapsing (Claude/Codex OAuth) is a **stream error** — per-conversation, in the
@@ -400,3 +489,135 @@ The conversation feed snapshot's `live` block projects the runtime-client
 - **Backpressure.** The pipe has none at this layer. If the host cannot keep up
   with `snapshot` pushes it should coalesce on its side — since each snapshot is
   a full replacement, dropping all but the latest per `sub` is always correct.
+
+---
+
+## 9. Native-backed ports (fetch + storage over the pipe)
+
+An embedded engine has no HTTP stack and no persistent store of its own. The SDK
+reaches both **through the host, over the same pipe**, as request/reply message
+pairs correlated by an **SDK-minted** `id` (a separate namespace from the
+host-minted command `id`/`sub`; ids appear only inside these `fetch/*` /
+`storage/*` frames, so they never collide with `result`/`snapshot` ids).
+
+### 9.1 fetch
+
+Every engine request — a `GET /agents`, a `POST …/messages`, and the long-lived
+`GET …/events` SSE — leaves as a `fetch/start`; the host performs the real
+network I/O and streams the response back:
+
+```json
+→ { "kind": "fetch/start", "id": "f7", "url": "http://127.0.0.1:4317/agents/ag_1/conversations/cv_42/events",
+    "method": "GET", "headers": { "accept": "text/event-stream", "authorization": "Bearer eyJ…" } }
+← { "kind": "fetch/response", "id": "f7", "status": 200, "ok": true }
+← { "kind": "fetch/chunk", "id": "f7", "bytesBase64": "ZGF0YTogeyJ0eXBlIjoic3luYyJ9Cgo=" }
+← { "kind": "fetch/chunk", "id": "f7", "bytesBase64": "ZGF0YTogeyJ0eXBlIjoidGV4dCJ9Cgo=" }
+← { "kind": "fetch/done", "id": "f7" }
+```
+
+- **`fetch/start { id, url, method, headers, body? }`** — `headers` is a flat
+  string map. `body` is a UTF-8 string (the SDK sends `JSON.stringify(...)` or
+  nothing); absent when there is no body.
+- **`fetch/response { id, status, ok }`** — resolves the SDK's `Response`.
+  Response headers are **not** carried: no consumer reads them (see the pinned
+  contract below).
+- **`fetch/chunk { id, bytesBase64 }`** — one body chunk, **base64** (the pipe
+  is JSON strings; raw bytes are not JSON-serializable). The SDK decodes to
+  `Uint8Array` and feeds its stream reader. Send as many as the body has;
+  a non-streaming JSON body is typically one chunk.
+- **`fetch/done { id }`** — the body ended cleanly. **`fetch/error { id, message }`**
+  — the request/stream failed; before `fetch/response` it rejects the `fetch`
+  promise, after it errors the body reader (which the resume loop reads as a
+  dropped connection and reconnects, §7).
+- **`fetch/abort { id }`** (SDK→host) — the SDK aborted this request (switching
+  conversations, teardown). The host cancels the native request; any later
+  `fetch/*` for that `id` is ignored.
+
+**The minimal `Response` the SDK assembles** — only these members are used, so
+only these are guaranteed (each pinned to its consumer in `@houston/runtime-client`
+/ `@houston/sdk`):
+
+| Member | Consumer |
+| --- | --- |
+| `status` | `client.ts` (EngineError), `auth-fetch.ts` (401), `agents/http.ts` |
+| `ok` | `client.ts`, `agents/http.ts` |
+| `text()` | `client.ts` (error body), `agents/http.ts` |
+| `json()` | `client.ts` (`json<T>`), `agents/http.ts` |
+| `body` (truthy) + `body.getReader()` | `client.ts` (`streamEvents`) |
+| `getReader().read() → { done, value: Uint8Array }` | `sse-read.ts` |
+
+`releaseLock()` exists as a no-op (spec symmetry) but no consumer calls it;
+`Response.headers` is never read.
+
+### 9.2 storage
+
+`SdkPorts.storage` (the token custody store) is a request/reply pair; the host
+serves it from Keychain / SecureStore / SharedPreferences:
+
+```json
+→ { "kind": "storage/get", "id": "k1", "key": "houston.sdk.session.token" }
+← { "kind": "storage/result", "id": "k1", "value": "eyJ…" }     // string, or null if absent
+→ { "kind": "storage/set", "id": "k2", "key": "houston.sdk.session.token", "value": "eyJ…" }
+← { "kind": "storage/result", "id": "k2" }                       // value omitted for set/delete
+→ { "kind": "storage/delete", "id": "k3", "key": "houston.sdk.session.token" }
+← { "kind": "storage/result", "id": "k3" }
+```
+
+`storage/result` carries `value` (string | null) only for a `get`; it is omitted
+for `set`/`delete`. If the host declared `native.storage: false` in `configure`
+(§2.1), the bridge serves storage from an in-memory map and emits no `storage/*`.
+
+### 9.3 clock + logger — not port-bridged
+
+- **Clock is NOT bridged.** The SDK's `setTimeout` / `clearTimeout` / `Date.now`
+  come from the JS engine's own globals (§10), which the host already backs with
+  its native run loop; the resume/backoff loops schedule against those globals
+  directly. Bridging the clock would put a message round-trip on every backoff
+  tick and idle-watchdog sweep for no benefit, so timers stay in-engine.
+- **Logger** forwards each line as `{ kind: "log", level, message, fields? }`
+  (SDK→host, no reply). Route it to your native log / Sentry, or drop it.
+
+### 9.4 Command vocabulary (informative)
+
+The bridge routes command `type` strings **opaquely** — they are owned by the
+SDK modules, not this contract (§2). The §6 flows use illustrative names; the
+**registered** types today are: `session/setToken` (§6.1/§6.6 call it
+`session/attach`), `agents/refresh` · `agents/create` · `agents/rename` ·
+`agents/delete`, `conversations/refresh` · `conversations/rename` ·
+`conversations/delete`, and `turns/send` · `turns/cancel` · `turns/observe`.
+New modules add types without touching the bridge.
+
+---
+
+## 10. Host polyfills (normative)
+
+The bundle targets a **bare** embedded engine (JavaScriptCore / Hermes outside a
+WebKit web context), so it assumes very little. The split:
+
+**The host MUST provide these globals** (no pure-JS substitute; they need the
+native run loop):
+
+- `setTimeout(fn, ms)` / `clearTimeout(id)`
+- `setInterval(fn, ms)` / `clearInterval(id)` — the per-conversation resume loop
+  arms an idle watchdog with `setInterval`.
+
+**The bundle self-provides these if the engine lacks them** (installed only when
+`typeof X === "undefined"`, so a host that already has them wins) — a host need
+NOT polyfill them, but MAY:
+
+- `Headers` + `Request` — `auth-fetch.ts` builds `new Headers()` on every
+  authenticated request and tests `input instanceof Request`.
+- `AbortController` / `AbortSignal` — stream cancellation.
+- `TextEncoder` / `TextDecoder` — UTF-8 SSE decoding (`TextDecoder` with
+  `{ stream: true }`).
+
+**Optional** (used if present, gracefully degraded if not):
+
+- `crypto.getRandomValues` — nonce entropy; falls back to `Math.random`.
+- `console` — the SDK logs through the `log` port, not `console`, so it is only
+  a convenience.
+
+The bundle needs **no** `fetch`, `btoa`/`atob`, `Buffer`, `process`, `document`,
+or `window`. A CI smoke test evaluates the built IIFE in a bare Node `vm` context
+with **only** the required globals injected and round-trips a command, so any
+hidden global dependency fails the build.

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -91,6 +91,7 @@ src/
   index.ts           # public entry (kernel + each module's contract)
   modules/           # session, agents, conversations, turns
   react/             # React bindings (exported as @houston/sdk/react)
+  bridge/            # native-bridge dispatcher + embeddable bundle (see below)
 ```
 
 Modules are internal: `HoustonSdk`'s constructor composes each
@@ -103,6 +104,51 @@ same transport and emits one canonical `session/tokenExpired` signal. Tear the
 SDK down with `sdk.dispose()` (stops the agents reactivity stream and every
 in-flight turn stream).
 
+## Native bridge — embedding the SDK in a mobile host
+
+`bridge/` is the JS side of the native bridge: it lets an iOS (JavaScriptCore)
+or Android (Hermes) shell run this exact SDK behind a string message pipe. The
+full wire contract — every message shape, ordering guarantee, error surface, and
+the normative host-polyfill list — is **`BRIDGE.md`**; this is the how-to.
+
+**In-process (tests, web tooling):** import the dispatcher directly.
+
+```ts
+import { createBridge } from "@houston/sdk";
+import { HoustonSdk } from "@houston/sdk";
+
+const bridge = createBridge((config) => new HoustonSdk(config), (msg) => sendToNative(msg));
+bridge.receive(inboundJsonString); // deliver one host→SDK message; never throws
+// … later …
+bridge.dispose();
+```
+
+**Embedded (the real mobile host):** build the self-contained IIFE and load it
+into the JS engine.
+
+```bash
+pnpm --filter @houston/sdk build:bridge   # → dist/houston-sdk.bridge.js (gitignored)
+```
+
+```js
+// inside the engine, after loading the bundle:
+const bridge = HoustonSdkBridge.create({ send: (msg) => postToNative(msg) });
+// first inbound message is always `configure`; the bridge replies `ready`:
+bridge.receive(JSON.stringify({ kind: "configure", baseUrl: "http://127.0.0.1:4317" }));
+// then attach the session token, subscribe to scopes, dispatch commands (BRIDGE.md §6).
+```
+
+The host implements two primitives: `send(msg: string)` (marshal outbound to
+native and return — never call `receive` re-entrantly, BRIDGE.md §8) and calls
+`receive(msg: string)` for each inbound message on one thread. The host also
+services the native ports the SDK needs over the same pipe — `fetch/*` (it does
+the HTTP, streaming the body back as base64 chunks) and `storage/*` (Keychain /
+SecureStore) — see BRIDGE.md §9. The bundle self-shims `Headers`, `Request`,
+`AbortController`, and `TextEncoder`/`TextDecoder`; the host need only provide
+`setTimeout`/`clearTimeout`/`setInterval`/`clearInterval` (BRIDGE.md §10). The
+built bundle is ~33 KiB minified and NOT committed — the iOS/Android build runs
+`build:bridge`.
+
 ## Out of scope for v1
 
 Deliberately not built yet (add when a real surface needs them):
@@ -114,5 +160,6 @@ Deliberately not built yet (add when a real surface needs them):
 - **Full control-plane migration** — the SDK wraps the conversation/agent surface
   first; broader control-plane operations stay on their current paths until
   migrated deliberately.
-- **Native bridge implementation** — the `dispatch`/snapshot contract is native-
-  ready (all JSON), but the actual iOS/Android bridge host is not in this package.
+- **Native host app** — the JS-side bridge dispatcher + embeddable bundle now
+  ship here (`bridge/`, see above), but the actual iOS/Android shell that loads
+  the bundle and backs the native ports lives in its own app, not this package.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -21,6 +21,7 @@
   ],
   "scripts": {
     "build": "tsgo -p tsconfig.json",
+    "build:bridge": "node scripts/build-bridge.mjs",
     "dev": "tsgo -p tsconfig.json --watch",
     "test": "vitest run --testTimeout=30000",
     "typecheck": "tsgo -p tsconfig.json --noEmit"
@@ -33,6 +34,7 @@
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "@typescript/native-preview": "7.0.0-dev.20260607.1",
+    "esbuild": "^0.25.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "typescript": "^6.0.2",

--- a/packages/sdk/scripts/build-bridge.mjs
+++ b/packages/sdk/scripts/build-bridge.mjs
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+/**
+ * Build the embeddable native-bridge bundle: a single self-contained IIFE at
+ * `dist/houston-sdk.bridge.js` exposing the global `HoustonSdkBridge`
+ * (`create({ send }) -> { receive, dispose }` + `version`).
+ *
+ * Target: JavaScriptCore / Hermes (Safari ES2022), NO Node/DOM globals beyond
+ * what the host polyfills (timers) and what the bundle self-shims
+ * (Headers/Request/AbortController/TextEncoder/TextDecoder — see
+ * `src/bridge/shims.ts`). The bundle is fully inlined; the iOS/Android build
+ * runs this script, so `dist/` is gitignored and never committed.
+ */
+
+import { mkdir, stat } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const pkgRoot = join(here, "..");
+const outfile = join(pkgRoot, "dist", "houston-sdk.bridge.js");
+
+await mkdir(dirname(outfile), { recursive: true });
+
+const result = await build({
+  entryPoints: [join(pkgRoot, "src", "bridge", "entry.ts")],
+  outfile,
+  bundle: true,
+  format: "iife",
+  globalName: "HoustonSdkBridge",
+  platform: "browser",
+  target: "es2022",
+  minify: true,
+  legalComments: "none",
+  metafile: true,
+  // The bundle must assume no ambient Node/DOM host globals. esbuild does not
+  // inject any; keeping `define` empty documents that intent.
+  define: {},
+});
+
+const { size } = await stat(outfile);
+const kib = (size / 1024).toFixed(1);
+if (result.warnings.length > 0) {
+  for (const w of result.warnings) console.warn("[build-bridge]", w.text);
+}
+console.log(`[build-bridge] wrote ${outfile} (${kib} KiB, ${size} bytes)`);

--- a/packages/sdk/src/bridge/base64.ts
+++ b/packages/sdk/src/bridge/base64.ts
@@ -1,0 +1,65 @@
+/**
+ * Base64 codec for the bridge's byte transport.
+ *
+ * Response bodies cross the string pipe as base64 (`fetch/chunk.bytesBase64`)
+ * because the pipe carries only JSON strings and raw bytes are not
+ * JSON-serializable. These helpers are self-contained on purpose: an embedded
+ * JavaScriptCore/Hermes context ships neither `btoa`/`atob` (WebKit-only) nor
+ * Node's `Buffer`, so the codec is written over plain `Uint8Array` + string
+ * arithmetic and depends on no host global.
+ */
+
+const ALPHABET =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/** Reverse lookup: char code -> 6-bit value (or -1 for non-alphabet bytes). */
+const LOOKUP = /* @__PURE__ */ (() => {
+  const table = new Int8Array(256).fill(-1);
+  for (let i = 0; i < ALPHABET.length; i++) table[ALPHABET.charCodeAt(i)] = i;
+  return table;
+})();
+
+/** Encode raw bytes to a standard (padded) base64 string. */
+export function bytesToBase64(bytes: Uint8Array): string {
+  let out = "";
+  let i = 0;
+  for (; i + 2 < bytes.length; i += 3) {
+    const n = (bytes[i] << 16) | (bytes[i + 1] << 8) | bytes[i + 2];
+    out +=
+      ALPHABET[(n >> 18) & 63] +
+      ALPHABET[(n >> 12) & 63] +
+      ALPHABET[(n >> 6) & 63] +
+      ALPHABET[n & 63];
+  }
+  const rem = bytes.length - i;
+  if (rem === 1) {
+    const n = bytes[i] << 16;
+    out += `${ALPHABET[(n >> 18) & 63]}${ALPHABET[(n >> 12) & 63]}==`;
+  } else if (rem === 2) {
+    const n = (bytes[i] << 16) | (bytes[i + 1] << 8);
+    out += `${ALPHABET[(n >> 18) & 63]}${ALPHABET[(n >> 12) & 63]}${ALPHABET[(n >> 6) & 63]}=`;
+  }
+  return out;
+}
+
+/** Decode a base64 string (padding optional) back to raw bytes. */
+export function base64ToBytes(b64: string): Uint8Array {
+  let len = b64.length;
+  while (len > 0 && (b64[len - 1] === "=" || b64[len - 1] === "\n")) len--;
+  const outLen = (len * 3) >> 2;
+  const out = new Uint8Array(outLen);
+  let o = 0;
+  let acc = 0;
+  let bits = 0;
+  for (let i = 0; i < len; i++) {
+    const v = LOOKUP[b64.charCodeAt(i)];
+    if (v < 0) continue; // skip stray whitespace / non-alphabet bytes
+    acc = (acc << 6) | v;
+    bits += 6;
+    if (bits >= 8) {
+      bits -= 8;
+      out[o++] = (acc >> bits) & 0xff;
+    }
+  }
+  return o === outLen ? out : out.subarray(0, o);
+}

--- a/packages/sdk/src/bridge/dispatcher.ts
+++ b/packages/sdk/src/bridge/dispatcher.ts
@@ -1,0 +1,200 @@
+/**
+ * The JS-side bridge dispatcher — the thin layer that turns the string pipe
+ * into `HoustonSdk` calls and back. It implements `packages/sdk/BRIDGE.md`.
+ *
+ * Lifecycle: `createBridge` returns `{ receive, dispose }` and waits. The host
+ * sends `configure` first (`baseUrl` + which ports are native); the dispatcher
+ * builds ports, constructs the SDK via the injected factory, wires the event
+ * channel, and replies `ready`. Thereafter it routes `command` -> `sdk.dispatch`
+ * -> one `result`; `subscribe`/`unsubscribe` -> `sdk.subscribe` with an initial
+ * `subscribed` snapshot then per-publish `snapshot` pushes; SDK events ->
+ * `event`, except `session/tokenExpired` -> `fatal`; and native `fetch/*` +
+ * `storage/*` replies -> the port host.
+ * It never throws across the pipe: every inbound message yields a reply or a
+ * documented no-reply (unknown `kind` inert per BRIDGE.md §4; port replies and
+ * an idempotent unknown `unsubscribe` are silent by contract).
+ */
+
+import { TOKEN_EXPIRED_EVENT } from "../auth-expiry";
+import type { CommandEnvelope } from "../commands";
+import type { SdkConfig } from "../ports";
+import type { HoustonSdk } from "../sdk";
+import type { SdkEvent } from "../store";
+import { PortHost } from "./ports";
+import {
+  asRecord,
+  BRIDGE_PROTOCOL_VERSION,
+  type BridgeOutbound,
+  type NativePorts,
+  type SendFn,
+} from "./wire";
+
+/** Constructs the SDK once the host's `configure` supplies its config. */
+export type SdkFactory = (config: SdkConfig) => HoustonSdk;
+
+/** The dispatcher handle handed to the host. */
+export interface Bridge {
+  /** Deliver one inbound message string. Never throws. */
+  receive(message: string): void;
+  /** Tear down the SDK, subscriptions, and in-flight port ops. */
+  dispose(): void;
+}
+
+/** Best-effort correlation id from an untrusted command envelope. */
+function envelopeId(value: unknown): string {
+  const id = asRecord(value)?.id;
+  return typeof id === "string" ? id : "";
+}
+
+export function createBridge(sdkFactory: SdkFactory, send: SendFn): Bridge {
+  const portHost = new PortHost(send);
+  const subs = new Map<string, () => void>();
+  let sdk: HoustonSdk | null = null;
+  let offEvent: (() => void) | null = null;
+
+  const emit = (msg: BridgeOutbound): void => send(JSON.stringify(msg));
+
+  function onSdkEvent(event: SdkEvent): void {
+    if (event.type === TOKEN_EXPIRED_EVENT) {
+      emit({
+        kind: "fatal",
+        reason: "tokenExpired",
+        message: "Houston session token expired; re-attach to continue.",
+      });
+    } else {
+      emit({ kind: "event", event });
+    }
+  }
+
+  function configure(msg: Record<string, unknown>): void {
+    if (sdk) {
+      emit({ kind: "error", message: "already configured" });
+      return;
+    }
+    const baseUrl = msg.baseUrl;
+    if (typeof baseUrl !== "string" || baseUrl.length === 0) {
+      emit({
+        kind: "error",
+        message: "configure: baseUrl must be a non-empty string",
+      });
+      return;
+    }
+    const native = (asRecord(msg.native) ?? undefined) as
+      | NativePorts
+      | undefined;
+    sdk = sdkFactory({ baseUrl, ports: portHost.ports(native) });
+    offEvent = sdk.on(onSdkEvent);
+    emit({ kind: "ready", v: BRIDGE_PROTOCOL_VERSION });
+  }
+
+  function onCommand(envelope: unknown): void {
+    const id = envelopeId(envelope);
+    if (!sdk) {
+      emit({
+        kind: "result",
+        result: { id, ok: false, error: { message: "not configured" } },
+      });
+      return;
+    }
+    sdk
+      .dispatch(envelope as CommandEnvelope)
+      .then((result) => emit({ kind: "result", result }))
+      .catch((err: unknown) =>
+        emit({
+          kind: "result",
+          result: { id, ok: false, error: { message: String(err) } },
+        }),
+      );
+  }
+
+  function onSubscribe(msg: Record<string, unknown>): void {
+    if (!sdk) {
+      emit({ kind: "error", message: "subscribe before configure" });
+      return;
+    }
+    const { sub, scope } = msg;
+    if (typeof sub !== "string" || typeof scope !== "string") {
+      emit({
+        kind: "error",
+        message: "subscribe requires string 'sub' and 'scope'",
+      });
+      return;
+    }
+    if (subs.has(sub)) {
+      emit({ kind: "error", message: `subscription already active: ${sub}` });
+      return;
+    }
+    const snapshot = sdk.getSnapshot(scope);
+    emit({
+      kind: "subscribed",
+      sub,
+      scope,
+      ...(snapshot !== undefined ? { snapshot } : {}),
+    });
+    subs.set(
+      sub,
+      sdk.subscribe(scope, (snap) =>
+        emit({ kind: "snapshot", sub, scope, snapshot: snap }),
+      ),
+    );
+  }
+
+  function onUnsubscribe(msg: Record<string, unknown>): void {
+    const sub = msg.sub;
+    if (typeof sub !== "string") {
+      emit({ kind: "error", message: "unsubscribe requires string 'sub'" });
+      return;
+    }
+    const off = subs.get(sub);
+    if (!off) return; // unknown sub: idempotent no-op (BRIDGE.md §2)
+    off();
+    subs.delete(sub);
+  }
+
+  function receive(message: string): void {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(message);
+    } catch {
+      emit({ kind: "error", message: "malformed message: not JSON" });
+      return;
+    }
+    const msg = asRecord(parsed);
+    if (!msg || typeof msg.kind !== "string") {
+      emit({
+        kind: "error",
+        message: "message must be an object with a string 'kind'",
+      });
+      return;
+    }
+    if (portHost.handle(msg)) return; // fetch/* + storage/* replies
+    switch (msg.kind) {
+      case "configure":
+        configure(msg);
+        return;
+      case "command":
+        onCommand(msg.envelope);
+        return;
+      case "subscribe":
+        onSubscribe(msg);
+        return;
+      case "unsubscribe":
+        onUnsubscribe(msg);
+        return;
+      default:
+        return; // unknown kind: inert per additive versioning (BRIDGE.md §4)
+    }
+  }
+
+  function dispose(): void {
+    for (const off of subs.values()) off();
+    subs.clear();
+    offEvent?.();
+    offEvent = null;
+    sdk?.dispose();
+    sdk = null;
+    portHost.dispose();
+  }
+
+  return { receive, dispose };
+}

--- a/packages/sdk/src/bridge/entry.ts
+++ b/packages/sdk/src/bridge/entry.ts
@@ -1,0 +1,35 @@
+/**
+ * The embeddable-bundle entry point. esbuild bundles this into a single
+ * self-contained IIFE (`dist/houston-sdk.bridge.js`) exposing one global,
+ * `HoustonSdkBridge`, with `create({ send }) -> { receive, dispose }` and a
+ * `version` constant.
+ *
+ * This is the ONLY module that installs the global shims and constructs the
+ * real {@link HoustonSdk} — the package's normal imports stay side-effect-free.
+ * A native host loads the bundle into its JS engine, then:
+ *
+ *   const bridge = HoustonSdkBridge.create({ send: postToNative });
+ *   // deliver inbound native messages:
+ *   bridge.receive(jsonString);
+ */
+
+import { HoustonSdk } from "../sdk";
+import { type Bridge, createBridge } from "./dispatcher";
+import { installGlobalShims } from "./shims";
+import { BRIDGE_PROTOCOL_VERSION, type SendFn } from "./wire";
+
+installGlobalShims();
+
+/** The bridge protocol major, matching the `ready` handshake `v`. */
+export const version = BRIDGE_PROTOCOL_VERSION;
+
+/** Options for {@link create}. */
+export interface CreateOptions {
+  /** Deliver one serialized outbound message to the native side. */
+  send: SendFn;
+}
+
+/** Construct a bridge over a real {@link HoustonSdk}. */
+export function create(options: CreateOptions): Bridge {
+  return createBridge((config) => new HoustonSdk(config), options.send);
+}

--- a/packages/sdk/src/bridge/fetch.ts
+++ b/packages/sdk/src/bridge/fetch.ts
@@ -1,0 +1,192 @@
+/**
+ * The bridge-fetch port: a `fetch`-shaped function whose HTTP work is performed
+ * natively by the host and streamed back over the pipe.
+ *
+ * A request leaves as `fetch/start { id, url, method, headers, body? }`; the
+ * host replies with `fetch/response { id, status, ok }` (which resolves the
+ * `Response`), then zero or more `fetch/chunk { id, bytesBase64 }`, then a
+ * terminal `fetch/done { id }` or `fetch/error { id, message }`. An
+ * `AbortSignal` on the request sends `fetch/abort { id }` and fails the stream,
+ * which is exactly how the runtime-client's resume loop detects a drop.
+ *
+ * Only the `Response` members the SDK consumes are assembled (see
+ * `response.ts`). Request bodies are always UTF-8 strings on the bridge (the
+ * SDK sends `JSON.stringify(...)` or nothing); a non-string body is coerced.
+ */
+
+import { base64ToBytes } from "./base64";
+import { BridgeResponse, ByteStream } from "./response";
+import type { BridgeOutbound, SendFn } from "./wire";
+
+/** An abort surfaced to the SDK as a rejected fetch/read (name `AbortError`). */
+function abortError(): Error {
+  const err = new Error("The operation was aborted.");
+  err.name = "AbortError";
+  return err;
+}
+
+/** One in-flight bridge-fetch: its Response promise and its body stream. */
+class PendingFetch {
+  readonly response: Promise<Response>;
+  private resolve!: (r: Response) => void;
+  private reject!: (e: unknown) => void;
+  private readonly stream = new ByteStream();
+  private responded = false;
+  /** Terminal (done/error/abort): the owner may drop it from the registry. */
+  settled = false;
+
+  constructor() {
+    this.response = new Promise<Response>((res, rej) => {
+      this.resolve = res;
+      this.reject = rej;
+    });
+  }
+
+  onResponse(status: number, ok: boolean): void {
+    if (this.responded) return;
+    this.responded = true;
+    this.resolve(
+      new BridgeResponse(status, ok, this.stream) as unknown as Response,
+    );
+  }
+
+  onChunk(bytes: Uint8Array): void {
+    this.stream.push(bytes);
+  }
+
+  onDone(): void {
+    this.settled = true;
+    this.stream.close();
+  }
+
+  onError(message: string): void {
+    this.fail(new Error(message));
+  }
+
+  abort(): void {
+    if (this.settled) return;
+    this.fail(abortError());
+  }
+
+  private fail(err: Error): void {
+    this.settled = true;
+    if (!this.responded) {
+      this.responded = true;
+      this.reject(err);
+    } else {
+      this.stream.fail(err);
+    }
+  }
+}
+
+/** Whether `input` is a `Request` (guarded: the global may be a shim/absent). */
+function isRequest(input: unknown): input is Request {
+  return typeof Request !== "undefined" && input instanceof Request;
+}
+
+/** Resolve the request URL from any `fetch` first-argument form. */
+function urlOf(input: RequestInfo | URL): string {
+  if (typeof input === "string") return input;
+  if (typeof URL !== "undefined" && input instanceof URL) return input.href;
+  return (input as Request).url;
+}
+
+/** Flatten headers (Headers | record | entries) into a plain string map. */
+function headerRecord(
+  input: RequestInfo | URL,
+  init?: RequestInit,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  const h = init?.headers ?? (isRequest(input) ? input.headers : undefined);
+  if (!h) return out;
+  if (Array.isArray(h)) {
+    for (const [k, v] of h) out[k] = v;
+  } else if (typeof (h as Headers).forEach === "function") {
+    (h as Headers).forEach((v, k) => {
+      out[k] = v;
+    });
+  } else {
+    for (const k of Object.keys(h))
+      out[k] = String((h as Record<string, string>)[k]);
+  }
+  return out;
+}
+
+/** Build the `fetch/start` frame body for a request. */
+function startFrame(
+  id: string,
+  input: RequestInfo | URL,
+  init: RequestInit | undefined,
+): Extract<BridgeOutbound, { kind: "fetch/start" }> {
+  const method = init?.method ?? (isRequest(input) ? input.method : "GET");
+  const frame: Extract<BridgeOutbound, { kind: "fetch/start" }> = {
+    kind: "fetch/start",
+    id,
+    url: urlOf(input),
+    method,
+    headers: headerRecord(input, init),
+  };
+  const body = init?.body;
+  if (body != null) frame.body = typeof body === "string" ? body : String(body);
+  return frame;
+}
+
+/** The fetch half of the port host: owns in-flight requests + routes replies. */
+export class FetchPort {
+  private readonly pending = new Map<string, PendingFetch>();
+
+  constructor(
+    private readonly send: SendFn,
+    private readonly mintId: () => string,
+  ) {}
+
+  /** A `fetch`-shaped function routed over the pipe. */
+  readonly fetch: typeof fetch = ((
+    input: RequestInfo | URL,
+    init?: RequestInit,
+  ) => {
+    const signal = init?.signal ?? undefined;
+    if (signal?.aborted) return Promise.reject(abortError());
+    const id = this.mintId();
+    const pending = new PendingFetch();
+    this.pending.set(id, pending);
+    this.send(JSON.stringify(startFrame(id, input, init)));
+    if (signal) {
+      const onAbort = () => {
+        if (!pending.settled)
+          this.send(JSON.stringify({ kind: "fetch/abort", id }));
+        pending.abort();
+        this.pending.delete(id);
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+    return pending.response;
+  }) as typeof fetch;
+
+  /** Route a `fetch/*` reply frame. Returns whether it was a fetch frame. */
+  handle(msg: Record<string, unknown>): boolean {
+    const kind = msg.kind;
+    if (typeof kind !== "string" || !kind.startsWith("fetch/")) return false;
+    const id = typeof msg.id === "string" ? msg.id : "";
+    const pending = this.pending.get(id);
+    if (!pending) return true; // unknown/settled id: recognized frame, no target
+    if (kind === "fetch/response") {
+      pending.onResponse(Number(msg.status), msg.ok === true);
+    } else if (kind === "fetch/chunk") {
+      pending.onChunk(base64ToBytes(String(msg.bytesBase64 ?? "")));
+    } else if (kind === "fetch/done") {
+      pending.onDone();
+      this.pending.delete(id);
+    } else if (kind === "fetch/error") {
+      pending.onError(String(msg.message ?? "fetch failed"));
+      this.pending.delete(id);
+    }
+    return true;
+  }
+
+  /** Fail every in-flight request (SDK teardown). */
+  dispose(): void {
+    for (const pending of this.pending.values()) pending.abort();
+    this.pending.clear();
+  }
+}

--- a/packages/sdk/src/bridge/ports.ts
+++ b/packages/sdk/src/bridge/ports.ts
@@ -1,0 +1,97 @@
+/**
+ * Assembles {@link SdkPorts} for a bridged session and routes the host's port
+ * replies back to the ports that issued the requests.
+ *
+ * - **fetch** and **storage** are native, backed by {@link FetchPort} /
+ *   {@link StoragePort} over the pipe. `fetch` is wrapped with the SDK's own
+ *   {@link createAuthFetch} exactly as the documented host wiring prescribes, so
+ *   the session token is stamped per request and 401s are classified.
+ * - **clock** is NOT bridged. It reads the JS engine's own `setTimeout` /
+ *   `clearTimeout` / `Date.now` — the host already polyfills the global timers
+ *   against its native run loop, and the resume/backoff loops in
+ *   `@houston/runtime-client` schedule against those globals directly. Bridging
+ *   the clock would add a message round-trip to every backoff tick and watchdog
+ *   sweep for no benefit, so timers stay in-engine.
+ * - **logger** forwards each line outbound as a `log` message.
+ */
+
+import { createAuthFetch } from "../modules/session/auth-fetch";
+import type { Clock, KeyValueStore, SdkLogger, SdkPorts } from "../ports";
+import { FetchPort } from "./fetch";
+import { StoragePort } from "./storage";
+import type { BridgeLogLevel, NativePorts, SendFn } from "./wire";
+
+/** An in-memory {@link KeyValueStore} for a host that does not back storage. */
+function memoryStore(): KeyValueStore {
+  const map = new Map<string, string>();
+  return {
+    get: async (key) => map.get(key) ?? null,
+    set: async (key, value) => void map.set(key, value),
+    delete: async (key) => void map.delete(key),
+  };
+}
+
+/** The engine-local clock: global timers + wall clock, never bridged. */
+function localClock(): Clock {
+  return {
+    now: () => Date.now(),
+    setTimeout: (fn, ms) => setTimeout(fn, ms) as unknown as number,
+    clearTimeout: (id) =>
+      clearTimeout(id as unknown as ReturnType<typeof setTimeout>),
+  };
+}
+
+/** Owns the native port machinery for one bridge and mints their request ids. */
+export class PortHost {
+  private counter = 0;
+  private readonly fetchPort: FetchPort;
+  private readonly storagePort: StoragePort;
+
+  constructor(private readonly send: SendFn) {
+    this.fetchPort = new FetchPort(send, () => `f${++this.counter}`);
+    this.storagePort = new StoragePort(send, () => `k${++this.counter}`);
+  }
+
+  /** Build the `SdkPorts` for a configured session. */
+  ports(native?: NativePorts): SdkPorts {
+    const storage =
+      native?.storage === false ? memoryStore() : this.storagePort.store;
+    return {
+      fetch: createAuthFetch(this.fetchPort.fetch, storage),
+      storage,
+      clock: localClock(),
+      logger: this.logger(),
+    };
+  }
+
+  /** Route an inbound `fetch/*` or `storage/*` reply. */
+  handle(msg: Record<string, unknown>): boolean {
+    return this.fetchPort.handle(msg) || this.storagePort.handle(msg);
+  }
+
+  /** Fail every in-flight fetch/storage op (SDK teardown). */
+  dispose(): void {
+    this.fetchPort.dispose();
+    this.storagePort.dispose();
+  }
+
+  private logger(): SdkLogger {
+    const at =
+      (level: BridgeLogLevel) =>
+      (message: string, fields?: Record<string, unknown>): void =>
+        this.send(
+          JSON.stringify({
+            kind: "log",
+            level,
+            message,
+            ...(fields ? { fields } : {}),
+          }),
+        );
+    return {
+      debug: at("debug"),
+      info: at("info"),
+      warn: at("warn"),
+      error: at("error"),
+    };
+  }
+}

--- a/packages/sdk/src/bridge/response.ts
+++ b/packages/sdk/src/bridge/response.ts
@@ -1,0 +1,130 @@
+/**
+ * The MINIMAL `Response` the SDK actually consumes, assembled from the host's
+ * `fetch/response` + `fetch/chunk` + `fetch/done`/`fetch/error` messages.
+ *
+ * This is a deliberately partial implementation — only the members the SDK's
+ * fetch consumers touch are provided, each pinned to its consumer:
+ *
+ *  - `status`     — client.ts:93, auth-fetch.ts:106, agents/http.ts:52/56
+ *  - `ok`         — client.ts:92, agents/http.ts:51
+ *  - `text()`     — client.ts:93, agents/http.ts:53
+ *  - `json()`     — client.ts:98, agents/http.ts:64/71/78
+ *  - `body`       — client.ts:284/286 (truthiness + `getReader`)
+ *  - `body.getReader().read() -> { done, value: Uint8Array }` — sse-read.ts:34/38
+ *
+ * `releaseLock` is provided as a no-op for spec symmetry but is NOT called by
+ * any consumer (verified by grep); no consumer reads `Response.headers`, so it
+ * is omitted. Bodies stream in incrementally so an SSE read starts folding
+ * frames before the turn settles; `text()`/`json()` drain to `fetch/done`.
+ */
+
+/** One pull from the body reader. */
+export interface ReadResult {
+  done: boolean;
+  value?: Uint8Array;
+}
+
+/**
+ * A single-consumer pull queue of byte chunks. `push` feeds a chunk, `close`
+ * ends the stream cleanly, `fail` ends it with an error (an abort or a
+ * transport failure) so the pending `read` rejects — which is exactly how the
+ * runtime-client's resume loop learns a connection dropped.
+ */
+export class ByteStream {
+  private readonly chunks: Uint8Array[] = [];
+  private ended = false;
+  private failure: unknown;
+  private resolve: ((r: ReadResult) => void) | null = null;
+  private reject: ((e: unknown) => void) | null = null;
+
+  push(bytes: Uint8Array): void {
+    if (this.ended || this.failure !== undefined) return;
+    if (this.resolve) {
+      const r = this.take().resolve;
+      r?.({ done: false, value: bytes });
+    } else {
+      this.chunks.push(bytes);
+    }
+  }
+
+  close(): void {
+    if (this.ended || this.failure !== undefined) return;
+    this.ended = true;
+    if (this.chunks.length === 0 && this.resolve) {
+      this.take().resolve?.({ done: true, value: undefined });
+    }
+  }
+
+  fail(error: unknown): void {
+    if (this.ended || this.failure !== undefined) return;
+    this.failure = error;
+    this.take().reject?.(error);
+  }
+
+  read(): Promise<ReadResult> {
+    const next = this.chunks.shift();
+    if (next !== undefined)
+      return Promise.resolve({ done: false, value: next });
+    if (this.failure !== undefined) return Promise.reject(this.failure);
+    if (this.ended) return Promise.resolve({ done: true, value: undefined });
+    return new Promise<ReadResult>((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+
+  /** Detach and return the current waiter callbacks (single-consumer). */
+  private take(): {
+    resolve: ((r: ReadResult) => void) | null;
+    reject: ((e: unknown) => void) | null;
+  } {
+    const resolve = this.resolve;
+    const reject = this.reject;
+    this.resolve = null;
+    this.reject = null;
+    return { resolve, reject };
+  }
+}
+
+/** Concatenate byte chunks into one buffer. */
+function concat(parts: Uint8Array[]): Uint8Array {
+  let total = 0;
+  for (const p of parts) total += p.length;
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const p of parts) {
+    out.set(p, offset);
+    offset += p.length;
+  }
+  return out;
+}
+
+/** The partial Response backed by a {@link ByteStream}. */
+export class BridgeResponse {
+  readonly body = {
+    getReader: () => ({
+      read: (): Promise<ReadResult> => this.stream.read(),
+      releaseLock: (): void => {},
+    }),
+  };
+
+  constructor(
+    readonly status: number,
+    readonly ok: boolean,
+    private readonly stream: ByteStream,
+  ) {}
+
+  async text(): Promise<string> {
+    const parts: Uint8Array[] = [];
+    for (;;) {
+      const { done, value } = await this.stream.read();
+      if (done) break;
+      if (value) parts.push(value);
+    }
+    return new TextDecoder().decode(concat(parts));
+  }
+
+  async json(): Promise<unknown> {
+    return JSON.parse(await this.text());
+  }
+}

--- a/packages/sdk/src/bridge/shims.ts
+++ b/packages/sdk/src/bridge/shims.ts
@@ -1,0 +1,189 @@
+/**
+ * Fallback shims for the globals the bundled SDK + runtime-client touch that a
+ * bare embedded JS engine (JavaScriptCore / Hermes, outside a WebKit web
+ * context) does not guarantee. Each is installed ONLY when absent, so a host
+ * that already provides a richer implementation wins.
+ *
+ * Covered here (self-provided by the bundle):
+ *  - `Headers` + `Request`  — `auth-fetch.ts` builds `new Headers()` on every
+ *    authenticated request and tests `input instanceof Request`.
+ *  - `AbortController` / `AbortSignal` — the resume/turn/observe/global-events
+ *    loops abort streams with these.
+ *  - `TextEncoder` / `TextDecoder` — SSE parsing decodes UTF-8 stream chunks.
+ *
+ * NOT shimmed (must come from the host — see BRIDGE.md "Host polyfills"):
+ *  - `setTimeout` / `clearTimeout` / `setInterval` / `clearInterval` — timers
+ *    need the native run loop; there is no pure-JS substitute.
+ *  - `crypto.getRandomValues` (optional; nonce falls back to `Math.random`) and
+ *    `console` (optional diagnostics).
+ */
+
+interface GlobalWithShims {
+  [key: string]: unknown;
+}
+
+class HeadersShim {
+  private readonly map = new Map<string, string>();
+  constructor(init?: unknown) {
+    if (!init) return;
+    if (Array.isArray(init)) {
+      for (const [k, v] of init as [string, string][]) this.set(k, v);
+    } else if (typeof (init as HeadersShim).forEach === "function") {
+      (init as HeadersShim).forEach((v, k) => {
+        this.set(k, v);
+      });
+    } else {
+      const rec = init as Record<string, unknown>;
+      for (const k of Object.keys(rec)) this.set(k, String(rec[k]));
+    }
+  }
+  set(key: string, value: string): void {
+    this.map.set(String(key).toLowerCase(), String(value));
+  }
+  append(key: string, value: string): void {
+    const cur = this.get(key);
+    this.set(key, cur !== null ? `${cur}, ${value}` : value);
+  }
+  get(key: string): string | null {
+    return this.map.get(String(key).toLowerCase()) ?? null;
+  }
+  has(key: string): boolean {
+    return this.map.has(String(key).toLowerCase());
+  }
+  delete(key: string): void {
+    this.map.delete(String(key).toLowerCase());
+  }
+  forEach(cb: (value: string, key: string, parent: HeadersShim) => void): void {
+    for (const [k, v] of this.map) cb(v, k, this);
+  }
+}
+
+class AbortSignalShim {
+  aborted = false;
+  reason: unknown;
+  onabort: ((ev: { type: "abort" }) => void) | null = null;
+  private readonly listeners = new Set<(ev: { type: "abort" }) => void>();
+  addEventListener(type: string, cb: (ev: { type: "abort" }) => void): void {
+    if (type === "abort") this.listeners.add(cb);
+  }
+  removeEventListener(type: string, cb: (ev: { type: "abort" }) => void): void {
+    if (type === "abort") this.listeners.delete(cb);
+  }
+  dispatchEvent(): boolean {
+    return true;
+  }
+  fire(reason: unknown): void {
+    if (this.aborted) return;
+    this.aborted = true;
+    this.reason = reason;
+    const ev = { type: "abort" as const };
+    this.onabort?.(ev);
+    for (const cb of [...this.listeners]) cb(ev);
+    this.listeners.clear();
+  }
+}
+
+class AbortControllerShim {
+  readonly signal = new AbortSignalShim();
+  abort(reason?: unknown): void {
+    this.signal.fire(reason ?? new Error("aborted"));
+  }
+}
+
+/** Streaming UTF-8 decoder: buffers a trailing incomplete sequence. */
+class TextDecoderShim {
+  private leftover = new Uint8Array(0);
+  decode(input?: Uint8Array, options?: { stream?: boolean }): string {
+    const bytes = input ?? new Uint8Array(0);
+    const buf = new Uint8Array(this.leftover.length + bytes.length);
+    buf.set(this.leftover, 0);
+    buf.set(bytes, this.leftover.length);
+    let out = "";
+    let i = 0;
+    while (i < buf.length) {
+      const b0 = buf[i];
+      if (b0 < 0x80) {
+        out += String.fromCharCode(b0);
+        i++;
+        continue;
+      }
+      let need: number;
+      let cp: number;
+      if (b0 >= 0xc0 && b0 < 0xe0) [need, cp] = [1, b0 & 0x1f];
+      else if (b0 >= 0xe0 && b0 < 0xf0) [need, cp] = [2, b0 & 0x0f];
+      else if (b0 >= 0xf0 && b0 < 0xf8) [need, cp] = [3, b0 & 0x07];
+      else {
+        out += "�";
+        i++;
+        continue;
+      }
+      if (i + need + 1 > buf.length) break; // incomplete: stash and wait
+      let ok = true;
+      for (let k = 1; k <= need; k++) {
+        const bk = buf[i + k];
+        if ((bk & 0xc0) !== 0x80) {
+          ok = false;
+          break;
+        }
+        cp = (cp << 6) | (bk & 0x3f);
+      }
+      if (!ok) {
+        out += "�";
+        i++;
+        continue;
+      }
+      i += need + 1;
+      if (cp > 0xffff) {
+        cp -= 0x10000;
+        out += String.fromCharCode(0xd800 + (cp >> 10), 0xdc00 + (cp & 0x3ff));
+      } else out += String.fromCharCode(cp);
+    }
+    const rest = buf.subarray(i);
+    if (options?.stream) {
+      this.leftover = rest;
+      return out;
+    }
+    this.leftover = new Uint8Array(0);
+    return rest.length > 0 ? `${out}�` : out;
+  }
+}
+
+class TextEncoderShim {
+  encode(input = ""): Uint8Array {
+    const out: number[] = [];
+    for (let i = 0; i < input.length; i++) {
+      let cp = input.charCodeAt(i);
+      if (cp >= 0xd800 && cp < 0xdc00 && i + 1 < input.length) {
+        cp = 0x10000 + ((cp - 0xd800) << 10) + (input.charCodeAt(++i) - 0xdc00);
+      }
+      if (cp < 0x80) out.push(cp);
+      else if (cp < 0x800) out.push(0xc0 | (cp >> 6), 0x80 | (cp & 0x3f));
+      else if (cp < 0x10000)
+        out.push(
+          0xe0 | (cp >> 12),
+          0x80 | ((cp >> 6) & 0x3f),
+          0x80 | (cp & 0x3f),
+        );
+      else
+        out.push(
+          0xf0 | (cp >> 18),
+          0x80 | ((cp >> 12) & 0x3f),
+          0x80 | ((cp >> 6) & 0x3f),
+          0x80 | (cp & 0x3f),
+        );
+    }
+    return new Uint8Array(out);
+  }
+}
+
+/** Install each shim into `globalThis` only where the global is missing. */
+export function installGlobalShims(): void {
+  const g = globalThis as unknown as GlobalWithShims;
+  if (typeof g.Headers === "undefined") g.Headers = HeadersShim;
+  if (typeof g.Request === "undefined") g.Request = class RequestShim {};
+  if (typeof g.AbortController === "undefined")
+    g.AbortController = AbortControllerShim;
+  if (typeof g.AbortSignal === "undefined") g.AbortSignal = AbortSignalShim;
+  if (typeof g.TextDecoder === "undefined") g.TextDecoder = TextDecoderShim;
+  if (typeof g.TextEncoder === "undefined") g.TextEncoder = TextEncoderShim;
+}

--- a/packages/sdk/src/bridge/storage.ts
+++ b/packages/sdk/src/bridge/storage.ts
@@ -1,0 +1,66 @@
+/**
+ * The bridge KeyValueStore port: `get`/`set`/`delete` performed by the host's
+ * native store (Keychain, SecureStore, SharedPreferences) over the pipe.
+ *
+ * A call leaves as `storage/get|set|delete { id, key, value? }` and the host
+ * replies once with `storage/result { id, value? }` — `value` (string | null)
+ * for a `get`, omitted for `set`/`delete`. Correlation is by the SDK-minted
+ * `id`. This backs `SdkPorts.storage`, which the session module uses to persist
+ * the auth token, so the host controls where the token lives.
+ */
+
+import type { KeyValueStore } from "../ports";
+import type { SendFn } from "./wire";
+
+interface Waiter {
+  resolve: (value: string | null) => void;
+  reject: (error: unknown) => void;
+}
+
+/** The storage half of the port host: owns in-flight ops + routes replies. */
+export class StoragePort {
+  private readonly pending = new Map<string, Waiter>();
+
+  constructor(
+    private readonly send: SendFn,
+    private readonly mintId: () => string,
+  ) {}
+
+  /** A {@link KeyValueStore} routed over the pipe. */
+  readonly store: KeyValueStore = {
+    get: (key) => this.request({ kind: "storage/get", key }),
+    set: async (key, value) => {
+      await this.request({ kind: "storage/set", key, value });
+    },
+    delete: async (key) => {
+      await this.request({ kind: "storage/delete", key });
+    },
+  };
+
+  private request(frame: Record<string, unknown>): Promise<string | null> {
+    const id = this.mintId();
+    return new Promise<string | null>((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.send(JSON.stringify({ ...frame, id }));
+    });
+  }
+
+  /** Route a `storage/result` reply frame. Returns whether it was one. */
+  handle(msg: Record<string, unknown>): boolean {
+    if (msg.kind !== "storage/result") return false;
+    const id = typeof msg.id === "string" ? msg.id : "";
+    const waiter = this.pending.get(id);
+    if (!waiter) return true;
+    this.pending.delete(id);
+    waiter.resolve(typeof msg.value === "string" ? msg.value : null);
+    return true;
+  }
+
+  /** Reject every in-flight op (SDK teardown). */
+  dispose(): void {
+    for (const waiter of this.pending.values()) {
+      waiter.reject(new Error("bridge disposed"));
+    }
+    this.pending.clear();
+  }
+}

--- a/packages/sdk/src/bridge/wire.ts
+++ b/packages/sdk/src/bridge/wire.ts
@@ -1,0 +1,91 @@
+/**
+ * The bridge wire union — the JSON message vocabulary a native host exchanges
+ * with the SDK dispatcher. This is the machine-readable form of the contract in
+ * `packages/sdk/BRIDGE.md`; every shape here is documented there with examples.
+ *
+ * Two halves: {@link BridgeInbound} (host -> SDK, delivered via `receive`) and
+ * {@link BridgeOutbound} (SDK -> host, delivered via `send`). Both are plain
+ * JSON — nothing crosses the pipe that is not JSON-serializable.
+ *
+ * Versioning is additive (BRIDGE.md §4): consumers ignore unknown fields and
+ * treat an unknown discriminant as inert. {@link BRIDGE_PROTOCOL_VERSION} is the
+ * single major carried in the `ready` handshake and bumps only on a breaking
+ * change.
+ */
+
+import type { CommandEnvelope, CommandResult } from "../commands";
+import type { SdkEvent } from "../store";
+
+/** Bridge protocol major version, carried in the `ready` handshake (`v`). */
+export const BRIDGE_PROTOCOL_VERSION = 1;
+
+/** Which capability ports the host services natively over the pipe. */
+export interface NativePorts {
+  /**
+   * Storage is host-backed via `storage/*` messages. Default `true`; set
+   * `false` to have the bridge use an in-memory store (tokens do not persist
+   * across restarts).
+   */
+  storage?: boolean;
+  /**
+   * Fetch is host-backed via `fetch/*` messages. Always `true` in practice —
+   * an embedded engine has no HTTP stack of its own — and accepted only for
+   * symmetry. A `false` here is ignored.
+   */
+  fetch?: boolean;
+}
+
+/** Structured log line forwarded to the host over the pipe. */
+export type BridgeLogLevel = "debug" | "info" | "warn" | "error";
+
+/** host -> SDK. */
+export type BridgeInbound =
+  | { kind: "configure"; baseUrl: string; native?: NativePorts }
+  | { kind: "command"; envelope: CommandEnvelope }
+  | { kind: "subscribe"; sub: string; scope: string }
+  | { kind: "unsubscribe"; sub: string }
+  // Native port replies (correlated to an SDK-minted outbound `id`).
+  | { kind: "fetch/response"; id: string; status: number; ok: boolean }
+  | { kind: "fetch/chunk"; id: string; bytesBase64: string }
+  | { kind: "fetch/done"; id: string }
+  | { kind: "fetch/error"; id: string; message: string }
+  | { kind: "storage/result"; id: string; value?: string | null };
+
+/** SDK -> host. */
+export type BridgeOutbound =
+  | { kind: "ready"; v: number }
+  | { kind: "result"; result: CommandResult }
+  | { kind: "subscribed"; sub: string; scope: string; snapshot?: unknown }
+  | { kind: "snapshot"; sub: string; scope: string; snapshot: unknown }
+  | { kind: "event"; event: SdkEvent }
+  | { kind: "fatal"; reason: string; message: string }
+  | { kind: "error"; message: string; detail?: unknown }
+  // Native port requests (host replies correlated by `id`).
+  | {
+      kind: "fetch/start";
+      id: string;
+      url: string;
+      method: string;
+      headers: Record<string, string>;
+      body?: string;
+    }
+  | { kind: "fetch/abort"; id: string }
+  | { kind: "storage/get"; id: string; key: string }
+  | { kind: "storage/set"; id: string; key: string; value: string }
+  | { kind: "storage/delete"; id: string; key: string }
+  | {
+      kind: "log";
+      level: BridgeLogLevel;
+      message: string;
+      fields?: Record<string, unknown>;
+    };
+
+/** The `send` primitive: hand one serialized outbound message to the host. */
+export type SendFn = (message: string) => void;
+
+/** A plain-object view of an unknown inbound value, or `null` if not an object. */
+export function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null
+    ? (value as Record<string, unknown>)
+    : null;
+}

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -18,6 +18,24 @@ export {
   isUnauthorized,
   TOKEN_EXPIRED_EVENT,
 } from "./auth-expiry";
+// ===== Native bridge (dispatcher + wire vocabulary) ====================
+// The JS-side dispatcher that implements `BRIDGE.md` for embedding hosts
+// (iOS/JavaScriptCore, Android/Hermes). The self-contained IIFE bundle entry
+// lives in `bridge/entry.ts` (built via `build:bridge`) and is NOT re-exported
+// here because it installs global shims as an import side effect.
+export {
+  type Bridge,
+  createBridge,
+  type SdkFactory,
+} from "./bridge/dispatcher";
+export {
+  BRIDGE_PROTOCOL_VERSION,
+  type BridgeInbound,
+  type BridgeLogLevel,
+  type BridgeOutbound,
+  type NativePorts,
+  type SendFn,
+} from "./bridge/wire";
 export type {
   CommandEnvelope,
   CommandHandler,
@@ -25,6 +43,19 @@ export type {
 } from "./commands";
 export { CommandRegistry, isCommandEnvelope } from "./commands";
 export type { ModuleContext } from "./module-context";
+// ===== Activities module contract ======================================
+export {
+  ACTIVITY_CHANGED_EVENT,
+  ACTIVITY_STATUSES,
+  ActivitiesCommand,
+  type ActivitiesCommandType,
+  ActivitiesHttpError,
+  type ActivitiesModule,
+  type ActivitiesViewModel,
+  type ActivityItem,
+  activitiesScope,
+  type CreatedActivity,
+} from "./modules/activities";
 // ===== Agents module contract ==========================================
 export {
   AGENTS_CHANGED_EVENT,
@@ -43,6 +74,12 @@ export {
   type ConversationListVM,
   conversationListScope,
 } from "./modules/conversations";
+// ===== Mission-search module contract ==================================
+export type {
+  MatchedIn,
+  MissionMatch,
+  MissionsSearchModule,
+} from "./modules/missions-search";
 // ===== Session module contract =========================================
 // `createAuthFetch` + `SESSION_TOKEN_KEY` are host-facing: the host composes the
 // auth-fetch into `ports.fetch` before constructing the SDK (see the module).
@@ -64,8 +101,10 @@ export {
   type BoardStatus,
   type ConversationVM,
   conversationScope,
+  type FeedFrame,
   type FeedItemVM,
   type FeedOutput,
+  historyToFeed,
   isNotConnectedError,
   isStoppedByUser,
   MultiplexFeedOutput,
@@ -81,6 +120,7 @@ export {
   type TerminalBoardStatus,
   TURN_DIED_MESSAGE,
   type TurnCancelInput,
+  type TurnHistoryInput,
   type TurnObserveInput,
   type TurnSendInput,
   turnErrorMessage,

--- a/packages/sdk/src/modules/activities/events-stream.ts
+++ b/packages/sdk/src/modules/activities/events-stream.ts
@@ -1,0 +1,103 @@
+/**
+ * The activities reactivity subscription: a long-lived SSE read of the host's
+ * `GET /v1/events`, built on the shared `streamGlobalEvents` loop
+ * (`@houston/runtime-client`) — the SAME one client-side loop the agents module
+ * and the web adapter consume. This module keeps only its own seams: header auth
+ * via the injected `fetch`, the clock-driven reconnect wait, and `ActivityChanged`
+ * translation (carrying the frame's `agentPath` so the module refetches just
+ * that agent).
+ *
+ * TWO subscriptions per SDK, by design. The agents module opens its own
+ * `/v1/events` read for `AgentsChanged`; this one reads `ActivityChanged`.
+ * Sharing ONE read would mean folding both filters into a kernel-owned
+ * fan-out and refactoring the agents module — out of scope here. The costly
+ * piece (the reconnect/read loop) is REUSED via `streamGlobalEvents`; only a
+ * second cheap SSE connection is added, mirroring how the web adapter already
+ * runs its `subscribeEvents` read alongside the SDK's.
+ *
+ * On EVERY (re)connect the caller refetches ({@link onConnect}), so events
+ * missed while the stream was down are caught up by the reload.
+ */
+
+import { streamGlobalEvents } from "@houston/runtime-client";
+import type { Clock, SdkLogger } from "../../ports";
+import { ACTIVITY_CHANGED_EVENT } from "./types";
+
+/** Fixed short reconnect delay, mirroring the shared helper's default. */
+const RECONNECT_DELAY_MS = 1500;
+
+export interface ActivitiesStreamHandlers {
+  /** (Re)connected — refetch known agents' activities to catch up missed events. */
+  onConnect(): void;
+  /**
+   * An `ActivityChanged` frame arrived. `agentPath` names the agent whose
+   * activities changed (absent on a malformed frame → refetch all known).
+   */
+  onActivityChanged(agentPath: string | undefined): void;
+  /** A `401` proved the Houston session token lapsed. */
+  onUnauthorized(): void;
+}
+
+export interface ActivitiesStreamDeps {
+  baseUrl: string;
+  fetch: typeof fetch;
+  clock: Clock;
+  logger: SdkLogger;
+  handlers: ActivitiesStreamHandlers;
+}
+
+/** Start the subscription. Returns a stop function that aborts it for good. */
+export function startActivitiesEventStream(
+  deps: ActivitiesStreamDeps,
+): () => void {
+  const ac = new AbortController();
+  const { clock, logger, handlers } = deps;
+  const root = deps.baseUrl.replace(/\/+$/, "");
+  void streamGlobalEvents({
+    url: () => `${root}/v1/events`,
+    fetch: deps.fetch,
+    signal: ac.signal,
+    delayMs: RECONNECT_DELAY_MS,
+    sleep: (ms, signal) => sleep(clock, ms, signal),
+    onConnect: () => handlers.onConnect(),
+    onUnauthorized: () => handlers.onUnauthorized(),
+    onError: (err) =>
+      logger.debug("activities event stream dropped", { error: String(err) }),
+    onEvent: (data) => {
+      const agentPath = activityChangedAgent(data);
+      if (agentPath !== null) handlers.onActivityChanged(agentPath);
+    },
+  });
+  return () => ac.abort();
+}
+
+/**
+ * The agent id off an `ActivityChanged` frame, `undefined` when the frame omits
+ * it, or `null` when the frame is not an `ActivityChanged` (not our signal).
+ */
+function activityChangedAgent(data: unknown): string | undefined | null {
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    (data as { type?: unknown }).type !== ACTIVITY_CHANGED_EVENT
+  )
+    return null;
+  const agentPath = (data as { agentPath?: unknown }).agentPath;
+  return typeof agentPath === "string" ? agentPath : undefined;
+}
+
+/** Backoff sleep on the injected clock, resolved early if the signal aborts. */
+function sleep(clock: Clock, ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) return resolve();
+    const id = clock.setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    function onAbort() {
+      clock.clearTimeout(id);
+      resolve();
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/sdk/src/modules/activities/http.ts
+++ b/packages/sdk/src/modules/activities/http.ts
@@ -1,0 +1,93 @@
+/**
+ * The per-agent activities REST calls, over the injected `fetch`.
+ *
+ * The runtime client (`@houston/runtime-client`) is scoped to one conversation
+ * and serves no typed `.houston` surface, so this module talks to the HOST's
+ * `/agents/:id/activities` routes directly through `ports.fetch` — the SAME
+ * routes `engine-adapter/control-plane.ts` uses. Auth rides the injected
+ * `fetch` (the host wires a bearer-attaching `fetch`), exactly as the agents
+ * module does.
+ *
+ * Errors never get swallowed: a non-2xx throws an {@link ActivitiesHttpError}
+ * carrying the HTTP `status`, which `CommandRegistry.dispatch` surfaces as an
+ * `ok: false` result. A `401` additionally fires {@link onUnauthorized} so a
+ * lapsed session token becomes a visible `tokenExpired` signal.
+ */
+
+import type { Activity, ActivityUpdate, NewActivity } from "@houston/protocol";
+import type { SdkPorts } from "../../ports";
+
+/** A failed `/activities` request. `status` is the upstream HTTP status. */
+export class ActivitiesHttpError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = "ActivitiesHttpError";
+  }
+}
+
+/** The activities operations the module (and mission search) need. */
+export interface ActivitiesHttp {
+  list(agentId: string): Promise<Activity[]>;
+  create(agentId: string, input: NewActivity): Promise<Activity>;
+  update(
+    agentId: string,
+    id: string,
+    update: ActivityUpdate,
+  ): Promise<Activity>;
+  remove(agentId: string, id: string): Promise<void>;
+}
+
+export function createActivitiesHttp(
+  baseUrl: string,
+  ports: SdkPorts,
+  onUnauthorized: () => void,
+): ActivitiesHttp {
+  const root = baseUrl.replace(/\/+$/, "");
+  const base = (agentId: string): string =>
+    `${root}/agents/${encodeURIComponent(agentId)}/activities`;
+
+  async function req(path: string, init?: RequestInit): Promise<Response> {
+    const res = await ports.fetch(path, {
+      ...init,
+      headers: { "Content-Type": "application/json", ...init?.headers },
+    });
+    if (!res.ok) {
+      if (res.status === 401) onUnauthorized();
+      const body = await res.text().catch(() => "");
+      throw new ActivitiesHttpError(
+        body || `activities request failed: ${res.status}`,
+        res.status,
+      );
+    }
+    return res;
+  }
+
+  return {
+    async list(agentId) {
+      const res = await req(base(agentId));
+      return ((await res.json()) as { items: Activity[] }).items;
+    },
+    async create(agentId, input) {
+      const res = await req(base(agentId), {
+        method: "POST",
+        body: JSON.stringify(input),
+      });
+      return (await res.json()) as Activity;
+    },
+    async update(agentId, id, update) {
+      const res = await req(`${base(agentId)}/${encodeURIComponent(id)}`, {
+        method: "PATCH",
+        body: JSON.stringify(update),
+      });
+      return (await res.json()) as Activity;
+    },
+    async remove(agentId, id) {
+      await req(`${base(agentId)}/${encodeURIComponent(id)}`, {
+        method: "DELETE",
+      });
+    },
+  };
+}

--- a/packages/sdk/src/modules/activities/index.ts
+++ b/packages/sdk/src/modules/activities/index.ts
@@ -1,0 +1,185 @@
+/**
+ * The activities module — the SDK-canonical board/missions read/write surface,
+ * one reactive scope per agent (`activities/<agentId>`), holding an
+ * {@link ActivitiesViewModel}. It mirrors what the desktop builds mission cards
+ * from (`app/src/components/use-mission-control.ts`).
+ *
+ * Reads: `refresh(agentId)` publishes the agent's `activities/<agentId>`
+ * snapshot, republished whole on every change. Writes (`create`, `setStatus`,
+ * `rename`, `delete`) mutate then refetch, so the snapshot always reflects the
+ * host. The same handlers back both the typed facade and the bridge `dispatch`
+ * path, so there is one implementation each.
+ *
+ * Reactivity: a `/v1/events` subscription refetches on every (re)connect and on
+ * each `ActivityChanged` frame for an agent we've loaded. 401s route through the
+ * shared {@link ModuleContext.authExpiry} notifier.
+ */
+
+import type { ModuleContext } from "../../module-context";
+import { startActivitiesEventStream } from "./events-stream";
+import { createActivitiesHttp } from "./http";
+import {
+  parseCreate,
+  parseDelete,
+  parseRefresh,
+  parseRename,
+  parseSetStatus,
+} from "./payloads";
+import {
+  ActivitiesCommand,
+  type ActivitiesModule,
+  type ActivitiesViewModel,
+  activitiesScope,
+  type CreatedActivity,
+  sessionKeyOf,
+  toActivityItem,
+} from "./types";
+
+export { ActivitiesHttpError } from "./http";
+export type {
+  ActivitiesModule,
+  ActivitiesViewModel,
+  ActivityItem,
+  CreatedActivity,
+} from "./types";
+export {
+  ACTIVITY_CHANGED_EVENT,
+  ACTIVITY_STATUSES,
+  ActivitiesCommand,
+  type ActivitiesCommandType,
+  activitiesScope,
+} from "./types";
+
+export function createActivitiesModule(ctx: ModuleContext): ActivitiesModule {
+  const { store, authExpiry } = ctx;
+  const { baseUrl, ports } = ctx.config;
+  const emitTokenExpired = () => authExpiry.notifyExpired();
+  const http = createActivitiesHttp(baseUrl, ports, emitTokenExpired);
+
+  /** Agents we've loaded at least once — the set the reactivity stream refetches. */
+  const known = new Set<string>();
+  // Monotonic per-agent request sequence, so a slow refetch that resolves after
+  // a newer one never flushes stale rows over the fresh snapshot (last-intent
+  // wins). Mirrors the conversations module's guard.
+  const loadSeq = new Map<string, number>();
+
+  // `silent` skips the intermediate `loaded:false` republish. An explicit
+  // (user) refresh signals loading so a surface can show a spinner; a
+  // background catch-up refetch (connect/event-driven) is silent — it must not
+  // flash the list to "loading" on every reactivity tick (and it keeps the
+  // already-loaded snapshot stable for a synchronous reader).
+  async function refresh(agentId: string, silent = false): Promise<void> {
+    known.add(agentId);
+    const scope = activitiesScope(agentId);
+    const seq = (loadSeq.get(agentId) ?? 0) + 1;
+    loadSeq.set(agentId, seq);
+    if (!silent) {
+      // Signal loading while keeping any prior items to avoid a flush-to-empty.
+      const prior = store.getSnapshot(scope) as ActivitiesViewModel | undefined;
+      store.publish(scope, { loaded: false, items: prior?.items ?? [] });
+    }
+    const items = await http.list(agentId);
+    if (loadSeq.get(agentId) === seq)
+      store.publish(scope, {
+        loaded: true,
+        items: items.map(toActivityItem),
+      } satisfies ActivitiesViewModel);
+  }
+
+  async function create(
+    agentId: string,
+    title: string,
+    description?: string,
+  ): Promise<CreatedActivity> {
+    const activity = await http.create(agentId, {
+      title,
+      ...(description !== undefined ? { description } : {}),
+    });
+    await refresh(agentId);
+    return { id: activity.id, sessionKey: sessionKeyOf(activity) };
+  }
+
+  async function setStatus(
+    agentId: string,
+    id: string,
+    status: string,
+  ): Promise<void> {
+    await http.update(agentId, id, { status });
+    await refresh(agentId);
+  }
+  async function rename(
+    agentId: string,
+    id: string,
+    title: string,
+  ): Promise<void> {
+    await http.update(agentId, id, { title });
+    await refresh(agentId);
+  }
+  async function del(agentId: string, id: string): Promise<void> {
+    await http.remove(agentId, id);
+    await refresh(agentId);
+  }
+
+  ctx.registerCommand(ActivitiesCommand.Refresh, (p) =>
+    refresh(parseRefresh(p).agentId),
+  );
+  ctx.registerCommand(ActivitiesCommand.Create, (p) => {
+    const { agentId, title, description } = parseCreate(p);
+    return create(agentId, title, description);
+  });
+  ctx.registerCommand(ActivitiesCommand.SetStatus, (p) => {
+    const { agentId, id, status } = parseSetStatus(p);
+    return setStatus(agentId, id, status);
+  });
+  ctx.registerCommand(ActivitiesCommand.Rename, (p) => {
+    const { agentId, id, title } = parseRename(p);
+    return rename(agentId, id, title);
+  });
+  ctx.registerCommand(ActivitiesCommand.Delete, (p) => {
+    const { agentId, id } = parseDelete(p);
+    return del(agentId, id);
+  });
+
+  // A stream-driven refetch is not a user action: a transient failure just
+  // leaves the snapshot stale until the next event. A 401 still surfaces (http
+  // fires emitTokenExpired), so only the noise is logged, never swallowed.
+  const backgroundRefresh = (agentId: string, where: string) =>
+    void refresh(agentId, true).catch((err) =>
+      ports.logger.debug(`activities refresh (${where}) failed`, {
+        error: String(err),
+        agentId,
+      }),
+    );
+
+  const dispose = startActivitiesEventStream({
+    baseUrl,
+    fetch: ports.fetch,
+    clock: ports.clock,
+    logger: ports.logger,
+    handlers: {
+      onConnect: () => {
+        for (const id of known) backgroundRefresh(id, "connect");
+      },
+      onActivityChanged: (agentPath) => {
+        // Targeted: only an agent we're showing. A frame with no agentPath can't
+        // be targeted, so refetch every known agent (catch-up, never a miss).
+        if (agentPath === undefined) {
+          for (const id of known) backgroundRefresh(id, "change");
+        } else if (known.has(agentPath)) {
+          backgroundRefresh(agentPath, "change");
+        }
+      },
+      onUnauthorized: emitTokenExpired,
+    },
+  });
+
+  return {
+    scope: activitiesScope,
+    refresh,
+    create,
+    setStatus,
+    rename,
+    delete: del,
+    dispose,
+  };
+}

--- a/packages/sdk/src/modules/activities/payloads.ts
+++ b/packages/sdk/src/modules/activities/payloads.ts
@@ -1,0 +1,71 @@
+/**
+ * Untrusted command-payload parsers for the activities module. The bridge
+ * (`dispatch`) hands these raw JSON; each parser throws on a bad shape
+ * (`CommandRegistry.dispatch` turns the throw into an `ok: false` result).
+ */
+
+/** Pull a required non-empty string off an untrusted command payload. */
+function requireString(payload: unknown, key: string): string {
+  const value =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>)[key]
+      : undefined;
+  if (typeof value !== "string" || value.length === 0)
+    throw new Error(`missing '${key}'`);
+  return value;
+}
+
+/** Pull an optional string off an untrusted command payload. */
+function optionalString(payload: unknown, key: string): string | undefined {
+  const value =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>)[key]
+      : undefined;
+  return typeof value === "string" ? value : undefined;
+}
+
+export interface RefreshArgs {
+  agentId: string;
+}
+export interface CreateArgs {
+  agentId: string;
+  title: string;
+  description?: string;
+}
+export interface SetStatusArgs {
+  agentId: string;
+  id: string;
+  status: string;
+}
+export interface RenameArgs {
+  agentId: string;
+  id: string;
+  title: string;
+}
+export interface DeleteArgs {
+  agentId: string;
+  id: string;
+}
+
+export const parseRefresh = (p: unknown): RefreshArgs => ({
+  agentId: requireString(p, "agentId"),
+});
+export const parseCreate = (p: unknown): CreateArgs => ({
+  agentId: requireString(p, "agentId"),
+  title: requireString(p, "title"),
+  description: optionalString(p, "description"),
+});
+export const parseSetStatus = (p: unknown): SetStatusArgs => ({
+  agentId: requireString(p, "agentId"),
+  id: requireString(p, "id"),
+  status: requireString(p, "status"),
+});
+export const parseRename = (p: unknown): RenameArgs => ({
+  agentId: requireString(p, "agentId"),
+  id: requireString(p, "id"),
+  title: requireString(p, "title"),
+});
+export const parseDelete = (p: unknown): DeleteArgs => ({
+  agentId: requireString(p, "agentId"),
+  id: requireString(p, "id"),
+});

--- a/packages/sdk/src/modules/activities/types.ts
+++ b/packages/sdk/src/modules/activities/types.ts
@@ -1,0 +1,132 @@
+/**
+ * Wire + view-model types for the activities module — the board/missions read
+ * surface the desktop builds its mission cards from
+ * (`app/src/components/use-mission-control.ts`).
+ *
+ * The `activities/<agentId>` scope snapshot is the SDK-canonical version of what
+ * the web control-plane adapter reads (`listActivities` →
+ * `GET /agents/:id/activities` → `{ items }`), republished whole on every
+ * change. Everything here is plain JSON — it crosses the
+ * `getSnapshot`/`subscribe` boundary unchanged. Fields are exactly what the wire
+ * `Activity` provides; nothing is invented.
+ */
+
+import type { Activity } from "@houston/protocol";
+
+/**
+ * The canonical activity statuses (`packages/domain/src/activities.ts`,
+ * `ui/agent-schemas/activity.schema.json`). `status` is typed `string`, not this
+ * union: the domain PRESERVES unknown statuses (forward-compat), so a surface
+ * renders an unrecognized one neutrally. This constant is the known vocabulary
+ * for a surface that maps statuses to columns, not a validation gate.
+ */
+export const ACTIVITY_STATUSES = [
+  "running",
+  "needs_you",
+  "done",
+  "error",
+  "archived",
+] as const;
+
+/** One board item inside the `activities/<agentId>` scope snapshot. */
+export interface ActivityItem {
+  id: string;
+  title: string;
+  /** The user's first message (raw; a surface decodes the `houston:` marker). */
+  description?: string;
+  /** Canonical status incl. `archived`; unknown values pass through unchanged. */
+  status: string;
+  /** ISO timestamp of the last change, when the wire carries one. */
+  updatedAt?: string;
+  /** The chat/session address — the wire's `session_key`, or `activity-<id>`. */
+  sessionKey: string;
+  /** Present when this activity is a routine's chat. */
+  routineId?: string;
+  /** The agent-mode/config the mission runs under, when set. */
+  agent?: string;
+  worktreePath?: string | null;
+  provider?: string;
+  model?: string;
+}
+
+/**
+ * The `activities/<agentId>` scope view-model: the WHOLE snapshot, republished
+ * on any change. `loaded` is false until the first list resolves.
+ */
+export interface ActivitiesViewModel {
+  loaded: boolean;
+  items: ActivityItem[];
+}
+
+/** The result of creating a mission: its id + the chat session to open (PARITY §6). */
+export interface CreatedActivity {
+  id: string;
+  sessionKey: string;
+}
+
+/** The typed facade for board/missions reads + writes. */
+export interface ActivitiesModule {
+  /** Scope string for `sdk.subscribe(...)` / `sdk.getSnapshot(...)`. */
+  scope(agentId: string): string;
+  /** Refetch the agent's activities and republish its scope snapshot. */
+  refresh(agentId: string): Promise<void>;
+  /** Create a mission (status `running`), then refetch. Returns id + sessionKey. */
+  create(
+    agentId: string,
+    title: string,
+    description?: string,
+  ): Promise<CreatedActivity>;
+  /** Transition a mission's status (approve→done, archive, reactivate), then refetch. */
+  setStatus(agentId: string, id: string, status: string): Promise<void>;
+  /** Rename a mission, then refetch. */
+  rename(agentId: string, id: string, title: string): Promise<void>;
+  /** Delete a mission, then refetch. */
+  delete(agentId: string, id: string): Promise<void>;
+  /** Stop the reactivity stream. Module-local; the kernel calls it on dispose. */
+  dispose(): void;
+}
+
+/** The reactive scope this module owns, per agent. */
+export const activitiesScope = (agentId: string): string =>
+  `activities/${agentId}`;
+
+/** The command types this module registers. Typed to defeat string drift. */
+export const ActivitiesCommand = {
+  Refresh: "activities/refresh",
+  Create: "activities/create",
+  SetStatus: "activities/setStatus",
+  Rename: "activities/rename",
+  Delete: "activities/delete",
+} as const;
+export type ActivitiesCommandType =
+  (typeof ActivitiesCommand)[keyof typeof ActivitiesCommand];
+
+/** The host wire-event `type` that means an agent's activities changed. */
+export const ACTIVITY_CHANGED_EVENT = "ActivityChanged";
+
+/**
+ * The board's session address for an activity: the explicit `session_key`, or
+ * the `activity-<id>` convention the board uses for missions with no explicit
+ * key (PARITY §6). A routine chat carries its own `session_key`.
+ */
+export function sessionKeyOf(a: Activity): string {
+  return a.session_key ?? `activity-${a.id}`;
+}
+
+/** Project a wire `Activity` onto the scope view-model item. Lossless for the
+ *  fields a surface reads; omits empty optionals so the snapshot stays clean. */
+export function toActivityItem(a: Activity): ActivityItem {
+  return {
+    id: a.id,
+    title: a.title,
+    status: a.status,
+    sessionKey: sessionKeyOf(a),
+    ...(a.description ? { description: a.description } : {}),
+    ...(a.updated_at !== undefined ? { updatedAt: a.updated_at } : {}),
+    ...(a.routine_id !== undefined ? { routineId: a.routine_id } : {}),
+    ...(a.agent !== undefined ? { agent: a.agent } : {}),
+    ...(a.worktree_path !== undefined ? { worktreePath: a.worktree_path } : {}),
+    ...(a.provider !== undefined ? { provider: a.provider } : {}),
+    ...(a.model !== undefined ? { model: a.model } : {}),
+  };
+}

--- a/packages/sdk/src/modules/missions-search/index.ts
+++ b/packages/sdk/src/modules/missions-search/index.ts
@@ -1,0 +1,180 @@
+/**
+ * The mission-search module — ranked full-text search over an agent's (or every
+ * agent's) missions, mirroring the desktop's semantics EXACTLY
+ * (`app/src/components/mission-search.ts`, PARITY §3): a TITLE match first, then
+ * a DESCRIPTION match, then the mission's lazily-fetched chat-history CONTENT,
+ * over the same per-feed-item searchable text. History is fetched ONLY for
+ * missions not already matched by title/description, with bounded concurrency
+ * and NO observers (a plain `getHistory`, never a stream). Search runs over ALL
+ * statuses (active + archived), as the board does.
+ *
+ * This is a pure command (`missions/search`) — it returns ranked matches, it
+ * publishes no scope and holds no long-lived resource.
+ */
+
+import type { Activity } from "@houston/protocol";
+import type { ModuleContext } from "../../module-context";
+import { createActivitiesHttp } from "../activities/http";
+import { sessionKeyOf } from "../activities/types";
+import { historyToFeed } from "../turns/history";
+import {
+  buildHistorySearchText,
+  extractSnippet,
+  matchesPhrase,
+  normalizeQuery,
+} from "./search-text";
+
+/** Where in a mission the query matched. Ranked in this order. */
+export type MatchedIn = "title" | "description" | "content";
+
+/** One ranked mission match. `snippet` is omitted for a title match (the title
+ *  already shows the phrase and is never highlighted, per the desktop). */
+export interface MissionMatch {
+  agentId: string;
+  activityId: string;
+  sessionKey: string;
+  title: string;
+  snippet?: string;
+  matchedIn: MatchedIn;
+}
+
+/** The typed facade for mission search. */
+export interface MissionsSearchModule {
+  /** Search `query` across `agentId`'s missions, or every agent's when omitted. */
+  search(query: string, agentId?: string): Promise<MissionMatch[]>;
+}
+
+/** How many history fetches (or agent activity lists) run at once. */
+const CONCURRENCY = 4;
+
+/** Run `fn` over `items` with at most `limit` in flight, preserving no order. */
+async function mapLimit<T>(
+  items: readonly T[],
+  limit: number,
+  fn: (item: T) => Promise<void>,
+): Promise<void> {
+  let i = 0;
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () =>
+    (async () => {
+      while (i < items.length) {
+        const item = items[i++];
+        await fn(item);
+      }
+    })(),
+  );
+  await Promise.all(workers);
+}
+
+interface Candidate {
+  agentId: string;
+  activity: Activity;
+}
+
+export function createMissionsSearchModule(
+  ctx: ModuleContext,
+): MissionsSearchModule {
+  const { config, clientFor, authExpiry } = ctx;
+  const { baseUrl, ports } = config;
+  const root = baseUrl.replace(/\/+$/, "");
+  const emitTokenExpired = () => authExpiry.notifyExpired();
+  const http = createActivitiesHttp(baseUrl, ports, emitTokenExpired);
+
+  /** The agents to search: the one given, else the whole personal workspace. */
+  async function resolveAgentIds(agentId?: string): Promise<string[]> {
+    if (agentId) return [agentId];
+    const res = await ports.fetch(`${root}/agents`, {
+      headers: { "Content-Type": "application/json" },
+    });
+    if (!res.ok) {
+      if (res.status === 401) emitTokenExpired();
+      throw new Error(`agents request failed: ${res.status}`);
+    }
+    return ((await res.json()) as { id: string }[]).map((a) => a.id);
+  }
+
+  function match(
+    c: Candidate,
+    matchedIn: MatchedIn,
+    snippet: string | null,
+  ): MissionMatch {
+    return {
+      agentId: c.agentId,
+      activityId: c.activity.id,
+      sessionKey: sessionKeyOf(c.activity),
+      title: c.activity.title,
+      matchedIn,
+      ...(snippet ? { snippet } : {}),
+    };
+  }
+
+  async function search(
+    query: string,
+    agentId?: string,
+  ): Promise<MissionMatch[]> {
+    const folded = normalizeQuery(query);
+    if (!folded) return [];
+
+    const agentIds = await resolveAgentIds(agentId);
+    const candidates: Candidate[] = [];
+    await mapLimit(agentIds, CONCURRENCY, async (id) => {
+      for (const activity of await http.list(id))
+        candidates.push({ agentId: id, activity });
+    });
+
+    const titleMatches: MissionMatch[] = [];
+    const descriptionMatches: MissionMatch[] = [];
+    const unmatched: Candidate[] = [];
+    for (const c of candidates) {
+      if (matchesPhrase(c.activity.title, folded)) {
+        titleMatches.push(match(c, "title", null));
+        continue;
+      }
+      const description = c.activity.description ?? "";
+      if (description && matchesPhrase(description, folded)) {
+        descriptionMatches.push(
+          match(c, "description", extractSnippet(description, folded)),
+        );
+        continue;
+      }
+      unmatched.push(c);
+    }
+
+    // Lazily search chat-history content for the still-unmatched missions,
+    // bounded so N missions never spawn N simultaneous fetches. A per-mission
+    // history failure degrades that mission (mirrors the desktop's non-fatal
+    // "couldn't search every mission" notice) — logged through the port, never
+    // silently dropped, and never failing the matches we already have.
+    const contentMatches: MissionMatch[] = [];
+    await mapLimit(unmatched, CONCURRENCY, async (c) => {
+      const sessionKey = sessionKeyOf(c.activity);
+      let text: string;
+      try {
+        const { messages } = await clientFor(c.agentId).getHistory(sessionKey);
+        text = buildHistorySearchText(historyToFeed(messages));
+      } catch (err) {
+        ports.logger.warn("mission search: history fetch failed", {
+          agentId: c.agentId,
+          sessionKey,
+          error: String(err),
+        });
+        return;
+      }
+      if (text && matchesPhrase(text, folded))
+        contentMatches.push(match(c, "content", extractSnippet(text, folded)));
+    });
+
+    return [...titleMatches, ...descriptionMatches, ...contentMatches];
+  }
+
+  ctx.registerCommand("missions/search", (payload) => {
+    const p = (payload ?? {}) as Record<string, unknown>;
+    if (typeof p.query !== "string")
+      throw new Error("missions/search requires a string query");
+    return search(
+      p.query,
+      typeof p.agentId === "string" ? p.agentId : undefined,
+    );
+  });
+
+  return { search };
+}

--- a/packages/sdk/src/modules/missions-search/search-text.test.ts
+++ b/packages/sdk/src/modules/missions-search/search-text.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { FeedFrame } from "../turns/history";
+import {
+  buildHistorySearchText,
+  extractSnippet,
+  matchesPhrase,
+  normalizeQuery,
+} from "./search-text";
+
+describe("normalizeQuery", () => {
+  it("folds accents/case and collapses internal whitespace to a phrase", () => {
+    expect(normalizeQuery("  Café   Crème ")).toBe("cafe creme");
+  });
+});
+
+describe("matchesPhrase", () => {
+  it("matches a folded phrase contiguously, whitespace flexible", () => {
+    const q = normalizeQuery("this month");
+    expect(matchesPhrase("plan for this\nmonth", q)).toBe(true);
+    // Scattered words are NOT a phrase match.
+    expect(matchesPhrase("this quarter, next month", q)).toBe(false);
+  });
+
+  it("is accent-insensitive both ways", () => {
+    expect(matchesPhrase("Tökyö", normalizeQuery("tokyo"))).toBe(true);
+  });
+
+  it("does not match an empty query or empty text", () => {
+    expect(matchesPhrase("anything", "")).toBe(false);
+    expect(matchesPhrase(undefined, normalizeQuery("x"))).toBe(false);
+  });
+});
+
+describe("extractSnippet", () => {
+  it("centers a clipped fragment on the first match with ellipses", () => {
+    const text = `${"a ".repeat(60)}the needle here ${"b ".repeat(60)}`;
+    const snip = extractSnippet(text, normalizeQuery("needle"));
+    expect(snip).not.toBeNull();
+    expect(snip).toContain("needle");
+    expect(snip?.startsWith("…")).toBe(true);
+    expect(snip?.endsWith("…")).toBe(true);
+  });
+
+  it("returns null when the phrase is absent", () => {
+    expect(extractSnippet("nothing here", normalizeQuery("absent"))).toBeNull();
+  });
+});
+
+describe("buildHistorySearchText", () => {
+  it("extracts per-frame searchable text mirroring the desktop", () => {
+    const frames: FeedFrame[] = [
+      { feed_type: "user_message", data: "deploy the api" },
+      { feed_type: "tool_call", data: { name: "shell", input: { cmd: "ls" } } },
+      { feed_type: "tool_result", data: { content: "ok", is_error: false } },
+      { feed_type: "assistant_text", data: "done deploying" },
+      {
+        feed_type: "final_result",
+        data: { result: "shipped", cost_usd: null, duration_ms: null },
+      },
+    ];
+    const text = buildHistorySearchText(frames);
+    expect(text).toContain("deploy the api");
+    expect(text).toContain("shell");
+    expect(text).toContain("ls");
+    expect(text).toContain("ok");
+    expect(text).toContain("done deploying");
+    expect(text).toContain("shipped");
+  });
+});

--- a/packages/sdk/src/modules/missions-search/search-text.ts
+++ b/packages/sdk/src/modules/missions-search/search-text.ts
@@ -1,0 +1,135 @@
+/**
+ * Mission-search text matching — ported from the desktop's `mission-search.ts`
+ * + `mission-highlight.ts` so the SDK matches EXACTLY what the board does:
+ * accent/case-insensitive, multi-word phrase matched contiguously with flexible
+ * whitespace, over the same per-feed-item searchable text.
+ *
+ * Headless: the desktop's `HighlightRange` output (a `@houston-ai/core` type) is
+ * a surface concern, so this port returns only the plain snippet STRING and a
+ * boolean match — a native surface re-highlights the phrase itself.
+ */
+
+import type { FeedFrame } from "../turns/history";
+
+const COMBINING_MARKS = /[\u0300-\u036f]/g;
+
+/** Fold one character for accent/case-insensitive matching. */
+function foldChar(char: string): string {
+  return char.normalize("NFKD").replace(COMBINING_MARKS, "").toLowerCase();
+}
+
+/** Fold a whole string for matching (case-folded, accents stripped). */
+export function foldForSearch(text: string): string {
+  let folded = "";
+  for (let i = 0; i < text.length; i++) folded += foldChar(text[i]);
+  return folded;
+}
+
+/** Fold `text` while recording, per folded char, the source char index. */
+function foldWithMap(text: string): { folded: string; map: number[] } {
+  let folded = "";
+  const map: number[] = [];
+  for (let i = 0; i < text.length; i++) {
+    const f = foldChar(text[i]);
+    for (let j = 0; j < f.length; j++) {
+      folded += f[j];
+      map.push(i);
+    }
+  }
+  map.push(text.length);
+  return { folded, map };
+}
+
+const REGEXP_SPECIALS = /[.*+?^${}()|[\]\\]/g;
+
+/** Regex source matching the folded phrase contiguously, whitespace flexible. */
+function phrasePattern(phrase: string): string {
+  const words = phrase.split(/\s+/).filter(Boolean);
+  if (words.length === 0) return "";
+  return words.map((w) => w.replace(REGEXP_SPECIALS, "\\$&")).join("\\s+");
+}
+
+/** Fold + collapse internal whitespace so a multi-word query matches as a phrase. */
+export function normalizeQuery(value: string): string {
+  return foldForSearch(value).replace(/\s+/g, " ").trim();
+}
+
+/** Whether `text` contains the already-folded `phrase`. */
+export function matchesPhrase(
+  text: string | undefined,
+  foldedPhrase: string,
+): boolean {
+  const pattern = phrasePattern(foldedPhrase);
+  if (!text || !pattern) return false;
+  return new RegExp(pattern).test(foldForSearch(text));
+}
+
+/**
+ * A short fragment of `text` centered on the first match of the already-folded
+ * `phrase`, with ellipses where clipped — the "why did this match" snippet.
+ * Null when the phrase does not occur.
+ */
+export function extractSnippet(
+  text: string,
+  foldedPhrase: string,
+  radius = 48,
+): string | null {
+  const pattern = phrasePattern(foldedPhrase);
+  if (!text || !pattern) return null;
+  const { folded, map } = foldWithMap(text);
+  const match = new RegExp(pattern).exec(folded);
+  if (!match || match[0].length === 0) return null;
+  const start = map[match.index];
+  const end = Math.max(map[match.index + match[0].length], start + 1);
+
+  const windowStart = Math.max(0, start - radius);
+  const windowEnd = Math.min(text.length, end + radius);
+  const prefix = windowStart > 0 ? "…" : "";
+  const suffix = windowEnd < text.length ? "…" : "";
+  const slice = text.slice(windowStart, windowEnd).replace(/\s+/g, " ").trim();
+  if (!slice) return null;
+  return `${prefix}${slice}${suffix}`;
+}
+
+/** Stringify a feed frame's `data` value for search (mirrors the desktop). */
+function valueToText(value: unknown): string {
+  if (typeof value === "string") return value;
+  if (value == null) return "";
+  if (typeof value === "number" || typeof value === "boolean")
+    return String(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return "";
+  }
+}
+
+/** The searchable text of one folded history frame (per-type, as the desktop does). */
+function frameToSearchText(frame: FeedFrame): string {
+  const data = frame.data;
+  switch (frame.feed_type) {
+    case "user_message":
+      return typeof data === "string" ? data : "";
+    case "tool_call": {
+      const d = data as { name?: string; input?: unknown };
+      return `${d?.name ?? ""} ${valueToText(d?.input)}`;
+    }
+    case "tool_result":
+      return (data as { content?: string })?.content ?? "";
+    case "tool_runtime_error":
+      return "";
+    case "file_changes": {
+      const d = data as { created?: string[]; modified?: string[] };
+      return [...(d?.created ?? []), ...(d?.modified ?? [])].join("\n");
+    }
+    case "final_result":
+      return (data as { result?: string })?.result ?? "";
+    default:
+      return valueToText(data);
+  }
+}
+
+/** The full searchable text of a folded conversation transcript. */
+export function buildHistorySearchText(frames: FeedFrame[]): string {
+  return frames.map(frameToSearchText).filter(Boolean).join("\n");
+}

--- a/packages/sdk/src/modules/turns/history.test.ts
+++ b/packages/sdk/src/modules/turns/history.test.ts
@@ -1,0 +1,104 @@
+import type { ChatMessage } from "@houston/runtime-client";
+import { describe, expect, it } from "vitest";
+import { historyToFeed } from "./history";
+
+describe("historyToFeed", () => {
+  it("folds a user + assistant turn into user_message, assistant_text, final_result", () => {
+    const messages: ChatMessage[] = [
+      { role: "user", content: "hi", ts: 1 },
+      {
+        role: "assistant",
+        content: "hello",
+        ts: 2,
+        usage: { context_tokens: 10, output_tokens: 2, cached_tokens: 0 },
+      },
+    ];
+    expect(historyToFeed(messages)).toEqual([
+      { feed_type: "user_message", data: "hi", author: undefined },
+      { feed_type: "assistant_text", data: "hello" },
+      {
+        feed_type: "final_result",
+        data: {
+          result: "hello",
+          cost_usd: null,
+          duration_ms: null,
+          usage: { context_tokens: 10, output_tokens: 2, cached_tokens: 0 },
+        },
+      },
+    ]);
+  });
+
+  it("carries the pi provider id through unchanged by default (identity map)", () => {
+    const feed = historyToFeed([
+      {
+        role: "assistant",
+        content: "on codex now",
+        ts: 1,
+        providerSwitch: { provider: "openai-codex", summarized: false },
+      },
+    ]);
+    expect(feed.find((f) => f.feed_type === "provider_switched")?.data).toEqual(
+      {
+        provider: "openai-codex",
+        summarized: false,
+        pre_tokens: undefined,
+      },
+    );
+  });
+
+  it("applies a caller's provider map to switch dividers and error cards", () => {
+    const map = (id: string) => (id === "openai-codex" ? "openai" : id);
+    const feed = historyToFeed(
+      [
+        {
+          role: "assistant",
+          content: "",
+          ts: 1,
+          providerError: {
+            kind: "unauthenticated",
+            provider: "openai-codex",
+            cause: "token_revoked",
+            message: "Your session has ended. Please log in again.",
+          },
+        },
+      ],
+      map,
+    );
+    expect(feed.find((f) => f.feed_type === "provider_error")?.data).toEqual({
+      kind: "unauthenticated",
+      provider: "openai",
+      cause: "token_revoked",
+      message: "Your session has ended. Please log in again.",
+    });
+  });
+
+  it("replays tool calls and preserves a multiplayer author on user messages", () => {
+    const feed = historyToFeed([
+      {
+        role: "user",
+        content: "run it",
+        ts: 1,
+        author: { userId: "u1", name: "Ada" },
+      },
+      {
+        role: "assistant",
+        content: "done",
+        ts: 2,
+        tools: [{ name: "shell", isError: true }],
+      },
+    ]);
+    expect(feed[0]).toEqual({
+      feed_type: "user_message",
+      data: "run it",
+      author: { userId: "u1", name: "Ada" },
+    });
+    expect(feed).toContainEqual({
+      feed_type: "tool_call",
+      data: { name: "shell", input: {} },
+    });
+    expect(feed).toContainEqual({
+      feed_type: "tool_result",
+      data: { content: "", is_error: true },
+    });
+  });
+});

--- a/packages/sdk/src/modules/turns/history.ts
+++ b/packages/sdk/src/modules/turns/history.ts
@@ -1,0 +1,98 @@
+/**
+ * The persisted-history → feed fold: turn a conversation's `ChatMessage[]`
+ * (the `getHistory` transcript) into the flat feed frames a client replays to
+ * rebuild the chat.
+ *
+ * THE one implementation of that fold. The SDK uses it to seed a conversation's
+ * reactive VM (the `turns/history` read and the `observe` hydration seam), and
+ * the web engine-adapter delegates to it (`engine-adapter/translate.ts`) with
+ * its OWN provider-id remap — so a wire change to what history carries lands in
+ * exactly one place. The provider id is carried through untouched by default
+ * (the SDK is provider-id-agnostic); a caller that renders old frontend ids
+ * passes a `mapProvider`.
+ */
+
+import type { ChatMessage } from "@houston/runtime-client";
+
+/**
+ * One replayed feed frame: the SAME `{ feed_type, data }` push the turn
+ * machinery emits, plus the optional multiplayer `author` on a user message
+ * (carried so a shared conversation attributes each teammate's bubble on
+ * reload). Plain JSON — it crosses the SDK/bridge boundary unchanged.
+ */
+export interface FeedFrame {
+  feed_type: string;
+  data: unknown;
+  /** Multiplayer only: who wrote a `user_message`. Absent single-player. */
+  author?: { userId: string; name?: string };
+}
+
+/** Identity provider map — the SDK default (carry the pi id through). */
+const identityProvider = (id: string): string => id;
+
+/**
+ * Fold a conversation transcript into replayable feed frames. Mirrors the live
+ * turn machinery's output so a seeded transcript and a live turn render the
+ * same: streaming text collapses to one `assistant_text`, a persisted provider
+ * switch/error replays its divider/card, and a turn's usage replays as an
+ * (invisible) `final_result` so the context indicator survives a reload.
+ */
+export function historyToFeed(
+  messages: ChatMessage[],
+  mapProvider: (id: string) => string = identityProvider,
+): FeedFrame[] {
+  const out: FeedFrame[] = [];
+  for (const m of messages) {
+    if (m.role === "user") {
+      out.push({
+        feed_type: "user_message",
+        data: m.content,
+        author: m.author,
+      });
+      continue;
+    }
+    // A persisted provider switch: replay the boundary divider before this
+    // turn's content so it survives a reload (and the window estimate resets).
+    if (m.providerSwitch) {
+      out.push({
+        feed_type: "provider_switched",
+        data: {
+          provider: mapProvider(m.providerSwitch.provider),
+          summarized: m.providerSwitch.summarized,
+          pre_tokens: m.providerSwitch.pre_tokens,
+        },
+      });
+    }
+    // A persisted provider failure: replay the typed card so the inline
+    // reconnect / rate-limit surface survives a reload.
+    if (m.providerError) {
+      out.push({
+        feed_type: "provider_error",
+        data: {
+          ...m.providerError,
+          provider: mapProvider(m.providerError.provider),
+        },
+      });
+    }
+    for (const t of m.tools ?? []) {
+      out.push({ feed_type: "tool_call", data: { name: t.name, input: {} } });
+      out.push({
+        feed_type: "tool_result",
+        data: { content: "", is_error: !!t.isError },
+      });
+    }
+    if (m.content) out.push({ feed_type: "assistant_text", data: m.content });
+    if (m.usage) {
+      out.push({
+        feed_type: "final_result",
+        data: {
+          result: m.content,
+          cost_usd: null,
+          duration_ms: null,
+          usage: m.usage,
+        },
+      });
+    }
+  }
+  return out;
+}

--- a/packages/sdk/src/modules/turns/index.test.ts
+++ b/packages/sdk/src/modules/turns/index.test.ts
@@ -94,10 +94,11 @@ async function waitFor(cond: () => boolean, ms = 2_000): Promise<void> {
   }
 }
 
-test("registers the turns/send, turns/cancel and turns/observe commands", () => {
+test("registers the turns/send, turns/cancel, turns/observe and turns/history commands", () => {
   const { commands } = harness();
   expect([...commands.keys()].sort()).toEqual([
     "turns/cancel",
+    "turns/history",
     "turns/observe",
     "turns/send",
   ]);

--- a/packages/sdk/src/modules/turns/index.ts
+++ b/packages/sdk/src/modules/turns/index.ts
@@ -1,10 +1,12 @@
 import type { ModuleContext } from "../../module-context";
 import { type FeedOutput, MultiplexFeedOutput } from "./feed-output";
+import { type FeedFrame, historyToFeed } from "./history";
 import { resolveModelSettings } from "./model-settings";
 import { observeConversation } from "./observe-stream";
-import { StreamRegistry } from "./stream-registry";
+import { StreamRegistry, streamKey } from "./stream-registry";
 import {
   asCancelInput,
+  asHistoryInput,
   asObserveInput,
   asSendInput,
   type TurnSendInput,
@@ -63,19 +65,25 @@ export function createTurnsModule(ctx: ModuleContext) {
 
   /**
    * Passively attach to a conversation with a turn started elsewhere (another
-   * client) or before a reload — observer mode. Loads history to seed the legacy
-   * settle guard, then drives {@link observeConversation} into the SAME VM the
-   * `send` path uses, so a mobile client opening an in-flight conversation sees
-   * the running turn. An idle conversation self-closes (the observer settles to
-   * a coherent idle VM); a no-op if the conversation is already streamed here.
+   * client) or before a reload — observer mode. Loads history, folds it, and
+   * SEEDS the conversation VM's feed FIRST so a mobile client opening the chat
+   * sees the full transcript immediately — THEN attaches {@link
+   * observeConversation} into the SAME VM the `send` path uses, so an in-flight
+   * turn keeps rendering live. History also seeds the legacy settle guard
+   * (`messages.length`). An idle conversation self-closes; a no-op if the
+   * conversation is already streamed here — in which case we DON'T re-seed
+   * (that live feed already owns the VM), which is the double-render guard.
    */
   const observe = async (
     conversationId: string,
     agentId?: string,
   ): Promise<void> => {
     const client = ctx.clientFor(agentId ?? "");
+    const key = streamKey(agentId ?? "", conversationId);
     const { messages } = await client.getHistory(conversationId);
     const output = new MultiplexFeedOutput([vm, ...external]);
+    if (!registry.get(key))
+      vm.seedHistory(conversationId, historyToFeed(messages));
     observeConversation(
       client,
       agentId ?? "",
@@ -84,6 +92,21 @@ export function createTurnsModule(ctx: ModuleContext) {
       messages.length,
       registry,
     );
+  };
+
+  /**
+   * Read-only: fold a conversation's persisted transcript into feed frames (the
+   * same fold `observe` seeds the VM with). The `turns/history` command surfaces
+   * it to a native shell that wants the transcript without attaching a stream.
+   */
+  const history = async (
+    conversationId: string,
+    agentId?: string,
+  ): Promise<FeedFrame[]> => {
+    const { messages } = await ctx
+      .clientFor(agentId ?? "")
+      .getHistory(conversationId);
+    return historyToFeed(messages);
   };
 
   /** Abort a conversation's in-flight turn in the agent's sandbox. */
@@ -103,11 +126,16 @@ export function createTurnsModule(ctx: ModuleContext) {
     const { conversationId, agentId } = asObserveInput(payload);
     return observe(conversationId, agentId);
   });
+  ctx.registerCommand("turns/history", (payload) => {
+    const { conversationId, agentId } = asHistoryInput(payload);
+    return history(conversationId, agentId);
+  });
 
   return {
     send,
     cancel,
     observe,
+    history,
     /**
      * Attach an extra {@link FeedOutput} that every subsequent turn also drives
      * (e.g. a host UI bus). Returns a detach function.
@@ -132,6 +160,7 @@ export {
   type SessionStatusValue,
   type TerminalBoardStatus,
 } from "./feed-output";
+export { type FeedFrame, historyToFeed } from "./history";
 export { observeConversation } from "./observe-stream";
 export {
   SEND_IN_FLIGHT_MESSAGE,
@@ -147,6 +176,7 @@ export {
 } from "./turn-errors";
 export type {
   TurnCancelInput,
+  TurnHistoryInput,
   TurnObserveInput,
   TurnSendInput,
 } from "./turn-inputs";

--- a/packages/sdk/src/modules/turns/turn-inputs.ts
+++ b/packages/sdk/src/modules/turns/turn-inputs.ts
@@ -36,6 +36,14 @@ export interface TurnObserveInput {
   conversationId: string;
 }
 
+/** The `turns/history` command payload. */
+export interface TurnHistoryInput {
+  /** The agent whose sandbox holds the conversation (omit for the single local runtime). */
+  agentId?: string;
+  /** The conversation whose persisted transcript to fold into feed frames. */
+  conversationId: string;
+}
+
 const str = (v: unknown): string | undefined =>
   typeof v === "string" ? v : undefined;
 
@@ -70,5 +78,15 @@ export function asObserveInput(payload: unknown): TurnObserveInput {
   return {
     conversationId: id,
     agentId: str((payload as TurnObserveInput)?.agentId),
+  };
+}
+
+export function asHistoryInput(payload: unknown): TurnHistoryInput {
+  const id = (payload as { conversationId?: unknown })?.conversationId;
+  if (typeof id !== "string")
+    throw new Error("turns/history requires a string conversationId");
+  return {
+    conversationId: id,
+    agentId: str((payload as TurnHistoryInput)?.agentId),
   };
 }

--- a/packages/sdk/src/modules/turns/vm-output.ts
+++ b/packages/sdk/src/modules/turns/vm-output.ts
@@ -85,6 +85,31 @@ export class ConversationVmOutput implements FeedOutput {
     return s;
   }
 
+  /**
+   * Replace a conversation's feed with a folded history transcript (fresh ids),
+   * the hydration seam `observe` uses so a chat opens COMPLETE before any live
+   * frame. History frames are all final, so the streaming map is reset — a live
+   * observer attaching next starts its running turn's bubble cleanly, never
+   * extending a seeded one. `sessionStatus`/`boardStatus` are untouched: the
+   * attaching observer owns those. The double-render guard is by construction —
+   * the running turn's reply is NOT yet in history (unsettled), so seeding it
+   * plus observing it live cannot duplicate; the caller only seeds when it is
+   * not already streaming this conversation.
+   */
+  seedHistory(
+    sessionKey: string,
+    frames: readonly { feed_type: string; data: unknown }[],
+  ): void {
+    const s = this.state(sessionKey);
+    s.feed = frames.map((f) => ({
+      id: `f${s.seq++}`,
+      feed_type: f.feed_type,
+      data: f.data,
+    }));
+    s.streaming.clear();
+    this.publish(sessionKey, s);
+  }
+
   pushFeedItem(_agentPath: string, sessionKey: string, item: unknown): void {
     const s = this.state(sessionKey);
     const { feed_type, data } = item as { feed_type: string; data: unknown };

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -10,8 +10,10 @@ import {
   isCommandEnvelope,
 } from "./commands";
 import type { ModuleContext } from "./module-context";
+import { createActivitiesModule } from "./modules/activities";
 import { createAgentsModule } from "./modules/agents";
 import { createConversationsModule } from "./modules/conversations";
+import { createMissionsSearchModule } from "./modules/missions-search";
 import { createSessionModule } from "./modules/session";
 import { createTurnsModule } from "./modules/turns";
 import type { SdkConfig } from "./ports";
@@ -70,6 +72,10 @@ export class HoustonSdk {
   readonly conversations: ReturnType<typeof createConversationsModule>;
   /** Turn facade (send message, drive a turn). */
   readonly turns: ReturnType<typeof createTurnsModule>;
+  /** Board/missions facade (per-agent activities read + CRUD). */
+  readonly activities: ReturnType<typeof createActivitiesModule>;
+  /** Mission-search facade (ranked full-text search across missions). */
+  readonly missions: ReturnType<typeof createMissionsSearchModule>;
 
   constructor(config: SdkConfig) {
     this.config = config;
@@ -99,6 +105,8 @@ export class HoustonSdk {
     this.agents = createAgentsModule(ctx);
     this.conversations = createConversationsModule(ctx);
     this.turns = createTurnsModule(ctx);
+    this.activities = createActivitiesModule(ctx);
+    this.missions = createMissionsSearchModule(ctx);
     // =====================================================================
   }
 
@@ -155,8 +163,8 @@ export class HoustonSdk {
   }
 
   /**
-   * Tear down every long-lived resource the SDK holds: the agents reactivity
-   * stream and all in-flight turn/observer streams. Call it when the SDK is
+   * Tear down every long-lived resource the SDK holds: the agents + activities
+   * reactivity streams and all in-flight turn/observer streams. Call it when the SDK is
    * being discarded (logout, teardown) so no background fetch loop outlives it.
    * Idempotent-friendly at the module level; the SDK instance is single-use
    * after disposal.
@@ -164,5 +172,6 @@ export class HoustonSdk {
   dispose(): void {
     this.agents.dispose();
     this.turns.dispose();
+    this.activities.dispose();
   }
 }

--- a/packages/sdk/tests/activities.contract.test.ts
+++ b/packages/sdk/tests/activities.contract.test.ts
@@ -1,0 +1,165 @@
+/**
+ * Activities contract: the `activities/<agentId>` view-model reflects the host's
+ * `GET /agents/:id/activities`, the CRUD facade mutates then refetches so the
+ * snapshot always reflects the server, and a change made by ANOTHER client (an
+ * out-of-band `ActivityChanged` on `/v1/events`) live-updates the snapshot.
+ *
+ * The `ActivitiesViewModel` is a cross-platform snapshot (the board/missions the
+ * iOS app renders), so its seed shape is pinned here as API.
+ */
+
+import { type FakeHost, SEED_AGENT_ID } from "@houston/fake-host";
+import {
+  type ActivitiesViewModel,
+  activitiesScope,
+  type CreatedActivity,
+} from "@houston/sdk";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { type Harness, makeSdk, resetHost, startHost, until } from "./harness";
+
+let host: FakeHost;
+
+beforeAll(async () => {
+  host = await startHost();
+});
+afterAll(async () => {
+  await host.stop();
+});
+
+let h: Harness;
+beforeEach(async () => {
+  await resetHost(host.url);
+  h = makeSdk(host.url);
+});
+afterEach(() => {
+  h.sdk.dispose();
+});
+
+const ISO = new Date(Date.UTC(2024, 0, 1)).toISOString();
+const scope = activitiesScope(SEED_AGENT_ID);
+const vm = (): ActivitiesViewModel | undefined =>
+  h.sdk.getSnapshot(scope) as ActivitiesViewModel | undefined;
+
+describe("activities VM", () => {
+  it("loads the seed activities into a pinned snapshot shape", async () => {
+    await h.sdk.activities.refresh(SEED_AGENT_ID);
+    // The reactivity stream's onConnect fires a concurrent background refetch,
+    // which briefly republishes a `loaded:false` catch-up snapshot; wait for it
+    // to settle so the pinned shape is read once the list is stable.
+    await until(() => vm()?.loaded === true, "activities loaded");
+
+    expect(vm()).toEqual({
+      loaded: true,
+      items: [
+        {
+          id: "act-1",
+          title: "Plan a trip to Tokyo",
+          description: "Research flights and hotels for the spring",
+          status: "needs_you",
+          updatedAt: ISO,
+          // No explicit session_key on the wire → the board's activity-<id>.
+          sessionKey: "activity-act-1",
+        },
+        {
+          id: "act-2",
+          title: "Draft the launch email",
+          description: "Write the beta announcement to the waitlist",
+          status: "done",
+          updatedAt: ISO,
+          sessionKey: "activity-act-2",
+        },
+      ],
+    } satisfies ActivitiesViewModel);
+  });
+
+  it("creates a mission and returns its id + session key", async () => {
+    const created: CreatedActivity = await h.sdk.activities.create(
+      SEED_AGENT_ID,
+      "Book the venue",
+      "for the launch party",
+    );
+    expect(created.sessionKey).toBe(`activity-${created.id}`);
+
+    await until(() => vm()?.items.length === 3, "created mission present");
+    const item = vm()?.items.find((a) => a.id === created.id);
+    expect(item).toMatchObject({
+      title: "Book the venue",
+      description: "for the launch party",
+      // New missions are created running (PARITY §1).
+      status: "running",
+      sessionKey: created.sessionKey,
+    });
+  });
+
+  it("sets status (approve → done), renames, and deletes", async () => {
+    await h.sdk.activities.setStatus(SEED_AGENT_ID, "act-1", "done");
+    await until(
+      () => vm()?.items.find((a) => a.id === "act-1")?.status === "done",
+      "act-1 approved to done",
+    );
+
+    await h.sdk.activities.rename(SEED_AGENT_ID, "act-1", "Trip to Kyoto");
+    await until(
+      () =>
+        vm()?.items.find((a) => a.id === "act-1")?.title === "Trip to Kyoto",
+      "act-1 renamed",
+    );
+
+    await h.sdk.activities.delete(SEED_AGENT_ID, "act-2");
+    await until(
+      () => vm()?.items.every((a) => a.id !== "act-2") === true,
+      "act-2 deleted",
+    );
+    expect(vm()?.items.map((a) => a.id)).toEqual(["act-1"]);
+  });
+
+  it("archives and reactivates via status (PARITY §2 — no separate flag)", async () => {
+    await h.sdk.activities.setStatus(SEED_AGENT_ID, "act-2", "archived");
+    await until(
+      () => vm()?.items.find((a) => a.id === "act-2")?.status === "archived",
+      "act-2 archived",
+    );
+    await h.sdk.activities.setStatus(SEED_AGENT_ID, "act-2", "running");
+    await until(
+      () => vm()?.items.find((a) => a.id === "act-2")?.status === "running",
+      "act-2 reactivated",
+    );
+  });
+
+  it("live-updates on an external ActivityChanged (another client created one)", async () => {
+    await h.sdk.activities.refresh(SEED_AGENT_ID);
+    await until(() => vm()?.items.length === 2, "seed loaded");
+
+    // A different client creates an activity directly on the host; the fake host
+    // emits ActivityChanged on /v1/events, which the SDK's reactivity stream
+    // catches and refetches from — no local mutation through the facade.
+    const res = await fetch(`${host.url}/agents/${SEED_AGENT_ID}/activities`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "Filed by another client" }),
+    });
+    expect(res.ok).toBe(true);
+
+    await until(
+      () => vm()?.items.length === 3,
+      "ActivityChanged refetch grew the list to 3",
+    );
+    expect(vm()?.items.map((a) => a.title)).toContain(
+      "Filed by another client",
+    );
+  });
+});
+
+describe("activities scope key", () => {
+  it("is 'activities/<agentId>'", () => {
+    expect(activitiesScope("abc")).toBe("activities/abc");
+  });
+});

--- a/packages/sdk/tests/bridge-bundle.smoke.test.ts
+++ b/packages/sdk/tests/bridge-bundle.smoke.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Smoke test for the embeddable bundle: build the IIFE with esbuild, then
+ * evaluate it in a BARE Node `vm` context injected with ONLY the documented
+ * host polyfills (timers + console — see BRIDGE.md "Host polyfills"). No
+ * `fetch`, `Headers`, `AbortController`, `TextEncoder`/`TextDecoder`, or
+ * `crypto` are provided: if the bundle needed a hidden global it would throw
+ * here. It then round-trips one real command through the built code.
+ */
+
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { createContext, runInContext } from "node:vm";
+import { build } from "esbuild";
+import { beforeAll, describe, expect, it } from "vitest";
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+let bundle = "";
+beforeAll(async () => {
+  const result = await build({
+    entryPoints: [join(here, "..", "src", "bridge", "entry.ts")],
+    bundle: true,
+    write: false,
+    format: "iife",
+    globalName: "HoustonSdkBridge",
+    platform: "browser",
+    target: "es2022",
+  });
+  bundle = result.outputFiles[0].text;
+});
+
+/** The ONLY globals a compliant host must polyfill (BRIDGE.md normative list). */
+function documentedPolyfills(): Record<string, unknown> {
+  const keep = (t: ReturnType<typeof setTimeout>) => {
+    (t as { unref?: () => void }).unref?.();
+    return t;
+  };
+  return {
+    setTimeout: (fn: () => void, ms?: number) => keep(setTimeout(fn, ms)),
+    clearTimeout: (id: unknown) =>
+      clearTimeout(id as ReturnType<typeof setTimeout>),
+    setInterval: (fn: () => void, ms?: number) => keep(setInterval(fn, ms)),
+    clearInterval: (id: unknown) =>
+      clearInterval(id as ReturnType<typeof setInterval>),
+    console,
+  };
+}
+
+interface BridgeGlobal {
+  version: number;
+  create(opts: { send: (m: string) => void }): {
+    receive(m: string): void;
+    dispose(): void;
+  };
+}
+
+describe("embeddable bundle in a bare vm", () => {
+  it("exposes one global with a version and self-provides all shims", () => {
+    const context = createContext(documentedPolyfills());
+    runInContext(bundle, context);
+    const g = (context as { HoustonSdkBridge: BridgeGlobal }).HoustonSdkBridge;
+    expect(typeof g).toBe("object");
+    expect(g.version).toBe(1);
+    expect(typeof g.create).toBe("function");
+  });
+
+  it("round-trips a command with only the documented polyfills present", async () => {
+    const context = createContext(documentedPolyfills());
+    runInContext(bundle, context);
+    const g = (context as { HoustonSdkBridge: BridgeGlobal }).HoustonSdkBridge;
+
+    const outbound: { kind: string; [k: string]: unknown }[] = [];
+    const store = new Map<string, string>();
+    const bridge = g.create({
+      send: (message: string) => {
+        const msg = JSON.parse(message);
+        outbound.push(msg);
+        // Play a minimal native host: serve storage, refuse the events fetch.
+        queueMicrotask(() => {
+          if (msg.kind === "storage/get")
+            bridge.receive(
+              JSON.stringify({
+                kind: "storage/result",
+                id: msg.id,
+                value: store.get(msg.key) ?? null,
+              }),
+            );
+          else if (msg.kind === "storage/set") {
+            store.set(msg.key, msg.value);
+            bridge.receive(
+              JSON.stringify({ kind: "storage/result", id: msg.id }),
+            );
+          } else if (msg.kind === "storage/delete") {
+            store.delete(msg.key);
+            bridge.receive(
+              JSON.stringify({ kind: "storage/result", id: msg.id }),
+            );
+          } else if (msg.kind === "fetch/start")
+            bridge.receive(
+              JSON.stringify({
+                kind: "fetch/error",
+                id: msg.id,
+                message: "offline",
+              }),
+            );
+        });
+      },
+    });
+
+    const waitFor = (
+      pred: (m: { kind: string; [k: string]: unknown }) => boolean,
+    ) =>
+      new Promise<{ kind: string; [k: string]: unknown }>((resolve) => {
+        const tick = () => {
+          const hit = outbound.find(pred);
+          if (hit) resolve(hit);
+          else setTimeout(tick, 5);
+        };
+        tick();
+      });
+
+    bridge.receive(
+      JSON.stringify({ kind: "configure", baseUrl: "http://127.0.0.1:9" }),
+    );
+    await waitFor((m) => m.kind === "ready");
+
+    bridge.receive(
+      JSON.stringify({
+        kind: "command",
+        envelope: {
+          id: "smoke-1",
+          type: "session/setToken",
+          payload: { token: "tok-123" },
+        },
+      }),
+    );
+    const result = (await waitFor(
+      (m) =>
+        m.kind === "result" &&
+        (m as { result: { id: string } }).result.id === "smoke-1",
+    )) as { result: { id: string; ok: boolean } };
+
+    expect(result.result).toEqual({ id: "smoke-1", ok: true });
+    expect(store.get("houston.sdk.session.token")).toBe("tok-123");
+    bridge.dispose();
+  });
+});

--- a/packages/sdk/tests/bridge-host.ts
+++ b/packages/sdk/tests/bridge-host.ts
@@ -1,0 +1,187 @@
+/**
+ * A scripted NATIVE host that drives the bridge dispatcher in-process, exactly
+ * as an iOS/Android shell would over the string pipe.
+ *
+ * It owns the `send` collector and plays the native side of every port: on a
+ * `fetch/start` it performs a REAL `fetch` (against the in-memory fake host over
+ * local HTTP) and streams the body back as base64 `fetch/chunk`s; on
+ * `storage/*` it serves an in-memory map. Port reactions are deferred to a fresh
+ * stack (BRIDGE.md §8: `send` marshals and returns; inbound work never re-enters
+ * `send`). Helpers mint command ids and await the correlated reply frames.
+ */
+
+import { bytesToBase64 } from "../src/bridge/base64";
+import { type Bridge, createBridge } from "../src/bridge/dispatcher";
+import type { BridgeOutbound, NativePorts } from "../src/bridge/wire";
+import type { CommandResult } from "../src/commands";
+import { HoustonSdk } from "../src/sdk";
+
+type Frame = Extract<BridgeOutbound, { kind: string }>;
+type Waiter = (msg: Frame) => void;
+
+export class ScriptedHost {
+  /** Every outbound frame the SDK sent, in order. */
+  readonly outbound: Frame[] = [];
+  /** The host-backed key/value store (what `storage/*` serves). */
+  readonly storage = new Map<string, string>();
+  readonly bridge: Bridge;
+  /** Count of `fetch/chunk` frames the host has streamed back (byte path proof). */
+  chunkCount = 0;
+  private readonly waiters = new Set<Waiter>();
+  private readonly fetches = new Map<string, AbortController>();
+  private cmdSeq = 0;
+
+  constructor() {
+    this.bridge = createBridge(
+      (config) => new HoustonSdk(config),
+      (message) => this.onSend(message),
+    );
+  }
+
+  private onSend(message: string): void {
+    const msg = JSON.parse(message) as Frame;
+    this.outbound.push(msg);
+    for (const w of [...this.waiters]) w(msg);
+    // React to native-port requests on a fresh stack (never re-enter receive).
+    if (msg.kind === "fetch/start") queueMicrotask(() => this.doFetch(msg));
+    else if (msg.kind === "fetch/abort") this.fetches.get(msg.id)?.abort();
+    else if (msg.kind === "storage/get")
+      queueMicrotask(() =>
+        this.deliver({
+          kind: "storage/result",
+          id: msg.id,
+          value: this.storage.get(msg.key) ?? null,
+        }),
+      );
+    else if (msg.kind === "storage/set")
+      queueMicrotask(() => {
+        this.storage.set(msg.key, msg.value);
+        this.deliver({ kind: "storage/result", id: msg.id });
+      });
+    else if (msg.kind === "storage/delete")
+      queueMicrotask(() => {
+        this.storage.delete(msg.key);
+        this.deliver({ kind: "storage/result", id: msg.id });
+      });
+  }
+
+  private async doFetch(
+    msg: Extract<Frame, { kind: "fetch/start" }>,
+  ): Promise<void> {
+    const ac = new AbortController();
+    this.fetches.set(msg.id, ac);
+    let res: Response;
+    try {
+      res = await fetch(msg.url, {
+        method: msg.method,
+        headers: msg.headers,
+        body: msg.body,
+        signal: ac.signal,
+      });
+    } catch (err) {
+      this.fetches.delete(msg.id);
+      this.deliver({ kind: "fetch/error", id: msg.id, message: String(err) });
+      return;
+    }
+    this.deliver({
+      kind: "fetch/response",
+      id: msg.id,
+      status: res.status,
+      ok: res.ok,
+    });
+    const reader = res.body?.getReader();
+    try {
+      while (reader) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+          this.chunkCount++;
+          this.deliver({
+            kind: "fetch/chunk",
+            id: msg.id,
+            bytesBase64: bytesToBase64(value),
+          });
+        }
+      }
+      this.deliver({ kind: "fetch/done", id: msg.id });
+    } catch (err) {
+      this.deliver({ kind: "fetch/error", id: msg.id, message: String(err) });
+    } finally {
+      this.fetches.delete(msg.id);
+    }
+  }
+
+  /** Deliver one inbound frame to the bridge (host -> SDK). */
+  deliver(msg: unknown): void {
+    this.bridge.receive(JSON.stringify(msg));
+  }
+
+  /** Deliver a raw (possibly malformed) inbound string. */
+  deliverRaw(raw: string): void {
+    this.bridge.receive(raw);
+  }
+
+  private waitFor(pred: (m: Frame) => boolean): Promise<Frame> {
+    const seen = this.outbound.find(pred);
+    if (seen) return Promise.resolve(seen);
+    return new Promise((resolve) => {
+      const w: Waiter = (m) => {
+        if (pred(m)) {
+          this.waiters.delete(w);
+          resolve(m);
+        }
+      };
+      this.waiters.add(w);
+    });
+  }
+
+  async configure(baseUrl: string, native?: NativePorts): Promise<void> {
+    this.deliver({ kind: "configure", baseUrl, ...(native ? { native } : {}) });
+    await this.waitFor((m) => m.kind === "ready");
+  }
+
+  async command(type: string, payload?: unknown): Promise<CommandResult> {
+    const id = `c${++this.cmdSeq}`;
+    const done = this.waitFor((m) => m.kind === "result" && m.result.id === id);
+    this.deliver({
+      kind: "command",
+      envelope: { id, type, ...(payload !== undefined ? { payload } : {}) },
+    });
+    return ((await done) as Extract<Frame, { kind: "result" }>).result;
+  }
+
+  async subscribe(
+    sub: string,
+    scope: string,
+  ): Promise<Extract<Frame, { kind: "subscribed" }>> {
+    const done = this.waitFor((m) => m.kind === "subscribed" && m.sub === sub);
+    this.deliver({ kind: "subscribe", sub, scope });
+    return (await done) as Extract<Frame, { kind: "subscribed" }>;
+  }
+
+  unsubscribe(sub: string): void {
+    this.deliver({ kind: "unsubscribe", sub });
+  }
+
+  /** Every `snapshot` push for `sub`, in order. */
+  snapshots(sub: string): Extract<Frame, { kind: "snapshot" }>[] {
+    return this.outbound.filter(
+      (m): m is Extract<Frame, { kind: "snapshot" }> =>
+        m.kind === "snapshot" && m.sub === sub,
+    );
+  }
+
+  /** Poll until `predicate` holds, then resolve. */
+  async until(
+    predicate: () => boolean,
+    label: string,
+    timeoutMs = 15000,
+  ): Promise<void> {
+    const start = Date.now();
+    while (!predicate()) {
+      if (Date.now() - start > timeoutMs)
+        throw new Error(`timed out: ${label}`);
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  }
+}

--- a/packages/sdk/tests/bridge.contract.test.ts
+++ b/packages/sdk/tests/bridge.contract.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Native-bridge contract: the dispatcher (`src/bridge/`) driven end-to-end by a
+ * scripted native host, with `ports.fetch` routed through the bridge-fetch
+ * message pair so the SSE streaming path is proven over the pipe — not mocked.
+ *
+ * Covers: handshake, session attach (storage round-trip), agents command +
+ * subscription push, a full send -> streamed conversation snapshots -> settle,
+ * abort propagation on dispose, malformed-input replies, and teardown.
+ */
+
+import {
+  FAKE_TOKEN,
+  type FakeHost,
+  SEED_AGENT_ID,
+  SEED_AGENT_NAME,
+  SEED_WORKSPACE_ID,
+  startFakeHost,
+} from "@houston/fake-host";
+import {
+  AGENTS_SCOPE,
+  AgentsCommand,
+  CONNECTION_SCOPE,
+  type ConversationVM,
+  conversationScope,
+  SESSION_TOKEN_KEY,
+  SET_TOKEN_COMMAND,
+} from "@houston/sdk";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { ScriptedHost } from "./bridge-host";
+
+let host: FakeHost;
+beforeAll(async () => {
+  host = await startFakeHost(0);
+});
+afterAll(async () => {
+  await host.stop();
+});
+
+async function resetHost(url: string): Promise<void> {
+  await fetch(`${url}/__test__/reset`, { method: "POST" });
+}
+
+let h: ScriptedHost;
+beforeEach(async () => {
+  await resetHost(host.url);
+  h = new ScriptedHost();
+});
+afterEach(() => {
+  h.bridge.dispose();
+});
+
+const seedUsage = { context_tokens: 1200, output_tokens: 80, cached_tokens: 0 };
+const cannedReply = (text: string): string => `Roger that. You said: "${text}"`;
+
+describe("handshake + configure", () => {
+  it("replies ready v:1 to configure and reads the token from native storage", async () => {
+    await h.configure(host.url);
+    expect(h.outbound.find((m) => m.kind === "ready")).toEqual({
+      kind: "ready",
+      v: 1,
+    });
+    // Session hydrate reads the persisted token natively over the pipe (this
+    // port I/O may precede `ready`, as it fires during SDK construction).
+    expect(
+      h.outbound.some(
+        (m) => m.kind === "storage/get" && m.key === SESSION_TOKEN_KEY,
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects a second configure", async () => {
+    await h.configure(host.url);
+    h.deliver({ kind: "configure", baseUrl: host.url });
+    expect(
+      h.outbound.some(
+        (m) => m.kind === "error" && /already configured/.test(m.message),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("session attach (storage round-trip)", () => {
+  it("persists the token natively and flips the connection VM", async () => {
+    await h.configure(host.url);
+    const sub = await h.subscribe("s-conn", CONNECTION_SCOPE);
+    expect((sub.snapshot as { hasToken: boolean }).hasToken).toBe(false);
+
+    const result = await h.command(SET_TOKEN_COMMAND, { token: FAKE_TOKEN });
+    expect(result.ok).toBe(true);
+    // The token really landed in the host-backed store via storage/set.
+    expect(h.storage.get(SESSION_TOKEN_KEY)).toBe(FAKE_TOKEN);
+
+    await h.until(
+      () =>
+        h
+          .snapshots("s-conn")
+          .some((s) => (s.snapshot as { hasToken: boolean }).hasToken),
+      "connection VM flipped hasToken",
+    );
+  });
+});
+
+describe("agents command + subscription", () => {
+  it("returns the list and pushes the seed snapshot to the scope", async () => {
+    await h.configure(host.url);
+    await h.subscribe("s-agents", AGENTS_SCOPE);
+    const result = await h.command(AgentsCommand.Refresh);
+    expect(result.ok).toBe(true);
+
+    await h.until(
+      () =>
+        h
+          .snapshots("s-agents")
+          .some((s) => (s.snapshot as { items: unknown[] }).items.length === 1),
+      "agents snapshot pushed",
+    );
+    const last = h.snapshots("s-agents").at(-1)?.snapshot as {
+      loaded: boolean;
+      items: { id: string; name: string; workspaceId: string }[];
+    };
+    expect(last.loaded).toBe(true);
+    expect(last.items[0]).toEqual({
+      id: SEED_AGENT_ID,
+      name: SEED_AGENT_NAME,
+      workspaceId: SEED_WORKSPACE_ID,
+      createdAt: Date.UTC(2024, 0, 1),
+    });
+  });
+});
+
+describe("send -> stream -> settle (bridge-fetch streaming path)", () => {
+  it("drives streamed conversation snapshots through settle", async () => {
+    const cid = "cv-bridge";
+    await h.configure(host.url);
+    await h.command(SET_TOKEN_COMMAND, { token: FAKE_TOKEN });
+    await h.subscribe("s-conv", conversationScope(cid));
+
+    const sent = await h.command("turns/send", {
+      agentId: SEED_AGENT_ID,
+      conversationId: cid,
+      text: "Ping",
+    });
+    expect(sent.ok).toBe(true);
+
+    await h.until(
+      () =>
+        h
+          .snapshots("s-conv")
+          .some((s) => (s.snapshot as ConversationVM).running === false),
+      "conversation settled over the bridge",
+    );
+
+    const settled = h
+      .snapshots("s-conv")
+      .map((s) => s.snapshot as ConversationVM)
+      .filter((vm) => vm.running === false)
+      .pop();
+    expect(settled).toEqual({
+      running: false,
+      sessionStatus: "completed",
+      boardStatus: "needs_you",
+      feed: [
+        { id: "f0", feed_type: "assistant_text", data: cannedReply("Ping") },
+        {
+          id: "f1",
+          feed_type: "final_result",
+          data: {
+            result: cannedReply("Ping"),
+            cost_usd: null,
+            duration_ms: null,
+            usage: seedUsage,
+          },
+        },
+      ],
+    } satisfies ConversationVM);
+
+    // The streaming SSE really flowed as base64 fetch/chunk messages over the
+    // pipe (host->SDK), and the SSE GET went out as a bridge-fetch.
+    expect(h.chunkCount).toBeGreaterThan(0);
+    expect(
+      h.outbound.some(
+        (m) => m.kind === "fetch/start" && m.url.includes("/events"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("abort propagation", () => {
+  it("sends fetch/abort for the in-flight SSE stream on dispose", async () => {
+    const cid = "cv-abort";
+    await h.configure(host.url);
+    await fetch(`${host.url}/__test__/chat-config`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ replyDelayMs: 200 }),
+    });
+    await h.subscribe("s-abort", conversationScope(cid));
+    await h.command("turns/send", {
+      agentId: SEED_AGENT_ID,
+      conversationId: cid,
+      text: "Ping",
+    });
+
+    await h.until(
+      () =>
+        h.outbound.some(
+          (m) => m.kind === "fetch/start" && m.url.includes("/events"),
+        ),
+      "SSE stream opened over the bridge",
+    );
+    const events = h.outbound.find(
+      (m) => m.kind === "fetch/start" && m.url.includes("/events"),
+    );
+    const eventsId = (events as { id: string }).id;
+
+    h.bridge.dispose();
+    expect(
+      h.outbound.some((m) => m.kind === "fetch/abort" && m.id === eventsId),
+    ).toBe(true);
+  });
+});
+
+describe("malformed input + lifecycle replies", () => {
+  it("replies error on non-JSON and on a kind-less object", () => {
+    h.deliverRaw("this is not json");
+    expect(h.outbound.at(-1)).toEqual({
+      kind: "error",
+      message: "malformed message: not JSON",
+    });
+    h.deliver({ noKind: true });
+    expect(h.outbound.at(-1)).toEqual({
+      kind: "error",
+      message: "message must be an object with a string 'kind'",
+    });
+  });
+
+  it("replies a result for a malformed command envelope, echoing its id", async () => {
+    await h.configure(host.url);
+    const before = h.outbound.length;
+    h.deliver({ kind: "command", envelope: { id: "x9" } });
+    await h.until(
+      () => h.outbound.slice(before).some((m) => m.kind === "result"),
+      "malformed-envelope result",
+    );
+    expect(
+      h.outbound.find((m) => m.kind === "result" && m.result.id === "x9"),
+    ).toEqual({
+      kind: "result",
+      result: {
+        id: "x9",
+        ok: false,
+        error: { message: "invalid command envelope" },
+      },
+    });
+  });
+
+  it("replies not-configured for a command before configure", () => {
+    h.deliver({
+      kind: "command",
+      envelope: { id: "c0", type: "agents/refresh" },
+    });
+    expect(h.outbound.at(-1)).toEqual({
+      kind: "result",
+      result: { id: "c0", ok: false, error: { message: "not configured" } },
+    });
+  });
+
+  it("ignores an unknown kind (inert) and an unknown unsubscribe (no-op)", () => {
+    h.deliver({ kind: "totally-new-frame", extra: 1 });
+    h.deliver({ kind: "unsubscribe", sub: "never-subscribed" });
+    expect(h.outbound).toEqual([]);
+  });
+
+  it("stops dispatching after dispose", async () => {
+    await h.configure(host.url);
+    h.bridge.dispose();
+    const result = await h.command("agents/refresh");
+    expect(result).toEqual({
+      id: "c1",
+      ok: false,
+      error: { message: "not configured" },
+    });
+  });
+});

--- a/packages/sdk/tests/missions-search.contract.test.ts
+++ b/packages/sdk/tests/missions-search.contract.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Mission-search contract: ranked full-text search over the host's missions,
+ * mirroring the desktop EXACTLY — a TITLE match first (no snippet), then a
+ * DESCRIPTION match, then lazily-fetched chat-history CONTENT. Title/description
+ * run off the activities list; content fetches each unmatched mission's history
+ * (bounded, no observers).
+ */
+
+import { type FakeHost, SEED_AGENT_ID } from "@houston/fake-host";
+import type { MissionMatch } from "@houston/sdk";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import {
+  cannedReply,
+  convVm,
+  type Harness,
+  makeSdk,
+  resetHost,
+  startHost,
+  until,
+} from "./harness";
+
+let host: FakeHost;
+
+beforeAll(async () => {
+  host = await startHost();
+});
+afterAll(async () => {
+  await host.stop();
+});
+
+let h: Harness;
+beforeEach(async () => {
+  await resetHost(host.url);
+  h = makeSdk(host.url);
+});
+afterEach(() => {
+  h.sdk.dispose();
+});
+
+describe("missions/search — ranked matches", () => {
+  it("matches the TITLE first, with no snippet (the title shows the phrase)", async () => {
+    const matches = await h.sdk.missions.search("Tokyo");
+    expect(matches).toEqual([
+      {
+        agentId: SEED_AGENT_ID,
+        activityId: "act-1",
+        sessionKey: "activity-act-1",
+        title: "Plan a trip to Tokyo",
+        matchedIn: "title",
+      } satisfies MissionMatch,
+    ]);
+  });
+
+  it("matches the DESCRIPTION with a highlighted snippet", async () => {
+    const matches = await h.sdk.missions.search("beta announcement");
+    expect(matches).toHaveLength(1);
+    const [m] = matches;
+    expect(m.activityId).toBe("act-2");
+    expect(m.matchedIn).toBe("description");
+    expect(m.snippet).toContain("beta announcement");
+  });
+
+  it("is accent/case-insensitive (folds like the desktop)", async () => {
+    // "tokyo" lower-cases the title match; the fold is the same one the board uses.
+    expect((await h.sdk.missions.search("tokyo"))[0]?.activityId).toBe("act-1");
+  });
+
+  it("falls through to lazily-fetched history CONTENT", async () => {
+    // A phrase in neither title nor description, only in the chat transcript.
+    const cid = "activity-act-1";
+    await h.sdk.turns.send({
+      agentId: SEED_AGENT_ID,
+      conversationId: cid,
+      text: "pistachio",
+    });
+    await until(() => convVm(h.sdk, cid)?.running === false, "turn settled");
+
+    const matches = await h.sdk.missions.search("pistachio");
+    expect(matches).toHaveLength(1);
+    const [m] = matches;
+    expect(m.activityId).toBe("act-1");
+    expect(m.matchedIn).toBe("content");
+    // The canned reply echoes the phrase, so the snippet surfaces it.
+    expect(m.snippet).toContain("pistachio");
+    expect(cannedReply("pistachio")).toContain("pistachio");
+  });
+
+  it("scopes to a single agent when agentId is given", async () => {
+    const matches = await h.sdk.missions.search("Tokyo", SEED_AGENT_ID);
+    expect(matches.map((m) => m.activityId)).toEqual(["act-1"]);
+  });
+
+  it("returns nothing for a blank or unmatched query", async () => {
+    expect(await h.sdk.missions.search("   ")).toEqual([]);
+    expect(await h.sdk.missions.search("nonexistent-zzz")).toEqual([]);
+  });
+});

--- a/packages/sdk/tests/turns-history.contract.test.ts
+++ b/packages/sdk/tests/turns-history.contract.test.ts
@@ -1,0 +1,135 @@
+/**
+ * Transcript hydration contract: `turns/history` folds a conversation's
+ * persisted messages into feed frames, and `turns/observe` SEEDS the
+ * conversation VM's feed from that history FIRST — so a mobile client opening a
+ * chat sees the full transcript immediately, with no double-render.
+ */
+
+import { type FakeHost, SEED_AGENT_ID } from "@houston/fake-host";
+import type { ConversationVM, FeedFrame } from "@houston/sdk";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import {
+  cannedReply,
+  convVm,
+  type Harness,
+  makeSdk,
+  resetHost,
+  startHost,
+  until,
+} from "./harness";
+
+let host: FakeHost;
+
+beforeAll(async () => {
+  host = await startHost();
+});
+afterAll(async () => {
+  await host.stop();
+});
+
+let h: Harness;
+beforeEach(async () => {
+  await resetHost(host.url);
+  h = makeSdk(host.url);
+});
+afterEach(() => {
+  h.sdk.dispose();
+});
+
+const seedUsage = { context_tokens: 1200, output_tokens: 80, cached_tokens: 0 };
+
+/** Send a turn and wait for it to settle, so a transcript is persisted. */
+async function seedOneTurn(cid: string, text: string): Promise<void> {
+  await h.sdk.turns.send({ agentId: SEED_AGENT_ID, conversationId: cid, text });
+  await until(() => convVm(h.sdk, cid)?.running === false, "turn settled");
+}
+
+describe("turns/history — fold persisted transcript", () => {
+  it("folds a settled turn into user_message, assistant_text, final_result", async () => {
+    const cid = "c-hist-fold";
+    await seedOneTurn(cid, "Ping");
+
+    const feed: FeedFrame[] = await h.sdk.turns.history(cid, SEED_AGENT_ID);
+    expect(feed).toEqual([
+      { feed_type: "user_message", data: "Ping", author: undefined },
+      { feed_type: "assistant_text", data: cannedReply("Ping") },
+      {
+        feed_type: "final_result",
+        data: {
+          result: cannedReply("Ping"),
+          cost_usd: null,
+          duration_ms: null,
+          usage: seedUsage,
+        },
+      },
+    ]);
+  });
+});
+
+describe("turns/observe — seed the VM feed from history", () => {
+  it("opens a chat complete for a client that never sent the turn", async () => {
+    const cid = "c-observe-seed";
+    // One client sends + settles the turn (persists the transcript).
+    await seedOneTurn(cid, "Ping");
+
+    // A SECOND, fresh client (a mobile app opening the chat) has never streamed
+    // this conversation. Observing must show the full transcript from history.
+    const h2 = makeSdk(host.url);
+    try {
+      await h2.sdk.turns.observe(cid, SEED_AGENT_ID);
+      await until(
+        () =>
+          convVm(h2.sdk, cid)?.feed.some(
+            (f) => f.feed_type === "assistant_text",
+          ) === true,
+        "seeded transcript visible on the fresh client",
+      );
+
+      const vm = convVm(h2.sdk, cid) as ConversationVM;
+      // Exactly the folded transcript — no duplication from the idle observer.
+      expect(vm.feed.map((f) => f.feed_type)).toEqual([
+        "user_message",
+        "assistant_text",
+        "final_result",
+      ]);
+      expect(vm.feed.find((f) => f.feed_type === "assistant_text")?.data).toBe(
+        cannedReply("Ping"),
+      );
+      // Stable, unique feed ids assigned by the seed.
+      expect(new Set(vm.feed.map((f) => f.id)).size).toBe(vm.feed.length);
+    } finally {
+      h2.sdk.dispose();
+    }
+  });
+
+  it("seeds the user bubble the live send omitted when re-observing idle", async () => {
+    const cid = "c-observe-reseed";
+    await seedOneTurn(cid, "Ping");
+    // The live send path never renders the user's own echo, so its settled feed
+    // has no user_message. Re-observing the now-idle conversation seeds the full
+    // transcript from history, so the user's bubble appears — without doubling
+    // the assistant reply.
+    expect(convVm(h.sdk, cid)?.feed.map((f) => f.feed_type)).toEqual([
+      "assistant_text",
+      "final_result",
+    ]);
+    await h.sdk.turns.observe(cid, SEED_AGENT_ID);
+    await until(
+      () => convVm(h.sdk, cid)?.feed[0]?.feed_type === "user_message",
+      "re-seeded transcript leads with the user bubble",
+    );
+    expect(convVm(h.sdk, cid)?.feed.map((f) => f.feed_type)).toEqual([
+      "user_message",
+      "assistant_text",
+      "final_result",
+    ]);
+  });
+});

--- a/packages/web/src/engine-adapter/translate.ts
+++ b/packages/web/src/engine-adapter/translate.ts
@@ -1,4 +1,5 @@
 import type { ChatMessage } from "@houston/runtime-client";
+import { historyToFeed as foldHistoryToFeed } from "@houston/sdk";
 import type { ChatHistoryEntry } from "../../../../ui/engine-client/src/types";
 import { toOldProvider } from "./synthetic";
 
@@ -11,65 +12,14 @@ export {
   turnErrorMessage,
 } from "@houston/sdk";
 
-/** Convert new-engine history (ChatMessage[]) into old FeedItem[] for replay. */
+/**
+ * Convert new-engine history (ChatMessage[]) into old FeedItem[] for replay.
+ *
+ * ONE fold, shared with the SDK (`@houston/sdk` `historyToFeed`) — the adapter
+ * just injects its own provider-id remap (`toOldProvider`), so the desktop's
+ * persisted provider-switch dividers and provider-error cards resolve the
+ * frontend provider NAME while the SDK carries the pi id through unchanged.
+ */
 export function historyToFeed(messages: ChatMessage[]): ChatHistoryEntry[] {
-  const out: ChatHistoryEntry[] = [];
-  for (const m of messages) {
-    if (m.role === "user") {
-      // Carry the author (C5) so a shared conversation attributes each teammate's
-      // bubble on reload. Absent in single-player mode → the bubble is unchanged.
-      out.push({
-        feed_type: "user_message",
-        data: m.content,
-        author: m.author,
-      });
-    } else {
-      // A persisted provider switch: replay the boundary divider before this
-      // turn's content so it survives a reload (and the window estimate resets).
-      if (m.providerSwitch) {
-        out.push({
-          feed_type: "provider_switched",
-          data: {
-            provider: toOldProvider(m.providerSwitch.provider),
-            summarized: m.providerSwitch.summarized,
-            pre_tokens: m.providerSwitch.pre_tokens,
-          },
-        });
-      }
-      // A persisted provider failure: replay the typed card so the inline
-      // reconnect / rate-limit surface survives a reload (the dedup in
-      // feedItemsToMessages keeps one card per (kind, provider) per turn).
-      if (m.providerError) {
-        out.push({
-          feed_type: "provider_error",
-          data: {
-            ...m.providerError,
-            provider: toOldProvider(m.providerError.provider),
-          },
-        });
-      }
-      for (const t of m.tools ?? []) {
-        out.push({ feed_type: "tool_call", data: { name: t.name, input: {} } });
-        out.push({
-          feed_type: "tool_result",
-          data: { content: "", is_error: !!t.isError },
-        });
-      }
-      if (m.content) out.push({ feed_type: "assistant_text", data: m.content });
-      // Replay the turn's usage as a final_result (which only flushes, never
-      // renders a bubble) so the context-usage indicator survives a reload.
-      if (m.usage) {
-        out.push({
-          feed_type: "final_result",
-          data: {
-            result: m.content,
-            cost_usd: null,
-            duration_ms: null,
-            usage: m.usage,
-          },
-        });
-      }
-    }
-  }
-  return out;
+  return foldHistoryToFeed(messages, toOldProvider) as ChatHistoryEntry[];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -422,6 +422,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260607.1
         version: 7.0.0-dev.20260607.1
+      esbuild:
+        specifier: ^0.25.0
+        version: 0.25.12
       react:
         specifier: ^19.0.0
         version: 19.2.4


### PR DESCRIPTION
The iOS-facing half of `@houston/sdk` — everything the iPhone app consumes, fully TS-verified. (The `mobile/ios` Swift tree follows in its own PR once Xcode is available for the compile-verification pass.)

## Bridge (BRIDGE.md → shipped)
`packages/sdk/src/bridge/`: dispatcher over a string message pipe (configure/ready, command↔result correlation, scope subscribe → snapshot pushes, events, fatal), **native-backed ports** — fetch with base64 chunk streaming (SSE-capable), storage, log — JSC-safe self-shims, and a 33 KB esbuild IIFE bundle. Contract tests run a real `HoustonSdk` against `@houston/fake-host` with fetch routed through bridge messages (streamed send→settle proven); a `vm` smoke test evaluates the bundle with only the documented polyfills (no hidden globals). BRIDGE.md updated additively (§9 ports, §10 normative polyfills).

## Mobile domain modules
- **activities**: per-agent missions VM (canonical statuses incl. `archived`), create/setStatus/rename/delete commands, live via `ActivityChanged` over the shared events loop.
- **turns/history**: `historyToFeed` moved into the SDK (web adapter now delegates — one implementation); `turns/observe` hydrates from history before attaching live, so a mobile chat opens complete.
- **missions/search**: desktop-exact search (title → description → transcript content, bounded concurrency, no observers) with ranked matches + snippets.
- **`mobile/PARITY.md`**: the extracted desktop parity contract the iOS surfaces are built against.

## Verification
SDK **201** tests (44 new incl. 13 bridge + contract suites) · web 27 unit + 15 e2e · fake-host 5 · typecheck/biome/boundaries/parity clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)