### PR TITLE
docs: update knowledge base for the AI Chat improvements

### DIFF
--- a/knowledge-base/README.md
+++ b/knowledge-base/README.md
@@ -22,6 +22,7 @@ Load on demand.
 | [windows-testing.md](windows-testing.md) | Windows testing loop from a Mac — UTM VM, SSH bridge, cross-compile |
 | [provider-errors.md](provider-errors.md) | Provider error taxonomy + card surface (now owned by the TS host / pi) |
 | [local-models.md](local-models.md) | BYO local model (LM Studio / Jan / Ollama) → cloud agent via the desktop tunnel bridge |
+| [dictation.md](dictation.md) | Desktop-only voice typing — whisper.cpp sidecar, model download UX, platform constraints |
 | [platform-matrix.md](platform-matrix.md) | _HISTORICAL_ — Windows support status at the (removed) Rust engine surface |
 
 **Custom-frontend integration** — the standalone `examples/smartbooks/` reference was REMOVED in the convergence sweep. The frontend-agnostic contract still holds; the canonical non-Tauri consumer is now `packages/web` (the full desktop UI over the host's protocol v3).

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -464,9 +464,23 @@ on the new provider seeded with prior context, reusing the compaction machinery:
 spend tokens, scaling with the current conversation size), with mode-specific
 copy. The switch is staged only on confirm.
 
-The size decision is frontend-only — the context-window catalog lives in
-`app/src/lib/providers.ts` (`app/src/lib/provider-switch.ts::decideHandoffMode`).
-The choice is staged in `app/src/stores/provider-switch.ts`, forwarded on the
+The size decision (`app/src/lib/provider-switch.ts::decideHandoffMode`) reads
+the SAME per-model context-window numbers the runtime's autocompact uses:
+`resolveModelWindow` / `effectiveModelWindow`
+(`@houston/protocol/model-windows`, a dependency-free subpath export) is the
+ONE `{default, max}` table, imported by both the frontend catalog
+(`app/src/lib/providers.ts`) and the runtime
+(`packages/runtime/src/session/exec-turn.ts`, autocompact + provider-switch
+sizing) — the context bar and the engine's compaction trigger always divide by
+the same denominator now. `default` is the starting estimate; the estimate
+snaps UP to `max` once observed usage exceeds `default`, proving the larger
+(plan/credit-gated) window is actually active. Anthropic's flagships
+(`claude-sonnet-4-6`, `claude-opus-4-7`, `claude-opus-4-8`) default to 200k and
+snap to 1M. `normalizeUsage` (`packages/runtime/src/backends/pi/wire.ts`)
+synthesizes `context_tokens` from the component fields when a provider's usage
+event omits a summed `totalTokens`, so a provider that under-reports usage
+still feeds the window estimate instead of going null. The choice is staged in
+`app/src/stores/provider-switch.ts`, forwarded on the
 next send as `POST .../sessions { providerSwitch: { mode, fromProvider } }`, and
 the engine reseeds in `houston_engine_core::sessions::run_start`: it clears the
 resolved provider's current resume id (so a switch-**back** never resumes a
@@ -481,37 +495,47 @@ event, so a failed switch is retried on the next send.
 
 ### Reasoning effort
 
+Four tiers, ascending: `low`, `medium`, `high`, `xhigh` (`EffortLevel` in
+`app/src/lib/providers.ts`). A fifth `max` tier used to sit above `xhigh`; it
+produced the byte-identical request as `xhigh` on every provider (a label with
+no effect), so it was removed. A persisted `"max"` (an older agent config; the
+JSON schema `ui/agent-schemas/src/config.schema.json` and
+`app/src/data/config.ts` still list it in the type for that reason) normalizes
+to `"xhigh"` on read (`normalizeEffort`); the runtime's own wire mapping
+(`toThinkingLevel`, `packages/runtime/src/ai/effort.ts`) also still accepts
+`"max"` and maps it to `xhigh`, so an unmigrated agent's turns run correctly
+even before the value is re-picked in the UI.
+
 Effort is **per-agent and model-gated**. Stored as `effort` in the agent's
-`.houston/config/config.json` (schema `ui/agent-schemas/src/config.schema.json`),
-set from the model picker (`app/src/components/chat-model-selector.tsx`), which
-shows only the levels the active model accepts.
+`.houston/config/config.json`, set from the model picker
+(`app/src/components/chat-model-selector.tsx`), which shows only the levels
+the active model accepts (`getEffortLevels`). `validEffortOrDefault` resolves
+the level actually used: the requested value if the model accepts it, else
+`DEFAULT_EFFORT` (`medium`) if the model offers it, else the model's lowest
+level; a model with no effort control gets `undefined` and the flag is omitted
+entirely.
 
