### PR TITLE
fix(runtime): real provider OAuth login cancel on the new engine (HOU-664)

### DIFF
--- a/packages/fake-host/src/routes.ts
+++ b/packages/fake-host/src/routes.ts
@@ -129,6 +129,7 @@ export function handleAgents(
       const action = rest[3]; // /auth/:provider/login | /logout
       if (action === "login" && rest[4] === "complete")
         return json({ ok: true });
+      if (action === "login" && rest[4] === "cancel") return json({ ok: true });
       if (action === "login")
         return json({ kind: "url", url: "https://example.test/connect" });
       if (action === "logout") return json({ ok: true });

--- a/packages/runtime-client/src/client.ts
+++ b/packages/runtime-client/src/client.ts
@@ -149,6 +149,16 @@ export class HoustonEngineClient {
       { method: "POST" },
     );
   }
+  /**
+   * Cancel an in-flight OAuth login on the runtime itself — aborts the
+   * device-code polling / closes the loopback callback server and frees the
+   * login slot so a retry starts clean. Benign when nothing is in flight.
+   */
+  cancelLogin(provider: ProviderId) {
+    return this.json<{ ok: boolean }>(`/auth/${provider}/login/cancel`, {
+      method: "POST",
+    });
+  }
   /** Submit a pasted code (the `auth_code` headless Claude path). */
   completeLogin(provider: ProviderId, code: string) {
     return this.json<{ ok: boolean }>(`/auth/${provider}/login/complete`, {

--- a/packages/runtime/src/auth/login.test.ts
+++ b/packages/runtime/src/auth/login.test.ts
@@ -5,7 +5,9 @@ import {
 import { expect, test } from "vitest";
 import {
   autoPromptAnswer,
+  cancelLogin,
   codexLoginMethod,
+  getAuthStatus,
   LOCAL_PLACEHOLDER_KEY,
   setApiKey,
   startLogin,
@@ -71,6 +73,44 @@ test("the OpenAI-compatible provider rejects the OAuth and api-key connect paths
   // start a sign-in pi has no provider for.
   await expect(startLogin("openai-compatible")).rejects.toThrow(/OAuth/);
   expect(() => setApiKey("openai-compatible", "k")).toThrow(/API key/);
+});
+
+test("cancelLogin: benign with nothing in flight, throws on an unknown provider", () => {
+  // The client fires cancel on dialog dismiss regardless of flow state, so a
+  // no-op cancel must never error; a typo'd provider id is a caller bug.
+  expect(() => cancelLogin("anthropic")).not.toThrow();
+  expect(() => cancelLogin("not-a-provider")).toThrow(/unknown provider/);
+});
+
+test("cancelLogin: tears down the in-flight flow so a retry starts clean (HOU-664)", async () => {
+  // Anthropic's OAuth flow binds the fixed loopback port (127.0.0.1:53692)
+  // once. The old cosmetic cancel left the flow alive and the slot pending, so
+  // a retry collided with the stale login (the HOU-438 failure class). A real
+  // cancel frees the slot immediately and closes the callback server.
+  const first = await startLogin("anthropic");
+  expect(first.kind).toBe("url");
+  expect(
+    getAuthStatus().providers.find((p) => p.provider === "anthropic")?.login
+      ?.status,
+  ).toBe("awaiting_user");
+
+  cancelLogin("anthropic");
+
+  // Slot freed at once: status no longer reports a pending login.
+  expect(
+    getAuthStatus().providers.find((p) => p.provider === "anthropic")?.login,
+  ).toBeNull();
+
+  // Let the rejected paste promise unwind pi's flow and close the server...
+  await new Promise((r) => setTimeout(r, 100));
+  // ...then a retry re-binds the port and yields a FRESH login (idempotent
+  // reuse of a live login returns the same info object; a fresh start builds
+  // a new one).
+  const second = await startLogin("anthropic");
+  expect(second.kind).toBe("url");
+  expect(second).not.toBe(first);
+  cancelLogin("anthropic");
+  await new Promise((r) => setTimeout(r, 100));
 });
 
 test("LOCAL_PLACEHOLDER_KEY exists for keyless local servers", () => {

--- a/packages/runtime/src/auth/login.ts
+++ b/packages/runtime/src/auth/login.ts
@@ -38,6 +38,8 @@ type LoginState = {
   info?: LoginInfo;
   error?: string;
   resolvePaste?: (code: string) => void;
+  rejectPaste?: (err: Error) => void;
+  abort?: AbortController;
 };
 
 const active = new Map<ProviderId, LoginState>();
@@ -131,12 +133,22 @@ export async function startLogin(
     return existing.info;
   }
 
-  const state: LoginState = { status: "starting" };
+  const state: LoginState = {
+    status: "starting",
+    abort: new AbortController(),
+  };
   active.set(provider, state);
 
   let resolveInfo!: (i: LoginInfo) => void;
   const infoReady = new Promise<LoginInfo>((r) => (resolveInfo = r));
-  const pastePromise = new Promise<string>((r) => (state.resolvePaste = r));
+  const pastePromise = new Promise<string>((resolve, reject) => {
+    state.resolvePaste = resolve;
+    state.rejectPaste = reject;
+  });
+  // Only the loopback flows consume the paste promise (onPrompt /
+  // onManualCodeInput); cancelling a device-code login rejects it with no
+  // consumer, which must not crash the process as an unhandled rejection.
+  pastePromise.catch(() => {});
 
   void authStorage
     .login(provider, {
@@ -171,12 +183,19 @@ export async function startLogin(
       },
       onManualCodeInput: () => pastePromise,
       onProgress: (m: string) => console.log(`[oauth:${provider}]`, m),
+      signal: state.abort?.signal,
     })
     .then(() => {
       state.status = "complete";
       console.log(`[oauth:${provider}] login complete`);
     })
     .catch((e: unknown) => {
+      if (state.abort?.signal.aborted) {
+        // User-initiated cancel (cancelLogin already dropped the state from
+        // `active`): the rejection is the flow unwinding, not a failure.
+        console.log(`[oauth:${provider}] login cancelled`);
+        return;
+      }
       state.status = "error";
       state.error = e instanceof Error ? e.message : String(e);
       console.error(`[oauth:${provider}] failed:`, state.error);
@@ -230,6 +249,26 @@ export function setCustomEndpoint(
   setCustomEndpointConfig(input);
   const key = input.apiKey?.trim() || LOCAL_PLACEHOLDER_KEY;
   authStorage.set(OPENAI_COMPATIBLE, { type: "api_key", key });
+}
+
+/**
+ * Cancel an in-flight OAuth login for real — not just the client's spinner.
+ * Two teardown paths cover every flow pi runs:
+ * - aborting the signal stops the device-code pollers (Codex device, Copilot);
+ * - rejecting the paste promise unwinds the loopback flows (Anthropic, Codex
+ *   browser): their onManualCodeInput rejection handler calls cancelWait(),
+ *   which closes the callback server and frees the port for a retry.
+ * Dropping the state from `active` immediately frees the slot, so a retried
+ * startLogin never collides with the cancelled one ("sign-in already pending",
+ * the HOU-438 failure class). Cancelling when nothing is in flight is benign.
+ */
+export function cancelLogin(providerId: string): void {
+  if (!known(providerId)) throw new Error(`unknown provider: ${providerId}`);
+  const state = active.get(providerId);
+  if (!state || state.status === "complete") return;
+  active.delete(providerId);
+  state.abort?.abort();
+  state.rejectPaste?.(new Error("login cancelled"));
 }
 
 /** Paste-code completion (Anthropic remote path). */

--- a/packages/runtime/src/transport/provider-routes.ts
+++ b/packages/runtime/src/transport/provider-routes.ts
@@ -1,5 +1,6 @@
 import { listProviders, setSettings } from "../ai/providers";
 import {
+  cancelLogin,
   completeLogin,
   getAuthStatus,
   logout,
@@ -61,7 +62,7 @@ export async function handleProviderRoute(ctx: RouteContext): Promise<boolean> {
   }
 
   const authMatch = path.match(
-    /^\/auth\/([^/]+)\/(login|login\/complete|logout)$/,
+    /^\/auth\/([^/]+)\/(login|login\/complete|login\/cancel|logout)$/,
   );
   if (method === "POST" && authMatch) {
     await handleAuthAction(ctx, authMatch[1], authMatch[2]);
@@ -120,6 +121,11 @@ async function handleAuthAction(
     if (action === "login/complete") {
       const { code } = await readJson(ctx.req);
       completeLogin(provider, String(code || ""));
+      json(ctx.res, 200, { ok: true });
+      return;
+    }
+    if (action === "login/cancel") {
+      cancelLogin(provider);
       json(ctx.res, 200, { ok: true });
       return;
     }

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -951,16 +951,25 @@ export class HoustonClient {
     await engine.completeLogin(pid, code);
   }
   async cancelProviderLogin(name?: string): Promise<void> {
-    if (!name || !toNewProvider(name)) return;
+    const pid = name ? toNewProvider(name) : undefined;
+    if (!name || !pid) return;
     if (this.cp) {
-      const pid = toNewProvider(name);
       // Key mirrors pollProviderConnect: the agent's id, or the setup-runtime
       // sentinel when the first-run login started before any agent existed.
       const agentId = this.currentAgentId();
-      if (pid) this.activeLogins.delete(`${agentId ?? SETUP_LOGIN_KEY}:${pid}`); // stop the poll
+      this.activeLogins.delete(`${agentId ?? SETUP_LOGIN_KEY}:${pid}`); // stop the poll
+      // Kill the runtime-side login too, in the same runtime the login started
+      // in (the agent's sandbox, or the hidden setup runtime pre-agent) —
+      // otherwise it keeps polling the provider until timeout and a retry
+      // collides with the stale flow ("sign-in already pending", HOU-664 /
+      // the HOU-438 failure class).
+      await this.providerEngine().cancelLogin(pid);
       return;
     }
     this.stopLoginWatch(name);
+    // Cancel the runtime's in-flight OAuth flow for real (frees the loopback
+    // port + login slot), not just the local watcher.
+    await this.engine.cancelLogin(pid);
     // Benign completion: clears the dialog + spinner without an error toast,
     // matching the old engine's cancel semantics.
     emitEvent("ProviderLoginComplete", {


### PR DESCRIPTION
## Summary

HOU-664: on the TS engine, cancelling a provider OAuth sign-in was cosmetic. The adapter's `cancelProviderLogin()` only deleted its local polling key / watcher, so the spinner cleared but the runtime-side login kept running until timeout — and because `startLogin` reuses an in-flight login, a retry silently collided with the stale flow (the same failure class as HOU-438 on the Rust engine).

### Root cause
`packages/runtime/src/auth/login.ts` had `startLogin` / `completeLogin` / `logout` but no cancel path at all, and no route existed for one.

### Fix
- **runtime** — new `cancelLogin(provider)`: aborts the pi OAuth flow via two teardown paths that together cover every flow pi runs: an `AbortSignal` (stops the device-code pollers: Codex device, Copilot) and rejecting the paste promise (unwinds the loopback flows: Anthropic, Codex browser — their `onManualCodeInput` rejection handler cancels the wait and closes the callback server, freeing the fixed port for a retry). The login slot is freed immediately so a retried `startLogin` starts clean.
- **runtime** — `POST /auth/:provider/login/cancel` route.
- **runtime-client** — `cancelLogin()` method.
- **web adapter** — `cancelProviderLogin()` now also cancels the runtime login on both the local path and the control-plane (cloud/sidecar) path. The host proxy is transparent, so no host change is needed.
- **fake-host** — stub for the new route.

### Verification

Before the fix (reproduces the bug):
1. Run the new-engine build, open provider settings, start a Claude (or Codex device-code) sign-in.
2. Cancel the dialog. The spinner clears, but the runtime keeps the login alive: `GET /auth/status` still reports `login: { status: "awaiting_user" }`, and on the Anthropic path the loopback port 53692 stays bound.
3. Retry sign-in: it silently reuses the stale flow's info instead of starting fresh.

After the fix:
1. Same flow: cancel the dialog.
2. `GET /auth/status` immediately reports `login: null`; the runtime logs `[oauth:<provider>] login cancelled` and the loopback server closes.
3. Retry starts a fresh login (new URL / new device code) with no collision.

Regression test: `packages/runtime/src/auth/login.test.ts` — starts a real Anthropic loopback flow, cancels, asserts the slot is freed and that a retry re-binds the port with a fresh login.

Gates: full runtime vitest suite (31 files, 245 tests), `pnpm -r typecheck`, `pnpm check` (Biome) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)