### PR TITLE
feat: Doer/Planner mode personas + selector design pass

### DIFF
--- a/app/src/components/chat-mode-selector.tsx
+++ b/app/src/components/chat-mode-selector.tsx
@@ -6,7 +6,7 @@ import {
 } from "@houston-ai/core";
 import type { Agent } from "@houston-ai/engine-client";
 import type { LucideIcon } from "lucide-react";
-import { Check, ChevronDown, ClipboardList, MessageSquare } from "lucide-react";
+import { Check, ChevronDown, NotebookPen, Zap } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../hooks/use-capabilities";
 import { modelSelectorDecision } from "../lib/model-selector-lock";
@@ -27,20 +27,23 @@ interface ChatModeSelectorProps {
   agent?: Pick<Agent, "access"> | null;
 }
 
+/** Doer = execute (acts on the world), Planner = plan (read-only, writes a
+ *  plan). Wire values stay `execute`/`plan`; only the persona labels change. */
 const MODE_ICONS: Record<TurnMode, LucideIcon> = {
-  execute: MessageSquare,
-  plan: ClipboardList,
+  execute: Zap,
+  plan: NotebookPen,
 };
 
 const MODE_ORDER: readonly TurnMode[] = ["execute", "plan"];
 
 /**
- * "Mode" dropdown, rendered beside {@link ChatModelSelector} in the composer.
- * Two entries — Chat (execute) and Plan (read-only planning) — each with an
- * icon and a one-line description. The trigger pill shows the active mode's
- * icon + label so the row reads at a glance. Hidden only for a member on a
- * pre-Teams multiplayer host (mirrors the model + effort selectors); otherwise
- * always available.
+ * "Mode" picker, rendered beside {@link ChatModelSelector} in the composer.
+ * Two personas — Doer (execute) and Planner (read-only planning) — each with an
+ * icon in a soft tile, a name, and a one-line description. The trigger is the
+ * same h-7 muted pill as the model + effort selectors; the menu matches the
+ * model picker's card (rounded-2xl, bordered, shadowed, roomy rows). Hidden only
+ * for a member on a pre-Teams multiplayer host (mirrors the other selectors);
+ * otherwise always available.
  */
 export function ChatModeSelector({
   mode,
@@ -52,12 +55,12 @@ export function ChatModeSelector({
   if (!modelSelectorDecision(capabilities, agent).show) return null;
 
   const labels: Record<TurnMode, string> = {
-    execute: t("modeSelector.chat"),
-    plan: t("modeSelector.plan"),
+    execute: t("modeSelector.doer"),
+    plan: t("modeSelector.planner"),
   };
   const descriptions: Record<TurnMode, string> = {
-    execute: t("modeSelector.chatDescription"),
-    plan: t("modeSelector.planDescription"),
+    execute: t("modeSelector.doerDescription"),
+    plan: t("modeSelector.plannerDescription"),
   };
 
   const ActiveIcon = MODE_ICONS[mode];
@@ -84,9 +87,12 @@ export function ChatModeSelector({
             <ChevronDown className="size-3 opacity-60" />
           </button>
         </DropdownMenuTrigger>
+        {/* Match the model picker card: rounded-2xl, hairline border, soft
+            shadow, roomy 1.5 padding — not the default menu slab. */}
         <DropdownMenuContent
           align="start"
-          className="w-[300px]"
+          sideOffset={6}
+          className="w-[300px] rounded-2xl border-border p-1.5 shadow-lg"
           onCloseAutoFocus={(e) => e.preventDefault()}
         >
           {MODE_ORDER.map((m) => {
@@ -96,18 +102,22 @@ export function ChatModeSelector({
               <DropdownMenuItem
                 key={m}
                 onSelect={() => onSelect(m)}
-                className="items-start gap-2.5 py-2"
+                className="items-start gap-3 rounded-xl px-2.5 py-2.5"
               >
-                <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
-                <div className="flex min-w-0 flex-col gap-0.5">
-                  <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+                <span className="mt-px flex size-8 shrink-0 items-center justify-center rounded-lg bg-secondary text-foreground">
+                  <Icon className="size-4 text-foreground" />
+                </span>
+                <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                  <span className="text-sm font-medium text-foreground">
                     {labels[m]}
-                    {active && <Check className="size-3.5 text-primary" />}
                   </span>
-                  <span className="text-xs text-muted-foreground">
+                  <span className="line-clamp-2 text-xs text-muted-foreground">
                     {descriptions[m]}
                   </span>
                 </div>
+                {active && (
+                  <Check className="mt-1 size-4 shrink-0 text-foreground" />
+                )}
               </DropdownMenuItem>
             );
           })}

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -88,10 +88,10 @@
   "modeSelector": {
     "mode": "Mode",
     "modeValue": "Mode: {{mode}}",
-    "chat": "Chat",
-    "chatDescription": "Houston can read, act, and make changes.",
-    "plan": "Plan",
-    "planDescription": "Houston only looks and writes up a plan for you to approve. It won't make changes or use your apps."
+    "doer": "Doer",
+    "doerDescription": "Gets things done: reads, acts, and makes changes.",
+    "planner": "Planner",
+    "plannerDescription": "Writes a plan for you to approve first. Makes no changes."
   },
   "modelSelector": {
     "selectModel": "Select model",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -88,10 +88,10 @@
   "modeSelector": {
     "mode": "Modo",
     "modeValue": "Modo: {{mode}}",
-    "chat": "Chat",
-    "chatDescription": "Houston puede leer, actuar y hacer cambios.",
-    "plan": "Plan",
-    "planDescription": "Houston solo mira y escribe un plan para que lo apruebes. No hará cambios ni usará tus aplicaciones."
+    "doer": "Ejecutor",
+    "doerDescription": "Hace las cosas: lee, actúa y realiza cambios.",
+    "planner": "Planificador",
+    "plannerDescription": "Primero escribe un plan para que lo apruebes. No hace cambios."
   },
   "modelSelector": {
     "selectModel": "Elige un modelo",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -88,10 +88,10 @@
   "modeSelector": {
     "mode": "Modo",
     "modeValue": "Modo: {{mode}}",
-    "chat": "Chat",
-    "chatDescription": "O Houston pode ler, agir e fazer alterações.",
-    "plan": "Plano",
-    "planDescription": "O Houston apenas observa e escreve um plano para você aprovar. Ele não fará alterações nem usará seus aplicativos."
+    "doer": "Executor",
+    "doerDescription": "Faz as coisas: lê, age e faz alterações.",
+    "planner": "Planejador",
+    "plannerDescription": "Primeiro escreve um plano para você aprovar. Não faz alterações."
   },
   "modelSelector": {
     "selectModel": "Escolha um modelo",

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -531,7 +531,8 @@ the real vendored pi-ai registry, not a test fixture).
 ### Turn mode
 
 A separate per-turn "Mode" pill sits next to the model + effort controls in
-the composer footer (`execute` vs `plan`, read-only investigation). Unlike
+the composer footer, labeled **Doer** (`execute`) vs **Planner** (`plan`,
+read-only investigation). Unlike
 effort it is NOT synced through `Settings` — full mechanics, the runtime
 enforcement (tool clamp + planning overlay), and the "forgotten `modeOverride`
 silently degrades to execute" gotcha are in `knowledge-base/architecture.md`

--- a/knowledge-base/architecture.md
+++ b/knowledge-base/architecture.md
@@ -204,7 +204,9 @@ backend keeps its SDK `permissionMode` default and simply gets no integration
 tools, so plan mode still holds.
 
 App side: a Mode pill in the composer footer
-(`app/src/components/chat-mode-selector.tsx`), remembered per-agent as `mode`
+(`app/src/components/chat-mode-selector.tsx`) — persona labels **Doer**
+(`execute`) and **Planner** (`plan`), the wire values are unchanged — remembered
+per-agent as `mode`
 in `.houston/config/config.json` (composer memory only — never synced to
 engine `Settings`). Every user-typed send forwards the pin explicitly as
 `modeOverride`.


### PR DESCRIPTION
## What

Follow-up polish on the chat Mode selector (#744):

- **Person-like names**: the modes now describe how the agent behaves — **Doer** (execute) and **Planner** (plan). es Ejecutor/Planificador, pt Executor/Planejador. Wire values `execute`/`plan` and the config contract are untouched; locale keys renamed to match (`doer`/`planner`).
- **Design pass**: the menu now reads as part of the composer picker family — trigger pill byte-identical to the model/effort pills; menu card matches the model picker's rounded-2xl border/shadow language; rows with a soft icon tile (Zap / NotebookPen), name, two-line description, right-aligned check on the active row. Radix DropdownMenu keyboard a11y preserved. Copy trimmed to fit the two-line clamp in all three languages.

Screenshot-verified against the sibling pickers via the Playwright fake-host harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)