### PR TITLE
feat(app): auto-continue the conversation after a provider reconnect (HOU-718)

### DIFF
--- a/app/src/components/shell/provider-error-cards/auth-presentation.ts
+++ b/app/src/components/shell/provider-error-cards/auth-presentation.ts
@@ -33,7 +33,7 @@ export function authCauseBodyKey(cause: UnauthCause): string {
 }
 
 /** The action a button fires. A `badge` button is a disabled status pill. */
-export type AuthCardAction = "reconnect" | "cancel" | "sendAgain";
+export type AuthCardAction = "reconnect" | "cancel";
 
 export type AuthCardButton =
   | { kind: "action"; labelKey: string; action: AuthCardAction }
@@ -51,10 +51,10 @@ export interface AuthCardPresentation {
 /**
  * Resolve the card's title/body/button from its phase.
  *
- * - `done` + a refused send (`hasFailedPrompt`): the resend already fired, so
- *   the pill is a disabled "Signed in" badge.
- * - `done`, mid-turn failure: an explicit "Send my message" button (only when
- *   the card can resend — `hasRetry`).
+ * - `done` with a retry handler: the resume already auto-fired, so the pill
+ *   is a disabled "Signed in" badge. The body says what resumed: the refused
+ *   send's message (`hasFailedPrompt`) or the interrupted task.
+ * - `done` without a retry handler: nothing to resume — plain confirmation.
  * - `waiting`: the wait is on the user's browser, so the action is Cancel.
  * - `failed` / `idle`: the Reconnect button relaunches sign-in.
  */
@@ -75,13 +75,19 @@ export function resolveAuthCardPresentation(args: {
         button: { kind: "badge", labelKey: `${K}.signedIn` },
       };
     }
+    if (hasRetry) {
+      return {
+        variant: "done",
+        titleKey: `${K}.reconnectedTitle`,
+        bodyKey: `${K}.reconnectedResuming`,
+        button: { kind: "badge", labelKey: `${K}.signedIn` },
+      };
+    }
     return {
       variant: "done",
       titleKey: `${K}.reconnectedTitle`,
       bodyKey: `${K}.reconnectedBody`,
-      button: hasRetry
-        ? { kind: "action", labelKey: `${K}.sendAgain`, action: "sendAgain" }
-        : null,
+      button: null,
     };
   }
 

--- a/app/src/components/shell/provider-error-cards/auth.tsx
+++ b/app/src/components/shell/provider-error-cards/auth.tsx
@@ -11,10 +11,12 @@
  * that frees the login slot and re-arms) until that event flips it to a green
  * confirmation, the failure, or a benign cancel.
  *
- * The confirmation depends on what failed. A refused SEND (`failed_prompt`: the
- * message never reached the engine) resends once — signing in IS the remaining
- * intent — then shows a disabled "Signed in" badge. A mid-turn failure keeps an
- * explicit resend CTA (that turn already has server-side context).
+ * Signing in IS the remaining intent, so a successful reconnect resumes the
+ * conversation automatically (once), then shows a disabled "Signed in" badge.
+ * What gets sent depends on what failed: a refused SEND (`failed_prompt`: the
+ * message never reached the engine) resends the original prompt; a mid-turn
+ * failure sends a hidden auto-continue nudge (that turn already has
+ * server-side context) — the split lives in the panel's `onRetry`.
  *
  * Every launch is cancelLogin -> launchLogin: the engine keeps one login slot
  * per provider and rejects a second launch as "already pending", so a relaunch
