### PR TITLE
fix(providers): Claude connect hung in dev + hover-to-cancel on the connecting card

### DIFF
--- a/app/src-tauri/src/claude_login/resolve.rs
+++ b/app/src-tauri/src/claude_login/resolve.rs
@@ -19,7 +19,11 @@ fn claude_bin_name() -> &'static str {
 ///   1. Explicit env override `HOUSTON_CLAUDE_BIN` (dev/test escape hatch —
 ///      honored verbatim, even if it points outside a bundle).
 ///   2. Sibling of the current executable — the bundled-sidecar location Tauri
-///      uses on shipping platforms — IF it exists.
+///      uses on shipping platforms — IF it exists. RELEASE ONLY: a debug /
+///      `tauri dev` build stages a no-op PLACEHOLDER there (`sleep infinity`;
+///      the real ~232 MB binary ships only in release), and spawning THAT hangs
+///      the login on a spinner forever. So in a debug build we skip the sibling
+///      and use the real `claude` on PATH instead.
 ///   3. Bare `claude`, resolved via `PATH` (the dev/test path). No panics.
 pub(super) fn resolve_claude_binary() -> PathBuf {
     // 1. Explicit env override.
@@ -27,7 +31,9 @@ pub(super) fn resolve_claude_binary() -> PathBuf {
         return PathBuf::from(p);
     }
 
-    // 2. Sibling of the current executable, if bundled.
+    // 2. Sibling of the current executable, if bundled — release builds only
+    //    (debug stages a `sleep`-forever placeholder; see the doc note above).
+    #[cfg(not(debug_assertions))]
     if let Ok(exe) = std::env::current_exe() {
         if let Some(exe_dir) = exe.parent() {
             let sibling = exe_dir.join(claude_bin_name());
@@ -37,7 +43,8 @@ pub(super) fn resolve_claude_binary() -> PathBuf {
         }
     }
 
-    // 3. Fall back to PATH.
+    // 3. Fall back to PATH (always in a debug build; the release fallback when
+    //    no bundled sibling is present).
     PathBuf::from("claude")
 }
 
@@ -77,6 +84,12 @@ pub(super) fn extract_visit_url(line: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes the tests that mutate the shared process env var
+    /// `HOUSTON_CLAUDE_BIN` — cargo runs tests in parallel, so without this they
+    /// race on the same global and flake.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn extract_visit_url_pulls_the_authorize_url() {
@@ -113,11 +126,24 @@ mod tests {
 
     #[test]
     fn resolve_claude_binary_honors_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap();
         // The override wins verbatim over sibling/PATH resolution.
         let sentinel = "/nonexistent/houston/claude-override";
         std::env::set_var("HOUSTON_CLAUDE_BIN", sentinel);
         let resolved = resolve_claude_binary();
         std::env::remove_var("HOUSTON_CLAUDE_BIN");
         assert_eq!(resolved, PathBuf::from(sentinel));
+    }
+
+    #[test]
+    #[cfg(debug_assertions)]
+    fn resolve_claude_binary_uses_path_in_debug_not_the_placeholder() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        // Tests run in a debug build, where the bundled sibling is a no-op
+        // `sleep`-forever placeholder. Resolution must SKIP it and fall back to
+        // the real `claude` on PATH — spawning the placeholder would hang the
+        // login on a spinner forever (the dev-mode bug this guards).
+        std::env::remove_var("HOUSTON_CLAUDE_BIN");
+        assert_eq!(resolve_claude_binary(), PathBuf::from("claude"));
     }
 }

--- a/app/src/components/ai-hub/provider-card.tsx
+++ b/app/src/components/ai-hub/provider-card.tsx
@@ -1,5 +1,5 @@
 import { AsyncButton, Button } from "@houston-ai/core";
