### PR TITLE
fix(host): single-flight runtime spawn so concurrent first requests don't 502 (HOU-639)

### DIFF
--- a/packages/host/src/launcher/process.test.ts
+++ b/packages/host/src/launcher/process.test.ts
@@ -107,6 +107,62 @@ test("a runtime that never becomes healthy is killed and not cached (the turn er
   expect(await launcher.status("bad")).toBe("asleep"); // not cached as running
 });
 
+test("concurrent callers during a boot share one spawn and resolve only once healthy", async () => {
+  // HOU-639: on a cold pod the desktop fires chat-history and provider-status
+  // together; the loser of the spawn race used to be handed a port the child
+  // hadn't bound yet and 502'd (rendered as an empty chat / disconnected
+  // provider). Both callers must ride the same boot to the same endpoint.
+  const { spawner, spawns } = recordingSpawner();
+  let releaseHealth!: () => void;
+  const health = new Promise<void>((r) => {
+    releaseHealth = r;
+  });
+  const launcher = new ProcessLauncher(
+    opts(spawner, { waitHealthy: () => health }),
+  );
+  const a = agent("sales");
+
+  const first = launcher.ensureAwake(a);
+  const second = launcher.ensureAwake(a);
+  let secondResolved = false;
+  void second.then(() => {
+    secondResolved = true;
+  });
+  await new Promise((r) => setTimeout(r, 10));
+  expect(secondResolved).toBe(false); // must not resolve before healthy
+
+  releaseHealth();
+  const [ep1, ep2] = await Promise.all([first, second]);
+  expect(ep2).toEqual(ep1);
+  expect(spawns).toHaveLength(1); // one shared spawn, not one per caller
+});
+
+test("a failed shared boot rejects every waiter; the next call respawns fresh", async () => {
+  const { spawner, spawns, killed } = recordingSpawner();
+  let failHealth!: (err: Error) => void;
+  const health = new Promise<void>((_, reject) => {
+    failHealth = reject;
+  });
+  let calls = 0;
+  const launcher = new ProcessLauncher(
+    opts(spawner, {
+      waitHealthy: () => (++calls === 1 ? health : Promise.resolve()),
+    }),
+  );
+  const a = agent("flaky");
+
+  const first = launcher.ensureAwake(a);
+  const second = launcher.ensureAwake(a);
+  failHealth(new Error("never healthy"));
+  await expect(first).rejects.toThrow("never healthy");
+  await expect(second).rejects.toThrow("never healthy");
+  expect(killed).toEqual([5000]); // the dead boot was reaped
+
+  const woken = await launcher.ensureAwake(a);
+  expect(woken.baseUrl).toBe("http://127.0.0.1:5001");
+  expect(spawns).toHaveLength(2);
+});
+
 test("multiple agents get distinct ports + processes", async () => {
   const { spawner } = recordingSpawner();
   const launcher = new ProcessLauncher(opts(spawner));

--- a/packages/host/src/launcher/process.ts
+++ b/packages/host/src/launcher/process.ts
@@ -108,6 +108,7 @@ async function pollHealth(port: number): Promise<void> {
  */
 export class ProcessLauncher implements RuntimeLauncher {
   private readonly running = new Map<AgentId, Running>();
+  private readonly booting = new Map<AgentId, Promise<RuntimeEndpoint>>();
   private readonly allocatePort: () => Promise<number>;
   private readonly waitHealthy: (port: number, token: string) => Promise<void>;
 
@@ -117,6 +118,14 @@ export class ProcessLauncher implements RuntimeLauncher {
   }
 
   async ensureAwake(agent: Agent): Promise<RuntimeEndpoint> {
+    // Single-flight per agent: the `running` entry exists BEFORE the child is
+    // healthy (so sleep/shutdown can kill a mid-boot process), so a concurrent
+    // caller must not read it as "awake" — it would be handed a port nobody has
+    // bound yet and proxy into connection-refused (surfacing as a 502 the
+    // desktop renders as an empty chat / disconnected provider). Everyone who
+    // arrives during a boot awaits the SAME spawn+health instead.
+    const inflight = this.booting.get(agent.id);
+    if (inflight) return inflight;
     const existing = this.running.get(agent.id);
     if (existing)
       return {
@@ -124,6 +133,16 @@ export class ProcessLauncher implements RuntimeLauncher {
         token: existing.token,
       };
 
+    const boot = this.spawnUntilHealthy(agent);
+    this.booting.set(agent.id, boot);
+    try {
+      return await boot;
+    } finally {
+      this.booting.delete(agent.id);
+    }
+  }
+
+  private async spawnUntilHealthy(agent: Agent): Promise<RuntimeEndpoint> {
     const token = this.opts.mintToken(agent);
     const port = await this.allocatePort();
     const cred = this.opts.credentialServing;


### PR DESCRIPTION
## Problem (HOU-639)

Cloud: sign out, close the app, reopen, sign in again — agents, routines and mission cards render with their titles, but chat message content is missing and the previously-connected AI provider shows as not connected. Clicking login on that same provider makes it load, and then the chat messages appear too.

## Root cause

Titles come from surfaces served without the per-agent runtime (gateway registry + host Vfs on the PVC). Chat message content (`GET …/conversations/:id/messages`) and provider status (`GET …/providers`) are the two boot-time reads that dispatch into the per-agent **runtime child**, which is spawned lazily on the first dispatch after a pod (or desktop host) starts.

`ProcessLauncher.ensureAwake` registered the child in its `running` map **before** it was healthy (`packages/host/src/launcher/process.ts`). The desktop fires the chat-history and provider-status reads roughly concurrently on login, so only the caller that triggered the spawn waited for `/health` — every concurrent caller was handed a port the child hadn't bound yet, the proxy burned its ~4s connection-refused retry budget, and the request surfaced as a 502.

The desktop then swallows exactly these two failures into successful-looking empty results (`loadChatHistory` → `[]`, `providerStatus` → `unauthenticated` in `packages/web/src/engine-adapter/client.ts`), and with the global `retry: false` those empty states stick. Clicking provider login worked because by then the child was warm: the login flow re-probes provider status, and its `osFocusWindow()` triggers the window-focus refetch that reloads the chat history.

## Fix

`ensureAwake` is now **single-flight per agent**: callers arriving during a boot await the same spawn+health promise and resolve together only once the child is actually serving. A failed boot rejects every waiter, is reaped, and the next call respawns fresh. `sleep`/`shutdownAll`/crash-reap semantics are unchanged (the `running` entry still exists during boot so a mid-boot child can be killed).

This fixes both the cloud pod and the desktop, since `ProcessLauncher` is the runtime launcher for both.

## Tests

Two new unit tests in `process.test.ts`, both verified red against the old code:
- concurrent callers during a boot share one spawn and resolve only once healthy
- a failed shared boot rejects every waiter and the next call respawns fresh

Full `packages/host` suite: 413 passed. Workspace typecheck + biome clean.

## Verify

Before the fix (cloud): create an agent, chat with it, connect a provider, then restart the agent pod (`kubectl -n houston-o-<slug> rollout restart deploy/agent-<slug>`; or sign out, close and reopen the app right after a pod restart). On sign-in the mission cards show titles but opening a chat shows no messages and the provider card reads not connected.

After the fix: same flow — opening the chat blocks briefly while the runtime child boots, then shows the full message history, and the provider card shows connected without re-running login.

## Follow-up (not in this PR)

The client-side swallow remains a footgun: `loadChatHistory` catch-all returns `[]` and `providerStatus` catch-all reports `unauthenticated`, conflating transport failures with genuinely-empty states, so any residual 502 (e.g. a runtime boot exceeding the 10s health budget) still renders as silently-empty until a refetch. Distinguishing `EngineError` 404 from transport errors there needs a UI-state audit across the board/search/palette callers, so it's left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)