### PR TITLE
fix(runtime): a stalled provider turn no longer freezes the agent or hides the queued message

### DIFF
--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -134,6 +134,21 @@ export const config = {
   runCodeMaxConcurrent: Number(env.HOUSTON_RUN_CODE_MAX_CONCURRENT || 2),
   runCodePerMinute: Number(env.HOUSTON_RUN_CODE_PER_MINUTE || 10),
 
+  /**
+   * How long a turn's model request may go with NO activity — no wire event,
+   * while no tool is running — before the runtime treats the provider as stalled,
+   * aborts it, and surfaces a typed error. A healthy turn streams text/thinking/
+   * tool events continuously; a stalled provider stream (a chatgpt.com SSE read
+   * that never returns another byte) emits nothing and, absent this, holds the
+   * per-workspace turn lock until the OS socket dies (19 min observed in prod;
+   * pi's SSE reader has no idle timeout, only its WebSocket path does).
+   * Defaults to pi's own 5-minute idle default, deliberately generous so it never
+   * clips a long-reasoning turn that streams no intermediate events; ops can lower
+   * it. `0` disables the watchdog. Non-finite/negative also disable (fail-safe:
+   * no false aborts). Tool execution is exempt — a long bash/build is silent.
+   */
+  turnStallTimeoutMs: Number(env.HOUSTON_TURN_STALL_TIMEOUT_MS || 300_000),
+
   version: "0.0.0",
 };
 

