### PR TITLE
feat(providers): zero-code ChatGPT connect via desktop loopback relay

### DIFF
--- a/app/src-tauri/src/codex_oauth_loopback.rs
+++ b/app/src-tauri/src/codex_oauth_loopback.rs
@@ -1,0 +1,177 @@
+//! One-shot localhost loopback listener for the OpenAI Codex OAuth redirect.
+//!
+//! OpenAI's Codex OAuth client has a SINGLE registered redirect URI —
+//! `http://localhost:1455/auth/callback` — so unlike the Supabase sign-in
+//! loopback (which picks the first free port from a small candidate list) this
+//! listener MUST bind port 1455 exactly. There is no fallback: if 1455 is held
+//! by another process the flow cannot complete, so we surface a clear error
+//! instead of silently retrying elsewhere.
+//!
+//! On the callback we forward the RAW query string (`code=...&state=...`) to
+//! the webview via the `codex-oauth://callback` Tauri event; the PKCE exchange
+//! runs in JS exactly as it does for the browser relay. Then we serve a small
+//! "you're connected" page, pull the app window to the front, and shut down.
+
+use std::time::Duration;
+
+use tauri::{AppHandle, Emitter};
+use tokio::net::TcpListener;
+
+use crate::loopback_util::{read_request_target, split_target, write_response};
+
+/// OpenAI's registered redirect port. FIXED — the redirect URI is baked into
+/// the Codex OAuth client, so we cannot choose another.
+const CODEX_PORT: u16 = 1455;
+
+/// Path OpenAI redirects to. Kept narrow so a stray `/` or `/favicon.ico`
+/// probe isn't mistaken for the callback.
+const CALLBACK_PATH: &str = "/auth/callback";
+
+/// Tauri event the webview listens on to receive the raw callback query.
+const CALLBACK_EVENT: &str = "codex-oauth://callback";
+
+/// Give up and free the socket if the browser never comes back (user closed
+/// the consent tab, bailed on the login, …). The frontend calls
+/// `start_codex_oauth_loopback` again for a fresh attempt.
+const LISTEN_TIMEOUT: Duration = Duration::from_secs(300);
+
+/// Start a one-shot loopback listener on the fixed Codex redirect port. The
+/// listener runs in a background task and shuts itself down after the first
+/// callback (or the timeout). Returns `Err` immediately if the port can't be
+/// bound so the frontend can toast the reason.
+#[tauri::command(rename_all = "snake_case")]
+pub async fn start_codex_oauth_loopback(app: AppHandle) -> Result<(), String> {
+    let listener = TcpListener::bind(("127.0.0.1", CODEX_PORT))
+        .await
+        .map_err(|e| {
+            format!(
+                "Could not start the Codex sign-in listener: port {CODEX_PORT} is unavailable ({e}). \
+                 OpenAI requires this exact port, so close whatever is using it and try again."
+            )
+        })?;
+    tracing::info!("[codex-oauth-loopback] listening on http://127.0.0.1:{CODEX_PORT}{CALLBACK_PATH}");
+
+    tokio::spawn(async move {
+        match tokio::time::timeout(LISTEN_TIMEOUT, serve_callback(&listener, &app)).await {
+            Ok(Ok(())) => {}
+            // The listener is a background task: the command already returned,
+            // so there's no Result left to bubble up to a toast. This is the
+            // documented event-callback exception to the no-silent-failure
+            // rule (no UI thread here). The frontend's retry is the safety net.
+            Ok(Err(e)) => tracing::error!("[codex-oauth-loopback] listener error: {e}"),
+            Err(_) => tracing::error!(
+                "[codex-oauth-loopback] timed out after {}s with no callback; freeing port",
+                LISTEN_TIMEOUT.as_secs()
+            ),
+        }
+    });
+
+    Ok(())
+}
+
+/// Accept connections until one hits the callback path, then handle it and
+/// return. Non-callback probes (favicon, etc.) get a 404 and we keep waiting.
+async fn serve_callback(listener: &TcpListener, app: &AppHandle) -> Result<(), String> {
+    loop {
+        let (mut stream, _) = listener
+            .accept()
+            .await
+            .map_err(|e| format!("accept failed: {e}"))?;
+
+        let target = match read_request_target(&mut stream).await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!("[codex-oauth-loopback] unreadable request: {e}");
+                let _ = write_response(&mut stream, "400 Bad Request", "Bad request").await;
+                continue;
+            }
+        };
+
+        let (path, query) = split_target(&target);
+
+        if path != CALLBACK_PATH {
+            let _ = write_response(&mut stream, "404 Not Found", "Not found").await;
+            continue;
+        }
+
+        // Forward the raw query verbatim; the JS side owns parsing + the PKCE
+        // exchange. Emitting is fallible but there's no user action left to
+        // toast against here, so a failure is logged, not surfaced.
+        if let Err(e) = app.emit(CALLBACK_EVENT, query.to_string()) {
+            tracing::error!("[codex-oauth-loopback] failed to emit callback event: {e}");
+        }
+
+        let _ = write_response(&mut stream, "200 OK", SUCCESS_PAGE).await;
+
+        crate::window_focus::bring_to_front(app);
+
+        return Ok(());
+    }
+}
+
+/// Self-contained success page — the loopback serves no other assets, so there
+/// are no external references to 404. Copy matches the English-only connect
+/// flow.
+const SUCCESS_PAGE: &str = r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Houston — Connected</title>
+  <style>
+    :root { color-scheme: light; }
+    body {
+      font-family: ui-sans-serif, -apple-system, system-ui, sans-serif;
+      display: flex; align-items: center; justify-content: center;
+      min-height: 100vh; margin: 0; background: #fafafa; color: #0d0d0d;
+    }
+    .card { text-align: center; padding: 60px 40px; max-width: 420px; }
+    h1 { font-size: 22px; font-weight: 600; margin: 0 0 12px; letter-spacing: -0.01em; }
+    p { font-size: 14px; color: #555; margin: 0; line-height: 1.5; }
+  </style>
+</head>
+<body>
+  <main class="card">
+    <h1>You're connected</h1>
+    <p>You can close this tab and return to Houston.</p>
+  </main>
+</body>
+</html>"#;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn callback_path_matches_and_query_is_extracted() {
+        // Mirror what `serve_callback` does with a request line's target.
+        let target = "/auth/callback?code=abc123&state=xyz";
+        let (path, query) = split_target(target);
+        assert_eq!(path, CALLBACK_PATH);
+        assert_eq!(query, "code=abc123&state=xyz");
+    }
+
+    #[test]
+    fn non_callback_path_is_a_404_and_keeps_listening() {
+        // `/favicon.ico` and friends must not be mistaken for the callback;
+        // `serve_callback` writes a 404 and continues the accept loop.
+        let (path, _) = split_target("/favicon.ico");
+        assert_ne!(path, CALLBACK_PATH);
+    }
+
+    #[test]
+    fn callback_with_no_query_yields_empty_string() {
+        // A bare `/auth/callback` (no `?`) still matches the path; the query
+        // is empty rather than panicking, and the empty payload is emitted.
+        let (path, query) = split_target("/auth/callback");
+        assert_eq!(path, CALLBACK_PATH);
+        assert_eq!(query, "");
+    }
+
+    #[test]
+    fn success_page_is_self_contained() {
+        // The loopback serves only this one page, so nothing may be fetched.
+        assert!(!SUCCESS_PAGE.contains("<img"));
+        assert!(!SUCCESS_PAGE.contains("src="));
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -1,11 +1,13 @@
 mod auth;
 mod bug_report;
+mod codex_oauth_loopback;
 mod commands;
 #[cfg(target_os = "macos")]
 mod dmg_guard;
 mod engine_supervisor;
 mod houston_prompt;
 mod logging;
+mod loopback_util;
 mod notification;
 mod oauth_loopback;
 mod window_focus;
@@ -401,6 +403,10 @@ pub fn run() {
             // keeps desktop sign-in on the user's machine (no website relay,
             // no custom-scheme dialog).
             oauth_loopback::start_oauth_loopback,
+            // One-shot loopback listener for the OpenAI Codex OAuth redirect —
+            // binds the fixed port 1455 OpenAI registered and forwards the raw
+            // callback query to the webview as `codex-oauth://callback`.
+            codex_oauth_loopback::start_codex_oauth_loopback,
             // Pull the app to the foreground when a flow finishes in the
             // browser (e.g. a Composio integration connection landing).
             window_focus::focus_main_window,

--- a/app/src-tauri/src/loopback_util.rs
+++ b/app/src-tauri/src/loopback_util.rs
@@ -1,0 +1,93 @@
+//! Shared HTTP plumbing for the one-shot localhost loopback listeners used by
+//! the browser-based OAuth flows.
+//!
+//! Both the Supabase/Google sign-in loopback (`oauth_loopback.rs`) and the
+//! OpenAI Codex loopback (`codex_oauth_loopback.rs`) accept a single browser
+//! redirect on `127.0.0.1`, read only the HTTP request line, and reply with a
+//! tiny self-contained page. The request-line parsing and response writing are
+//! identical, so they live here and both listeners call in.
+
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+
+/// Read just the HTTP request line and pull out the request target
+/// (`/auth/callback?code=...`). We only need the first line, so stop as soon
+/// as we've seen a `\r\n`.
+pub async fn read_request_target(stream: &mut TcpStream) -> Result<String, String> {
+    let mut buf = Vec::with_capacity(1024);
+    let mut chunk = [0u8; 1024];
+    loop {
+        let n = stream
+            .read(&mut chunk)
+            .await
+            .map_err(|e| format!("read failed: {e}"))?;
+        if n == 0 {
+            return Err("connection closed before request line".into());
+        }
+        buf.extend_from_slice(&chunk[..n]);
+        if let Some(pos) = buf.windows(2).position(|w| w == b"\r\n") {
+            let line = String::from_utf8_lossy(&buf[..pos]);
+            let mut parts = line.split_whitespace();
+            let _method = parts.next().ok_or("empty request line")?;
+            let target = parts.next().ok_or("request line had no target")?;
+            return Ok(target.to_string());
+        }
+        if buf.len() > 8192 {
+            return Err("request line too long".into());
+        }
+    }
+}
+
+/// Split a request target into its `(path, query)` halves. The query is
+/// everything after the first `?` (empty when there is none), returned raw so
+/// the caller can forward it verbatim to the webview.
+pub fn split_target(target: &str) -> (&str, &str) {
+    match target.split_once('?') {
+        Some((path, query)) => (path, query),
+        None => (target, ""),
+    }
+}
+
+/// Write a complete HTTP/1.1 response and close the connection.
+pub async fn write_response(
+    stream: &mut TcpStream,
+    status: &str,
+    body: &str,
+) -> Result<(), String> {
+    let response = format!(
+        "HTTP/1.1 {status}\r\n\
+         Content-Type: text/html; charset=utf-8\r\n\
+         Content-Length: {len}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {body}",
+        len = body.len(),
+    );
+    stream
+        .write_all(response.as_bytes())
+        .await
+        .map_err(|e| format!("write failed: {e}"))?;
+    stream
+        .flush()
+        .await
+        .map_err(|e| format!("flush failed: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_target_extracts_query() {
+        let (path, query) = split_target("/auth/callback?code=abc123&state=xyz");
+        assert_eq!(path, "/auth/callback");
+        assert_eq!(query, "code=abc123&state=xyz");
+    }
+
+    #[test]
+    fn split_target_empty_query_when_no_question_mark() {
+        let (path, query) = split_target("/favicon.ico");
+        assert_eq!(path, "/favicon.ico");
+        assert_eq!(query, "");
+    }
+}

--- a/app/src-tauri/src/oauth_loopback.rs
+++ b/app/src-tauri/src/oauth_loopback.rs
@@ -25,8 +25,9 @@
 use std::time::Duration;
 
 use tauri::AppHandle;
-use tokio::io::{AsyncReadExt, AsyncWriteExt};
-use tokio::net::{TcpListener, TcpStream};
+use tokio::net::TcpListener;
+
+use crate::loopback_util::{read_request_target, split_target, write_response};
 
 /// Loopback ports we try, in order. EVERY port here must be registered in
 /// the Supabase project's redirect allow-list as
@@ -104,10 +105,7 @@ async fn serve_callback(listener: &TcpListener, app: &AppHandle) -> Result<(), S
             }
         };
 
-        let (path, query) = match target.split_once('?') {
-            Some((p, q)) => (p, q),
-            None => (target.as_str(), ""),
-        };
+        let (path, query) = split_target(&target);
 
         if path != CALLBACK_PATH {
             let _ = write_response(&mut stream, "404 Not Found", "Not found").await;
@@ -125,55 +123,6 @@ async fn serve_callback(listener: &TcpListener, app: &AppHandle) -> Result<(), S
 
         return Ok(());
     }
-}
-
-/// Read just the HTTP request line and pull out the request target
-/// (`/auth/callback?code=...`). We only need the first line, so stop as soon
-/// as we've seen a `\r\n`.
-async fn read_request_target(stream: &mut TcpStream) -> Result<String, String> {
-    let mut buf = Vec::with_capacity(1024);
-    let mut chunk = [0u8; 1024];
-    loop {
-        let n = stream
-            .read(&mut chunk)
-            .await
-            .map_err(|e| format!("read failed: {e}"))?;
-        if n == 0 {
-            return Err("connection closed before request line".into());
-        }
-        buf.extend_from_slice(&chunk[..n]);
-        if let Some(pos) = buf.windows(2).position(|w| w == b"\r\n") {
-            let line = String::from_utf8_lossy(&buf[..pos]);
-            let mut parts = line.split_whitespace();
-            let _method = parts.next().ok_or("empty request line")?;
-            let target = parts.next().ok_or("request line had no target")?;
-            return Ok(target.to_string());
-        }
-        if buf.len() > 8192 {
-            return Err("request line too long".into());
-        }
-    }
-}
-
-/// Write a complete HTTP/1.1 response and close the connection.
-async fn write_response(stream: &mut TcpStream, status: &str, body: &str) -> Result<(), String> {
-    let response = format!(
-        "HTTP/1.1 {status}\r\n\
-         Content-Type: text/html; charset=utf-8\r\n\
-         Content-Length: {len}\r\n\
-         Connection: close\r\n\
-         \r\n\
-         {body}",
-        len = body.len(),
-    );
-    stream
-        .write_all(response.as_bytes())
-        .await
-        .map_err(|e| format!("write failed: {e}"))?;
-    stream
-        .flush()
-        .await
-        .map_err(|e| format!("flush failed: {e}"))
 }
 
 /// Self-contained success page — the loopback serves no other assets, so the

