### PR TITLE
fix(ai-hub): dark-mode surfaces, scroll-aware header, modal scroll, "AI Models"

### DIFF
--- a/app/src/components/ai-hub/ai-hub-view.tsx
+++ b/app/src/components/ai-hub/ai-hub-view.tsx
@@ -75,9 +75,13 @@ export function AiHubView() {
         </div>
       ) : (
         <>
-          {/* Fixed masthead: the hero title + tabs never scroll away. Solid
-              `bg-background` so the scrolling list below never bleeds through. */}
-          <div className="shrink-0 bg-background">
+          {/* Fixed masthead: the hero title + tabs never scroll away. No
+              background of its own — it's a non-overlapping flex sibling of the
+              scroll region below (nothing renders behind it), so it inherits the
+              `.canvas-screen` glass. An opaque `bg-background` here painted a
+              solid slab that broke the frosted-glass screen in dark mode (the
+              aurora bleeds through everywhere else). */}
+          <div className="shrink-0">
             <div className="mx-auto flex max-w-5xl flex-col gap-6 px-8 pt-10 pb-4">
               <HubHero modelCount={catalog.modelCount} />
               <AiHubTabs

--- a/app/src/components/ai-hub/modal-shell.tsx
+++ b/app/src/components/ai-hub/modal-shell.tsx
@@ -76,7 +76,12 @@ export function ModalShell({
             ) : null}
           </div>
         )}
-        <div className="overflow-y-auto">{children}</div>
+        {/* `min-h-0` lets this 1fr grid row shrink below its content so it
+            becomes the SINGLE bounded scroll area. Without it the row's default
+            `min-height: auto` grows to the content, the modal overflows its
+            `max-h`, and the inner scroll never engages — the tall provider model
+            lists then read as a second, janky scroll. */}
+        <div className="min-h-0 overflow-y-auto">{children}</div>
         {footer ? (
           <div className="border-t border-border px-5 py-3">{footer}</div>
         ) : null}

