### PR TITLE
feat(app): glass modals + reorganize new-agent picker

### DIFF
--- a/app/src/components/ai-hub/modal-shell.tsx
+++ b/app/src/components/ai-hub/modal-shell.tsx
@@ -1,10 +1,10 @@
 /**
  * The redesign's modal primitive. Built on the app's shared Radix Dialog
  * (`@houston-ai/core`) so focus-trap, ESC and aria come for free; the panel is
- * a three-row grid (fixed header, scrolling body, thin footer) on a SOLID
- * `bg-background` surface (opaque white in light, solid near-black in dark — no
- * glass, no page bleed-through) with `ht-shadow-modal` for float. Core's
- * DialogContent renders the ONE scrim (`bg-black/40`); we don't stack a second.
+ * a three-row grid (fixed header, scrolling body, thin footer) on the shared
+ * glass modal surface (`bg-card` — translucent + frosted blur, so the aurora
+ * canvas bleeds through in dark mode) with `ht-shadow-modal` for float. Core's
+ * DialogContent renders the ONE scrim (`bg-black/25`); we don't stack a second.
  * The calm entry (fade + a small 0.98→1 scale, reduced-motion honored) lives in
  * `.ai-hub-modal-surface` (futuristic.css). Presentational and props-only:
  * titles/labels arrive already translated (parents own i18n).
@@ -54,7 +54,7 @@ export function ModalShell({
       <DialogContent
         showCloseButton={false}
         className={cn(
-          "grid max-h-[84vh] min-h-[60vh] w-[min(620px,calc(100vw-2.5rem))] max-w-none grid-rows-[auto_1fr_auto] gap-0 overflow-hidden rounded-2xl border-0 bg-background p-0 ht-shadow-modal ai-hub-modal-surface sm:max-w-none",
+          "grid max-h-[84vh] min-h-[60vh] w-[min(620px,calc(100vw-2.5rem))] max-w-none grid-rows-[auto_1fr_auto] gap-0 overflow-hidden rounded-2xl border-0 bg-card p-0 ht-shadow-modal ai-hub-modal-surface sm:max-w-none",
           className,
         )}
       >

--- a/app/src/components/shell/agent-picker-step.tsx
+++ b/app/src/components/shell/agent-picker-step.tsx
@@ -1,5 +1,5 @@
 import { Input } from "@houston-ai/core";
-import { Gift, Search } from "lucide-react";
+import { Search } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
@@ -45,9 +45,13 @@ export function AgentPickerStep({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agents, t, i18n.language]);
 
-  const filteredAgents = useMemo(
+  // The "From library" grid: every catalog agent EXCEPT the blank starter
+  // (it has its own "From scratch" card in the Create section) and Houston's
+  // own already-installed copies, narrowed by the active search query.
+  const libraryAgents = useMemo(
     () =>
       agents.filter((d) => {
+        if (d.config.id === "blank") return false;
         if (d.source === "installed" && d.config.author === "Houston") {
           return false;
         }
@@ -57,90 +61,88 @@ export function AgentPickerStep({
     [agents, query, localizedAgents],
   );
 
-  const reorderedAgents = useMemo(() => {
-    if (!query) {
-      const result = [...filteredAgents];
-      const paIndex = result.findIndex(
-        (a) => a.config.id === "personal-assistant",
-      );
-      // Pin personal-assistant to array index 1 (grid slot 1) so it sits right
-      // after the SkillCard tile, which renders outside this map at grid slot 0.
-      if (paIndex >= 0 && paIndex !== 1) {
-        const [pa] = result.splice(paIndex, 1);
-        result.splice(1, 0, pa);
-      }
-      return result;
-    }
-    return filteredAgents;
-  }, [filteredAgents, query]);
-
   return (
     <>
-      <div className="shrink-0 px-6 pb-4">
-        <div className="relative">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
-          <Input
-            value={search}
-            onChange={(e) => onSearchChange(e.target.value)}
-            placeholder={t("store.searchPlaceholder")}
-            className="pl-9 rounded-full bg-secondary border-border focus:bg-background"
+      {/* Create — three uniform cards, pinned above the library. These are the
+          ways to make a NEW agent, always one click away (search below only
+          narrows the library). */}
+      <div className="shrink-0 px-6 pb-5">
+        <h3 className="text-sm font-medium text-foreground mb-3">
+          {t("newAgent.createSection")}
+        </h3>
+        <div className="grid grid-cols-1 md:grid-cols-3 gap-3">
+          <SkillCard
+            image="pencil"
+            title={t("newAgent.fromScratchCard")}
+            description={t("newAgent.fromScratchDescription")}
+            className="min-h-[128px]"
+            onClick={() => onSelect("blank")}
+          />
+          <SkillCard
+            image="rocket"
+            title={t("aiAssist.cardTitle")}
+            description={t("aiAssist.cardDescription")}
+            className="min-h-[128px]"
+            onClick={onCreateWithAi}
+          />
+          <SkillCard
+            image="wrapped-gift"
+            title={t("portable:newAgent.fromFriendCard")}
+            description={t("portable:newAgent.fromFriendDescription")}
+            className="min-h-[128px]"
+            onClick={() => {
+              setCreateOpen(false);
+              setImportOpen(true);
+            }}
           />
         </div>
       </div>
 
