### PR TITLE
fix(skills): Add Skills marketplace works through the cloud gateway

### DIFF
--- a/app/src/components/tabs/use-skill-surface.ts
+++ b/app/src/components/tabs/use-skill-surface.ts
@@ -76,7 +76,7 @@ export function useSkillSurface(agentPath: string) {
   const deleteSkill = useDeleteSkill(agentPath);
   const createSkill = useCreateSkill(agentPath);
   const installCommunity = useInstallCommunitySkill(agentPath);
-  const listFromRepo = useListSkillsFromRepo();
+  const listFromRepo = useListSkillsFromRepo(agentPath);
   const installFromRepo = useInstallSkillFromRepo(agentPath);
 
   const selectedSkill: Skill | undefined =
@@ -121,13 +121,13 @@ export function useSkillSurface(agentPath: string) {
 
   const handleSearch = useCallback(
     (query: string, signal?: AbortSignal) =>
-      tauriSkills.searchCommunity(query, signal),
-    [],
+      tauriSkills.searchCommunity(agentPath, query, signal),
+    [agentPath],
   );
 
   const handlePopular = useCallback(
-    (signal?: AbortSignal) => tauriSkills.popularCommunity(signal),
-    [],
+    (signal?: AbortSignal) => tauriSkills.popularCommunity(agentPath, signal),
+    [agentPath],
   );
 
   const handleInstallCommunity = useCallback(

--- a/app/src/hooks/queries/use-skills.ts
+++ b/app/src/hooks/queries/use-skills.ts
@@ -70,9 +70,12 @@ export function useSaveSkill(agentPath: string | undefined) {
   });
 }
 
-export function useListSkillsFromRepo() {
+export function useListSkillsFromRepo(agentPath: string | undefined) {
   return useMutation({
-    mutationFn: (source: string) => tauriSkills.listFromRepo(source),
+    mutationFn: (source: string) => {
+      if (!agentPath) throw new Error("agentPath is required");
+      return tauriSkills.listFromRepo(agentPath, source);
+    },
   });
 }
 

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -498,10 +498,10 @@ export const tauriSkills = {
       getEngine().saveSkill(name, { workspacePath: agentPath, content }),
     );
   },
-  listFromRepo: (source: string) =>
+  listFromRepo: (agentPath: string, source: string) =>
     call<RepoSkill[]>(
       "list_skills_from_repo",
-      () => getEngine().listSkillsFromRepo(source),
+      () => getEngine().listSkillsFromRepo(agentPath, source),
       undefined,
       // The Add Skills dialog renders repo failures (typo'd repo, private,
       // no skills) inline with plain-English copy — no red bug toast.
@@ -521,31 +521,35 @@ export const tauriSkills = {
       { toast: false },
     );
   },
-  searchCommunity: (query: string, signal?: AbortSignal) =>
+  searchCommunity: (agentPath: string, query: string, signal?: AbortSignal) =>
     call<CommunitySkillResult[]>(
       "search_community_skills",
       async () =>
-        (await getEngine().searchCommunitySkills(query, signal)).map((s) => ({
-          id: s.id,
-          skillId: s.skillId,
-          name: s.name,
-          installs: s.installs,
-          source: s.source,
-        })),
+        (await getEngine().searchCommunitySkills(agentPath, query, signal)).map(
+          (s) => ({
+            id: s.id,
+            skillId: s.skillId,
+            name: s.name,
+            installs: s.installs,
+            source: s.source,
+          }),
+        ),
       undefined,
       { toast: false },
     ),
-  popularCommunity: (signal?: AbortSignal) =>
+  popularCommunity: (agentPath: string, signal?: AbortSignal) =>
     call<CommunitySkillResult[]>(
       "popular_community_skills",
       async () =>
-        (await getEngine().popularCommunitySkills(signal)).map((s) => ({
-          id: s.id,
-          skillId: s.skillId,
-          name: s.name,
-          installs: s.installs,
-          source: s.source,
-        })),
+        (await getEngine().popularCommunitySkills(agentPath, signal)).map(
+          (s) => ({
+            id: s.id,
+            skillId: s.skillId,
+            name: s.name,
+            installs: s.installs,
+            source: s.source,
+          }),
+        ),
       undefined,
       { toast: false },
     ),

--- a/knowledge-base/skills.md
+++ b/knowledge-base/skills.md
@@ -98,10 +98,14 @@ problem" bug toasts for marketplace search misses.
 
 Both engines implement the same routes and resilience. TS host (current):
 the read-only marketplace surface (search/popular/repo-list — no workspace
-touched) is served top-level at `POST /v1/skills/...`
-(`packages/host/src/routes/skills-directory.ts`, what the web/desktop host
-adapter in `packages/web/src/engine-adapter/` calls) AND agent-scoped for the
-engine-client wire; installs are agent-scoped only.
+touched) is served agent-scoped at `POST /agents/:id/skills/...` — the path
+every shipped client uses, because the hosted gateway proxies ONLY
+`/agents/:slug/*` (a top-level read 404'd there and broke the whole Add
+Skills dialog against the cloud) — AND top-level at `POST /v1/skills/...`
+(`packages/host/src/routes/skills-directory.ts`, kept for direct host API
+callers). The web/desktop adapter (`packages/web/src/engine-adapter/`)
+threads the browsing agent's id through search/popular/repo-list for that
+reason; installs are agent-scoped only.
 `packages/host/src/routes/skills-remote.ts` dispatches
 `POST skills/community/{search,popular,install}` and
 `POST skills/repo/{list,install}` to `packages/host/src/skills/`

