### PR TITLE
fix: white kanban resting cards in light mode

### DIFF
--- a/app/src/styles/futuristic.css
+++ b/app/src/styles/futuristic.css
@@ -221,7 +221,7 @@ body {
 
 /* ── 7. Kanban card resting fill ────────────────────────────────
    The resting (non-selected) card uses a palette token, --ht-card-rest:
-   #2C2C2B in dark (sampled from the running card), a soft gray in light.
+   #2C2C2B in dark (sampled from the running card), white in light.
    Solid, not translucent. Running cards use the SAME fill for their
    center (--glow-bg) so every non-selected card reads uniformly — only
    the running card's animated border marks it. Selected/highlighted

--- a/knowledge-base/design-system.md
+++ b/knowledge-base/design-system.md
@@ -226,7 +226,7 @@ those four primitives — no modal should hardcode its own background.
 
 **Primary button** — flat and sober (`[data-variant="default"]:is(button, a)`),
 not a glossy slab. Kanban resting cards use one token, `--ht-card-rest` (`#2c2c2b`
-dark / cool light), unified across resting + running + needs-you.
+dark / white light), unified across resting + running + needs-you.
 
 **Seamless title bar (macOS desktop only)** — `titleBarStyle: "Overlay"` +
 `hiddenTitle`; the content extends to the top so the traffic lights float over

--- a/packages/design-tokens/test/legacy-resolved.json
+++ b/packages/design-tokens/test/legacy-resolved.json
@@ -9,7 +9,7 @@
     "ht-card": "rgba(255, 255, 255, 0.68)",
     "ht-card-hover": "rgba(255, 255, 255, 0.76)",
     "ht-card-fg": "#0d0d0d",
-    "ht-card-rest": "#f4f6fc",
+    "ht-card-rest": "#ffffff",
     "ht-destructive": "#e02e2a",
     "ht-destructive-fg": "#ffffff",
     "ht-foreground": "#14161d",

--- a/packages/design-tokens/tokens/semantic/color.light.json
+++ b/packages/design-tokens/tokens/semantic/color.light.json
@@ -32,7 +32,7 @@
     "warning-fg": { "$value": "{color.base.white}" },
     "highlight": { "$value": "{color.brand.highlight-45}" },
     "highlight-fg": { "$value": "{color.status.highlight-ink-light}" },
-    "card-rest": { "$value": "{color.cool.surface}" },
+    "card-rest": { "$value": "{color.base.white}" },
     "canvas-gutter": { "$value": "{color.cool.gutter}" },
     "canvas-screen": { "$value": "{color.base.white}" },
     "agent": {


### PR DESCRIPTION
## What
Light-mode kanban resting cards rendered with a cool blue tint (`#f4f6fc`). Make them white.

## Why
`--ht-card-rest` mapped to `{color.cool.surface}` (`#f4f6fc`) in light mode. Per the client-surface rule, fixed via a design-token edit — not a hardcoded hex.

## Changes
- `tokens/semantic/color.light.json` — `card-rest` → `{color.base.white}` (`#ffffff`). Dark unchanged (`#2c2c2b`).
- Updated the `zero-diff` regression fixture (required for a deliberate visual change). 94/94 tests pass.
- Refreshed two descriptive comments (design-system KB, `futuristic.css`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)