-import { Loader2 } from "lucide-react";
+import { Loader2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { HubCatalog } from "../../lib/ai-hub/catalog-types";
 import type { ProviderInfo } from "../../lib/providers";
@@ -17,6 +17,7 @@ interface ProviderCardProps {
   connecting: boolean;
   onOpen: (provider: ProviderInfo) => void;
   onConnect: (provider: ProviderInfo) => void;
+  onCancel: (provider: ProviderInfo) => void;
 }
 
 /**
@@ -35,6 +36,7 @@ export function ProviderCard({
   connecting,
   onOpen,
   onConnect,
+  onCancel,
 }: ProviderCardProps) {
   const { t } = useTranslation("aiHub");
 
@@ -85,16 +87,36 @@ export function ProviderCard({
         ) : (
           <>
             <AsyncButton
+              // While connecting the button stays clickable and, on hover, flips
+              // to Cancel — so a stuck or unwanted sign-in can be aborted and
+              // retried instead of the user waiting out a dead spinner.
               size="sm"
               spinner={false}
-              disabled={connecting}
-              className="flex-1"
-              onClick={() => onConnect(provider)}
+              className="group/connect relative flex-1"
+              aria-label={connecting ? t("card.cancel") : undefined}
+              onClick={() =>
+                connecting ? onCancel(provider) : onConnect(provider)
+              }
             >
               {connecting ? (
-                <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
-              ) : null}
-              {t("card.connect")}
+                <>
+                  {/* Resting: spinner + "Connecting" — fades out on hover. */}
+                  <span className="flex items-center justify-center gap-1.5 transition-opacity group-hover/connect:opacity-0">
+                    <Loader2
+                      className="size-3.5 animate-spin"
+                      aria-hidden="true"
+                    />
+                    {t("card.connecting")}
+                  </span>
+                  {/* Hover: Cancel — click aborts so the user can retry. */}
+                  <span className="absolute inset-0 flex items-center justify-center gap-1.5 opacity-0 transition-opacity group-hover/connect:opacity-100">
+                    <X className="size-3.5" aria-hidden="true" />
+                    {t("card.cancel")}
+                  </span>
+                </>
+              ) : (
+                t("card.connect")
+              )}
             </AsyncButton>
             {seeMore}
           </>

--- a/app/src/components/ai-hub/provider-grid.tsx
+++ b/app/src/components/ai-hub/provider-grid.tsx
@@ -73,6 +73,7 @@ export function ProviderGrid({
       connecting={connections.busy[provider.id] === "connecting"}
       onOpen={onOpen}
       onConnect={connections.connect}
+      onCancel={connections.cancel}
     />
   );
 

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -14,6 +14,7 @@
   },
   "card": {
     "connect": "Connect",
+    "connecting": "Connecting",
     "seeMore": "See more",
     "connected": "Connected",
     "cancel": "Cancel",

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -14,6 +14,7 @@
   },
   "card": {
     "connect": "Conectar",
+    "connecting": "Conectando",
     "seeMore": "Ver más",
     "connected": "Conectado",
     "cancel": "Cancelar",

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -14,6 +14,7 @@
   },
   "card": {
     "connect": "Conectar",
+    "connecting": "Conectando",
     "seeMore": "Ver mais",
     "connected": "Conectado",
     "cancel": "Cancelar",


### PR DESCRIPTION
Two fixes to the zero-terminal Claude connect (#675), from real testing.

## 1. Connect hung on a spinner in `pnpm dev` (no browser opened)
A debug / `tauri dev` build stages a `sleep 2147483647` **placeholder** for the bundled `claude` sidecar (the real ~232 MB binary ships only in release). `resolve_claude_binary` resolved that placeholder sibling and spawned it → the login hung forever with no browser. It now **skips the sibling in debug builds and uses the real `claude` on PATH** (release still uses the bundled binary). Locked with a test.

## 2. Hover-to-cancel on the connecting card
The AI-models card's Connect button stays clickable while connecting and **flips to Cancel on hover** (spinner + "Connecting" at rest, ✕ + "Cancel" on hover), so a stuck or unwanted sign-in can be aborted and retried instead of waiting out a dead spinner. Wired to the existing `connections.cancel`; `connecting` label added in en/es/pt.

## Verification
app 613 tests · 16 cargo login tests · full `pnpm typecheck` (25 shims) · Biome · check-locales — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)