### PR TITLE
fix(portable): import reveals the agent optimistically, same as create (HOU-710)

### DIFF
--- a/app/src/components/portable/import-wizard.tsx
+++ b/app/src/components/portable/import-wizard.tsx
@@ -36,10 +36,12 @@ import { invoke } from "@tauri-apps/api/core";
 import { Check } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
+import { finishAgentSetup } from "../../lib/agent-setup";
 import { analytics } from "../../lib/analytics";
 import { getEngine } from "../../lib/engine";
 import { getDefaultModel } from "../../lib/providers";
-import { tauriConfig, tauriProvider } from "../../lib/tauri";
+import { tauriProvider, toAgent } from "../../lib/tauri";
 import { useAgentStore } from "../../stores/agents";
 import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
@@ -59,7 +61,7 @@ export function ImportAgentWizard() {
   const setOpen = useUIStore((s) => s.setImportFromFriendOpen);
   const addToast = useUIStore((s) => s.addToast);
   const currentWorkspace = useWorkspaceStore((s) => s.current);
-  const loadAgents = useAgentStore((s) => s.loadAgents);
+  const adoptAgent = useAgentStore((s) => s.adopt);
 
   const [stepIndex, setStepIndex] = useState(0);
   const [uploaded, setUploaded] =
@@ -195,18 +197,18 @@ export function ImportAgentWizard() {
           includeLearningIds: Array.from(selection.learningIds),
         },
       });
-      // Always persist provider/model on the imported agent's config — same
-      // contract as the create-agent dialog. Workspace-level defaults are
-      // gone, so a blank field would resolve to the platform default.
-      const cfg = await tauriConfig.read(installed.agentPath);
-      await tauriConfig.write(installed.agentPath, {
-        ...cfg,
-        provider: provider as "anthropic" | "openai",
-        model,
-      });
+      // Keep the sticky last-used in sync (local, so it's cheap to await).
       await tauriProvider.setLastUsed(provider, model);
-      await loadAgents(currentWorkspace.id);
       analytics.track("agent_imported", { agent_slug: installed.agentName });
+      // Reveal the agent NOW — the same optimistic contract as the
+      // create-agent dialog (HOU-710). `adopt` marks the agent provisioning
+      // (HOU-693): the sidebar shows it, chat parks sends behind the "being
+      // created" card, and a readiness probe clears the mark. The provider/
+      // model write dispatches to the agent's engine — on the hosted profile
+      // a pod still cold-starting — so awaiting it here would freeze the
+      // dialog for the whole warm-up; it finishes in the background and
+      // surfaces its own error toast on failure.
+      adoptAgent(toAgent(installed.agent));
       addToast({
         variant: "success",
         title: t("import.toasts.installedTitle"),
@@ -214,8 +216,14 @@ export function ImportAgentWizard() {
           name: installed.agentName,
         }),
       });
+      useUIStore.getState().setViewMode(DEFAULT_TAB_ID);
       setOpen(false);
       reset();
