### PR TITLE
fix: stop Claude turns hanging forever on the binary placeholder stub

### DIFF
--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -283,11 +283,16 @@ fn stage_external_bin(source_stem: &str, dest_stem: &str, label: &str) -> Result
             // Debug builds (typical for `pnpm tauri dev`, which talks to an
             // externally-run host and never spawns this file): Tauri's
             // externalBin bundling still requires the file to exist, so stage
-            // a placeholder.
+            // a placeholder. It EXITS NON-ZERO immediately (never `sleep`s): if
+            // something does spawn it — the engine supervisor, or the Claude
+            // Agent SDK handed this as its `claude` binary — the process must die
+            // loud so the failure surfaces, NOT hang forever waiting on a stub.
+            // (A `sleep`-forever stub here is exactly what hung every Claude turn
+            // on "mission in progress".) Mirrors the frpc placeholder below.
             let placeholder = if cfg!(windows) {
-                "@echo off\r\nexit /b 0\r\n"
+                "@echo off\r\necho placeholder external bin (real binary not staged) - run scripts/build-host-sidecar.sh 1>&2\r\nexit /b 1\r\n"
             } else {
-                "#!/bin/sh\n# placeholder external bin (real binary not staged)\nsleep 2147483647\n"
+                "#!/bin/sh\necho 'placeholder external bin (real binary not staged) - run scripts/build-host-sidecar.sh' >&2\nexit 1\n"
             };
             std::fs::write(&dest, placeholder)
                 .map_err(|e| format!("write placeholder {label}: {e}"))?;

--- a/app/src-tauri/src/claude_login/resolve.rs
+++ b/app/src-tauri/src/claude_login/resolve.rs
@@ -6,7 +6,10 @@ use std::process::Stdio;
 
 use tokio::process::Command;
 
