### PR TITLE
feat: enforced Plan mode for chat turns

### DIFF
--- a/app/src/components/board/board-source.ts
+++ b/app/src/components/board/board-source.ts
@@ -2,6 +2,7 @@ import type { KanbanItem, NewPanelOpener } from "@houston-ai/board";
 import type { FeedItem } from "@houston-ai/chat";
 import type { ReactNode } from "react";
 import type { HistoryLoadOptions } from "../../lib/tauri";
+import type { TurnMode } from "../../lib/turn-mode";
 import type { Agent, AgentDefinition } from "../../lib/types";
 
 /**
@@ -27,6 +28,8 @@ import type { Agent, AgentDefinition } from "../../lib/types";
 export interface SendOverrides {
   providerOverride: string;
   modelOverride: string;
+  /** Turn mode pin for user-typed sends; absent = execute. */
+  modeOverride?: TurnMode;
 }
 
 /**

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -69,8 +69,9 @@ export function MissionBoard({ source }: { source: BoardSource }) {
     () => ({
       providerOverride: panel.effectiveProvider,
       modelOverride: panel.effectiveModel,
+      modeOverride: panel.turnMode,
     }),
-    [panel.effectiveProvider, panel.effectiveModel],
+    [panel.effectiveProvider, panel.effectiveModel, panel.turnMode],
   );
 
   const sendQueue = useBoardSendQueue({

--- a/app/src/components/board/use-agent-board-send.ts
+++ b/app/src/components/board/use-agent-board-send.ts
@@ -87,6 +87,7 @@ export function useAgentBoardSend({
       files,
       providerOverride,
       modelOverride,
+      modeOverride,
     }: { text: string; files: File[] } & SendOverrides) => {
       const agentMode = pendingAgentMode ?? agentModes?.[0]?.id;
       const mode = agentModes?.find((m) => m.id === agentMode);
@@ -106,6 +107,7 @@ export function useAgentBoardSend({
           promptFile: mode?.promptFile,
           providerOverride,
           modelOverride,
+          modeOverride,
           titleText: visible,
           buildPrompt: async (activityId) => {
             const saved = await tauriAttachments.save(
@@ -180,6 +182,7 @@ export function useAgentBoardSend({
           promptFile: warmingMode?.promptFile,
           provider: overrides.providerOverride,
           model: overrides.modelOverride,
+          mode: overrides.modeOverride,
         });
       if (queuedWarm) {
         // No loading flag: while the message is parked the provisioning card
@@ -198,6 +201,7 @@ export function useAgentBoardSend({
           mode: mode?.promptFile,
           providerOverride: overrides.providerOverride,
           modelOverride: overrides.modelOverride,
+          modeOverride: overrides.modeOverride,
           // If the conversation is mid-turn the adapter holds this send; the
           // queued bubble shows the user's words, not the built prompt.
           queuedPreview: {

--- a/app/src/components/board/use-mission-control-archived-send.ts
+++ b/app/src/components/board/use-mission-control-archived-send.ts
@@ -4,7 +4,8 @@ import { useTranslation } from "react-i18next";
 import { analytics } from "../../lib/analytics";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { classifyFileKind } from "../../lib/file-kind";
-import { tauriAttachments, tauriChat } from "../../lib/tauri";
+import { tauriAttachments, tauriChat, tauriConfig } from "../../lib/tauri";
+import { readAgentTurnMode } from "../../lib/turn-mode";
 import type { Agent, AgentDefinition } from "../../lib/types";
 import { useAgentStore } from "../../stores/agents";
 import { useUIStore } from "../../stores/ui";
@@ -56,6 +57,7 @@ export function useMissionControlArchivedSend({
           mode: mode?.promptFile,
           providerOverride,
           modelOverride,
+          modeOverride: await readAgentTurnMode(agentPath, tauriConfig.read),
         });
         analytics.track("chat_message_sent");
         for (const f of files)

--- a/app/src/components/chat-mode-selector.tsx
+++ b/app/src/components/chat-mode-selector.tsx
@@ -1,0 +1,118 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@houston-ai/core";
+import type { Agent } from "@houston-ai/engine-client";
+import type { LucideIcon } from "lucide-react";
+import { Check, ChevronDown, ClipboardList, MessageSquare } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useCapabilities } from "../hooks/use-capabilities";
+import { modelSelectorDecision } from "../lib/model-selector-lock";
+import type { TurnMode } from "../lib/turn-mode";
+
+interface ChatModeSelectorProps {
+  /** Currently-pinned turn mode. */
+  mode: TurnMode;
+  /** Called when the user picks a mode. */
+  onSelect: (mode: TurnMode) => void;
+  /**
+   * The agent this control configures, when composer-scoped. Threaded so the
+   * Mode pill follows the same audience as the model + effort selectors: shown
+   * for everyone in a Teams org and in single-player, hidden only for a member
+   * on a pre-Teams multiplayer host. Omit outside an agent scope and it always
+   * shows.
+   */
+  agent?: Pick<Agent, "access"> | null;
+}
+
+const MODE_ICONS: Record<TurnMode, LucideIcon> = {
+  execute: MessageSquare,
+  plan: ClipboardList,
+};
+
+const MODE_ORDER: readonly TurnMode[] = ["execute", "plan"];
+
+/**
+ * "Mode" dropdown, rendered beside {@link ChatModelSelector} in the composer.
+ * Two entries — Chat (execute) and Plan (read-only planning) — each with an
+ * icon and a one-line description. The trigger pill shows the active mode's
+ * icon + label so the row reads at a glance. Hidden only for a member on a
+ * pre-Teams multiplayer host (mirrors the model + effort selectors); otherwise
+ * always available.
+ */
+export function ChatModeSelector({
+  mode,
+  onSelect,
+  agent,
+}: ChatModeSelectorProps) {
+  const { t } = useTranslation("chat");
+  const { capabilities } = useCapabilities();
+  if (!modelSelectorDecision(capabilities, agent).show) return null;
+
+  const labels: Record<TurnMode, string> = {
+    execute: t("modeSelector.chat"),
+    plan: t("modeSelector.plan"),
+  };
+  const descriptions: Record<TurnMode, string> = {
+    execute: t("modeSelector.chatDescription"),
+    plan: t("modeSelector.planDescription"),
+  };
+
+  const ActiveIcon = MODE_ICONS[mode];
+
+  return (
+    // Stop pointer events from bubbling — keeps the board detail panel from
+    // reading trigger clicks as "click outside → close panel".
+    <fieldset
+      className="contents border-0 p-0 m-0"
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => e.stopPropagation()}
+      onKeyDown={(e) => e.stopPropagation()}
+    >
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            aria-label={t("modeSelector.modeValue", { mode: labels[mode] })}
+            title={descriptions[mode]}
+            className="flex items-center gap-1.5 h-7 px-2 rounded-lg text-xs text-muted-foreground hover:text-foreground hover:bg-accent transition-colors outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          >
+            <ActiveIcon className="size-3.5" />
+            <span>{labels[mode]}</span>
+            <ChevronDown className="size-3 opacity-60" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="w-[300px]"
+          onCloseAutoFocus={(e) => e.preventDefault()}
+        >
+          {MODE_ORDER.map((m) => {
+            const Icon = MODE_ICONS[m];
+            const active = m === mode;
+            return (
+              <DropdownMenuItem
+                key={m}
+                onSelect={() => onSelect(m)}
+                className="items-start gap-2.5 py-2"
+              >
+                <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <div className="flex min-w-0 flex-col gap-0.5">
+                  <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+                    {labels[m]}
+                    {active && <Check className="size-3.5 text-primary" />}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {descriptions[m]}
+                  </span>
+                </div>
+              </DropdownMenuItem>
+            );
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </fieldset>
+  );
+}

--- a/app/src/components/mission-control-send.ts
+++ b/app/src/components/mission-control-send.ts
@@ -33,6 +33,8 @@ export interface ActivityOverrideSource {
 export interface SendOverrides {
   providerOverride?: string;
   modelOverride?: string;
+  /** Turn mode pin for user-typed sends; absent = execute. */
+  modeOverride?: "execute" | "plan";
 }
 
 /**

--- a/app/src/components/tabs/use-archived-send-message.ts
+++ b/app/src/components/tabs/use-archived-send-message.ts
@@ -5,7 +5,8 @@ import type { Activity } from "../../data/activity";
 import { analytics } from "../../lib/analytics";
 import { buildAttachmentPrompt } from "../../lib/attachment-message";
 import { classifyFileKind } from "../../lib/file-kind";
-import { tauriAttachments, tauriChat } from "../../lib/tauri";
+import { tauriAttachments, tauriChat, tauriConfig } from "../../lib/tauri";
+import { readAgentTurnMode } from "../../lib/turn-mode";
 import type { AgentDefinition } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 
@@ -53,6 +54,7 @@ export function useArchivedSendMessage({
           mode: mode?.promptFile,
           providerOverride: effectiveProvider,
           modelOverride: effectiveModel,
+          modeOverride: await readAgentTurnMode(agentPath, tauriConfig.read),
         });
         analytics.track("chat_message_sent");
         for (const f of files) {

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -99,11 +99,13 @@ import {
   tauriProvider,
   withAttachmentPaths,
 } from "../lib/tauri";
+import { normalizeTurnMode, type TurnMode } from "../lib/turn-mode";
 import type { Agent, AgentDefinition, SkillSummary } from "../lib/types";
 import { useUIStore } from "../stores/ui";
 import { ChatConnectInteractionCard } from "./chat-connect-interaction-card";
 import { resolveEffectiveProvider } from "./chat-effective-provider";
 import { ChatEffortSelector } from "./chat-effort-selector";
+import { ChatModeSelector } from "./chat-mode-selector";
 import { ChatModelSelector } from "./chat-model-selector";
 import { ContextCompactedDivider } from "./context-compacted-divider";
 import { ContextIndicator } from "./context-indicator";
@@ -182,6 +184,9 @@ interface AgentChatPanelProps {
   /** Effective provider/model for sending. */
   effectiveProvider: string;
   effectiveModel: string;
+  /** The composer's turn mode (execute | plan); consumers forward it as
+   *  `modeOverride` on user-typed sends — an unpinned turn is execute. */
+  turnMode: TurnMode;
   /** Multiplayer only (C5): the signed-in viewer's user id, for attributing
    *  teammates' messages. Undefined when signed out / single-player. */
   currentUserId: ChatPanelProps["currentUserId"];
@@ -246,11 +251,15 @@ export function useAgentChatPanel({
   const [agentProvider, setAgentProvider] = useState<string | null>(null);
   const [agentModel, setAgentModel] = useState<string | null>(null);
   const [agentEffort, setAgentEffort] = useState<string | null>(null);
+  // Composer "Mode" pin (execute/plan). Loaded from config as memory only; the
+  // send path forwards it as `modeOverride`. Unknown/legacy values → execute.
+  const [turnMode, setTurnMode] = useState<TurnMode>("execute");
   useEffect(() => {
     if (!path) {
       setAgentProvider(null);
       setAgentModel(null);
       setAgentEffort(null);
+      setTurnMode("execute");
       return;
     }
     tauriConfig
@@ -259,6 +268,7 @@ export function useAgentChatPanel({
         setAgentProvider((cfg.provider as string) ?? null);
         setAgentModel(normalizeLegacyModel((cfg.model as string) ?? null));
         setAgentEffort((cfg.effort as string) ?? null);
+        setTurnMode(normalizeTurnMode(cfg.mode));
       })
       .catch(() => {});
   }, [path]);
@@ -572,6 +582,27 @@ export function useAgentChatPanel({
     },
     [path, addToast, t],
   );
+  const handleModeSelect = useCallback(
+    async (mode: TurnMode) => {
+      // Mode is per-agent composer memory (never synced to engine Settings):
+      // persist it so the pill reopens where the user left it. Optimistic flip;
+      // the actual plan/execute pin rides each send as `modeOverride`.
+      setTurnMode(mode);
+      try {
+        if (path) {
+          const cfg = await tauriConfig.read(path);
+          await tauriConfig.write(path, { ...cfg, mode });
+        }
+      } catch (err) {
+        addToast({
+          title: t("chat:errors.modelPersistFailed"),
+          description: String(err),
+          variant: "error",
+        });
+      }
+    },
+    [path, addToast, t],
+  );
 
   // Route a composer model / effort pick. In personal (Teams) mode it writes the
   // acting user's per-agent choice (the gateway clamps it to the ceiling and
@@ -699,6 +730,7 @@ export function useAgentChatPanel({
           providerOverride: effectiveProvider,
           modelOverride: effectiveModel,
           effortOverride: effectiveEffort,
+          modeOverride: turnMode,
         });
       } else {
         // New conversation: createMission with `title` override so the
@@ -721,6 +753,7 @@ export function useAgentChatPanel({
             providerOverride: effectiveProvider,
             modelOverride: effectiveModel,
             effortOverride: effectiveEffort,
+            modeOverride: turnMode,
             buildPrompt: async (activityId) => {
               const paths = await tauriAttachments.save(
                 `activity-${activityId}`,
@@ -755,6 +788,7 @@ export function useAgentChatPanel({
       effectiveProvider,
       effectiveModel,
       effectiveEffort,
+      turnMode,
       queryClient,
     ],
   );
@@ -789,6 +823,7 @@ export function useAgentChatPanel({
           providerOverride: effectiveProvider,
           modelOverride: effectiveModel,
           effortOverride: effectiveEffort,
+          modeOverride: turnMode,
         })
         .catch((err) => {
           addToast({
@@ -804,6 +839,7 @@ export function useAgentChatPanel({
       effectiveProvider,
       effectiveModel,
       effectiveEffort,
+      turnMode,
       addToast,
       t,
     ],
@@ -848,6 +884,7 @@ export function useAgentChatPanel({
           providerOverride: effectiveProvider,
           modelOverride: effectiveModel,
           effortOverride: effectiveEffort,
+          modeOverride: turnMode,
         })
         .catch((err) => {
           addToast({
@@ -862,6 +899,7 @@ export function useAgentChatPanel({
       effectiveProvider,
       effectiveModel,
       effectiveEffort,
+      turnMode,
       addToast,
       t,
     ],
@@ -991,6 +1029,7 @@ export function useAgentChatPanel({
                 providerOverride: effectiveProvider,
                 modelOverride: effectiveModel,
                 effortOverride: effectiveEffort,
+                modeOverride: turnMode,
               });
             }}
             onSwitchModel={
@@ -1033,6 +1072,7 @@ export function useAgentChatPanel({
                 providerOverride: effectiveProvider,
                 modelOverride: effectiveModel,
                 effortOverride: effectiveEffort,
+                modeOverride: turnMode,
                 // A refused not-connected send left its prompt's bubble in
                 // the feed already — resending it must not add a second one.
                 suppressUserBubble: resendsOriginalPrompt(providerError),
@@ -1052,6 +1092,7 @@ export function useAgentChatPanel({
       effectiveModel,
       effectiveProvider,
       effectiveEffort,
+      turnMode,
       selectModel,
       path,
       selectedSessionKey,
@@ -1183,6 +1224,11 @@ export function useAgentChatPanel({
           <Play className="size-3 fill-current" />
           {t("composerSkill.browse")}
         </button>
+        <ChatModeSelector
+          mode={turnMode}
+          onSelect={handleModeSelect}
+          agent={agent}
+        />
         <ChatModelSelector
           provider={displayModelPin.provider}
           model={displayModelPin.model}
@@ -1213,6 +1259,8 @@ export function useAgentChatPanel({
     displayModelPin,
     selectModel,
     selectEffort,
+    turnMode,
+    handleModeSelect,
     allowedModels,
     contextUsage,
     contextWindow,
@@ -1288,6 +1336,7 @@ export function useAgentChatPanel({
     pickerDialog,
     effectiveProvider,
     effectiveModel,
+    turnMode,
     currentUserId,
     authorLabels,
   };

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -19,7 +19,9 @@ import {
   tauriActivity,
   tauriAttachments,
   tauriChat,
+  tauriConfig,
 } from "../lib/tauri";
+import { readAgentTurnMode } from "../lib/turn-mode";
 import type { Agent } from "../lib/types";
 import { useAgentCatalogStore } from "../stores/agent-catalog";
 import { useUIStore } from "../stores/ui";
@@ -195,6 +197,12 @@ export function useMissionControl(agents: Agent[]) {
         // in agreement.
         const list = await tauriActivity.list(agentPath);
         const overrides = resolveActivityOverride(sessionKey, list);
+        // Mode is per-agent composer memory (config.mode), not per-activity:
+        // Mission Control has no live pill state, so read it at send time.
+        overrides.modeOverride = await readAgentTurnMode(
+          agentPath,
+          tauriConfig.read,
+        );
         // The turn stream pushes the user bubble into the conversation VM
         // itself — no app-side optimistic push. If the conversation is
         // mid-turn the adapter holds this send; the queued bubble shows the
@@ -260,6 +268,8 @@ export function useMissionControl(agents: Agent[]) {
             promptFile: opts?.promptFile,
             providerOverride: opts?.providerOverride,
             modelOverride: opts?.modelOverride,
+            // Per-agent composer memory; Mission Control has no pill state.
+            modeOverride: await readAgentTurnMode(agentPath, tauriConfig.read),
             titleText: visible,
             buildPrompt: async (activityId) => {
               const saved = await tauriAttachments.save(

--- a/app/src/data/config.ts
+++ b/app/src/data/config.ts
@@ -11,6 +11,14 @@ export interface Config {
   // sit in older on-disk configs. It is tolerated on read and normalized to
   // `xhigh` at the UI boundary (see `normalizeEffort`), so it stays here.
   effort?: "low" | "medium" | "high" | "xhigh" | "max";
+  /**
+   * Composer "Mode" selector memory ONLY: the last mode the user picked for this
+   * agent, so the pill reopens where they left it. Per-agent, local. It is NEVER
+   * synced to engine Settings — the actual plan/execute pin rides each send as
+   * `modeOverride` (an unpinned turn is `execute`). Unknown values normalize to
+   * `execute` at the UI boundary (see `normalizeTurnMode`).
+   */
+  mode?: "execute" | "plan";
   [extra: string]: unknown;
 }
 

--- a/app/src/lib/agent-provisioning.ts
+++ b/app/src/lib/agent-provisioning.ts
@@ -63,6 +63,8 @@ export interface PendingWarmingSend {
   provider?: string;
   model?: string;
   effort?: string;
+  /** Per-turn mode pin (composer "Mode" selector), forwarded at flush time. */
+  mode?: "execute" | "plan";
 }
 
 export interface ProvisioningEntry {

--- a/app/src/lib/create-mission-warming.ts
+++ b/app/src/lib/create-mission-warming.ts
@@ -69,6 +69,7 @@ export function createMissionWhileWarming(
       provider: opts.providerOverride,
       model: opts.modelOverride,
       effort: opts.effortOverride,
+      mode: opts.modeOverride,
     });
   if (!queued) {
     // The agent turned ready between the caller's provisioning check and the
@@ -104,6 +105,7 @@ export function createMissionWhileWarming(
         providerOverride: opts.providerOverride,
         modelOverride: opts.modelOverride,
         effortOverride: opts.effortOverride,
+        modeOverride: opts.modeOverride,
       });
     })().catch(() => {
       // tauriChat.send toasted the real reason already.

--- a/app/src/lib/create-mission.ts
+++ b/app/src/lib/create-mission.ts
@@ -71,6 +71,8 @@ export interface CreateMissionOptions {
   modelOverride?: string;
   /** Reasoning-effort override forwarded to tauriChat.send. */
   effortOverride?: string;
+  /** Per-turn mode pin (composer "Mode" selector) forwarded to tauriChat.send. */
+  modeOverride?: "execute" | "plan";
   /**
    * Explicit activity title. Overrides the default `autoTitleFromText(text)`.
    * Used by action invocations where `text` is a structured marker that
@@ -131,6 +133,7 @@ export async function createMission(
       providerOverride: opts.providerOverride,
       modelOverride: opts.modelOverride,
       effortOverride: opts.effortOverride,
+      modeOverride: opts.modeOverride,
     });
 
     analytics.track("mission_created", { agent_mode: opts.agentMode });

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -347,6 +347,13 @@ export const tauriChat = {
       providerOverride?: string;
       modelOverride?: string;
       effortOverride?: string;
+      /**
+       * Per-turn mode pin (composer "Mode" selector). `"plan"` pins a read-only
+       * planning turn; `"execute"` (or omitted) is a normal turn. Distinct from
+       * the legacy `mode`/`promptFile` opts above (Rust-era prompt profiles,
+       * dropped at this boundary) — never collides with them.
+       */
+      modeOverride?: "execute" | "plan";
       /** Resend of a prompt whose bubble is already in the feed (see SessionStartRequest). */
       suppressUserBubble?: boolean;
       /** Queue display (user's words + attachment names) if the send is held (see SessionStartRequest). */
@@ -366,6 +373,7 @@ export const tauriChat = {
         provider: opts?.providerOverride,
         model: opts?.modelOverride,
         effort: opts?.effortOverride,
+        mode: opts?.modeOverride,
         suppressUserBubble: opts?.suppressUserBubble,
         queuedPreview: opts?.queuedPreview,
       });

--- a/app/src/lib/turn-mode.ts
+++ b/app/src/lib/turn-mode.ts
@@ -1,0 +1,40 @@
+/**
+ * Turn mode — the composer "Mode" selector's two states.
+ *
+ * `execute` is a normal turn (Houston can read, act, and change things).
+ * `plan` pins a read-only planning turn: the runtime restricts the turn to
+ * read-only tools and a planning overlay via the per-turn pin. An UNPINNED
+ * turn is always `execute`, so `plan` only takes effect on sends that forward
+ * it as `modeOverride`.
+ *
+ * The user's last pick is remembered per-agent in `.houston/config` (composer
+ * memory only — never synced to engine Settings), so unknown/legacy values on
+ * read normalize back to `execute`.
+ */
+export type TurnMode = "execute" | "plan";
+
+export const DEFAULT_TURN_MODE: TurnMode = "execute";
+
+/** Tolerant read: only the exact `"plan"` string is plan; anything else (a
+ *  stale value, `undefined`, a typo) falls back to `execute`. */
+export function normalizeTurnMode(value: unknown): TurnMode {
+  return value === "plan" ? "plan" : "execute";
+}
+
+/**
+ * The agent's remembered turn mode, for send paths that assemble their own
+ * overrides (Mission Control, archived resumes) instead of holding the chat
+ * panel's live pill state. A failed config read falls back to `execute` — the
+ * safe default for a preference lookup; the send itself still surfaces its own
+ * errors.
+ */
+export async function readAgentTurnMode(
+  agentPath: string,
+  readConfig: (path: string) => Promise<{ mode?: string }>,
+): Promise<TurnMode> {
+  try {
+    return normalizeTurnMode((await readConfig(agentPath)).mode);
+  } catch {
+    return DEFAULT_TURN_MODE;
+  }
+}

--- a/app/src/lib/warming-sends.ts
+++ b/app/src/lib/warming-sends.ts
@@ -48,6 +48,7 @@ export interface QueueWarmingSendArgs {
   provider?: string;
   model?: string;
   effort?: string;
+  mode?: "execute" | "plan";
 }
 
 /**
@@ -68,6 +69,7 @@ export function buildWarmingSend(
     provider: args.provider,
     model: args.model,
     effort: args.effort,
+    mode: args.mode,
   };
   if (args.buildPrompt) promptBuilders.set(send.id, args.buildPrompt);
   return send;
@@ -151,6 +153,7 @@ export async function flushWarmingSends(
         providerOverride: send.provider,
         modelOverride: send.model,
         effortOverride: send.effort,
+        modeOverride: send.mode,
         suppressUserBubble: suppress,
       });
     } catch (e) {

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -72,6 +72,14 @@
     "signedIn": "Signed in",
     "signIn": "Sign in"
   },
+  "modeSelector": {
+    "mode": "Mode",
+    "modeValue": "Mode: {{mode}}",
+    "chat": "Chat",
+    "chatDescription": "Houston can read, act, and make changes.",
+    "plan": "Plan",
+    "planDescription": "Houston only looks and writes up a plan for you to approve. It won't make changes or use your apps."
+  },
   "modelSelector": {
     "selectModel": "Select model",
     "model": "Model",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -72,6 +72,14 @@
     "signedIn": "Conectado",
     "signIn": "Iniciar sesión"
   },
+  "modeSelector": {
+    "mode": "Modo",
+    "modeValue": "Modo: {{mode}}",
+    "chat": "Chat",
+    "chatDescription": "Houston puede leer, actuar y hacer cambios.",
+    "plan": "Plan",
+    "planDescription": "Houston solo mira y escribe un plan para que lo apruebes. No hará cambios ni usará tus aplicaciones."
+  },
   "modelSelector": {
     "selectModel": "Elige un modelo",
     "model": "Modelo",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -72,6 +72,14 @@
     "signedIn": "Conectado",
     "signIn": "Entrar"
   },
+  "modeSelector": {
+    "mode": "Modo",
+    "modeValue": "Modo: {{mode}}",
+    "chat": "Chat",
+    "chatDescription": "O Houston pode ler, agir e fazer alterações.",
+    "plan": "Plano",
+    "planDescription": "O Houston apenas observa e escreve um plano para você aprovar. Ele não fará alterações nem usará seus aplicativos."
+  },
   "modelSelector": {
     "selectModel": "Escolha um modelo",
     "model": "Modelo",

--- a/app/tests/turn-mode.test.ts
+++ b/app/tests/turn-mode.test.ts
@@ -1,0 +1,59 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  DEFAULT_TURN_MODE,
+  normalizeTurnMode,
+  readAgentTurnMode,
+} from "../src/lib/turn-mode.ts";
+
+// The composer "Mode" pin is loaded from per-agent config, which is untyped on
+// disk. `normalizeTurnMode` is the read-side guard: only the exact `"plan"`
+// string is plan; everything else falls back to execute so a stale or garbage
+// value never strands the composer in an unknown mode.
+describe("normalizeTurnMode", () => {
+  it("keeps the two known modes", () => {
+    strictEqual(normalizeTurnMode("plan"), "plan");
+    strictEqual(normalizeTurnMode("execute"), "execute");
+  });
+
+  it("normalizes absent / unset values to execute", () => {
+    strictEqual(normalizeTurnMode(undefined), "execute");
+    strictEqual(normalizeTurnMode(null), "execute");
+    strictEqual(normalizeTurnMode(""), "execute");
+  });
+
+  it("normalizes unknown / legacy / wrong-typed values to execute", () => {
+    strictEqual(normalizeTurnMode("planning"), "execute");
+    strictEqual(normalizeTurnMode("Plan"), "execute"); // case-sensitive
+    strictEqual(normalizeTurnMode("readonly"), "execute");
+    strictEqual(normalizeTurnMode(42), "execute");
+    strictEqual(normalizeTurnMode({ mode: "plan" }), "execute");
+  });
+
+  it("defaults to execute (unpinned turns are execute)", () => {
+    strictEqual(DEFAULT_TURN_MODE, "execute");
+  });
+});
+
+describe("readAgentTurnMode", () => {
+  it("reads and normalizes the agent's remembered mode", async () => {
+    strictEqual(
+      await readAgentTurnMode("Agent", async () => ({ mode: "plan" })),
+      "plan",
+    );
+    strictEqual(
+      await readAgentTurnMode("Agent", async () => ({ mode: "legacy" })),
+      "execute",
+    );
+    strictEqual(await readAgentTurnMode("Agent", async () => ({})), "execute");
+  });
+
+  it("falls back to execute when the config read fails", async () => {
+    strictEqual(
+      await readAgentTurnMode("Agent", async () => {
+        throw new Error("missing config");
+      }),
+      "execute",
+    );
+  });
+});

--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -119,6 +119,17 @@ export interface Settings {
   effort?: string;
 }
 
+/**
+ * Per-turn agent execution mode. "execute" = full read/write/act (the default
+ * and today's only behavior for unpinned turns — routines and cloud turns never
+ * inherit plan); "plan" = read-only tools plus a planning overlay, producing a
+ * plan for the user to approve. Deliberately NOT part of `Settings`: mode rides
+ * the per-turn pin only, so an unpinned turn is always "execute".
+ */
+export type TurnMode = "execute" | "plan";
+export const TURN_MODES: readonly TurnMode[] = ["execute", "plan"];
+export const DEFAULT_TURN_MODE: TurnMode = "execute";
+
 export type ChatRole = "user" | "assistant";
 
 export interface ToolCallRecord {

--- a/packages/runtime-client/src/client-send.test.ts
+++ b/packages/runtime-client/src/client-send.test.ts
@@ -44,4 +44,13 @@ test("a pin-less sendMessage omits the pin fields entirely", async () => {
   // JSON.stringify drops undefined values — the runtime must see NO pin keys,
   // so its `typeof x === "string"` guards leave the turn on its own resolution.
   expect(bodies[0]).toEqual({ text: "hi", nonce: "n1" });
+  // The plan-mode pin is part of that contract: an unpinned send carries NO
+  // `mode` key, so the runtime defaults the turn to "execute".
+  expect(bodies[0]).not.toHaveProperty("mode");
+});
+
+test("sendMessage carries the per-turn plan mode on the wire", async () => {
+  const { client, bodies } = capture();
+  await client.sendMessage("c1", "hi", { nonce: "n1", mode: "plan" });
+  expect(bodies[0]).toEqual({ text: "hi", nonce: "n1", mode: "plan" });
 });

--- a/packages/runtime-client/src/client.ts
+++ b/packages/runtime-client/src/client.ts
@@ -54,6 +54,13 @@ export interface SendOptions {
   model?: string;
   /** Per-turn reasoning-effort pin. */
   effort?: string;
+  /**
+   * Per-turn execution mode. "execute" (the default for an unpinned turn) =
+   * full read/write/act; "plan" = read-only tools plus a planning overlay.
+   * Omitted, the runtime runs the turn as "execute". Mirrors the protocol's
+   * `TurnMode` (kept inline — this package stays zero-dep, like `effort`).
+   */
+  mode?: "execute" | "plan";
   signal?: AbortSignal;
 }
 
@@ -300,6 +307,7 @@ export class HoustonEngineClient {
         provider: opts.provider,
         model: opts.model,
         effort: opts.effort,
+        mode: opts.mode,
       }),
       signal: opts.signal,
     });

--- a/packages/runtime/src/backends/claude/backend-mcp.test.ts
+++ b/packages/runtime/src/backends/claude/backend-mcp.test.ts
@@ -44,10 +44,13 @@ const model: ResolvedModel = {
   contextWindow: 200_000,
 };
 
-async function runTurn(integrations?: {
-  baseUrl: string;
-  sandboxToken: string;
-}): Promise<Options> {
+async function runTurn(
+  integrations?: {
+    baseUrl: string;
+    sandboxToken: string;
+  },
+  mode?: "execute" | "plan",
+): Promise<Options> {
   h.capturedOptions = undefined;
   h.capturedMcp = undefined;
   const root = mkdtempSync(join(tmpdir(), "houston-mcp-test-"));
@@ -59,7 +62,11 @@ async function runTurn(integrations?: {
     systemPrompt: "system",
     integrations,
   });
-  const session = await backend.createSession({ conversationId: "c1", model });
+  const session = await backend.createSession({
+    conversationId: "c1",
+    model,
+    ...(mode ? { mode } : {}),
+  });
   await session.prompt("hi");
   const options = h.capturedOptions;
   if (!options) throw new Error("query was not called");
@@ -88,4 +95,18 @@ test("without the integrations gate only ask_user is allow-listed", async () => 
 test("AskUserQuestion stays disabled — Houston ships its own ask_user", async () => {
   const options = await runTurn(undefined);
   expect(options.disallowedTools).toContain("AskUserQuestion");
+});
+
+test("plan mode builds the MCP server WITHOUT integrations — only ask_user", async () => {
+  // Even with the integrations gate present, plan mode withholds the integration
+  // tools (they act on the user's connected apps), leaving just ask_user.
+  const options = await runTurn(
+    { baseUrl: "http://host.local", sandboxToken: "tok" },
+    "plan",
+  );
+  expect(options.mcpServers?.houston).toBeDefined();
+  expect(options.allowedTools).toEqual(["mcp__houston__ask_user"]);
+  expect(h.capturedMcp?.tools.map((t) => t.name)).toEqual(["ask_user"]);
+  // And the built-ins are the read-only plan subset.
+  expect(options.tools).toEqual(["Read", "Glob", "Grep"]);
 });

--- a/packages/runtime/src/backends/claude/backend.ts
+++ b/packages/runtime/src/backends/claude/backend.ts
@@ -80,14 +80,18 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
         // `createSdkMcpServer` is only touched once the SDK is confirmed present.
         houstonMcp = buildHoustonMcpServer({
           createSdkMcpServer: sdk.createSdkMcpServer,
-          integrations: deps.integrations,
+          // Plan mode is read-only + takes no real-world action, so the MCP
+          // server exposes only `ask_user` — the integration tools (which act on
+          // the user's connected apps) are withheld exactly as in an unconnected
+          // runtime, mirroring the pi path's `planToolNames` drop.
+          integrations: opts.mode === "plan" ? undefined : deps.integrations,
         });
       } catch (err) {
         throw new ClaudeBackendUnavailableError(err);
       }
 
       const localBash = deps.toolSelection.toolNames.includes("bash");
-      const policy = buildToolPolicy({ localBash });
+      const policy = buildToolPolicy({ localBash, mode: opts.mode });
       // undefined on the Node path (self-host / engine-pod / per-turn Docker +
       // dev/tests): the SDK resolves its own native binary. Only set inside the
       // Bun-compiled desktop sidecar, where require.resolve can't reach it.
@@ -106,7 +110,11 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
         mcpServers: { [HOUSTON_MCP_SERVER_NAME]: houstonMcp.server },
         allowedTools: houstonMcp.allowedTools,
         canUseTool: makeCanUseTool(deps.workspaceDir),
-        systemPrompt: buildSystemPrompt(deps.workspaceDir, deps.systemPrompt),
+        systemPrompt: buildSystemPrompt(
+          deps.workspaceDir,
+          deps.systemPrompt,
+          opts.mode,
+        ),
         includePartialMessages: true,
         permissionMode: "default",
       };

--- a/packages/runtime/src/backends/claude/system-prompt.ts
+++ b/packages/runtime/src/backends/claude/system-prompt.ts
@@ -1,5 +1,7 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import type { TurnMode } from "@houston/protocol";
+import { withPlanOverlay } from "../../session/plan-overlay";
 
 /**
  * Build the full-replace `systemPrompt` string for a Claude session: Houston's
@@ -18,9 +20,16 @@ import { join } from "node:path";
  */
 const CONTEXT_CANDIDATES = ["AGENTS.md", "AGENTS.MD", "CLAUDE.md", "CLAUDE.MD"];
 
-export function buildSystemPrompt(cwd: string, systemPrompt: string): string {
+export function buildSystemPrompt(
+  cwd: string,
+  systemPrompt: string,
+  mode?: TurnMode,
+): string {
   const context = loadWorkspaceContextFile(cwd);
-  return context ? `${systemPrompt}\n\n${context}` : systemPrompt;
+  const base = context ? `${systemPrompt}\n\n${context}` : systemPrompt;
+  // Plan overlay LAST — after Houston's prompt AND the workspace context file —
+  // so its read-only mandate is the final word the model reads.
+  return withPlanOverlay(base, mode);
 }
 
 /** The first workspace-root context file's contents, or null when none exists. */

--- a/packages/runtime/src/backends/claude/tool-policy.test.ts
+++ b/packages/runtime/src/backends/claude/tool-policy.test.ts
@@ -53,6 +53,28 @@ test("buildToolPolicy grants Bash only when code execution is local", () => {
   expect(off.disallowedTools).toContain("Bash");
 });
 
+test("plan mode clamps built-ins to Read/Glob/Grep and denies Edit/Write/Bash", () => {
+  const plan = buildToolPolicy({ localBash: true, mode: "plan" });
+  expect(plan.tools).toEqual(["Read", "Glob", "Grep"]);
+  for (const denied of ["Edit", "Write", "Bash"])
+    expect(plan.disallowedTools).toContain(denied);
+  // The pi-lacking set is still denied on top of the write/exec denials.
+  expect(plan.disallowedTools).toContain("WebSearch");
+  // localBash is irrelevant in plan mode: no Bash either way.
+  const planNoBash = buildToolPolicy({ localBash: false, mode: "plan" });
+  expect(planNoBash.tools).toEqual(["Read", "Glob", "Grep"]);
+  expect(planNoBash.disallowedTools).toContain("Bash");
+});
+
+test("execute mode is unchanged by the added mode param", () => {
+  expect(buildToolPolicy({ localBash: true, mode: "execute" })).toEqual(
+    buildToolPolicy({ localBash: true }),
+  );
+  expect(buildToolPolicy({ localBash: false, mode: "execute" })).toEqual(
+    buildToolPolicy({ localBash: false }),
+  );
+});
+
 test("the pi-lacking Claude Code tools are always disallowed", () => {
   const { disallowedTools } = buildToolPolicy({ localBash: true });
   for (const t of [

--- a/packages/runtime/src/backends/claude/tool-policy.ts
+++ b/packages/runtime/src/backends/claude/tool-policy.ts
@@ -3,6 +3,7 @@ import type {
   CanUseTool,
   PermissionResult,
 } from "@anthropic-ai/claude-agent-sdk";
+import type { TurnMode } from "@houston/protocol";
 import { WorkspaceGuard } from "../../session/tools/fs-guard";
 
 /**
@@ -55,9 +56,18 @@ const PI_LACKS = [
   "SlashCommand",
 ] as const;
 
+/** The read-only file tools plan mode allows (SDK names). No Edit/Write. */
+const PLAN_FILE_TOOLS = ["Read", "Glob", "Grep"] as const;
+
 export interface ToolPolicyInput {
   /** True when code execution is local — the only mode that grants Bash. */
   localBash: boolean;
+  /**
+   * The turn's execution mode. "plan" clamps the SDK built-ins to the read-only
+   * subset (Read/Glob/Grep) and denies Edit/Write/Bash; absent or "execute" is
+   * the full policy gated only by `localBash`.
+   */
+  mode?: TurnMode;
 }
 
 export interface ToolPolicy {
@@ -67,6 +77,16 @@ export interface ToolPolicy {
 
 /** Build the `{ tools, disallowedTools }` SDK options (this object sets no `allowedTools` — see above). */
 export function buildToolPolicy(input: ToolPolicyInput): ToolPolicy {
+  // Plan mode: read-only built-ins only, and deny every write/exec tool. We do
+  // NOT switch the SDK to permissionMode "plan" — that forces the ExitPlanMode
+  // tool (which pi lacks) and the SDK's own plan prompt; Houston keeps
+  // permissionMode "default" and enforces plan via this allowlist + the overlay.
+  if (input.mode === "plan") {
+    return {
+      tools: [...PLAN_FILE_TOOLS],
+      disallowedTools: [...PI_LACKS, "Edit", "Write", "Bash"],
+    };
+  }
   const tools = input.localBash ? [...FILE_TOOLS, "Bash"] : [...FILE_TOOLS];
   // Deny Bash outright when code execution is off, on top of omitting it above.
   const disallowedTools = input.localBash

--- a/packages/runtime/src/backends/pi/backend.ts
+++ b/packages/runtime/src/backends/pi/backend.ts
@@ -8,6 +8,7 @@ import {
   SessionManager,
 } from "@earendil-works/pi-coding-agent";
 import { makeAgentLoader } from "../../session/resource-loader";
+import { planToolNames } from "../../session/tool-selection";
 import type {
   CreateSessionOptions,
   HarnessBackend,
@@ -45,7 +46,12 @@ export function createPiBackend(deps: PiBackendDeps): HarnessBackend {
   return {
     id: "pi",
     async createSession(opts: CreateSessionOptions): Promise<HarnessSession> {
-      const loader = makeAgentLoader(deps.workspaceDir);
+      // Plan mode overlays the planning prompt (via the loader) and clamps the
+      // allowlist to the read-only subset. The customTools list is UNCHANGED —
+      // pi gates its custom tools by the `tools` name allowlist, so filtering
+      // the names here drops edit/write/run_code/integration tools from the
+      // model's reach without rebuilding the tool objects.
+      const loader = makeAgentLoader(deps.workspaceDir, opts.mode);
       await loader.reload();
       const { session } = await createAgentSession({
         cwd: deps.workspaceDir,
@@ -59,7 +65,7 @@ export function createPiBackend(deps: PiBackendDeps): HarnessBackend {
           join(deps.dataDir, "sessions", opts.conversationId),
         ),
         resourceLoader: loader,
-        tools: deps.tools,
+        tools: opts.mode === "plan" ? planToolNames(deps.tools) : deps.tools,
         customTools: deps.customTools,
       });
       return new PiSession(session);

--- a/packages/runtime/src/backends/types.ts
+++ b/packages/runtime/src/backends/types.ts
@@ -1,3 +1,4 @@
+import type { TurnMode } from "@houston/protocol";
 import type { WireEvent } from "@houston/runtime-client";
 import type { PiThinkingLevel } from "../ai/effort";
 
@@ -60,6 +61,13 @@ export interface CreateSessionOptions {
   conversationId: string;
   model: ResolvedModel;
   thinkingLevel?: ThinkingLevel;
+  /**
+   * The turn's execution mode. "plan" opens the session with the read-only tool
+   * subset + the planning prompt overlay; absent or "execute" is the full
+   * read/write/act session. A mode change on a live conversation rebuilds the
+   * session (see `switchModeIfNeeded`), so this is fixed for the session's life.
+   */
+  mode?: TurnMode;
 }
 
 /** A pluggable turn-execution backend for a provider. */

--- a/packages/runtime/src/session/backend-switch.test.ts
+++ b/packages/runtime/src/session/backend-switch.test.ts
@@ -107,6 +107,7 @@ function convWith(session: SpySession, provider: string, model: string) {
     provider,
     model,
     backendId: session.backendId,
+    mode: "execute",
   } as unknown as Conversation;
 }
 

--- a/packages/runtime/src/session/conversation-cache.ts
+++ b/packages/runtime/src/session/conversation-cache.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_TURN_MODE, type TurnMode } from "@houston/protocol";
 import { resolveModel } from "../ai/providers";
 import { authStorage, modelRegistry } from "../auth/storage";
 import { createClaudeBackend } from "../backends/claude/backend";
@@ -143,6 +144,14 @@ export type Conversation = {
    */
   backendId: string;
   /**
+   * The execution mode the live session was built with ("execute" by default,
+   * "plan" for a read-only planning session). A per-turn mode flip that differs
+   * from this REBUILDS the session on the same backend — plan and execute need
+   * different tool allowlists + system prompts, which are fixed at build time.
+   * See `switchModeIfNeeded`.
+   */
+  mode: TurnMode;
+  /**
    * The wire id of the turn EXECUTING right now (undefined between turns).
    * cancelTurn stamps it on the "Stopped by user" terminal frame so the stop
    * settles the turn it actually interrupts, not whatever a client guesses.
@@ -169,9 +178,13 @@ export async function getConversation(
   // session through it. The backend rehydrates prior turns from disk when the
   // conversation already exists — see createPiBackend.
   const backend = backendFor(builtModel.provider);
+  // The first turn's mode fixes how the session is built (read-only + planning
+  // overlay for "plan"). A later flip rebuilds via `switchModeIfNeeded`.
+  const mode = pin?.mode ?? DEFAULT_TURN_MODE;
   const session = await backend.createSession({
     conversationId: id,
     model: builtModel,
+    mode,
   });
 
   const conv: Conversation = {
@@ -180,6 +193,7 @@ export async function getConversation(
     provider: builtModel.provider,
     model: builtModel.id,
     backendId: backend.id,
+    mode,
   };
   conversations.set(id, conv);
   return conv;
@@ -208,6 +222,7 @@ export async function switchBackendIfNeeded(
   conv: Conversation,
   conversationId: string,
   model: ResolvedModel,
+  mode: TurnMode,
 ): Promise<{ rebuilt: boolean; preTokens: number | null }> {
   const backend = backendFor(model.provider);
   if (backend.id === conv.backendId) return { rebuilt: false, preTokens: null };
@@ -216,12 +231,50 @@ export async function switchBackendIfNeeded(
   // so the switch can still be sized against the new model's window downstream.
   const preTokens = conv.session.getContextUsage()?.tokens ?? null;
   conv.session.dispose();
+  // Build the new backend's session directly at the requested mode, so a switch
+  // that ALSO flips mode lands on it in ONE rebuild — `switchModeIfNeeded` then
+  // no-ops (conv.mode is already the requested mode).
   conv.session = await backend.createSession({
     conversationId,
     model,
+    mode,
   });
   conv.backendId = backend.id;
   conv.provider = model.provider;
   conv.model = model.id;
+  conv.mode = mode;
   return { rebuilt: true, preTokens };
+}
+
+/**
+ * Ensure the live session sits in the requested execution mode, REBUILDING it on
+ * the SAME backend when the mode flips (execute ⇄ plan). Plan and execute differ
+ * in the tool allowlist AND the system prompt — both fixed at session-build time
+ * — so a flip cannot be applied to a live session; it is rebuilt.
+ *
+ * History is NOT lost across the rebuild: the backend reopens THIS conversation's
+ * persisted session by id (pi via `SessionManager.continueRecent` on the
+ * conversation's dedicated sessions dir; Claude via its `sessions.json` +
+ * transcript store keyed by conversationId), so prior turns rehydrate into the
+ * fresh session. Nothing is cleared here.
+ *
+ * A mode flip is INTERNAL — same provider, same model — so it emits NO
+ * `provider_switched` frame (unlike a cross-backend switch). No-op when the mode
+ * is unchanged, so the common execute→execute turn keeps the live session.
+ */
+export async function switchModeIfNeeded(
+  conv: Conversation,
+  conversationId: string,
+  model: ResolvedModel,
+  mode: TurnMode,
+): Promise<{ rebuilt: boolean }> {
+  if (conv.mode === mode) return { rebuilt: false };
+  conv.session.dispose();
+  conv.session = await backendFor(model.provider).createSession({
+    conversationId,
+    model,
+    mode,
+  });
+  conv.mode = mode;
+  return { rebuilt: true };
 }

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -44,6 +44,7 @@ vi.mock("./conversation-cache", () => ({
     rebuilt: false,
     preTokens: null,
   })),
+  switchModeIfNeeded: vi.fn(async () => ({ rebuilt: false })),
 }));
 
 // The durable store is irrelevant to the frame contract under test.
@@ -57,6 +58,7 @@ const { execTurn } = await import("./exec-turn");
 const { subscribe } = await import("./bus");
 const { recordQuestions, recordConnection } = await import("./interaction");
 const { appendAssistantMessage } = await import("../store/conversations");
+const { switchModeIfNeeded } = await import("./conversation-cache");
 
 afterAll(() => vi.restoreAllMocks());
 
@@ -101,6 +103,7 @@ function fakeConv(
     provider: "openai",
     model: "gpt-x",
     backendId: "pi",
+    mode: "execute",
   } as Conv;
 }
 
@@ -178,6 +181,38 @@ test("a provider_error turn emits no done — the pending interaction never ride
   expect(events.some((e) => e.type === "provider_error")).toBe(true);
   // The recorded interaction must NOT be persisted on a failed turn either.
   expect(persistedInteraction(id)).toBeUndefined();
+});
+
+test("pin.mode is threaded into switchModeIfNeeded for the turn", async () => {
+  vi.mocked(switchModeIfNeeded).mockClear();
+  const id = "exec-mode-plan";
+  const conv = fakeConv((emit) => emit({ type: "text", data: "planning" }));
+
+  await execTurn(
+    conv,
+    id,
+    "turn-1",
+    "plan it",
+    { author: undefined, priorAuthors: [] },
+    { mode: "plan" },
+  );
+
+  expect(switchModeIfNeeded).toHaveBeenCalledTimes(1);
+  // (conv, id, model, mode) — the pin's "plan" reaches the mode arg.
+  expect(vi.mocked(switchModeIfNeeded).mock.calls[0][3]).toBe("plan");
+});
+
+test("an absent pin defaults the turn to execute mode", async () => {
+  vi.mocked(switchModeIfNeeded).mockClear();
+  const id = "exec-mode-default";
+  const conv = fakeConv((emit) => emit({ type: "text", data: "doing" }));
+
+  await execTurn(conv, id, "turn-1", "do it", {
+    author: undefined,
+    priorAuthors: [],
+  });
+
+  expect(vi.mocked(switchModeIfNeeded).mock.calls[0][3]).toBe("execute");
 });
 
 test("a thrown turn emits an error frame and no done", async () => {

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_TURN_MODE, type TurnMode } from "@houston/protocol";
 import { effectiveModelWindow } from "@houston/protocol/model-windows";
 import type {
   ChatMessage,
@@ -22,7 +23,11 @@ import {
 } from "./attribution";
 import { needsAutocompact } from "./autocompact";
 import { publish } from "./bus";
-import { type Conversation, switchBackendIfNeeded } from "./conversation-cache";
+import {
+  type Conversation,
+  switchBackendIfNeeded,
+  switchModeIfNeeded,
+} from "./conversation-cache";
 import {
   diffSnapshots,
   type FileSnapshot,
@@ -37,6 +42,12 @@ export interface TurnPin {
   provider?: string | null;
   model?: string | null;
   effort?: string | null;
+  /**
+   * The turn's execution mode ("plan" = read-only + planning overlay). Rides the
+   * per-turn pin ONLY — never `Settings` — so an unpinned turn is always
+   * "execute". A flip from the live session's mode rebuilds the session.
+   */
+  mode?: TurnMode | null;
 }
 
 /**
@@ -179,6 +190,9 @@ export async function execTurn(
     // firing on ITS provider no matter what other chats picked in between.
     // A bad model id throws here → surfaces as the turn's error event.
     const model = resolveModel(pin?.model, pin?.provider);
+    // The turn's execution mode: the pin's, else execute. Never inherited from
+    // Settings — an unpinned turn (incl. every routine + cloud turn) is execute.
+    const mode = pin?.mode ?? DEFAULT_TURN_MODE;
     const providerChanged = model.provider !== conv.provider;
     const modelChanged = model.id !== conv.model;
     // COMPLIANCE GATE: when this turn's model crosses a BACKEND boundary
@@ -186,10 +200,17 @@ export async function execTurn(
     // the correct backend rather than `setModel` a foreign model into the live
     // one — the harness-spoofing route the whole backend seam exists to prevent.
     // A same-backend change falls through to the cheap `setModel` fast path below.
+    // The rebuild lands directly on `mode`, so a switch that also flips mode is a
+    // single rebuild and `switchModeIfNeeded` below then no-ops.
     const { rebuilt, preTokens: rebuiltPreTokens } =
-      await switchBackendIfNeeded(conv, id, model);
+      await switchBackendIfNeeded(conv, id, model, mode);
+    // MODE FLIP: a plan⇄execute change on the SAME backend rebuilds the session
+    // read-only (or back). History rehydrates from disk; no provider_switched
+    // frame (same provider/model). No-op when the mode is unchanged — including
+    // right after a cross-backend rebuild that already landed on `mode`.
+    await switchModeIfNeeded(conv, id, model, mode);
     // Attach the turn's listeners to the SETTLED session (the rebuilt one when we
-    // crossed a backend, else the session we entered with).
+    // crossed a backend or flipped mode, else the session we entered with).
     subscribeSession();
     if (rebuilt) {
       // Cross-backend rebuild: the new session starts fresh (no in-memory history

--- a/packages/runtime/src/session/mode-switch.test.ts
+++ b/packages/runtime/src/session/mode-switch.test.ts
@@ -1,0 +1,292 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { TurnMode } from "@houston/protocol";
+import type { WireEvent } from "@houston/runtime-client";
+import { afterEach, expect, test, vi } from "vitest";
+import type {
+  CreateSessionOptions,
+  HarnessBackend,
+  HarnessSession,
+  ResolvedModel,
+} from "../backends/types";
+
+/**
+ * PLAN MODE — the per-turn mode flip rebuilds the session read-only while
+ * preserving history, emits no provider_switched frame, and a cross-backend
+ * switch that ALSO flips mode lands on the requested mode in ONE rebuild.
+ *
+ * History carryover is the load-bearing guarantee: a real backend reopens THIS
+ * conversation's persisted session by id on rebuild (pi via continueRecent, the
+ * Claude store keyed by conversationId), so prior turns rehydrate. The fake
+ * backend here models that with a per-conversation "disk" the rebuilt session
+ * re-attaches to — proving switchModeIfNeeded keys the rebuild by conversationId
+ * and clears nothing.
+ */
+
+process.env.HOUSTON_DATA_DIR = mkdtempSync(
+  join(tmpdir(), "houston-mode-data-"),
+);
+process.env.HOUSTON_WORKSPACE_DIR = mkdtempSync(
+  join(tmpdir(), "houston-mode-ws-"),
+);
+
+const modelState = vi.hoisted(() => ({ model: null as ResolvedModel | null }));
+vi.mock("../ai/providers", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../ai/providers")>();
+  return {
+    ...real,
+    resolveModel: () => modelState.model,
+    activeEffort: () => null,
+  };
+});
+
+await import("./conversation-cache");
+const { execTurn } = await import("./exec-turn");
+const { switchModeIfNeeded, getConversation, conversations } = await import(
+  "./conversation-cache"
+);
+const { registerBackend, setDefaultBackend } = await import(
+  "../backends/registry"
+);
+const { subscribe } = await import("./bus");
+type Conversation = import("./conversation-cache").Conversation;
+
+/**
+ * A session backed by a shared per-conversation "disk": its `prompts` array is
+ * the conversation's transcript, so a rebuilt session for the same id re-attaches
+ * to the SAME transcript — modeling on-disk rehydration (continueRecent / the
+ * Claude store). Records the mode it was built at + dispose.
+ */
+class HistSession implements HarnessSession {
+  disposed = false;
+  private listeners = new Set<(e: WireEvent) => void>();
+  constructor(
+    readonly backendId: string,
+    readonly builtMode: TurnMode,
+    readonly prompts: string[],
+  ) {}
+  subscribe(l: (e: WireEvent) => void): () => void {
+    this.listeners.add(l);
+    return () => {
+      this.listeners.delete(l);
+    };
+  }
+  async prompt(text: string): Promise<void> {
+    this.prompts.push(text);
+  }
+  async abort(): Promise<void> {}
+  dispose(): void {
+    this.disposed = true;
+    this.listeners.clear();
+  }
+  async setModel(): Promise<void> {}
+  async compact(): Promise<void> {}
+  setThinkingLevel(): void {}
+  getContextUsage(): { tokens: number | null } {
+    return { tokens: 0 };
+  }
+}
+
+/** A backend whose sessions rehydrate from a shared per-conversation disk. */
+function histBackend(
+  id: string,
+  disk: Map<string, string[]>,
+  built: HistSession[],
+): HarnessBackend {
+  return {
+    id,
+    async createSession(opts: CreateSessionOptions): Promise<HarnessSession> {
+      const transcript = disk.get(opts.conversationId) ?? [];
+      disk.set(opts.conversationId, transcript);
+      const s = new HistSession(id, opts.mode ?? "execute", transcript);
+      built.push(s);
+      return s;
+    },
+  };
+}
+
+afterEach(() => {
+  modelState.model = null;
+  conversations.clear();
+});
+
+const OPENAI: ResolvedModel = {
+  provider: "openai-codex",
+  id: "gpt-5-codex",
+  contextWindow: 400_000,
+};
+const ANTHROPIC: ResolvedModel = {
+  provider: "anthropic",
+  id: "claude-sonnet-4-5",
+  contextWindow: 200_000,
+};
+
+test("switchModeIfNeeded no-ops when the mode is unchanged", async () => {
+  const disk = new Map<string, string[]>();
+  const built: HistSession[] = [];
+  setDefaultBackend(histBackend("pi", disk, built));
+  const session = new HistSession("pi", "execute", []);
+  const conv = {
+    session,
+    queue: Promise.resolve(),
+    provider: "openai-codex",
+    model: "gpt-5-codex",
+    backendId: "pi",
+    mode: "execute",
+  } as unknown as Conversation;
+
+  const res = await switchModeIfNeeded(conv, "c", OPENAI, "execute");
+  expect(res.rebuilt).toBe(false);
+  expect(session.disposed).toBe(false);
+  expect(conv.session).toBe(session);
+  expect(built).toHaveLength(0);
+});
+
+test("switchModeIfNeeded rebuilds on a flip and the rebuilt session keeps prior history", async () => {
+  const disk = new Map<string, string[]>([["c", ["earlier turn"]]]);
+  const built: HistSession[] = [];
+  setDefaultBackend(histBackend("pi", disk, built));
+  const session = new HistSession("pi", "execute", disk.get("c") as string[]);
+  const conv = {
+    session,
+    queue: Promise.resolve(),
+    provider: "openai-codex",
+    model: "gpt-5-codex",
+    backendId: "pi",
+    mode: "execute",
+  } as unknown as Conversation;
+
+  const res = await switchModeIfNeeded(conv, "c", OPENAI, "plan");
+  expect(res.rebuilt).toBe(true);
+  expect(session.disposed).toBe(true);
+  expect(conv.mode).toBe("plan");
+  expect(built).toHaveLength(1);
+  // Rebuilt read-only, and the prior turn rehydrated (same conversation disk).
+  expect(built[0].builtMode).toBe("plan");
+  expect(built[0].prompts).toEqual(["earlier turn"]);
+  // A flip back to execute rebuilds again and still sees the history.
+  const back = await switchModeIfNeeded(conv, "c", OPENAI, "execute");
+  expect(back.rebuilt).toBe(true);
+  expect(conv.mode).toBe("execute");
+  expect(built[1].builtMode).toBe("execute");
+  expect(built[1].prompts).toEqual(["earlier turn"]);
+});
+
+test("getConversation records the pin's mode and builds the session at it", async () => {
+  const disk = new Map<string, string[]>();
+  const built: HistSession[] = [];
+  setDefaultBackend(histBackend("pi", disk, built));
+  modelState.model = OPENAI;
+
+  const conv = await getConversation("c-init", {
+    provider: "openai-codex",
+    model: "gpt-5-codex",
+    mode: "plan",
+  });
+  expect(conv.mode).toBe("plan");
+  expect(built).toHaveLength(1);
+  expect(built[0].builtMode).toBe("plan");
+});
+
+test("getConversation defaults to execute when the pin sets no mode", async () => {
+  const disk = new Map<string, string[]>();
+  const built: HistSession[] = [];
+  setDefaultBackend(histBackend("pi", disk, built));
+  modelState.model = OPENAI;
+
+  const conv = await getConversation("c-default", {});
+  expect(conv.mode).toBe("execute");
+  expect(built[0].builtMode).toBe("execute");
+});
+
+test("a mode-only flip through execTurn rebuilds read-only, keeps history, and emits NO provider_switched", async () => {
+  const disk = new Map<string, string[]>([["conv-flip", ["prior turn"]]]);
+  const built: HistSession[] = [];
+  setDefaultBackend(histBackend("pi", disk, built));
+  registerBackend("anthropic", histBackend("anthropic", new Map(), []));
+
+  const session = new HistSession(
+    "pi",
+    "execute",
+    disk.get("conv-flip") as string[],
+  );
+  const conv = {
+    session,
+    queue: Promise.resolve(),
+    provider: "openai-codex",
+    model: "gpt-5-codex",
+    backendId: "pi",
+    mode: "execute",
+  } as unknown as Conversation;
+  modelState.model = OPENAI; // same provider/model — only the mode changes
+
+  const events: WireEvent[] = [];
+  const unsub = subscribe("conv-flip", (e) => events.push(e));
+  await execTurn(
+    conv,
+    "conv-flip",
+    "turn-plan",
+    "draft me a plan",
+    { author: undefined, priorAuthors: [] },
+    { mode: "plan" },
+  );
+  unsub();
+
+  expect(session.disposed).toBe(true);
+  expect(conv.mode).toBe("plan");
+  // Exactly one rebuild — the read-only session ran the turn on the prior history.
+  expect(built).toHaveLength(1);
+  expect(built[0].builtMode).toBe("plan");
+  expect(built[0].prompts).toEqual(["prior turn", "draft me a plan"]);
+  // A mode flip is internal (same provider/model): no divider frame.
+  expect(events.some((e) => e.type === "provider_switched")).toBe(false);
+});
+
+test("a cross-backend switch that also flips mode lands on plan in a SINGLE rebuild", async () => {
+  const piDisk = new Map<string, string[]>([["conv-x", ["pi turn"]]]);
+  const claudeDisk = new Map<string, string[]>();
+  const piBuilt: HistSession[] = [];
+  const claudeBuilt: HistSession[] = [];
+  setDefaultBackend(histBackend("pi", piDisk, piBuilt));
+  registerBackend(
+    "anthropic",
+    histBackend("anthropic", claudeDisk, claudeBuilt),
+  );
+
+  const piSession = new HistSession(
+    "pi",
+    "execute",
+    piDisk.get("conv-x") as string[],
+  );
+  const conv = {
+    session: piSession,
+    queue: Promise.resolve(),
+    provider: "openai-codex",
+    model: "gpt-5-codex",
+    backendId: "pi",
+    mode: "execute",
+  } as unknown as Conversation;
+  modelState.model = ANTHROPIC; // cross-backend AND plan
+
+  const events: WireEvent[] = [];
+  const unsub = subscribe("conv-x", (e) => events.push(e));
+  await execTurn(
+    conv,
+    "conv-x",
+    "turn-1",
+    "plan across backends",
+    { author: undefined, priorAuthors: [] },
+    { mode: "plan" },
+  );
+  unsub();
+
+  expect(piSession.disposed).toBe(true);
+  expect(conv.backendId).toBe("anthropic");
+  expect(conv.mode).toBe("plan");
+  // ONE session built on the anthropic backend, already at plan (no double flip).
+  expect(claudeBuilt).toHaveLength(1);
+  expect(claudeBuilt[0].builtMode).toBe("plan");
+  // The cross-backend boundary still draws its divider.
+  expect(events.some((e) => e.type === "provider_switched")).toBe(true);
+});

--- a/packages/runtime/src/session/plan-overlay.test.ts
+++ b/packages/runtime/src/session/plan-overlay.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "vitest";
+import { PLAN_MODE_OVERLAY, withPlanOverlay } from "./plan-overlay";
+
+test("withPlanOverlay appends the overlay only for plan mode", () => {
+  const base = "You are Houston.";
+  expect(withPlanOverlay(base, "plan")).toBe(`${base}\n\n${PLAN_MODE_OVERLAY}`);
+});
+
+test("withPlanOverlay passes the prompt through for execute / absent mode", () => {
+  const base = "You are Houston.";
+  expect(withPlanOverlay(base, "execute")).toBe(base);
+  expect(withPlanOverlay(base)).toBe(base);
+});
+
+test("the overlay is placed LAST, after the base prompt", () => {
+  const base = "BASE-PROMPT-MARKER";
+  const out = withPlanOverlay(base, "plan");
+  expect(out.indexOf(base)).toBeLessThan(out.indexOf(PLAN_MODE_OVERLAY));
+  expect(out.endsWith(PLAN_MODE_OVERLAY)).toBe(true);
+});
+
+test("the overlay speaks in a non-technical voice (no file/JSON/CLI jargon)", () => {
+  // The target user is non-technical; the product prompt forbids naming files,
+  // JSON, configs, or CLIs. Guard the overlay copy against that jargon leaking in.
+  const lower = PLAN_MODE_OVERLAY.toLowerCase();
+  for (const banned of ["file", "json", "cli"])
+    expect(lower).not.toContain(banned);
+});
+
+test("the overlay establishes the read-only, plan-then-approve contract", () => {
+  const lower = PLAN_MODE_OVERLAY.toLowerCase();
+  expect(lower).toContain("plan mode");
+  expect(lower).toContain("must not change anything");
+  expect(lower).toContain("review");
+});

--- a/packages/runtime/src/session/plan-overlay.ts
+++ b/packages/runtime/src/session/plan-overlay.ts
@@ -1,0 +1,33 @@
+import type { TurnMode } from "@houston/protocol";
+
+/**
+ * Plan mode's system-prompt overlay. Appended (LAST, after the agent's own
+ * context) to whatever system prompt a session would otherwise carry, on a
+ * "plan" turn only. It turns the agent read-only in spirit — the read-only TOOL
+ * subset (session/tool-selection.ts + the Claude tool policy) enforces it in
+ * fact; this overlay tells the model WHY and shapes the output into a plan the
+ * user approves before anything is done.
+ *
+ * Voice: the target user is non-technical (see the product prompt rules), so the
+ * overlay names no files, JSON, CLIs, or tools — it speaks in plain outcomes.
+ */
+export const PLAN_MODE_OVERLAY = [
+  "You are in Plan mode. Here you help the user think through and design an approach before anything is actually done.",
+  "",
+  "- Look into whatever you need to understand the request fully. You may look at the user's information, but you must not change anything, and you must not use the user's connected apps or take any real-world action.",
+  "- Do not create, edit, or delete anything. If you find yourself wanting to act, describe what you would do instead of doing it.",
+  "- Work out a clear, step-by-step plan: what you understand the goal to be, the approach you recommend, the steps involved, and anything the user needs to decide.",
+  "- Write the plan in plain, friendly language the user can follow. Keep it concrete and specific to their situation.",
+  "- Finish by presenting the plan and asking the user to review it, so they can approve it or ask for changes before you carry it out.",
+].join("\n");
+
+/**
+ * Append the plan overlay to a system prompt on a "plan" turn; pass an
+ * "execute" (or absent) mode through unchanged. Both backends call this with
+ * the overlay LAST so it sits after the workspace context file.
+ */
+export function withPlanOverlay(systemPrompt: string, mode?: TurnMode): string {
+  return mode === "plan"
+    ? `${systemPrompt}\n\n${PLAN_MODE_OVERLAY}`
+    : systemPrompt;
+}

--- a/packages/runtime/src/session/resource-loader.ts
+++ b/packages/runtime/src/session/resource-loader.ts
@@ -1,8 +1,10 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { DefaultResourceLoader } from "@earendil-works/pi-coding-agent";
+import type { TurnMode } from "@houston/protocol";
 import { config } from "../config";
 import { makeCompactionGuard } from "./compaction-guard";
+import { withPlanOverlay } from "./plan-overlay";
 
 export const SYSTEM_PROMPT = [
   "You are Houston, a friendly AI assistant for a non-technical user.",
@@ -69,10 +71,12 @@ export function buildAgentLoader(opts: {
  * <workspace>/.agents/skills (Agent Skills standard — Houston's existing
  * on-disk layout loads as-is) unless HOUSTON_SKILLS_DIR overrides.
  */
-export function makeAgentLoader(cwd: string) {
+export function makeAgentLoader(cwd: string, mode?: TurnMode) {
   return buildAgentLoader({
     cwd,
     skillsDir: config.skillsDirOverride || join(cwd, ".agents", "skills"),
-    systemPrompt: config.systemPrompt || SYSTEM_PROMPT,
+    // Plan mode appends the planning overlay to the agent's system prompt; an
+    // execute (or absent) mode passes it through unchanged.
+    systemPrompt: withPlanOverlay(config.systemPrompt || SYSTEM_PROMPT, mode),
   });
 }

--- a/packages/runtime/src/session/tool-selection.test.ts
+++ b/packages/runtime/src/session/tool-selection.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from "vitest";
-import { buildToolSelection } from "./tool-selection";
+import {
+  buildToolSelection,
+  PLAN_MODE_TOOL_NAMES,
+  planToolNames,
+} from "./tool-selection";
 import { CLAMPED_FILE_TOOL_NAMES } from "./tools/clamped-fs";
 
 describe("buildToolSelection", () => {
@@ -64,5 +68,49 @@ describe("buildToolSelection", () => {
       "integration_execute",
       "request_connection",
     ]);
+  });
+});
+
+describe("planToolNames", () => {
+  const EXPECTED = ["read", "ls", "grep", "find", "ask_user"];
+
+  test("keeps exactly the read-only subset from the local (bash) selection", () => {
+    const local = buildToolSelection({
+      codeExecution: "local",
+      integrations: true,
+    });
+    // Local selection has edit/write/bash + all integration tools; plan strips
+    // every writer/actor and keeps only read/ls/grep/find/ask_user.
+    expect(planToolNames(local.toolNames)).toEqual(EXPECTED);
+    for (const dropped of [
+      "edit",
+      "write",
+      "bash",
+      "integration_search",
+      "integration_execute",
+      "request_connection",
+    ])
+      expect(planToolNames(local.toolNames)).not.toContain(dropped);
+  });
+
+  test("drops run_code from the remote selection", () => {
+    const remote = buildToolSelection({
+      codeExecution: "remote",
+      integrations: true,
+    });
+    expect(planToolNames(remote.toolNames)).toEqual(EXPECTED);
+    expect(planToolNames(remote.toolNames)).not.toContain("run_code");
+  });
+
+  test("the disabled, integration-less selection already reduces to the subset", () => {
+    const disabled = buildToolSelection({
+      codeExecution: "disabled",
+      integrations: false,
+    });
+    expect(planToolNames(disabled.toolNames)).toEqual(EXPECTED);
+  });
+
+  test("the subset constant is exactly read/ls/grep/find/ask_user", () => {
+    expect([...PLAN_MODE_TOOL_NAMES]).toEqual(EXPECTED);
   });
 });

--- a/packages/runtime/src/session/tool-selection.ts
+++ b/packages/runtime/src/session/tool-selection.ts
@@ -19,6 +19,33 @@ export interface ToolSelection {
  * decision pure so managed pods can prove code execution is disabled without
  * spinning up a live model session.
  */
+/**
+ * The read-only tool subset a "plan" turn is clamped to: the clamped-fs READ
+ * tools (`read, ls, grep, find` — never `edit`/`write`) plus `ask_user` (holds
+ * no credential, takes no real-world action). Everything that mutates or acts is
+ * dropped: `edit, write, bash, run_code`, and ALL integration tools
+ * (`integration_search`, `integration_execute`, `request_connection` — an
+ * integration call is a real-world action against the user's connected apps).
+ */
+export const PLAN_MODE_TOOL_NAMES: readonly string[] = [
+  "read",
+  "ls",
+  "grep",
+  "find",
+  ASK_USER_TOOL_NAME,
+];
+
+/**
+ * Clamp an execute-mode tool allowlist to the plan-mode read-only subset: keep
+ * only the names in {@link PLAN_MODE_TOOL_NAMES}, preserving their order. Applied
+ * to whatever `buildToolSelection` produced, so plan mode composes with every
+ * code-execution / integration selection (a `bash`/`run_code`/`integration_*`
+ * name is simply filtered out).
+ */
+export function planToolNames(all: readonly string[]): string[] {
+  return all.filter((name) => PLAN_MODE_TOOL_NAMES.includes(name));
+}
+
 export function buildToolSelection(input: ToolSelectionInput): ToolSelection {
   const executable =
     input.codeExecution === "local"

--- a/packages/runtime/src/session/turn-resilience.test.ts
+++ b/packages/runtime/src/session/turn-resilience.test.ts
@@ -122,6 +122,7 @@ function convWith(session: HarnessSession): Conversation {
     provider: "openai-codex",
     model: "gpt-5-codex",
     backendId: "pi",
+    mode: "execute",
   } as unknown as Conversation;
 }
 

--- a/packages/runtime/src/transport/conversation-routes.ts
+++ b/packages/runtime/src/transport/conversation-routes.ts
@@ -121,11 +121,16 @@ async function handleConversationTitle(ctx: RouteContext, id: string) {
 }
 
 async function handleStartTurn(ctx: RouteContext, id: string) {
-  const { text, nonce, model, effort, provider } = await readJson(ctx.req);
+  const { text, nonce, model, effort, provider, mode } = await readJson(
+    ctx.req,
+  );
   if (!text || typeof text !== "string") {
     json(ctx.res, 400, { error: "missing 'text'" });
     return;
   }
+  // Never trust the wire: only the exact string "plan" turns plan mode on;
+  // everything else (absent, garbage, "execute") is execute.
+  const turnMode = mode === "plan" ? "plan" : "execute";
   // A provider-pinned turn (a routine) is never auth-gated on the ACTIVE
   // provider — the pin names its own; a disconnected pin surfaces as the
   // turn's provider error. The credential sync inside ensureProviderForTurn
@@ -150,6 +155,7 @@ async function handleStartTurn(ctx: RouteContext, id: string) {
       provider: pinnedProvider,
       model: typeof model === "string" ? model : undefined,
       effort: typeof effort === "string" ? effort : undefined,
+      mode: turnMode,
     },
     acting,
   );

--- a/packages/runtime/src/turn/server.ts
+++ b/packages/runtime/src/turn/server.ts
@@ -111,6 +111,7 @@ async function executeTurn(
         signal: abort.signal,
         nonce: turn.nonce,
         pin: { model: turn.model, effort: turn.effort },
+        mode: turn.mode,
         turnId,
       });
     }

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -1,5 +1,6 @@
 import { join } from "node:path";
 import { AuthStorage, ModelRegistry } from "@earendil-works/pi-coding-agent";
+import type { TurnMode } from "@houston/protocol";
 import type {
   PendingInteraction,
   ProviderError,
@@ -70,6 +71,12 @@ export interface PiTurnRequest {
   nonce?: string;
   pin?: TurnModelPin;
   /**
+   * The turn's execution mode ("plan" = read-only + planning overlay). Absent =
+   * execute. Threaded into the pi session's tool allowlist + system prompt via
+   * `createSession`, identical to the long-lived server path.
+   */
+  mode?: TurnMode;
+  /**
    * The turn's wire identity, minted by the per-turn SERVER (which also stamps
    * it on the terminal frame it sends after sync-back) — stamped here on every
    * emitted frame and persisted on both stored messages.
@@ -81,7 +88,8 @@ export async function runPiTurn(
   root: string,
   turn: PiTurnRequest,
 ): Promise<TurnOutcome> {
-  const { conversationId, text, provider, signal, nonce, pin, turnId } = turn;
+  const { conversationId, text, provider, signal, nonce, pin, mode, turnId } =
+    turn;
   const emit = (e: WireFrame) => turn.emit({ ...e, turnId });
   const workspaceDir = join(root, "workspace");
   const dataDir = join(root, "data");
@@ -165,6 +173,10 @@ export async function runPiTurn(
       conversationId,
       model,
       ...(thinkingLevel ? { thinkingLevel } : {}),
+      // Plan mode clamps this pi session read-only + overlays the planning
+      // prompt, exactly as the long-lived server path does (createPiBackend
+      // applies `planToolNames` + the loader overlay from `opts.mode`).
+      ...(mode ? { mode } : {}),
     });
 
     // Snapshot the hydrated workspace so the turn's created/modified files can

--- a/packages/runtime/src/turn/types.test.ts
+++ b/packages/runtime/src/turn/types.test.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "vitest";
+import { parseTurnRequest } from "./types";
+
+const BASE = {
+  workspaceId: "w1",
+  agentId: "a1",
+  conversationId: "c1",
+  text: "hello",
+  gcsPrefix: "ws/w1/a1",
+};
+
+test("parseTurnRequest defaults mode to execute when absent", () => {
+  expect(parseTurnRequest(BASE).mode).toBe("execute");
+});
+
+test("parseTurnRequest accepts an explicit plan mode", () => {
+  expect(parseTurnRequest({ ...BASE, mode: "plan" }).mode).toBe("plan");
+});
+
+test("parseTurnRequest never trusts the wire — anything but 'plan' is execute", () => {
+  expect(parseTurnRequest({ ...BASE, mode: "execute" }).mode).toBe("execute");
+  expect(parseTurnRequest({ ...BASE, mode: "PLAN" }).mode).toBe("execute");
+  expect(parseTurnRequest({ ...BASE, mode: "" }).mode).toBe("execute");
+  expect(parseTurnRequest({ ...BASE, mode: 1 }).mode).toBe("execute");
+});

--- a/packages/runtime/src/turn/types.ts
+++ b/packages/runtime/src/turn/types.ts
@@ -1,3 +1,4 @@
+import type { TurnMode } from "@houston/protocol";
 import type { ServedCredential } from "../auth/auth-file";
 
 /**
@@ -21,6 +22,11 @@ export interface TurnRequest {
   model?: string;
   /** Per-turn reasoning-effort override (a routine's pinned effort). Absent = inherit. */
   effort?: string;
+  /**
+   * Per-turn execution mode ("plan" = read-only + planning overlay). Absent =
+   * execute. Routines never set plan; a plan turn here is a user-initiated one.
+   */
+  mode?: TurnMode;
 }
 
 const ID = /^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/;
@@ -74,5 +80,7 @@ export function parseTurnRequest(body: unknown): TurnRequest {
     credential,
     model: typeof b.model === "string" ? b.model : undefined,
     effort: typeof b.effort === "string" ? b.effort : undefined,
+    // Never trust the wire: only the exact string "plan" enables plan mode.
+    mode: b.mode === "plan" ? "plan" : "execute",
   };
 }

--- a/packages/sdk/src/modules/providers/operations.ts
+++ b/packages/sdk/src/modules/providers/operations.ts
@@ -138,10 +138,13 @@ export function createProviderOps(ctx: ModuleContext): ProviderOps {
     const client = ctx.clientFor(agentId);
     // Reuse the shared resolver: it pairs a model with its owning provider (the
     // runtime hard-fails a model that belongs to a different active provider).
+    // `mode` is a per-turn pin only — never an agent-wide setting (HOU-695) —
+    // so a settings write always resolves it as undefined.
     const settings = await resolveModelSettings(
       client,
       opts.model,
       opts.effort,
+      undefined,
     );
     if (opts.provider !== undefined) settings.activeProvider = opts.provider;
     await client.setSettings(settings);

--- a/packages/sdk/src/modules/turns/index.ts
+++ b/packages/sdk/src/modules/turns/index.ts
@@ -53,16 +53,22 @@ export function createTurnsModule(ctx: ModuleContext) {
     // typed reconnect card when the runtime refuses the send as not-connected
     // (the refusal itself can't name a provider — nothing is connected).
     let pin: TurnWirePin | undefined;
-    if (input.model !== undefined || input.effort !== undefined) {
+    if (
+      input.model !== undefined ||
+      input.effort !== undefined ||
+      input.mode !== undefined
+    ) {
       const resolved = await resolveModelSettings(
         client,
         input.model,
         input.effort,
+        input.mode,
       );
       pin = {
         provider: resolved.activeProvider,
         model: resolved.model,
         effort: resolved.effort,
+        mode: resolved.mode,
       };
     }
     const output = new MultiplexFeedOutput([vm, ...external]);

--- a/packages/sdk/src/modules/turns/model-settings.ts
+++ b/packages/sdk/src/modules/turns/model-settings.ts
@@ -1,10 +1,13 @@
 import type { HoustonEngineClient, ProviderId } from "@houston/runtime-client";
 
-/** A per-turn model/effort pick, resolved to its owning provider. */
+/** A per-turn model/effort/mode pick, resolved to its owning provider. */
 export interface ModelSettings {
   activeProvider?: ProviderId;
   model?: string;
   effort?: string;
+  /** Per-turn execution mode ("plan" = read-only + planning overlay); a pure
+   *  passthrough like `effort`, never gated by the provider resolution. */
+  mode?: "execute" | "plan";
 }
 
 /**
@@ -24,8 +27,9 @@ export async function resolveModelSettings(
   client: HoustonEngineClient,
   model: string | undefined,
   effort: string | undefined,
+  mode: "execute" | "plan" | undefined,
 ): Promise<ModelSettings> {
-  if (model === undefined) return { effort };
+  if (model === undefined) return { effort, mode };
   let activeProvider: ProviderId | undefined;
   try {
     const providers = await client.listProviders();
@@ -36,5 +40,5 @@ export async function resolveModelSettings(
     // Engine unreachable / no provider selected: fall through to a bare model
     // write. The runtime settles the provider on its side.
   }
-  return { activeProvider, model, effort };
+  return { activeProvider, model, effort, mode };
 }

--- a/packages/sdk/src/modules/turns/turn-inputs.ts
+++ b/packages/sdk/src/modules/turns/turn-inputs.ts
@@ -22,6 +22,12 @@ export interface TurnSendInput {
   model?: string;
   /** Reasoning effort to apply alongside `model`. */
   effort?: string;
+  /**
+   * Per-turn execution mode ("plan" = read-only + planning overlay). A pure
+   * per-turn pin like `effort` — never writes agent settings (HOU-695).
+   * Omitted, the runtime runs the turn as "execute".
+   */
+  mode?: "execute" | "plan";
 }
 
 /** The `turns/cancel` command payload. */
@@ -51,6 +57,11 @@ export interface TurnHistoryInput {
 const str = (v: unknown): string | undefined =>
   typeof v === "string" ? v : undefined;
 
+/** Untrusted-envelope guard for the per-turn mode pin: only the two known
+ *  literals pass; anything else drops to undefined (turn stays "execute"). */
+const mode = (v: unknown): "execute" | "plan" | undefined =>
+  v === "execute" || v === "plan" ? v : undefined;
+
 export function asSendInput(payload: unknown): TurnSendInput {
   const p = (payload ?? {}) as Record<string, unknown>;
   if (typeof p.conversationId !== "string" || typeof p.text !== "string")
@@ -62,6 +73,7 @@ export function asSendInput(payload: unknown): TurnSendInput {
     nonce: str(p.nonce),
     model: str(p.model),
     effort: str(p.effort),
+    mode: mode(p.mode),
   };
 }
 

--- a/packages/sdk/src/modules/turns/turn-stream.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.ts
@@ -34,6 +34,9 @@ export interface TurnWirePin {
   provider?: string;
   model?: string;
   effort?: string;
+  /** Per-turn execution mode ("plan" = read-only + planning overlay). Omitted
+   *  runs the turn as "execute", the runtime's default for an unpinned turn. */
+  mode?: "execute" | "plan";
 }
 
 /** Optional knobs for {@link streamTurn}. */

--- a/packages/web/src/engine-adapter/synthetic.ts
+++ b/packages/web/src/engine-adapter/synthetic.ts
@@ -134,13 +134,27 @@ export function credentialSiblings(pid: NewProviderId): NewProviderId[] {
  *   id would hard-fail the turn (the runtime validates pins strictly);
  * - a model with no provider can't be ownership-checked, so it is dropped too;
  * - effort passes through verbatim; an effort-only send still pins it.
+ * - mode passes through verbatim; a mode-only send still pins it.
  */
 export function wireTurnPin(req: {
   provider?: string;
   model?: string;
   effort?: string;
-}): { provider?: string; model?: string; effort?: string } | undefined {
-  const pin: { provider?: string; model?: string; effort?: string } = {};
+  mode?: "execute" | "plan";
+}):
+  | {
+      provider?: string;
+      model?: string;
+      effort?: string;
+      mode?: "execute" | "plan";
+    }
+  | undefined {
+  const pin: {
+    provider?: string;
+    model?: string;
+    effort?: string;
+    mode?: "execute" | "plan";
+  } = {};
   if (req.provider) {
     const provider = canonicalProviderId(req.provider);
     if (provider) {
@@ -164,7 +178,8 @@ export function wireTurnPin(req: {
     );
   }
   if (req.effort) pin.effort = req.effort;
-  return pin.provider || pin.effort ? pin : undefined;
+  if (req.mode) pin.mode = req.mode;
+  return pin.provider || pin.effort || pin.mode ? pin : undefined;
 }
 
 /**

--- a/packages/web/tests/wire-turn-pin.test.ts
+++ b/packages/web/tests/wire-turn-pin.test.ts
@@ -56,6 +56,29 @@ test("a model without a provider cannot be ownership-checked and is dropped", ()
   expect(wireTurnPin({ model: "gpt-5.5" })).toBeUndefined();
 });
 
+test("mode passes through verbatim alongside the pin", () => {
+  expect(
+    wireTurnPin({
+      provider: "anthropic",
+      model: "claude-opus-4-8",
+      mode: "plan",
+    }),
+  ).toEqual({
+    provider: "anthropic",
+    model: "claude-opus-4-8",
+    mode: "plan",
+  });
+});
+
+test("a mode-only send still pins the mode (plan mode with no provider override)", () => {
+  expect(wireTurnPin({ mode: "plan" })).toEqual({ mode: "plan" });
+});
+
+test("no mode key when the send carries no mode", () => {
+  const pin = wireTurnPin({ provider: "anthropic", model: "claude-opus-4-8" });
+  expect(pin).not.toHaveProperty("mode");
+});
+
 test("no overrides → no pin (the runtime's own resolution is untouched)", () => {
   expect(wireTurnPin({})).toBeUndefined();
 });

--- a/ui/agent-schemas/src/config.schema.json
+++ b/ui/agent-schemas/src/config.schema.json
@@ -10,6 +10,10 @@
     "effort": {
       "type": "string",
       "enum": ["low", "medium", "high", "xhigh", "max"]
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["execute", "plan"]
     }
   },
   "additionalProperties": true

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -825,6 +825,12 @@ export interface SessionStartRequest {
    */
   effort?: string;
   /**
+   * Per-turn agent mode. `"plan"` runs the turn read-only (no file writes or
+   * side effects), `"execute"` (the default when omitted) runs it normally.
+   * Forwarded verbatim to the runtime, which enforces it.
+   */
+  mode?: "execute" | "plan";
+  /**
    * Skip the turn stream's optimistic user bubble — for resends of a prompt
    * whose bubble is already in the conversation VM (a refused not-connected
    * send being retried verbatim).


### PR DESCRIPTION
## What

A **Mode** pill in the chat composer (Chat | Plan) with genuine enforcement, not a prompt suggestion:

- **Plan mode** rebuilds the live session with a **read-only tool subset** (`read, ls, grep, find, ask_user` — no edit/write/bash/run_code, no integrations) plus a planning system-prompt overlay, on **both** backends. The Claude backend keeps `permissionMode: "default"` (SDK plan mode would force the disallowed ExitPlanMode tool); the allowlist is the enforcement.
- **Wire**: new protocol `TurnMode` rides the same per-turn pin path as effort (runtime-client body → SDK `TurnWirePin` → `SessionStartRequest` → `wireTurnPin`). Deliberately **not** an engine Setting, so unpinned turns — routines, cloud per-turn dispatch — always execute.
- **Mode flips mid-conversation** rebuild the session same-backend: history rehydrates (locked by a test), no `provider_switched` divider; a simultaneous backend+mode switch rebuilds exactly once.
- **App**: pill next to the model selector (dropdown with plain-language descriptions, en/es/pt), remembered per-agent in `config.json` as composer memory only. Every user-typed send carries `modeOverride`: composer sends, new conversations, Mission Control, archived resumes, the warming queue, and skill/retry/interaction sends.

Known limitation (pre-existing shape): per-turn cloud workspaces drop chat-body pins today (model/effort too), so plan degrades to execute there.

## Verification

- runtime 508/508 (25 new: tool subset, overlay, mode rebuild + history carryover, wire normalization), runtime-client 59, SDK 248, web 90 — all green; boundaries clean.
- Playwright fake-host run: the pill renders, Plan selects, and a plain typed message's POST body carries `mode: "plan"` (asserted via request interception).

Series: #734, #738, #739, #740 merged; dictation is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)