### PR TITLE
feat: ask_user batches up to 3 questions; question card rebuilt to composer grade

### DIFF
--- a/app/src-tauri/src/houston_prompt/base.rs
+++ b/app/src-tauri/src/houston_prompt/base.rs
@@ -24,7 +24,7 @@ Assume the user is smart and busy, but not technical.
 
 - Be concise. No throat-clearing, filler, praise, or restating the request.
 - Use plain words. Avoid jargon unless the user uses it first.
-- When you need something from the user, a question, a choice, or a go-ahead, ask through the `ask_user` tool, then end your turn. The question appears to the user as an interactive card in place of the chat box, so do not repeat it in your reply, and never leave a question sitting in plain text. Their answer comes back as a normal user message.
+- When you need something from the user, a question, a choice, or a go-ahead, ask through the `ask_user` tool, then end your turn. Batch everything you need before you can act into that ONE call, up to 3 questions at once, never one question per turn. The questions appear to the user as a single interactive card in place of the chat box, so do not repeat them in your reply, and never leave a question sitting in plain text. Their answers come back as a normal user message.
 - Briefly explain why you need missing information or an integration.
 - Report outcomes, choices, blockers, and approval requests. Do not narrate implementation steps.
 - For long-running or risky work, give short status updates in user language.
@@ -42,7 +42,7 @@ Use this loop silently before acting. Do not show this checklist to the user.
    - Required integrations: which connected apps or accounts are needed?
    - Approval: does execution need explicit user approval?
 3. Ask only for what is missing. Whenever you need to ask the user for anything, use the `ask_user` tool and then end your turn. Never end a turn with a question written in plain text.
-   - If information is missing, ask for one thing at a time with `ask_user`.
+   - If information is missing, gather everything you still need and ask it in ONE `ask_user` call, up to 3 questions. Three is a cap, not a target.
    - If an integration is missing, briefly say what must be connected and why, then call `request_connection`.
    - If approval is required, ask with `ask_user` before execution, offering the choices as options.
 4. Execute when ready.

--- a/app/src-tauri/src/houston_prompt/mod.rs
+++ b/app/src-tauri/src/houston_prompt/mod.rs
@@ -82,6 +82,18 @@ mod tests {
     }
 
     #[test]
