### PR TITLE
feat(sdk): clean turns settle to done; needs_you only with a pending interaction

### DIFF
--- a/packages/fake-host/README.md
+++ b/packages/fake-host/README.md
@@ -52,6 +52,7 @@ They drive the failure/reactivity scenarios the specs assert against:
 | `/__test__/reset` | — | Restore the seed + clear all chat channels (called before each test). |
 | `/__test__/emit` | `{ type, agentPath? }` | Push a domain event onto the `/v1/events` reactivity feed. |
 | `/__test__/chat-config` | `{ replyDelayMs }` | Slow the canned reply so a drop/kill lands mid-turn deterministically. |
+| `/__test__/chat-interaction` | `{ interaction }` | Arm the NEXT scripted turn to end on a `PendingInteraction` (its `done` frame carries it) so the settle lands the card on `needs_you` + composer card. `null` disarms. |
 | `/__test__/drop-chat-streams` | — | Sever every open chat stream WITHOUT ending the turns (network blip). Returns `{ dropped }`. |
 | `/__test__/kill-turn` | — | Synthesize the host reaper's terminal `error` frame on every running turn (dead-turn settle). Returns `{ killed }`. |
 | `/__test__/turn-boundary` | `{ nextText }` | End the running turn while nobody watches, then start the next one, so a reconnect resyncs onto a DIFFERENT turnId. Returns `{ advanced }`. |

--- a/packages/fake-host/src/chat-turn.ts
+++ b/packages/fake-host/src/chat-turn.ts
@@ -15,6 +15,7 @@
  * mid-turn. Test controls that drive these primitives live in chat-controls.ts.
  */
 
+import type { PendingInteraction } from "@houston/protocol";
 import { type ChatChannel, channel, chatKey, publish } from "./chat-channel";
 import * as state from "./state";
 
@@ -31,9 +32,21 @@ export function setReplyDelay(ms: number): void {
   replyDelayMs = ms;
 }
 
-/** Reset the per-delta delay (test reset). Controls live in chat-controls.ts. */
+/**
+ * Arm the NEXT scripted turn to end on a pending interaction — its `done` frame
+ * carries it, so the client settles the card to `needs_you` and drives the
+ * composer-replacing question/connect card (element 4's e2e). One-shot:
+ * consumed when that turn finishes. `null` disarms.
+ */
+let nextInteraction: PendingInteraction | null = null;
+export function setNextInteraction(pi: PendingInteraction | null): void {
+  nextInteraction = pi;
+}
+
+/** Reset the per-delta delay + armed interaction (test reset). */
 export function resetReplyDelay(): void {
   replyDelayMs = DEFAULT_REPLY_DELAY_MS;
+  nextInteraction = null;
 }
 
 function cannedReply(userText: string): string {
@@ -76,19 +89,29 @@ async function streamReply(
     await delay(replyDelayMs);
   }
   if (ch.epoch !== epoch || ch.pending?.turnId !== turnId) return;
-  finishTurn(agentId, cid, ch, turnId, reply);
+  // Consume any armed interaction: this turn's `done` carries it (one-shot).
+  const interaction = nextInteraction;
+  nextInteraction = null;
+  finishTurn(agentId, cid, ch, turnId, reply, interaction);
 }
 
-/** Publish the turn's usage + done and persist the assistant reply. */
+/** Publish the turn's usage + done and persist the assistant reply. The `done`
+ *  frame carries `pendingInteraction` when the turn ended asking the user. */
 export function finishTurn(
   agentId: string,
   cid: string,
   ch: ChatChannel,
   turnId: string,
   reply: string,
+  pendingInteraction: PendingInteraction | null = null,
 ): void {
   publish(ch, { type: "usage", data: state.seedUsage, turnId });
-  publish(ch, { type: "done", data: null, turnId });
+  publish(ch, {
+    type: "done",
+    data: null,
+    turnId,
+    ...(pendingInteraction ? { pendingInteraction } : {}),
+  });
   state.appendAssistantMessage(agentId, cid, reply, turnId);
   ch.pending = null;
 }

--- a/packages/fake-host/src/index.ts
+++ b/packages/fake-host/src/index.ts
@@ -9,8 +9,9 @@
  *  - The host + seed constants (ports, token, seeded agent) from `./config`.
  *
  * The server's `POST /__test__/*` control endpoints (reset, emit, chat-config,
