### PR TITLE
fix(portable): import an agent in cloud via create-with-seeds (HOU-707)

### DIFF
--- a/packages/domain/src/portable-edit.ts
+++ b/packages/domain/src/portable-edit.ts
@@ -2,7 +2,10 @@ import type {
   PortableExportOverrides,
   PortableSelection,
 } from "@houston/protocol";
+import { docKey } from "./layout";
 import type { PortableContent, PortablePackage } from "./portable";
+import { skillKey } from "./skills";
+import { jsonDoc } from "./store";
 
 /**
  * Pure edits on portable content: the install-time subset and the accepted
@@ -29,6 +32,37 @@ export function filterPackage(
     skills: pkg.skills.filter((s) => skillSlugs.has(s.slug)),
     routines: pkg.routines.filter((r) => routineIds.has(r.id)),
     learnings: pkg.learnings.filter((l) => learningIds.has(l.id)),
+  };
+}
+
+/** Root-relative form of a key built by the canonical `<root>/…` builders. */
+const relativeKey = (key: string) => key.slice(1);
+
+/**
+ * Serialize portable content into the agent-create seed payload: CLAUDE.md
+ * plus a flat `relativePath → contents` map in the exact on-disk layout
+ * (`.agents/skills/<slug>/SKILL.md`, `.houston/<family>/<family>.json`).
+ * This is what lets an import ride the ordinary create-agent pipeline —
+ * including a hosted-cloud gateway, which persists the payload and seeds the
+ * new agent's pod with it — instead of needing a dedicated install route.
+ */
+export function packageSeed(content: PortableContent): {
+  claudeMd?: string;
+  seeds: Record<string, string>;
+} {
+  const seeds: Record<string, string> = {};
+  for (const s of content.skills) {
+    seeds[relativeKey(skillKey("", s.slug))] = s.body;
+  }
+  if (content.routines.length) {
+    seeds[relativeKey(docKey("", "routines"))] = jsonDoc(content.routines);
+  }
+  if (content.learnings.length) {
+    seeds[relativeKey(docKey("", "learnings"))] = jsonDoc(content.learnings);
+  }
+  return {
+    ...(content.claudeMd !== undefined ? { claudeMd: content.claudeMd } : {}),
+    seeds,
   };
 }
 

--- a/packages/domain/src/portable.test.ts
+++ b/packages/domain/src/portable.test.ts
@@ -6,7 +6,7 @@ import {
   portableInventory,
   unpackAgent,
 } from "./portable";
-import { filterPackage } from "./portable-edit";
+import { filterPackage, packageSeed } from "./portable-edit";
 import { createRoutine } from "./routines";
 
 /**
@@ -199,4 +199,36 @@ test("filterPackage with everything selected is the identity", () => {
     learningIds: pkg.learnings.map((l) => l.id),
   });
   expect(filtered).toEqual(pkg);
+});
+
+test("packageSeed lays content out exactly like a direct install", () => {
+  const c = content();
+  const seed = packageSeed(c);
+
+  expect(seed.claudeMd).toBe(c.claudeMd);
+  expect(Object.keys(seed.seeds).sort()).toEqual([
+    ".agents/skills/research/SKILL.md",
+    ".agents/skills/weekly/SKILL.md",
+    ".houston/learnings/learnings.json",
+    ".houston/routines/routines.json",
+  ]);
+  expect(seed.seeds[".agents/skills/research/SKILL.md"]).toBe(
+    c.skills[0]?.body,
+  );
+  // The JSON docs are the canonical on-disk form and parse back to the items.
+  expect(
+    JSON.parse(seed.seeds[".houston/routines/routines.json"] ?? ""),
+  ).toEqual(c.routines);
+  expect(
+    JSON.parse(seed.seeds[".houston/learnings/learnings.json"] ?? ""),
+  ).toEqual(c.learnings);
+  expect(seed.seeds[".houston/routines/routines.json"]?.endsWith("\n")).toBe(
+    true,
+  );
+});
+
+test("packageSeed omits what the package lacks (no empty docs, no CLAUDE.md key)", () => {
+  const seed = packageSeed({ skills: [], routines: [], learnings: [] });
+  expect(seed).toEqual({ seeds: {} });
+  expect("claudeMd" in seed).toBe(false);
 });

--- a/packages/domain/src/store.ts
+++ b/packages/domain/src/store.ts
@@ -44,11 +44,16 @@ export async function loadJson<T>(
   }
 }
 
+/** The canonical on-disk JSON document form: pretty-printed, trailing newline. */
+export function jsonDoc(value: unknown): string {
+  return `${JSON.stringify(value, null, 2)}\n`;
+}
+
 /** Pretty-printed write: agents and users read these files directly (files-first). */
 export async function saveJson(
   store: TextStore,
   key: string,
   value: unknown,
 ): Promise<void> {
-  await store.writeText(key, `${JSON.stringify(value, null, 2)}\n`);
+  await store.writeText(key, jsonDoc(value));
 }

