### PR TITLE
fix(chat): drop duplicate Skills/Effort/Model from composer + menu (HOU-678)

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -891,7 +891,7 @@ export function useAgentChatPanel({
 
   const attachMenu = useMemo<AIBoardProps["attachMenu"]>(() => {
     if (!agent) return undefined;
-    return ({ openFilePicker, close }) => (
+    return ({ openFilePicker }) => (
       <div className="flex flex-col gap-0.5">
         <button
           type="button"
@@ -903,43 +903,9 @@ export function useAgentChatPanel({
           <Paperclip className="size-4 text-muted-foreground" />
           {t("composerAttach.addFiles")}
         </button>
-        <button
-          type="button"
-          onClick={() => {
-            setPickerOpen(true);
-            close();
-          }}
-          className="flex items-center gap-2 px-2 py-1.5 rounded-md text-sm text-foreground hover:bg-accent transition-colors"
-        >
-          <Play className="size-4 text-muted-foreground fill-current" />
-          {t("composerSkill.browse")}
-        </button>
-        <div className="px-2 py-1">
-          <ChatModelSelector
-            provider={effectiveProvider}
-            model={effectiveModel}
-            onSelect={handleModelSelect}
-          />
-        </div>
-        <div className="px-2 py-1">
-          <ChatEffortSelector
-            provider={effectiveProvider}
-            model={effectiveModel}
-            effort={effectiveEffort}
-            onSelect={handleEffortSelect}
-          />
-        </div>
       </div>
     );
-  }, [
-    agent,
-    t,
-    effectiveProvider,
-    effectiveModel,
-    effectiveEffort,
-    handleModelSelect,
-    handleEffortSelect,
-  ]);
+  }, [agent, t]);
 
   const pickerDialog = agent ? (
     <>


### PR DESCRIPTION
## Summary

The chat input's **"+" menu** offered four items: **Add files**, **Skills**, **Model**, and **Effort**. But Skills, Model, and Effort are already present as their own controls in the **footer toolbar directly below the text input** — so the "+" menu was showing the exact same three controls twice.

This removes the duplicated **Skills**, **Model**, and **Effort** entries from the "+" menu, leaving only **Add files** (the one item that has no footer equivalent). The footer controls are untouched.

Closes HOU-678.

## Root cause

Both the "+" menu and the footer were built in the same hook — `app/src/components/use-agent-chat-panel.tsx` — and the `attachMenu` render-prop embedded the same `ChatModelSelector` / `ChatEffortSelector` components and Skills button that the `footer` render-prop already rendered. The two blocks reference identical components and `t()` keys, so it was a literal duplication.

## Change

- `app/src/components/use-agent-chat-panel.tsx` — `attachMenu` now renders only the **Add files** button. Removed the Skills button and the embedded `ChatModelSelector` / `ChatEffortSelector`, dropped the now-unused `close` render-prop arg, and trimmed the `useMemo` dependency array to `[agent, t]`.

No imports became orphaned: `Play`, `ChatModelSelector`, `ChatEffortSelector`, `setPickerOpen`, and the `effective*` / `handle*` symbols are all still used by the `footer` block. No i18n keys were removed (`composerSkill.browse`, `modelSelector.*` are still used by the footer). Net diff: 2 insertions, 36 deletions, one file.

## Verification

**Before (bug):** open an agent chat, click the **"+"** button to the left of the composer. The popover shows **Add files, Skills, Model, Effort** — Skills/Model/Effort are identical to the controls already in the row directly beneath the input.

**After (fixed):** click the **"+"** button. The popover shows **only "Add files"**. Skills, Model, and Effort remain fully functional in the footer row below the input.

Gates run locally, all green:
- `pnpm typecheck` (app) — clean
- `pnpm check-locales` (app) — locales in sync
- `pnpm check:fix` (Biome, workspace root) — 1410 files, no fixes needed
- pre-commit hook typechecked `ui/board`, `app`, and `packages/web` — all passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
