### PR TITLE
fix(chat): loadChatHistory surfaces load failures instead of faking an empty conversation (HOU-666)

### DIFF
--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -52,7 +52,7 @@ import {
   toNewProvider,
   toOldProvider,
 } from "./synthetic";
-import { historyToFeed } from "./translate";
+import { historyToFeed, isConversationNotFound } from "./translate";
 import { observeConversation, streamTurn } from "./turn-stream";
 
 export interface HoustonClientOptions {
@@ -1146,8 +1146,14 @@ export class HoustonClient {
         );
       }
       return historyToFeed(history.messages);
-    } catch {
-      return [];
+    } catch (err) {
+      // A conversation with no persisted turns yet 404s — that IS an empty
+      // conversation (a fresh card opened before its first turn lands), not
+      // a failure. Anything else (network drop, auth, 5xx) propagates so the
+      // app's `call()` wrapper toasts it with the Report-bug affordance —
+      // returning [] would render a fake empty chat and swallow the error.
+      if (isConversationNotFound(err)) return [];
+      throw err;
     }
   }
   /**

--- a/packages/web/src/engine-adapter/translate.ts
+++ b/packages/web/src/engine-adapter/translate.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage } from "@houston/runtime-client";
+import { type ChatMessage, EngineError } from "@houston/runtime-client";
 import { historyToFeed as foldHistoryToFeed } from "@houston/sdk";
 import type { ChatHistoryEntry } from "../../../../ui/engine-client/src/types";
 import { toOldProvider } from "./synthetic";
@@ -22,4 +22,15 @@ export {
  */
 export function historyToFeed(messages: ChatMessage[]): ChatHistoryEntry[] {
   return foldHistoryToFeed(messages, toOldProvider) as ChatHistoryEntry[];
+}
+
+/**
+ * Whether a history load failed because the conversation simply doesn't exist
+ * on the runtime yet. A conversation persists on its FIRST turn, so a fresh
+ * card opened before that turn lands 404s on `GET /conversations/:id/messages`
+ * — that IS an empty conversation, not a failure. Everything else (network
+ * drop, auth, 5xx) is a real error and must surface, never render as empty.
+ */
+export function isConversationNotFound(err: unknown): boolean {
+  return err instanceof EngineError && err.status === 404;
 }

--- a/packages/web/tests/translate.test.ts
+++ b/packages/web/tests/translate.test.ts
@@ -188,3 +188,29 @@ test("a failing status persist surfaces in the feed, not silently", async () => 
   });
   expect(surfaced).toBe(true);
 });
+
+// HOU-666: loadChatHistory must only treat "conversation not found" (404 — a
+// fresh chat whose first turn hasn't persisted yet) as an empty conversation.
+// Every other failure (network drop, auth, 5xx) must propagate to the app's
+// `call()` wrapper so the user gets a toast + Report-bug, never a fake empty
+// chat. The classifier is the seam that decides which is which.
+test("isConversationNotFound: only an engine 404 reads as no-history-yet", async () => {
+  const { isConversationNotFound } = await import(
+    "../src/engine-adapter/translate"
+  );
+  const { EngineError } = await import("@houston/runtime-client");
+
+  expect(
+    isConversationNotFound(
+      new EngineError(404, '{"error":"conversation not found"}'),
+    ),
+  ).toBe(true);
+  // Real failures keep throwing: server error, auth, and transport drops
+  // (fetch rejects with a plain TypeError, not an EngineError).
+  expect(isConversationNotFound(new EngineError(500, "boom"))).toBe(false);
+  expect(isConversationNotFound(new EngineError(401, "unauthorized"))).toBe(
+    false,
+  );
+  expect(isConversationNotFound(new TypeError("Load failed"))).toBe(false);
+  expect(isConversationNotFound(undefined)).toBe(false);
+});

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -340,7 +340,14 @@ export function AIBoard({
         .then((h) => {
           if (h.length > 0) onHistoryLoaded?.(sk, h);
         })
-        .catch(console.error);
+        .catch((err) => {
+          // Un-mark the session so re-selecting the conversation retries the
+          // load instead of permanently rendering it empty. Surfacing the
+          // failure (toast, report) is the parent's job — its loader rejects
+          // through its own error path before landing here.
+          hydratedKeys.current.delete(sk);
+          console.error(err);
+        });
     },
     [onLoadHistory, onHistoryLoaded, sessionKeyFor],
   );


### PR DESCRIPTION
## Summary

Fixes HOU-666.

`loadChatHistory()` in the new-engine adapter (`packages/web/src/engine-adapter/client.ts`) caught **all** errors and returned `[]`, so a network drop, auth failure, or server error rendered exactly like an empty conversation: no toast, no Report-bug affordance, no Sentry capture. A direct violation of the no-silent-failures beta policy (banned pattern `.catch(() => [])`).

## Root cause & fix

- The adapter's blanket `catch { return [] }` hid every failure from the app's `call()` wrapper (`app/src/lib/tauri.ts`), which is the layer that toasts `errorMessage(err)` with the Report-bug affordance and captures to Sentry.
- **Fix:** only a **404** still reads as empty. A conversation persists on its first turn, so a fresh card opened before that turn lands legitimately 404s on `GET /conversations/:id/messages` — that IS an empty conversation, not a failure. The classifier is `isConversationNotFound()` in `engine-adapter/translate.ts` (an `EngineError` with `status === 404`). Everything else now propagates, and the existing `call()` path surfaces it.
- **Retry instead of fake-empty:** `ui/board` `hydrateSession` marked a session as hydrated *before* loading, so a failed load could never retry. On failure the session key is now un-marked, so re-opening the conversation retries the load. (Toasting stays in app/, per the library boundary.)
- Bulk readers (mission search, archived search) already handle rejections via `Promise.allSettled` + `onHistoryLoadError` — those paths were written for the Rust engine, which throws; this restores parity on the TS engine.

## Verification

**Before the fix (repro):**
1. Run the app on the new TS engine, open a conversation with existing messages.
2. Kill the host process (or drop the network / revoke the auth token) and re-open the conversation (fresh app start so nothing is cached).
3. The chat renders as an empty conversation — no error toast, nothing in Sentry.

**After the fix:**
1. Same setup: history endpoint failing (host down / network drop / 500).
2. Opening the conversation shows the red error toast with the real reason and the Report-bug affordance; the failure is captured to Sentry.
3. Restore the host and re-select the conversation: the history loads (retry works, no restart needed).
4. Opening a brand-new chat (no turns yet) stays silent — the 404 renders as a genuinely empty conversation, no toast.

Tests: `pnpm --filter houston-web test` (new classifier test in `packages/web/tests/translate.test.ts`), `pnpm typecheck`, `pnpm check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)