### PR TITLE
fix(host): record the gateway acting identity as a routine's created_by (HOU-689)

### DIFF
--- a/packages/domain/src/routines.ts
+++ b/packages/domain/src/routines.ts
@@ -119,21 +119,31 @@ export function createRoutine(
  * Apply a partial update. Undefined leaves a field alone. A stray legacy
  * `timezone` key is ignored: the per-routine override was removed in HOU-470
  * (one account-wide zone), so a client still sending it must not write it back.
- * `created_by` is server-owned identity, never client-updateable.
+ * `created_by` is server-owned identity, never client-updateable: only
+ * `actorSub` — the server's own verified resolution of WHO is editing (C2) —
+ * may re-stamp it. The last verified editor is who a fired routine acts as
+ * (they authorized the routine's current shape), and re-stamping on edit also
+ * heals routines recorded before gateway-fronted pods stamped real subs.
  */
 export function applyRoutineUpdate(
   current: Routine,
   update: RoutineUpdate,
   nowIso: string,
+  actorSub?: string,
 ): Routine {
   const defined = Object.fromEntries(
     Object.entries(update).filter(
       ([k, v]) => v !== undefined && k !== "timezone" && k !== "created_by",
     ),
   );
-  // `...current` preserves `created_by` (RoutineUpdate can't set it, so a client
-  // can never reassign a routine's creator — it stays whoever created it).
-  return { ...current, ...defined, updated_at: nowIso } as Routine;
+  // `...current` preserves `created_by` when no verified actor is known — a
+  // client can never reassign a routine's acting identity through the body.
+  return {
+    ...current,
+    ...defined,
+    ...(actorSub ? { created_by: actorSub } : {}),
+    updated_at: nowIso,
+  } as Routine;
 }
 
 /** Normalize raw routine runs (written by the scheduler; read by the UI). */

--- a/packages/host/src/auth/acting.test.ts
+++ b/packages/host/src/auth/acting.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest";
+import { actingSubFromHeader } from "./acting";
+
+const payload = (obj: unknown) =>
+  Buffer.from(JSON.stringify(obj)).toString("base64url");
+
+test("decodes the sub from a well-formed acting-as header", () => {
+  const token = `acting-v1.${payload({ sub: "user-123", agent: "a1", exp: 1 })}.sig`;
+  expect(actingSubFromHeader(token)).toBe("user-123");
+});
+
+test("takes the first value of a repeated header", () => {
+  const token = `acting-v1.${payload({ sub: "first" })}.sig`;
+  expect(actingSubFromHeader([token, "acting-v1.other.sig"])).toBe("first");
+});
+
+test("anything malformed reads as no acting identity, never a throw", () => {
+  expect(actingSubFromHeader(undefined)).toBeUndefined();
+  expect(actingSubFromHeader("")).toBeUndefined();
+  expect(actingSubFromHeader("acting-v1.onlytwo")).toBeUndefined();
+  expect(actingSubFromHeader("wrong-prefix.abc.sig")).toBeUndefined();
+  expect(actingSubFromHeader("acting-v1.!!!not-base64url!!!.sig")).toBe(
+    undefined,
+  );
+  expect(
+    actingSubFromHeader(
+      `acting-v1.${Buffer.from("not json").toString("base64url")}.sig`,
+    ),
+  ).toBeUndefined();
+  expect(
+    actingSubFromHeader(`acting-v1.${payload({ agent: "a1" })}.sig`),
+  ).toBeUndefined();
+  expect(
+    actingSubFromHeader(`acting-v1.${payload({ sub: "" })}.sig`),
+  ).toBeUndefined();
+  expect(
+    actingSubFromHeader(`acting-v1.${payload({ sub: 42 })}.sig`),
+  ).toBeUndefined();
+});

--- a/packages/host/src/auth/acting.ts
+++ b/packages/host/src/auth/acting.ts
@@ -1,0 +1,44 @@
+/**
+ * Pod-side reading of the gateway-minted acting-as header (C2).
+ *
+ * The gateway stamps `x-houston-acting-as: acting-v1.<payloadB64Url>.<sig>` on
+ * every request it proxies to a managed pod; the payload names the driving
+ * user. A pod cannot VERIFY the signature — the HMAC secret never leaves the
+ * gateway — so decoding is safe only where a trusted gateway fronts every
+ * request (gatewayFronted), the same stance under which the raw header is
+ * already relayed to the runtime. On the desktop an inbound acting header is
+ * untrusted client input and must never reach this decode.
+ */
+
+/** The gateway-minted acting-as identity header (C2), lowercase for Node's
+ *  IncomingMessage.headers. */
+export const ACTING_AS_HEADER = "x-houston-acting-as";
+
+const PREFIX = "acting-v1";
+
+/**
+ * The `sub` claimed by an acting-as header value, or undefined for anything
+ * malformed (wrong prefix, bad base64, non-JSON, missing/empty sub). Never
+ * throws — a garbled header reads as "no acting identity", the same as absent.
+ * Expiry is deliberately not checked: the gateway minted the token on this very
+ * request, and the sub is recorded as attribution the gateway re-authorizes at
+ * routine fire time (membership + assignment), not used as a live credential.
+ */
+export function actingSubFromHeader(
+  value: string | string[] | undefined,
+): string | undefined {
+  const raw = Array.isArray(value) ? value[0] : value;
+  if (!raw) return undefined;
+  const parts = raw.split(".");
+  if (parts.length !== 3 || parts[0] !== PREFIX || !parts[1]) return undefined;
+  try {
+    const payload = JSON.parse(
+      Buffer.from(parts[1], "base64url").toString("utf8"),
+    ) as { sub?: unknown };
+    return typeof payload.sub === "string" && payload.sub
+      ? payload.sub
+      : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -319,6 +319,10 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     integrations,
     integrationGrants,
     agentConfigs,
+    // Managed pods record the gateway-minted acting identity as a routine's
+    // `created_by` (C2 — the sub the gateway re-authorizes at fire time);
+    // the desktop ignores the header and keeps stamping the local owner.
+    gatewayFronted: opts.gatewayFronted ?? false,
     // The desktop shell reveals/opens agent folders in the OS file manager;
     // give it the REAL directory (the agent id is a route key, not a path).
     agentDir: (_ws, a) => agentDir(a.id),

--- a/packages/host/src/routes/agent-authz.ts
+++ b/packages/host/src/routes/agent-authz.ts
@@ -38,6 +38,13 @@ export interface AgentRouteDeps {
    * agent id is a route key, not a path (HOU-677). Cloud deployments omit it.
    */
   agentDir?: (ws: Workspace, agent: Agent) => string;
+  /**
+   * True only when a trusted gateway fronts EVERY request (the managed cloud
+   * pod) — mirrors ControlPlaneDeps.gatewayFronted. Routine writes then take
+   * their recorded identity from the gateway-minted acting-as header instead
+   * of this host's single local user id.
+   */
+  gatewayFronted?: boolean;
 }
 
 export const DEFAULT_PATHS = new CloudPaths();

--- a/packages/host/src/routes/agent-data.test.ts
+++ b/packages/host/src/routes/agent-data.test.ts
@@ -216,6 +216,91 @@ test("routines: created_by is server-owned and cannot be spoofed", async () => {
   expect(next.created_by).toBe("alice");
 });
 
+/** A gateway-shaped acting-as token; the pod decodes the payload, never the sig. */
+const actingToken = (sub: string) =>
+  `acting-v1.${Buffer.from(
+    JSON.stringify({ sub, agent: "a1", exp: 4102444800 }),
+  ).toString("base64url")}.sig`;
+
+test("routines: an inbound acting-as header is ignored when not gateway-fronted", async () => {
+  const created = await fetch(`${base}/agents/${agentId}/routines`, {
+    method: "POST",
+    headers: {
+      ...auth("alice"),
+      "x-houston-acting-as": actingToken("mallory-sub"),
+    },
+    body: JSON.stringify({
+      name: "Spoof attempt",
+      prompt: "Write it",
+      schedule: "0 9 * * 1-5",
+    }),
+  });
+  expect(created.status).toBe(201);
+  expect(((await created.json()) as Routine).created_by).toBe("alice");
+});
+
+test("routines (gateway-fronted): created_by records the acting sub, PATCH re-stamps it, and a missing header stays creator-less (HOU-689)", async () => {
+  // A managed pod: same store/vfs, but the server trusts the gateway-minted
+  // acting-as header for routine identity instead of the pod-local user id.
+  const fronted = createControlPlaneServer({ ...deps(), gatewayFronted: true });
+  await new Promise<void>((r) => fronted.listen(0, "127.0.0.1", () => r()));
+  const addr = fronted.address();
+  const frontedBase = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+  try {
+    const created = await fetch(`${frontedBase}/agents/${agentId}/routines`, {
+      method: "POST",
+      headers: {
+        ...auth("alice"),
+        "x-houston-acting-as": actingToken("supabase-sub-1"),
+      },
+      body: JSON.stringify({
+        name: "Send the morning email",
+        prompt: "Send it",
+        schedule: "0 9 * * 1-5",
+      }),
+    });
+    expect(created.status).toBe(201);
+    const routine = (await created.json()) as Routine;
+    // NOT the pod-local verifier id — the sub the gateway can re-authorize
+    // when the fired routine's integration calls present it (C1 auth mode 3).
+    expect(routine.created_by).toBe("supabase-sub-1");
+
+    // Editing re-stamps to the current verified editor — which also heals
+    // routines recorded before pods stamped real subs.
+    const patched = await fetch(
+      `${frontedBase}/agents/${agentId}/routines/${routine.id}`,
+      {
+        method: "PATCH",
+        headers: {
+          ...auth("alice"),
+          "x-houston-acting-as": actingToken("supabase-sub-2"),
+        },
+        body: JSON.stringify({ name: "Renamed", created_by: "mallory" }),
+      },
+    );
+    expect(patched.status).toBe(200);
+    expect(((await patched.json()) as Routine).created_by).toBe(
+      "supabase-sub-2",
+    );
+
+    // No header (nothing the gateway vouched for) → creator-less, never the
+    // pod-local id (which would 401 at fire time — the HOU-689 failure mode).
+    const bare = await fetch(`${frontedBase}/agents/${agentId}/routines`, {
+      method: "POST",
+      headers: auth("alice"),
+      body: JSON.stringify({
+        name: "Headerless",
+        prompt: "Write it",
+        schedule: "0 9 * * 1-5",
+      }),
+    });
+    expect(bare.status).toBe(201);
+    expect("created_by" in ((await bare.json()) as Routine)).toBe(false);
+  } finally {
+    await new Promise<void>((r) => fronted.close(() => r()));
+  }
+});
+
 test("routines: an invalid cron is rejected at create (400), never saved to fail silently", async () => {
   const bad = await fetch(`${base}/agents/${agentId}/routines`, {
     method: "POST",

--- a/packages/host/src/routes/agent-data.ts
+++ b/packages/host/src/routes/agent-data.ts
@@ -72,9 +72,12 @@ export async function handleAgentData(
   req: IncomingMessage,
   res: ServerResponse,
   emit?: (event: HoustonEvent) => void,
-  // The authenticated caller's id — recorded as a new routine's `created_by`
-  // so a fired routine turn can act as its creator (C2). Absent in callers that
-  // don't carry identity (local single-user); the field then stays absent.
+  // The verified acting identity of THIS request (C2) — recorded as a new
+  // routine's `created_by` and re-stamped on PATCH, so a fired routine turn
+  // acts as whoever last shaped it. Gateway-fronted pods pass the gateway-
+  // minted acting sub (the id the gateway re-authorizes at fire time, HOU-689);
+  // the desktop passes its local owner. Absent in callers that don't carry
+  // identity; the field then stays as-is (absent on create).
   createdBy?: string,
 ): Promise<boolean> {
   const m = rest.match(
@@ -163,7 +166,7 @@ export async function handleAgentData(
       }
       if (method === "PATCH") {
         const update = await readJson(req);
-        const next = applyRoutineUpdate(current, update, nowIso);
+        const next = applyRoutineUpdate(current, update, nowIso, createdBy);
         // A PATCH may change the schedule; validate it against the account-wide
         // zone (HOU-470: no per-routine timezone).
         const accountTz = await getPreference(

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -1,6 +1,7 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { seedSchemas } from "@houston/domain";
 import type { CustomEndpoint, HoustonEvent } from "@houston/protocol";
+import { ACTING_AS_HEADER, actingSubFromHeader } from "../auth/acting";
 import type { Agent, UserId, Workspace } from "../domain/types";
 import { isApiKeyProvider } from "../providers";
 import { handleAttachments } from "../turn/attachments";
@@ -382,6 +383,17 @@ export async function handleAgents(
     // Typed .houston families + skills are served by the HOST off the workspace
     // vfs — the runtime surface (chat, auth, settings, files) goes to the channel.
     const paths = deps.paths ?? DEFAULT_PATHS;
+    // WHO a routine write records as its acting identity (C2). A gateway-fronted
+    // pod authenticates every request as its single local user, and that id has
+    // no membership upstream — a routine stamped with it 401s every integration
+    // call when it fires (HOU-689). The gateway minted the acting-as header for
+    // exactly this: its sub is the identity the gateway re-authorizes at fire
+    // time. On the desktop the header is untrusted client input, so the local
+    // userId stays the recorded creator (routine turns there authenticate with
+    // the frontend session instead).
+    const routineActor = deps.gatewayFronted
+      ? actingSubFromHeader(req.headers[ACTING_AS_HEADER])
+      : userId;
     if (
       await handleAgentData(
         deps.vfs,
@@ -392,7 +404,7 @@ export async function handleAgents(
         req,
         res,
         emit,
-        userId,
+        routineActor,
       )
     )
       return true;

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -128,6 +128,18 @@ export interface ControlPlaneDeps {
    * answer 503.
    */
   agentConfigs?: AgentConfigsDeps;
+  /**
+   * True only when a trusted gateway fronts EVERY request to this host (the
+   * managed cloud pod — same stance as LocalHostOptions.gatewayFronted).
+   * Routine writes then record the gateway-minted acting identity (the
+   * `x-houston-acting-as` payload sub) as `created_by` instead of this host's
+   * single local user id — that sub is what the gateway can re-authorize when
+   * the fired routine's integration calls present it (C2 auth mode 3; the
+   * pod's local user id has no upstream membership, so it would 401 every
+   * call). Leave false on the desktop: an inbound acting header there is
+   * untrusted client input and is ignored.
+   */
+  gatewayFronted?: boolean;
   corsOrigin?: string;
 }
 


### PR DESCRIPTION
## Root cause (HOU-689)

A managed cloud pod authenticates every request as its single local user (`SingleUserVerifier` → `local-owner`), so routines created through the gateway were stamped `created_by: "local-owner"`. When the routine fired, the pod's integration calls presented `x-houston-acting-user: local-owner` with its pod token (C1 auth mode 3); the gateway found no membership for that sub and answered 401, `RemoteIntegrationProvider` mapped that to signin-required, and the agent reported *"email access is failing right now"* on every scheduled run.

A hand-typed message worked because the gateway mints a real per-turn acting-as token on every proxied request (C2 mint point 1) — which is exactly why the reporter's "yes you can!" message sent the email while the schedule kept failing.

## Fix

- **`packages/host/src/auth/acting.ts` (new)** — decode the `sub` from the gateway-minted `x-houston-acting-as` payload. The pod can't verify the HMAC (the secret never leaves the gateway), so the decode is gated on the same `gatewayFronted` trust stance that already relays this header to the runtime verbatim.
- **Routine writes record the acting identity**: on a gateway-fronted host, `created_by` is stamped from the acting-as sub — the id the gateway re-authorizes (membership + assignment) when the fired routine's integration calls present it. On the desktop the header remains untrusted client input and is ignored; the local owner is recorded as before.
- **PATCH re-stamps `created_by` to the current verified editor** — the last person to shape a routine is who it acts as, and an edit heals routines recorded before this fix. `created_by` stays un-settable from the request body.

## Reproduce (before)

1. On hosted cloud, create an agent, connect the Composio Gmail integration, grant it to the agent.
2. Create a routine whose prompt requires the integration (e.g. "Send an email to …").
3. Wait for a scheduled fire (or run-now): the run fails with the agent saying email access is failing / it is blocked. Gateway logs show 401 on `POST /v1/integrations/composio/execute`; the routine doc on the pod PVC shows `"created_by": "local-owner"`.
4. Send any manual chat message asking it to send: it succeeds (per-turn acting-as token), then the next scheduled run fails again.

## Verify (after)

1. Deploy the engine-pod image with this change.
2. Edit the existing routine (any field, e.g. rename) **or** create a new one — the routine doc now records the creator's Supabase sub in `created_by`.
3. Trigger the routine (run-now or wait for the schedule): the integration call authenticates via the gateway's routine path (pod token + `x-houston-acting-user: <sub>`), and the email sends with no manual message needed.
4. Tests: `pnpm --filter @houston/host test` — new coverage in `src/auth/acting.test.ts` and `src/routes/agent-data.test.ts` (gateway-fronted stamping, PATCH re-stamp, desktop spoof-proofing); full host suite 548 passed, domain 88 passed, `pnpm -r typecheck` and biome clean.

HOU-689

🤖 Generated with [Claude Code](https://claude.com/claude-code)