### PR TITLE
fix(chat): logged-out send settles as the persistent reconnect card (HOU-676)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -6,6 +6,7 @@ import { SignInScreen } from "./components/auth/sign-in-screen";
 import { MigrationReconnectScreen } from "./components/onboarding/migration-reconnect-screen";
 import { isFirstRun } from "./components/onboarding/missions/onboarding-flow";
 import { PersonalAssistantOnboarding } from "./components/onboarding/personal-assistant-onboarding";
+import { ProviderLoginFallback } from "./components/shell/provider-login-fallback";
 import { WorkspaceShell } from "./components/shell/workspace-shell";
 import { useAgentInvalidation } from "./hooks/use-agent-invalidation";
 import { useAnalyticsSubscriber } from "./hooks/use-analytics-subscriber";
@@ -249,8 +250,22 @@ export default function App() {
   // without a provider anyway). Falls through the instant a provider connects or
   // the user dismisses — see useMigrationReconnect for the full trigger.
   if (migrationReconnect.show) {
-    return <MigrationReconnectScreen onDone={migrationReconnect.dismiss} />;
+    return (
+      <>
+        <ProviderLoginFallback />
+        <MigrationReconnectScreen onDone={migrationReconnect.dismiss} />
+      </>
+    );
   }
 
-  return <WorkspaceShell toasts={mappedToasts} onDismissToast={dismissToast} />;
+  // The fallback rides alongside the shell so a sign-in launched from a
+  // surface without its own login handler (the in-chat reconnect card) still
+  // opens the browser / dialog. Onboarding + tutorial mount their own handler
+  // (the login mission), so they don't need it.
+  return (
+    <>
+      <ProviderLoginFallback />
+      <WorkspaceShell toasts={mappedToasts} onDismissToast={dismissToast} />
+    </>
+  );
 }

--- a/app/src/components/onboarding/missions/use-provider-login-events.ts
+++ b/app/src/components/onboarding/missions/use-provider-login-events.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 import { subscribeHoustonEvents } from "../../../lib/events";
 import { osIsTauri } from "../../../lib/os-bridge";
 import { tauriSystem } from "../../../lib/tauri";
+import { claimProviderLoginSurface } from "../../shell/provider-login-surface";
 import { shouldOpenLoginUrlDirectly } from "../../shell/provider-login-url";
 
 /** The remote / device-code fallback the mission renders a dialog for. */
