### PR TITLE
fix(cloud): survive gateway restarts and expired bearers without 401 toasts (HOU-687)

### DIFF
--- a/app/src/components/shell/engine-gate.tsx
+++ b/app/src/components/shell/engine-gate.tsx
@@ -3,13 +3,14 @@ import { useSession } from "../../hooks/use-session";
 import { installDeepLinkListener } from "../../lib/auth";
 import {
   hostedOauthGateActive,
+  installHostedSessionRefresh,
   isEngineReady,
   setHostedEngineSessionToken,
   whenEngineReady,
 } from "../../lib/engine";
 import { hostedGateState } from "../../lib/engine-mode";
 import i18n from "../../lib/i18n";
-import { isAuthConfigured } from "../../lib/supabase";
+import { isAuthConfigured, supabase } from "../../lib/supabase";
 import { SignInScreen } from "../auth/sign-in-screen";
 
 /**
@@ -32,6 +33,20 @@ function HostedEngineGate({ children }: { children: ReactNode }) {
   useEffect(() => {
     if (!isAuthConfigured()) return;
     return installDeepLinkListener();
+  }, []);
+
+  useEffect(() => {
+    if (!isAuthConfigured()) return;
+    // The 401 → refresh → replay seam (HOU-687): when the gateway rejects a
+    // bearer (token expired while the app idled, connections severed by a
+    // gateway roll), the adapter force-mints a fresh access token and retries
+    // instead of toasting. refreshSession failing (revoked/absent refresh
+    // token) resolves null — a real sign-out, surfaced by the auth gate.
+    return installHostedSessionRefresh(async () => {
+      const { data, error } = await supabase.auth.refreshSession();
+      if (error) return null;
+      return data.session?.access_token ?? null;
+    });
   }, []);
 
   useEffect(() => {

--- a/app/src/lib/engine.ts
+++ b/app/src/lib/engine.ts
@@ -11,6 +11,10 @@ declare global {
       baseUrl: string;
       token: string;
     };
+    /** Hosted-session refresher the engine adapter calls on a gateway 401 —
+     *  mints a fresh Supabase access token so the request can be replayed
+     *  invisibly (HOU-687). Installed by installHostedSessionRefresh below. */
+    __HOUSTON_SESSION_REFRESH__?: () => Promise<string | null>;
   }
 }
 
@@ -169,6 +173,33 @@ export function setHostedEngineSessionToken(token: string | null): void {
     _ws.disconnect();
     _ws.connect();
   }
+}
+
+/**
+ * Installs the hosted-session refresher the engine adapter's gatewayAuthFetch
+ * calls when the gateway answers 401: `refresh` force-mints a fresh Supabase
+ * access token (or resolves null when the session is truly gone), the new
+ * token is pushed onto the engine global, and the adapter replays the failed
+ * request — so an expired bearer never reaches the user as an error toast
+ * (HOU-687). Hosted mode only; returns an uninstaller.
+ */
+export function installHostedSessionRefresh(
+  refresh: () => Promise<string | null>,
+): () => void {
+  if (!HOSTED_ENGINE_URL || typeof window === "undefined") return () => {};
+  const handler = async () => {
+    const token = await refresh();
+    // Push synchronously so every liveToken() read after this refresh sees the
+    // new bearer — the React session state catches up on its own schedule.
+    if (token) setHostedEngineSessionToken(token);
+    return token;
+  };
+  window.__HOUSTON_SESSION_REFRESH__ = handler;
+  return () => {
+    if (window.__HOUSTON_SESSION_REFRESH__ === handler) {
+      delete window.__HOUSTON_SESSION_REFRESH__;
+    }
+  };
 }
 
 // Initial attempt — config may already be injected via window.eval before

