### PR TITLE
fix(app): agent icon running spinner is a thin orbit line, not a radar sweep (HOU-720)

### DIFF
--- a/app/src/components/shell/agent-sidebar-status.tsx
+++ b/app/src/components/shell/agent-sidebar-status.tsx
@@ -1,5 +1,4 @@
 import { Badge, cn, HoustonAvatar, resolveAgentColor } from "@houston-ai/core";
-import type { CSSProperties } from "react";
 
 interface AgentSidebarIconProps {
   color?: string;
@@ -22,9 +21,8 @@ export function AgentSidebarIcon({
     <span
       className={cn(
         "size-6 shrink-0 rounded-full flex items-center justify-center",
-        "card-running-glow",
+        "avatar-running-ring",
       )}
-      style={{ "--glow-bg": "var(--color-sidebar)" } as CSSProperties}
       title={runningLabel}
     >
       {avatar}

--- a/ui/core/src/components/houston-avatar.tsx
+++ b/ui/core/src/components/houston-avatar.tsx
@@ -1,6 +1,6 @@
 /**
  * HoustonAvatar — the colored Houston helmet glyph, optionally wrapped in
- * the "card-running-glow" comet halo when an agent is actively working.
+ * the "avatar-running-ring" comet halo when an agent is actively working.
  *
  * This is the single source of truth for rendering an agent's avatar
  * across every Houston surface (desktop, mobile, any third-party
@@ -8,12 +8,11 @@
  * `mobile/` duplicated the SVG path data + the running-glow wrapper;
  * every tweak had to be done twice. Not anymore.
  *
- * Pair `running` with the `.card-running-glow` rule shipped from
+ * Pair `running` with the `.avatar-running-ring` rule shipped from
  * `globals.css` so the halo animation stays in lockstep with the
  * kanban card / detail panel variants. If your app doesn't import the
  * core globals, the avatar still renders — the halo is just inert.
  */
-import type { CSSProperties } from "react";
 import { cn } from "../utils";
 
 const HOUSTON_GRAY = "#9b9b9b";
@@ -65,7 +64,7 @@ interface HoustonAvatarProps {
   /** Outer circle diameter in pixels. Helmet sizes itself to ~65% of
    *  this to match the existing desktop look. */
   diameter?: number;
-  /** When true, wraps the badge in a `.card-running-glow` halo — the
+  /** When true, wraps the badge in a `.avatar-running-ring` halo — the
    *  same comet-trail effect the desktop uses on kanban cards and the
    *  chat panel header when a session is mid-flight. */
   running?: boolean;
@@ -101,14 +100,8 @@ export function HoustonAvatar({
   if (!running) return inner;
   return (
     <span
-      className="shrink-0 rounded-full flex items-center justify-center card-running-glow"
-      style={
-        {
-          width: diameter,
-          height: diameter,
-          "--glow-bg": "var(--color-background, #ffffff)",
-        } as CSSProperties
-      }
+      className="shrink-0 rounded-full flex items-center justify-center avatar-running-ring"
+      style={{ width: diameter, height: diameter }}
     >
       {inner}
     </span>

--- a/ui/core/src/globals.css
+++ b/ui/core/src/globals.css
@@ -150,6 +150,44 @@ body {
   animation: glow-spin 2.5s linear infinite;
 }
 
+/* Same comet trace as .card-running-glow, but masked to the ring only.
+ * .card-running-glow hides the conic's interior behind an opaque
+ * --glow-bg fill, so on a transparent/translucent surface (the glass
+ * sidebar) the sweep leaks into the middle and reads as a radar dish.
+ * This variant needs no backdrop: the mask keeps just the 1.5px line. */
+.avatar-running-ring {
+  --glow-angle: 0deg;
+  position: relative;
+}
+
+.avatar-running-ring::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1.5px;
+  background: conic-gradient(
+    from var(--glow-angle),
+    transparent 60%,
+    rgba(59, 130, 246, 0.15) 68%,
+    #3b82f6 74%,
+    #818cf8 78%,
+    #f97316 82%,
+    #fbbf24 84%,
+    transparent 88%
+  );
+  -webkit-mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  -webkit-mask-composite: xor;
+  mask:
+    linear-gradient(#000 0 0) content-box,
+    linear-gradient(#000 0 0);
+  mask-composite: exclude;
+  animation: glow-spin 2.5s linear infinite;
+  pointer-events: none;
+}
+
 
 /* Typing dots — WhatsApp-style "•••" bouncing while an agent is
  * working. Apply `.typing-dot` to three sibling elements; the


### PR DESCRIPTION
## Summary

Fixes HOU-720.

**Root cause:** the sidebar agent icon (`AgentSidebarIcon`) reused `.card-running-glow`, which paints the animated conic gradient across the whole border-box and relies on an opaque `--glow-bg` layer (`padding-box`) to hide everything except the 1.5px border. The icon passed `--glow-bg: var(--color-sidebar)`, but the sidebar surface token is **transparent** (the sidebar melts into the window background), so the mask hid nothing and the rainbow sweep filled the entire avatar circle like a radar dish. Mission cards look correct only because their `--glow-bg` is opaque.

**Fix:** a new `.avatar-running-ring` class in `ui/core/src/globals.css` paints the same comet gradient on an `::before` overlay masked to just the ring (`mask-composite: exclude` + `-webkit-mask-composite: xor`), so it stays a thin orbiting line over any backdrop — transparent, glass, or opaque. The sidebar icon and `HoustonAvatar`'s `running` halo (warming dialog, provisioning card, chat panel header) now use it. Kanban/mission cards keep `.card-running-glow` unchanged.

## Before / after verification

**Reproduce the bug (before):** run the app, start a chat so an agent session is mid-flight, and look at that agent's icon in the sidebar "Your Agents" list — the avatar is covered by a rotating rainbow sweep filling the whole circle.

**Verify the fix (after):** same steps — the busy agent's icon now shows only a thin comet line orbiting the avatar's edge, matching the running mission-card border. Also check the agent-warming dialog and provisioning card spinners still render as rings, and running mission cards are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)