-/// Executable name of the bundled `claude` sidecar (`.exe` on Windows).
+/// Executable name of the bundled `claude` sidecar (`.exe` on Windows). Only the
+/// release-build sibling-resolution arm reads it; in a debug build that arm is
+/// `cfg`'d out (we use PATH `claude` there), so mark it allowed-unused there.
+#[cfg_attr(debug_assertions, allow(dead_code))]
 fn claude_bin_name() -> &'static str {
     if cfg!(windows) {
         "claude.exe"
@@ -20,10 +23,10 @@ fn claude_bin_name() -> &'static str {
 ///      honored verbatim, even if it points outside a bundle).
 ///   2. Sibling of the current executable — the bundled-sidecar location Tauri
 ///      uses on shipping platforms — IF it exists. RELEASE ONLY: a debug /
-///      `tauri dev` build stages a no-op PLACEHOLDER there (`sleep infinity`;
-///      the real ~232 MB binary ships only in release), and spawning THAT hangs
-///      the login on a spinner forever. So in a debug build we skip the sibling
-///      and use the real `claude` on PATH instead.
+///      `tauri dev` build stages a no-op PLACEHOLDER there (a stub that exits
+///      non-zero; the real ~232 MB binary ships only in release), and spawning
+///      THAT fails the login. So in a debug build we skip the sibling and use
+///      the real `claude` on PATH instead.
 ///   3. Bare `claude`, resolved via `PATH` (the dev/test path). No panics.
 pub(super) fn resolve_claude_binary() -> PathBuf {
     // 1. Explicit env override.

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -328,6 +328,21 @@ How the SDK subprocess runs (`backend.ts`):
   SDK at the `<dir of sidecar>/claude` sibling via `pathToClaudeCodeExecutable`.
   Which images carry vs strip the ~250 MB binary (and the deferred desktop
   externalBin wiring) is in `convergence/README.md`.
+  - **Placeholder guard (silent-hang bug fixed 2026-07):** `build.rs` stages a
+    stub in `binaries/claude-<triple>` when the real binary isn't compiled in
+    (any local/dev bundle built WITHOUT `scripts/build-host-sidecar.sh`; release
+    CI always stages the real one and `build.rs` panics if it can't). The stub
+    was historically `sleep 2147483647` — so a debug bundle that spawned the
+    sidecar handed the SDK a sleep-forever "claude" and EVERY Claude turn hung on
+    "mission in progress" with no output and no error (`prompt()` awaits a
+    generator that never yields → no catch, no `done`). Two guards now: (1) the
+    stub EXITS NON-ZERO instead of sleeping (build.rs, like the frpc stub); (2)
+    `resolveClaudeExecutable` sniffs the sibling's first bytes and throws
+    `ClaudeBackendUnavailableError` for a `#!`/`@echo` stub BEFORE spawning, so
+    the turn fails loud (surfaced via exec-turn's catch → `error` frame) instead
+    of hanging. To actually USE Claude in a local bundle, run
+    `scripts/build-host-sidecar.sh <triple>` first (stages the real binary); the
+    external-host dev loop (`pnpm dev:host`, Node) self-resolves and needs nothing.
 
 **Cloud per-turn keeps Anthropic OFF** (ToS). The multi-tenant per-turn Cloud Run
 image strips the `claude` binary and the catalog doesn't advertise `anthropic`;

--- a/packages/runtime/src/backends/claude/binary-path.test.ts
+++ b/packages/runtime/src/backends/claude/binary-path.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest";
 import { ClaudeBackendUnavailableError } from "./backend";
-import { isBunCompiled, resolveClaudeExecutable } from "./binary-path";
+import {
+  isBunCompiled,
+  looksLikePlaceholder,
+  resolveClaudeExecutable,
+} from "./binary-path";
+
+// The leading bytes of a real native `claude` image (Mach-O magic here) — never
+// a shebang or a batch marker, so it must NOT read as a placeholder.
+const MACHO_MAGIC = "\xcf\xfa\xed\xfe\x0c\x00\x00\x01";
+// The two placeholder stubs build.rs stages when the real binary is absent.
+const POSIX_PLACEHOLDER =
+  "#!/bin/sh\necho 'placeholder external bin' >&2\nexit 1\n";
+const WINDOWS_PLACEHOLDER = "@echo off\r\nexit /b 1\r\n";
 
 describe("isBunCompiled", () => {
   it("is false for a normal Node file:// module url", () => {
@@ -42,6 +54,7 @@ describe("resolveClaudeExecutable", () => {
         seen.push(p);
         return true;
       },
+      readHead: () => MACHO_MAGIC, // a real binary
     });
     expect(path).toBe("/Applications/Houston.app/Contents/MacOS/claude");
     expect(seen).toEqual(["/Applications/Houston.app/Contents/MacOS/claude"]);
@@ -53,6 +66,7 @@ describe("resolveClaudeExecutable", () => {
       execPath: "C:\\Program Files\\Houston\\houston-engine.exe",
       platform: "win32",
       exists: () => true,
+      readHead: () => MACHO_MAGIC,
     });
     expect(path?.endsWith("claude.exe")).toBe(true);
   });
@@ -66,5 +80,57 @@ describe("resolveClaudeExecutable", () => {
         exists: () => false,
       }),
     ).toThrow(ClaudeBackendUnavailableError);
+  });
+
+  it("throws when the sibling is a POSIX placeholder stub (would hang the turn)", () => {
+    // A present-but-placeholder `claude` is the silent-hang bug: the SDK would
+    // spawn it and (historically) sleep forever. Refuse it → loud typed error.
+    expect(() =>
+      resolveClaudeExecutable({
+        moduleUrl: "file:///$bunfs/root/binary-path.ts",
+        execPath: "/Applications/Houston.app/Contents/MacOS/houston-engine",
+        platform: "darwin",
+        exists: () => true,
+        readHead: () => POSIX_PLACEHOLDER,
+      }),
+    ).toThrow(ClaudeBackendUnavailableError);
+  });
+
+  it("throws when the sibling is a Windows batch placeholder", () => {
+    expect(() =>
+      resolveClaudeExecutable({
+        moduleUrl: "file:///B:/~BUN/root/binary-path.ts",
+        execPath: "C:\\Program Files\\Houston\\houston-engine.exe",
+        platform: "win32",
+        exists: () => true,
+        readHead: () => WINDOWS_PLACEHOLDER,
+      }),
+    ).toThrow(ClaudeBackendUnavailableError);
+  });
+});
+
+describe("looksLikePlaceholder", () => {
+  it("flags a POSIX shebang stub", () => {
+    expect(looksLikePlaceholder("/x/claude", () => POSIX_PLACEHOLDER)).toBe(
+      true,
+    );
+  });
+
+  it("flags a Windows batch stub", () => {
+    expect(looksLikePlaceholder("/x/claude", () => WINDOWS_PLACEHOLDER)).toBe(
+      true,
+    );
+  });
+
+  it("passes a real native binary (magic bytes)", () => {
+    expect(looksLikePlaceholder("/x/claude", () => MACHO_MAGIC)).toBe(false);
+  });
+
+  it("treats an unreadable file as non-placeholder (a spawn error is loud enough)", () => {
+    expect(
+      looksLikePlaceholder("/x/claude", () => {
+        throw new Error("ENOENT");
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/runtime/src/backends/claude/binary-path.ts
+++ b/packages/runtime/src/backends/claude/binary-path.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "node:fs";
+import { closeSync, existsSync, openSync, readSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { ClaudeBackendUnavailableError } from "./backend";
 
@@ -32,6 +32,51 @@ export interface ResolveClaudeExecutableDeps {
   platform?: NodeJS.Platform;
   /** Filesystem existence probe (injected for tests). */
   exists?: (path: string) => boolean;
+  /**
+   * Read the first few bytes of a file (injected for tests). Used to tell a real
+   * native `claude` binary from the `build.rs` dev placeholder that is staged in
+   * its place when the real one is absent — see `looksLikePlaceholder`.
+   */
+  readHead?: (path: string) => string;
+}
+
+/** Read the first `n` bytes of a file as latin1, without loading the whole file. */
+function readHeadBytes(path: string, n = 8): string {
+  const fd = openSync(path, "r");
+  try {
+    const buf = Buffer.alloc(n);
+    const read = readSync(fd, buf, 0, n, 0);
+    return buf.subarray(0, read).toString("latin1");
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * True when the file at `path` is the `build.rs` externalBin PLACEHOLDER rather
+ * than the real native `claude` binary. When the ~232 MB SDK binary isn't staged
+ * (a local/dev bundle built without `scripts/build-host-sidecar.sh`), `build.rs`
+ * writes a tiny stub script in its place so Tauri's bundler is satisfied. Handing
+ * THAT to the SDK as `claude` is catastrophic: the historic stub `sleep`s
+ * forever, so every Claude turn hangs on "mission in progress" with no output and
+ * no error. A real `claude` is a Mach-O / ELF / PE image whose first bytes are
+ * binary magic; the placeholder is a POSIX shell script (`#!`) or a Windows batch
+ * file (`@echo`). Detect that shape and refuse it so the turn fails LOUD (a typed
+ * error the UI can surface) instead of hanging silently.
+ */
+export function looksLikePlaceholder(
+  path: string,
+  readHead: (path: string) => string = readHeadBytes,
+): boolean {
+  let head: string;
+  try {
+    head = readHead(path);
+  } catch {
+    // Unreadable → let the caller treat it as usable; a spawn failure there is a
+    // loud, distinct error, not this silent-hang case.
+    return false;
+  }
+  return head.startsWith("#!") || head.startsWith("@echo");
 }
 
 /**
@@ -48,7 +93,9 @@ export function isBunCompiled(moduleUrl: string = import.meta.url): boolean {
  * The Claude Code executable path to pass as `options.pathToClaudeCodeExecutable`,
  * or `undefined` on the Node path (let the SDK self-resolve). Throws a typed
  * `ClaudeBackendUnavailableError` when running Bun-compiled but the sibling
- * binary is missing — a build that shipped the sidecar without staging `claude`.
+ * binary is missing OR is the `build.rs` placeholder stub — a build that shipped
+ * the sidecar without staging the real `claude`. Failing here turns a silent
+ * forever-hang (SDK spawns the stub) into a loud, surfaced turn error.
  */
 export function resolveClaudeExecutable(
   deps: ResolveClaudeExecutableDeps = {},
@@ -67,6 +114,18 @@ export function resolveClaudeExecutable(
       new Error(
         `Claude Code binary not found next to the sidecar (expected ${sibling}). ` +
           "The host-sidecar build must stage it via scripts/build-host-sidecar.sh.",
+      ),
+    );
+  }
+  // A present-but-placeholder sibling is WORSE than a missing one: the SDK would
+  // spawn it and the historic stub `sleep`s forever, hanging every turn with no
+  // output. Refuse it here so the turn fails loud instead (see looksLikePlaceholder).
+  if (looksLikePlaceholder(sibling, deps.readHead)) {
+    throw new ClaudeBackendUnavailableError(
+      new Error(
+        `Claude Code binary at ${sibling} is a build placeholder, not the real ` +
+          "binary. This bundle was built without staging it — run " +
+          "scripts/build-host-sidecar.sh (release CI does this automatically).",
       ),
     );
   }


### PR DESCRIPTION
## The bug
Connecting Anthropic worked, but chatting hung on **"mission in progress"** forever — no output, no error.

## Root cause
A local/dev desktop bundle built **without** `scripts/build-host-sidecar.sh` gets a `build.rs` stub staged at `binaries/claude-<triple>` in place of the real ~232 MB SDK binary. The stub was `sleep 2147483647`. When the Bun sidecar handed it to the Claude Agent SDK as its `claude` binary, the SDK's `query()` generator never yielded → `ClaudeSession.prompt()` awaited forever → no `catch`, no `done` → the UI sat on "mission in progress" indefinitely. Login still worked (debug resolves `claude` on `PATH`), which masked the cause.

Proven by isolated probes: the real SDK and the real Claude backend both succeed in ~4 s with the user's credential; a valid cred succeeds fast, a missing cred errors fast in ~0.3 s — **only the placeholder binary hangs**.

## Fix (two guards)
- **`build.rs`** — the external-bin placeholder now **exits non-zero** instead of `sleep`ing (matching the `frpc` stub), so anything that spawns it (engine supervisor or the SDK) dies loud instead of hanging.
- **`binary-path.ts`** — `resolveClaudeExecutable` sniffs the sibling's first bytes and throws `ClaudeBackendUnavailableError` for a `#!`/`@echo` stub **before** spawning. The turn then fails loud, surfaced via `exec-turn`'s catch as an `error` frame, instead of hanging silently.

## Tests
- `binary-path.test.ts`: +placeholder-detection cases (POSIX shebang, Windows batch, real magic bytes, unreadable) — 13 pass; full Claude backend suite 108 pass.
- `cargo test claude_login::resolve` 5 pass; `cargo check` clean (also silenced a pre-existing dead-code warning on `claude_bin_name`).

## Note
To actually **use** Claude in a local bundle, run `scripts/build-host-sidecar.sh <triple>` first (release CI already stages the real binary and `build.rs` panics if it's missing). The external-host dev loop (`pnpm dev:host`, Node) self-resolves and needs nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)