### PR TITLE
fix(skills): pin the GitHub install button width so WebKit stops ghosting its old cap

### DIFF
--- a/packages/fake-host/src/routes.ts
+++ b/packages/fake-host/src/routes.ts
@@ -31,6 +31,16 @@ export function authStatusBody() {
   return state.authStatusFor(state.FLAT_KEY);
 }
 
+/** Canned repo skills for the Add Skills GitHub tab (list-from-repo). A dozen
+ *  so the install button reads a two-digit "Install 12" the test can compare
+ *  against "Install 0" after a deselect-all. */
+const REPO_SKILLS = Array.from({ length: 12 }, (_, i) => ({
+  id: `repo-skill-${i}`,
+  name: `Repo Skill ${i + 1}`,
+  description: `Canned repo skill number ${i + 1}`,
+  path: `skills/repo-skill-${i}/SKILL.md`,
+}));
+
 function makeTitle(text: string): string {
   return (
     text.replace(/\s+/g, " ").trim().split(" ").slice(0, 6).join(" ") ||
@@ -92,9 +102,24 @@ export function handleAgents(
       return noContent(405);
     }
 
+    case "skills": {
+      // Marketplace + repo reads are agent-scoped (PR #706). Model the GitHub
+      // "list skills from a repo" then "install the selected ones" flow the
+      // Add Skills dialog drives, so the UI test can exercise it end to end.
+      if (rest[2] === "repo" && rest[3] === "list" && method === "POST")
+        return json(REPO_SKILLS);
+      if (rest[2] === "repo" && rest[3] === "install" && method === "POST") {
+        const picked = Array.isArray(body?.skills) ? body.skills : [];
+        return json(
+          picked.map((s) => String((s as { name?: string }).name ?? "skill")),
+        );
+      }
+      if (method === "GET") return json({ items: [] });
+      return noContent(); // create/update/delete/run — accepted no-ops
+    }
+
     case "routines":
     case "routine_runs":
-    case "skills":
       if (method === "GET") return json({ items: [] });
       return noContent(); // create/update/delete/run — accepted no-ops
 

--- a/packages/web/e2e/skills-add-dialog.spec.ts
+++ b/packages/web/e2e/skills-add-dialog.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "./support/fixtures";
+
+/**
+ * Add Skills dialog, GitHub tab. Regression guard for the WebKit repaint ghost
+ * (skills-from-GitHub bug): the action button is right-pinned by the flex-1
+ * search input, so any width change slides its LEFT edge, and on the dialog's
+ * frosted `backdrop-filter` surface WebKit leaves a dark ghost of the old
+ * rounded cap. The fix pins the button to a stable width (min-w-32) across every
+ * label ("Find skills" / "Install N" / "Install 0"), so nothing is ever vacated.
+ *
+ * We can't screenshot a live-compositor ghost (any snapshot forces a clean
+ * repaint), so we assert the mechanism instead: the button's rendered width does
+ * not change as its label changes. Browser-agnostic — the width invariant holds
+ * everywhere, and killing the width churn is what kills the ghost on WebKit.
+ */
+test("GitHub install button keeps a stable width across label changes", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  // Agent Settings (job-description) → Skills row → Add skill.
+  await page.getByRole("button", { name: "Agent Settings" }).click();
+  await page.getByText("Skills", { exact: true }).click();
+  await page.getByRole("button", { name: "Add skill" }).click();
+
+  const dialog = page.getByRole("dialog");
+  await expect(dialog.getByText("Add skills")).toBeVisible();
+
+  // GitHub tab: enter a repo, discover its skills.
+  await dialog.getByRole("button", { name: "GitHub" }).click();
+
+  // The discover button is the first state of the pinned action button.
+  const findButton = dialog.getByRole("button", { name: "Find skills" });
+  const findWidth = (await findButton.boundingBox())?.width ?? 0;
+
+  await dialog.getByPlaceholder("owner/repo").fill("mattpocock/skills");
+  await findButton.click();
+
+  // The fake host returns a canned dozen; all are selected by default.
+  await expect(dialog.getByText("12 skills found")).toBeVisible();
+  const installAll = dialog.getByRole("button", { name: "Install 12" });
+  await expect(installAll).toBeVisible();
+  const installAllWidth = (await installAll.boundingBox())?.width ?? 0;
+
+  // Deselect all → the count drops to a narrower label.
+  await dialog.getByText("Deselect all").click();
+  const installNone = dialog.getByRole("button", { name: "Install 0" });
+  await expect(installNone).toBeVisible();
+  const installNoneWidth = (await installNone.boundingBox())?.width ?? 0;
+
+  // The label changed width ("Find skills" / "Install 12" / "Install 0" have
+  // different intrinsic widths) but the rendered button must not: no vacated
+  // rounded cap for WebKit to ghost.
+  expect(installAllWidth).toBeGreaterThan(0);
+  expect(Math.abs(installAllWidth - installNoneWidth)).toBeLessThan(0.5);
+  expect(Math.abs(installAllWidth - findWidth)).toBeLessThan(0.5);
+  // And it's the padded, stable pill width, not the intrinsic label width.
+  expect(installNoneWidth).toBeGreaterThanOrEqual(120);
+});

--- a/ui/skills/src/add-skill-dialog-repo-view.tsx
+++ b/ui/skills/src/add-skill-dialog-repo-view.tsx
@@ -116,11 +116,19 @@ export function RepoView({ onList, onInstall, labels }: RepoViewProps) {
                            disabled:opacity-60 disabled:cursor-not-allowed"
               />
             </div>
+            {/* Fixed width across every label ("Find skills" / "Install N" /
+                spinner) and both branches. The button is right-pinned by the
+                flex-1 input, so any width change slides its LEFT edge; on the
+                dialog's frosted `backdrop-filter` surface WebKit fails to
+                invalidate the vacated rounded cap and leaves a dark ghost of
+                the old fill (HOU skills-from-GitHub bug). A stable width means
+                nothing is ever vacated. min-w-32 = 128px clears the widest
+                label (es/pt "Buscar skills" ~115px). */}
             {stage.kind === "input" || stage.kind === "loading" ? (
               <Button
                 onClick={handleDiscover}
                 disabled={!source.trim() || isLoading}
-                className="rounded-full shrink-0"
+                className="rounded-full shrink-0 min-w-32"
               >
                 {isLoading ? <Spinner className="size-4" /> : l.findSkills}
               </Button>
@@ -128,7 +136,7 @@ export function RepoView({ onList, onInstall, labels }: RepoViewProps) {
               <Button
                 onClick={handleInstall}
                 disabled={selected.size === 0 || isInstalling}
-                className="rounded-full shrink-0"
+                className="rounded-full shrink-0 min-w-32"
               >
                 {isInstalling ? (
                   <Spinner className="size-4" />


### PR DESCRIPTION
## What

Fixes the dark crescent that appears left of the action button in **Add Skills → GitHub** ([screenshot in the report]).

## Root cause

It's not a real element — it's a **WebKit repaint ghost**. The action button ("Find skills" → "Install N" → "Install 0") is right-pinned by the `flex-1` search input, so every label change slides its **left edge** while the right edge stays put. That button sits over the dialog's frosted `backdrop-filter` glass (`bg-card`), and on WebKit a solid element resizing over a backdrop-filter leaves the vacated region un-invalidated — the dark rounded **left cap** of the previous, wider button lingers as a ghost.

Pixel analysis of the report screenshot confirms it: a vertical lens of near-black hugging the pill's left edge, tapering top and bottom — exactly a pill's left cap.

## Fix

Pin both action buttons to a stable `min-w-32` (128px), which clears the widest label across en/es/pt ("Buscar skills" ≈ 115px). The width no longer changes with the label, so the left edge never moves and nothing is ever vacated for WebKit to ghost.

## Testing

- New **WebKit + Chromium** e2e (`packages/web/e2e/skills-add-dialog.spec.ts`) drives the real flow (Agent Settings → Skills → Add skill → GitHub → find → deselect-all) and asserts the button's rendered width stays constant across label changes.
- **Confirmed it catches the regression**: with the fix reverted, "Install 12" vs "Install 0" differ by ~6px and the test fails.
- To make the flow testable, the fake host now models `/skills/repo/{list,install}`.
- Full workspace typecheck, Biome, boundaries, and fake-host unit tests all pass.

Note: a live-compositor ghost can't be screenshotted (any snapshot forces a clean repaint), so the test asserts the *mechanism* — killing the width churn is what kills the ghost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)