### PR TITLE
feat(protocol): PendingInteraction foundation for first-class user interactions

### DIFF
--- a/app/src/components/mission-board-columns.ts
+++ b/app/src/components/mission-board-columns.ts
@@ -13,7 +13,7 @@ interface MissionBoardColumnLabels {
 const COLUMN_STATUSES = {
   running: ["running"],
   needs_you: ["needs_you", "error"],
-  done: ["done", "cancelled"],
+  done: ["done"],
 } as const;
 
 export function buildMissionBoardColumns(

--- a/app/src/data/activity.ts
+++ b/app/src/data/activity.ts
@@ -5,6 +5,7 @@
  * Written atomically on every mutation (the backend handles the temp-file + rename).
  */
 
+import type { PendingInteraction } from "@houston/protocol";
 import schema from "@houston-ai/agent-schemas/activity.schema.json";
 import { applyBulkPatch, applyBulkRemove, applyRemove } from "./activity-bulk";
 import { newId, now, readAgentJson, writeAgentJson } from "./agent-file";
@@ -33,6 +34,7 @@ export interface Activity {
   updated_at?: string;
   provider?: string;
   model?: string;
+  pending_interaction?: PendingInteraction;
 }
 
 export interface ActivityUpdate {

--- a/app/tests/mission-board-columns.test.ts
+++ b/app/tests/mission-board-columns.test.ts
@@ -28,7 +28,7 @@ describe("mission board columns", () => {
           label: "Needs you",
           statuses: ["needs_you", "error"],
         },
-        { id: "done", label: "Done", statuses: ["done", "cancelled"] },
+        { id: "done", label: "Done", statuses: ["done"] },
       ],
     );
     strictEqual(columns[0].onAdd, openNewMission);

--- a/packages/domain/src/activities.ts
+++ b/packages/domain/src/activities.ts
@@ -1,4 +1,9 @@
-import type { Activity, ActivityUpdate, NewActivity } from "@houston/protocol";
+import type {
+  Activity,
+  ActivityUpdate,
+  NewActivity,
+  PendingInteraction,
+} from "@houston/protocol";
 import { docKey } from "./layout";
 import {
   type DocDiagnostic,
@@ -18,6 +23,15 @@ export const ACTIVITY_STATUSES = [
 
 const isRecord = (v: unknown): v is Record<string, unknown> =>
   typeof v === "object" && v !== null && !Array.isArray(v);
+
+/** Validate the pending_interaction discriminated union (mirrors the schema):
+ *  a `question` needs a `question` string, a `connect` needs a `toolkit`. */
+const isValidPendingInteraction = (v: unknown): v is PendingInteraction => {
+  if (!isRecord(v)) return false;
+  if (v.kind === "question") return typeof v.question === "string";
+  if (v.kind === "connect") return typeof v.toolkit === "string";
+  return false;
+};
 
 /**
  * Normalize a raw activity array (agents write this file with file tools, so
@@ -45,7 +59,18 @@ export function normalizeActivities(
       typeof entry.title === "string" &&
       typeof entry.status === "string"
     ) {
-      items.push({ description: "", ...entry } as Activity);
+      const activity = { description: "", ...entry } as Activity;
+      if (
+        entry.pending_interaction !== undefined &&
+        !isValidPendingInteraction(entry.pending_interaction)
+      ) {
+        delete activity.pending_interaction;
+        diagnostics.push({
+          key,
+          message: `dropped invalid pending_interaction on activity ${entry.id}: ${JSON.stringify(entry.pending_interaction)?.slice(0, 120)}`,
+        });
+      }
+      items.push(activity);
     } else {
       diagnostics.push({
         key,
@@ -99,10 +124,17 @@ export function applyActivityUpdate(
   update: ActivityUpdate,
   nowIso: string,
 ): Activity {
+  const { pending_interaction, ...rest } = update;
   const defined = Object.fromEntries(
-    Object.entries(update).filter(([, v]) => v !== undefined),
+    Object.entries(rest).filter(([, v]) => v !== undefined),
   );
-  return { ...current, ...defined, updated_at: nowIso } as Activity;
+  const next = { ...current, ...defined, updated_at: nowIso } as Activity;
+  if (pending_interaction === null) {
+    delete next.pending_interaction;
+  } else if (pending_interaction !== undefined) {
+    next.pending_interaction = pending_interaction;
+  }
+  return next;
 }
 
 export function upsertById<T extends { id: string }>(items: T[], item: T): T[] {

--- a/packages/domain/src/domain.test.ts
+++ b/packages/domain/src/domain.test.ts
@@ -4,6 +4,7 @@ import {
   applyActivityUpdate,
   createActivity,
   loadActivities,
+  normalizeActivities,
   removeById,
   saveActivities,
   upsertById,
@@ -93,6 +94,85 @@ test("activity update: undefined leaves fields alone, updated_at bumps", () => {
   expect(next.status).toBe("done");
   expect(next.title).toBe("T");
   expect(next.updated_at).toBe(NOW);
+});
+
+test("normalize: a valid pending_interaction survives, an invalid one is stripped with a diagnostic", () => {
+  const { items, diagnostics } = normalizeActivities(
+    [
+      {
+        id: "q",
+        title: "Ask",
+        status: "needs_you",
+        description: "",
+        pending_interaction: {
+          kind: "question",
+          question: "Which deck?",
+          options: [{ id: "q2", label: "Q2" }],
+        },
+      },
+      {
+        id: "c",
+        title: "Connect",
+        status: "needs_you",
+        description: "",
+        pending_interaction: { kind: "connect", toolkit: "gmail" },
+      },
+      {
+        id: "bad",
+        title: "Broken",
+        status: "needs_you",
+        description: "",
+        // missing the required `question` for kind=question
+        pending_interaction: { kind: "question" },
+      },
+    ],
+    "k",
+  );
+
+  expect(items.map((a) => a.id)).toEqual(["q", "c", "bad"]); // activity kept, only the field dropped
+  expect(items[0]?.pending_interaction).toEqual({
+    kind: "question",
+    question: "Which deck?",
+    options: [{ id: "q2", label: "Q2" }],
+  });
+  expect(items[1]?.pending_interaction).toEqual({
+    kind: "connect",
+    toolkit: "gmail",
+  });
+  expect(items[2]?.pending_interaction).toBeUndefined();
+  expect(diagnostics).toHaveLength(1);
+  expect(diagnostics[0]?.message).toContain("pending_interaction");
+});
+
+test("activity update: pending_interaction set / clear / untouched", () => {
+  const withInteraction = applyActivityUpdate(
+    createActivity({ title: "T" }, "a1", NOW),
+    { pending_interaction: { kind: "connect", toolkit: "slack" } },
+    NOW,
+  );
+  expect(withInteraction.pending_interaction).toEqual({
+    kind: "connect",
+    toolkit: "slack",
+  });
+
+  // undefined leaves the current interaction alone
+  const untouched = applyActivityUpdate(
+    withInteraction,
+    { status: "running" },
+    NOW,
+  );
+  expect(untouched.pending_interaction).toEqual({
+    kind: "connect",
+    toolkit: "slack",
+  });
+
+  // explicit null clears the field entirely (not stored as null)
+  const cleared = applyActivityUpdate(
+    withInteraction,
+    { pending_interaction: null },
+    NOW,
+  );
+  expect("pending_interaction" in cleared).toBe(false);
 });
 
 test("upsert/remove by id", () => {

--- a/packages/protocol/src/domain/activity.ts
+++ b/packages/protocol/src/domain/activity.ts
@@ -2,6 +2,8 @@
 // .houston schemas (ui/agent-schemas) — files-first: the wire mirrors disk.
 // `claude_session_id` is a legacy field name baked into user data; it stays.
 
+import type { PendingInteraction } from "./interaction";
+
 export interface Activity {
   id: string;
   title: string;
@@ -16,6 +18,9 @@ export interface Activity {
   updated_at?: string;
   provider?: string;
   model?: string;
+  /** The one thing this mission is waiting on the user for, if any. Present
+   *  drives the `needs_you` card; absent means the mission needs nothing. */
+  pending_interaction?: PendingInteraction;
 }
 
 export interface ActivityUpdate {
@@ -30,6 +35,8 @@ export interface ActivityUpdate {
   routine_run_id?: string;
   provider?: string;
   model?: string;
+  /** Set to record a new pending interaction; `null` clears it explicitly. */
+  pending_interaction?: PendingInteraction | null;
 }
 
 export interface NewActivity {

--- a/packages/protocol/src/domain/interaction.test.ts
+++ b/packages/protocol/src/domain/interaction.test.ts
@@ -1,0 +1,17 @@
+import { expectTypeOf, test } from "vitest";
+import type { PendingInteraction } from "../index";
+
+test("the protocol index re-exports PendingInteraction", () => {
+  const question: PendingInteraction = {
+    kind: "question",
+    question: "Which slide deck?",
+    options: [{ id: "q2", label: "Q2 review" }],
+  };
+  const connect: PendingInteraction = { kind: "connect", toolkit: "gmail" };
+
+  expectTypeOf(question).toMatchTypeOf<PendingInteraction>();
+  expectTypeOf(connect).toMatchTypeOf<PendingInteraction>();
+  // @ts-expect-error — `kind` is the discriminant; other values are not assignable
+  const bad: PendingInteraction = { kind: "unknown" };
+  void bad;
+});

--- a/packages/protocol/src/domain/interaction.ts
+++ b/packages/protocol/src/domain/interaction.ts
@@ -1,0 +1,14 @@
+// A pending interaction: the one thing a mission is waiting on the user for.
+// Recorded when the model calls ask_user / request_connection; carried on the
+// terminal `done` wire frame and persisted on the Activity so the board card
+// settles to `needs_you` (present) vs `done` (absent) and the UI can render a
+// composer-replacing card.
+
+export interface InteractionOption {
+  id: string;
+  label: string;
+}
+
+export type PendingInteraction =
+  | { kind: "question"; question: string; options?: InteractionOption[] }
+  | { kind: "connect"; toolkit: string; reason?: string };

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -4,6 +4,7 @@ export * from "./conversation";
 export * from "./core";
 export * from "./domain/activity";
 export * from "./domain/config";
+export * from "./domain/interaction";
 export * from "./domain/portable";
 export * from "./domain/routine";
 export * from "./domain/skill";

--- a/packages/protocol/src/wire.ts
+++ b/packages/protocol/src/wire.ts
@@ -5,6 +5,7 @@
  */
 
 import type { TokenUsage } from "./conversation";
+import type { PendingInteraction } from "./domain/interaction";
 import type { ProviderError } from "./provider-error";
 
 /**
@@ -125,7 +126,19 @@ export type WireEvent =
       type: "file_changes";
       data: { created: string[]; modified: string[] };
     }
-  | { type: "done"; data: null }
+  | {
+      /**
+       * The turn ended normally. `pendingInteraction` is present only when the
+       * model finished by asking the user for something (ask_user /
+       * request_connection) — the turn settles the board card to `needs_you`
+       * and carries the interaction to render; absent means the card settles to
+       * `done`. Also persisted on the turn's assistant `ChatMessage` so it
+       * survives a reload.
+       */
+      type: "done";
+      data: null;
+      pendingInteraction?: PendingInteraction;
+    }
   | { type: "error"; data: { message: string } };
 
 export type WireEventType = WireEvent["type"];

--- a/ui/agent-schemas/src/activity.schema.json
+++ b/ui/agent-schemas/src/activity.schema.json
@@ -22,7 +22,39 @@
       "routine_run_id": { "type": "string" },
       "updated_at": { "type": "string", "format": "date-time" },
       "provider": { "type": "string" },
-      "model": { "type": "string" }
+      "model": { "type": "string" },
+      "pending_interaction": {
+        "type": "object",
+        "description": "The one thing this mission is waiting on the user for.",
+        "required": ["kind"],
+        "properties": {
+          "kind": { "type": "string", "enum": ["question", "connect"] },
+          "question": { "type": "string" },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "required": ["id", "label"],
+              "properties": {
+                "id": { "type": "string" },
+                "label": { "type": "string" }
+              }
+            }
+          },
+          "toolkit": { "type": "string" },
+          "reason": { "type": "string" }
+        },
+        "oneOf": [
+          {
+            "properties": { "kind": { "const": "question" } },
+            "required": ["question"]
+          },
+          {
+            "properties": { "kind": { "const": "connect" } },
+            "required": ["toolkit"]
+          }
+        ]
+      }
     },
     "additionalProperties": false
   }


