### PR TITLE
Run routines in autopilot mode

### DIFF
--- a/convergence/parity-checklist.md
+++ b/convergence/parity-checklist.md
@@ -72,7 +72,7 @@ pinned here. Read this top-to-bottom to know what CI already guarantees.
 | Skills lifecycle over the host (create→list→read→edit→delete, dup→409, ownership wall) | `src/routes/agent-data.test.ts` |
 | **A skill created via the API lands at the EXACT on-disk path pi loads** (`.agents/skills/<slug>/SKILL.md`, real FsVfs) — "the agent uses it next session" made concrete | `src/local/reactivity.test.ts` |
 | Routine fires on schedule: scheduler scans, fires due-in-window once, records a running run, dedups across replicas, marks errored never stuck, account-timezone re-times | `src/schedule/scheduler.test.ts` |
-| Routine firer routes the prompt through the same channel a user message uses (incl. model/effort pins); ProxyChannel.fireTurn POSTs to the runtime conversation endpoint | `src/schedule/firer.test.ts` |
+| Routine firer routes the prompt through the same channel a user message uses (incl. model/effort/autopilot mode pins); ProxyChannel.fireTurn POSTs to the runtime conversation endpoint | `src/schedule/firer.test.ts` |
 | Run a routine on demand over HTTP (records a run, calls fireTurn with the prompt, suppression instruction rides the prompt, fire-failure→502+errored, unknown→404, cross-user→403) | `src/routes/run-routine.test.ts` |
 | Routine run reconciles: silent (ROUTINE_OK+suppress, no card) vs surfaced (→ `needs_you` board Activity), pre-start replies ignored, 15-min timeout→errored, activity reused across runs | `src/schedule/reconcile.test.ts` |
 | Board live-reactivity (host mutation): a mutation emits its HoustonEvent on the owner's `/v1/events` stream and NEVER another tenant's; 503 with no hub; auth required | `src/routes/events-stream.test.ts` |

--- a/knowledge-base/architecture.md
+++ b/knowledge-base/architecture.md
@@ -186,10 +186,11 @@ transcripts. Client-side settle detail: `knowledge-base/client-architecture.md`.
 
 Each turn optionally pins a `TurnMode`: `"execute" | "plan" | "auto"`
 (`packages/protocol/src/conversation.ts`). `execute` is full read/write/act,
-today's only behavior for an UNPINNED turn — routines and per-turn cloud
-workspaces never inherit a mode, so they always execute. Deliberately NOT part
-of `Settings` (which persists `effort`): mode rides the per-turn pin only, so
-an unpinned turn can never accidentally end up read-only.
+today's only behavior for an UNPINNED turn. Routine fire paths explicitly pin
+`auto`, so scheduled work never waits on the user; per-turn cloud user sends do
+not inherit a mode. Deliberately NOT part of `Settings` (which persists
+`effort`): mode rides the per-turn pin only, so an unpinned turn can never
+accidentally end up read-only.
 
 `plan` clamps the turn to a read-only tool subset — `PLAN_MODE_TOOL_NAMES`
 (`read, ls, grep, find, ask_user`, `packages/runtime/src/session/tool-selection.ts`)
@@ -220,9 +221,9 @@ engine `Settings`). Every user-typed send forwards the pin explicitly as
 
 **Gotcha.** Mode must ride EVERY send path explicitly, unlike effort (which
 syncs through `Settings` and so is implicitly present on every send) — a send
