### PR TITLE
fix(ui): make dark mode consistent with the light design (HOU-673)

### DIFF
--- a/app/src/components/ai-hub/provider-card.tsx
+++ b/app/src/components/ai-hub/provider-card.tsx
@@ -56,7 +56,7 @@ export function ProviderCard({
       tabIndex={0}
       onClick={onOpen}
       onKeyDown={onKeyDown}
-      className="group flex cursor-pointer flex-col rounded-2xl border border-black/5 bg-card p-5 transition-shadow duration-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+      className="group flex cursor-pointer flex-col rounded-2xl border border-foreground/5 bg-card p-5 transition-shadow duration-200 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
     >
       <div className="flex size-10 items-center justify-center rounded-xl bg-secondary text-foreground">
         <ProviderGlyph providerId={provider.id} />
@@ -121,7 +121,7 @@ export function ComingSoonProviderCard({
   return (
     <div
       aria-disabled="true"
-      className="flex select-none flex-col rounded-2xl border border-black/5 bg-card p-5 opacity-60"
+      className="flex select-none flex-col rounded-2xl border border-foreground/5 bg-card p-5 opacity-60"
     >
       <div className="flex size-10 items-center justify-center rounded-xl bg-secondary text-[11px] font-semibold text-muted-foreground">
         {provider.mark}

--- a/app/src/components/ai-hub/provider-grid.tsx
+++ b/app/src/components/ai-hub/provider-grid.tsx
@@ -112,7 +112,7 @@ function ProviderGridSkeleton({ count }: { count: number }) {
         <div
           // biome-ignore lint/suspicious/noArrayIndexKey: fixed-length static placeholder list, no reordering.
           key={i}
-          className="flex flex-col rounded-2xl border border-black/5 bg-card p-5"
+          className="flex flex-col rounded-2xl border border-foreground/5 bg-card p-5"
         >
           <div className="size-10 animate-pulse rounded-xl bg-secondary" />
           <div className="mt-3 h-4 w-24 animate-pulse rounded bg-secondary" />

--- a/app/src/components/attachment-rejection-dialog.tsx
+++ b/app/src/components/attachment-rejection-dialog.tsx
@@ -54,7 +54,7 @@ export function useAttachmentRejectionDialog(): AttachmentValidationDialogApi {
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
             <div className="flex items-start gap-3">
-              <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md bg-amber-50 text-amber-700">
+              <span className="mt-0.5 flex size-9 shrink-0 items-center justify-center rounded-md bg-amber-50 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400">
                 <AlertTriangle className="size-5" />
               </span>
               <div>

--- a/app/src/components/onboarding/setup-card.tsx
+++ b/app/src/components/onboarding/setup-card.tsx
@@ -54,7 +54,7 @@ export function SetupCard({
           each step change, but not on in-step state updates like typing. */}
       <div
         key={title}
-        className="setup-step-in relative z-10 flex h-[680px] max-h-[88vh] w-full max-w-2xl flex-col rounded-2xl border border-black/10 bg-background p-8 shadow-[0_4px_24px_rgba(0,0,0,0.06)]"
+        className="setup-step-in relative z-10 flex h-[680px] max-h-[88vh] w-full max-w-2xl flex-col rounded-2xl border border-foreground/10 bg-background p-8 shadow-[0_4px_24px_rgba(0,0,0,0.06)]"
       >
         {icon && <div className="mb-4">{icon}</div>}
         {eyebrow && (
@@ -162,7 +162,7 @@ export function OptionCard({
         "flex w-full flex-col gap-3 rounded-xl p-4 text-left transition-colors",
         disabled
           ? "cursor-not-allowed bg-secondary/50 opacity-60"
-          : "bg-secondary hover:bg-black/[0.06]",
+          : "bg-secondary hover:bg-foreground/[0.06]",
         // Inset so the selection ring is drawn INSIDE the card box — an
         // outset ring on an edge card gets clipped by the scroll container.
         selected && !disabled && "ring-1 ring-inset ring-foreground",
@@ -202,7 +202,7 @@ function RadioDot({ selected }: { selected: boolean }) {
       aria-hidden
       className={cn(
         "flex size-5 items-center justify-center rounded-full border transition-colors",
-        selected ? "border-foreground bg-foreground" : "border-black/25",
+        selected ? "border-foreground bg-foreground" : "border-foreground/25",
       )}
     >
       {selected && <Check className="size-3 text-background" />}

--- a/app/src/components/portable/export-wizard.tsx
+++ b/app/src/components/portable/export-wizard.tsx
@@ -715,7 +715,7 @@ function ChoiceCard({
       onClick={onClick}
       className={cn(
         "rounded-xl border bg-background p-4 text-left transition-all",
-        "border-black/5 hover:border-black/15 hover:shadow-[0_1px_0_rgba(0,0,0,0.05)]",
+        "border-foreground/5 hover:border-foreground/15 hover:shadow-[0_1px_0_rgba(0,0,0,0.05)]",
         selected && "border-foreground shadow-[0_1px_0_rgba(0,0,0,0.05)]",
       )}
     >
@@ -744,7 +744,7 @@ function DiffCard({
 }) {
   const { t } = useTranslation("portable");
   return (
-    <article className="rounded-xl border border-black/5 bg-background p-4">
+    <article className="rounded-xl border border-foreground/5 bg-background p-4">
       <header className="flex items-center justify-between gap-3 mb-3">
         <p className="text-sm font-medium">{title}</p>
         <button
@@ -786,7 +786,7 @@ function RoutineDiffCard({
 }) {
   const { t } = useTranslation("portable");
   return (
-    <article className="rounded-xl border border-black/5 bg-background p-4">
+    <article className="rounded-xl border border-foreground/5 bg-background p-4">
       <header className="flex items-center justify-between gap-3 mb-3">
         <p className="text-sm font-medium">
           {t("export.step2.routineTitle", { id: routineId })}

--- a/app/src/components/portable/import-wizard.tsx
+++ b/app/src/components/portable/import-wizard.tsx
@@ -669,7 +669,7 @@ function ChoiceCard({
       onClick={onClick}
       className={cn(
         "rounded-xl border bg-background p-4 text-left transition-all",
-        "border-black/5 hover:border-black/15 hover:shadow-[0_1px_0_rgba(0,0,0,0.05)]",
+        "border-foreground/5 hover:border-foreground/15 hover:shadow-[0_1px_0_rgba(0,0,0,0.05)]",
         selected && "border-foreground shadow-[0_1px_0_rgba(0,0,0,0.05)]",
       )}
     >

--- a/app/src/components/settings/sections/connect-phone.tsx
+++ b/app/src/components/settings/sections/connect-phone.tsx
@@ -143,7 +143,7 @@ export function ConnectPhoneSection() {
         )}
 
         {info && !info.connected && !error && (
-          <div className="rounded-lg bg-amber-50 px-3 py-2 text-[11px] text-amber-800 leading-relaxed text-center max-w-[260px]">
+          <div className="rounded-lg bg-amber-50 px-3 py-2 text-[11px] text-amber-800 leading-relaxed text-center max-w-[260px] dark:bg-amber-950/40 dark:text-amber-300">
             {t("settings:connectPhone.connectingStatus")}
           </div>
         )}

--- a/app/src/components/settings/sections/members-add-form.tsx
+++ b/app/src/components/settings/sections/members-add-form.tsx
@@ -38,7 +38,7 @@ export function AddMemberForm() {
   };
 
   return (
-    <div className="mb-6 rounded-xl border border-black/5 bg-secondary p-4">
+    <div className="mb-6 rounded-xl border border-foreground/5 bg-secondary p-4">
       <h3 className="text-sm font-medium mb-3">{t("members.add.title")}</h3>
       <div className="flex flex-col gap-2 sm:flex-row sm:items-end">
         <div className="flex-1">

--- a/app/src/components/settings/sections/members-roster.tsx
+++ b/app/src/components/settings/sections/members-roster.tsx
@@ -43,7 +43,7 @@ export function MemberRoster({
           return (
             <li
               key={member.userId}
-              className="flex items-center gap-3 rounded-xl border border-black/5 bg-card px-4 py-3"
+              className="flex items-center gap-3 rounded-xl border border-foreground/5 bg-card px-4 py-3"
             >
               <div className="flex-1 min-w-0">
                 <div className="text-sm font-medium truncate">

--- a/app/src/components/shell/agent-setup-form.tsx
+++ b/app/src/components/shell/agent-setup-form.tsx
@@ -186,7 +186,7 @@ export function AgentSetupForm({
           className={cn(
             "w-full px-4 py-3 text-sm text-foreground leading-relaxed",
             "placeholder:text-muted-foreground/60",
-            "bg-secondary border border-black/[0.04] rounded-xl",
+            "bg-secondary border border-foreground/[0.04] rounded-xl",
             "outline-none resize-none transition-shadow duration-200",
             "focus:shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
             "disabled:opacity-60 disabled:cursor-not-allowed",

--- a/app/src/components/shell/ai-review-step.tsx
+++ b/app/src/components/shell/ai-review-step.tsx
@@ -112,7 +112,7 @@ export function AiReviewStep({
                 rows={Math.max(10, instructions.split("\n").length + 2)}
                 className={cn(
                   "w-full px-4 py-3 text-sm text-foreground leading-relaxed",
-                  "bg-background border border-black/[0.04] rounded-lg",
+                  "bg-background border border-foreground/[0.04] rounded-lg",
                   "outline-none resize-none transition-shadow duration-200",
                   "focus:shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
                 )}

--- a/app/src/components/shell/ai-routine-step.tsx
+++ b/app/src/components/shell/ai-routine-step.tsx
@@ -75,7 +75,7 @@ export function AiRoutineStep({
               rows={3}
               className={cn(
                 "w-full px-4 py-3 text-sm text-foreground leading-relaxed",
-                "bg-secondary border border-black/[0.04] rounded-xl",
+                "bg-secondary border border-foreground/[0.04] rounded-xl",
                 "outline-none resize-none transition-shadow duration-200",
                 "focus:shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
               )}
@@ -101,7 +101,7 @@ export function AiRoutineStep({
 
           <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 px-4 py-3 space-y-2">
             <div className="flex items-center gap-2">
-              <AlertTriangle className="w-4 h-4 text-amber-600 shrink-0" />
+              <AlertTriangle className="w-4 h-4 text-amber-600 dark:text-amber-400 shrink-0" />
               <p className="text-sm font-medium text-foreground">
                 {t("aiRoutine.consentTitle")}
               </p>

--- a/app/src/components/shell/ai-step-footer.tsx
+++ b/app/src/components/shell/ai-step-footer.tsx
@@ -23,7 +23,7 @@ export function AiStepFooter({
   const { t } = useTranslation("common");
 
   return (
-    <footer className="shrink-0 border-t border-black/[0.06] px-6 py-4">
+    <footer className="shrink-0 border-t border-foreground/[0.06] px-6 py-4">
       <div className="max-w-2xl mx-auto flex items-center justify-between gap-3">
         <Button
           type="button"

--- a/app/src/components/shell/provider-cards.tsx
+++ b/app/src/components/shell/provider-cards.tsx
@@ -97,7 +97,7 @@ export function ProviderCard({
             ? t("card.signOutTitle", { name: provider.name })
             : t("card.connectTitle", { name: provider.name })
       }
-      className="group w-full text-left flex items-center gap-3 px-3 py-2.5 rounded-xl bg-secondary hover:bg-black/[0.05] transition-colors focus-visible:outline-none focus-visible:bg-black/[0.05]"
+      className="group w-full text-left flex items-center gap-3 px-3 py-2.5 rounded-xl bg-secondary hover:bg-foreground/[0.05] transition-colors focus-visible:outline-none focus-visible:bg-foreground/[0.05]"
     >
       <div className="size-8 rounded-lg bg-background flex items-center justify-center shrink-0">
         <ProviderLogo provider={provider} />

--- a/app/src/components/shell/ui-tour.tsx
+++ b/app/src/components/shell/ui-tour.tsx
@@ -284,7 +284,7 @@ export function UiTour({ steps, onDismiss }: UiTourProps) {
           is no target. */}
       <div
         className={cn(
-          "fixed z-[60] rounded-2xl border border-black/5 bg-background p-5 shadow-[0_10px_40px_rgba(0,0,0,0.18)]",
+          "fixed z-[60] rounded-2xl border border-foreground/5 bg-background p-5 shadow-[0_10px_40px_rgba(0,0,0,0.18)]",
         )}
         style={{
           top: tooltip.top,

--- a/app/src/components/tabs/agent-access-section.tsx
+++ b/app/src/components/tabs/agent-access-section.tsx
@@ -73,7 +73,7 @@ export function AgentAccessSection({ agent }: { agent: Agent }) {
             return (
               <li
                 key={member.userId}
-                className="flex items-center gap-3 rounded-xl border border-black/5 bg-card px-4 py-3"
+                className="flex items-center gap-3 rounded-xl border border-foreground/5 bg-card px-4 py-3"
               >
                 <div className="flex-1 min-w-0 text-sm truncate">
                   {member.email ?? member.userId}

--- a/app/src/components/tabs/files-tab.tsx
+++ b/app/src/components/tabs/files-tab.tsx
@@ -80,7 +80,7 @@ export default function FilesTab({ agent }: TabProps) {
             <button
               type="button"
               onClick={() => tauriFiles.revealAgent(path)}
-              className="flex items-center gap-1 text-[11px] text-[#6d6d6d] hover:text-[#0d0d0d] transition-colors"
+              className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
             >
               <FolderOpen className="size-3" />
               {t("files.openInFileManager")}

--- a/app/src/components/tabs/integrations-app-rows.tsx
+++ b/app/src/components/tabs/integrations-app-rows.tsx
@@ -29,7 +29,7 @@ export function BrowseAppRow({
       onClick={onConnect}
       disabled={connecting}
       title={t("browse.connectTitle", { name: app.name })}
-      className="group flex w-full items-center gap-3 rounded-xl bg-secondary px-3 py-2.5 text-left transition-colors hover:bg-black/[0.05] focus-visible:bg-black/[0.05] focus-visible:outline-none disabled:cursor-wait disabled:opacity-60"
+      className="group flex w-full items-center gap-3 rounded-xl bg-secondary px-3 py-2.5 text-left transition-colors hover:bg-foreground/[0.05] focus-visible:bg-foreground/[0.05] focus-visible:outline-none disabled:cursor-wait disabled:opacity-60"
     >
       <Logo app={app} />
       <div className="min-w-0 flex-1">

--- a/app/src/components/tabs/integrations-connected-row.tsx
+++ b/app/src/components/tabs/integrations-connected-row.tsx
@@ -50,7 +50,7 @@ export function ConnectedAppRow({
 }) {
   const { t } = useTranslation("integrations");
   return (
-    <div className="flex items-center gap-3 rounded-xl bg-secondary px-3 py-2.5 transition-colors hover:bg-black/[0.05]">
+    <div className="flex items-center gap-3 rounded-xl bg-secondary px-3 py-2.5 transition-colors hover:bg-foreground/[0.05]">
       <Logo app={app} />
       <div className="min-w-0 flex-1">
         <p className="flex items-center gap-1.5 truncate text-[13px] font-medium text-foreground">
@@ -77,7 +77,7 @@ export function ConnectedAppRow({
             type="button"
             disabled={busy}
             aria-label={t("connected.menu.aria", { name: app.name })}
-            className="inline-flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground/70 transition-colors hover:bg-black/[0.06] hover:text-foreground focus-visible:bg-black/[0.06] focus-visible:outline-none disabled:cursor-wait disabled:opacity-50"
+            className="inline-flex size-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground/70 transition-colors hover:bg-foreground/[0.06] hover:text-foreground focus-visible:bg-foreground/[0.06] focus-visible:outline-none disabled:cursor-wait disabled:opacity-50"
           >
             {busy ? (
               <Loader2 className="size-4 animate-spin" />
@@ -121,7 +121,7 @@ export function AvailableAppRow({
 }) {
   const { t } = useTranslation("integrations");
   return (
-    <div className="flex items-center gap-3 rounded-xl bg-secondary px-3 py-2.5 transition-colors hover:bg-black/[0.05]">
+    <div className="flex items-center gap-3 rounded-xl bg-secondary px-3 py-2.5 transition-colors hover:bg-foreground/[0.05]">
       <Logo app={app} />
       <div className="min-w-0 flex-1">
         <p className="flex items-center gap-1.5 truncate text-[13px] font-medium text-foreground">

--- a/app/src/components/tabs/integrations-states.tsx
+++ b/app/src/components/tabs/integrations-states.tsx
@@ -29,7 +29,7 @@ export function LoadingState() {
         <EmptyTitle>{t("loading.title")}</EmptyTitle>
         <EmptyDescription>{t("loading.body")}</EmptyDescription>
       </EmptyHeader>
-      <div className="h-[2px] w-48 overflow-hidden rounded-full bg-black/10">
+      <div className="h-[2px] w-48 overflow-hidden rounded-full bg-foreground/10">
         <div
           ref={barRef}
           className="h-full rounded-full bg-foreground"

--- a/app/src/components/tabs/job-description-parts.tsx
+++ b/app/src/components/tabs/job-description-parts.tsx
@@ -113,7 +113,7 @@ export function InstructionsContent({
           className={cn(
             "w-full px-4 py-3 text-sm text-foreground leading-relaxed",
             "placeholder:text-muted-foreground/60",
-            "bg-background border border-black/[0.04] rounded-lg",
+            "bg-background border border-foreground/[0.04] rounded-lg",
             "outline-none resize-none transition-shadow duration-200",
             "focus:shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
           )}

--- a/app/src/components/tabs/learning-card-preview.tsx
+++ b/app/src/components/tabs/learning-card-preview.tsx
@@ -27,7 +27,7 @@ export function LearningPreview({
           onClick={onToggle}
           className={cn(
             "size-7 shrink-0 rounded-lg flex items-center justify-center",
-            "text-muted-foreground hover:bg-black/[0.04] hover:text-foreground",
+            "text-muted-foreground hover:bg-foreground/[0.04] hover:text-foreground",
             "transition-colors",
           )}
           aria-label={
@@ -98,7 +98,7 @@ function IconButton({
       onClick={onClick}
       className={cn(
         "size-7 rounded-lg flex items-center justify-center text-muted-foreground",
-        "hover:bg-black/[0.04] transition-colors",
+        "hover:bg-foreground/[0.04] transition-colors",
         danger ? "hover:text-red-500" : "hover:text-foreground",
       )}
       aria-label={label}

--- a/app/src/components/tabs/learning-card.tsx
+++ b/app/src/components/tabs/learning-card.tsx
@@ -63,7 +63,7 @@ export function LearningCard({
   };
 
   return (
-    <article className="rounded-xl border border-black/[0.05] bg-secondary px-4 py-3 shadow-[0_1px_0_rgba(0,0,0,0.03)]">
+    <article className="rounded-xl border border-foreground/[0.05] bg-secondary px-4 py-3 shadow-[0_1px_0_rgba(0,0,0,0.03)]">
       {editing ? (
         <LearningEditor
           value={value}
@@ -119,9 +119,9 @@ function LearningEditor({
         placeholder={isDraft ? t("agents:learnings.inputPlaceholder") : ""}
         rows={Math.max(4, value.split("\n").length + 1)}
         className={cn(
-          "w-full resize-none rounded-lg border border-black/[0.08] bg-background",
+          "w-full resize-none rounded-lg border border-foreground/[0.08] bg-background",
           "px-3 py-2 text-sm leading-relaxed text-foreground outline-none",
-          "placeholder:text-muted-foreground/60 focus:border-black/20",
+          "placeholder:text-muted-foreground/60 focus:border-foreground/20",
         )}
       />
       <div className="flex justify-end gap-2">

--- a/ui/agent/src/file-row.tsx
+++ b/ui/agent/src/file-row.tsx
@@ -252,7 +252,7 @@ export function FileRow({
                 }
               }}
               onBlur={commitRename}
-              className="flex-1 text-[13px] bg-white text-[#0d0d0d] outline-none rounded px-1 -ml-1 min-w-0 border border-[#2068d0] shadow-sm"
+              className="flex-1 text-[13px] bg-background text-foreground outline-none rounded px-1 -ml-1 min-w-0 border border-[#2068d0] shadow-sm"
             />
           ) : (
             <span className="text-[13px] truncate">{file.name}</span>

--- a/ui/agent/src/instructions-panel.tsx
+++ b/ui/agent/src/instructions-panel.tsx
@@ -1,7 +1,7 @@
 /**
  * InstructionsPanel — editable instruction files for an agent workspace.
  * Visual style matches Houston's ContextTab exactly: labeled textareas
- * with auto-save on blur, bg-[#f9f9f9], subtle borders.
+ * with auto-save on blur, secondary-surface fill, subtle borders.
  */
 import { useEffect, useState } from "react";
 import type { InstructionFile } from "./types";
@@ -97,7 +97,7 @@ function InstructionField({
         onBlur={handleBlur}
         placeholder="Write instructions for your agent here..."
         rows={Math.max(4, value.split("\n").length + 1)}
-        className="w-full text-sm text-foreground leading-relaxed bg-[#f9f9f9] outline-none rounded-xl px-4 py-3 border border-black/[0.04] hover:border-black/[0.1] focus:border-black/[0.15] focus:bg-white transition-all duration-200 resize-none placeholder:text-muted-foreground/30"
+        className="w-full text-sm text-foreground leading-relaxed bg-secondary outline-none rounded-xl px-4 py-3 border border-foreground/[0.04] hover:border-foreground/10 focus:border-foreground/15 focus:bg-background transition-all duration-200 resize-none placeholder:text-muted-foreground/30"
       />
     </div>
   );

--- a/ui/board/src/conversation-list.tsx
+++ b/ui/board/src/conversation-list.tsx
@@ -42,7 +42,7 @@ export function ConversationList({ entries, onSelect }: ConversationListProps) {
       {entries.map((entry) => (
         <Card
           key={entry.id}
-          className="cursor-pointer hover:shadow-md transition-shadow border-black/5 px-4 py-3"
+          className="cursor-pointer hover:shadow-md transition-shadow border-foreground/5 px-4 py-3"
           onClick={() => onSelect(entry)}
         >
           <div className="flex items-center justify-between gap-3">

--- a/ui/chat/src/attachment-chip.tsx
+++ b/ui/chat/src/attachment-chip.tsx
@@ -106,7 +106,7 @@ export interface AttachmentChipProps {
 export function AttachmentChip({ name, onRemove }: AttachmentChipProps) {
   const ext = getExt(name);
   return (
-    <div className="relative flex items-center gap-2.5 rounded-xl border border-black/[0.08] bg-background pl-2.5 pr-8 py-2 min-w-0 shrink-0 max-w-[240px] shadow-sm">
+    <div className="relative flex items-center gap-2.5 rounded-xl border border-foreground/[0.08] bg-background pl-2.5 pr-8 py-2 min-w-0 shrink-0 max-w-[240px] shadow-sm">
       <AttachmentIcon ext={ext} />
       <div className="min-w-0">
         <p className="text-xs font-medium text-foreground truncate leading-tight">

--- a/ui/chat/src/chat-input-parts.tsx
+++ b/ui/chat/src/chat-input-parts.tsx
@@ -18,7 +18,7 @@ export interface FileChipProps {
 
 export function FileChip({ name, onRemove }: FileChipProps) {
   return (
-    <div className="flex items-center gap-1 bg-secondary border border-black/[0.08] rounded-md px-2 py-1 text-xs text-foreground">
+    <div className="flex items-center gap-1 bg-secondary border border-foreground/[0.08] rounded-md px-2 py-1 text-xs text-foreground">
       <FileIcon className="size-3 shrink-0 text-muted-foreground" />
       <span className="max-w-[140px] truncate">{name}</span>
       <button
@@ -81,7 +81,7 @@ export function AttachMenu({ items, onClose, anchorRef }: AttachMenuProps) {
       />
       <div
         ref={menuRef}
-        className="fixed z-50 min-w-[180px] rounded-xl border border-black/[0.08] bg-white shadow-lg py-1"
+        className="fixed z-50 min-w-[180px] rounded-xl border border-border/80 bg-popover shadow-lg py-1"
         style={
           pos
             ? { left: pos.left, bottom: pos.bottom }

--- a/ui/chat/src/chat-sidebar.tsx
+++ b/ui/chat/src/chat-sidebar.tsx
@@ -63,7 +63,7 @@ function ProgressCard({
 
   return (
     <Collapsible open={open} onOpenChange={setOpen}>
-      <div className="rounded-xl border border-border bg-white shadow-sm">
+      <div className="rounded-xl border border-border bg-card shadow-sm">
         <CollapsibleTrigger className="flex items-center justify-between w-full px-4 py-3 text-sm font-medium">
           Progress
           <ChevronDown

--- a/ui/chat/src/tool-code.tsx
+++ b/ui/chat/src/tool-code.tsx
@@ -41,7 +41,7 @@ export const TruncatedCode = memo(
                 ? "text-red-400"
                 : "text-zinc-300"
               : isError
-                ? "text-red-600 bg-red-50"
+                ? "text-red-600 bg-red-50 dark:text-red-300 dark:bg-red-950/40"
                 : "text-foreground bg-muted/50"
           }`}
         >

--- a/ui/chat/src/tool-content.tsx
+++ b/ui/chat/src/tool-content.tsx
@@ -88,7 +88,7 @@ function EditContent({
 }) {
   if (result?.is_error) {
     return (
-      <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700">
+      <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-700 dark:border-red-900/60 dark:bg-red-950/40 dark:text-red-300">
         {result.content}
       </div>
     );
@@ -115,14 +115,20 @@ function DiffLine({
 }) {
   return (
     <div
-      className={`${tone === "red" ? "bg-red-50 border-b" : "bg-green-50"} px-3 py-1.5 border-border/30`}
+      className={`${tone === "red" ? "bg-red-50 dark:bg-red-950/40 border-b" : "bg-green-50 dark:bg-green-950/40"} px-3 py-1.5 border-border/30`}
     >
       <span
         className={`${tone === "red" ? "text-red-400" : "text-green-400"} select-none`}
       >
         {sign}{" "}
       </span>
-      <span className={tone === "red" ? "text-red-700" : "text-green-700"}>
+      <span
+        className={
+          tone === "red"
+            ? "text-red-700 dark:text-red-300"
+            : "text-green-700 dark:text-green-300"
+        }
+      >
         {truncateStr(text, 200)}
       </span>
     </div>

--- a/ui/core/src/globals.css
+++ b/ui/core/src/globals.css
@@ -7,7 +7,10 @@
    re-exports these to Tailwind's --color-* utilities. */
 @import "@houston/design-tokens/css";
 
-@custom-variant dark (&:is(.dark *));
+/* The app toggles dark mode via data-theme="dark" on <html> (see
+   app/src/lib/theme.ts) — NOT a .dark class. The variant must key on the
+   attribute or every `dark:` utility silently never applies. */
+@custom-variant dark (&:where([data-theme="dark"], [data-theme="dark"] *));
 
 /* Dark mode needs the native form controls / scrollbars to follow suit; the
    colour values themselves come from the imported tokens above. */

--- a/ui/routines/src/routine-editor.tsx
+++ b/ui/routines/src/routine-editor.tsx
@@ -295,7 +295,7 @@ export function RoutineEditor({
                 className={cn(
                   "w-full px-3 py-2 text-sm text-foreground",
                   "placeholder:text-muted-foreground/60",
-                  "bg-background border border-black/[0.04] rounded-lg",
+                  "bg-background border border-foreground/[0.04] rounded-lg",
                   "outline-none transition-shadow duration-200",
                   "focus:shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
                 )}
@@ -313,7 +313,7 @@ export function RoutineEditor({
                 className={cn(
                   "w-full px-3 py-2 text-sm text-foreground",
                   "placeholder:text-muted-foreground/60",
-                  "bg-background border border-black/[0.04] rounded-lg",
+                  "bg-background border border-foreground/[0.04] rounded-lg",
                   "outline-none transition-shadow duration-200",
                   "focus:shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
                 )}
@@ -329,7 +329,7 @@ export function RoutineEditor({
                 className={cn(
                   "w-full px-3 py-2 text-sm text-foreground leading-relaxed",
                   "placeholder:text-muted-foreground/60",
-                  "bg-background border border-black/[0.04] rounded-lg",
+                  "bg-background border border-foreground/[0.04] rounded-lg",
                   "outline-none resize-none transition-shadow duration-200",
                   "focus:shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
                 )}
@@ -346,7 +346,7 @@ export function RoutineEditor({
             />
 
             {/* Live "Next run" callout — white well inside the gray card */}
-            <div className="flex items-start gap-3 rounded-lg bg-background border border-black/[0.04] px-4 py-3">
+            <div className="flex items-start gap-3 rounded-lg bg-background border border-foreground/[0.04] px-4 py-3">
               <CalendarClock
                 className="size-4 text-muted-foreground mt-0.5 shrink-0"
                 strokeWidth={1.75}

--- a/ui/routines/src/routine-row.tsx
+++ b/ui/routines/src/routine-row.tsx
@@ -101,8 +101,8 @@ export function RoutineRow({
       className={cn(
         "group relative flex items-center gap-4 px-5 py-4 cursor-pointer",
         "transition-colors duration-150",
-        "hover:bg-black/[0.03]",
-        "focus-visible:outline-none focus-visible:bg-black/[0.03]",
+        "hover:bg-foreground/[0.03]",
+        "focus-visible:outline-none focus-visible:bg-foreground/[0.03]",
         !routine.enabled && "opacity-55",
       )}
     >

--- a/ui/routines/src/run-history.tsx
+++ b/ui/routines/src/run-history.tsx
@@ -109,7 +109,7 @@ export function RunHistory({
             key={run.id}
             className={cn(
               "group flex items-center gap-3 px-3 py-2.5 rounded-lg",
-              "bg-background border border-black/[0.04]",
+              "bg-background border border-foreground/[0.04]",
               "transition-shadow duration-150",
               "hover:shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
             )}

--- a/ui/routines/src/schedule-builder.tsx
+++ b/ui/routines/src/schedule-builder.tsx
@@ -80,7 +80,7 @@ export function ScheduleBuilder({
               "h-8 px-3 rounded-full text-xs font-medium transition-colors",
               activePreset === preset
                 ? "bg-primary text-primary-foreground"
-                : "bg-background border border-black/[0.04] text-muted-foreground hover:text-foreground",
+                : "bg-background border border-foreground/[0.04] text-muted-foreground hover:text-foreground",
             )}
           >
             {labels.presets[preset]}

--- a/ui/skills/src/skill-row.tsx
+++ b/ui/skills/src/skill-row.tsx
@@ -38,8 +38,8 @@ export function SkillRow({ skill, onClick, onDelete }: SkillRowProps) {
         "group flex items-start gap-3 px-5 py-4 cursor-pointer w-full text-left",
         "bg-transparent border-0 p-0",
         "transition-colors duration-150",
-        "hover:bg-black/[0.03]",
-        "focus-visible:outline-none focus-visible:bg-black/[0.03]",
+        "hover:bg-foreground/[0.03]",
+        "focus-visible:outline-none focus-visible:bg-foreground/[0.03]",
       )}
     >
       <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary

Full dark-theme review (HOU-673). Three root causes fixed:

**1. The `dark:` Tailwind variant was dead everywhere.** `ui/core/src/globals.css` bound it to a `.dark` class, but the app toggles dark mode with `data-theme="dark"` on `<html>` (`app/src/lib/theme.ts`) — nothing ever sets a `.dark` class, so all ~44 `dark:` utilities across `ui/` and `app/` never applied. The variant is now keyed on the attribute, which activates the intended dark styling on dialogs (shadows), inputs/textareas/selects (`dark:bg-input/30`), tabs, switches, badges and destructive buttons.

**2. Hardcoded light-only surfaces.** The chat-input context menu (`bg-white`), the chat progress sidebar card (`bg-white`), the agent instructions editor (`#f9f9f9` / `focus:bg-white`), the file-manager rename input (`bg-white text-[#0d0d0d]`), the files status-bar link (fixed grey hexes), tool error/diff chips (`red-50`/`green-50`), and the phone-connect + attachment-rejection notices (`amber-50`) all rendered as white/light slabs in dark mode. They now use semantic tokens or carry `dark:` pairs. The WhatsApp QR tile intentionally stays white for scannability.

**3. Ink-alpha hairlines and hovers.** `border-black/[0.04..0.10]`, `hover:bg-black/[0.03..0.06]` etc. across the create-agent flow, settings, integrations, routines, skills, AI hub, onboarding, ui-tour and the import/export wizards are invisible (black-on-black) or hover the wrong direction (darker instead of lighter) in dark mode. Mapped `black` → `foreground` alpha: light mode stays pixel-identical (light foreground ≈ ink) and dark mode flips to white-alpha automatically.

## Verification

Driven with the Playwright web harness against the fake host (same React tree as desktop).

**Repro before the fix:**
1. `pnpm --filter houston-web fake-host` + `VITE_NEW_ENGINE=1 pnpm --filter houston-web dev`, open `http://localhost:1430`, switch Settings → Appearance → Dark.
2. Open **New agent** → pick a template: the textarea/footer hairlines vanish and provider-row hovers darken instead of lighten.
3. In a chat, the attachment context menu and the progress card render solid white; an Edit-tool error renders a pink `red-50` chip.
4. In DevTools: `document.querySelector('.dark\\:bg-input\\/30')` styles never change when `data-theme` flips — the variant is dead.

**After:**
1. Same flows: every surface stays dark, hairlines visible, hovers lighten.
2. Computed-style probe confirms `dark:` utilities activate when `data-theme="dark"` is set.
3. Light mode is visually unchanged (screenshot-compared before/after).
4. `pnpm check` clean, `pnpm -r typecheck` passes, `houston-web` 43/43 unit + 18/18 Playwright e2e pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)