### PR TITLE
feat(ios): Settings tab, AI Models, and Integrations surfaces

### DIFF
--- a/design/inventory/manifests/ios.yaml
+++ b/design/inventory/manifests/ios.yaml
@@ -7,11 +7,14 @@
 # STATUS OF THIS SURFACE (2026-07): a full v1 has been BUILT on @houston/sdk
 # (JavaScriptCore bridge + native fetch/storage ports, Supabase auth, the
 # DesignSystem over @houston/design-tokens, and the Agents / Mission Control /
-# New Mission / Chat surfaces). Per-component statuses below reflect what is
-# actually built. inventoryVersion STAYS 0 and enforced STAYS false because the
-# app has not yet been compiled+shipped: the build environment has no Xcode, so
-# the Swift is disciplined-but-compiler-unverified. Raise inventoryVersion only
-# once it compiles, tests pass on a simulator, and it ships at that version.
+# New Mission / Chat / Settings / AI Models / Integrations surfaces). Per-component
+# statuses below reflect what is actually built. The app now COMPILES with Xcode
+# and its unit suite passes on a simulator (iPhone 17 Pro) — the Swift is no
+# longer compiler-unverified. inventoryVersion STAYS 0 and enforced STAYS false
+# because the app has not yet SHIPPED; raise inventoryVersion only once it ships,
+# at that version. Note: the Settings, Appearance, Language, Account, and
+# Integrations surfaces are not represented by inventory.yaml component ids, so
+# they have no rows here (only the inventoried AI-models components do).
 
 surface: ios
 enforced: false
@@ -102,8 +105,25 @@ components:
     status: not-started
     notes: No toast system in mobile v1; action failures surface via alerts carrying the real reason.
   ai-provider-card:
-    status: not-started
+    status: implemented
+    ref: mobile/ios/Houston/Features/AIModels/ProviderCardView.swift
+    notes: >-
+      Per-agent provider grid tile (logo via ProviderGlyph, name, description,
+      model-count) with available/connected/connecting/coming-soon states and a
+      footer action; opens the connect flow (ProviderConnectSheet) or the
+      connected detail (ProviderDetailSheet). Connection state is read from the
+      per-agent providers/<agentId> scope, never hardcoded.
   ai-model-row:
-    status: not-started
+    status: partial
+    ref: mobile/ios/Houston/Features/AIModels/ModelPickerView.swift
+    notes: >-
+      provider-model-row variant built — the per-agent model picker and the
+      connected provider's model list (ProviderDetailSheet) with context/effort
+      badges. The cross-provider "Models · N" directory-row variant is not ported
+      (iOS is provider-first; there is no standalone model directory yet).
   ai-model-offer-row:
     status: not-started
+    notes: >-
+      No cross-model detail / "Get it through" offers list on iOS. Connecting a
+      provider-model happens from the provider card + detail instead of a
+      per-model offer row.