--- a/packages/host/src/routes/portable.ts
+++ b/packages/host/src/routes/portable.ts
@@ -4,11 +4,9 @@ import {
   filterPackage,
   type PortablePackage,
   packAgent,
+  packageSeed,
   portableInventory,
-  saveLearnings,
-  saveRoutines,
   seedSchemas,
-  skillKey,
   unpackAgent,
 } from "@houston/domain";
 import type {
@@ -20,6 +18,7 @@ import type { WorkspacePaths } from "../paths";
 import { CloudPaths } from "../paths";
 import type { WorkspaceStore } from "../ports";
 import type { Vfs } from "../vfs";
+import { writeAgentSeeds } from "./agent-seed";
 import { json, readJson } from "./http";
 import { gatherPortableContent } from "./portable-content";
 
@@ -31,8 +30,6 @@ async function readBytes(req: IncomingMessage): Promise<Buffer> {
   for await (const c of req) chunks.push(c as Buffer);
   return Buffer.concat(chunks);
 }
-
-const ctxFile = (root: string) => `${root}/CLAUDE.md`;
 
 /**
  * Export an agent as a `.houstonagent` (agent-scoped: POST
@@ -165,13 +162,9 @@ export async function handlePortableAccount(
   });
   const root = paths.agentRoot(ws, agent);
   await seedSchemas(deps.vfs, root);
-
-  if (pkg.claudeMd !== undefined)
-    await deps.vfs.writeText(ctxFile(root), pkg.claudeMd);
-  for (const s of pkg.skills)
-    await deps.vfs.writeText(skillKey(root, s.slug), s.body);
-  if (pkg.routines.length) await saveRoutines(deps.vfs, root, pkg.routines);
-  if (pkg.learnings.length) await saveLearnings(deps.vfs, root, pkg.learnings);
+  // The SAME serialization the browser adapter sends through create-with-seeds
+  // on hosted cloud — one layout, wherever the install lands.
+  await writeAgentSeeds(deps.vfs, root, packageSeed(pkg));
 
   json(res, 201, { agent, installed: portableInventory(pkg) });
   return true;

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -80,10 +80,6 @@ function writeOverlay(overlay: Record<string, string>): void {
 function setColor(agentId: string, color: string): void {
   writeOverlay({ ...colorOverlay(), [agentId]: color });
 }
-/** Record an agent's overlay color from outside this module (portable install). */
-export function rememberAgentColor(agentId: string, color: string): void {
-  setColor(agentId, color);
-}
 function moveColor(fromId: string, toId: string): void {
   writeOverlay(renameColorOverlay(colorOverlay(), fromId, toId));
 }

--- a/packages/web/src/engine-adapter/portable-map.ts
+++ b/packages/web/src/engine-adapter/portable-map.ts
@@ -90,13 +90,3 @@ export function packagePreview(pkg: PortablePackage): {
     },
   };
 }
-
-/** btoa chokes on one giant fromCharCode spread; encode in chunks. */
-export function toBase64(bytes: Uint8Array): string {
-  let bin = "";
-  const CHUNK = 0x8000;
-  for (let i = 0; i < bytes.length; i += CHUNK) {
-    bin += String.fromCharCode(...bytes.subarray(i, i + CHUNK));
-  }
-  return btoa(bin);
-}

--- a/packages/web/src/engine-adapter/portable.ts
+++ b/packages/web/src/engine-adapter/portable.ts
@@ -4,15 +4,17 @@
  * Export preview + packaging go through the host's v3 portable routes. An
  * uploaded `.houstonagent` is unpacked IN THE BROWSER with the same domain
  * code the host runs (`@houston/domain`), held in memory under a packageId,
