### PR TITLE
fix(release): de-duplicate the frpc fetch steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -472,7 +472,7 @@ jobs:
       # A missing arch would break half of our Mac users, so fail hard. The
       # `claude` binary is large (~232MB/arch → ~470MB universal), so this step
       # dominates disk + build time.
-      - name: Compile Houston host sidecar + stage claude + frpc (aarch64 + x86_64) + lipo universal
+      - name: Compile Houston host sidecar + stage claude (aarch64 + x86_64) + lipo universal
         run: |
           set -euo pipefail
           for TRIPLE in aarch64-apple-darwin x86_64-apple-darwin; do
@@ -502,27 +502,13 @@ jobs:
           chmod +x app/src-tauri/binaries/claude-universal-apple-darwin
           lipo -info app/src-tauri/binaries/claude-universal-apple-darwin
 
-          echo "=== Fetch + lipo universal frpc tunnel client ==="
-          # frpc (fatedier/frp) is a Tauri externalBin; the universal bundle
-          # needs a fat binaries/frpc-universal-apple-darwin, same as the two
-          # above. fetch-frpc.sh SHA256-verifies each per-arch download.
-          scripts/fetch-frpc.sh aarch64-apple-darwin
-          scripts/fetch-frpc.sh x86_64-apple-darwin
-          lipo -create \
-            target/frpc/frpc-aarch64-apple-darwin \
-            target/frpc/frpc-x86_64-apple-darwin \
-            -output app/src-tauri/binaries/frpc-universal-apple-darwin
-          chmod +x app/src-tauri/binaries/frpc-universal-apple-darwin
-          lipo -info app/src-tauri/binaries/frpc-universal-apple-darwin
-
           ls -la \
             target/host-sidecar/houston-host-aarch64-apple-darwin \
             target/host-sidecar/houston-host-x86_64-apple-darwin \
             target/host-sidecar/claude-aarch64-apple-darwin \
             target/host-sidecar/claude-x86_64-apple-darwin \
             app/src-tauri/binaries/houston-engine-universal-apple-darwin \
-            app/src-tauri/binaries/claude-universal-apple-darwin \
-            app/src-tauri/binaries/frpc-universal-apple-darwin
+            app/src-tauri/binaries/claude-universal-apple-darwin
 
       # Fetch the frpc tunnel client (fatedier/frp, Apache-2.0) for both arches
       # and lipo a universal fat binary, mirroring the host sidecar above.
@@ -1164,18 +1150,6 @@ jobs:
         if: ${{ env.IS_CLOUD == 'true' }}
         shell: bash
         run: bash scripts/ci/point-updater-at-cloud-manifest.sh
-
-      # frpc is a Tauri externalBin (the local-model bridge tunnel client).
-      # Without a real binary, build.rs stages an exit-1 placeholder and the
-      # shipped tunnel is dead. Fetch the SHA256-verified frpc for this arch so
-      # build.rs stages it as binaries/frpc-${{ matrix.target }}.exe.
-      - name: Fetch frpc tunnel client (${{ matrix.target }})
-        shell: bash
-        run: |
-          set -euo pipefail
-          scripts/fetch-frpc.sh ${{ matrix.target }}
-          test -f "target/frpc/frpc-${{ matrix.target }}.exe" \
-            || { echo "::error::frpc missing for ${{ matrix.target }}"; exit 1; }
 
       - name: Build Tauri app (Windows MSI)
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
## Why

Two fixes for the same problem (frpc never bundled by the release pipeline) landed back-to-back:

- `09b906a0` — *ci(release): bundle the frpc tunnel client in packaged app builds*
- #714 — *fix(release): bundle a real frpc on every OS, not a dead placeholder*

#714 was branched before `09b906a0` merged, so it squashed on top of it. Result: **macOS and Windows each ended up with two frpc fetch/lipo steps.** It still builds (the fetches are idempotent — each just overwrites the same `binaries/frpc-*`), but it downloads frpc twice per platform and clutters the jobs.

## What

Keep exactly one frpc path per platform:

| Platform | Kept | Dropped |
|----------|------|---------|
| macOS | dedicated `Fetch + lipo universal frpc` step (`09b906a0`) | the copy #714 folded into the sidecar-compile step |
| Windows | guarded fetch step (`09b906a0`) | #714's duplicate fetch step |
| Linux | #714's fetch step | — (`09b906a0` never added one; this is the only thing that unbroke the AppImage) |

`scripts/fetch-frpc.sh` already merged cleanly across the two PRs (the `windows_arm64` case + the `bsdtar`-when-no-`unzip` fallback), so it's untouched here.

## Verification

- Exactly one frpc fetch per platform after the change (grep-confirmed): macOS Julian-step, Windows matrix, Linux x86_64.
- `actionlint` finding count unchanged (12 pre-existing info/style); Ruby YAML parses.
- Net effect is removal of redundant work only — the bundled `frpc` binaries are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)