--- a/mobile/ios/Houston/App/RootTabs.swift
+++ b/mobile/ios/Houston/App/RootTabs.swift
@@ -14,6 +14,12 @@ import SwiftUI
 /// (the aggregate `needs_you` count across agents — see `PARITY.md` §4).
 struct RootTabs: View {
     @Environment(BadgeModel.self) private var badge
+    @Environment(\.colorScheme) private var systemScheme
+
+    /// Device-local appearance choice (Settings › Appearance). Read here so the
+    /// whole signed-in shell re-themes: nothing else applies `houstonTheme(...)`,
+    /// so this is where the app's light/dark resolves. See `AppearancePreference`.
+    @AppStorage(AppearancePreference.storageKey) private var appearance = ""
 
     @State private var selection: Tab = .agents
     /// The last *real* tab, restored when the New Mission tab is intercepted.
@@ -24,6 +30,12 @@ struct RootTabs: View {
         case agents
         case newMission   // sentinel — never actually shown
         case missionControl
+        case settings
+    }
+
+    private var themeMode: HoustonTheme {
+        AppearancePreference.resolve(
+            stored: appearance.isEmpty ? nil : appearance, system: systemScheme)
     }
 
     var body: some View {
@@ -46,7 +58,14 @@ struct RootTabs: View {
                 }
                 .badge(badge.needsYouCount)
                 .tag(Tab.missionControl)
+
+            SettingsView()
+                .tabItem {
+                    Label(Strings.Tabs.settings, systemImage: "gearshape")
+                }
+                .tag(Tab.settings)
         }
+        .houstonTheme(themeMode)
         .onChange(of: selection) { _, newValue in
             guard newValue == .newMission else {
                 lastRealSelection = newValue

--- a/mobile/ios/Houston/App/Strings+App.swift
+++ b/mobile/ios/Houston/App/Strings+App.swift
@@ -12,6 +12,7 @@ extension Strings {
         static let agents = "Agents"
         static let newMission = "New Mission"
         static let missionControl = "Mission Control"
+        static let settings = "Settings"
     }
 
     enum Startup {

--- a/mobile/ios/Houston/Core/Auth/AuthController+Refresh.swift
+++ b/mobile/ios/Houston/Core/Auth/AuthController+Refresh.swift
@@ -65,6 +65,9 @@ extension AuthController {
         session = nil
         try? keychain.clear()
         await sdk.setToken(nil)
+        // Same purge as the explicit sign-out: this is the terminal path for a
+        // failed refresh / `tokenExpired`, so drop the previous user's caches.
+        sdk.purgeUserData()
         state = .signedOut
     }
 }

--- a/mobile/ios/Houston/Core/Auth/AuthController.swift
+++ b/mobile/ios/Houston/Core/Auth/AuthController.swift
@@ -109,6 +109,9 @@ final class AuthController {
             errorMessage = Self.describe(error)
         }
         await sdk.setToken(nil)
+        // Purge the previous user's cached scope snapshots so a different user
+        // signing in on this device never reads them (fixed scope keys).
+        sdk.purgeUserData()
         state = .signedOut
     }
 

--- a/mobile/ios/Houston/Core/Bridge/Models/SdkScope.swift
+++ b/mobile/ios/Houston/Core/Bridge/Models/SdkScope.swift
@@ -34,6 +34,18 @@ enum SdkScope {
     "activities/\(agentId)"
   }
 
+  /// One agent's AI-provider connect/status VM — `providers/<agentId>`
+  /// (`providersScope`, `packages/sdk/src/modules/providers/types.ts`). Provider
+  /// credentials are per-agent-pod in hosted mode, so the scope is agent-keyed.
+  static func providers(agentId: String) -> String {
+    "providers/\(agentId)"
+  }
+
+  /// The single integrations VM scope — `integrations` (`INTEGRATIONS_SCOPE`,
+  /// `packages/sdk/src/modules/integrations/types.ts`). User-scoped, NOT
+  /// per-agent: integrations are gateway-owned and keyed by the session `sub`.
+  static let integrations = "integrations"
+
   /// The JS `encodeURIComponent` unreserved set: percent-encode everything
   /// EXCEPT `A-Z a-z 0-9 - _ . ! ~ * ' ( )`. Foundation's `.urlQueryAllowed`
   /// differs (it keeps `/`, `?`, `&`, `=`, … and treats non-ASCII letters as

--- a/mobile/ios/Houston/Core/Bridge/ScopeStore.swift
+++ b/mobile/ios/Houston/Core/Bridge/ScopeStore.swift
@@ -14,6 +14,16 @@ protocol ScopeSubscribing: AnyObject {
   func closeScopeSubscription(sub: String)
 }
 
+/// The type-erased seam ``SdkClient/purgeUserData()`` uses to reset every cached
+/// ``ScopeStore`` (which are held as `AnyObject`, keyed by scope) on sign-out,
+/// without knowing each store's concrete snapshot type.
+@MainActor
+protocol ScopePurgeable: AnyObject {
+  /// Drop the cached snapshot and detach from the current subscription so a
+  /// different user's session never reads the previous user's data.
+  func purge()
+}
+
 /// A reactive, decoded view of one SDK scope's latest snapshot.
 ///
 /// Observation-driven lifecycle: the bridge subscription opens on the FIRST
@@ -79,6 +89,20 @@ final class ScopeStore<T: Decodable & Sendable> {
       log.error(
         "scope \(self.scope, privacy: .public) decode failed: \(self.lastError ?? "", privacy: .public)")
     }
+  }
+}
+
+extension ScopeStore: ScopePurgeable {
+  /// Reset to the pre-first-snapshot state: publish an unloaded snapshot (so a
+  /// bound view drops the previous user's data instead of showing it until a
+  /// refetch) and forget the current subscription. The bridge `unsubscribe` is
+  /// sent once, centrally, by ``SdkClient/purgeUserData()``; this only clears the
+  /// local `sub`/refcount so a later ``retain()`` reopens a fresh subscription.
+  func purge() {
+    snapshot = nil
+    lastError = nil
+    sub = nil
+    refCount = 0
   }
 }
 

