### PR TITLE
feat(app): friendly workspace loading screen (HOU-690)

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,12 +1,12 @@
 import "./styles/globals.css";
 import type { Toast } from "@houston-ai/core";
 import { useEffect, useRef } from "react";
-import { useTranslation } from "react-i18next";
 import { SignInScreen } from "./components/auth/sign-in-screen";
 import { MigrationReconnectScreen } from "./components/onboarding/migration-reconnect-screen";
 import { isFirstRun } from "./components/onboarding/missions/onboarding-flow";
 import { PersonalAssistantOnboarding } from "./components/onboarding/personal-assistant-onboarding";
 import { ProviderLoginFallback } from "./components/shell/provider-login-fallback";
+import { WorkspaceLoading } from "./components/shell/workspace-loading";
 import { WorkspaceShell } from "./components/shell/workspace-shell";
 import { useAgentInvalidation } from "./hooks/use-agent-invalidation";
 import { useAnalyticsSubscriber } from "./hooks/use-analytics-subscriber";
@@ -130,7 +130,6 @@ export default function App() {
     return () => document.removeEventListener("contextmenu", handler);
   }, []);
 
-  const { t } = useTranslation("shell");
   const wsLoading = useWorkspaceStore((s) => s.loading);
   const workspaces = useWorkspaceStore((s) => s.workspaces);
   const agentLoading = useAgentStore((s) => s.loading);
