### PR TITLE
feat(sdk): providers, integrations, and preferences modules for mobile

### DIFF
--- a/mobile/PARITY-SETTINGS.md
+++ b/mobile/PARITY-SETTINGS.md
@@ -1,0 +1,142 @@
+# iOS Parity Spec — Settings · AI Models · Integrations (hosted mode)
+
+> Extracted from houston/ + cloud/ on 2026-07-05 (citations were file:line-verified at extraction).
+> Companion to `mobile/PARITY.md`; same rules: en copy is authoritative (es/pt mirror keys),
+> update via the client-architecture procedures when desktop changes.
+
+## 0. Architecture facts that gate everything
+
+- iOS data path: Swift → SDK bridge bundle → `@houston/sdk` → `@houston/runtime-client`. iOS does
+  NOT use `ui/engine-client` (desktop/web front door).
+- Per-agent URL scoping: `sdk.ts clientFor(agentId)` → `${baseUrl}/agents/<id>/…`; flat calls go to
+  `${baseUrl}/…`. The injected fetch carries the Supabase JWT.
+- **Provider credentials are per-agent-pod** in hosted mode (`/auth/*`, `/providers`, `/settings`
+  are per-agent). There is NO global "connect Claude once".
+- **Integrations are the opposite**: gateway-owned, user-scoped (`caller.sub`), shared across the
+  user's agents; per-agent grants gate which agent may use each connected app.
+
+## 1. Settings surface (desktop: SettingsView/SettingsIndex)
+
+Header "Settings" (`settings:title`); subtitle "Manage your workspace and account."
+Rows/groups in desktop order (iOS ports all marked ✅):
+
+| Element | Copy key | Behavior | iOS |
+|---|---|---|---|
+| Workspace name | `settings:workspace.title` | rename → engine; toast `settings:toasts.workspaceRenamed` | ✅ |
+| Appearance | `settings:appearance.title` (+ `.light`/`.dark`) | DEVICE-LOCAL theme (no wire) | ✅ local |
+| Language | `settings:nav.language` | en/es/pt; persists `PATCH /workspaces/:id/locale {locale}` + local change; toast `common:language.toastChanged` | ✅ |
+| Account | `settings:account.title`; button `settings:account.signOut` "Sign out"; `.fallbackName` "Signed in" | avatar (`user_metadata.avatar_url`) + name (full_name→name→email) + email; Sign out = signOut(), NO confirm dialog | ✅ sign-out lives here |
+| Members | `org:members.navLabel` + `settings:index.rows.members` | only when `canSeeMembers(capabilities)` | ⚠ org only |
+| Group "Context" | `settings:index.groups.context` | | ✅ |
+| Workspace context | `settings:nav.workspaceContext` (+ value "Set" `.values.set`) | drill-in editor | ✅ |
+| Your context | `settings:nav.userContext` | drill-in editor | ✅ |
+| Group "Support" | `settings:index.groups.support` | | ✅ |
+| Report bug | `settings:nav.reportBug` "Report bug" / "Something broke? Tell us" (`settings:reportBug.*`) | message + recent logs | ✅ adapt log capture |
+| Danger zone | `settings:dangerZone.*` ("Danger zone", "Delete workspace", confirm keys) | deleteWorkspace; blocked if last (`.createAnotherFirst`) | ✅ destructive |
+| Version footer | `settings:version` "Version {{version}}" | tap copies; toasts `.versionCopied`/`.versionCopyFailed` | ✅ |
+
+SKIP on iOS: Keyboard shortcuts; Connect phone / QR pairing (legacy tunnel, dead); updater;
+local-engine rows.
+
+## 2. AI Models (desktop: ai-hub view, header `ai-hub:hero.title` "AI Models")
+
+Two tabs on desktop: Providers grid + "Models · N" directory.
+
+### 2a. Provider catalog (two id namespaces!)
+Frontend catalog: `app/src/lib/providers.ts` (UI ids, connect cards, logos; Codex = `openai`).
+Host/wire catalog: `packages/host/src/providers.ts` (Codex = `openai-codex`).
+Mapping: `capabilityIdsForProvider` (`app/src/lib/providers.ts:688`) — port to iOS.
+
+| UI id | Name | Auth | cloud? | Logo component |
+|---|---|---|---|---|
+| openai (wire openai-codex) | OpenAI (Codex) | oauth device-code | ✅ | OpenAILogo |
+| anthropic | Anthropic (Claude) | oauth device-code | ❌ ToS | ClaudeLogo |
+| github-copilot | GitHub Copilot | oauth device-code (+Enterprise dialog) | ❌ | GitHubCopilotLogo |
+| opencode + opencode-go (merged ONE card, `gatewayIds`) | OpenCode | apiKey | ✅ | OpenCodeLogo |
+| openrouter | OpenRouter | apiKey | ❌ | OpenRouterLogo |
+| deepseek | DeepSeek | apiKey | ❌ | DeepSeekLogo |
+| google | Google Gemini | apiKey | ❌ | GeminiLogo |
+| amazon-bedrock | Amazon Bedrock | apiKey | ❌ | AmazonBedrockLogo |
+| minimax | MiniMax | apiKey | ❌ | MiniMaxLogo |
+| openai-compatible | Local model | — | — | DESKTOP-ONLY, exclude |
+| subq | SubQ | coming soon | — | "SQ" mark |
+
+**LOGOS: no asset files — inline React SVG components in
+`app/src/components/shell/provider-logos.tsx`** (24×24 viewBox, currentColor; OpenCode two-tone
+240×300; OpenRouter/LocalModel/Bedrock stroked). Port the exact `<path d>` strings to SwiftUI.
+Dispatcher `ProviderGlyph` switches on id (google/gemini → GeminiLogo), falls back to first initial.
+Model lists per provider (id, label, effortLevels, contextWindow): `providers.ts:117-672` — port
+verbatim where iOS shows a model picker. Effort vocab low/medium/high/xhigh/max, default medium,
+model-clamped (`providers.ts:11-28,898-924`).
+
+### 2b. Hosted connect flow (wire = runtime-client, all per-agent paths)
+| Op | Wire |
+|---|---|
+| List | GET /providers → ProviderInfo[] {id,name,configured,isActive,activeModel,models[]} |
+| Status | GET /auth/status → {providers: ProviderAuth[], activeProvider} |
+| Start OAuth | POST /auth/:provider/login?deviceAuth=true[&enterpriseDomain=] → LoginInfo |
+| Cancel | POST /auth/:provider/login/cancel |
+| Complete (paste) | POST /auth/:provider/login/complete {code} — only `auth_code` kind |
+| API key | POST /auth/:provider/api-key {key} |
+| Logout | POST /auth/:provider/logout |
+| Active model | PUT /settings {activeProvider?, model?, effort?} (use SDK resolveModelSettings semantics) |
+
+`LoginInfo` union: `{kind:"url"}` (local only — not hosted) · `{kind:"auth_code", url, instructions?}`
+(open url, paste code → complete) · `{kind:"device_code", verificationUri, userCode}` (show code,
+open uri, poll GET /auth/status until configured flips). Hosted = deviceAuth=true default.
+Copy: `providers:providerLogin.*` (deviceCodeLabel "One-time code", deviceCodeHint, deviceWaiting,
+copyCode/codeCopied, deviceSettingsHint for OpenAI), `providers:apiKey.*` ("Connect {{name}}",
+save "Connect", getKey "Get your API key"), `providers:signOutConfirm.*`, card states
+`providers:card.*` ("Connected"/"Not connected"/"Connecting..."/"Coming soon"), toasts
+`providers:toast.*`.
+
+## 3. Integrations (Composio; KB houston/knowledge-base/integrations.md, contracts C1/C4)
+
+Surfaces: global page (Connected apps grid + card→per-agent access sheet; always-visible
+"Connect more apps" catalog: A-Z ~1000 apps, category dropdown, search, load-more) and a per-agent
+tab (Apps this agent can use w/ deactivate toggles · Other apps connected (Activate=grant) ·
+Connect more). Degraded mode when grants null: all connected usable, no toggles.
+
+Wire (gateway, user JWT):
+- GET /v1/integrations → readiness ({provider:"composio", ready})
+- GET /v1/integrations/composio/toolkits → {items: {slug,name,description?,logoUrl?,categories?}}
+- GET /v1/integrations/composio/connections (+/:id poll) → {toolkit, connectionId, status: active|pending|error}
+- POST /v1/integrations/composio/connect {toolkit} → {redirectUrl, connectionId}: open URL (OAuth), poll until active
+- POST /v1/integrations/composio/disconnect {toolkit}
+- GET /v1/agents/:slug/integration-grants → {toolkits[]}; **404 → null → "unsupported, no toggles"; [] → nothing granted** (distinct!)
+- PUT /v1/agents/:slug/integration-grants {toolkits} (replace-set, slugs [a-z0-9_-]+; 403 not_assigned)
+
+503 when no COMPOSIO key on the gateway → show `integrations:unavailable` "Integrations are not
+available in this setup." Sign-in state: `integrations:signin.*`. **Toolkit logos are REMOTE
+`logoUrl`s (AsyncImage) — provider logos are inline SVG. Two rendering paths.**
+Copy: `integrations.json` — title "Integrations", `.home.description`, `.status.*` (Connected /
+Finishing up / Needs reconnecting), `.waiting.*`, disconnect confirms, `.agentTab.*`,
+`.connectMore.title`, `.picker.*`, `.browse.*`, recovery keys.
+
+## 4. SDK gaps (as of extraction)
+
+- providers: wire exists on runtime-client; NO SDK module → build `providers` module (per-agent).
+- integrations: absent from runtime-client (only ui/engine-client) → add user-scoped methods to
+  runtime-client + SDK `integrations` module (keep 404→null and 503 semantics).
+- preferences/locale: absent from runtime-client → add GET/PUT /preferences/:key +
+  PATCH /workspaces/:id/locale + SDK module.
+
+## 5. iOS IA (mirror desktop nav names/order)
+
+Desktop sidebar order: Mission Control · Integrations ("Integrations", icon Blocks) · AI Models
+("AI Models", icon Boxes) · Settings ("Settings", icon Settings). Per-agent tab set separately has
+Integrations + Agent Settings. Mobile: Settings tab groups rows as desktop (top card → Context →
+Support → Danger).
+
+## 6. Hosted-mode landmines
+1. Per-agent provider credentials — no user-level store; surface the scoping clearly.
+2. OAuth in hosted = device-code only; poll /auth/status; no loopback; no paste-back except auth_code.
+3. Provider availability varies by pod — read /providers at runtime, never hardcode (anthropic +
+   most apiKey providers are cloud:false today).
+4. Two provider-id namespaces (openai vs openai-codex; google/gemini) — carry the mapping.
+5. Integrations user-scoped, grants per-agent; 404-null vs empty-array are different states.
+6. 503 unconfigured must not crash the tab.
+7. Toolkit logos remote, provider logos inline SVG.
+8. openai-compatible is desktop-only.
+9. Theme device-local; language engine-persisted.
+10. Members rows conditional on capabilities.

--- a/mobile/PARITY.md
+++ b/mobile/PARITY.md
@@ -24,7 +24,21 @@ Unknown statuses are preserved and rendered neutrally. New activities are create
 settles `sessionStatus === "error"` **but** `boardStatus === "needs_you"`. **Read the pair, never
 `sessionStatus` alone** — keying off sessionStatus renders a normal Stop as red.
 `boardStatus:"needs_you"` = handled / your attention; `boardStatus:"error"` = genuine failure.
-`ConversationVM` exposes `{ feed, running, sessionStatus, boardStatus }`.
+`ConversationVM` exposes `{ feed, running, sessionStatus, boardStatus, queued? }` (`queued`
+additive — see §5).
+
+### BRIDGE addressing — the conversation VM scope (agent-qualified)
+`packages/sdk/src/modules/turns/vm-output.ts:83-87` (`conversationScope`): the conversation VM is
+published on **`conversation/<encodeURIComponent(agentPath)>/<encodeURIComponent(sessionKey)>`** —
+agent-qualified, because a `sessionKey` is unique only WITHIN one agent. The `agentPath` segment is
+the SAME string the surface passes as `agentId` to the `turns/*` commands (`index.ts:66,90-98` use
+the command's `agentId` verbatim as the scope's agent segment), so the subscribe scope and the
+publish scope stay in lockstep.
+- **iOS**: `SdkScope.conversation(agentPath:sessionKey:)` builds it; every component is escaped by a
+  from-scratch `encodeURIComponent` (unreserved set `A-Z a-z 0-9 - _ . ! ~ * ' ( )`, UTF-8 bytes,
+  uppercase hex) — Foundation's `.urlQueryAllowed` is NOT equivalent. Pinned to JS-generated fixtures
+  in `SdkScopeTests` (e.g. `"Houston/My Agent"` → `Houston%2FMy%20Agent`). A mismatch subscribes to a
+  scope the SDK never publishes on → the chat feed goes dead, so this is a hard contract.
 
 ### Board columns (kanban) — `app/src/components/mission-board-columns.ts`
 Left-to-right order and status→column mapping (single source of truth):
@@ -117,6 +131,45 @@ Status lines (`chat.json:process`): active = "Mission in progress..."; with acti
 "Mission in progress: {{action}}"; settled = "Mission log". Shimmer while active.
 **There is NO "Stopped by user" string** — a Stop moves the card to Needs you silently
 (the `cancelled` provider_error is dropped).
