### PR TITLE
feat(app): reuse model picker in create-agent modal; fix OpenRouter selection + polish

### DIFF
--- a/app/src/components/chat-model-selector-labels.ts
+++ b/app/src/components/chat-model-selector-labels.ts
@@ -19,7 +19,6 @@ export function buildLabels(
     favorites: k("favorites"),
     results: k("results"),
     all: k("all"),
-    connected: k("connected"),
     notConnected: k("notConnected"),
     connect: k("connect"),
     sort: k("sort"),

--- a/app/src/components/portable/import-wizard.tsx
+++ b/app/src/components/portable/import-wizard.tsx
@@ -43,7 +43,7 @@ import { tauriConfig, tauriProvider } from "../../lib/tauri";
 import { useAgentStore } from "../../stores/agents";
 import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
-import { InlineModelSelector } from "../shell/naming-step";
+import { ChatModelSelector } from "../chat-model-selector";
 
 type StepId = "upload" | "name" | "skills" | "routines" | "learnings";
 
@@ -540,11 +540,14 @@ function NameStep({
           placeholder={t("import.step2.namePlaceholder")}
           className="text-center rounded-full"
         />
-        <InlineModelSelector
-          provider={provider}
-          model={model}
-          onSelect={onProviderChange}
-        />
+        <div className="flex justify-center">
+          <ChatModelSelector
+            provider={provider}
+            model={model}
+            onSelect={onProviderChange}
+            agent={null}
+          />
+        </div>
       </div>
     </div>
   );

--- a/app/src/components/shell/ai-assist-step.tsx
+++ b/app/src/components/shell/ai-assist-step.tsx
@@ -3,10 +3,10 @@ import type { SuggestedRoutine } from "@houston-ai/engine-client";
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { tauriAgents, tauriProvider } from "../../lib/tauri";
+import { ChatModelSelector } from "../chat-model-selector";
 import { AgentSetupForm, type AgentSetupFormValues } from "./agent-setup-form";
 import { serializeFormValues } from "./agent-setup-utils";
 import { AiStepFooter } from "./ai-step-footer";
-import { InlineModelSelector } from "./naming-step";
 
 interface AiAssistStepProps {
   provider: string;
@@ -112,10 +112,11 @@ export function AiAssistStep({
             <p className="text-xs font-medium text-muted-foreground">
               {t("aiAssist.brainLabel")}
             </p>
-            <InlineModelSelector
+            <ChatModelSelector
               provider={provider}
               model={model}
               onSelect={handlePickerChange}
+              agent={null}
             />
           </div>
 

--- a/app/src/components/shell/naming-step.tsx
+++ b/app/src/components/shell/naming-step.tsx
@@ -9,14 +9,13 @@ import {
   resolveAgentColor,
   Spinner,
 } from "@houston-ai/core";
-import { ArrowLeft, Check, ChevronDown, FolderOpen } from "lucide-react";
+import { ArrowLeft, Check, FolderOpen } from "lucide-react";
 import type { FormEvent } from "react";
-import { useCallback, useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { localizeCatalogCopy } from "../../agents/catalog-labels";
-import { getModel, getProvider, PROVIDERS } from "../../lib/providers";
-import { type ProviderStatus, tauriProvider } from "../../lib/tauri";
 import type { AgentDefinition } from "../../lib/types";
+import { ChatModelSelector } from "../chat-model-selector";
 
 interface NamingStepProps {
   selectedAgent: AgentDefinition | undefined;
@@ -168,11 +167,14 @@ export function NamingStep({
         )}
 
         {/* AI model selector */}
-        <InlineModelSelector
-          provider={provider}
-          model={model}
-          onSelect={onProviderChange}
-        />
+        <div className="flex justify-center">
+          <ChatModelSelector
+            provider={provider}
+            model={model}
+            onSelect={onProviderChange}
+            agent={null}
+          />
+        </div>
 
         {error && (
           <p className="text-xs text-destructive text-center">{error}</p>
@@ -193,156 +195,5 @@ export function NamingStep({
         </Button>
       </form>
     </div>
-  );
-}
-
-/** Bigger model selector for the agent creation dialog. */
-export function InlineModelSelector({
-  provider,
-  model,
-  onSelect,
-}: {
-  provider: string;
-  model: string;
-  onSelect: (provider: string, model: string) => void;
-}) {
-  const { t } = useTranslation(["providers", "chat"]);
-  const [statuses, setStatuses] = useState<Record<string, ProviderStatus>>({});
-  const [open, setOpen] = useState(false);
-
-  const loadStatuses = useCallback(async () => {
-    // ONE round-trip for all providers (HOU-650) instead of a probe per card.
-    setStatuses(
-      await tauriProvider.checkAllStatuses(PROVIDERS.map((p) => p.id)),
-    );
-  }, []);
-
-  useEffect(() => {
-    loadStatuses();
-  }, [loadStatuses]);
-
-  const currentProvider = getProvider(provider);
-  const currentModel = getModel(provider, model);
-
-  return (
-    <div className="w-full">
-      <button
-        type="button"
-        onClick={() => setOpen(!open)}
-        className={cn(
-          "w-full flex items-center gap-3 px-4 py-3 rounded-xl border transition-colors text-left",
-          open
-            ? "border-foreground/20 bg-secondary"
-            : "border-border hover:border-foreground/15 hover:bg-accent/50",
-        )}
-      >
-        <ProviderIcon providerId={provider} className="size-5 shrink-0" />
-        <div className="flex-1 min-w-0">
-          <div className="text-sm font-medium">
-            {currentModel?.label ?? model}
-          </div>
-          <div className="text-xs text-muted-foreground">
-            {currentProvider?.name}
-          </div>
-        </div>
-        <ChevronDown
-          className={cn(
-            "size-4 text-muted-foreground transition-transform",
-            open && "rotate-180",
-          )}
-        />
-      </button>
-
-      {open && (
-        <div className="mt-2 max-h-72 overflow-y-auto overscroll-contain rounded-xl border border-border bg-card p-1 space-y-0.5">
-          {PROVIDERS.map((prov) => {
-            const status = statuses[prov.id];
-            const connected =
-              (status?.cli_installed && status?.authenticated) ?? false;
-            if (!connected && prov.id !== provider) return null;
-            return (
-              <div key={prov.id}>
-                <div className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-muted-foreground">
-                  <ProviderIcon providerId={prov.id} className="size-3.5" />
-                  {prov.name}
-                  {!connected && (
-                    <span className="text-[10px] text-muted-foreground/60 ml-auto">
-                      {t("card.notConnected")}
-                    </span>
-                  )}
-                </div>
-                {prov.models.map((m) => {
-                  const isActive = prov.id === provider && m.id === model;
-                  return (
-                    <button
-                      key={m.id}
-                      type="button"
-                      disabled={!connected}
-                      onClick={() => {
-                        onSelect(prov.id, m.id);
-                        setOpen(false);
-                      }}
-                      className={cn(
-                        "w-full flex items-start gap-2.5 px-3 py-2 rounded-lg text-left transition-colors",
-                        isActive ? "bg-accent" : "hover:bg-accent/50",
-                        !connected && "opacity-50 cursor-not-allowed",
-                      )}
-                    >
-                      <div className="w-4 shrink-0 mt-0.5 flex justify-center">
-                        {isActive && (
-                          <Check className="h-3.5 w-3.5 text-foreground" />
-                        )}
-                      </div>
-                      <div className="min-w-0 flex-1">
-                        <div className="text-sm">{m.label}</div>
-                        <div className="text-xs text-muted-foreground leading-snug">
-                          {t(
-                            `chat:modelSelector.modelDescriptions.${m.id.replace(/\./g, "_")}`,
-                            { defaultValue: m.description },
-                          )}
-                        </div>
-                      </div>
-                    </button>
-                  );
-                })}
-              </div>
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}
-
-function ProviderIcon({
-  providerId,
-  className,
-}: {
-  providerId: string;
-  className?: string;
-}) {
-  if (providerId === "anthropic") {
-    return (
-      <svg
-        viewBox="0 0 24 24"
-        className={className}
-        fill="currentColor"
-        role="img"
-        aria-label="Anthropic"
-      >
-        <path d="m4.7144 15.9555 4.7174-2.6471.079-.2307-.079-.1275h-.2307l-.7893-.0486-2.6956-.0729-2.3375-.0971-2.2646-.1214-.5707-.1215-.5343-.7042.0546-.3522.4797-.3218.686.0608 1.5179.1032 2.2767.1578 1.6514.0972 2.4468.255h.3886l.0546-.1579-.1336-.0971-.1032-.0972L6.973 9.8356l-2.55-1.6879-1.3356-.9714-.7225-.4918-.3643-.4614-.1578-1.0078.6557-.7225.8803.0607.2246.0607.8925.686 1.9064 1.4754 2.4893 1.8336.3643.3035.1457-.1032.0182-.0728-.164-.2733-1.3539-2.4467-1.445-2.4893-.6435-1.032-.17-.6194c-.0607-.255-.1032-.4674-.1032-.7285L6.287.1335 6.6997 0l.9957.1336.419.3642.6192 1.4147 1.0018 2.2282 1.5543 3.0296.4553.8985.2429.8318.091.255h.1579v-.1457l.1275-1.706.2368-2.0947.2307-2.6957.0789-.7589.3764-.9107.7468-.4918.5828.2793.4797.686-.0668.4433-.2853 1.8517-.5586 2.9021-.3643 1.9429h.2125l.2429-.2429.9835-1.3053 1.6514-2.0643.7286-.8196.85-.9046.5464-.4311h1.0321l.759 1.1293-.34 1.1657-1.0625 1.3478-.8804 1.1414-1.2628 1.7-.7893 1.36.0729.1093.1882-.0183 2.8535-.607 1.5421-.2794 1.8396-.3157.8318.3886.091.3946-.3278.8075-1.967.4857-2.3072.4614-3.4364.8136-.0425.0304.0486.0607 1.5482.1457.6618.0364h1.621l3.0175.2247.7892.522.4736.6376-.079.4857-1.2142.6193-1.6393-.3886-3.825-.9107-1.3113-.3279h-.1822v.1093l1.0929 1.0686 2.0035 1.8092 2.5075 2.3314.1275.5768-.3218.4554-.34-.0486-2.2039-1.6575-.85-.7468-1.9246-1.621h-.1275v.17l.4432.6496 2.3436 3.5214.1214 1.0807-.17.3521-.6071.2125-.6679-.1214-1.3721-1.9246L14.38 17.959l-1.1414-1.9428-.1397.079-.674 7.2552-.3156.3703-.7286.2793-.6071-.4614-.3218-.7468.3218-1.4753.3886-1.9246.3157-1.53.2853-1.9004.17-.6314-.0121-.0425-.1397.0182-1.4328 1.9672-2.1796 2.9446-1.7243 1.8456-.4128.164-.7164-.3704.0667-.6618.4008-.5889 2.386-3.0357 1.4389-1.882.929-1.0868-.0062-.1579h-.0546l-6.3385 4.1164-1.1293.1457-.4857-.4554.0608-.7467.2307-.2429 1.9064-1.3114Z" />
-      </svg>
-    );
-  }
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      className={className}
-      fill="currentColor"
-      role="img"
-      aria-label="OpenAI"
-    >
-      <path d="M22.282 9.821a5.985 5.985 0 0 0-.516-4.91 6.046 6.046 0 0 0-6.51-2.9A6.065 6.065 0 0 0 4.981 4.18a5.998 5.998 0 0 0-3.998 2.9 6.047 6.047 0 0 0 .743 7.097 5.98 5.98 0 0 0 .51 4.911 6.051 6.051 0 0 0 6.515 2.9A5.985 5.985 0 0 0 13.26 24a6.056 6.056 0 0 0 5.772-4.206 5.99 5.99 0 0 0 3.997-2.9 6.056 6.056 0 0 0-.747-7.073zM13.26 22.43a4.476 4.476 0 0 1-2.876-1.04l.141-.081 4.779-2.758a.795.795 0 0 0 .392-.681v-6.737l2.02 1.168a.071.071 0 0 1 .038.052v5.583a4.504 4.504 0 0 1-4.494 4.494zM3.6 18.304a4.47 4.47 0 0 1-.535-3.014l.142.085 4.783 2.759a.771.771 0 0 0 .78 0l5.843-3.369v2.332a.08.08 0 0 1-.033.062L9.74 19.95a4.5 4.5 0 0 1-6.14-1.646zM2.34 7.896a4.485 4.485 0 0 1 2.366-1.973V11.6a.766.766 0 0 0 .388.676l5.815 3.355-2.02 1.168a.076.076 0 0 1-.071 0l-4.83-2.786A4.504 4.504 0 0 1 2.34 7.872zm16.597 3.855l-5.833-3.387L15.119 7.2a.076.076 0 0 1 .071 0l4.83 2.791a4.494 4.494 0 0 1-.676 8.105v-5.678a.79.79 0 0 0-.407-.667zm2.01-3.023l-.141-.085-4.774-2.782a.776.776 0 0 0-.785 0L9.409 9.23V6.897a.066.066 0 0 1 .028-.061l4.83-2.787a4.5 4.5 0 0 1 6.68 4.66zm-12.64 4.135l-2.02-1.164a.08.08 0 0 1-.038-.057V6.075a4.5 4.5 0 0 1 7.375-3.453l-.142.08L8.704 5.46a.795.795 0 0 0-.393.681zm1.097-2.365l2.602-1.5 2.607 1.5v2.999l-2.597 1.5-2.607-1.5z" />
-    </svg>
   );
 }

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -867,13 +867,36 @@ export function validProviderOrNull(
  * getDefaultModel(provider)` so the picker and the wire call agree on a
  * model the server will actually accept.
  */
+/**
+ * Providers whose model catalog is OPEN: the curated `PROVIDERS[].models` is a
+ * seed for the picker, NOT the exhaustive runnable set, so a live selection must
+ * not be validated against it. OpenRouter serves the 300+ models the picker
+ * fetches live; the local OpenAI-compatible endpoint runs whatever model the
+ * user's server exposes. Mirrors the domain's pass-through set (providers absent
+ * from `VALID_MODELS` in `@houston/domain`).
+ */
+const OPEN_CATALOG_PROVIDERS: ReadonlySet<string> = new Set([
+  "openrouter",
+  "openai-compatible",
+]);
+
+/** Whether `providerId` runs any model id its upstream serves (see above). */
+export function isOpenCatalogProvider(
+  providerId: string | null | undefined,
+): boolean {
+  return !!providerId && OPEN_CATALOG_PROVIDERS.has(providerId);
+}
+
 export function validModelOrNull(
   providerId: string | null | undefined,
   modelId: string | null | undefined,
 ): string | null {
-  return providerId && modelId && getModel(providerId, modelId)
-    ? modelId
-    : null;
+  if (!providerId || !modelId) return null;
+  // Open-catalog providers accept any live id, so never null a picked model
+  // against the small curated seed list — otherwise the effective-model chain
+  // silently reverts a live OpenRouter pick to the provider default.
+  if (isOpenCatalogProvider(providerId)) return modelId;
+  return getModel(providerId, modelId) ? modelId : null;
 }
 
 /**

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -88,7 +88,6 @@
       "favorites": "Favorites",
       "results": "Results",
       "all": "All models",
-      "connected": "Connected",
       "notConnected": "Not connected",
       "connect": "Connect",
       "sort": "Sort",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -88,7 +88,6 @@
       "favorites": "Favoritos",
       "results": "Resultados",
       "all": "Todos los modelos",
-      "connected": "Conectado",
       "notConnected": "Sin conexión",
       "connect": "Conectar",
       "sort": "Ordenar",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -88,7 +88,6 @@
       "favorites": "Favoritos",
       "results": "Resultados",
       "all": "Todos os modelos",
-      "connected": "Conectado",
       "notConnected": "Sem conexão",
       "connect": "Conectar",
       "sort": "Ordenar",

--- a/app/tests/providers.test.ts
+++ b/app/tests/providers.test.ts
@@ -1,0 +1,56 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  getDefaultModel,
+  isOpenCatalogProvider,
+  validModelOrNull,
+} from "../src/lib/providers.ts";
+
+describe("isOpenCatalogProvider", () => {
+  it("is true for pass-through catalogs (OpenRouter, local endpoint)", () => {
+    strictEqual(isOpenCatalogProvider("openrouter"), true);
+    strictEqual(isOpenCatalogProvider("openai-compatible"), true);
+  });
+  it("is false for curated providers and empty input", () => {
+    strictEqual(isOpenCatalogProvider("anthropic"), false);
+    strictEqual(isOpenCatalogProvider("openai"), false);
+    strictEqual(isOpenCatalogProvider(null), false);
+    strictEqual(isOpenCatalogProvider(undefined), false);
+  });
+});
+
+describe("validModelOrNull", () => {
+  it("keeps ANY live model id for an open-catalog provider", () => {
+    // The bug: a live OpenRouter model that isn't one of the ~5 curated seeds
+    // used to null out here, so the effective-model chain reverted the pick to
+    // the provider default. It must now pass through verbatim.
+    strictEqual(
+      validModelOrNull("openrouter", "moonshotai/kimi-k2"),
+      "moonshotai/kimi-k2",
+    );
+    strictEqual(validModelOrNull("openrouter", "x-ai/grok-5"), "x-ai/grok-5");
+    strictEqual(
+      validModelOrNull("openai-compatible", "my-local-model"),
+      "my-local-model",
+    );
+  });
+
+  it("still rejects unknown ids for a curated provider", () => {
+    // Retired / phantom SKUs on a curated provider stay nulled so the chain
+    // falls through to a model the server will actually accept.
+    strictEqual(validModelOrNull("anthropic", "gpt-5.5-codex"), null);
+    strictEqual(validModelOrNull("openai", "not-a-real-model"), null);
+  });
+
+  it("accepts a genuinely-listed curated model", () => {
+    const m = getDefaultModel("anthropic");
+    strictEqual(validModelOrNull("anthropic", m), m);
+  });
+
+  it("returns null for empty provider or model", () => {
+    strictEqual(validModelOrNull("openrouter", ""), null);
+    strictEqual(validModelOrNull("", "x/y"), null);
+    strictEqual(validModelOrNull(null, "x/y"), null);
+    strictEqual(validModelOrNull("openrouter", null), null);
+  });
+});

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -350,12 +350,30 @@ pinned **Recents** and **Favorites**, and rich rows (brand icon, price tier,
 The library component is props-only and i18n-agnostic (`labels?`); all app
 wiring lives in `app/src/components/chat-model-selector.tsx`.
 
+- **Reused in the create-agent modal too.** `ChatModelSelector` is the ONE model
+  selector: the chat composer AND the create/import-agent flows
+  (`naming-step.tsx`, `ai-assist-step.tsx`, `portable/import-wizard.tsx`) render
+  it with `agent={null}` (never locks — there is no agent yet). The old
+  hand-rolled `InlineModelSelector` (curated-only, hid disconnected providers) is
+  gone; the create flow now gets the same live 300+ catalog + Connect affordance.
 - **Only ever offers runnable `(provider, model)` pairs.** The mapping
   (`app/src/lib/chat-model-picker-map.ts`, pure + unit-tested) encodes each row
   id as `` `${provider}::${model}` `` (split on the FIRST `::`), decoded on
   select back into the existing `handleModelSelect(provider, model)` — so the
   cross-provider `ProviderSwitchDialog` consent, effort selector, and all
   persistence are untouched. The effort control stays a SEPARATE composer button.
+- **Open-catalog providers accept any live id (don't revert it).**
+  `validModelOrNull` (`app/src/lib/providers.ts`) would null any model not in a
+  provider's curated `PROVIDERS[].models`, so the effective-model chain
+  (`validModelOrNull(...) ?? ... ?? getDefaultModel`) silently reverted a live
+  OpenRouter pick to the default. `isOpenCatalogProvider(providerId)` (currently
+  `openrouter` + the local `openai-compatible`) now short-circuits that check so
+  a live id passes through — mirrors the domain's pass-through set (providers
+  absent from `VALID_MODELS`). Caveat: the RUNTIME still resolves ids through
+  pi-ai's generated registry (~259 openrouter models), so a brand-new live id
+  outside that registry persists but fails the turn at `safeGetModel`
+  (`packages/runtime/src/ai/providers.ts`) with a clean "model not available"
+  error — closing that tail needs pi-ai pass-through model construction.
 - **Two data sources, one view-model.** Non-OpenRouter providers enumerate their
   curated `PROVIDERS[].models` (plus the synthesized local `openai-compatible`
   runtime row), enriched with capabilities/pricing/context by an exact

--- a/ui/core/src/components/model-picker/model-list.tsx
+++ b/ui/core/src/components/model-picker/model-list.tsx
@@ -131,25 +131,18 @@ function SectionHeading({
   const { label, icon } = headingText(section, provider, labels);
   const disconnected = provider?.connection === "disconnected";
   return (
-    <div className="flex items-center gap-2 pt-2 text-[0.65rem] font-semibold tracking-wider text-muted-foreground uppercase">
+    <div className="flex items-center gap-2 pt-2 text-xs font-semibold text-muted-foreground">
       {icon}
       <span>{label}</span>
-      <span className="h-px flex-1 bg-border/60" />
-      {provider &&
-        (disconnected ? (
-          <button
-            type="button"
-            onClick={() => onConnect?.(provider.id)}
-            className="text-[0.7rem] font-semibold text-foreground normal-case transition-colors hover:text-muted-foreground"
-          >
-            {labels.connect} →
-          </button>
-        ) : (
-          <span className="inline-flex items-center gap-1.5 text-[0.7rem] font-medium text-muted-foreground normal-case">
-            <span className="size-1.5 rounded-full bg-muted-foreground" />
-            {labels.connected}
-          </span>
-        ))}
+      {provider && disconnected && (
+        <button
+          type="button"
+          onClick={() => onConnect?.(provider.id)}
+          className="ml-auto text-xs font-semibold text-foreground transition-colors hover:text-muted-foreground"
+        >
+          {labels.connect} →
+        </button>
+      )}
     </div>
   );
 }

--- a/ui/core/src/components/model-picker/model-row.tsx
+++ b/ui/core/src/components/model-picker/model-row.tsx
@@ -49,15 +49,12 @@ export function ModelRow({
       disabled={disconnected}
       onSelect={() => onSelect(model.id)}
       className={cn(
-        "relative flex cursor-pointer flex-col rounded-xl px-3 py-2.5 outline-none",
+        "flex cursor-pointer flex-col rounded-xl px-3 py-2.5 outline-none",
         "data-[selected=true]:bg-accent",
         selected && "bg-accent",
         disconnected && "cursor-default",
       )}
     >
-      {selected && (
-        <span className="absolute top-1/2 left-0 h-5 w-[3px] -translate-y-1/2 rounded-full bg-foreground" />
-      )}
       <div className="flex items-center gap-3">
         <div className={cn("min-w-0 flex-1", disconnected && "opacity-55")}>
           <div className="truncate text-sm font-semibold text-foreground">

--- a/ui/core/src/components/model-picker/provider-rail.tsx
+++ b/ui/core/src/components/model-picker/provider-rail.tsx
@@ -36,17 +36,19 @@ export function ProviderRail({
     <div className="flex w-[60px] shrink-0 flex-col items-center gap-1 overflow-y-auto border-r border-border/60 py-2.5">
       <RailButton
         active={active === "fav"}
+        prominent
         title={labels.favorites}
         onClick={() => onSelect("fav")}
       >
-        <Star className="size-4" />
+        <Star className="size-3.5" />
       </RailButton>
       <RailButton
         active={active === "all"}
+        prominent
         title={labels.all}
         onClick={() => onSelect("all")}
       >
-        <Boxes className="size-4" />
+        <Boxes className="size-3.5" />
       </RailButton>
       {connected.map((p) => (
         <ProviderRailButton
@@ -92,6 +94,7 @@ function ProviderRailButton({
   return (
     <RailButton
       active={active}
+      prominent={!disconnected}
       title={
         disconnected
           ? `${provider.name} · ${labels.notConnected}`
@@ -100,11 +103,14 @@ function ProviderRailButton({
       dimmed={disconnected}
       onClick={() => onSelect(provider.id)}
     >
+      {/* No text color here: the glyph inherits the button's currentColor, so a
+          connected provider reads as foreground (white on dark) and a
+          disconnected one as muted grey. */}
       <ProviderIcon
         providerId={provider.id}
         name={provider.name}
         render={renderProviderIcon}
-        className="size-[26px] rounded-lg text-muted-foreground"
+        className="size-[18px] rounded-md"
       />
     </RailButton>
   );
@@ -112,12 +118,15 @@ function ProviderRailButton({
 
 function RailButton({
   active,
+  prominent,
   title,
   dimmed,
   onClick,
   children,
 }: {
   active: boolean;
+  /** Render at full foreground (connected / always-available) vs muted grey. */
+  prominent?: boolean;
   title: string;
   dimmed?: boolean;
   onClick: () => void;
@@ -131,14 +140,12 @@ function RailButton({
       aria-pressed={active}
       onClick={onClick}
       className={cn(
-        "relative inline-flex size-10 items-center justify-center rounded-xl text-muted-foreground transition-colors hover:bg-accent hover:text-foreground",
+        "inline-flex size-10 items-center justify-center rounded-xl transition-colors hover:bg-accent hover:text-foreground",
+        prominent ? "text-foreground" : "text-muted-foreground",
         active && "bg-accent text-foreground",
         dimmed && "opacity-45",
       )}
     >
-      {active && (
-        <span className="absolute top-1/2 -left-2.5 h-5 w-[3px] -translate-y-1/2 rounded-full bg-foreground" />
-      )}
       {children}
     </button>
   );

--- a/ui/core/src/components/model-picker/types.ts
+++ b/ui/core/src/components/model-picker/types.ts
@@ -53,7 +53,6 @@ export interface ModelPickerLabels {
   favorites: string;
   results: string;
   all: string;
-  connected: string;
   notConnected: string;
   connect: string;
   sort: string;
@@ -98,7 +97,6 @@ export const DEFAULT_MODEL_PICKER_LABELS: ModelPickerLabels = {
   favorites: "Favorites",
   results: "Results",
   all: "All models",
-  connected: "Connected",
   notConnected: "Not connected",
   connect: "Connect",
   sort: "Sort",


### PR DESCRIPTION
Follow-up to #674 / #690.

## Reuse in the create-agent modal
The create / import-agent flows (`naming-step`, `ai-assist-step`, `import-wizard`) now render the **same** `ChatModelSelector` (`agent={null}`, never locks) instead of the hand-rolled `InlineModelSelector` — so creating an agent gets the same live OpenRouter catalog, search, and favorites. `InlineModelSelector` is removed.

## Bug fix — OpenRouter selections no longer revert
Selecting a live OpenRouter model silently snapped back to the default: `validModelOrNull` nulled any id outside the ~5 curated seed models, so the effective-model chain fell through to `getDefaultModel`. Added `isOpenCatalogProvider` (`openrouter` + local `openai-compatible`) so a live id passes through. Unit-tested (`app/tests/providers.test.ts`).
- **Scope note:** the runtime resolves ids via pi-ai's generated registry (~259 OpenRouter models — includes all mainstream ones like `moonshotai/kimi-k2`). A brand-new live id outside that registry persists but fails the turn with a clean "model not available" error; fully closing that tail needs pi-ai pass-through model construction (follow-up).

## Picker polish
- Rail logos **smaller**.
- **Connected** provider icons render at full foreground (white on dark / black on light); **not-connected** stay dimmed grey — clear contrast.
- Removed the vertical bar on the selected row and the active rail item (hover/fill is enough).
- Section headers: dropped the divider line, **Title Case** (not uppercase), and no "Connected" text — only a **Connect** button when needed. Dropped the now-dead `connected` label.

## Verification
`pnpm -r typecheck` (all 22 packages), app **739** tests, `check:boundaries`, `check:parity`, `check-locales`, Biome, and the web production build — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)