### PR TITLE
fix(release): bundle a real frpc on every OS, not a dead placeholder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,7 +472,7 @@ jobs:
       # A missing arch would break half of our Mac users, so fail hard. The
       # `claude` binary is large (~232MB/arch → ~470MB universal), so this step
       # dominates disk + build time.
-      - name: Compile Houston host sidecar + stage claude (aarch64 + x86_64) + lipo universal
+      - name: Compile Houston host sidecar + stage claude + frpc (aarch64 + x86_64) + lipo universal
         run: |
           set -euo pipefail
           for TRIPLE in aarch64-apple-darwin x86_64-apple-darwin; do
@@ -502,13 +502,27 @@ jobs:
           chmod +x app/src-tauri/binaries/claude-universal-apple-darwin
           lipo -info app/src-tauri/binaries/claude-universal-apple-darwin
 
+          echo "=== Fetch + lipo universal frpc tunnel client ==="
+          # frpc (fatedier/frp) is a Tauri externalBin; the universal bundle
+          # needs a fat binaries/frpc-universal-apple-darwin, same as the two
+          # above. fetch-frpc.sh SHA256-verifies each per-arch download.
+          scripts/fetch-frpc.sh aarch64-apple-darwin
+          scripts/fetch-frpc.sh x86_64-apple-darwin
+          lipo -create \
+            target/frpc/frpc-aarch64-apple-darwin \
+            target/frpc/frpc-x86_64-apple-darwin \
+            -output app/src-tauri/binaries/frpc-universal-apple-darwin
+          chmod +x app/src-tauri/binaries/frpc-universal-apple-darwin
+          lipo -info app/src-tauri/binaries/frpc-universal-apple-darwin
+
           ls -la \
             target/host-sidecar/houston-host-aarch64-apple-darwin \
             target/host-sidecar/houston-host-x86_64-apple-darwin \
             target/host-sidecar/claude-aarch64-apple-darwin \
             target/host-sidecar/claude-x86_64-apple-darwin \
             app/src-tauri/binaries/houston-engine-universal-apple-darwin \
-            app/src-tauri/binaries/claude-universal-apple-darwin
+            app/src-tauri/binaries/claude-universal-apple-darwin \
+            app/src-tauri/binaries/frpc-universal-apple-darwin
 
       # Build only — no release creation (no tagName).
       # tauri-action handles certificate import, code signing, .app notarization + stapling.
@@ -1113,6 +1127,18 @@ jobs:
         shell: bash
         run: bash scripts/ci/point-updater-at-cloud-manifest.sh
 
+      # frpc is a Tauri externalBin (the local-model bridge tunnel client).
+      # Without a real binary, build.rs stages an exit-1 placeholder and the
+      # shipped tunnel is dead. Fetch the SHA256-verified frpc for this arch so
+      # build.rs stages it as binaries/frpc-${{ matrix.target }}.exe.
+      - name: Fetch frpc tunnel client (${{ matrix.target }})
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/fetch-frpc.sh ${{ matrix.target }}
+          test -f "target/frpc/frpc-${{ matrix.target }}.exe" \
+            || { echo "::error::frpc missing for ${{ matrix.target }}"; exit 1; }
+
       - name: Build Tauri app (Windows MSI)
         uses: tauri-apps/tauri-action@v0
         with:
@@ -1350,6 +1376,17 @@ jobs:
       # they pass the key and feed latest.json.
       - name: Disable updater artifacts (Linux is download-only)
         run: bash scripts/ci/configure-ts-engine-unsigned.sh
+
+      # frpc is a Tauri externalBin (the local-model bridge tunnel client). The
+      # exit-1 placeholder build.rs stages when frpc is absent is not an ELF, so
+      # linuxdeploy's ldd pass aborts the AppImage bundling. Fetch the real,
+      # SHA256-verified frpc so build.rs stages binaries/frpc-x86_64-unknown-linux-gnu.
+      - name: Fetch frpc tunnel client (x86_64-unknown-linux-gnu)
+        run: |
+          set -euo pipefail
+          scripts/fetch-frpc.sh x86_64-unknown-linux-gnu
+          test -f target/frpc/frpc-x86_64-unknown-linux-gnu \
+            || { echo "::error::frpc missing for x86_64-unknown-linux-gnu"; exit 1; }
 
       - name: Build Tauri app (Linux AppImage)
         uses: tauri-apps/tauri-action@v0

--- a/scripts/fetch-frpc.sh
+++ b/scripts/fetch-frpc.sh
@@ -23,7 +23,7 @@
 # Supported <rust-triple>:
 #   aarch64-apple-darwin, x86_64-apple-darwin,
 #   x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu,
-#   x86_64-pc-windows-msvc
+#   x86_64-pc-windows-msvc, aarch64-pc-windows-msvc
 #
 # Override the frp version with FRP_VERSION (default below).
 # ============================================================================
