### PR TITLE
fix(chat): mission log stays open and shows thinking + tool calls everywhere (HOU-717)

### DIFF
--- a/packages/host/src/turn/relay-dialect.ts
+++ b/packages/host/src/turn/relay-dialect.ts
@@ -55,6 +55,20 @@ export function parseSnapshot(raw: string | null): ConversationSnapshot {
       partial: s.partial,
       seq: s.seq,
       ...(s.turnId ? { turnId: s.turnId } : {}),
+      // The running turn's activity (HOU-717) — ADDITIVE fields, so no
+      // dialect bump: an old replica's parse simply drops them (the sync
+      // degrades to text-only), and an old snapshot reads as "no activity".
+      ...(typeof s.thinking === "string" ? { thinking: s.thinking } : {}),
+      ...(Array.isArray(s.tools)
+        ? {
+            tools: s.tools.filter(
+              (t): t is NonNullable<ConversationSnapshot["tools"]>[number] =>
+                t !== null &&
+                typeof t === "object" &&
+                typeof (t as { name?: unknown }).name === "string",
+            ),
+          }
+        : {}),
     };
   }
   return EMPTY_SNAPSHOT;

--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -150,6 +150,13 @@ export type ChatRole = "user" | "assistant";
 
 export interface ToolCallRecord {
   name: string;
+  /**
+   * The tool call's arguments, exactly as the live `tool_start` frame carried
+   * them. Persisted so a reloaded conversation's mission log shows WHAT each
+   * tool did (the command run, the file written), not just the tool's name
+   * (HOU-717). Absent on records written before this field existed.
+   */
+  input?: unknown;
   isError?: boolean;
 }
 
