### PR TITLE
fix(files): chat uploads land in a durable, visible uploads/ folder (HOU-706)

### DIFF
--- a/app/src/components/board/use-cross-agent-selection.ts
+++ b/app/src/components/board/use-cross-agent-selection.ts
@@ -2,7 +2,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { ARCHIVED_STATUS } from "../../lib/mission-selection";
 import { queryKeys } from "../../lib/query-keys";
-import { tauriActivity, tauriAttachments } from "../../lib/tauri";
+import { tauriActivity } from "../../lib/tauri";
 import { useDraftStore } from "../../stores/drafts";
 import type { BoardSelectionModel } from "./board-source";
 import { groupIdsByAgent } from "./group-ids-by-agent";
@@ -63,11 +63,9 @@ export function useCrossAgentSelection({
           tauriActivity.bulkDelete(agentPath, groupIds),
         ),
       );
-      // Per-conversation cleanup is idempotent + best-effort; the bulk delete
-      // above already succeeded, so a stray attachment/draft must not fail the
-      // whole action. Mirrors useBulkDeleteActivity.
+      // Attached files stay in each workspace's uploads/ folder (HOU-706);
+      // only the unsent drafts need clearing. Mirrors useBulkDeleteActivity.
       for (const id of ids) {
-        await tauriAttachments.delete(`activity-${id}`).catch(() => {});
         useDraftStore.getState().clearDraft(`activity-${id}`);
       }
       invalidate(Object.keys(groups));

--- a/app/src/components/board/use-mission-control-archived.ts
+++ b/app/src/components/board/use-mission-control-archived.ts
@@ -9,7 +9,6 @@ import { missionCardTags } from "../../lib/mission-card";
 import {
   type HistoryLoadOptions,
   tauriActivity,
-  tauriAttachments,
   tauriChat,
 } from "../../lib/tauri";
 import type { Agent } from "../../lib/types";
@@ -142,7 +141,8 @@ export function useMissionControlArchived(agents: Agent[]) {
       const agentPath = pathMapRef.current[item.id];
       if (!agentPath) return;
       await tauriActivity.delete(agentPath, item.id);
-      await tauriAttachments.delete(`activity-${item.id}`).catch(() => {});
+      // Files attached in this conversation stay in the workspace's uploads/
+      // folder — they are agent context, not conversation scratch (HOU-706).
       if (selectedId === item.id) setSelectedId(null);
     },
     [selectedId],

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -152,8 +152,8 @@ export function useMissionControl(agents: Agent[]) {
       const agentPath = pathMapRef.current[item.id];
       if (!agentPath) return;
       await tauriActivity.delete(agentPath, item.id);
-      // Drop any cached attachments for this conversation. Idempotent.
-      await tauriAttachments.delete(`activity-${item.id}`).catch(() => {});
+      // Files attached in this conversation stay in the workspace's uploads/
+      // folder — they are agent context, not conversation scratch (HOU-706).
       if (selectedId === item.id) setSelectedId(null);
     },
     [selectedId],

--- a/app/src/hooks/queries/use-activity.ts
+++ b/app/src/hooks/queries/use-activity.ts
@@ -1,6 +1,6 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "../../lib/query-keys";
-import { tauriActivity, tauriAttachments } from "../../lib/tauri";
+import { tauriActivity } from "../../lib/tauri";
 import { useDraftStore } from "../../stores/drafts";
 
 export function useActivity(agentPath: string | undefined) {
@@ -71,8 +71,8 @@ export function useDeleteActivity(agentPath: string | undefined) {
     mutationFn: async (activityId: string) => {
       if (!agentPath) throw new Error("agentPath required");
       await tauriActivity.delete(agentPath, activityId);
-      // Wipe any attachments associated with this conversation. Idempotent.
-      await tauriAttachments.delete(`activity-${activityId}`).catch(() => {});
+      // Files attached in this conversation stay in the workspace's uploads/
+      // folder — they are agent context, not conversation scratch (HOU-706).
       // Clear any unsent draft for this conversation.
       useDraftStore.getState().clearDraft(`activity-${activityId}`);
     },
@@ -104,18 +104,15 @@ export function useBulkUpdateActivity(agentPath: string | undefined) {
   });
 }
 
-/** Delete many activities at once, wiping each one's attachments + draft. */
+/** Delete many activities at once, wiping each one's draft. */
 export function useBulkDeleteActivity(agentPath: string | undefined) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (ids: string[]) => {
       if (!agentPath) throw new Error("agentPath required");
       await tauriActivity.bulkDelete(agentPath, ids);
+      // Attached files stay in the workspace's uploads/ folder (HOU-706).
       for (const id of ids) {
-        // Per-conversation cleanup is idempotent + best-effort; the bulk
-        // delete above already succeeded, so a stray attachment/draft must
-        // not fail the whole action.
-        await tauriAttachments.delete(`activity-${id}`).catch(() => {});
         useDraftStore.getState().clearDraft(`activity-${id}`);
       }
     },

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -388,10 +388,6 @@ export const tauriAttachments = {
       getEngine().saveAttachments(scopeId, files),
     );
   },