--- a/packages/host/src/routes/skills-directory.ts
+++ b/packages/host/src/routes/skills-directory.ts
@@ -6,10 +6,11 @@ import { json, readJson } from "./http";
 
 /**
  * The read-only marketplace surface: skills.sh search/popular and GitHub repo
- * discovery. These touch no workspace, so they're served both top-level
- * (`/v1/skills/...` — what the web/desktop host adapter calls, which has no
- * agent in scope while browsing) and agent-scoped (skills-remote.ts, the
- * engine-client wire). One directory instance per process so the skills.sh
+ * discovery. These touch no workspace, so they're served both agent-scoped
+ * (skills-remote.ts — what the web/desktop adapter and the engine-client wire
+ * call; the hosted gateway proxies ONLY /agents/:slug/*, so this is the shape
+ * that works everywhere) and top-level (`/v1/skills/...` — kept for direct
+ * host API callers). One directory instance per process so the skills.sh
  * cache + request spacing are global (mirrors the Rust engine's static cache).
  */
 

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -241,8 +241,9 @@ async function handle(
   }
 
   // User-level resources (workspaces, preferences) — no agent in the path.
-  // Marketplace reads (skills.sh search/popular, GitHub repo discovery) are
-  // user-scoped too: browsing has no agent yet; only installs are per-agent.
+  // Marketplace reads (skills.sh search/popular, GitHub repo discovery) also
+  // answer top-level for direct API callers; the shipped clients call them
+  // agent-scoped (skills-remote.ts) so the hosted gateway can proxy them.
   if (await handleSkillsDirectory(method, path, req, res)) return;
   if (await handleAccount(deps, userId, method, path, req, res)) return;
   // Live OpenRouter model catalog for the picker (user-scoped; empty when no key

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -925,24 +925,32 @@ export class HoustonClient {
   // web has no marketplace backend — searches answer empty (the dialog shows
   // its "unavailable" state), installs refuse loudly rather than no-op.
   async searchCommunitySkills(
+    agentPath: string,
     query: string,
     signal?: AbortSignal,
   ): Promise<CommunitySkill[]> {
     if (!this.cp) return [];
-    return controlPlane.searchCommunitySkills(this.cp, query, signal);
+    return controlPlane.searchCommunitySkills(
+      this.cp,
+      agentPath,
+      query,
+      signal,
+    );
   }
   async popularCommunitySkills(
+    agentPath: string,
     signal?: AbortSignal,
   ): Promise<CommunitySkill[]> {
     if (!this.cp) return [];
-    return controlPlane.popularCommunitySkills(this.cp, signal);
+    return controlPlane.popularCommunitySkills(this.cp, agentPath, signal);
   }
   async listSkillsFromRepo(
+    agentPath: string,
     source: string,
     signal?: AbortSignal,
   ): Promise<RepoSkill[]> {
     if (!this.cp) return [];
-    return controlPlane.listSkillsFromRepo(this.cp, source, signal);
+    return controlPlane.listSkillsFromRepo(this.cp, agentPath, source, signal);
   }
   async installCommunitySkill(
     req: InstallCommunityRequest,

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -682,37 +682,48 @@ export async function installAgentFromGithub(
   return (await res.json()) as { agentId: string };
 }
 
-// Marketplace reads are user-scoped (browsing has no agent yet); installs
-// write into a specific agent's skills folder. Mirrors the host's split
-// between /v1/skills/* and /agents/:id/skills/*.
+// Marketplace reads ride the same agent scope as installs: the Add Skills
+// dialog always browses FOR a specific agent, and the hosted gateway proxies
+// nothing but /agents/:slug/* (a top-level /v1/skills/* has no pod to land on
+// and 404s — the "Couldn't load suggestions" failure). The host serves these
+// read routes agent-scoped too (skills-remote.ts), so one path shape works
+// against both the local sidecar and the gateway.
 export async function searchCommunitySkills(
   cfg: ControlPlaneConfig,
+  agentId: string,
   query: string,
   signal?: AbortSignal,
 ): Promise<CommunitySkill[]> {
-  const res = await cpFetch(cfg, "/v1/skills/community/search", {
-    method: "POST",
-    body: JSON.stringify({ query }),
-    signal,
-  });
+  const res = await cpFetch(
+    cfg,
+    `${agentPath(agentId)}/skills/community/search`,
+    {
+      method: "POST",
+      body: JSON.stringify({ query }),
+      signal,
+    },
+  );
   return (await res.json()) as CommunitySkill[];
 }
 export async function popularCommunitySkills(
   cfg: ControlPlaneConfig,
+  agentId: string,
   signal?: AbortSignal,
 ): Promise<CommunitySkill[]> {
-  const res = await cpFetch(cfg, "/v1/skills/community/popular", {
-    method: "POST",
-    signal,
-  });
+  const res = await cpFetch(
+    cfg,
+    `${agentPath(agentId)}/skills/community/popular`,
+    { method: "POST", signal },
+  );
   return (await res.json()) as CommunitySkill[];
 }
 export async function listSkillsFromRepo(
   cfg: ControlPlaneConfig,
+  agentId: string,
   source: string,
   signal?: AbortSignal,
 ): Promise<RepoSkill[]> {
-  const res = await cpFetch(cfg, "/v1/skills/repo/list", {
+  const res = await cpFetch(cfg, `${agentPath(agentId)}/skills/repo/list`, {
     method: "POST",
     body: JSON.stringify({ source }),
     signal,

--- a/packages/web/tests/marketplace-agent-scope.test.ts
+++ b/packages/web/tests/marketplace-agent-scope.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  listSkillsFromRepo,
+  popularCommunitySkills,
+  searchCommunitySkills,
+} from "../src/engine-adapter/control-plane";
+
+/**
+ * The hosted gateway proxies nothing but `/agents/:slug/*` — a top-level
+ * `/v1/skills/*` has no pod to land on and 404s, which broke every Add Skills
+ * marketplace read against the cloud (skills.sh suggestions/search AND the
+ * GitHub repo lookup). The reads must ride the same agent scope installs
+ * already use; the host serves those agent-scoped routes too
+ * (packages/host/src/routes/skills-remote.ts), so the shape holds for the
+ * local sidecar as well.
+ */
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+function json(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+/** Stub fetch with a queue of responses; records every requested url. */
+function stubFetch(...responses: Response[]) {
+  const calls: string[] = [];
+  globalThis.fetch = vi.fn(async (input: unknown) => {
+    calls.push(String(input));
+    const next = responses.shift();
+    if (!next) throw new Error("stubFetch: no responses left");
+    return next;
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+const CFG = { baseUrl: "https://gateway.example", token: "t" };
+
+test("community search rides the agent scope the gateway can proxy", async () => {
+  const calls = stubFetch(json(200, []));
+
+  await searchCommunitySkills(CFG, "Houston/Growth", "research");
+
+  expect(calls).toEqual([
+    "https://gateway.example/agents/Houston%2FGrowth/skills/community/search",
+  ]);
+});
+
+test("community popular rides the agent scope the gateway can proxy", async () => {
+  const calls = stubFetch(json(200, []));
+
+  await popularCommunitySkills(CFG, "Houston/Growth");
+
+  expect(calls).toEqual([
+    "https://gateway.example/agents/Houston%2FGrowth/skills/community/popular",
+  ]);
+});
+
+test("GitHub repo listing rides the agent scope the gateway can proxy", async () => {
+  const calls = stubFetch(json(200, []));
+
+  await listSkillsFromRepo(CFG, "Houston/Growth", "owner/repo");
+
+  expect(calls).toEqual([
+    "https://gateway.example/agents/Houston%2FGrowth/skills/repo/list",
+  ]);
+});
+
+test("a marketplace failure surfaces with the host's reason — never swallowed", async () => {
+  stubFetch(json(502, { error: "skills.sh unavailable" }));
+
+  await expect(
+    searchCommunitySkills(CFG, "Houston/Growth", "research"),
+  ).rejects.toThrow("skills.sh unavailable (engine error 502)");
+});

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -820,7 +820,12 @@ export class HoustonClient {
       workspacePath,
     });
   }
+  // Marketplace reads carry the browsing agent's path: the hosted gateway only
+  // proxies agent-scoped routes, so the adapter needs the scope. Against a
+  // direct host this client reaches the same directory via the top-level
+  // routes, so the path is unused here — the parameter is the wire contract.
   searchCommunitySkills(
+    _agentPath: string,
     query: string,
     signal?: AbortSignal,
   ): Promise<CommunitySkill[]> {
@@ -834,7 +839,10 @@ export class HoustonClient {
       true,
     );
   }
-  popularCommunitySkills(signal?: AbortSignal): Promise<CommunitySkill[]> {
+  popularCommunitySkills(
+    _agentPath: string,
+    signal?: AbortSignal,
+  ): Promise<CommunitySkill[]> {
     // Read-only POST → replay-safe.
     return this.request(
       "POST",
@@ -858,6 +866,7 @@ export class HoustonClient {
     );
   }
   listSkillsFromRepo(
+    _agentPath: string,
     source: string,
     signal?: AbortSignal,
   ): Promise<RepoSkill[]> {

--- a/ui/engine-client/tests/client-retry.test.ts
+++ b/ui/engine-client/tests/client-retry.test.ts
@@ -247,7 +247,7 @@ describe("HoustonClient transport retry (HOU-432)", () => {
     });
     // searchCommunitySkills threads the AbortSignal through to send().
     await rejects(
-      client.searchCommunitySkills("q", controller.signal),
+      client.searchCommunitySkills("Houston/Agent", "q", controller.signal),
       (err: unknown) => err instanceof Error && err.name === "AbortError",
     );
     strictEqual(calls, 0);
@@ -274,7 +274,7 @@ describe("HoustonClient transport retry (HOU-432)", () => {
       },
     });
     await rejects(
-      client.searchCommunitySkills("q", controller.signal),
+      client.searchCommunitySkills("Houston/Agent", "q", controller.signal),
       (err: unknown) => err instanceof Error && err.name === "AbortError",
     );
     strictEqual(calls, 1);


### PR DESCRIPTION
## Problem

Using the desktop app against the hosted cloud, the Add Skills dialog was fully broken:

- **Skills.sh tab**: "Couldn't load suggestions" on open, search returned nothing, Try again did nothing.
- **GitHub tab**: "Find skills" on any `owner/repo` failed.

## Cause

The web/desktop adapter called the read-only marketplace routes **top-level** (`POST /v1/skills/community/search|popular`, `POST /v1/skills/repo/list`). The hosted gateway deliberately proxies nothing except `/agents/:slug/*` (no blind catch-all), so every one of those reads answered 404 before reaching any engine pod. Reproduced against the live gateway: top-level `POST /v1/skills/community/popular` → 404, while the agent-scoped equivalent through the same gateway returns real skills.sh data.

## Fix

The host has always served these reads agent-scoped too (`routes/skills-remote.ts`) — installs already use that shape and work through the gateway. The reads now ride the same agent scope:

- `control-plane.ts`: search/popular/repo-list POST to `/agents/:id/skills/...` — one path shape that works against both the local sidecar and the gateway.
- `agentPath` threaded through the adapter, engine-client signatures, `tauriSkills`, and `useSkillSurface` (the dialog is always per-agent; the path was already in scope).
- Top-level `/v1/skills/*` on the host stays for direct API callers; comments/KB updated to reflect who calls what.

## Verification

- New `packages/web/tests/marketplace-agent-scope.test.ts` pins the wire paths and the no-swallow error surface.
- Live gateway probe: `POST /agents/<slug>/skills/community/popular` → 200 with skills.sh results; `POST /agents/<slug>/skills/repo/list` (`anthropics/skills`) → 200 with the repo's skill list.
- Gates: Biome clean, boundaries clean, app tsgo + web typecheck (shim parity), host 624 ✓ / web 82 ✓ / app 767 ✓ / engine-client 36 ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)