### PR TITLE
fix(sdk): transport-failed send waits for stream evidence instead of failing the turn (HOU-683)

### DIFF
--- a/packages/sdk/src/modules/turns/stream-registry.ts
+++ b/packages/sdk/src/modules/turns/stream-registry.ts
@@ -4,6 +4,13 @@ import type { ResumableBackoff } from "@houston/runtime-client";
 export interface StreamTuning {
   idleTimeoutMs?: number;
   backoff?: ResumableBackoff;
+  /**
+   * Grace before an AMBIGUOUS send failure (transport error — the engine may
+   * or may not have received the POST) settles the turn as an error. Within
+   * the window the live stream can prove the send landed (nonce echo /
+   * running sync) and the turn proceeds as if the send had succeeded.
+   */
+  sendVerdictMs?: number;
 }
 
 /**
@@ -21,6 +28,23 @@ export const STREAM_LOST_MESSAGE = "Lost the connection to the engine.";
  * turn keeps showing progress and this only explains the ignored duplicate.
  */
 export const SEND_IN_FLIGHT_MESSAGE = "A message is already being sent.";
+
+/**
+ * How long an ambiguously-failed send (see {@link StreamTuning.sendVerdictMs})
+ * waits for the stream to prove the turn started before settling as an error.
+ * Long enough for the resumable stream to ride out the same network blip that
+ * broke the send (a few backoff attempts), short enough that a genuinely lost
+ * send doesn't leave the user staring at a spinner.
+ */
+export const SEND_VERDICT_MS = 15_000;
+/**
+ * Copy for a send that provably never landed: the send fetch failed at the
+ * transport level AND no evidence of the turn arrived within the verdict
+ * window. Product voice (no status codes, no `TypeError: Load failed`), and
+ * actionable — resending is safe precisely because the turn never started.
+ */
+export const SEND_LOST_MESSAGE =
+  "Your message didn't reach the agent. Check your connection and send it again.";
 
 /**
  * One live subscription per conversation, whoever opened it: a turn we sent

--- a/packages/sdk/src/modules/turns/turn-errors.ts
+++ b/packages/sdk/src/modules/turns/turn-errors.ts
@@ -29,6 +29,24 @@ export function turnErrorMessage(e: unknown): string {
 }
 
 /**
+ * Whether a failed send is AMBIGUOUS about whether the engine received it.
+ *
+ * An {@link EngineError} is a server verdict (the engine answered — 409, 401,
+ * …) and an abort is the caller's own cancellation: both are definitive.
+ * Everything else is `fetch` reporting a transport failure (WebKit's
+ * `TypeError: Load failed`, a reset, DNS…), which CANNOT distinguish "the
+ * request never reached the engine" from "the engine accepted it but the
+ * response was lost" — the turn may be running. Callers must not settle the
+ * turn as failed on such an error without independent evidence (see
+ * `streamTurn`'s send-verdict window).
+ */
+export function isAmbiguousSendFailure(e: unknown): boolean {
+  if (e instanceof EngineError) return false;
+  if (e instanceof Error && e.name === "AbortError") return false;
+  return true;
+}
+
+/**
  * Whether a turn failure is the runtime's "no provider connected" refusal — the
  * verbatim message it raises when the chat's provider is logged out (runtime
  * `ai/providers.ts`, `transport/server.ts`, `turn/server.ts`; all prefixed

--- a/packages/sdk/src/modules/turns/turn-sink.ts
+++ b/packages/sdk/src/modules/turns/turn-sink.ts
@@ -55,9 +55,29 @@ export class TurnSink {
   sendAccepted(): void {
     this.accepted = true;
   }
+  /**
+   * Turn mode: the send failed at the TRANSPORT level, so the engine may have
+   * accepted it anyway (the 202 was lost with the connection). Adopt the same
+   * posture as an accepted send — a running sync on reconnect may be OUR turn
+   * — while `failUnlessStarted` arbitrates whether it really began.
+   */
+  sendMaybeAccepted(): void {
+    this.accepted = true;
+  }
   /** The send failed / stream broke before a terminal frame: settle as error. */
   fail(msg: string): void {
     finishErr(this.s, msg);
+  }
+  /**
+   * Verdict on an ambiguous send: settle as an error UNLESS evidence arrived
+   * that the turn actually started (our nonce echo, frames, a running sync) or
+   * a settle is already underway. Returns whether it failed the turn, so the
+   * caller knows to tear the stream down.
+   */
+  failUnlessStarted(msg: string): boolean {
+    if (this.sawRunning || this.settling || this.s.settled) return false;
+    finishErr(this.s, msg);
+    return true;
   }
 
   onFrame(ev: WireFrame): void {

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -10,6 +10,7 @@ import type { FeedOutput } from "./feed-output";
 import { TURN_DIED_MESSAGE } from "./settle-from-history";
 import {
   SEND_IN_FLIGHT_MESSAGE,
+  SEND_LOST_MESSAGE,
   STREAM_LOST_MESSAGE,
   StreamRegistry,
 } from "./stream-registry";
@@ -1092,4 +1093,114 @@ test("two registries are isolated: same key coexists and dispose crosses no boun
 
   regB.disposeAll();
   await waitFor(() => abortFlags.b);
+});
+
+// ── Ambiguous send failure (HOU-683) ─────────────────────────────────────────
+// fetch can't distinguish "the POST never reached the engine" from "the engine
+// accepted it but the 202 was lost with the connection" — both throw a bare
+// TypeError (WebKit: "Load failed"). The stream is the arbiter.
+
+test("a transport-failed send whose turn actually started renders and settles normally", async () => {
+  const { engine, nonces } = fakeEngine(
+    [
+      (o) =>
+        new Promise<void>((resolve) => {
+          // Delayed so sendMessage has run (and thrown) and the nonce is known.
+          setTimeout(() => {
+            o.onEvent(sync(false, "", 0));
+            // The engine DID accept the send: our echo arrives with the nonce.
+            o.onEvent({
+              type: "user",
+              data: { content: "Yes.", ts: 1, nonce: nonces[0] },
+              turnId: "t-1",
+              seq: 1,
+            });
+            o.onEvent({ type: "text", data: "Done", turnId: "t-1", seq: 2 });
+            o.onEvent({ type: "done", data: null, turnId: "t-1", seq: 3 });
+            resolve();
+          }, 10);
+        }).then(() => hang(o)),
+    ],
+    [],
+    { sendError: new TypeError("Load failed") },
+  );
+  const { items, sessionStatuses, board, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bob",
+    "activity-ambiguous-landed",
+    "Yes.",
+    output,
+    registry,
+    { tuning: fast },
+  );
+
+  // The turn settled from the live frames — never as an error.
+  expect(sessionStatuses).not.toContain("error");
+  expect(finals(items)).toHaveLength(1);
+  const texts = items.filter((i) => i.feed_type === "assistant_text");
+  expect(texts).toEqual([{ feed_type: "assistant_text", data: "Done" }]);
+  // No misleading transport-error line reached the feed.
+  expect(items.map((i) => i.data)).not.toContain("Load failed");
+  expect(items.map((i) => i.data)).not.toContain(SEND_LOST_MESSAGE);
+  expect(board).toEqual(["running", "needs_you"]);
+});
+
+test("a transport-failed send with no evidence of the turn settles as lost after the verdict window", async () => {
+  const { engine } = fakeEngine(
+    [
+      (o) => {
+        // The engine never saw the send: the conversation stays idle.
+        o.onEvent(sync(false, "", 0));
+        return hang(o);
+      },
+    ],
+    [],
+    { sendError: new TypeError("Load failed") },
+  );
+  const { items, sessionStatuses, board, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bob",
+    "activity-ambiguous-lost",
+    "hi",
+    output,
+    registry,
+    { tuning: { ...fast, sendVerdictMs: 50 } },
+  );
+
+  expect(sessionStatuses).toContain("error");
+  expect(items).toContainEqual({
+    feed_type: "system_message",
+    data: SEND_LOST_MESSAGE,
+  });
+  expect(board).toEqual(["running", "error"]);
+});
+
+test("a definitive send rejection (the engine answered) still fails the turn immediately", async () => {
+  const { engine } = fakeEngine([hang], [], {
+    sendError: new EngineError(
+      409,
+      JSON.stringify({ error: "A turn is already running" }),
+    ),
+  });
+  const { items, sessionStatuses, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bob",
+    "activity-definitive-reject",
+    "hi",
+    output,
+    registry,
+    { tuning: fast },
+  );
+
+  expect(sessionStatuses).toContain("error");
+  expect(items).toContainEqual({
+    feed_type: "system_message",
+    data: "A turn is already running",
+  });
 });

