### PR TITLE
fix(sidebar): agent count badges no longer flash away when deleting an agent (HOU-700)

### DIFF
--- a/app/src/hooks/queries/use-conversations.ts
+++ b/app/src/hooks/queries/use-conversations.ts
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { keepPreviousData, useQuery } from "@tanstack/react-query";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriChat, tauriConversations } from "../../lib/tauri";
 
@@ -18,6 +18,9 @@ export function useAllConversations(agentPaths: string[]) {
     queryKey: queryKeys.allConversations(agentPaths),
     queryFn: () => tauriConversations.listAll(agentPaths),
     enabled: agentPaths.length > 0,
+    // The key embeds every agent path, so adding/removing an agent re-keys the
+    // query; without this the sidebar counts render as 0 until the refetch lands.
+    placeholderData: keepPreviousData,
   });
 }
 

--- a/app/src/hooks/queries/use-conversations.ts
+++ b/app/src/hooks/queries/use-conversations.ts
@@ -18,8 +18,6 @@ export function useAllConversations(agentPaths: string[]) {
     queryKey: queryKeys.allConversations(agentPaths),
     queryFn: () => tauriConversations.listAll(agentPaths),
     enabled: agentPaths.length > 0,
-    // The key embeds every agent path, so adding/removing an agent re-keys the
-    // query; without this the sidebar counts render as 0 until the refetch lands.
     placeholderData: keepPreviousData,
   });
 }


### PR DESCRIPTION
## Summary

Fixes HOU-700: after deleting an agent, the activity count badges next to **every** agent in the sidebar disappeared for a moment, then reappeared.

**Root cause.** The sidebar badges are derived from the `useAllConversations` query, whose key embeds every agent path: `["all-conversations", ...agentPaths]`. Deleting an agent updates the agent store optimistically, which changes `agentPaths` and therefore the query key. TanStack Query treats the new key as a brand-new query with no cached data, so `data` is `undefined` while it refetches, the summaries hook falls back to `[]`, every agent's `needsYouCount` computes to 0, and all badges unmount until the refetch resolves. The same flash happened when adding an agent.

**Fix.** Add `placeholderData: keepPreviousData` to `useAllConversations`, so the previous result stays rendered while the re-keyed query refetches. Stale rows belonging to the deleted agent are harmless during that window: `buildAgentActivitySummaries` already skips conversations whose `agent_path` isn't in the current agent list (covered by the existing `/workspace/missing` case in `app/tests/agent-activity-summary-model.test.ts`).

## Reproduce (before the fix)

1. Have several agents in the sidebar with activity badges showing (needs-you counts > 0 on multiple agents).
2. Delete one agent (sidebar context menu → delete, confirm).
3. Watch the other agents' badges: they all vanish the instant the agent disappears, then pop back in once the conversations refetch completes.

## Verify (after the fix)

1. Same setup: several agents with visible count badges.
2. Delete one agent.
3. The deleted agent's row disappears; the remaining agents' badges stay visible the whole time, with no flash to zero. (Also holds when creating a new agent.)

Gates: `pnpm check` clean, `app` + `packages/web` typecheck clean, `pnpm test` in `app/` 723/723 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)