### PR TITLE
fix: guard persisted pending_interaction shapes at every read seam

### DIFF
--- a/app/src/lib/active-interaction.ts
+++ b/app/src/lib/active-interaction.ts
@@ -1,4 +1,8 @@
 import type { PendingInteraction } from "@houston/protocol";
+// Subpath import (like @houston/protocol/model-windows): the app's node:test
+// runner loads value imports for real, and the package index's extensionless
+// import chain only resolves under bundler resolution.
+import { isPendingInteraction } from "@houston/protocol/interaction";
 import type { BoardStatus } from "@houston/sdk";
 
 /**
@@ -24,7 +28,12 @@ export function deriveActiveInteraction(args: {
   persisted: PendingInteraction | null | undefined;
 }): PendingInteraction | null {
   if (args.running) return null;
-  return args.live ?? args.persisted ?? null;
+  // Both sources are persisted data that can outlive the code that wrote it
+  // (an activity or message from a pre-step build has no `steps`): render only
+  // a structurally valid sequence, treat anything else as absent.
+  if (isPendingInteraction(args.live)) return args.live;
+  if (isPendingInteraction(args.persisted)) return args.persisted;
+  return null;
 }
 
 /**
@@ -36,9 +45,8 @@ export function deriveActiveInteraction(args: {
 export function interactionQuestionCount(
   interaction: PendingInteraction | null | undefined,
 ): number {
-  return (
-    interaction?.steps.filter((step) => step.kind === "question").length ?? 0
-  );
+  if (!isPendingInteraction(interaction)) return 0;
+  return interaction.steps.filter((step) => step.kind === "question").length;
 }
 
 /**
@@ -56,7 +64,10 @@ export function interactionNotificationBodyKey(
   | "sessionComplete.connect" {
   if (interactionQuestionCount(interaction) > 0)
     return "sessionComplete.question";
-  if (interaction?.steps.some((step) => step.kind === "connect"))
+  if (
+    isPendingInteraction(interaction) &&
+    interaction.steps.some((step) => step.kind === "connect")
+  )
     return "sessionComplete.connect";
   return "sessionComplete.body";
 }

--- a/app/tests/active-interaction.test.ts
+++ b/app/tests/active-interaction.test.ts
@@ -75,6 +75,58 @@ describe("deriveActiveInteraction", () => {
   });
 });
 
+// Interactions persisted by OLDER builds (pre-step shapes without `steps`)
+// outlive the code that wrote them. They must read as "nothing pending",
+// never crash (`undefined is not an object (evaluating 'steps.some')`).
+const legacyQuestion = {
+  kind: "question",
+  question: "Which account?",
+  options: [{ id: "a", label: "Work" }],
+} as unknown as PendingInteraction;
+const legacyConnect = {
+  kind: "connect",
+  toolkit: "gmail",
+} as unknown as PendingInteraction;
+
+describe("legacy persisted shapes (no steps)", () => {
+  it("deriveActiveInteraction treats them as absent, both sources", () => {
+    strictEqual(
+      deriveActiveInteraction({
+        running: false,
+        live: legacyQuestion,
+        persisted: legacyConnect,
+      }),
+      null,
+    );
+  });
+
+  it("falls through an invalid live value to a valid persisted one", () => {
+    strictEqual(
+      deriveActiveInteraction({
+        running: false,
+        live: legacyQuestion,
+        persisted: connect,
+      }),
+      connect,
+    );
+  });
+
+  it("notification body falls back to the plain body without throwing", () => {
+    strictEqual(
+      interactionNotificationBodyKey(legacyQuestion),
+      "sessionComplete.body",
+    );
+    strictEqual(
+      interactionNotificationBodyKey(legacyConnect),
+      "sessionComplete.body",
+    );
+  });
+
+  it("question count is 0 without throwing", () => {
+    strictEqual(interactionQuestionCount(legacyQuestion), 0);
+  });
+});
+
 describe("interactionNotificationBodyKey", () => {
   it("maps a pending question to the question body", () => {
     strictEqual(

--- a/packages/domain/src/activities.ts
+++ b/packages/domain/src/activities.ts
@@ -1,8 +1,8 @@
-import type {
-  Activity,
-  ActivityUpdate,
-  NewActivity,
-  PendingInteraction,
+import {
+  type Activity,
+  type ActivityUpdate,
+  isPendingInteraction,
+  type NewActivity,
 } from "@houston/protocol";
 import { docKey } from "./layout";
 import {
@@ -24,25 +24,11 @@ export const ACTIVITY_STATUSES = [
 const isRecord = (v: unknown): v is Record<string, unknown> =>
   typeof v === "object" && v !== null && !Array.isArray(v);
 
-/** One interaction step is valid when it carries a string `id` and the fields
- *  its `kind` requires: a `question` needs a string `question`, a `connect`
- *  needs a string `toolkit`. */
-const isValidInteractionStep = (v: unknown): boolean => {
-  if (!isRecord(v) || typeof v.id !== "string") return false;
-  if (v.kind === "question") return typeof v.question === "string";
-  if (v.kind === "connect") return typeof v.toolkit === "string";
-  return false;
-};
-
-/** Validate the pending_interaction shape (mirrors the schema): a non-empty
- *  `steps` array, each step a valid question or connect. An old top-level
- *  `{kind, questions}` / `{kind, toolkit}` shape has no `steps`, so a value
- *  persisted before the step-sequence change is dropped. */
-const isValidPendingInteraction = (v: unknown): v is PendingInteraction =>
-  isRecord(v) &&
-  Array.isArray(v.steps) &&
-  v.steps.length > 0 &&
-  v.steps.every(isValidInteractionStep);
+/** Validate the pending_interaction shape (mirrors the schema). The canonical
+ *  structural guard lives beside the type in @houston/protocol: an old
+ *  top-level `{kind, questions}` / `{kind, toolkit}` shape has no `steps`, so a
+ *  value persisted before the step-sequence change is dropped. */
+const isValidPendingInteraction = isPendingInteraction;
 
 /**
  * Normalize a raw activity array (agents write this file with file tools, so
@@ -143,7 +129,12 @@ export function applyActivityUpdate(
   if (pending_interaction === null) {
     delete next.pending_interaction;
   } else if (pending_interaction !== undefined) {
-    next.pending_interaction = pending_interaction;
+    // PATCH bodies are untrusted at runtime (an old client or stale message can
+    // carry a pre-step shape the compile-time type can't catch): only a
+    // structurally valid sequence is persisted; anything else leaves the
+    // current value alone.
+    if (isValidPendingInteraction(pending_interaction))
+      next.pending_interaction = pending_interaction;
   }
   return next;
 }

--- a/packages/domain/src/domain.test.ts
+++ b/packages/domain/src/domain.test.ts
@@ -190,6 +190,33 @@ test("activity update: pending_interaction set / clear / untouched", () => {
   expect("pending_interaction" in cleared).toBe(false);
 });
 
+test("activity update: an invalid (pre-step legacy) pending_interaction is not persisted", () => {
+  const current = applyActivityUpdate(
+    createActivity({ title: "T" }, "a1", NOW),
+    {
+      pending_interaction: {
+        steps: [{ kind: "connect", id: "c1", toolkit: "slack" }],
+      },
+    },
+    NOW,
+  );
+  // A PATCH carrying the old top-level shape (no `steps`) must leave the
+  // current value alone instead of storing a shape the UI cannot render.
+  const legacy = applyActivityUpdate(
+    current,
+    {
+      pending_interaction: {
+        kind: "question",
+        question: "Which deck?",
+      } as unknown as import("@houston/protocol").PendingInteraction,
+    },
+    NOW,
+  );
+  expect(legacy.pending_interaction).toEqual({
+    steps: [{ kind: "connect", id: "c1", toolkit: "slack" }],
+  });
+});
+
 test("upsert/remove by id", () => {
   const a = createActivity({ title: "A" }, "a", NOW);
   const b = createActivity({ title: "B" }, "b", NOW);

--- a/packages/protocol/package.json
+++ b/packages/protocol/package.json
@@ -14,6 +14,10 @@
     "./model-windows": {
       "types": "./src/model-windows.ts",
       "import": "./src/model-windows.ts"
+    },
+    "./interaction": {
+      "types": "./src/domain/interaction.ts",
+      "import": "./src/domain/interaction.ts"
     }
   },
   "files": [

--- a/packages/protocol/src/domain/interaction.test.ts
+++ b/packages/protocol/src/domain/interaction.test.ts
@@ -1,5 +1,39 @@
-import { expectTypeOf, test } from "vitest";
-import type { PendingInteraction } from "../index";
+import { expect, expectTypeOf, test } from "vitest";
+import { isPendingInteraction, type PendingInteraction } from "../index";
+
+test("isPendingInteraction accepts the step-sequence shape and rejects legacy shapes", () => {
+  expect(
+    isPendingInteraction({
+      steps: [
+        { kind: "question", id: "q1", question: "Which deck?" },
+        { kind: "connect", id: "c1", toolkit: "gmail", reason: "to send it" },
+      ],
+    }),
+  ).toBe(true);
+
+  // Pre-step shapes persisted by older builds: no `steps`.
+  expect(
+    isPendingInteraction({ kind: "question", question: "Which deck?" }),
+  ).toBe(false);
+  expect(
+    isPendingInteraction({
+      kind: "question",
+      questions: [{ id: "q1", question: "Which deck?" }],
+    }),
+  ).toBe(false);
+  expect(isPendingInteraction({ kind: "connect", toolkit: "gmail" })).toBe(
+    false,
+  );
+
+  // Structural junk.
+  expect(isPendingInteraction(null)).toBe(false);
+  expect(isPendingInteraction(undefined)).toBe(false);
+  expect(isPendingInteraction({ steps: [] })).toBe(false);
+  expect(isPendingInteraction({ steps: [{ kind: "question" }] })).toBe(false);
+  expect(isPendingInteraction({ steps: [{ kind: "connect", id: "c1" }] })).toBe(
+    false,
+  );
+});
 
 test("the protocol index re-exports PendingInteraction", () => {
   const pending: PendingInteraction = {

--- a/packages/protocol/src/domain/interaction.ts
+++ b/packages/protocol/src/domain/interaction.ts
@@ -32,3 +32,25 @@ export type InteractionStep =
 export interface PendingInteraction {
   steps: InteractionStep[];
 }
+
+const isRecord = (v: unknown): v is Record<string, unknown> =>
+  typeof v === "object" && v !== null;
+
+/** One step, structurally valid. */
+export const isInteractionStep = (v: unknown): v is InteractionStep => {
+  if (!isRecord(v) || typeof v.id !== "string") return false;
+  if (v.kind === "question") return typeof v.question === "string";
+  if (v.kind === "connect") return typeof v.toolkit === "string";
+  return false;
+};
+
+/** Structural guard for persisted/wire data. Interactions outlive code: an
+ *  activity, chat message, or localStorage entry written by an OLDER build
+ *  (the pre-step `{kind, question}` / `{kind, questions}` / `{kind, toolkit}`
+ *  shapes) has no `steps` and must be treated as absent, never rendered.
+ *  Every seam that READS a persisted interaction goes through this guard. */
+export const isPendingInteraction = (v: unknown): v is PendingInteraction =>
+  isRecord(v) &&
+  Array.isArray(v.steps) &&
+  v.steps.length > 0 &&
+  v.steps.every(isInteractionStep);

