### PR TITLE
fix: context indicator and autocompact share one effective model window

### DIFF
--- a/app/src/lib/context-usage.ts
+++ b/app/src/lib/context-usage.ts
@@ -61,6 +61,11 @@ export function sessionContextUsage(
  * The result is floored at the observed peak, so even a mis-catalogued ceiling
  * can't make the indicator read over 100% — that guarantee lives here in the
  * data layer, with the component's clamp as defense in depth.
+ *
+ * The snap-up rule here is mirrored by `effectiveModelWindow` in
+ * `@houston/protocol`, which the runtime's autocompact uses — same table of
+ * `{ default, max }` numbers (see `getContextWindowConfig`), same math, so the
+ * gauge and the engine's compaction point stay in lockstep.
  */
 export function effectiveContextWindow(
   cfg: ContextWindowConfig | undefined,
@@ -73,9 +78,12 @@ export function effectiveContextWindow(
 
 /**
  * How full the context window is, 0-100, or `null` when usage or the window
- * isn't known. Rounded and clamped so the displayed gauge and the runtime's
- * trigger agree on the same number. Shared by `ContextIndicator` (display) and
- * `shouldAutocompactForSession` (the trigger decision).
+ * isn't known. Rounded and clamped for the displayed gauge (`ContextIndicator`).
+ * The runtime owns the autocompact TRIGGER separately (`needsAutocompact` in
+ * `packages/runtime`), but the two now agree on the denominator: both size the
+ * window from the shared `@houston/protocol` table (`effectiveModelWindow` there
+ * mirrors `effectiveContextWindow` above), so the gauge and the compaction point
+ * line up.
  */
 export function contextFillPercent(
   usage: TokenUsage | null,

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -8,11 +8,13 @@ import type { EffortLevel, ProviderInfo } from "./providers.ts";
  *
  * pi-ai does NOT ship the Houston-specific presentation metadata, though: brand
  * names (its provider `name` is a titleized id like "Openrouter" or an OAuth
- * subscription string), per-model marketing labels/descriptions, the credit-gated
- * snap-up ceilings (`contextWindowMax`), or the curated per-gateway effort sets
- * (pi has no `"max"` level, and the same model exposes different effort via
- * different gateways). This module carries ONLY that missing metadata, keyed by
- * the Houston provider id, so the hydrator can layer it over pi's catalog.
+ * subscription string), per-model marketing labels/descriptions, or the curated
+ * per-gateway effort sets (pi has no `"max"` level, and the same model exposes
+ * different effort via different gateways). This module carries ONLY that missing
+ * metadata, keyed by the Houston provider id, so the hydrator can layer it over
+ * pi's catalog. The per-model CONTEXT-WINDOW overrides (defaults + credit-gated
+ * snap-up ceilings) live in `@houston/protocol` (`MODEL_WINDOW_OVERRIDES`), shared
+ * verbatim with the runtime's autocompact so the bar and the engine agree.
  *
  * It also defines the two constructs pi-ai has no concept of: the local
  * OpenAI-compatible provider (appended verbatim), and the `openai-codex → openai`
@@ -25,19 +27,6 @@ export interface ModelOverride {
   label?: string;
   /** One-line picker description (pi ships none). */
   description?: string;
-  /**
-   * Starting context-window default (tokens), overriding pi's raw provider
-   * window. Set where Houston shows a different number than pi's raw offer —
-   * notably Codex, whose `/status` reports a 95%-EFFECTIVE window (e.g. 258400
-   * for gpt-5.5's raw 272000). Absent → pi's raw `contextWindow` is used.
-   */
-  contextWindow?: number;
-  /**
-   * Snap-up ceiling (tokens) for the self-correcting usage estimate — set only
-   * for models whose window is gated upward at runtime (credits/plan). pi
-   * reports the default window; this is Houston's known ceiling above it.
-   */
-  contextWindowMax?: number;
   /**
    * Curated reasoning-effort set, overriding what `deriveEffortLevels` would
    * produce from pi's `thinkingLevels`. Present where the curation differs from
@@ -224,33 +213,21 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
         label: "GPT-5.5",
         description: "OpenAI's frontier model.",
         effortLevels: ["low", "medium", "high", "xhigh"],
-        // Codex's `/status` reports the 95%-EFFECTIVE window (0.95 × 272000 raw),
-        // the number the user sees — so the indicator's denominator matches it.
-        contextWindow: 258_400,
-        // Codex exposes an opt-in 1M variant (max_context_window 1M × 95%
-        // effective); the usage indicator snaps up to it once observed usage
-        // exceeds the effective default window.
-        contextWindowMax: 950_000,
       },
       "gpt-5.4": {
         label: "GPT-5.4",
         description: "Strong model for everyday coding.",
         effortLevels: ["low", "medium", "high", "xhigh"],
-        contextWindow: 258_400,
-        contextWindowMax: 950_000,
       },
       "gpt-5.4-mini": {
         label: "GPT-5.4-Mini",
         description: "Small, fast, and cost-efficient for simpler tasks.",
         effortLevels: ["low", "medium", "high", "xhigh"],
-        contextWindow: 258_400,
       },
       "gpt-5.3-codex-spark": {
         label: "GPT-5.3-Codex-Spark",
         description: "Ultra-fast coding model.",
         effortLevels: ["low", "medium", "high", "xhigh"],
-        // 0.95 × 128000 raw (spark's smaller window).
-        contextWindow: 121_600,
       },
     },
   },
@@ -275,8 +252,6 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
         description: "Best balance of speed and quality.",
         // Sonnet 4.6: has `max`, no `xhigh`.
         effortLevels: ["low", "medium", "high", "max"],
-        // Credit-gated 1M window over pi's reported default (200k on every plan).
-        contextWindowMax: 1_000_000,
       },
       "claude-opus-4-8": {
         label: "Opus 4.8",

--- a/app/src/lib/providers.test.mjs
+++ b/app/src/lib/providers.test.mjs
@@ -582,11 +582,30 @@ test("model contextWindow: an override default wins over pi's raw window", () =>
     default: 121_600,
     max: 121_600,
   });
-  // A model with no contextWindow override falls back to pi's raw window
-  // (Opus 4.8 = 1M in the sample), so the fallback path stays exercised.
-  assert.deepEqual(getContextWindowConfig("anthropic", "claude-opus-4-8"), {
+  // A model with no window override falls back to pi's raw window (Fable 5 = 1M
+  // in the sample, un-gated), so the fallback path stays exercised.
+  assert.deepEqual(getContextWindowConfig("anthropic", "claude-fable-5"), {
     default: 1_000_000,
     max: 1_000_000,
+  });
+});
+
+test("model contextWindow: the Anthropic flagships credit-gate 1M behind a 200k default", () => {
+  // pi reports a flat 1M for Opus 4.7/4.8 (SAMPLE_CATALOG), but standard plans
+  // get 200k; the shared @houston/protocol table starts the estimate at 200k and
+  // snaps to 1M once observed usage proves the credit-gated window — the same
+  // numbers the runtime autocompact divides by. Drift here fails CI.
+  for (const id of ["claude-opus-4-8", "claude-opus-4-7"]) {
+    assert.deepEqual(getContextWindowConfig("anthropic", id), {
+      default: 200_000,
+      max: 1_000_000,
+    });
+  }
+  // Gemini via the native google provider is already correct in pi (1,048,576),
+  // so it gets NO override — the bar and the engine both divide by the full 1M.
+  assert.deepEqual(getContextWindowConfig("google", "gemini-3-flash-preview"), {
+    default: 1_048_576,
+    max: 1_048_576,
   });
 });
 

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -1,4 +1,8 @@
 import type { CatalogModelEntry, ProviderCatalog } from "@houston/protocol";
+// Value import via the self-contained subpath (NOT the barrel): the app's
+// node --experimental-strip-types test runner can't resolve the barrel's
+// extensionless re-exports, and this leaf module has no imports of its own.
+import { resolveModelWindow } from "@houston/protocol/model-windows";
 import type { Capabilities } from "@houston-ai/engine-client";
 import { normalizeKey } from "./ai-hub/catalog-key.ts";
 import {
@@ -190,15 +194,24 @@ function buildProvider(
       const effort =
         mo?.effortLevels ??
         deriveEffortLevels(entry.thinkingLevels, entry.reasoning);
+      // Window sizing comes from the SHARED `@houston/protocol` table (keyed by
+      // pi's provider id — pre-rename, so Codex is `openai-codex` here), the same
+      // source the runtime's autocompact reads, so the bar and the engine divide
+      // by identical numbers. Falls back to pi's raw window when uncurated.
+      const window = resolveModelWindow(
+        piProvider.id,
+        entry.id,
+        entry.contextWindow,
+      );
       return {
         id: entry.id,
         label: mo?.label ?? entry.name,
         description: mo?.description ?? "",
-        // pi reports the raw provider window; the override carries Houston's
-        // 95%-effective window (the number the provider's `/status` shows, e.g.
-        // Codex's 258k for gpt-5.5) when it differs — see `ModelOverride`.
-        contextWindow: mo?.contextWindow ?? entry.contextWindow,
-        contextWindowMax: mo?.contextWindowMax,
+        contextWindow: window.default,
+        // Omit when there is no upward gating, matching the "absent = no snap"
+        // contract `getContextWindowConfig` reads.
+        contextWindowMax:
+          window.max !== window.default ? window.max : undefined,
         // Empty → omit, so `getEffortLevels`/the picker treat it as no effort row.
         effortLevels: effort.length > 0 ? effort : undefined,
       };

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./src/index.ts",
       "import": "./src/index.ts"
+    },
+    "./model-windows": {
+      "types": "./src/model-windows.ts",
+      "import": "./src/model-windows.ts"
     }
   },
   "files": [

--- a/packages/protocol/src/index.ts
+++ b/packages/protocol/src/index.ts
@@ -9,6 +9,7 @@ export * from "./domain/routine";
 export * from "./domain/skill";
 export * from "./domain/workspace";
 export * from "./events";
+export * from "./model-windows";
 export * from "./provider-catalog";
 export * from "./provider-error";
 export * from "./wire";

--- a/packages/protocol/src/model-windows.ts
+++ b/packages/protocol/src/model-windows.ts
@@ -1,0 +1,109 @@
+/**
+ * The ONE source of truth for context-window sizing, shared by the frontend
+ * usage indicator (the "context bar") and the runtime's autocompact + provider-
+ * switch decisions. Both used to size the window independently — the bar divided
+ * by Houston's per-model default (snapping up to a ceiling once observed usage
+ * proved a larger window), while the runtime divided by pi-ai's RAW registry
+ * window — so they disagreed: the runtime never compacted a 200k-real Claude
+ * chat pi reports as 1M, and needlessly compacted a Gemini chat pi under-reports.
+ *
+ * This module lives in `@houston/protocol` (an OPEN, dependency-free leaf that
+ * already owns the catalog wire shapes) so the runtime (`@houston/runtime`) and
+ * the app catalog (`app/src/lib/providers.ts`) both import the SAME numbers and
+ * the SAME snap-up rule. Option A of the context-bar fix: one table, no drift,
+ * no cross-package parity test needed (the runtime tests pin these values).
+ *
+ * Keys are pi-ai PROVIDER ids (the runtime speaks these verbatim; the app looks
+ * up by the pre-rename `piProvider.id`, so `openai-codex` — not the app's
+ * post-rename `openai` — is the key here).
+ *
+ * Only models whose real window differs from pi-ai's raw registry value appear.
+ * Notably ABSENT: the `google` provider's Gemini models — pi-ai already reports
+ * their true 1,048,576 window, so no override is needed (the stale 128,000 some
+ * research cited is `github-copilot`'s Gemini copy, a legitimately smaller cap
+ * we do not touch).
+ */
+
+/** A model's window sizing: the starting denominator and its snap-up ceiling. */
+export interface ModelWindow {
+  /** Starting denominator for the usage estimate. */
+  default: number;
+  /** Ceiling the estimate snaps up to once observed usage exceeds `default`. */
+  max: number;
+}
+
+/** A curated override entry; `max` defaults to `default` (no upward gating). */
+interface WindowOverride {
+  default: number;
+  max?: number;
+}
+
+/**
+ * Per-model window overrides, keyed by pi-ai provider id then model id. Present
+ * ONLY where Houston's real window differs from pi-ai's raw registry value:
+ *
+ * - `anthropic` — pi reports 1,000,000 for the flagships, but standard (Pro,
+ *   non-credit) plans get 200k; the 1M window is credit/plan-gated, so the
+ *   estimate starts at 200k and snaps to 1M once observed usage proves it.
+ *   `claude-fable-5` is intentionally omitted (no evidence it is plan-gated —
+ *   pi's 1M stands). `claude-sonnet-5` is not yet in pi's registry.
+ * - `openai-codex` — Codex's `/status` reports a 95%-EFFECTIVE window (the number
+ *   the user sees), and gpt-5.5/5.4 expose an opt-in 1M variant (× 95%).
+ */
+export const MODEL_WINDOW_OVERRIDES: Readonly<
+  Record<string, Readonly<Record<string, WindowOverride>>>
+> = {
+  anthropic: {
+    "claude-sonnet-4-6": { default: 200_000, max: 1_000_000 },
+    "claude-opus-4-7": { default: 200_000, max: 1_000_000 },
+    "claude-opus-4-8": { default: 200_000, max: 1_000_000 },
+  },
+  "openai-codex": {
+    "gpt-5.5": { default: 258_400, max: 950_000 },
+    "gpt-5.4": { default: 258_400, max: 950_000 },
+    "gpt-5.4-mini": { default: 258_400 },
+    "gpt-5.3-codex-spark": { default: 121_600 },
+  },
+};
+
+/**
+ * The window sizing for a provider+model: the curated override when one exists,
+ * else pi-ai's raw registry window as both default and ceiling (no snapping).
+ * `piRawWindow` is what pi reports for THIS provider's copy of the model.
+ */
+export function resolveModelWindow(
+  providerId: string,
+  modelId: string,
+  piRawWindow: number,
+): ModelWindow {
+  const override = MODEL_WINDOW_OVERRIDES[providerId]?.[modelId];
+  const def = override?.default ?? piRawWindow;
+  return { default: def, max: override?.max ?? def };
+}
+
+/**
+ * The window to divide by (tokens), given observed usage. Self-correcting:
+ * starts at the model's default and snaps UP to the ceiling once observed usage
+ * exceeds the default, which proves the larger (plan/credit-gated) window is
+ * active — the provider auto-compacts before its limit, so observed usage can
+ * never exceed the true window. Floored at the observed count so a mis-catalogued
+ * ceiling can never read as over 100%.
+ *
+ * This MUST match the frontend's `effectiveContextWindow` (app/src/lib/
+ * context-usage.ts) exactly — that one takes a pre-resolved `{default,max}` and
+ * applies the identical rule, so both surfaces agree on the denominator.
+ */
+export function effectiveModelWindow(
+  providerId: string,
+  modelId: string,
+  piRawWindow: number,
+  observedTokens: number,
+): number {
+  const { default: def, max } = resolveModelWindow(
+    providerId,
+    modelId,
+    piRawWindow,
+  );
+  const estimate = observedTokens > def ? max : def;
+  return Math.max(estimate, observedTokens);
+}

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -16,6 +16,7 @@
     "@earendil-works/pi-ai": "0.79.10",
     "@earendil-works/pi-coding-agent": "0.79.10",
     "@google-cloud/storage": "7.21.0",
+    "@houston/protocol": "workspace:*",
     "@houston/runtime-client": "workspace:*",
     "tsx": "4.23.0",
     "typebox": "1.1.38",

--- a/packages/runtime/src/backends/pi/wire.test.ts
+++ b/packages/runtime/src/backends/pi/wire.test.ts
@@ -85,7 +85,30 @@ test("normalizeUsage: missing/garbage usage degrades to null (no misleading zero
   expect(normalizeUsage(undefined)).toBeNull();
   expect(normalizeUsage(null)).toBeNull();
   expect(normalizeUsage({})).toBeNull();
-  expect(normalizeUsage({ output: 5 })).toBeNull(); // no totalTokens
+  // Output alone carries no context signal, and there is no totalTokens to derive
+  // one from → null rather than a misleading empty context.
+  expect(normalizeUsage({ output: 5 })).toBeNull();
+  expect(normalizeUsage({ output: 5, totalTokens: "x" })).toBeNull();
+});
+
+test("normalizeUsage: no totalTokens → synthesizes context from the components", () => {
+  // The Gemini-through-pi case: components present, but pi never summed them.
+  // context_tokens = input + cacheRead + cacheWrite (everything but output).
+  expect(
+    normalizeUsage({ input: 100, output: 20, cacheRead: 300, cacheWrite: 50 }),
+  ).toEqual({ context_tokens: 450, output_tokens: 20, cached_tokens: 300 });
+  // Input only (no cache, no total): context is the input.
+  expect(normalizeUsage({ input: 5000, output: 100 })).toEqual({
+    context_tokens: 5000,
+    output_tokens: 100,
+    cached_tokens: 0,
+  });
+  // A lone cacheRead is a valid context signal on its own.
+  expect(normalizeUsage({ cacheRead: 200 })).toEqual({
+    context_tokens: 200,
+    output_tokens: 0,
+    cached_tokens: 200,
+  });
 });
 
 test("normalizeUsage: clamps a degenerate output > total to zero, never negative", () => {

--- a/packages/runtime/src/backends/pi/wire.ts
+++ b/packages/runtime/src/backends/pi/wire.ts
@@ -11,18 +11,53 @@ import { classifyProviderError } from "../../ai/provider-error";
  * the same shape), so the prompt that occupies the context window is everything
  * but `output`: `context_tokens = totalTokens - output`. `cached_tokens` is the
  * cache-read portion. This mirrors the Rust engine's `ClaudeUsageRaw::normalize`.
+ *
+ * Some providers (notably Gemini through pi's OpenAI-completions path) deliver
+ * the component fields WITHOUT a summed `totalTokens`. Rather than drop that turn
+ * to null (an empty context bar that never triggers autocompact), synthesize the
+ * window fill from the components: `context_tokens = input + cacheRead + cacheWrite`.
+ * `output` alone says nothing about context size, so a usage with no
+ * context-contributing field left stays null (no misleading zero).
  */
 export function normalizeUsage(u: unknown): TokenUsage | null {
   const usage = u as
-    | { totalTokens?: number; output?: number; cacheRead?: number }
+    | {
+        totalTokens?: number;
+        input?: number;
+        output?: number;
+        cacheRead?: number;
+        cacheWrite?: number;
+      }
     | null
     | undefined;
-  if (!usage || typeof usage.totalTokens !== "number") return null;
-  const output = usage.output ?? 0;
+  if (!usage) return null;
+  const num = (v: unknown): number | undefined =>
+    typeof v === "number" && Number.isFinite(v) ? v : undefined;
+  const output = num(usage.output) ?? 0;
+  const cacheRead = num(usage.cacheRead) ?? 0;
+  const total = num(usage.totalTokens);
+  if (total !== undefined) {
+    return {
+      context_tokens: Math.max(0, total - output),
+      output_tokens: output,
+      cached_tokens: cacheRead,
+    };
+  }
+  // No totalTokens: fall back to the components. Require at least one
+  // context-contributing field (input / cacheRead / cacheWrite); output-only or
+  // an empty object carries no window signal and degrades to null.
+  const input = num(usage.input);
+  const cacheWrite = num(usage.cacheWrite);
+  if (
+    input === undefined &&
+    cacheWrite === undefined &&
+    num(usage.cacheRead) === undefined
+  )
+    return null;
   return {
-    context_tokens: Math.max(0, usage.totalTokens - output),
+    context_tokens: Math.max(0, (input ?? 0) + cacheRead + (cacheWrite ?? 0)),
     output_tokens: output,
-    cached_tokens: usage.cacheRead ?? 0,
+    cached_tokens: cacheRead,
   };
 }
 

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -1,3 +1,4 @@
+import { effectiveModelWindow } from "@houston/protocol/model-windows";
 import type {
   ChatMessage,
   ProviderError,
@@ -219,8 +220,18 @@ export async function execTurn(
         // Mid-session PROVIDER switch. Carry the conversation verbatim when it
         // comfortably fits the new model's window (replay); otherwise compact it
         // first so it fits — pi summarizes with the now-active target model.
+        // Size the target window with Houston's effective rule (same as the bar),
+        // not pi's raw registry number; observed usage on the fresh target is 0,
+        // so it starts at the default — matching the frontend's peak reset on a
+        // provider switch.
+        const targetWindow = effectiveModelWindow(
+          model.provider,
+          model.id,
+          model.contextWindow,
+          0,
+        );
         let summarized = false;
-        if (switchNeedsCompaction(preTokens, model.contextWindow)) {
+        if (switchNeedsCompaction(preTokens, targetWindow)) {
           await conv.session.compact();
           summarized = true;
         }
@@ -249,7 +260,18 @@ export async function execTurn(
     // never re-compacts.
     if (!providerSwitch?.summarized) {
       const fill = conv.session.getContextUsage()?.tokens ?? null;
-      if (needsAutocompact(fill, model.contextWindow)) {
+      // Divide by Houston's EFFECTIVE window (default, snapping up to the ceiling
+      // once observed fill proves the larger plan/credit-gated window is active),
+      // the SAME denominator the frontend context bar uses — so the runtime
+      // compacts a 200k-real Claude chat pi reports as 1M, and does NOT
+      // needlessly compact a Gemini chat pi under-reports as 128k.
+      const window = effectiveModelWindow(
+        model.provider,
+        model.id,
+        model.contextWindow,
+        fill ?? 0,
+      );
+      if (needsAutocompact(fill, window)) {
         await conv.session.compact();
         compaction = { trigger: "proactive", pre_tokens: fill };
         // Stream the boundary so the chat draws the divider + resets its

--- a/packages/runtime/src/session/model-windows.test.ts
+++ b/packages/runtime/src/session/model-windows.test.ts
@@ -1,0 +1,69 @@
+import {
+  effectiveModelWindow,
+  MODEL_WINDOW_OVERRIDES,
+  resolveModelWindow,
+} from "@houston/protocol/model-windows";
+import { expect, test } from "vitest";
+
+test("resolveModelWindow: an override wins over pi's raw window", () => {
+  // pi reports 1,000,000 for the anthropic flagship, but the real default is 200k.
+  expect(resolveModelWindow("anthropic", "claude-opus-4-8", 1_000_000)).toEqual(
+    { default: 200_000, max: 1_000_000 },
+  );
+});
+
+test("resolveModelWindow: no override falls back to pi's raw as both default + max", () => {
+  // Gemini via the native `google` provider: pi's 1,048,576 is correct, so no
+  // override — default and max are both the raw window (no snapping).
+  expect(
+    resolveModelWindow("google", "gemini-3-flash-preview", 1_048_576),
+  ).toEqual({ default: 1_048_576, max: 1_048_576 });
+  // An entirely unknown model likewise passes pi's raw window through.
+  expect(resolveModelWindow("nope", "who", 12_345)).toEqual({
+    default: 12_345,
+    max: 12_345,
+  });
+});
+
+test("effectiveModelWindow: starts at the default before observed usage proves more", () => {
+  expect(
+    effectiveModelWindow("anthropic", "claude-opus-4-8", 1_000_000, 40_000),
+  ).toBe(200_000);
+});
+
+test("effectiveModelWindow: snaps up to the ceiling once observed exceeds the default", () => {
+  // 250k observed proves the credit-gated 1M window is active.
+  expect(
+    effectiveModelWindow("anthropic", "claude-opus-4-8", 1_000_000, 250_000),
+  ).toBe(1_000_000);
+});
+
+test("effectiveModelWindow: never reads below the observed count (mis-catalogued ceiling)", () => {
+  // Observed above even the max floors the window at observed, so % <= 100.
+  expect(
+    effectiveModelWindow("anthropic", "claude-opus-4-8", 1_000_000, 1_200_000),
+  ).toBe(1_200_000);
+});
+
+test("effectiveModelWindow: no-override model divides by pi's raw window", () => {
+  expect(
+    effectiveModelWindow("google", "gemini-2.5-pro", 1_048_576, 50_000),
+  ).toBe(1_048_576);
+});
+
+// Pins the curated Anthropic windows so a pi-ai catalog drift (or an accidental
+// edit) fails CI rather than silently changing the bar + autocompact denominator.
+test("MODEL_WINDOW_OVERRIDES: Anthropic flagships are 200k default / 1M ceiling", () => {
+  for (const id of [
+    "claude-sonnet-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+  ]) {
+    expect(MODEL_WINDOW_OVERRIDES.anthropic[id]).toEqual({
+      default: 200_000,
+      max: 1_000_000,
+    });
+  }
+  // fable-5 is intentionally NOT gated (pi's 1M stands).
+  expect(MODEL_WINDOW_OVERRIDES.anthropic["claude-fable-5"]).toBeUndefined();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -335,6 +335,9 @@ importers:
       '@google-cloud/storage':
         specifier: 7.21.0
         version: 7.21.0
+      '@houston/protocol':
+        specifier: workspace:*
+        version: link:../protocol
       '@houston/runtime-client':
         specifier: workspace:*
         version: link:../runtime-client


### PR DESCRIPTION
## What

The chat context bar and the runtime's autocompact divided by different denominators, and both were wrong for plan-gated Anthropic models:

- **New `@houston/protocol/model-windows`** — single dependency-free source for per-model `{default, max}` context windows with snap-up semantics (`effectiveModelWindow`): the window is the plan-safe default until observed usage exceeds it, then snaps to the max. Consumed by **both** the app catalog and the runtime (autocompact + provider-switch), replacing the app-only numeric overrides. Runtime gains a `@houston/protocol` workspace dep (boundaries checked, green).
- **Anthropic flagships plan-gated**: `claude-sonnet-4-6` / `claude-opus-4-7` / `claude-opus-4-8` now default to 200k (real window on non-credit plans) and snap up to 1M — previously the bar divided by 1M and read ~5x too low, never warning before the model ran out; autocompact fired at 930k, far past a 200k session.
- **`normalizeUsage` fallback**: when a pi provider omits `totalTokens` (uncatalogued OpenRouter/OpenCode models), usage is synthesized from input/output/cache components instead of returning null — the bar no longer stays permanently empty.
- Gemini windows verified correct in pi's `google` provider (1,048,576); the 128k values live only under `github-copilot` and are that gateway's genuine caps, deliberately untouched.
- Fixed the stale `contextFillPercent` docstring that claimed a shared autocompact trigger.

## Verification

Runtime 483/483 (incl. new window + usage-fallback tests), app tests green incl. a flagship window-gating pin test, `pnpm check:boundaries` green, repo typecheck + biome clean.

Part of the AI Chat improvements series (#734 was 1/6; picker, effort, plan mode, dictation follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)