### PR TITLE
fix(board): Mission Control keeps routine/mode tags on the new engine (HOU-665)

### DIFF
--- a/app/src/components/board/use-agent-board-data.ts
+++ b/app/src/components/board/use-agent-board-data.ts
@@ -73,9 +73,6 @@ export function useAgentBoardData({
           ...(activity.session_key ? { sessionKey: activity.session_key } : {}),
           ...(activity.routine_id ? { routineId: activity.routine_id } : {}),
           ...(activity.agent ? { agent: activity.agent } : {}),
-          ...(activity.worktree_path
-            ? { worktreePath: activity.worktree_path }
-            : {}),
         },
       })),
     [agent.name, agentModes, activeRaw, t],

--- a/app/src/components/board/use-mission-control-archived.ts
+++ b/app/src/components/board/use-mission-control-archived.ts
@@ -101,7 +101,6 @@ export function useMissionControlArchived(agents: Agent[]) {
             sessionKey: c.session_key,
             ...(c.agent ? { agent: c.agent } : {}),
             ...(c.routine_id ? { routineId: c.routine_id } : {}),
-            ...(c.worktree_path ? { worktreePath: c.worktree_path } : {}),
           },
         };
       });

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -125,7 +125,6 @@ export function useMissionControl(agents: Agent[]) {
             sessionKey: c.session_key,
             ...(c.agent ? { agent: c.agent } : {}),
             ...(c.routine_id ? { routineId: c.routine_id } : {}),
-            ...(c.worktree_path ? { worktreePath: c.worktree_path } : {}),
           },
         };
       });