-- The engine resolves it in `houston_engine_core::sessions::resolve_effort`
-  (`engine/houston-engine-core/src/sessions/provider.rs`): the configured value
-  when the **final** provider accepts it, else the provider's `default_effort`
-  (`medium`), else `None` for providers with no effort control. An explicit
-  `effort` on `POST .../sessions` (the onboarding tutorial) still wins over
-  config. Applies to chat, board missions, routines, and onboarding alike.
-- Valid levels live on the `ProviderAdapter` (`effort_levels` / `default_effort`)
-  as a provider-level **superset** used for validation; per-model availability
-  is a picker concern (`ModelOption.effortLevels` in `providers.ts`).
+**Per-model levels derive from pi by default, not a hand-maintained table.**
+`deriveEffortLevels` (`app/src/lib/providers.ts`) maps each model's pi-ai
+`thinkingLevels` (pi's `getSupportedThinkingLevels`, vendored
+`@earendil-works/pi-ai`, surfaced via `/v1/catalog`) straight onto Houston's
+four-tier scale, dropping pi's `off`/`minimal` (Houston's scale starts at
+`low`). This keeps the effort set honest as pi adds/changes models, with no
+curated list to fall out of date. `PROVIDER_OVERRIDES[].models[id].effortLevels`
+(`app/src/lib/provider-overrides.ts`) is an escape hatch ONLY for a genuine
+gateway-imposed cap that differs from what pi reports — no override sets it
+today. If one is added naming a model id the shipped pi-ai catalog doesn't
+carry, `app/tests/provider-overrides-drift.test.ts` fails the build (it reads
+the real vendored pi-ai registry, not a test fixture).
 
-| Provider | Model | Effort levels offered | CLI flag |
-|---|---|---|---|
-| `anthropic` | `claude-fable-5` (Fable 5) | low, medium, high, xhigh, max | `--effort <v>` |
-| `anthropic` | `claude-opus-4-8` (Opus 4.8) | low, medium, high, xhigh, max | `--effort <v>` |
-| `anthropic` | `claude-opus-4-7` (Opus 4.7) | low, medium, high, xhigh, max | `--effort <v>` |
-| `anthropic` | `claude-sonnet-5` (Sonnet 5) | low, medium, high, xhigh, max | `--effort <v>` |
-| `anthropic` | `claude-sonnet-4-6` (Sonnet 4.6) | low, medium, high, max (no `xhigh`) | `--effort <v>` |
-| `openai` | `gpt-5.5` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
-| `openai` | `gpt-5.4` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
-| `openai` | `gpt-5.4-mini` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
-| `openai` | `gpt-5.3-codex-spark` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
-| `gemini` | any | none | (no flag) |
+### Turn mode
 
-Claude self-clamps an unsupported `--effort` down to its highest supported
-level; codex has no such fallback, so `max` (an unknown variant to codex) is
-never offered for OpenAI. Default for every effort-capable provider is `medium`.
+A separate per-turn "Mode" pill sits next to the model + effort controls in
+the composer footer (`execute` vs `plan`, read-only investigation). Unlike
+effort it is NOT synced through `Settings` — full mechanics, the runtime
+enforcement (tool clamp + planning overlay), and the "forgotten `modeOverride`
+silently degrades to execute" gotcha are in `knowledge-base/architecture.md`
+("Turn modes").
 
 ## AI models hub
 

--- a/knowledge-base/architecture.md
+++ b/knowledge-base/architecture.md
@@ -182,6 +182,39 @@ The old `#houston_toolkit=` markdown-link connect hack is GONE from the prompt a
 tool guidance; the app's legacy link-card renderer survives only to render old
 transcripts. Client-side settle detail: `knowledge-base/client-architecture.md`.
 
+## Turn modes (execute / plan)
+
+Each turn optionally pins a `TurnMode`: `"execute" | "plan"`
+(`packages/protocol/src/conversation.ts`). `execute` is full read/write/act,
+today's only behavior for an UNPINNED turn — routines and per-turn cloud
+workspaces never inherit a mode, so they always execute. Deliberately NOT part
+of `Settings` (which persists `effort`): mode rides the per-turn pin only, so
+an unpinned turn can never accidentally end up read-only.
+
+`plan` clamps the turn to a read-only tool subset — `PLAN_MODE_TOOL_NAMES`
+(`read, ls, grep, find, ask_user`, `packages/runtime/src/session/tool-selection.ts`)
+with `edit, write, bash, run_code`, and every integration tool dropped — plus a
+system-prompt overlay (`PLAN_MODE_OVERLAY`,
+`packages/runtime/src/session/plan-overlay.ts`) that tells the model to
+investigate and propose a plan rather than act. `switchModeIfNeeded`
+(`packages/runtime/src/session/conversation-cache.ts`) rebuilds the session
+when the pinned mode differs from the live one, keyed by conversation id. Both
+backends honor it: the pi backend swaps its tool allowlist; the Claude-SDK
+backend keeps its SDK `permissionMode` default and simply gets no integration
+tools, so plan mode still holds.
+
+App side: a Mode pill in the composer footer
+(`app/src/components/chat-mode-selector.tsx`), remembered per-agent as `mode`
+in `.houston/config/config.json` (composer memory only — never synced to
+engine `Settings`). Every user-typed send forwards the pin explicitly as
+`modeOverride`.
+
+**Gotcha.** Mode must ride EVERY send path explicitly, unlike effort (which
+syncs through `Settings` and so is implicitly present on every send) — a send
+path that forgets `modeOverride` silently degrades to `execute`. Per-turn
+cloud workspaces drop chat-body pins entirely; that's pre-existing and not
+specific to plan mode.
+
 ## Current gap to vision
 
 | Goal | Status |

