### PR TITLE
feat(skills): bring back the skills.sh marketplace + GitHub install (HOU-652)

### DIFF
--- a/app/src/components/tabs/job-description-tab.tsx
+++ b/app/src/components/tabs/job-description-tab.tsx
@@ -101,6 +101,11 @@ export default function JobDescriptionTab({ agent }: TabProps) {
               loading={surface.skillsLoading}
               loadingSkillName={surface.loadingSkillName}
               onSkillClick={surface.selectSkill}
+              onSearch={surface.handleSearch}
+              onPopular={surface.handlePopular}
+              onInstallCommunity={surface.handleInstallCommunity}
+              onListFromRepo={surface.handleListFromRepo}
+              onInstallFromRepo={surface.handleInstallFromRepo}
               onCreateFromScratch={surface.handleCreateFromScratch}
               installedSkillNames={surface.installedSkillNames}
             />

--- a/app/src/components/tabs/skills-content.tsx
+++ b/app/src/components/tabs/skills-content.tsx
@@ -5,6 +5,7 @@ import {
   EmptyTitle,
   Spinner,
 } from "@houston-ai/core";
+import type { CommunitySkill, RepoSkill } from "@houston-ai/skills";
 import { AddSkillDialog } from "@houston-ai/skills";
 import { Plus } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -19,6 +20,11 @@ export function SkillsContent({
   loading,
   loadingSkillName,
   onSkillClick,
+  onSearch,
+  onPopular,
+  onInstallCommunity,
+  onListFromRepo,
+  onInstallFromRepo,
   onCreateFromScratch,
   installedSkillNames,
 }: {
@@ -27,6 +33,17 @@ export function SkillsContent({
   /** Name of the skill whose detail is loading; its card spins + disables. */
   loadingSkillName?: string | null;
   onSkillClick: (name: string) => void;
+  onSearch?: (query: string, signal?: AbortSignal) => Promise<CommunitySkill[]>;
+  onPopular?: (signal?: AbortSignal) => Promise<CommunitySkill[]>;
+  onInstallCommunity?: (
+    skill: CommunitySkill,
+    signal?: AbortSignal,
+  ) => Promise<string>;
+  onListFromRepo?: (source: string) => Promise<RepoSkill[]>;
+  onInstallFromRepo?: (
+    source: string,
+    skills: RepoSkill[],
+  ) => Promise<string[]>;
   onCreateFromScratch?: (input: {
     name: string;
     description: string;
@@ -43,6 +60,11 @@ export function SkillsContent({
   );
   const addDialogProps = onCreateFromScratch
     ? {
+        onSearch,
+        onPopular,
+        onInstallCommunity,
+        onListFromRepo,
+        onInstallFromRepo,
         onCreateFromScratch,
         installedSkillNames,
       }

--- a/app/src/components/tabs/use-skill-surface.ts
+++ b/app/src/components/tabs/use-skill-surface.ts
@@ -1,16 +1,20 @@
-import type { Skill } from "@houston-ai/skills";
+import type { CommunitySkill, RepoSkill, Skill } from "@houston-ai/skills";
 import { useQueryClient } from "@tanstack/react-query";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useCreateSkill,
   useDeleteSkill,
+  useInstallCommunitySkill,
+  useInstallSkillFromRepo,
+  useListSkillsFromRepo,
   useSaveSkill,
   useSkillDetail,
   useSkills,
 } from "../../hooks/queries";
 import { isMissingSkillError } from "../../lib/missing-skill";
 import { queryKeys } from "../../lib/query-keys";
+import { tauriSkills } from "../../lib/tauri";
 import { useUIStore } from "../../stores/ui";
 import { resolveLoadingSkillName } from "./skill-loading-model";
 import { useSkillSurfaceLabels } from "./use-skill-surface-labels";
@@ -71,6 +75,9 @@ export function useSkillSurface(agentPath: string) {
   const saveSkill = useSaveSkill(agentPath);
   const deleteSkill = useDeleteSkill(agentPath);
   const createSkill = useCreateSkill(agentPath);
+  const installCommunity = useInstallCommunitySkill(agentPath);
+  const listFromRepo = useListSkillsFromRepo();
+  const installFromRepo = useInstallSkillFromRepo(agentPath);
 
   const selectedSkill: Skill | undefined =
     selectedSkillName && skillDetail
@@ -112,6 +119,38 @@ export function useSkillSurface(agentPath: string) {
     [deleteSkill],
   );
 
+  const handleSearch = useCallback(
+    (query: string, signal?: AbortSignal) =>
+      tauriSkills.searchCommunity(query, signal),
+    [],
+  );
+
+  const handlePopular = useCallback(
+    (signal?: AbortSignal) => tauriSkills.popularCommunity(signal),
+    [],
+  );
+
+  const handleInstallCommunity = useCallback(
+    async (skill: CommunitySkill, signal?: AbortSignal) =>
+      installCommunity.mutateAsync({
+        source: skill.source,
+        skillId: skill.skillId,
+        signal,
+      }),
+    [installCommunity],
+  );
+
+  const handleListFromRepo = useCallback(
+    async (source: string) => listFromRepo.mutateAsync(source),
+    [listFromRepo],
+  );
+
+  const handleInstallFromRepo = useCallback(
+    async (source: string, skills: RepoSkill[]) =>
+      installFromRepo.mutateAsync({ source, skills }),
+    [installFromRepo],
+  );
+
   const handleCreateFromScratch = useCallback(
     async (input: { name: string; description: string; content: string }) => {
       await createSkill.mutateAsync(input);
@@ -130,6 +169,11 @@ export function useSkillSurface(agentPath: string) {
     clearSelectedSkill,
     handleSkillSave,
     handleSkillDelete,
+    handleSearch,
+    handlePopular,
+    handleInstallCommunity,
+    handleListFromRepo,
+    handleInstallFromRepo,
     handleCreateFromScratch,
     installedSkillNames,
   };

--- a/app/src/hooks/queries/index.ts
+++ b/app/src/hooks/queries/index.ts
@@ -52,6 +52,9 @@ export {
 export {
   useCreateSkill,
   useDeleteSkill,
+  useInstallCommunitySkill,
+  useInstallSkillFromRepo,
+  useListSkillsFromRepo,
   useSaveSkill,
   useSkillDetail,
   useSkills,

--- a/app/src/hooks/queries/use-skills.ts
+++ b/app/src/hooks/queries/use-skills.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriSkills } from "../../lib/tauri";
+import type { RepoSkill } from "../../lib/types";
 
 export function useSkills(agentPath: string | undefined) {
   return useQuery({
@@ -65,6 +66,54 @@ export function useSaveSkill(agentPath: string | undefined) {
           queryKey: queryKeys.skillDetail(agentPath, name),
         });
       }
+    },
+  });
+}
+
+export function useListSkillsFromRepo() {
+  return useMutation({
+    mutationFn: (source: string) => tauriSkills.listFromRepo(source),
+  });
+}
+
+export function useInstallSkillFromRepo(agentPath: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      source,
+      skills,
+    }: {
+      source: string;
+      skills: RepoSkill[];
+    }) => {
+      if (!agentPath) throw new Error("agentPath is required");
+      return tauriSkills.installFromRepo(agentPath, source, skills);
+    },
+    onSuccess: () => {
+      if (agentPath)
+        qc.invalidateQueries({ queryKey: queryKeys.skills(agentPath) });
+    },
+  });
+}
+
+export function useInstallCommunitySkill(agentPath: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      source,
+      skillId,
+      signal,
+    }: {
+      source: string;
+      skillId: string;
+      signal?: AbortSignal;
+    }) => {
+      if (!agentPath) throw new Error("agentPath is required");
+      return tauriSkills.installCommunity(agentPath, source, skillId, signal);
+    },
+    onSuccess: () => {
+      if (agentPath)
+        qc.invalidateQueries({ queryKey: queryKeys.skills(agentPath) });
     },
   });
 }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -33,7 +33,9 @@ import { osIsTauri, osPickDirectory } from "./os-bridge";
 import { normalizeLegacyModel } from "./providers";
 import type {
   Agent,
+  CommunitySkillResult,
   FileEntry,
+  RepoSkill,
   SkillDetail,
   SkillSummary,
   Workspace,
@@ -430,6 +432,75 @@ export const tauriSkills = {
   save: (agentPath: string, name: string, content: string) =>
     call<void>("save_skill", () =>
       getEngine().saveSkill(name, { workspacePath: agentPath, content }),
+    ),
+  listFromRepo: (source: string) =>
+    call<RepoSkill[]>(
+      "list_skills_from_repo",
+      () => getEngine().listSkillsFromRepo(source),
+      undefined,
+      // The Add Skills dialog renders repo failures (typo'd repo, private,
+      // no skills) inline with plain-English copy — no red bug toast.
+      { toast: false },
+    ),
+  installFromRepo: (agentPath: string, source: string, skills: RepoSkill[]) =>
+    call<string[]>(
+      "install_skills_from_repo",
+      () =>
+        getEngine().installSkillsFromRepo({
+          workspacePath: agentPath,
+          source,
+          skills,
+        }),
+      undefined,
+      { toast: false },
+    ),
+  searchCommunity: (query: string, signal?: AbortSignal) =>
+    call<CommunitySkillResult[]>(
+      "search_community_skills",
+      async () =>
+        (await getEngine().searchCommunitySkills(query, signal)).map((s) => ({
+          id: s.id,
+          skillId: s.skillId,
+          name: s.name,
+          installs: s.installs,
+          source: s.source,
+        })),
+      undefined,
+      { toast: false },
+    ),
+  popularCommunity: (signal?: AbortSignal) =>
+    call<CommunitySkillResult[]>(
+      "popular_community_skills",
+      async () =>
+        (await getEngine().popularCommunitySkills(signal)).map((s) => ({
+          id: s.id,
+          skillId: s.skillId,
+          name: s.name,
+          installs: s.installs,
+          source: s.source,
+        })),
+      undefined,
+      { toast: false },
+    ),
+  installCommunity: (
+    agentPath: string,
+    source: string,
+    skillId: string,
+    signal?: AbortSignal,
+  ) =>
+    call<string>(
+      "install_community_skill",
+      () =>
+        getEngine().installCommunitySkill(
+          {
+            workspacePath: agentPath,
+            source,
+            skillId,
+          },
+          signal,
+        ),
+      undefined,
+      { toast: false },
     ),
 };
 

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -123,6 +123,23 @@ export interface SkillDetail {
   content: string;
 }
 
+/** Community skill search result */
+export interface CommunitySkillResult {
+  id: string;
+  skillId: string;
+  name: string;
+  installs: number;
+  source: string;
+}
+
+/** A skill discovered in a GitHub repo */
+export interface RepoSkill {
+  id: string;
+  name: string;
+  description: string;
+  path: string;
+}
+
 /** File entry returned by list_project_files */
 export interface FileEntry {
   path: string;

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -95,6 +95,11 @@ failures inline in the Add Skills UI; they should not show global "Houston
 problem" bug toasts for marketplace search misses.
 
 Both engines implement the same routes and resilience. TS host (current):
+the read-only marketplace surface (search/popular/repo-list — no workspace
+touched) is served top-level at `POST /v1/skills/...`
+(`packages/host/src/routes/skills-directory.ts`, what the web/desktop host
+adapter in `packages/web/src/engine-adapter/` calls) AND agent-scoped for the
+engine-client wire; installs are agent-scoped only.
 `packages/host/src/routes/skills-remote.ts` dispatches
 `POST skills/community/{search,popular,install}` and
 `POST skills/repo/{list,install}` to `packages/host/src/skills/`

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -88,18 +88,30 @@ Step-by-step instructions Claude follows when the Skill runs.
 ## Community search behavior
 
 `POST /v1/skills/community/search` calls `skills.sh`, which can rate-limit.
-Engine owns the resilience: successful searches are cached in-memory, outbound
-requests are globally spaced, and stale cached results are returned during a
-temporary 429/network failure. App search callers handle remaining failures
-inline in the Add Skills UI; they should not show global "Houston problem" bug
-toasts for marketplace search misses.
+The engine owns the resilience: successful searches are cached in-memory,
+outbound requests are globally spaced, and stale cached results are returned
+during a temporary 429/network failure. App search callers handle remaining
+failures inline in the Add Skills UI; they should not show global "Houston
+problem" bug toasts for marketplace search misses.
+
+Both engines implement the same routes and resilience. TS host (current):
+`packages/host/src/routes/skills-remote.ts` dispatches
+`POST skills/community/{search,popular,install}` and
+`POST skills/repo/{list,install}` to `packages/host/src/skills/`
+(`community.ts` = skills.sh cache/spacing/stale-fallback, `github.ts` +
+`github-parse.ts` = repo discovery, `install.ts` = install composition on the
+workspace Vfs). Typed failures answer `{error: {code, message, details:
+{kind}}}` so `HoustonEngineError.kind` carries the same
+`ui/skills/src/skill-error-kinds.ts` taxonomy the Rust engine emits. Legacy
+Rust oracle: `engine/houston-skills/src/remote.rs`.
 
 ## Installing a community / repo skill
 
 `install_skill` (skills.sh) and `install_from_repo` (GitHub) both route the
-fetched `SKILL.md` through `houston_skills::install_skill_md`, which **preserves
-the author's frontmatter** (description, category, integrations, image, inputs)
-instead of rebuilding a bare one. Two invariants matter:
+fetched `SKILL.md` through `houston_skills::install_skill_md` (Rust) /
+`composeInstalledSkillMd` in `packages/domain/src/skill-install.ts` (TS host),
+which **preserves the author's frontmatter** (description, category,
+integrations, image) instead of rebuilding a bare one. Two invariants matter:
 
 - The install slug owns the on-disk directory **and** the frontmatter `name`
   (derived from the source `name:` when valid, else a slugified id), so the two
@@ -112,8 +124,9 @@ instead of rebuilding a bare one. Two invariants matter:
 
 ### Repo input parsing (the "Install from another repo" field)
 
-`normalize_source` in `engine/houston-skills/src/remote.rs` is the single
-front door for whatever the user types into the repo field. It anchors on the
+`normalize_source` in `engine/houston-skills/src/remote.rs` (Rust) and
+`normalizeSource` in `packages/host/src/skills/github-parse.ts` (TS host) are
+the single front door for whatever the user types into the repo field. It anchors on the
 `github.com` host wherever it appears, so it recovers `owner/repo` from the
 short form, a full URL (`.git`, `/tree/main`, `?query`, `#frag` all tolerated),
 the SSH form (`git@github.com:owner/repo`), and even a whole pasted shell
@@ -236,6 +249,9 @@ The Rust engine applied the same directory-slug identity rule through different 
 |------|-------|
 | Skills domain (TS, current) | [`packages/domain/src/skills.ts`](../packages/domain/src/skills.ts) — parse + `loadSkills`/`loadSkillDetail`, identity = directory slug |
 | Skills host routes (TS, current) | [`packages/host/src/routes/skills.ts`](../packages/host/src/routes/skills.ts) — GET/POST/PUT/DELETE; missing skill → 404 |
+| Marketplace host routes (TS, current) | [`packages/host/src/routes/skills-remote.ts`](../packages/host/src/routes/skills-remote.ts) — skills.sh search/popular/install + GitHub repo list/install |
+| Marketplace remote logic (TS, current) | [`packages/host/src/skills/`](../packages/host/src/skills/) — community cache, GitHub discovery, install composition |
+| Install composition (TS, current) | [`packages/domain/src/skill-install.ts`](../packages/domain/src/skill-install.ts) — `composeInstalledSkillMd`, frontmatter-preserving |
 | Missing-skill classifier (TS, current) | [`app/src/lib/missing-skill.ts`](../app/src/lib/missing-skill.ts) — `isMissingSkillError` (404) keeps it off the bug-toast/Sentry path |
 | Skills surface hook (TS, current) | [`app/src/components/tabs/use-skill-surface.ts`](../app/src/components/tabs/use-skill-surface.ts) — inline "Skill unavailable" handling |
 | Schema (Rust) | [`engine/houston-skills/src/lib.rs`](../engine/houston-skills/src/lib.rs) |

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -7,5 +7,6 @@ export * from "./provider-model";
 export * from "./reactivity";
 export * from "./routines";
 export * from "./schedule";
+export * from "./skill-install";
 export * from "./skills";
 export * from "./store";

--- a/packages/domain/src/skill-install.test.ts
+++ b/packages/domain/src/skill-install.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "vitest";
+import {
+  composeInstalledSkillMd,
+  MAX_SKILL_DESCRIPTION_LEN,
+} from "./skill-install";
+import { parseSkillMd } from "./skills";
+
+const TODAY = "2026-07-03";
+
+const AUTHORED = `---
+name: Writing Plans
+description: Plan multi-step writing work
+version: 4
+created: 2024-01-01
+last_used: 2025-02-02
+category: writing
+integrations: [gmail]
+image: memo
+tags: [docs]
+---
+
+## Procedure
+Do the thing.
+`;
+
+test("preserves author frontmatter, resets bookkeeping, features the install", () => {
+  const md = composeInstalledSkillMd({
+    slug: "writing-plans",
+    rawMd: AUTHORED,
+    fallbackDescription: "fallback",
+    todayIsoDate: TODAY,
+  });
+  const parsed = parseSkillMd("writing-plans", md);
+  if ("error" in parsed) throw new Error(parsed.error);
+  expect(parsed.summary.name).toBe("writing-plans");
+  expect(parsed.summary.description).toBe("Plan multi-step writing work");
+  expect(parsed.summary.version).toBe(1);
+  expect(parsed.summary.created).toBe(TODAY);
+  expect(parsed.summary.lastUsed).toBe(TODAY);
+  expect(parsed.summary.featured).toBe(true);
+  expect(parsed.summary.category).toBe("writing");
+  expect(parsed.summary.integrations).toEqual(["gmail"]);
+  expect(parsed.summary.image).toBe("memo");
+  expect(parsed.summary.tags).toEqual(["docs"]);
+  expect(parsed.body).toContain("Do the thing.");
+});
+
+test("bare SKILL.md without frontmatter installs with the fallback description", () => {
+  const md = composeInstalledSkillMd({
+    slug: "bare-skill",
+    rawMd: "# Bare Skill\n\nJust instructions.",
+    fallbackDescription: "fallback desc",
+    todayIsoDate: TODAY,
+  });
+  const parsed = parseSkillMd("bare-skill", md);
+  if ("error" in parsed) throw new Error(parsed.error);
+  expect(parsed.summary.description).toBe("fallback desc");
+  expect(parsed.summary.featured).toBe(true);
+  expect(parsed.body).toContain("# Bare Skill");
+});
+
+test("empty author description falls back, long description is clamped", () => {
+  const long = "x".repeat(MAX_SKILL_DESCRIPTION_LEN + 50);
+  const md = composeInstalledSkillMd({
+    slug: "clamp-me",
+    rawMd: `---\nname: clamp-me\ndescription: ${long}\n---\n\nbody`,
+    fallbackDescription: "unused",
+    todayIsoDate: TODAY,
+  });
+  const parsed = parseSkillMd("clamp-me", md);
+  if ("error" in parsed) throw new Error(parsed.error);
+  expect(parsed.summary.description.length).toBeLessThanOrEqual(
+    MAX_SKILL_DESCRIPTION_LEN,
+  );
+
+  const empty = composeInstalledSkillMd({
+    slug: "no-desc",
+    rawMd: "---\nname: no-desc\n---\n\nbody",
+    fallbackDescription: "from fallback",
+    todayIsoDate: TODAY,
+  });
+  const p2 = parseSkillMd("no-desc", empty);
+  if ("error" in p2) throw new Error(p2.error);
+  expect(p2.summary.description).toBe("from fallback");
+});
+
+test("frontmatter name never survives — the slug owns identity", () => {
+  const md = composeInstalledSkillMd({
+    slug: "ai-sdk",
+    rawMd: "---\nname: Totally Different\ndescription: d\n---\n\nbody",
+    fallbackDescription: "f",
+    todayIsoDate: TODAY,
+  });
+  expect(md).toContain("name: ai-sdk");
+  expect(md).not.toContain("Totally Different");
+});

--- a/packages/domain/src/skill-install.ts
+++ b/packages/domain/src/skill-install.ts
@@ -1,0 +1,66 @@
+import { stringify as stringifyYaml } from "yaml";
+import { parseSkillMd } from "./skills";
+
+/**
+ * Compose the SKILL.md for an installed community/repo skill, **preserving the
+ * author's frontmatter** (description, category, integrations, image, tags)
+ * instead of rebuilding a bare one like the create flow does.
+ *
+ * `slug` becomes both the on-disk directory and the frontmatter `name`, so the
+ * two never drift. Bookkeeping is reset to a fresh install (version 1, today's
+ * dates) and the skill is marked `featured` — the user explicitly chose to
+ * install it, so it must surface on the chat empty state rather than hiding
+ * under "Other". Falls back to a minimal skill (`fallbackDescription` + the
+ * raw body) when the source has no parseable frontmatter, so a bare SKILL.md
+ * still installs instead of failing.
+ *
+ * Pure: the caller supplies the date and writes the result to its store.
+ */
+
+export const MAX_SKILL_DESCRIPTION_LEN = 256;
+
+export function composeInstalledSkillMd(input: {
+  slug: string;
+  rawMd: string;
+  fallbackDescription: string;
+  todayIsoDate: string;
+}): string {
+  const parsed = parseSkillMd(input.slug, input.rawMd);
+  const source =
+    "error" in parsed
+      ? { summary: null, body: input.rawMd.trim() }
+      : { summary: parsed.summary, body: parsed.body.trim() };
+
+  const description = clampLen(
+    (source.summary?.description.trim() || input.fallbackDescription).trim(),
+    MAX_SKILL_DESCRIPTION_LEN,
+  );
+
+  const fm: Record<string, unknown> = {
+    name: input.slug,
+    description,
+    version: 1,
+    created: input.todayIsoDate,
+    last_used: input.todayIsoDate,
+  };
+  if (source.summary?.category) fm.category = source.summary.category;
+  fm.featured = true;
+  if (source.summary?.integrations.length)
+    fm.integrations = source.summary.integrations;
+  if (source.summary?.image) fm.image = source.summary.image;
+  if (source.summary?.tags.length) fm.tags = source.summary.tags;
+
+  return `---\n${stringifyYaml(fm).trimEnd()}\n---\n\n${source.body}\n`;
+}
+
+/** Truncate to `max` characters without splitting a surrogate pair. */
+function clampLen(s: string, max: number): string {
+  if (s.length <= max) return s;
+  const chars = [...s];
+  let out = "";
+  for (const c of chars) {
+    if (out.length + c.length > max) break;
+    out += c;
+  }
+  return out.trimEnd();
+}

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -26,6 +26,7 @@ import { handleAgentFile } from "./agent-file";
 import { json, readJson } from "./http";
 import { handlePortableExport } from "./portable";
 import { handleSkills } from "./skills";
+import { handleSkillsRemote } from "./skills-remote";
 
 export interface AgentRouteDeps {
   store: WorkspaceStore;
@@ -486,6 +487,19 @@ export async function handleAgents(
     )
       return true;
     if (await handleSkills(deps.vfs, paths, ctx, method, rest, req, res, emit))
+      return true;
+    if (
+      await handleSkillsRemote(
+        deps.vfs,
+        paths,
+        ctx,
+        method,
+        rest,
+        req,
+        res,
+        emit,
+      )
+    )
       return true;
     // The Files tab: served by the HOST off the workspace vfs for every profile
     // (the runtime has no /files route). Same handler cloud + local — zero drift.

--- a/packages/host/src/routes/skills-directory.test.ts
+++ b/packages/host/src/routes/skills-directory.test.ts
@@ -1,0 +1,83 @@
+import { createServer, type Server } from "node:http";
+import { afterAll, beforeAll, expect, test } from "vitest";
+import { handleSkillsDirectory } from "./skills-directory";
+
+/**
+ * The user-scoped (no-agent) marketplace reads the web/desktop host adapter
+ * calls while browsing: /v1/skills/community/{search,popular} + repo/list.
+ */
+
+const outbound: typeof fetch = async (input) => {
+  const url = String(input);
+  if (url === "https://api.github.com/repos/owner/repo")
+    return new Response("{}");
+  if (url.includes("git/trees/HEAD"))
+    return new Response(
+      JSON.stringify({
+        tree: [{ path: "research/SKILL.md", type: "blob" }],
+        truncated: false,
+      }),
+    );
+  if (url.includes("raw.githubusercontent.com/owner/repo/main/research/"))
+    return new Response(
+      "---\nname: research\ndescription: Deep research\n---\n\n# Research\n\nSteps.",
+    );
+  return new Response("", { status: 404 });
+};
+
+let server: Server;
+let base = "";
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    void handleSkillsDirectory(req.method ?? "GET", req.url ?? "/", req, res, {
+      fetchImpl: outbound,
+    }).then((handled) => {
+      if (!handled) {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((r) => server.close(() => r()));
+});
+
+test("top-level repo list serves discovery without an agent in scope", async () => {
+  const res = await fetch(`${base}/v1/skills/repo/list`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ source: "github.com/owner/repo" }),
+  });
+  expect(res.status).toBe(200);
+  const skills = (await res.json()) as Array<{ id: string }>;
+  expect(skills[0]?.id).toBe("research");
+});
+
+test("typed errors expose kind at both shapes the two clients read", async () => {
+  const res = await fetch(`${base}/v1/skills/repo/list`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ source: "not a repo" }),
+  });
+  expect(res.status).toBe(400);
+  const body = (await res.json()) as {
+    error: { kind: string; details: { kind: string } };
+  };
+  expect(body.error.kind).toBe("invalid_repo_source");
+  expect(body.error.details.kind).toBe("invalid_repo_source");
+});
+
+test("non-marketplace paths fall through; GET answers 405", async () => {
+  const miss = await fetch(`${base}/v1/skills/community/install`, {
+    method: "POST",
+  });
+  expect(miss.status).toBe(404); // install is agent-scoped, not served here
+  const get = await fetch(`${base}/v1/skills/repo/list`);
+  expect(get.status).toBe(405);
+});

