### PR TITLE
chore: add pnpm start (install then dev)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "check:parity": "node scripts/check-parity.mjs",
     "prepare": "husky || true",
     "test": "pnpm -r --if-present --no-bail test",
+    "start": "pnpm install && pnpm dev",
     "dev": "mprocs",
     "dev:host": "HOUSTON_HOST_TOKEN=devtoken HOUSTON_HOST_PORT=4318 pnpm --filter @houston/host dev",
     "dev:app": "cd app && VITE_NEW_ENGINE_URL=http://127.0.0.1:4318 VITE_NEW_ENGINE_TOKEN=devtoken VITE_HOSTED_ENGINE_URL= pnpm tauri dev"


### PR DESCRIPTION
## What
Adds a `start` script to the root `package.json`:

```json
"start": "pnpm install && pnpm dev"
```

## Why
Fresh worktrees (created by the `clh`/`cxh` task launcher) have no `node_modules`. A single `pnpm start` now installs dependencies and then launches the dev environment (`mprocs`), so you can go from a clean worktree to a running app with one command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)