### PR TITLE
refactor(settings): overview with inline controls, no sidebar

### DIFF
--- a/app/src/components/settings/sections/account.tsx
+++ b/app/src/components/settings/sections/account.tsx
@@ -1,9 +1,10 @@
 import { Button } from "@houston-ai/core";
-import { User } from "lucide-react";
+import { UserCircle } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useSession } from "../../../hooks/use-session";
 import { signOut } from "../../../lib/auth";
 import { isAuthConfigured } from "../../../lib/supabase";
+import { SettingsControlRow } from "../settings-row";
 
 export function AccountSection() {
   const { t } = useTranslation("settings");
@@ -21,34 +22,26 @@ export function AccountSection() {
   const avatar = meta.avatar_url ?? null;
 
   return (
-    <section>
-      <h2 className="text-lg font-semibold mb-4">{t("account.title")}</h2>
-      <div className="flex items-center gap-3 rounded-xl border border-border bg-card px-4 py-3">
-        {avatar ? (
+    <SettingsControlRow
+      leading={
+        avatar ? (
           <img
             src={avatar}
             alt=""
-            className="h-10 w-10 rounded-full"
+            className="size-6 rounded-full"
             referrerPolicy="no-referrer"
           />
         ) : (
-          <div className="h-10 w-10 rounded-full bg-muted flex items-center justify-center">
-            <User className="h-5 w-5 text-muted-foreground" />
-          </div>
-        )}
-        <div className="flex-1 min-w-0">
-          <div className="text-sm font-medium truncate">{displayName}</div>
-          {user.email && (
-            <div className="text-xs text-muted-foreground truncate">
-              {user.email}
-            </div>
-          )}
-        </div>
-        <Button variant="outline" onClick={() => signOut()}>
-          {t("account.signOut")}
-        </Button>
-      </div>
-    </section>
+          <UserCircle className="size-[18px] text-muted-foreground" />
+        )
+      }
+      title={displayName}
+      description={user.email ?? undefined}
+    >
+      <Button variant="outline" size="sm" onClick={() => signOut()}>
+        {t("account.signOut")}
+      </Button>
+    </SettingsControlRow>
   );
 }
 

--- a/app/src/components/settings/sections/appearance.tsx
+++ b/app/src/components/settings/sections/appearance.tsx
@@ -1,8 +1,9 @@
-import { Moon, Sun } from "lucide-react";
+import { Moon, Palette, Sun } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { tauriPreferences } from "../../../lib/tauri";
 import { setTheme, type Theme } from "../../../lib/theme";
+import { SettingsControlRow } from "../settings-row";
 
 export function AppearanceSection() {
   const { t } = useTranslation("settings");
@@ -22,18 +23,20 @@ export function AppearanceSection() {
     await setTheme(value);
   };
 
+  const pill = (value: Theme) =>
+    `flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm transition-colors ${
+      theme === value
+        ? "bg-primary text-primary-foreground"
+        : "text-muted-foreground hover:text-foreground"
+    }`;
+
   return (
-    <section>
-      <h2 className="text-lg font-semibold mb-4">{t("appearance.title")}</h2>
-      <div className="flex gap-2">
+    <SettingsControlRow icon={Palette} title={t("appearance.title")}>
+      <div className="flex items-center gap-1 rounded-full bg-secondary p-0.5">
         <button
           type="button"
           onClick={() => handleThemeToggle("light")}
-          className={`flex items-center gap-2 px-4 py-2.5 rounded-full text-sm transition-colors ${
-            theme === "light"
-              ? "bg-primary text-primary-foreground"
-              : "bg-secondary text-foreground hover:bg-accent"
-          }`}
+          className={pill("light")}
         >
           <Sun className="size-4" />
           {t("appearance.light")}
@@ -41,16 +44,12 @@ export function AppearanceSection() {
         <button
           type="button"
           onClick={() => handleThemeToggle("dark")}
-          className={`flex items-center gap-2 px-4 py-2.5 rounded-full text-sm transition-colors ${
-            theme === "dark"
-              ? "bg-primary text-primary-foreground"
-              : "bg-secondary text-foreground hover:bg-accent"
-          }`}
+          className={pill("dark")}
         >
           <Moon className="size-4" />
           {t("appearance.dark")}
         </button>
       </div>
-    </section>
+    </SettingsControlRow>
   );
 }

--- a/app/src/components/settings/sections/danger.tsx
+++ b/app/src/components/settings/sections/danger.tsx
@@ -1,8 +1,10 @@
 import { Button, ConfirmDialog } from "@houston-ai/core";
+import { Trash2 } from "lucide-react";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useAgentStore } from "../../../stores/agents";
 import { useWorkspaceStore } from "../../../stores/workspaces";
+import { SettingsControlRow } from "../settings-row";
 
 export function DangerSection() {
   const { t } = useTranslation("settings");
@@ -15,6 +17,8 @@ export function DangerSection() {
 
   if (!currentWorkspace) return null;
 
+  const isOnlyWorkspace = workspaces.length <= 1;
+
   const handleDelete = async () => {
     const remaining = workspaces.filter((w) => w.id !== currentWorkspace.id);
     await deleteWorkspace(currentWorkspace.id);
@@ -26,26 +30,26 @@ export function DangerSection() {
   };
 
   return (
-    <section>
-      <h2 className="text-lg font-semibold text-destructive mb-1">
-        {t("dangerZone.title")}
-      </h2>
-      <p className="text-sm text-muted-foreground mb-4">
-        {t("dangerZone.description")}
-      </p>
-      <Button
-        variant="destructive"
-        className="rounded-full"
-        disabled={workspaces.length <= 1}
-        onClick={() => setShowConfirm(true)}
+    <>
+      <SettingsControlRow
+        icon={Trash2}
+        title={t("nav.danger")}
+        description={
+          isOnlyWorkspace
+            ? t("dangerZone.createAnotherFirst")
+            : t("dangerZone.description")
+        }
+        destructive
       >
-        {t("dangerZone.deleteButton")}
-      </Button>
-      {workspaces.length <= 1 && (
-        <p className="text-xs text-muted-foreground mt-2">
-          {t("dangerZone.createAnotherFirst")}
-        </p>
-      )}
+        <Button
+          variant="destructive"
+          size="sm"
+          disabled={isOnlyWorkspace}
+          onClick={() => setShowConfirm(true)}
+        >
+          {t("dangerZone.confirmLabel")}
+        </Button>
+      </SettingsControlRow>
 
       <ConfirmDialog
         open={showConfirm}
@@ -55,6 +59,6 @@ export function DangerSection() {
         confirmLabel={t("dangerZone.confirmLabel")}
         onConfirm={handleDelete}
       />
-    </section>
+    </>
   );
 }

--- a/app/src/components/settings/sections/language.tsx
+++ b/app/src/components/settings/sections/language.tsx
@@ -5,6 +5,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@houston-ai/core";
+import { Languages } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import {
   changeLocale,
@@ -14,6 +15,7 @@ import {
 } from "../../../lib/i18n";
 import { useUIStore } from "../../../stores/ui";
 import { useWorkspaceStore } from "../../../stores/workspaces";
+import { SettingsControlRow } from "../settings-row";
 
 const LOCALE_LABELS: Record<SupportedLocale, string> = {
   en: "English",
@@ -22,7 +24,7 @@ const LOCALE_LABELS: Record<SupportedLocale, string> = {
 };
 
 export function LanguageSection() {
-  const { t, i18n } = useTranslation("common");
+  const { t, i18n } = useTranslation(["settings", "common"]);
   const addToast = useUIStore((s) => s.addToast);
   const current = useWorkspaceStore((s) => s.current);
   const setWorkspaceLocale = useWorkspaceStore((s) => s.setLocale);
@@ -31,43 +33,33 @@ export function LanguageSection() {
     : "en";
 
   const handleLocaleChange = async (value: string) => {
-    // This picker lives under the Workspace settings tab, which SettingsView
-    // only renders once a workspace is active — so `current` is guaranteed; the
-    // guard just defends the rare unmount race. Persist the override FIRST so
-    // the engine is the source of truth; if it fails the error surfaces and the
-    // UI never switches to an unsaved language.
+    // Persist the workspace override FIRST so the engine is the source of truth;
+    // if it fails the error surfaces and the UI never switches to an unsaved
+    // language. `current` is guaranteed once a workspace is active; the guard
+    // just defends the rare unmount race.
     if (!isSupported(value) || !current) return;
     await setWorkspaceLocale(current.id, value);
     await changeLocale(value);
-    addToast({ title: t("language.toastChanged") });
+    addToast({ title: t("common:language.toastChanged") });
   };
 
   return (
-    <section>
-      <h2 className="text-lg font-semibold mb-1">{t("language.title")}</h2>
-      <p className="text-sm text-muted-foreground mb-4">
-        {t("language.description")}
-      </p>
-      <div>
-        <label
-          htmlFor="language-select"
-          className="text-xs text-muted-foreground block mb-1.5"
+    <SettingsControlRow icon={Languages} title={t("settings:nav.language")}>
+      <Select value={currentLocale} onValueChange={handleLocaleChange}>
+        <SelectTrigger
+          aria-label={t("settings:nav.language")}
+          className="w-40 rounded-lg"
         >
-          {t("language.label")}
-        </label>
-        <Select value={currentLocale} onValueChange={handleLocaleChange}>
-          <SelectTrigger id="language-select" className="w-full rounded-xl">
-            <SelectValue />
-          </SelectTrigger>
-          <SelectContent>
-            {SUPPORTED_LOCALES.map((loc) => (
-              <SelectItem key={loc} value={loc}>
-                {LOCALE_LABELS[loc]}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-    </section>
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {SUPPORTED_LOCALES.map((loc) => (
+            <SelectItem key={loc} value={loc}>
+              {LOCALE_LABELS[loc]}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </SettingsControlRow>
   );
 }

--- a/app/src/components/settings/sections/workspace.tsx
+++ b/app/src/components/settings/sections/workspace.tsx
@@ -1,7 +1,9 @@
+import { Settings } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useUIStore } from "../../../stores/ui";
 import { useWorkspaceStore } from "../../../stores/workspaces";
+import { SettingsControlRow } from "../settings-row";
 
 export function WorkspaceSection() {
   const { t } = useTranslation("settings");
@@ -25,27 +27,18 @@ export function WorkspaceSection() {
   };
 
   return (
-    <section>
-      <h2 className="text-lg font-semibold mb-4">{t("workspace.title")}</h2>
-      <div>
-        <label
-          htmlFor="workspace-name"
-          className="text-xs text-muted-foreground block mb-1.5"
-        >
-          {t("workspace.nameLabel")}
-        </label>
-        <input
-          id="workspace-name"
-          type="text"
-          value={wsName}
-          onChange={(e) => setWsName(e.target.value)}
-          onBlur={handleRename}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") handleRename();
-          }}
-          className="w-full rounded-xl border border-border bg-card px-4 py-2.5 text-sm outline-none focus:ring-1 focus:ring-ring transition-all"
-        />
-      </div>
-    </section>
+    <SettingsControlRow icon={Settings} title={t("workspace.title")}>
+      <input
+        aria-label={t("workspace.title")}
+        type="text"
+        value={wsName}
+        onChange={(e) => setWsName(e.target.value)}
+        onBlur={handleRename}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") e.currentTarget.blur();
+        }}
+        className="w-52 rounded-lg border border-border bg-background px-3 py-1.5 text-sm outline-none transition-all focus:ring-1 focus:ring-ring"
+      />
+    </SettingsControlRow>
   );
 }

--- a/app/src/components/settings/settings-index.tsx
+++ b/app/src/components/settings/settings-index.tsx
@@ -1,0 +1,140 @@
+import { Bug, FileText, Keyboard, User, Users } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useOrg } from "../../hooks/queries";
+import { useWorkspaceContext } from "../../hooks/queries/use-workspace-context";
+import { useUIStore } from "../../stores/ui";
+import { useWorkspaceStore } from "../../stores/workspaces";
+import { AccountSection } from "./sections/account";
+import { AppearanceSection } from "./sections/appearance";
+import { DangerSection } from "./sections/danger";
+import { LanguageSection } from "./sections/language";
+import { WorkspaceSection } from "./sections/workspace";
+import { SettingsCard, SettingsRow } from "./settings-row";
+
+/** A settings section that opens on its own screen (a back bar returns here). */
+export type SettingsSectionId =
+  | "members"
+  | "workspaceContext"
+  | "userContext"
+  | "shortcuts"
+  | "reportBug";
+
+interface SettingsIndexProps {
+  accountAvailable: boolean;
+  showMembers: boolean;
+  onSelect: (id: SettingsSectionId) => void;
+}
+
+/**
+ * The settings landing page. Simple settings (workspace name, appearance,
+ * language, account, delete) are resolved inline as control rows; the heavier
+ * ones (context editors, members, shortcuts, bug report) are navigable rows that
+ * drill into their own screen. Account and members appear only when applicable.
+ */
+export function SettingsIndex({
+  accountAvailable,
+  showMembers,
+  onSelect,
+}: SettingsIndexProps) {
+  const { t } = useTranslation(["settings", "org"]);
+  const workspace = useWorkspaceStore((s) => s.current);
+  const org = useOrg(showMembers);
+  const { data: context } = useWorkspaceContext(workspace?.id);
+  const addToast = useUIStore((s) => s.addToast);
+
+  const memberCount = org.data?.members?.length ?? 0;
+  const contextValue = (slot: "workspace" | "user") =>
+    context?.[slot]?.trim() ? t("settings:index.values.set") : undefined;
+
+  async function handleVersionClick() {
+    try {
+      await navigator.clipboard.writeText(__APP_VERSION__);
+      addToast({ title: t("settings:toasts.versionCopied") });
+    } catch (err) {
+      addToast({
+        title: t("settings:toasts.versionCopyFailed"),
+        description: err instanceof Error ? err.message : String(err),
+        variant: "error",
+      });
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-2xl px-8 py-10">
+      <header className="mb-8 px-1">
+        <h1 className="text-[28px] font-normal text-foreground">
+          {t("settings:title")}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {t("settings:index.subtitle")}
+        </p>
+      </header>
+
+      <div className="space-y-8">
+        <SettingsCard>
+          <WorkspaceSection />
+          <AppearanceSection />
+          <LanguageSection />
+          {accountAvailable && <AccountSection />}
+          {showMembers && (
+            <SettingsRow
+              icon={Users}
+              title={t("org:members.navLabel")}
+              description={t("settings:index.rows.members")}
+              value={t("settings:index.values.membersCount", {
+                count: memberCount,
+              })}
+              onClick={() => onSelect("members")}
+            />
+          )}
+        </SettingsCard>
+
+        <SettingsCard title={t("settings:index.groups.context")}>
+          <SettingsRow
+            icon={FileText}
+            title={t("settings:nav.workspaceContext")}
+            description={t("settings:index.rows.workspaceContext")}
+            value={contextValue("workspace")}
+            onClick={() => onSelect("workspaceContext")}
+          />
+          <SettingsRow
+            icon={User}
+            title={t("settings:nav.userContext")}
+            description={t("settings:index.rows.userContext")}
+            value={contextValue("user")}
+            onClick={() => onSelect("userContext")}
+          />
+        </SettingsCard>
+
+        <SettingsCard title={t("settings:index.groups.support")}>
+          <SettingsRow
+            icon={Keyboard}
+            title={t("settings:nav.shortcuts")}
+            description={t("settings:index.rows.shortcuts")}
+            onClick={() => onSelect("shortcuts")}
+          />
+          <SettingsRow
+            icon={Bug}
+            title={t("settings:nav.reportBug")}
+            description={t("settings:index.rows.reportBug")}
+            onClick={() => onSelect("reportBug")}
+          />
+        </SettingsCard>
+
+        <SettingsCard>
+          <DangerSection />
+        </SettingsCard>
+      </div>
+
+      <footer className="mt-10 px-1">
+        <button
+          type="button"
+          onClick={() => void handleVersionClick()}
+          className="cursor-pointer text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          {t("settings:version", { version: __APP_VERSION__ })}
+        </button>
+      </footer>
+    </div>
+  );
+}

--- a/app/src/components/settings/settings-row.tsx
+++ b/app/src/components/settings/settings-row.tsx
@@ -1,0 +1,141 @@
+import { ChevronRight, type LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+interface SettingsCardProps {
+  /** Group heading shown above the card. Omit for the lead group. */
+  title?: string;
+  children: ReactNode;
+}
+
+/** A titled group of settings rows, rendered as one hairline-divided card. */
+export function SettingsCard({ title, children }: SettingsCardProps) {
+  return (
+    <section>
+      {title && (
+        <h2 className="mb-3 px-1 text-base font-semibold text-foreground">
+          {title}
+        </h2>
+      )}
+      <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-card">
+        {children}
+      </div>
+    </section>
+  );
+}
+
+function Leading({
+  icon: Icon,
+  leading,
+  destructive,
+}: {
+  icon?: LucideIcon;
+  leading?: ReactNode;
+  destructive?: boolean;
+}) {
+  if (leading) return <span className="shrink-0">{leading}</span>;
+  if (!Icon) return null;
+  return (
+    <Icon
+      className={`size-[18px] shrink-0 ${
+        destructive ? "text-destructive" : "text-muted-foreground"
+      }`}
+    />
+  );
+}
+
+interface RowTextProps {
+  title: string;
+  description?: string;
+  destructive?: boolean;
+}
+
+function RowText({ title, description, destructive }: RowTextProps) {
+  return (
+    <span className="min-w-0 flex-1">
+      <span
+        className={`block truncate text-sm font-medium ${
+          destructive ? "text-destructive" : "text-foreground"
+        }`}
+      >
+        {title}
+      </span>
+      {description && (
+        <span className="block truncate text-xs text-muted-foreground">
+          {description}
+        </span>
+      )}
+    </span>
+  );
+}
+
+interface SettingsRowProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  /** Right-aligned current value, e.g. "2 members". */
+  value?: string;
+  destructive?: boolean;
+  onClick: () => void;
+}
+
+/** A navigable settings entry: bare icon, title, description, value, chevron. */
+export function SettingsRow({
+  icon,
+  title,
+  description,
+  value,
+  destructive,
+  onClick,
+}: SettingsRowProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="group flex w-full items-center gap-3 px-4 py-3.5 text-left transition-colors hover:bg-secondary/60"
+    >
+      <Leading icon={icon} destructive={destructive} />
+      <RowText
+        title={title}
+        description={description}
+        destructive={destructive}
+      />
+      {value && (
+        <span className="shrink-0 text-sm text-muted-foreground">{value}</span>
+      )}
+      <ChevronRight className="size-4 shrink-0 text-muted-foreground/70 transition-colors group-hover:text-muted-foreground" />
+    </button>
+  );
+}
+
+interface SettingsControlRowProps {
+  icon?: LucideIcon;
+  /** Replaces the icon (e.g. an avatar). */
+  leading?: ReactNode;
+  title: string;
+  description?: string;
+  destructive?: boolean;
+  /** The inline control rendered on the right (input, toggle, select, button). */
+  children: ReactNode;
+}
+
+/** A settings entry resolved in place: bare icon, title, and a right-side control. */
+export function SettingsControlRow({
+  icon,
+  leading,
+  title,
+  description,
+  destructive,
+  children,
+}: SettingsControlRowProps) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3">
+      <Leading icon={icon} leading={leading} destructive={destructive} />
+      <RowText
+        title={title}
+        description={description}
+        destructive={destructive}
+      />
+      <div className="shrink-0">{children}</div>
+    </div>
+  );
+}

--- a/app/src/components/settings/settings-view.tsx
+++ b/app/src/components/settings/settings-view.tsx
@@ -1,47 +1,19 @@
 import { Spinner } from "@houston-ai/core";
-import {
-  Bug,
-  FileText,
-  Folder,
-  Keyboard,
-  User,
-  UserCircle,
-  Users,
-} from "lucide-react";
-import { useMemo, useState } from "react";
+import { ChevronLeft } from "lucide-react";
+import { useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { canSeeMembers } from "../../lib/org-roles";
-import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
-import {
-  type SidebarSectionItem,
-  SidebarSectionNav,
-} from "../shared/sidebar-section-nav";
-
-type SettingsSectionId =
-  | "account"
-  | "members"
-  | "workspace"
-  | "workspaceContext"
-  | "userContext"
-  | "phone"
-  | "shortcuts"
-  | "reportBug";
-
-import { AccountSection, useAccountAvailable } from "./sections/account";
-import { AppearanceSection } from "./sections/appearance";
-import { ConnectPhoneSection } from "./sections/connect-phone";
-import { DangerSection } from "./sections/danger";
-import { LanguageSection } from "./sections/language";
+import { useAccountAvailable } from "./sections/account";
 import { MembersSection } from "./sections/members";
 import { ReportBugSection } from "./sections/report-bug";
 import { ShortcutsSection } from "./sections/shortcuts";
-import { WorkspaceSection } from "./sections/workspace";
 import {
   UserContextSection,
   WorkspaceContextSection,
 } from "./sections/workspace-context";
+import { SettingsIndex, type SettingsSectionId } from "./settings-index";
 
 export function SettingsView() {
   const { t } = useTranslation(["settings", "common", "org"]);
@@ -49,58 +21,7 @@ export function SettingsView() {
   const accountAvailable = useAccountAvailable();
   const { capabilities } = useCapabilities();
   const showMembers = canSeeMembers(capabilities);
-  const addToast = useUIStore((s) => s.addToast);
-
-  async function handleVersionClick() {
-    try {
-      await navigator.clipboard.writeText(__APP_VERSION__);
-      addToast({ title: t("settings:toasts.versionCopied") });
-    } catch (err) {
-      addToast({
-        title: t("settings:toasts.versionCopyFailed"),
-        description: err instanceof Error ? err.message : String(err),
-        variant: "error",
-      });
-    }
-  }
-
-  const items = useMemo<SidebarSectionItem<SettingsSectionId>[]>(() => {
-    const list: SidebarSectionItem<SettingsSectionId>[] = [];
-    if (accountAvailable) {
-      list.push({
-        id: "account",
-        label: t("settings:nav.account"),
-        icon: User,
-      });
-    }
-    if (showMembers) {
-      list.push({
-        id: "members",
-        label: t("org:members.navLabel"),
-        icon: Users,
-      });
-    }
-    list.push(
-      { id: "workspace", label: t("settings:nav.workspace"), icon: Folder },
-      {
-        id: "workspaceContext",
-        label: t("settings:nav.workspaceContext"),
-        icon: FileText,
-      },
-      {
-        id: "userContext",
-        label: t("settings:nav.userContext"),
-        icon: UserCircle,
-      },
-      { id: "shortcuts", label: t("settings:nav.shortcuts"), icon: Keyboard },
-      { id: "reportBug", label: t("settings:nav.reportBug"), icon: Bug },
-    );
-    return list;
-  }, [accountAvailable, showMembers, t]);
-
-  const [active, setActive] = useState<SettingsSectionId>(
-    accountAvailable ? "account" : "workspace",
-  );
+  const [active, setActive] = useState<SettingsSectionId | null>(null);
 
   if (!currentWorkspace) {
     return (
@@ -110,51 +31,40 @@ export function SettingsView() {
     );
   }
 
-  // If the active id was hidden (e.g., signed out), fall back to a visible one.
-  const activeVisible = items.some((i) => i.id === active)
-    ? active
-    : items[0].id;
+  if (active === null) {
+    return (
+      <div className="flex-1 overflow-y-auto">
+        <SettingsIndex
+          accountAvailable={accountAvailable}
+          showMembers={showMembers}
+          onSelect={setActive}
+        />
+      </div>
+    );
+  }
 
   return (
-    <div className="flex-1 flex min-h-0">
-      <SidebarSectionNav
-        ariaLabel={t("settings:title")}
-        items={items}
-        active={activeVisible}
-        onSelect={setActive}
-        footer={
-          <button
-            type="button"
-            onClick={() => void handleVersionClick()}
-            className="text-xs text-muted-foreground px-2.5 hover:text-foreground transition-colors cursor-pointer"
-          >
-            {t("settings:version", { version: __APP_VERSION__ })}
-          </button>
-        }
-      />
+    <div className="flex-1 flex min-h-0 flex-col">
+      <div className="shrink-0 px-8 pt-8 pb-2">
+        <button
+          type="button"
+          onClick={() => setActive(null)}
+          className="inline-flex cursor-pointer items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ChevronLeft className="size-4" />
+          {t("settings:title")}
+        </button>
+      </div>
       <div className="flex-1 overflow-y-auto">
-        {activeVisible === "workspaceContext" ? (
+        {active === "workspaceContext" ? (
           <WorkspaceContextSection />
-        ) : activeVisible === "userContext" ? (
+        ) : active === "userContext" ? (
           <UserContextSection />
         ) : (
-          <div className="mx-auto max-w-xl px-8 py-10">
-            {activeVisible === "account" && <AccountSection />}
-            {activeVisible === "members" && <MembersSection />}
-            {activeVisible === "workspace" && (
-              <div className="space-y-10">
-                <WorkspaceSection />
-                <LanguageSection />
-                <AppearanceSection />
-                <DangerSection />
-              </div>
-            )}
-            {/* Connect-phone section kept but intentionally not in the nav above:
-                the entry point was removed (HOU-473) so it's unreachable today.
-                Re-add the `phone` nav item to surface it again. */}
-            {activeVisible === "phone" && <ConnectPhoneSection />}
-            {activeVisible === "shortcuts" && <ShortcutsSection />}
-            {activeVisible === "reportBug" && <ReportBugSection />}
+          <div className="mx-auto max-w-xl px-8 pb-10">
+            {active === "members" && <MembersSection />}
+            {active === "shortcuts" && <ShortcutsSection />}
+            {active === "reportBug" && <ReportBugSection />}
           </div>
         )}
       </div>

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -1,13 +1,12 @@
 {
   "title": "Settings",
   "nav": {
-    "account": "Account",
-    "workspace": "Workspace",
     "workspaceContext": "Workspace context",
-    "userContext": "User context",
-    "phone": "Connect phone",
+    "userContext": "Your context",
+    "language": "Language",
     "shortcuts": "Keyboard shortcuts",
-    "reportBug": "Report bug"
+    "reportBug": "Report bug",
+    "danger": "Delete workspace"
   },
   "account": {
     "title": "Account",
@@ -15,8 +14,7 @@
     "fallbackName": "Signed in"
   },
   "workspace": {
-    "title": "Workspace",
-    "nameLabel": "Name"
+    "title": "Workspace name"
   },
   "workspaceContext": {
     "emptyTitle": "Tell every agent about this workspace",
@@ -98,5 +96,24 @@
     "providerSwitched": "Switched to {{provider}} ({{model}})",
     "versionCopied": "Version copied",
     "versionCopyFailed": "Couldn't copy version"
+  },
+  "index": {
+    "subtitle": "Manage your workspace and account.",
+    "groups": {
+      "context": "Context",
+      "support": "Support"
+    },
+    "rows": {
+      "members": "People who can use your agents",
+      "workspaceContext": "What every agent knows about this workspace",
+      "userContext": "What every agent knows about you",
+      "shortcuts": "Run Houston without the mouse",
+      "reportBug": "Something broke? Tell us"
+    },
+    "values": {
+      "set": "Set",
+      "membersCount_one": "{{count}} member",
+      "membersCount_other": "{{count}} members"
+    }
   }
 }

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -1,13 +1,12 @@
 {
   "title": "Configuración",
   "nav": {
-    "account": "Cuenta",
-    "workspace": "Espacio de trabajo",
     "workspaceContext": "Contexto del espacio",
-    "userContext": "Contexto del usuario",
-    "phone": "Conectar celular",
+    "userContext": "Tu contexto",
+    "language": "Idioma",
     "shortcuts": "Atajos de teclado",
-    "reportBug": "Reportar bug"
+    "reportBug": "Reportar bug",
+    "danger": "Eliminar espacio"
   },
   "account": {
     "title": "Cuenta",
@@ -15,8 +14,7 @@
     "fallbackName": "Sesión iniciada"
   },
   "workspace": {
-    "title": "Espacio de trabajo",
-    "nameLabel": "Nombre"
+    "title": "Nombre del espacio"
   },
   "workspaceContext": {
     "emptyTitle": "Cuéntale a todo agente sobre este espacio",
@@ -98,5 +96,24 @@
     "providerSwitched": "Cambiaste a {{provider}} ({{model}})",
     "versionCopied": "Versión copiada",
     "versionCopyFailed": "No se pudo copiar la versión"
+  },
+  "index": {
+    "subtitle": "Administra tu espacio de trabajo y tu cuenta.",
+    "groups": {
+      "context": "Contexto",
+      "support": "Soporte"
+    },
+    "rows": {
+      "members": "Personas que pueden usar tus agentes",
+      "workspaceContext": "Lo que cada agente sabe sobre este espacio",
+      "userContext": "Lo que cada agente sabe sobre ti",
+      "shortcuts": "Usa Houston sin el mouse",
+      "reportBug": "¿Algo falló? Cuéntanos"
+    },
+    "values": {
+      "set": "Definido",
+      "membersCount_one": "{{count}} miembro",
+      "membersCount_other": "{{count}} miembros"
+    }
   }
 }

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -1,13 +1,12 @@
 {
   "title": "Configurações",
   "nav": {
-    "account": "Conta",
-    "workspace": "Espaço de trabalho",
     "workspaceContext": "Contexto do espaço",
-    "userContext": "Contexto do usuário",
-    "phone": "Conectar celular",
+    "userContext": "Seu contexto",
+    "language": "Idioma",
     "shortcuts": "Atalhos de teclado",
-    "reportBug": "Reportar bug"
+    "reportBug": "Reportar bug",
+    "danger": "Excluir espaço"
   },
   "account": {
     "title": "Conta",
@@ -15,8 +14,7 @@
     "fallbackName": "Sessão iniciada"
   },
   "workspace": {
-    "title": "Espaço de trabalho",
-    "nameLabel": "Nome"
+    "title": "Nome do espaço"
   },
   "workspaceContext": {
     "emptyTitle": "Conte para todo agente sobre este espaço",
@@ -98,5 +96,24 @@
     "providerSwitched": "Mudou para {{provider}} ({{model}})",
     "versionCopied": "Versão copiada",
     "versionCopyFailed": "Não foi possível copiar a versão"
+  },
+  "index": {
+    "subtitle": "Gerencie seu espaço de trabalho e sua conta.",
+    "groups": {
+      "context": "Contexto",
+      "support": "Suporte"
+    },
+    "rows": {
+      "members": "Pessoas que podem usar seus agentes",
+      "workspaceContext": "O que todo agente sabe sobre este espaço",
+      "userContext": "O que todo agente sabe sobre você",
+      "shortcuts": "Use o Houston sem o mouse",
+      "reportBug": "Algo quebrou? Conte para nós"
+    },
+    "values": {
+      "set": "Definido",
+      "membersCount_one": "{{count}} membro",
+      "membersCount_other": "{{count}} membros"
+    }
   }
 }

--- a/knowledge-base/design-system.md
+++ b/knowledge-base/design-system.md
@@ -230,3 +230,21 @@ Capabilities: `core:window:allow-set-theme` + `…allow-start-dragging`.
 blur, `--ht-card-rest`, the canvas tokens). Dark mode is the loved baseline —
 when adjusting, scope changes to light (`:root`) and pin dark
 (`[data-theme="dark"]`) so it stays put.
+
+**Settings (`app/src/components/settings/`)** — no sidebar. The landing is the
+**overview** (`settings-index.tsx`); its title uses the integrations page font
+(`text-[28px] font-normal`). Two row primitives (`settings-row.tsx`), both with a
+**bare icon** (no tile/background): `SettingsControlRow` resolves a setting in
+place (bare icon · title · right-side control) and `SettingsRow` navigates (adds
+a value + chevron). Simple settings are inline control rows rendered straight
+into the overview — the section files ARE the controls: `WorkspaceSection`
+(name input), `AppearanceSection` (theme pills), `LanguageSection` (locale
+select), `AccountSection` (avatar + sign out), `DangerSection` (red delete +
+confirm). Only the heavier sections navigate: workspace/user context editors,
+members, shortcuts, bug report. Selecting a nav row sets `SettingsView`'s
+`active` (the section-id union lives in `settings-index.tsx`); the two context
+editors render full-width, the rest in a centered `max-w-xl` column, all under a
+`← Settings` back bar. `active === null` is the overview. Account/members rows
+appear only when `accountAvailable` / `showMembers`. Version string = overview
+footer. Nav-row copy + group titles + `Set`/count values live under
+`settings.index.*` / `settings.nav.*` in the three locale files.


### PR DESCRIPTION
## What

Refactors the Settings screen from a hard-to-navigate sidebar + pane into a single **overview**.

- **Inline, no drill-in** for simple settings — resolved in place as control rows:
  - **Workspace name** (input, was "General"), **Appearance** (Light/Dark), **Language** (select), **Account** (avatar + Sign out), **Delete workspace** (button + confirm)
- **Drill-in** (behind a `← Settings` back bar) only for the heavier sections: workspace/your context editors, members, keyboard shortcuts, report bug
- **Bare icons** — dropped the rounded tile/background; icons sit bare in `muted-foreground`
- **Title** now uses the integrations-page font (`text-[28px] font-normal`) and reads **"Settings"**

## Files

- `settings-row.tsx` — `SettingsRow` (nav) + new `SettingsControlRow` (inline; avatar via `leading`)
- `sections/{workspace,appearance,language,account,danger}.tsx` — presentation → inline control rows (logic unchanged)
- `settings-index.tsx` (new) — the overview; owns the trimmed `SettingsSectionId`
- `settings-view.tsx` — overview ⇄ detail switch; `SidebarSectionNav` no longer used here (still used by `job-description-tab`)
- i18n en/es/pt — `workspace.title` → "Workspace name"; pruned now-unused keys
- KB `design-system.md` updated

## Verify

`pnpm -r typecheck` (all 22 projects, via pre-commit), web shim-parity, `pnpm check-locales` in sync, Biome clean.

Note: `ConnectPhoneSection` (parked/unreachable since HOU-473) lost its last import in an earlier step of this refactor — the feature files are left intact, not deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)