@@ -61,6 +61,7 @@ case "$TRIPLE" in
   x86_64-unknown-linux-gnu)   FRP_OS="linux";   FRP_ARCH="amd64"; ARCHIVE_EXT="tar.gz"; BIN="frpc" ;;
   aarch64-unknown-linux-gnu)  FRP_OS="linux";   FRP_ARCH="arm64"; ARCHIVE_EXT="tar.gz"; BIN="frpc" ;;
   x86_64-pc-windows-msvc)     FRP_OS="windows"; FRP_ARCH="amd64"; ARCHIVE_EXT="zip";    BIN="frpc.exe" ;;
+  aarch64-pc-windows-msvc)    FRP_OS="windows"; FRP_ARCH="arm64"; ARCHIVE_EXT="zip";    BIN="frpc.exe" ;;
   *) echo "ERROR: unsupported triple '$TRIPLE'" >&2; exit 1 ;;
 esac
 
@@ -104,7 +105,13 @@ echo "  sha256 OK"
 # Extract only the frpc binary.
 echo "  extracting ${BIN}…"
 if [ "$ARCHIVE_EXT" = "zip" ]; then
-  unzip -q -o "$TMP/$ASSET" "${INNER_DIR}/${BIN}" -d "$TMP"
+  # Windows runners don't always ship `unzip`; bsdtar (`tar`, built into
+  # Windows 10+) can extract a single member from a zip, so fall back to it.
+  if command -v unzip >/dev/null 2>&1; then
+    unzip -q -o "$TMP/$ASSET" "${INNER_DIR}/${BIN}" -d "$TMP"
+  else
+    tar -xf "$TMP/$ASSET" -C "$TMP" "${INNER_DIR}/${BIN}"
+  fi
 else
   tar -xzf "$TMP/$ASSET" -C "$TMP" "${INNER_DIR}/${BIN}"
 fi


### PR DESCRIPTION
## Problem

`frpc` (the [fatedier/frp](https://github.com/fatedier/frp) tunnel client the desktop **local-model bridge** spawns to publish a user's locally-running model to a cloud agent at `https://<subdomain>.tunnels.gethouston.ai`) became a Tauri `externalBin` in commit `82299d97` — but the release pipeline was **never taught to fetch it**. `release.yml` had zero `frpc` handling, so `build.rs` staged its exit-1 shell-script placeholder on every platform:

- **macOS** (universal) hard-failed bundling — no `binaries/frpc-universal-apple-darwin` (nothing lipo'd it, unlike `houston-engine`/`claude`).
- **Linux** hard-failed — the placeholder is a shell script, not an ELF, so `linuxdeploy`'s `ldd` pass aborted the AppImage.
- **Windows** built green but shipped a **non-functional** tunnel (the placeholder).

Net: the local-model→cloud tunnel worked in **zero** release builds. This surfaced when the v0.5.1 test tag's macOS job failed at `resource path binaries/frpc-universal-apple-darwin doesn't exist` (after #711 cleared the earlier SDK-version failure), and Linux failed identically twice at `failed to run linuxdeploy`.

At v0.5.0 `externalBin` was just `["binaries/houston-engine"]`, which is why v0.5.0 built cleanly on all three.

## Fix

Wire the existing, SHA256-verifying `scripts/fetch-frpc.sh` into all three build jobs so `build.rs` stages a real `frpc` instead of the placeholder:

- **macOS**: fetch both darwin arches and `lipo` `binaries/frpc-universal-apple-darwin` (mirrors the `houston-engine` + `claude` universal handling in the same step).
- **Linux**: fetch `x86_64-unknown-linux-gnu` so `linuxdeploy` gets a real ELF.
- **Windows**: fetch per matrix arch (x64 + arm64).

Plus in `fetch-frpc.sh`:
- Add the `aarch64-pc-windows-msvc` triple (frp publishes `frp_*_windows_arm64.zip`), so Windows arm64 ships a real tunnel too.
- Fall back to `bsdtar` when a Windows runner lacks `unzip`.

Each fetch step is `set -euo pipefail` + a `test -f`, so the build **fails hard** if `frpc` can't be staged — we never silently ship the placeholder again (beta no-silent-failures policy).

## Verification

Run locally on macOS (the exact command sequence the workflow uses):
- `fetch-frpc.sh aarch64-apple-darwin` + `x86_64-apple-darwin` → both SHA256-verify; `lipo -create` yields a universal Mach-O (`x86_64 arm64`) that **runs** and reports `0.69.0`.
- New `fetch-frpc.sh aarch64-pc-windows-msvc` → downloads `frp_0.69.0_windows_arm64.zip`, SHA256-verifies, extracts a valid `PE32+ Aarch64` `frpc.exe`.
- `build.rs` reads `target/frpc/frpc-<TARGET>` (repo-root target), the exact path `fetch-frpc.sh` writes — confirmed the placeholder is replaced.
- `actionlint` finding count unchanged (12 pre-existing info/style, none on the new steps); Ruby YAML parses.

> Linux's `linuxdeploy` path can't be exercised without CI; the diagnosis (placeholder shell-script vs. real ELF, given the pre-existing `ldd` shim is for the self-contained sidecar) is strong but may need a CI round-trip to fully confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)