### PR TITLE
fix: name reconnect-card actions instead of ambiguous "Try again"

### DIFF
--- a/app/src/components/shell/provider-error-cards/auth-presentation.ts
+++ b/app/src/components/shell/provider-error-cards/auth-presentation.ts
@@ -1,0 +1,120 @@
+import type { ProviderError } from "@houston-ai/chat";
+
+/**
+ * Pure state -> presentation mapping for the inline `UnauthenticatedCard`.
+ *
+ * The card is a 4-phase machine (`idle | waiting | done | failed`). Its labels
+ * carried two OPPOSITE meanings under one "Try again" string, so the mapping is
+ * pulled out here where every phase can be asserted without mounting React. The
+ * component keeps ALL side effects (launchLogin, cancel, resend) and only reads
+ * the keys + action tag this returns.
+ */
+
+export type LoginPhase = "idle" | "waiting" | "done" | "failed";
+
+type UnauthCause = Extract<ProviderError, { kind: "unauthenticated" }>["cause"];
+
+const K = "providerError.unauthenticated";
+
+/** Every auth-failure cause maps to a body key so the card always names a reason. */
+export function authCauseBodyKey(cause: UnauthCause): string {
+  switch (cause) {
+    case "token_expired":
+      return `${K}.bodyTokenExpired`;
+    case "no_credentials":
+      return `${K}.bodyNoCredentials`;
+    case "invalid_api_key":
+      return `${K}.bodyInvalidApiKey`;
+    case "token_revoked":
+      return `${K}.bodyTokenRevoked`;
+    default:
+      return `${K}.bodyUnknown`;
+  }
+}
+
+/** The action a button fires. A `badge` button is a disabled status pill. */
+export type AuthCardAction = "reconnect" | "cancel" | "sendAgain";
+
+export type AuthCardButton =
+  | { kind: "action"; labelKey: string; action: AuthCardAction }
+  | { kind: "badge"; labelKey: string }
+  | null;
+
+export interface AuthCardPresentation {
+  /** `done` = green confirmation card; `active` = the provider-glyph card. */
+  variant: "done" | "active";
+  titleKey: string;
+  bodyKey: string;
+  button: AuthCardButton;
+}
+
+/**
+ * Resolve the card's title/body/button from its phase.
+ *
+ * - `done` + a refused send (`hasFailedPrompt`): the resend already fired, so
+ *   the pill is a disabled "Signed in" badge.
+ * - `done`, mid-turn failure: an explicit "Send my message" button (only when
+ *   the card can resend — `hasRetry`).
+ * - `waiting`: the wait is on the user's browser, so the action is Cancel.
+ * - `failed` / `idle`: the Reconnect button relaunches sign-in.
+ */
+export function resolveAuthCardPresentation(args: {
+  phase: LoginPhase;
+  hasFailedPrompt: boolean;
+  hasRetry: boolean;
+  causeBodyKey: string;
+}): AuthCardPresentation {
+  const { phase, hasFailedPrompt, hasRetry, causeBodyKey } = args;
+
+  if (phase === "done") {
+    if (hasFailedPrompt) {
+      return {
+        variant: "done",
+        titleKey: `${K}.reconnectedTitle`,
+        bodyKey: `${K}.reconnectedResending`,
+        button: { kind: "badge", labelKey: `${K}.signedIn` },
+      };
+    }
+    return {
+      variant: "done",
+      titleKey: `${K}.reconnectedTitle`,
+      bodyKey: `${K}.reconnectedBody`,
+      button: hasRetry
+        ? { kind: "action", labelKey: `${K}.sendAgain`, action: "sendAgain" }
+        : null,
+    };
+  }
+
+  if (phase === "waiting") {
+    return {
+      variant: "active",
+      titleKey: `${K}.title`,
+      bodyKey: `${K}.waiting`,
+      button: {
+        kind: "action",
+        labelKey: "common:actions.cancel",
+        action: "cancel",
+      },
+    };
+  }
+
+  if (phase === "failed") {
+    return {
+      variant: "active",
+      titleKey: `${K}.title`,
+      bodyKey: `${K}.failedBody`,
+      button: {
+        kind: "action",
+        labelKey: `${K}.reconnect`,
+        action: "reconnect",
+      },
+    };
+  }
+
+  return {
+    variant: "active",
+    titleKey: `${K}.title`,
+    bodyKey: causeBodyKey,
+    button: { kind: "action", labelKey: `${K}.reconnect`, action: "reconnect" },
+  };
+}

