### PR TITLE
feat(routines): guided routine creation in chat (HOU-714)

### DIFF
--- a/app/src/components/board/use-mission-control-archived.ts
+++ b/app/src/components/board/use-mission-control-archived.ts
@@ -6,6 +6,7 @@ import { useTranslation } from "react-i18next";
 import { useAllConversations } from "../../hooks/queries";
 import { useConversationFeed } from "../../hooks/use-conversation-vm";
 import { missionCardTags } from "../../lib/mission-card";
+import { isRoutineSetupMode } from "../../lib/routine-chat-setup";
 import {
   type HistoryLoadOptions,
   tauriActivity,
@@ -54,7 +55,12 @@ export function useMissionControlArchived(agents: Agent[]) {
       { agentPath: string; activityId: string }
     > = {};
     const result = convos
-      .filter((c) => c.type === "activity" && c.status === "archived")
+      .filter(
+        (c) =>
+          c.type === "activity" &&
+          c.status === "archived" &&
+          !isRoutineSetupMode(c.agent),
+      )
       .map((c) => {
         const agent = agentMap[c.agent_path];
         const agentModes = agent

--- a/app/src/components/command-palette.tsx
+++ b/app/src/components/command-palette.tsx
@@ -16,6 +16,7 @@ import { useTranslation } from "react-i18next";
 import { DEFAULT_TAB_ID } from "../agents/standard-tabs";
 import { useAllConversations } from "../hooks/queries";
 import { orderAgents } from "../lib/agent-order";
+import { isRoutineSetupMode } from "../lib/routine-chat-setup";
 import { shortcutLabel } from "../lib/shortcuts";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
@@ -62,7 +63,12 @@ export function CommandPalette() {
       convos
         // Archived missions live in the per-agent Archived tab, not the
         // quick-switcher's recent list.
-        .filter((c) => c.type === "activity" && c.status !== "archived")
+        .filter(
+          (c) =>
+            c.type === "activity" &&
+            c.status !== "archived" &&
+            !isRoutineSetupMode(c.agent),
+        )
         .slice()
         .sort((a, b) => (b.updated_at ?? "").localeCompare(a.updated_at ?? ""))
         .slice(0, RECENT_MISSION_LIMIT)

--- a/app/src/components/shell/agent-activity-summary-model.ts
+++ b/app/src/components/shell/agent-activity-summary-model.ts
@@ -1,3 +1,5 @@
+import { isRoutineSetupMode } from "../../lib/routine-chat-setup.ts";
+
 export interface AgentActivitySummaryInput {
   id: string;
   folderPath: string;
@@ -7,6 +9,8 @@ export interface ActivityConversationSummaryInput {
   agent_path: string;
   type: "primary" | "activity";
   status?: string | null;
+  /** Agent-mode id; routine-setup chats never count toward badges. */
+  agent?: string | null;
 }
 
 export interface AgentActivitySummary {
@@ -28,6 +32,7 @@ export function buildAgentActivitySummaries(
 
   for (const conversation of conversations) {
     if (conversation.type !== "activity") continue;
+    if (isRoutineSetupMode(conversation.agent)) continue;
 
     const agentId = agentIdByPath.get(conversation.agent_path);
     if (!agentId) continue;

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -29,6 +29,7 @@ import { useKeyboardShortcuts } from "../../hooks/use-keyboard-shortcuts";
 import { analytics } from "../../lib/analytics";
 import { osIsTauri } from "../../lib/os-bridge";
 import { isMac } from "../../lib/platform";
+import { isRoutineSetupMode } from "../../lib/routine-chat-setup";
 import { shortcutLabel } from "../../lib/shortcuts";
 import { isTopLevelView } from "../../lib/top-level-views";
 import { useAgentCatalogStore } from "../../stores/agent-catalog";
@@ -104,7 +105,7 @@ export function WorkspaceShell({
   const agentDef = currentAgent ? getById(currentAgent.configId) : undefined;
   const { data: activities } = useActivity(currentAgent?.folderPath);
   const needsYouCount = (activities ?? []).filter(
-    (a) => a.status === "needs_you",
+    (a) => a.status === "needs_you" && !isRoutineSetupMode(a.agent),
   ).length;
   const isAgentView = !isTopLevelView(viewMode);
   // Resolve against the CALLER-visible tab set, not the raw standard ids:

--- a/app/src/components/tabs/routine-create-choice-dialog.tsx
+++ b/app/src/components/tabs/routine-create-choice-dialog.tsx
@@ -1,0 +1,61 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@houston-ai/core";
+import { useTranslation } from "react-i18next";
+import { SkillCard } from "../skill-card";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** "Create it in chat" — may take a moment (starts a mission). */
+  onChat: () => void;
+  /** "Fill in the details myself" — opens the routine form. */
+  onForm: () => void;
+  /** Disables both options while the chat mission is starting. */
+  busy?: boolean;
+}
+
+/**
+ * The New-routine chooser: guided setup in chat, or the classic form.
+ * Reuses the SkillCard option-card treatment from the New Mission picker.
+ */
+export function RoutineCreateChoiceDialog({
+  open,
+  onOpenChange,
+  onChat,
+  onForm,
+  busy,
+}: Props) {
+  const { t } = useTranslation("routines");
+  return (
+    <Dialog open={open} onOpenChange={(next) => !busy && onOpenChange(next)}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t("createChoice.title")}</DialogTitle>
+          <DialogDescription>{t("createChoice.description")}</DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-2">
+          <SkillCard
+            image="speech-balloon"
+            title={t("createChoice.chatTitle")}
+            description={t("createChoice.chatDescription")}
+            onClick={onChat}
+            disabled={busy}
+            busy={busy}
+          />
+          <SkillCard
+            image="memo"
+            title={t("createChoice.formTitle")}
+            description={t("createChoice.formDescription")}
+            onClick={onForm}
+            disabled={busy}
+          />
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/tabs/routine-setup-chat.tsx
+++ b/app/src/components/tabs/routine-setup-chat.tsx
@@ -13,6 +13,7 @@ import type { TabProps } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
 import { useAgentBoardSend } from "../board/use-agent-board-send";
+import { useBoardLabels } from "../board/use-board-labels";
 import { useBoardSendQueue } from "../board/use-board-send-queue";
 import { AgentPanelAvatar } from "../shell/agent-panel-avatar";
 import { useDetailPanelContainer } from "../shell/detail-panel-context";
@@ -40,7 +41,9 @@ export function RoutineSetupChat({ agent, agentDef, showBanner }: Props) {
   const path = agent.folderPath;
   const panelContainer = useDetailPanelContainer();
   const queuedLabels = useQueuedMessageLabels();
+  const { composerLabels } = useBoardLabels();
   const attachmentValidation = useAttachmentRejectionDialog();
+  const addToast = useUIStore((s) => s.addToast);
   const viewMode = useUIStore((s) => s.viewMode);
   const openAgentId = useUIStore((s) => s.routineSetupChatAgentId);
   const setOpenAgentId = useUIStore((s) => s.setRoutineSetupChatAgentId);
@@ -203,6 +206,12 @@ export function RoutineSetupChat({ agent, agentDef, showBanner }: Props) {
           onStopSession={send.stopSession}
           onPanelOpenChange={setMissionPanelOpen}
           onOpenLink={(url) => openAgentHref(url, path)}
+          onNotice={(message) => addToast({ title: message })}
+          // The ask_user question card that replaces the composer when the
+          // turn settles needs_you — the interview IS this card, so dropping
+          // it turns the guided setup into a dead chat.
+          composerOverride={panel.composerOverride}
+          composerLabels={composerLabels}
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           thinkingIndicator={panel.thinkingIndicator}

--- a/app/src/components/tabs/routine-setup-chat.tsx
+++ b/app/src/components/tabs/routine-setup-chat.tsx
@@ -1,0 +1,231 @@
+import type { KanbanItem } from "@houston-ai/board";
+import { AIBoard } from "@houston-ai/board";
+import type { FeedItem } from "@houston-ai/chat";
+import { Button } from "@houston-ai/core";
+import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { useUpdateActivity } from "../../hooks/queries";
+import { useConversationFeed } from "../../hooks/use-conversation-vm";
+import { openAgentHref } from "../../lib/open-href";
+import { type HistoryLoadOptions, tauriChat } from "../../lib/tauri";
+import type { TabProps } from "../../lib/types";
+import { useUIStore } from "../../stores/ui";
+import { useAttachmentRejectionDialog } from "../attachment-rejection-dialog";
+import { useAgentBoardSend } from "../board/use-agent-board-send";
+import { useBoardSendQueue } from "../board/use-board-send-queue";
+import { AgentPanelAvatar } from "../shell/agent-panel-avatar";
+import { useDetailPanelContainer } from "../shell/detail-panel-context";
+import { useAgentChatPanel } from "../use-agent-chat-panel";
+import { useQueuedMessageLabels } from "../use-queued-message-labels";
+import { useRoutineChatSetup } from "./use-routine-chat-setup";
+
+const noop = () => {};
+
+interface Props extends TabProps {
+  /** Render the "continue setting up" banner (grid view only). */
+  showBanner: boolean;
+}
+
+/**
+ * The routine-setup chat's only home. The guided chat is a real mission
+ * under the hood, but every board filters it out — so this component mounts
+ * its own AIBoard whose list stays hidden while the detail panel portals
+ * into the shared right-side container (the Archived tab does the same).
+ * A finished chat cleans itself up: once the interview settles "done" and
+ * the panel is closed, the activity is archived and disappears for good.
+ */
+export function RoutineSetupChat({ agent, agentDef, showBanner }: Props) {
+  const { t } = useTranslation("routines");
+  const path = agent.folderPath;
+  const panelContainer = useDetailPanelContainer();
+  const queuedLabels = useQueuedMessageLabels();
+  const attachmentValidation = useAttachmentRejectionDialog();
+  const viewMode = useUIStore((s) => s.viewMode);
+  const openAgentId = useUIStore((s) => s.routineSetupChatAgentId);
+  const setOpenAgentId = useUIStore((s) => s.setRoutineSetupChatAgentId);
+  const setMissionPanelOpen = useUIStore((s) => s.setMissionPanelOpen);
+  const updateActivity = useUpdateActivity(path);
+  const { setupActivity: activity, start } = useRoutineChatSetup(agent);
+
+  // The flag is agent-scoped, so switching agents shows the other agent's
+  // Routines tab closed without clobbering a pending cross-agent nav.
+  const open = openAgentId === agent.id;
+  const setOpen = useCallback(
+    (next: boolean) => setOpenAgentId(next ? agent.id : null),
+    [setOpenAgentId, agent.id],
+  );
+
+  // All tabs stay mounted and every AIBoard portals its panel into the SAME
+  // shared container: drop our panel whenever the Routines tab isn't active.
+  useEffect(() => {
+    if (viewMode !== "routines" && open) setOpen(false);
+  }, [viewMode, open, setOpen]);
+
+  // Self-cleanup: a setup chat that settled "done" with its panel closed is
+  // finished — archive it (archived setup chats render nowhere).
+  const archivedIdsRef = useRef(new Set<string>());
+  useEffect(() => {
+    if (!activity || open || activity.status !== "done") return;
+    if (archivedIdsRef.current.has(activity.id)) return;
+    archivedIdsRef.current.add(activity.id);
+    updateActivity.mutate({
+      activityId: activity.id,
+      update: { status: "archived" },
+    });
+  }, [activity, open, updateActivity.mutate]);
+
+  const sessionKey = activity
+    ? (activity.session_key ?? `activity-${activity.id}`)
+    : null;
+  const selectedId = open && activity ? activity.id : null;
+  const selectedSessionKey = selectedId ? sessionKey : null;
+
+  const handleSelect = useCallback(
+    (id: string | null) => {
+      if (!id) setOpen(false);
+    },
+    [setOpen],
+  );
+
+  const panel = useAgentChatPanel({
+    agent,
+    agentDef,
+    selectedSessionKey,
+    onSelectSession: handleSelect,
+  });
+  const overrides = useMemo(
+    () => ({
+      providerOverride: panel.effectiveProvider,
+      modelOverride: panel.effectiveModel,
+      modeOverride: panel.turnMode,
+    }),
+    [panel.effectiveProvider, panel.effectiveModel, panel.turnMode],
+  );
+
+  const rawItems = useMemo(() => (activity ? [activity] : []), [activity]);
+  const send = useAgentBoardSend({
+    agent,
+    agentDef,
+    rawItems,
+    pendingAgentMode: null,
+    setPendingAgentMode: noop,
+  });
+  const sendQueue = useBoardSendQueue({
+    selectedSessionKey,
+    selectedAgentPath: path,
+    overrides,
+    sendMessageNow: send.sendMessageNow,
+  });
+
+  const activeFeed = useConversationFeed(path, selectedSessionKey);
+  const feedItems = useMemo<Record<string, FeedItem[]>>(
+    () => (selectedSessionKey ? { [selectedSessionKey]: activeFeed } : {}),
+    [selectedSessionKey, activeFeed],
+  );
+  const loadHistory = useCallback(
+    async (key: string, opts?: HistoryLoadOptions) =>
+      (await tauriChat.loadHistory(path, key, opts)) as FeedItem[],
+    [path],
+  );
+
+  const items: KanbanItem[] = useMemo(
+    () =>
+      activity
+        ? [
+            {
+              id: activity.id,
+              title: activity.title,
+              description: "",
+              status: activity.status,
+              updatedAt: activity.updated_at ?? new Date().toISOString(),
+              group: agent.name,
+              metadata: sessionKey ? { sessionKey } : {},
+            },
+          ]
+        : [],
+    [activity, agent.name, sessionKey],
+  );
+
+  const discard = useCallback(() => {
+    if (!activity) return;
+    updateActivity.mutate({
+      activityId: activity.id,
+      update: { status: "archived" },
+    });
+  }, [activity, updateActivity]);
+
+  if (!activity) return null;
+  const running = activity.status === "running";
+
+  return (
+    <>
+      {showBanner && !open && (
+        <div className="mx-6 mt-4 flex items-center gap-3 rounded-2xl bg-secondary px-4 py-3">
+          <div className="min-w-0 flex-1">
+            <p className="text-sm font-medium text-foreground">
+              {t("setupChat.bannerTitle")}
+            </p>
+            <p className="text-xs text-foreground/70">
+              {t("setupChat.bannerDescription")}
+            </p>
+          </div>
+          <Button variant="ghost" onClick={discard}>
+            {t("setupChat.discard")}
+          </Button>
+          <Button onClick={() => void start()}>
+            {t("setupChat.continue")}
+          </Button>
+        </div>
+      )}
+      {/* The list never shows; only the portaled detail panel is visible. */}
+      <div className="hidden">
+        <AIBoard
+          layout="list"
+          items={items}
+          selectedId={selectedId}
+          onSelect={handleSelect}
+          panelContainer={panelContainer}
+          feedItems={feedItems}
+          isLoading={send.effectiveLoading}
+          sessionKeyFor={() => sessionKey ?? ""}
+          onSendMessage={sendQueue.handleSendMessage}
+          onComposerSubmit={panel.onComposerSubmit}
+          queuedMessages={sendQueue.queuedMessages}
+          onRemoveQueuedMessage={sendQueue.onRemoveQueuedMessage}
+          queuedLabels={queuedLabels}
+          onLoadHistory={loadHistory}
+          onStopSession={send.stopSession}
+          onPanelOpenChange={setMissionPanelOpen}
+          onOpenLink={(url) => openAgentHref(url, path)}
+          prepareAttachments={attachmentValidation.prepareAttachments}
+          onAttachmentRejections={attachmentValidation.onAttachmentRejections}
+          thinkingIndicator={panel.thinkingIndicator}
+          loadingIndicator={panel.loadingIndicator}
+          panelAgentName={agent.name}
+          panelAvatar={
+            <AgentPanelAvatar color={agent.color} running={running} />
+          }
+          chatEmptyState={panel.chatEmptyState}
+          composerHeader={panel.composerHeader}
+          canSendEmpty={panel.canSendEmpty}
+          footer={panel.footer}
+          attachMenu={panel.attachMenu}
+          renderUserMessage={panel.renderUserMessage}
+          renderLink={panel.renderLink}
+          currentUserId={panel.currentUserId}
+          authorLabels={panel.authorLabels}
+          renderSystemMessage={panel.renderSystemMessage}
+          mapFeedItems={panel.mapFeedItems}
+          afterMessages={panel.afterMessages}
+          isSpecialTool={panel.isSpecialTool}
+          renderToolResult={panel.renderToolResult}
+          processLabels={panel.processLabels}
+          getThinkingMessage={panel.getThinkingMessage}
+          renderTurnSummary={panel.renderTurnSummary}
+        />
+      </div>
+      {panel.pickerDialog}
+      {attachmentValidation.dialog}
+    </>
+  );
+}

--- a/app/src/components/tabs/routine-setup-chat.tsx
+++ b/app/src/components/tabs/routine-setup-chat.tsx
@@ -2,10 +2,11 @@ import type { KanbanItem } from "@houston-ai/board";
 import { AIBoard } from "@houston-ai/board";
 import type { FeedItem } from "@houston-ai/chat";
 import { Button } from "@houston-ai/core";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { useUpdateActivity } from "../../hooks/queries";
 import { useConversationFeed } from "../../hooks/use-conversation-vm";
+import { logger } from "../../lib/logger";
 import { openAgentHref } from "../../lib/open-href";
 import { type HistoryLoadOptions, tauriChat } from "../../lib/tauri";
 import type { TabProps } from "../../lib/types";
@@ -62,17 +63,22 @@ export function RoutineSetupChat({ agent, agentDef, showBanner }: Props) {
   }, [viewMode, open, setOpen]);
 
   // Self-cleanup: a setup chat that settled "done" with its panel closed is
-  // finished — archive it (archived setup chats render nowhere).
-  const archivedIdsRef = useRef(new Set<string>());
+  // finished — archive it (archived setup chats render nowhere). No once-only
+  // guard: the settle's own status write can race this archive and resurrect
+  // "done" (client-side read-modify-write), so the effect must be free to
+  // re-fire on the next refetch until the archive sticks. `isPending` keeps
+  // it to one write at a time; the archive itself is idempotent.
   useEffect(() => {
     if (!activity || open || activity.status !== "done") return;
-    if (archivedIdsRef.current.has(activity.id)) return;
-    archivedIdsRef.current.add(activity.id);
-    updateActivity.mutate({
-      activityId: activity.id,
-      update: { status: "archived" },
-    });
-  }, [activity, open, updateActivity.mutate]);
+    if (updateActivity.isPending) return;
+    updateActivity.mutate(
+      { activityId: activity.id, update: { status: "archived" } },
+      {
+        onError: (err) =>
+          logger.error(`[routine-setup] auto-archive failed: ${err}`),
+      },
+    );
+  }, [activity, open, updateActivity.isPending, updateActivity.mutate]);
 
   const sessionKey = activity
     ? (activity.session_key ?? `activity-${activity.id}`)

--- a/app/src/components/tabs/routines-tab.tsx
+++ b/app/src/components/tabs/routines-tab.tsx
@@ -19,6 +19,7 @@ import type { TabProps } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 import { RoutineCreateChoiceDialog } from "./routine-create-choice-dialog";
 import { RoutineModelControls } from "./routine-model-controls";
+import { RoutineSetupChat } from "./routine-setup-chat";
 import {
   EMPTY_FORM,
   formMatchesRoutine,
@@ -29,7 +30,7 @@ import {
 } from "./routines-tab-model";
 import { useRoutineChatSetup } from "./use-routine-chat-setup";
 
-export default function RoutinesTab({ agent }: TabProps) {
+export default function RoutinesTab({ agent, agentDef }: TabProps) {
   const { t } = useTranslation("routines");
   const labels = useRoutineLabels();
   const path = agent.folderPath;
@@ -205,46 +206,55 @@ export default function RoutinesTab({ agent }: TabProps) {
       ? (allRuns ?? []).filter((r) => r.routine_id === view.editId)
       : [];
 
+    // data-keep-panel-open: interacting with routines content must not
+    // dismiss the setup-chat panel via AIBoard's outside-click close.
     return (
-      <RoutineEditor
-        value={form}
-        onChange={handleFormChange}
-        onBack={() => setView({ type: "grid" })}
-        onSubmit={handleSubmit}
-        routine={editing}
-        runs={editingRuns}
-        onRunNow={editing ? () => handleRunNow(editing.id) : undefined}
-        runNowPending={runNow.isPending}
-        onCancelRun={
-          editing
-            ? (runId: string) => handleCancelRun(editing.id, runId)
-            : undefined
-        }
-        onToggle={
-          editing ? (enabled) => handleToggle(editing.id, enabled) : undefined
-        }
-        onDelete={editing ? () => handleDelete(editing.id) : undefined}
-        accountTimezone={tz.timezone}
-        hasChanges={!formMatchesRoutine(form, baseline)}
-        modelPicker={
-          <RoutineModelControls
-            agent={agent}
-            agentPath={path}
-            form={form}
-            onChange={handleFormChange}
-          />
-        }
-        labels={labels.editor}
-        scheduleLabels={labels.schedule}
-        nextFireLabels={labels.nextFire}
-        runHistoryLabels={labels.runHistory}
-        locale={labels.locale}
-      />
+      <div className="contents" data-keep-panel-open>
+        <RoutineSetupChat
+          agent={agent}
+          agentDef={agentDef}
+          showBanner={false}
+        />
+        <RoutineEditor
+          value={form}
+          onChange={handleFormChange}
+          onBack={() => setView({ type: "grid" })}
+          onSubmit={handleSubmit}
+          routine={editing}
+          runs={editingRuns}
+          onRunNow={editing ? () => handleRunNow(editing.id) : undefined}
+          runNowPending={runNow.isPending}
+          onCancelRun={
+            editing
+              ? (runId: string) => handleCancelRun(editing.id, runId)
+              : undefined
+          }
+          onToggle={
+            editing ? (enabled) => handleToggle(editing.id, enabled) : undefined
+          }
+          onDelete={editing ? () => handleDelete(editing.id) : undefined}
+          accountTimezone={tz.timezone}
+          hasChanges={!formMatchesRoutine(form, baseline)}
+          modelPicker={
+            <RoutineModelControls
+              agent={agent}
+              agentPath={path}
+              form={form}
+              onChange={handleFormChange}
+            />
+          }
+          labels={labels.editor}
+          scheduleLabels={labels.schedule}
+          nextFireLabels={labels.nextFire}
+          runHistoryLabels={labels.runHistory}
+          locale={labels.locale}
+        />
+      </div>
     );
   }
 
   return (
-    <>
+    <div className="contents" data-keep-panel-open>
       <RoutineCreateChoiceDialog
         open={choiceOpen}
         onOpenChange={setChoiceOpen}
@@ -252,6 +262,7 @@ export default function RoutinesTab({ agent }: TabProps) {
         onForm={handleCreateWithForm}
         busy={chatSetup.pending}
       />
+      <RoutineSetupChat agent={agent} agentDef={agentDef} showBanner />
       <RoutinesGrid
         routines={routines ?? []}
         lastRuns={lastRuns}
@@ -267,6 +278,6 @@ export default function RoutinesTab({ agent }: TabProps) {
         nextFireLabels={labels.nextFire}
         locale={labels.locale}
       />
-    </>
+    </div>
   );
 }

--- a/app/src/components/tabs/routines-tab.tsx
+++ b/app/src/components/tabs/routines-tab.tsx
@@ -17,6 +17,7 @@ import { analytics } from "../../lib/analytics";
 import { genericErrorDescription } from "../../lib/error-toast";
 import type { TabProps } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
+import { RoutineCreateChoiceDialog } from "./routine-create-choice-dialog";
 import { RoutineModelControls } from "./routine-model-controls";
 import {
   EMPTY_FORM,
@@ -26,6 +27,7 @@ import {
   routineToFormData,
   type View,
 } from "./routines-tab-model";
+import { useRoutineChatSetup } from "./use-routine-chat-setup";
 
 export default function RoutinesTab({ agent }: TabProps) {
   const { t } = useTranslation("routines");
@@ -43,6 +45,8 @@ export default function RoutinesTab({ agent }: TabProps) {
   const cancelRun = useCancelRoutineRun(path);
 
   const [view, setView] = useState<View>(() => freshRoutinesState().view);
+  const [choiceOpen, setChoiceOpen] = useState(false);
+  const chatSetup = useRoutineChatSetup(agent);
   const [form, setForm] = useState<RoutineFormData>(
     () => freshRoutinesState().form,
   );
@@ -65,16 +69,27 @@ export default function RoutinesTab({ agent }: TabProps) {
     setView(fresh.view);
     setForm(fresh.form);
     setBaseline(fresh.baseline);
+    setChoiceOpen(false);
   }
 
   // Most recent run per routine, for the grid's "last run" badges.
   const lastRuns = useMemo(() => latestRunByRoutine(allRuns), [allRuns]);
 
-  const handleCreate = useCallback(() => {
+  // "New routine" opens a chooser: guided setup in chat, or the form.
+  const handleCreate = useCallback(() => setChoiceOpen(true), []);
+
+  const handleCreateWithForm = useCallback(() => {
+    setChoiceOpen(false);
     setForm(EMPTY_FORM);
     setBaseline(EMPTY_FORM);
     setView({ type: "editor" });
   }, []);
+
+  const handleCreateInChat = useCallback(async () => {
+    // On success the view switches to the new conversation, so only close
+    // the dialog then — a failed start keeps the chooser up for a retry.
+    if (await chatSetup.start()) setChoiceOpen(false);
+  }, [chatSetup]);
 
   const openEditor = useCallback(
     (routineId: string) => {
@@ -229,20 +244,29 @@ export default function RoutinesTab({ agent }: TabProps) {
   }
 
   return (
-    <RoutinesGrid
-      routines={routines ?? []}
-      lastRuns={lastRuns}
-      accountTimezone={tz.timezone}
-      onTimezoneChange={handleTimezoneChange}
-      loading={isLoading}
-      onSelect={openEditor}
-      onCreate={handleCreate}
-      onToggle={handleToggle}
-      labels={labels.grid}
-      rowLabels={labels.rowLabels}
-      scheduleSummaryLabels={labels.schedule.summary}
-      nextFireLabels={labels.nextFire}
-      locale={labels.locale}
-    />
+    <>
+      <RoutineCreateChoiceDialog
+        open={choiceOpen}
+        onOpenChange={setChoiceOpen}
+        onChat={handleCreateInChat}
+        onForm={handleCreateWithForm}
+        busy={chatSetup.pending}
+      />
+      <RoutinesGrid
+        routines={routines ?? []}
+        lastRuns={lastRuns}
+        accountTimezone={tz.timezone}
+        onTimezoneChange={handleTimezoneChange}
+        loading={isLoading}
+        onSelect={openEditor}
+        onCreate={handleCreate}
+        onToggle={handleToggle}
+        labels={labels.grid}
+        rowLabels={labels.rowLabels}
+        scheduleSummaryLabels={labels.schedule.summary}
+        nextFireLabels={labels.nextFire}
+        locale={labels.locale}
+      />
+    </>
   );
 }

--- a/app/src/components/tabs/use-routine-chat-setup.ts
+++ b/app/src/components/tabs/use-routine-chat-setup.ts
@@ -1,0 +1,59 @@
+import { useCallback, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { analytics } from "../../lib/analytics";
+import { createMission } from "../../lib/create-mission";
+import { encodeRoutineSetupMessage } from "../../lib/routine-chat-setup";
+import { tauriConfig } from "../../lib/tauri";
+import { readAgentTurnMode } from "../../lib/turn-mode";
+import type { Agent } from "../../lib/types";
+import { useUIStore } from "../../stores/ui";
+
+/**
+ * The "Create it in chat" branch of the New-routine chooser: start a fresh
+ * mission whose first message primes the agent to interview the user and
+ * schedule the routine, then jump to that conversation (the same
+ * view-mode + activity-panel handoff the archived-resume flow uses).
+ * The routine itself is created by the agent, so the Routines grid updates
+ * through the normal RoutinesChanged reactivity — nothing to do here.
+ */
+export function useRoutineChatSetup(agent: Agent) {
+  const { t } = useTranslation("routines");
+  const addToast = useUIStore((s) => s.addToast);
+  const setViewMode = useUIStore((s) => s.setViewMode);
+  const setActivityPanelId = useUIStore((s) => s.setActivityPanelId);
+  const [pending, setPending] = useState(false);
+
+  const start = useCallback(async () => {
+    setPending(true);
+    try {
+      const text = encodeRoutineSetupMessage({
+        title: t("createChoice.cardTitle"),
+        description: t("createChoice.cardDescription"),
+      });
+      const { conversationId } = await createMission(agent, text, {
+        title: t("createChoice.missionTitle"),
+        modeOverride: await readAgentTurnMode(
+          agent.folderPath,
+          tauriConfig.read,
+        ),
+      });
+      analytics.track("routine_chat_setup_started");
+      setViewMode("activity");
+      setActivityPanelId(conversationId, { forceOpen: true });
+      return true;
+    } catch (err) {
+      // The mission never started (createMission rolled the activity back),
+      // so a toast is the only surface for the failure.
+      addToast({
+        title: t("toasts.chatSetupError"),
+        description: err instanceof Error ? err.message : String(err),
+        variant: "error",
+      });
+      return false;
+    } finally {
+      setPending(false);
+    }
+  }, [agent, t, addToast, setViewMode, setActivityPanelId]);
+
+  return { start, pending };
+}

--- a/app/src/components/tabs/use-routine-chat-setup.ts
+++ b/app/src/components/tabs/use-routine-chat-setup.ts
@@ -1,45 +1,70 @@
-import { useCallback, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useActivity } from "../../hooks/queries";
 import { analytics } from "../../lib/analytics";
 import { createMission } from "../../lib/create-mission";
-import { encodeRoutineSetupMessage } from "../../lib/routine-chat-setup";
+import { queryKeys } from "../../lib/query-keys";
+import {
+  encodeRoutineSetupMessage,
+  isRoutineSetupMode,
+  ROUTINE_SETUP_AGENT_MODE,
+} from "../../lib/routine-chat-setup";
 import { tauriConfig } from "../../lib/tauri";
 import { readAgentTurnMode } from "../../lib/turn-mode";
 import type { Agent } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 
 /**
- * The "Create it in chat" branch of the New-routine chooser: start a fresh
- * mission whose first message primes the agent to interview the user and
- * schedule the routine, then jump to that conversation (the same
- * view-mode + activity-panel handoff the archived-resume flow uses).
- * The routine itself is created by the agent, so the Routines grid updates
- * through the normal RoutinesChanged reactivity — nothing to do here.
+ * The "Create it in chat" branch of the New-routine chooser. The guided chat
+ * is a normal mission under the hood, but tagged with the routine-setup
+ * sentinel so it never shows as a board card — its only home is the Routines
+ * tab's own panel (`RoutineSetupChat`). At most one setup chat is live per
+ * agent: starting again resumes the existing one.
  */
 export function useRoutineChatSetup(agent: Agent) {
   const { t } = useTranslation("routines");
+  const path = agent.folderPath;
+  const queryClient = useQueryClient();
   const addToast = useUIStore((s) => s.addToast);
-  const setViewMode = useUIStore((s) => s.setViewMode);
-  const setActivityPanelId = useUIStore((s) => s.setActivityPanelId);
+  const setRoutineSetupChatAgentId = useUIStore(
+    (s) => s.setRoutineSetupChatAgentId,
+  );
+  const { data: rawItems } = useActivity(path);
   const [pending, setPending] = useState(false);
 
+  const setupActivity = useMemo(
+    () =>
+      (rawItems ?? []).find(
+        (a) => isRoutineSetupMode(a.agent) && a.status !== "archived",
+      ),
+    [rawItems],
+  );
+
+  const openPanel = useCallback(() => {
+    // Every AIBoard portals its detail panel into the SAME shared container;
+    // close whatever chat another surface left open so panels never stack.
+    useUIStore.getState().onPanelClose?.();
+    setRoutineSetupChatAgentId(agent.id);
+  }, [setRoutineSetupChatAgentId, agent.id]);
+
   const start = useCallback(async () => {
+    if (setupActivity) {
+      openPanel();
+      return true;
+    }
     setPending(true);
     try {
-      const text = encodeRoutineSetupMessage({
-        title: t("createChoice.cardTitle"),
-        description: t("createChoice.cardDescription"),
-      });
-      const { conversationId } = await createMission(agent, text, {
+      await createMission(agent, encodeRoutineSetupMessage(), {
         title: t("createChoice.missionTitle"),
-        modeOverride: await readAgentTurnMode(
-          agent.folderPath,
-          tauriConfig.read,
-        ),
+        agentMode: ROUTINE_SETUP_AGENT_MODE,
+        modeOverride: await readAgentTurnMode(path, tauriConfig.read),
       });
+      // createMission bypasses useCreateActivity — refetch so the panel's
+      // backing activity exists before it tries to render.
+      queryClient.invalidateQueries({ queryKey: queryKeys.activity(path) });
       analytics.track("routine_chat_setup_started");
-      setViewMode("activity");
-      setActivityPanelId(conversationId, { forceOpen: true });
+      openPanel();
       return true;
     } catch (err) {
       // The mission never started (createMission rolled the activity back),
@@ -53,7 +78,7 @@ export function useRoutineChatSetup(agent: Agent) {
     } finally {
       setPending(false);
     }
-  }, [agent, t, addToast, setViewMode, setActivityPanelId]);
+  }, [agent, path, setupActivity, openPanel, queryClient, t, addToast]);
 
-  return { start, pending };
+  return { setupActivity, start, pending };
 }

--- a/app/src/components/use-mission-control.ts
+++ b/app/src/components/use-mission-control.ts
@@ -14,6 +14,7 @@ import { createMission } from "../lib/create-mission";
 import { missionCardTags } from "../lib/mission-card";
 import { queryKeys } from "../lib/query-keys";
 import { formatVisibleMessageText } from "../lib/queued-chat";
+import { isRoutineSetupMode } from "../lib/routine-chat-setup";
 import {
   type HistoryLoadOptions,
   tauriActivity,
@@ -71,9 +72,14 @@ export function useMissionControl(agents: Agent[]) {
     > = {};
     const result = convos
       // Archived missions live in the per-agent Archived tab — keep them off
-      // the cross-agent active board.
+      // the cross-agent active board. Routine-setup chats live in the
+      // Routines tab, never as a card.
       .filter(
-        (c) => c.type === "activity" && c.status && c.status !== "archived",
+        (c) =>
+          c.type === "activity" &&
+          c.status &&
+          c.status !== "archived" &&
+          !isRoutineSetupMode(c.agent),
       )
       .map((c) => {
         const agent = agentMap[c.agent_path];

--- a/app/src/hooks/session-notifications.ts
+++ b/app/src/hooks/session-notifications.ts
@@ -11,6 +11,7 @@ import { osShowSessionNotification } from "../lib/os-bridge";
 import { isMac } from "../lib/platform";
 import { queryClient } from "../lib/query-client";
 import { queryKeys } from "../lib/query-keys";
+import { isRoutineSetupMode } from "../lib/routine-chat-setup";
 import { tauriActivity } from "../lib/tauri";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
@@ -29,16 +30,19 @@ export function describePendingNotificationNav() {
  * time; `fetchQuery` re-reads through the same key the board uses, so it both
  * resolves the routine chat and warms the cache for the agent we switch to.
  */
-async function resolveActivityId(
+async function resolveActivityTarget(
   agentPath: string,
   sessionKey: string,
-): Promise<string | null> {
+): Promise<{ activityId: string; routineSetup: boolean } | null> {
   try {
     const activities = await queryClient.fetchQuery({
       queryKey: queryKeys.activity(agentPath),
       queryFn: () => tauriActivity.list(agentPath),
     });
-    return activityIdForSessionKey(activities, sessionKey);
+    const activityId = activityIdForSessionKey(activities, sessionKey);
+    if (!activityId) return null;
+    const activity = activities.find((a) => a.id === activityId);
+    return { activityId, routineSetup: isRoutineSetupMode(activity?.agent) };
   } catch (e) {
     // Log-only (no toast): nav is best-effort and this same path fires on a
     // bare macOS refocus, where a toast would be noise. A standard mission key
@@ -46,7 +50,8 @@ async function resolveActivityId(
     logger.error(
       `[notification] failed to list activities for nav (${sessionKey}): ${e}`,
     );
-    return activityIdForSessionKey([], sessionKey);
+    const activityId = activityIdForSessionKey([], sessionKey);
+    return activityId ? { activityId, routineSetup: false } : null;
   }
 }
 
@@ -69,8 +74,8 @@ export async function consumePendingNav() {
     return;
   }
 
-  const activityId = await resolveActivityId(agent.folderPath, sessionKey);
-  if (!activityId) {
+  const target = await resolveActivityTarget(agent.folderPath, sessionKey);
+  if (!target) {
     logger.debug(
       `[notification] no activity matches sessionKey=${sessionKey}, cannot navigate`,
     );
@@ -78,11 +83,20 @@ export async function consumePendingNav() {
   }
 
   logger.debug(
-    `[notification] navigating to agent=${agent.name} activity=${activityId} (sessionKey=${sessionKey})`,
+    `[notification] navigating to agent=${agent.name} activity=${target.activityId} (sessionKey=${sessionKey})`,
   );
-  useUIStore.getState().setViewMode("activity");
   useAgentStore.getState().setCurrent(agent);
-  useUIStore.getState().setActivityPanelId(activityId, { forceOpen: true });
+  if (target.routineSetup) {
+    // A routine-setup chat has no board card: its home is the Routines tab,
+    // where the panel reopens on the spot.
+    useUIStore.getState().setViewMode("routines");
+    useUIStore.getState().setRoutineSetupChatAgentId(agent.id);
+    return;
+  }
+  useUIStore.getState().setViewMode("activity");
+  useUIStore.getState().setActivityPanelId(target.activityId, {
+    forceOpen: true,
+  });
 }
 
 export async function sendSessionNotification(

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -74,6 +74,7 @@ export type AnalyticsEventName =
   | "skill_used"
   | "routine_scheduled"
   | "routine_executed"
+  | "routine_chat_setup_started"
   | "tab_opened"
   | "file_attached"
   | "mobile_paired"

--- a/app/src/lib/mission-selection.ts
+++ b/app/src/lib/mission-selection.ts
@@ -4,6 +4,8 @@
  * testable and reusable from both the board tab and the archived tab.
  */
 
+import { isRoutineSetupMode } from "./routine-chat-setup.ts";
+
 /** The status that hides a mission from the active board and surfaces it in
  *  the Archived missions tab. Matches `activity.schema.json`. */
 export const ARCHIVED_STATUS = "archived";
@@ -64,12 +66,24 @@ export function isArchived<T extends { status: string }>(item: T): boolean {
   return item.status === ARCHIVED_STATUS;
 }
 
-/** Missions shown on the active board (everything not archived). */
-export function selectActive<T extends { status: string }>(items: T[]): T[] {
-  return items.filter((item) => !isArchived(item));
+interface SelectableMission {
+  status: string;
+  /** Agent-mode id; the routine-setup sentinel hides the mission entirely. */
+  agent?: string | null;
 }
 
-/** Missions shown in the Archived missions tab. */
-export function selectArchived<T extends { status: string }>(items: T[]): T[] {
-  return items.filter(isArchived);
+/** Missions shown on the active board (not archived, not a routine-setup
+ *  chat — that guided chat lives in the Routines tab, never as a card). */
+export function selectActive<T extends SelectableMission>(items: T[]): T[] {
+  return items.filter(
+    (item) => !isArchived(item) && !isRoutineSetupMode(item.agent),
+  );
+}
+
+/** Missions shown in the Archived missions tab. Closed routine-setup chats
+ *  stay out of here too: they were never a mission the user managed. */
+export function selectArchived<T extends SelectableMission>(items: T[]): T[] {
+  return items.filter(
+    (item) => isArchived(item) && !isRoutineSetupMode(item.agent),
+  );
 }

--- a/app/src/lib/routine-chat-setup.ts
+++ b/app/src/lib/routine-chat-setup.ts
@@ -1,0 +1,72 @@
+/**
+ * "Create a routine in chat" — the guided alternative to the routine form.
+ *
+ * The first chat message reuses the skill-invocation marker
+ * (`<!--houston:skill ...-->`, decoded by `@houston-ai/chat`) so the
+ * conversation renders a friendly card instead of the raw interview
+ * instructions — the exact pattern a Skill run uses. The body after the
+ * marker is the Claude-facing prompt. The product prompt's Routines
+ * guidance (interview via ask_user, approval, schema-checked save) does
+ * the heavy lifting; this prompt kicks it off and covers the choices the
+ * form exposes (schedule, one chat vs fresh chats, quiet runs).
+ */
+
+import type { SkillInvocation } from "@houston-ai/chat";
+
+const MARKER_PREFIX = "<!--houston:skill ";
+const MARKER_SUFFIX = "-->";
+
+/** Fluent 3D emoji slug for the chat card. */
+const ROUTINE_SETUP_IMAGE = "alarm-clock";
+
+/**
+ * Marker slug for the setup card. Not a real on-disk skill — the chat
+ * renderer draws the card purely from the marker payload.
+ */
+const ROUTINE_SETUP_SLUG = "set-up-a-routine";
+
+export interface RoutineSetupLabels {
+  /** Card heading shown in the conversation, e.g. "Set up a routine". */
+  title: string;
+  /** Card subtitle; also the mission-card preview text. */
+  description: string;
+}
+
+/**
+ * The Claude-facing kickoff. English on purpose (all prompts are); the
+ * agent mirrors the user's language when it answers.
+ */
+export const ROUTINE_SETUP_PROMPT = `The user clicked "New routine" and chose to set it up here in chat. Guide them through creating ONE new Routine, then create it.
+
+Follow your Routines guidance, with these specifics:
+- Interview the user with the ask_user tool (batch related questions, at most 3 per call). Cover, in plain language:
+  1. What the routine should do, plus any details you need to do it well.
+  2. When it should run (how often, and at what time).
+  3. Which of their connected apps it should use, if the task touches email, calendar, or other apps.
+  4. Whether every run should add to one ongoing chat, or each run should start a fresh chat.
+  5. Whether they want to hear about every run, or only when something needs their attention.
+- If their answers already cover a point, do not ask it again.
+- Propose a short name and a one-line description yourself; let the user adjust them.
+- Do not ask about models, providers, or other technical settings. The routine uses this agent's settings.
+- Keep the whole conversation friendly and non-technical. Never mention files, JSON, schemas, or field names.
+
+When you have everything, summarize the routine in a few plain lines and ask for approval with ask_user (Yes / No). Only create it after a Yes. Then confirm it is scheduled and mention they can see it, change it, or pause it anytime in this agent's Routines tab.`;
+
+/**
+ * Build the full first-message body: marker (for the card) + kickoff
+ * prompt (for the model). Labels are localized at send time so the
+ * persisted card matches the user's language.
+ */
+export function encodeRoutineSetupMessage(labels: RoutineSetupLabels): string {
+  const payload: SkillInvocation = {
+    skill: ROUTINE_SETUP_SLUG,
+    displayName: labels.title,
+    image: ROUTINE_SETUP_IMAGE,
+    description: labels.description,
+    integrations: [],
+    fields: [],
+    message: "",
+    attachments: [],
+  };
+  return `${MARKER_PREFIX}${JSON.stringify(payload)}${MARKER_SUFFIX}\n\n${ROUTINE_SETUP_PROMPT}`;
+}

--- a/app/src/lib/routine-chat-setup.ts
+++ b/app/src/lib/routine-chat-setup.ts
@@ -1,72 +1,59 @@
 /**
  * "Create a routine in chat" — the guided alternative to the routine form.
  *
- * The first chat message reuses the skill-invocation marker
- * (`<!--houston:skill ...-->`, decoded by `@houston-ai/chat`) so the
- * conversation renders a friendly card instead of the raw interview
- * instructions — the exact pattern a Skill run uses. The body after the
- * marker is the Claude-facing prompt. The product prompt's Routines
- * guidance (interview via ask_user, approval, schema-checked save) does
- * the heavy lifting; this prompt kicks it off and covers the choices the
- * form exposes (schedule, one chat vs fresh chats, quiet runs).
+ * The kickoff rides the auto-continue marker (`lib/auto-continue-message.ts`):
+ * the user never typed anything, so the transcript hides the bubble on both
+ * the optimistic and reload paths, and the conversation opens with the
+ * AGENT's greeting + first question. The product prompt's Routines guidance
+ * (schema-checked save, approval gate) does the heavy lifting; this prompt
+ * kicks it off and slows the interview down to one question per turn.
  */
 
-import type { SkillInvocation } from "@houston-ai/chat";
-
-const MARKER_PREFIX = "<!--houston:skill ";
-const MARKER_SUFFIX = "-->";
-
-/** Fluent 3D emoji slug for the chat card. */
-const ROUTINE_SETUP_IMAGE = "alarm-clock";
+import { encodeAutoContinueMessage } from "./auto-continue-message.ts";
 
 /**
- * Marker slug for the setup card. Not a real on-disk skill — the chat
- * renderer draws the card purely from the marker payload.
+ * Sentinel stored in the activity's `agent` (mode) field so every mission
+ * surface can recognize a routine-setup chat. Namespaced with `houston:` so
+ * it can never collide with a user-defined agent-mode id, and reusing the
+ * existing field means no schema change and the value already flows through
+ * the conversation adapters (HOU-665 keeps `agent` alive end to end).
  */
-const ROUTINE_SETUP_SLUG = "set-up-a-routine";
+export const ROUTINE_SETUP_AGENT_MODE = "houston:routine-setup";
 
-export interface RoutineSetupLabels {
-  /** Card heading shown in the conversation, e.g. "Set up a routine". */
-  title: string;
-  /** Card subtitle; also the mission-card preview text. */
-  description: string;
+/** True when an activity's `agent` (mode) marks it as a routine-setup chat. */
+export function isRoutineSetupMode(agent: string | null | undefined): boolean {
+  return agent === ROUTINE_SETUP_AGENT_MODE;
 }
 
 /**
  * The Claude-facing kickoff. English on purpose (all prompts are); the
  * agent mirrors the user's language when it answers.
  */
-export const ROUTINE_SETUP_PROMPT = `The user clicked "New routine" and chose to set it up here in chat. Guide them through creating ONE new Routine, then create it.
+export const ROUTINE_SETUP_PROMPT = `Houston sent this message automatically: the user clicked "New routine" and chose to set it up here in chat. The user has not said anything yet.
 
-Follow your Routines guidance, with these specifics:
-- Interview the user with the ask_user tool (batch related questions, at most 3 per call). Cover, in plain language:
-  1. What the routine should do, plus any details you need to do it well.
-  2. When it should run (how often, and at what time).
-  3. Which of their connected apps it should use, if the task touches email, calendar, or other apps.
-  4. Whether every run should add to one ongoing chat, or each run should start a fresh chat.
-  5. Whether they want to hear about every run, or only when something needs their attention.
-- If their answers already cover a point, do not ask it again.
-- Propose a short name and a one-line description yourself; let the user adjust them.
-- Do not ask about models, providers, or other technical settings. The routine uses this agent's settings.
-- Keep the whole conversation friendly and non-technical. Never mention files, JSON, schemas, or field names.
+Guide them through creating ONE new Routine, then create it.
+
+How to run this conversation:
+- Open by greeting the user in one short line and asking your first question right away.
+- Ask exactly ONE question at a time, always through the ask_user tool. In this guided setup, never batch several questions into one call. Offer answer options whenever the question allows it.
+- Keep every message short, friendly, and non-technical. Never mention files, JSON, schemas, or field names.
+- If an earlier answer already covers a later question, skip that question.
+
+What you need to learn, one step at a time:
+1. What the routine should do, plus any details you need to do it well.
+2. When it should run (how often, and at what time).
+3. Which of their connected apps it should use, if the task touches email, calendar, or other apps.
+4. Whether every run should add to one ongoing chat, or each run should start a fresh chat.
+5. Whether they want to hear about every run, or only when something needs their attention.
+
+Do not ask about models, providers, or other technical settings. The routine uses this agent's settings. Propose a short name and a one-line description yourself.
 
 When you have everything, summarize the routine in a few plain lines and ask for approval with ask_user (Yes / No). Only create it after a Yes. Then confirm it is scheduled and mention they can see it, change it, or pause it anytime in this agent's Routines tab.`;
 
 /**
- * Build the full first-message body: marker (for the card) + kickoff
- * prompt (for the model). Labels are localized at send time so the
- * persisted card matches the user's language.
+ * The full first-message body: marker (hides the bubble) + kickoff prompt
+ * (what the model acts on).
  */
-export function encodeRoutineSetupMessage(labels: RoutineSetupLabels): string {
-  const payload: SkillInvocation = {
-    skill: ROUTINE_SETUP_SLUG,
-    displayName: labels.title,
-    image: ROUTINE_SETUP_IMAGE,
-    description: labels.description,
-    integrations: [],
-    fields: [],
-    message: "",
-    attachments: [],
-  };
-  return `${MARKER_PREFIX}${JSON.stringify(payload)}${MARKER_SUFFIX}\n\n${ROUTINE_SETUP_PROMPT}`;
+export function encodeRoutineSetupMessage(): string {
+  return encodeAutoContinueMessage(ROUTINE_SETUP_PROMPT);
 }

--- a/app/src/lib/routine-chat-setup.ts
+++ b/app/src/lib/routine-chat-setup.ts
@@ -29,14 +29,19 @@ export function isRoutineSetupMode(agent: string | null | undefined): boolean {
  * The Claude-facing kickoff. English on purpose (all prompts are); the
  * agent mirrors the user's language when it answers.
  */
-export const ROUTINE_SETUP_PROMPT = `Houston sent this message automatically: the user clicked "New routine" and chose to set it up here in chat. The user has not said anything yet.
+export const ROUTINE_SETUP_PROMPT = `Houston sent this message automatically: the user clicked "New routine" and chose to set it up here in chat. The user has not said anything yet and is waiting for you to start.
 
-Guide them through creating ONE new Routine, then create it.
+Your job in this conversation: guide the user through creating ONE new Routine, then create it.
 
-How to run this conversation:
-- Open by greeting the user in one short line and asking your first question right away.
-- Ask exactly ONE question at a time, always through the ask_user tool. In this guided setup, never batch several questions into one call. Offer answer options whenever the question allows it.
-- Keep every message short, friendly, and non-technical. Never mention files, JSON, schemas, or field names.
+Start RIGHT NOW, in this same turn:
+1. Write exactly one short, friendly opening line (match the user's language; no headings, no lists, no explanations).
+2. Then, still in this turn, call the ask_user tool with your first question: what the routine should do for them. Offer 3 or 4 concrete example options based on what you help this user with (for example "Watch my inbox for anything urgent", "Send me a morning summary of my day", "Remind me before deadlines"), and they can always describe their own idea instead.
+Do not stop after the greeting. In this conversation, a turn that ends without an ask_user call is a mistake, until the routine is created.
+
+Interview rules:
+- Ask exactly ONE question per ask_user call. Never batch several questions into one call here, even though your general guidance allows up to 3. One question, wait for the answer, then the next.
+- Offer answer options whenever the question allows it (schedule choices, yes/no, app choices).
+- Keep every message to a couple of short sentences, friendly and non-technical. Never mention files, JSON, schemas, tools, or field names.
 - If an earlier answer already covers a later question, skip that question.
 
 What you need to learn, one step at a time:

--- a/app/src/locales/en/routines.json
+++ b/app/src/locales/en/routines.json
@@ -11,6 +11,17 @@
     "timezoneSearchPlaceholder": "Search timezones…",
     "timezoneNoResults": "No timezones found"
   },
+  "createChoice": {
+    "title": "New routine",
+    "description": "How would you like to set it up?",
+    "chatTitle": "Create it in chat",
+    "chatDescription": "Tell your agent what you need. It asks a few questions and schedules the routine for you.",
+    "formTitle": "Fill in the details myself",
+    "formDescription": "Set the name, schedule, and instructions with the form.",
+    "cardTitle": "Set up a routine",
+    "cardDescription": "Your agent will ask a few questions and schedule it for you.",
+    "missionTitle": "Set up a new routine"
+  },
   "editor": {
     "back": "Back to routines",
     "newRoutine": "New routine",
@@ -150,6 +161,7 @@
   },
   "toasts": {
     "timezoneSet": "Timezone set to {{zone}}",
-    "timezoneError": "Couldn't update the timezone"
+    "timezoneError": "Couldn't update the timezone",
+    "chatSetupError": "Couldn't start the routine setup chat"
   }
 }

--- a/app/src/locales/en/routines.json
+++ b/app/src/locales/en/routines.json
@@ -18,9 +18,13 @@
     "chatDescription": "Tell your agent what you need. It asks a few questions and schedules the routine for you.",
     "formTitle": "Fill in the details myself",
     "formDescription": "Set the name, schedule, and instructions with the form.",
-    "cardTitle": "Set up a routine",
-    "cardDescription": "Your agent will ask a few questions and schedule it for you.",
     "missionTitle": "Set up a new routine"
+  },
+  "setupChat": {
+    "bannerTitle": "You are creating a routine in chat",
+    "bannerDescription": "Pick up where you left off, or discard the draft chat.",
+    "continue": "Continue",
+    "discard": "Discard"
   },
   "editor": {
     "back": "Back to routines",

--- a/app/src/locales/es/routines.json
+++ b/app/src/locales/es/routines.json
@@ -18,9 +18,13 @@
     "chatDescription": "Cuéntale a tu agente lo que necesitas. Te hará algunas preguntas y programará la rutina por ti.",
     "formTitle": "Completar los detalles por mi cuenta",
     "formDescription": "Define el nombre, el horario y las instrucciones con el formulario.",
-    "cardTitle": "Configurar una rutina",
-    "cardDescription": "Tu agente te hará algunas preguntas y la programará por ti.",
     "missionTitle": "Configurar una nueva rutina"
+  },
+  "setupChat": {
+    "bannerTitle": "Estás creando una rutina en el chat",
+    "bannerDescription": "Retoma donde quedaste o descarta el chat en curso.",
+    "continue": "Continuar",
+    "discard": "Descartar"
   },
   "editor": {
     "back": "Volver a rutinas",

--- a/app/src/locales/es/routines.json
+++ b/app/src/locales/es/routines.json
@@ -11,6 +11,17 @@
     "timezoneSearchPlaceholder": "Buscar zonas horarias…",
     "timezoneNoResults": "No se encontraron zonas horarias"
   },
+  "createChoice": {
+    "title": "Nueva rutina",
+    "description": "¿Cómo quieres configurarla?",
+    "chatTitle": "Crearla en el chat",
+    "chatDescription": "Cuéntale a tu agente lo que necesitas. Te hará algunas preguntas y programará la rutina por ti.",
+    "formTitle": "Completar los detalles por mi cuenta",
+    "formDescription": "Define el nombre, el horario y las instrucciones con el formulario.",
+    "cardTitle": "Configurar una rutina",
+    "cardDescription": "Tu agente te hará algunas preguntas y la programará por ti.",
+    "missionTitle": "Configurar una nueva rutina"
+  },
   "editor": {
     "back": "Volver a rutinas",
     "newRoutine": "Nueva rutina",
@@ -150,6 +161,7 @@
   },
   "toasts": {
     "timezoneSet": "Zona horaria establecida en {{zone}}",
-    "timezoneError": "No se pudo actualizar la zona horaria"
+    "timezoneError": "No se pudo actualizar la zona horaria",
+    "chatSetupError": "No se pudo iniciar el chat para configurar la rutina"
   }
 }

--- a/app/src/locales/pt/routines.json
+++ b/app/src/locales/pt/routines.json
@@ -18,9 +18,13 @@
     "chatDescription": "Conte ao seu agente o que você precisa. Ele faz algumas perguntas e agenda a rotina para você.",
     "formTitle": "Preencher os detalhes por conta própria",
     "formDescription": "Defina o nome, o horário e as instruções no formulário.",
-    "cardTitle": "Configurar uma rotina",
-    "cardDescription": "Seu agente vai fazer algumas perguntas e agendar a rotina para você.",
     "missionTitle": "Configurar uma nova rotina"
+  },
+  "setupChat": {
+    "bannerTitle": "Você está criando uma rotina no chat",
+    "bannerDescription": "Continue de onde parou ou descarte o chat em andamento.",
+    "continue": "Continuar",
+    "discard": "Descartar"
   },
   "editor": {
     "back": "Voltar para rotinas",

--- a/app/src/locales/pt/routines.json
+++ b/app/src/locales/pt/routines.json
@@ -11,6 +11,17 @@
     "timezoneSearchPlaceholder": "Buscar fusos horários…",
     "timezoneNoResults": "Nenhum fuso horário encontrado"
   },
+  "createChoice": {
+    "title": "Nova rotina",
+    "description": "Como você quer configurá-la?",
+    "chatTitle": "Criar no chat",
+    "chatDescription": "Conte ao seu agente o que você precisa. Ele faz algumas perguntas e agenda a rotina para você.",
+    "formTitle": "Preencher os detalhes por conta própria",
+    "formDescription": "Defina o nome, o horário e as instruções no formulário.",
+    "cardTitle": "Configurar uma rotina",
+    "cardDescription": "Seu agente vai fazer algumas perguntas e agendar a rotina para você.",
+    "missionTitle": "Configurar uma nova rotina"
+  },
   "editor": {
     "back": "Voltar para rotinas",
     "newRoutine": "Nova rotina",
@@ -150,6 +161,7 @@
   },
   "toasts": {
     "timezoneSet": "Fuso horário definido como {{zone}}",
-    "timezoneError": "Não foi possível atualizar o fuso horário"
+    "timezoneError": "Não foi possível atualizar o fuso horário",
+    "chatSetupError": "Não foi possível iniciar o chat para configurar a rotina"
   }
 }

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -37,6 +37,8 @@ interface UIState {
   agentArchivedSearchLoading: Record<string, boolean>;
   /** Whether the mission chat panel is open (hides tab bar for full-height panel) */
   missionPanelOpen: boolean;
+  /** Agent id whose routine-setup chat panel (Routines tab) is open, or null. */
+  routineSetupChatAgentId: string | null;
   /** Whether the global command palette (⌘K) is open. */
   paletteOpen: boolean;
   /** Whether the keyboard shortcut cheatsheet (?) is open. */
@@ -87,6 +89,7 @@ interface UIState {
   setAgentArchivedSearchQuery: (agentPath: string, query: string) => void;
   setAgentArchivedSearchLoading: (agentPath: string, loading: boolean) => void;
   setMissionPanelOpen: (open: boolean) => void;
+  setRoutineSetupChatAgentId: (agentId: string | null) => void;
   setPaletteOpen: (open: boolean) => void;
   setCheatsheetOpen: (open: boolean) => void;
   setOnBoardNavigate: (
@@ -124,6 +127,7 @@ export const useUIStore = create<UIState>()(
       agentArchivedSearchQueries: {},
       agentArchivedSearchLoading: {},
       missionPanelOpen: false,
+      routineSetupChatAgentId: null,
       paletteOpen: false,
       cheatsheetOpen: false,
       onBoardNavigate: null,
@@ -211,6 +215,8 @@ export const useUIStore = create<UIState>()(
           return { agentArchivedSearchLoading: next };
         }),
       setMissionPanelOpen: (missionPanelOpen) => set({ missionPanelOpen }),
+      setRoutineSetupChatAgentId: (routineSetupChatAgentId) =>
+        set({ routineSetupChatAgentId }),
       setPaletteOpen: (paletteOpen) => set({ paletteOpen }),
       setCheatsheetOpen: (cheatsheetOpen) => set({ cheatsheetOpen }),
       setOnBoardNavigate: (onBoardNavigate) => set({ onBoardNavigate }),

--- a/app/tests/routine-chat-setup.test.ts
+++ b/app/tests/routine-chat-setup.test.ts
@@ -86,10 +86,12 @@ describe("routine chat setup message", () => {
     // about models or providers.
     for (const needle of [
       "The user has not said anything yet",
-      "greeting the user",
-      "exactly ONE question at a time",
-      "never batch",
-      "ask_user",
+      "Start RIGHT NOW, in this same turn",
+      "one short, friendly opening line",
+      "Do not stop after the greeting",
+      "a turn that ends without an ask_user call is a mistake",
+      "exactly ONE question per ask_user call",
+      "Never batch",
       "one ongoing chat",
       "fresh chat",
       "needs their attention",

--- a/app/tests/routine-chat-setup.test.ts
+++ b/app/tests/routine-chat-setup.test.ts
@@ -1,48 +1,94 @@
-import { ok, strictEqual } from "node:assert/strict";
+import { deepStrictEqual, ok } from "node:assert/strict";
 import { describe, it } from "node:test";
-// Deep import: the @houston-ai/chat barrel drags in React components that
-// node:test cannot resolve; the decoder module itself is dependency-free.
-import { decodeSkillMessage } from "../../ui/chat/src/skill-message.ts";
+import { buildAgentActivitySummaries } from "../src/components/shell/agent-activity-summary-model.ts";
+import {
+  filterAutoContinueFeedItems,
+  isAutoContinueMessage,
+} from "../src/lib/auto-continue-message.ts";
+import { selectActive, selectArchived } from "../src/lib/mission-selection.ts";
 import {
   encodeRoutineSetupMessage,
+  isRoutineSetupMode,
+  ROUTINE_SETUP_AGENT_MODE,
   ROUTINE_SETUP_PROMPT,
 } from "../src/lib/routine-chat-setup.ts";
 
-// The "Create it in chat" first message must round-trip through the shared
-// skill-marker decoder: the renderer draws a friendly card from the marker
-// payload while the model reads only the kickoff prompt after it. If either
-// side drifts, non-technical users see raw interview instructions as their
-// own message.
-
-const LABELS = {
-  title: "Set up a routine",
-  description: "Your agent will ask a few questions and schedule it for you.",
-};
+// The "Create it in chat" kickoff is Houston-sent, not user-typed: it must
+// ride the auto-continue marker so the transcript hides the bubble (live and
+// on reload) and the conversation opens with the AGENT's greeting. If the
+// marker drifts, non-technical users see raw interview instructions as their
+// own first message.
 
 describe("routine chat setup message", () => {
-  it("decodes as a skill-invocation card with the localized labels", () => {
-    const body = encodeRoutineSetupMessage(LABELS);
-    const invocation = decodeSkillMessage(body);
-    ok(invocation, "marker must decode");
-    strictEqual(invocation.displayName, LABELS.title);
-    strictEqual(invocation.description, LABELS.description);
-    // No composer text: the mission-card subtitle falls back to the
-    // description instead of leaking prompt internals.
-    strictEqual(invocation.message, "");
-    strictEqual(invocation.attachments.length, 0);
+  it("is tagged as an auto-continue message and filtered from the feed", () => {
+    const body = encodeRoutineSetupMessage();
+    ok(isAutoContinueMessage(body));
+    const filtered = filterAutoContinueFeedItems([
+      { feed_type: "user_message", data: body },
+    ]);
+    ok(filtered.length === 0, "kickoff bubble must not render");
   });
 
   it("carries the kickoff prompt as the model-facing body", () => {
-    const body = encodeRoutineSetupMessage(LABELS);
-    ok(body.startsWith("<!--houston:skill "));
-    ok(body.endsWith(ROUTINE_SETUP_PROMPT));
+    ok(encodeRoutineSetupMessage().endsWith(ROUTINE_SETUP_PROMPT));
   });
 
-  it("kickoff prompt covers the interview the issue asks for", () => {
-    // Load-bearing beats: interview via ask_user, chat-mode choice, quiet
-    // runs, approval gate, and no model/provider questions for
-    // non-technical users.
+  it("setup chats never surface as missions", () => {
+    const setup = {
+      id: "s1",
+      status: "needs_you",
+      agent: ROUTINE_SETUP_AGENT_MODE,
+    };
+    const archivedSetup = {
+      id: "s2",
+      status: "archived",
+      agent: ROUTINE_SETUP_AGENT_MODE,
+    };
+    const normal = { id: "n1", status: "needs_you", agent: "researcher" };
+    const archivedNormal = { id: "n2", status: "archived" };
+    ok(isRoutineSetupMode(ROUTINE_SETUP_AGENT_MODE));
+    ok(!isRoutineSetupMode("researcher"));
+    ok(!isRoutineSetupMode(null));
+    // Active board: only the normal mission survives.
+    deepStrictEqual(
+      selectActive([setup, archivedSetup, normal, archivedNormal]).map(
+        (i) => i.id,
+      ),
+      ["n1"],
+    );
+    // Archived tab: closed setup chats stay invisible too.
+    deepStrictEqual(
+      selectArchived([setup, archivedSetup, normal, archivedNormal]).map(
+        (i) => i.id,
+      ),
+      ["n2"],
+    );
+  });
+
+  it("setup chats never count toward the needs-you badge", () => {
+    const agents = [{ id: "a", folderPath: "/w/a" }];
+    const summaries = buildAgentActivitySummaries(agents, [
+      {
+        agent_path: "/w/a",
+        type: "activity",
+        status: "needs_you",
+        agent: ROUTINE_SETUP_AGENT_MODE,
+      },
+      { agent_path: "/w/a", type: "activity", status: "needs_you" },
+    ]);
+    deepStrictEqual(summaries.a, { needsYouCount: 1, runningCount: 0 });
+  });
+
+  it("kickoff prompt covers the guided interview the issue asks for", () => {
+    // Load-bearing beats: the agent opens the conversation, asks exactly one
+    // question per ask_user call, covers the chat-mode and quiet-run choices,
+    // gates creation on approval, and never quizzes non-technical users
+    // about models or providers.
     for (const needle of [
+      "The user has not said anything yet",
+      "greeting the user",
+      "exactly ONE question at a time",
+      "never batch",
       "ask_user",
       "one ongoing chat",
       "fresh chat",
@@ -55,10 +101,5 @@ describe("routine chat setup message", () => {
         `prompt must mention: ${needle}`,
       );
     }
-  });
-
-  it("card labels never leak into the model prompt", () => {
-    // The prompt is a fixed constant; labels live only in the marker JSON.
-    ok(!ROUTINE_SETUP_PROMPT.includes(LABELS.description));
   });
 });

--- a/app/tests/routine-chat-setup.test.ts
+++ b/app/tests/routine-chat-setup.test.ts
@@ -1,0 +1,64 @@
+import { ok, strictEqual } from "node:assert/strict";
+import { describe, it } from "node:test";
+// Deep import: the @houston-ai/chat barrel drags in React components that
+// node:test cannot resolve; the decoder module itself is dependency-free.
+import { decodeSkillMessage } from "../../ui/chat/src/skill-message.ts";
+import {
+  encodeRoutineSetupMessage,
+  ROUTINE_SETUP_PROMPT,
+} from "../src/lib/routine-chat-setup.ts";
+
+// The "Create it in chat" first message must round-trip through the shared
+// skill-marker decoder: the renderer draws a friendly card from the marker
+// payload while the model reads only the kickoff prompt after it. If either
+// side drifts, non-technical users see raw interview instructions as their
+// own message.
+
+const LABELS = {
+  title: "Set up a routine",
+  description: "Your agent will ask a few questions and schedule it for you.",
+};
+
+describe("routine chat setup message", () => {
+  it("decodes as a skill-invocation card with the localized labels", () => {
+    const body = encodeRoutineSetupMessage(LABELS);
+    const invocation = decodeSkillMessage(body);
+    ok(invocation, "marker must decode");
+    strictEqual(invocation.displayName, LABELS.title);
+    strictEqual(invocation.description, LABELS.description);
+    // No composer text: the mission-card subtitle falls back to the
+    // description instead of leaking prompt internals.
+    strictEqual(invocation.message, "");
+    strictEqual(invocation.attachments.length, 0);
+  });
+
+  it("carries the kickoff prompt as the model-facing body", () => {
+    const body = encodeRoutineSetupMessage(LABELS);
+    ok(body.startsWith("<!--houston:skill "));
+    ok(body.endsWith(ROUTINE_SETUP_PROMPT));
+  });
+
+  it("kickoff prompt covers the interview the issue asks for", () => {
+    // Load-bearing beats: interview via ask_user, chat-mode choice, quiet
+    // runs, approval gate, and no model/provider questions for
+    // non-technical users.
+    for (const needle of [
+      "ask_user",
+      "one ongoing chat",
+      "fresh chat",
+      "needs their attention",
+      "approval",
+      "Do not ask about models, providers",
+    ]) {
+      ok(
+        ROUTINE_SETUP_PROMPT.includes(needle),
+        `prompt must mention: ${needle}`,
+      );
+    }
+  });
+
+  it("card labels never leak into the model prompt", () => {
+    // The prompt is a fixed constant; labels live only in the marker JSON.
+    ok(!ROUTINE_SETUP_PROMPT.includes(LABELS.description));
+  });
+});

--- a/packages/web/e2e/routine-setup-chat.spec.ts
+++ b/packages/web/e2e/routine-setup-chat.spec.ts
@@ -110,8 +110,14 @@ test("finished setup chat cleans itself up after the panel closes", async ({
   await expect(page.getByText(/Roger that\./)).toBeVisible({
     timeout: 15_000,
   });
+  // Wait for the turn to SETTLE (the composer's Stop flips back to Submit):
+  // self-archive only triggers on a "done" activity, and switching tabs
+  // mid-turn would race the settle's own status write.
+  await expect(
+    page.getByRole("button", { name: "Submit" }).first(),
+  ).toBeVisible({ timeout: 15_000 });
 
-  // The canned turn settles "done" with no pending interaction. Leaving the
+  // The canned turn settled "done" with no pending interaction. Leaving the
   // tab closes the panel; the finished chat archives itself — no banner, no
   // board card, nothing left behind.
   await page.locator('[data-tour-target="tab-activity"]').click();

--- a/packages/web/e2e/routine-setup-chat.spec.ts
+++ b/packages/web/e2e/routine-setup-chat.spec.ts
@@ -125,11 +125,10 @@ test("finished setup chat cleans itself up after the panel closes", async ({
   });
 
   // Drive the settled state deterministically: PATCH the setup activity to
-  // "done" through the fake host's REST (which emits ActivityChanged, so the
-  // app refetches). The archive-on-close logic under test only consumes the
-  // persisted status — waiting on the LIVE settle here made the test hostage
-  // to done-frame delivery on loaded CI machines, which chat.spec's
-  // reconnect coverage already owns.
+  // "done" through the fake host's REST. Waiting for the LIVE settle here
+  // made the test hostage to done-frame/event delivery on loaded CI
+  // machines — transport robustness is chat.spec's reconnect coverage, not
+  // this test's subject.
   const agents = (await (await fetch(`${FAKE_HOST_URL}/agents`)).json()) as {
     id: string;
   }[];
@@ -145,15 +144,17 @@ test("finished setup chat cleans itself up after the panel closes", async ({
     body: JSON.stringify({ status: "done" }),
   });
 
-  // A "done" setup chat cleans itself up once the panel closes. Leaving the
-  // tab closes the panel; the finished chat archives itself — no banner, no
-  // board card, nothing left behind.
-  await page.locator('[data-tour-target="tab-activity"]').click();
-  await expect(
-    page.getByText("Set up a new routine", { exact: true }),
-  ).not.toBeVisible();
+  // Fresh visit (the real user journey: finish the interview, come back
+  // later): the app boots on the "done" setup chat with its panel closed,
+  // and the self-cleanup archives it — no banner, no board card, nothing
+  // left behind.
+  await page.reload();
   await openRoutinesTab(page);
   await expect(
     page.getByText("You are creating a routine in chat"),
   ).toHaveCount(0);
+  await page.locator('[data-tour-target="tab-activity"]').click();
+  await expect(
+    page.getByText("Set up a new routine", { exact: true }),
+  ).not.toBeVisible();
 });

--- a/packages/web/e2e/routine-setup-chat.spec.ts
+++ b/packages/web/e2e/routine-setup-chat.spec.ts
@@ -117,25 +117,35 @@ test("mid-interview: no board card, tab switch leaves a Continue banner", async 
 test("finished setup chat cleans itself up after the panel closes", async ({
   page,
 }) => {
-  // Triple budget: this test depends on the turn's DONE frame landing, and on
-  // a loaded CI machine a connection blip can force the chat stream through a
-  // full drop + resync cycle before the settle arrives.
-  test.slow();
   await page.goto("/");
   await openRoutinesTab(page);
   await startSetupChat(page);
   await expect(page.getByText(/Roger that\./)).toBeVisible({
     timeout: 15_000,
   });
-  // Wait for the turn to SETTLE (the composer's Stop flips back to Submit):
-  // self-archive only triggers on a "done" activity, and switching tabs
-  // mid-turn would race the settle's own status write. Generous timeout for
-  // the drop + resync worst case.
-  await expect(
-    page.getByRole("button", { name: "Submit" }).first(),
-  ).toBeVisible({ timeout: 45_000 });
 
-  // The canned turn settled "done" with no pending interaction. Leaving the
+  // Drive the settled state deterministically: PATCH the setup activity to
+  // "done" through the fake host's REST (which emits ActivityChanged, so the
+  // app refetches). The archive-on-close logic under test only consumes the
+  // persisted status — waiting on the LIVE settle here made the test hostage
+  // to done-frame delivery on loaded CI machines, which chat.spec's
+  // reconnect coverage already owns.
+  const agents = (await (await fetch(`${FAKE_HOST_URL}/agents`)).json()) as {
+    id: string;
+  }[];
+  const agentId = agents[0].id;
+  const { items } = (await (
+    await fetch(`${FAKE_HOST_URL}/agents/${agentId}/activities`)
+  ).json()) as { items: { id: string; title: string }[] };
+  const setup = items.find((a) => a.title === "Set up a new routine");
+  expect(setup).toBeTruthy();
+  await fetch(`${FAKE_HOST_URL}/agents/${agentId}/activities/${setup?.id}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ status: "done" }),
+  });
+
+  // A "done" setup chat cleans itself up once the panel closes. Leaving the
   // tab closes the panel; the finished chat archives itself — no banner, no
   // board card, nothing left behind.
   await page.locator('[data-tour-target="tab-activity"]').click();

--- a/packages/web/e2e/routine-setup-chat.spec.ts
+++ b/packages/web/e2e/routine-setup-chat.spec.ts
@@ -82,6 +82,15 @@ test("mid-interview: no board card, tab switch leaves a Continue banner", async 
     timeout: 15_000,
   });
 
+  // The ask_user question card REPLACES the composer once the turn settles —
+  // this is the interview's whole interaction surface, so the setup panel
+  // must forward composerOverride like the board panel does.
+  await expect(page.getByText("What should the routine do?")).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole("radio")).toHaveCount(2);
+  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+
   // No VISIBLE card on the Activity board (the setup surface's own hidden
   // list still holds the item, so assert visibility, not count).
   await page.locator('[data-tour-target="tab-activity"]').click();

--- a/packages/web/e2e/routine-setup-chat.spec.ts
+++ b/packages/web/e2e/routine-setup-chat.spec.ts
@@ -1,0 +1,125 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * HOU-714: "New routine" → "Create it in chat". The guided setup chat opens
+ * as a panel owned by the Routines tab, the agent speaks first (the Houston-
+ * sent kickoff bubble never renders), and the chat never appears as a board
+ * card. Left mid-interview it leaves a Continue/Discard banner; finished, it
+ * cleans itself up.
+ */
+
+async function openRoutinesTab(page: import("@playwright/test").Page) {
+  await page.locator('[data-tour-target="tab-routines"]').click();
+  await expect(
+    page.getByRole("button", { name: "New routine" }).first(),
+  ).toBeVisible();
+}
+
+async function startSetupChat(page: import("@playwright/test").Page) {
+  await page.getByRole("button", { name: "New routine" }).first().click();
+  await page.getByRole("button", { name: "Create it in chat" }).click();
+}
+
+test("guided setup: the panel opens on the Routines tab and the agent speaks first", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await openRoutinesTab(page);
+  await startSetupChat(page);
+
+  // The panel opens on the Routines tab with the mission title, still on the
+  // Routines tab (no view switch).
+  const panelHeader = page.getByText("Mission: Set up a new routine");
+  await expect(panelHeader).toBeVisible({ timeout: 10_000 });
+  await expect(
+    page.getByRole("button", { name: "New routine" }).first(),
+  ).toBeVisible();
+
+  // The agent's reply is the FIRST visible message — the user typed nothing.
+  // (The fake host's canned reply echoes the kickoff prompt, so "no kickoff
+  // bubble" can't be asserted by text here — the unit test on
+  // filterAutoContinueFeedItems covers it.)
+  await expect(page.getByText(/Roger that\./)).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.screenshot({
+    path: test.info().outputPath("setup-chat-open.png"),
+  });
+});
+
+test("mid-interview: no board card, tab switch leaves a Continue banner", async ({
+  page,
+}) => {
+  // Arm the turn to settle on an ask_user interaction — mid-interview state.
+  await fetch(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      interaction: {
+        steps: [
+          {
+            kind: "question",
+            id: "q1",
+            question: "What should the routine do?",
+            options: [
+              { id: "email", label: "Check my email" },
+              { id: "brief", label: "Morning brief" },
+            ],
+          },
+        ],
+      },
+    }),
+  });
+
+  await page.goto("/");
+  await openRoutinesTab(page);
+  await startSetupChat(page);
+  await expect(page.getByText("Mission: Set up a new routine")).toBeVisible({
+    timeout: 10_000,
+  });
+  await expect(page.getByText(/Roger that\./)).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // No VISIBLE card on the Activity board (the setup surface's own hidden
+  // list still holds the item, so assert visibility, not count).
+  await page.locator('[data-tour-target="tab-activity"]').click();
+  await expect(
+    page.getByText("Set up a new routine", { exact: true }),
+  ).not.toBeVisible();
+
+  // Back on Routines: the tab switch auto-closed the panel, and the
+  // needs-you setup chat surfaces as the Continue/Discard banner.
+  await openRoutinesTab(page);
+  await expect(
+    page.getByText("You are creating a routine in chat"),
+  ).toBeVisible();
+
+  // Continue reopens the same chat (no duplicate mission created).
+  await page.getByRole("button", { name: "Continue" }).click();
+  await expect(page.getByText("Mission: Set up a new routine")).toBeVisible();
+});
+
+test("finished setup chat cleans itself up after the panel closes", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await openRoutinesTab(page);
+  await startSetupChat(page);
+  await expect(page.getByText(/Roger that\./)).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // The canned turn settles "done" with no pending interaction. Leaving the
+  // tab closes the panel; the finished chat archives itself — no banner, no
+  // board card, nothing left behind.
+  await page.locator('[data-tour-target="tab-activity"]').click();
+  await expect(
+    page.getByText("Set up a new routine", { exact: true }),
+  ).not.toBeVisible();
+  await openRoutinesTab(page);
+  await expect(
+    page.getByText("You are creating a routine in chat"),
+  ).toHaveCount(0);
+});

--- a/packages/web/e2e/routine-setup-chat.spec.ts
+++ b/packages/web/e2e/routine-setup-chat.spec.ts
@@ -51,6 +51,9 @@ test("guided setup: the panel opens on the Routines tab and the agent speaks fir
 test("mid-interview: no board card, tab switch leaves a Continue banner", async ({
   page,
 }) => {
+  // Settle-dependent (the interaction rides the DONE frame): triple budget
+  // for a CI drop + resync cycle, same as the cleanup test below.
+  test.slow();
   // Arm the turn to settle on an ask_user interaction — mid-interview state.
   await fetch(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
     method: "POST",
@@ -84,9 +87,10 @@ test("mid-interview: no board card, tab switch leaves a Continue banner", async 
 
   // The ask_user question card REPLACES the composer once the turn settles —
   // this is the interview's whole interaction surface, so the setup panel
-  // must forward composerOverride like the board panel does.
+  // must forward composerOverride like the board panel does. Settle-dependent,
+  // so generous for a CI drop + resync cycle.
   await expect(page.getByText("What should the routine do?")).toBeVisible({
-    timeout: 15_000,
+    timeout: 45_000,
   });
   await expect(page.getByRole("radio")).toHaveCount(2);
   await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
@@ -113,6 +117,10 @@ test("mid-interview: no board card, tab switch leaves a Continue banner", async 
 test("finished setup chat cleans itself up after the panel closes", async ({
   page,
 }) => {
+  // Triple budget: this test depends on the turn's DONE frame landing, and on
+  // a loaded CI machine a connection blip can force the chat stream through a
+  // full drop + resync cycle before the settle arrives.
+  test.slow();
   await page.goto("/");
   await openRoutinesTab(page);
   await startSetupChat(page);
@@ -121,10 +129,11 @@ test("finished setup chat cleans itself up after the panel closes", async ({
   });
   // Wait for the turn to SETTLE (the composer's Stop flips back to Submit):
   // self-archive only triggers on a "done" activity, and switching tabs
-  // mid-turn would race the settle's own status write.
+  // mid-turn would race the settle's own status write. Generous timeout for
+  // the drop + resync worst case.
   await expect(
     page.getByRole("button", { name: "Submit" }).first(),
-  ).toBeVisible({ timeout: 15_000 });
+  ).toBeVisible({ timeout: 45_000 });
 
   // The canned turn settled "done" with no pending interaction. Leaving the
   // tab closes the panel; the finished chat archives itself — no banner, no

--- a/packages/web/e2e/server-events.spec.ts
+++ b/packages/web/e2e/server-events.spec.ts
@@ -1,0 +1,40 @@
+import { SEED_AGENT_ID } from "@houston/fake-host";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * The host's global reactivity stream (`/v1/events`) must actually reach the
+ * app: a server-side domain event has to invalidate the matching query and
+ * trigger a refetch. Regression guard for the unbound-fetch "Illegal
+ * invocation" bug that silently killed the whole stream in browsers — every
+ * unit test passed (Node's fetch is receiver-agnostic) while no server event
+ * ever reached a real client, so agent-written routines/skills/files never
+ * refreshed without a remount.
+ */
+test("a server-emitted domain event triggers a client refetch", async ({
+  page,
+  emitHostEvent,
+}) => {
+  let routineFetches = 0;
+  page.on("request", (req) => {
+    if (req.method() === "GET" && req.url().includes("/routines"))
+      routineFetches += 1;
+  });
+
+  await page.goto("/");
+  await page.locator('[data-tour-target="tab-routines"]').click();
+  await expect(
+    page.getByRole("button", { name: "New routine" }).first(),
+  ).toBeVisible();
+
+  // Let the mount-time fetches settle, then take the baseline.
+  await page.waitForTimeout(500);
+  const baseline = routineFetches;
+
+  // A host-side change (e.g. the agent writing routines.json caught by the
+  // host's watcher) emits RoutinesChanged on /v1/events → the app must
+  // refetch the routines query without any navigation.
+  await emitHostEvent("RoutinesChanged", SEED_AGENT_ID);
+  await expect
+    .poll(() => routineFetches, { timeout: 10_000 })
+    .toBeGreaterThan(baseline);
+});

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -608,17 +608,33 @@ export class HoustonClient {
       emitLocalEcho("ActivityChanged", { agentPath });
       return;
     }
-    const list = await controlPlane.listActivities(this.cp, agentPath);
-    const match = list.find(
-      (a) => a.session_key === sessionKey || `activity-${a.id}` === sessionKey,
-    );
-    if (!match) return; // transient session with no board card — nothing to update
-    // `pending_interaction: null` clears it explicitly (the host route +
-    // domain applyActivityUpdate honor null); a value records the interaction.
-    await controlPlane.updateActivity(this.cp, agentPath, match.id, {
-      status,
-      pending_interaction: pendingInteraction,
-    });
+    // This write MUST land: the turn flipped its card to "running", and a
+    // turn guarantees a terminal status on exit — a lost settle write leaves
+    // the mission visibly stuck on "running" forever. The PATCH is idempotent
+    // (fixed status + interaction), so retrying a network blip or proxy
+    // hiccup is safe. cpFetch deliberately never blind-retries writes; this
+    // caller knows its write is replay-safe.
+    const retryDelaysMs = [500, 1500, 3000];
+    for (let i = 0; ; i++) {
+      try {
+        const list = await controlPlane.listActivities(this.cp, agentPath);
+        const match = list.find(
+          (a) =>
+            a.session_key === sessionKey || `activity-${a.id}` === sessionKey,
+        );
+        if (!match) return; // transient session with no board card — nothing to update
+        // `pending_interaction: null` clears it explicitly (the host route +
+        // domain applyActivityUpdate honor null); a value records the interaction.
+        await controlPlane.updateActivity(this.cp, agentPath, match.id, {
+          status,
+          pending_interaction: pendingInteraction,
+        });
+        break;
+      } catch (err) {
+        if (i >= retryDelaysMs.length) throw err;
+        await new Promise((r) => setTimeout(r, retryDelaysMs[i]));
+      }
+    }
     emitLocalEcho("ActivityChanged", { agentPath });
   }
 

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -952,11 +952,20 @@ export function subscribeEvents(
   void streamGlobalEvents({
     url: () =>
       `${cfg.baseUrl}/v1/events?token=${encodeURIComponent(liveToken(cfg.token))}`,
-    fetch,
+    // Wrapped, never the bare reference: streamGlobalEvents calls
+    // `opts.fetch(...)`, and a browser's window.fetch invoked with a foreign
+    // receiver throws "Illegal invocation" BEFORE any request goes out — the
+    // stream then silently retry-looped forever and no server event ever
+    // reached the app (agent-written routines/skills/files never refreshed).
+    // Node's fetch is receiver-agnostic, so unit tests never caught it.
+    fetch: (input, init) => fetch(input, init),
     signal: ac.signal,
     onUnauthorized: () => {
       void refreshLiveToken();
     },
+    // Log-only (no toast): a background stream that auto-reconnects — but it
+    // must never fail silently again.
+    onError: (err) => console.warn("[events] global stream error:", err),
     onEvent: (data) =>
       onEvent(
         toInvalidationEvent(

--- a/ui/chat/src/ai-elements/conversation.tsx
+++ b/ui/chat/src/ai-elements/conversation.tsx
@@ -4,7 +4,7 @@ import { Button, cn } from "@houston-ai/core";
 import type { UIMessage } from "ai";
 import { ArrowDownIcon, DownloadIcon } from "lucide-react";
 import type { ComponentProps } from "react";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
@@ -18,17 +18,7 @@ export const Conversation = ({ className, ...props }: ConversationProps) => (
     // keep role="log" + tabIndex={-1} on the outer so the app shell
     // can focus it on Escape; the programmatic chat-scroll lives in
     // use-keyboard-shortcuts and targets the inner pane by class.
-    //
-    // The top mask fades scrolled-out content over the first 16px (the
-    // content pane's own top padding) so a streaming line dissolves as it
-    // leaves the viewport instead of hard-clipping mid-glyph against the
-    // panel header's border. An alpha mask, so it holds in both themes.
-    className={cn(
-      "relative flex-1 outline-none",
-      "[-webkit-mask-image:linear-gradient(to_bottom,transparent,black_16px)]",
-      "[mask-image:linear-gradient(to_bottom,transparent,black_16px)]",
-      className,
-    )}
+    className={cn("relative flex-1 outline-none", className)}
     initial="smooth"
     resize="smooth"
     role="log"
@@ -90,6 +80,42 @@ export const ConversationEmptyState = ({
     )}
   </div>
 );
+
+/**
+ * Top scroll fade: a background-colored gradient pinned under the panel
+ * header, visible ONLY while content is scrolled — a streaming line then
+ * dissolves as it leaves the viewport instead of hard-clipping mid-glyph
+ * against the header's border. At rest (nothing scrolled out) it is fully
+ * transparent, so the first message never renders washed out. Mount inside
+ * a <Conversation>.
+ */
+export const ConversationTopFade = () => {
+  const { scrollRef } = useStickToBottomContext();
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    // Programmatic scrolls (the stick-to-bottom spring) fire scroll events
+    // too, so one listener covers user and auto scrolling alike.
+    const onScroll = () => setScrolled(el.scrollTop > 0);
+    onScroll();
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [scrollRef]);
+
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        "pointer-events-none absolute inset-x-0 top-0 z-10 h-8",
+        "bg-gradient-to-b from-background to-transparent",
+        "transition-opacity duration-150",
+        scrolled ? "opacity-100" : "opacity-0",
+      )}
+    />
+  );
+};
 
 export type ConversationScrollButtonProps = ComponentProps<typeof Button>;
 

--- a/ui/chat/src/ai-elements/conversation.tsx
+++ b/ui/chat/src/ai-elements/conversation.tsx
@@ -18,7 +18,17 @@ export const Conversation = ({ className, ...props }: ConversationProps) => (
     // keep role="log" + tabIndex={-1} on the outer so the app shell
     // can focus it on Escape; the programmatic chat-scroll lives in
     // use-keyboard-shortcuts and targets the inner pane by class.
-    className={cn("relative flex-1 outline-none", className)}
+    //
+    // The top mask fades scrolled-out content over the first 16px (the
+    // content pane's own top padding) so a streaming line dissolves as it
+    // leaves the viewport instead of hard-clipping mid-glyph against the
+    // panel header's border. An alpha mask, so it holds in both themes.
+    className={cn(
+      "relative flex-1 outline-none",
+      "[-webkit-mask-image:linear-gradient(to_bottom,transparent,black_16px)]",
+      "[mask-image:linear-gradient(to_bottom,transparent,black_16px)]",
+      className,
+    )}
     initial="smooth"
     resize="smooth"
     role="log"

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -11,6 +11,7 @@ import {
   ConversationAutoScroll,
   ConversationContent,
   ConversationScrollButton,
+  ConversationTopFade,
 } from "./ai-elements/conversation";
 import type { RenderLinkProps } from "./ai-elements/message";
 import {
@@ -133,6 +134,7 @@ export function ChatMessages({
   return (
     <Conversation className="flex-1 min-h-0">
       <ConversationAutoScroll status={status} />
+      <ConversationTopFade />
       <ConversationContent className="max-w-3xl mx-auto">
         {displayItems.map((item) => {
           if (item.kind === "process") {


### PR DESCRIPTION
## Summary

HOU-714. "New routine" (Routines tab, header button + empty-state CTA) now opens a chooser with two options:

- **Create it in chat** (new): a guided chat where the agent interviews the user and schedules the routine for them.
- **Fill in the details myself**: the existing `RoutineEditor` form, unchanged.

## How the chat path works

- **The agent speaks first, and always with a question.** The Houston-sent kickoff rides the auto-continue marker (hidden from the transcript live and on reload), so the conversation opens with the agent. The kickoff scripts the first turn exactly: one short friendly line, then an `ask_user` call **in the same turn** with 3-4 concrete example options for what the routine could do ("Watch my inbox for anything urgent", "Send me a morning summary", ...). "A turn that ends without an ask_user call is a mistake" until the routine is created — this holds up on small models that previously greeted and stopped. A one-line greeting plus a question card also can't scroll, so the long-first-reply case where streaming text slid under the panel header is gone.
- **One question at a time.** Exactly one `ask_user` question per turn (explicitly overriding the product prompt's batch-up-to-3 rule for this conversation), answer options wherever possible, skip anything already answered. Covers: what the routine does, when it runs, which connected apps, one ongoing chat vs a fresh chat per run, quiet-run behavior. The agent proposes the name/description itself, never asks about models/providers (the routine inherits the agent's settings), and only creates after an explicit Yes.
- **No board card.** The setup chat is a real mission under the hood, but its activity carries a reserved agent-mode sentinel (`houston:routine-setup`) that every mission surface filters: the agent board, the Archived tab, Mission Control (active + archived), the command palette's recent missions, the sidebar needs-you badges, and the tab-bar badge. No schema change — the sentinel reuses the existing `agent` field, which already flows through the conversation adapters (HOU-665).
- **Its home is the Routines tab.** A hidden `AIBoard` (the Archived-tab pattern) portals the chat panel into the shared right-side container, so the user chats next to the routines grid and watches the new routine appear live (`RoutinesChanged` reactivity — no backend changes). A banner offers **Continue** / **Discard** if a setup chat is left mid-way; a chat that settled "done" with its panel closed archives itself and disappears for good. OS-notification clicks route to the Routines tab instead of the board. At most one live setup chat per agent — starting again resumes it.

## Changes

- `app/src/lib/routine-chat-setup.ts` — kickoff prompt (first-turn script, one-question interview), auto-continue encoding, `ROUTINE_SETUP_AGENT_MODE` sentinel + predicate.
- `app/src/components/tabs/routine-create-choice-dialog.tsx` — the chooser (SkillCard option cards).
- `app/src/components/tabs/use-routine-chat-setup.ts` — create-or-resume, panel open, error toast.
- `app/src/components/tabs/routine-setup-chat.tsx` — the setup chat surface (hidden AIBoard + portaled panel + banner + self-archive).
- Filters: `mission-selection.ts`, `use-mission-control.ts`, `use-mission-control-archived.ts`, `command-palette.tsx`, `agent-activity-summary-model.ts`, `workspace-shell.tsx`.
- `session-notifications.ts` — setup chats navigate to the Routines tab.
- `stores/ui.ts` — agent-scoped `routineSetupChatAgentId`.
- i18n: `createChoice.*` + `setupChat.*` + `toasts.chatSetupError` in en/es/pt.
- Analytics: `routine_chat_setup_started`.
- Unit tests: `app/tests/routine-chat-setup.test.ts` — auto-continue round-trip (kickoff bubble filtered), first-turn-script + interview prompt coverage, board/badge exclusion via `selectActive`/`selectArchived`/`buildAgentActivitySummaries`.
- **Playwright e2e** (`packages/web/e2e/routine-setup-chat.spec.ts`, fake host): panel opens on the Routines tab with the agent speaking first; no visible board card; mid-interview tab switch leaves the Continue/Discard banner and Continue resumes the same chat; a finished setup chat cleans itself up.

## Before (reproduction of the gap)

1. Open an agent → Routines tab → click **New routine**.
2. The form editor opens immediately; there is no guided/chat option. A non-technical user must hand-fill name, prompt, cron schedule, and behavior toggles.

## After (verification)

1. Routines tab → **New routine** → a dialog offers **Create it in chat** and **Fill in the details myself**.
2. **Fill in the details myself** → the existing editor opens exactly as before.
3. **Create it in chat** → a chat panel opens on the right of the Routines tab; the agent greets you in one line and immediately shows a question card with example options (you never see a sent "user" message, and nothing renders under the panel header). Each answer produces exactly one follow-up question.
4. Switch to the Activity tab and Mission Control: **no card** for the setup chat; the sidebar/tab needs-you badges don't count it.
5. Close the panel mid-interview → a "You are creating a routine in chat" banner appears above the grid with Continue/Discard; **New routine → Create it in chat** also resumes the same chat.
6. Finish the interview, approve with Yes → the agent schedules the routine; the grid updates in place without a refresh. Close the panel → the setup chat disappears everywhere (self-archived).
7. Locale check: repeat step 1 in es/pt; the chooser and banner render translated.

Gates: `pnpm check`, app tests (952 pass), **Playwright e2e (36 pass, 3 new)**, `pnpm tsgo --noEmit` (app + workspace), `pnpm check-locales`, `pnpm check:boundaries`, `pnpm --filter houston-web typecheck` + `typecheck:e2e` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)