--- a/packages/sdk/src/modules/turns/turn-stream.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.ts
@@ -5,13 +5,15 @@ import { randomNonce } from "./random-nonce";
 import {
   type ActiveStream,
   SEND_IN_FLIGHT_MESSAGE,
+  SEND_LOST_MESSAGE,
+  SEND_VERDICT_MS,
   STREAM_FAILURE_BUDGET,
   STREAM_LOST_MESSAGE,
   type StreamRegistry,
   type StreamTuning,
   streamKey,
 } from "./stream-registry";
-import { turnErrorMessage } from "./turn-errors";
+import { isAmbiguousSendFailure, turnErrorMessage } from "./turn-errors";
 import { TurnSink } from "./turn-sink";
 
 export { observeConversation } from "./observe-stream";
@@ -44,6 +46,17 @@ export interface StreamTurnOptions {
  * persisted history, by turnId), on a rejected send, on a fatal (401/403/404/
  * 410) stream refusal, or after `STREAM_FAILURE_BUDGET` dead reconnects —
  * never from partial text on a silent close.
+ *
+ * A send that fails at the TRANSPORT level (fetch threw — no engine verdict)
+ * is AMBIGUOUS: the engine may have accepted the message and be running the
+ * turn with only the 202 lost to the dropped connection. Failing the turn
+ * immediately would render an error card against a live turn whose reply then
+ * lands anyway (HOU-683). So the ambiguous path settles nothing: the already-
+ * open subscription arbitrates — our nonce echo or a running sync proves the
+ * turn started (it then renders and settles normally); if no evidence arrives
+ * within `tuning.sendVerdictMs`, the send provably never landed and the turn
+ * fails with `SEND_LOST_MESSAGE`. A definitive rejection (the engine answered:
+ * EngineError) or the caller's own abort still fails immediately.
  *
  * When a live observer holds the conversation, the send goes FIRST and the
  * observer keeps rendering until it is accepted: a 202 disposes the observer