--- a/mobile/ios/Houston/Core/Bridge/SdkClient+Subscriptions.swift
+++ b/mobile/ios/Houston/Core/Bridge/SdkClient+Subscriptions.swift
@@ -43,4 +43,30 @@ extension SdkClient {
   func deliverSnapshot(sub: String, value: JSONValue) {
     subscriptions[sub]?.sink(value)
   }
+
+  /// Drop every trace of the signed-in user's SCOPE data so a different user
+  /// signing in on the same device never reads the previous user's snapshots
+  /// (the scope keys `agents`/`integrations` are fixed, so a stale snapshot would
+  /// otherwise show through until a refetch landed). Closes every live scope
+  /// subscription on the bridge, clears the subscription table, and resets every
+  /// cached ``ScopeStore`` to an unloaded snapshot (bound views drop stale data).
+  ///
+  /// Event sinks and in-flight commands are transient — not cached user data —
+  /// and are intentionally left intact so the app-lifetime `tokenExpired`
+  /// observer (``AuthController/observeSdkFatal()``) keeps working across the next
+  /// sign-in. Call from EVERY sign-out exit (``AuthController/signOut()`` and the
+  /// `forceSignOut`/`tokenExpired` terminal path).
+  func purgeUserData() {
+    for sub in subscriptions.keys {
+      do {
+        try deliver(.unsubscribe(sub: sub))
+      } catch {
+        log.error("purge unsubscribe \(sub, privacy: .public) failed: \(String(describing: error), privacy: .public)")
+      }
+    }
+    subscriptions.removeAll()
+    for store in scopeStores.values {
+      (store as? ScopePurgeable)?.purge()
+    }
+  }
 }

