### PR TITLE
fix(files): working Files tab on the TS engine — OS reveal, uploads, moves, Download all (HOU-677)

### DIFF
--- a/app/src/components/tabs/files-tab.tsx
+++ b/app/src/components/tabs/files-tab.tsx
@@ -1,15 +1,18 @@
 import { type FileEntry, FilesBrowser } from "@houston-ai/agent";
 import { isTauri } from "@tauri-apps/api/core";
-import { FolderOpen } from "lucide-react";
-import { useState } from "react";
+import { Download, FolderOpen, Upload } from "lucide-react";
+import { type ReactNode, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useCreateFolder,
   useDeleteFile,
   useFiles,
+  useMoveFile,
   useRenameFile,
+  useUploadFiles,
 } from "../../hooks/queries";
 import { useCapabilities } from "../../hooks/use-capabilities";
+import { isCoLocatedEngine, newEngineActive } from "../../lib/engine";
 import { saveBlob } from "../../lib/save-blob";
 import { tauriFiles } from "../../lib/tauri";
 import type { TabProps } from "../../lib/types";
@@ -17,15 +20,28 @@ import { FilePreviewDialog } from "./file-preview-dialog";
 
 export default function FilesTab({ agent }: TabProps) {
   const { t } = useTranslation("agents");
-  // Web build: no OS to open/reveal with — double-click previews in-browser,
-  // the context menu offers Download, and the file-manager footer goes away.
+  // No OS to open/reveal with (web build, cloud pod, remote host): double-click
+  // previews in-browser, the context menu offers Download, and the footer
+  // becomes "Download all" instead of "Open in File Manager".
   const desktop = isTauri();
   const { capabilities } = useCapabilities();
-  const canUseLocalFiles = desktop && (capabilities?.revealInOs ?? true);
+  // The directory the OS can actually open: the host-reported real path (TS
+  // engine, co-located hosts only), or the legacy engine's folderPath (already
+  // absolute). On the TS engine folderPath is a route key, never a path —
+  // handing it to the OS was HOU-677.
+  const osDir =
+    agent.localDir ?? (newEngineActive() ? undefined : agent.folderPath);
+  const canUseLocalFiles =
+    desktop &&
+    isCoLocatedEngine() &&
+    (capabilities?.revealInOs ?? true) &&
+    osDir !== undefined;
   const [preview, setPreview] = useState<FileEntry | null>(null);
+  const fileInput = useRef<HTMLInputElement>(null);
   const browserLabels = {
     columnName: t("files.columns.name"),
     columnDateModified: t("files.columns.dateModified"),
+    columnDateCreated: t("files.columns.dateCreated"),
     columnSize: t("files.columns.size"),
     columnKind: t("files.columns.kind"),
     loading: t("files.loading"),
@@ -43,6 +59,8 @@ export default function FilesTab({ agent }: TabProps) {
   const deleteFile = useDeleteFile(path);
   const renameFile = useRenameFile(path);
   const createFolder = useCreateFolder(path);
+  const uploadFiles = useUploadFiles(path);
+  const moveFile = useMoveFile(path);
 
   const downloadFile = (file: FileEntry) => {
     // call() already toasts + captures the failure; nothing more to surface.
@@ -51,18 +69,38 @@ export default function FilesTab({ agent }: TabProps) {
       .then(({ blob }) => saveBlob(file.name, blob))
       .catch(() => {});
   };
+  const downloadAll = () => {
+    tauriFiles
+      .downloadArchive(path)
+      .then(({ blob }) => saveBlob(`${agent.name} files.zip`, blob))
+      .catch(() => {});
+  };
+  const pickFiles = () => fileInput.current?.click();
 
   return (
     <div className="h-full overflow-hidden p-4">
+      <input
+        ref={fileInput}
+        type="file"
+        multiple
+        className="hidden"
+        onChange={(e) => {
+          const picked = Array.from(e.currentTarget.files ?? []);
+          if (picked.length > 0) uploadFiles.mutate({ files: picked });
+          e.currentTarget.value = ""; // allow re-picking the same file
+        }}
+      />
       <FilesBrowser
         files={files ?? []}
         loading={loading}
         onOpen={(file) =>
-          canUseLocalFiles ? tauriFiles.open(path, file.path) : setPreview(file)
+          canUseLocalFiles && osDir
+            ? tauriFiles.open(osDir, file.path)
+            : setPreview(file)
         }
         onReveal={
-          canUseLocalFiles
-            ? (file) => tauriFiles.reveal(path, file.path)
+          canUseLocalFiles && osDir
+            ? (file) => tauriFiles.reveal(osDir, file.path)
             : undefined
         }
         onDownload={canUseLocalFiles ? undefined : downloadFile}
@@ -71,21 +109,48 @@ export default function FilesTab({ agent }: TabProps) {
           renameFile.mutate({ relativePath: file.path, newName })
         }
         onCreateFolder={(name) => createFolder.mutate(name)}
+        onFilesDropped={(dropped, targetFolder) =>
+          uploadFiles.mutate({
+            files: dropped,
+            targetDir: targetFolder ?? null,
+          })
+        }
+        onMove={
+          // Drag-move needs the TS host's move route; the legacy engine has none.
+          newEngineActive()
+            ? (sourcePath, targetFolder) =>
+                moveFile.mutate({
+                  relativePath: sourcePath,
+                  toDir: targetFolder,
+                })
+            : undefined
+        }
+        onBrowse={pickFiles}
         emptyTitle={t("files.emptyTitle")}
         emptyDescription={t("files.emptyDescription")}
         labels={browserLabels}
         menuLabels={menuLabels}
         statusBarAction={
-          canUseLocalFiles ? (
-            <button
-              type="button"
-              onClick={() => tauriFiles.revealAgent(path)}
-              className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <FolderOpen className="size-3" />
-              {t("files.openInFileManager")}
-            </button>
-          ) : undefined
+          <div className="flex items-center gap-3">
+            <FooterButton
+              onClick={pickFiles}
+              icon={<Upload className="size-3" />}
+              label={t("files.uploadFiles")}
+            />
+            {canUseLocalFiles && osDir ? (
+              <FooterButton
+                onClick={() => tauriFiles.revealAgent(osDir)}
+                icon={<FolderOpen className="size-3" />}
+                label={t("files.openInFileManager")}
+              />
+            ) : (
+              <FooterButton
+                onClick={downloadAll}
+                icon={<Download className="size-3" />}
+                label={t("files.downloadAll")}
+              />
+            )}
+          </div>
         }
       />
       <FilePreviewDialog
@@ -95,5 +160,26 @@ export default function FilesTab({ agent }: TabProps) {
         onClose={() => setPreview(null)}
       />
     </div>
+  );
+}
+
+function FooterButton({
+  onClick,
+  icon,
+  label,
+}: {
+  onClick: () => void;
+  icon: ReactNode;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex items-center gap-1 text-[11px] text-muted-foreground hover:text-foreground transition-colors"
+    >
+      {icon}
+      {label}
+    </button>
   );
 }

--- a/app/src/hooks/queries/index.ts
+++ b/app/src/hooks/queries/index.ts
@@ -16,7 +16,9 @@ export {
   useCreateFolder,
   useDeleteFile,
   useFiles,
+  useMoveFile,
   useRenameFile,
+  useUploadFiles,
 } from "./use-files";
 export { useInstructions, useSaveInstructions } from "./use-instructions";
 export {

--- a/app/src/hooks/queries/use-files.ts
+++ b/app/src/hooks/queries/use-files.ts
@@ -60,3 +60,43 @@ export function useCreateFolder(agentPath: string | undefined) {
     },
   });
 }
+
+export function useUploadFiles(agentPath: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      files,
+      targetDir,
+    }: {
+      files: File[];
+      targetDir?: string | null;
+    }) => {
+      if (!agentPath) throw new Error("agentPath is required");
+      return tauriFiles.upload(agentPath, files, targetDir);
+    },
+    onSuccess: () => {
+      if (agentPath)
+        qc.invalidateQueries({ queryKey: queryKeys.files(agentPath) });
+    },
+  });
+}
+
+export function useMoveFile(agentPath: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      relativePath,
+      toDir,
+    }: {
+      relativePath: string;
+      toDir: string | null;
+    }) => {
+      if (!agentPath) throw new Error("agentPath is required");
+      return tauriFiles.move(agentPath, relativePath, toDir);
+    },
+    onSuccess: () => {
+      if (agentPath)
+        qc.invalidateQueries({ queryKey: queryKeys.files(agentPath) });
+    },
+  });
+}

--- a/app/src/lib/engine.ts
+++ b/app/src/lib/engine.ts
@@ -2,7 +2,11 @@
 
 import { EngineWebSocket, HoustonClient } from "@houston-ai/engine-client";
 import { pullEngineHandshakeWithRetry } from "./engine-handshake";
-import { controlPlaneBuild, resolveEngine } from "./engine-mode";
+import {
+  controlPlaneBuild,
+  isLoopbackHostUrl,
+  resolveEngine,
+} from "./engine-mode";
 import { installRustEngineLifecycleListeners } from "./engine-tauri-events";
 
 declare global {
@@ -149,6 +153,21 @@ export function hostedOauthGateActive(): boolean {
  */
 export function isRemoteEngine(): boolean {
   return REMOTE_HOST_MODE;
+}
+
+/**
+ * True when the active engine runs on THIS machine: the Tauri-spawned sidecar
+ * (Rust engine or TS host), or a dev `VITE_NEW_ENGINE_URL` pointing at
+ * loopback (the two-terminal setup). OS affordances — reveal/open in the file
+ * manager — only make sense then: a remote host's paths don't exist on this
+ * machine, even when that host serves the local capability profile
+ * (self-host VPS). Mirrors the provider-auth co-location rule
+ * (`providerLoginUsesDeviceAuthByDefault`).
+ */
+export function isCoLocatedEngine(): boolean {
+  if (!REMOTE_HOST_MODE) return true;
+  if (STATIC_HOST_URL) return isLoopbackHostUrl(STATIC_HOST_URL);
+  return false; // hosted gateways are always remote
 }
 
 /** Updates the hosted engine bearer token from the current Supabase session. */

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -180,6 +180,7 @@ function toAgent(a: import("@houston-ai/engine-client").Agent): Agent {
     id: a.id,
     name: a.name,
     folderPath: a.folderPath,
+    localDir: a.localDir,
     configId: a.configId,
     color: a.color,
     createdAt: a.createdAt,
@@ -645,6 +646,7 @@ export const tauriFiles = {
         size: f.size,
         is_directory: f.is_directory,
         dateModified: f.date_modified,
+        dateCreated: f.date_created,
       })),
     ),
   open: (agentPath: string, relativePath: string) =>