--- a/app/src/components/shell/provider-device-code.tsx
+++ b/app/src/components/shell/provider-device-code.tsx
@@ -1,7 +1,8 @@
 import { Button, DialogFooter, Spinner } from "@houston-ai/core";
 import { Check, Copy } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
-import { useTranslation } from "react-i18next";
+import { Trans, useTranslation } from "react-i18next";
+import { tauriSystem } from "../../lib/tauri";
 import { useUIStore } from "../../stores/ui";
 
 /**
@@ -12,14 +13,31 @@ import { useUIStore } from "../../stores/ui";
  * `ProviderLoginDialog` auto-closes on `ProviderLoginComplete`. Rendered
  * only when the engine surfaced a `userCode`. Split out to keep the
  * dialog under the 200-line ceiling.
+ *
+ * On mount we open the verification page once (`verificationUri`) so a
+ * non-technical user lands where the code goes without hunting for a
+ * button. Popup blockers can veto an open that isn't tied to a click, so
+ * the parent dialog's "Open URL" button stays as the user-driven
+ * fallback. `settingsUrl`, when set (OpenAI/ChatGPT), surfaces the
+ * "turn on device-code sign-in" hint that catches the most common
+ * dead-end: device login switched off in the provider's own settings.
  */
 interface Props {
   code: string;
   providerName: string;
+  verificationUri: string;
+  /** Provider settings page to enable device-code sign-in. OpenAI only. */
+  settingsUrl?: string | null;
   onClose: () => void;
 }
 