--- a/packages/runtime/src/session/backend-switch.test.ts
+++ b/packages/runtime/src/session/backend-switch.test.ts
@@ -137,7 +137,10 @@ test("openai→anthropic REBUILDS on the anthropic backend — the pi session is
 
   const events: WireEvent[] = [];
   const unsub = subscribe("conv-a", (e) => events.push(e));
-  await execTurn(conv, "conv-a", "turn-1", "hello");
+  await execTurn(conv, "conv-a", "turn-1", "hello", {
+    author: undefined,
+    priorAuthors: [],
+  });
   unsub();
 
   // The compliance gate: the live pi session must NOT touch this anthropic turn.
@@ -168,7 +171,10 @@ test("anthropic→openai REBUILDS on the pi backend — the Claude session is di
 
   const events: WireEvent[] = [];
   const unsub = subscribe("conv-b", (e) => events.push(e));
-  await execTurn(conv, "conv-b", "turn-1", "hello");
+  await execTurn(conv, "conv-b", "turn-1", "hello", {
+    author: undefined,
+    priorAuthors: [],
+  });
   unsub();
 
   expect(claudeSession.prompts).toEqual([]);
@@ -195,7 +201,10 @@ test("same-backend model change (openai→google, both pi) stays on the setModel
     contextWindow: 1_000_000,
   };
 
-  await execTurn(conv, "conv-c", "turn-1", "hello");
+  await execTurn(conv, "conv-c", "turn-1", "hello", {
+    author: undefined,
+    priorAuthors: [],
+  });
 
   // No teardown: the live session is kept and re-pointed via setModel.
   expect(piSession.disposed).toBe(false);

--- a/packages/runtime/src/session/chat.ts
+++ b/packages/runtime/src/session/chat.ts
@@ -15,7 +15,7 @@ import {
   conversations,
   getConversation,
 } from "./conversation-cache";
-import { execTurn, type TurnPin } from "./exec-turn";
+import { execTurn, recordUserTurn, type TurnPin } from "./exec-turn";
 import { withWorkdirLock } from "./workdir-lock";
 
 /**
@@ -120,11 +120,18 @@ export async function runTurn(
   // mutating the same files concurrently (the Rust engine's workdir_locks
   // behavior). The conv.queue link resolves before the lock is requested, so
   // the two layers can't deadlock.
-  const run = conv.queue.then(() =>
-    withWorkdirLock(config.workspaceDir, () =>
-      execTurn(conv, id, turnId, text, nonce, pin, acting),
-    ),
-  );
+  const run = conv.queue.then(() => {
+    // Persist + announce the user message BEFORE taking the workdir lock, so a
+    // brand-new conversation's message is durable and visible (GET /messages)
+    // the instant the turn is accepted — even while ANOTHER conversation holds
+    // the lock in a stalled provider call. The transcript write is a
+    // per-conversation file already ordered by conv.queue; only the turn's
+    // file-mutating body needs the workspace-wide lock.
+    const recorded = recordUserTurn(conv, id, turnId, text, nonce, acting);
+    return withWorkdirLock(config.workspaceDir, () =>
+      execTurn(conv, id, turnId, text, recorded, pin, acting),
+    );
+  });
   // Keep the queue chain alive past a turn. execTurn already surfaces its own
   // failure as an `error` event, so this guard never swallows a user-visible one.
   conv.queue = run.catch(() => {});

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -14,7 +14,11 @@ import {
   getHistory,
 } from "../store/conversations";
 import { type ActingContext, runWithActingContext } from "./acting-context";
-import { decodeActingAuthor, framePrompt } from "./attribution";
+import {
+  decodeActingAuthor,
+  framePrompt,
+  type MessageAuthor,
+} from "./attribution";
 import { needsAutocompact } from "./autocompact";
 import { publish } from "./bus";
 import { type Conversation, switchBackendIfNeeded } from "./conversation-cache";
@@ -24,6 +28,7 @@ import {
   snapshotWorkspace,
 } from "./file-changes";
 import { switchNeedsCompaction } from "./provider-switch";
+import { createStallWatchdog } from "./stall-watchdog";
 
 /** A routine's pinned provider/model/effort for this turn. Absent = keep the session's current. */
 export interface TurnPin {
@@ -32,26 +37,41 @@ export interface TurnPin {
   effort?: string | null;
 }
 
+/**
+ * A turn's user message, already persisted + announced by `recordUserTurn`, plus
+ * the framing inputs `execTurn` still needs. Splitting the record step OUT of
+ * `execTurn` is what lets it run BEFORE the workdir lock (chat.ts) — see the note
+ * on `recordUserTurn`.
+ */
+export interface RecordedUserTurn {
+  author: MessageAuthor | undefined;
+  priorAuthors: ReadonlyArray<MessageAuthor | undefined>;
+}
+
 const errMessage = (err: unknown) =>
   err instanceof Error ? err.message : String(err);
 
 /**
- * Execute one turn: record the user + assistant messages durably and publish
- * every event to the conversation's bus. Self-contained: any failure is published
- * as an `error` event and never rethrown, so the per-conversation queue survives.
+ * Persist the user's message durably + announce it on the conversation bus, and
+ * return the inputs the model-framing decision needs. Called by `runTurn` BEFORE
+ * it takes the per-workspace workdir lock: the transcript is a per-conversation
+ * file already ordered by `conv.queue`, and never needed the workspace-wide lock
+ * (which serializes concurrent FILE mutations BETWEEN conversations). Recording
+ * here means a brand-new conversation's message lands on disk — and so is visible
+ * to `GET /conversations` + `/messages` — the instant the turn is accepted, even
+ * while ANOTHER conversation holds the lock in a stalled provider call. This
+ * write used to live inside the lock, so a stalled routine hid the user's next
+ * message (404, empty chat) for as long as it hung.
  */
-export async function execTurn(
+export function recordUserTurn(
   conv: Conversation,
   id: string,
   turnId: string,
   text: string,
   nonce?: string,
-  pin?: TurnPin,
   acting?: ActingContext,
-) {
-  // Every frame and persisted message of this turn carries `turnId`, so a
-  // client (resyncing, or watching another writer's turn — a teammate, a
-  // second tab, a routine) can attribute what it sees to exactly one turn.
+): RecordedUserTurn {
+  // Stamp the executing turn's id up front so a cancel/stop settles this turn.
   conv.turnId = turnId;
   // WHO wrote this message (C5): decode the acting-as token's payload (the
   // gateway already verified it; the runtime only reads it). Absent → no author,
@@ -74,6 +94,26 @@ export async function execTurn(
     data: { content: text, ts: Date.now(), nonce, author },
     turnId,
   });
+  return { author, priorAuthors };
+}
+
+/**
+ * Execute one turn: run the model, record the assistant reply durably, and
+ * publish every event to the conversation's bus. The user message is already
+ * persisted + announced (`recordUserTurn`, run before the workdir lock).
+ * Self-contained: any failure is published as an `error`/`provider_error` and
+ * never rethrown, so the per-conversation queue survives.
+ */
+export async function execTurn(
+  conv: Conversation,
+  id: string,
+  turnId: string,
+  text: string,
+  recorded: RecordedUserTurn,
+  pin?: TurnPin,
+  acting?: ActingContext,
+) {
+  const { author, priorAuthors } = recorded;
 
   let assistantText = "";
   let usage: TokenUsage | null = null;
@@ -84,6 +124,22 @@ export async function execTurn(
   // assistant message (so the inline card survives a reload) AND skip the clean
   // `done` that would settle the chat as a success on top of the error.
   let providerError: ProviderError | undefined;
+
+  // Stall watchdog: a provider stream that goes silent mid-turn resolves neither
+  // success nor error and would hold the workdir lock until the socket dies.
+  // When it trips, `stalled` turns the aborted (contentless) turn into a typed
+  // error below — see stall-watchdog.ts. Fed every wire event by the
+  // subscription; armed/disarmed around the model round-trip only.
+  let stalled = false;
+  const watchdog = createStallWatchdog({
+    timeoutMs: config.turnStallTimeoutMs,
+    onStall: () => {
+      stalled = true;
+      // Fire-and-forget: the awaited prompt() resolves once pi unwinds the
+      // aborted stream; that resolution, not this call, advances the turn.
+      void conv.session.abort();
+    },
+  });
 
   // Subscribes THIS turn's session once it is settled on the correct backend
   // (a cross-backend switch below rebuilds `conv.session`, so the subscription
@@ -99,6 +155,9 @@ export async function execTurn(
         const t = tools[tools.length - 1];
         if (t) t.isError = wire.data.isError;
       } else if (wire.type === "provider_error") providerError = wire.data;
+      // Every event proves the provider is alive → reset the stall clock (the
+      // watchdog suspends itself while a tool runs and re-arms when it ends).
+      watchdog.onEvent(wire);
       publish(id, { ...wire, turnId });
     });
   };
@@ -230,8 +289,33 @@ export async function execTurn(
     }
     // Hold the turn's acting-as identity (C2) for the DURATION of the prompt so
     // the integration tools' proxy calls (which run inside this async subtree)
-    // attach it. Absent → runs plainly (act as owner).
-    await runWithActingContext(acting, () => conv.session.prompt(promptText));
+    // attach it. Absent → runs plainly (act as owner). The watchdog covers the
+    // model round-trip only — tools run inside prompt() and re-arm/suspend it as
+    // they start/end; the finally disarms it whether prompt() resolves or throws.
+    watchdog.arm();
+    try {
+      await runWithActingContext(acting, () => conv.session.prompt(promptText));
+    } finally {
+      watchdog.disarm();
+    }
+    // A stall-abort resolves prompt() the same way a user Stop does (pi marks it
+    // "aborted" and emits no provider_error), so synthesize the typed failure
+    // here — else the empty, contentless turn would settle below as a clean
+    // success. `provider_internal` is the honest card: the request DID reach the
+    // provider (the socket was live) and it then failed to deliver — a
+    // provider-side fault, "try again in a moment", NOT the user's connectivity.
+    // No HTTP status: the stream went silent, it never returned a response code.
+    if (stalled && !providerError) {
+      providerError = {
+        kind: "provider_internal",
+        provider: model.provider,
+        http_status: null,
+        message: `The AI provider stopped responding (no response for ${Math.round(
+          config.turnStallTimeoutMs / 1000,
+        )}s). Please try again.`,
+      };
+      publish(id, { type: "provider_error", data: providerError, turnId });
+    }
     // Diff what this turn created/modified. Skipped on a failed turn — a
     // provider error means the model never finished, so attributing partial
     // writes would be noise (mirrors the Rust engine's error gate).
@@ -289,6 +373,8 @@ export async function execTurn(
     publish(id, { type: "error", data: { message: errMessage(err) }, turnId });
   } finally {
     conv.turnId = undefined;
+    // Never leak the stall timer past the turn (no-op if it threw before arming).
+    watchdog.disarm();
     // Undefined only if resolveModel/switchBackendIfNeeded threw before we
     // subscribed (a bad pin) — nothing to tear down in that case.
     unsub?.();

--- a/packages/runtime/src/session/stall-watchdog.test.ts
+++ b/packages/runtime/src/session/stall-watchdog.test.ts
@@ -1,0 +1,125 @@
+import type { WireEvent } from "@houston/runtime-client";
+import { afterEach, expect, test, vi } from "vitest";
+import { createStallWatchdog } from "./stall-watchdog";
+
+/**
+ * The stall watchdog is the stalled-provider backstop: it fires `onStall` when a turn's
+ * model round-trip goes silent for `timeoutMs` while no tool is running, so a
+ * dead SSE read can't hold the workdir lock forever. These drive it with fake
+ * timers — no live session — to pin the exact timing contract.
+ */
+
+const textEvent: WireEvent = { type: "text", data: "x" };
+const toolStart = (name: string): WireEvent => ({
+  type: "tool_start",
+  data: { name, args: {} },
+});
+const toolEnd = (name: string): WireEvent => ({
+  type: "tool_end",
+  data: { name, isError: false },
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+test("fires once after the idle window when armed and silent", () => {
+  vi.useFakeTimers();
+  let stalls = 0;
+  const wd = createStallWatchdog({ timeoutMs: 1000, onStall: () => stalls++ });
+
+  wd.arm();
+  vi.advanceTimersByTime(999);
+  expect(stalls).toBe(0); // not yet
+  vi.advanceTimersByTime(1);
+  expect(stalls).toBe(1); // tripped at the threshold
+  vi.advanceTimersByTime(10_000);
+  expect(stalls).toBe(1); // and only once
+});
+
+test("every event resets the clock, so a steadily streaming turn never trips", () => {
+  vi.useFakeTimers();
+  let stalls = 0;
+  const wd = createStallWatchdog({ timeoutMs: 1000, onStall: () => stalls++ });
+
+  wd.arm();
+  // A token just under the threshold, five times over: 4.5s elapsed, never idle
+  // for a full second.
+  for (let i = 0; i < 5; i++) {
+    vi.advanceTimersByTime(900);
+    wd.onEvent(textEvent);
+  }
+  expect(stalls).toBe(0);
+  // Then it goes quiet — now it trips.
+  vi.advanceTimersByTime(1000);
+  expect(stalls).toBe(1);
+});
+
+test("a tool in flight suspends the watchdog; it re-arms only once the tool ends", () => {
+  vi.useFakeTimers();
+  let stalls = 0;
+  const wd = createStallWatchdog({ timeoutMs: 1000, onStall: () => stalls++ });
+
+  wd.arm();
+  wd.onEvent(toolStart("bash"));
+  // A long, legitimately silent build must NOT be aborted.
+  vi.advanceTimersByTime(60_000);
+  expect(stalls).toBe(0);
+  // Tool ends; the provider then stays silent → back to watching → trips.
+  wd.onEvent(toolEnd("bash"));
+  vi.advanceTimersByTime(1000);
+  expect(stalls).toBe(1);
+});
+
+test("parallel tools: re-arms only after the LAST tool ends", () => {
+  vi.useFakeTimers();
+  let stalls = 0;
+  const wd = createStallWatchdog({ timeoutMs: 1000, onStall: () => stalls++ });
+
+  wd.arm();
+  wd.onEvent(toolStart("a"));
+  wd.onEvent(toolStart("b"));
+  wd.onEvent(toolEnd("b"));
+  vi.advanceTimersByTime(5000); // tool "a" still running → no trip
+  expect(stalls).toBe(0);
+  wd.onEvent(toolEnd("a"));
+  vi.advanceTimersByTime(1000);
+  expect(stalls).toBe(1);
+});
+
+test("unbalanced tool_end never drives depth negative or disables the watchdog", () => {
+  vi.useFakeTimers();
+  let stalls = 0;
+  const wd = createStallWatchdog({ timeoutMs: 1000, onStall: () => stalls++ });
+
+  wd.arm();
+  // A stray tool_end (no matching start) must not push depth below zero, which
+  // would leave a later real tool_start unable to suspend the clock.
+  wd.onEvent(toolEnd("ghost"));
+  vi.advanceTimersByTime(1000);
+  expect(stalls).toBe(1);
+});
+
+test("disarm cancels a pending stall", () => {
+  vi.useFakeTimers();
+  let stalls = 0;
+  const wd = createStallWatchdog({ timeoutMs: 1000, onStall: () => stalls++ });
+
+  wd.arm();
+  vi.advanceTimersByTime(500);
+  wd.disarm();
+  vi.advanceTimersByTime(10_000);
+  expect(stalls).toBe(0);
+});
+
+test("a non-positive or non-finite timeout disables the watchdog entirely", () => {
+  vi.useFakeTimers();
+  let stalls = 0;
+  for (const timeoutMs of [0, -1, Number.NaN]) {
+    const wd = createStallWatchdog({ timeoutMs, onStall: () => stalls++ });
+    wd.arm();
+    wd.onEvent(textEvent);
+    vi.advanceTimersByTime(10_000);
+  }
+  expect(stalls).toBe(0);
+});

--- a/packages/runtime/src/session/stall-watchdog.ts
+++ b/packages/runtime/src/session/stall-watchdog.ts
@@ -1,0 +1,71 @@
+import type { WireEvent } from "@houston/runtime-client";
+
+/**
+ * Guards a turn's model round-trip against a provider that goes silent — an SSE
+ * read that never returns another byte and so never resolves `prompt()`.
+ *
+ * pi resolves a turn on success or a provider_error frame, but a stalled stream
+ * resolves NEITHER and emits nothing. pi's SSE reader has no idle timeout (only
+ * its WebSocket transport does), so without an external nudge the turn holds the
+ * per-workspace workdir lock until the OS socket finally dies — 19 minutes in the
+ * production incident, freezing every queued turn on the agent behind it.
+ *
+ * The watchdog is armed for the model round-trip only and reset by every wire
+ * event: a healthy turn streams text/thinking/tool events continuously, so it
+ * never trips; a genuinely silent stream does. Tool execution is EXEMPT — a long
+ * `bash`/build is legitimately silent — so the clock is suspended while ≥1 tool
+ * runs (tracked by `tool_start`/`tool_end`) and re-armed when the last one ends.
+ *
+ * Timer-library-agnostic (plain `setTimeout`/`clearTimeout`) so tests drive it
+ * with fake timers and no live session. `timeoutMs <= 0` (or non-finite) disables
+ * it entirely — a fail-safe: a misconfigured timeout never fires a false abort.
+ */
+export interface StallWatchdog {
+  /** Begin watching (call right before awaiting the model). */
+  arm(): void;
+  /** Feed one wire event: resets the idle clock, tracks tool depth. */
+  onEvent(event: WireEvent): void;
+  /** Stop watching + clear any pending timer (call in a `finally`). Idempotent. */
+  disarm(): void;
+}
+
+export function createStallWatchdog(opts: {
+  timeoutMs: number;
+  /** Fired once when the idle window elapses while armed and no tool is running. */
+  onStall: () => void;
+}): StallWatchdog {
+  const { timeoutMs, onStall } = opts;
+  const enabled = Number.isFinite(timeoutMs) && timeoutMs > 0;
+  let armed = false;
+  let toolDepth = 0;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const clear = () => {
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      timer = undefined;
+    }
+  };
+  // (Re)start the idle clock — unless disabled, disarmed, or a tool is in flight.
+  const reset = () => {
+    clear();
+    if (!enabled || !armed || toolDepth > 0) return;
+    timer = setTimeout(onStall, timeoutMs);
+  };
+
+  return {
+    arm() {
+      armed = true;
+      reset();
+    },
+    onEvent(event) {
+      if (event.type === "tool_start") toolDepth++;
+      else if (event.type === "tool_end" && toolDepth > 0) toolDepth--;
+      reset();
+    },
+    disarm() {
+      armed = false;
+      clear();
+    },
+  };
+}

--- a/packages/runtime/src/session/turn-resilience.test.ts
+++ b/packages/runtime/src/session/turn-resilience.test.ts
@@ -1,0 +1,211 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { WireEvent } from "@houston/runtime-client";
+import { afterEach, expect, test, vi } from "vitest";
+import type {
+  CreateSessionOptions,
+  HarnessBackend,
+  HarnessSession,
+  ResolvedModel,
+} from "../backends/types";
+
+/**
+ * Stalled-provider resilience: a turn whose provider stream goes silent must (a) be
+ * aborted and surfaced as a typed error rather than holding the workdir lock
+ * forever, and (b) its user message must be durable + visible the instant the
+ * turn is accepted, even while another conversation holds the lock.
+ */
+
+// Point config at throwaway dirs + a short stall window BEFORE the module graph
+// loads (config reads env at import; conversation-cache wires backends at load).
+process.env.HOUSTON_DATA_DIR = mkdtempSync(
+  join(tmpdir(), "houston-resilience-data-"),
+);
+process.env.HOUSTON_WORKSPACE_DIR = mkdtempSync(
+  join(tmpdir(), "houston-resilience-ws-"),
+);
+process.env.HOUSTON_TURN_STALL_TIMEOUT_MS = "5000";
+
+const STALL_MS = 5000;
+
+const state = vi.hoisted(() => ({
+  model: null as ResolvedModel | null,
+  provider: null as string | null,
+}));
+vi.mock("../ai/providers", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../ai/providers")>();
+  return {
+    ...real,
+    resolveModel: () => state.model,
+    activeProvider: () => state.provider,
+    activeEffort: () => null,
+  };
+});
+
+// Import AFTER the mocks + env so the backend graph + config use them.
+await import("./conversation-cache");
+const { execTurn } = await import("./exec-turn");
+const { runTurn } = await import("./chat");
+const { subscribe } = await import("./bus");
+const { getHistory } = await import("../store/conversations");
+const { withWorkdirLock } = await import("./workdir-lock");
+const { setDefaultBackend } = await import("../backends/registry");
+const { config } = await import("../config");
+type Conversation = import("./conversation-cache").Conversation;
+
+const OPENAI: ResolvedModel = {
+  provider: "openai-codex",
+  id: "gpt-5-codex",
+  contextWindow: 400_000,
+};
+
+/** A session whose prompt() hangs (a stalled provider stream) until abort() is
+ *  called — pi's own behavior once its request signal fires. Emits nothing. */
+class StallSession implements HarnessSession {
+  aborted = false;
+  private listeners = new Set<(e: WireEvent) => void>();
+  private resolvePrompt: (() => void) | undefined;
+  subscribe(l: (e: WireEvent) => void): () => void {
+    this.listeners.add(l);
+    return () => {
+      this.listeners.delete(l);
+    };
+  }
+  prompt(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.resolvePrompt = resolve;
+    });
+  }
+  async abort(): Promise<void> {
+    this.aborted = true;
+    this.resolvePrompt?.();
+  }
+  dispose(): void {
+    this.listeners.clear();
+  }
+  async setModel(): Promise<void> {}
+  async compact(): Promise<void> {}
+  setThinkingLevel(): void {}
+  getContextUsage(): { tokens: number | null } {
+    return { tokens: 100 };
+  }
+}
+
+/** A trivial session that answers instantly — stands in for a healthy backend so
+ *  runTurn can build a conversation without a network. */
+class QuietSession implements HarnessSession {
+  private listeners = new Set<(e: WireEvent) => void>();
+  subscribe(l: (e: WireEvent) => void): () => void {
+    this.listeners.add(l);
+    return () => {
+      this.listeners.delete(l);
+    };
+  }
+  async prompt(): Promise<void> {}
+  async abort(): Promise<void> {}
+  dispose(): void {
+    this.listeners.clear();
+  }
+  async setModel(): Promise<void> {}
+  async compact(): Promise<void> {}
+  setThinkingLevel(): void {}
+  getContextUsage(): { tokens: number | null } {
+    return { tokens: 0 };
+  }
+}
+
+function convWith(session: HarnessSession): Conversation {
+  return {
+    session,
+    queue: Promise.resolve(),
+    provider: "openai-codex",
+    model: "gpt-5-codex",
+    backendId: "pi",
+  } as unknown as Conversation;
+}
+
+function quietBackend(): HarnessBackend {
+  return {
+    id: "pi",
+    async createSession(_opts: CreateSessionOptions): Promise<HarnessSession> {
+      return new QuietSession();
+    },
+  };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  state.model = null;
+  state.provider = null;
+});
+
+test("a turn whose provider goes silent is aborted at the stall window and surfaces a typed network error, never a clean done", async () => {
+  vi.useFakeTimers();
+  state.model = OPENAI;
+  const session = new StallSession();
+  const conv = convWith(session);
+
+  const events: WireEvent[] = [];
+  const unsub = subscribe("conv-stall", (e) => events.push(e));
+  const done = execTurn(conv, "conv-stall", "turn-1", "hi", {
+    author: undefined,
+    priorAuthors: [],
+  });
+
+  // Let execTurn reach prompt() and arm the watchdog; the stream stays silent.
+  await vi.advanceTimersByTimeAsync(0);
+  expect(session.aborted).toBe(false);
+
+  // Cross the stall window: the watchdog aborts, which unblocks prompt().
+  await vi.advanceTimersByTimeAsync(STALL_MS);
+  await done;
+  unsub();
+
+  expect(session.aborted).toBe(true);
+  const pe = events.find(
+    (e): e is Extract<WireEvent, { type: "provider_error" }> =>
+      e.type === "provider_error",
+  );
+  // A provider-side fault (the socket was live; it went silent), not the user's
+  // connectivity — see the card-copy rationale in exec-turn.ts.
+  expect(pe?.data.kind).toBe("provider_internal");
+  // No false success: the empty turn must NOT settle as done.
+  expect(events.some((e) => e.type === "done")).toBe(false);
+});
+
+test("a queued message is persisted + visible BEFORE the workdir lock frees — a stalled turn on another conversation can't hide it", async () => {
+  state.model = OPENAI;
+  state.provider = "openai-codex";
+  setDefaultBackend(quietBackend());
+
+  // Occupy the shared per-workspace turn lock with a turn that never finishes —
+  // the production incident's stalled routine.
+  let release: (() => void) | undefined;
+  const held = withWorkdirLock(
+    config.workspaceDir,
+    () =>
+      new Promise<void>((r) => {
+        release = r;
+      }),
+  );
+
+  // Start a turn on a DIFFERENT, brand-new conversation. Its user message must
+  // land + become visible immediately, then it blocks on the lock — not the
+  // reverse (which is what made the message vanish for minutes before the fix).
+  const turn = runTurn("conv-visible", "are you there?");
+
+  await vi.waitFor(() => {
+    expect(getHistory("conv-visible")?.messages?.[0]).toMatchObject({
+      role: "user",
+      content: "are you there?",
+    });
+  });
+  // The turn itself is still parked on the lock: user message only, no reply yet.
+  expect(getHistory("conv-visible")?.messages).toHaveLength(1);
+
+  // Release the lock and let the turn settle so nothing leaks into later tests.
+  release?.();
+  await held;
+  await turn.catch(() => {});
+});


