### PR TITLE
fix(app): reveal a new agent immediately, background its pod-bound setup (HOU-649)

### DIFF
--- a/app/src/components/onboarding/create-personal-assistant.ts
+++ b/app/src/components/onboarding/create-personal-assistant.ts
@@ -1,3 +1,4 @@
+import { logger } from "../../lib/logger";
 import { tauriConfig } from "../../lib/tauri";
 import type { Agent } from "../../lib/types";
 import { useAgentStore } from "../../stores/agents";
@@ -25,16 +26,35 @@ export async function createPersonalAssistantForWorkspace(
       options.instructions,
     );
 
+  // The provider/model write dispatches to the agent's engine, which on the
+  // hosted profile is a pod still cold-starting — awaiting it would stall the
+  // whole first-run onboarding on the pod warm-up (HOU-649). The agent already
+  // exists; write the config in the background so the "assistant created" screen
+  // shows immediately. It lands well before the user can send their first
+  // message (the pod must finish warming for that too), and a failure surfaces
+  // via the tauri wrapper's own error toast.
   if (options.provider || options.model) {
-    const cfg = await tauriConfig.read(agent.folderPath);
-    await tauriConfig.write(agent.folderPath, {
+    void applyProviderModel(agent.folderPath, options);
+  }
+
+  return agent;
+}
+
+async function applyProviderModel(
+  agentPath: string,
+  options: CreatePersonalAssistantOptions,
+): Promise<void> {
+  try {
+    const cfg = await tauriConfig.read(agentPath);
+    await tauriConfig.write(agentPath, {
       ...cfg,
       ...(options.provider === "anthropic" || options.provider === "openai"
         ? { provider: options.provider }
         : {}),
       ...(options.model ? { model: options.model } : {}),
     });
+  } catch (e) {
+    // The tauri wrapper already showed a red error toast; leave a breadcrumb.
+    logger.error(`[onboarding] provider/model write failed: ${e}`);
   }
-
-  return agent;
 }

--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -91,11 +91,14 @@ export function CreateAgentDialog() {
 
   const handleCreateAgent = async () => {
     const trimmed = name.trim();
-    if (!trimmed || !selectedConfigId || !currentWorkspace) return;
+    // `creating` also gates re-entry: the submit button is disabled while in
+    // flight, but Enter in the name input still fires the form's onSubmit.
+    if (creating || !trimmed || !selectedConfigId || !currentWorkspace) return;
     setError(null);
     setCreating(true);
     // AI-generated instructions take priority over the template's claudeMd.
     const claudeMd = generatedClaudeMd ?? selectedDef?.config.claudeMd;
+    let agentPath: string;
     try {
       const { agent } = await createAgent(
         currentWorkspace.id,
@@ -107,50 +110,29 @@ export function CreateAgentDialog() {
         selectedDef?.config.agentSeeds,
         existingPath ?? undefined,
       );
-      // Always write provider/model to the agent's own config. With workspace
-      // defaults retired, the agent is the single source of truth — leaving
-      // the field blank would make the engine resolver fall back to its
-      // platform default rather than the user's pick.
-      const cfg = await tauriConfig.read(agent.folderPath);
-      await tauriConfig.write(agent.folderPath, {
-        ...cfg,
-        provider: provider as "anthropic" | "openai",
-        model,
-      });
-      // Keep the sticky last-used in sync so the next new agent inherits
-      // the user's most recent choice.
-      await tauriProvider.setLastUsed(provider, model);
-      if (routineAccepted && routineForm) {
-        // The agent is brand new, so its scheduler was never started
-        // (create() doesn't go through setCurrent, and use-houston-init
-        // only starts schedulers that existed at launch). startScheduler
-        // is idempotent and picks up the just-written routine; plain
-        // syncScheduler would be a no-op for an unstarted agent.
-        try {
-          await tauriRoutines.create(agent.folderPath, {
-            name: routineForm.name,
-            description: routineForm.description,
-            prompt: routineForm.prompt,
-            schedule: routineForm.schedule,
-            enabled: true,
-            suppress_when_silent: routineForm.suppress_when_silent,
-            chat_mode: routineForm.chat_mode,
-          });
-          await tauriRoutines.startScheduler(agent.folderPath);
-        } catch (e) {
-          // The agent is already created and the tauri wrapper surfaced
-          // its own error toast. Log a breadcrumb and don't abort the
-          // post-create flow over the routine.
-          logger.error(`[new-agent] routine setup failed: ${e}`);
-        }
-      }
-      useUIStore.getState().setViewMode(DEFAULT_TAB_ID);
-      handleClose();
+      agentPath = agent.folderPath;
     } catch (err) {
       setError(String(err));
-    } finally {
       setCreating(false);
+      return;
     }
+    // Keep the sticky last-used in sync so the next new agent inherits the
+    // user's most recent choice (local, so it's cheap to await).
+    await tauriProvider.setLastUsed(provider, model);
+    // Reveal the agent NOW. The provider/model write and routine setup dispatch
+    // to the agent's engine, which on the hosted profile is a pod still
+    // cold-starting — awaiting them here would re-block the dialog for the whole
+    // pod warm-up (HOU-649), the exact stall this is fixing. The agent already
+    // exists and is current; finish its setup in the background. Both writes
+    // land before the pod is usable enough to send a message, and each surfaces
+    // its own error toast on failure.
+    useUIStore.getState().setViewMode(DEFAULT_TAB_ID);
+    handleClose();
+    void finishAgentSetup(agentPath, {
+      provider,
+      model,
+      routine: routineAccepted ? routineForm : null,
+    });
   };
 
   const handleSubmit = async (e: FormEvent) => {
@@ -276,6 +258,7 @@ export function CreateAgentDialog() {
             existingPath={existingPath}
             provider={provider}
             model={model}
+            creating={creating}
             showLinkProject={selectedDef?.config.features?.includes(
               "link-project",
             )}
@@ -293,4 +276,55 @@ export function CreateAgentDialog() {
       </DialogContent>
     </Dialog>
   );
+}
+
+/**
+ * The pod-bound tail of agent creation, run after the dialog has already
+ * revealed the agent (HOU-649): persist the picked provider/model and, if the
+ * user accepted one, its starter routine. Both dispatch to the agent's engine,
+ * so on the hosted profile they wait out the pod's cold start — off the create
+ * click. Each step surfaces its own error toast via the tauri wrappers; we only
+ * add a breadcrumb so a background failure is traceable.
+ */
+async function finishAgentSetup(
+  agentPath: string,
+  opts: { provider: string; model: string; routine: RoutineFormData | null },
+): Promise<void> {
+  try {
+    // Always write provider/model to the agent's own config. With workspace
+    // defaults retired, the agent is the single source of truth — leaving the
+    // field blank would make the engine resolver fall back to its platform
+    // default rather than the user's pick.
+    const cfg = await tauriConfig.read(agentPath);
+    await tauriConfig.write(agentPath, {
+      ...cfg,
+      provider: opts.provider as "anthropic" | "openai",
+      model: opts.model,
+    });
+  } catch (e) {
+    logger.error(`[new-agent] provider/model write failed: ${e}`);
+  }
+
+  if (opts.routine) {
+    // The agent is brand new, so its scheduler was never started (create()
+    // doesn't go through setCurrent, and use-houston-init only starts
+    // schedulers that existed at launch). startScheduler is idempotent and
+    // picks up the just-written routine; plain syncScheduler would be a no-op
+    // for an unstarted agent.
+    try {
+      await tauriRoutines.create(agentPath, {
+        name: opts.routine.name,
+        description: opts.routine.description,
+        prompt: opts.routine.prompt,
+        schedule: opts.routine.schedule,
+        enabled: true,
+        suppress_when_silent: opts.routine.suppress_when_silent,
+        chat_mode: opts.routine.chat_mode,
+      });
+      await tauriRoutines.startScheduler(agentPath);
+    } catch (e) {
+      // The tauri wrapper surfaced its own error toast; leave a breadcrumb.
+      logger.error(`[new-agent] routine setup failed: ${e}`);
+    }
+  }
 }

--- a/app/src/components/shell/naming-step.tsx
+++ b/app/src/components/shell/naming-step.tsx
@@ -7,6 +7,7 @@ import {
   HoustonAvatar,
   Input,
   resolveAgentColor,
+  Spinner,
 } from "@houston-ai/core";
 import { ArrowLeft, Check, ChevronDown, FolderOpen } from "lucide-react";
 import type { FormEvent } from "react";
@@ -25,6 +26,8 @@ interface NamingStepProps {
   existingPath: string | null;
   provider: string;
   model: string;
+  /** The create request is in flight — lock the submit and show progress. */
+  creating: boolean;
   /** Show "Link existing project" option (opt-in via agent features). */
   showLinkProject?: boolean;
   onNameChange: (value: string) => void;
@@ -43,6 +46,7 @@ export function NamingStep({
   existingPath,
   provider,
   model,
+  creating,
   onNameChange,
   onColorChange,
   onExistingPathChange,
@@ -175,10 +179,17 @@ export function NamingStep({
         )}
         <Button
           type="submit"
-          disabled={!name.trim()}
+          disabled={!name.trim() || creating}
           className="w-full rounded-full"
         >
-          {t("naming.createAgent")}
+          {creating ? (
+            <>
+              <Spinner className="size-4" />
+              {t("naming.createAgent")}
+            </>
+          ) : (
+            t("naming.createAgent")
+          )}
         </Button>
       </form>
     </div>


### PR DESCRIPTION
## HOU-649 — "Create Agent" feels frozen for minutes

### Root cause
Two layers, one symptom. The cloud gateway blocked `POST /agents` on the pod cold start. But even with a fast create response, the **client** re-incurred the wait: right after `create()` returned, `handleCreateAgent` (and the first-run onboarding) `await`ed a provider/model config write on the new agent. That write dispatches to the agent's engine — a pod still cold-starting on the hosted profile — so the dialog / onboarding still froze for the whole warm-up, and the template-path Create button gave no feedback at all while it was in flight.

Per-agent pods can't be provisioned at login, so the fix is the issue's fallback: **reveal the agent immediately and finish its pod-bound setup in the background.**

### The change
- **`create-workspace-dialog`**: after `create()` resolves, switch view + close the dialog immediately (the agent is already current), then run the provider/model write + starter-routine setup in the background (`finishAgentSetup`). The pod-bound writes wait out the cold start off the create click.
- **`create-personal-assistant`** (first-run onboarding — the "first agent" case named in the issue): background the provider/model write the same way, so the "assistant created" screen shows without waiting on the pod.
- **`naming-step`**: the template-path Create Agent button now shows a spinner and is disabled while the (now-fast) create call is in flight; `handleCreateAgent` guards re-entry since Enter in the name field still submits while the button is disabled.

### Not a silent failure
Both background writes go through the tauri `call()` wrappers, which show a red error toast (and Sentry-report) on failure by default; each catch adds only a log breadcrumb. They're issued the instant the agent exists and land before the pod is warm enough to send a first message, so the user's model pick still applies.

### Tests
`packages/web/e2e/agents.spec.ts` (create → agent appears in sidebar, switch, rename) passes against the fake host. Workspace-wide `pnpm -r typecheck` + Biome clean.

### Verify
- **Before (hosted):** New agent → Start from scratch → name → Create Agent. The dialog spinner (or dead button) hangs for the pod cold start (up to minutes on a first agent) before the agent appears. First-run onboarding's "create assistant" step hangs the same way.
- **After:** the dialog closes / onboarding advances immediately with the agent selected; provider/model + routine land in the background while the pod warms. On desktop (local engine) the writes complete near-instantly as before.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
