### PR TITLE
fix(ui): make the sidebar Change-color submenu clickable on WebKit (HOU-708)

### DIFF
--- a/packages/fake-host/src/routes.ts
+++ b/packages/fake-host/src/routes.ts
@@ -192,6 +192,19 @@ export function handleAgents(
       if (method === "POST") return json({ paths: [] });
       return noContent();
 
+    case "portable":
+      // Share-with-a-friend export inventory. An empty (but well-shaped)
+      // preview is enough for the wizard to open; the default `{items: []}`
+      // fallthrough made `preview.skills.map` throw, silently closing it.
+      if (rest[2] === "preview" && method === "GET")
+        return json({
+          claudeMd: null,
+          skills: [],
+          routines: [],
+          learnings: [],
+        });
+      return noContent(405);
+
     default:
       console.warn(
         `[fake-host] unmodeled route ${method} /agents/${id}/${rest.slice(1).join("/")}`,

--- a/packages/web/e2e/README.md
+++ b/packages/web/e2e/README.md
@@ -13,10 +13,16 @@ app's UI too: it's the same React tree. (True Tauri-shell E2E would need
 
 ```bash
 pnpm --filter houston-web test:e2e        # headless, starts both servers itself
+pnpm --filter houston-web test:e2e:webkit # same suite on WebKit — what the desktop WKWebView runs
 pnpm --filter houston-web test:e2e:ui     # Playwright UI mode (watch / debug)
 pnpm --filter houston-web test:e2e:report # open the last HTML report
 pnpm --filter houston-web typecheck:e2e   # typecheck the harness
 ```
+
+The WebKit run needs a one-time `pnpm exec playwright install webkit`. Run it
+when a change touches popovers/menus/positioning: Chromium and WebKit disagree
+on overflow clipping and hit-testing (the HOU-708 color submenu was clickable
+on Chromium and dead on WebKit).
 
 Playwright boots two servers automatically (see `playwright.config.ts`):
 

--- a/packages/web/e2e/agent-sidebar-menu.spec.ts
+++ b/packages/web/e2e/agent-sidebar-menu.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "./support/fixtures";
+
+/**
+ * HOU-708 repro: changing an agent's color from the sidebar kebab menu.
+ * Color is a client-side overlay (localStorage `houston.web.cp.agentColors`);
+ * picking a swatch must update the sidebar avatar's fill immediately.
+ */
+test("changes agent color from the sidebar menu", async ({ page }) => {
+  await page.goto("/");
+
+  const agent = page
+    .getByRole("button", { name: "Houston", exact: true })
+    .last();
+  await agent.hover();
+  await page.getByRole("button", { name: "Agent menu" }).click();
+
+  // Open the Change color submenu and pick Navy.
+  await page.getByRole("menuitem", { name: "Change color" }).hover();
+  await page.getByRole("menuitemradio", { name: "Navy" }).click();
+
+  // The overlay must record the pick...
+  await expect
+    .poll(async () =>
+      page.evaluate(() =>
+        window.localStorage.getItem("houston.web.cp.agentColors"),
+      ),
+    )
+    .toContain("navy");
+
+  // ...and the sidebar avatar must repaint with the navy var.
+  const helmet = agent.locator("svg").first();
+  await expect(helmet).toHaveAttribute("style", /ht-agent-navy/);
+});
+
+/** The Share menu item opens the export wizard dialog. */
+test("opens the share wizard from the sidebar menu", async ({ page }) => {
+  await page.goto("/");
+
+  const agent = page
+    .getByRole("button", { name: "Houston", exact: true })
+    .last();
+  await agent.hover();
+  await page.getByRole("button", { name: "Agent menu" }).click();
+  await page.getByRole("menuitem", { name: "Share with a friend" }).click();
+
+  await expect(page.getByText("What should we share?")).toBeVisible();
+});
+
+/** Deleting an agent from the sidebar menu removes it from the list. */
+test("deletes an agent from the sidebar menu", async ({ page }) => {
+  await page.goto("/");
+
+  // Create a second agent to delete (never delete the only one).
+  await page.getByRole("button", { name: "New agent" }).click();
+  await page.getByText("From scratch").click();
+  await page.getByPlaceholder("e.g. Project Alpha").fill("Doomed Bot");
+  await page.getByRole("button", { name: "Create Agent" }).click();
+  await expect(page.getByText("Doomed Bot").first()).toBeVisible();
+
+  const doomed = page
+    .getByRole("button", { name: "Doomed Bot", exact: true })
+    .last();
+  await doomed.hover();
+  // Scope to Doomed Bot's own row — every agent row has an "Agent menu" button.
+  await doomed
+    .locator("..")
+    .getByRole("button", { name: "Agent menu" })
+    .click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+
+  // Confirm dialog.
+  await page.getByRole("button", { name: "Delete" }).click();
+
+  await expect(page.getByText("Doomed Bot")).toHaveCount(0);
+});

--- a/packages/web/e2e/agents.spec.ts
+++ b/packages/web/e2e/agents.spec.ts
@@ -64,10 +64,13 @@ test("renames an agent", async ({ page }) => {
   await page.getByRole("menuitem", { name: "Rename" }).click();
 
   // Rename swaps the sidebar row for an inline text field (the search box is a
-  // searchbox role, so this textbox is unambiguous).
+  // searchbox role, so this textbox is unambiguous). It must arrive focused
+  // with the current name selected, so typing replaces it without another
+  // click (HOU-708 follow-up).
   const input = page.getByRole("textbox");
-  await input.fill("Mission Control Bot");
-  await input.press("Enter");
+  await expect(input).toBeFocused();
+  await page.keyboard.type("Mission Control Bot");
+  await page.keyboard.press("Enter");
 
   await expect(page.getByText("Mission Control Bot").first()).toBeVisible();
 });

--- a/packages/web/e2e/files.spec.ts
+++ b/packages/web/e2e/files.spec.ts
@@ -82,7 +82,14 @@ test("renames and deletes a file from the context menu", async ({ page }) => {
 
 test("a folder downloads as its own zip from the context menu", async ({
   page,
+  browserName,
 }) => {
+  // Playwright WebKit never emits `download` for blob-anchor saves; the real
+  // desktop WKWebView doesn't use this path at all (native save_download IPC).
+  test.skip(
+    browserName === "webkit",
+    "no download events on Playwright WebKit",
+  );
   await openFilesTab(page);
 
   await page.getByText("Docs", { exact: true }).click({ button: "right" });
@@ -98,7 +105,14 @@ test("a folder downloads as its own zip from the context menu", async ({
   expect(zip.toString("latin1")).toContain("Docs/sales.csv");
 });
 
-test("Download all saves the whole workspace as one zip", async ({ page }) => {
+test("Download all saves the whole workspace as one zip", async ({
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName === "webkit",
+    "no download events on Playwright WebKit",
+  );
   await openFilesTab(page);
 
   const [download] = await Promise.all([

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -13,6 +13,7 @@
     "typecheck:e2e": "tsgo --noEmit -p e2e/tsconfig.json",
     "test": "vitest run ./tests --testTimeout=30000",
     "test:e2e": "playwright test --fail-on-flaky-tests",
+    "test:e2e:webkit": "playwright test --config playwright.webkit.config.ts --fail-on-flaky-tests",
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",
     "fake-host": "pnpm --filter @houston/fake-host start",

--- a/packages/web/playwright.webkit.config.ts
+++ b/packages/web/playwright.webkit.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig, devices } from "@playwright/test";
+import base from "./playwright.config";
+
+/**
+ * The e2e suite on WebKit (`pnpm test:e2e:webkit`) — the engine the desktop
+ * app's WKWebView actually runs. Chromium-only runs miss WebKit-specific
+ * breakage: the sidebar Change-color submenu was un-clickable ONLY on WebKit
+ * (overflow clipping of the un-portalled Radix SubContent, HOU-708). Same
+ * config as the default run, different browser. Needs a one-time
+ * `pnpm exec playwright install webkit`. Not wired into CI (yet).
+ */
+export default defineConfig({
+  ...base,
+  projects: [{ name: "webkit", use: { ...devices["Desktop Safari"] } }],
+});

--- a/ui/core/src/components/dropdown-menu.tsx
+++ b/ui/core/src/components/dropdown-menu.tsx
@@ -227,14 +227,21 @@ function DropdownMenuSubContent({
   ...props
 }: React.ComponentProps<typeof DropdownMenuPrimitive.SubContent>) {
   return (
-    <DropdownMenuPrimitive.SubContent
-      data-slot="dropdown-menu-sub-content"
-      className={cn(
-        "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
-        className,
-      )}
-      {...props}
-    />
+    // Portalled like DropdownMenuContent, NOT rendered inline: inline puts the
+    // submenu's fixed-position popper inside the parent content's
+    // overflow-x-hidden/overflow-y-auto box, and WebKit (the desktop WKWebView,
+    // Safari) clips it there — the submenu paints but no click can reach it
+    // (HOU-708). Chromium doesn't clip, which is why this only broke on desktop.
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.SubContent
+        data-slot="dropdown-menu-sub-content"
+        className={cn(
+          "z-50 min-w-[8rem] origin-(--radix-dropdown-menu-content-transform-origin) overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95",
+          className,
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
   );
 }
 

--- a/ui/layout/src/sidebar-item-row.tsx
+++ b/ui/layout/src/sidebar-item-row.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuTrigger,
 } from "@houston-ai/core";
 import { MoreHorizontal } from "lucide-react";
-import { type KeyboardEvent, useState } from "react";
+import { type KeyboardEvent, useCallback, useRef, useState } from "react";
 import type { SidebarItem } from "./sidebar";
 import { sidebarItemRowClasses } from "./sidebar-classes";
 
@@ -55,6 +55,16 @@ export function SidebarItemRow({
 }: SidebarItemRowProps) {
   const l = { ...DEFAULT_LABELS, ...labels };
   const [menuOpen, setMenuOpen] = useState(false);
+  // Picking Rename swaps the whole row (trigger included) for the input, so
+  // nothing focuses it by default — the user had to click again before typing.
+  // Focus + select-all when the input mounts (stable callback: a fresh inline
+  // ref would re-run per keystroke and re-select what's being typed), and stop
+  // the closing menu's focus restore from stealing it back.
+  const renameStarted = useRef(false);
+  const focusEditInput = useCallback((el: HTMLInputElement | null) => {
+    el?.focus();
+    el?.select();
+  }, []);
 
   return (
     <div
@@ -65,6 +75,7 @@ export function SidebarItemRow({
     >
       {isEditing ? (
         <input
+          ref={focusEditInput}
           value={editValue}
           onChange={(e) => onEditChange(e.target.value)}
           onBlur={() => onCommitRename(item.id)}
@@ -116,10 +127,22 @@ export function SidebarItemRow({
                   <MoreHorizontal className="size-4" />
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" side="bottom">
+              <DropdownMenuContent
+                align="end"
+                side="bottom"
+                onCloseAutoFocus={(e) => {
+                  if (renameStarted.current) {
+                    renameStarted.current = false;
+                    e.preventDefault();
+                  }
+                }}
+              >
                 {onStartRename && (
                   <DropdownMenuItem
-                    onClick={() => onStartRename(item.id, item.name)}
+                    onClick={() => {
+                      renameStarted.current = true;
+                      onStartRename(item.id, item.name);
+                    }}
                   >
                     {l.renameItem}
                   </DropdownMenuItem>


### PR DESCRIPTION
## Summary

**HOU-708** — picking a color from the agent's sidebar kebab menu did nothing on the desktop app (and Safari on the web app), local and cloud alike.

### Root cause

The color picker is the app's only dropdown **sub**menu, and `DropdownMenuSubContent` was rendered inline inside the parent `DropdownMenuContent`, which has `overflow-x-hidden overflow-y-auto` (for long scrollable menus). The submenu's fixed-position popper lands outside that box, and **WebKit clips it there** — the swatches paint but are not hit-testable: every click falls through to `<html>` (the body is `pointer-events: none` while a menu is open), so selecting a color never fires. Chromium doesn't clip fixed poppers whose containing block sits outside the scroll container, which is why the bug never showed in Chrome — but the desktop shell is a WKWebView, so it was broken there since the submenu was introduced.

### Fix

`DropdownMenuSubContent` now renders through `DropdownMenuPrimitive.Portal` (the documented Radix composition, same as the main menu content), so the submenu escapes the clipping box entirely. One-line-of-structure change in `ui/core`; no visual difference.

### Also in this PR (per the "verify every sidebar agent option" ask)

- **New e2e spec `agent-sidebar-menu.spec.ts`** covering every sidebar agent menu action: change color, share, delete (rename was already covered in `agents.spec.ts`). All run in control-plane mode — the same client path cloud uses.
- **`pnpm --filter houston-web test:e2e:webkit`** — the whole e2e suite on WebKit, the engine the desktop actually ships. A Chromium-only run passes with this bug present; the WebKit run is what catches it. The two blob-download Files specs are skipped on WebKit (Playwright WebKit emits no `download` events, and the real desktop saves through the native `save_download` IPC path anyway).
- **Fake host now models `GET /agents/:id/portable/preview`**: the generic `{items: []}` fallthrough made the share wizard's preview parse throw and self-close, which hid the Share flow from the tests.

Rename and delete were verified working on both engines (existing + new specs); no product bug found in those paths.

## Rename focus (second commit)

Picking **Rename** swapped the row for the inline input but never focused it, so typing required a second click. The input now arrives focused with the current name selected (typing replaces it), and the closing menu cannot steal focus back. The rename e2e types straight into the field with no click, on both engines.

## Repro (before the fix)

1. Open the Houston **desktop app** (or the web app in **Safari**), any engine — local or cloud.
2. Hover an agent in the sidebar → kebab (⋯) → **Change color** → click any swatch.
3. Nothing happens: the swatch doesn't select and the avatar keeps its color.
4. Automated: `pnpm exec playwright install webkit && pnpm --filter houston-web test:e2e:webkit` — `agent-sidebar-menu.spec.ts › changes agent color from the sidebar menu` times out with "`<html>` intercepts pointer events" on the swatch click.

## Verify (after the fix)

1. Same steps: kebab → Change color → pick **Navy** — the swatch selects, the menu closes, and the agent's avatar recolors immediately (and survives reload; in CP mode the pick is stored in the `houston.web.cp.agentColors` localStorage overlay).
2. Rename, Share with a friend, and Delete from the same menu all work.
3. Automated: `pnpm --filter houston-web test:e2e` (26 passed) and `pnpm --filter houston-web test:e2e:webkit` (24 passed, 2 skipped download specs).
4. Gates: `pnpm check`, `pnpm typecheck` (all packages), `pnpm check:parity`, `pnpm check:boundaries` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)