@@ -60,9 +62,6 @@ export function UnauthenticatedCard({
   // complete several logins while the chat stays open) would double-send.
   const autoResendFiredRef = useRef(false);
   const provider = providerLabel(error.provider);
-  // A refused SEND (see header): reconnect auto-resends; mid-turn failures keep
-  // the explicit CTA.
-  const autoResend = !!error.failed_prompt;
   // In a ref so the subscription mounts once (resubscribing per render could
   // drop a completion event in the gap).
   const onRetryRef = useRef(onRetry);
@@ -80,7 +79,7 @@ export function UnauthenticatedCard({
         if (useUIStore.getState().authRequired === error.provider) {
           setAuthRequired(null);
         }
-        if (autoResend && onRetryRef.current && !autoResendFiredRef.current) {
+        if (onRetryRef.current && !autoResendFiredRef.current) {
           autoResendFiredRef.current = true;
           setRetrying(true);
           void Promise.resolve(onRetryRef.current())
@@ -99,7 +98,7 @@ export function UnauthenticatedCard({
         setPhase("idle");
       }
     });
-  }, [error.provider, setAuthRequired, autoResend]);
+  }, [error.provider, setAuthRequired]);
 
   const reconnect = async () => {
     if (launching) return;
@@ -126,25 +125,15 @@ export function UnauthenticatedCard({
     }
   };
 
-  const sendAgain = async () => {
-    if (!onRetry || retrying) return;
-    setRetrying(true);
-    try {
-      await onRetry();
-    } finally {
-      setRetrying(false);
-    }
-  };
-
   const pres = resolveAuthCardPresentation({
     phase,
-    hasFailedPrompt: autoResend,
+    hasFailedPrompt: !!error.failed_prompt,
     hasRetry: !!onRetry,
     causeBodyKey: authCauseBodyKey(error.cause),
   });
 
   // Map the resolved button spec to its live handler + pending state. The
-  // "done" resend badge is a disabled status pill that spins during the resend;
+  // "done" resume badge is a disabled status pill that spins during the resume;
   // Cancel (bail out of the browser wait) is the only outline action pill.
   const renderButton = (button: AuthCardButton) => {
     if (!button) return undefined;
@@ -159,23 +148,12 @@ export function UnauthenticatedCard({
         />
       );
     }
-    const handler =
-      button.action === "cancel"
-        ? cancelSignIn
-        : button.action === "sendAgain"
-          ? sendAgain
-          : reconnect;
+    const handler = button.action === "cancel" ? cancelSignIn : reconnect;
     return (
       <RowCardButton
         label={t(button.labelKey)}
         onClick={handler}
-        loading={
-          button.action === "reconnect"
-            ? launching
-            : button.action === "sendAgain"
-              ? retrying
-              : false
-        }
+        loading={button.action === "reconnect" ? launching : false}
         variant={button.action === "cancel" ? "outline" : "default"}
       />
     );

--- a/app/src/components/shell/provider-error-cards/not-connected.ts
+++ b/app/src/components/shell/provider-error-cards/not-connected.ts
@@ -41,15 +41,34 @@ export function resendsOriginalPrompt(err: ProviderError): boolean {
 
 /**
  * Whether this card's retry resumes an INTERRUPTED turn (HOU-718) — a
- * mid-turn auth failure, where the conversation context (including the
- * user's message) is already persisted server-side. Such a retry fires
- * automatically once sign-in completes and sends a hidden auto-continue
- * nudge (see `lib/auto-continue-message.ts`) so the agent picks the task
- * back up without the user retyping. The refused-send card resends its
- * original prompt instead (`resendsOriginalPrompt`).
+ * mid-turn auth failure, where the user's message is already persisted in
+ * the transcript. Such a retry fires automatically once sign-in completes
+ * and sends a hidden auto-continue message (see
+ * `lib/auto-continue-message.ts`) so the agent picks the task back up
+ * without the user retyping — and without a second visible bubble. The
+ * refused-send card resends its original prompt instead
+ * (`resendsOriginalPrompt`).
  */
 export function continuesTaskAfterReconnect(err: ProviderError): boolean {
   return err.kind === "unauthenticated" && !err.failed_prompt;
+}
+
+/**
+ * What the hidden auto-continue retry re-delivers: the turn's undelivered
+ * user text when the model never received it (pi's prompt-time credential
+ * guard raises BEFORE recording the message in its session store, so no
+ * session context or rebuild ever sees it — a bare "continue" would earn an
+ * honest "I don't see a previous task"), else the caller's generic continue
+ * nudge (a streamed mid-turn failure: the model saw the message, its context
+ * is intact).
+ */
+export function reconnectContinueText(
+  err: ProviderError,
+  genericContinuePrompt: string,
+): string {
+  return err.kind === "unauthenticated" && err.undelivered_prompt
+    ? err.undelivered_prompt
+    : genericContinuePrompt;
 }
 
 /**

--- a/app/src/components/shell/provider-error-cards/not-connected.ts
+++ b/app/src/components/shell/provider-error-cards/not-connected.ts
@@ -40,6 +40,19 @@ export function resendsOriginalPrompt(err: ProviderError): boolean {
 }
 
 /**
+ * Whether this card's retry resumes an INTERRUPTED turn (HOU-718) — a
+ * mid-turn auth failure, where the conversation context (including the
+ * user's message) is already persisted server-side. Such a retry fires
+ * automatically once sign-in completes and sends a hidden auto-continue
+ * nudge (see `lib/auto-continue-message.ts`) so the agent picks the task
+ * back up without the user retyping. The refused-send card resends its
+ * original prompt instead (`resendsOriginalPrompt`).
+ */
+export function continuesTaskAfterReconnect(err: ProviderError): boolean {
+  return err.kind === "unauthenticated" && !err.failed_prompt;
+}
+
+/**
  * What the card's retry should send: the refused original prompt when the
  * message never reached the engine, else the caller's generic retry prompt
  * (the turn's context is already server-side for live-turn failures).

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -124,6 +124,7 @@ import { SelectedSkillChip } from "./selected-skill-chip";
 import { AgentProvisioningCard } from "./shell/agent-provisioning-card";
 import { ProviderErrorCard } from "./shell/provider-error-card";
 import {
+  continuesTaskAfterReconnect,
   isInlineAuthCardForChat,
   providerErrorRetryText,
   resendsOriginalPrompt,
@@ -1093,13 +1094,20 @@ export function useAgentChatPanel({
             onRetry={async () => {
               if (!path || !selectedSessionKey) return;
               // A refused not-connected send never reached the engine —
-              // the card resends the original message verbatim (and fires
-              // itself on reconnect). Live-turn failures keep the generic
-              // retry prompt (their context is already server-side).
-              const text = providerErrorRetryText(
-                providerError,
-                t("chat:toolRuntimeError.retryPrompt"),
-              );
+              // the card resends the original message verbatim. A mid-turn
+              // auth failure's context is already server-side, so reconnect
+              // resumes the interrupted task with a hidden auto-continue
+              // nudge (the transcript filters its bubble, see
+              // `mapFeedItems`). Both fire automatically on reconnect;
+              // other failures keep the generic visible retry prompt.
+              const text = continuesTaskAfterReconnect(providerError)
+                ? encodeAutoContinueMessage(
+                    t("chat:providerError.reconnectedContinue"),
+                  )
+                : providerErrorRetryText(
+                    providerError,
+                    t("chat:toolRuntimeError.retryPrompt"),
+                  );
               await tauriChat.send(path, text, selectedSessionKey, {
                 providerOverride: effectiveProvider,
                 modelOverride: effectiveModel,

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -127,6 +127,7 @@ import {
   continuesTaskAfterReconnect,
   isInlineAuthCardForChat,
   providerErrorRetryText,
+  reconnectContinueText,
   resendsOriginalPrompt,
   resolveProviderErrorForChat,
 } from "./shell/provider-error-cards/not-connected";
@@ -1102,7 +1103,10 @@ export function useAgentChatPanel({
               // other failures keep the generic visible retry prompt.
               const text = continuesTaskAfterReconnect(providerError)
                 ? encodeAutoContinueMessage(
-                    t("chat:providerError.reconnectedContinue"),
+                    reconnectContinueText(
+                      providerError,
+                      t("chat:providerError.reconnectedContinue"),
+                    ),
                   )
                 : providerErrorRetryText(
                     providerError,

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -57,7 +57,7 @@
     "retryPrompt": "Try again."
   },
   "providerError": {
-    "reconnectedContinue": "I'm signed in again. Please continue where you left off."
+    "reconnectedContinue": "I'm signed in again. Please continue where you left off. If my last message hasn't been answered yet, answer it now."
   },
   "attachmentIssues": {
     "title": "Some files were not attached",

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -56,6 +56,9 @@
   "toolRuntimeError": {
     "retryPrompt": "Try again."
   },
+  "providerError": {
+    "reconnectedContinue": "I'm signed in again. Please continue where you left off."
+  },
   "attachmentIssues": {
     "title": "Some files were not attached",
     "description": "Houston kept your prompt and the files it can use.",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -293,8 +293,8 @@
       "reconnectedTitle": "Reconnected to {{provider}}",
       "reconnectedBody": "You are signed in again. Pick up where you left off.",
       "reconnectedResending": "You are signed in again. Houston is answering your message now.",
+      "reconnectedResuming": "You are signed in again. Houston is continuing where you left off.",
       "signedIn": "Signed in",
-      "sendAgain": "Send my message",
       "failedBody": "The {{provider}} sign-in did not finish. Sign in again. {{detail}}"
     },
     "networkUnreachable": {

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -56,6 +56,9 @@
   "toolRuntimeError": {
     "retryPrompt": "Intenta de nuevo."
   },
+  "providerError": {
+    "reconnectedContinue": "Ya inicié sesión de nuevo. Por favor continúa donde quedaste."
+  },
   "attachmentIssues": {
     "title": "Algunos archivos no se adjuntaron",
     "description": "Houston conservó tu mensaje y los archivos que sí puede usar.",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -57,7 +57,7 @@
     "retryPrompt": "Intenta de nuevo."
   },
   "providerError": {
-    "reconnectedContinue": "Ya inicié sesión de nuevo. Por favor continúa donde quedaste."
+    "reconnectedContinue": "Ya inicié sesión de nuevo. Por favor continúa donde quedaste. Si aún no has respondido mi último mensaje, respóndelo ahora."
   },
   "attachmentIssues": {
     "title": "Algunos archivos no se adjuntaron",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -293,8 +293,8 @@
       "reconnectedTitle": "Reconectado a {{provider}}",
       "reconnectedBody": "Ya iniciaste sesión de nuevo. Continúa donde quedaste.",
       "reconnectedResending": "Ya iniciaste sesión de nuevo. Houston está respondiendo tu mensaje ahora.",
+      "reconnectedResuming": "Ya iniciaste sesión de nuevo. Houston está continuando donde quedaste.",
       "signedIn": "Sesión iniciada",
-      "sendAgain": "Enviar mi mensaje",
       "failedBody": "El inicio de sesión de {{provider}} no se completó. Inicia sesión de nuevo. {{detail}}"
     },
     "networkUnreachable": {

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -57,7 +57,7 @@
     "retryPrompt": "Tente de novo."
   },
   "providerError": {
-    "reconnectedContinue": "Entrei de novo. Por favor, continue de onde parou."
+    "reconnectedContinue": "Entrei de novo. Por favor, continue de onde parou. Se ainda não respondeu minha última mensagem, responda agora."
   },
   "attachmentIssues": {
     "title": "Alguns arquivos não foram anexados",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -56,6 +56,9 @@
   "toolRuntimeError": {
     "retryPrompt": "Tente de novo."
   },
+  "providerError": {
+    "reconnectedContinue": "Entrei de novo. Por favor, continue de onde parou."
+  },
   "attachmentIssues": {
     "title": "Alguns arquivos não foram anexados",
     "description": "Houston manteve sua mensagem e os arquivos que pode usar.",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -278,8 +278,8 @@
       "reconnectedTitle": "Reconectado a {{provider}}",
       "reconnectedBody": "Você entrou de novo. Continue de onde parou.",
       "reconnectedResending": "Você entrou de novo. O Houston está respondendo sua mensagem agora.",
+      "reconnectedResuming": "Você entrou de novo. O Houston está continuando de onde parou.",
       "signedIn": "Sessão iniciada",
-      "sendAgain": "Enviar minha mensagem",
       "failedBody": "O login de {{provider}} não foi concluído. Entre novamente. {{detail}}"
     },
     "networkUnreachable": {

--- a/app/tests/auth-card-presentation.test.ts
+++ b/app/tests/auth-card-presentation.test.ts
@@ -7,8 +7,9 @@ import {
 
 // The card once labeled two opposite actions "Try again". These assert the
 // state -> title/body/button mapping so each phase names its real action:
-// idle/failed -> Reconnect, waiting -> Cancel, done -> Send my message (or a
-// disabled "Signed in" badge when the refused send auto-resent).
+// idle/failed -> Reconnect, waiting -> Cancel, done -> a disabled "Signed in"
+// badge (the resume auto-fired: the refused send's prompt, or the hidden
+// auto-continue nudge for a mid-turn failure — HOU-718).
 
 const CAUSE = "providerError.unauthenticated.bodyTokenExpired";
 
@@ -125,7 +126,7 @@ describe("resolveAuthCardPresentation", () => {
     );
   });
 
-  it("done + mid-turn failure: an explicit send-my-message button", () => {
+  it("done + mid-turn failure: Signed-in badge, resuming body (HOU-718)", () => {
     deepStrictEqual(
       resolveAuthCardPresentation({
         phase: "done",
@@ -136,11 +137,10 @@ describe("resolveAuthCardPresentation", () => {
       {
         variant: "done",
         titleKey: "providerError.unauthenticated.reconnectedTitle",
-        bodyKey: "providerError.unauthenticated.reconnectedBody",
+        bodyKey: "providerError.unauthenticated.reconnectedResuming",
         button: {
-          kind: "action",
-          labelKey: "providerError.unauthenticated.sendAgain",
-          action: "sendAgain",
+          kind: "badge",
+          labelKey: "providerError.unauthenticated.signedIn",
         },
       },
     );

--- a/app/tests/not-connected-card.test.ts
+++ b/app/tests/not-connected-card.test.ts
@@ -5,6 +5,7 @@ import {
   continuesTaskAfterReconnect,
   isInlineAuthCardForChat,
   providerErrorRetryText,
+  reconnectContinueText,
   resendsOriginalPrompt,
   resolveProviderErrorForChat,
 } from "../src/components/shell/provider-error-cards/not-connected.ts";
@@ -92,6 +93,42 @@ describe("continuesTaskAfterReconnect", () => {
         message: "slow down",
       }),
       false,
+    );
+  });
+});
+
+describe("reconnectContinueText", () => {
+  it("re-delivers the undelivered prompt when the model never received it", () => {
+    // pi's prompt-time credential guard raised before recording the message
+    // in its session store — a bare "continue" would meet a model that never
+    // saw the message ("I don't see a previous task").
+    strictEqual(
+      reconnectContinueText(
+        {
+          kind: "unauthenticated",
+          provider: "openai",
+          cause: "no_credentials",
+          message: "No API key found for openai-codex.",
+          undelivered_prompt: "is this working",
+        },
+        "Please continue.",
+      ),
+      "is this working",
+    );
+  });
+
+  it("keeps the generic nudge for a streamed mid-turn failure (context intact)", () => {
+    strictEqual(
+      reconnectContinueText(
+        {
+          kind: "unauthenticated",
+          provider: "anthropic",
+          cause: "token_expired",
+          message: "session expired",
+        },
+        "Please continue.",
+      ),
+      "Please continue.",
     );
   });
 });

--- a/app/tests/not-connected-card.test.ts
+++ b/app/tests/not-connected-card.test.ts
@@ -2,6 +2,7 @@ import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import type { FeedItem, ProviderError } from "@houston-ai/chat";
 import {
+  continuesTaskAfterReconnect,
   isInlineAuthCardForChat,
   providerErrorRetryText,
   resendsOriginalPrompt,
@@ -56,6 +57,34 @@ describe("resendsOriginalPrompt", () => {
     );
     strictEqual(
       resendsOriginalPrompt({
+        kind: "rate_limited",
+        provider: "anthropic",
+        model: null,
+        retry_after_seconds: null,
+        message: "slow down",
+      }),
+      false,
+    );
+  });
+});
+
+describe("continuesTaskAfterReconnect", () => {
+  it("marks the mid-turn auth failure: reconnect resumes the task (HOU-718)", () => {
+    strictEqual(
+      continuesTaskAfterReconnect({
+        kind: "unauthenticated",
+        provider: "anthropic",
+        cause: "token_expired",
+        message: "session expired",
+      }),
+      true,
+    );
+  });
+
+  it("never marks the refused send (it resends its prompt) or other kinds", () => {
+    strictEqual(continuesTaskAfterReconnect(notConnectedCard), false);
+    strictEqual(
+      continuesTaskAfterReconnect({
         kind: "rate_limited",
         provider: "anthropic",
         model: null,

--- a/packages/protocol/src/provider-error.ts
+++ b/packages/protocol/src/provider-error.ts
@@ -59,6 +59,17 @@ export type ProviderError =
       provider: string;
       cause: AuthFailureCause;
       message: string;
+      /**
+       * The turn's user text when it never reached the MODEL: pi raises a
+       * missing/expired credential at prompt time, BEFORE recording the
+       * message in its session store, so neither the live context nor a
+       * session rebuild ever sees it (HOU-718). The reconnect retry must
+       * re-deliver this text (the surface hides the re-send under its
+       * auto-continue marker — the transcript already shows the original,
+       * persisted bubble). Distinct from the frontend-only `failed_prompt`,
+       * which marks a send the ENGINE refused before persisting anything.
+       */
+      undelivered_prompt?: string;
     }
   | {
       kind: "rate_limited";

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -48,6 +48,34 @@ test("Codex session-kill → unauthenticated / token_revoked (terminal, not tran
   if (err.kind === "unauthenticated") expect(err.cause).toBe("token_revoked");
 });
 
+test("pi prompt-time 'No API key found' → unauthenticated / no_credentials (HOU-718)", () => {
+  // pi RAISES this (formatNoApiKeyFoundMessage) when the user logged out of a
+  // provider that stayed selected — it never arrives as an errored
+  // AssistantMessage, so exec-turn/turn-session classify the throw. Without
+  // this the chat showed the raw text (node_modules doc paths included)
+  // instead of the reconnect card.
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: null,
+    message:
+      "No API key found for openai-codex.\n\nUse /login to log into a provider via OAuth or API key. See:\n  /app/node_modules/@earendil-works/pi-coding-agent/docs/providers.md\n  /app/node_modules/@earendil-works/pi-coding-agent/docs/models.md",
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("no_credentials");
+});
+
+test("pi prompt-time OAuth guard ('Authentication failed … Run /login') → unauthenticated / token_expired", () => {
+  // pi's OAuth flavor of the same prompt-time guard.
+  const err = classifyProviderError({
+    provider: "openai-codex",
+    model: null,
+    message:
+      "Authentication failed for \"openai-codex\". Credentials may have expired or network is unavailable. Run '/login openai-codex' to re-authenticate.",
+  });
+  expect(err.kind).toBe("unauthenticated");
+  if (err.kind === "unauthenticated") expect(err.cause).toBe("token_expired");
+});
+
 test("Anthropic 403 permission_error (authZ) is NOT a reconnect prompt → unknown", () => {
   // A 403 permission_error is authorization, not authentication — re-logging-in
   // won't fix it, so it must NOT render the reconnect card. Only 401 (or a 403

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -49,6 +49,15 @@ const INVALID_KEY_PATTERNS = [
 ];
 
 /**
+ * The credential is simply ABSENT — the user logged out (or never connected)
+ * while the provider stayed selected. pi RAISES this at prompt time (its
+ * `formatNoApiKeyFoundMessage`: "No API key found for <provider>.\n\nUse /login
+ * …"), it never arrives as an errored AssistantMessage, so the exec-turn /
+ * turn-session catch is where this classification happens (HOU-718).
+ */
+const NO_CREDENTIALS_PATTERNS = ["no api key found"];
+
+/**
  * The gateway rejected the REQUESTED MODEL itself (not the credential): GitHub
  * Copilot answers a premium model its plan doesn't include with
  * `code: "model_not_supported"`; OpenAI uses `model_not_found` ("does not exist
@@ -199,11 +208,14 @@ function isAuth(lower: string, status: number | null): boolean {
     // "oauth token" (not bare "oauth"): a token error, not any mention of OAuth.
     lower.includes("oauth token") ||
     INVALID_KEY_PATTERNS.some((p) => lower.includes(p)) ||
+    NO_CREDENTIALS_PATTERNS.some((p) => lower.includes(p)) ||
     TERMINAL_SESSION_PATTERNS.some((p) => lower.includes(p))
   );
 }
 
 function authCause(lower: string): AuthFailureCause {
+  if (NO_CREDENTIALS_PATTERNS.some((p) => lower.includes(p)))
+    return "no_credentials";
   if (INVALID_KEY_PATTERNS.some((p) => lower.includes(p)))
     return "invalid_api_key";
   // The provider ended this session server-side — the user must reconnect, a

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -183,6 +183,72 @@ test("a provider_error turn emits no done — the pending interaction never ride
   expect(persistedInteraction(id)).toBeUndefined();
 });
 
+/** The providerError persisted on `id`'s assistant message, or undefined. */
+function persistedProviderError(id: string): unknown {
+  const call = vi
+    .mocked(appendAssistantMessage)
+    .mock.calls.find((c) => c[0] === id);
+  return (call?.[2] as { providerError?: unknown } | undefined)?.providerError;
+}
+
+test("a prompt-time credential throw becomes a typed provider_error frame, not raw error text (HOU-718)", async () => {
+  // pi RAISES a missing credential at prompt time (the user logged out of a
+  // provider that stayed active) — no stream ever exists, so the catch must
+  // classify the throw. Before this, the chat showed pi's raw message
+  // (node_modules doc paths included) and no reconnect card ever appeared.
+  const id = "exec-throw-no-credentials";
+  const { events, unsub } = collect(id);
+  const conv = fakeConv(() => {
+    throw new Error(
+      "No API key found for openai-codex.\n\nUse /login to log into a provider via OAuth or API key. See:\n  /app/docs/providers.md\n  /app/docs/models.md",
+    );
+  });
+
+  await execTurn(conv, id, "turn-1", "hey", {
+    author: undefined,
+    priorAuthors: [],
+  });
+  unsub();
+
+  const providerError = events.find(
+    (e): e is Extract<WireEvent, { type: "provider_error" }> =>
+      e.type === "provider_error",
+  );
+  expect(providerError?.data).toMatchObject({
+    kind: "unauthenticated",
+    cause: "no_credentials",
+  });
+  // The typed frame IS the terminal: no generic error, no clean done.
+  expect(events.some((e) => e.type === "error")).toBe(false);
+  expect(events.some((e) => e.type === "done")).toBe(false);
+  // Persisted too, so the reconnect card survives a reload.
+  expect(persistedProviderError(id)).toMatchObject({
+    kind: "unauthenticated",
+    cause: "no_credentials",
+  });
+});
+
+test("an unrecognized throw keeps the generic error frame and the unknown card", async () => {
+  const id = "exec-throw-unknown";
+  const { events, unsub } = collect(id);
+  const conv = fakeConv(() => {
+    throw new Error("segfault in the flux capacitor");
+  });
+
+  await execTurn(conv, id, "turn-1", "hey", {
+    author: undefined,
+    priorAuthors: [],
+  });
+  unsub();
+
+  expect(events.some((e) => e.type === "provider_error")).toBe(false);
+  const error = events.find(
+    (e): e is Extract<WireEvent, { type: "error" }> => e.type === "error",
+  );
+  expect(error?.data.message).toContain("flux capacitor");
+  expect(persistedProviderError(id)).toMatchObject({ kind: "unknown" });
+});
+
 test("pin.mode is threaded into switchModeIfNeeded for the turn", async () => {
   vi.mocked(switchModeIfNeeded).mockClear();
   const id = "exec-mode-plan";

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -217,6 +217,10 @@ test("a prompt-time credential throw becomes a typed provider_error frame, not r
   expect(providerError?.data).toMatchObject({
     kind: "unauthenticated",
     cause: "no_credentials",
+    // pi threw BEFORE recording the message in its session store, so the card
+    // carries the text for the reconnect retry to re-deliver — a bare
+    // "continue" would meet a model that never saw the message.
+    undelivered_prompt: "hey",
   });
   // The typed frame IS the terminal: no generic error, no clean done.
   expect(events.some((e) => e.type === "error")).toBe(false);
@@ -225,6 +229,7 @@ test("a prompt-time credential throw becomes a typed provider_error frame, not r
   expect(persistedProviderError(id)).toMatchObject({
     kind: "unauthenticated",
     cause: "no_credentials",
+    undelivered_prompt: "hey",
   });
 });
 

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -8,6 +8,7 @@ import type {
   WireEvent,
 } from "@houston/runtime-client";
 import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
+import { classifyProviderError } from "../ai/provider-error";
 import { activeEffort, resolveModel } from "../ai/providers";
 import { config } from "../config";
 import {
@@ -428,19 +429,43 @@ export async function execTurn(
     // provider_error frame does — an unattended reader (a routine's reconcile)
     // reads the real reason off this message instead of timing the run out
     // with a vague error 15 minutes later.
+    //
+    // Classify the throw before falling back to `unknown`: pi RAISES a
+    // missing/expired credential at prompt time ("No API key found for
+    // <provider>. Use /login …"), before any stream exists, so this catch is
+    // the only place it can become the typed reconnect card (HOU-718). A
+    // recognized kind is published as a provider_error frame — the turn's
+    // terminal surface, same as the streamed path — so the live chat renders
+    // the card (and auto-continues after reconnect) instead of raw error
+    // text. An unrecognized throw keeps the generic error frame.
+    const thrown =
+      providerError ??
+      classifyProviderError({
+        provider: pin?.provider ?? conv.provider,
+        model: pin?.model ?? null,
+        message: errMessage(err),
+      });
+    const typed = thrown.kind !== "unknown" ? thrown : undefined;
     appendAssistantMessage(id, assistantText, {
       tools,
       usage,
       providerSwitch,
       compaction,
-      providerError: providerError ?? {
+      providerError: typed ?? {
         kind: "unknown",
         provider: pin?.provider ?? conv.provider,
         raw_excerpt: errMessage(err),
       },
       turnId,
     });
-    publish(id, { type: "error", data: { message: errMessage(err) }, turnId });
+    if (typed && !providerError)
+      publish(id, { type: "provider_error", data: typed, turnId });
+    else if (!typed)
+      publish(id, {
+        type: "error",
+        data: { message: errMessage(err) },
+        turnId,
+      });
   } finally {
     conv.turnId = undefined;
     // Never leak the stall timer past the turn (no-op if it threw before arming).

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -445,6 +445,17 @@ export async function execTurn(
         model: pin?.model ?? null,
         message: errMessage(err),
       });
+    // An auth throw with NOTHING streamed = pi's prompt-time credential guard,
+    // which raises BEFORE recording the user message in pi's session store —
+    // neither the live context nor a rebuild will ever see it. Carry the text
+    // on the card so the reconnect retry re-delivers it to the model.
+    if (
+      thrown.kind === "unauthenticated" &&
+      !providerError &&
+      !assistantText &&
+      tools.length === 0
+    )
+      thrown.undelivered_prompt = text;
     const typed = thrown.kind !== "unknown" ? thrown : undefined;
     appendAssistantMessage(id, assistantText, {
       tools,

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -275,6 +275,15 @@ export async function runPiTurn(
         model: pin?.model ?? null,
         message,
       });
+      // Prompt-time credential guard: pi raised BEFORE recording the user
+      // message in its session store, so the reconnect retry must re-deliver
+      // the text (mirrors exec-turn).
+      if (
+        thrown.kind === "unauthenticated" &&
+        !assistantText &&
+        tools.length === 0
+      )
+        thrown.undelivered_prompt = text;
       if (thrown.kind !== "unknown") {
         appendAssistantMessageAt(
           conversationsDir,

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -10,6 +10,7 @@ import type {
   WireFrame,
 } from "@houston/runtime-client";
 import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
+import { classifyProviderError } from "../ai/provider-error";
 import { createPiBackend } from "../backends/pi/backend";
 import { config } from "../config";
 import {
@@ -259,6 +260,32 @@ export async function runPiTurn(
     // provider error (mirrors exec-turn: only the clean `done` carries it).
     return providerError ? {} : { pendingInteraction: interaction.pending };
   } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    // Classify the throw before reporting a generic outcome error: pi RAISES
+    // a missing/expired credential at prompt time ("No API key found for
+    // <provider>. Use /login …"), before any stream exists, so this catch is
+    // the only place it can become the typed reconnect card (HOU-718 —
+    // mirrors exec-turn). The typed error is emitted as a provider_error
+    // frame (the terminal the client settles on) and persisted so the card
+    // survives a reload; returning `{}` keeps the per-turn server from
+    // stacking a second, generic error frame on top of it.
+    if (!providerError) {
+      const thrown = classifyProviderError({
+        provider,
+        model: pin?.model ?? null,
+        message,
+      });
+      if (thrown.kind !== "unknown") {
+        appendAssistantMessageAt(
+          conversationsDir,
+          conversationId,
+          assistantText,
+          { tools, usage, providerError: thrown, turnId },
+        );
+        emit({ type: "provider_error", data: thrown });
+        return {};
+      }
+    }
     if (assistantText || providerError)
       appendAssistantMessageAt(
         conversationsDir,
@@ -266,6 +293,6 @@ export async function runPiTurn(
         assistantText,
         { tools, usage, providerError, turnId },
       );
-    return { error: err instanceof Error ? err.message : String(err) };
+    return { error: message };
   }
 }

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -146,6 +146,15 @@ export type ProviderError =
        * a generic "try again" prompt would arrive with no context to retry.
        */
       failed_prompt?: string;
+      /**
+       * Wire-carried (HOU-718): the turn's user text when the engine PERSISTED
+       * it but the model never received it — pi raises a missing credential at
+       * prompt time, before recording the message in its session store. The
+       * reconnect retry re-delivers this text hidden under the auto-continue
+       * marker: the transcript already shows the original bubble, so unlike
+       * `failed_prompt` the re-send must never render a second one.
+       */
+      undelivered_prompt?: string;
     }
   | { kind: "network_unreachable"; provider: string; message: string }
   | {


### PR DESCRIPTION
## Summary

Fixes HOU-718. Two fixes, one flow: (1) after a successful provider reconnect the agent now continues the conversation automatically, and (2) pi's prompt-time credential throw is classified into the typed reconnect card in the first place (previously it leaked as raw error text and no card ever appeared).

### Fix 1 — auto-continue after reconnect (frontend)

When a provider fails mid-turn with an auth error, the chat shows the inline reconnect card. Reconnecting worked, but the conversation then sat idle: the card flipped to a green state with an explicit "Send my message" button the user had to click before the agent resumed.

Root cause: the card's auto-resend on `ProviderLoginComplete` was gated on `failed_prompt`, which only the send-time "not connected" refusal carries. A mid-turn failure has no `failed_prompt`, so nothing fired after reconnect — even though the turn's context (including the user's message) is already persisted server-side and a fresh send is all that's needed.

- `UnauthenticatedCard` now auto-fires its retry once on every successful reconnect, not just for refused sends.
- For the mid-turn case, the retry sends a hidden auto-continue nudge (the same `<!--houston:auto_continue-->` marker used when an integration connects mid-chat), so the agent resumes without a fake user bubble in the transcript. The refused-send case keeps its existing verbatim resend of the original prompt.
- The reconnected card state becomes a disabled "Signed in" badge with a "Houston is continuing where you left off" body; the now-dead `sendAgain` action and its locale keys are removed.
- New `chat:providerError.reconnectedContinue` + `shell:...reconnectedResuming` strings in en/es/pt.

### Fix 2 — classify pi's prompt-time credential throw (runtime)

Disconnecting a provider that stays active (Settings → disconnect OpenAI, then send) surfaced pi's raw thrown message in the chat — "No API key found for openai-codex. Use /login … `<node_modules doc paths>`" — with no reconnect card, so the flow above never engaged.

Root cause: pi RAISES missing/expired credentials at prompt time (it never resolves the turn with an errored message on this path), and both turn runners' catch blocks stamped every throw `kind: "unknown"` and published a generic `error` frame, bypassing `classifyProviderError` entirely.

- Both catches (`exec-turn.ts` for the long-lived host, `turn-session.ts` for the cloud per-turn runtime) now classify the throw: a recognized kind is persisted on the assistant message and emitted as the `provider_error` terminal frame, so the typed card renders live and survives reload. Unrecognized throws keep the generic error frame.
- The classifier learns pi's "No API key found" pattern → `unauthenticated` / `no_credentials`; pi's OAuth guard variant ("Authentication failed … Run '/login …'") already classified via "authentication" and is now pinned by a test.

### Fix 3 — re-deliver the undelivered prompt (runtime + app)

Testing fix 1+2 end-to-end exposed a context gap: after reconnecting from a prompt-time credential failure, the agent answered "I don't see a previous task". pi's credential guard raises BEFORE recording the user message in its session store, so neither the live session context nor any rebuild ever sees the message — only Houston's transcript has it. A bare "please continue" nudge is meaningless to a model that never received the prompt.

- The turn runners stamp the thrown-turn card with the turn's user text (new additive wire field `unauthenticated.undelivered_prompt`, set only when nothing streamed).
- The reconnect retry re-delivers THAT text hidden under the auto-continue marker: the agent finally receives the message, while the transcript keeps the single original bubble.
- Streamed mid-turn failures (model context intact) keep the generic continue nudge, hardened with "if my last message hasn't been answered yet, answer it now."

## Before (reproduction)

Mid-turn auth failure:
1. Start a conversation with an Anthropic-backed agent and let a turn fail with an auth error (expired/revoked OAuth token — the chat shows the "Sign in to Anthropic again" card).
2. Click **Reconnect** and finish the OAuth flow in the browser.
3. The card turns green but shows **Send my message** — the agent does NOT continue until you click it.

Disconnected provider:
1. Connect OpenAI, chat once, then Settings → disconnect OpenAI (leaving it the active provider).
2. Send another message in the same conversation.
3. Raw error text appears in the chat ("…found for openai-codex. Use /login to log into a provider via OAuth or API key. See: `<node_modules paths>`") — no reconnect card at all.

## After (verification)

1. Mid-turn auth failure → reconnect card → **Reconnect** → finish sign-in: the card flips to "Reconnected … Houston is continuing where you left off" with a disabled **Signed in** badge and the agent resumes automatically — no extra click, no synthetic user bubble (also after a reload).
2. Disconnected provider → send: the chat shows the typed "Sign in to openai again" reconnect card (clean copy, no doc paths). Reconnect → the agent answers the ORIGINAL unanswered message (not "I don't see a previous task"), with no duplicate user bubble, also after a reload.
3. The send-time refusal path still behaves as before: no provider connected → send → card → reconnect → the original message is resent automatically, no duplicate bubble.

## Tests

- `app/tests/auth-card-presentation.test.ts` — done-phase mapping updated (badge + resuming body for mid-turn).
- `app/tests/not-connected-card.test.ts` — new `continuesTaskAfterReconnect` coverage.
- `packages/runtime/src/ai/provider-error.test.ts` — pi's two prompt-time credential messages pinned (verbatim).
- `packages/runtime/src/session/exec-turn.test.ts` — a credential throw emits the typed `provider_error` terminal (no generic error, no done) and persists it; an unrecognized throw keeps the generic error frame.
- `pnpm test` (app, 964), runtime (532) + host (634) + domain vitest, `pnpm -r typecheck`, `pnpm check`, `pnpm check-locales` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
