### PR TITLE
fix(local-model): serialize bridge lifecycle (concurrent starts dead-ended the tunnel)

### DIFF
--- a/app/src-tauri/src/local_bridge/commands.rs
+++ b/app/src-tauri/src/local_bridge/commands.rs
@@ -7,7 +7,7 @@ use tauri::{AppHandle, Manager};
 use super::state::{self, SavedBridgeTarget};
 use super::{
     detection, keys, launch, origin_of, stop_internal, BridgeStatusKind, BridgeStatusPayload,
-    DetectedServer, LaunchParams, StartBridgeResult, STATUS,
+    DetectedServer, LaunchParams, StartBridgeResult, BRIDGE_OP, STATUS,
 };
 
 /// Probe the well-known local model-server ports and report what's running.
@@ -39,6 +39,10 @@ pub async fn start_local_bridge(
     // handed back by `saved_bridge_target`. Absent → derived from the origin.
     app_name: Option<String>,
 ) -> Result<StartBridgeResult, String> {
+    // Serialize the whole lifecycle: hold BRIDGE_OP across launch AND the
+    // descriptor write so no concurrent reconnect/stop can interleave (see the
+    // static's doc for the crossed-port hang this prevents).
+    let _op = BRIDGE_OP.lock().await;
     // Resolve the bundled frpc BEFORE starting anything, so a missing binary
     // fails fast without leaking a listener.
     let frpc_binary = resolve_frpc(&app)?;
@@ -86,6 +90,9 @@ pub async fn reconnect_local_bridge(
     subdomain: String,
     token: String,
 ) -> Result<StartBridgeResult, String> {
+    // Serialize against a concurrent start/stop — a boot auto-reconnect and a
+    // manual connect must not run launch() at the same time (see BRIDGE_OP).
+    let _op = BRIDGE_OP.lock().await;
     let desc = state::load()?
         .ok_or_else(|| "no saved local-bridge to reconnect — start one first".to_string())?;
     let frpc_binary = resolve_frpc(&app)?;
@@ -120,6 +127,9 @@ pub fn saved_bridge_target() -> Result<Option<SavedBridgeTarget>, String> {
 /// we never auto-reconnect after an explicit disconnect. Idempotent.
 #[tauri::command]
 pub async fn stop_local_bridge(app: AppHandle) -> Result<(), String> {
+    // Same serializer: a stop must not race a concurrent start/reconnect, or it
+    // could tear down a bridge the other op is mid-way through standing up.
+    let _op = BRIDGE_OP.lock().await;
     stop_internal(&app)?;
     state::delete()
 }

--- a/app/src-tauri/src/local_bridge/frpc.rs
+++ b/app/src-tauri/src/local_bridge/frpc.rs
@@ -9,7 +9,7 @@
 //! loop here; we only parse its logs to drive bridge status.
 
 use std::io::{BufRead, BufReader};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
@@ -17,6 +17,7 @@ use std::thread;
 
 use crate::child_guard;
 use crate::local_bridge::log_sanitize;
+use crate::local_bridge::pidfile;
 use crate::local_bridge::BridgeStatusKind;
 
 /// Callback invoked (from log-reader threads) whenever frpc's state changes.
@@ -39,12 +40,21 @@ pub struct FrpcParams<'a> {
 pub struct FrpcSupervisor {
     child: Arc<Mutex<Option<Child>>>,
     stopping: Arc<AtomicBool>,
+    /// Owned copy of the local-bridge config dir (holds `frpc.pid`), so a clean
+    /// [`kill`](FrpcSupervisor::kill) / `Drop` can remove the pidfile.
+    config_dir: PathBuf,
     #[cfg(windows)]
     _job: child_guard::win_job::KillOnCloseJob,
 }
 
 impl FrpcSupervisor {
     pub fn spawn(params: FrpcParams, on_status: StatusCallback) -> Result<Self, String> {
+        // Reap any frpc left orphaned by a previous UNCLEAN app exit (a `tauri
+        // dev` SIGKILL or a production crash never runs `RunEvent::Exit`) BEFORE
+        // spawning a new one, so the orphan can't keep reconnecting and fight the
+        // new frpc over the same subdomain. Best-effort — never blocks the start.
+        pidfile::reap_orphan(params.config_dir);
+
         let config = render_config(&params)?;
         std::fs::create_dir_all(params.config_dir)
             .map_err(|e| format!("frpc: create config dir: {e}"))?;
@@ -92,6 +102,11 @@ impl FrpcSupervisor {
             }
         };
 
+        // Record the new pid so a future UNCLEAN exit can reap THIS frpc. After
+        // a successful spawn (and, on Windows, a successful job bind) so we only
+        // ever persist a pid that really launched. Best-effort.
+        pidfile::write(params.config_dir, child.id());
+
         let stdout = child.stdout.take().ok_or("frpc: no stdout")?;
         let stderr = child.stderr.take().ok_or("frpc: no stderr")?;
         let stopping = Arc::new(AtomicBool::new(false));
@@ -104,6 +119,7 @@ impl FrpcSupervisor {
         Ok(Self {
             child: Arc::new(Mutex::new(Some(child))),
             stopping,
+            config_dir: params.config_dir.to_path_buf(),
             #[cfg(windows)]
             _job,
         })
@@ -121,6 +137,8 @@ impl FrpcSupervisor {
                 let _ = child.wait();
             }
         }
+        // Clean stop: drop the pidfile so the next spawn finds nothing to reap.
+        pidfile::remove(&self.config_dir);
     }
 }
 
@@ -362,6 +380,7 @@ mod tests {
         let sup = FrpcSupervisor {
             child: Arc::new(Mutex::new(Some(child))),
             stopping: Arc::new(AtomicBool::new(false)),
+            config_dir: std::env::temp_dir(),
         };
         sup.kill();
 

--- a/app/src-tauri/src/local_bridge/mod.rs
+++ b/app/src-tauri/src/local_bridge/mod.rs
@@ -16,6 +16,7 @@ mod detection;
 mod frpc;
 mod keys;
 mod log_sanitize;
+mod pidfile;
 mod proxy;
 mod state;
 mod types;

--- a/app/src-tauri/src/local_bridge/mod.rs
+++ b/app/src-tauri/src/local_bridge/mod.rs
@@ -19,6 +19,7 @@ mod log_sanitize;
 mod proxy;
 mod state;
 mod types;
+mod url;
 
 use std::sync::{Arc, Mutex};
 
@@ -27,10 +28,22 @@ use tauri::{AppHandle, Emitter};
 pub use detection::DetectedServer;
 use types::StoredStatus;
 pub use types::{BridgeStatusKind, BridgeStatusPayload, StartBridgeResult};
+use url::origin_of;
 
 /// The single live bridge, if any. A new `launch` tears down the previous one so
 /// we never leak a proxy port or an frpc child.
 static BRIDGE: Mutex<Option<RunningBridge>> = Mutex::new(None);
+
+/// Serializes the WHOLE bridge lifecycle (start / reconnect / stop). Held across
+/// the awaits inside [`launch`] so two concurrent starts can never interleave —
+/// the frontend fires a boot auto-reconnect AND a manual connect at once, and
+/// without this they raced on the single `frpc.toml`, leaving frpc forwarding to
+/// a proxy port whose accept-task had already been torn down (turn hangs
+/// forever). The std [`BRIDGE`] mutex stays the state cell; it must NEVER be held
+/// across an await (that's the original bug / a deadlock), so this async mutex is
+/// the operation serializer instead. Acquired by the three command entry points
+/// in [`commands`] — [`launch`] assumes it is already held.
+static BRIDGE_OP: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 /// Last known status, mirrored into the `local-bridge-status` event. Read by
 /// [`local_bridge_status`] so the frontend can pull it without waiting for an
@@ -65,6 +78,11 @@ struct LaunchParams {
 /// Stand up the bearer-gated loopback proxy in front of `origin`, then spawn
 /// frpc to publish it. Tears down any prior bridge first. Leaves the proxy port
 /// unpublished if frpc fails to launch.
+///
+/// PRECONDITION: the caller MUST hold [`BRIDGE_OP`] for the whole call. That is
+/// the only thing keeping `stop_internal` + the shared `frpc.toml` write + the
+/// `BRIDGE` store atomic against a concurrent lifecycle op; the lock is acquired
+/// in the command handlers (not here) so it also spans descriptor persistence.
 async fn launch(app: &AppHandle, p: LaunchParams) -> Result<StartBridgeResult, String> {
     // Tear down any prior bridge first.
     stop_internal(app)?;
@@ -137,6 +155,11 @@ fn stop_internal(app: &AppHandle) -> Result<(), String> {
 /// at process exit, so this MUST be called explicitly from `RunEvent::Exit` —
 /// otherwise frpc (own process group, null stdin) orphans and holds its
 /// subdomain, auto-reconnecting.
+///
+/// Deliberately does NOT take [`BRIDGE_OP`]: it runs at process exit where no
+/// command can still be racing, it must not block on a lock a stuck op might
+/// hold, and it's a sync fn on the Tauri run-loop thread (no `.await`). It
+/// touches `BRIDGE` directly, which is safe — that's a plain sync mutex.
 pub fn shutdown() {
     if let Ok(mut guard) = BRIDGE.lock() {
         if let Some(RunningBridge { proxy, frpc }) = guard.take() {
@@ -169,51 +192,9 @@ fn set_status(app: &AppHandle, kind: BridgeStatusKind, detail: Option<String>) {
     }
 }
 
-/// Reduce a base URL to its `scheme://host[:port]` origin (drop any path), which
-/// is what the proxy forwards against.
-fn origin_of(base: &str) -> Result<String, String> {
-    let base = base.trim();
-    let scheme_end = base
-        .find("://")
-        .ok_or_else(|| format!("targetBaseUrl {base:?} is missing a scheme"))?;
-    let authority_start = scheme_end + 3;
-    let rest = &base[authority_start..];
-    let authority_len = rest.find('/').unwrap_or(rest.len());
-    if authority_len == 0 {
-        return Err(format!("targetBaseUrl {base:?} has no host"));
-    }
-    Ok(format!(
-        "{}{}",
-        &base[..authority_start],
-        &rest[..authority_len]
-    ))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn origin_strips_path() {
-        assert_eq!(
-            origin_of("http://127.0.0.1:1234/v1").unwrap(),
-            "http://127.0.0.1:1234"
-        );
-        assert_eq!(
-            origin_of("http://127.0.0.1:1234").unwrap(),
-            "http://127.0.0.1:1234"
-        );
-        assert_eq!(
-            origin_of("https://host:8443/a/b/c").unwrap(),
-            "https://host:8443"
-        );
-    }
-
-    #[test]
-    fn origin_rejects_bad_input() {
-        assert!(origin_of("127.0.0.1:1234").is_err()); // no scheme
-        assert!(origin_of("http:///v1").is_err()); // no host
-    }
 
     #[test]
     fn detected_server_serializes_camel_case() {
@@ -229,5 +210,132 @@ mod tests {
         assert!(json.contains("\"kind\":\"lmstudio\""));
         assert!(json.contains("\"baseUrl\":\"http://127.0.0.1:1234\""));
         assert!(json.contains("\"reachable\":true"));
+    }
+}
+
+/// Concurrency tests for the [`BRIDGE_OP`] lifecycle serializer.
+///
+/// These model `launch()`'s non-atomic sequence: allocate a loopback proxy port,
+/// then (after awaits) record that port into the SINGLE shared `frpc.toml`. The
+/// live-repro bug: two concurrent launches share one config file, so `BRIDGE`
+/// ends up holding proxy A while frpc forwards to port B — frpc alive, nothing
+/// listening on B, every tunneled request dead-ends and the turn hangs. The
+/// pairing invariant is `proxy.port == frpc local_port`; `BRIDGE_OP` must keep
+/// it true under concurrency by making the whole sequence mutually exclusive.
+#[cfg(test)]
+mod concurrency_tests {
+    use super::BRIDGE_OP;
+    use crate::local_bridge::proxy;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+
+    /// A distinct temp path standing in for the single shared `frpc.toml`.
+    fn shared_config_path(tag: &str) -> std::path::PathBuf {
+        let unique = format!(
+            "houston-bridge-race-{}-{}-{tag}.toml",
+            std::process::id(),
+            COUNTER.fetch_add(1, Ordering::Relaxed),
+        );
+        std::env::temp_dir().join(unique)
+    }
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    /// Model the `localPort = N` line frpc would forward to.
+    fn write_frpc_local_port(path: &std::path::Path, port: u16) {
+        std::fs::write(path, format!("localPort = {port}\n")).expect("write frpc config");
+    }
+    fn read_frpc_local_port(path: &std::path::Path) -> u16 {
+        let s = std::fs::read_to_string(path).expect("read frpc config");
+        s.trim()
+            .strip_prefix("localPort = ")
+            .and_then(|n| n.parse().ok())
+            .expect("parse localPort")
+    }
+
+    /// One serialized lifecycle: bind a REAL proxy, record its port into the
+    /// shared config, yield (the await window where a rival op could clobber the
+    /// file), then read back what frpc would forward to. Tracks peak concurrency
+    /// so the test can prove the critical sections never overlap.
+    async fn guarded_lifecycle(
+        cfg: std::path::PathBuf,
+        active: Arc<AtomicUsize>,
+        peak: Arc<AtomicUsize>,
+    ) -> (u16, u16) {
+        let _op = BRIDGE_OP.lock().await;
+        let now = active.fetch_add(1, Ordering::SeqCst) + 1;
+        peak.fetch_max(now, Ordering::SeqCst);
+
+        let bridge =
+            proxy::start_auth_proxy("http://127.0.0.1:1".to_string(), "k".to_string(), None)
+                .await
+                .expect("proxy start");
+        let proxy_port = bridge.port;
+        write_frpc_local_port(&cfg, proxy_port);
+        // Give the scheduler every chance to interleave a rival op here.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        let frpc_local = read_frpc_local_port(&cfg);
+
+        bridge.shutdown();
+        active.fetch_sub(1, Ordering::SeqCst);
+        (proxy_port, frpc_local)
+    }
+
+    /// THE FIX: two concurrent lifecycles sharing one config file never overlap
+    /// and each keeps `proxy.port == frpc local_port`. Would flake/fail without
+    /// `BRIDGE_OP` (see `crossed_ports_without_serializer` for the mechanism).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn bridge_op_serializes_and_keeps_ports_paired() {
+        let cfg = shared_config_path("guarded");
+        let active = Arc::new(AtomicUsize::new(0));
+        let peak = Arc::new(AtomicUsize::new(0));
+
+        let a = tokio::spawn(guarded_lifecycle(cfg.clone(), active.clone(), peak.clone()));
+        let b = tokio::spawn(guarded_lifecycle(cfg.clone(), active.clone(), peak.clone()));
+        let (pa, fa) = a.await.expect("task a");
+        let (pb, fb) = b.await.expect("task b");
+
+        assert_eq!(pa, fa, "op A: frpc must forward to A's proxy port");
+        assert_eq!(pb, fb, "op B: frpc must forward to B's proxy port");
+        assert_eq!(
+            peak.load(Ordering::SeqCst),
+            1,
+            "BRIDGE_OP must keep the two lifecycles from ever overlapping"
+        );
+        let _ = std::fs::remove_file(&cfg);
+    }
+
+    /// REPRODUCES the bug deterministically: with NO serializer, op B slips into
+    /// op A's await window and overwrites the shared `frpc.toml`, so A ends up
+    /// paired with B's port — frpc forwards to B while BRIDGE holds proxy A. This
+    /// is the crossed-port dead-end `BRIDGE_OP` closes.
+    #[tokio::test]
+    async fn crossed_ports_without_serializer() {
+        let cfg = shared_config_path("unguarded");
+
+        // Op A: bind proxy, write the shared config...
+        let a = proxy::start_auth_proxy("http://127.0.0.1:1".to_string(), "k".to_string(), None)
+            .await
+            .expect("proxy a");
+        write_frpc_local_port(&cfg, a.port);
+
+        // ...but before A records the pairing, op B interleaves (the missing
+        // guard) and clobbers the SAME file with its own port.
+        let b = proxy::start_auth_proxy("http://127.0.0.1:1".to_string(), "k".to_string(), None)
+            .await
+            .expect("proxy b");
+        write_frpc_local_port(&cfg, b.port);
+
+        // A now reads what frpc forwards to — and gets B's port.
+        let frpc_local = read_frpc_local_port(&cfg);
+        assert_ne!(
+            a.port, frpc_local,
+            "reproduces the crossed pairing BRIDGE_OP must prevent"
+        );
+        assert_eq!(b.port, frpc_local, "frpc ends up bound to op B's port");
+
+        a.shutdown();
+        b.shutdown();
+        let _ = std::fs::remove_file(&cfg);
     }
 }

--- a/app/src-tauri/src/local_bridge/pidfile.rs
+++ b/app/src-tauri/src/local_bridge/pidfile.rs
@@ -1,0 +1,298 @@
+//! frpc orphan-reaper: pidfile write/read/remove + a liveness- and
+//! identity-guarded kill of a previous frpc instance.
+//!
+//! WHY THIS EXISTS: frpc runs in its own process group (Unix) so it survives
+//! the app being SIGKILLed — which is EVERY `tauri dev` recompile, and any
+//! production crash — because `RunEvent::Exit` never fires to call
+//! [`crate::local_bridge::shutdown`]. The orphaned frpc keeps auto-reconnecting
+//! to the relay and fights the new app's frpc over the same subdomain (frps
+//! new-proxy / proxy-closing churn), so the tunnel never stabilizes. There is
+//! no OS-level parent-death signal we relied on, so we persist the live frpc's
+//! pid to a file and reap it on the NEXT spawn.
+//!
+//! PID-REUSE GUARD: a pid is not unique over time — by the time we read the
+//! pidfile the OS may have recycled that number for an unrelated process. So we
+//! never kill on the pidfile alone: we (1) confirm the pid is alive and (2)
+//! confirm the live process is actually an frpc (its command/image contains
+//! `frpc`). Only then do we kill its whole process group. Everything here is
+//! best-effort cleanup — a failure to reap must NEVER break a bridge start, so
+//! callers ignore the outcome and we only log at debug.
+
+use std::path::{Path, PathBuf};
+
+/// Substring that identifies our frpc process in a `ps`/`tasklist` line. The
+/// bundled binary is resolved from base name `frpc` (plain or `frpc-<triple>`),
+/// so its command line / image name always contains this.
+const FRPC_NEEDLE: &str = "frpc";
+
+/// Absolute path of the pidfile inside the local-bridge config dir (the same
+/// dir that holds `frpc.toml`).
+fn pid_path(config_dir: &Path) -> PathBuf {
+    config_dir.join("frpc.pid")
+}
+
+/// Persist `pid` to `<config_dir>/frpc.pid`. Best-effort: a write failure is
+/// logged at warn (it only degrades the next reap, it never breaks this spawn).
+pub fn write(config_dir: &Path, pid: u32) {
+    let path = pid_path(config_dir);
+    if let Err(e) = std::fs::write(&path, pid.to_string()) {
+        tracing::warn!(
+            "[local-bridge] failed to write frpc pidfile {}: {e}",
+            path.display()
+        );
+    }
+}
+
+/// Remove the pidfile on a CLEAN stop so a subsequent spawn finds no stale pid.
+/// Best-effort: a missing file (already gone) or IO error is logged at debug.
+pub fn remove(config_dir: &Path) {
+    let path = pid_path(config_dir);
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+        Err(e) => tracing::debug!(
+            "[local-bridge] failed to remove frpc pidfile {}: {e}",
+            path.display()
+        ),
+    }
+}
+
+/// Read a pid from the pidfile, or `None` if absent/empty/unparseable.
+fn read(config_dir: &Path) -> Option<u32> {
+    let s = std::fs::read_to_string(pid_path(config_dir)).ok()?;
+    s.trim().parse::<u32>().ok()
+}
+
+/// Reap a previous frpc instance recorded in the pidfile, BEFORE spawning a new
+/// one. Runs at the top of every [`super::frpc::FrpcSupervisor::spawn`], so it
+/// covers boot auto-reconnect (first spawn after a restart reaps the
+/// pre-restart orphan) and every reconnect. Best-effort: never returns / never
+/// panics on failure — a lost reap must not block the bridge.
+pub fn reap_orphan(config_dir: &Path) {
+    let Some(pid) = read(config_dir) else {
+        return; // No pidfile → clean prior exit, nothing to reap.
+    };
+    if !is_alive(pid) {
+        // Stale pidfile from an already-dead frpc; nothing to kill.
+        tracing::debug!("[local-bridge] frpc pidfile {pid} is not alive; skipping reap");
+        return;
+    }
+    if !is_our_frpc(read_process_command, pid, FRPC_NEEDLE) {
+        // PID-REUSE GUARD: the number is alive but belongs to some other
+        // process now — leave it strictly alone.
+        tracing::debug!("[local-bridge] pid {pid} is not an frpc (reused); not killing");
+        return;
+    }
+    tracing::debug!("[local-bridge] reaping orphaned frpc pid {pid}");
+    kill(pid);
+}
+
+/// Decide whether `pid` is one of our frpc processes, using `read_cmd` to fetch
+/// its command line / image name. Split out (and generic over the reader) so the
+/// pid-reuse decision is unit-testable without a real process. Returns false
+/// when the reader yields nothing (process gone or unreadable) — fail closed, we
+/// never kill on doubt.
+fn is_our_frpc<F: Fn(u32) -> Option<String>>(read_cmd: F, pid: u32, needle: &str) -> bool {
+    match read_cmd(pid) {
+        Some(cmd) => cmd
+            .to_ascii_lowercase()
+            .contains(&needle.to_ascii_lowercase()),
+        None => false,
+    }
+}
+
+// ---- OS-specific liveness / identity / kill --------------------------------
+
+/// Is `pid` a live process? Unix: `kill(pid, 0)` succeeds for a signalable live
+/// process. Windows: presence in `tasklist`.
+#[cfg(unix)]
+fn is_alive(pid: u32) -> bool {
+    // SAFETY: signal 0 sends no signal; it only probes existence/permission and
+    // touches no Rust state. Returns 0 when the process exists and is
+    // signalable by us (always true for our own child's pid).
+    unsafe { libc_kill(pid as i32, 0) == 0 }
+}
+
+#[cfg(windows)]
+fn is_alive(pid: u32) -> bool {
+    // tasklist prints a data row only when the pid exists (see
+    // `read_process_command`); no row → not alive.
+    read_process_command(pid).is_some()
+}
+
+/// Read a live process's command line (Unix) / image name (Windows), or `None`
+/// if the pid does not exist. Shelling out to `ps`/`tasklist` keeps this a
+/// zero-dependency identity probe (no `sysinfo`); it runs at most once per
+/// bridge start, so the process spawn cost is irrelevant.
+#[cfg(unix)]
+fn read_process_command(pid: u32) -> Option<String> {
+    let out = std::process::Command::new("ps")
+        .args(["-p", &pid.to_string(), "-o", "command="])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None; // `ps` exits non-zero when the pid is gone.
+    }
+    let cmd = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if cmd.is_empty() {
+        None
+    } else {
+        Some(cmd)
+    }
+}
+
+#[cfg(windows)]
+fn read_process_command(pid: u32) -> Option<String> {
+    // CSV, no header: a live pid yields e.g. `"frpc.exe","1234",...`; a dead pid
+    // yields `INFO: No tasks are running ...` on stderr and no CSV row.
+    let out = std::process::Command::new("tasklist")
+        .args(["/FI", &format!("PID eq {pid}"), "/FO", "CSV", "/NH"])
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&out.stdout);
+    let line = text.lines().find(|l| l.trim_start().starts_with('"'))?;
+    // First CSV field is the image name; strip the surrounding quotes.
+    let image = line.split(',').next()?.trim().trim_matches('"').to_string();
+    if image.is_empty() {
+        None
+    } else {
+        Some(image)
+    }
+}
+
+/// Kill the reaped frpc. Unix: its whole process group (it was placed in its own
+/// group at spawn, so pid == pgid) via the shared [`crate::child_guard`] path.
+/// Windows: a force tree-kill by pid.
+#[cfg(unix)]
+fn kill(pid: u32) {
+    crate::child_guard::kill_process_group(pid as i32);
+}
+
+#[cfg(windows)]
+fn kill(pid: u32) {
+    // /T also takes any children; /F forces it. Best-effort — ignore outcome.
+    let _ = std::process::Command::new("taskkill")
+        .args(["/PID", &pid.to_string(), "/T", "/F"])
+        .output();
+}
+
+#[cfg(unix)]
+extern "C" {
+    /// `kill(2)` — with signal 0 it performs only existence/permission checks.
+    /// Named `libc_kill` to avoid colliding with the module-local [`kill`] reaper.
+    #[link_name = "kill"]
+    fn libc_kill(pid: i32, sig: i32) -> i32;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp_dir(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!(
+            "houston-frpc-pidfile-{}-{}-{tag}",
+            std::process::id(),
+            tag
+        ));
+        std::fs::create_dir_all(&dir).expect("create tmp dir");
+        dir
+    }
+
+    #[test]
+    fn write_read_remove_round_trip() {
+        let dir = tmp_dir("roundtrip");
+
+        // No file yet → None.
+        assert_eq!(read(&dir), None);
+
+        // Write then read back the exact pid.
+        write(&dir, 4242);
+        assert!(pid_path(&dir).exists());
+        assert_eq!(read(&dir), Some(4242));
+
+        // Remove clears it; a second remove is a no-op (best-effort).
+        remove(&dir);
+        assert!(!pid_path(&dir).exists());
+        assert_eq!(read(&dir), None);
+        remove(&dir); // must not panic on a missing file
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn read_ignores_garbage_pidfile() {
+        let dir = tmp_dir("garbage");
+        std::fs::write(pid_path(&dir), "not-a-pid").expect("write");
+        assert_eq!(read(&dir), None);
+        // Whitespace around a valid pid is tolerated.
+        std::fs::write(pid_path(&dir), "  99 \n").expect("write");
+        assert_eq!(read(&dir), Some(99));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The pid-reuse guard: kill ONLY when the live process really is an frpc.
+    /// Uses a stubbed command-reader so no real process is required.
+    #[test]
+    fn is_our_frpc_matches_only_frpc_command() {
+        // A matching command (our bundled binary, triple-suffixed) → kill.
+        assert!(is_our_frpc(
+            |_pid| Some("/opt/houston/frpc-aarch64-apple-darwin -c /x/frpc.toml".to_string()),
+            1234,
+            FRPC_NEEDLE,
+        ));
+        // Plain `frpc.exe` image name (Windows tasklist) → kill.
+        assert!(is_our_frpc(
+            |_pid| Some("frpc.exe".to_string()),
+            1234,
+            FRPC_NEEDLE,
+        ));
+        // A reused pid now running something unrelated → DO NOT kill.
+        assert!(!is_our_frpc(
+            |_pid| Some("/usr/bin/postgres -D /var/lib/pg".to_string()),
+            1234,
+            FRPC_NEEDLE,
+        ));
+        // Process gone / command unreadable → fail closed, DO NOT kill.
+        assert!(!is_our_frpc(|_pid| None, 1234, FRPC_NEEDLE));
+    }
+
+    #[test]
+    fn is_our_frpc_is_case_insensitive() {
+        assert!(is_our_frpc(
+            |_pid| Some("C:\\Program Files\\Houston\\FRPC.EXE".to_string()),
+            7,
+            FRPC_NEEDLE,
+        ));
+    }
+
+    /// reap_orphan is a no-op (and never panics) when there is no pidfile — the
+    /// clean-exit path.
+    #[test]
+    fn reap_orphan_without_pidfile_is_noop() {
+        let dir = tmp_dir("noreap");
+        remove(&dir); // ensure absent
+        reap_orphan(&dir); // must not panic
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// A pidfile pointing at a dead pid is skipped (stale), not killed. Uses a
+    /// pid that is almost certainly not live.
+    #[test]
+    fn reap_orphan_skips_dead_pid() {
+        let dir = tmp_dir("deadpid");
+        // A very high pid that is not alive on the test host.
+        write(&dir, 2_000_000_000);
+        assert!(!is_alive(2_000_000_000));
+        reap_orphan(&dir); // takes the stale branch, no kill, no panic
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    /// The current test process IS alive — the liveness probe must agree.
+    #[test]
+    fn is_alive_true_for_self() {
+        assert!(is_alive(std::process::id()));
+    }
+}

--- a/app/src-tauri/src/local_bridge/url.rs
+++ b/app/src-tauri/src/local_bridge/url.rs
@@ -1,0 +1,49 @@
+//! URL helpers for the local bridge — reducing a caller's base URL to the
+//! `scheme://host[:port]` origin the auth proxy forwards against.
+
+/// Reduce a base URL to its `scheme://host[:port]` origin (drop any path), which
+/// is what the proxy forwards against.
+pub fn origin_of(base: &str) -> Result<String, String> {
+    let base = base.trim();
+    let scheme_end = base
+        .find("://")
+        .ok_or_else(|| format!("targetBaseUrl {base:?} is missing a scheme"))?;
+    let authority_start = scheme_end + 3;
+    let rest = &base[authority_start..];
+    let authority_len = rest.find('/').unwrap_or(rest.len());
+    if authority_len == 0 {
+        return Err(format!("targetBaseUrl {base:?} has no host"));
+    }
+    Ok(format!(
+        "{}{}",
+        &base[..authority_start],
+        &rest[..authority_len]
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn origin_strips_path() {
+        assert_eq!(
+            origin_of("http://127.0.0.1:1234/v1").unwrap(),
+            "http://127.0.0.1:1234"
+        );
+        assert_eq!(
+            origin_of("http://127.0.0.1:1234").unwrap(),
+            "http://127.0.0.1:1234"
+        );
+        assert_eq!(
+            origin_of("https://host:8443/a/b/c").unwrap(),
+            "https://host:8443"
+        );
+    }
+
+    #[test]
+    fn origin_rejects_bad_input() {
+        assert!(origin_of("127.0.0.1:1234").is_err()); // no scheme
+        assert!(origin_of("http:///v1").is_err()); // no host
+    }
+}

--- a/app/src/hooks/use-local-bridge-autoreconnect.ts
+++ b/app/src/hooks/use-local-bridge-autoreconnect.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 import { providerAppearsConnected } from "../components/shell/provider-reconnect-state";
 import {
+  isBridgeOpInFlight,
   LOCAL_PROVIDER_ID,
   reconnectLocalModel,
 } from "../lib/local-model-connect";
@@ -39,6 +40,11 @@ export function useLocalBridgeAutoReconnect(enabled: boolean): void {
         return null;
       });
       if (!savedTarget) return;
+
+      // A manual connect/reconnect is already running — don't fire a second,
+      // redundant lifecycle op (the native side serializes them, but skipping
+      // avoids a needless teardown-rebuild). Closes the status-read TOCTOU.
+      if (isBridgeOpInFlight()) return;
 
       // Already up (native side kept it, or a prior mount reconnected)? Nothing
       // to do — never restart a healthy bridge.

--- a/app/src/lib/local-model-connect.ts
+++ b/app/src/lib/local-model-connect.ts
@@ -29,6 +29,25 @@ import { tauriProvider } from "./tauri";
 /** The engine provider id the local endpoint registers under. */
 export const LOCAL_PROVIDER_ID = "openai-compatible";
 
+/**
+ * Set while a bridge lifecycle op (connect/reconnect) is running, so the boot
+ * auto-reconnect can skip when a manual connect is already in flight. The native
+ * side serializes bridge ops regardless (BRIDGE_OP), but this avoids a redundant
+ * teardown-rebuild that the hook's status TOCTOU would otherwise let through.
+ */
+let bridgeOpInFlight = false;
+export function isBridgeOpInFlight(): boolean {
+  return bridgeOpInFlight;
+}
+async function withBridgeOp<T>(fn: () => Promise<T>): Promise<T> {
+  bridgeOpInFlight = true;
+  try {
+    return await fn();
+  } finally {
+    bridgeOpInFlight = false;
+  }
+}
+
 /** Surface a raw native-bridge failure with the standard Report-bug toast. */
 function surfaceRaw(command: string, err: unknown): void {
   const message = err instanceof Error ? err.message : String(err);
@@ -86,47 +105,49 @@ export async function connectDetectedModel(opts: {
   reasoning?: boolean;
   signal?: AbortSignal;
 }): Promise<void> {
-  const cred = await tauriProvider.getTunnelCredentials();
-  if (isAbort(opts.signal)) throw new ConnectAborted();
+  return withBridgeOp(async () => {
+    const cred = await tauriProvider.getTunnelCredentials();
+    if (isAbort(opts.signal)) throw new ConnectAborted();
 
-  let bridge: Awaited<ReturnType<typeof osStartLocalBridge>>;
-  try {
-    bridge = await osStartLocalBridge({
-      targetBaseUrl: opts.server.baseUrl,
-      relayHost: cred.relayHost,
-      relayPort: cred.relayPort,
-      subdomain: cred.subdomain,
-      token: cred.token,
-      transport: cred.transport,
-      appName: opts.appName,
+    let bridge: Awaited<ReturnType<typeof osStartLocalBridge>>;
+    try {
+      bridge = await osStartLocalBridge({
+        targetBaseUrl: opts.server.baseUrl,
+        relayHost: cred.relayHost,
+        relayPort: cred.relayPort,
+        subdomain: cred.subdomain,
+        token: cred.token,
+        transport: cred.transport,
+        appName: opts.appName,
+      });
+    } catch (err) {
+      surfaceRaw("start_local_bridge", err);
+      throw err;
+    }
+
+    // Aborted while frpc came up: tear it back down, don't register a dangling
+    // endpoint or leave a half-open bridge.
+    if (isAbort(opts.signal)) {
+      await stopBridgeSurfaced();
+      throw new ConnectAborted();
+    }
+
+    const endpoint = buildLocalEndpoint({
+      publicUrl: bridge.publicUrl,
+      model: opts.model,
+      name: opts.name,
+      proxyKey: bridge.proxyKey,
+      reasoning: opts.reasoning,
     });
-  } catch (err) {
-    surfaceRaw("start_local_bridge", err);
-    throw err;
-  }
-
-  // Aborted while frpc came up: tear it back down, don't register a dangling
-  // endpoint or leave a half-open bridge.
-  if (isAbort(opts.signal)) {
-    await stopBridgeSurfaced();
-    throw new ConnectAborted();
-  }
-
-  const endpoint = buildLocalEndpoint({
-    publicUrl: bridge.publicUrl,
-    model: opts.model,
-    name: opts.name,
-    proxyKey: bridge.proxyKey,
-    reasoning: opts.reasoning,
+    try {
+      await tauriProvider.setCustomEndpoint(endpoint);
+    } catch (err) {
+      // Roll back the half-open bridge; the primary failure already toasted and
+      // a rollback failure is surfaced too (no silent zombie tunnel).
+      await stopBridgeSurfaced();
+      throw err;
+    }
   });
-  try {
-    await tauriProvider.setCustomEndpoint(endpoint);
-  } catch (err) {
-    // Roll back the half-open bridge; the primary failure already toasted and a
-    // rollback failure is surfaced too (no silent zombie tunnel).
-    await stopBridgeSurfaced();
-    throw err;
-  }
 }
 
 /**
@@ -135,14 +156,16 @@ export async function connectDetectedModel(opts: {
  * reusing the persisted proxyKey so no endpoint re-registration is needed.
  */
 export async function reconnectLocalModel(signal?: AbortSignal): Promise<void> {
-  const cred = await tauriProvider.getTunnelCredentials();
-  if (isAbort(signal)) throw new ConnectAborted();
-  try {
-    await osReconnectLocalBridge(reconnectBridgeArgs(cred));
-  } catch (err) {
-    surfaceRaw("reconnect_local_bridge", err);
-    throw err;
-  }
+  return withBridgeOp(async () => {
+    const cred = await tauriProvider.getTunnelCredentials();
+    if (isAbort(signal)) throw new ConnectAborted();
+    try {
+      await osReconnectLocalBridge(reconnectBridgeArgs(cred));
+    } catch (err) {
+      surfaceRaw("reconnect_local_bridge", err);
+      throw err;
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
Found from a live repro: after an app restart, the boot auto-reconnect and a manual reconnect ran **concurrently**. `launch()` releases the bridge lock across its awaits, so the two interleaved over the single shared `frpc.toml` and left a **running frpc forwarding to a proxy port whose server was already torn down** — every tunneled request dead-ended and the turn hung forever. Fingerprint in the frpc log: repeated `start error: proxy [...] already exists`.

**Rust:** an async `BRIDGE_OP` mutex serializes start/reconnect/stop end-to-end so lifecycle ops can't interleave (Exit path bypasses it, sync, no race at exit). Reproduce-first tests: one shows the crossed-port dead-end without the serializer; one proves the fix keeps `proxy.port == frpc local_port` with peak concurrency 1. 34 local_bridge tests pass.

**Frontend:** the boot auto-reconnect hook skips when a manual connect is already in flight (shared `isBridgeOpInFlight` flag), closing the status-read TOCTOU that let both fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)