### PR TITLE
fix(runtime): bound compaction's summarizer input so over-window chats unwedge (HOU-709)

### DIFF
--- a/packages/runtime/src/session/compaction-guard.test.ts
+++ b/packages/runtime/src/session/compaction-guard.test.ts
@@ -1,0 +1,204 @@
+import {
+  type CompactionResult,
+  DEFAULT_COMPACTION_SETTINGS,
+  type ExtensionAPI,
+  type ExtensionContext,
+  type SessionBeforeCompactEvent,
+} from "@earendil-works/pi-coding-agent";
+import { describe, expect, it, vi } from "vitest";
+import {
+  boundMessages,
+  droppedNotice,
+  makeCompactionGuard,
+  SUMMARIZER_INPUT_FRACTION,
+  summarizerInputBudget,
+} from "./compaction-guard";
+
+type Msg =
+  SessionBeforeCompactEvent["preparation"]["messagesToSummarize"][number];
+type Handler = (
+  event: SessionBeforeCompactEvent,
+  ctx: ExtensionContext,
+) => Promise<{ compaction?: CompactionResult } | undefined>;
+
+/** A user message estimating to exactly `tokens` (pi's chars/4 heuristic). */
+const msg = (tokens: number): Msg =>
+  ({
+    role: "user",
+    content: "x".repeat(tokens * 4),
+    timestamp: 1,
+  }) as unknown as Msg;
+
+const okCompaction: CompactionResult = {
+  summary: "S",
+  firstKeptEntryId: "e1",
+  tokensBefore: 5000,
+};
+
+function loadHandler(compactFn: Parameters<typeof makeCompactionGuard>[0]) {
+  let handler: Handler | undefined;
+  const pi = {
+    on: (_name: string, h: unknown) => {
+      handler = h as Handler;
+    },
+  } as unknown as ExtensionAPI;
+  makeCompactionGuard(compactFn)(pi);
+  if (!handler) throw new Error("session_before_compact never registered");
+  return handler;
+}
+
+function makeCtx(opts: {
+  contextWindow?: number;
+  auth?: { ok: boolean; apiKey?: string };
+}) {
+  const getApiKeyAndHeaders = vi.fn(
+    async () => opts.auth ?? { ok: true, apiKey: "key", headers: {} },
+  );
+  const ctx = {
+    model:
+      opts.contextWindow === undefined
+        ? undefined
+        : { contextWindow: opts.contextWindow },
+    modelRegistry: { getApiKeyAndHeaders },
+  } as unknown as ExtensionContext;
+  return { ctx, getApiKeyAndHeaders };
+}
+
+function makeEvent(
+  messages: Msg[],
+  opts: { prefix?: Msg[]; previousSummary?: string } = {},
+): SessionBeforeCompactEvent {
+  return {
+    type: "session_before_compact",
+    preparation: {
+      firstKeptEntryId: "e1",
+      messagesToSummarize: messages,
+      turnPrefixMessages: opts.prefix ?? [],
+      isSplitTurn: false,
+      tokensBefore: 5000,
+      previousSummary: opts.previousSummary,
+      fileOps: { read: new Set(), written: new Set(), edited: new Set() },
+      settings: DEFAULT_COMPACTION_SETTINGS,
+    },
+    branchEntries: [],
+    reason: "threshold",
+    willRetry: false,
+    signal: new AbortController().signal,
+  } as unknown as SessionBeforeCompactEvent;
+}
+
+describe("boundMessages", () => {
+  it("keeps the newest messages that fit, in order", () => {
+    const messages = [msg(100), msg(100), msg(100), msg(100)];
+    const { kept, dropped } = boundMessages(messages, 250);
+    expect(kept).toEqual(messages.slice(2));
+    expect(dropped).toBe(2);
+  });
+
+  it("keeps everything under budget", () => {
+    const messages = [msg(100), msg(100)];
+    expect(boundMessages(messages, 250)).toEqual({
+      kept: messages,
+      dropped: 0,
+    });
+  });
+
+  it("keeps nothing when even the newest message overflows", () => {
+    expect(boundMessages([msg(300)], 250)).toEqual({ kept: [], dropped: 1 });
+  });
+});
+
+describe("summarizerInputBudget", () => {
+  it("is the guard fraction of the window", () => {
+    expect(summarizerInputBudget(272_000)).toBe(
+      Math.floor(272_000 * SUMMARIZER_INPUT_FRACTION),
+    );
+  });
+});
+
+describe("makeCompactionGuard", () => {
+  // Window 1000 → budget 700 (at the 0.7 fraction).
+  it("declines when the summarizer input fits (pi's default path runs)", async () => {
+    const compactFn = vi.fn(async () => okCompaction);
+    const handler = loadHandler(compactFn);
+    const { ctx } = makeCtx({ contextWindow: 1000 });
+    const result = await handler(makeEvent([msg(300), msg(300)]), ctx);
+    expect(result).toBeUndefined();
+    expect(compactFn).not.toHaveBeenCalled();
+  });
+
+  it("bounds an overflowing history and prefixes the drop notice", async () => {
+    const compactFn = vi.fn(async (..._args: unknown[]) => okCompaction);
+    const handler = loadHandler(compactFn);
+    const { ctx } = makeCtx({ contextWindow: 1000 });
+    const messages = [msg(300), msg(300), msg(300)]; // 900 > 700: drops oldest
+    const result = await handler(makeEvent(messages), ctx);
+    expect(compactFn).toHaveBeenCalledOnce();
+    const bounded = compactFn.mock.calls[0]?.[0] as unknown as {
+      messagesToSummarize: Msg[];
+    };
+    expect(bounded.messagesToSummarize).toEqual(messages.slice(1));
+    expect(result?.compaction?.summary).toBe(`${droppedNotice(1)}\n\nS`);
+    expect(result?.compaction?.firstKeptEntryId).toBe("e1");
+  });
+
+  it("compacts deterministically when not even the newest message fits", async () => {
+    const compactFn = vi.fn(async () => okCompaction);
+    const handler = loadHandler(compactFn);
+    const { ctx, getApiKeyAndHeaders } = makeCtx({ contextWindow: 1000 });
+    const result = await handler(
+      makeEvent([msg(800)], { previousSummary: "PREV" }),
+      ctx,
+    );
+    expect(compactFn).not.toHaveBeenCalled();
+    expect(getApiKeyAndHeaders).not.toHaveBeenCalled();
+    expect(result?.compaction?.summary).toBe(`PREV\n\n${droppedNotice(1)}`);
+    expect(result?.compaction?.firstKeptEntryId).toBe("e1");
+    expect(result?.compaction?.tokensBefore).toBe(5000);
+  });
+
+  it("declines when the bounded summarization itself fails (retried next turn)", async () => {
+    const compactFn = vi.fn(async () => {
+      throw new Error("rate limited");
+    });
+    const handler = loadHandler(compactFn);
+    const { ctx } = makeCtx({ contextWindow: 1000 });
+    const result = await handler(
+      makeEvent([msg(300), msg(300), msg(300)]),
+      ctx,
+    );
+    expect(result).toBeUndefined();
+  });
+
+  it("declines without a model, a sane window, or auth", async () => {
+    const compactFn = vi.fn(async () => okCompaction);
+    const handler = loadHandler(compactFn);
+    const over = [msg(300), msg(300), msg(300)];
+
+    const noModel = makeCtx({});
+    expect(await handler(makeEvent(over), noModel.ctx)).toBeUndefined();
+
+    const zeroWindow = makeCtx({ contextWindow: 0 });
+    expect(await handler(makeEvent(over), zeroWindow.ctx)).toBeUndefined();
+
+    const noAuth = makeCtx({ contextWindow: 1000, auth: { ok: false } });
+    expect(await handler(makeEvent(over), noAuth.ctx)).toBeUndefined();
+    expect(compactFn).not.toHaveBeenCalled();
+  });
+
+  it("bounds the turn-prefix request separately from the history request", async () => {
+    const compactFn = vi.fn(async (..._args: unknown[]) => okCompaction);
+    const handler = loadHandler(compactFn);
+    const { ctx } = makeCtx({ contextWindow: 1000 });
+    const prefix = [msg(300), msg(300), msg(300)]; // 900 > 700: drops oldest
+    const result = await handler(makeEvent([msg(300)], { prefix }), ctx);
+    expect(compactFn).toHaveBeenCalledOnce();
+    const bounded = compactFn.mock.calls[0]?.[0] as unknown as {
+      messagesToSummarize: Msg[];
+      turnPrefixMessages: Msg[];
+    };
+    expect(bounded.messagesToSummarize).toHaveLength(1);
+    expect(bounded.turnPrefixMessages).toEqual(prefix.slice(1));
+    expect(result?.compaction?.summary).toBe(`${droppedNotice(1)}\n\nS`);
+  });
+});