-      <div
-        data-tour-target="agentStore"
-        className="flex-1 min-h-0 overflow-y-auto px-6 pb-6"
-      >
-        <button
-          type="button"
-          onClick={() => {
-            setCreateOpen(false);
-            setImportOpen(true);
-          }}
-          className="w-full mb-3 rounded-xl border border-border/40 bg-secondary px-4 py-3 text-left hover:bg-accent transition-colors flex items-start gap-3"
+      {/* From library — its own header carries the search box; only the grid
+          below it scrolls, so the section title + search stay pinned. */}
+      <div className="flex-1 min-h-0 flex flex-col border-t border-border/50 px-6 pt-4 pb-6">
+        <div className="shrink-0 flex flex-col gap-3 pb-3 sm:flex-row sm:items-center sm:justify-between">
+          <h3 className="text-sm font-medium text-foreground">
+            {t("newAgent.librarySection")}
+          </h3>
+          <div className="relative sm:w-64">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
+            <Input
+              value={search}
+              onChange={(e) => onSearchChange(e.target.value)}
+              placeholder={t("store.searchPlaceholder")}
+              className="pl-9 rounded-full bg-secondary border-border"
+            />
+          </div>
+        </div>
+
+        <div
+          data-tour-target="agentStore"
+          className="flex-1 min-h-0 overflow-y-auto"
         >