--- a/packages/host/src/routes/skills-directory.ts
+++ b/packages/host/src/routes/skills-directory.ts
@@ -1,0 +1,110 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { CommunityDirectory } from "../skills/community";
+import { listSkillsFromRepo } from "../skills/github";
+import { SkillRemoteError } from "../skills/remote-error";
+import { json, readJson } from "./http";
+
+/**
+ * The read-only marketplace surface: skills.sh search/popular and GitHub repo
+ * discovery. These touch no workspace, so they're served both top-level
+ * (`/v1/skills/...` — what the web/desktop host adapter calls, which has no
+ * agent in scope while browsing) and agent-scoped (skills-remote.ts, the
+ * engine-client wire). One directory instance per process so the skills.sh
+ * cache + request spacing are global (mirrors the Rust engine's static cache).
+ */
+
+const directory = new CommunityDirectory();
+
+/** Typed errors answer `{error: {code, message, kind, details: {kind}}}` so
+ *  both `HoustonEngineError` shapes — the engine-client's (`details.kind`) and
+ *  the web adapter's (`error.kind`) — surface the same taxonomy the Add Skills
+ *  dialog matches on. */
+export function failSkill(res: ServerResponse, err: unknown): void {
+  if (err instanceof SkillRemoteError) {
+    const code =
+      err.httpStatus === 400
+        ? "BAD_REQUEST"
+        : err.httpStatus === 404
+          ? "NOT_FOUND"
+          : "UNAVAILABLE";
+    json(res, err.httpStatus, {
+      error: {
+        code,
+        message: err.message,
+        kind: err.kind,
+        details: { kind: err.kind },
+      },
+    });
+    return;
+  }
+  json(res, 502, {
+    error: err instanceof Error ? err.message : String(err),
+  });
+}
+
+export async function communitySearchAction(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const body = await readJson(req);
+  if (typeof body.query !== "string") {
+    json(res, 400, { error: "missing 'query'" });
+    return;
+  }
+  try {
+    json(res, 200, await directory.search(body.query));
+  } catch (err) {
+    failSkill(res, err);
+  }
+}
+
+export async function communityPopularAction(
+  res: ServerResponse,
+): Promise<void> {
+  try {
+    json(res, 200, await directory.popular());
+  } catch (err) {
+    failSkill(res, err);
+  }
+}
+
+export async function repoListAction(
+  req: IncomingMessage,
+  res: ServerResponse,
+  fetchImpl: typeof fetch,
+): Promise<void> {
+  const body = await readJson(req);
+  if (typeof body.source !== "string") {
+    json(res, 400, { error: "missing 'source'" });
+    return;
+  }
+  try {
+    const { skills } = await listSkillsFromRepo(fetchImpl, body.source);
+    json(res, 200, skills);
+  } catch (err) {
+    failSkill(res, err);
+  }
+}
+
+/** Top-level (user-scoped, post-auth) marketplace reads. Returns true when handled. */
+export async function handleSkillsDirectory(
+  method: string,
+  path: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: { fetchImpl?: typeof fetch } = {},
+): Promise<boolean> {
+  const m = path.match(
+    /^\/v1\/skills\/(community\/(?:search|popular)|repo\/list)$/,
+  );
+  if (!m) return false;
+  if (method !== "POST") {
+    json(res, 405, { error: "method not allowed" });
+    return true;
+  }
+  const route = m[1];
+  if (route === "community/search") await communitySearchAction(req, res);
+  else if (route === "community/popular") await communityPopularAction(res);
+  else await repoListAction(req, res, deps.fetchImpl ?? fetch);
+  return true;
+}