--- a/app/src/components/shell/provider-error-cards/auth.tsx
+++ b/app/src/components/shell/provider-error-cards/auth.tsx
@@ -1,36 +1,26 @@
 /**
- * UnauthenticatedCard — drives the user back into the provider's
- * connect flow. Body copy varies by [`AuthFailureCause`] so the user
- * understands WHY they need to reconnect. Renders through the shared
- * `RowCard` with the provider's monochrome `ProviderGlyph` on the left
- * (never a hand-picked brand logo) and a text-only `RowCardButton`.
+ * UnauthenticatedCard — drives the user back into the provider's connect flow.
+ * Body copy varies by cause (see `authCauseBodyKey`) so the user understands WHY
+ * they must reconnect. The state -> title/body/button mapping lives in
+ * `./auth-presentation`; this component owns only the side effects.
  *
- * Reconnect lifecycle (the button must not fire-and-forget):
- * `launchLogin` resolves when the engine STARTS the sign-in flow, not
- * when the user finishes it in the browser — completion arrives later as
- * the `ProviderLoginComplete` WS event (the same signal Settings uses to
- * flip its chip). So the card holds a "finish in your browser" state —
- * where the pill becomes a Cancel that frees the login slot and re-arms
- * (lost the OAuth tab, wrong account, second thoughts) — until that
- * event lands, then flips to a green confirmation, or shows the failure
- * and re-arms the button. A benign cancel (`success:false`, no error)
- * just re-arms.
+ * Reconnect lifecycle (the button must not fire-and-forget): `launchLogin`
+ * resolves when the engine STARTS sign-in, not when the user finishes in the
+ * browser — completion arrives later as the `ProviderLoginComplete` event. So
+ * the card holds a "finish in your browser" state (the pill becomes a Cancel
+ * that frees the login slot and re-arms) until that event flips it to a green
+ * confirmation, the failure, or a benign cancel.
  *
- * The confirmation's shape depends on what failed. A refused SEND (the
- * card carries `failed_prompt` — the message never reached the engine)
- * resends it automatically, once: the user already said what they
- * wanted, so signing in IS the remaining intent, and the pill settles
- * into a disabled "Signed in" badge. A mid-turn failure (token expired
- * during a live turn) keeps the explicit "Try again" CTA — re-running a
- * turn that already has server-side context stays a user decision.
+ * The confirmation depends on what failed. A refused SEND (`failed_prompt`: the
+ * message never reached the engine) resends once — signing in IS the remaining
+ * intent — then shows a disabled "Signed in" badge. A mid-turn failure keeps an
+ * explicit resend CTA (that turn already has server-side context).
  *
- * Every launch goes through cancelLogin → launchLogin: the engine keeps
- * one login slot per provider and rejects a second launch as "already
- * pending", so a relaunch after a cancel (or a stale slot from a
- * previous run) must free the slot first. cancelLogin is idempotent, so
- * the first press pays one no-op call. The benign ProviderLoginComplete
- * our own cancel triggers is ignored via `relaunchingRef` so the card
- * does not flicker back to idle mid-relaunch.
+ * Every launch is cancelLogin -> launchLogin: the engine keeps one login slot
+ * per provider and rejects a second launch as "already pending", so a relaunch
+ * frees the slot first (cancelLogin is idempotent). The benign completion our
+ * own cancel triggers is ignored via `relaunchingRef` so the card does not
+ * flicker to idle mid-relaunch.
  */
 
 import type { ProviderError } from "@houston-ai/chat";
