### PR TITLE
fix(ios): absorb main drift — agent-qualified chat scope, queued VM, status parity

### DIFF
--- a/mobile/PARITY-SETTINGS.md
+++ b/mobile/PARITY-SETTINGS.md
@@ -1,0 +1,142 @@
+# iOS Parity Spec — Settings · AI Models · Integrations (hosted mode)
+
+> Extracted from houston/ + cloud/ on 2026-07-05 (citations were file:line-verified at extraction).
+> Companion to `mobile/PARITY.md`; same rules: en copy is authoritative (es/pt mirror keys),
+> update via the client-architecture procedures when desktop changes.
+
+## 0. Architecture facts that gate everything
+
+- iOS data path: Swift → SDK bridge bundle → `@houston/sdk` → `@houston/runtime-client`. iOS does
+  NOT use `ui/engine-client` (desktop/web front door).
+- Per-agent URL scoping: `sdk.ts clientFor(agentId)` → `${baseUrl}/agents/<id>/…`; flat calls go to
+  `${baseUrl}/…`. The injected fetch carries the Supabase JWT.
+- **Provider credentials are per-agent-pod** in hosted mode (`/auth/*`, `/providers`, `/settings`
+  are per-agent). There is NO global "connect Claude once".
+- **Integrations are the opposite**: gateway-owned, user-scoped (`caller.sub`), shared across the
+  user's agents; per-agent grants gate which agent may use each connected app.
+
+## 1. Settings surface (desktop: SettingsView/SettingsIndex)
+
+Header "Settings" (`settings:title`); subtitle "Manage your workspace and account."
+Rows/groups in desktop order (iOS ports all marked ✅):
+
+| Element | Copy key | Behavior | iOS |
+|---|---|---|---|
+| Workspace name | `settings:workspace.title` | rename → engine; toast `settings:toasts.workspaceRenamed` | ✅ |
+| Appearance | `settings:appearance.title` (+ `.light`/`.dark`) | DEVICE-LOCAL theme (no wire) | ✅ local |
+| Language | `settings:nav.language` | en/es/pt; persists `PATCH /workspaces/:id/locale {locale}` + local change; toast `common:language.toastChanged` | ✅ |
+| Account | `settings:account.title`; button `settings:account.signOut` "Sign out"; `.fallbackName` "Signed in" | avatar (`user_metadata.avatar_url`) + name (full_name→name→email) + email; Sign out = signOut(), NO confirm dialog | ✅ sign-out lives here |
+| Members | `org:members.navLabel` + `settings:index.rows.members` | only when `canSeeMembers(capabilities)` | ⚠ org only |
+| Group "Context" | `settings:index.groups.context` | | ✅ |
+| Workspace context | `settings:nav.workspaceContext` (+ value "Set" `.values.set`) | drill-in editor | ✅ |
+| Your context | `settings:nav.userContext` | drill-in editor | ✅ |
+| Group "Support" | `settings:index.groups.support` | | ✅ |
+| Report bug | `settings:nav.reportBug` "Report bug" / "Something broke? Tell us" (`settings:reportBug.*`) | message + recent logs | ✅ adapt log capture |
+| Danger zone | `settings:dangerZone.*` ("Danger zone", "Delete workspace", confirm keys) | deleteWorkspace; blocked if last (`.createAnotherFirst`) | ✅ destructive |
+| Version footer | `settings:version` "Version {{version}}" | tap copies; toasts `.versionCopied`/`.versionCopyFailed` | ✅ |
+
+SKIP on iOS: Keyboard shortcuts; Connect phone / QR pairing (legacy tunnel, dead); updater;
+local-engine rows.
+
+## 2. AI Models (desktop: ai-hub view, header `ai-hub:hero.title` "AI Models")
+
+Two tabs on desktop: Providers grid + "Models · N" directory.
+
+### 2a. Provider catalog (two id namespaces!)
+Frontend catalog: `app/src/lib/providers.ts` (UI ids, connect cards, logos; Codex = `openai`).
+Host/wire catalog: `packages/host/src/providers.ts` (Codex = `openai-codex`).
+Mapping: `capabilityIdsForProvider` (`app/src/lib/providers.ts:688`) — port to iOS.
+
+| UI id | Name | Auth | cloud? | Logo component |
+|---|---|---|---|---|
+| openai (wire openai-codex) | OpenAI (Codex) | oauth device-code | ✅ | OpenAILogo |
+| anthropic | Anthropic (Claude) | oauth device-code | ❌ ToS | ClaudeLogo |
+| github-copilot | GitHub Copilot | oauth device-code (+Enterprise dialog) | ❌ | GitHubCopilotLogo |
+| opencode + opencode-go (merged ONE card, `gatewayIds`) | OpenCode | apiKey | ✅ | OpenCodeLogo |
+| openrouter | OpenRouter | apiKey | ❌ | OpenRouterLogo |
+| deepseek | DeepSeek | apiKey | ❌ | DeepSeekLogo |
+| google | Google Gemini | apiKey | ❌ | GeminiLogo |
+| amazon-bedrock | Amazon Bedrock | apiKey | ❌ | AmazonBedrockLogo |
+| minimax | MiniMax | apiKey | ❌ | MiniMaxLogo |
+| openai-compatible | Local model | — | — | DESKTOP-ONLY, exclude |
+| subq | SubQ | coming soon | — | "SQ" mark |
+
+**LOGOS: no asset files — inline React SVG components in
+`app/src/components/shell/provider-logos.tsx`** (24×24 viewBox, currentColor; OpenCode two-tone
+240×300; OpenRouter/LocalModel/Bedrock stroked). Port the exact `<path d>` strings to SwiftUI.
+Dispatcher `ProviderGlyph` switches on id (google/gemini → GeminiLogo), falls back to first initial.
+Model lists per provider (id, label, effortLevels, contextWindow): `providers.ts:117-672` — port
+verbatim where iOS shows a model picker. Effort vocab low/medium/high/xhigh/max, default medium,
+model-clamped (`providers.ts:11-28,898-924`).
+
+### 2b. Hosted connect flow (wire = runtime-client, all per-agent paths)
+| Op | Wire |
+|---|---|
+| List | GET /providers → ProviderInfo[] {id,name,configured,isActive,activeModel,models[]} |
+| Status | GET /auth/status → {providers: ProviderAuth[], activeProvider} |
+| Start OAuth | POST /auth/:provider/login?deviceAuth=true[&enterpriseDomain=] → LoginInfo |
+| Cancel | POST /auth/:provider/login/cancel |
+| Complete (paste) | POST /auth/:provider/login/complete {code} — only `auth_code` kind |
+| API key | POST /auth/:provider/api-key {key} |
+| Logout | POST /auth/:provider/logout |
+| Active model | PUT /settings {activeProvider?, model?, effort?} (use SDK resolveModelSettings semantics) |
+
+`LoginInfo` union: `{kind:"url"}` (local only — not hosted) · `{kind:"auth_code", url, instructions?}`
+(open url, paste code → complete) · `{kind:"device_code", verificationUri, userCode}` (show code,
+open uri, poll GET /auth/status until configured flips). Hosted = deviceAuth=true default.
+Copy: `providers:providerLogin.*` (deviceCodeLabel "One-time code", deviceCodeHint, deviceWaiting,
+copyCode/codeCopied, deviceSettingsHint for OpenAI), `providers:apiKey.*` ("Connect {{name}}",
+save "Connect", getKey "Get your API key"), `providers:signOutConfirm.*`, card states
+`providers:card.*` ("Connected"/"Not connected"/"Connecting..."/"Coming soon"), toasts
+`providers:toast.*`.
+
+## 3. Integrations (Composio; KB houston/knowledge-base/integrations.md, contracts C1/C4)
+
+Surfaces: global page (Connected apps grid + card→per-agent access sheet; always-visible
+"Connect more apps" catalog: A-Z ~1000 apps, category dropdown, search, load-more) and a per-agent
+tab (Apps this agent can use w/ deactivate toggles · Other apps connected (Activate=grant) ·
+Connect more). Degraded mode when grants null: all connected usable, no toggles.
+
+Wire (gateway, user JWT):
+- GET /v1/integrations → readiness ({provider:"composio", ready})
+- GET /v1/integrations/composio/toolkits → {items: {slug,name,description?,logoUrl?,categories?}}
+- GET /v1/integrations/composio/connections (+/:id poll) → {toolkit, connectionId, status: active|pending|error}
+- POST /v1/integrations/composio/connect {toolkit} → {redirectUrl, connectionId}: open URL (OAuth), poll until active
+- POST /v1/integrations/composio/disconnect {toolkit}
+- GET /v1/agents/:slug/integration-grants → {toolkits[]}; **404 → null → "unsupported, no toggles"; [] → nothing granted** (distinct!)
+- PUT /v1/agents/:slug/integration-grants {toolkits} (replace-set, slugs [a-z0-9_-]+; 403 not_assigned)
+
+503 when no COMPOSIO key on the gateway → show `integrations:unavailable` "Integrations are not
+available in this setup." Sign-in state: `integrations:signin.*`. **Toolkit logos are REMOTE
+`logoUrl`s (AsyncImage) — provider logos are inline SVG. Two rendering paths.**
+Copy: `integrations.json` — title "Integrations", `.home.description`, `.status.*` (Connected /
+Finishing up / Needs reconnecting), `.waiting.*`, disconnect confirms, `.agentTab.*`,
+`.connectMore.title`, `.picker.*`, `.browse.*`, recovery keys.
+
+## 4. SDK gaps (as of extraction)
+
+- providers: wire exists on runtime-client; NO SDK module → build `providers` module (per-agent).
+- integrations: absent from runtime-client (only ui/engine-client) → add user-scoped methods to
+  runtime-client + SDK `integrations` module (keep 404→null and 503 semantics).
+- preferences/locale: absent from runtime-client → add GET/PUT /preferences/:key +
+  PATCH /workspaces/:id/locale + SDK module.
+
+## 5. iOS IA (mirror desktop nav names/order)
+
+Desktop sidebar order: Mission Control · Integrations ("Integrations", icon Blocks) · AI Models
+("AI Models", icon Boxes) · Settings ("Settings", icon Settings). Per-agent tab set separately has
+Integrations + Agent Settings. Mobile: Settings tab groups rows as desktop (top card → Context →
+Support → Danger).
+
+## 6. Hosted-mode landmines
+1. Per-agent provider credentials — no user-level store; surface the scoping clearly.
+2. OAuth in hosted = device-code only; poll /auth/status; no loopback; no paste-back except auth_code.
+3. Provider availability varies by pod — read /providers at runtime, never hardcode (anthropic +
+   most apiKey providers are cloud:false today).
+4. Two provider-id namespaces (openai vs openai-codex; google/gemini) — carry the mapping.
+5. Integrations user-scoped, grants per-agent; 404-null vs empty-array are different states.
+6. 503 unconfigured must not crash the tab.
+7. Toolkit logos remote, provider logos inline SVG.
+8. openai-compatible is desktop-only.
+9. Theme device-local; language engine-persisted.
+10. Members rows conditional on capabilities.