--- a/app/src/lib/error-toast.ts
+++ b/app/src/lib/error-toast.ts
@@ -52,7 +52,25 @@ export function reportError(
  * Sentry not configured or not flushed → no green toast. Red toast still
  * shown. This is the right behavior for forks / personal builds and for
  * network failures where we cannot honestly say the report was sent.
+ *
+ * A message identical to one toasted moments ago is deduped (toast pair
+ * skipped, Sentry capture kept): one root cause failing N concurrent calls —
+ * a dozen queries all hitting the same rejected bearer during a cloud deploy
+ * (HOU-687) — must read as ONE problem, not a toast storm.
  */
+const TOAST_DEDUPE_WINDOW_MS = 5_000;
+const recentToasts = new Map<string, number>();
+
+function isDuplicateToast(message: string, now: number): boolean {
+  const last = recentToasts.get(message);
+  recentToasts.set(message, now);
+  // The map only ever holds messages from the current burst — evict as we go.
+  for (const [msg, at] of recentToasts) {
+    if (now - at > TOAST_DEDUPE_WINDOW_MS) recentToasts.delete(msg);
+  }
+  return last !== undefined && now - last <= TOAST_DEDUPE_WINDOW_MS;
+}
+
 export function showErrorToast(
   command: string,
   message: string,
@@ -63,6 +81,21 @@ export function showErrorToast(
     source: command,
     error_kind: classifyAnalyticsError(message),
   });
+
+  if (isDuplicateToast(message, Date.now())) {
+    // Still worth the report (Sentry dedupes server-side); just not a second
+    // identical red toast within the window.
+    const error = createSentryReportError(command, message, originalError);
+    if (!sentrySuppressedInDev) {
+      void sentryCapture(error, {
+        source: command,
+        error_kind: classifyAnalyticsError(message),
+      }).catch((flushErr: unknown) => {
+        console.error("[sentry] failed to flush captured error", flushErr);
+      });
+    }
+    return;
+  }
 
   addToast({
     title: i18n.t("shell:errorToast.problemTitle"),

--- a/packages/web/src/cloud-login.tsx
+++ b/packages/web/src/cloud-login.tsx
@@ -49,7 +49,23 @@ export function CloudApp({ controlPlaneUrl }: { controlPlaneUrl: string }) {
     const { data: sub } = supabase.auth.onAuthStateChange((_event, session) =>
       apply(session?.access_token ?? ""),
     );
-    return () => sub.subscription.unsubscribe();
+    // The 401 → refresh → replay seam (HOU-687): the adapter's gatewayAuthFetch
+    // calls this to force-mint a fresh access token when the gateway rejects
+    // the current one (expired while the tab idled, gateway roll severed the
+    // streams). Null = the session is really gone; the 401 surfaces.
+    const refresher = async () => {
+      const { data, error } = await supabase.auth.refreshSession();
+      const token = error ? null : (data.session?.access_token ?? null);
+      if (token) apply(token);
+      return token;
+    };
+    window.__HOUSTON_SESSION_REFRESH__ = refresher;
+    return () => {
+      sub.subscription.unsubscribe();
+      if (window.__HOUSTON_SESSION_REFRESH__ === refresher) {
+        delete window.__HOUSTON_SESSION_REFRESH__;
+      }
+    };
   }, [controlPlaneUrl]);
 
   return <AppTree />;

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -153,9 +153,13 @@ export class HoustonClient {
     this.cp = useCp
       ? { baseUrl: opts.baseUrl.replace(/\/+$/, ""), token: opts.token }
       : null;
+    // Live-token auth fetch (not a pinned `token`): hosted mode rotates the
+    // Supabase bearer mid-session, and a 401 must refresh + replay instead of
+    // surfacing (HOU-687). Outside hosted mode liveToken falls back to the
+    // captured static token, so local/static hosts are unchanged.
     this.engine = new HoustonEngineClient({
       baseUrl: opts.baseUrl,
-      token: opts.token || undefined,
+      fetch: controlPlane.gatewayAuthFetch(opts.token),
     });
     // Mark the new TS engine as the active backend so the frontend can surface
     // new-engine-only capabilities (e.g. API-key providers like OpenCode). The
@@ -253,14 +257,12 @@ export class HoustonClient {
     return (await this.engine.version()) as never;
   }
   async capabilities(): Promise<Capabilities> {
-    // Raw fetch (not `this.engine.capabilities()`) on purpose: the inner engine
-    // client captured its token at construction, but hosted mode rotates the
-    // Supabase bearer mid-session, so we MUST read the live token here.
-    const res = await fetch(`${this.baseUrl}/v1/capabilities`, {
-      headers: {
-        Authorization: `Bearer ${controlPlane.liveToken(this.token)}`,
-      },
-    });
+    // gatewayAuthFetch (not `this.engine.capabilities()`) on purpose: hosted
+    // mode rotates the Supabase bearer mid-session, so the live token is read
+    // per attempt and a 401 refreshes + replays (HOU-687).
+    const res = await controlPlane.gatewayAuthFetch(this.token)(
+      `${this.baseUrl}/v1/capabilities`,
+    );
     if (!res.ok) {
       const body = await res.json().catch(() => ({}));
       throw new HoustonEngineError(res.status, body);
@@ -610,12 +612,11 @@ export class HoustonClient {
     if (!this.cp)
       throw new Error("cpFilesFetch called without a control-plane config");
     const cp = this.cp;
-    const res = await fetch(
+    const res = await controlPlane.gatewayAuthFetch(cp.token)(
       `${cp.baseUrl}/agents/${encodeURIComponent(agentId)}/${path}`,
       {
         ...init,
         headers: {
-          Authorization: `Bearer ${controlPlane.liveToken(cp.token)}`,
           "Content-Type": "application/json",
           ...init?.headers,
         },

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -18,6 +18,7 @@ import type {
   Workspace,
 } from "../../../../ui/engine-client/src/types";
 import { HoustonEngineError } from "./client";
+import { refreshLiveToken } from "./session-refresh";
 import { DEFAULT_AGENT_COLOR, DEFAULT_AGENT_CONFIG_ID } from "./synthetic";
 
 /**
@@ -156,19 +157,74 @@ export function liveToken(fallback: string): string {
   return fallback;
 }
 
+/**
+ * A `fetch` for gateway calls that keeps auth invisible across cloud restarts
+ * (HOU-687): the bearer is read LIVE per attempt (never a pinned copy), and a
+ * 401 triggers one single-flight session refresh and one replay with the fresh
+ * token. A 401 that survives the refresh is returned as-is — a real sign-out
+ * must surface, not spin. With no refresher installed (static tokens, tests)
+ * the refresh resolves null and this degrades to a plain live-token fetch.
+ */
+export function gatewayAuthFetch(fallbackToken: string): typeof fetch {
+  return async (input, init) => {
+    const send = (bearer: string) => {
+      const headers = new Headers(init?.headers);
+      if (bearer) headers.set("Authorization", `Bearer ${bearer}`);
+      return fetch(input, { ...init, headers });
+    };
+    const res = await send(liveToken(fallbackToken));
+    if (res.status !== 401) return res;
+    const fresh = await refreshLiveToken();
+    if (!fresh) return res;
+    return send(fresh);
+  };
+}
+
+/** Gateway statuses that mean "rolling deploy / pod handoff in progress", not a
+ *  real answer: worth a brief blind retry for reads. */
+const TRANSIENT_STATUSES = new Set([502, 503, 504]);
+/** Two retries, ~2s total — bridges a gateway roll's LB handoff, without
+ *  masking a real outage for long. */
+const TRANSIENT_RETRY_DELAYS_MS = [500, 1500];
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
 async function cpFetch(
   cfg: ControlPlaneConfig,
   path: string,
   init?: RequestInit,
 ): Promise<Response> {
-  const res = await fetch(`${cfg.baseUrl}${path}`, {
-    ...init,
-    headers: {
-      Authorization: `Bearer ${liveToken(cfg.token)}`,
-      "Content-Type": "application/json",
-      ...init?.headers,
-    },
-  });
+  const doFetch = gatewayAuthFetch(cfg.token);
+  const attempt = () =>
+    doFetch(`${cfg.baseUrl}${path}`, {
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...init?.headers,
+      },
+    });
+
+  // Reads retry through the deploy window; writes never blind-retry (a thrown
+  // network error on a POST may have reached the gateway — the caller decides).
+  const method = (init?.method ?? "GET").toUpperCase();
+  const retriable = method === "GET" || method === "HEAD";
+  let res: Response | undefined;
+  let failure: unknown;
+  for (let i = 0; ; i++) {
+    failure = undefined;
+    try {
+      res = await attempt();
+    } catch (err) {
+      failure = err; // network-level: connection refused/reset mid-roll
+    }
+    const transient = res === undefined || TRANSIENT_STATUSES.has(res.status);
+    if (!transient || !retriable || i >= TRANSIENT_RETRY_DELAYS_MS.length) {
+      break;
+    }
+    await sleep(TRANSIENT_RETRY_DELAYS_MS[i]);
+    res = undefined;
+  }
+  if (failure !== undefined || res === undefined) throw failure;
   if (!res.ok) {
     // Surface the real failure (auth, not-found, server) — never swallow.
     const body = await res.json().catch(() => ({}));
@@ -339,9 +395,12 @@ export function runtimeClientFor(
   cfg: ControlPlaneConfig,
   agentId: string,
 ): HoustonEngineClient {
+  // Auth rides gatewayAuthFetch, never a pinned token: these clients back
+  // long-lived turn streams, whose reconnects must present the CURRENT bearer
+  // (and refresh it on 401) or a gateway roll kills the turn (HOU-687).
   return new HoustonEngineClient({
     baseUrl: `${cfg.baseUrl}/agents/${encodeURIComponent(agentId)}`,
-    token: liveToken(cfg.token) || undefined,
+    fetch: gatewayAuthFetch(cfg.token),
   });
 }
 
@@ -358,7 +417,7 @@ export function setupRuntimeClientFor(
 ): HoustonEngineClient {
   return new HoustonEngineClient({
     baseUrl: `${cfg.baseUrl}/setup-runtime`,
-    token: liveToken(cfg.token) || undefined,
+    fetch: gatewayAuthFetch(cfg.token),
   });
 }
 
@@ -801,8 +860,10 @@ export async function setPreference(
  * token is always current), and host events `{ type, agentPath, workspaceId }`
  * are translated to the shape the UI's invalidation map reads
  * (`{ type, data: { agent_path, workspace_id } }`). Malformed frames are
- * dropped and the loop reconnects with a short backoff on any drop — including
- * a `401`, which (with no `onUnauthorized` seam) simply reconnects.
+ * dropped and the loop reconnects with a short backoff on any drop. A `401`
+ * forces a session refresh (single-flight, HOU-687) so the next attempt's
+ * re-read of `liveToken` carries a valid bearer — without it, an expired token
+ * would 401-loop forever because nothing else re-mints while the app idles.
  */
 export function subscribeEvents(
   cfg: ControlPlaneConfig,
@@ -814,6 +875,9 @@ export function subscribeEvents(
       `${cfg.baseUrl}/v1/events?token=${encodeURIComponent(liveToken(cfg.token))}`,
     fetch,
     signal: ac.signal,
+    onUnauthorized: () => {
+      void refreshLiveToken();
+    },
     onEvent: (data) =>
       onEvent(
         toInvalidationEvent(

--- a/packages/web/src/engine-adapter/portable.ts
+++ b/packages/web/src/engine-adapter/portable.ts
@@ -29,7 +29,7 @@ import type {
 import { HoustonEngineError } from "./client";
 import {
   type ControlPlaneConfig,
-  liveToken,
+  gatewayAuthFetch,
   rememberAgentColor,
 } from "./control-plane";
 import { packagePreview, toBase64, toWireSelection } from "./portable-map";
@@ -42,10 +42,10 @@ async function hostFetch(
   path: string,
   init?: RequestInit,
 ): Promise<Response> {
-  const res = await fetch(`${cfg.baseUrl}${path}`, {
+  // gatewayAuthFetch: live bearer per attempt + 401 refresh/replay (HOU-687).
+  const res = await gatewayAuthFetch(cfg.token)(`${cfg.baseUrl}${path}`, {
     ...init,
     headers: {
-      Authorization: `Bearer ${liveToken(cfg.token)}`,
       "Content-Type": "application/json",
       ...init?.headers,
     },

--- a/packages/web/src/engine-adapter/session-refresh.ts
+++ b/packages/web/src/engine-adapter/session-refresh.ts
@@ -1,0 +1,46 @@
+/**
+ * The hosted-session refresh seam: when the gateway answers 401, the transport
+ * asks the app layer for a freshly-minted Supabase access token and replays the
+ * request, so an expired bearer never surfaces to the user (HOU-687).
+ *
+ * The app layer (desktop `EngineGate`, web `CloudApp`) installs the refresher on
+ * `window.__HOUSTON_SESSION_REFRESH__` — the same global-injection idiom as
+ * `__HOUSTON_ENGINE__` — because this adapter must not import the Supabase
+ * client: auth ownership stays with the shell that configured it. No refresher
+ * installed (static-token hosts, dev bearers, tests) → refresh resolves null
+ * and the original 401 stands.
+ */
+
+declare global {
+  interface Window {
+    __HOUSTON_SESSION_REFRESH__?: () => Promise<string | null>;
+  }
+}
+
+/** The one in-flight refresh — a 401 storm across N concurrent requests must
+ *  collapse to a single token mint, not N racing refresh calls (Supabase
+ *  rotates the refresh token on use, so racing refreshes can invalidate each
+ *  other and sign the user out). */
+let inflight: Promise<string | null> | null = null;
+
+/**
+ * Force-refresh the hosted session and resolve the new access token, or null
+ * when there is no refresher or the refresh failed (a real sign-out — the
+ * caller lets its 401 surface). Concurrent callers share one refresh; a caller
+ * arriving after it settles starts a new one.
+ */
+export function refreshLiveToken(): Promise<string | null> {
+  const refresh =
+    typeof window !== "undefined"
+      ? window.__HOUSTON_SESSION_REFRESH__
+      : undefined;
+  if (!refresh) return Promise.resolve(null);
+  if (!inflight) {
+    inflight = refresh()
+      .catch(() => null)
+      .finally(() => {
+        inflight = null;
+      });
+  }
+  return inflight;
+}

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -26,4 +26,7 @@ interface Window {
   __HOUSTON_ENGINE__?: { baseUrl: string; token: string };
   /** When true, the engine-adapter routes agents + chat through the control plane (cloud). */
   __HOUSTON_CP__?: boolean;
+  /** Hosted-session refresher: mints a fresh Supabase access token on a
+   *  gateway 401 so the adapter can replay the request (HOU-687). */
+  __HOUSTON_SESSION_REFRESH__?: () => Promise<string | null>;
 }

--- a/packages/web/tests/gateway-reauth.test.ts
+++ b/packages/web/tests/gateway-reauth.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  gatewayAuthFetch,
+  listAgents,
+  renameAgent,
+} from "../src/engine-adapter/control-plane";
+import { refreshLiveToken } from "../src/engine-adapter/session-refresh";
+
+/**
+ * The 401 → refresh → replay seam (HOU-687): a gateway roll (or an access
+ * token that expired while the app idled) must be invisible — the transport
+ * re-mints the bearer and replays instead of surfacing a toast storm.
+ */
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  if (originalWindow) {
+    Object.defineProperty(globalThis, "window", originalWindow);
+  } else {
+    Reflect.deleteProperty(globalThis, "window");
+  }
+  globalThis.fetch = originalFetch;
+  vi.useRealTimers();
+});
+
+function setEngineWindow(opts: {
+  token: string;
+  refresh?: () => Promise<string | null>;
+}): void {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      __HOUSTON_ENGINE__: {
+        baseUrl: "https://gateway.example",
+        token: opts.token,
+      },
+      __HOUSTON_SESSION_REFRESH__: opts.refresh,
+    },
+  });
+}
+
+function json(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Stub fetch with a queue of responses; records every (url, init) call. */
+function stubFetch(...responses: Response[]) {
+  const calls: { url: string; init: RequestInit | undefined }[] = [];
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    const next = responses.shift();
+    if (!next) throw new Error("stubFetch: no responses left");
+    return next;
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+function bearerOf(call: { init: RequestInit | undefined }): string | null {
+  return new Headers(call.init?.headers).get("Authorization");
+}
+
+const CFG = { baseUrl: "https://gateway.example", token: "captured" };
+
+test("a 401 refreshes the session once and replays with the fresh bearer", async () => {
+  const refresh = vi.fn(async () => "fresh");
+  setEngineWindow({ token: "stale", refresh });
+  const calls = stubFetch(json(401), json(200, { ok: true }));
+
+  const res = await gatewayAuthFetch(CFG.token)("https://gateway.example/x");
+
+  expect(res.status).toBe(200);
+  expect(refresh).toHaveBeenCalledTimes(1);
+  expect(calls.map(bearerOf)).toEqual(["Bearer stale", "Bearer fresh"]);
+});
+
+test("a 401 with no refresher installed surfaces as-is", async () => {
+  setEngineWindow({ token: "stale" });
+  const calls = stubFetch(json(401));
+
+  const res = await gatewayAuthFetch(CFG.token)("https://gateway.example/x");
+
+  expect(res.status).toBe(401);
+  expect(calls).toHaveLength(1);
+});
+
+test("a 401 whose refresh fails (real sign-out) surfaces as-is", async () => {
+  setEngineWindow({ token: "stale", refresh: async () => null });
+  const calls = stubFetch(json(401));
+
+  const res = await gatewayAuthFetch(CFG.token)("https://gateway.example/x");
+
+  expect(res.status).toBe(401);
+  expect(calls).toHaveLength(1);
+});
+
+test("concurrent 401s share one refresh (single-flight)", async () => {
+  let resolveRefresh: (token: string) => void = () => {};
+  const refresh = vi.fn(
+    () => new Promise<string | null>((r) => (resolveRefresh = r)),
+  );
+  setEngineWindow({ token: "stale", refresh });
+
+  const first = refreshLiveToken();
+  const second = refreshLiveToken();
+  resolveRefresh("fresh");
+  expect(await first).toBe("fresh");
+  expect(await second).toBe("fresh");
+  expect(refresh).toHaveBeenCalledTimes(1);
+
+  // After settling, a later 401 starts a NEW refresh (not the stale result).
+  const again = vi.fn(async () => "fresher");
+  setEngineWindow({ token: "fresh", refresh: again });
+  expect(await refreshLiveToken()).toBe("fresher");
+});
+
+test("reads retry through a transient gateway-roll status", async () => {
+  vi.useFakeTimers();
+  setEngineWindow({ token: "tok" });
+  const calls = stubFetch(json(503), json(200, []));
+
+  const pending = listAgents(CFG);
+  await vi.advanceTimersByTimeAsync(600);
+
+  expect(await pending).toEqual([]);
+  expect(calls).toHaveLength(2);
+});
+
+test("writes never blind-retry a transient status", async () => {
+  setEngineWindow({ token: "tok" });
+  const calls = stubFetch(json(503));
+
+  await expect(renameAgent(CFG, "a1", "new name")).rejects.toMatchObject({
+    status: 503,
+  });
+  expect(calls).toHaveLength(1);
+});


### PR DESCRIPTION
## Summary

Fixes HOU-687: after a gateway redeploy, the desktop app threw a storm of red 401 toasts.

**Root cause.** The gateway's auth is stateless (Supabase JWT verified per request against env-configured JWKS) — a deploy invalidates nothing server-side. But it authenticates only at connect/request time, and the hosted client transport had **no 401 handling at all**: when the rolling deploy severed every open SSE stream and the app replayed ~a dozen concurrent REST calls plus reconnects, each one re-presented the cached Supabase access token. If that token had expired while the app idled (webview background throttling starves supabase-js's timer-based auto-refresh — matching "when I went back to the desktop app"), every call got `401 invalid or expired token`; with `retry: false` in React Query and no 401 special-casing, each raised its own toast.

## Fix (client transport seam)

- **`gatewayAuthFetch`** (new, `packages/web/src/engine-adapter/control-plane.ts`): every gateway request reads the **live** bearer per attempt and, on 401, forces one **single-flight** session refresh (`window.__HOUSTON_SESSION_REFRESH__`) and replays once with the fresh token. A 401 that survives the refresh (real sign-out) still surfaces. All hosted REST paths now ride it: `cpFetch`, `capabilities`, `cpFilesFetch`, portable's `hostFetch`.
- **Turn streams survive rolls**: `runtimeClientFor`/`setupRuntimeClientFor` and the adapter's inner engine client no longer pin the token at construction — resumable conversation streams reconnect (with their `?after=` cursor) presenting the current bearer instead of dying with `FatalResumeError(401)`.
- **`/v1/events`**: a 401 now triggers the refresh seam, so the reconnect loop converges instead of silently 401-looping with a stale `?token=`.
- **Deploy-window bridging**: `cpFetch` GET/HEAD retry briefly (2 tries, ~2s) through 502/503/504 and connection drops. Writes never blind-retry.
- **Refresher installation**: desktop `EngineGate` and web `CloudApp` install `supabase.auth.refreshSession()` as the refresher; the adapter never imports Supabase. Concurrent 401s collapse to one refresh (Supabase rotates refresh tokens on use — racing refreshes can sign the user out).
- **Toast dedupe**: identical error messages within 5s collapse to one toast (Sentry capture kept), so one root cause reads as one problem.

Non-hosted modes (local sidecar, static-token hosts) are unchanged: with no refresher installed the wrapper degrades to a plain live-token fetch, and `liveToken` falls back to the captured static token.

## Reproduction (before the fix)

1. Open the desktop app connected to the cloud gateway; sign in and leave it open (ideally idle/backgrounded >1h so the access token expires).
2. Roll the gateway: push any commit to `gethouston/cloud` main (the deploy workflow runs `kubectl rollout restart deployment/gateway`), or `kubectl rollout restart deployment/gateway -n <gateway ns>` directly.
3. Return to the app and interact: multiple red "we have a problem" toasts with 401 appear at once; open conversations' streams die.

## Verification (after the fix)

1. Same setup: app open + signed in, token allowed to go stale (or force it: `kubectl rollout restart deployment/gateway` while the app idles in background for >1h; for a faster check, temporarily lower the Supabase project's JWT expiry).
2. Roll the gateway mid-session, including while a turn is streaming.
3. Expected: no 401 toasts; the events feed and the in-flight turn stream reconnect and resume (turn replays from its `?after=` cursor); REST queries succeed after one silent refresh+replay. Only a genuinely dead session (revoked refresh token) drops you to the sign-in screen.
4. Unit coverage: `pnpm --filter houston-web test` → `tests/gateway-reauth.test.ts` (401 refresh+replay, single-flight, no-refresher passthrough, GET-only transient retry).

Tests: 53 passing in `packages/web`, 576 in `app`; full workspace typecheck + biome clean. Reviewed by Codex (`codex review --base houston/main`): no actionable findings; its sweep surfaced the `portable.ts` call site covered in the follow-up commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)