+
+### Status reclassification — loading indicator vs streaming (`ui/chat/src/chat-status.ts:27-49`)
+`deriveStatus`: only `assistant_text_streaming` counts as **streaming** (its visible growing text
+IS the progress signal, so the loading indicator would just compete with it). `thinking_streaming`,
+tool cycles, and silent gaps all resolve to **submitted** → the loading indicator STAYS VISIBLE
+through reasoning + tool phases (HOU-655: treating `thinking_streaming` as streaming flickered the
+indicator off during every thinking stretch).
+- **iOS**: `ChatStatus.derive(feed:running:)` (pure mirror) + `ChatScreenModel.showLoadingLabel`.
+  The `MissionStatusLine` renders while the turn is `running`; its "Mission in progress..." dot +
+  shimmer label is suppressed while assistant text streams (`showLabel:false`), leaving only the
+  **Stop** control (Stop stays available the entire running turn, matching desktop's composer stop).
+  Pinned in `ChatStatusTests`.
+
+### Queued messages while a turn runs (`ConversationVM.queued`, `vm-output.ts:35-58`)
+Additive optional `queued?: QueuedMessageVM[]` (`{ id, text, attachmentNames? }`): messages typed
+while a turn runs are HELD and flushed as ONE combined send at settle. **Queueing is SDK/engine-
+adapter behavior, never the surface** (desktop: `packages/web/src/engine-adapter/send-queue.ts`) —
+the surface only renders the published list (client-architecture.md invariant 1).
+- **iOS**: `QueuedMessageVM` model + `ConversationVM.queued`; `QueuedMessagesView` renders each as a
+  dimmed, pending, right-aligned bubble (clock glyph) above the composer. **Populate path deferred**:
+  the SDK *bridge* path iOS uses has no send-queue (only the web engine-adapter drives `setQueued`),
+  so `queued` is empty on iOS today — rendering is wired and forward-compatible for when a bridge-side
+  queue lands. The removable affordance stays deferred until the bridge exposes a `removeQueued` seam.
+
+### `failed_prompt` on the unauthenticated reconnect card (`ui/chat/src/types.ts:142-148`)
+The `unauthenticated` provider error gained optional `failed_prompt` (JSON key `failed_prompt`) —
+client-synthesized only (never on the wire; synthesized in `packages/sdk turn-settle.ts:92-104`):
+the prompt whose SEND the engine refused because no provider was connected, so a "Send again"
+affordance can resend THAT exact text.
+- **iOS**: carried on `ProviderError.unauthenticated(..., failedPrompt:)`. The iOS provider-error card
+  (`ProviderErrorCardView`) has **no action buttons** (v1 scope cut), so the "Send again" affordance
+  **stays deferred** — the field is modeled + decoded now so the card can wire it later with no
+  contract change.
+
+### Shell / splash copy
+Desktop shows a startup splash "Loading your workspace…" (`shell.json:278 starting`). **iOS has no
+equivalent splash copy**: `RootView` branches only to the SDK-startup error view, the sign-in gate,
+or the tabs — there is no loading-workspace screen, so nothing to align. (If a mobile startup splash
+is added later, mirror this string.)
 
 ## 6. New-mission flow (wire) — `app/src/lib/create-mission.ts`
 1. Create activity (`status:"running"`), id → session key `activity-{id}`.

--- a/mobile/ios/Houston/Core/Bridge/Models/ConversationVM.swift
+++ b/mobile/ios/Houston/Core/Bridge/Models/ConversationVM.swift
@@ -16,6 +16,22 @@ struct ConversationVM: Decodable, Equatable, Sendable {
   /// handled-vs-error signal: `needsYou` = handled / attention, `error` = a real
   /// failure.
   var boardStatus: BoardStatus?
+  /// Messages typed while a turn runs — held and flushed as ONE combined send
+  /// when the turn settles (additive; absent when none). Rendered as pending
+  /// bubbles above the composer so the user sees their queued texts. Queueing
+  /// itself is behavior owned by the SDK/engine adapter, never the surface; this
+  /// surface only mirrors the published list (client-architecture.md invariant 1).
+  var queued: [QueuedMessageVM]?
+}
+
+/// A message queued while a turn runs (SDK `QueuedMessageVM`, `vm-output.ts`):
+/// a stable id, the user's text, and any attachment names. Rendered visually
+/// pending; removable once the SDK bridge exposes the remove seam.
+struct QueuedMessageVM: Decodable, Equatable, Identifiable, Sendable {
+  let id: String
+  let text: String
+  /// Attachment file names shown alongside the queued text; absent when none.
+  var attachmentNames: [String]?
 }
 
 /// A single reactive feed entry: a stable id plus the raw push payload. The

--- a/mobile/ios/Houston/Core/Bridge/Models/ProviderError.swift
+++ b/mobile/ios/Houston/Core/Bridge/Models/ProviderError.swift
@@ -14,7 +14,8 @@ enum ProviderError: Decodable, Equatable, Sendable {
   case modelUnavailable(
     provider: String, model: String, reason: ModelUnavailableReason,
     suggestedFallback: String?, message: String)
-  case unauthenticated(provider: String, cause: AuthFailureCause, message: String)
+  case unauthenticated(
+    provider: String, cause: AuthFailureCause, message: String, failedPrompt: String?)
   case networkUnreachable(provider: String, message: String)
   case providerInternal(provider: String, httpStatus: Int?, message: String)
   case sessionResumeMissing(provider: String, sessionId: String)
@@ -52,9 +53,12 @@ enum ProviderError: Decodable, Equatable, Sendable {
         reason: ModelUnavailableReason(raw: raw["reason"]?.stringValue),
         suggestedFallback: raw["suggested_fallback"]?.stringValue, message: message)
     case "unauthenticated":
+      // `failed_prompt` is client-synthesized only (never on the wire): the
+      // prompt whose SEND the engine refused because no provider was connected,
+      // so a "Send again" affordance can resend THIS text (turn-settle.ts).
       self = .unauthenticated(
         provider: provider, cause: AuthFailureCause(raw: raw["cause"]?.stringValue),
-        message: message)
+        message: message, failedPrompt: raw["failed_prompt"]?.stringValue)
     case "network_unreachable":
       self = .networkUnreachable(provider: provider, message: message)
     case "provider_internal":

--- a/mobile/ios/Houston/Core/Bridge/Models/SdkScope.swift
+++ b/mobile/ios/Houston/Core/Bridge/Models/SdkScope.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Typed builders for the SDK scope strings a surface subscribes to.
 ///
-/// Scopes are opaque strings on the wire (`"agents"`, `"conversation/<id>"`,
+/// Scopes are opaque strings on the wire (`"agents"`, `"conversation/<agent>/<id>"`,
 /// `"activities/<agentId>"`); centralizing their construction here keeps callers
 /// from hand-formatting one and risking a typo. The values mirror the scope
 /// helpers in `packages/sdk/src` verbatim.
@@ -13,15 +13,40 @@ enum SdkScope {
     "conversations/\(agentId)"
   }
 
-  /// One conversation's live feed VM — `conversation/<sessionKey>`
-  /// (`conversationScope`).
-  static func conversation(sessionKey: String) -> String {
-    "conversation/\(sessionKey)"
+  /// One conversation's live feed VM — `conversation/<agentPath>/<sessionKey>`
+  /// (`conversationScope`, `packages/sdk/src/modules/turns/vm-output.ts`).
+  ///
+  /// Agent-qualified: a session key is unique only WITHIN one agent, so the
+  /// scope carries both. Each component is `encodeURIComponent`-escaped exactly
+  /// as the SDK escapes it (`encodeURIComponent(agentPath)/encodeURIComponent(
+  /// sessionKey)`) — a mismatch here silently subscribes to a scope the SDK
+  /// never publishes on, so the chat feed goes dead. `agentPath` is the SAME
+  /// string this surface passes as `agentId` to the `turns/*` commands (the SDK
+  /// uses the command's `agentId` verbatim as the scope's agent segment), which
+  /// keeps the subscribe scope and the publish scope in lockstep.
+  static func conversation(agentPath: String, sessionKey: String) -> String {
+    "conversation/\(encodeURIComponent(agentPath))/\(encodeURIComponent(sessionKey))"
   }
 
   /// One agent's board/missions list — `activities/<agentId>`
   /// (`activitiesScope`).
   static func activities(agentId: String) -> String {
     "activities/\(agentId)"
+  }
+
+  /// The JS `encodeURIComponent` unreserved set: percent-encode everything
+  /// EXCEPT `A-Z a-z 0-9 - _ . ! ~ * ' ( )`. Foundation's `.urlQueryAllowed`
+  /// differs (it keeps `/`, `?`, `&`, `=`, … and treats non-ASCII letters as
+  /// allowed), so it is NOT usable here — the set is spelled out ASCII-only.
+  private static let encodeURIComponentAllowed: CharacterSet = CharacterSet(
+    charactersIn:
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_.!~*'()")
+
+  /// Escape one scope component exactly as JS `encodeURIComponent` does:
+  /// UTF-8 bytes, uppercase hex, only the unreserved set left literal.
+  /// `addingPercentEncoding` is total for a native `String` (always valid
+  /// UTF-8), so the force-unwrap is a genuine invariant, not a swallowed error.
+  static func encodeURIComponent(_ component: String) -> String {
+    component.addingPercentEncoding(withAllowedCharacters: encodeURIComponentAllowed)!
   }
 }

--- a/mobile/ios/Houston/Features/Chat/ChatScreenModel.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatScreenModel.swift
@@ -38,7 +38,8 @@ final class ChatScreenModel {
   ) {
     self.agentId = agentId
     self.conversationId = conversationId
-    self.conversation = client.scope(SdkScope.conversation(sessionKey: conversationId))
+    self.conversation = client.scope(
+      SdkScope.conversation(agentPath: agentId, sessionKey: conversationId))
     self.activities = client.scope(SdkScope.activities(agentId: agentId))
     self.commands = commands ?? SdkChatCommands(client: client)
   }
@@ -49,6 +50,21 @@ final class ChatScreenModel {
   var rows: [ChatRow] { MissionFeedFold.rows(from: vm?.feed ?? []) }
   var running: Bool { vm?.running ?? false }
   var isEmpty: Bool { vm?.feed.isEmpty ?? true }
+
+  /// Messages queued while the turn runs, rendered as pending bubbles above the
+  /// composer (PARITY §5). Empty until the SDK bridge publishes a `queued` list.
+  var queued: [QueuedMessageVM] { vm?.queued ?? [] }
+
+  /// The in-flight display status (mirrors desktop `deriveStatus`). Drives the
+  /// loading indicator: shown while ``running`` UNLESS assistant text is
+  /// streaming (then the visible bubble is the progress signal); the Stop
+  /// control stays available throughout the running turn regardless.
+  var chatStatus: ChatStatus { ChatStatus.derive(feed: vm?.feed ?? [], running: running) }
+
+  /// Whether the "Mission in progress..." loading label shows: only when a turn
+  /// is in flight and no assistant text is streaming. Reasoning + tool phases
+  /// keep it visible (`chat-status.ts`, HOU-655).
+  var showLoadingLabel: Bool { running && chatStatus != .streaming }
 
   /// The Approve bar shows only when the board card is `needs_you` AND no turn is
   /// running — read the pair, never `sessionStatus` alone (PARITY §1/§5).

--- a/mobile/ios/Houston/Features/Chat/ChatStatus.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatStatus.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// The chat's in-flight display state, mirroring the desktop `ChatStatus`
+/// (`ui/chat/src/chat-panel-types.ts`) and its `deriveStatus` reclassification
+/// (`ui/chat/src/chat-status.ts`).
+///
+/// Only `assistant_text_streaming` counts as `.streaming`: it is the ONE feed
+/// type whose progressively-appearing content is visible on screen, so the
+/// loading indicator would just compete with it. `thinking_streaming` used to
+/// count too, but since HOU-448 the reasoning streams inside a collapsed block —
+/// nothing moves on screen — so treating it as streaming flickered the loading
+/// state off during every thinking stretch (HOU-655). EVERY in-flight case with
+/// no visible text streaming resolves to `.submitted` so the loading indicator
+/// stays visible through reasoning + tool phases.
+enum ChatStatus: Equatable, Sendable {
+  /// Settled — no loading indicator.
+  case ready
+  /// Assistant text is streaming; the bubble IS the progress signal, so the
+  /// standalone loading indicator is suppressed.
+  case streaming
+  /// A turn is in flight with nothing visibly streaming — show the loading
+  /// indicator (the only signal during reasoning / tool / silent-gap stretches).
+  case submitted
+
+  /// Reclassify the feed + running flag into a status, byte-for-byte the desktop
+  /// `deriveStatus(items, isLoading)`: last frame `assistant_text_streaming` →
+  /// `.streaming`; otherwise any running turn (or a just-sent optimistic
+  /// `user_message`) → `.submitted`; else `.ready`.
+  static func derive(feed: [FeedItemVM], running: Bool) -> ChatStatus {
+    let lastType = feed.last?.feedType
+    if lastType == "assistant_text_streaming" { return .streaming }
+    if running { return .submitted }
+    if lastType == "user_message" { return .submitted }
+    return .ready
+  }
+}

--- a/mobile/ios/Houston/Features/Chat/ChatView.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatView.swift
@@ -56,15 +56,20 @@ struct ChatView: View {
     @Bindable var model = model
     return VStack(spacing: 0) {
       if model.running {
-        MissionStatusLine(action: nil) { model.stop() }
+        MissionStatusLine(action: nil, showLabel: model.showLoadingLabel) { model.stop() }
       }
       if model.showApproveBar {
         ApproveBar { model.approve() }
       }
+      if !model.queued.isEmpty {
+        QueuedMessagesView(messages: model.queued)
+      }
       MissionComposer(text: $model.draft, isSending: model.isSending) { model.send() }
     }
     .animation(.smooth(duration: Motion.fast), value: model.running)
+    .animation(.smooth(duration: Motion.fast), value: model.showLoadingLabel)
     .animation(.smooth(duration: Motion.fast), value: model.showApproveBar)
+    .animation(.smooth(duration: Motion.fast), value: model.queued)
   }
 
   private var errorPresented: Binding<Bool> {

--- a/mobile/ios/Houston/Features/Chat/MissionFeedFold.swift
+++ b/mobile/ios/Houston/Features/Chat/MissionFeedFold.swift
@@ -147,7 +147,7 @@ extension ProviderError {
     case let .quotaExhausted(p, _, _, _, _): return "quota_exhausted:\(p)"
     case let .usageLimitPaused(p, _, _): return "usage_limit_paused:\(p)"
     case let .modelUnavailable(p, _, _, _, _): return "model_unavailable:\(p)"
-    case let .unauthenticated(p, _, _): return "unauthenticated:\(p)"
+    case let .unauthenticated(p, _, _, _): return "unauthenticated:\(p)"
     case let .networkUnreachable(p, _): return "network_unreachable:\(p)"
     case let .providerInternal(p, _, _): return "provider_internal:\(p)"
     case let .sessionResumeMissing(p, _): return "session_resume_missing:\(p)"

--- a/mobile/ios/Houston/Features/Chat/MissionStatusLine.swift
+++ b/mobile/ios/Houston/Features/Chat/MissionStatusLine.swift
@@ -4,22 +4,31 @@ import SwiftUI
 /// a shimmering "Mission in progress..." (with ": {{action}}" when the VM exposes
 /// a current action) and a Stop control. Stop cancels the turn — there is NO
 /// "stopped" copy; a Stop moves the card to Needs you silently.
+///
+/// The loading label is suppressed while assistant text is streaming
+/// (`showLabel == false`): the visible streaming bubble is the progress signal,
+/// so only the Stop control remains (mirrors desktop `deriveStatus`, PARITY §5).
 struct MissionStatusLine: View {
   @Environment(\.theme) private var theme
   /// The current action the VM exposes, if any; nil renders the base copy.
   var action: String?
+  /// Whether the loading dot + "Mission in progress..." label shows. When false
+  /// (assistant text streaming), only the Stop control renders.
+  var showLabel: Bool = true
   let onStop: () -> Void
 
   var body: some View {
     HStack(spacing: Spacing.space10) {
-      Circle()
-        .fill(GlowColor.running)
-        .frame(width: 6, height: 6)  // status-dot diameter, matching StatusChip
-      Text(label)
-        .font(Typography.label)
-        .foregroundStyle(theme.mutedFg)
-        .lineLimit(1)
-        .shimmer(active: true)
+      if showLabel {
+        Circle()
+          .fill(GlowColor.running)
+          .frame(width: 6, height: 6)  // status-dot diameter, matching StatusChip
+        Text(label)
+          .font(Typography.label)
+          .foregroundStyle(theme.mutedFg)
+          .lineLimit(1)
+          .shimmer(active: true)
+      }
       Spacer(minLength: Spacing.space8)
       Button(action: onStop) {
         Text(Strings.Chat.stop)

--- a/mobile/ios/Houston/Features/Chat/ProviderErrorPresentation.swift
+++ b/mobile/ios/Houston/Features/Chat/ProviderErrorPresentation.swift
@@ -38,7 +38,7 @@ extension ProviderError {
         title: C.modelUnavailableTitle,
         detail: C.modelUnavailableBody(model: model, provider: provider))
 
-    case let .unauthenticated(provider, cause, _):
+    case let .unauthenticated(provider, cause, _, _):
       return .init(
         title: C.unauthenticatedTitle(provider: provider),
         detail: Self.unauthDetail(provider: provider, cause: cause))

--- a/mobile/ios/Houston/Features/Chat/QueuedMessagesView.swift
+++ b/mobile/ios/Houston/Features/Chat/QueuedMessagesView.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// The pending queued-message bubbles shown above the composer while a turn runs
+/// (PARITY §5): a send typed mid-turn is held by the SDK and flushed as one
+/// combined send at settle, and its text renders here as a dimmed, right-aligned
+/// user bubble with a "pending" clock so the user sees what will send next.
+///
+/// Mirrors the desktop composer's queued-bubble affordance
+/// (`packages/web/src/engine-adapter/send-queue.ts`). Rendered only when the VM
+/// publishes a non-empty `queued` list.
+struct QueuedMessagesView: View {
+  let messages: [QueuedMessageVM]
+
+  var body: some View {
+    VStack(spacing: Spacing.space6) {
+      ForEach(messages) { message in
+        QueuedBubble(message: message)
+      }
+    }
+    .padding(.horizontal, Spacing.space12)
+    .padding(.top, Spacing.space6)
+    .accessibilityElement(children: .contain)
+    .accessibilityLabel(Strings.Chat.queued)
+  }
+}
+
+/// One pending queued message: a dimmed user bubble with a leading clock glyph
+/// and, when present, its attachment names.
+private struct QueuedBubble: View {
+  @Environment(\.theme) private var theme
+  let message: QueuedMessageVM
+
+  var body: some View {
+    HStack(alignment: .bottom, spacing: Spacing.space6) {
+      Spacer(minLength: Spacing.space40)
+      Image(systemName: "clock")
+        .font(Typography.caption)
+        .foregroundStyle(theme.mutedFg)
+      VStack(alignment: .trailing, spacing: Spacing.space2) {
+        Text(message.text)
+          .font(Typography.body)
+          .foregroundStyle(theme.primaryFg)
+          .padding(.horizontal, Spacing.space12)
+          .padding(.vertical, Spacing.space8)
+          .background(theme.primary, in: BubbleShape(tail: .trailing))
+        if let names = message.attachmentNames, !names.isEmpty {
+          Text(names.joined(separator: ", "))
+            .font(Typography.caption)
+            .foregroundStyle(theme.mutedFg)
+            .lineLimit(1)
+        }
+      }
+      .opacity(0.6)  // visually pending until the queued send flushes at settle
+    }
+  }
+}

--- a/mobile/ios/Houston/Features/Chat/Strings+Chat.swift
+++ b/mobile/ios/Houston/Features/Chat/Strings+Chat.swift
@@ -23,6 +23,8 @@ extension Strings {
     }
     /// The settled turn-summary heading (chat.json:process.complete).
     static let missionLog = "Mission log"
+    /// Accessibility label for the pending queued-message bubbles (PARITY §5).
+    static let queued = "Queued messages"
 
     // Reasoning block (chat.json:reasoning).
     static let thinking = "Thinking..."

--- a/mobile/ios/HoustonTests/Chat/ChatStatusTests.swift
+++ b/mobile/ios/HoustonTests/Chat/ChatStatusTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+
+@testable import Houston
+
+/// Pins the status reclassification to desktop `deriveStatus`
+/// (`ui/chat/src/chat-status.ts`): only `assistant_text_streaming` is
+/// `.streaming`; `thinking_streaming` and tool phases keep the loading state
+/// (`.submitted`) visible (HOU-655).
+final class ChatStatusTests: XCTestCase {
+  private func feed(_ types: [String]) -> [FeedItemVM] {
+    types.enumerated().map { index, type in
+      vm("f\(index)", type)
+    }
+  }
+
+  private func vm(_ id: String, _ type: String) -> FeedItemVM {
+    let object = JSONValue.object([
+      "id": .string(id), "feed_type": .string(type), "data": .string(""),
+    ])
+    guard let item = try? object.decode(FeedItemVM.self) else {
+      fatalError("FeedItemVM fixture failed to decode")
+    }
+    return item
+  }
+
+  func testAssistantTextStreamingIsStreaming() {
+    let status = ChatStatus.derive(
+      feed: feed(["user_message", "thinking", "assistant_text_streaming"]), running: true)
+    XCTAssertEqual(status, .streaming, "visible streaming text is the progress signal")
+  }
+
+  func testThinkingStreamingStaysSubmitted() {
+    // The reclassification's whole point: reasoning keeps the loading indicator.
+    let status = ChatStatus.derive(
+      feed: feed(["user_message", "thinking_streaming"]), running: true)
+    XCTAssertEqual(status, .submitted)
+  }
+
+  func testToolCycleStaysSubmitted() {
+    let status = ChatStatus.derive(feed: feed(["tool_call", "tool_result"]), running: true)
+    XCTAssertEqual(status, .submitted, "silent tool/gap stretches keep the indicator")
+  }
+
+  func testRunningWithEmptyFeedIsSubmitted() {
+    XCTAssertEqual(ChatStatus.derive(feed: [], running: true), .submitted)
+  }
+
+  func testJustSentUserMessageIsSubmittedEvenBeforeRunning() {
+    XCTAssertEqual(ChatStatus.derive(feed: feed(["user_message"]), running: false), .submitted)
+  }
+
+  func testSettledIsReady() {
+    let status = ChatStatus.derive(
+      feed: feed(["user_message", "assistant_text", "final_result"]), running: false)
+    XCTAssertEqual(status, .ready)
+  }
+}

--- a/mobile/ios/HoustonTests/SdkClient/ModelDecodingTests.swift
+++ b/mobile/ios/HoustonTests/SdkClient/ModelDecodingTests.swift
@@ -61,6 +61,47 @@ final class ModelDecodingTests: XCTestCase {
     XCTAssertEqual(result.usage?.contextTokens, 8000)
   }
 
+  func testConversationVMDecodesQueuedMessages() throws {
+    // Additive `queued` list: messages typed while a turn runs (vm-output.ts).
+    let json = """
+      {"feed":[],"running":true,"sessionStatus":"running","boardStatus":"running",
+       "queued":[{"id":"q0","text":"and also check email","attachmentNames":["report.pdf"]},
+                 {"id":"q1","text":"thanks"}]}
+      """
+    let vm = try BridgeTestJSON.decode(ConversationVM.self, json)
+    XCTAssertEqual(vm.queued?.count, 2)
+    XCTAssertEqual(vm.queued?.first?.id, "q0")
+    XCTAssertEqual(vm.queued?.first?.text, "and also check email")
+    XCTAssertEqual(vm.queued?.first?.attachmentNames, ["report.pdf"])
+    XCTAssertNil(vm.queued?.last?.attachmentNames, "attachmentNames absent → nil")
+  }
+
+  func testConversationVMQueuedAbsentIsNil() throws {
+    // The field is omitted when empty; the decode must not require it.
+    let vm = try BridgeTestJSON.decode(
+      ConversationVM.self,
+      #"{"feed":[],"running":false,"sessionStatus":"idle"}"#)
+    XCTAssertNil(vm.queued)
+  }
+
+  func testUnauthenticatedCarriesFailedPrompt() throws {
+    // Client-synthesized `failed_prompt` rides the not-connected reconnect card
+    // (turn-settle.ts) so a "Send again" affordance can resend the exact text.
+    let error = try BridgeTestJSON.decode(
+      ProviderError.self,
+      #"{"kind":"unauthenticated","provider":"claude","cause":"no_credentials","message":"m","failed_prompt":"draft an invoice"}"#)
+    guard case let .unauthenticated(_, _, _, failedPrompt) = error else { return XCTFail() }
+    XCTAssertEqual(failedPrompt, "draft an invoice")
+  }
+
+  func testUnauthenticatedFailedPromptAbsentIsNil() throws {
+    let error = try BridgeTestJSON.decode(
+      ProviderError.self,
+      #"{"kind":"unauthenticated","provider":"claude","cause":"token_expired","message":"m"}"#)
+    guard case let .unauthenticated(_, _, _, failedPrompt) = error else { return XCTFail() }
+    XCTAssertNil(failedPrompt)
+  }
+
   func testFeedItemUnknownTypeFallsBack() throws {
     let vm = try BridgeTestJSON.decode(
       ConversationVM.self,

--- a/mobile/ios/HoustonTests/SdkClient/SdkScopeTests.swift
+++ b/mobile/ios/HoustonTests/SdkClient/SdkScopeTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+
+@testable import Houston
+
+/// Pins `SdkScope.conversation` to the SDK's `conversationScope`
+/// (`packages/sdk/src/modules/turns/vm-output.ts`): agent-qualified and
+/// `encodeURIComponent`-escaped per component. A drift here silently subscribes
+/// to a scope the SDK never publishes on, so the chat feed goes dead.
+///
+/// The expected strings are the output of Node's `encodeURIComponent` — Swift's
+/// `.urlQueryAllowed` is NOT equivalent (it keeps `/`, `&`, `=`, … literal and
+/// treats non-ASCII letters as allowed), so this guards the exact unreserved set
+/// `A-Z a-z 0-9 - _ . ! ~ * ' ( )`.
+final class SdkScopeTests: XCTestCase {
+  // MARK: encodeURIComponent parity (JS-generated fixtures)
+
+  func testEncodeURIComponentMatchesJSFixtures() {
+    // Each pair is `encodeURIComponent(input)` captured from Node.
+    let vectors: [(String, String)] = [
+      ("Houston/My Agent", "Houston%2FMy%20Agent"),
+      ("activity-42", "activity-42"),
+      ("-_.!~*'()", "-_.!~*'()"),  // the full unreserved set is left literal
+      ("a b/c?d&e=f#g", "a%20b%2Fc%3Fd%26e%3Df%23g"),
+      ("Café/Über", "Caf%C3%A9%2F%C3%9Cber"),  // non-ASCII → UTF-8, uppercase hex
+      ("100% done", "100%25%20done"),
+      ("tab\tnew\nline", "tab%09new%0Aline"),
+      ("x+y z", "x%2By%20z"),  // '+' is NOT unreserved (unlike a query encoder)
+    ]
+    for (input, expected) in vectors {
+      XCTAssertEqual(
+        SdkScope.encodeURIComponent(input), expected,
+        "encodeURIComponent(\(input))")
+    }
+  }
+
+  // MARK: agent-qualified scope
+
+  func testConversationScopeIsAgentQualifiedAndEscaped() {
+    XCTAssertEqual(
+      SdkScope.conversation(agentPath: "Houston/My Agent", sessionKey: "activity-42"),
+      "conversation/Houston%2FMy%20Agent/activity-42")
+  }
+
+  func testConversationScopeEscapesBothComponents() {
+    // A session key with reserved characters must be escaped independently of
+    // the agent segment (each `encodeURIComponent`, joined by a literal '/').
+    XCTAssertEqual(
+      SdkScope.conversation(agentPath: "Acme Co", sessionKey: "a/b c"),
+      "conversation/Acme%20Co/a%2Fb%20c")
+  }
+
+  func testConversationScopeKeepsPrefixForSubscriptionRouting() {
+    // The bridge routes conversation subscriptions by the `conversation/` prefix;
+    // the qualified form must preserve it.
+    XCTAssertTrue(
+      SdkScope.conversation(agentPath: "ag1", sessionKey: "s1").hasPrefix("conversation/"))
+  }
+}

--- a/mobile/ios/scripts/dev-sim.sh
+++ b/mobile/ios/scripts/dev-sim.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-command iOS dev loop: build the app and run it in the iOS Simulator.
+#   pnpm ios            (from the repo root)
+# Regenerates the Xcode project, builds Debug for the simulator (the pre-build
+# phases bundle the SDK + sync design tokens), boots a simulator if none is
+# booted, installs, launches, and brings the Simulator window to front.
+
+HERE="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$HERE"
+
+# Xcode may be installed while xcode-select still points at CommandLineTools
+# (switching needs sudo). DEVELOPER_DIR is the no-sudo equivalent.
+if ! xcodebuild -version >/dev/null 2>&1; then
+  export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+fi
+xcodebuild -version >/dev/null 2>&1 || {
+  echo "error: Xcode not found (install it from the App Store)" >&2; exit 1; }
+command -v xcodegen >/dev/null 2>&1 || {
+  echo "error: xcodegen not found (brew install xcodegen)" >&2; exit 1; }
+
+echo "▸ xcodegen"
+xcodegen generate --quiet
+
+echo "▸ building (Debug, iOS Simulator)"
+xcodebuild -project Houston.xcodeproj -scheme Houston \
+  -configuration Debug -destination 'generic/platform=iOS Simulator' \
+  -derivedDataPath build/DerivedData -quiet build
+
+APP="build/DerivedData/Build/Products/Debug-iphonesimulator/Houston.app"
+test -d "$APP" || { echo "error: built app not found at $APP" >&2; exit 1; }
+
+# Reuse the booted simulator, else boot the first available iPhone.
+DEV="$(xcrun simctl list devices booted | grep -m1 -oE '[A-F0-9-]{36}' || true)"
+if [ -z "$DEV" ]; then
+  DEV="$(xcrun simctl list devices available | grep -m1 -E 'iPhone' | grep -oE '[A-F0-9-]{36}')"
+  [ -n "$DEV" ] || { echo "error: no iPhone simulator available (Xcode > Settings > Components)" >&2; exit 1; }
+  echo "▸ booting simulator $DEV"
+  xcrun simctl boot "$DEV"
+  xcrun simctl bootstatus "$DEV" >/dev/null
+fi
+
+echo "▸ installing + launching"
+xcrun simctl install "$DEV" "$APP"
+xcrun simctl terminate "$DEV" com.gethouston.Houston >/dev/null 2>&1 || true
+xcrun simctl launch "$DEV" com.gethouston.Houston >/dev/null
+open -a Simulator
+echo "✓ Houston is running in the Simulator"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "start": "pnpm install && pnpm dev",
     "dev": "mprocs",
     "dev:host": "HOUSTON_HOST_TOKEN=devtoken HOUSTON_HOST_PORT=4318 pnpm --filter @houston/host dev",
-    "dev:app": "cd app && VITE_NEW_ENGINE_URL=http://127.0.0.1:4318 VITE_NEW_ENGINE_TOKEN=devtoken VITE_HOSTED_ENGINE_URL= pnpm tauri dev"
+    "dev:app": "cd app && VITE_NEW_ENGINE_URL=http://127.0.0.1:4318 VITE_NEW_ENGINE_TOKEN=devtoken VITE_HOSTED_ENGINE_URL= pnpm tauri dev",
+    "ios": "bash mobile/ios/scripts/dev-sim.sh"
   },
   "devDependencies": {
     "@biomejs/biome": "2.5.0",

--- a/packages/fake-host/src/provider-catalog.ts
+++ b/packages/fake-host/src/provider-catalog.ts
@@ -1,0 +1,57 @@
+/**
+ * The fake host's AI-provider catalog — the static shape of each provider the
+ * per-agent connect flow exposes (name, auth kind, the `LoginInfo` kind its
+ * `startLogin` returns, its selectable models). The mutable per-agent
+ * credential/active state lives in `state-providers.ts`; this is the fixed spine
+ * it reads.
+ *
+ * A small but realistic set spanning both auth kinds and both hosted login kinds
+ * (`auth_code` = paste-back Claude; `device_code` = Codex/Copilot), so a contract
+ * test can exercise every branch. Wire types come from the real package so a
+ * `ProviderId` change breaks the typecheck here instead of drifting the mock.
+ */
+
+import type { ProviderId } from "@houston/runtime-client";
+
+export interface ProviderSpec {
+  id: ProviderId;
+  name: string;
+  /** How the user connects: an OAuth dance or a pasted API key. */
+  connect: "oauth" | "apiKey";
+  /** The `LoginInfo` kind `startLogin` returns for the OAuth providers. */
+  loginKind: "auth_code" | "device_code";
+  models: string[];
+}
+
+export const CATALOG: ProviderSpec[] = [
+  {
+    id: "anthropic",
+    name: "Anthropic (Claude)",
+    connect: "oauth",
+    loginKind: "auth_code",
+    models: ["claude-sonnet-4-6", "claude-opus-4-8"],
+  },
+  {
+    id: "openai-codex",
+    name: "OpenAI (Codex)",
+    connect: "oauth",
+    loginKind: "device_code",
+    models: ["gpt-5-codex", "o4-mini"],
+  },
+  {
+    id: "github-copilot",
+    name: "GitHub Copilot",
+    connect: "oauth",
+    loginKind: "device_code",
+    models: ["gpt-4.1", "claude-sonnet-4-6"],
+  },
+  {
+    id: "openrouter",
+    name: "OpenRouter",
+    connect: "apiKey",
+    loginKind: "device_code",
+    models: ["auto", "z-ai/glm-4.6"],
+  },
+];
+
+export const SPEC = new Map(CATALOG.map((s) => [s.id, s]));

--- a/packages/fake-host/src/router.ts
+++ b/packages/fake-host/src/router.ts
@@ -15,8 +15,9 @@ import {
   killRunningTurns,
   turnBoundary,
 } from "./chat-controls";
-import { CORS, json, noContent } from "./http";
+import { CORS, json } from "./http";
 import { authStatusBody, handleAgents, providersBody } from "./routes";
+import { handleUserRoutes } from "./routes-integrations";
 import { sseResponse } from "./sse";
 import * as state from "./state";
 
@@ -91,6 +92,23 @@ export async function handle(req: Request): Promise<Response> {
       advanced: turnBoundary(String(body?.nextText ?? "next turn")),
     });
   }
+  // Toggle Composio readiness: "ready" | "unavailable" (503) | "signin".
+  if (path === "/__test__/integrations-mode" && method === "POST") {
+    const body = await parseBody(req);
+    state.setIntegrationsMode(
+      body?.mode === "unavailable" || body?.mode === "signin"
+        ? body.mode
+        : "ready",
+    );
+    return json({ mode: state.integrationsMode() });
+  }
+  // Flip a pending connection to active (models the OAuth completing).
+  if (path === "/__test__/integrations-activate" && method === "POST") {
+    const body = await parseBody(req);
+    return json({
+      activated: state.activateConnection(String(body?.connectionId ?? "")),
+    });
+  }
 
   // --- global reactivity feed ---
   if (path === "/v1/events" && method === "GET") return openDomainStream(req);
@@ -120,13 +138,9 @@ export async function handle(req: Request): Promise<Response> {
     };
     return json(caps);
   }
-  if (segs[0] === "v1" && segs[1] === "workspaces") return json([]);
-  // Composio integrations: report none connected (control-plane.ts wants `{ items }`).
-  if (segs[0] === "v1" && segs[1] === "integrations")
-    return json({ items: [] });
-  if (segs[0] === "v1" && segs[1] === "preferences") {
-    return method === "GET" ? json({ value: null }) : noContent();
-  }
+  // --- user-scoped gateway routes (integrations, grants, preferences, locale) ---
+  const userRoute = handleUserRoutes(method, segs, body);
+  if (userRoute) return userRoute;
 
   // --- everything under /agents/* ---
   if (segs[0] === "agents") {

--- a/packages/fake-host/src/routes-integrations.ts
+++ b/packages/fake-host/src/routes-integrations.ts
@@ -1,0 +1,163 @@
+/**
+ * User-scoped gateway routes for the fake host: Composio integrations, per-agent
+ * integration grants, key/value preferences, and the workspace-locale override.
+ *
+ * These mirror the cloud gateway (`user-routes.ts` + `integrations-routes.ts`)
+ * and the host `account.ts`, keyed by "the acting user" — there is one user in
+ * the fake host, so no per-user keying is modeled. Returns a `Response` when a
+ * route matched, or `undefined` to let the router fall through.
+ */
+
+import { SEED_WORKSPACE_ID } from "./config";
+import { json } from "./http";
+import * as state from "./state";
+
+/** The workspace wire shape the gateway/host return (account.ts `toWire`). */
+function workspaceWire() {
+  return {
+    id: SEED_WORKSPACE_ID,
+    name: SEED_WORKSPACE_ID,
+    isDefault: true,
+    createdAt: new Date(0).toISOString(),
+    locale: state.getPreference("locale"),
+  };
+}
+
+/** Every integrations + grants route 503s when no Composio key is configured. */
+function unavailable(): Response {
+  return json({ error: "integrations not configured" }, 503);
+}
+
+function handleComposio(
+  method: string,
+  tail: string[],
+  body: Record<string, unknown> | undefined,
+): Response {
+  // GET /v1/integrations/composio/toolkits
+  if (tail.length === 1 && tail[0] === "toolkits" && method === "GET") {
+    return json({ items: state.listToolkits() });
+  }
+  // GET /v1/integrations/composio/connections
+  if (tail.length === 1 && tail[0] === "connections" && method === "GET") {
+    return json({ items: state.listConnections() });
+  }
+  // GET /v1/integrations/composio/connections/:id
+  if (tail.length === 2 && tail[0] === "connections" && method === "GET") {
+    const conn = state.getConnection(tail[1]);
+    return conn ? json(conn) : json({ error: "connection not found" }, 404);
+  }
+  // POST /v1/integrations/composio/connect { toolkit }
+  if (tail.length === 1 && tail[0] === "connect" && method === "POST") {
+    const toolkit = String(body?.toolkit ?? "");
+    if (!toolkit) return json({ error: "missing toolkit" }, 400);
+    return json(state.connect(toolkit));
+  }
+  // POST /v1/integrations/composio/disconnect { toolkit }
+  if (tail.length === 1 && tail[0] === "disconnect" && method === "POST") {
+    const toolkit = String(body?.toolkit ?? "");
+    if (!toolkit) return json({ error: "missing toolkit" }, 400);
+    state.disconnect(toolkit);
+    return json({ ok: true });
+  }
+  return json({ error: "not found" }, 404);
+}
+
+function handleIntegrations(
+  method: string,
+  segs: string[],
+  body: Record<string, unknown> | undefined,
+): Response {
+  if (state.integrationsMode() === "unavailable") return unavailable();
+  const rest = segs.slice(2); // after ["v1","integrations"]
+  // GET /v1/integrations — readiness list
+  if (rest.length === 0) {
+    if (method !== "GET") return json({ error: "not found" }, 404);
+    return json({ items: state.integrationStatus() });
+  }
+  if (rest[0] !== "composio") return json({ error: "not found" }, 404);
+  return handleComposio(method, rest.slice(1), body);
+}
+
+function handleGrants(
+  method: string,
+  agentSlug: string,
+  body: Record<string, unknown> | undefined,
+): Response {
+  if (state.integrationsMode() === "unavailable") return unavailable();
+  if (method === "GET") {
+    const toolkits = state.getGrants(agentSlug);
+    // Missing record → 404 (client degrades to null); a present record (even
+    // []) → `{toolkits}`. This is the null-vs-[] distinction, end to end.
+    return toolkits === undefined
+      ? json({ error: "not found" }, 404)
+      : json({ toolkits });
+  }
+  if (method === "PUT") {
+    const raw = Array.isArray(body?.toolkits) ? body.toolkits : null;
+    if (!raw?.every((t): t is string => typeof t === "string")) {
+      return json({ error: "toolkits must be an array of strings" }, 400);
+    }
+    state.setGrants(agentSlug, raw);
+    return json({ ok: true });
+  }
+  return json({ error: "not found" }, 404);
+}
+
+function handlePreference(
+  method: string,
+  key: string,
+  body: Record<string, unknown> | undefined,
+): Response {
+  if (method === "GET") return json({ value: state.getPreference(key) });
+  if (method === "PUT") {
+    const value =
+      body?.value === null || body?.value === undefined
+        ? null
+        : String(body.value);
+    state.setPreference(key, value);
+    return json({ value });
+  }
+  return json({ error: "not found" }, 404);
+}
+
+/** Route a user-scoped gateway request, or return `undefined` to fall through. */
+export function handleUserRoutes(
+  method: string,
+  segs: string[],
+  body: Record<string, unknown> | undefined,
+): Response | undefined {
+  // /v1/integrations[/composio/...]
+  if (segs[0] === "v1" && segs[1] === "integrations") {
+    return handleIntegrations(method, segs, body);
+  }
+  // /v1/agents/:slug/integration-grants
+  if (
+    segs[0] === "v1" &&
+    segs[1] === "agents" &&
+    segs.length === 4 &&
+    segs[3] === "integration-grants"
+  ) {
+    return handleGrants(method, segs[2], body);
+  }
+  // /v1/preferences/:key
+  if (segs[0] === "v1" && segs[1] === "preferences" && segs.length === 3) {
+    return handlePreference(method, segs[2], body);
+  }
+  // GET /v1/workspaces · PATCH /v1/workspaces/:id (locale)
+  if (segs[0] === "v1" && segs[1] === "workspaces") {
+    if (segs.length === 2 && method === "GET") return json([workspaceWire()]);
+    if (segs.length === 3 && method === "PATCH") {
+      if (segs[2] !== SEED_WORKSPACE_ID) {
+        return json({ error: "workspace not found" }, 404);
+      }
+      if (body && "locale" in body) {
+        state.setPreference(
+          "locale",
+          body.locale === null ? null : String(body.locale),
+        );
+      }
+      return json(workspaceWire());
+    }
+  }
+  return undefined;
+}

--- a/packages/fake-host/src/routes.ts
+++ b/packages/fake-host/src/routes.ts
@@ -14,33 +14,21 @@
  * → `done`) when the message lands. See translate.ts `streamTurn`.
  */
 
+import type { ProviderId } from "@houston/runtime-client";
 import { cancelChat, openChatStream, sendMessage } from "./chat";
 import { json, noContent } from "./http";
 import { handleWorkspaceFiles } from "./routes-files";
 import * as state from "./state";
 
-/** Canned provider list — one connected, active Claude. */
+/** Flat (non-agent) provider list — the local single-runtime slot's providers,
+ *  seeded with Claude connected + active so the WebApp connect gate clears. */
 export function providersBody() {
-  return [
-    {
-      id: "anthropic",
-      name: "Claude",
-      configured: true,
-      isActive: true,
-      activeModel: "claude-sonnet-4-6",
-      models: ["claude-sonnet-4-6", "claude-opus-4-8"],
-    },
-  ];
+  return state.providerList(state.FLAT_KEY);
 }
 
-/** Auth status with an active provider — clears the WebApp connect gate. */
+/** Flat (non-agent) auth status — the local single-runtime slot. */
 export function authStatusBody() {
-  return {
-    providers: [
-      { provider: "anthropic", name: "Claude", configured: true, login: null },
-    ],
-    activeProvider: "anthropic",
-  };
+  return state.authStatusFor(state.FLAT_KEY);
 }
 
 function makeTitle(text: string): string {
@@ -114,26 +102,45 @@ export function handleAgents(
       return noContent(); // capture / forget
 
     case "providers":
-      return json(providersBody());
+      return json(state.providerList(id));
 
     case "settings":
-      return json({
-        activeProvider: body?.activeProvider ?? "anthropic",
-        models: {},
-      });
+      return json(
+        state.setSettings(id, {
+          activeProvider: body?.activeProvider as ProviderId | undefined,
+          model: typeof body?.model === "string" ? body.model : undefined,
+          effort: typeof body?.effort === "string" ? body.effort : undefined,
+        }),
+      );
 
     case "title":
       return json({ title: makeTitle(String(body?.text ?? "")) });
 
     case "auth": {
-      if (rest[2] === "status") return json(authStatusBody());
-      const action = rest[3]; // /auth/:provider/login | /logout
-      if (action === "login" && rest[4] === "complete")
+      if (rest[2] === "status") return json(state.authStatusFor(id));
+      const provider = rest[2] as ProviderId; // /auth/:provider/...
+      const action = rest[3];
+      if (action === "login" && rest[4] === "complete") {
+        state.completeLogin(id, provider);
         return json({ ok: true });
-      if (action === "login" && rest[4] === "cancel") return json({ ok: true });
-      if (action === "login")
-        return json({ kind: "url", url: "https://example.test/connect" });
-      if (action === "logout") return json({ ok: true });
+      }
+      if (action === "login" && rest[4] === "cancel") {
+        state.cancelLogin(id, provider);
+        return json({ ok: true });
+      }
+      if (action === "login") {
+        const enterpriseDomain =
+          new URL(req.url).searchParams.get("enterpriseDomain") ?? undefined;
+        return json(state.startLogin(id, provider, enterpriseDomain));
+      }
+      if (action === "api-key") {
+        state.setApiKey(id, provider);
+        return json({ ok: true });
+      }
+      if (action === "logout") {
+        state.logout(id, provider);
+        return json({ ok: true });
+      }
       return noContent();
     }
 

--- a/packages/fake-host/src/state-integrations.ts
+++ b/packages/fake-host/src/state-integrations.ts
@@ -1,0 +1,119 @@
+/**
+ * User-scoped gateway state: Composio integrations, per-agent grants, and
+ * key/value preferences. These mirror the cloud gateway's `/v1/integrations/*`,
+ * `/v1/agents/:slug/integration-grants`, and `/v1/preferences/:key` surfaces
+ * (docs/contracts C1/C4 + gateway `user-routes.ts`) faithfully enough for the
+ * SDK's contract tests — including the 503 (unavailable) and signin readiness
+ * modes and the grants 404-vs-`[]` distinction.
+ *
+ * Wire shapes come from `@houston/runtime-client` so a contract change breaks
+ * the typecheck here instead of silently drifting the mock.
+ */
+
+import type {
+  IntegrationConnection,
+  IntegrationProviderStatus,
+  IntegrationToolkit,
+} from "@houston/runtime-client";
+import { type IntegrationsMode, state } from "./state-store";
+
+/** A small, stable A-Z toolkit catalog — enough for catalog + connect flows. */
+export const SEED_TOOLKITS: IntegrationToolkit[] = [
+  {
+    slug: "github",
+    name: "GitHub",
+    description: "Issues, PRs, and repos",
+    logoUrl: "https://logos.test/github.png",
+    categories: ["developer-tools"],
+  },
+  {
+    slug: "gmail",
+    name: "Gmail",
+    description: "Send and read email",
+    logoUrl: "https://logos.test/gmail.png",
+    categories: ["productivity"],
+  },
+  {
+    slug: "slack",
+    name: "Slack",
+    description: "Team messaging",
+    logoUrl: "https://logos.test/slack.png",
+    categories: ["communication"],
+  },
+];
+
+export function integrationsMode(): IntegrationsMode {
+  return state.integrationsMode;
+}
+
+export function setIntegrationsMode(mode: IntegrationsMode): void {
+  state.integrationsMode = mode;
+}
+
+/** The readiness list the gateway serves at `GET /v1/integrations`. */
+export function integrationStatus(): IntegrationProviderStatus[] {
+  const ready = state.integrationsMode === "ready";
+  const status: IntegrationProviderStatus = { provider: "composio", ready };
+  if (state.integrationsMode === "signin") status.reason = "signin";
+  return [status];
+}
+
+export function listToolkits(): IntegrationToolkit[] {
+  return SEED_TOOLKITS;
+}
+
+export function listConnections(): IntegrationConnection[] {
+  return [...state.connections.values()];
+}
+
+export function getConnection(id: string): IntegrationConnection | undefined {
+  return state.connections.get(id);
+}
+
+/** Start an OAuth connect: mint a PENDING connection, return the link + id. */
+export function connect(toolkit: string): {
+  redirectUrl: string;
+  connectionId: string;
+} {
+  const connectionId = `conn-${toolkit}-${state.connSeq++}`;
+  state.connections.set(connectionId, {
+    toolkit,
+    connectionId,
+    status: "pending",
+  });
+  return { redirectUrl: `https://connect.test/${toolkit}`, connectionId };
+}
+
+/** Flip a pending connection to active (models the OAuth completing). */
+export function activateConnection(id: string): boolean {
+  const conn = state.connections.get(id);
+  if (!conn) return false;
+  state.connections.set(id, { ...conn, status: "active" });
+  return true;
+}
+
+/** Disconnect a toolkit everywhere: drop all of its connections. */
+export function disconnect(toolkit: string): void {
+  for (const [id, conn] of state.connections) {
+    if (conn.toolkit === toolkit) state.connections.delete(id);
+  }
+}
+
+/** Grants for an agent, or `undefined` when NO record exists (→ route 404). */
+export function getGrants(agentId: string): string[] | undefined {
+  return state.grants.get(agentId);
+}
+
+/** Replace an agent's grant record (creating it if absent). */
+export function setGrants(agentId: string, toolkits: string[]): void {
+  state.grants.set(agentId, [...toolkits]);
+}
+
+export function getPreference(key: string): string | null {
+  return state.preferences.get(key) ?? null;
+}
+
+export function setPreference(key: string, value: string | null): void {
+  if (value === null) state.preferences.delete(key);
+  else state.preferences.set(key, value);
+}

--- a/packages/fake-host/src/state-providers.ts
+++ b/packages/fake-host/src/state-providers.ts
@@ -1,0 +1,173 @@
+/**
+ * Stateful AI-provider credentials for the fake host — the per-agent-pod
+ * provider model the SDK `providers` module and the hosted connect flow exercise
+ * (PARITY-SETTINGS §2, §6). Credentials are PER AGENT in hosted mode, so state
+ * is keyed by agent id; the flat `/providers` + `/auth/status` routes (the local
+ * single-runtime profile) share the {@link FLAT_KEY} slot.
+ *
+ * Every slot seeds with Claude connected + active (what the old static
+ * `providersBody`/`authStatusBody` returned, so the WebApp connect gate still
+ * clears). Mutations — start/complete/cancel login, api-key, logout, settings —
+ * flip the slot so a `GET /providers` + `GET /auth/status` refetch reflects them,
+ * exactly as the real runtime does.
+ *
+ * Wire types come from the real packages so a contract change breaks the
+ * typecheck here instead of silently drifting the mock.
+ */
+
+import type {
+  AuthStatus,
+  LoginInfo,
+  LoginState,
+  ProviderAuth,
+  ProviderId,
+  ProviderInfo,
+  Settings,
+} from "@houston/runtime-client";
+import { CATALOG, SPEC } from "./provider-catalog";
+
+/** The slot the flat (non-agent) `/providers` + `/auth/status` routes read. */
+export const FLAT_KEY = "__flat__";
+
+interface Slot {
+  configured: Set<ProviderId>;
+  login: Map<ProviderId, LoginState>;
+  activeProvider: ProviderId | null;
+  activeModel: Map<ProviderId, string>;
+  enterpriseUrl: Map<ProviderId, string>;
+  effort?: string;
+}
+
+function seedSlot(): Slot {
+  return {
+    configured: new Set<ProviderId>(["anthropic"]),
+    login: new Map(),
+    activeProvider: "anthropic",
+    activeModel: new Map([["anthropic", "claude-sonnet-4-6"]]),
+    enterpriseUrl: new Map(),
+  };
+}
+
+let slots = new Map<string, Slot>();
+
+function slot(agentId: string): Slot {
+  let s = slots.get(agentId);
+  if (!s) {
+    s = seedSlot();
+    slots.set(agentId, s);
+  }
+  return s;
+}
+
+/** Restore the seed. Wired into the store's `reset()`. */
+export function resetProviders(): void {
+  slots = new Map();
+}
+
+/** `GET /providers` (or `/agents/:id/providers`) → the rich `ProviderInfo[]`. */
+export function providerList(agentId: string): ProviderInfo[] {
+  const s = slot(agentId);
+  return CATALOG.map((spec) => ({
+    id: spec.id,
+    name: spec.name,
+    configured: s.configured.has(spec.id),
+    isActive: s.activeProvider === spec.id,
+    activeModel: s.activeModel.get(spec.id) ?? spec.models[0],
+    models: spec.models,
+  }));
+}
+
+/** `GET /auth/status` (or `/agents/:id/auth/status`) → the credential/login view. */
+export function authStatusFor(agentId: string): AuthStatus {
+  const s = slot(agentId);
+  const providers: ProviderAuth[] = CATALOG.map((spec) => {
+    const entry: ProviderAuth = {
+      provider: spec.id,
+      name: spec.name,
+      configured: s.configured.has(spec.id),
+      login: s.login.get(spec.id) ?? null,
+    };
+    const ent = s.enterpriseUrl.get(spec.id);
+    if (spec.id === "github-copilot") entry.enterpriseUrl = ent ?? null;
+    return entry;
+  });
+  return { providers, activeProvider: s.activeProvider };
+}
+
+/** Start an OAuth login: records the awaiting-user state, returns the kind the
+ *  provider uses. `enterpriseDomain` (Copilot) is remembered for the credential. */
+export function startLogin(
+  agentId: string,
+  provider: ProviderId,
+  enterpriseDomain?: string,
+): LoginInfo {
+  const spec = SPEC.get(provider);
+  const info: LoginInfo =
+    spec?.loginKind === "auth_code"
+      ? {
+          kind: "auth_code",
+          url: `https://connect.test/${provider}`,
+          instructions: "Paste the code shown after you approve.",
+        }
+      : {
+          kind: "device_code",
+          verificationUri: `https://connect.test/${provider}/device`,
+          userCode: "WXYZ-1234",
+        };
+  slot(agentId).login.set(provider, { status: "awaiting_user", info });
+  if (enterpriseDomain)
+    slot(agentId).enterpriseUrl.set(provider, enterpriseDomain);
+  return info;
+}
+
+export function cancelLogin(agentId: string, provider: ProviderId): void {
+  slot(agentId).login.delete(provider);
+}
+
+/** Mark a provider connected + clear its login; adopt it as active if none. */
+function connect(s: Slot, provider: ProviderId): void {
+  s.configured.add(provider);
+  s.login.delete(provider);
+  if (s.activeProvider === null) {
+    s.activeProvider = provider;
+    if (!s.activeModel.has(provider))
+      s.activeModel.set(provider, SPEC.get(provider)?.models[0] ?? "");
+  }
+}
+
+export function completeLogin(agentId: string, provider: ProviderId): void {
+  connect(slot(agentId), provider);
+}
+
+export function setApiKey(agentId: string, provider: ProviderId): void {
+  connect(slot(agentId), provider);
+}
+
+/** Disconnect a provider; if it was active, fall back to another connected one. */
+export function logout(agentId: string, provider: ProviderId): void {
+  const s = slot(agentId);
+  s.configured.delete(provider);
+  s.login.delete(provider);
+  s.activeModel.delete(provider);
+  if (s.activeProvider === provider)
+    s.activeProvider = [...s.configured][0] ?? null;
+}
+
+/** `PUT /settings` — apply an active-provider / model / effort switch. */
+export function setSettings(
+  agentId: string,
+  input: { activeProvider?: ProviderId; model?: string; effort?: string },
+): Settings {
+  const s = slot(agentId);
+  if (input.activeProvider) s.activeProvider = input.activeProvider;
+  if (input.model && s.activeProvider)
+    s.activeModel.set(s.activeProvider, input.model);
+  if (input.effort !== undefined) s.effort = input.effort;
+  const models: Partial<Record<ProviderId, string>> = {};
+  for (const [id, model] of s.activeModel) models[id] = model;
+  return {
+    ...(s.activeProvider ? { activeProvider: s.activeProvider } : {}),
+    models,
+    ...(s.effort !== undefined ? { effort: s.effort } : {}),
+  };
+}

--- a/packages/fake-host/src/state-store.ts
+++ b/packages/fake-host/src/state-store.ts
@@ -13,8 +13,21 @@
  */
 
 import type { Activity } from "@houston/protocol";
-import type { ChatMessage, TokenUsage } from "@houston/runtime-client";
+import type {
+  ChatMessage,
+  IntegrationConnection,
+  TokenUsage,
+} from "@houston/runtime-client";
 import { SEED_AGENT_ID, SEED_AGENT_NAME, SEED_WORKSPACE_ID } from "./config";
+import { resetProviders } from "./state-providers";
+
+/**
+ * Gateway integrations readiness, toggled by `/__test__/integrations-mode`:
+ *  - `ready` — a Composio key is configured (the default),
+ *  - `unavailable` — no key → every integrations route 503s,
+ *  - `signin` — the provider reports `ready:false, reason:"signin"`.
+ */
+export type IntegrationsMode = "ready" | "unavailable" | "signin";
 
 /** The host's agent wire model, mapped to the UI `Agent` by control-plane.ts. */
 export interface CpAgent {
@@ -60,6 +73,21 @@ export interface HostState {
   histories: Map<string, ChatMessage[]>;
   agentSeq: number;
   activitySeq: number;
+  // ── user-scoped gateway state (integrations, grants, preferences) ──
+  /** Composio readiness, toggled by the `/__test__/integrations-mode` control. */
+  integrationsMode: IntegrationsMode;
+  /** connectionId -> the acting user's connected account. */
+  connections: Map<string, IntegrationConnection>;
+  /**
+   * agentId -> granted toolkit slugs. PRESENCE is the record: a missing key
+   * means "no grants record" → GET 404 → the client degrades to `null`; a
+   * present key (even `[]`) means "record exists" → GET `{toolkits}`.
+   */
+  grants: Map<string, string[]>;
+  /** Per-user preference key -> value (locale, timezone, …). */
+  preferences: Map<string, string>;
+  /** Monotonic counter for minted connection ids. */
+  connSeq: number;
 }
 
 export function fileKey(agentId: string, relPath: string): string {
@@ -87,6 +115,13 @@ function freshState(): HostState {
     created: EPOCH,
     modified: EPOCH,
   });
+  // One seeded active connection so the connections list has a row on first read.
+  const connections = new Map<string, IntegrationConnection>([
+    [
+      "conn-gmail-0",
+      { toolkit: "gmail", connectionId: "conn-gmail-0", status: "active" },
+    ],
+  ]);
   return {
     agents: [
       {
@@ -101,6 +136,13 @@ function freshState(): HostState {
     histories: new Map(),
     agentSeq: 1,
     activitySeq: 2,
+    integrationsMode: "ready",
+    connections,
+    // No seeded grants record: the seed agent starts "grants unsupported" (404 →
+    // null), so a suite can assert the null→[] distinction by writing one.
+    grants: new Map(),
+    preferences: new Map(),
+    connSeq: 1,
   };
 }
 
@@ -109,6 +151,7 @@ export let state: HostState = freshState();
 /** Restore the seed. Called by the harness before each test. */
 export function reset(): void {
   state = freshState();
+  resetProviders();
   domainListeners.clear();
 }
 

--- a/packages/fake-host/src/state.ts
+++ b/packages/fake-host/src/state.ts
@@ -22,5 +22,7 @@
 export * from "./state-activities";
 export * from "./state-agents";
 export * from "./state-history";
+export * from "./state-integrations";
+export * from "./state-providers";
 export * from "./state-store";
 export * from "./state-workspace";

--- a/packages/runtime-client/src/client-integrations.ts
+++ b/packages/runtime-client/src/client-integrations.ts
@@ -1,0 +1,172 @@
+/**
+ * The user-scoped gateway surface: Composio integrations, per-agent integration
+ * grants, key/value preferences, and the workspace-locale override. Unlike
+ * {@link HoustonEngineClient} (rooted at ONE conversation / agent), these routes
+ * are keyed by the caller's verified session `sub` and shared across the user's
+ * agents — so they hit the gateway root (`/v1/...`), never `/agents/:id/*`.
+ *
+ * Both classes share the same {@link Requester} plumbing as the conversation
+ * client (base-URL joining, bearer auth, non-2xx → {@link EngineError}), so
+ * there is one way this package talks to the engine.
+ */
+
+import { createRequester, EngineError, type Requester } from "./requester";
+import type {
+  EngineClientConfig,
+  IntegrationConnection,
+  IntegrationProviderStatus,
+  IntegrationToolkit,
+  PreferenceValue,
+  Workspace,
+} from "./types";
+
+const JSON_HEADERS = { "Content-Type": "application/json" } as const;
+
+/** Composio is the only integration provider today; the gateway keys every
+ *  route on this segment (`/v1/integrations/composio/*`). */
+const COMPOSIO = "composio";
+
+/** Integrations + per-agent grants (C1/C4). All calls carry the session JWT. */
+export class IntegrationsClient {
+  private readonly r: Requester;
+
+  constructor(config: EngineClientConfig) {
+    this.r = createRequester(config);
+  }
+
+  /** Provider readiness list. 503 (no key configured) throws {@link EngineError}. */
+  async listIntegrations(): Promise<IntegrationProviderStatus[]> {
+    return (
+      await this.r.json<{ items: IntegrationProviderStatus[] }>(
+        "/v1/integrations",
+      )
+    ).items;
+  }
+
+  /** The full connectable-app catalog (cached upstream). */
+  async listToolkits(): Promise<IntegrationToolkit[]> {
+    return (
+      await this.r.json<{ items: IntegrationToolkit[] }>(
+        `/v1/integrations/${COMPOSIO}/toolkits`,
+      )
+    ).items;
+  }
+
+  /** The acting user's connected accounts. */
+  async listConnections(): Promise<IntegrationConnection[]> {
+    return (
+      await this.r.json<{ items: IntegrationConnection[] }>(
+        `/v1/integrations/${COMPOSIO}/connections`,
+      )
+    ).items;
+  }
+
+  /** Poll one connection after {@link connect} until its OAuth finishes. */
+  getConnection(connectionId: string): Promise<IntegrationConnection> {
+    return this.r.json(
+      `/v1/integrations/${COMPOSIO}/connections/${encodeURIComponent(connectionId)}`,
+    );
+  }
+
+  /** Start an OAuth connect. The caller opens `redirectUrl`, then polls
+   *  {@link getConnection} on `connectionId` until it is `active`. */
+  connect(
+    toolkit: string,
+  ): Promise<{ redirectUrl: string; connectionId: string }> {
+    return this.r.json(`/v1/integrations/${COMPOSIO}/connect`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ toolkit }),
+    });
+  }
+
+  /** Disconnect a toolkit for the user everywhere (removes its connections). */
+  async disconnect(toolkit: string): Promise<void> {
+    await this.r.request(`/v1/integrations/${COMPOSIO}/disconnect`, {
+      method: "POST",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ toolkit }),
+    });
+  }
+
+  /**
+   * The toolkit slugs granted to `agentSlug`, or `null` when the host does not
+   * serve grants (404 — a deployment without per-agent grants). `null` means
+   * "unsupported, show no per-agent toggles"; `[]` means "record exists, nothing
+   * granted" — the two are DISTINCT. Every other error still throws.
+   */
+  async getIntegrationGrants(agentSlug: string): Promise<string[] | null> {
+    try {
+      return (
+        await this.r.json<{ toolkits: string[] }>(
+          `/v1/agents/${encodeURIComponent(agentSlug)}/integration-grants`,
+        )
+      ).toolkits;
+    } catch (err) {
+      if (err instanceof EngineError && err.status === 404) return null;
+      throw err;
+    }
+  }
+
+  /** Replace the toolkit slugs granted to `agentSlug` (a replace-set). */
+  async putIntegrationGrants(
+    agentSlug: string,
+    toolkits: string[],
+  ): Promise<void> {
+    await this.r.request(
+      `/v1/agents/${encodeURIComponent(agentSlug)}/integration-grants`,
+      {
+        method: "PUT",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ toolkits }),
+      },
+    );
+  }
+}
+
+/** Per-user preferences + the workspace-locale override (the boot/settings path). */
+export class PreferencesClient {
+  private readonly r: Requester;
+
+  constructor(config: EngineClientConfig) {
+    this.r = createRequester(config);
+  }
+
+  /** Read a preference value, or `null` when unset. */
+  async getPreference(key: string): Promise<string | null> {
+    return (
+      await this.r.json<PreferenceValue>(
+        `/v1/preferences/${encodeURIComponent(key)}`,
+      )
+    ).value;
+  }
+
+  /** Write (or, with `null`, clear) a preference; echoes the stored value. */
+  async setPreference(
+    key: string,
+    value: string | null,
+  ): Promise<string | null> {
+    return (
+      await this.r.json<PreferenceValue>(
+        `/v1/preferences/${encodeURIComponent(key)}`,
+        {
+          method: "PUT",
+          headers: JSON_HEADERS,
+          body: JSON.stringify({ value }),
+        },
+      )
+    ).value;
+  }
+
+  /** Set (or clear, with `null`) the workspace's UI-locale override. */
+  setWorkspaceLocale(
+    workspaceId: string,
+    locale: string | null,
+  ): Promise<Workspace> {
+    return this.r.json(`/v1/workspaces/${encodeURIComponent(workspaceId)}`, {
+      method: "PATCH",
+      headers: JSON_HEADERS,
+      body: JSON.stringify({ locale }),
+    });
+  }
+}

--- a/packages/runtime-client/src/client.ts
+++ b/packages/runtime-client/src/client.ts
@@ -1,3 +1,4 @@
+import { createRequester, EngineError, type Requester } from "./requester";
 import { readEventStream } from "./sse-read";
 import type {
   AuthStatus,
@@ -15,15 +16,7 @@ import type {
   WireFrame,
 } from "./types";
 
-export class EngineError extends Error {
-  constructor(
-    public status: number,
-    public body: string,
-  ) {
-    super(`engine request failed (${status}): ${body}`);
-    this.name = "EngineError";
-  }
-}
+export { EngineError };
 
 export interface EventStreamOptions {
   /** Abort to close the stream (e.g. when switching conversations). */
@@ -69,34 +62,18 @@ export interface SendOptions {
  *   // ac.abort() stops observing; the turn keeps running server-side.
  */
 export class HoustonEngineClient {
-  private base: string;
-  private token?: string;
-  private fetchImpl: typeof fetch;
+  private readonly requester: Requester;
 
   constructor(config: EngineClientConfig) {
-    this.base = config.baseUrl.replace(/\/+$/, "");
-    this.token = config.token;
-    this.fetchImpl = config.fetch ?? globalThis.fetch.bind(globalThis);
+    this.requester = createRequester(config);
   }
 
-  private headers(extra?: Record<string, string>): Record<string, string> {
-    const h: Record<string, string> = { ...extra };
-    if (this.token) h.Authorization = `Bearer ${this.token}`;
-    return h;
+  private request(path: string, init?: RequestInit): Promise<Response> {
+    return this.requester.request(path, init);
   }
 
-  private async request(path: string, init?: RequestInit): Promise<Response> {
-    const res = await this.fetchImpl(this.base + path, {
-      ...init,
-      headers: this.headers(init?.headers as Record<string, string>),
-    });
-    if (!res.ok)
-      throw new EngineError(res.status, await res.text().catch(() => ""));
-    return res;
-  }
-
-  private async json<T>(path: string, init?: RequestInit): Promise<T> {
-    return (await this.request(path, init)).json() as Promise<T>;
+  private json<T>(path: string, init?: RequestInit): Promise<T> {
+    return this.requester.json<T>(path, init);
   }
 
   // --- meta ---

--- a/packages/runtime-client/src/index.ts
+++ b/packages/runtime-client/src/index.ts
@@ -1,5 +1,6 @@
 export type { EventStreamOptions, SendOptions } from "./client";
 export { EngineError, HoustonEngineClient } from "./client";
+export { IntegrationsClient, PreferencesClient } from "./client-integrations";
 export type { GlobalEventsOptions } from "./global-events";
 export { streamGlobalEvents } from "./global-events";
 export type { SequencedFrame } from "./replay";
@@ -10,6 +11,7 @@ export {
   REPLAY_BUFFER_CAP,
   ReplayLog,
 } from "./replay";
+export type { Requester } from "./requester";
 export { streamEventsResumable } from "./resume";
 export type {
   ConversationEventSource,

--- a/packages/runtime-client/src/requester.ts
+++ b/packages/runtime-client/src/requester.ts
@@ -1,0 +1,55 @@
+import type { EngineClientConfig } from "./types";
+
+/** A non-2xx response from the engine. `status` is the upstream HTTP status;
+ *  `body` is the raw response text (empty when unreadable). */
+export class EngineError extends Error {
+  constructor(
+    public status: number,
+    public body: string,
+  ) {
+    super(`engine request failed (${status}): ${body}`);
+    this.name = "EngineError";
+  }
+}
+
+/**
+ * The shared fetch plumbing every runtime-client class is built on: base-URL
+ * joining, bearer auth, non-2xx → {@link EngineError}, and JSON decoding. A
+ * single implementation so the conversation client and the user-scoped
+ * integration/preference clients cannot drift in how they talk to the engine.
+ */
+export interface Requester {
+  /** Issue a request; throws {@link EngineError} on a non-2xx response. */
+  request(path: string, init?: RequestInit): Promise<Response>;
+  /** Issue a request and decode its JSON body. */
+  json<T>(path: string, init?: RequestInit): Promise<T>;
+}
+
+/** Build a {@link Requester} from an {@link EngineClientConfig}. */
+export function createRequester(config: EngineClientConfig): Requester {
+  const base = config.baseUrl.replace(/\/+$/, "");
+  const token = config.token;
+  const fetchImpl = config.fetch ?? globalThis.fetch.bind(globalThis);
+
+  const headers = (extra?: Record<string, string>): Record<string, string> => {
+    const h: Record<string, string> = { ...extra };
+    if (token) h.Authorization = `Bearer ${token}`;
+    return h;
+  };
+
+  async function request(path: string, init?: RequestInit): Promise<Response> {
+    const res = await fetchImpl(base + path, {
+      ...init,
+      headers: headers(init?.headers as Record<string, string>),
+    });
+    if (!res.ok)
+      throw new EngineError(res.status, await res.text().catch(() => ""));
+    return res;
+  }
+
+  async function json<T>(path: string, init?: RequestInit): Promise<T> {
+    return (await request(path, init)).json() as Promise<T>;
+  }
+
+  return { request, json };
+}

--- a/packages/runtime-client/src/types.ts
+++ b/packages/runtime-client/src/types.ts
@@ -28,10 +28,47 @@ export type {
   WireEvent,
   WireEventType,
   WireFrame,
+  Workspace,
 } from "@houston/protocol";
 
 /** The runtime's own conversation-core surface version (`GET /version`). */
 export const PROTOCOL_VERSION = 2;
+
+// ── integrations (Composio, platform mode) — gateway-owned, user-scoped ──────
+// These routes live on the cloud gateway (`/v1/integrations/*`), keyed by the
+// caller's verified Supabase `sub`, and are shared across the user's agents —
+// NOT nested under `/agents/:id`. Per-agent access is gated by grants below.
+
+/** One integration provider's readiness. `ready:false` + `reason:"signin"` ⇒
+ *  the UI prompts a Houston sign-in (the gateway needs a valid session). */
+export interface IntegrationProviderStatus {
+  provider: string;
+  ready: boolean;
+  reason?: "signin";
+  /** Legacy per-user Composio connections were found — the user reconnects once. */
+  reconnect?: boolean;
+}
+
+/** A connectable app in the Composio catalog. `logoUrl` is a REMOTE image. */
+export interface IntegrationToolkit {
+  slug: string;
+  name: string;
+  description?: string;
+  logoUrl?: string;
+  categories?: string[];
+}
+
+/** One of the acting user's connected accounts for a toolkit. */
+export interface IntegrationConnection {
+  toolkit: string;
+  connectionId: string;
+  status: "active" | "pending" | "error";
+}
+
+/** The `{value}` envelope the preferences routes return (null ⇒ unset). */
+export interface PreferenceValue {
+  value: string | null;
+}
 
 export interface EngineClientConfig {
   /** Base URL of the engine, e.g. "http://127.0.0.1:4317". */

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -74,12 +74,46 @@ export {
   type ConversationListVM,
   conversationListScope,
 } from "./modules/conversations";
+// ===== Integrations module contract ====================================
+export {
+  type ConnectResult,
+  INTEGRATIONS_SCOPE,
+  type IntegrationConnection,
+  IntegrationsCommand,
+  type IntegrationsCommandType,
+  type IntegrationsModule,
+  type IntegrationsUnavailableReason,
+  type IntegrationsViewModel,
+  type IntegrationToolkit,
+} from "./modules/integrations";
 // ===== Mission-search module contract ==================================
 export type {
   MatchedIn,
   MissionMatch,
   MissionsSearchModule,
 } from "./modules/missions-search";
+// ===== Preferences module contract =====================================
+export {
+  PreferencesCommand,
+  type PreferencesCommandType,
+  type PreferencesModule,
+} from "./modules/preferences";
+// ===== Providers module contract =======================================
+export {
+  type LoginInfo,
+  type LoginOptions,
+  type LoginState,
+  mergeProviders,
+  overlayStatus,
+  type ProviderId,
+  ProvidersCommand,
+  type ProvidersCommandType,
+  type ProvidersModule,
+  type ProvidersViewModel,
+  type ProviderVM,
+  providersScope,
+  type SetModelOptions,
+} from "./modules/providers";
 // ===== Session module contract =========================================
 // `createAuthFetch` + `SESSION_TOKEN_KEY` are host-facing: the host composes the
 // auth-fetch into `ports.fetch` before constructing the SDK (see the module).

--- a/packages/sdk/src/modules/integrations/index.ts
+++ b/packages/sdk/src/modules/integrations/index.ts
@@ -1,0 +1,177 @@
+/**
+ * The integrations module — the SDK-canonical Composio surface.
+ *
+ * Reads: publishes the {@link INTEGRATIONS_SCOPE} view-model — readiness plus
+ * the toolkit catalog and the user's connections — republished whole on every
+ * refresh. Writes: connect / disconnect / poll / grants flow as commands; the
+ * same handlers back both the typed facade and the bridge `dispatch` path.
+ *
+ * SEAM — user-scoped, NOT per-agent. Integrations are gateway-owned and keyed by
+ * the caller's session `sub`, so this module talks to the flat
+ * {@link IntegrationsClient} (rooted at the base URL), never `clientFor(agentId)`.
+ * Per-agent scoping is ONLY the grants read/write (keyed by agent slug).
+ *
+ * Degradation is explicit and end-to-end:
+ *  - 503 (no key) → VM `{ready:false, reason:"unavailable"}` — the tab never crashes.
+ *  - provider `ready:false, reason:"signin"` → VM `{ready:false, reason:"signin"}`.
+ *  - a 401 routes through the shared {@link ModuleContext.authExpiry} notifier.
+ *  - grants 404 → `null` ("unsupported, no toggles"), distinct from `[]` ("nothing
+ *    granted") — carried through untouched.
+ */
+
+import {
+  EngineError,
+  type IntegrationConnection,
+  IntegrationsClient,
+} from "@houston/runtime-client";
+import type { ModuleContext } from "../../module-context";
+import {
+  INTEGRATIONS_SCOPE,
+  IntegrationsCommand,
+  type IntegrationsViewModel,
+  requireString,
+  requireStringArray,
+  unavailableVm,
+} from "./types";
+
+export type {
+  IntegrationConnection,
+  IntegrationsCommandType,
+  IntegrationsUnavailableReason,
+  IntegrationsViewModel,
+  IntegrationToolkit,
+} from "./types";
+export { INTEGRATIONS_SCOPE, IntegrationsCommand } from "./types";
+
+/** The result of a connect: the URL the surface opens, plus the id to poll. */
+export interface ConnectResult {
+  redirectUrl: string;
+  connectionId: string;
+}
+
+/** The typed facade for integration reads + writes. */
+export interface IntegrationsModule {
+  /** Scope string for `sdk.subscribe(...)` / `sdk.getSnapshot(...)`. */
+  readonly scope: string;
+  /** Refetch readiness + catalog + connections and republish the VM. */
+  refresh(): Promise<IntegrationsViewModel>;
+  /** Start an OAuth connect; the surface opens `redirectUrl`, then polls. */
+  connect(toolkit: string): Promise<ConnectResult>;
+  /** Poll one connection until its OAuth finishes (status flips to active). */
+  pollConnection(connectionId: string): Promise<IntegrationConnection>;
+  /** Disconnect a toolkit everywhere, then refetch the VM. */
+  disconnect(toolkit: string): Promise<IntegrationsViewModel>;
+  /** Toolkit slugs granted to `agentId`, or `null` when grants are unsupported. */
+  grants(agentId: string): Promise<string[] | null>;
+  /** Replace `agentId`'s granted toolkit slugs. */
+  setGrants(agentId: string, toolkits: string[]): Promise<void>;
+}
+
+export function createIntegrationsModule(
+  ctx: ModuleContext,
+): IntegrationsModule {
+  const { store, authExpiry } = ctx;
+  const { baseUrl, ports } = ctx.config;
+
+  const client = new IntegrationsClient({ baseUrl, fetch: ports.fetch });
+  const emitTokenExpired = () => authExpiry.notifyExpired();
+
+  /** Run a client call, surfacing a 401 as the shared token-expiry signal. */
+  async function run<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (err) {
+      if (err instanceof EngineError && err.status === 401) emitTokenExpired();
+      throw err;
+    }
+  }
+
+  const publish = (vm: IntegrationsViewModel): IntegrationsViewModel => {
+    store.publish(INTEGRATIONS_SCOPE, vm);
+    return vm;
+  };
+
+  async function refresh(): Promise<IntegrationsViewModel> {
+    let statuses: Awaited<ReturnType<typeof client.listIntegrations>>;
+    try {
+      statuses = await run(() => client.listIntegrations());
+    } catch (err) {
+      // A missing gateway key (503) is a first-class state, not a failure: the
+      // tab shows "not available" instead of red-toasting.
+      if (err instanceof EngineError && err.status === 503) {
+        return publish(unavailableVm("unavailable", true));
+      }
+      throw err;
+    }
+
+    const composio = statuses.find((s) => s.provider === "composio");
+    if (!composio?.ready) {
+      const reason = composio?.reason === "signin" ? "signin" : "unavailable";
+      return publish(unavailableVm(reason, true));
+    }
+
+    const [toolkits, connections] = await Promise.all([
+      run(() => client.listToolkits()),
+      run(() => client.listConnections()),
+    ]);
+    return publish({ loaded: true, ready: true, toolkits, connections });
+  }
+
+  async function connect(toolkit: string): Promise<ConnectResult> {
+    return run(() => client.connect(toolkit));
+  }
+
+  function pollConnection(
+    connectionId: string,
+  ): Promise<IntegrationConnection> {
+    return run(() => client.getConnection(connectionId));
+  }
+
+  async function disconnect(toolkit: string): Promise<IntegrationsViewModel> {
+    await run(() => client.disconnect(toolkit));
+    return refresh();
+  }
+
+  function grants(agentId: string): Promise<string[] | null> {
+    return run(() => client.getIntegrationGrants(agentId));
+  }
+
+  async function setGrants(agentId: string, toolkits: string[]): Promise<void> {
+    await run(() => client.putIntegrationGrants(agentId, toolkits));
+  }
+
+  ctx.registerCommand(IntegrationsCommand.Refresh, () => refresh());
+  ctx.registerCommand(IntegrationsCommand.Connect, (p) =>
+    connect(requireString(p, "toolkit")),
+  );
+  ctx.registerCommand(IntegrationsCommand.PollConnection, (p) =>
+    pollConnection(requireString(p, "connectionId")),
+  );
+  ctx.registerCommand(IntegrationsCommand.Disconnect, (p) =>
+    disconnect(requireString(p, "toolkit")),
+  );
+  ctx.registerCommand(IntegrationsCommand.Grants, (p) =>
+    grants(requireString(p, "agentId")),
+  );
+  ctx.registerCommand(IntegrationsCommand.SetGrants, (p) =>
+    setGrants(requireString(p, "agentId"), requireStringArray(p, "toolkits")),
+  );
+
+  // Publish a defined "loading" snapshot asynchronously, so a subscriber reads
+  // `undefined` until the first real load lands (mirrors the agents module).
+  void Promise.resolve().then(() => {
+    if (store.getSnapshot(INTEGRATIONS_SCOPE) === undefined) {
+      store.publish(INTEGRATIONS_SCOPE, unavailableVm(undefined, false));
+    }
+  });
+
+  return {
+    scope: INTEGRATIONS_SCOPE,
+    refresh,
+    connect,
+    pollConnection,
+    disconnect,
+    grants,
+    setGrants,
+  };
+}

--- a/packages/sdk/src/modules/integrations/types.ts
+++ b/packages/sdk/src/modules/integrations/types.ts
@@ -1,0 +1,98 @@
+/**
+ * View-model shape, scope key, and command vocabulary for the integrations
+ * module — the SDK contract every surface (web, desktop, native) binds to.
+ *
+ * Everything here is plain JSON (see `store.ts` "snapshots, not patches"): the
+ * VM crosses the native bridge unchanged. The wire toolkit/connection shapes are
+ * re-exported from `@houston/runtime-client` so a contract change breaks the
+ * typecheck here instead of silently drifting.
+ */
+
+import type {
+  IntegrationConnection,
+  IntegrationToolkit,
+} from "@houston/runtime-client";
+
+export type {
+  IntegrationConnection,
+  IntegrationToolkit,
+} from "@houston/runtime-client";
+
+/** The single scope the integrations VM is published under. */
+export const INTEGRATIONS_SCOPE = "integrations";
+
+/**
+ * Why integrations are not usable, when `ready` is false:
+ *  - `"unavailable"` — the gateway has no Composio key (503); the tab shows the
+ *    "not available in this setup" message. Never crashes the tab.
+ *  - `"signin"` — the provider reports it needs a Houston sign-in first.
+ * A 401 (expired session) is NOT a reason here — it routes through the shared
+ * `tokenExpired` signal instead.
+ */
+export type IntegrationsUnavailableReason = "unavailable" | "signin";
+
+/** Snapshot published under {@link INTEGRATIONS_SCOPE}. */
+export interface IntegrationsViewModel {
+  /** `true` once a refresh has resolved; `false` while loading / never fetched. */
+  loaded: boolean;
+  /** Whether integrations are usable (a Composio key is configured + ready). */
+  ready: boolean;
+  /** Present only when `ready` is false — why. */
+  reason?: IntegrationsUnavailableReason;
+  /** The connectable-app catalog (empty until ready). */
+  toolkits: IntegrationToolkit[];
+  /** The user's connected accounts (empty until ready). */
+  connections: IntegrationConnection[];
+}
+
+/** The write vocabulary — the same constants back the facade and the bridge. */
+export const IntegrationsCommand = {
+  Refresh: "integrations/refresh",
+  Connect: "integrations/connect",
+  PollConnection: "integrations/pollConnection",
+  Disconnect: "integrations/disconnect",
+  Grants: "integrations/grants",
+  SetGrants: "integrations/setGrants",
+} as const;
+
+export type IntegrationsCommandType =
+  (typeof IntegrationsCommand)[keyof typeof IntegrationsCommand];
+
+/** The empty VM used for a not-ready state (503 or signin) and for loading. */
+export function unavailableVm(
+  reason: IntegrationsUnavailableReason | undefined,
+  loaded: boolean,
+): IntegrationsViewModel {
+  const vm: IntegrationsViewModel = {
+    loaded,
+    ready: false,
+    toolkits: [],
+    connections: [],
+  };
+  if (reason) vm.reason = reason;
+  return vm;
+}
+
+/** A required non-empty string off an untrusted command payload. */
+export function requireString(payload: unknown, key: string): string {
+  const value =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>)[key]
+      : undefined;
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`missing '${key}'`);
+  }
+  return value;
+}
+
+/** A string[] off an untrusted command payload (each item must be a string). */
+export function requireStringArray(payload: unknown, key: string): string[] {
+  const value =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>)[key]
+      : undefined;
+  if (!Array.isArray(value) || !value.every((v) => typeof v === "string")) {
+    throw new Error(`'${key}' must be an array of strings`);
+  }
+  return value as string[];
+}

--- a/packages/sdk/src/modules/preferences/index.ts
+++ b/packages/sdk/src/modules/preferences/index.ts
@@ -1,0 +1,104 @@
+/**
+ * The preferences module — per-user key/value preferences plus the
+ * workspace-locale override (the desktop's boot + language-settings path).
+ *
+ * These are pure commands: they read/write the gateway's user-scoped routes and
+ * return the value; there is no reactive scope to publish (a preference read is
+ * on-demand, and the locale write is a one-shot the surface acts on). The same
+ * handlers back both the typed facade and the bridge `dispatch` path.
+ *
+ * SEAM — user-scoped, NOT per-agent. Preferences are keyed by the caller's
+ * session `sub`, so this module talks to the flat {@link PreferencesClient}
+ * (rooted at the base URL), never `clientFor(agentId)`. A 401 routes through the
+ * shared {@link ModuleContext.authExpiry} notifier.
+ */
+
+import {
+  EngineError,
+  PreferencesClient,
+  type Workspace,
+} from "@houston/runtime-client";
+import type { ModuleContext } from "../../module-context";
+
+/** The write vocabulary — the same constants back the facade and the bridge. */
+export const PreferencesCommand = {
+  Get: "preferences/get",
+  Set: "preferences/set",
+  SetLocale: "workspace/setLocale",
+} as const;
+
+export type PreferencesCommandType =
+  (typeof PreferencesCommand)[keyof typeof PreferencesCommand];
+
+/** The typed facade for preference reads/writes + the workspace locale. */
+export interface PreferencesModule {
+  /** Read a preference value, or `null` when unset. */
+  get(key: string): Promise<string | null>;
+  /** Write (or, with `null`, clear) a preference; echoes the stored value. */
+  set(key: string, value: string | null): Promise<string | null>;
+  /** Set (or clear, with `null`) the workspace's UI-locale override. */
+  setLocale(workspaceId: string, locale: string | null): Promise<Workspace>;
+}
+
+/** A required non-empty string off an untrusted command payload. */
+function requireString(payload: unknown, key: string): string {
+  const value =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>)[key]
+      : undefined;
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`missing '${key}'`);
+  }
+  return value;
+}
+
+/** A nullable-string field off an untrusted command payload. */
+function optionalString(payload: unknown, key: string): string | null {
+  const value =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>)[key]
+      : undefined;
+  if (value === null || value === undefined) return null;
+  if (typeof value !== "string") throw new Error(`'${key}' must be a string`);
+  return value;
+}
+
+export function createPreferencesModule(ctx: ModuleContext): PreferencesModule {
+  const { authExpiry } = ctx;
+  const { baseUrl, ports } = ctx.config;
+
+  const client = new PreferencesClient({ baseUrl, fetch: ports.fetch });
+  const emitTokenExpired = () => authExpiry.notifyExpired();
+
+  /** Run a client call, surfacing a 401 as the shared token-expiry signal. */
+  async function run<T>(fn: () => Promise<T>): Promise<T> {
+    try {
+      return await fn();
+    } catch (err) {
+      if (err instanceof EngineError && err.status === 401) emitTokenExpired();
+      throw err;
+    }
+  }
+
+  const get = (key: string): Promise<string | null> =>
+    run(() => client.getPreference(key));
+  const set = (key: string, value: string | null): Promise<string | null> =>
+    run(() => client.setPreference(key, value));
+  const setLocale = (
+    workspaceId: string,
+    locale: string | null,
+  ): Promise<Workspace> =>
+    run(() => client.setWorkspaceLocale(workspaceId, locale));
+
+  ctx.registerCommand(PreferencesCommand.Get, (p) =>
+    get(requireString(p, "key")),
+  );
+  ctx.registerCommand(PreferencesCommand.Set, (p) =>
+    set(requireString(p, "key"), optionalString(p, "value")),
+  );
+  ctx.registerCommand(PreferencesCommand.SetLocale, (p) =>
+    setLocale(requireString(p, "workspaceId"), optionalString(p, "locale")),
+  );
+
+  return { get, set, setLocale };
+}

--- a/packages/sdk/src/modules/providers/index.ts
+++ b/packages/sdk/src/modules/providers/index.ts
@@ -1,0 +1,95 @@
+/**
+ * The providers module — the SDK-canonical per-agent AI-provider connect/status
+ * surface (PARITY-SETTINGS §2, §6). One reactive scope per agent
+ * (`providers/<agentId>`) holding a {@link ProvidersViewModel} that merges the
+ * runtime's `GET /providers` + `GET /auth/status` reads (see `merge.ts`). The
+ * read/mutation functions live in `operations.ts`; this factory wires them to
+ * the command registry and returns the typed facade — one implementation backs
+ * both the facade and the bridge `dispatch` path.
+ *
+ * Provider credentials are per-agent-pod in hosted mode, so every call is routed
+ * through `ctx.clientFor(agentId)` (`/agents/<id>/…`). 401s need no handling
+ * here: `ctx.config.ports.fetch` is the shared auth-fetch, which classifies a
+ * 401 and reports it to the `session/tokenExpired` notifier for EVERY request it
+ * stamps — the engine client the module calls runs on that same fetch, so a
+ * lapsed token surfaces automatically (verified, not reimplemented).
+ *
+ * **Login polling contract.** `login` STARTS an OAuth session and returns the
+ * {@link LoginInfo} verbatim; for a `device_code`/`auth_code` login the
+ * credential only lands once the user completes it out of band. The SDK owns no
+ * timer — the SURFACE polls {@link ProvidersModule.refreshStatus} (the cheap
+ * `/auth/status`-only read) on its own cadence and watches the provider's
+ * `configured` flip to true (a `device_code` login) or drives
+ * {@link ProvidersModule.completeLogin} with the pasted code (an `auth_code`
+ * login). The module stays imperative throughout.
+ */
+
+import type { ModuleContext } from "../../module-context";
+import { createProviderOps } from "./operations";
+import {
+  parseCompleteLogin,
+  parseLogin,
+  parseProviderAction,
+  parseRefresh,
+  parseSetApiKey,
+  parseSetModel,
+} from "./payloads";
+import {
+  ProvidersCommand,
+  type ProvidersModule,
+  providersScope,
+} from "./types";
+
+export { mergeProviders, overlayStatus } from "./merge";
+export type {
+  LoginInfo,
+  LoginOptions,
+  LoginState,
+  ProviderId,
+  ProvidersModule,
+  ProvidersViewModel,
+  ProviderVM,
+  SetModelOptions,
+} from "./types";
+export {
+  ProvidersCommand,
+  type ProvidersCommandType,
+  providersScope,
+} from "./types";
+
+export function createProvidersModule(ctx: ModuleContext): ProvidersModule {
+  const ops = createProviderOps(ctx);
+
+  ctx.registerCommand(ProvidersCommand.Refresh, (p) =>
+    ops.refresh(parseRefresh(p).agentId),
+  );
+  ctx.registerCommand(ProvidersCommand.RefreshStatus, (p) =>
+    ops.refreshStatus(parseRefresh(p).agentId),
+  );
+  ctx.registerCommand(ProvidersCommand.Login, (p) => {
+    const { agentId, provider, deviceAuth, enterpriseDomain } = parseLogin(p);
+    return ops.login(agentId, provider, { deviceAuth, enterpriseDomain });
+  });
+  ctx.registerCommand(ProvidersCommand.CancelLogin, (p) => {
+    const { agentId, provider } = parseProviderAction(p);
+    return ops.cancelLogin(agentId, provider);
+  });
+  ctx.registerCommand(ProvidersCommand.CompleteLogin, (p) => {
+    const { agentId, provider, code } = parseCompleteLogin(p);
+    return ops.completeLogin(agentId, provider, code);
+  });
+  ctx.registerCommand(ProvidersCommand.SetApiKey, (p) => {
+    const { agentId, provider, key } = parseSetApiKey(p);
+    return ops.setApiKey(agentId, provider, key);
+  });
+  ctx.registerCommand(ProvidersCommand.Logout, (p) => {
+    const { agentId, provider } = parseProviderAction(p);
+    return ops.logout(agentId, provider);
+  });
+  ctx.registerCommand(ProvidersCommand.SetModel, (p) => {
+    const { agentId, model, effort, provider } = parseSetModel(p);
+    return ops.setModel(agentId, { model, effort, provider });
+  });
+
+  return { scope: providersScope, ...ops };
+}

--- a/packages/sdk/src/modules/providers/merge.ts
+++ b/packages/sdk/src/modules/providers/merge.ts
@@ -1,0 +1,95 @@
+/**
+ * Coherent merge of the runtime's two provider reads into the
+ * `providers/<agentId>` view-model.
+ *
+ * `GET /providers` (`ProviderInfo[]`) is the rich base — it carries each
+ * provider's models + active model + availability. `GET /auth/status`
+ * (`AuthStatus`) overlays the credential/login truth: `configured`, the
+ * in-flight `login` state, the Copilot `enterpriseUrl`, and the runtime's
+ * `activeProvider`. The two lists come from the SAME per-agent runtime, so they
+ * describe one set of providers; we union by id (list order first, any
+ * auth-only providers appended) so nothing the wire reported is dropped.
+ *
+ * `configured` prefers the auth-status value (the credential source of truth the
+ * login poll reads) and falls back to the list's flag; `isActive` is COMPUTED as
+ * `id === activeProvider` so the snapshot is always internally consistent rather
+ * than echoing the list's possibly-stale flag.
+ */
+
+import type {
+  AuthStatus,
+  ProviderAuth,
+  ProviderId,
+  ProviderInfo,
+} from "@houston/runtime-client";
+import type { ProvidersViewModel, ProviderVM } from "./types";
+
+/** The `ProviderInfo` fields the merge reads. A prior {@link ProviderVM}
+ *  structurally satisfies this, so a status-only overlay can reuse it as the
+ *  model-carrying base. */
+type ProviderInfoLike = Pick<
+  ProviderInfo,
+  "id" | "name" | "activeModel" | "models" | "configured"
+>;
+
+function toVM(
+  activeProvider: ProviderId | null,
+  id: ProviderId,
+  info: ProviderInfoLike | undefined,
+  auth: ProviderAuth | undefined,
+): ProviderVM {
+  const vm: ProviderVM = {
+    id,
+    name: info?.name ?? auth?.name ?? id,
+    configured: auth?.configured ?? info?.configured ?? false,
+    isActive: activeProvider === id,
+    activeModel: info?.activeModel ?? "",
+    models: info?.models ?? [],
+  };
+  if (auth) vm.login = auth.login;
+  if (auth?.enterpriseUrl !== undefined) vm.enterpriseUrl = auth.enterpriseUrl;
+  return vm;
+}
+
+/** Build the VM from a model-carrying base list + the auth overlay, unioned by
+ *  id (base order first, auth-only ids appended). */
+function build(base: ProviderInfoLike[], auth: AuthStatus): ProvidersViewModel {
+  const authById = new Map(auth.providers.map((a) => [a.provider, a]));
+  const active = auth.activeProvider;
+  const seen = new Set<ProviderId>();
+  const providers: ProviderVM[] = [];
+  for (const info of base) {
+    seen.add(info.id);
+    providers.push(toVM(active, info.id, info, authById.get(info.id)));
+  }
+  for (const a of auth.providers) {
+    if (seen.has(a.provider)) continue;
+    providers.push(toVM(active, a.provider, undefined, a));
+  }
+  return {
+    loaded: true,
+    providers,
+    ...(active ? { activeProvider: active } : {}),
+  };
+}
+
+/** Full merge of `GET /providers` + `GET /auth/status`. */
+export function mergeProviders(
+  infos: ProviderInfo[],
+  auth: AuthStatus,
+): ProvidersViewModel {
+  return build(infos, auth);
+}
+
+/**
+ * Status-only overlay for the cheap login poll: keep the model info the prior
+ * snapshot already holds, refresh every credential/login/active field from
+ * `GET /auth/status`. With no prior snapshot it degrades to an auth-only VM
+ * (empty model lists) so a first poll before any full refresh still publishes.
+ */
+export function overlayStatus(
+  prior: ProvidersViewModel | undefined,
+  auth: AuthStatus,
+): ProvidersViewModel {
+  return build(prior?.providers ?? [], auth);
+}

--- a/packages/sdk/src/modules/providers/operations.ts
+++ b/packages/sdk/src/modules/providers/operations.ts
@@ -1,0 +1,161 @@
+/**
+ * The providers module's operations — the read/merge + credential-mutation
+ * functions the typed facade and the bridge command handlers both call. Kept out
+ * of `index.ts` so the factory there stays a thin wiring layer.
+ *
+ * Every call is routed through `ctx.clientFor(agentId)` (`/agents/<id>/…`, the
+ * per-agent-pod credential scope). Writes mutate then refetch, so the published
+ * snapshot always reflects the runtime. See `index.ts` for the login-polling
+ * contract (the SURFACE polls {@link ProviderOps.refreshStatus}; the SDK owns no
+ * timer) and the 401 seam (the shared auth-fetch surfaces it automatically).
+ */
+
+import type { ModuleContext } from "../../module-context";
+import { resolveModelSettings } from "../turns/model-settings";
+import { mergeProviders, overlayStatus } from "./merge";
+import {
+  type LoginInfo,
+  type LoginOptions,
+  type ProviderId,
+  type ProvidersViewModel,
+  providersScope,
+  type SetModelOptions,
+} from "./types";
+
+export interface ProviderOps {
+  refresh(agentId: string): Promise<void>;
+  refreshStatus(agentId: string): Promise<void>;
+  login(
+    agentId: string,
+    provider: ProviderId,
+    opts?: LoginOptions,
+  ): Promise<LoginInfo>;
+  cancelLogin(agentId: string, provider: ProviderId): Promise<void>;
+  completeLogin(
+    agentId: string,
+    provider: ProviderId,
+    code: string,
+  ): Promise<void>;
+  setApiKey(agentId: string, provider: ProviderId, key: string): Promise<void>;
+  logout(agentId: string, provider: ProviderId): Promise<void>;
+  setModel(agentId: string, opts: SetModelOptions): Promise<void>;
+}
+
+export function createProviderOps(ctx: ModuleContext): ProviderOps {
+  const { store } = ctx;
+
+  // Monotonic per-agent request sequence: a slow full refresh that resolves
+  // after a newer one never flushes a stale snapshot over the fresh one
+  // (last-intent wins). Mirrors the activities module's guard.
+  const loadSeq = new Map<string, number>();
+
+  async function refresh(agentId: string): Promise<void> {
+    const scope = providersScope(agentId);
+    const seq = (loadSeq.get(agentId) ?? 0) + 1;
+    loadSeq.set(agentId, seq);
+    // Signal loading while keeping any prior providers to avoid a flush-to-empty.
+    const prior = store.getSnapshot(scope) as ProvidersViewModel | undefined;
+    store.publish(scope, {
+      loaded: false,
+      providers: prior?.providers ?? [],
+      ...(prior?.activeProvider
+        ? { activeProvider: prior.activeProvider }
+        : {}),
+    });
+    const client = ctx.clientFor(agentId);
+    const [infos, auth] = await Promise.all([
+      client.listProviders(),
+      client.authStatus(),
+    ]);
+    if (loadSeq.get(agentId) === seq)
+      store.publish(scope, mergeProviders(infos, auth));
+  }
+
+  async function refreshStatus(agentId: string): Promise<void> {
+    const auth = await ctx.clientFor(agentId).authStatus();
+    const scope = providersScope(agentId);
+    const prior = store.getSnapshot(scope) as ProvidersViewModel | undefined;
+    store.publish(scope, overlayStatus(prior, auth));
+  }
+
+  async function login(
+    agentId: string,
+    provider: ProviderId,
+    opts?: LoginOptions,
+  ): Promise<LoginInfo> {
+    const info = await ctx
+      .clientFor(agentId)
+      .startLogin(provider, opts?.deviceAuth ?? true, opts?.enterpriseDomain);
+    // Reflect the now-awaiting login state so a surface can paint "Connecting…"
+    // — best-effort: the login already started, so a status hiccup must not mask
+    // the LoginInfo the user needs to proceed.
+    try {
+      await refreshStatus(agentId);
+    } catch (err) {
+      ctx.config.ports.logger.debug(
+        "providers refreshStatus after login failed",
+        { error: String(err), agentId },
+      );
+    }
+    return info;
+  }
+
+  async function cancelLogin(
+    agentId: string,
+    provider: ProviderId,
+  ): Promise<void> {
+    await ctx.clientFor(agentId).cancelLogin(provider);
+    await refreshStatus(agentId);
+  }
+
+  async function completeLogin(
+    agentId: string,
+    provider: ProviderId,
+    code: string,
+  ): Promise<void> {
+    await ctx.clientFor(agentId).completeLogin(provider, code);
+    await refresh(agentId);
+  }
+
+  async function setApiKey(
+    agentId: string,
+    provider: ProviderId,
+    key: string,
+  ): Promise<void> {
+    await ctx.clientFor(agentId).setApiKey(provider, key);
+    await refresh(agentId);
+  }
+
+  async function logout(agentId: string, provider: ProviderId): Promise<void> {
+    await ctx.clientFor(agentId).logout(provider);
+    await refresh(agentId);
+  }
+
+  async function setModel(
+    agentId: string,
+    opts: SetModelOptions,
+  ): Promise<void> {
+    const client = ctx.clientFor(agentId);
+    // Reuse the shared resolver: it pairs a model with its owning provider (the
+    // runtime hard-fails a model that belongs to a different active provider).
+    const settings = await resolveModelSettings(
+      client,
+      opts.model,
+      opts.effort,
+    );
+    if (opts.provider !== undefined) settings.activeProvider = opts.provider;
+    await client.setSettings(settings);
+    await refresh(agentId);
+  }
+
+  return {
+    refresh,
+    refreshStatus,
+    login,
+    cancelLogin,
+    completeLogin,
+    setApiKey,
+    logout,
+    setModel,
+  };
+}

--- a/packages/sdk/src/modules/providers/payloads.ts
+++ b/packages/sdk/src/modules/providers/payloads.ts
@@ -1,0 +1,93 @@
+/**
+ * Untrusted command-payload parsers for the providers module. The bridge
+ * (`dispatch`) hands these raw JSON; each parser throws on a bad shape
+ * (`CommandRegistry.dispatch` turns the throw into an `ok: false` result).
+ *
+ * `provider` is validated as a non-empty string and carried as {@link ProviderId}
+ * — the runtime rejects an unknown id server-side, so the union is not
+ * re-validated here (it would only drift from the wire's own list).
+ */
+
+import type { ProviderId } from "@houston/runtime-client";
+
+function requireString(payload: unknown, key: string): string {
+  const value =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>)[key]
+      : undefined;
+  if (typeof value !== "string" || value.length === 0)
+    throw new Error(`missing '${key}'`);
+  return value;
+}
+
+function optionalString(payload: unknown, key: string): string | undefined {
+  const value =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>)[key]
+      : undefined;
+  return typeof value === "string" ? value : undefined;
+}
+
+function optionalBoolean(payload: unknown, key: string): boolean | undefined {
+  const value =
+    typeof payload === "object" && payload !== null
+      ? (payload as Record<string, unknown>)[key]
+      : undefined;
+  return typeof value === "boolean" ? value : undefined;
+}
+
+const provider = (p: unknown): ProviderId =>
+  requireString(p, "provider") as ProviderId;
+
+export const parseRefresh = (p: unknown): { agentId: string } => ({
+  agentId: requireString(p, "agentId"),
+});
+
+export interface LoginArgs {
+  agentId: string;
+  provider: ProviderId;
+  deviceAuth?: boolean;
+  enterpriseDomain?: string;
+}
+export const parseLogin = (p: unknown): LoginArgs => ({
+  agentId: requireString(p, "agentId"),
+  provider: provider(p),
+  deviceAuth: optionalBoolean(p, "deviceAuth"),
+  enterpriseDomain: optionalString(p, "enterpriseDomain"),
+});
+
+export const parseProviderAction = (
+  p: unknown,
+): { agentId: string; provider: ProviderId } => ({
+  agentId: requireString(p, "agentId"),
+  provider: provider(p),
+});
+
+export const parseCompleteLogin = (
+  p: unknown,
+): { agentId: string; provider: ProviderId; code: string } => ({
+  agentId: requireString(p, "agentId"),
+  provider: provider(p),
+  code: requireString(p, "code"),
+});
+
+export const parseSetApiKey = (
+  p: unknown,
+): { agentId: string; provider: ProviderId; key: string } => ({
+  agentId: requireString(p, "agentId"),
+  provider: provider(p),
+  key: requireString(p, "key"),
+});
+
+export interface SetModelArgs {
+  agentId: string;
+  model?: string;
+  effort?: string;
+  provider?: ProviderId;
+}
+export const parseSetModel = (p: unknown): SetModelArgs => ({
+  agentId: requireString(p, "agentId"),
+  model: optionalString(p, "model"),
+  effort: optionalString(p, "effort"),
+  provider: optionalString(p, "provider") as ProviderId | undefined,
+});

--- a/packages/sdk/src/modules/providers/types.ts
+++ b/packages/sdk/src/modules/providers/types.ts
@@ -1,0 +1,141 @@
+/**
+ * Wire + view-model types for the providers module — the per-agent AI-provider
+ * connect/status surface (PARITY-SETTINGS §2, §6). Provider credentials are
+ * per-agent-pod in hosted mode, so every scope, command, and call is keyed by
+ * `agentId` and routed through `ctx.clientFor(agentId)` (`/agents/<id>/…`).
+ *
+ * The `providers/<agentId>` snapshot merges the runtime's two provider reads
+ * coherently: `GET /providers` (the rich list — models + active model +
+ * availability) is the base, and `GET /auth/status` overlays the credential
+ * truth (`configured`), the in-flight `login` state, the Copilot Enterprise
+ * `enterpriseUrl`, and the runtime's `activeProvider`. Everything here is plain
+ * JSON — it crosses the `getSnapshot`/`subscribe`/`dispatch` boundary unchanged.
+ *
+ * Fields are exactly what the wire provides (`@houston/protocol` via
+ * `@houston/runtime-client`); nothing is invented.
+ */
+
+import type {
+  LoginInfo,
+  LoginState,
+  ProviderId,
+} from "@houston/runtime-client";
+
+export type { LoginInfo, LoginState, ProviderId };
+
+/**
+ * One provider inside the `providers/<agentId>` snapshot: the `ProviderInfo`
+ * fields (`GET /providers`) enriched with the `GET /auth/status` overlay.
+ *
+ * `isActive` is computed as `id === activeProvider`, so it is always coherent
+ * with the snapshot's top-level `activeProvider` (never a stale echo of the
+ * runtime's own flag). `login` (present only when the provider appears in
+ * `/auth/status`) carries the in-flight OAuth state a surface polls on;
+ * `enterpriseUrl` distinguishes a Copilot Enterprise credential.
+ */
+export interface ProviderVM {
+  id: ProviderId;
+  name: string;
+  /** Credential present (auth-status truth; falls back to the list's flag). */
+  configured: boolean;
+  /** `id === activeProvider` — the provider new turns run under. */
+  isActive: boolean;
+  /** The runtime's active model for this provider (may be empty pre-connect). */
+  activeModel: string;
+  /** The provider's selectable models (empty for an auth-only provider). */
+  models: string[];
+  /** In-flight/last OAuth login state, or null when idle. Absent when the
+   *  provider isn't in `/auth/status`. The SURFACE polls this via
+   *  {@link ProvidersModule.refreshStatus}; the SDK never hides a timer. */
+  login?: LoginState | null;
+  /** GitHub Copilot Enterprise domain the credential was issued for, else null.
+   *  Absent for every non-Copilot provider. */
+  enterpriseUrl?: string | null;
+}
+
+/**
+ * The `providers/<agentId>` view-model: the WHOLE snapshot, republished on any
+ * change. `loaded` is false until the first merge resolves; `activeProvider` is
+ * omitted when the runtime has none selected.
+ */
+export interface ProvidersViewModel {
+  loaded: boolean;
+  providers: ProviderVM[];
+  activeProvider?: ProviderId;
+}
+
+/** The reactive scope this module owns, per agent. */
+export const providersScope = (agentId: string): string =>
+  `providers/${agentId}`;
+
+/** The command types this module registers. Typed to defeat string drift. */
+export const ProvidersCommand = {
+  Refresh: "providers/refresh",
+  RefreshStatus: "providers/refreshStatus",
+  Login: "providers/login",
+  CancelLogin: "providers/cancelLogin",
+  CompleteLogin: "providers/completeLogin",
+  SetApiKey: "providers/setApiKey",
+  Logout: "providers/logout",
+  SetModel: "providers/setModel",
+} as const;
+export type ProvidersCommandType =
+  (typeof ProvidersCommand)[keyof typeof ProvidersCommand];
+
+/** Options for {@link ProvidersModule.login}. Hosted mode defaults `deviceAuth`
+ *  true (no loopback callback); `enterpriseDomain` is GitHub Copilot only. */
+export interface LoginOptions {
+  deviceAuth?: boolean;
+  enterpriseDomain?: string;
+}
+
+/** Options for {@link ProvidersModule.setModel}: a per-agent model/effort/
+ *  provider switch, applied through the shared `resolveModelSettings` semantics. */
+export interface SetModelOptions {
+  model?: string;
+  effort?: string;
+  /** Explicit active-provider override (else resolved from the model's owner). */
+  provider?: ProviderId;
+}
+
+/**
+ * The typed facade for per-agent provider reads + writes.
+ *
+ * Every mutating call refreshes the agent's snapshot before it resolves, so a
+ * caller that awaits it reads the settled VM. The login flow is the exception
+ * to "refresh the whole VM": `login` starts an OAuth session and returns the
+ * {@link LoginInfo} verbatim (the discriminated union the surface renders), then
+ * the SURFACE polls {@link refreshStatus} (the cheap `/auth/status`-only read)
+ * until `configured` flips — the SDK stays imperative and owns no timers.
+ */
+export interface ProvidersModule {
+  /** Scope string for `sdk.subscribe(...)` / `sdk.getSnapshot(...)`. */
+  scope(agentId: string): string;
+  /** Full read: merge `GET /providers` + `GET /auth/status`, republish. */
+  refresh(agentId: string): Promise<void>;
+  /** Cheap poll: `GET /auth/status` only, overlaid onto the current snapshot.
+   *  The login-polling read (`configured` flips here when a device/auth-code
+   *  login completes). */
+  refreshStatus(agentId: string): Promise<void>;
+  /** Start an OAuth login; returns the {@link LoginInfo} to render (verbatim).
+   *  Refreshes status (surfaces the awaiting-user state) before resolving. */
+  login(
+    agentId: string,
+    provider: ProviderId,
+    opts?: LoginOptions,
+  ): Promise<LoginInfo>;
+  /** Abort an in-flight login, then refresh status. */
+  cancelLogin(agentId: string, provider: ProviderId): Promise<void>;
+  /** Submit a pasted code (the `auth_code` path), then refresh. */
+  completeLogin(
+    agentId: string,
+    provider: ProviderId,
+    code: string,
+  ): Promise<void>;
+  /** Store an API key for an api-key provider, then refresh (configured flips). */
+  setApiKey(agentId: string, provider: ProviderId, key: string): Promise<void>;
+  /** Disconnect a provider, then refresh (configured flips off). */
+  logout(agentId: string, provider: ProviderId): Promise<void>;
+  /** Apply a model/effort/provider switch (resolveModelSettings), then refresh. */
+  setModel(agentId: string, opts: SetModelOptions): Promise<void>;
+}

--- a/packages/sdk/src/sdk.ts
+++ b/packages/sdk/src/sdk.ts
@@ -13,7 +13,10 @@ import type { ModuleContext } from "./module-context";
 import { createActivitiesModule } from "./modules/activities";
 import { createAgentsModule } from "./modules/agents";
 import { createConversationsModule } from "./modules/conversations";
+import { createIntegrationsModule } from "./modules/integrations";
 import { createMissionsSearchModule } from "./modules/missions-search";
+import { createPreferencesModule } from "./modules/preferences";
+import { createProvidersModule } from "./modules/providers";
 import { createSessionModule } from "./modules/session";
 import { createTurnsModule } from "./modules/turns";
 import type { SdkConfig } from "./ports";
@@ -76,6 +79,12 @@ export class HoustonSdk {
   readonly activities: ReturnType<typeof createActivitiesModule>;
   /** Mission-search facade (ranked full-text search across missions). */
   readonly missions: ReturnType<typeof createMissionsSearchModule>;
+  /** Per-agent AI-provider facade (connect, status, active model). */
+  readonly providers: ReturnType<typeof createProvidersModule>;
+  /** Integrations facade (Composio readiness, connections, per-agent grants). */
+  readonly integrations: ReturnType<typeof createIntegrationsModule>;
+  /** Preferences facade (key/value preferences + workspace locale). */
+  readonly preferences: ReturnType<typeof createPreferencesModule>;
 
   constructor(config: SdkConfig) {
     this.config = config;
@@ -107,6 +116,9 @@ export class HoustonSdk {
     this.turns = createTurnsModule(ctx);
     this.activities = createActivitiesModule(ctx);
     this.missions = createMissionsSearchModule(ctx);
+    this.providers = createProvidersModule(ctx);
+    this.integrations = createIntegrationsModule(ctx);
+    this.preferences = createPreferencesModule(ctx);
     // =====================================================================
   }
 

--- a/packages/sdk/tests/integrations.contract.test.ts
+++ b/packages/sdk/tests/integrations.contract.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Integrations contract: the `integrations` view-model reflects the gateway's
+ * Composio readiness + catalog + connections, degrades to explicit not-ready
+ * states (503 → `unavailable`, provider → `signin`) WITHOUT crashing, drives the
+ * connect → poll → active flow, and keeps the grants 404-null vs `[]` distinction
+ * end to end (both the typed facade and the bridge `dispatch` path).
+ *
+ * The `IntegrationsViewModel` is a cross-platform snapshot, so its shape is
+ * pinned here as API.
+ */
+
+import { type FakeHost, SEED_AGENT_ID } from "@houston/fake-host";
+import {
+  INTEGRATIONS_SCOPE,
+  IntegrationsCommand,
+  type IntegrationsViewModel,
+} from "@houston/sdk";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import {
+  control,
+  type Harness,
+  makeSdk,
+  resetHost,
+  startHost,
+} from "./harness";
+
+let host: FakeHost;
+
+beforeAll(async () => {
+  host = await startHost();
+});
+afterAll(async () => {
+  await host.stop();
+});
+
+let h: Harness;
+beforeEach(async () => {
+  await resetHost(host.url);
+  h = makeSdk(host.url);
+});
+afterEach(() => {
+  h.sdk.dispose();
+});
+
+const vm = (): IntegrationsViewModel | undefined =>
+  h.sdk.getSnapshot(INTEGRATIONS_SCOPE) as IntegrationsViewModel | undefined;
+
+describe("integrations VM", () => {
+  it("scope key is 'integrations'", () => {
+    expect(INTEGRATIONS_SCOPE).toBe("integrations");
+  });
+
+  it("loads readiness + catalog + connections into a pinned snapshot", async () => {
+    const result = await h.sdk.integrations.refresh();
+
+    expect(result).toEqual({
+      loaded: true,
+      ready: true,
+      toolkits: [
+        expect.objectContaining({ slug: "github", name: "GitHub" }),
+        expect.objectContaining({ slug: "gmail", name: "Gmail" }),
+        expect.objectContaining({ slug: "slack", name: "Slack" }),
+      ],
+      connections: [
+        { toolkit: "gmail", connectionId: "conn-gmail-0", status: "active" },
+      ],
+    });
+    expect(vm()).toEqual(result);
+    // No `reason` key on a ready VM.
+    expect("reason" in (vm() as object)).toBe(false);
+  });
+
+  it("degrades to {ready:false, reason:'unavailable'} on a 503 (no key)", async () => {
+    await control(host.url, "integrations-mode", { mode: "unavailable" });
+    await h.sdk.integrations.refresh();
+
+    expect(vm()).toEqual({
+      loaded: true,
+      ready: false,
+      reason: "unavailable",
+      toolkits: [],
+      connections: [],
+    });
+  });
+
+  it("surfaces the provider signin state as {ready:false, reason:'signin'}", async () => {
+    await control(host.url, "integrations-mode", { mode: "signin" });
+    await h.sdk.integrations.refresh();
+
+    expect(vm()).toMatchObject({
+      loaded: true,
+      ready: false,
+      reason: "signin",
+      toolkits: [],
+      connections: [],
+    });
+  });
+
+  it("connect → poll pending → activate → poll active", async () => {
+    const { redirectUrl, connectionId } =
+      await h.sdk.integrations.connect("slack");
+    expect(redirectUrl).toBe("https://connect.test/slack");
+    expect(connectionId).toMatch(/^conn-slack-/);
+
+    expect(await h.sdk.integrations.pollConnection(connectionId)).toEqual({
+      toolkit: "slack",
+      connectionId,
+      status: "pending",
+    });
+
+    await control(host.url, "integrations-activate", { connectionId });
+    expect(await h.sdk.integrations.pollConnection(connectionId)).toEqual({
+      toolkit: "slack",
+      connectionId,
+      status: "active",
+    });
+  });
+
+  it("disconnect removes the toolkit's connections and refetches the VM", async () => {
+    const result = await h.sdk.integrations.disconnect("gmail");
+    expect(result.connections).toEqual([]);
+    expect(vm()?.connections).toEqual([]);
+  });
+});
+
+describe("integrations grants — 404-null vs [] is preserved end to end", () => {
+  it("an agent with no grants record resolves to null (unsupported)", async () => {
+    expect(await h.sdk.integrations.grants(SEED_AGENT_ID)).toBeNull();
+  });
+
+  it("writing a grant set makes it a real record; [] stays distinct from null", async () => {
+    await h.sdk.integrations.setGrants(SEED_AGENT_ID, ["gmail"]);
+    expect(await h.sdk.integrations.grants(SEED_AGENT_ID)).toEqual(["gmail"]);
+
+    await h.sdk.integrations.setGrants(SEED_AGENT_ID, []);
+    // A record exists now → [], NOT null.
+    expect(await h.sdk.integrations.grants(SEED_AGENT_ID)).toEqual([]);
+  });
+
+  it("routes 404-null through the bridge dispatch path too", async () => {
+    const res = await h.sdk.dispatch({
+      id: "g1",
+      type: IntegrationsCommand.Grants,
+      payload: { agentId: SEED_AGENT_ID },
+    });
+    expect(res).toEqual({ id: "g1", ok: true, value: null });
+  });
+});

--- a/packages/sdk/tests/preferences.contract.test.ts
+++ b/packages/sdk/tests/preferences.contract.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Preferences contract: key/value preferences round-trip (null clears), and the
+ * workspace-locale override persists as the `locale` preference (the gateway
+ * stores locale in the same per-user store) — over both the typed facade and the
+ * bridge `dispatch` path.
+ */
+
+import { type FakeHost, SEED_WORKSPACE_ID } from "@houston/fake-host";
+import { PreferencesCommand } from "@houston/sdk";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { type Harness, makeSdk, resetHost, startHost } from "./harness";
+
+let host: FakeHost;
+
+beforeAll(async () => {
+  host = await startHost();
+});
+afterAll(async () => {
+  await host.stop();
+});
+
+let h: Harness;
+beforeEach(async () => {
+  await resetHost(host.url);
+  h = makeSdk(host.url);
+});
+afterEach(() => {
+  h.sdk.dispose();
+});
+
+describe("preferences", () => {
+  it("reads null for an unset key, then round-trips a value", async () => {
+    expect(await h.sdk.preferences.get("locale")).toBeNull();
+
+    expect(await h.sdk.preferences.set("locale", "es")).toBe("es");
+    expect(await h.sdk.preferences.get("locale")).toBe("es");
+  });
+
+  it("clears a preference when set to null", async () => {
+    await h.sdk.preferences.set("locale", "es");
+    expect(await h.sdk.preferences.set("locale", null)).toBeNull();
+    expect(await h.sdk.preferences.get("locale")).toBeNull();
+  });
+
+  it("round-trips over the bridge dispatch path", async () => {
+    const setRes = await h.sdk.dispatch({
+      id: "p1",
+      type: PreferencesCommand.Set,
+      payload: { key: "timezone", value: "America/New_York" },
+    });
+    expect(setRes).toEqual({ id: "p1", ok: true, value: "America/New_York" });
+
+    const getRes = await h.sdk.dispatch({
+      id: "p2",
+      type: PreferencesCommand.Get,
+      payload: { key: "timezone" },
+    });
+    expect(getRes).toEqual({ id: "p2", ok: true, value: "America/New_York" });
+  });
+});
+
+describe("workspace locale", () => {
+  it("PATCHes the workspace and persists as the locale preference", async () => {
+    const ws = await h.sdk.preferences.setLocale(SEED_WORKSPACE_ID, "pt");
+    expect(ws).toMatchObject({ id: SEED_WORKSPACE_ID, locale: "pt" });
+    // Locale is stored in the same per-user preference store.
+    expect(await h.sdk.preferences.get("locale")).toBe("pt");
+  });
+
+  it("clears the locale override with null", async () => {
+    await h.sdk.preferences.setLocale(SEED_WORKSPACE_ID, "pt");
+    const ws = await h.sdk.preferences.setLocale(SEED_WORKSPACE_ID, null);
+    expect(ws.locale).toBeNull();
+    expect(await h.sdk.preferences.get("locale")).toBeNull();
+  });
+});

--- a/packages/sdk/tests/providers.contract.test.ts
+++ b/packages/sdk/tests/providers.contract.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Providers contract: the `providers/<agentId>` view-model merges the runtime's
+ * `GET /providers` + `GET /auth/status` reads coherently, and the per-agent
+ * connect facade (login → LoginInfo kinds, api-key → configured flip, logout,
+ * setModel → {activeProvider, model}) mutates then refetches so the snapshot
+ * always reflects the pod (PARITY-SETTINGS §2, §6).
+ *
+ * These drive a REAL fake host over HTTP (per-agent-pod provider state), so what
+ * they pin is the wire contract, not a mock's guess. The `ProvidersViewModel` is
+ * a cross-platform snapshot (the AI Models grid iOS renders), so its shape is
+ * pinned here as API.
+ */
+
+import { type FakeHost, SEED_AGENT_ID } from "@houston/fake-host";
+import {
+  ProvidersCommand,
+  type ProvidersViewModel,
+  type ProviderVM,
+  providersScope,
+} from "@houston/sdk";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from "vitest";
+import { type Harness, makeSdk, resetHost, startHost } from "./harness";
+
+let host: FakeHost;
+beforeAll(async () => {
+  host = await startHost();
+});
+afterAll(async () => {
+  await host.stop();
+});
+
+let h: Harness;
+beforeEach(async () => {
+  await resetHost(host.url);
+  h = makeSdk(host.url);
+});
+afterEach(() => {
+  h.sdk.dispose();
+});
+
+const scope = providersScope(SEED_AGENT_ID);
+const vm = (): ProvidersViewModel | undefined =>
+  h.sdk.getSnapshot(scope) as ProvidersViewModel | undefined;
+const find = (id: string): ProviderVM | undefined =>
+  vm()?.providers.find((p) => p.id === id);
+
+describe("providers VM — list + status merge", () => {
+  it("merges GET /providers + GET /auth/status into a pinned snapshot", async () => {
+    await h.sdk.providers.refresh(SEED_AGENT_ID);
+    expect(vm()?.loaded).toBe(true);
+    expect(vm()?.activeProvider).toBe("anthropic");
+
+    // The connected+active provider: ProviderInfo fields + the auth overlay.
+    expect(find("anthropic")).toEqual({
+      id: "anthropic",
+      name: "Anthropic (Claude)",
+      configured: true,
+      isActive: true,
+      activeModel: "claude-sonnet-4-6",
+      models: ["claude-sonnet-4-6", "claude-opus-4-8"],
+      login: null,
+    });
+
+    // An unconnected OAuth provider: configured/isActive false, login idle.
+    expect(find("openai-codex")).toMatchObject({
+      configured: false,
+      isActive: false,
+      login: null,
+    });
+    // Copilot carries the Enterprise-domain discriminator (null when individual).
+    expect(find("github-copilot")).toMatchObject({ enterpriseUrl: null });
+  });
+
+  it("scope key is 'providers/<agentId>'", () => {
+    expect(providersScope("abc")).toBe("providers/abc");
+  });
+});
+
+describe("providers — login returns the LoginInfo kind verbatim", () => {
+  it("openai-codex → device_code; anthropic → auth_code; surfaces awaiting", async () => {
+    await h.sdk.providers.refresh(SEED_AGENT_ID);
+
+    const codex = await h.sdk.providers.login(SEED_AGENT_ID, "openai-codex");
+    expect(codex).toEqual({
+      kind: "device_code",
+      verificationUri: expect.any(String),
+      userCode: expect.any(String),
+    });
+
+    const claude = await h.sdk.providers.login(SEED_AGENT_ID, "anthropic");
+    expect(claude.kind).toBe("auth_code");
+    if (claude.kind === "auth_code") expect(claude.url).toMatch(/^https?:/);
+
+    // login refreshes status, so the awaiting-user state is now on the VM.
+    expect(find("openai-codex")?.login?.status).toBe("awaiting_user");
+    expect(find("anthropic")?.login?.status).toBe("awaiting_user");
+  });
+
+  it("carries the Copilot Enterprise domain through login", async () => {
+    await h.sdk.providers.login(SEED_AGENT_ID, "github-copilot", {
+      enterpriseDomain: "acme.ghe.com",
+    });
+    expect(find("github-copilot")?.enterpriseUrl).toBe("acme.ghe.com");
+  });
+});
+
+describe("providers — login polling contract (surface polls; SDK imperative)", () => {
+  it("refreshStatus reads /auth/status only; completeLogin flips configured", async () => {
+    await h.sdk.providers.refresh(SEED_AGENT_ID);
+    const info = await h.sdk.providers.login(SEED_AGENT_ID, "openai-codex");
+    expect(info.kind).toBe("device_code");
+
+    // The surface polls refreshStatus while the user completes it out of band.
+    await h.sdk.providers.refreshStatus(SEED_AGENT_ID);
+    expect(find("openai-codex")?.configured).toBe(false);
+    expect(find("openai-codex")?.login?.status).toBe("awaiting_user");
+    // The cheap poll preserves the model info from the prior full refresh.
+    expect(find("openai-codex")?.models).toEqual(["gpt-5-codex", "o4-mini"]);
+
+    await h.sdk.providers.completeLogin(
+      SEED_AGENT_ID,
+      "openai-codex",
+      "code-1",
+    );
+    expect(find("openai-codex")?.configured).toBe(true);
+    expect(find("openai-codex")?.login ?? null).toBeNull();
+  });
+
+  it("cancelLogin clears the in-flight login state", async () => {
+    await h.sdk.providers.login(SEED_AGENT_ID, "openai-codex");
+    expect(find("openai-codex")?.login?.status).toBe("awaiting_user");
+    await h.sdk.providers.cancelLogin(SEED_AGENT_ID, "openai-codex");
+    expect(find("openai-codex")?.login ?? null).toBeNull();
+  });
+});
+
+describe("providers — credential mutations refetch", () => {
+  it("setApiKey flips an api-key provider to configured", async () => {
+    await h.sdk.providers.refresh(SEED_AGENT_ID);
+    expect(find("openrouter")?.configured).toBe(false);
+
+    await h.sdk.providers.setApiKey(SEED_AGENT_ID, "openrouter", "sk-test");
+    expect(find("openrouter")?.configured).toBe(true);
+  });
+
+  it("logout disconnects and drops the active provider", async () => {
+    await h.sdk.providers.refresh(SEED_AGENT_ID);
+    expect(find("anthropic")?.configured).toBe(true);
+
+    await h.sdk.providers.logout(SEED_AGENT_ID, "anthropic");
+    expect(find("anthropic")?.configured).toBe(false);
+    // anthropic was the only connected provider → no active provider remains.
+    expect(vm()?.activeProvider).toBeUndefined();
+  });
+});
+
+describe("providers — setModel (resolveModelSettings semantics)", () => {
+  it("writes {activeProvider, model} pairing a model with its owner", async () => {
+    await h.sdk.providers.setModel(SEED_AGENT_ID, { model: "claude-opus-4-8" });
+    expect(vm()?.activeProvider).toBe("anthropic");
+    expect(find("anthropic")?.activeModel).toBe("claude-opus-4-8");
+    expect(find("anthropic")?.isActive).toBe(true);
+  });
+
+  it("switches the active provider when the model belongs to another", async () => {
+    await h.sdk.providers.setModel(SEED_AGENT_ID, { model: "gpt-5-codex" });
+    expect(vm()?.activeProvider).toBe("openai-codex");
+    expect(find("openai-codex")?.activeModel).toBe("gpt-5-codex");
+  });
+
+  it("honors an explicit provider override with no model", async () => {
+    await h.sdk.providers.setModel(SEED_AGENT_ID, {
+      provider: "github-copilot",
+    });
+    expect(vm()?.activeProvider).toBe("github-copilot");
+  });
+});
+
+describe("providers — bridge dispatch parity", () => {
+  it("runs refresh + login through the same handlers, and rejects a bad payload", async () => {
+    const refreshed = await h.sdk.dispatch({
+      id: "c1",
+      type: ProvidersCommand.Refresh,
+      payload: { agentId: SEED_AGENT_ID },
+    });
+    expect(refreshed).toMatchObject({ id: "c1", ok: true });
+    expect(vm()?.loaded).toBe(true);
+
+    // login surfaces the LoginInfo as the command's `value`.
+    const login = await h.sdk.dispatch({
+      id: "c2",
+      type: ProvidersCommand.Login,
+      payload: { agentId: SEED_AGENT_ID, provider: "anthropic" },
+    });
+    expect(login).toMatchObject({
+      id: "c2",
+      ok: true,
+      value: { kind: "auth_code" },
+    });
+
+    // A missing required field is a validation failure, not a throw.
+    const bad = await h.sdk.dispatch({
+      id: "c3",
+      type: ProvidersCommand.SetApiKey,
+      payload: { agentId: SEED_AGENT_ID },
+    });
+    expect(bad).toMatchObject({ id: "c3", ok: false });
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,10 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  gaxios>uuid: ^11.1.1
-  teeny-request>uuid: ^11.1.1
-
 importers:
 
   .:
@@ -338,6 +334,10 @@ importers:
       typebox:
         specifier: 1.1.38
         version: 1.1.38
+    optionalDependencies:
+      '@anthropic-ai/claude-agent-sdk':
+        specifier: 0.3.201
+        version: 0.3.201(@anthropic-ai/sdk@0.91.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
     devDependencies:
       '@types/node':
         specifier: 22.20.0
@@ -348,10 +348,6 @@ importers:
       vitest:
         specifier: 3.2.6
         version: 3.2.6(@types/debug@4.1.13)(@types/node@22.20.0)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.23.0)(yaml@2.9.0)
-    optionalDependencies:
-      '@anthropic-ai/claude-agent-sdk':
-        specifier: 0.3.201
-        version: 0.3.201(@anthropic-ai/sdk@0.91.1(zod@4.4.3))(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(zod@4.4.3)
 
   packages/runtime-client:
     dependencies:
@@ -801,25 +797,21 @@ packages:
     resolution: {integrity: sha512-EiqbpfJIpChfkn+8Uj061Qjyw0eaRcOXtdrvVuHANyj8ZErVOr8HlH6op9PSeIUa9TX0m2+tNgKPQvOGseQckA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@anthropic-ai/claude-agent-sdk-linux-arm64@0.3.201':
     resolution: {integrity: sha512-mShTo3MwF0gkN4dDw78wWJiB6aBDVRkl81cnApvoBofpdyUBYgm9Gw16CCjDTgelMKeBFqN6ErJpwjI3wbP00A==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.3.201':
     resolution: {integrity: sha512-IbxnzO5UCbqbm2TnzCHkSyJorAFw2isdKdIsFCTxJJjSs3ZC+v3LC1QSUiVCx0qi+CV6w3MKx6mLI11mrvhbbQ==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@anthropic-ai/claude-agent-sdk-linux-x64@0.3.201':
     resolution: {integrity: sha512-jrJBrRWrSuoFKIgjyqxHqmfd6Pb3Bs5Bvakg0knXCTC4fbUXGnC9Q6u7gdDwgXohUNP6/DD+s8U7bivvvVv0dg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@anthropic-ai/claude-agent-sdk-win32-arm64@0.3.201':
     resolution: {integrity: sha512-UsoytRJ/037uHpb3ATrIoe+AgwTf+PwKuFLGjddHAV/11wERJs0hlrnSmcnp43kf0PFxoSNinngme96YYASmQg==}
@@ -1054,28 +1046,24 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.5.0':
     resolution: {integrity: sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.5.0':
     resolution: {integrity: sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.5.0':
     resolution: {integrity: sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.5.0':
     resolution: {integrity: sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw==}
@@ -1648,35 +1636,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.9':
     resolution: {integrity: sha512-AGuJdgKsmJdm4Pych7kv3sqe591ERRaAHW3xjLooiFzn8J+PxUyof++7YZrB5Y5tpnTO+K18Og3taj2NpluCRQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.9':
     resolution: {integrity: sha512-DXBEAiuMpk7dhS1a9NzNxVAFi1vaKoPu7rQNgY8LIDLGrK3lnIp3nT10DUum+PKVJoJppIP+NAA8IZe4DMNDPw==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.9':
     resolution: {integrity: sha512-WORrMLd6EpElEME7JRKfSaY34nW1P5LbdgK5YNCS1ncG2LqmITsSMEJ8nh2mpvxb3TxqbOOKgY7k9eMJYlW9Mw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.9':
     resolution: {integrity: sha512-/DHn+1DrfL6oRaPPWXaOKvonFFrni666fxd+zFqiQEfvBH0tsHVWjq9iqBk0oDp0qaPA72lIMy5BptxISBEhZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.9':
     resolution: {integrity: sha512-O5FHD3ErkMwMhNzAfu3ggy0ug4z7btZuoQgwwxlzPrwV2bxlD6WDpqBY4NCgICAgZdDKdp+loUEKVAVt8aYnhQ==}
@@ -2499,79 +2482,66 @@ packages:
     resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.62.2':
     resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.62.2':
     resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.62.2':
     resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.62.2':
     resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.62.2':
     resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.62.2':
     resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.62.2':
     resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.62.2':
     resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.62.2':
     resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.62.2':
     resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
@@ -2859,28 +2829,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.2':
     resolution: {integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.2':
     resolution: {integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.2':
     resolution: {integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.2':
     resolution: {integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==}
@@ -2953,35 +2919,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.4':
     resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
     resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.4':
     resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.4':
     resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
     resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
@@ -4495,28 +4456,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5717,12 +5674,13 @@ packages:
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
 
-  uuid@11.1.1:
-    resolution: {integrity: sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==}
-    hasBin: true
-
   uuid@14.0.1:
     resolution: {integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==}
+    hasBin: true
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   vary@1.1.2:
@@ -9353,7 +9311,7 @@ snapshots:
       https-proxy-agent: 7.0.6
       is-stream: 2.0.1
       node-fetch: 2.7.0
-      uuid: 11.1.1
+      uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11346,7 +11304,7 @@ snapshots:
       https-proxy-agent: 5.0.1
       node-fetch: 2.7.0
       stream-events: 1.0.5
-      uuid: 11.1.1
+      uuid: 9.0.1
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -11523,9 +11481,9 @@ snapshots:
       is-typed-array: 1.1.15
       which-typed-array: 1.1.22
 
-  uuid@11.1.1: {}
-
   uuid@14.0.1: {}
+
+  uuid@9.0.1: {}
 
   vary@1.1.2:
     optional: true


### PR DESCRIPTION
The TS halves of the mobile **Settings / AI Models / Integrations** surfaces, built against the extracted desktop contract (`mobile/PARITY-SETTINGS.md`).

- **providers** (per-agent — hosted pods hold their own credentials): catalog+auth-status merged VM, device-code/auth-code login flows (surface polls; SDK owns no timers), API keys, logout, provider-aware model+effort selection (reuses `resolveModelSettings`).
- **integrations** (user-scoped through the gateway): toolkits/connections VM, connect→redirectUrl+poll, disconnect, per-agent grants with the **404-null vs `[]`** distinction preserved; 503→unavailable and signin degradation.
- **preferences**: get/set + workspace locale via the verified real route (spec corrected: `PATCH /v1/workspaces/:id {locale}`).
- runtime-client requester extraction + user-scoped client surface; stateful fake-host fixtures (found+fixed a body-less 204 that would break clients).

SDK **236** tests (26 new) · runtime-client 56 · web 64 + 22 e2e · boundaries/parity clean. iOS surfaces wave follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)