### PR TITLE
fix(app): no bogus 'engine error 503' toast when integrations aren't configured

### DIFF
--- a/app/src/components/tabs/integrations-tab-model.ts
+++ b/app/src/components/tabs/integrations-tab-model.ts
@@ -1,4 +1,5 @@
 import type {
+  Capabilities,
   IntegrationConnection,
   IntegrationToolkit,
 } from "@houston-ai/engine-client";
@@ -9,6 +10,21 @@ import type {
  * no sign-in step in this tab.
  */
 export const INTEGRATION_PROVIDER = "composio";
+
+/**
+ * Whether this deployment serves the integration routes at all. The host
+ * advertises the providers actually wired in `/v1/capabilities` — a deployment
+ * with neither a gateway URL nor a platform key honestly serves `[]` and
+ * answers every `/v1/integrations` route with 503 ("integrations not
+ * configured"), so callers must not fetch there. `null` capabilities (still
+ * loading, or the legacy Rust engine, which has no integration routes) also
+ * means don't fetch. Pure so it's unit-testable.
+ */
+export function integrationsSupported(
+  capabilities: Pick<Capabilities, "integrations"> | null,
+): boolean {
+  return (capabilities?.integrations.length ?? 0) > 0;
+}
 
 /** How long to wait between connection polls, and how many times to poll. */
 export const POLL_INTERVAL_MS = 2000;

--- a/app/src/components/tabs/integrations-tab.tsx
+++ b/app/src/components/tabs/integrations-tab.tsx
@@ -50,7 +50,10 @@ export default function IntegrationsTab({ agent }: TabProps) {
   // Grants are a multiplayer-only concept (C4): per-(user, agent) toolkit
   // permission. In single-player they don't exist (`canManageAgentGrants` is
   // false outside multiplayer) and the tab renders exactly as before.
-  const { capabilities } = useCapabilities();
+  // `isLoading` also covers the status query: it's gated on the advertised
+  // `integrations` capability, so until capabilities resolve the status query
+  // sits idle — show the loading state, not a premature "unavailable".
+  const { capabilities, isLoading: capabilitiesLoading } = useCapabilities();
   const canUseGrants = canManageAgentGrants(capabilities, agent);
   const grantsQuery = useAgentGrants(agent.id, ready && canUseGrants);
   const grantSet = useMemo(
@@ -132,7 +135,7 @@ export default function IntegrationsTab({ agent }: TabProps) {
           </p>
         </div>
 
-        {status.isLoading || sessionSyncPending ? (
+        {status.isLoading || capabilitiesLoading || sessionSyncPending ? (
           <LoadingState />
         ) : !composio ? (
           <UnavailableState />

--- a/app/src/hooks/queries/use-integrations.ts
+++ b/app/src/hooks/queries/use-integrations.ts
@@ -1,18 +1,30 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { integrationsSupported } from "../../components/tabs/integrations-tab-model";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriIntegrations } from "../../lib/tauri";
+import { useCapabilities } from "../use-capabilities";
 import {
   applyGrantChange,
   type GrantChange,
   reverseGrantChange,
 } from "./grant-set";
 
-/** Per-provider readiness (usable now? needs a Houston sign-in?). User-level. */
+/**
+ * Per-provider readiness (usable now? needs a Houston sign-in?). User-level.
+ *
+ * Gated on the host-advertised `integrations` capability: a deployment with no
+ * integration provider wired answers `/v1/integrations` with 503, so fetching
+ * there would surface a red bug toast for a configuration that's perfectly
+ * legitimate (dev host, self-host without a Composio key). The disabled query
+ * stays idle with no data and the tab renders its unavailable state.
+ */
 export function useIntegrationStatus() {
+  const { capabilities } = useCapabilities();
   return useQuery({
     queryKey: queryKeys.integrationStatus(),
     queryFn: () => tauriIntegrations.status(),
     staleTime: 30_000,
+    enabled: integrationsSupported(capabilities),
   });
 }
 

--- a/app/tests/integrations-supported.test.ts
+++ b/app/tests/integrations-supported.test.ts
@@ -1,0 +1,17 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { integrationsSupported } from "../src/components/tabs/integrations-tab-model.ts";
+
+describe("integrationsSupported", () => {
+  it("true when the host advertises a wired provider", () => {
+    strictEqual(integrationsSupported({ integrations: ["composio"] }), true);
+  });
+
+  it("false when the deployment wired no provider (host 503s the routes)", () => {
+    strictEqual(integrationsSupported({ integrations: [] }), false);
+  });
+
+  it("false while capabilities are unresolved (loading, or legacy engine)", () => {
+    strictEqual(integrationsSupported(null), false);
+  });
+});

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -67,7 +67,20 @@ export class HoustonEngineError extends Error {
     public status: number,
     public body: unknown,
   ) {
-    super(`engine error ${status}`);
+    // Carry the host's own explanation into the message: the v3 host answers
+    // errors as `{error: "reason"}` (some routes as `{error: {message}}`).
+    // Dropping it here would reduce every failure to "engine error <status>"
+    // in the toast/log/Sentry report — the status code without the reason.
+    const detail = (body as { error?: unknown } | null)?.error;
+    const reason =
+      typeof detail === "string"
+        ? detail
+        : typeof (detail as { message?: unknown } | null)?.message === "string"
+          ? (detail as { message: string }).message
+          : undefined;
+    super(
+      reason ? `${reason} (engine error ${status})` : `engine error ${status}`,
+    );
     this.name = "HoustonEngineError";
   }
   get code(): string | undefined {

--- a/packages/web/tests/engine-error-message.test.ts
+++ b/packages/web/tests/engine-error-message.test.ts
@@ -1,0 +1,31 @@
+import { expect, test } from "vitest";
+import { HoustonEngineError } from "../src/engine-adapter/client";
+
+// The host's own explanation must survive into the error message — it is what
+// the red toast, the frontend log, and the Sentry report show. A bare
+// "engine error <status>" is only acceptable when the body carried no reason.
+
+test("carries the host's string error body into the message", () => {
+  const err = new HoustonEngineError(503, {
+    error: "integrations not configured",
+  });
+  expect(err.message).toBe("integrations not configured (engine error 503)");
+});
+
+test("carries an object error body's message", () => {
+  const err = new HoustonEngineError(500, {
+    error: { message: "runtime crashed", kind: "runtime_dead" },
+  });
+  expect(err.message).toBe("runtime crashed (engine error 500)");
+  expect(err.kind).toBe("runtime_dead");
+});
+
+test("falls back to the bare status when the body has no reason", () => {
+  expect(new HoustonEngineError(503, null).message).toBe("engine error 503");
+  expect(new HoustonEngineError(502, "<html>bad gateway</html>").message).toBe(
+    "engine error 502",
+  );
+  expect(new HoustonEngineError(503, { error: 42 }).message).toBe(
+    "engine error 503",
+  );
+});


### PR DESCRIPTION
## Problem

On any deployment without an integration provider wired (dev host, self-host without a Composio key), opening the Integrations tab pops the red **"Houston, we have a problem! engine error 503"** bug toast — for a configuration that is perfectly legitimate.

The host side already behaves correctly: with neither `COMPOSIO_API_KEY` nor `HOUSTON_INTEGRATIONS_URL` set it honestly advertises `integrations: []` in `/v1/capabilities` and answers `/v1/integrations` with 503 `{error: "integrations not configured"}`. The frontend ignored that flag and fetched the status unconditionally, so the guaranteed 503 flowed through the generic `call()` error surfacing. Worse, the adapter's `HoustonEngineError` discarded the response body, reducing the toast to the bare status code.

## Fix

- **Gate the fetch on the capability** (`use-integrations.ts`): `useIntegrationStatus` is `enabled` only when the host advertises a wired provider (new pure `integrationsSupported()` predicate in `integrations-tab-model.ts`). Unconfigured deployment → the query stays idle and the tab renders its existing `UnavailableState`; no request, no toast. This is the contract the capabilities design already prescribed: UI gates affordances on host-advertised flags.
- **No "unavailable" flash** (`integrations-tab.tsx`): the tab shows the loading state while capabilities resolve.
- **Error-message fidelity** (`engine-adapter/client.ts`): `HoustonEngineError` now carries the host's error body into its message — a real, unexpected failure reads e.g. `integrations not configured (engine error 503)` in the toast, frontend log, and Sentry report instead of masking the reason. Nothing is silenced; only the expected no-integrations state stops toasting.

## Tests

- `app/tests/integrations-supported.test.ts` — wired provider / empty list / unresolved capabilities.
- `packages/web/tests/engine-error-message.test.ts` — string body, `{error:{message}}` body, and no-reason fallback.

Biome clean; full workspace typecheck green; app suite 462/462, web suite 33/33.

🤖 Generated with [Claude Code](https://claude.com/claude-code)