### PR TITLE
fix(app): agent library integration chips use the Composio catalog logos (HOU-701)

### DIFF
--- a/app/src/components/agent-integration-chips.tsx
+++ b/app/src/components/agent-integration-chips.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
-import { fallbackLogo } from "./integrations/app-display";
+import { useMemo, useState } from "react";
+import { useIntegrationStatus, useIntegrationToolkits } from "../hooks/queries";
+import { appDisplay, INTEGRATION_PROVIDER } from "./integrations";
 
 interface Props {
   /** Composio toolkit slugs the agent is designed to work with. */
@@ -13,15 +14,34 @@ interface Props {
  * agent is designed to use. Purely informational: on the TS engine the user
  * connects apps once in the Integrations tab (Composio), and every agent's
  * skills reach them through the integration tools.
+ *
+ * Logos resolve through the Composio toolkit catalog (the same `appDisplay`
+ * path as the Integrations tab), because the favicon guess alone breaks for
+ * every slug that isn't literally a `.com` domain (googledocs, metaads,
+ * perplexityai, ...). While the catalog hasn't loaded — or on a deployment
+ * with no integration provider wired — `appDisplay` falls back to the guess.
  */
 export function AgentIntegrationChips({ slugs, max = 6 }: Props) {
+  const status = useIntegrationStatus();
+  const ready = !!status.data?.find((p) => p.provider === INTEGRATION_PROVIDER)
+    ?.ready;
+  const catalog = useIntegrationToolkits(INTEGRATION_PROVIDER, ready);
+  const bySlug = useMemo(
+    () => new Map((catalog.data ?? []).map((tk) => [tk.slug, tk])),
+    [catalog.data],
+  );
+
   if (slugs.length === 0) return null;
   const shown = slugs.slice(0, max);
   const extra = slugs.length - shown.length;
   return (
     <div className="flex items-center gap-1.5">
       {shown.map((slug) => (
-        <IntegrationPip key={slug} slug={slug} />
+        <IntegrationPip
+          key={slug}
+          slug={slug}
+          logoUrl={appDisplay(slug, bySlug.get(slug)).logoUrl}
+        />
       ))}
       {extra > 0 && (
         <span className="text-[10px] font-medium text-muted-foreground">
@@ -32,9 +52,12 @@ export function AgentIntegrationChips({ slugs, max = 6 }: Props) {
   );
 }
 
-function IntegrationPip({ slug }: { slug: string }) {
-  const [broken, setBroken] = useState(false);
-  if (broken) {
+function IntegrationPip({ slug, logoUrl }: { slug: string; logoUrl: string }) {
+  // Remember WHICH url failed, not just that one did: when the catalog loads
+  // and upgrades the src from the favicon guess to the real logo, a boolean
+  // would keep the letter fallback on screen for the new, working url.
+  const [brokenUrl, setBrokenUrl] = useState<string | null>(null);
+  if (brokenUrl === logoUrl) {
     return (
       <span
         title={slug}
@@ -46,11 +69,11 @@ function IntegrationPip({ slug }: { slug: string }) {
   }
   return (
     <img
-      src={fallbackLogo(slug)}
+      src={logoUrl}
       alt={slug}
       title={slug}
       className="size-4 rounded-[4px] bg-background object-contain"
-      onError={() => setBroken(true)}
+      onError={() => setBrokenUrl(logoUrl)}
     />
   );
 }

--- a/app/tests/app-display.test.ts
+++ b/app/tests/app-display.test.ts
@@ -1,0 +1,46 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { IntegrationToolkit } from "@houston-ai/engine-client";
+import {
+  appDisplay,
+  fallbackLogo,
+} from "../src/components/integrations/app-display.ts";
+
+const tk = (
+  slug: string,
+  name: string,
+  logoUrl?: string,
+): IntegrationToolkit => ({
+  slug,
+  name,
+  categories: [],
+  description: `${name} desc`,
+  logoUrl,
+});
+
+describe("appDisplay logo resolution", () => {
+  it("prefers the catalog logoUrl when present", () => {
+    const app = appDisplay(
+      "googledocs",
+      tk("googledocs", "Google Docs", "https://cdn.example/googledocs.svg"),
+    );
+    strictEqual(app.logoUrl, "https://cdn.example/googledocs.svg");
+    strictEqual(app.name, "Google Docs");
+  });
+
+  it("falls back to the favicon guess when the catalog entry has no logo", () => {
+    const app = appDisplay("slack", tk("slack", "Slack"));
+    strictEqual(app.logoUrl, fallbackLogo("slack"));
+  });
+
+  it("falls back to the favicon guess when the catalog entry has an empty logoUrl", () => {
+    const app = appDisplay("slack", tk("slack", "Slack", ""));
+    strictEqual(app.logoUrl, fallbackLogo("slack"));
+  });
+
+  it("falls back to slug name + favicon guess when the toolkit is absent entirely", () => {
+    const app = appDisplay("quickbooks", undefined);
+    strictEqual(app.name, "quickbooks");
+    strictEqual(app.logoUrl, fallbackLogo("quickbooks"));
+  });
+});


### PR DESCRIPTION
Fixes HOU-701

## Root cause

The integration chips on agent library/store cards (`AgentIntegrationChips`) resolved every logo with a favicon guess: `https://www.google.com/s2/favicons?domain=<slug>.com`. That only works when the Composio toolkit slug happens to be a real `.com` domain. Slugs like `googledocs`, `googlesheets`, `googledrive`, `metaads`, `perplexityai`, `customerio` etc. resolved to Google's generic globe placeholder or errored into the single-letter fallback — the blank/globe/letter chips in the issue screenshot. The chips never consulted the Composio platform toolkit catalog, even though the Integrations tab and the in-chat connect card already render real logos from it (`appDisplay` → `toolkit.logoUrl`).

## Fix

- `AgentIntegrationChips` now loads the Composio toolkit catalog (`useIntegrationStatus` + `useIntegrationToolkits`, the same gating as the in-chat connect card) and resolves each chip through the shared `appDisplay` path, so chips show the real hosted toolkit logos. The favicon guess remains only as the pre-load / integrations-not-configured fallback.
- A pip's "broken image" state is now tracked per URL, so a chip whose favicon guess failed recovers the moment the catalog upgrades its src to the real logo instead of being stuck on the letter fallback.
- Added tests for the `appDisplay` logo-resolution contract (catalog logo preferred; favicon fallback on missing/empty `logoUrl` and on absent toolkit), which was previously untested.

## Reproduce (before the fix)

1. Run the app signed in to a deployment with integrations configured (cloud gateway or a host with `COMPOSIO_API_KEY`).
2. Open new agent creation → "From library".
3. Look at the icon row on cards like Bookkeeping (`googledocs`, `googledrive`, `googlesheets`, `quickbooks`, ...) or Marketing (`metaads`, `perplexityai`, `googleads`, ...): several chips render as generic globes, blank squares, or single letters instead of app logos.

## Verify (after the fix)

1. Same screen: the chips on Bookkeeping/Marketing/Outbound cards render the real app logos (Google Docs, Google Sheets, Meta Ads, Perplexity, ...), matching the logos shown in the Integrations tab for the same apps.
2. On first paint before the catalog loads, chips may briefly show the favicon guess, then upgrade to catalog logos; no chip stays stuck on a letter fallback once the catalog is loaded.
3. `cd app && pnpm test` — 727 tests pass, including the new `tests/app-display.test.ts`.
4. `pnpm check` and `pnpm -r typecheck` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)