### PR TITLE
ci(release): bundle frpc in packaged app builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -510,6 +510,30 @@ jobs:
             app/src-tauri/binaries/houston-engine-universal-apple-darwin \
             app/src-tauri/binaries/claude-universal-apple-darwin
 
+      # Fetch the frpc tunnel client (fatedier/frp, Apache-2.0) for both arches
+      # and lipo a universal fat binary, mirroring the host sidecar above.
+      # build.rs::stage_frpc_sidecar also stages per-arch copies during tauri's
+      # per-arch cargo runs, but the `--target universal-apple-darwin` bundle
+      # ships this fat binary at binaries/frpc-universal-apple-darwin. Without it
+      # the local-model tunnel ships a loud-fail placeholder and never connects.
+      - name: Fetch + lipo universal frpc tunnel client (aarch64 + x86_64)
+        run: |
+          set -euo pipefail
+          for TRIPLE in aarch64-apple-darwin x86_64-apple-darwin; do
+            echo "=== fetching frpc for $TRIPLE ==="
+            scripts/fetch-frpc.sh "$TRIPLE"
+            test -x "target/frpc/frpc-$TRIPLE" \
+              || { echo "::error::frpc missing for $TRIPLE"; exit 1; }
+          done
+          mkdir -p app/src-tauri/binaries
+          echo "=== Lipo universal frpc ==="
+          lipo -create \
+            target/frpc/frpc-aarch64-apple-darwin \
+            target/frpc/frpc-x86_64-apple-darwin \
+            -output app/src-tauri/binaries/frpc-universal-apple-darwin
+          chmod +x app/src-tauri/binaries/frpc-universal-apple-darwin
+          lipo -info app/src-tauri/binaries/frpc-universal-apple-darwin
+
       # Build only — no release creation (no tagName).
       # tauri-action handles certificate import, code signing, .app notarization + stapling.
       #
@@ -1104,6 +1128,20 @@ jobs:
             || { echo "::error::host sidecar missing for ${{ matrix.target }}"; exit 1; }
           echo "Sidecar size:"
           ls -lah target/host-sidecar/houston-host-${{ matrix.target }}.exe
+
+      # Fetch the frpc tunnel client (fatedier/frp, Apache-2.0) for the matrix
+      # target BEFORE tauri build. build.rs::stage_frpc_sidecar copies
+      # target/frpc/frpc-<target>.exe to the externalBin name
+      # binaries/frpc-<target>.exe (same pattern as the host sidecar). Without it
+      # the local-model tunnel ships a loud-fail placeholder and never connects.
+      - name: Fetch frpc tunnel client (${{ matrix.target }})
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/fetch-frpc.sh ${{ matrix.target }}
+          test -x "target/frpc/frpc-${{ matrix.target }}.exe" \
+            || { echo "::error::frpc missing for ${{ matrix.target }}"; exit 1; }
+          ls -lah target/frpc/frpc-${{ matrix.target }}.exe
 
       # CLOUD channel only: repoint the updater at `latest-cloud.json` before the
       # build bakes tauri.conf.json in (see build-macos for the why). The script

--- a/scripts/fetch-frpc.sh
+++ b/scripts/fetch-frpc.sh
@@ -23,7 +23,7 @@
 # Supported <rust-triple>:
 #   aarch64-apple-darwin, x86_64-apple-darwin,
 #   x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu,
-#   x86_64-pc-windows-msvc
+#   x86_64-pc-windows-msvc, aarch64-pc-windows-msvc
 #
 # Override the frp version with FRP_VERSION (default below).
 # ============================================================================
@@ -61,6 +61,7 @@ case "$TRIPLE" in
   x86_64-unknown-linux-gnu)   FRP_OS="linux";   FRP_ARCH="amd64"; ARCHIVE_EXT="tar.gz"; BIN="frpc" ;;
   aarch64-unknown-linux-gnu)  FRP_OS="linux";   FRP_ARCH="arm64"; ARCHIVE_EXT="tar.gz"; BIN="frpc" ;;
   x86_64-pc-windows-msvc)     FRP_OS="windows"; FRP_ARCH="amd64"; ARCHIVE_EXT="zip";    BIN="frpc.exe" ;;
+  aarch64-pc-windows-msvc)    FRP_OS="windows"; FRP_ARCH="arm64"; ARCHIVE_EXT="zip";    BIN="frpc.exe" ;;
   *) echo "ERROR: unsupported triple '$TRIPLE'" >&2; exit 1 ;;
 esac
 


### PR DESCRIPTION
Packaged/release app builds shipped a loud-fail `frpc` placeholder, so the local-model tunnel could only work in a dev tree where `fetch-frpc.sh` had been run manually. This wires `fetch-frpc.sh` into the release workflow so the installable app bundles `frpc`.

- **macOS**: fetch both arches + lipo a universal binary at `binaries/frpc-universal-apple-darwin` (mirrors the host sidecar; the `--target universal-apple-darwin` bundle ships the fat binary).
- **Windows**: fetch per matrix target; `build.rs` stages `binaries/frpc-<target>.exe`.
- `fetch-frpc.sh` gains `aarch64-pc-windows-msvc` (the Windows matrix builds arm64; frp v0.69.0 publishes windows_arm64).

`frpc` lands in `binaries/` where tauri-action's deep sign + notarization already reach it. Tested locally: fetch+sha256+lipo verified for all four triples; workflow YAML validates.

This is the last piece so a released app's local-model tunnel works out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)