+      void finishAgentSetup(installed.agentPath, {
+        provider,
+        model,
+        routine: null,
+      });
     } catch (err) {
       addToast({
         variant: "error",

--- a/app/src/components/shell/create-workspace-dialog.tsx
+++ b/app/src/components/shell/create-workspace-dialog.tsx
@@ -12,9 +12,9 @@ import { STORE_TEMPLATE_IDS } from "../../agents/builtin/store-catalog";
 import { loadStoreTemplate } from "../../agents/builtin/store-template-loader";
 import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
 import { useCreateFromTemplate } from "../../hooks/use-create-from-template";
-import { logger } from "../../lib/logger";
+import { finishAgentSetup } from "../../lib/agent-setup";
 import { getDefaultModel } from "../../lib/providers";
-import { tauriConfig, tauriProvider, tauriRoutines } from "../../lib/tauri";
+import { tauriProvider } from "../../lib/tauri";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
 import { useAgentStore } from "../../stores/agents";
 import { useUIStore } from "../../stores/ui";
@@ -302,66 +302,4 @@ export function CreateAgentDialog() {
       </DialogContent>
     </Dialog>
   );
-}
-
-/**
- * The pod-bound tail of agent creation, run after the dialog has already
- * revealed the agent (HOU-649): persist the picked provider/model and, if the
- * user accepted one, its starter routine. Both dispatch to the agent's engine,
- * so on the hosted profile they wait out the pod's cold start — off the create
- * click. Each step surfaces its own error toast via the tauri wrappers; we only
- * add a breadcrumb so a background failure is traceable.
- */
-async function finishAgentSetup(
-  agentPath: string,
-  opts: { provider: string; model: string; routine: RoutineFormData | null },
-): Promise<void> {
-  try {
-    // Always write provider/model to the agent's own config. With workspace
-    // defaults retired, the agent is the single source of truth — leaving the
-    // field blank would make the engine resolver fall back to its platform
-    // default rather than the user's pick.
-    const cfg = await tauriConfig.read(agentPath);
-    await tauriConfig.write(
-      agentPath,
-      {
-        ...cfg,
-        provider: opts.provider as "anthropic" | "openai",
-        model: opts.model,
-      },
-      // Post-create setup rides as a held request that lands when the engine
-      // wakes (HOU-649) — never blocked by the warming-write dialog.
-      { allowWhileWarming: true },
-    );
-  } catch (e) {
-    logger.error(`[new-agent] provider/model write failed: ${e}`);
-  }
-
-  if (opts.routine) {
-    // The agent is brand new, so its scheduler was never started (create()
-    // doesn't go through setCurrent, and use-houston-init only starts
-    // schedulers that existed at launch). startScheduler is idempotent and
-    // picks up the just-written routine; plain syncScheduler would be a no-op
-    // for an unstarted agent.
-    try {
-      await tauriRoutines.create(
-        agentPath,
-        {
-          name: opts.routine.name,
-          description: opts.routine.description,
-          prompt: opts.routine.prompt,
-          schedule: opts.routine.schedule,
-          enabled: true,
-          suppress_when_silent: opts.routine.suppress_when_silent,
-          chat_mode: opts.routine.chat_mode,
-        },
-        // Same held-request posture as the config write above.
-        { allowWhileWarming: true },
-      );
-      await tauriRoutines.startScheduler(agentPath);
-    } catch (e) {
-      // The tauri wrapper surfaced its own error toast; leave a breadcrumb.
-      logger.error(`[new-agent] routine setup failed: ${e}`);
-    }
-  }
 }

--- a/app/src/lib/agent-setup.ts
+++ b/app/src/lib/agent-setup.ts
@@ -1,0 +1,68 @@
+import type { RoutineFormData } from "@houston-ai/routines";
+import { logger } from "./logger";
+import { tauriConfig, tauriRoutines } from "./tauri";
+
+/**
+ * The pod-bound tail of agent creation, run after the dialog has already
+ * revealed the agent (HOU-649): persist the picked provider/model and, if the
+ * user accepted one, its starter routine. Both dispatch to the agent's engine,
+ * so on the hosted profile they wait out the pod's cold start — off the create
+ * click. Each step surfaces its own error toast via the tauri wrappers; we only
+ * add a breadcrumb so a background failure is traceable.
+ *
+ * Shared by the create-agent dialog and the import wizard (HOU-710) — both
+ * must reveal first and finish setup in the background.
+ */
+export async function finishAgentSetup(
+  agentPath: string,
+  opts: { provider: string; model: string; routine: RoutineFormData | null },
+): Promise<void> {
+  try {
+    // Always write provider/model to the agent's own config. With workspace
+    // defaults retired, the agent is the single source of truth — leaving the
+    // field blank would make the engine resolver fall back to its platform
+    // default rather than the user's pick.
+    const cfg = await tauriConfig.read(agentPath);
+    await tauriConfig.write(
+      agentPath,
+      {
+        ...cfg,
+        provider: opts.provider as "anthropic" | "openai",
+        model: opts.model,
+      },
+      // Post-create setup rides as a held request that lands when the engine
+      // wakes (HOU-649) — never blocked by the warming-write dialog.
+      { allowWhileWarming: true },
+    );
+  } catch (e) {
+    logger.error(`[new-agent] provider/model write failed: ${e}`);
+  }
+
+  if (opts.routine) {
+    // The agent is brand new, so its scheduler was never started (create()
+    // doesn't go through setCurrent, and use-houston-init only starts
+    // schedulers that existed at launch). startScheduler is idempotent and
+    // picks up the just-written routine; plain syncScheduler would be a no-op
+    // for an unstarted agent.
+    try {
+      await tauriRoutines.create(
+        agentPath,
+        {
+          name: opts.routine.name,
+          description: opts.routine.description,
+          prompt: opts.routine.prompt,
+          schedule: opts.routine.schedule,
+          enabled: true,
+          suppress_when_silent: opts.routine.suppress_when_silent,
+          chat_mode: opts.routine.chat_mode,
+        },
+        // Same held-request posture as the config write above.
+        { allowWhileWarming: true },
+      );
+      await tauriRoutines.startScheduler(agentPath);
+    } catch (e) {
+      // The tauri wrapper surfaced its own error toast; leave a breadcrumb.
+      logger.error(`[new-agent] routine setup failed: ${e}`);
+    }
+  }
+}

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -187,7 +187,9 @@ export interface CreateAgentResult {
   agent: Agent;
 }
 
-function toAgent(a: import("@houston-ai/engine-client").Agent): Agent {
+/** Engine wire agent → app Agent. Exported for flows that receive an agent
+ *  record outside the tauriAgents wrappers (the import wizard, HOU-710). */
+export function toAgent(a: import("@houston-ai/engine-client").Agent): Agent {
   return {
     id: a.id,
     name: a.name,

--- a/app/src/stores/agents.ts
+++ b/app/src/stores/agents.ts
@@ -44,6 +44,13 @@ interface AgentState {
     options?: { silent?: boolean },
   ) => Promise<void>;
   setCurrent: (agent: Agent) => void;
+  /**
+   * Reveal a freshly created agent: mark it provisioning (HOU-693), append it
+   * to the sidebar optimistically, and select it. The tail of `create`, also
+   * used by flows that create through another pipeline (agent import,
+   * HOU-710) so every creation gets the same optimistic contract.
+   */
+  adopt: (agent: Agent) => void;
   create: (
     workspaceId: string,
     name: string,
@@ -95,6 +102,18 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     startAgentSideEffects(agent);
   },
 
+  adopt: (agent) => {
+    // Hosted profile: the create answered but the agent's engine is still
+    // warming up (HOU-693). Track it so every surface can say so instead of
+    // hanging mutely; a readiness probe clears the mark. No-op co-located.
+    useAgentProvisioningStore.getState().markProvisioning(agent);
+    set((s) => ({
+      agents: [...s.agents, agent],
+      current: agent,
+    }));
+    startAgentSideEffects(agent);
+  },
+
   create: async (
     workspaceId: string,
     name: string,
@@ -119,15 +138,7 @@ export const useAgentStore = create<AgentState>((set, get) => ({
     );
     analytics.track("agent_created", { config_id: configId });
     const { agent } = result;
-    // Hosted profile: the create answered but the agent's engine is still
-    // warming up (HOU-693). Track it so every surface can say so instead of
-    // hanging mutely; a readiness probe clears the mark. No-op co-located.
-    useAgentProvisioningStore.getState().markProvisioning(agent);
-    set((s) => ({
-      agents: [...s.agents, agent],
-      current: agent,
-    }));
-    startAgentSideEffects(agent);
+    get().adopt(agent);
     return { agent };
   },
 

--- a/packages/web/src/engine-adapter/portable.ts
+++ b/packages/web/src/engine-adapter/portable.ts
@@ -168,5 +168,6 @@ export async function install(
     agentName: agent.name,
     workspaceName: req.workspaceName,
     requiredIntegrations: [],
+    agent,
   };
 }

--- a/packages/web/tests/portable-install.test.ts
+++ b/packages/web/tests/portable-install.test.ts
@@ -116,6 +116,13 @@ test("install creates the agent with the package as its seed payload", async () 
     agentName: "Sales",
     workspaceName: "Houston",
     requiredIntegrations: [],
+    // The created record rides along so the wizard can adopt it into the
+    // agent store optimistically — same reveal contract as create (HOU-710).
+    agent: expect.objectContaining({
+      id: "abcd1234abcd1234",
+      folderPath: "abcd1234abcd1234",
+      name: "Sales",
+    }),
   });
 });
 

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1204,6 +1204,10 @@ export interface PortableInstalledAgent {
   agentName: string;
   workspaceName: string;
   requiredIntegrations: string[];
+  /** The created agent record, so the wizard can reveal it optimistically
+   *  (same contract as agent create) instead of re-listing behind a warming
+   *  pod (HOU-710). */
+  agent: Agent;
 }
 
 // ── integrations (Composio, platform mode) ───────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes HOU-710.

**Root cause:** the import wizard's Install button awaited the *entire* tail of the install before closing: the create-with-seeds call, then a provider/model config read + write — which dispatch to the imported agent's engine, on the hosted profile a pod still cold-starting — then a full agent re-list. The dialog (and its disabled button) froze for the whole pod warm-up, while event invalidation had already surfaced the new agent in the sidebar behind it. The flow also never registered the agent with the provisioning store, so none of the "Your agent is being created…" affordances from normal creation applied.

**Fix:** import now follows the exact optimistic contract of the create-agent dialog (HOU-693/HOU-649):

- `PortableInstalledAgent` now carries the created agent record, which the engine adapter's `install` already had in hand and was discarding.
- The optimistic tail of `useAgentStore.create` (provisioning mark → optimistic sidebar append → select) is extracted into a new `adopt(agent)` action; `create` and the import wizard both use it. The imported agent gets the readiness probe, the in-chat "being created" card, and parked sends while its pod warms — for free.
- `finishAgentSetup` (the pod-bound provider/model write, with `allowWhileWarming`) is extracted from the create dialog into `lib/agent-setup.ts` and shared; the wizard now closes immediately and runs it in the background, surfacing its own error toast on failure.
- After install the app switches to the default chat tab with the new agent selected, same as create.

## Before (reproduce the bug)

1. On a cloud-hosted account, export any agent (`Share with a friend`) to get a `.houstonagent` file.
2. Open `Import from a friend`, pick the file, walk to the last step, click **Install**.
3. Observe: the button sticks in "Installing…" for many seconds (the pod warm-up), the agent meanwhile appears in the sidebar behind the still-open dialog, and the dialog only closes well after that.

## After (verify the fix)

1. Same steps: import a `.houstonagent` and click **Install**.
2. The dialog closes as soon as the create answers (~1–2s); the agent appears in the sidebar selected, on the chat tab.
3. Send a message right away while the pod warms: the "Your agent is being created…" card shows and the message is parked, then delivered once the engine answers — identical to normal agent creation.
4. When the pod is up, confirm the picked provider/model stuck (Agent Settings) — the write completed in the background.
5. Unit coverage: `pnpm --filter houston-web test` (portable-install contract), `cd app && pnpm test`, full `pnpm typecheck` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)