### PR TITLE
feat(local-model): per-app server hint in connect dialog

### DIFF
--- a/app/src/components/shell/local-model-dialog-parts.tsx
+++ b/app/src/components/shell/local-model-dialog-parts.tsx
@@ -72,6 +72,9 @@ export function EmptyScreen({
               <span className="text-[11px] text-muted-foreground">
                 {t(`localModel.empty.apps.${kind}`)}
               </span>
+              <span className="mt-0.5 text-[11px] font-medium text-foreground/75">
+                {t(`localModel.empty.hint.${kind}`)}
+              </span>
             </span>
             <button
               type="button"

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -136,6 +136,11 @@
         "jan": "An open, easy model app.",
         "ollama": "Popular and simple to set up."
       },
+      "hint": {
+        "lmstudio": "Open its Developer tab, then switch the server on.",
+        "jan": "In Settings, turn on the Local API Server.",
+        "ollama": "Runs on its own once installed. Nothing to switch on."
+      },
       "get": "Get it",
       "reassure": "Once it's open, Houston takes care of the rest.",
       "recheck": "Check again"

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -136,6 +136,11 @@
         "jan": "Una app de modelos abierta y fácil.",
         "ollama": "Popular y simple de configurar."
       },
+      "hint": {
+        "lmstudio": "Abre su pestaña Developer y activa el servidor.",
+        "jan": "En Configuración, activa el servidor de API local.",
+        "ollama": "Funciona solo una vez instalado. No hay que activar nada."
+      },
       "get": "Descargar",
       "reassure": "Cuando esté abierta, Houston se encarga del resto.",
       "recheck": "Buscar de nuevo"

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -136,6 +136,11 @@
         "jan": "Um app de modelos aberto e fácil.",
         "ollama": "Popular e simples de configurar."
       },
+      "hint": {
+        "lmstudio": "Abra a aba Developer e ative o servidor.",
+        "jan": "Em Configurações, ative o servidor de API local.",
+        "ollama": "Funciona sozinho depois de instalado. Não precisa ativar nada."
+      },
       "get": "Baixar",
       "reassure": "Assim que estiver aberto, o Houston cuida do resto.",
       "recheck": "Procurar de novo"


### PR DESCRIPTION
Adds a per-app 'turn on the server' hint to the local-model connect dialog's empty state — the step users miss (e.g. LM Studio's local server is off by default, so the model reads as 'not detected'). LM Studio / Jan / Ollama, en/es/pt.

Prompted by real testing: detection failed purely because LM Studio's server wasn't started.

🤖 Generated with [Claude Code](https://claude.com/claude-code)