### PR TITLE
fix(providers): Claude Connect opened a docs page instead of the setup-token dialog

### DIFF
--- a/app/src/components/ai-hub/provider-connection-dialogs.tsx
+++ b/app/src/components/ai-hub/provider-connection-dialogs.tsx
@@ -49,6 +49,7 @@ export function ProviderConnectionDialogs({
         provider={loginDialog?.provider ?? null}
         url={loginDialog?.url ?? null}
         userCode={loginDialog?.userCode ?? null}
+        instructions={loginDialog?.instructions ?? null}
         onClose={onCloseLoginDialog}
       />
 

--- a/app/src/components/onboarding/missions/provider-login.tsx
+++ b/app/src/components/onboarding/missions/provider-login.tsx
@@ -193,6 +193,7 @@ export function ProviderLoginMission({
           provider={dialog ? (provider ?? null) : null}
           url={dialog?.url ?? null}
           userCode={dialog?.userCode}
+          instructions={dialog?.instructions ?? null}
           onClose={closeDialog}
         />
       </div>

--- a/app/src/components/onboarding/missions/use-provider-login-events.ts
+++ b/app/src/components/onboarding/missions/use-provider-login-events.ts
@@ -11,6 +11,8 @@ import { shouldOpenLoginUrlDirectly } from "../../shell/provider-login-url";
 export interface LoginDialogState {
   url: string;
   userCode: string | null;
+  /** Setup-token paste-flow steps (Claude/Anthropic). Absent for other flows. */
+  instructions?: string | null;
 }
 
 /**
@@ -72,6 +74,9 @@ export function useProviderLoginEvents(opts: {
           shouldOpenLoginUrlDirectly({
             isDesktop: osIsTauri(),
             userCode: ev.data.user_code,
+            // Claude/Anthropic setup-token: url is docs-only, so never auto-open
+            // — fall through to the paste dialog below.
+            authCode: ev.data.auth_code,
           })
         ) {
           // Open the browser and step aside: pi's own in-process loopback
@@ -90,6 +95,7 @@ export function useProviderLoginEvents(opts: {
         setDialog((current) => ({
           url: ev.data.url,
           userCode: ev.data.user_code ?? current?.userCode ?? null,
+          instructions: ev.data.instructions,
         }));
         return;
       }

--- a/app/src/components/shell/provider-login-dialog.tsx
+++ b/app/src/components/shell/provider-login-dialog.tsx
@@ -22,8 +22,14 @@ import { providerLoginUrlHost } from "./provider-login-url";
  * engine surfaces the sign-in URL via a `ProviderLoginUrl` WS event; this
  * dialog shows it plus the per-provider completion step:
  *
- *  - Paste-back (Claude): a text input relays the verification code to
- *    `POST /v1/providers/:name/login/code` (written to the CLI's stdin).
+ *  - Setup-token paste (Claude/Anthropic): the event carries `instructions`
+ *    (e.g. "Run `claude setup-token`…, paste the token — starts with
+ *    sk-ant-oat01") and `url` is only a docs REFERENCE, not a sign-in page.
+ *    We render the instructions prominently above the paste field and demote
+ *    the url to a small optional "Reference" link — never auto-opened. This is
+ *    the ONE flow that shows on desktop too (see `shouldOpenLoginUrlDirectly`).
+ *  - Paste-back (Claude, no instructions): a text input relays the verification
+ *    code to `POST /v1/providers/:name/login/code` (written to the CLI's stdin).
  *  - Device-grant (codex `--device-auth`): when the event carries
  *    `userCode`, we render <ProviderDeviceCode> with that one-time code
  *    for the user to enter on the provider's verification page. The CLI
@@ -31,16 +37,21 @@ import { providerLoginUrlHost } from "./provider-login-url";
  *    dialog waits for `ProviderLoginComplete` (handled by the parent) to
  *    auto-close.
  *
- * Desktop no longer shows this dialog: there the picker/settings handler opens
- * the user's browser directly for the co-located loopback flow (see
- * `shouldOpenLoginUrlDirectly`), so the dialog is now a remote / headless-only
- * affordance (issue #453).
+ * Apart from the setup-token flow above, desktop opens the user's browser
+ * directly for the co-located loopback flow (see `shouldOpenLoginUrlDirectly`),
+ * so for those the dialog is a remote / headless-only affordance (issue #453).
  */
 interface Props {
   provider: ProviderInfo | null;
   url: string | null;
   /** Device-grant one-time code (codex). Null/absent = paste-back flow. */
   userCode?: string | null;
+  /**
+   * Setup-token paste-flow steps (Claude/Anthropic). When present, `url` is a
+   * docs reference (not a sign-in page): we show these steps prominently and
+   * demote the url to a small "Reference" link. Absent for other flows.
+   */
+  instructions?: string | null;
   onClose: () => void;
 }
 
@@ -48,6 +59,7 @@ export function ProviderLoginDialog({
   provider,
   url,
   userCode,
+  instructions,
   onClose,
 }: Props) {
   const { t } = useTranslation("providers");
@@ -83,6 +95,12 @@ export function ProviderLoginDialog({
   // Friendly destination shown in place of the raw URL. Null when the URL
   // isn't parseable; we then just omit the hint.
   const host = providerLoginUrlHost(url);
+
+  // Setup-token paste flow (Claude/Anthropic): `url` is a docs reference, not a
+  // sign-in page. We surface the runtime's step-by-step `instructions` above the
+  // paste field and demote the url to a small "Reference" link, rather than the
+  // Open/Copy/reveal button row meant for a real OAuth URL.
+  const isAuthCode = !!instructions;
 
   const handleCopyUrl = async () => {
     try {
@@ -130,67 +148,94 @@ export function ProviderLoginDialog({
             {t("providerLogin.title", { name: provider.name })}
           </DialogTitle>
           <DialogDescription>
-            {userCode
-              ? t("providerLogin.deviceDescription", { name: provider.name })
-              : t("providerLogin.description", { name: provider.name })}
+            {isAuthCode
+              ? t("providerLogin.authCodeDescription", { name: provider.name })
+              : userCode
+                ? t("providerLogin.deviceDescription", { name: provider.name })
+                : t("providerLogin.description", { name: provider.name })}
           </DialogDescription>
         </DialogHeader>
 
         <div className="space-y-4">
-          {host && (
-            <p className="text-[13px] text-muted-foreground">
-              {t("providerLogin.destinationHint", { host })}
-            </p>
-          )}
-
-          <div className="flex flex-wrap gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="gap-1.5"
-              onClick={() => void tauriSystem.openUrl(url)}
-            >
-              <ExternalLink className="size-3.5" />
-              {t("providerLogin.openUrl")}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="gap-1.5"
-              onClick={handleCopyUrl}
-            >
-              <Copy className="size-3.5" />
-              {t("providerLogin.copyUrl")}
-            </Button>
-            <Button
-              type="button"
-              variant="ghost"
-              size="sm"
-              className="gap-1.5"
-              aria-expanded={showUrl}
-              aria-controls="provider-login-url"
-              onClick={() => setShowUrl((v) => !v)}
-            >
-              {showUrl ? (
-                <EyeOff className="size-3.5" />
-              ) : (
-                <Eye className="size-3.5" />
+          {isAuthCode ? (
+            <>
+              {/* Setup-token steps from the runtime, shown prominently above
+                  the paste field. The docs `url` is only a small reference
+                  link (opened on click) — never auto-opened. */}
+              <p className="rounded-md border bg-muted/40 p-3 text-[13px] whitespace-pre-line">
+                {instructions}
+              </p>
+              {host && (
+                <Button
+                  type="button"
+                  variant="link"
+                  size="sm"
+                  className="h-auto gap-1.5 p-0 text-muted-foreground"
+                  onClick={() => void tauriSystem.openUrl(url)}
+                >
+                  <ExternalLink className="size-3.5" />
+                  {t("providerLogin.reference")}
+                </Button>
               )}
-              {showUrl
-                ? t("providerLogin.hideUrl")
-                : t("providerLogin.showUrl")}
-            </Button>
-          </div>
+            </>
+          ) : (
+            <>
+              {host && (
+                <p className="text-[13px] text-muted-foreground">
+                  {t("providerLogin.destinationHint", { host })}
+                </p>
+              )}
 
-          {showUrl && (
-            <div
-              id="provider-login-url"
-              className="max-h-24 select-all overflow-y-auto rounded-md border bg-muted/40 p-3 text-[12px] break-all font-mono"
-            >
-              {url}
-            </div>
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={() => void tauriSystem.openUrl(url)}
+                >
+                  <ExternalLink className="size-3.5" />
+                  {t("providerLogin.openUrl")}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="gap-1.5"
+                  onClick={handleCopyUrl}
+                >
+                  <Copy className="size-3.5" />
+                  {t("providerLogin.copyUrl")}
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  className="gap-1.5"
+                  aria-expanded={showUrl}
+                  aria-controls="provider-login-url"
+                  onClick={() => setShowUrl((v) => !v)}
+                >
+                  {showUrl ? (
+                    <EyeOff className="size-3.5" />
+                  ) : (
+                    <Eye className="size-3.5" />
+                  )}
+                  {showUrl
+                    ? t("providerLogin.hideUrl")
+                    : t("providerLogin.showUrl")}
+                </Button>
+              </div>
+
+              {showUrl && (
+                <div
+                  id="provider-login-url"
+                  className="max-h-24 select-all overflow-y-auto rounded-md border bg-muted/40 p-3 text-[12px] break-all font-mono"
+                >
+                  {url}
+                </div>
+              )}
+            </>
           )}
 
           {userCode ? (

--- a/app/src/components/shell/provider-login-fallback.tsx
+++ b/app/src/components/shell/provider-login-fallback.tsx
@@ -17,6 +17,7 @@ interface FallbackDialogState {
   provider: ProviderInfo;
   url: string;
   userCode: string | null;
+  instructions?: string | null;
 }
 
 /**
@@ -60,6 +61,9 @@ export function ProviderLoginFallback() {
           claimed,
           isDesktop: osIsTauri(),
           userCode: ev.data.user_code,
+          // Claude/Anthropic setup-token: url is docs-only, so resolve to the
+          // paste dialog, never an auto-open.
+          authCode: ev.data.auth_code,
         });
         if (action === "ignore") return;
         const prov = PROVIDERS.find((p) => p.id === ev.data.provider);
@@ -88,6 +92,7 @@ export function ProviderLoginFallback() {
             userCode:
               ev.data.user_code ??
               (current?.provider.id === prov.id ? current.userCode : null),
+            instructions: ev.data.instructions,
           }));
         }
         return;
@@ -108,6 +113,7 @@ export function ProviderLoginFallback() {
       provider={dialog.provider}
       url={dialog.url}
       userCode={dialog.userCode}
+      instructions={dialog.instructions ?? null}
       onClose={() => setDialog(null)}
     />
   );

--- a/app/src/components/shell/provider-login-surface.ts
+++ b/app/src/components/shell/provider-login-surface.ts
@@ -36,14 +36,19 @@ export function providerLoginSurfaceClaimed(): boolean {
  * What the global fallback should do with a `ProviderLoginUrl` event:
  * nothing when a dedicated surface owns the event; otherwise open the
  * browser directly on desktop loopback flows (no code to show), or surface
- * the dialog for device-code / remote flows. Mirrors the dedicated
- * handlers' own branch (`shouldOpenLoginUrlDirectly`).
+ * the dialog for device-code / remote / setup-token-paste flows. Mirrors the
+ * dedicated handlers' own branch (`shouldOpenLoginUrlDirectly`).
+ *
+ * `authCode` is the Claude/Anthropic setup-token paste flow: its `url` is a
+ * docs reference, not a page to auto-open, so it ALWAYS resolves to "dialog"
+ * even on a co-located desktop.
  */
 export function providerLoginFallbackAction(opts: {
   claimed: boolean;
   isDesktop: boolean;
   userCode: string | null | undefined;
+  authCode?: boolean;
 }): "ignore" | "open" | "dialog" {
   if (opts.claimed) return "ignore";
-  return opts.isDesktop && !opts.userCode ? "open" : "dialog";
+  return opts.isDesktop && !opts.userCode && !opts.authCode ? "open" : "dialog";
 }

--- a/app/src/components/shell/provider-login-url.ts
+++ b/app/src/components/shell/provider-login-url.ts
@@ -43,12 +43,18 @@ export function providerLoginUrlHost(url: string): string | null {
  * user can read it, and remote / headless web clients always use the dialog
  * because their runtime can't reach a local browser. Mirrors the runtime's own
  * loopback-vs-headless split (see the runtime's `codexLoginMethod`).
+ *
+ * `authCode` is the Claude/Anthropic setup-token paste flow: the event's `url`
+ * is only a docs reference, not a page to sign in on, and the user finishes by
+ * pasting a token. It ALWAYS needs the dialog — never auto-open — so an
+ * `authCode` event returns false even on a co-located desktop.
  */
 export function shouldOpenLoginUrlDirectly(opts: {
   isDesktop: boolean;
   userCode: string | null | undefined;
+  authCode?: boolean;
 }): boolean {
-  return opts.isDesktop && !opts.userCode;
+  return opts.isDesktop && !opts.userCode && !opts.authCode;
 }
 
 /**

--- a/app/src/components/shell/provider-picker.tsx
+++ b/app/src/components/shell/provider-picker.tsx
@@ -55,6 +55,7 @@ export function ProviderPicker({ onSelect }: Props) {
     provider: ProviderInfo;
     url: string;
     userCode: string | null;
+    instructions?: string | null;
   } | null>(null);
   // The paste-a-key dialog for API-key providers (OpenCode Zen / Go).
   const [apiKeyDialog, setApiKeyDialog] = useState<ProviderInfo | null>(null);
@@ -179,6 +180,9 @@ export function ProviderPicker({ onSelect }: Props) {
           shouldOpenLoginUrlDirectly({
             isDesktop: osIsTauri(),
             userCode: ev.data.user_code,
+            // Claude/Anthropic setup-token: url is docs-only, so never auto-open
+            // — fall through to the paste dialog below.
+            authCode: ev.data.auth_code,
           })
         ) {
           // Desktop: the runtime is co-located, so a loopback OAuth flow
@@ -208,6 +212,7 @@ export function ProviderPicker({ onSelect }: Props) {
             userCode:
               ev.data.user_code ??
               (current?.provider.id === prov.id ? current.userCode : null),
+            instructions: ev.data.instructions,
           }));
         }
       } else if (ev.type === "ProviderLoginComplete") {
@@ -411,6 +416,7 @@ export function ProviderPicker({ onSelect }: Props) {
         provider={loginDialog?.provider ?? null}
         url={loginDialog?.url ?? null}
         userCode={loginDialog?.userCode ?? null}
+        instructions={loginDialog?.instructions ?? null}
         onClose={() => setLoginDialog(null)}
       />
 

--- a/app/src/hooks/provider-connections/types.ts
+++ b/app/src/hooks/provider-connections/types.ts
@@ -20,13 +20,17 @@ export type ProvidersT = (
 /**
  * OAuth relay dialog state for remote/headless engines. The engine surfaces the
  * fallback sign-in URL via `ProviderLoginUrl`; `userCode` is set for codex's
- * device-grant flow (null for Claude's paste-back). Desktop never opens this
- * dialog (it opens the browser directly — see `shouldOpenLoginUrlDirectly`).
+ * device-grant flow (null for Claude's paste-back). Desktop opens the browser
+ * directly for a co-located loopback flow (see `shouldOpenLoginUrlDirectly`),
+ * but the Claude/Anthropic setup-token paste flow (`instructions` present)
+ * always shows this dialog so the user can read the steps and paste the token.
  */
 export interface ProviderLoginDialogState {
   provider: ProviderInfo;
   url: string;
   userCode: string | null;
+  /** Setup-token paste-flow steps (Claude/Anthropic). Absent for other flows. */
+  instructions?: string | null;
 }
 
 /** Which provider card is mid-flight, and for which action. Only one at a time. */

--- a/app/src/hooks/provider-connections/use-provider-login-events.ts
+++ b/app/src/hooks/provider-connections/use-provider-login-events.ts
@@ -70,6 +70,9 @@ export function useProviderLoginEvents({
           shouldOpenLoginUrlDirectly({
             isDesktop: osIsTauri(),
             userCode: ev.data.user_code,
+            // Claude/Anthropic setup-token: url is docs-only, so never auto-open
+            // — fall through to the paste dialog below.
+            authCode: ev.data.auth_code,
           })
         ) {
           // Desktop: the runtime is co-located, so a loopback OAuth flow
@@ -97,6 +100,7 @@ export function useProviderLoginEvents({
             userCode:
               ev.data.user_code ??
               (current?.provider.id === prov.id ? current.userCode : null),
+            instructions: ev.data.instructions,
           }));
         }
       } else if (ev.type === "ProviderLoginComplete") {

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -37,6 +37,8 @@
   "providerLogin": {
     "title": "Finish signing in to {{name}}",
     "description": "Open the sign-in page in your browser, complete sign-in, then paste the verification code back here.",
+    "authCodeDescription": "Paste a setup token to finish connecting {{name}}.",
+    "reference": "Reference",
     "openUrl": "Open URL",
     "copyUrl": "Copy URL",
     "urlCopied": "URL copied to clipboard",

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -37,6 +37,8 @@
   "providerLogin": {
     "title": "Termina de iniciar sesión en {{name}}",
     "description": "Abre la página de inicio de sesión en tu navegador, completa el inicio de sesión y luego pega aquí el código de verificación.",
+    "authCodeDescription": "Pega un token de configuración para terminar de conectar {{name}}.",
+    "reference": "Referencia",
     "openUrl": "Abrir URL",
     "copyUrl": "Copiar URL",
     "urlCopied": "URL copiada al portapapeles",

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -37,6 +37,8 @@
   "providerLogin": {
     "title": "Termine de entrar em {{name}}",
     "description": "Abra a página de login no seu navegador, finalize o login e cole aqui o código de verificação.",
+    "authCodeDescription": "Cole um token de configuração para terminar de conectar {{name}}.",
+    "reference": "Referência",
     "openUrl": "Abrir URL",
     "copyUrl": "Copiar URL",
     "urlCopied": "URL copiada para a área de transferência",

--- a/app/tests/provider-login-fallback.test.ts
+++ b/app/tests/provider-login-fallback.test.ts
@@ -91,4 +91,18 @@ describe("providerLoginFallbackAction", () => {
       "dialog",
     );
   });
+
+  it("shows the dialog for the Claude/Anthropic setup-token paste flow (auth_code), even on desktop", () => {
+    // The event's url is a docs reference, not a sign-in page — auto-opening it
+    // would drop the user on docs and skip the paste box (the reported bug).
+    strictEqual(
+      providerLoginFallbackAction({
+        claimed: false,
+        isDesktop: true,
+        userCode: null,
+        authCode: true,
+      }),
+      "dialog",
+    );
+  });
 });

--- a/app/tests/provider-login-url.test.ts
+++ b/app/tests/provider-login-url.test.ts
@@ -97,6 +97,38 @@ describe("shouldOpenLoginUrlDirectly", () => {
       true,
     );
   });
+
+  it("keeps the dialog for the Claude/Anthropic setup-token paste flow (auth_code) — its url is docs, not a sign-in page", () => {
+    // Desktop must NOT auto-open the docs URL: the user needs the paste dialog.
+    strictEqual(
+      shouldOpenLoginUrlDirectly({
+        isDesktop: true,
+        userCode: null,
+        authCode: true,
+      }),
+      false,
+    );
+    // Web behaves the same (it always dialogs anyway).
+    strictEqual(
+      shouldOpenLoginUrlDirectly({
+        isDesktop: false,
+        userCode: null,
+        authCode: true,
+      }),
+      false,
+    );
+  });
+
+  it("still opens directly on desktop for a loopback flow that is explicitly not auth_code", () => {
+    strictEqual(
+      shouldOpenLoginUrlDirectly({
+        isDesktop: true,
+        userCode: null,
+        authCode: false,
+      }),
+      true,
+    );
+  });
 });
 
 // The Codex loopback relay drives ChatGPT sign-in for openai on a Tauri desktop

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -316,12 +316,28 @@ a long-lived `sk-ant-oat01…` token) and PASTES that token into Houston. A cons
 path) and never spawns the `claude` binary for login (it is an Ink TUI that needs
 a real TTY and deadlocks on the runtime's piped stdio).
 
-**Wire shape is unchanged:** `startLogin("anthropic")` emits the same
+**Wire shape:** `startLogin("anthropic")` emits a
 `{ kind:"auth_code", url, instructions }` LoginInfo and reuses `completeLogin`'s
-paste promise, so the existing connect UX (`connect.tsx` /
-`provider-login-dialog.tsx`) works verbatim — the pasted value is a token, not an
-OAuth code. `url` is Anthropic's CLI-reference help page, shown next to the paste
-box.
+paste promise — the pasted value is a token, not an OAuth code. `url` is
+Anthropic's CLI-reference **docs** page, NOT a sign-in page.
+
+**The `auth_code` event flag (the "opens docs instead of paste box" fix).** The
+app adapter (`engine-adapter/client.ts`, both emit paths) forwards
+`auth_code: info.kind === "auth_code"` and the runtime's `instructions` on the
+`ProviderLoginUrl` bus event (`ui/core` `HoustonEvent`, additive fields). This
+is load-bearing: without it a setup-token event (paste flow, docs url, no
+`user_code`) is indistinguishable from a co-located loopback `url`, so on desktop
+`shouldOpenLoginUrlDirectly({isDesktop,userCode})` returned true and the app
+**auto-opened the docs cli-reference page and skipped the paste dialog**. Now
+`shouldOpenLoginUrlDirectly` / `providerLoginFallbackAction` take an `authCode`
+flag and always resolve to the **dialog** for `auth_code` (never auto-open), and
+every `ProviderLoginUrl` consumer (`use-provider-login-events.ts` in
+`hooks/provider-connections` + `onboarding/missions`, `provider-picker.tsx`,
+`provider-login-fallback.tsx`) passes it through. `provider-login-dialog.tsx`
+renders the `instructions` prominently above the paste field and demotes the docs
+`url` to a small optional "Reference" link. The codex loopback relay
+(`shouldUseCodexLoopback`, openai-only) and codex device-code paths are
+unaffected — anthropic is never openai and never carries a `user_code`.
 
 **What's stored + why the shape matters:** the token is persisted under
 `"anthropic"` as pi's **`api_key`** PiCred variant

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -1005,6 +1005,11 @@ export class HoustonClient {
         provider: name,
         url,
         user_code: userCode,
+        // `auth_code` (headless Claude setup-token): `url` is only docs, so the
+        // handler must show the paste dialog, never auto-open it. `instructions`
+        // is the runtime's paste-step copy the dialog renders above the field.
+        auth_code: info.kind === "auth_code",
+        instructions: info.kind === "auth_code" ? info.instructions : undefined,
       });
       this.watchLoginCompletion(pid, name);
       return;
@@ -1035,6 +1040,11 @@ export class HoustonClient {
         provider: old,
         url: info.url,
         user_code: null,
+        // Setup-token paste flow (Claude): the url is docs-only, so the handler
+        // shows the paste dialog instead of opening it. `instructions` carries
+        // the runtime's paste-step copy; absent for the loopback `url` kind.
+        auth_code: info.kind === "auth_code",
+        instructions: info.kind === "auth_code" ? info.instructions : undefined,
       });
     }
     void this.pollProviderConnect(agentId, pid, old);

--- a/packages/web/tests/provider-login-auth-code.test.ts
+++ b/packages/web/tests/provider-login-auth-code.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+/**
+ * The Claude/Anthropic connect uses the sanctioned setup-token flow: the
+ * runtime returns a `{ kind: "auth_code", url: <docs cli-reference>,
+ * instructions }` LoginInfo where the url is only a docs reference and the user
+ * finishes by pasting a token. The adapter MUST forward both `auth_code: true`
+ * and `instructions` on the `ProviderLoginUrl` bus event so the app shows the
+ * paste dialog (with the steps) instead of auto-opening the docs page — the
+ * reported bug. A co-located loopback `url` login stays `auth_code: false`.
+ */
+
+const startLogin = vi.fn();
+
+vi.mock("@houston/runtime-client", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("@houston/runtime-client")>();
+  return {
+    ...actual,
+    HoustonEngineClient: class {
+      startLogin = startLogin;
+      // watchLoginCompletion polls this; empty providers keeps it a no-op.
+      authStatus = async () => ({ providers: [] });
+    },
+  };
+});
+
+import { bus } from "../src/engine-adapter/bus";
+import { HoustonClient } from "../src/engine-adapter/client";
+
+beforeEach(() => {
+  // Freeze the login-completion poll interval so it never fires during the test.
+  vi.useFakeTimers();
+  startLogin.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+function client() {
+  return new HoustonClient({ baseUrl: "http://host", token: "t" });
+}
+
+function captureLoginUrl(): Array<{
+  type: string;
+  data: Record<string, unknown>;
+}> {
+  const events: Array<{ type: string; data: Record<string, unknown> }> = [];
+  bus.on((e) =>
+    events.push(e as { type: string; data: Record<string, unknown> }),
+  );
+  return events;
+}
+
+test("anthropic setup-token: ProviderLoginUrl carries auth_code:true + instructions, no user_code", async () => {
+  startLogin.mockResolvedValue({
+    kind: "auth_code",
+    url: "https://docs.claude.com/en/docs/claude-code/cli-reference",
+    instructions:
+      "Run `claude setup-token` in your terminal, then paste the token it prints (starts with sk-ant-oat01).",
+  });
+
+  const events = captureLoginUrl();
+  await client().providerLogin("anthropic");
+
+  const login = events.find((e) => e.type === "ProviderLoginUrl");
+  expect(login).toBeDefined();
+  expect(login?.data.provider).toBe("anthropic");
+  expect(login?.data.auth_code).toBe(true);
+  expect(login?.data.instructions).toMatch(/claude setup-token/);
+  // Paste flow, not device-grant.
+  expect(login?.data.user_code).toBeNull();
+});
+
+test("co-located loopback url: ProviderLoginUrl stays auth_code:false with no instructions", async () => {
+  startLogin.mockResolvedValue({
+    kind: "url",
+    url: "https://auth.openai.com/authorize?client_id=abc",
+  });
+
+  const events = captureLoginUrl();
+  await client().providerLogin("openai");
+
+  const login = events.find((e) => e.type === "ProviderLoginUrl");
+  expect(login).toBeDefined();
+  expect(login?.data.auth_code).toBe(false);
+  expect(login?.data.instructions).toBeUndefined();
+});

--- a/ui/core/src/types.ts
+++ b/ui/core/src/types.ts
@@ -177,7 +177,20 @@ export type HoustonEvent =
       // one-time code the user enters on the provider's verification page
       // (no paste-back). The relay may emit twice for one device sign-in:
       // first URL-only, then again with the code.
-      data: { provider: string; url: string; user_code: string | null };
+      //
+      // `auth_code` is true for the setup-token paste flow (Claude/Anthropic):
+      // `url` is only a docs reference, NOT a page to auto-open, and the user
+      // finishes by pasting a token. The UI MUST show the paste dialog (never
+      // auto-open the URL) — see `shouldOpenLoginUrlDirectly`. `instructions`
+      // carries the runtime's step-by-step copy to render above the paste
+      // field (absent for the loopback `url` and device-code flows).
+      data: {
+        provider: string;
+        url: string;
+        user_code: string | null;
+        auth_code?: boolean;
+        instructions?: string;
+      };
     }
   | {
       type: "ProviderLoginComplete";


### PR DESCRIPTION
## Bug (user-reported)

Clicking **Connect** for Claude/Anthropic opened the Claude Code docs (`cli-reference`) instead of the connect flow — the paste box never appeared.

## Cause

Anthropic connect is the setup-token flow: the runtime returns `{kind:"auth_code", url:<docs>, instructions:"run claude setup-token…"}` — the `url` is just documentation, the user pastes a token. But the `ProviderLoginUrl` bus event **dropped the `kind`**, so `auth_code` was indistinguishable from a co-located loopback `url`. On desktop, `shouldOpenLoginUrlDirectly(isDesktop && !userCode)` returned true and auto-opened the docs URL, skipping the dialog.

## Fix

Thread the login `kind` + `instructions` through the event and route `auth_code` to the paste dialog:

- `ui/core` `ProviderLoginUrl` gains optional `auth_code` + `instructions` (additive event-contract change); the web adapter sets them in both emit paths (device-code branch untouched).
- `shouldOpenLoginUrlDirectly` / `providerLoginFallbackAction` return **dialog** (not open) when `auth_code` is set; all four login consumers (AI-hub hook, global fallback, picker, onboarding) pass the flag.
- `provider-login-dialog` renders the runtime instructions prominently ("run `claude setup-token`, paste the `sk-ant-oat01` token") and demotes the docs URL to a small optional **Reference** link — never auto-opened.

Codex loopback relay + device-code paths untouched (Anthropic is never `openai` and carries no `user_code`). en/es/pt strings added, no em dashes.

## Verification

- app `tsgo` + `node --test` (569 pass), `houston-web` tests (64 pass, incl. a new adapter test asserting `auth_code:true` + instructions), `check-locales`, full `pnpm typecheck`, `pnpm check`, `pnpm check:boundaries` — all green.

Follow-up to the provider-auth overhaul (#636/#648/#650).

🤖 Generated with [Claude Code](https://claude.com/claude-code)