--- a/packages/host/src/routes/skills-remote.test.ts
+++ b/packages/host/src/routes/skills-remote.test.ts
@@ -1,0 +1,150 @@
+import { createServer, type Server } from "node:http";
+import type { HoustonEvent } from "@houston/protocol";
+import { afterAll, beforeAll, expect, test } from "vitest";
+import type { Agent, Workspace } from "../domain/types";
+import { CloudPaths } from "../paths";
+import { MemoryVfs } from "../vfs";
+import { handleSkillsRemote } from "./skills-remote";
+
+/**
+ * The marketplace routes: skills.sh search/install + GitHub repo list/install
+ * land under the same per-agent skills surface, write real SKILL.md files,
+ * emit SkillsChanged, and answer typed `{error: {details: {kind}}}` bodies so
+ * the Add Skills dialog renders plain-English error states.
+ */
+
+const ws = { id: "w1", ownerUserId: "alice" } as Workspace;
+const agent = { id: "a1", workspaceId: "w1" } as Agent;
+const paths = new CloudPaths();
+const vfs = new MemoryVfs();
+const events: HoustonEvent[] = [];
+
+const RESEARCH_MD =
+  "---\nname: research\ndescription: Deep research\n---\n\n# Research\n\nSteps.";
+
+const outbound: typeof fetch = async (input) => {
+  const url = String(input);
+  if (url.startsWith("https://skills.sh/api/search"))
+    return new Response(
+      JSON.stringify({
+        skills: [
+          {
+            id: "owner/repo/research",
+            skillId: "research",
+            name: "research",
+            installs: 42,
+            source: "owner/repo",
+          },
+        ],
+      }),
+    );
+  if (url === "https://api.github.com/repos/owner/repo")
+    return new Response("{}");
+  if (url.includes("api.github.com/repos/owner/repo/git/trees/HEAD"))
+    return new Response(
+      JSON.stringify({
+        tree: [{ path: "research/SKILL.md", type: "blob" }],
+        truncated: false,
+      }),
+    );
+  if (url.includes("raw.githubusercontent.com/owner/repo/main/"))
+    return url.includes("research/SKILL.md")
+      ? new Response(RESEARCH_MD)
+      : new Response("", { status: 404 });
+  return new Response("", { status: 404 });
+};
+
+let server: Server;
+let base = "";
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const rest = (req.url ?? "").replace(/^\//, "");
+    void handleSkillsRemote(
+      vfs,
+      paths,
+      { workspace: ws, agent },
+      req.method ?? "GET",
+      rest,
+      req,
+      res,
+      (e) => events.push(e),
+      { fetchImpl: outbound },
+    ).then((handled) => {
+      if (!handled) {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((r) => server.close(() => r()));
+});
+
+const post = (path: string, body?: unknown) =>
+  fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+test("community search + popular answer skills.sh results", async () => {
+  const search = await post("/skills/community/search", { query: "research" });
+  expect(search.status).toBe(200);
+  const hits = (await search.json()) as Array<{ skillId: string }>;
+  expect(hits[0]?.skillId).toBe("research");
+
+  const popular = await post("/skills/community/popular");
+  expect(popular.status).toBe(200);
+});
+
+test("repo list + install write the skill and emit SkillsChanged", async () => {
+  const list = await post("/skills/repo/list", {
+    source: "https://github.com/owner/repo",
+  });
+  expect(list.status).toBe(200);
+  const skills = (await list.json()) as Array<{ id: string; path: string }>;
+  expect(skills[0]?.id).toBe("research");
+
+  const install = await post("/skills/repo/install", {
+    source: "owner/repo",
+    skills,
+  });
+  expect(install.status).toBe(200);
+  expect(await install.json()).toEqual(["research"]);
+
+  const root = paths.agentRoot(ws, agent);
+  const md = await vfs.readText(`${root}/.agents/skills/research/SKILL.md`);
+  expect(md).toContain("featured: true");
+  expect(events.some((e) => e.type === "SkillsChanged")).toBe(true);
+});
+
+test("community install resolves the skill and returns its slug", async () => {
+  const res = await post("/skills/community/install", {
+    source: "owner/repo",
+    skillId: "research",
+  });
+  expect(res.status).toBe(200);
+  expect(await res.json()).toBe("research");
+});
+
+test("garbage repo input answers a typed invalid_repo_source", async () => {
+  const res = await post("/skills/repo/list", { source: "reconciliation" });
+  expect(res.status).toBe(400);
+  const body = (await res.json()) as {
+    error: { details: { kind: string } };
+  };
+  expect(body.error.details.kind).toBe("invalid_repo_source");
+});
+
+test("unhandled paths fall through; bad methods answer 405", async () => {
+  const get = await fetch(`${base}/skills/repo/list`);
+  expect(get.status).toBe(405);
+  const misc = await post("/skills/community/unknown");
+  expect(misc.status).toBe(404);
+});

--- a/packages/host/src/routes/skills-remote.ts
+++ b/packages/host/src/routes/skills-remote.ts
@@ -1,0 +1,163 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { HoustonEvent, RepoSkill } from "@houston/protocol";
+import type { Agent, Workspace } from "../domain/types";
+import type { WorkspacePaths } from "../paths";
+import { CommunityDirectory } from "../skills/community";
+import { listSkillsFromRepo } from "../skills/github";
+import {
+  installCommunitySkill,
+  installSkillsFromRepo,
+} from "../skills/install";
+import { SkillRemoteError } from "../skills/remote-error";
+import type { Vfs } from "../vfs";
+import { json, readJson } from "./http";
+
+/**
+ * The marketplace half of the skills surface: skills.sh community search +
+ * install and GitHub-repo discovery + install, feeding the same
+ * `.agents/skills/<slug>/SKILL.md` folders the CRUD routes serve. One
+ * directory instance per process so the skills.sh cache + request spacing are
+ * global (mirrors the legacy Rust engine's static cache).
+ */
+
+const directory = new CommunityDirectory();
+
+/** Typed errors answer `{error: {code, message, details: {kind}}}` so the
+ *  engine-client's `HoustonEngineError.kind` (and the Add Skills dialog's
+ *  plain-English error states) work identically against both engines. */
+function fail(res: ServerResponse, err: unknown): void {
+  if (err instanceof SkillRemoteError) {
+    const code =
+      err.httpStatus === 400
+        ? "BAD_REQUEST"
+        : err.httpStatus === 404
+          ? "NOT_FOUND"
+          : "UNAVAILABLE";
+    json(res, err.httpStatus, {
+      error: { code, message: err.message, details: { kind: err.kind } },
+    });
+    return;
+  }
+  json(res, 502, {
+    error: err instanceof Error ? err.message : String(err),
+  });
+}
+
+export interface RemoteSkillsDeps {
+  /** Injection point for tests; production uses the global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+export async function handleSkillsRemote(
+  vfs: Vfs | undefined,
+  paths: WorkspacePaths,
+  ctx: { workspace: Workspace; agent: Agent },
+  method: string,
+  rest: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+  emit?: (event: HoustonEvent) => void,
+  deps: RemoteSkillsDeps = {},
+): Promise<boolean> {
+  const m = rest.match(/^skills\/(community|repo)\/([a-z]+)$/);
+  if (!m) return false;
+  const [, family, action] = m;
+  if (method !== "POST") {
+    json(res, 405, { error: "method not allowed" });
+    return true;
+  }
+  const fetchImpl = deps.fetchImpl ?? fetch;
+
+  if (family === "community" && action === "search") {
+    const body = await readJson(req);
+    if (typeof body.query !== "string") {
+      json(res, 400, { error: "missing 'query'" });
+      return true;
+    }
+    try {
+      json(res, 200, await directory.search(body.query));
+    } catch (err) {
+      fail(res, err);
+    }
+    return true;
+  }
+
+  if (family === "community" && action === "popular") {
+    try {
+      json(res, 200, await directory.popular());
+    } catch (err) {
+      fail(res, err);
+    }
+    return true;
+  }
+
+  if (!vfs) {
+    json(res, 503, { error: "agent data not configured" });
+    return true;
+  }
+  const root = paths.agentRoot(ctx.workspace, ctx.agent);
+  const fireChange = () =>
+    emit?.({ type: "SkillsChanged", agentPath: ctx.agent.id });
+
+  if (family === "community" && action === "install") {
+    const body = await readJson(req);
+    if (typeof body.source !== "string" || typeof body.skillId !== "string") {
+      json(res, 400, { error: "missing 'source' or 'skillId'" });
+      return true;
+    }
+    try {
+      const slug = await installCommunitySkill(
+        fetchImpl,
+        vfs,
+        root,
+        body.source,
+        body.skillId,
+      );
+      fireChange();
+      json(res, 200, slug);
+    } catch (err) {
+      fail(res, err);
+    }
+    return true;
+  }
+
+  if (family === "repo" && action === "list") {
+    const body = await readJson(req);
+    if (typeof body.source !== "string") {
+      json(res, 400, { error: "missing 'source'" });
+      return true;
+    }
+    try {
+      const { skills } = await listSkillsFromRepo(fetchImpl, body.source);
+      json(res, 200, skills);
+    } catch (err) {
+      fail(res, err);
+    }
+    return true;
+  }
+
+  if (family === "repo" && action === "install") {
+    const body = await readJson(req);
+    if (typeof body.source !== "string" || !Array.isArray(body.skills)) {
+      json(res, 400, { error: "missing 'source' or 'skills'" });
+      return true;
+    }
+    try {
+      const installed = await installSkillsFromRepo(
+        fetchImpl,
+        vfs,
+        root,
+        body.source,
+        body.skills as RepoSkill[],
+      );
+      fireChange();
+      json(res, 200, installed);
+    } catch (err) {
+      fail(res, err);
+    }
+    return true;
+  }
+
+  json(res, 404, { error: "not found" });
+  return true;
+}

--- a/packages/host/src/routes/skills-remote.ts
+++ b/packages/host/src/routes/skills-remote.ts
@@ -2,46 +2,26 @@ import type { IncomingMessage, ServerResponse } from "node:http";
 import type { HoustonEvent, RepoSkill } from "@houston/protocol";
 import type { Agent, Workspace } from "../domain/types";
 import type { WorkspacePaths } from "../paths";
-import { CommunityDirectory } from "../skills/community";
-import { listSkillsFromRepo } from "../skills/github";
 import {
   installCommunitySkill,
   installSkillsFromRepo,
 } from "../skills/install";
-import { SkillRemoteError } from "../skills/remote-error";
 import type { Vfs } from "../vfs";
 import { json, readJson } from "./http";
+import {
+  communityPopularAction,
+  communitySearchAction,
+  failSkill,
+  repoListAction,
+} from "./skills-directory";
 
 /**
- * The marketplace half of the skills surface: skills.sh community search +
- * install and GitHub-repo discovery + install, feeding the same
- * `.agents/skills/<slug>/SKILL.md` folders the CRUD routes serve. One
- * directory instance per process so the skills.sh cache + request spacing are
- * global (mirrors the legacy Rust engine's static cache).
+ * The agent-scoped marketplace surface: installs write into the agent's
+ * `.agents/skills/<slug>/SKILL.md` (the same folders pi loads), and the
+ * read-only search/popular/list routes are also served here for the
+ * engine-client wire (which scopes every call under /agents/:id). The shared
+ * skills.sh cache + typed error shape live in skills-directory.ts.
  */
-
-const directory = new CommunityDirectory();
-
-/** Typed errors answer `{error: {code, message, details: {kind}}}` so the
- *  engine-client's `HoustonEngineError.kind` (and the Add Skills dialog's
- *  plain-English error states) work identically against both engines. */
-function fail(res: ServerResponse, err: unknown): void {
-  if (err instanceof SkillRemoteError) {
-    const code =
-      err.httpStatus === 400
-        ? "BAD_REQUEST"
-        : err.httpStatus === 404
-          ? "NOT_FOUND"
-          : "UNAVAILABLE";
-    json(res, err.httpStatus, {
-      error: { code, message: err.message, details: { kind: err.kind } },
-    });
-    return;
-  }
-  json(res, 502, {
-    error: err instanceof Error ? err.message : String(err),
-  });
-}
 
 export interface RemoteSkillsDeps {
   /** Injection point for tests; production uses the global fetch. */
@@ -69,25 +49,15 @@ export async function handleSkillsRemote(
   const fetchImpl = deps.fetchImpl ?? fetch;
 
   if (family === "community" && action === "search") {
-    const body = await readJson(req);
-    if (typeof body.query !== "string") {
-      json(res, 400, { error: "missing 'query'" });
-      return true;
-    }
-    try {
-      json(res, 200, await directory.search(body.query));
-    } catch (err) {
-      fail(res, err);
-    }
+    await communitySearchAction(req, res);
     return true;
   }
-
   if (family === "community" && action === "popular") {
-    try {
-      json(res, 200, await directory.popular());
-    } catch (err) {
-      fail(res, err);
-    }
+    await communityPopularAction(res);
+    return true;
+  }
+  if (family === "repo" && action === "list") {
+    await repoListAction(req, res, fetchImpl);
     return true;
   }
 
@@ -116,22 +86,7 @@ export async function handleSkillsRemote(
       fireChange();
       json(res, 200, slug);
     } catch (err) {
-      fail(res, err);
-    }
-    return true;
-  }
-
-  if (family === "repo" && action === "list") {
-    const body = await readJson(req);
-    if (typeof body.source !== "string") {
-      json(res, 400, { error: "missing 'source'" });
-      return true;
-    }
-    try {
-      const { skills } = await listSkillsFromRepo(fetchImpl, body.source);
-      json(res, 200, skills);
-    } catch (err) {
-      fail(res, err);
+      failSkill(res, err);
     }
     return true;
   }
@@ -153,7 +108,7 @@ export async function handleSkillsRemote(
       fireChange();
       json(res, 200, installed);
     } catch (err) {
-      fail(res, err);
+      failSkill(res, err);
     }
     return true;
   }

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -31,6 +31,7 @@ import {
 } from "./routes/integrations";
 import { handleSandboxIntegrations } from "./routes/integrations-sandbox";
 import { handlePortableAccount } from "./routes/portable";
+import { handleSkillsDirectory } from "./routes/skills-directory";
 import type { Vfs } from "./vfs";
 
 export type { RuntimeProxy } from "./channel/proxy";
@@ -194,6 +195,9 @@ async function handle(
   }
 
   // User-level resources (workspaces, preferences) — no agent in the path.
+  // Marketplace reads (skills.sh search/popular, GitHub repo discovery) are
+  // user-scoped too: browsing has no agent yet; only installs are per-agent.
+  if (await handleSkillsDirectory(method, path, req, res)) return;
   if (await handleAccount(deps, userId, method, path, req, res)) return;
   if (await handlePortableAccount(deps, userId, method, path, req, res)) return;
   if (await handleIntegrations(deps, userId, method, path, req, res)) return;

--- a/packages/host/src/skills/community.ts
+++ b/packages/host/src/skills/community.ts
@@ -1,0 +1,174 @@
+import type { CommunitySkill } from "@houston/protocol";
+import { SkillRemoteError } from "./remote-error";
+
+/**
+ * skills.sh community directory client. The host owns the resilience the KB
+ * documents for this surface: successful searches are cached in-memory,
+ * outbound requests are globally spaced, and stale cached results are
+ * returned during a temporary 429/network failure — so a rate-limited
+ * marketplace degrades to slightly-old results instead of an error wall.
+ */
+
+const SEARCH_ENDPOINT = "https://skills.sh/api/search";
+const SEARCH_RETRY_DELAY_MS = 3_000;
+const SEARCH_FRESH_TTL_MS = 10 * 60_000;
+const SEARCH_STALE_TTL_MS = 24 * 60 * 60_000;
+const SEARCH_MIN_INTERVAL_MS = 750;
+
+/**
+ * Seed query for the "popular" feed. skills.sh has no dedicated popular
+ * endpoint, but /api/search returns results sorted by install count
+ * regardless of relevance, so any broad term works. Cached 24h on its own
+ * slot so it never competes with user-typed search.
+ */
+const POPULAR_SEED = "ai";
+const POPULAR_FRESH_TTL_MS = 24 * 60 * 60_000;
+const POPULAR_LIMIT = 20;
+
+interface CachedSearch {
+  skills: CommunitySkill[];
+  fetchedAt: number;
+}
+
+export interface CommunityDirectoryOptions {
+  fetchImpl?: typeof fetch;
+  endpoint?: string;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  retryDelayMs?: number;
+  minIntervalMs?: number;
+  freshTtlMs?: number;
+  staleTtlMs?: number;
+  popularFreshTtlMs?: number;
+}
+
+const realSleep = (ms: number) =>
+  new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+export class CommunityDirectory {
+  private readonly fetchImpl: typeof fetch;
+  private readonly endpoint: string;
+  private readonly now: () => number;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly retryDelayMs: number;
+  private readonly minIntervalMs: number;
+  private readonly freshTtlMs: number;
+  private readonly staleTtlMs: number;
+  private readonly popularFreshTtlMs: number;
+
+  private readonly entries = new Map<string, CachedSearch>();
+  private popularEntry: CachedSearch | null = null;
+  /** Earliest timestamp the next outbound request may fire (global spacing). */
+  private nextAllowedRequest = 0;
+
+  constructor(opts: CommunityDirectoryOptions = {}) {
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+    this.endpoint = opts.endpoint ?? SEARCH_ENDPOINT;
+    this.now = opts.now ?? Date.now;
+    this.sleep = opts.sleep ?? realSleep;
+    this.retryDelayMs = opts.retryDelayMs ?? SEARCH_RETRY_DELAY_MS;
+    this.minIntervalMs = opts.minIntervalMs ?? SEARCH_MIN_INTERVAL_MS;
+    this.freshTtlMs = opts.freshTtlMs ?? SEARCH_FRESH_TTL_MS;
+    this.staleTtlMs = opts.staleTtlMs ?? SEARCH_STALE_TTL_MS;
+    this.popularFreshTtlMs = opts.popularFreshTtlMs ?? POPULAR_FRESH_TTL_MS;
+  }
+
+  async search(query: string): Promise<CommunitySkill[]> {
+    const trimmed = query.trim();
+    if ([...trimmed].length < 2) return [];
+    const key = trimmed.toLowerCase();
+
+    const cached = this.entries.get(key);
+    if (cached && this.now() - cached.fetchedAt <= this.freshTtlMs)
+      return cached.skills;
+
+    await this.waitForRequestSlot();
+    try {
+      const skills = await this.fetchSearch(trimmed);
+      this.entries.set(key, { skills, fetchedAt: this.now() });
+      return skills;
+    } catch (err) {
+      const stale = this.entries.get(key);
+      if (stale && this.now() - stale.fetchedAt <= this.staleTtlMs) {
+        console.warn(
+          `[host-skills] community search failed, returning cached results: ${err}`,
+        );
+        return stale.skills;
+      }
+      throw err;
+    }
+  }
+
+  async popular(): Promise<CommunitySkill[]> {
+    const fresh = this.popularEntry;
+    if (fresh && this.now() - fresh.fetchedAt <= this.popularFreshTtlMs)
+      return fresh.skills.slice(0, POPULAR_LIMIT);
+
+    await this.waitForRequestSlot();
+    try {
+      const skills = await this.fetchSearch(POPULAR_SEED);
+      this.popularEntry = { skills, fetchedAt: this.now() };
+      return skills.slice(0, POPULAR_LIMIT);
+    } catch (err) {
+      const stale = this.popularEntry;
+      if (stale && this.now() - stale.fetchedAt <= this.staleTtlMs) {
+        console.warn(
+          `[host-skills] popular feed fetch failed, returning cached results: ${err}`,
+        );
+        return stale.skills.slice(0, POPULAR_LIMIT);
+      }
+      throw err;
+    }
+  }
+
+  /** Reserve the next outbound slot and wait until it opens. */
+  private async waitForRequestSlot(): Promise<void> {
+    const now = this.now();
+    const target = Math.max(this.nextAllowedRequest, now);
+    this.nextAllowedRequest = target + this.minIntervalMs;
+    if (target > now) await this.sleep(target - now);
+  }
+
+  /** One search round-trip. Retries once after a delay on HTTP 429. */
+  private async fetchSearch(query: string): Promise<CommunitySkill[]> {
+    for (let attempt = 0; ; attempt++) {
+      let res: Response;
+      try {
+        res = await this.fetchImpl(
+          `${this.endpoint}?q=${encodeURIComponent(query)}`,
+          { headers: { "User-Agent": "houston-skills/1.0" } },
+        );
+      } catch (err) {
+        throw new SkillRemoteError(
+          "offline",
+          `skills.sh search failed: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      if (res.status === 429 && attempt === 0) {
+        await this.sleep(this.retryDelayMs);
+        continue;
+      }
+      if (res.status === 429) {
+        throw new SkillRemoteError(
+          "rate_limited",
+          "skills.sh rate limit hit, wait a moment and try again",
+        );
+      }
+      if (!res.ok) {
+        throw new SkillRemoteError(
+          "offline",
+          `Skills search failed (${res.status})`,
+        );
+      }
+
+      const body = (await res.json().catch(() => null)) as {
+        skills?: unknown;
+      } | null;
+      if (!body || !Array.isArray(body.skills)) {
+        throw new SkillRemoteError("offline", "Failed to parse results");
+      }
+      return body.skills as CommunitySkill[];
+    }
+  }
+}

--- a/packages/host/src/skills/github-parse.ts
+++ b/packages/host/src/skills/github-parse.ts
@@ -1,0 +1,135 @@
+/**
+ * Pure parsing halves of GitHub skill discovery: source normalization, slug
+ * derivation, and lightweight remote-SKILL.md metadata extraction. Network
+ * calls live in ./github.ts.
+ */
+
+/**
+ * Extract a GitHub `owner/repo` from arbitrary user-supplied input: the short
+ * form, full URLs (`.git`, `/tree/main`, `?query`, `#frag` tolerated), the SSH
+ * form (`git@github.com:owner/repo`), or a whole pasted shell command — by
+ * anchoring on the `github.com` host wherever it appears. Returns null when no
+ * owner/repo shape can be recovered, so callers surface a typed
+ * `invalid_repo_source` instead of firing a doomed GitHub lookup. (HOU-440)
+ */
+export function normalizeSource(source: string): string | null {
+  const trimmed = source.trim().replace(/^["'`]+|["'`]+$/g, "");
+
+  let afterHost = trimmed;
+  for (const marker of ["github.com/", "github.com:"]) {
+    const idx = trimmed.indexOf(marker);
+    if (idx !== -1) {
+      afterHost = trimmed.slice(idx + marker.length);
+      break;
+    }
+  }
+
+  // A pasted command carries trailing args; a URL may carry a query or
+  // fragment. Keep the first whitespace token, truncated at any `?`/`#`.
+  const candidate = (afterHost.split(/\s+/)[0] ?? "").split(/[?#]/)[0] ?? "";
+
+  const segments = candidate.split("/").filter(Boolean);
+  const owner = segments[0];
+  const repo = segments[1]?.replace(/\.git$/, "");
+  if (!owner || !repo) return null;
+
+  // GitHub's allowed charsets: owner `[A-Za-z0-9-]`, repo `[A-Za-z0-9._-]`.
+  if (!/^[A-Za-z0-9-]+$/.test(owner) || !/^[A-Za-z0-9._-]+$/.test(repo))
+    return null;
+  return `${owner}/${repo}`;
+}
+
+/** A valid install slug per the skills schema: lowercase kebab, ≤64 chars. */
+export function isValidSkillSlug(s: string): boolean {
+  return s.length > 0 && s.length <= 64 && /^[a-z0-9-]+$/.test(s);
+}
+
+/** Coerce an arbitrary string into a valid install slug (never empty). */
+export function slugifyInstallId(s: string): string {
+  const slug = s
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64)
+    .replace(/-+$/, "");
+  return slug || "skill";
+}
+
+/** `research/SKILL.md` → `research`; a root `SKILL.md` → the repo name. */
+export function skillIdFromPath(path: string, repoName: string): string {
+  if (!path.endsWith("/SKILL.md")) return repoName;
+  const dir = path.slice(0, -"/SKILL.md".length);
+  return dir.split("/").at(-1) ?? repoName;
+}
+
+/** Extract the `name:` field from YAML frontmatter, if any. */
+export function extractFrontmatterName(content: string): string | null {
+  let inFrontmatter = false;
+  for (const line of content.split("\n")) {
+    if (line.trim() === "---") {
+      if (inFrontmatter) return null;
+      inFrontmatter = true;
+      continue;
+    }
+    if (inFrontmatter && line.startsWith("name:")) {
+      return line
+        .slice("name:".length)
+        .trim()
+        .replace(/^["']|["']$/g, "");
+    }
+  }
+  return null;
+}
+
+/** Lightweight title + description pulled from a remote SKILL.md for listing. */
+export function parseRemoteSkillMd(
+  content: string,
+  fallbackId: string,
+): { name: string; description: string } {
+  let description = "";
+  const bodyLines: string[] = [];
+  let inFrontmatter = false;
+  let frontmatterDone = false;
+
+  for (const line of content.split("\n")) {
+    if (line.trim() === "---" && !frontmatterDone) {
+      if (inFrontmatter) frontmatterDone = true;
+      else inFrontmatter = true;
+      continue;
+    }
+    if (inFrontmatter && !frontmatterDone) {
+      if (line.startsWith("description:"))
+        description = line
+          .slice("description:".length)
+          .trim()
+          .replace(/^"|"$/g, "");
+    } else if (frontmatterDone) {
+      bodyLines.push(line);
+    }
+  }
+  const body = frontmatterDone ? bodyLines : content.split("\n");
+
+  let name = "";
+  for (const line of body) {
+    if (line.startsWith("# ")) {
+      name = line.slice(2).trim();
+      break;
+    }
+  }
+  if (!name) name = kebabToTitle(fallbackId);
+
+  if (description.length > 200) {
+    const cut = description.slice(0, 200);
+    const pos = cut.lastIndexOf(". ");
+    description = pos !== -1 ? description.slice(0, pos + 1) : cut;
+  }
+  return { name, description };
+}
+
+export function kebabToTitle(s: string): string {
+  return s
+    .split("-")
+    .filter(Boolean)
+    .map((w) => w[0]?.toUpperCase() + w.slice(1))
+    .join(" ");
+}

--- a/packages/host/src/skills/github.ts
+++ b/packages/host/src/skills/github.ts
@@ -1,0 +1,153 @@
+import type { RepoSkill } from "@houston/protocol";
+import {
+  extractFrontmatterName,
+  isValidSkillSlug,
+  kebabToTitle,
+  normalizeSource,
+  parseRemoteSkillMd,
+  skillIdFromPath,
+  slugifyInstallId,
+} from "./github-parse";
+import { SkillRemoteError } from "./remote-error";
+
+/**
+ * GitHub-side skill discovery over the network: list every SKILL.md in a repo
+ * (Git Trees API) and fetch a SKILL.md's raw content. Pure parsing lives in
+ * ./github-parse.ts; install composition in ./install.ts.
+ */
+
+const GH_HEADERS = { "User-Agent": "houston-skills/1.0" };
+
+/** Fetch a SKILL.md's raw content, trying the `main` then `master` branch. */
+export async function fetchSkillMdAtPath(
+  fetchImpl: typeof fetch,
+  source: string,
+  path: string,
+): Promise<string> {
+  for (const branch of ["main", "master"]) {
+    try {
+      const res = await fetchImpl(
+        `https://raw.githubusercontent.com/${source}/${branch}/${path}`,
+        { headers: GH_HEADERS },
+      );
+      if (res.ok) return await res.text();
+    } catch {
+      // Network failure on one branch — try the next; the caller surfaces
+      // a typed error when both miss.
+    }
+  }
+  throw new SkillRemoteError(
+    "offline",
+    `Could not fetch '${path}' from ${source}`,
+  );
+}
+
+/**
+ * Discover all SKILL.md files in a GitHub repo via the Git Trees API.
+ * Accepts `owner/repo` or anything `normalizeSource` recovers.
+ */
+export async function listSkillsFromRepo(
+  fetchImpl: typeof fetch,
+  rawSource: string,
+): Promise<{ source: string; skills: RepoSkill[] }> {
+  const source = normalizeSource(rawSource);
+  if (!source)
+    throw new SkillRemoteError("invalid_repo_source", rawSource.trim());
+
+  let repoRes: Response;
+  try {
+    repoRes = await fetchImpl(`https://api.github.com/repos/${source}`, {
+      headers: GH_HEADERS,
+    });
+  } catch (err) {
+    throw new SkillRemoteError(
+      "offline",
+      `Network error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (repoRes.status === 401 || repoRes.status === 403)
+    throw new SkillRemoteError("repo_private", `Repo '${source}' is private`);
+  if (repoRes.status === 404)
+    throw new SkillRemoteError(
+      "repo_not_found",
+      `Couldn't find a repo named '${source}'`,
+    );
+  if (repoRes.status === 429)
+    throw new SkillRemoteError(
+      "github_rate_limited",
+      "GitHub rate limit hit, wait a moment and try again",
+    );
+  if (!repoRes.ok)
+    throw new SkillRemoteError(
+      "offline",
+      `GitHub returned ${repoRes.status} for repo '${source}'`,
+    );
+
+  let treeRes: Response;
+  try {
+    treeRes = await fetchImpl(
+      `https://api.github.com/repos/${source}/git/trees/HEAD?recursive=1`,
+      { headers: GH_HEADERS },
+    );
+  } catch (err) {
+    throw new SkillRemoteError(
+      "offline",
+      `Network error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!treeRes.ok)
+    throw new SkillRemoteError(
+      "offline",
+      `Could not read repo contents (${treeRes.status})`,
+    );
+  const tree = (await treeRes.json().catch(() => null)) as {
+    tree?: Array<{ path: string; type: string }>;
+    truncated?: boolean;
+  } | null;
+  if (!tree || !Array.isArray(tree.tree))
+    throw new SkillRemoteError("offline", "Failed to parse repo tree");
+  if (tree.truncated)
+    console.warn(
+      `[host-skills] repo tree for ${source} was truncated — some skills may be missing`,
+    );
+
+  const skillPaths = tree.tree
+    .filter((e) => e.type === "blob" && e.path.endsWith("SKILL.md"))
+    .map((e) => e.path);
+  if (skillPaths.length === 0)
+    throw new SkillRemoteError(
+      "repo_no_skills",
+      `No skills found in '${source}'`,
+    );
+
+  // Fetch content so the frontmatter `name:` can override a path-derived id —
+  // repos named `My_Repo` can't be install ids, but authors declare a slug.
+  const repoName = source.split("/").at(-1) ?? source;
+  const skills: RepoSkill[] = [];
+  for (const path of skillPaths) {
+    const derivedId = skillIdFromPath(path, repoName);
+    try {
+      const raw = await fetchSkillMdAtPath(fetchImpl, source, path);
+      const parsed = parseRemoteSkillMd(raw, derivedId);
+      const fmName = extractFrontmatterName(raw);
+      const id =
+        fmName && isValidSkillSlug(fmName)
+          ? fmName
+          : slugifyInstallId(derivedId);
+      skills.push({
+        id,
+        name: parsed.name,
+        description: parsed.description,
+        path,
+      });
+    } catch {
+      skills.push({
+        id: slugifyInstallId(derivedId),
+        name: kebabToTitle(derivedId),
+        description: "",
+        path,
+      });
+    }
+  }
+  return { source, skills };
+}

--- a/packages/host/src/skills/install.ts
+++ b/packages/host/src/skills/install.ts
@@ -1,0 +1,187 @@
+import {
+  composeInstalledSkillMd,
+  parseSkillMd,
+  skillKey,
+} from "@houston/domain";
+import type { RepoSkill } from "@houston/protocol";
+import type { Vfs } from "../vfs";
+import { fetchSkillMdAtPath } from "./github";
+import {
+  extractFrontmatterName,
+  isValidSkillSlug,
+  normalizeSource,
+  parseRemoteSkillMd,
+  skillIdFromPath,
+  slugifyInstallId,
+} from "./github-parse";
+import { SkillRemoteError } from "./remote-error";
+
+/**
+ * Install composition for community/repo skills, mirroring the legacy Rust
+ * engine's semantics: the fetched SKILL.md keeps the author's frontmatter,
+ * the install slug owns both the directory and the frontmatter `name`, and
+ * installing something already present is an idempotent success (a healthy
+ * copy is preserved with local edits; a corrupt one is healed by rewrite).
+ */
+
+/** True when a healthy skill already sits at `slug` (idempotent no-op). */
+async function healthyInstalled(
+  vfs: Vfs,
+  root: string,
+  slug: string,
+): Promise<boolean> {
+  const existing = await vfs.readText(skillKey(root, slug));
+  return existing !== null && !("error" in parseSkillMd(slug, existing));
+}
+
+async function writeInstall(
+  vfs: Vfs,
+  root: string,
+  slug: string,
+  rawMd: string,
+  fallbackDescription: string,
+): Promise<void> {
+  const today = new Date().toISOString().slice(0, 10);
+  await vfs.writeText(
+    skillKey(root, slug),
+    composeInstalledSkillMd({
+      slug,
+      rawMd,
+      fallbackDescription,
+      todayIsoDate: today,
+    }),
+  );
+}
+
+/**
+ * Install a single community skill by fetching its SKILL.md from GitHub.
+ * `source` is the `owner/repo` from the search result, `skillId` the skill's
+ * directory name on skills.sh. Returns the installed slug.
+ */
+export async function installCommunitySkill(
+  fetchImpl: typeof fetch,
+  vfs: Vfs,
+  root: string,
+  rawSource: string,
+  skillId: string,
+): Promise<string> {
+  const source = normalizeSource(rawSource);
+  if (!source)
+    throw new SkillRemoteError("invalid_repo_source", rawSource.trim());
+
+  // Try common path patterns first (cheap — no API call), then fall back to
+  // scanning the repo tree and matching by directory name or frontmatter name.
+  const candidates = [
+    `skills/${skillId}/SKILL.md`,
+    `${skillId}/SKILL.md`,
+    "SKILL.md",
+  ];
+  let rawMd: string | null = null;
+  for (const candidate of candidates) {
+    rawMd = await fetchSkillMdAtPath(fetchImpl, source, candidate).catch(
+      () => null,
+    );
+    if (rawMd !== null) break;
+  }
+  if (rawMd === null) {
+    const path = await findSkillPathInRepo(fetchImpl, source, skillId).catch(
+      () => null,
+    );
+    if (path)
+      rawMd = await fetchSkillMdAtPath(fetchImpl, source, path).catch(
+        () => null,
+      );
+  }
+  if (rawMd === null)
+    throw new SkillRemoteError(
+      "skill_not_in_repo",
+      `Could not find '${skillId}' in ${source}`,
+    );
+
+  // Prefer the SKILL.md's own `name:` (the authoritative slug); fall back to
+  // a slugified id so a community id that isn't a clean slug still installs.
+  const fmName = extractFrontmatterName(rawMd);
+  const slug =
+    fmName && isValidSkillSlug(fmName) ? fmName : slugifyInstallId(skillId);
+
+  if (!(await healthyInstalled(vfs, root, slug))) {
+    const parsed = parseRemoteSkillMd(rawMd, skillId);
+    await writeInstall(vfs, root, slug, rawMd, parsed.description);
+  }
+  return slug;
+}
+
+/**
+ * Install the user's selection out of what `listSkillsFromRepo` returned.
+ * Fails fast on the first error so the user sees the real reason instead of
+ * "installed 0 skills". Returns the installed slugs.
+ */
+export async function installSkillsFromRepo(
+  fetchImpl: typeof fetch,
+  vfs: Vfs,
+  root: string,
+  rawSource: string,
+  skills: RepoSkill[],
+): Promise<string[]> {
+  const source = normalizeSource(rawSource);
+  if (!source)
+    throw new SkillRemoteError("invalid_repo_source", rawSource.trim());
+
+  const installed: string[] = [];
+  for (const skill of skills) {
+    // The id becomes a vfs key segment — reject anything that isn't a clean
+    // slug before touching storage (the UI only sends ids we listed, but the
+    // route is reachable directly).
+    if (!isValidSkillSlug(skill.id))
+      throw new SkillRemoteError(
+        "validation",
+        `'${skill.id}' is not a valid skill name`,
+      );
+    if (await healthyInstalled(vfs, root, skill.id)) {
+      installed.push(skill.id);
+      continue;
+    }
+    const rawMd = await fetchSkillMdAtPath(fetchImpl, source, skill.path);
+    const parsed = parseRemoteSkillMd(rawMd, skill.id);
+    await writeInstall(vfs, root, skill.id, rawMd, parsed.description);
+    installed.push(skill.id);
+  }
+  return installed;
+}
+
+/**
+ * Locate a SKILL.md matching `skillId` via the Git Trees API. Two passes:
+ * exact directory-name match first, then peek at frontmatter `name:` for
+ * paths containing the id (capped at 10 fetches).
+ */
+async function findSkillPathInRepo(
+  fetchImpl: typeof fetch,
+  source: string,
+  skillId: string,
+): Promise<string | null> {
+  const res = await fetchImpl(
+    `https://api.github.com/repos/${source}/git/trees/HEAD?recursive=1`,
+    { headers: { "User-Agent": "houston-skills/1.0" } },
+  );
+  if (!res.ok) return null;
+  const tree = (await res.json().catch(() => null)) as {
+    tree?: Array<{ path: string; type: string }>;
+  } | null;
+  if (!tree || !Array.isArray(tree.tree)) return null;
+
+  const repoName = source.split("/").at(-1) ?? source;
+  const fuzzy: string[] = [];
+  for (const entry of tree.tree) {
+    if (entry.type !== "blob" || !entry.path.endsWith("SKILL.md")) continue;
+    if (skillIdFromPath(entry.path, repoName) === skillId) return entry.path;
+    if (entry.path.includes(skillId)) fuzzy.push(entry.path);
+  }
+  for (const path of fuzzy.slice(0, 10)) {
+    const content = await fetchSkillMdAtPath(fetchImpl, source, path).catch(
+      () => null,
+    );
+    if (content !== null && extractFrontmatterName(content) === skillId)
+      return path;
+  }
+  return null;
+}

--- a/packages/host/src/skills/remote-error.ts
+++ b/packages/host/src/skills/remote-error.ts
@@ -1,0 +1,43 @@
+/**
+ * Typed failures for the community/repo skill routes. `kind` is the stable
+ * machine-readable tag the frontend matches on to render plain-English copy —
+ * keep the values in sync with `ui/skills/src/skill-error-kinds.ts` (the same
+ * taxonomy the legacy Rust engine emits, so both engines read identically).
+ */
+
+export type SkillRemoteErrorKind =
+  | "rate_limited"
+  | "offline"
+  | "skill_not_in_repo"
+  | "invalid_repo_source"
+  | "repo_private"
+  | "repo_not_found"
+  | "repo_no_skills"
+  | "github_rate_limited"
+  | "validation";
+
+const HTTP_STATUS: Record<SkillRemoteErrorKind, number> = {
+  rate_limited: 429,
+  offline: 503,
+  skill_not_in_repo: 404,
+  invalid_repo_source: 400,
+  repo_private: 403,
+  repo_not_found: 404,
+  repo_no_skills: 404,
+  github_rate_limited: 429,
+  validation: 400,
+};
+
+export class SkillRemoteError extends Error {
+  readonly kind: SkillRemoteErrorKind;
+
+  constructor(kind: SkillRemoteErrorKind, message: string) {
+    super(message);
+    this.name = "SkillRemoteError";
+    this.kind = kind;
+  }
+
+  get httpStatus(): number {
+    return HTTP_STATUS[this.kind];
+  }
+}

--- a/packages/host/src/skills/remote.test.ts
+++ b/packages/host/src/skills/remote.test.ts
@@ -1,0 +1,348 @@
+import { expect, test } from "vitest";
+import { MemoryVfs } from "../vfs";
+import { CommunityDirectory } from "./community";
+import { listSkillsFromRepo } from "./github";
+import {
+  normalizeSource,
+  parseRemoteSkillMd,
+  skillIdFromPath,
+  slugifyInstallId,
+} from "./github-parse";
+import { installCommunitySkill, installSkillsFromRepo } from "./install";
+import { SkillRemoteError } from "./remote-error";
+
+// ── normalizeSource (ported from the Rust oracle, HOU-440) ─────────
+
+test("normalizeSource accepts urls, ssh, and pasted commands", () => {
+  expect(normalizeSource("owner/repo")).toBe("owner/repo");
+  expect(normalizeSource("https://github.com/owner/repo")).toBe("owner/repo");
+  expect(normalizeSource("https://github.com/owner/repo/tree/main")).toBe(
+    "owner/repo",
+  );
+  expect(normalizeSource("https://github.com/owner/repo.git")).toBe(
+    "owner/repo",
+  );
+  expect(normalizeSource("https://github.com/owner/repo?tab=readme")).toBe(
+    "owner/repo",
+  );
+  expect(normalizeSource("git@github.com:owner/repo.git")).toBe("owner/repo");
+  expect(normalizeSource("  owner/repo  ")).toBe("owner/repo");
+  expect(normalizeSource('"owner/repo"')).toBe("owner/repo");
+  expect(
+    normalizeSource(
+      "npx skills add https://github.com/shadcn/improve --skill improve",
+    ),
+  ).toBe("shadcn/improve");
+});
+
+test("normalizeSource rejects unparseable input", () => {
+  expect(normalizeSource("reconciliation")).toBeNull();
+  expect(normalizeSource("please install my skills for me")).toBeNull();
+  expect(normalizeSource("")).toBeNull();
+  expect(normalizeSource("npx skills add reconciliation")).toBeNull();
+  expect(normalizeSource("@owner/repo!")).toBeNull();
+  expect(normalizeSource("my_org/repo")).toBeNull();
+});
+
+test("slug + path helpers", () => {
+  expect(slugifyInstallId("refero_skill")).toBe("refero-skill");
+  expect(slugifyInstallId("My-Repo")).toBe("my-repo");
+  expect(slugifyInstallId("___")).toBe("skill");
+  expect(slugifyInstallId("a".repeat(120)).length).toBe(64);
+  expect(skillIdFromPath("SKILL.md", "my-repo")).toBe("my-repo");
+  expect(skillIdFromPath("tools/code-review/SKILL.md", "r")).toBe(
+    "code-review",
+  );
+});
+
+test("parseRemoteSkillMd pulls title + frontmatter description", () => {
+  const parsed = parseRemoteSkillMd(
+    "---\nname: my-skill\ndescription: A test skill\n---\n\n# My Awesome Skill\n\nBody.",
+    "my-skill",
+  );
+  expect(parsed.name).toBe("My Awesome Skill");
+  expect(parsed.description).toBe("A test skill");
+  const bare = parseRemoteSkillMd("no heading here", "no-title-skill");
+  expect(bare.name).toBe("No Title Skill");
+});
+
+// ── fetch fakes ────────────────────────────────────────────────────
+
+type Route = (url: string) => Response | null;
+const fakeFetch =
+  (...routes: Route[]): typeof fetch =>
+  async (input) => {
+    const url = String(input);
+    for (const route of routes) {
+      const res = route(url);
+      if (res) return res;
+    }
+    return new Response("not found", { status: 404 });
+  };
+
+const jsonRes = (body: unknown, status = 200) =>
+  new Response(JSON.stringify(body), { status });
+
+const SKILL_HIT = {
+  id: "owner/repo/writing",
+  skillId: "writing",
+  name: "writing",
+  installs: 7,
+  source: "owner/repo",
+};
+
+// ── CommunityDirectory ─────────────────────────────────────────────
+
+function fakeClock() {
+  const state = { t: 0 };
+  return {
+    state,
+    now: () => state.t,
+    sleep: async (ms: number) => {
+      state.t += ms;
+    },
+  };
+}
+
+test("community search caches fresh results and normalizes the key", async () => {
+  let calls = 0;
+  const clock = fakeClock();
+  const dir = new CommunityDirectory({
+    endpoint: "https://x/api/search",
+    now: clock.now,
+    sleep: clock.sleep,
+    fetchImpl: fakeFetch((url) => {
+      calls++;
+      return url.includes("q=Writing") || url.includes("q=writing")
+        ? jsonRes({ skills: [SKILL_HIT] })
+        : null;
+    }),
+  });
+  const first = await dir.search("Writing");
+  const second = await dir.search(" writing ");
+  expect(first[0]?.id).toBe("owner/repo/writing");
+  expect(second[0]?.id).toBe("owner/repo/writing");
+  expect(calls).toBe(1);
+});
+
+test("community search returns stale cache when skills.sh rate limits", async () => {
+  let mode: "ok" | "limited" = "ok";
+  const clock = fakeClock();
+  const dir = new CommunityDirectory({
+    endpoint: "https://x/api/search",
+    now: clock.now,
+    sleep: clock.sleep,
+    freshTtlMs: 0,
+    fetchImpl: fakeFetch(() =>
+      mode === "ok"
+        ? jsonRes({ skills: [SKILL_HIT] })
+        : new Response("", { status: 429 }),
+    ),
+  });
+  await dir.search("writing");
+  mode = "limited";
+  clock.state.t += 1;
+  const skills = await dir.search("writing");
+  expect(skills[0]?.id).toBe("owner/repo/writing");
+});
+
+test("community search maps a persistent 429 to rate_limited when no cache", async () => {
+  const clock = fakeClock();
+  const dir = new CommunityDirectory({
+    endpoint: "https://x/api/search",
+    now: clock.now,
+    sleep: clock.sleep,
+    fetchImpl: fakeFetch(() => new Response("", { status: 429 })),
+  });
+  const err = await dir.search("writing").catch((e) => e);
+  expect(err).toBeInstanceOf(SkillRemoteError);
+  expect((err as SkillRemoteError).kind).toBe("rate_limited");
+});
+
+test("queries under two chars return empty without a network call", async () => {
+  const dir = new CommunityDirectory({
+    fetchImpl: fakeFetch(() => {
+      throw new Error("should not fetch");
+    }),
+  });
+  expect(await dir.search(" a ")).toEqual([]);
+});
+
+test("popular uses its own cache slot and truncates to 20", async () => {
+  let calls = 0;
+  const clock = fakeClock();
+  const many = Array.from({ length: 30 }, (_, i) => ({
+    ...SKILL_HIT,
+    id: `a/b/s${i}`,
+    skillId: `s${i}`,
+  }));
+  const dir = new CommunityDirectory({
+    endpoint: "https://x/api/search",
+    now: clock.now,
+    sleep: clock.sleep,
+    fetchImpl: fakeFetch(() => {
+      calls++;
+      return jsonRes({ skills: many });
+    }),
+  });
+  const first = await dir.popular();
+  const second = await dir.popular();
+  expect(first.length).toBe(20);
+  expect(second.length).toBe(20);
+  expect(calls).toBe(1);
+});
+
+// ── listSkillsFromRepo ─────────────────────────────────────────────
+
+const TREE = {
+  tree: [
+    { path: "research/SKILL.md", type: "blob" },
+    { path: "README.md", type: "blob" },
+  ],
+  truncated: false,
+};
+const RESEARCH_MD =
+  "---\nname: research\ndescription: Deep research\n---\n\n# Research\n\nSteps.";
+
+const repoRoutes: Route[] = [
+  (url) =>
+    url === "https://api.github.com/repos/owner/repo" ? jsonRes({}) : null,
+  (url) => (url.includes("/git/trees/HEAD") ? jsonRes(TREE) : null),
+  (url) =>
+    url.includes("raw.githubusercontent.com/owner/repo/main/research/SKILL.md")
+      ? new Response(RESEARCH_MD)
+      : null,
+];
+
+test("listSkillsFromRepo rejects garbage before any network call", async () => {
+  const err = await listSkillsFromRepo(
+    fakeFetch(() => {
+      throw new Error("should not fetch");
+    }),
+    "reconciliation",
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("invalid_repo_source");
+});
+
+test("listSkillsFromRepo surfaces typed repo errors", async () => {
+  const notFound = await listSkillsFromRepo(
+    fakeFetch(() => new Response("", { status: 404 })),
+    "owner/gone",
+  ).catch((e) => e);
+  expect((notFound as SkillRemoteError).kind).toBe("repo_not_found");
+
+  const empty = await listSkillsFromRepo(
+    fakeFetch(
+      (url) =>
+        url === "https://api.github.com/repos/owner/repo" ? jsonRes({}) : null,
+      (url) =>
+        url.includes("/git/trees/HEAD")
+          ? jsonRes({ tree: [], truncated: false })
+          : null,
+    ),
+    "owner/repo",
+  ).catch((e) => e);
+  expect((empty as SkillRemoteError).kind).toBe("repo_no_skills");
+});
+
+test("listSkillsFromRepo returns one RepoSkill per SKILL.md", async () => {
+  const { source, skills } = await listSkillsFromRepo(
+    fakeFetch(...repoRoutes),
+    "https://github.com/owner/repo",
+  );
+  expect(source).toBe("owner/repo");
+  expect(skills).toEqual([
+    {
+      id: "research",
+      name: "Research",
+      description: "Deep research",
+      path: "research/SKILL.md",
+    },
+  ]);
+});
+
+// ── installs ───────────────────────────────────────────────────────
+
+const ROOT = "ws/w1/a1/workspace";
+
+test("installSkillsFromRepo writes the composed skill and is idempotent", async () => {
+  const vfs = new MemoryVfs();
+  const skills = [
+    {
+      id: "research",
+      name: "Research",
+      description: "Deep research",
+      path: "research/SKILL.md",
+    },
+  ];
+  const installed = await installSkillsFromRepo(
+    fakeFetch(...repoRoutes),
+    vfs,
+    ROOT,
+    "owner/repo",
+    skills,
+  );
+  expect(installed).toEqual(["research"]);
+  const md = await vfs.readText(`${ROOT}/.agents/skills/research/SKILL.md`);
+  expect(md).toContain("name: research");
+  expect(md).toContain("featured: true");
+
+  // Local edits survive a reinstall (healthy copy = no-op).
+  await vfs.writeText(
+    `${ROOT}/.agents/skills/research/SKILL.md`,
+    "---\nname: research\ndescription: edited\n---\n\nlocal edits\n",
+  );
+  await installSkillsFromRepo(
+    fakeFetch(...repoRoutes),
+    vfs,
+    ROOT,
+    "owner/repo",
+    skills,
+  );
+  const kept = await vfs.readText(`${ROOT}/.agents/skills/research/SKILL.md`);
+  expect(kept).toContain("local edits");
+});
+
+test("installSkillsFromRepo rejects ids that are not clean slugs", async () => {
+  const err = await installSkillsFromRepo(
+    fakeFetch(...repoRoutes),
+    new MemoryVfs(),
+    ROOT,
+    "owner/repo",
+    [{ id: "../escape", name: "x", description: "", path: "x/SKILL.md" }],
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("validation");
+});
+
+test("installCommunitySkill finds the skill under common paths and uses the frontmatter slug", async () => {
+  const vfs = new MemoryVfs();
+  const slug = await installCommunitySkill(
+    fakeFetch((url) =>
+      url.includes("owner/repo/main/skills/writing/SKILL.md")
+        ? new Response(
+            "---\nname: writing-plans\ndescription: d\n---\n\n# Writing\n\nBody.",
+          )
+        : null,
+    ),
+    vfs,
+    ROOT,
+    "owner/repo",
+    "writing",
+  );
+  expect(slug).toBe("writing-plans");
+  const md = await vfs.readText(
+    `${ROOT}/.agents/skills/writing-plans/SKILL.md`,
+  );
+  expect(md).toContain("name: writing-plans");
+});
+
+test("installCommunitySkill surfaces skill_not_in_repo when nothing matches", async () => {
+  const err = await installCommunitySkill(
+    fakeFetch(() => new Response("", { status: 404 })),
+    new MemoryVfs(),
+    ROOT,
+    "owner/repo",
+    "ghost",
+  ).catch((e) => e);
+  expect((err as SkillRemoteError).kind).toBe("skill_not_in_repo");
+});

--- a/packages/protocol/src/domain/skill.ts
+++ b/packages/protocol/src/domain/skill.ts
@@ -26,6 +26,28 @@ export interface SkillDetail {
   content: string;
 }
 
+/** A skill in the skills.sh community directory (marketplace search hit). */
+export interface CommunitySkill {
+  id: string;
+  skillId: string;
+  name: string;
+  installs: number;
+  /** GitHub `owner/repo` the skill installs from. */
+  source: string;
+}
+
+/** A skill discovered in a GitHub repo (one per SKILL.md found). */
+export interface RepoSkill {
+  /** The install slug — the SKILL.md's frontmatter name or its directory. */
+  id: string;
+  /** Human-readable title (SKILL.md `# Heading`, or title-cased id). */
+  name: string;
+  /** Short description from the SKILL.md frontmatter, if any. */
+  description: string;
+  /** Full path within the repo (e.g. `research/SKILL.md`). */
+  path: string;
+}
+
 export interface CreateSkill {
   name: string;
   description: string;

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -11,15 +11,19 @@ import type {
   Agent,
   Capabilities,
   ChatHistoryEntry,
+  CommunitySkill,
   ConversationEntry,
   CreateAgent,
   CreateAgentResult,
   CreateSkillRequest,
+  InstallCommunityRequest,
+  InstallFromRepoRequest,
   NewActivity,
   NewRoutine,
   ProjectConfig,
   ProjectFile,
   ProviderStatus,
+  RepoSkill,
   Routine,
   RoutineUpdate,
   SaveSkillRequest,
@@ -676,6 +680,57 @@ export class HoustonClient {
     if (!this.cp) return;
     await controlPlane.deleteSkill(this.cp, workspacePath, name);
     emitLocalEcho("SkillsChanged", { agentPath: workspacePath });
+  }
+  // Marketplace: skills.sh search/install + GitHub repo discovery. Standalone
+  // web has no marketplace backend — searches answer empty (the dialog shows
+  // its "unavailable" state), installs refuse loudly rather than no-op.
+  async searchCommunitySkills(
+    query: string,
+    signal?: AbortSignal,
+  ): Promise<CommunitySkill[]> {
+    if (!this.cp) return [];
+    return controlPlane.searchCommunitySkills(this.cp, query, signal);
+  }
+  async popularCommunitySkills(
+    signal?: AbortSignal,
+  ): Promise<CommunitySkill[]> {
+    if (!this.cp) return [];
+    return controlPlane.popularCommunitySkills(this.cp, signal);
+  }
+  async listSkillsFromRepo(
+    source: string,
+    signal?: AbortSignal,
+  ): Promise<RepoSkill[]> {
+    if (!this.cp) return [];
+    return controlPlane.listSkillsFromRepo(this.cp, source, signal);
+  }
+  async installCommunitySkill(
+    req: InstallCommunityRequest,
+    signal?: AbortSignal,
+  ): Promise<string> {
+    if (!this.cp) throw new Error("Installing skills needs a cloud workspace.");
+    const slug = await controlPlane.installCommunitySkill(
+      this.cp,
+      req.workspacePath,
+      { source: req.source, skillId: req.skillId },
+      signal,
+    );
+    emitLocalEcho("SkillsChanged", { agentPath: req.workspacePath });
+    return slug;
+  }
+  async installSkillsFromRepo(
+    req: InstallFromRepoRequest,
+    signal?: AbortSignal,
+  ): Promise<string[]> {
+    if (!this.cp) throw new Error("Installing skills needs a cloud workspace.");
+    const installed = await controlPlane.installSkillsFromRepo(
+      this.cp,
+      req.workspacePath,
+      { source: req.source, skills: req.skills },
+      signal,
+    );
+    emitLocalEcho("SkillsChanged", { agentPath: req.workspacePath });
+    return installed;
   }
 
   // ---- providers (auth) ----

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -6,8 +6,10 @@ import type {
   Activity,
   ActivityUpdate,
   Agent,
+  CommunitySkill,
   CustomEndpoint,
   NewActivity,
+  RepoSkill,
   Routine,
   RoutineRun,
   SkillSummary,
@@ -454,6 +456,70 @@ export async function runRoutineNow(
     `${agentPath(agentId)}/routines/${encodeURIComponent(id)}/run`,
     { method: "POST" },
   );
+}
+
+// Marketplace reads are user-scoped (browsing has no agent yet); installs
+// write into a specific agent's skills folder. Mirrors the host's split
+// between /v1/skills/* and /agents/:id/skills/*.
+export async function searchCommunitySkills(
+  cfg: ControlPlaneConfig,
+  query: string,
+  signal?: AbortSignal,
+): Promise<CommunitySkill[]> {
+  const res = await cpFetch(cfg, "/v1/skills/community/search", {
+    method: "POST",
+    body: JSON.stringify({ query }),
+    signal,
+  });
+  return (await res.json()) as CommunitySkill[];
+}
+export async function popularCommunitySkills(
+  cfg: ControlPlaneConfig,
+  signal?: AbortSignal,
+): Promise<CommunitySkill[]> {
+  const res = await cpFetch(cfg, "/v1/skills/community/popular", {
+    method: "POST",
+    signal,
+  });
+  return (await res.json()) as CommunitySkill[];
+}
+export async function listSkillsFromRepo(
+  cfg: ControlPlaneConfig,
+  source: string,
+  signal?: AbortSignal,
+): Promise<RepoSkill[]> {
+  const res = await cpFetch(cfg, "/v1/skills/repo/list", {
+    method: "POST",
+    body: JSON.stringify({ source }),
+    signal,
+  });
+  return (await res.json()) as RepoSkill[];
+}
+export async function installCommunitySkill(
+  cfg: ControlPlaneConfig,
+  agentId: string,
+  body: { source: string; skillId: string },
+  signal?: AbortSignal,
+): Promise<string> {
+  const res = await cpFetch(
+    cfg,
+    `${agentPath(agentId)}/skills/community/install`,
+    { method: "POST", body: JSON.stringify(body), signal },
+  );
+  return (await res.json()) as string;
+}
+export async function installSkillsFromRepo(
+  cfg: ControlPlaneConfig,
+  agentId: string,
+  body: { source: string; skills: RepoSkill[] },
+  signal?: AbortSignal,
+): Promise<string[]> {
+  const res = await cpFetch(cfg, `${agentPath(agentId)}/skills/repo/install`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    signal,
+  });
+  return (await res.json()) as string[];
 }
 
 export async function createSkill(


### PR DESCRIPTION
## Summary

HOU-652 — the Add Skills dialog lost its Skills.sh marketplace and GitHub tabs.

**Root cause:** the houston-web integration (#584) dropped the store/repo wiring from the app (`skills-content.tsx`, `use-skill-surface.ts`, the query hooks, and the `tauriSkills` wrappers), leaving only create-from-scratch — and the new TS host never implemented the marketplace routes, so even with the wiring the new-engine path had nothing to call. The building blocks (`ui/skills` dialog views, `@houston-ai/engine-client` methods, the Rust engine routes) all still existed.

**Fix — both halves restored:**
- **packages/host** (new): `POST /v1/skills/community/{search,popular,install}` + `POST /v1/skills/repo/{list,install}` in `routes/skills-remote.ts`, backed by `src/skills/` — skills.sh search with in-memory cache, global request spacing, stale-on-429 fallback and one retry; GitHub source normalization (accepts URLs, SSH form, pasted commands — HOU-440), Trees-API discovery, and idempotent installs that preserve local edits (HOU-439). Typed failures answer `{error:{code,message,details:{kind}}}` with the same kind taxonomy the Rust engine emits, so the dialog's plain-English error states work identically on both engines.
- **packages/domain**: `composeInstalledSkillMd` — frontmatter-preserving install composition (slug owns identity, bookkeeping reset, `featured: true`).
- **packages/protocol**: `CommunitySkill` / `RepoSkill` wire types.
- **app**: partial revert of #584's removals — `tauriSkills` wrappers, `useInstallCommunitySkill`/`useListSkillsFromRepo`/`useInstallSkillFromRepo` hooks, `useSkillSurface` handlers, and the Skills tab props, so the dialog offers **Skills.sh / GitHub / From scratch** again.

The legacy Rust engine still serves these routes, so the default desktop build gets the tabs back with the frontend wiring alone; the TS host work makes them live under `VITE_NEW_ENGINE` and in cloud.

## Reproduction (before)

1. Open Houston → any agent → Agent Settings → Skills → **Add skill**.
2. The dialog shows only the create-from-scratch form — no Skills.sh search, no "install from GitHub repo" view.

## Verification (after)

1. Same path: the dialog now shows three tabs: **Skills.sh**, **GitHub**, **From scratch**.
2. Skills.sh tab: popular skills load on open; typing searches skills.sh; Install writes `.agents/skills/<slug>/SKILL.md` and the card appears in the Skills tab (featured).
3. GitHub tab: paste `anthropics/skills` (or a full URL / pasted `npx skills add …` command) → skills list → select → install. Garbage input (e.g. `reconciliation`) shows the "type owner/repo" hint, no bug toast.
4. Against the TS host: `pnpm --filter @houston/host test` (marketplace route + remote-module suites), `pnpm --filter @houston/domain test`.
5. Gates: `pnpm typecheck` (23 packages), `pnpm check`, `pnpm check:boundaries`, app unit tests — all green. (`pnpm check-locales` fails on `shell.*` keys on this branch's base too — pre-existing, untouched here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)