### PR TITLE
fix(release): teach the AppImage ldd shim about the claude + frpc externalBins

### DIFF
--- a/scripts/ci/appimage-ldd-shim.sh
+++ b/scripts/ci/appimage-ldd-shim.sh
@@ -3,24 +3,28 @@
 # the Linux CI job).
 #
 # linuxdeploy runs `ldd` on every ELF in the AppDir to discover the shared
-# libraries it must bundle. Our externalBin sidecar `houston-engine` is a
-# self-contained Bun-compiled binary; `ldd` cannot trace it (it ends up executing
-# the binary, which does not honour LD_TRACE_LOADED_OBJECTS and exits non-zero),
-# so linuxdeploy aborts with:
+# libraries it must bundle. Three of our externalBins can't be traced by `ldd`
+# and make it exit non-zero, which aborts the whole bundle with:
 #     terminate called after throwing an instance of 'std::runtime_error'
 #       what():  Failed to run ldd: exited with code 1
+#   * houston-engine — self-contained Bun-compiled sidecar; `ldd` ends up
+#     executing it, it ignores LD_TRACE_LOADED_OBJECTS and exits non-zero.
+#   * claude         — self-contained Claude Code binary, same story.
+#   * frpc           — static Go binary; `ldd` prints "not a dynamic executable"
+#     and exits 1.
 #
-# The sidecar bundles its own runtime and only needs the ordinary system libc at
-# runtime, so it has NO libraries for linuxdeploy to deploy. Report it as "not a
-# dynamic executable" with a success exit so linuxdeploy deploys nothing for it
-# and moves on, and defer to the real ldd for every other file (so genuine
-# library resolution is unaffected).
+# All three bundle their own runtime (or are static) and only need the ordinary
+# system libc, so they have NO libraries for linuxdeploy to deploy. Report each
+# as "not a dynamic executable" with a success exit so linuxdeploy deploys
+# nothing for them and moves on, and defer to the real ldd for every other file
+# (so genuine library resolution is unaffected). Any future self-contained
+# externalBin must be added to the match below.
 set -euo pipefail
 
 for arg in "$@"; do
   case "$arg" in
     -*) continue ;; # flags such as --version / --help
-    *houston-engine*)
+    *houston-engine* | *claude* | *frpc*)
       printf '\tnot a dynamic executable\n'
       exit 0
       ;;


### PR DESCRIPTION
## Problem

The Linux AppImage build fails at bundling — `failed to run linuxdeploy` — on every `v0.5.1` tag, even after #714 fetched a real `frpc`.

`linuxdeploy` runs `ldd` on every externalBin in the AppDir to find libraries to bundle. `scripts/ci/appimage-ldd-shim.sh` exists precisely because `ldd` can't trace a self-contained binary (it executes it, gets a non-zero exit), which aborts linuxdeploy with `Failed to run ldd: exited with code 1`. But the shim only rewrote `ldd` for **`houston-engine`**.

Commit `82299d97` added **two more** externalBins the shim never learned about:
- **`claude`** — self-contained Claude Code binary (~230 MB); `ldd` executes it → non-zero.
- **`frpc`** — static Go binary; `ldd` prints "not a dynamic executable" → exits 1.

Either one aborts linuxdeploy. This is why **v0.5.0 passed** (only `houston-engine` was an externalBin then) but every **v0.5.1** run failed Linux.

## Fix

Extend the shim's match from `*houston-engine*` to `*houston-engine* | *claude* | *frpc*`, so linuxdeploy deploys nothing for these self-contained/static binaries and moves on — still deferring to the real `ldd` for genuine libraries (design intent preserved). Added a note that any future self-contained externalBin must be added here.

## Verification

- `bash -n` clean.
- Behavioral test: paths containing `houston-engine`, `claude`, `frpc` all return `\tnot a dynamic executable` + exit 0; other paths (`/bin/ls`) and flags (`--version`) still `exec` the real `/usr/bin/ldd`.

> tauri suppresses linuxdeploy's stderr (the log jumps straight from "Bundling" to "failed to run linuxdeploy"), so this is diagnosed from the shim's own documented failure mode + the v0.5.0-vs-v0.5.1 externalBin differential, not a captured error line. The prior tag build already proved **macOS + Windows (x64 + arm64) go green** with the frpc fixes; this is the last platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)