### PR TITLE
fix: honest effort levels derived from the pi catalog

### DIFF
--- a/app/src/components/chat-effort-selector.tsx
+++ b/app/src/components/chat-effort-selector.tsx
@@ -7,6 +7,7 @@ import {
   EFFORT_ORDER,
   type EffortLevel,
   getEffortLevels,
+  normalizeEffort,
 } from "../lib/providers";
 import { EffortIcon } from "./effort-icon";
 
@@ -32,7 +33,7 @@ interface ChatEffortSelectorProps {
 /**
  * Reasoning-effort cycle button, rendered beside {@link ChatModelSelector} in
  * the composer. One click advances to the next level the active model accepts,
- * wrapping after the last (low → … → max → low). The icon's filled bars and
+ * wrapping after the last (low → … → xhigh → low). The icon's filled bars and
  * the label both track the level, so the control reads at a glance without a
  * menu. Renders nothing when the model has no effort control (e.g. Gemini), so
  * the composer row collapses cleanly.
@@ -58,23 +59,24 @@ export function ChatEffortSelector({
     medium: t("modelSelector.effortLevels.medium"),
     high: t("modelSelector.effortLevels.high"),
     xhigh: t("modelSelector.effortLevels.xhigh"),
-    max: t("modelSelector.effortLevels.max"),
   };
   const descriptions: Record<EffortLevel, string> = {
     low: t("modelSelector.effortDescriptions.low"),
     medium: t("modelSelector.effortDescriptions.medium"),
     high: t("modelSelector.effortDescriptions.high"),
     xhigh: t("modelSelector.effortDescriptions.xhigh"),
-    max: t("modelSelector.effortDescriptions.max"),
   };
 
+  // Normalize a persisted legacy `max` to `xhigh` so an agent carrying it still
+  // reads as its top tier (not "unset") until the next pick rewrites it.
+  const current = normalizeEffort(effort);
   // The current level (only when the stored value is one this model accepts)
   // and the level a click advances to, wrapping past the last back to the first.
   const activeLevel =
-    effort && levels.includes(effort as EffortLevel)
-      ? (effort as EffortLevel)
+    current && levels.includes(current as EffortLevel)
+      ? (current as EffortLevel)
       : undefined;
-  const nextLevel = nextEffort(levels, effort);
+  const nextLevel = nextEffort(levels, current);
 
   const activeLabel = activeLevel
     ? labels[activeLevel]
@@ -105,7 +107,7 @@ export function ChatEffortSelector({
           so the gauge looks identical across models — a 2-level model no longer
           renders as a lone short + tall bar. Cycling still uses the model's own
           `levels` above. */}
-      <EffortIcon levels={EFFORT_ORDER} active={effort} className="size-3.5" />
+      <EffortIcon levels={EFFORT_ORDER} active={current} className="size-3.5" />
       <span>{activeLabel}</span>
     </button>
   );

--- a/app/src/data/config.ts
+++ b/app/src/data/config.ts
@@ -7,6 +7,9 @@ export interface Config {
   name?: string;
   provider?: "anthropic" | "openai";
   model?: string;
+  // The active vocabulary is `low|medium|high|xhigh`; a legacy `"max"` may still
+  // sit in older on-disk configs. It is tolerated on read and normalized to
+  // `xhigh` at the UI boundary (see `normalizeEffort`), so it stays here.
   effort?: "low" | "medium" | "high" | "xhigh" | "max";
   [extra: string]: unknown;
 }

--- a/app/src/lib/effort-bars.test.mjs
+++ b/app/src/lib/effort-bars.test.mjs
@@ -6,29 +6,29 @@ import { EFFORT_ORDER } from "./providers.ts";
 test("effortFillCount is the 1-based position of the active level", () => {
   assert.equal(effortFillCount(EFFORT_ORDER, "low"), 1);
   assert.equal(effortFillCount(EFFORT_ORDER, "high"), 3);
-  assert.equal(effortFillCount(EFFORT_ORDER, "max"), 5);
+  assert.equal(effortFillCount(EFFORT_ORDER, "xhigh"), 4);
   // Unset or not in the set → nothing solid.
   assert.equal(effortFillCount(EFFORT_ORDER, null), 0);
-  assert.equal(effortFillCount(EFFORT_ORDER, "ultra"), 0);
+  assert.equal(effortFillCount(EFFORT_ORDER, "max"), 0); // retired tier, not a member
 });
 