### PR DESCRIPTION
## What

Element 1 of the interaction refactor: make "the model needs the user" a first-class, structured concept instead of a prose convention.

- New `PendingInteraction` type in `@houston/protocol` (`question` | `connect`), exported from the package index.
- Terminal `done` wire frame gains optional `pendingInteraction`.
- `Activity` persists optional `pending_interaction` (JSON schema + domain `normalizeActivities`/`applyActivityUpdate` + app-side mirror). `null` in an update clears it.
- No new status values; `ACTIVITY_STATUSES` unchanged.
- Cleanup: removed phantom `"cancelled"` from the done column mapping (nothing ever writes it to an Activity).

## Why

Today every finished turn settles to `needs_you`, whether the model asked something or simply finished. Upcoming elements add `ask_user`/`request_connection` runtime tools that record a `PendingInteraction`; turns with one settle to `needs_you`, turns without settle to `done`, and the UI renders the interaction as a composer-replacing card.

Follow-ups: runtime tools (element 2), SDK settle split (element 3), app/UI cards + labels (element 4).

## Tests

- `@houston/protocol` vitest 18 passed (new `interaction.test.ts` incl. type-level export check)
- `@houston/domain` vitest 92 passed (new normalize/apply pending_interaction tests)
- `@houston/host` vitest 624 passed
- `app/tests/mission-board-columns.test.ts` updated + passing
- Typecheck green across protocol, domain, host, sdk, fake-host, runtime-client, web, app; biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)