### PR TITLE
feat: emit turn_start event carrying provider and model

### DIFF
--- a/packages/protocol/src/wire.test.ts
+++ b/packages/protocol/src/wire.test.ts
@@ -1,0 +1,22 @@
+import { expectTypeOf, test } from "vitest";
+import type { WireEvent } from "./index";
+
+test("the protocol index re-exports the turn_start WireEvent arm", () => {
+  const turnStart: WireEvent = {
+    type: "turn_start",
+    data: { provider: "anthropic", model: "claude-sonnet-4-6" },
+  };
+
+  expectTypeOf(turnStart).toMatchTypeOf<WireEvent>();
+  // `type` is the discriminant → narrows `data` to the turn_start shape.
+  if (turnStart.type === "turn_start") {
+    expectTypeOf(turnStart.data).toEqualTypeOf<{
+      provider: string;
+      model: string;
+    }>();
+  }
+
+  // @ts-expect-error — `type` is the discriminant; unknown values are not assignable
+  const bad: WireEvent = { type: "not_an_event", data: null };
+  void bad;
+});

--- a/packages/protocol/src/wire.ts
+++ b/packages/protocol/src/wire.ts
@@ -23,6 +23,7 @@ import type { ProviderError } from "./provider-error";
  *   be served — the client must treat the stream as fresh (refetch history,
  *   rebuild from this snapshot) instead of splicing.
  * - `user`  — a user message was added (by any client); `nonce` echoes the sender's.
+ * - `turn_start` — the provider + resolved model this turn runs against.
  * - `text` / `thinking` — assistant output deltas.
  * - `tool_start` / `tool_end` — tool activity within the turn.
  * - `usage` — normalized token usage for the turn (when the provider reports it),
@@ -99,6 +100,18 @@ export type WireEvent =
          */
         mentions?: { userId: string; name?: string }[];
       };
+    }
+  | {
+      /**
+       * Turn metadata, emitted once at turn start: the provider and the
+       * concrete model this turn resolved to after applying any per-turn pin
+       * (not the raw pin, which may be absent = inherit). Lets a client
+       * attribute a turn's output to a specific provider + model without
+       * inferring it from a later `provider_switched` / `provider_error` (which
+       * only fire on a switch or a failure).
+       */
+      type: "turn_start";
+      data: { provider: string; model: string };
     }
   | { type: "text"; data: string }
   | { type: "thinking"; data: string }