+    fn prompt_tells_the_agent_to_batch_questions_into_one_call() {
+        let prompt = system_prompt_pi();
+
+        assert!(prompt.contains("up to 3 questions"));
+        assert!(prompt.contains("never one question per turn"));
+        assert!(prompt.contains("Three is a cap, not a target"));
+        // The old one-question-per-turn drip is gone.
+        assert!(!prompt.contains("one thing at a time"));
+        assert!(!prompt.contains("one question at a time"));
+    }
+
+    #[test]
     fn memory_guidance_requires_user_opt_in() {
         let prompt = system_prompt_pi();
 

--- a/app/src-tauri/src/houston_prompt/routines.rs
+++ b/app/src-tauri/src/houston_prompt/routines.rs
@@ -8,7 +8,7 @@ Do not confuse Routines with other persistent behavior:
 - A reusable workflow the user runs manually is a Skill.
 - Automatic future work on a schedule is a Routine.
 
-Before creating or updating a Routine, confirm the following with the user (ask through the `ask_user` tool, one question at a time, then end your turn):
+Before creating or updating a Routine, confirm the following with the user (ask through the `ask_user` tool, batching what you still need into one call, up to 3 questions, then end your turn):
 - What should happen.
 - When it should run.
 - What information is needed.

--- a/app/src-tauri/src/houston_prompt/skills_memory.rs
+++ b/app/src-tauri/src/houston_prompt/skills_memory.rs
@@ -40,7 +40,7 @@ Skill rules:
 - `image` should be a Fluent emoji slug or a full https URL.
 - `featured: yes` makes the Skill visible in the chat empty state.
 - `integrations` lists Composio toolkit slugs when the Skill needs connected apps.
-- If a Skill needs missing details, the procedure should ask one targeted question through the `ask_user` tool and continue when the answer arrives.
+- If a Skill needs missing details, the procedure should ask for them together through the `ask_user` tool, up to 3 questions in one call, and continue when the answers arrive.
 - The desktop adds an explicit `Use the <skill> skill.` prefix so invocation stays deterministic.
 
 The Skill body is allowed to contain technical procedure details. But any text it tells the AI to say to the user must follow the user-voice rules above.

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -867,7 +867,6 @@ export function useAgentChatPanel({
 
   const questionCardLabels = useMemo(
     () => ({
-      typeOwnAnswer: t("chat:questionCard.typeOwnAnswer"),
       placeholder: t("chat:questionCard.placeholder"),
       send: t("chat:questionCard.send"),
     }),
@@ -879,8 +878,7 @@ export function useAgentChatPanel({
     if (activeInteraction.kind === "question") {
       return (
         <ChatQuestionCard
-          question={activeInteraction.question}
-          options={activeInteraction.options}
+          questions={activeInteraction.questions}
           onAnswer={handleInteractionAnswer}
           labels={questionCardLabels}
         />

--- a/app/src/hooks/use-session-events.ts
+++ b/app/src/hooks/use-session-events.ts
@@ -144,6 +144,12 @@ export function useSessionEvents() {
                   bodyKey === "sessionComplete.question"
                     ? handlersRef.current.t(
                         "common:notifications.sessionComplete.question",
+                        {
+                          count:
+                            interaction?.kind === "question"
+                              ? interaction.questions.length
+                              : 1,
+                        },
                       )
                     : bodyKey === "sessionComplete.connect"
                       ? handlersRef.current.t(

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -25,7 +25,6 @@
     "description": "Type a message to talk to your assistant."
   },
   "questionCard": {
-    "typeOwnAnswer": "Answer in your own words",
     "placeholder": "Type your answer...",
     "send": "Send"
   },

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -40,7 +40,8 @@
     "sessionComplete": {
       "title": "{{workspace}} · {{agent}}",
       "body": "Your agent has finished working.",
-      "question": "Your agent has a question for you.",
+      "question_one": "Your agent has a question for you.",
+      "question_other": "Your agent has questions for you.",
       "connect": "Your agent needs you to connect an app."
     }
   }

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -25,7 +25,6 @@
     "description": "Escribe un mensaje para hablar con tu asistente."
   },
   "questionCard": {
-    "typeOwnAnswer": "Responde con tus propias palabras",
     "placeholder": "Escribe tu respuesta...",
     "send": "Enviar"
   },

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -40,7 +40,8 @@
     "sessionComplete": {
       "title": "{{workspace}} · {{agent}}",
       "body": "Tu agente terminó de trabajar.",
-      "question": "Tu agente tiene una pregunta para ti.",
+      "question_one": "Tu agente tiene una pregunta para ti.",
+      "question_other": "Tu agente tiene preguntas para ti.",
       "connect": "Tu agente necesita que conectes una aplicación."
     }
   }

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -25,7 +25,6 @@
     "description": "Digite uma mensagem para falar com seu assistente."
   },
   "questionCard": {
-    "typeOwnAnswer": "Responda com suas próprias palavras",
     "placeholder": "Digite sua resposta...",
     "send": "Enviar"
   },

--- a/app/src/locales/pt/common.json
+++ b/app/src/locales/pt/common.json
@@ -40,7 +40,8 @@
     "sessionComplete": {
       "title": "{{workspace}} · {{agent}}",
       "body": "Seu agente terminou de trabalhar.",
-      "question": "Seu agente tem uma pergunta para você.",
+      "question_one": "Seu agente tem uma pergunta para você.",
+      "question_other": "Seu agente tem perguntas para você.",
       "connect": "Seu agente precisa que você conecte um aplicativo."
     }
   }

--- a/app/tests/active-interaction.test.ts
+++ b/app/tests/active-interaction.test.ts
@@ -9,8 +9,13 @@ import {
 
 const question: PendingInteraction = {
   kind: "question",
-  question: "Which account?",
-  options: [{ id: "a", label: "Work" }],
+  questions: [
+    {
+      id: "q1",
+      question: "Which account?",
+      options: [{ id: "a", label: "Work" }],
+    },
+  ],
 };
 const connect: PendingInteraction = { kind: "connect", toolkit: "gmail" };
 

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,22 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v5 - 2026-07-06
+
+Redesign `question-card` to the composer family and batch questions. `ask_user`
+now asks 1-3 questions in one call (protocol `question` variant carries
+`questions[]`). The card stacks questions vertically, each with vertical
+single-select option rows (role=radio, toggle on re-click), and a free-text
+field that is ALWAYS visible at the bottom (the "own-answer-toggle" is removed,
+satisfying no-hover-only-affordances directly). The surface adopts the
+composer's exact vocabulary — `rounded-[28px]` `bg-card`, soft shadow with a
+focus-within lift, a borderless inline textarea, and the round `PromptInputSubmit`
+send — so card and composer read as one family. Fast path: a single question
+with options and empty input sends on option click. Send otherwise composes one
+`"<question>: <label>"` line per answered question plus appended free text.
+Still shared web (`@houston-ai/chat` `ChatQuestionCard`), so it stays
+`implemented`.
+
 ## v4 - 2026-07-06
 
 Add `question-card`: the in-chat surface shown when the agent pauses mid-turn to

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 4
+version: 5
 
 components:
   - id: agent-avatar
@@ -229,16 +229,19 @@ components:
 
   - id: question-card
     title: Question card
-    purpose: In-chat surface shown when the agent pauses mid-turn to ask the user a question; replaces the composer until answered.
-    anatomy: [question-prompt, option-buttons, own-answer-toggle, free-text-input, send-action]
-    states: [with-options, free-text-only, free-text-open, disabled]
-    variants: [choice, open-ended]
+    purpose: In-chat surface shown when the agent pauses mid-turn to ask the user 1-3 questions; replaces the composer until answered.
+    anatomy: [question-block, option-row, free-text-input, send-action]
+    states: [single, batched, with-options, free-text-only, disabled]
+    variants: [choice, open-ended, batched]
     behavior: >-
-      Rendered from the turn's pending interaction (kind=question). Option click
-      answers with that option's label; the toggle reveals an inline free-text
-      answer (shown directly when no options). Answering resumes the turn;
-      disabled while another turn is active.
-    a11y: question announced as the primary prompt; options and the free-text toggle are labeled buttons visible at rest (no hover gate).
+      Rendered from the turn's pending interaction (kind=question,
+      questions[1..3]). Questions stack vertically; each offers vertical
+      single-select option rows (toggle on re-click). A free-text field is
+      ALWAYS visible at the bottom (no toggle). Fast path: one question with
+      options and empty input sends on option click. Otherwise send composes one
+      "<question>: <label>" line per answered question plus appended free text.
+      Answering resumes the turn; disabled while another turn is active.
+    a11y: questions announced in order; option rows are role=radio in a radiogroup, keyboard-toggleable and visible at rest (no hover gate); free-text input always present.
     since: 4
 
   - id: deliverable-card

--- a/packages/domain/src/activities.ts
+++ b/packages/domain/src/activities.ts
@@ -24,11 +24,22 @@ export const ACTIVITY_STATUSES = [
 const isRecord = (v: unknown): v is Record<string, unknown> =>
   typeof v === "object" && v !== null && !Array.isArray(v);
 
+/** One batched question is valid when it carries a string `id` + `question`. */
+const isValidInteractionQuestion = (v: unknown): boolean =>
+  isRecord(v) && typeof v.id === "string" && typeof v.question === "string";
+
 /** Validate the pending_interaction discriminated union (mirrors the schema):
- *  a `question` needs a `question` string, a `connect` needs a `toolkit`. */
+ *  a `question` needs a non-empty `questions` array (each with id + question),
+ *  a `connect` needs a `toolkit`. An old singular-`question` shape fails here,
+ *  so a persisted value from before the batching change is dropped. */
 const isValidPendingInteraction = (v: unknown): v is PendingInteraction => {
   if (!isRecord(v)) return false;
-  if (v.kind === "question") return typeof v.question === "string";
+  if (v.kind === "question")
+    return (
+      Array.isArray(v.questions) &&
+      v.questions.length > 0 &&
+      v.questions.every(isValidInteractionQuestion)
+    );
   if (v.kind === "connect") return typeof v.toolkit === "string";
   return false;
 };

--- a/packages/domain/src/domain.test.ts
+++ b/packages/domain/src/domain.test.ts
@@ -106,8 +106,13 @@ test("normalize: a valid pending_interaction survives, an invalid one is strippe
         description: "",
         pending_interaction: {
           kind: "question",
-          question: "Which deck?",
-          options: [{ id: "q2", label: "Q2" }],
+          questions: [
+            {
+              id: "q1",
+              question: "Which deck?",
+              options: [{ id: "q2", label: "Q2" }],
+            },
+          ],
         },
       },
       {
@@ -122,8 +127,8 @@ test("normalize: a valid pending_interaction survives, an invalid one is strippe
         title: "Broken",
         status: "needs_you",
         description: "",
-        // missing the required `question` for kind=question
-        pending_interaction: { kind: "question" },
+        // the old singular-`question` shape is no longer valid after batching
+        pending_interaction: { kind: "question", question: "Which deck?" },
       },
     ],
     "k",
@@ -132,8 +137,13 @@ test("normalize: a valid pending_interaction survives, an invalid one is strippe
   expect(items.map((a) => a.id)).toEqual(["q", "c", "bad"]); // activity kept, only the field dropped
   expect(items[0]?.pending_interaction).toEqual({
     kind: "question",
-    question: "Which deck?",
-    options: [{ id: "q2", label: "Q2" }],
+    questions: [
+      {
+        id: "q1",
+        question: "Which deck?",
+        options: [{ id: "q2", label: "Q2" }],
+      },
+    ],
   });
   expect(items[1]?.pending_interaction).toEqual({
     kind: "connect",

--- a/packages/host/src/houston-prompt.test.ts
+++ b/packages/host/src/houston-prompt.test.ts
@@ -69,6 +69,16 @@ test("blocking questions, choices, and approvals route through the ask_user tool
   expect(p).not.toMatch(/ask: "Want me to remember/);
 });
 
+test("the prompt tells the agent to batch questions into one ask_user call", () => {
+  const p = houstonSystemPrompt();
+  expect(p).toContain("up to 3 questions");
+  expect(p).toContain("never one question per turn");
+  expect(p).toContain("Three is a cap, not a target");
+  // The old one-question-per-turn drip is gone.
+  expect(p).not.toContain("one thing at a time");
+  expect(p).not.toContain("one question at a time");
+});
+
 test("the guidance is provider-agnostic and CLI-free (Composio CLI cut in the convergence)", () => {
   const p = houstonSystemPrompt();
   expect(p).not.toContain("Composio");

--- a/packages/host/src/houston-prompt.ts
+++ b/packages/host/src/houston-prompt.ts
@@ -37,7 +37,7 @@ Assume the user is smart and busy, but not technical.
 
 - Be concise. No throat-clearing, filler, praise, or restating the request.
 - Use plain words. Avoid jargon unless the user uses it first.
-- When you need something from the user, a question, a choice, or a go-ahead, ask through the \`ask_user\` tool, then end your turn. The question appears to the user as an interactive card in place of the chat box, so do not repeat it in your reply, and never leave a question sitting in plain text. Their answer comes back as a normal user message.
+- When you need something from the user, a question, a choice, or a go-ahead, ask through the \`ask_user\` tool, then end your turn. Batch everything you need before you can act into that ONE call, up to 3 questions at once, never one question per turn. The questions appear to the user as a single interactive card in place of the chat box, so do not repeat them in your reply, and never leave a question sitting in plain text. Their answers come back as a normal user message.
 - Briefly explain why you need missing information or an integration.
 - Report outcomes, choices, blockers, and approval requests. Do not narrate implementation steps.
 - For long-running or risky work, give short status updates in user language.
@@ -55,7 +55,7 @@ Use this loop silently before acting. Do not show this checklist to the user.
    - Required integrations: which connected apps or accounts are needed?
    - Approval: does execution need explicit user approval?
 3. Ask only for what is missing. Whenever you need to ask the user for anything, use the \`ask_user\` tool and then end your turn. Never end a turn with a question written in plain text.
-   - If information is missing, ask for one thing at a time with \`ask_user\`.
+   - If information is missing, gather everything you still need and ask it in ONE \`ask_user\` call, up to 3 questions. Three is a cap, not a target.
    - If an integration is missing, briefly say what must be connected and why, then call \`request_connection\`.
    - If approval is required, ask with \`ask_user\` before execution, offering the choices as options.
 4. Execute when ready.
@@ -130,7 +130,7 @@ Skill rules:
 - \`description\` is shown to the user and drives tool matching. Lead with the outcome in plain language.
 - \`image\` should be a Fluent emoji slug or a full https URL.
 - \`featured: yes\` makes the Skill visible in the chat empty state.
-- If a Skill needs missing details, the procedure should ask one targeted question through the \`ask_user\` tool and continue when the answer arrives.
+- If a Skill needs missing details, the procedure should ask for them together through the \`ask_user\` tool, up to 3 questions in one call, and continue when the answers arrive.
 
 The Skill body is allowed to contain technical procedure details. But any text it tells the AI to say to the user must follow the user-voice rules above.
 
@@ -159,7 +159,7 @@ Do not confuse Routines with other persistent behavior:
 - A reusable workflow the user runs manually is a Skill.
 - Automatic future work on a schedule is a Routine.
 
-Before creating or updating a Routine, confirm the following with the user (ask through the \`ask_user\` tool, one question at a time, then end your turn):
+Before creating or updating a Routine, confirm the following with the user (ask through the \`ask_user\` tool, batching what you still need into one call, up to 3 questions, then end your turn):
 - What should happen.
 - When it should run.
 - What information is needed.

--- a/packages/protocol/src/domain/interaction.test.ts
+++ b/packages/protocol/src/domain/interaction.test.ts
@@ -4,8 +4,14 @@ import type { PendingInteraction } from "../index";
 test("the protocol index re-exports PendingInteraction", () => {
   const question: PendingInteraction = {
     kind: "question",
-    question: "Which slide deck?",
-    options: [{ id: "q2", label: "Q2 review" }],
+    questions: [
+      { id: "q1", question: "Which slide deck?" },
+      {
+        id: "q2",
+        question: "Send it now?",
+        options: [{ id: "yes", label: "Send" }],
+      },
+    ],
   };
   const connect: PendingInteraction = { kind: "connect", toolkit: "gmail" };
 

--- a/packages/protocol/src/domain/interaction.ts
+++ b/packages/protocol/src/domain/interaction.ts
@@ -3,12 +3,25 @@
 // terminal `done` wire frame and persisted on the Activity so the board card
 // settles to `needs_you` (present) vs `done` (absent) and the UI can render a
 // composer-replacing card.
+//
+// `ask_user` batches everything it needs into ONE call: the `question` variant
+// carries 1 to 3 questions, each with its own optional single-select options,
+// rendered as one interactive card in place of the composer.
 
 export interface InteractionOption {
   id: string;
   label: string;
 }
 
+/** One question in a batched `ask_user` card. `id` is tool-assigned (`q1`..`qN`)
+ *  so the answer for each question is addressable; `options`, when present, are
+ *  the single-select choices offered for that question. */
+export interface InteractionQuestion {
+  id: string;
+  question: string;
+  options?: InteractionOption[];
+}
+
 export type PendingInteraction =
-  | { kind: "question"; question: string; options?: InteractionOption[] }
+  | { kind: "question"; questions: InteractionQuestion[] }
   | { kind: "connect"; toolkit: string; reason?: string };

--- a/packages/runtime/src/backends/claude/custom-tools.test.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.test.ts
@@ -151,19 +151,22 @@ test("bridged schemas expose the same property keys as the pi tool params", () =
 
 test("bridged schemas enforce the same required vs optional split as pi", () => {
   const { tools } = build(INTEGRATIONS);
-  // ask_user: question required, options optional.
+  // ask_user: a `questions` array is required; each question needs `question`,
+  // options optional.
   const ask = z.object(byName(tools, "ask_user").inputSchema);
-  expect(ask.safeParse({ question: "Proceed?" }).success).toBe(true);
+  expect(ask.safeParse({ questions: [{ question: "Proceed?" }] }).success).toBe(
+    true,
+  );
   expect(ask.safeParse({}).success).toBe(false);
   expect(
     ask.safeParse({
-      question: "Pick",
-      options: [{ id: "y", label: "Yes" }],
+      questions: [{ question: "Pick", options: [{ id: "y", label: "Yes" }] }],
     }).success,
   ).toBe(true);
   // A malformed option (missing label) is rejected — nested object shape matched.
   expect(
-    ask.safeParse({ question: "Pick", options: [{ id: "y" }] }).success,
+    ask.safeParse({ questions: [{ question: "Pick", options: [{ id: "y" }] }] })
+      .success,
   ).toBe(false);
 
   // integration_execute: action required, params (a record) optional.
@@ -206,12 +209,20 @@ test("the ask_user handler records a question interaction into the turn holder",
   const handler = handlerOf(byName(tools, "ask_user"));
   const holder = newInteractionHolder();
   await runWithInteractionCapture(holder, () =>
-    handler({ question: "Proceed?", options: [{ id: "y", label: "Yes" }] }, {}),
+    handler(
+      {
+        questions: [
+          { question: "Proceed?", options: [{ id: "y", label: "Yes" }] },
+        ],
+      },
+      {},
+    ),
   );
   expect(holder.pending).toEqual({
     kind: "question",
-    question: "Proceed?",
-    options: [{ id: "y", label: "Yes" }],
+    questions: [
+      { id: "q1", question: "Proceed?", options: [{ id: "y", label: "Yes" }] },
+    ],
   });
 });
 
@@ -233,7 +244,7 @@ test("the request_connection handler records a connect interaction", async () =>
 test("a handler run outside any turn records nothing and still returns content", async () => {
   const { tools } = build(INTEGRATIONS);
   const result = await handlerOf(byName(tools, "ask_user"))(
-    { question: "Anyone there?" },
+    { questions: [{ question: "Anyone there?" }] },
     {},
   );
   expect(result.content[0]).toMatchObject({ type: "text" });
@@ -264,7 +275,7 @@ test("an ask_user call dispatched during a Claude-session turn lands in the turn
   const query: ClaudeQuery = () => {
     const dispatched = (async () => {
       await Promise.resolve();
-      await handler({ question: "Ready to send?" }, {});
+      await handler({ questions: [{ question: "Ready to send?" }] }, {});
     })();
     // A stream that yields nothing but only reports done once the background
     // dispatch (the handler call) has run — mirrors a turn whose sole effect was
@@ -294,6 +305,6 @@ test("an ask_user call dispatched during a Claude-session turn lands in the turn
   // attaches to the clean `done` frame as `pendingInteraction`.
   expect(holder.pending).toEqual({
     kind: "question",
-    question: "Ready to send?",
+    questions: [{ id: "q1", question: "Ready to send?" }],
   });
 });

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -115,7 +115,10 @@ test("the clean done frame carries the turn's recorded pending interaction", asy
   const { events, unsub } = collect(id);
   const conv = fakeConv((emit) => {
     emit({ type: "text", data: "on it" });
-    recordPendingInteraction({ kind: "question", question: "Which date?" });
+    recordPendingInteraction({
+      kind: "question",
+      questions: [{ id: "q1", question: "Which date?" }],
+    });
   });
 
   await execTurn(conv, id, "turn-1", "book it", {
@@ -130,12 +133,12 @@ test("the clean done frame carries the turn's recorded pending interaction", asy
   expect(done).toBeDefined();
   expect(done?.pendingInteraction).toEqual({
     kind: "question",
-    question: "Which date?",
+    questions: [{ id: "q1", question: "Which date?" }],
   });
   // ...and it is persisted on the assistant message for a missed-`done` reload.
   expect(persistedInteraction(id)).toEqual({
     kind: "question",
-    question: "Which date?",
+    questions: [{ id: "q1", question: "Which date?" }],
   });
 });
 
@@ -186,7 +189,10 @@ test("a thrown turn emits an error frame and no done", async () => {
   const id = "exec-pending-thrown";
   const { events, unsub } = collect(id);
   const conv = fakeConv(() => {
-    recordPendingInteraction({ kind: "question", question: "lost?" });
+    recordPendingInteraction({
+      kind: "question",
+      questions: [{ id: "q1", question: "lost?" }],
+    });
     throw new Error("kaboom");
   });
 

--- a/packages/runtime/src/session/interaction.test.ts
+++ b/packages/runtime/src/session/interaction.test.ts
@@ -15,19 +15,34 @@ import {
 test("records the interaction on the ambient holder", () => {
   const holder = newInteractionHolder();
   runWithInteractionCapture(holder, () => {
-    recordPendingInteraction({ kind: "question", question: "Which one?" });
+    recordPendingInteraction({
+      kind: "question",
+      questions: [{ id: "q1", question: "Which one?" }],
+    });
   });
-  expect(holder.pending).toEqual({ kind: "question", question: "Which one?" });
+  expect(holder.pending).toEqual({
+    kind: "question",
+    questions: [{ id: "q1", question: "Which one?" }],
+  });
 });
 
 test("last call wins within a single turn", () => {
   const holder = newInteractionHolder();
   runWithInteractionCapture(holder, () => {
-    recordPendingInteraction({ kind: "question", question: "first?" });
+    recordPendingInteraction({
+      kind: "question",
+      questions: [{ id: "q1", question: "first?" }],
+    });
     recordPendingInteraction({ kind: "connect", toolkit: "gmail" });
-    recordPendingInteraction({ kind: "question", question: "final?" });
+    recordPendingInteraction({
+      kind: "question",
+      questions: [{ id: "q1", question: "final?" }],
+    });
   });
-  expect(holder.pending).toEqual({ kind: "question", question: "final?" });
+  expect(holder.pending).toEqual({
+    kind: "question",
+    questions: [{ id: "q1", question: "final?" }],
+  });
 });
 
 test("a fresh holder each turn is the reset — nothing leaks across turns", () => {
@@ -49,7 +64,10 @@ test("a fresh holder each turn is the reset — nothing leaks across turns", () 
 test("recording outside a turn is a no-op (undefined store)", () => {
   // No runWithInteractionCapture → getStore() is undefined → nothing recorded.
   expect(() =>
-    recordPendingInteraction({ kind: "question", question: "orphan?" }),
+    recordPendingInteraction({
+      kind: "question",
+      questions: [{ id: "q1", question: "orphan?" }],
+    }),
   ).not.toThrow();
 });
 
@@ -57,10 +75,13 @@ test("the holder survives async work inside the capture (ALS propagation)", asyn
   const holder = newInteractionHolder();
   await runWithInteractionCapture(holder, async () => {
     await Promise.resolve();
-    recordPendingInteraction({ kind: "question", question: "after await?" });
+    recordPendingInteraction({
+      kind: "question",
+      questions: [{ id: "q1", question: "after await?" }],
+    });
   });
   expect(holder.pending).toEqual({
     kind: "question",
-    question: "after await?",
+    questions: [{ id: "q1", question: "after await?" }],
   });
 });

--- a/packages/runtime/src/session/tools/ask-user.test.ts
+++ b/packages/runtime/src/session/tools/ask-user.test.ts
@@ -7,9 +7,10 @@ import {
 import { ASK_USER_TOOL_NAME, makeAskUserTool } from "./ask-user";
 
 /**
- * The always-available blocking-question tool. These pin: the tool records a
- * `question` interaction on the turn's holder (with options when offered), tells
- * the model to end its turn, and last-call-wins when asked twice.
+ * The always-available blocking-question tool. These pin: the tool assigns
+ * `q1`..`qN` ids and records a `question` interaction on the turn's holder (with
+ * per-question options when offered), tells the model to end its turn, rejects a
+ * batch over 3, and last-call-wins when asked twice.
  */
 
 const askUser = makeAskUserTool();
@@ -25,56 +26,94 @@ test("is named ask_user", () => {
   expect(ASK_USER_TOOL_NAME).toBe("ask_user");
 });
 
-test("records an open question and instructs the model to end its turn", async () => {
+test("records a single open question with a q1 id and ends the turn", async () => {
   const holder = newInteractionHolder();
   const out = await runWithInteractionCapture(holder, () =>
-    run({ question: "What city are you in?" }),
+    run({ questions: [{ question: "What city are you in?" }] }),
   );
   expect(holder.pending).toEqual({
     kind: "question",
-    question: "What city are you in?",
+    questions: [{ id: "q1", question: "What city are you in?" }],
   });
   const text = (out.content[0] as { text: string }).text;
   expect(text).toMatch(/end your turn/i);
 });
 
-test("records offered options for a choice/approval", async () => {
+test("batches up to three questions, assigning q1..qN ids and keeping options", async () => {
   const holder = newInteractionHolder();
   await runWithInteractionCapture(holder, () =>
     run({
-      question: "Send it?",
-      options: [
-        { id: "yes", label: "Send" },
-        { id: "no", label: "Cancel" },
+      questions: [
+        { question: "What city are you in?" },
+        {
+          question: "Send it?",
+          options: [
+            { id: "yes", label: "Send" },
+            { id: "no", label: "Cancel" },
+          ],
+        },
+        { question: "Anything to add?" },
       ],
     }),
   );
   expect(holder.pending).toEqual({
     kind: "question",
-    question: "Send it?",
-    options: [
-      { id: "yes", label: "Send" },
-      { id: "no", label: "Cancel" },
+    questions: [
+      { id: "q1", question: "What city are you in?" },
+      {
+        id: "q2",
+        question: "Send it?",
+        options: [
+          { id: "yes", label: "Send" },
+          { id: "no", label: "Cancel" },
+        ],
+      },
+      { id: "q3", question: "Anything to add?" },
     ],
   });
 });
 
-test("an empty options array is dropped (recorded as an open question)", async () => {
+test("an empty options array on a question is dropped (recorded as open)", async () => {
   const holder = newInteractionHolder();
   await runWithInteractionCapture(holder, () =>
-    run({ question: "Anything else?", options: [] }),
+    run({ questions: [{ question: "Anything else?", options: [] }] }),
   );
   expect(holder.pending).toEqual({
     kind: "question",
-    question: "Anything else?",
+    questions: [{ id: "q1", question: "Anything else?" }],
   });
+});
+
+test("throws with merge/trim guidance when asked more than three questions", async () => {
+  const holder = newInteractionHolder();
+  await expect(
+    runWithInteractionCapture(holder, () =>
+      run({
+        questions: [
+          { question: "one?" },
+          { question: "two?" },
+          { question: "three?" },
+          { question: "four?" },
+        ],
+      }),
+    ),
+  ).rejects.toThrow(/1 to 3 questions/i);
+  // Nothing recorded on the rejected call.
+  expect(holder.pending).toBeUndefined();
+});
+
+test("throws when given no questions", async () => {
+  await expect(run({ questions: [] })).rejects.toThrow(/1 to 3 questions/i);
 });
 
 test("last call wins when the model asks twice in a turn", async () => {
   const holder = newInteractionHolder();
   await runWithInteractionCapture(holder, async () => {
-    await run({ question: "first?" });
-    await run({ question: "second?" });
+    await run({ questions: [{ question: "first?" }] });
+    await run({ questions: [{ question: "second?" }] });
   });
-  expect(holder.pending).toEqual({ kind: "question", question: "second?" });
+  expect(holder.pending).toEqual({
+    kind: "question",
+    questions: [{ id: "q1", question: "second?" }],
+  });
 });

--- a/packages/runtime/src/session/tools/ask-user.ts
+++ b/packages/runtime/src/session/tools/ask-user.ts
@@ -5,42 +5,56 @@ import { recordPendingInteraction } from "../interaction";
 /**
  * The blocking-question tool. Any time the model needs the user to answer,
  * choose, or approve before it can continue, it calls `ask_user` instead of
- * ending its turn with a question in plain text. Executing it records the
- * pending interaction for this turn (carried on the terminal `done` frame), and
- * Houston renders the question as an interactive card in place of the chat
- * input. The user's answer arrives as a normal user message on the next turn.
+ * ending its turn with a question in plain text. It batches EVERYTHING it needs
+ * — up to 3 questions — into ONE call: executing it records the pending
+ * interaction for this turn (carried on the terminal `done` frame), and Houston
+ * renders the batch as a single interactive card in place of the chat input.
+ * The user's answers arrive as a normal user message on the next turn.
  *
  * Available in EVERY mode/backend that can receive Houston's custom tools (i.e.
  * the pi backend) — it holds no credential and makes no network call.
  */
 
+/** The most questions one `ask_user` card may carry. A cap, not a norm. */
+const MAX_QUESTIONS = 3;
+
 const AskUserParams = Type.Object({
-  question: Type.String({
-    description:
-      "The exact question to show the user, in plain everyday language. Ask one thing.",
-  }),
-  options: Type.Optional(
-    Type.Array(
-      Type.Object({
-        id: Type.String({
-          description: "A short stable identifier for this choice.",
-        }),
-        label: Type.String({
-          description: "The short user-facing label for this choice.",
-        }),
-      }),
-      {
+  questions: Type.Array(
+    Type.Object({
+      question: Type.String({
         description:
-          "Optional 2-6 short, mutually-exclusive choices to offer as buttons. Use for a choice or an approval; omit for an open question.",
-      },
-    ),
+          "One question to show the user, in plain everyday language.",
+      }),
+      options: Type.Optional(
+        Type.Array(
+          Type.Object({
+            id: Type.String({
+              description: "A short stable identifier for this choice.",
+            }),
+            label: Type.String({
+              description: "The short user-facing label for this choice.",
+            }),
+          }),
+          {
+            description:
+              "Optional 2-6 short, mutually-exclusive choices for this question, offered as single-select rows. Use for a choice or an approval; omit for an open question.",
+          },
+        ),
+      ),
+    }),
+    {
+      minItems: 1,
+      maxItems: MAX_QUESTIONS,
+      description:
+        "1 to 3 questions to ask together as one card. Batch everything you need before acting into this ONE call; never ask one question per turn.",
+    },
   ),
 });
 type AskUserParams = Static<typeof AskUserParams>;
 
-/** The instruction returned to the model after the question is recorded. */
+/** The instruction returned to the model after the questions are recorded. */
 const ASK_USER_INSTRUCTION =
-  "Your question is now shown to the user as an interactive card in place of the chat input. End your turn immediately. Do not repeat the question in your reply text, and do not ask anything else — the user's answer will arrive as a normal message.";
+  "Your questions are now shown to the user as one interactive card in place of the chat input. End your turn immediately. Do not repeat the questions in your reply text, and do not ask anything else — the user's answers will arrive as a normal message.";
 
 /** The always-available blocking-question tool. */
 export function makeAskUserTool() {
@@ -48,23 +62,28 @@ export function makeAskUserTool() {
     name: "ask_user",
     label: "Ask the user",
     description:
-      "Ask the user a blocking question, offer them a choice, or request their approval before continuing. Houston shows it as an interactive card in place of the chat input; end your turn right after calling this. ALWAYS use this instead of ending your turn with a question written in plain text.",
-    promptSnippet: "Ask the user a question and wait for their answer",
+      "Ask the user up to 3 blocking questions, offer choices, or request approval before continuing. Batch everything you need before you can act into this ONE call — never drip one question per turn. Houston shows the batch as a single interactive card in place of the chat input; end your turn right after calling this. ALWAYS use this instead of ending your turn with a question written in plain text.",
+    promptSnippet: "Ask the user up to 3 questions and wait for their answers",
     parameters: AskUserParams,
     executionMode: "sequential",
     async execute(_id: string, params: AskUserParams) {
-      const options =
-        params.options && params.options.length > 0
-          ? params.options
-          : undefined;
-      recordPendingInteraction({
-        kind: "question",
-        question: params.question,
-        ...(options ? { options } : {}),
-      });
+      if (
+        params.questions.length < 1 ||
+        params.questions.length > MAX_QUESTIONS
+      ) {
+        throw new Error(
+          `ask_user takes 1 to ${MAX_QUESTIONS} questions in one call (got ${params.questions.length}). Merge or trim your questions so at most ${MAX_QUESTIONS} are asked together.`,
+        );
+      }
+      const questions = params.questions.map((q, i) => ({
+        id: `q${i + 1}`,
+        question: q.question,
+        ...(q.options && q.options.length > 0 ? { options: q.options } : {}),
+      }));
+      recordPendingInteraction({ kind: "question", questions });
       return {
         content: [{ type: "text" as const, text: ASK_USER_INSTRUCTION }],
-        details: { question: params.question, options: options ?? [] },
+        details: { questions },
       };
     },
   });

--- a/packages/runtime/src/store/conversation-file.test.ts
+++ b/packages/runtime/src/store/conversation-file.test.ts
@@ -141,7 +141,10 @@ test("assistant message persists the pending interaction so a reload settles nee
   appendUserMessageAt(dir, "c1", "book it", { turnId: "t-1" });
   appendAssistantMessageAt(dir, "c1", "which date?", {
     turnId: "t-1",
-    pendingInteraction: { kind: "question", question: "Which date?" },
+    pendingInteraction: {
+      kind: "question",
+      questions: [{ id: "q1", question: "Which date?" }],
+    },
   });
 
   const history = getHistoryAt(dir, "c1");
@@ -150,7 +153,7 @@ test("assistant message persists the pending interaction so a reload settles nee
   if (!msg) throw new Error("no assistant message found in history");
   expect(msg.pendingInteraction).toEqual({
     kind: "question",
-    question: "Which date?",
+    questions: [{ id: "q1", question: "Which date?" }],
   });
 });
 

--- a/packages/sdk/src/modules/turns/turn-settle.test.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.test.ts
@@ -81,8 +81,13 @@ test("matches the assistant reply by turnId and adopts its text + usage", () => 
 test("a persisted pendingInteraction recovers on reload: needs_you + the interaction", () => {
   const interaction: PendingInteraction = {
     kind: "question",
-    question: "Which date?",
-    options: [{ id: "a", label: "Fri" }],
+    questions: [
+      {
+        id: "q1",
+        question: "Which date?",
+        options: [{ id: "a", label: "Fri" }],
+      },
+    ],
   };
   const { s, statuses } = run(
     [
@@ -221,8 +226,13 @@ test("finishOk with a captured interaction settles needs_you and keeps the inter
   s.text = "which one?";
   const interaction: PendingInteraction = {
     kind: "question",
-    question: "Pick a flight?",
-    options: [{ id: "a", label: "Morning" }],
+    questions: [
+      {
+        id: "q1",
+        question: "Pick a flight?",
+        options: [{ id: "a", label: "Morning" }],
+      },
+    ],
   };
   // The `done` frame stashes the interaction before finishOk (turn-frames.ts).
   s.pendingInteraction = interaction;

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -167,8 +167,13 @@ test("a silent stream close mid-turn reconnects with the cursor and settles on t
 test("a clean done carrying a pending interaction settles needs_you and persists the interaction", async () => {
   const interaction: PendingInteraction = {
     kind: "question",
-    question: "Which flight?",
-    options: [{ id: "m", label: "Morning" }],
+    questions: [
+      {
+        id: "q1",
+        question: "Which flight?",
+        options: [{ id: "m", label: "Morning" }],
+      },
+    ],
   };
   const { engine } = fakeEngine([
     (o) => {

--- a/packages/sdk/src/modules/turns/vm-output.test.ts
+++ b/packages/sdk/src/modules/turns/vm-output.test.ts
@@ -138,8 +138,9 @@ test("a clean settle folds the pending interaction into the VM; turn start clear
   const { snap, vm } = harness();
   const interaction = {
     kind: "question" as const,
-    question: "Which one?",
-    options: [{ id: "a", label: "A" }],
+    questions: [
+      { id: "q1", question: "Which one?", options: [{ id: "a", label: "A" }] },
+    ],
   };
   // Settle carrying the interaction: needs_you + the interaction on the VM.
   await vm.persistBoardStatus("a", "c1", "needs_you", interaction);

--- a/packages/web/e2e/interaction.spec.ts
+++ b/packages/web/e2e/interaction.spec.ts
@@ -8,27 +8,137 @@ import { expect, test } from "./support/fixtures";
  * REPLACES the composer with the interaction card (`composerOverride`). These
  * specs arm the fake host's `/__test__/chat-interaction` control so the next
  * scripted turn ends on an interaction, then drive the whole seam end-to-end:
- * card replaces composer → user answers → normal composer returns.
+ * card replaces composer -> user answers -> normal composer returns.
+ *
+ * `ask_user` batches up to three questions into ONE call. The card stacks them
+ * vertically, renders each question's options as single-select rows, and keeps
+ * a free-text input ALWAYS visible at the bottom.
  */
 
 /**
- * A question interaction: the card replaces the composer with the prompt and
- * its option buttons, clicking an option sends its label as a new user message,
- * and the follow-up composer returns once the answering turn starts.
+ * A batched (three-question) interaction: the card stacks the questions with
+ * their option rows and an always-visible free-text field, the user answers two
+ * by option and adds free text, and Send composes them into ONE user message.
  */
-test("shows the question card in place of the composer and answers via an option", async ({
+test("batches three questions in one card and composes a single reply", async ({
   page,
   request,
 }) => {
-  // Arm the NEXT turn to end asking the user to pick a flight time.
+  // Arm the NEXT turn to end asking three questions (mixed with/without options).
   await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
     data: {
       interaction: {
         kind: "question",
-        question: "Do you want the morning or evening flight?",
-        options: [
-          { id: "morning", label: "Morning flight" },
-          { id: "evening", label: "Evening flight" },
+        questions: [
+          {
+            id: "q1",
+            question: "Which city are you flying to?",
+            options: [
+              { id: "paris", label: "Paris" },
+              { id: "tokyo", label: "Tokyo" },
+            ],
+          },
+          {
+            id: "q2",
+            question: "Anything special I should know about the trip?",
+          },
+          {
+            id: "q3",
+            question: "Morning or evening flight?",
+            options: [
+              { id: "morning", label: "Morning flight" },
+              { id: "evening", label: "Evening flight" },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  await page.goto("/");
+  await page.locator('[data-tour-target="newMission"]').click();
+
+  const composer = page.getByPlaceholder("What should the agent work on?");
+  await expect(composer).toBeVisible();
+  await composer.fill("plan my trip");
+  await composer.press("Enter");
+
+  await expect(page.getByText(/Roger that\. You said:/)).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // The card has taken over the composer slot. All three questions stack
+  // vertically at once (not one-per-turn).
+  await expect(page.getByText("Which city are you flying to?")).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(
+    page.getByText("Anything special I should know about the trip?"),
+  ).toBeVisible();
+  await expect(page.getByText("Morning or evening flight?")).toBeVisible();
+
+  // Two questions offer single-select option rows (the third is free-text only).
+  await expect(page.getByRole("radiogroup")).toHaveCount(2);
+  await expect(page.getByRole("radio")).toHaveCount(4);
+
+  // The free-text field is ALWAYS visible (no toggle), and the normal follow-up
+  // composer is gone.
+  const freeText = page.getByPlaceholder("Type your answer...");
+  await expect(freeText).toBeVisible();
+  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+
+  // Answer two questions by option; clicking does NOT send (more than one
+  // question), it selects.
+  await page.getByRole("radio", { name: "Paris" }).click();
+  await page.getByRole("radio", { name: "Morning flight" }).click();
+  await expect(page.getByRole("radio", { name: "Paris" })).toHaveAttribute(
+    "aria-checked",
+    "true",
+  );
+  // Still on the card — nothing sent yet.
+  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+
+  // Add free text and Send.
+  await freeText.fill("Window seat please");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  // ONE composed user message carries both option answers and the free text.
+  const composed = page
+    .locator(".is-user")
+    .filter({ hasText: "Window seat please" });
+  await expect(composed).toHaveCount(1);
+  await expect(composed).toContainText("Paris");
+  await expect(composed).toContainText("Morning flight");
+
+  // The answering turn starts, so the card retires and the composer returns.
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole("radiogroup")).toHaveCount(0);
+});
+
+/**
+ * The single-question fast path: one question with options and an empty input.
+ * Clicking an option sends immediately (no separate Send press), the composed
+ * reply is one user message, and the follow-up composer returns.
+ */
+test("single question with options sends on option click (fast path)", async ({
+  page,
+  request,
+}) => {
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: {
+      interaction: {
+        kind: "question",
+        questions: [
+          {
+            id: "q1",
+            question: "Do you want the morning or evening flight?",
+            options: [
+              { id: "morning", label: "Morning flight" },
+              { id: "evening", label: "Evening flight" },
+            ],
+          },
         ],
       },
     },
@@ -42,36 +152,36 @@ test("shows the question card in place of the composer and answers via an option
   await composer.fill("book my flight");
   await composer.press("Enter");
 
-  // The turn streams its canned reply and settles on the interaction.
   await expect(page.getByText(/Roger that\. You said:/)).toBeVisible({
     timeout: 15_000,
   });
 
-  // The question card has taken over the composer slot: the prompt reads as
-  // the one thing to do, its options are always-visible buttons, and the
-  // normal follow-up composer is gone.
+  // The question card owns the composer slot; its options are always-visible
+  // rows and the normal follow-up composer is gone.
   await expect(
     page.getByText("Do you want the morning or evening flight?"),
   ).toBeVisible({ timeout: 15_000 });
-  const morning = page.getByRole("button", { name: "Morning flight" });
+  const morning = page.getByRole("radio", { name: "Morning flight" });
   await expect(morning).toBeVisible();
   await expect(
-    page.getByRole("button", { name: "Evening flight" }),
+    page.getByRole("radio", { name: "Evening flight" }),
   ).toBeVisible();
   await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
 
-  // Clicking an option sends its label as a normal user message...
+  // Clicking an option sends immediately as one composed user message...
   await morning.click();
 
-  await expect(page.getByText("Morning flight").first()).toBeVisible();
-  // ...the answering turn starts, so the card retires and the normal composer
-  // returns through the same reactivity.
+  await expect(
+    page.locator(".is-user").filter({ hasText: "Morning flight" }),
+  ).toHaveCount(1);
+  // ...the answering turn starts, so the card retires (its option rows are gone)
+  // and the normal composer returns through the same reactivity.
   await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible({
     timeout: 15_000,
   });
-  await expect(
-    page.getByText("Do you want the morning or evening flight?"),
-  ).toHaveCount(0);
+  await expect(page.getByRole("radio", { name: "Evening flight" })).toHaveCount(
+    0,
+  );
 });
 
 /**

--- a/packages/web/tests/feed-output.test.ts
+++ b/packages/web/tests/feed-output.test.ts
@@ -91,8 +91,9 @@ test("persistBoardStatus forwards status + interaction to the injected setter", 
   });
   const interaction = {
     kind: "question" as const,
-    question: "Which one?",
-    options: [{ id: "a", label: "A" }],
+    questions: [
+      { id: "q1", question: "Which one?", options: [{ id: "a", label: "A" }] },
+    ],
   };
   // A settle carrying an interaction forwards it verbatim...
   await out.persistBoardStatus("Houston/Bo", "c1", "needs_you", interaction);

--- a/ui/agent-schemas/src/activity.schema.json
+++ b/ui/agent-schemas/src/activity.schema.json
@@ -29,15 +29,28 @@
         "required": ["kind"],
         "properties": {
           "kind": { "type": "string", "enum": ["question", "connect"] },
-          "question": { "type": "string" },
-          "options": {
+          "questions": {
             "type": "array",
+            "description": "1 to 3 questions asked together as one card.",
+            "minItems": 1,
+            "maxItems": 3,
             "items": {
               "type": "object",
-              "required": ["id", "label"],
+              "required": ["id", "question"],
               "properties": {
                 "id": { "type": "string" },
-                "label": { "type": "string" }
+                "question": { "type": "string" },
+                "options": {
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "required": ["id", "label"],
+                    "properties": {
+                      "id": { "type": "string" },
+                      "label": { "type": "string" }
+                    }
+                  }
+                }
               }
             }
           },
@@ -47,7 +60,7 @@
         "oneOf": [
           {
             "properties": { "kind": { "const": "question" } },
-            "required": ["question"]
+            "required": ["questions"]
           },
           {
             "properties": { "kind": { "const": "connect" } },

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -213,6 +213,7 @@ export { ProgressPanel } from "./progress-panel";
 // The in-chat surface shown when the agent pauses to ask the user something;
 // replaces the composer while a pending interaction is awaiting an answer.
 export type {
+  ChatQuestion,
   ChatQuestionCardProps,
   ChatQuestionOption,
 } from "./question-card";

--- a/ui/chat/src/question-card-logic.ts
+++ b/ui/chat/src/question-card-logic.ts
@@ -7,18 +7,26 @@ export interface ChatQuestionOption {
   label: string;
 }
 
-/** The question must read as the single next action: this card REPLACES the
- *  composer while shown, so the prompt is sized up and weighted. */
+export interface ChatQuestion {
+  id: string;
+  question: string;
+  options?: ChatQuestionOption[];
+}
+
+/** Per-question selected option id (or null when that question is unanswered by
+ *  option). One entry per question, keyed by question id. Free text lives once,
+ *  shared, at the bottom of the card. */
+export type QuestionSelections = Record<string, string | null>;
+
+/** A single question head. Sized up + weighted when it's the ONLY question (the
+ *  card replaces the composer, so a lone prompt reads as "the one thing to do").
+ *  Batched cards drop to the base size so the stack has rhythm without shouting. */
 export const QUESTION_TEXT_CLASS =
   "text-lg font-medium leading-snug text-foreground";
+export const QUESTION_TEXT_CLASS_BATCHED =
+  "text-base font-medium leading-snug text-foreground";
 
-/** The "answer in your own words" escape hatch stays visible at all times
- *  (never hover-gated, per the no-hover-only-affordances rule) but reads as a
- *  quiet, secondary action. */
-export const OWN_ANSWER_TOGGLE_CLASS =
-  "mt-3 text-sm text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground disabled:pointer-events-none disabled:opacity-50";
-
-/** True when the agent offered concrete choices (option buttons render). */
+/** True when the agent offered concrete choices (option rows render). */
 export function hasSelectableOptions(options?: ChatQuestionOption[]): boolean {
   return Array.isArray(options) && options.length > 0;
 }
@@ -27,4 +35,62 @@ export function hasSelectableOptions(options?: ChatQuestionOption[]): boolean {
 export function normalizeAnswer(text: string): string | null {
   const trimmed = text.trim();
   return trimmed.length > 0 ? trimmed : null;
+}
+
+/** The selected option's label for one question, or null when none is chosen. */
+function selectedLabel(
+  question: ChatQuestion,
+  selections: QuestionSelections,
+): string | null {
+  const optionId = selections[question.id];
+  if (!optionId) return null;
+  const option = question.options?.find((o) => o.id === optionId);
+  return option ? option.label : null;
+}
+
+/**
+ * Compose the reply the user sends. For each ANSWERED question a line
+ * `"<question>: <selected label>"`, joined by newlines; the shared free text (if
+ * any) is appended after a blank line. Only-text → just the text. Returns null
+ * when nothing is answered (send stays disabled).
+ */
+export function composeReply(
+  questions: ChatQuestion[],
+  selections: QuestionSelections,
+  freeText: string,
+): string | null {
+  const lines: string[] = [];
+  for (const question of questions) {
+    const label = selectedLabel(question, selections);
+    if (label !== null) lines.push(`${question.question}: ${label}`);
+  }
+  const text = normalizeAnswer(freeText);
+  if (lines.length === 0) return text; // only-text (or null when empty)
+  const body = lines.join("\n");
+  return text === null ? body : `${body}\n\n${text}`;
+}
+
+/** Send is enabled when at least one question is answered OR the input has text. */
+export function canSend(
+  questions: ChatQuestion[],
+  selections: QuestionSelections,
+  freeText: string,
+): boolean {
+  return composeReply(questions, selections, freeText) !== null;
+}
+
+/**
+ * Fast path: exactly one question that HAS options and an empty input. Clicking
+ * an option then sends immediately (no separate send press) — the common
+ * single-choice case stays one tap.
+ */
+export function isFastPath(
+  questions: ChatQuestion[],
+  freeText: string,
+): boolean {
+  return (
+    questions.length === 1 &&
+    hasSelectableOptions(questions[0]?.options) &&
+    normalizeAnswer(freeText) === null
+  );
 }

--- a/ui/chat/src/question-card-parts.tsx
+++ b/ui/chat/src/question-card-parts.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { cn } from "@houston-ai/core";
+import { CheckIcon } from "lucide-react";
+import {
+  type ChatQuestion,
+  type ChatQuestionOption,
+  hasSelectableOptions,
+  QUESTION_TEXT_CLASS,
+  QUESTION_TEXT_CLASS_BATCHED,
+} from "./question-card-logic";
+
+/** One selectable answer, a full-width single-select row (toggle on re-click). */
+export function OptionRow({
+  option,
+  selected,
+  disabled,
+  onSelect,
+}: {
+  option: ChatQuestionOption;
+  selected: boolean;
+  disabled: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: a full-width single-select row needs a native <button> (focus + Enter/Space activation) with role="radio" for the radiogroup semantics; <input type="radio"> can't carry this layout/content.
+    <button
+      aria-checked={selected}
+      className={cn(
+        "flex w-full items-center gap-3 rounded-2xl border border-border/50 bg-background px-3.5 py-2.5 text-left text-sm text-foreground outline-none transition-colors",
+        "hover:border-border hover:bg-accent",
+        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+        "disabled:pointer-events-none disabled:opacity-50",
+        selected && "border-primary bg-primary/5 hover:border-primary",
+      )}
+      disabled={disabled}
+      onClick={onSelect}
+      role="radio"
+      type="button"
+    >
+      <span className="flex-1">{option.label}</span>
+      <span className="flex size-4 shrink-0 items-center justify-center">
+        {selected && <CheckIcon className="size-4 text-primary" />}
+      </span>
+    </button>
+  );
+}
+
+/** A question head plus its vertical single-select option rows (if any). */
+export function QuestionBlock({
+  question,
+  batched,
+  selectedId,
+  disabled,
+  onSelect,
+}: {
+  question: ChatQuestion;
+  batched: boolean;
+  selectedId: string | null;
+  disabled: boolean;
+  onSelect: (optionId: string) => void;
+}) {
+  return (
+    <div>
+      <p
+        className={batched ? QUESTION_TEXT_CLASS_BATCHED : QUESTION_TEXT_CLASS}
+      >
+        {question.question}
+      </p>
+      {hasSelectableOptions(question.options) && (
+        <div className="mt-3 flex flex-col gap-2" role="radiogroup">
+          {question.options?.map((option) => (
+            <OptionRow
+              disabled={disabled}
+              key={option.id}
+              onSelect={() => onSelect(option.id)}
+              option={option}
+              selected={selectedId === option.id}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/chat/src/question-card.tsx
+++ b/ui/chat/src/question-card.tsx
@@ -1,137 +1,129 @@
 "use client";
 
-import { Button, cn, Textarea } from "@houston-ai/core";
+import { cn } from "@houston-ai/core";
 import { type KeyboardEvent, useCallback, useState } from "react";
+import { PromptInputSubmit } from "./ai-elements/prompt-input";
 import {
-  type ChatQuestionOption,
-  hasSelectableOptions,
-  normalizeAnswer,
-  OWN_ANSWER_TOGGLE_CLASS,
-  QUESTION_TEXT_CLASS,
+  type ChatQuestion,
+  canSend,
+  composeReply,
+  isFastPath,
+  type QuestionSelections,
+} from "./question-card-logic";
+import { QuestionBlock } from "./question-card-parts";
+
+export type {
+  ChatQuestion,
+  ChatQuestionOption,
 } from "./question-card-logic";
 
-export type { ChatQuestionOption } from "./question-card-logic";
-
 export interface ChatQuestionCardProps {
-  question: string;
-  options?: ChatQuestionOption[];
-  /** Option click sends the option's label; free-text sends the typed text. */
+  /** 1..3 questions, rendered in order. */
+  questions: ChatQuestion[];
+  /** Receives the fully composed reply (see composeReply). */
   onAnswer: (text: string) => void;
   disabled?: boolean;
-  labels?: { typeOwnAnswer?: string; placeholder?: string; send?: string };
+  labels?: { placeholder?: string; send?: string };
 }
 
 /**
  * The in-chat surface shown when the agent pauses to ask the user something.
- * It REPLACES the composer, so it must read as "the one thing to do now":
- * a prominent question, always-visible option buttons, and a quiet toggle to
- * an inline free-text answer. With no options, the text input shows directly.
+ * It REPLACES the composer, so it is built from the composer's own vocabulary
+ * (rounded-[28px] bg-card surface, borderless inline textarea, round submit)
+ * and reads as one family with ChatInput. Questions stack vertically; each
+ * offers single-select option rows; a free-text field is ALWAYS visible at the
+ * bottom as the "answer in your own words" channel.
  */
 export function ChatQuestionCard({
-  question,
-  options,
+  questions,
   onAnswer,
   disabled = false,
   labels,
 }: ChatQuestionCardProps) {
-  const hasOptions = hasSelectableOptions(options);
-  // No options → free-text is the only way to answer, so show it immediately
-  // rather than behind a toggle.
-  const [showFreeText, setShowFreeText] = useState(!hasOptions);
-  const [text, setText] = useState("");
+  const [selections, setSelections] = useState<QuestionSelections>({});
+  const [freeText, setFreeText] = useState("");
 
-  const typeOwnAnswerLabel =
-    labels?.typeOwnAnswer ?? "Answer in your own words";
   const placeholder = labels?.placeholder ?? "Type your answer...";
   const sendLabel = labels?.send ?? "Send";
+  const batched = questions.length > 1;
 
-  const answer = useCallback(
-    (value: string) => {
+  const send = useCallback(
+    (state: QuestionSelections, text: string) => {
       if (disabled) return;
-      const normalized = normalizeAnswer(value);
-      if (normalized === null) return;
-      onAnswer(normalized);
+      const reply = composeReply(questions, state, text);
+      if (reply === null) return;
+      onAnswer(reply);
     },
-    [disabled, onAnswer],
+    [disabled, questions, onAnswer],
   );
 
-  const submitFreeText = useCallback(() => {
-    answer(text);
-    setText("");
-  }, [answer, text]);
+  const handleSelect = useCallback(
+    (questionId: string, optionId: string) => {
+      if (disabled) return;
+      // Fast path: one question with options + empty input → send on click.
+      if (isFastPath(questions, freeText)) {
+        send({ [questionId]: optionId }, freeText);
+        return;
+      }
+      setSelections((prev) => ({
+        ...prev,
+        [questionId]: prev[questionId] === optionId ? null : optionId,
+      }));
+    },
+    [disabled, questions, freeText, send],
+  );
 
   const handleKeyDown = useCallback(
     (e: KeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
-        submitFreeText();
+        send(selections, freeText);
       }
     },
-    [submitFreeText],
+    [send, selections, freeText],
   );
 
-  // A pure card: the composer slot that hosts it owns the outer layout
-  // (padding + max-width + centering), so this component adds none — it sits
-  // consistently beside the connect interaction card in the same slot.
   return (
     <div
       aria-disabled={disabled || undefined}
       className={cn(
-        "rounded-3xl border border-border/60 bg-card p-5 shadow-sm",
+        "overflow-clip rounded-[28px] border border-border/50 bg-card p-2.5",
+        "shadow-[0_1px_6px_rgba(0,0,0,0.06)] focus-within:shadow-[0_1px_10px_rgba(0,0,0,0.1)]",
+        "dark:shadow-[0_1px_6px_rgba(0,0,0,0.2)] dark:focus-within:shadow-[0_1px_10px_rgba(0,0,0,0.3)]",
         disabled && "opacity-50",
       )}
     >
-      <p className={QUESTION_TEXT_CLASS}>{question}</p>
-
-      {hasOptions && (
-        <div className="mt-4 flex flex-wrap gap-2">
-          {options?.map((option) => (
-            <Button
-              className="rounded-full"
+      <div className="flex flex-col px-2.5 pt-2 pb-2">
+        {questions.map((question, i) => (
+          <div className={cn(i > 0 && "mt-8")} key={question.id}>
+            <QuestionBlock
+              batched={batched}
               disabled={disabled}
-              key={option.id}
-              onClick={() => answer(option.label)}
-              type="button"
-              variant="outline"
-            >
-              {option.label}
-            </Button>
-          ))}
-        </div>
-      )}
+              onSelect={(optionId) => handleSelect(question.id, optionId)}
+              question={question}
+              selectedId={selections[question.id] ?? null}
+            />
+          </div>
+        ))}
 
-      {hasOptions && !showFreeText && (
-        <button
-          className={OWN_ANSWER_TOGGLE_CLASS}
-          disabled={disabled}
-          onClick={() => setShowFreeText(true)}
-          type="button"
-        >
-          {typeOwnAnswerLabel}
-        </button>
-      )}
-
-      {showFreeText && (
-        <div className={cn("flex items-end gap-2", hasOptions && "mt-4")}>
-          <Textarea
-            className="min-h-11 flex-1 resize-none rounded-2xl"
+        <div className="mt-4 flex items-end gap-2 rounded-2xl border border-border/50 bg-background px-3 py-2 transition-colors focus-within:border-border">
+          <textarea
+            className="max-h-40 flex-1 resize-none border-none bg-transparent py-1 text-base text-foreground leading-[1.2] outline-none placeholder:text-muted-foreground/50"
             disabled={disabled}
-            onChange={(e) => setText(e.target.value)}
+            onChange={(e) => setFreeText(e.target.value)}
             onKeyDown={handleKeyDown}
             placeholder={placeholder}
             rows={1}
-            value={text}
+            value={freeText}
           />
-          <Button
-            className="rounded-full"
-            disabled={disabled || normalizeAnswer(text) === null}
-            onClick={submitFreeText}
-            type="button"
-          >
-            {sendLabel}
-          </Button>
+          <PromptInputSubmit
+            aria-label={sendLabel}
+            className="shrink-0"
+            disabled={disabled || !canSend(questions, selections, freeText)}
+            onClick={() => send(selections, freeText)}
+          />
         </div>
-      )}
+      </div>
     </div>
   );
 }

--- a/ui/chat/tests/question-card.test.ts
+++ b/ui/chat/tests/question-card.test.ts
@@ -1,15 +1,37 @@
 import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import {
+  type ChatQuestion,
+  canSend,
+  composeReply,
   hasSelectableOptions,
+  isFastPath,
   normalizeAnswer,
-  OWN_ANSWER_TOGGLE_CLASS,
   QUESTION_TEXT_CLASS,
+  QUESTION_TEXT_CLASS_BATCHED,
 } from "../src/question-card-logic.ts";
 
 function tokens(className: string): Set<string> {
   return new Set(className.split(/\s+/).filter(Boolean));
 }
+
+const Q1: ChatQuestion = {
+  id: "q1",
+  question: "Which quarter?",
+  options: [
+    { id: "o1", label: "Q1" },
+    { id: "o2", label: "Q2" },
+  ],
+};
+const Q2: ChatQuestion = {
+  id: "q2",
+  question: "Include drafts?",
+  options: [
+    { id: "y", label: "Yes" },
+    { id: "n", label: "No" },
+  ],
+};
+const OPEN: ChatQuestion = { id: "q3", question: "Anything else?" };
 
 describe("hasSelectableOptions", () => {
   it("is true when the agent offered concrete choices", () => {
@@ -33,27 +55,87 @@ describe("normalizeAnswer", () => {
   });
 });
 
+describe("composeReply", () => {
+  it("returns null when nothing is answered", () => {
+    assert.equal(composeReply([Q1], {}, ""), null);
+    assert.equal(composeReply([Q1], { q1: null }, "  "), null);
+  });
+
+  it("emits '<question>: <label>' for one answered question", () => {
+    assert.equal(composeReply([Q1], { q1: "o2" }, ""), "Which quarter?: Q2");
+  });
+
+  it("joins multiple answered questions with newlines", () => {
+    const reply = composeReply([Q1, Q2], { q1: "o1", y: "n", q2: "y" }, "");
+    assert.equal(reply, "Which quarter?: Q1\nInclude drafts?: Yes");
+  });
+
+  it("skips unanswered questions in a batch", () => {
+    const reply = composeReply([Q1, Q2], { q2: "n" }, "");
+    assert.equal(reply, "Include drafts?: No");
+  });
+
+  it("appends trimmed free text after a blank line", () => {
+    const reply = composeReply([Q1], { q1: "o1" }, "  and Q4 too ");
+    assert.equal(reply, "Which quarter?: Q1\n\nand Q4 too");
+  });
+
+  it("returns just the text when only free text is given", () => {
+    assert.equal(composeReply([OPEN], {}, "  the report "), "the report");
+  });
+
+  it("ignores a selected option id that no longer exists", () => {
+    assert.equal(composeReply([Q1], { q1: "gone" }, ""), null);
+  });
+});
+
+describe("canSend", () => {
+  it("is disabled with no selection and no text", () => {
+    assert.equal(canSend([Q1, Q2], {}, ""), false);
+  });
+
+  it("is enabled with at least one selection", () => {
+    assert.equal(canSend([Q1, Q2], { q1: "o1" }, ""), true);
+  });
+
+  it("is enabled with only free text", () => {
+    assert.equal(canSend([Q1], {}, "typed"), true);
+  });
+});
+
+describe("isFastPath", () => {
+  it("is true for one question with options and an empty input", () => {
+    assert.equal(isFastPath([Q1], ""), true);
+    assert.equal(isFastPath([Q1], "   "), true);
+  });
+
+  it("is false when the input has text", () => {
+    assert.equal(isFastPath([Q1], "wait"), false);
+  });
+
+  it("is false for multiple questions", () => {
+    assert.equal(isFastPath([Q1, Q2], ""), false);
+  });
+
+  it("is false for a single open (option-less) question", () => {
+    assert.equal(isFastPath([OPEN], ""), false);
+  });
+});
+
 describe("question-card class tokens", () => {
-  // The card replaces the composer, so the question must read as the single
-  // next action — sized up and weighted.
-  it("renders the question prominently", () => {
+  // A lone question replaces the composer, so it reads as the single next
+  // action — sized up and weighted.
+  it("renders a solo question prominently (text-lg)", () => {
     const t = tokens(QUESTION_TEXT_CLASS);
     assert.ok(t.has("text-lg"));
     assert.ok(t.has("font-medium"));
   });
 
-  // No-hover-only-affordances rule: the "answer in your own words" toggle must
-  // be visible at rest, never gated behind a hover/opacity trick.
-  it("keeps the free-text toggle visible without hover", () => {
-    const t = tokens(OWN_ANSWER_TOGGLE_CLASS);
-    assert.ok(!t.has("hidden"));
-    assert.ok(!t.has("opacity-0"));
-    assert.ok(!t.has("group-hover:opacity-100"));
-    for (const token of t) {
-      assert.ok(
-        !token.startsWith("group-hover:"),
-        `toggle must not be hover-gated: ${token}`,
-      );
-    }
+  // Batched questions drop to the base size so the stack has rhythm without
+  // every head shouting.
+  it("drops batched question heads to text-base", () => {
+    const t = tokens(QUESTION_TEXT_CLASS_BATCHED);
+    assert.ok(t.has("text-base"));
+    assert.ok(t.has("font-medium"));
   });
 });

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -352,14 +352,21 @@ export interface InteractionOption {
   label: string;
 }
 
+/** One question in a batched `ask_user` card (`id` is `q1`..`qN`). */
+export interface InteractionQuestion {
+  id: string;
+  question: string;
+  options?: InteractionOption[];
+}
+
 /**
  * The one thing a mission is waiting on the user for — recorded when the model
  * ends a turn by asking (ask_user / request_connection). Present drives the
  * `needs_you` board card and the composer-replacing card; absent means the
- * mission needs nothing.
+ * mission needs nothing. `ask_user` batches 1 to 3 questions into one card.
  */
 export type PendingInteraction =
-  | { kind: "question"; question: string; options?: InteractionOption[] }
+  | { kind: "question"; questions: InteractionQuestion[] }
   | { kind: "connect"; toolkit: string; reason?: string };
 
 export interface Activity {


### PR DESCRIPTION
## What

Iteration on the interaction refactor from live feedback: users answer once and expect to be done, and the card needed to match the composer's bar.

- **Batched questions**: the question interaction is now `questions[]` (1-3; tool assigns ids; >3 throws with merge/trim guidance). The system prompt (host + Rust mirror) now says: gather everything blocking into ONE `ask_user` call — three is a cap, not a target, never one-question-per-turn drip. Old singular persisted shape degrades safely (field dropped with diagnostic, activity kept).
- **Card rebuilt on the composer's exact design vocabulary** (extracted into a spec first: 28px radius, `border-border/50`, single focus elevation, `PromptInputSubmit`): questions stacked vertically with whitespace-only separation, vertical single-select option rows (radiogroup + check), and the **free-text input always visible at the bottom**. Fast path: a single option-only question sends on click. Reply composed as `question: label` lines + free text.
- Screenshot-driven design review against the ChatInput reference caught and fixed: double focus elevation, stray `cursor-text`, decorative separators.
- Notifications pluralized by question count (en/es/pt). Inventory v5.

## Tests

runtime 477, host 632 (prompt batching asserted), domain 92, sdk 248, web 83, app 837, ui/chat card 20; cargo prompt tests 8; e2e interaction spec covers the 3-question flow + fast path; typecheck/check-locales/check:parity/biome green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)