### PR DESCRIPTION
## What happened

A message sent from the desktop app disappeared: no echo, no reply, and switching chats showed it gone. It came back ~13 minutes later.

**Root cause.** A routine's model request opened its provider stream and then went silent — no data — for ~19 minutes. pi's SSE reader has **no idle timeout** (only its WebSocket transport enforces one), so `prompt()` never resolved and the turn held the per-workspace turn lock the whole time, freezing every other turn on that agent. And because the **user message is persisted inside that lock**, the message queued behind the stall was never written to disk, so `GET /messages` 404'd and the chat rendered empty until the stall finally cleared.

## The fix (two parts)

**1. Bound the stall — `session/stall-watchdog.ts`.** A tool-aware inactivity watchdog wraps the model round-trip in `execTurn`. If no wire event arrives for `turnStallTimeoutMs` while no tool is running, it aborts the session (which unblocks pi's stalled SSE read via the request signal). Because pi reports that abort as `"aborted"` (silent, like a user Stop), `execTurn` synthesizes a typed `provider_internal` error so the turn surfaces honestly instead of settling as a fake empty success.

- Default **5 min** (`HOUSTON_TURN_STALL_TIMEOUT_MS`, `0` disables) — matches pi's own idle default; deliberately conservative so it never clips a long-reasoning turn that streams no intermediate events. Tool execution is exempt (a long `bash`/build is legitimately silent).
- `provider_internal`, not `network_unreachable`: the socket was live and the provider went silent — a provider-side fault ("try again in a moment"), not the user's connectivity (whose card reads "check your internet").

**2. The message can never disappear again — `recordUserTurn` in `exec-turn.ts` + `chat.ts`.** The user message is now persisted + announced **before** the workdir lock. The transcript is a per-conversation file already ordered by `conv.queue`; it never needed the workspace-wide lock (which only guards concurrent file mutations *between* conversations). So a brand-new conversation's message is durable and visible the instant the turn is accepted, even while another conversation holds the lock in a stalled call.

## Tests

- `session/stall-watchdog.test.ts` — threshold timing, event-resets-clock, tool suspension, parallel/unbalanced tools, disarm, disabled.
- `session/turn-resilience.test.ts` — `execTurn` aborts a silent turn and surfaces `provider_internal` with no `done`; a queued message is visible while another conversation holds the lock.
- Full suite green: runtime + host tests, typecheck, Biome, boundaries.

## Known gaps (follow-ups, not fixed here)

- A stall inside `compact()` (autocompact / provider-switch) isn't covered — pi's `abort()` doesn't cancel its compaction controller.
- The real long-term fix belongs upstream in pi: its SSE reader should honor the idle timeout it already plumbs through for the WebSocket transport.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
