### PR TITLE
feat: Teams — agent templates UI (save, create from, manage)

### DIFF
--- a/app/src/components/organization/org-template-card.tsx
+++ b/app/src/components/organization/org-template-card.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@houston-ai/core";
+import { LayoutTemplate, Trash2 } from "lucide-react";
+
+interface OrgTemplateCardProps {
+  name: string;
+  description: string;
+  /** The composed summary line, e.g. "3 skills · Claude · 2 apps". */
+  meta: string;
+  /** "Created by …" line (already resolved to a name). */
+  createdBy: string;
+  /** Whether to show the delete affordance (owner or the template's creator). */
+  canDelete: boolean;
+  /** Accessible label for the delete action (already translated). */
+  deleteLabel: string;
+  onDelete: () => void;
+}
+
+/**
+ * One template tile in the Organization > Templates grid (Teams v2): a template
+ * glyph + name, its description, the plain-language summary line, who created it,
+ * and a delete action gated to the owner or the creator. Presentational only —
+ * the tab resolves every string and decides `canDelete`. The delete button is
+ * always visible (no hover-only affordance).
+ */
+export function OrgTemplateCard({
+  name,
+  description,
+  meta,
+  createdBy,
+  canDelete,
+  deleteLabel,
+  onDelete,
+}: OrgTemplateCardProps) {
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-border/50 bg-card p-4">
+      <div className="flex items-start gap-3">
+        <span
+          aria-hidden
+          className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-secondary text-muted-foreground"
+        >
+          <LayoutTemplate className="size-[18px]" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-medium text-foreground">{name}</p>
+          {description && (
+            <p className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+              {description}
+            </p>
+          )}
+        </div>
+        {canDelete && (
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="-mt-1 -mr-1 shrink-0 rounded-lg text-muted-foreground hover:text-destructive"
+            aria-label={deleteLabel}
+            onClick={onDelete}
+          >
+            <Trash2 className="size-4" />
+          </Button>
+        )}
+      </div>
+      <div className="flex items-center justify-between gap-3 text-xs text-muted-foreground">
+        <span className="truncate">{meta}</span>
+        <span className="shrink-0 truncate">{createdBy}</span>
+      </div>
+    </div>
+  );
+}

--- a/app/src/components/organization/org-templates-model.ts
+++ b/app/src/components/organization/org-templates-model.ts
@@ -1,0 +1,32 @@
+/**
+ * Pure, DOM-free logic for the Organization > Templates tab (Teams v2). Kept out
+ * of the view so the delete gate is unit-tested in isolation (node:test), never
+ * importing React. Model-brand labelling lives in `lib/template-summary`
+ * (`modelBrand`) so this tab and the create-from-template picker stay in sync.
+ */
+
+/** Inputs to the who-can-delete decision for one template. */
+export interface TemplateDeleteGate {
+  /** Is the caller the org owner? */
+  isOwner: boolean;
+  /** The template's creator user id. */
+  createdBy: string;
+  /** The caller's own user id, or null when the session isn't loaded. */
+  currentUserId: string | null;
+}
+
+/**
+ * Whether the caller may delete a template. Owners may delete any template; an
+ * admin may delete only the templates they created. Mirrors the gateway wire
+ * gate (`deleteOrgTemplate` 403s otherwise) — this only decides whether to show
+ * the affordance; the gateway stays the enforcer. Pure so it's unit-tested
+ * without React.
+ */
+export function canDeleteTemplate({
+  isOwner,
+  createdBy,
+  currentUserId,
+}: TemplateDeleteGate): boolean {
+  if (isOwner) return true;
+  return currentUserId !== null && createdBy === currentUserId;
+}

--- a/app/src/components/organization/org-view-model.ts
+++ b/app/src/components/organization/org-view-model.ts
@@ -7,13 +7,14 @@ import { canSeeMembers } from "../../lib/org-roles.ts";
  * (node:test), never importing React.
  */
 
-/** The four sections of the Organization dashboard, in tab order. */
-export type OrgTabId = "people" | "agents" | "activity" | "usage";
+/** The sections of the Organization dashboard, in tab order. */
+export type OrgTabId = "people" | "agents" | "templates" | "activity" | "usage";
 
 /** Tab ids in display order. Labels are supplied by the app via `t()`. */
 export const ORG_TAB_IDS: readonly OrgTabId[] = [
   "people",
   "agents",
+  "templates",
   "activity",
   "usage",
 ] as const;

--- a/app/src/components/organization/organization-view.tsx
+++ b/app/src/components/organization/organization-view.tsx
@@ -7,6 +7,7 @@ import ActivityTab from "./activity-tab";
 import AgentsTab from "./agents-tab";
 import MembersTab from "./members-tab";
 import { ORG_TAB_IDS, type OrgTabId } from "./org-view-model";
+import TemplatesTab from "./templates-tab";
 import UsageTab from "./usage-tab";
 
 /**
@@ -30,6 +31,7 @@ export interface OrgTabProps {
 const TAB_COMPONENTS: Record<OrgTabId, (props: OrgTabProps) => ReactNode> = {
   people: MembersTab,
   agents: AgentsTab,
+  templates: TemplatesTab,
   activity: ActivityTab,
   usage: UsageTab,
 };

--- a/app/src/components/organization/templates-tab.tsx
+++ b/app/src/components/organization/templates-tab.tsx
@@ -1,0 +1,122 @@
+import {
+  ConfirmDialog,
+  Empty,
+  EmptyDescription,
+  EmptyTitle,
+  Spinner,
+} from "@houston-ai/core";
+import type { TemplateSummary } from "@houston-ai/engine-client";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useDeleteTemplate, useOrgTemplates } from "../../hooks/queries";
+import { useSession } from "../../hooks/use-session";
+import { modelBrand } from "../../lib/template-summary";
+import { memberLabel } from "./org-roster";
+import { OrgTemplateCard } from "./org-template-card";
+import { canDeleteTemplate } from "./org-templates-model";
+import type { OrgTabProps } from "./organization-view";
+
+/**
+ * Organization > Templates: the org's saved agent templates as list cards
+ * (name, description, "3 skills · Claude · 2 apps", and who created it, resolved
+ * to a name against the roster). A confirm-gated delete is shown only to the
+ * owner or the template's creator — the gateway is the real enforcer, this hides
+ * an affordance the caller can't act on. Fresh orgs get an empty state nudging
+ * them to save an agent as a template. The shell already gates this view to a
+ * multiplayer owner/admin, so it never mounts elsewhere. Delete failures surface
+ * through the mutation's `call()` wrapper (toast + Report bug).
+ */
+export default function TemplatesTab({ ctx }: OrgTabProps) {
+  const { t } = useTranslation("teams");
+  const { data: session } = useSession();
+  const currentUserId = session?.user?.id ?? null;
+  const enabled = ctx.role === "owner" || ctx.role === "admin";
+  const { data: templates, isLoading, isError } = useOrgTemplates(enabled);
+  const deleteTemplate = useDeleteTemplate();
+  const [pendingDelete, setPendingDelete] = useState<TemplateSummary | null>(
+    null,
+  );
+
+  const members = ctx.org.members;
+
+  const metaLine = (template: TemplateSummary): string => {
+    const segments = [
+      t("templatesTab.card.skills", { count: template.skillCount }),
+      modelBrand(template.model),
+      template.allowedToolkitCount === null
+        ? t("templatesTab.card.allApps")
+        : t("templatesTab.card.apps", { count: template.allowedToolkitCount }),
+    ];
+    return segments.filter(Boolean).join(" · ");
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16">
+        <Spinner />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="py-10 text-sm text-muted-foreground">
+        {t("templatesTab.error")}
+      </p>
+    );
+  }
+
+  if (!templates || templates.length === 0) {
+    return (
+      <Empty className="mt-6">
+        <EmptyTitle>{t("templatesTab.empty.title")}</EmptyTitle>
+        <EmptyDescription>{t("templatesTab.empty.body")}</EmptyDescription>
+      </Empty>
+    );
+  }
+
+  return (
+    <div className="mt-2">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {templates.map((template) => (
+          <OrgTemplateCard
+            key={template.id}
+            name={template.name}
+            description={template.description}
+            meta={metaLine(template)}
+            createdBy={t("templatesTab.card.createdBy", {
+              name: memberLabel(template.createdBy, members),
+            })}
+            canDelete={canDeleteTemplate({
+              isOwner: ctx.isOwner,
+              createdBy: template.createdBy,
+              currentUserId,
+            })}
+            deleteLabel={t("templatesTab.deleteLabel", {
+              name: template.name,
+            })}
+            onDelete={() => setPendingDelete(template)}
+          />
+        ))}
+      </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+        title={t("templatesTab.deleteConfirm.title", {
+          name: pendingDelete?.name ?? "",
+        })}
+        description={t("templatesTab.deleteConfirm.description")}
+        confirmLabel={t("templatesTab.deleteConfirm.confirm")}
+        cancelLabel={t("templatesTab.deleteConfirm.cancel")}
+        onConfirm={() => {
+          const target = pendingDelete;
+          setPendingDelete(null);
+          if (target) deleteTemplate.mutate(target.id);
+        }}
+      />
+    </div>
+  );
+}

--- a/app/src/components/shell/agent-picker-step.tsx
+++ b/app/src/components/shell/agent-picker-step.tsx
@@ -1,4 +1,5 @@
 import { Input } from "@houston-ai/core";
+import type { TemplateSummary } from "@houston-ai/engine-client";
 import { Search } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