- * and posted to `/v1/portable/install` when the user confirms — nothing is
- * staged server-side, and the export download is just the route's response
+ * and installed on confirm as a create-with-seeds (`POST /agents`) — nothing
+ * is staged server-side, and the export download is just the route's response
  * bytes (no pod-volume storage on cloud).
  *
  * Pure shape mappings live in `portable-map.ts`.
  */
 
 import {
+  filterPackage,
   type PortablePackage,
+  packageSeed,
   scanContent,
   unpackAgent,
 } from "@houston/domain";
@@ -29,13 +31,13 @@ import type {
 import { HoustonEngineError } from "./client";
 import {
   type ControlPlaneConfig,
+  createAgent,
   gatewayAuthFetch,
-  rememberAgentColor,
 } from "./control-plane";
-import { packagePreview, toBase64, toWireSelection } from "./portable-map";
+import { packagePreview, toWireSelection } from "./portable-map";
 
-/** Uploaded archives awaiting install, keyed by the packageId handed to the wizard. */
-const uploads = new Map<string, { bytes: Uint8Array; pkg: PortablePackage }>();
+/** Unpacked uploads awaiting install, keyed by the packageId handed to the wizard. */
+const uploads = new Map<string, PortablePackage>();
 
 async function hostFetch(
   cfg: ControlPlaneConfig,
@@ -107,8 +109,8 @@ export async function anonymize(
 }
 
 /**
- * Unpack an uploaded `.houstonagent` locally and park the bytes until the
- * user confirms the install. Throws the domain's own message on junk bytes /
+ * Unpack an uploaded `.houstonagent` locally and park it until the user
+ * confirms the install. Throws the domain's own message on junk bytes /
  * future formats — the wizard toasts it verbatim.
  */
 export function previewUpload(
@@ -117,7 +119,7 @@ export function previewUpload(
   const u8 = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
   const pkg = unpackAgent(u8);
   const packageId = crypto.randomUUID();
-  uploads.set(packageId, { bytes: u8, pkg });
+  uploads.set(packageId, pkg);
   return { packageId, ...packagePreview(pkg) };
 }
 
@@ -127,40 +129,39 @@ export function previewUpload(
  * pure `@houston/domain` code the host would run.
  */
 export function scanUpload(packageId: string): PortableScanResponse {
-  const upload = uploads.get(packageId);
-  if (!upload) {
+  const pkg = uploads.get(packageId);
+  if (!pkg) {
     throw new Error(
       "The uploaded agent file is no longer available — pick the file again.",
     );
   }
-  return scanContent(upload.pkg);
+  return scanContent(pkg);
 }
 
-/** Install the parked archive as a new agent via the host. */
+/**
+ * Install the parked archive as a new agent — as an ordinary agent create
+ * carrying the selected content as its seed payload (CLAUDE.md + file map).
+ * That pipeline exists on BOTH backends: the local host writes the seeds on
+ * create, and the hosted-cloud gateway (which serves no account-level
+ * portable route) persists them and seeds the new agent's pod with them.
+ */
 export async function install(
   cfg: ControlPlaneConfig,
   req: PortableInstallRequest,
 ): Promise<PortableInstalledAgent> {
-  const upload = uploads.get(req.packageId);
-  if (!upload) {
+  const parked = uploads.get(req.packageId);
+  if (!parked) {
     throw new Error(
       "The uploaded agent file is no longer available — pick the file again.",
     );
   }
-  const res = await hostFetch(cfg, "/v1/portable/install", {
-    method: "POST",
-    body: JSON.stringify({
-      agentName: req.agentName,
-      archive: toBase64(upload.bytes),
-      selection: toWireSelection(req.selection),
-    }),
-  });
-  const { agent } = (await res.json()) as {
-    agent: { id: string; name: string };
-  };
-  // Color is a client-side overlay in control-plane mode (the host model is
-  // id/name only) — same contract as createAgent.
-  if (req.agentColor) rememberAgentColor(agent.id, req.agentColor);
+  const pkg = filterPackage(parked, toWireSelection(req.selection));
+  const agent = await createAgent(
+    cfg,
+    req.agentName,
+    req.agentColor ?? undefined,
+    packageSeed(pkg),
+  );
   uploads.delete(req.packageId);
   return {
     agentPath: agent.id, // in control-plane mode the agent id IS the path key

--- a/packages/web/tests/portable-install.test.ts
+++ b/packages/web/tests/portable-install.test.ts
@@ -1,0 +1,138 @@
+import { packAgent } from "@houston/domain";
+import { afterEach, expect, test, vi } from "vitest";
+import { install, previewUpload } from "../src/engine-adapter/portable";
+
+/**
+ * The import wizard's confirm step: installing a parked `.houstonagent` is an
+ * ordinary agent CREATE carrying the selected content as its seed payload —
+ * never a POST to the account-level /v1/portable routes, which the hosted
+ * cloud's gateway does not serve (HOU-707). One request shape for both
+ * backends: the local host writes the seeds on create; the gateway persists
+ * them and seeds the new agent's pod.
+ */
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+// createAgent records the picked color in the localStorage overlay; the node
+// test env has no storage, so give it an inert one.
+(globalThis as { localStorage?: unknown }).localStorage = {
+  getItem: () => null,
+  setItem: () => {},
+  removeItem: () => {},
+};
+
+const NOW = "2026-07-06T00:00:00.000Z";
+const CFG = { baseUrl: "https://gateway.example", token: "tok" };
+
+const ROUTINE = {
+  id: "r1",
+  name: "Daily",
+  description: "",
+  prompt: "check the inbox",
+  schedule: "0 9 * * *",
+  enabled: true,
+  suppress_when_silent: false,
+  chat_mode: "shared" as const,
+  integrations: [],
+  created_at: NOW,
+  updated_at: NOW,
+};
+
+function archive() {
+  return packAgent(
+    {
+      claudeMd: "# Role\nYou are the sales agent.",
+      skills: [
+        { slug: "research", body: "---\nname: research\n---\n\nDig in.\n" },
+      ],
+      routines: [ROUTINE],
+      learnings: [{ id: "l1", text: "Prefers brevity.", created_at: NOW }],
+    },
+    { agentName: "Sales", houstonVersion: "0.5.0" },
+    NOW,
+  );
+}
+
+function stubFetch(...responses: Response[]) {
+  const calls: { url: string; init: RequestInit | undefined }[] = [];
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    const next = responses.shift();
+    if (!next) throw new Error("stubFetch: no responses left");
+    return next;
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+test("install creates the agent with the package as its seed payload", async () => {
+  const { packageId } = previewUpload(archive());
+  const calls = stubFetch(
+    new Response(
+      JSON.stringify({ id: "abcd1234abcd1234", name: "Sales", createdAt: 0 }),
+      { status: 201, headers: { "Content-Type": "application/json" } },
+    ),
+  );
+
+  const installed = await install(CFG, {
+    packageId,
+    workspaceName: "Houston",
+    agentName: "Sales",
+    agentColor: "#ff0000",
+    selection: {
+      includeClaudeMd: true,
+      includeSkillSlugs: ["research"],
+      includeRoutineIds: ["r1"],
+      includeLearningIds: [],
+    },
+  });
+
+  expect(calls).toHaveLength(1);
+  const call = calls[0];
+  expect(call?.url).toBe("https://gateway.example/agents");
+  expect(call?.init?.method).toBe("POST");
+  const body = JSON.parse(String(call?.init?.body)) as {
+    name: string;
+    claudeMd?: string;
+    seeds?: Record<string, string>;
+  };
+  expect(body.name).toBe("Sales");
+  expect(body.claudeMd).toContain("sales agent");
+  expect(Object.keys(body.seeds ?? {}).sort()).toEqual([
+    ".agents/skills/research/SKILL.md",
+    ".houston/routines/routines.json",
+  ]);
+  // The unticked learning stays out of the payload entirely.
+  expect(JSON.stringify(body)).not.toContain("Prefers brevity");
+  expect(
+    JSON.parse(body.seeds?.[".houston/routines/routines.json"] ?? ""),
+  ).toEqual([ROUTINE]);
+
+  expect(installed).toEqual({
+    agentPath: "abcd1234abcd1234",
+    agentName: "Sales",
+    workspaceName: "Houston",
+    requiredIntegrations: [],
+  });
+});
+
+test("installing an evicted packageId fails loudly without a request", async () => {
+  const calls = stubFetch();
+  await expect(
+    install(CFG, {
+      packageId: "gone",
+      workspaceName: "Houston",
+      agentName: "X",
+      selection: {
+        includeClaudeMd: false,
+        includeSkillSlugs: [],
+        includeRoutineIds: [],
+        includeLearningIds: [],
+      },
+    }),
+  ).rejects.toThrow(/no longer available/);
+  expect(calls).toHaveLength(0);
+});

--- a/packages/web/tests/portable-map.test.ts
+++ b/packages/web/tests/portable-map.test.ts
@@ -2,7 +2,6 @@ import { packAgent, unpackAgent } from "@houston/domain";
 import { expect, test } from "vitest";
 import {
   packagePreview,
-  toBase64,
   toWireSelection,
 } from "../src/engine-adapter/portable-map";
 
@@ -99,10 +98,4 @@ test("a package without CLAUDE.md previews claudeMd as null", () => {
     ),
   );
   expect(packagePreview(bare).preview.claudeMd).toBeNull();
-});
-
-test("toBase64 survives payloads larger than one chunk", () => {
-  const big = new Uint8Array(0x8000 * 2 + 17).map((_, i) => i % 251);
-  const decoded = Uint8Array.from(atob(toBase64(big)), (c) => c.charCodeAt(0));
-  expect(decoded).toEqual(big);
 });


### PR DESCRIPTION
## Root cause

Importing a `.houstonagent` on hosted cloud failed with **"HoustonEngineError: not available on hosted cloud (engine error 501)"** (HOU-707). The import wizard's confirm step POSTed the account-level `/v1/portable/install` — a route the cloud gateway deliberately does not serve: with one pod per agent there is no single pod that could answer an account-level install, so everything under `/v1/portable*` returns 501. Export was unaffected because it rides the per-agent `/agents/:id/portable/*` routes, which proxy to the agent's pod.

## Fix

Install now rides the ordinary **agent-create pipeline** instead of a dedicated route. The browser already unpacks, threat-scans, and parks the archive locally; on confirm it filters the package by the user's selection and sends the content as the create's seed payload — `POST /agents { name, claudeMd, seeds }`, the same contract builtin templates use. The local host writes the seeds on create; the cloud gateway persists the payload and seeds the new agent's pod with it, so the same request works on both backends.

- **`@houston/domain`**: new pure `packageSeed(content)` serializer — portable content → `{ claudeMd, seeds }` in the exact on-disk layout (`.agents/skills/<slug>/SKILL.md`, `.houston/routines/routines.json`, `.houston/learnings/learnings.json`); `jsonDoc` extracted from `saveJson` so the document form is defined once.
- **`packages/host`**: the host's own `/v1/portable/install` now installs through `writeAgentSeeds(packageSeed(pkg))` too, so the two install paths share one serialization and cannot drift (the existing portable round-trip tests pin the layout).
- **`packages/web` adapter**: `install()` calls `createAgent` with the seed payload; the parked upload no longer keeps raw archive bytes (nothing re-uploads them), and `toBase64` / `rememberAgentColor` lost their last callers and are removed.

## Tests

- domain: `packageSeed` layout + omission tests (`packages/domain/src/portable.test.ts`)
- web: new `packages/web/tests/portable-install.test.ts` asserts install issues exactly one `POST /agents` with the filtered seed payload (and never touches `/v1/portable/*`)
- host: full suite green (622 passed) including the export → preview → install round-trip
- `pnpm check`, `pnpm check:boundaries`, `pnpm typecheck` (all packages), `app` tsgo all pass

## Verification

**Before the fix (reproduce):**
1. On a desktop or web build, open an agent's settings → Share with a friend → export a `.houstonagent` (works — per-agent routes).
2. Sign in to Houston Cloud, choose "From a friend", pick the exported file, confirm the install.
3. Red toast: "Could not install the agent. HoustonEngineError: not available on hosted cloud (engine error 501)".

**After the fix:**
1. Repeat the same import on cloud: the wizard completes, the new agent appears in the sidebar (pod cold-starts in the background like any created agent).
2. Once awake, the agent has the imported instructions, skills, routines, and learnings (check its Skills/Routines tabs).
3. Desktop/self-host import still works identically (same layout, now written through the shared serializer).

Fixes HOU-707

🤖 Generated with [Claude Code](https://claude.com/claude-code)