### PR TITLE
feat: local dictation in the chat composer (whisper.cpp sidecar)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,6 +534,31 @@ jobs:
           chmod +x app/src-tauri/binaries/frpc-universal-apple-darwin
           lipo -info app/src-tauri/binaries/frpc-universal-apple-darwin
 
+      # Build the whisper.cpp dictation sidecar (whisper-cli, MIT) for both arches
+      # and lipo a universal fat binary, mirroring frpc + the host sidecar above.
+      # build.rs::stage_whisper_sidecar also stages per-arch copies during tauri's
+      # per-arch cargo runs, but the `--target universal-apple-darwin` bundle ships
+      # this fat binary at binaries/whisper-cli-universal-apple-darwin. The `test -x`
+      # gate FAILS the release if a whisper build breaks, so we never ship the
+      # loud-fail placeholder instead of a working local-dictation binary.
+      - name: Build + lipo universal whisper-cli dictation sidecar (aarch64 + x86_64)
+        run: |
+          set -euo pipefail
+          for TRIPLE in aarch64-apple-darwin x86_64-apple-darwin; do
+            echo "=== building whisper-cli for $TRIPLE ==="
+            scripts/build-whisper.sh "$TRIPLE"
+            test -x "target/whisper/whisper-cli-$TRIPLE" \
+              || { echo "::error::whisper-cli missing for $TRIPLE"; exit 1; }
+          done
+          mkdir -p app/src-tauri/binaries
+          echo "=== Lipo universal whisper-cli ==="
+          lipo -create \
+            target/whisper/whisper-cli-aarch64-apple-darwin \
+            target/whisper/whisper-cli-x86_64-apple-darwin \
+            -output app/src-tauri/binaries/whisper-cli-universal-apple-darwin
+          chmod +x app/src-tauri/binaries/whisper-cli-universal-apple-darwin
+          lipo -info app/src-tauri/binaries/whisper-cli-universal-apple-darwin
+
       # Build only — no release creation (no tagName).
       # tauri-action handles certificate import, code signing, .app notarization + stapling.
       #
@@ -1143,6 +1168,21 @@ jobs:
             || { echo "::error::frpc missing for ${{ matrix.target }}"; exit 1; }
           ls -lah target/frpc/frpc-${{ matrix.target }}.exe
 
+      # Build the whisper.cpp dictation sidecar (whisper-cli, MIT) for the matrix
+      # target BEFORE tauri build. build.rs::stage_whisper_sidecar copies
+      # target/whisper/whisper-cli-<target>.exe to the externalBin name
+      # binaries/whisper-cli-<target>.exe (same pattern as frpc). CPU-only portable
+      # (GGML_NATIVE=OFF), self-contained (static). The `test -x` gate FAILS the
+      # release rather than shipping the loud-fail placeholder.
+      - name: Build whisper-cli dictation sidecar (${{ matrix.target }})
+        shell: bash
+        run: |
+          set -euo pipefail
+          scripts/build-whisper.sh ${{ matrix.target }}
+          test -x "target/whisper/whisper-cli-${{ matrix.target }}.exe" \
+            || { echo "::error::whisper-cli missing for ${{ matrix.target }}"; exit 1; }
+          ls -lah target/whisper/whisper-cli-${{ matrix.target }}.exe
+
       # CLOUD channel only: repoint the updater at `latest-cloud.json` before the
       # build bakes tauri.conf.json in (see build-macos for the why). The script
       # is Node-based so it also runs on windows-11-arm, where jq is absent.
@@ -1399,6 +1439,18 @@ jobs:
           scripts/fetch-frpc.sh x86_64-unknown-linux-gnu
           test -f target/frpc/frpc-x86_64-unknown-linux-gnu \
             || { echo "::error::frpc missing for x86_64-unknown-linux-gnu"; exit 1; }
+
+      # Build the whisper.cpp dictation sidecar (whisper-cli, MIT). Like frpc, the
+      # exit-1 placeholder build.rs stages when whisper-cli is absent is not an ELF
+      # and would abort linuxdeploy's ldd pass, so build the real CPU-only
+      # (GGML_NATIVE=OFF), self-contained binary before bundling. The `test -x`
+      # gate FAILS the release rather than shipping the placeholder.
+      - name: Build whisper-cli dictation sidecar (x86_64-unknown-linux-gnu)
+        run: |
+          set -euo pipefail
+          scripts/build-whisper.sh x86_64-unknown-linux-gnu
+          test -x target/whisper/whisper-cli-x86_64-unknown-linux-gnu \
+            || { echo "::error::whisper-cli missing for x86_64-unknown-linux-gnu"; exit 1; }
 
       - name: Build Tauri app (Linux AppImage)
         uses: tauri-apps/tauri-action@v0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,6 +1948,7 @@ dependencies = [
  "sentry-tracing",
  "serde",
  "serde_json",
+ "sha2",
  "tauri",
  "tauri-build",
  "tauri-plugin-deep-link",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -47,6 +47,10 @@ bytes = "1"
 futures-util = "0.3"
 # High-entropy proxy-key generation (src/local_bridge/keys.rs).
 rand = "0.9"
+# sha256 verification of the downloaded whisper.cpp dictation model
+# (src/dictation/model.rs). Streamed into the hasher during download so the
+# 181 MB file is never read twice.
+sha2 = "0.10"
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }

--- a/app/src-tauri/Info.plist
+++ b/app/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Houston uses your microphone for voice typing in the chat box.</string>
+</dict>
+</plist>

--- a/app/src-tauri/build.rs
+++ b/app/src-tauri/build.rs
@@ -57,6 +57,19 @@ fn main() {
         println!("cargo:warning=frpc staging skipped: {e}");
     }
 
+    // Stage the bundled whisper.cpp dictation sidecar into
+    // `binaries/whisper-cli-<triple>` for Tauri's `externalBin`. Like frpc (and
+    // unlike the host sidecar), a missing whisper-cli NEVER fails the build —
+    // not even a release build. It is deliberately kept OUT of the fail-closed
+    // host-sidecar stamp guard: a broken/absent whisper build must be caught by
+    // the release workflow's own `test -x` gate (scripts/build-whisper.sh runs
+    // there before `tauri build`), not by build.rs, so a local `pnpm tauri
+    // build` never hard-depends on having built whisper first. Missing → a
+    // placeholder that exits non-zero, so a dictation attempt fails loudly.
+    if let Err(e) = stage_whisper_sidecar() {
+        println!("cargo:warning=whisper staging skipped: {e}");
+    }
+
     tauri_build::build()
 }
 
@@ -571,6 +584,84 @@ fn stage_frpc_sidecar() -> Result<(), String> {
             .permissions();
         perms.set_mode(0o755);
         std::fs::set_permissions(&dest, perms).map_err(|e| format!("chmod frpc: {e}"))?;
+    }
+    Ok(())
+}
+
+/// Stage the bundled whisper.cpp dictation sidecar as the Tauri externalBin
+/// `binaries/whisper-cli-<triple>`.
+///
+/// Source: `target/whisper/whisper-cli-<triple>[.exe]`, produced by
+/// `scripts/build-whisper.sh` (or the release CI whisper-build step). Missing
+/// whisper-cli → a placeholder that exits non-zero (so a dictation attempt
+/// fails loudly), NOT a build failure — even for a release build. Local
+/// dictation is only exercised when the user voice-types, so an app build must
+/// never hard-depend on having built it. This staging is deliberately kept
+/// independent of the host-sidecar fail-closed stamp guard: a broken whisper
+/// build is caught by the release workflow's `test -x` gate, not build.rs.
+fn stage_whisper_sidecar() -> Result<(), String> {
+    let manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace = manifest
+        .parent()
+        .and_then(|p| p.parent())
+        .ok_or("could not resolve workspace root from CARGO_MANIFEST_DIR")?;
+    let triple = std::env::var("TARGET").unwrap_or_default();
+    let ext = if cfg!(windows) { ".exe" } else { "" };
+
+    let src_dir = workspace.join("target").join("whisper");
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if !triple.is_empty() {
+        candidates.push(src_dir.join(format!("whisper-cli-{triple}{ext}")));
+    }
+    candidates.push(src_dir.join(format!("whisper-cli{ext}")));
+
+    // Re-run when a built whisper-cli appears/changes so a staged placeholder is
+    // replaced on the next build (mirrors the frpc + host-sidecar staging).
+    for candidate in &candidates {
+        println!("cargo:rerun-if-changed={}", candidate.display());
+    }
+
+    let dest_dir = manifest.join("binaries");
+    std::fs::create_dir_all(&dest_dir).map_err(|e| format!("mkdir binaries: {e}"))?;
+    let dest_name = if triple.is_empty() {
+        format!("whisper-cli{ext}")
+    } else {
+        format!("whisper-cli-{triple}{ext}")
+    };
+    let dest = dest_dir.join(&dest_name);
+
+    match candidates.iter().find(|p| p.exists()) {
+        Some(src) => {
+            std::fs::copy(src, &dest).map_err(|e| format!("copy whisper-cli: {e}"))?;
+            println!(
+                "cargo:warning=whisper-cli: staged {} -> {}",
+                src.display(),
+                dest.display()
+            );
+        }
+        None => {
+            let placeholder = if cfg!(windows) {
+                "@echo off\r\necho whisper-cli not built - run scripts/build-whisper.sh 1>&2\r\nexit /b 1\r\n"
+            } else {
+                "#!/bin/sh\necho 'whisper-cli not built - run scripts/build-whisper.sh' >&2\nexit 1\n"
+            };
+            std::fs::write(&dest, placeholder)
+                .map_err(|e| format!("write whisper-cli placeholder: {e}"))?;
+            println!(
+                "cargo:warning=whisper-cli binary not built - staged a placeholder at {} (run scripts/build-whisper.sh for local dictation)",
+                dest.display()
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = std::fs::metadata(&dest)
+            .map_err(|e| format!("stat whisper-cli: {e}"))?
+            .permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&dest, perms).map_err(|e| format!("chmod whisper-cli: {e}"))?;
     }
     Ok(())
 }

--- a/app/src-tauri/entitlements.plist
+++ b/app/src-tauri/entitlements.plist
@@ -10,5 +10,7 @@
     <true/>
     <key>com.apple.security.automation.apple-events</key>
     <true/>
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>

--- a/app/src-tauri/src/dictation/mod.rs
+++ b/app/src-tauri/src/dictation/mod.rs
@@ -1,0 +1,25 @@
+//! On-device dictation via a bundled whisper.cpp sidecar.
+//!
+//! Three Tauri commands power the desktop's push-to-talk transcription:
+//!   - [`transcribe_audio`] runs `whisper-cli` over a recorded WAV and returns
+//!     the recognized text (raw audio rides the IPC payload, not JSON).
+//!   - [`dictation_model_status`] reports whether the pinned model is on disk.
+//!   - [`download_dictation_model`] fetches + sha256-verifies that model.
+//!
+//! The model is downloaded once into the app data dir; the sidecar binary is
+//! staged by Tauri's `externalBin` and resolved via [`crate::child_guard`],
+//! sharing the same orphan-prevention discipline as the engine/frpc sidecars.
+
+mod model;
+mod types;
+mod verify;
+mod wav;
+mod whisper;
+
+// Glob re-exports so `tauri::generate_handler!` in `lib.rs` can reach both each
+// command AND the hidden `__cmd__*` items the `#[tauri::command]` macro emits
+// alongside it (a named `pub use` would leave those behind). The wire types in
+// `types` are used by these commands' signatures and serialized to the frontend
+// as JSON, so they need no path-level re-export here.
+pub use model::*;
+pub use whisper::*;

--- a/app/src-tauri/src/dictation/model.rs
+++ b/app/src-tauri/src/dictation/model.rs
@@ -1,0 +1,151 @@
+//! The pinned dictation model: manifest, on-disk status, and a verified,
+//! resumable-safe download.
+//!
+//! One model is shipped — whisper.cpp's `ggml-small-q5_1` (~181 MB). The
+//! sha256 was taken from Hugging Face's file tree API (the LFS `oid`) WITHOUT
+//! pulling the blob:
+//!   `curl https://huggingface.co/api/models/ggerganov/whisper.cpp/tree/main`
+//! and pinned below. The download streams to a `.part` sibling, hashing as it
+//! goes, and only atomically renames into place after the digest matches — so a
+//! truncated or corrupted fetch can never masquerade as a ready model.
+
+use std::path::{Path, PathBuf};
+
+use sha2::{Digest, Sha256};
+use tauri::{AppHandle, Emitter, Manager};
+use tokio::io::AsyncWriteExt;
+
+use super::types::{DictationModelStatus, ModelProgress, ModelProgressPhase};
+use super::verify::{hex, verify_and_finalize, PartGuard};
+use futures_util::StreamExt;
+
+/// Stable identifier the frontend uses to name the model.
+pub const MODEL_ID: &str = "ggml-small-q5_1";
+const FILE_NAME: &str = "ggml-small-q5_1.bin";
+const MODEL_URL: &str =
+    "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-small-q5_1.bin";
+/// LFS oid from the HF tree API (see module docs).
+const MODEL_SHA256: &str = "ae85e4a935d7a567bd102fe55afc16bb595bdb618e11b2fc7591bc08120411bb";
+const MODEL_SIZE_BYTES: u64 = 190_085_487;
+
+/// The progress event channel the frontend listens on.
+const PROGRESS_EVENT: &str = "dictation-model-progress";
+
+/// `<app_data_dir>/models/whisper/ggml-small-q5_1.bin`.
+pub fn model_path(app: &AppHandle) -> Result<PathBuf, String> {
+    let dir = app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("dictation: resolve app data dir: {e}"))?;
+    Ok(dir.join("models").join("whisper").join(FILE_NAME))
+}
+
+/// Ready = the file exists AND is exactly the expected size. A size check is a
+/// cheap corruption guard that avoids re-hashing 181 MB on every status poll;
+/// the full sha256 is enforced once, at download time.
+fn is_ready(path: &Path) -> bool {
+    matches!(std::fs::metadata(path), Ok(m) if m.len() == MODEL_SIZE_BYTES)
+}
+
+#[tauri::command]
+pub async fn dictation_model_status(app: AppHandle) -> Result<DictationModelStatus, String> {
+    let path = model_path(&app)?;
+    Ok(DictationModelStatus {
+        ready: is_ready(&path),
+        model_id: MODEL_ID.to_string(),
+        size_bytes: MODEL_SIZE_BYTES,
+    })
+}
+
+#[tauri::command]
+pub async fn download_dictation_model(app: AppHandle) -> Result<(), String> {
+    let final_path = model_path(&app)?;
+    // Idempotent: a ready model resolves immediately with a terminal Done tick.
+    if is_ready(&final_path) {
+        emit(
+            &app,
+            MODEL_SIZE_BYTES,
+            MODEL_SIZE_BYTES,
+            ModelProgressPhase::Done,
+        );
+        return Ok(());
+    }
+    match download_inner(&app, &final_path).await {
+        Ok(()) => Ok(()),
+        Err(e) => {
+            // No-silent-failure: surface an Error tick AND propagate the Err so
+            // the frontend can toast the real reason with a Report-bug button.
+            emit(&app, 0, MODEL_SIZE_BYTES, ModelProgressPhase::Error);
+            Err(e)
+        }
+    }
+}
+
+async fn download_inner(app: &AppHandle, final_path: &Path) -> Result<(), String> {
+    let dir = final_path
+        .parent()
+        .ok_or_else(|| "dictation: model path has no parent".to_string())?;
+    tokio::fs::create_dir_all(dir)
+        .await
+        .map_err(|e| format!("dictation: create model dir: {e}"))?;
+
+    let part = final_path.with_extension("part");
+    // Removes the partial file on any early return unless we disarm it on success.
+    let guard = PartGuard::new(part.clone());
+
+    let resp = reqwest::get(MODEL_URL)
+        .await
+        .map_err(|e| format!("dictation: request model: {e}"))?;
+    if !resp.status().is_success() {
+        return Err(format!("dictation: model download HTTP {}", resp.status()));
+    }
+    let total = resp.content_length().unwrap_or(MODEL_SIZE_BYTES);
+
+    let mut file = tokio::fs::File::create(&part)
+        .await
+        .map_err(|e| format!("dictation: create {}: {e}", part.display()))?;
+    let mut hasher = Sha256::new();
+    let mut received: u64 = 0;
+    let mut last_emit = std::time::Instant::now();
+    emit(app, 0, total, ModelProgressPhase::Downloading);
+
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(|e| format!("dictation: read model stream: {e}"))?;
+        file.write_all(&chunk)
+            .await
+            .map_err(|e| format!("dictation: write {}: {e}", part.display()))?;
+        hasher.update(&chunk);
+        received += chunk.len() as u64;
+        // Throttle to ~4 ticks/second so a 181 MB stream can't flood the webview.
+        if last_emit.elapsed().as_millis() >= 250 {
+            emit(app, received, total, ModelProgressPhase::Downloading);
+            last_emit = std::time::Instant::now();
+        }
+    }
+    file.flush()
+        .await
+        .map_err(|e| format!("dictation: flush {}: {e}", part.display()))?;
+    drop(file);
+
+    emit(app, received, total, ModelProgressPhase::Verifying);
+    let actual = hex(&hasher.finalize());
+    verify_and_finalize(&part, final_path, &actual, MODEL_SHA256)?;
+
+    guard.disarm();
+    emit(app, total, total, ModelProgressPhase::Done);
+    Ok(())
+}
+
+fn emit(app: &AppHandle, received: u64, total: u64, phase: ModelProgressPhase) {
+    let payload = ModelProgress {
+        received,
+        total,
+        phase,
+    };
+    // Event-emit callback: no UI thread to toast on here, so a failed emit is
+    // logged (the documented exception to the no-silent-failure rule).
+    if let Err(e) = app.emit(PROGRESS_EVENT, payload) {
+        tracing::error!("[dictation] failed to emit progress event: {e}");
+    }
+}