--- a/packages/runtime/src/session/compaction-guard.ts
+++ b/packages/runtime/src/session/compaction-guard.ts
@@ -1,0 +1,161 @@
+import {
+  type ExtensionFactory,
+  estimateTokens,
+  compact as piCompact,
+  type SessionBeforeCompactEvent,
+} from "@earendil-works/pi-coding-agent";
+
+/**
+ * COMPACTION OVERFLOW GUARD (HOU-709). pi's compaction summarizes the pre-cut
+ * history by serializing ALL of it into ONE summarization request against the
+ * active model — with no input bound. Once a conversation's history outgrows
+ * the model's real input window (long-running shared routine chats get there
+ * on schedule), that request is rejected (`context_length_exceeded`), the
+ * turn errors with "Summarization failed", and NOTHING ever shrinks the
+ * history — every later turn re-triggers the same doomed compaction forever.
+ *
+ * This pi extension bounds the summarizer's input: when the messages to
+ * summarize don't plausibly fit the model's window, it summarizes only the
+ * newest slice that fits and drops the rest (noting the drop in the summary),
+ * via pi's own `compact()` so file-op tracking, split-turn handling, and the
+ * previous-summary merge stay byte-identical to the default path. When the
+ * input fits — every healthy compaction — it declines, and pi's default path
+ * runs untouched.
+ */
+
+type Preparation = SessionBeforeCompactEvent["preparation"];
+type AgentMessage = Preparation["messagesToSummarize"][number];
+type CompactFn = typeof piCompact;
+
+/**
+ * Fraction of the model's context window the summarization request's input
+ * may use (as estimated by pi's chars/4 heuristic). The remainder absorbs the
+ * estimate's error, the summarizer's prompt scaffolding, and the reserved
+ * summary output — generous because a too-big request is a wedged
+ * conversation, while a too-small one only loses some old context to the
+ * drop notice.
+ */
+export const SUMMARIZER_INPUT_FRACTION = 0.7;
+
+/** The summarizer's input token budget for a model window (0 = unknown). */
+export function summarizerInputBudget(contextWindow: number): number {
+  return Math.floor(contextWindow * SUMMARIZER_INPUT_FRACTION);
+}
+
+/**
+ * Keep the NEWEST messages whose estimated tokens fit the budget — the same
+ * newest-first accumulation pi's branch summarization uses, so what survives
+ * is the context closest to the work in flight. Returns the kept slice in
+ * chronological order plus how many older messages fell off.
+ */
+export function boundMessages(
+  messages: AgentMessage[],
+  budget: number,
+): { kept: AgentMessage[]; dropped: number } {
+  const kept: AgentMessage[] = [];
+  let total = 0;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (!message) continue;
+    const cost = estimateTokens(message);
+    if (total + cost > budget) break;
+    total += cost;
+    kept.unshift(message);
+  }
+  return { kept, dropped: messages.length - kept.length };
+}
+
+/** The summary preamble recording what the bounded summarizer never saw. */
+export function droppedNotice(dropped: number): string {
+  return (
+    `[Note: the oldest ${dropped} message(s) of this conversation exceeded ` +
+    "the model's context window and were dropped without being summarized.]"
+  );
+}
+
+const errMessage = (err: unknown): string =>
+  err instanceof Error ? err.message : String(err);
+
+/**
+ * The `session_before_compact` extension. Injected into every agent loader
+ * (resource-loader.ts), so both the long-lived server and the per-request
+ * cloud runtime inherit it, on every compaction trigger (our proactive
+ * autocompact, pi's threshold, pi's overflow recovery, provider switches).
+ *
+ * Failure posture: a transient failure inside the bounded path (rate limit,
+ * network) declines back to pi's default — the turn fails visibly with the
+ * real reason and the NEXT turn re-enters this guard, so nothing is dropped
+ * on a blip. Only the truly unsummarizable (not even the newest message fits)
+ * compacts deterministically — previous summary + drop notice, no model call —
+ * because every alternative leaves the conversation wedged forever.
+ */
+export function makeCompactionGuard(
+  compactFn: CompactFn = piCompact,
+): ExtensionFactory {
+  return (pi) => {
+    pi.on("session_before_compact", async (event, ctx) => {
+      const model = ctx.model;
+      if (!model || model.contextWindow <= 0) return undefined;
+
+      const budget = summarizerInputBudget(model.contextWindow);
+      const prep = event.preparation;
+      // History and turn prefix are summarized in SEPARATE requests
+      // (pi runs them in parallel), so each gets the full budget.
+      const history = boundMessages(prep.messagesToSummarize, budget);
+      const prefix = boundMessages(prep.turnPrefixMessages, budget);
+      if (history.dropped === 0 && prefix.dropped === 0) return undefined;
+
+      const dropped = history.dropped + prefix.dropped;
+      if (history.kept.length === 0 && prefix.kept.length === 0) {
+        // Even the newest message alone overflows the budget: no
+        // summarization request can succeed, ever. Compact deterministically
+        // so the conversation survives with the recent (kept-live) messages.
+        const summary = [prep.previousSummary, droppedNotice(dropped)]
+          .filter(Boolean)
+          .join("\n\n");
+        return {
+          compaction: {
+            summary,
+            firstKeptEntryId: prep.firstKeptEntryId,
+            tokensBefore: prep.tokensBefore,
+          },
+        };
+      }
+
+      try {
+        // Same auth pi's own compaction resolves (model-registry).
+        const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+        if (!auth.ok || !auth.apiKey) return undefined;
+        const bounded: Preparation = {
+          ...prep,
+          messagesToSummarize: history.kept,
+          turnPrefixMessages: prefix.kept,
+        };
+        const result = await compactFn(
+          bounded,
+          model,
+          auth.apiKey,
+          auth.headers,
+          event.customInstructions,
+          event.signal,
+          undefined,
+          undefined,
+          auth.env,
+        );
+        return {
+          compaction: {
+            ...result,
+            summary: `${droppedNotice(dropped)}\n\n${result.summary}`,
+          },
+        };
+      } catch (err) {
+        // Decline; pi's default path surfaces the turn's real failure and the
+        // next compaction attempt re-enters this guard.
+        console.warn(
+          `[compaction-guard] bounded summarization failed; deferring to pi's default: ${errMessage(err)}`,
+        );
+        return undefined;
+      }
+    });
+  };
+}

