### PR TITLE
feat(integrations): agent-offered in-chat connect card on the TS engine (HOU-670)

### DIFF
--- a/app/src-tauri/src/houston_prompt/integrations.rs
+++ b/app/src-tauri/src/houston_prompt/integrations.rs
@@ -1,4 +1,38 @@
+/// Integrations guidance for the TS engine (pi runtime), where the agent has
+/// the in-process `integration_search` / `integration_execute` tools and NO
+/// provider CLI. The connect hand-off is the `#houston_toolkit=<slug>` link
+/// the chat renders as a rich connect card (HOU-670). Keep in sync with the
+/// `INTEGRATIONS` section of packages/host/src/houston-prompt.ts.
+pub const PI_INTEGRATIONS_GUIDANCE: &str = "\n\n---\n\n\
+## How-To Guidance: Connected Apps (Integrations)\n\n\
+You can act on the user's apps (Gmail, Google Calendar, Slack, Notion, and \
+many more) with two tools: `integration_search` finds an action and its \
+input parameters; `integration_execute` runs it. Search first, then \
+execute. The user's own account is used automatically - you never handle \
+credentials.\n\n\
+When a needed app is not connected yet (search marks its actions NOT \
+CONNECTED, or execute fails because no account is linked):\n\n\
+1. Briefly say what must be connected and why, in plain language.\n\
+2. Offer the connection right in chat: include a markdown link whose URL \
+   ends with `#houston_toolkit=<toolkit>`, written exactly like \
+   `[Connect Gmail](https://gethouston.ai/connect#houston_toolkit=gmail)`. \
+   Houston renders it as a rich connect card with a one-click button. Use \
+   the toolkit slug from the search results, one link per app that needs \
+   connecting.\n\
+3. Do NOT ask the user to tell you when they're done, and do NOT promise \
+   to \"check\" the connection yourself. Houston detects the moment the \
+   connection goes live and automatically sends you a short message \
+   (e.g. \"I've connected Gmail. Please continue.\") so you can resume the \
+   task on your own. Phrase your message to set that expectation, e.g. \
+   \"Once you approve access in the browser, I'll keep going from here \
+   automatically.\" Then stop and wait.\n\n\
+Never read the link URL, fragment, or toolkit slug out loud to the user, \
+and never name the integrations provider - the card speaks for itself.";
+
 /// Composio CLI integration guidance, including rich connect-card links.
+/// (Default Rust-engine build only — host-sidecar builds compile out its
+/// caller, `system_prompt`.)
+#[cfg_attr(feature = "host-sidecar", allow(dead_code))]
 pub const COMPOSIO_GUIDANCE: &str = "\n\n---\n\n# Integrations - Composio CLI\n\n\
 When a task needs a connected app or account, prefer Composio when a suitable tool exists. \
 Search Composio before using another integration path. \

--- a/app/src-tauri/src/houston_prompt/mod.rs
+++ b/app/src-tauri/src/houston_prompt/mod.rs
@@ -12,16 +12,29 @@ mod routines;
 mod skills_memory;
 
 pub use base::HOUSTON_SYSTEM_PROMPT;
-pub use integrations::COMPOSIO_GUIDANCE;
+pub use integrations::{COMPOSIO_GUIDANCE, PI_INTEGRATIONS_GUIDANCE};
 pub use onboarding::ONBOARDING_GUIDANCE;
 pub use routines::ROUTINES_GUIDANCE;
 pub use skills_memory::SELF_IMPROVEMENT_GUIDANCE;
 
 /// Build the composite system prompt the engine uses as its fallback.
 /// Order: base identity, skills/memory guidance, routines guidance, Composio guidance.
+/// (Default Rust-engine build only — host-sidecar builds use `system_prompt_pi`.)
+#[cfg_attr(feature = "host-sidecar", allow(dead_code))]
 pub fn system_prompt() -> String {
     format!(
         "{HOUSTON_SYSTEM_PROMPT}\n\n---\n\n{SELF_IMPROVEMENT_GUIDANCE}\n\n---\n\n{ROUTINES_GUIDANCE}{COMPOSIO_GUIDANCE}"
+    )
+}
+
+/// The composite prompt for the TS engine (`host-sidecar` builds). Same
+/// product voice, but the integrations section teaches the in-process
+/// `integration_search`/`integration_execute` tools + the in-chat connect
+/// card instead of the retired Composio CLI (HOU-670).
+#[cfg_attr(not(feature = "host-sidecar"), allow(dead_code))]
+pub fn system_prompt_pi() -> String {
+    format!(
+        "{HOUSTON_SYSTEM_PROMPT}\n\n---\n\n{SELF_IMPROVEMENT_GUIDANCE}\n\n---\n\n{ROUTINES_GUIDANCE}{PI_INTEGRATIONS_GUIDANCE}"
     )
 }
 
@@ -50,6 +63,24 @@ mod tests {
         assert!(prompt.contains(
             "Ask for explicit approval before work that will change persistent user data"
         ));
+    }
+
+    #[test]
+    fn pi_prompt_swaps_cli_guidance_for_integration_tools() {
+        let prompt = system_prompt_pi();
+
+        // The pi runtime has in-process tools + the in-chat connect card…
+        assert!(prompt.contains("integration_search"));
+        assert!(prompt.contains("integration_execute"));
+        assert!(prompt.contains("#houston_toolkit=<toolkit>"));
+        assert!(prompt.contains("I've connected Gmail. Please continue."));
+        // …and none of the retired CLI guidance.
+        assert!(!prompt.contains("Composio CLI"));
+        assert!(!prompt.contains("composio link"));
+        assert!(!prompt.contains("houston_composio_signin"));
+
+        // The legacy Rust-engine prompt keeps the CLI guidance untouched.
+        assert!(system_prompt().contains("Composio CLI"));
     }
 
     #[test]

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -654,9 +654,11 @@ fn spawn_host_sidecar(
         ("HOUSTON_HOST_PORT".into(), port.to_string()),
         // The product voice — the host reads this exact env var and injects it
         // into every runtime it spawns (main.ts → buildLocalHost.systemPrompt).
+        // The pi variant: same identity, but integrations guidance for the
+        // in-process tools + in-chat connect card, not the retired CLI.
         (
             "HOUSTON_APP_SYSTEM_PROMPT".into(),
-            houston_prompt::system_prompt(),
+            houston_prompt::system_prompt_pi(),
         ),
     ];
     // Integrations gateway (platform-mode Composio): Houston's cloud host owns

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -176,6 +176,7 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           footer={panel.footer}
           attachMenu={panel.attachMenu}
           renderUserMessage={panel.renderUserMessage}