-path that forgets `modeOverride` silently degrades to `execute`. Per-turn
-cloud workspaces drop chat-body pins entirely; that's pre-existing and not
-specific to plan mode.
+path that forgets `modeOverride` silently degrades to `execute`. The routine
+firer pins `auto` itself. Per-turn cloud workspaces drop chat-body pins entirely;
+that's pre-existing and not specific to plan mode.
 
 ## Current gap to vision
 

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -118,9 +118,9 @@ export class ProxyChannel implements RuntimeChannel {
     // Wake the standing runtime and POST the routine's prompt as a normal
     // message — the runtime starts the turn (202) and persists the reply into
     // the conversation, exactly as a user message would. The routine's
-    // provider/model/effort pins ride alongside (omitted when absent → the
-    // session's current). A non-2xx throws so the scheduler records an
-    // errored run.
+    // provider/model/effort/mode pins ride alongside (omitted when absent →
+    // the session's current/default). A non-2xx throws so the scheduler records
+    // an errored run.
     const endpoint = await this.opts.launcher.ensureAwake(ctx.agent);
     const res = await fetch(
       `${endpoint.baseUrl}/conversations/${encodeURIComponent(conversationId)}/messages`,
@@ -139,6 +139,7 @@ export class ProxyChannel implements RuntimeChannel {
           ...(pin?.provider ? { provider: pin.provider } : {}),
           ...(pin?.model ? { model: pin.model } : {}),
           ...(pin?.effort ? { effort: pin.effort } : {}),
+          ...(pin?.mode ? { mode: pin.mode } : {}),
         }),
       },
     );

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -1,5 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import type { ClaudeOAuthCredential, CustomEndpoint } from "@houston/protocol";
+import type {
+  ClaudeOAuthCredential,
+  CustomEndpoint,
+  TurnMode,
+} from "@houston/protocol";
 import type {
   Agent,
   AgentId,
@@ -115,15 +119,16 @@ export interface ChannelCtx {
 }
 
 /**
- * A routine's pinned provider/model/effort, carried into the turn it fires.
- * Absent fields mean "inherit the agent default", resolved by the runtime.
- * The pin is per-turn only — it never touches the agent's saved settings, so
- * a pinned routine and the chats around it can't clobber each other.
+ * A routine's pinned provider/model/effort/mode, carried into the turn it fires.
+ * Absent provider/model/effort fields mean "inherit the agent default", resolved
+ * by the runtime. The pin is per-turn only — it never touches the agent's saved
+ * settings, so a pinned routine and the chats around it can't clobber each other.
  */
 export interface TurnPin {
   provider?: string | null;
   model?: string | null;
   effort?: string | null;
+  mode?: TurnMode | null;
 }
 
 export type CaptureResult =
@@ -152,7 +157,7 @@ export interface RuntimeChannel {
    * turn is ACCEPTED; throws when it can't be started (busy / quota / transport)
    * so the caller records an errored run instead of a silent miss.
    *
-   * `pin` carries the routine's model/effort overrides (absent = inherit).
+   * `pin` carries the routine's provider/model/effort/mode overrides.
    * `actingUser` (C2) is the routine creator's Supabase `sub` — forwarded to the
    * runtime as `x-houston-acting-user` so its integration calls act as that user.
    * Absent for legacy routines (no creator recorded) → the runtime acts as owner.

--- a/packages/host/src/routes/run-routine.test.ts
+++ b/packages/host/src/routes/run-routine.test.ts
@@ -3,7 +3,12 @@ import { loadRoutineRuns } from "@houston/domain";
 import type { Capabilities, Routine, RoutineRun } from "@houston/protocol";
 import { beforeEach, expect, test } from "vitest";
 import { MemoryCredentialStore } from "../credentials/store";
-import type { ChannelCtx, RuntimeChannel, TokenVerifier } from "../ports";
+import type {
+  ChannelCtx,
+  RuntimeChannel,
+  TokenVerifier,
+  TurnPin,
+} from "../ports";
 import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
 import { MemoryWorkspaceStore } from "../store/memory";
 import { MemoryVfs } from "../vfs";
@@ -25,15 +30,16 @@ const verifier: TokenVerifier = {
 
 /** A channel that records every fireTurn; optionally throws to exercise the error path. */
 class SpyChannel implements RuntimeChannel {
-  fired: { conversationId: string; text: string }[] = [];
+  fired: { conversationId: string; text: string; pin?: TurnPin }[] = [];
   throwMessage: string | null = null;
   async dispatch() {}
   async fireTurn(
     _ctx: ChannelCtx,
     conversationId: string,
     text: string,
+    pin?: TurnPin,
   ): Promise<void> {
-    this.fired.push({ conversationId, text });
+    this.fired.push({ conversationId, text, pin });
     if (this.throwMessage) throw new Error(this.throwMessage);
   }
   async cancelTurn() {
@@ -134,6 +140,7 @@ test("fires the routine now: records a running run and calls fireTurn with the p
   if (!fired0) throw new Error("expected channel.fired[0] to exist");
   expect(fired0.text).toBe("send the weekly digest");
   expect(fired0.conversationId).toBe(`routine-${routine.id}`);
+  expect(fired0.pin?.mode).toBe("auto");
 
   // A run was recorded (the same record a scheduled fire writes).
   const ws = await store.getOrCreatePersonalWorkspace("alice");

--- a/packages/host/src/schedule/firer.test.ts
+++ b/packages/host/src/schedule/firer.test.ts
@@ -98,7 +98,7 @@ test("ChannelRoutineFirer routes the prompt to the workspace's channel", async (
     {
       cid: "routine-r1",
       text: "Write the daily report",
-      pin: { provider: null, model: null, effort: undefined },
+      pin: { provider: null, model: null, effort: undefined, mode: "auto" },
       actingUser: undefined,
     },
   ]);
@@ -118,7 +118,7 @@ test("ChannelRoutineFirer threads the routine creator as the turn's acting user 
   expect(cloudrun.calls[0]?.actingUser).toBe("sub-alice");
 });
 
-test("ChannelRoutineFirer carries the routine's provider/model/effort pins", async () => {
+test("ChannelRoutineFirer carries provider/model/effort plus autopilot mode", async () => {
   const cloudrun = recordingChannel();
   const firer = new ChannelRoutineFirer({ cloudrun });
   await firer.fire(
@@ -139,6 +139,7 @@ test("ChannelRoutineFirer carries the routine's provider/model/effort pins", asy
     provider: "anthropic",
     model: "claude-opus-4-8",
     effort: "max",
+    mode: "auto",
   });
 });
 
@@ -221,7 +222,7 @@ test("ProxyChannel.fireTurn posts the prompt to the runtime's conversation endpo
   }
 });
 
-test("ProxyChannel.fireTurn includes the routine's model/effort pins in the message body", async () => {
+test("ProxyChannel.fireTurn includes the routine's model/effort/mode pins in the message body", async () => {
   let body: unknown = null;
   const runtime = await startTestFetchServer(async (req) => {
     body = await req.json();
@@ -252,6 +253,7 @@ test("ProxyChannel.fireTurn includes the routine's model/effort pins in the mess
         provider: "openai-codex",
         model: "gpt-5.5",
         effort: "high",
+        mode: "auto",
       },
     );
     expect(body).toEqual({
@@ -259,6 +261,7 @@ test("ProxyChannel.fireTurn includes the routine's model/effort pins in the mess
       provider: "openai-codex",
       model: "gpt-5.5",
       effort: "high",
+      mode: "auto",
     });
   } finally {
     await runtime.stop();

--- a/packages/host/src/schedule/firer.ts
+++ b/packages/host/src/schedule/firer.ts
@@ -26,11 +26,12 @@ export class ChannelRoutineFirer implements RoutineFirer {
     // The routine's provider/model/effort pins ride alongside (absent =
     // inherit), with routinePin applying the read-time legacy id mapping —
     // the pin is what makes a routine's provider stick regardless of what
-    // other chats or routines have picked since.
+    // other chats or routines have picked since. Routine fires also pin
+    // Autopilot mode so they never block on ask_user/request_connection.
     // The creator's sub (C2) is threaded as the turn's acting-user so integration
     // calls act as them; absent for legacy creator-less routines → acts as owner.
     const createdBy = job.routine.created_by;
-    const pin = routinePin(job.routine);
+    const pin = { ...routinePin(job.routine), mode: "auto" as const };
     // A pin that resolves to no known provider (junk or a legacy id no alias
     // maps — routinePin passes those through verbatim) fails the run RIGHT
     // HERE with the real reason: fireRoutineRun marks the run errored with

--- a/packages/host/src/turn/dispatch.test.ts
+++ b/packages/host/src/turn/dispatch.test.ts
@@ -12,6 +12,7 @@ import type { TurnDeps } from "./deps";
 import { dispatchCloudrun } from "./dispatch";
 import { TurnQuota } from "./quota";
 import { TurnRelay } from "./relay";
+import { dispatchTurn } from "./start-turn";
 
 /**
  * End-to-end cloudrun dispatch against a FAKE turn runtime speaking the real
@@ -169,6 +170,30 @@ test("a turn: refreshes the expiring credential, sends access-only, pumps frames
   } finally {
     close();
   }
+});
+
+test("a pinned routine turn sends autopilot mode to the runtime", async () => {
+  const { deps } = makeDeps();
+  turnBodies = [];
+  const done = new Promise<void>((r) => {
+    deps.relay.subscribe("agent-1/c-auto", (e) => {
+      if (e.type === "done" || e.type === "error") r();
+    });
+  });
+
+  const outcome = await dispatchTurn(
+    deps,
+    ws,
+    agent,
+    "c-auto",
+    "run unattended",
+    undefined,
+    { provider: "openai-codex", mode: "auto" },
+  );
+  expect(outcome.status).toBe("accepted");
+  await done;
+
+  expect(turnBodies[0]?.mode).toBe("auto");
 });
 
 test("conversation list + history read straight from object storage", async () => {

--- a/packages/host/src/turn/start-turn.ts
+++ b/packages/host/src/turn/start-turn.ts
@@ -95,9 +95,11 @@ export async function dispatchTurn(
               conversationId: cid,
               text,
               nonce,
-              // Model/effort for this turn (omitted when absent → runtime inherits).
+              // Model/effort/mode for this turn (omitted when absent →
+              // runtime inherits/defaults).
               ...(pin?.model ? { model: pin.model } : {}),
               ...(effort ? { effort } : {}),
+              ...(pin?.mode ? { mode: pin.mode } : {}),
               gcsPrefix: prefix,
               credential: cred
                 ? {

--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -121,9 +121,9 @@ export interface Settings {
 
 /**
  * Per-turn agent execution mode. "execute" = full read/write/act (the default
- * for unpinned turns — routines and cloud turns never inherit a pinned mode);
- * "plan" = read-only tools plus a planning overlay, producing a plan for the
- * user to approve; "auto" (Autopilot) = acts with everything EXCEPT the two
+ * for unpinned turns; routine fire paths explicitly pin "auto"); "plan" =
+ * read-only tools plus a planning overlay, producing a plan for the user to
+ * approve; "auto" (Autopilot) = acts with everything EXCEPT the two
  * blocking/interactive tools (`ask_user`, `request_connection`) — it never waits
  * on the user, makes its own sensible choices, and reports back at the end.
  * Deliberately NOT part of `Settings`: mode rides the per-turn pin only, so an

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -38,15 +38,15 @@ import { newInteractionHolder, runWithInteractionCapture } from "./interaction";
 import { switchNeedsCompaction } from "./provider-switch";
 import { createStallWatchdog } from "./stall-watchdog";
 
-/** A routine's pinned provider/model/effort for this turn. Absent = keep the session's current. */
+/** A turn's pinned provider/model/effort/mode. Absent = keep current/default. */
 export interface TurnPin {
   provider?: string | null;
   model?: string | null;
   effort?: string | null;
   /**
-   * The turn's execution mode ("plan" = read-only + planning overlay). Rides the
-   * per-turn pin ONLY — never `Settings` — so an unpinned turn is always
-   * "execute". A flip from the live session's mode rebuilds the session.
+   * The turn's execution mode ("plan" = read-only + planning overlay, "auto" =
+   * Autopilot). Rides the per-turn pin ONLY — never `Settings` — so an unpinned
+   * turn is always "execute". A flip from the live session's mode rebuilds it.
    */
   mode?: TurnMode | null;
 }
@@ -192,7 +192,7 @@ export async function execTurn(
     // A bad model id throws here → surfaces as the turn's error event.
     const model = resolveModel(pin?.model, pin?.provider);
     // The turn's execution mode: the pin's, else execute. Never inherited from
-    // Settings — an unpinned turn (incl. every routine + cloud turn) is execute.
+    // Settings. Routine fire paths pin auto; an actually unpinned turn is execute.
     const mode = pin?.mode ?? DEFAULT_TURN_MODE;
     const providerChanged = model.provider !== conv.provider;
     const modelChanged = model.id !== conv.model;

--- a/packages/runtime/src/turn/types.ts
+++ b/packages/runtime/src/turn/types.ts
@@ -24,8 +24,8 @@ export interface TurnRequest {
   effort?: string;
   /**
    * Per-turn execution mode ("plan" = read-only + planning overlay; "auto" =
-   * Autopilot, acts without the blocking tools). Absent = execute. Routines never
-   * set a mode; a non-execute turn here is a user-initiated one.
+   * Autopilot, acts without the blocking tools). Absent = execute. Routine fire
+   * paths set "auto" so scheduled work never waits for user intervention.
    */
   mode?: TurnMode;
 }


### PR DESCRIPTION
## Summary

- Pin routine-fired turns to Autopilot mode so scheduled work cannot block on ask_user/request_connection
- Forward turn mode through standing runtime and per-turn cloud dispatch paths
- Add coverage for routine autopilot mode propagation and update architecture notes

## Tests
- pnpm check:fix
- pnpm check
- pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test
- pnpm --filter @houston/host --filter @houston/runtime --filter @houston/protocol 