-          <Gift className="size-5 text-foreground mt-0.5 shrink-0" />
-          <div className="min-w-0">
-            <p className="text-sm font-medium text-foreground">
-              {t("portable:newAgent.fromFriendCard")}
-            </p>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {t("portable:newAgent.fromFriendDescription")}
-            </p>
-          </div>
-        </button>
-        {filteredAgents.length > 0 ? (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-            {!query && (
-              <SkillCard
-                image="rocket"
-                title={t("aiAssist.cardTitle")}
-                description={t("aiAssist.cardDescription")}
-                className="min-h-[132px]"
-                onClick={onCreateWithAi}
-              />
-            )}
-            {reorderedAgents.map((def) => {
-              const display = localizedAgents.get(def.config.id);
-              return (
-                <AgentCard
-                  key={def.config.id}
-                  config={def.config}
-                  title={display?.name}
-                  description={display?.description}
-                  onSelect={onSelect}
-                />
-              );
-            })}
-          </div>
-        ) : (
-          <div className="flex items-center justify-center py-16">
-            <p className="text-sm text-muted-foreground">
-              {t("store.noResults")}
-            </p>
-          </div>
-        )}
+          {libraryAgents.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+              {libraryAgents.map((def) => {
+                const display = localizedAgents.get(def.config.id);
+                return (
+                  <AgentCard
+                    key={def.config.id}
+                    config={def.config}
+                    title={display?.name}
+                    description={display?.description}
+                    onSelect={onSelect}
+                  />
+                );
+              })}
+            </div>
+          ) : (
+            <div className="flex items-center justify-center py-16">
+              <p className="text-sm text-muted-foreground">
+                {t("store.noResults")}
+              </p>
+            </div>
+          )}
+        </div>
       </div>
     </>
   );

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -169,7 +169,7 @@
     "dismissAction": "Dismiss update for now"
   },
   "store": {
-    "searchPlaceholder": "Search the store...",
+    "searchPlaceholder": "Search the library...",
     "noResults": "No agents match your search"
   },
   "naming": {
@@ -181,7 +181,11 @@
     "createAgent": "Create Agent"
   },
   "newAgent": {
-    "dialogTitle": "New agent"
+    "dialogTitle": "New agent",
+    "createSection": "Create",
+    "librarySection": "From library",
+    "fromScratchCard": "From scratch",
+    "fromScratchDescription": "A blank agent with no instructions or actions. Build it your way."
   },
   "aiAssist": {
     "brainLabel": "Set up with",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -169,7 +169,7 @@
     "dismissAction": "Descartar actualización por ahora"
   },
   "store": {
-    "searchPlaceholder": "Buscar en la tienda...",
+    "searchPlaceholder": "Buscar en la biblioteca...",
     "noResults": "Ningún agente coincide con tu búsqueda"
   },
   "naming": {
@@ -181,7 +181,11 @@
     "createAgent": "Crear agente"
   },
   "newAgent": {
-    "dialogTitle": "Nuevo agente"
+    "dialogTitle": "Nuevo agente",
+    "createSection": "Crear",
+    "librarySection": "De la biblioteca",
+    "fromScratchCard": "Desde cero",
+    "fromScratchDescription": "Un agente en blanco, sin instrucciones ni acciones. Constrúyelo a tu manera."
   },
   "aiAssist": {
     "brainLabel": "Configurar con",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -169,7 +169,7 @@
     "dismissAction": "Dispensar atualização por enquanto"
   },
   "store": {
-    "searchPlaceholder": "Buscar na loja...",
+    "searchPlaceholder": "Buscar na biblioteca...",
     "noResults": "Nenhum agente corresponde à sua busca"
   },
   "naming": {
@@ -181,7 +181,11 @@
     "createAgent": "Criar agente"
   },
   "newAgent": {
-    "dialogTitle": "Novo agente"
+    "dialogTitle": "Novo agente",
+    "createSection": "Criar",
+    "librarySection": "Da biblioteca",
+    "fromScratchCard": "Do zero",
+    "fromScratchDescription": "Um agente em branco, sem instruções ou ações. Construa do seu jeito."
   },
   "aiAssist": {
     "brainLabel": "Configurar com",

--- a/knowledge-base/design-system.md
+++ b/knowledge-base/design-system.md
@@ -215,6 +215,15 @@ second rounded card with a gutter gap.
 "glitter" over solid surfaces): gutter `#eef1f7`, screen `#fff`, cards `#f4f6fc`,
 cool blue/indigo border. Clean and futuristic by restraint, not decoration.
 
+**Modals are glass, not slabs.** All modal primitives — `DialogContent`
+(`ui/core/components/dialog.tsx`), `AlertDialogContent`, `SheetContent`, and the
+AI-Hub `ModalShell` — render on the translucent **`bg-card`** surface (frosted
+blur + top sheen from futuristic.css), NOT opaque `bg-background`, so the aurora
+canvas bleeds through in dark mode like the kanban columns (`bg-secondary`). The
+scrims are deliberately light for the same reason: Dialog overlay `bg-black/25`,
+Alert/Sheet `bg-black/35` (down from /40–/50). Change the surface centrally in
+those four primitives — no modal should hardcode its own background.
+
 **Primary button** — flat and sober (`[data-variant="default"]:is(button, a)`),
 not a glossy slab. Kanban resting cards use one token, `--ht-card-rest` (`#2c2c2b`
 dark / cool light), unified across resting + running + needs-you.