+          renderLink={panel.renderLink}
           renderSystemMessage={panel.renderSystemMessage}
           mapFeedItems={panel.mapFeedItems}
           afterMessages={panel.afterMessages}

--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -158,6 +158,7 @@ export function MissionControlArchived({
           footer={panel.footer}
           attachMenu={panel.attachMenu}
           renderUserMessage={panel.renderUserMessage}
+          renderLink={panel.renderLink}
           currentUserId={panel.currentUserId}
           authorLabels={panel.authorLabels}
           renderSystemMessage={panel.renderSystemMessage}

--- a/app/src/components/integration-connect-card-state.ts
+++ b/app/src/components/integration-connect-card-state.ts
@@ -1,0 +1,80 @@
+import type {
+  IntegrationConnection,
+  IntegrationToolkit,
+} from "@houston-ai/engine-client";
+
+/**
+ * Pure logic for the inline integration connect card (`IntegrationConnectCard`)
+ * — the rich card the chat renders in place of a markdown link the agent tags
+ * with `#houston_toolkit=<slug>` when a needed app isn't connected (HOU-670).
+ * Extracted so the parsing and the three-way visual state are unit-testable
+ * without a DOM; the component stays a thin shell over these functions.
+ */
+
+/**
+ * Parse an agent-authored link for the `#houston_toolkit=<slug>` fragment
+ * (per the system prompt). Returns the slug, or `null` when the URL doesn't
+ * carry one — the chat link renderer's signal to fall back to a plain
+ * markdown link. Accepts ANY base URL so cards survive across prompt
+ * revisions (the legacy Rust engine embedded real Composio OAuth URLs; the
+ * TS engine uses a stable placeholder — both carry the same fragment).
+ */
+export function parseToolkitFromHref(href: string): string | null {
+  try {
+    const url = new URL(href);
+    const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+    if (!hash) return null;
+    const slug = new URLSearchParams(hash).get("houston_toolkit");
+    return slug && slug.length > 0 ? slug : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Canonical slug form for comparisons: the provider catalog and connection
+ * lists report lowercased slugs, while the fragment is agent-authored and can
+ * carry any casing or stray whitespace. Comparing raw values silently misses
+ * a real connection and leaves the card stuck on "Connect" forever.
+ */
+export function normalizeToolkitSlug(slug: string): string {
+  return slug.trim().toLowerCase();
+}
+
+/** Does the user hold an ACTIVE connection to this toolkit? */
+export function isToolkitConnected(
+  connections: IntegrationConnection[] | undefined,
+  toolkit: string,
+): boolean {
+  const slug = normalizeToolkitSlug(toolkit);
+  return (connections ?? []).some(
+    (c) => c.status === "active" && normalizeToolkitSlug(c.toolkit) === slug,
+  );
+}
+
+/** The catalog entry for an agent-authored slug (casing-insensitive). */
+export function findCatalogToolkit(
+  catalog: IntegrationToolkit[] | undefined,
+  toolkit: string,
+): IntegrationToolkit | undefined {
+  const slug = normalizeToolkitSlug(toolkit);
+  return (catalog ?? []).find((t) => normalizeToolkitSlug(t.slug) === slug);
+}
+
+/**
+ * What the card renders:
+ *   - "connected"  — green "Connected" badge (the real status always wins).
+ *   - "connecting" — loading badge while the OAuth the user started from this
+ *                    card is being polled.
+ *   - "idle"       — the "Connect" call-to-action.
+ */
+export type ConnectCardView = "idle" | "connecting" | "connected";
+
+export function deriveConnectCardView(
+  isConnected: boolean,
+  isConnecting: boolean,
+): ConnectCardView {
+  if (isConnected) return "connected";
+  if (isConnecting) return "connecting";
+  return "idle";
+}

--- a/app/src/components/integration-connect-card.tsx
+++ b/app/src/components/integration-connect-card.tsx
@@ -1,0 +1,174 @@
+import { Check, ExternalLink, Loader2 } from "lucide-react";
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  useIntegrationConnections,
+  useIntegrationStatus,
+  useIntegrationToolkits,
+} from "../hooks/queries";
+import { analytics } from "../lib/analytics";
+import { useUIStore } from "../stores/ui";
+import { RowCard } from "./cards/row-card";
+import { RowCardButton } from "./cards/row-card-button";
+import {
+  deriveConnectCardView,
+  findCatalogToolkit,
+  isToolkitConnected,
+  normalizeToolkitSlug,
+} from "./integration-connect-card-state";
+import { appDisplay } from "./tabs/integrations-app-display";
+import { INTEGRATION_PROVIDER } from "./tabs/integrations-tab-model";
+import { useIntegrationConnect } from "./tabs/use-integration-connect";
+
+interface IntegrationConnectCardProps {
+  /** The raw `#houston_toolkit=<slug>` fragment from the agent's link. */
+  toolkit: string;
+  /** The agent whose chat hosts the card (multiplayer grant attribution). */
+  agentId: string;
+  /** Multiplayer: auto-grant a fresh connection to this agent (C4). */
+  autoGrant: boolean;
+  /**
+   * Fired once when a connection the user started from THIS card lands. The
+   * chat panel uses it to nudge the agent ("I've connected X. Please
+   * continue.") so the task resumes without the user having to type.
+   */
+  onConnected?: (toolkit: string, appName: string) => void;
+}
+
+/**
+ * Rich inline card rendered in place of a plain markdown link when the agent
+ * tags a URL with `#houston_toolkit=<slug>` — the in-chat integration connect
+ * hand-off on the TS engine (HOU-670). Clicking Connect mints the hosted
+ * OAuth link, opens the system browser, and polls until the connection turns
+ * active (`useIntegrationConnect`, the same flow as the Integrations tab).
+ *
+ * The card owns its own connection status: it renders inside Streamdown,
+ * which memoizes finished markdown blocks by source text and stops re-invoking
+ * the link renderer — a parent-computed prop would freeze at first render and
+ * never reflect a connection that lands afterwards. Subscribing to the shared
+ * queries here re-renders the card the moment status changes; TanStack dedupes
+ * the fetches, so N cards still issue one request per tick.
+ */
+export function IntegrationConnectCard({
+  toolkit,
+  agentId,
+  autoGrant,
+  onConnected,
+}: IntegrationConnectCardProps) {
+  const { t } = useTranslation("chat");
+  const addToast = useUIStore((s) => s.addToast);
+
+  const status = useIntegrationStatus();
+  const ready = !!status.data?.find((p) => p.provider === INTEGRATION_PROVIDER)
+    ?.ready;
+  const connections = useIntegrationConnections(INTEGRATION_PROVIDER, ready);
+  const catalog = useIntegrationToolkits(INTEGRATION_PROVIDER, ready);
+
+  const slug = normalizeToolkitSlug(toolkit);
+  const isConnected = isToolkitConnected(connections.data, toolkit);
+  const app = appDisplay(slug, findCatalogToolkit(catalog.data, toolkit));
+  const displayName = app.name === slug ? toolkit.trim() : app.name;
+
+  const { connectingToolkit, connect } = useIntegrationConnect({
+    agentId,
+    autoGrant,
+  });
+  // The nudge fires at most once per card, and only for a connection the
+  // user drove from HERE — a connection landing via the Integrations tab or
+  // another card must not make this one speak.
+  const followupFired = useRef(false);
+
+  const startConnect = async () => {
+    const outcome = await connect(slug);
+    if (outcome !== "active" || followupFired.current) return;
+    followupFired.current = true;
+    analytics.track("integration_connected", { integration_slug: slug });
+    onConnected?.(slug, displayName);
+    addToast({
+      title: t("composio.verifiedToast", { name: displayName }),
+      variant: "success",
+    });
+  };
+
+  const view = deriveConnectCardView(isConnected, connectingToolkit !== null);
+
+  return (
+    <RowCard
+      inline
+      truncate
+      media={<AppLogo name={displayName} logoUrl={app.logoUrl} />}
+      title={displayName}
+      description={
+        isConnected
+          ? t("composio.alreadyConnected")
+          : app.description || t("composio.integration")
+      }
+      action={<ConnectStatusSlot view={view} onConnect={startConnect} />}
+    />
+  );
+}
+
+/**
+ * Right-slot: status (badge) stays visually distinct from the action (the
+ * Connect button) — see issue #379 for why fusing them was ambiguous.
+ */
+function ConnectStatusSlot({
+  view,
+  onConnect,
+}: {
+  view: ReturnType<typeof deriveConnectCardView>;
+  onConnect: () => Promise<void>;
+}) {
+  const { t } = useTranslation("chat");
+
+  if (view === "connected") {
+    return (
+      <span className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full bg-emerald-50 text-emerald-700 dark:bg-emerald-950 dark:text-emerald-400 text-xs font-medium shrink-0">
+        <Check className="size-3" />
+        {t("composio.connected")}
+      </span>
+    );
+  }
+  if (view === "connecting") {
+    return (
+      <span className="inline-flex items-center gap-1 h-7 px-2.5 rounded-full bg-secondary text-muted-foreground text-xs font-medium shrink-0">
+        <Loader2 className="size-3 animate-spin" />
+        {t("composio.connecting")}
+      </span>
+    );
+  }
+  return (
+    <RowCardButton
+      label={t("composio.connect")}
+      onClick={onConnect}
+      icon={<ExternalLink className="size-3" />}
+      iconPosition="trailing"
+    />
+  );
+}
+
+/**
+ * App logo with an initial-letter fallback, span-based (NOT the block `Logo`
+ * from the Integrations tab) so it nests validly inside the inline RowCard
+ * embedded in chat prose.
+ */
+function AppLogo({ name, logoUrl }: { name: string; logoUrl: string }) {
+  const [imgError, setImgError] = useState(false);
+  if (imgError) {
+    return (
+      <span className="size-8 rounded-lg bg-accent flex items-center justify-center shrink-0">
+        <span className="text-xs font-semibold text-muted-foreground">
+          {name.charAt(0).toUpperCase()}
+        </span>
+      </span>
+    );
+  }
+  return (
+    <img
+      src={logoUrl}
+      alt={name}
+      className="size-8 rounded-lg object-contain shrink-0"
+      onError={() => setImgError(true)}
+    />
+  );
+}

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -167,6 +167,7 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
           footer={panel.footer}
           attachMenu={panel.attachMenu}
           renderUserMessage={panel.renderUserMessage}
+          renderLink={panel.renderLink}
           currentUserId={panel.currentUserId}
           authorLabels={panel.authorLabels}
           renderSystemMessage={panel.renderSystemMessage}

--- a/app/src/components/tabs/use-integration-connect.ts
+++ b/app/src/components/tabs/use-integration-connect.ts
@@ -8,6 +8,7 @@ import { tauriIntegrations, tauriSystem } from "../../lib/tauri";
 import {
   INTEGRATION_PROVIDER,
   POLL_INTERVAL_MS,
+  type PollOutcome,
   pollConnectionUntilActive,
 } from "./integrations-tab-model";
 
@@ -27,7 +28,12 @@ export function useIntegrationConnect(opts: {
   autoGrant: boolean;
 }): {
   connectingToolkit: string | null;
-  connect: (toolkit: string) => Promise<void>;
+  /**
+   * Resolves with the poll outcome so callers can react to a LANDED
+   * connection (the chat card nudges the agent on "active"); `null` when the
+   * flow failed before/while polling (already surfaced via `call()`).
+   */
+  connect: (toolkit: string) => Promise<PollOutcome | null>;
 } {
   const { agentId, autoGrant } = opts;
   const { t } = useTranslation("integrations");
@@ -90,10 +96,12 @@ export function useIntegrationConnect(opts: {
             t("connectResult.failed"),
           );
         }
+        return outcome;
       } catch {
         // The failing engine call (connect / open-url / poll / grant) already
         // surfaced via `call()`. Swallow the re-throw so the click handler never
         // leaks an unhandled rejection.
+        return null;
       } finally {
         if (!cancelled.current) setConnectingToolkit(null);
       }

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -37,18 +37,23 @@ import {
 } from "react";
 import { useTranslation } from "react-i18next";
 import { useActivity, useSkills } from "../hooks/queries";
+import { useCapabilities } from "../hooks/use-capabilities";
 import { useFileToolRenderer } from "../hooks/use-file-tool-renderer";
 import { useProviderStatuses } from "../hooks/use-provider-statuses";
 import { useSession } from "../hooks/use-session";
 import { analytics } from "../lib/analytics";
 import { attachmentReferences } from "../lib/attachment-message";
-import { filterAutoContinueFeedItems } from "../lib/auto-continue-message";
+import {
+  encodeAutoContinueMessage,
+  filterAutoContinueFeedItems,
+} from "../lib/auto-continue-message";
 import {
   effectiveContextWindow,
   sessionContextUsage,
 } from "../lib/context-usage";
 import { createMission } from "../lib/create-mission";
 import { humanizeSkillName } from "../lib/humanize-skill-name";
+import { canManageAgentGrants } from "../lib/org-roles";
 import {
   decideHandoffMode,
   estimateConversationTokens,
@@ -85,6 +90,8 @@ import { ChatEffortSelector } from "./chat-effort-selector";
 import { ChatModelSelector } from "./chat-model-selector";
 import { ContextCompactedDivider } from "./context-compacted-divider";
 import { ContextIndicator } from "./context-indicator";
+import { IntegrationConnectCard } from "./integration-connect-card";
+import { parseToolkitFromHref } from "./integration-connect-card-state";
 import { NewMissionPickerDialog } from "./new-mission-picker-dialog";
 import { ProviderSwitchDialog } from "./provider-switch-dialog";
 import { SelectedSkillChip } from "./selected-skill-chip";
@@ -92,6 +99,7 @@ import { ProviderErrorCard } from "./shell/provider-error-card";
 import { ProviderReconnectCard } from "./shell/provider-reconnect-card";
 import { ToolRuntimeErrorCard } from "./shell/tool-runtime-error-card";
 import { SkillCard } from "./skill-card";
+import { integrationsSupported } from "./tabs/integrations-tab-model";
 import {
   filterProviderAuthFeedItems,
   isProviderAuthMessage,
@@ -127,6 +135,8 @@ interface AgentChatPanelProps {
   attachMenu: AIBoardProps["attachMenu"];
   /** Decodes skill-invocation user messages into a card. */
   renderUserMessage: AIBoardProps["renderUserMessage"];
+  /** Renders agent-authored `#houston_toolkit=` links as connect cards. */
+  renderLink: AIBoardProps["renderLink"];
   /** Forwarded to AIBoard / ChatPanel for tool rendering. */
   isSpecialTool: ChatPanelProps["isSpecialTool"];
   renderToolResult: ChatPanelProps["renderToolResult"];
@@ -172,6 +182,12 @@ export function useAgentChatPanel({
   const { data: session } = useSession();
   const currentUserId = session?.user.id;
   const authorLabels = undefined;
+
+  // Integration connect cards are a new-engine feature: the host advertises
+  // its wired providers in capabilities; the legacy Rust engine (null) and
+  // unconfigured deployments fall back to plain markdown links.
+  const { capabilities } = useCapabilities();
+  const integrationsEnabled = integrationsSupported(capabilities);
 
   const path = agent?.folderPath ?? null;
   const agentModes = agentDef?.config.agents;
@@ -580,6 +596,65 @@ export function useAgentChatPanel({
     [],
   );
 
+  // ── Integration connect card support (HOU-670) ───────────────────────
+  // The card owns its own connection status (it subscribes to the shared
+  // integration queries directly so it stays reactive inside Streamdown's
+  // memoized markdown blocks). The panel only supplies the agent nudge.
+  //
+  // When a connection the user started from a chat card lands, proactively
+  // nudge the agent so it resumes the task without the user having to
+  // retype. The agent needs a user turn to resume, but the user didn't type
+  // one — tag it with the auto-continue marker so the agent still receives
+  // the instruction while the transcript hides the bubble (see
+  // `mapFeedItems`). No optimistic push: we never want it shown, and the
+  // engine-persisted copy is filtered the same way on reload.
+  const handleIntegrationConnected = useCallback(
+    (_toolkit: string, appName: string) => {
+      if (!path || !selectedSessionKey) return;
+      const message = encodeAutoContinueMessage(
+        t("chat:composio.connectedFollowup", { name: appName }),
+      );
+      tauriChat
+        .send(path, message, selectedSessionKey, {
+          providerOverride: effectiveProvider,
+          modelOverride: effectiveModel,
+          effortOverride: effectiveEffort,
+        })
+        .catch((err) => {
+          addToast({
+            title: t("chat:composio.followupFailed", { name: appName }),
+            description: String(err),
+            variant: "error",
+          });
+        });
+    },
+    [
+      path,
+      selectedSessionKey,
+      effectiveProvider,
+      effectiveModel,
+      effectiveEffort,
+      addToast,
+      t,
+    ],
+  );
+  const renderLink = useCallback<NonNullable<AIBoardProps["renderLink"]>>(
+    ({ href }) => {
+      if (!integrationsEnabled || !agent) return undefined;
+      const toolkit = parseToolkitFromHref(href);
+      if (!toolkit) return undefined;
+      return (
+        <IntegrationConnectCard
+          toolkit={toolkit}
+          agentId={agent.id}
+          autoGrant={canManageAgentGrants(capabilities, agent)}
+          onConnected={handleIntegrationConnected}
+        />
+      );
+    },
+    [integrationsEnabled, agent, capabilities, handleIntegrationConnected],
+  );
+
   // ── Built JSX bundles ─────────────────────────────────────────────────
   const renderUserMessage = useCallback(
     (msg: { content: string }) => {
@@ -902,6 +977,7 @@ export function useAgentChatPanel({
     footer,
     attachMenu,
     renderUserMessage,
+    renderLink,
     isSpecialTool,
     renderToolResult,
     processLabels,

--- a/app/tests/integration-connect-card-state.test.ts
+++ b/app/tests/integration-connect-card-state.test.ts
@@ -1,0 +1,91 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { IntegrationConnection } from "@houston-ai/engine-client";
+import {
+  deriveConnectCardView,
+  findCatalogToolkit,
+  isToolkitConnected,
+  normalizeToolkitSlug,
+  parseToolkitFromHref,
+} from "../src/components/integration-connect-card-state.ts";
+
+describe("parseToolkitFromHref", () => {
+  it("extracts the slug from the prompt's canonical link shape", () => {
+    strictEqual(
+      parseToolkitFromHref(
+        "https://gethouston.ai/connect#houston_toolkit=gmail",
+      ),
+      "gmail",
+    );
+  });
+
+  it("accepts any base URL carrying the fragment (legacy Rust-engine links)", () => {
+    strictEqual(
+      parseToolkitFromHref(
+        "https://connect.composio.dev/link/lk_abc#houston_toolkit=googledrive",
+      ),
+      "googledrive",
+    );
+  });
+
+  it("returns null for ordinary links, empty slugs, and garbage", () => {
+    strictEqual(parseToolkitFromHref("https://example.com/docs"), null);
+    strictEqual(
+      parseToolkitFromHref("https://example.com/#other_fragment=1"),
+      null,
+    );
+    strictEqual(
+      parseToolkitFromHref("https://example.com/#houston_toolkit="),
+      null,
+    );
+    strictEqual(parseToolkitFromHref("not a url"), null);
+  });
+});
+
+describe("isToolkitConnected", () => {
+  const connections: IntegrationConnection[] = [
+    { toolkit: "gmail", connectionId: "ca_1", status: "active" },
+    { toolkit: "slack", connectionId: "ca_2", status: "pending" },
+    { toolkit: "notion", connectionId: "ca_3", status: "error" },
+  ];
+
+  it("matches only ACTIVE connections", () => {
+    strictEqual(isToolkitConnected(connections, "gmail"), true);
+    strictEqual(isToolkitConnected(connections, "slack"), false);
+    strictEqual(isToolkitConnected(connections, "notion"), false);
+    strictEqual(isToolkitConnected(connections, "linear"), false);
+  });
+
+  it("normalizes the agent-authored slug (casing + whitespace)", () => {
+    // The fragment is agent-authored: `GMail ` must still match the
+    // catalog's `gmail`, or the card sticks on "Connect" while connected.
+    strictEqual(isToolkitConnected(connections, " GMail "), true);
+    strictEqual(normalizeToolkitSlug(" GoogleDrive "), "googledrive");
+  });
+
+  it("treats missing data as not connected", () => {
+    strictEqual(isToolkitConnected(undefined, "gmail"), false);
+  });
+});
+
+describe("findCatalogToolkit", () => {
+  const catalog = [
+    { slug: "gmail", name: "Gmail", logoUrl: "https://l/g.png" },
+    { slug: "googlecalendar", name: "Google Calendar" },
+  ];
+
+  it("resolves casing-insensitively and misses gracefully", () => {
+    deepStrictEqual(findCatalogToolkit(catalog, "GMAIL"), catalog[0]);
+    strictEqual(findCatalogToolkit(catalog, "linear"), undefined);
+    strictEqual(findCatalogToolkit(undefined, "gmail"), undefined);
+  });
+});
+
+describe("deriveConnectCardView", () => {
+  it("the real connection status always wins over the local phase", () => {
+    strictEqual(deriveConnectCardView(true, true), "connected");
+    strictEqual(deriveConnectCardView(true, false), "connected");
+    strictEqual(deriveConnectCardView(false, true), "connecting");
+    strictEqual(deriveConnectCardView(false, false), "idle");
+  });
+});

--- a/packages/host/src/houston-prompt.test.ts
+++ b/packages/host/src/houston-prompt.test.ts
@@ -45,6 +45,17 @@ test("memory guidance requires explicit opt-in", () => {
   expect(p).toContain(".houston/learnings/learnings.json");
 });
 
-test("Composio is dropped (cut in the convergence)", () => {
-  expect(houstonSystemPrompt()).not.toContain("Composio");
+test("integrations guidance teaches the tools + the in-chat connect card (HOU-670)", () => {
+  const p = houstonSystemPrompt();
+  expect(p).toContain("## How-To Guidance: Connected Apps (Integrations)");
+  expect(p).toContain("integration_search");
+  expect(p).toContain("integration_execute");
+  expect(p).toContain("#houston_toolkit=<toolkit>");
+  expect(p).toContain("I've connected Gmail. Please continue.");
+});
+
+test("the guidance is provider-agnostic and CLI-free (Composio CLI cut in the convergence)", () => {
+  const p = houstonSystemPrompt();
+  expect(p).not.toContain("Composio");
+  expect(p).not.toContain("composio link");
 });

--- a/packages/host/src/houston-prompt.ts
+++ b/packages/host/src/houston-prompt.ts
@@ -1,8 +1,10 @@
 /**
  * The Houston product system prompt — the authoritative identity + how-to copy
  * for the Houston agent, ported verbatim from app/src-tauri/src/houston_prompt/*
- * (base + skills_memory + routines). The Composio section is intentionally
- * dropped (Composio is cut in the convergence).
+ * (base + skills_memory + routines). The legacy Composio-CLI section is
+ * replaced by the in-process integrations guidance (integration_search /
+ * integration_execute + the in-chat connect card, HOU-670) — keep it in sync
+ * with `PI_INTEGRATIONS_GUIDANCE` in app/src-tauri/src/houston_prompt/integrations.rs.
  *
  * This is PRODUCT content. The host stays prompt-agnostic: it merely injects
  * this into the runtime via HOUSTON_SYSTEM_PROMPT. The real desktop app may
@@ -167,7 +169,19 @@ Ask for approval before creating, enabling, or changing a Routine. Scheduling is
 
 When saving a Routine, read \`.houston/routines/routines.schema.json\`, then update \`.houston/routines/routines.json\` to match it exactly.`;
 
-/** The composite Houston product prompt (base + skills/memory + routines). */
+const INTEGRATIONS = `## How-To Guidance: Connected Apps (Integrations)
+
+You can act on the user's apps (Gmail, Google Calendar, Slack, Notion, and many more) with two tools: \`integration_search\` finds an action and its input parameters; \`integration_execute\` runs it. Search first, then execute. The user's own account is used automatically — you never handle credentials.
+
+When a needed app is not connected yet (search marks its actions NOT CONNECTED, or execute fails because no account is linked):
+
+1. Briefly say what must be connected and why, in plain language.
+2. Offer the connection right in chat: include a markdown link whose URL ends with \`#houston_toolkit=<toolkit>\`, written exactly like \`[Connect Gmail](https://gethouston.ai/connect#houston_toolkit=gmail)\`. Houston renders it as a rich connect card with a one-click button. Use the toolkit slug from the search results, one link per app that needs connecting.
+3. Do NOT ask the user to tell you when they're done, and do NOT promise to "check" the connection yourself. Houston detects the moment the connection goes live and automatically sends you a short message (e.g. "I've connected Gmail. Please continue.") so you can resume the task on your own. Phrase your message to set that expectation, e.g. "Once you approve access in the browser, I'll keep going from here automatically." Then stop and wait.
+
+Never read the link URL, fragment, or toolkit slug out loud to the user, and never name the integrations provider — the card speaks for itself.`;
+
+/** The composite Houston product prompt (base + skills/memory + routines + integrations). */
 export function houstonSystemPrompt(): string {
-  return `${BASE}\n\n---\n\n${SKILLS_AND_MEMORY}\n\n---\n\n${ROUTINES}`;
+  return `${BASE}\n\n---\n\n${SKILLS_AND_MEMORY}\n\n---\n\n${ROUTINES}\n\n---\n\n${INTEGRATIONS}`;
 }

--- a/packages/host/src/integrations/composio.test.ts
+++ b/packages/host/src/integrations/composio.test.ts
@@ -333,6 +333,7 @@ test("search scopes to the user's connected toolkits and maps tools", async () =
       toolkit: "gmail",
       description: "Send an email",
       inputParams: { type: "object" },
+      connected: true,
     },
   ]);
   // Scoped to the ACTIVE connected toolkits (deduped) — Composio's global
@@ -369,16 +370,86 @@ test("a zero-hit scoped query degrades to listing the connected toolkits' action
   });
   const found = await provider.search(USER, "read my latest 5 emails");
   expect(found.map((t) => t.action)).toEqual(["GMAIL_FETCH_EMAILS"]);
+  expect(found[0]?.connected).toBe(true);
   expect(calls[2]?.path).toBe("/api/v3/tools?limit=50&toolkit_slug=gmail");
+});
+
+test("a scoped miss also surfaces global matches marked NOT connected (HOU-670)", async () => {
+  // "send it via gmail" with only Slack linked: the scoped query misses, so
+  // the fallback must ALSO search globally and mark the gmail actions
+  // connected:false — that is what lets the agent offer the connect card.
+  const { provider, calls } = harness((url) => {
+    if (url.pathname === "/api/v3/connected_accounts") {
+      return {
+        body: { items: [{ toolkit: { slug: "slack" }, status: "ACTIVE" }] },
+      };
+    }
+    // The scoped query (query + toolkit_slug) misses…
+    if (url.searchParams.has("query") && url.searchParams.has("toolkit_slug"))
+      return { body: { items: [] } };
+    // …the connected-toolkit listing returns Slack's actions…
+    if (url.searchParams.has("toolkit_slug")) {
+      return {
+        body: {
+          items: [
+            {
+              slug: "SLACK_SEND_MESSAGE",
+              toolkit: { slug: "slack" },
+              description: "Send a message",
+            },
+          ],
+        },
+      };
+    }
+    // …and the global query finds the not-connected app (plus a duplicate of
+    // an already-connected one, which must be dropped from the global half).
+    return {
+      body: {
+        items: [
+          {
+            slug: "GMAIL_SEND_EMAIL",
+            toolkit: { slug: "gmail" },
+            description: "Send an email",
+          },
+          {
+            slug: "SLACK_SEND_MESSAGE",
+            toolkit: { slug: "slack" },
+            description: "Send a message",
+          },
+        ],
+      },
+    };
+  });
+  const found = await provider.search(USER, "send an email via gmail");
+  expect(found.map((t) => [t.action, t.connected])).toEqual([
+    ["SLACK_SEND_MESSAGE", true],
+    ["GMAIL_SEND_EMAIL", false],
+  ]);
+  // connections + scoped query + (connected listing ∥ global query).
+  expect(calls).toHaveLength(4);
 });
 
 test("search falls back to the global catalog when nothing is connected", async () => {
   const { provider, calls } = harness((url) => {
     if (url.pathname === "/api/v3/connected_accounts")
       return { body: { items: [] } };
-    return { body: { items: [] } };
+    return {
+      body: {
+        items: [
+          {
+            slug: "GMAIL_SEND_EMAIL",
+            toolkit: { slug: "gmail" },
+            description: "Send an email",
+          },
+        ],
+      },
+    };
   });
-  expect(await provider.search(USER, "send an email")).toEqual([]);
+  const found = await provider.search(USER, "send an email");
+  // Discoverable but marked not-connected → the agent offers the card.
+  expect(found.map((t) => [t.action, t.connected])).toEqual([
+    ["GMAIL_SEND_EMAIL", false],
+  ]);
   expect(calls[1]?.path).toBe("/api/v3/tools?query=send+an+email&limit=10");
 });
 

--- a/packages/host/src/integrations/composio.ts
+++ b/packages/host/src/integrations/composio.ts
@@ -171,32 +171,49 @@ export class ComposioProvider implements IntegrationProvider {
     // Composio's full-text search is weak unqualified ("send an email" ranks
     // unrelated marketing tools above GMAIL_SEND_EMAIL — verified live), so
     // scope to the user's CONNECTED toolkits when they have any: those are the
-    // only actions execute() can run for them anyway. No connections yet →
-    // global search, so the agent can still discover what to suggest.
+    // only actions execute() can run for them anyway. Every match carries
+    // `connected` so the agent can tell "run it" from "offer to connect it".
     const connected = await this.listConnections(userId);
     const slugs = [
       ...new Set(
         connected.filter((c) => c.status === "active").map((c) => c.toolkit),
       ),
     ];
-    const body = await this.http.call<{ items?: RawTool[] }>("/api/v3/tools", {
-      query: {
-        query,
-        limit: "10",
-        ...(slugs.length ? { toolkit_slug: slugs.join(",") } : {}),
-      },
+    const isConnected = (toolkit: string) =>
+      slugs.some((s) => s.toLowerCase() === toolkit.toLowerCase());
+    const tools = async (query: Record<string, string>) => {
+      const body = await this.http.call<{ items?: RawTool[] }>(
+        "/api/v3/tools",
+        { query },
+      );
+      return (body?.items ?? []).map((t) => {
+        const match = mapTool(t);
+        return { ...match, connected: isConnected(match.toolkit) };
+      });
+    };
+    // No connections yet → global search, so the agent can still discover
+    // what to suggest connecting (every match reports connected:false).
+    if (slugs.length === 0) return tools({ query, limit: "10" });
+    const matched = await tools({
+      query,
+      limit: "10",
+      toolkit_slug: slugs.join(","),
     });
-    const matched = (body?.items ?? []).map(mapTool);
-    if (matched.length > 0 || slugs.length === 0) return matched;
-    // Composio's full-text match is naive AND-ish: an everyday phrasing like
-    // "read my latest 5 emails" scores ZERO against GMAIL_FETCH_EMAILS
-    // (verified live). Scoped to connected toolkits the catalog is small, so
-    // degrade to listing their actions instead of returning nothing — the
-    // agent picks the right slug from the list.
-    const all = await this.http.call<{ items?: RawTool[] }>("/api/v3/tools", {
-      query: { limit: "50", toolkit_slug: slugs.join(",") },
-    });
-    return (all?.items ?? []).map(mapTool);
+    if (matched.length > 0) return matched;
+    // The scoped query missed. Two distinct reasons, both worth answering:
+    //  - Composio's full-text match is naive AND-ish: an everyday phrasing
+    //    like "read my latest 5 emails" scores ZERO against GMAIL_FETCH_EMAILS
+    //    (verified live). Scoped to connected toolkits the catalog is small,
+    //    so degrade to listing their actions — the agent picks the slug.
+    //  - The user wants an app they never connected ("send it via gmail" with
+    //    only Slack linked). A global search surfaces those actions marked
+    //    connected:false, so the agent can offer the in-chat connect card
+    //    (HOU-670) instead of dead-ending.
+    const [listing, global] = await Promise.all([
+      tools({ limit: "50", toolkit_slug: slugs.join(",") }),
+      tools({ query, limit: "10" }),
+    ]);
+    return [...listing, ...global.filter((t) => !t.connected)];
   }
 
   async execute(

--- a/packages/host/src/integrations/fake.ts
+++ b/packages/host/src/integrations/fake.ts
@@ -99,7 +99,7 @@ export class FakeIntegrationProvider implements IntegrationProvider {
   }
 
   async search(
-    _userId: string,
+    userId: string,
     query: string,
     acting?: ActingContext,
   ): Promise<ToolMatch[]> {
@@ -107,11 +107,18 @@ export class FakeIntegrationProvider implements IntegrationProvider {
     if (this.throwSigninRequired) throw new IntegrationSigninRequiredError();
     if (this.throwSearchExecute) throw this.throwSearchExecute;
     const q = query.toLowerCase();
-    return this.actions.filter(
-      (a) =>
-        a.description.toLowerCase().includes(q) ||
-        a.action.toLowerCase().includes(q),
+    const activeToolkits = new Set(
+      (this.connections.get(userId) ?? [])
+        .filter((c) => c.status === "active")
+        .map((c) => c.toolkit),
     );
+    return this.actions
+      .filter(
+        (a) =>
+          a.description.toLowerCase().includes(q) ||
+          a.action.toLowerCase().includes(q),
+      )
+      .map((a) => ({ ...a, connected: activeToolkits.has(a.toolkit) }));
   }
 
   async execute(

--- a/packages/host/src/integrations/types.ts
+++ b/packages/host/src/integrations/types.ts
@@ -45,6 +45,12 @@ export interface ToolMatch {
   description: string;
   /** JSON-schema-shaped description of the action's params, for the model. */
   inputParams?: unknown;
+  /**
+   * Whether the user has an active connection to this action's toolkit.
+   * `false` means execute() would fail — the agent should offer the in-chat
+   * connect card instead (HOU-670). Absent = unknown (older adapters).
+   */
+  connected?: boolean;
 }
 
 /** The outcome of running an action. */

--- a/packages/runtime/src/session/tools/integrations.test.ts
+++ b/packages/runtime/src/session/tools/integrations.test.ts
@@ -86,6 +86,42 @@ test("search POSTs to the host proxy with the sandbox token + formats matches", 
   const text = (out.content[0] as { text: string }).text;
   expect(text).toContain("GMAIL_SEND_EMAIL");
   expect(text).toContain("Send an email");
+  // Everything matched is connected → no connect-card instruction noise.
+  expect(text).not.toContain("NOT CONNECTED");
+  expect(text).not.toContain("#houston_toolkit=");
+});
+
+test("search marks not-connected matches and teaches the connect link (HOU-670)", async () => {
+  mockFetch(() => ({
+    body: {
+      items: [
+        {
+          action: "SLACK_SEND_MESSAGE",
+          toolkit: "slack",
+          description: "Send a message",
+          connected: true,
+        },
+        {
+          action: "GMAIL_SEND_EMAIL",
+          toolkit: "gmail",
+          description: "Send an email",
+          connected: false,
+        },
+      ],
+    },
+  }));
+  const out = await run(search, { query: "send an email via gmail" });
+  const text = (out.content[0] as { text: string }).text;
+  expect(text).toContain("- SLACK_SEND_MESSAGE (slack): Send a message");
+  expect(text).toContain(
+    "- GMAIL_SEND_EMAIL (gmail, NOT CONNECTED): Send an email",
+  );
+  // The hand-off instruction rides with the results, at the moment the model
+  // actually faces a not-connected app.
+  expect(text).toContain("#houston_toolkit=<toolkit>");
+  expect(text).toContain(
+    "[Connect Gmail](https://gethouston.ai/connect#houston_toolkit=gmail)",
+  );
 });
 
 test("execute runs an action and returns its data; a failed action surfaces", async () => {
@@ -102,6 +138,23 @@ test("execute runs an action and returns its data; a failed action surfaces", as
   await expect(
     run(execute, { action: "GMAIL_SEND_EMAIL", params: {} }),
   ).rejects.toThrow(/did not succeed: missing recipient/);
+});
+
+test("a no-connected-account failure carries the connect-link hand-off (HOU-670)", async () => {
+  mockFetch(() => ({
+    body: { successful: false, error: "no connected account found for user" },
+  }));
+  const failure = run(execute, { action: "GMAIL_SEND_EMAIL", params: {} });
+  await expect(failure).rejects.toThrow(/has not connected this app/);
+  await expect(failure).rejects.toThrow(/#houston_toolkit=<toolkit>/);
+
+  // An ordinary app rejection stays hint-free — no false connect offers.
+  mockFetch(() => ({
+    body: { successful: false, error: "quota exceeded" },
+  }));
+  await expect(
+    run(execute, { action: "GMAIL_SEND_EMAIL", params: {} }),
+  ).rejects.toThrow(/did not succeed: quota exceeded$/);
 });
 
 test("a 409 (not connected) becomes an actionable message, not a crash dump", async () => {

--- a/packages/runtime/src/session/tools/integrations.ts
+++ b/packages/runtime/src/session/tools/integrations.ts
@@ -48,7 +48,18 @@ interface ToolMatch {
   toolkit: string;
   description: string;
   inputParams?: unknown;
+  /** Host-reported: does the user have this action's app connected? */
+  connected?: boolean;
 }
+
+/**
+ * The instruction appended to search results (and connection-shaped execute
+ * failures) that teaches the model the in-chat connect hand-off (HOU-670):
+ * a markdown link carrying the `#houston_toolkit=<slug>` fragment, which the
+ * Houston chat renders as a rich connect card with a one-click button.
+ */
+const CONNECT_LINK_GUIDANCE =
+  "To let the user connect an app, include a markdown link in your reply whose URL ends with `#houston_toolkit=<toolkit>` — exactly like `[Connect Gmail](https://gethouston.ai/connect#houston_toolkit=gmail)`. Houston renders it as a connect button. After the user connects, Houston automatically sends you a message so you can continue — do not ask them to confirm.";
 interface ActionResult {
   successful: boolean;
   data?: unknown;
@@ -103,7 +114,7 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
     name: "integration_search",
     label: "Find an app action",
     description:
-      "Search the user's connected apps (Gmail, Google Calendar, Slack, Notion, and many more) for an action you can run. Returns action slugs with their input parameters. Call this first to discover what's possible, then run one with integration_execute.",
+      "Search the user's apps (Gmail, Google Calendar, Slack, Notion, and many more) for an action you can run. Returns action slugs with their input parameters; actions marked NOT CONNECTED need the user to connect the app first (the result explains how to offer that). Call this first to discover what's possible, then run one with integration_execute.",
     promptSnippet: "Search the user's connected apps for an action to run",
     parameters: SearchParams,
     executionMode: "sequential",
@@ -128,14 +139,20 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
           details: { matches: 0, actions: [] as string[] },
         };
       }
-      const text = items
+      const list = items
         .map((m) => {
+          const status = m.connected === false ? ", NOT CONNECTED" : "";
           const schema = m.inputParams
             ? `\n  params: ${JSON.stringify(m.inputParams)}`
             : "";
-          return `- ${m.action} (${m.toolkit}): ${m.description}${schema}`;
+          return `- ${m.action} (${m.toolkit}${status}): ${m.description}${schema}`;
         })
         .join("\n");
+      // Some matches need a connection first → teach the hand-off inline, at
+      // the moment the model actually faces a not-connected app (HOU-670).
+      const text = items.some((m) => m.connected === false)
+        ? `${list}\n\nActions marked NOT CONNECTED will fail until the user connects that app. ${CONNECT_LINK_GUIDANCE}`
+        : list;
       return {
         content: [{ type: "text" as const, text }],
         details: { matches: items.length, actions: items.map((m) => m.action) },
@@ -163,9 +180,13 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
       );
       // The action ran but the app rejected it → surface, don't pretend success.
       if (!result.successful) {
-        throw new Error(
-          `"${params.action}" did not succeed: ${result.error ?? "unknown error"}`,
-        );
+        const reason = result.error ?? "unknown error";
+        // A missing connection is an actionable state, not a dead end: hand
+        // the model the connect-card instruction right in the error (HOU-670).
+        const hint = /connected account|not connected/i.test(reason)
+          ? ` The user has not connected this app. ${CONNECT_LINK_GUIDANCE}`
+          : "";
+        throw new Error(`"${params.action}" did not succeed: ${reason}${hint}`);
       }
       const text = result.data ? JSON.stringify(result.data, null, 2) : "Done.";
       return {


### PR DESCRIPTION
Restores the in-chat integration connect hand-off on the TS engine (pi runtime): when the agent needs an app the user hasn't connected, it once again posts a rich **Connect** card in the conversation, and resumes the task automatically after the OAuth lands.

Fixes HOU-670.

## Root cause

The legacy flow was CLI-shaped end to end, and every link in the chain broke in the convergence:

1. **Desktop prompt override**: `spawn_host_sidecar` handed the TS host the legacy Rust prompt via `HOUSTON_APP_SYSTEM_PROMPT`, whose Composio section instructs the agent to run `composio link` via Bash — a CLI pi doesn't have. The host's own `houstonSystemPrompt()` intentionally dropped integrations guidance, so no code path taught the agent the hand-off.
2. **No detection**: `ComposioProvider.search` scoped strictly to the user's connected toolkits, so the agent couldn't even discover the action slug of a not-connected app, let alone learn it wasn't connected.
3. **No card**: the chat card components were deleted in the houston-web merge (#584); only the generic `renderLink` seam in `ui/chat` survived.

## The fix

- **host** — `ToolMatch` gains `connected`; `search` marks every match, and on a scoped miss also runs a global search so not-connected apps are discoverable (connected-toolkit listing + global matches marked `connected:false`). Fake adapter mirrors the contract.
- **runtime** — `integration_search` output marks `NOT CONNECTED` actions and appends the connect-link instruction (a markdown link ending in `#houston_toolkit=<slug>`); `integration_execute` appends the same hand-off when the failure is a missing connection.
- **prompts** — `houstonSystemPrompt()` (cloud/self-host default) gains a "Connected Apps" section; the desktop host-sidecar spawn now passes `system_prompt_pi()` — same product voice, pi-native integrations guidance instead of the CLI-era section. The Rust-engine build keeps its prompt untouched.
- **app** — new `IntegrationConnectCard` rendered through the chat `renderLink` seam for `#houston_toolkit=` links: shows the app's real name/logo from the catalog, mints the hosted OAuth link, opens the system browser, polls until the connection turns active (same `useIntegrationConnect` flow as the Integrations tab, auto-granting to the agent in multiplayer), then nudges the agent with the hidden auto-continue message ("I've connected X. Please continue.") so the task resumes without the user typing. Gated on the host-advertised `integrations` capability; everywhere else the link falls back to plain markdown.

## Repro (before the fix)

1. Desktop app on the new engine (host-sidecar build / `VITE_NEW_ENGINE`), signed in to Houston, with the integrations gateway configured and **Gmail not connected**.
2. Ask the agent: "Send an email to yourself saying hi via Gmail."
3. The agent either dead-ends on the tool error or tells you to go connect Gmail yourself; no Connect button appears in chat (and with some phrasings it can't even name the app's actions, since search only covered connected toolkits).

## Verify (after the fix)

1. Same setup; ask the same thing.
2. `integration_search` now returns the Gmail actions marked `NOT CONNECTED`, and the agent replies with a **Connect Gmail** card (logo + name + Connect button) in the conversation.
3. Click **Connect** → the system browser opens Composio's hosted OAuth; the card shows "Connecting…".
4. Finish the OAuth → the card flips to a green "Connected" badge, a success toast appears, and the agent automatically continues and sends the email — no extra user turn, and no visible "I've connected Gmail" bubble in the transcript.
5. Already-connected apps never show the card flow: search returns their actions unmarked and execution proceeds directly.

Automated coverage: adapter search marking/fallback (`packages/host/src/integrations/composio.test.ts`), tool text + execute hint (`packages/runtime/src/session/tools/integrations.test.ts`), prompt content on both engines (`packages/host/src/houston-prompt.test.ts`, `app/src-tauri/src/houston_prompt/mod.rs`), link parsing + card state (`app/tests/integration-connect-card-state.test.ts`).

Gates: biome, boundaries, `@houston/host` (467) / `@houston/runtime` (258) / app (470) tests, full workspace typecheck, `cargo check` with and without `host-sidecar`, cargo prompt tests. `pnpm check-locales` fails on pre-existing missing `setup.tutorial.missions.brain.*` keys unrelated to this change (no locale keys added — the card reuses the existing `chat:composio.*` strings in en/es/pt).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