-test("the composer gauge always has five bars regardless of the model's level count", () => {
+test("the composer gauge always has four bars regardless of the model's level count", () => {
   // The composer passes EFFORT_ORDER (not the model's own levels) so the gauge
   // is identical across models. A 2-level model used to render as two lone bars
-  // (a short one + a tall one); now it fills a prefix of the full 5-bar gauge.
-  for (const active of [undefined, "low", "high", "xhigh", "max"]) {
-    assert.equal(effortBars(EFFORT_ORDER, active).length, 5);
+  // (a short one + a tall one); now it fills a prefix of the full 4-bar gauge.
+  for (const active of [undefined, "low", "high", "xhigh"]) {
+    assert.equal(effortBars(EFFORT_ORDER, active).length, 4);
   }
 });
 
-test("a 2-level model (high/max) fills the shared gauge by absolute position", () => {
-  // deepseek-v4-flash-free accepts only [high, max]. Cycling sets active to one
-  // of those; the gauge fills to that level's position in EFFORT_ORDER, so it
-  // reads as a near-full / full gauge, never "one short + one tall".
+test("a 2-level model (high/xhigh) fills the shared gauge by absolute position", () => {
+  // deepseek-v4-flash accepts only [high, xhigh]. Cycling sets active to one of
+  // those; the gauge fills to that level's position in EFFORT_ORDER, so it reads
+  // as a near-full / full gauge, never "one short + one tall".
   const solid = (active) =>
     effortBars(EFFORT_ORDER, active).filter((b) => b.filled).length;
   assert.equal(solid("high"), 3);
-  assert.equal(solid("max"), 5);
+  assert.equal(solid("xhigh"), 4);
 });
 
 test("bars ascend in height and share one baseline", () => {

--- a/app/src/lib/effort-bars.ts
+++ b/app/src/lib/effort-bars.ts
@@ -5,9 +5,9 @@
  *
  * One ascending bar per level the active model accepts, solid up to (and
  * including) the current level and dimmed beyond it, so the glyph itself
- * encodes the effort. Bar count tracks the model's own level set (Codex = 4,
- * Opus/Fable = 5), keeping the provider > model > effort cascade legible at a
- * glance.
+ * encodes the effort. Bar count tracks the model's own level set (up to the
+ * four-tier low→xhigh spectrum), keeping the provider > model > effort cascade
+ * legible at a glance.
  */
 
 /** Square viewBox the bars are laid out in (bottom-aligned). */

--- a/app/src/lib/provider-overrides.ts
+++ b/app/src/lib/provider-overrides.ts
@@ -8,11 +8,14 @@ import type { EffortLevel, ProviderInfo } from "./providers.ts";
  *
  * pi-ai does NOT ship the Houston-specific presentation metadata, though: brand
  * names (its provider `name` is a titleized id like "Openrouter" or an OAuth
- * subscription string), per-model marketing labels/descriptions, or the curated
- * per-gateway effort sets (pi has no `"max"` level, and the same model exposes
- * different effort via different gateways). This module carries ONLY that missing
- * metadata, keyed by the Houston provider id, so the hydrator can layer it over
- * pi's catalog. The per-model CONTEXT-WINDOW overrides (defaults + credit-gated
+ * subscription string) and per-model marketing labels/descriptions. This module
+ * carries ONLY that missing metadata, keyed by the Houston provider id, so the
+ * hydrator can layer it over pi's catalog. A model's reasoning-effort set is NO
+ * longer curated here: it is derived from pi's per-model thinking levels
+ * (`deriveEffortLevels`), the same source the runtime clamps against, so the two
+ * can't drift. An override may still pin `effortLevels` for a genuine gateway cap
+ * pi doesn't encode, but none currently need it. The per-model CONTEXT-WINDOW
+ * overrides (defaults + credit-gated
  * snap-up ceilings) live in `@houston/protocol` (`MODEL_WINDOW_OVERRIDES`), shared
  * verbatim with the runtime's autocompact so the bar and the engine agree.
  *
@@ -28,11 +31,14 @@ export interface ModelOverride {
   /** One-line picker description (pi ships none). */
   description?: string;
   /**
-   * Curated reasoning-effort set, overriding what `deriveEffortLevels` would
-   * produce from pi's `thinkingLevels`. Present where the curation differs from
-   * pi (adds Houston's `"max"`, caps a gateway that can't reach a level, or
-   * pins `[]` to hide the effort row for a model pi marks reasoning). An empty
-   * array explicitly hides the effort row.
+   * ESCAPE HATCH for a genuine gateway cap `deriveEffortLevels` can't see. By
+   * default a model's effort set is derived from pi's per-model thinking levels;
+   * set this ONLY when a specific gateway documents a real ceiling below what pi
+   * reports (then comment the source), or `[]` to hide the effort row for a
+   * model pi wrongly flags as reasoning. Do NOT use it to merely duplicate or
+   * trim the derived list — that is the exact drift this catalog removed, and
+   * the drift guard test rejects any id here that pi doesn't ship. None are set
+   * today.
    */
   effortLevels?: readonly EffortLevel[];
 }
@@ -212,22 +218,18 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
       "gpt-5.5": {
         label: "GPT-5.5",
         description: "OpenAI's frontier model.",
-        effortLevels: ["low", "medium", "high", "xhigh"],
       },
       "gpt-5.4": {
         label: "GPT-5.4",
         description: "Strong model for everyday coding.",
-        effortLevels: ["low", "medium", "high", "xhigh"],
       },
       "gpt-5.4-mini": {
         label: "GPT-5.4-Mini",
         description: "Small, fast, and cost-efficient for simpler tasks.",
-        effortLevels: ["low", "medium", "high", "xhigh"],
       },
       "gpt-5.3-codex-spark": {
         label: "GPT-5.3-Codex-Spark",
         description: "Ultra-fast coding model.",
-        effortLevels: ["low", "medium", "high", "xhigh"],
       },
     },
   },
@@ -240,36 +242,23 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
     auth: "oauth",
     defaultModel: "claude-sonnet-4-6",
     models: {
-      "claude-sonnet-5": {
-        label: "Sonnet 5",
-        description: "Newest Sonnet. Stronger agentic coding and tool use.",
-        // Sonnet 5 accepts the full range INCLUDING `xhigh` and `max`; pi has
-        // no `max`, so the curated set carries it.
-        effortLevels: ["low", "medium", "high", "xhigh", "max"],
-      },
       "claude-sonnet-4-6": {
         label: "Sonnet 4.6",
         description: "Best balance of speed and quality.",
-        // Sonnet 4.6: has `max`, no `xhigh`.
-        effortLevels: ["low", "medium", "high", "max"],
       },
       "claude-opus-4-8": {
         label: "Opus 4.8",
         description:
           "Latest Opus. Better alignment and agentic coding than 4.7.",
-        // Full range. `ultracode` is a harness mode, not an effort level.
-        effortLevels: ["low", "medium", "high", "xhigh", "max"],
       },
       "claude-fable-5": {
         label: "Fable 5",
         description: "Most capable model. Costs 2x more credits than Opus 4.8.",
-        effortLevels: ["low", "medium", "high", "xhigh", "max"],
       },
       "claude-opus-4-7": {
         label: "Opus 4.7",
         description:
           "Previous flagship. Strong coding autonomy and complex reasoning.",
-        effortLevels: ["low", "medium", "high", "xhigh", "max"],
       },
     },
   },
@@ -290,39 +279,31 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
       "gpt-4.1": {
         label: "GPT-4.1",
         description: "Available on every plan, including Copilot Free.",
-        // Base model, no effort row.
-        effortLevels: [],
       },
       "claude-sonnet-4.6": {
         label: "Claude Sonnet 4.6",
         description: "Best balance of speed and quality. Needs Copilot Pro.",
-        effortLevels: ["low", "medium", "high", "max"],
       },
       "claude-opus-4.8": {
         label: "Claude Opus 4.8",
         description:
           "Anthropic's flagship. Most capable, slower. Needs Copilot Pro.",
-        effortLevels: ["low", "medium", "high", "xhigh", "max"],
       },
       "claude-haiku-4.5": {
         label: "Claude Haiku 4.5",
         description: "Anthropic's fastest, for quick tasks. Needs Copilot Pro.",
-        effortLevels: [],
       },
       "gpt-5.5": {
         label: "GPT-5.5",
         description: "OpenAI's frontier model. Needs Copilot Pro.",
-        effortLevels: ["low", "medium", "high", "xhigh"],
       },
       "gpt-5-mini": {
         label: "GPT-5 Mini",
         description: "OpenAI's fast, lightweight model. Needs Copilot Pro.",
-        effortLevels: ["low", "medium", "high"],
       },
       "gemini-3-flash-preview": {
         label: "Gemini 3 Flash",
         description: "Google's fast model. Needs Copilot Pro.",
-        effortLevels: ["low", "medium", "high"],
       },
     },
   },
