### PR TITLE
fix: OpenAI wire provider id is always openai-codex (hosted 'No credential found for openai')

### DIFF
--- a/app/src/hooks/queries/use-agent-model-choice.ts
+++ b/app/src/hooks/queries/use-agent-model-choice.ts
@@ -1,7 +1,38 @@
-import type { AgentModelChoice } from "@houston-ai/engine-client";
+import type {
+  AgentModelChoice,
+  AgentModelChoiceInfo,
+} from "@houston-ai/engine-client";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  toCanonicalProviderId,
+  toDisplayProviderId,
+} from "../../lib/provider-overrides";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriAgentModelChoice } from "../../lib/tauri";
+
+/**
+ * The stored model choice crosses a provider-id DIALECT boundary here, the
+ * single read+write seam for it. The gateway stores + injects the CANONICAL
+ * engine id (pi's `openai-codex`); the whole app UI speaks the DISPLAY id
+ * (Houston renames it to `openai`, see `PROVIDER_ID_RENAME`). So a read maps
+ * engine → display and a write maps display → engine, keeping every downstream
+ * comparison (picker highlight, `resolvePersonalModelPin`, the effort re-write)
+ * in the display dialect it already assumes while the wire stays canonical — the
+ * client mirror of the runtime's `canonicalPinProvider` backstop. Only Codex
+ * differs; every other id is identical on both sides.
+ */
+function toDisplayChoice(
+  info: AgentModelChoiceInfo | null,
+): AgentModelChoiceInfo | null {
+  if (!info?.choice) return info;
+  return {
+    ...info,
+    choice: {
+      ...info.choice,
+      provider: toDisplayProviderId(info.choice.provider),
+    },
+  };
+}
 
 /**
  * Teams v2: the ACTING user's model choice for one shared agent plus the agent's
@@ -16,7 +47,8 @@ import { tauriAgentModelChoice } from "../../lib/tauri";
 export function useAgentModelChoice(agentId: string, enabled: boolean) {
   return useQuery({
     queryKey: queryKeys.agentModelChoice(agentId),
-    queryFn: () => tauriAgentModelChoice.get(agentId),
+    queryFn: async () =>
+      toDisplayChoice(await tauriAgentModelChoice.get(agentId)),
     enabled,
     staleTime: 30_000,
   });
@@ -34,7 +66,10 @@ export function useSetAgentModelChoice(agentId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (choice: AgentModelChoice) =>
-      tauriAgentModelChoice.set(agentId, choice),
+      tauriAgentModelChoice.set(agentId, {
+        ...choice,
+        provider: toCanonicalProviderId(choice.provider),
+      }),
     onSuccess: () =>
       qc.invalidateQueries({
         queryKey: queryKeys.agentModelChoice(agentId),

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -93,6 +93,42 @@ export const PROVIDER_ID_RENAME: Readonly<Record<string, string>> = {
   "openai-codex": "openai",
 };
 
+/** Inverse of `PROVIDER_ID_RENAME`: DISPLAY id → engine id (openai → openai-codex). */
+const PROVIDER_ID_UNRENAME: Readonly<Record<string, string>> =
+  Object.fromEntries(
+    Object.entries(PROVIDER_ID_RENAME).map(([engine, display]) => [
+      display,
+      engine,
+    ]),
+  );
+
+/**
+ * ENGINE provider id → the DISPLAY id the picker/logos use (applies
+ * `PROVIDER_ID_RENAME`: openai-codex → openai; everything else passes through).
+ * Used to map a stored model-choice back to the display dialect on READ, mirror
+ * of the engine-adapter's `toOldProvider` and `@houston/domain`'s
+ * `PROVIDER_ALIASES` — duplicated here (not imported) because `app/` does not
+ * depend on those packages, exactly as `use-conversation-vm` duplicates
+ * `toOldProvider`.
+ */
+export function toDisplayProviderId(id: string): string {
+  return PROVIDER_ID_RENAME[id] ?? id;
+}
+
+/**
+ * DISPLAY provider id → the canonical ENGINE id (the inverse: openai →
+ * openai-codex). The picker offers `openai` (Houston's rename of pi's
+ * `openai-codex`), but the gateway/runtime resolve pi's `openai-codex`, so a
+ * model-choice WRITE must canonicalize before it leaves the client — the same
+ * mapping the direct-send path applies via `@houston/domain`
+ * `canonicalProviderId` / `PROVIDER_ALIASES`. Houston never offers pi's raw
+ * platform-key `openai`; if it ever does, this alias AND `PROVIDER_ID_RENAME`
+ * must be removed together.
+ */
+export function toCanonicalProviderId(id: string): string {
+  return PROVIDER_ID_UNRENAME[id] ?? id;
+}
+
 /**
  * pi providers dropped BEFORE the rename is applied. pi's direct api-key `openai`
  * provider collides with the `openai-codex → openai` rename (Houston surfaces the

--- a/packages/runtime/src/ai/providers.test.ts
+++ b/packages/runtime/src/ai/providers.test.ts
@@ -154,6 +154,18 @@ test("resolveModel honors a pinned provider regardless of the active one (never 
   expect(m.id).toBe("claude-opus-4-8");
 });
 
+test("resolveModel canonicalizes a wire `openai` pin to the openai-codex product", () => {
+  // Houston's UI renames pi's openai-codex → `openai` and never offers pi's raw
+  // platform-key `openai` provider. So a wire pin/override of `openai` (the
+  // hosted Teams model-choice path, a routine pin, a hand-crafted body) must
+  // resolve to the Codex product — else the turn lands on pi's raw `openai`
+  // provider and misses the openai-codex credential ("No credential found for
+  // openai"). The backstop enforces the same mapping the frontend's wireTurnPin
+  // applies, so no caller can reproduce that class of bug.
+  const m = resolveModel(undefined, "openai") as { provider?: string };
+  expect(m.provider).toBe("openai-codex");
+});
+
 test("resolveModel throws a readable error for an unknown pinned provider", () => {
   // A junk pin must fail the turn with the reason — never silently fall back
   // to whatever provider happens to be active.

--- a/packages/runtime/src/ai/providers.ts
+++ b/packages/runtime/src/ai/providers.ts
@@ -425,6 +425,28 @@ export function safeGetModel(
 }
 
 /**
+ * Canonicalize a wire provider id arriving on a turn PIN / provider override.
+ *
+ * Houston's UI RENAMES pi's `openai-codex` subscription to the display id
+ * `openai` and never offers pi's raw platform-key `openai` provider (frontend
+ * `PROVIDER_ID_RENAME` in `app/src/lib/provider-overrides.ts`; shared alias
+ * table `PROVIDER_ALIASES` in `@houston/domain`). So on the wire a bare `openai`
+ * ALWAYS means the Codex product. The frontend's `wireTurnPin` already applies
+ * this before send; we enforce the SAME mapping here — the single pin-entry seam
+ * every turn's provider override flows through (exec-turn, conversation-cache,
+ * generate-agent) — so NO caller (the hosted Teams model-choice path, a routine
+ * pin, a hand-crafted request body) can land a turn on pi's raw `openai`
+ * provider and miss the `openai-codex` credential.
+ *
+ * TRADEOFF: this hard-codes that wire `openai` == Codex. If Houston ever offers
+ * platform-key OpenAI as its own provider, THIS alias and the frontend rename
+ * must be removed together.
+ */
+function canonicalPinProvider(id: string): string {
+  return id === "openai" ? "openai-codex" : id;
+}
+
+/**
  * Resolve the pi-ai model for the active provider (used when starting a turn).
  * An optional `override` (a routine's pinned model) wins over the saved model;
  * a bad pin surfaces as the turn's error, while a stale SAVED id falls back to
@@ -445,9 +467,10 @@ export function resolveModel(
 ): Model<Api> {
   let provider: ProviderId | null;
   if (providerOverride) {
-    if (!isProvider(providerOverride))
+    const canonical = canonicalPinProvider(providerOverride);
+    if (!isProvider(canonical))
       throw new Error(`unknown provider: ${providerOverride}`);
-    provider = providerOverride;
+    provider = canonical;
   } else {
     provider = activeProvider();
   }

--- a/packages/web/tests/model-choice-dialect.test.ts
+++ b/packages/web/tests/model-choice-dialect.test.ts
@@ -1,0 +1,38 @@
+import {
+  toCanonicalProviderId,
+  toDisplayProviderId,
+} from "@houston/app/lib/provider-overrides.ts";
+import { expect, test } from "vitest";
+
+/**
+ * The hosted Teams model-choice path crosses a provider-id DIALECT boundary in
+ * `use-agent-model-choice` (read engine → display, write display → engine).
+ * These are the pure helpers that seam uses. The picker offers Houston's DISPLAY
+ * id `openai` (its rename of pi's `openai-codex`), but the gateway/runtime
+ * resolve pi's `openai-codex`; writing the display id verbatim would land the
+ * turn on pi's raw `openai` provider and miss the openai-codex credential ("No
+ * credential found for openai"). Canonicalizing on write — mirror of the
+ * direct-send `wireTurnPin` and the runtime backstop — prevents that; the read
+ * mapping keeps every downstream comparison in the display dialect it assumes.
+ */
+
+test("write canonicalizes the display id to the engine id (openai → openai-codex)", () => {
+  expect(toCanonicalProviderId("openai")).toBe("openai-codex");
+});
+
+test("read maps the stored engine id back to the display id (openai-codex → openai)", () => {
+  expect(toDisplayProviderId("openai-codex")).toBe("openai");
+});
+
+test("every other provider is identical on both sides (only Codex differs)", () => {
+  for (const id of ["anthropic", "opencode", "opencode-go", "groq", "google"]) {
+    expect(toCanonicalProviderId(id)).toBe(id);
+    expect(toDisplayProviderId(id)).toBe(id);
+  }
+});
+
+test("the two mappings are inverses — a stored choice round-trips to what the picker shows", () => {
+  for (const display of ["openai", "anthropic", "opencode-go", "groq"]) {
+    expect(toDisplayProviderId(toCanonicalProviderId(display))).toBe(display);
+  }
+});