--- a/mobile/PARITY.md
+++ b/mobile/PARITY.md
@@ -24,7 +24,21 @@ Unknown statuses are preserved and rendered neutrally. New activities are create
 settles `sessionStatus === "error"` **but** `boardStatus === "needs_you"`. **Read the pair, never
 `sessionStatus` alone** — keying off sessionStatus renders a normal Stop as red.
 `boardStatus:"needs_you"` = handled / your attention; `boardStatus:"error"` = genuine failure.
-`ConversationVM` exposes `{ feed, running, sessionStatus, boardStatus }`.
+`ConversationVM` exposes `{ feed, running, sessionStatus, boardStatus, queued? }` (`queued`
+additive — see §5).
+
+### BRIDGE addressing — the conversation VM scope (agent-qualified)
+`packages/sdk/src/modules/turns/vm-output.ts:83-87` (`conversationScope`): the conversation VM is
+published on **`conversation/<encodeURIComponent(agentPath)>/<encodeURIComponent(sessionKey)>`** —
+agent-qualified, because a `sessionKey` is unique only WITHIN one agent. The `agentPath` segment is
+the SAME string the surface passes as `agentId` to the `turns/*` commands (`index.ts:66,90-98` use
+the command's `agentId` verbatim as the scope's agent segment), so the subscribe scope and the
+publish scope stay in lockstep.
+- **iOS**: `SdkScope.conversation(agentPath:sessionKey:)` builds it; every component is escaped by a
+  from-scratch `encodeURIComponent` (unreserved set `A-Z a-z 0-9 - _ . ! ~ * ' ( )`, UTF-8 bytes,
+  uppercase hex) — Foundation's `.urlQueryAllowed` is NOT equivalent. Pinned to JS-generated fixtures
+  in `SdkScopeTests` (e.g. `"Houston/My Agent"` → `Houston%2FMy%20Agent`). A mismatch subscribes to a
+  scope the SDK never publishes on → the chat feed goes dead, so this is a hard contract.
 
 ### Board columns (kanban) — `app/src/components/mission-board-columns.ts`
 Left-to-right order and status→column mapping (single source of truth):