--- a/packages/web/e2e/agents.spec.ts
+++ b/packages/web/e2e/agents.spec.ts
@@ -12,7 +12,7 @@ test("creates an agent and shows it in the sidebar", async ({ page }) => {
   await expect(page.getByText("Your Agents")).toBeVisible();
 
   await page.getByRole("button", { name: "New agent" }).click();
-  await page.getByText("Start from scratch").click();
+  await page.getByText("From scratch").click();
 
   await page.getByPlaceholder("e.g. Project Alpha").fill("Marketing Bot");
   await page.getByRole("button", { name: "Create Agent" }).click();
@@ -33,7 +33,7 @@ test("switches between two agents", async ({ page }) => {
 
   // Create a second agent; it becomes selected, with an empty board of its own.
   await page.getByRole("button", { name: "New agent" }).click();
-  await page.getByText("Start from scratch").click();
+  await page.getByText("From scratch").click();
   await page.getByPlaceholder("e.g. Project Alpha").fill("Research Bot");
   await page.getByRole("button", { name: "Create Agent" }).click();
 

--- a/ui/core/src/components/alert-dialog.tsx
+++ b/ui/core/src/components/alert-dialog.tsx
@@ -34,7 +34,7 @@ function AlertDialogOverlay({
     <AlertDialogPrimitive.Overlay
       data-slot="alert-dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/35 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className,
       )}
       {...props}
@@ -56,7 +56,7 @@ function AlertDialogContent({
         data-slot="alert-dialog-content"
         data-size={size}
         className={cn(
-          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-background p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
+          "group/alert-dialog-content fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border bg-card p-6 shadow-lg duration-200 data-[size=sm]:max-w-xs data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 data-[size=default]:sm:max-w-lg",
           className,
         )}
         {...props}

--- a/ui/core/src/components/dialog.tsx
+++ b/ui/core/src/components/dialog.tsx
@@ -39,7 +39,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/40 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/25 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className,
       )}
       {...props}
@@ -64,7 +64,10 @@ function DialogContent({
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-5 rounded-2xl border border-border/50 bg-background p-6 shadow-[0_4px_4px_rgba(0,0,0,0.04),0_4px_80px_8px_rgba(0,0,0,0.04),0_0_1px_rgba(0,0,0,0.62)] dark:shadow-[0_4px_4px_rgba(0,0,0,0.1),0_4px_80px_8px_rgba(0,0,0,0.2),0_0_1px_rgba(255,255,255,0.1)] duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
+          // Glass surface: translucent `bg-card` (+ frosted blur & top sheen
+          // from futuristic.css) so the aurora canvas bleeds through in dark
+          // mode, instead of a flat opaque `bg-background` panel.
+          "fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-5 rounded-2xl border border-border/50 bg-card p-6 shadow-[0_4px_4px_rgba(0,0,0,0.04),0_4px_80px_8px_rgba(0,0,0,0.04),0_0_1px_rgba(0,0,0,0.62)] dark:shadow-[0_4px_4px_rgba(0,0,0,0.1),0_4px_80px_8px_rgba(0,0,0,0.2),0_0_1px_rgba(255,255,255,0.1)] duration-200 outline-none data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95 sm:max-w-lg",
           className,
         )}
         {...props}

--- a/ui/core/src/components/sheet.tsx
+++ b/ui/core/src/components/sheet.tsx
@@ -34,7 +34,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        "fixed inset-0 z-50 bg-black/35 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
         className,
       )}
       {...props}
@@ -58,7 +58,7 @@ function SheetContent({
       <SheetPrimitive.Content
         data-slot="sheet-content"
         className={cn(
-          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          "fixed z-50 flex flex-col gap-4 bg-card shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
           side === "right" &&
             "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
           side === "left" &&


### PR DESCRIPTION
## What

Two fixes to the create-new-agent menu, plus a system-wide modal polish.

### 1. Glass modals (all modals)
Modals rendered on opaque `bg-background`, reading as a flat solid slab in dark mode instead of the futuristic glass surface. Switched every modal **primitive** to the translucent `bg-card` surface (frosted blur + top sheen) and softened the scrims so the aurora canvas bleeds through, matching the kanban columns:

| Primitive | Change |
|---|---|
| `ui/core/…/dialog.tsx` | `bg-background`→`bg-card`, scrim `/40`→`/25` |
| `ui/core/…/alert-dialog.tsx` | `bg-background`→`bg-card`, scrim `/50`→`/35` |
| `ui/core/…/sheet.tsx` | `bg-background`→`bg-card`, scrim `/50`→`/35` |
| `app/…/ai-hub/modal-shell.tsx` | `bg-background`→`bg-card` |

Centralized — no modal hardcodes its own background, so this recolors every dialog/sheet/confirm in the app.

### 2. Reorganized the new-agent picker
- **Create** — pinned at top, always visible: three uniform cards (From scratch · Create with AI · From a friend). The blank starter is now the "From scratch" card, filtered out of the library grid.
- **From library** — its own header carries the search box (rescoped to the library); only the agent grid scrolls.

## Verify
- Biome clean · full-workspace typecheck (pre-commit) · `check-locales` in sync (en/es/pt)
- Playwright `agents.spec.ts` 3/3 (create-from-scratch flow intact)
- Visually verified dark + light (new-agent dialog) and a dark delete-confirm (glass bleed confirmed)

## Blast radius
Touches shared `ui/core` modal primitives → **all** modals are now glass. Intended ("true of all modals"). className-only, no API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)