--- a/packages/sdk/src/modules/turns/settle-from-history.ts
+++ b/packages/sdk/src/modules/turns/settle-from-history.ts
@@ -1,3 +1,4 @@
+import { isPendingInteraction } from "@houston/protocol";
 import type { ChatMessage } from "@houston/runtime-client";
 import {
   finishErr,
@@ -77,7 +78,10 @@ function adoptReply(s: TurnState, reply: ChatMessage): void {
   // (runtime, clean path only). Adopt it BEFORE finishOk so a settle from
   // history splits to `needs_you` with the interaction — matching the live
   // `done` frame we missed — instead of collapsing to a false `done`.
-  if (reply.pendingInteraction) s.pendingInteraction = reply.pendingInteraction;
+  // Guarded: persisted messages outlive code, and a reply written by an older
+  // build carries a pre-step interaction shape that must not reach the VM.
+  if (isPendingInteraction(reply.pendingInteraction))
+    s.pendingInteraction = reply.pendingInteraction;
   finishOk(s);
 }
 

--- a/packages/sdk/src/modules/turns/turn-settle.test.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.test.ts
@@ -111,6 +111,32 @@ test("a persisted pendingInteraction recovers on reload: needs_you + the interac
   expect(statuses).toEqual([["completed", undefined]]);
 });
 