--- a/knowledge-base/dictation.md
+++ b/knowledge-base/dictation.md
@@ -1,0 +1,63 @@
+# Dictation (desktop-only voice typing)
+
+Push-to-talk voice typing in the chat composer. Desktop only — no cloud
+round-trip, no mic access on web (the mic control is absent entirely there).
+
+## Architecture
+
+- **Sidecar**: `whisper.cpp`'s `whisper-cli` (v1.9.1, MIT), built per-target by
+  `scripts/build-whisper.sh` and staged by `app/src-tauri/build.rs`
+  (`stage_whisper_sidecar`) like `frpc` and the host sidecar — Tauri
+  `externalBin`, staged as `binaries/whisper-cli-<triple>`. Built fully static
+  (no shared-lib dependency); macOS Metal is embedded in the binary.
+- **Model**: `ggml-small-q5_1` (~181 MB, sha256-pinned in
+  `app/src-tauri/src/dictation/model.rs`), downloaded once into the app data
+  dir (`<app_data_dir>/models/whisper/ggml-small-q5_1.bin`) on first use.
+  Streams to a `.part` sibling, hashing as it goes, and only renames into
+  place once the digest matches — a truncated/corrupted fetch can never
+  masquerade as ready.
+- **Tauri commands** (`app/src-tauri/src/dictation/`): `transcribe_audio`
+  (raw-WAV over the IPC payload as `InvokeBody::Raw` — JSON-encoding a
+  multi-megabyte clip would freeze the webview, same reasoning as
+  `commands::save_file`; the language hint rides the `x-dictation-lang`
+  header), `dictation_model_status`, `download_dictation_model`. The sidecar
+  child gets the same orphan-prevention discipline as the engine/frpc
+  sidecars (Unix process group + `killpg`, Windows Job Object).
+- **Capture** (`app/src/lib/dictation/`): `getUserMedia` → an `AudioContext`
+  pinned to 16 kHz → an `AudioWorklet` posting raw Float32 frames to the main
+  thread → accumulate → resample if the platform ignored the requested rate →
+  encode as WAV. Deliberately **not** `MediaRecorder` — WKWebView's
+  `MediaRecorder` only emits AAC, no PCM/Opus container whisper can consume.
+  Auto-stops at 120s.
+- **UI**: `ui/chat` exposes a prop-driven `DictationControl` contract
+  (`ui/chat/src/dictation-types.ts`) — the library renders mic /
+  recording / transcribing states, all capture and transcription logic stays
+  in the app. `control === undefined` → mic hidden entirely (the web build
+  passes no control). `app/src/lib/dictation/use-dictation.ts` is the state
+  machine hook wired into the composer.
+
+## Model-download UX
+
+First use probes `dictation_model_status`. Not ready → a consent dialog opens
+showing the size (`DictationModelSetup` / `use-dictation-model-setup.ts`),
+progress streams via a Tauri event (`dictation-model-progress`), and the model
+state stays outside the capture/transcribe phase machine —
+`DictationControl.state` stays `"idle"` while the dialog is open, since
+nothing is being captured yet. A "model-not-ready" failure from a downstream
+`transcribe_audio` call re-probes and reopens the dialog.
+
+## Platform constraints
+
+macOS needs `com.apple.security.device.audio-input`
+(`app/src-tauri/entitlements.plist`) plus `NSMicrophoneUsageDescription` (new
+`app/src-tauri/Info.plist`, merged in by the Tauri bundler). No mic access
+without both.
+
+## Release gates
+
+`.github/workflows/release.yml` builds `whisper-cli` per target and asserts
+the binary is executable before continuing (same fail-closed pattern as the
+host sidecar and frpc — never ship the loud-fail placeholder `build.rs` stages
+when the binary is absent): macOS builds aarch64 + x86_64 separately and
+`lipo`s them into one universal `whisper-cli-universal-apple-darwin`; Windows
+and Linux build per matrix target with a `test -x` gate.