@@ -338,39 +319,30 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
       "claude-sonnet-4-6": {
         label: "Sonnet 4.6",
         description: "Best balance of speed and quality.",
-        // models.dev lists max; pi can't reach this gateway's max, cap at high.
-        effortLevels: ["low", "medium", "high"],
       },
       "claude-opus-4-8": {
         label: "Opus 4.8",
         description: "Most capable Claude, slower.",
-        effortLevels: ["low", "medium", "high", "xhigh"],
       },
       "gpt-5.5": {
         label: "GPT-5.5",
         description: "OpenAI's frontier model.",
-        effortLevels: ["low", "medium", "high", "xhigh"],
       },
       "gemini-3.5-flash": {
         label: "Gemini 3.5 Flash",
         description: "Fast and capable.",
-        // No discrete effort on this gateway model.
-        effortLevels: [],
       },
       "deepseek-v4-flash-free": {
         label: "DeepSeek V4 Flash (Free)",
         description: "Fast. Free to try.",
-        effortLevels: ["high", "max"],
       },
       "mimo-v2.5-free": {
         label: "MiMo V2.5 (Free)",
         description: "Free to try.",
-        effortLevels: [],
       },
       "nemotron-3-ultra-free": {
         label: "Nemotron 3 Ultra (Free)",
         description: "NVIDIA. Free to try.",
-        effortLevels: [],
       },
     },
   },
@@ -386,27 +358,22 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
       "glm-5.1": {
         label: "GLM-5.1",
         description: "Strong open coding model.",
-        effortLevels: [],
       },
       "kimi-k2.6": {
         label: "Kimi K2.6",
         description: "Fast, capable open model.",
-        effortLevels: [],
       },
       "minimax-m3": {
         label: "MiniMax M3",
         description: "Capable open model.",
-        effortLevels: [],
       },
       "qwen3.7-max": {
         label: "Qwen3.7 Max",
         description: "Large open model.",
-        effortLevels: [],
       },
       "deepseek-v4-pro": {
         label: "DeepSeek V4 Pro",
         description: "Strong reasoning.",
-        effortLevels: ["high", "max"],
       },
     },
   },
@@ -422,27 +389,22 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
       "openrouter/free": {
         label: "Free (auto-routed)",
         description: "OpenRouter's free tier. Good for testing, no cost.",
-        effortLevels: [],
       },
       "anthropic/claude-sonnet-4.6": {
         label: "Claude Sonnet 4.6",
         description: "Anthropic's balanced model, via OpenRouter.",
-        effortLevels: ["low", "medium", "high", "max"],
       },
       "anthropic/claude-opus-4.8": {
         label: "Claude Opus 4.8",
         description: "Anthropic's flagship, via OpenRouter.",
-        effortLevels: ["low", "medium", "high", "xhigh", "max"],
       },
       "google/gemini-3-flash-preview": {
         label: "Gemini 3 Flash",
         description: "Google's fast model, via OpenRouter.",
-        effortLevels: ["low", "medium", "high"],
       },
       "deepseek/deepseek-v4-pro": {
         label: "DeepSeek V4 Pro",
         description: "DeepSeek's flagship, via OpenRouter.",
-        effortLevels: ["high", "xhigh"],
       },
     },
   },
@@ -458,12 +420,10 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
       "deepseek-v4-flash": {
         label: "DeepSeek V4 Flash",
         description: "Fast, low-cost DeepSeek model.",
-        effortLevels: ["high", "xhigh"],
       },
       "deepseek-v4-pro": {
         label: "DeepSeek V4 Pro",
         description: "DeepSeek's most capable model.",
-        effortLevels: ["high", "xhigh"],
       },
     },
   },
@@ -479,22 +439,18 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
       "gemini-3-flash-preview": {
         label: "Gemini 3 Flash",
         description: "Fast and capable. Best default.",
-        effortLevels: ["low", "medium", "high"],
       },
       "gemini-3-pro-preview": {
         label: "Gemini 3 Pro",
         description: "Google's most capable, slower.",
-        effortLevels: ["low", "high"],
       },
       "gemini-2.5-flash": {
         label: "Gemini 2.5 Flash",
         description: "Previous fast model.",
-        effortLevels: ["low", "medium", "high"],
       },
       "gemini-2.5-pro": {
         label: "Gemini 2.5 Pro",
         description: "Previous flagship.",
-        effortLevels: ["low", "medium", "high"],
       },
     },
   },
@@ -510,22 +466,18 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
       "anthropic.claude-sonnet-4-6": {
         label: "Claude Sonnet 4.6",
         description: "Anthropic's balanced model, via Bedrock.",
-        effortLevels: ["low", "medium", "high", "xhigh"],
       },
       "anthropic.claude-opus-4-8": {
         label: "Claude Opus 4.8",
         description: "Anthropic's flagship, via Bedrock.",
-        effortLevels: ["low", "medium", "high", "xhigh"],
       },
       "amazon.nova-pro-v1:0": {
         label: "Nova Pro",
         description: "Amazon's capable general-purpose model.",
-        effortLevels: [],
       },
       "amazon.nova-lite-v1:0": {
         label: "Nova Lite",
         description: "Amazon's fast, lower-cost model.",
-        effortLevels: [],
       },
     },
   },
@@ -541,17 +493,14 @@ export const PROVIDER_OVERRIDES: Record<string, ProviderOverride> = {
       "MiniMax-M3": {
         label: "MiniMax M3",
         description: "Best default. Long-context multimodal model.",
-        effortLevels: ["low", "medium", "high"],
       },
       "MiniMax-M2.7": {
         label: "MiniMax M2.7",
         description: "Lower cost. Text-only reasoning model.",
-        effortLevels: ["low", "medium", "high"],
       },
       "MiniMax-M2.7-highspeed": {
         label: "MiniMax M2.7 Highspeed",
         description: "Faster M2.7 tier for latency-sensitive chats.",
-        effortLevels: ["low", "medium", "high"],
       },
     },
   },

