### PR TITLE
fix(release): read Claude SDK version from optionalDependencies (macOS universal build)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -441,7 +441,14 @@ jobs:
       - name: Force-install both macOS Claude SDK platform packages (universal lipo)
         run: |
           set -euo pipefail
-          SDK_VER=$(jq -r '.dependencies["@anthropic-ai/claude-agent-sdk"]' packages/runtime/package.json)
+          # The SDK is pinned under optionalDependencies (the platform binaries
+          # are optional per-arch packages), so read both blocks. Fail hard if
+          # the pin is absent — a null version would silently `pnpm add …@null`.
+          SDK_VER=$(jq -r '.dependencies["@anthropic-ai/claude-agent-sdk"] // .optionalDependencies["@anthropic-ai/claude-agent-sdk"] // ""' packages/runtime/package.json)
+          if [ -z "$SDK_VER" ] || [ "$SDK_VER" = "null" ]; then
+            echo "ERROR: @anthropic-ai/claude-agent-sdk is not pinned in packages/runtime/package.json (.dependencies or .optionalDependencies)" >&2
+            exit 1
+          fi
           echo "Claude Agent SDK version pinned by packages/runtime: $SDK_VER"
           pnpm add -w \
             "@anthropic-ai/claude-agent-sdk-darwin-arm64@$SDK_VER" \


### PR DESCRIPTION
## Problem

The macOS release job's step **"Force-install both macOS Claude SDK platform packages (universal lipo)"** reads the pinned SDK version with:

```bash
SDK_VER=$(jq -r '.dependencies["@anthropic-ai/claude-agent-sdk"]' packages/runtime/package.json)
```

But `@anthropic-ai/claude-agent-sdk` is pinned under **`optionalDependencies`** in `packages/runtime/package.json` (the platform binaries are optional per-arch packages). So `SDK_VER` resolves to the literal string `null`, and the step runs:

```bash
pnpm add -w @anthropic-ai/claude-agent-sdk-darwin-arm64@null @anthropic-ai/claude-agent-sdk-darwin-x64@null --force
```

which fails — taking down the whole macOS universal build.

## Why it wasn't caught earlier

This step was added **after v0.5.0** (PR #675), so it had never executed on a real release. The first tag build to include it (`v0.5.1`) failed on it:

```
build-macos: completed/failure
FAILED STEP: Force-install both macOS Claude SDK platform packages (universal lipo)
```

Every release cut from current `main` would fail the same way.

## Fix

- Read the pin from either `.dependencies` or `.optionalDependencies`.
- Fail loud with a clear message if the pin is ever missing, so a `null` version can't silently poison `pnpm add` again (matches the step's existing "fail hard" intent).

```bash
SDK_VER=$(jq -r '.dependencies["@anthropic-ai/claude-agent-sdk"] // .optionalDependencies["@anthropic-ai/claude-agent-sdk"] // ""' packages/runtime/package.json)
if [ -z "$SDK_VER" ] || [ "$SDK_VER" = "null" ]; then
  echo "ERROR: @anthropic-ai/claude-agent-sdk is not pinned in packages/runtime/package.json (.dependencies or .optionalDependencies)" >&2
  exit 1
fi
```

## Verification

- Simulated the step locally against the real `packages/runtime/package.json` → resolves `SDK_VER=0.3.201`; both `@anthropic-ai/claude-agent-sdk-darwin-{arm64,x64}@0.3.201` exist on the registry.
- `actionlint` reports no new findings on this step; `bash -n` and Ruby YAML parse clean.
- Scope is macOS-only: this is the sole place in `release.yml` that reads the SDK version. Windows/Linux install their runner-native optional package via `pnpm install`.

> Note: the v0.5.1 test build also hit a **separate** Linux `failed to run linuxdeploy` AppImage error (almost certainly transient flakiness; the compile succeeded and v0.5.0's Linux build passed). Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)