### PR TITLE
fix(tests): update stale tests for the runtime-hydrated model catalog

### DIFF
--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -16,7 +16,6 @@
   "card": {
     "connect": "Connect",
     "connecting": "Connecting",
-    "seeMore": "See more",
     "connected": "Connected",
     "signOut": "Sign out",
     "cancel": "Cancel",

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -16,7 +16,6 @@
   "card": {
     "connect": "Conectar",
     "connecting": "Conectando",
-    "seeMore": "Ver más",
     "connected": "Conectado",
     "signOut": "Cerrar sesión",
     "cancel": "Cancelar",

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -16,7 +16,6 @@
   "card": {
     "connect": "Conectar",
     "connecting": "Conectando",
-    "seeMore": "Ver mais",
     "connected": "Conectado",
     "signOut": "Sair",
     "cancel": "Cancelar",

--- a/app/tests/agent-admin-model-ceiling.test.ts
+++ b/app/tests/agent-admin-model-ceiling.test.ts
@@ -1,7 +1,45 @@
 import { deepStrictEqual, ok, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
+import type { ProviderCatalog } from "@houston/protocol";
 import { modelCatalog } from "../src/components/tabs/agent-admin/agent-admin-models-catalog.ts";
 import { ceilingValue } from "../src/components/tabs/agent-admin/agent-admin-row-values.ts";
+import { hydrateProviderCatalog } from "../src/lib/providers.ts";
+
+// The model catalog is runtime-hydrated from the host's GET /v1/catalog (#701):
+// `PROVIDERS` seeds with empty model lists, so `modelCatalog()` is empty until
+// `hydrateProviderCatalog` runs. Feed a minimal catalog matching the real
+// payload shape (`ProviderCatalog`) so the picker source has models to expose.
+const CATALOG_FIXTURE: ProviderCatalog = [
+  {
+    id: "anthropic",
+    name: "Anthropic",
+    auth: "oauth",
+    models: [
+      {
+        id: "claude-opus-4-8",
+        name: "Claude Opus 4.8",
+        pricing: { input: 15, output: 75 },
+        contextWindow: 200_000,
+        maxTokens: 64_000,
+        reasoning: true,
+        vision: true,
+        thinkingLevels: ["low", "medium", "high"],
+      },
+      {
+        id: "claude-sonnet-4-6",
+        name: "Claude Sonnet 4.6",
+        pricing: { input: 3, output: 15 },
+        contextWindow: 200_000,
+        maxTokens: 64_000,
+        reasoning: true,
+        vision: true,
+        thinkingLevels: ["low", "medium", "high"],
+      },
+    ],
+  },
+];
+
+hydrateProviderCatalog(CATALOG_FIXTURE);
 
 describe("ceilingValue — inline row state for a ceiling", () => {
   it("undefined (loading / non-Teams host) yields null → show no value yet", () => {

--- a/packages/web/e2e/ai-hub.spec.ts
+++ b/packages/web/e2e/ai-hub.spec.ts
@@ -2,13 +2,13 @@ import { expect, test } from "./support/fixtures";
 
 /**
  * The AI models hub, end to end against the fake host. The marketplace shows the
- * capability-visible provider cards and the directory holds their models. Cards
- * are not whole-card clickable: a "See more" button opens the provider MODAL,
- * which now embeds the same models ledger (search + table) as the Models tab.
- * Flow: sidebar nav → provider grid → "See more" opens the provider modal →
- * Escape closes → Models tab → search → a row opens the model MODAL ("Get it
- * through" offers) → Escape closes. OAuth is never driven (no credentials in the
- * harness); we assert presence + the modal open/close flow only.
+ * capability-visible provider rows and the directory holds their models. The
+ * provider row itself is the open affordance: clicking the row opens the provider
+ * MODAL, which embeds the same models ledger (search + table) as the Models tab.
+ * Flow: sidebar nav → provider list → click a provider row opens the provider
+ * modal → Escape closes → Models tab → search → a row opens the model MODAL ("Get
+ * it through" offers) → Escape closes. OAuth is never driven (no credentials in
+ * the harness); we assert presence + the modal open/close flow only.
  */
 test("opens the AI hub, browses providers and models via modals", async ({
   page,
@@ -22,15 +22,16 @@ test("opens the AI hub, browses providers and models via modals", async ({
   await expect(page.getByRole("tab", { name: "Providers" })).toBeVisible();
   await expect(page.getByRole("tab", { name: /Models/ })).toBeVisible();
 
-  // Cards render with always-visible footer actions (no hover gate): every card
-  // has a "See more", available providers also a "Connect".
+  // Provider rows render as focusable role="button" bodies (no hover gate); the
+  // accessible name leads with the provider name. The Connect / Sign out action
+  // lives inside the row but stops propagation, so it never doubles as the open.
   await expect(page.getByText("Anthropic").first()).toBeVisible();
-  const seeMore = page.getByRole("button", { name: "See more" }).first();
-  await expect(seeMore).toBeVisible();
+  const providerRow = page.getByRole("button", { name: /Anthropic/ }).first();
+  await expect(providerRow).toBeVisible();
 
-  // "See more" opens the provider MODAL: a Radix dialog that embeds the shared
-  // models ledger (its own search box), not a full-page drill-in.
-  await seeMore.click();
+  // Clicking the row opens the provider MODAL: a Radix dialog that embeds the
+  // shared models ledger (its own search box), not a full-page drill-in.
+  await providerRow.click();
   const providerModal = page.getByRole("dialog");
   await expect(providerModal).toBeVisible();
   await expect(providerModal.getByPlaceholder("Search models")).toBeVisible();


### PR DESCRIPTION
## What

Unbreaks main CI, red since #701/#716. Both failures were stale tests; product behavior is correct.

- `app/tests/agent-admin-model-ceiling.test.ts` — the catalog is runtime-hydrated since #701 (providers seed with `models: []`), so the bare node:test saw an empty catalog. The test now calls `hydrateProviderCatalog` with a minimal fixture before asserting. No static fallback added to `providers.ts` (that would reintroduce the drift #701 removed).
- `packages/web/e2e/ai-hub.spec.ts` — the "See more" button was deleted with `provider-card.tsx`; rows are the open affordance now. The spec clicks the provider row (`getByRole("button", { name: /Anthropic/ })`); all modal assertions kept.
- Dropped the orphaned `card.seeMore` key from en/es/pt `ai-hub.json`.

## Tests

- App unit test 6/6; `tsgo --noEmit` app + e2e harness; `check-locales` green
- Full web Playwright suite executed locally: 27 passed, 0 failed
- Biome clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)