- * drop-chat-streams, kill-turn, turn-boundary) are HTTP routes documented in
- * this package's README; the harness drives them over HTTP, not via exports.
+ * chat-interaction, drop-chat-streams, kill-turn, turn-boundary) are HTTP routes
+ * documented in this package's README; the harness drives them over HTTP, not
+ * via exports.
  */
 
 export {

--- a/packages/fake-host/src/router.ts
+++ b/packages/fake-host/src/router.ts
@@ -8,8 +8,8 @@
  */
 
 import { buildProviderCatalog } from "@houston/host/src/providers/pi-catalog";
-import type { Capabilities } from "@houston/protocol";
-import { setReplyDelay } from "./chat";
+import type { Capabilities, PendingInteraction } from "@houston/protocol";
+import { setNextInteraction, setReplyDelay } from "./chat";
 import {
   clearChatStreams,
   dropChatStreams,
@@ -79,6 +79,15 @@ export async function handle(req: Request): Promise<Response> {
   if (path === "/__test__/chat-config" && method === "POST") {
     const body = await parseBody(req);
     setReplyDelay(Number(body?.replyDelayMs ?? 15));
+    return json({ ok: true });
+  }
+  // Arm the NEXT scripted turn to end on a pending interaction: its `done`
+  // frame carries it, so the settle lands the card on needs_you + composer card.
+  if (path === "/__test__/chat-interaction" && method === "POST") {
+    const body = await parseBody(req);
+    setNextInteraction(
+      (body?.interaction as PendingInteraction | null) ?? null,
+    );
     return json({ ok: true });
   }
   // Synthesize the dead-pump reaper's terminal error on every running turn.

--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -6,6 +6,7 @@
  * provider-error.ts.
  */
 
+import type { PendingInteraction } from "./domain/interaction";
 import type { ProviderError } from "./provider-error";
 
 /**
@@ -199,6 +200,16 @@ export interface ChatMessage {
    * carried `provider` is the pi provider id; the frontend maps it.
    */
   providerError?: ProviderError;
+  /**
+   * What this turn ended waiting on the user for (ask_user / request_connection),
+   * persisted ONLY when the turn ended clean (no provider error, not thrown) —
+   * the exact condition that attaches it to the terminal `done` wire frame. A
+   * client that MISSES the live `done` (connection blip / observer reload) and
+   * settles from this history reads the interaction here and lands the board
+   * card on `needs_you`, instead of dropping the question/connect card to a
+   * false `done`. Absent when the turn ended with nothing outstanding.
+   */
+  pendingInteraction?: PendingInteraction;
 }
 
 export interface ConversationSummary {

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -9,6 +9,9 @@ import type { HarnessSession } from "../backends/types";
  * execTurn's terminal-frame contract for pending interactions: the clean `done`
  * carries whatever the model recorded via ask_user / request_connection this
  * turn, and NO error path (provider_error or a thrown turn) ever carries it.
+ * It also PERSISTS the same interaction on the assistant message under the same
+ * clean-only condition, so a client that missed the live `done` recovers it
+ * from history (see conversation-file.test.ts + settle-from-history).
  */
 
 process.env.HOUSTON_DATA_DIR = mkdtempSync(
@@ -53,8 +56,18 @@ vi.mock("../store/conversations", () => ({
 const { execTurn } = await import("./exec-turn");
 const { subscribe } = await import("./bus");
 const { recordPendingInteraction } = await import("./interaction");
+const { appendAssistantMessage } = await import("../store/conversations");
 
 afterAll(() => vi.restoreAllMocks());
+
+/** The pendingInteraction persisted on `id`'s assistant message, or undefined. */
+function persistedInteraction(id: string): unknown {
+  const call = vi
+    .mocked(appendAssistantMessage)
+    .mock.calls.find((c) => c[0] === id);
+  return (call?.[2] as { pendingInteraction?: unknown } | undefined)
+    ?.pendingInteraction;
+}
 
 type Conv = Parameters<typeof execTurn>[0];
 
@@ -119,6 +132,11 @@ test("the clean done frame carries the turn's recorded pending interaction", asy
     kind: "question",
     question: "Which date?",
   });
+  // ...and it is persisted on the assistant message for a missed-`done` reload.
+  expect(persistedInteraction(id)).toEqual({
+    kind: "question",
+    question: "Which date?",
+  });
 });
 
 test("the done frame omits pendingInteraction when the model asked nothing", async () => {
@@ -137,6 +155,7 @@ test("the done frame omits pendingInteraction when the model asked nothing", asy
   );
   expect(done).toBeDefined();
   expect(done?.pendingInteraction).toBeUndefined();
+  expect(persistedInteraction(id)).toBeUndefined();
 });
 
 test("a provider_error turn emits no done — the pending interaction never rides an error", async () => {
@@ -159,6 +178,8 @@ test("a provider_error turn emits no done — the pending interaction never ride
 
   expect(events.some((e) => e.type === "done")).toBe(false);
   expect(events.some((e) => e.type === "provider_error")).toBe(true);
+  // The recorded interaction must NOT be persisted on a failed turn either.
+  expect(persistedInteraction(id)).toBeUndefined();
 });
 
 test("a thrown turn emits an error frame and no done", async () => {
@@ -180,4 +201,6 @@ test("a thrown turn emits an error frame and no done", async () => {
     (e): e is Extract<WireEvent, { type: "error" }> => e.type === "error",
   );
   expect(err?.data.message).toContain("kaboom");
+  // A thrown turn settles via the catch path, which never carries the interaction.
+  expect(persistedInteraction(id)).toBeUndefined();
 });

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -354,6 +354,12 @@ export async function execTurn(
       compaction,
       providerError,
       fileChanges,
+      // Persist what the turn is waiting on the user for under the SAME
+      // condition that puts it on the clean `done` frame below (no provider
+      // error) — so a client that misses the live `done` settles from history
+      // to `needs_you`, never dropping the question/connect card to a false
+      // `done`. A failed/stalled turn (providerError set) never carries it.
+      pendingInteraction: providerError ? undefined : interaction.pending,
       turnId,
     });
     if (fileChanges)

--- a/packages/runtime/src/store/conversation-file.test.ts
+++ b/packages/runtime/src/store/conversation-file.test.ts
@@ -136,6 +136,38 @@ test("assistant message with no switch stores no providerSwitch field", () => {
   expect(msg?.providerSwitch ?? null).toBeNull();
 });
 
+test("assistant message persists the pending interaction so a reload settles needs_you", () => {
+  const dir = freshDir();
+  appendUserMessageAt(dir, "c1", "book it", { turnId: "t-1" });
+  appendAssistantMessageAt(dir, "c1", "which date?", {
+    turnId: "t-1",
+    pendingInteraction: { kind: "question", question: "Which date?" },
+  });
+
+  const history = getHistoryAt(dir, "c1");
+  if (!history) throw new Error("getHistoryAt returned null after append");
+  const msg = history.messages.find((m) => m.role === "assistant");
+  if (!msg) throw new Error("no assistant message found in history");
+  expect(msg.pendingInteraction).toEqual({
+    kind: "question",
+    question: "Which date?",
+  });
+});
+
+test("assistant message with no pending interaction stays interaction-free in the JSON", () => {
+  const dir = freshDir();
+  appendUserMessageAt(dir, "c1", "hi");
+  appendAssistantMessageAt(dir, "c1", "all done");
+
+  const msg = getHistoryAt(dir, "c1")?.messages.find(
+    (m) => m.role === "assistant",
+  );
+  expect(msg?.pendingInteraction ?? null).toBeNull();
+  // Absent, not present-and-undefined — a plain turn's record is unchanged.
+  const raw = readFileSync(join(dir, "c1.json"), "utf8");
+  expect(raw).not.toContain("pendingInteraction");
+});
+
 test("a user message from an acting-as token persists its author (C5), served on read-back", () => {
   const dir = freshDir();
   // The runtime decodes WHO the turn acts as off the C2 token, then stamps it.

--- a/packages/runtime/src/store/conversation-file.ts
+++ b/packages/runtime/src/store/conversation-file.ts
@@ -71,6 +71,13 @@ export interface AssistantMessageMeta {
   providerError?: ChatMessage["providerError"];
   /** Files the turn created/modified (relative paths); omitted when empty. */
   fileChanges?: ChatMessage["fileChanges"];
+  /**
+   * What the turn ended waiting on the user for — set ONLY on a clean turn (the
+   * caller mirrors the `done`-frame condition). Persisted so a client that
+   * missed the live `done` and settles from history lands on `needs_you`
+   * instead of a false `done`.
+   */
+  pendingInteraction?: ChatMessage["pendingInteraction"];
   /** The turn's wire id (`WireFrame.turnId`) — same as the user message's. */
   turnId?: string;
 }
@@ -122,6 +129,7 @@ export function appendAssistantMessageAt(
     compaction: meta.compaction,
     providerError: meta.providerError,
     fileChanges: meta.fileChanges,
+    pendingInteraction: meta.pendingInteraction,
     turnId: meta.turnId,
   });
   conv.updatedAt = Date.now();

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -232,6 +232,11 @@ export async function runPiTurn(
       usage,
       providerError,
       fileChanges,
+      // Same clean-only condition as the returned outcome (below): persist the
+      // pending question only when the turn ended without a provider error, so
+      // a reload of this cloud conversation settles to `needs_you`, not a false
+      // `done`. Mirrors exec-turn — only the clean turn carries it.
+      pendingInteraction: providerError ? undefined : interaction.pending,
       turnId,
     });
     if (fileChanges) emit({ type: "file_changes", data: fileChanges });

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -144,6 +144,7 @@ export {
   isStoppedByUser,
   MultiplexFeedOutput,
   observeConversation,
+  type PendingInteraction,
   type QueuedMessageVM,
   SEND_IN_FLIGHT_MESSAGE,
   type SessionStatusValue,

--- a/packages/sdk/src/modules/turns/feed-output.ts
+++ b/packages/sdk/src/modules/turns/feed-output.ts
@@ -14,6 +14,10 @@
  * are the same ones the desktop UI reacts to, carried along unchanged.
  */
 
+import type { PendingInteraction } from "@houston/runtime-client";
+
+export type { PendingInteraction } from "@houston/runtime-client";
+
 /**
  * The session statuses a streamed turn produces. The desktop reacts to exactly
  * these: `running` drives the spinner/loading flag, `completed` the
@@ -22,8 +26,15 @@
  */
 export type SessionStatusValue = "starting" | "running" | "completed" | "error";
 
-/** Terminal board-card status, persisted once the turn settles. */
-export type TerminalBoardStatus = "needs_you" | "error";
+/**
+ * Terminal board-card status, persisted once the turn settles. A clean turn
+ * splits on its pending interaction: it ended asking the user for something
+ * (ask_user / connect) → `needs_you` and the interaction rides the persist;
+ * it ended with nothing outstanding → `done`. A handled non-success (user Stop,
+ * logged-out provider) also lands `needs_you` (never carrying an interaction);
+ * a real failure is `error`.
+ */
+export type TerminalBoardStatus = "needs_you" | "error" | "done";
 
 /** Board-card statuses a streamed turn writes: running in flight, then terminal. */
 export type BoardStatus = "running" | TerminalBoardStatus;
@@ -44,11 +55,17 @@ export interface FeedOutput {
     status: SessionStatusValue,
     error?: string,
   ): void;
-  /** Persist the board-card status through the host's (cloud-aware) seam. */
+  /**
+   * Persist the board-card status through the host's (cloud-aware) seam.
+   * `pendingInteraction` rides the terminal persist: the interaction a clean
+   * turn ended on (drives `needs_you`), or `null` to clear it (turn start, and
+   * every settle that carries no interaction). Omitted is treated as `null`.
+   */
   persistBoardStatus(
     agentPath: string,
     sessionKey: string,
     status: BoardStatus,
+    pendingInteraction?: PendingInteraction | null,
   ): Promise<void>;
 }
 
@@ -79,10 +96,11 @@ export class MultiplexFeedOutput implements FeedOutput {
     agentPath: string,
     sessionKey: string,
     status: BoardStatus,
+    pendingInteraction?: PendingInteraction | null,
   ): Promise<void> {
     await Promise.all(
       this.outputs.map((o) =>
-        o.persistBoardStatus(agentPath, sessionKey, status),
+        o.persistBoardStatus(agentPath, sessionKey, status, pendingInteraction),
       ),
     );
   }

--- a/packages/sdk/src/modules/turns/index.ts
+++ b/packages/sdk/src/modules/turns/index.ts
@@ -171,6 +171,7 @@ export {
   type BoardStatus,
   type FeedOutput,
   MultiplexFeedOutput,
+  type PendingInteraction,
   type SessionStatusValue,
   type TerminalBoardStatus,
 } from "./feed-output";

--- a/packages/sdk/src/modules/turns/observe-stream.ts
+++ b/packages/sdk/src/modules/turns/observe-stream.ts
@@ -102,6 +102,11 @@ export function observeConversation(
       registry.release(key, entry);
     }
     if (sink.terminal)
-      await output.persistBoardStatus(agentPath, sessionKey, sink.terminal);
+      await output.persistBoardStatus(
+        agentPath,
+        sessionKey,
+        sink.terminal,
+        sink.terminalInteraction,
+      );
   })();
 }

--- a/packages/sdk/src/modules/turns/settle-from-history.ts
+++ b/packages/sdk/src/modules/turns/settle-from-history.ts
@@ -73,6 +73,11 @@ function adoptReply(s: TurnState, reply: ChatMessage): void {
   }
   s.text = reply.content;
   if (reply.usage) s.usage = reply.usage;
+  // A turn that ended asking the user for something persisted its interaction
+  // (runtime, clean path only). Adopt it BEFORE finishOk so a settle from
+  // history splits to `needs_you` with the interaction — matching the live
+  // `done` frame we missed — instead of collapsing to a false `done`.
+  if (reply.pendingInteraction) s.pendingInteraction = reply.pendingInteraction;
   finishOk(s);
 }
 

--- a/packages/sdk/src/modules/turns/turn-frames.ts
+++ b/packages/sdk/src/modules/turns/turn-frames.ts
@@ -77,6 +77,11 @@ export function applyTurnFrame(
       stop();
       break;
     case "done":
+      // A clean terminal frame carries the interaction the turn ended on
+      // (ask_user / request_connection) only when the model finished by asking
+      // the user for something. Capture it so finishOk settles the card to
+      // needs_you (present) vs done (absent) and it rides the board persist.
+      if (ev.pendingInteraction) s.pendingInteraction = ev.pendingInteraction;
       finishOk(s);
       stop();
       break;

--- a/packages/sdk/src/modules/turns/turn-settle.test.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.test.ts
@@ -1,8 +1,13 @@
 import type { ChatMessage } from "@houston/runtime-client";
 import { expect, test } from "vitest";
-import type { FeedOutput } from "./feed-output";
+import type { FeedOutput, PendingInteraction } from "./feed-output";
 import { settleFromHistory, TURN_DIED_MESSAGE } from "./settle-from-history";
-import { finishErr, newTurnState, type TurnState } from "./turn-settle";
+import {
+  finishErr,
+  finishOk,
+  newTurnState,
+  type TurnState,
+} from "./turn-settle";
 
 /**
  * settleFromHistory — the "terminal frame was lost" settle. With a turnId the
@@ -57,7 +62,9 @@ test("matches the assistant reply by turnId and adopts its text + usage", () => 
     "t-1",
   );
   expect(s.settled).toBe(true);
-  expect(s.terminal).toBe("needs_you");
+  // New semantics: a clean settle with NO pending interaction lands on `done`
+  // (the reloaded reply carries none — the terminal `done` frame was lost).
+  expect(s.terminal).toBe("done");
   expect(items).toContainEqual({
     feed_type: "assistant_text",
     data: "Full reply",
@@ -68,6 +75,34 @@ test("matches the assistant reply by turnId and adopts its text + usage", () => 
   };
   expect(final.result).toBe("Full reply");
   expect(final.usage).toEqual(usage);
+  expect(statuses).toEqual([["completed", undefined]]);
+});
+
+test("a persisted pendingInteraction recovers on reload: needs_you + the interaction", () => {
+  const interaction: PendingInteraction = {
+    kind: "question",
+    question: "Which date?",
+    options: [{ id: "a", label: "Fri" }],
+  };
+  const { s, statuses } = run(
+    [
+      { role: "user", content: "book it", ts: 1, turnId: "t-1" },
+      {
+        role: "assistant",
+        content: "which date?",
+        ts: 2,
+        turnId: "t-1",
+        pendingInteraction: interaction,
+      },
+    ],
+    "t-1",
+  );
+  expect(s.settled).toBe(true);
+  // The live `done` was missed; recovering the persisted interaction lands the
+  // card on needs_you (not a false `done`) and carries it for the terminal
+  // persist — the element-3 machinery reads s.pendingInteraction from here.
+  expect(s.terminal).toBe("needs_you");
+  expect(s.pendingInteraction).toEqual(interaction);
   expect(statuses).toEqual([["completed", undefined]]);
 });
 
@@ -129,7 +164,7 @@ test("legacy: a rejected guard settles the streamed accumulation as completed", 
     undefined,
     { guard: false, streamed: "what we streamed" },
   );
-  expect(s.terminal).toBe("needs_you");
+  expect(s.terminal).toBe("done"); // clean settle, no interaction
   expect(items).toContainEqual({
     feed_type: "assistant_text",
     data: "what we streamed",
@@ -152,7 +187,7 @@ test("legacy: a rejected guard with NOTHING streamed settles as the dead-turn er
 
 test("a failed history reload (null) still settles: streamed text as completed, nothing as error", () => {
   const withText = run(null, "t-1", { streamed: "partial tail" });
-  expect(withText.s.terminal).toBe("needs_you");
+  expect(withText.s.terminal).toBe("done"); // clean settle, no interaction
   expect(withText.items).toContainEqual({
     feed_type: "assistant_text",
     data: "partial tail",
@@ -160,6 +195,41 @@ test("a failed history reload (null) still settles: streamed text as completed, 
 
   const withoutText = run(null, "t-1");
   expect(withoutText.s.terminal).toBe("error");
+});
+
+/**
+ * finishOk — the clean-settle board split (element 3). A turn that ended with
+ * a captured pending interaction lands `needs_you` (and the interaction rides
+ * the persist via the sink); one with nothing outstanding lands `done`. The
+ * session status is `completed` either way.
+ */
+
+test("finishOk without a captured interaction settles the card to done", () => {
+  const { statuses, output } = recorder();
+  const s = newTurnState("Houston/Bo", "activity-done", output);
+  s.text = "all set";
+  finishOk(s);
+  expect(s.settled).toBe(true);
+  expect(s.terminal).toBe("done");
+  expect(s.pendingInteraction).toBe(null);
+  expect(statuses).toEqual([["completed", undefined]]);
+});
+
+test("finishOk with a captured interaction settles needs_you and keeps the interaction", () => {
+  const { statuses, output } = recorder();
+  const s = newTurnState("Houston/Bo", "activity-ask", output);
+  s.text = "which one?";
+  const interaction: PendingInteraction = {
+    kind: "question",
+    question: "Pick a flight?",
+    options: [{ id: "a", label: "Morning" }],
+  };
+  // The `done` frame stashes the interaction before finishOk (turn-frames.ts).
+  s.pendingInteraction = interaction;
+  finishOk(s);
+  expect(s.terminal).toBe("needs_you");
+  expect(s.pendingInteraction).toEqual(interaction);
+  expect(statuses).toEqual([["completed", undefined]]);
 });
 
 /**

--- a/packages/sdk/src/modules/turns/turn-settle.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.ts
@@ -1,4 +1,8 @@
-import type { ProviderError, TokenUsage } from "@houston/runtime-client";
+import type {
+  PendingInteraction,
+  ProviderError,
+  TokenUsage,
+} from "@houston/runtime-client";
 import type { FeedOutput, TerminalBoardStatus } from "./feed-output";
 import { isNotConnectedError, isStoppedByUser } from "./turn-errors";
 
@@ -29,6 +33,15 @@ export interface TurnState {
   usage: TokenUsage | null;
   settled: boolean;
   terminal: TerminalBoardStatus | null;
+  /**
+   * The interaction the turn ended on (ask_user / request_connection), captured
+   * from the clean `done` frame; `null` when the turn settled without one. It
+   * splits a clean settle to `needs_you` (present) vs `done` (absent) in
+   * {@link finishOk} and rides the terminal board persist so the card can
+   * render its composer-replacing question/connect card. Handled non-success
+   * settles (user Stop, provider error) never set it.
+   */
+  pendingInteraction: PendingInteraction | null;
 }
 
 export function newTurnState(
@@ -48,6 +61,7 @@ export function newTurnState(
     usage: null,
     settled: false,
     terminal: null,
+    pendingInteraction: null,
   };
 }
 
@@ -61,7 +75,12 @@ const invisibleFinal = (s: TurnState) =>
     data: { result: "", cost_usd: null, duration_ms: null, usage: null },
   });
 