@@ -676,6 +678,23 @@ export const tauriFiles = {
     call<void>("create_agent_folder", async () => {
       await getEngine().createFolder(agentPath, name);
     }),
+  /** Upload browser Files into the workspace (drag-drop / Browse), optionally
+   * into a subfolder. */
+  upload: (agentPath: string, files: File[], targetDir?: string | null) =>
+    call<void>("upload_project_files", () =>
+      getEngine().uploadProjectFiles(agentPath, files, targetDir),
+    ),
+  /** Move a file/folder into another folder (null = workspace root). */
+  move: (agentPath: string, relPath: string, toDir: string | null) =>
+    call<void>("move_project_file", () =>
+      getEngine().moveProjectFile(agentPath, relPath, toDir),
+    ),
+  /** The whole workspace as one zip — "Download all" where there is no local
+   * file manager to reveal in (cloud pods, web builds). */
+  downloadArchive: (agentPath: string) =>
+    call<{ blob: Blob; contentType: string }>("download_project_archive", () =>
+      getEngine().downloadProjectArchive(agentPath),
+    ),
   revealAgent: (agentPath: string) => osRevealAgent(agentPath),
 };
 

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -64,6 +64,12 @@ export interface Agent {
   createdAt: string;
   lastOpenedAt?: string;
   /**
+   * Absolute on-disk directory, present only when the engine is co-located
+   * with the files (TS host, local profile). What OS reveal/open needs — on
+   * the TS engine `folderPath` is a route key, not a path (HOU-677).
+   */
+  localDir?: string;
+  /**
    * Multiplayer only: whether the CURRENT user is assigned this agent (may use
    * it). Absent in single-player mode. Kept in sync (by hand) with the
    * engine-client `Agent` shape.

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -149,9 +149,12 @@
     "openInFileManager": "Open in File Manager",
     "loading": "Loading…",
     "browseFiles": "Browse files",
+    "uploadFiles": "Upload files",
+    "downloadAll": "Download all",
     "columns": {
       "name": "Name",
       "dateModified": "Date Modified",
+      "dateCreated": "Date Created",
       "size": "Size",
       "kind": "Kind"
     },

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -149,9 +149,12 @@
     "openInFileManager": "Abrir en el Explorador de Archivos",
     "loading": "Cargando…",
     "browseFiles": "Elegir archivos",
+    "uploadFiles": "Subir archivos",
+    "downloadAll": "Descargar todo",
     "columns": {
       "name": "Nombre",
       "dateModified": "Fecha de modificación",
+      "dateCreated": "Fecha de creación",
       "size": "Tamaño",
       "kind": "Tipo"
     },

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -149,9 +149,12 @@
     "openInFileManager": "Abrir no Explorador de Arquivos",
     "loading": "Carregando…",
     "browseFiles": "Escolher arquivos",
+    "uploadFiles": "Enviar arquivos",
+    "downloadAll": "Baixar tudo",
     "columns": {
       "name": "Nome",
       "dateModified": "Data de modificação",
+      "dateCreated": "Data de criação",
       "size": "Tamanho",
       "kind": "Tipo"
     },

--- a/packages/fake-host/package.json
+++ b/packages/fake-host/package.json
@@ -23,7 +23,8 @@
   },
   "dependencies": {
     "@houston/protocol": "workspace:*",
-    "@houston/runtime-client": "workspace:*"
+    "@houston/runtime-client": "workspace:*",
+    "fflate": "0.8.3"
   },
   "devDependencies": {
     "@types/node": "22.20.0",

--- a/packages/fake-host/src/routes-files.ts
+++ b/packages/fake-host/src/routes-files.ts
@@ -1,0 +1,86 @@
+/**
+ * `/agents/:id/files*` — the Files tab's workspace surface, mirroring the real
+ * host's `turn/files*.ts` routes: list, download, archive (a real zip), import
+ * (upload), move, rename, folder create, delete. Backed by `state-workspace.ts`.
+ */
+
+import { type Zippable, zipSync } from "fflate";
+import { CORS, json, noContent } from "./http";
+import * as state from "./state";
+
+export function handleWorkspaceFiles(
+  method: string,
+  id: string,
+  rest: string[],
+  req: Request,
+  body: Record<string, unknown> | undefined,
+): Response {
+  const sub = rest[2];
+  const query = new URL(req.url).searchParams;
+
+  if (sub === undefined) {
+    if (method === "GET") return json(state.listWorkspaceFiles(id));
+    if (method === "DELETE") {
+      state.deleteWorkspaceEntry(id, query.get("path") ?? "");
+      return json({ ok: true });
+    }
+    return noContent(405);
+  }
+
+  if (sub === "download" && method === "GET") {
+    const f = state.readWorkspaceFile(id, query.get("path") ?? "");
+    if (!f) return json({ error: "file not found" }, 404);
+    return new Response(new Uint8Array(f.bytes), {
+      status: 200,
+      headers: { ...CORS, "Content-Type": "application/octet-stream" },
+    });
+  }
+
+  if (sub === "archive" && method === "GET") {
+    const files = state.listWorkspaceFiles(id).filter((f) => !f.is_directory);
+    if (files.length === 0) return json({ error: "no files to download" }, 404);
+    const entries: Zippable = {};
+    for (const f of files) {
+      const w = state.readWorkspaceFile(id, f.path);
+      if (w) entries[f.path] = new Uint8Array(w.bytes);
+    }
+    return new Response(new Uint8Array(zipSync(entries)), {
+      status: 200,
+      headers: { ...CORS, "Content-Type": "application/zip" },
+    });
+  }
+
+  if (sub === "import" && method === "POST") {
+    const files = (Array.isArray(body?.files) ? body.files : []) as {
+      name: string;
+      contentBase64: string;
+    }[];
+    const dir = typeof body?.dir === "string" && body.dir ? body.dir : null;
+    return json({ paths: state.importWorkspaceFiles(id, dir, files) });
+  }
+
+  if (sub === "move" && method === "POST") {
+    const toDir =
+      typeof body?.toDir === "string" && body.toDir !== "" ? body.toDir : null;
+    return json({
+      moved: state.moveWorkspaceEntry(id, String(body?.path ?? ""), toDir),
+    });
+  }
+
+  if (sub === "rename" && method === "POST") {
+    state.renameWorkspaceEntry(
+      id,
+      String(body?.path ?? ""),
+      String(body?.newName ?? ""),
+    );
+    return json({ ok: true });
+  }
+
+  if (sub === "folder" && method === "POST") {
+    return json({
+      created: state.createWorkspaceFolder(id, String(body?.path ?? "")),
+    });
+  }
+
+  return noContent(405);
+}

--- a/packages/fake-host/src/routes.ts
+++ b/packages/fake-host/src/routes.ts
@@ -16,6 +16,7 @@
 
 import { cancelChat, openChatStream, sendMessage } from "./chat";
 import { json, noContent } from "./http";
+import { handleWorkspaceFiles } from "./routes-files";
 import * as state from "./state";
 
 /** Canned provider list — one connected, active Claude. */
@@ -177,8 +178,8 @@ export function handleAgents(
     }
 
     case "files":
-      if (method === "GET") return json([]);
-      return noContent();
+      // The Files tab's workspace surface (list/upload/move/…): routes-files.ts.
+      return handleWorkspaceFiles(method, id, rest, req, body);
 
     case "attachments":
       if (method === "POST") return json({ paths: [] });

--- a/packages/fake-host/src/state-store.ts
+++ b/packages/fake-host/src/state-store.ts
@@ -54,6 +54,8 @@ export interface HostState {
   agents: CpAgent[];
   /** `${agentId}:${relPath}` -> file content (the `.houston/**` files-first store) */
   files: Map<string, string>;
+  /** `${agentId}:${relPath}` -> workspace file (the Files tab's real files). */
+  workspace: Map<string, { bytes: Buffer; created: number; modified: number }>;
   /** `${agentId}:${conversationId}` -> message history */
   histories: Map<string, ChatMessage[]>;
   agentSeq: number;
@@ -70,6 +72,21 @@ function freshState(): HostState {
     fileKey(SEED_AGENT_ID, ACTIVITY_PATH),
     JSON.stringify(SEED_ACTIVITIES),
   );
+  // Two seeded workspace files so the Files tab has rows on first paint.
+  const workspace = new Map<
+    string,
+    { bytes: Buffer; created: number; modified: number }
+  >();
+  workspace.set(fileKey(SEED_AGENT_ID, "Q3 report.pdf"), {
+    bytes: Buffer.from("PDF-BYTES"),
+    created: EPOCH,
+    modified: EPOCH + 86_400_000,
+  });
+  workspace.set(fileKey(SEED_AGENT_ID, "Docs/sales.csv"), {
+    bytes: Buffer.from("a,b\n1,2\n"),
+    created: EPOCH,
+    modified: EPOCH,
+  });
   return {
     agents: [
       {
@@ -80,6 +97,7 @@ function freshState(): HostState {
       },
     ],
     files,
+    workspace,
     histories: new Map(),
     agentSeq: 1,
     activitySeq: 2,

--- a/packages/fake-host/src/state-workspace.ts
+++ b/packages/fake-host/src/state-workspace.ts
@@ -1,0 +1,187 @@
+/**
+ * The agent's WORKSPACE files — what the Files tab lists, uploads into, moves,
+ * renames, deletes, and downloads. Distinct from the `.houston/**` files-first
+ * store (state-agents.ts): this models the real host's `turn/files*.ts` surface
+ * (list with synthesized folders + dates, Finder-style upload dedupe, `.keep`
+ * folder markers, prefix deletes/moves) faithfully enough for UI tests.
+ */
+
+import { emitDomain, state } from "./state-store";
+
+/** The v3 files-listing wire shape (host `turn/files-ops.ts` ProjectFile). */
+interface ProjectFile {
+  path: string;
+  name: string;
+  extension: string;
+  size: number;
+  is_directory: boolean;
+  date_modified?: number;
+  date_created?: number;
+}
+
+export interface WorkspaceFile {
+  bytes: Buffer;
+  created: number;
+  modified: number;
+}
+
+const KEEP = ".keep";
+const key = (agentId: string, rel: string) => `${agentId}:${rel}`;
+const extOf = (name: string) => {
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(dot + 1) : "";
+};
+
+function entries(agentId: string): [string, WorkspaceFile][] {
+  const prefix = `${agentId}:`;
+  return [...state.workspace.entries()]
+    .filter(([k]) => k.startsWith(prefix))
+    .map(([k, v]) => [k.slice(prefix.length), v]);
+}
+
+export function writeWorkspaceFile(
+  agentId: string,
+  rel: string,
+  bytes: Buffer,
+  ts: number,
+): void {
+  const existing = state.workspace.get(key(agentId, rel));
+  state.workspace.set(key(agentId, rel), {
+    bytes,
+    created: existing?.created ?? ts,
+    modified: ts,
+  });
+}
+
+/** Files + synthesized folder rows, exactly the shape the real host lists. */
+export function listWorkspaceFiles(agentId: string): ProjectFile[] {
+  const out: ProjectFile[] = [];
+  const dirs = new Map<string, { updated: number; created: number }>();
+  for (const [rel, f] of entries(agentId)) {
+    const segments = rel.split("/");
+    for (let i = 1; i < segments.length; i++) {
+      const dir = segments.slice(0, i).join("/");
+      const cur = dirs.get(dir) ?? { updated: 0, created: f.created };
+      cur.updated = Math.max(cur.updated, f.modified);
+      cur.created = Math.min(cur.created, f.created);
+      dirs.set(dir, cur);
+    }
+    const name = segments[segments.length - 1] ?? "";
+    if (name === KEEP) continue;
+    out.push({
+      path: rel,
+      name,
+      extension: extOf(name),
+      size: f.bytes.length,
+      is_directory: false,
+      date_modified: f.modified,
+      date_created: f.created,
+    });
+  }
+  for (const [dir, meta] of dirs) {
+    out.push({
+      path: dir,
+      name: dir.split("/").pop() ?? "",
+      extension: "",
+      size: 0,
+      is_directory: true,
+      date_modified: meta.updated,
+      date_created: meta.created,
+    });
+  }
+  return out.sort((a, b) => {
+    if (a.is_directory !== b.is_directory) return a.is_directory ? -1 : 1;
+    return a.path.localeCompare(b.path);
+  });
+}
+
+export function readWorkspaceFile(
+  agentId: string,
+  rel: string,
+): WorkspaceFile | undefined {
+  return state.workspace.get(key(agentId, rel));
+}
+
+/** Finder-style upload: never overwrite, suffix " (n)" instead. */
+export function importWorkspaceFiles(
+  agentId: string,
+  dir: string | null,
+  files: { name: string; contentBase64: string }[],
+): string[] {
+  const now = Date.now();
+  const paths: string[] = [];
+  for (const f of files) {
+    let rel = dir ? `${dir}/${f.name}` : f.name;
+    const dot = rel.lastIndexOf(".");
+    for (let n = 1; state.workspace.has(key(agentId, rel)); n++) {
+      const stem = dot > 0 ? rel.slice(0, dot) : rel;
+      const ext = dot > 0 ? rel.slice(dot) : "";
+      rel = `${stem} (${n})${ext}`;
+    }
+    writeWorkspaceFile(
+      agentId,
+      rel,
+      Buffer.from(f.contentBase64, "base64"),
+      now,
+    );
+    paths.push(rel);
+  }
+  emitDomain("FilesChanged", agentId);
+  return paths;
+}
+
+/** Delete a file, or a folder with everything under it. */
+export function deleteWorkspaceEntry(agentId: string, rel: string): void {
+  state.workspace.delete(key(agentId, rel));
+  for (const k of [...state.workspace.keys()]) {
+    if (k.startsWith(`${key(agentId, rel)}/`)) state.workspace.delete(k);
+  }
+  emitDomain("FilesChanged", agentId);
+}
+
+export function renameWorkspaceEntry(
+  agentId: string,
+  rel: string,
+  newName: string,
+): void {
+  const parent = rel.includes("/")
+    ? rel.slice(0, rel.lastIndexOf("/") + 1)
+    : "";
+  moveKeys(agentId, rel, `${parent}${newName}`);
+}
+
+/** Move a file/folder into `toDir` (null = root), keeping its name. */
+export function moveWorkspaceEntry(
+  agentId: string,
+  rel: string,
+  toDir: string | null,
+): string {
+  const name = rel.split("/").pop() ?? "";
+  const to = toDir ? `${toDir}/${name}` : name;
+  moveKeys(agentId, rel, to);
+  return to;
+}
+
+function moveKeys(agentId: string, from: string, to: string): void {
+  const exact = state.workspace.get(key(agentId, from));
+  if (exact) {
+    state.workspace.delete(key(agentId, from));
+    state.workspace.set(key(agentId, to), exact);
+  }
+  for (const k of [...state.workspace.keys()]) {
+    const prefix = `${key(agentId, from)}/`;
+    if (k.startsWith(prefix)) {
+      const v = state.workspace.get(k);
+      state.workspace.delete(k);
+      if (v)
+        state.workspace.set(`${key(agentId, to)}/${k.slice(prefix.length)}`, v);
+    }
+  }
+  emitDomain("FilesChanged", agentId);
+}
+
+export function createWorkspaceFolder(agentId: string, folder: string): string {
+  writeWorkspaceFile(agentId, `${folder}/${KEEP}`, Buffer.alloc(0), Date.now());
+  emitDomain("FilesChanged", agentId);
+  return folder;
+}

--- a/packages/fake-host/src/state.ts
+++ b/packages/fake-host/src/state.ts
@@ -23,3 +23,4 @@ export * from "./state-activities";
 export * from "./state-agents";
 export * from "./state-history";
 export * from "./state-store";
+export * from "./state-workspace";

--- a/packages/host/package.json
+++ b/packages/host/package.json
@@ -24,6 +24,7 @@
     "@houston/domain": "workspace:*",
     "@houston/protocol": "workspace:*",
     "@houston/runtime-client": "workspace:*",
+    "fflate": "0.8.3",
     "tsx": "4.23.0"
   },
   "devDependencies": {

--- a/packages/host/src/dual-profile.test.ts
+++ b/packages/host/src/dual-profile.test.ts
@@ -171,12 +171,20 @@ function norm(v: unknown, agentId: string): unknown {
   if (Array.isArray(v)) return v.map((x) => norm(x, agentId));
   if (v && typeof v === "object") {
     const out: Record<string, unknown> = {};
-    for (const [k, val] of Object.entries(v))
+    for (const [k, val] of Object.entries(v)) {
+      // `dir` (the agent's real on-disk directory, HOU-677) is a DOCUMENTED
+      // profile asymmetry — local serves it, cloud has no local path to serve.
+      // Dropped here; its presence/absence is pinned in the asymmetries test.
+      if (ASYMMETRIC.has(k)) continue;
       out[k] = VOLATILE.has(k) ? "<X>" : norm(val, agentId);
+    }
     return out;
   }
   return v;
 }
+
+/** Keys that legitimately exist on one profile only (see the asymmetries test). */
+const ASYMMETRIC = new Set(["dir"]);
 
 type Step = {
   label: string;
@@ -463,6 +471,27 @@ test("the documented profile asymmetries are exactly the intended ones", async (
     expect(cc.providers).toEqual(lc.providers);
     expect(lc.openaiCompatible).toBe(true);
     expect(cc.openaiCompatible).toBe(false);
+
+    // Agent payloads: only the LOCAL profile reports the agent's real on-disk
+    // directory (`dir`) — the desktop shell needs it for OS reveal/open
+    // (HOU-677); a cloud deployment has no local path to report. Pinned here
+    // because the parity battery deliberately drops the key (ASYMMETRIC).
+    const mk = async (base: string) =>
+      (await (
+        await fetch(`${base}/agents`, {
+          method: "POST",
+          headers: auth,
+          body: JSON.stringify({ name: "DirProbe" }),
+        })
+      ).json()) as { id: string; dir?: string };
+    const localAgent = await mk(local.base);
+    const cloudAgent = await mk(cloud.base);
+    expect(typeof localAgent.dir).toBe("string");
+    // Separator-agnostic: the id is slash-joined, the dir is OS-native.
+    expect(localAgent.dir?.split("\\").join("/").endsWith(localAgent.id)).toBe(
+      true,
+    );
+    expect(cloudAgent.dir).toBeUndefined();
 
     // Shared invariants: mobile/tunnel is gone everywhere; one protocol version.
     expect(lc.tunnel).toBe(false);

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -297,6 +297,9 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     integrations,
     integrationGrants,
     agentConfigs,
+    // The desktop shell reveals/opens agent folders in the OS file manager;
+    // give it the REAL directory (the agent id is a route key, not a path).
+    agentDir: (_ws, a) => agentDir(a.id),
     corsOrigin: "*",
   };
 

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -43,6 +43,13 @@ export interface AgentRouteDeps {
   events?: EventHub;
   /** Deployment capabilities; gates local-only routes (OpenAI-compatible connect). */
   capabilities?: Capabilities;
+  /**
+   * The agent's absolute on-disk directory, when this deployment is co-located
+   * with the files (local profile). Serialized as `dir` on agent payloads so
+   * the desktop shell can reveal/open the folder in the OS file manager — the
+   * agent id is a route key, not a path (HOU-677). Cloud deployments omit it.
+   */
+  agentDir?: (ws: Workspace, agent: Agent) => string;
 }
 
 const DEFAULT_PATHS = new CloudPaths();
@@ -85,6 +92,11 @@ function channelFor(
 const noChannel = (res: ServerResponse, runtime: WorkspaceRuntime) =>
   json(res, 503, { error: `${runtime} runtime not configured` });
 
+/** Attach the agent's real directory (`dir`) when this deployment has one. */
+function withAgentDir(deps: AgentRouteDeps, ws: Workspace, agent: Agent) {
+  return deps.agentDir ? { ...agent, dir: deps.agentDir(ws, agent) } : agent;
+}
+
 /**
  * The user's agents: list/create/rename/delete, connect-once capture, and the
  * per-agent runtime dispatch (chat, SSE, providers, settings, files) — all
@@ -103,7 +115,12 @@ export async function handleAgents(
   // The user's own agents — their personal workspace, auto-provisioned on first hit.
   if (path === "/agents" && method === "GET") {
     const ws = await deps.store.getOrCreatePersonalWorkspace(userId);
-    json(res, 200, await deps.store.listAgents(ws.id));
+    const agents = await deps.store.listAgents(ws.id);
+    json(
+      res,
+      200,
+      agents.map((a) => withAgentDir(deps, ws, a)),
+    );
     return true;
   }
   if (path === "/agents" && method === "POST") {
@@ -143,7 +160,7 @@ export async function handleAgents(
       type: "AgentsChanged",
       workspaceId: ws.id,
     });
-    json(res, 201, agent);
+    json(res, 201, withAgentDir(deps, ws, agent));
     return true;
   }
 
@@ -172,7 +189,7 @@ export async function handleAgents(
         type: "AgentsChanged",
         workspaceId: authz.workspace.id,
       });
-      json(res, 200, renamed);
+      json(res, 200, withAgentDir(deps, authz.workspace, renamed));
       return true;
     }
 
@@ -533,6 +550,7 @@ export async function handleAgents(
         req,
         res,
         url.searchParams,
+        emit,
       )
     )
       return true;

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -5,7 +5,12 @@ import {
   type ServerResponse,
 } from "node:http";
 import { type Capabilities, PROTOCOL_VERSION } from "@houston/protocol";
-import type { UserId, WorkspaceRuntime } from "./domain/types";
+import type {
+  Agent,
+  UserId,
+  Workspace,
+  WorkspaceRuntime,
+} from "./domain/types";
 import type { EventHub } from "./events/hub";
 import {
   type FeedbackPayload,
@@ -84,6 +89,12 @@ export interface ControlPlaneDeps {
   events?: EventHub;
   /** What this deployment can do; served at /v1/capabilities for the UI to gate on. */
   capabilities: Capabilities;
+  /**
+   * The agent's absolute on-disk directory, when this deployment is co-located
+   * with the files (local profile). Serialized as `dir` on agent payloads so
+   * the desktop shell can reveal/open in the OS file manager (HOU-677).
+   */
+  agentDir?: (ws: Workspace, agent: Agent) => string;
   /**
    * True when this install carried over a legacy Rust-desktop chat-history db —
    * i.e. the user is migrating from the old desktop build. Surfaced on

--- a/packages/host/src/testing/vfs-contract.ts
+++ b/packages/host/src/testing/vfs-contract.ts
@@ -79,6 +79,27 @@ export function runVfsContract(name: string, make: () => Vfs): void {
       expect(await vfs.readText(`ws/w1/agent-2/keep.txt`)).toBe("keep");
     });
 
+    test("listDetailed on a plain-file prefix answers empty, never throws", async () => {
+      const vfs = make();
+      await vfs.writeText(`${P}/workspace/report.txt`, "x");
+      // A file is not a prefix — no keys live UNDER it. The Files tab's delete
+      // path relies on this to tell files from folders.
+      expect(await vfs.listDetailed(`${P}/workspace/report.txt`)).toEqual([]);
+    });
+
+    test("createdMs, when reported, survives overwrite and move", async () => {
+      const vfs = make();
+      await vfs.writeText(`${P}/workspace/doc.txt`, "v1");
+      const first = (await vfs.listDetailed(P))[0];
+      if (first?.createdMs === undefined) return; // backend has no birthtime — allowed
+      await vfs.writeText(`${P}/workspace/doc.txt`, "v2 (longer content)");
+      const overwritten = (await vfs.listDetailed(P))[0];
+      expect(overwritten?.createdMs).toBe(first.createdMs);
+      await vfs.move(`${P}/workspace/doc.txt`, `${P}/workspace/renamed.txt`);
+      const moved = (await vfs.listDetailed(P))[0];
+      expect(moved?.createdMs).toBe(first.createdMs);
+    });
+
     test("traversal keys are rejected, never mapped", async () => {
       const vfs = make();
       await expect(

--- a/packages/host/src/turn/attachments.ts
+++ b/packages/host/src/turn/attachments.ts
@@ -3,6 +3,7 @@ import type { Agent, Workspace } from "../domain/types";
 import type { WorkspacePaths } from "../paths";
 import type { Vfs } from "../vfs";
 import { json, readJson } from "./deps";
+import { MAX_UPLOAD_BYTES } from "./files-import";
 
 /**
  * Composer attachments — files the user drops on a chat message, uploaded INTO
@@ -29,8 +30,9 @@ import { json, readJson } from "./deps";
 /** The on-disk dir name. Top-level dot-dir → invisible to + untouchable by the Files tab. */
 const ATTACHMENTS_DIR = ".attachments";
 
-/** Cap a single upload request so a runaway/oversized body fails loudly, not silently. */
-const MAX_UPLOAD_BYTES = 64 * 1024 * 1024; // 64 MiB across all files in one request
+// A single request is capped at MAX_UPLOAD_BYTES (shared with files/import so
+// the composer's client-side per-file limit and the host cap can't drift; the
+// client uploads one request per file, so per-file = per-request).
 
 export class AttachmentError extends Error {
   constructor(
@@ -88,7 +90,13 @@ export async function saveAttachments(
   files: readonly UploadFile[],
 ): Promise<string[]> {
   safeSegment(scopeId, "scopeId");
-  const used = new Set<string>();
+  // Seed the dedup set with what this scope already holds, so a batch split
+  // across several requests (the client uploads one request per file to bound
+  // request size) still never silently overwrites an earlier file.
+  const scopePrefix = dirKey(root, scopeId);
+  const used = new Set<string>(
+    (await vfs.list(scopePrefix)).map((k) => k.slice(scopePrefix.length + 1)),
+  );
   const paths: string[] = [];
   for (const f of files) {
     const filename = dedupe(safeSegment(f.name, "filename"), used);

--- a/packages/host/src/turn/files-archive.test.ts
+++ b/packages/host/src/turn/files-archive.test.ts
@@ -1,0 +1,37 @@
+import { unzipSync } from "fflate";
+import { expect, test } from "vitest";
+import { MemoryVfs } from "../vfs";
+import { archiveWorkspace } from "./files-archive";
+import { FileOpError } from "./files-ops";
+
+/**
+ * "Download all" — one zip of the agent's visible files. Must mirror the
+ * listing's visibility rules exactly: what the Files tab shows is what the
+ * archive holds, nothing more (no internal state) and nothing less.
+ */
+
+const ROOT = "ws/w1/agent-1/workspace";
+
+test("zips the visible files round-trip, hiding internals and .keep markers", async () => {
+  const vfs = new MemoryVfs();
+  await vfs.writeText(`${ROOT}/report.md`, "# Q3");
+  await vfs.writeBytes(`${ROOT}/Decks/deck.pptx`, Buffer.from([1, 2, 3]));
+  await vfs.writeText(`${ROOT}/Empty/.keep`, "");
+  await vfs.writeText(`${ROOT}/.houston/activity/activity.json`, "[]");
+  await vfs.writeText(`${ROOT}/.attachments/scope/secret.txt`, "s");
+
+  const zip = await archiveWorkspace(vfs, ROOT);
+  const entries = unzipSync(new Uint8Array(zip));
+  expect(Object.keys(entries).sort()).toEqual(["Decks/deck.pptx", "report.md"]);
+  expect(Buffer.from(entries["report.md"] ?? []).toString()).toBe("# Q3");
+  expect([...(entries["Decks/deck.pptx"] ?? [])]).toEqual([1, 2, 3]);
+});
+
+test("an empty workspace answers 404, not an empty zip", async () => {
+  const vfs = new MemoryVfs();
+  await vfs.writeText(`${ROOT}/.houston/config.json`, "{}"); // internals only
+  await expect(archiveWorkspace(vfs, ROOT)).rejects.toThrow(FileOpError);
+  await expect(archiveWorkspace(vfs, ROOT)).rejects.toThrow(
+    "no files to download",
+  );
+});

--- a/packages/host/src/turn/files-archive.ts
+++ b/packages/host/src/turn/files-archive.ts
@@ -1,0 +1,48 @@
+import { type Zippable, zipSync } from "fflate";
+import type { Vfs } from "../vfs";
+import { FileOpError, fileKey, listWorkspace } from "./files-ops";
+
+/**
+ * Zip the agent's visible workspace files — the Files tab's "Download all" on
+ * deployments with no local OS to reveal a folder in (cloud pods, web builds).
+ * Same visibility rules as the listing (`listWorkspace`): internal dot-dirs and
+ * `.keep` markers never land in the archive. STORE-only (level 0): the
+ * deliverables agents produce (pdf/docx/xlsx/png) are already compressed, and a
+ * predictable fast pass beats squeezing bytes on the host's event loop.
+ */
+
+/** Refuse absurd archives rather than buffering them in host memory. */
+export const MAX_ARCHIVE_BYTES = 256 * 1024 * 1024;
+
+// Zip can only encode 1980–2099 mtimes; anything else (backends with synthetic
+// counters, files with bogus clocks) is omitted rather than crashing the zip.
+const ZIP_MTIME_MIN = Date.UTC(1980, 0, 2);
+const ZIP_MTIME_MAX = Date.UTC(2099, 0, 1);
+
+export async function archiveWorkspace(
+  vfs: Vfs,
+  root: string,
+): Promise<Buffer> {
+  const files = (await listWorkspace(vfs, root)).filter((f) => !f.is_directory);
+  if (files.length === 0) throw new FileOpError(404, "no files to download");
+  const total = files.reduce((sum, f) => sum + f.size, 0);
+  if (total > MAX_ARCHIVE_BYTES) {
+    throw new FileOpError(
+      413,
+      "the agent's files are too large to download as one archive",
+    );
+  }
+  const entries: Zippable = {};
+  for (const f of files) {
+    const buf = await vfs.readBytes(fileKey(root, f.path));
+    if (buf === null) continue; // deleted mid-archive — skip it, don't fail the download
+    const mtime = f.date_modified;
+    const validMtime =
+      mtime !== undefined && mtime >= ZIP_MTIME_MIN && mtime <= ZIP_MTIME_MAX;
+    entries[f.path] = [
+      new Uint8Array(buf),
+      { level: 0, ...(validMtime ? { mtime } : {}) },
+    ];
+  }
+  return Buffer.from(zipSync(entries));
+}

--- a/packages/host/src/turn/files-import.test.ts
+++ b/packages/host/src/turn/files-import.test.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "vitest";
+import { MemoryVfs } from "../vfs";
+import {
+  importWorkspaceFiles,
+  MAX_UPLOAD_BYTES,
+  moveWorkspaceEntry,
+  parseImportBody,
+} from "./files-import";
+import { FileOpError, FilePathError, listWorkspace } from "./files-ops";
+
+/**
+ * The write half of the Files tab: uploads (drag-drop / Browse) and drag-moves.
+ * Uploads must never clobber, never escape the root, never touch internal
+ * dot-dirs; moves must keep names, refuse conflicts, and take folders whole.
+ */
+
+const ROOT = "ws/w1/agent-1/workspace";
+
+const b64 = (s: string) => Buffer.from(s, "utf8").toString("base64");
+
+test("parseImportBody validates shape and caps the request size", () => {
+  expect(() => parseImportBody({})).toThrow(FileOpError);
+  expect(() => parseImportBody({ files: [] })).toThrow("missing 'files'");
+  expect(() => parseImportBody({ files: [{ name: 42 }] })).toThrow(
+    "needs string",
+  );
+  const oversized = "A".repeat(Math.ceil((MAX_UPLOAD_BYTES * 4) / 3) + 8);
+  expect(() =>
+    parseImportBody({ files: [{ name: "big.bin", contentBase64: oversized }] }),
+  ).toThrow("size limit");
+  const ok = parseImportBody({
+    dir: "Reports",
+    files: [{ name: "a.txt", contentBase64: b64("hi") }],
+  });
+  expect(ok.dir).toBe("Reports");
+  expect(ok.files).toHaveLength(1);
+});
+
+test("imports land at the root or in a target folder, byte-exact", async () => {
+  const vfs = new MemoryVfs();
+  const paths = await importWorkspaceFiles(vfs, ROOT, null, [
+    { name: "report.pdf", contentBase64: b64("PDF") },
+  ]);
+  expect(paths).toEqual(["report.pdf"]);
+  const nested = await importWorkspaceFiles(vfs, ROOT, "Docs/2026", [
+    { name: "notes.md", contentBase64: b64("# hi") },
+  ]);
+  expect(nested).toEqual(["Docs/2026/notes.md"]);
+  expect((await vfs.readBytes(`${ROOT}/Docs/2026/notes.md`))?.toString()).toBe(
+    "# hi",
+  );
+});
+
+test("colliding names get Finder-style ' (n)' suffixes, never overwrite", async () => {
+  const vfs = new MemoryVfs();
+  await vfs.writeText(`${ROOT}/report.pdf`, "original");
+  const paths = await importWorkspaceFiles(vfs, ROOT, null, [
+    { name: "report.pdf", contentBase64: b64("second") },
+    { name: "report.pdf", contentBase64: b64("third") },
+  ]);
+  expect(paths).toEqual(["report (1).pdf", "report (2).pdf"]);
+  expect(await vfs.readText(`${ROOT}/report.pdf`)).toBe("original");
+});
+
+test("upload names are single segments: traversal, separators, dot-files refused", async () => {
+  const vfs = new MemoryVfs();
+  for (const name of ["../evil.txt", "a/b.txt", ".env", "..", ""]) {
+    await expect(
+      importWorkspaceFiles(vfs, ROOT, null, [
+        { name, contentBase64: b64("x") },
+      ]),
+    ).rejects.toThrow(FilePathError);
+  }
+  // Target dir goes through the same wall as every other path op.
+  await expect(
+    importWorkspaceFiles(vfs, ROOT, ".houston", [
+      { name: "ok.txt", contentBase64: b64("x") },
+    ]),
+  ).rejects.toThrow(FilePathError);
+});
+
+test("move takes a file into a folder and back to the root", async () => {
+  const vfs = new MemoryVfs();
+  await vfs.writeText(`${ROOT}/a.txt`, "a");
+  expect(await moveWorkspaceEntry(vfs, ROOT, "a.txt", "Docs")).toBe(
+    "Docs/a.txt",
+  );
+  expect(await vfs.readText(`${ROOT}/Docs/a.txt`)).toBe("a");
+  expect(await moveWorkspaceEntry(vfs, ROOT, "Docs/a.txt", null)).toBe("a.txt");
+  expect(await vfs.readText(`${ROOT}/a.txt`)).toBe("a");
+});
+
+test("move takes a folder whole (children + markers), leaving nothing behind", async () => {
+  const vfs = new MemoryVfs();
+  await vfs.writeText(`${ROOT}/Docs/a.txt`, "a");
+  await vfs.writeText(`${ROOT}/Docs/sub/b.txt`, "b");
+  await vfs.writeText(`${ROOT}/Archive/.keep`, "");
+  expect(await moveWorkspaceEntry(vfs, ROOT, "Docs", "Archive")).toBe(
+    "Archive/Docs",
+  );
+  expect(await vfs.readText(`${ROOT}/Archive/Docs/a.txt`)).toBe("a");
+  expect(await vfs.readText(`${ROOT}/Archive/Docs/sub/b.txt`)).toBe("b");
+  const listed = (await listWorkspace(vfs, ROOT)).map((f) => f.path);
+  expect(listed.some((p) => p === "Docs" || p.startsWith("Docs/"))).toBe(false);
+});
+
+test("move refuses conflicts (409), self-nesting (400), and ghosts (404)", async () => {
+  const vfs = new MemoryVfs();
+  await vfs.writeText(`${ROOT}/a.txt`, "a");
+  await vfs.writeText(`${ROOT}/Docs/a.txt`, "taken");
+  await expect(moveWorkspaceEntry(vfs, ROOT, "a.txt", "Docs")).rejects.toThrow(
+    "already exists",
+  );
+  await expect(
+    moveWorkspaceEntry(vfs, ROOT, "Docs", "Docs/inner"),
+  ).rejects.toThrow("into itself");
+  await expect(
+    moveWorkspaceEntry(vfs, ROOT, "ghost.txt", "Docs"),
+  ).rejects.toThrow("file not found");
+  await expect(
+    moveWorkspaceEntry(vfs, ROOT, "a.txt", ".houston"),
+  ).rejects.toThrow(FilePathError);
+});

--- a/packages/host/src/turn/files-import.ts
+++ b/packages/host/src/turn/files-import.ts
@@ -1,0 +1,154 @@
+import type { Vfs } from "../vfs";
+import { FileOpError, FilePathError, fileKey, safeRel } from "./files-ops";
+
+/**
+ * Uploads into + moves within an agent's workspace — the write half of the
+ * Files tab (drag-drop / Browse / drag-a-row-onto-a-folder). Same path-safety
+ * wall as every other files op: nothing lands in (or moves into) the internal
+ * top-level dot-dirs, and nothing escapes the workspace root.
+ */
+
+/**
+ * Per-request upload cap. Matches the composer's per-file client limit
+ * (`app/src/lib/attachment-validation.ts`), so a file the UI accepts is never
+ * rejected here — the two limits drifting apart was a silent 413 trap.
+ */
+export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
+
+/** One uploaded file: original name + its base64-encoded bytes. */
+export interface UploadFile {
+  name: string;
+  contentBase64: string;
+}
+
+/** Validate an uploaded filename: one path segment, no traversal, no hidden files. */
+function safeUploadName(name: string): string {
+  if (
+    name === "" ||
+    name === "." ||
+    name === ".." ||
+    name.includes("/") ||
+    name.includes("\\") ||
+    name.startsWith(".")
+  ) {
+    throw new FilePathError(name);
+  }
+  return name;
+}
+
+/** Parse + validate the `files/import` body. Throws (→ 4xx) on malformed input. */
+export function parseImportBody(body: Record<string, unknown>): {
+  dir: string | null;
+  files: UploadFile[];
+} {
+  const dir = typeof body.dir === "string" && body.dir !== "" ? body.dir : null;
+  if (!Array.isArray(body.files) || body.files.length === 0) {
+    throw new FileOpError(400, "missing 'files' array");
+  }
+  let total = 0;
+  const files = body.files.map((raw, i) => {
+    const f = raw as { name?: unknown; contentBase64?: unknown };
+    if (typeof f.name !== "string" || typeof f.contentBase64 !== "string") {
+      throw new FileOpError(
+        400,
+        `file[${i}] needs string 'name' and 'contentBase64'`,
+      );
+    }
+    // base64 is ~4/3 the byte size; estimate to fail oversized uploads loudly.
+    total += Math.floor((f.contentBase64.length * 3) / 4);
+    if (total > MAX_UPLOAD_BYTES) {
+      throw new FileOpError(413, "upload exceeds the size limit");
+    }
+    return { name: f.name, contentBase64: f.contentBase64 };
+  });
+  return { dir, files };
+}
+
+/** Pick a unique rel path, appending " (n)" before the extension while taken. */
+function dedupeRel(rel: string, taken: (r: string) => boolean): string {
+  if (!taken(rel)) return rel;
+  const slash = rel.lastIndexOf("/");
+  const dirPart = slash === -1 ? "" : rel.slice(0, slash + 1);
+  const name = slash === -1 ? rel : rel.slice(slash + 1);
+  const dot = name.lastIndexOf(".");
+  const stem = dot > 0 ? name.slice(0, dot) : name;
+  const ext = dot > 0 ? name.slice(dot) : "";
+  for (let n = 1; ; n++) {
+    const candidate = `${dirPart}${stem} (${n})${ext}`;
+    if (!taken(candidate)) return candidate;
+  }
+}
+
+/**
+ * Write each uploaded file into the workspace (under `dir` when given) and
+ * return the relative paths stored. Existing files are never silently
+ * overwritten — colliding names get " (n)" suffixes, Finder-style.
+ */
+export async function importWorkspaceFiles(
+  vfs: Vfs,
+  root: string,
+  dir: string | null,
+  files: readonly UploadFile[],
+): Promise<string[]> {
+  const target = dir === null ? "" : safeRel(dir);
+  const existing = new Set((await vfs.listDetailed(root)).map((s) => s.key));
+  const paths: string[] = [];
+  for (const f of files) {
+    const name = safeUploadName(f.name);
+    const rel = dedupeRel(target ? `${target}/${name}` : name, (r) =>
+      existing.has(fileKey(root, r)),
+    );
+    await vfs.writeBytes(
+      fileKey(root, rel),
+      Buffer.from(f.contentBase64, "base64"),
+    );
+    existing.add(fileKey(root, rel));
+    paths.push(rel);
+  }
+  return paths;
+}
+
+/**
+ * Move a file or folder into `toDir` (null = workspace root), keeping its name.
+ * Refuses to clobber an existing target (409) and to move a folder into itself.
+ * Returns the new relative path.
+ */
+export async function moveWorkspaceEntry(
+  vfs: Vfs,
+  root: string,
+  rel: string,
+  toDir: string | null,
+): Promise<string> {
+  const from = safeRel(rel);
+  const target = toDir === null ? "" : safeRel(toDir);
+  if (target === from || target.startsWith(`${from}/`)) {
+    throw new FileOpError(400, "cannot move a folder into itself");
+  }
+  const name = from.split("/").pop() ?? "";
+  const to = target ? `${target}/${name}` : name;
+  if (to === from) return from;
+
+  const fromKey = fileKey(root, from);
+  const toKey = fileKey(root, to);
+  const children = await vfs.listDetailed(fromKey); // non-empty ⇒ a directory
+  const existing = new Set((await vfs.listDetailed(root)).map((s) => s.key));
+  const targetTaken =
+    existing.has(toKey) || [...existing].some((k) => k.startsWith(`${toKey}/`));
+  if (targetTaken) {
+    throw new FileOpError(409, `"${name}" already exists there`);
+  }
+
+  if (children.length > 0) {
+    for (const c of children) {
+      await vfs.move(c.key, `${toKey}${c.key.slice(fromKey.length)}`);
+    }
+    // Per-key moves leave the (now empty) source directory tree behind on a
+    // real filesystem; sweep it.
+    await vfs.deletePrefix(fromKey);
+    await vfs.deleteKey(fromKey);
+  } else {
+    if (!existing.has(fromKey)) throw new FileOpError(404, "file not found");
+    await vfs.move(fromKey, toKey);
+  }
+  return to;
+}

--- a/packages/host/src/turn/files-ops.fs.test.ts
+++ b/packages/host/src/turn/files-ops.fs.test.ts
@@ -1,0 +1,40 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { FsVfs } from "../vfs";
+import { deleteWorkspaceFile, listWorkspace } from "./files-ops";
+
+/**
+ * Files-tab deletes against the REAL filesystem adapter. This pins the desktop
+ * regression the Memory-backed suite could not see: `rm` without `recursive`
+ * refuses directories, and walking a plain file as a prefix used to throw
+ * ENOTDIR — so on the TS desktop, deleting anything from the Files tab 500'd.
+ */
+
+const ROOT = "Houston/Bo"; // local layout: the agent dir IS the workspace root
+
+function freshVfs(): FsVfs {
+  return new FsVfs(mkdtempSync(join(tmpdir(), "houston-files-")));
+}
+
+test("deletes a plain file on disk", async () => {
+  const vfs = freshVfs();
+  await vfs.writeText(`${ROOT}/report.txt`, "x");
+  await vfs.writeText(`${ROOT}/keep.txt`, "k");
+  await deleteWorkspaceFile(vfs, ROOT, "report.txt");
+  expect((await listWorkspace(vfs, ROOT)).map((f) => f.path)).toEqual([
+    "keep.txt",
+  ]);
+});
+
+test("deletes a folder with nested content on disk", async () => {
+  const vfs = freshVfs();
+  await vfs.writeText(`${ROOT}/trash/a.txt`, "a");
+  await vfs.writeText(`${ROOT}/trash/sub/b.txt`, "b");
+  await vfs.writeText(`${ROOT}/keep.txt`, "k");
+  await deleteWorkspaceFile(vfs, ROOT, "trash");
+  expect((await listWorkspace(vfs, ROOT)).map((f) => f.path)).toEqual([
+    "keep.txt",
+  ]);
+});

--- a/packages/host/src/turn/files-ops.ts
+++ b/packages/host/src/turn/files-ops.ts
@@ -1,0 +1,196 @@
+import { posix } from "node:path";
+import type { Vfs } from "../vfs";
+
+/**
+ * Pure workspace file operations behind the Files tab — shared by the HTTP
+ * handler (`files.ts`), uploads/moves (`files-import.ts`), and the zip download
+ * (`files-archive.ts`). Layout-blind: `root` is the agent's workspace root in
+ * the vfs (cloud `<prefix>/workspace`, local `<Workspace>/<Agent>`).
+ */
+
+export const FOLDER_KEEP = ".keep"; // marker that lets an empty folder show up in a listing
+
+/** The desktop ProjectFile shape the FilesBrowser renders. */
+export interface ProjectFile {
+  path: string;
+  name: string;
+  extension: string;
+  size: number;
+  is_directory: boolean;
+  date_modified?: number;
+  date_created?: number;
+}
+
+export class FilePathError extends Error {
+  constructor(rel: string) {
+    super(`invalid workspace path: ${rel}`);
+    this.name = "FilePathError";
+  }
+}
+
+/** A file operation that failed with a specific HTTP status (409 conflict, 413 too large, …). */
+export class FileOpError extends Error {
+  constructor(
+    readonly status: number,
+    message: string,
+  ) {
+    super(message);
+    this.name = "FileOpError";
+  }
+}
+
+/** Normalize a UI-supplied relative path; require it to stay inside the workspace and clear of internal dot-dirs. */
+export function safeRel(rel: string): string {
+  const cleaned = rel.replace(/\\/g, "/");
+  // Absolute (POSIX or Windows-drive) paths are anomalous — reject, don't silently clamp.
+  if (cleaned.startsWith("/") || /^[A-Za-z]:/.test(cleaned))
+    throw new FilePathError(rel);
+  const norm = posix.normalize(cleaned);
+  if (
+    norm === "" ||
+    norm === "." ||
+    norm.startsWith("..") ||
+    norm.split("/").includes("..")
+  ) {
+    throw new FilePathError(rel);
+  }
+  // Internal Houston state lives in top-level dot-dirs (.houston, .agents). The
+  // Files tab must never read or write there.
+  if (norm.split("/")[0]?.startsWith(".")) throw new FilePathError(rel);
+  return norm;
+}
+
+export const fileKey = (root: string, rel: string) => `${root}/${rel}`;
+export const extOf = (name: string) => {
+  const dot = name.lastIndexOf(".");
+  return dot > 0 ? name.slice(dot + 1) : "";
+};
+
+/**
+ * List every file under the agent's workspace, plus a synthesized entry for
+ * each directory that contains something — so the browser can render folders.
+ * The `.keep` markers that back empty folders are hidden but still surface their
+ * directory; internal top-level dot-dirs (`.houston`, `.agents`) are hidden whole.
+ */
+export async function listWorkspace(
+  vfs: Vfs,
+  root: string,
+): Promise<ProjectFile[]> {
+  const stats = await vfs.listDetailed(root);
+  const files: ProjectFile[] = [];
+  // dir path -> latest mtime / earliest creation under it
+  const dirs = new Map<string, { updated: number; created?: number }>();
+
+  for (const s of stats) {
+    const rel = s.key.slice(root.length + 1);
+    if (!rel) continue;
+    const segments = rel.split("/");
+    // Hide internal Houston state (top-level .houston / .agents) from the browser.
+    if (segments[0]?.startsWith(".")) continue;
+    // Record every ancestor directory (freshest mtime, oldest creation beneath it).
+    for (let i = 1; i < segments.length; i++) {
+      const dir = segments.slice(0, i).join("/");
+      const cur = dirs.get(dir) ?? { updated: 0 };
+      cur.updated = Math.max(cur.updated, s.updatedMs);
+      if (s.createdMs !== undefined) {
+        cur.created =
+          cur.created === undefined
+            ? s.createdMs
+            : Math.min(cur.created, s.createdMs);
+      }
+      dirs.set(dir, cur);
+    }
+    if (segments[segments.length - 1] === FOLDER_KEEP) continue; // hide the marker file itself
+    const name = segments[segments.length - 1] ?? "";
+    files.push({
+      path: rel,
+      name,
+      extension: extOf(name),
+      size: s.size,
+      is_directory: false,
+      date_modified: s.updatedMs || undefined,
+      date_created: s.createdMs || undefined,
+    });
+  }
+
+  for (const [dir, meta] of dirs) {
+    const name = dir.split("/").pop() ?? "";
+    files.push({
+      path: dir,
+      name,
+      extension: "",
+      size: 0,
+      is_directory: true,
+      date_modified: meta.updated || undefined,
+      date_created: meta.created || undefined,
+    });
+  }
+  return files.sort((a, b) => {
+    if (a.is_directory !== b.is_directory) return a.is_directory ? -1 : 1; // folders first
+    return a.path.localeCompare(b.path);
+  });
+}
+
+/** Read one workspace file. Text comes back as `content`; binary as base64. */
+export async function readWorkspaceFile(
+  vfs: Vfs,
+  root: string,
+  rel: string,
+): Promise<{ content: string; base64: boolean } | null> {
+  const buf = await vfs.readBytes(fileKey(root, safeRel(rel)));
+  if (buf === null) return null;
+  // Treat a buffer as text only if it round-trips through UTF-8 without
+  // replacement chars (so a .pptx comes back as base64 for download, not garbage).
+  const text = buf.toString("utf8");
+  const isText = !text.includes("�");
+  return isText
+    ? { content: text, base64: false }
+    : { content: buf.toString("base64"), base64: true };
+}
+
+export async function deleteWorkspaceFile(
+  vfs: Vfs,
+  root: string,
+  rel: string,
+): Promise<void> {
+  const norm = safeRel(rel);
+  const key = fileKey(root, norm);
+  const stats = await vfs.listDetailed(key);
+  if (stats.length > 0) {
+    // A directory: recursive prefix delete — deleting the child keys one by one
+    // can't remove the directory node itself on a real filesystem.
+    await vfs.deletePrefix(key);
+  }
+  await vfs.deleteKey(key);
+}
+
+export async function renameWorkspaceFile(
+  vfs: Vfs,
+  root: string,
+  rel: string,
+  newName: string,
+): Promise<void> {
+  const from = safeRel(rel);
+  if (
+    newName.includes("/") ||
+    newName.includes("\\") ||
+    newName === "" ||
+    newName.includes("..") ||
+    newName.startsWith(".")
+  )
+    throw new FilePathError(newName);
+  const parent = from.includes("/")
+    ? from.slice(0, from.lastIndexOf("/") + 1)
+    : "";
+  await vfs.move(fileKey(root, from), fileKey(root, `${parent}${newName}`));
+}
+
+export async function createWorkspaceFolder(
+  vfs: Vfs,
+  root: string,
+  folder: string,
+): Promise<string> {
+  const norm = safeRel(folder);
+  await vfs.writeText(fileKey(root, `${norm}/${FOLDER_KEEP}`), "");
+  return norm;
+}

--- a/packages/host/src/turn/files.test.ts
+++ b/packages/host/src/turn/files.test.ts
@@ -284,3 +284,112 @@ test("a missing vfs answers 503 for files routes", async () => {
   expect(handled).toBe(true);
   expect(state.status).toBe(503);
 });
+
+test("listing reports date_created for files and the oldest one for folders", async () => {
+  const objects = new MemoryVfs();
+  await seed(objects, "data/first.csv", "1"); // created @ clock 1
+  await seed(objects, "data/second.csv", "2"); // created @ clock 2
+  await objects.writeText(`${ROOT}/data/first.csv`, "1-updated"); // overwrite keeps createdMs
+
+  const byPath = Object.fromEntries(
+    (await listWorkspace(objects, ROOT)).map((f) => [f.path, f]),
+  );
+  expect(byPath["data/first.csv"]?.date_created).toBe(1);
+  expect(byPath["data/second.csv"]?.date_created).toBe(2);
+  // The folder inherits the OLDEST creation and the NEWEST modification beneath it.
+  expect(byPath.data?.date_created).toBe(1);
+  expect(byPath.data?.date_modified).toBe(3);
+});
+
+/** A fake IncomingMessage that yields a JSON body once (async-iterable). */
+function fakeReq(body: unknown) {
+  const buf = Buffer.from(JSON.stringify(body));
+  return (async function* () {
+    yield buf;
+  })() as never;
+}
+
+test("every files mutation emits FilesChanged; reads do not", async () => {
+  const objects = new MemoryVfs();
+  await seed(objects, "Docs/a.txt", "a");
+  const ctx = {
+    workspace: {} as Workspace,
+    agent: { id: "Houston/Bo" } as Agent,
+  };
+  const events: string[] = [];
+  const emit = (e: { type: string; agentPath?: string }) => {
+    expect(e.agentPath).toBe("Houston/Bo");
+    events.push(e.type);
+  };
+  const run = (
+    method: string,
+    rest: string,
+    req: unknown,
+    query: Record<string, string> = {},
+  ) =>
+    handleFiles(
+      objects,
+      PATHS,
+      ctx,
+      method,
+      rest,
+      req as never,
+      fakeRes().res,
+      new URLSearchParams(query),
+      emit as never,
+    );
+
+  await run("GET", "files", { url: "/x" });
+  expect(events).toEqual([]);
+
+  await run(
+    "POST",
+    "files/import",
+    fakeReq({
+      files: [
+        { name: "up.txt", contentBase64: Buffer.from("up").toString("base64") },
+      ],
+    }),
+  );
+  await run("POST", "files/move", fakeReq({ path: "up.txt", toDir: "Docs" }));
+  await run(
+    "POST",
+    "files/rename",
+    fakeReq({ path: "Docs/up.txt", newName: "up2.txt" }),
+  );
+  await run("POST", "files/folder", fakeReq({ path: "Reports" }));
+  await run("DELETE", "files", { url: "/x" }, { path: "Docs/up2.txt" });
+  expect(events).toEqual([
+    "FilesChanged",
+    "FilesChanged",
+    "FilesChanged",
+    "FilesChanged",
+    "FilesChanged",
+  ]);
+});
+
+test("files/archive serves a zip of the workspace over HTTP", async () => {
+  const objects = new MemoryVfs();
+  await seed(objects, "report.md", "# hi");
+  const ctx = {
+    workspace: {} as Workspace,
+    agent: { id: "Houston/Bo", name: "Bo" } as Agent,
+  };
+  const { res, state } = fakeRes();
+  await handleFiles(
+    objects,
+    PATHS,
+    ctx,
+    "GET",
+    "files/archive",
+    { url: "/x" } as never,
+    res,
+    new URLSearchParams(),
+  );
+  expect(state.status).toBe(200);
+  expect(state.headers["Content-Type"]).toBe("application/zip");
+  expect(String(state.headers["Content-Disposition"])).toContain(
+    "Bo files.zip",
+  );
+  expect(state.body?.subarray(0, 2).toString("latin1")).toBe("PK");
+});

--- a/packages/host/src/turn/files.ts
+++ b/packages/host/src/turn/files.ts
@@ -1,9 +1,27 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { posix } from "node:path";
+import type { HoustonEvent } from "@houston/protocol";
 import type { Agent, Workspace } from "../domain/types";
 import type { WorkspacePaths } from "../paths";
 import type { Vfs } from "../vfs";
 import { json, readJson } from "./deps";
+import { archiveWorkspace } from "./files-archive";
+import {
+  importWorkspaceFiles,
+  moveWorkspaceEntry,
+  parseImportBody,
+} from "./files-import";
+import {
+  createWorkspaceFolder,
+  deleteWorkspaceFile,
+  extOf,
+  FileOpError,
+  FilePathError,
+  fileKey,
+  listWorkspace,
+  readWorkspaceFile,
+  renameWorkspaceFile,
+  safeRel,
+} from "./files-ops";
 
 /**
  * Files browser for an agent's workspace — the HOST serves it for EVERY
@@ -11,8 +29,8 @@ import { json, readJson } from "./deps";
  * the web Files tab behaves identically everywhere with no drift. `root` is the
  * agent's workspace root (`WorkspacePaths.agentRoot`): cloud `<prefix>/workspace`,
  * local `<Workspace>/<Agent>`. The agent writes deck.pptx / sheet.xlsx / etc.
- * there during a turn; these endpoints list, read, download, rename, delete, and
- * create folders against it.
+ * there during a turn; these endpoints list, read, download, upload, move,
+ * rename, delete, create folders, and zip it up for "Download all".
  *
  * Internal Houston state — the top-level `.houston/` (typed data) and `.agents/`
  * (skills) dot-directories — is hidden from the listing and refused by every
@@ -20,53 +38,12 @@ import { json, readJson } from "./deps";
  *
  * Path safety: every model/UI-supplied relative path is validated to stay inside
  * `root` (no `..`, no absolute, no top-level dot-dir) before it touches storage.
+ * The pure operations live in `files-ops.ts` / `files-import.ts` /
+ * `files-archive.ts`; this module is the HTTP surface.
  */
 
-const FOLDER_KEEP = ".keep"; // marker that lets an empty folder show up in a listing
-
-/** The desktop ProjectFile shape the FilesBrowser renders. */
-export interface ProjectFile {
-  path: string;
-  name: string;
-  extension: string;
-  size: number;
-  is_directory: boolean;
-  date_modified?: number;
-}
-
-export class FilePathError extends Error {
-  constructor(rel: string) {
-    super(`invalid workspace path: ${rel}`);
-    this.name = "FilePathError";
-  }
-}
-
-/** Normalize a UI-supplied relative path; require it to stay inside the workspace and clear of internal dot-dirs. */
-function safeRel(rel: string): string {
-  const cleaned = rel.replace(/\\/g, "/");
-  // Absolute (POSIX or Windows-drive) paths are anomalous — reject, don't silently clamp.
-  if (cleaned.startsWith("/") || /^[A-Za-z]:/.test(cleaned))
-    throw new FilePathError(rel);
-  const norm = posix.normalize(cleaned);
-  if (
-    norm === "" ||
-    norm === "." ||
-    norm.startsWith("..") ||
-    norm.split("/").includes("..")
-  ) {
-    throw new FilePathError(rel);
-  }
-  // Internal Houston state lives in top-level dot-dirs (.houston, .agents). The
-  // Files tab must never read or write there.
-  if (norm.split("/")[0]?.startsWith(".")) throw new FilePathError(rel);
-  return norm;
-}
-
-const fileKey = (root: string, rel: string) => `${root}/${rel}`;
-const extOf = (name: string) => {
-  const dot = name.lastIndexOf(".");
-  return dot > 0 ? name.slice(dot + 1) : "";
-};
+// The pure ops are part of this module's public surface (tests, attachments).
+export * from "./files-ops";
 
 /** Extension → MIME for the deliverables agents actually produce. */
 const MIME: Record<string, string> = {
@@ -106,126 +83,12 @@ export const contentDisposition = (
 };
 
 /**
- * List every file under the agent's workspace, plus a synthesized entry for
- * each directory that contains something — so the browser can render folders.
- * The `.keep` markers that back empty folders are hidden but still surface their
- * directory; internal top-level dot-dirs (`.houston`, `.agents`) are hidden whole.
- */
-export async function listWorkspace(
-  vfs: Vfs,
-  root: string,
-): Promise<ProjectFile[]> {
-  const stats = await vfs.listDetailed(root);
-  const files: ProjectFile[] = [];
-  const dirs = new Map<string, number>(); // dir path -> latest mtime under it
-
-  for (const s of stats) {
-    const rel = s.key.slice(root.length + 1);
-    if (!rel) continue;
-    const segments = rel.split("/");
-    // Hide internal Houston state (top-level .houston / .agents) from the browser.
-    if (segments[0]?.startsWith(".")) continue;
-    // Record every ancestor directory (with the freshest mtime beneath it).
-    for (let i = 1; i < segments.length; i++) {
-      const dir = segments.slice(0, i).join("/");
-      dirs.set(dir, Math.max(dirs.get(dir) ?? 0, s.updatedMs));
-    }
-    if (segments[segments.length - 1] === FOLDER_KEEP) continue; // hide the marker file itself
-    const name = segments[segments.length - 1] ?? "";
-    files.push({
-      path: rel,
-      name,
-      extension: extOf(name),
-      size: s.size,
-      is_directory: false,
-      date_modified: s.updatedMs || undefined,
-    });
-  }
-
-  for (const [dir, mtime] of dirs) {
-    const name = dir.split("/").pop() ?? "";
-    files.push({
-      path: dir,
-      name,
-      extension: "",
-      size: 0,
-      is_directory: true,
-      date_modified: mtime || undefined,
-    });
-  }
-  return files.sort((a, b) => {
-    if (a.is_directory !== b.is_directory) return a.is_directory ? -1 : 1; // folders first
-    return a.path.localeCompare(b.path);
-  });
-}
-
-/** Read one workspace file. Text comes back as `content`; binary as base64. */
-export async function readWorkspaceFile(
-  vfs: Vfs,
-  root: string,
-  rel: string,
-): Promise<{ content: string; base64: boolean } | null> {
-  const buf = await vfs.readBytes(fileKey(root, safeRel(rel)));
-  if (buf === null) return null;
-  // Treat a buffer as text only if it round-trips through UTF-8 without
-  // replacement chars (so a .pptx comes back as base64 for download, not garbage).
-  const text = buf.toString("utf8");
-  const isText = !text.includes("�");
-  return isText
-    ? { content: text, base64: false }
-    : { content: buf.toString("base64"), base64: true };
-}
-
-export async function deleteWorkspaceFile(
-  vfs: Vfs,
-  root: string,
-  rel: string,
-): Promise<void> {
-  const norm = safeRel(rel);
-  const stats = await vfs.listDetailed(fileKey(root, norm));
-  if (stats.length > 0) {
-    // A directory: delete everything under it.
-    for (const s of stats) await vfs.deleteKey(s.key);
-  }
-  await vfs.deleteKey(fileKey(root, norm));
-}
-
-export async function renameWorkspaceFile(
-  vfs: Vfs,
-  root: string,
-  rel: string,
-  newName: string,
-): Promise<void> {
-  const from = safeRel(rel);
-  if (
-    newName.includes("/") ||
-    newName.includes("\\") ||
-    newName === "" ||
-    newName.includes("..") ||
-    newName.startsWith(".")
-  )
-    throw new FilePathError(newName);
-  const parent = from.includes("/")
-    ? from.slice(0, from.lastIndexOf("/") + 1)
-    : "";
-  await vfs.move(fileKey(root, from), fileKey(root, `${parent}${newName}`));
-}
-
-export async function createWorkspaceFolder(
-  vfs: Vfs,
-  root: string,
-  folder: string,
-): Promise<string> {
-  const norm = safeRel(folder);
-  await vfs.writeText(fileKey(root, `${norm}/${FOLDER_KEEP}`), "");
-  return norm;
-}
-
-/**
  * HTTP handler for `files*` routes, intercepted by the host BEFORE the runtime
  * channel (the runtime has no /files route). Returns true when it owns the
  * request (every `files*` path — so a files request is never forwarded to the
  * runtime). A missing vfs 503s; path-safety failures 400. Nothing is swallowed.
+ * Every mutation fires `FilesChanged` through `emit` so other clients' Files
+ * tabs refresh (the uploader's own tab invalidates on mutation success).
  */
 export async function handleFiles(
   vfs: Vfs | undefined,
@@ -236,6 +99,7 @@ export async function handleFiles(
   req: IncomingMessage,
   res: ServerResponse,
   query: URLSearchParams,
+  emit?: (event: HoustonEvent) => void,
 ): Promise<boolean> {
   if (rest !== "files" && !rest.startsWith("files/")) return false;
   if (!vfs) {
@@ -243,6 +107,8 @@ export async function handleFiles(
     return true;
   }
   const root = paths.agentRoot(ctx.workspace, ctx.agent);
+  const changed = () =>
+    emit?.({ type: "FilesChanged", agentPath: ctx.agent.id });
   try {
     if (method === "GET" && rest === "files") {
       await json(res, 200, await listWorkspace(vfs, root));
@@ -267,6 +133,20 @@ export async function handleFiles(
       res.end(buf);
       return true;
     }
+    if (method === "GET" && rest === "files/archive") {
+      const zip = await archiveWorkspace(vfs, root);
+      res.writeHead(200, {
+        "Content-Type": "application/zip",
+        "Content-Disposition": contentDisposition(
+          "attachment",
+          `${ctx.agent.name} files.zip`,
+        ),
+        "Content-Length": zip.length,
+        "Cache-Control": "no-store",
+      });
+      res.end(zip);
+      return true;
+    }
     if (method === "GET" && rest === "files/read") {
       const got = await readWorkspaceFile(vfs, root, query.get("path") ?? "");
       if (!got) {
@@ -278,7 +158,27 @@ export async function handleFiles(
     }
     if (method === "DELETE" && rest === "files") {
       await deleteWorkspaceFile(vfs, root, query.get("path") ?? "");
+      changed();
       await json(res, 200, { ok: true });
+      return true;
+    }
+    if (method === "POST" && rest === "files/import") {
+      const { dir, files } = parseImportBody(await readJson(req));
+      const saved = await importWorkspaceFiles(vfs, root, dir, files);
+      changed();
+      await json(res, 200, { paths: saved });
+      return true;
+    }
+    if (method === "POST" && rest === "files/move") {
+      const b = await readJson(req);
+      const moved = await moveWorkspaceEntry(
+        vfs,
+        root,
+        String(b.path ?? ""),
+        typeof b.toDir === "string" && b.toDir !== "" ? b.toDir : null,
+      );
+      changed();
+      await json(res, 200, { moved });
       return true;
     }
     if (method === "POST" && rest === "files/rename") {
@@ -289,6 +189,7 @@ export async function handleFiles(
         String(b.path ?? ""),
         String(b.newName ?? ""),
       );
+      changed();
       await json(res, 200, { ok: true });
       return true;
     }
@@ -299,6 +200,7 @@ export async function handleFiles(
         root,
         String(b.path ?? b.folder_name ?? ""),
       );
+      changed();
       await json(res, 200, { created });
       return true;
     }
@@ -309,6 +211,10 @@ export async function handleFiles(
   } catch (err) {
     if (err instanceof FilePathError) {
       json(res, 400, { error: err.message });
+      return true;
+    }
+    if (err instanceof FileOpError) {
+      json(res, err.status, { error: err.message });
       return true;
     }
     throw err;

--- a/packages/host/src/vfs/fs.ts
+++ b/packages/host/src/vfs/fs.ts
@@ -29,7 +29,7 @@ export class FsVfs implements Vfs {
 
   private async walk(
     dir: string,
-    out: { path: string; size: number; mtimeMs: number }[],
+    out: { path: string; size: number; mtimeMs: number; birthMs: number }[],
   ): Promise<void> {
     const entries = await readdir(dir, { withFileTypes: true });
     for (const e of entries) {
@@ -37,15 +37,27 @@ export class FsVfs implements Vfs {
       if (e.isDirectory()) await this.walk(p, out);
       else if (e.isFile()) {
         const s = await stat(p);
-        out.push({ path: p, size: s.size, mtimeMs: s.mtimeMs });
+        out.push({
+          path: p,
+          size: s.size,
+          mtimeMs: s.mtimeMs,
+          birthMs: s.birthtimeMs,
+        });
       }
     }
   }
 
   private async statsUnder(prefix: string): Promise<ObjectStat[]> {
     const dir = this.pathFor(prefix);
-    if (!existsSync(dir)) return [];
-    const found: { path: string; size: number; mtimeMs: number }[] = [];
+    // A prefix that resolves to a plain file has no keys UNDER it — same answer
+    // an object store gives. Walking it would readdir() a file and throw.
+    if (!existsSync(dir) || !(await stat(dir)).isDirectory()) return [];
+    const found: {
+      path: string;
+      size: number;
+      mtimeMs: number;
+      birthMs: number;
+    }[] = [];
     await this.walk(dir, found);
     return found
       .map((f) => ({
@@ -55,6 +67,8 @@ export class FsVfs implements Vfs {
           .join("/"),
         size: f.size,
         updatedMs: Math.round(f.mtimeMs),
+        // Linux filesystems without birthtime report 0 — omit rather than lie.
+        ...(f.birthMs > 0 ? { createdMs: Math.round(f.birthMs) } : {}),
       }))
       .sort((a, b) => a.key.localeCompare(b.key));
   }

--- a/packages/host/src/vfs/memory.ts
+++ b/packages/host/src/vfs/memory.ts
@@ -2,7 +2,10 @@ import { assertSafeKey, type ObjectStat, type Vfs } from "./vfs";
 
 /** In-memory Vfs for tests and CP_DEV=1. */
 export class MemoryVfs implements Vfs {
-  private files = new Map<string, { content: Buffer; updatedMs: number }>();
+  private files = new Map<
+    string,
+    { content: Buffer; updatedMs: number; createdMs: number }
+  >();
   private clock = 1;
 
   async list(prefix: string): Promise<string[]> {
@@ -18,6 +21,7 @@ export class MemoryVfs implements Vfs {
         key,
         size: v.content.byteLength,
         updatedMs: v.updatedMs,
+        createdMs: v.createdMs,
       }))
       .sort((a, b) => a.key.localeCompare(b.key));
   }
@@ -31,16 +35,14 @@ export class MemoryVfs implements Vfs {
   }
 
   async writeText(key: string, content: string): Promise<void> {
-    assertSafeKey(key);
-    this.files.set(key, {
-      content: Buffer.from(content, "utf8"),
-      updatedMs: this.clock++,
-    });
+    await this.writeBytes(key, Buffer.from(content, "utf8"));
   }
 
   async writeBytes(key: string, content: Buffer): Promise<void> {
     assertSafeKey(key);
-    this.files.set(key, { content, updatedMs: this.clock++ });
+    // An overwrite keeps the original creation time (filesystem semantics).
+    const createdMs = this.files.get(key)?.createdMs ?? this.clock;
+    this.files.set(key, { content, updatedMs: this.clock++, createdMs });
   }
 
   async deleteKey(key: string): Promise<void> {
@@ -51,7 +53,12 @@ export class MemoryVfs implements Vfs {
     assertSafeKey(toKey);
     const v = this.files.get(fromKey);
     if (!v) throw new Error(`move: source not found: ${fromKey}`);
-    this.files.set(toKey, { content: v.content, updatedMs: this.clock++ });
+    // A move keeps the creation time — renaming a file doesn't re-create it.
+    this.files.set(toKey, {
+      content: v.content,
+      updatedMs: this.clock++,
+      createdMs: v.createdMs,
+    });
     this.files.delete(fromKey);
   }
 

--- a/packages/host/src/vfs/vfs.ts
+++ b/packages/host/src/vfs/vfs.ts
@@ -3,6 +3,9 @@ export interface ObjectStat {
   key: string;
   size: number;
   updatedMs: number;
+  /** Creation time (ms epoch). Absent when the backend can't report one
+   * (e.g. Linux filesystems without birthtime). */
+  createdMs?: number;
 }
 
 /**

--- a/packages/runtime/src/session/file-changes.test.ts
+++ b/packages/runtime/src/session/file-changes.test.ts
@@ -14,14 +14,20 @@ afterEach(() => {
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-test("detects created user-visible files only", () => {
+test("announces every file the Files tab would show, whatever the extension", () => {
+  // The chat card and the Files tab must agree: an agent-created file that
+  // shows in the tab is announced in chat. The old extension allowlist hid
+  // extensionless files ("create a file named ping") — the tab showed them,
+  // the chat said nothing (HOU-677 follow-up).
   const before = snapshotWorkspace(dir);
 
   writeFileSync(join(dir, "deck.pptx"), "ppt");
+  writeFileSync(join(dir, "ping"), "pong");
   writeFileSync(join(dir, "make_deck.py"), "print('x')");
+  writeFileSync(join(dir, ".env"), "SECRET=1"); // dot-files stay hidden
 
   const changes = diffSnapshots(before, snapshotWorkspace(dir));
-  expect(changes.created).toEqual(["deck.pptx"]);
+  expect(changes.created).toEqual(["deck.pptx", "make_deck.py", "ping"]);
   expect(changes.modified).toEqual([]);
 });
 

--- a/packages/runtime/src/session/file-changes.ts
+++ b/packages/runtime/src/session/file-changes.ts
@@ -4,9 +4,15 @@ import { join } from "node:path";
 /**
  * Per-turn file-change tracking: snapshot the workspace's USER-VISIBLE files
  * before a turn, diff after, and surface what the turn created/modified as a
- * `file_changes` wire frame + `ChatMessage.fileChanges`. Port of the Rust
- * engine's `sessions/file_changes.rs`, sharing its visibility rules so the
- * "files this mission touched" summary behaves identically across engines.
+ * `file_changes` wire frame + `ChatMessage.fileChanges`.
+ *
+ * Visibility matches the Files tab's listing (host `turn/files-ops.ts`): every
+ * file the tab shows is announced in chat, so the two surfaces never disagree
+ * about whether the agent "made a file". The Rust port's extension allowlist
+ * hid anything without a known deliverable extension — an agent creating a
+ * file named `ping` showed in the Files tab but produced no in-chat card
+ * (HOU-677 follow-up). Only dot-files, the seeded role files, and scaffolding
+ * dirs stay hidden.
  *
  * Paths are workspace-RELATIVE with `/` separators (portable across the
  * desktop and cloud pods; the frontend renders basenames either way).
@@ -25,34 +31,8 @@ const SKIP_DIRS = new Set([
 ]);
 
 /**
- * Only user-deliverable file types count as "visible" — documents, images,
- * plain text. Code/config files an agent writes as scaffolding never show up
- * in the chat summary. Mirrors the Rust `USER_EXTENSIONS` allowlist.
- */
-const USER_EXTENSIONS = new Set([
-  "docx",
-  "doc",
-  "xlsx",
-  "xls",
-  "pptx",
-  "ppt",
-  "pdf",
-  "png",
-  "jpg",
-  "jpeg",
-  "svg",
-  "gif",
-  "txt",
-  "rtf",
-  "csv",
-  "md",
-  "markdown",
-]);
-
-/**
- * Markdown passes the extension gate, but the seeded role files must NOT be
- * reported — otherwise every agent's first session would falsely claim it
- * created its own instructions (Rust test: role files ignored, issue #294).
+ * The seeded role files must NOT be reported — otherwise every agent's first
+ * session would falsely claim it created its own instructions (issue #294).
  */
 const HIDDEN_ROLE_FILES = new Set(["claude.md", "agents.md", "gemini.md"]);
 
@@ -67,10 +47,10 @@ export interface FileChanges {
 }
 
 function isUserVisible(name: string): boolean {
-  if (HIDDEN_ROLE_FILES.has(name.toLowerCase())) return false;
-  const dot = name.lastIndexOf(".");
-  if (dot <= 0) return false;
-  return USER_EXTENSIONS.has(name.slice(dot + 1).toLowerCase());
+  // Dot-files are markers/config (.keep, .env, …), never deliverables — and
+  // the Files tab hides them too.
+  if (name.startsWith(".")) return false;
+  return !HIDDEN_ROLE_FILES.has(name.toLowerCase());
 }
 
 function walk(dir: string, rel: string, out: FileSnapshot): void {

--- a/packages/web/.claude/skills/verify/SKILL.md
+++ b/packages/web/.claude/skills/verify/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: verify
+description: Drive Houston's TS host + web UI end-to-end to verify a change against the running system (host HTTP battery + Playwright Files/board flows).
+---
+
+# Verifying Houston changes at runtime
+
+## TS host (the real desktop sidecar), hermetically
+
+```bash
+mkdir -p /tmp/hh/workspaces/Personal/"Agent 1"
+HOUSTON_HOME=/tmp/hh HOUSTON_HOST_PORT=48123 HOUSTON_HOST_TOKEN=t \
+  node --import tsx packages/host/src/local/main.ts
+# wait for {"status":"ok"}:
+curl -s http://127.0.0.1:48123/health
+```
+
+- Auth: `Authorization: Bearer t`. Agent ids are `<Workspace>/<Agent>` —
+  URL-encode the slash (`/agents/Personal%2FAgent%201/files`).
+- SSE reactivity feed: `curl -N 'http://127.0.0.1:48123/v1/events?token=t'`.
+- The runtime is only spawned for chat turns; files/agents routes need no
+  provider credentials.
+
+## Web UI (the same React tree the desktop ships)
+
+Playwright + the fake host (`@houston/fake-host`), all boot handled by the
+harness:
+
+```bash
+pnpm --filter houston-web test:e2e             # whole suite
+cd packages/web && npx playwright test e2e/files.spec.ts --reporter=line
+```
+
+- Specs live in `packages/web/e2e/`; fixtures reset the fake host per test.
+- One-off screenshots: drop a temp spec in `e2e/`, `page.screenshot(...)`,
+  delete it after (testDir is pinned to `e2e/`).
+- Gotchas: controlled inputs never match `input[value=…]` (use
+  `getByRole("textbox")`); headless Chromium names blob downloads with a GUID —
+  assert downloaded bytes, not `suggestedFilename()`.
+
+## Gates (CI-equivalent, not a substitute for the above)
+
+`pnpm check` · `pnpm typecheck` (ui+app+web) · `pnpm --filter @houston/host test`
+· `cd app && pnpm check-locales` · `pnpm check:boundaries`

--- a/packages/web/e2e/files.spec.ts
+++ b/packages/web/e2e/files.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "./support/fixtures";
+
+/**
+ * The Files tab on the host adapter (HOU-677 follow-through): listing with
+ * full metadata, uploads through the footer button, context-menu rename +
+ * delete, and the browser-mode footer ("Download all" — reveal-in-OS only
+ * exists on a co-located desktop). The fake host models the real host's
+ * `files*` routes (see `@houston/fake-host` routes-files.ts).
+ */
+
+async function openFilesTab(page: import("@playwright/test").Page) {
+  await page.goto("/");
+  await page.getByRole("button", { name: "Files", exact: true }).click();
+  // Seeded workspace: Q3 report.pdf + Docs/sales.csv.
+  await expect(page.getByText("Q3 report.pdf")).toBeVisible();
+}
+
+test("lists files with kind, size, and both date columns", async ({ page }) => {
+  await openFilesTab(page);
+
+  // Column headers, including the new Date Created.
+  for (const col of ["Name", "Date Modified", "Date Created", "Size", "Kind"]) {
+    await expect(page.getByRole("button", { name: col })).toBeVisible();
+  }
+  // The folder row and the file row, with Finder-style kind labels.
+  await expect(page.getByText("Docs", { exact: true })).toBeVisible();
+  await expect(page.getByText("PDF Document")).toBeVisible();
+
+  // Browser build: no OS file manager — the footer offers Download all +
+  // Upload files, never "Open in File Manager".
+  await expect(
+    page.getByRole("button", { name: "Upload files" }),
+  ).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Download all" }),
+  ).toBeVisible();
+  await expect(page.getByText("Open in File Manager")).toHaveCount(0);
+});
+
+test("uploads a file through the footer button", async ({ page }) => {
+  await openFilesTab(page);
+
+  const [chooser] = await Promise.all([
+    page.waitForEvent("filechooser"),
+    page.getByRole("button", { name: "Upload files" }).click(),
+  ]);
+  await chooser.setFiles({
+    name: "notes.md",
+    mimeType: "text/markdown",
+    buffer: Buffer.from("# uploaded from the files tab"),
+  });
+
+  // The upload lands in the fake host's workspace and the listing refreshes.
+  await expect(page.getByText("notes.md")).toBeVisible();
+  await expect(page.getByText("Markdown", { exact: true })).toBeVisible();
+});
+
+test("renames and deletes a file from the context menu", async ({ page }) => {
+  await openFilesTab(page);
+
+  const row = page.getByText("Q3 report.pdf");
+  await row.click({ button: "right" });
+  // Browser mode: Preview + Download (no reveal). Rename swaps in an inline input.
+  await expect(page.getByRole("menu").getByText("Download")).toBeVisible();
+  await expect(
+    page.getByRole("menu").getByText("Show in File Manager"),
+  ).toHaveCount(0);
+  await page.getByRole("menu").getByText("Rename").click();
+  // The inline rename field is the only textbox on the Files tab (the sidebar
+  // search is a searchbox). A controlled input's value is a DOM property, so
+  // an attribute selector would never match it.
+  const input = page.getByRole("textbox");
+  await expect(input).toHaveValue("Q3 report.pdf");
+  await input.fill("Q3 final.pdf");
+  await input.press("Enter");
+  await expect(page.getByText("Q3 final.pdf")).toBeVisible();
+
+  await page.getByText("Q3 final.pdf").click({ button: "right" });
+  await page.getByRole("menu").getByText("Move to Trash").click();
+  await expect(page.getByText("Q3 final.pdf")).toHaveCount(0);
+});
+
+test("Download all saves the whole workspace as one zip", async ({ page }) => {
+  await openFilesTab(page);
+
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.getByRole("button", { name: "Download all" }).click(),
+  ]);
+  // Headless Chromium names blob downloads with a GUID, so assert the content
+  // (a real zip with bytes in it), not the browser-computed filename.
+  const file = await download.path();
+  const { readFileSync } = await import("node:fs");
+  const zip = readFileSync(file);
+  expect(zip.subarray(0, 2).toString("latin1")).toBe("PK");
+  expect(zip.length).toBeGreaterThan(50);
+});

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -676,6 +676,53 @@ export class HoustonClient {
       })
     ).json()) as { created: string };
   }
+  /** Upload browser Files into the workspace (Files tab drag-drop / Browse),
+   * optionally into a subfolder. One request per file, so each request stays
+   * within the host's upload cap regardless of how many files were dropped. */
+  async uploadProjectFiles(
+    agentPath: string,
+    files: File[],
+    targetDir?: string | null,
+  ): Promise<void> {
+    if (files.length === 0) return;
+    if (!this.cp) throw new Error("Uploading files needs a connected host.");
+    for (const f of files) {
+      const contentBase64 = controlPlane.bytesToBase64(
+        new Uint8Array(await f.arrayBuffer()),
+      );
+      await this.cpFilesFetch(agentPath, "files/import", {
+        method: "POST",
+        body: JSON.stringify({
+          dir: targetDir ?? null,
+          files: [{ name: f.name, contentBase64 }],
+        }),
+      });
+    }
+  }
+  /** Move a file/folder into another folder (null = workspace root). */
+  async moveProjectFile(
+    agentPath: string,
+    relPath: string,
+    toDir: string | null,
+  ): Promise<void> {
+    if (!this.cp) throw new Error("Moving files needs a connected host.");
+    await this.cpFilesFetch(agentPath, "files/move", {
+      method: "POST",
+      body: JSON.stringify({ path: relPath, toDir }),
+    });
+  }
+  /** The whole workspace as one zip — "Download all" where there's no local
+   * file manager to reveal in (cloud pods, web builds). */
+  async downloadProjectArchive(
+    agentPath: string,
+  ): Promise<{ blob: Blob; contentType: string }> {
+    if (!this.cp) throw new Error("Downloads need a connected host.");
+    const res = await this.cpFilesFetch(agentPath, "files/archive");
+    return {
+      blob: await res.blob(),
+      contentType: res.headers.get("content-type") ?? "application/zip",
+    };
+  }
 
   // ---- conversations / routines / skills (mostly empty) ----
   async listConversations(agentPath: string): Promise<ConversationEntry[]> {

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -43,6 +43,9 @@ interface CpAgent {
   workspaceId: string;
   name: string;
   createdAt: number;
+  /** Absolute on-disk directory — present only when the host is co-located
+   * with the files (local profile). Feeds the OS reveal/open commands. */
+  dir?: string;
   assigned?: boolean;
   assignedUserIds?: string[];
 }
@@ -128,6 +131,9 @@ function toUiAgent(a: CpAgent, colors = colorOverlay()): Agent {
     id: a.id,
     name: a.name,
     folderPath: a.id, // the agent id IS the chat route key: /agents/${id}/conversations/...
+    // The REAL directory (local hosts only) — what OS reveal/open needs, since
+    // folderPath here is a route key, not a path (HOU-677).
+    localDir: a.dir,
     configId: DEFAULT_AGENT_CONFIG_ID,
     color: colors[a.id] ?? DEFAULT_AGENT_COLOR,
     createdAt: iso,
@@ -699,20 +705,27 @@ export async function saveAttachments(
   scopeId: string,
   files: readonly File[],
 ): Promise<string[]> {
-  const payload = {
-    scopeId,
-    files: await Promise.all(
-      files.map(async (f) => ({
-        name: f.name,
-        contentBase64: bytesToBase64(new Uint8Array(await f.arrayBuffer())),
-      })),
-    ),
-  };
-  const res = await cpFetch(cfg, `${agentPath(agentId)}/attachments`, {
-    method: "POST",
-    body: JSON.stringify(payload),
-  });
-  return ((await res.json()) as { paths: string[] }).paths;
+  // One request per file: bounds each request to the client's per-file limit,
+  // so a multi-file drop can't blow past the host's per-request upload cap
+  // (the host dedupes against the scope's existing files across requests).
+  const paths: string[] = [];
+  for (const f of files) {
+    const payload = {
+      scopeId,
+      files: [
+        {
+          name: f.name,
+          contentBase64: bytesToBase64(new Uint8Array(await f.arrayBuffer())),
+        },
+      ],
+    };
+    const res = await cpFetch(cfg, `${agentPath(agentId)}/attachments`, {
+      method: "POST",
+      body: JSON.stringify(payload),
+    });
+    paths.push(...((await res.json()) as { paths: string[] }).paths);
+  }
+  return paths;
 }
 
 export async function deleteAttachments(
@@ -730,7 +743,7 @@ export async function deleteAttachments(
 }
 
 /** Base64-encode bytes without blowing the call stack on large files (chunked btoa). */
-function bytesToBase64(bytes: Uint8Array): string {
+export function bytesToBase64(bytes: Uint8Array): string {
   let binary = "";
   const CHUNK = 0x8000;
   for (let i = 0; i < bytes.length; i += CHUNK) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -252,6 +252,9 @@ importers:
       '@houston/runtime-client':
         specifier: workspace:*
         version: link:../runtime-client
+      fflate:
+        specifier: 0.8.3
+        version: 0.8.3
     devDependencies:
       '@types/node':
         specifier: 22.20.0
@@ -286,6 +289,9 @@ importers:
       '@houston/runtime-client':
         specifier: workspace:*
         version: link:../runtime-client
+      fflate:
+        specifier: 0.8.3
+        version: 0.8.3
       tsx:
         specifier: 4.23.0
         version: 4.23.0

--- a/ui/agent/src/file-row.tsx
+++ b/ui/agent/src/file-row.tsx
@@ -22,7 +22,7 @@ const BASE_INDENT = 12;
 const TRIANGLE_AREA = 16;
 
 /** Column grid shared between header and rows. */
-export const COL_GRID = "1fr 190px 80px 130px";
+export const COL_GRID = "1fr 160px 160px 80px 130px";
 
 export function FolderSection({
   node,
@@ -93,7 +93,10 @@ export function FolderSection({
           <span className="text-[13px] truncate">{node.name}</span>
         </div>
         <span className="text-[11px] text-muted-foreground truncate px-2">
-          {"\u2014"}
+          {formatFileManagerDate(node.entry?.dateModified)}
+        </span>
+        <span className="text-[11px] text-muted-foreground truncate px-2">
+          {formatFileManagerDate(node.entry?.dateCreated)}
         </span>
         <span className="text-[11px] text-muted-foreground text-right px-2">
           --
@@ -260,6 +263,9 @@ export function FileRow({
         </div>
         <span className={cn("text-[11px] truncate px-2", sec)}>
           {formatFileManagerDate(file.dateModified)}
+        </span>
+        <span className={cn("text-[11px] truncate px-2", sec)}>
+          {formatFileManagerDate(file.dateCreated)}
         </span>
         <span className={cn("text-[11px] text-right px-2", sec)}>
           {formatSize(file.size)}

--- a/ui/agent/src/files-browser.tsx
+++ b/ui/agent/src/files-browser.tsx
@@ -18,6 +18,7 @@ import { type SortDirection, type SortKey, sortTree } from "./utils";
 export interface FilesBrowserLabels {
   columnName?: string;
   columnDateModified?: string;
+  columnDateCreated?: string;
   columnSize?: string;
   columnKind?: string;
   loading?: string;
@@ -27,6 +28,7 @@ export interface FilesBrowserLabels {
 const DEFAULT_LABELS: Required<FilesBrowserLabels> = {
   columnName: "Name",
   columnDateModified: "Date Modified",
+  columnDateCreated: "Date Created",
   columnSize: "Size",
   columnKind: "Kind",
   loading: "Loading\u2026",
@@ -191,6 +193,13 @@ export function FilesBrowser({
           <HeaderCell
             label={l.columnDateModified}
             col="dateModified"
+            sortKey={sortKey}
+            sortDir={sortDir}
+            onSort={handleSort}
+          />
+          <HeaderCell
+            label={l.columnDateCreated}
+            col="dateCreated"
             sortKey={sortKey}
             sortDir={sortDir}
             onSort={handleSort}

--- a/ui/agent/src/tree.ts
+++ b/ui/agent/src/tree.ts
@@ -10,6 +10,8 @@ export interface FolderNode {
   /** Relative path from workspace root (e.g. "2025/Investments - Fidelity") */
   path: string;
   children: TreeNode[];
+  /** The folder's own listing entry (dates), when the backend reported one. */
+  entry?: FileEntry;
 }
 
 export interface FileNode {
@@ -51,6 +53,8 @@ export function buildTree(files: FileEntry[]): FolderNode {
         }
         node = child;
       }
+      // This entry IS the folder — keep its metadata (dates) on the node.
+      node.entry = file;
       continue;
     }
 

--- a/ui/agent/src/types.ts
+++ b/ui/agent/src/types.ts
@@ -13,6 +13,8 @@ export interface FileEntry {
   is_directory?: boolean;
   /** Last modified timestamp in milliseconds (Date.now() format) */
   dateModified?: number;
+  /** Creation timestamp in milliseconds (Date.now() format) */
+  dateCreated?: number;
 }
 
 // --- Instructions panel ---

--- a/ui/agent/src/utils.ts
+++ b/ui/agent/src/utils.ts
@@ -89,7 +89,7 @@ export function getKind(extension: string): string {
 
 // --- Sort ---
 
-export type SortKey = "name" | "dateModified" | "size" | "kind";
+export type SortKey = "name" | "dateModified" | "dateCreated" | "size" | "kind";
 export type SortDirection = "asc" | "desc";
 
 /** Recursively sort a tree (folders first, then by selected column). */
@@ -113,6 +113,9 @@ export function sortTree(
         break;
       case "dateModified":
         cmp = (fa.dateModified ?? 0) - (fb.dateModified ?? 0);
+        break;
+      case "dateCreated":
+        cmp = (fa.dateCreated ?? 0) - (fb.dateCreated ?? 0);
         break;
       case "size":
         cmp = fa.size - fb.size;

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -135,6 +135,16 @@ function isAbortError(err: unknown): boolean {
   return err instanceof Error && err.name === "AbortError";
 }
 
+/** Base64-encode bytes without blowing the call stack on large files (chunked btoa). */
+function bytesToBase64(bytes: Uint8Array): string {
+  let binary = "";
+  const CHUNK = 0x8000;
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
+  }
+  return btoa(binary);
+}
+
 function makeAbortError(): Error {
   if (typeof DOMException !== "undefined") {
     return new DOMException("The operation was aborted.", "AbortError");
@@ -605,6 +615,35 @@ export class HoustonClient {
       file_name: fileName,
       data_base64: dataBase64,
     });
+  }
+  /** Upload browser Files into the agent's workspace (Files tab drag-drop /
+   * Browse). This engine's import route takes one file per request and has no
+   * target-folder parameter, so uploads land at the workspace root. */
+  async uploadProjectFiles(
+    agentPath: string,
+    files: File[],
+    _targetDir?: string | null,
+  ): Promise<void> {
+    for (const f of files) {
+      const bytes = new Uint8Array(await f.arrayBuffer());
+      await this.importFileBytes(agentPath, f.name, bytesToBase64(bytes));
+    }
+  }
+  /** This engine has no move route; the Files tab only offers drag-move on the
+   * TS host. Refuse loudly rather than pretend the file moved. */
+  async moveProjectFile(
+    _agentPath: string,
+    _relPath: string,
+    _toDir: string | null,
+  ): Promise<void> {
+    throw new Error("Moving files is not supported on this engine.");
+  }
+  /** This engine has no archive route ("Download all" is a TS-host feature);
+   * it is never offered in the UI here, so refuse loudly if reached. */
+  async downloadProjectArchive(
+    _agentPath: string,
+  ): Promise<{ blob: Blob; contentType: string }> {
+    throw new Error("Downloading all files is not supported on this engine.");
   }
 
   // ---------- agents: activities ----------

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -163,6 +163,14 @@ export interface Agent {
   createdAt: string;
   lastOpenedAt?: string;
   /**
+   * The agent's absolute on-disk directory, reported only when the engine is
+   * co-located with the files (TS host, local profile). This is what the
+   * desktop shell hands to the OS reveal/open commands — `folderPath` there is
+   * a route key, not a path (HOU-677). Absent on cloud and on the legacy Rust
+   * engine (whose `folderPath` is already the real path).
+   */
+  localDir?: string;
+  /**
    * Multiplayer only: whether the CURRENT user has been assigned this agent
    * (i.e. may use it). Absent in single-player mode, where every agent is the
    * sole user's. The host computes this per-caller.
@@ -349,6 +357,9 @@ export interface ProjectFile {
   /** Last modification time in milliseconds since the UNIX epoch. Omitted
    * when the filesystem doesn't expose mtime for the entry. */
   date_modified?: number;
+  /** Creation time in milliseconds since the UNIX epoch. Omitted when the
+   * storage backend doesn't report one (e.g. Linux without birthtime). */
+  date_created?: number;
 }
 
 export interface InstalledConfig {


### PR DESCRIPTION
## Root cause (HOU-677)

On the TS engine, `agent.folderPath` is the agent **id** (a chat route key like `Personal/Agent 3`), but the Files tab handed it straight to the Tauri shell's native `reveal_*`/`open_file` commands, which treat it as a filesystem path. Every "Show in File Manager" / "Open in File Manager" click failed with `File does not exist: Personal/Agent 3/stuff.md`.

## Fix

- **Host**: the local profile now reports each agent's real absolute directory as `dir` on agent payloads (list/create/rename). It's a documented profile asymmetry — cloud has no local path to report — pinned in `dual-profile.test.ts`.
- **Adapter/client**: `dir` maps to a new additive `Agent.localDir`; the Files tab hands **that** to the OS commands, gated on `isCoLocatedEngine()` (sidecar or loopback host) so a remote host's paths can never leak into Finder. The legacy engine keeps using its already-absolute `folderPath`.
- **Cloud/web**: where there is no local OS, the footer button becomes **Download all** — a new `GET files/archive` host route that zips the visible workspace (fflate, store-only, 256 MiB cap).

## Files-tab parity on the TS engine (rest of the sweep)

- **Uploads**: drag-drop (incl. onto folders), a Browse button in the empty state, and a visible footer "Upload files" button — via a new `POST files/import` route (Finder-style `" (n)"` dedupe against existing files, single-segment name validation, 100 MiB cap). The legacy engine gets the same UI riding its existing `import-bytes` route (root-level).
- **Drag-move**: new `POST files/move` route — folders move whole, 409 on name conflict, refuses self-nesting; wired in the UI on the TS engine only.
- **Metadata**: `date_created` now flows Vfs → listing → a new sortable **Date Created** column; folder rows show real modified/created dates instead of dashes.
- **Reactivity**: every files mutation now emits `FilesChanged`, so other clients' Files tabs refresh; the uploader's own tab refreshes via mutation success.
- **Repairs found along the way**:
  - Deleting a file **or folder** from the Files tab 500'd on the desktop FsVfs (non-recursive `rm` on directories; `readdir` crash on plain-file prefixes). Fixed + pinned with FsVfs tests.
  - Composer attachments: client per-file limit (100 MiB) vs host per-request cap (64 MiB) mismatch — the adapter now uploads one request per file and the caps share one constant; the host dedupes across requests within a scope.

## Follow-up: in-chat "new file" card missed extensionless files

Asking the agent to *"create a file named ping"* put `ping` in the Files tab but produced **no in-chat file card**; renaming it to `ping.txt` suddenly did. Cause: the runtime's per-turn `file_changes` diff used the Rust-ported extension **allowlist**, so anything without a known deliverable extension was invisible to the chat while fully visible in the Files tab.

The chat card and the Files tab now share one visibility rule: **everything the tab lists is announced** — only dot-files, the seeded role files (CLAUDE.md/AGENTS.md/GEMINI.md), and scaffolding dirs (`node_modules`, `scripts`, `skills`, …) stay hidden. Note this is a deliberate product-behavior change: agent-written code files at the workspace root (e.g. `make_deck.py`) are now announced too, because they appear in the Files tab and the two surfaces disagreeing is exactly the reported bug.

Verify: ask an agent to create a file named `ping` → the "1 new file" card appears immediately, extension or not.

## Tests

- Vfs contract: `createdMs` survives overwrite/move; plain-file prefixes list empty (both impls).
- New `files-import` / `files-archive` / `files-ops.fs` suites; `files.test.ts` covers the new routes + `FilesChanged` emits; dual-profile pins the `dir` asymmetry.
- New Playwright `files.spec.ts` (first UI coverage for the Files tab): listing with both date columns, upload through the footer button, context-menu rename/delete, Download-all producing a real zip — against a fake host that now models the `files*` surface.

## Repro (before)

1. Desktop build with the TS engine (`VITE_NEW_ENGINE=1`, host sidecar), agent with any file.
2. Files tab → right-click a file → "Show in File Manager" (or the bottom-right "Open in File Manager").
3. Toast: `Houston, we have a problem! File does not exist: <Workspace>/<Agent>/<file>`.

## Verify (after)

1. Same build: right-click → "Show in File Manager" opens Finder/Explorer with the file selected; the footer button opens the agent folder. (Verified the wire half live: `GET /agents` on a booted local host returns `dir` as the real absolute path; the native commands receive it unchanged.)
2. Drag any pdf/docx/xlsx/png/md onto the Files tab (or footer → Upload files): it appears with size/kind/dates; dropping onto a folder lands inside it; a name collision produces `name (1).ext`.
3. Point the app at a cloud workspace: the footer shows **Download all** instead, and it saves `<Agent> files.zip`; per-file right-click offers Download.
4. `pnpm --filter @houston/host test` (505 ✓) and `cd packages/web && npx playwright test e2e/files.spec.ts` (4 ✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