@@ -141,6 +154,7 @@ export async function streamTurn(
   });
   if (sent) sink.sendAccepted();
 
+  let sendVerdict: ReturnType<typeof setTimeout> | undefined;
   try {
     const streaming = streamEventsResumable(engine, sessionKey, {
       signal: ac.signal,
@@ -164,8 +178,20 @@ export async function streamTurn(
     // `await streaming`) so nothing becomes an unhandled rejection.
     streaming.catch(() => {});
     if (!sent) {
-      await engine.sendMessage(sessionKey, prompt, { nonce });
-      sink.sendAccepted();
+      try {
+        await engine.sendMessage(sessionKey, prompt, { nonce });
+        sink.sendAccepted();
+      } catch (e) {
+        // A definitive failure (engine verdict / our abort) settles below.
+        if (!isAmbiguousSendFailure(e)) throw e;
+        // Transport failure — the engine may be running the turn regardless.
+        // Keep the subscription as the arbiter: evidence of the turn settles
+        // it normally; a verdict window with no evidence fails it as lost.
+        sink.sendMaybeAccepted();
+        sendVerdict = setTimeout(() => {
+          if (sink.failUnlessStarted(SEND_LOST_MESSAGE)) ac.abort();
+        }, opts.tuning?.sendVerdictMs ?? SEND_VERDICT_MS);
+      }
     }
     await streaming; // resolves only once the sink settled and aborted
   } catch (e) {
@@ -175,6 +201,7 @@ export async function streamTurn(
     // and the reason surfaces.
     if (!sink.settled) sink.fail(turnErrorMessage(e));
   } finally {
+    if (sendVerdict !== undefined) clearTimeout(sendVerdict);
     ac.abort();
     registry.release(key, entry);
   }


### PR DESCRIPTION
## Summary

Fixes HOU-683 — a transient network drop while sending a chat message renders **"Session error: Load failed"** and orphans the turn, even though the engine accepted the message and is running it.

### Root cause

Observed in production (2026-07-05 15:45Z, cloud agent Bob): the message POST reached the gateway and got a 202 (`response_sent_by_backend` in the GCLB logs, engine started the turn), but the client's HTTP/3 connection died before the response arrived — GCLB logged the events SSE as `client_disconnected_after_partial_response`. `fetch` surfaces that as a bare `TypeError: Load failed`, and `streamTurn` treated **every** send rejection as fatal (`sink.fail(...)`), so the UI settled the turn as an error while the real turn kept running server-side and its reply was lost.

A transport-level send failure is inherently ambiguous: it cannot distinguish "the request never reached the engine" from "the engine ran it, but the response was lost". HOU-432 solved this for replay-safe requests with retries and deliberately excluded mutating POSTs like this one — blind resend could double-run a turn.

### Fix

The turn machinery already holds the arbiter: the resumable events subscription is opened **before** the send, and the `user` echo carries our nonce. On an ambiguous send failure `streamTurn` now settles nothing and lets the stream decide:

- Evidence the turn started (nonce echo, frames, running sync) → the turn renders and settles normally, exactly as if the 202 had arrived.
- No evidence within the verdict window (`tuning.sendVerdictMs`, default 15 s) → the send provably never landed; the turn fails with actionable copy ("Your message didn't reach the agent. Check your connection and send it again.") instead of a raw `Load failed`.
- Definitive failures are unchanged: an engine verdict (`EngineError`, e.g. the 409 one-turn gate) or the caller's own abort still fail immediately.

### Reproduction (before the fix)

1. Open a cloud-agent chat in the desktop app and send a message.
2. Kill the connection right after the send leaves (e.g. `sudo pfctl`-drop or toggle Wi-Fi within ~1 s; the server still receives the POST).
3. The chat renders *Load failed* + *Session error: Load failed*; the agent's reply never appears, though the turn ran server-side (visible in the agent pod logs).

Deterministic repro: `packages/sdk/src/modules/turns/turn-stream.test.ts` — "a transport-failed send whose turn actually started…" fails on `main` (settles `error`, feed contains `Load failed`) and passes with this change.

### Verification (after the fix)

- `pnpm -C packages/sdk test` — 209/209 pass, including 3 new tests: ambiguous send + turn started → settles normally with the full reply; ambiguous send + no evidence → fails after the verdict window with the new copy; definitive `EngineError` rejection → still fails immediately.
- `pnpm typecheck` (full workspace) and `biome check` — clean.
- Manual: repeat the repro above; the turn now renders the reply and settles `completed` once the connection returns (the resumable stream replays the gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)