### PR TITLE
fix(ai-hub): provider card offers Cancel during an in-flight login (HOU-698)

### DIFF
--- a/app/src/components/ai-hub/provider-card.tsx
+++ b/app/src/components/ai-hub/provider-card.tsx
@@ -17,14 +17,19 @@ interface ProviderCardProps {
   connecting: boolean;
   onOpen: (provider: ProviderInfo) => void;
   onConnect: (provider: ProviderInfo) => void;
+  /** Abort an in-flight sign-in so a user who closed the OAuth tab isn't
+   *  stuck watching a spinner with no way out. */
+  onCancel: (provider: ProviderInfo) => void;
 }
 
 /**
  * A marketplace tile for one provider. The card itself is NOT clickable — every
  * action lives in the footer as a real focusable button: an available provider
  * offers a primary Connect pill plus a ghost "See more" that opens the detail
- * (`onOpen`); a connected provider swaps Connect for a live status readout and
- * keeps "See more" to reopen its modal. Every card wears the same calm gray
+ * (`onOpen`); while a sign-in is in flight the pill becomes a Cancel button
+ * (spinner + visible label, never a dead disabled spinner) that aborts the
+ * login (`onCancel`); a connected provider swaps Connect for a live status
+ * readout and keeps "See more" to reopen its modal. Every card wears the same calm gray
  * surface + hairline ring — connected and available look identical, differing
  * only in the footer (live status vs Connect pill). No accent, no glow.
  */
@@ -35,6 +40,7 @@ export function ProviderCard({
   connecting,
   onOpen,
   onConnect,
+  onCancel,
 }: ProviderCardProps) {
   const { t } = useTranslation("aiHub");
 
@@ -84,18 +90,27 @@ export function ProviderCard({
           </>
         ) : (
           <>
-            <AsyncButton
-              size="sm"
-              spinner={false}
-              disabled={connecting}
-              className="flex-1"
-              onClick={() => onConnect(provider)}
-            >
-              {connecting ? (
+            {connecting ? (
+              <AsyncButton
+                size="sm"
+                variant="secondary"
+                spinner={false}
+                className="flex-1"
+                onClick={() => onCancel(provider)}
+              >
                 <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
-              ) : null}
-              {t("card.connect")}
-            </AsyncButton>
+                {t("card.cancel")}
+              </AsyncButton>
+            ) : (
+              <AsyncButton
+                size="sm"
+                spinner={false}
+                className="flex-1"
+                onClick={() => onConnect(provider)}
+              >
+                {t("card.connect")}
+              </AsyncButton>
+            )}
             {seeMore}
           </>
         )}

--- a/app/src/components/ai-hub/provider-grid.tsx
+++ b/app/src/components/ai-hub/provider-grid.tsx
@@ -73,6 +73,7 @@ export function ProviderGrid({
       connecting={connections.busy[provider.id] === "connecting"}
       onOpen={onOpen}
       onConnect={connections.connect}
+      onCancel={connections.cancel}
     />
   );
 

--- a/app/tests/provider-card-cancel.test.ts
+++ b/app/tests/provider-card-cancel.test.ts
@@ -1,0 +1,47 @@
+import { ok } from "node:assert";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const read = (rel: string) =>
+  readFileSync(new URL(rel, import.meta.url), "utf8");
+
+// ---------------------------------------------------------------------------
+// HOU-698 — an in-flight provider sign-in must always offer a way out.
+//
+// The AI-hub grid card used to render a *disabled* Connect button with a bare
+// spinner while `connecting`, so a user who closed the OAuth tab was stuck
+// watching it forever (the modal header had a Cancel, the grid card did not).
+// These are source contracts: the card must swap Connect for a Cancel action
+// while connecting, and the grid must wire that action to the connections
+// hook's `cancel` (which aborts the engine-side login so a retry isn't
+// rejected as "already pending").
+// ---------------------------------------------------------------------------
+describe("ai-hub provider card offers cancel while connecting (HOU-698)", () => {
+  const card = read("../src/components/ai-hub/provider-card.tsx");
+
+  it("swaps the Connect pill for a Cancel button during an in-flight login", () => {
+    ok(
+      card.includes("onCancel(provider)"),
+      "connecting state must invoke onCancel",
+    );
+    ok(
+      card.includes('t("card.cancel")'),
+      "cancel affordance must carry a visible localized label, not just a spinner",
+    );
+  });
+
+  it("never renders a disabled dead-end while connecting", () => {
+    ok(
+      !card.includes("disabled={connecting}"),
+      "the connecting state must not disable the only actionable button",
+    );
+  });
+
+  it("grid wires the card's onCancel to the connections hook", () => {
+    const grid = read("../src/components/ai-hub/provider-grid.tsx");
+    ok(
+      grid.includes("onCancel={connections.cancel}"),
+      "ProviderGrid must pass connections.cancel to ProviderCard",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes HOU-698.

**Root cause:** the AI Models Hub grid card rendered a *disabled* Connect button with a bare spinner while a provider sign-in was in flight. Cancel support already existed end-to-end (runtime `POST auth/:provider/login/cancel`, `tauriProvider.cancelLogin`, the connections hook's `cancel`) and every other login surface offered it (provider modal header, onboarding mission, login dialogs) — the grid card was the one surface that trapped the user. Close the OAuth tab and the card spins forever with no way out.

**Fix:** while `connecting`, the card's Connect pill now swaps to a secondary **Cancel** button (spinner + visible localized label), wired to `connections.cancel`, which aborts the engine-side login so a retry isn't rejected as "already pending". Mirrors the existing pattern in the modal header's `ConnectButton`.

## Changes
- `app/src/components/ai-hub/provider-card.tsx` — Connect ⇄ Cancel swap during `connecting`; new `onCancel` prop.
- `app/src/components/ai-hub/provider-grid.tsx` — passes `connections.cancel` down.
- `app/tests/provider-card-cancel.test.ts` — source contracts: cancel action present, visible label, no disabled dead-end, grid wiring.

## Reproduce (before)
1. Open Settings → AI Models, find a disconnected OAuth provider (e.g. OpenAI) in the grid.
2. Click **Connect** on the grid card (not "See more"), then close the browser tab that opens without completing the login.
3. The card shows a disabled spinner indefinitely — no cancel, no retry.

## Verify (after)
1. Repeat steps 1–2: while the login is in flight the card shows a **Cancel** button (spinner + label) instead of a disabled pill.
2. Click Cancel — the card returns to **Connect** immediately.
3. Click Connect again — the retry starts a fresh login (not rejected as already pending).
4. Gates: `pnpm test` in `app/` (736 pass, incl. the new contract test), `pnpm tsgo --noEmit`, `pnpm --filter houston-web typecheck`, `pnpm check`, `pnpm check-locales` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)