@@ -47,7 +48,10 @@ export function useProviderLoginEvents(opts: {
 
   const { providerId } = opts;
   useEffect(() => {
-    return subscribeHoustonEvents((ev: HoustonEvent) => {
+    // This step owns `ProviderLoginUrl` while mounted — the shell's global
+    // fallback stands down so the URL is never opened twice.
+    const release = claimProviderLoginSurface();
+    const off = subscribeHoustonEvents((ev: HoustonEvent) => {
       if (ev.type === "ProviderLoginUrl") {
         if (ev.data.provider !== providerId) return;
         if (
@@ -83,6 +87,10 @@ export function useProviderLoginEvents(opts: {
         // screen to connected and advances.
       }
     });
+    return () => {
+      off();
+      release();
+    };
   }, [providerId]);
 
   return { dialog, closeDialog: () => setDialog(null) };

--- a/app/src/components/shell/provider-error-cards/auth.tsx
+++ b/app/src/components/shell/provider-error-cards/auth.tsx
@@ -6,21 +6,31 @@
  * (never a hand-picked brand logo) and a text-only `RowCardButton`.
  *
  * Reconnect lifecycle (the button must not fire-and-forget):
- * `launchLogin` resolves when the engine SPAWNS the login CLI, not when
- * the user finishes the browser flow — completion arrives later as the
- * `ProviderLoginComplete` WS event (the same signal Settings uses to
- * flip its chip). So the card holds a "finish in your browser" state
- * until that event lands, then flips to a green confirmation with a
- * "try again" CTA, or shows the failure and re-arms the button. A
- * benign cancel (`success:false`, no error) just re-arms.
+ * `launchLogin` resolves when the engine STARTS the sign-in flow, not
+ * when the user finishes it in the browser — completion arrives later as
+ * the `ProviderLoginComplete` WS event (the same signal Settings uses to
+ * flip its chip). So the card holds a "finish in your browser" state —
+ * where the pill becomes a Cancel that frees the login slot and re-arms
+ * (lost the OAuth tab, wrong account, second thoughts) — until that
+ * event lands, then flips to a green confirmation, or shows the failure
+ * and re-arms the button. A benign cancel (`success:false`, no error)
+ * just re-arms.
  *
- * Every press goes through cancelLogin → launchLogin: the engine keeps
+ * The confirmation's shape depends on what failed. A refused SEND (the
+ * card carries `failed_prompt` — the message never reached the engine)
+ * resends it automatically, once: the user already said what they
+ * wanted, so signing in IS the remaining intent, and the pill settles
+ * into a disabled "Signed in" badge. A mid-turn failure (token expired
+ * during a live turn) keeps the explicit "Try again" CTA — re-running a
+ * turn that already has server-side context stays a user decision.
+ *
+ * Every launch goes through cancelLogin → launchLogin: the engine keeps
  * one login slot per provider and rejects a second launch as "already
- * pending", so relaunching from the waiting state (lost the OAuth tab)
- * must free the slot first. cancelLogin is idempotent, so the first
- * press pays one no-op call. The benign ProviderLoginComplete our own
- * cancel triggers is ignored via `relaunchingRef` so the card does not
- * flicker back to idle mid-relaunch.
+ * pending", so a relaunch after a cancel (or a stale slot from a
+ * previous run) must free the slot first. cancelLogin is idempotent, so
+ * the first press pays one no-op call. The benign ProviderLoginComplete
+ * our own cancel triggers is ignored via `relaunchingRef` so the card
+ * does not flicker back to idle mid-relaunch.
  */
 
 import type { ProviderError } from "@houston-ai/chat";
@@ -45,14 +55,26 @@ export function UnauthenticatedCard({
   error: Extract<ProviderError, { kind: "unauthenticated" }>;
   onRetry?: () => Promise<void> | void;
 }) {
-  const { t } = useTranslation("shell");
+  const { t } = useTranslation(["shell", "common"]);
   const setAuthRequired = useUIStore((s) => s.setAuthRequired);
   const [phase, setPhase] = useState<LoginPhase>("idle");
   const [launching, setLaunching] = useState(false);
   const [failureDetail, setFailureDetail] = useState<string | null>(null);
   const [retrying, setRetrying] = useState(false);
   const relaunchingRef = useRef(false);
+  // The auto-resend must fire ONCE per card even if the provider completes
+  // several logins while the chat stays open — a second fire would send the
+  // same message twice.
+  const autoResendFiredRef = useRef(false);
   const provider = providerLabel(error.provider);
+  // A refused SEND (the message never reached the engine): reconnecting
+  // completes the user's stated intent, so the reply is fetched without
+  // another press. Mid-turn failures (no failed_prompt) keep the explicit CTA.
+  const autoResend = !!error.failed_prompt;
+  // In a ref so the subscription mounts once — resubscribing on every parent
+  // render could drop a completion event in the gap.
+  const onRetryRef = useRef(onRetry);
+  onRetryRef.current = onRetry;
 
   useEffect(() => {
     return subscribeHoustonEvents((ev: HoustonEvent) => {
@@ -67,6 +89,16 @@ export function UnauthenticatedCard({
         if (useUIStore.getState().authRequired === error.provider) {
           setAuthRequired(null);
         }
+        if (autoResend && onRetryRef.current && !autoResendFiredRef.current) {
+          autoResendFiredRef.current = true;
+          setRetrying(true);
+          void Promise.resolve(onRetryRef.current())
+            .catch(() => {
+              // The send already surfaced its own failure (call()'s toast +
+              // Report bug); this catch only stops an unhandled rejection.
+            })
+            .finally(() => setRetrying(false));
+        }
       } else if (ev.data.error) {
         setPhase("failed");
         setFailureDetail(ev.data.error);
@@ -78,7 +110,7 @@ export function UnauthenticatedCard({
         setPhase("idle");
       }
     });
-  }, [error.provider, setAuthRequired]);
+  }, [error.provider, setAuthRequired, autoResend]);
 
   // Map every cause to a body string so the user always sees a reason
   // (instead of a generic "session expired" wall). Keeps the card
@@ -118,6 +150,16 @@ export function UnauthenticatedCard({
     }
   };
 
+  // Waiting-state Cancel: free the runtime's login slot for real (idempotent —
+  // a no-pending cancel is benign) and re-arm so the user can relaunch.
+  const cancelSignIn = async () => {
+    try {
+      await tauriProvider.cancelLogin(error.provider);
+    } finally {
+      setPhase("idle");
+    }
+  };
+
   const sendAgain = async () => {
     if (!onRetry || retrying) return;
     setRetrying(true);
@@ -136,16 +178,31 @@ export function UnauthenticatedCard({
           title={t("providerError.unauthenticated.reconnectedTitle", {
             provider,
           })}
-          description={t("providerError.unauthenticated.reconnectedBody", {
-            provider,
-          })}
+          description={t(
+            autoResend
+              ? "providerError.unauthenticated.reconnectedResending"
+              : "providerError.unauthenticated.reconnectedBody",
+            { provider },
+          )}
           action={
-            onRetry && (
+            autoResend ? (
+              // The resend fired itself — the pill is a status badge, not an
+              // action (it spins while the resend request is in flight).
               <RowCardButton
-                label={t("providerError.unauthenticated.sendAgain")}
-                onClick={sendAgain}
+                label={t("providerError.unauthenticated.signedIn")}
+                onClick={() => {}}
+                disabled
                 loading={retrying}
+                variant="outline"
               />
+            ) : (
+              onRetry && (
+                <RowCardButton
+                  label={t("providerError.unauthenticated.sendAgain")}
+                  onClick={sendAgain}
+                  loading={retrying}
+                />
+              )
             )
           }
         />
@@ -170,12 +227,22 @@ export function UnauthenticatedCard({
               : t(bodyKey, { provider })
         }
         action={
-          <RowCardButton
-            label={t("providerError.unauthenticated.reconnect")}
-            onClick={reconnect}
-            loading={launching}
-            variant={waiting ? "outline" : "default"}
-          />
+          waiting ? (
+            // The wait is on the user's browser, not on Houston — the useful
+            // action here is bailing out (lost the tab, wrong account), which
+            // re-arms the Reconnect button.
+            <RowCardButton
+              label={t("common:actions.cancel")}
+              onClick={cancelSignIn}
+              variant="outline"
+            />
+          ) : (
+            <RowCardButton
+              label={t("providerError.unauthenticated.reconnect")}
+              onClick={reconnect}
+              loading={launching}
+            />
+          )
         }
       />
     </div>

--- a/app/src/components/shell/provider-error-cards/not-connected.ts
+++ b/app/src/components/shell/provider-error-cards/not-connected.ts
@@ -1,0 +1,60 @@
+import type { FeedItem, ProviderError } from "@houston-ai/chat";
+
+/**
+ * Pure helpers for the not-connected reconnect card (HOU-676).
+ *
+ * When the TS engine refuses a send because no provider is connected, the SDK
+ * settles the turn as a typed `unauthenticated` card. Two things about that
+ * card only the SURFACE can resolve:
+ *
+ *  - `provider` may be empty — the runtime can't name one (nothing is
+ *    connected) and the SDK only knows the composer's pick when the send
+ *    carried an explicit switch. The chat itself always knows its provider.
+ *  - `failed_prompt` marks a send that never reached the engine: retrying
+ *    with the generic "try again" prompt would arrive with no context, so
+ *    "Send again" must resend the original text.
+ */
+
+/**
+ * Label a provider-error card with THIS chat's provider when the engine
+ * couldn't name one. Never rewrites a card that already names a provider —
+ * a foreign provider's card must stay honest about who failed.
+ */
+export function resolveProviderErrorForChat(
+  err: ProviderError,
+  chatProvider: string,
+): ProviderError {
+  if (err.provider) return err;
+  return { ...err, provider: chatProvider };
+}
+
+/**
+ * What the card's retry CTA should send: the refused original prompt when the
+ * message never reached the engine, else the caller's generic retry prompt
+ * (the turn's context is already server-side for live-turn failures).
+ */
+export function providerErrorRetryText(
+  err: ProviderError,
+  genericRetryPrompt: string,
+): string {
+  return err.kind === "unauthenticated" && err.failed_prompt
+    ? err.failed_prompt
+    : genericRetryPrompt;
+}
+
+/**
+ * Whether a feed item is the persisted inline reconnect card for THIS chat's
+ * provider — the signal that the store-driven (auto-dismissing) card must not
+ * also render. An empty provider on the card counts as this chat's: it means
+ * NO provider was connected at all, which necessarily includes this one.
+ */
+export function isInlineAuthCardForChat(
+  item: FeedItem,
+  chatProvider: string,
+): boolean {
+  return (
+    item.feed_type === "provider_error" &&
+    item.data.kind === "unauthenticated" &&
+    (item.data.provider === chatProvider || item.data.provider === "")
+  );
+}

--- a/app/src/components/shell/provider-error-cards/not-connected.ts
+++ b/app/src/components/shell/provider-error-cards/not-connected.ts
@@ -29,7 +29,18 @@ export function resolveProviderErrorForChat(
 }
 
 /**
- * What the card's retry CTA should send: the refused original prompt when the
+ * Whether this card's retry re-delivers the ORIGINAL refused prompt (the send
+ * never reached the engine). Such a retry fires automatically on reconnect
+ * and must NOT push a second user bubble — the original bubble already shows
+ * the message, and a duplicate would read as a double send. A generic retry
+ * (live-turn failure) is a new message and keeps its bubble.
+ */
+export function resendsOriginalPrompt(err: ProviderError): boolean {
+  return err.kind === "unauthenticated" && !!err.failed_prompt;
+}
+
+/**
+ * What the card's retry should send: the refused original prompt when the
  * message never reached the engine, else the caller's generic retry prompt
  * (the turn's context is already server-side for live-turn failures).
  */

--- a/app/src/components/shell/provider-login-fallback.tsx
+++ b/app/src/components/shell/provider-login-fallback.tsx
@@ -1,0 +1,96 @@
+import type { HoustonEvent } from "@houston-ai/core";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { subscribeHoustonEvents } from "../../lib/events";
+import { osIsTauri } from "../../lib/os-bridge";
+import { PROVIDERS, type ProviderInfo } from "../../lib/providers";
+import { tauriSystem } from "../../lib/tauri";
+import { useUIStore } from "../../stores/ui";
+import { ProviderLoginDialog } from "./provider-login-dialog";
+import {
+  providerLoginFallbackAction,
+  providerLoginSurfaceClaimed,
+} from "./provider-login-surface";
+
+interface FallbackDialogState {
+  provider: ProviderInfo;
+  url: string;
+  userCode: string | null;
+}
+
+/**
+ * Shell-global consumer of last resort for `ProviderLoginUrl` (HOU-676).
+ *
+ * A sign-in launched from a surface WITHOUT its own login handler — the
+ * in-chat reconnect card, the store-driven card — used to emit the OAuth URL
+ * into the void: the runtime had started the flow, but nothing opened the
+ * browser, so the button read as dead. Mounted once in the shell, this acts
+ * exactly like the dedicated handlers (open the browser for a desktop
+ * loopback flow, show the dialog for device-code / remote flows) and stands
+ * down whenever a dedicated surface holds the claim
+ * (`provider-login-surface.ts`).
+ */
+export function ProviderLoginFallback() {
+  const { t } = useTranslation("providers");
+  const addToast = useUIStore((s) => s.addToast);
+  const [dialog, setDialog] = useState<FallbackDialogState | null>(null);
+
+  useEffect(() => {
+    return subscribeHoustonEvents((ev: HoustonEvent) => {
+      if (ev.type === "ProviderLoginUrl") {
+        const action = providerLoginFallbackAction({
+          claimed: providerLoginSurfaceClaimed(),
+          isDesktop: osIsTauri(),
+          userCode: ev.data.user_code,
+        });
+        if (action === "ignore") return;
+        const prov = PROVIDERS.find((p) => p.id === ev.data.provider);
+        if (action === "open") {
+          // Desktop loopback flow: pi's in-process callback server finishes
+          // the exchange; the client only opens the URL. Surface a failed
+          // open — the launching card sits in "waiting" otherwise.
+          tauriSystem.openUrl(ev.data.url).catch((err) => {
+            addToast({
+              title: t("toast.signInFailed", {
+                provider: prov?.name ?? ev.data.provider,
+              }),
+              description: err instanceof Error ? err.message : String(err),
+              variant: "error",
+            });
+          });
+          return;
+        }
+        if (prov) {
+          // Device-code / remote flow: show the dialog. Keep a code already
+          // shown if a later URL-only frame arrives for the same provider
+          // (codex's device flow can emit twice).
+          setDialog((current) => ({
+            provider: prov,
+            url: ev.data.url,
+            userCode:
+              ev.data.user_code ??
+              (current?.provider.id === prov.id ? current.userCode : null),
+          }));
+        }
+        return;
+      }
+      if (ev.type === "ProviderLoginComplete") {
+        // Only clear a dialog showing THIS provider — a completion for a
+        // different provider must not clobber an in-flight sign-in.
+        setDialog((current) =>
+          current?.provider.id === ev.data.provider ? null : current,
+        );
+      }
+    });
+  }, [addToast, t]);
+
+  if (!dialog) return null;
+  return (
+    <ProviderLoginDialog
+      provider={dialog.provider}
+      url={dialog.url}
+      userCode={dialog.userCode}
+      onClose={() => setDialog(null)}
+    />
+  );
+}

--- a/app/src/components/shell/provider-login-surface.ts
+++ b/app/src/components/shell/provider-login-surface.ts
@@ -1,0 +1,49 @@
+/**
+ * Who acts on a `ProviderLoginUrl` event (HOU-676).
+ *
+ * On the v3 wire the runtime can't touch the user's browser: the adapter
+ * surfaces the OAuth URL as a bus event and expects the ACTIVE view to act on
+ * it. The AI hub, the provider picker, and the onboarding login step each
+ * mount a handler — but a login can also be launched from surfaces that don't
+ * (the in-chat reconnect card, the store-driven card), and an event nobody
+ * consumes is a sign-in button that silently does nothing.
+ *
+ * So the shell mounts ONE global fallback (`ProviderLoginFallback`), and every
+ * dedicated login surface CLAIMS the event while mounted. The fallback acts
+ * only when no claim is held — never alongside a dedicated surface, which
+ * would double-open the browser or stack two dialogs.
+ */
+
+let claims = 0;
+
+/** Mark a dedicated login surface as mounted. Returns the release function. */
+export function claimProviderLoginSurface(): () => void {
+  claims += 1;
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    claims -= 1;
+  };
+}
+
+/** Whether any dedicated login surface currently owns `ProviderLoginUrl`. */
+export function providerLoginSurfaceClaimed(): boolean {
+  return claims > 0;
+}
+
+/**
+ * What the global fallback should do with a `ProviderLoginUrl` event:
+ * nothing when a dedicated surface owns the event; otherwise open the
+ * browser directly on desktop loopback flows (no code to show), or surface
+ * the dialog for device-code / remote flows. Mirrors the dedicated
+ * handlers' own branch (`shouldOpenLoginUrlDirectly`).
+ */
+export function providerLoginFallbackAction(opts: {
+  claimed: boolean;
+  isDesktop: boolean;
+  userCode: string | null | undefined;
+}): "ignore" | "open" | "dialog" {
+  if (opts.claimed) return "ignore";
+  return opts.isDesktop && !opts.userCode ? "open" : "dialog";
+}

--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -26,6 +26,7 @@ import { OpenAiCompatibleDialog } from "./openai-compatible-dialog";
 import { ProviderApiKeyDialog } from "./provider-api-key-dialog";
 import { ComingSoonCard, ProviderCard } from "./provider-cards";
 import { ProviderLoginDialog } from "./provider-login-dialog";
+import { claimProviderLoginSurface } from "./provider-login-surface";
 import { shouldOpenLoginUrlDirectly } from "./provider-login-url";
 import { useCopilotConnect } from "./use-copilot-connect";
 
@@ -149,6 +150,9 @@ export function ProviderPicker({ onSelect }: Props) {
   // setState avoids stale-closure reads when several providers fire
   // events concurrently.
   useEffect(() => {
+    // This surface owns `ProviderLoginUrl` while mounted — the shell's global
+    // fallback stands down so the URL is never opened twice.
+    const release = claimProviderLoginSurface();
     const off = subscribeHoustonEvents((ev: HoustonEvent) => {
       if (ev.type === "ProviderLoginUrl") {
         // Resolve the display name from the connect list first so the merged
@@ -226,7 +230,10 @@ export function ProviderPicker({ onSelect }: Props) {
         loadStatuses();
       }
     });
-    return off;
+    return () => {
+      off();
+      release();
+    };
   }, [addToast, loadStatuses, t, visibleProviders]);
 
   // Start the OAuth device/loopback login for a provider. `enterpriseDomain` is

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -96,6 +96,11 @@ import { NewMissionPickerDialog } from "./new-mission-picker-dialog";
 import { ProviderSwitchDialog } from "./provider-switch-dialog";
 import { SelectedSkillChip } from "./selected-skill-chip";
 import { ProviderErrorCard } from "./shell/provider-error-card";
+import {
+  isInlineAuthCardForChat,
+  providerErrorRetryText,
+  resolveProviderErrorForChat,
+} from "./shell/provider-error-cards/not-connected";
 import { ProviderReconnectCard } from "./shell/provider-reconnect-card";
 import { ToolRuntimeErrorCard } from "./shell/tool-runtime-error-card";
 import { SkillCard } from "./skill-card";
@@ -719,12 +724,26 @@ export function useAgentChatPanel({
       // shows `msg.content` ("") — i.e. NOTHING. That's why a 429 card and the
       // OpenAI reconnect card never appeared in chat.
       if (msg.providerError) {
+        // The not-connected card arrives provider-less (the refusal can't name
+        // one — nothing was connected); label it with THIS chat's provider so
+        // its reconnect flow targets the provider the send actually used.
+        const providerError = resolveProviderErrorForChat(
+          msg.providerError,
+          effectiveProvider,
+        );
         return (
           <ProviderErrorCard
-            error={msg.providerError}
+            error={providerError}
             onRetry={async () => {
               if (!path || !selectedSessionKey) return;
-              const text = t("chat:toolRuntimeError.retryPrompt");
+              // A refused not-connected send never reached the engine —
+              // "Send again" resends the original message verbatim. Live-turn
+              // failures keep the generic retry prompt (their context is
+              // already server-side).
+              const text = providerErrorRetryText(
+                providerError,
+                t("chat:toolRuntimeError.retryPrompt"),
+              );
               await tauriChat.send(path, text, selectedSessionKey, {
                 providerOverride: effectiveProvider,
                 modelOverride: effectiveModel,
@@ -771,11 +790,8 @@ export function useAgentChatPanel({
       // (auto-dismisses) when the provider's auth probe is unreliable, e.g.
       // codex reporting "authenticated" off a stale ~/.codex/auth.json after a
       // server-side session kill. One card, and it stays put.
-      const hasInlineAuthCard = feedItems.some(
-        (it) =>
-          it.feed_type === "provider_error" &&
-          it.data.kind === "unauthenticated" &&
-          it.data.provider === effectiveProvider,
+      const hasInlineAuthCard = feedItems.some((it) =>
+        isInlineAuthCardForChat(it, effectiveProvider),
       );
       if (hasInlineAuthCard) return null;
       const signalKey = providerAuthSignalKey(feedItems);

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -99,6 +99,7 @@ import { ProviderErrorCard } from "./shell/provider-error-card";
 import {
   isInlineAuthCardForChat,
   providerErrorRetryText,
+  resendsOriginalPrompt,
   resolveProviderErrorForChat,
 } from "./shell/provider-error-cards/not-connected";
 import { ProviderReconnectCard } from "./shell/provider-reconnect-card";
@@ -737,9 +738,9 @@ export function useAgentChatPanel({
             onRetry={async () => {
               if (!path || !selectedSessionKey) return;
               // A refused not-connected send never reached the engine —
-              // "Send again" resends the original message verbatim. Live-turn
-              // failures keep the generic retry prompt (their context is
-              // already server-side).
+              // the card resends the original message verbatim (and fires
+              // itself on reconnect). Live-turn failures keep the generic
+              // retry prompt (their context is already server-side).
               const text = providerErrorRetryText(
                 providerError,
                 t("chat:toolRuntimeError.retryPrompt"),
@@ -749,10 +750,14 @@ export function useAgentChatPanel({
                 modelOverride: effectiveModel,
                 effortOverride: effectiveEffort,
               });
-              pushFeedItem(path, selectedSessionKey, {
-                feed_type: "user_message",
-                data: text,
-              });
+              // The refused prompt's bubble is already in the feed; only a
+              // generic retry is a NEW message that needs one.
+              if (!resendsOriginalPrompt(providerError)) {
+                pushFeedItem(path, selectedSessionKey, {
+                  feed_type: "user_message",
+                  data: text,
+                });
+              }
             }}
             // "Pick another model" pops the MODEL picker (not the Skills picker);
             // "Switch to <fallback>" applies it directly on the same provider.

--- a/app/src/hooks/provider-connections/use-provider-login-events.ts
+++ b/app/src/hooks/provider-connections/use-provider-login-events.ts
@@ -1,5 +1,6 @@
 import type { HoustonEvent } from "@houston-ai/core";
 import { type Dispatch, type SetStateAction, useEffect } from "react";
+import { claimProviderLoginSurface } from "../../components/shell/provider-login-surface";
 import { shouldOpenLoginUrlDirectly } from "../../components/shell/provider-login-url";
 import { subscribeHoustonEvents } from "../../lib/events";
 import { osIsTauri } from "../../lib/os-bridge";
@@ -40,6 +41,9 @@ export function useProviderLoginEvents({
   setPending,
 }: Args): void {
   useEffect(() => {
+    // This surface owns `ProviderLoginUrl` while mounted — the shell's global
+    // fallback stands down so the URL is never opened twice.
+    const release = claimProviderLoginSurface();
     const off = subscribeHoustonEvents((ev: HoustonEvent) => {
       if (ev.type === "ProviderLoginUrl") {
         // Resolve the display name from the connect list first so the merged
@@ -117,7 +121,10 @@ export function useProviderLoginEvents({
         loadStatuses();
       }
     });
-    return off;
+    return () => {
+      off();
+      release();
+    };
   }, [
     visibleProviders,
     addToast,

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -314,6 +314,8 @@
       "waiting": "Finish signing in using your browser",
       "reconnectedTitle": "Reconnected to {{provider}}",
       "reconnectedBody": "You are signed in again. Pick up where you left off.",
+      "reconnectedResending": "You are signed in again. Houston is answering your message now.",
+      "signedIn": "Signed in",
       "sendAgain": "Try again",
       "failedBody": "The {{provider}} sign-in did not finish. Try again. {{detail}}"
     },

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -314,6 +314,8 @@
       "waiting": "Termina de iniciar sesión en tu navegador",
       "reconnectedTitle": "Reconectado a {{provider}}",
       "reconnectedBody": "Ya iniciaste sesión de nuevo. Continúa donde quedaste.",
+      "reconnectedResending": "Ya iniciaste sesión de nuevo. Houston está respondiendo tu mensaje ahora.",
+      "signedIn": "Sesión iniciada",
       "sendAgain": "Intentar de nuevo",
       "failedBody": "El inicio de sesión de {{provider}} no se completó. Inténtalo de nuevo. {{detail}}"
     },

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -299,6 +299,8 @@
       "waiting": "Conclua o login no seu navegador",
       "reconnectedTitle": "Reconectado a {{provider}}",
       "reconnectedBody": "Você entrou de novo. Continue de onde parou.",
+      "reconnectedResending": "Você entrou de novo. O Houston está respondendo sua mensagem agora.",
+      "signedIn": "Sessão iniciada",
       "sendAgain": "Tentar novamente",
       "failedBody": "O login de {{provider}} não foi concluído. Tente novamente. {{detail}}"
     },

--- a/app/tests/not-connected-card.test.ts
+++ b/app/tests/not-connected-card.test.ts
@@ -1,0 +1,115 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { FeedItem, ProviderError } from "@houston-ai/chat";
+import {
+  isInlineAuthCardForChat,
+  providerErrorRetryText,
+  resolveProviderErrorForChat,
+} from "../src/components/shell/provider-error-cards/not-connected.ts";
+
+// HOU-676: the not-connected refusal settles as a typed unauthenticated card
+// synthesized client-side. These helpers are the surface's half of that
+// contract: label a provider-less card with the chat's own provider, resend
+// the refused prompt (not the generic retry), and keep the auto-dismissing
+// store-driven card suppressed while the inline card is present.
+
+const notConnectedCard: ProviderError = {
+  kind: "unauthenticated",
+  provider: "",
+  cause: "no_credentials",
+  message: "No provider connected. Connect an AI provider first.",
+  failed_prompt: "hey",
+};
+
+describe("resolveProviderErrorForChat", () => {
+  it("labels a provider-less card with this chat's provider", () => {
+    const resolved = resolveProviderErrorForChat(notConnectedCard, "openai");
+    strictEqual(resolved.provider, "openai");
+  });
+
+  it("never rewrites a card that already names its provider", () => {
+    const wireCard: ProviderError = {
+      kind: "unauthenticated",
+      provider: "anthropic",
+      cause: "token_expired",
+      message: "session expired",
+    };
+    deepStrictEqual(resolveProviderErrorForChat(wireCard, "openai"), wireCard);
+  });
+});
+
+describe("providerErrorRetryText", () => {
+  it("resends the refused prompt when the send never reached the engine", () => {
+    strictEqual(providerErrorRetryText(notConnectedCard, "Try again"), "hey");
+  });
+
+  it("keeps the generic retry prompt for live-turn failures", () => {
+    const liveCard: ProviderError = {
+      kind: "unauthenticated",
+      provider: "anthropic",
+      cause: "token_expired",
+      message: "session expired",
+    };
+    strictEqual(providerErrorRetryText(liveCard, "Try again"), "Try again");
+    const rateLimited: ProviderError = {
+      kind: "rate_limited",
+      provider: "anthropic",
+      model: null,
+      retry_after_seconds: null,
+      message: "slow down",
+    };
+    strictEqual(providerErrorRetryText(rateLimited, "Try again"), "Try again");
+  });
+});
+
+describe("isInlineAuthCardForChat", () => {
+  const item = (data: ProviderError): FeedItem => ({
+    feed_type: "provider_error",
+    data,
+  });
+
+  it("matches this chat's provider and the provider-less refusal", () => {
+    strictEqual(
+      isInlineAuthCardForChat(
+        item({ ...notConnectedCard, provider: "openai" }),
+        "openai",
+      ),
+      true,
+    );
+    // Empty provider = NOTHING was connected, which includes this chat's.
+    strictEqual(
+      isInlineAuthCardForChat(item(notConnectedCard), "openai"),
+      true,
+    );
+  });
+
+  it("never matches a foreign provider's card or other kinds", () => {
+    strictEqual(
+      isInlineAuthCardForChat(
+        item({ ...notConnectedCard, provider: "anthropic" }),
+        "openai",
+      ),
+      false,
+    );
+    strictEqual(
+      isInlineAuthCardForChat(
+        item({
+          kind: "rate_limited",
+          provider: "openai",
+          model: null,
+          retry_after_seconds: null,
+          message: "slow down",
+        }),
+        "openai",
+      ),
+      false,
+    );
+    strictEqual(
+      isInlineAuthCardForChat(
+        { feed_type: "system_message", data: "hello" } as FeedItem,
+        "openai",
+      ),
+      false,
+    );
+  });
+});

--- a/app/tests/not-connected-card.test.ts
+++ b/app/tests/not-connected-card.test.ts
@@ -4,6 +4,7 @@ import type { FeedItem, ProviderError } from "@houston-ai/chat";
 import {
   isInlineAuthCardForChat,
   providerErrorRetryText,
+  resendsOriginalPrompt,
   resolveProviderErrorForChat,
 } from "../src/components/shell/provider-error-cards/not-connected.ts";
 
@@ -35,6 +36,34 @@ describe("resolveProviderErrorForChat", () => {
       message: "session expired",
     };
     deepStrictEqual(resolveProviderErrorForChat(wireCard, "openai"), wireCard);
+  });
+});
+
+describe("resendsOriginalPrompt", () => {
+  it("marks the refused-send card: auto-resend, no duplicate bubble", () => {
+    strictEqual(resendsOriginalPrompt(notConnectedCard), true);
+  });
+
+  it("never marks live-turn failures: explicit CTA, bubble kept", () => {
+    strictEqual(
+      resendsOriginalPrompt({
+        kind: "unauthenticated",
+        provider: "anthropic",
+        cause: "token_expired",
+        message: "session expired",
+      }),
+      false,
+    );
+    strictEqual(
+      resendsOriginalPrompt({
+        kind: "rate_limited",
+        provider: "anthropic",
+        model: null,
+        retry_after_seconds: null,
+        message: "slow down",
+      }),
+      false,
+    );
   });
 });
 

--- a/app/tests/provider-login-fallback.test.ts
+++ b/app/tests/provider-login-fallback.test.ts
@@ -1,0 +1,94 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  claimProviderLoginSurface,
+  providerLoginFallbackAction,
+  providerLoginSurfaceClaimed,
+} from "../src/components/shell/provider-login-surface.ts";
+
+// HOU-676: a sign-in launched from a surface without its own login handler
+// (the in-chat reconnect card) emitted `ProviderLoginUrl` into the void — the
+// runtime had started the OAuth flow but nothing opened the browser, so the
+// button read as dead. The shell-global fallback acts on the event exactly
+// when no dedicated login surface (AI hub, picker, onboarding step) is
+// mounted; these tests pin the claim lifecycle and the routing decision.
+
+describe("claimProviderLoginSurface", () => {
+  it("claims while held, releases on the returned function, and is idempotent", () => {
+    strictEqual(providerLoginSurfaceClaimed(), false);
+    const releaseA = claimProviderLoginSurface();
+    const releaseB = claimProviderLoginSurface();
+    strictEqual(providerLoginSurfaceClaimed(), true);
+    releaseA();
+    // The other surface still holds a claim.
+    strictEqual(providerLoginSurfaceClaimed(), true);
+    // Double release (a re-run effect cleanup) must not free B's claim.
+    releaseA();
+    strictEqual(providerLoginSurfaceClaimed(), true);
+    releaseB();
+    strictEqual(providerLoginSurfaceClaimed(), false);
+  });
+});
+
+describe("providerLoginFallbackAction", () => {
+  it("stands down whenever a dedicated surface holds the claim", () => {
+    strictEqual(
+      providerLoginFallbackAction({
+        claimed: true,
+        isDesktop: true,
+        userCode: null,
+      }),
+      "ignore",
+    );
+    strictEqual(
+      providerLoginFallbackAction({
+        claimed: true,
+        isDesktop: false,
+        userCode: "ABCD-1234",
+      }),
+      "ignore",
+    );
+  });
+
+  it("opens the browser directly for the desktop loopback flow (no code to show)", () => {
+    strictEqual(
+      providerLoginFallbackAction({
+        claimed: false,
+        isDesktop: true,
+        userCode: null,
+      }),
+      "open",
+    );
+    strictEqual(
+      providerLoginFallbackAction({
+        claimed: false,
+        isDesktop: true,
+        userCode: undefined,
+      }),
+      "open",
+    );
+  });
+
+  it("shows the dialog for device-code and web/remote flows", () => {
+    // Device code: the user must read the one-time code, browser-open alone
+    // would strand them.
+    strictEqual(
+      providerLoginFallbackAction({
+        claimed: false,
+        isDesktop: true,
+        userCode: "ABCD-1234",
+      }),
+      "dialog",
+    );
+    // Web client: popup-blockers eat a non-gesture open; the dialog's button
+    // gives the user gesture.
+    strictEqual(
+      providerLoginFallbackAction({
+        claimed: false,
+        isDesktop: false,
+        userCode: null,
+      }),
+      "dialog",
+    );
+  });
+});

--- a/packages/host/src/routes/setup-runtime.test.ts
+++ b/packages/host/src/routes/setup-runtime.test.ts
@@ -117,6 +117,9 @@ test("login + status dispatch to a hidden setup agent on the PERSONAL workspace"
     for (const [method, path] of [
       ["POST", "auth/openai-codex/login?deviceAuth=false"],
       ["POST", "auth/openai-codex/login/complete"],
+      // The reconnect card's every press goes cancel → launch, so a blocked
+      // cancel 404s and the login never launches (HOU-676).
+      ["POST", "auth/openai-codex/login/cancel"],
       ["GET", "auth/status"],
       ["GET", "providers"],
     ] as const) {
@@ -129,6 +132,7 @@ test("login + status dispatch to a hidden setup agent on the PERSONAL workspace"
     expect(channel.dispatched.map((d) => d.rest)).toEqual([
       "auth/openai-codex/login",
       "auth/openai-codex/login/complete",
+      "auth/openai-codex/login/cancel",
       "auth/status",
       "providers",
     ]);

--- a/packages/host/src/routes/setup-runtime.ts
+++ b/packages/host/src/routes/setup-runtime.ts
@@ -39,7 +39,11 @@ export interface SetupRuntimeDeps {
 function allowedRest(method: string, rest: string): boolean {
   if (method === "GET") return rest === "providers" || rest === "auth/status";
   if (method === "POST") {
-    return /^auth\/[^/]+\/login(\/complete)?$/.test(rest);
+    // login/cancel is part of the connect surface: the reconnect card's every
+    // press goes cancel → launch (the runtime keeps one login slot per
+    // provider), so blocking cancel 404s the chain and the login never
+    // launches (HOU-676).
+    return /^auth\/[^/]+\/login(\/(complete|cancel))?$/.test(rest);
   }
   return false;
 }

--- a/packages/sdk/src/modules/turns/index.ts
+++ b/packages/sdk/src/modules/turns/index.ts
@@ -47,10 +47,19 @@ export function createTurnsModule(ctx: ModuleContext) {
    */
   const send = async (input: TurnSendInput): Promise<void> => {
     const client = ctx.clientFor(input.agentId ?? "");
-    if (input.model !== undefined || input.effort !== undefined)
-      await client.setSettings(
-        await resolveModelSettings(client, input.model, input.effort),
+    // Remember the provider the pick resolved to: it labels the typed
+    // reconnect card when the runtime refuses the send as not-connected
+    // (the refusal itself can't name a provider — nothing is connected).
+    let provider: string | undefined;
+    if (input.model !== undefined || input.effort !== undefined) {
+      const settings = await resolveModelSettings(
+        client,
+        input.model,
+        input.effort,
       );
+      await client.setSettings(settings);
+      provider = settings.activeProvider;
+    }
     const output = new MultiplexFeedOutput([vm, ...external]);
     void streamTurn(
       client,
@@ -59,7 +68,7 @@ export function createTurnsModule(ctx: ModuleContext) {
       input.text,
       output,
       registry,
-      { nonce: input.nonce },
+      { nonce: input.nonce, provider },
     );
   };
 
@@ -162,6 +171,7 @@ export {
 } from "./feed-output";
 export { type FeedFrame, historyToFeed } from "./history";
 export { observeConversation } from "./observe-stream";
+export { TURN_DIED_MESSAGE } from "./settle-from-history";
 export {
   SEND_IN_FLIGHT_MESSAGE,
   STREAM_FAILURE_BUDGET,
@@ -180,7 +190,6 @@ export type {
   TurnObserveInput,
   TurnSendInput,
 } from "./turn-inputs";
-export { TURN_DIED_MESSAGE } from "./turn-settle";
 export { type StreamTurnOptions, streamTurn } from "./turn-stream";
 export {
   type ConversationVM,

--- a/packages/sdk/src/modules/turns/settle-from-history.ts
+++ b/packages/sdk/src/modules/turns/settle-from-history.ts
@@ -1,0 +1,103 @@
+import type { ChatMessage } from "@houston/runtime-client";
+import {
+  finishErr,
+  finishOk,
+  push,
+  settleProviderErrorCard,
+  type TurnState,
+} from "./turn-settle";
+
+/**
+ * Settling a turn whose terminal frame was LOST — the reconnect resynced and
+ * the turn is over, so persisted history (complete once a turn ends) is the
+ * settle source. The live-frame settles live in turn-settle.ts.
+ */
+
+/**
+ * A turn that died without persisting a reply — the same copy the host's
+ * dead-pump reaper stamps on the terminal `error` frame it synthesizes
+ * (`packages/host/src/turn/relay-dialect.ts` TURN_DIED_MESSAGE), so the
+ * surface reads identically whether the server or this client detected it.
+ */
+export const TURN_DIED_MESSAGE = "The turn ended unexpectedly";
+
+/**
+ * Settle a turn whose terminal frame was lost. With a known `turnId` the
+ * settle is exact: adopt the assistant message persisted FOR THIS TURN
+ * (text/usage/providerError); no such message means the turn died before
+ * persisting a reply — an error surface with the server's own dead-turn
+ * copy, NEVER an empty "completed" render.
+ *
+ * Without turn ids (legacy servers / old histories) fall back to the trailing
+ * assistant message gated by `guard` — a heuristic with a known weakness:
+ * turn mode matches the newest user message against the prompt, so two
+ * identical prompts in a row can adopt the PREVIOUS turn's reply. When the
+ * guard rejects, the streamed accumulation is all there is: settle it as
+ * completed when text was streamed, else as the dead-turn error.
+ */
+export function settleFromHistory(
+  s: TurnState,
+  messages: ChatMessage[] | null,
+  turnId: string | undefined,
+  guard: (messages: ChatMessage[]) => boolean,
+): void {
+  if (messages && turnId) {
+    const reply = messages.find(
+      (m) => m.role === "assistant" && m.turnId === turnId,
+    );
+    if (reply) {
+      adoptReply(s, reply);
+      return;
+    }
+    finishErr(s, TURN_DIED_MESSAGE);
+    return;
+  }
+  if (messages) {
+    // Legacy fallback: no turn ids anywhere — trailing reply + guard.
+    const last = messages[messages.length - 1];
+    if (last?.role === "assistant" && guard(messages)) {
+      adoptReply(s, last);
+      return;
+    }
+  }
+  // History reload failed, or the legacy guard rejected the trailing reply:
+  // the streamed accumulation is all there is.
+  if (s.text) finishOk(s);
+  else finishErr(s, TURN_DIED_MESSAGE);
+}
+
+function adoptReply(s: TurnState, reply: ChatMessage): void {
+  if (reply.providerError) {
+    settleProviderErrorCard(s, reply.providerError);
+    return;
+  }
+  s.text = reply.content;
+  if (reply.usage) s.usage = reply.usage;
+  finishOk(s);
+}
+
+/**
+ * Refetch history and settle from it (`settleFromHistory`), then stop the
+ * subscription. A failed reload surfaces as a system message (no silent
+ * fallback) and the settle proceeds from the streamed accumulation — the UI
+ * must never hang.
+ */
+export async function reloadAndSettle(
+  s: TurnState,
+  reloadHistory: () => Promise<ChatMessage[]>,
+  turnId: string | undefined,
+  guard: (messages: ChatMessage[]) => boolean,
+  stop: () => void,
+): Promise<void> {
+  let messages: ChatMessage[] | null = null;
+  try {
+    messages = await reloadHistory();
+  } catch (e) {
+    push(s, {
+      feed_type: "system_message",
+      data: `Couldn't reload the conversation: ${e instanceof Error ? e.message : String(e)}`,
+    });
+  }
+  if (!s.settled) settleFromHistory(s, messages, turnId, guard);
+  stop();
+}

--- a/packages/sdk/src/modules/turns/turn-settle.test.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.test.ts
@@ -1,12 +1,8 @@
 import type { ChatMessage } from "@houston/runtime-client";
 import { expect, test } from "vitest";
 import type { FeedOutput } from "./feed-output";
-import {
-  newTurnState,
-  settleFromHistory,
-  TURN_DIED_MESSAGE,
-  type TurnState,
-} from "./turn-settle";
+import { settleFromHistory, TURN_DIED_MESSAGE } from "./settle-from-history";
+import { finishErr, newTurnState, type TurnState } from "./turn-settle";
 
 /**
  * settleFromHistory — the "terminal frame was lost" settle. With a turnId the
@@ -164,4 +160,83 @@ test("a failed history reload (null) still settles: streamed text as completed, 
 
   const withoutText = run(null, "t-1");
   expect(withoutText.s.terminal).toBe("error");
+});
+
+/**
+ * finishErr — the not-connected refusal (HOU-676). A logged-out send is
+ * refused BEFORE the message reaches the engine, so it must settle as the
+ * persistent typed reconnect card (which survives the reconnect and offers
+ * "Send again" with the original text) — never as the raw system message
+ * that only fed the auto-dismissing store-driven card.
+ */
+
+const NOT_CONNECTED = "No provider connected. Connect an AI provider first.";
+
+test("a not-connected refusal settles as the typed card carrying provider + failed prompt", () => {
+  const { items, statuses, output } = recorder();
+  const s = newTurnState("Houston/Bo", "activity-nc", output, {
+    provider: "openai",
+    prompt: "hey",
+  });
+  finishErr(s, NOT_CONNECTED);
+  expect(s.settled).toBe(true);
+  expect(s.terminal).toBe("needs_you");
+  expect(items).toContainEqual({
+    feed_type: "provider_error",
+    data: {
+      kind: "unauthenticated",
+      provider: "openai",
+      cause: "no_credentials",
+      message: NOT_CONNECTED,
+      failed_prompt: "hey",
+    },
+  });
+  // The card IS the surface: no raw system_message duplicate, and the
+  // invisible final_result stops the progress line.
+  expect(items.some((i) => i.feed_type === "system_message")).toBe(false);
+  expect(items.some((i) => i.feed_type === "final_result")).toBe(true);
+  // Status clears the loading flag with NO text — text would re-synthesize
+  // the "Session error:" echo that fed the auto-dismissing card.
+  expect(statuses).toEqual([["error", undefined]]);
+});
+
+test("a not-connected refusal without send context still cards (surface resolves the provider)", () => {
+  const { items, output } = recorder();
+  const s = newTurnState("Houston/Bo", "activity-nc", output);
+  finishErr(s, "No provider connected. Connect your subscription first.");
+  const card = items.find((i) => i.feed_type === "provider_error")?.data as {
+    provider: string;
+    failed_prompt?: string;
+  };
+  expect(card.provider).toBe("");
+  expect("failed_prompt" in card).toBe(false);
+});
+
+test("a real turn failure still settles as system_message + red error", () => {
+  const { items, statuses, output } = recorder();
+  const s = newTurnState("Houston/Bo", "activity-boom", output, {
+    provider: "openai",
+    prompt: "hey",
+  });
+  finishErr(s, "upstream exploded");
+  expect(s.terminal).toBe("error");
+  expect(items).toContainEqual({
+    feed_type: "system_message",
+    data: "upstream exploded",
+  });
+  expect(items.some((i) => i.feed_type === "provider_error")).toBe(false);
+  expect(statuses).toEqual([["error", "upstream exploded"]]);
+});
+
+test("a user stop still settles as the neutral needs_you, never a card", () => {
+  const { items, statuses, output } = recorder();
+  const s = newTurnState("Houston/Bo", "activity-stop", output);
+  finishErr(s, "Stopped by user");
+  expect(s.terminal).toBe("needs_you");
+  expect(items).toContainEqual({
+    feed_type: "system_message",
+    data: "Stopped by user",
+  });
+  expect(items.some((i) => i.feed_type === "provider_error")).toBe(false);
+  expect(statuses).toEqual([["error", undefined]]);
 });

--- a/packages/sdk/src/modules/turns/turn-settle.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.ts
@@ -1,18 +1,11 @@
-import type {
-  ChatMessage,
-  ProviderError,
-  TokenUsage,
-} from "@houston/runtime-client";
+import type { ProviderError, TokenUsage } from "@houston/runtime-client";
 import type { FeedOutput, TerminalBoardStatus } from "./feed-output";
 import { isNotConnectedError, isStoppedByUser } from "./turn-errors";
 
 /**
- * A turn that died without persisting a reply — the same copy the host's
- * dead-pump reaper stamps on the terminal `error` frame it synthesizes
- * (`packages/host/src/turn/relay-dialect.ts` TURN_DIED_MESSAGE), so the
- * surface reads identically whether the server or this client detected it.
+ * The turn state + live-frame settles. The lost-terminal-frame settle path
+ * (history reload) lives in settle-from-history.ts.
  */
-export const TURN_DIED_MESSAGE = "The turn ended unexpectedly";
 
 /** One streamed turn's accumulation + settle state (owned by TurnSink). */
 export interface TurnState {
@@ -20,6 +13,17 @@ export interface TurnState {
   sessionKey: string;
   /** Where every FeedItem / SessionStatus for this turn is emitted. */
   output: FeedOutput;
+  /**
+   * The provider this chat INTENDED to run on (the composer's pick, in the
+   * caller's id dialect). The runtime can't name one in its not-connected
+   * refusal — nothing is connected — so the reconnect card is labeled with
+   * this instead. Null when the caller had no pick (observer mode, no
+   * per-turn switch): the surface falls back to the chat's own provider.
+   */
+  provider: string | null;
+  /** The turn's prompt — carried on the not-connected card so "Send again"
+   *  can resend the exact text the runtime refused (it was never delivered). */
+  prompt: string | null;
   text: string;
   thinking: string;
   usage: TokenUsage | null;
@@ -31,11 +35,14 @@ export function newTurnState(
   agentPath: string,
   sessionKey: string,
   output: FeedOutput,
+  send?: { provider?: string; prompt?: string },
 ): TurnState {
   return {
     agentPath,
     sessionKey,
     output,
+    provider: send?.provider ?? null,
+    prompt: send?.prompt ?? null,
     text: "",
     thinking: "",
     usage: null,
@@ -70,24 +77,38 @@ export function finishOk(s: TurnState): void {
 
 /**
  * Settle an errored turn. A user Stop or a logged-out provider is a HANDLED
- * state (the message drives the in-chat surface): an invisible final_result
- * stops the progress line, an `error` status (with text only for
- * not-connected, which the reconnect card reads) clears the loading flag, and
- * the card lands on needs_you — never the red error state. Anything else is a
- * real failure.
+ * state: an invisible final_result stops the progress line, an `error` status
+ * clears the loading flag, and the card lands on needs_you — never the red
+ * error state. Anything else is a real failure.
+ *
+ * A logged-out provider refuses the SEND itself (409), so the message never
+ * reached the engine. That settles as the typed `unauthenticated` card — the
+ * stable inline reconnect surface with the reconnected → "Send again"
+ * lifecycle — NOT as a raw system message: the message-driven ephemeral card
+ * auto-dismisses the moment the provider reconnects, dead-ending the
+ * undelivered prompt with no reply and no affordance (HOU-676). The card
+ * carries the refused prompt so "Send again" resends it verbatim.
  */
 export function finishErr(s: TurnState, msg: string): void {
   if (s.settled) return;
+  if (isNotConnectedError(msg)) {
+    const card: ProviderError & { failed_prompt?: string } = {
+      kind: "unauthenticated",
+      // Empty when the caller had no pick — the surface resolves it to the
+      // chat's own provider (the runtime can't name one: nothing is connected).
+      provider: s.provider ?? "",
+      cause: "no_credentials",
+      message: msg,
+    };
+    if (s.prompt) card.failed_prompt = s.prompt;
+    settleProviderErrorCard(s, card);
+    return;
+  }
   s.settled = true;
   push(s, { feed_type: "system_message", data: msg });
-  if (isStoppedByUser(msg) || isNotConnectedError(msg)) {
+  if (isStoppedByUser(msg)) {
     invisibleFinal(s);
-    s.output.sessionStatus(
-      s.agentPath,
-      s.sessionKey,
-      "error",
-      isNotConnectedError(msg) ? msg : undefined,
-    );
+    s.output.sessionStatus(s.agentPath, s.sessionKey, "error");
     s.terminal = "needs_you";
     return;
   }
@@ -99,12 +120,13 @@ export function finishErr(s: TurnState, msg: string): void {
  * The turn's terminal surface for a typed provider failure — the runtime does
  * NOT emit a clean `done` after one (that would settle the chat as a success).
  * The typed card IS the message (no system_message); settle like the
- * not-connected path: invisible final_result, `error` status with no text,
- * card on needs_you.
+ * user-stop path: invisible final_result, `error` status with no text,
+ * card on needs_you. `failed_prompt` rides along only on the client-built
+ * not-connected card (see {@link finishErr}) — never on a wire frame.
  */
 export function settleProviderErrorCard(
   s: TurnState,
-  err: ProviderError,
+  err: ProviderError & { failed_prompt?: string },
 ): void {
   push(s, { feed_type: "provider_error", data: { ...err } });
   if (s.settled) return;
@@ -112,86 +134,4 @@ export function settleProviderErrorCard(
   invisibleFinal(s);
   s.output.sessionStatus(s.agentPath, s.sessionKey, "error");
   s.terminal = "needs_you";
-}
-
-/**
- * Settle a turn whose terminal frame was lost (the reconnect resynced and the
- * turn is over). Persisted history is complete once a turn ends, so with a
- * known `turnId` the settle is exact: adopt the assistant message persisted
- * FOR THIS TURN (text/usage/providerError); no such message means the turn
- * died before persisting a reply — an error surface with the server's own
- * dead-turn copy, NEVER an empty "completed" render.
- *
- * Without turn ids (legacy servers / old histories) fall back to the trailing
- * assistant message gated by `guard` — a heuristic with a known weakness:
- * turn mode matches the newest user message against the prompt, so two
- * identical prompts in a row can adopt the PREVIOUS turn's reply. When the
- * guard rejects, the streamed accumulation is all there is: settle it as
- * completed when text was streamed, else as the dead-turn error.
- */
-export function settleFromHistory(
-  s: TurnState,
-  messages: ChatMessage[] | null,
-  turnId: string | undefined,
-  guard: (messages: ChatMessage[]) => boolean,
-): void {
-  if (messages && turnId) {
-    const reply = messages.find(
-      (m) => m.role === "assistant" && m.turnId === turnId,
-    );
-    if (reply) {
-      adoptReply(s, reply);
-      return;
-    }
-    finishErr(s, TURN_DIED_MESSAGE);
-    return;
-  }
-  if (messages) {
-    // Legacy fallback: no turn ids anywhere — trailing reply + guard.
-    const last = messages[messages.length - 1];
-    if (last?.role === "assistant" && guard(messages)) {
-      adoptReply(s, last);
-      return;
-    }
-  }
-  // History reload failed, or the legacy guard rejected the trailing reply:
-  // the streamed accumulation is all there is.
-  if (s.text) finishOk(s);
-  else finishErr(s, TURN_DIED_MESSAGE);
-}
-
-function adoptReply(s: TurnState, reply: ChatMessage): void {
-  if (reply.providerError) {
-    settleProviderErrorCard(s, reply.providerError);
-    return;
-  }
-  s.text = reply.content;
-  if (reply.usage) s.usage = reply.usage;
-  finishOk(s);
-}
-
-/**
- * Refetch history and settle from it (`settleFromHistory`), then stop the
- * subscription. A failed reload surfaces as a system message (no silent
- * fallback) and the settle proceeds from the streamed accumulation — the UI
- * must never hang.
- */
-export async function reloadAndSettle(
-  s: TurnState,
-  reloadHistory: () => Promise<ChatMessage[]>,
-  turnId: string | undefined,
-  guard: (messages: ChatMessage[]) => boolean,
-  stop: () => void,
-): Promise<void> {
-  let messages: ChatMessage[] | null = null;
-  try {
-    messages = await reloadHistory();
-  } catch (e) {
-    push(s, {
-      feed_type: "system_message",
-      data: `Couldn't reload the conversation: ${e instanceof Error ? e.message : String(e)}`,
-    });
-  }
-  if (!s.settled) settleFromHistory(s, messages, turnId, guard);
-  stop();
 }

--- a/packages/sdk/src/modules/turns/turn-sink-options.ts
+++ b/packages/sdk/src/modules/turns/turn-sink-options.ts
@@ -15,6 +15,15 @@ export interface TurnSinkOptions {
   mode: "turn" | "observer";
   /** Turn mode: the nonce our send carried — its `user` echo names OUR turnId. */
   nonce?: string;
+  /**
+   * Turn mode: the provider the composer targeted (caller's id dialect) and
+   * the prompt we sent. Neither is knowable from the wire when the runtime
+   * refuses a not-connected send — nothing is connected, and the prompt was
+   * never delivered — so the typed reconnect card is built from these
+   * (see `finishErr`). Absent in observer mode.
+   */
+  provider?: string;
+  prompt?: string;
   /** Abort the resumable subscription (the turn settled / nothing to watch). */
   stop: () => void;
   /** Refetch persisted history (the resync settle source). */

--- a/packages/sdk/src/modules/turns/turn-sink.ts
+++ b/packages/sdk/src/modules/turns/turn-sink.ts
@@ -1,14 +1,9 @@
 import type { WireFrame } from "@houston/runtime-client";
 import type { TerminalBoardStatus } from "./feed-output";
+import { reloadAndSettle } from "./settle-from-history";
 import { applyTurnFrame } from "./turn-frames";
 import { classifyFrame, classifyRunningSync } from "./turn-identity";
-import {
-  finishErr,
-  newTurnState,
-  push,
-  reloadAndSettle,
-  type TurnState,
-} from "./turn-settle";
+import { finishErr, newTurnState, push, type TurnState } from "./turn-settle";
 import type { TurnSinkOptions } from "./turn-sink-options";
 
 export type { TurnSinkOptions } from "./turn-sink-options";
@@ -40,7 +35,10 @@ export class TurnSink {
   private accepted = false;
 
   constructor(private readonly o: TurnSinkOptions) {
-    this.s = newTurnState(o.agentPath, o.sessionKey, o.output);
+    this.s = newTurnState(o.agentPath, o.sessionKey, o.output, {
+      provider: o.provider,
+      prompt: o.prompt,
+    });
   }
 
   get settled(): boolean {

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -7,12 +7,12 @@ import type {
 import { EngineError } from "@houston/runtime-client";
 import { afterEach, expect, test } from "vitest";
 import type { FeedOutput } from "./feed-output";
+import { TURN_DIED_MESSAGE } from "./settle-from-history";
 import {
   SEND_IN_FLIGHT_MESSAGE,
   STREAM_LOST_MESSAGE,
   StreamRegistry,
 } from "./stream-registry";
-import { TURN_DIED_MESSAGE } from "./turn-settle";
 import {
   observeConversation,
   type StreamTuning,

--- a/packages/sdk/src/modules/turns/turn-stream.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.ts
@@ -21,6 +21,12 @@ export type { StreamRegistry, StreamTuning } from "./stream-registry";
 export interface StreamTurnOptions {
   /** Override the wire nonce (default: a fresh UUID). Its `user` echo names our turnId. */
   nonce?: string;
+  /**
+   * The provider this turn targets (caller's id dialect). Only labels the
+   * typed reconnect card when the runtime refuses the send as not-connected —
+   * the runtime can't name a provider in that refusal (nothing is connected).
+   */
+  provider?: string;
   /** Reconnect tuning (tests inject fast backoff). */
   tuning?: StreamTuning;
 }
@@ -123,6 +129,8 @@ export async function streamTurn(
     output,
     mode: "turn",
     nonce,
+    provider: opts.provider,
+    prompt,
     stop: () => ac.abort(),
     reloadHistory: async () => (await engine.getHistory(sessionKey)).messages,
     // LEGACY fallback (no turn ids anywhere): trust history's trailing reply

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -1,6 +1,7 @@
 import { agentFileEventType, migrateProviderModel } from "@houston/domain";
 import {
   type CustomEndpoint,
+  EngineError,
   HoustonEngineClient,
   type ProviderId,
 } from "@houston/runtime-client";
@@ -111,6 +112,18 @@ export function isHoustonEngineError(e: unknown): e is HoustonEngineError {
  * (first-run: it runs in the host's hidden setup runtime, not an agent's).
  */
 const SETUP_LOGIN_KEY = "__setup__";
+
+/**
+ * Treat a 404 on login/cancel as benign: it means no login was pending (or an
+ * older host lacks the cancel route), so cancel's postcondition — the login
+ * slot is free — already holds. The reconnect card's every press goes
+ * cancel → launch, so propagating this 404 aborted the chain and the login
+ * never launched (HOU-676). Every other failure still propagates.
+ */
+function benignCancelMiss(e: unknown): void {
+  if (e instanceof EngineError && e.status === 404) return;
+  throw e;
+}
 
 /**
  * Drop-in replacement for `@houston-ai/engine-client`'s HoustonClient, backed by
@@ -895,12 +908,15 @@ export class HoustonClient {
       );
       const url = info.kind === "device_code" ? info.verificationUri : info.url;
       const userCode = info.kind === "device_code" ? info.userCode : null;
+      // The bus event is the ONE opening path: an app-side handler (a mounted
+      // login surface, else the shell's global fallback) opens the URL via the
+      // platform opener. A direct window.open here double-opened next to those
+      // handlers — and was a silent no-op inside the desktop's WKWebView.
       emitEvent("ProviderLoginUrl", {
         provider: name,
         url,
         user_code: userCode,
       });
-      if (typeof window !== "undefined") window.open(url, "_blank", "noopener");
       this.watchLoginCompletion(pid, name);
       return;
     }
@@ -955,13 +971,13 @@ export class HoustonClient {
       // otherwise it keeps polling the provider until timeout and a retry
       // collides with the stale flow ("sign-in already pending", HOU-664 /
       // the HOU-438 failure class).
-      await this.providerEngine().cancelLogin(pid);
+      await this.providerEngine().cancelLogin(pid).catch(benignCancelMiss);
       return;
     }
     this.stopLoginWatch(name);
     // Cancel the runtime's in-flight OAuth flow for real (frees the loopback
     // port + login slot), not just the local watcher.
-    await this.engine.cancelLogin(pid);
+    await this.engine.cancelLogin(pid).catch(benignCancelMiss);
     // Benign completion: clears the dialog + spinner without an error toast,
     // matching the old engine's cancel semantics.
     emitEvent("ProviderLoginComplete", {

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -1205,8 +1205,13 @@ export class HoustonClient {
       : this.engine;
     // Fire-and-stream: events flow to the feed store over the bus/WS adapter.
     // The board-status setter is cloud-aware (writes land where the board reads).
-    void streamTurn(engine, path, req.sessionKey, req.prompt, (status) =>
-      this.setActivityStatus(path, req.sessionKey, status),
+    void streamTurn(
+      engine,
+      path,
+      req.sessionKey,
+      req.prompt,
+      (status) => this.setActivityStatus(path, req.sessionKey, status),
+      req.provider,
     );
     return { sessionKey: req.sessionKey };
   }

--- a/packages/web/src/engine-adapter/turn-stream.ts
+++ b/packages/web/src/engine-adapter/turn-stream.ts
@@ -26,10 +26,12 @@ export function disposeAllStreams(): void {
 /**
  * The web adapter's turn entry. The turn/feed machinery lives in `@houston/sdk`
  * now; this drives it with a bus-backed {@link createBusFeedOutput} FeedOutput
- * and keeps the historical `(…, setActivityStatus, tuning?)` signature so app
+ * and keeps the historical `(…, setActivityStatus)` signature shape so app
  * callers and the adapter's unit tests are unchanged. `setActivityStatus` is
  * already bound to this turn's conversation, so the FeedOutput ignores the
- * (agentPath, sessionKey) it re-supplies.
+ * (agentPath, sessionKey) it re-supplies. `provider` is the chat's composer
+ * pick (frontend id) — it labels the typed reconnect card when the runtime
+ * refuses the send as not-connected.
  */
 export function streamTurn(
   engine: HoustonEngineClient,
@@ -37,6 +39,7 @@ export function streamTurn(
   sessionKey: string,
   prompt: string,
   setActivityStatus: (status: BoardStatus) => Promise<void>,
+  provider?: string,
   tuning?: StreamTuning,
 ): Promise<void> {
   const output = createBusFeedOutput((_a, _s, status) =>
@@ -50,6 +53,7 @@ export function streamTurn(
     output,
     registry,
     {
+      provider,
       tuning,
     },
   );

--- a/packages/web/tests/cancel-login-benign.test.ts
+++ b/packages/web/tests/cancel-login-benign.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+/**
+ * HOU-676: the reconnect card's every press goes cancelLogin → launchLogin
+ * (the engine keeps one login slot per provider, so a relaunch must free it
+ * first). The card's contract says cancel is IDEMPOTENT — but with nothing
+ * pending the runtime/host can answer 404, and a propagated 404 aborts the
+ * chain: the card flips to "failed" and the login never launches. A 404 on
+ * cancel means the slot is already free — cancel's postcondition holds — so
+ * the adapter treats it as benign. Every other failure still propagates.
+ */
+
+const cancelLogin = vi.fn();
+
+vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../src/engine-adapter/control-plane")
+    >();
+  return {
+    ...actual,
+    runtimeClientFor: vi.fn(() => ({ cancelLogin })),
+  };
+});
+
+import { EngineError } from "@houston/runtime-client";
+import { HoustonClient } from "../src/engine-adapter/client";
+
+beforeEach(() => {
+  // cp-mode `providerEngine()` needs a selected agent id; the adapter reads it
+  // from localStorage, which the default node test env doesn't provide.
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) =>
+      k === "houston.pref.last_agent_id" ? "agent-1" : null,
+    setItem: () => {},
+    removeItem: () => {},
+  };
+  cancelLogin.mockReset();
+});
+
+afterEach(() => vi.clearAllMocks());
+
+function client() {
+  return new HoustonClient({
+    baseUrl: "http://host",
+    token: "t",
+    controlPlane: true,
+  });
+}
+
+test("a 404 on cancel (nothing pending) is benign — the card's cancel → launch chain survives", async () => {
+  cancelLogin.mockRejectedValue(new EngineError(404, '{"error":"not found"}'));
+
+  await expect(client().cancelProviderLogin("openai")).resolves.toBeUndefined();
+  expect(cancelLogin).toHaveBeenCalledTimes(1);
+});
+
+test("a real cancel failure still propagates — never swallowed", async () => {
+  cancelLogin.mockRejectedValue(new EngineError(500, "runtime exploded"));
+
+  await expect(client().cancelProviderLogin("openai")).rejects.toThrow(
+    "engine request failed (500)",
+  );
+});

--- a/packages/web/tests/translate.test.ts
+++ b/packages/web/tests/translate.test.ts
@@ -189,6 +189,60 @@ test("a failing status persist surfaces in the feed, not silently", async () => 
   expect(surfaced).toBe(true);
 });
 
+// HOU-676: a logged-out send is refused by the runtime (409) BEFORE the
+// message reaches the engine. That must settle as the typed unauthenticated
+// card — stamped with the chat's provider and carrying the refused prompt so
+// "Send again" can resend it — never as the raw system message that only fed
+// the auto-dismissing store-driven reconnect card (which vanished on
+// reconnect and dead-ended the undelivered message).
+test("a refused not-connected send surfaces the typed reconnect card with provider + prompt", async () => {
+  const statuses: string[] = [];
+  const feed = collectFeed();
+  const { EngineError } = await import("@houston/runtime-client");
+  const engine = {
+    async streamEvents() {},
+    async sendMessage() {
+      throw new EngineError(
+        409,
+        JSON.stringify({
+          error: "No provider connected. Connect an AI provider first.",
+        }),
+      );
+    },
+  } as unknown as HoustonEngineClient;
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-nc",
+    "hey",
+    async (s) => {
+      statuses.push(s);
+    },
+    "openai",
+  );
+  feed.stop();
+
+  const card = feed.items.find(
+    (i) => (i as { feed_type?: string })?.feed_type === "provider_error",
+  ) as { data?: Record<string, unknown> } | undefined;
+  expect(card?.data).toEqual({
+    kind: "unauthenticated",
+    provider: "openai",
+    cause: "no_credentials",
+    message: "No provider connected. Connect an AI provider first.",
+    failed_prompt: "hey",
+  });
+  // No raw system_message duplicate — the card is the whole surface.
+  expect(
+    feed.items.some(
+      (i) => (i as { feed_type?: string })?.feed_type === "system_message",
+    ),
+  ).toBe(false);
+  // A handled state: the board card lands on needs_you, never the red error.
+  expect(statuses).toEqual(["running", "needs_you"]);
+});
+
 // HOU-666: loadChatHistory must only treat "conversation not found" (404 — a
 // fresh chat whose first turn hasn't persisted yet) as an empty conversation.
 // Every other failure (network drop, auth, 5xx) must propagate to the app's

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -139,6 +139,13 @@ export type ProviderError =
       provider: string;
       cause: AuthFailureCause;
       message: string;
+      /**
+       * Client-synthesized only (never on the wire): the prompt whose SEND the
+       * engine refused because no provider was connected. The message never
+       * reached the engine, so the card's "Send again" must resend THIS text —
+       * a generic "try again" prompt would arrive with no context to retry.
+       */
+      failed_prompt?: string;
     }
   | { kind: "network_unreachable"; provider: string; message: string }
   | {


### PR DESCRIPTION
## Summary

Fixes HOU-676: send a message while the provider is logged out, reconnect from the in-chat card, and the card disappears, leaving your message with no response and no way to get one. Follow-up testing also showed the card's Reconnect button itself did nothing (no browser opened) — diagnosed and fixed here too.

### Part 1: the card vanished after reconnect

**Root cause.** On the TS engine a logged-out send is refused by the runtime (409 `No provider connected...`) before the message ever reaches it. The SDK settled that refusal as a hidden `system_message`, which only drove the ephemeral store-polling `ProviderReconnectCard`. That card is designed to auto-dismiss the moment a status probe reports the provider authenticated, which is correct for its original purpose but a dead end here: the message was never delivered, so after reconnecting there is nothing to answer it and nothing left to act on.

**Fix.** The not-connected refusal now settles as the typed `unauthenticated` `provider_error` card, the stable inline surface that already has the right lifecycle: it stays in the conversation, flips to a green "Reconnected" state when the login completes, and offers "Send again".

- `@houston/sdk` (`finishErr`): a not-connected failure synthesizes the typed card instead of the raw system message. The card is stamped with the chat's intended provider (threaded from the composer through `SessionStartRequest.provider` into the turn sink; the refusal itself cannot name one because nothing is connected) and carries the refused prompt as `failed_prompt`.
- `app`: "Send again" resends the original message verbatim when `failed_prompt` is present (a generic "try again" prompt would reach the engine with no context, since the original send never landed). Provider-less cards are labeled with the chat's own provider, and the ephemeral card stays suppressed while the inline card is present.
- Split `settle-from-history.ts` out of `turn-settle.ts` to stay under the 200-line limit.

### Part 2: the card's Reconnect button did nothing

Two causes, both confirmed from dev logs:

1. **The OAuth URL was emitted into the void.** On the v3 wire the adapter surfaces the sign-in URL as a `ProviderLoginUrl` bus event and expects the active view to act on it — but only the AI hub, the provider picker, and the onboarding login step mount a handler. A login launched from the chat had no consumer: the runtime started the OAuth flow, nothing opened the browser, and the button read as dead with zero errors logged. Fix: a shell-global `ProviderLoginFallback` consumes the event exactly like the dedicated handlers (browser for the desktop loopback flow, dialog for device-code/remote) and stands down while any dedicated surface holds a claim (`provider-login-surface.ts`), so the URL is never handled twice. The adapter's direct `window.open` is removed — it double-opened next to the handlers and was a silent no-op inside WKWebView anyway.
2. **Cancel 404s aborted the cancel → launch chain.** Every press of the card goes `cancelLogin` → `launchLogin` (the runtime keeps one login slot per provider). The host's setup-runtime allowlist blocked `auth/*/login/cancel` (404 `not found`, verbatim in the log), and the adapter propagated cancel 404s — either kills the chain before the launch. Fix: allowlist `login/cancel`, and treat a 404 on cancel as benign in the adapter (nothing was pending, so the slot is already free — cancel's postcondition holds). Every other failure still propagates.

### Part 3: card lifecycle polish

- **Waiting state:** while the OAuth tab is open the pill becomes **Cancel** (outline) instead of a second "Reconnect" — it frees the runtime's login slot and re-arms the Reconnect button, covering the lost-tab / wrong-account / retrigger case. The description keeps saying "Finish signing in using your browser".
- **Auto-answer on sign-in:** when `ProviderLoginComplete` lands for a card that carries `failed_prompt` (a refused send — the message never reached the engine), the card resends it automatically, exactly once, and the pill settles into a disabled **"Signed in"** badge. No duplicate bubble is pushed: the original message is already in the feed. This also covers reconnecting from Settings while the chat is open. Mid-turn auth failures (no `failed_prompt`) keep the explicit "Try again" CTA — re-running a turn that has server-side context stays a user decision.
- New locale keys (`reconnectedResending`, `signedIn`) in en/es/pt; `pnpm check-locales` passes.

**Known limitation (pre-existing):** because the runtime refuses the send before persisting anything, the undelivered message and the card do not survive an app restart. Making refused sends durable is a runtime contract change, out of scope here.

## Repro (before the fix)

1. Run the app on the TS engine (`VITE_NEW_ENGINE`) with no provider connected (or sign out of the chat's provider).
2. Send a message in a chat. A reconnect card appears under it.
3. Click "Sign in with ..." — no browser opens (bug, part 2).
4. Complete the login from Settings instead: the in-chat card disappears and the message sits with no response; nothing retries it (bug, part 1).

## Verify (after the fix)

1. Same setup: send a message while logged out.
2. The inline card appears: "Connect <provider>" with the no-credentials copy, and it does not flicker or auto-dismiss.
3. Click Reconnect on the card: the browser opens the provider's OAuth page (from the chat, with no settings screen open).
4. While the browser tab is open, the card's pill reads "Cancel"; pressing it re-arms "Reconnect".
5. Complete the login: the card flips to green "Reconnected", shows a disabled "Signed in" badge, and your original message is answered automatically with no duplicate bubble and no extra click.
6. Gates: `pnpm --filter @houston/sdk test` (206), `pnpm --filter houston-web test` (47), `pnpm --filter @houston/host test` (472), `cd app && pnpm test` (553), `cd ui/chat && pnpm test` (44), `pnpm typecheck`, `pnpm check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