### PR DESCRIPTION
## Bug

Hosted turns failed with pi's `No credential found for openai. Use /login…`.

The app renames pi's `openai-codex` (ChatGPT OAuth) to the display id `openai` and hides pi's raw API-key `openai` provider. The direct send path and the config path both translate back to `openai-codex` before the wire — but the Teams per-user **model-choice** path stored the display id verbatim in gateway state, and the gateway injects that stored provider into every send body. Once the full-catalog change made `openai` a resolvable pi provider, the pod resolved the raw API-key provider and looked up credentials under the wrong key.

## Fix

- `use-agent-model-choice` maps ids at the hook boundary: writes store canonical `openai-codex`, reads return the display id — covering both writers (`selectModel` and `selectEffort`) and keeping every downstream consumer (picker matching, model pin, effort re-write) in the display dialect it already assumes.
- `provider-overrides` gains `toDisplayProviderId` / `toCanonicalProviderId` next to the rename table they invert.
- Runtime backstop: `resolveModel` canonicalizes a pin/override of `openai` → `openai-codex` (the seam every managed-pod turn path flows through), so no caller can ever dispatch the raw API-key provider Houston never offers. Comment documents the removal condition (if platform-key OpenAI is ever offered, alias + rename go together).

## Tests

- New runtime test `resolveModel(undefined, "openai") → openai-codex` — verified failing before the fix.
- New `model-choice-dialect.test.ts`: write canonicalization, read display mapping, other-provider passthrough, round-trip.
- Full suites green: biome, host 633 / runtime 478 / domain 92, houston-web typecheck + 91 tests, app tsgo.

Counterpart: gateway-side canonicalization (PUT + dispatch body-rewrite, heals already-stored poisoned rows) in the sibling cloud PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)