--- a/app/src-tauri/src/dictation/types.rs
+++ b/app/src-tauri/src/dictation/types.rs
@@ -1,0 +1,67 @@
+//! Wire types shared by the dictation commands. The frontend binds against
+//! these exact shapes, so the field names / casing are load-bearing.
+
+/// Whether the pinned dictation model is present on disk, reported by
+/// [`super::dictation_model_status`].
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationModelStatus {
+    pub ready: bool,
+    pub model_id: String,
+    pub size_bytes: u64,
+}
+
+/// A single progress tick emitted on the `dictation-model-progress` channel
+/// while [`super::download_dictation_model`] runs.
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ModelProgress {
+    pub received: u64,
+    pub total: u64,
+    pub phase: ModelProgressPhase,
+}
+
+/// The stage a download is in. `Error` accompanies a returned `Err` (the beta
+/// no-silent-failure policy: the user sees both the toast and the failed tick).
+#[derive(Clone, Copy, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ModelProgressPhase {
+    Downloading,
+    Verifying,
+    Done,
+    Error,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn status_serializes_camel_case() {
+        let json = serde_json::to_string(&DictationModelStatus {
+            ready: true,
+            model_id: "ggml-small-q5_1".to_string(),
+            size_bytes: 42,
+        })
+        .unwrap();
+        assert!(json.contains("\"ready\":true"));
+        assert!(json.contains("\"modelId\":\"ggml-small-q5_1\""));
+        assert!(json.contains("\"sizeBytes\":42"));
+    }
+
+    #[test]
+    fn progress_phase_serializes_lowercase() {
+        let json = serde_json::to_string(&ModelProgress {
+            received: 1,
+            total: 2,
+            phase: ModelProgressPhase::Downloading,
+        })
+        .unwrap();
+        assert!(json.contains("\"received\":1"));
+        assert!(json.contains("\"total\":2"));
+        assert!(json.contains("\"phase\":\"downloading\""));
+        assert!(serde_json::to_string(&ModelProgressPhase::Error)
+            .unwrap()
+            .contains("error"));
+    }
+}