@@ -9,6 +10,7 @@ import {
 import type { AgentDefinition } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 import { SkillCard } from "../skill-card";
+import { CreateFromTemplatePicker } from "./create-from-template-picker";
 import { AgentCard } from "./experience-card";
 
 interface AgentPickerStepProps {
@@ -17,6 +19,16 @@ interface AgentPickerStepProps {
   agents: AgentDefinition[];
   onSelect: (id: string) => void;
   onCreateWithAi: () => void;
+  /**
+   * Multiplayer only (Teams v2): the org's agent templates. Empty/undefined on
+   * single-player, self-host, or for a plain member — the template section then
+   * never renders and the flow is byte-identical to today.
+   */
+  templates?: TemplateSummary[];
+  /** Id of the template being stamped into an agent, or null. */
+  creatingTemplateId?: string | null;
+  /** Create an agent from the chosen template. */
+  onSelectTemplate?: (id: string) => void;
 }
 
 export function AgentPickerStep({
@@ -25,6 +37,9 @@ export function AgentPickerStep({
   agents,
   onSelect,
   onCreateWithAi,
+  templates,
+  creatingTemplateId = null,
+  onSelectTemplate,
 }: AgentPickerStepProps) {
   const { t, i18n } = useTranslation(["shell", "portable", "agents"]);
   const setImportOpen = useUIStore((s) => s.setImportFromFriendOpen);
@@ -63,6 +78,17 @@ export function AgentPickerStep({
 
   return (
     <>
+      {/* Start from a template (Teams v2) — pinned above "Create" when the org
+          has templates and the caller can stamp them. Absent otherwise, so the
+          non-teams flow is unchanged. */}
+      {templates && templates.length > 0 && onSelectTemplate && (
+        <CreateFromTemplatePicker
+          templates={templates}
+          creatingId={creatingTemplateId}
+          onSelect={onSelectTemplate}
+        />
+      )}
+
       {/* Create — three uniform cards, pinned above the library. These are the
           ways to make a NEW agent, always one click away (search below only
           narrows the library). */}

--- a/app/src/components/shell/create-from-template-picker.tsx
+++ b/app/src/components/shell/create-from-template-picker.tsx
@@ -1,0 +1,78 @@
+import type { TemplateSummary } from "@houston-ai/engine-client";
+import { useTranslation } from "react-i18next";
+import { templateSummaryParts } from "../../lib/template-summary";
+import { SkillCard } from "../skill-card";
+
+interface CreateFromTemplatePickerProps {
+  /** The org's templates, newest first. Assumed non-empty by the caller. */
+  templates: TemplateSummary[];
+  /** Id of the template currently being stamped into an agent, or null. */
+  creatingId: string | null;
+  /** Create a new agent from the chosen template. */
+  onSelect: (id: string) => void;
+}
+
+/**
+ * The "Start from a template" section of the new-agent picker (Teams v2). Lists
+ * the org's templates as cards with a plain-language summary ("3 skills · Claude
+ * · 2 apps"); picking one stamps out an agent. Multiplayer + owner/admin only —
+ * the caller gates rendering on a non-empty template list, so single-player and
+ * self-host never see it.
+ */
+export function CreateFromTemplatePicker({
+  templates,
+  creatingId,
+  onSelect,
+}: CreateFromTemplatePickerProps) {
+  const { t } = useTranslation("teams");
+  const creating = creatingId !== null;
+
+  return (
+    <div className="shrink-0 px-6 pb-5 border-b border-border/50">
+      <h3 className="text-sm font-medium text-foreground mb-3">
+        {t("templates.pickerTitle")}
+      </h3>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {templates.map((tpl) => {
+          const isCreating = creatingId === tpl.id;
+          return (
+            <SkillCard
+              key={tpl.id}
+              image="memo"
+              title={tpl.name}
+              description={
+                isCreating
+                  ? t("templates.settingUp")
+                  : tpl.description || undefined
+              }
+              footer={isCreating ? undefined : summaryLine(tpl, t)}
+              busy={isCreating}
+              disabled={creating && !isCreating}
+              onClick={() => onSelect(tpl.id)}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+/** The middot-joined summary: skills · model brand · apps. */
+function summaryLine(
+  tpl: TemplateSummary,
+  t: ReturnType<typeof useTranslation<"teams">>["t"],
+) {
+  const parts = templateSummaryParts(tpl);
+  const pieces = [t("templates.summary.skills", { count: parts.skillCount })];
+  if (parts.model) pieces.push(parts.model);
+  pieces.push(
+    parts.allApps
+      ? t("templates.summary.allApps")
+      : t("templates.summary.apps", { count: parts.appCount ?? 0 }),
+  );
+  return (
+    <span className="text-[11px] text-muted-foreground">
+      {pieces.join(" · ")}
+    </span>
+  );
+}

--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -11,6 +11,7 @@ import { useTranslation } from "react-i18next";
 import { STORE_TEMPLATE_IDS } from "../../agents/builtin/store-catalog";
 import { loadStoreTemplate } from "../../agents/builtin/store-template-loader";
 import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
+import { useCreateFromTemplate } from "../../hooks/use-create-from-template";
 import { logger } from "../../lib/logger";
 import { getDefaultModel } from "../../lib/providers";
 import { tauriConfig, tauriProvider, tauriRoutines } from "../../lib/tauri";
@@ -54,6 +55,17 @@ export function CreateAgentDialog() {
   const [existingPath, setExistingPath] = useState<string | null>(null);
   const [provider, setProvider] = useState<string>("anthropic");
   const [model, setModel] = useState<string>(getDefaultModel("anthropic"));
+
+  // "Create from template" (Teams v2) — multiplayer + create-capable + open
+  // gated inside the hook; `[]` (and no picker section) everywhere else.
+  const { templates, creatingTemplateId, createFromTemplate } =
+    useCreateFromTemplate({
+      open,
+      onCreated: () => {
+        useUIStore.getState().setViewMode(DEFAULT_TAB_ID);
+        handleClose();
+      },
+    });
 
   // Reset form on close. On open, sync the picker to the sticky last-used
   // pair. Reading on open (not mount) prevents the old "stale workspace
@@ -191,6 +203,9 @@ export function CreateAgentDialog() {
               search={search}
               onSearchChange={setSearch}
               agents={agentDefs}
+              templates={templates}
+              creatingTemplateId={creatingTemplateId}
+              onSelectTemplate={createFromTemplate}
               onSelect={(id) => {
                 setSelectedConfigId(id);
                 setGeneratedClaudeMd(undefined);

--- a/app/src/components/tabs/job-description-tab.tsx
+++ b/app/src/components/tabs/job-description-tab.tsx
@@ -25,6 +25,7 @@ import { isConfigReadOnly } from "./job-description-access";
 import { InstructionsContent, type SubTab } from "./job-description-parts";
 import { LearningsContent } from "./learnings-content";
 import { ManagedAgentBanner } from "./managed-agent-banner";
+import { SaveAsTemplateSection } from "./save-as-template-section";
 import { SkillsContent } from "./skills-content";
 import { useSkillSurface } from "./use-skill-surface";
 
@@ -140,8 +141,9 @@ export default function JobDescriptionTab({ agent }: TabProps) {
 
         {activeTab === "general" && (
           <>
-            <div className="mx-auto max-w-xl px-8 pt-10 empty:hidden">
+            <div className="mx-auto max-w-xl px-8 pt-10 empty:hidden space-y-10">
               <AgentAccessSection agent={agent} />
+              <SaveAsTemplateSection agent={agent} />
             </div>
             <AgentSettingsContent
               name={agent.name}

--- a/app/src/components/tabs/save-as-template-dialog.tsx
+++ b/app/src/components/tabs/save-as-template-dialog.tsx
@@ -1,0 +1,182 @@
+import {
+  AsyncButton,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+  Textarea,
+} from "@houston-ai/core";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  useAgentConfig,
+  useCreateTemplate,
+  useInstructions,
+  useSkills,
+} from "../../hooks/queries";
+import { useAgentSettings } from "../../hooks/queries/use-agent-settings";
+import { useCapabilities } from "../../hooks/use-capabilities";
+import { isMultiplayer } from "../../lib/org-roles";
+import { tauriSkills } from "../../lib/tauri";
+import type { Agent } from "../../lib/types";
+import { useUIStore } from "../../stores/ui";
+import {
+  allowedToolkitsReady,
+  assembleSpec,
+  canSaveTemplate,
+  summarizeSpec,
+} from "./save-as-template-model";
+import { CapturedSummary } from "./save-as-template-summary";
+
+/**
+ * Name + description + a plain-language "what this captures" summary, assembled
+ * from the queries the manager is already viewing (instructions, skills, model
+ * config, allowed apps). On submit it loads each skill's body, builds the
+ * {@link assembleSpec} spec, and POSTs it. Errors surface via the `call()` path
+ * (red toast + Report bug) behind the mutation and the skill loads. Gated to
+ * agent-managers by {@link SaveAsTemplateSection}; the gateway re-enforces.
+ */
+export function SaveAsTemplateDialog({
+  agent,
+  open,
+  onOpenChange,
+}: {
+  agent: Agent;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useTranslation("teams");
+  const { capabilities } = useCapabilities();
+  const multiplayer = isMultiplayer(capabilities);
+  const path = open ? agent.folderPath : undefined;
+  const { data: instructions } = useInstructions(path);
+  const { data: skills } = useSkills(path);
+  const { data: config } = useAgentConfig(path);
+  const settings = useAgentSettings(agent.id, open && multiplayer);
+  const createTemplate = useCreateTemplate();
+  const addToast = useUIStore((s) => s.addToast);
+
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+
+  // In multiplayer the real ceiling must have loaded before we capture it: an
+  // absent/errored settings fetch would read as null = ALL apps and silently
+  // over-permission the template past the agent's restricted set.
+  const ceilingReady = allowedToolkitsReady(
+    multiplayer,
+    settings.data !== undefined,
+  );
+  const allowedToolkits = settings.data?.allowedToolkits ?? null;
+  const segments = summarizeSpec({
+    instructions: instructions ?? "",
+    skillCount: skills?.length ?? 0,
+    provider: config?.provider,
+    model: config?.model,
+    allowedToolkits,
+  });
+
+  const close = () => {
+    onOpenChange(false);
+    setName("");
+    setDescription("");
+  };
+
+  const handleSave = async () => {
+    if (!canSaveTemplate(name) || !ceilingReady) return;
+    try {
+      const details = await Promise.all(
+        (skills ?? []).map((s) => tauriSkills.load(agent.folderPath, s.name)),
+      );
+      const spec = assembleSpec({
+        instructions: instructions ?? "",
+        skills: details.map((d) => ({ name: d.name, content: d.content })),
+        provider: config?.provider,
+        model: config?.model,
+        effort: config?.effort,
+        allowedToolkits,
+      });
+      await createTemplate.mutateAsync({
+        name: name.trim(),
+        description: description.trim(),
+        spec,
+      });
+      addToast({
+        variant: "success",
+        title: t("templates.save.toast.title"),
+        description: t("templates.save.toast.body", { name: name.trim() }),
+      });
+      close();
+    } catch {
+      // A failing skill load or template create already surfaced the real
+      // reason as a red toast + Report bug (the `call()` wrapper). Swallow here
+      // so the dialog stays open with the user's draft intact.
+    }
+  };
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(o) => (o ? onOpenChange(true) : close())}
+    >
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("templates.save.dialog.title")}</DialogTitle>
+          <DialogDescription>
+            {t("templates.save.dialog.subtitle", { name: agent.name })}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-1.5">
+            <label
+              htmlFor="save-template-name"
+              className="text-xs text-muted-foreground"
+            >
+              {t("templates.save.nameLabel")}
+            </label>
+            <Input
+              id="save-template-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder={t("templates.save.namePlaceholder")}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <label
+              htmlFor="save-template-description"
+              className="text-xs text-muted-foreground"
+            >
+              {t("templates.save.descriptionLabel")}
+            </label>
+            <Textarea
+              id="save-template-description"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
+              placeholder={t("templates.save.descriptionPlaceholder")}
+            />
+          </div>
+
+          <CapturedSummary segments={segments} loading={!ceilingReady} />
+        </div>
+
+        <DialogFooter>
+          <Button variant="secondary" className="rounded-full" onClick={close}>
+            {t("templates.save.cancel")}
+          </Button>
+          <AsyncButton
+            className="rounded-full"
+            disabled={!canSaveTemplate(name) || !ceilingReady}
+            onClick={() => handleSave()}
+          >
+            {t("templates.save.submit")}
+          </AsyncButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/tabs/save-as-template-model.ts
+++ b/app/src/components/tabs/save-as-template-model.ts
@@ -1,0 +1,117 @@
+/**
+ * Pure, DOM/i18n-free helpers for the "Save as template" dialog (Teams v2).
+ *
+ * Two jobs, both unit-tested in isolation: assemble a {@link TemplateSpec} from
+ * the data a manager is already viewing (instructions, skill bodies, model
+ * config, allowed apps), and describe that spec as an ordered list of segments
+ * the dialog renders as a plain-language "what this captures" summary
+ * ("Instructions · 3 skills · Claude · 2 allowed apps"). The segments carry
+ * only counts + ids so the component can localize each part — no English here.
+ */
+
+import type { TemplateSpec } from "@houston-ai/engine-client";
+
+export interface AssembleSpecInput {
+  /** The agent's CLAUDE.md instructions (verbatim; the gateway stores as-is). */
+  instructions: string;
+  /** Each skill's name + SKILL.md body, already loaded by the caller. */
+  skills: { name: string; content: string }[];
+  provider?: string;
+  model?: string;
+  effort?: string;
+  /** The allowed-app ceiling; `null` = all apps allowed. */
+  allowedToolkits: string[] | null;
+}
+
+/**
+ * Map already-loaded agent data into a {@link TemplateSpec}. Optional model
+ * fields are omitted (not emitted as empty strings) when absent, so a template
+ * that pins no model carries none.
+ */
+export function assembleSpec(input: AssembleSpecInput): TemplateSpec {
+  const spec: TemplateSpec = {
+    instructions: input.instructions,
+    skills: input.skills.map((s) => ({ name: s.name, content: s.content })),
+    allowedToolkits: input.allowedToolkits,
+  };
+  if (input.provider) spec.provider = input.provider;
+  if (input.model) spec.model = input.model;
+  if (input.effort) spec.effort = input.effort;
+  return spec;
+}
+
+/** One part of the plain-language "what this captures" summary. */
+export type SpecSummarySegment =
+  | { kind: "instructions" }
+  | { kind: "skills"; count: number }
+  | { kind: "model"; provider?: string; model?: string }
+  | { kind: "allApps" }
+  | { kind: "apps"; count: number };
+
+export interface SummaryInput {
+  instructions: string;
+  skillCount: number;
+  provider?: string;
+  model?: string;
+  allowedToolkits: string[] | null;
+}
+
+/**
+ * Describe what a template would capture as ordered segments. Instructions and
+ * skills segments appear only when there is something to capture; the model
+ * segment only when a model is pinned; the apps segment is always present
+ * (`allApps` when unrestricted, else the count of allowed apps).
+ */
+export function summarizeSpec(input: SummaryInput): SpecSummarySegment[] {
+  const segments: SpecSummarySegment[] = [];
+  if (input.instructions.trim().length > 0)
+    segments.push({ kind: "instructions" });
+  if (input.skillCount > 0) {
+    segments.push({ kind: "skills", count: input.skillCount });
+  }
+  if (input.provider || input.model) {
+    segments.push({
+      kind: "model",
+      provider: input.provider,
+      model: input.model,
+    });
+  }
+  if (input.allowedToolkits === null) segments.push({ kind: "allApps" });
+  else segments.push({ kind: "apps", count: input.allowedToolkits.length });
+  return segments;
+}
+
+/**
+ * The friendly brand name for a pinned provider, or `null` for an unknown one
+ * (brand names are not translated). Falls back to the raw model id at the call
+ * site when this is `null`.
+ */
+export function providerBrand(provider?: string): string | null {
+  switch (provider) {
+    case "anthropic":
+      return "Claude";
+    case "openai":
+      return "OpenAI";
+    default:
+      return null;
+  }
+}
+
+/** Whether a template is savable: a non-empty name after trimming. */
+export function canSaveTemplate(name: string): boolean {
+  return name.trim().length > 0;
+}
+
+/**
+ * Whether the allowed-app ceiling is known and safe to capture. In multiplayer
+ * the agent-settings query MUST have resolved with data first: absent data
+ * (still loading, or the fetch errored) reads as `null` = ALL apps, which would
+ * silently over-permission the template past the agent's real restricted set.
+ * In single-player there is no ceiling concept, so it is always ready.
+ */
+export function allowedToolkitsReady(
+  multiplayer: boolean,
+  hasSettingsData: boolean,
+): boolean {
+  return !multiplayer || hasSettingsData;
+}

--- a/app/src/components/tabs/save-as-template-section.tsx
+++ b/app/src/components/tabs/save-as-template-section.tsx
@@ -1,0 +1,44 @@
+import { Button } from "@houston-ai/core";
+import { LayoutTemplate } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useCapabilities } from "../../hooks/use-capabilities";
+import { isAgentManager, isMultiplayer } from "../../lib/org-roles";
+import type { Agent } from "../../lib/types";
+import { SaveAsTemplateDialog } from "./save-as-template-dialog";
+
+/**
+ * The "Save as template" manager action on an agent's General settings. Renders
+ * only in multiplayer mode AND only for an agent-manager of this agent (matrix
+ * v2); single-player / self-host and non-managers see nothing. Opens the
+ * {@link SaveAsTemplateDialog}. The gateway enforces the same authority.
+ */
+export function SaveAsTemplateSection({ agent }: { agent: Agent }) {
+  const { t } = useTranslation("teams");
+  const { capabilities } = useCapabilities();
+  const [open, setOpen] = useState(false);
+
+  if (!isMultiplayer(capabilities) || !isAgentManager(capabilities, agent)) {
+    return null;
+  }
+
+  return (
+    <section>
+      <h2 className="mb-1 text-lg font-semibold">
+        {t("templates.save.sectionTitle")}
+      </h2>
+      <p className="mb-4 text-sm text-muted-foreground">
+        {t("templates.save.sectionHelper")}
+      </p>
+      <Button
+        variant="secondary"
+        className="rounded-full"
+        onClick={() => setOpen(true)}
+      >
+        <LayoutTemplate className="size-4" />
+        {t("templates.save.button")}
+      </Button>
+      <SaveAsTemplateDialog agent={agent} open={open} onOpenChange={setOpen} />
+    </section>
+  );
+}

--- a/app/src/components/tabs/save-as-template-summary.tsx
+++ b/app/src/components/tabs/save-as-template-summary.tsx
@@ -1,0 +1,60 @@
+import { Spinner } from "@houston-ai/core";
+import { Fragment } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  providerBrand,
+  type SpecSummarySegment,
+} from "./save-as-template-model";
+
+/** One summary segment ("3 skills", "Claude", ...) as localized text. */
+function segmentLabel(
+  segment: SpecSummarySegment,
+  t: (key: string, opts?: Record<string, unknown>) => string,
+): string {
+  switch (segment.kind) {
+    case "instructions":
+      return t("templates.save.summary.instructions");
+    case "skills":
+      return t("templates.save.summary.skills", { count: segment.count });
+    case "model":
+      return providerBrand(segment.provider) ?? segment.model ?? "";
+    case "allApps":
+      return t("templates.save.summary.allApps");
+    case "apps":
+      return t("templates.save.summary.apps", { count: segment.count });
+  }
+}
+
+/**
+ * The plain-language "what this captures" block — an interpunct-joined list of
+ * the template's contents ("Instructions · 3 skills · Claude · 2 allowed apps"),
+ * or a spinner while the source queries are still loading.
+ */
+export function CapturedSummary({
+  segments,
+  loading,
+}: {
+  segments: SpecSummarySegment[];
+  loading: boolean;
+}) {
+  const { t } = useTranslation("teams");
+  return (
+    <div className="rounded-xl bg-secondary px-4 py-3">
+      <p className="mb-1 text-xs font-medium text-foreground">
+        {t("templates.save.capturedTitle")}
+      </p>
+      {loading ? (
+        <Spinner className="size-4" />
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          {segments.map((segment, i) => (
+            <Fragment key={segment.kind}>
+              {i > 0 && <span className="mx-1.5">·</span>}
+              {segmentLabel(segment, t)}
+            </Fragment>
+          ))}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/app/src/hooks/queries/index.ts
+++ b/app/src/hooks/queries/index.ts
@@ -43,6 +43,12 @@ export {
   useSetMemberRole,
 } from "./use-org";
 export { useOrgAudit } from "./use-org-audit";
+export {
+  useCreateTemplate,
+  useDeleteTemplate,
+  useOrgTemplate,
+  useOrgTemplates,
+} from "./use-org-templates";
 export { USAGE_DEFAULT_DAYS, useOrgUsage } from "./use-org-usage";
 export {
   useCancelRoutineRun,

--- a/app/src/hooks/queries/use-org-templates.ts
+++ b/app/src/hooks/queries/use-org-templates.ts
@@ -1,0 +1,71 @@
+import type { TemplateSpec } from "@houston-ai/engine-client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { queryKeys } from "../../lib/query-keys";
+import { tauriOrg } from "../../lib/tauri";
+
+/**
+ * The org's agent templates (Teams v2), newest first, as list-card summaries.
+ *
+ * Multiplayer-only and owner/admin-only: on a single-player/self-host host the
+ * gateway 404s (the engine-client degrades that to `[]`), and the Templates tab
+ * is never rendered anyway. The caller gates `enabled` on
+ * `capabilities.multiplayer` + role. One org per user, so it's app-scoped.
+ *
+ * No `HoustonEvent` maps to template writes; the create/delete mutations below
+ * invalidate this key directly, and a window-focus refetch covers a teammate's
+ * change. Failures surface via the `tauriOrg.templates.*` → `call()` path
+ * (toast + Report bug), so no `onError` is needed here.
+ */
+export function useOrgTemplates(enabled: boolean) {
+  return useQuery({
+    queryKey: queryKeys.orgTemplates(),
+    queryFn: () => tauriOrg.templates.list(),
+    enabled,
+    staleTime: 30_000,
+    refetchOnWindowFocus: true,
+  });
+}
+
+/**
+ * One template with its full `spec` (Teams v2), fetched lazily by id — only when
+ * a caller actually needs the whole configuration (e.g. inspecting it), since
+ * the create-from-template flow passes the id to the gateway rather than
+ * shipping the spec back. Stays disabled until an `id` is chosen. A deleted or
+ * unsupported template resolves to `null` (the engine-client swallows the 404).
+ */
+export function useOrgTemplate(id: string | null, enabled = true) {
+  return useQuery({
+    queryKey: queryKeys.orgTemplate(id ?? ""),
+    queryFn: () => tauriOrg.templates.get(id as string),
+    enabled: enabled && !!id,
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * The mutations below carry no `onError`: their `mutationFn` routes through the
+ * `tauriOrg.templates.*` wrappers, each wrapped by the `call()` adapter in
+ * `lib/tauri.ts`, which already surfaces the real error as a red toast AND
+ * reports it to Sentry before re-throwing. Adding an `onError` would double-toast.
+ */
+export function useCreateTemplate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (input: {
+      name: string;
+      description: string;
+      spec: TemplateSpec;
+    }) => tauriOrg.templates.create(input),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.orgTemplates() }),
+  });
+}
+
+export function useDeleteTemplate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => tauriOrg.templates.remove(id),
+    onSuccess: () =>
+      qc.invalidateQueries({ queryKey: queryKeys.orgTemplates() }),
+  });
+}

--- a/app/src/hooks/use-create-from-template.ts
+++ b/app/src/hooks/use-create-from-template.ts
@@ -1,0 +1,81 @@
+import type { TemplateSummary } from "@houston-ai/engine-client";
+import { useCallback, useEffect, useState } from "react";
+import { isMultiplayer } from "../lib/org-roles";
+import { useAgentStore } from "../stores/agents";
+import { useWorkspaceStore } from "../stores/workspaces";
+import { useOrgTemplates } from "./queries/use-org-templates";
+import { useCanCreateAgents } from "./use-can-create-agents";
+import { useCapabilities } from "./use-capabilities";
+
+/**
+ * "Create from template" wiring for the new-agent dialog (Teams v2). Fetches the
+ * org's templates and stamps a new agent from the chosen one.
+ *
+ * Gated to a multiplayer host + a caller who may create agents + the dialog
+ * being open: on single-player/self-host (or for a plain member) the query
+ * stays disabled and `templates` is `[]`, so the picker section never renders
+ * and the create flow is byte-identical to today.
+ *
+ * The new agent takes the template's name; the gateway applies the template's
+ * instructions, skills, model, and allowed apps in the background (the agent
+ * list reacts to `AgentsChanged` when that lands), so there is deliberately NO
+ * local provider/model write here — that would fight the template's own model.
+ */
+export function useCreateFromTemplate(opts: {
+  /** Whether the new-agent dialog is open (gates the query + resets state). */
+  open: boolean;
+  /** Called after the agent is created, to reveal it and close the dialog. */
+  onCreated: () => void;
+}): {
+  templates: TemplateSummary[];
+  creatingTemplateId: string | null;
+  createFromTemplate: (templateId: string) => Promise<void>;
+} {
+  const { open, onCreated } = opts;
+  const { capabilities } = useCapabilities();
+  const { canCreate } = useCanCreateAgents();
+  const currentWorkspace = useWorkspaceStore((s) => s.current);
+  const createAgent = useAgentStore((s) => s.create);
+  const [creatingTemplateId, setCreatingTemplateId] = useState<string | null>(
+    null,
+  );
+
+  const enabled = open && isMultiplayer(capabilities) && canCreate;
+  const { data: templates = [] } = useOrgTemplates(enabled);
+
+  // Clear the in-flight card state whenever the dialog closes.
+  useEffect(() => {
+    if (!open) setCreatingTemplateId(null);
+  }, [open]);
+
+  const createFromTemplate = useCallback(
+    async (templateId: string) => {
+      const tpl = templates.find((x) => x.id === templateId);
+      if (creatingTemplateId || !tpl || !currentWorkspace) return;
+      setCreatingTemplateId(templateId);
+      try {
+        await createAgent(
+          currentWorkspace.id,
+          tpl.name,
+          "blank",
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          templateId,
+        );
+      } catch {
+        // createAgent routes through the tauri `call()` wrapper, which already
+        // surfaced the real error as a toast + Sentry report. Just clear the
+        // in-flight state so the card is clickable again.
+        setCreatingTemplateId(null);
+        return;
+      }
+      onCreated();
+    },
+    [templates, creatingTemplateId, currentWorkspace, createAgent, onCreated],
+  );
+
+  return { templates, creatingTemplateId, createFromTemplate };
+}

--- a/app/src/lib/query-keys.ts
+++ b/app/src/lib/query-keys.ts
@@ -79,4 +79,13 @@ export const queryKeys = {
    * this and the agent's grant set (the gateway prunes disallowed grants).
    */
   agentSettings: (agentId: string) => ["agent-settings", agentId] as const,
+  /**
+   * Teams v2: the org's agent templates. `orgTemplates` is the list of
+   * summaries (app-scoped — one org per user); `orgTemplate` is one template's
+   * full spec, fetched lazily by id only when a caller needs the whole
+   * configuration (creating an agent from it). Both are served only by a Teams
+   * gateway; the surface gates on `capabilities.multiplayer`.
+   */
+  orgTemplates: () => ["org-templates"] as const,
+  orgTemplate: (id: string) => ["org-template", id] as const,
 };

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -213,6 +213,7 @@ export const tauriAgents = {
     installedPath?: string,
     seeds?: Record<string, string>,
     existingPath?: string,
+    templateId?: string,
   ) =>
     call<CreateAgentResult>("create_agent", async () => {
       const r = await getEngine().createAgent(workspaceId, {
@@ -223,6 +224,7 @@ export const tauriAgents = {
         installedPath,
         seeds,
         existingPath,
+        templateId,
       });
       return {
         agent: toAgent(r.agent),
@@ -1400,4 +1402,26 @@ export const tauriOrg = {
   /** Per-agent/user usage counters over the last `days` (owner org-wide; admin
    *  their managed agents; plain members 403). */
   usage: (days: number) => call("org_usage", () => getEngine().orgUsage(days)),
+  /**
+   * Agent templates (Teams v2). Reads degrade to `[]`/`null` on a non-Teams
+   * host (the engine-client/adapter swallow the 404); the surface gates on
+   * `capabilities.multiplayer`. Every call routes through `call()` so a failure
+   * reaches the user as a toast + Report bug, same as the wrappers above.
+   */
+  templates: {
+    list: () =>
+      call("list_org_templates", () => getEngine().listOrgTemplates()),
+    get: (id: string) =>
+      call("get_org_template", () => getEngine().getOrgTemplate(id)),
+    create: (input: {
+      name: string;
+      description: string;
+      spec: import("@houston-ai/engine-client").TemplateSpec;
+    }) =>
+      call("create_org_template", () => getEngine().createOrgTemplate(input)),
+    remove: (id: string) =>
+      call<void>("delete_org_template", () =>
+        getEngine().deleteOrgTemplate(id),
+      ),
+  },
 };

--- a/app/src/lib/template-summary.ts
+++ b/app/src/lib/template-summary.ts
@@ -1,0 +1,68 @@
+import type { TemplateSummary } from "@houston-ai/engine-client";
+
+/**
+ * Pure, DOM/i18n-free logic for the "create from template" picker (Teams v2).
+ * Turns a {@link TemplateSummary} into the pieces of its one-line description
+ * ("3 skills · Claude · 2 apps"). The component joins the localized parts; only
+ * the shape logic lives here so it unit-tests under bare Node.
+ */
+
+/**
+ * Map a template's pinned model id to its consumer-facing brand family
+ * ("Claude", "GPT", "Gemini") for the summary line. Brand names are never
+ * translated (see the i18n glossary), so they are literals here. An unknown id
+ * falls back to the raw id rather than being dropped — the summary must never
+ * silently omit a model the template pins. Returns `null` when no model is set.
+ */
+export function modelBrand(modelId: string | undefined | null): string | null {
+  if (!modelId) return null;
+  const id = modelId.toLowerCase();
+  if (
+    id.startsWith("claude") ||
+    id.includes("sonnet") ||
+    id.includes("opus") ||
+    id.includes("haiku") ||
+    id.includes("fable")
+  ) {
+    return "Claude";
+  }
+  if (
+    id.startsWith("gpt") ||
+    id.startsWith("o1") ||
+    id.startsWith("o3") ||
+    id.startsWith("o4") ||
+    id.includes("codex")
+  ) {
+    return "GPT";
+  }
+  if (id.startsWith("gemini")) return "Gemini";
+  return modelId;
+}
+
+/** The structured, localization-ready pieces of a template's summary line. */
+export interface TemplateSummaryParts {
+  /** Number of skills the template captures (always shown). */
+  skillCount: number;
+  /** Brand family of the pinned model, or `null` when the template pins none. */
+  model: string | null;
+  /** `true` when every app is allowed (`allowedToolkitCount === null`). */
+  allApps: boolean;
+  /** Count of allowed apps when restricted; `null` when {@link allApps}. */
+  appCount: number | null;
+}
+
+/**
+ * Derive the summary pieces from a template's cheap summary fields. The caller
+ * localizes and joins them (skills → model brand → apps) with a middot.
+ */
+export function templateSummaryParts(
+  t: Pick<TemplateSummary, "skillCount" | "model" | "allowedToolkitCount">,
+): TemplateSummaryParts {
+  const allApps = t.allowedToolkitCount === null;
+  return {
+    skillCount: t.skillCount,
+    model: modelBrand(t.model),
+    allApps,
+    appCount: allApps ? null : t.allowedToolkitCount,
+  };
+}

--- a/app/src/locales/en/teams.json
+++ b/app/src/locales/en/teams.json
@@ -34,6 +34,7 @@
     "tabs": {
       "people": "People",
       "agents": "Agents",
+      "templates": "Templates",
       "activity": "Activity",
       "usage": "Usage"
     },
@@ -178,5 +179,66 @@
     },
     "lastOpened": "Opened {{time}}",
     "open": "Open {{name}}"
+  },
+  "templates": {
+    "pickerTitle": "Start from a template",
+    "settingUp": "Setting up your agent...",
+    "summary": {
+      "skills_one": "{{count}} skill",
+      "skills_other": "{{count}} skills",
+      "apps_one": "{{count}} app",
+      "apps_other": "{{count}} apps",
+      "allApps": "All apps"
+    },
+    "save": {
+      "sectionTitle": "Save as template",
+      "sectionHelper": "Capture this agent's setup as a reusable template your team can start new agents from.",
+      "button": "Save as template",
+      "dialog": {
+        "title": "Save as template",
+        "subtitle": "Reuse {{name}}'s setup to start new agents just like it."
+      },
+      "nameLabel": "Template name",
+      "namePlaceholder": "e.g. Sales Agent",
+      "descriptionLabel": "Description",
+      "descriptionPlaceholder": "What is this template for? (optional)",
+      "capturedTitle": "What this captures",
+      "summary": {
+        "instructions": "Instructions",
+        "skills_one": "{{count}} skill",
+        "skills_other": "{{count}} skills",
+        "allApps": "All apps allowed",
+        "apps_one": "{{count}} allowed app",
+        "apps_other": "{{count}} allowed apps"
+      },
+      "cancel": "Cancel",
+      "submit": "Save template",
+      "toast": {
+        "title": "Template saved",
+        "body": "{{name}} is ready to reuse."
+      }
+    }
+  },
+  "templatesTab": {
+    "error": "Couldn't load templates.",
+    "empty": {
+      "title": "No templates yet",
+      "body": "Save an agent as a template to reuse its setup across your team."
+    },
+    "card": {
+      "skills_one": "{{count}} skill",
+      "skills_other": "{{count}} skills",
+      "apps_one": "{{count}} app",
+      "apps_other": "{{count}} apps",
+      "allApps": "All apps",
+      "createdBy": "Created by {{name}}"
+    },
+    "deleteLabel": "Delete {{name}}",
+    "deleteConfirm": {
+      "title": "Delete {{name}}?",
+      "description": "This template will be removed for everyone in your organization. Agents already created from it aren't affected.",
+      "confirm": "Delete",
+      "cancel": "Cancel"
+    }
   }
 }

--- a/app/src/locales/es/teams.json
+++ b/app/src/locales/es/teams.json
@@ -34,6 +34,7 @@
     "tabs": {
       "people": "Personas",
       "agents": "Agentes",
+      "templates": "Plantillas",
       "activity": "Actividad",
       "usage": "Uso"
     },
@@ -178,5 +179,66 @@
     },
     "lastOpened": "Abierto {{time}}",
     "open": "Abrir {{name}}"
+  },
+  "templates": {
+    "pickerTitle": "Empezar desde una plantilla",
+    "settingUp": "Configurando tu agente...",
+    "summary": {
+      "skills_one": "{{count}} habilidad",
+      "skills_other": "{{count}} habilidades",
+      "apps_one": "{{count}} app",
+      "apps_other": "{{count}} apps",
+      "allApps": "Todas las apps"
+    },
+    "save": {
+      "sectionTitle": "Guardar como plantilla",
+      "sectionHelper": "Captura la configuración de este agente como una plantilla reutilizable para crear nuevos agentes con tu equipo.",
+      "button": "Guardar como plantilla",
+      "dialog": {
+        "title": "Guardar como plantilla",
+        "subtitle": "Reutiliza la configuración de {{name}} para crear nuevos agentes iguales."
+      },
+      "nameLabel": "Nombre de la plantilla",
+      "namePlaceholder": "ej. Agente de Ventas",
+      "descriptionLabel": "Descripción",
+      "descriptionPlaceholder": "¿Para qué sirve esta plantilla? (opcional)",
+      "capturedTitle": "Lo que se incluye",
+      "summary": {
+        "instructions": "Instrucciones",
+        "skills_one": "{{count}} habilidad",
+        "skills_other": "{{count}} habilidades",
+        "allApps": "Todas las apps permitidas",
+        "apps_one": "{{count}} app permitida",
+        "apps_other": "{{count}} apps permitidas"
+      },
+      "cancel": "Cancelar",
+      "submit": "Guardar plantilla",
+      "toast": {
+        "title": "Plantilla guardada",
+        "body": "{{name}} está lista para reutilizar."
+      }
+    }
+  },
+  "templatesTab": {
+    "error": "No se pudieron cargar las plantillas.",
+    "empty": {
+      "title": "Aún no hay plantillas",
+      "body": "Guarda un agente como plantilla para reutilizar su configuración en todo tu equipo."
+    },
+    "card": {
+      "skills_one": "{{count}} habilidad",
+      "skills_other": "{{count}} habilidades",
+      "apps_one": "{{count}} app",
+      "apps_other": "{{count}} apps",
+      "allApps": "Todas las apps",
+      "createdBy": "Creada por {{name}}"
+    },
+    "deleteLabel": "Eliminar {{name}}",
+    "deleteConfirm": {
+      "title": "¿Eliminar {{name}}?",
+      "description": "Esta plantilla se eliminará para todos en tu organización. Los agentes ya creados a partir de ella no se verán afectados.",
+      "confirm": "Eliminar",
+      "cancel": "Cancelar"
+    }
   }
 }

--- a/app/src/locales/pt/teams.json
+++ b/app/src/locales/pt/teams.json
@@ -34,6 +34,7 @@
     "tabs": {
       "people": "Pessoas",
       "agents": "Agentes",
+      "templates": "Modelos",
       "activity": "Atividade",
       "usage": "Uso"
     },
@@ -178,5 +179,66 @@
     },
     "lastOpened": "Aberto {{time}}",
     "open": "Abrir {{name}}"
+  },
+  "templates": {
+    "pickerTitle": "Começar a partir de um modelo",
+    "settingUp": "Configurando seu agente...",
+    "summary": {
+      "skills_one": "{{count}} habilidade",
+      "skills_other": "{{count}} habilidades",
+      "apps_one": "{{count}} app",
+      "apps_other": "{{count}} apps",
+      "allApps": "Todos os apps"
+    },
+    "save": {
+      "sectionTitle": "Salvar como modelo",
+      "sectionHelper": "Capture a configuração deste agente como um modelo reutilizável para criar novos agentes com sua equipe.",
+      "button": "Salvar como modelo",
+      "dialog": {
+        "title": "Salvar como modelo",
+        "subtitle": "Reutilize a configuração de {{name}} para criar novos agentes iguais."
+      },
+      "nameLabel": "Nome do modelo",
+      "namePlaceholder": "ex. Agente de Vendas",
+      "descriptionLabel": "Descrição",
+      "descriptionPlaceholder": "Para que serve este modelo? (opcional)",
+      "capturedTitle": "O que é incluído",
+      "summary": {
+        "instructions": "Instruções",
+        "skills_one": "{{count}} habilidade",
+        "skills_other": "{{count}} habilidades",
+        "allApps": "Todos os apps permitidos",
+        "apps_one": "{{count}} app permitido",
+        "apps_other": "{{count}} apps permitidos"
+      },
+      "cancel": "Cancelar",
+      "submit": "Salvar modelo",
+      "toast": {
+        "title": "Modelo salvo",
+        "body": "{{name}} está pronto para reutilizar."
+      }
+    }
+  },
+  "templatesTab": {
+    "error": "Não foi possível carregar os modelos.",
+    "empty": {
+      "title": "Ainda não há modelos",
+      "body": "Salve um agente como modelo para reutilizar a configuração em toda a sua equipe."
+    },
+    "card": {
+      "skills_one": "{{count}} habilidade",
+      "skills_other": "{{count}} habilidades",
+      "apps_one": "{{count}} app",
+      "apps_other": "{{count}} apps",
+      "allApps": "Todos os apps",
+      "createdBy": "Criado por {{name}}"
+    },
+    "deleteLabel": "Excluir {{name}}",
+    "deleteConfirm": {
+      "title": "Excluir {{name}}?",
+      "description": "Este modelo será removido para todos na sua organização. Os agentes já criados a partir dele não serão afetados.",
+      "confirm": "Excluir",
+      "cancel": "Cancelar"
+    }
   }
 }

--- a/app/src/stores/agents.ts
+++ b/app/src/stores/agents.ts
@@ -53,6 +53,7 @@ interface AgentState {
     installedPath?: string,
     seeds?: Record<string, string>,
     existingPath?: string,
+    templateId?: string,
   ) => Promise<CreatedAgent>;
   delete: (workspaceId: string, id: string) => Promise<void>;
   rename: (workspaceId: string, id: string, newName: string) => Promise<void>;
@@ -103,6 +104,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     installedPath?: string,
     seeds?: Record<string, string>,
     existingPath?: string,
+    templateId?: string,
   ) => {
     const result = await tauriAgents.create(
       workspaceId,
@@ -113,6 +115,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
       installedPath,
       seeds,
       existingPath,
+      templateId,
     );
     analytics.track("agent_created", { config_id: configId });
     const { agent } = result;

--- a/app/tests/org-templates-model.test.ts
+++ b/app/tests/org-templates-model.test.ts
@@ -1,0 +1,46 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { canDeleteTemplate } from "../src/components/organization/org-templates-model.ts";
+
+describe("canDeleteTemplate", () => {
+  it("lets the owner delete any template", () => {
+    strictEqual(
+      canDeleteTemplate({
+        isOwner: true,
+        createdBy: "someone-else",
+        currentUserId: "me",
+      }),
+      true,
+    );
+  });
+
+  it("lets an admin delete only their own template", () => {
+    strictEqual(
+      canDeleteTemplate({
+        isOwner: false,
+        createdBy: "me",
+        currentUserId: "me",
+      }),
+      true,
+    );
+    strictEqual(
+      canDeleteTemplate({
+        isOwner: false,
+        createdBy: "someone-else",
+        currentUserId: "me",
+      }),
+      false,
+    );
+  });
+
+  it("hides the affordance when the session isn't loaded", () => {
+    strictEqual(
+      canDeleteTemplate({
+        isOwner: false,
+        createdBy: "me",
+        currentUserId: null,
+      }),
+      false,
+    );
+  });
+});

--- a/app/tests/org-view-model.test.ts
+++ b/app/tests/org-view-model.test.ts
@@ -36,8 +36,11 @@ describe("canSeeOrganization", () => {
 });
 
 describe("ORG_TAB_IDS", () => {
-  it("is the four sections in display order", () => {
-    strictEqual(ORG_TAB_IDS.join(","), "people,agents,activity,usage");
+  it("is the sections in display order", () => {
+    strictEqual(
+      ORG_TAB_IDS.join(","),
+      "people,agents,templates,activity,usage",
+    );
   });
 });
 

--- a/app/tests/save-as-template-model.test.ts
+++ b/app/tests/save-as-template-model.test.ts
@@ -1,0 +1,152 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  allowedToolkitsReady,
+  assembleSpec,
+  canSaveTemplate,
+  providerBrand,
+  summarizeSpec,
+} from "../src/components/tabs/save-as-template-model.ts";
+
+describe("save-as-template model — assembleSpec", () => {
+  it("maps instructions, skills, and allowed apps verbatim", () => {
+    const spec = assembleSpec({
+      instructions: "You are a sales agent.",
+      skills: [{ name: "Email", content: "# Email\nbody" }],
+      provider: "anthropic",
+      model: "claude-opus",
+      effort: "high",
+      allowedToolkits: ["gmail", "slack"],
+    });
+    deepStrictEqual(spec, {
+      instructions: "You are a sales agent.",
+      skills: [{ name: "Email", content: "# Email\nbody" }],
+      allowedToolkits: ["gmail", "slack"],
+      provider: "anthropic",
+      model: "claude-opus",
+      effort: "high",
+    });
+  });
+
+  it("omits absent model fields rather than emitting empty strings", () => {
+    const spec = assembleSpec({
+      instructions: "",
+      skills: [],
+      allowedToolkits: null,
+    });
+    deepStrictEqual(spec, {
+      instructions: "",
+      skills: [],
+      allowedToolkits: null,
+    });
+    strictEqual("provider" in spec, false);
+    strictEqual("model" in spec, false);
+    strictEqual("effort" in spec, false);
+  });
+
+  it("keeps allowedToolkits null (all apps allowed) distinct from empty", () => {
+    strictEqual(
+      assembleSpec({ instructions: "", skills: [], allowedToolkits: null })
+        .allowedToolkits,
+      null,
+    );
+    deepStrictEqual(
+      assembleSpec({ instructions: "", skills: [], allowedToolkits: [] })
+        .allowedToolkits,
+      [],
+    );
+  });
+});
+
+describe("save-as-template model — summarizeSpec", () => {
+  it("emits instructions, skills, model, and app-count segments in order", () => {
+    deepStrictEqual(
+      summarizeSpec({
+        instructions: "hi",
+        skillCount: 3,
+        provider: "anthropic",
+        model: "claude-opus",
+        allowedToolkits: ["gmail", "slack"],
+      }),
+      [
+        { kind: "instructions" },
+        { kind: "skills", count: 3 },
+        { kind: "model", provider: "anthropic", model: "claude-opus" },
+        { kind: "apps", count: 2 },
+      ],
+    );
+  });
+
+  it("drops the instructions segment when instructions are blank", () => {
+    deepStrictEqual(
+      summarizeSpec({
+        instructions: "   ",
+        skillCount: 0,
+        allowedToolkits: null,
+      }),
+      [{ kind: "allApps" }],
+    );
+  });
+
+  it("drops the skills segment at zero and the model segment when unpinned", () => {
+    deepStrictEqual(
+      summarizeSpec({
+        instructions: "x",
+        skillCount: 0,
+        allowedToolkits: [],
+      }),
+      [{ kind: "instructions" }, { kind: "apps", count: 0 }],
+    );
+  });
+
+  it("shows the model segment when only a model (no provider) is pinned", () => {
+    deepStrictEqual(
+      summarizeSpec({
+        instructions: "",
+        skillCount: 0,
+        model: "gpt-5",
+        allowedToolkits: null,
+      }),
+      [
+        { kind: "model", provider: undefined, model: "gpt-5" },
+        { kind: "allApps" },
+      ],
+    );
+  });
+});
+
+describe("save-as-template model — providerBrand", () => {
+  it("maps known providers to brand names, others to null", () => {
+    strictEqual(providerBrand("anthropic"), "Claude");
+    strictEqual(providerBrand("openai"), "OpenAI");
+    strictEqual(providerBrand("mistral"), null);
+    strictEqual(providerBrand(undefined), null);
+  });
+});
+
+describe("save-as-template model — canSaveTemplate", () => {
+  it("requires a non-empty name after trimming", () => {
+    strictEqual(canSaveTemplate("Sales Agent"), true);
+    strictEqual(canSaveTemplate("  Sales  "), true);
+    strictEqual(canSaveTemplate(""), false);
+    strictEqual(canSaveTemplate("   "), false);
+  });
+});
+
+describe("save-as-template model — allowedToolkitsReady", () => {
+  it("blocks save in multiplayer when settings are absent (loading or errored)", () => {
+    // Regression: an errored/absent agent-settings fetch leaves the ceiling
+    // undefined, read as null = ALL apps. The guard must not let a manager
+    // capture that over-permissioned ceiling.
+    strictEqual(allowedToolkitsReady(true, false), false);
+  });
+
+  it("allows save in multiplayer once the real ceiling has resolved", () => {
+    strictEqual(allowedToolkitsReady(true, true), true);
+  });
+
+  it("is always ready in single-player, where there is no ceiling concept", () => {
+    strictEqual(allowedToolkitsReady(false, false), true);
+    strictEqual(allowedToolkitsReady(false, true), true);
+  });
+});

--- a/app/tests/template-summary.test.ts
+++ b/app/tests/template-summary.test.ts
@@ -1,0 +1,90 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  modelBrand,
+  templateSummaryParts,
+} from "../src/lib/template-summary.ts";
+
+describe("modelBrand", () => {
+  it("maps Anthropic model ids to Claude", () => {
+    strictEqual(modelBrand("claude-opus-4-8"), "Claude");
+    strictEqual(modelBrand("claude-sonnet-5"), "Claude");
+    strictEqual(modelBrand("claude-fable-5"), "Claude");
+  });
+
+  it("maps OpenAI model ids to GPT", () => {
+    strictEqual(modelBrand("gpt-5.5"), "GPT");
+    strictEqual(modelBrand("gpt-5.3-codex-spark"), "GPT");
+  });
+
+  it("maps Gemini model ids to Gemini", () => {
+    strictEqual(modelBrand("gemini-3-flash-preview"), "Gemini");
+  });
+
+  it("is case-insensitive", () => {
+    strictEqual(modelBrand("CLAUDE-OPUS-4-8"), "Claude");
+  });
+
+  it("returns null when no model is pinned", () => {
+    strictEqual(modelBrand(undefined), null);
+    strictEqual(modelBrand(null), null);
+    strictEqual(modelBrand(""), null);
+  });
+
+  it("falls back to the raw id for an unknown model", () => {
+    strictEqual(modelBrand("mystery-model-9"), "mystery-model-9");
+  });
+
+  it("labels the same id identically on both template surfaces", () => {
+    // The Templates tab and the create-from-template picker now share this one
+    // helper. A bare Fable id and a Bedrock-style id used to diverge (the tab
+    // split on the first token → "Fable" / "Us"; the picker showed "Claude").
+    strictEqual(modelBrand("fable-5"), "Claude");
+    strictEqual(modelBrand("us.anthropic.claude-opus"), "Claude");
+  });
+});
+
+describe("templateSummaryParts", () => {
+  it("restricted apps → concrete count, model brand, skill count", () => {
+    deepStrictEqual(
+      templateSummaryParts({
+        skillCount: 3,
+        model: "claude-opus-4-8",
+        allowedToolkitCount: 2,
+      }),
+      { skillCount: 3, model: "Claude", allApps: false, appCount: 2 },
+    );
+  });
+
+  it("null allowedToolkitCount → all apps allowed", () => {
+    deepStrictEqual(
+      templateSummaryParts({
+        skillCount: 1,
+        model: "gpt-5.5",
+        allowedToolkitCount: null,
+      }),
+      { skillCount: 1, model: "GPT", allApps: true, appCount: null },
+    );
+  });
+
+  it("no model pinned → model is null", () => {
+    deepStrictEqual(
+      templateSummaryParts({
+        skillCount: 0,
+        model: undefined,
+        allowedToolkitCount: 0,
+      }),
+      { skillCount: 0, model: null, allApps: false, appCount: 0 },
+    );
+  });
+
+  it("zero allowed apps is not the same as all apps", () => {
+    const parts = templateSummaryParts({
+      skillCount: 5,
+      model: "claude-sonnet-4-6",
+      allowedToolkitCount: 0,
+    });
+    strictEqual(parts.allApps, false);
+    strictEqual(parts.appCount, 0);
+  });
+});

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -341,6 +341,7 @@ export class HoustonClient {
         agent: await controlPlane.createAgent(this.cp, req.name, req.color, {
           claudeMd: req.claudeMd,
           seeds: req.seeds,
+          templateId: req.templateId,
         }),
       };
     return agents.createAgent(workspaceId, req);
@@ -1677,6 +1678,32 @@ export class HoustonClient {
   async orgUsage(days: number): Promise<controlPlane.UsageRow[]> {
     if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
     return controlPlane.orgUsage(this.cp, days);
+  }
+
+  // ---- agent templates (multiplayer) — hosted gateway only ----
+  // Reads degrade to `[]`/`null` without a host (mirrors grants): a non-Teams
+  // surface never renders templates. Writes require the gateway and throw.
+  async listOrgTemplates(): Promise<controlPlane.TemplateSummary[]> {
+    if (!this.cp) return [];
+    return controlPlane.listOrgTemplates(this.cp);
+  }
+  async getOrgTemplate(
+    id: string,
+  ): Promise<controlPlane.TemplateRecord | null> {
+    if (!this.cp) return null;
+    return controlPlane.getOrgTemplate(this.cp, id);
+  }
+  async createOrgTemplate(input: {
+    name: string;
+    description: string;
+    spec: controlPlane.TemplateSpec;
+  }): Promise<controlPlane.TemplateSummary> {
+    if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
+    return controlPlane.createOrgTemplate(this.cp, input);
+  }
+  async deleteOrgTemplate(id: string): Promise<void> {
+    if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
+    return controlPlane.deleteOrgTemplate(this.cp, id);
   }
   // Grants degrade gracefully: `null` means "this deployment has no grants
   // model" (the legacy engine path, or a host that 404s the route), which the UI

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -250,17 +250,23 @@ export async function createAgent(
   cfg: ControlPlaneConfig,
   name: string,
   color?: string,
-  seed?: { claudeMd?: string; seeds?: Record<string, string> },
+  seed?: {
+    claudeMd?: string;
+    seeds?: Record<string, string>;
+    templateId?: string;
+  },
 ): Promise<Agent> {
   const res = await cpFetch(cfg, "/agents", {
     method: "POST",
     // The host seeds CLAUDE.md + the seed-file map on create (builtin
-    // templates, AI-assist instructions). JSON.stringify drops undefined
-    // fields, so a plain create still posts just `{ name }`.
+    // templates, AI-assist instructions). `templateId`, when set, tells a Teams
+    // gateway to stamp the agent from an org template. JSON.stringify drops
+    // undefined fields, so a plain create still posts just `{ name }`.
     body: JSON.stringify({
       name,
       claudeMd: seed?.claudeMd,
       seeds: seed?.seeds,
+      templateId: seed?.templateId,
     }),
   });
   const agent = (await res.json()) as CpAgent;
@@ -982,6 +988,9 @@ export type {
   OrgMember,
   OrgRole,
   OrgSettings,
+  TemplateRecord,
+  TemplateSpec,
+  TemplateSummary,
   UsageRow,
 } from "../../../../ui/engine-client/src/types";
 
@@ -997,6 +1006,9 @@ import type {
   OrgInfo,
   OrgRole,
   OrgSettings,
+  TemplateRecord,
+  TemplateSpec,
+  TemplateSummary,
   UsageRow,
 } from "../../../../ui/engine-client/src/types";
 
@@ -1248,4 +1260,60 @@ export async function setAgentIntegrationGrants(
     `/v1/agents/${encodeURIComponent(agentSlugOrId)}/integration-grants`,
     { method: "PUT", body: JSON.stringify({ toolkits }) },
   );
+}
+
+/**
+ * List the org's agent templates as list-card summaries (Teams v2). Degrades to
+ * `[]` when the gateway does not serve templates (404) — a non-Teams host — so
+ * the surface, already gated on `capabilities.multiplayer`, never hard-fails.
+ */
+export async function listOrgTemplates(
+  cfg: ControlPlaneConfig,
+): Promise<TemplateSummary[]> {
+  try {
+    const res = await cpFetch(cfg, "/v1/org/templates");
+    return ((await res.json()) as { templates: TemplateSummary[] }).templates;
+  } catch (err) {
+    if (err instanceof HoustonEngineError && err.status === 404) return [];
+    throw err;
+  }
+}
+
+/** Fetch one template with its full `spec`, or `null` if gone/unsupported (404). */
+export async function getOrgTemplate(
+  cfg: ControlPlaneConfig,
+  id: string,
+): Promise<TemplateRecord | null> {
+  try {
+    const res = await cpFetch(
+      cfg,
+      `/v1/org/templates/${encodeURIComponent(id)}`,
+    );
+    return (await res.json()) as TemplateRecord;
+  } catch (err) {
+    if (err instanceof HoustonEngineError && err.status === 404) return null;
+    throw err;
+  }
+}
+
+/** Create an org template from a client-assembled spec (manager only). */
+export async function createOrgTemplate(
+  cfg: ControlPlaneConfig,
+  input: { name: string; description: string; spec: TemplateSpec },
+): Promise<TemplateSummary> {
+  const res = await cpFetch(cfg, "/v1/org/templates", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+  return (await res.json()) as TemplateSummary;
+}
+
+/** Delete an org template (owner, or the admin who created it). */
+export async function deleteOrgTemplate(
+  cfg: ControlPlaneConfig,
+  id: string,
+): Promise<void> {
+  await cpFetch(cfg, `/v1/org/templates/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
 }

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -87,6 +87,9 @@ import type {
   StoreListing,
   SummarizeOptions,
   SummarizeResult,
+  TemplateRecord,
+  TemplateSpec,
+  TemplateSummary,
   TunnelCredentials,
   TunnelStatus,
   UpdateAgent,
@@ -1238,6 +1241,53 @@ export class HoustonClient {
       `/agents/${this.seg(agentSlugOrId)}/integration-grants`,
       { toolkits },
     );
+  }
+
+  // ---------- agent templates (multiplayer) — hosted gateway only ----------
+  //
+  // Reusable agent configurations, owned by the org. Only a Teams gateway serves
+  // these routes; every other host (single-player, self-host, legacy engine)
+  // 404s them, so the reads degrade to `[]`/`null` and the UI — already gated on
+  // `capabilities.multiplayer` — never shows the surface. The writes are only
+  // ever invoked from that gated surface, so they throw normally.
+
+  /** List the org's templates as list-card summaries (newest first). */
+  async listOrgTemplates(): Promise<TemplateSummary[]> {
+    try {
+      return (
+        await this.request<{ templates: TemplateSummary[] }>(
+          "GET",
+          "/org/templates",
+        )
+      ).templates;
+    } catch (err) {
+      if (isHoustonEngineError(err) && err.status === 404) return [];
+      throw err;
+    }
+  }
+  /** Fetch one template with its full `spec`, or `null` if it's gone/unsupported. */
+  async getOrgTemplate(id: string): Promise<TemplateRecord | null> {
+    try {
+      return await this.request<TemplateRecord>(
+        "GET",
+        `/org/templates/${this.seg(id)}`,
+      );
+    } catch (err) {
+      if (isHoustonEngineError(err) && err.status === 404) return null;
+      throw err;
+    }
+  }
+  /** Create an org template from a client-assembled spec (manager only). */
+  createOrgTemplate(input: {
+    name: string;
+    description: string;
+    spec: TemplateSpec;
+  }): Promise<TemplateSummary> {
+    return this.request("POST", "/org/templates", input);
+  }
+  /** Delete an org template (owner, or the admin who created it). */
+  async deleteOrgTemplate(id: string): Promise<void> {
+    await this.request("DELETE", `/org/templates/${this.seg(id)}`);
   }
 
   // ---------- store ----------

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -213,6 +213,63 @@ export interface UsageRow {
   messages: number;
 }
 
+// ---------- Agent templates (multiplayer) ----------
+
+/**
+ * The captured configuration of an agent, reusable to stamp out new agents
+ * (Teams v2). Assembled CLIENT-SIDE from what a manager is already viewing
+ * (instructions, skills, model config, allowed apps) and stored verbatim by the
+ * gateway. Kept in sync (by hand) with the gateway — the server is the source
+ * of truth and validates shape + size on write.
+ */
+export interface TemplateSpec {
+  /** The agent's CLAUDE.md instructions. */
+  instructions: string;
+  /** Each skill as a `{name, content}` pair (the SKILL.md body). */
+  skills: { name: string; content: string }[];
+  /** The pinned AI model, when the template captures one. */
+  provider?: string;
+  model?: string;
+  effort?: string;
+  /** The allowed-app ceiling; `null` = all apps allowed. */
+  allowedToolkits: string[] | null;
+}
+
+/**
+ * A template as it appears in a list card (Teams v2), from `GET /org/templates`.
+ * The heavy `spec` is intentionally omitted; the derived counts (`skillCount`,
+ * `model`, `allowedToolkitCount`) are enough to describe the template without
+ * shipping every skill body. `createdAt` is epoch milliseconds.
+ */
+export interface TemplateSummary {
+  id: string;
+  name: string;
+  description: string;
+  createdBy: string;
+  createdAt: number;
+  /** Number of skills the template captures. */
+  skillCount: number;
+  /** The pinned model id, when the template captures one. */
+  model?: string;
+  /** Count of allowed apps; `null` = all apps allowed. */
+  allowedToolkitCount: number | null;
+}
+
+/**
+ * A full template (Teams v2) with its `spec`, from `GET /org/templates/:id`.
+ * Fetched lazily only when a caller needs the whole configuration (creating an
+ * agent from it, or inspecting it) — list surfaces use `TemplateSummary`.
+ */
+export interface TemplateRecord {
+  id: string;
+  orgId: string;
+  name: string;
+  description: string;
+  createdBy: string;
+  spec: TemplateSpec;
+  createdAt: number;
+}
+
 // ---------- Workspaces ----------
 
 export interface Workspace {
@@ -305,6 +362,13 @@ export interface CreateAgent {
   installedPath?: string;
   seeds?: Record<string, string>;
   existingPath?: string;
+  /**
+   * Multiplayer only (Teams v2): create this agent from an org template. The
+   * gateway sets the agent's allowed apps synchronously and applies the
+   * template's instructions/skills/model to the pod in the background. Ignored
+   * by single-player/self-host hosts, which have no templates.
+   */
+  templateId?: string;
 }
 
 export interface CreateAgentResult {

--- a/ui/engine-client/tests/client-templates.test.ts
+++ b/ui/engine-client/tests/client-templates.test.ts
@@ -1,0 +1,157 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { HoustonClient } from "../src/client.ts";
+import type { TemplateSpec } from "../src/types.ts";
+
+/**
+ * Teams v2 agent-template client surface (TEAMS-CONTRACT-E5 §client): the
+ * list/get/create/delete methods, the optional `templateId` on `createAgent`,
+ * and the 404-degrade-to-`[]`/`null` behavior on a non-Teams host.
+ *
+ * A capturing `fetchImpl` records the outgoing `{method, url, body}` so we can
+ * assert the exact wire request, and returns a canned body (or a 404) so the
+ * parse/unwrap and degrade paths are covered.
+ */
+
+interface Captured {
+  method: string;
+  url: string;
+  body: unknown;
+}
+
+function makeClient(response: { status?: number; body?: unknown } = {}): {
+  client: HoustonClient;
+  calls: Captured[];
+} {
+  const calls: Captured[] = [];
+  const client = new HoustonClient({
+    baseUrl: "http://127.0.0.1:9999",
+    token: "tok",
+    fetchImpl: async (url, init) => {
+      calls.push({
+        method: init?.method ?? "GET",
+        url: String(url),
+        body:
+          typeof init?.body === "string" ? JSON.parse(init.body) : init?.body,
+      });
+      return new Response(JSON.stringify(response.body ?? {}), {
+        status: response.status ?? 200,
+        headers: { "content-type": "application/json" },
+      });
+    },
+  });
+  return { client, calls };
+}
+
+const spec: TemplateSpec = {
+  instructions: "Be helpful.",
+  skills: [{ name: "greet", content: "Say hi." }],
+  provider: "anthropic",
+  model: "claude-opus-4",
+  allowedToolkits: ["gmail"],
+};
+
+describe("HoustonClient templates — reads", () => {
+  it("listOrgTemplates GETs /org/templates and unwraps templates", async () => {
+    const templates = [
+      {
+        id: "t1",
+        name: "Sales Agent",
+        description: "",
+        createdBy: "u1",
+        createdAt: 5,
+        skillCount: 3,
+        model: "claude-opus-4",
+        allowedToolkitCount: 2,
+      },
+    ];
+    const { client, calls } = makeClient({ body: { templates } });
+    const got = await client.listOrgTemplates();
+    strictEqual(calls[0].method, "GET");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org/templates");
+    deepStrictEqual(got, templates);
+  });
+
+  it("listOrgTemplates degrades to [] on a 404 (non-Teams host)", async () => {
+    const { client } = makeClient({ status: 404, body: { error: {} } });
+    deepStrictEqual(await client.listOrgTemplates(), []);
+  });
+
+  it("getOrgTemplate GETs /org/templates/:id and returns the record", async () => {
+    const record = {
+      id: "t1",
+      orgId: "o1",
+      name: "Sales Agent",
+      description: "",
+      createdBy: "u1",
+      createdAt: 5,
+      spec,
+    };
+    const { client, calls } = makeClient({ body: record });
+    const got = await client.getOrgTemplate("t1");
+    strictEqual(calls[0].method, "GET");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org/templates/t1");
+    deepStrictEqual(got, record);
+  });
+
+  it("getOrgTemplate degrades to null on a 404", async () => {
+    const { client } = makeClient({ status: 404, body: { error: {} } });
+    strictEqual(await client.getOrgTemplate("gone"), null);
+  });
+});
+
+describe("HoustonClient templates — writes", () => {
+  it("createOrgTemplate POSTs the {name, description, spec} body", async () => {
+    const summary = {
+      id: "t2",
+      name: "Support Agent",
+      description: "Answers tickets",
+      createdBy: "u1",
+      createdAt: 9,
+      skillCount: 1,
+      allowedToolkitCount: 1,
+    };
+    const { client, calls } = makeClient({ status: 201, body: summary });
+    const input = {
+      name: "Support Agent",
+      description: "Answers tickets",
+      spec,
+    };
+    const got = await client.createOrgTemplate(input);
+    strictEqual(calls[0].method, "POST");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org/templates");
+    deepStrictEqual(calls[0].body, input);
+    deepStrictEqual(got, summary);
+  });
+
+  it("deleteOrgTemplate DELETEs /org/templates/:id", async () => {
+    const { client, calls } = makeClient({ body: { ok: true } });
+    await client.deleteOrgTemplate("t2");
+    strictEqual(calls[0].method, "DELETE");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/org/templates/t2");
+  });
+});
+
+describe("HoustonClient createAgent — templateId", () => {
+  it("forwards templateId in the create body when present", async () => {
+    const { client, calls } = makeClient({ body: { agent: {} } });
+    await client.createAgent("ws1", {
+      name: "Rep 1",
+      configId: "cfg",
+      templateId: "t1",
+    });
+    strictEqual(calls[0].method, "POST");
+    strictEqual(calls[0].url, "http://127.0.0.1:9999/v1/workspaces/ws1/agents");
+    deepStrictEqual(calls[0].body, {
+      name: "Rep 1",
+      configId: "cfg",
+      templateId: "t1",
+    });
+  });
+
+  it("omits templateId for a plain create", async () => {
+    const { client, calls } = makeClient({ body: { agent: {} } });
+    await client.createAgent("ws1", { name: "Blank", configId: "cfg" });
+    deepStrictEqual(calls[0].body, { name: "Blank", configId: "cfg" });
+  });
+});


### PR DESCRIPTION
Client surfaces for agent templates (gateway side merged in cloud #49). Everything feature-detects `capabilities.multiplayer` and is invisible in single-player, self-host, and to non-managers. Completes the Teams build.

- **Save as template**: agent managers get a "Save as template" action (Agent settings → General) capturing the agent's instructions, skills, AI model, and allowed apps into a named org template, with a plain-language summary of what's captured. Save is blocked until the allowed-apps ceiling has loaded, so a template never silently captures "all apps" from a pending/errored fetch.
- **Create from template**: the new-agent flow offers "Start from a template" (name, description, "3 skills · Claude · 2 apps") alongside "Start blank"; picking one stamps a new agent via `createAgent(templateId)` with a brief setup state while the gateway applies the spec. Blank flow byte-identical.
- **Organization → Templates tab**: manage org templates (cards with delete gated to owner or creator; designed empty state).
- **engine-client + web adapter**: `TemplateSpec/Summary/Record` types, list/get/create/delete methods, `createAgent` `templateId`; TanStack Query hooks. All 404-degrade on non-teams hosts.
- en/es/pt copy (template / plantilla / modelo), consistent across surfaces.

## Verification
`pnpm check`, `pnpm typecheck`, app `tsgo`, `check-locales`, `houston-web typecheck` (shim parity), host/runtime/domain vitest, all app model tests — green. Adversarial review ran; confirmed findings (settings-load over-permissioning, model-brand inconsistency) fixed test-first.

Companion (gateway) PR: gethouston/cloud#49.

🤖 Generated with [Claude Code](https://claude.com/claude-code)