--- a/knowledge-base/provider-errors.md
+++ b/knowledge-base/provider-errors.md
@@ -42,7 +42,7 @@ now removed.)
 | `QuotaExhausted`           | Long-window / billing-period limit. Wait won't help.                                    | Upgrade plan (`upgrade_url`), Switch provider.       |
 | `UsageLimitPaused`         | Plan-window limit hit (today: Anthropic claude-code's 5-hour subscription session limit). Fires from `rate_limit_event` `status:"rejected"` (structured `resetsAt` epoch), a `429` result whose body names a session/usage limit + reset, or the stderr "usage limit ... reset at" banner. Retrying now fails — wait for the reset. | Chat: `UsageLimitPausedCard` (title + "resets at {time}" from `resets_at`, plus Switch model — a different provider has its own limit). Routines surface "Waiting · resumes at HH:MM" via `routine_run.paused_until`. |
 | `ModelUnavailable`         | The requested model isn't available to this account (preview, deprecated, regioned).    | Switch to `suggested_fallback`, Pick another model.  |
-| `Unauthenticated`          | Auth missing/expired/invalid. `cause` narrows the body copy.                            | Reconnect (drives `tauriProvider.launchLogin`); the card then WAITS on the `ProviderLoginComplete` WS event (launchLogin resolves at CLI spawn, not completion) and flips to a green "Reconnected" state with a retry CTA, or shows the failure and re-arms. |
+| `Unauthenticated`          | Auth missing/expired/invalid. `cause` narrows the body copy.                            | Reconnect (drives `tauriProvider.launchLogin`); the card then WAITS on the `ProviderLoginComplete` WS event (launchLogin resolves at CLI spawn, not completion) and flips to a green "Reconnected" state with a "Send my message" CTA (`providerError.unauthenticated.sendAgain`, only shown when there's a failed prompt to resend) or a disabled "Signed in" badge, or shows the failure and re-arms with "Reconnect". |
 | `NetworkUnreachable`       | Cannot reach the provider's API (DNS, connect refused, ECONNRESET).                     | Retry, Check status page.                            |
 | `ProviderInternal`         | 5xx from upstream, transient infra failure.                                             | Retry, Check status page.                            |
 | `SessionResumeMissing`     | Resume target is gone or unrecoverable. Codex: `no rollout found`. Anthropic: claude exits with `result/error_during_execution/duration_ms:0` on the very first stdout line — the `~/.claude/projects/<encoded-cwd>/<id>.jsonl` transcript is corrupt. Both runners auto-restart fresh; the card is informational. | Try again (re-sends after the auto-restart in case the fresh attempt also failed). |
@@ -177,6 +177,21 @@ feed already carries an inline `provider_error` `unauthenticated` card for
 this chat's provider — the persisted inline card is the stable surface.
 (The underlying probe false-positive is still unfixed; it needs a
 server-validating auth check.)
+
+**Two cards, two copy sets, kept deliberately distinct.** The inline
+`UnauthenticatedCard` (above) and the store `ProviderReconnectCard` used to
+share ambiguous "Try again" / "Reconnect" wording across two different
+actions (resend a message vs. relaunch sign-in). Their phase-to-copy mappings
+are now pure, unit-tested lookups: `resolveAuthCardPresentation`
+(`app/src/components/shell/provider-error-cards/auth-presentation.ts`) for the
+inline card's 4-phase machine (`idle | waiting | done | failed`), and
+`resolveReconnectCardPresentation`
+(`app/src/components/shell/provider-reconnect-presentation.ts`) for the store
+card's 2-state machine (`loginLaunched`). The store card's launched-state
+button now names its real action, `providerReconnect.signInAgain` ("Sign in
+again"), instead of borrowing the shared `common:actions.tryAgain`; the
+now-unused `providerReconnect.reconnect` / `providerReconnect.tryAgain` i18n
+keys were deleted.
 
 **Where the card actually mounts (don't let this regress).** A
 `FeedItem::ProviderError` becomes a `ChatMessage` with `providerError` set


### PR DESCRIPTION
Phase-10 knowledge-base sweep for the six-PR AI Chat series (#734, #738, #739, #740, #744, #745):

- **provider-errors.md**: current reconnect-card CTAs ("Send my message" / "Sign in again") and the extracted pure presentation modules; deleted locale keys noted.
- **agent-manifest.md**: 4-tier effort scale ("max" removed; legacy configs normalize to xhigh), pi-derived per-model effort levels with the override escape hatch + drift guard, shared `@houston/protocol/model-windows` for context windows, turn-mode cross-reference. Also purged a stale Rust-era 5-tier effort table.
- **architecture.md**: new "Turn modes (execute / plan)" section, including the gotcha that mode must ride every send path explicitly (unlike effort it never syncs via Settings).
- **dictation.md** (new, indexed in the KB README): whisper.cpp sidecar architecture, first-use model download, platform constraints, release gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)