--- a/app/src/components/ai-hub/models-browser.tsx
+++ b/app/src/components/ai-hub/models-browser.tsx
@@ -1,8 +1,10 @@
 /**
  * The reusable model browser: the FULL controls + table the Models tab shows.
  * A search Input plus the "AI provider" / "Good at" dropdowns (DirectoryFilters)
- * AND the ledger's column header share ONE sticky, solid `bg-background` unit so
- * neither disappears on scroll — the rows below pass cleanly BEHIND it. The body
+ * AND the ledger's column header share ONE sticky unit so neither disappears on
+ * scroll — the rows below pass cleanly BEHIND it. The bar is transparent at rest
+ * and fades in a frosted-glass `bg-popover` (the blur masks the rows; an opaque
+ * fill would slab over the theme) only once it pins on scroll. The body
  * (`ModelsLedger`) scrolls horizontally when narrow (e.g. inside the provider
  * modal); an `onScroll` handler mirrors that `scrollLeft` onto the sticky header
  * track so the pinned header stays column-aligned with the rows. Owns the
@@ -19,6 +21,7 @@ import { Search } from "lucide-react";
 import {
   useCallback,
   useDeferredValue,
+  useEffect,
   useMemo,
   useRef,
   useState,
@@ -63,6 +66,37 @@ export function ModelsBrowser({
     if (track) track.scrollLeft = event.currentTarget.scrollLeft;
   }, []);
 
+  // Scroll-aware chrome: the sticky bar is transparent while it sits at rest and
+  // only fades in its frosted `bg-popover` (+ divider) once rows scroll BEHIND
+  // it. A zero-height sentinel at the bar's natural top marks when the bar has
+  // pinned — it stays put while the sentinel scrolls up past the scroll
+  // container's top edge. Self-contained so both mounts (the Models tab's scroll
+  // region and the provider modal's body) work without threading a scroll ref.
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const [stuck, setStuck] = useState(false);
+  useEffect(() => {
+    const sentinel = sentinelRef.current;
+    if (!sentinel) return;
+    let scroller = sentinel.parentElement;
+    while (scroller) {
+      const overflowY = getComputedStyle(scroller).overflowY;
+      if (overflowY === "auto" || overflowY === "scroll") break;
+      scroller = scroller.parentElement;
+    }
+    const update = () => {
+      const top = scroller ? scroller.getBoundingClientRect().top : 0;
+      setStuck(sentinel.getBoundingClientRect().top < top - 0.5);
+    };
+    update();
+    const target: HTMLElement | Window = scroller ?? window;
+    target.addEventListener("scroll", update, { passive: true });
+    window.addEventListener("resize", update);
+    return () => {
+      target.removeEventListener("scroll", update);
+      window.removeEventListener("resize", update);
+    };
+  }, []);
+
   const results = useMemo(() => {
     const byFilter = filterModels(models, {
       lab: provider === "all" ? undefined : provider,
@@ -81,9 +115,24 @@ export function ModelsBrowser({
 
   return (
     <div className={cn("flex flex-col", className)}>
-      {/* Controls + column header as ONE solid sticky unit: neither disappears
-          on scroll, and the rows below pass cleanly BEHIND it (no bleed). */}
-      <div className="sticky top-0 z-20 border-border border-b bg-background">
+      {/* Sentinel marking the bar's natural top (see the stuck effect above). */}
+      <div ref={sentinelRef} aria-hidden className="h-0" />
+      {/* Controls + column header as ONE sticky unit: neither disappears on
+          scroll, and the rows below pass cleanly BEHIND it (no bleed). At rest
+          the bar is fully transparent; once pinned it fades in the frosted-glass
+          `bg-popover` surface (blur masks the scrolling rows) — just the fill, no
+          framing lines: no bottom divider, and `shadow-none!` kills the inset top
+          sheen `bg-popover` carries in the futuristic theme. An opaque
+          `bg-background` slab here broke the aurora glass screen in dark mode,
+          and a permanent fill looked heavy at rest. `rounded-2xl` makes the fill
+          read as a floating panel (the bg + its backdrop blur follow the
+          radius). */}
+      <div
+        className={cn(
+          "sticky top-0 z-20 transition-colors",
+          stuck ? "rounded-2xl bg-popover shadow-none!" : "",
+        )}
+      >
         <div className="flex flex-wrap items-center gap-3 pt-1 pb-3">
           <div className="relative min-w-[200px] flex-1">
             <Search className="pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground" />

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -1,6 +1,6 @@
 {
   "hero": {
-    "title": "AI models",
+    "title": "AI Models",
     "subtitle": "Use your ChatGPT, Claude, or Copilot subscription, or connect {{models}}+ models from every major lab with your own keys.",
     "subtitleFew": "Use your ChatGPT, Claude, or Copilot subscription, or connect models from every major lab with your own keys."
   },

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -1,7 +1,7 @@
 {
   "sidebar": {
     "missionControl": "Mission Control",
-    "aiModels": "AI models",
+    "aiModels": "AI Models",
     "integrations": "Integrations",
     "settings": "Settings",
     "yourAgents": "Your Agents",


### PR DESCRIPTION
## What

Fixes several dark-mode / scroll rough edges on the **AI Models** hub (Providers + Models tabs).

- **Masthead slab (dark mode).** The hero+tabs masthead painted an opaque `bg-background` over the translucent `.canvas-screen` glass, reading as a wrong solid block. Removed — it's a non-overlapping flex sibling of the scroll region, so it inherits the glass with no bleed-through.
- **Scroll-aware controls bar.** The sticky search + dropdowns + column-header bar was another opaque `bg-background` slab. Now transparent at rest, fading in a **rounded frosted-glass `bg-popover` panel** (the blur masks the rows scrolling behind it) only once it pins. A zero-height sentinel detects the stuck state; no framing lines (no bottom divider, `shadow-none!` kills the theme's inset top sheen).
- **Provider modal double scroll.** The "See more" modal body (`ModalShell`) lacked `min-h-0` on its `1fr` grid row, so tall model lists grew the row past `max-h-[84vh]` instead of scrolling — a janky nested scroll. Added `min-h-0` for one clean bounded scroll (matches every other dialog in the app).
- **Label capitalization.** "AI models" → **"AI Models"** (hero title + sidebar). es/pt already read "Modelos de IA".

## Files
- `app/src/components/ai-hub/ai-hub-view.tsx`
- `app/src/components/ai-hub/models-browser.tsx`
- `app/src/components/ai-hub/modal-shell.tsx`
- `app/src/locales/en/ai-hub.json`, `app/src/locales/en/shell.json`

## Test
- `pnpm exec biome check` — clean on all touched files
- `pnpm -r typecheck` — passes (pre-commit hook)
- `pnpm check-locales` — es/pt in sync
- Manual: verify in dark mode — masthead + list share the glass, the controls bar fades in a rounded frosted panel on scroll with no border lines, and the provider modal scrolls once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)