### PR TITLE
feat: Teams client surface — role matrix v2, managed-agent read-only gating, integration allowlists

### DIFF
--- a/app/src/components/chat-effort-selector.tsx
+++ b/app/src/components/chat-effort-selector.tsx
@@ -1,5 +1,10 @@
+import { Tooltip, TooltipContent, TooltipTrigger } from "@houston-ai/core";
+import type { Agent } from "@houston-ai/engine-client";
+import { Lock } from "lucide-react";
 import { useTranslation } from "react-i18next";
+import { useCapabilities } from "../hooks/use-capabilities";
 import { nextEffort } from "../lib/effort-cycle";
+import { isModelSelectorLocked } from "../lib/model-selector-lock";
 import {
   EFFORT_ORDER,
   type EffortLevel,
@@ -16,6 +21,14 @@ interface ChatEffortSelectorProps {
   effort?: string;
   /** Called when the user advances to the next level. */
   onSelect: (effort: EffortLevel) => void;
+  /**
+   * The agent this control configures, when composer-scoped. Threaded so the
+   * effort cycle LOCKS for org members who may not change the agent's model
+   * config (Teams matrix v2) — effort is part of the model pin. A non-manager
+   * sees the current level read-only. Omit outside an agent scope and it never
+   * locks; single-player is never locked.
+   */
+  agent?: Pick<Agent, "access"> | null;
 }
 
 /**
@@ -31,8 +44,12 @@ export function ChatEffortSelector({
   model,
   effort,
   onSelect,
+  agent,
 }: ChatEffortSelectorProps) {
   const { t } = useTranslation("chat");
+  const { t: tTeams } = useTranslation("teams");
+  const { capabilities } = useCapabilities();
+  const locked = isModelSelectorLocked(capabilities, agent);
   const levels = getEffortLevels(provider, model);
   if (levels.length === 0) return null;
 
@@ -62,6 +79,39 @@ export function ChatEffortSelector({
   const activeLabel = activeLevel
     ? labels[activeLevel]
     : t("modelSelector.effort");
+
+  // Teams v2: a non-manager sees the current effort read-only. Mirrors the
+  // locked model selector (`aria-disabled` keeps it focusable so the tooltip
+  // reason reaches keyboard + screen-reader users); effort is part of the
+  // model config pin, so it reuses the same tooltip copy.
+  if (locked) {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            aria-disabled="true"
+            aria-label={
+              activeLevel
+                ? t("modelSelector.effortValue", { level: activeLabel })
+                : t("modelSelector.effort")
+            }
+            onClick={(e) => e.preventDefault()}
+            className="flex items-center gap-1.5 h-7 px-2 rounded-lg text-xs text-muted-foreground cursor-not-allowed opacity-80 outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <EffortIcon
+              levels={EFFORT_ORDER}
+              active={effort}
+              className="size-3.5"
+            />
+            <span>{activeLabel}</span>
+            <Lock className="size-3 opacity-60" />
+          </button>
+        </TooltipTrigger>
+        <TooltipContent>{tTeams("model.lockedTooltip")}</TooltipContent>
+      </Tooltip>
+    );
+  }
 
   return (
     <button

--- a/app/src/components/chat-model-selector.tsx
+++ b/app/src/components/chat-model-selector.tsx
@@ -2,8 +2,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from "@houston-ai/core";
-import { ChevronDown } from "lucide-react";
+import type { Agent } from "@houston-ai/engine-client";
+import { ChevronDown, Lock } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../hooks/use-capabilities";
 import { useProviderStatuses } from "../hooks/use-provider-statuses";
@@ -12,6 +16,7 @@ import {
   providerPickerState,
   shouldShowProviderInPicker,
 } from "../lib/model-picker";
+import { isModelSelectorLocked } from "../lib/model-selector-lock";
 import { osIsTauri } from "../lib/os-bridge";
 import {
   EMPTY_PROVIDER_CAPABILITIES,
@@ -42,6 +47,14 @@ interface ChatModelSelectorProps {
    */
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
+  /**
+   * The agent this selector configures, when rendered in an agent-scoped
+   * surface (the composer). Threaded so the picker can LOCK for org members
+   * who may not change the agent's AI model (Teams matrix v2): a non-manager
+   * sees the pinned provider/model read-only. Omit outside an agent scope and
+   * the picker never locks; single-player is never locked.
+   */
+  agent?: Pick<Agent, "access"> | null;
 }
 
 export function ChatModelSelector({
@@ -50,10 +63,13 @@ export function ChatModelSelector({
   onSelect,
   open,
   onOpenChange,
+  agent,
 }: ChatModelSelectorProps) {
   const { t } = useTranslation("chat");
+  const { t: tTeams } = useTranslation("teams");
   const { statuses, isLoading } = useProviderStatuses();
   const { capabilities } = useCapabilities();
+  const locked = isModelSelectorLocked(capabilities, agent);
   const newEngine = newEngineActive();
   const providerCapabilities =
     capabilities ?? (newEngine ? EMPTY_PROVIDER_CAPABILITIES : undefined);
@@ -74,6 +90,37 @@ export function ChatModelSelector({
     (model || undefined) ??
     currentProvider?.subtitle ??
     t("modelSelector.selectModel");
+
+  if (locked) {
+    // Members see WHICH model the agent uses (a feature, not a leak) but can't
+    // change it: no dropdown, no provider/effort switch. `aria-disabled` (not
+    // the native `disabled` attribute) keeps the trigger focusable so the
+    // tooltip reason still reaches keyboard + screen-reader users.
+    return (
+      <fieldset
+        className="contents border-0 p-0 m-0"
+        onPointerDown={(e) => e.stopPropagation()}
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <button
+              type="button"
+              aria-disabled="true"
+              onClick={(e) => e.preventDefault()}
+              className="flex items-center gap-1.5 h-7 px-2 rounded-lg text-xs text-muted-foreground cursor-not-allowed opacity-80 outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            >
+              <ProviderIcon providerId={provider} className="size-3.5" />
+              <span>{displayLabel}</span>
+              <Lock className="size-3 opacity-60" />
+            </button>
+          </TooltipTrigger>
+          <TooltipContent>{tTeams("model.lockedTooltip")}</TooltipContent>
+        </Tooltip>
+      </fieldset>
+    );
+  }
 
   return (
     // Stop pointer events from bubbling — prevents the board detail panel

--- a/app/src/components/tabs/agent-access-model.ts
+++ b/app/src/components/tabs/agent-access-model.ts
@@ -1,3 +1,6 @@
+import type { Agent, Capabilities } from "@houston-ai/engine-client";
+import { canManageAssignments, isMultiplayer } from "../../lib/org-roles.ts";
+
 /**
  * Pure toggle logic for the "Who can use this agent" block. The host convention
  * makes an EMPTY `assignedUserIds` mean "everyone in the org", so toggling off
@@ -6,6 +9,28 @@
  * returned as `confirmOpenToAll` for the UI to confirm-gate. Pure so it's
  * unit-testable.
  */
+
+/**
+ * Should the "Who can use this agent" share block render at all? Two conditions,
+ * both required:
+ *
+ * 1. The deployment is multiplayer — single-player / self-host has no org to
+ *    share within, so the block is meaningless and must degrade to nothing
+ *    (like the grants surface does). `canManageAssignments` alone is NOT enough:
+ *    under matrix v2 it short-circuits to `true` in single-player, so gating on
+ *    it only would resurrect an empty, non-functional org-share block on every
+ *    self-host agent.
+ * 2. The caller can manage this agent's assignments (agent-manager authority).
+ *
+ * Pure so the visibility gate is unit-tested in isolation.
+ */
+export function canShowAgentShareBlock(
+  caps: Capabilities | null | undefined,
+  agent: Pick<Agent, "access">,
+): boolean {
+  return isMultiplayer(caps) && canManageAssignments(caps, agent);
+}
+
 export type AssignmentToggleResult =
   | { kind: "set"; userIds: string[] }
   | { kind: "confirmOpenToAll" };

--- a/app/src/components/tabs/agent-access-section.tsx
+++ b/app/src/components/tabs/agent-access-section.tsx
@@ -4,15 +4,18 @@ import { useTranslation } from "react-i18next";
 import { useOrg, useSetAgentAssignments } from "../../hooks/queries";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { useSession } from "../../hooks/use-session";
-import { canManageAssignments, isMultiplayer } from "../../lib/org-roles";
+import { isMultiplayer } from "../../lib/org-roles";
 import type { Agent } from "../../lib/types";
-import { assignmentToggle } from "./agent-access-model";
+import { assignmentToggle, canShowAgentShareBlock } from "./agent-access-model";
 
 /**
  * The "Who can use this agent" block on an agent's General settings. Lists org
  * members with a per-member toggle backed by `agent.assignedUserIds` (empty =
- * everyone). Owner sees it for any agent; admin only for agents they're
- * assigned to; plain `user` never (the whole block returns null). The gateway
+ * everyone). Rendered only in multiplayer mode AND only for an agent-manager of
+ * this agent (matrix v2): owner for any org agent; an admin only when their
+ * effective `access` on the agent is `"manager"` — mere assignment no longer
+ * qualifies. Single-player / self-host has no org, so the block degrades to
+ * nothing. Plain members and admins-who-only-use never see it. The gateway
  * enforces the same authority — these toggles only drive the call.
  */
 export function AgentAccessSection({ agent }: { agent: Agent }) {
@@ -25,7 +28,7 @@ export function AgentAccessSection({ agent }: { agent: Agent }) {
   // (empty set = everyone) — that widening is confirm-gated, never silent.
   const [confirmOpenToAll, setConfirmOpenToAll] = useState(false);
 
-  if (!canManageAssignments(capabilities, agent)) return null;
+  if (!canShowAgentShareBlock(capabilities, agent)) return null;
 
   const selfId = session?.user?.id ?? null;
   const members = org.data?.members ?? [];

--- a/app/src/components/tabs/agent-integrations/agent-allowlist-section.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-allowlist-section.tsx
@@ -1,0 +1,170 @@
+import type { IntegrationToolkit } from "@houston-ai/engine-client";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { appDisplay } from "../../integrations/app-display";
+import { ToolkitPicker } from "./toolkit-picker";
+
+interface AgentAllowlistSectionProps {
+  /** The agent-level ceiling: `null` = all allowed, else the explicit set. */
+  allowedToolkits: string[] | null;
+  /** The org-wide ceiling the agent set may only narrow (`null` = all). */
+  orgAllowedToolkits: string[] | null;
+  /** Catalog for resolving slugs to real app names. */
+  catalog: IntegrationToolkit[];
+  /** This user's connected toolkits — the seed when first restricting. */
+  connectedToolkits: string[];
+  /** A save is in flight (disables the controls). */
+  saving: boolean;
+  /** Persist the next ceiling: `null` = allow all, else the explicit set. */
+  onSave: (next: string[] | null) => void;
+}
+
+/**
+ * Agent-manager-only editor for this agent's integration allowlist ceiling
+ * (Teams v2). Two resting states: "All integrations allowed" (`null`) with a
+ * Restrict affordance, or the explicit allowed set with Edit / Allow-all. Edit
+ * opens a multi-select over the org ceiling; Save writes the chosen set. The
+ * gateway is the real enforcer (this only previews + writes the ceiling).
+ */
+export function AgentAllowlistSection({
+  allowedToolkits,
+  orgAllowedToolkits,
+  catalog,
+  connectedToolkits,
+  saving,
+  onSave,
+}: AgentAllowlistSectionProps) {
+  const { t } = useTranslation("teams");
+  const [editing, setEditing] = useState(false);
+  const [working, setWorking] = useState<Set<string>>(new Set());
+
+  // The selectable universe: the org ceiling if one is set, else the whole
+  // catalog. A manager can only allow apps the org itself allows.
+  const universe = useMemo(() => {
+    if (orgAllowedToolkits === null) return catalog;
+    const org = new Set(orgAllowedToolkits);
+    return catalog.filter((tk) => org.has(tk.slug));
+  }, [catalog, orgAllowedToolkits]);
+  const universeSlugs = useMemo(
+    () => new Set(universe.map((tk) => tk.slug)),
+    [universe],
+  );
+  const bySlug = useMemo(
+    () => new Map(catalog.map((tk) => [tk.slug, tk])),
+    [catalog],
+  );
+
+  const startRestrict = () => {
+    // Seed with the apps this user already has connected (kept within the org
+    // ceiling) so restricting does not instantly cut off in-use apps.
+    setWorking(new Set(connectedToolkits.filter((s) => universeSlugs.has(s))));
+    setEditing(true);
+  };
+  const startEdit = () => {
+    setWorking(new Set(allowedToolkits ?? []));
+    setEditing(true);
+  };
+  const toggle = (slug: string) =>
+    setWorking((prev) => {
+      const next = new Set(prev);
+      if (next.has(slug)) next.delete(slug);
+      else next.add(slug);
+      return next;
+    });
+  const save = () => {
+    onSave([...working].sort());
+    setEditing(false);
+  };
+
+  return (
+    <section className="mt-8 rounded-xl border border-border p-4">
+      <div className="mb-1 flex items-center justify-between gap-3">
+        <h2 className="text-sm font-medium text-foreground">
+          {t("integrations.allowlist.title")}
+        </h2>
+        {!editing && allowedToolkits !== null && (
+          <button
+            type="button"
+            disabled={saving}
+            onClick={() => onSave(null)}
+            className="text-xs text-muted-foreground underline underline-offset-4 hover:text-foreground disabled:opacity-50"
+          >
+            {t("integrations.allowlist.allowAll")}
+          </button>
+        )}
+      </div>
+      <p className="mb-3 text-xs text-muted-foreground">
+        {t("integrations.allowlist.subtitle")}
+      </p>
+
+      {editing ? (
+        <div className="flex flex-col gap-3">
+          <ToolkitPicker
+            options={universe}
+            selected={working}
+            onToggle={toggle}
+          />
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              disabled={saving}
+              onClick={save}
+              className="inline-flex h-8 items-center rounded-full bg-primary px-4 text-xs font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+            >
+              {t("integrations.allowlist.save")}
+            </button>
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() => setEditing(false)}
+              className="inline-flex h-8 items-center rounded-full border border-border bg-background px-4 text-xs font-medium text-foreground transition-colors hover:bg-secondary disabled:opacity-50"
+            >
+              {t("integrations.allowlist.cancel")}
+            </button>
+          </div>
+        </div>
+      ) : allowedToolkits === null ? (
+        <div className="flex items-center justify-between gap-3">
+          <p className="text-sm text-foreground">
+            {t("integrations.allowlist.allAllowed")}
+          </p>
+          <button
+            type="button"
+            disabled={saving}
+            onClick={startRestrict}
+            className="inline-flex h-8 shrink-0 items-center rounded-full border border-border bg-background px-4 text-xs font-medium text-foreground transition-colors hover:bg-secondary disabled:opacity-50"
+          >
+            {t("integrations.allowlist.restrict")}
+          </button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {allowedToolkits.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              {t("integrations.allowlist.none")}
+            </p>
+          ) : (
+            <div className="flex flex-wrap gap-1.5">
+              {allowedToolkits.map((slug) => (
+                <span
+                  key={slug}
+                  className="rounded-full bg-secondary px-2.5 py-1 text-xs text-foreground"
+                >
+                  {appDisplay(slug, bySlug.get(slug)).name}
+                </span>
+              ))}
+            </div>
+          )}
+          <button
+            type="button"
+            disabled={saving}
+            onClick={startEdit}
+            className="inline-flex h-8 w-fit items-center rounded-full border border-border bg-background px-4 text-xs font-medium text-foreground transition-colors hover:bg-secondary disabled:opacity-50"
+          >
+            {t("integrations.allowlist.edit")}
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/app/src/components/tabs/agent-integrations/agent-apps-body.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-apps-body.tsx
@@ -1,0 +1,81 @@
+import { useTranslation } from "react-i18next";
+import type { ConnectFlow } from "../../integrations";
+import { AgentAccountAppsSection } from "./agent-account-apps-section";
+import { AgentAppsSection, type AppsSectionCopy } from "./agent-apps-section";
+import { AgentDisallowedAppsSection } from "./agent-disallowed-apps-section";
+import type { AgentIntegrationsView } from "./model";
+
+interface AgentAppsBodyProps {
+  view: AgentIntegrationsView;
+  canEdit: boolean;
+  connectFlow: ConnectFlow;
+  /** Grants mode: drop this agent's grant for an active app. */
+  onRemoveGrant: (toolkit: string) => void;
+  /** Grants mode: grant an already-connected account app to this agent. */
+  onActivate: (toolkit: string) => void;
+  /** Degraded mode: fully disconnect the app from the account. */
+  onDisconnect: (toolkit: string) => void;
+}
+
+/**
+ * The mode-specific apps list of the Integrations tab. Grants mode stacks the
+ * usable apps, the "ready to activate" account apps, and the Teams-disallowed
+ * apps; degraded mode (no grant routes) shows every connected app as usable.
+ * Split out of the tab so the gate ladder there stays readable and each mode's
+ * copy lives next to its sections.
+ */
+export function AgentAppsBody({
+  view,
+  canEdit,
+  connectFlow,
+  onRemoveGrant,
+  onActivate,
+  onDisconnect,
+}: AgentAppsBodyProps) {
+  const { t } = useTranslation("integrations");
+
+  if (view.mode !== "grants") {
+    const degradedCopy: AppsSectionCopy = {
+      title: t("agentTab.allApps.title"),
+      subtitle: t("agentTab.allApps.subtitle"),
+      emptyTitle: t("agentTab.empty.title"),
+      emptyBody: t("agentTab.empty.body"),
+    };
+    return (
+      <AgentAppsSection
+        copy={degradedCopy}
+        rows={view.rows}
+        canEdit={canEdit}
+        connectFlow={connectFlow}
+        onRemove={onDisconnect}
+      />
+    );
+  }
+
+  const grantsCopy: AppsSectionCopy = {
+    title: t("agentTab.activeTitle"),
+    emptyTitle: t("agentTab.empty.title"),
+    emptyBody: t("agentTab.empty.body"),
+  };
+  return (
+    <>
+      <AgentAppsSection
+        copy={grantsCopy}
+        rows={view.activeRows}
+        canEdit={canEdit}
+        connectFlow={connectFlow}
+        onDeactivate={onRemoveGrant}
+        onRemove={onRemoveGrant}
+      />
+      {canEdit && view.accountRows.length > 0 && (
+        <AgentAccountAppsSection
+          rows={view.accountRows}
+          onActivate={onActivate}
+        />
+      )}
+      {view.disallowedRows.length > 0 && (
+        <AgentDisallowedAppsSection rows={view.disallowedRows} />
+      )}
+    </>
+  );
+}

--- a/app/src/components/tabs/agent-integrations/agent-disallowed-apps-section.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-disallowed-apps-section.tsx
@@ -1,0 +1,47 @@
+import { useTranslation } from "react-i18next";
+import { AppRow } from "../../integrations";
+import type { AgentAppRow as AgentAppRowVM } from "./model";
+
+interface AgentDisallowedAppsSectionProps {
+  /** Connected apps the agent's Teams allowlist ceiling forbids. */
+  rows: AgentAppRowVM[];
+}
+
+/**
+ * Connected apps a manager has excluded from this agent's allowlist. Shown so
+ * the state is transparent (the app is connected on the account but this agent
+ * may not use it) rather than silently vanishing. Read-only: no connect or
+ * activate affordance, a plain "Not allowed" badge and an explanation. Rendered
+ * by the tab only when there is at least one such app.
+ */
+export function AgentDisallowedAppsSection({
+  rows,
+}: AgentDisallowedAppsSectionProps) {
+  const { t } = useTranslation("teams");
+
+  return (
+    <section className="mt-8">
+      <h2 className="text-sm font-medium text-foreground">
+        {t("integrations.notAllowed.title")}
+      </h2>
+      <p className="mb-3 mt-0.5 text-xs text-muted-foreground">
+        {t("integrations.notAllowed.body")}
+      </p>
+
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {rows.map(({ connection, app }) => (
+          <AppRow
+            key={connection.connectionId || connection.toolkit}
+            display={app}
+            description={app.description}
+            trailing={
+              <span className="rounded-full bg-secondary px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                {t("integrations.notAllowed.badge")}
+              </span>
+            }
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/app/src/components/tabs/agent-integrations/agent-integrations-tab.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-integrations-tab.tsx
@@ -7,8 +7,13 @@ import {
   useIntegrationConnections,
   useIntegrationToolkits,
 } from "../../../hooks/queries";
+import {
+  effectiveAllowlist,
+  useAgentSettings,
+  useSetAgentSettings,
+} from "../../../hooks/queries/use-agent-settings";
 import { useCapabilities } from "../../../hooks/use-capabilities";
-import { canEditAgentGrants } from "../../../lib/org-roles";
+import { canEditAgentGrants, isAgentManager } from "../../../lib/org-roles";
 import type { TabProps } from "../../../lib/types";
 import { useUIStore } from "../../../stores/ui";
 import {
@@ -22,27 +27,33 @@ import {
   useIntegrationsGate,
 } from "../../integrations";
 import { INTEGRATIONS_VIEW_ID } from "../../integrations-view/id";
-import { AgentAccountAppsSection } from "./agent-account-apps-section";
-import { AgentAppsSection, type AppsSectionCopy } from "./agent-apps-section";
+import { AgentAllowlistSection } from "./agent-allowlist-section";
+import { AgentAppsBody } from "./agent-apps-body";
 import { agentIntegrationsView } from "./model";
 
 /**
- * The per-agent Integrations tab, three stacked sections: the apps this agent
- * can use, the account apps ready to activate here (grants mode), and the
+ * The per-agent Integrations tab. Sections: the apps this agent can use, the
+ * account apps ready to activate here (grants mode), the apps a Teams allowlist
+ * forbids, the manager's allowlist editor (Teams + agent-manager only), and the
  * always-visible "Connect more apps" catalog. One tab-level connect flow with
  * `autoGrant` so a brand-new connection auto-activates on this agent. Behind the
  * shared boot gate; the grant view (multiplayer) and degraded view (host without
- * grant routes) are a discriminated union so the two never mix.
+ * grant routes) are a discriminated union so the two never mix. On a Teams host
+ * the effective allowlist (agent ceiling ∩ org ceiling) filters the browse
+ * catalog and splits disallowed connected apps out; non-Teams hosts feature-
+ * detect off and render exactly as before.
  */
 export default function IntegrationsTab({ agent }: TabProps) {
   const { t } = useTranslation("integrations");
   const gate = useIntegrationsGate();
   const ready = gate.kind === "ready";
+  const { capabilities } = useCapabilities();
+  const teamsEnabled = capabilities?.teams === true;
 
   const connections = useIntegrationConnections(INTEGRATION_PROVIDER, ready);
   const catalog = useIntegrationToolkits(INTEGRATION_PROVIDER, ready);
   const grantsQuery = useAgentGrants(agent.id, ready);
-  const { capabilities } = useCapabilities();
+  const settingsQuery = useAgentSettings(agent.id, ready && teamsEnabled);
 
   const grants = grantsQuery.data ?? null;
   const grantsSupported = grants !== null;
@@ -50,7 +61,15 @@ export default function IntegrationsTab({ agent }: TabProps) {
     ? canEditAgentGrants(capabilities, agent)
     : true;
 
+  const settings = settingsQuery.data;
+  const allowlist = useMemo(
+    () => (settings ? effectiveAllowlist(settings) : null),
+    [settings],
+  );
+  const isManager = isAgentManager(capabilities, agent);
+
   const grantMutation = useAgentGrantMutation(agent.id);
+  const settingsMutation = useSetAgentSettings(agent.id);
   const disconnect = useDisconnectIntegration(INTEGRATION_PROVIDER);
   const connectFlow = useConnectFlow({
     agentId: agent.id,
@@ -64,30 +83,31 @@ export default function IntegrationsTab({ agent }: TabProps) {
         connections: connections.data ?? [],
         catalog: catalog.data ?? [],
         grants,
+        allowlist,
       }),
-    [connections.data, catalog.data, grants],
+    [connections.data, catalog.data, grants, allowlist],
   );
+
+  // The browse catalog is narrowed to the effective allowlist so a member can
+  // only connect apps the agent is allowed to use (null = unrestricted).
+  const browseCatalog = useMemo(() => {
+    const all = catalog.data ?? [];
+    if (allowlist === null) return all;
+    const set = new Set(allowlist);
+    return all.filter((tk) => set.has(tk.slug));
+  }, [catalog.data, allowlist]);
 
   const bodyLoading =
     ready &&
-    (grantsQuery.isLoading || connections.isLoading || catalog.isLoading);
+    (grantsQuery.isLoading ||
+      connections.isLoading ||
+      catalog.isLoading ||
+      settingsQuery.isLoading);
 
   const removeGrant = (toolkit: string) =>
     grantMutation.mutate({ toolkit, op: "remove" });
   const activate = (toolkit: string) =>
     grantMutation.mutate({ toolkit, op: "add" });
-
-  const grantsCopy: AppsSectionCopy = {
-    title: t("agentTab.activeTitle"),
-    emptyTitle: t("agentTab.empty.title"),
-    emptyBody: t("agentTab.empty.body"),
-  };
-  const degradedCopy: AppsSectionCopy = {
-    title: t("agentTab.allApps.title"),
-    subtitle: t("agentTab.allApps.subtitle"),
-    emptyTitle: t("agentTab.empty.title"),
-    emptyBody: t("agentTab.empty.body"),
-  };
 
   return (
     <div className="h-full overflow-auto">
@@ -111,36 +131,31 @@ export default function IntegrationsTab({ agent }: TabProps) {
               <ReconnectBanner onDismiss={gate.dismissReconnect} />
             )}
 
-            {view.mode === "grants" ? (
-              <>
-                <AgentAppsSection
-                  copy={grantsCopy}
-                  rows={view.activeRows}
-                  canEdit={canEdit}
-                  connectFlow={connectFlow}
-                  onDeactivate={removeGrant}
-                  onRemove={removeGrant}
-                />
-                {canEdit && view.accountRows.length > 0 && (
-                  <AgentAccountAppsSection
-                    rows={view.accountRows}
-                    onActivate={activate}
-                  />
+            <AgentAppsBody
+              view={view}
+              canEdit={canEdit}
+              connectFlow={connectFlow}
+              onRemoveGrant={removeGrant}
+              onActivate={activate}
+              onDisconnect={(toolkit) => disconnect.mutate(toolkit)}
+            />
+
+            {teamsEnabled && settings && isManager && (
+              <AgentAllowlistSection
+                allowedToolkits={settings.allowedToolkits}
+                orgAllowedToolkits={settings.orgAllowedToolkits}
+                catalog={catalog.data ?? []}
+                connectedToolkits={(connections.data ?? []).map(
+                  (c) => c.toolkit,
                 )}
-              </>
-            ) : (
-              <AgentAppsSection
-                copy={degradedCopy}
-                rows={view.rows}
-                canEdit={canEdit}
-                connectFlow={connectFlow}
-                onRemove={(toolkit) => disconnect.mutate(toolkit)}
+                saving={settingsMutation.isPending}
+                onSave={(next) => settingsMutation.mutate(next)}
               />
             )}
 
             <div className="mt-8">
               <ConnectMoreAppsSection
-                catalog={catalog.data ?? []}
+                catalog={browseCatalog}
                 connections={connections.data ?? []}
                 connectFlow={connectFlow}
                 loading={catalog.isLoading}

--- a/app/src/components/tabs/agent-integrations/model.ts
+++ b/app/src/components/tabs/agent-integrations/model.ts
@@ -24,6 +24,9 @@ export interface AgentAppRow {
  *                 with a one-click grant-add (the promoted "Ready to activate"
  *                 group). Only ACTIVE connections are activatable — a pending or
  *                 errored connection is not a usable app to hand this agent.
+ *                 `disallowedRows` are connected apps the agent's Teams allowlist
+ *                 ceiling forbids (visible, non-connectable, for transparency);
+ *                 empty unless a Teams host serves a restrictive allowlist.
  *  - `degraded` — grants resolved to `null` (host has no grant routes, e.g.
  *                 single-player). There is no per-agent permission, so every
  *                 connected app is usable by this agent; the list shows them all
@@ -34,19 +37,26 @@ export type AgentIntegrationsView =
       mode: "grants";
       activeRows: AgentAppRow[];
       accountRows: AgentAppRow[];
+      disallowedRows: AgentAppRow[];
       grantedToolkits: Set<string>;
     }
   | { mode: "degraded"; rows: AgentAppRow[] };
 
 /**
- * Build the agent view from the raw connections, catalog, and this agent's
- * grant set (`null` = unsupported host → degraded). Pure so the mode split and
- * row derivation are unit-testable without React.
+ * Build the agent view from the raw connections, catalog, this agent's grant
+ * set (`null` = unsupported host → degraded), and the Teams effective allowlist
+ * (`allowlist`: `null`/absent = unrestricted, so no app is disallowed). A
+ * connected toolkit outside the allowlist is split into `disallowedRows` and
+ * never appears as active/activatable — the manager restricted it (the gateway
+ * also prunes such grants server-side, so this is defence in depth, not the
+ * enforcer). Pure so the mode split and row derivation are unit-testable
+ * without React.
  */
 export function agentIntegrationsView(opts: {
   connections: IntegrationConnection[];
   catalog: IntegrationToolkit[];
   grants: string[] | null;
+  allowlist?: string[] | null;
 }): AgentIntegrationsView {
   if (opts.grants === null) {
     return {
@@ -55,8 +65,17 @@ export function agentIntegrationsView(opts: {
     };
   }
   const grantedToolkits = new Set(opts.grants);
+  const allowed = opts.allowlist == null ? null : new Set(opts.allowlist);
+  const allowedConns: IntegrationConnection[] = [];
+  const disallowedConns: IntegrationConnection[] = [];
+  for (const c of opts.connections) {
+    (allowed === null || allowed.has(c.toolkit)
+      ? allowedConns
+      : disallowedConns
+    ).push(c);
+  }
   const { granted, available } = splitByGrant({
-    connections: opts.connections,
+    connections: allowedConns,
     grants: grantedToolkits,
   });
   return {
@@ -66,6 +85,28 @@ export function agentIntegrationsView(opts: {
       available.filter((c) => c.status === "active"),
       opts.catalog,
     ),
+    disallowedRows: connectionRows(disallowedConns, opts.catalog),
     grantedToolkits,
   };
+}
+
+/**
+ * The effective integration allowlist for an agent: the agent-level ceiling
+ * intersected with the org-wide ceiling, where `null` on either side means
+ * "unrestricted" (the whole catalog). Returns `null` when BOTH are unrestricted
+ * (nothing to filter); otherwise the concrete set of allowed toolkit slugs
+ * (possibly empty = none allowed). Mirrors the gateway's intersection so the UI
+ * previews exactly what the server will enforce. Pure + unit-tested.
+ */
+export function effectiveAllowlist(settings: {
+  allowedToolkits: string[] | null;
+  orgAllowedToolkits: string[] | null;
+}): string[] | null {
+  const agent = settings.allowedToolkits;
+  const org = settings.orgAllowedToolkits;
+  if (agent === null && org === null) return null;
+  if (agent === null) return org;
+  if (org === null) return agent;
+  const orgSet = new Set(org);
+  return agent.filter((slug) => orgSet.has(slug));
 }

--- a/app/src/components/tabs/agent-integrations/toolkit-picker.tsx
+++ b/app/src/components/tabs/agent-integrations/toolkit-picker.tsx
@@ -1,0 +1,88 @@
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@houston-ai/core";
+import type { IntegrationToolkit } from "@houston-ai/engine-client";
+import { Check, ChevronDown } from "lucide-react";
+import { useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { appDisplay } from "../../integrations/app-display";
+
+interface ToolkitPickerProps {
+  /** The selectable universe (already narrowed to the org ceiling). */
+  options: IntegrationToolkit[];
+  /** Currently-checked toolkit slugs. */
+  selected: ReadonlySet<string>;
+  /** Toggle one toolkit in/out of the selection. */
+  onToggle: (slug: string) => void;
+}
+
+/**
+ * A searchable multi-select checklist over the agent's selectable toolkits (the
+ * org allowlist ceiling). Managers use it to build an explicit per-agent
+ * allowlist. Options list A-Z; a search box filters by app name; each row shows
+ * a check when selected. Mirrors the category picker in the shared catalog
+ * browser (Popover + Command) so the two read as one system.
+ */
+export function ToolkitPicker({
+  options,
+  selected,
+  onToggle,
+}: ToolkitPickerProps) {
+  const { t } = useTranslation("teams");
+  const [open, setOpen] = useState(false);
+
+  const sorted = useMemo(
+    () =>
+      [...options]
+        .map((tk) => appDisplay(tk.slug, tk))
+        .sort((a, b) => a.name.localeCompare(b.name)),
+    [options],
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="inline-flex h-9 cursor-pointer items-center gap-2 rounded-full border border-border bg-background pl-3 pr-2.5 text-sm text-foreground hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring/20"
+        >
+          <span>{t("integrations.allowlist.selectApps")}</span>
+          {selected.size > 0 && (
+            <span className="rounded-full bg-secondary px-1.5 text-xs tabular-nums text-muted-foreground">
+              {selected.size}
+            </span>
+          )}
+          <ChevronDown className="size-3.5 shrink-0 text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className="w-72 p-0">
+        <Command>
+          <CommandInput placeholder={t("integrations.allowlist.searchApps")} />
+          <CommandList>
+            <CommandEmpty>{t("integrations.allowlist.noApps")}</CommandEmpty>
+            {sorted.map((app) => {
+              const isSelected = selected.has(app.toolkit);
+              return (
+                <CommandItem
+                  key={app.toolkit}
+                  value={app.name}
+                  onSelect={() => onToggle(app.toolkit)}
+                >
+                  <span className="flex-1 truncate">{app.name}</span>
+                  {isSelected && <Check className="size-4" />}
+                </CommandItem>
+              );
+            })}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/app/src/components/tabs/agent-settings-content.tsx
+++ b/app/src/components/tabs/agent-settings-content.tsx
@@ -25,6 +25,7 @@ export function AgentSettingsContent({
   onChangeColor,
   onShare,
   onDelete,
+  canEdit = true,
 }: {
   name: string;
   color: string | undefined;
@@ -32,6 +33,13 @@ export function AgentSettingsContent({
   onChangeColor: (color: string) => Promise<unknown>;
   onShare: () => void;
   onDelete: () => Promise<unknown>;
+  /**
+   * Whether the caller may reconfigure the agent (matrix v2: agent-manager).
+   * When false the rename field is locked, the color swatches are disabled, and
+   * the danger/delete section is hidden — rename + delete are manager-scope on
+   * the wire. Defaults to true so single-player is unchanged.
+   */
+  canEdit?: boolean;
 }) {
   const { t } = useTranslation(["agents", "shell", "common", "portable"]);
   const [draftName, setDraftName] = useState(name);
@@ -85,8 +93,12 @@ export function AgentSettingsContent({
           onKeyDown={(e) => {
             if (e.key === "Enter") void handleRename();
           }}
+          readOnly={!canEdit}
           placeholder={t("agents:agentSettings.namePlaceholder")}
-          className="w-full rounded-xl border border-border bg-card px-4 py-2.5 text-sm outline-none focus:ring-1 focus:ring-ring transition-all"
+          className={cn(
+            "w-full rounded-xl border border-border bg-card px-4 py-2.5 text-sm outline-none focus:ring-1 focus:ring-ring transition-all",
+            !canEdit && "cursor-default text-muted-foreground",
+          )}
         />
       </section>
 
@@ -111,10 +123,12 @@ export function AgentSettingsContent({
                 aria-label={label}
                 aria-pressed={isActive}
                 title={label}
+                disabled={!canEdit}
                 onClick={() => void onChangeColor(entry.id)}
                 className={cn(
-                  "size-7 rounded-full transition-transform hover:scale-110",
+                  "size-7 rounded-full transition-transform",
                   "ring-offset-2 ring-offset-background",
+                  canEdit ? "hover:scale-110" : "cursor-default opacity-60",
                   isActive && "ring-2 ring-ring",
                 )}
                 style={{ backgroundColor: colorHex(entry) }}
@@ -137,21 +151,23 @@ export function AgentSettingsContent({
         </Button>
       </section>
 
-      <section>
-        <h2 className="text-lg font-semibold text-destructive mb-1">
-          {t("agents:agentSettings.dangerTitle")}
-        </h2>
-        <p className="text-sm text-muted-foreground mb-4">
-          {t("agents:agentSettings.dangerHelper")}
-        </p>
-        <Button
-          variant="destructive"
-          className="rounded-full"
-          onClick={() => setShowConfirm(true)}
-        >
-          {t("common:actions.delete")}
-        </Button>
-      </section>
+      {canEdit && (
+        <section>
+          <h2 className="text-lg font-semibold text-destructive mb-1">
+            {t("agents:agentSettings.dangerTitle")}
+          </h2>
+          <p className="text-sm text-muted-foreground mb-4">
+            {t("agents:agentSettings.dangerHelper")}
+          </p>
+          <Button
+            variant="destructive"
+            className="rounded-full"
+            onClick={() => setShowConfirm(true)}
+          >
+            {t("common:actions.delete")}
+          </Button>
+        </section>
+      )}
 
       <ConfirmDialog
         open={showConfirm}

--- a/app/src/components/tabs/job-description-access.ts
+++ b/app/src/components/tabs/job-description-access.ts
@@ -1,0 +1,21 @@
+import type { Agent, Capabilities } from "@houston-ai/engine-client";
+import { canEditAgentConfig } from "../../lib/org-roles.ts";
+
+/**
+ * Whether the Agent Settings tab (instructions / skills / learnings / general)
+ * should render as a READ-ONLY "managed by your organization" surface for the
+ * current caller. Matrix v2 (contract §1): configure-scope edits are
+ * agent-manager only. A plain member sees the content but no editing
+ * affordances; the gateway 403s any write regardless.
+ *
+ * Delegates entirely to {@link canEditAgentConfig} (=== `isAgentManager`) so the
+ * one authority definition stays in `org-roles`. Single-player / self-host (no
+ * multiplayer capability) always returns `false` here — zero visual change from
+ * today, the sole user owns everything.
+ */
+export function isConfigReadOnly(
+  caps: Capabilities | null | undefined,
+  agent: Pick<Agent, "access">,
+): boolean {
+  return !canEditAgentConfig(caps, agent);
+}

--- a/app/src/components/tabs/job-description-parts.tsx
+++ b/app/src/components/tabs/job-description-parts.tsx
@@ -27,10 +27,17 @@ export function InstructionsContent({
   content,
   onSave,
   labels,
+  readOnly = false,
 }: {
   content: string;
   onSave: (content: string) => Promise<unknown>;
   labels?: InstructionsContentLabels;
+  /**
+   * Managed-agent read-only mode (matrix v2): a non-manager sees the
+   * instructions but cannot edit them. Hides the "Write" affordance, locks the
+   * textarea, and drops the save-on-blur. The gateway 403s writes regardless.
+   */
+  readOnly?: boolean;
 }) {
   const { t } = useTranslation("agents");
   const resolved: InstructionsContentLabels = labels ?? {
@@ -58,7 +65,7 @@ export function InstructionsContent({
   );
 
   const handleBlur = async () => {
-    if (value === content) return;
+    if (readOnly || value === content) return;
     setState("saving");
     await onSave(value);
     setState("saved");
@@ -72,10 +79,12 @@ export function InstructionsContent({
           <EmptyTitle>{resolved.emptyTitle}</EmptyTitle>
           <EmptyDescription>{resolved.emptyDescription}</EmptyDescription>
         </EmptyHeader>
-        <Button onClick={() => setEditing(true)}>
-          <FileText className="size-4" />
-          {resolved.writeButton}
-        </Button>
+        {!readOnly && (
+          <Button onClick={() => setEditing(true)}>
+            <FileText className="size-4" />
+            {resolved.writeButton}
+          </Button>
+        )}
       </div>
     );
   }
@@ -108,6 +117,7 @@ export function InstructionsContent({
           value={value}
           onChange={(e) => setValue(e.target.value)}
           onBlur={handleBlur}
+          readOnly={readOnly}
           placeholder={resolved.placeholder}
           rows={Math.max(12, value.split("\n").length + 2)}
           className={cn(
@@ -116,6 +126,7 @@ export function InstructionsContent({
             "bg-background border border-foreground/[0.04] rounded-lg",
             "outline-none resize-none transition-shadow duration-200",
             "focus:shadow-[0_1px_2px_rgba(0,0,0,0.04)]",
+            readOnly && "cursor-default text-muted-foreground",
           )}
         />
       </section>

--- a/app/src/components/tabs/job-description-tab.tsx
+++ b/app/src/components/tabs/job-description-tab.tsx
@@ -10,6 +10,7 @@ import {
   useSaveInstructions,
   useUpdateLearning,
 } from "../../hooks/queries";
+import { useCapabilities } from "../../hooks/use-capabilities";
 import type { TabProps } from "../../lib/types";
 import { useAgentStore } from "../../stores/agents";
 import { useUIStore } from "../../stores/ui";
@@ -20,13 +21,20 @@ import {
 } from "../shared/sidebar-section-nav";
 import { AgentAccessSection } from "./agent-access-section";
 import { AgentSettingsContent } from "./agent-settings-content";
+import { isConfigReadOnly } from "./job-description-access";
 import { InstructionsContent, type SubTab } from "./job-description-parts";
 import { LearningsContent } from "./learnings-content";
+import { ManagedAgentBanner } from "./managed-agent-banner";
 import { SkillsContent } from "./skills-content";
 import { useSkillSurface } from "./use-skill-surface";
 
 export default function JobDescriptionTab({ agent }: TabProps) {
-  const { t } = useTranslation("agents");
+  const { t } = useTranslation(["agents", "teams"]);
+  const { capabilities } = useCapabilities();
+  // Matrix v2: non-managers get a read-only "managed by your org" surface across
+  // every sub-tab (instructions, skills, learnings, general). Single-player and
+  // owners/agent-managers are unaffected. The gateway is the real enforcer.
+  const readOnly = isConfigReadOnly(capabilities, agent);
   const path = agent.folderPath;
   const surface = useSkillSurface(path);
   const [activeTab, setActiveTab] = useState<SubTab>("instructions");
@@ -71,7 +79,11 @@ export default function JobDescriptionTab({ agent }: TabProps) {
         onBack={surface.clearSelectedSkill}
         onSave={surface.handleSkillSave}
         onDelete={surface.handleSkillDelete}
-        labels={surface.skillDetailLabels}
+        readOnly={readOnly}
+        labels={{
+          ...surface.skillDetailLabels,
+          managedNote: t("teams:managedAgent.banner"),
+        }}
       />
     );
   }
@@ -85,9 +97,12 @@ export default function JobDescriptionTab({ agent }: TabProps) {
         onSelect={setActiveTab}
       />
       <div className="flex-1 min-h-0 overflow-y-auto flex flex-col">
+        {readOnly && <ManagedAgentBanner />}
+
         {activeTab === "instructions" && (
           <InstructionsContent
             content={instructions ?? ""}
+            readOnly={readOnly}
             onSave={(c) =>
               saveInstructions.mutateAsync({ name: "CLAUDE.md", content: c })
             }
@@ -100,6 +115,7 @@ export default function JobDescriptionTab({ agent }: TabProps) {
               skills={surface.skills}
               loading={surface.skillsLoading}
               loadingSkillName={surface.loadingSkillName}
+              readOnly={readOnly}
               onSkillClick={surface.selectSkill}
               onSearch={surface.handleSearch}
               onPopular={surface.handlePopular}
@@ -115,6 +131,7 @@ export default function JobDescriptionTab({ agent }: TabProps) {
         {activeTab === "learnings" && (
           <LearningsContent
             entries={learningsData?.entries ?? []}
+            readOnly={readOnly}
             onAdd={(text) => addLearning.mutateAsync(text)}
             onRemove={(index) => removeLearning.mutateAsync(index)}
             onUpdate={(id, text) => updateLearning.mutateAsync({ id, text })}
@@ -129,6 +146,7 @@ export default function JobDescriptionTab({ agent }: TabProps) {
             <AgentSettingsContent
               name={agent.name}
               color={agent.color}
+              canEdit={!readOnly}
               onRename={(newName) =>
                 currentWorkspace
                   ? renameAgent(currentWorkspace.id, agent.id, newName)

--- a/app/src/components/tabs/learning-card-preview.tsx
+++ b/app/src/components/tabs/learning-card-preview.tsx
@@ -15,7 +15,8 @@ export function LearningPreview({
   expanded: boolean;
   canExpand: boolean;
   onToggle: () => void;
-  onEdit: () => void;
+  /** Omitted in read-only mode: no edit affordance is rendered. */
+  onEdit?: () => void;
   onDelete?: () => void;
 }) {
   const { t } = useTranslation(["agents", "common"]);
@@ -57,24 +58,28 @@ export function LearningPreview({
       >
         {expanded || !canExpand ? text : learningPreviewText(text)}
       </p>
-      <div className="flex shrink-0 items-center gap-1">
-        <IconButton
-          label={t("agents:learnings.editAria")}
-          title={t("common:actions.edit")}
-          onClick={onEdit}
-        >
-          <Pencil className="size-3.5" />
-        </IconButton>
-        {onDelete && (
-          <IconButton
-            label={t("agents:learnings.removeAria")}
-            onClick={onDelete}
-            danger
-          >
-            <Trash2 className="size-3.5" />
-          </IconButton>
-        )}
-      </div>
+      {(onEdit || onDelete) && (
+        <div className="flex shrink-0 items-center gap-1">
+          {onEdit && (
+            <IconButton
+              label={t("agents:learnings.editAria")}
+              title={t("common:actions.edit")}
+              onClick={onEdit}
+            >
+              <Pencil className="size-3.5" />
+            </IconButton>
+          )}
+          {onDelete && (
+            <IconButton
+              label={t("agents:learnings.removeAria")}
+              onClick={onDelete}
+              danger
+            >
+              <Trash2 className="size-3.5" />
+            </IconButton>
+          )}
+        </div>
+      )}
     </div>
   );
 }

--- a/app/src/components/tabs/learning-card.tsx
+++ b/app/src/components/tabs/learning-card.tsx
@@ -11,12 +11,15 @@ export function LearningCard({
   onDelete,
   onCancel,
   isDraft,
+  readOnly = false,
 }: {
   initialText: string;
   onSave: (text: string) => Promise<unknown> | unknown;
   onDelete?: () => void;
   onCancel?: () => void;
   isDraft?: boolean;
+  /** Managed-agent read-only: preview only, no edit/delete affordances. */
+  readOnly?: boolean;
 }) {
   const [value, setValue] = useState(initialText);
   const [expanded, setExpanded] = useState(false);
@@ -64,7 +67,7 @@ export function LearningCard({
 
   return (
     <article className="rounded-xl border border-foreground/[0.05] bg-secondary px-4 py-3 shadow-[0_1px_0_rgba(0,0,0,0.03)]">
-      {editing ? (
+      {editing && !readOnly ? (
         <LearningEditor
           value={value}
           saving={saving}
@@ -80,8 +83,8 @@ export function LearningCard({
           expanded={expanded}
           canExpand={canExpand}
           onToggle={() => setExpanded((next) => !next)}
-          onEdit={startEditing}
-          onDelete={onDelete}
+          onEdit={readOnly ? undefined : startEditing}
+          onDelete={readOnly ? undefined : onDelete}
         />
       )}
     </article>

--- a/app/src/components/tabs/learnings-content.tsx
+++ b/app/src/components/tabs/learnings-content.tsx
@@ -22,12 +22,19 @@ export function LearningsContent({
   onRemove,
   onUpdate,
   layout = "full",
+  readOnly = false,
 }: {
   entries: LearningEntry[];
   onAdd: (text: string) => Promise<unknown>;
   onRemove: (index: number) => Promise<unknown>;
   onUpdate: (id: string, text: string) => Promise<unknown>;
   layout?: "full" | "section";
+  /**
+   * Managed-agent read-only mode (matrix v2): learnings shape agent behavior, so
+   * a non-manager may read them but not add/edit/delete. Hides the add
+   * affordance and renders each card read-only. The gateway 403s writes.
+   */
+  readOnly?: boolean;
 }) {
   const { t } = useTranslation("agents");
   const [drafts, setDrafts] = useState<string[]>([]);
@@ -64,10 +71,12 @@ export function LearningsContent({
           <EmptyTitle>{t("learnings.emptyTitle")}</EmptyTitle>
           <EmptyDescription>{t("learnings.emptyDescription")}</EmptyDescription>
         </EmptyHeader>
-        <Button onClick={addDraft}>
-          <Plus className="size-4" />
-          {t("learnings.addLearning")}
-        </Button>
+        {!readOnly && (
+          <Button onClick={addDraft}>
+            <Plus className="size-4" />
+            {t("learnings.addLearning")}
+          </Button>
+        )}
       </div>
     );
   }
@@ -82,26 +91,30 @@ export function LearningsContent({
         <p className="text-xs text-muted-foreground max-w-md">
           {t("learnings.helper")}
         </p>
-        <Button size="sm" onClick={addDraft} className="shrink-0">
-          <Plus className="size-3.5" />
-          {t("learnings.addLearning")}
-        </Button>
+        {!readOnly && (
+          <Button size="sm" onClick={addDraft} className="shrink-0">
+            <Plus className="size-3.5" />
+            {t("learnings.addLearning")}
+          </Button>
+        )}
       </div>
 
       <div className="flex flex-col gap-3">
-        {drafts.map((localId) => (
-          <LearningCard
-            key={localId}
-            initialText=""
-            isDraft
-            onSave={(text) => handleSaveDraft(localId, text)}
-            onCancel={() => removeDraft(localId)}
-          />
-        ))}
+        {!readOnly &&
+          drafts.map((localId) => (
+            <LearningCard
+              key={localId}
+              initialText=""
+              isDraft
+              onSave={(text) => handleSaveDraft(localId, text)}
+              onCancel={() => removeDraft(localId)}
+            />
+          ))}
         {entries.map((entry) => (
           <LearningCard
             key={entry.id}
             initialText={entry.text}
+            readOnly={readOnly}
             onSave={(text) => onUpdate(entry.id, text)}
             onDelete={() => setPendingRemove(entry)}
           />

--- a/app/src/components/tabs/managed-agent-banner.tsx
+++ b/app/src/components/tabs/managed-agent-banner.tsx
@@ -1,0 +1,20 @@
+import { Lock } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+/**
+ * Read-only notice shown atop an agent's Settings sub-tabs when the current
+ * caller is not an agent-manager (matrix v2 configure-scope). Explains why the
+ * editing affordances are gone: the org owns the agent and only its managers can
+ * reconfigure it. Cosmetic only — the gateway is the real enforcer.
+ */
+export function ManagedAgentBanner() {
+  const { t } = useTranslation("teams");
+  return (
+    <div className="mx-auto max-w-3xl w-full px-6 pt-4">
+      <div className="flex items-center gap-2.5 rounded-xl border border-foreground/5 bg-secondary px-4 py-2.5 text-sm text-muted-foreground">
+        <Lock className="size-4 shrink-0" aria-hidden="true" />
+        <span>{t("managedAgent.banner")}</span>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/tabs/skills-content.tsx
+++ b/app/src/components/tabs/skills-content.tsx
@@ -19,6 +19,7 @@ export function SkillsContent({
   skills,
   loading,
   loadingSkillName,
+  readOnly = false,
   onSkillClick,
   onSearch,
   onPopular,
@@ -32,6 +33,12 @@ export function SkillsContent({
   loading: boolean;
   /** Name of the skill whose detail is loading; its card spins + disables. */
   loadingSkillName?: string | null;
+  /**
+   * Managed-agent read-only mode (matrix v2): a non-manager may view and open
+   * skills but not add/create/install any. Hides the add affordance entirely;
+   * skill detail opens read-only. The gateway 403s writes regardless.
+   */
+  readOnly?: boolean;
   onSkillClick: (name: string) => void;
   onSearch?: (query: string, signal?: AbortSignal) => Promise<CommunitySkill[]>;
   onPopular?: (signal?: AbortSignal) => Promise<CommunitySkill[]>;
@@ -58,17 +65,18 @@ export function SkillsContent({
     () => [...skills].sort((a, b) => a.name.localeCompare(b.name)),
     [skills],
   );
-  const addDialogProps = onCreateFromScratch
-    ? {
-        onSearch,
-        onPopular,
-        onInstallCommunity,
-        onListFromRepo,
-        onInstallFromRepo,
-        onCreateFromScratch,
-        installedSkillNames,
-      }
-    : null;
+  const addDialogProps =
+    !readOnly && onCreateFromScratch
+      ? {
+          onSearch,
+          onPopular,
+          onInstallCommunity,
+          onListFromRepo,
+          onInstallFromRepo,
+          onCreateFromScratch,
+          installedSkillNames,
+        }
+      : null;
 
   if (loading && sorted.length === 0) {
     return (

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -858,12 +858,14 @@ export function useAgentChatPanel({
           onSelect={handleModelSelect}
           open={modelPickerOpen}
           onOpenChange={setModelPickerOpen}
+          agent={agent}
         />
         <ChatEffortSelector
           provider={effectiveProvider}
           model={effectiveModel}
           effort={effectiveEffort}
           onSelect={handleEffortSelect}
+          agent={agent}
         />
         <div className="ml-auto">
           <ContextIndicator

--- a/app/src/hooks/queries/use-agent-settings.ts
+++ b/app/src/hooks/queries/use-agent-settings.ts
@@ -1,0 +1,61 @@
+import type { AgentSettings } from "@houston-ai/engine-client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "../../lib/query-keys";
+import { tauriAgentSettings } from "../../lib/tauri";
+
+export { effectiveAllowlist } from "../../components/tabs/agent-integrations/model";
+
+/**
+ * Teams v2 only: this agent's settings — the allowed-toolkit ceilings (agent +
+ * org) plus the caller's effective `access`. Gated on the `teams` capability
+ * via `enabled`: a host that predates Teams has no settings route (or the
+ * desktop/local engine throws), so the query stays idle there and the
+ * Integrations tab renders exactly as it does today. On a Teams host the route
+ * always answers for an assigned caller or owner, so no 404→null degradation is
+ * needed here — feature detection is the `teams` flag, not a swallowed error.
+ */
+export function useAgentSettings(agentId: string, enabled: boolean) {
+  return useQuery({
+    queryKey: queryKeys.agentSettings(agentId),
+    queryFn: () => tauriAgentSettings.get(agentId),
+    enabled,
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * Teams v2, agent-manager only: replace this agent's allowed-toolkit ceiling
+ * (`null` = all allowed, `[]` = none). Optimistic — a single manager action, so
+ * a whole-value swap with rollback on error is enough (no overlapping-toggle
+ * race like the grant set has). The host prunes now-disallowed toolkits from
+ * existing grants, so this also invalidates the agent's grant set to reflect the
+ * server-side revocation. Carries no `onError` toast: the `tauriAgentSettings.*`
+ * wrappers route through `call()`, which surfaces + reports the failure once
+ * (adding one here would double-toast); the `onError` below only rolls the
+ * optimistic value back.
+ */
+export function useSetAgentSettings(agentId: string) {
+  const qc = useQueryClient();
+  const key = queryKeys.agentSettings(agentId);
+  return useMutation({
+    mutationFn: (allowedToolkits: string[] | null) =>
+      tauriAgentSettings.set(agentId, { allowedToolkits }),
+    onMutate: async (allowedToolkits) => {
+      await qc.cancelQueries({ queryKey: key });
+      const prev = qc.getQueryData<AgentSettings>(key);
+      if (prev) {
+        qc.setQueryData<AgentSettings>(key, { ...prev, allowedToolkits });
+      }
+      return { prev };
+    },
+    onError: (_err, _next, ctx) => {
+      if (ctx?.prev) qc.setQueryData(key, ctx.prev);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: key });
+      // Restricting the ceiling prunes grants server-side (contract §5); refresh
+      // this agent's grant set so the revocation shows without a remount.
+      qc.invalidateQueries({ queryKey: queryKeys.agentGrants(agentId) });
+    },
+  });
+}

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -30,6 +30,7 @@ import settingsEn from "../locales/en/settings.json";
 import setupEn from "../locales/en/setup.json";
 import shellEn from "../locales/en/shell.json";
 import skillsEn from "../locales/en/skills.json";
+import teamsEn from "../locales/en/teams.json";
 import agentsEs from "../locales/es/agents.json";
 import aiHubEs from "../locales/es/ai-hub.json";
 import boardEs from "../locales/es/board.json";
@@ -49,6 +50,7 @@ import settingsEs from "../locales/es/settings.json";
 import setupEs from "../locales/es/setup.json";
 import shellEs from "../locales/es/shell.json";
 import skillsEs from "../locales/es/skills.json";
+import teamsEs from "../locales/es/teams.json";
 import agentsPt from "../locales/pt/agents.json";
 import aiHubPt from "../locales/pt/ai-hub.json";
 import boardPt from "../locales/pt/board.json";
@@ -68,6 +70,7 @@ import settingsPt from "../locales/pt/settings.json";
 import setupPt from "../locales/pt/setup.json";
 import shellPt from "../locales/pt/shell.json";
 import skillsPt from "../locales/pt/skills.json";
+import teamsPt from "../locales/pt/teams.json";
 import {
   activeWorkspaceLocale,
   isSupported,
@@ -138,6 +141,7 @@ const resources = {
     portable: portableEn,
     context: contextEn,
     org: orgEn,
+    teams: teamsEn,
   },
   es: {
     common: commonEs,
@@ -159,6 +163,7 @@ const resources = {
     portable: portableEs,
     context: contextEs,
     org: orgEs,
+    teams: teamsEs,
   },
   pt: {
     common: commonPt,
@@ -180,6 +185,7 @@ const resources = {
     portable: portablePt,
     context: contextPt,
     org: orgPt,
+    teams: teamsPt,
   },
 } as const;
 
@@ -220,6 +226,7 @@ void i18n
       "portable",
       "context",
       "org",
+      "teams",
     ],
     interpolation: { escapeValue: false }, // react already escapes
     detection: {

--- a/app/src/lib/model-selector-lock.ts
+++ b/app/src/lib/model-selector-lock.ts
@@ -1,0 +1,29 @@
+/**
+ * Pure lock decision for the chat model picker (ChatModelSelector).
+ *
+ * Split out from the component (like the sibling `model-picker.ts` helpers) so
+ * the Teams gate is unit-testable without a React renderer and the container
+ * stays under the file-size budget.
+ */
+
+import type { Agent, Capabilities } from "@houston-ai/engine-client";
+import { canEditAgentConfig } from "./org-roles.ts";
+
+/**
+ * Whether the model picker must render locked (read-only) for the current
+ * caller. Teams matrix v2 (contract §1/§6): only an agent-manager may change an
+ * agent's AI model; a plain org member sees the pinned provider/model but
+ * cannot open the dropdown or switch provider/effort.
+ *
+ * - No `agent` scope (`null`/`undefined`) → never locked. Non-agent surfaces
+ *   (and callers that don't thread an agent) keep their prior free behavior.
+ * - Otherwise defer to {@link canEditAgentConfig}, which short-circuits to
+ *   editable in single-player and for owners, so self-host is never locked.
+ */
+export function isModelSelectorLocked(
+  capabilities: Capabilities | null | undefined,
+  agent: Pick<Agent, "access"> | null | undefined,
+): boolean {
+  if (agent == null) return false;
+  return !canEditAgentConfig(capabilities, agent);
+}

--- a/app/src/lib/org-roles.ts
+++ b/app/src/lib/org-roles.ts
@@ -1,10 +1,12 @@
 import type { Agent, Capabilities, OrgRole } from "@houston-ai/engine-client";
 
 /**
- * Pure, DOM-free role logic for the multiplayer org surface. Mirrors the C3
- * role matrix (`convergence/contracts/C3-org-role-model.md`); the GATEWAY is
- * the real enforcer (these gates only hide affordances, never grant power).
- * Extracted so the who-can-see-what rules are unit-tested in isolation.
+ * Pure, DOM-free role logic for the multiplayer org surface. Mirrors the Teams
+ * role matrix v2 (contract §1 — supersedes the old C3 matrix; note the admin
+ * "see all agents" rule is GONE, and per-agent authority is now the agent
+ * `access` level rather than mere assignment). The GATEWAY is the real enforcer
+ * (these gates only hide affordances, never grant power). Extracted so the
+ * who-can-see-what rules are unit-tested in isolation.
  */
 
 /** True when the deployment runs in multiplayer mode (paid org). */
@@ -52,18 +54,54 @@ export function canManageMembers(
 }
 
 /**
+ * Is this caller an "agent-manager" for a specific agent — the per-agent editor
+ * role (Google Drive: managers are editors of the shared folder)? This is the
+ * single per-agent authority gate behind renaming/deleting, sharing, and
+ * configuring an agent (contract §1 matrix v2).
+ *
+ * - Single-player (no org): always true — the sole user owns everything.
+ * - Multiplayer `owner`: always true (owner manages every org agent).
+ * - Otherwise: the caller's effective `access` on this agent is `"manager"`.
+ *
+ * Purely trusts `agent.access`: the gateway already CLAMPS access to the org
+ * role at read/enforcement time, so a role-`user` never carries an effective
+ * `access="manager"` on the wire (a stale `manager` row is clamped away before
+ * it reaches the client). The client therefore does not re-clamp by role —
+ * `access` is already effective. Admins are NOT auto-managers of agents they
+ * merely use; they must hold `access="manager"` (matrix v2 dropped the admin
+ * "see/manage all" rule).
+ */
+export function isAgentManager(
+  caps: Capabilities | null | undefined,
+  agent: Pick<Agent, "access">,
+): boolean {
+  if (!isMultiplayer(caps)) return true;
+  if (orgRole(caps) === "owner") return true;
+  return agent.access === "manager";
+}
+
+/**
+ * Semantic alias of {@link isAgentManager}: can this caller EDIT an agent's
+ * configuration — instructions (CLAUDE.md), skills, the AI model, and agent
+ * settings (allowed toolkits)? Same gate, named for the config-editing call
+ * sites so their intent reads clearly (matrix v2: configure-scope is
+ * agent-manager only; a plain member gets a read-only view and the gateway
+ * 403s any write).
+ */
+export const canEditAgentConfig = isAgentManager;
+
+/**
  * Can this caller manage assignments for a specific agent (the "Who can use
- * this agent" block)? Owner for any org agent; admin only for agents they're
- * themselves assigned to; plain `user` never.
+ * this agent" / share block)? Agent-manager semantics (contract §1): owner for
+ * any org agent; otherwise only when the caller's effective `access` on the
+ * agent is `"manager"`; plain members and admins-who-only-use never can. The
+ * old "admin manages any agent they're assigned to" rule is gone in matrix v2.
  */
 export function canManageAssignments(
   caps: Capabilities | null | undefined,
-  agent: Pick<Agent, "assigned">,
+  agent: Pick<Agent, "access">,
 ): boolean {
-  const role = orgRole(caps);
-  if (role === "owner") return true;
-  if (role === "admin") return agent.assigned === true;
-  return false;
+  return isAgentManager(caps, agent);
 }
 
 /** Can this caller read/edit their own per-agent integration grants? */
@@ -80,7 +118,8 @@ export function canManageAgentGrants(
  * Single-player (no org roles) always can — the sole user owns everything, the
  * same short-circuit the global Integrations page uses; without it a self-host /
  * local sidecar that serves grants would render the agent tab fully read-only.
- * Multiplayer defers to the C3 assignment rule. Whether the host serves grants
+ * Multiplayer defers to the assignment rule (any assigned user gates their OWN
+ * grants, independent of agent-manager authority). Whether the host serves grants
  * at all is a separate concern the caller gates on.
  */
 export function canEditAgentGrants(

--- a/app/src/lib/query-keys.ts
+++ b/app/src/lib/query-keys.ts
@@ -67,4 +67,10 @@ export const queryKeys = {
   // per user); per-agent integration grants are keyed by agent id.
   org: () => ["org"] as const,
   agentGrants: (agentId: string) => ["agent-grants", agentId] as const,
+  /**
+   * Teams v2: an agent's allowed-toolkit settings (agent + org ceilings +
+   * caller access). Fetched only on a Teams host; the mutation self-invalidates
+   * this and the agent's grant set (the gateway prunes disallowed grants).
+   */
+  agentSettings: (agentId: string) => ["agent-settings", agentId] as const,
 };

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -186,6 +186,8 @@ function toAgent(a: import("@houston-ai/engine-client").Agent): Agent {
     lastOpenedAt: a.lastOpenedAt,
     assigned: a.assigned,
     assignedUserIds: a.assignedUserIds,
+    access: a.access,
+    assignments: a.assignments,
   };
 }
 
@@ -250,6 +252,27 @@ export const tauriAgents = {
   setAssignments: (agentSlugOrId: string, userIds: string[]) =>
     call<void>("set_agent_assignments", () =>
       getEngine().setAgentAssignments(agentSlugOrId, userIds),
+    ),
+};
+
+/**
+ * Teams v2: an agent's allowed-toolkit ceiling. `get` reads the agent + org
+ * ceilings plus the caller's effective access; `set` (agent-manager only)
+ * replaces the agent ceiling (`null` = all allowed, `[]` = none), and the host
+ * prunes now-disallowed toolkits from existing grants. Both route through
+ * `call()` so failures surface as toasts with a Report-bug affordance.
+ */
+export const tauriAgentSettings = {
+  get: (agentSlugOrId: string) =>
+    call("get_agent_settings", () =>
+      getEngine().getAgentSettings(agentSlugOrId),
+    ),
+  set: (
+    agentSlugOrId: string,
+    settings: { allowedToolkits: string[] | null },
+  ) =>
+    call<void>("set_agent_settings", () =>
+      getEngine().setAgentSettings(agentSlugOrId, settings),
     ),
 };
 

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -80,6 +80,21 @@ export interface Agent {
    * means "everyone in the org". Absent in single-player mode.
    */
   assignedUserIds?: string[];
+  /**
+   * Teams v2: the CURRENT caller's effective access to this agent (`manager`
+   * may reconfigure it, `user` may only use it). Absent in single-player mode.
+   * Drives the client-side read-only gating (org-roles `isAgentManager`);
+   * the gateway is the sole enforcer. Kept in sync (by hand) with the
+   * engine-client `Agent` shape.
+   */
+  access?: "manager" | "user";
+  /**
+   * Teams v2: the full assignee list with per-person access level. Populated
+   * only for callers who may manage assignments (owner or agent-manager);
+   * absent in single-player mode. `assignedUserIds` mirrors these user ids for
+   * back-compat.
+   */
+  assignments?: { userId: string; access: "manager" | "user" }[];
 }
 
 /** Props injected into every tab component */

--- a/app/src/locales/en/teams.json
+++ b/app/src/locales/en/teams.json
@@ -1,0 +1,29 @@
+{
+  "managedAgent": {
+    "banner": "This agent is managed by your organization. Only its managers can make changes."
+  },
+  "model": {
+    "lockedTooltip": "Your organization's manager sets this agent's AI model."
+  },
+  "integrations": {
+    "allowlist": {
+      "title": "Allowed integrations",
+      "subtitle": "Choose which apps this agent can use. Members can only connect apps you allow here.",
+      "allAllowed": "All integrations allowed",
+      "restrict": "Restrict to specific apps",
+      "allowAll": "Allow all apps",
+      "none": "No apps allowed. This agent cannot use any integrations.",
+      "edit": "Edit",
+      "save": "Save",
+      "cancel": "Cancel",
+      "selectApps": "Select apps",
+      "searchApps": "Search apps",
+      "noApps": "No apps found"
+    },
+    "notAllowed": {
+      "title": "Not allowed for this agent",
+      "body": "These apps are connected to your account, but your organization does not allow this agent to use them.",
+      "badge": "Not allowed"
+    }
+  }
+}

--- a/app/src/locales/es/teams.json
+++ b/app/src/locales/es/teams.json
@@ -1,0 +1,29 @@
+{
+  "managedAgent": {
+    "banner": "Este agente lo administra tu organización. Solo sus administradores pueden hacer cambios."
+  },
+  "model": {
+    "lockedTooltip": "El administrador de tu organización define el modelo de IA de este agente."
+  },
+  "integrations": {
+    "allowlist": {
+      "title": "Integraciones permitidas",
+      "subtitle": "Elige qué aplicaciones puede usar este agente. Los miembros solo pueden conectar las que permitas aquí.",
+      "allAllowed": "Todas las integraciones permitidas",
+      "restrict": "Restringir a aplicaciones específicas",
+      "allowAll": "Permitir todas las aplicaciones",
+      "none": "Ninguna aplicación permitida. Este agente no puede usar integraciones.",
+      "edit": "Editar",
+      "save": "Guardar",
+      "cancel": "Cancelar",
+      "selectApps": "Seleccionar aplicaciones",
+      "searchApps": "Buscar aplicaciones",
+      "noApps": "No se encontraron aplicaciones"
+    },
+    "notAllowed": {
+      "title": "No permitida para este agente",
+      "body": "Estas aplicaciones están conectadas a tu cuenta, pero tu organización no permite que este agente las use.",
+      "badge": "No permitida"
+    }
+  }
+}

--- a/app/src/locales/pt/teams.json
+++ b/app/src/locales/pt/teams.json
@@ -1,0 +1,29 @@
+{
+  "managedAgent": {
+    "banner": "Este agente é gerenciado pela sua organização. Apenas seus administradores podem fazer alterações."
+  },
+  "model": {
+    "lockedTooltip": "O administrador da sua organização define o modelo de IA deste agente."
+  },
+  "integrations": {
+    "allowlist": {
+      "title": "Integrações permitidas",
+      "subtitle": "Escolha quais aplicativos este agente pode usar. Os membros só podem conectar os que você permitir aqui.",
+      "allAllowed": "Todas as integrações permitidas",
+      "restrict": "Restringir a aplicativos específicos",
+      "allowAll": "Permitir todos os aplicativos",
+      "none": "Nenhum aplicativo permitido. Este agente não pode usar integrações.",
+      "edit": "Editar",
+      "save": "Salvar",
+      "cancel": "Cancelar",
+      "selectApps": "Selecionar aplicativos",
+      "searchApps": "Buscar aplicativos",
+      "noApps": "Nenhum aplicativo encontrado"
+    },
+    "notAllowed": {
+      "title": "Não permitido para este agente",
+      "body": "Estes aplicativos estão conectados à sua conta, mas sua organização não permite que este agente os use.",
+      "badge": "Não permitido"
+    }
+  }
+}

--- a/app/src/types/react-i18next.d.ts
+++ b/app/src/types/react-i18next.d.ts
@@ -26,6 +26,7 @@ import type settings from "../locales/en/settings.json";
 import type setup from "../locales/en/setup.json";
 import type shell from "../locales/en/shell.json";
 import type skills from "../locales/en/skills.json";
+import type teams from "../locales/en/teams.json";
 
 declare module "react-i18next" {
   interface CustomTypeOptions {
@@ -50,6 +51,7 @@ declare module "react-i18next" {
       portable: typeof portable;
       context: typeof context;
       org: typeof org;
+      teams: typeof teams;
     };
   }
 }

--- a/app/tests/agent-access-toggle.test.ts
+++ b/app/tests/agent-access-toggle.test.ts
@@ -1,6 +1,10 @@
-import { deepStrictEqual } from "node:assert";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
-import { assignmentToggle } from "../src/components/tabs/agent-access-model.ts";
+import type { Capabilities } from "@houston-ai/engine-client";
+import {
+  assignmentToggle,
+  canShowAgentShareBlock,
+} from "../src/components/tabs/agent-access-model.ts";
 
 const MEMBERS = ["alice", "bob", "carol"];
 
@@ -77,5 +81,61 @@ describe("assignmentToggle", () => {
       }),
       { kind: "set", userIds: ["alice", "bob", "carol"] },
     );
+  });
+});
+
+describe("canShowAgentShareBlock", () => {
+  const SINGLE_PLAYER: Capabilities = {};
+  const SINGLE_PLAYER_EXPLICIT: Capabilities = { multiplayer: false };
+  const OWNER: Capabilities = { multiplayer: true, role: "owner" };
+  const ADMIN: Capabilities = { multiplayer: true, role: "admin" };
+  const MEMBER: Capabilities = { multiplayer: true, role: "user" };
+
+  it("single-player NEVER renders the share block, even though the caller manages everything", () => {
+    // Regression guard: canManageAssignments short-circuits to true in
+    // single-player (matrix v2), so gating on it alone would resurrect an
+    // empty, non-functional org-share block on every self-host agent.
+    strictEqual(
+      canShowAgentShareBlock(SINGLE_PLAYER, { access: undefined }),
+      false,
+    );
+    strictEqual(
+      canShowAgentShareBlock(SINGLE_PLAYER, { access: "manager" }),
+      false,
+    );
+    strictEqual(
+      canShowAgentShareBlock(SINGLE_PLAYER_EXPLICIT, { access: "manager" }),
+      false,
+    );
+    strictEqual(canShowAgentShareBlock(null, { access: "manager" }), false);
+    strictEqual(
+      canShowAgentShareBlock(undefined, { access: "manager" }),
+      false,
+    );
+  });
+
+  it("multiplayer owner sees the block for any agent", () => {
+    strictEqual(canShowAgentShareBlock(OWNER, { access: undefined }), true);
+    strictEqual(canShowAgentShareBlock(OWNER, { access: "user" }), true);
+    strictEqual(canShowAgentShareBlock(OWNER, { access: "manager" }), true);
+  });
+
+  it("multiplayer admin sees the block only as an agent-manager, never by mere use", () => {
+    strictEqual(canShowAgentShareBlock(ADMIN, { access: "manager" }), true);
+    strictEqual(canShowAgentShareBlock(ADMIN, { access: "user" }), false);
+    strictEqual(canShowAgentShareBlock(ADMIN, { access: undefined }), false);
+  });
+
+  it("multiplayer plain member with a use/absent access never sees the block", () => {
+    strictEqual(canShowAgentShareBlock(MEMBER, { access: "user" }), false);
+    strictEqual(canShowAgentShareBlock(MEMBER, { access: undefined }), false);
+  });
+
+  it("the client trusts the wire `access` field, which the gateway clamps by role", () => {
+    // A role-`user` never carries `access="manager"` on the wire (the gateway
+    // clamps stale rows away before they reach the client), so this pairing is
+    // an impossible state. The pure gate trusts the already-effective `access`
+    // rather than re-clamping by role, matching isAgentManager.
+    strictEqual(canShowAgentShareBlock(MEMBER, { access: "manager" }), true);
   });
 });

--- a/app/tests/agent-allowlist.test.ts
+++ b/app/tests/agent-allowlist.test.ts
@@ -1,0 +1,187 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type {
+  IntegrationConnection,
+  IntegrationToolkit,
+} from "@houston-ai/engine-client";
+import {
+  agentIntegrationsView,
+  effectiveAllowlist,
+} from "../src/components/tabs/agent-integrations/model.ts";
+
+const tk = (slug: string, name: string): IntegrationToolkit => ({
+  slug,
+  name,
+  categories: [],
+  description: `${name} desc`,
+});
+
+const conn = (
+  toolkit: string,
+  status: IntegrationConnection["status"] = "active",
+): IntegrationConnection => ({
+  toolkit,
+  connectionId: `ca_${toolkit}`,
+  status,
+});
+
+const CATALOG: IntegrationToolkit[] = [
+  tk("slack", "Slack"),
+  tk("gmail", "Gmail"),
+  tk("notion", "Notion"),
+];
+
+describe("effectiveAllowlist", () => {
+  it("both ceilings null → unrestricted (null)", () => {
+    strictEqual(
+      effectiveAllowlist({ allowedToolkits: null, orgAllowedToolkits: null }),
+      null,
+    );
+  });
+
+  it("agent null → the org ceiling", () => {
+    deepStrictEqual(
+      effectiveAllowlist({
+        allowedToolkits: null,
+        orgAllowedToolkits: ["gmail", "slack"],
+      }),
+      ["gmail", "slack"],
+    );
+  });
+
+  it("org null → the agent ceiling", () => {
+    deepStrictEqual(
+      effectiveAllowlist({
+        allowedToolkits: ["gmail"],
+        orgAllowedToolkits: null,
+      }),
+      ["gmail"],
+    );
+  });
+
+  it("both set → intersection in agent order", () => {
+    deepStrictEqual(
+      effectiveAllowlist({
+        allowedToolkits: ["gmail", "slack", "notion"],
+        orgAllowedToolkits: ["notion", "gmail", "asana"],
+      }),
+      ["gmail", "notion"],
+    );
+  });
+
+  it("disjoint ceilings → empty (nothing allowed)", () => {
+    deepStrictEqual(
+      effectiveAllowlist({
+        allowedToolkits: ["gmail"],
+        orgAllowedToolkits: ["slack"],
+      }),
+      [],
+    );
+  });
+
+  it("empty agent ceiling → empty regardless of org", () => {
+    deepStrictEqual(
+      effectiveAllowlist({ allowedToolkits: [], orgAllowedToolkits: null }),
+      [],
+    );
+  });
+});
+
+describe("agentIntegrationsView (allowlist overlay)", () => {
+  it("no allowlist → nothing disallowed (behaves as before)", () => {
+    const view = agentIntegrationsView({
+      connections: [conn("gmail"), conn("slack")],
+      catalog: CATALOG,
+      grants: ["gmail", "slack"],
+    });
+    if (view.mode !== "grants") throw new Error("unreachable");
+    deepStrictEqual(view.disallowedRows, []);
+    deepStrictEqual(
+      view.activeRows.map((r) => r.connection.toolkit),
+      ["gmail", "slack"],
+    );
+  });
+
+  it("splits connected apps outside the allowlist into disallowedRows", () => {
+    const view = agentIntegrationsView({
+      connections: [conn("gmail"), conn("slack")],
+      catalog: CATALOG,
+      grants: ["gmail", "slack"],
+      allowlist: ["gmail"],
+    });
+    if (view.mode !== "grants") throw new Error("unreachable");
+    // slack is granted but the ceiling forbids it → not usable, shown as disallowed.
+    deepStrictEqual(
+      view.activeRows.map((r) => r.connection.toolkit),
+      ["gmail"],
+    );
+    deepStrictEqual(
+      view.disallowedRows.map((r) => r.connection.toolkit),
+      ["slack"],
+    );
+  });
+
+  it("a disallowed, ungranted app is not offered as an accountRow", () => {
+    const view = agentIntegrationsView({
+      connections: [conn("gmail"), conn("notion")],
+      catalog: CATALOG,
+      grants: ["gmail"],
+      allowlist: ["gmail"],
+    });
+    if (view.mode !== "grants") throw new Error("unreachable");
+    // notion is connected + active + ungranted, but disallowed → not activatable.
+    deepStrictEqual(view.accountRows, []);
+    deepStrictEqual(
+      view.disallowedRows.map((r) => r.connection.toolkit),
+      ["notion"],
+    );
+  });
+
+  it("an empty allowlist disallows every connected app", () => {
+    const view = agentIntegrationsView({
+      connections: [conn("gmail"), conn("slack")],
+      catalog: CATALOG,
+      grants: ["gmail", "slack"],
+      allowlist: [],
+    });
+    if (view.mode !== "grants") throw new Error("unreachable");
+    deepStrictEqual(view.activeRows, []);
+    deepStrictEqual(view.accountRows, []);
+    deepStrictEqual(
+      view.disallowedRows.map((r) => r.connection.toolkit),
+      ["gmail", "slack"],
+    );
+  });
+
+  it("disallowed rows keep non-active statuses (name-sorted)", () => {
+    const view = agentIntegrationsView({
+      connections: [conn("slack", "pending"), conn("notion", "error")],
+      catalog: CATALOG,
+      grants: [],
+      allowlist: ["gmail"],
+    });
+    if (view.mode !== "grants") throw new Error("unreachable");
+    deepStrictEqual(
+      view.disallowedRows.map((r) => r.connection.toolkit),
+      ["notion", "slack"],
+    );
+    const byToolkit = new Map(
+      view.disallowedRows.map((r) => [
+        r.connection.toolkit,
+        r.connection.status,
+      ]),
+    );
+    strictEqual(byToolkit.get("slack"), "pending");
+    strictEqual(byToolkit.get("notion"), "error");
+  });
+
+  it("degraded mode ignores the allowlist entirely", () => {
+    const view = agentIntegrationsView({
+      connections: [conn("gmail"), conn("slack")],
+      catalog: CATALOG,
+      grants: null,
+      allowlist: ["gmail"],
+    });
+    strictEqual(view.mode, "degraded");
+  });
+});

--- a/app/tests/job-description-access.test.ts
+++ b/app/tests/job-description-access.test.ts
@@ -1,0 +1,79 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { Capabilities, OrgRole } from "@houston-ai/engine-client";
+import { isConfigReadOnly } from "../src/components/tabs/job-description-access.ts";
+
+const caps = (over: Partial<Capabilities> = {}): Capabilities => ({
+  profile: "cloud",
+  revealInOs: false,
+  terminal: false,
+  tunnel: false,
+  codeExecution: "remote-sandbox",
+  providers: [],
+  openaiCompatible: false,
+  integrations: [],
+  ...over,
+});
+
+const multiplayer = (role: OrgRole): Capabilities =>
+  caps({ multiplayer: true, role });
+
+type AgentAccess = "manager" | "user";
+
+describe("job description access — isConfigReadOnly (matrix v2)", () => {
+  it("single-player is NEVER read-only (zero visual change from today)", () => {
+    // The whole point: self-host / local sidecar keeps every affordance.
+    for (const access of ["manager", "user", undefined] as const) {
+      strictEqual(isConfigReadOnly(caps(), { access }), false);
+      strictEqual(isConfigReadOnly(null, { access }), false);
+    }
+  });
+
+  it("multiplayer owner edits every agent", () => {
+    strictEqual(
+      isConfigReadOnly(multiplayer("owner"), { access: "user" }),
+      false,
+    );
+    strictEqual(
+      isConfigReadOnly(multiplayer("owner"), { access: undefined }),
+      false,
+    );
+  });
+
+  it("agent-manager (access='manager') edits; everyone else is read-only", () => {
+    for (const role of ["admin", "user"] as const) {
+      strictEqual(
+        isConfigReadOnly(multiplayer(role), { access: "manager" }),
+        false,
+      );
+      strictEqual(
+        isConfigReadOnly(multiplayer(role), { access: "user" }),
+        true,
+      );
+      strictEqual(
+        isConfigReadOnly(multiplayer(role), { access: undefined }),
+        true,
+      );
+    }
+  });
+
+  it("exhaustive role x access matrix mirrors the manager gate", () => {
+    const roles: readonly OrgRole[] = ["owner", "admin", "user"];
+    const accesses: readonly (AgentAccess | undefined)[] = [
+      "manager",
+      "user",
+      undefined,
+    ];
+    const readOnly = (role: OrgRole, access?: AgentAccess): boolean =>
+      !(role === "owner" || access === "manager");
+    for (const role of roles) {
+      for (const access of accesses) {
+        strictEqual(
+          isConfigReadOnly(multiplayer(role), { access }),
+          readOnly(role, access),
+          `role=${role} access=${access}`,
+        );
+      }
+    }
+  });
+});

--- a/app/tests/model-selector-lock.test.ts
+++ b/app/tests/model-selector-lock.test.ts
@@ -1,0 +1,68 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { Capabilities, OrgRole } from "@houston-ai/engine-client";
+import { isModelSelectorLocked } from "../src/lib/model-selector-lock.ts";
+
+const caps = (over: Partial<Capabilities> = {}): Capabilities => ({
+  profile: "cloud",
+  revealInOs: false,
+  terminal: false,
+  tunnel: false,
+  codeExecution: "remote-sandbox",
+  providers: [],
+  openaiCompatible: false,
+  integrations: [],
+  ...over,
+});
+
+const multiplayer = (role: OrgRole): Capabilities =>
+  caps({ multiplayer: true, role });
+
+// The wire type lives on `Agent.access` (engine-client); the lock only reads
+// that field, so the fixtures pass a minimal `{ access }` shape.
+const agent = (access?: "manager" | "user") => ({ access });
+
+describe("isModelSelectorLocked", () => {
+  it("never locks when no agent scope is threaded", () => {
+    // A caller who could never edit (multiplayer member) still isn't locked
+    // when the selector isn't tied to a specific agent.
+    strictEqual(isModelSelectorLocked(multiplayer("user"), null), false);
+    strictEqual(isModelSelectorLocked(multiplayer("user"), undefined), false);
+    strictEqual(isModelSelectorLocked(caps(), null), false);
+  });
+
+  it("never locks in single-player (self-host), even with an agent", () => {
+    for (const access of ["manager", "user", undefined] as const) {
+      strictEqual(isModelSelectorLocked(caps(), agent(access)), false);
+      strictEqual(isModelSelectorLocked(null, agent(access)), false);
+      strictEqual(isModelSelectorLocked(undefined, agent(access)), false);
+    }
+  });
+
+  it("never locks the org owner (manages every agent)", () => {
+    for (const access of ["manager", "user", undefined] as const) {
+      strictEqual(
+        isModelSelectorLocked(multiplayer("owner"), agent(access)),
+        false,
+      );
+    }
+  });
+
+  it("locks a multiplayer non-owner unless their access is manager", () => {
+    for (const role of ["admin", "user"] as const) {
+      strictEqual(
+        isModelSelectorLocked(multiplayer(role), agent("manager")),
+        false,
+      );
+      strictEqual(
+        isModelSelectorLocked(multiplayer(role), agent("user")),
+        true,
+      );
+      // Missing access defaults to locked (no proof of manager authority).
+      strictEqual(
+        isModelSelectorLocked(multiplayer(role), agent(undefined)),
+        true,
+      );
+    }
+  });
+});

--- a/app/tests/org-roles.test.ts
+++ b/app/tests/org-roles.test.ts
@@ -3,12 +3,14 @@ import { describe, it } from "node:test";
 import type { Capabilities, OrgRole } from "@houston-ai/engine-client";
 import {
   canCreateAgents,
+  canEditAgentConfig,
   canEditAgentGrants,
   canManageAgentGrants,
   canManageAssignments,
   canManageMembers,
   canSeeMembers,
   GRANTABLE_ROLES,
+  isAgentManager,
   isMultiplayer,
   orgRole,
 } from "../src/lib/org-roles.ts";
@@ -27,6 +29,18 @@ const caps = (over: Partial<Capabilities> = {}): Capabilities => ({
 
 const multiplayer = (role: OrgRole): Capabilities =>
   caps({ multiplayer: true, role });
+
+// Per-agent effective access (contract §0). Defined locally: the wire type
+// lives on `Agent.access` (engine-client), added alongside this work; the tests
+// only need the value union.
+type AgentAccess = "manager" | "user";
+
+const ROLES: readonly OrgRole[] = ["owner", "admin", "user"] as const;
+const ACCESSES: readonly (AgentAccess | undefined)[] = [
+  "manager",
+  "user",
+  undefined,
+] as const;
 
 describe("isMultiplayer / orgRole", () => {
   it("single-player: no org, no role", () => {
@@ -77,39 +91,126 @@ describe("canSeeMembers / canManageMembers", () => {
   });
 });
 
-describe("canManageAssignments", () => {
-  it("owner manages any agent regardless of assignment", () => {
+describe("isAgentManager (matrix v2)", () => {
+  it("single-player is always an agent-manager regardless of access", () => {
+    // No org => the sole user owns everything; access is absent on the wire.
+    for (const access of ACCESSES) {
+      strictEqual(isAgentManager(caps(), { access }), true);
+      strictEqual(isAgentManager(null, { access }), true);
+    }
+  });
+
+  it("multiplayer owner is an agent-manager of every agent", () => {
+    for (const access of ACCESSES) {
+      strictEqual(isAgentManager(multiplayer("owner"), { access }), true);
+    }
+  });
+
+  it("multiplayer non-owner defers purely to effective access", () => {
+    // admin and user alike: only access='manager' grants manager authority.
+    // Matrix v2 dropped the admin "manages all" rule.
+    for (const role of ["admin", "user"] as const) {
+      strictEqual(
+        isAgentManager(multiplayer(role), { access: "manager" }),
+        true,
+      );
+      strictEqual(isAgentManager(multiplayer(role), { access: "user" }), false);
+      strictEqual(
+        isAgentManager(multiplayer(role), { access: undefined }),
+        false,
+      );
+    }
+  });
+
+  it("purely trusts agent.access — the gateway already clamped it", () => {
+    // A role-`user` carrying access='manager' does NOT occur on the wire: the
+    // gateway clamps a stale manager row to the org role before sending it.
+    // The client trusts the (already-effective) access rather than re-clamping,
+    // so this synthetic combination returns true — documenting the boundary.
     strictEqual(
-      canManageAssignments(multiplayer("owner"), { assigned: false }),
-      true,
-    );
-    strictEqual(
-      canManageAssignments(multiplayer("owner"), { assigned: true }),
+      isAgentManager(multiplayer("user"), { access: "manager" }),
       true,
     );
   });
 
-  it("admin manages only agents they are assigned to", () => {
-    strictEqual(
-      canManageAssignments(multiplayer("admin"), { assigned: true }),
-      true,
-    );
-    strictEqual(
-      canManageAssignments(multiplayer("admin"), { assigned: false }),
-      false,
-    );
-  });
-
-  it("plain user never manages assignments; single-player never sees the block", () => {
-    strictEqual(
-      canManageAssignments(multiplayer("user"), { assigned: true }),
-      false,
-    );
-    strictEqual(canManageAssignments(caps(), { assigned: true }), false);
+  it("exhaustive role x access matrix", () => {
+    const expected = (role: OrgRole, access?: AgentAccess): boolean =>
+      role === "owner" || access === "manager";
+    for (const role of ROLES) {
+      for (const access of ACCESSES) {
+        strictEqual(
+          isAgentManager(multiplayer(role), { access }),
+          expected(role, access),
+          `role=${role} access=${access}`,
+        );
+      }
+    }
   });
 });
 
-describe("canManageAgentGrants", () => {
+describe("canEditAgentConfig", () => {
+  it("is the isAgentManager gate (same reference)", () => {
+    strictEqual(canEditAgentConfig, isAgentManager);
+  });
+
+  it("gates config edits (instructions/skills/model/settings) by manager authority", () => {
+    strictEqual(canEditAgentConfig(caps(), { access: undefined }), true);
+    strictEqual(
+      canEditAgentConfig(multiplayer("owner"), { access: "user" }),
+      true,
+    );
+    strictEqual(
+      canEditAgentConfig(multiplayer("admin"), { access: "manager" }),
+      true,
+    );
+    strictEqual(
+      canEditAgentConfig(multiplayer("admin"), { access: "user" }),
+      false,
+    );
+    strictEqual(
+      canEditAgentConfig(multiplayer("user"), { access: "user" }),
+      false,
+    );
+  });
+});
+
+describe("canManageAssignments (agent-manager semantics)", () => {
+  it("mirrors isAgentManager across the full matrix", () => {
+    for (const role of ROLES) {
+      for (const access of ACCESSES) {
+        strictEqual(
+          canManageAssignments(multiplayer(role), { access }),
+          isAgentManager(multiplayer(role), { access }),
+          `role=${role} access=${access}`,
+        );
+      }
+    }
+  });
+
+  it("owner manages any agent; managers manage their agent; others cannot", () => {
+    strictEqual(
+      canManageAssignments(multiplayer("owner"), { access: "user" }),
+      true,
+    );
+    strictEqual(
+      canManageAssignments(multiplayer("admin"), { access: "manager" }),
+      true,
+    );
+    // Admin who merely uses an agent (access='user') can no longer share it.
+    strictEqual(
+      canManageAssignments(multiplayer("admin"), { access: "user" }),
+      false,
+    );
+    strictEqual(
+      canManageAssignments(multiplayer("user"), { access: "user" }),
+      false,
+    );
+    // Single-player never renders the share block, but the gate is permissive.
+    strictEqual(canManageAssignments(caps(), { access: undefined }), true);
+  });
+});
+
+describe("canManageAgentGrants (own-grants, assignment semantics)", () => {
   it("requires multiplayer assignment for every role", () => {
     strictEqual(
       canManageAgentGrants(multiplayer("owner"), { assigned: true }),
@@ -131,7 +232,7 @@ describe("canManageAgentGrants", () => {
   });
 });
 
-describe("canEditAgentGrants", () => {
+describe("canEditAgentGrants (own-grants, assignment semantics)", () => {
   it("single-player can always edit its own agent's grants (regression)", () => {
     // A self-host / local sidecar serves grants but has no org roles; the tab
     // must stay editable there, not fall read-only.

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -1531,9 +1531,16 @@ export class HoustonClient {
     if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
     return controlPlane.getOrg(this.cp);
   }
-  async addOrgMember(email: string, role: controlPlane.OrgRole): Promise<void> {
+  async addOrgMember(
+    email: string,
+    role: controlPlane.OrgRole,
+  ): Promise<controlPlane.AddOrgMemberResult> {
     if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
     return controlPlane.addOrgMember(this.cp, email, role);
+  }
+  async deleteOrgInvite(inviteId: string): Promise<void> {
+    if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
+    return controlPlane.deleteOrgInvite(this.cp, inviteId);
   }
   async removeOrgMember(userId: string): Promise<void> {
     if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
@@ -1550,10 +1557,47 @@ export class HoustonClient {
   // ---- per-agent assignments + integration grants (multiplayer) ----
   async setAgentAssignments(
     agentSlugOrId: string,
-    userIds: string[],
+    assignments: controlPlane.AgentAssignment[] | string[],
   ): Promise<void> {
     if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
-    return controlPlane.setAgentAssignments(this.cp, agentSlugOrId, userIds);
+    return controlPlane.setAgentAssignments(
+      this.cp,
+      agentSlugOrId,
+      assignments,
+    );
+  }
+  async getAgentSettings(
+    agentSlugOrId: string,
+  ): Promise<controlPlane.AgentSettings> {
+    if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
+    return controlPlane.getAgentSettings(this.cp, agentSlugOrId);
+  }
+  async setAgentSettings(
+    agentSlugOrId: string,
+    settings: { allowedToolkits: string[] | null },
+  ): Promise<void> {
+    if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
+    return controlPlane.setAgentSettings(this.cp, agentSlugOrId, settings);
+  }
+  async getOrgSettings(): Promise<controlPlane.OrgSettings> {
+    if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
+    return controlPlane.getOrgSettings(this.cp);
+  }
+  async setOrgSettings(settings: {
+    allowedToolkits: string[] | null;
+  }): Promise<void> {
+    if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
+    return controlPlane.setOrgSettings(this.cp, settings);
+  }
+  async orgAudit(
+    opts: { before?: number; limit?: number } = {},
+  ): Promise<controlPlane.AuditEntry[]> {
+    if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
+    return controlPlane.orgAudit(this.cp, opts);
+  }
+  async orgUsage(days: number): Promise<controlPlane.UsageRow[]> {
+    if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
+    return controlPlane.orgUsage(this.cp, days);
   }
   // Grants degrade gracefully: `null` means "this deployment has no grants
   // model" (the legacy engine path, or a host that 404s the route), which the UI

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -49,6 +49,10 @@ interface CpAgent {
   dir?: string;
   assigned?: boolean;
   assignedUserIds?: string[];
+  /** Teams v2: the caller's effective access to this agent. */
+  access?: AgentAccess;
+  /** Teams v2: full assignee list with per-person access (managers/owner only). */
+  assignments?: AgentAssignment[];
 }
 
 // Color is a client-side cosmetic the control plane intentionally does not store
@@ -141,6 +145,8 @@ function toUiAgent(a: CpAgent, colors = colorOverlay()): Agent {
     lastOpenedAt: iso,
     assigned: a.assigned,
     assignedUserIds: a.assignedUserIds,
+    access: a.access,
+    assignments: a.assignments,
   };
 }
 
@@ -926,20 +932,35 @@ export function toInvalidationEvent(frame: {
 // keep one import site, and the v1 client agrees).
 
 export type {
+  AddOrgMemberResult,
+  AgentAccess,
+  AgentAssignment,
+  AgentSettings,
+  AuditEntry,
   IntegrationConnection,
   IntegrationProviderStatus,
   IntegrationToolkit,
   OrgInfo,
+  OrgInvite,
   OrgMember,
   OrgRole,
+  OrgSettings,
+  UsageRow,
 } from "../../../../ui/engine-client/src/types";
 
 import type {
+  AddOrgMemberResult,
+  AgentAccess,
+  AgentAssignment,
+  AgentSettings,
+  AuditEntry,
   IntegrationConnection,
   IntegrationProviderStatus,
   IntegrationToolkit,
   OrgInfo,
   OrgRole,
+  OrgSettings,
+  UsageRow,
 } from "../../../../ui/engine-client/src/types";
 
 const integrationPath = (provider: string) =>
@@ -1041,10 +1062,20 @@ export async function addOrgMember(
   cfg: ControlPlaneConfig,
   email: string,
   role: OrgRole,
-): Promise<void> {
-  await cpFetch(cfg, "/v1/org/members", {
+): Promise<AddOrgMemberResult> {
+  const res = await cpFetch(cfg, "/v1/org/members", {
     method: "POST",
     body: JSON.stringify({ email, role }),
+  });
+  return (await res.json()) as AddOrgMemberResult;
+}
+
+export async function deleteOrgInvite(
+  cfg: ControlPlaneConfig,
+  inviteId: string,
+): Promise<void> {
+  await cpFetch(cfg, `/v1/org/invites/${encodeURIComponent(inviteId)}`, {
+    method: "DELETE",
   });
 }
 
@@ -1071,13 +1102,80 @@ export async function setOrgMemberRole(
 export async function setAgentAssignments(
   cfg: ControlPlaneConfig,
   agentSlugOrId: string,
-  userIds: string[],
+  assignments: AgentAssignment[] | string[],
 ): Promise<void> {
+  const isV2 = assignments.length > 0 && typeof assignments[0] !== "string";
+  const body = isV2
+    ? { assignments: assignments as AgentAssignment[] }
+    : { userIds: assignments as string[] };
   await cpFetch(
     cfg,
     `/v1/agents/${encodeURIComponent(agentSlugOrId)}/assignments`,
-    { method: "PUT", body: JSON.stringify({ userIds }) },
+    { method: "PUT", body: JSON.stringify(body) },
   );
+}
+
+export async function getAgentSettings(
+  cfg: ControlPlaneConfig,
+  agentSlugOrId: string,
+): Promise<AgentSettings> {
+  const res = await cpFetch(
+    cfg,
+    `/v1/agents/${encodeURIComponent(agentSlugOrId)}/settings`,
+  );
+  return (await res.json()) as AgentSettings;
+}
+
+export async function setAgentSettings(
+  cfg: ControlPlaneConfig,
+  agentSlugOrId: string,
+  settings: { allowedToolkits: string[] | null },
+): Promise<void> {
+  await cpFetch(
+    cfg,
+    `/v1/agents/${encodeURIComponent(agentSlugOrId)}/settings`,
+    { method: "PUT", body: JSON.stringify(settings) },
+  );
+}
+
+export async function getOrgSettings(
+  cfg: ControlPlaneConfig,
+): Promise<OrgSettings> {
+  const res = await cpFetch(cfg, "/v1/org/settings");
+  return (await res.json()) as OrgSettings;
+}
+
+export async function setOrgSettings(
+  cfg: ControlPlaneConfig,
+  settings: { allowedToolkits: string[] | null },
+): Promise<void> {
+  await cpFetch(cfg, "/v1/org/settings", {
+    method: "PUT",
+    body: JSON.stringify(settings),
+  });
+}
+
+export async function orgAudit(
+  cfg: ControlPlaneConfig,
+  opts: { before?: number; limit?: number } = {},
+): Promise<AuditEntry[]> {
+  const q = new URLSearchParams();
+  if (opts.before !== undefined) q.set("before", opts.before.toString());
+  if (opts.limit !== undefined) q.set("limit", opts.limit.toString());
+  const suffix = q.toString();
+  const res = await cpFetch(cfg, `/v1/org/audit${suffix ? `?${suffix}` : ""}`);
+  return ((await res.json()) as { entries: AuditEntry[] }).entries;
+}
+
+export async function orgUsage(
+  cfg: ControlPlaneConfig,
+  days: number,
+): Promise<UsageRow[]> {
+  const res = await cpFetch(
+    cfg,
+    `/v1/org/usage?days=${encodeURIComponent(days.toString())}`,
+  );
+  return ((await res.json()) as { rows: UsageRow[] }).rows;
 }
 
 /**

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -14,9 +14,13 @@ import { planAttachmentUploadBatches } from "./attachments.ts";
 import type {
   Activity,
   ActivityUpdate,
+  AddOrgMemberResult,
   Agent,
+  AgentAssignment,
+  AgentSettings,
   AttachmentManifest,
   AttachmentUploadResult,
+  AuditEntry,
   Capabilities,
   ChatHistoryEntry,
   ClaudeStatus,
@@ -51,6 +55,7 @@ import type {
   NewRoutine,
   OrgInfo,
   OrgRole,
+  OrgSettings,
   PairingCode,
   PortableAnonymizeRequest,
   PortableAnonymizeResponse,
@@ -85,6 +90,7 @@ import type {
   TunnelStatus,
   UpdateAgent,
   UpdateProvider,
+  UsageRow,
   VersionResponse,
   Workspace,
   WorkspaceContext,
@@ -1063,9 +1069,18 @@ export class HoustonClient {
   getOrg(): Promise<OrgInfo> {
     return this.request("GET", "/org");
   }
-  /** Invite a member by email at a role. Owner/admin only (enforced by the host). */
-  async addOrgMember(email: string, role: OrgRole): Promise<void> {
-    await this.request("POST", "/org/members", { email, role });
+  /**
+   * Add a member by email at a role (owner only; enforced by the host). A known
+   * Houston user is added directly; an unknown email creates a pending invite
+   * instead (host answers `202 {invited:true,...}`). The parsed body is returned
+   * so the caller can tell the two apart (`invited` / `userId`).
+   */
+  addOrgMember(email: string, role: OrgRole): Promise<AddOrgMemberResult> {
+    return this.request("POST", "/org/members", { email, role });
+  }
+  /** Revoke a pending invite by id (owner only). */
+  async deleteOrgInvite(inviteId: string): Promise<void> {
+    await this.request("DELETE", `/org/invites/${this.seg(inviteId)}`);
   }
   /** Remove a member from the org. */
   async removeOrgMember(userId: string): Promise<void> {
@@ -1079,18 +1094,93 @@ export class HoustonClient {
   // ---------- per-agent assignments + integration grants (multiplayer) ----------
 
   /**
-   * Set which org members may use this agent. Empty `userIds` means "everyone".
-   * Owner/admin only.
+   * Set who may use this agent, and at what access level (Teams v2).
+   *
+   * Pass `AgentAssignment[]` (`{userId, access}`) to send the v2 body
+   * `{assignments}` — the host set-replaces the roster and honors each
+   * per-person `manager`/`user` level. Pass a plain `string[]` of user ids to
+   * send the legacy body `{userIds}` (mapped to `access: "user"` server-side,
+   * except users who already had `manager` keep it). An empty array takes the
+   * legacy `{userIds: []}` path, preserving the old "empty = everyone" meaning.
+   * Gate: owner any agent; admin only if agent-manager (enforced by the host).
    */
   async setAgentAssignments(
     agentSlugOrId: string,
-    userIds: string[],
+    assignments: AgentAssignment[] | string[],
   ): Promise<void> {
+    const isV2 = assignments.length > 0 && typeof assignments[0] !== "string";
+    const body = isV2
+      ? { assignments: assignments as AgentAssignment[] }
+      : { userIds: assignments as string[] };
     await this.request(
       "PUT",
       `/agents/${this.seg(agentSlugOrId)}/assignments`,
-      { userIds },
+      body,
     );
+  }
+  /**
+   * Read this agent's Teams settings (any assigned caller or owner):
+   * `allowedToolkits` (agent integration ceiling), `orgAllowedToolkits` (org
+   * ceiling it's intersected with), and the caller's effective `access`.
+   */
+  getAgentSettings(agentSlugOrId: string): Promise<AgentSettings> {
+    return this.request("GET", `/agents/${this.seg(agentSlugOrId)}/settings`);
+  }
+  /**
+   * Replace this agent's allowed-toolkit ceiling (agent-manager only). `null`
+   * means unrestricted, `[]` means none. The host also prunes now-disallowed
+   * toolkits from existing grants so revocation takes effect immediately.
+   */
+  async setAgentSettings(
+    agentSlugOrId: string,
+    settings: { allowedToolkits: string[] | null },
+  ): Promise<void> {
+    await this.request(
+      "PUT",
+      `/agents/${this.seg(agentSlugOrId)}/settings`,
+      settings,
+    );
+  }
+  /** Read the org-wide allowed-toolkit ceiling (any member). */
+  getOrgSettings(): Promise<OrgSettings> {
+    return this.request("GET", "/org/settings");
+  }
+  /** Replace the org-wide allowed-toolkit ceiling (owner only). */
+  async setOrgSettings(settings: {
+    allowedToolkits: string[] | null;
+  }): Promise<void> {
+    await this.request("PUT", "/org/settings", settings);
+  }
+  /**
+   * Read the org audit log, newest first (owner org-wide; admin filtered to
+   * their managed agents; plain members 403). `before` pages by entry id,
+   * `limit` caps the page (host clamps to ≤ 200).
+   */
+  async orgAudit(
+    opts: { before?: number; limit?: number } = {},
+  ): Promise<AuditEntry[]> {
+    return (
+      await this.request<{ entries: AuditEntry[] }>(
+        "GET",
+        "/org/audit",
+        undefined,
+        {
+          before: opts.before?.toString(),
+          limit: opts.limit?.toString(),
+        },
+      )
+    ).entries;
+  }
+  /**
+   * Read per-agent/user usage counters over the last `days` (owner org-wide;
+   * admin their managed agents; plain members 403). Host clamps `days` to ≤ 90.
+   */
+  async orgUsage(days: number): Promise<UsageRow[]> {
+    return (
+      await this.request<{ rows: UsageRow[] }>("GET", "/org/usage", undefined, {
+        days: days.toString(),
+      })
+    ).rows;
   }
   /**
    * The integration toolkit slugs granted to this agent, or `null` when the host

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -83,6 +83,13 @@ export interface Capabilities {
   multiplayer?: boolean;
   /** The current user's role in the org, when `multiplayer` is on. */
   role?: OrgRole;
+  /**
+   * Whether this deployment serves the Teams v2 surface (per-agent access
+   * levels, share dialog, org dashboard). A feature-detect flag the frontend
+   * reads to enable the v2 UI; absent/false on hosts that predate Teams so
+   * every existing single-player/self-host profile stays valid.
+   */
+  teams?: boolean;
 }
 
 // ---------- Org / roles (multiplayer) ----------
@@ -104,9 +111,37 @@ export interface OrgMember {
 }
 
 /**
+ * A per-agent access level (Teams v2). `manager` may reconfigure the agent
+ * (instructions, skills, model, allowed toolkits, assignments); `user` may only
+ * use it. Kept in sync (by hand) with the gateway — the server is the source of
+ * truth and clamps a stale `manager` row for a plain `user` member at read time.
+ */
+export type AgentAccess = "manager" | "user";
+
+/** One member's access level for a shared agent. */
+export interface AgentAssignment {
+  userId: string;
+  access: AgentAccess;
+}
+
+/**
+ * A pending invite to the org, surfaced to owner/admin on `GET /org`. `email`
+ * is the invited address; the invite is consumed on that user's first sign-in.
+ * `createdAt` is epoch milliseconds.
+ */
+export interface OrgInvite {
+  id: string;
+  email: string;
+  role: OrgRole;
+  invitedBy: string;
+  createdAt: number;
+}
+
+/**
  * The current user's org, with the caller's own role. `members` is populated
  * only for callers allowed to see the roster (owner/admin); a plain `user`
- * gets just the identity fields.
+ * gets just the identity fields. `invites` (pending, un-consumed) is likewise
+ * owner/admin only.
  */
 export interface OrgInfo {
   id: string;
@@ -114,6 +149,68 @@ export interface OrgInfo {
   name: string;
   role: OrgRole;
   members?: OrgMember[];
+  /** Pending invites, for owner/admin callers only. */
+  invites?: OrgInvite[];
+}
+
+/**
+ * Result of `POST /org/members` (Teams v2). A known Houston user is added
+ * directly (`userId` set); an unknown email creates a pending invite instead
+ * and the host answers `202` with `invited: true`. `role` echoes the requested
+ * role in both cases.
+ */
+export interface AddOrgMemberResult {
+  /** Set when an existing user was added directly (not invited). */
+  userId?: string;
+  role: OrgRole;
+  /** True when an invite was created because the email is not yet a user. */
+  invited?: boolean;
+  /** The invited email, echoed on the invite path. */
+  email?: string;
+}
+
+/**
+ * Per-agent settings (Teams v2), from `GET /agents/:slug/settings`.
+ * `allowedToolkits` is the agent-level integration ceiling (`null` =
+ * unrestricted, `[]` = none); `orgAllowedToolkits` is the org-wide ceiling the
+ * agent ceiling is intersected with; `access` is the caller's effective access.
+ */
+export interface AgentSettings {
+  allowedToolkits: string[] | null;
+  orgAllowedToolkits: string[] | null;
+  access: AgentAccess;
+}
+
+/** Org-wide settings (Teams v2), from `GET /org/settings`. */
+export interface OrgSettings {
+  /** Org-wide integration ceiling; `null` = unrestricted, `[]` = none. */
+  allowedToolkits: string[] | null;
+}
+
+/**
+ * One audit-log entry (Teams v2), newest-first from `GET /org/audit`.
+ * `action` is a stable slug (e.g. `agent.rename`, `member.add`, `grants.set`);
+ * `subject` is action-specific JSON; `createdAt` is epoch milliseconds.
+ */
+export interface AuditEntry {
+  id: number;
+  orgId: string;
+  actor: string;
+  action: string;
+  agentSlug?: string;
+  subject: unknown;
+  createdAt: number;
+}
+
+/**
+ * One usage-counter row (Teams v2) from `GET /org/usage`: message count for a
+ * (agent, user, day) tuple. `day` is a `YYYY-MM-DD` UTC date.
+ */
+export interface UsageRow {
+  agentSlug: string;
+  userId: string;
+  day: string;
+  messages: number;
 }
 
 // ---------- Workspaces ----------
@@ -180,8 +277,24 @@ export interface Agent {
    * Multiplayer only: the org-member user ids this agent is assigned to.
    * Empty means "everyone in the org". Absent in single-player mode. Only
    * populated for callers who may manage assignments (owner/admin).
+   *
+   * Retained for back-compat alongside the richer `assignments` (Teams v2);
+   * the two carry the same user set for a manager/owner caller.
    */
   assignedUserIds?: string[];
+  /**
+   * Teams v2: the CURRENT caller's effective access to this agent —
+   * `"manager"` (may reconfigure) or `"user"` (may only use). Owner is always
+   * `"manager"`. Absent in single-player mode and on hosts that predate Teams.
+   */
+  access?: AgentAccess;
+  /**
+   * Teams v2: the full assignee list with per-person access level. Populated
+   * only for callers who may manage the agent (owner, or an admin who is an
+   * agent-manager); absent for agents an admin merely uses, and in
+   * single-player mode. `assignedUserIds` mirrors these user ids for back-compat.
+   */
+  assignments?: AgentAssignment[];
 }
 
 export interface CreateAgent {

--- a/ui/engine-client/tests/client-teams.test.ts
+++ b/ui/engine-client/tests/client-teams.test.ts
@@ -1,0 +1,180 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { HoustonClient } from "../src/client.ts";
+
+/**
+ * Teams v2 client surface (contract §5/§6): the new settings/audit/usage/invite
+ * methods and the dual-shape `setAgentAssignments`.
+ *
+ * A capturing `fetchImpl` records the outgoing `{method, url, body}` so we can
+ * assert the exact wire request each method issues, and return a canned JSON
+ * body so the parse/unwrap side is covered too.
+ */
+
+interface Captured {
+  method: string;
+  url: string;
+  body: unknown;
+}
+
+function makeClient(responseBody: unknown = {}): {
+  client: HoustonClient;
+  calls: Captured[];
+} {
+  const calls: Captured[] = [];
+  const client = new HoustonClient({
+    baseUrl: "http://127.0.0.1:9999",
+    token: "tok",
+    fetchImpl: async (url, init) => {
+      calls.push({
+        method: init?.method ?? "GET",
+        url: String(url),
+        body:
+          typeof init?.body === "string" ? JSON.parse(init.body) : init?.body,
+      });
+      return new Response(JSON.stringify(responseBody), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  return { client, calls };
+}
+
+describe("HoustonClient Teams v2 — setAgentAssignments dual shape", () => {
+  it("sends {assignments} for an AgentAssignment[] argument", async () => {
+    const { client, calls } = makeClient();
+    await client.setAgentAssignments("agent-1", [
+      { userId: "u1", access: "manager" },
+      { userId: "u2", access: "user" },
+    ]);
+    strictEqual(calls.length, 1);
+    strictEqual(calls[0].method, "PUT");
+    strictEqual(
+      calls[0].url,
+      "http://127.0.0.1:9999/v1/agents/agent-1/assignments",
+    );
+    deepStrictEqual(calls[0].body, {
+      assignments: [
+        { userId: "u1", access: "manager" },
+        { userId: "u2", access: "user" },
+      ],
+    });
+  });
+
+  it("sends {userIds} for a legacy string[] argument", async () => {
+    const { client, calls } = makeClient();
+    await client.setAgentAssignments("agent-1", ["u1", "u2"]);
+    deepStrictEqual(calls[0].body, { userIds: ["u1", "u2"] });
+  });
+
+  it("sends {userIds: []} for an empty array (legacy 'everyone')", async () => {
+    const { client, calls } = makeClient();
+    await client.setAgentAssignments("agent-1", []);
+    deepStrictEqual(calls[0].body, { userIds: [] });
+  });
+});
+
+describe("HoustonClient Teams v2 — agent + org settings", () => {
+  it("getAgentSettings GETs /agents/:id/settings and returns the body", async () => {
+    const settings = {
+      allowedToolkits: ["gmail"],
+      orgAllowedToolkits: null,
+      access: "manager",
+    };
+    const { client, calls } = makeClient(settings);
+    const got = await client.getAgentSettings("agent-1");
+    strictEqual(calls[0].method, "GET");
+    strictEqual(
+      calls[0].url,
+      "http://127.0.0.1:9999/v1/agents/agent-1/settings",
+    );
+    deepStrictEqual(got, settings);
+  });
+
+  it("setAgentSettings PUTs the allowedToolkits body", async () => {
+    const { client, calls } = makeClient();
+    await client.setAgentSettings("agent-1", { allowedToolkits: null });
+    strictEqual(calls[0].method, "PUT");
+    strictEqual(
+      calls[0].url,
+      "http://127.0.0.1:9999/v1/agents/agent-1/settings",
+    );
+    deepStrictEqual(calls[0].body, { allowedToolkits: null });
+  });
+
+  it("getOrgSettings GETs /org/settings", async () => {
+    const { client, calls } = makeClient({ allowedToolkits: [] });
+    const got = await client.getOrgSettings();
+    strictEqual(calls[0].method, "GET");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org/settings");
+    deepStrictEqual(got, { allowedToolkits: [] });
+  });
+
+  it("setOrgSettings PUTs /org/settings", async () => {
+    const { client, calls } = makeClient();
+    await client.setOrgSettings({ allowedToolkits: ["slack"] });
+    strictEqual(calls[0].method, "PUT");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org/settings");
+    deepStrictEqual(calls[0].body, { allowedToolkits: ["slack"] });
+  });
+});
+
+describe("HoustonClient Teams v2 — invites, audit, usage", () => {
+  it("addOrgMember returns the parsed 202 invite body", async () => {
+    const { client, calls } = makeClient({
+      invited: true,
+      email: "new@x.io",
+      role: "user",
+    });
+    const res = await client.addOrgMember("new@x.io", "user");
+    strictEqual(calls[0].method, "POST");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org/members");
+    deepStrictEqual(res, { invited: true, email: "new@x.io", role: "user" });
+  });
+
+  it("deleteOrgInvite DELETEs /org/invites/:id", async () => {
+    const { client, calls } = makeClient();
+    await client.deleteOrgInvite("inv-1");
+    strictEqual(calls[0].method, "DELETE");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org/invites/inv-1");
+  });
+
+  it("orgAudit passes before/limit query and unwraps entries", async () => {
+    const entries = [
+      {
+        id: 2,
+        orgId: "o",
+        actor: "a",
+        action: "agent.rename",
+        subject: {},
+        createdAt: 5,
+      },
+    ];
+    const { client, calls } = makeClient({ entries });
+    const got = await client.orgAudit({ before: 10, limit: 50 });
+    strictEqual(calls[0].method, "GET");
+    strictEqual(
+      calls[0].url,
+      "http://127.0.0.1:9999/v1/org/audit?before=10&limit=50",
+    );
+    deepStrictEqual(got, entries);
+  });
+
+  it("orgAudit omits absent query params", async () => {
+    const { client, calls } = makeClient({ entries: [] });
+    await client.orgAudit();
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org/audit");
+  });
+
+  it("orgUsage passes days and unwraps rows", async () => {
+    const rows = [
+      { agentSlug: "s", userId: "u", day: "2026-07-05", messages: 3 },
+    ];
+    const { client, calls } = makeClient({ rows });
+    const got = await client.orgUsage(30);
+    strictEqual(calls[0].method, "GET");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org/usage?days=30");
+    deepStrictEqual(got, rows);
+  });
+});

--- a/ui/skills/src/skill-detail-header-actions.tsx
+++ b/ui/skills/src/skill-detail-header-actions.tsx
@@ -1,0 +1,85 @@
+import {
+  Button,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@houston-ai/core";
+import { Lock, MoreHorizontal, Trash2 } from "lucide-react";
+
+export interface SkillDetailHeaderActionsLabels {
+  saveChanges: string;
+  savingChanges: string;
+  moreOptions: string;
+  delete: string;
+  managedNote: string;
+}
+
+export interface SkillDetailHeaderActionsProps {
+  /**
+   * Read-only mode (a non-manager on a managed agent): render the managed-note
+   * indicator instead of the Save + Delete affordances.
+   */
+  readOnly: boolean;
+  isDirty: boolean;
+  saving: boolean;
+  deleting: boolean;
+  onSave: () => void;
+  onRequestDelete: () => void;
+  labels: SkillDetailHeaderActionsLabels;
+}
+
+/**
+ * Trailing action cluster of the skill detail header. Split out of
+ * `SkillDetailPage` so the two header variants (read-only note vs. the editable
+ * Save/Delete controls) live in one focused component and the page file stays
+ * under the file-size limit.
+ */
+export function SkillDetailHeaderActions({
+  readOnly,
+  isDirty,
+  saving,
+  deleting,
+  onSave,
+  onRequestDelete,
+  labels,
+}: SkillDetailHeaderActionsProps) {
+  if (readOnly) {
+    return (
+      <span className="flex items-center gap-1.5 shrink-0 text-xs text-muted-foreground">
+        <Lock className="size-3.5" aria-hidden="true" />
+        {labels.managedNote}
+      </span>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1.5 shrink-0">
+      <Button
+        size="sm"
+        onClick={onSave}
+        disabled={!isDirty || saving || deleting}
+      >
+        {saving ? labels.savingChanges : labels.saveChanges}
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={labels.moreOptions}
+            disabled={deleting}
+          >
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-44">
+          <DropdownMenuItem variant="destructive" onClick={onRequestDelete}>
+            <Trash2 className="size-3.5" />
+            {labels.delete}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}

--- a/ui/skills/src/skill-detail-page.tsx
+++ b/ui/skills/src/skill-detail-page.tsx
@@ -1,14 +1,7 @@
-import {
-  Button,
-  ConfirmDialog,
-  cn,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@houston-ai/core";
-import { ArrowLeft, MoreHorizontal, Trash2 } from "lucide-react";
+import { Button, ConfirmDialog, cn } from "@houston-ai/core";
+import { ArrowLeft } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
+import { SkillDetailHeaderActions } from "./skill-detail-header-actions";
 import type { Skill } from "./types";
 
 export interface SkillDetailPageLabels {
@@ -22,6 +15,8 @@ export interface SkillDetailPageLabels {
   deleteDescription?: string;
   deleteConfirmLabel?: string;
   instructionsPlaceholder?: string;
+  /** Note shown in the header when `readOnly` — e.g. "Managed by your org". */
+  managedNote?: string;
 }
 
 const DEFAULT_LABELS: Required<SkillDetailPageLabels> = {
@@ -36,6 +31,7 @@ const DEFAULT_LABELS: Required<SkillDetailPageLabels> = {
     "This removes the skill from your agent. You can reinstall it later.",
   deleteConfirmLabel: "Delete",
   instructionsPlaceholder: "Instructions for this skill...",
+  managedNote: "Managed by your organization",
 };
 
 export interface SkillDetailPageProps {
@@ -43,6 +39,13 @@ export interface SkillDetailPageProps {
   onBack: () => void;
   onSave: (skillName: string, instructions: string) => Promise<void>;
   onDelete: (skillName: string) => Promise<void>;
+  /**
+   * Read-only mode: the skill is visible but not editable (a non-manager on a
+   * managed agent). Hides the Save + Delete affordances and locks the textarea;
+   * shows `labels.managedNote` in the header instead. The gateway enforces this
+   * for real.
+   */
+  readOnly?: boolean;
   labels?: SkillDetailPageLabels;
 }
 
@@ -51,6 +54,7 @@ export function SkillDetailPage({
   onBack,
   onSave,
   onDelete,
+  readOnly = false,
   labels,
 }: SkillDetailPageProps) {
   const l = { ...DEFAULT_LABELS, ...labels };
@@ -116,36 +120,15 @@ export function SkillDetailPage({
             {displayName}
           </p>
 
-          <div className="flex items-center gap-1.5 shrink-0">
-            <Button
-              size="sm"
-              onClick={handleSave}
-              disabled={!isDirty || saving || deleting}
-            >
-              {saving ? l.savingChanges : l.saveChanges}
-            </Button>
-            <DropdownMenu>
-              <DropdownMenuTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  aria-label={l.moreOptions}
-                  disabled={deleting}
-                >
-                  <MoreHorizontal className="size-4" />
-                </Button>
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="w-44">
-                <DropdownMenuItem
-                  variant="destructive"
-                  onClick={() => setConfirmOpen(true)}
-                >
-                  <Trash2 className="size-3.5" />
-                  {l.delete}
-                </DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
-          </div>
+          <SkillDetailHeaderActions
+            readOnly={readOnly}
+            isDirty={isDirty}
+            saving={saving}
+            deleting={deleting}
+            onSave={handleSave}
+            onRequestDelete={() => setConfirmOpen(true)}
+            labels={l}
+          />
         </div>
       </header>
 
@@ -170,6 +153,7 @@ export function SkillDetailPage({
             <textarea
               value={instructions}
               onChange={(e) => setInstructions(e.target.value)}
+              readOnly={readOnly}
               rows={18}
               placeholder={l.instructionsPlaceholder}
               className={cn(
@@ -178,6 +162,7 @@ export function SkillDetailPage({
                 "bg-background border border-border/20 rounded-lg",
                 "outline-none resize-y transition-shadow duration-200",
                 "focus:shadow-sm",
+                readOnly && "cursor-default text-muted-foreground resize-none",
               )}
             />
           </section>


### PR DESCRIPTION
Client half of the Teams (multiplayer org) build. Gateway-side enforcement lands separately in the private cloud repo (contracts C3 v2 / C7); every gate here only hides affordances and feature-detects, so single-player and self-host behavior is unchanged.

## What's in
- **engine-client**: `Agent.access`/`assignments`, `Capabilities.teams`, `OrgInfo.invites`, new agent/org settings + audit + usage methods, assignments v2 body (legacy `{userIds}` still supported), `addOrgMember` 202-invite result. Web control-plane adapter kept in shim parity.
- **org-roles v2**: `isAgentManager`/`canEditAgentConfig` — an agent is manageable by the org owner or an admin holding per-agent `manager` access; admins no longer see or manage all org agents.
- **Managed-agent read-only surfaces** for plain members: instructions, skills, learnings, general settings, and the model/effort selectors lock with a "managed by your organization" explanation (i18n en/es/pt, new `teams` namespace).
- **Per-agent Integrations tab**: catalog narrowed to the effective allowlist (org ceiling ∩ agent ceiling), connected-but-disallowed apps surfaced as non-connectable, "Allowed integrations" editor for agent managers.

## Verification
- `pnpm check`, `pnpm typecheck`, `app tsgo --noEmit`, `check-locales`, `houston-web typecheck` (incl. Tauri shim parity), host/runtime/domain vitest — all green.
- Multi-agent adversarial review ran on the diff; confirmed findings (single-player regression of the access section, stale JSDoc, a 200-line-limit breach) were fixed with tests-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)