--- a/app/src/data/activity.ts
+++ b/app/src/data/activity.ts
@@ -28,7 +28,6 @@ export interface Activity {
   claude_session_id?: string | null;
   session_key?: string;
   agent?: string;
-  worktree_path?: string | null;
   routine_id?: string;
   routine_run_id?: string;
   updated_at?: string;
@@ -43,7 +42,6 @@ export interface ActivityUpdate {
   claude_session_id?: string | null;
   session_key?: string;
   agent?: string;
-  worktree_path?: string | null;
   routine_id?: string;
   routine_run_id?: string;
   provider?: string;
@@ -62,7 +60,6 @@ export async function create(
   title: string,
   description = "",
   agent?: string,
-  worktreePath?: string,
   provider?: string,
   model?: string,
 ): Promise<Activity> {
@@ -74,7 +71,6 @@ export async function create(
     status: "running",
     claude_session_id: null,
     agent,
-    worktree_path: worktreePath ?? null,
     updated_at: now(),
     provider,
     model,

--- a/app/src/lib/create-mission.ts
+++ b/app/src/lib/create-mission.ts
@@ -107,7 +107,6 @@ export async function createMission(
     title,
     description,
     opts.agentMode,
-    undefined,
     opts.providerOverride,
     opts.modelOverride,
   );

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -733,7 +733,6 @@ interface RawConversation {
   agent_name: string;
   agent?: string;
   routine_id?: string;
-  worktree_path?: string | null;
 }
 
 export const tauriConversations = {
@@ -764,7 +763,6 @@ function conversationToRaw(
     agent_name: c.agent_name,
     agent: c.agent,
     routine_id: c.routine_id,
-    worktree_path: c.worktree_path,
   };
 }
 
@@ -827,7 +825,6 @@ export const tauriActivity = {
     title: string,
     description?: string,
     agent?: string,
-    worktreePath?: string,
     provider?: string,
     model?: string,
   ) =>
@@ -836,7 +833,6 @@ export const tauriActivity = {
       title,
       description ?? "",
       agent,
-      worktreePath,
       provider,
       model,
     ),

--- a/packages/web/src/engine-adapter/activities.ts
+++ b/packages/web/src/engine-adapter/activities.ts
@@ -1,6 +1,7 @@
 import type {
   Activity,
   ActivityUpdate,
+  ConversationEntry,
   NewActivity,
 } from "../../../../ui/engine-client/src/types";
 import { readAgentFile, writeAgentFile } from "./agent-files";
@@ -34,6 +35,31 @@ export function listActivities(agentPath: string): Activity[] {
   return read(agentPath);
 }
 
+/**
+ * Board card ← activity. Mission Control renders tags/attribution from
+ * `agent` (mode) and `routine_id` (routine chat), so both must survive the
+ * mapping — dropping them loses the card's routine/mode tags (HOU-665).
+ */
+export function activityToConversation(
+  a: Activity,
+  agentPath: string,
+  agentName: string,
+): ConversationEntry {
+  return {
+    id: a.id,
+    title: a.title,
+    description: a.description,
+    status: a.status,
+    type: "activity",
+    session_key: a.session_key ?? `activity-${a.id}`,
+    updated_at: a.updated_at,
+    agent_path: agentPath,
+    agent_name: agentName,
+    agent: a.agent,
+    routine_id: a.routine_id,
+  };
+}
+
 export function createActivity(
   agentPath: string,
   input: NewActivity,
@@ -46,7 +72,6 @@ export function createActivity(
     status: "running",
     session_key: `activity-${id}`,
     agent: input.agent,
-    worktree_path: input.worktree_path ?? null,
     provider: input.provider,
     model: input.model,
     updated_at: new Date().toISOString(),

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -599,17 +599,9 @@ export class HoustonClient {
     // The board/missions list is derived from activities; in cloud those live on
     // the host (this.listActivities un-fakes it), not localStorage.
     const acts = await this.listActivities(agentPath);
-    return acts.map((a) => ({
-      id: a.id,
-      title: a.title,
-      description: a.description,
-      status: a.status,
-      type: "activity",
-      session_key: a.session_key ?? `activity-${a.id}`,
-      updated_at: a.updated_at,
-      agent_path: agentPath,
-      agent_name: agentName,
-    }));
+    return acts.map((a) =>
+      activities.activityToConversation(a, agentPath, agentName),
+    );
   }
   async listAllConversations(
     agentPaths: string[],

--- a/packages/web/tests/activity-conversation.test.ts
+++ b/packages/web/tests/activity-conversation.test.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "vitest";
+import { activityToConversation } from "../src/engine-adapter/activities";
+
+test("conversation mapping keeps the mission-card metadata (agent mode + routine)", () => {
+  // Mission Control derives card tags from `agent` and `routine_id`; the
+  // adapter dropping them left new-engine cards untagged (HOU-665).
+  const entry = activityToConversation(
+    {
+      id: "act-1",
+      title: "Morning digest",
+      description: "Summarize inbox",
+      status: "running",
+      session_key: "conv-abc",
+      agent: "research",
+      routine_id: "routine-7",
+      updated_at: "2026-07-04T08:00:00Z",
+    },
+    "/agents/Houston",
+    "Houston",
+  );
+  expect(entry).toEqual({
+    id: "act-1",
+    title: "Morning digest",
+    description: "Summarize inbox",
+    status: "running",
+    type: "activity",
+    session_key: "conv-abc",
+    updated_at: "2026-07-04T08:00:00Z",
+    agent_path: "/agents/Houston",
+    agent_name: "Houston",
+    agent: "research",
+    routine_id: "routine-7",
+  });
+});
+
+test("conversation mapping falls back to the activity-<id> session key", () => {
+  const entry = activityToConversation(
+    {
+      id: "act-2",
+      title: "New chat",
+      description: "",
+      status: "running",
+    },
+    "/agents/Houston",
+    "Houston",
+  );
+  expect(entry.session_key).toBe("activity-act-2");
+  expect(entry.agent).toBeUndefined();
+  expect(entry.routine_id).toBeUndefined();
+});

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -204,7 +204,6 @@ export interface Activity {
   claude_session_id?: string | null;
   session_key?: string;
   agent?: string;
-  worktree_path?: string | null;
   routine_id?: string;
   routine_run_id?: string;
   updated_at?: string;
@@ -219,7 +218,6 @@ export interface ActivityUpdate {
   claude_session_id?: string | null;
   session_key?: string;
   agent?: string;
-  worktree_path?: string | null;
   routine_id?: string;
   routine_run_id?: string;
   provider?: string;
@@ -230,7 +228,6 @@ export interface NewActivity {
   title: string;
   description?: string;
   agent?: string;
-  worktree_path?: string;
   provider?: string;
   model?: string;
 }
@@ -373,7 +370,6 @@ export interface ConversationEntry {
   agent_name: string;
   agent?: string;
   routine_id?: string;
-  worktree_path?: string | null;
 }
 
 // ---------- Skills ----------


### PR DESCRIPTION
## Summary

HOU-665: on the new TS engine, Mission Control cards lost their routine tag and agent-mode attribution. The engine-adapter's `listConversations` derives the board from activities but only mapped id/title/description/status/session fields, dropping `agent` and `routine_id` — the fields `missionCardTags` and the card metadata are built from.

**Root cause fix:** map `agent` + `routine_id` through the adapter's activity → conversation mapping, extracted as a pure `activityToConversation` helper in `packages/web/src/engine-adapter/activities.ts` and covered by a new unit test.

**Cleanup (per the issue):** `worktree_path` was vestigial (worktrees were cut in the convergence sweep) — removed it from the conversation/board path: `ConversationEntry`, `RawConversation` + `conversationToRaw`, the activity create signatures (`NewActivity`, `activityData.create`, `tauriActivity.create`), and the write-only `worktreePath` card-metadata spreads in the three board hooks. The `worktree_path` property stays in `activity.schema.json` so existing on-disk `activity.json` files (which have `additionalProperties: false` validation) still parse.

## Before (repro)

1. Run the app on the new engine (`VITE_NEW_ENGINE=1`) or cloud web.
2. Create a mission with a non-default agent mode (e.g. via the mode picker), and let a routine create a chat.
3. Open Mission Control: the cards render but have no mode tag and no Routine tag; `metadata.agent` / `metadata.routineId` are absent.

## After (verify)

1. Same setup; the mode-tagged mission card shows its agent-mode tag and the routine chat shows the Routine tag, matching the Rust-engine board.
2. `pnpm --filter houston-web test` — includes the new `activity-conversation.test.ts` regression test.
3. `pnpm typecheck`, `cd app && pnpm test` (459 pass), `pnpm check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)