+test("a legacy pre-step pendingInteraction on a persisted reply is ignored, not adopted", () => {
+  // Written by an older build: no `steps`. Adopting it would crash every
+  // consumer that reads interaction.steps ("undefined is not an object").
+  const legacy = {
+    kind: "question",
+    question: "which date?",
+    options: [{ id: "a", label: "Fri" }],
+  } as unknown as PendingInteraction;
+  const { s } = run(
+    [
+      { role: "user", content: "book it", ts: 1, turnId: "t-1" },
+      {
+        role: "assistant",
+        content: "which date?",
+        ts: 2,
+        turnId: "t-1",
+        pendingInteraction: legacy,
+      },
+    ],
+    "t-1",
+  );
+  expect(s.settled).toBe(true);
+  expect(s.pendingInteraction).toBeNull();
+  expect(s.terminal).toBe("done");
+});
+
 test("a persisted providerError for our turn settles as the typed card", () => {
   const providerError = {
     kind: "rate_limited",


### PR DESCRIPTION
## What

Production crash: `undefined is not an object (evaluating 'steps.some')`. Interactions persisted by pre-step builds (the old `{kind, question(s)}` / `{kind, toolkit}` shapes) outlive the code: settle-from-history adopted an old `ChatMessage.pendingInteraction` unvalidated, `applyActivityUpdate` persisted whatever a PATCH carried, and the UI dereferenced `.steps` on a shape without it.

- Canonical structural guard `isPendingInteraction` beside the type in `@houston/protocol` (+ a `./interaction` subpath export mirroring `./model-windows`, so the app's node:test runner can value-import it); domain's duplicate validator delegates to it.
- Guarded seams: SDK settle-from-history (legacy reply interaction ignored → turn settles `done`), domain `applyActivityUpdate` (invalid PATCH leaves the current value), app `deriveActiveInteraction` + notification derivation (both sources — also covers the web localStorage path).

## Tests

Reproduced first: the new app legacy-shape suite fails 4/4 against the pre-fix code (the exact crash), green after. Protocol guard suite (19), domain PATCH rejection (93), SDK legacy-adopt (249), app 929, host 634, web 87; repo typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)