--- a/app/src/lib/providers.test.mjs
+++ b/app/src/lib/providers.test.mjs
@@ -115,45 +115,25 @@ const SAMPLE_CATALOG = [
 
 test.before(() => hydrateProviderCatalog(SAMPLE_CATALOG));
 
-test("effort levels are per model", () => {
-  // Codex: has xhigh, no max. Every catalogued GPT model shares this set
-  // (verified against Codex's models_cache.json supported_reasoning_levels).
+test("effort levels are derived per model from pi's thinking ladder", () => {
+  // Every reasoning model derives the four-tier low→xhigh spectrum from pi
+  // (the fixture gives each the full ladder); the retired `max` never appears.
+  const FULL = ["low", "medium", "high", "xhigh"];
   for (const id of [
     "gpt-5.5",
     "gpt-5.4",
     "gpt-5.4-mini",
     "gpt-5.3-codex-spark",
   ]) {
-    assert.deepEqual(
-      getEffortLevels("openai", id),
-      ["low", "medium", "high", "xhigh"],
-      id,
-    );
+    assert.deepEqual(getEffortLevels("openai", id), FULL, id);
   }
-  // Sonnet 4.6: has max, no xhigh.
-  assert.deepEqual(getEffortLevels("anthropic", "claude-sonnet-4-6"), [
-    "low",
-    "medium",
-    "high",
-    "max",
-  ]);
-  // Opus 4.7: full range.
-  assert.deepEqual(getEffortLevels("anthropic", "claude-opus-4-7"), [
-    "low",
-    "medium",
-    "high",
-    "xhigh",
-    "max",
-  ]);
-  // Opus 4.8: full range, identical to 4.7. `ultracode` is a Claude Code
-  // harness mode, not an effort level — it must never appear here.
-  assert.deepEqual(getEffortLevels("anthropic", "claude-opus-4-8"), [
-    "low",
-    "medium",
-    "high",
-    "xhigh",
-    "max",
-  ]);
+  for (const id of [
+    "claude-sonnet-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+  ]) {
+    assert.deepEqual(getEffortLevels("anthropic", id), FULL, id);
+  }
 });
 
 test("effort levels empty for unknown / effort-less models", () => {
@@ -168,10 +148,6 @@ test("effort levels empty for unknown / effort-less models", () => {
 });
 
 test("validEffortOrDefault keeps a value the model accepts", () => {
-  assert.equal(
-    validEffortOrDefault("anthropic", "claude-sonnet-4-6", "max"),
-    "max",
-  );
   assert.equal(validEffortOrDefault("openai", "gpt-5.5", "xhigh"), "xhigh");
   assert.equal(
     validEffortOrDefault("anthropic", "claude-opus-4-7", "high"),
@@ -183,13 +159,23 @@ test("validEffortOrDefault keeps a value the model accepts", () => {
   );
 });
 
-test("validEffortOrDefault clamps a value the model rejects to the default", () => {
-  // Sonnet has no xhigh; codex has no max — both fall back to medium.
+test("validEffortOrDefault normalizes a legacy `max` to the top tier", () => {
+  // A persisted `max` (the retired tier) resolves to `xhigh` — the deepest
+  // reasoning the model offers — never a silent downgrade to the default.
   assert.equal(
-    validEffortOrDefault("anthropic", "claude-sonnet-4-6", "xhigh"),
+    validEffortOrDefault("anthropic", "claude-sonnet-4-6", "max"),
+    "xhigh",
+  );
+  assert.equal(validEffortOrDefault("openai", "gpt-5.5", "max"), "xhigh");
+});
+
+test("validEffortOrDefault clamps a value the model rejects to the default", () => {
+  // Garbage the model doesn't accept falls back to the shared default.
+  assert.equal(
+    validEffortOrDefault("anthropic", "claude-sonnet-4-6", "bogus"),
     "medium",
   );
-  assert.equal(validEffortOrDefault("openai", "gpt-5.5", "max"), "medium");
+  assert.equal(validEffortOrDefault("openai", "gpt-5.5", ""), "medium");
 });
 
 test("validEffortOrDefault falls back to default when unset or garbage", () => {
@@ -268,7 +254,7 @@ test("OpenCode Zen + Go are api-key providers with a dashboard URL", () => {
     // Every model needs a contextWindow so the composer's usage indicator shows
     // a % (not a raw token count / empty ring). The OpenCode gateway serves a
     // fixed window per model.
-    const VALID_EFFORT = new Set(["low", "medium", "high", "xhigh", "max"]);
+    const VALID_EFFORT = new Set(["low", "medium", "high", "xhigh"]);
     for (const m of p.models) {
       assert.ok(
         typeof m.contextWindow === "number" && m.contextWindow > 0,
@@ -301,35 +287,28 @@ test("OpenCode Zen + Go are api-key providers with a dashboard URL", () => {
   assert.notEqual(getProvider("openai").auth, "apiKey");
 });
 
-test("OpenCode effort levels match models.dev reasoning_options", () => {
+test("OpenCode effort levels are derived from pi (reasoning → ladder, else omitted)", () => {
   const effortOf = (prov, id) =>
     getProvider(prov).models.find((m) => m.id === id)?.effortLevels;
-  // Models with discrete effort (models.dev reasoning_options.effort.values).
-  assert.deepEqual(effortOf("opencode", "claude-opus-4-8"), [
-    "low",
-    "medium",
-    "high",
-    "xhigh",
-  ]);
-  assert.deepEqual(effortOf("opencode", "gpt-5.5"), [
-    "low",
-    "medium",
-    "high",
-    "xhigh",
-  ]);
-  assert.deepEqual(effortOf("opencode", "deepseek-v4-flash-free"), [
-    "high",
-    "max",
-  ]);
-  assert.deepEqual(effortOf("opencode-go", "deepseek-v4-pro"), ["high", "max"]);
-  // Open models expose only a reasoning toggle (no discrete effort) → omitted.
+  const FULL = ["low", "medium", "high", "xhigh"];
+  // Reasoning models get the derived spectrum — no hand-curated per-gateway list
+  // (which used to drift, e.g. minimax-m3 pinned `[]` here but derived elsewhere).
   for (const [prov, id] of [
+    ["opencode", "claude-opus-4-8"],
+    ["opencode", "gpt-5.5"],
     ["opencode", "gemini-3.5-flash"],
+    ["opencode", "deepseek-v4-flash-free"],
+    ["opencode-go", "minimax-m3"],
+    ["opencode-go", "deepseek-v4-pro"],
+  ]) {
+    assert.deepEqual(effortOf(prov, id), FULL, `${prov}/${id}`);
+  }
+  // Non-reasoning models expose no effort → the row is omitted (undefined).
+  for (const [prov, id] of [
     ["opencode", "mimo-v2.5-free"],
     ["opencode", "nemotron-3-ultra-free"],
     ["opencode-go", "glm-5.1"],
     ["opencode-go", "kimi-k2.6"],
-    ["opencode-go", "minimax-m3"],
     ["opencode-go", "qwen3.7-max"],
   ]) {
     assert.equal(
@@ -356,7 +335,7 @@ test("MiniMax is an active api-key provider backed by pi-ai's global provider", 
       typeof m.contextWindow === "number" && m.contextWindow > 0,
       `${m.id} has a contextWindow`,
     );
-    assert.deepEqual(m.effortLevels, ["low", "medium", "high"]);
+    assert.deepEqual(m.effortLevels, ["low", "medium", "high", "xhigh"]);
   }
   assert.ok(
     !COMING_SOON_PROVIDERS.some((provider) => provider.id === "minimax"),
@@ -368,7 +347,7 @@ test("EFFORT_ORDER is the full ascending spectrum and a superset of every model'
   // The composer renders the gauge against EFFORT_ORDER (not the model's own
   // levels) so every model shows the SAME number of bars. That only reads right
   // if EFFORT_ORDER is the canonical low->high spectrum...
-  assert.deepEqual(EFFORT_ORDER, ["low", "medium", "high", "xhigh", "max"]);
+  assert.deepEqual(EFFORT_ORDER, ["low", "medium", "high", "xhigh"]);
   // ...and a superset of every model's effortLevels, so any active level a model
   // can hold has a position on the shared gauge (else a bar would never fill).
   const order = new Set(EFFORT_ORDER);

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -14,27 +14,27 @@ import {
 } from "./provider-overrides.ts";
 
 /**
- * Reasoning-effort levels, ordered low→high. The set a given model accepts
- * is model-specific (see `ModelOption.effortLevels`):
- * - Codex `model_reasoning_effort`: low/medium/high/xhigh (no `max`).
- * - Claude `--effort`: Opus 4.7/4.8 and Sonnet 5 = all five; Sonnet 4.6 =
- *   low/medium/high/max (no `xhigh`). Claude self-clamps an unsupported
- *   value; Codex does not.
+ * Reasoning-effort levels, ordered low→high. `xhigh` is the top tier: it is the
+ * deepest reasoning any provider actually exposes (pi's ceiling, which the
+ * Claude backend maps to the SDK's `max` effort). Houston used to carry a fifth
+ * `max` tier above `xhigh`, but the two produced the byte-identical API request
+ * on every provider — a label with no effect — so it was removed. The set a
+ * given model accepts is model-specific (see `ModelOption.effortLevels`),
+ * derived from pi's per-model thinking levels (`deriveEffortLevels`).
  */
-export type EffortLevel = "low" | "medium" | "high" | "xhigh" | "max";
+export type EffortLevel = "low" | "medium" | "high" | "xhigh";
 
 /**
  * The full effort vocabulary, ascending. Drives the composer's effort-gauge so
  * the icon always shows the SAME number of bars (filled to the active level's
  * position), regardless of how many levels a given model offers — a model with
- * only `high`/`max` reads as a full gauge filled high, not two lone bars.
+ * only `high`/`xhigh` reads as a nearly-full gauge, not two lone bars.
  */
 export const EFFORT_ORDER: readonly EffortLevel[] = [
   "low",
   "medium",
   "high",
   "xhigh",
-  "max",
 ];
 
 /** Effort applied when nothing else is configured. Mirrors the engine. */
@@ -119,10 +119,12 @@ export interface ProviderInfo {
 /**
  * pi-ai's per-model `thinkingLevels` → Houston `EffortLevel`s, low→high. Drops
  * pi's `off` and `minimal` (Houston's effort scale starts at `low`) and passes
- * `low|medium|high|xhigh` through 1:1. pi has no `max` — that level only ever
- * comes from a curated override. Non-reasoning models, or reasoning models with
- * no thinking levels, get `[]`, so the picker hides the effort row. Input order
- * (pi emits ascending) is preserved.
+ * `low|medium|high|xhigh` through 1:1. This is the DEFAULT source of a model's
+ * effort set — pi's per-model reasoning ladder is authoritative, so the catalog
+ * stays honest as pi adds models without a hand-curated list to maintain.
+ * Non-reasoning models, or reasoning models with no thinking levels, get `[]`,
+ * so the picker hides the effort row. Input order (pi emits ascending) is
+ * preserved.
  */
 const PI_EFFORT_MAP: Readonly<Record<string, EffortLevel>> = {
   low: "low",
@@ -575,11 +577,29 @@ export function getEffortLevels(
 }
 
 /**
+ * Normalize a persisted effort value. Configs written by older Houston builds
+ * may still carry the retired `"max"` tier; it always meant "the deepest
+ * reasoning this model offers", which is now `"xhigh"` (the two produced the
+ * identical API request), so map it there. Every other value passes through
+ * unchanged, and `null`/`undefined` stay as-is so it composes in `??` chains.
+ * The runtime still ACCEPTS `"max"` on the wire (`toThinkingLevel` maps it to
+ * pi's `xhigh`), so a stored `"max"` runs correctly even before it is re-picked;
+ * this keeps the UI honest by surfacing the level the user actually gets.
+ */
+export function normalizeEffort(
+  effort: string | null | undefined,
+): string | null | undefined {
+  return effort === "max" ? "xhigh" : effort;
+}
+
+/**
  * The effort to actually use for a provider+model: the requested value when
  * the model accepts it, otherwise the shared default (or the lowest level if
- * the model somehow lacks `medium`). Returns `undefined` when the model has
- * no effort control, so callers omit the flag entirely. Mirrors the engine's
- * `sessions::resolve_effort`, keeping the picker honest about what will run.
+ * the model somehow lacks `medium`). A legacy `"max"` is normalized to `"xhigh"`
+ * first, so an agent carrying it keeps its top-tier reasoning instead of being
+ * silently reset to the default. Returns `undefined` when the model has no
+ * effort control, so callers omit the flag entirely. Mirrors the engine's
+ * effort resolution, keeping the picker honest about what will run.
  */
 export function validEffortOrDefault(
   providerId: string | null | undefined,
@@ -588,8 +608,9 @@ export function validEffortOrDefault(
 ): EffortLevel | undefined {
   const levels = getEffortLevels(providerId, modelId);
   if (levels.length === 0) return undefined;
-  if (effort && levels.includes(effort as EffortLevel))
-    return effort as EffortLevel;
+  const normalized = normalizeEffort(effort);
+  if (normalized && levels.includes(normalized as EffortLevel))
+    return normalized as EffortLevel;
   return levels.includes(DEFAULT_EFFORT) ? DEFAULT_EFFORT : levels[0];
 }
 

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -77,15 +77,13 @@
       "low": "Low",
       "medium": "Medium",
       "high": "High",
-      "xhigh": "Extra high",
-      "max": "Max"
+      "xhigh": "Extra high"
     },
     "effortDescriptions": {
       "low": "Fastest, lightest thinking.",
       "medium": "Balanced speed and depth.",
       "high": "Deeper thinking for harder work.",
-      "xhigh": "Best for complex, agentic tasks.",
-      "max": "Deepest thinking, no token limit."
+      "xhigh": "Best for complex, agentic tasks."
     },
     "picker": {
       "searchPlaceholder": "Search models…",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -77,15 +77,13 @@
       "low": "Bajo",
       "medium": "Medio",
       "high": "Alto",
-      "xhigh": "Muy alto",
-      "max": "Máximo"
+      "xhigh": "Muy alto"
     },
     "effortDescriptions": {
       "low": "Más rápido, menos análisis.",
       "medium": "Equilibrio entre velocidad y profundidad.",
       "high": "Análisis más profundo para tareas difíciles.",
-      "xhigh": "Ideal para tareas complejas.",
-      "max": "Análisis máximo, sin límite de tokens."
+      "xhigh": "Ideal para tareas complejas."
     },
     "picker": {
       "searchPlaceholder": "Busca modelos…",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -77,15 +77,13 @@
       "low": "Baixo",
       "medium": "Médio",
       "high": "Alto",
-      "xhigh": "Muito alto",
-      "max": "Máximo"
+      "xhigh": "Muito alto"
     },
     "effortDescriptions": {
       "low": "Mais rápido, menos análise.",
       "medium": "Equilíbrio entre velocidade e profundidade.",
       "high": "Análise mais profunda para tarefas difíceis.",
-      "xhigh": "Ideal para tarefas complexas.",
-      "max": "Análise máxima, sem limite de tokens."
+      "xhigh": "Ideal para tarefas complexas."
     },
     "picker": {
       "searchPlaceholder": "Busque modelos…",

--- a/app/tests/anthropic-model-catalog.test.ts
+++ b/app/tests/anthropic-model-catalog.test.ts
@@ -8,35 +8,14 @@ import {
 } from "../src/lib/providers.ts";
 import { SAMPLE_CATALOG } from "./fixtures/sample-catalog.ts";
 
-// Regression guards for HOU-618 (Sonnet 5 context window) plus the Fable 5
-// picker restore. Anthropic's models now come from pi (windows) + the Houston
-// override (labels, effort, snap-up ceiling); the sample catalog carries pi's
-// windows, so these lock in the hydrated result the picker reads.
+// Regression guards for the Anthropic window sizing plus the Fable 5 picker
+// restore. Anthropic's models now come from pi (windows + effort) + the Houston
+// override (labels, snap-up ceiling); the sample catalog carries pi's windows,
+// so these lock in the hydrated result the picker reads. `claude-sonnet-5` is
+// intentionally NOT asserted: pi-ai 0.79.10 ships no such id, its curated
+// override was orphaned and removed, and the drift guard
+// (provider-overrides-drift.test.ts) now rejects any override id pi lacks.
 before(() => hydrateProviderCatalog(SAMPLE_CATALOG));
-
-describe("Sonnet 5 catalog (HOU-618)", () => {
-  it("has a flat 1M context window — no 200k snap-up (unlike Sonnet 4.6)", () => {
-    // Sonnet 5's 1M is the default AND only variant (no credit-gated 200k),
-    // so default === max === 1M. The bug started the estimate at 200k by
-    // copying Sonnet 4.6's credit-gated snap-up, which doesn't apply here.
-    deepStrictEqual(getContextWindowConfig("anthropic", "claude-sonnet-5"), {
-      default: 1_000_000,
-      max: 1_000_000,
-    });
-  });
-
-  it("keeps all five effort levels including max", () => {
-    // Anthropic's effort docs list Sonnet 5 for both `xhigh` and `max`, so
-    // `max` stays in the picker (it is not an Opus-only level).
-    deepStrictEqual(getEffortLevels("anthropic", "claude-sonnet-5"), [
-      "low",
-      "medium",
-      "high",
-      "xhigh",
-      "max",
-    ]);
-  });
-});
 
 describe("Sonnet 4.6 still credit-gates its 1M window", () => {
   it("starts at 200k and snaps up to 1M (unchanged by HOU-618)", () => {
@@ -61,13 +40,12 @@ describe("Fable 5 restored to the picker", () => {
     });
   });
 
-  it("accepts all five effort levels", () => {
+  it("derives its effort straight from pi (low→xhigh, no retired max)", () => {
     deepStrictEqual(getEffortLevels("anthropic", "claude-fable-5"), [
       "low",
       "medium",
       "high",
       "xhigh",
-      "max",
     ]);
   });
 });

--- a/app/tests/effort-bars.test.ts
+++ b/app/tests/effort-bars.test.ts
@@ -6,60 +6,61 @@ import {
   effortFillCount,
 } from "../src/lib/effort-bars.ts";
 
-// Opus/Fable accept all five; Codex stops at xhigh (no max).
-const FIVE = ["low", "medium", "high", "xhigh", "max"] as const;
-const FOUR = ["low", "medium", "high", "xhigh"] as const;
+// The full spectrum is four tiers now (low→xhigh); a two-level model (e.g.
+// DeepSeek high/xhigh) still renders one bar per level it accepts.
+const FULL = ["low", "medium", "high", "xhigh"] as const;
+const TWO = ["high", "xhigh"] as const;
 
 describe("effortFillCount", () => {
   it("is the 1-based position of the active level", () => {
-    strictEqual(effortFillCount(FIVE, "low"), 1);
-    strictEqual(effortFillCount(FIVE, "high"), 3);
-    strictEqual(effortFillCount(FIVE, "max"), 5);
-    strictEqual(effortFillCount(FOUR, "xhigh"), 4);
+    strictEqual(effortFillCount(FULL, "low"), 1);
+    strictEqual(effortFillCount(FULL, "high"), 3);
+    strictEqual(effortFillCount(FULL, "xhigh"), 4);
+    strictEqual(effortFillCount(TWO, "xhigh"), 2);
   });
 
   it("is 0 when the level is absent, unset, or the set is empty", () => {
-    strictEqual(effortFillCount(FOUR, "max"), 0); // Codex has no max
-    strictEqual(effortFillCount(FIVE, undefined), 0);
-    strictEqual(effortFillCount(FIVE, null), 0);
+    strictEqual(effortFillCount(TWO, "low"), 0); // low isn't in this model's set
+    strictEqual(effortFillCount(FULL, undefined), 0);
+    strictEqual(effortFillCount(FULL, null), 0);
     strictEqual(effortFillCount([], "low"), 0);
   });
 });
 
 describe("effortBars", () => {
   it("emits one bar per level", () => {
-    strictEqual(effortBars(FIVE, "high").length, 5);
-    strictEqual(effortBars(FOUR, "high").length, 4);
+    strictEqual(effortBars(FULL, "high").length, 4);
+    strictEqual(effortBars(TWO, "high").length, 2);
     deepStrictEqual(effortBars([], "low"), []);
   });
 
   it("fills bars up to and including the active level", () => {
     deepStrictEqual(
-      effortBars(FIVE, "high").map((b) => b.filled),
-      [true, true, true, false, false],
+      effortBars(FULL, "high").map((b) => b.filled),
+      [true, true, true, false],
     );
     deepStrictEqual(
-      effortBars(FOUR, "xhigh").map((b) => b.filled),
+      effortBars(FULL, "xhigh").map((b) => b.filled),
       [true, true, true, true],
     );
   });
 
   it("leaves every bar dimmed when nothing is selected", () => {
     deepStrictEqual(
-      effortBars(FIVE, undefined).map((b) => b.filled),
-      [false, false, false, false, false],
+      effortBars(FULL, undefined).map((b) => b.filled),
+      [false, false, false, false],
     );
   });
 
   it("ascends in height from left to right", () => {
-    const bars = effortBars(FIVE, "max");
+    const bars = effortBars(FULL, "xhigh");
     for (let i = 1; i < bars.length; i++) {
       strictEqual(bars[i].height > bars[i - 1].height, true);
     }
   });
 
   it("centers the bar group within the viewBox", () => {
-    const bars = effortBars(FOUR, "low");
+    const bars = effortBars(FULL, "low");
     const left = bars[0].x;
     const last = bars[bars.length - 1];
     const right = EFFORT_ICON_VIEWBOX - (last.x + last.width);
@@ -67,7 +68,7 @@ describe("effortBars", () => {
   });
 
   it("keeps every bar inside the viewBox", () => {
-    for (const levels of [FOUR, FIVE]) {
+    for (const levels of [TWO, FULL]) {
       for (const bar of effortBars(levels, "high")) {
         strictEqual(bar.x >= 0, true);
         strictEqual(bar.x + bar.width <= EFFORT_ICON_VIEWBOX, true);

--- a/app/tests/effort-cycle.test.ts
+++ b/app/tests/effort-cycle.test.ts
@@ -2,32 +2,33 @@ import { strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import { nextEffort } from "../src/lib/effort-cycle.ts";
 
-// Opus/Fable accept all five; Codex stops at xhigh (no max).
-const FIVE = ["low", "medium", "high", "xhigh", "max"] as const;
-const FOUR = ["low", "medium", "high", "xhigh"] as const;
+// A model that accepts the full four-tier spectrum (e.g. Codex / Opus); xhigh is
+// the top tier (the retired `max` is gone).
+const FULL = ["low", "medium", "high", "xhigh"] as const;
+// A two-level model (e.g. DeepSeek: high / xhigh).
+const PARTIAL = ["high", "xhigh"] as const;
 
 describe("nextEffort", () => {
-  it("advances to the next level low → … → max", () => {
-    strictEqual(nextEffort(FIVE, "low"), "medium");
-    strictEqual(nextEffort(FIVE, "medium"), "high");
-    strictEqual(nextEffort(FIVE, "high"), "xhigh");
-    strictEqual(nextEffort(FIVE, "xhigh"), "max");
+  it("advances to the next level low → … → xhigh", () => {
+    strictEqual(nextEffort(FULL, "low"), "medium");
+    strictEqual(nextEffort(FULL, "medium"), "high");
+    strictEqual(nextEffort(FULL, "high"), "xhigh");
   });
 
   it("wraps past the last level back to the first", () => {
-    strictEqual(nextEffort(FIVE, "max"), "low");
-    strictEqual(nextEffort(FOUR, "xhigh"), "low"); // Codex tops out at xhigh
+    strictEqual(nextEffort(FULL, "xhigh"), "low");
+    strictEqual(nextEffort(PARTIAL, "xhigh"), "high"); // wraps within its 2 levels
   });
 
   it("starts at the first level when current is unset", () => {
-    strictEqual(nextEffort(FIVE, undefined), "low");
-    strictEqual(nextEffort(FIVE, null), "low");
-    strictEqual(nextEffort(FIVE, ""), "low");
+    strictEqual(nextEffort(FULL, undefined), "low");
+    strictEqual(nextEffort(FULL, null), "low");
+    strictEqual(nextEffort(FULL, ""), "low");
   });
 
   it("starts at the first level when current isn't in this model's set", () => {
-    // e.g. an agent carrying `max` after switching to a Codex model.
-    strictEqual(nextEffort(FOUR, "max"), "low");
+    // e.g. an agent carrying `low` after switching to a high-only model.
+    strictEqual(nextEffort(PARTIAL, "low"), "high");
   });
 
   it("returns undefined when the model has no effort control", () => {

--- a/app/tests/provider-catalog.test.ts
+++ b/app/tests/provider-catalog.test.ts
@@ -8,6 +8,7 @@ import {
   getModel,
   getProvider,
   hydrateProviderCatalog,
+  normalizeEffort,
   normalizeLegacyModel,
   PROVIDERS,
   validEffortOrDefault,
@@ -71,23 +72,26 @@ describe("hydrateProviderCatalog: model metadata", () => {
     });
   });
 
-  it("keeps the curated effort set (incl. `max`, which pi can't supply)", () => {
+  it("derives the effort set straight from pi (no hand-curated per-model list)", () => {
+    // Both are reasoning models with pi's full ladder in the fixture → the
+    // four-tier low→xhigh spectrum, with no retired `max`.
     deepStrictEqual(getEffortLevels("anthropic", "claude-sonnet-4-6"), [
       "low",
       "medium",
       "high",
-      "max",
+      "xhigh",
     ]);
     deepStrictEqual(getEffortLevels("anthropic", "claude-opus-4-8"), [
       "low",
       "medium",
       "high",
       "xhigh",
-      "max",
     ]);
   });
 
-  it("hides the effort row for models the override pins empty", () => {
+  it("hides the effort row for a non-reasoning model", () => {
+    // gpt-4.1 is non-reasoning in the fixture → pi reports no thinking levels,
+    // so the derived set is empty and the effort row is omitted (no override).
     strictEqual(getModel("github-copilot", "gpt-4.1")?.effortLevels, undefined);
     strictEqual(getEffortLevels("github-copilot", "gpt-4.1").length, 0);
   });
@@ -121,6 +125,17 @@ describe("hydrateProviderCatalog: a genuinely new provider (no override)", () =>
   });
 });
 
+describe("normalizeEffort (legacy `max` tolerance)", () => {
+  it("maps a persisted `max` to `xhigh`, passes everything else through", () => {
+    strictEqual(normalizeEffort("max"), "xhigh");
+    strictEqual(normalizeEffort("low"), "low");
+    strictEqual(normalizeEffort("xhigh"), "xhigh");
+    // null/undefined stay as-is so it composes in `??` chains.
+    strictEqual(normalizeEffort(null), null);
+    strictEqual(normalizeEffort(undefined), undefined);
+  });
+});
+
 describe("helpers read the hydrated cache", () => {
   it("getDefaultModel: override pick for curated, first model for new providers", () => {
     strictEqual(getDefaultModel("anthropic"), "claude-sonnet-4-6");
@@ -142,13 +157,19 @@ describe("helpers read the hydrated cache", () => {
   });
 
   it("validEffortOrDefault clamps against the hydrated model's levels", () => {
+    // A persisted legacy `max` normalizes to the top tier the model accepts,
+    // so an agent carrying it keeps its top-tier reasoning (not the default).
     strictEqual(
       validEffortOrDefault("anthropic", "claude-sonnet-4-6", "max"),
-      "max",
+      "xhigh",
     );
-    // Sonnet 4.6 has no xhigh → clamp to the shared default.
     strictEqual(
       validEffortOrDefault("anthropic", "claude-sonnet-4-6", "xhigh"),
+      "xhigh",
+    );
+    // Garbage clamps to the shared default.
+    strictEqual(
+      validEffortOrDefault("anthropic", "claude-sonnet-4-6", "bogus"),
       "medium",
     );
     // A model with no effort row → undefined (caller omits the flag).

--- a/app/tests/provider-overrides-drift.test.ts
+++ b/app/tests/provider-overrides-drift.test.ts
@@ -1,0 +1,59 @@
+import { ok } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  PROVIDER_ID_RENAME,
+  PROVIDER_OVERRIDES,
+} from "../src/lib/provider-overrides.ts";
+
+/**
+ * Drift guard: every model id a `PROVIDER_OVERRIDES` entry curates must actually
+ * exist in the pi-ai catalog Houston ships. Overrides only add presentation
+ * metadata (labels, descriptions, and — for a genuine cap — effort) layered onto
+ * pi's runnable model set; an id pi doesn't ship is an ORPHAN that never renders
+ * (the `claude-sonnet-5` override was exactly this bug, hidden because the unit
+ * tests fed a synthetic catalog). This test reads the REAL pi-ai registry so a
+ * new orphan can't slip in.
+ *
+ * pi-ai isn't an app dependency, so we resolve it through the host package (which
+ * depends on it) via its stable node_modules symlink — no lockfile change, and
+ * the app's `node --experimental-strip-types --test` runner imports it directly.
+ */
+const pi = (await import(
+  new URL(
+    "../../packages/host/node_modules/@earendil-works/pi-ai/dist/index.js",
+    import.meta.url,
+  ).href
+)) as {
+  getModel(provider: string, id: string): unknown;
+  getProviders(): string[];
+};
+
+// Houston provider id → pi provider id (reverse of PROVIDER_ID_RENAME, which is
+// pi → Houston, e.g. `openai-codex` → `openai`). Identity for every other id.
+const houstonToPi: Record<string, string> = {};
+for (const [piId, houstonId] of Object.entries(PROVIDER_ID_RENAME))
+  houstonToPi[houstonId] = piId;
+
+describe("PROVIDER_OVERRIDES stay in sync with the shipped pi-ai catalog", () => {
+  const piProviders = new Set(pi.getProviders());
+
+  for (const [houstonId, override] of Object.entries(PROVIDER_OVERRIDES)) {
+    const piId = houstonToPi[houstonId] ?? houstonId;
+
+    it(`${houstonId} names a provider pi-ai ships`, () => {
+      ok(
+        piProviders.has(piId),
+        `PROVIDER_OVERRIDES["${houstonId}"] maps to pi provider "${piId}", which pi-ai does not ship`,
+      );
+    });
+
+    for (const modelId of Object.keys(override.models ?? {})) {
+      it(`${houstonId}/${modelId} exists in pi-ai`, () => {
+        ok(
+          pi.getModel(piId, modelId) != null,
+          `PROVIDER_OVERRIDES["${houstonId}"].models["${modelId}"] is an orphan: pi-ai (provider "${piId}") ships no such model. Remove it or fix the id.`,
+        );
+      });
+    }
+  }
+});


### PR DESCRIPTION
## What

The reasoning-effort selector offered levels that lied or hid:

- **The fake "Max" tier is gone.** Houston `max` and `xhigh` always mapped to the identical API request (both → pi `xhigh`, → SDK `max` on the Claude backend), so picking "Max" over "Extra high" changed nothing. `EffortLevel`/`EFFORT_ORDER` are now 4-tier `low..xhigh`; persisted configs with `effort: "max"` normalize to `xhigh` on read; the runtime keeps accepting `max` on the wire as tolerance.
- **Effort levels now derive from pi's `getSupportedThinkingLevels` by default.** Every hand-curated `effortLevels` override is deleted — audited one by one, none encoded a genuine cap: they were redundant copies, over-claims (bedrock sonnet-4-6 listed an `xhigh` pi can't reach), or `[]` pins on reasoning models that silently ran at medium with no control. Seven models regain the selector (copilot claude-haiku-4.5; opencode gemini-3.5-flash, mimo, nemotron; opencode-go glm-5.1, kimi-k2.6, qwen3.7-max) and minimax-m3 is now consistent across gateways. The override field stays as a documented escape hatch for future genuine caps.
- **Removed the orphaned `claude-sonnet-5` override** — the id doesn't exist in pi-ai 0.79.10, so the entry never rendered; the old test masked this with a synthetic catalog. A new **drift-guard test** resolves the real pi-ai catalog and fails whenever an override references an unknown model id.

## Verification

App suite 903/903 (incl. new normalization, derive-merge, and drift-guard tests; guard proven to fail on the orphan), `check-locales` in sync, repo typecheck + biome clean.

Series: #734, #738, #739 merged; plan mode and dictation follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)