--- a/packages/runtime-client/src/snapshot.ts
+++ b/packages/runtime-client/src/snapshot.ts
@@ -146,11 +146,13 @@ export function reduceSnapshot(
       // clears the in-flight snapshot — otherwise a late subscriber's `sync`
       // would report the turn as still running forever.
       return { running: false, partial: "", seq };
+    case "turn_start":
     case "provider_switched":
     case "context_compacted":
-      // Boundary markers (a mid-session provider switch / a proactive context
-      // compaction), not turn progress — published while a turn is live, so
-      // leave running/partial untouched.
+      // Boundary / metadata markers (the turn's provider+model announcement, a
+      // mid-session provider switch, a proactive context compaction), not turn
+      // progress — published while a turn is live, so leave running/partial
+      // untouched.
       return {
         running: prev.running,
         partial: prev.partial,

--- a/packages/runtime/src/session/chat.ts
+++ b/packages/runtime/src/session/chat.ts
@@ -149,6 +149,19 @@ export async function runTurn(
     return;
   }
 
+  // turn_start metadata: the provider + concrete model this turn resolves to
+  // under its pin, for observers that attribute a turn's output to a model.
+  // Best-effort — getConversation already validated the pin, so this resolves;
+  // a resolve failure must never block the turn, so it degrades to blank.
+  const startProvider = pin?.provider ?? activeProvider();
+  let startModel = "";
+  try {
+    startModel =
+      (resolveModel(pin?.model, pin?.provider) as { id?: string }).id ?? "";
+  } catch {
+    /* leave blank — the turn still runs; provider still rides later frames */
+  }
+
   // Two layers of serialization: per-conversation ordering (conv.queue) AND
   // the per-workdir lock — every conversation in this runtime shares ONE
   // workspaceDir, so a routine's turn and a user chat queue instead of
@@ -177,6 +190,14 @@ export async function runTurn(
       displayText,
       mentions,
     );
+    // turn_start rides right after the user frame (metadata for the live turn),
+    // matching the cloud executor where the concrete model is only known then.
+    if (startProvider)
+      publish(id, {
+        type: "turn_start",
+        data: { provider: startProvider, model: startModel },
+        turnId,
+      });
     return withWorkdirLock(config.workspaceDir, () =>
       execTurn(conv, id, turnId, text, recorded, pin, acting),
     );

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -189,6 +189,10 @@ export async function runPiTurn(
     console.log(
       `[turn] provider=${provider} model=${m.id} baseUrl=${m.baseUrl}`,
     );
+    // Announce the turn's resolved provider + model to observers (turn_start).
+    // Emitted here — the first point the concrete model is known (after applying
+    // the pin) — so it carries the real model id, not the raw pin.
+    emit({ type: "turn_start", data: { provider, model: m.id ?? "" } });
     // Effort → pi's thinking level. The turn's pin (the host bakes the agent's
     // saved effort into it) wins; if none and the model can reason, default to
     // medium so a "thinking" model actually reasons (pi enables reasoning only


### PR DESCRIPTION
Closes #725.

## What

Implements the accepted spec in #725 (emit provider + model on the wire per turn).

Adds an additive `turn_start` `WireEvent` carrying the turn's **provider** and resolved **model**, emitted once per turn. Consumers currently cannot attribute a turn's output to a provider/model on protocol v3 — provider and model are internal-only and only surface indirectly via a later `provider_switched` / `provider_error`, which fire only on a switch or a failure. `turn_start` gives observers the provider + concrete model up front, deterministically, on every turn.

```ts
| {
    type: "turn_start";
    data: { provider: string; model: string };
  }
```

## Emission points (one `turn_start` per turn)

`turn_start` is emitted **exactly once per turn**. The two emission sites cover the two mutually-exclusive execution paths — a turn runs through one or the other, never both:

- **Local / in-process runtime** — `packages/runtime/src/session/chat.ts` (`runTurn`, via `publish`). This is the long-lived desktop / self-host runtime (`conversation-routes.ts` → `runTurn` → `execTurn` → backend/session). The model is pin-resolved (`resolveModel(pin?.model, pin?.provider)`); resolution is best-effort and degrades to blank rather than blocking the turn.
- **Cloud per-turn executor** — `packages/runtime/src/turn/turn-session.ts` (`runPiTurn`, via `emit`). This is the stateless per-request cloud server (`turn/server.ts`: one HTTP request = one agent turn). It emits at the first point the concrete model is known, after applying the pin (`m.id`), so it carries the real model id, not the raw pin.

`execTurn` (local path) never calls `runPiTurn` (cloud path); the two are separate code paths, so a given turn produces a single `turn_start` carrying the concrete model it runs against.

## Backward-compatible / additive

- New arm in the `WireEvent` discriminated union — **no existing event is changed**.
- Snapshot reducer (`packages/runtime-client/src/snapshot.ts`) handles the new arm as a metadata marker (grouped with `provider_switched` / `context_compacted`): it does not touch `running` / `partial`, so live-turn snapshot semantics are unchanged.

## Rebase

Rebased onto **engine-pod-v0.5.24** (`ef469f25`), current `main`. **Rebases cleanly — no conflicts.** Upstream's `chat.ts` refactor and this PR's `turn_start` emission touch non-overlapping regions, so the three-way merge applies them side by side. `resolveModel`'s signature (`resolveModel(override?, providerOverride?)`) is unchanged across the range, so the local-path call `resolveModel(pin?.model, pin?.provider)` still matches, and the cloud path still exposes `provider` + resolved `m.id` at the emission point.

## Tests (all green on `ef469f25`)

- `@houston/protocol` typecheck → clean
- `packages/protocol/src/wire.test.ts` (protocol re-export + discriminant narrowing) → 1/1 pass
- `@houston/runtime` → 737/737
- `@houston/runtime-client` → 136/136

## Files

- `packages/protocol/src/wire.ts` — new `turn_start` union arm
- `packages/protocol/src/wire.test.ts` — type test
- `packages/runtime/src/session/chat.ts` — local-runtime emission
- `packages/runtime/src/turn/turn-session.ts` — cloud-executor emission
- `packages/runtime-client/src/snapshot.ts` — reducer handles the new arm