--- a/mobile/ios/Houston/Features/AgentMissions/AgentMissionsView.swift
+++ b/mobile/ios/Houston/Features/AgentMissions/AgentMissionsView.swift
@@ -21,6 +21,10 @@ struct AgentMissionsView: View {
     let agent: AgentListItem
     let onOpenChat: (ChatRoute) -> Void
     let onOpenArchived: () -> Void
+    /// Per-agent AI Models + Integrations, opened from the toolbar menu (both
+    /// surfaces are per-agent — provider credentials per-pod, grants per-agent).
+    let onOpenAIModels: () -> Void
+    let onOpenIntegrations: () -> Void
 
     @State private var retention: ScopeRetention?
     @State private var presentingComposer = false
@@ -49,6 +53,7 @@ struct AgentMissionsView: View {
         .background(theme.background)
         .navigationTitle(agent.name)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar { ToolbarItem(placement: .topBarTrailing) { agentMenu } }
         .safeAreaInset(edge: .bottom) { composer }
         .sheet(isPresented: $presentingComposer) { NewMissionSheet(preselectedAgent: agent) }
         .missionActionDialogs(
@@ -70,6 +75,23 @@ struct AgentMissionsView: View {
     }
 
     // MARK: Pieces
+
+    /// Toolbar overflow: this agent's AI Models + Integrations. Kept subtle (a
+    /// single ellipsis menu) so the missions screen stays focused on the work.
+    private var agentMenu: some View {
+        Menu {
+            Button { onOpenAIModels() } label: {
+                Label(Strings.AIModels.title, systemImage: "cpu")
+            }
+            Button { onOpenIntegrations() } label: {
+                Label(Strings.Integrations.title, systemImage: "puzzlepiece.extension")
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+                .foregroundStyle(theme.foreground)
+        }
+        .accessibilityLabel(Strings.AgentMissions.moreMenu)
+    }
 
     private var header: some View {
         HStack(spacing: Spacing.space12) {

--- a/mobile/ios/Houston/Features/AgentMissions/Strings+AgentMissions.swift
+++ b/mobile/ios/Houston/Features/AgentMissions/Strings+AgentMissions.swift
@@ -16,5 +16,10 @@ extension Strings {
         /// reuses `Strings.Board.delete` ("Delete").
         static let deleteConfirmTitle = "Delete mission?"
         static let deleteConfirmBody = "This removes the mission and its chat for good. You can't undo this."
+
+        /// Accessibility label for the toolbar overflow menu that opens this
+        /// agent's AI Models + Integrations. Product-voice (desktop reaches these
+        /// from top-level nav, not a per-agent menu).
+        static let moreMenu = "Agent settings"
     }
 }

--- a/mobile/ios/Houston/Features/Agents/AgentsRoute.swift
+++ b/mobile/ios/Houston/Features/Agents/AgentsRoute.swift
@@ -17,12 +17,22 @@ enum AgentsNavRoute: Hashable {
     case chat(ChatRoute)
     /// An agent's archived missions list (PARITY §2), pushed from its bottom row.
     case archived(AgentListItem)
+    /// This agent's AI Models grid (PARITY-SETTINGS §2), pushed from its menu.
+    case aiModels(AgentListItem)
+    /// This agent's Integrations tab (PARITY-SETTINGS §3), pushed from its menu.
+    case integrations(AgentListItem)
+    /// The global, user-scoped Integrations surface (the per-agent tab's
+    /// "Manage all integrations" hand-off).
+    case globalIntegrations
 
     private var key: String {
         switch self {
         case let .missions(agent): return "missions:\(agent.id)"
         case let .chat(route): return "chat:\(route.sessionKey)"
         case let .archived(agent): return "archived:\(agent.id)"
+        case let .aiModels(agent): return "aiModels:\(agent.id)"
+        case let .integrations(agent): return "integrations:\(agent.id)"
+        case .globalIntegrations: return "globalIntegrations"
         }
     }
 

--- a/mobile/ios/Houston/Features/Agents/AgentsView.swift
+++ b/mobile/ios/Houston/Features/Agents/AgentsView.swift
@@ -75,12 +75,21 @@ struct AgentsView: View {
             AgentMissionsView(
                 agent: agent,
                 onOpenChat: { path.append(.chat($0)) },
-                onOpenArchived: { path.append(.archived(agent)) }
+                onOpenArchived: { path.append(.archived(agent)) },
+                onOpenAIModels: { path.append(.aiModels(agent)) },
+                onOpenIntegrations: { path.append(.integrations(agent)) }
             )
         case let .chat(route):
             ChatView(agentId: route.agentId, conversationId: route.sessionKey, title: route.title)
         case let .archived(agent):
             AgentArchivedMissionsView(agent: agent, onOpen: { path.append(.chat($0)) })
+        case let .aiModels(agent):
+            AIModelsView(agentId: agent.id)
+        case let .integrations(agent):
+            AgentIntegrationsView(
+                agentId: agent.id, onManageAll: { path.append(.globalIntegrations) })
+        case .globalIntegrations:
+            IntegrationsView()
         }
     }
 

--- a/mobile/ios/HoustonTests/SdkClient/SdkClientTestSupport.swift
+++ b/mobile/ios/HoustonTests/SdkClient/SdkClientTestSupport.swift
@@ -59,6 +59,13 @@ enum BridgeTestJSON {
     return (try? JSONDecoder().decode(Wrap.self, from: data))?.sub
   }
 
+  /// The `scope` of a captured `subscribe` inbound message.
+  static func scope(from raw: String) -> String? {
+    struct Wrap: Decodable { let scope: String? }
+    guard let data = raw.data(using: .utf8) else { return nil }
+    return (try? JSONDecoder().decode(Wrap.self, from: data))?.scope
+  }
+
   /// Decode a JSON string literal into a model type.
   static func decode<T: Decodable>(_ type: T.Type, _ json: String) throws -> T {
     try JSONDecoder().decode(T.self, from: Data(json.utf8))

--- a/mobile/ios/README.md
+++ b/mobile/ios/README.md
@@ -53,7 +53,8 @@ mobile/ios/
     Core/Bridge/           SdkClient facade, Codable models, transport + native ports
     Core/Auth/             Supabase auth + SignInView
     DesignSystem/          tokens wrapper, Strings, shared styles
-    Features/              Agents, AgentMissions, Chat, MissionControl, NewMission
+    Features/              Agents, AgentMissions, Chat, MissionControl, NewMission,
+                           Settings, AIModels, Integrations
     Generated/             built at build time (gitignored): SDK bundle + tokens
   HoustonTests/            unit tests
   scripts/                 build-phase shell scripts


### PR DESCRIPTION
Completes the founder-requested surfaces per `mobile/PARITY-SETTINGS.md` (exact desktop names/order/copy/logos):

- **Settings tab** — workspace, appearance, language, **Account with Sign out**, contexts, report-bug, danger zone; honest disabled states where the wire lacks a surface (gap list documented in-code + report).
- **AI Models** — live wire-driven provider grid (catalog metadata merged on, never hardcoded), device-code/auth-code/API-key connect flows with correct polling cancellation, per-provider sign-out, per-agent model+effort selection; per-agent scoping explicit.
- **Integrations** — connected apps (remote logos), connect+poll flow, searchable catalog, per-agent grants with the 404-null vs `[]` tri-state as a proper enum.
- **Provider logos** — desktop's exact SVG path data via the shared decoder; pixel-identical marks.
- **Review fixes (failing-first)**: transient grants-read errors are retriable error states, never conflated with 'unsupported'; sign-out purges SdkClient scope caches on all exits (no cross-user stale snapshots).

**337/337** unit tests (+124 this wave). Adversarial review ran on the risk seams (device-code polling, grants tri-state, per-agent scoping, string parity, sign-out): 3 clean, 2 findings fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)