--- a/packages/runtime/src/session/loader.test.ts
+++ b/packages/runtime/src/session/loader.test.ts
@@ -111,3 +111,16 @@ test("no skills dir, no context file: loader stays empty (nothing discovered fro
   expect(loader.getAgentsFiles().agentsFiles).toHaveLength(0);
   expect(loader.getSystemPrompt()).toBe("You are Houston.");
 });
+
+test("the compaction guard loads as an inline extension despite noExtensions (HOU-709)", async () => {
+  const { ws } = freshWorkspace();
+  const loader = loaderFor(ws);
+  await loader.reload();
+
+  const { extensions, errors } = loader.getExtensions();
+  expect(errors).toHaveLength(0);
+  // The guard is the ONE inline factory; it must survive noExtensions (which
+  // only gates on-disk discovery) and register the compaction handler.
+  expect(extensions).toHaveLength(1);
+  expect(extensions[0]?.handlers.has("session_before_compact")).toBe(true);
+});

--- a/packages/runtime/src/session/resource-loader.ts
+++ b/packages/runtime/src/session/resource-loader.ts
@@ -2,6 +2,7 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { DefaultResourceLoader } from "@earendil-works/pi-coding-agent";
 import { config } from "../config";
+import { makeCompactionGuard } from "./compaction-guard";
 
 export const SYSTEM_PROMPT = [
   "You are Houston, a friendly AI assistant for a non-technical user.",
@@ -51,6 +52,10 @@ export function buildAgentLoader(opts: {
     noPromptTemplates: true,
     noThemes: true,
     noContextFiles: true,
+    // Inline factories load even with noExtensions (that flag only gates
+    // on-disk discovery). The guard keeps compaction's summarization request
+    // within the model's window — see compaction-guard.ts (HOU-709).
+    extensionFactories: [makeCompactionGuard()],
     additionalSkillPaths: existsSync(opts.skillsDir) ? [opts.skillsDir] : [],
     agentsFilesOverride: () => ({
       agentsFiles: loadWorkspaceContextFile(opts.cwd),


### PR DESCRIPTION
## Root cause

pi's context compaction serializes the **entire** pre-cut conversation history into a single summarization request against the active model, with no input bound. Agent A2's "time" routine (every 5 minutes, "Keep results in one chat") grew its shared conversation past gpt-5.5's real input window (~272k tokens; the last successful turn reported 263,619 context tokens). From then on:

1. Each run's turn triggers autocompact (fill ≥ 93% of the window).
2. The compaction's own summarization request — the serialized full history — exceeds the window and Codex rejects it with `context_length_exceeded`.
3. The turn errors with `Summarization failed: Codex error: {...}`, nothing shrinks the history, and the next run repeats the identical failure. The conversation is wedged **forever** (~500 consecutive failed runs on A2).

## Fix

A `session_before_compact` pi extension (`packages/runtime/src/session/compaction-guard.ts`), registered as an inline factory on the agent loader so both the long-lived server and the per-request cloud runtime inherit it on every compaction trigger (proactive autocompact, pi's threshold, pi's overflow recovery, provider switches):

- When the summarizer's estimated input fits a budgeted fraction (0.7) of the model's window, the guard **declines** and pi's default path runs untouched — healthy compactions are byte-identical to before.
- When it doesn't fit, the guard keeps only the newest messages that fit the budget, notes the drop in the summary, and reuses pi's own exported `compact()` for the rest (file-op tracking, split turns, previous-summary merge).
- A transient failure inside the bounded path declines back to pi's default (visible turn error, retried on the next turn) — nothing is silently dropped on a blip.
- Only when not even the newest message fits does it compact deterministically (previous summary + drop notice, no model call), because every alternative leaves the conversation dead.

Existing wedged conversations self-heal: the next routine run triggers compaction, the guard bounds it, and the session reseeds under the window.

## Repro (before the fix)

1. Create a routine on a gpt-5.5 (Codex) agent with "Keep results in one chat" on and a frequent schedule; let the shared conversation grow until context fill crosses the autocompact threshold (93% of 272k) — or reach the state faster with `HOUSTON_AUTOCOMPACT_THRESHOLD` low and a history whose serialized form exceeds the model window.
2. Every subsequent run errors after ~30s with `Summarization failed: Codex error: {"type":"error","error":{...,"code":"context_length_exceeded",...}}` in Routines → Recent runs, indefinitely.

## Verify (after the fix)

1. Same setup: the first run past the threshold compacts successfully (the run record shows the routine's normal reply, not `Summarization failed`), and the compaction summary starts with the drop notice when history had to be bounded.
2. For an already-wedged conversation (e.g. A2's "time" routine once a build with this fix is deployed): the next scheduled run compacts, completes, and subsequent runs stay green.
3. `pnpm --filter @houston/runtime test` — includes 11 new tests (`compaction-guard.test.ts` + loader wiring test): fits→decline, over-budget→bounded with notice, prefix bounded separately, unsummarizable→deterministic, transient failure→decline, and the guard surviving `noExtensions`.

Gates: runtime/host/domain vitest ✓, `pnpm typecheck` ✓, `pnpm check` ✓, `pnpm check:boundaries` ✓.

HOU-709

🤖 Generated with [Claude Code](https://claude.com/claude-code)