-export function ProviderDeviceCode({ code, providerName, onClose }: Props) {
+export function ProviderDeviceCode({
+  code,
+  providerName,
+  verificationUri,
+  settingsUrl,
+  onClose,
+}: Props) {
   const { t } = useTranslation("providers");
   const addToast = useUIStore((s) => s.addToast);
   // Brief inline confirmation: on copy the code box swaps to "Code
@@ -28,6 +46,9 @@ export function ProviderDeviceCode({ code, providerName, onClose }: Props) {
   // right where they're looking.
   const [copied, setCopied] = useState(false);
   const revertTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Open the verification page exactly once per mounted panel, even if a
+  // re-emit swaps the code prop underneath us.
+  const openedRef = useRef(false);
 
   // Drop the confirmation if a fresh code arrives (e.g. a re-emit), and
   // clear any pending timer on unmount so it can't fire into an unmounted
@@ -41,6 +62,21 @@ export function ProviderDeviceCode({ code, providerName, onClose }: Props) {
       if (revertTimer.current) clearTimeout(revertTimer.current);
     };
   }, []);
+
+  // Auto-open the verification page on first render. A failed open is
+  // surfaced (never swallowed) so the user knows to use the dialog's
+  // "Open URL" button instead of staring at a code with nowhere to enter it.
+  useEffect(() => {
+    if (openedRef.current || !verificationUri) return;
+    openedRef.current = true;
+    tauriSystem.openUrl(verificationUri).catch((err) => {
+      addToast({
+        title: t("providerLogin.deviceOpenFailed"),
+        description: err instanceof Error ? err.message : String(err),
+        variant: "error",
+      });
+    });
+  }, [verificationUri, addToast, t]);
 
   const copyCode = async () => {
     try {
@@ -57,41 +93,59 @@ export function ProviderDeviceCode({ code, providerName, onClose }: Props) {
     }
   };
 
+  const openSettings = () => {
+    if (!settingsUrl) return;
+    tauriSystem.openUrl(settingsUrl).catch((err) => {
+      addToast({
+        title: t("providerLogin.deviceSettingsOpenFailed"),
+        description: err instanceof Error ? err.message : String(err),
+        variant: "error",
+      });
+    });
+  };
+
   return (
     <div className="space-y-3">
-      <div className="space-y-1.5">
+      <div className="space-y-2">
         <span className="block text-[13px] font-medium">
           {t("providerLogin.deviceCodeLabel")}
         </span>
-        <div className="flex items-center gap-2">
-          <code
-            aria-live="polite"
-            className={`flex-1 rounded-md border bg-background px-3 py-2 text-center font-mono ${
-              copied
-                ? "text-[14px] font-medium text-emerald-600 dark:text-emerald-400"
-                : "text-[18px] tracking-[0.25em]"
-            }`}
-          >
-            {copied ? t("providerLogin.codeCopied") : code}
-          </code>
-          <Button
-            type="button"
-            variant="outline"
-            size="sm"
-            aria-label={t("providerLogin.copyCode")}
-            onClick={copyCode}
-          >
-            {copied ? (
-              <Check className="size-3.5" />
-            ) : (
-              <Copy className="size-3.5" />
-            )}
-          </Button>
-        </div>
+        <code
+          aria-live="polite"
+          className={`block rounded-md border bg-background px-3 py-2 text-center font-mono ${
+            copied
+              ? "text-[14px] font-medium text-emerald-600 dark:text-emerald-400"
+              : "text-[20px] tracking-[0.3em]"
+          }`}
+        >
+          {copied ? t("providerLogin.codeCopied") : code}
+        </code>
+        <Button type="button" className="w-full gap-1.5" onClick={copyCode}>
+          {copied ? <Check className="size-4" /> : <Copy className="size-4" />}
+          {copied ? t("providerLogin.codeCopied") : t("providerLogin.copyCode")}
+        </Button>
         <p className="text-[12px] text-muted-foreground">
           {t("providerLogin.deviceCodeHint", { name: providerName })}
         </p>
       </div>
+
+      {settingsUrl && (
+        <p className="text-[12px] text-muted-foreground">
+          <Trans
+            t={t}
+            i18nKey="providerLogin.deviceSettingsHint"
+            components={{
+              link: (
+                <button
+                  type="button"
+                  onClick={openSettings}
+                  className="font-medium text-foreground underline underline-offset-2"
+                />
+              ),
+            }}
+          />
+        </p>
+      )}
 
       <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
         <Spinner className="size-3.5" />

--- a/app/src/components/shell/provider-login-dialog.tsx
+++ b/app/src/components/shell/provider-login-dialog.tsx
@@ -197,6 +197,12 @@ export function ProviderLoginDialog({
             <ProviderDeviceCode
               code={userCode}
               providerName={provider.name}
+              verificationUri={url}
+              settingsUrl={
+                provider.id === "openai"
+                  ? "https://chatgpt.com/#settings/Security"
+                  : null
+              }
               onClose={onClose}
             />
           ) : (

--- a/app/src/components/shell/provider-login-url.ts
+++ b/app/src/components/shell/provider-login-url.ts
@@ -48,3 +48,22 @@ export function shouldOpenLoginUrlDirectly(opts: {
 }): boolean {
   return opts.isDesktop && !opts.userCode;
 }
+
+/**
+ * Decide whether a `ProviderLoginUrl` event for Codex/OpenAI should drive the
+ * desktop's zero-code loopback relay (`beginCodexBrowserLogin`) instead of the
+ * plain open-in-browser path or the device-code dialog.
+ *
+ * True only for Codex (`provider === "openai"`) on a desktop client with no
+ * device code: there the desktop binds its own localhost listener and relays
+ * the callback code, which works even against a remote engine. A device code
+ * (`userCode` present) means the runtime chose the headless flow, and web
+ * clients have no local listener — both keep their existing paths.
+ */
+export function shouldUseCodexLoopback(opts: {
+  provider: string;
+  isDesktop: boolean;
+  userCode: string | null | undefined;
+}): boolean {
+  return opts.provider === "openai" && opts.isDesktop && !opts.userCode;
+}

--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { analytics } from "../../lib/analytics";
+import { beginCodexBrowserLogin } from "../../lib/codex-loopback";
 import { newEngineActive } from "../../lib/engine";
 import { subscribeHoustonEvents } from "../../lib/events";
 import { osIsTauri } from "../../lib/os-bridge";
@@ -25,7 +26,10 @@ import { OpenAiCompatibleDialog } from "./openai-compatible-dialog";
 import { ProviderApiKeyDialog } from "./provider-api-key-dialog";
 import { ComingSoonCard, ProviderCard } from "./provider-cards";
 import { ProviderLoginDialog } from "./provider-login-dialog";
-import { shouldOpenLoginUrlDirectly } from "./provider-login-url";
+import {
+  shouldOpenLoginUrlDirectly,
+  shouldUseCodexLoopback,
+} from "./provider-login-url";
 import { useCopilotConnect } from "./use-copilot-connect";
 
 interface Props {
@@ -161,6 +165,20 @@ export function ProviderPicker({ onSelect }: Props) {
         const prov =
           visibleProviders.find((p) => p.id === ev.data.provider) ??
           PROVIDERS.find((p) => p.id === ev.data.provider);
+        if (
+          shouldUseCodexLoopback({
+            provider: ev.data.provider,
+            isDesktop: osIsTauri(),
+            userCode: ev.data.user_code,
+          })
+        ) {
+          // Codex/OpenAI on desktop: bind our own localhost listener and relay
+          // the callback code, so ChatGPT sign-in works with zero device code
+          // even against a remote engine. beginCodexBrowserLogin surfaces its
+          // own failure toast and never leaves an orphaned listener.
+          void beginCodexBrowserLogin(ev.data.provider, ev.data.url);
+          return;
+        }
         if (
           shouldOpenLoginUrlDirectly({
             isDesktop: osIsTauri(),

--- a/app/src/components/shell/provider-settings.tsx
+++ b/app/src/components/shell/provider-settings.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { analytics } from "../../lib/analytics";
+import { beginCodexBrowserLogin } from "../../lib/codex-loopback";
 import { newEngineActive } from "../../lib/engine";
 import { subscribeHoustonEvents } from "../../lib/events";
 import { osIsTauri } from "../../lib/os-bridge";
@@ -24,7 +25,10 @@ import { OpenAiCompatibleDialog } from "./openai-compatible-dialog";
 import { ProviderAccountRow } from "./provider-account-row";
 import { ProviderApiKeyDialog } from "./provider-api-key-dialog";
 import { ProviderLoginDialog } from "./provider-login-dialog";
-import { shouldOpenLoginUrlDirectly } from "./provider-login-url";
+import {
+  shouldOpenLoginUrlDirectly,
+  shouldUseCodexLoopback,
+} from "./provider-login-url";
 import { providerAppearsConnected } from "./provider-reconnect-state";
 import { useCopilotConnect } from "./use-copilot-connect";
 
@@ -191,6 +195,20 @@ export function ProviderSettings() {
         const prov =
           visibleProviders.find((p) => p.id === ev.data.provider) ??
           PROVIDERS.find((p) => p.id === ev.data.provider);
+        if (
+          shouldUseCodexLoopback({
+            provider: ev.data.provider,
+            isDesktop: osIsTauri(),
+            userCode: ev.data.user_code,
+          })
+        ) {
+          // Codex/OpenAI on desktop: bind our own localhost listener and relay
+          // the callback code, so ChatGPT sign-in works with zero device code
+          // even against a remote engine. beginCodexBrowserLogin surfaces its
+          // own failure toast and never leaves an orphaned listener.
+          void beginCodexBrowserLogin(ev.data.provider, ev.data.url);
+          return;
+        }
         if (
           shouldOpenLoginUrlDirectly({
             isDesktop: osIsTauri(),

--- a/app/src/lib/codex-loopback.ts
+++ b/app/src/lib/codex-loopback.ts
@@ -1,0 +1,118 @@
+/**
+ * Codex/OpenAI (ChatGPT) desktop OAuth loopback relay.
+ *
+ * The runtime hands the frontend an authorize URL for Codex sign-in (see the
+ * `deviceAuth:false` default in {@link tauri.launchLogin}). On desktop we don't
+ * want the user to copy a device code: instead the native side binds its OWN
+ * localhost listener (`start_codex_oauth_loopback`), we open the URL in the
+ * user's browser, and when OpenAI redirects back the native `codex-oauth://
+ * callback` event carries the raw `code=...&state=...` query string, which we
+ * relay to the engine via `submitLoginCode` (pi accepts the string verbatim).
+ *
+ * This works even when the engine is REMOTE — the loopback lives on the user's
+ * machine, so co-location with the engine is irrelevant.
+ */
+
+import { useUIStore } from "../stores/ui";
+import i18n from "./i18n";
+import {
+  legacyListen,
+  osOpenUrl,
+  osStartCodexOauthLoopback,
+} from "./os-bridge";
+import { PROVIDERS } from "./providers";
+import { tauriProvider } from "./tauri";
+
+/** Native event carrying the OAuth redirect's raw `code=...&state=...` query. */
+const CODEX_OAUTH_CALLBACK_EVENT = "codex-oauth://callback";
+
+/**
+ * Safety net for a callback that never arrives (the user abandons the browser
+ * tab, or the native loopback server times out). The engine's
+ * `ProviderLoginComplete(success:false)` surfaces the real failure to the user;
+ * this timer only tears down our one-shot listener so it can't leak. Generous
+ * because a user may sit on the OpenAI consent screen for a while.
+ */
+const CALLBACK_TIMEOUT_MS = 5 * 60_000;
+
+type Unlisten = Awaited<ReturnType<typeof legacyListen>>;
+
+/** Reuse the existing "couldn't open sign-in" toast key with the provider's
+ *  display name; falls back to the raw id for an unknown provider. */
+function failCodexLogin(frontendProviderId: string, err: unknown): void {
+  const name =
+    PROVIDERS.find((p) => p.id === frontendProviderId)?.name ??
+    frontendProviderId;
+  useUIStore.getState().addToast({
+    title: i18n.t("providers:toast.signInFailed", { provider: name }),
+    description: err instanceof Error ? err.message : String(err),
+    variant: "error",
+  });
+}
+
+/** Relay the callback's query string to the engine. `submitLoginCode`'s
+ *  engine-call wrapper already surfaces a failure toast + Sentry report, so the
+ *  catch here only keeps the promise from floating unhandled. */
+async function relayCodexCode(
+  frontendProviderId: string,
+  payload: string,
+): Promise<void> {
+  try {
+    await tauriProvider.submitLoginCode(frontendProviderId, payload);
+  } catch (err) {
+    console.error("[codex-loopback] submitLoginCode failed:", err);
+  }
+}
+
+/**
+ * Drive the desktop Codex/OpenAI browser sign-in: listen for the loopback
+ * callback, bind the native listener, open the authorize URL, and relay the
+ * code back to the engine. Surfaces a toast and cleans up the listener on any
+ * setup failure; never leaves an orphaned listener on any path (success, error,
+ * or timeout). Resolves once the browser has been opened (the callback is
+ * handled asynchronously); never rejects.
+ */
+export async function beginCodexBrowserLogin(
+  frontendProviderId: string,
+  authorizeUrl: string,
+): Promise<void> {
+  let unlisten: Unlisten | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let settled = false;
+
+  const cleanup = () => {
+    settled = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (unlisten) {
+      unlisten();
+      unlisten = null;
+    }
+  };
+
+  // Register the callback listener BEFORE binding the loopback so a fast
+  // redirect can't race ahead of us.
+  try {
+    unlisten = await legacyListen<string>(CODEX_OAUTH_CALLBACK_EVENT, (ev) => {
+      if (settled) return;
+      cleanup();
+      void relayCodexCode(frontendProviderId, ev.payload);
+    });
+  } catch (err) {
+    cleanup();
+    failCodexLogin(frontendProviderId, err);
+    return;
+  }
+
+  timer = setTimeout(cleanup, CALLBACK_TIMEOUT_MS);
+
+  try {
+    await osStartCodexOauthLoopback();
+    await osOpenUrl(authorizeUrl);
+  } catch (err) {
+    cleanup();
+    failCodexLogin(frontendProviderId, err);
+  }
+}

--- a/app/src/lib/engine-mode.ts
+++ b/app/src/lib/engine-mode.ts
@@ -52,6 +52,23 @@ export function providerLoginUsesDeviceAuthByDefault(
   );
 }
 
+/**
+ * Whether Codex/OpenAI (ChatGPT) sign-in should use the desktop's own
+ * zero-code loopback relay instead of the device-code flow.
+ *
+ * Unlike {@link providerLoginUsesDeviceAuthByDefault}, this is true for a Tauri
+ * desktop even when the engine is REMOTE: the runtime hands back an authorize
+ * URL, the desktop binds its OWN localhost listener
+ * (`start_codex_oauth_loopback`), opens the URL in the user's browser, and
+ * relays the `code=...&state=...` the callback carries back to the engine via
+ * `submitLoginCode`. The callback lands on the user's machine, so co-location
+ * with the engine is irrelevant. A plain browser client has no local listener
+ * and still falls back to device code.
+ */
+export function codexUsesLoopbackRelay(client: { isTauri: boolean }): boolean {
+  return client.isTauri;
+}
+
 /** How the desktop authenticates to the hosted engine (`VITE_HOSTED_ENGINE_URL`). */
 export type HostedAuthMode =
   /** Supabase Google login: prompt sign-in, send the session token as bearer. */

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -77,6 +77,17 @@ export function osStartOauthLoopback(): Promise<string> {
   return invoke<string>("start_oauth_loopback");
 }
 
+/** Bind a one-shot localhost listener for the Codex/OpenAI OAuth redirect. On
+ * success the native side emits `codex-oauth://callback` with the raw
+ * `code=...&state=...` query string once OpenAI bounces the browser back;
+ * rejects with a message string if the port can't be bound. Desktop only —
+ * keeps ChatGPT sign-in on the user's machine even when the engine is remote,
+ * so the relay works without a device code. Mirrors {@link osStartOauthLoopback}
+ * (the Supabase Google loopback). */
+export function osStartCodexOauthLoopback(): Promise<void> {
+  return invoke<void>("start_codex_oauth_loopback");
+}
+
 /** Pull the Houston window to the front. Used when a flow finishes in the
  * user's browser (e.g. a Composio integration connection lands) and we want
  * the app to surface itself — the same snap-back the sign-in loopback does.

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -26,7 +26,10 @@ import { shouldAutocompactForSession } from "./autocompact";
 import { COMPOSIO_ALREADY_CONNECTED_KIND } from "./composio-already-connected";
 import { getEngine, isRemoteEngine } from "./engine";
 import { engineCallSurface } from "./engine-call-policy";
-import { providerLoginUsesDeviceAuthByDefault } from "./engine-mode";
+import {
+  codexUsesLoopbackRelay,
+  providerLoginUsesDeviceAuthByDefault,
+} from "./engine-mode";
 import { logger } from "./logger";
 import { isMissingSkillError } from "./missing-skill";
 import { osIsTauri, osPickDirectory } from "./os-bridge";
@@ -946,18 +949,27 @@ export const tauriProvider = {
         getEngine().providerLogin(provider, {
           deviceAuth:
             opts?.deviceAuth ??
-            // A runtime `remote` choice (HOU-621) makes the engine remote without
-            // any baked URL env, so OR in isRemoteEngine() — else the topology
-            // helper (build-env only) would pick browser loopback against a
-            // callback that lives on the remote host and the login strands.
-            (isRemoteEngine() ||
-              providerLoginUsesDeviceAuthByDefault(
-                (import.meta.env ?? {}) as {
-                  VITE_NEW_ENGINE_URL?: string;
-                  VITE_HOSTED_ENGINE_URL?: string;
-                },
-                { isTauri: osIsTauri() },
-              )),
+            // Codex/OpenAI on a Tauri desktop uses the zero-code loopback relay
+            // even against a REMOTE engine: the desktop binds its own localhost
+            // listener and relays the callback code, so it always wants an
+            // authorize URL (deviceAuth:false), never device code. Every other
+            // provider keeps the connection-topology default below.
+            (provider === "openai" &&
+            codexUsesLoopbackRelay({ isTauri: osIsTauri() })
+              ? false
+              : // A runtime `remote` choice (HOU-621) makes the engine remote
+                // without any baked URL env, so OR in isRemoteEngine() — else the
+                // topology helper (build-env only) would pick browser loopback
+                // against a callback that lives on the remote host and the login
+                // strands.
+                isRemoteEngine() ||
+                providerLoginUsesDeviceAuthByDefault(
+                  (import.meta.env ?? {}) as {
+                    VITE_NEW_ENGINE_URL?: string;
+                    VITE_HOSTED_ENGINE_URL?: string;
+                  },
+                  { isTauri: osIsTauri() },
+                )),
           enterpriseDomain: opts?.enterpriseDomain,
         }),
       undefined,

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -56,6 +56,9 @@
     "copyCode": "Copy code",
     "codeCopied": "Code copied!",
     "codeCopyFailed": "Couldn't copy the code",
+    "deviceOpenFailed": "Couldn't open the sign-in page",
+    "deviceSettingsHint": "Not seeing a code prompt? Turn on device-code sign-in in <link>ChatGPT Settings > Security</link>.",
+    "deviceSettingsOpenFailed": "Couldn't open ChatGPT settings",
     "cancel": "Cancel"
   },
   "apiKey": {

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -56,6 +56,9 @@
     "copyCode": "Copiar código",
     "codeCopied": "¡Código copiado!",
     "codeCopyFailed": "No se pudo copiar el código",
+    "deviceOpenFailed": "No se pudo abrir la página de inicio de sesión",
+    "deviceSettingsHint": "¿No aparece la solicitud de código? Activa el inicio de sesión con código de dispositivo en <link>Configuración de ChatGPT > Seguridad</link>.",
+    "deviceSettingsOpenFailed": "No se pudo abrir la configuración de ChatGPT",
     "cancel": "Cancelar"
   },
   "apiKey": {

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -56,6 +56,9 @@
     "copyCode": "Copiar código",
     "codeCopied": "Código copiado!",
     "codeCopyFailed": "Não foi possível copiar o código",
+    "deviceOpenFailed": "Não foi possível abrir a página de login",
+    "deviceSettingsHint": "Não apareceu o pedido de código? Ative o login por código de dispositivo em <link>Configurações do ChatGPT > Segurança</link>.",
+    "deviceSettingsOpenFailed": "Não foi possível abrir as configurações do ChatGPT",
     "cancel": "Cancelar"
   },
   "apiKey": {

--- a/app/tests/engine-mode.test.ts
+++ b/app/tests/engine-mode.test.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
+  codexUsesLoopbackRelay,
   controlPlaneBuild,
   hostedAuthMode,
   hostedGateState,
@@ -104,6 +105,21 @@ describe("providerLoginUsesDeviceAuthByDefault", () => {
       providerLoginUsesDeviceAuthByDefault({}, { isTauri: false }),
       true,
     );
+  });
+});
+
+// Codex/OpenAI (ChatGPT) sign-in uses the desktop's own loopback relay even
+// against a remote engine — the desktop binds its localhost listener and relays
+// the callback code, so unlike providerLoginUsesDeviceAuthByDefault it does NOT
+// fall back to device code just because the engine is remote. A plain browser
+// client has no local listener and still can't relay.
+describe("codexUsesLoopbackRelay", () => {
+  it("uses the loopback relay on the Tauri desktop (even against a remote engine)", () => {
+    strictEqual(codexUsesLoopbackRelay({ isTauri: true }), true);
+  });
+
+  it("does not use the loopback relay in a plain browser client", () => {
+    strictEqual(codexUsesLoopbackRelay({ isTauri: false }), false);
   });
 });
 

--- a/app/tests/provider-login-url.test.ts
+++ b/app/tests/provider-login-url.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   providerLoginUrlHost,
   shouldOpenLoginUrlDirectly,
+  shouldUseCodexLoopback,
 } from "../src/components/shell/provider-login-url.ts";
 
 describe("providerLoginUrlHost", () => {
@@ -94,6 +95,68 @@ describe("shouldOpenLoginUrlDirectly", () => {
     strictEqual(
       shouldOpenLoginUrlDirectly({ isDesktop: true, userCode: "" }),
       true,
+    );
+  });
+});
+
+describe("shouldUseCodexLoopback", () => {
+  it("drives the loopback relay for Codex on desktop with no device code", () => {
+    strictEqual(
+      shouldUseCodexLoopback({
+        provider: "openai",
+        isDesktop: true,
+        userCode: null,
+      }),
+      true,
+    );
+    strictEqual(
+      shouldUseCodexLoopback({
+        provider: "openai",
+        isDesktop: true,
+        userCode: undefined,
+      }),
+      true,
+    );
+    strictEqual(
+      shouldUseCodexLoopback({
+        provider: "openai",
+        isDesktop: true,
+        userCode: "",
+      }),
+      true,
+    );
+  });
+
+  it("does not use the relay when a device code must be shown", () => {
+    strictEqual(
+      shouldUseCodexLoopback({
+        provider: "openai",
+        isDesktop: true,
+        userCode: "WXYZ-1234",
+      }),
+      false,
+    );
+  });
+
+  it("does not use the relay for a web / non-desktop client", () => {
+    strictEqual(
+      shouldUseCodexLoopback({
+        provider: "openai",
+        isDesktop: false,
+        userCode: null,
+      }),
+      false,
+    );
+  });
+
+  it("does not use the relay for a non-Codex provider (e.g. Claude)", () => {
+    strictEqual(
+      shouldUseCodexLoopback({
+        provider: "anthropic",
+        isDesktop: true,
+        userCode: null,
+      }),
+      false,
     );
   });
 });

--- a/packages/runtime/src/auth/login.test.ts
+++ b/packages/runtime/src/auth/login.test.ts
@@ -11,30 +11,31 @@ import {
   startLogin,
 } from "./login";
 
-test("codexLoginMethod: browser login only for a co-located client on a loopback runtime", () => {
-  // The desktop app sends deviceAuth:false and the desktop runtime is non-headless:
-  // the user approves in their own browser and the localhost callback finishes it.
-  expect(codexLoginMethod({ deviceAuth: false, headless: false })).toBe(
+test("codexLoginMethod: browser login for any client that can catch/relay the loopback callback", () => {
+  // The desktop app sends deviceAuth:false: the user approves in their own
+  // browser, the client catches the fixed localhost:1455 redirect and relays
+  // code+state, and the runtime finishes the token exchange.
+  expect(codexLoginMethod({ deviceAuth: false })).toBe(
     OPENAI_CODEX_BROWSER_LOGIN_METHOD,
   );
 });
 
 test("codexLoginMethod: device code for any remote client (deviceAuth) — cloud and self-host", () => {
   // A remote webapp (cloud OR self-host) sends deviceAuth:true: the user types a
-  // one-time code while the runtime polls, regardless of how the runtime binds.
-  expect(codexLoginMethod({ deviceAuth: true, headless: false })).toBe(
-    OPENAI_CODEX_DEVICE_CODE_LOGIN_METHOD,
-  );
-  expect(codexLoginMethod({ deviceAuth: true, headless: true })).toBe(
+  // one-time code while the runtime polls.
+  expect(codexLoginMethod({ deviceAuth: true })).toBe(
     OPENAI_CODEX_DEVICE_CODE_LOGIN_METHOD,
   );
 });
 
-test("codexLoginMethod: device code when a co-located client hits a headless runtime", () => {
-  // Exotic: desktop pointed at a remote headless runtime. The loopback can't be
-  // reached, so fall back to the device code even though deviceAuth is false.
-  expect(codexLoginMethod({ deviceAuth: false, headless: true })).toBe(
-    OPENAI_CODEX_DEVICE_CODE_LOGIN_METHOD,
+test("codexLoginMethod: browser login for a headless/remote runtime whose client relays the callback", () => {
+  // Cloud-relay scenario: the runtime is headless but the desktop client still
+  // catches http://localhost:1455/auth/callback and relays code+state via
+  // completeLogin. The browser flow races its local callback server against that
+  // manually-relayed code, so headless no longer forces the device code — only
+  // deviceAuth decides, and deviceAuth:false means the client CAN relay.
+  expect(codexLoginMethod({ deviceAuth: false })).toBe(
+    OPENAI_CODEX_BROWSER_LOGIN_METHOD,
   );
 });
 

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -17,7 +17,6 @@ import {
   type ProviderId,
   providerAuthMethod,
 } from "../ai/providers";
-import { config } from "../config";
 import { authStorage, providerConnected } from "./storage";
 
 /**
@@ -44,24 +43,23 @@ type LoginState = {
 const active = new Map<ProviderId, LoginState>();
 
 /**
- * Which Codex OAuth flow to run. The browser/loopback login (the user approves
- * in their own browser, the localhost callback finishes it, no code to type) is
- * used ONLY when the client is co-located: it asked for it (`deviceAuth: false`,
- * which only the desktop app sends — `!osIsTauri()`) AND this runtime can host a
- * loopback callback the browser actually reaches (`!headless`). Otherwise the
- * device-code grant, where the user enters a one-time code while the runtime
- * polls. `deviceAuth` is the load-bearing signal — a remote webapp (cloud OR
- * self-host) sends `deviceAuth: true` and gets the device code regardless of how
- * the runtime binds; `headless` only guards the exotic "desktop pointed at a
- * remote headless runtime" case where the loopback can't be reached.
+ * Which Codex OAuth flow to run — decided SOLELY by `deviceAuth`. The
+ * browser/loopback login (the user approves in their own browser, no code to
+ * type) works even against a headless/remote runtime: pi's loginOpenAICodex
+ * races its own local callback server against a manually-relayed code
+ * (`onManualCodeInput`, wired below). The desktop client catches the fixed
+ * `http://localhost:1455/auth/callback` redirect and relays code+state via
+ * `completeLogin`, and the runtime performs the token exchange — so the loopback
+ * never needs to be reachable from the runtime itself. `deviceAuth: false` is
+ * only sent by clients that can catch/relay that loopback callback; everyone
+ * else (a remote webapp, cloud OR self-host) sends `deviceAuth: true` and gets
+ * the device-code grant, where the user types a one-time code while the runtime
+ * polls.
  */
-export function codexLoginMethod(opts: {
-  deviceAuth: boolean;
-  headless: boolean;
-}): string {
-  return !opts.deviceAuth && !opts.headless
-    ? OPENAI_CODEX_BROWSER_LOGIN_METHOD
-    : OPENAI_CODEX_DEVICE_CODE_LOGIN_METHOD;
+export function codexLoginMethod(opts: { deviceAuth: boolean }): string {
+  return opts.deviceAuth
+    ? OPENAI_CODEX_DEVICE_CODE_LOGIN_METHOD
+    : OPENAI_CODEX_BROWSER_LOGIN_METHOD;
 }
 
 /**
@@ -166,8 +164,7 @@ export async function startLogin(
       // Codex offers browser (loopback) or device-code login; let the client
       // pick so the co-located desktop redirects to the browser to approve and
       // remote webapp clients type a code (see codexLoginMethod).
-      onSelect: async () =>
-        codexLoginMethod({ deviceAuth, headless: config.headless }),
+      onSelect: async () => codexLoginMethod({ deviceAuth }),
       onPrompt: () => {
         const auto = autoPromptAnswer(provider, enterpriseDomain);
         return auto === null ? pastePromise : Promise.resolve(auto);

--- a/packages/web/src/new-engine/connect.tsx
+++ b/packages/web/src/new-engine/connect.tsx
@@ -3,8 +3,35 @@ import type {
   ProviderId,
   ProviderInfo,
 } from "@houston/runtime-client";
-import { useEffect, useState } from "react";
+import { type CSSProperties, useEffect, useState } from "react";
 import { ui } from "./styles";
+
+// ChatGPT security settings, where device-code sign-in is toggled on. The
+// most common device-login dead-end is that switch being off.
+const CHATGPT_SECURITY_URL = "https://chatgpt.com/#settings/Security";
+
+// Inline text link, matching the card's dark-on-dark palette. This surface
+// paints before app CSS loads, so it carries its own styles (see styles.ts).
+const linkStyle: CSSProperties = {
+  background: "none",
+  border: "none",
+  padding: 0,
+  font: "inherit",
+  color: "#9a9cff",
+  textDecoration: "underline",
+  cursor: "pointer",
+};
+
+const codeBoxStyle: CSSProperties = {
+  ...ui.input,
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  height: 52,
+  fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+  fontSize: 22,
+  letterSpacing: "0.3em",
+};
 
 /**
  * Connect screen for the new engine: lists subscription providers and starts the
@@ -28,6 +55,13 @@ export function ConnectView({
     hint?: string;
   } | null>(null);
   const [code, setCode] = useState("");
+  // Set for the Codex/ChatGPT device-code flow: the one-time code the user
+  // types on the verification page (opened automatically) to finish sign-in.
+  const [deviceCode, setDeviceCode] = useState<{
+    code: string;
+    verificationUri: string;
+  } | null>(null);
+  const [deviceCopied, setDeviceCopied] = useState(false);
 
   useEffect(() => {
     client
@@ -47,6 +81,7 @@ export function ConnectView({
         } else if (pr?.login?.status === "error") {
           clearInterval(poll);
           setPendingCode(null);
+          setDeviceCode(null);
           setNote(`Login failed: ${pr.login.error}`);
         }
       } catch {
@@ -58,6 +93,8 @@ export function ConnectView({
   const connect = async (p: ProviderInfo) => {
     setNote(`Starting ${p.name} login…`);
     setPendingCode(null);
+    setDeviceCode(null);
+    setDeviceCopied(false);
     setCode("");
     try {
       const info = await client.startLogin(p.id);
@@ -72,16 +109,31 @@ export function ConnectView({
         );
         setPendingCode({ id: p.id, hint: info.instructions });
       } else {
+        // Device code: open the verification page now and show the code with a
+        // one-click copy affordance. pollUntilConnected auto-advances on success.
         window.open(info.verificationUri, "_blank", "noopener");
-        setNote(
-          `Open ${info.verificationUri} and enter code: ${info.userCode}`,
-        );
+        setDeviceCode({
+          code: info.userCode,
+          verificationUri: info.verificationUri,
+        });
+        setNote("Waiting for you to authorize in the new tab…");
       }
     } catch (e) {
       setNote(e instanceof Error ? e.message : String(e));
       return;
     }
     pollUntilConnected(p.id);
+  };
+
+  const copyDeviceCode = async () => {
+    if (!deviceCode) return;
+    try {
+      await navigator.clipboard.writeText(deviceCode.code);
+      setDeviceCopied(true);
+      setTimeout(() => setDeviceCopied(false), 2000);
+    } catch (e) {
+      setNote(e instanceof Error ? e.message : String(e));
+    }
   };
 
   const submitCode = async () => {
@@ -114,6 +166,39 @@ export function ConnectView({
             {p.configured ? `✓ ${p.name} connected` : `Connect ${p.name}`}
           </button>
         ))}
+        {deviceCode ? (
+          <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+            <div style={codeBoxStyle}>{deviceCode.code}</div>
+            <button type="button" style={ui.button} onClick={copyDeviceCode}>
+              {deviceCopied ? "Code copied!" : "Copy code"}
+            </button>
+            <p style={ui.note}>
+              Enter this code on the ChatGPT tab that opened.{" "}
+              <button
+                type="button"
+                style={linkStyle}
+                onClick={() =>
+                  window.open(deviceCode.verificationUri, "_blank", "noopener")
+                }
+              >
+                Open the page again
+              </button>
+            </p>
+            <p style={ui.note}>
+              Not seeing a code prompt? Turn on device-code sign-in in ChatGPT
+              Settings {">"} Security.{" "}
+              <button
+                type="button"
+                style={linkStyle}
+                onClick={() =>
+                  window.open(CHATGPT_SECURITY_URL, "_blank", "noopener")
+                }
+              >
+                Open settings
+              </button>
+            </p>
+          </div>
+        ) : null}
         {pendingCode ? (
           <div style={{ display: "flex", gap: 8 }}>
             <input

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -174,6 +174,7 @@ export async function invoke<T = unknown>(
 
     // ── Desktop-only: surface a clear error if a user triggers them ─────
     case "start_oauth_loopback": // desktop uses a native loopback listener; web uses the redirect flow
+    case "start_codex_oauth_loopback": // desktop relays the Codex 1455 callback; web stays on device-code
     case "get_engine_handshake": // web injects window.__HOUSTON_ENGINE__ directly
     case "pick_directory":
     case "reveal_file":


### PR DESCRIPTION
## Problem

In hosted/cloud mode, connecting a ChatGPT subscription used the OAuth device-code flow: users had to enable "Allow device code login" in ChatGPT security settings AND type a one-time code. Non-technical users failed at both steps.

## What

**Desktop (Tauri), any engine (local or remote): zero-code connect.**
- Runtime: `codexLoginMethod` decides browser-vs-device-code from the client's `deviceAuth` declaration alone; pi's browser flow already races its local callback against a manually-relayed code (`onManualCodeInput`), so the pod keeps the PKCE verifier and performs the token exchange.
- Tauri: new one-shot listener on `127.0.0.1:1455` (OpenAI's fixed redirect) catching `/auth/callback` and emitting the raw `code=…&state=…` query to JS; shared HTTP helpers extracted to `loopback_util.rs`.
- App glue: OpenAI on desktop defaults `deviceAuth:false`; new `codex-loopback.ts` binds the listener, opens the browser, relays the code via the existing complete-login route. State is verified by pi against the value it generated (CSRF-safe, stronger than device-code).
- Security: no new routes; refresh tokens keep flowing only through the existing capture→central-store→scrub pipeline (Gate #2 untouched); desktop never sees a refresh token.

**Web fallback (device-code) polished:** auto-open verification URL, one-click copy button, auto-advance on approval, inline hint linking to the ChatGPT security setting (en/es/pt).

## Verification

- Runtime vitest (login flip) 8/8; app node tests 53/53; Tauri `cargo test` 54 passed (6 new); full `pnpm typecheck` incl. web shim-parity (new invoke shimmed), Biome clean, boundaries clean. Re-verified after rebase onto latest main.
- Pre-existing `check-locales` divergences in `shell.*`/`setup.tutorial.*` (es/pt) exist on main and are untouched here.
- Known caveat: listener binds IPv4 `127.0.0.1` matching pi's own callback host; flagged for IPv6-preferring hosts.

Part 2 of the provider-auth overhaul (part 1: #612).

🤖 Generated with [Claude Code](https://claude.com/claude-code)