### PR TITLE
feat(local-model): show-the-thinking toggle for reasoning models

### DIFF
--- a/app/src/components/shell/local-model-dialog-parts.tsx
+++ b/app/src/components/shell/local-model-dialog-parts.tsx
@@ -1,4 +1,4 @@
-import { Button, Spinner } from "@houston-ai/core";
+import { Button, Spinner, Switch } from "@houston-ai/core";
 import { ExternalLink, Laptop } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { appDisplayName, type LocalModelKind } from "../../lib/local-model";
@@ -116,6 +116,48 @@ export function ErrorScreen({
         <ManualLink onClick={onManual} />
         <Button onClick={onRetry}>{t("localModel.error.retry")}</Button>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Opt-in "show the model's thinking" toggle, shared by the guided pick step and
+ * the manual form. On => the saved endpoint is marked as a reasoning model, so
+ * Houston surfaces its chain-of-thought. Accessible label + microcopy, design
+ * tokens only. `id` keeps the label association unique per host form.
+ */
+export function ReasoningToggle({
+  id = "lm-reasoning",
+  checked,
+  onChange,
+  disabled,
+}: {
+  id?: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+}) {
+  const { t } = useTranslation("providers");
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-xl border border-border bg-secondary px-3 py-2.5">
+      <label
+        htmlFor={id}
+        className="flex min-w-0 flex-1 cursor-pointer flex-col"
+      >
+        <span className="text-[13px] font-medium text-foreground">
+          {t("localModel.reasoning.label")}
+        </span>
+        <span className="text-[11px] leading-relaxed text-muted-foreground">
+          {t("localModel.reasoning.help")}
+        </span>
+      </label>
+      <Switch
+        id={id}
+        checked={checked}
+        onCheckedChange={onChange}
+        disabled={disabled}
+        className="mt-0.5"
+      />
     </div>
   );
 }

--- a/app/src/components/shell/local-model-dialog.tsx
+++ b/app/src/components/shell/local-model-dialog.tsx
@@ -50,6 +50,8 @@ export function LocalModelDialog({ provider, onClose, onConnected }: Props) {
     selected,
     model,
     setModel,
+    reasoning,
+    setReasoning,
     selectServer,
     runDetect,
     connect,
@@ -100,6 +102,8 @@ export function LocalModelDialog({ provider, onClose, onConnected }: Props) {
             onSelectServer={selectServer}
             model={model}
             onSelectModel={setModel}
+            reasoning={reasoning}
+            onReasoningChange={setReasoning}
             onConnect={() => void connect()}
             onManual={goManual}
           />

--- a/app/src/components/shell/local-model-manual-form.tsx
+++ b/app/src/components/shell/local-model-manual-form.tsx
@@ -1,7 +1,9 @@
 import { Button } from "@houston-ai/core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useReasoningToggle } from "../../hooks/use-reasoning-toggle";
 import { connectManualEndpoint } from "../../lib/local-model-connect";
+import { ReasoningToggle } from "./local-model-dialog-parts";
 import {
   LabeledTextField,
   SecretField,
@@ -31,6 +33,14 @@ export function LocalModelManualForm({
   const [showKey, setShowKey] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const { reasoning, setReasoning, applyModelDefault } = useReasoningToggle();
+
+  // Typing a model id re-applies the reasoning default until the user flips the
+  // toggle themselves (then their choice sticks).
+  const handleModelChange = (next: string) => {
+    setModel(next);
+    applyModelDefault(next);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -52,6 +62,7 @@ export function LocalModelManualForm({
         model: trimmedModel,
         name: name.trim() || undefined,
         apiKey: key.trim() || undefined,
+        ...(reasoning ? { reasoning: true } : {}),
       });
       onConnected?.(trimmedModel);
       onClose();
@@ -79,7 +90,7 @@ export function LocalModelManualForm({
         label={t("openaiCompatible.modelLabel")}
         help={t("openaiCompatible.modelHelp")}
         value={model}
-        onChange={setModel}
+        onChange={handleModelChange}
         placeholder={t("openaiCompatible.modelPlaceholder")}
         disabled={submitting}
         mono
@@ -105,6 +116,12 @@ export function LocalModelManualForm({
         onToggleShow={() => setShowKey((v) => !v)}
         showLabel={t("openaiCompatible.show")}
         hideLabel={t("openaiCompatible.hide")}
+      />
+      <ReasoningToggle
+        id="lm-manual-reasoning"
+        checked={reasoning}
+        onChange={setReasoning}
+        disabled={submitting}
       />
 
       {error && (

--- a/app/src/components/shell/local-model-pick.tsx
+++ b/app/src/components/shell/local-model-pick.tsx
@@ -9,7 +9,7 @@ import {
 import { Check, Laptop } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { appDisplayName, type DetectedServer } from "../../lib/local-model";
-import { ManualLink } from "./local-model-dialog-parts";
+import { ManualLink, ReasoningToggle } from "./local-model-dialog-parts";
 
 /**
  * Pick a detected local server + one of its models, then Connect. Non-technical:
@@ -21,6 +21,8 @@ export function PickScreen({
   onSelectServer,
   model,
   onSelectModel,
+  reasoning,
+  onReasoningChange,
   onConnect,
   onManual,
 }: {
@@ -29,6 +31,8 @@ export function PickScreen({
   onSelectServer: (index: number) => void;
   model: string;
   onSelectModel: (model: string) => void;
+  reasoning: boolean;
+  onReasoningChange: (value: boolean) => void;
   onConnect: () => void;
   onManual: () => void;
 }) {
@@ -89,6 +93,7 @@ export function PickScreen({
           </SelectContent>
         </Select>
       </div>
+      <ReasoningToggle checked={reasoning} onChange={onReasoningChange} />
       <div className="flex items-center justify-between gap-2 pt-1">
         <ManualLink onClick={onManual} />
         <Button onClick={onConnect} disabled={!model}>

--- a/app/src/hooks/use-local-model-connect.ts
+++ b/app/src/hooks/use-local-model-connect.ts
@@ -10,6 +10,7 @@ import {
   connectDetectedModel,
   detectLocalModels,
 } from "../lib/local-model-connect";
+import { useReasoningToggle } from "./use-reasoning-toggle";
 
 export type LocalModelMode =
   | "detecting"
@@ -61,7 +62,23 @@ export function useLocalModelConnect(opts: {
   const [mode, setMode] = useState<LocalModelMode>("detecting");
   const [servers, setServers] = useState<DetectedServer[]>([]);
   const [selected, setSelected] = useState(0);
-  const [model, setModel] = useState("");
+  const [model, setModelState] = useState("");
+  // "Show the model's thinking" toggle (heuristic default, user can override).
+  const {
+    reasoning,
+    setReasoning,
+    applyModelDefault,
+    reset: resetReasoning,
+  } = useReasoningToggle();
+
+  /** Pick a model and re-apply the reasoning default for it. */
+  const chooseModel = useCallback(
+    (next: string) => {
+      setModelState(next);
+      applyModelDefault(next);
+    },
+    [applyModelDefault],
+  );
 
   // The controller for the current in-flight step (detect or connect); Cancel /
   // close abort it. `mounted` guards setState after the dialog unmounts.
@@ -95,31 +112,32 @@ export function useLocalModelConnect(opts: {
       }
       setServers(found);
       setSelected(0);
-      setModel(defaultModelFor(found[0]));
+      chooseModel(defaultModelFor(found[0]));
       setMode("pick");
     } catch {
       // detectLocalModels already toasted the real reason (Report-bug); an abort
       // is a silent cancel. Either way, land on the calm error state if visible.
       if (!controller.signal.aborted && mounted.current) setMode("error");
     }
-  }, []);
+  }, [chooseModel]);
 
   // Fresh start on every open: guided detection on desktop, manual in a browser.
   useEffect(() => {
     if (!active) return;
     setServers([]);
     setSelected(0);
-    setModel("");
+    resetReasoning();
+    chooseModel("");
     if (desktop) void runDetect();
     else setMode("manual");
-  }, [active, desktop, runDetect]);
+  }, [active, desktop, runDetect, chooseModel, resetReasoning]);
 
   const selectServer = useCallback(
     (index: number) => {
       setSelected(index);
-      setModel(defaultModelFor(servers[index]));
+      chooseModel(defaultModelFor(servers[index]));
     },
-    [servers],
+    [servers, chooseModel],
   );
 
   const connect = useCallback(async () => {
@@ -137,6 +155,7 @@ export function useLocalModelConnect(opts: {
             model,
             name: defaultEndpointName(server.kind, model),
             appName: appDisplayName(server.kind),
+            reasoning,
             signal,
           }),
         CONNECT_TIMEOUT_MS,
@@ -150,7 +169,7 @@ export function useLocalModelConnect(opts: {
       // the bridge back. Show a calm retry state unless we were cancelled/closed.
       if (!controller.signal.aborted && mounted.current) setMode("error");
     }
-  }, [servers, selected, model, onConnected, onClose]);
+  }, [servers, selected, model, reasoning, onConnected, onClose]);
 
   /** Cancel the in-flight detect/connect: abort the work (the connect's own
    *  abort path rolls back any half-open bridge) and close the dialog. */
@@ -169,7 +188,9 @@ export function useLocalModelConnect(opts: {
     servers,
     selected,
     model,
-    setModel,
+    setModel: chooseModel,
+    reasoning,
+    setReasoning,
     selectServer,
     runDetect,
     connect,

--- a/app/src/hooks/use-reasoning-toggle.ts
+++ b/app/src/hooks/use-reasoning-toggle.ts
@@ -1,0 +1,36 @@
+import { useCallback, useRef, useState } from "react";
+import { looksLikeReasoningModel } from "../lib/local-model-reasoning";
+
+/**
+ * Owns the "show the model's thinking" toggle for the connect-a-local-model
+ * flow. Defaults to the reasoning heuristic for the current model until the user
+ * flips it, after which their choice sticks.
+ *
+ * - `setReasoning` records that the user overrode the default.
+ * - `applyModelDefault(model)` re-runs the heuristic when the picked/typed model
+ *   changes (a no-op once the user has overridden).
+ * - `reset` returns to the untouched default (used when the dialog reopens).
+ *
+ * Shared by the guided pick step (`useLocalModelConnect`) and the manual form so
+ * the default/override behaviour is identical on both paths.
+ */
+export function useReasoningToggle() {
+  const [reasoning, setReasoningState] = useState(false);
+  const touched = useRef(false);
+
+  const setReasoning = useCallback((value: boolean) => {
+    touched.current = true;
+    setReasoningState(value);
+  }, []);
+
+  const applyModelDefault = useCallback((model: string) => {
+    if (!touched.current) setReasoningState(looksLikeReasoningModel(model));
+  }, []);
+
+  const reset = useCallback(() => {
+    touched.current = false;
+    setReasoningState(false);
+  }, []);
+
+  return { reasoning, setReasoning, applyModelDefault, reset };
+}

--- a/app/src/lib/local-model-connect.ts
+++ b/app/src/lib/local-model-connect.ts
@@ -82,6 +82,8 @@ export async function connectDetectedModel(opts: {
   model: string;
   name: string;
   appName: string;
+  /** Surface the model's chain-of-thought as thinking in Houston. */
+  reasoning?: boolean;
   signal?: AbortSignal;
 }): Promise<void> {
   const cred = await tauriProvider.getTunnelCredentials();
@@ -115,6 +117,7 @@ export async function connectDetectedModel(opts: {
     model: opts.model,
     name: opts.name,
     proxyKey: bridge.proxyKey,
+    reasoning: opts.reasoning,
   });
   try {
     await tauriProvider.setCustomEndpoint(endpoint);

--- a/app/src/lib/local-model-reasoning.ts
+++ b/app/src/lib/local-model-reasoning.ts
@@ -1,0 +1,32 @@
+/**
+ * Reasoning-model heuristic for the "connect a local model" flow. DOM-free and
+ * Tauri-free so it unit-tests under bare Node (`app/tests/local-model.test.ts`).
+ *
+ * Used ONLY to pre-check the "show the model's thinking" toggle as a hint — the
+ * user can always override it. The saved endpoint's `reasoning` flag is what
+ * actually surfaces the model's chain-of-thought (the backend already consumes
+ * it); this heuristic just picks a sensible default.
+ */
+
+/** Substrings that mark a model id as a reasoning (chain-of-thought) model. */
+const REASONING_ID_HINTS = [
+  "r1",
+  "qwq",
+  "magistral",
+  "thinking",
+  "reasoning",
+  "deepseek-r",
+  "o1",
+  "o3",
+  "-a4b",
+  "phi-4-reasoning",
+] as const;
+
+/**
+ * Heuristic: does this model id look like a reasoning model? Case-insensitive
+ * substring match against common reasoning-model markers.
+ */
+export function looksLikeReasoningModel(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  return REASONING_ID_HINTS.some((hint) => id.includes(hint));
+}

--- a/app/src/lib/local-model.ts
+++ b/app/src/lib/local-model.ts
@@ -131,12 +131,16 @@ export function buildLocalEndpoint(opts: {
   model: string;
   name: string;
   proxyKey: string;
+  /** Surface the model's chain-of-thought as thinking in Houston. Omitted from
+   *  the payload unless true, to keep saved endpoints clean. */
+  reasoning?: boolean;
 }): CustomEndpoint {
   return {
     baseUrl: `${opts.publicUrl.replace(/\/+$/, "")}/v1`,
     model: opts.model,
     name: opts.name,
     apiKey: opts.proxyKey,
+    ...(opts.reasoning ? { reasoning: true } : {}),
   };
 }
 

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -152,6 +152,10 @@
       "modelLabel": "Model",
       "connect": "Connect"
     },
+    "reasoning": {
+      "label": "Show the model's thinking",
+      "help": "Turn this on for reasoning models (they think before answering)."
+    },
     "error": {
       "body": "Something went wrong while connecting. Make sure the app is still open on your computer, then try again.",
       "retry": "Try again"

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -152,6 +152,10 @@
       "modelLabel": "Modelo",
       "connect": "Conectar"
     },
+    "reasoning": {
+      "label": "Mostrar el razonamiento del modelo",
+      "help": "Actívalo para modelos de razonamiento (piensan antes de responder)."
+    },
     "error": {
       "body": "Algo salió mal al conectar. Asegúrate de que la app siga abierta en tu computador e inténtalo de nuevo.",
       "retry": "Intentar de nuevo"

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -152,6 +152,10 @@
       "modelLabel": "Modelo",
       "connect": "Conectar"
     },
+    "reasoning": {
+      "label": "Mostrar o raciocínio do modelo",
+      "help": "Ative isto para modelos de raciocínio (eles pensam antes de responder)."
+    },
     "error": {
       "body": "Algo deu errado ao conectar. Confira se o app ainda está aberto no seu computador e tente de novo.",
       "retry": "Tentar de novo"

--- a/app/tests/local-model.test.ts
+++ b/app/tests/local-model.test.ts
@@ -11,6 +11,7 @@ import {
   type SavedBridgeTarget,
   sessionOwnsBridge,
 } from "../src/lib/local-model.ts";
+import { looksLikeReasoningModel } from "../src/lib/local-model-reasoning.ts";
 
 function server(extra: Partial<DetectedServer> = {}): DetectedServer {
   return {
@@ -71,6 +72,49 @@ describe("local-model helpers", () => {
         apiKey: "secret",
       },
     );
+  });
+
+  it("marks the endpoint as reasoning only when the toggle is on", () => {
+    const base = {
+      publicUrl: "https://sub.relay.example.com",
+      model: "deepseek-r1",
+      name: "n",
+      proxyKey: "k",
+    };
+    // Off / omitted => no reasoning key on the payload (kept clean).
+    strictEqual("reasoning" in buildLocalEndpoint(base), false);
+    strictEqual(
+      "reasoning" in buildLocalEndpoint({ ...base, reasoning: false }),
+      false,
+    );
+    // On => reasoning: true.
+    strictEqual(
+      buildLocalEndpoint({ ...base, reasoning: true }).reasoning,
+      true,
+    );
+  });
+
+  it("detects reasoning models by id substring, case-insensitively", () => {
+    for (const id of [
+      "DeepSeek-R1",
+      "deepseek-r1-distill",
+      "QwQ-32B",
+      "Magistral-Small",
+      "phi-4-reasoning",
+      "phi-4-reasoning-plus",
+      "some-thinking-model",
+      "openai/o1-preview",
+      "o3-mini",
+      "Qwen3-30B-A4B",
+    ]) {
+      strictEqual(looksLikeReasoningModel(id), true, id);
+    }
+  });
+
+  it("does not flag ordinary chat models as reasoning", () => {
+    for (const id of ["llama-3.1", "gemma-2-9b", "mistral-7b", "gpt-4o-mini"]) {
+      strictEqual(looksLikeReasoningModel(id), false, id);
+    }
   });
 
   it("does not double the slash when publicUrl has a trailing slash", () => {


### PR DESCRIPTION
Adds an opt-in "Show the model's thinking" switch to the connect-a-local-model flow. Local reasoning models (DeepSeek-R1, QwQ, gemma `-a4b`, phi-4-reasoning, o1/o3) stream `reasoning_content` that pi-ai already turns into thinking blocks — but the UI never set `CustomEndpoint.reasoning`, so it was suppressed. The toggle auto-pre-checks for reasoning-looking model ids (user can override) and saves `reasoning: true`; thinking then streams into the same display Houston uses for Claude. Default off so non-reasoning models aren't sent reasoning params. en/es/pt.

Prompted by real testing: gemma-4-26b-a4b-qat's thinking wasn't showing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)