### PR TITLE
fix(providers): instant AI-provider cards — one status round-trip on the TS engine + sidebar entry (HOU-650)

### DIFF
--- a/app/src/components/shell/naming-step.tsx
+++ b/app/src/components/shell/naming-step.tsx
@@ -200,12 +200,10 @@ export function InlineModelSelector({
   const [open, setOpen] = useState(false);
 
   const loadStatuses = useCallback(async () => {
-    const entries = await Promise.all(
-      PROVIDERS.map(
-        async (p) => [p.id, await tauriProvider.checkStatus(p.id)] as const,
-      ),
+    // ONE round-trip for all providers (HOU-650) instead of a probe per card.
+    setStatuses(
+      await tauriProvider.checkAllStatuses(PROVIDERS.map((p) => p.id)),
     );
-    setStatuses(Object.fromEntries(entries));
   }, []);
 
   useEffect(() => {

--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -16,6 +16,7 @@ import {
   providerGatewayIds,
 } from "../../lib/providers";
 import {
+  mergeGatewayStatus,
   type ProviderStatus,
   tauriProvider,
   tauriSystem,
@@ -80,23 +81,18 @@ export function ProviderPicker({ onSelect }: Props) {
 
   const prevStatuses = useRef<Record<string, ProviderStatus>>({});
   const loadStatuses = useCallback(async () => {
-    // Probe every visible provider in parallel. New providers added to the
-    // catalog are picked up automatically; never hardcode ids here.
-    const results = await Promise.all(
-      visibleProviders.map(
-        async (p) =>
-          // A connect card may front several gateways (OpenCode's Zen + Go share
-          // one key); probe them together so the merged card reads as connected
-          // when either is. `providerGatewayIds` is `[p.id]` for everything else.
-          [
-            p.id,
-            await tauriProvider.checkMergedStatus(providerGatewayIds(p)),
-          ] as const,
-      ),
-    );
+    // ONE engine round-trip for every card (HOU-650). A card may front several
+    // gateways (OpenCode's Zen + Go share one key); probe the union and merge per
+    // card so the merged card reads as connected when either gateway is. New
+    // catalog providers are picked up automatically; never hardcode ids here.
+    const gatewayIds = [
+      ...new Set(visibleProviders.flatMap((p) => providerGatewayIds(p))),
+    ];
+    const byId = await tauriProvider.checkAllStatuses(gatewayIds);
     const next: Record<string, ProviderStatus> = {};
-    for (const [id, status] of results) {
-      next[id] = status;
+    for (const p of visibleProviders) {
+      const merged = mergeGatewayStatus(providerGatewayIds(p), byId);
+      if (merged) next[p.id] = merged;
     }
     for (const prov of visibleProviders) {
       const wasConnected =

--- a/app/src/components/shell/provider-settings.tsx
+++ b/app/src/components/shell/provider-settings.tsx
@@ -1,5 +1,5 @@
 import type { HoustonEvent } from "@houston-ai/core";
-import { ConfirmDialog, Spinner } from "@houston-ai/core";
+import { ConfirmDialog } from "@houston-ai/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../../hooks/use-capabilities";
@@ -7,6 +7,10 @@ import { analytics } from "../../lib/analytics";
 import { newEngineActive } from "../../lib/engine";
 import { subscribeHoustonEvents } from "../../lib/events";
 import { osIsTauri } from "../../lib/os-bridge";
+import {
+  loadCachedProviderStatuses,
+  saveCachedProviderStatuses,
+} from "../../lib/provider-status-cache";
 import {
   EMPTY_PROVIDER_CAPABILITIES,
   getConnectProviders,
@@ -43,8 +47,12 @@ import { useCopilotConnect } from "./use-copilot-connect";
  */
 export function ProviderSettings() {
   const { t } = useTranslation("providers");
-  const [statuses, setStatuses] = useState<Record<string, ProviderStatus>>({});
-  const [loading, setLoading] = useState(true);
+  // Seed from the last scan's snapshot so the cards paint instantly with
+  // their last-known connected state instead of hiding behind a spinner
+  // while the CLIs are probed. The probe below reconciles within seconds.
+  const [statuses, setStatuses] = useState<Record<string, ProviderStatus>>(() =>
+    loadCachedProviderStatuses(),
+  );
   const [pendingId, setPendingId] = useState<string | null>(null);
   const [confirmSignOutFor, setConfirmSignOutFor] =
     useState<ProviderInfo | null>(null);
@@ -123,7 +131,8 @@ export function ProviderSettings() {
     }
     prevStatuses.current = next;
     hasBaseline.current = true;
-    setLoading(false);
+    // Persist the confirmed scan so the NEXT visit paints instantly.
+    saveCachedProviderStatuses(next);
   }, [visibleProviders]);
 
   // Optimistically reflect an auth outcome we already know succeeded (a
@@ -390,14 +399,6 @@ export function ProviderSettings() {
     }
     return [...connected, ...disconnected];
   }, [statuses, visibleProviders]);
-
-  if (loading) {
-    return (
-      <div className="flex justify-center py-12">
-        <Spinner className="h-5 w-5" />
-      </div>
-    );
-  }
 
   return (
     <>

--- a/app/src/components/shell/provider-settings.tsx
+++ b/app/src/components/shell/provider-settings.tsx
@@ -19,6 +19,7 @@ import {
   providerGatewayIds,
 } from "../../lib/providers";
 import {
+  mergeGatewayStatus,
   type ProviderStatus,
   tauriProvider,
   tauriSystem,
@@ -98,26 +99,21 @@ export function ProviderSettings() {
   const hasBaseline = useRef(false);
   const prevStatuses = useRef<Record<string, ProviderStatus>>({});
   const loadStatuses = useCallback(async () => {
-    const results = await Promise.all(
-      visibleProviders.map(async (p) => {
-        // A connect card may front several engine gateways (OpenCode's Zen + Go
-        // share one key) — probe them together so the merged card is connected
-        // when either is. `providerGatewayIds` is just `[p.id]` for everything else.
-        const status = await tauriProvider.checkMergedStatus(
-          providerGatewayIds(p),
-        );
-        // Paint each card the moment ITS probe resolves instead of blocking
-        // every card on the slowest provider — each CLI shell-out can take
-        // up to its 5s timeout, and gating the whole batch made the section
-        // feel frozen for ~6s after connect/sign-out.
-        setStatuses((prev) => ({ ...prev, [p.id]: status }));
-        return [p.id, status] as const;
-      }),
-    );
+    // ONE engine round-trip for every card. On the new engine this collapses to
+    // a single listProviders() (HOU-650); probing each card separately meant a
+    // round-trip per gateway (~a dozen) to the agent's sandbox each scan. A card
+    // may front several gateways (OpenCode's Zen + Go share one key), so we probe
+    // the union of gateway ids and merge per card below.
+    const gatewayIds = [
+      ...new Set(visibleProviders.flatMap((p) => providerGatewayIds(p))),
+    ];
+    const byId = await tauriProvider.checkAllStatuses(gatewayIds);
     const next: Record<string, ProviderStatus> = {};
-    for (const [id, status] of results) {
-      next[id] = status;
+    for (const p of visibleProviders) {
+      const merged = mergeGatewayStatus(providerGatewayIds(p), byId);
+      if (merged) next[p.id] = merged;
     }
+    setStatuses((prev) => ({ ...prev, ...next }));
     if (hasBaseline.current) {
       for (const prov of visibleProviders) {
         const prev = prevStatuses.current[prov.id];

--- a/app/src/components/shell/providers-view.tsx
+++ b/app/src/components/shell/providers-view.tsx
@@ -1,0 +1,17 @@
+import { ProviderSection } from "../settings/sections/provider";
+
+/**
+ * Standalone AI-providers page for the sidebar's top-level nav entry.
+ * Renders the exact same section as Settings → AI provider (which stays);
+ * this is just a second, quicker route to it. Same column width as the
+ * settings content pane so switching between the two doesn't reflow.
+ */
+export function ProvidersView() {
+  return (
+    <div className="flex-1 overflow-y-auto">
+      <div className="mx-auto max-w-xl px-8 py-10">
+        <ProviderSection />
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -1,6 +1,6 @@
 import { ConfirmDialog } from "@houston-ai/core";
 import { AppSidebar, WorkspaceSwitcher } from "@houston-ai/layout";
-import { LayoutDashboard, Settings } from "lucide-react";
+import { Bot, LayoutDashboard, Settings } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
@@ -70,7 +70,10 @@ export function Sidebar({ children }: { children: ReactNode }) {
     onShareAgent: (agentId) => useUIStore.getState().setShareAgentId(agentId),
     shareLabel: t("portable:shareMenu"),
   });
-  const isTopLevel = viewMode === "dashboard" || viewMode === "settings";
+  const isTopLevel =
+    viewMode === "dashboard" ||
+    viewMode === "settings" ||
+    viewMode === "providers";
 
   const handleWorkspaceSwitch = async (wsId: string) => {
     if (wsId === currentWorkspace?.id) return;
@@ -151,6 +154,12 @@ export function Sidebar({ children }: { children: ReactNode }) {
               icon: <LayoutDashboard className="h-4 w-4" />,
               onClick: () => setViewMode("dashboard"),
               dataAttrs: { "data-tour-target": "nav-dashboard" },
+            },
+            {
+              id: "providers",
+              label: t("shell:sidebar.aiProviders"),
+              icon: <Bot className="h-4 w-4" />,
+              onClick: () => setViewMode("providers"),
             },
             {
               id: "settings",

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -41,6 +41,7 @@ import { CreateAgentDialog } from "./create-workspace-dialog";
 import { DetailPanelProvider } from "./detail-panel-context";
 import { HoustonLogo } from "./experience-card";
 import { AgentRenderer } from "./experience-renderer";
+import { ProvidersView } from "./providers-view";
 import { Sidebar } from "./sidebar";
 import { UiTour } from "./ui-tour";
 
@@ -90,7 +91,10 @@ export function WorkspaceShell({
   const needsYouCount = (activities ?? []).filter(
     (a) => a.status === "needs_you",
   ).length;
-  const isAgentView = viewMode !== "dashboard" && viewMode !== "settings";
+  const isAgentView =
+    viewMode !== "dashboard" &&
+    viewMode !== "settings" &&
+    viewMode !== "providers";
   const tabOr = (id: string) =>
     STANDARD_TAB_IDS.has(id) ? id : DEFAULT_TAB_ID;
 
@@ -159,6 +163,8 @@ export function WorkspaceShell({
                   <Dashboard />
                 ) : viewMode === "settings" ? (
                   <SettingsView />
+                ) : viewMode === "providers" ? (
+                  <ProvidersView />
                 ) : currentAgent && agentDef && isAgentView ? (
                   <>
                     <div data-tour-target="tabs">

--- a/app/src/hooks/use-provider-statuses.ts
+++ b/app/src/hooks/use-provider-statuses.ts
@@ -46,12 +46,10 @@ export function useProviderStatuses(): ProviderStatusesState {
         desktop: osIsTauri(),
         capabilities: providerCapabilities,
       });
-      const entries = await Promise.all(
-        providers.map(
-          async (p) => [p.id, await tauriProvider.checkStatus(p.id)] as const,
-        ),
-      );
-      return Object.fromEntries(entries);
+      // ONE round-trip for every provider (HOU-650): on the new engine this is a
+      // single listProviders(), versus the old per-provider probe that fired N
+      // identical round-trips to the agent's sandbox each time the picker opened.
+      return tauriProvider.checkAllStatuses(providers.map((p) => p.id));
     },
     staleTime: 30_000,
   });

--- a/app/src/lib/provider-status-cache.ts
+++ b/app/src/lib/provider-status-cache.ts
@@ -1,0 +1,61 @@
+import type { ProviderStatus } from "./tauri";
+
+/**
+ * Boot-time cache of the last provider-status scan.
+ *
+ * Provider probes shell out to CLIs and can take seconds each (up to a 5s
+ * timeout per provider), so the settings screen seeds its cards from this
+ * snapshot and paints instantly; the live probe still runs and reconciles.
+ * Same philosophy as the i18n locale flash-cache: localStorage is never the
+ * source of truth, only a first-paint hint.
+ */
+const CACHE_KEY = "houston.providerStatusCache.v1";
+
+function isProviderStatus(value: unknown): value is ProviderStatus {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.provider === "string" &&
+    typeof v.cli_installed === "boolean" &&
+    typeof v.auth_state === "string" &&
+    typeof v.authenticated === "boolean" &&
+    typeof v.cli_name === "string"
+  );
+}
+
+type StatusStore = Pick<Storage, "getItem" | "setItem">;
+
+/**
+ * Last-known statuses, keyed by provider id. Invalid or unparseable entries
+ * are dropped rather than trusted — a bad hint is worse than no hint.
+ */
+export function loadCachedProviderStatuses(
+  storage: StatusStore = localStorage,
+): Record<string, ProviderStatus> {
+  try {
+    const raw = storage.getItem(CACHE_KEY);
+    if (!raw) return {};
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return {};
+    const out: Record<string, ProviderStatus> = {};
+    for (const [id, status] of Object.entries(parsed)) {
+      if (isProviderStatus(status)) out[id] = status;
+    }
+    return out;
+  } catch {
+    // Cache read is a paint hint, not a user action — a broken/blocked
+    // localStorage just means we fall back to the probe-only path.
+    return {};
+  }
+}
+
+export function saveCachedProviderStatuses(
+  statuses: Record<string, ProviderStatus>,
+  storage: StatusStore = localStorage,
+): void {
+  try {
+    storage.setItem(CACHE_KEY, JSON.stringify(statuses));
+  } catch {
+    // Same rationale as the read path: losing the hint is harmless.
+  }
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -884,17 +884,28 @@ export const tauriProvider = {
   /**
    * Connect status for many provider / gateway ids in ONE engine round-trip.
    *
-   * On the new TS engine this maps to a single `listProviders()` call (HOU-650);
-   * on the legacy Rust engine it fans out to per-provider probes. Returns a map
-   * keyed by the ids passed. Screens that show several provider cards (settings,
-   * onboarding picker, chat model picker) call this once instead of probing each
-   * card separately — otherwise a dozen cards meant a dozen round-trips.
+   * The new TS engine's adapter exposes a batched `providerStatuses()` that
+   * resolves every card from a single `listProviders()` call (HOU-650). The
+   * legacy Rust client has no such method — and won't get one, it's being
+   * retired — so we feature-detect it and fall back to per-provider probes there
+   * (that path keeps its old N-round-trip behavior; no Rust-side change). Returns
+   * a map keyed by the ids passed. Screens that show several provider cards
+   * (settings, onboarding picker, chat model picker) call this once instead of
+   * probing each card separately.
    */
   checkAllStatuses: (ids: readonly string[]) =>
     call<Record<string, ProviderStatus>>(
       "check_provider_statuses",
       async () => {
-        const list = await getEngine().providerStatuses([...ids]);
+        const engine = getEngine() as {
+          providerStatus: (name: string) => Promise<EngineProviderStatus>;
+          providerStatuses?: (
+            names: readonly string[],
+          ) => Promise<EngineProviderStatus[]>;
+        };
+        const list = engine.providerStatuses
+          ? await engine.providerStatuses([...ids])
+          : await Promise.all(ids.map((id) => engine.providerStatus(id)));
         const out: Record<string, ProviderStatus> = {};
         ids.forEach((id, i) => {
           const p = list[i];

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -847,6 +847,23 @@ export interface ProviderStatus {
   active_model?: string;
 }
 
+/**
+ * Pick the connected gateway for a card that spans several engine gateway ids —
+ * OpenCode's Zen + Go share one key, so the merged "OpenCode" account reads as
+ * connected when EITHER gateway is. Returns the first authenticated probe, else
+ * the first probe present. `byId` is a `checkAllStatuses` result; `[p.id]` for a
+ * normal single-gateway provider just returns its own probe.
+ */
+export function mergeGatewayStatus(
+  gatewayIds: readonly string[],
+  byId: Record<string, ProviderStatus>,
+): ProviderStatus | undefined {
+  const probes = gatewayIds
+    .map((id) => byId[id])
+    .filter((s): s is ProviderStatus => Boolean(s));
+  return probes.find((s) => s.cli_installed && s.authenticated) ?? probes[0];
+}
+
 const DEFAULT_PROVIDER_PREF_KEY = "default_provider";
 const DEFAULT_MODEL_PREF_KEY = "default_model";
 
@@ -865,21 +882,35 @@ export const tauriProvider = {
       };
     }),
   /**
-   * Combined connect status for a card that spans several engine gateway ids —
-   * OpenCode's Zen + Go share one key, so the merged "OpenCode" account reads as
-   * connected when EITHER gateway is. Probes each in parallel (one probe for a
-   * normal single-id provider) and returns the first authenticated status, else
-   * the first probe. The adapter writes / clears both gateways together, so this
-   * also reconciles a credential left under a single gateway by an older build.
+   * Connect status for many provider / gateway ids in ONE engine round-trip.
+   *
+   * On the new TS engine this maps to a single `listProviders()` call (HOU-650);
+   * on the legacy Rust engine it fans out to per-provider probes. Returns a map
+   * keyed by the ids passed. Screens that show several provider cards (settings,
+   * onboarding picker, chat model picker) call this once instead of probing each
+   * card separately — otherwise a dozen cards meant a dozen round-trips.
    */
-  checkMergedStatus: async (
-    ids: readonly string[],
-  ): Promise<ProviderStatus> => {
-    const probes = await Promise.all(
-      ids.map((id) => tauriProvider.checkStatus(id)),
-    );
-    return probes.find((s) => s.cli_installed && s.authenticated) ?? probes[0];
-  },
+  checkAllStatuses: (ids: readonly string[]) =>
+    call<Record<string, ProviderStatus>>(
+      "check_provider_statuses",
+      async () => {
+        const list = await getEngine().providerStatuses([...ids]);
+        const out: Record<string, ProviderStatus> = {};
+        ids.forEach((id, i) => {
+          const p = list[i];
+          if (!p) return;
+          out[id] = {
+            provider: p.provider,
+            cli_installed: p.cliInstalled,
+            auth_state: p.authState,
+            authenticated: p.authState === "authenticated",
+            cli_name: p.cliName,
+            active_model: p.activeModel,
+          };
+        });
+        return out;
+      },
+    ),
   getDefault: () =>
     call<string>(
       "get_default_provider",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -2,6 +2,7 @@
   "sidebar": {
     "missionControl": "Mission Control",
     "integrations": "Integrations",
+    "aiProviders": "AI providers",
     "settings": "Settings",
     "yourAgents": "Your Agents",
     "selectWorkspace": "Select workspace",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -1,6 +1,7 @@
 {
   "sidebar": {
     "missionControl": "Central de missões",
+    "aiProviders": "Provedores de IA",
     "settings": "Configurações",
     "yourAgents": "Seus agentes",
     "selectWorkspace": "Escolha um espaço de trabalho",

--- a/app/tests/provider-status-cache.test.ts
+++ b/app/tests/provider-status-cache.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  loadCachedProviderStatuses,
+  saveCachedProviderStatuses,
+} from "../src/lib/provider-status-cache.ts";
+import type { ProviderStatus } from "../src/lib/tauri.ts";
+
+function memoryStorage(initial: Record<string, string> = {}) {
+  const store = new Map<string, string>(Object.entries(initial));
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    dump: () => Object.fromEntries(store),
+  };
+}
+
+const CONNECTED: ProviderStatus = {
+  provider: "anthropic",
+  cli_installed: true,
+  auth_state: "authenticated",
+  authenticated: true,
+  cli_name: "claude",
+};
+
+test("round-trips a status snapshot", () => {
+  const storage = memoryStorage();
+  saveCachedProviderStatuses({ anthropic: CONNECTED }, storage);
+  assert.deepEqual(loadCachedProviderStatuses(storage), {
+    anthropic: CONNECTED,
+  });
+});
+
+test("empty storage yields an empty snapshot", () => {
+  assert.deepEqual(loadCachedProviderStatuses(memoryStorage()), {});
+});
+
+test("corrupt JSON yields an empty snapshot", () => {
+  const storage = memoryStorage({
+    "houston.providerStatusCache.v1": "{not json",
+  });
+  assert.deepEqual(loadCachedProviderStatuses(storage), {});
+});
+
+test("malformed entries are dropped, valid ones kept", () => {
+  const storage = memoryStorage({
+    "houston.providerStatusCache.v1": JSON.stringify({
+      anthropic: CONNECTED,
+      openai: { provider: "openai" }, // missing fields
+      google: "authenticated", // not an object
+    }),
+  });
+  assert.deepEqual(loadCachedProviderStatuses(storage), {
+    anthropic: CONNECTED,
+  });
+});
+
+test("a throwing storage backend is treated as no cache", () => {
+  const throwing = {
+    getItem: () => {
+      throw new Error("denied");
+    },
+    setItem: () => {
+      throw new Error("denied");
+    },
+  };
+  assert.deepEqual(loadCachedProviderStatuses(throwing), {});
+  assert.doesNotThrow(() =>
+    saveCachedProviderStatuses({ anthropic: CONNECTED }, throwing),
+  );
+});

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -684,35 +684,46 @@ export class HoustonClient {
   // on the PVC). Login is surfaced through the same ProviderLoginUrl/Complete bus
   // events the desktop connect dialog already consumes, so the UI is unchanged.
   async providerStatus(name: string): Promise<ProviderStatus> {
-    const pid = toNewProvider(name);
-    let configured = false;
-    let activeModel: string | undefined;
-    if (pid) {
-      try {
-        const engine = this.providerEngine();
-        if (engine) {
-          // listProviders (not authStatus) so we also learn the configured
-          // model id — the OpenAI-compatible provider's model is dynamic and
-          // absent from the static catalog, so the picker has no other source.
-          // `configured` here matches authStatus for credential providers and
-          // is endpoint-aware for the local one.
-          const p = (await engine.listProviders()).find((x) => x.id === pid);
-          configured = p?.configured ?? false;
-          activeModel = p?.activeModel || undefined;
-        }
-      } catch {
-        /* sandbox unreachable / no agent selected → report not-connected */
+    return (await this.providerStatuses([name]))[0];
+  }
+  /**
+   * Batched provider status: ONE `listProviders()` round-trip, then derive every
+   * requested provider's status from it.
+   *
+   * `listProviders` already returns EVERY provider (with its configured flag and
+   * dynamic model id — the OpenAI-compatible provider's model is absent from the
+   * static catalog, so this is the picker's only source). The old per-card
+   * `providerStatus` fetched that whole list and threw away all but one entry, so
+   * a settings screen with a dozen cards fired a dozen identical round-trips —
+   * each proxied to the agent's sandbox in cloud. Fetching once and mapping N
+   * cards off the result is the fix for HOU-650.
+   */
+  async providerStatuses(names: readonly string[]): Promise<ProviderStatus[]> {
+    const byId = new Map<
+      string,
+      { configured?: boolean; activeModel?: string }
+    >();
+    try {
+      const engine = this.providerEngine();
+      if (engine) {
+        for (const p of await engine.listProviders()) byId.set(p.id, p);
       }
+    } catch {
+      /* sandbox unreachable / no agent selected → all report not-connected */
     }
-    return {
-      provider: name,
-      cliInstalled: true,
-      authState: configured ? "authenticated" : "unauthenticated",
-      cliName: name,
-      installSource: "managed",
-      cliPath: null,
-      activeModel,
-    } as ProviderStatus;
+    return names.map((name) => {
+      const pid = toNewProvider(name);
+      const p = pid ? byId.get(pid) : undefined;
+      return {
+        provider: name,
+        cliInstalled: true,
+        authState: p?.configured ? "authenticated" : "unauthenticated",
+        cliName: name,
+        installSource: "managed",
+        cliPath: null,
+        activeModel: p?.activeModel || undefined,
+      } as ProviderStatus;
+    });
   }
   // `deviceAuth` is the client's "I can't catch a loopback callback" flag — the
   // co-located desktop sends false (it CAN), remote webapps send true. It steers

--- a/packages/web/tests/provider-statuses-batch.test.ts
+++ b/packages/web/tests/provider-statuses-batch.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+/**
+ * HOU-650: the settings AI-provider section and the chat model picker probe a
+ * dozen provider cards at once. The engine adapter's per-card `providerStatus`
+ * used to fetch the WHOLE provider list and keep one entry — so N cards fired N
+ * identical round-trips, each proxied to the agent's sandbox in cloud. The
+ * batched `providerStatuses` fetches `listProviders()` ONCE and derives every
+ * card's status from it. These tests pin that single-round-trip contract.
+ */
+
+const listProviders = vi.fn();
+
+vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../src/engine-adapter/control-plane")
+    >();
+  return {
+    ...actual,
+    // Every provider/auth call resolves to the same fake runtime client, so we
+    // can count how many times the adapter reaches for the provider list.
+    runtimeClientFor: vi.fn(() => ({ listProviders })),
+  };
+});
+
+import { HoustonClient } from "../src/engine-adapter/client";
+
+beforeEach(() => {
+  // cp-mode `providerEngine()` needs a selected agent id; the adapter reads it
+  // from localStorage, which the default node test env doesn't provide.
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) =>
+      k === "houston.pref.last_agent_id" ? "agent-1" : null,
+    setItem: () => {},
+    removeItem: () => {},
+  };
+  listProviders.mockReset();
+});
+
+afterEach(() => vi.clearAllMocks());
+
+function client() {
+  return new HoustonClient({
+    baseUrl: "http://host",
+    token: "t",
+    controlPlane: true,
+  });
+}
+
+test("providerStatuses fetches the provider list ONCE for many cards", async () => {
+  listProviders.mockResolvedValue([
+    { id: "anthropic", configured: true, activeModel: "claude-sonnet-4-6" },
+    { id: "openai-codex", configured: false },
+    { id: "opencode", configured: true },
+  ]);
+
+  const names = [
+    "anthropic",
+    "openai", // maps to openai-codex (not configured)
+    "opencode",
+    "opencode-go", // absent from the list
+    "openrouter", // absent from the list
+    "not-a-provider", // unmapped id
+  ];
+  const statuses = await client().providerStatuses(names);
+
+  // The whole point: N cards, ONE round-trip.
+  expect(listProviders).toHaveBeenCalledTimes(1);
+  expect(statuses.map((s) => s.authState)).toEqual([
+    "authenticated",
+    "unauthenticated",
+    "authenticated",
+    "unauthenticated",
+    "unauthenticated",
+    "unauthenticated",
+  ]);
+  // Each status echoes the frontend name it was asked about, not the engine id.
+  expect(statuses.map((s) => s.provider)).toEqual(names);
+  // Dynamic model id (e.g. the local OpenAI-compatible provider) is carried through.
+  expect(statuses[0].activeModel).toBe("claude-sonnet-4-6");
+});
+
+test("providerStatus delegates to the batch (one fetch, correct entry)", async () => {
+  listProviders.mockResolvedValue([{ id: "anthropic", configured: true }]);
+
+  const status = await client().providerStatus("anthropic");
+
+  expect(listProviders).toHaveBeenCalledTimes(1);
+  expect(status.authState).toBe("authenticated");
+  expect(status.provider).toBe("anthropic");
+});
+
+test("an unreachable runtime reports every card not-connected without throwing", async () => {
+  listProviders.mockRejectedValue(new Error("sandbox unreachable"));
+
+  const statuses = await client().providerStatuses(["anthropic", "opencode"]);
+
+  expect(statuses.map((s) => s.authState)).toEqual([
+    "unauthenticated",
+    "unauthenticated",
+  ]);
+});

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -846,19 +846,6 @@ export class HoustonClient {
     return this.request("GET", `/providers/${this.seg(name)}/status`);
   }
   /**
-   * Connect status for several providers at once. The legacy Rust engine has no
-   * batch endpoint, so this fans out to per-provider probes — identical to the
-   * `Promise.all(providerStatus)` callers used to write inline. The new TS-engine
-   * adapter OVERRIDES this with a single `listProviders()` round-trip (see
-   * `packages/web/src/engine-adapter/client.ts`), which is the whole point:
-   * screens that show many provider cards (settings, onboarding picker, chat
-   * model picker) call this once instead of probing each card separately, so on
-   * the new engine a dozen cards cost one round-trip, not a dozen (HOU-650).
-   */
-  providerStatuses(names: readonly string[]): Promise<ProviderStatus[]> {
-    return Promise.all(names.map((name) => this.providerStatus(name)));
-  }
-  /**
    * Launch the provider's CLI login. `opts.deviceAuth` requests the
    * provider's headless device-code flow (OpenAI/codex `--device-auth`)
    * for remote engines that can't receive the CLI's `localhost` OAuth

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -846,6 +846,19 @@ export class HoustonClient {
     return this.request("GET", `/providers/${this.seg(name)}/status`);
   }
   /**
+   * Connect status for several providers at once. The legacy Rust engine has no
+   * batch endpoint, so this fans out to per-provider probes — identical to the
+   * `Promise.all(providerStatus)` callers used to write inline. The new TS-engine
+   * adapter OVERRIDES this with a single `listProviders()` round-trip (see
+   * `packages/web/src/engine-adapter/client.ts`), which is the whole point:
+   * screens that show many provider cards (settings, onboarding picker, chat
+   * model picker) call this once instead of probing each card separately, so on
+   * the new engine a dozen cards cost one round-trip, not a dozen (HOU-650).
+   */
+  providerStatuses(names: readonly string[]): Promise<ProviderStatus[]> {
+    return Promise.all(names.map((name) => this.providerStatus(name)));
+  }
+  /**
    * Launch the provider's CLI login. `opts.deviceAuth` requests the
    * provider's headless device-code flow (OpenAI/codex `--device-auth`)
    * for remote engines that can't receive the CLI's `localhost` OAuth


### PR DESCRIPTION
Fixes HOU-650.

## Root cause (TS runtime engine)

On the **new TypeScript runtime engine**, `@houston-ai/engine-client` is aliased to the web engine-adapter (`packages/web/src/engine-adapter/client.ts`). Its per-card `providerStatus(name)` fetches the **entire** provider list via `listProviders()` and keeps a single entry.

The settings AI-provider section probes **every** card at once (`loadStatuses` mapped `checkMergedStatus` over ~a dozen providers, OpenCode counting as two gateways). So each scan fired **~a dozen identical `listProviders()` round-trips**, and in cloud every one is proxied through the control plane to the agent's sandbox pod. That fan-out is what made the cards slow. The same fan-out existed in the chat model picker (`useProviderStatuses`), the onboarding provider picker, and the agent-creation model selector.

## Fix

**Collapse N round-trips to 1 — new engine only, Rust engine untouched:**
- New batched `providerStatuses(names)` on the **new-engine adapter**: one `listProviders()`, derive every requested card's status from it. `providerStatus` delegates to it.
- `tauriProvider.checkAllStatuses(ids)` **feature-detects** that batched method and falls back to the existing per-provider `providerStatus` probe when it's absent. The legacy Rust engine client (`ui/engine-client`) is **not modified at all** — it's being retired, so it gets zero new code and keeps its current behavior via the fallback. (`ui/engine-client` has a zero diff against `main`.)
- A shared `mergeGatewayStatus()` helper replaces the per-card `checkMergedStatus()`. The settings section, onboarding picker, `useProviderStatuses` hook, and naming-step selector each now issue **one** round-trip per scan instead of N.

**Instant first paint (the "optimistic loading" ask):**
- `app/src/lib/provider-status-cache.ts` persists the last confirmed scan to localStorage; the settings section seeds its cards from it and renders immediately (no blocking spinner), then reconciles with the single live round-trip. Same boot-cache philosophy as the i18n locale flash-cache — a paint hint, never the source of truth. The `provider_configured` analytics baseline still comes from the first real scan, so the cached seed can't fire fake connect events.

## Sidebar entry

New **AI providers** item in the left sidebar (top-level `providers` view) rendering the same `ProviderSection`; the Settings → AI provider section stays. Localized en/pt (es `shell.json` is wholesale-divergent on main since #584 — pre-existing, untouched).

## Verify

**Before (on main):** open Settings → AI provider with several providers connected → cards sit behind a spinner while each provider is probed in its own round-trip (in cloud, ~a dozen proxied round-trips to the sandbox → multi-second wait).

**After:**
1. Settings → AI provider paints cards instantly from cache; the live reconcile is a single `listProviders()` round-trip (confirm in devtools/network: one provider-list fetch per scan, not one per card).
2. Left sidebar shows an **AI providers** item between Mission Control and Settings; it opens the same section.
3. Sign a provider out out-of-band and reopen → card shows last-known state briefly, then reconciles.

## Tests
- `packages/web/tests/provider-statuses-batch.test.ts`: batched adapter fetches the provider list **once** for many cards, maps each correctly (incl. gateway/unmapped/unreachable cases), and `providerStatus` delegates to the batch.
- `app/tests/provider-status-cache.test.ts`: round-trip, corrupt JSON, malformed entries, throwing storage.
- App suite 458/458, web suite 30/30, full monorepo typecheck + Biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)