@@ -189,6 +196,14 @@ export interface ChatMessage {
    */
   author?: { userId: string; name?: string };
   tools?: ToolCallRecord[];
+  /**
+   * The turn's full reasoning text (the model's thinking blocks, concatenated
+   * in stream order). Persisted so a reloaded conversation's mission log
+   * replays the reasoning alongside the tool calls (HOU-717) instead of
+   * dropping it. Absent on messages written before this field existed and on
+   * turns that produced no reasoning.
+   */
+  thinking?: string;
   /** Normalized usage for the turn this assistant message completed, when the
    *  provider reported it. Persisted so the context indicator survives a reload. */
   usage?: TokenUsage | null;

--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -157,6 +157,12 @@ export interface ToolCallRecord {
    * (HOU-717). Absent on records written before this field existed.
    */
   input?: unknown;
+  /**
+   * The tool's output preview, as the live `tool_end` frame carried it
+   * (already clipped to `TOOL_RESULT_PREVIEW_MAX` at the backend). Same
+   * reload story and absence semantics as `input`.
+   */
+  result?: string;
   isError?: boolean;
 }
 

--- a/packages/protocol/src/wire.ts
+++ b/packages/protocol/src/wire.ts
@@ -48,6 +48,20 @@ export type WireEvent =
         resync?: boolean;
         /** The RUNNING turn's id (see WireFrame.turnId). Absent when idle. */
         turnId?: string;
+        /**
+         * The running turn's reasoning so far (cumulative, like `partial`).
+         * A client attaching mid-turn replays it so the mission log shows the
+         * thinking that streamed before it connected (HOU-717). Absent when
+         * idle, when the turn produced none, or from a pre-field server.
+         */
+        thinking?: string;
+        /**
+         * The running turn's tool calls so far, in stream order. `isError`
+         * present means the tool has ENDED (with that error flag); absent
+         * means it is still running — only the last entry can be. Same
+         * absence semantics as `thinking`.
+         */
+        tools?: { name: string; input?: unknown; isError?: boolean }[];
       };
     }
   | {

--- a/packages/protocol/src/wire.ts
+++ b/packages/protocol/src/wire.ts
@@ -58,10 +58,16 @@ export type WireEvent =
         /**
          * The running turn's tool calls so far, in stream order. `isError`
          * present means the tool has ENDED (with that error flag); absent
-         * means it is still running — only the last entry can be. Same
-         * absence semantics as `thinking`.
+         * means it is still running — only the last entry can be. `content`
+         * is an ended tool's output preview (already clipped). Same absence
+         * semantics as `thinking`.
          */
-        tools?: { name: string; input?: unknown; isError?: boolean }[];
+        tools?: {
+          name: string;
+          input?: unknown;
+          isError?: boolean;
+          content?: string;
+        }[];
       };
     }
   | {
@@ -81,7 +87,20 @@ export type WireEvent =
   | { type: "text"; data: string }
   | { type: "thinking"; data: string }
   | { type: "tool_start"; data: { name: string; args: unknown } }
-  | { type: "tool_end"; data: { name: string; isError: boolean } }
+  | {
+      type: "tool_end";
+      data: {
+        name: string;
+        isError: boolean;
+        /**
+         * The tool's output text (what the model saw), clipped to
+         * {@link TOOL_RESULT_PREVIEW_MAX} at the emitting backend so the
+         * mission log can show WHAT a tool returned (HOU-717). Absent from
+         * pre-field servers and from tools that produced no text.
+         */
+        content?: string;
+      };
+    }
   | { type: "usage"; data: TokenUsage }
   | {
       /**
@@ -156,6 +175,22 @@ export type WireEvent =
   | { type: "error"; data: { message: string } };
 
 export type WireEventType = WireEvent["type"];
+
+/**
+ * Cap for the tool-output preview carried on `tool_end` (and persisted /
+ * replayed from it). Applied at the EMITTING backend, so everything
+ * downstream — feed, snapshot, conversation file — carries already-clipped
+ * text. Generous enough for the mission log's truncated code block; a full
+ * transcript is the model's context, not the UI's.
+ */
+export const TOOL_RESULT_PREVIEW_MAX = 4_000;
+
+/** Clip a tool-output preview to {@link TOOL_RESULT_PREVIEW_MAX}. */
+export function clipToolResult(text: string): string {
+  return text.length <= TOOL_RESULT_PREVIEW_MAX
+    ? text
+    : `${text.slice(0, TOOL_RESULT_PREVIEW_MAX)}\n… (truncated)`;
+}
 
 /**
  * A conversation-stream frame: a WireEvent plus its position in the stream.

--- a/packages/runtime-client/src/snapshot.test.ts
+++ b/packages/runtime-client/src/snapshot.test.ts
@@ -56,17 +56,25 @@ test("thinking + tools accumulate for the running turn and reset on the next (HO
   });
   s = reduceSnapshot(s, {
     type: "tool_end",
-    data: { name: "bash", isError: false },
+    data: { name: "bash", isError: false, content: "file-a\nfile-b" },
     seq: 5,
   });
   s = reduceSnapshot(s, { type: "text", data: "done", seq: 6 });
-  // text carries the activity through; tool_end stamps the ended flag.
+  // text carries the activity through; tool_end stamps the ended flag and
+  // the output preview.
   expect(s).toEqual({
     running: true,
     partial: "done",
     seq: 6,
     thinking: "plan steps",
-    tools: [{ name: "bash", input: { cmd: "ls" }, isError: false }],
+    tools: [
+      {
+        name: "bash",
+        input: { cmd: "ls" },
+        isError: false,
+        content: "file-a\nfile-b",
+      },
+    ],
   });
   // A NEW turn starts clean: no inherited thinking/tools (and the omitted
   // fields must not serialize).

--- a/packages/runtime-client/src/snapshot.test.ts
+++ b/packages/runtime-client/src/snapshot.test.ts
@@ -22,10 +22,62 @@ test("seq follows the folded frames' seq, including through the terminal frame",
     data: { name: "ls", args: {} },
     seq: 4,
   });
-  expect(s).toEqual({ running: true, partial: "Hello", seq: 4 });
+  expect(s).toEqual({
+    running: true,
+    partial: "Hello",
+    seq: 4,
+    tools: [{ name: "ls", input: {} }],
+  });
   s = reduceSnapshot(s, { type: "done", data: null, seq: 5 });
   // Turn over, watermark kept — the counter outlives the turn.
   expect(s).toEqual({ running: false, partial: "", seq: 5 });
+});
+
+test("thinking + tools accumulate for the running turn and reset on the next (HOU-717)", () => {
+  let s = reduceSnapshot(EMPTY_SNAPSHOT, {
+    type: "user",
+    data: { content: "go", ts: 1 },
+    seq: 1,
+  });
+  s = reduceSnapshot(s, { type: "thinking", data: "plan ", seq: 2 });
+  s = reduceSnapshot(s, { type: "thinking", data: "steps", seq: 3 });
+  s = reduceSnapshot(s, {
+    type: "tool_start",
+    data: { name: "bash", args: { cmd: "ls" } },
+    seq: 4,
+  });
+  // The started tool is tracked WITHOUT isError — it is still running.
+  expect(s).toEqual({
+    running: true,
+    partial: "",
+    seq: 4,
+    thinking: "plan steps",
+    tools: [{ name: "bash", input: { cmd: "ls" } }],
+  });
+  s = reduceSnapshot(s, {
+    type: "tool_end",
+    data: { name: "bash", isError: false },
+    seq: 5,
+  });
+  s = reduceSnapshot(s, { type: "text", data: "done", seq: 6 });
+  // text carries the activity through; tool_end stamps the ended flag.
+  expect(s).toEqual({
+    running: true,
+    partial: "done",
+    seq: 6,
+    thinking: "plan steps",
+    tools: [{ name: "bash", input: { cmd: "ls" }, isError: false }],
+  });
+  // A NEW turn starts clean: no inherited thinking/tools (and the omitted
+  // fields must not serialize).
+  s = reduceSnapshot(s, {
+    type: "user",
+    data: { content: "next", ts: 2 },
+    seq: 7,
+  });
+  expect(s).toEqual({ running: true, partial: "", seq: 7 });
+  expect("thinking" in s).toBe(false);
+  expect("tools" in s).toBe(false);
 });
 
 test("an unsequenced event keeps the previous watermark", () => {

--- a/packages/runtime-client/src/snapshot.ts
+++ b/packages/runtime-client/src/snapshot.ts
@@ -19,8 +19,15 @@ import type { WireFrame } from "./types";
  * the terminal frame it synthesizes.
  */
 /** One of the running turn's tool calls, as the snapshot tracks it. `isError`
- *  present = the tool ENDED (with that flag); absent = still running. */
-export type SnapshotTool = { name: string; input?: unknown; isError?: boolean };
+ *  present = the tool ENDED (with that flag); absent = still running.
+ *  `content` is an ended tool's output preview (already clipped at the
+ *  emitting backend). */
+export type SnapshotTool = {
+  name: string;
+  input?: unknown;
+  isError?: boolean;
+  content?: string;
+};
 
 export type ConversationSnapshot = {
   running: boolean;
@@ -105,7 +112,11 @@ export function reduceSnapshot(
       for (let i = tools.length - 1; i >= 0; i--) {
         const t = tools[i];
         if (t && t.isError === undefined) {
-          tools[i] = { ...t, isError: event.data.isError };
+          tools[i] = {
+            ...t,
+            isError: event.data.isError,
+            ...(event.data.content ? { content: event.data.content } : {}),
+          };
           break;
         }
       }

--- a/packages/runtime-client/src/snapshot.ts
+++ b/packages/runtime-client/src/snapshot.ts
@@ -18,11 +18,22 @@ import type { WireFrame } from "./types";
  * WHICH turn is running, and it is what the relay's dead-pump reaper stamps on
  * the terminal frame it synthesizes.
  */
+/** One of the running turn's tool calls, as the snapshot tracks it. `isError`
+ *  present = the tool ENDED (with that flag); absent = still running. */
+export type SnapshotTool = { name: string; input?: unknown; isError?: boolean };
+
 export type ConversationSnapshot = {
   running: boolean;
   partial: string;
   seq: number;
   turnId?: string;
+  /** The running turn's reasoning so far (cumulative, like `partial`). Omitted
+   *  when idle or when the turn produced none — a late subscriber replays it
+   *  so the mission log shows what streamed before it connected (HOU-717). */
+  thinking?: string;
+  /** The running turn's tool calls so far, in stream order. Same omission
+   *  semantics as `thinking`. */
+  tools?: SnapshotTool[];
 };
 
 export const EMPTY_SNAPSHOT: ConversationSnapshot = {
@@ -32,15 +43,15 @@ export const EMPTY_SNAPSHOT: ConversationSnapshot = {
 };
 
 /**
- * Fold a wire frame into the running snapshot. Pure. `partial` tracks only
- * assistant *text* (enough to redraw the in-flight bubble); tool/thinking
- * frames keep the turn marked running without touching it. `seq` advances to
- * the frame's seq (kept as-is for an unsequenced event) — including on the
- * terminal frames, so the watermark outlives the turn. `turnId` is adopted
- * from the frames (a `user` frame starts a new turn, so its id — possibly
- * absent on a legacy frame — REPLACES the previous one) and dropped with the
- * terminal frame; `undefined` fields are omitted so the snapshot serializes
- * without noise.
+ * Fold a wire frame into the running snapshot. Pure. `partial` tracks the
+ * assistant *text*; `thinking`/`tools` track the turn's reasoning and tool
+ * activity (HOU-717 — a late subscriber replays them so the mission log is
+ * complete, not just the text bubble). `seq` advances to the frame's seq
+ * (kept as-is for an unsequenced event) — including on the terminal frames,
+ * so the watermark outlives the turn. `turnId` is adopted from the frames (a
+ * `user` frame starts a new turn, so its id — possibly absent on a legacy
+ * frame — REPLACES the previous one) and dropped with the terminal frame;
+ * `undefined` fields are omitted so the snapshot serializes without noise.
  */
 export function reduceSnapshot(
   prev: ConversationSnapshot,
@@ -48,8 +59,15 @@ export function reduceSnapshot(
 ): ConversationSnapshot {
   const seq = event.seq ?? prev.seq;
   const turnOf = (id: string | undefined) => (id ? { turnId: id } : {});
+  // The running turn's accumulated activity, carried through non-terminal
+  // frames (omitted keys stay omitted so the snapshot serializes lean).
+  const activity = () => ({
+    ...(prev.thinking !== undefined ? { thinking: prev.thinking } : {}),
+    ...(prev.tools !== undefined ? { tools: prev.tools } : {}),
+  });
   switch (event.type) {
     case "user":
+      // A new turn: reset text AND the previous turn's thinking/tools.
       return { running: true, partial: "", seq, ...turnOf(event.turnId) };
     case "text":
       return {
@@ -57,10 +75,49 @@ export function reduceSnapshot(
         partial: prev.partial + event.data,
         seq,
         ...turnOf(event.turnId ?? prev.turnId),
+        ...activity(),
       };
     case "thinking":
+      return {
+        running: true,
+        partial: prev.partial,
+        seq,
+        ...turnOf(event.turnId ?? prev.turnId),
+        ...activity(),
+        thinking: (prev.thinking ?? "") + event.data,
+      };
     case "tool_start":
-    case "tool_end":
+      return {
+        running: true,
+        partial: prev.partial,
+        seq,
+        ...turnOf(event.turnId ?? prev.turnId),
+        ...activity(),
+        tools: [
+          ...(prev.tools ?? []),
+          { name: event.data.name, input: event.data.args },
+        ],
+      };
+    case "tool_end": {
+      // Mark the last still-running tool as ended. Tools run one at a time
+      // within a turn, so that is the tool this frame closes.
+      const tools = [...(prev.tools ?? [])];
+      for (let i = tools.length - 1; i >= 0; i--) {
+        const t = tools[i];
+        if (t && t.isError === undefined) {
+          tools[i] = { ...t, isError: event.data.isError };
+          break;
+        }
+      }
+      return {
+        running: true,
+        partial: prev.partial,
+        seq,
+        ...turnOf(event.turnId ?? prev.turnId),
+        ...activity(),
+        ...(tools.length ? { tools } : {}),
+      };
+    }
     case "usage":
     case "file_changes":
       return {
@@ -68,6 +125,7 @@ export function reduceSnapshot(
         partial: prev.partial,
         seq,
         ...turnOf(event.turnId ?? prev.turnId),
+        ...activity(),
       };
     case "done":
     case "error":
@@ -87,6 +145,7 @@ export function reduceSnapshot(
         partial: prev.partial,
         seq,
         ...turnOf(event.turnId ?? prev.turnId),
+        ...activity(),
       };
     case "sync":
       return prev; // sync is a read-out, never published back in

--- a/packages/runtime-client/src/types.ts
+++ b/packages/runtime-client/src/types.ts
@@ -36,7 +36,13 @@ export type {
 } from "@houston/protocol";
 // The Claude-subscription credential VALIDATOR (a value, not just a type) — the
 // runtime's host→pod materialization route validates the pushed envelope with it.
-export { parseClaudeOAuthEnvelope } from "@houston/protocol";
+// The tool-output preview clip (values) — applied by every backend that emits
+// `tool_end.content`, so downstream carriers never re-clip.
+export {
+  clipToolResult,
+  parseClaudeOAuthEnvelope,
+  TOOL_RESULT_PREVIEW_MAX,
+} from "@houston/protocol";
 
 /** The runtime's own conversation-core surface version (`GET /version`). */
 export const PROTOCOL_VERSION = 2;

--- a/packages/runtime/src/backends/claude/translate-support.ts
+++ b/packages/runtime/src/backends/claude/translate-support.ts
@@ -84,4 +84,19 @@ export interface UserContentBlock {
   type?: string;
   tool_use_id?: string;
   is_error?: boolean;
+  /** Result payload: a plain string or text/image blocks. */
+  content?: string | { type?: string; text?: string }[];
+}
+
+/**
+ * The text a `tool_result` block returned to the model — a plain string, or
+ * its `text` blocks joined. Image blocks have no text and are skipped.
+ */
+export function toolResultText(content: UserContentBlock["content"]): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((b) => b?.type === "text" && typeof b.text === "string")
+    .map((b) => b.text as string)
+    .join("\n");
 }

--- a/packages/runtime/src/backends/claude/translate.test.ts
+++ b/packages/runtime/src/backends/claude/translate.test.ts
@@ -161,6 +161,39 @@ test("a tool_result for an unknown id (replayed/foreign) is dropped", () => {
   expect(events).toEqual([]);
 });
 
+test("a tool_result's text rides the tool_end as its content preview (HOU-717)", () => {
+  const withContent = {
+    type: "user",
+    message: {
+      role: "user",
+      content: [
+        {
+          type: "tool_result",
+          tool_use_id: "abc",
+          is_error: false,
+          content: [
+            { type: "text", text: "line one" },
+            { type: "text", text: "line two" },
+          ],
+        },
+      ],
+    },
+    parent_tool_use_id: null,
+  } as unknown as SDKMessage;
+  const { events } = collect([
+    toolStart(0, "abc", "Grep"),
+    blockStop(0),
+    withContent,
+  ]);
+  expect(events).toEqual([
+    { type: "tool_start", data: { name: "Grep", args: {} } },
+    {
+      type: "tool_end",
+      data: { name: "Grep", isError: false, content: "line one\nline two" },
+    },
+  ]);
+});
+
 // --- result / usage / context ----------------------------------------------
 
 test("a success result yields a usage frame and updates context tokens", () => {

--- a/packages/runtime/src/backends/claude/translate.ts
+++ b/packages/runtime/src/backends/claude/translate.ts
@@ -1,11 +1,12 @@
 import type { SDKMessage } from "@anthropic-ai/claude-agent-sdk";
-import type { WireEvent } from "@houston/runtime-client";
+import { clipToolResult, type WireEvent } from "@houston/runtime-client";
 import { classifyText, mapSdkError } from "./errors";
 import {
   type EventLike,
   normalizeUsage,
   parseArgs,
   type ToolBlock,
+  toolResultText,
   type UserContentBlock,
 } from "./translate-support";
 
@@ -107,7 +108,17 @@ export function createStreamTranslator(cb: TranslatorCallbacks) {
       // replayed/foreign result (e.g. resume history) and must not emit tool_end.
       const name = block.tool_use_id && toolNameById.get(block.tool_use_id);
       if (!name) continue;
-      out.push({ type: "tool_end", data: { name, isError: !!block.is_error } });
+      // Carry the result's text (clipped) so the mission log can show what
+      // the tool returned — same contract as the pi backend (HOU-717).
+      const content = toolResultText(block.content);
+      out.push({
+        type: "tool_end",
+        data: {
+          name,
+          isError: !!block.is_error,
+          ...(content ? { content: clipToolResult(content) } : {}),
+        },
+      });
     }
     return out;
   }

--- a/packages/runtime/src/backends/pi/wire.test.ts
+++ b/packages/runtime/src/backends/pi/wire.test.ts
@@ -232,3 +232,54 @@ test("toWire ignores a stopReason 'error' with no errorMessage (falls back to us
     data: { context_tokens: 20, output_tokens: 5, cached_tokens: 0 },
   });
 });
+
+test("toWire carries a tool_execution_end's result text, clipped (HOU-717)", () => {
+  const ev = {
+    type: "tool_execution_end",
+    toolCallId: "t1",
+    toolName: "bash",
+    result: {
+      content: [
+        { type: "text", text: "file-a.ts" },
+        { type: "image", data: "…" },
+        { type: "text", text: "file-b.ts" },
+      ],
+      details: {},
+    },
+    isError: false,
+  } as unknown as AgentSessionEvent;
+  expect(toWire(ev)).toEqual({
+    type: "tool_end",
+    data: { name: "bash", isError: false, content: "file-a.ts\nfile-b.ts" },
+  });
+});
+
+test("toWire omits tool_end content for a text-less or malformed result", () => {
+  const bare = {
+    type: "tool_execution_end",
+    toolCallId: "t1",
+    toolName: "bash",
+    result: null,
+    isError: true,
+  } as unknown as AgentSessionEvent;
+  expect(toWire(bare)).toEqual({
+    type: "tool_end",
+    data: { name: "bash", isError: true },
+  });
+});
+
+test("toWire clips an oversized tool result to the preview cap", () => {
+  const ev = {
+    type: "tool_execution_end",
+    toolCallId: "t1",
+    toolName: "read",
+    result: { content: [{ type: "text", text: "x".repeat(10_000) }] },
+    isError: false,
+  } as unknown as AgentSessionEvent;
+  const wire = toWire(ev) as Extract<
+    NonNullable<ReturnType<typeof toWire>>,
+    { type: "tool_end" }
+  >;
+  expect(wire.data.content?.length).toBeLessThan(4_100);
+  expect(wire.data.content?.endsWith("… (truncated)")).toBe(true);
+});

--- a/packages/runtime/src/backends/pi/wire.ts
+++ b/packages/runtime/src/backends/pi/wire.ts
@@ -1,6 +1,10 @@
 import type { AssistantMessage } from "@earendil-works/pi-ai";
 import type { AgentSessionEvent } from "@earendil-works/pi-coding-agent";
-import type { TokenUsage, WireEvent } from "@houston/runtime-client";
+import {
+  clipToolResult,
+  type TokenUsage,
+  type WireEvent,
+} from "@houston/runtime-client";
 import { classifyProviderError } from "../../ai/provider-error";
 
 /**
@@ -79,11 +83,21 @@ export function toWire(e: AgentSessionEvent): WireEvent | null {
     }
     case "tool_execution_start":
       return { type: "tool_start", data: { name: e.toolName, args: e.args } };
-    case "tool_execution_end":
+    case "tool_execution_end": {
+      // Carry the tool's output text (what the model saw), clipped here at
+      // the source so every downstream carrier — feed, snapshot, history —
+      // holds a bounded preview (HOU-717). Image blocks have no text and
+      // are skipped; a text-less result omits the field.
+      const content = toolResultText(e.result);
       return {
         type: "tool_end",
-        data: { name: e.toolName, isError: !!e.isError },
+        data: {
+          name: e.toolName,
+          isError: !!e.isError,
+          ...(content ? { content: clipToolResult(content) } : {}),
+        },
       };
+    }
     case "turn_end": {
       // Fired once per turn with the final assistant message.
       //
@@ -135,6 +149,26 @@ export function toWire(e: AgentSessionEvent): WireEvent | null {
     default:
       return null;
   }
+}
+
+/**
+ * The text a pi tool result returned to the model — its `content` text blocks
+ * joined. Best-effort against `result: any`: anything not shaped like pi's
+ * `AgentToolResult` reads as "no text" rather than throwing mid-stream.
+ */
+function toolResultText(result: unknown): string {
+  const content = (result as { content?: unknown } | null | undefined)?.content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(
+      (b): b is { type: "text"; text: string } =>
+        b !== null &&
+        typeof b === "object" &&
+        (b as { type?: unknown }).type === "text" &&
+        typeof (b as { text?: unknown }).text === "string",
+    )
+    .map((b) => b.text)
+    .join("\n");
 }
 
 /**

--- a/packages/runtime/src/session/bus.test.ts
+++ b/packages/runtime/src/session/bus.test.ts
@@ -93,7 +93,13 @@ test("reduceSnapshot keeps the turn running through tool/thinking frames", () =>
   );
   s = reduceSnapshot(s, { type: "text", data: "work" });
   s = reduceSnapshot(s, { type: "tool_start", data: { name: "ls", args: {} } });
-  expect(s).toEqual({ running: true, partial: "work", seq: 0 }); // tool frame doesn't touch text
+  // tool frame doesn't touch text — it lands in the tools list (HOU-717)
+  expect(s).toEqual({
+    running: true,
+    partial: "work",
+    seq: 0,
+    tools: [{ name: "ls", input: {} }],
+  });
   s = reduceSnapshot(s, {
     type: "tool_end",
     data: { name: "ls", isError: false },

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -189,7 +189,10 @@ test("the turn's thinking and tool inputs are persisted on the assistant message
     emit({ type: "thinking", data: "first list, " });
     emit({ type: "thinking", data: "then decide" });
     emit({ type: "tool_start", data: { name: "bash", args: { cmd: "ls" } } });
-    emit({ type: "tool_end", data: { name: "bash", isError: false } });
+    emit({
+      type: "tool_end",
+      data: { name: "bash", isError: false, content: "file-a\nfile-b" },
+    });
     emit({ type: "text", data: "done" });
   });
 
@@ -206,7 +209,12 @@ test("the turn's thinking and tool inputs are persisted on the assistant message
     | undefined;
   expect(meta?.thinking).toBe("first list, then decide");
   expect(meta?.tools).toEqual([
-    { name: "bash", input: { cmd: "ls" }, isError: false },
+    {
+      name: "bash",
+      input: { cmd: "ls" },
+      result: "file-a\nfile-b",
+      isError: false,
+    },
   ]);
 });
 

--- a/packages/runtime/src/session/exec-turn.test.ts
+++ b/packages/runtime/src/session/exec-turn.test.ts
@@ -183,6 +183,33 @@ test("a provider_error turn emits no done — the pending interaction never ride
   expect(persistedInteraction(id)).toBeUndefined();
 });
 
+test("the turn's thinking and tool inputs are persisted on the assistant message (HOU-717)", async () => {
+  const id = "exec-activity-persist";
+  const conv = fakeConv((emit) => {
+    emit({ type: "thinking", data: "first list, " });
+    emit({ type: "thinking", data: "then decide" });
+    emit({ type: "tool_start", data: { name: "bash", args: { cmd: "ls" } } });
+    emit({ type: "tool_end", data: { name: "bash", isError: false } });
+    emit({ type: "text", data: "done" });
+  });
+
+  await execTurn(conv, id, "turn-1", "run it", {
+    author: undefined,
+    priorAuthors: [],
+  });
+
+  const call = vi
+    .mocked(appendAssistantMessage)
+    .mock.calls.find((c) => c[0] === id);
+  const meta = call?.[2] as
+    | { thinking?: string; tools?: unknown[] }
+    | undefined;
+  expect(meta?.thinking).toBe("first list, then decide");
+  expect(meta?.tools).toEqual([
+    { name: "bash", input: { cmd: "ls" }, isError: false },
+  ]);
+});
+
 test("pin.mode is threaded into switchModeIfNeeded for the turn", async () => {
   vi.mocked(switchModeIfNeeded).mockClear();
   const id = "exec-mode-plan";

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -172,7 +172,11 @@ export async function execTurn(
         tools.push({ name: wire.data.name, input: wire.data.args });
       else if (wire.type === "tool_end") {
         const t = tools[tools.length - 1];
-        if (t) t.isError = wire.data.isError;
+        if (t) {
+          t.isError = wire.data.isError;
+          // Already clipped at the backend — persist for reload replay.
+          if (wire.data.content) t.result = wire.data.content;
+        }
       } else if (wire.type === "provider_error") providerError = wire.data;
       // Every event proves the provider is alive → reset the stall clock (the
       // watchdog suspends itself while a tool runs and re-arms when it ends).

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -129,6 +129,9 @@ export async function execTurn(
   const { author, priorAuthors } = recorded;
 
   let assistantText = "";
+  // The turn's reasoning, accumulated for persistence so a history reload can
+  // replay it in the mission log (HOU-717) — same lifecycle as assistantText.
+  let thinkingText = "";
   let usage: TokenUsage | null = null;
   const tools: ToolCallRecord[] = [];
   // A typed provider failure for this turn. pi resolves the turn rather than
@@ -162,8 +165,10 @@ export async function execTurn(
   const subscribeSession = () => {
     unsub = conv.session.subscribe((wire: WireEvent) => {
       if (wire.type === "text") assistantText += wire.data;
+      else if (wire.type === "thinking") thinkingText += wire.data;
       else if (wire.type === "usage") usage = wire.data;
-      else if (wire.type === "tool_start") tools.push({ name: wire.data.name });
+      else if (wire.type === "tool_start")
+        tools.push({ name: wire.data.name, input: wire.data.args });
       else if (wire.type === "tool_end") {
         const t = tools[tools.length - 1];
         if (t) t.isError = wire.data.isError;
@@ -392,6 +397,7 @@ export async function execTurn(
     // (pi resolves the turn, it does not throw) with empty text, not in the catch.
     appendAssistantMessage(id, assistantText, {
       tools,
+      thinking: thinkingText || undefined,
       usage,
       providerSwitch,
       compaction,
@@ -430,6 +436,7 @@ export async function execTurn(
     // with a vague error 15 minutes later.
     appendAssistantMessage(id, assistantText, {
       tools,
+      thinking: thinkingText || undefined,
       usage,
       providerSwitch,
       compaction,

--- a/packages/runtime/src/store/conversation-file.ts
+++ b/packages/runtime/src/store/conversation-file.ts
@@ -65,6 +65,8 @@ export interface UserMessageMeta {
 /** Optional fields of a persisted assistant message. */
 export interface AssistantMessageMeta {
   tools?: ToolCallRecord[];
+  /** The turn's reasoning text, replayed into the mission log on reload (HOU-717). */
+  thinking?: string;
   usage?: TokenUsage | null;
   providerSwitch?: ChatMessage["providerSwitch"];
   compaction?: ChatMessage["compaction"];
@@ -124,6 +126,7 @@ export function appendAssistantMessageAt(
     content,
     ts: Date.now(),
     tools: meta.tools?.length ? meta.tools : undefined,
+    thinking: meta.thinking || undefined,
     usage: meta.usage ?? undefined,
     providerSwitch: meta.providerSwitch,
     compaction: meta.compaction,

--- a/packages/sdk/src/modules/turns/history.test.ts
+++ b/packages/sdk/src/modules/turns/history.test.ts
@@ -110,7 +110,14 @@ describe("historyToFeed", () => {
         content: "done",
         ts: 2,
         thinking: "first list the files, then decide",
-        tools: [{ name: "bash", input: { cmd: "ls" }, isError: false }],
+        tools: [
+          {
+            name: "bash",
+            input: { cmd: "ls" },
+            result: "file-a\nfile-b",
+            isError: false,
+          },
+        ],
       },
     ]);
     const thinkingIdx = feed.findIndex((f) => f.feed_type === "thinking");
@@ -123,6 +130,11 @@ describe("historyToFeed", () => {
     expect(feed[toolIdx]).toEqual({
       feed_type: "tool_call",
       data: { name: "bash", input: { cmd: "ls" } },
+    });
+    // The persisted output preview replays as the tool's result.
+    expect(feed[toolIdx + 1]).toEqual({
+      feed_type: "tool_result",
+      data: { content: "file-a\nfile-b", is_error: false },
     });
   });
 

--- a/packages/sdk/src/modules/turns/history.test.ts
+++ b/packages/sdk/src/modules/turns/history.test.ts
@@ -102,6 +102,30 @@ describe("historyToFeed", () => {
     });
   });
 
+  it("replays persisted reasoning before the tool calls, with their inputs (HOU-717)", () => {
+    const feed = historyToFeed([
+      { role: "user", content: "run it", ts: 1 },
+      {
+        role: "assistant",
+        content: "done",
+        ts: 2,
+        thinking: "first list the files, then decide",
+        tools: [{ name: "bash", input: { cmd: "ls" }, isError: false }],
+      },
+    ]);
+    const thinkingIdx = feed.findIndex((f) => f.feed_type === "thinking");
+    const toolIdx = feed.findIndex((f) => f.feed_type === "tool_call");
+    expect(feed[thinkingIdx]).toEqual({
+      feed_type: "thinking",
+      data: "first list the files, then decide",
+    });
+    expect(thinkingIdx).toBeLessThan(toolIdx);
+    expect(feed[toolIdx]).toEqual({
+      feed_type: "tool_call",
+      data: { name: "bash", input: { cmd: "ls" } },
+    });
+  });
+
   it("replays a persisted file-change summary after the assistant text", () => {
     const feed = historyToFeed([
       { role: "user", content: "make a report", ts: 1 },

--- a/packages/sdk/src/modules/turns/history.ts
+++ b/packages/sdk/src/modules/turns/history.ts
@@ -99,7 +99,7 @@ export function historyToFeed(
       });
       out.push({
         feed_type: "tool_result",
-        data: { content: "", is_error: !!t.isError },
+        data: { content: t.result ?? "", is_error: !!t.isError },
       });
     }
     if (m.content) out.push({ feed_type: "assistant_text", data: m.content });

--- a/packages/sdk/src/modules/turns/history.ts
+++ b/packages/sdk/src/modules/turns/history.ts
@@ -85,8 +85,18 @@ export function historyToFeed(
         },
       });
     }
+    // Replay the turn's reasoning BEFORE its tool calls — the live VM keeps a
+    // single thinking entry positioned where the first thinking block streamed
+    // (ahead of the tools), so a reload renders the mission log in the same
+    // order a live watcher saw (HOU-717).
+    if (m.thinking) {
+      out.push({ feed_type: "thinking", data: m.thinking });
+    }
     for (const t of m.tools ?? []) {
-      out.push({ feed_type: "tool_call", data: { name: t.name, input: {} } });
+      out.push({
+        feed_type: "tool_call",
+        data: { name: t.name, input: t.input ?? {} },
+      });
       out.push({
         feed_type: "tool_result",
         data: { content: "", is_error: !!t.isError },

--- a/packages/sdk/src/modules/turns/index.test.ts
+++ b/packages/sdk/src/modules/turns/index.test.ts
@@ -210,6 +210,57 @@ test("the turns/observe command drives the same observe path", async () => {
   expect(vm().feed.some((f) => f.data === "observed reply")).toBe(true);
 });
 
+test("observe replays the running turn's thinking + tools from the sync, deduped across a resync (HOU-717)", async () => {
+  const activityTurn: WireFrame[] = [
+    {
+      type: "sync",
+      data: {
+        running: true,
+        partial: "",
+        seq: 2,
+        thinking: "planning the steps",
+        tools: [
+          { name: "bash", input: { cmd: "ls" }, isError: false },
+          { name: "read", input: { path: "a.txt" } }, // still running
+        ],
+      },
+      seq: 2,
+    },
+    // Reconnect resync: same activity again (must NOT double), and the
+    // still-running tool has since ended (its result must land).
+    {
+      type: "sync",
+      data: {
+        running: true,
+        partial: "",
+        seq: 3,
+        resync: true,
+        thinking: "planning the steps",
+        tools: [
+          { name: "bash", input: { cmd: "ls" }, isError: false },
+          { name: "read", input: { path: "a.txt" }, isError: false },
+        ],
+      },
+      seq: 3,
+    },
+    { type: "text", data: "observed reply", seq: 4 },
+    { type: "done", data: null, seq: 5 },
+  ];
+  const { mod, vm } = harness(activityTurn);
+  await mod.observe("c1");
+  await waitFor(() => vm()?.sessionStatus === "completed");
+  const feed = vm().feed;
+  const thinking = feed.filter((f) => f.feed_type === "thinking");
+  expect(thinking).toHaveLength(1);
+  expect(thinking[0].data).toBe("planning the steps");
+  const calls = feed.filter((f) => f.feed_type === "tool_call");
+  expect(calls.map((f) => f.data)).toEqual([
+    { name: "bash", input: { cmd: "ls" } },
+    { name: "read", input: { path: "a.txt" } },
+  ]);
+  expect(feed.filter((f) => f.feed_type === "tool_result")).toHaveLength(2);
+});
+
 test("turns/cancel aborts the conversation's turn", async () => {
   const { commands, calls } = harness();
   await commands.get("turns/cancel")?.({ conversationId: "c1" });

--- a/packages/sdk/src/modules/turns/index.test.ts
+++ b/packages/sdk/src/modules/turns/index.test.ts
@@ -220,7 +220,7 @@ test("observe replays the running turn's thinking + tools from the sync, deduped
         seq: 2,
         thinking: "planning the steps",
         tools: [
-          { name: "bash", input: { cmd: "ls" }, isError: false },
+          { name: "bash", input: { cmd: "ls" }, isError: false, content: "ok" },
           { name: "read", input: { path: "a.txt" } }, // still running
         ],
       },
@@ -237,8 +237,13 @@ test("observe replays the running turn's thinking + tools from the sync, deduped
         resync: true,
         thinking: "planning the steps",
         tools: [
-          { name: "bash", input: { cmd: "ls" }, isError: false },
-          { name: "read", input: { path: "a.txt" }, isError: false },
+          { name: "bash", input: { cmd: "ls" }, isError: false, content: "ok" },
+          {
+            name: "read",
+            input: { path: "a.txt" },
+            isError: false,
+            content: "the file body",
+          },
         ],
       },
       seq: 3,
@@ -258,7 +263,12 @@ test("observe replays the running turn's thinking + tools from the sync, deduped
     { name: "bash", input: { cmd: "ls" } },
     { name: "read", input: { path: "a.txt" } },
   ]);
-  expect(feed.filter((f) => f.feed_type === "tool_result")).toHaveLength(2);
+  // Both results landed exactly once, carrying their output previews.
+  const results = feed.filter((f) => f.feed_type === "tool_result");
+  expect(results.map((f) => f.data)).toEqual([
+    { content: "ok", is_error: false },
+    { content: "the file body", is_error: false },
+  ]);
 });
 
 test("turns/cancel aborts the conversation's turn", async () => {

--- a/packages/sdk/src/modules/turns/settle-from-history.ts
+++ b/packages/sdk/src/modules/turns/settle-from-history.ts
@@ -73,6 +73,10 @@ function adoptReply(s: TurnState, reply: ChatMessage): void {
     return;
   }
   s.text = reply.content;
+  // Adopt the persisted reasoning only when nothing streamed live — a settle
+  // from history must not clobber (or double) what the watcher already saw
+  // (finishOk flushes `s.thinking` into the feed).
+  if (reply.thinking && !s.thinking) s.thinking = reply.thinking;
   if (reply.usage) s.usage = reply.usage;
   // A turn that ended asking the user for something persisted its interaction
   // (runtime, clean path only). Adopt it BEFORE finishOk so a settle from

--- a/packages/sdk/src/modules/turns/turn-frames.ts
+++ b/packages/sdk/src/modules/turns/turn-frames.ts
@@ -31,12 +31,14 @@ export function applyTurnFrame(
       push(s, { feed_type: "thinking_streaming", data: s.thinking });
       break;
     case "tool_start":
+      s.toolsSeen++;
       push(s, {
         feed_type: "tool_call",
         data: { name: ev.data.name, input: ev.data.args },
       });
       break;
     case "tool_end":
+      s.toolResultsSeen++;
       push(s, {
         feed_type: "tool_result",
         data: { content: "", is_error: ev.data.isError },

--- a/packages/sdk/src/modules/turns/turn-frames.ts
+++ b/packages/sdk/src/modules/turns/turn-frames.ts
@@ -41,7 +41,7 @@ export function applyTurnFrame(
       s.toolResultsSeen++;
       push(s, {
         feed_type: "tool_result",
-        data: { content: "", is_error: ev.data.isError },
+        data: { content: ev.data.content ?? "", is_error: ev.data.isError },
       });
       break;
     case "usage":

--- a/packages/sdk/src/modules/turns/turn-settle.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.ts
@@ -30,6 +30,14 @@ export interface TurnState {
   prompt: string | null;
   text: string;
   thinking: string;
+  /**
+   * How many of this turn's `tool_call` feed items were already pushed (live
+   * frames + sync replay) — the dedup cursor a running `sync`'s tool replay
+   * starts from, so a resync never doubles a tool row (HOU-717).
+   */
+  toolsSeen: number;
+  /** Same cursor for `tool_result` pushes. */
+  toolResultsSeen: number;
   usage: TokenUsage | null;
   settled: boolean;
   terminal: TerminalBoardStatus | null;
@@ -58,6 +66,8 @@ export function newTurnState(
     prompt: send?.prompt ?? null,
     text: "",
     thinking: "",
+    toolsSeen: 0,
+    toolResultsSeen: 0,
     usage: null,
     settled: false,
     terminal: null,

--- a/packages/sdk/src/modules/turns/turn-sink.ts
+++ b/packages/sdk/src/modules/turns/turn-sink.ts
@@ -8,6 +8,14 @@ import type { TurnSinkOptions } from "./turn-sink-options";
 
 export type { TurnSinkOptions } from "./turn-sink-options";
 
+/** One of the running turn's tools, as the `sync` frame reports it. */
+type SyncTool = {
+  name: string;
+  input?: unknown;
+  isError?: boolean;
+  content?: string;
+};
+
 /**
  * Folds one conversation's wire frames into FeedItem + SessionStatus pushes on
  * the sink's {@link FeedOutput}, and settles the turn ONLY on a terminal frame
@@ -130,7 +138,7 @@ export class TurnSink {
     resync?: boolean;
     turnId?: string;
     thinking?: string;
-    tools?: { name: string; input?: unknown; isError?: boolean }[];
+    tools?: SyncTool[];
   }): void {
     // Any sync after the first is a reconnect catch-up: seq servers only
     // re-sync when our cursor was unserviceable (`resync: true`), legacy
@@ -158,7 +166,7 @@ export class TurnSink {
     partial: string;
     turnId?: string;
     thinking?: string;
-    tools?: { name: string; input?: unknown; isError?: boolean }[];
+    tools?: SyncTool[];
   }): void {
     const mayAdopt = this.o.mode === "observer" || this.accepted;
     switch (classifyRunningSync(this.turnId, data.turnId, mayAdopt)) {
@@ -198,7 +206,7 @@ export class TurnSink {
    */
   private replaySyncActivity(data: {
     thinking?: string;
-    tools?: { name: string; input?: unknown; isError?: boolean }[];
+    tools?: SyncTool[];
   }): void {
     const s = this.s;
     if (data.thinking && data.thinking !== s.thinking) {
@@ -210,11 +218,11 @@ export class TurnSink {
     // A tool whose call we already pushed may have ENDED while we were away —
     // close it first (tools run serially, so results land in call order).
     while (s.toolResultsSeen < Math.min(s.toolsSeen, tools.length)) {
-      const ended = tools[s.toolResultsSeen].isError;
-      if (ended === undefined) break;
+      const t = tools[s.toolResultsSeen];
+      if (t.isError === undefined) break;
       push(s, {
         feed_type: "tool_result",
-        data: { content: "", is_error: ended },
+        data: { content: t.content ?? "", is_error: t.isError },
       });
       s.toolResultsSeen++;
     }
@@ -229,7 +237,7 @@ export class TurnSink {
       if (t.isError !== undefined) {
         push(s, {
           feed_type: "tool_result",
-          data: { content: "", is_error: t.isError },
+          data: { content: t.content ?? "", is_error: t.isError },
         });
         s.toolResultsSeen++;
       }

--- a/packages/sdk/src/modules/turns/turn-sink.ts
+++ b/packages/sdk/src/modules/turns/turn-sink.ts
@@ -129,6 +129,8 @@ export class TurnSink {
     partial: string;
     resync?: boolean;
     turnId?: string;
+    thinking?: string;
+    tools?: { name: string; input?: unknown; isError?: boolean }[];
   }): void {
     // Any sync after the first is a reconnect catch-up: seq servers only
     // re-sync when our cursor was unserviceable (`resync: true`), legacy
@@ -152,7 +154,12 @@ export class TurnSink {
     }
   }
 
-  private onRunningSync(data: { partial: string; turnId?: string }): void {
+  private onRunningSync(data: {
+    partial: string;
+    turnId?: string;
+    thinking?: string;
+    tools?: { name: string; input?: unknown; isError?: boolean }[];
+  }): void {
     const mayAdopt = this.o.mode === "observer" || this.accepted;
     switch (classifyRunningSync(this.turnId, data.turnId, mayAdopt)) {
       case "foreign":
@@ -167,6 +174,9 @@ export class TurnSink {
         break;
     }
     this.markRunning();
+    // Replay the running turn's activity BEFORE the text so the mission log
+    // folds in live order (thinking, then tools, then the reply bubble).
+    this.replaySyncActivity(data);
     // The server's authoritative in-flight assistant text REPLACES our
     // accumulation — empty string included: a stale splice must never survive
     // a resync. (Replayed frames, when servable, never reach a sync.)
@@ -176,6 +186,53 @@ export class TurnSink {
         feed_type: "assistant_text_streaming",
         data: this.s.text,
       });
+    }
+  }
+
+  /**
+   * Fold a running sync's `thinking`/`tools` (what streamed BEFORE we
+   * connected — a fresh attach gets no frame replay) into the feed, deduped
+   * so a resync never doubles what live frames or an earlier sync already
+   * pushed (HOU-717). Absent fields (pre-field server, or a turn with no
+   * activity yet) fold nothing.
+   */
+  private replaySyncActivity(data: {
+    thinking?: string;
+    tools?: { name: string; input?: unknown; isError?: boolean }[];
+  }): void {
+    const s = this.s;
+    if (data.thinking && data.thinking !== s.thinking) {
+      // Server-authoritative cumulative reasoning, same posture as `partial`.
+      s.thinking = data.thinking;
+      push(s, { feed_type: "thinking_streaming", data: s.thinking });
+    }
+    const tools = data.tools ?? [];
+    // A tool whose call we already pushed may have ENDED while we were away —
+    // close it first (tools run serially, so results land in call order).
+    while (s.toolResultsSeen < Math.min(s.toolsSeen, tools.length)) {
+      const ended = tools[s.toolResultsSeen].isError;
+      if (ended === undefined) break;
+      push(s, {
+        feed_type: "tool_result",
+        data: { content: "", is_error: ended },
+      });
+      s.toolResultsSeen++;
+    }
+    // Then the calls we never saw, each with its result when it already ended.
+    while (s.toolsSeen < tools.length) {
+      const t = tools[s.toolsSeen];
+      s.toolsSeen++;
+      push(s, {
+        feed_type: "tool_call",
+        data: { name: t.name, input: t.input ?? {} },
+      });
+      if (t.isError !== undefined) {
+        push(s, {
+          feed_type: "tool_result",
+          data: { content: "", is_error: t.isError },
+        });
+        s.toolResultsSeen++;
+      }
     }
   }
 

--- a/ui/chat/src/ai-elements/tool-block.tsx
+++ b/ui/chat/src/ai-elements/tool-block.tsx
@@ -46,28 +46,34 @@ export const ToolBlock = memo(
   ({ tool, isActive, toolLabels }: ToolBlockProps) => {
     // Bash output is shell stdout — opt out of the auto-open-while-active
     // behavior so the chat stays clean. The user can still click to expand.
-    const autoOpenWhileActive = toolShortName(tool.name) !== "Bash";
+    // (Two dialects: Claude's "Bash", pi's "bash".)
+    const autoOpenWhileActive =
+      toolShortName(tool.name).toLowerCase() !== "bash";
 
-    const [isOpen, setIsOpen] = useState(autoOpenWhileActive && isActive);
+    const initialAutoOpen = autoOpenWhileActive && isActive;
+    const [isOpen, setIsOpen] = useState(initialAutoOpen);
     const wasActiveRef = useRef(isActive);
-    const hasAutoClosedRef = useRef(false);
+    // Auto-close is armed ONLY while the pane is open from an AUTO open. A
+    // manual open must stay open until the user closes it — closing a row the
+    // user just expanded is the HOU-717 "dropdown keeps closing" bug.
+    const autoOpenedRef = useRef(initialAutoOpen);
 
     // Auto-open when becoming active (unless this tool opted out).
     useEffect(() => {
       if (!autoOpenWhileActive) return;
       if (isActive && !wasActiveRef.current) {
         setIsOpen(true);
-        hasAutoClosedRef.current = false;
+        autoOpenedRef.current = true;
       }
       wasActiveRef.current = isActive;
     }, [isActive, autoOpenWhileActive]);
 
-    // Auto-close after result arrives
+    // Auto-close after the result arrives — only an auto-opened pane.
     useEffect(() => {
-      if (tool.result && !isActive && isOpen && !hasAutoClosedRef.current) {
+      if (tool.result && !isActive && isOpen && autoOpenedRef.current) {
         const timer = setTimeout(() => {
           setIsOpen(false);
-          hasAutoClosedRef.current = true;
+          autoOpenedRef.current = false;
         }, AUTO_CLOSE_DELAY);
         return () => clearTimeout(timer);
       }
@@ -75,7 +81,8 @@ export const ToolBlock = memo(
 
     const handleOpenChange = useCallback((open: boolean) => {
       setIsOpen(open);
-      if (!open) hasAutoClosedRef.current = true;
+      // Any user toggle takes ownership: never auto-close a manual open.
+      autoOpenedRef.current = false;
     }, []);
 
     const Icon = getToolIcon(tool.name);

--- a/ui/chat/src/chat-process-groups.ts
+++ b/ui/chat/src/chat-process-groups.ts
@@ -49,10 +49,15 @@ function segmentFrom(
   };
 }
 
+/**
+ * HOU-717: keyed by the FIRST segment only. A streaming turn keeps appending
+ * segments, so a key that also names the last segment changes on every new
+ * thinking/tool block — React remounts the block and the user's open mission
+ * log snaps shut mid-run. The first segment is fixed for the life of the
+ * block (blocks flush on user/content boundaries, so no two share a first).
+ */
 function processKey(segments: ChatProcessSegment[]): string {
-  const first = segments[0]?.key ?? "empty";
-  const last = segments[segments.length - 1]?.key ?? first;
-  return `process-${first}-${last}`;
+  return `process-${segments[0]?.key ?? "empty"}`;
 }
 
 export function getChatDisplayItems(

--- a/ui/chat/src/tool-content.tsx
+++ b/ui/chat/src/tool-content.tsx
@@ -12,20 +12,29 @@ export const ToolContent = memo(({ tool }: { tool: ToolEntry }) => {
   const inp = tool.input as Record<string, unknown> | null | undefined;
   const result = tool.result;
 
+  // Two dialects: Claude tool names (PascalCase) and pi coding-agent names
+  // (lowercase). Same renderers for both (HOU-717).
   switch (short) {
     case "Bash":
+    case "bash":
       return <BashContent command={inp?.command as string} result={result} />;
     case "Read":
+    case "read":
       return <FileContent result={result} />;
     case "Edit":
+    case "edit":
       return <EditContent input={inp} result={result} />;
     case "Write":
+    case "write":
       return <FileContent result={result} label="Written" />;
     case "Grep":
     case "Glob":
+    case "grep":
+    case "find":
+    case "ls":
       return <SearchContent result={result} />;
     default:
-      return <GenericContent result={result} />;
+      return <GenericContent tool={tool} />;
   }
 });
 ToolContent.displayName = "ToolContent";
@@ -37,6 +46,11 @@ function BashContent({
   command?: string;
   result?: ToolEntry["result"];
 }) {
+  // A result with no text (a command with no stdout, or history from before
+  // outputs were persisted) renders the command line alone — never an empty
+  // output box (HOU-717).
+  const output = result?.content ? result : undefined;
+  if (!command && !output) return null;
   return (
     <div className="rounded-lg bg-zinc-900 text-zinc-100 overflow-hidden">
       {command && (
@@ -45,14 +59,14 @@ function BashContent({
             <span className="text-zinc-500">$ </span>
             {command}
           </div>
-          {result && <CodeBlockActions code={result.content} dark />}
+          {output && <CodeBlockActions code={output.content} dark />}
         </div>
       )}
-      {result && (
+      {output && (
         <TruncatedCode
-          content={result.content}
+          content={output.content}
           maxLines={15}
-          isError={result.is_error}
+          isError={output.is_error}
           dark
           showActions={!command}
         />
@@ -68,7 +82,7 @@ function FileContent({
   result?: ToolEntry["result"];
   label?: string;
 }) {
-  if (!result) return null;
+  if (!result?.content) return null;
   if (label && result.content === "ok") {
     return <p className="text-xs text-muted-foreground py-1">{label}</p>;
   }
@@ -93,13 +107,30 @@ function EditContent({
       </div>
     );
   }
+  // Claude's Edit carries old_string/new_string; pi's edit carries
+  // edits: [{ oldText, newText }] — normalize both to diff pairs.
+  const pairs: { old?: string; new?: string }[] = [];
   const oldStr = input?.old_string as string | undefined;
   const newStr = input?.new_string as string | undefined;
-  if (!oldStr && !newStr) return <GenericContent result={result} />;
+  if (oldStr || newStr) pairs.push({ old: oldStr, new: newStr });
+  const piEdits = input?.edits;
+  if (Array.isArray(piEdits)) {
+    for (const e of piEdits as { oldText?: string; newText?: string }[]) {
+      if (e?.oldText || e?.newText)
+        pairs.push({ old: e.oldText, new: e.newText });
+    }
+  }
+  if (pairs.length === 0) return <CodeResult result={result} maxLines={10} />;
   return (
     <div className="rounded-lg border border-border/50 overflow-hidden text-xs font-mono">
-      {oldStr && <DiffLine sign="-" text={oldStr} tone="red" />}
-      {newStr && <DiffLine sign="+" text={newStr} tone="green" />}
+      {pairs.map((p, i) => (
+        // Order is the render identity here: pairs are derived per render.
+        // biome-ignore lint/suspicious/noArrayIndexKey: static derived list
+        <div key={i}>
+          {p.old && <DiffLine sign="-" text={p.old} tone="red" />}
+          {p.new && <DiffLine sign="+" text={p.new} tone="green" />}
+        </div>
+      ))}
     </div>
   );
 }
@@ -136,22 +167,46 @@ function DiffLine({
 }
 
 function SearchContent({ result }: { result?: ToolEntry["result"] }) {
-  if (!result) return null;
   return <CodeResult result={result} maxLines={12} />;
 }
 
-function GenericContent({ result }: { result?: ToolEntry["result"] }) {
-  if (!result) return null;
-  return <CodeResult result={result} maxLines={10} />;
+/**
+ * Unknown tools: show the result text when there is one, else fall back to
+ * the call's arguments — an opened row must show SOMETHING about the call,
+ * never an empty box (HOU-717).
+ */
+function GenericContent({ tool }: { tool: ToolEntry }) {
+  if (tool.result?.content)
+    return <CodeResult result={tool.result} maxLines={10} />;
+  const args = formatArgs(tool.input);
+  if (!args) return null;
+  return (
+    <div className="rounded-lg border border-border/50 overflow-hidden">
+      <TruncatedCode content={args} maxLines={10} />
+    </div>
+  );
+}
+
+/** Pretty-print tool arguments; empty/absent args read as "nothing to show". */
+function formatArgs(input: unknown): string | null {
+  if (input == null) return null;
+  if (typeof input === "string") return input || null;
+  try {
+    const json = JSON.stringify(input, null, 2);
+    return json === "{}" || json === "[]" ? null : json;
+  } catch {
+    return null;
+  }
 }
 
 function CodeResult({
   result,
   maxLines,
 }: {
-  result: NonNullable<ToolEntry["result"]>;
+  result?: ToolEntry["result"];
   maxLines: number;
 }) {
+  if (!result?.content) return null;
   return (
     <div className="rounded-lg border border-border/50 overflow-hidden">
       <TruncatedCode content={result.content} maxLines={maxLines} />

--- a/ui/chat/src/tool-formatters.tsx
+++ b/ui/chat/src/tool-formatters.tsx
@@ -10,6 +10,7 @@ import {
   DownloadIcon,
   FilePlusIcon,
   FileTextIcon,
+  FolderIcon,
   FolderSearchIcon,
   GlobeIcon,
   PencilIcon,
@@ -27,6 +28,8 @@ export { ToolContent } from "./tool-content";
 
 type LucideIcon = ComponentType<{ className?: string }>;
 
+// Claude tool names (PascalCase) AND pi coding-agent names (lowercase) — both
+// dialects reach this map, so both get real icons instead of the wrench.
 const TOOL_ICONS: Record<string, LucideIcon> = {
   Bash: TerminalIcon,
   Read: FileTextIcon,
@@ -36,6 +39,13 @@ const TOOL_ICONS: Record<string, LucideIcon> = {
   Glob: FolderSearchIcon,
   WebSearch: GlobeIcon,
   WebFetch: DownloadIcon,
+  bash: TerminalIcon,
+  read: FileTextIcon,
+  edit: PencilIcon,
+  write: FilePlusIcon,
+  grep: SearchIcon,
+  find: FolderSearchIcon,
+  ls: FolderIcon,
 };
 
 export function getToolIcon(name: string): LucideIcon {
@@ -53,18 +63,27 @@ export function getToolDetail(name: string, input: unknown): string | null {
   const short = name.includes("__") ? (name.split("__").pop() ?? name) : name;
 
   switch (short) {
-    case "Bash": {
+    case "Bash":
+    case "bash": {
       const cmd = inp.command as string | undefined;
       if (!cmd) return null;
       return cmd.length > 80 ? `${cmd.slice(0, 77)}...` : cmd;
     }
+    // Claude's file tools carry `file_path`; pi's carry `path`.
     case "Read":
     case "Write":
     case "Edit":
-      return shortPath(inp.file_path as string | undefined);
+    case "read":
+    case "write":
+    case "edit":
+      return shortPath((inp.file_path ?? inp.path) as string | undefined);
     case "Grep":
     case "Glob":
+    case "grep":
+    case "find":
       return (inp.pattern as string | undefined) ?? null;
+    case "ls":
+      return shortPath(inp.path as string | undefined);
     case "WebSearch":
       return (inp.query as string | undefined) ?? null;
     case "WebFetch":

--- a/ui/chat/src/tool-labels.ts
+++ b/ui/chat/src/tool-labels.ts
@@ -9,6 +9,10 @@
  * locale (matching how the in-pane tool rows have always rendered).
  */
 
+// Two dialects share these maps: the Claude tool names (PascalCase) and the
+// pi coding-agent tool names (lowercase: bash/read/write/edit/grep/find/ls).
+// Both run through the same engine, so both must resolve to the same verbs —
+// an unmapped name leaks a raw "bash" row into the mission log (HOU-717).
 const ACTIVE_LABELS: Record<string, string> = {
   Read: "Reading file",
   Write: "Writing file",
@@ -20,6 +24,13 @@ const ACTIVE_LABELS: Record<string, string> = {
   WebFetch: "Fetching page",
   ToolSearch: "Looking up tools",
   Agent: "Delegating task",
+  read: "Reading file",
+  write: "Writing file",
+  edit: "Editing file",
+  bash: "Running command",
+  find: "Searching files",
+  grep: "Searching code",
+  ls: "Listing files",
 };
 
 const DONE_LABELS: Record<string, string> = {
@@ -33,6 +44,13 @@ const DONE_LABELS: Record<string, string> = {
   WebFetch: "Fetched page",
   ToolSearch: "Looked up tools",
   Agent: "Delegated task",
+  read: "Read file",
+  write: "Wrote file",
+  edit: "Edited file",
+  bash: "Ran command",
+  find: "Searched files",
+  grep: "Searched code",
+  ls: "Listed files",
 };
 
 /** The bare tool name with any MCP `server__tool` prefix stripped. */

--- a/ui/chat/tests/chat-process-groups.test.ts
+++ b/ui/chat/tests/chat-process-groups.test.ts
@@ -1,0 +1,68 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import { getChatDisplayItems } from "../src/chat-process-groups.ts";
+import type { ChatMessage } from "../src/feed-to-messages.ts";
+
+function assistant(key: string, over: Partial<ChatMessage>): ChatMessage {
+  return {
+    key,
+    from: "assistant",
+    content: "",
+    isStreaming: false,
+    tools: [],
+    fileChanges: [],
+    ...over,
+  };
+}
+
+const user: ChatMessage = {
+  key: "user-0",
+  from: "user",
+  content: "go",
+  isStreaming: false,
+  tools: [],
+  fileChanges: [],
+};
+
+// HOU-717: the process block's React key must be STABLE while a turn streams.
+// It used to encode the LAST segment too, so every new thinking/tool block
+// changed the key, remounted the block, and snapped the user's open mission
+// log shut mid-run.
+describe("process item key stability", () => {
+  it("keeps the same key as segments stream in, and across settle", () => {
+    const thinking = assistant("assistant-1", {
+      reasoning: { content: "hmm", isStreaming: true },
+    });
+    const early = getChatDisplayItems([user, thinking], "streaming");
+    const earlyProcess = early.find((i) => i.kind === "process");
+
+    const withTool = assistant("assistant-2", {
+      tools: [{ name: "bash", input: { cmd: "ls" } }],
+    });
+    const later = getChatDisplayItems([user, thinking, withTool], "streaming");
+    const laterProcess = later.find((i) => i.kind === "process");
+
+    const settled = getChatDisplayItems([user, thinking, withTool], "ready");
+    const settledProcess = settled.find((i) => i.kind === "process");
+
+    strictEqual(earlyProcess?.key, laterProcess?.key);
+    strictEqual(laterProcess?.key, settledProcess?.key);
+  });
+
+  it("gives distinct process blocks distinct keys", () => {
+    const first = assistant("assistant-1", {
+      tools: [{ name: "bash", input: {} }],
+    });
+    const secondUser: ChatMessage = { ...user, key: "user-2" };
+    const second = assistant("assistant-3", {
+      tools: [{ name: "read", input: {} }],
+    });
+    const items = getChatDisplayItems(
+      [user, first, secondUser, second],
+      "ready",
+    );
+    const keys = items.filter((i) => i.kind === "process").map((i) => i.key);
+    strictEqual(keys.length, 2);
+    strictEqual(new Set(keys).size, 2);
+  });
+});

--- a/ui/chat/tests/chat-process-header.test.ts
+++ b/ui/chat/tests/chat-process-header.test.ts
@@ -138,3 +138,24 @@ describe("getCurrentActionToolName", () => {
     strictEqual(getCurrentActionToolName([]), undefined);
   });
 });
+
+// HOU-717: the pi engine's tools are lowercase (bash/read/grep/find/ls) —
+// they must resolve to the same human verbs the Claude names do, or the
+// header reads "Mission in progress: bash".
+describe("pi tool-name labels", () => {
+  it("maps pi's lowercase tool names to verbs", () => {
+    const segments = [seg([{ name: "bash" }])];
+    strictEqual(
+      buildProcessHeaderLabel({ isActive: true, segments }),
+      "Mission in progress: Running command",
+    );
+  });
+
+  it("keeps the Claude names working unchanged", () => {
+    const segments = [seg([{ name: "Bash" }])];
+    strictEqual(
+      buildProcessHeaderLabel({ isActive: true, segments }),
+      "Mission in progress: Running command",
+    );
+  });
+});


### PR DESCRIPTION
Fixes HOU-717 — the "Mission in progress" log was unusable: the dropdown snapped shut on its own while the agent worked, and most of the time it showed nothing (no thinking, no tool calls).

## Root causes and fixes

**1. The open log closed by itself (the "buggy dropdown").**
The process block's React key was `process-<first>-<last>` over its segments. A streaming turn keeps appending segments, so the key changed on every new thinking/tool block, React remounted the block, and the Collapsible's `isOpen` state reset to closed. The key is now derived from the first segment only, which is stable for the life of the block (`ui/chat/src/chat-process-groups.ts`).

**2. A reopened conversation's mission log was empty.**
Persisted history (`ChatMessage`) carried no reasoning at all and only bare tool names (no inputs). Now:
- `ChatMessage.thinking` and `ToolCallRecord.input` are persisted (additive protocol fields),
- the runtime records them from the turn's wire frames (`exec-turn.ts`),
- the SDK history fold replays them — thinking before tools, matching live render order (`history.ts`),
- a settle-from-history adopts the persisted reasoning when nothing streamed live.

**3. Opening a RUNNING mission showed nothing until the next frame.**
A fresh SSE attach gets a `sync` frame that only carried the partial assistant text. The shared snapshot reducer now accumulates the running turn's thinking and tool calls, the `sync` frame carries them (additive, legacy servers/clients unaffected), and the turn sink replays them into the feed, deduped across resyncs so nothing doubles (`snapshot.ts`, `turn-sink.ts`). The host relay's snapshot parser carries the new fields through (no bus dialect bump needed — the fields are additive in both directions).

## Reproduction (before the fix)

1. Ask an agent something that runs several tools (e.g. "list my workspace files and summarize each one").
2. While "Mission in progress: …" is showing, click the chevron to open the log → within a second or two (as the next thinking/tool block streams in) the pane closes by itself.
3. Let the mission finish, close and reopen the conversation → open "Mission log": no reasoning at all, tools show names only.
4. Start a long mission, close the conversation, reopen it while the agent is still working → the log shows nothing that happened before you reopened.

## Verification (after the fix)

1. Same mission: open the log while the agent works → it stays open, thinking and tool calls stream in live.
2. Reopen a settled conversation → "Mission log" replays the reasoning and each tool call with its input.
3. Reopen a conversation mid-run → the log shows the thinking and tool calls that streamed before you attached, and continues live without duplicates.
4. `pnpm --filter @houston/protocol --filter @houston/runtime-client --filter @houston/runtime --filter @houston/sdk --filter @houston/host --filter @houston/domain test`, `pnpm -r typecheck`, `pnpm check`, `pnpm check:boundaries`, and `cd ui/chat && pnpm test` all pass. New tests cover the stable process key, the history fold, the snapshot accumulation, the sync replay dedup, and the runtime persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)