### PR TITLE
fix(host): org-level credential store for managed pods — connect-once across agents (HOU-680)

### DIFF
--- a/packages/host/src/credentials/gateway-wire.ts
+++ b/packages/host/src/credentials/gateway-wire.ts
@@ -1,0 +1,63 @@
+import type { WorkspaceCredential } from "../ports";
+
+/**
+ * The wire shape the credential gateway serves per provider. No refresh token
+ * ever crosses this wire on a GET — the gateway is the org's single refresher.
+ */
+export interface GatewayCredential {
+  provider: string;
+  kind: "oauth" | "api_key";
+  access: string;
+  expires: number;
+  accountId?: string | null;
+  enterpriseUrl?: string | null;
+}
+
+/**
+ * Validate + map a gateway body to the store's credential shape. Served
+ * credentials are access-only: refreshToken is always "" so no downstream
+ * consumer ever tries (or leaks) a refresh the pod doesn't own.
+ */
+export function credentialFromGateway(
+  provider: string,
+  body: GatewayCredential,
+): Omit<WorkspaceCredential, "workspaceId"> {
+  if (
+    body.provider !== provider ||
+    (body.kind !== "oauth" && body.kind !== "api_key") ||
+    typeof body.access !== "string" ||
+    typeof body.expires !== "number"
+  ) {
+    throw new Error(`credential gateway returned malformed ${provider} body`);
+  }
+  return {
+    provider: body.provider,
+    kind: body.kind,
+    accessToken: body.access,
+    refreshToken: "",
+    expiresAt: body.expires,
+    ...(typeof body.accountId === "string"
+      ? { accountId: body.accountId }
+      : {}),
+    ...(typeof body.enterpriseUrl === "string"
+      ? { enterpriseUrl: body.enterpriseUrl }
+      : {}),
+  };
+}
+
+/**
+ * True only for the gateway's own "not connected" 404 — a JSON body carrying an
+ * `error` field (the /v1/pod/credentials contract). A route-level 404 (deploy
+ * skew: a gateway build without the route, a mistyped HOUSTON_CREDENTIALS_URL)
+ * must NOT read as "logged out": callers treat it as a transport error so the
+ * runtime keeps its last hydrated token instead of wiping the org's credentials.
+ */
+export async function isNotConnected404(res: Response): Promise<boolean> {
+  if (res.status !== 404) return false;
+  try {
+    const body = (await res.clone().json()) as { error?: unknown };
+    return typeof body?.error === "string";
+  } catch {
+    return false;
+  }
+}

--- a/packages/host/src/credentials/remote-store.test.ts
+++ b/packages/host/src/credentials/remote-store.test.ts
@@ -206,6 +206,86 @@ test("put writes the gateway row and invalidates the provider cache", async () =
   ]);
 });
 