-/** Settle a successful turn: flush accumulations, final_result, completed. */
+/**
+ * Settle a successful turn: flush accumulations, final_result, completed. The
+ * board split is on the captured interaction (the `done` frame stashes it into
+ * `s.pendingInteraction` before calling here): the turn ended asking the user
+ * for something → `needs_you`; it ended with nothing outstanding → `done`.
+ */
 export function finishOk(s: TurnState): void {
   if (s.settled) return;
   s.settled = true;
@@ -72,7 +91,7 @@ export function finishOk(s: TurnState): void {
     data: { result: s.text, cost_usd: null, duration_ms: null, usage: s.usage },
   });
   s.output.sessionStatus(s.agentPath, s.sessionKey, "completed");
-  s.terminal = "needs_you";
+  s.terminal = s.pendingInteraction ? "needs_you" : "done";
 }
 
 /**

--- a/packages/sdk/src/modules/turns/turn-sink.ts
+++ b/packages/sdk/src/modules/turns/turn-sink.ts
@@ -1,4 +1,4 @@
-import type { WireFrame } from "@houston/runtime-client";
+import type { PendingInteraction, WireFrame } from "@houston/runtime-client";
 import type { TerminalBoardStatus } from "./feed-output";
 import { reloadAndSettle } from "./settle-from-history";
 import { applyTurnFrame } from "./turn-frames";
@@ -46,6 +46,10 @@ export class TurnSink {
   }
   get terminal(): TerminalBoardStatus | null {
     return this.s.terminal;
+  }
+  /** The interaction a clean turn settled on (rides the terminal persist), or null. */
+  get terminalInteraction(): PendingInteraction | null {
+    return this.s.pendingInteraction;
   }
   /** Whether a turn was ever observed in flight on this subscription. */
   get active(): boolean {

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -2,6 +2,7 @@ import type {
   ChatMessage,
   EventStreamOptions,
   HoustonEngineClient,
+  PendingInteraction,
   WireFrame,
 } from "@houston/runtime-client";
 import { EngineError } from "@houston/runtime-client";
@@ -80,6 +81,9 @@ function makeOutput() {
   const items: Item[] = [];
   const sessionStatuses: string[] = [];
   const board: string[] = [];
+  // The interaction each board persist carried (parallel to `board`): null on
+  // the "running" start-clear, the captured interaction (or null) on settle.
+  const boardInteractions: Array<PendingInteraction | null | undefined> = [];
   const output: FeedOutput = {
     pushFeedItem: (_a, _s, item) => {
       items.push(item as Item);
@@ -87,11 +91,12 @@ function makeOutput() {
     sessionStatus: (_a, _s, status) => {
       sessionStatuses.push(status);
     },
-    persistBoardStatus: async (_a, _s, status) => {
+    persistBoardStatus: async (_a, _s, status, pendingInteraction) => {
       board.push(status);
+      boardInteractions.push(pendingInteraction);
     },
   };
-  return { items, sessionStatuses, board, output };
+  return { items, sessionStatuses, board, boardInteractions, output };
 }
 
 async function waitFor(cond: () => boolean, ms = 2_000): Promise<void> {
@@ -155,7 +160,44 @@ test("a silent stream close mid-turn reconnects with the cursor and settles on t
   expect(
     (finals(items)[0]?.data as { result?: string } | undefined)?.result,
   ).toBe("Hello");
+  // A clean `done` with NO interaction settles the card to `done`.
+  expect(board).toEqual(["running", "done"]);
+});
+
+test("a clean done carrying a pending interaction settles needs_you and persists the interaction", async () => {
+  const interaction: PendingInteraction = {
+    kind: "question",
+    question: "Which flight?",
+    options: [{ id: "m", label: "Morning" }],
+  };
+  const { engine } = fakeEngine([
+    (o) => {
+      o.onEvent(sync(false, "", 0));
+      o.onEvent({ type: "text", data: "Options:", seq: 1 });
+      o.onEvent({
+        type: "done",
+        data: null,
+        pendingInteraction: interaction,
+        seq: 2,
+      });
+    },
+  ]);
+  const { board, boardInteractions, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-ask",
+    "hi",
+    output,
+    registry,
+    { tuning: fast },
+  );
+
+  // Turn start clears (running + null); the settle lands needs_you and the
+  // interaction rides the terminal persist for the composer card to render.
   expect(board).toEqual(["running", "needs_you"]);
+  expect(boardInteractions).toEqual([null, interaction]);
 });
 
 test("a resync after the turn ended settles from refreshed history, not partial text", async () => {
@@ -209,7 +251,8 @@ test("a resync after the turn ended settles from refreshed history, not partial 
     | undefined;
   expect(final?.result).toBe("Hello world");
   expect(final?.usage?.context_tokens).toBe(42);
-  expect(board).toEqual(["running", "needs_you"]);
+  // Settled from refreshed history (clean, no interaction) → `done`.
+  expect(board).toEqual(["running", "done"]);
 });
 
 test("a resync for a turn that died unpersisted settles from the streamed text", async () => {
@@ -339,7 +382,7 @@ test("observer mode surfaces a running turn (spinner + partial) and settles on d
     registry,
     fast,
   );
-  await waitFor(() => board.includes("needs_you"));
+  await waitFor(() => board.includes("done"));
 
   // The spinner flipped on for the observed turn, then completed.
   expect(sessionStatuses).toEqual(["running", "completed"]);
@@ -349,7 +392,8 @@ test("observer mode surfaces a running turn (spinner + partial) and settles on d
   expect(streaming[0]?.data).toBe("Hi the"); // the sync partial seeded the bubble
   const texts = items.filter((i) => i.feed_type === "assistant_text");
   expect(texts).toEqual([{ feed_type: "assistant_text", data: "Hi there" }]);
-  expect(board).toEqual(["needs_you"]); // terminal persist only, no "running" rewrite
+  // Clean observed done, no interaction → `done`; observer never writes "running".
+  expect(board).toEqual(["done"]);
 });
 
 test("observer mode closes silently on an idle conversation", async () => {
@@ -1312,7 +1356,8 @@ test("a transport-failed send whose turn actually started renders and settles no
   // No misleading transport-error line reached the feed.
   expect(items.map((i) => i.data)).not.toContain("Load failed");
   expect(items.map((i) => i.data)).not.toContain(SEND_LOST_MESSAGE);
-  expect(board).toEqual(["running", "needs_you"]);
+  // Clean `done`, no interaction → `done`.
+  expect(board).toEqual(["running", "done"]);
 });
 
 test("a transport-failed send with no evidence of the turn settles as lost after the verdict window", async () => {

--- a/packages/sdk/src/modules/turns/turn-stream.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.ts
@@ -118,9 +118,10 @@ export async function streamTurn(
     });
   }
   // Flip the card to "running" for this turn (re-running a needs_you/done
-  // activity must reset it). Fire concurrently so it never delays turn start;
-  // persistBoardStatus surfaces its own failure.
-  void output.persistBoardStatus(agentPath, sessionKey, "running");
+  // activity must reset it) and CLEAR any interaction the prior settle stored
+  // (null) — a re-run is no longer waiting on the user. Fire concurrently so it
+  // never delays turn start; persistBoardStatus surfaces its own failure.
+  void output.persistBoardStatus(agentPath, sessionKey, "running", null);
 
   const key = streamKey(agentPath, sessionKey);
   const nonce = opts.nonce ?? randomNonce();
@@ -249,5 +250,10 @@ export async function streamTurn(
   // the board reads. An externally disposed stream (logout teardown) settles
   // nothing and persists nothing: the client is gone.
   if (sink.terminal)
-    await output.persistBoardStatus(agentPath, sessionKey, sink.terminal);
+    await output.persistBoardStatus(
+      agentPath,
+      sessionKey,
+      sink.terminal,
+      sink.terminalInteraction,
+    );
 }

--- a/packages/sdk/src/modules/turns/vm-output.test.ts
+++ b/packages/sdk/src/modules/turns/vm-output.test.ts
@@ -129,8 +129,34 @@ test("running is derived from sessionStatus, and boardStatus defaults to null", 
   vm.pushFeedItem("a", "c1", { feed_type: "system_message", data: "hi" });
   expect(snap().running).toBe(false);
   expect(snap().boardStatus).toBe(null); // no board persist yet
+  expect(snap().pendingInteraction).toBe(null); // no interaction yet
   vm.sessionStatus("a", "c1", "running");
   expect(snap().running).toBe(true);
+});
+
+test("a clean settle folds the pending interaction into the VM; turn start clears it", async () => {
+  const { snap, vm } = harness();
+  const interaction = {
+    kind: "question" as const,
+    question: "Which one?",
+    options: [{ id: "a", label: "A" }],
+  };
+  // Settle carrying the interaction: needs_you + the interaction on the VM.
+  await vm.persistBoardStatus("a", "c1", "needs_you", interaction);
+  expect(snap().boardStatus).toBe("needs_you");
+  expect(snap().pendingInteraction).toEqual(interaction);
+
+  // Turn start re-runs the card: running + null clears the stored interaction.
+  await vm.persistBoardStatus("a", "c1", "running", null);
+  expect(snap().boardStatus).toBe("running");
+  expect(snap().pendingInteraction).toBe(null);
+});
+
+test("a clean settle with no interaction lands boardStatus done and no interaction", async () => {
+  const { snap, vm } = harness();
+  await vm.persistBoardStatus("a", "c1", "done", null);
+  expect(snap().boardStatus).toBe("done");
+  expect(snap().pendingInteraction).toBe(null);
 });
 
 test("distinct conversations get distinct scopes", () => {

--- a/packages/sdk/src/modules/turns/vm-output.ts
+++ b/packages/sdk/src/modules/turns/vm-output.ts
@@ -1,3 +1,4 @@
+import type { PendingInteraction } from "@houston/runtime-client";
 import type { ScopeStore } from "../../store";
 import type {
   BoardStatus,
@@ -48,9 +49,18 @@ export interface ConversationVM {
   /**
    * The persisted board-card status (the `persistBoardStatus` seam), or `null`
    * before any turn ran. Handled-vs-error lives HERE: `needs_you` = handled /
-   * attention (a user Stop settles here), `error` = a real failure.
+   * attention (a user Stop, or a clean turn that ended asking the user for
+   * something, settles here), `done` = a clean turn with nothing outstanding,
+   * `error` = a real failure.
    */
   boardStatus: BoardStatus | null;
+  /**
+   * The interaction a clean turn settled on (ask_user / request_connection),
+   * mirrored from the terminal board persist so a surface can render the
+   * composer-replacing card; `null` when the turn is not waiting on the user
+   * (cleared on turn start and on every settle that carries no interaction).
+   */
+  pendingInteraction: PendingInteraction | null;
   /**
    * Messages queued while a turn runs (additive; absent when none). The sender
    * flushes them as ONE combined send when the turn settles.
@@ -62,6 +72,7 @@ interface ConvState {
   feed: FeedItemVM[];
   sessionStatus: SessionStatusValue | "idle";
   boardStatus: BoardStatus | null;
+  pendingInteraction: PendingInteraction | null;
   seq: number;
   /** Open streaming run: its streaming feed_type -> the feed entry id it updates. */
   streaming: Map<string, string>;
@@ -99,6 +110,7 @@ export class ConversationVmOutput implements FeedOutput {
         feed: [],
         sessionStatus: "idle",
         boardStatus: null,
+        pendingInteraction: null,
         seq: 0,
         streaming: new Map(),
         queued: [],
@@ -195,9 +207,14 @@ export class ConversationVmOutput implements FeedOutput {
     agentPath: string,
     sessionKey: string,
     status: BoardStatus,
+    pendingInteraction?: PendingInteraction | null,
   ): Promise<void> {
     const s = this.state(agentPath, sessionKey);
     s.boardStatus = status;
+    // Turn start persists `running` + null (clears); a settle persists the
+    // terminal status + the interaction it ended on (or null). An omitted arg
+    // clears — no interaction means the card is not waiting on the user.
+    s.pendingInteraction = pendingInteraction ?? null;
     this.publish(agentPath, sessionKey, s);
   }
 
@@ -218,6 +235,7 @@ export class ConversationVmOutput implements FeedOutput {
       running: s.sessionStatus === "running",
       sessionStatus: s.sessionStatus,
       boardStatus: s.boardStatus,
+      pendingInteraction: s.pendingInteraction,
       ...(s.queued.length ? { queued: s.queued.map((q) => ({ ...q })) } : {}),
     };
     this.store.publish(conversationScope(agentPath, sessionKey), snapshot);

--- a/packages/sdk/tests/bridge.contract.test.ts
+++ b/packages/sdk/tests/bridge.contract.test.ts
@@ -166,7 +166,9 @@ describe("send -> stream -> settle (bridge-fetch streaming path)", () => {
     expect(settled).toEqual({
       running: false,
       sessionStatus: "completed",
-      boardStatus: "needs_you",
+      // A clean turn with nothing outstanding settles to `done`.
+      boardStatus: "done",
+      pendingInteraction: null,
       feed: [
         // The optimistic push — the ONE user bubble (its echo never renders).
         { id: "f0", feed_type: "user_message", data: "Ping" },

--- a/packages/sdk/tests/resilience.contract.test.ts
+++ b/packages/sdk/tests/resilience.contract.test.ts
@@ -173,7 +173,8 @@ describe("observer attach on a running turn", () => {
     expect(out.statuses).toContain("completed");
     const finalText = out.feed.find((f) => f.feed_type === "assistant_text");
     expect(finalText?.data).toBe(cannedReply("Ping"));
-    expect(out.board).toContain("needs_you");
+    // A clean turn with no pending interaction settles the board to done.
+    expect(out.board).toContain("done");
   });
 
   it("sdk.turns.observe surfaces a turn started elsewhere into the VM", async () => {
@@ -205,7 +206,8 @@ describe("observer attach on a running turn", () => {
     );
 
     const vm = convVm(h.sdk, cid);
-    expect(vm?.boardStatus).toBe("needs_you");
+    // No pending interaction on the observed turn: it settles done.
+    expect(vm?.boardStatus).toBe("done");
     expect(vm?.feed.some((f) => f.data === cannedReply("Ping"))).toBe(true);
   });
 

--- a/packages/sdk/tests/turns.contract.test.ts
+++ b/packages/sdk/tests/turns.contract.test.ts
@@ -69,8 +69,11 @@ describe("turn send → stream → settle", () => {
       running: false,
       sessionStatus: "completed",
       // The persisted board status now rides the VM (the handled-vs-error
-      // signal a native shell reads); a clean turn lands on needs_you.
-      boardStatus: "needs_you",
+      // signal a native shell reads); a clean turn with nothing outstanding
+      // lands on `done` (needs_you is for a turn that ended asking the user).
+      boardStatus: "done",
+      // No pending interaction — the canned turn ended asking nothing.
+      pendingInteraction: null,
       feed: [
         // The optimistic push — the ONE user bubble (its echo never renders).
         { id: "f0", feed_type: "user_message", data: "Ping" },

--- a/packages/web/src/engine-adapter/activities.ts
+++ b/packages/web/src/engine-adapter/activities.ts
@@ -3,6 +3,7 @@ import type {
   ActivityUpdate,
   ConversationEntry,
   NewActivity,
+  PendingInteraction,
 } from "../../../../ui/engine-client/src/types";
 import { readAgentFile, writeAgentFile } from "./agent-files";
 
@@ -88,11 +89,17 @@ export function updateActivity(
   const items = read(agentPath);
   const idx = items.findIndex((a) => a.id === id);
   if (idx < 0) throw new Error(`activity ${id} not found`);
+  // `pending_interaction: null` clears it, a value sets it, absent leaves it —
+  // the same contract as the domain's applyActivityUpdate (null is an
+  // update-only signal; the Activity itself never stores null).
+  const { pending_interaction, ...rest } = updates;
   const next: Activity = {
     ...items[idx],
-    ...updates,
+    ...rest,
     updated_at: new Date().toISOString(),
   };
+  if (pending_interaction) next.pending_interaction = pending_interaction;
+  else if (pending_interaction === null) delete next.pending_interaction;
   items[idx] = next;
   write(agentPath, items);
   return next;
@@ -114,12 +121,22 @@ export function setStatusBySessionKey(
   agentPath: string,
   sessionKey: string,
   status: string,
+  pendingInteraction: PendingInteraction | null,
 ): void {
   const items = read(agentPath);
   const idx = items.findIndex(
     (a) => a.session_key === sessionKey || `activity-${a.id}` === sessionKey,
   );
   if (idx < 0) return;
-  items[idx] = { ...items[idx], status, updated_at: new Date().toISOString() };
+  // A settle records the interaction it ended on; `null` (turn start, or any
+  // settle with none) clears it so the card stops waiting on the user.
+  const next: Activity = {
+    ...items[idx],
+    status,
+    updated_at: new Date().toISOString(),
+  };
+  if (pendingInteraction) next.pending_interaction = pendingInteraction;
+  else delete next.pending_interaction;
+  items[idx] = next;
   write(agentPath, items);
 }

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -26,6 +26,7 @@ import type {
   InstallFromRepoRequest,
   NewActivity,
   NewRoutine,
+  PendingInteraction,
   PortableAnonymizeRequest,
   PortableAnonymizeResponse,
   PortableExportRequest,
@@ -574,9 +575,15 @@ export class HoustonClient {
     agentPath: string,
     sessionKey: string,
     status: BoardStatus,
+    pendingInteraction: PendingInteraction | null,
   ): Promise<void> {
     if (!this.cp) {
-      activities.setStatusBySessionKey(agentPath, sessionKey, status);
+      activities.setStatusBySessionKey(
+        agentPath,
+        sessionKey,
+        status,
+        pendingInteraction,
+      );
       // Write-through echo: this is the settle path (a turn finishing PATCHes
       // its board status). Without it the card sticks on "running" until a
       // server event that, in hosted mode, historically never comes.
@@ -588,7 +595,12 @@ export class HoustonClient {
       (a) => a.session_key === sessionKey || `activity-${a.id}` === sessionKey,
     );
     if (!match) return; // transient session with no board card — nothing to update
-    await controlPlane.updateActivity(this.cp, agentPath, match.id, { status });
+    // `pending_interaction: null` clears it explicitly (the host route +
+    // domain applyActivityUpdate honor null); a value records the interaction.
+    await controlPlane.updateActivity(this.cp, agentPath, match.id, {
+      status,
+      pending_interaction: pendingInteraction,
+    });
     emitLocalEcho("ActivityChanged", { agentPath });
   }
 
@@ -1465,7 +1477,13 @@ export class HoustonClient {
       path,
       req.sessionKey,
       req.prompt,
-      (status) => this.setActivityStatus(path, req.sessionKey, status),
+      (status, pendingInteraction) =>
+        this.setActivityStatus(
+          path,
+          req.sessionKey,
+          status,
+          pendingInteraction,
+        ),
       req.provider,
       undefined,
       req.suppressUserBubble,
@@ -1497,7 +1515,8 @@ export class HoustonClient {
     // status alone — writing it here too would race that terminal write.
     const { cancelled } = await engine.cancel(sessionKey);
     if (cancelled !== true) {
-      await this.setActivityStatus(agentPath, sessionKey, "needs_you");
+      // Orphan rescue: a user Stop on a dead turn — never a pending interaction.
+      await this.setActivityStatus(agentPath, sessionKey, "needs_you", null);
     }
     return { cancelled: cancelled === true };
   }
@@ -1542,7 +1561,13 @@ export class HoustonClient {
           engine,
           agentPath,
           sessionKey,
-          (status) => this.setActivityStatus(agentPath, sessionKey, status),
+          (status, pendingInteraction) =>
+            this.setActivityStatus(
+              agentPath,
+              sessionKey,
+              status,
+              pendingInteraction,
+            ),
           history.messages.length,
         );
       }

--- a/packages/web/src/engine-adapter/feed-output.ts
+++ b/packages/web/src/engine-adapter/feed-output.ts
@@ -1,4 +1,9 @@
-import type { BoardStatus, FeedOutput, SessionStatusValue } from "@houston/sdk";
+import type {
+  BoardStatus,
+  FeedOutput,
+  PendingInteraction,
+  SessionStatusValue,
+} from "@houston/sdk";
 import { emitEvent } from "./bus";
 import { toOldProvider } from "./synthetic";
 
@@ -42,6 +47,7 @@ export function createBusFeedOutput(
     agentPath: string,
     sessionKey: string,
     status: BoardStatus,
+    pendingInteraction: PendingInteraction | null,
   ) => Promise<void>,
 ): FeedOutput {
   return {
@@ -60,9 +66,19 @@ export function createBusFeedOutput(
         error,
       });
     },
-    async persistBoardStatus(agentPath, sessionKey, status) {
+    async persistBoardStatus(
+      agentPath,
+      sessionKey,
+      status,
+      pendingInteraction,
+    ) {
       try {
-        await setActivityStatus(agentPath, sessionKey, status);
+        await setActivityStatus(
+          agentPath,
+          sessionKey,
+          status,
+          pendingInteraction ?? null,
+        );
       } catch (e) {
         emitEvent("FeedItem", {
           agent_path: agentPath,

--- a/packages/web/src/engine-adapter/turn-stream.ts
+++ b/packages/web/src/engine-adapter/turn-stream.ts
@@ -4,6 +4,7 @@ import {
   conversationScope,
   type FeedFrame,
   MultiplexFeedOutput,
+  type PendingInteraction,
   StreamRegistry,
   type StreamTuning,
   observeConversation as sdkObserveConversation,
@@ -36,11 +37,16 @@ export function disposeAllStreams(): void {
  * state).
  */
 function composedOutput(
-  setActivityStatus: (status: BoardStatus) => Promise<void>,
+  setActivityStatus: (
+    status: BoardStatus,
+    pendingInteraction: PendingInteraction | null,
+  ) => Promise<void>,
 ) {
   return new MultiplexFeedOutput([
     conversationVm,
-    createBusFeedOutput((_a, _s, status) => setActivityStatus(status)),
+    createBusFeedOutput((_a, _s, status, pendingInteraction) =>
+      setActivityStatus(status, pendingInteraction),
+    ),
   ]);
 }
 
@@ -103,7 +109,10 @@ export function streamTurn(
   agentPath: string,
   sessionKey: string,
   prompt: string,
-  setActivityStatus: (status: BoardStatus) => Promise<void>,
+  setActivityStatus: (
+    status: BoardStatus,
+    pendingInteraction: PendingInteraction | null,
+  ) => Promise<void>,
   provider?: string,
   tuning?: StreamTuning,
   suppressUserBubble?: boolean,
@@ -130,7 +139,10 @@ export function observeConversation(
   engine: HoustonEngineClient,
   agentPath: string,
   sessionKey: string,
-  setActivityStatus: (status: BoardStatus) => Promise<void>,
+  setActivityStatus: (
+    status: BoardStatus,
+    pendingInteraction: PendingInteraction | null,
+  ) => Promise<void>,
   messagesAtOpen: number,
   tuning?: StreamTuning,
 ): void {

--- a/packages/web/tests/feed-output.test.ts
+++ b/packages/web/tests/feed-output.test.ts
@@ -84,13 +84,24 @@ test("sessionStatus emits a SessionStatus event", () => {
   });
 });
 
-test("persistBoardStatus forwards to the injected setter", async () => {
-  const seen: Array<[string, string, string]> = [];
-  const out = createBusFeedOutput(async (a, s, status) => {
-    seen.push([a, s, status]);
+test("persistBoardStatus forwards status + interaction to the injected setter", async () => {
+  const seen: Array<[string, string, string, unknown]> = [];
+  const out = createBusFeedOutput(async (a, s, status, pi) => {
+    seen.push([a, s, status, pi]);
   });
-  await out.persistBoardStatus("Houston/Bo", "c1", "needs_you");
-  expect(seen).toEqual([["Houston/Bo", "c1", "needs_you"]]);
+  const interaction = {
+    kind: "question" as const,
+    question: "Which one?",
+    options: [{ id: "a", label: "A" }],
+  };
+  // A settle carrying an interaction forwards it verbatim...
+  await out.persistBoardStatus("Houston/Bo", "c1", "needs_you", interaction);
+  // ...and one with no interaction (omitted) forwards `null` (the clear).
+  await out.persistBoardStatus("Houston/Bo", "c1", "done");
+  expect(seen).toEqual([
+    ["Houston/Bo", "c1", "needs_you", interaction],
+    ["Houston/Bo", "c1", "done", null],
+  ]);
 });
 
 test("a failing board persist surfaces in the feed, not silently", async () => {

--- a/packages/web/tests/translate.test.ts
+++ b/packages/web/tests/translate.test.ts
@@ -39,9 +39,11 @@ function collectFeed(): { items: unknown[]; stop: () => void } {
 
 // THE REGRESSION: a completed turn's board status must reach the injected
 // (cloud-aware) setter — NOT a localStorage write the board never reads. Before
-// the fix, `done` flipped the card to needs_you in localStorage while the board
-// read the host, so the card hung in "running" forever.
-test("a completed turn drives the activity setter running -> needs_you", async () => {
+// the fix, `done` flipped the card in localStorage while the board read the
+// host, so the card hung in "running" forever. A clean turn with nothing
+// outstanding now settles to `done` (needs_you is reserved for a turn that
+// ended asking the user for something).
+test("a completed turn drives the activity setter running -> done", async () => {
   const statuses: string[] = [];
   const setStatus = async (s: string) => {
     statuses.push(s);
@@ -60,7 +62,7 @@ test("a completed turn drives the activity setter running -> needs_you", async (
   );
   feed.stop();
 
-  expect(statuses).toEqual(["running", "needs_you"]);
+  expect(statuses).toEqual(["running", "done"]);
   // The agent's text reached the feed as a final result (the turn really ran).
   expect(
     feed.items.some(
@@ -165,7 +167,7 @@ test("historyToFeed emits no final_result when the message has no usage", () => 
 // the beta no-silent-failure rule.
 test("a failing status persist surfaces in the feed, not silently", async () => {
   const setStatus = async (s: string) => {
-    if (s === "needs_you") throw new Error("host unreachable");
+    if (s === "done") throw new Error("host unreachable");
   };
   const feed = collectFeed();
 

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -347,6 +347,21 @@ export interface UpdateAgent {
 
 // ---------- Agents / agent-data files ----------
 
+export interface InteractionOption {
+  id: string;
+  label: string;
+}
+
+/**
+ * The one thing a mission is waiting on the user for — recorded when the model
+ * ends a turn by asking (ask_user / request_connection). Present drives the
+ * `needs_you` board card and the composer-replacing card; absent means the
+ * mission needs nothing.
+ */
+export type PendingInteraction =
+  | { kind: "question"; question: string; options?: InteractionOption[] }
+  | { kind: "connect"; toolkit: string; reason?: string };
+
 export interface Activity {
   id: string;
   title: string;
@@ -360,6 +375,7 @@ export interface Activity {
   updated_at?: string;
   provider?: string;
   model?: string;
+  pending_interaction?: PendingInteraction;
 }
 
 export interface ActivityUpdate {
@@ -373,6 +389,8 @@ export interface ActivityUpdate {
   routine_run_id?: string;
   provider?: string;
   model?: string;
+  /** Set to record a new pending interaction; `null` clears it explicitly. */
+  pending_interaction?: PendingInteraction | null;
 }
 
 export interface NewActivity {


### PR DESCRIPTION
## What

Element 3 of the interaction refactor (#718 → #721 → #722). The board status now tells the truth:

- A clean turn WITHOUT a pending interaction settles the card to **done** (engine-set, new).
- **needs_you** is reserved for turns that ended asking the user (`ask_user`/`request_connection`), user stops, and handled provider errors.
- `ConversationVM.pendingInteraction` (additive) — set on settle, cleared on turn start.
- Persistence: the web adapter PATCHes `{ status, pending_interaction }` (null clears) on cloud + localStorage paths; turn start clears; orphan rescue passes null.
- Reload survival: `ChatMessage` persists `pendingInteraction` on the clean path (session + cloud per-turn) and settle-from-history recovers it — a missed `done` frame can't demote an asking turn to done.
- fake-host: `POST /__test__/chat-interaction` arms the next turn's done frame with an interaction (for element 4 e2e).
- Contract/unit expectations updated to the new semantics.

No app/ui behavior changes yet — element 4 renders the composer-replacing cards, relabels Archived→Completed, and splits notifications.

## Tests

SDK 248 passed (incl. new settle-split, VM, reload-recovery tests); web 83; fake-host 6; runtime 475; protocol/app typecheck; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)