### PR TITLE
fix(files): make Files-tab downloads actually work on desktop + per-folder zips (HOU-703)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1940,6 +1940,7 @@ dependencies = [
  "notify-rust",
  "objc2",
  "objc2-app-kit",
+ "percent-encoding",
  "rand",
  "reqwest 0.12.28",
  "rfd",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
 dirs = "5"
+percent-encoding = "2"
 chrono = { version = "0.4", features = ["serde"] }
 tauri-plugin-notification = "2"
 tauri-plugin-updater = "2"

--- a/app/src-tauri/src/commands/dialogs.rs
+++ b/app/src-tauri/src/commands/dialogs.rs
@@ -1,0 +1,144 @@
+//! OS-native file dialogs shared by the commands that save/open files on the
+//! user's machine (portable agent share/import, workspace file downloads).
+//!
+//! Shells out to osascript on macOS and PowerShell on Windows so we don't
+//! pull in a Tauri dialog plugin for a handful of operations. Callers pass
+//! the user-visible prompt; the Windows save dialog additionally takes an
+//! optional `"label|*.ext"` filter.
+
+use tokio::process::Command;
+
+/// Escape a string for interpolation inside an AppleScript double-quoted
+/// literal (filenames can contain `"` and `\`).
+#[cfg(target_os = "macos")]
+fn applescript_escape(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('"', "\\\"")
+}
+
+/// Escape a string for interpolation inside a PowerShell single-quoted
+/// literal (only `'` is special there).
+#[cfg(target_os = "windows")]
+fn powershell_escape(s: &str) -> String {
+    s.replace('\'', "''")
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) async fn save_dialog(
+    prompt: &str,
+    default_name: &str,
+    _win_filter: Option<&str>,
+) -> Result<Option<String>, String> {
+    let script = format!(
+        r#"POSIX path of (choose file name with prompt "{}" default name "{}")"#,
+        applescript_escape(prompt),
+        applescript_escape(default_name),
+    );
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .await
+        .map_err(|e| format!("Failed to open save dialog: {e}"))?;
+    if !output.status.success() {
+        // User cancelled — osascript returns non-zero. Treat as None.
+        return Ok(None);
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if path.is_empty() { None } else { Some(path) })
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) async fn save_dialog(
+    _prompt: &str,
+    default_name: &str,
+    win_filter: Option<&str>,
+) -> Result<Option<String>, String> {
+    let filter = win_filter.unwrap_or("All files (*.*)|*.*");
+    let script = format!(
+        r#"
+Add-Type -AssemblyName System.Windows.Forms | Out-Null
+$dlg = New-Object System.Windows.Forms.SaveFileDialog
+$dlg.FileName = '{}'
+$dlg.Filter = '{}'
+if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {{
+    Write-Output $dlg.FileName
+}}
+"#,
+        powershell_escape(default_name),
+        powershell_escape(filter),
+    );
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-Sta", "-Command", &script])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to open save dialog: {e}"))?;
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if path.is_empty() { None } else { Some(path) })
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub(crate) async fn save_dialog(
+    _prompt: &str,
+    _default_name: &str,
+    _win_filter: Option<&str>,
+) -> Result<Option<String>, String> {
+    Err("Save dialog not yet implemented on this platform.".into())
+}
+
+#[cfg(target_os = "macos")]
+pub(crate) async fn open_dialog(
+    prompt: &str,
+    _win_filter: Option<&str>,
+) -> Result<Option<String>, String> {
+    // `choose file` always returns a POSIX path. The user can pick any
+    // extension; callers validate the bytes.
+    let script = format!(
+        r#"POSIX path of (choose file with prompt "{}")"#,
+        applescript_escape(prompt),
+    );
+    let output = Command::new("osascript")
+        .arg("-e")
+        .arg(&script)
+        .output()
+        .await
+        .map_err(|e| format!("Failed to open file dialog: {e}"))?;
+    if !output.status.success() {
+        return Ok(None);
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if path.is_empty() { None } else { Some(path) })
+}
+
+#[cfg(target_os = "windows")]
+pub(crate) async fn open_dialog(
+    _prompt: &str,
+    win_filter: Option<&str>,
+) -> Result<Option<String>, String> {
+    let filter = win_filter.unwrap_or("All files (*.*)|*.*");
+    let script = format!(
+        r#"
+Add-Type -AssemblyName System.Windows.Forms | Out-Null
+$dlg = New-Object System.Windows.Forms.OpenFileDialog
+$dlg.Filter = '{}'
+if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {{
+    Write-Output $dlg.FileName
+}}
+"#,
+        powershell_escape(filter),
+    );
+    let output = Command::new("powershell")
+        .args(["-NoProfile", "-Sta", "-Command", &script])
+        .output()
+        .await
+        .map_err(|e| format!("Failed to open file dialog: {e}"))?;
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    Ok(if path.is_empty() { None } else { Some(path) })
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+pub(crate) async fn open_dialog(
+    _prompt: &str,
+    _win_filter: Option<&str>,
+) -> Result<Option<String>, String> {
+    Err("Open dialog not yet implemented on this platform.".into())
+}

--- a/app/src-tauri/src/commands/mod.rs
+++ b/app/src-tauri/src/commands/mod.rs
@@ -3,8 +3,10 @@
 use std::path::{Path, PathBuf};
 
 pub mod diagnostics;
+mod dialogs;
 pub mod os;
 pub mod portable;
+pub mod save_file;
 pub mod terminal;
 pub mod update;
 

--- a/app/src-tauri/src/commands/portable.rs
+++ b/app/src-tauri/src/commands/portable.rs
@@ -4,100 +4,14 @@
 //!   * Pick a save destination and write zip bytes to it (export).
 //!   * Pick a `.houstonagent` file on disk and read its bytes (import).
 //!
-//! Both shell out to OS-native dialogs (osascript on macOS, PowerShell on
-//! Windows) so we don't pull in a Tauri dialog plugin just for two
-//! operations. Mirrors the existing `pick_directory` pattern in `os.rs`.
+//! The platform dialogs themselves live in `super::dialogs` (shared with the
+//! Files-tab download command in `save_file.rs`).
 
 use std::path::PathBuf;
-use tokio::process::Command;
 
-#[cfg(target_os = "macos")]
-async fn save_dialog(default_name: &str) -> Result<Option<String>, String> {
-    let script = format!(
-        r#"POSIX path of (choose file name with prompt "Save shared agent" default name "{default_name}")"#
-    );
-    let output = Command::new("osascript")
-        .arg("-e")
-        .arg(&script)
-        .output()
-        .await
-        .map_err(|e| format!("Failed to open save dialog: {e}"))?;
-    if !output.status.success() {
-        // User cancelled — osascript returns non-zero. Treat as None.
-        return Ok(None);
-    }
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok(if path.is_empty() { None } else { Some(path) })
-}
+use super::dialogs::{open_dialog, save_dialog};
 
-#[cfg(target_os = "windows")]
-async fn save_dialog(default_name: &str) -> Result<Option<String>, String> {
-    let script = format!(
-        r#"
-Add-Type -AssemblyName System.Windows.Forms | Out-Null
-$dlg = New-Object System.Windows.Forms.SaveFileDialog
-$dlg.FileName = "{default_name}"
-$dlg.Filter = "Houston Agent (*.houstonagent)|*.houstonagent"
-if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {{
-    Write-Output $dlg.FileName
-}}
-"#
-    );
-    let output = Command::new("powershell")
-        .args(["-NoProfile", "-Sta", "-Command", &script])
-        .output()
-        .await
-        .map_err(|e| format!("Failed to open save dialog: {e}"))?;
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok(if path.is_empty() { None } else { Some(path) })
-}
-
-#[cfg(target_os = "macos")]
-async fn open_dialog() -> Result<Option<String>, String> {
-    // `choose file` always returns a POSIX path. The user can pick any
-    // extension; we validate the bytes parse server-side.
-    let script = r#"POSIX path of (choose file with prompt "Pick an agent file from a friend")"#;
-    let output = Command::new("osascript")
-        .arg("-e")
-        .arg(script)
-        .output()
-        .await
-        .map_err(|e| format!("Failed to open file dialog: {e}"))?;
-    if !output.status.success() {
-        return Ok(None);
-    }
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok(if path.is_empty() { None } else { Some(path) })
-}
-
-#[cfg(target_os = "windows")]
-async fn open_dialog() -> Result<Option<String>, String> {
-    let script = r#"
-Add-Type -AssemblyName System.Windows.Forms | Out-Null
-$dlg = New-Object System.Windows.Forms.OpenFileDialog
-$dlg.Filter = "Houston Agent (*.houstonagent)|*.houstonagent|All files (*.*)|*.*"
-if ($dlg.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {
-    Write-Output $dlg.FileName
-}
-"#;
-    let output = Command::new("powershell")
-        .args(["-NoProfile", "-Sta", "-Command", script])
-        .output()
-        .await
-        .map_err(|e| format!("Failed to open file dialog: {e}"))?;
-    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    Ok(if path.is_empty() { None } else { Some(path) })
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-async fn save_dialog(_default_name: &str) -> Result<Option<String>, String> {
-    Err("Save dialog not yet implemented on this platform.".into())
-}
-
-#[cfg(not(any(target_os = "macos", target_os = "windows")))]
-async fn open_dialog() -> Result<Option<String>, String> {
-    Err("Open dialog not yet implemented on this platform.".into())
-}
+const WIN_FILTER: &str = "Houston Agent (*.houstonagent)|*.houstonagent|All files (*.*)|*.*";
 
 /// Show a save dialog and write the provided bytes to the chosen path.
 /// Returns the path the user picked, or `None` if cancelled.
@@ -106,7 +20,8 @@ pub async fn save_portable_agent(
     default_name: String,
     bytes: Vec<u8>,
 ) -> Result<Option<String>, String> {
-    let Some(path) = save_dialog(&default_name).await? else {
+    let Some(path) = save_dialog("Save shared agent", &default_name, Some(WIN_FILTER)).await?
+    else {
         return Ok(None);
     };
     let target = PathBuf::from(&path);
@@ -120,7 +35,8 @@ pub async fn save_portable_agent(
 /// `None` if the user cancelled.
 #[tauri::command(rename_all = "snake_case")]
 pub async fn open_portable_agent() -> Result<Option<Vec<u8>>, String> {
-    let Some(path) = open_dialog().await? else {
+    let Some(path) = open_dialog("Pick an agent file from a friend", Some(WIN_FILTER)).await?
+    else {
         return Ok(None);
     };
     let bytes = tokio::fs::read(&path)

--- a/app/src-tauri/src/commands/save_file.rs
+++ b/app/src-tauri/src/commands/save_file.rs
@@ -1,0 +1,87 @@
+//! Save downloaded workspace bytes to the user's machine.
+//!
+//! The desktop webview (WKWebView on macOS) ignores `<a download>` clicks on
+//! `blob:` URLs, so the Files tab's Download actions can't rely on the
+//! browser's download machinery like the web build does (HOU-703). Instead
+//! the frontend fetches the bytes itself (with auth) and hands them to this
+//! command, which shows an OS save dialog and writes the file natively.
+//!
+//! The bytes arrive as a raw IPC payload (`InvokeBody::Raw`), NOT a JSON
+//! array — workspace archives can be hundreds of megabytes and JSON-encoding
+//! them number-by-number would freeze the webview. The filename travels in
+//! the percent-encoded `x-download-name` request header.
+
+use percent_encoding::percent_decode_str;
+use tauri::ipc::{InvokeBody, Request};
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use super::dialogs::save_dialog;
+
+/// The suggested filename, decoded from the `x-download-name` header and
+/// stripped of path separators so it can't steer the dialog's directory.
+fn requested_name(request: &Request<'_>) -> String {
+    let raw = request
+        .headers()
+        .get("x-download-name")
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+    let decoded = percent_decode_str(raw).decode_utf8_lossy();
+    let cleaned = decoded.replace(['/', '\\'], "-").trim().to_string();
+    if cleaned.is_empty() {
+        "download".to_string()
+    } else {
+        cleaned
+    }
+}
+
+/// Pick a save destination and write the payload there. Returns the chosen
+/// path, or `None` when the user cancelled the dialog.
+///
+/// Linux has no dialog helper yet (mirrors the portable share flow); there we
+/// write straight into the OS download directory under a collision-free name,
+/// which matches what a browser download would do anyway.
+#[tauri::command]
+pub async fn save_download(request: Request<'_>) -> Result<Option<String>, String> {
+    let InvokeBody::Raw(bytes) = request.body() else {
+        return Err("save_download expects a raw byte payload".into());
+    };
+    let name = requested_name(&request);
+    let Some(path) = pick_destination(&name).await? else {
+        return Ok(None);
+    };
+    tokio::fs::write(&path, bytes)
+        .await
+        .map_err(|e| format!("Failed to save file: {e}"))?;
+    Ok(Some(path))
+}
+
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+async fn pick_destination(name: &str) -> Result<Option<String>, String> {
+    save_dialog("Save file", name, None).await
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+async fn pick_destination(name: &str) -> Result<Option<String>, String> {
+    // No native dialog on this platform — save into ~/Downloads like a
+    // browser would, deduplicating "name.ext" → "name (2).ext".
+    let dir = dirs::download_dir()
+        .or_else(dirs::home_dir)
+        .ok_or_else(|| "Could not resolve a download directory".to_string())?;
+    Ok(Some(dedupe_path(&dir, name).to_string_lossy().into_owned()))
+}
+
+#[cfg(not(any(target_os = "macos", target_os = "windows")))]
+fn dedupe_path(dir: &std::path::Path, name: &str) -> std::path::PathBuf {
+    let first = dir.join(name);
+    if !first.exists() {
+        return first;
+    }
+    let (stem, ext) = match name.rsplit_once('.') {
+        Some((s, e)) if !s.is_empty() => (s.to_string(), format!(".{e}")),
+        _ => (name.to_string(), String::new()),
+    };
+    (2u32..)
+        .map(|n| dir.join(format!("{stem} ({n}){ext}")))
+        .find(|p| !p.exists())
+        .expect("some free filename exists")
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -353,6 +353,9 @@ pub fn run() {
             commands::terminal::open_terminal,
             commands::portable::save_portable_agent,
             commands::portable::open_portable_agent,
+            // Native "Save as…" for Files-tab downloads — the webview ignores
+            // anchor-download clicks, so the shell writes the bytes itself.
+            commands::save_file::save_download,
             commands::update::current_app_bundle_path,
             commands::update::relaunch_app_from_path,
             // Hidden Sentry smoke command for native stack verification.

--- a/app/src/components/tabs/file-preview-dialog.tsx
+++ b/app/src/components/tabs/file-preview-dialog.tsx
@@ -9,7 +9,7 @@ import {
 } from "@houston-ai/core";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { saveBlob } from "../../lib/save-blob";
+import { useSaveDownload } from "../../hooks/use-save-download";
 import { tauriFiles } from "../../lib/tauri";
 
 /**
@@ -43,6 +43,7 @@ export function FilePreviewDialog({
   onClose,
 }: Props) {
   const { t } = useTranslation("agents");
+  const save = useSaveDownload();
   const [loaded, setLoaded] = useState<Loaded>({ state: "loading" });
 
   useEffect(() => {
@@ -143,7 +144,7 @@ export function FilePreviewDialog({
             {t("files.preview.close")}
           </Button>
           {blob && (
-            <Button type="button" onClick={() => saveBlob(fileName, blob)}>
+            <Button type="button" onClick={() => void save(fileName, blob)}>
               {t("files.preview.download")}
             </Button>
           )}

--- a/app/src/components/tabs/files-tab.tsx
+++ b/app/src/components/tabs/files-tab.tsx
@@ -12,8 +12,8 @@ import {
   useUploadFiles,
 } from "../../hooks/queries";
 import { useCapabilities } from "../../hooks/use-capabilities";
+import { useSaveDownload } from "../../hooks/use-save-download";
 import { isCoLocatedEngine, newEngineActive } from "../../lib/engine";
-import { saveBlob } from "../../lib/save-blob";
 import { tauriFiles } from "../../lib/tauri";
 import type { TabProps } from "../../lib/types";
 import { FilePreviewDialog } from "./file-preview-dialog";
@@ -62,17 +62,25 @@ export default function FilesTab({ agent }: TabProps) {
   const uploadFiles = useUploadFiles(path);
   const moveFile = useMoveFile(path);
 
+  // save() surfaces its own success/failure toasts and never rejects; the
+  // empty catch below only silences the fetch failure call() already toasted.
+  const save = useSaveDownload();
   const downloadFile = (file: FileEntry) => {
-    // call() already toasts + captures the failure; nothing more to surface.
     tauriFiles
       .download(path, file.path)
-      .then(({ blob }) => saveBlob(file.name, blob))
+      .then(({ blob }) => save(file.name, blob))
+      .catch(() => {});
+  };
+  const downloadFolder = (folder: FileEntry) => {
+    tauriFiles
+      .downloadArchive(path, folder.path)
+      .then(({ blob }) => save(`${folder.name}.zip`, blob))
       .catch(() => {});
   };
   const downloadAll = () => {
     tauriFiles
       .downloadArchive(path)
-      .then(({ blob }) => saveBlob(`${agent.name} files.zip`, blob))
+      .then(({ blob }) => save(`${agent.name} files.zip`, blob))
       .catch(() => {});
   };
   const pickFiles = () => fileInput.current?.click();
@@ -104,6 +112,7 @@ export default function FilesTab({ agent }: TabProps) {
             : undefined
         }
         onDownload={canUseLocalFiles ? undefined : downloadFile}
+        onDownloadFolder={canUseLocalFiles ? undefined : downloadFolder}
         onDelete={(file) => deleteFile.mutate(file.path)}
         onRename={(file, newName) =>
           renameFile.mutate({ relativePath: file.path, newName })

--- a/app/src/hooks/use-save-download.ts
+++ b/app/src/hooks/use-save-download.ts
@@ -1,0 +1,53 @@
+import { useCallback } from "react";
+import { useTranslation } from "react-i18next";
+import { logger } from "../lib/logger";
+import { osRevealPath } from "../lib/os-bridge";
+import { saveBlob } from "../lib/save-blob";
+import { useUIStore } from "../stores/ui";
+
+/**
+ * Save a downloaded Blob to the user's machine and toast the outcome.
+ *
+ * Browser builds stay silent on success (the browser shows its own download
+ * UI); the desktop shell writes the file natively and gets a "Saved" toast
+ * with a reveal action. Never rejects — a failure surfaces as an error toast
+ * (beta policy: no silent failures), a cancelled save dialog stays quiet.
+ */
+export function useSaveDownload(): (name: string, blob: Blob) => Promise<void> {
+  const { t } = useTranslation("agents");
+  const addToast = useUIStore((s) => s.addToast);
+  return useCallback(
+    async (name: string, blob: Blob) => {
+      try {
+        const result = await saveBlob(name, blob);
+        if (result.kind !== "saved" || result.path === null) return;
+        const path = result.path;
+        addToast({
+          variant: "success",
+          title: t("files.toasts.savedTitle"),
+          description: t("files.toasts.savedDescription", { name }),
+          action: {
+            label: t("files.toasts.revealAction"),
+            onClick: () => {
+              void osRevealPath(path).catch((err) =>
+                addToast({
+                  variant: "error",
+                  title: t("files.toasts.revealFailed"),
+                  description: String(err),
+                }),
+              );
+            },
+          },
+        });
+      } catch (err) {
+        logger.error(`[files:save-download] ${String(err)}`, name);
+        addToast({
+          variant: "error",
+          title: t("files.toasts.saveFailedTitle"),
+          description: err instanceof Error ? err.message : String(err),
+        });
+      }
+    },
+    [t, addToast],
+  );
+}

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -157,6 +157,21 @@ export function osRevealPath(path: string): Promise<void> {
   return invoke<void>("reveal_path", { path });
 }
 
+/** Native "Save as…" for downloaded bytes — the desktop webview ignores
+ * anchor-download clicks (no download delegate), so the shell shows the OS
+ * save dialog and writes the file itself (HOU-703). The bytes travel as a raw
+ * IPC payload (not JSON) so large archives don't freeze the webview; the
+ * filename rides in the percent-encoded `x-download-name` header. Resolves
+ * with the chosen path, or null when the user cancelled the dialog. */
+export function osSaveDownload(
+  fileName: string,
+  bytes: Uint8Array,
+): Promise<string | null> {
+  return invoke<string | null>("save_download", bytes, {
+    headers: { "x-download-name": encodeURIComponent(fileName) },
+  });
+}
+
 /** Open an agent-relative file with the user's default application. */
 export function osOpenFile(
   agentPath: string,

--- a/app/src/lib/save-blob.ts
+++ b/app/src/lib/save-blob.ts
@@ -1,8 +1,28 @@
+import { isTauri } from "@tauri-apps/api/core";
+import { osSaveDownload } from "./os-bridge";
+
+export type SaveBlobResult =
+  | { kind: "saved"; path: string | null }
+  | { kind: "cancelled" };
+
 /**
- * Hand a Blob to the browser as a named download. Web-build only — the
- * desktop app opens files with the OS instead (tauriFiles.open/reveal).
+ * Hand a Blob to the user as a named download.
+ *
+ * Browser builds use the anchor-download machinery. The desktop webview
+ * (WKWebView) ignores those clicks — there is no download delegate — so on
+ * desktop the bytes go to the native shell instead, which shows an OS save
+ * dialog and writes the file itself (HOU-703). `path` is non-null only on
+ * that native path; browsers manage their own download location.
  */
-export function saveBlob(name: string, blob: Blob): void {
+export async function saveBlob(
+  name: string,
+  blob: Blob,
+): Promise<SaveBlobResult> {
+  if (isTauri()) {
+    const bytes = new Uint8Array(await blob.arrayBuffer());
+    const path = await osSaveDownload(name, bytes);
+    return path === null ? { kind: "cancelled" } : { kind: "saved", path };
+  }
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");
   a.href = url;
@@ -12,4 +32,5 @@ export function saveBlob(name: string, blob: Blob): void {
   a.remove();
   // Revoke once the download has had time to start.
   setTimeout(() => URL.revokeObjectURL(url), 10_000);
+  return { kind: "saved", path: null };
 }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -714,11 +714,14 @@ export const tauriFiles = {
     call<void>("move_project_file", () =>
       getEngine().moveProjectFile(agentPath, relPath, toDir),
     ),
-  /** The whole workspace as one zip — "Download all" where there is no local
-   * file manager to reveal in (cloud pods, web builds). */
-  downloadArchive: (agentPath: string) =>
-    call<{ blob: Blob; contentType: string }>("download_project_archive", () =>
-      getEngine().downloadProjectArchive(agentPath),
+  /** One zip of the whole workspace ("Download all") or, with `relPath`, of a
+   * single folder — where there is no local file manager to reveal in (cloud
+   * pods, web builds). */
+  downloadArchive: (agentPath: string, relPath?: string) =>
+    call<{ blob: Blob; contentType: string }>(
+      "download_project_archive",
+      () => getEngine().downloadProjectArchive(agentPath, relPath),
+      { agentPath, relPath },
     ),
   revealAgent: (agentPath: string) => osRevealAgent(agentPath),
 };

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -173,6 +173,13 @@
       "download": "Download",
       "close": "Close",
       "errorTitle": "Couldn't load the file"
+    },
+    "toasts": {
+      "savedTitle": "File saved",
+      "savedDescription": "{{name}} was saved to your computer.",
+      "revealAction": "Show in File Manager",
+      "revealFailed": "Couldn't show the file",
+      "saveFailedTitle": "Couldn't save the file"
     }
   }
 }

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -173,6 +173,13 @@
       "download": "Descargar",
       "close": "Cerrar",
       "errorTitle": "No se pudo cargar el archivo"
+    },
+    "toasts": {
+      "savedTitle": "Archivo guardado",
+      "savedDescription": "{{name}} se guardó en tu computador.",
+      "revealAction": "Mostrar en el Explorador de Archivos",
+      "revealFailed": "No se pudo mostrar el archivo",
+      "saveFailedTitle": "No se pudo guardar el archivo"
     }
   }
 }

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -173,6 +173,13 @@
       "download": "Baixar",
       "close": "Fechar",
       "errorTitle": "Não foi possível carregar o arquivo"
+    },
+    "toasts": {
+      "savedTitle": "Arquivo salvo",
+      "savedDescription": "{{name}} foi salvo no seu computador.",
+      "revealAction": "Mostrar no Explorador de Arquivos",
+      "revealFailed": "Não foi possível mostrar o arquivo",
+      "saveFailedTitle": "Não foi possível salvar o arquivo"
     }
   }
 }

--- a/packages/fake-host/src/routes-files.ts
+++ b/packages/fake-host/src/routes-files.ts
@@ -37,12 +37,20 @@ export function handleWorkspaceFiles(
   }
 
   if (sub === "archive" && method === "GET") {
-    const files = state.listWorkspaceFiles(id).filter((f) => !f.is_directory);
+    // No `path` → whole workspace; with `path` → that folder's subtree, with
+    // the folder itself as the zip's root entry (like the real host).
+    const folder = query.get("path");
+    const base = folder ? folder.slice(0, folder.lastIndexOf("/") + 1) : "";
+    const files = state
+      .listWorkspaceFiles(id)
+      .filter(
+        (f) => !f.is_directory && (!folder || f.path.startsWith(`${folder}/`)),
+      );
     if (files.length === 0) return json({ error: "no files to download" }, 404);
     const entries: Zippable = {};
     for (const f of files) {
       const w = state.readWorkspaceFile(id, f.path);
-      if (w) entries[f.path] = new Uint8Array(w.bytes);
+      if (w) entries[f.path.slice(base.length)] = new Uint8Array(w.bytes);
     }
     return new Response(new Uint8Array(zipSync(entries)), {
       status: 200,

--- a/packages/host/src/turn/files-archive.test.ts
+++ b/packages/host/src/turn/files-archive.test.ts
@@ -35,3 +35,30 @@ test("an empty workspace answers 404, not an empty zip", async () => {
     "no files to download",
   );
 });
+
+test("a folder subtree zips with the folder as the archive root", async () => {
+  const vfs = new MemoryVfs();
+  await vfs.writeText(`${ROOT}/report.md`, "# Q3");
+  await vfs.writeText(`${ROOT}/Decks/2025/deck.md`, "slides");
+  await vfs.writeText(`${ROOT}/Decks/notes.md`, "n");
+
+  const zip = await archiveWorkspace(vfs, ROOT, "Decks");
+  const entries = unzipSync(new Uint8Array(zip));
+  expect(Object.keys(entries).sort()).toEqual([
+    "Decks/2025/deck.md",
+    "Decks/notes.md",
+  ]);
+
+  // A nested folder becomes the root entry itself (parent prefix stripped).
+  const nested = await archiveWorkspace(vfs, ROOT, "Decks/2025");
+  const nestedEntries = unzipSync(new Uint8Array(nested));
+  expect(Object.keys(nestedEntries)).toEqual(["2025/deck.md"]);
+});
+
+test("a missing or empty folder answers 404, and prefixes don't false-match", async () => {
+  const vfs = new MemoryVfs();
+  await vfs.writeText(`${ROOT}/Decks2/other.md`, "x"); // sibling with the same prefix
+  await expect(archiveWorkspace(vfs, ROOT, "Decks")).rejects.toThrow(
+    "no files to download",
+  );
+});

--- a/packages/host/src/turn/files-archive.ts
+++ b/packages/host/src/turn/files-archive.ts
@@ -3,8 +3,9 @@ import type { Vfs } from "../vfs";
 import { FileOpError, fileKey, listWorkspace } from "./files-ops";
 
 /**
- * Zip the agent's visible workspace files — the Files tab's "Download all" on
- * deployments with no local OS to reveal a folder in (cloud pods, web builds).
+ * Zip the agent's visible workspace files — the Files tab's "Download all"
+ * (whole workspace) and per-folder Download on deployments with no local OS
+ * to reveal a folder in (cloud pods, web builds, desktop → remote host).
  * Same visibility rules as the listing (`listWorkspace`): internal dot-dirs and
  * `.keep` markers never land in the archive. STORE-only (level 0): the
  * deliverables agents produce (pdf/docx/xlsx/png) are already compressed, and a
@@ -22,9 +23,16 @@ const ZIP_MTIME_MAX = Date.UTC(2099, 0, 1);
 export async function archiveWorkspace(
   vfs: Vfs,
   root: string,
+  folder?: string,
 ): Promise<Buffer> {
-  const files = (await listWorkspace(vfs, root)).filter((f) => !f.is_directory);
+  const all = (await listWorkspace(vfs, root)).filter((f) => !f.is_directory);
+  const files = folder
+    ? all.filter((f) => f.path.startsWith(`${folder}/`))
+    : all;
   if (files.length === 0) throw new FileOpError(404, "no files to download");
+  // Zip a folder the way Finder does: the folder itself is the archive's root
+  // entry, so entry names are relative to the folder's PARENT.
+  const base = folder ? folder.slice(0, folder.lastIndexOf("/") + 1) : "";
   const total = files.reduce((sum, f) => sum + f.size, 0);
   if (total > MAX_ARCHIVE_BYTES) {
     throw new FileOpError(
@@ -39,7 +47,7 @@ export async function archiveWorkspace(
     const mtime = f.date_modified;
     const validMtime =
       mtime !== undefined && mtime >= ZIP_MTIME_MIN && mtime <= ZIP_MTIME_MAX;
-    entries[f.path] = [
+    entries[f.path.slice(base.length)] = [
       new Uint8Array(buf),
       { level: 0, ...(validMtime ? { mtime } : {}) },
     ];

--- a/packages/host/src/turn/files.ts
+++ b/packages/host/src/turn/files.ts
@@ -134,13 +134,17 @@ export async function handleFiles(
       return true;
     }
     if (method === "GET" && rest === "files/archive") {
-      const zip = await archiveWorkspace(vfs, root);
+      // No `path` → the whole workspace ("Download all"); with `path` → just
+      // that folder's subtree (the folder row's Download).
+      const rawFolder = query.get("path");
+      const folder = rawFolder ? safeRel(rawFolder) : undefined;
+      const zip = await archiveWorkspace(vfs, root, folder);
+      const zipName = folder
+        ? `${folder.split("/").pop()}.zip`
+        : `${ctx.agent.name} files.zip`;
       res.writeHead(200, {
         "Content-Type": "application/zip",
-        "Content-Disposition": contentDisposition(
-          "attachment",
-          `${ctx.agent.name} files.zip`,
-        ),
+        "Content-Disposition": contentDisposition("attachment", zipName),
         "Content-Length": zip.length,
         "Cache-Control": "no-store",
       });

--- a/packages/web/e2e/files.spec.ts
+++ b/packages/web/e2e/files.spec.ts
@@ -80,6 +80,24 @@ test("renames and deletes a file from the context menu", async ({ page }) => {
   await expect(page.getByText("Q3 final.pdf")).toHaveCount(0);
 });
 
+test("a folder downloads as its own zip from the context menu", async ({
+  page,
+}) => {
+  await openFilesTab(page);
+
+  await page.getByText("Docs", { exact: true }).click({ button: "right" });
+  const [download] = await Promise.all([
+    page.waitForEvent("download"),
+    page.getByRole("menu").getByText("Download").click(),
+  ]);
+  const file = await download.path();
+  const { readFileSync } = await import("node:fs");
+  const zip = readFileSync(file);
+  expect(zip.subarray(0, 2).toString("latin1")).toBe("PK");
+  // Zip entry names are stored verbatim; the folder is the archive's root.
+  expect(zip.toString("latin1")).toContain("Docs/sales.csv");
+});
+
 test("Download all saves the whole workspace as one zip", async ({ page }) => {
   await openFilesTab(page);
 

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -753,13 +753,18 @@ export class HoustonClient {
       body: JSON.stringify({ path: relPath, toDir }),
     });
   }
-  /** The whole workspace as one zip — "Download all" where there's no local
-   * file manager to reveal in (cloud pods, web builds). */
+  /** One zip of the workspace ("Download all") or, with `path`, of a single
+   * folder's subtree — for deployments with no local file manager to reveal
+   * in (cloud pods, web builds). */
   async downloadProjectArchive(
     agentPath: string,
+    path?: string,
   ): Promise<{ blob: Blob; contentType: string }> {
     if (!this.cp) throw new Error("Downloads need a connected host.");
-    const res = await this.cpFilesFetch(agentPath, "files/archive");
+    const res = await this.cpFilesFetch(
+      agentPath,
+      `files/archive${path ? `?path=${encodeURIComponent(path)}` : ""}`,
+    );
     return {
       blob: await res.blob(),
       contentType: res.headers.get("content-type") ?? "application/zip",

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -23,7 +23,11 @@ export function isTauri(): boolean {
   return false;
 }
 
-type InvokeArgs = Record<string, unknown> | undefined;
+type InvokeArgs = Record<string, unknown> | Uint8Array | undefined;
+
+/** Mirror of `@tauri-apps/api`'s InvokeOptions (headers ride the raw-payload
+ * IPC on desktop). The web shim has no native IPC, so they're ignored. */
+type InvokeOptions = { headers?: Record<string, string> };
 
 function notAvailable(cmd: string): never {
   throw new Error(
@@ -89,8 +93,12 @@ function pickFileBytes(accept: string): Promise<number[] | null> {
 
 export async function invoke<T = unknown>(
   cmd: string,
-  args?: InvokeArgs,
+  rawArgs?: InvokeArgs,
+  _options?: InvokeOptions,
 ): Promise<T> {
+  // Raw-payload invokes (desktop's binary IPC) carry bytes, not a record.
+  const payload = rawArgs instanceof Uint8Array ? rawArgs : undefined;
+  const args = rawArgs instanceof Uint8Array ? undefined : rawArgs;
   switch (cmd) {
     // ── Implemented with a browser-native equivalent ────────────────────
     case "open_url": {
@@ -133,6 +141,14 @@ export async function invoke<T = unknown>(
     case "open_portable_agent": {
       const bytes = await pickFileBytes(".houstonagent,application/zip");
       return bytes as T;
+    }
+    case "save_download": {
+      // Unreachable in practice: `saveBlob` checks isTauri() (false here) and
+      // uses the anchor download directly. Keep an honest fallback anyway —
+      // returning null means "the browser manages the download", so the
+      // caller shows no desktop-style saved toast.
+      if (payload) downloadBytes("download", Array.from(payload));
+      return null as T;
     }
 
     case "report_bug": {

--- a/ui/agent/src/file-row.tsx
+++ b/ui/agent/src/file-row.tsx
@@ -32,6 +32,7 @@ export function FolderSection({
   onOpen,
   onReveal,
   onDownload,
+  onDownloadFolder,
   onDelete,
   onRename,
   onFilesDropped,
@@ -46,6 +47,8 @@ export function FolderSection({
   onOpen?: (file: FileEntry) => void;
   onReveal?: (file: FileEntry) => void;
   onDownload?: (file: FileEntry) => void;
+  /** Download the folder's subtree (as a zip). Adds a context menu to folder rows. */
+  onDownloadFolder?: (folder: FileEntry) => void;
   onDelete?: (file: FileEntry) => void;
   onRename?: (file: FileEntry, newName: string) => void;
   onFilesDropped?: (files: File[], targetFolder?: string) => void;
@@ -54,6 +57,7 @@ export function FolderSection({
   menuLabels?: FileMenuLabels;
 }) {
   const [open, setOpen] = useState(true);
+  const [menu, setMenu] = useState<{ x: number; y: number } | null>(null);
   const [dragging, setDragging] = useState(false);
   const { isOver, folderHandlers } = useFolderDropTarget();
 
@@ -62,6 +66,15 @@ export function FolderSection({
   }, [isOver, node.path, onDragActive]);
 
   const padLeft = BASE_INDENT + depth * DEPTH_INDENT;
+  // The menu reuses FileMenu, which speaks FileEntry — implied parent folders
+  // have no listing entry, so synthesize one from the node.
+  const folderEntry: FileEntry = node.entry ?? {
+    path: node.path,
+    name: node.name,
+    extension: "",
+    size: 0,
+    is_directory: true,
+  };
 
   return (
     <>
@@ -76,6 +89,11 @@ export function FolderSection({
         onDragEnd={() => setDragging(false)}
         onClick={() => setOpen(!open)}
         onKeyDown={(e) => e.key === "Enter" && setOpen(!open)}
+        onContextMenu={(e) => {
+          if (!onDownloadFolder) return;
+          e.preventDefault();
+          setMenu({ x: e.clientX, y: e.clientY });
+        }}
         className={cn(
           "h-[24px] select-none cursor-default items-center w-full text-left",
           isOver ? "!bg-[rgba(0,122,255,0.12)] !rounded-lg" : "",
@@ -105,6 +123,15 @@ export function FolderSection({
           Folder
         </span>
       </button>
+      {menu && (
+        <FileMenu
+          file={folderEntry}
+          position={menu}
+          onClose={() => setMenu(null)}
+          onDownload={onDownloadFolder}
+          labels={menuLabels}
+        />
+      )}
       {open &&
         node.children.map((child) =>
           child.kind === "folder" ? (
@@ -117,6 +144,7 @@ export function FolderSection({
               onOpen={onOpen}
               onReveal={onReveal}
               onDownload={onDownload}
+              onDownloadFolder={onDownloadFolder}
               onDelete={onDelete}
               onRename={onRename}
               onFilesDropped={onFilesDropped}

--- a/ui/agent/src/files-browser.tsx
+++ b/ui/agent/src/files-browser.tsx
@@ -44,6 +44,8 @@ export interface FilesBrowserProps {
   onReveal?: (file: FileEntry) => void;
   /** Save the file to the user's machine (browser builds; desktop uses onOpen/onReveal). */
   onDownload?: (file: FileEntry) => void;
+  /** Save a folder's subtree as a zip. Adds a context menu to folder rows. */
+  onDownloadFolder?: (folder: FileEntry) => void;
   onDelete?: (file: FileEntry) => void;
   onFilesDropped?: (files: File[], targetFolder?: string) => void;
   /** Move a file/folder to a new location (null = root) */
@@ -69,6 +71,7 @@ export function FilesBrowser({
   onOpen,
   onReveal,
   onDownload,
+  onDownloadFolder,
   onDelete,
   onFilesDropped,
   onMove,
@@ -270,6 +273,7 @@ export function FilesBrowser({
                     onOpen={onOpen}
                     onReveal={onReveal}
                     onDownload={onDownload}
+                    onDownloadFolder={onDownloadFolder}
                     onDelete={onDelete}
                     onRename={onRename}
                     onFilesDropped={onFilesDropped}

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -652,6 +652,7 @@ export class HoustonClient {
    * it is never offered in the UI here, so refuse loudly if reached. */
   async downloadProjectArchive(
     _agentPath: string,
+    _path?: string,
   ): Promise<{ blob: Blob; contentType: string }> {
     throw new Error("Downloading all files is not supported on this engine.");
   }


### PR DESCRIPTION
## Root cause

Every download in the Files tab funnels into `saveBlob`, which creates an `<a download>` pointing at a `blob:` URL and clicks it. That works in real browsers, but the desktop webview (WKWebView) ignores those clicks entirely — there is no download delegate and the Tauri shell had no native save path. So on the desktop app running against a remote host (the cloud product), **single-file Download, the preview dialog's Download button, and "Download all" all silently did nothing** — no file, no error, no toast. There was also no way to download a folder: folder rows had no context menu, and the host's archive route could only zip the whole workspace.

## The fix

- **Native save path in the shell** (`commands/save_file.rs`): a new `save_download` command receives the bytes as a **raw IPC payload** (not a JSON number array — archives can be hundreds of MB and JSON-encoding them would freeze the webview), with the filename in a percent-encoded `x-download-name` header. It shows the OS save dialog and writes the file natively. The platform dialogs are extracted from the portable share flow into a shared `commands/dialogs.rs`, now with proper AppleScript/PowerShell escaping.
- **`saveBlob` branches by platform**: Tauri → native save; browser → the existing anchor download. A shared `useSaveDownload` hook surfaces the outcome per the no-silent-failures policy: saved → success toast with a "Show in File Manager" action, failure → error toast, cancelled dialog → quiet. New `files.toasts` strings in en/es/pt.
- **Per-folder download**: the host's `GET files/archive` now accepts `?path=<folder>` and zips just that subtree with the folder as the zip's root entry (Finder-style). Folder rows get a context menu with Download (wired only where there's no local OS to reveal in, same gate as file downloads).
- **Web shim parity**: `save_download` case + widened `invoke` signature for raw payloads, keeping `check-tauri-shims` green.

## Reproduce (before)

1. In the desktop app signed into Houston Cloud (or any remote host), open an agent → **Files** tab.
2. Right-click any file → **Download** → nothing happens (no dialog, no file, no error).
3. Same for **Download all** in the footer and **Download** inside the preview dialog.
4. Right-click a folder → no menu at all; there is no way to download a folder.

## Verify (after)

1. Same setup → right-click a file → **Download** → OS save dialog appears; saving writes the file and shows a "File saved" toast whose action reveals it in Finder/Explorer.
2. Footer **Download all** → save dialog for `<agent> files.zip`; the zip contains exactly the visible workspace files.
3. Right-click a folder → **Download** → save dialog for `<folder>.zip`; the zip contains just that folder's subtree, rooted at the folder.
4. Cancelling any save dialog does nothing (no error toast).
5. Web build (`packages/web`) still downloads via the browser's own download UI (covered by Playwright: `files.spec.ts`, including the new folder-download test).

Tests: host vitest (folder subtree naming, 404 on empty/missing folder, sibling-prefix no-match), fake-host `?path=` support, new Playwright e2e; `cargo test`, tsgo across the workspace, biome, `check-locales`, `check:parity`, `check:boundaries` all green.

HOU-703

🤖 Generated with [Claude Code](https://claude.com/claude-code)