+test("a 404 without the gateway error body is a transport error, not a logout", async () => {
+  // Deploy skew: a gateway build without the /v1/pod/credentials route (or a
+  // mistyped HOUSTON_CREDENTIALS_URL) answers a route-level 404 with no JSON
+  // error body. That must throw, not read as "org signed out".
+  let skewed = true;
+  const { calls, fetchImpl } = fakeFetch(() => {
+    if (skewed)
+      return new Response("<html>route not found</html>", { status: 404 });
+    return json(gatewayCredential({ access: "AT-after-fix" }));
+  });
+  const s = store(fetchImpl);
+
+  await expect(s.get("ws_1", "openai-codex")).rejects.toThrow("failed (404)");
+  skewed = false;
+  // The skewed 404 was not negative-cached: the next get succeeds immediately.
+  expect((await s.get("ws_1", "openai-codex"))?.accessToken).toBe(
+    "AT-after-fix",
+  );
+  expect(calls).toHaveLength(2);
+});
+
+test("remove treats the gateway's not-connected 404 as already signed out and clears the fallback", async () => {
+  let fallbackCred: WorkspaceCredential | null = {
+    workspaceId: "ws_1",
+    provider: "openai-codex",
+    kind: "oauth",
+    accessToken: "AT-legacy",
+    refreshToken: "RT-legacy",
+    expiresAt: 123,
+  };
+  const fallback: CredentialStore = {
+    get: async () => fallbackCred,
+    put: async () => {},
+    remove: async () => {
+      fallbackCred = null;
+    },
+  };
+  const { calls, fetchImpl } = fakeFetch(() =>
+    json({ error: "org not connected" }, 404),
+  );
+  const s = store(fetchImpl, fallback);
+
+  // Idempotent: another pod already deleted the row; sign-out still succeeds.
+  await s.remove("ws_1", "openai-codex");
+  expect(fallbackCred).toBeNull();
+  // And the logout sticks: no gateway row, no fallback left to re-adopt.
+  expect(await s.get("ws_1", "openai-codex")).toBeNull();
+  expect(calls.map((c) => c.init?.method ?? "GET")).toEqual(["DELETE", "GET"]);
+});
+
+test("logout cannot resurrect through the legacy fallback after remove", async () => {
+  let fallbackCred: WorkspaceCredential | null = {
+    workspaceId: "ws_1",
+    provider: "openai-codex",
+    kind: "oauth",
+    accessToken: "AT-legacy",
+    refreshToken: "RT-legacy",
+    expiresAt: 123,
+  };
+  const fallback: CredentialStore = {
+    get: async () => fallbackCred,
+    put: async () => {},
+    remove: async () => {
+      fallbackCred = null;
+    },
+  };
+  const { calls, fetchImpl } = fakeFetch((call) => {
+    if (call.init?.method === "DELETE") return json({ ok: true });
+    if (call.init?.method === "PUT")
+      throw new Error("unexpected re-adoption PUT after logout");
+    return json({ error: "org not connected" }, 404);
+  });
+  const s = store(fetchImpl, fallback);
+
+  await s.remove("ws_1", "openai-codex");
+  // The next get must NOT re-adopt the removed credential into the gateway.
+  expect(await s.get("ws_1", "openai-codex")).toBeNull();
+  expect(calls.map((c) => c.init?.method ?? "GET")).toEqual(["DELETE", "GET"]);
+});
+
 test("remove deletes remotely and invalidates the provider cache", async () => {
   const { calls, fetchImpl } = fakeFetch((call, index) => {
     if (index === 0) return json(gatewayCredential());

--- a/packages/host/src/credentials/remote-store.test.ts
+++ b/packages/host/src/credentials/remote-store.test.ts
@@ -1,0 +1,229 @@
+import { expect, test } from "vitest";
+import type { CredentialStore, WorkspaceCredential } from "../ports";
+import { RemoteCredentialStore } from "./remote-store";
+
+type FetchCall = { url: string; init?: RequestInit };
+
+const ORG = "0011223344556677";
+const AGENT = "8899aabbccddeeff";
+const BASE = "https://gateway.test";
+const PATH = `${BASE}/v1/pod/credentials/${ORG}/${AGENT}/openai-codex`;
+
+function gatewayCredential(over: Record<string, unknown> = {}) {
+  return {
+    provider: "openai-codex",
+    kind: "oauth",
+    access: "AT-central",
+    expires: 1_730_000_000_000,
+    accountId: null,
+    enterpriseUrl: null,
+    ...over,
+  };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+function fakeFetch(
+  handler: (call: FetchCall, index: number) => Response | Promise<Response>,
+) {
+  const calls: FetchCall[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const call = { url: String(input), init };
+    calls.push(call);
+    return await handler(call, calls.length - 1);
+  }) as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+function store(fetchImpl: typeof fetch, fallback?: CredentialStore) {
+  return new RemoteCredentialStore({
+    baseUrl: `${BASE}/`,
+    orgSlug: ORG,
+    agentSlug: AGENT,
+    podToken: "pod-token",
+    fallback,
+    fetchImpl,
+  });
+}
+
+function headers(call: FetchCall): Record<string, string> {
+  return call.init?.headers as Record<string, string>;
+}
+
+function requestBody(call: FetchCall): Record<string, unknown> {
+  if (typeof call.init?.body !== "string")
+    throw new Error("expected string request body");
+  return JSON.parse(call.init.body) as Record<string, unknown>;
+}
+
+test("get maps a 200 gateway credential and strips refresh", async () => {
+  const { calls, fetchImpl } = fakeFetch((call) => {
+    expect(call.url).toBe(PATH);
+    expect(headers(call).Authorization).toBe("Bearer pod-token");
+    return json(
+      gatewayCredential({
+        accountId: "acct-1",
+        enterpriseUrl: "acme.ghe.com",
+      }),
+    );
+  });
+
+  const got = await store(fetchImpl).get("ws_9", "openai-codex");
+
+  expect(calls).toHaveLength(1);
+  expect(got).toEqual({
+    workspaceId: "ws_9",
+    provider: "openai-codex",
+    kind: "oauth",
+    accessToken: "AT-central",
+    refreshToken: "",
+    expiresAt: 1_730_000_000_000,
+    accountId: "acct-1",
+    enterpriseUrl: "acme.ghe.com",
+  });
+});
+
+test("404 means not connected and is cached as a negative result", async () => {
+  const { calls, fetchImpl } = fakeFetch(() =>
+    json({ error: "org not connected" }, 404),
+  );
+  const s = store(fetchImpl);
+
+  expect(await s.get("ws_1", "openai-codex")).toBeNull();
+  expect(await s.get("ws_2", "openai-codex")).toBeNull();
+  expect(calls).toHaveLength(1);
+});
+
+test("404 adopts a legacy fallback credential with insert-only PUT, then re-gets the winner", async () => {
+  const legacy: WorkspaceCredential = {
+    workspaceId: "ws_1",
+    provider: "openai-codex",
+    kind: "oauth",
+    accessToken: "AT-legacy",
+    refreshToken: "RT-legacy",
+    expiresAt: 123,
+    accountId: "acct-old",
+  };
+  const fallback: CredentialStore = {
+    get: async () => legacy,
+    put: async () => {},
+    remove: async () => {},
+  };
+  const { calls, fetchImpl } = fakeFetch((call, index) => {
+    if (index === 0) return json({ error: "org not connected" }, 404);
+    if (index === 1) {
+      expect(call.init?.method).toBe("PUT");
+      expect(headers(call)["x-houston-if-absent"]).toBe("1");
+      expect(requestBody(call)).toMatchObject({
+        kind: "oauth",
+        access: "AT-legacy",
+        refresh: "RT-legacy",
+        expires: 123,
+        accountId: "acct-old",
+      });
+      return json({ ok: true });
+    }
+    return json(gatewayCredential({ access: "AT-winner" }));
+  });
+
+  const got = await store(fetchImpl, fallback).get("ws_1", "openai-codex");
+
+  expect(calls.map((c) => c.init?.method ?? "GET")).toEqual([
+    "GET",
+    "PUT",
+    "GET",
+  ]);
+  expect(got?.accessToken).toBe("AT-winner");
+  expect(got?.refreshToken).toBe("");
+});
+
+test("transport errors throw and are not cached", async () => {
+  let fail = true;
+  const { calls, fetchImpl } = fakeFetch(() => {
+    if (fail) {
+      fail = false;
+      throw new Error("gateway down");
+    }
+    return json(gatewayCredential({ access: "AT-after-retry" }));
+  });
+  const s = store(fetchImpl);
+
+  await expect(s.get("ws_1", "openai-codex")).rejects.toThrow("gateway down");
+  expect((await s.get("ws_1", "openai-codex"))?.accessToken).toBe(
+    "AT-after-retry",
+  );
+  expect(calls).toHaveLength(2);
+});
+
+test("positive cache absorbs repeated gets within the TTL", async () => {
+  const { calls, fetchImpl } = fakeFetch(() =>
+    json(gatewayCredential({ access: "AT-cached" })),
+  );
+  const s = store(fetchImpl);
+
+  expect((await s.get("ws_1", "openai-codex"))?.accessToken).toBe("AT-cached");
+  expect((await s.get("ws_2", "openai-codex"))?.workspaceId).toBe("ws_2");
+  expect(calls).toHaveLength(1);
+});
+
+test("put writes the gateway row and invalidates the provider cache", async () => {
+  let getCount = 0;
+  const { calls, fetchImpl } = fakeFetch((call) => {
+    if (call.init?.method === "PUT") {
+      expect(headers(call)["x-houston-if-absent"]).toBeUndefined();
+      expect(requestBody(call)).toMatchObject({
+        kind: "oauth",
+        access: "AT-local",
+        refresh: "RT-local",
+        expires: 456,
+      });
+      return json({ ok: true });
+    }
+    getCount++;
+    return json(
+      gatewayCredential({
+        access: getCount === 1 ? "AT-before" : "AT-after",
+      }),
+    );
+  });
+  const s = store(fetchImpl);
+
+  expect((await s.get("ws_1", "openai-codex"))?.accessToken).toBe("AT-before");
+  await s.put({
+    workspaceId: "ws_1",
+    provider: "openai-codex",
+    accessToken: "AT-local",
+    refreshToken: "RT-local",
+    expiresAt: 456,
+  });
+  expect((await s.get("ws_1", "openai-codex"))?.accessToken).toBe("AT-after");
+  expect(calls.map((c) => c.init?.method ?? "GET")).toEqual([
+    "GET",
+    "PUT",
+    "GET",
+  ]);
+});
+
+test("remove deletes remotely and invalidates the provider cache", async () => {
+  const { calls, fetchImpl } = fakeFetch((call, index) => {
+    if (index === 0) return json(gatewayCredential());
+    if (index === 1) {
+      expect(call.init?.method).toBe("DELETE");
+      expect(headers(call).Authorization).toBe("Bearer pod-token");
+      return json({ ok: true });
+    }
+    return json({ error: "org not connected" }, 404);
+  });
+  const s = store(fetchImpl);
+
+  expect(await s.get("ws_1", "openai-codex")).not.toBeNull();
+  await s.remove("ws_1", "openai-codex");
+  expect(await s.get("ws_1", "openai-codex")).toBeNull();
+  expect(calls.map((c) => c.init?.method ?? "GET")).toEqual([
+    "GET",
+    "DELETE",
+    "GET",
+  ]);
+});

--- a/packages/host/src/credentials/remote-store.ts
+++ b/packages/host/src/credentials/remote-store.ts
@@ -4,18 +4,15 @@ import {
   isApiKeyCredential,
   type WorkspaceCredential,
 } from "../ports";
+import {
+  credentialFromGateway,
+  type GatewayCredential,
+  isNotConnected404,
+} from "./gateway-wire";
 
 const CACHE_TTL_MS = 15_000;
 type CachedCredential = Omit<WorkspaceCredential, "workspaceId">;
 
-interface GatewayCredential {
-  provider: string;
-  kind: "oauth" | "api_key";
-  access: string;
-  expires: number;
-  accountId?: string | null;
-  enterpriseUrl?: string | null;
-}
 export interface RemoteCredentialStoreOptions {
   baseUrl: string;
   orgSlug: string;
@@ -28,9 +25,11 @@ export interface RemoteCredentialStoreOptions {
 /**
  * Managed-pod credential store: the pod never owns refresh-token rotation. The
  * gateway is the single refresher for org credentials (OpenAI refresh tokens
- * rotate), and pods fetch only access/API-key material just-in-time. A 404 is the
- * authoritative "not connected" signal; transport/5xx errors must throw so the
- * runtime keeps its last hydrated token instead of logging the org out locally.
+ * rotate), and pods fetch only access/API-key material just-in-time. Only the
+ * gateway's own "not connected" 404 (JSON error body — see isNotConnected404)
+ * means logged out; every other failure, including a route-level 404 from a
+ * misdeployed gateway, must throw so the runtime keeps its last hydrated token
+ * instead of logging the org out locally.
  */
 export class RemoteCredentialStore implements CredentialStore {
   private readonly baseUrl: string;
@@ -77,13 +76,21 @@ export class RemoteCredentialStore implements CredentialStore {
     this.cache.delete(cred.provider);
   }
 
-  async remove(_workspaceId: WorkspaceId, provider: string): Promise<void> {
+  async remove(workspaceId: WorkspaceId, provider: string): Promise<void> {
     const res = await this.fetchImpl(this.url(provider), {
       method: "DELETE",
       headers: this.authHeaders(),
     });
-    if (res.status !== 200)
+    // Sign-out is idempotent, like the file store: the gateway's "not
+    // connected" 404 means the row is already gone (another pod removed it, or
+    // this provider was never adopted) — callers forget credential siblings
+    // unconditionally and rely on the no-op.
+    if (res.status !== 200 && !(await isNotConnected404(res)))
       throw await this.errorFromResponse(res, "DELETE", provider);
+    // Clear the legacy adoption source too — leaving the file entry would let
+    // the next get()'s 404-adoption silently resurrect the credential the user
+    // just removed, org-wide.
+    await this.fallback?.remove(workspaceId, provider);
     this.cache.delete(provider);
   }
 
@@ -104,11 +111,14 @@ export class RemoteCredentialStore implements CredentialStore {
     const res = await this.fetchImpl(this.url(provider), {
       headers: this.authHeaders(),
     });
-    if (res.status === 404) return null;
+    if (await isNotConnected404(res)) return null;
     if (res.status !== 200)
       throw await this.errorFromResponse(res, "GET", provider);
 
-    return this.fromGateway(provider, (await res.json()) as GatewayCredential);
+    return credentialFromGateway(
+      provider,
+      (await res.json()) as GatewayCredential,
+    );
   }
 
   private async putRemote(
@@ -135,33 +145,6 @@ export class RemoteCredentialStore implements CredentialStore {
     });
     if (res.status !== 200)
       throw await this.errorFromResponse(res, "PUT", provider);
-  }
-
-  private fromGateway(
-    provider: string,
-    body: GatewayCredential,
-  ): CachedCredential {
-    if (
-      body.provider !== provider ||
-      (body.kind !== "oauth" && body.kind !== "api_key") ||
-      typeof body.access !== "string" ||
-      typeof body.expires !== "number"
-    ) {
-      throw new Error(`credential gateway returned malformed ${provider} body`);
-    }
-    return {
-      provider: body.provider,
-      kind: body.kind,
-      accessToken: body.access,
-      refreshToken: "",
-      expiresAt: body.expires,
-      ...(typeof body.accountId === "string"
-        ? { accountId: body.accountId }
-        : {}),
-      ...(typeof body.enterpriseUrl === "string"
-        ? { enterpriseUrl: body.enterpriseUrl }
-        : {}),
-    };
   }
 
   private withWorkspace(

--- a/packages/host/src/credentials/remote-store.ts
+++ b/packages/host/src/credentials/remote-store.ts
@@ -1,0 +1,200 @@
+import type { WorkspaceId } from "../domain/types";
+import {
+  type CredentialStore,
+  isApiKeyCredential,
+  type WorkspaceCredential,
+} from "../ports";
+
+const CACHE_TTL_MS = 15_000;
+type CachedCredential = Omit<WorkspaceCredential, "workspaceId">;
+
+interface GatewayCredential {
+  provider: string;
+  kind: "oauth" | "api_key";
+  access: string;
+  expires: number;
+  accountId?: string | null;
+  enterpriseUrl?: string | null;
+}
+export interface RemoteCredentialStoreOptions {
+  baseUrl: string;
+  orgSlug: string;
+  agentSlug: string;
+  podToken: string;
+  fallback?: CredentialStore;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * Managed-pod credential store: the pod never owns refresh-token rotation. The
+ * gateway is the single refresher for org credentials (OpenAI refresh tokens
+ * rotate), and pods fetch only access/API-key material just-in-time. A 404 is the
+ * authoritative "not connected" signal; transport/5xx errors must throw so the
+ * runtime keeps its last hydrated token instead of logging the org out locally.
+ */
+export class RemoteCredentialStore implements CredentialStore {
+  private readonly baseUrl: string;
+  private readonly orgSlug: string;
+  private readonly agentSlug: string;
+  private readonly podToken: string;
+  private readonly fallback?: CredentialStore;
+  private readonly fetchImpl: typeof fetch;
+  private readonly cache = new Map<
+    string,
+    { until: number; value: CachedCredential | null }
+  >();
+
+  constructor(opts: RemoteCredentialStoreOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.orgSlug = opts.orgSlug;
+    this.agentSlug = opts.agentSlug;
+    this.podToken = opts.podToken;
+    this.fallback = opts.fallback;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async get(
+    workspaceId: WorkspaceId,
+    provider: string,
+  ): Promise<WorkspaceCredential | null> {
+    const cached = this.cache.get(provider);
+    if (cached && cached.until > Date.now())
+      return this.withWorkspace(workspaceId, cached.value);
+
+    const remote = await this.fetchRemote(provider);
+    if (remote) {
+      this.cache.set(provider, this.cacheEntry(remote));
+      return this.withWorkspace(workspaceId, remote);
+    }
+
+    const adopted = await this.adoptFallback(workspaceId, provider);
+    this.cache.set(provider, this.cacheEntry(adopted));
+    return this.withWorkspace(workspaceId, adopted);
+  }
+
+  async put(cred: WorkspaceCredential): Promise<void> {
+    await this.putRemote(cred.provider, cred);
+    this.cache.delete(cred.provider);
+  }
+
+  async remove(_workspaceId: WorkspaceId, provider: string): Promise<void> {
+    const res = await this.fetchImpl(this.url(provider), {
+      method: "DELETE",
+      headers: this.authHeaders(),
+    });
+    if (res.status !== 200)
+      throw await this.errorFromResponse(res, "DELETE", provider);
+    this.cache.delete(provider);
+  }
+
+  private async adoptFallback(
+    workspaceId: WorkspaceId,
+    provider: string,
+  ): Promise<CachedCredential | null> {
+    const local = await this.fallback?.get(workspaceId, provider);
+    if (!local) return null;
+
+    await this.putRemote(provider, local, { ifAbsent: true });
+    return await this.fetchRemote(provider);
+  }
+
+  private async fetchRemote(
+    provider: string,
+  ): Promise<CachedCredential | null> {
+    const res = await this.fetchImpl(this.url(provider), {
+      headers: this.authHeaders(),
+    });
+    if (res.status === 404) return null;
+    if (res.status !== 200)
+      throw await this.errorFromResponse(res, "GET", provider);
+
+    return this.fromGateway(provider, (await res.json()) as GatewayCredential);
+  }
+
+  private async putRemote(
+    provider: string,
+    cred: WorkspaceCredential,
+    opts: { ifAbsent?: boolean } = {},
+  ): Promise<void> {
+    const res = await this.fetchImpl(this.url(provider), {
+      method: "PUT",
+      headers: this.authHeaders({
+        "content-type": "application/json",
+        ...(opts.ifAbsent ? { "x-houston-if-absent": "1" } : {}),
+      }),
+      body: JSON.stringify({
+        kind: isApiKeyCredential(cred) ? "api_key" : "oauth",
+        access: cred.accessToken,
+        refresh: cred.refreshToken,
+        expires: cred.expiresAt,
+        ...(cred.accountId !== undefined ? { accountId: cred.accountId } : {}),
+        ...(cred.enterpriseUrl !== undefined
+          ? { enterpriseUrl: cred.enterpriseUrl }
+          : {}),
+      }),
+    });
+    if (res.status !== 200)
+      throw await this.errorFromResponse(res, "PUT", provider);
+  }
+
+  private fromGateway(
+    provider: string,
+    body: GatewayCredential,
+  ): CachedCredential {
+    if (
+      body.provider !== provider ||
+      (body.kind !== "oauth" && body.kind !== "api_key") ||
+      typeof body.access !== "string" ||
+      typeof body.expires !== "number"
+    ) {
+      throw new Error(`credential gateway returned malformed ${provider} body`);
+    }
+    return {
+      provider: body.provider,
+      kind: body.kind,
+      accessToken: body.access,
+      refreshToken: "",
+      expiresAt: body.expires,
+      ...(typeof body.accountId === "string"
+        ? { accountId: body.accountId }
+        : {}),
+      ...(typeof body.enterpriseUrl === "string"
+        ? { enterpriseUrl: body.enterpriseUrl }
+        : {}),
+    };
+  }
+
+  private withWorkspace(
+    workspaceId: WorkspaceId,
+    value: CachedCredential | null,
+  ): WorkspaceCredential | null {
+    return value ? { workspaceId, ...value } : null;
+  }
+
+  private cacheEntry(value: CachedCredential | null) {
+    return { value, until: Date.now() + CACHE_TTL_MS };
+  }
+
+  private url(provider: string): string {
+    return `${this.baseUrl}/v1/pod/credentials/${encodeURIComponent(this.orgSlug)}/${encodeURIComponent(this.agentSlug)}/${encodeURIComponent(provider)}`;
+  }
+
+  private authHeaders(
+    extra: Record<string, string> = {},
+  ): Record<string, string> {
+    return { Authorization: `Bearer ${this.podToken}`, ...extra };
+  }
+
+  private async errorFromResponse(
+    res: Response,
+    method: string,
+    provider: string,
+  ): Promise<Error> {
+    const body = await res.text().catch(() => "");
+    return new Error(
+      `credential gateway ${method} ${provider} failed (${res.status})${
+        body ? `: ${body.slice(0, 200)}` : ""
+      }`,
+    );
+  }
+}

--- a/packages/host/src/local/host.test.ts
+++ b/packages/host/src/local/host.test.ts
@@ -6,9 +6,14 @@ import { join } from "node:path";
 import type { Capabilities, Workspace } from "@houston/protocol";
 import { expect, test } from "vitest";
 import { MANAGED_CLOUD_CAPABILITIES } from "../capabilities";
+import { EnvCredentialVault } from "../credentials/vault";
 import type { Agent } from "../domain/types";
 import type { RuntimeSpawner } from "../launcher/process";
-import { buildLocalHost, LOCAL_CAPABILITIES } from "./host";
+import {
+  buildLocalHost,
+  LOCAL_CAPABILITIES,
+  type LocalHostOptions,
+} from "./host";
 
 /**
  * The local host wired end-to-end at the route level: the SAME server, driven
@@ -38,6 +43,7 @@ async function setup(opts?: {
   capabilities?: Capabilities;
   integrations?: { gatewayUrl?: string; composioApiKey?: string };
   gatewayFronted?: boolean;
+  credentials?: LocalHostOptions["credentials"];
   spawner?: RuntimeSpawner;
 }) {
   const workspacesRoot = mkdtempSync(join(tmpdir(), "houston-localhost-"));
@@ -57,6 +63,7 @@ async function setup(opts?: {
     capabilities: opts?.capabilities,
     integrations: opts?.integrations,
     gatewayFronted: opts?.gatewayFronted,
+    credentials: opts?.credentials,
   });
   await host.start();
   return { host, base: `http://127.0.0.1:${port}`, workspacesRoot };
@@ -102,6 +109,68 @@ test("capabilities can report the managed cloud pod profile", async () => {
     expect(caps.openaiCompatible).toBe(false);
   } finally {
     host.stop();
+  }
+});
+
+test("managed credential config serves sandbox credentials from the gateway", async () => {
+  const orgSlug = "0011223344556677";
+  const agentSlug = "8899aabbccddeeff";
+  const seen: { url?: string; auth?: string }[] = [];
+  const gateway = createHttpServer((req, res) => {
+    seen.push({ url: req.url, auth: req.headers.authorization });
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(
+      JSON.stringify({
+        provider: "openai-codex",
+        kind: "oauth",
+        access: "AT-org",
+        expires: 1_730_000_000_000,
+        accountId: null,
+        enterpriseUrl: null,
+      }),
+    );
+  });
+  await new Promise<void>((r) => gateway.listen(0, "127.0.0.1", () => r()));
+  try {
+    const addr = gateway.address();
+    const gatewayUrl = `http://127.0.0.1:${
+      typeof addr === "object" && addr ? addr.port : 0
+    }`;
+    const { host, base } = await setup({
+      credentials: {
+        url: gatewayUrl,
+        orgSlug,
+        agentSlug,
+        podToken: "pod-secret",
+      },
+    });
+    try {
+      const sbx = new EnvCredentialVault({
+        secret: "boot-secret",
+      }).sandboxToken("Work", "Work/Sales");
+      const r = await fetch(
+        `${base}/sandbox/credential?provider=openai-codex`,
+        {
+          headers: { Authorization: `Bearer ${sbx}` },
+        },
+      );
+      expect(r.status).toBe(200);
+      expect(await r.json()).toMatchObject({
+        provider: "openai-codex",
+        access: "AT-org",
+        kind: "oauth",
+      });
+      const first = seen.at(0);
+      if (!first) throw new Error("expected a gateway credential request");
+      expect(first.url).toBe(
+        `/v1/pod/credentials/${orgSlug}/${agentSlug}/openai-codex`,
+      );
+      expect(first.auth).toBe("Bearer pod-secret");
+    } finally {
+      host.stop();
+    }
+  } finally {
+    await new Promise<void>((r) => gateway.close(() => r()));
   }
 });
 

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -5,6 +5,7 @@ import { SingleUserVerifier } from "../auth/verify";
 import { LOCAL_CAPABILITIES } from "../capabilities";
 import { ProxyChannel } from "../channel/proxy";
 import { FileCredentialStore } from "../credentials/file-store";
+import { RemoteCredentialStore } from "../credentials/remote-store";
 import { EnvCredentialVault } from "../credentials/vault";
 import { BusEventHub } from "../events/hub";
 import { ComposioProvider } from "../integrations/composio";
@@ -87,6 +88,17 @@ export interface LocalHostOptions {
   /** Override served capabilities; managed K8s pods use the cloud profile. */
   capabilities?: ControlPlaneDeps["capabilities"];
   /**
+   * Managed pod credential gateway. When present, provider credentials live at
+   * the org level in the gateway (single refresher); the local file is only a
+   * one-time adoption fallback for pods that already captured a legacy credential.
+   */
+  credentials?: {
+    url: string;
+    orgSlug: string;
+    agentSlug: string;
+    podToken: string;
+  };
+  /**
    * Integration wiring (platform model):
    *  - `gatewayUrl`: Houston's cloud host; the desktop forwards with the user's
    *    Supabase session, so no provider key ever lives on this machine.
@@ -136,7 +148,16 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
   const bus = new MemoryTurnBus();
   const events = new BusEventHub(bus);
   const vault = new EnvCredentialVault({ secret: opts.token });
-  const credentials = new FileCredentialStore(opts.credentialsPath);
+  const fileCredentials = new FileCredentialStore(opts.credentialsPath);
+  const credentials = opts.credentials
+    ? new RemoteCredentialStore({
+        baseUrl: opts.credentials.url,
+        orgSlug: opts.credentials.orgSlug,
+        agentSlug: opts.credentials.agentSlug,
+        podToken: opts.credentials.podToken,
+        fallback: fileCredentials,
+      })
+    : fileCredentials;
   const controlPlaneUrl = `http://127.0.0.1:${opts.port}`;
 
   const spawner =

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -25,6 +25,9 @@ import { buildLocalHost } from "./host";
  *   HOUSTON_HOST_BIND         127.0.0.1 (desktop). Self-host on a VPS sets
  *                             0.0.0.0 to expose it behind a TLS reverse proxy.
  *   HOUSTON_HOST_TOKEN        random per boot (set a fixed one for self-host)
+ *   HOUSTON_CREDENTIALS_URL   managed pod only: gateway base URL for org credentials
+ *   HOUSTON_ORG_SLUG          managed pod only: org slug for org credentials
+ *   HOUSTON_AGENT_SLUG        managed pod only: agent slug for org credentials
  *   HOUSTON_RUNTIME_COMMAND   argv to launch a pi-runtime (space-separated);
  *                             explicit override (highest priority). Otherwise:
  *                             the compiled sidecar spawns ITSELF (in runtime
@@ -58,7 +61,25 @@ function runtimeCommand(): string[] {
   return [process.execPath, "--import", "tsx", runtimeMain];
 }
 
+function remoteCredentialConfig(hostTokenEnv: string | undefined) {
+  const url = process.env.HOUSTON_CREDENTIALS_URL;
+  const orgSlug = process.env.HOUSTON_ORG_SLUG;
+  const agentSlug = process.env.HOUSTON_AGENT_SLUG;
+  const any = !!url || !!orgSlug || !!agentSlug;
+  if (url && orgSlug && agentSlug && hostTokenEnv) {
+    return { url, orgSlug, agentSlug, podToken: hostTokenEnv };
+  }
+  if (any) {
+    console.warn(
+      "[local-host] incomplete managed credential gateway env; set HOUSTON_CREDENTIALS_URL, HOUSTON_ORG_SLUG, HOUSTON_AGENT_SLUG, and HOUSTON_HOST_TOKEN. Falling back to file credentials.",
+    );
+  }
+  return undefined;
+}
+
 const houstonHome = process.env.HOUSTON_HOME || join(homedir(), ".houston");
+const hostTokenEnv = process.env.HOUSTON_HOST_TOKEN;
+const hostToken = hostTokenEnv || randomBytes(32).toString("hex");
 const host = buildLocalHost({
   workspacesRoot:
     process.env.HOUSTON_WORKSPACES_ROOT || join(houstonHome, "workspaces"),
@@ -77,7 +98,7 @@ const host = buildLocalHost({
   port: Number(process.env.HOUSTON_HOST_PORT || 4318),
   // Loopback by default (desktop). Self-host sets HOUSTON_HOST_BIND=0.0.0.0.
   bind: process.env.HOUSTON_HOST_BIND || undefined,
-  token: process.env.HOUSTON_HOST_TOKEN || randomBytes(32).toString("hex"),
+  token: hostToken,
   // Redact the token in the startup banner whenever it came from the
   // environment (a pod/self-host token an orchestrator already knows) or we are
   // a managed cloud pod — echoing it there just leaks a credential into
@@ -85,8 +106,7 @@ const host = buildLocalHost({
   // HOUSTON_HOST_TOKEN) and its supervisor reads it back from this line, so
   // that case keeps the full token.
   redactBannerToken:
-    !!process.env.HOUSTON_HOST_TOKEN ||
-    process.env.HOUSTON_MANAGED_CLOUD === "1",
+    !!hostTokenEnv || process.env.HOUSTON_MANAGED_CLOUD === "1",
   runtimeCommand: runtimeCommand(),
   // The real Tauri app hands over its own product prompt; this is the built-in
   // default so the agent knows how to create Skills/Routines/learnings.
@@ -99,6 +119,7 @@ const host = buildLocalHost({
   // x-houston-acting-as); relay that header to the runtime so integration
   // calls act as the driving user. Desktop/self-host stay direct → false.
   gatewayFronted: process.env.HOUSTON_MANAGED_CLOUD === "1",
+  credentials: remoteCredentialConfig(hostTokenEnv),
   // Platform-mode integrations: desktops get HOUSTON_INTEGRATIONS_URL (the
   // cloud gateway holding Houston's Composio key); self-host + the managed pod
   // set their own COMPOSIO_API_KEY and go direct. Neither → integrations off.
@@ -109,7 +130,7 @@ const host = buildLocalHost({
     // it): pass it as the pod token so a routine turn authenticates as its
     // creator (C2). The desktop's token is a random per-boot secret, not a pod
     // token the gateway knows, so leave it unset there.
-    podToken: process.env.HOUSTON_HOST_TOKEN || undefined,
+    podToken: hostTokenEnv || undefined,
   },
   onRuntimeLog: (line) => process.stderr.write(line),
 });

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -65,14 +65,19 @@ function remoteCredentialConfig(hostTokenEnv: string | undefined) {
   const url = process.env.HOUSTON_CREDENTIALS_URL;
   const orgSlug = process.env.HOUSTON_ORG_SLUG;
   const agentSlug = process.env.HOUSTON_AGENT_SLUG;
-  const any = !!url || !!orgSlug || !!agentSlug;
   if (url && orgSlug && agentSlug && hostTokenEnv) {
     return { url, orgSlug, agentSlug, podToken: hostTokenEnv };
   }
-  if (any) {
-    console.warn(
-      "[local-host] incomplete managed credential gateway env; set HOUSTON_CREDENTIALS_URL, HOUSTON_ORG_SLUG, HOUSTON_AGENT_SLUG, and HOUSTON_HOST_TOKEN. Falling back to file credentials.",
+  if (url || orgSlug || agentSlug) {
+    // A partial env is always a deploy bug — no profile sets only some of these.
+    // Falling back to the (empty) file store would make every credential serve
+    // read as an org-wide logout, and a legacy pod would even start rotating
+    // refresh tokens locally against the gateway's rotation. Die loudly so the
+    // pod restarts into a fixed spec instead of degrading silently.
+    console.error(
+      "[local-host] incomplete managed credential gateway env: set HOUSTON_CREDENTIALS_URL, HOUSTON_ORG_SLUG, HOUSTON_AGENT_SLUG, and HOUSTON_HOST_TOKEN together.",
     );
+    process.exit(1);
   }
   return undefined;
 }

--- a/packages/host/src/routes/credential.test.ts
+++ b/packages/host/src/routes/credential.test.ts
@@ -36,12 +36,17 @@ type ServedBody = {
 
 function mockRes(): {
   res: ServerResponse;
-  out: { status?: number; body: ServedBody };
+  out: { status?: number; headers?: Record<string, string>; body: ServedBody };
 } {
-  const out: { status?: number; body: ServedBody } = { body: {} };
+  const out: {
+    status?: number;
+    headers?: Record<string, string>;
+    body: ServedBody;
+  } = { body: {} };
   const res = {
-    writeHead(status: number) {
+    writeHead(status: number, headers?: Record<string, string>) {
       out.status = status;
+      out.headers = headers;
     },
     end(buf: Buffer | string) {
       out.body = JSON.parse(buf.toString());
@@ -128,4 +133,7 @@ test("404 when the workspace has not connected the provider", async () => {
   const r = mockRes();
   expect(await call(credentials, "anthropic", r)).toBe(true);
   expect(r.out.status).toBe(404);
+  // The authoritative marker: the runtime only drops served credentials on
+  // marked 404s, never on a bare route-level 404.
+  expect(r.out.headers?.["x-houston-not-connected"]).toBe("1");
 });

--- a/packages/host/src/routes/credential.test.ts
+++ b/packages/host/src/routes/credential.test.ts
@@ -103,6 +103,26 @@ test("serves an api-key credential as kind=api_key without refreshing", async ()
   });
 });
 
+test("serves a gateway access-only OAuth credential without local refresh", async () => {
+  const credentials = new MemoryCredentialStore();
+  await credentials.put({
+    workspaceId: "w1",
+    provider: "openai-codex",
+    accessToken: "served-AT",
+    refreshToken: "",
+    expiresAt: 1, // expiring, but the gateway is the only refresher
+    kind: "oauth",
+  });
+  const r = mockRes();
+  expect(await call(credentials, "openai-codex", r)).toBe(true);
+  expect(r.out.status).toBe(200);
+  expect(r.out.body).toMatchObject({
+    provider: "openai-codex",
+    access: "served-AT",
+    kind: "oauth",
+  });
+});
+
 test("404 when the workspace has not connected the provider", async () => {
   const credentials = new MemoryCredentialStore();
   const r = mockRes();

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -34,7 +34,15 @@ export async function handleSandboxCredential(
   const provider = url.searchParams.get("provider") || "openai-codex";
   let cred = await deps.credentials.get(claim.workspaceId, provider);
   if (!cred) {
-    json(res, 404, { error: "workspace not connected" });
+    // The marker makes this 404 the store's own authoritative "not connected"
+    // answer. The runtime only drops served credentials on marked 404s — a bare
+    // 404 (old host, wrong control-plane URL) must never read as a logout.
+    json(
+      res,
+      404,
+      { error: "workspace not connected" },
+      { "x-houston-not-connected": "1" },
+    );
     return true;
   }
   if (isExpiring(cred) && cred.refreshToken) {

--- a/packages/host/src/routes/credential.ts
+++ b/packages/host/src/routes/credential.ts
@@ -37,7 +37,7 @@ export async function handleSandboxCredential(
     json(res, 404, { error: "workspace not connected" });
     return true;
   }
-  if (isExpiring(cred)) {
+  if (isExpiring(cred) && cred.refreshToken) {
     try {
       cred = await refreshCredential(cred);
       await deps.credentials.put(cred);

--- a/packages/host/src/routes/http.ts
+++ b/packages/host/src/routes/http.ts
@@ -1,8 +1,16 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 
-export function json(res: ServerResponse, status: number, body: unknown): void {
+export function json(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+): void {
   const buf = Buffer.from(JSON.stringify(body));
-  res.writeHead(status, { "Content-Type": "application/json; charset=utf-8" });
+  res.writeHead(status, {
+    "Content-Type": "application/json; charset=utf-8",
+    ...headers,
+  });
   res.end(buf);
 }
 

--- a/packages/runtime/src/auth/auth-file.ts
+++ b/packages/runtime/src/auth/auth-file.ts
@@ -105,3 +105,27 @@ export function scrubRefreshTokensAt(path: string): string[] {
   if (scrubbed.length) writeAuthFile(path, auth);
   return scrubbed;
 }
+
+/**
+ * Remove one provider only when the entry is owned by the serve path: an OAuth
+ * credential already scrubbed to refresh="" or an API key served from the host.
+ * A refresh-bearing OAuth entry is pi's just-connected credential before capture
+ * + scrub, so a transient gateway 404 must not delete it.
+ */
+export function removeServedCredentialAt(
+  path: string,
+  provider: string,
+): boolean {
+  const auth = readAuthFile(path);
+  const cred = auth[provider];
+  if (
+    !cred ||
+    (cred.type === "oauth" && cred.refresh) ||
+    (cred.type !== "oauth" && cred.type !== "api_key")
+  ) {
+    return false;
+  }
+  delete auth[provider];
+  writeAuthFile(path, auth);
+  return true;
+}

--- a/packages/runtime/src/auth/auth-file.ts
+++ b/packages/runtime/src/auth/auth-file.ts
@@ -57,10 +57,14 @@ export function readAuthFile(path: string): Record<string, PiCred> {
   }
 }
 
-function writeAuthFile(path: string, contents: Record<string, PiCred>): void {
+function writeJsonAtomic(path: string, contents: unknown): void {
   const tmp = `${path}.tmp`;
   writeFileSync(tmp, JSON.stringify(contents), { mode: 0o600 }); // atomic write
   renameSync(tmp, path);
+}
+
+function writeAuthFile(path: string, contents: Record<string, PiCred>): void {
+  writeJsonAtomic(path, contents);
 }
 
 /**
@@ -107,10 +111,39 @@ export function scrubRefreshTokensAt(path: string): string[] {
 }
 
 /**
+ * Provenance manifest ("served-providers.json", next to auth.json): the
+ * providers whose auth.json entry was written by the serve path. An
+ * authoritative central 404 may only remove providers listed here — a
+ * locally-connected credential the central store never held (the Anthropic
+ * setup token, an openai-compatible local-model key) is shaped exactly like a
+ * served one (api_key / refresh=""), so shape alone cannot prove ownership.
+ */
+export function readServedProvidersAt(path: string): string[] {
+  if (!existsSync(path)) return [];
+  try {
+    const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+    return Array.isArray(parsed)
+      ? parsed.filter((p): p is string => typeof p === "string")
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+export function writeServedProvidersAt(
+  path: string,
+  providers: string[],
+): void {
+  writeJsonAtomic(path, providers);
+}
+
+/**
  * Remove one provider only when the entry is owned by the serve path: an OAuth
  * credential already scrubbed to refresh="" or an API key served from the host.
  * A refresh-bearing OAuth entry is pi's just-connected credential before capture
- * + scrub, so a transient gateway 404 must not delete it.
+ * + scrub, so a transient gateway 404 must not delete it. The caller gates this
+ * further on the served-providers manifest (see serve.ts) — shape is defense in
+ * depth, provenance is the decider.
  */
 export function removeServedCredentialAt(
   path: string,

--- a/packages/runtime/src/auth/export.ts
+++ b/packages/runtime/src/auth/export.ts
@@ -1,0 +1,59 @@
+import { join } from "node:path";
+import { config } from "../config";
+import { type PiCred, readAuthFile } from "./auth-file";
+
+export type ExportedCredential = {
+  provider: string;
+  access: string;
+  refresh: string;
+  expires: number;
+  accountId?: string;
+  enterpriseUrl?: string;
+};
+
+/**
+ * Pure: choose the OAuth credential to export from an auth.json record. When
+ * `provider` is given, returns EXACTLY that provider (connect-once capture is
+ * provider-specific — capturing a github-copilot connect must never grab a
+ * different OAuth provider that comes first in the record). Without a provider,
+ * returns the first connected OAuth provider. Only OAuth credentials with both
+ * access + refresh are exportable (an API key is submitted to the host directly,
+ * and a scrubbed entry has refresh=""). Testable without the dataDir singleton.
+ */
+export function selectExportCredential(
+  auth: Record<string, PiCred>,
+  provider?: string,
+): ExportedCredential | null {
+  for (const [p, c] of Object.entries(auth)) {
+    if (provider && p !== provider) continue;
+    if (c?.type === "oauth" && c.access && c.refresh) {
+      return {
+        provider: p,
+        access: c.access,
+        refresh: c.refresh,
+        expires: c.expires,
+        accountId: c.accountId,
+        enterpriseUrl: c.enterpriseUrl,
+      };
+    }
+  }
+  return null;
+}
+
+/**
+ * Export the locally-held credential so the control plane can capture it into
+ * the workspace's central store right after a device-code connect. When
+ * `provider` is given, exports EXACTLY that provider — connect-once capture is
+ * provider-specific, so capturing a github-copilot connect must never grab a
+ * different OAuth provider that happens to come first in auth.json (which would
+ * leave Copilot un-persisted centrally and 404 every per-turn serve). Without a
+ * provider, falls back to the first connected OAuth provider. Returns null when
+ * the (requested) provider isn't connected — also the post-scrub state, so
+ * capture must run before scrub.
+ */
+export function exportCredential(provider?: string): ExportedCredential | null {
+  return selectExportCredential(
+    readAuthFile(join(config.dataDir, "auth.json")),
+    provider,
+  );
+}

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -7,6 +7,7 @@ import { config } from "../config";
 import {
   applyServedCredential,
   type PiCred,
+  removeServedCredentialAt,
   scrubRefreshTokensAt,
 } from "./auth-file";
 import { selectExportCredential, syncServedCredential } from "./serve";
@@ -57,9 +58,11 @@ async function withServeMode(
 ): Promise<void> {
   const prevUrl = config.controlPlaneUrl;
   const prevTok = config.sandboxToken;
+  const prevDataDir = config.dataDir;
   const prevFetch = globalThis.fetch;
   config.controlPlaneUrl = "http://control-plane.test";
   config.sandboxToken = "sbx-token";
+  config.dataDir = mkdtempSync(join(tmpdir(), "houston-servemode-"));
   globalThis.fetch = fetchImpl;
   try {
     await body();
@@ -67,6 +70,7 @@ async function withServeMode(
     globalThis.fetch = prevFetch;
     config.controlPlaneUrl = prevUrl;
     config.sandboxToken = prevTok;
+    config.dataDir = prevDataDir;
   }
 }
 
@@ -112,6 +116,44 @@ test("syncServedCredential is a no-op when serve mode is off (local desktop)", a
     config.controlPlaneUrl = prevUrl;
     config.sandboxToken = prevTok;
   }
+});
+
+test("syncServedCredential removes served-owned credentials on a central 404", async () => {
+  const fetchImpl = (async () => {
+    return new Response(null, { status: 404 });
+  }) as unknown as typeof globalThis.fetch;
+  await withServeMode(fetchImpl, async () => {
+    const path = join(config.dataDir, "auth.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        "openai-codex": {
+          type: "oauth",
+          access: "AT-served",
+          refresh: "",
+          expires: 1,
+        },
+        "github-copilot": {
+          type: "oauth",
+          access: "AT-pending",
+          refresh: "RT-pending-capture",
+          expires: 2,
+        },
+        opencode: { type: "api_key", key: "sk-served" },
+      }),
+    );
+
+    expect(await syncServedCredential()).toEqual([]);
+    const auth = readAuth(path);
+    expect(auth["openai-codex"]).toBeUndefined();
+    expect(auth.opencode).toBeUndefined();
+    expect(auth["github-copilot"]).toEqual({
+      type: "oauth",
+      access: "AT-pending",
+      refresh: "RT-pending-capture",
+      expires: 2,
+    });
+  });
 });
 
 test("selectExportCredential without a provider falls back to the first OAuth credential", () => {
@@ -279,6 +321,53 @@ test("scrub is idempotent and a missing auth.json is a no-op", () => {
     }),
   );
   expect(scrubRefreshTokensAt(path)).toEqual([]); // already clean
+});
+
+test("removeServedCredentialAt removes only served-owned credentials for the requested provider", () => {
+  const path = freshAuthPath();
+  writeFileSync(
+    path,
+    JSON.stringify({
+      "openai-codex": { type: "oauth", access: "A1", refresh: "", expires: 1 },
+      anthropic: { type: "oauth", access: "A2", refresh: "", expires: 2 },
+      opencode: { type: "api_key", key: "sk-opencode" },
+    }),
+  );
+
+  expect(removeServedCredentialAt(path, "openai-codex")).toBe(true);
+  expect(removeServedCredentialAt(path, "opencode")).toBe(true);
+  const auth = readAuth(path);
+  expect(auth["openai-codex"]).toBeUndefined();
+  expect(auth.opencode).toBeUndefined();
+  expect(auth.anthropic).toEqual({
+    type: "oauth",
+    access: "A2",
+    refresh: "",
+    expires: 2,
+  });
+});
+
+test("removeServedCredentialAt keeps a refresh-bearing OAuth credential mid-capture", () => {
+  const path = freshAuthPath();
+  writeFileSync(
+    path,
+    JSON.stringify({
+      "github-copilot": {
+        type: "oauth",
+        access: "AT-pending",
+        refresh: "RT-pending-capture",
+        expires: 2,
+      },
+    }),
+  );
+
+  expect(removeServedCredentialAt(path, "github-copilot")).toBe(false);
+  expect(readAuth(path)["github-copilot"]).toEqual({
+    type: "oauth",
+    access: "AT-pending",
+    refresh: "RT-pending-capture",
+    expires: 2,
+  });
 });
 
 // --- API-key providers (openrouter, deepseek, google, amazon-bedrock) ---

--- a/packages/runtime/src/auth/serve.test.ts
+++ b/packages/runtime/src/auth/serve.test.ts
@@ -7,10 +7,20 @@ import { config } from "../config";
 import {
   applyServedCredential,
   type PiCred,
+  readServedProvidersAt,
   removeServedCredentialAt,
   scrubRefreshTokensAt,
+  writeServedProvidersAt,
 } from "./auth-file";
-import { selectExportCredential, syncServedCredential } from "./serve";
+import { selectExportCredential } from "./export";
+import { syncServedCredential } from "./serve";
+
+/** The host's authoritative "not connected" 404 (see routes/credential.ts). */
+const notConnected404 = () =>
+  new Response(null, {
+    status: 404,
+    headers: { "x-houston-not-connected": "1" },
+  });
 
 /**
  * Connect-once capture must be PROVIDER-SPECIFIC. The runtime exports the
@@ -80,7 +90,7 @@ test("concurrent syncServedCredential calls share one in-flight sync (no auth.js
   // pure while still exercising one full per-provider probe sweep.
   const fetchImpl = (async () => {
     calls++;
-    return new Response(null, { status: 404 });
+    return notConnected404();
   }) as unknown as typeof globalThis.fetch;
   await withServeMode(fetchImpl, async () => {
     const [a, b, c] = await Promise.all([
@@ -118,12 +128,13 @@ test("syncServedCredential is a no-op when serve mode is off (local desktop)", a
   }
 });
 
-test("syncServedCredential removes served-owned credentials on a central 404", async () => {
+test("syncServedCredential removes manifest-tracked credentials on a central 404", async () => {
   const fetchImpl = (async () => {
-    return new Response(null, { status: 404 });
+    return notConnected404();
   }) as unknown as typeof globalThis.fetch;
   await withServeMode(fetchImpl, async () => {
     const path = join(config.dataDir, "auth.json");
+    const manifestPath = join(config.dataDir, "served-providers.json");
     writeFileSync(
       path,
       JSON.stringify({
@@ -142,17 +153,121 @@ test("syncServedCredential removes served-owned credentials on a central 404", a
         opencode: { type: "api_key", key: "sk-served" },
       }),
     );
+    // These three were hydrated by earlier serves; the sign-out may touch them.
+    writeServedProvidersAt(manifestPath, [
+      "openai-codex",
+      "github-copilot",
+      "opencode",
+    ]);
 
     expect(await syncServedCredential()).toEqual([]);
     const auth = readAuth(path);
     expect(auth["openai-codex"]).toBeUndefined();
     expect(auth.opencode).toBeUndefined();
+    // Mid-capture (refresh-bearing) survives even when manifest-tracked.
     expect(auth["github-copilot"]).toEqual({
       type: "oauth",
       access: "AT-pending",
       refresh: "RT-pending-capture",
       expires: 2,
     });
+    // The signed-out providers left the manifest.
+    expect(readServedProvidersAt(manifestPath)).toEqual([]);
+  });
+});
+
+test("a central 404 leaves locally-connected credentials alone (no manifest entry)", async () => {
+  const fetchImpl = (async () => {
+    return notConnected404();
+  }) as unknown as typeof globalThis.fetch;
+  await withServeMode(fetchImpl, async () => {
+    const path = join(config.dataDir, "auth.json");
+    // The Anthropic setup token and an openai-compatible local-model key are
+    // written by pi locally and NEVER exist centrally — every serve 404s them.
+    // They are shaped exactly like served entries, so only provenance saves them.
+    writeFileSync(
+      path,
+      JSON.stringify({
+        anthropic: { type: "api_key", key: "sk-ant-oat01-SETUP" },
+        "openai-compatible": { type: "api_key", key: "houston-local" },
+      }),
+    );
+
+    expect(await syncServedCredential()).toEqual([]);
+    const auth = readAuth(path);
+    expect(auth.anthropic).toEqual({
+      type: "api_key",
+      key: "sk-ant-oat01-SETUP",
+    });
+    expect(auth["openai-compatible"]).toEqual({
+      type: "api_key",
+      key: "houston-local",
+    });
+  });
+});
+
+test("a bare 404 without the not-connected marker is a hiccup, not a logout", async () => {
+  // An old host, a wrong control-plane URL, or a route-level miss all produce
+  // unmarked 404s — none of them may delete a working credential.
+  const fetchImpl = (async () => {
+    return new Response(null, { status: 404 });
+  }) as unknown as typeof globalThis.fetch;
+  await withServeMode(fetchImpl, async () => {
+    const path = join(config.dataDir, "auth.json");
+    const manifestPath = join(config.dataDir, "served-providers.json");
+    writeFileSync(
+      path,
+      JSON.stringify({
+        "openai-codex": {
+          type: "oauth",
+          access: "AT-served",
+          refresh: "",
+          expires: 1,
+        },
+      }),
+    );
+    writeServedProvidersAt(manifestPath, ["openai-codex"]);
+
+    expect(await syncServedCredential()).toEqual([]);
+    expect(readAuth(path)["openai-codex"]).toEqual({
+      type: "oauth",
+      access: "AT-served",
+      refresh: "",
+      expires: 1,
+    });
+    expect(readServedProvidersAt(manifestPath)).toEqual(["openai-codex"]);
+  });
+});
+
+test("a serve marks the provider in the manifest, so a later sign-out removes it", async () => {
+  let signedOut = false;
+  const fetchImpl = (async (input: RequestInfo | URL) => {
+    if (!signedOut && String(input).includes("provider=openai-codex")) {
+      return new Response(
+        JSON.stringify({
+          provider: "openai-codex",
+          kind: "oauth",
+          access: "AT-central",
+          expires: 1_900_000_000_000,
+          accountId: null,
+        }),
+        { status: 200 },
+      );
+    }
+    return notConnected404();
+  }) as unknown as typeof globalThis.fetch;
+  await withServeMode(fetchImpl, async () => {
+    const path = join(config.dataDir, "auth.json");
+    const manifestPath = join(config.dataDir, "served-providers.json");
+
+    expect(await syncServedCredential()).toEqual(["openai-codex"]);
+    expect(readServedProvidersAt(manifestPath)).toEqual(["openai-codex"]);
+    expect(readAuth(path)["openai-codex"]?.access).toBe("AT-central");
+
+    signedOut = true; // org-wide sign-out: central store now 404s everything
+    expect(await syncServedCredential()).toEqual([]);
+    expect(readAuth(path)["openai-codex"]).toBeUndefined();
+    expect(readServedProvidersAt(manifestPath)).toEqual([]);
   });
 });
 

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -5,6 +5,7 @@ import {
   applyServedCredential,
   type PiCred,
   readAuthFile,
+  removeServedCredentialAt,
   type ServedCredential,
   scrubRefreshTokensAt,
 } from "./auth-file";
@@ -110,6 +111,7 @@ export function syncServedCredential(): Promise<string[]> {
 async function runServedSync(): Promise<string[]> {
   if (!serveModeOn()) return [];
   const applied: string[] = [];
+  const removed: string[] = [];
   for (const p of PROVIDERS) {
     const res = await fetch(
       `${config.controlPlaneUrl}/sandbox/credential?provider=${p.id}`,
@@ -117,7 +119,13 @@ async function runServedSync(): Promise<string[]> {
         headers: { Authorization: `Bearer ${config.sandboxToken}` },
       },
     );
-    if (res.status === 404) continue; // this provider isn't connected
+    if (res.status === 404) {
+      // Authoritative logout from the central store: remove only credentials this
+      // runtime learned from serve mode. A refresh-bearing OAuth entry is the
+      // device-code connect flow mid-capture, before scrub, and must survive.
+      if (removeServedCredentialAt(authPathFor(), p.id)) removed.push(p.id);
+      continue;
+    }
     if (!res.ok) {
       // Internal serve hiccup for ONE provider must not strand the others; the
       // turn still surfaces "No provider connected" downstream if nothing applied.
@@ -135,7 +143,7 @@ async function runServedSync(): Promise<string[]> {
   // pi's AuthStorage caches auth.json in memory at startup; a direct write is
   // invisible to hasAuth()/resolveModel() until we re-read it. This is the line
   // that makes a never-connected agent actually see the served credential.
-  if (applied.length) authStorage.reload();
+  if (applied.length || removed.length) authStorage.reload();
   // One-line per-turn diagnostic: which central credentials this serve applied.
   // If a connected provider is absent here (its serve 404'd), its token can't be
   // refreshed centrally — the silent-404 path that left Copilot un-served.

--- a/packages/runtime/src/auth/serve.ts
+++ b/packages/runtime/src/auth/serve.ts
@@ -3,51 +3,13 @@ import { PROVIDERS } from "../ai/providers";
 import { config } from "../config";
 import {
   applyServedCredential,
-  type PiCred,
-  readAuthFile,
+  readServedProvidersAt,
   removeServedCredentialAt,
   type ServedCredential,
   scrubRefreshTokensAt,
+  writeServedProvidersAt,
 } from "./auth-file";
 import { authStorage } from "./storage";
-
-export type ExportedCredential = {
-  provider: string;
-  access: string;
-  refresh: string;
-  expires: number;
-  accountId?: string;
-  enterpriseUrl?: string;
-};
-
-/**
- * Pure: choose the OAuth credential to export from an auth.json record. When
- * `provider` is given, returns EXACTLY that provider (connect-once capture is
- * provider-specific — capturing a github-copilot connect must never grab a
- * different OAuth provider that comes first in the record). Without a provider,
- * returns the first connected OAuth provider. Only OAuth credentials with both
- * access + refresh are exportable (an API key is submitted to the host directly,
- * and a scrubbed entry has refresh=""). Testable without the dataDir singleton.
- */
-export function selectExportCredential(
-  auth: Record<string, PiCred>,
-  provider?: string,
-): ExportedCredential | null {
-  for (const [p, c] of Object.entries(auth)) {
-    if (provider && p !== provider) continue;
-    if (c?.type === "oauth" && c.access && c.refresh) {
-      return {
-        provider: p,
-        access: c.access,
-        refresh: c.refresh,
-        expires: c.expires,
-        accountId: c.accountId,
-        enterpriseUrl: c.enterpriseUrl,
-      };
-    }
-  }
-  return null;
-}
 
 /**
  * Connect-once serve mode (security Gate #2: access-token-only).
@@ -70,6 +32,19 @@ export function selectExportCredential(
  */
 
 const authPathFor = () => join(config.dataDir, "auth.json");
+const servedManifestPathFor = () =>
+  join(config.dataDir, "served-providers.json");
+
+/**
+ * Marker the host sets on its /sandbox/credential 404: the credential store's
+ * own "not connected" answer. Only marked 404s are an authoritative logout —
+ * a bare 404 (an old host, a mistyped control-plane URL, a route-level miss)
+ * must never delete a working credential.
+ */
+const NOT_CONNECTED_HEADER = "x-houston-not-connected";
+
+/** One stalled host/gateway socket must not hang every hydrating route. */
+const SERVE_FETCH_TIMEOUT_MS = 10_000;
 
 /** True when the sandbox is wired to serve a central workspace credential. */
 export function serveModeOn(): boolean {
@@ -91,12 +66,13 @@ export function scrubRefreshTokens(): string[] {
  * provider the next turn uses. Returns the providers that were applied; an empty
  * result means the workspace hasn't connected anything yet.
  *
- * Concurrent callers SHARE one in-flight sync. GET /auth/status now hydrates too
- * (so a brand-new agent's model picker shows the workspace's connected providers
- * before its first turn — HOU-573), and the picker fires one status request PER
- * provider in parallel. Without sharing, those N requests would run N syncs that
- * each rewrite auth.json at once — a write race. A turn and a status poll can also
- * overlap. One sync, one auth.json write, every caller gets the same result.
+ * Concurrent callers SHARE one in-flight sync. GET /auth/status and GET /providers
+ * hydrate too (so a brand-new agent's model picker shows the workspace's connected
+ * providers before its first turn — HOU-573/HOU-680), and the picker fires one
+ * status request PER provider in parallel. Without sharing, those N requests would
+ * run N syncs that each rewrite auth.json at once — a write race. A turn and a
+ * status poll can also overlap. One sync, one auth.json write, every caller gets
+ * the same result.
  */
 let serveSyncInFlight: Promise<string[]> | null = null;
 
@@ -108,38 +84,94 @@ export function syncServedCredential(): Promise<string[]> {
   return serveSyncInFlight;
 }
 
-async function runServedSync(): Promise<string[]> {
-  if (!serveModeOn()) return [];
-  const applied: string[] = [];
-  const removed: string[] = [];
-  for (const p of PROVIDERS) {
+/**
+ * Best-effort wrapper for read routes and turn start: hydration must never fail
+ * the request it precedes. A missing connection still surfaces downstream as
+ * the runtime's normal "No provider connected" when nothing was applied.
+ */
+export async function syncServedCredentialSafe(tag: string): Promise<void> {
+  try {
+    await syncServedCredential();
+  } catch (err) {
+    console.error(
+      `[${tag}] credential sync failed:`,
+      err instanceof Error ? err.message : err,
+    );
+  }
+}
+
+type ServeProbe =
+  | { id: string; state: "served"; cred: ServedCredential }
+  | { id: string; state: "not-connected" }
+  | { id: string; state: "error"; detail: string };
+
+/** One provider's central lookup. Never throws — an internal serve hiccup for
+ *  ONE provider must not strand the others. */
+async function probeProvider(id: string): Promise<ServeProbe> {
+  try {
     const res = await fetch(
-      `${config.controlPlaneUrl}/sandbox/credential?provider=${p.id}`,
+      `${config.controlPlaneUrl}/sandbox/credential?provider=${id}`,
       {
         headers: { Authorization: `Bearer ${config.sandboxToken}` },
+        signal: AbortSignal.timeout(SERVE_FETCH_TIMEOUT_MS),
       },
     );
-    if (res.status === 404) {
-      // Authoritative logout from the central store: remove only credentials this
-      // runtime learned from serve mode. A refresh-bearing OAuth entry is the
-      // device-code connect flow mid-capture, before scrub, and must survive.
-      if (removeServedCredentialAt(authPathFor(), p.id)) removed.push(p.id);
-      continue;
-    }
-    if (!res.ok) {
-      // Internal serve hiccup for ONE provider must not strand the others; the
-      // turn still surfaces "No provider connected" downstream if nothing applied.
-      console.error(
-        `[serve] credential ${p.id} (${res.status}): ${await res.text().catch(() => "")}`,
-      );
-      continue;
-    }
-    applyServedCredential(
-      authPathFor(),
-      (await res.json()) as ServedCredential,
-    );
-    applied.push(p.id);
+    if (res.status === 404 && res.headers.get(NOT_CONNECTED_HEADER) === "1")
+      return { id, state: "not-connected" };
+    if (!res.ok)
+      return {
+        id,
+        state: "error",
+        detail: `${res.status}: ${await res.text().catch(() => "")}`,
+      };
+    return {
+      id,
+      state: "served",
+      cred: (await res.json()) as ServedCredential,
+    };
+  } catch (err) {
+    return {
+      id,
+      state: "error",
+      detail: err instanceof Error ? err.message : String(err),
+    };
   }
+}
+
+async function runServedSync(): Promise<string[]> {
+  if (!serveModeOn()) return [];
+  // Probes are independent — run them in parallel so a hydrating route pays one
+  // round-trip, not eleven. The auth.json writes below stay serial.
+  const probes = await Promise.all(PROVIDERS.map((p) => probeProvider(p.id)));
+  const applied: string[] = [];
+  const removed: string[] = [];
+  // Provenance gate: an authoritative "not connected" may only remove providers
+  // this runtime learned from serve mode. A locally-connected credential the
+  // central store never held (the Anthropic setup token, an openai-compatible
+  // local model) is shaped like a served one, so shape alone cannot decide.
+  const manifest = new Set(readServedProvidersAt(servedManifestPathFor()));
+  let manifestDirty = false;
+  for (const probe of probes) {
+    if (probe.state === "served") {
+      applyServedCredential(authPathFor(), probe.cred);
+      applied.push(probe.id);
+      if (!manifest.has(probe.id)) {
+        manifest.add(probe.id);
+        manifestDirty = true;
+      }
+    } else if (probe.state === "not-connected" && manifest.has(probe.id)) {
+      // A refresh-bearing OAuth entry still survives inside
+      // removeServedCredentialAt: that's the device-code connect mid-capture.
+      if (removeServedCredentialAt(authPathFor(), probe.id))
+        removed.push(probe.id);
+      manifest.delete(probe.id);
+      manifestDirty = true;
+    } else if (probe.state === "error") {
+      console.error(`[serve] credential ${probe.id}: ${probe.detail}`);
+    }
+  }
+  if (manifestDirty)
+    writeServedProvidersAt(servedManifestPathFor(), [...manifest]);
   // pi's AuthStorage caches auth.json in memory at startup; a direct write is
   // invisible to hasAuth()/resolveModel() until we re-read it. This is the line
   // that makes a never-connected agent actually see the served credential.
@@ -151,19 +183,4 @@ async function runServedSync(): Promise<string[]> {
     `[serve] applied central credentials: ${applied.join(", ") || "(none)"}`,
   );
   return applied;
-}
-
-/**
- * Export the locally-held credential so the control plane can capture it into
- * the workspace's central store right after a device-code connect. When
- * `provider` is given, exports EXACTLY that provider — connect-once capture is
- * provider-specific, so capturing a github-copilot connect must never grab a
- * different OAuth provider that happens to come first in auth.json (which would
- * leave Copilot un-persisted centrally and 404 every per-turn serve). Without a
- * provider, falls back to the first connected OAuth provider. Returns null when
- * the (requested) provider isn't connected — also the post-scrub state, so
- * capture must run before scrub.
- */
-export function exportCredential(provider?: string): ExportedCredential | null {
-  return selectExportCredential(readAuthFile(authPathFor()), provider);
 }

--- a/packages/runtime/src/session/chat.ts
+++ b/packages/runtime/src/session/chat.ts
@@ -1,7 +1,7 @@
 import { rmSync } from "node:fs";
 import { join } from "node:path";
 import { activeProvider, resolveModel } from "../ai/providers";
-import { syncServedCredential } from "../auth/serve";
+import { syncServedCredentialSafe } from "../auth/serve";
 import { cleanupClaudeConversation } from "../backends/claude/cleanup";
 import { config } from "../config";
 import {
@@ -42,11 +42,7 @@ export async function ensureProviderForTurn(): Promise<string | null> {
   // Connect-once: pull the workspace's current central credential into auth.json
   // so pi uses the user's own token. Best-effort — a transient failure leaves the
   // existing (still-valid) credential; a forgotten connection => activeProvider null.
-  try {
-    await syncServedCredential();
-  } catch (err) {
-    console.error("[serve] credential sync failed:", errMessage(err));
-  }
+  await syncServedCredentialSafe("serve");
   const provider = activeProvider();
   // Ground-truth diagnostic: the provider + model + the model's actual API base
   // URL this turn will run against. baseUrl is unambiguous — opencode.ai/zen/go/v1

--- a/packages/runtime/src/transport/provider-routes.test.ts
+++ b/packages/runtime/src/transport/provider-routes.test.ts
@@ -1,0 +1,94 @@
+import { mkdtempSync } from "node:fs";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test, vi } from "vitest";
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function mockRes(): {
+  res: ServerResponse;
+  out: { status?: number; body?: unknown };
+} {
+  const out: { status?: number; body?: unknown } = {};
+  const res = {
+    writeHead(status: number) {
+      out.status = status;
+    },
+    end(buf: Buffer | string) {
+      out.body = JSON.parse(buf.toString());
+    },
+  } as unknown as ServerResponse;
+  return { res, out };
+}
+
+test("GET /providers hydrates served credentials before listing providers", async () => {
+  const prevDataDir = process.env.HOUSTON_DATA_DIR;
+  const prevControlPlaneUrl = process.env.HOUSTON_CONTROL_PLANE_URL;
+  const prevSandboxToken = process.env.HOUSTON_SANDBOX_TOKEN;
+  const prevFetch = globalThis.fetch;
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-provider-route-"));
+
+  process.env.HOUSTON_DATA_DIR = dataDir;
+  process.env.HOUSTON_CONTROL_PLANE_URL = "http://control-plane.test";
+  process.env.HOUSTON_SANDBOX_TOKEN = "sbx-token";
+  globalThis.fetch = (async (input: RequestInfo | URL) => {
+    const url = String(input);
+    if (url.includes("provider=openai-codex")) {
+      return new Response(
+        JSON.stringify({
+          provider: "openai-codex",
+          kind: "oauth",
+          access: "AT-served",
+          expires: 1_730_000_000_000,
+          accountId: null,
+          enterpriseUrl: null,
+        }),
+        { status: 200 },
+      );
+    }
+    return new Response(null, { status: 404 });
+  }) as typeof fetch;
+
+  try {
+    vi.resetModules();
+    const { handleProviderRoute } = await import("./provider-routes");
+    const { readAuthFile } = await import("../auth/auth-file");
+    const { res, out } = mockRes();
+
+    expect(
+      await handleProviderRoute({
+        method: "GET",
+        path: "/providers",
+        url: new URL("http://runtime.test/providers"),
+        req: { headers: {} } as IncomingMessage,
+        res,
+      }),
+    ).toBe(true);
+
+    expect(out.status).toBe(200);
+    expect(readAuthFile(join(dataDir, "auth.json"))["openai-codex"]).toEqual({
+      type: "oauth",
+      access: "AT-served",
+      refresh: "",
+      expires: 1_730_000_000_000,
+    });
+    expect(
+      (
+        out.body as {
+          id: string;
+          configured: boolean;
+        }[]
+      ).find((p) => p.id === "openai-codex")?.configured,
+    ).toBe(true);
+  } finally {
+    globalThis.fetch = prevFetch;
+    restoreEnv("HOUSTON_DATA_DIR", prevDataDir);
+    restoreEnv("HOUSTON_CONTROL_PLANE_URL", prevControlPlaneUrl);
+    restoreEnv("HOUSTON_SANDBOX_TOKEN", prevSandboxToken);
+    vi.resetModules();
+  }
+});

--- a/packages/runtime/src/transport/provider-routes.test.ts
+++ b/packages/runtime/src/transport/provider-routes.test.ts
@@ -50,7 +50,10 @@ test("GET /providers hydrates served credentials before listing providers", asyn
         { status: 200 },
       );
     }
-    return new Response(null, { status: 404 });
+    return new Response(null, {
+      status: 404,
+      headers: { "x-houston-not-connected": "1" },
+    });
   }) as typeof fetch;
 
   try {

--- a/packages/runtime/src/transport/provider-routes.ts
+++ b/packages/runtime/src/transport/provider-routes.ts
@@ -1,4 +1,5 @@
 import { listProviders, setSettings } from "../ai/providers";
+import { exportCredential } from "../auth/export";
 import {
   cancelLogin,
   completeLogin,
@@ -8,22 +9,14 @@ import {
   setCustomEndpoint,
   startLogin,
 } from "../auth/login";
-import {
-  exportCredential,
-  scrubRefreshTokens,
-  syncServedCredential,
-} from "../auth/serve";
+import { scrubRefreshTokens, syncServedCredentialSafe } from "../auth/serve";
 import { json, type RouteContext, readJson } from "./http-helpers";
 
 export async function handleProviderRoute(ctx: RouteContext): Promise<boolean> {
   const { method, path, req, res, url } = ctx;
 
   if (method === "GET" && path === "/providers") {
-    try {
-      await syncServedCredential();
-    } catch (e) {
-      console.error("[providers] list credential sync failed:", e);
-    }
+    await syncServedCredentialSafe("providers");
     json(res, 200, listProviders());
     return true;
   }
@@ -38,11 +31,7 @@ export async function handleProviderRoute(ctx: RouteContext): Promise<boolean> {
   }
 
   if (method === "GET" && path === "/auth/status") {
-    try {
-      await syncServedCredential();
-    } catch (e) {
-      console.error("[auth] status credential sync failed:", e);
-    }
+    await syncServedCredentialSafe("auth");
     json(res, 200, getAuthStatus());
     return true;
   }

--- a/packages/runtime/src/transport/provider-routes.ts
+++ b/packages/runtime/src/transport/provider-routes.ts
@@ -19,6 +19,11 @@ export async function handleProviderRoute(ctx: RouteContext): Promise<boolean> {
   const { method, path, req, res, url } = ctx;
 
   if (method === "GET" && path === "/providers") {
+    try {
+      await syncServedCredential();
+    } catch (e) {
+      console.error("[providers] list credential sync failed:", e);
+    }
     json(res, 200, listProviders());
     return true;
   }


### PR DESCRIPTION
## Summary

Engine half of HOU-680: in managed cloud, provider credentials were per-agent-pod, so every new agent booted disconnected and raised the OpenAI reconnect card despite a live connection on another agent.

Supersedes #649 — same single fix commit, re-cut onto current main. #649 was accidentally opened from a fork-drifted branch, so it displayed 341 unrelated commits (+8.7K LOC); the actual change is this: 12 files, +789/−9, ~500 of which are tests.

Pairs with gethouston/cloud#34 (gateway half).

## Changes

- **`RemoteCredentialStore`** (packages/host): when the gateway injects `HOUSTON_CREDENTIALS_URL` + `HOUSTON_ORG_SLUG` + `HOUSTON_AGENT_SLUG`, the pod host's one `CredentialStore` seam swaps from the PVC file to the gateway's org-scoped `/v1/pod/credentials` API (authenticated with the pod's own `HOUSTON_HOST_TOKEN`). That one swap covers all four credential flows — capture, per-turn serve, logout, api-key. Served credentials are **access-only**; the gateway is the single refresher (openai-codex refresh tokens rotate). 15s TTL cache absorbs the per-turn serve fan; 404 vs transport-error stay distinct so a gateway blip never reads as "logged out". The legacy local file is a one-time **adoption fallback** (if-absent PUT) so pre-central pods migrate without forcing a reconnect.
- **`routes/credential.ts`**: skip the doomed local refresh when a served credential has no refresh token.
- **runtime `GET /providers` now hydrates** served credentials first (previously only `/auth/status` did, HOU-573) — a brand-new pod's provider cards read connected before its first turn, which is what keeps the desktop's reconnect-card probe green.
- **runtime serve sync removes served-owned `auth.json` entries on an authoritative central 404** (oauth with `refresh:""` or api-key only — a refresh-bearing entry is a connect mid-capture and survives), so an org-wide sign-out reaches already-hydrated pods.

Desktop/self-host: byte-identical without the env (file store as before).

## Repro (before) / verify (after)

**Before:** desktop → cloud, OpenAI connected and chatting on agent A → create agent B (any template) → send a message immediately → B's chat shows the OpenAI reconnect card; B's pod `/data/credentials.json` is empty.

**After (both halves deployed):** connect OpenAI once on any agent → create a new agent → send a message immediately → the turn runs with no reconnect card. Sign out on any agent → every agent's next status poll reads disconnected.

## Verify

On current main (post engine-removal #619): `@houston/host` 540 passed, `@houston/runtime` 370 passed, both tsconfigs clean, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Review hardening (second commit)

A multi-agent review of the first commit confirmed six issues; all are fixed in `2544c8dd`:

- **Provenance manifest gates the 404-removal.** The runtime now records which providers the serve path itself hydrated (`served-providers.json` next to `auth.json`) and a central 404 only removes those. Without this, the sync deleted locally-connected credentials that never exist centrally — the Anthropic setup token (desktop Claude connect could never complete: the connect dialog's own status poll deleted the just-pasted token) and openai-compatible local-model keys.
- **A 404 must prove it means "not connected".** The host marks its `/sandbox/credential` 404 with `x-houston-not-connected: 1` and the runtime only treats marked 404s as an authoritative logout; the pod store likewise only accepts a gateway 404 that carries the JSON `error` body. A route-level 404 (gateway deploy skew, mistyped `HOUSTON_CREDENTIALS_URL`) is now a transport error that keeps the last hydrated token instead of wiping the org's credentials. **Gateway contract note (cloud#34): the `/v1/pod/credentials` 404 must keep its JSON `{"error": ...}` body.**
- **Sign-out is idempotent and sticks.** `RemoteCredentialStore.remove()` treats the gateway's not-connected 404 as already-signed-out (the sibling-forget loop in the client relies on the no-op) and clears the legacy fallback file, so the next `get()`'s adoption path can no longer silently resurrect the credential the user just removed.
- **Partial credential-gateway env fails the boot.** One typo'd var out of `HOUSTON_CREDENTIALS_URL`/`HOUSTON_ORG_SLUG`/`HOUSTON_AGENT_SLUG` previously warned once and degraded to an empty per-pod file store — which the 404 path would then read as an org-wide logout, and a legacy pod would even rotate refresh tokens against the gateway's rotation. The pod now exits with a clear error so the deploy gets fixed instead.
- **The serve sync is parallel and bounded.** All provider probes run concurrently with a 10s timeout, so `GET /providers` (the model picker's steady-state read, which this PR made hydrate) pays one round-trip instead of eleven serialized, unbounded ones.
- **One `syncServedCredentialSafe` helper** replaces the three copy-pasted best-effort sync blocks (`/providers`, `/auth/status`, turn start), giving the hydrate-before-read invariant a single home.

Migration note: pods hydrated before this change have no manifest yet; their entries get marked on the next successful serve, after which org sign-out propagates as designed (fail-safe in the interim: unmarked entries are kept, never deleted).

Re-verified: `@houston/host` 543 passed, `@houston/runtime` 373 passed, full workspace typecheck clean, biome clean, boundaries clean.
