### PR TITLE
fix(ui): collapsed sidebar expands from the top monogram + rail clicks (HOU-657)

### DIFF
--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -145,6 +145,8 @@ export function Sidebar({ children }: { children: ReactNode }) {
               onCreate={handleCreateWorkspace}
               collapsed={collapsed}
               createLabel={t("shell:sidebar.createWorkspace")}
+              onExpand={() => setSidebarCollapsed(false)}
+              expandLabel={t("shell:sidebar.expand")}
             />
           }
           navItems={[
@@ -183,7 +185,6 @@ export function Sidebar({ children }: { children: ReactNode }) {
             renameItem: t("common:actions.rename"),
             deleteItem: t("common:actions.delete"),
             collapseSidebar: t("shell:sidebar.collapse"),
-            expandSidebar: t("shell:sidebar.expand"),
           }}
           footer={
             <div className="flex flex-col">

--- a/packages/web/e2e/sidebar.spec.ts
+++ b/packages/web/e2e/sidebar.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "./support/fixtures";
+
+/**
+ * Collapsed-sidebar expand affordances (HOU-657): the workspace monogram at
+ * the TOP of the rail doubles as the expand button (hover swaps the initial
+ * for the expand icon), clicking empty rail space also expands, and clicks on
+ * interactive rail elements (nav, agents) keep their own action.
+ */
+test("collapsed sidebar expands from the top monogram and rail clicks", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await expect(page.getByText("Mission Control")).toBeVisible();
+
+  const sidebar = page.locator("[data-tour-target='sidebar']");
+
+  // Collapse via the (unchanged) top-right collapse button.
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  await expect(sidebar).toHaveCSS("width", "56px");
+
+  // Exactly one expand button, and it sits at the TOP of the rail (the
+  // monogram slot) — not at the bottom where the old toggle lived.
+  const expandBtn = page.getByRole("button", { name: "Expand sidebar" });
+  await expect(expandBtn).toHaveCount(1);
+  const btnBox = await expandBtn.boundingBox();
+  const asideBox = await sidebar.boundingBox();
+  if (!btnBox || !asideBox) throw new Error("missing bounding boxes");
+  expect(btnBox.y - asideBox.y).toBeLessThan(30);
+
+  // Hover swaps the monogram for the expand icon; click expands.
+  await expandBtn.hover();
+  await expect(expandBtn.locator("svg")).toBeVisible();
+  await expandBtn.click();
+  await expect(sidebar).toHaveCSS("width", "220px");
+
+  // Clicking an EMPTY spot on the collapsed rail expands too.
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  await expect(sidebar).toHaveCSS("width", "56px");
+  await page.mouse.click(asideBox.x + 28, asideBox.y + asideBox.height - 200);
+  await expect(sidebar).toHaveCSS("width", "220px");
+
+  // Clicking an interactive rail element (a nav button) must NOT expand.
+  await page.getByRole("button", { name: "Collapse sidebar" }).click();
+  await expect(sidebar).toHaveCSS("width", "56px");
+  await sidebar.locator("nav button").first().click();
+  await expect(sidebar).toHaveCSS("width", "56px");
+});

--- a/ui/layout/src/sidebar-rail-expand.ts
+++ b/ui/layout/src/sidebar-rail-expand.ts
@@ -1,0 +1,19 @@
+/**
+ * Collapsed-rail "click anywhere to expand" guard. A click on the rail
+ * expands the sidebar unless it landed on (or inside) something that is
+ * itself interactive — agent buttons, nav items, menus, inputs — whose own
+ * action must win.
+ */
+export const RAIL_INTERACTIVE_SELECTOR =
+  "button, a, input, textarea, select, [role='menuitem'], [role='menu'], [data-rail-no-expand]";
+
+export interface RailClickTarget {
+  closest(selector: string): unknown;
+}
+
+export function shouldExpandFromRailClick(
+  target: RailClickTarget | null,
+): boolean {
+  if (!target) return true;
+  return !target.closest(RAIL_INTERACTIVE_SELECTOR);
+}

--- a/ui/layout/src/sidebar.tsx
+++ b/ui/layout/src/sidebar.tsx
@@ -5,13 +5,19 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@houston-ai/core";
-import { PanelLeftClose, PanelLeftOpen, Plus } from "lucide-react";
-import { type KeyboardEvent, type ReactNode, useState } from "react";
+import { PanelLeftClose, Plus } from "lucide-react";
+import {
+  type KeyboardEvent,
+  type MouseEvent,
+  type ReactNode,
+  useState,
+} from "react";
 import { sidebarClasses } from "./sidebar-classes";
 import { SidebarCollapsedItem } from "./sidebar-collapsed-item";
 import type { SidebarItemRowLabels } from "./sidebar-item-row";
 import { SidebarItemRow } from "./sidebar-item-row";
 import { SidebarNavItem } from "./sidebar-nav";
+import { shouldExpandFromRailClick } from "./sidebar-rail-expand";
 
 export interface SidebarItem {
   id: string;
@@ -65,7 +71,6 @@ export interface SidebarProps {
 export interface SidebarLabels extends SidebarItemRowLabels {
   addItem?: string;
   collapseSidebar?: string;
-  expandSidebar?: string;
 }
 
 const DEFAULT_LABELS: Required<SidebarLabels> = {
@@ -74,7 +79,6 @@ const DEFAULT_LABELS: Required<SidebarLabels> = {
   renameItem: "Rename",
   deleteItem: "Delete",
   collapseSidebar: "Collapse sidebar",
-  expandSidebar: "Expand sidebar",
 };
 
 export function AppSidebar({
@@ -124,45 +128,52 @@ export function AppSidebar({
 
   const showLogo = logo && !header;
 
-  const toggleLabel = collapsed ? l.expandSidebar : l.collapseSidebar;
-
+  // Collapse control for the EXPANDED state only. When collapsed, expanding
+  // happens at the top of the rail (the header's monogram doubles as the
+  // expand button) or by clicking anywhere on the rail itself.
   const toggleButton = onToggleCollapsed ? (
     <Tooltip>
       <TooltipTrigger asChild>
         <button
           type="button"
-          aria-label={toggleLabel}
-          aria-pressed={collapsed}
+          aria-label={l.collapseSidebar}
           onClick={onToggleCollapsed}
           className="flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
         >
-          {collapsed ? (
-            <PanelLeftOpen className="size-4" />
-          ) : (
-            <PanelLeftClose className="size-4" />
-          )}
+          <PanelLeftClose className="size-4" />
         </button>
       </TooltipTrigger>
       <TooltipContent side="right" sideOffset={8}>
-        {toggleLabel}
+        {l.collapseSidebar}
       </TooltipContent>
     </Tooltip>
   ) : null;
 
+  const handleRailClick = (e: MouseEvent<HTMLElement>) => {
+    if (!collapsed || !onToggleCollapsed) return;
+    if (!shouldExpandFromRailClick(e.target as HTMLElement)) return;
+    onToggleCollapsed();
+  };
+
   return (
     <>
+      {/* Rail click-to-expand is a redundant convenience affordance; keyboard
+          users expand via the always-focusable header button. */}
+      {/* biome-ignore lint/a11y/useKeyWithClickEvents: see above */}
       <aside
         data-tour-target="sidebar"
+        onClick={handleRailClick}
         className={cn(
           "bg-sidebar text-sidebar-foreground flex flex-col h-full shrink-0 overflow-hidden",
           "transition-[width] duration-200 ease-out",
-          collapsed ? "w-[56px]" : "w-[220px]",
+          collapsed ? "w-[56px] cursor-pointer" : "w-[220px]",
         )}
       >
         {/* Header + collapse toggle. Expanded: the toggle shares the workspace
-            switcher's row (top-right). Collapsed: just the monogram here — the
-            toggle moves to the BOTTOM of the rail (see footer area). Always
-            visible, never hover-gated. */}
+            switcher's row (top-right). Collapsed: the header's monogram is the
+            expand button (see WorkspaceSwitcher onExpand), and clicking any
+            non-interactive spot on the rail also expands. Always visible,
+            never hover-gated. */}
         {collapsed ? (
           header
         ) : (
@@ -310,11 +321,6 @@ export function AppSidebar({
 
         {/* Footer slot (e.g., update notification) */}
         {footer}
-
-        {/* Collapsed: the toggle lives at the bottom of the rail. */}
-        {collapsed && toggleButton && (
-          <div className="flex justify-center pb-4 pt-1">{toggleButton}</div>
-        )}
       </aside>
 
       {children}

--- a/ui/layout/src/workspace-switcher.tsx
+++ b/ui/layout/src/workspace-switcher.tsx
@@ -4,8 +4,11 @@ import {
   DropdownMenuItem,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@houston-ai/core";
-import { ChevronDown, Plus } from "lucide-react";
+import { ChevronDown, PanelLeftOpen, Plus } from "lucide-react";
 
 export interface WorkspaceSwitcherProps {
   workspaces: { id: string; name: string }[];
@@ -17,6 +20,15 @@ export interface WorkspaceSwitcherProps {
   collapsed?: boolean;
   /** Label for the "create workspace" action (defaults to English). */
   createLabel?: string;
+  /**
+   * Collapsed rail only: the monogram becomes the expand-sidebar button —
+   * it shows the workspace initial at rest and swaps to the expand icon on
+   * hover/focus. Clicking expands instead of opening the switcher menu
+   * (the menu is reachable once expanded).
+   */
+  onExpand?: () => void;
+  /** Label for the expand-sidebar action (defaults to English). */
+  expandLabel?: string;
 }
 
 function workspaceMonogram(name: string): string {
@@ -32,6 +44,8 @@ export function WorkspaceSwitcher({
   onCreate,
   collapsed = false,
   createLabel = "Create workspace",
+  onExpand,
+  expandLabel = "Expand sidebar",
 }: WorkspaceSwitcherProps) {
   const menu = (
     <DropdownMenuContent align="start" className="w-48">
@@ -51,6 +65,34 @@ export function WorkspaceSwitcher({
       </DropdownMenuItem>
     </DropdownMenuContent>
   );
+
+  if (collapsed && onExpand) {
+    return (
+      <div
+        className="flex justify-center px-2 pt-3 pb-1"
+        data-tauri-drag-region
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-label={expandLabel}
+              onClick={onExpand}
+              className="group flex size-9 items-center justify-center rounded-lg bg-accent text-sm font-semibold text-foreground transition-colors hover:bg-accent/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <span className="group-hover:hidden group-focus-visible:hidden">
+                {workspaceMonogram(currentName)}
+              </span>
+              <PanelLeftOpen className="hidden size-4 group-hover:block group-focus-visible:block" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent side="right" sideOffset={8}>
+            {expandLabel}
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    );
+  }
 
   if (collapsed) {
     return (

--- a/ui/layout/tests/sidebar-rail-expand.test.ts
+++ b/ui/layout/tests/sidebar-rail-expand.test.ts
@@ -1,0 +1,43 @@
+import { equal } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  RAIL_INTERACTIVE_SELECTOR,
+  type RailClickTarget,
+  shouldExpandFromRailClick,
+} from "../src/sidebar-rail-expand.ts";
+
+function targetInside(...tags: string[]): RailClickTarget {
+  return {
+    closest(selector: string) {
+      const wanted = selector.split(",").map((s) => s.trim());
+      return tags.some((t) => wanted.includes(t)) ? {} : null;
+    },
+  };
+}
+
+describe("collapsed rail click-to-expand guard", () => {
+  it("expands on clicks over non-interactive rail area", () => {
+    equal(shouldExpandFromRailClick(targetInside("div")), true);
+    equal(shouldExpandFromRailClick(targetInside("aside")), true);
+    equal(shouldExpandFromRailClick(null), true);
+  });
+
+  it("does not steal clicks from interactive elements", () => {
+    equal(shouldExpandFromRailClick(targetInside("button")), false);
+    equal(shouldExpandFromRailClick(targetInside("a")), false);
+    equal(shouldExpandFromRailClick(targetInside("input")), false);
+    equal(shouldExpandFromRailClick(targetInside("[role='menuitem']")), false);
+    equal(
+      shouldExpandFromRailClick(targetInside("[data-rail-no-expand]")),
+      false,
+    );
+  });
+
+  it("covers the affordances that live on the rail today", () => {
+    // Agent items, nav items, add-agent, user menu, and the monogram/expand
+    // button all render as <button>; dropdown menus render role=menuitem.
+    for (const sel of ["button", "[role='menuitem']"]) {
+      equal(RAIL_INTERACTIVE_SELECTOR.includes(sel), true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

HOU-657 — the expand-sidebar button lived at the bottom of the collapsed rail, far from where the collapse button is and easy to miss.

- **Expand moves to the top of the rail, into the workspace monogram's exact spot.** At rest the button shows the workspace initial (the "H"); on hover/focus it swaps to the expand icon (with tooltip); clicking it expands the sidebar. The workspace switcher menu is reachable once expanded.
- **Clicking anywhere on the collapsed rail expands it** — except on interactive elements (agent buttons, nav items, menus, inputs), which keep their own action. The rail gets a pointer cursor while collapsed.
- **The expanded state is unchanged**: the collapse button stays top-right of the workspace switcher row.
- The bottom-of-rail toggle is removed, and the now-dead `expandSidebar` label is dropped from `AppSidebar`'s labels (the label moved to `WorkspaceSwitcher.expandLabel`).

Library changes are in `ui/layout` (`AppSidebar`, `WorkspaceSwitcher`, new `sidebar-rail-expand.ts` guard); the app only wires two new props with existing i18n keys.

## Tests

- Unit test for the rail-click guard (`ui/layout/tests/sidebar-rail-expand.test.ts`).
- New Playwright spec (`packages/web/e2e/sidebar.spec.ts`) driving the real UI: expand button position at the top, hover icon swap, click-to-expand, rail-click-to-expand, and nav clicks NOT expanding. Full e2e suite passes (17/17).
- `pnpm check`, all workspace typechecks green. (`pnpm check-locales` fails identically on base `main` — pre-existing, no locale files touched here.)

## Verify

Before the fix: collapse the sidebar → the only expand button is at the very bottom of the rail; clicking the top "H" opens the workspace menu; clicking empty rail space does nothing.

After: collapse the sidebar → the bottom button is gone; hover the top "H" → it turns into the expand icon; click it → sidebar expands. Collapse again and click any empty spot on the rail → it expands. Clicking Mission Control / an agent icon still navigates without expanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)