### PR TITLE
fix(board): stop the chat panel flickering on a new chat's first message (HOU-640)

### DIFF
--- a/packages/web/e2e/chat.spec.ts
+++ b/packages/web/e2e/chat.spec.ts
@@ -47,6 +47,56 @@ test("sends a message with the Submit button", async ({ page }) => {
 });
 
 /**
+ * HOU-640: the first send must not flicker. AIBoard used to close its "new
+ * mission" state as soon as the created activity was selected, but the detail
+ * panel was gated on that activity being present in the refetched board
+ * query — so the whole chat panel unmounted until the refetch landed, then
+ * remounted. Stall the activity-list refetch and assert the optimistic user
+ * message renders immediately and stays visible through the whole window.
+ */
+test("first message keeps the chat panel mounted while the board refetches", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.locator('[data-tour-target="newMission"]').click();
+
+  const composer = page.getByPlaceholder("What should the agent work on?");
+  await expect(composer).toBeVisible();
+  await composer.fill("no flicker please");
+
+  // Once the create path has written the new activity (the PUT), stall every
+  // re-read of the board's activity list (both the files-first activity.json
+  // read and the REST route): the created activity stays absent from the
+  // board query for a beat — exactly the window where the panel used to
+  // unmount. The create path's own read-modify-write must NOT stall, so the
+  // stall arms only after the PUT.
+  let activityWritten = false;
+  await page.route(/\/activity\.json$|\/activities$/, async (route) => {
+    const req = route.request();
+    if (req.method() === "PUT") {
+      activityWritten = true;
+    } else if (activityWritten && req.method() === "GET") {
+      await new Promise((resolve) => setTimeout(resolve, 1500));
+    }
+    await route.continue();
+  });
+
+  await composer.press("Enter");
+
+  // The user's message renders right away, well before the stalled refetch
+  // resolves...
+  const message = page.getByText("no flicker please").first();
+  await expect(message).toBeVisible({ timeout: 1_000 });
+
+  // ...and never disappears — neither while the refetch is still pending nor
+  // when it lands and the panel switches to the resolved activity.
+  for (let i = 0; i < 10; i++) {
+    await page.waitForTimeout(200);
+    await expect(message).toBeVisible({ timeout: 100 });
+  }
+});
+
+/**
  * Reconnect resilience — the settle-on-close truncation regression. The SSE
  * stream is severed server-side mid-turn (a simulated network blip) while the
  * turn keeps producing into the fake host's replay log; the client must

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -363,6 +363,12 @@ export function AIBoard({
     if (selectedId) hydrateSession(selectedId);
   }, []);
 
+  // Set by handleSend right before it selects the conversation it just
+  // created, so the selection effect below can tell that internal
+  // selection apart from an external one (arrow keys, notification
+  // jump). Only external changes may close the "new mission" panel.
+  const createdSelectionRef = useRef<string | null>(null);
+
   // When the selection changes from OUTSIDE (e.g. arrow-key navigation
   // sets selectedId via the controlled prop, or session-notifications
   // jumps to a different mission), hydrate the new session, close any
@@ -371,7 +377,15 @@ export function AIBoard({
   useEffect(() => {
     if (!selectedId) return;
     hydrateSession(selectedId);
-    setNewPanelOpen(false);
+    if (createdSelectionRef.current === selectedId) {
+      // First-send flow: the freshly created activity isn't in `items`
+      // yet (the parent's list query is still refetching), so closing
+      // `newPanelOpen` would collapse `showPanel` and unmount the chat
+      // panel until the refetch lands (HOU-640).
+      createdSelectionRef.current = null;
+    } else {
+      setNewPanelOpen(false);
+    }
     setComposerFocusToken((prev) => (prev ?? 0) + 1);
   }, [selectedId, hydrateSession]);
 
@@ -412,8 +426,11 @@ export function AIBoard({
     [setSelectedId],
   );
 
-  // Resolve which session key and feed to show (merge persisted history + live items)
-  const activeSessionKey = selectedItem ? sessionKeyFor(selectedItem.id) : null;
+  // Resolve which session key and feed to show (merge persisted history +
+  // live items). Keyed off `selectedId`, not the resolved item: right after
+  // the first send the created activity isn't in `items` yet, but its feed
+  // (seeded with the optimistic user message) must render immediately.
+  const activeSessionKey = selectedId ? sessionKeyFor(selectedId) : null;
   // The session key currently visible in the detail panel's ChatPanel.
   const activeDraftKey = activeSessionKey ?? "new-conversation";
   const rawActiveFeed = activeSessionKey
@@ -437,8 +454,12 @@ export function AIBoard({
         onDraftChange?.(activeDraftKey, "");
         return;
       }
-      if (selectedItem && onSendMessage) {
-        await onSendMessage(sessionKeyFor(selectedItem.id), text, files);
+      if (activeSessionKey && onSendMessage) {
+        // Keyed off `activeSessionKey` (derived from `selectedId`), not
+        // `selectedItem`: a send fired while the created activity is
+        // still absent from `items` must go to the existing session,
+        // never fall through and create a duplicate conversation.
+        await onSendMessage(activeSessionKey, text, files);
         onDraftChange?.(activeDraftKey, "");
       } else if (newPanelOpen && onCreateConversation) {
         const activityId = await onCreateConversation(text, files);
@@ -448,9 +469,12 @@ export function AIBoard({
         // freshly-created activity isn't yet in `items` (the parent
         // invalidates the activity query asynchronously) and during
         // that window `selectedItem` is still null. Closing
-        // `newPanelOpen` here would collapse `showPanel` to false and
-        // dismiss the panel mid-create. `newPanelOpen` resets naturally
-        // on the next opener call, card select, or outside-click close.
+        // `newPanelOpen` would collapse `showPanel` to false and
+        // dismiss the panel mid-create — `createdSelectionRef` tells
+        // the selection effect above to keep it open. `newPanelOpen`
+        // resets naturally on the next external selection, card
+        // select, or outside-click close.
+        createdSelectionRef.current = activityId;
         setSelectedId(activityId);
       }
     },
@@ -460,9 +484,7 @@ export function AIBoard({
       activeFeed.length,
       activeDraftKey,
       onDraftChange,
-      selectedItem,
       onSendMessage,
-      sessionKeyFor,
       newPanelOpen,
       onCreateConversation,
       setSelectedId,
@@ -664,7 +686,7 @@ export function AIBoard({
           }
           queuedLabels={queuedLabels}
           placeholder={
-            selectedItem
+            activeSessionKey
               ? "Send a follow-up..."
               : "What should the agent work on?"
           }


### PR DESCRIPTION
Fixes HOU-640.

## Symptom

Start a new chat, send the first message: the chat panel closes for about a second, then reappears. Most visible on cloud/web, where the board-list refetch is a real network round-trip.

## Root cause

`AIBoard` gates its detail panel on `showPanel = selectedItem || newPanelOpen`. After the first send, `handleSend` selects the freshly created conversation — but the created activity is not yet in `items` (the parent invalidates the board list query asynchronously), so `selectedItem` is `null` during the refetch window.

`handleSend` deliberately leaves `newPanelOpen` truthy to bridge exactly that window (there's a long-standing comment documenting the race). The keyboard-navigation selection effect added later reintroduced the race from another path: it runs on **every** `selectedId` change and unconditionally calls `setNewPanelOpen(false)` — including for the internal selection right after create. `showPanel` collapsed to `false`, the portalled panel unmounted, and it remounted only when the refetch landed.

## Fix (`ui/board/src/ai-board.tsx`)

- `handleSend` marks its create-originated selection via a ref; the selection effect keeps `newPanelOpen` open for that one change. External selection changes (arrow keys, session-notification jumps) still close the new-mission panel as before.
- `activeSessionKey` now derives from `selectedId` instead of the resolved item, so the optimistic user message and the thinking indicator render immediately during the window instead of an empty "New conversation" state. Every `sessionKeyFor` implementation falls back to `activity-${id}`, which is exactly the key `createMission` seeds the feed under.
- The follow-up send branch keys off `activeSessionKey` too: a second send fired during the window now goes to the created session instead of falling through to `onCreateConversation` and creating a duplicate conversation.

## Reproduce (before the fix)

1. Run the web app against a host with real latency (or dev with network throttling).
2. Click "New mission", type a message, press Enter.
3. The detail panel disappears for the duration of the board refetch (~1s on cloud), then reappears with the message.

Deterministic repro: check out this branch, revert `ui/board/src/ai-board.tsx`, and run `pnpm --filter houston-web test:e2e chat.spec.ts -g "keeps the chat panel mounted"` — the new test fails (the sent message vanishes mid-window).

## Verify (after the fix)

1. Same steps as above: the panel stays mounted, the sent message and thinking indicator are visible continuously, and the panel header swaps in the generated title once the list refetch lands. No close/reopen.
2. `pnpm --filter houston-web test:e2e` — 16/16 pass, including the new regression test, which stalls the post-create activity-list re-read by 1.5s and asserts the sent message appears within 1s and stays visible through and past the stalled window.
3. `pnpm check`, `pnpm -r typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)