### PR TITLE
fix(sdk): turn stream outlasts cold cloud wakes; no raw "Fetch is aborted" in chat (HOU-705)

### DIFF
--- a/packages/sdk/src/modules/turns/stream-registry.ts
+++ b/packages/sdk/src/modules/turns/stream-registry.ts
@@ -14,11 +14,17 @@ export interface StreamTuning {
 }
 
 /**
- * Consecutive frameless connection attempts before a subscription gives up
- * (~30s at the default backoff cap): a turn settles as an error (the old
- * dead-server UX, not an eternal spinner); an observer disposes silently.
+ * Consecutive frameless connection attempts before a subscription gives up:
+ * a turn settles as an error (the old dead-server UX, not an eternal
+ * spinner); an observer disposes silently. Attempts that fail FAST (dead
+ * local sidecar refusing the connection) spend it in ~45s of backoff; an
+ * attempt that HANGS costs a full 45s idle watchdog, so the budget must
+ * outlast the cloud gateway's cold-wake hold — ensureAwake keeps every
+ * request open for up to 300s while the agent pod starts, and a budget of 6
+ * used to give up at ~283s, moments before a slow wake would have delivered
+ * (HOU-705). 8 hung attempts ≈ 6+ minutes, past the gateway's own verdict.
  */
-export const STREAM_FAILURE_BUDGET = 6;
+export const STREAM_FAILURE_BUDGET = 8;
 /** Budget-exhaustion copy when no attempt surfaced a concrete error. */
 export const STREAM_LOST_MESSAGE = "Lost the connection to the engine.";
 /**

--- a/packages/sdk/src/modules/turns/turn-errors.ts
+++ b/packages/sdk/src/modules/turns/turn-errors.ts
@@ -16,16 +16,30 @@ import { EngineError, FatalResumeError } from "@houston/runtime-client";
  * A fatal stream refusal (FatalResumeError) unwraps to the EngineError it carries.
  */
 export function turnErrorMessage(e: unknown): string {
+  const verdict = engineVerdictMessage(e);
+  if (verdict !== undefined) return verdict;
   if (e instanceof FatalResumeError) e = e.cause;
-  if (e instanceof EngineError) {
-    try {
-      const body = JSON.parse(e.body) as { error?: string };
-      if (body?.error) return body.error;
-    } catch {
-      /* body wasn't JSON — fall through to the generic message */
-    }
-  }
   return e instanceof Error ? e.message : String(e);
+}
+
+/**
+ * The engine's own error copy when `e` carries one, else undefined. Only an
+ * {@link EngineError} (directly or inside a FatalResumeError) with a JSON
+ * `{ error }` body qualifies — that string is authored product copy. Anything
+ * else (a transport failure, the resume loop's own watchdog abort — WebKit's
+ * "Fetch is aborted" / "Load failed") is developer speak that must never
+ * reach the chat (HOU-705); callers substitute their product-voice fallback.
+ */
+export function engineVerdictMessage(e: unknown): string | undefined {
+  if (e instanceof FatalResumeError) e = e.cause;
+  if (!(e instanceof EngineError)) return undefined;
+  try {
+    const body = JSON.parse(e.body) as { error?: string };
+    if (body?.error) return body.error;
+  } catch {
+    /* body wasn't JSON — no product copy to surface */
+  }
+  return undefined;
 }
 
 /**

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -727,10 +727,75 @@ test("the failure budget settles a dead-server turn instead of spinning forever"
     },
   );
 
-  expect(afters).toHaveLength(6); // exactly the budget, then settle + abort
+  expect(afters).toHaveLength(8); // exactly the budget, then settle + abort
   expect(items).toContainEqual({
     feed_type: "system_message",
     data: STREAM_LOST_MESSAGE,
+  });
+  expect(sessionStatuses).toEqual(["running", "error"]);
+});
+
+// HOU-705: a cold cloud wake holds the SSE connect with no bytes, the resume
+// loop's idle watchdog aborts each held attempt, and the budget settle used to
+// surface that abort's raw message — WebKit's "Fetch is aborted" — in the chat.
+test("budget exhaustion on aborted/hung attempts settles with product copy, never the raw transport error", async () => {
+  const { engine, afters } = fakeEngine([
+    () => {
+      const e = new Error("Fetch is aborted"); // WebKit's AbortError message
+      e.name = "AbortError";
+      throw e;
+    },
+  ]);
+  const { items, sessionStatuses, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-budget-abort",
+    "hi",
+    output,
+    registry,
+    { tuning: fast },
+  );
+
+  expect(afters).toHaveLength(8);
+  expect(items).toContainEqual({
+    feed_type: "system_message",
+    data: STREAM_LOST_MESSAGE,
+  });
+  expect(items).not.toContainEqual({
+    feed_type: "system_message",
+    data: "Fetch is aborted",
+  });
+  expect(sessionStatuses).toEqual(["running", "error"]);
+});
+
+test("budget exhaustion keeps the engine's own verdict when the attempts got one", async () => {
+  // The gateway answering 503 after a failed wake IS a verdict with product
+  // copy — that survives; only transport-level messages are replaced.
+  const { engine } = fakeEngine([
+    () => {
+      throw new EngineError(
+        503,
+        JSON.stringify({ error: "engine unavailable" }),
+      );
+    },
+  ]);
+  const { items, sessionStatuses, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-budget-verdict",
+    "hi",
+    output,
+    registry,
+    { tuning: fast },
+  );
+
+  expect(items).toContainEqual({
+    feed_type: "system_message",
+    data: "engine unavailable",
   });
   expect(sessionStatuses).toEqual(["running", "error"]);
 });

--- a/packages/sdk/src/modules/turns/turn-stream.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.ts
@@ -13,7 +13,11 @@ import {
   type StreamTuning,
   streamKey,
 } from "./stream-registry";
-import { isAmbiguousSendFailure, turnErrorMessage } from "./turn-errors";
+import {
+  engineVerdictMessage,
+  isAmbiguousSendFailure,
+  turnErrorMessage,
+} from "./turn-errors";
 import { TurnSink } from "./turn-sink";
 
 export { observeConversation } from "./observe-stream";
@@ -199,10 +203,11 @@ export async function streamTurn(
       onRetry: ({ consecutiveFailures, error }) => {
         if (consecutiveFailures < STREAM_FAILURE_BUDGET) return;
         // The engine has been unreachable for the whole budget: settle with
-        // the real reason (old dead-server UX) instead of spinning forever.
-        sink.fail(
-          error === undefined ? STREAM_LOST_MESSAGE : turnErrorMessage(error),
-        );
+        // the engine's own verdict when the last attempt got one, else the
+        // product copy. Never the raw transport error — a watchdog-aborted
+        // hang rejects with WebKit's "Fetch is aborted", which is developer
+        // speak, not a message (HOU-705).
+        sink.fail(engineVerdictMessage(error) ?? STREAM_LOST_MESSAGE);
         ac.abort();
       },
       ...opts.tuning,


### PR DESCRIPTION
## Root cause (HOU-705)

Sending a message to a cold cloud agent races the client's stream failure budget against the gateway's wake hold — and the loser leaked a raw WebKit error into the chat:

1. `streamTurn` subscribes to the conversation's SSE **before** sending. On a cold agent the gateway holds every per-agent request in `ensureAwake` (up to `GW_READY_TIMEOUT_MS` = 300s) while the pod starts, so the SSE connect delivers no bytes.
2. The resume loop's 45s idle watchdog aborts each held attempt; every abort counts as a frameless failure.
3. After `STREAM_FAILURE_BUDGET` = 6 attempts (~283s — *just under* the gateway's own 300s window, moments before a slow wake would have delivered), the turn settled with the last attempt's raw error. That error is the watchdog's own `AbortError`, whose WebKit message is literally **"Fetch is aborted"** — rendered verbatim in the chat.

So a slow-but-eventually-successful wake was guaranteed to fail client-side, with developer-speak copy, right before it would have succeeded.

## Fix

- **Never surface raw transport errors.** The budget settle now uses a new `engineVerdictMessage()` helper: only an `EngineError` carrying a JSON `{ error }` body (authored product copy, e.g. the gateway's 503 `engine unavailable`) surfaces; any transport-level failure (watchdog abort, `Load failed`, resets) falls back to `STREAM_LOST_MESSAGE`. Status codes and raw fetch messages can no longer reach the chat from this path.
- **`STREAM_FAILURE_BUDGET` 6 → 8** so hung attempts (~6+ minutes) outlast the gateway's 300s wake hold. A slow wake now completes the turn normally; a genuinely failed wake settles with the gateway's own verdict (its 503 answers the held send at 300s) instead of a client-side race. Fast-failing dead-server attempts (desktop sidecar down) still settle in well under a minute.

## Repro (before the fix)

1. On cloud, use an agent whose pod is not running (freshly created, or idle long enough to be scaled down).
2. Send any message and wait. The gateway holds the send + SSE connect while the pod wakes.
3. If the wake takes longer than ~283s, the chat settles as an error with the italic text "Fetch is aborted" even though the pod may come up seconds later.

## Verify (after the fix)

1. Same setup: cold agent, send a message.
2. A wake that completes within the gateway's 300s window now delivers the turn normally (the client rides out the held connects).
3. Simulated total failure (kill the engine/host and keep it down): the chat settles with "Lost the connection to the engine." (or the gateway's own `engine unavailable` verdict) — never a raw fetch error.
4. `pnpm --filter @houston/sdk test` — includes two new regression tests: budget exhaustion on aborted/hung attempts surfaces `STREAM_LOST_MESSAGE` (never "Fetch is aborted"), and an engine verdict (503 JSON body) keeps its own copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)