### PR TITLE
fix(cloud): stop "not found (engine error 404)" toasts against the hosted gateway (HOU-688)

### DIFF
--- a/app/src/hooks/migration-reconnect-trigger.ts
+++ b/app/src/hooks/migration-reconnect-trigger.ts
@@ -10,6 +10,14 @@
 export interface MigrationReconnectInputs {
   /** Active backend is the new TS host (the only build that migrates). */
   newEngine: boolean;
+  /**
+   * The engine runs on THIS machine (Tauri sidecar / loopback dev host). The
+   * migration is a local-install moment — a legacy Rust-desktop db carried
+   * over on disk — so a remote engine (hosted gateway, self-host VPS) can
+   * never be "this install migrated": whatever its `/v1/version` reports, the
+   * gate must stay closed (HOU-688).
+   */
+  coLocated: boolean;
   /** Host reports this install carried over a legacy Rust-desktop history db. */
   migrated: boolean;
   /** A provider is currently connected (auth complete). */
@@ -37,6 +45,7 @@ export function shouldShowMigrationReconnect(
 ): boolean {
   if (i.loading) return false;
   if (!i.newEngine) return false;
+  if (!i.coLocated) return false;
   if (!i.migrated) return false;
   if (i.hasProvider) return false;
   if (i.dismissed) return false;

--- a/app/src/hooks/use-migration-reconnect.ts
+++ b/app/src/hooks/use-migration-reconnect.ts
@@ -1,7 +1,7 @@
 import { MIGRATION_RECONNECT_DISMISSED_KEY } from "@houston-ai/engine-client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { newEngineActive } from "../lib/engine";
+import { isCoLocatedEngine, newEngineActive } from "../lib/engine";
 import { queryKeys } from "../lib/query-keys";
 import { tauriPreferences, tauriSystem } from "../lib/tauri";
 import { shouldShowMigrationReconnect } from "./migration-reconnect-trigger";
@@ -33,11 +33,17 @@ export interface MigrationReconnectState {
 export function useMigrationReconnect(): MigrationReconnectState {
   const qc = useQueryClient();
 
+  // Remote engines (hosted gateway, self-host VPS) can never be "this install
+  // migrated" — don't even probe them; the trigger holds the gate closed on
+  // `coLocated` regardless of what their `/v1/version` reports (HOU-688).
+  const coLocated = isCoLocatedEngine();
+
   const migratedQuery = useQuery({
     queryKey: queryKeys.migrationReconnect(),
     // The host's answer is stable for the life of the install; fetch once.
     queryFn: () => tauriSystem.chatHistoryMigrated(),
     staleTime: Number.POSITIVE_INFINITY,
+    enabled: coLocated,
   });
 
   const dismissedQuery = useQuery({
@@ -67,11 +73,14 @@ export function useMigrationReconnect(): MigrationReconnectState {
 
   const show = shouldShowMigrationReconnect({
     newEngine: newEngineActive(),
+    coLocated,
     migrated: migratedQuery.data ?? false,
     hasProvider,
     dismissed: dismissedQuery.data ?? false,
     loading:
-      migratedQuery.isLoading || dismissedQuery.isLoading || statusesLoading,
+      (coLocated && migratedQuery.isLoading) ||
+      dismissedQuery.isLoading ||
+      statusesLoading,
   });
 
   return { show, dismiss };

--- a/app/tests/migration-reconnect-trigger.test.ts
+++ b/app/tests/migration-reconnect-trigger.test.ts
@@ -6,6 +6,7 @@ import { shouldShowMigrationReconnect } from "../src/hooks/migration-reconnect-t
 // prior dismissal, once every signal has resolved.
 const SHOW = {
   newEngine: true,
+  coLocated: true,
   migrated: true,
   hasProvider: false,
   dismissed: false,
@@ -44,6 +45,15 @@ test("hidden once the user has dismissed it — never shows twice", () => {
 test("hidden on the legacy Rust engine even if it looks migrated", () => {
   assert.equal(
     shouldShowMigrationReconnect({ ...SHOW, newEngine: false }),
+    false,
+  );
+});
+
+test("hidden on a remote engine even if its /v1/version claims migrated (HOU-688)", () => {
+  // The hosted gateway synthesizes `chatHistoryMigrated: true`; a remote
+  // engine can never be "this install migrated", so the gate stays closed.
+  assert.equal(
+    shouldShowMigrationReconnect({ ...SHOW, coLocated: false }),
     false,
   );
 });

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -259,7 +259,20 @@ export class HoustonClient {
     return { status: h.status, version: h.version, protocol: 1 } as never;
   }
   async version() {
-    return (await this.engine.version()) as never;
+    // gatewayAuthFetch on `/v1/version` (not `this.engine.version()`): the
+    // runtime-protocol client asks `/version`, a path only the pi runtime
+    // serves — the host's and the gateway's meta surface is `/v1/version`, so
+    // the old call 404'd against every host, silently breaking the
+    // migration-reconnect probe (HOU-688). Live-bearer fetch for the same
+    // reason as capabilities() (HOU-687).
+    const res = await controlPlane.gatewayAuthFetch(this.token)(
+      `${this.baseUrl}/v1/version`,
+    );
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({}));
+      throw new HoustonEngineError(res.status, body);
+    }
+    return (await res.json()) as never;
   }
   async capabilities(): Promise<Capabilities> {
     // gatewayAuthFetch (not `this.engine.capabilities()`) on purpose: hosted

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -614,8 +614,17 @@ export async function cancelRoutineRun(
 export async function listInstalledConfigs(
   cfg: ControlPlaneConfig,
 ): Promise<InstalledConfig[]> {
-  const res = await cpFetch(cfg, "/v1/agent-configs");
-  return (await res.json()) as InstalledConfig[];
+  try {
+    const res = await cpFetch(cfg, "/v1/agent-configs");
+    return (await res.json()) as InstalledConfig[];
+  } catch (err) {
+    // The hosted gateway keeps no account-level config library (one pod per
+    // agent, no shared disk) and answers 404 for the route — the same honest
+    // answer as standalone web: nothing installed, the picker shows the
+    // bundled templates (HOU-688). Every other failure still propagates.
+    if (err instanceof HoustonEngineError && err.status === 404) return [];
+    throw err;
+  }
 }
 export async function installAgentFromGithub(
   cfg: ControlPlaneConfig,

--- a/packages/web/tests/gateway-404-fallbacks.test.ts
+++ b/packages/web/tests/gateway-404-fallbacks.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  HoustonClient,
+  HoustonEngineError,
+} from "../src/engine-adapter/client";
+import { listInstalledConfigs } from "../src/engine-adapter/control-plane";
+
+/**
+ * HOU-688: two desktop calls 404'd against the hosted gateway and red-toasted
+ * "not found (engine error 404)".
+ *
+ * - `version()` rode the runtime-protocol client, whose path is `/version` —
+ *   a route only the pi runtime serves. The host's and the gateway's meta
+ *   surface is `/v1/version`, so the probe 404'd against EVERY host and the
+ *   migration-reconnect signal was permanently "unknown".
+ * - `/v1/agent-configs` has no gateway disposition (one pod per agent — no
+ *   account-level config library), so the create-agent picker's library read
+ *   404'd and toasted. Nothing installed is the honest answer there, exactly
+ *   like standalone web.
+ */
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+function json(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Stub fetch with a queue of responses; records every requested url. */
+function stubFetch(...responses: Response[]) {
+  const calls: string[] = [];
+  globalThis.fetch = vi.fn(async (input: unknown) => {
+    calls.push(String(input));
+    const next = responses.shift();
+    if (!next) throw new Error("stubFetch: no responses left");
+    return next;
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+const CFG = { baseUrl: "https://gateway.example", token: "t" };
+
+test("version() asks the host meta surface /v1/version, not the runtime's /version", async () => {
+  const calls = stubFetch(
+    json(200, { engine: "houston-gateway", protocol: 3, build: null }),
+  );
+  const client = new HoustonClient({ ...CFG, controlPlane: true });
+
+  const version = (await client.version()) as { engine: string };
+
+  expect(calls).toEqual(["https://gateway.example/v1/version"]);
+  expect(version.engine).toBe("houston-gateway");
+});
+
+test("version() surfaces a real failure with the host's reason", async () => {
+  stubFetch(json(500, { error: "boom" }));
+  const client = new HoustonClient({ ...CFG, controlPlane: true });
+
+  await expect(client.version()).rejects.toThrow("boom (engine error 500)");
+});
+
+test("a 404 on /v1/agent-configs reads as an empty library — no toast (HOU-688)", async () => {
+  stubFetch(json(404, { error: "not found" }));
+
+  await expect(listInstalledConfigs(CFG)).resolves.toEqual([]);
+});
+
+test("every other agent-configs failure still propagates — never swallowed", async () => {
+  stubFetch(json(500, { error: "library exploded" }));
+
+  await expect(listInstalledConfigs(CFG)).rejects.toThrow(HoustonEngineError);
+  stubFetch(json(500, { error: "library exploded" }));
+  await expect(listInstalledConfigs(CFG)).rejects.toThrow(
+    "library exploded (engine error 500)",
+  );
+});


### PR DESCRIPTION
## Summary

Running the desktop app against the hosted gateway red-toasts **"Houston, we have a problem! not found (engine error 404)"** on boot. Two desktop calls were hitting routes the gateway (and in one case, every host) does not serve:

- **`version()` asked `/version` instead of `/v1/version`.** The engine adapter rode the runtime-protocol client for its meta probe, but `/version` is a pi-runtime route — the host's and the gateway's meta surface is `/v1/version`. The probe 404'd against every host (`engine request failed (404): {"error":"not found"}` in the frontend log), permanently breaking the migration-reconnect signal. It now fetches `/v1/version` directly with the live-bearer fetch, mirroring `capabilities()` (HOU-687 pattern).
- **`/v1/agent-configs` has no gateway disposition.** One pod per agent means no account-level config library, so the gateway 404s the route and the create-agent picker's library read toasted on every boot. A 404 now reads as an empty library — the same honest answer standalone web already gives — and the picker falls back to the bundled templates. Every other failure still propagates.

Fixing the version probe would have unmasked the gateway's synthesized `chatHistoryMigrated: true` as a bogus "reconnect your AI" gate for hosted users with no provider connected yet. The migration-reconnect trigger therefore now also requires a **co-located engine**: the migration is a local-install moment (a legacy desktop db carried over on disk) and can never apply to a remote host.

## Reproduction (before)

1. In the repo root, set `.env.local` with `VITE_HOSTED_ENGINE_URL=<gateway url>` (OAuth default) and run the dev app from `main`.
2. Sign in and open any agent.
3. A red toast appears: "Houston, we have a problem! not found (engine error 404)" (from the agent-config library read), and `~/.dev-houston/logs/frontend.log` fills with `[engine:chat_history_migrated] engine request failed (404)` + `[engine:list_installed_configs] not found (engine error 404)`.

Also reproducible against a plain local host: `curl -H "Authorization: Bearer devtoken" http://127.0.0.1:4318/version` → `404 {"error":"not found"}`, while `/v1/version` answers 200.

## Verification (after)

1. Same hosted-gateway dev setup: boot the app, sign in, open an agent — no 404 toast; the create-agent gallery shows the bundled templates.
2. `frontend.log` no longer accumulates the two 404 lines; `chat_history_migrated` resolves from `/v1/version`.
3. Local sidecar/dev host: the installed-config library and the migration-reconnect gate behave exactly as before (`/v1/agent-configs` still 200s; a genuinely migrated local install still gets the reconnect moment).
4. `pnpm --filter houston-web test` (57 passing, incl. 4 new in `gateway-404-fallbacks.test.ts`), `cd app && pnpm test` (575 passing, incl. new trigger case), `pnpm -r typecheck`, `pnpm check` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)