@@ -172,13 +171,7 @@ export default function App() {
   // transient Supabase blip (access token still valid in Keychain)
   // is unlikely because getSession() reads locally, not remotely.
   if (isAuthConfigured() && sessionLoading) {
-    return (
-      <div className="h-screen flex items-center justify-center bg-background text-foreground">
-        <p className="text-muted-foreground text-sm">
-          {t("engineGate.starting")}
-        </p>
-      </div>
-    );
+    return <WorkspaceLoading />;
   }
   if (isAuthConfigured() && !session) {
     // Local account login. Keep the dev-only paste-the-code fallback (#146) — a
@@ -217,13 +210,7 @@ export default function App() {
     capabilitiesLoading ||
     (newEngineActive() && !agentsLoaded)
   ) {
-    return (
-      <div className="h-screen flex items-center justify-center bg-background text-foreground">
-        <p className="text-muted-foreground text-sm">
-          {t("engineGate.starting")}
-        </p>
-      </div>
-    );
+    return <WorkspaceLoading />;
   }
 
   // First-run signal differs by wire (HOU-653): the legacy Rust engine uses

--- a/app/src/components/shell/engine-gate.tsx
+++ b/app/src/components/shell/engine-gate.tsx
@@ -12,6 +12,7 @@ import { hostedGateState } from "../../lib/engine-mode";
 import i18n from "../../lib/i18n";
 import { isAuthConfigured, supabase } from "../../lib/supabase";
 import { SignInScreen } from "../auth/sign-in-screen";
+import { WorkspaceLoading } from "./workspace-loading";
 
 /**
  * Blocks app rendering until the selected engine transport is ready. The hosted
@@ -77,7 +78,7 @@ function HostedEngineGate({ children }: { children: ReactNode }) {
     case "ready":
       return <>{children}</>;
     default:
-      return <EngineStarting />;
+      return <WorkspaceLoading />;
   }
 }
 
@@ -94,12 +95,8 @@ function SidecarEngineGate({ children }: { children: ReactNode }) {
     };
   }, [ready]);
 
-  if (!ready) return <EngineStarting />;
+  if (!ready) return <WorkspaceLoading />;
   return <>{children}</>;
-}
-
-function EngineStarting() {
-  return <GateMessage>{i18n.t("shell:engineGate.starting")}</GateMessage>;
 }
 
 function HostedAuthMisconfigured() {

--- a/app/src/components/shell/workspace-loading.tsx
+++ b/app/src/components/shell/workspace-loading.tsx
@@ -1,0 +1,30 @@
+import { HoustonAvatar } from "@houston-ai/core";
+import i18n from "../../lib/i18n";
+
+/**
+ * Full-screen boot splash: a rounded card with the Houston helmet inside the
+ * spinning comet halo (the same `running` treatment chat avatars get, scaled
+ * up) so the wait always shows movement. One component covers every boot
+ * blocker — the engine handshake (EngineGate, desktop + web), the auth-session
+ * resolve, and the first workspace/agent load (App.tsx) — so the whole startup
+ * reads as a single continuous "loading your workspace" state.
+ *
+ * Reads the i18n singleton directly (not useTranslation): the web EngineGate
+ * renders this OUTSIDE <I18nextProvider>, and at gate time the saved language
+ * isn't applied yet anyway (LanguageGate mounts after the engine is ready).
+ */
+export function WorkspaceLoading() {
+  return (
+    <div className="flex h-screen items-center justify-center bg-background px-6 text-foreground">
+      <div
+        role="status"
+        className="workspace-loading-card flex w-full max-w-xs flex-col items-center gap-7 rounded-3xl border border-border bg-card px-10 py-14 shadow-[0_16px_60px_rgba(0,0,0,0.08)]"
+      >
+        <HoustonAvatar diameter={96} running />
+        <p className="text-sm text-muted-foreground">
+          {i18n.t("shell:engineGate.starting")}
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -271,7 +271,7 @@
     "continueButton": "Continue"
   },
   "engineGate": {
-    "starting": "Starting Houston engine…",
+    "starting": "Loading your workspace…",
     "reconnected": "Houston reconnected",
     "loadFailed": "Couldn't load your available AI models. Check your connection and try again.",
     "authRequiredTitle": "Sign-in required",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -271,7 +271,7 @@
     "continueButton": "Continuar"
   },
   "engineGate": {
-    "starting": "Iniciando el motor de Houston…",
+    "starting": "Cargando tu espacio de trabajo…",
     "reconnected": "Houston se reconectó",
     "loadFailed": "No pudimos cargar tus modelos de IA disponibles. Revisa tu conexión e inténtalo de nuevo.",
     "authRequiredTitle": "Inicio de sesión requerido",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -261,7 +261,7 @@
     "continueButton": "Continuar"
   },
   "engineGate": {
-    "starting": "Iniciando o motor do Houston…",
+    "starting": "Carregando seu espaço de trabalho…",
     "reconnected": "Houston reconectou",
     "loadFailed": "Não foi possível carregar seus modelos de IA disponíveis. Verifique sua conexão e tente novamente.",
     "authRequiredTitle": "Login necessário",

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -189,3 +189,26 @@ body {
     animation: none;
   }
 }
+
+/* Boot splash card (WorkspaceLoading) — a gentle rise-in so the card doesn't
+   pop into place; the spinning comet halo supplies the ongoing motion. */
+@keyframes workspace-loading-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.workspace-loading-card {
+  animation: workspace-loading-in 0.45s cubic-bezier(0.16, 1, 0.3, 1);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .workspace-loading-card {
+    animation: none;
+  }
+}

--- a/packages/web/e2e/boot.spec.ts
+++ b/packages/web/e2e/boot.spec.ts
@@ -24,7 +24,7 @@ test("boots past every gate to the app shell", async ({ page }) => {
   // None of the boot gates are left on screen.
   await expect(
     page.getByText(
-      /Connecting to engine|Starting Houston|Language · Idioma|Can't reach the engine/i,
+      /Connecting to engine|Loading your workspace|Language · Idioma|Can't reach the engine/i,
     ),
   ).toHaveCount(0);
 });

--- a/packages/web/src/app-tree.tsx
+++ b/packages/web/src/app-tree.tsx
@@ -16,6 +16,7 @@
 import App from "@houston/app/App";
 import { DisclaimerGate } from "@houston/app/components/shell/disclaimer-gate";
 import { LanguageGate } from "@houston/app/components/shell/language-gate";
+import { WorkspaceLoading } from "@houston/app/components/shell/workspace-loading";
 import { analytics, classifyAnalyticsError } from "@houston/app/lib/analytics";
 import { isEngineReady, whenEngineReady } from "@houston/app/lib/engine";
 import { showErrorToast } from "@houston/app/lib/error-toast";
@@ -120,22 +121,9 @@ function EngineGate({ children }: { children: ReactNode }) {
   }, [ready]);
 
   if (!ready) {
-    // Rendered OUTSIDE <I18nextProvider>; use the i18n singleton directly.
-    return (
-      <div
-        style={{
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          height: "100vh",
-          fontFamily: "system-ui, sans-serif",
-          color: "#888",
-          fontSize: 14,
-        }}
-      >
-        {i18n.t("shell:engineGate.starting")}
-      </div>
-    );
+    // Rendered OUTSIDE <I18nextProvider> — WorkspaceLoading reads the i18n
+    // singleton directly, so that's fine.
+    return <WorkspaceLoading />;
   }
   return <>{children}</>;
 }

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -37,7 +37,7 @@ if (controlPlaneUrl && window.location.pathname.startsWith("/admin")) {
   // boots in host mode. app/src/lib/engine.ts reads these globals at
   // module-eval (which fires as soon as cloud-login statically imports the app
   // tree), so they MUST be set before that import — otherwise EngineGate hangs
-  // on "Starting Houston engine". CloudApp keeps the token in sync with the
+  // on the "Loading your workspace" splash. CloudApp keeps the token in sync with the
   // live session; the engine adapter reads it live per request.
   window.__HOUSTON_CP__ = true;
   window.__HOUSTON_ENGINE__ = { baseUrl: controlPlaneUrl, token: "" };


### PR DESCRIPTION
## Summary

Fixes HOU-690.

The boot splash said **"Starting Houston engine…"** — jargon for the non-technical audience (what's an engine?), rendered as a bare gray string with zero movement. Users had no signal that anything was happening.

Now every boot blocker shows one **WorkspaceLoading** screen: a rounded card (Discord-splash style) with the Houston helmet inside the spinning comet halo — the same `running` treatment chat avatars get, scaled up to 96px — above **"Loading your workspace…"** (en / es / pt). A gentle rise-in entrance animation is disabled under `prefers-reduced-motion`; the card carries `role="status"` for screen readers.

## What changed

- **New** `app/src/components/shell/workspace-loading.tsx` — the shared splash (uses `HoustonAvatar running` from `@houston-ai/core`, semantic tokens only, works in light + dark).
- `engine-gate.tsx` — both gates (hosted + sidecar) render it instead of the bare text.
- `App.tsx` — the auth-session and workspace/agent-load splashes render it too, so the whole startup reads as one continuous loading state instead of three different placeholders.
- `packages/web/src/app-tree.tsx` — the web EngineGate uses the same component (it reads the i18n singleton, so rendering outside `<I18nextProvider>` stays safe).
- Copy: `engineGate.starting` → "Loading your workspace…" / "Cargando tu espacio de trabajo…" / "Carregando seu espaço de trabalho…" (also picks up the in-shell placeholder in `workspace-shell.tsx`).
- `packages/web/e2e/boot.spec.ts` — gate-left-on-screen regex updated to the new copy.
- `app/src/styles/globals.css` — `workspace-loading-in` rise-in keyframe with a reduced-motion guard.

## Before

Bare centered gray text: `Starting Houston engine…` (hardcoded `#888`, no motion, no theming).

To reproduce the old behavior: check out `main`, launch the app (or `pnpm dev`), and watch the boot splash before the shell mounts — plain text only.

## After / verification

1. `pnpm dev` (or a packaged build) → on launch you see the rounded card with the helmet, the comet halo spinning around it, and "Loading your workspace…". Same screen covers the engine handshake, session resolve, and first workspace load.
2. Switch language to es/pt → translated copy.
3. Dark mode → card and halo render on the dark tokens (verified via screenshot in both themes).
4. Gates: `pnpm check` ✓ · `pnpm -r typecheck` ✓ · `cd app && pnpm check-locales` ✓ · `cd app && pnpm test` (566 pass) ✓ · `pnpm --filter houston-web test:e2e` (22 pass, includes the boot-gate spec) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)