### PR TITLE
fix(onboarding): first-run agent create feels instant — don't block the click on pod warm-up

### DIFF
--- a/app/src/components/onboarding/first-run-provision.ts
+++ b/app/src/components/onboarding/first-run-provision.ts
@@ -1,0 +1,30 @@
+/**
+ * First-run agent creation must return as soon as the agent RECORD exists and
+ * refresh the stores in the BACKGROUND — it must never block on that refresh.
+ *
+ * Right after `POST /agents` the app already holds the agent record, which is
+ * all the next onboarding step (connect your email) needs. The store refresh,
+ * by contrast, reads providers/agents through the NEW agent's runtime — a pod
+ * still cold-starting on the hosted profile (HOU-649). Awaiting it stalled the
+ * "create" click ~20s while the pod warmed. Surfacing the agent first lets
+ * onboarding advance immediately; the pod finishes warming while the user
+ * connects their inbox, so their first message lands on an already-ready pod.
+ *
+ * Pure + dependency-injected so the "don't block on the refresh" contract is
+ * unit-tested without the React / store / tauri graph.
+ */
+export async function surfaceAgentThenRefresh<A>(
+  create: () => Promise<A>,
+  surface: (agent: A) => void,
+  refresh: (agent: A) => Promise<void>,
+  onRefreshError: (err: unknown) => void,
+): Promise<A> {
+  const agent = await create();
+  // Release the UI on the record alone — the caller may now advance the flow.
+  surface(agent);
+  // Fire-and-forget: refresh() dispatches reads to the agent's cold pod, so
+  // awaiting here would reintroduce the ~20s stall this function exists to
+  // remove. A failure is logged; the stores self-heal on their next load.
+  void refresh(agent).catch(onRefreshError);
+  return agent;
+}