@@ -117,6 +131,45 @@ Status lines (`chat.json:process`): active = "Mission in progress..."; with acti
 "Mission in progress: {{action}}"; settled = "Mission log". Shimmer while active.
 **There is NO "Stopped by user" string** — a Stop moves the card to Needs you silently
 (the `cancelled` provider_error is dropped).
+
+### Status reclassification — loading indicator vs streaming (`ui/chat/src/chat-status.ts:27-49`)
+`deriveStatus`: only `assistant_text_streaming` counts as **streaming** (its visible growing text
+IS the progress signal, so the loading indicator would just compete with it). `thinking_streaming`,
+tool cycles, and silent gaps all resolve to **submitted** → the loading indicator STAYS VISIBLE
+through reasoning + tool phases (HOU-655: treating `thinking_streaming` as streaming flickered the
+indicator off during every thinking stretch).
+- **iOS**: `ChatStatus.derive(feed:running:)` (pure mirror) + `ChatScreenModel.showLoadingLabel`.
+  The `MissionStatusLine` renders while the turn is `running`; its "Mission in progress..." dot +
+  shimmer label is suppressed while assistant text streams (`showLabel:false`), leaving only the
+  **Stop** control (Stop stays available the entire running turn, matching desktop's composer stop).
+  Pinned in `ChatStatusTests`.
+
+### Queued messages while a turn runs (`ConversationVM.queued`, `vm-output.ts:35-58`)
+Additive optional `queued?: QueuedMessageVM[]` (`{ id, text, attachmentNames? }`): messages typed
+while a turn runs are HELD and flushed as ONE combined send at settle. **Queueing is SDK/engine-
+adapter behavior, never the surface** (desktop: `packages/web/src/engine-adapter/send-queue.ts`) —
+the surface only renders the published list (client-architecture.md invariant 1).
+- **iOS**: `QueuedMessageVM` model + `ConversationVM.queued`; `QueuedMessagesView` renders each as a
+  dimmed, pending, right-aligned bubble (clock glyph) above the composer. **Populate path deferred**:
+  the SDK *bridge* path iOS uses has no send-queue (only the web engine-adapter drives `setQueued`),
+  so `queued` is empty on iOS today — rendering is wired and forward-compatible for when a bridge-side
+  queue lands. The removable affordance stays deferred until the bridge exposes a `removeQueued` seam.
+
+### `failed_prompt` on the unauthenticated reconnect card (`ui/chat/src/types.ts:142-148`)
+The `unauthenticated` provider error gained optional `failed_prompt` (JSON key `failed_prompt`) —
+client-synthesized only (never on the wire; synthesized in `packages/sdk turn-settle.ts:92-104`):
+the prompt whose SEND the engine refused because no provider was connected, so a "Send again"
+affordance can resend THAT exact text.
+- **iOS**: carried on `ProviderError.unauthenticated(..., failedPrompt:)`. The iOS provider-error card
+  (`ProviderErrorCardView`) has **no action buttons** (v1 scope cut), so the "Send again" affordance
+  **stays deferred** — the field is modeled + decoded now so the card can wire it later with no
+  contract change.
+
+### Shell / splash copy
+Desktop shows a startup splash "Loading your workspace…" (`shell.json:278 starting`). **iOS has no
+equivalent splash copy**: `RootView` branches only to the SDK-startup error view, the sign-in gate,
+or the tabs — there is no loading-workspace screen, so nothing to align. (If a mobile startup splash
+is added later, mirror this string.)
 
 ## 6. New-mission flow (wire) — `app/src/lib/create-mission.ts`
 1. Create activity (`status:"running"`), id → session key `activity-{id}`.

--- a/mobile/ios/Houston/Core/Bridge/Models/ConversationVM.swift
+++ b/mobile/ios/Houston/Core/Bridge/Models/ConversationVM.swift
@@ -16,6 +16,22 @@ struct ConversationVM: Decodable, Equatable, Sendable {
   /// handled-vs-error signal: `needsYou` = handled / attention, `error` = a real
   /// failure.
   var boardStatus: BoardStatus?
+  /// Messages typed while a turn runs — held and flushed as ONE combined send
+  /// when the turn settles (additive; absent when none). Rendered as pending
+  /// bubbles above the composer so the user sees their queued texts. Queueing
+  /// itself is behavior owned by the SDK/engine adapter, never the surface; this
+  /// surface only mirrors the published list (client-architecture.md invariant 1).
+  var queued: [QueuedMessageVM]?
+}
+
+/// A message queued while a turn runs (SDK `QueuedMessageVM`, `vm-output.ts`):
+/// a stable id, the user's text, and any attachment names. Rendered visually
+/// pending; removable once the SDK bridge exposes the remove seam.
+struct QueuedMessageVM: Decodable, Equatable, Identifiable, Sendable {
+  let id: String
+  let text: String
+  /// Attachment file names shown alongside the queued text; absent when none.
+  var attachmentNames: [String]?
 }
 
 /// A single reactive feed entry: a stable id plus the raw push payload. The

--- a/mobile/ios/Houston/Core/Bridge/Models/ProviderError.swift
+++ b/mobile/ios/Houston/Core/Bridge/Models/ProviderError.swift
@@ -14,7 +14,8 @@ enum ProviderError: Decodable, Equatable, Sendable {
   case modelUnavailable(
     provider: String, model: String, reason: ModelUnavailableReason,
     suggestedFallback: String?, message: String)
-  case unauthenticated(provider: String, cause: AuthFailureCause, message: String)
+  case unauthenticated(
+    provider: String, cause: AuthFailureCause, message: String, failedPrompt: String?)
   case networkUnreachable(provider: String, message: String)
   case providerInternal(provider: String, httpStatus: Int?, message: String)
   case sessionResumeMissing(provider: String, sessionId: String)
@@ -52,9 +53,12 @@ enum ProviderError: Decodable, Equatable, Sendable {
         reason: ModelUnavailableReason(raw: raw["reason"]?.stringValue),
         suggestedFallback: raw["suggested_fallback"]?.stringValue, message: message)
     case "unauthenticated":
+      // `failed_prompt` is client-synthesized only (never on the wire): the
+      // prompt whose SEND the engine refused because no provider was connected,
+      // so a "Send again" affordance can resend THIS text (turn-settle.ts).
       self = .unauthenticated(
         provider: provider, cause: AuthFailureCause(raw: raw["cause"]?.stringValue),
-        message: message)
+        message: message, failedPrompt: raw["failed_prompt"]?.stringValue)
     case "network_unreachable":
       self = .networkUnreachable(provider: provider, message: message)
     case "provider_internal":

--- a/mobile/ios/Houston/Core/Bridge/Models/SdkScope.swift
+++ b/mobile/ios/Houston/Core/Bridge/Models/SdkScope.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Typed builders for the SDK scope strings a surface subscribes to.
 ///
-/// Scopes are opaque strings on the wire (`"agents"`, `"conversation/<id>"`,
+/// Scopes are opaque strings on the wire (`"agents"`, `"conversation/<agent>/<id>"`,
 /// `"activities/<agentId>"`); centralizing their construction here keeps callers
 /// from hand-formatting one and risking a typo. The values mirror the scope
 /// helpers in `packages/sdk/src` verbatim.
@@ -13,15 +13,40 @@ enum SdkScope {
     "conversations/\(agentId)"
   }
 
-  /// One conversation's live feed VM — `conversation/<sessionKey>`
-  /// (`conversationScope`).
-  static func conversation(sessionKey: String) -> String {
-    "conversation/\(sessionKey)"
+  /// One conversation's live feed VM — `conversation/<agentPath>/<sessionKey>`
+  /// (`conversationScope`, `packages/sdk/src/modules/turns/vm-output.ts`).
+  ///
+  /// Agent-qualified: a session key is unique only WITHIN one agent, so the
+  /// scope carries both. Each component is `encodeURIComponent`-escaped exactly
+  /// as the SDK escapes it (`encodeURIComponent(agentPath)/encodeURIComponent(
+  /// sessionKey)`) — a mismatch here silently subscribes to a scope the SDK
+  /// never publishes on, so the chat feed goes dead. `agentPath` is the SAME
+  /// string this surface passes as `agentId` to the `turns/*` commands (the SDK
+  /// uses the command's `agentId` verbatim as the scope's agent segment), which
+  /// keeps the subscribe scope and the publish scope in lockstep.
+  static func conversation(agentPath: String, sessionKey: String) -> String {
+    "conversation/\(encodeURIComponent(agentPath))/\(encodeURIComponent(sessionKey))"
   }
 
   /// One agent's board/missions list — `activities/<agentId>`
   /// (`activitiesScope`).
   static func activities(agentId: String) -> String {
     "activities/\(agentId)"
+  }
+
+  /// The JS `encodeURIComponent` unreserved set: percent-encode everything
+  /// EXCEPT `A-Z a-z 0-9 - _ . ! ~ * ' ( )`. Foundation's `.urlQueryAllowed`
+  /// differs (it keeps `/`, `?`, `&`, `=`, … and treats non-ASCII letters as
+  /// allowed), so it is NOT usable here — the set is spelled out ASCII-only.
+  private static let encodeURIComponentAllowed: CharacterSet = CharacterSet(
+    charactersIn:
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.!~*'()")
+
+  /// Escape one scope component exactly as JS `encodeURIComponent` does:
+  /// UTF-8 bytes, uppercase hex, only the unreserved set left literal.
+  /// `addingPercentEncoding` is total for a native `String` (always valid
+  /// UTF-8), so the force-unwrap is a genuine invariant, not a swallowed error.
+  static func encodeURIComponent(_ component: String) -> String {
+    component.addingPercentEncoding(withAllowedCharacters: encodeURIComponentAllowed)!
   }
 }

--- a/mobile/ios/Houston/Features/Chat/ChatScreenModel.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatScreenModel.swift
@@ -38,7 +38,8 @@ final class ChatScreenModel {
   ) {
     self.agentId = agentId
     self.conversationId = conversationId
-    self.conversation = client.scope(SdkScope.conversation(sessionKey: conversationId))
+    self.conversation = client.scope(
+      SdkScope.conversation(agentPath: agentId, sessionKey: conversationId))
     self.activities = client.scope(SdkScope.activities(agentId: agentId))
     self.commands = commands ?? SdkChatCommands(client: client)
   }
@@ -49,6 +50,21 @@ final class ChatScreenModel {
   var rows: [ChatRow] { MissionFeedFold.rows(from: vm?.feed ?? []) }
   var running: Bool { vm?.running ?? false }
   var isEmpty: Bool { vm?.feed.isEmpty ?? true }
+
+  /// Messages queued while the turn runs, rendered as pending bubbles above the
+  /// composer (PARITY §5). Empty until the SDK bridge publishes a `queued` list.
+  var queued: [QueuedMessageVM] { vm?.queued ?? [] }
+
+  /// The in-flight display status (mirrors desktop `deriveStatus`). Drives the
+  /// loading indicator: shown while ``running`` UNLESS assistant text is
+  /// streaming (then the visible bubble is the progress signal); the Stop
+  /// control stays available throughout the running turn regardless.
+  var chatStatus: ChatStatus { ChatStatus.derive(feed: vm?.feed ?? [], running: running) }
+
+  /// Whether the "Mission in progress..." loading label shows: only when a turn
+  /// is in flight and no assistant text is streaming. Reasoning + tool phases
+  /// keep it visible (`chat-status.ts`, HOU-655).
+  var showLoadingLabel: Bool { running && chatStatus != .streaming }
 
   /// The Approve bar shows only when the board card is `needs_you` AND no turn is
   /// running — read the pair, never `sessionStatus` alone (PARITY §1/§5).

--- a/mobile/ios/Houston/Features/Chat/ChatStatus.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatStatus.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// The chat's in-flight display state, mirroring the desktop `ChatStatus`
+/// (`ui/chat/src/chat-panel-types.ts`) and its `deriveStatus` reclassification
+/// (`ui/chat/src/chat-status.ts`).
+///
+/// Only `assistant_text_streaming` counts as `.streaming`: it is the ONE feed
+/// type whose progressively-appearing content is visible on screen, so the
+/// loading indicator would just compete with it. `thinking_streaming` used to
+/// count too, but since HOU-448 the reasoning streams inside a collapsed block —
+/// nothing moves on screen — so treating it as streaming flickered the loading
+/// state off during every thinking stretch (HOU-655). EVERY in-flight case with
+/// no visible text streaming resolves to `.submitted` so the loading indicator
+/// stays visible through reasoning + tool phases.
+enum ChatStatus: Equatable, Sendable {
+  /// Settled — no loading indicator.
+  case ready
+  /// Assistant text is streaming; the bubble IS the progress signal, so the
+  /// standalone loading indicator is suppressed.
+  case streaming
+  /// A turn is in flight with nothing visibly streaming — show the loading
+  /// indicator (the only signal during reasoning / tool / silent-gap stretches).
+  case submitted
+
+  /// Reclassify the feed + running flag into a status, byte-for-byte the desktop
+  /// `deriveStatus(items, isLoading)`: last frame `assistant_text_streaming` →
+  /// `.streaming`; otherwise any running turn (or a just-sent optimistic
+  /// `user_message`) → `.submitted`; else `.ready`.
+  static func derive(feed: [FeedItemVM], running: Bool) -> ChatStatus {
+    let lastType = feed.last?.feedType
+    if lastType == "assistant_text_streaming" { return .streaming }
+    if running { return .submitted }
+    if lastType == "user_message" { return .submitted }
+    return .ready
+  }
+}

--- a/mobile/ios/Houston/Features/Chat/ChatView.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatView.swift
@@ -56,15 +56,20 @@ struct ChatView: View {
     @Bindable var model = model
     return VStack(spacing: 0) {
       if model.running {
-        MissionStatusLine(action: nil) { model.stop() }
+        MissionStatusLine(action: nil, showLabel: model.showLoadingLabel) { model.stop() }
       }
       if model.showApproveBar {
         ApproveBar { model.approve() }
       }
+      if !model.queued.isEmpty {
+        QueuedMessagesView(messages: model.queued)
+      }
       MissionComposer(text: $model.draft, isSending: model.isSending) { model.send() }
     }
     .animation(.smooth(duration: Motion.fast), value: model.running)
+    .animation(.smooth(duration: Motion.fast), value: model.showLoadingLabel)
     .animation(.smooth(duration: Motion.fast), value: model.showApproveBar)
+    .animation(.smooth(duration: Motion.fast), value: model.queued)
   }
 
   private var errorPresented: Binding<Bool> {

--- a/mobile/ios/Houston/Features/Chat/MissionFeedFold.swift
+++ b/mobile/ios/Houston/Features/Chat/MissionFeedFold.swift
@@ -147,7 +147,7 @@ extension ProviderError {
     case let .quotaExhausted(p, _, _, _, _): return "quota_exhausted:\(p)"
     case let .usageLimitPaused(p, _, _): return "usage_limit_paused:\(p)"
     case let .modelUnavailable(p, _, _, _, _): return "model_unavailable:\(p)"
-    case let .unauthenticated(p, _, _): return "unauthenticated:\(p)"
+    case let .unauthenticated(p, _, _, _): return "unauthenticated:\(p)"
     case let .networkUnreachable(p, _): return "network_unreachable:\(p)"
     case let .providerInternal(p, _, _): return "provider_internal:\(p)"
     case let .sessionResumeMissing(p, _): return "session_resume_missing:\(p)"

--- a/mobile/ios/Houston/Features/Chat/MissionStatusLine.swift
+++ b/mobile/ios/Houston/Features/Chat/MissionStatusLine.swift
@@ -4,22 +4,31 @@ import SwiftUI
 /// a shimmering "Mission in progress..." (with ": {{action}}" when the VM exposes
 /// a current action) and a Stop control. Stop cancels the turn — there is NO
 /// "stopped" copy; a Stop moves the card to Needs you silently.
+///
+/// The loading label is suppressed while assistant text is streaming
+/// (`showLabel == false`): the visible streaming bubble is the progress signal,
+/// so only the Stop control remains (mirrors desktop `deriveStatus`, PARITY §5).
 struct MissionStatusLine: View {
   @Environment(\.theme) private var theme
   /// The current action the VM exposes, if any; nil renders the base copy.
   var action: String?
+  /// Whether the loading dot + "Mission in progress..." label shows. When false
+  /// (assistant text streaming), only the Stop control renders.
+  var showLabel: Bool = true
   let onStop: () -> Void
 
   var body: some View {
     HStack(spacing: Spacing.space10) {
-      Circle()
-        .fill(GlowColor.running)
-        .frame(width: 6, height: 6)  // status-dot diameter, matching StatusChip
-      Text(label)
-        .font(Typography.label)
-        .foregroundStyle(theme.mutedFg)
-        .lineLimit(1)
-        .shimmer(active: true)
+      if showLabel {
+        Circle()
+          .fill(GlowColor.running)
+          .frame(width: 6, height: 6)  // status-dot diameter, matching StatusChip
+        Text(label)
+          .font(Typography.label)
+          .foregroundStyle(theme.mutedFg)
+          .lineLimit(1)
+          .shimmer(active: true)
+      }
       Spacer(minLength: Spacing.space8)
       Button(action: onStop) {
         Text(Strings.Chat.stop)

--- a/mobile/ios/Houston/Features/Chat/ProviderErrorPresentation.swift
+++ b/mobile/ios/Houston/Features/Chat/ProviderErrorPresentation.swift
@@ -38,7 +38,7 @@ extension ProviderError {
         title: C.modelUnavailableTitle,
         detail: C.modelUnavailableBody(model: model, provider: provider))
 
-    case let .unauthenticated(provider, cause, _):
+    case let .unauthenticated(provider, cause, _, _):
       return .init(
         title: C.unauthenticatedTitle(provider: provider),
         detail: Self.unauthDetail(provider: provider, cause: cause))

--- a/mobile/ios/Houston/Features/Chat/QueuedMessagesView.swift
+++ b/mobile/ios/Houston/Features/Chat/QueuedMessagesView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// The pending queued-message bubbles shown above the composer while a turn runs
+/// (PARITY §5): a send typed mid-turn is held by the SDK and flushed as one
+/// combined send at settle, and its text renders here as a dimmed, right-aligned
+/// user bubble with a "pending" clock so the user sees what will send next.
+///
+/// Mirrors the desktop composer's queued-bubble affordance
+/// (`packages/web/src/engine-adapter/send-queue.ts`). Rendered only when the VM
+/// publishes a non-empty `queued` list.
+struct QueuedMessagesView: View {
+  let messages: [QueuedMessageVM]
+
+  var body: some View {
+    VStack(spacing: Spacing.space6) {
+      ForEach(messages) { message in
+        QueuedBubble(message: message)
+      }
+    }
+    .padding(.horizontal, Spacing.space12)
+    .padding(.top, Spacing.space6)
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel(Strings.Chat.queued)
+  }
+}
+
+/// One pending queued message: a dimmed user bubble with a leading clock glyph
+/// and, when present, its attachment names.
+private struct QueuedBubble: View {
+  @Environment(\.theme) private var theme
+  let message: QueuedMessageVM
+
+  var body: some View {
+    HStack(alignment: .bottom, spacing: Spacing.space6) {
+      Spacer(minLength: Spacing.space40)
+      Image(systemName: "clock")
+        .font(Typography.caption)
+        .foregroundStyle(theme.mutedFg)
+      VStack(alignment: .trailing, spacing: Spacing.space2) {
+        Text(message.text)
+          .font(Typography.body)
+          .foregroundStyle(theme.primaryFg)
+          .padding(.horizontal, Spacing.space12)
+          .padding(.vertical, Spacing.space8)
+          .background(theme.primary, in: BubbleShape(tail: .trailing))
+        if let names = message.attachmentNames, !names.isEmpty {
+          Text(names.joined(separator: ", "))
+            .font(Typography.caption)
+            .foregroundStyle(theme.mutedFg)
+            .lineLimit(1)
+        }
+      }
+      .opacity(0.6)  // visually pending until the queued send flushes at settle
+    }
+  }
+}

--- a/mobile/ios/Houston/Features/Chat/Strings+Chat.swift
+++ b/mobile/ios/Houston/Features/Chat/Strings+Chat.swift
@@ -23,6 +23,8 @@ extension Strings {
     }
     /// The settled turn-summary heading (chat.json:process.complete).
     static let missionLog = "Mission log"
+    /// Accessibility label for the pending queued-message bubbles (PARITY §5).
+    static let queued = "Queued messages"
 
     // Reasoning block (chat.json:reasoning).
     static let thinking = "Thinking..."

--- a/mobile/ios/HoustonTests/Chat/ChatStatusTests.swift
+++ b/mobile/ios/HoustonTests/Chat/ChatStatusTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import Houston
+
+/// Pins the status reclassification to desktop `deriveStatus`
+/// (`ui/chat/src/chat-status.ts`): only `assistant_text_streaming` is
+/// `.streaming`; `thinking_streaming` and tool phases keep the loading state
+/// (`.submitted`) visible (HOU-655).
+final class ChatStatusTests: XCTestCase {
+  private func feed(_ types: [String]) -> [FeedItemVM] {
+    types.enumerated().map { index, type in
+      vm("f\(index)", type)
+    }
+  }
+
+  private func vm(_ id: String, _ type: String) -> FeedItemVM {
+    let object = JSONValue.object([
+      "id": .string(id), "feed_type": .string(type), "data": .string(""),
+    ])
+    guard let item = try? object.decode(FeedItemVM.self) else {
+      fatalError("FeedItemVM fixture failed to decode")
+    }
+    return item
+  }
+
+  func testAssistantTextStreamingIsStreaming() {
+    let status = ChatStatus.derive(
+      feed: feed(["user_message", "thinking", "assistant_text_streaming"]), running: true)
+    XCTAssertEqual(status, .streaming, "visible streaming text is the progress signal")
+  }
+
+  func testThinkingStreamingStaysSubmitted() {
+    // The reclassification's whole point: reasoning keeps the loading indicator.
+    let status = ChatStatus.derive(
+      feed: feed(["user_message", "thinking_streaming"]), running: true)
+    XCTAssertEqual(status, .submitted)
+  }
+
+  func testToolCycleStaysSubmitted() {
+    let status = ChatStatus.derive(feed: feed(["tool_call", "tool_result"]), running: true)
+    XCTAssertEqual(status, .submitted, "silent tool/gap stretches keep the indicator")
+  }
+
+  func testRunningWithEmptyFeedIsSubmitted() {
+    XCTAssertEqual(ChatStatus.derive(feed: [], running: true), .submitted)
+  }
+
+  func testJustSentUserMessageIsSubmittedEvenBeforeRunning() {
+    XCTAssertEqual(ChatStatus.derive(feed: feed(["user_message"]), running: false), .submitted)
+  }
+
+  func testSettledIsReady() {
+    let status = ChatStatus.derive(
+      feed: feed(["user_message", "assistant_text", "final_result"]), running: false)
+    XCTAssertEqual(status, .ready)
+  }
+}

--- a/mobile/ios/HoustonTests/SdkClient/ModelDecodingTests.swift
+++ b/mobile/ios/HoustonTests/SdkClient/ModelDecodingTests.swift
@@ -61,6 +61,47 @@ final class ModelDecodingTests: XCTestCase {
     XCTAssertEqual(result.usage?.contextTokens, 8000)
   }
 
+  func testConversationVMDecodesQueuedMessages() throws {
+    // Additive `queued` list: messages typed while a turn runs (vm-output.ts).
+    let json = """
+      {"feed":[],"running":true,"sessionStatus":"running","boardStatus":"running",
+       "queued":[{"id":"q0","text":"and also check email","attachmentNames":["report.pdf"]},
+                 {"id":"q1","text":"thanks"}]}
+      """
+    let vm = try BridgeTestJSON.decode(ConversationVM.self, json)
+    XCTAssertEqual(vm.queued?.count, 2)
+    XCTAssertEqual(vm.queued?.first?.id, "q0")
+    XCTAssertEqual(vm.queued?.first?.text, "and also check email")
+    XCTAssertEqual(vm.queued?.first?.attachmentNames, ["report.pdf"])
+    XCTAssertNil(vm.queued?.last?.attachmentNames, "attachmentNames absent → nil")
+  }
+
+  func testConversationVMQueuedAbsentIsNil() throws {
+    // The field is omitted when empty; the decode must not require it.
+    let vm = try BridgeTestJSON.decode(
+      ConversationVM.self,
+      #"{"feed":[],"running":false,"sessionStatus":"idle"}"#)
+    XCTAssertNil(vm.queued)
+  }
+
+  func testUnauthenticatedCarriesFailedPrompt() throws {
+    // Client-synthesized `failed_prompt` rides the not-connected reconnect card
+    // (turn-settle.ts) so a "Send again" affordance can resend the exact text.
+    let error = try BridgeTestJSON.decode(
+      ProviderError.self,
+      #"{"kind":"unauthenticated","provider":"claude","cause":"no_credentials","message":"m","failed_prompt":"draft an invoice"}"#)
+    guard case let .unauthenticated(_, _, _, failedPrompt) = error else { return XCTFail() }
+    XCTAssertEqual(failedPrompt, "draft an invoice")
+  }
+
+  func testUnauthenticatedFailedPromptAbsentIsNil() throws {
+    let error = try BridgeTestJSON.decode(
+      ProviderError.self,
+      #"{"kind":"unauthenticated","provider":"claude","cause":"token_expired","message":"m"}"#)
+    guard case let .unauthenticated(_, _, _, failedPrompt) = error else { return XCTFail() }
+    XCTAssertNil(failedPrompt)
+  }
+
   func testFeedItemUnknownTypeFallsBack() throws {
     let vm = try BridgeTestJSON.decode(
       ConversationVM.self,

--- a/mobile/ios/HoustonTests/SdkClient/SdkScopeTests.swift
+++ b/mobile/ios/HoustonTests/SdkClient/SdkScopeTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import Houston
+
+/// Pins `SdkScope.conversation` to the SDK's `conversationScope`
+/// (`packages/sdk/src/modules/turns/vm-output.ts`): agent-qualified and
+/// `encodeURIComponent`-escaped per component. A drift here silently subscribes
+/// to a scope the SDK never publishes on, so the chat feed goes dead.
+///
+/// The expected strings are the output of Node's `encodeURIComponent` — Swift's
+/// `.urlQueryAllowed` is NOT equivalent (it keeps `/`, `&`, `=`, … literal and
+/// treats non-ASCII letters as allowed), so this guards the exact unreserved set
+/// `A-Z a-z 0-9 - _ . ! ~ * ' ( )`.
+final class SdkScopeTests: XCTestCase {
+  // MARK: encodeURIComponent parity (JS-generated fixtures)
+
+  func testEncodeURIComponentMatchesJSFixtures() {
+    // Each pair is `encodeURIComponent(input)` captured from Node.
+    let vectors: [(String, String)] = [
+      ("Houston/My Agent", "Houston%2FMy%20Agent"),
+      ("activity-42", "activity-42"),
+      ("-_.!~*'()", "-_.!~*'()"),  // the full unreserved set is left literal
+      ("a b/c?d&e=f#g", "a%20b%2Fc%3Fd%26e%3Df%23g"),
+      ("Café/Über", "Caf%C3%A9%2F%C3%9Cber"),  // non-ASCII → UTF-8, uppercase hex
+      ("100% done", "100%25%20done"),
+      ("tab\tnew\nline", "tab%09new%0Aline"),
+      ("x+y z", "x%2By%20z"),  // '+' is NOT unreserved (unlike a query encoder)
+    ]
+    for (input, expected) in vectors {
+      XCTAssertEqual(
+        SdkScope.encodeURIComponent(input), expected,
+        "encodeURIComponent(\(input))")
+    }
+  }
+
+  // MARK: agent-qualified scope
+
+  func testConversationScopeIsAgentQualifiedAndEscaped() {
+    XCTAssertEqual(
+      SdkScope.conversation(agentPath: "Houston/My Agent", sessionKey: "activity-42"),
+      "conversation/Houston%2FMy%20Agent/activity-42")
+  }
+
+  func testConversationScopeEscapesBothComponents() {
+    // A session key with reserved characters must be escaped independently of
+    // the agent segment (each `encodeURIComponent`, joined by a literal '/').
+    XCTAssertEqual(
+      SdkScope.conversation(agentPath: "Acme Co", sessionKey: "a/b c"),
+      "conversation/Acme%20Co/a%2Fb%20c")
+  }
+
+  func testConversationScopeKeepsPrefixForSubscriptionRouting() {
+    // The bridge routes conversation subscriptions by the `conversation/` prefix;
+    // the qualified form must preserve it.
+    XCTAssertTrue(
+      SdkScope.conversation(agentPath: "ag1", sessionKey: "s1").hasPrefix("conversation/"))
+  }
+}

--- a/mobile/ios/scripts/dev-sim.sh
+++ b/mobile/ios/scripts/dev-sim.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-command iOS dev loop: build the app and run it in the iOS Simulator.
+#   pnpm ios            (from the repo root)
+# Regenerates the Xcode project, builds Debug for the simulator (the pre-build
+# phases bundle the SDK + sync design tokens), boots a simulator if none is
+# booted, installs, launches, and brings the Simulator window to front.
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$HERE"
+
+# Xcode may be installed while xcode-select still points at CommandLineTools
+# (switching needs sudo). DEVELOPER_DIR is the no-sudo equivalent.
+if ! xcodebuild -version >/dev/null 2>&1; then
+  export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+fi
+xcodebuild -version >/dev/null 2>&1 || {
+  echo "error: Xcode not found (install it from the App Store)" >&2; exit 1; }
+command -v xcodegen >/dev/null 2>&1 || {
+  echo "error: xcodegen not found (brew install xcodegen)" >&2; exit 1; }
+
+echo "▸ xcodegen"
+xcodegen generate --quiet
+
+echo "▸ building (Debug, iOS Simulator)"
+xcodebuild -project Houston.xcodeproj -scheme Houston \
+  -configuration Debug -destination 'generic/platform=iOS Simulator' \
+  -derivedDataPath build/DerivedData -quiet build
+
+APP="build/DerivedData/Build/Products/Debug-iphonesimulator/Houston.app"
+test -d "$APP" || { echo "error: built app not found at $APP" >&2; exit 1; }
+
+# Reuse the booted simulator, else boot the first available iPhone.
+DEV="$(xcrun simctl list devices booted | grep -m1 -oE '[A-F0-9-]{36}' || true)"
+if [ -z "$DEV" ]; then
+  DEV="$(xcrun simctl list devices available | grep -m1 -E 'iPhone' | grep -oE '[A-F0-9-]{36}')"
+  [ -n "$DEV" ] || { echo "error: no iPhone simulator available (Xcode > Settings > Components)" >&2; exit 1; }
+  echo "▸ booting simulator $DEV"
+  xcrun simctl boot "$DEV"
+  xcrun simctl bootstatus "$DEV" >/dev/null
+fi
+
+echo "▸ installing + launching"
+xcrun simctl install "$DEV" "$APP"
+xcrun simctl terminate "$DEV" com.gethouston.Houston >/dev/null 2>&1 || true
+xcrun simctl launch "$DEV" com.gethouston.Houston >/dev/null
+open -a Simulator
+echo "✓ Houston is running in the Simulator"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "pnpm install && pnpm dev",
     "dev": "mprocs",
     "dev:host": "HOUSTON_HOST_TOKEN=devtoken HOUSTON_HOST_PORT=4318 pnpm --filter @houston/host dev",
-    "dev:app": "cd app && VITE_NEW_ENGINE_URL=http://127.0.0.1:4318 VITE_NEW_ENGINE_TOKEN=devtoken VITE_HOSTED_ENGINE_URL= pnpm tauri dev"
+    "dev:app": "cd app && VITE_NEW_ENGINE_URL=http://127.0.0.1:4318 VITE_NEW_ENGINE_TOKEN=devtoken VITE_HOSTED_ENGINE_URL= pnpm tauri dev",
+    "ios": "bash mobile/ios/scripts/dev-sim.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.0",


### PR DESCRIPTION
Drift-repair after the last ~60 main commits (verified by a full parity-drift analysis — board/status contract survived intact; these were the only mobile impacts):

- **Breaking fix**: the conversation VM scope became agent-qualified + URI-encoded on main; iOS chat was subscribed to a dead scope. Exact `encodeURIComponent` port (JS unreserved set, UTF-8, uppercase hex — Foundation's `.urlQueryAllowed` is not equivalent), vectors pinned in tests.
- Additive: `ConversationVM.queued` + pending-bubble UI (population deferred to an SDK-bridge send-queue — surfaces never re-implement behavior), `failed_prompt` on auth errors (affordance deferred with the v1 card cut), HOU-655 status reclassification mirrored (loading persists through thinking/tool phases).
- `mobile/PARITY.md` errata + new BRIDGE-addressing section; `mobile/PARITY-SETTINGS.md` added (extracted desktop contract for the upcoming Settings / AI Models / Integrations wave).
- DX: **`pnpm ios`** — one-command build+launch into the iOS Simulator.

iOS build clean; **213/213** unit tests (14 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)