### PR TITLE
fix(host): real runtime boot budget + fail-fast on mid-boot crash

### DIFF
--- a/packages/host/src/launcher/process.test.ts
+++ b/packages/host/src/launcher/process.test.ts
@@ -107,6 +107,36 @@ test("a runtime that never becomes healthy is killed and not cached (the turn er
   expect(await launcher.status("bad")).toBe("asleep"); // not cached as running
 });
 
+test("a runtime that exits mid-boot fails fast instead of waiting out the health budget", async () => {
+  // The health probe alone can't tell "still booting" from "already dead" — it
+  // would poll a dead port for the full budget. The exit signal must preempt it.
+  const killed: number[] = [];
+  let exitCb: (() => void) | undefined;
+  const spawner: RuntimeSpawner = {
+    spawn() {
+      return {
+        port: 5000,
+        kill: () => killed.push(5000),
+        onExit: (cb) => {
+          exitCb = cb;
+        },
+      };
+    },
+  };
+  const launcher = new ProcessLauncher(
+    opts(spawner, { waitHealthy: () => new Promise(() => {}) }), // never settles
+  );
+
+  const boot = launcher.ensureAwake(agent("crash"));
+  // Let the async spawn (behind allocatePort's await) actually run, then die.
+  await new Promise((r) => setTimeout(r, 0));
+  if (!exitCb) throw new Error("spawn never registered onExit");
+  exitCb(); // the child dies before ever answering /health
+  await expect(boot).rejects.toThrow("exited before becoming healthy");
+  expect(killed).toEqual([5000]); // kill() on an exited child is a safe no-op
+  expect(await launcher.status("crash")).toBe("asleep"); // not cached as running
+});
+
 test("concurrent callers during a boot share one spawn and resolve only once healthy", async () => {
   // HOU-639: on a cold pod the desktop fires chat-history and provider-status
   // together; the loser of the spawn race used to be handed a port the child

--- a/packages/host/src/launcher/process.ts
+++ b/packages/host/src/launcher/process.ts
@@ -14,7 +14,8 @@ export interface RuntimeHandle {
    * Register a one-shot callback fired when the underlying process exits on its
    * own (crash, OOM, the runtime's own SIGTERM handler). Lets the launcher reap
    * a dead child from its live-set so a phantom "running" entry never hands a
-   * dead endpoint to the next turn. A handle whose process cannot crash (a test
+   * dead endpoint to the next turn — and fail a boot fast when the child dies
+   * before ever answering /health. A handle whose process cannot crash (a test
    * stub) may leave this undefined.
    */
   onExit?(cb: () => void): void;
@@ -79,9 +80,19 @@ function osAllocatePort(): Promise<number> {
   });
 }
 
-/** Default health probe: GET /health until 200 or a ~10s budget elapses. */
+/**
+ * How long a spawned runtime gets to bind its port and answer /health. A cold
+ * boot inside a CPU-capped engine pod measures ~10.5s — the old 10s budget lost
+ * that race by milliseconds and SIGTERM'd runtimes right as they logged
+ * "runtime listening" (surfacing as "never became healthy" on the first message
+ * to a fresh agent). Generous is safe here: a runtime that DIES during boot
+ * fails fast via the launcher's onExit abort and never waits this out.
+ */
+const BOOT_HEALTH_BUDGET_MS = 60_000;
+
+/** Default health probe: GET /health until 200 or the boot budget elapses. */
 async function pollHealth(port: number): Promise<void> {
-  const deadline = Date.now() + 10_000;
+  const deadline = Date.now() + BOOT_HEALTH_BUDGET_MS;
   for (;;) {
     try {
       const r = await fetch(`http://127.0.0.1:${port}/health`);
@@ -93,7 +104,9 @@ async function pollHealth(port: number): Promise<void> {
       // not up yet
     }
     if (Date.now() > deadline)
-      throw new Error(`runtime on port ${port} never became healthy`);
+      throw new Error(
+        `runtime on port ${port} never became healthy within ${BOOT_HEALTH_BUDGET_MS / 1000}s`,
+      );
     await new Promise((r) => setTimeout(r, 100));
   }
 }
@@ -164,17 +177,32 @@ export class ProcessLauncher implements RuntimeLauncher {
     // dies on its own (OOM, panic) lingers as a phantom "running" entry and
     // ensureAwake keeps handing its dead port to every turn. Only evict if the
     // map still points at THIS handle — a sleep()+respawn must not be clobbered.
+    // The SAME (single) registration also aborts a boot in flight: a child that
+    // dies mid-boot fails the caller NOW instead of polling a dead port until
+    // the health budget runs out.
+    let abortBoot: ((err: Error) => void) | undefined;
     handle.onExit?.(() => {
       if (this.running.get(agent.id) === entry) this.running.delete(agent.id);
+      abortBoot?.(new Error("runtime exited before becoming healthy"));
     });
     try {
-      await this.waitHealthy(handle.port, token);
+      // The raced rejection is always observed — race() subscribes to both
+      // promises up front — so an exit after settle can't surface as an
+      // unhandled rejection (and clearing abortBoot below stops it firing at all).
+      await Promise.race([
+        this.waitHealthy(handle.port, token),
+        new Promise<never>((_, reject) => {
+          abortBoot = reject;
+        }),
+      ]);
     } catch (err) {
       // A runtime that never came up must not linger as a zombie nor be cached
       // as "running" — kill it and surface the failure (the turn errors visibly).
       handle.kill();
       this.running.delete(agent.id);
       throw err;
+    } finally {
+      abortBoot = undefined;
     }
     return { baseUrl: `http://127.0.0.1:${handle.port}`, token };
   }


### PR DESCRIPTION
## Problem

Every first message to a fresh cloud agent failed with **"runtime on port N never became healthy"** — usually twice in a row.

Prod pod logs show why: the launcher's `/health` poll gives a spawned pi-runtime a **10s** budget, but a cold boot inside the CPU-capped engine pod measures **~10.5s**. The probe lost the race by milliseconds and SIGTERM'd runtimes *right as they logged "runtime listening"*:

```
23:25:45.651 "runtime listening" … port 42327
23:25:45.656 "runtime shutdown requested" signal=SIGTERM   ← 5ms later
23:25:56.201 "runtime listening" … port 36737
23:25:56.205 "runtime shutdown requested" signal=SIGTERM   ← 4ms later
23:26:06.304 "runtime listening" … port 40005              ← third try squeaked under
```

## Fix

- Boot health budget 10s → **60s** (`BOOT_HEALTH_BUDGET_MS`, with the measurement documented).
- The generous budget is safe because it's no longer the only exit from a bad boot: the existing `onExit` reaper registration now **also aborts an in-flight health wait**, so a child that crashes during boot fails the caller immediately ("runtime exited before becoming healthy") instead of polling a dead port for the full budget.
- Timeout message now includes the budget for future debuggability.

## Verification

- New test: a runtime that exits mid-boot rejects immediately, is reaped, and isn't cached as running.
- `@houston/host`: 549 tests pass, typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)