--- a/app/src/components/onboarding/use-create-assistant.ts
+++ b/app/src/components/onboarding/use-create-assistant.ts
@@ -1,16 +1,46 @@
 import { useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { analytics } from "../../lib/analytics";
+import { logger } from "../../lib/logger";
 import { tauriAgents, tauriProvider, tauriWorkspaces } from "../../lib/tauri";
-import type { Agent } from "../../lib/types";
+import type { Agent, Workspace } from "../../lib/types";
 import { useAgentStore } from "../../stores/agents";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { createPersonalAssistantForWorkspace } from "./create-personal-assistant";
-import { ensureWorkspaceWithAssistant } from "./ensure-default-assistant";
+import {
+  type EnsuredWorkspace,
+  ensureWorkspaceWithAssistant,
+} from "./ensure-default-assistant";
+import { surfaceAgentThenRefresh } from "./first-run-provision";
 import {
   buildAssistantInstructions,
   defaultAssistantSetup,
 } from "./personal-assistant-artifacts";
+
+/**
+ * Post-create bookkeeping: persist the last-used pick and reload the stores.
+ * Runs in the BACKGROUND — `loadWorkspaces()` reads providers through the
+ * freshly-created (cold) agent pod, so awaiting it would stall the create click
+ * ~20s (HOU-649). The `create` store action already made the new agent current
+ * and listed, so the shell is correct without this; it only refreshes.
+ */
+async function refreshAfterCreate(
+  ensured: EnsuredWorkspace<Workspace, Agent>,
+  provider: string,
+  model: string,
+): Promise<void> {
+  await tauriProvider.setLastUsed(provider, model);
+  if (ensured.createdWorkspace) {
+    analytics.track("workspace_created", { provider, source: "onboarding" });
+  }
+  await useWorkspaceStore.getState().loadWorkspaces();
+  useWorkspaceStore.getState().setCurrent(ensured.workspace);
+  await useAgentStore.getState().loadAgents(ensured.workspace.id);
+  const refreshed = useAgentStore
+    .getState()
+    .agents.find((a) => a.id === ensured.assistant.id);
+  if (refreshed) useAgentStore.getState().setCurrent(refreshed);
+}
 
 interface UseCreateAssistantArgs {
   assistantName: string;
@@ -48,51 +78,40 @@ export function useCreateAssistant({
   ): Promise<Agent> => {
     if (creationRef.current) return creationRef.current;
 
-    const op = (async (): Promise<Agent> => {
-      const setup = defaultAssistantSetup({
-        workspaceName: t("tutorial.defaults.workspaceName"),
-        assistantName:
-          assistantName.trim() || t("tutorial.defaults.assistantName"),
-        focus: t("tutorial.defaults.focus"),
-        approvalRule: t("tutorial.defaults.approvalRule"),
-      });
-      setup.color = assistantColor;
-
-      const {
-        workspace: ws,
-        assistant: created,
-        createdWorkspace,
-      } = await ensureWorkspaceWithAssistant(setup.workspaceName, {
-        listWorkspaces: () => tauriWorkspaces.list(),
-        createWorkspace: (name) => tauriWorkspaces.create(name),
-        listAgents: (workspaceId) => tauriAgents.list(workspaceId),
-        createAssistant: (workspaceId) =>
-          createPersonalAssistantForWorkspace(workspaceId, {
-            name: setup.assistantName.trim(),
-            instructions: buildAssistantInstructions(setup, missionTitle),
-            color: setup.color,
-            provider: pickedProvider,
-            model: pickedModel,
-          }),
-      });
-
-      await tauriProvider.setLastUsed(pickedProvider, pickedModel);
-      if (createdWorkspace) {
-        analytics.track("workspace_created", {
-          provider: pickedProvider,
-          source: "onboarding",
+    const op = surfaceAgentThenRefresh<EnsuredWorkspace<Workspace, Agent>>(
+      // Create the workspace + assistant; resolves once the agent RECORD exists
+      // (POST /agents), which is all the next (email) step needs.
+      () => {
+        const setup = defaultAssistantSetup({
+          workspaceName: t("tutorial.defaults.workspaceName"),
+          assistantName:
+            assistantName.trim() || t("tutorial.defaults.assistantName"),
+          focus: t("tutorial.defaults.focus"),
+          approvalRule: t("tutorial.defaults.approvalRule"),
         });
-      }
-      await useWorkspaceStore.getState().loadWorkspaces();
-      useWorkspaceStore.getState().setCurrent(ws);
-      await useAgentStore.getState().loadAgents(ws.id);
-      const refreshed =
-        useAgentStore.getState().agents.find((a) => a.id === created.id) ??
-        created;
-      useAgentStore.getState().setCurrent(refreshed);
-      setAgent(refreshed);
-      return refreshed;
-    })();
+        setup.color = assistantColor;
+        return ensureWorkspaceWithAssistant(setup.workspaceName, {
+          listWorkspaces: () => tauriWorkspaces.list(),
+          createWorkspace: (name) => tauriWorkspaces.create(name),
+          listAgents: (workspaceId) => tauriAgents.list(workspaceId),
+          createAssistant: (workspaceId) =>
+            createPersonalAssistantForWorkspace(workspaceId, {
+              name: setup.assistantName.trim(),
+              instructions: buildAssistantInstructions(setup, missionTitle),
+              color: setup.color,
+              provider: pickedProvider,
+              model: pickedModel,
+            }),
+        });
+      },
+      // Surface the agent the instant its record lands so onboarding advances to
+      // the email step immediately; the refresh below must not gate this.
+      (ensured) => setAgent(ensured.assistant),
+      // Background: the pod-dependent refresh that used to stall the click.
+      (ensured) => refreshAfterCreate(ensured, pickedProvider, pickedModel),
+      (err) =>
+        logger.error(`[onboarding] post-create store refresh failed: ${err}`),
+    ).then((ensured) => ensured.assistant);
 
     creationRef.current = op;
     op.catch(() => {

--- a/app/tests/first-run-provision.test.ts
+++ b/app/tests/first-run-provision.test.ts
@@ -1,0 +1,87 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { surfaceAgentThenRefresh } from "../src/components/onboarding/first-run-provision.ts";
+
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+describe("surfaceAgentThenRefresh", () => {
+  it("resolves and surfaces the agent WITHOUT waiting on the background refresh", async () => {
+    const events: string[] = [];
+    let releaseRefresh: () => void = () => {};
+    const refreshDone = new Promise<void>((r) => {
+      releaseRefresh = r;
+    });
+    let surfaced: { id: string } | null = null;
+
+    const agent = await surfaceAgentThenRefresh<{ id: string }>(
+      async () => {
+        events.push("created");
+        return { id: "a1" };
+      },
+      (a) => {
+        surfaced = a;
+        events.push("surfaced");
+      },
+      async () => {
+        events.push("refresh-start");
+        await refreshDone;
+        events.push("refresh-done");
+      },
+      () => events.push("refresh-error"),
+    );
+
+    // The call returned before the refresh settled — the pod cold-start (modeled
+    // by the still-pending refreshDone) never gated it.
+    deepStrictEqual(events, ["created", "surfaced", "refresh-start"]);
+    strictEqual(agent.id, "a1");
+    strictEqual(surfaced?.id, "a1");
+
+    // The refresh still finishes in the background afterwards.
+    releaseRefresh();
+    await refreshDone;
+    await tick();
+    strictEqual(events.includes("refresh-done"), true);
+  });
+
+  it("surfaces the agent even when the background refresh rejects, routing the error out", async () => {
+    const errors: unknown[] = [];
+    let surfaced = false;
+
+    const agent = await surfaceAgentThenRefresh<{ id: string }>(
+      async () => ({ id: "b2" }),
+      () => {
+        surfaced = true;
+      },
+      async () => {
+        throw new Error("cold pod");
+      },
+      (e) => errors.push(e),
+    );
+
+    strictEqual(agent.id, "b2");
+    strictEqual(surfaced, true);
+    // The rejected background refresh must not surface as an unhandled rejection;
+    // it lands on onRefreshError instead.
+    await tick();
+    strictEqual(errors.length, 1);
+    strictEqual((errors[0] as Error).message, "cold pod");
+  });
+
+  it("propagates a create() failure and never surfaces or refreshes", async () => {
+    const events: string[] = [];
+    try {
+      await surfaceAgentThenRefresh<{ id: string }>(
+        async () => {
+          throw new Error("create failed");
+        },
+        () => events.push("surfaced"),
+        async () => events.push("refresh"),
+        () => events.push("refresh-error"),
+      );
+      events.push("resolved");
+    } catch (e) {
+      events.push(`threw:${(e as Error).message}`);
+    }
+    deepStrictEqual(events, ["threw:create failed"]);
+  });
+});


### PR DESCRIPTION
## Problem

On the hosted profile, clicking **"create your first agent"** during onboarding stalls ~20s before advancing.

## Root cause (not where it looks)

The gateway's `POST /agents` already returns fast — apiserver time, with the pod cold-start backgrounded (HOU-649). The wall is **client-side**: after `createAssistant`, `useCreateAssistant` `await`ed `loadWorkspaces()`. The synthetic workspace carries a provider/model label resolved via `activeOld()` → `providerEngine().listProviders()`, which — now that `last_agent_id` points at the **just-created agent** — dispatches to that agent's **cold pod** and blocks until it's ready. Because it was awaited *before* `setAgent`, it gated both the create promise (the Meet spinner) and the email step's `agent &&` render.

## Fix

Surface the agent the instant its record exists; run the pod-dependent store refresh in the **background** (`surfaceAgentThenRefresh`). Onboarding advances to *"connect your email"* immediately, and the pod finishes warming while the user does the OAuth dance — so their first message lands on an already-ready pod. Exactly the create-then-overlap-with-email flow we wanted.

Safe because:
- The `create` store action already makes the new agent current + listed, so the shell is correct without the refresh; `refreshAfterCreate` only reloads.
- Its transient workspace `loading: true` can't pop the boot splash: `App.tsx` renders the tutorial on `tutorialActive` **before** the loading gate (a deliberate guard against exactly this — the agent-create flow unmounting the orchestrator).
- The pre-create calls hit the **warm setup pod** + fast gateway routes; the only cold-pod dispatch left is the backgrounded one.

## Tests

`app/tests/first-run-provision.test.ts`: the create resolves and surfaces the agent **without** awaiting the refresh (the cold-pod stall can't gate it), a refresh rejection routes to the error sink (no unhandled rejection), and a `create()` failure propagates without surfacing/refreshing. Full app suite **736 pass**; tsgo + biome clean (full workspace typecheck green in pre-commit).

Depends on the hosted `/setup-runtime` pod (gethouston/cloud#51, merged) being deployed — the setup pod warms the node/image so the real agent pod comes up in ~20s, which this change moves off the critical path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)