### PR TITLE
feat(app): interaction cards replace the composer; Completed relabel; split notifications

### DIFF
--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -177,6 +177,7 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           {...(selectionProps ?? {})}
           chatEmptyState={panel.chatEmptyState}
           composerHeader={panel.composerHeader}
+          composerOverride={panel.composerOverride}
           canSendEmpty={panel.canSendEmpty}
           onComposerSubmit={panel.onComposerSubmit}
           footer={panel.footer}

--- a/app/src/components/chat-connect-interaction-card.tsx
+++ b/app/src/components/chat-connect-interaction-card.tsx
@@ -1,0 +1,43 @@
+import { IntegrationConnectCard } from "./integration-connect-card";
+
+interface ChatConnectInteractionCardProps {
+  /** The `#houston_toolkit=<slug>` app the agent asked the user to connect. */
+  toolkit: string;
+  /** The agent whose chat hosts the card (multiplayer grant attribution). */
+  agentId: string;
+  /** Multiplayer: auto-grant the fresh connection to this agent (C4). */
+  autoGrant: boolean;
+  /** Why the agent needs the connection, surfaced above the card when present. */
+  reason?: string;
+  /** Fired once when the connection the user drove from here lands — the panel
+   *  nudges the agent to resume (reuses the auto-continue path). */
+  onConnected: (toolkit: string, appName: string) => void;
+}
+
+/**
+ * The composer-replacing surface for a `request_connection` interaction: the
+ * agent's turn ended asking the user to connect an app, so the whole composer
+ * is taken over by the reason plus the SAME rich {@link IntegrationConnectCard}
+ * the inline `#houston_toolkit` link renders. Once the connection lands the
+ * turn resumes through `onConnected` (the auto-continue nudge) and the SDK
+ * clears the interaction, so this card disappears via the same reactivity.
+ */
+export function ChatConnectInteractionCard({
+  toolkit,
+  agentId,
+  autoGrant,
+  reason,
+  onConnected,
+}: ChatConnectInteractionCardProps) {
+  return (
+    <div className="flex flex-col gap-2 rounded-2xl border border-border bg-card p-4 shadow-sm">
+      {reason && <p className="text-sm text-foreground">{reason}</p>}
+      <IntegrationConnectCard
+        toolkit={toolkit}
+        agentId={agentId}
+        autoGrant={autoGrant}
+        onConnected={onConnected}
+      />
+    </div>
+  );
+}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -20,6 +20,7 @@
 import type { AIBoardProps } from "@houston-ai/board";
 import type { ChatMessage, ChatPanelProps, FeedItem } from "@houston-ai/chat";
 import {
+  ChatQuestionCard,
   decodeAttachmentMessage,
   UserAttachmentMessage,
   type UserAttachmentMessageLabels,
@@ -43,10 +44,14 @@ import {
   useSkills,
 } from "../hooks/queries";
 import { useCapabilities } from "../hooks/use-capabilities";
-import { useConversationFeed } from "../hooks/use-conversation-vm";
+import {
+  useConversationFeed,
+  useConversationVm,
+} from "../hooks/use-conversation-vm";
 import { useFileToolRenderer } from "../hooks/use-file-tool-renderer";
 import { useProviderStatuses } from "../hooks/use-provider-statuses";
 import { useSession } from "../hooks/use-session";
+import { deriveActiveInteraction } from "../lib/active-interaction";
 import { analytics } from "../lib/analytics";
 import { attachmentReferences } from "../lib/attachment-message";
 import {
@@ -94,6 +99,7 @@ import {
 } from "../lib/tauri";
 import type { Agent, AgentDefinition, SkillSummary } from "../lib/types";
 import { useUIStore } from "../stores/ui";
+import { ChatConnectInteractionCard } from "./chat-connect-interaction-card";
 import { resolveEffectiveProvider } from "./chat-effective-provider";
 import { ChatEffortSelector } from "./chat-effort-selector";
 import { ChatModelSelector } from "./chat-model-selector";
@@ -142,6 +148,10 @@ interface AgentChatPanelProps {
   chatEmptyState: AIBoardProps["chatEmptyState"];
   /** Selected Skill chip rendered above the prompt input. */
   composerHeader: AIBoardProps["composerHeader"];
+  /** Replaces the whole composer with the interaction card (ask_user /
+   *  request_connection) when the mission is waiting on the user. Undefined
+   *  when nothing is pending or a turn is running. */
+  composerOverride: AIBoardProps["composerOverride"];
   /** Submit can run the selected Skill without extra text. */
   canSendEmpty: AIBoardProps["canSendEmpty"];
   /** Intercepts composer submit while a Skill is selected. */
@@ -319,6 +329,12 @@ export function useAgentChatPanel({
   // turn-state source (history seeded by the adapter on load; live turns
   // folded by the SDK machinery).
   const sessionFeedItems = useConversationFeed(path, selectedSessionKey);
+
+  // The live turn state for this conversation, for the pending-interaction
+  // override: `running` gates the card (a running turn shows the composer, not
+  // the card) and `pendingInteraction` is the live source the derivation
+  // prefers over the persisted activity fallback.
+  const conversationVm = useConversationVm(path, selectedSessionKey);
 
   // Whether the open conversation already has turns. Once it does, the chat's
   // provider is frozen (see resolveEffectiveProvider): a provider that logs out
@@ -807,6 +823,87 @@ export function useAgentChatPanel({
     [integrationsEnabled, agent, capabilities, handleIntegrationConnected],
   );
 
+  // ── Pending-interaction override (ask_user / request_connection) ──────
+  // The one thing the mission is waiting on the user for: the live VM
+  // interaction if this client settled the turn, else the activity's persisted
+  // one (reload / observer). Gated on `running` so a fresh turn's composer wins
+  // and the card disappears the instant the user answers.
+  const activeInteraction = deriveActiveInteraction({
+    running: conversationVm?.running ?? false,
+    live: conversationVm?.pendingInteraction,
+    persisted: selectedActivity?.pending_interaction,
+  });
+
+  // Answering a question sends the text as a normal user message through the
+  // existing follow-up send path; the turn start clears the interaction, so the
+  // card retires through the same reactivity. A failure surfaces (no silent
+  // swallow) — the composer is gone, so a toast is the only channel left.
+  const handleInteractionAnswer = useCallback(
+    (text: string) => {
+      if (!path || !selectedSessionKey) return;
+      tauriChat
+        .send(path, text, selectedSessionKey, {
+          providerOverride: effectiveProvider,
+          modelOverride: effectiveModel,
+          effortOverride: effectiveEffort,
+        })
+        .catch((err) => {
+          addToast({
+            title: t("chat:errors.sessionStart", { error: String(err) }),
+            variant: "error",
+          });
+        });
+    },
+    [
+      path,
+      selectedSessionKey,
+      effectiveProvider,
+      effectiveModel,
+      effectiveEffort,
+      addToast,
+      t,
+    ],
+  );
+
+  const questionCardLabels = useMemo(
+    () => ({
+      typeOwnAnswer: t("chat:questionCard.typeOwnAnswer"),
+      placeholder: t("chat:questionCard.placeholder"),
+      send: t("chat:questionCard.send"),
+    }),
+    [t],
+  );
+
+  const composerOverride = useMemo<AIBoardProps["composerOverride"]>(() => {
+    if (!agent || !activeInteraction) return undefined;
+    if (activeInteraction.kind === "question") {
+      return (
+        <ChatQuestionCard
+          question={activeInteraction.question}
+          options={activeInteraction.options}
+          onAnswer={handleInteractionAnswer}
+          labels={questionCardLabels}
+        />
+      );
+    }
+    return (
+      <ChatConnectInteractionCard
+        toolkit={activeInteraction.toolkit}
+        agentId={agent.id}
+        autoGrant={canManageAgentGrants(capabilities, agent)}
+        reason={activeInteraction.reason}
+        onConnected={handleIntegrationConnected}
+      />
+    );
+  }, [
+    agent,
+    activeInteraction,
+    handleInteractionAnswer,
+    questionCardLabels,
+    capabilities,
+    handleIntegrationConnected,
+  ]);
+
   // ── Built JSX bundles ─────────────────────────────────────────────────
   const renderUserMessage = useCallback(
     (msg: { content: string }) => {
@@ -1126,6 +1223,7 @@ export function useAgentChatPanel({
   return {
     chatEmptyState,
     composerHeader,
+    composerOverride,
     canSendEmpty: activeSkill != null,
     onComposerSubmit: handleSkillComposerSubmit,
     footer,

--- a/app/src/hooks/completion-latches.ts
+++ b/app/src/hooks/completion-latches.ts
@@ -1,0 +1,98 @@
+/**
+ * Completion-notification latches, keyed by `agentPath::sessionKey`.
+ *
+ * A session's OS notification is latched at `SessionStatus completed` and fired
+ * on the settle's `ActivityChanged` echo — the ordering where the interaction
+ * the turn ended on has been folded into the conversation VM (by
+ * `persistBoardStatus`) and is readable, so the body reads question / connect /
+ * plain finish correctly.
+ *
+ * The catch: `ActivityChanged` carries only an `agentPath`, no session key (see
+ * `packages/protocol/src/events.ts`). So a single agent's echo can't name WHICH
+ * of its sessions settled. Firing every latch for the agent is wrong: a second
+ * session that completed in the same batch — or an unrelated `.houston` write
+ * that also emits `ActivityChanged` — would fire a latch whose own settle hasn't
+ * folded yet, sending it the plain body and then discarding it, so its real echo
+ * has nothing left to correct. The `ready` gate closes that window: a latch
+ * fires on an agent echo ONLY once its own settle has folded; a premature echo
+ * is skipped, leaving the latch for the session's own (later) echo. The grace
+ * timer force-fires as the backstop for a completed session this client never
+ * folds a VM for (no board card).
+ */
+
+/** The clock seam — real timers in the app, controllable ones in tests. */
+export interface LatchTimers {
+  set: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clear: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+interface Latch {
+  agentPath: string;
+  /** True once this session's settle has folded (its notification body is
+   *  readable). A non-forced fire is skipped until this returns true. */
+  ready: () => boolean;
+  /** Build + deliver the notification (reads the folded body at fire time). */
+  send: () => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const defaultTimers: LatchTimers = { set: setTimeout, clear: clearTimeout };
+
+export class CompletionLatches {
+  private readonly map = new Map<string, Latch>();
+  private readonly graceMs: number;
+  private readonly timers: LatchTimers;
+
+  constructor(graceMs: number, timers: LatchTimers = defaultTimers) {
+    this.graceMs = graceMs;
+    this.timers = timers;
+  }
+
+  /**
+   * Latch a completed session's notification. Re-latching the same key resets
+   * its grace timer (a session that completes twice keeps one pending latch).
+   */
+  latch(
+    agentPath: string,
+    sessionKey: string,
+    ready: () => boolean,
+    send: () => void,
+  ): void {
+    const key = `${agentPath}::${sessionKey}`;
+    const existing = this.map.get(key);
+    if (existing) this.timers.clear(existing.timer);
+    const timer = this.timers.set(() => this.fire(key, true), this.graceMs);
+    this.map.set(key, { agentPath, ready, send, timer });
+  }
+
+  /**
+   * An `ActivityChanged` echo landed for `agentPath`. Fire every latched
+   * completion for that agent whose OWN settle has folded; leave the rest for
+   * their own echo (this echo may belong to a sibling session or an unrelated
+   * write).
+   */
+  fireForAgent(agentPath: string): void {
+    // Snapshot keys first: `fire` mutates the map (deletes the fired entry).
+    for (const [key, entry] of [...this.map]) {
+      if (entry.agentPath === agentPath) this.fire(key, false);
+    }
+  }
+
+  /** Clear every pending timer and drop all latches (hook teardown). */
+  dispose(): void {
+    for (const entry of this.map.values()) this.timers.clear(entry.timer);
+    this.map.clear();
+  }
+
+  private fire(key: string, force: boolean): void {
+    const entry = this.map.get(key);
+    if (!entry) return;
+    // A non-forced (echo-driven) fire waits until this session's settle folded,
+    // so a sibling's or an unrelated write's echo can't fire it with the wrong
+    // body. The grace timer forces past the gate.
+    if (!force && !entry.ready()) return;
+    this.timers.clear(entry.timer);
+    this.map.delete(key);
+    entry.send();
+  }
+}

--- a/app/src/hooks/use-conversation-vm.ts
+++ b/app/src/hooks/use-conversation-vm.ts
@@ -42,6 +42,10 @@ export interface ConversationView {
   sessionStatus: ConversationVM["sessionStatus"];
   boardStatus: ConversationVM["boardStatus"];
   queued: ConversationVM["queued"];
+  /** What this conversation ended waiting on the user for (ask_user /
+   *  request_connection), or null. Set on settle, cleared on the next turn
+   *  start — drives the composer-replacing interaction card. */
+  pendingInteraction: ConversationVM["pendingInteraction"];
 }
 
 const EMPTY_FEED: FeedItem[] = [];
@@ -53,6 +57,7 @@ function toView(vm: ConversationVM): ConversationView {
     sessionStatus: vm.sessionStatus,
     boardStatus: vm.boardStatus,
     queued: vm.queued,
+    pendingInteraction: vm.pendingInteraction,
   };
 }
 
@@ -110,4 +115,39 @@ export function getConversationStatus(
     conversationScope(agentPath, sessionKey),
   ) as ConversationVM | undefined;
   return vm?.sessionStatus;
+}
+
+/**
+ * Synchronous, non-reactive read of a conversation's settled interaction — for
+ * the completion-notification body (use-session-events). The VM folds it via
+ * `persistBoardStatus`, which runs AFTER the `SessionStatus` bus event but
+ * BEFORE the `ActivityChanged` echo that same persist emits, so reading here on
+ * that echo sees the settled value. `undefined` = nothing published for this
+ * conversation yet; `null` = settled with nothing outstanding.
+ */
+export function getConversationInteraction(
+  agentPath: string,
+  sessionKey: string,
+): ConversationVM["pendingInteraction"] | undefined {
+  const vm = conversationStore.getSnapshot(
+    conversationScope(agentPath, sessionKey),
+  ) as ConversationVM | undefined;
+  return vm?.pendingInteraction;
+}
+
+/**
+ * Synchronous, non-reactive read of a conversation's board-card status — the
+ * completion latch's readiness gate (use-session-events). `persistBoardStatus`
+ * flips it from "running" to a terminal value in the SAME fold that stamps the
+ * settled interaction, so "not running" is the signal the notification body is
+ * readable. `undefined`/`null` = no board card folded for this conversation.
+ */
+export function getConversationBoardStatus(
+  agentPath: string,
+  sessionKey: string,
+): ConversationVM["boardStatus"] | undefined {
+  const vm = conversationStore.getSnapshot(
+    conversationScope(agentPath, sessionKey),
+  ) as ConversationVM | undefined;
+  return vm?.boardStatus;
 }

--- a/app/src/hooks/use-session-events.ts
+++ b/app/src/hooks/use-session-events.ts
@@ -1,6 +1,10 @@
 import type { HoustonEvent } from "@houston-ai/core";
 import { useEffect, useRef } from "react";
 import { useTranslation } from "react-i18next";
+import {
+  completionInteractionReady,
+  interactionNotificationBodyKey,
+} from "../lib/active-interaction";
 import { listenOsEvent, subscribeHoustonEvents } from "../lib/events";
 import { logger } from "../lib/logger";
 import {
@@ -11,12 +15,24 @@ import { isMac } from "../lib/platform";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
 import { useWorkspaceStore } from "../stores/workspaces";
+import { CompletionLatches } from "./completion-latches";
 import {
   consumePendingNav,
   describePendingNotificationNav,
   listenForNotificationFocus,
   sendSessionNotification,
 } from "./session-notifications";
+import {
+  getConversationBoardStatus,
+  getConversationInteraction,
+} from "./use-conversation-vm";
+
+/**
+ * How long a completed session waits for its settle `ActivityChanged` echo
+ * before its notification fires with the plain body. The echo normally lands
+ * within a tick; this is only the no-board-card backstop.
+ */
+const COMPLETION_INTERACTION_GRACE_MS = 2000;
 
 /**
  * Subscribe to "houston-event" from the engine bus.
@@ -46,6 +62,18 @@ export function useSessionEvents() {
     getAgent: () => useAgentStore.getState().current,
     t,
   };
+
+  // Completion notifications latched at `SessionStatus completed` and fired on
+  // the settle's `ActivityChanged` echo — the ordering where the interaction the
+  // turn ended on (folded into the conversation VM by `persistBoardStatus`) is
+  // readable, so the body reads question / connect / plain finish. A latch fires
+  // only once ITS session's settle has folded (`completionInteractionReady`), so
+  // a sibling session's echo or an unrelated `.houston` write — `ActivityChanged`
+  // carries no session key — can't fire it early with the plain body. The grace
+  // timer is the backstop for a completed session with no folded board card.
+  const latchesRef = useRef(
+    new CompletionLatches(COMPLETION_INTERACTION_GRACE_MS),
+  );
 
   useEffect(() => {
     if ("Notification" in window && Notification.permission === "default") {
@@ -93,15 +121,48 @@ export function useSessionEvents() {
               );
             }
 
-            sendSessionNotification(
-              h.t("common:notifications.sessionComplete.title", {
-                workspace: workspaceName,
-                agent: agentName,
-              }),
-              h.t("common:notifications.sessionComplete.body"),
-              nav,
+            const title = h.t("common:notifications.sessionComplete.title", {
+              workspace: workspaceName,
+              agent: agentName,
+            });
+            // Latch: the body depends on the interaction the turn settled on,
+            // which `persistBoardStatus` folds into the VM AFTER this event but
+            // BEFORE the settle's `ActivityChanged` echo. `ready` gates the echo
+            // fire on that fold having landed; the send reads the settled body.
+            latchesRef.current.latch(
+              agent_path,
+              session_key,
+              () =>
+                completionInteractionReady(
+                  getConversationBoardStatus(agent_path, session_key),
+                ),
+              () => {
+                const interaction =
+                  getConversationInteraction(agent_path, session_key) ?? null;
+                const bodyKey = interactionNotificationBodyKey(interaction);
+                const body =
+                  bodyKey === "sessionComplete.question"
+                    ? handlersRef.current.t(
+                        "common:notifications.sessionComplete.question",
+                      )
+                    : bodyKey === "sessionComplete.connect"
+                      ? handlersRef.current.t(
+                          "common:notifications.sessionComplete.connect",
+                        )
+                      : handlersRef.current.t(
+                          "common:notifications.sessionComplete.body",
+                        );
+                sendSessionNotification(title, body, nav);
+              },
             );
           }
+          break;
+        }
+        case "ActivityChanged": {
+          // The settle's write-through echo: fire any completion latched for
+          // this agent whose own settle has folded (a premature echo — sibling
+          // session or unrelated write — leaves the rest for their own echo).
+          latchesRef.current.fireForAgent(payload.data.agent_path);
           break;
         }
         case "Toast":
@@ -197,7 +258,9 @@ export function useSessionEvents() {
     // Fallback: Tauri window focus event (macOS only — see listenForNotificationFocus).
     const unlistenTauriFocus = listenForNotificationFocus();
 
+    const latches = latchesRef.current;
     return () => {
+      latches.dispose();
       unlisten();
       unlistenActivated();
       unlistenNotifClick();

--- a/app/src/lib/active-interaction.ts
+++ b/app/src/lib/active-interaction.ts
@@ -1,0 +1,61 @@
+import type { PendingInteraction } from "@houston/protocol";
+import type { BoardStatus } from "@houston/sdk";
+
+/**
+ * The one interaction the open conversation is waiting on the user for, or
+ * null. Drives the composer-replacing card (see `useAgentChatPanel`) and the
+ * differentiated completion notification.
+ *
+ * Two sources, in priority order:
+ *  1. `live` — the SDK conversation VM's `pendingInteraction`, set when THIS
+ *     client settled the turn on an `ask_user` / `request_connection`.
+ *  2. `persisted` — the activity's `pending_interaction`, the reload/observer
+ *     case: a client that never saw the live `done` frame reads the interaction
+ *     the engine stamped onto the board card.
+ *
+ * The override is shown ONLY when no turn is running: a fresh turn clears the
+ * VM interaction (running + null) the instant it starts, so returning null
+ * while `running` makes the card disappear through the same reactivity the
+ * turn start already drives — no separate teardown.
+ */
+export function deriveActiveInteraction(args: {
+  running: boolean;
+  live: PendingInteraction | null | undefined;
+  persisted: PendingInteraction | null | undefined;
+}): PendingInteraction | null {
+  if (args.running) return null;
+  return args.live ?? args.persisted ?? null;
+}
+
+/**
+ * Which completion-notification body an ended turn takes. `question` and
+ * `connect` are the two "the agent needs you" settles; everything else (a clean
+ * finish, a user stop, a provider error) reads as the plain "finished" body.
+ * Pure so the copy mapping is unit-tested without the event plumbing.
+ */
+export function interactionNotificationBodyKey(
+  interaction: PendingInteraction | null | undefined,
+):
+  | "sessionComplete.body"
+  | "sessionComplete.question"
+  | "sessionComplete.connect" {
+  if (interaction?.kind === "question") return "sessionComplete.question";
+  if (interaction?.kind === "connect") return "sessionComplete.connect";
+  return "sessionComplete.body";
+}
+
+/**
+ * Whether a completed session's notification body is READY to read: true once
+ * the turn's terminal board persist has folded (`boardStatus` left "running"),
+ * which is the same instant the settled interaction becomes readable. Until
+ * then a latched completion must not fire on an `ActivityChanged` echo — that
+ * echo may belong to a sibling session or an unrelated `.houston` write (the
+ * event carries no session key), and firing early would send the plain body.
+ * `null`/`undefined` (no board card folded) stays not-ready; the grace timer is
+ * that case's backstop. Pure so the gate is unit-tested without event plumbing.
+ */
+export function completionInteractionReady(
+  boardStatus: BoardStatus | null | undefined,
+): boolean {
+  return boardStatus != null && boardStatus !== "running";
+}

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -89,7 +89,7 @@
   },
   "tabLabels": {
     "activity": "Activity",
-    "archived": "Archived",
+    "archived": "Completed",
     "routines": "Routines",
     "files": "Files",
     "job-description": "Agent Settings",

--- a/app/src/locales/en/board.json
+++ b/app/src/locales/en/board.json
@@ -57,7 +57,7 @@
     "selected_one": "{{count}} selected",
     "selected_other": "{{count}} selected",
     "moveTo": "Move to",
-    "archive": "Archive",
+    "archive": "Complete",
     "delete": "Delete",
     "clear": "Clear selection",
     "cancel": "Cancel",
@@ -69,10 +69,10 @@
       "action": "Move"
     },
     "confirmArchive": {
-      "title": "Archive missions?",
-      "description_one": "Archive {{count}} mission? You can reopen it from the Archived tab.",
-      "description_other": "Archive {{count}} missions? You can reopen them from the Archived tab.",
-      "action": "Archive"
+      "title": "Complete missions?",
+      "description_one": "Complete {{count}} mission? You can reopen it from the Completed tab.",
+      "description_other": "Complete {{count}} missions? You can reopen them from the Completed tab.",
+      "action": "Complete"
     },
     "confirmDelete": {
       "title": "Delete missions?",
@@ -86,9 +86,9 @@
     "selectAll": "Select all in column"
   },
   "archived": {
-    "emptyTitle": "No archived missions",
-    "emptyDescription": "Archived missions appear here. Reply to one to bring it back.",
-    "searchPlaceholder": "Search archived missions"
+    "emptyTitle": "No completed missions",
+    "emptyDescription": "Completed missions appear here. Reply to one to bring it back.",
+    "searchPlaceholder": "Search completed missions"
   },
   "dnd": {
     "moveError": "Couldn't move the mission: {{error}}"

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -24,6 +24,11 @@
     "title": "Start a conversation",
     "description": "Type a message to talk to your assistant."
   },
+  "questionCard": {
+    "typeOwnAnswer": "Answer in your own words",
+    "placeholder": "Type your answer...",
+    "send": "Send"
+  },
   "errors": {
     "sessionStart": "Failed to start session: {{error}}",
     "stopSession": "Couldn't stop the mission: {{error}}",

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -39,7 +39,9 @@
   "notifications": {
     "sessionComplete": {
       "title": "{{workspace}} · {{agent}}",
-      "body": "Your agent has finished working."
+      "body": "Your agent has finished working.",
+      "question": "Your agent has a question for you.",
+      "connect": "Your agent needs you to connect an app."
     }
   }
 }

--- a/app/src/locales/en/dashboard.json
+++ b/app/src/locales/en/dashboard.json
@@ -2,8 +2,8 @@
   "title": "Mission Control",
   "archived": {
     "back": "Back",
-    "button": "Archived",
-    "title": "Archived"
+    "button": "Completed",
+    "title": "Completed"
   },
   "filter": {
     "allAgents": "All agents"

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -89,7 +89,7 @@
   },
   "tabLabels": {
     "activity": "Actividad",
-    "archived": "Archivadas",
+    "archived": "Completadas",
     "routines": "Rutinas",
     "files": "Archivos",
     "job-description": "Configuración del agente",

--- a/app/src/locales/es/board.json
+++ b/app/src/locales/es/board.json
@@ -57,7 +57,7 @@
     "selected_one": "{{count}} seleccionada",
     "selected_other": "{{count}} seleccionadas",
     "moveTo": "Mover a",
-    "archive": "Archivar",
+    "archive": "Completar",
     "delete": "Eliminar",
     "clear": "Quitar selección",
     "cancel": "Cancelar",
@@ -69,10 +69,10 @@
       "action": "Mover"
     },
     "confirmArchive": {
-      "title": "¿Archivar misiones?",
-      "description_one": "¿Archivar {{count}} misión? Puedes reabrirla desde la pestaña Archivadas.",
-      "description_other": "¿Archivar {{count}} misiones? Puedes reabrirlas desde la pestaña Archivadas.",
-      "action": "Archivar"
+      "title": "¿Completar misiones?",
+      "description_one": "¿Completar {{count}} misión? Puedes reabrirla desde la pestaña Completadas.",
+      "description_other": "¿Completar {{count}} misiones? Puedes reabrirlas desde la pestaña Completadas.",
+      "action": "Completar"
     },
     "confirmDelete": {
       "title": "¿Eliminar misiones?",
@@ -86,9 +86,9 @@
     "selectAll": "Seleccionar toda la columna"
   },
   "archived": {
-    "emptyTitle": "No hay misiones archivadas",
-    "emptyDescription": "Las misiones archivadas aparecen aquí. Responde a una para reactivarla.",
-    "searchPlaceholder": "Buscar misiones archivadas"
+    "emptyTitle": "No hay misiones completadas",
+    "emptyDescription": "Las misiones completadas aparecen aquí. Responde a una para reactivarla.",
+    "searchPlaceholder": "Buscar misiones completadas"
   },
   "dnd": {
     "moveError": "No se pudo mover la misión: {{error}}"

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -24,6 +24,11 @@
     "title": "Empieza una conversación",
     "description": "Escribe un mensaje para hablar con tu asistente."
   },
+  "questionCard": {
+    "typeOwnAnswer": "Responde con tus propias palabras",
+    "placeholder": "Escribe tu respuesta...",
+    "send": "Enviar"
+  },
   "errors": {
     "sessionStart": "No se pudo iniciar la sesión: {{error}}",
     "stopSession": "No se pudo detener la misión: {{error}}",

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -39,7 +39,9 @@
   "notifications": {
     "sessionComplete": {
       "title": "{{workspace}} · {{agent}}",
-      "body": "Tu agente terminó de trabajar."
+      "body": "Tu agente terminó de trabajar.",
+      "question": "Tu agente tiene una pregunta para ti.",
+      "connect": "Tu agente necesita que conectes una aplicación."
     }
   }
 }

--- a/app/src/locales/es/dashboard.json
+++ b/app/src/locales/es/dashboard.json
@@ -2,8 +2,8 @@
   "title": "Centro de misiones",
   "archived": {
     "back": "Volver",
-    "button": "Archivadas",
-    "title": "Archivadas"
+    "button": "Completadas",
+    "title": "Completadas"
   },
   "filter": {
     "allAgents": "Todos los agentes"

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -89,7 +89,7 @@
   },
   "tabLabels": {
     "activity": "Atividade",
-    "archived": "Arquivadas",
+    "archived": "Concluídas",
     "routines": "Rotinas",
     "files": "Arquivos",
     "job-description": "Configurações do agente",

--- a/app/src/locales/pt/board.json
+++ b/app/src/locales/pt/board.json
@@ -57,7 +57,7 @@
     "selected_one": "{{count}} selecionada",
     "selected_other": "{{count}} selecionadas",
     "moveTo": "Mover para",
-    "archive": "Arquivar",
+    "archive": "Concluir",
     "delete": "Excluir",
     "clear": "Limpar seleção",
     "cancel": "Cancelar",
@@ -69,10 +69,10 @@
       "action": "Mover"
     },
     "confirmArchive": {
-      "title": "Arquivar missões?",
-      "description_one": "Arquivar {{count}} missão? Você pode reabrir pela aba Arquivadas.",
-      "description_other": "Arquivar {{count}} missões? Você pode reabrir pela aba Arquivadas.",
-      "action": "Arquivar"
+      "title": "Concluir missões?",
+      "description_one": "Concluir {{count}} missão? Você pode reabrir pela aba Concluídas.",
+      "description_other": "Concluir {{count}} missões? Você pode reabrir pela aba Concluídas.",
+      "action": "Concluir"
     },
     "confirmDelete": {
       "title": "Excluir missões?",
@@ -86,9 +86,9 @@
     "selectAll": "Selecionar toda a coluna"
   },
   "archived": {
-    "emptyTitle": "Nenhuma missão arquivada",
-    "emptyDescription": "As missões arquivadas aparecem aqui. Responda a uma para reativá-la.",
-    "searchPlaceholder": "Buscar missões arquivadas"
+    "emptyTitle": "Nenhuma missão concluída",
+    "emptyDescription": "As missões concluídas aparecem aqui. Responda a uma para reativá-la.",
+    "searchPlaceholder": "Buscar missões concluídas"
   },
   "dnd": {
     "moveError": "Não foi possível mover a missão: {{error}}"

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -24,6 +24,11 @@
     "title": "Comece uma conversa",
     "description": "Digite uma mensagem para falar com seu assistente."
   },
+  "questionCard": {
+    "typeOwnAnswer": "Responda com suas próprias palavras",
+    "placeholder": "Digite sua resposta...",
+    "send": "Enviar"
+  },
   "errors": {
     "sessionStart": "Não foi possível iniciar a sessão: {{error}}",
     "stopSession": "Não foi possível parar a missão: {{error}}",

--- a/app/src/locales/pt/common.json
+++ b/app/src/locales/pt/common.json
@@ -39,7 +39,9 @@
   "notifications": {
     "sessionComplete": {
       "title": "{{workspace}} · {{agent}}",
-      "body": "Seu agente terminou de trabalhar."
+      "body": "Seu agente terminou de trabalhar.",
+      "question": "Seu agente tem uma pergunta para você.",
+      "connect": "Seu agente precisa que você conecte um aplicativo."
     }
   }
 }

--- a/app/src/locales/pt/dashboard.json
+++ b/app/src/locales/pt/dashboard.json
@@ -2,8 +2,8 @@
   "title": "Central de missões",
   "archived": {
     "back": "Voltar",
-    "button": "Arquivadas",
-    "title": "Arquivadas"
+    "button": "Concluídas",
+    "title": "Concluídas"
   },
   "filter": {
     "allAgents": "Todos os agentes"

--- a/app/tests/active-interaction.test.ts
+++ b/app/tests/active-interaction.test.ts
@@ -1,0 +1,102 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { PendingInteraction } from "@houston/protocol";
+import {
+  completionInteractionReady,
+  deriveActiveInteraction,
+  interactionNotificationBodyKey,
+} from "../src/lib/active-interaction.ts";
+
+const question: PendingInteraction = {
+  kind: "question",
+  question: "Which account?",
+  options: [{ id: "a", label: "Work" }],
+};
+const connect: PendingInteraction = { kind: "connect", toolkit: "gmail" };
+
+describe("deriveActiveInteraction", () => {
+  it("hides the override while a turn is running", () => {
+    strictEqual(
+      deriveActiveInteraction({
+        running: true,
+        live: question,
+        persisted: connect,
+      }),
+      null,
+    );
+  });
+
+  it("prefers the live VM interaction over the persisted one", () => {
+    strictEqual(
+      deriveActiveInteraction({
+        running: false,
+        live: question,
+        persisted: connect,
+      }),
+      question,
+    );
+  });
+
+  it("falls back to the persisted interaction on reload (no live)", () => {
+    strictEqual(
+      deriveActiveInteraction({
+        running: false,
+        live: null,
+        persisted: connect,
+      }),
+      connect,
+    );
+  });
+
+  it("is null when nothing is pending", () => {
+    strictEqual(
+      deriveActiveInteraction({
+        running: false,
+        live: null,
+        persisted: undefined,
+      }),
+      null,
+    );
+  });
+});
+
+describe("interactionNotificationBodyKey", () => {
+  it("maps a pending question to the question body", () => {
+    strictEqual(
+      interactionNotificationBodyKey(question),
+      "sessionComplete.question",
+    );
+  });
+
+  it("maps a pending connect to the connect body", () => {
+    strictEqual(
+      interactionNotificationBodyKey(connect),
+      "sessionComplete.connect",
+    );
+  });
+
+  it("maps a clean finish (no interaction) to the plain body", () => {
+    strictEqual(interactionNotificationBodyKey(null), "sessionComplete.body");
+    strictEqual(
+      interactionNotificationBodyKey(undefined),
+      "sessionComplete.body",
+    );
+  });
+});
+
+describe("completionInteractionReady", () => {
+  it("is not ready while the turn is still running (fold pending)", () => {
+    strictEqual(completionInteractionReady("running"), false);
+  });
+
+  it("is not ready when no board card has folded", () => {
+    strictEqual(completionInteractionReady(null), false);
+    strictEqual(completionInteractionReady(undefined), false);
+  });
+
+  it("is ready once the terminal board persist folded", () => {
+    strictEqual(completionInteractionReady("done"), true);
+    strictEqual(completionInteractionReady("needs_you"), true);
+    strictEqual(completionInteractionReady("error"), true);
+  });
+});

--- a/app/tests/completion-latches.test.ts
+++ b/app/tests/completion-latches.test.ts
@@ -1,0 +1,156 @@
+import { deepStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  CompletionLatches,
+  type LatchTimers,
+} from "../src/hooks/completion-latches.ts";
+
+/**
+ * A controllable clock: latch timers never fire on their own; the test runs
+ * them explicitly via `runAll` to exercise the grace backstop.
+ */
+function fakeTimers(): LatchTimers & { runAll: () => void } {
+  const pending = new Map<number, () => void>();
+  let next = 1;
+  return {
+    set(fn) {
+      const id = next++;
+      pending.set(id, fn);
+      return id as unknown as ReturnType<typeof setTimeout>;
+    },
+    clear(handle) {
+      pending.delete(handle as unknown as number);
+    },
+    runAll() {
+      for (const [id, fn] of [...pending]) {
+        pending.delete(id);
+        fn();
+      }
+    },
+  };
+}
+
+describe("CompletionLatches", () => {
+  it("fires a session's notification on its own echo once the settle folded", () => {
+    const timers = fakeTimers();
+    const latches = new CompletionLatches(2000, timers);
+    const sent: string[] = [];
+    let ready = false;
+
+    latches.latch(
+      "Work/Sales",
+      "s1",
+      () => ready,
+      () => sent.push("s1"),
+    );
+
+    // Echo before the fold: nothing fires yet.
+    latches.fireForAgent("Work/Sales");
+    deepStrictEqual(sent, []);
+
+    // The settle folds; its own echo now fires.
+    ready = true;
+    latches.fireForAgent("Work/Sales");
+    deepStrictEqual(sent, ["s1"]);
+
+    // A later echo is a no-op (the latch is gone).
+    latches.fireForAgent("Work/Sales");
+    deepStrictEqual(sent, ["s1"]);
+  });
+
+  it("does NOT fire a sibling latch whose settle has not folded yet (the bug)", () => {
+    const timers = fakeTimers();
+    const latches = new CompletionLatches(2000, timers);
+    // Body each session WOULD send, resolved from its own fold state at fire
+    // time — the real hook reads the VM interaction the same way.
+    const body: string[] = [];
+    const foldedA = { done: false };
+    const foldedB = { done: false };
+
+    // A finishes cleanly; B ends on a question. Both are latched for the SAME
+    // agent, before either settle folds.
+    latches.latch(
+      "Work/Sales",
+      "A",
+      () => foldedA.done,
+      () => body.push(foldedA.done ? "A:plain" : "A:unfolded"),
+    );
+    latches.latch(
+      "Work/Sales",
+      "B",
+      () => foldedB.done,
+      () => body.push(foldedB.done ? "B:question" : "B:plain"),
+    );
+
+    // A's settle folds and emits `ActivityChanged` (no session key). Pre-fix,
+    // the handler fired EVERY latch for the agent, so B fired here — unfolded —
+    // and would have sent "B:plain", then been discarded.
+    foldedA.done = true;
+    latches.fireForAgent("Work/Sales");
+    deepStrictEqual(body, ["A:plain"]);
+
+    // B's own settle folds; its echo fires with the correct question body.
+    foldedB.done = true;
+    latches.fireForAgent("Work/Sales");
+    deepStrictEqual(body, ["A:plain", "B:question"]);
+  });
+
+  it("grace timer force-fires a completed session that never folds a board card", () => {
+    const timers = fakeTimers();
+    const latches = new CompletionLatches(2000, timers);
+    const sent: string[] = [];
+
+    latches.latch(
+      "Work/Sales",
+      "s1",
+      () => false, // no board card ever folds
+      () => sent.push("s1"),
+    );
+
+    latches.fireForAgent("Work/Sales");
+    deepStrictEqual(sent, []); // gate holds
+
+    timers.runAll(); // backstop
+    deepStrictEqual(sent, ["s1"]);
+  });
+
+  it("scopes fires by agent path", () => {
+    const timers = fakeTimers();
+    const latches = new CompletionLatches(2000, timers);
+    const sent: string[] = [];
+
+    latches.latch(
+      "Work/Sales",
+      "s1",
+      () => true,
+      () => sent.push("sales"),
+    );
+    latches.latch(
+      "Work/Ops",
+      "s2",
+      () => true,
+      () => sent.push("ops"),
+    );
+
+    latches.fireForAgent("Work/Ops");
+    deepStrictEqual(sent, ["ops"]);
+  });
+
+  it("dispose clears pending latches so nothing fires after teardown", () => {
+    const timers = fakeTimers();
+    const latches = new CompletionLatches(2000, timers);
+    const sent: string[] = [];
+
+    latches.latch(
+      "Work/Sales",
+      "s1",
+      () => true,
+      () => sent.push("s1"),
+    );
+    latches.dispose();
+
+    latches.fireForAgent("Work/Sales");
+    timers.runAll();
+    deepStrictEqual(sent, []);
+  });
+});

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,15 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v4 - 2026-07-06
+
+Add `question-card`: the in-chat surface shown when the agent pauses mid-turn to
+ask the user a question (protocol `PendingInteraction` kind=question). Replaces
+the composer until answered; prominent prompt, always-visible option buttons, a
+quiet toggle to an inline free-text answer (shown directly when there are no
+options). Web ships it as a shared `ui/` piece (`@houston-ai/chat`
+`ChatQuestionCard`), so it lands `implemented`.
+
 ## v3 - 2026-07-05
 
 Add `agent-provisioning-card` (HOU-693): the in-chat notice (and its

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 3
+version: 4
 
 components:
   - id: agent-avatar
@@ -226,6 +226,20 @@ components:
       mission, feedback returns it to the agent. Status drives the indicator.
     a11y: needs-you item announced; approve is a labeled primary button; live status.
     since: 1
+
+  - id: question-card
+    title: Question card
+    purpose: In-chat surface shown when the agent pauses mid-turn to ask the user a question; replaces the composer until answered.
+    anatomy: [question-prompt, option-buttons, own-answer-toggle, free-text-input, send-action]
+    states: [with-options, free-text-only, free-text-open, disabled]
+    variants: [choice, open-ended]
+    behavior: >-
+      Rendered from the turn's pending interaction (kind=question). Option click
+      answers with that option's label; the toggle reveals an inline free-text
+      answer (shown directly when no options). Answering resumes the turn;
+      disabled while another turn is active.
+    a11y: question announced as the primary prompt; options and the free-text toggle are labeled buttons visible at rest (no hover gate).
+    since: 4
 
   - id: deliverable-card
     title: Deliverable card

--- a/design/inventory/manifests/android.yaml
+++ b/design/inventory/manifests/android.yaml
@@ -63,3 +63,5 @@ components:
     status: not-started
   agent-provisioning-card:
     status: not-started
+  question-card:
+    status: not-started

--- a/design/inventory/manifests/ios.yaml
+++ b/design/inventory/manifests/ios.yaml
@@ -130,3 +130,6 @@ components:
   agent-provisioning-card:
     status: not-started
     notes: Hosted-engine warm-up notice (HOU-693); mobile v1 has no create-agent flow yet.
+  question-card:
+    status: not-started
+    notes: In-chat ask-the-user question surface; mid-turn pending-interaction flow not in mobile v1.

--- a/design/inventory/manifests/web.yaml
+++ b/design/inventory/manifests/web.yaml
@@ -13,7 +13,7 @@
 
 surface: web
 enforced: true
-inventoryVersion: 3
+inventoryVersion: 4
 
 components:
   agent-avatar:
@@ -86,6 +86,10 @@ components:
   approval-surface:
     status: implemented
     ref: "@houston-ai/review ReviewItem / ReviewDetailPanel / DeliverableCard"
+
+  question-card:
+    status: implemented
+    ref: "@houston-ai/chat ChatQuestionCard (question-card + question-card-logic)"
 
   deliverable-card:
     status: implemented

--- a/packages/web/e2e/interaction.spec.ts
+++ b/packages/web/e2e/interaction.spec.ts
@@ -1,0 +1,116 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * Element 4: the pending-interaction hand-off. When a turn ends on an
+ * `ask_user` / `request_connection`, its `done` frame carries a
+ * `PendingInteraction`; the SDK settles the board to `needs_you` and the app
+ * REPLACES the composer with the interaction card (`composerOverride`). These
+ * specs arm the fake host's `/__test__/chat-interaction` control so the next
+ * scripted turn ends on an interaction, then drive the whole seam end-to-end:
+ * card replaces composer → user answers → normal composer returns.
+ */
+
+/**
+ * A question interaction: the card replaces the composer with the prompt and
+ * its option buttons, clicking an option sends its label as a new user message,
+ * and the follow-up composer returns once the answering turn starts.
+ */
+test("shows the question card in place of the composer and answers via an option", async ({
+  page,
+  request,
+}) => {
+  // Arm the NEXT turn to end asking the user to pick a flight time.
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: {
+      interaction: {
+        kind: "question",
+        question: "Do you want the morning or evening flight?",
+        options: [
+          { id: "morning", label: "Morning flight" },
+          { id: "evening", label: "Evening flight" },
+        ],
+      },
+    },
+  });
+
+  await page.goto("/");
+  await page.locator('[data-tour-target="newMission"]').click();
+
+  const composer = page.getByPlaceholder("What should the agent work on?");
+  await expect(composer).toBeVisible();
+  await composer.fill("book my flight");
+  await composer.press("Enter");
+
+  // The turn streams its canned reply and settles on the interaction.
+  await expect(page.getByText(/Roger that\. You said:/)).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // The question card has taken over the composer slot: the prompt reads as
+  // the one thing to do, its options are always-visible buttons, and the
+  // normal follow-up composer is gone.
+  await expect(
+    page.getByText("Do you want the morning or evening flight?"),
+  ).toBeVisible({ timeout: 15_000 });
+  const morning = page.getByRole("button", { name: "Morning flight" });
+  await expect(morning).toBeVisible();
+  await expect(
+    page.getByRole("button", { name: "Evening flight" }),
+  ).toBeVisible();
+  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+
+  // Clicking an option sends its label as a normal user message...
+  await morning.click();
+
+  await expect(page.getByText("Morning flight").first()).toBeVisible();
+  // ...the answering turn starts, so the card retires and the normal composer
+  // returns through the same reactivity.
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(
+    page.getByText("Do you want the morning or evening flight?"),
+  ).toHaveCount(0);
+});
+
+/**
+ * A connect interaction: the card replaces the composer with the reason and the
+ * rich integration connect card (the same `IntegrationConnectCard` the inline
+ * `#houston_toolkit` link renders) for the toolkit the agent asked for.
+ */
+test("shows the connect card in the composer slot for a request_connection", async ({
+  page,
+  request,
+}) => {
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: {
+      interaction: {
+        kind: "connect",
+        toolkit: "gmail",
+        reason: "I need access to your Gmail to send the trip itinerary.",
+      },
+    },
+  });
+
+  await page.goto("/");
+  await page.locator('[data-tour-target="newMission"]').click();
+
+  const composer = page.getByPlaceholder("What should the agent work on?");
+  await expect(composer).toBeVisible();
+  await composer.fill("email me the itinerary");
+  await composer.press("Enter");
+
+  await expect(page.getByText(/Roger that\. You said:/)).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // The connect card owns the composer slot: the reason plus the rich
+  // integration connect card (its Connect action is the distinctive proof the
+  // IntegrationConnectCard rendered), with the normal composer gone.
+  await expect(
+    page.getByText("I need access to your Gmail to send the trip itinerary."),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByRole("button", { name: "Connect" })).toBeVisible();
+  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+});

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -209,6 +209,14 @@ export { distinctAuthorCount } from "./feed-to-messages";
 export { messagePreviewText } from "./message-preview";
 export type { ProgressPanelProps } from "./progress-panel";
 export { ProgressPanel } from "./progress-panel";
+// === Question Card ===
+// The in-chat surface shown when the agent pauses to ask the user something;
+// replaces the composer while a pending interaction is awaiting an answer.
+export type {
+  ChatQuestionCardProps,
+  ChatQuestionOption,
+} from "./question-card";
+export { ChatQuestionCard } from "./question-card";
 export type {
   QueuedChatMessage,
   QueuedMessageLabels,

--- a/ui/chat/src/question-card-logic.ts
+++ b/ui/chat/src/question-card-logic.ts
@@ -1,0 +1,30 @@
+// Pure, DOM-free logic + class tokens for ChatQuestionCard. Kept in a plain
+// `.ts` module (mirroring chat-process-classes.ts) so the node:test suite can
+// import and assert them without a DOM — the .tsx component re-uses them.
+
+export interface ChatQuestionOption {
+  id: string;
+  label: string;
+}
+
+/** The question must read as the single next action: this card REPLACES the
+ *  composer while shown, so the prompt is sized up and weighted. */
+export const QUESTION_TEXT_CLASS =
+  "text-lg font-medium leading-snug text-foreground";
+
+/** The "answer in your own words" escape hatch stays visible at all times
+ *  (never hover-gated, per the no-hover-only-affordances rule) but reads as a
+ *  quiet, secondary action. */
+export const OWN_ANSWER_TOGGLE_CLASS =
+  "mt-3 text-sm text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-50";
+
+/** True when the agent offered concrete choices (option buttons render). */
+export function hasSelectableOptions(options?: ChatQuestionOption[]): boolean {
+  return Array.isArray(options) && options.length > 0;
+}
+
+/** Trim a typed free-text answer; whitespace-only answers are not sendable. */
+export function normalizeAnswer(text: string): string | null {
+  const trimmed = text.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/ui/chat/src/question-card.tsx
+++ b/ui/chat/src/question-card.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Button, cn, Textarea } from "@houston-ai/core";
+import { type KeyboardEvent, useCallback, useState } from "react";
+import {
+  type ChatQuestionOption,
+  hasSelectableOptions,
+  normalizeAnswer,
+  OWN_ANSWER_TOGGLE_CLASS,
+  QUESTION_TEXT_CLASS,
+} from "./question-card-logic";
+
+export type { ChatQuestionOption } from "./question-card-logic";
+
+export interface ChatQuestionCardProps {
+  question: string;
+  options?: ChatQuestionOption[];
+  /** Option click sends the option's label; free-text sends the typed text. */
+  onAnswer: (text: string) => void;
+  disabled?: boolean;
+  labels?: { typeOwnAnswer?: string; placeholder?: string; send?: string };
+}
+
+/**
+ * The in-chat surface shown when the agent pauses to ask the user something.
+ * It REPLACES the composer, so it must read as "the one thing to do now":
+ * a prominent question, always-visible option buttons, and a quiet toggle to
+ * an inline free-text answer. With no options, the text input shows directly.
+ */
+export function ChatQuestionCard({
+  question,
+  options,
+  onAnswer,
+  disabled = false,
+  labels,
+}: ChatQuestionCardProps) {
+  const hasOptions = hasSelectableOptions(options);
+  // No options → free-text is the only way to answer, so show it immediately
+  // rather than behind a toggle.
+  const [showFreeText, setShowFreeText] = useState(!hasOptions);
+  const [text, setText] = useState("");
+
+  const typeOwnAnswerLabel =
+    labels?.typeOwnAnswer ?? "Answer in your own words";
+  const placeholder = labels?.placeholder ?? "Type your answer...";
+  const sendLabel = labels?.send ?? "Send";
+
+  const answer = useCallback(
+    (value: string) => {
+      if (disabled) return;
+      const normalized = normalizeAnswer(value);
+      if (normalized === null) return;
+      onAnswer(normalized);
+    },
+    [disabled, onAnswer],
+  );
+
+  const submitFreeText = useCallback(() => {
+    answer(text);
+    setText("");
+  }, [answer, text]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        e.preventDefault();
+        submitFreeText();
+      }
+    },
+    [submitFreeText],
+  );
+
+  // A pure card: the composer slot that hosts it owns the outer layout
+  // (padding + max-width + centering), so this component adds none — it sits
+  // consistently beside the connect interaction card in the same slot.
+  return (
+    <div
+      aria-disabled={disabled || undefined}
+      className={cn(
+        "rounded-3xl border border-border/60 bg-card p-5 shadow-sm",
+        disabled && "opacity-50",
+      )}
+    >
+      <p className={QUESTION_TEXT_CLASS}>{question}</p>
+
+      {hasOptions && (
+        <div className="mt-4 flex flex-wrap gap-2">
+          {options?.map((option) => (
+            <Button
+              className="rounded-full"
+              disabled={disabled}
+              key={option.id}
+              onClick={() => answer(option.label)}
+              type="button"
+              variant="outline"
+            >
+              {option.label}
+            </Button>
+          ))}
+        </div>
+      )}
+
+      {hasOptions && !showFreeText && (
+        <button
+          className={OWN_ANSWER_TOGGLE_CLASS}
+          disabled={disabled}
+          onClick={() => setShowFreeText(true)}
+          type="button"
+        >
+          {typeOwnAnswerLabel}
+        </button>
+      )}
+
+      {showFreeText && (
+        <div className={cn("flex items-end gap-2", hasOptions && "mt-4")}>
+          <Textarea
+            className="min-h-11 flex-1 resize-none rounded-2xl"
+            disabled={disabled}
+            onChange={(e) => setText(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={placeholder}
+            rows={1}
+            value={text}
+          />
+          <Button
+            className="rounded-full"
+            disabled={disabled || normalizeAnswer(text) === null}
+            onClick={submitFreeText}
+            type="button"
+          >
+            {sendLabel}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/chat/tests/question-card.test.ts
+++ b/ui/chat/tests/question-card.test.ts
@@ -1,0 +1,59 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  hasSelectableOptions,
+  normalizeAnswer,
+  OWN_ANSWER_TOGGLE_CLASS,
+  QUESTION_TEXT_CLASS,
+} from "../src/question-card-logic.ts";
+
+function tokens(className: string): Set<string> {
+  return new Set(className.split(/\s+/).filter(Boolean));
+}
+
+describe("hasSelectableOptions", () => {
+  it("is true when the agent offered concrete choices", () => {
+    assert.equal(hasSelectableOptions([{ id: "a", label: "Yes" }]), true);
+  });
+
+  it("is false for an empty or missing option list (free-text only)", () => {
+    assert.equal(hasSelectableOptions([]), false);
+    assert.equal(hasSelectableOptions(undefined), false);
+  });
+});
+
+describe("normalizeAnswer", () => {
+  it("trims a typed answer", () => {
+    assert.equal(normalizeAnswer("  last quarter  "), "last quarter");
+  });
+
+  it("blocks a whitespace-only answer from being sent", () => {
+    assert.equal(normalizeAnswer("   "), null);
+    assert.equal(normalizeAnswer(""), null);
+  });
+});
+
+describe("question-card class tokens", () => {
+  // The card replaces the composer, so the question must read as the single
+  // next action — sized up and weighted.
+  it("renders the question prominently", () => {
+    const t = tokens(QUESTION_TEXT_CLASS);
+    assert.ok(t.has("text-lg"));
+    assert.ok(t.has("font-medium"));
+  });
+
+  // No-hover-only-affordances rule: the "answer in your own words" toggle must
+  // be visible at rest, never gated behind a hover/opacity trick.
+  it("keeps the free-text toggle visible without hover", () => {
+    const t = tokens(OWN_ANSWER_TOGGLE_CLASS);
+    assert.ok(!t.has("hidden"));
+    assert.ok(!t.has("opacity-0"));
+    assert.ok(!t.has("group-hover:opacity-100"));
+    for (const token of t) {
+      assert.ok(
+        !token.startsWith("group-hover:"),
+        `toggle must not be hover-gated: ${token}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## What

Element 4 — the visible half of the interaction refactor (#718 → #721 → #722 → #723). Users don't read questions buried in reply text; now a pending interaction takes over the input area.

- **`ChatQuestionCard`** (new in `@houston-ai/chat`, props-only, tokens-only): prominent question, option buttons, always-visible free-text escape. Inventory v4 + web manifest + CHANGELOG bumped (`check:parity` green).
- **Composer takeover**: live `ConversationVM.pendingInteraction`, falling back to the activity's persisted `pending_interaction` after reload; never shown while a turn runs. Question answers send as a normal turn; connect interactions reuse `IntegrationConnectCard` (existing auto-continue) in the composer slot. Legacy `#houston_toolkit` link cards in old transcripts unaffected.
- **Notifications split by outcome**: question / connect / plain-finish copy; completion latch keyed per conversation so concurrent settles can't cross-fire (adversarial-review finding, fixed with a failing test first).
- **Archived → Completed** relabel across en/es/pt (tab, bulk actions, confirm dialogs, empty states); internal status stays `archived`. Done column copy reflects engine-set done.
- New Playwright spec (`packages/web/e2e/interaction.spec.ts`) drives question + connect cards through the fake-host `/__test__/chat-interaction` route.

## Tests

App unit 837 passed; ui/chat card tests 6; app + repo typecheck; check-locales green; check:parity green; full web e2e suite green (incl. new spec); biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)