### PR TITLE
fix(ci): cloud desktop auto-update via fixed-tag cloud-latest manifest pointer (HOU-667)

### DIFF
--- a/.github/workflows/cloud-updater-manifest.yml
+++ b/.github/workflows/cloud-updater-manifest.yml
@@ -1,0 +1,70 @@
+# Cloud updater-manifest promotion (HOU-667)
+#
+# Cloud desktop builds (`cloud-v*`) ship as PRERELEASES so they can never
+# become GitHub's "latest release" and shadow the local channel's
+# `releases/latest/download/latest.json` endpoint. The flip side: the
+# `/latest/` alias only resolves to non-prereleases, so a cloud app can't use
+# it to find its own channel's manifest. Instead the cloud build's updater is
+# baked to the FIXED tag `releases/download/cloud-latest/latest-cloud.json`
+# (see scripts/ci/point-updater-at-cloud-manifest.sh), and this workflow keeps
+# that pointer current: whenever a `cloud-v*` release is PUBLISHED (draft →
+# public, manual after QA — same flow as the local channel), it copies the
+# release's finalized `latest-cloud.json` (macOS + Windows entries, merged by
+# the release workflow's finalize job) onto the rolling `cloud-latest`
+# release.
+#
+# Properties that matter:
+#   - `cloud-latest` is itself a PRERELEASE, so it can never become "latest"
+#     and shadow the local channel either.
+#   - Publishing is the trigger, so the pointer only ever advertises builds
+#     whose assets are publicly downloadable (draft assets 404 for users).
+#   - The copy is an unconditional clobber: re-publishing an OLDER cloud
+#     release repoints the channel at it, which is exactly the rollback story
+#     the local channel gets from un-publishing a bad "latest".
+#   - The tag `cloud-latest` matches neither `v*` nor `cloud-v*`, so creating
+#     it never triggers the release workflow.
+name: Cloud updater manifest
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  promote:
+    if: startsWith(github.event.release.tag_name, 'cloud-v')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # No checkout — `gh` only needs to know the repo.
+    env:
+      GH_REPO: ${{ github.repository }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Promote latest-cloud.json to the cloud-latest release
+        run: |
+          set -euo pipefail
+          TAG="${{ github.event.release.tag_name }}"
+
+          gh release download "$TAG" --pattern 'latest-cloud.json' --dir .
+          if [ ! -s latest-cloud.json ]; then
+            echo "::error::latest-cloud.json missing from release $TAG — was the release workflow's finalize job green?"
+            exit 1
+          fi
+          echo "Manifest from $TAG:"
+          cat latest-cloud.json
+
+          # First cloud publish ever: create the rolling pointer release. It
+          # must be a prerelease (never GitHub's "latest") and needs SOME
+          # commit to tag; which one is irrelevant — only its assets are read.
+          if ! gh release view cloud-latest --json id --jq .id >/dev/null 2>&1; then
+            gh release create cloud-latest \
+              --target "${{ github.sha }}" \
+              --prerelease \
+              --title "Houston Cloud updater pointer" \
+              --notes "Machine-managed rolling release: hosts the current cloud channel's updater manifest (\`latest-cloud.json\`). Cloud desktop apps poll this fixed tag for auto-updates. Do not edit or delete — it is rewritten on every \`cloud-v*\` publish by the cloud-updater-manifest workflow."
+          fi
+
+          gh release upload cloud-latest latest-cloud.json --clobber
+          echo "::notice::cloud-latest now serves the $TAG updater manifest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -275,10 +275,11 @@ jobs:
           # shadow that URL (a cloud release ships latest-cloud.json, not
           # latest.json) and every installed local app's auto-updater would 404.
           # Keeping cloud releases as prereleases means they never become "latest",
-          # so the local updater feed is unaffected. (Consequence: cloud auto-update
-          # via the /latest/ endpoint is a documented follow-up — see the PR /
-          # convergence/README.md; contamination is already prevented by the
-          # channel-specific manifest name.)
+          # so the local updater feed is unaffected. Cloud apps instead poll the
+          # fixed-tag `cloud-latest` pointer release, which the
+          # cloud-updater-manifest workflow refreshes when a cloud release is
+          # published (contamination is additionally prevented by the
+          # channel-specific manifest name).
           case "$GITHUB_REF_NAME" in
             cloud-*) TITLE="Houston Cloud v$VERSION"; PRERELEASE=(--prerelease) ;;
             *)       TITLE="Houston v$VERSION";       PRERELEASE=() ;;

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -308,13 +308,26 @@ pub fn run() {
             // VITE_HOSTED_ENGINE_URL (Supabase bearer) is set, the frontend
             // talks to an external Houston host/gateway (see app/src/lib/engine.ts),
             // so don't spawn or health-check the Rust engine sidecar at all.
-            let host_mode = ["VITE_NEW_ENGINE_URL", "VITE_HOSTED_ENGINE_URL"]
-                .iter()
-                .any(|name| {
-                    std::env::var(name)
-                        .map(|v| !v.trim().is_empty())
-                        .unwrap_or(false)
-                });
+            //
+            // Two places to look: the runtime env covers `pnpm tauri dev`
+            // (Vite and this process share the shell env), while `option_env!`
+            // covers PACKAGED cloud builds — release CI bakes the gateway URL
+            // into the frontend at compile time, and the installed app's
+            // runtime env is empty, so without the compile-time check a cloud
+            // app would spawn an idle sidecar it never talks to.
+            let host_mode = [
+                option_env!("VITE_NEW_ENGINE_URL"),
+                option_env!("VITE_HOSTED_ENGINE_URL"),
+            ]
+            .iter()
+            .any(|v| v.is_some_and(|v| !v.trim().is_empty()))
+                || ["VITE_NEW_ENGINE_URL", "VITE_HOSTED_ENGINE_URL"]
+                    .iter()
+                    .any(|name| {
+                        std::env::var(name)
+                            .map(|v| !v.trim().is_empty())
+                            .unwrap_or(false)
+                    });
             if host_mode {
                 tracing::info!(
                     "[engine] host mode — skipping the Rust engine sidecar"

--- a/convergence/README.md
+++ b/convergence/README.md
@@ -129,17 +129,19 @@ into a local build (dropping the baked gateway) or vice-versa. Cloud releases ar
 also created as **prereleases** so they can never become GitHub's "latest release"
 (which is the newest NON-prerelease) and shadow the local channel's baked
 `…/releases/latest/download/latest.json` endpoint — otherwise the first published
-cloud release would 404 every installed local app's auto-updater. The desktop
-hosted path itself is unchanged app code (`app/src/lib/engine-mode.ts`,
-`knowledge-base/auth.md`); this is purely the CI that ships it. Known non-blocking
-follow-ups: the packaged app still spawns an idle host sidecar in hosted mode
-(`lib.rs` `host_mode` reads runtime env, which is empty in a packaged app — an
-`option_env!` check would let it skip the spawn); and cloud auto-update itself is
-not wired up yet — because cloud releases are prereleases, the cloud app's
-`…/releases/latest/download/latest-cloud.json` endpoint resolves to the latest
-non-prerelease (a local release) and 404s, so cloud is effectively download-only
-until a fixed-tag / channel-pinned updater endpoint exists (the manifest isolation
-here is the foundation for that).
+cloud release would 404 every installed local app's auto-updater. Because the
+`/latest/` alias only ever resolves to non-prereleases, the cloud app's updater is
+instead pinned to a FIXED tag: `…/releases/download/cloud-latest/latest-cloud.json`.
+The rolling `cloud-latest` pointer release (itself a prerelease, so it can't shadow
+the local channel either) is maintained by
+`.github/workflows/cloud-updater-manifest.yml`, which copies the finalized
+`latest-cloud.json` onto it whenever a `cloud-v*` release is published — so cloud
+auto-update only ever advertises published (post-QA) builds, and re-publishing an
+older cloud release doubles as channel rollback (HOU-667). The packaged cloud app
+also skips spawning the idle host sidecar: `lib.rs` `host_mode` checks
+`option_env!` (compile-time, catches the CI-baked gateway URL) in addition to the
+runtime env (dev). The desktop hosted path itself is unchanged app code
+(`app/src/lib/engine-mode.ts`, `knowledge-base/auth.md`).
 
 This is a CI-only cutover: it flips what the RELEASE ships to the TS engine, but
 the app's build DEFAULTS are untouched (a plain `pnpm tauri build` still builds the

--- a/scripts/ci/point-updater-at-cloud-manifest.sh
+++ b/scripts/ci/point-updater-at-cloud-manifest.sh
@@ -2,16 +2,24 @@
 # Point the in-app updater at the CLOUD release channel's manifest.
 #
 # The desktop app ships two channels from this repo's releases:
-#   - local build  (tag `v*`)       → updater manifest `latest.json`
-#   - cloud build  (tag `cloud-v*`) → updater manifest `latest-cloud.json`
+#   - local build  (tag `v*`)       → `releases/latest/download/latest.json`
+#   - cloud build  (tag `cloud-v*`) → `releases/download/cloud-latest/latest-cloud.json`
 #
 # A cloud app must NEVER read the local channel's `latest.json`: doing so would
 # auto-update it into a LOCAL build, dropping the baked gateway URL and dumping
 # the user back on the connection chooser (and symmetrically a local app must
-# not read a cloud manifest). Repointing the cloud build's updater endpoint at
-# `latest-cloud.json` keeps the two channels' manifests as distinct release
+# not read a cloud manifest). The two channels' manifests are distinct release
 # assets, so neither can ever feed the other — the worst case is "no update
 # found", never a wrong-channel update.
+#
+# The cloud endpoint is pinned to the fixed tag `cloud-latest` rather than the
+# `/latest/` alias because cloud releases are PRERELEASES (so they can never
+# become GitHub's "latest release" and shadow the local channel's endpoint) —
+# and `/latest/` only ever resolves to non-prereleases, so a
+# `releases/latest/download/latest-cloud.json` URL would permanently 404.
+# The `cloud-latest` rolling release is maintained by
+# .github/workflows/cloud-updater-manifest.yml, which copies the published
+# cloud release's `latest-cloud.json` onto it on every `cloud-v*` publish.
 #
 # Edits ONLY the runner's checkout of tauri.conf.json — never committed. Uses
 # Node (present on every GitHub runner, including windows-11-arm where jq is
@@ -30,9 +38,11 @@ if (!Array.isArray(eps) || eps.length === 0) {
   console.error("::error::plugins.updater.endpoints missing — cannot repoint the cloud updater");
   process.exit(1);
 }
-const next = eps.map((u) => u.replace(/latest\.json$/, "latest-cloud.json"));
+const next = eps.map((u) =>
+  u.replace(/releases\/latest\/download\/latest\.json$/, "releases/download/cloud-latest/latest-cloud.json")
+);
 if (next.every((u, i) => u === eps[i])) {
-  console.error("::error::no endpoint ended in latest.json — refusing to ship a cloud build on the local updater feed");
+  console.error("::error::no endpoint matched releases/latest/download/latest.json — refusing to ship a cloud build on the local updater feed");
   process.exit(1);
 }
 c.plugins.updater.endpoints = next;


### PR DESCRIPTION
Fixes HOU-667.

## Root cause

The `cloud-v*` channel bakes the updater endpoint `…/releases/latest/download/latest-cloud.json` into cloud builds. But cloud releases are deliberately **prereleases** (so they never become GitHub's "latest release" and shadow the local channel's `latest.json`), and the `/latest/` alias only ever resolves to the newest NON-prerelease — a local release, which carries no `latest-cloud.json`. The URL permanently 404s, so cloud desktop builds were download-only with no auto-update.

## Fix

Channel-pinned updater endpoint, as sketched in `convergence/README.md`:

- `scripts/ci/point-updater-at-cloud-manifest.sh` now repoints the cloud build's updater at the **fixed tag** `…/releases/download/cloud-latest/latest-cloud.json` (fixed-tag asset URLs resolve for prereleases; `/latest/` does not). The fail-safe is kept: if no endpoint matches the local-channel URL, the build dies rather than shipping a cloud app on the wrong feed.
- New workflow `.github/workflows/cloud-updater-manifest.yml` (trigger: `release: published`, gated to `cloud-v*` tags) copies the release's finalized `latest-cloud.json` (macOS + Windows entries, merged by the release workflow's finalize job) onto a rolling `cloud-latest` **prerelease** pointer, creating it on first use.
  - Publish is the trigger, so the pointer only ever advertises builds whose assets are publicly downloadable (the manual-after-QA publish flow is unchanged).
  - The copy is an unconditional clobber, so re-publishing an older cloud release doubles as channel rollback.
  - `cloud-latest` is itself a prerelease and matches neither `v*` nor `cloud-v*`, so it can't shadow the local channel or trigger the release workflow.

### Ride-along (also from HOU-667)

Packaged cloud apps spawned an idle host sidecar: `lib.rs` `host_mode` only read the **runtime** env, which is empty in an installed app (release CI bakes `VITE_HOSTED_ENGINE_URL` at compile time). `host_mode` now also checks `option_env!`, so hosted builds skip the spawn; the runtime check stays for `pnpm tauri dev`.

Docs updated: `convergence/README.md` follow-ups section + the release.yml prerelease comment.

## Before (reproduces the bug)

1. Install a cloud desktop build (any `cloud-v*` release asset).
2. `curl -sI https://github.com/gethouston/houston/releases/latest/download/latest-cloud.json` → **404** (resolves against the newest non-prerelease). The in-app updater polls this exact URL and never finds an update.
3. In the packaged cloud app, Activity Monitor shows a `houston-engine`/host sidecar process even though the app talks to the cloud gateway.

## After (verification)

1. Tag the next cloud release (`cloud-vX.Y.Z`) built from this branch; after QA, publish the draft.
2. The `Cloud updater manifest` workflow runs and creates/updates the `cloud-latest` release.
3. `curl -sL https://github.com/gethouston/houston/releases/download/cloud-latest/latest-cloud.json` → returns the manifest with `version` = X.Y.Z and mac + Windows platform entries.
4. An installed older cloud app now shows the update prompt and updates in place (staying on the cloud channel — the manifest URLs all point at `cloud-v*` assets).
5. Local channel unaffected: `curl -sI https://github.com/gethouston/houston/releases/latest/download/latest.json` still resolves to the newest local release.
6. Sidecar ride-along: launch the new packaged cloud build — no host sidecar process spawns; `pnpm tauri dev` without hosted env vars still spawns it.

Pre-merge checks run locally: the repoint script verified against `tauri.conf.json` (correct rewrite + fail-safe fires on no-match), `cargo check` for `app/src-tauri` in both default and `--features host-sidecar` + baked-URL configurations, `actionlint` clean on the new workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)