### PR TITLE
feat(chat): cache cloud conversations locally so chats paint instantly (HOU-712)

### DIFF
--- a/app/src/lib/auth.ts
+++ b/app/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import { clearConversationCache } from "@houston-ai/engine-client";
 import type { Session } from "@supabase/supabase-js";
 import { listen } from "@tauri-apps/api/event";
 import { analytics } from "./analytics";
@@ -223,6 +224,9 @@ export async function signOut(): Promise<void> {
   } catch (e) {
     logger.warn(`[auth] signOut failed: ${e}`);
   }
+  // Cached cloud transcripts are per-user data on this machine — wipe them so
+  // nothing from the account lingers after sign-out (HOU-712). Never throws.
+  await clearConversationCache();
   analytics.track("user_signed_out");
   analytics.reset();
 }

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -59,6 +59,13 @@ import * as agents from "./agents";
 import { bus, emitEvent, emitLocalEcho } from "./bus";
 import type { ControlPlaneConfig } from "./control-plane";
 import * as controlPlane from "./control-plane";
+import {
+  conversationCacheScope,
+  deleteCachedConversation,
+  readCachedConversation,
+  setConversationCacheIdentity,
+  writeCachedConversation,
+} from "./conversation-cache";
 import * as portable from "./portable";
 import {
   flushQueuedSends,
@@ -78,6 +85,7 @@ import {
 } from "./synthetic";
 import { historyToFeed, isConversationNotFound } from "./translate";
 import {
+  clearConversationVm,
   observeConversation,
   seedConversationVm,
   streamTurn,
@@ -174,6 +182,16 @@ export class HoustonClient {
     this.cp = useCp
       ? { baseUrl: opts.baseUrl.replace(/\/+$/, ""), token: opts.token }
       : null;
+    // Local conversation cache (HOU-712) — cloud only, scoped per gateway +
+    // signed-in user. Reads the LIVE bearer so a token refresh keeps the same
+    // scope while a different account lands in different keys; local engines
+    // resolve null and never cache (their reads are local disk, never held).
+    const cp = this.cp;
+    setConversationCacheIdentity(() =>
+      cp
+        ? conversationCacheScope(cp.baseUrl, controlPlane.liveToken(cp.token))
+        : null,
+    );
     // Live-token auth fetch (not a pinned `token`): hosted mode rotates the
     // Supabase bearer mid-session, and a 401 must refresh + replay instead of
     // surfacing (HOU-687). Outside hosted mode liveToken falls back to the
@@ -1531,11 +1549,31 @@ export class HoustonClient {
     sessionKey: string,
     opts: { observe?: boolean } = {},
   ): Promise<ChatHistoryEntry[]> {
+    // Cache-first paint (HOU-712): a cloud read is HELD by the gateway for
+    // the whole engine-pod cold start, so seed the VM from the last locally
+    // persisted transcript NOW — the chat shows its messages instantly — and
+    // let the network read below revalidate whenever it lands. The seed
+    // guards in seedConversationVm keep a live or richer VM untouched, so a
+    // stale cache can never clobber fresh state.
+    let cacheSeeded = false;
+    if (this.cp && opts.observe !== false) {
+      const cached = await readCachedConversation(agentPath, sessionKey);
+      if (cached && cached.length > 0) {
+        seedConversationVm(agentPath, sessionKey, cached);
+        cacheSeeded = true;
+      }
+    }
     try {
       const engine = this.cp
         ? controlPlane.runtimeClientFor(this.cp, agentPath)
         : this.engine;
       const history = await engine.getHistory(sessionKey);
+      const sdkFeed = sdkHistoryToFeed(history.messages);
+      // Refresh the local copy on EVERY successful read (bulk scans too), so
+      // the next cold open paints the freshest transcript we ever saw.
+      if (this.cp) {
+        void writeCachedConversation(agentPath, sessionKey, sdkFeed);
+      }
       // Observer mode: a loaded chat may have a turn in flight that THIS client
       // isn't streaming (page reloaded mid-turn, or another client sent it).
       // Attach a passive resumable stream: if the server's `sync` reports a
@@ -1552,11 +1590,7 @@ export class HoustonClient {
         // seedConversationVm) — its feed IS the VM. The VM seed is the SDK's
         // UNMAPPED fold: the VM carries engine provider ids uniformly (seeded
         // and live alike); the app's binding hook owns the old-id remap.
-        seedConversationVm(
-          agentPath,
-          sessionKey,
-          sdkHistoryToFeed(history.messages),
-        );
+        seedConversationVm(agentPath, sessionKey, sdkFeed);
         observeConversation(
           engine,
           agentPath,
@@ -1578,7 +1612,14 @@ export class HoustonClient {
       // a failure. Anything else (network drop, auth, 5xx) propagates so the
       // app's `call()` wrapper toasts it with the Report-bug affordance —
       // returning [] would render a fake empty chat and swallow the error.
-      if (isConversationNotFound(err)) return [];
+      if (isConversationNotFound(err)) {
+        // The server says the conversation is gone: drop the local copy and
+        // clear a cache-seeded VM so no ghost transcript lingers (guarded —
+        // a live turn racing this read keeps its feed).
+        if (this.cp) void deleteCachedConversation(agentPath, sessionKey);
+        if (cacheSeeded) clearConversationVm(agentPath, sessionKey);
+        return [];
+      }
       throw err;
     }
   }

--- a/packages/web/src/engine-adapter/conversation-cache-idb.ts
+++ b/packages/web/src/engine-adapter/conversation-cache-idb.ts
@@ -1,0 +1,96 @@
+/**
+ * IndexedDB backend for the local conversation cache (HOU-712).
+ *
+ * Transcripts are too big for localStorage (a busy conversation folds to
+ * hundreds of KB), so the cache lives in IndexedDB: one object store, records
+ * `{k, frames, updatedAt}` keyed on `k` (the cache module's scoped key) with
+ * an `updatedAt` index so the prune sweep reads KEYS ONLY — it runs on every
+ * write and must never load transcripts. Plumbing only — validation, scoping,
+ * and prune policy live in conversation-cache.ts.
+ */
+
+import type {
+  CacheRecord,
+  ConversationCacheBackend,
+} from "./conversation-cache";
+
+const DB_NAME = "houston-conversation-cache";
+const DB_VERSION = 1;
+const STORE = "conversations";
+const BY_UPDATED_AT = "updatedAt";
+
+type StoredRecord = CacheRecord & { k: string };
+
+function req<T>(r: IDBRequest<T>): Promise<T> {
+  return new Promise((resolve, reject) => {
+    r.onsuccess = () => resolve(r.result);
+    r.onerror = () => reject(r.error);
+  });
+}
+
+export function createIdbBackend(idb: IDBFactory): ConversationCacheBackend {
+  // One connection per session, opened lazily; dropped on close/error so the
+  // next operation reopens instead of failing forever.
+  let dbPromise: Promise<IDBDatabase> | null = null;
+
+  function open(): Promise<IDBDatabase> {
+    if (!dbPromise) {
+      dbPromise = new Promise((resolve, reject) => {
+        const openReq = idb.open(DB_NAME, DB_VERSION);
+        openReq.onupgradeneeded = () => {
+          const db = openReq.result;
+          if (!db.objectStoreNames.contains(STORE)) {
+            const store = db.createObjectStore(STORE, { keyPath: "k" });
+            store.createIndex(BY_UPDATED_AT, "updatedAt");
+          }
+        };
+        openReq.onsuccess = () => {
+          const db = openReq.result;
+          db.onclose = () => {
+            dbPromise = null;
+          };
+          resolve(db);
+        };
+        openReq.onerror = () => {
+          dbPromise = null;
+          reject(openReq.error);
+        };
+      });
+    }
+    return dbPromise;
+  }
+
+  async function store(mode: IDBTransactionMode): Promise<IDBObjectStore> {
+    const db = await open();
+    return db.transaction(STORE, mode).objectStore(STORE);
+  }
+
+  return {
+    async get(key) {
+      const s = await store("readonly");
+      const value = (await req(s.get(key))) as StoredRecord | undefined;
+      return value
+        ? { frames: value.frames, updatedAt: value.updatedAt }
+        : null;
+    },
+    async set(key, record) {
+      const s = await store("readwrite");
+      await req(s.put({ ...record, k: key } satisfies StoredRecord));
+    },
+    async delete(key) {
+      const s = await store("readwrite");
+      await req(s.delete(key));
+    },
+    async keysOldestFirst() {
+      const s = await store("readonly");
+      // The index orders by updatedAt ascending; getAllKeys returns the
+      // records' PRIMARY keys in that order, loading no values.
+      const keys = await req(s.index(BY_UPDATED_AT).getAllKeys());
+      return keys.map(String);
+    },
+    async clear() {
+      const s = await store("readwrite");
+      await req(s.clear());
+    },
+  };
+}

--- a/packages/web/src/engine-adapter/conversation-cache-identity.ts
+++ b/packages/web/src/engine-adapter/conversation-cache-identity.ts
@@ -1,0 +1,35 @@
+/**
+ * Cache-scope identity for the local conversation cache (HOU-712): entries
+ * are keyed per gateway + signed-in user so cached transcripts never leak
+ * across accounts on a shared machine.
+ */
+
+/**
+ * The `sub` claim of a Supabase access token, or null when the token isn't a
+ * readable JWT.
+ */
+export function jwtSub(token: string): string | null {
+  try {
+    const payload = token.split(".")[1];
+    if (!payload) return null;
+    const b64 = payload.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+    const { sub } = JSON.parse(atob(padded)) as { sub?: unknown };
+    return typeof sub === "string" && sub ? sub : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The cache scope for a gateway + bearer, or null when the bearer carries no
+ * user (static tokens, tests) — null disables caching rather than risking a
+ * cross-account key.
+ */
+export function conversationCacheScope(
+  baseUrl: string,
+  token: string,
+): string | null {
+  const sub = jwtSub(token);
+  return sub ? `${baseUrl}|${sub}` : null;
+}

--- a/packages/web/src/engine-adapter/conversation-cache.ts
+++ b/packages/web/src/engine-adapter/conversation-cache.ts
@@ -1,0 +1,180 @@
+/**
+ * Local conversation cache (HOU-712).
+ *
+ * Cloud chats live on a per-agent engine pod behind the gateway, and a cold
+ * pod HOLDS `GET …/conversations/:id/messages` until it wakes — minutes in
+ * the worst case — so opening a chat painted nothing until the read landed.
+ * This module persists each cloud conversation's folded feed frames locally
+ * (IndexedDB); `loadChatHistory` seeds the conversation VM from it instantly,
+ * then the network read revalidates when it finally resolves.
+ *
+ * Every operation is best-effort BY DESIGN: the cache is an accelerator,
+ * never a source of truth, and the network path is untouched — so a storage
+ * failure logs once and degrades to exactly today's behavior instead of
+ * breaking the chat (a deliberate carve-out from the no-silent-failures rule:
+ * no user-initiated outcome is swallowed).
+ *
+ * Entries are keyed per gateway + user (the Supabase JWT `sub`), so cached
+ * transcripts never leak across accounts on a shared machine; sign-out clears
+ * the whole store. Local/desktop engines never cache (reads are local disk).
+ */
+
+import { createIdbBackend } from "./conversation-cache-idb";
+
+export {
+  conversationCacheScope,
+  jwtSub,
+} from "./conversation-cache-identity";
+
+/** One cached feed frame — the folded `{feed_type, data}` the VM seeds from. */
+export interface CachedFrame {
+  feed_type: string;
+  data: unknown;
+}
+
+/** A stored transcript: its frames plus a write stamp (prune order). */
+export interface CacheRecord {
+  frames: CachedFrame[];
+  updatedAt: number;
+}
+
+/** The storage the cache runs on — IndexedDB in the app, in-memory in tests. */
+export interface ConversationCacheBackend {
+  get(key: string): Promise<CacheRecord | null>;
+  set(key: string, record: CacheRecord): Promise<void>;
+  delete(key: string): Promise<void>;
+  /**
+   * Every stored key, oldest write first — the prune sweep's input. Keys
+   * ONLY: the sweep runs on every write, so it must never load transcripts.
+   */
+  keysOldestFirst(): Promise<string[]>;
+  clear(): Promise<void>;
+}
+
+/** Disk cap: keep the most recently written transcripts, evict the oldest. */
+export const MAX_CACHED_CONVERSATIONS = 256;
+
+/**
+ * The current cache scope, or null when caching is off (local engine, no
+ * signed-in user). Installed by the adapter's HoustonClient so the scope
+ * tracks the LIVE bearer — a token refresh keeps the same `sub`, a different
+ * account lands in different keys.
+ */
+let identity: () => string | null = () => null;
+
+export function setConversationCacheIdentity(fn: () => string | null): void {
+  identity = fn;
+}
+
+let backend: ConversationCacheBackend | null | undefined;
+
+/** Test seam. Pass null to disable, undefined to restore the default. */
+export function setConversationCacheBackend(
+  b: ConversationCacheBackend | null | undefined,
+): void {
+  backend = b;
+}
+
+function activeBackend(): ConversationCacheBackend | null {
+  if (backend === undefined) {
+    backend =
+      typeof indexedDB === "undefined" ? null : createIdbBackend(indexedDB);
+  }
+  return backend;
+}
+
+let warned = false;
+function warnOnce(op: string, err: unknown): void {
+  if (warned) return;
+  warned = true;
+  console.warn(`[conversation-cache] ${op} failed — caching degraded:`, err);
+}
+
+function cacheKey(agentPath: string, sessionKey: string): string | null {
+  const scope = identity();
+  if (!scope) return null;
+  return `${scope}|${encodeURIComponent(agentPath)}|${encodeURIComponent(sessionKey)}`;
+}
+
+function validFrames(value: unknown): CachedFrame[] | null {
+  if (!Array.isArray(value)) return null;
+  for (const f of value) {
+    if (
+      typeof (f as CachedFrame)?.feed_type !== "string" ||
+      !("data" in (f as object))
+    ) {
+      return null;
+    }
+  }
+  return value as CachedFrame[];
+}
+
+/** The locally cached transcript, or null (no cache / caching off / corrupt). */
+export async function readCachedConversation(
+  agentPath: string,
+  sessionKey: string,
+): Promise<CachedFrame[] | null> {
+  const key = cacheKey(agentPath, sessionKey);
+  const b = activeBackend();
+  if (!key || !b) return null;
+  try {
+    const record = await b.get(key);
+    return record ? validFrames(record.frames) : null;
+  } catch (err) {
+    warnOnce("read", err);
+    return null;
+  }
+}
+
+/** Persist a transcript (full replace), then prune past the cap. */
+export async function writeCachedConversation(
+  agentPath: string,
+  sessionKey: string,
+  frames: readonly CachedFrame[],
+): Promise<void> {
+  const key = cacheKey(agentPath, sessionKey);
+  const b = activeBackend();
+  if (!key || !b || frames.length === 0) return;
+  try {
+    await b.set(key, {
+      frames: frames.map((f) => ({ feed_type: f.feed_type, data: f.data })),
+      updatedAt: Date.now(),
+    });
+    const keys = await b.keysOldestFirst();
+    if (keys.length > MAX_CACHED_CONVERSATIONS) {
+      const oldest = keys.slice(0, keys.length - MAX_CACHED_CONVERSATIONS);
+      for (const k of oldest) await b.delete(k);
+    }
+  } catch (err) {
+    warnOnce("write", err);
+  }
+}
+
+/** Drop one conversation's cached transcript (server says it's gone). */
+export async function deleteCachedConversation(
+  agentPath: string,
+  sessionKey: string,
+): Promise<void> {
+  const key = cacheKey(agentPath, sessionKey);
+  const b = activeBackend();
+  if (!key || !b) return;
+  try {
+    await b.delete(key);
+  } catch (err) {
+    warnOnce("delete", err);
+  }
+}
+
+/**
+ * Wipe every cached transcript — the sign-out hook, so nothing from this
+ * account lingers on a shared machine. Never throws.
+ */
+export async function clearConversationCache(): Promise<void> {
+  const b = activeBackend();
+  if (!b) return;
+  try {
+    await b.clear();
+  } catch (err) {
+    warnOnce("clear", err);
+  }
+}

--- a/packages/web/src/engine-adapter/index.ts
+++ b/packages/web/src/engine-adapter/index.ts
@@ -13,6 +13,9 @@ export {
   HoustonEngineError,
   isHoustonEngineError,
 } from "./client";
+// Local conversation cache (HOU-712): sign-out wipes the per-user cached
+// transcripts so nothing lingers on a shared machine.
+export { clearConversationCache } from "./conversation-cache";
 // Warming-engine send queue (HOU-693): show the message as sent while the
 // engine boots; the deferred real send suppresses its own bubble.
 export { pushPendingUserMessage } from "./turn-stream";

--- a/packages/web/src/engine-adapter/turn-stream.ts
+++ b/packages/web/src/engine-adapter/turn-stream.ts
@@ -3,6 +3,7 @@ import {
   type BoardStatus,
   conversationScope,
   type FeedFrame,
+  type FeedOutput,
   MultiplexFeedOutput,
   type PendingInteraction,
   StreamRegistry,
@@ -12,6 +13,7 @@ import {
   streamKey,
   type TurnWirePin,
 } from "@houston/sdk";
+import { writeCachedConversation } from "./conversation-cache";
 import { createBusFeedOutput } from "./feed-output";
 import { conversationStore, conversationVm } from "./vm";
 
@@ -31,10 +33,40 @@ export function disposeAllStreams(): void {
 }
 
 /**
- * Every stream folds into BOTH halves: the conversation VM (the app's one
- * turn-state source, read via `useSdkSnapshot`) and the legacy event bus
+ * Persist the VM's folded feed to the local conversation cache when a turn
+ * (or observed turn) settles, so the transcript a cold reopen paints includes
+ * everything sent THIS session — not just the state at the last history read
+ * (HOU-712). Frames were already folded by the VM (first in the multiplex);
+ * this just snapshots them. Cloud-only by construction: the cache no-ops
+ * without a gateway identity. Fire-and-forget — a cache write must never
+ * delay a settle.
+ */
+function cachePersistOutput(): FeedOutput {
+  return {
+    pushFeedItem() {},
+    sessionStatus() {},
+    async persistBoardStatus(agentPath, sessionKey, status) {
+      if (status === "running") return;
+      const snapshot = conversationStore.getSnapshot(
+        conversationScope(agentPath, sessionKey),
+      ) as { feed?: { feed_type: string; data: unknown }[] } | undefined;
+      const frames = snapshot?.feed;
+      if (!frames || frames.length === 0) return;
+      void writeCachedConversation(
+        agentPath,
+        sessionKey,
+        frames.map((f) => ({ feed_type: f.feed_type, data: f.data })),
+      );
+    },
+  };
+}
+
+/**
+ * Every stream folds into ALL halves: the conversation VM (the app's one
+ * turn-state source, read via `useSdkSnapshot`), the legacy event bus
  * (which still drives query invalidation and notifications — events, not
- * state).
+ * state), and the settle-time local-cache persist (order matters: the VM
+ * folds first so the cache snapshots a settled feed).
  */
 function composedOutput(
   setActivityStatus: (
@@ -47,6 +79,7 @@ function composedOutput(
     createBusFeedOutput((_a, _s, status, pendingInteraction) =>
       setActivityStatus(status, pendingInteraction),
     ),
+    cachePersistOutput(),
   ]);
 }
 
@@ -72,6 +105,21 @@ export function seedConversationVm(
   ) as { feed?: unknown[] } | undefined;
   if ((current?.feed?.length ?? 0) >= frames.length) return;
   conversationVm.seedHistory(agentPath, sessionKey, frames);
+}
+
+/**
+ * Empty a conversation's VM — the cache-seeded-then-404 cleanup (HOU-712): the
+ * server says the conversation is gone, so a transcript painted from the local
+ * cache must not linger. Guarded like a seed: a live turn or observer owns its
+ * VM (its feed IS the conversation — e.g. a first send racing the history read
+ * that 404s because no turn has persisted yet), so never wipe under it.
+ */
+export function clearConversationVm(
+  agentPath: string,
+  sessionKey: string,
+): void {
+  if (registry.get(streamKey(agentPath, sessionKey))) return;
+  conversationVm.seedHistory(agentPath, sessionKey, []);
 }
 
 /**

--- a/packages/web/tests/chat-history-cache.test.ts
+++ b/packages/web/tests/chat-history-cache.test.ts
@@ -1,0 +1,190 @@
+import { conversationScope } from "@houston/sdk";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { HoustonClient } from "../src/engine-adapter/client";
+import {
+  type CachedFrame,
+  type CacheRecord,
+  type ConversationCacheBackend,
+  setConversationCacheBackend,
+  setConversationCacheIdentity,
+} from "../src/engine-adapter/conversation-cache";
+import { conversationStore } from "../src/engine-adapter/vm";
+
+/**
+ * loadChatHistory × the local conversation cache (HOU-712): opening a cloud
+ * chat paints the VM from the cached transcript IMMEDIATELY — even while the
+ * gateway holds the history read for an engine-pod cold start — and every
+ * successful read refreshes the cache. A 404 (conversation gone) drops both
+ * the cache entry and the cache-seeded VM.
+ */
+
+function memoryBackend() {
+  const map = new Map<string, CacheRecord>();
+  const backend: ConversationCacheBackend = {
+    get: async (key) => map.get(key) ?? null,
+    set: async (key, record) => {
+      map.set(key, record);
+    },
+    delete: async (key) => {
+      map.delete(key);
+    },
+    keysOldestFirst: async () =>
+      [...map.entries()]
+        .sort(([, a], [, z]) => a.updatedAt - z.updatedAt)
+        .map(([key]) => key),
+    clear: async () => {
+      map.clear();
+    },
+  };
+  return { map, backend };
+}
+
+const GW = "https://gateway.example";
+
+function fakeJwt(sub: string): string {
+  const b64u = (o: object) =>
+    Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b64u({ alg: "none" })}.${b64u({ sub })}.sig`;
+}
+
+const CACHED: CachedFrame[] = [
+  { feed_type: "user_message", data: "cached question" },
+  { feed_type: "assistant_text", data: "cached answer" },
+];
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function vmFeed(agentPath: string, sessionKey: string): unknown[] {
+  const snap = conversationStore.getSnapshot(
+    conversationScope(agentPath, sessionKey),
+  ) as { feed?: { feed_type: string; data: unknown }[] } | undefined;
+  return (snap?.feed ?? []).map((f) => ({
+    feed_type: f.feed_type,
+    data: f.data,
+  }));
+}
+
+let store: ReturnType<typeof memoryBackend>;
+const originalFetch = globalThis.fetch;
+let convSeq = 0;
+
+beforeEach(() => {
+  store = memoryBackend();
+  setConversationCacheBackend(store.backend);
+});
+
+afterEach(() => {
+  setConversationCacheBackend(undefined);
+  setConversationCacheIdentity(() => null);
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+/** A cloud client; its constructor installs the cache identity for GW+sub. */
+function cloudClient(): HoustonClient {
+  return new HoustonClient({
+    baseUrl: GW,
+    token: fakeJwt("user-1"),
+    controlPlane: true,
+  });
+}
+
+async function seedCache(agentPath: string, sessionKey: string): Promise<void> {
+  await store.backend.set(
+    `${GW}|user-1|${encodeURIComponent(agentPath)}|${encodeURIComponent(sessionKey)}`,
+    { frames: CACHED, updatedAt: 1 },
+  );
+}
+
+test("a held history read paints the chat from the cache immediately", async () => {
+  const agentPath = "Ws/Agent";
+  const sessionKey = `held-${convSeq++}`;
+  const client = cloudClient();
+  await seedCache(agentPath, sessionKey);
+  // The gateway holds the read for a cold pod: the fetch never resolves.
+  globalThis.fetch = vi.fn(
+    () => new Promise<Response>(() => {}),
+  ) as unknown as typeof fetch;
+
+  const pending = client.loadChatHistory(agentPath, sessionKey);
+  await vi.waitFor(() => expect(vmFeed(agentPath, sessionKey)).toEqual(CACHED));
+  // The read is still held — nothing resolved, nothing threw.
+  let settled = false;
+  void pending.finally(() => {
+    settled = true;
+  });
+  await new Promise((r) => setTimeout(r, 20));
+  expect(settled).toBe(false);
+});
+
+test("a successful read refreshes the cache and reseeds the VM", async () => {
+  const agentPath = "Ws/Agent";
+  const sessionKey = `fresh-${convSeq++}`;
+  const client = cloudClient();
+  await seedCache(agentPath, sessionKey);
+  const messages = [
+    { role: "user", content: "cached question", ts: 1 },
+    { role: "assistant", content: "cached answer", ts: 2 },
+    { role: "user", content: "new question", ts: 3 },
+    { role: "assistant", content: "new answer", ts: 4 },
+  ];
+  globalThis.fetch = vi.fn(async (input: unknown) => {
+    const url = String(input);
+    if (url.includes("/messages")) {
+      return json(200, { id: sessionKey, title: "t", messages });
+    }
+    // The post-load observer stream: an empty body ends it immediately.
+    return new Response("", { status: 200 });
+  }) as unknown as typeof fetch;
+
+  const feed = await client.loadChatHistory(agentPath, sessionKey, {
+    observe: false,
+  });
+  expect(feed.map((f) => f.data)).toEqual([
+    "cached question",
+    "cached answer",
+    "new question",
+    "new answer",
+  ]);
+  await vi.waitFor(async () => {
+    const key = `${GW}|user-1|${encodeURIComponent(agentPath)}|${encodeURIComponent(sessionKey)}`;
+    const record = await store.backend.get(key);
+    expect(record?.frames.length).toBe(4);
+  });
+});
+
+test("a 404 drops the cache entry and clears the cache-seeded VM", async () => {
+  const agentPath = "Ws/Agent";
+  const sessionKey = `gone-${convSeq++}`;
+  const client = cloudClient();
+  await seedCache(agentPath, sessionKey);
+  globalThis.fetch = vi.fn(async () =>
+    json(404, { error: "not found" }),
+  ) as unknown as typeof fetch;
+
+  const feed = await client.loadChatHistory(agentPath, sessionKey);
+  expect(feed).toEqual([]);
+  expect(vmFeed(agentPath, sessionKey)).toEqual([]);
+  await vi.waitFor(async () => {
+    expect(await store.backend.keysOldestFirst()).toEqual([]);
+  });
+});
+
+test("a real failure still surfaces (cache-first never swallows the error)", async () => {
+  const agentPath = "Ws/Agent";
+  const sessionKey = `boom-${convSeq++}`;
+  const client = cloudClient();
+  await seedCache(agentPath, sessionKey);
+  globalThis.fetch = vi.fn(async () =>
+    json(500, { error: "pod exploded" }),
+  ) as unknown as typeof fetch;
+
+  await expect(client.loadChatHistory(agentPath, sessionKey)).rejects.toThrow();
+  // The cached paint survives the failure — the user keeps their transcript.
+  expect(vmFeed(agentPath, sessionKey)).toEqual(CACHED);
+});

--- a/packages/web/tests/conversation-cache.test.ts
+++ b/packages/web/tests/conversation-cache.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import {
+  type CachedFrame,
+  type CacheRecord,
+  type ConversationCacheBackend,
+  clearConversationCache,
+  conversationCacheScope,
+  deleteCachedConversation,
+  jwtSub,
+  MAX_CACHED_CONVERSATIONS,
+  readCachedConversation,
+  setConversationCacheBackend,
+  setConversationCacheIdentity,
+  writeCachedConversation,
+} from "../src/engine-adapter/conversation-cache";
+
+/**
+ * The local conversation cache (HOU-712): per-gateway+user scoping, round
+ * trips, corruption tolerance, prune, and the never-throws guarantee — the
+ * cache is an accelerator, so any storage failure must degrade to "no cache",
+ * never break the chat.
+ */
+
+function memoryBackend(): ConversationCacheBackend & {
+  map: Map<string, CacheRecord>;
+} {
+  const map = new Map<string, CacheRecord>();
+  return {
+    map,
+    get: async (key) => map.get(key) ?? null,
+    set: async (key, record) => {
+      map.set(key, record);
+    },
+    delete: async (key) => {
+      map.delete(key);
+    },
+    keysOldestFirst: async () =>
+      [...map.entries()]
+        .sort(([, a], [, z]) => a.updatedAt - z.updatedAt)
+        .map(([key]) => key),
+    clear: async () => {
+      map.clear();
+    },
+  };
+}
+
+const FRAMES: CachedFrame[] = [
+  { feed_type: "user_message", data: "hi" },
+  { feed_type: "assistant_text", data: "hello!" },
+];
+
+let backend: ReturnType<typeof memoryBackend>;
+
+beforeEach(() => {
+  backend = memoryBackend();
+  setConversationCacheBackend(backend);
+  setConversationCacheIdentity(() => "https://gw|user-1");
+});
+
+afterEach(() => {
+  setConversationCacheBackend(undefined);
+  setConversationCacheIdentity(() => null);
+  vi.useRealTimers();
+});
+
+function fakeJwt(payload: object): string {
+  const b64u = (o: object) =>
+    Buffer.from(JSON.stringify(o)).toString("base64url");
+  return `${b64u({ alg: "none" })}.${b64u(payload)}.sig`;
+}
+
+test("jwtSub extracts the sub claim, null for anything unreadable", () => {
+  expect(jwtSub(fakeJwt({ sub: "user-42" }))).toBe("user-42");
+  expect(jwtSub(fakeJwt({ role: "authenticated" }))).toBeNull();
+  expect(jwtSub("not-a-jwt")).toBeNull();
+  expect(jwtSub("")).toBeNull();
+  expect(jwtSub("a.%%%.c")).toBeNull();
+});
+
+test("conversationCacheScope keys per gateway + user, null without a user", () => {
+  expect(
+    conversationCacheScope("https://gw", fakeJwt({ sub: "user-42" })),
+  ).toBe("https://gw|user-42");
+  expect(conversationCacheScope("https://gw", "static-token")).toBeNull();
+});
+
+test("write/read round trip", async () => {
+  await writeCachedConversation("Ws/Agent", "sess-1", FRAMES);
+  expect(await readCachedConversation("Ws/Agent", "sess-1")).toEqual(FRAMES);
+  expect(await readCachedConversation("Ws/Agent", "other")).toBeNull();
+});
+
+test("no identity (local engine / static token) disables the cache", async () => {
+  setConversationCacheIdentity(() => null);
+  await writeCachedConversation("Ws/Agent", "sess-1", FRAMES);
+  expect(backend.map.size).toBe(0);
+  expect(await readCachedConversation("Ws/Agent", "sess-1")).toBeNull();
+});
+
+test("transcripts never leak across users", async () => {
+  await writeCachedConversation("Ws/Agent", "sess-1", FRAMES);
+  setConversationCacheIdentity(() => "https://gw|user-2");
+  expect(await readCachedConversation("Ws/Agent", "sess-1")).toBeNull();
+});
+
+test("a corrupt record reads as no cache", async () => {
+  await writeCachedConversation("Ws/Agent", "sess-1", FRAMES);
+  const key = [...backend.map.keys()][0];
+  backend.map.set(key, {
+    frames: [{ nope: true }] as unknown as CachedFrame[],
+    updatedAt: 1,
+  });
+  expect(await readCachedConversation("Ws/Agent", "sess-1")).toBeNull();
+});
+
+test("empty frame lists are not persisted", async () => {
+  await writeCachedConversation("Ws/Agent", "sess-1", []);
+  expect(backend.map.size).toBe(0);
+});
+
+test("delete drops one conversation, clear drops everything", async () => {
+  await writeCachedConversation("Ws/Agent", "sess-1", FRAMES);
+  await writeCachedConversation("Ws/Agent", "sess-2", FRAMES);
+  await deleteCachedConversation("Ws/Agent", "sess-1");
+  expect(await readCachedConversation("Ws/Agent", "sess-1")).toBeNull();
+  expect(await readCachedConversation("Ws/Agent", "sess-2")).toEqual(FRAMES);
+  await clearConversationCache();
+  expect(backend.map.size).toBe(0);
+});
+
+test("prune evicts the oldest transcripts past the cap", async () => {
+  vi.useFakeTimers();
+  vi.setSystemTime(1_000);
+  for (let i = 0; i < MAX_CACHED_CONVERSATIONS + 3; i++) {
+    vi.setSystemTime(1_000 + i);
+    await writeCachedConversation("Ws/Agent", `sess-${i}`, FRAMES);
+  }
+  expect(backend.map.size).toBe(MAX_CACHED_CONVERSATIONS);
+  expect(await readCachedConversation("Ws/Agent", "sess-0")).toBeNull();
+  expect(await readCachedConversation("Ws/Agent", "sess-2")).toBeNull();
+  expect(await readCachedConversation("Ws/Agent", "sess-3")).toEqual(FRAMES);
+});
+
+test("a broken backend degrades to no cache instead of throwing", async () => {
+  const boom = async () => {
+    throw new Error("storage exploded");
+  };
+  setConversationCacheBackend({
+    get: boom,
+    set: boom,
+    delete: boom,
+    keysOldestFirst: boom,
+    clear: boom,
+  });
+  const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  await expect(
+    writeCachedConversation("Ws/Agent", "sess-1", FRAMES),
+  ).resolves.toBeUndefined();
+  expect(await readCachedConversation("Ws/Agent", "sess-1")).toBeNull();
+  await expect(
+    deleteCachedConversation("Ws/Agent", "s"),
+  ).resolves.toBeUndefined();
+  await expect(clearConversationCache()).resolves.toBeUndefined();
+  warn.mockRestore();
+});

--- a/ui/engine-client/src/vm.ts
+++ b/ui/engine-client/src/vm.ts
@@ -31,3 +31,10 @@ export function pushPendingUserMessage(
   _sessionKey: string,
   _text: string,
 ): void {}
+
+/**
+ * Local conversation cache (HOU-712) — inert here for the same reason: the
+ * aliased adapter's implementation wipes the per-user cached transcripts on
+ * sign-out. This package's client never caches, so there is nothing to clear.
+ */
+export async function clearConversationCache(): Promise<void> {}


### PR DESCRIPTION
## Summary

Fixes HOU-712.

On desktop + hosted cloud, opening a chat sometimes showed **no messages** until the user clicked around chats/agents and waited. Root cause: the transcript renders from the in-memory conversation VM, which is seeded only by `GET /agents/:id/conversations/:id/messages` — and the gateway **holds that read for the whole engine-pod cold start** (up to minutes, then 503). Nothing was persisted client-side, so a cold pod meant a blank conversation (PR #623 made the eventual failure loud, but the wait was still blank).

## The fix — a local transcript cache, cache-first paint

- **New `conversation-cache` module** (`packages/web/src/engine-adapter/`): persists each cloud conversation's folded feed frames in IndexedDB (`houston-conversation-cache`), behind an injectable backend (in-memory in tests).
- **`loadChatHistory` seeds the VM from the cache immediately**, then the network read revalidates whenever it lands. The existing `seedConversationVm` guards keep a live or richer VM untouched, so a stale cache can never clobber fresh state. Error semantics are unchanged: a real failure still rejects into the toast + retry-on-reselect path — but the user now keeps the cached transcript on screen instead of a blank chat.
- **Write-through:** every successful history read refreshes the cache, and every turn settle snapshots the VM feed (via a third `FeedOutput` in the stream multiplex), so a restart during a cold pod still paints everything sent last session.
- **Scoping & hygiene:** entries are keyed per gateway + Supabase user (`sub` claim) so transcripts never leak across accounts; no user identity → caching disabled. Capped at 256 conversations (oldest evicted; keys-only prune via an `updatedAt` index — no transcript loads). Sign-out wipes the store. A server 404 drops the entry and clears a cache-seeded VM (registry-guarded so a live turn's feed is never wiped).
- **Local desktop/self-host unaffected:** without a control plane the cache identity resolves null and every operation no-ops (local reads are local disk, never held).
- Cache failures are deliberately best-effort: any storage error logs once and degrades to exactly today's behavior.

## Tests

- `packages/web/tests/conversation-cache.test.ts` — scoping, round trip, per-user isolation, corruption tolerance, prune, never-throws.
- `packages/web/tests/chat-history-cache.test.ts` — through `HoustonClient.loadChatHistory`: a held read paints from cache immediately; a successful read refreshes cache + VM; a 404 drops cache + clears the seeded VM; a real failure still surfaces while the cached paint survives.
- Gates: `pnpm --filter houston-web test` (104 passed), `pnpm typecheck` (workspace), `pnpm check`, `pnpm check:boundaries`.

## Repro (before the fix)

1. Sign in to hosted cloud on desktop, chat with an agent, quit the app.
2. Wait for the agent's engine pod to scale down/recycle (or force it).
3. Reopen the app and open that conversation.
4. The chat is blank (spinner/empty) for the whole pod warm-up; clicking other chats/agents and coming back eventually shows messages once the pod answers.

## Verify (after the fix)

1. Same steps: sign in, chat, quit, let the pod go cold.
2. Reopen the app and open the conversation.
3. The transcript appears **immediately** (from the local cache), including messages from the previous session; once the pod wakes, the view silently refreshes with the authoritative history.
4. Sign out → the IndexedDB store `houston-conversation-cache` is emptied (check via web inspector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)