### PR TITLE
fix(chat): keep the loading helmet up while tools run and thinking streams (HOU-655)

### DIFF
--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -157,6 +157,7 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           onOpenLink={handleOpenLink}
           cardAvatar={source.cardAvatar}
           thinkingIndicator={panel.thinkingIndicator}
+          loadingIndicator={panel.loadingIndicator}
           panelAgentName={source.panelAgentName}
           panelAvatar={
             <AgentPanelAvatar

--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -141,6 +141,7 @@ export function MissionControlArchived({
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           thinkingIndicator={panel.thinkingIndicator}
+          loadingIndicator={panel.loadingIndicator}
           panelAgentName={activeAgent?.name ?? selectedItem?.subtitle}
           panelAvatar={
             <AgentPanelAvatar color={activeAgent?.color} running={false} />

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -152,6 +152,7 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           cardAvatar={<AgentCardAvatar color={agent.color} />}
           thinkingIndicator={panel.thinkingIndicator}
+          loadingIndicator={panel.loadingIndicator}
           panelAgentName={agent.name}
           panelAvatar={<AgentPanelAvatar color={agent.color} running={false} />}
           cardLabels={{

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -133,6 +133,7 @@ interface AgentChatPanelProps {
   processLabels: ChatPanelProps["processLabels"];
   getThinkingMessage: ChatPanelProps["getThinkingMessage"];
   thinkingIndicator: ChatPanelProps["thinkingIndicator"];
+  loadingIndicator: ChatPanelProps["loadingIndicator"];
   renderTurnSummary: ChatPanelProps["renderTurnSummary"];
   renderSystemMessage: AIBoardProps["renderSystemMessage"];
   mapFeedItems: AIBoardProps["mapFeedItems"];
@@ -156,8 +157,12 @@ export function useAgentChatPanel({
   onSelectSession,
 }: UseAgentChatPanelArgs): AgentChatPanelProps {
   const { t } = useTranslation(["board", "chat"]);
-  const { processLabels, getThinkingMessage, thinkingIndicator } =
-    useChatDisplayLabels();
+  const {
+    processLabels,
+    getThinkingMessage,
+    thinkingIndicator,
+    loadingIndicator,
+  } = useChatDisplayLabels();
   const queryClient = useQueryClient();
   const addToast = useUIStore((s) => s.addToast);
   const pushFeedItem = useFeedStore((s) => s.pushFeedItem);
@@ -902,6 +907,7 @@ export function useAgentChatPanel({
     processLabels,
     getThinkingMessage,
     thinkingIndicator,
+    loadingIndicator,
     renderTurnSummary,
     renderSystemMessage,
     mapFeedItems,

--- a/app/src/components/use-chat-display-labels.tsx
+++ b/app/src/components/use-chat-display-labels.tsx
@@ -6,7 +6,10 @@ import { HoustonLogo } from "./shell/experience-card";
 
 export function useChatDisplayLabels(): Pick<
   ChatPanelProps,
-  "processLabels" | "getThinkingMessage" | "thinkingIndicator"
+  | "processLabels"
+  | "getThinkingMessage"
+  | "thinkingIndicator"
+  | "loadingIndicator"
 > {
   const { t } = useTranslation("chat");
   const processLabels = useMemo(
@@ -32,29 +35,32 @@ export function useChatDisplayLabels(): Pick<
   );
 
   // HOU-655: while a turn is in flight, the loading state is a single blinking
-  // Houston helmet sitting under the calm, shimmering "Mission in progress..."
-  // label. We keep ONE helmet (no small glyph on the label here) so the pulsing
-  // mark reads as the loader, not a duplicate icon, and give it real breathing
-  // room below the line. It vanishes the instant the turn settles — there is no
-  // longer a static helmet at the end of the reply.
+  // Houston helmet under the "Mission in progress" line. The two pieces are
+  // separate props because they live on different clocks: the shimmering label
+  // (`thinkingIndicator`) yields to the mission-log header the moment a tool
+  // action takes over the status line, while the helmet (`loadingIndicator`)
+  // stays up for the WHOLE turn — under either line — and vanishes the instant
+  // the reply streams. One helmet, no duplicate label; ChatMessages owns the
+  // spacing between them.
   const thinkingIndicator = useMemo(
     () => (
-      <div className="flex flex-col items-start gap-4 py-1">
-        <Shimmer as="span" duration={1} className="text-xs">
-          {t("process.active")}
-        </Shimmer>
-        <HoustonLogo
-          size={20}
-          className="animate-pulse text-muted-foreground"
-        />
-      </div>
+      <Shimmer as="span" duration={1} className="text-xs">
+        {t("process.active")}
+      </Shimmer>
     ),
     [t],
+  );
+  const loadingIndicator = useMemo(
+    () => (
+      <HoustonLogo size={20} className="animate-pulse text-muted-foreground" />
+    ),
+    [],
   );
 
   return {
     processLabels,
     getThinkingMessage,
     thinkingIndicator,
+    loadingIndicator,
   };
 }

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -71,6 +71,8 @@ export interface AIBoardProps {
   chatEmptyState?: ReactNode;
   /** Custom thinking indicator for the chat panel. */
   thinkingIndicator?: ReactNode;
+  /** Loader shown for the whole in-flight turn (see ChatPanel). */
+  loadingIndicator?: ReactNode;
   /** Avatar element shown on every kanban card (e.g. small agent icon). */
   cardAvatar?: ReactNode;
   /** Avatar element shown in the detail panel header. */
@@ -258,6 +260,7 @@ export function AIBoard({
   onPanelCloserReady,
   chatEmptyState,
   thinkingIndicator,
+  loadingIndicator,
   cardAvatar,
   panelAvatar,
   panelAgentName,
@@ -688,6 +691,7 @@ export function AIBoard({
           }
           emptyState={activeFeed.length === 0 ? chatEmptyState : undefined}
           thinkingIndicator={thinkingIndicator}
+          loadingIndicator={loadingIndicator}
           value={drafts ? (drafts[activeDraftKey] ?? "") : undefined}
           onValueChange={
             onDraftChange

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -40,6 +40,12 @@ export interface ChatMessagesProps {
   messages: ChatMessage[];
   status: "ready" | "streaming" | "submitted";
   thinkingIndicator: ReactNode;
+  /** Rendered below the last item for the WHOLE in-flight turn (status
+   *  `"submitted"`), even while an active mission-log header is surfacing
+   *  "Mission in progress: <action>" and the standalone `thinkingIndicator`
+   *  is therefore suppressed (HOU-655: the loading helmet must not vanish
+   *  when a tool label takes over the status line). */
+  loadingIndicator?: ReactNode;
   transformContent?: (content: string) => {
     content: string;
     extra?: ReactNode;
@@ -85,6 +91,7 @@ export function ChatMessages({
   messages,
   status,
   thinkingIndicator,
+  loadingIndicator,
   transformContent,
   toolLabels,
   isSpecialTool,
@@ -209,9 +216,15 @@ export function ChatMessages({
             </Message>
           );
         })}
-        {showThinkingIndicator ? (
+        {status === "submitted" &&
+        (showThinkingIndicator || loadingIndicator) ? (
           <Message from="assistant">
-            <MessageContent>{thinkingIndicator}</MessageContent>
+            <MessageContent>
+              <div className="flex flex-col items-start gap-4 py-1">
+                {showThinkingIndicator ? thinkingIndicator : null}
+                {loadingIndicator}
+              </div>
+            </MessageContent>
           </Message>
         ) : null}
         {afterMessages}

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -67,6 +67,11 @@ export interface ChatPanelProps {
   canSendEmpty?: boolean;
   status?: ChatStatus;
   thinkingIndicator?: ReactNode;
+  /** Loader (e.g. the pulsing Houston helmet) shown for the WHOLE in-flight
+   *  turn — it stays up while the active mission-log header reads "Mission in
+   *  progress: <action>" and the standalone `thinkingIndicator` is suppressed
+   *  (HOU-655). Hidden the moment the reply text streams or the turn settles. */
+  loadingIndicator?: ReactNode;
   transformContent?: (content: string) => {
     content: string;
     extra?: ReactNode;

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -33,6 +33,7 @@ export function ChatPanel({
   emptyState,
   status: statusProp,
   thinkingIndicator,
+  loadingIndicator,
   transformContent,
   toolLabels,
   isSpecialTool,
@@ -147,6 +148,7 @@ export function ChatPanel({
           messages={messages}
           status={status}
           thinkingIndicator={thinkingIndicator ?? <DefaultThinkingIndicator />}
+          loadingIndicator={loadingIndicator}
           transformContent={transformContent}
           toolLabels={toolLabels}
           isSpecialTool={isSpecialTool}

--- a/ui/chat/src/chat-status.ts
+++ b/ui/chat/src/chat-status.ts
@@ -4,14 +4,18 @@ import type { FeedItem } from "./types";
 /**
  * Derive the chat-panel status from the feed and the controller's loading
  * flag. The status decides whether [`ChatMessages`](./chat-messages.tsx)
- * renders the thinking indicator (`"submitted"`) or hides it because the
- * actual stream is the progress signal (`"streaming"`).
+ * renders the in-flight loading indicator (`"submitted"`) or hides it
+ * because the actual stream is the progress signal (`"streaming"`).
  *
- * The two streaming-class feed-item types below carry visible
- * progressively-appearing content; while one of them is the most recent
- * item, the indicator would just compete with the streaming text, so we
- * yield "streaming" instead. EVERY other case where a turn is in flight
- * resolves to "submitted" so the user sees a thinking indicator.
+ * Only `assistant_text_streaming` counts as "streaming": it is the one
+ * feed-item type whose progressively-appearing content is VISIBLE, so the
+ * indicator would just compete with it. `thinking_streaming` used to count
+ * too, but since HOU-448 the reasoning streams inside the collapsed-by-
+ * default mission log — nothing on screen moves, so treating it as
+ * "streaming" made the loading helmet flicker off during every thinking
+ * stretch (HOU-655 follow-up). EVERY case where a turn is in flight and no
+ * visible text is streaming resolves to "submitted" so the user sees a
+ * loading indicator.
  *
  * The previous logic returned `"streaming"` whenever `isLoading` was
  * true and the chat had any prior items — which hid the indicator
@@ -25,10 +29,7 @@ export function deriveStatus(
   isLoading: boolean,
 ): ChatStatus {
   const last = items[items.length - 1];
-  if (
-    last?.feed_type === "assistant_text_streaming" ||
-    last?.feed_type === "thinking_streaming"
-  ) {
+  if (last?.feed_type === "assistant_text_streaming") {
     return "streaming";
   }
   // Active turn → indicator visible. Covers:
@@ -36,7 +37,8 @@ export function deriveStatus(
   //   - user just sent (last == user_message)
   //   - provider mid-tool-cycle (last == tool_call / tool_result),
   //     waiting on the model's next chunk
-  //   - thinking block just landed, still waiting on the response
+  //   - reasoning streaming or just landed inside the collapsed
+  //     mission log, still waiting on the response
   //   - any silent gap between tokens for batchy providers (Gemini)
   if (isLoading) return "submitted";
   // Idle but the user just typed and sent — the optimistic

--- a/ui/chat/tests/chat-status.test.ts
+++ b/ui/chat/tests/chat-status.test.ts
@@ -1,0 +1,69 @@
+import { equal } from "node:assert";
+import { describe, it } from "node:test";
+import { deriveStatus } from "../src/chat-status.ts";
+import type { FeedItem } from "../src/types.ts";
+
+const user = (data = "hi"): FeedItem => ({ feed_type: "user_message", data });
+const toolCall = (): FeedItem => ({
+  feed_type: "tool_call",
+  data: { name: "read", input: {} },
+});
+const toolResult = (): FeedItem => ({
+  feed_type: "tool_result",
+  data: { content: "ok", is_error: false },
+});
+
+describe("deriveStatus", () => {
+  it("is ready when idle with a settled feed", () => {
+    equal(
+      deriveStatus(
+        [user(), { feed_type: "assistant_text", data: "hi" }],
+        false,
+      ),
+      "ready",
+    );
+  });
+
+  it("is submitted on a brand-new chat while loading", () => {
+    equal(deriveStatus([], true), "submitted");
+  });
+
+  it("is submitted right after the user sends, before isLoading flips", () => {
+    equal(deriveStatus([user()], false), "submitted");
+  });
+
+  it("is streaming only while visible reply text streams", () => {
+    equal(
+      deriveStatus(
+        [user(), { feed_type: "assistant_text_streaming", data: "he" }],
+        true,
+      ),
+      "streaming",
+    );
+  });
+
+  it("stays submitted mid-tool-cycle (HOU-655: loader must not vanish)", () => {
+    equal(deriveStatus([user(), toolCall()], true), "submitted");
+    equal(deriveStatus([user(), toolCall(), toolResult()], true), "submitted");
+  });
+
+  it("stays submitted while reasoning streams inside the collapsed log", () => {
+    // Since HOU-448 the thinking stream is hidden behind the collapsed
+    // mission log — nothing visible moves, so it must NOT count as
+    // "streaming" or the loading helmet flickers off every thinking stretch.
+    equal(
+      deriveStatus(
+        [user(), { feed_type: "thinking_streaming", data: "hmm" }],
+        true,
+      ),
+      "submitted",
+    );
+  });
+
+  it("stays submitted after a thinking block lands, awaiting the reply", () => {
+    equal(
+      deriveStatus([user(), { feed_type: "thinking", data: "hmm" }], true),
+      "submitted",
+    );
+  });
+});


### PR DESCRIPTION
## HOU-655 — loading helmet disappears when the status line shows a tool

Follow-up to #618, which added the blinking helmet as the in-flight loader.

### Root cause (two halves of the same symptom)
1. **Tool phases.** The helmet lived inside the standalone `thinkingIndicator` node, and `shouldShowThinkingIndicator` suppresses that node the moment an active mission-log block is trailing — its header already reads "Mission in progress: \<action\>". Correct for the *label* (it would duplicate), but it dragged the helmet down with it, so the loader vanished whenever a tool like read/ls surfaced.
2. **Thinking phases.** `deriveStatus` mapped `thinking_streaming` to `"streaming"`, which hides the loader on the premise that visible streaming text is the progress signal. Since HOU-448 the reasoning streams inside the **collapsed-by-default** mission log, so nothing on screen actually moves — the helmet just flickered off during every thinking stretch.

Net effect: during a turn the helmet blinked in and out (gap → thinking → tool → thinking → …) instead of staying up.

### The fix
- **Split the loader from the label.** `thinkingIndicator` is now only the shimmering "Mission in progress..." label and keeps its HOU-471 contract (suppressed while an active mission-log header shows). A new `loadingIndicator` prop (the pulsing helmet) renders for the **whole** `"submitted"` state, under whichever line is showing — standalone label or "Mission in progress: \<action\>" header. `ChatMessages` owns the shared layout (`flex flex-col gap-4`), so the visuals are unchanged in the pre-tool gap.
- **`deriveStatus`:** only `assistant_text_streaming` counts as `"streaming"` now. `thinking_streaming` resolves to `"submitted"` like every other in-flight state, since it carries no visible content.

### Files
- `ui/chat/src/chat-status.ts` — `thinking_streaming` no longer yields `"streaming"`.
- `ui/chat/src/chat-messages.tsx` — render `loadingIndicator` for the whole submitted state; label stays gated on `shouldShowThinkingIndicator`.
- `ui/chat/src/{chat-panel,chat-panel-types}.ts(x)`, `ui/board/src/ai-board.tsx` — thread the new optional `loadingIndicator` prop.
- `app/src/components/use-chat-display-labels.tsx` — split the old combined node into label (`thinkingIndicator`) + helmet (`loadingIndicator`).
- `app/src/components/use-agent-chat-panel.tsx`, `tabs/archived-tab.tsx`, `board/{mission-board,mission-control-archived}.tsx` — forward it.
- `ui/chat/tests/chat-status.test.ts` — new `deriveStatus` suite (tool cycles and thinking streams stay `"submitted"`; only visible reply text is `"streaming"`).

### Verification
**Before (bug):** send a message that makes the agent use tools (e.g. "list the files in the project"). The helmet shows under "Mission in progress...", then **disappears** as soon as the line changes to "Mission in progress: read" / ": ls", and also flickers off while the agent thinks between tools.

**After (fixed):** same prompt — the pulsing helmet stays below the "Mission in progress" line for the entire turn, through tool actions and thinking stretches alike, and disappears exactly when the reply text starts streaming.

### Checks
- `pnpm -r typecheck` — all 23 packages green.
- `pnpm --filter @houston-ai/chat test` — 44/44 (7 new `deriveStatus` cases).
- `pnpm check` (Biome) — exits 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)