--- a/app/src-tauri/src/dictation/verify.rs
+++ b/app/src-tauri/src/dictation/verify.rs
@@ -1,0 +1,123 @@
+//! Checksum + atomic-finalize primitives for the model download: hex encoding,
+//! the sha256 gate that moves a `.part` into place, and the RAII guard that
+//! removes a partial file on a failed download.
+
+use std::path::{Path, PathBuf};
+
+/// Lowercase hex encoding of a digest.
+pub fn hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        s.push_str(&format!("{b:02x}"));
+    }
+    s
+}
+
+/// Compare digests and, on a match, atomically move `part` into place. On a
+/// mismatch the partial file is removed and an Err returned — a corrupt blob
+/// never lands at the final path.
+pub fn verify_and_finalize(
+    part: &Path,
+    final_path: &Path,
+    actual_hex: &str,
+    expected_hex: &str,
+) -> Result<(), String> {
+    if !actual_hex.eq_ignore_ascii_case(expected_hex) {
+        std::fs::remove_file(part)
+            .map_err(|e| format!("dictation: remove corrupt {}: {e}", part.display()))?;
+        return Err(format!(
+            "dictation: model checksum mismatch (expected {expected_hex}, got {actual_hex})"
+        ));
+    }
+    std::fs::rename(part, final_path)
+        .map_err(|e| format!("dictation: finalize {}: {e}", final_path.display()))
+}
+
+/// Removes a `.part` file on drop unless [`disarm`](PartGuard::disarm)ed, so a
+/// failed download never leaves a stray partial behind.
+pub struct PartGuard {
+    path: PathBuf,
+    armed: bool,
+}
+
+impl PartGuard {
+    pub fn new(path: PathBuf) -> Self {
+        Self { path, armed: true }
+    }
+    pub fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for PartGuard {
+    fn drop(&mut self) {
+        if self.armed && self.path.exists() {
+            if let Err(e) = std::fs::remove_file(&self.path) {
+                tracing::debug!("dictation: cleanup of {} failed: {e}", self.path.display());
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sha2::{Digest, Sha256};
+
+    #[test]
+    fn hex_of_known_input() {
+        // sha256("") — a fixed vector anchoring the hex encoder + digest wiring.
+        assert_eq!(
+            hex(&Sha256::digest(b"")),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn finalize_renames_on_match() {
+        let dir = std::env::temp_dir().join(format!("dict-fin-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let part = dir.join("m.part");
+        let final_path = dir.join("m.bin");
+        std::fs::write(&part, b"hello").unwrap();
+        let actual = hex(&Sha256::digest(b"hello"));
+
+        verify_and_finalize(&part, &final_path, &actual, &actual).unwrap();
+        assert!(!part.exists(), "part removed after rename");
+        assert_eq!(std::fs::read(&final_path).unwrap(), b"hello");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn finalize_rejects_mismatch_and_removes_part() {
+        let dir = std::env::temp_dir().join(format!("dict-mis-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let part = dir.join("m.part");
+        let final_path = dir.join("m.bin");
+        std::fs::write(&part, b"corrupt").unwrap();
+
+        let err = verify_and_finalize(&part, &final_path, "deadbeef", "cafe").unwrap_err();
+        assert!(err.contains("checksum mismatch"));
+        assert!(!part.exists(), "corrupt part removed");
+        assert!(!final_path.exists(), "nothing landed at the final path");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn part_guard_removes_on_drop_but_not_after_disarm() {
+        let dir = std::env::temp_dir().join(format!("dict-guard-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let armed = dir.join("armed.part");
+        std::fs::write(&armed, b"x").unwrap();
+        drop(PartGuard::new(armed.clone()));
+        assert!(!armed.exists(), "armed guard removes the part on drop");
+
+        let kept = dir.join("kept.part");
+        std::fs::write(&kept, b"x").unwrap();
+        PartGuard::new(kept.clone()).disarm();
+        assert!(kept.exists(), "disarmed guard leaves the file");
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+}

--- a/app/src-tauri/src/dictation/wav.rs
+++ b/app/src-tauri/src/dictation/wav.rs
@@ -1,0 +1,126 @@
+//! Pure helpers for deriving a transcription timeout from a recorded WAV, plus
+//! the worker-thread clamp. No I/O — all unit-testable without the sidecar.
+
+use std::time::Duration;
+
+/// Bytes/second for the recorder's format (16 kHz mono 16-bit PCM): the
+/// fallback rate when a WAV header can't be parsed.
+const FALLBACK_BYTE_RATE: u64 = 16_000 * 2;
+
+/// The floor a transcription is always allowed, regardless of clip length.
+const MIN_TIMEOUT_SECS: u64 = 30;
+
+/// Estimated audio duration, in seconds, from the raw WAV bytes.
+///
+/// Parses the RIFF/`fmt `/`data` chunks to read the real byte rate and sample
+/// data size; on any malformed/short header it falls back to dividing the whole
+/// buffer by the recorder's known byte rate. Never panics.
+pub fn duration_secs(bytes: &[u8]) -> f64 {
+    if let Some(d) = parse_duration(bytes) {
+        return d;
+    }
+    (bytes.len() as f64) / (FALLBACK_BYTE_RATE as f64)
+}
+
+fn parse_duration(bytes: &[u8]) -> Option<f64> {
+    if bytes.len() < 12 || &bytes[0..4] != b"RIFF" || &bytes[8..12] != b"WAVE" {
+        return None;
+    }
+    let mut byte_rate: Option<u32> = None;
+    let mut data_size: Option<u32> = None;
+    // Walk chunks: [4-byte id][4-byte LE size][size bytes of body].
+    let mut pos = 12usize;
+    while pos + 8 <= bytes.len() {
+        let id = &bytes[pos..pos + 4];
+        let size = u32::from_le_bytes(bytes[pos + 4..pos + 8].try_into().ok()?) as usize;
+        let body = pos + 8;
+        match id {
+            b"fmt " if body + 16 <= bytes.len() => {
+                // fmt layout: format(2) channels(2) sampleRate(4) byteRate(4)...
+                byte_rate = Some(u32::from_le_bytes(
+                    bytes[body + 8..body + 12].try_into().ok()?,
+                ));
+            }
+            b"data" => data_size = Some(size as u32),
+            _ => {}
+        }
+        // Chunk bodies are word-aligned: odd sizes carry a pad byte.
+        pos = body + size + (size & 1);
+    }
+    let rate = byte_rate.filter(|r| *r > 0)?;
+    let data = data_size?;
+    Some((data as f64) / (rate as f64))
+}
+
+/// Timeout for one transcription: `max(30s, 4 × audio duration)`.
+pub fn transcription_timeout(duration_secs: f64) -> Duration {
+    let scaled = (duration_secs * 4.0).ceil().max(0.0);
+    let secs = (scaled as u64).max(MIN_TIMEOUT_SECS);
+    Duration::from_secs(secs)
+}
+
+/// whisper worker threads: available parallelism clamped to `1..=8`.
+pub fn clamp_threads(available: usize) -> usize {
+    available.clamp(1, 8)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a minimal but valid 16 kHz mono 16-bit PCM WAV header wrapping
+    /// `data_len` bytes of (absent) sample data.
+    fn synthetic_header(data_len: u32) -> Vec<u8> {
+        let byte_rate: u32 = 16_000 * 2;
+        let mut w = Vec::new();
+        w.extend_from_slice(b"RIFF");
+        w.extend_from_slice(&(36 + data_len).to_le_bytes());
+        w.extend_from_slice(b"WAVE");
+        w.extend_from_slice(b"fmt ");
+        w.extend_from_slice(&16u32.to_le_bytes()); // fmt chunk size
+        w.extend_from_slice(&1u16.to_le_bytes()); // PCM
+        w.extend_from_slice(&1u16.to_le_bytes()); // mono
+        w.extend_from_slice(&16_000u32.to_le_bytes()); // sample rate
+        w.extend_from_slice(&byte_rate.to_le_bytes());
+        w.extend_from_slice(&2u16.to_le_bytes()); // block align
+        w.extend_from_slice(&16u16.to_le_bytes()); // bits/sample
+        w.extend_from_slice(b"data");
+        w.extend_from_slice(&data_len.to_le_bytes());
+        w
+    }
+
+    #[test]
+    fn duration_parsed_from_header() {
+        // 2 seconds of audio = byte_rate * 2 = 64000 data bytes.
+        let wav = synthetic_header(64_000);
+        assert!((duration_secs(&wav) - 2.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn duration_falls_back_when_header_garbage() {
+        // Not a RIFF/WAVE buffer: divide whole length by the fallback rate.
+        let junk = vec![0u8; 32_000];
+        assert!((duration_secs(&junk) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn timeout_honors_30s_floor() {
+        // A 1s clip → 4s, floored up to the 30s minimum.
+        assert_eq!(transcription_timeout(1.0), Duration::from_secs(30));
+        assert_eq!(transcription_timeout(0.0), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn timeout_scales_4x_past_floor() {
+        // A 60s clip → 240s dominates the floor.
+        assert_eq!(transcription_timeout(60.0), Duration::from_secs(240));
+    }
+
+    #[test]
+    fn threads_clamped_to_1_8() {
+        assert_eq!(clamp_threads(0), 1);
+        assert_eq!(clamp_threads(1), 1);
+        assert_eq!(clamp_threads(4), 4);
+        assert_eq!(clamp_threads(32), 8);
+    }
+}

--- a/app/src-tauri/src/dictation/whisper.rs
+++ b/app/src-tauri/src/dictation/whisper.rs
@@ -1,0 +1,246 @@
+//! `transcribe_audio`: run the bundled `whisper-cli` over a recorded WAV.
+//!
+//! The raw 16 kHz mono 16-bit PCM audio rides the IPC payload as
+//! [`InvokeBody::Raw`] (JSON-encoding a multi-megabyte clip number-by-number
+//! would freeze the webview — same reasoning as `commands::save_file`). The
+//! language hint travels in the `x-dictation-lang` header. The sidecar child
+//! gets the SAME orphan-prevention discipline as the engine/frpc sidecars
+//! (Unix process group + `killpg`, Windows kill-on-close Job Object).
+
+use std::io::{BufReader, Read};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, Instant};
+
+use tauri::ipc::{InvokeBody, Request};
+use tauri::{AppHandle, Manager};
+
+use super::{model, wav};
+use crate::child_guard;
+
+/// Monotonic suffix so concurrent transcriptions never collide on a temp path.
+static TEMP_SEQ: AtomicU64 = AtomicU64::new(0);
+
+#[tauri::command]
+pub async fn transcribe_audio(app: AppHandle, request: Request<'_>) -> Result<String, String> {
+    let InvokeBody::Raw(bytes) = request.body() else {
+        return Err("transcribe_audio expects a raw byte payload".into());
+    };
+    let lang = normalize_lang(
+        request
+            .headers()
+            .get("x-dictation-lang")
+            .and_then(|v| v.to_str().ok()),
+    );
+
+    let model_path = model::model_path(&app)?;
+    if std::fs::metadata(&model_path).is_err() {
+        // Exact string — the frontend maps it to the "download the model" flow.
+        return Err("model-not-ready".into());
+    }
+
+    let resource_dir = app.path().resource_dir().ok();
+    let binary = child_guard::resolve_bundled_binary(
+        "whisper-cli",
+        resource_dir.as_ref(),
+        "HOUSTON_WHISPER_BIN",
+    )?;
+
+    let wav_file = TempWav::write(bytes)?;
+    let threads = wav::clamp_threads(
+        std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(1),
+    );
+    let timeout = wav::transcription_timeout(wav::duration_secs(bytes));
+    let args = build_args(&model_path, wav_file.path(), lang, threads);
+
+    run_whisper(&binary, &args, timeout).await
+}
+
+/// Validate the language hint against the supported set; anything missing or
+/// unrecognized falls through to whisper's autodetect.
+fn normalize_lang(raw: Option<&str>) -> &'static str {
+    match raw.map(str::trim) {
+        Some("en") => "en",
+        Some("es") => "es",
+        Some("pt") => "pt",
+        _ => "auto",
+    }
+}
+
+/// `-nt` (no timestamps) + `-np` (no progress prints) keep stdout to the bare
+/// transcript; no `-o*` flags means whisper writes no output files.
+fn build_args(model: &Path, wav: &Path, lang: &str, threads: usize) -> Vec<String> {
+    vec![
+        "-m".into(),
+        model.to_string_lossy().into_owned(),
+        "-f".into(),
+        wav.to_string_lossy().into_owned(),
+        "-l".into(),
+        lang.into(),
+        "-t".into(),
+        threads.to_string(),
+        "-nt".into(),
+        "-np".into(),
+    ]
+}
+
+/// Spawn the hardened child, drain its stdout, and enforce the timeout by
+/// polling `try_wait`. On timeout the whole process group / job is killed and
+/// `Err("transcription-timeout")` returned.
+async fn run_whisper(binary: &Path, args: &[String], timeout: Duration) -> Result<String, String> {
+    let mut cmd = Command::new(binary);
+    cmd.args(args)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .stdin(Stdio::null());
+
+    #[cfg(unix)]
+    unsafe {
+        use std::os::unix::process::CommandExt;
+        cmd.pre_exec(child_guard::set_new_process_group);
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(child_guard::CREATE_NEW_PROCESS_GROUP | child_guard::CREATE_NO_WINDOW);
+    }
+
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("dictation: spawn {}: {e}", binary.display()))?;
+
+    #[cfg(windows)]
+    let _job = match child_guard::win_job::assign(&child) {
+        Ok(job) => job,
+        Err(e) => {
+            child
+                .kill()
+                .map_err(|e| format!("dictation: kill after job-bind fail: {e}"))?;
+            return Err(format!("dictation: bind to job object: {e}"));
+        }
+    };
+
+    // Drain stdout on a thread so a full pipe buffer can't deadlock the child.
+    let stdout = child.stdout.take().ok_or("dictation: no stdout")?;
+    let reader = std::thread::spawn(move || {
+        let mut buf = String::new();
+        BufReader::new(stdout).read_to_string(&mut buf).map(|_| buf)
+    });
+
+    let deadline = Instant::now() + timeout;
+    let status = loop {
+        match child
+            .try_wait()
+            .map_err(|e| format!("dictation: wait on whisper: {e}"))?
+        {
+            Some(status) => break status,
+            None if Instant::now() >= deadline => {
+                #[cfg(unix)]
+                child_guard::kill_process_group(child.id() as i32);
+                #[cfg(windows)]
+                child
+                    .kill()
+                    .map_err(|e| format!("dictation: kill on timeout: {e}"))?;
+                return Err("transcription-timeout".into());
+            }
+            None => tokio::time::sleep(Duration::from_millis(50)).await,
+        }
+    };
+
+    let text = reader
+        .join()
+        .map_err(|_| "dictation: stdout reader panicked".to_string())?
+        .map_err(|e| format!("dictation: read whisper stdout: {e}"))?;
+    if !status.success() {
+        return Err(format!("dictation: whisper exited with {status}"));
+    }
+    Ok(text.trim().to_string())
+}
+
+/// A uniquely-named temp WAV whose file is removed when this handle drops,
+/// regardless of how the transcription returns.
+struct TempWav {
+    path: PathBuf,
+}
+
+impl TempWav {
+    fn write(bytes: &[u8]) -> Result<Self, String> {
+        let seq = TEMP_SEQ.fetch_add(1, Ordering::Relaxed);
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = std::env::temp_dir().join(format!(
+            "houston-dictation-{}-{seq}-{nanos}.wav",
+            std::process::id()
+        ));
+        std::fs::write(&path, bytes)
+            .map_err(|e| format!("dictation: write temp wav {}: {e}", path.display()))?;
+        Ok(Self { path })
+    }
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempWav {
+    fn drop(&mut self) {
+        if let Err(e) = std::fs::remove_file(&self.path) {
+            tracing::debug!("dictation: temp wav cleanup failed: {e}");
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lang_hint_maps_supported_langs() {
+        assert_eq!(normalize_lang(Some("en")), "en");
+        assert_eq!(normalize_lang(Some("es")), "es");
+        assert_eq!(normalize_lang(Some("pt")), "pt");
+        assert_eq!(normalize_lang(Some("auto")), "auto");
+    }
+
+    #[test]
+    fn lang_hint_defaults_to_auto() {
+        assert_eq!(normalize_lang(None), "auto");
+        assert_eq!(normalize_lang(Some("fr")), "auto");
+        assert_eq!(normalize_lang(Some("")), "auto");
+    }
+
+    #[test]
+    fn args_carry_model_wav_lang_threads_and_flags() {
+        let args = build_args(Path::new("/m/model.bin"), Path::new("/t/clip.wav"), "es", 4);
+        assert_eq!(
+            args,
+            vec![
+                "-m",
+                "/m/model.bin",
+                "-f",
+                "/t/clip.wav",
+                "-l",
+                "es",
+                "-t",
+                "4",
+                "-nt",
+                "-np",
+            ]
+        );
+    }
+
+    #[test]
+    fn temp_wav_written_then_removed_on_drop() {
+        let path;
+        {
+            let wav = TempWav::write(b"RIFFdata").unwrap();
+            path = wav.path().to_path_buf();
+            assert_eq!(std::fs::read(&path).unwrap(), b"RIFFdata");
+        }
+        assert!(!path.exists(), "temp wav removed when handle drops");
+    }
+}

--- a/app/src-tauri/src/lib.rs
+++ b/app/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ mod child_guard;
 mod claude_login;
 mod codex_oauth_loopback;
 mod commands;
+mod dictation;
 #[cfg(target_os = "macos")]
 mod dmg_guard;
 mod engine_supervisor;
@@ -408,6 +409,11 @@ pub fn run() {
             // proxy key so the cloud endpoint's apiKey stays valid.
             local_bridge::commands::saved_bridge_target,
             local_bridge::commands::reconnect_local_bridge,
+            // On-device dictation: transcribe recorded audio with the bundled
+            // whisper.cpp sidecar, and download/verify its pinned model.
+            dictation::transcribe_audio,
+            dictation::dictation_model_status,
+            dictation::download_dictation_model,
         ])
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/app/src-tauri/tauri.conf.json
+++ b/app/src-tauri/tauri.conf.json
@@ -49,7 +49,8 @@
     "externalBin": [
       "binaries/houston-engine",
       "binaries/claude",
-      "binaries/frpc"
+      "binaries/frpc",
+      "binaries/whisper-cli"
     ],
     "resources": {
       "../../store": "store"

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -159,6 +159,7 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           composerLabels={composerLabels}
           currentUserId={panel.currentUserId}
           authorLabels={panel.authorLabels}
+          dictation={panel.dictation}
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           onOpenLink={handleOpenLink}

--- a/app/src/components/dictation-setup-dialog.tsx
+++ b/app/src/components/dictation-setup-dialog.tsx
@@ -1,0 +1,72 @@
+/**
+ * One-time consent dialog for the dictation model download (~181 MB,
+ * whisper.cpp `ggml-small-q5_1`). Shown by `useDictation` the first time the
+ * user hits the mic and the model isn't on disk yet; download progress
+ * streams in via `onDictationModelProgress` (`use-dictation.ts` owns the
+ * subscription, this component just renders the resulting numbers).
+ */
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Progress,
+} from "@houston-ai/core";
+import { useTranslation } from "react-i18next";
+import type { DictationModelSetup } from "../lib/dictation/use-dictation";
+
+export function DictationSetupDialog({
+  modelSetup,
+}: {
+  modelSetup: DictationModelSetup;
+}) {
+  const { t } = useTranslation("chat");
+
+  return (
+    <Dialog
+      open={modelSetup.open}
+      onOpenChange={(next) => {
+        if (!next) modelSetup.dismiss();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("composer.dictation.setupTitle")}</DialogTitle>
+          <DialogDescription>
+            {t("composer.dictation.setupBody", {
+              sizeMb: modelSetup.sizeMb,
+            })}
+          </DialogDescription>
+        </DialogHeader>
+        {modelSetup.downloading && (
+          <div className="flex flex-col gap-2">
+            <Progress value={modelSetup.progressPct} />
+            <p className="text-xs text-muted-foreground">
+              {t("composer.dictation.setupProgress", {
+                pct: modelSetup.progressPct,
+              })}
+            </p>
+          </div>
+        )}
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={modelSetup.dismiss}
+            disabled={modelSetup.downloading}
+          >
+            {t("composer.dictation.cancel")}
+          </Button>
+          <Button
+            onClick={modelSetup.confirm}
+            disabled={modelSetup.downloading}
+          >
+            {t("composer.dictation.setupConfirm")}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -64,6 +64,8 @@ import {
   sessionContextUsage,
 } from "../lib/context-usage";
 import { createMission } from "../lib/create-mission";
+import { resolveDictationLangHint } from "../lib/dictation/types";
+import { useDictation } from "../lib/dictation/use-dictation";
 import { humanizeSkillName } from "../lib/humanize-skill-name";
 import { composeInteractionReply } from "../lib/interaction-reply";
 import {
@@ -71,6 +73,7 @@ import {
   resolvePersonalModelPin,
 } from "../lib/model-selector-lock";
 import { canManageAgentGrants, isMultiplayer } from "../lib/org-roles";
+import { osIsTauri } from "../lib/os-bridge";
 import {
   decideHandoffMode,
   estimateConversationTokens,
@@ -101,6 +104,7 @@ import {
 } from "../lib/tauri";
 import { normalizeTurnMode, type TurnMode } from "../lib/turn-mode";
 import type { Agent, AgentDefinition, SkillSummary } from "../lib/types";
+import { useDraftStore } from "../stores/drafts";
 import { useUIStore } from "../stores/ui";
 import { ChatConnectInteractionCard } from "./chat-connect-interaction-card";
 import { resolveEffectiveProvider } from "./chat-effective-provider";
@@ -109,6 +113,7 @@ import { ChatModeSelector } from "./chat-mode-selector";
 import { ChatModelSelector } from "./chat-model-selector";
 import { ContextCompactedDivider } from "./context-compacted-divider";
 import { ContextIndicator } from "./context-indicator";
+import { DictationSetupDialog } from "./dictation-setup-dialog";
 import { IntegrationConnectCard } from "./integration-connect-card";
 import { parseToolkitFromHref } from "./integration-connect-card-state";
 import { integrationsSupported } from "./integrations/model";
@@ -192,6 +197,9 @@ interface AgentChatPanelProps {
   currentUserId: ChatPanelProps["currentUserId"];
   /** Localized author-attribution labels forwarded to ChatPanel. */
   authorLabels: ChatPanelProps["authorLabels"];
+  /** Prop-driven dictation control for the composer mic. Undefined on web
+   *  (no native mic capture) — ChatPanel hides the mic entirely. */
+  dictation: ChatPanelProps["dictation"];
 }
 
 export function useAgentChatPanel({
@@ -200,7 +208,7 @@ export function useAgentChatPanel({
   selectedSessionKey,
   onSelectSession,
 }: UseAgentChatPanelArgs): AgentChatPanelProps {
-  const { t } = useTranslation(["board", "chat", "teams"]);
+  const { t, i18n } = useTranslation(["board", "chat", "teams"]);
   const {
     processLabels,
     getThinkingMessage,
@@ -215,6 +223,29 @@ export function useAgentChatPanel({
   const { data: session } = useSession();
   const currentUserId = session?.user.id;
   const authorLabels = undefined;
+
+  // ── Dictation (desktop-only voice typing) ──────────────────────────────
+  // Transcript text is appended to the SAME draft store AIBoard's
+  // `drafts`/`onDraftChange` read from (`useBoardDrafts` in mission-board.tsx)
+  // — the key mirrors AIBoard's own `activeSessionKey ?? "new-conversation"`
+  // derivation, so dictating into a fresh composer lands in the same draft
+  // the user would see if they typed instead.
+  const draftKey = selectedSessionKey ?? "new-conversation";
+  const handleDictationTranscript = useCallback(
+    (text: string) => {
+      const current = useDraftStore.getState().drafts[draftKey]?.text ?? "";
+      const needsSpace = current.length > 0 && !current.endsWith(" ");
+      useDraftStore
+        .getState()
+        .setDraftText(draftKey, `${current}${needsSpace ? " " : ""}${text}`);
+    },
+    [draftKey],
+  );
+  const { dictation, modelSetup } = useDictation({
+    onTranscript: handleDictationTranscript,
+    langHint: resolveDictationLangHint(i18n.resolvedLanguage),
+    enabled: osIsTauri(),
+  });
 
   // Integration connect cards are a new-engine feature: the host advertises
   // its wired providers in capabilities; the legacy Rust engine (null) and
@@ -1310,6 +1341,7 @@ export function useAgentChatPanel({
         onConfirm={confirmProviderSwitch}
         onCancel={() => setSwitchDialog(null)}
       />
+      <DictationSetupDialog modelSetup={modelSetup} />
     </>
   ) : null;
 
@@ -1339,5 +1371,6 @@ export function useAgentChatPanel({
     turnMode,
     currentUserId,
     authorLabels,
+    dictation,
   };
 }

--- a/app/src/lib/dictation/dictation-reducer.ts
+++ b/app/src/lib/dictation/dictation-reducer.ts
@@ -1,0 +1,80 @@
+/**
+ * Pure state machine for the composer's dictation control. Mirrors
+ * `DictationState` from `@houston-ai/chat` exactly (idle | requesting |
+ * recording | transcribing) so `use-dictation.ts` can hand `state` straight
+ * through to `DictationControl`. Kept separate from the hook so the
+ * transitions (including error paths and the 120s auto-stop) are unit
+ * testable without a DOM/React runner (`app/tests/dictation-reducer.test.ts`).
+ *
+ * The model-download consent dialog is deliberately NOT part of this
+ * machine: per contract, `DictationControl.state` stays "idle" while that
+ * dialog is open (nothing is being captured yet) — `use-dictation.ts` tracks
+ * it as separate `modelSetup` state.
+ */
+
+export type DictationPhase =
+  | "idle"
+  | "requesting"
+  | "recording"
+  | "transcribing";
+
+export interface DictationMachineState {
+  phase: DictationPhase;
+  /** Epoch ms capture began. Set on `micGranted`, cleared once idle again. */
+  recordingStartedAt?: number;
+}
+
+export type DictationEvent =
+  | { type: "start" }
+  | { type: "micGranted"; startedAt: number }
+  | { type: "micFailed" }
+  | { type: "stop" }
+  | { type: "autoStop" }
+  | { type: "cancel" }
+  | { type: "transcribeSettled" }
+  | { type: "reset" };
+
+export const INITIAL_DICTATION_STATE: DictationMachineState = { phase: "idle" };
+
+/**
+ * Advance the machine. Events that don't apply to the current phase are
+ * no-ops (returns the same reference) rather than throwing — a stray
+ * `micGranted` after the user already cancelled, or a `cancel` while
+ * transcribing (there's nothing left to discard), must not crash the
+ * composer.
+ */
+export function dictationReducer(
+  state: DictationMachineState,
+  event: DictationEvent,
+): DictationMachineState {
+  switch (event.type) {
+    case "start":
+      return state.phase === "idle" ? { phase: "requesting" } : state;
+
+    case "micGranted":
+      return state.phase === "requesting"
+        ? { phase: "recording", recordingStartedAt: event.startedAt }
+        : state;
+
+    case "micFailed":
+      return state.phase === "requesting" ? { phase: "idle" } : state;
+
+    case "stop":
+    case "autoStop":
+      return state.phase === "recording" ? { phase: "transcribing" } : state;
+
+    case "cancel":
+      return state.phase === "requesting" || state.phase === "recording"
+        ? { phase: "idle" }
+        : state;
+
+    case "transcribeSettled":
+      return state.phase === "transcribing" ? { phase: "idle" } : state;
+
+    case "reset":
+      return state.phase === "idle" ? state : { phase: "idle" };
+
+    default:
+      return state;
+  }
+}

--- a/app/src/lib/dictation/model-download.ts
+++ b/app/src/lib/dictation/model-download.ts
@@ -1,0 +1,25 @@
+/**
+ * Thin wrapper around the model-download IPC pair (`osDownloadDictationModel`
+ * + the `dictation-model-progress` event) so `use-dictation.ts` doesn't carry
+ * the subscribe/unsubscribe boilerplate inline.
+ */
+import {
+  onDictationModelProgress,
+  osDownloadDictationModel,
+} from "../os-bridge";
+
+/** Download (and sha256-verify) the pinned dictation model, reporting 0-100
+ *  progress as it streams. Rethrows any failure after cleaning up the
+ *  progress subscription — the caller is responsible for surfacing it. */
+export async function downloadDictationModel(
+  onProgress: (pct: number) => void,
+): Promise<void> {
+  const unlisten = await onDictationModelProgress((p) => {
+    onProgress(p.total > 0 ? Math.round((p.received / p.total) * 100) : 0);
+  }).catch(() => undefined);
+  try {
+    await osDownloadDictationModel();
+  } finally {
+    unlisten?.();
+  }
+}

--- a/app/src/lib/dictation/recorder-worklet.ts
+++ b/app/src/lib/dictation/recorder-worklet.ts
@@ -1,0 +1,23 @@
+/**
+ * Source for the `dictation-capture` AudioWorkletProcessor, as a plain
+ * string. There's no other worklet/worker in this repo to follow a
+ * `public/` asset convention from, so this loads via a Blob URL instead
+ * (see `recorder.ts`) — no bundler wiring needed, works identically under
+ * Vite dev and the packaged Tauri app.
+ *
+ * Posts each 128-frame render quantum's mono channel data back to the main
+ * thread as a Float32Array (structured-clone copy, so the processor's
+ * internal buffer can't be mutated out from under an in-flight postMessage).
+ */
+export const DICTATION_WORKLET_SOURCE = `
+class DictationCaptureProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const channel = inputs[0]?.[0];
+    if (channel && channel.length > 0) {
+      this.port.postMessage(channel.slice());
+    }
+    return true;
+  }
+}
+registerProcessor("dictation-capture", DictationCaptureProcessor);
+`;

--- a/app/src/lib/dictation/recorder.ts
+++ b/app/src/lib/dictation/recorder.ts
@@ -1,0 +1,128 @@
+/**
+ * Desktop dictation audio capture.
+ *
+ * WKWebView's `MediaRecorder` only emits AAC (no PCM/Opus container we could
+ * feed whisper), so capture instead goes: `getUserMedia` -> an `AudioContext`
+ * pinned to 16 kHz -> an `AudioWorklet` that posts raw Float32 frames back to
+ * the main thread -> accumulate -> on stop, resample (if the platform ignored
+ * the requested rate) -> encode as WAV (`wav.ts`).
+ *
+ * Auto-stops at 120s via `onAutoStop`; the caller (the dictation state
+ * machine in `use-dictation.ts`) treats that identically to a user-initiated
+ * stop — it still has to call `.stop()` to get the encoded bytes.
+ */
+
+import { DICTATION_WORKLET_SOURCE } from "./recorder-worklet";
+import {
+  DICTATION_SAMPLE_RATE,
+  encodeWav,
+  mergeFloat32,
+  resampleLinear,
+} from "./wav";
+
+const MAX_RECORDING_MS = 120_000;
+const WORKLET_NAME = "dictation-capture";
+
+export interface DictationRecording {
+  /** Stop capture, tear down all audio resources, and return the encoded WAV. */
+  stop(): Promise<Uint8Array>;
+  /** Discard capture and tear down all audio resources. */
+  cancel(): void;
+}
+
+/** True when this webview can capture microphone audio at all. Mirrors the
+ *  feature-detect `captureScreenshot` does in ui/chat/prompt-input.tsx. */
+export function isDictationCaptureSupported(): boolean {
+  return (
+    typeof navigator !== "undefined" && !!navigator.mediaDevices?.getUserMedia
+  );
+}
+
+function createWorkletModuleUrl(): string {
+  const blob = new Blob([DICTATION_WORKLET_SOURCE], {
+    type: "application/javascript",
+  });
+  return URL.createObjectURL(blob);
+}
+
+function stopTracks(stream: MediaStream): void {
+  for (const track of stream.getTracks()) track.stop();
+}
+
+/**
+ * Start capturing microphone audio. Rejects with the raw `getUserMedia`
+ * error (`NotAllowedError` / `NotFoundError` / ...) so the caller can map it
+ * to specific copy.
+ */
+export async function startDictationRecording(
+  onAutoStop: () => void,
+): Promise<DictationRecording> {
+  if (!isDictationCaptureSupported()) {
+    throw new DOMException(
+      "No microphone input is available.",
+      "NotFoundError",
+    );
+  }
+
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true },
+  });
+
+  const audioContext = new AudioContext({ sampleRate: DICTATION_SAMPLE_RATE });
+  let node: AudioWorkletNode;
+  try {
+    const moduleUrl = createWorkletModuleUrl();
+    try {
+      await audioContext.audioWorklet.addModule(moduleUrl);
+    } finally {
+      URL.revokeObjectURL(moduleUrl);
+    }
+    node = new AudioWorkletNode(audioContext, WORKLET_NAME);
+  } catch (err) {
+    stopTracks(stream);
+    await audioContext.close();
+    throw err;
+  }
+
+  const frames: Float32Array[] = [];
+  node.port.onmessage = (event: MessageEvent<Float32Array>) => {
+    frames.push(event.data);
+  };
+  const source = audioContext.createMediaStreamSource(stream);
+  source.connect(node);
+  // Deliberately no `.connect(audioContext.destination)` — the user must
+  // never hear their own mic looped back through the app.
+
+  let tornDown = false;
+  function teardown(): void {
+    if (tornDown) return;
+    tornDown = true;
+    clearTimeout(autoStopTimer);
+    node.port.onmessage = null;
+    node.disconnect();
+    source.disconnect();
+    stopTracks(stream);
+    void audioContext.close();
+  }
+
+  const autoStopTimer = setTimeout(() => {
+    if (!tornDown) onAutoStop();
+  }, MAX_RECORDING_MS);
+
+  return {
+    async stop() {
+      const actualRate = audioContext.sampleRate;
+      const merged = mergeFloat32(frames);
+      teardown();
+      const resampled = resampleLinear(
+        merged,
+        actualRate,
+        DICTATION_SAMPLE_RATE,
+      );
+      return encodeWav(resampled, DICTATION_SAMPLE_RATE);
+    },
+    cancel() {
+      teardown();
+    },
+  };
+}

--- a/app/src/lib/dictation/types.ts
+++ b/app/src/lib/dictation/types.ts
@@ -1,0 +1,49 @@
+/**
+ * Wire shapes the Rust shell's three dictation commands speak
+ * (`app/src-tauri/src/dictation/`), plus small pure helpers used by the
+ * composer wiring. Kept dependency-free (bar `../locale`) so it loads under
+ * the bare Node test runner.
+ */
+
+import { normalizeLocale } from "../locale";
+
+/** Mirrors `DictationModelStatus` in `app/src-tauri/src/dictation/types.rs`
+ *  (`dictation_model_status`'s return shape). */
+export interface DictationModelStatus {
+  ready: boolean;
+  modelId: string;
+  sizeBytes: number;
+}
+
+/** A single progress tick on the `dictation-model-progress` event, mirroring
+ *  `ModelProgress` in the Rust shell (`download_dictation_model`). */
+export interface DictationModelProgress {
+  received: number;
+  total: number;
+  phase: "downloading" | "verifying" | "done" | "error";
+}
+
+/** The `x-dictation-lang` header value `transcribe_audio` accepts. */
+export type DictationLangHint = "en" | "es" | "pt" | "auto";
+
+/** Maps the app's resolved UI language to whisper's language hint;
+ *  unsupported/unresolved locales fall through to "auto" (whisper
+ *  autodetects rather than mis-transcribing under a wrong forced language). */
+export function resolveDictationLangHint(
+  resolvedLanguage: string | undefined,
+): DictationLangHint {
+  return normalizeLocale(resolvedLanguage) ?? "auto";
+}
+
+/** Tauri rejects with either a raw string (Rust's `Err(String)`, e.g. the
+ *  sentinel `"model-not-ready"`) or an `Error`; normalize to plain text. */
+export function dictationErrorText(err: unknown): string {
+  if (typeof err === "string") return err;
+  if (err instanceof Error) return err.message;
+  return String(err);
+}
+
+/** Bytes -> whole MB, floored at 1 so a tiny/zero size never reads as "0 MB". */
+export function dictationSizeMb(sizeBytes: number): number {
+  return Math.max(1, Math.round(sizeBytes / 1_000_000));
+}

--- a/app/src/lib/dictation/use-dictation-model-setup.ts
+++ b/app/src/lib/dictation/use-dictation-model-setup.ts
@@ -1,0 +1,110 @@
+/**
+ * Model-download consent state for dictation: whether the pinned whisper
+ * model needs downloading, its download progress, and the confirm/dismiss
+ * actions `DictationSetupDialog` drives. Split out of `use-dictation.ts` so
+ * that hook stays focused on the capture/transcribe state machine.
+ *
+ * Deliberately outside `dictation-reducer.ts`'s phase machine: per contract
+ * `DictationControl.state` stays "idle" while this dialog is open — nothing
+ * is being captured yet.
+ */
+import { useCallback, useMemo, useState } from "react";
+import { showErrorToast } from "../error-toast";
+import { osDictationModelStatus } from "../os-bridge";
+import { downloadDictationModel } from "./model-download";
+import {
+  dictationErrorText as errorText,
+  dictationSizeMb as toMb,
+} from "./types";
+
+/** Matches `MODEL_SIZE_BYTES` in `app/src-tauri/src/dictation/model.rs`;
+ *  used only as a size-hint fallback if a status probe fails. */
+const DEFAULT_MODEL_SIZE_MB = 181;
+
+export interface DictationModelSetup {
+  open: boolean;
+  downloading: boolean;
+  progressPct: number;
+  sizeMb: number;
+  confirm: () => void;
+  dismiss: () => void;
+}
+
+export interface UseDictationModelSetupResult {
+  modelSetup: DictationModelSetup;
+  /** Probe status: ready -> call `onReady()`; not ready -> open the dialog
+   *  with a fresh size hint. Surfaces a probe failure itself (toast). */
+  ensureReady: () => Promise<void>;
+  /** Re-probe + reopen after a downstream "model-not-ready" failure (the
+   *  model vanished after an earlier ready check). Best-effort size fetch —
+   *  the dialog opens either way. */
+  reopen: () => Promise<void>;
+  /** Force-close, e.g. on disable/unmount. */
+  reset: () => void;
+}
+
+export function useDictationModelSetup(
+  onReady: () => void,
+): UseDictationModelSetupResult {
+  const [open, setOpen] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [progressPct, setProgressPct] = useState(0);
+  const [sizeMb, setSizeMb] = useState(DEFAULT_MODEL_SIZE_MB);
+
+  const reopen = useCallback(async () => {
+    try {
+      setSizeMb(toMb((await osDictationModelStatus()).sizeBytes));
+    } catch {
+      /* keep the last-known size hint */
+    }
+    setOpen(true);
+  }, []);
+
+  const ensureReady = useCallback(async () => {
+    try {
+      const status = await osDictationModelStatus();
+      if (status.ready) {
+        onReady();
+        return;
+      }
+      setSizeMb(toMb(status.sizeBytes));
+      setOpen(true);
+    } catch (err) {
+      showErrorToast("dictation_model_status", errorText(err), err);
+    }
+  }, [onReady]);
+
+  const confirm = useCallback(async () => {
+    setDownloading(true);
+    setProgressPct(0);
+    try {
+      await downloadDictationModel(setProgressPct);
+      setOpen(false);
+      setDownloading(false);
+      onReady();
+    } catch (err) {
+      setDownloading(false);
+      showErrorToast("dictation_download_model", errorText(err), err);
+    }
+  }, [onReady]);
+
+  const dismiss = useCallback(() => setOpen(false), []);
+  const reset = useCallback(() => {
+    setOpen(false);
+    setDownloading(false);
+  }, []);
+
+  const modelSetup: DictationModelSetup = useMemo(
+    () => ({
+      open,
+      downloading,
+      progressPct,
+      sizeMb,
+      confirm: () => void confirm(),
+      dismiss,
+    }),
+    [open, downloading, progressPct, sizeMb, confirm, dismiss],
+  );
+
+  return { modelSetup, ensureReady, reopen, reset };
+}

--- a/app/src/lib/dictation/use-dictation.ts
+++ b/app/src/lib/dictation/use-dictation.ts
@@ -1,0 +1,173 @@
+/**
+ * Dictation state machine hook: mic capture + transcription, exposed as a
+ * `DictationControl` the composer hands straight to `ChatPanel`
+ * (`@houston-ai/chat`). Model-download consent is a sibling concern, split
+ * out to `use-dictation-model-setup.ts`.
+ *
+ * The capture/transcribe phases are the pure `dictationReducer`
+ * (`dictation-reducer.ts`); this hook drives it and layers on the I/O.
+ */
+import type { DictationControl, DictationLabels } from "@houston-ai/chat";
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useUIStore } from "../../stores/ui";
+import { showErrorToast } from "../error-toast";
+import { osTranscribeAudio } from "../os-bridge";
+import { dictationReducer, INITIAL_DICTATION_STATE } from "./dictation-reducer";
+import { type DictationRecording, startDictationRecording } from "./recorder";
+import {
+  type DictationLangHint,
+  dictationErrorText as errorText,
+} from "./types";
+import {
+  type DictationModelSetup,
+  useDictationModelSetup,
+} from "./use-dictation-model-setup";
+
+export type { DictationModelSetup };
+
+export interface UseDictationArgs {
+  /** Called with the recognized text once a transcription succeeds and is
+   *  non-empty. Never called for a discarded (cancelled) capture. */
+  onTranscript: (text: string) => void;
+  langHint: DictationLangHint;
+  /** False on web (no native mic capture) — `dictation` stays undefined so
+   *  ChatPanel hides the mic entirely. */
+  enabled: boolean;
+}
+
+export interface UseDictationResult {
+  dictation: DictationControl | undefined;
+  modelSetup: DictationModelSetup;
+}
+
+export function useDictation({
+  onTranscript,
+  langHint,
+  enabled,
+}: UseDictationArgs): UseDictationResult {
+  const { t } = useTranslation("chat");
+  const addToast = useUIStore((s) => s.addToast);
+  const [machine, dispatch] = useReducer(
+    dictationReducer,
+    INITIAL_DICTATION_STATE,
+  );
+
+  const recordingRef = useRef<DictationRecording | null>(null);
+  const onTranscriptRef = useRef(onTranscript);
+  const langHintRef = useRef(langHint);
+  useEffect(() => {
+    onTranscriptRef.current = onTranscript;
+  }, [onTranscript]);
+  useEffect(() => {
+    langHintRef.current = langHint;
+  }, [langHint]);
+
+  // Forward reference so `runStop`/`beginCapture` and the model-setup hook's
+  // `onReady` callback can name each other despite the declaration order
+  // (the setup hook must exist before `runStop`, but its `onReady` is
+  // `beginCapture`, which is declared after `runStop`).
+  const beginCaptureRef = useRef<() => void>(() => {});
+  const {
+    modelSetup,
+    ensureReady,
+    reopen,
+    reset: resetSetup,
+  } = useDictationModelSetup(() => beginCaptureRef.current());
+
+  const runStop = useCallback(
+    async (eventType: "stop" | "autoStop") => {
+      const session = recordingRef.current;
+      if (!session) return;
+      recordingRef.current = null;
+      dispatch({ type: eventType });
+      try {
+        const wav = await session.stop();
+        const text = await osTranscribeAudio(wav, langHintRef.current);
+        dispatch({ type: "transcribeSettled" });
+        if (text.trim()) onTranscriptRef.current(text.trim());
+      } catch (err) {
+        dispatch({ type: "transcribeSettled" });
+        if (errorText(err) === "model-not-ready") void reopen();
+        else showErrorToast("dictation_transcribe", errorText(err), err);
+      }
+    },
+    [reopen],
+  );
+
+  const beginCapture = useCallback(async () => {
+    dispatch({ type: "start" });
+    try {
+      const session = await startDictationRecording(() => {
+        void runStop("autoStop");
+      });
+      recordingRef.current = session;
+      dispatch({ type: "micGranted", startedAt: Date.now() });
+    } catch (err) {
+      dispatch({ type: "micFailed" });
+      if (err instanceof DOMException && err.name === "NotAllowedError") {
+        addToast({
+          title: t("composer.dictation.micDenied"),
+          variant: "error",
+        });
+      } else if (err instanceof DOMException && err.name === "NotFoundError") {
+        addToast({ title: t("composer.dictation.noMic"), variant: "error" });
+      } else {
+        showErrorToast("dictation_start_capture", errorText(err), err);
+      }
+    }
+  }, [runStop, addToast, t]);
+  useEffect(() => {
+    beginCaptureRef.current = () => void beginCapture();
+  }, [beginCapture]);
+
+  const handleStart = useCallback(() => {
+    if (machine.phase !== "idle") return;
+    void ensureReady();
+  }, [machine.phase, ensureReady]);
+
+  const handleCancel = useCallback(() => {
+    const session = recordingRef.current;
+    recordingRef.current = null;
+    session?.cancel();
+    dispatch({ type: "cancel" });
+  }, []);
+
+  // Disabled mid-flow, or unmounting: never leak a live mic stream/context.
+  useEffect(() => {
+    if (!enabled) {
+      recordingRef.current?.cancel();
+      recordingRef.current = null;
+      dispatch({ type: "reset" });
+      resetSetup();
+    }
+    return () => {
+      recordingRef.current?.cancel();
+      recordingRef.current = null;
+    };
+  }, [enabled, resetSetup]);
+
+  const labels: DictationLabels = useMemo(
+    () => ({
+      start: t("composer.dictation.start"),
+      stop: t("composer.dictation.stop"),
+      cancel: t("composer.dictation.cancel"),
+      recording: t("composer.dictation.recording"),
+      transcribing: t("composer.dictation.transcribing"),
+    }),
+    [t],
+  );
+
+  const dictation: DictationControl | undefined = enabled
+    ? {
+        state: machine.phase,
+        recordingStartedAt: machine.recordingStartedAt,
+        onStart: handleStart,
+        onStop: () => void runStop("stop"),
+        onCancel: handleCancel,
+        labels,
+      }
+    : undefined;
+
+  return { dictation, modelSetup };
+}

--- a/app/src/lib/dictation/wav.ts
+++ b/app/src/lib/dictation/wav.ts
@@ -1,0 +1,102 @@
+/**
+ * Pure PCM/WAV helpers for on-device dictation. No DOM, no Tauri — the
+ * recorder (`recorder.ts`) is the only caller, and this module exists
+ * separately so the encode/resample math can run under the bare Node test
+ * runner (`app/tests/dictation-wav.test.ts`).
+ *
+ * Output format is fixed: mono, 16-bit signed PCM, 16 kHz — exactly what the
+ * bundled whisper-cli sidecar expects (`transcribe_audio` in
+ * `app/src-tauri/src/dictation/whisper.rs`).
+ */
+
+/** The sample rate the whisper model expects. `AudioContext({ sampleRate })`
+ *  is requested at this rate; some platforms silently ignore the request, so
+ *  the recorder resamples to this rate on stop regardless. */
+export const DICTATION_SAMPLE_RATE = 16000;
+
+/** Concatenate the Float32 frames captured across the AudioWorklet's
+ *  lifetime into one contiguous buffer. */
+export function mergeFloat32(chunks: Float32Array[]): Float32Array {
+  const total = chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+  const out = new Float32Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    out.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return out;
+}
+
+/**
+ * Linear-interpolation resample from `fromRate` to `toRate`. Good enough for
+ * speech-to-text (whisper itself tolerates far worse); a sinc/FFT resampler
+ * would be overkill for a mono voice clip capped at 120s.
+ */
+export function resampleLinear(
+  input: Float32Array,
+  fromRate: number,
+  toRate: number,
+): Float32Array {
+  if (fromRate === toRate || input.length === 0) return input;
+  const ratio = fromRate / toRate;
+  const outLength = Math.max(0, Math.round(input.length / ratio));
+  const out = new Float32Array(outLength);
+  const lastIndex = input.length - 1;
+  for (let i = 0; i < outLength; i++) {
+    const srcPos = i * ratio;
+    const idx0 = Math.min(Math.floor(srcPos), lastIndex);
+    const idx1 = Math.min(idx0 + 1, lastIndex);
+    const frac = srcPos - idx0;
+    const a = input[idx0] ?? 0;
+    const b = input[idx1] ?? 0;
+    out[i] = a + (b - a) * frac;
+  }
+  return out;
+}
+
+/** Clamp to [-1, 1] and scale to a signed 16-bit sample, rounding half away
+ *  from zero so the mapping is deterministic (and testable byte-exact). */
+export function floatTo16BitPCM(input: Float32Array): Int16Array {
+  const out = new Int16Array(input.length);
+  for (let i = 0; i < input.length; i++) {
+    const clamped = Math.max(-1, Math.min(1, input[i]));
+    out[i] = Math.round(clamped < 0 ? clamped * 0x8000 : clamped * 0x7fff);
+  }
+  return out;
+}
+
+function writeAsciiString(view: DataView, offset: number, value: string): void {
+  for (let i = 0; i < value.length; i++) {
+    view.setUint8(offset + i, value.charCodeAt(i));
+  }
+}
+
+/** Encode mono 16-bit PCM samples as a standard 44-byte-header WAV file. */
+export function encodeWav(
+  samples: Float32Array,
+  sampleRate: number = DICTATION_SAMPLE_RATE,
+): Uint8Array {
+  const pcm = floatTo16BitPCM(samples);
+  const dataSize = pcm.length * 2;
+  const buffer = new ArrayBuffer(44 + dataSize);
+  const view = new DataView(buffer);
+
+  writeAsciiString(view, 0, "RIFF");
+  view.setUint32(4, 36 + dataSize, true);
+  writeAsciiString(view, 8, "WAVE");
+
+  writeAsciiString(view, 12, "fmt ");
+  view.setUint32(16, 16, true); // fmt chunk size (PCM)
+  view.setUint16(20, 1, true); // audio format: 1 = PCM
+  view.setUint16(22, 1, true); // channels: mono
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true); // byte rate (mono, 16-bit)
+  view.setUint16(32, 2, true); // block align (mono, 16-bit)
+  view.setUint16(34, 16, true); // bits per sample
+
+  writeAsciiString(view, 36, "data");
+  view.setUint32(40, dataSize, true);
+  new Int16Array(buffer, 44, pcm.length).set(pcm);
+
+  return new Uint8Array(buffer);
+}

--- a/app/src/lib/os-bridge.ts
+++ b/app/src/lib/os-bridge.ts
@@ -25,6 +25,10 @@ import {
   type UnlistenFn,
 } from "@tauri-apps/api/event";
 import type {
+  DictationModelProgress,
+  DictationModelStatus,
+} from "./dictation/types";
+import type {
   BridgeStatus,
   DetectedServer,
   ReconnectBridgeArgs,
@@ -274,4 +278,46 @@ export function osStopLocalBridge(): Promise<void> {
  *  event streams the same shape). */
 export function osLocalBridgeStatus(): Promise<BridgeStatus> {
   return invoke<BridgeStatus>("local_bridge_status");
+}
+
+// ── On-device dictation (bundled whisper.cpp sidecar) ──────────────────────
+// Native, desktop-only: transcription runs entirely on the user's machine, so
+// (like the local-model bridge above) this never moves to the engine.
+
+/** Transcribe a recorded WAV clip. The raw bytes ride the IPC payload (same
+ *  raw-payload pattern as `osSaveDownload`) so a multi-megabyte clip can't
+ *  freeze the webview; the language hint rides the `x-dictation-lang` header.
+ *  Rejects with the exact string "model-not-ready" when the model hasn't
+ *  been downloaded yet, or "transcription-timeout" on a stalled transcribe. */
+export function osTranscribeAudio(
+  wav: Uint8Array,
+  langHint: string,
+): Promise<string> {
+  return invoke<string>("transcribe_audio", wav, {
+    headers: { "x-dictation-lang": langHint },
+  });
+}
+
+/** Whether the pinned dictation model is on disk. */
+export function osDictationModelStatus(): Promise<DictationModelStatus> {
+  return invoke<DictationModelStatus>("dictation_model_status");
+}
+
+/** Download (and sha256-verify) the pinned dictation model. Idempotent —
+ *  resolves immediately if already ready. Progress rides the
+ *  `dictation-model-progress` event; subscribe via
+ *  {@link onDictationModelProgress} before calling this. */
+export function osDownloadDictationModel(): Promise<void> {
+  return invoke<void>("download_dictation_model");
+}
+
+/** Subscribe to `dictation-model-progress` ticks emitted while
+ *  {@link osDownloadDictationModel} runs. Mirrors how `local-bridge-status`
+ *  is consumed (see `useLocalBridgeStatus`) — resolves with the unlisten fn. */
+export function onDictationModelProgress(
+  handler: (progress: DictationModelProgress) => void,
+): Promise<UnlistenFn> {
+  return listen<DictationModelProgress>("dictation-model-progress", (ev) =>
+    handler(ev.payload),
+  );
 }

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -5,7 +5,20 @@
     "dropTitle": "Drop your files",
     "dropDescription": "Drop them here to add them to the conversation",
     "imagePasteUnavailable": "Couldn't read the pasted image. Try dragging the file in instead.",
-    "addFiles": "Add files"
+    "addFiles": "Add files",
+    "dictation": {
+      "start": "Start voice typing",
+      "stop": "Stop and insert",
+      "cancel": "Cancel",
+      "recording": "Recording",
+      "transcribing": "Transcribing...",
+      "setupTitle": "Set up voice typing",
+      "setupBody": "One-time download, about {{sizeMb}} MB.",
+      "setupConfirm": "Download",
+      "setupProgress": "Downloading... {{pct}}%",
+      "micDenied": "Houston needs microphone access. Allow it in system settings, then try again.",
+      "noMic": "No microphone was found."
+    }
   },
   "attribution": {
     "you": "You"

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -5,7 +5,20 @@
     "dropTitle": "Suelta tus archivos",
     "dropDescription": "Suéltalos aquí para añadirlos a la conversación",
     "imagePasteUnavailable": "No se pudo leer la imagen pegada. Prueba a arrastrar el archivo.",
-    "addFiles": "Agregar archivos"
+    "addFiles": "Agregar archivos",
+    "dictation": {
+      "start": "Iniciar dictado por voz",
+      "stop": "Detener e insertar",
+      "cancel": "Cancelar",
+      "recording": "Grabando",
+      "transcribing": "Transcribiendo...",
+      "setupTitle": "Configurar dictado por voz",
+      "setupBody": "Descarga única de unos {{sizeMb}} MB.",
+      "setupConfirm": "Descargar",
+      "setupProgress": "Descargando... {{pct}}%",
+      "micDenied": "Houston necesita acceso al micrófono. Permítelo en la configuración del sistema y vuelve a intentarlo.",
+      "noMic": "No se encontró ningún micrófono."
+    }
   },
   "attribution": {
     "you": "Tú"

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -5,7 +5,20 @@
     "dropTitle": "Solte seus arquivos",
     "dropDescription": "Solte-os aqui para adicioná-los à conversa",
     "imagePasteUnavailable": "Não foi possível ler a imagem colada. Tente arrastar o arquivo.",
-    "addFiles": "Adicionar arquivos"
+    "addFiles": "Adicionar arquivos",
+    "dictation": {
+      "start": "Iniciar ditado por voz",
+      "stop": "Parar e inserir",
+      "cancel": "Cancelar",
+      "recording": "Gravando",
+      "transcribing": "Transcrevendo...",
+      "setupTitle": "Configurar ditado por voz",
+      "setupBody": "Download único de cerca de {{sizeMb}} MB.",
+      "setupConfirm": "Baixar",
+      "setupProgress": "Baixando... {{pct}}%",
+      "micDenied": "O Houston precisa de acesso ao microfone. Permita nas configurações do sistema e tente novamente.",
+      "noMic": "Nenhum microfone foi encontrado."
+    }
   },
   "attribution": {
     "you": "Você"

--- a/app/tests/dictation-reducer.test.ts
+++ b/app/tests/dictation-reducer.test.ts
@@ -1,0 +1,87 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  type DictationMachineState,
+  dictationReducer,
+  INITIAL_DICTATION_STATE,
+} from "../src/lib/dictation/dictation-reducer.ts";
+
+describe("dictationReducer", () => {
+  it("starts idle", () => {
+    deepStrictEqual(INITIAL_DICTATION_STATE, { phase: "idle" });
+  });
+
+  it("idle -> requesting -> recording -> transcribing -> idle (happy path)", () => {
+    let state: DictationMachineState = INITIAL_DICTATION_STATE;
+    state = dictationReducer(state, { type: "start" });
+    strictEqual(state.phase, "requesting");
+
+    state = dictationReducer(state, { type: "micGranted", startedAt: 1000 });
+    strictEqual(state.phase, "recording");
+    strictEqual(state.recordingStartedAt, 1000);
+
+    state = dictationReducer(state, { type: "stop" });
+    strictEqual(state.phase, "transcribing");
+
+    state = dictationReducer(state, { type: "transcribeSettled" });
+    strictEqual(state.phase, "idle");
+  });
+
+  it("120s auto-stop behaves identically to a user-initiated stop", () => {
+    const recording: DictationMachineState = {
+      phase: "recording",
+      recordingStartedAt: 1000,
+    };
+    const stopped = dictationReducer(recording, { type: "autoStop" });
+    strictEqual(stopped.phase, "transcribing");
+  });
+
+  it("mic permission denial returns to idle (error path)", () => {
+    const requesting: DictationMachineState = { phase: "requesting" };
+    const next = dictationReducer(requesting, { type: "micFailed" });
+    strictEqual(next.phase, "idle");
+  });
+
+  it("cancel discards a requesting or recording capture", () => {
+    strictEqual(
+      dictationReducer({ phase: "requesting" }, { type: "cancel" }).phase,
+      "idle",
+    );
+    strictEqual(
+      dictationReducer(
+        { phase: "recording", recordingStartedAt: 5 },
+        { type: "cancel" },
+      ).phase,
+      "idle",
+    );
+  });
+
+  it("cancel is a no-op while transcribing (nothing left to discard)", () => {
+    const transcribing: DictationMachineState = { phase: "transcribing" };
+    const next = dictationReducer(transcribing, { type: "cancel" });
+    strictEqual(next, transcribing);
+  });
+
+  it("stop/micGranted/transcribeSettled are no-ops from the wrong phase", () => {
+    const idle: DictationMachineState = { phase: "idle" };
+    strictEqual(dictationReducer(idle, { type: "stop" }), idle);
+    strictEqual(dictationReducer(idle, { type: "autoStop" }), idle);
+    strictEqual(
+      dictationReducer(idle, { type: "micGranted", startedAt: 1 }),
+      idle,
+    );
+    strictEqual(dictationReducer(idle, { type: "transcribeSettled" }), idle);
+
+    const recording: DictationMachineState = { phase: "recording" };
+    strictEqual(dictationReducer(recording, { type: "start" }), recording);
+  });
+
+  it("reset forces idle from any phase, and is a no-op if already idle", () => {
+    strictEqual(
+      dictationReducer({ phase: "transcribing" }, { type: "reset" }).phase,
+      "idle",
+    );
+    const idle: DictationMachineState = { phase: "idle" };
+    strictEqual(dictationReducer(idle, { type: "reset" }), idle);
+  });
+});

--- a/app/tests/dictation-wav.test.ts
+++ b/app/tests/dictation-wav.test.ts
@@ -1,0 +1,91 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  encodeWav,
+  floatTo16BitPCM,
+  mergeFloat32,
+  resampleLinear,
+} from "../src/lib/dictation/wav.ts";
+
+describe("floatTo16BitPCM", () => {
+  it("maps exact endpoints without rounding drift", () => {
+    const out = floatTo16BitPCM(new Float32Array([0, 1, -1]));
+    deepStrictEqual(Array.from(out), [0, 32767, -32768]);
+  });
+
+  it("clamps out-of-range samples instead of wrapping", () => {
+    const out = floatTo16BitPCM(new Float32Array([2, -2]));
+    deepStrictEqual(Array.from(out), [32767, -32768]);
+  });
+});
+
+describe("mergeFloat32", () => {
+  it("concatenates chunks in order", () => {
+    const merged = mergeFloat32([
+      new Float32Array([1, 2]),
+      new Float32Array([]),
+      new Float32Array([3]),
+    ]);
+    deepStrictEqual(Array.from(merged), [1, 2, 3]);
+  });
+});
+
+describe("resampleLinear", () => {
+  it("is a no-op when rates already match", () => {
+    const input = new Float32Array([0.1, 0.2, 0.3]);
+    strictEqual(resampleLinear(input, 16000, 16000), input);
+  });
+
+  it("scales length from 48kHz down to 16kHz (3:1)", () => {
+    const input = new Float32Array(480); // 10ms @ 48kHz
+    const out = resampleLinear(input, 48000, 16000);
+    strictEqual(out.length, 160); // 10ms @ 16kHz
+  });
+
+  it("interpolates linearly between neighboring samples", () => {
+    // 2:1 downsample of a ramp: out[i] should land near input[2*i].
+    const input = Float32Array.from({ length: 8 }, (_, i) => i);
+    const out = resampleLinear(input, 2, 1);
+    strictEqual(out.length, 4);
+    deepStrictEqual(Array.from(out), [0, 2, 4, 6]);
+  });
+});
+
+describe("encodeWav", () => {
+  it("writes a byte-exact 44-byte header + PCM body for a known input", () => {
+    const samples = new Float32Array([0, 1, -1, 0.5]);
+    const bytes = encodeWav(samples, 16000);
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+
+    const ascii = (offset: number, len: number) =>
+      String.fromCharCode(...bytes.subarray(offset, offset + len));
+
+    strictEqual(bytes.length, 44 + samples.length * 2);
+    strictEqual(ascii(0, 4), "RIFF");
+    strictEqual(view.getUint32(4, true), 36 + samples.length * 2);
+    strictEqual(ascii(8, 4), "WAVE");
+    strictEqual(ascii(12, 4), "fmt ");
+    strictEqual(view.getUint32(16, true), 16);
+    strictEqual(view.getUint16(20, true), 1); // PCM
+    strictEqual(view.getUint16(22, true), 1); // mono
+    strictEqual(view.getUint32(24, true), 16000);
+    strictEqual(view.getUint32(28, true), 32000); // byte rate
+    strictEqual(view.getUint16(32, true), 2); // block align
+    strictEqual(view.getUint16(34, true), 16); // bits per sample
+    strictEqual(ascii(36, 4), "data");
+    strictEqual(view.getUint32(40, true), samples.length * 2);
+
+    const pcm = new Int16Array(
+      bytes.buffer,
+      bytes.byteOffset + 44,
+      samples.length,
+    );
+    deepStrictEqual(Array.from(pcm), [0, 32767, -32768, 16384]);
+  });
+
+  it("defaults to the 16kHz dictation sample rate", () => {
+    const bytes = encodeWav(new Float32Array([0]));
+    const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+    strictEqual(view.getUint32(24, true), 16000);
+  });
+});

--- a/packages/web/src/shims/tauri-core.ts
+++ b/packages/web/src/shims/tauri-core.ts
@@ -208,6 +208,12 @@ export async function invoke<T = unknown>(
     case "reconnect_local_bridge":
     case "stop_local_bridge":
     case "local_bridge_status":
+    // On-device dictation runs a bundled whisper.cpp sidecar — desktop-only,
+    // no browser equivalent. `useDictation` gates on `osIsTauri()` so the web
+    // build never triggers these; surface a clear error if it somehow does.
+    case "transcribe_audio":
+    case "dictation_model_status":
+    case "download_dictation_model":
     case "pick_directory":
     case "reveal_file":
     case "reveal_agent":

--- a/scripts/build-whisper.sh
+++ b/scripts/build-whisper.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# ============================================================================
+# Build the ggml-org/whisper.cpp `whisper-cli` binary for a target platform and
+# stage it where `app/src-tauri/build.rs` (`stage_whisper_sidecar`) picks it up
+# for Tauri's `externalBin` bundling as `binaries/whisper-cli-<triple>`.
+#
+# whisper-cli is the local-dictation sidecar the desktop spawns to transcribe
+# microphone audio for voice typing in the chat box (no cloud round-trip).
+# whisper.cpp is MIT.
+#
+# The pinned source tarball is SHA256-verified before building. The binary is
+# built fully static (`-DBUILD_SHARED_LIBS=OFF`) so it carries no whisper/ggml
+# shared-library dependency, and on macOS Metal is embedded into the binary
+# (`-DGGML_METAL_EMBED_LIBRARY=ON`) so there is no sibling `.metallib` to ship.
+# On macOS the result is verified dylib-free with `otool -L`.
+#
+# Output:
+#   target/whisper/whisper-cli-<rust-triple>          (macOS / Linux)
+#   target/whisper/whisper-cli-<rust-triple>.exe      (Windows)
+#
+# Usage:
+#   scripts/build-whisper.sh                    # current host triple
+#   scripts/build-whisper.sh <rust-triple>      # an explicit target (CI, per-arch)
+#
+# Supported <rust-triple>:
+#   aarch64-apple-darwin, x86_64-apple-darwin,
+#   x86_64-unknown-linux-gnu, aarch64-unknown-linux-gnu,
+#   x86_64-pc-windows-msvc, aarch64-pc-windows-msvc
+#
+# On macOS a non-host arch is cross-built via CMAKE_OSX_ARCHITECTURES (this is
+# how the release workflow produces both slices for the universal lipo). On
+# Linux/Windows the requested arch must match the host arch (each release runner
+# builds its own arch natively) — a mismatch is rejected.
+#
+# Override the whisper.cpp version with WHISPER_VERSION (default below); update
+# WHISPER_SHA256 to match when bumping.
+# ============================================================================
+set -euo pipefail
+
+WHISPER_VERSION="${WHISPER_VERSION:-1.9.1}"
+# SHA256 of https://github.com/ggml-org/whisper.cpp/archive/refs/tags/v${WHISPER_VERSION}.tar.gz
+WHISPER_SHA256="${WHISPER_SHA256:-147267177eef7b22ec3d2476dd514d1b12e160e176230b740e3d1bd600118447}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_DIR="$REPO_ROOT/target/whisper"
+# macOS deployment target — kept in sync with tauri.conf.json minimumSystemVersion.
+MACOS_DEPLOYMENT_TARGET="10.15"
+
+# Derive the Rust target triple for the current host (matches the suffix
+# tauri-cli appends to `externalBin` names).
+host_triple() {
+  local arch os
+  case "$(uname -m)" in
+    arm64 | aarch64) arch="aarch64" ;;
+    x86_64 | amd64) arch="x86_64" ;;
+    *) echo "ERROR: unsupported host arch $(uname -m)" >&2; exit 1 ;;
+  esac
+  case "$(uname -s)" in
+    Darwin) os="apple-darwin" ;;
+    Linux) os="unknown-linux-gnu" ;;
+    MINGW* | MSYS* | CYGWIN*) os="pc-windows-msvc" ;;
+    *) echo "ERROR: unsupported host OS $(uname -s)" >&2; exit 1 ;;
+  esac
+  echo "${arch}-${os}"
+}
+
+# Rust-arch token ("aarch64"/"x86_64") of the current host, for the
+# same-OS/same-arch guard on Linux and Windows.
+host_arch() {
+  case "$(uname -m)" in
+    arm64 | aarch64) echo "aarch64" ;;
+    x86_64 | amd64) echo "x86_64" ;;
+    *) echo "ERROR: unsupported host arch $(uname -m)" >&2; exit 1 ;;
+  esac
+}
+
+TRIPLE="${1:-$(host_triple)}"
+
+# Map a Rust triple to the target OS, the Rust-arch token, the macOS Apple-arch
+# token (for CMAKE_OSX_ARCHITECTURES), and the staged binary's extension.
+case "$TRIPLE" in
+  aarch64-apple-darwin)       OS="macos";   ARCH="aarch64"; OSX_ARCH="arm64";  BIN_EXT="" ;;
+  x86_64-apple-darwin)        OS="macos";   ARCH="x86_64";  OSX_ARCH="x86_64"; BIN_EXT="" ;;
+  x86_64-unknown-linux-gnu)   OS="linux";   ARCH="x86_64";  OSX_ARCH="";       BIN_EXT="" ;;
+  aarch64-unknown-linux-gnu)  OS="linux";   ARCH="aarch64"; OSX_ARCH="";       BIN_EXT="" ;;
+  x86_64-pc-windows-msvc)     OS="windows"; ARCH="x86_64";  OSX_ARCH="";       BIN_EXT=".exe" ;;
+  aarch64-pc-windows-msvc)    OS="windows"; ARCH="aarch64"; OSX_ARCH="";       BIN_EXT=".exe" ;;
+  *) echo "ERROR: unsupported triple '$TRIPLE'" >&2; exit 1 ;;
+esac
+
+# Linux/Windows build natively per-arch (no cross toolchain here); reject an
+# arch that doesn't match the host. macOS cross-builds any arch via
+# CMAKE_OSX_ARCHITECTURES, so it is exempt from this guard.
+if [ "$OS" != "macos" ] && [ "$ARCH" != "$(host_arch)" ]; then
+  echo "ERROR: cannot build $TRIPLE on a $(host_arch) host — build each $OS arch on its native runner" >&2
+  exit 1
+fi
+
+command -v cmake >/dev/null 2>&1 || { echo "ERROR: cmake not found (required to build whisper.cpp)" >&2; exit 1; }
+
+TAG="v${WHISPER_VERSION}"
+ASSET="whisper.cpp-${WHISPER_VERSION}.tar.gz"
+INNER_DIR="whisper.cpp-${WHISPER_VERSION}"
+TARBALL_URL="https://github.com/ggml-org/whisper.cpp/archive/refs/tags/${TAG}.tar.gz"
+
+DEST="$OUT_DIR/whisper-cli-${TRIPLE}${BIN_EXT}"
+
+echo "whisper.cpp ${TAG} · ${TRIPLE} → whisper-cli"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "  downloading source tarball…"
+curl -fsSL "$TARBALL_URL" -o "$TMP/$ASSET"
+
+# Verify SHA256 against the pinned checksum.
+if command -v sha256sum >/dev/null 2>&1; then
+  ACTUAL="$(sha256sum "$TMP/$ASSET" | awk '{print $1}')"
+else
+  ACTUAL="$(shasum -a 256 "$TMP/$ASSET" | awk '{print $1}')"
+fi
+if [ "$WHISPER_SHA256" != "$ACTUAL" ]; then
+  echo "ERROR: SHA256 mismatch for ${ASSET}" >&2
+  echo "  expected: $WHISPER_SHA256" >&2
+  echo "  actual:   $ACTUAL" >&2
+  exit 1
+fi
+echo "  sha256 OK"
+
+echo "  extracting source…"
+tar -xzf "$TMP/$ASSET" -C "$TMP"
+SRC="$TMP/$INNER_DIR"
+BUILD="$TMP/build"
+
+# Common CMake flags: static libs (self-contained binary, no whisper/ggml
+# dylib), no OpenMP (avoids a libomp/libgomp shared dep), CLI only.
+CMAKE_FLAGS=(
+  -DCMAKE_BUILD_TYPE=Release
+  -DBUILD_SHARED_LIBS=OFF
+  -DGGML_OPENMP=OFF
+  -DWHISPER_BUILD_TESTS=OFF
+  -DWHISPER_BUILD_EXAMPLES=ON
+  -DWHISPER_BUILD_SERVER=OFF
+)
+case "$OS" in
+  macos)
+    # Metal embedded into the binary → no sibling .metallib to ship.
+    # BLAS is disabled: whisper.cpp defaults GGML_BLAS=ON on Apple (Accelerate),
+    # but Accelerate's new cblas ILP64 entry points are weak-linked and marked
+    # available only on macOS 13.3+, which would crash on our 10.15 floor. Metal
+    # is the accelerator on Apple anyway; the CPU fallback uses ggml's own kernels.
+    CMAKE_FLAGS+=(
+      -DGGML_METAL=ON
+      -DGGML_METAL_EMBED_LIBRARY=ON
+      -DGGML_BLAS=OFF
+      "-DCMAKE_OSX_ARCHITECTURES=${OSX_ARCH}"
+      "-DCMAKE_OSX_DEPLOYMENT_TARGET=${MACOS_DEPLOYMENT_TARGET}"
+    )
+    ;;
+  windows | linux)
+    # CPU-only, portable across CPUs (no -march=native), self-contained.
+    CMAKE_FLAGS+=(-DGGML_NATIVE=OFF)
+    ;;
+esac
+
+echo "  configuring…"
+cmake -S "$SRC" -B "$BUILD" "${CMAKE_FLAGS[@]}"
+
+echo "  building whisper-cli…"
+cmake --build "$BUILD" --config Release --target whisper-cli -j
+
+# Locate the built binary: single-config generators emit build/bin/whisper-cli;
+# multi-config (Visual Studio) emit build/bin/Release/whisper-cli.exe.
+BUILT=""
+for cand in \
+  "$BUILD/bin/whisper-cli${BIN_EXT}" \
+  "$BUILD/bin/Release/whisper-cli${BIN_EXT}"; do
+  if [ -f "$cand" ]; then BUILT="$cand"; break; fi
+done
+if [ -z "$BUILT" ]; then
+  echo "ERROR: whisper-cli binary not found after build under $BUILD/bin" >&2
+  exit 1
+fi
+
+# On macOS, verify the binary is self-contained: no dependency outside the
+# always-present system paths (/usr/lib, /System/Library). A whisper/ggml or
+# @rpath dylib dependency means the static/embed flags regressed.
+if [ "$OS" = "macos" ] && command -v otool >/dev/null 2>&1; then
+  BAD="$(otool -L "$BUILT" | tail -n +2 | awk '{print $1}' \
+    | grep -vE '^(/usr/lib/|/System/Library/)' || true)"
+  if [ -n "$BAD" ]; then
+    echo "ERROR: whisper-cli has non-system dynamic dependencies (expected fully self-contained):" >&2
+    echo "$BAD" | awk '{print "  " $0}' >&2
+    exit 1
+  fi
+  echo "  dylib check OK (system-only dependencies)"
+fi
+
+mkdir -p "$OUT_DIR"
+cp "$BUILT" "$DEST"
+chmod 0755 "$DEST"
+
+echo "  staged → ${DEST}"
+echo "Done. build.rs will copy this into app/src-tauri/binaries/whisper-cli-${TRIPLE}${BIN_EXT}."

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -194,6 +194,9 @@ export interface AIBoardProps {
   currentUserId?: ChatPanelProps["currentUserId"];
   /** Localized author-attribution labels. Forwarded to ChatPanel. */
   authorLabels?: ChatPanelProps["authorLabels"];
+  /** Prop-driven dictation control for the composer mic. Forwarded to
+   *  ChatPanel; omit (or ChatPanel's own default) hides the mic entirely. */
+  dictation?: ChatPanelProps["dictation"];
   /** Left-pane layout. "board" = kanban columns (default); "list" = a single
    *  column-less vertical list (used by the Archived missions tab). */
   layout?: "board" | "list";
@@ -306,6 +309,7 @@ export function AIBoard({
   composerLabels,
   currentUserId,
   authorLabels,
+  dictation,
   layout = "board",
   listAlign,
   searchSnippets,
@@ -724,6 +728,7 @@ export function AIBoard({
           renderUserMessage={renderUserMessage}
           currentUserId={currentUserId}
           authorLabels={authorLabels}
+          dictation={dictation}
           afterMessages={renderedAfterMessages}
           onNotice={onNotice}
           prepareAttachments={prepareAttachments}

--- a/ui/chat/src/attachment-chip.tsx
+++ b/ui/chat/src/attachment-chip.tsx
@@ -13,6 +13,12 @@ import {
   XIcon,
 } from "lucide-react";
 import { PromptInputSubmit } from "./ai-elements/prompt-input";
+import {
+  DictationRecording,
+  DictationTranscribing,
+} from "./dictation-controls";
+import type { DictationControl } from "./dictation-types";
+import { isDictationBusy, resolveDictationView } from "./dictation-types";
 
 export function getExt(name: string): string {
   const dot = name.lastIndexOf(".");
@@ -132,35 +138,50 @@ export interface ComposerTrailingProps {
   status: "ready" | "streaming" | "submitted";
   hasContent: boolean;
   onStop?: () => void;
+  /** When absent (e.g. the web build) no mic affordance renders at all. */
+  dictation?: DictationControl;
 }
 
 /**
- * Trailing button row: dictate (idle, optional) + always-visible submit.
+ * Trailing button row: dictation affordance (prop-driven, optional) +
+ * always-visible submit.
  *
- * The submit button is rendered as `disabled` when there's no content to
- * send, which keeps the affordance stable in the same spot. The previous
- * "voice mode" wave icon was removed because it wasn't wired to anything.
+ * With no `dictation` control nothing but submit renders. When present the
+ * control's state picks the affordance: a mic button (idle), the recording
+ * controls (requesting/recording), or a transcribing spinner. Submit is
+ * disabled while a capture is in flight so it can't race the transcript.
  */
 export function ComposerTrailing({
   status,
   hasContent,
   onStop,
+  dictation,
 }: ComposerTrailingProps) {
+  const view = resolveDictationView(dictation);
+  const submitDisabled =
+    (status === "ready" && !hasContent) || isDictationBusy(dictation);
   return (
     <div className="flex items-center gap-1.5 [grid-area:trailing]">
-      {status === "ready" && (
+      {view.kind === "idle" && status === "ready" && dictation && (
         <button
           type="button"
+          onClick={dictation.onStart}
           className="flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground hover:bg-accent transition-colors"
-          aria-label="Dictate"
+          aria-label={dictation.labels.start}
         >
           <MicIcon className="size-5" />
         </button>
       )}
+      {view.kind === "recording" && dictation && (
+        <DictationRecording control={dictation} startedAt={view.startedAt} />
+      )}
+      {view.kind === "transcribing" && dictation && (
+        <DictationTranscribing label={dictation.labels.transcribing} />
+      )}
       <PromptInputSubmit
         status={status}
         onStop={onStop}
-        disabled={status === "ready" && !hasContent}
+        disabled={submitDisabled}
       />
     </div>
   );

--- a/ui/chat/src/chat-input-types.ts
+++ b/ui/chat/src/chat-input-types.ts
@@ -1,0 +1,54 @@
+import type { ReactNode } from "react";
+import type {
+  AttachmentRejection,
+  ChatComposerLabels,
+  PrepareAttachments,
+} from "./chat-panel-types";
+import type { DictationControl } from "./dictation-types";
+import type {
+  QueuedChatMessage,
+  QueuedMessageLabels,
+} from "./queued-message-list";
+
+export type InputStatus = "ready" | "streaming" | "submitted";
+
+export interface ChatInputProps {
+  /** Controlled text. Omit to use internal state. */
+  value?: string;
+  /** Required if `value` is provided. */
+  onValueChange?: (value: string) => void;
+  /** Controlled attachments. Omit to use internal state. */
+  attachments?: File[];
+  /** Required if `attachments` is provided. */
+  onAttachmentsChange?: (files: File[]) => void;
+  /** Called on submit. The current text + files are always passed for convenience. */
+  onSend: (text: string, files: File[]) => void | Promise<void>;
+  onStop?: () => void;
+  status?: InputStatus;
+  placeholder?: string;
+  /** Emitted when the library wants to surface a short notice to the user
+   *  (e.g. a duplicate-file drop). The app decides how to display it. */
+  onNotice?: (message: string) => void;
+  prepareAttachments?: PrepareAttachments;
+  onAttachmentRejections?: (rejections: AttachmentRejection[]) => void;
+  /** Optional content rendered in the composer footer (e.g. model selector). */
+  footer?: ReactNode;
+  /** Optional content rendered inside the composer above the textarea. */
+  header?: ReactNode;
+  /** Optional menu rendered in a popover anchored to the paperclip button.
+   *  When provided, clicking the button opens the popover instead of going
+   *  straight to the file picker. The render-prop form receives an API the
+   *  caller can use to trigger the file picker from inside the menu. */
+  attachMenu?:
+    | ReactNode
+    | ((api: { openFilePicker: () => void; close: () => void }) => ReactNode);
+  /** Messages accepted while a turn is active, waiting to be sent as one turn. */
+  queuedMessages?: QueuedChatMessage[];
+  onRemoveQueuedMessage?: (id: string) => void;
+  queuedLabels?: QueuedMessageLabels;
+  /** Enables submit even when text/files are empty. */
+  canSendEmpty?: boolean;
+  labels?: ChatComposerLabels;
+  /** Prop-driven dictation affordance. Omit to hide the mic (web build). */
+  dictation?: DictationControl;
+}

--- a/ui/chat/src/chat-input.tsx
+++ b/ui/chat/src/chat-input.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import { useCallback } from "react";
 import type { PromptInputMessage } from "./ai-elements/prompt-input";
 import {
@@ -12,61 +11,14 @@ import {
   ChatInputAttachButton,
   ChatInputAttachments,
 } from "./chat-input-attachments";
-import type {
-  AttachmentRejection,
-  ChatComposerLabels,
-  PrepareAttachments,
-} from "./chat-panel-types";
-import type {
-  QueuedChatMessage,
-  QueuedMessageLabels,
-} from "./queued-message-list";
+import type { ChatInputProps } from "./chat-input-types";
+import { isDictationCapturing } from "./dictation-types";
 import { QueuedMessageList } from "./queued-message-list";
 import { useComposerAttachments } from "./use-composer-attachments";
 import { useControllable } from "./use-file-drop-zone";
 
-type InputStatus = "ready" | "streaming" | "submitted";
-
+export type { ChatInputProps } from "./chat-input-types";
 export type { ChatComposerLabels } from "./chat-panel-types";
-
-export interface ChatInputProps {
-  /** Controlled text. Omit to use internal state. */
-  value?: string;
-  /** Required if `value` is provided. */
-  onValueChange?: (value: string) => void;
-  /** Controlled attachments. Omit to use internal state. */
-  attachments?: File[];
-  /** Required if `attachments` is provided. */
-  onAttachmentsChange?: (files: File[]) => void;
-  /** Called on submit. The current text + files are always passed for convenience. */
-  onSend: (text: string, files: File[]) => void | Promise<void>;
-  onStop?: () => void;
-  status?: InputStatus;
-  placeholder?: string;
-  /** Emitted when the library wants to surface a short notice to the user
-   *  (e.g. a duplicate-file drop). The app decides how to display it. */
-  onNotice?: (message: string) => void;
-  prepareAttachments?: PrepareAttachments;
-  onAttachmentRejections?: (rejections: AttachmentRejection[]) => void;
-  /** Optional content rendered in the composer footer (e.g. model selector). */
-  footer?: ReactNode;
-  /** Optional content rendered inside the composer above the textarea. */
-  header?: ReactNode;
-  /** Optional menu rendered in a popover anchored to the paperclip button.
-   *  When provided, clicking the button opens the popover instead of going
-   *  straight to the file picker. The render-prop form receives an API the
-   *  caller can use to trigger the file picker from inside the menu. */
-  attachMenu?:
-    | ReactNode
-    | ((api: { openFilePicker: () => void; close: () => void }) => ReactNode);
-  /** Messages accepted while a turn is active, waiting to be sent as one turn. */
-  queuedMessages?: QueuedChatMessage[];
-  onRemoveQueuedMessage?: (id: string) => void;
-  queuedLabels?: QueuedMessageLabels;
-  /** Enables submit even when text/files are empty. */
-  canSendEmpty?: boolean;
-  labels?: ChatComposerLabels;
-}
 
 export function ChatInput({
   value,
@@ -88,6 +40,7 @@ export function ChatInput({
   queuedLabels,
   canSendEmpty = false,
   labels,
+  dictation,
 }: ChatInputProps) {
   const [text, setText] = useControllable(value, onValueChange, "");
   const isTextControlled = value !== undefined;
@@ -116,12 +69,18 @@ export function ChatInput({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Escape discards an in-flight capture first, before any streaming stop.
+      if (e.key === "Escape" && isDictationCapturing(dictation)) {
+        e.preventDefault();
+        dictation?.onCancel();
+        return;
+      }
       if (e.key === "Escape" && status !== "ready" && onStop) {
         e.preventDefault();
         onStop();
       }
     },
-    [status, onStop],
+    [status, onStop, dictation],
   );
 
   const handleSubmit = useCallback(
@@ -187,6 +146,7 @@ export function ChatInput({
             status={status}
             hasContent={hasContent}
             onStop={onStop}
+            dictation={dictation}
           />
         </PromptInput>
 

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import type { ToolsAndCardsProps } from "./chat-helpers";
 import type { ChatMessagesProps } from "./chat-messages";
+import type { DictationControl } from "./dictation-types";
 import type { ChatMessage } from "./feed-to-messages";
 import type {
   QueuedChatMessage,
@@ -97,6 +98,9 @@ export interface ChatPanelProps {
   renderLink?: ChatMessagesProps["renderLink"];
   composerOverride?: ReactNode;
   composerLabels?: ChatComposerLabels;
+  /** Prop-driven dictation control for the composer. Omit to hide the mic
+   *  affordance entirely (e.g. the web build with no speech capture). */
+  dictation?: DictationControl;
   /**
    * Multiplayer only (C5): the signed-in viewer's user id, so the panel can tell
    * the viewer's own bubbles from teammates'. Absent in single-player mode.

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -66,6 +66,7 @@ export function ChatPanel({
   canSendEmpty,
   composerOverride,
   composerLabels,
+  dictation,
   currentUserId,
   authorLabels,
 }: ChatPanelProps) {
@@ -199,6 +200,7 @@ export function ChatPanel({
           queuedLabels={queuedLabels}
           canSendEmpty={canSendEmpty}
           labels={composerLabels}
+          dictation={dictation}
         />
       )}
     </div>

--- a/ui/chat/src/dictation-controls.tsx
+++ b/ui/chat/src/dictation-controls.tsx
@@ -1,0 +1,73 @@
+/**
+ * Active-dictation controls rendered in the composer trailing row while a
+ * capture is in flight. All affordances are always visible (no hover gating):
+ *  - DictationRecording: pulsing dot + live mm:ss + stop + cancel
+ *  - DictationTranscribing: spinner + label
+ */
+
+import { Loader2Icon, SquareIcon, XIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import type { DictationControl } from "./dictation-types";
+import { formatElapsed } from "./dictation-types";
+
+/** Ticks once a second while recording so the elapsed clock stays live. */
+function useElapsedLabel(startedAt?: number): string {
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    if (startedAt === undefined) return;
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 500);
+    return () => clearInterval(id);
+  }, [startedAt]);
+  return formatElapsed(startedAt, now);
+}
+
+const CONTROL_BUTTON =
+  "flex h-9 w-9 items-center justify-center rounded-full text-muted-foreground hover:bg-accent transition-colors";
+
+export function DictationRecording({
+  control,
+  startedAt,
+}: {
+  control: DictationControl;
+  startedAt?: number;
+}) {
+  const elapsed = useElapsedLabel(startedAt);
+  const { labels } = control;
+  return (
+    <div className="flex items-center gap-1.5">
+      <div className="flex items-center gap-1.5 pl-1 pr-0.5" role="status">
+        <span className="size-2 rounded-full bg-red-500 animate-pulse" />
+        <span className="sr-only">{labels.recording}</span>
+        <span className="text-xs tabular-nums text-muted-foreground">
+          {elapsed}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={control.onCancel}
+        className={CONTROL_BUTTON}
+        aria-label={labels.cancel}
+      >
+        <XIcon className="size-5" />
+      </button>
+      <button
+        type="button"
+        onClick={control.onStop}
+        className="flex h-9 w-9 items-center justify-center rounded-full bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
+        aria-label={labels.stop}
+      >
+        <SquareIcon className="size-3.5 fill-current" />
+      </button>
+    </div>
+  );
+}
+
+export function DictationTranscribing({ label }: { label: string }) {
+  return (
+    <div className="flex items-center gap-1.5 px-1" role="status">
+      <Loader2Icon className="size-4 animate-spin text-muted-foreground" />
+      <span className="text-xs text-muted-foreground">{label}</span>
+    </div>
+  );
+}

--- a/ui/chat/src/dictation-types.ts
+++ b/ui/chat/src/dictation-types.ts
@@ -1,0 +1,104 @@
+/**
+ * Contract for the composer's dictation affordance. The library renders a
+ * prop-driven mic / recording / transcribing control; all speech capture and
+ * transcription lives in the app (props only, no store, no i18n here).
+ *
+ * The pure helpers (`resolveDictationView`, `formatElapsed`, ...) hold the
+ * state -> render decision so it can be unit-tested without a DOM runner.
+ */
+
+export type DictationState =
+  | "idle"
+  | "requesting"
+  | "recording"
+  | "transcribing";
+
+/** English defaults live in the app; consumers pass `t()` results in. */
+export interface DictationLabels {
+  start: string;
+  stop: string;
+  cancel: string;
+  recording: string;
+  transcribing: string;
+}
+
+export interface DictationControl {
+  state: DictationState;
+  /** Epoch ms the capture began; the UI computes mm:ss locally off it. */
+  recordingStartedAt?: number;
+  onStart: () => void;
+  /** Stop recording and begin transcribing. */
+  onStop: () => void;
+  /** Discard the capture (Escape / cancel affordance). */
+  onCancel: () => void;
+  labels: DictationLabels;
+}
+
+/** English fallbacks for apps that don't localize dictation yet. No em dashes. */
+export const DEFAULT_DICTATION_LABELS: DictationLabels = {
+  start: "Dictate",
+  stop: "Stop recording",
+  cancel: "Cancel dictation",
+  recording: "Recording",
+  transcribing: "Transcribing",
+};
+
+/** Which control the composer trailing row should render. */
+export type DictationView =
+  | { kind: "hidden" }
+  | { kind: "idle" }
+  | { kind: "recording"; startedAt?: number }
+  | { kind: "transcribing" };
+
+/**
+ * Maps a (possibly absent) control to the single control to render.
+ * `undefined` -> hidden (the web build passes no control at all).
+ * `requesting`/`recording` collapse to one recording view; `requesting`
+ * has no start time yet, so the timer shows 0:00.
+ */
+export function resolveDictationView(
+  control?: DictationControl,
+): DictationView {
+  if (!control) return { kind: "hidden" };
+  switch (control.state) {
+    case "idle":
+      return { kind: "idle" };
+    case "requesting":
+    case "recording":
+      return { kind: "recording", startedAt: control.recordingStartedAt };
+    case "transcribing":
+      return { kind: "transcribing" };
+  }
+}
+
+/** True while a capture/transcription is in flight — submit must be disabled. */
+export function isDictationBusy(control?: DictationControl): boolean {
+  return control !== undefined && control.state !== "idle";
+}
+
+/**
+ * True while audio is being captured (requesting or recording). Escape
+ * discards the capture only in these states; during transcribing there is
+ * nothing to cancel.
+ */
+export function isDictationCapturing(control?: DictationControl): boolean {
+  return (
+    control !== undefined &&
+    (control.state === "requesting" || control.state === "recording")
+  );
+}
+
+/**
+ * mm:ss elapsed between `startedAt` and `now` (both epoch ms). Returns 0:00
+ * when the capture hasn't started (requesting) or the clock is behind.
+ */
+export function formatElapsed(
+  startedAt: number | undefined,
+  now: number,
+): string {
+  if (startedAt === undefined) return "0:00";
+  const total = Math.max(0, Math.floor((now - startedAt) / 1000));
+  const minutes = Math.floor(total / 60);
+  const seconds = total % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -191,6 +191,20 @@ export type { ChatSidebarProps } from "./chat-sidebar";
 export { ChatSidebar } from "./chat-sidebar";
 export type { ChatStatusLineProps } from "./chat-status-line";
 export { ChatStatusLine } from "./chat-status-line";
+// === Dictation ===
+export type {
+  DictationControl,
+  DictationLabels,
+  DictationState,
+  DictationView,
+} from "./dictation-types";
+export {
+  DEFAULT_DICTATION_LABELS,
+  formatElapsed,
+  isDictationBusy,
+  isDictationCapturing,
+  resolveDictationView,
+} from "./dictation-types";
 export type { MergeFeedOptions, PendingUserEcho } from "./feed-merge";
 export {
   mergeFeedHistory,

--- a/ui/chat/tests/dictation.test.ts
+++ b/ui/chat/tests/dictation.test.ts
@@ -1,0 +1,121 @@
+import { deepEqual, equal } from "node:assert";
+import { describe, it } from "node:test";
+import type {
+  DictationControl,
+  DictationState,
+} from "../src/dictation-types.ts";
+import {
+  DEFAULT_DICTATION_LABELS,
+  formatElapsed,
+  isDictationBusy,
+  isDictationCapturing,
+  resolveDictationView,
+} from "../src/dictation-types.ts";
+
+const control = (
+  state: DictationState,
+  recordingStartedAt?: number,
+): DictationControl => ({
+  state,
+  recordingStartedAt,
+  onStart: () => {},
+  onStop: () => {},
+  onCancel: () => {},
+  labels: DEFAULT_DICTATION_LABELS,
+});
+
+describe("resolveDictationView", () => {
+  it("hides when no control is provided (web build)", () => {
+    deepEqual(resolveDictationView(undefined), { kind: "hidden" });
+  });
+
+  it("renders the idle mic button", () => {
+    deepEqual(resolveDictationView(control("idle")), { kind: "idle" });
+  });
+
+  it("shows the recording view while requesting, with no start time yet", () => {
+    deepEqual(resolveDictationView(control("requesting")), {
+      kind: "recording",
+      startedAt: undefined,
+    });
+  });
+
+  it("shows the recording view with the start time while recording", () => {
+    deepEqual(resolveDictationView(control("recording", 1000)), {
+      kind: "recording",
+      startedAt: 1000,
+    });
+  });
+
+  it("shows the transcribing view", () => {
+    deepEqual(resolveDictationView(control("transcribing")), {
+      kind: "transcribing",
+    });
+  });
+});
+
+describe("isDictationBusy (submit gating)", () => {
+  it("is false when absent or idle", () => {
+    equal(isDictationBusy(undefined), false);
+    equal(isDictationBusy(control("idle")), false);
+  });
+
+  it("is true for every active state", () => {
+    equal(isDictationBusy(control("requesting")), true);
+    equal(isDictationBusy(control("recording")), true);
+    equal(isDictationBusy(control("transcribing")), true);
+  });
+});
+
+describe("isDictationCapturing (Escape cancels)", () => {
+  it("captures only while requesting or recording", () => {
+    equal(isDictationCapturing(control("requesting")), true);
+    equal(isDictationCapturing(control("recording")), true);
+  });
+
+  it("does not capture when idle, transcribing, or absent", () => {
+    equal(isDictationCapturing(control("idle")), false);
+    equal(isDictationCapturing(control("transcribing")), false);
+    equal(isDictationCapturing(undefined), false);
+  });
+});
+
+describe("Escape while recording fires onCancel and nothing else", () => {
+  // Mirrors chat-input handleKeyDown: capture states route Escape to onCancel.
+  it("calls onCancel exactly once, never onStop", () => {
+    let cancels = 0;
+    let stops = 0;
+    const c: DictationControl = {
+      ...control("recording", Date.now()),
+      onCancel: () => {
+        cancels += 1;
+      },
+      onStop: () => {
+        stops += 1;
+      },
+    };
+    if (isDictationCapturing(c)) c.onCancel();
+    equal(cancels, 1);
+    equal(stops, 0);
+  });
+});
+
+describe("formatElapsed", () => {
+  it("is 0:00 before the capture starts (requesting)", () => {
+    equal(formatElapsed(undefined, 5000), "0:00");
+  });
+
+  it("floors to whole seconds and zero-pads", () => {
+    equal(formatElapsed(0, 5900), "0:05");
+    equal(formatElapsed(0, 9000), "0:09");
+  });
+
+  it("rolls minutes over at 60 seconds", () => {
+    equal(formatElapsed(0, 60_000), "1:00");
+    equal(formatElapsed(0, 125_000), "2:05");
+  });
+
+  it("clamps a backwards clock to 0:00", () => {
+    equal(formatElapsed(5000, 1000), "0:00");
+  });
+});


### PR DESCRIPTION
## What

The composer's dead mic button becomes real on-device voice typing. Desktop-only; the web build renders no mic at all.

- **Capture**: getUserMedia + AudioWorklet (Blob-URL module) → 16 kHz mono Int16 WAV encoded in the webview. No MediaRecorder — WKWebView emits AAC. 120 s auto-stop; Escape cancels; submit gated while recording/transcribing; transcripts append to the same draft store typed text uses.
- **Shell**: `whisper-cli` sidecar (whisper.cpp **v1.9.1**, built per target in CI, Metal-embedded and dylib-free on macOS with `GGML_BLAS=OFF` to avoid a macOS 13.3-only weak symbol on our 10.15 floor, CPU-portable on Windows) behind three Tauri commands in `app/src-tauri/src/dictation/`: `transcribe_audio` (raw WAV IPC + `x-dictation-lang` header), `dictation_model_status`, `download_dictation_model`. child_guard process-group/Job-Object hardening, stdout capture, duration-derived timeout.
- **Model**: `ggml-small-q5_1` (~181 MB), downloaded on first use behind a consent dialog with progress, sha256-pinned (HF LFS oid), atomic `.part` rename, stored in the app data dir. Installer size unchanged (binary is ~3 MB).
- **UI**: prop-driven `DictationControl` in `@houston-ai/chat` (mic hidden entirely when the prop is undefined); recording state with pulsing dot + live mm:ss; non-technical en/es/pt copy.
- **Packaging**: `externalBin` whisper-cli; `com.apple.security.device.audio-input` entitlement + `NSMicrophoneUsageDescription` (new merged `Info.plist`); `release.yml` gains gated build steps (macOS slices + lipo, Windows matrix, Linux) that fail the release on a broken whisper build instead of shipping a placeholder.

## Verification

- 935 app tests (16 new: byte-exact WAV encoder, resampler, reducer transitions), 130 cargo tests, 78 ui/chat tests, web shim-parity guard green (35 commands shimmed), repo typecheck/biome/locales clean.
- Real round-trip on macOS arm64 with the pinned model (sha256 matched the manifest): `say`-synthesized audio transcribed **word-perfect in English, Spanish, and Portuguese** via the locally-built sidecar (~7 s incl. model load).
- Playwright web run asserts no mic affordance renders in the browser build.

Remaining manual QA (needs packaged builds): macOS TCC mic prompt in the signed app, Windows WebView2 mic prompt, and cmake availability on the windows-11-arm runner (the release gate fails closed if absent).

Series: #734, #738, #739, #740, #744 merged — this is 6/6; a KB docs PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)