@@ -44,9 +34,13 @@ import { useUIStore } from "../../../stores/ui";
 import { RowCard } from "../../cards/row-card";
 import { RowCardButton } from "../../cards/row-card-button";
 import { ProviderGlyph } from "../provider-logos";
+import {
+  type AuthCardButton,
+  authCauseBodyKey,
+  type LoginPhase,
+  resolveAuthCardPresentation,
+} from "./auth-presentation";
 import { providerLabel } from "./shared";
-
-type LoginPhase = "idle" | "waiting" | "done" | "failed";
 
 export function UnauthenticatedCard({
   error,
@@ -62,17 +56,15 @@ export function UnauthenticatedCard({
   const [failureDetail, setFailureDetail] = useState<string | null>(null);
   const [retrying, setRetrying] = useState(false);
   const relaunchingRef = useRef(false);
-  // The auto-resend must fire ONCE per card even if the provider completes
-  // several logins while the chat stays open — a second fire would send the
-  // same message twice.
+  // The auto-resend must fire ONCE per card — a second fire (the provider can
+  // complete several logins while the chat stays open) would double-send.
   const autoResendFiredRef = useRef(false);
   const provider = providerLabel(error.provider);
-  // A refused SEND (the message never reached the engine): reconnecting
-  // completes the user's stated intent, so the reply is fetched without
-  // another press. Mid-turn failures (no failed_prompt) keep the explicit CTA.
+  // A refused SEND (see header): reconnect auto-resends; mid-turn failures keep
+  // the explicit CTA.
   const autoResend = !!error.failed_prompt;
-  // In a ref so the subscription mounts once — resubscribing on every parent
-  // render could drop a completion event in the gap.
+  // In a ref so the subscription mounts once (resubscribing per render could
+  // drop a completion event in the gap).
   const onRetryRef = useRef(onRetry);
   onRetryRef.current = onRetry;
 
@@ -83,9 +75,8 @@ export function UnauthenticatedCard({
       if (ev.data.success) {
         setPhase("done");
         setFailureDetail(null);
-        // The login this card prompted for just succeeded — clear the
-        // global flag so other surfaces (store reconnect card, session
-        // error suppression) stop treating the provider as signed out.
+        // Login succeeded — clear the global flag so other surfaces (store
+        // reconnect card, error suppression) stop treating it as signed out.
         if (useUIStore.getState().authRequired === error.provider) {
           setAuthRequired(null);
         }
@@ -93,10 +84,9 @@ export function UnauthenticatedCard({
           autoResendFiredRef.current = true;
           setRetrying(true);
           void Promise.resolve(onRetryRef.current())
-            .catch(() => {
-              // The send already surfaced its own failure (call()'s toast +
-              // Report bug); this catch only stops an unhandled rejection.
-            })
+            // The send surfaces its own failure (toast + Report bug); this
+            // catch only stops an unhandled rejection.
+            .catch(() => {})
             .finally(() => setRetrying(false));
         }
       } else if (ev.data.error) {
@@ -104,31 +94,12 @@ export function UnauthenticatedCard({
         setFailureDetail(ev.data.error);
       } else if (!relaunchingRef.current) {
         // Benign cancel (user gave up on the OAuth tab) — re-arm quietly.
-        // Skipped when WE issued the cancel as the first half of a
-        // relaunch: the new login is already spawning and the card must
-        // stay in its waiting state.
+        // Skipped when WE issued the cancel as the first half of a relaunch:
+        // the new login is spawning and the card must stay in its waiting state.
         setPhase("idle");
       }
     });
   }, [error.provider, setAuthRequired, autoResend]);
-
-  // Map every cause to a body string so the user always sees a reason
-  // (instead of a generic "session expired" wall). Keeps the card
-  // honest about what we know.
-  const bodyKey: string = (() => {
-    switch (error.cause) {
-      case "token_expired":
-        return "providerError.unauthenticated.bodyTokenExpired";
-      case "no_credentials":
-        return "providerError.unauthenticated.bodyNoCredentials";
-      case "invalid_api_key":
-        return "providerError.unauthenticated.bodyInvalidApiKey";
-      case "token_revoked":
-        return "providerError.unauthenticated.bodyTokenRevoked";
-      default:
-        return "providerError.unauthenticated.bodyUnknown";
-    }
-  })();
 
   const reconnect = async () => {
     if (launching) return;
@@ -136,9 +107,6 @@ export function UnauthenticatedCard({
     relaunchingRef.current = true;
     setFailureDetail(null);
     try {
-      // Free the engine's single login slot (idempotent no-op when
-      // nothing is pending) so a relaunch is never rejected as
-      // "already pending", then spawn a fresh browser sign-in.
       await tauriProvider.cancelLogin(error.provider);
       await tauriProvider.launchLogin(error.provider);
       setPhase("waiting");
@@ -150,8 +118,6 @@ export function UnauthenticatedCard({
     }
   };
 
-  // Waiting-state Cancel: free the runtime's login slot for real (idempotent —
-  // a no-pending cancel is benign) and re-arm so the user can relaunch.
   const cancelSignIn = async () => {
     try {
       await tauriProvider.cancelLogin(error.provider);
@@ -170,80 +136,64 @@ export function UnauthenticatedCard({
     }
   };
 
-  if (phase === "done") {
-    return (
-      <div className="w-full px-1 py-2">
-        <RowCard
-          media={<CheckCircle2Icon className="size-5 text-green-600" />}
-          title={t("providerError.unauthenticated.reconnectedTitle", {
-            provider,
-          })}
-          description={t(
-            autoResend
-              ? "providerError.unauthenticated.reconnectedResending"
-              : "providerError.unauthenticated.reconnectedBody",
-            { provider },
-          )}
-          action={
-            autoResend ? (
-              // The resend fired itself — the pill is a status badge, not an
-              // action (it spins while the resend request is in flight).
-              <RowCardButton
-                label={t("providerError.unauthenticated.signedIn")}
-                onClick={() => {}}
-                disabled
-                loading={retrying}
-                variant="outline"
-              />
-            ) : (
-              onRetry && (
-                <RowCardButton
-                  label={t("providerError.unauthenticated.sendAgain")}
-                  onClick={sendAgain}
-                  loading={retrying}
-                />
-              )
-            )
-          }
-        />
-      </div>
-    );
-  }
+  const pres = resolveAuthCardPresentation({
+    phase,
+    hasFailedPrompt: autoResend,
+    hasRetry: !!onRetry,
+    causeBodyKey: authCauseBodyKey(error.cause),
+  });
 
-  const waiting = phase === "waiting";
+  // Map the resolved button spec to its live handler + pending state. The
+  // "done" resend badge is a disabled status pill that spins during the resend;
+  // Cancel (bail out of the browser wait) is the only outline action pill.
+  const renderButton = (button: AuthCardButton) => {
+    if (!button) return undefined;
+    if (button.kind === "badge") {
+      return (
+        <RowCardButton
+          label={t(button.labelKey)}
+          onClick={() => {}}
+          disabled
+          loading={retrying}
+          variant="outline"
+        />
+      );
+    }
+    const handler =
+      button.action === "cancel"
+        ? cancelSignIn
+        : button.action === "sendAgain"
+          ? sendAgain
+          : reconnect;
+    return (
+      <RowCardButton
+        label={t(button.labelKey)}
+        onClick={handler}
+        loading={
+          button.action === "reconnect"
+            ? launching
+            : button.action === "sendAgain"
+              ? retrying
+              : false
+        }
+        variant={button.action === "cancel" ? "outline" : "default"}
+      />
+    );
+  };
+
   return (
     <div className="w-full px-1 py-2">
       <RowCard
-        media={<ProviderGlyph providerId={error.provider} />}
-        title={t("providerError.unauthenticated.title", { provider })}
-        description={
-          phase === "failed"
-            ? t("providerError.unauthenticated.failedBody", {
-                provider,
-                detail: failureDetail ?? "",
-              })
-            : waiting
-              ? t("providerError.unauthenticated.waiting")
-              : t(bodyKey, { provider })
-        }
-        action={
-          waiting ? (
-            // The wait is on the user's browser, not on Houston — the useful
-            // action here is bailing out (lost the tab, wrong account), which
-            // re-arms the Reconnect button.
-            <RowCardButton
-              label={t("common:actions.cancel")}
-              onClick={cancelSignIn}
-              variant="outline"
-            />
+        media={
+          pres.variant === "done" ? (
+            <CheckCircle2Icon className="size-5 text-green-600" />
           ) : (
-            <RowCardButton
-              label={t("providerError.unauthenticated.reconnect")}
-              onClick={reconnect}
-              loading={launching}
-            />
+            <ProviderGlyph providerId={error.provider} />
           )
         }
+        title={t(pres.titleKey, { provider })}
+        description={t(pres.bodyKey, { provider, detail: failureDetail ?? "" })}
+        action={renderButton(pres.button)}
       />
     </div>
   );

--- a/app/src/components/shell/provider-reconnect-card.tsx
+++ b/app/src/components/shell/provider-reconnect-card.tsx
@@ -7,6 +7,7 @@ import { RowCard } from "../cards/row-card";
 import { RowCardButton } from "../cards/row-card-button";
 import { LocalModelDialog } from "./local-model-dialog";
 import { ProviderGlyph } from "./provider-logos";
+import { resolveReconnectCardPresentation } from "./provider-reconnect-presentation";
 import {
   providerIsAuthenticated,
   providerReconnectSignalState,
@@ -125,29 +126,21 @@ export function ProviderReconnectCard({
 
   if (!activeProviderId || !provider) return null;
 
-  const description = loginError
-    ? t("shell:providerReconnect.launchError")
-    : loginLaunched
-      ? t("shell:providerReconnect.waiting")
-      : t("shell:providerReconnect.body", { provider: provider.name });
+  // Two states keyed on loginLaunched: the launched button now names its
+  // action ("Sign in again"), not the ambiguous shared "Try again".
+  const pres = resolveReconnectCardPresentation({ loginLaunched, loginError });
 
   return (
     <div className="w-full px-1 py-2">
       <RowCard
         media={<ProviderGlyph providerId={activeProviderId} />}
         title={t("shell:providerReconnect.title")}
-        description={description}
+        description={t(pres.descriptionKey, { provider: provider.name })}
         action={
           <RowCardButton
-            label={
-              loginLaunched
-                ? t("common:actions.tryAgain")
-                : t("shell:authReconnect.signInWith", {
-                    provider: provider.name,
-                  })
-            }
+            label={t(pres.buttonLabelKey, { provider: provider.name })}
             onClick={handleSignIn}
-            variant={loginLaunched ? "outline" : "default"}
+            variant={pres.buttonVariant}
           />
         }
       />

--- a/app/src/components/shell/provider-reconnect-presentation.ts
+++ b/app/src/components/shell/provider-reconnect-presentation.ts
@@ -1,0 +1,34 @@
+/**
+ * Pure state -> presentation mapping for the store-driven
+ * `ProviderReconnectCard`.
+ *
+ * The card has two states, keyed on `loginLaunched`: the resting "sign in"
+ * prompt and the "finish in your browser" state after a launch. The launched
+ * button used to borrow `common:actions.tryAgain` ("Try again"), which read as
+ * a message-retry; it now names its real action, "Sign in again". Extracted so
+ * both states are unit-testable without mounting React.
+ */
+
+export interface ReconnectCardPresentation {
+  descriptionKey: string;
+  buttonLabelKey: string;
+  buttonVariant: "outline" | "default";
+}
+
+export function resolveReconnectCardPresentation(args: {
+  loginLaunched: boolean;
+  loginError: boolean;
+}): ReconnectCardPresentation {
+  const { loginLaunched, loginError } = args;
+  return {
+    descriptionKey: loginError
+      ? "shell:providerReconnect.launchError"
+      : loginLaunched
+        ? "shell:providerReconnect.waiting"
+        : "shell:providerReconnect.body",
+    buttonLabelKey: loginLaunched
+      ? "shell:providerReconnect.signInAgain"
+      : "shell:authReconnect.signInWith",
+    buttonVariant: loginLaunched ? "outline" : "default",
+  };
+}

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -127,9 +127,8 @@
   "providerReconnect": {
     "title": "Session expired",
     "body": "Your {{provider}} connection ended, this happens from time to time. Sign back in and you're good to go.",
-    "reconnect": "Reconnect to {{provider}}",
     "waiting": "Waiting for browser sign-in...",
-    "tryAgain": "Try again",
+    "signInAgain": "Sign in again",
     "launchError": "Could not open sign-in. Try again."
   },
   "agentProvisioning": {
@@ -328,8 +327,8 @@
       "reconnectedBody": "You are signed in again. Pick up where you left off.",
       "reconnectedResending": "You are signed in again. Houston is answering your message now.",
       "signedIn": "Signed in",
-      "sendAgain": "Try again",
-      "failedBody": "The {{provider}} sign-in did not finish. Try again. {{detail}}"
+      "sendAgain": "Send my message",
+      "failedBody": "The {{provider}} sign-in did not finish. Sign in again. {{detail}}"
     },
     "networkUnreachable": {
       "title": "Cannot reach {{provider}}",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -127,9 +127,8 @@
   "providerReconnect": {
     "title": "Sesión expirada",
     "body": "Tu conexión con {{provider}} se terminó, pasa de vez en cuando. Inicia sesión otra vez y listo.",
-    "reconnect": "Reconectar a {{provider}}",
     "waiting": "Esperando el inicio de sesión en el navegador...",
-    "tryAgain": "Intentar de nuevo",
+    "signInAgain": "Iniciar sesión de nuevo",
     "launchError": "No se pudo abrir el inicio de sesión. Intenta otra vez."
   },
   "agentProvisioning": {
@@ -328,8 +327,8 @@
       "reconnectedBody": "Ya iniciaste sesión de nuevo. Continúa donde quedaste.",
       "reconnectedResending": "Ya iniciaste sesión de nuevo. Houston está respondiendo tu mensaje ahora.",
       "signedIn": "Sesión iniciada",
-      "sendAgain": "Intentar de nuevo",
-      "failedBody": "El inicio de sesión de {{provider}} no se completó. Inténtalo de nuevo. {{detail}}"
+      "sendAgain": "Enviar mi mensaje",
+      "failedBody": "El inicio de sesión de {{provider}} no se completó. Inicia sesión de nuevo. {{detail}}"
     },
     "networkUnreachable": {
       "title": "No se puede conectar con {{provider}}",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -127,9 +127,8 @@
   "providerReconnect": {
     "title": "Sessão expirada",
     "body": "Sua conexão com o {{provider}} encerrou, isso acontece de vez em quando. Entre de novo e está tudo certo.",
-    "reconnect": "Reconectar ao {{provider}}",
     "waiting": "Aguardando o login no navegador...",
-    "tryAgain": "Tentar de novo",
+    "signInAgain": "Entrar novamente",
     "launchError": "Não foi possível abrir o login. Tente de novo."
   },
   "agentProvisioning": {
@@ -313,8 +312,8 @@
       "reconnectedBody": "Você entrou de novo. Continue de onde parou.",
       "reconnectedResending": "Você entrou de novo. O Houston está respondendo sua mensagem agora.",
       "signedIn": "Sessão iniciada",
-      "sendAgain": "Tentar novamente",
-      "failedBody": "O login de {{provider}} não foi concluído. Tente novamente. {{detail}}"
+      "sendAgain": "Enviar minha mensagem",
+      "failedBody": "O login de {{provider}} não foi concluído. Entre novamente. {{detail}}"
     },
     "networkUnreachable": {
       "title": "Não foi possível alcançar o {{provider}}",

--- a/app/tests/auth-card-presentation.test.ts
+++ b/app/tests/auth-card-presentation.test.ts
@@ -1,0 +1,159 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  authCauseBodyKey,
+  resolveAuthCardPresentation,
+} from "../src/components/shell/provider-error-cards/auth-presentation.ts";
+
+// The card once labeled two opposite actions "Try again". These assert the
+// state -> title/body/button mapping so each phase names its real action:
+// idle/failed -> Reconnect, waiting -> Cancel, done -> Send my message (or a
+// disabled "Signed in" badge when the refused send auto-resent).
+
+const CAUSE = "providerError.unauthenticated.bodyTokenExpired";
+
+describe("authCauseBodyKey", () => {
+  it("maps every known cause to its own body key", () => {
+    strictEqual(
+      authCauseBodyKey("token_expired"),
+      "providerError.unauthenticated.bodyTokenExpired",
+    );
+    strictEqual(
+      authCauseBodyKey("no_credentials"),
+      "providerError.unauthenticated.bodyNoCredentials",
+    );
+    strictEqual(
+      authCauseBodyKey("invalid_api_key"),
+      "providerError.unauthenticated.bodyInvalidApiKey",
+    );
+    strictEqual(
+      authCauseBodyKey("token_revoked"),
+      "providerError.unauthenticated.bodyTokenRevoked",
+    );
+  });
+
+  it("falls back to the unknown body for any other cause", () => {
+    strictEqual(
+      // deliberately outside the union
+      authCauseBodyKey("mystery" as never),
+      "providerError.unauthenticated.bodyUnknown",
+    );
+  });
+});
+
+describe("resolveAuthCardPresentation", () => {
+  it("idle: reconnect button, cause-derived body, glyph card", () => {
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "idle",
+        hasFailedPrompt: false,
+        hasRetry: false,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "active",
+        titleKey: "providerError.unauthenticated.title",
+        bodyKey: CAUSE,
+        button: {
+          kind: "action",
+          labelKey: "providerError.unauthenticated.reconnect",
+          action: "reconnect",
+        },
+      },
+    );
+  });
+
+  it("waiting: the action is Cancel, not a retry", () => {
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "waiting",
+        hasFailedPrompt: true,
+        hasRetry: true,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "active",
+        titleKey: "providerError.unauthenticated.title",
+        bodyKey: "providerError.unauthenticated.waiting",
+        button: {
+          kind: "action",
+          labelKey: "common:actions.cancel",
+          action: "cancel",
+        },
+      },
+    );
+  });
+
+  it("failed: reconnect button with the failed body", () => {
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "failed",
+        hasFailedPrompt: false,
+        hasRetry: true,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "active",
+        titleKey: "providerError.unauthenticated.title",
+        bodyKey: "providerError.unauthenticated.failedBody",
+        button: {
+          kind: "action",
+          labelKey: "providerError.unauthenticated.reconnect",
+          action: "reconnect",
+        },
+      },
+    );
+  });
+
+  it("done + refused send: disabled Signed-in badge, resending body", () => {
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "done",
+        hasFailedPrompt: true,
+        hasRetry: true,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "done",
+        titleKey: "providerError.unauthenticated.reconnectedTitle",
+        bodyKey: "providerError.unauthenticated.reconnectedResending",
+        button: {
+          kind: "badge",
+          labelKey: "providerError.unauthenticated.signedIn",
+        },
+      },
+    );
+  });
+
+  it("done + mid-turn failure: an explicit send-my-message button", () => {
+    deepStrictEqual(
+      resolveAuthCardPresentation({
+        phase: "done",
+        hasFailedPrompt: false,
+        hasRetry: true,
+        causeBodyKey: CAUSE,
+      }),
+      {
+        variant: "done",
+        titleKey: "providerError.unauthenticated.reconnectedTitle",
+        bodyKey: "providerError.unauthenticated.reconnectedBody",
+        button: {
+          kind: "action",
+          labelKey: "providerError.unauthenticated.sendAgain",
+          action: "sendAgain",
+        },
+      },
+    );
+  });
+
+  it("done without a retry handler: no button at all", () => {
+    const pres = resolveAuthCardPresentation({
+      phase: "done",
+      hasFailedPrompt: false,
+      hasRetry: false,
+      causeBodyKey: CAUSE,
+    });
+    strictEqual(pres.variant, "done");
+    strictEqual(pres.button, null);
+  });
+});

--- a/app/tests/provider-reconnect-presentation.test.ts
+++ b/app/tests/provider-reconnect-presentation.test.ts
@@ -1,0 +1,65 @@
+import { deepStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { resolveReconnectCardPresentation } from "../src/components/shell/provider-reconnect-presentation.ts";
+
+// The store-driven reconnect card has two states keyed on loginLaunched. The
+// launched button used to borrow common:actions.tryAgain ("Try again"), which
+// read as a message-retry; it now names its real action, "Sign in again".
+
+describe("resolveReconnectCardPresentation", () => {
+  it("resting state: sign-in prompt, default button", () => {
+    deepStrictEqual(
+      resolveReconnectCardPresentation({
+        loginLaunched: false,
+        loginError: false,
+      }),
+      {
+        descriptionKey: "shell:providerReconnect.body",
+        buttonLabelKey: "shell:authReconnect.signInWith",
+        buttonVariant: "default",
+      },
+    );
+  });
+
+  it("launched state: waiting body, scoped Sign-in-again button (not tryAgain)", () => {
+    deepStrictEqual(
+      resolveReconnectCardPresentation({
+        loginLaunched: true,
+        loginError: false,
+      }),
+      {
+        descriptionKey: "shell:providerReconnect.waiting",
+        buttonLabelKey: "shell:providerReconnect.signInAgain",
+        buttonVariant: "outline",
+      },
+    );
+  });
+
+  it("launch error: error body wins, button still names Sign in again", () => {
+    deepStrictEqual(
+      resolveReconnectCardPresentation({
+        loginLaunched: true,
+        loginError: true,
+      }),
+      {
+        descriptionKey: "shell:providerReconnect.launchError",
+        buttonLabelKey: "shell:providerReconnect.signInAgain",
+        buttonVariant: "outline",
+      },
+    );
+  });
+
+  it("error before launch: error body, resting sign-in button", () => {
+    deepStrictEqual(
+      resolveReconnectCardPresentation({
+        loginLaunched: false,
+        loginError: true,
+      }),
+      {
+        descriptionKey: "shell:providerReconnect.launchError",
+        buttonLabelKey: "shell:authReconnect.signInWith",
+        buttonVariant: "default",
+      },
+    );
+  });
+});


### PR DESCRIPTION
## What

The provider-disconnect cards reused the label **"Try again"** with two opposite meanings, so users read both as "connect again":

- Inline `UnauthenticatedCard` (done phase, after a successful reconnect): "Try again" actually **resends the failed chat message** → now **"Send my message"** (es "Enviar mi mensaje", pt "Enviar minha mensagem").
- Store `ProviderReconnectCard` (sign-in launched): "Try again" (borrowed from `common:actions.tryAgain`) actually **relaunches the sign-in** → now scoped `providerReconnect.signInAgain` **"Sign in again"**.
- `failedBody` copy now says "Sign in again." instead of "Try again."
- Removed dead locale keys `providerReconnect.reconnect` and `providerReconnect.tryAgain` (verified unreferenced).

## How

Phase→presentation mapping extracted into pure modules (`auth-presentation.ts`, `provider-reconnect-presentation.ts`) used by the cards, with 12 unit tests covering every phase/state — these labels had zero test coverage before. `auth.tsx` shrank 251→200 lines. No flow changes: mid-turn resend stays a manual user decision by design.

## Verification

- `app` tests 849/849 (incl. 12 new), `pnpm check-locales` in sync (en/es/pt), repo-wide `pnpm typecheck` + `pnpm check` + `pnpm check:boundaries` green.

Part of the AI Chat improvements series (context bar, effort, model picker, plan mode, dictation follow in separate PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)