### PR TITLE
feat(providers): zero-code ChatGPT connect in cloud via remote-only loopback relay

### DIFF
--- a/app/src/components/onboarding/missions/use-provider-login-events.ts
+++ b/app/src/components/onboarding/missions/use-provider-login-events.ts
@@ -1,5 +1,6 @@
 import type { HoustonEvent } from "@houston-ai/core";
 import { useEffect, useRef, useState } from "react";
+import { tryBeginCodexLoopbackLogin } from "../../../lib/codex-loopback";
 import { subscribeHoustonEvents } from "../../../lib/events";
 import { osIsTauri } from "../../../lib/os-bridge";
 import { tauriSystem } from "../../../lib/tauri";
@@ -54,6 +55,19 @@ export function useProviderLoginEvents(opts: {
     const off = subscribeHoustonEvents((ev: HoustonEvent) => {
       if (ev.type === "ProviderLoginUrl") {
         if (ev.data.provider !== providerId) return;
+        // MUST precede the open/dialog decision: for a REMOTE-engine desktop the
+        // engine emits a codex URL with no user_code, so shouldOpenLoginUrlDirectly
+        // would plainly openUrl — but pi's callback server is in the pod and
+        // unreachable. The relay intercepts, binds a LOCAL 1455, and relays the code.
+        if (
+          tryBeginCodexLoopbackLogin({
+            provider: ev.data.provider,
+            url: ev.data.url,
+            userCode: ev.data.user_code,
+          })
+        ) {
+          return;
+        }
         if (
           shouldOpenLoginUrlDirectly({
             isDesktop: osIsTauri(),

--- a/app/src/components/shell/provider-login-fallback.tsx
+++ b/app/src/components/shell/provider-login-fallback.tsx
@@ -1,6 +1,7 @@
 import type { HoustonEvent } from "@houston-ai/core";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { tryBeginCodexLoopbackLogin } from "../../lib/codex-loopback";
 import { subscribeHoustonEvents } from "../../lib/events";
 import { osIsTauri } from "../../lib/os-bridge";
 import { PROVIDERS, type ProviderInfo } from "../../lib/providers";
@@ -38,8 +39,25 @@ export function ProviderLoginFallback() {
   useEffect(() => {
     return subscribeHoustonEvents((ev: HoustonEvent) => {
       if (ev.type === "ProviderLoginUrl") {
+        const claimed = providerLoginSurfaceClaimed();
+        // MUST precede the open/dialog decision: for a REMOTE-engine desktop the
+        // engine emits a codex URL with no user_code, so the fallback action
+        // would resolve to "open" and plainly openUrl — but pi's callback server
+        // is in the pod and unreachable. The relay intercepts, binds a LOCAL 1455,
+        // and relays the code. Gated on `!claimed`: a dedicated surface, if
+        // mounted, runs the relay itself, so we don't double-bind 1455.
+        if (
+          !claimed &&
+          tryBeginCodexLoopbackLogin({
+            provider: ev.data.provider,
+            url: ev.data.url,
+            userCode: ev.data.user_code,
+          })
+        ) {
+          return;
+        }
         const action = providerLoginFallbackAction({
-          claimed: providerLoginSurfaceClaimed(),
+          claimed,
           isDesktop: osIsTauri(),
           userCode: ev.data.user_code,
         });

--- a/app/src/components/shell/provider-login-url.ts
+++ b/app/src/components/shell/provider-login-url.ts
@@ -9,6 +9,8 @@
  * dialog stays a thin render layer and the host parse is unit-testable.
  */
 
+import { codexUsesLoopbackRelay } from "../../lib/engine-mode.ts";
+
 /**
  * Friendly host for the "you'll be taken to …" hint. Returns the bare
  * hostname (no scheme, no `www.`, no port/path/query) or `null` when the
@@ -49,10 +51,29 @@ export function shouldOpenLoginUrlDirectly(opts: {
   return opts.isDesktop && !opts.userCode;
 }
 
-// NOTE: the desktop's own Codex OAuth loopback relay (`shouldUseCodexLoopback`
-// + `beginCodexBrowserLogin`) is GONE. pi runs the whole OAuth flow in-process:
-// for a loopback (no-code) login it binds the fixed localhost callback port
-// itself and completes the token exchange — an app-side listener on the same
-// port could only fight it. Every topology that genuinely can't catch the
-// callback (hosted cloud, a truly remote host) gets the device-code flow from
-// `providerLoginUsesDeviceAuthByDefault` instead.
+/**
+ * Decide whether a `ProviderLoginUrl` event for Codex/OpenAI should drive the
+ * desktop's zero-code loopback relay (`beginCodexBrowserLogin`) instead of the
+ * plain open-in-browser path or the device-code dialog.
+ *
+ * True only for Codex (`provider === "openai"`) on a Tauri desktop whose engine
+ * is REMOTE (`codexUsesLoopbackRelay`) and with no device code pending: there
+ * pi's own 1455 lives in the pod, so the desktop binds a LOCAL 1455 and relays
+ * the callback code — ChatGPT sign-in with zero device code even against a
+ * remote engine, and no collision with pi. A CO-LOCATED desktop (local sidecar
+ * or a loopback dev URL) returns false and keeps pi's own browser flow (pi owns
+ * 1455 there — an app bind would fight it). A device code present, or a web
+ * client, also stay on their existing paths.
+ */
+export function shouldUseCodexLoopback(opts: {
+  provider: string;
+  env: { VITE_NEW_ENGINE_URL?: string; VITE_HOSTED_ENGINE_URL?: string };
+  isTauri: boolean;
+  userCode: string | null | undefined;
+}): boolean {
+  return (
+    opts.provider === "openai" &&
+    codexUsesLoopbackRelay(opts.env, { isTauri: opts.isTauri }) &&
+    !opts.userCode
+  );
+}

--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { analytics } from "../../lib/analytics";
+import { tryBeginCodexLoopbackLogin } from "../../lib/codex-loopback";
 import { newEngineActive } from "../../lib/engine";
 import { subscribeHoustonEvents } from "../../lib/events";
 import { osIsTauri } from "../../lib/os-bridge";
@@ -161,6 +162,19 @@ export function ProviderPicker({ onSelect }: Props) {
         const prov =
           visibleProviders.find((p) => p.id === ev.data.provider) ??
           PROVIDERS.find((p) => p.id === ev.data.provider);
+        // MUST precede the open/dialog decision: for a REMOTE-engine desktop the
+        // engine emits a codex URL with no user_code, so shouldOpenLoginUrlDirectly
+        // would plainly openUrl — but pi's callback server is in the pod and
+        // unreachable. The relay intercepts, binds a LOCAL 1455, and relays the code.
+        if (
+          tryBeginCodexLoopbackLogin({
+            provider: ev.data.provider,
+            url: ev.data.url,
+            userCode: ev.data.user_code,
+          })
+        ) {
+          return;
+        }
         if (
           shouldOpenLoginUrlDirectly({
             isDesktop: osIsTauri(),

--- a/app/src/hooks/provider-connections/use-provider-login-events.ts
+++ b/app/src/hooks/provider-connections/use-provider-login-events.ts
@@ -2,6 +2,7 @@ import type { HoustonEvent } from "@houston-ai/core";
 import { type Dispatch, type SetStateAction, useEffect } from "react";
 import { claimProviderLoginSurface } from "../../components/shell/provider-login-surface";
 import { shouldOpenLoginUrlDirectly } from "../../components/shell/provider-login-url";
+import { tryBeginCodexLoopbackLogin } from "../../lib/codex-loopback";
 import { subscribeHoustonEvents } from "../../lib/events";
 import { osIsTauri } from "../../lib/os-bridge";
 import { PROVIDERS, type ProviderInfo } from "../../lib/providers";
@@ -52,6 +53,19 @@ export function useProviderLoginEvents({
         const prov =
           visibleProviders.find((p) => p.id === ev.data.provider) ??
           PROVIDERS.find((p) => p.id === ev.data.provider);
+        // MUST precede the open/dialog decision: for a REMOTE-engine desktop the
+        // engine emits a codex URL with no user_code, so shouldOpenLoginUrlDirectly
+        // would plainly openUrl — but pi's callback server is in the pod and
+        // unreachable. The relay intercepts, binds a LOCAL 1455, and relays the code.
+        if (
+          tryBeginCodexLoopbackLogin({
+            provider: ev.data.provider,
+            url: ev.data.url,
+            userCode: ev.data.user_code,
+          })
+        ) {
+          return;
+        }
         if (
           shouldOpenLoginUrlDirectly({
             isDesktop: osIsTauri(),

--- a/app/src/lib/codex-loopback.ts
+++ b/app/src/lib/codex-loopback.ts
@@ -1,0 +1,158 @@
+/**
+ * Codex/OpenAI (ChatGPT) desktop OAuth loopback relay.
+ *
+ * The runtime hands the frontend an authorize URL for Codex sign-in (see the
+ * `deviceAuth:false` default in {@link tauri.launchLogin}). On desktop we don't
+ * want the user to copy a device code: instead the native side binds its OWN
+ * localhost listener (`start_codex_oauth_loopback`), we open the URL in the
+ * user's browser, and when OpenAI redirects back the native `codex-oauth://
+ * callback` event carries the raw `code=...&state=...` query string, which we
+ * relay to the engine via `submitLoginCode` (pi accepts the string verbatim).
+ *
+ * This is used ONLY against a REMOTE engine (see `codexUsesLoopbackRelay`): the
+ * loopback lives on the user's machine while pi's own 1455 is in the pod, so
+ * the local bind can't collide. A co-located engine keeps pi's own browser flow.
+ */
+
+import { shouldUseCodexLoopback } from "../components/shell/provider-login-url";
+import { useUIStore } from "../stores/ui";
+import i18n from "./i18n";
+import {
+  legacyListen,
+  osIsTauri,
+  osOpenUrl,
+  osStartCodexOauthLoopback,
+} from "./os-bridge";
+import { PROVIDERS } from "./providers";
+import { tauriProvider } from "./tauri";
+
+/** Native event carrying the OAuth redirect's raw `code=...&state=...` query. */
+const CODEX_OAUTH_CALLBACK_EVENT = "codex-oauth://callback";
+
+/**
+ * Safety net for a callback that never arrives (the user abandons the browser
+ * tab, or the native loopback server times out). The engine's
+ * `ProviderLoginComplete(success:false)` surfaces the real failure to the user;
+ * this timer only tears down our one-shot listener so it can't leak. Generous
+ * because a user may sit on the OpenAI consent screen for a while.
+ */
+const CALLBACK_TIMEOUT_MS = 5 * 60_000;
+
+type Unlisten = Awaited<ReturnType<typeof legacyListen>>;
+
+/** Reuse the existing "couldn't open sign-in" toast key with the provider's
+ *  display name; falls back to the raw id for an unknown provider. */
+function failCodexLogin(frontendProviderId: string, err: unknown): void {
+  const name =
+    PROVIDERS.find((p) => p.id === frontendProviderId)?.name ??
+    frontendProviderId;
+  useUIStore.getState().addToast({
+    title: i18n.t("providers:toast.signInFailed", { provider: name }),
+    description: err instanceof Error ? err.message : String(err),
+    variant: "error",
+  });
+}
+
+/** Relay the callback's query string to the engine. `submitLoginCode`'s
+ *  engine-call wrapper already surfaces a failure toast + Sentry report, so the
+ *  catch here only keeps the promise from floating unhandled. */
+async function relayCodexCode(
+  frontendProviderId: string,
+  payload: string,
+): Promise<void> {
+  try {
+    await tauriProvider.submitLoginCode(frontendProviderId, payload);
+  } catch (err) {
+    console.error("[codex-loopback] submitLoginCode failed:", err);
+  }
+}
+
+/**
+ * Drive the desktop Codex/OpenAI browser sign-in: listen for the loopback
+ * callback, bind the native listener, open the authorize URL, and relay the
+ * code back to the engine. Surfaces a toast and cleans up the listener on any
+ * setup failure; never leaves an orphaned listener on any path (success, error,
+ * or timeout). Resolves once the browser has been opened (the callback is
+ * handled asynchronously); never rejects.
+ */
+export async function beginCodexBrowserLogin(
+  frontendProviderId: string,
+  authorizeUrl: string,
+): Promise<void> {
+  let unlisten: Unlisten | null = null;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let settled = false;
+
+  const cleanup = () => {
+    settled = true;
+    if (timer) {
+      clearTimeout(timer);
+      timer = null;
+    }
+    if (unlisten) {
+      unlisten();
+      unlisten = null;
+    }
+  };
+
+  // Register the callback listener BEFORE binding the loopback so a fast
+  // redirect can't race ahead of us.
+  try {
+    unlisten = await legacyListen<string>(CODEX_OAUTH_CALLBACK_EVENT, (ev) => {
+      if (settled) return;
+      cleanup();
+      void relayCodexCode(frontendProviderId, ev.payload);
+    });
+  } catch (err) {
+    cleanup();
+    failCodexLogin(frontendProviderId, err);
+    return;
+  }
+
+  timer = setTimeout(cleanup, CALLBACK_TIMEOUT_MS);
+
+  try {
+    await osStartCodexOauthLoopback();
+    await osOpenUrl(authorizeUrl);
+  } catch (err) {
+    cleanup();
+    failCodexLogin(frontendProviderId, err);
+  }
+}
+
+/**
+ * Shared `ProviderLoginUrl` relay branch for every login surface (picker, AI
+ * hub, onboarding, shell fallback). Reads the topology (`shouldUseCodexLoopback`
+ * → `codexUsesLoopbackRelay`) and, when a Codex/OpenAI sign-in on a REMOTE-engine
+ * desktop qualifies, drives {@link beginCodexBrowserLogin} and returns `true` so
+ * the caller RETURNS before its own open-in-browser / device-code decision. Any
+ * other case (co-located desktop, device code pending, non-openai, web) returns
+ * `false` and the caller keeps its existing path. Centralized so the critical
+ * "relay first" ordering isn't copy-pasted — and can't drift — across surfaces.
+ */
+export function tryBeginCodexLoopbackLogin(ev: {
+  provider: string;
+  url: string;
+  userCode: string | null | undefined;
+}): boolean {
+  if (
+    !shouldUseCodexLoopback({
+      provider: ev.provider,
+      env: (import.meta.env ?? {}) as {
+        VITE_NEW_ENGINE_URL?: string;
+        VITE_HOSTED_ENGINE_URL?: string;
+      },
+      isTauri: osIsTauri(),
+      userCode: ev.userCode,
+    })
+  ) {
+    return false;
+  }
+  // Codex/OpenAI against a REMOTE engine on desktop: bind our OWN local
+  // 127.0.0.1:1455 listener and relay the callback code, so ChatGPT sign-in
+  // works with zero device code. pi's 1455 is in the pod, so no collision.
+  // beginCodexBrowserLogin surfaces its own failure toast and never leaves an
+  // orphaned listener.
+  void beginCodexBrowserLogin(ev.provider, ev.url);
+  return true;
+}

--- a/app/src/lib/engine-mode.ts
+++ b/app/src/lib/engine-mode.ts
@@ -78,6 +78,17 @@ export function providerLoginUsesDeviceAuthByDefault(
   return false;
 }
 
+/** Gate for the desktop Codex/OpenAI zero-code loopback relay: ON only for a
+ * REMOTE engine, where pi's own 1455 is in the pod so the desktop's LOCAL 1455
+ * can't collide. Co-located/web keep existing flows; collision rationale
+ * (#615/#620) is at the relay call sites (codex-loopback.ts). */
+export function codexUsesLoopbackRelay(
+  env: Pick<EngineModeEnv, "VITE_NEW_ENGINE_URL" | "VITE_HOSTED_ENGINE_URL">,
+  client: { isTauri: boolean },
+): boolean {
+  return client.isTauri && providerLoginUsesDeviceAuthByDefault(env, client);
+}
+
 /** How the desktop authenticates to the hosted engine (`VITE_HOSTED_ENGINE_URL`). */
 export type HostedAuthMode =
   /** Supabase Google login: prompt sign-in, send the session token as bearer. */

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -77,6 +77,17 @@ export function osStartOauthLoopback(): Promise<string> {
   return invoke<string>("start_oauth_loopback");
 }
 
+/** Bind a one-shot localhost listener for the Codex/OpenAI OAuth redirect. On
+ * success the native side emits `codex-oauth://callback` with the raw
+ * `code=...&state=...` query string once OpenAI bounces the browser back;
+ * rejects with a message string if the port can't be bound. Desktop only, and
+ * only used against a REMOTE engine (pi's own 1455 is in the pod, so binding a
+ * LOCAL 1455 can't collide) — keeps ChatGPT sign-in zero-code even remotely.
+ * Mirrors {@link osStartOauthLoopback} (the Supabase Google loopback). */
+export function osStartCodexOauthLoopback(): Promise<void> {
+  return invoke<void>("start_codex_oauth_loopback");
+}
+
 /** Pull the Houston window to the front. Used when a flow finishes in the
  * user's browser (e.g. a Composio integration connection lands) and we want
  * the app to surface itself — the same snap-back the sign-in loopback does.

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -25,6 +25,7 @@ import { COMPOSIO_ALREADY_CONNECTED_KIND } from "./composio-already-connected";
 import { getEngine, isRemoteEngine } from "./engine";
 import { engineCallSurface } from "./engine-call-policy";
 import {
+  codexUsesLoopbackRelay,
   isLoopbackHostUrl,
   providerLoginUsesDeviceAuthByDefault,
 } from "./engine-mode";
@@ -1037,26 +1038,44 @@ export const tauriProvider = {
         getEngine().providerLogin(provider, {
           deviceAuth:
             opts?.deviceAuth ??
-            // The browser/loopback flow needs the runtime CO-LOCATED with the
-            // user's browser: pi binds the provider's fixed localhost callback
-            // port in-process and completes the exchange itself, so the client
-            // only opens the URL. A truly remote engine (hosted cloud, a VPS,
-            // or the HOU-621 runtime `remote` choice with no baked env — hence
-            // the isRemoteEngine() OR) must use device code instead. A LOOPBACK
-            // `VITE_NEW_ENGINE_URL` (the dev two-terminal setup) is co-located
-            // despite being URL-configured, so it keeps the browser flow like
-            // the packaged host-sidecar build.
-            ((isRemoteEngine() &&
-              !isLoopbackHostUrl(
-                import.meta.env?.VITE_NEW_ENGINE_URL as string | undefined,
-              )) ||
-              providerLoginUsesDeviceAuthByDefault(
-                (import.meta.env ?? {}) as {
-                  VITE_NEW_ENGINE_URL?: string;
-                  VITE_HOSTED_ENGINE_URL?: string;
-                },
-                { isTauri: osIsTauri() },
-              )),
+            // Codex/OpenAI on a Tauri desktop against a REMOTE engine uses the
+            // zero-code loopback relay (`codexUsesLoopbackRelay`): the desktop
+            // binds its OWN local 127.0.0.1:1455 and relays the callback code,
+            // so it wants an authorize URL (deviceAuth:false), never a device
+            // code. pi's own 1455 is in the pod, so no collision. Co-located
+            // desktop (local sidecar / loopback dev URL) is NOT a relay case —
+            // pi owns 1455 there and its own browser flow already resolves to
+            // deviceAuth:false via the topology default below.
+            (provider === "openai" &&
+            codexUsesLoopbackRelay(
+              (import.meta.env ?? {}) as {
+                VITE_NEW_ENGINE_URL?: string;
+                VITE_HOSTED_ENGINE_URL?: string;
+              },
+              { isTauri: osIsTauri() },
+            )
+              ? false
+              : // The browser/loopback flow needs the runtime CO-LOCATED with
+                // the user's browser: pi binds the provider's fixed localhost
+                // callback port in-process and completes the exchange itself, so
+                // the client only opens the URL. A truly remote engine (hosted
+                // cloud, a VPS, or the HOU-621 runtime `remote` choice with no
+                // baked env — hence the isRemoteEngine() OR) must use device
+                // code instead. A LOOPBACK `VITE_NEW_ENGINE_URL` (the dev
+                // two-terminal setup) is co-located despite being URL-configured,
+                // so it keeps the browser flow like the packaged host-sidecar
+                // build.
+                (isRemoteEngine() &&
+                  !isLoopbackHostUrl(
+                    import.meta.env?.VITE_NEW_ENGINE_URL as string | undefined,
+                  )) ||
+                providerLoginUsesDeviceAuthByDefault(
+                  (import.meta.env ?? {}) as {
+                    VITE_NEW_ENGINE_URL?: string;
+                    VITE_HOSTED_ENGINE_URL?: string;
+                  },
+                  { isTauri: osIsTauri() },
+                )),
           enterpriseDomain: opts?.enterpriseDomain,
         }),
       undefined,

--- a/app/tests/engine-mode.test.ts
+++ b/app/tests/engine-mode.test.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
+  codexUsesLoopbackRelay,
   controlPlaneBuild,
   hostedAuthMode,
   hostedGateState,
@@ -134,6 +135,60 @@ describe("isLoopbackHostUrl + the co-located dev URL case", () => {
       ),
       false,
     );
+  });
+});
+
+// The desktop Codex/OpenAI loopback relay is re-introduced but gated to the
+// REMOTE-engine cases ONLY. When the engine is CO-LOCATED, pi binds 1455
+// in-process on THIS machine — an app-side bind would lose the race (the #615
+// collision, reverted in #620). Relay ON is therefore exactly the set where
+// topology would otherwise force device-code, and OFF for every co-located /
+// web case. The two OFF cases below are the regression guard proving the #620
+// collision cannot recur.
+describe("codexUsesLoopbackRelay (B2 truth table)", () => {
+  it("relay OFF for the local sidecar desktop (tauri, no URLs — pi owns 1455)", () => {
+    strictEqual(codexUsesLoopbackRelay({}, { isTauri: true }), false);
+  });
+
+  it("relay OFF for a loopback VITE_NEW_ENGINE_URL (co-located dev — pi owns 1455)", () => {
+    strictEqual(
+      codexUsesLoopbackRelay(
+        { VITE_NEW_ENGINE_URL: "http://127.0.0.1:4318" },
+        { isTauri: true },
+      ),
+      false,
+    );
+  });
+
+  it("relay ON for the hosted gateway (remote — pi's 1455 is in the pod)", () => {
+    strictEqual(
+      codexUsesLoopbackRelay(
+        { VITE_HOSTED_ENGINE_URL: "https://cloud.example" },
+        { isTauri: true },
+      ),
+      true,
+    );
+  });
+
+  it("relay ON for a non-loopback VITE_NEW_ENGINE_URL (remote host)", () => {
+    strictEqual(
+      codexUsesLoopbackRelay(
+        { VITE_NEW_ENGINE_URL: "https://houston.example.com/engine" },
+        { isTauri: true },
+      ),
+      true,
+    );
+  });
+
+  it("relay OFF for a web client (can't bind a local port — device-code)", () => {
+    strictEqual(
+      codexUsesLoopbackRelay(
+        { VITE_HOSTED_ENGINE_URL: "https://cloud.example" },
+        { isTauri: false },
+      ),
+      false,
+    );
+    strictEqual(codexUsesLoopbackRelay({}, { isTauri: false }), false);
   });
 });
 

--- a/app/tests/provider-login-url.test.ts
+++ b/app/tests/provider-login-url.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from "node:test";
 import {
   providerLoginUrlHost,
   shouldOpenLoginUrlDirectly,
+  shouldUseCodexLoopback,
 } from "../src/components/shell/provider-login-url.ts";
 
 describe("providerLoginUrlHost", () => {
@@ -94,6 +95,105 @@ describe("shouldOpenLoginUrlDirectly", () => {
     strictEqual(
       shouldOpenLoginUrlDirectly({ isDesktop: true, userCode: "" }),
       true,
+    );
+  });
+});
+
+// The Codex loopback relay drives ChatGPT sign-in for openai on a Tauri desktop
+// ONLY when the engine is remote (pi's 1455 is in the pod, so a local bind can't
+// collide). Co-located desktop, a pending device code, a non-openai provider,
+// and web clients all stay on their existing paths.
+describe("shouldUseCodexLoopback", () => {
+  const hosted = { VITE_HOSTED_ENGINE_URL: "https://cloud.example" };
+  const remoteHost = { VITE_NEW_ENGINE_URL: "https://houston.example.com" };
+  const loopbackDev = { VITE_NEW_ENGINE_URL: "http://127.0.0.1:4318" };
+
+  it("drives the relay for openai on a remote-engine desktop with no device code", () => {
+    for (const env of [hosted, remoteHost]) {
+      strictEqual(
+        shouldUseCodexLoopback({
+          provider: "openai",
+          env,
+          isTauri: true,
+          userCode: null,
+        }),
+        true,
+      );
+      strictEqual(
+        shouldUseCodexLoopback({
+          provider: "openai",
+          env,
+          isTauri: true,
+          userCode: undefined,
+        }),
+        true,
+      );
+      strictEqual(
+        shouldUseCodexLoopback({
+          provider: "openai",
+          env,
+          isTauri: true,
+          userCode: "",
+        }),
+        true,
+      );
+    }
+  });
+
+  it("does NOT relay for a co-located desktop (local sidecar / loopback dev URL)", () => {
+    strictEqual(
+      shouldUseCodexLoopback({
+        provider: "openai",
+        env: {},
+        isTauri: true,
+        userCode: null,
+      }),
+      false,
+    );
+    strictEqual(
+      shouldUseCodexLoopback({
+        provider: "openai",
+        env: loopbackDev,
+        isTauri: true,
+        userCode: null,
+      }),
+      false,
+    );
+  });
+
+  it("does not relay when a device code must be shown", () => {
+    strictEqual(
+      shouldUseCodexLoopback({
+        provider: "openai",
+        env: hosted,
+        isTauri: true,
+        userCode: "WXYZ-1234",
+      }),
+      false,
+    );
+  });
+
+  it("does not relay for a web / non-desktop client", () => {
+    strictEqual(
+      shouldUseCodexLoopback({
+        provider: "openai",
+        env: hosted,
+        isTauri: false,
+        userCode: null,
+      }),
+      false,
+    );
+  });
+
+  it("does not relay for a non-Codex provider (e.g. Claude)", () => {
+    strictEqual(
+      shouldUseCodexLoopback({
+        provider: "anthropic",
+        env: hosted,
+        isTauri: true,
+        userCode: null,
+      }),
+      false,
     );
   });
 });

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -174,6 +174,7 @@ export async function invoke<T = unknown>(
 
     // ── Desktop-only: surface a clear error if a user triggers them ─────
     case "start_oauth_loopback": // desktop uses a native loopback listener; web uses the redirect flow
+    case "start_codex_oauth_loopback": // desktop relays the Codex 1455 callback; web stays on device-code
     case "get_engine_handshake": // web injects window.__HOUSTON_ENGINE__ directly
     case "pick_directory":
     case "reveal_file":


### PR DESCRIPTION
## Problem

Connecting an OpenAI/ChatGPT subscription in **hosted/cloud** mode (desktop pointed at a remote engine) uses the OAuth **device-code** flow — enable a ChatGPT security setting AND type a one-time code. Non-technical users fail both. Local/co-located desktop already gets a seamless browser flow (pi owns the loopback in-process).

## Why the first attempt (#615) was reverted

#615 activated the desktop 1455 relay on **all** Tauri desktops; with a **local** engine pi *also* binds 1455 in-process, so the relay lost the race → no browser, failure toast. #620 reverted it ("let pi own the OAuth loopback").

## The fix — remote-only relay

`codexUsesLoopbackRelay = isTauri && providerLoginUsesDeviceAuthByDefault` — ON only when the engine is remote:

| Topology (tauri unless noted) | Relay |
|---|---|
| local sidecar | **OFF** — pi owns 1455 |
| loopback `VITE_NEW_ENGINE_URL` (dev) | **OFF** — pi owns 1455 |
| `VITE_HOSTED_ENGINE_URL` | **ON** |
| non-loopback `VITE_NEW_ENGINE_URL` | **ON** |
| web (not tauri) | **OFF** — device-code |

Remote → pi's loopback is in the **pod**, desktop binds 1455 **locally** → no collision. The two OFF cases are asserted by tests as the **regression guard** so the #615 collision can't recur.

## Integration into main's post-#635 login structure

The relay intercepts `ProviderLoginUrl` **before** the open/dialog decision in **all four** consumers (dedicated hook, onboarding surface, provider-picker, and the global fallback — the fallback only when no dedicated surface is mounted, so 1455 is never double-bound). Without this, a remote desktop emits a URL with no `user_code`, `shouldOpenLoginUrlDirectly` returns true, and it would openUrl with no local listener → hang.

Reuses the existing `start_codex_oauth_loopback` Rust command (no Rust changes). Refresh tokens still flow only through the existing capture/scrub path. Web keeps the polished device-code fallback.

## Verification

- app `tsgo` + `node --test` (580 pass), `cargo check`, web shim-parity (22 commands), Biome, repo-wide `pnpm typecheck` — all green.

Follow-up to #615/#620; completes the provider-auth overhaul (#612 seam, #636/#647 Anthropic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)