-  delete: (scopeId: string) =>
-    call<void>("delete_attachments", () =>
-      getEngine().deleteAttachments(scopeId),
-    ),
 };
 
 // ─── Agent-data files (`.houston/**`) ─────────────────────────────────

--- a/app/src/stores/agents.ts
+++ b/app/src/stores/agents.ts
@@ -3,7 +3,6 @@ import { selectCurrentAgent } from "../lib/agent-selection";
 import { analytics } from "../lib/analytics";
 import {
   tauriAgents,
-  tauriAttachments,
   tauriPreferences,
   tauriRoutines,
   tauriWatcher,
@@ -137,13 +136,10 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     await tauriAgents.delete(workspaceId, id);
     // A deleted agent is never "being created" — stop the probe and the UI.
     useAgentProvisioningStore.getState().clearProvisioning(id);
-    // The server confirmed the delete — reflect it in the UI NOW. In cloud
-    // mode the attachments cleanup below dispatches into the agent's pod,
-    // which this very delete just tore down, so awaiting it here can block
-    // on a dead endpoint for many seconds — leaving the "deleted" agent
-    // sitting in the sidebar (and 404ing when reopened).
+    // The server confirmed the delete — reflect it in the UI NOW.
     // Conversation state lives in the SDK conversation VM; a deleted agent's
-    // scopes are simply never subscribed again.
+    // scopes are simply never subscribed again. Uploaded files need no
+    // cleanup either: they live in the agent's workspace, which died with it.
     // Clear the free-form chat draft for this agent.
     useDraftStore.getState().clearDraft(`chat-${id}`);
     let nextCurrent: Agent | null = null;
@@ -156,10 +152,6 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     if (wasCurrent && nextCurrent) {
       startAgentSideEffects(nextCurrent);
     }
-    // Wipe any chat composer attachments scoped to this agent's chat —
-    // fire-and-forget best-effort: the agent's own data died with it.
-    // Per-activity attachments are wiped via useDeleteActivity / handleDelete.
-    void tauriAttachments.delete(`agent-${id}`).catch(() => {});
   },
 
   rename: async (workspaceId, id, newName) => {

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -511,8 +511,9 @@ export async function handleAgents(
       )
     )
       return true;
