### PR TITLE
fix(onboarding): stale agent pref no longer 404s first-run provider login

### DIFF
--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -528,6 +528,27 @@ once from `connections.dialogProps`. The hub view renders both once and passes
 dialogs (co-located browser callback); see `knowledge-base/auth.md` for the
 connect/re-auth event contract.
 
+### Where a provider connect executes (agent runtime vs setup runtime)
+
+Credentials are **workspace-central** (connect-once): a captured credential
+lands on the personal workspace and every agent runtime is served from it
+(`/sandbox/credential`). But the OAuth dance itself still needs a runtime to
+run in, so the web adapter's `providerEngine()` routes the connect surface
+(status, login, complete, cancel) by the persisted selection pref
+`houston.pref.last_agent_id`:
+
+- pref names an agent → that agent's runtime (`/agents/:id/auth/...`);
+- pref absent → the host's hidden **setup runtime** (`/setup-runtime/auth/...`,
+  `packages/host/src/routes/setup-runtime.ts`) — the pre-agent first-run path.
+
+**Invariant: the pref never names an agent the control plane doesn't have.**
+The adapter prunes it in cp `listAgents` (boot runs that before any connect
+surface mounts) and clears it in cp `deleteAgent` when the deleted agent was
+the remembered one (`packages/web/tests/stale-agent-pref.test.ts`). A stale
+pref (deleted last agent, wiped `~/.houston` with surviving localStorage,
+account switch) used to send first-run onboarding logins to
+`/agents/<dead>/auth/:pid/login` → 404 "agent not found".
+
 ### Removed / moved
 
 - **Settings no longer manages providers.** Deleted: `provider-settings.tsx`,

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -128,6 +128,13 @@ export function isHoustonEngineError(e: unknown): e is HoustonEngineError {
 const SETUP_LOGIN_KEY = "__setup__";
 
 /**
+ * localStorage key persisting the selected agent (`setPreference("last_agent_id")`).
+ * `providerEngine()` routes provider connects by it, so it must never name an
+ * agent the host doesn't have — see `dropLastAgentPref`.
+ */
+const LAST_AGENT_PREF = "houston.pref.last_agent_id";
+
+/**
  * Treat a 404 on login/cancel as benign: it means no login was pending (or an
  * older host lacks the cancel route), so cancel's postcondition — the login
  * slot is free — already holds. The reconnect card's every press goes
@@ -236,10 +243,28 @@ export class HoustonClient {
   /** The CP agent the user has selected (persisted as last_agent_id), or null. */
   private currentAgentId(): string | null {
     try {
-      const id = localStorage.getItem("houston.pref.last_agent_id");
+      const id = localStorage.getItem(LAST_AGENT_PREF);
       return id && id !== DEFAULT_AGENT_ID ? id : null;
     } catch {
       return null;
+    }
+  }
+  /**
+   * Forget the persisted agent selection when it names an agent the control
+   * plane no longer has (deleted last agent, wiped user data, account switch).
+   * Credentials are workspace-central (connect-once), so provider connects
+   * don't need an agent — but `providerEngine()` routes them through the
+   * remembered agent's runtime whenever this pref is set. A stale id sent
+   * first-run onboarding logins to `/agents/<dead>/auth/:pid/login` → 404
+   * "agent not found" instead of the pre-agent `/setup-runtime` surface.
+   */
+  private dropLastAgentPref(isStale: (id: string) => boolean): void {
+    try {
+      const id = localStorage.getItem(LAST_AGENT_PREF);
+      if (id && id !== DEFAULT_AGENT_ID && isStale(id))
+        localStorage.removeItem(LAST_AGENT_PREF);
+    } catch {
+      /* storage disabled — currentAgentId() reads null there anyway */
     }
   }
   /** The selected agent id, or a user-facing error if none is open. */
@@ -301,7 +326,14 @@ export class HoustonClient {
     return [syntheticWorkspace(provider, model)];
   }
   async listAgents(workspaceId: string): Promise<Agent[]> {
-    if (this.cp) return controlPlane.listAgents(this.cp);
+    if (this.cp) {
+      const list = await controlPlane.listAgents(this.cp);
+      // CP agent ids are global (the list ignores workspaceId), so this list is
+      // the full truth the selection pref must exist in. Pruning here heals a
+      // stale pref at boot, before the first-run connect surface mounts.
+      this.dropLastAgentPref((id) => !list.some((a) => a.id === id));
+      return list;
+    }
     return agents.listAgents(workspaceId);
   }
   async createWorkspace(req: { name?: string }): Promise<Workspace> {
@@ -365,7 +397,14 @@ export class HoustonClient {
     return agents.updateAgentColor(workspaceId, agentId, req.color);
   }
   async deleteAgent(workspaceId: string, agentId: string): Promise<void> {
-    if (this.cp) return controlPlane.deleteAgent(this.cp, agentId);
+    if (this.cp) {
+      await controlPlane.deleteAgent(this.cp, agentId);
+      // The selection pref must not outlive its agent: when the deleted agent
+      // was the remembered one (and it was the last — the app re-points the
+      // pref otherwise), provider connects must fall back to the setup runtime.
+      this.dropLastAgentPref((id) => id === agentId);
+      return;
+    }
     agents.deleteAgent(workspaceId, agentId);
   }
   /**

--- a/packages/web/tests/stale-agent-pref.test.ts
+++ b/packages/web/tests/stale-agent-pref.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+
+/**
+ * Credentials are workspace-central (connect-once), so provider connects don't
+ * need an agent — but cp-mode `providerEngine()` routes them through the agent
+ * remembered in `houston.pref.last_agent_id` whenever that pref is set. A STALE
+ * pref (deleted last agent, wiped user data, account switch on the same
+ * browser) sent first-run onboarding logins to `/agents/<dead>/auth/:pid/login`
+ * → 404 "agent not found" instead of the pre-agent `/setup-runtime` surface.
+ *
+ * The invariant under test: the pref never outlives its agent. `listAgents`
+ * (which boot runs before any connect surface mounts) prunes a pref naming an
+ * agent the control plane doesn't have, and `deleteAgent` clears the pref when
+ * the deleted agent was the remembered one.
+ */
+
+const { cpListAgents, cpDeleteAgent, runtimeClientFor, setupRuntimeClientFor } =
+  vi.hoisted(() => ({
+    cpListAgents: vi.fn(),
+    cpDeleteAgent: vi.fn(),
+    runtimeClientFor: vi.fn(),
+    setupRuntimeClientFor: vi.fn(),
+  }));
+
+vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../src/engine-adapter/control-plane")
+    >();
+  return {
+    ...actual,
+    listAgents: cpListAgents,
+    deleteAgent: cpDeleteAgent,
+    runtimeClientFor,
+    setupRuntimeClientFor,
+  };
+});
+
+import { HoustonClient } from "../src/engine-adapter/client";
+import { DEFAULT_AGENT_ID } from "../src/engine-adapter/synthetic";
+
+const PREF = "houston.pref.last_agent_id";
+
+let store: Map<string, string>;
+
+beforeEach(() => {
+  // Freeze timers so pollProviderConnect's 4s poll loop never fires mid-test.
+  vi.useFakeTimers();
+  store = new Map();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  cpListAgents.mockReset();
+  cpDeleteAgent.mockReset();
+  runtimeClientFor.mockReset();
+  setupRuntimeClientFor.mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+function client() {
+  return new HoustonClient({
+    baseUrl: "http://host",
+    token: "t",
+    controlPlane: true,
+  });
+}
+
+const agent = (id: string) => ({
+  id,
+  name: id,
+  folderPath: id,
+  configId: "c",
+  color: "#000",
+  createdAt: "2026-01-01T00:00:00.000Z",
+  lastOpenedAt: "2026-01-01T00:00:00.000Z",
+});
+
+test("listAgents prunes a pref naming an agent the control plane doesn't have", async () => {
+  store.set(PREF, "ws/Deleted Agent");
+  cpListAgents.mockResolvedValue([agent("ws/Other")]);
+
+  await client().listAgents("ws");
+
+  expect(store.has(PREF)).toBe(false);
+});
+
+test("listAgents keeps a pref naming an existing agent", async () => {
+  store.set(PREF, "ws/Alive");
+  cpListAgents.mockResolvedValue([agent("ws/Alive"), agent("ws/Other")]);
+
+  await client().listAgents("ws");
+
+  expect(store.get(PREF)).toBe("ws/Alive");
+});
+
+test("listAgents leaves the synthetic default-agent sentinel alone", async () => {
+  store.set(PREF, DEFAULT_AGENT_ID);
+  cpListAgents.mockResolvedValue([]);
+
+  await client().listAgents("ws");
+
+  expect(store.get(PREF)).toBe(DEFAULT_AGENT_ID);
+});
+
+test("deleteAgent clears the pref when the deleted agent was the remembered one", async () => {
+  store.set(PREF, "ws/Doomed");
+  cpDeleteAgent.mockResolvedValue(undefined);
+
+  await client().deleteAgent("ws", "ws/Doomed");
+
+  expect(store.has(PREF)).toBe(false);
+});
+
+test("deleteAgent keeps the pref when another agent was deleted", async () => {
+  store.set(PREF, "ws/Kept");
+  cpDeleteAgent.mockResolvedValue(undefined);
+
+  await client().deleteAgent("ws", "ws/Doomed");
+
+  expect(store.get(PREF)).toBe("ws/Kept");
+});
+
+test("regression: after boot prunes a stale pref, first-run login runs on the SETUP runtime, not the dead agent's", async () => {
+  store.set(PREF, "ws/Deleted Agent");
+  cpListAgents.mockResolvedValue([]); // fresh install: zero agents → onboarding
+  const startLogin = vi.fn().mockResolvedValue({
+    kind: "device_code",
+    verificationUri: "https://auth.example/device",
+    userCode: "ABCD-1234",
+  });
+  setupRuntimeClientFor.mockReturnValue({ startLogin });
+  runtimeClientFor.mockReturnValue({
+    startLogin: vi.fn().mockRejectedValue(new Error("agent not found")),
+  });
+
+  const c = client();
+  await c.listAgents("ws"); // boot's load pass
+  await c.providerLogin("openai");
+
+  expect(setupRuntimeClientFor).toHaveBeenCalled();
+  expect(runtimeClientFor).not.toHaveBeenCalled();
+  expect(startLogin).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
## Bug

During first-run onboarding, clicking **Log in** on any provider at the "Log in to your AI subscription" step failed with `engine request failed (404): {"error":"agent not found"}`.

## Root cause

Credentials are workspace-central now (connect-once), so a provider connect needs no agent — but the web adapter's `providerEngine()` routes the connect surface (status/login/complete/cancel) through the agent remembered in `localStorage["houston.pref.last_agent_id"]` whenever that pref is set, **without validating it**. A stale pref (deleted last agent, wiped `~/.houston` with surviving localStorage, account switch on the same browser) sent the login to `POST /agents/<dead>/auth/:pid/login`, which the host's ownership gate (`authorizeAgent`) answers with the 404. The correct pre-agent path — the host's hidden `/setup-runtime` surface, which lands the credential on the personal workspace — is only taken when the pref is absent.

Nothing maintained that pref: deleting the last agent left it dangling, and boot silently ignored (but kept) an invalid value.

## Fix

Enforce the invariant *the pref never names an agent the control plane doesn't have*, at the two places the adapter learns the truth:

- **`listAgents` (cp)** prunes a pref absent from the fetched list. Boot's agent load runs before any connect surface mounts (the first-run gate waits on `loaded`), so a stale install heals before onboarding renders.
- **`deleteAgent` (cp)** clears the pref when the deleted agent was the remembered one (the app re-points it itself when a next agent exists).

With the pref gone, `providerEngine()` falls back to the setup runtime and first-run login works. Local (non-cp) mode is untouched — its agent ids are workspace-scoped and `providerEngine()` ignores the pref there.

## Tests

- `packages/web/tests/stale-agent-pref.test.ts`: prune on stale, keep on valid, sentinel untouched, clear on delete-of-remembered, keep on delete-of-other, and the regression — stale pref + boot ⇒ login starts on the **setup runtime**, never the dead agent's.
- Full `packages/web` suite: 18 files / 77 tests green. Repo biome clean; full workspace typecheck green (pre-commit).

Also documents the connect-routing invariant in `knowledge-base/agent-manifest.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)