### PR TITLE
fix(app): stop blocking sidebar removal of a deleted agent on pod cleanup

### DIFF
--- a/app/src/stores/agents.ts
+++ b/app/src/stores/agents.ts
@@ -127,9 +127,11 @@ export const useAgentStore = create<AgentState>((set, get) => ({
   delete: async (workspaceId, id) => {
     const wasCurrent = get().current?.id === id;
     await tauriAgents.delete(workspaceId, id);
-    // Wipe any chat composer attachments scoped to this agent's chat.
-    // Per-activity attachments are wiped via useDeleteActivity / handleDelete.
-    await tauriAttachments.delete(`agent-${id}`).catch(() => {});
+    // The server confirmed the delete — reflect it in the UI NOW. In cloud
+    // mode the attachments cleanup below dispatches into the agent's pod,
+    // which this very delete just tore down, so awaiting it here can block
+    // on a dead endpoint for many seconds — leaving the "deleted" agent
+    // sitting in the sidebar (and 404ing when reopened).
     // Conversation state lives in the SDK conversation VM; a deleted agent's
     // scopes are simply never subscribed again.
     // Clear the free-form chat draft for this agent.
@@ -144,6 +146,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     if (wasCurrent && nextCurrent) {
       startAgentSideEffects(nextCurrent);
     }
+    // Wipe any chat composer attachments scoped to this agent's chat —
+    // fire-and-forget best-effort: the agent's own data died with it.
+    // Per-activity attachments are wiped via useDeleteActivity / handleDelete.
+    void tauriAttachments.delete(`agent-${id}`).catch(() => {});
   },
 
   rename: async (workspaceId, id, newName) => {


### PR DESCRIPTION
## Problem

Deleting an agent in cloud mode appeared to do nothing: the agent stayed in the sidebar, a second delete click errored with 404, and reopening the agent later showed an engine 404.

Confirmed in gateway prod logs (2026-07-05 22:57 UTC, slug `1f4e6197163e6ead`): the DELETE succeeded server-side in 250ms, but the store's next awaited step — the composer-attachments cleanup — dispatched `DELETE /agents/:slug/attachments` into the pod that the delete had just torn down. The gateway proxied it into a dead ClusterIP and it hung ~15s (connect timeouts + retry) before the client aborted. Sidebar removal in `useAgentStore.delete` runs *after* that await, so the "deleted" agent stayed visible, was re-deleted (404 → throw → removal skipped for good), and 404ed when revisited.

## Fix

Remove the agent from the store immediately after the server confirms the delete; run the attachments cleanup afterwards, fire-and-forget. It was already best-effort (`.catch(() => {})`), and the agent's data dies with its pod anyway.

Pairs with the gateway-side fix (cloud repo) that makes dispatches to a deleted agent fail fast with 404 instead of burning the proxy retry budget against the dead endpoint.

## Testing

- `pnpm -r typecheck` green (pre-push hook), biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)