-    // Composer attachments: uploaded into the workspace so the runtime's clamped
-    // file tools can Read them during the turn (the runtime has no /attachments).
+    // Composer attachments: uploaded into the workspace's visible `uploads/`
+    // folder so the runtime's clamped file tools can Read them during this turn
+    // AND any later conversation (the runtime has no /attachments).
     if (
       await handleAttachments(
         deps.vfs,
@@ -522,7 +523,7 @@ export async function handleAgents(
         rest,
         req,
         res,
-        url.searchParams,
+        emit,
       )
     )
       return true;

--- a/packages/host/src/turn/attachments.test.ts
+++ b/packages/host/src/turn/attachments.test.ts
@@ -1,42 +1,40 @@
+import type { HoustonEvent } from "@houston/protocol";
 import { expect, test } from "vitest";
 import type { Agent, Workspace } from "../domain/types";
 import type { WorkspacePaths } from "../paths";
 import { MemoryVfs } from "../vfs";
 import {
   AttachmentError,
-  deleteAttachments,
   handleAttachments,
   saveAttachments,
 } from "./attachments";
 import { listWorkspace } from "./files";
 
 /**
- * Composer attachments over an agent's workspace root. The files land under a
- * top-level `.attachments/<scopeId>/` dot-dir so the runtime's clamped file
- * tools (rooted at the same dir) can Read them at the RELATIVE path returned,
- * while the Files tab — which hides + refuses top-level dot-dirs — never shows
- * or touches them. Path safety stops a hostile scopeId/filename escaping.
+ * Composer attachments over an agent's workspace root. Files land in a VISIBLE
+ * top-level `uploads/` folder (HOU-706): the runtime's clamped file tools
+ * (rooted at the same dir) Read them at the RELATIVE path returned, the Files
+ * tab lists them, and nothing ever deletes them behind the user's back — an
+ * upload from one conversation stays referenceable from every later one.
+ * Path safety stops a hostile filename escaping the folder.
  */
 
 const ROOT = "ws/w1/agent-1/workspace"; // cloud agentRoot
 const PATHS = { agentRoot: () => ROOT } as unknown as WorkspacePaths;
-const CTX = { workspace: {} as Workspace, agent: {} as Agent };
+const CTX = { workspace: {} as Workspace, agent: { id: "a-1" } as Agent };
 
 const b64 = (s: string) => Buffer.from(s, "utf8").toString("base64");
 
 test("save returns relative workspace paths; bytes land where the agent reads them", async () => {
   const vfs = new MemoryVfs();
-  const paths = await saveAttachments(vfs, ROOT, "activity-7", [
+  const paths = await saveAttachments(vfs, ROOT, [
     { name: "brief.txt", contentBase64: b64("hello brief") },
     { name: "data.csv", contentBase64: b64("a,b\n1,2") },
   ]);
 
   // The returned paths are relative to the workspace root (what the agent's
-  // Read tool resolves), keyed by scopeId.
-  expect(paths).toEqual([
-    ".attachments/activity-7/brief.txt",
-    ".attachments/activity-7/data.csv",
-  ]);
+  // Read tool resolves).
+  expect(paths).toEqual(["uploads/brief.txt", "uploads/data.csv"]);
   // The bytes are at `<root>/<relPath>` — i.e. resolvable under the clamp root.
   expect(await vfs.readText(`${ROOT}/${paths[0]}`)).toBe("hello brief");
   expect(await vfs.readText(`${ROOT}/${paths[1]}`)).toBe("a,b\n1,2");
@@ -45,7 +43,7 @@ test("save returns relative workspace paths; bytes land where the agent reads th
 test("binary round-trips byte-for-byte through base64", async () => {
   const vfs = new MemoryVfs();
   const payload = Buffer.from([0x50, 0x4b, 0x03, 0x04, 0xff, 0x00, 0x80]);
-  const [rel] = await saveAttachments(vfs, ROOT, "s1", [
+  const [rel] = await saveAttachments(vfs, ROOT, [
     { name: "deck.pptx", contentBase64: payload.toString("base64") },
   ]);
   const stored = await vfs.readBytes(`${ROOT}/${rel}`);
@@ -56,65 +54,56 @@ test("binary round-trips byte-for-byte through base64", async () => {
 
 test("duplicate filenames in one batch are disambiguated, never overwritten", async () => {
   const vfs = new MemoryVfs();
-  const paths = await saveAttachments(vfs, ROOT, "s1", [
+  const paths = await saveAttachments(vfs, ROOT, [
     { name: "report.pdf", contentBase64: b64("first") },
     { name: "report.pdf", contentBase64: b64("second") },
   ]);
-  expect(paths).toEqual([
-    ".attachments/s1/report.pdf",
-    ".attachments/s1/report (1).pdf",
-  ]);
+  expect(paths).toEqual(["uploads/report.pdf", "uploads/report (1).pdf"]);
   expect(await vfs.readText(`${ROOT}/${paths[0]}`)).toBe("first");
   expect(await vfs.readText(`${ROOT}/${paths[1]}`)).toBe("second");
 });
 
-test("attachments are invisible to the Files tab (top-level dot-dir)", async () => {
+test("uploads persist across saves: a later conversation's same-named file never clobbers an earlier one", async () => {
+  const vfs = new MemoryVfs();
+  const first = await saveAttachments(vfs, ROOT, [
+    { name: "report.pdf", contentBase64: b64("from chat one") },
+  ]);
+  // A different conversation, days later, attaches a file with the same name.
+  const second = await saveAttachments(vfs, ROOT, [
+    { name: "report.pdf", contentBase64: b64("from chat two") },
+  ]);
+  expect(first).toEqual(["uploads/report.pdf"]);
+  expect(second).toEqual(["uploads/report (1).pdf"]);
+  expect(await vfs.readText(`${ROOT}/${first[0]}`)).toBe("from chat one");
+  expect(await vfs.readText(`${ROOT}/${second[0]}`)).toBe("from chat two");
+});
+
+test("uploads are visible in the Files tab listing", async () => {
   const vfs = new MemoryVfs();
   await vfs.writeText(`${ROOT}/report.txt`, "visible");
-  await saveAttachments(vfs, ROOT, "s1", [
-    { name: "secret.txt", contentBase64: b64("x") },
+  await saveAttachments(vfs, ROOT, [
+    { name: "attached.txt", contentBase64: b64("x") },
   ]);
   const listed = (await listWorkspace(vfs, ROOT)).map((f) => f.path);
   expect(listed).toContain("report.txt");
-  expect(listed.some((p) => p.startsWith(".attachments"))).toBe(false);
+  expect(listed).toContain("uploads/attached.txt");
 });
 
-test("delete drops the whole scope's batch", async () => {
-  const vfs = new MemoryVfs();
-  await saveAttachments(vfs, ROOT, "s1", [
-    { name: "a.txt", contentBase64: b64("a") },
-    { name: "b.txt", contentBase64: b64("b") },
-  ]);
-  await saveAttachments(vfs, ROOT, "s2", [
-    { name: "c.txt", contentBase64: b64("c") },
-  ]);
-
-  await deleteAttachments(vfs, ROOT, "s1");
-  expect(await vfs.list(`${ROOT}/.attachments/s1`)).toEqual([]);
-  // A different scope is untouched.
-  expect(await vfs.readText(`${ROOT}/.attachments/s2/c.txt`)).toBe("c");
-});
-
-test("traversal in scopeId or filename is rejected, never silently clamped", async () => {
+test("traversal or dotfile in filename is rejected, never silently clamped", async () => {
   const vfs = new MemoryVfs();
   await expect(
-    saveAttachments(vfs, ROOT, "../escape", [
-      { name: "a.txt", contentBase64: b64("a") },
-    ]),
-  ).rejects.toThrow(AttachmentError);
-  await expect(
-    saveAttachments(vfs, ROOT, "s1", [
+    saveAttachments(vfs, ROOT, [
       { name: "../../auth.json", contentBase64: b64("x") },
     ]),
   ).rejects.toThrow(AttachmentError);
   await expect(
-    saveAttachments(vfs, ROOT, "s1", [
+    saveAttachments(vfs, ROOT, [
       { name: "sub/evil.txt", contentBase64: b64("x") },
     ]),
   ).rejects.toThrow(AttachmentError);
-  await expect(deleteAttachments(vfs, ROOT, "..")).rejects.toThrow(
-    AttachmentError,
-  );
+  await expect(
+    saveAttachments(vfs, ROOT, [{ name: ".env", contentBase64: b64("x") }]),
+  ).rejects.toThrow(AttachmentError);
 });
 
 // --- HTTP handler ---
@@ -146,34 +135,44 @@ function fakeReq(body: unknown) {
   } as never;
 }
 
-test("POST uploads then DELETE clears, over the HTTP handler", async () => {
+test("POST uploads over the HTTP handler and fires FilesChanged", async () => {
   const vfs = new MemoryVfs();
+  const events: HoustonEvent[] = [];
 
   const post = fakeRes();
-  const handledPost = await handleAttachments(
+  const handled = await handleAttachments(
     vfs,
     PATHS,
     CTX,
     "POST",
     "attachments",
+    // Legacy clients still send `scopeId` (older pods require it); it must be
+    // accepted and ignored, not 400ed.
     fakeReq({
       scopeId: "activity-1",
       files: [{ name: "n.txt", contentBase64: b64("body") }],
     }),
     post.res,
-    new URLSearchParams(),
+    (e) => events.push(e),
   );
-  expect(handledPost).toBe(true);
+  expect(handled).toBe(true);
   expect(post.state.status).toBe(200);
   expect((post.state.body as { paths: string[] }).paths).toEqual([
-    ".attachments/activity-1/n.txt",
+    "uploads/n.txt",
   ]);
-  expect(await vfs.readText(`${ROOT}/.attachments/activity-1/n.txt`)).toBe(
-    "body",
-  );
+  expect(await vfs.readText(`${ROOT}/uploads/n.txt`)).toBe("body");
+  // The upload landed in a visible folder → other Files tabs must refresh.
+  expect(events).toEqual([{ type: "FilesChanged", agentPath: "a-1" }]);
+});
+
+test("the legacy DELETE (per-scope wipe) is refused — uploads are permanent", async () => {
+  const vfs = new MemoryVfs();
+  await saveAttachments(vfs, ROOT, [
+    { name: "keep.txt", contentBase64: b64("keep") },
+  ]);
 
   const del = fakeRes();
-  await handleAttachments(
+  const handled = await handleAttachments(
     vfs,
     PATHS,
     CTX,
@@ -181,27 +180,28 @@ test("POST uploads then DELETE clears, over the HTTP handler", async () => {
     "attachments",
     fakeReq({}),
     del.res,
-    new URLSearchParams({ scopeId: "activity-1" }),
   );
-  expect(del.state.status).toBe(200);
-  expect(await vfs.list(`${ROOT}/.attachments/activity-1`)).toEqual([]);
+  expect(handled).toBe(true);
+  expect(del.state.status).toBe(405);
+  expect(await vfs.readText(`${ROOT}/uploads/keep.txt`)).toBe("keep");
 });
 
-test("malformed upload bodies fail loudly (400), DELETE without scopeId 400s", async () => {
+test("malformed upload bodies fail loudly (400) and emit nothing", async () => {
   const vfs = new MemoryVfs();
+  const events: HoustonEvent[] = [];
 
-  const noScope = fakeRes();
+  const noFiles = fakeRes();
   await handleAttachments(
     vfs,
     PATHS,
     CTX,
     "POST",
     "attachments",
-    fakeReq({ files: [] }),
-    noScope.res,
-    new URLSearchParams(),
+    fakeReq({}),
+    noFiles.res,
+    (e) => events.push(e),
   );
-  expect(noScope.state.status).toBe(400);
+  expect(noFiles.state.status).toBe(400);
 
   const badFile = fakeRes();
   await handleAttachments(
@@ -210,24 +210,12 @@ test("malformed upload bodies fail loudly (400), DELETE without scopeId 400s", a
     CTX,
     "POST",
     "attachments",
-    fakeReq({ scopeId: "s1", files: [{ name: "n.txt" }] }),
+    fakeReq({ files: [{ name: "n.txt" }] }),
     badFile.res,
-    new URLSearchParams(),
+    (e) => events.push(e),
   );
   expect(badFile.state.status).toBe(400);
-
-  const delNoScope = fakeRes();
-  await handleAttachments(
-    vfs,
-    PATHS,
-    CTX,
-    "DELETE",
-    "attachments",
-    fakeReq({}),
-    delNoScope.res,
-    new URLSearchParams(),
-  );
-  expect(delNoScope.state.status).toBe(400);
+  expect(events).toEqual([]);
 });
 
 test("a missing vfs answers 503 for attachments routes", async () => {
@@ -238,9 +226,8 @@ test("a missing vfs answers 503 for attachments routes", async () => {
     CTX,
     "POST",
     "attachments",
-    fakeReq({ scopeId: "s1", files: [] }),
+    fakeReq({ files: [] }),
     res,
-    new URLSearchParams(),
   );
   expect(handled).toBe(true);
   expect(state.status).toBe(503);
@@ -256,7 +243,6 @@ test("non-attachments rest is not handled (returns false)", async () => {
     "files",
     fakeReq({}),
     res,
-    new URLSearchParams(),
   );
   expect(handled).toBe(false);
 });

--- a/packages/host/src/turn/attachments.ts
+++ b/packages/host/src/turn/attachments.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
+import type { HoustonEvent } from "@houston/protocol";
 import type { Agent, Workspace } from "../domain/types";
 import type { WorkspacePaths } from "../paths";
 import type { Vfs } from "../vfs";
@@ -10,25 +11,30 @@ import { MAX_UPLOAD_BYTES } from "./files-import";
  * the agent's workspace so the runtime's clamped file tools can Read them during
  * the turn.
  *
- * Storage: `<agentRoot>/.attachments/<scopeId>/<filename>`. `agentRoot` is
+ * Storage: `<agentRoot>/uploads/<filename>`. `agentRoot` is
  * HOUSTON_WORKSPACE_DIR — the very root the runtime's WorkspaceGuard clamps to —
- * so the RELATIVE path we return (`.attachments/<scopeId>/<filename>`) is exactly
- * what the agent's Read tool resolves and is allowed to open (a leading dot-dir
- * is fine: the clamp only blocks `..` / absolute / `~` escapes). The frontend
- * encodes that path verbatim into the message text ("Read these attached
- * files: …"), so what we store and what we return MUST agree.
+ * so the RELATIVE path we return (`uploads/<filename>`) is exactly what the
+ * agent's Read tool resolves and is allowed to open. The frontend encodes that
+ * path verbatim into the message text ("Read these attached files: …"), so what
+ * we store and what we return MUST agree.
  *
- * `.attachments` is a top-level dot-dir, so the Files tab (which hides + refuses
- * top-level dot-dirs) never shows or clobbers it — same wall that hides
- * `.houston` / `.agents`.
+ * `uploads` is a regular, VISIBLE workspace folder: uploads are permanent agent
+ * context, not per-conversation scratch (HOU-706). The user sees them in the
+ * Files tab, the agent can find them from ANY later conversation, and clearing
+ * or deleting a chat never removes them. (The pre-HOU-706 layout — a hidden
+ * `.attachments/<scopeId>/` dot-dir wiped on chat delete — made every upload
+ * silently vanish from the user's point of view. Files already stored there
+ * stay readable at their old paths; new uploads never land there.)
  *
  * Transport: base64 JSON (dependency-free, binary-safe — the same base64 path
- * `files/read` already uses). `scopeId` keys the per-message folder so
- * `deleteAttachments(scopeId)` can drop the whole batch.
+ * `files/read` already uses). The body's `scopeId` is legacy: older hosts keyed
+ * storage (and a DELETE route) on it. It is accepted and ignored so current
+ * clients — which still send it to stay compatible with not-yet-updated cloud
+ * pods — never 400.
  */
 
-/** The on-disk dir name. Top-level dot-dir → invisible to + untouchable by the Files tab. */
-const ATTACHMENTS_DIR = ".attachments";
+/** The on-disk dir name — a visible, durable folder in the agent's workspace. */
+const UPLOADS_DIR = "uploads";
 
 // A single request is capped at MAX_UPLOAD_BYTES (shared with files/import so
 // the composer's client-side per-file limit and the host cap can't drift; the
@@ -51,64 +57,57 @@ interface UploadFile {
 }
 
 /**
- * Validate a scopeId / filename segment: a single path component, no traversal,
- * no separators, no leading dot (the dot-dir is ours to add). Rejected loudly.
+ * Validate a filename: a single path component, no traversal, no separators,
+ * no leading dot (a dotfile would be invisible in the Files tab, defeating the
+ * whole point of durable uploads). Rejected loudly.
  */
-function safeSegment(seg: string, kind: "scopeId" | "filename"): string {
+function safeFilename(name: string): string {
   if (
-    seg === "" ||
-    seg === "." ||
-    seg === ".." ||
-    seg.includes("/") ||
-    seg.includes("\\") ||
-    seg.startsWith(".")
+    name === "" ||
+    name === "." ||
+    name === ".." ||
+    name.includes("/") ||
+    name.includes("\\") ||
+    name.startsWith(".")
   ) {
-    throw new AttachmentError(400, `invalid attachment ${kind}: ${seg}`);
+    throw new AttachmentError(400, `invalid attachment filename: ${name}`);
   }
-  return seg;
+  return name;
 }
 
-/** The relative path (under agentRoot) the agent's Read tool resolves. */
-function relPath(scopeId: string, filename: string): string {
-  return `${ATTACHMENTS_DIR}/${scopeId}/${filename}`;
-}
-
-const dirKey = (root: string, scopeId: string) =>
-  `${root}/${ATTACHMENTS_DIR}/${scopeId}`;
-const fileKey = (root: string, rel: string) => `${root}/${rel}`;
+const uploadsKey = (root: string) => `${root}/${UPLOADS_DIR}`;
 
 /**
- * Write each uploaded file under `.attachments/<scopeId>/` and return the
- * RELATIVE workspace paths the agent will read. Duplicate filenames in one batch
- * are disambiguated (`name.ext`, `name (1).ext`, …) so nothing is silently
- * overwritten and every returned path resolves to a distinct stored file.
+ * Write each uploaded file under `uploads/` and return the RELATIVE workspace
+ * paths the agent will read. Names colliding with anything already in the
+ * folder — or with each other within a batch — are disambiguated (`name.ext`,
+ * `name (1).ext`, …) so an upload never silently overwrites an earlier one and
+ * every returned path resolves to a distinct stored file.
  */
 export async function saveAttachments(
   vfs: Vfs,
   root: string,
-  scopeId: string,
   files: readonly UploadFile[],
 ): Promise<string[]> {
-  safeSegment(scopeId, "scopeId");
-  // Seed the dedup set with what this scope already holds, so a batch split
-  // across several requests (the client uploads one request per file to bound
-  // request size) still never silently overwrites an earlier file.
-  const scopePrefix = dirKey(root, scopeId);
+  // Seed the dedup set with what the folder already holds: uploads are durable
+  // across conversations, so "report.pdf" attached today must not clobber the
+  // "report.pdf" attached last week.
+  const prefix = uploadsKey(root);
   const used = new Set<string>(
-    (await vfs.list(scopePrefix)).map((k) => k.slice(scopePrefix.length + 1)),
+    (await vfs.list(prefix)).map((k) => k.slice(prefix.length + 1)),
   );
   const paths: string[] = [];
   for (const f of files) {
-    const filename = dedupe(safeSegment(f.name, "filename"), used);
+    const filename = dedupe(safeFilename(f.name), used);
     const bytes = Buffer.from(f.contentBase64, "base64");
-    const rel = relPath(scopeId, filename);
-    await vfs.writeBytes(fileKey(root, rel), bytes);
+    const rel = `${UPLOADS_DIR}/${filename}`;
+    await vfs.writeBytes(`${root}/${rel}`, bytes);
     paths.push(rel);
   }
   return paths;
 }
 
-/** Pick a unique filename within a batch, appending " (n)" before the extension. */
+/** Pick a unique filename within the folder, appending " (n)" before the extension. */
 function dedupe(name: string, used: Set<string>): string {
   if (!used.has(name)) {
     used.add(name);
@@ -126,30 +125,14 @@ function dedupe(name: string, used: Set<string>): string {
   }
 }
 
-/** Drop every file stored for a scope (the whole `.attachments/<scopeId>` dir). */
-export async function deleteAttachments(
-  vfs: Vfs,
-  root: string,
-  scopeId: string,
-): Promise<void> {
-  safeSegment(scopeId, "scopeId");
-  await vfs.deletePrefix(dirKey(root, scopeId));
-}
-
 /** Parse + validate the upload body. Throws AttachmentError (→ 4xx) on any malformed input. */
-function parseUploadBody(body: Record<string, unknown>): {
-  scopeId: string;
-  files: UploadFile[];
-} {
-  const scopeId = body.scopeId;
-  if (typeof scopeId !== "string" || scopeId === "") {
-    throw new AttachmentError(400, "missing 'scopeId'");
-  }
+function parseUploadBody(body: Record<string, unknown>): UploadFile[] {
+  // `scopeId` (legacy per-conversation storage key) is deliberately not read.
   if (!Array.isArray(body.files)) {
     throw new AttachmentError(400, "missing 'files' array");
   }
   let total = 0;
-  const files: UploadFile[] = body.files.map((raw, i) => {
+  return body.files.map((raw, i) => {
     const f = raw as { name?: unknown; contentBase64?: unknown };
     if (typeof f.name !== "string" || typeof f.contentBase64 !== "string") {
       throw new AttachmentError(
@@ -167,7 +150,6 @@ function parseUploadBody(body: Record<string, unknown>): {
     }
     return { name: f.name, contentBase64: f.contentBase64 };
   });
-  return { scopeId, files };
 }
 
 /**
@@ -175,8 +157,16 @@ function parseUploadBody(body: Record<string, unknown>): {
  * runtime channel (the runtime has no /attachments route). Returns true when it
  * owns the request. A missing vfs 503s; malformed input 4xxs. Nothing swallowed.
  *
- *   POST   attachments  { scopeId, files: [{ name, contentBase64 }] } → { paths }
- *   DELETE attachments?scopeId=<id>                                   → { ok }
+ *   POST attachments  { files: [{ name, contentBase64 }] } → { paths }
+ *
+ * DELETE (the legacy per-scope wipe) is gone: uploads are permanent workspace
+ * files the user manages through the Files tab. Old clients still fire a
+ * best-effort DELETE when a chat is cleared; they get the 405 below and ignore
+ * it — and, crucially, nothing they do can remove a stored upload.
+ *
+ * Every upload fires `FilesChanged` through `emit`: the files now land in a
+ * visible folder, so Files tabs (this client's and everyone else's) must
+ * refresh without a manual reload.
  */
 export async function handleAttachments(
   vfs: Vfs | undefined,
@@ -186,7 +176,7 @@ export async function handleAttachments(
   rest: string,
   req: IncomingMessage,
   res: ServerResponse,
-  query: URLSearchParams,
+  emit?: (event: HoustonEvent) => void,
 ): Promise<boolean> {
   if (rest !== "attachments") return false;
   if (!vfs) {
@@ -196,19 +186,11 @@ export async function handleAttachments(
   const root = paths.agentRoot(ctx.workspace, ctx.agent);
   try {
     if (method === "POST") {
-      const { scopeId, files } = parseUploadBody(await readJson(req));
-      const saved = await saveAttachments(vfs, root, scopeId, files);
+      const files = parseUploadBody(await readJson(req));
+      const saved = await saveAttachments(vfs, root, files);
+      if (saved.length > 0)
+        emit?.({ type: "FilesChanged", agentPath: ctx.agent.id });
       json(res, 200, { paths: saved });
-      return true;
-    }
-    if (method === "DELETE") {
-      const scopeId = query.get("scopeId") ?? "";
-      if (!scopeId) {
-        json(res, 400, { error: "missing 'scopeId'" });
-        return true;
-      }
-      await deleteAttachments(vfs, root, scopeId);
-      json(res, 200, { ok: true });
       return true;
     }
     json(res, 405, { error: "method not allowed" });

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -654,10 +654,11 @@ export class HoustonClient {
   async migrateAgentFiles(): Promise<void> {}
 
   // ---- composer attachments ----
-  // Cloud: upload the dropped files into the selected agent's workspace via the
-  // host's /agents/:id/attachments route; the runtime's clamped file tools then
-  // Read them at the relative paths returned here (the sender encodes those paths
-  // into the message). Standalone web has no workspace to write into — fail loud.
+  // Upload the dropped files into the selected agent's workspace (its durable
+  // `uploads/` folder) via the host's /agents/:id/attachments route; the
+  // runtime's clamped file tools then Read them at the relative paths returned
+  // here (the sender encodes those paths into the message), in this turn or any
+  // later conversation. Standalone web has no workspace to write into — fail loud.
   async saveAttachments(scopeId: string, files: File[]): Promise<string[]> {
     if (files.length === 0) return [];
     if (!this.cp) throw new Error("Attachments need a cloud workspace.");
@@ -666,14 +667,6 @@ export class HoustonClient {
       this.requireAgentId(),
       scopeId,
       files,
-    );
-  }
-  async deleteAttachments(scopeId: string): Promise<void> {
-    if (!this.cp) throw new Error("Attachments need a cloud workspace.");
-    return controlPlane.deleteAttachments(
-      this.cp,
-      this.requireAgentId(),
-      scopeId,
     );
   }
 

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -820,12 +820,17 @@ export async function writeAgentFile(
 }
 
 /**
- * Composer attachments. Upload the dropped files INTO the agent's workspace so
- * the runtime's clamped file tools can Read them during the turn, and return the
- * RELATIVE workspace paths the host stored them at — which the sender encodes
- * verbatim into the message ("Read these attached files: …"). Binary rides as
- * base64 JSON (the host writes the bytes through its Vfs); the agent resolves
- * each path against its workspace root.
+ * Composer attachments. Upload the dropped files INTO the agent's workspace —
+ * its durable, Files-tab-visible `uploads/` folder — so the runtime's clamped
+ * file tools can Read them during this turn and any later conversation
+ * (HOU-706), and return the RELATIVE workspace paths the host stored them at —
+ * which the sender encodes verbatim into the message ("Read these attached
+ * files: …"). Binary rides as base64 JSON (the host writes the bytes through
+ * its Vfs); the agent resolves each path against its workspace root.
+ *
+ * `scopeId` is legacy: current hosts ignore it, but engine pods that predate
+ * the durable-uploads layout still 400 without it — keep sending it until no
+ * pre-HOU-706 pod remains.
  */
 export async function saveAttachments(
   cfg: ControlPlaneConfig,
@@ -854,20 +859,6 @@ export async function saveAttachments(
     paths.push(...((await res.json()) as { paths: string[] }).paths);
   }
   return paths;
-}
-
-export async function deleteAttachments(
-  cfg: ControlPlaneConfig,
-  agentId: string,
-  scopeId: string,
-): Promise<void> {
-  await cpFetch(
-    cfg,
-    `${agentPath(agentId)}/attachments?scopeId=${encodeURIComponent(scopeId)}`,
-    {
-      method: "DELETE",
-    },
-  );
 }
 
 /** Base64-encode bytes without blowing the call stack on large files (chunked btoa). */


### PR DESCRIPTION
## Summary

Fixes HOU-706: a file uploaded in chat effectively vanished — it was written to a hidden `.attachments/<scopeId>/` dot-dir (invisible in the Files tab) and the frontend wiped that dir whenever the conversation or the agent chat scope was deleted. So the user could never see the file, and the agent could never find it again from a later conversation.

### Root cause

The upload transport itself works end-to-end (verified live: web adapter → cloud gateway → pod host → pod volume). The problem was the storage model:

- Files landed in a top-level dot-dir the Files tab deliberately hides, so nothing visible ever appeared.
- Every chat-clear / activity-delete / agent-delete call site fired a best-effort `DELETE /attachments?scopeId=…`, wiping the uploads.
- Only the original message's prompt text knew the path, so later conversations had no way to reference the file.

### The fix

**Host (`packages/host/src/turn/attachments.ts`)**
- Uploads now land at `<workspace>/uploads/<name>` — a normal, visible folder on the pod volume (cloud) / agent folder (desktop) that the agent's clamped Read tool and the Files tab both see.
- Filenames dedupe against the folder's existing contents (`report.pdf`, `report (1).pdf`), so a later chat's upload never clobbers an earlier one.
- Each upload emits `FilesChanged` so every client's Files tab refreshes live (AI-native reactivity rule).
- The per-scope `DELETE` route is removed (405): uploads are permanent workspace files the user manages via the Files tab. Old clients' best-effort DELETE is already `.catch(() => {})`-swallowed, and can no longer destroy uploads.
- The legacy `scopeId` body field is accepted and ignored; clients keep sending it so not-yet-updated cloud pods (which 400 without it) keep working during rollout.
- Files already stored under `.attachments/` stay readable at their old paths (old chat history references them); new uploads never land there. No migration needed.

**App/web**
- Removed every delete-attachments-on-clear call site (`use-activity`, `use-mission-control`, `use-mission-control-archived`, `use-cross-agent-selection`, `stores/agents`) and the dead client plumbing (`tauriAttachments.delete`, adapter + control-plane `deleteAttachments`).

## Repro (before the fix)

1. In Houston (cloud or desktop), open an agent chat, attach any file, send.
2. Open the Files tab → the file is nowhere to be seen (it's in the hidden `.attachments/` dir).
3. Delete that conversation, start a new chat, and ask the agent to read the file → it's gone (the scope dir was wiped on delete).

## Verification (after the fix)

Automated: `pnpm --filter @houston/host test` (attachments suite rewritten: durable paths, cross-save dedupe, Files-tab visibility, FilesChanged emission, legacy DELETE refused, scopeId ignored), `pnpm typecheck`, `pnpm check`, `pnpm check:boundaries` — all green.

Driven live against a locally booted host:
1. `POST /agents/:id/attachments` (with and without legacy `scopeId`) → `{"paths":["uploads/plan.md"]}`, bytes on disk at `workspaces/<ws>/<agent>/uploads/plan.md`.
2. Same filename uploaded again (a "new chat") → `uploads/plan (1).md`, first file intact.
3. `GET /agents/:id/files` lists `uploads/plan.md` + `uploads/plan (1).md` (visible in the Files tab).
4. Legacy `DELETE …/attachments?scopeId=…` → 405, uploads untouched.
5. `/v1/events` stream received `FilesChanged` for each upload.

To verify in the product: attach a file in a chat, open the Files tab (an `uploads` folder appears immediately with the file), delete the conversation, start a new chat and ask the agent to read `uploads/<name>` → it can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)