### PR TITLE
fix(app): remove the comet-head glow orb from orbit-loader

### DIFF
--- a/app/src/components/space/orbit-core.tsx
+++ b/app/src/components/space/orbit-core.tsx
@@ -2,9 +2,9 @@ import { ORBIT_CENTER } from "./orbit-path";
 
 /**
  * Shared SVG <defs> for {@link OrbitLoader}: the invisible motion path, the
- * core-bloom + comet-head radial gradients, and the trail-blur filter that
- * blends the streak capsules into one continuous glow. Split out so the loader
- * component stays under the 200-line limit.
+ * core-bloom radial gradient, and the trail-blur filter that blends the streak
+ * capsules into one continuous glow. Split out so the loader component stays
+ * under the 200-line limit.
  */
 export function OrbitDefs({ path }: { path: string }) {
   return (
@@ -28,18 +28,6 @@ export function OrbitDefs({ path }: { path: string }) {
           stopOpacity="0.14"
         />
         <stop offset="100%" stopColor="var(--ht-space-star)" stopOpacity="0" />
-      </radialGradient>
-      <radialGradient id="orbit-comet-glow">
-        <stop
-          offset="0%"
-          stopColor="var(--ht-space-foreground)"
-          stopOpacity="0.7"
-        />
-        <stop
-          offset="100%"
-          stopColor="var(--ht-space-foreground)"
-          stopOpacity="0"
-        />
       </radialGradient>
       {/* Soft blur so the overlapping streak capsules blend into one continuous
           glowing trail instead of reading as discrete blobs. userSpaceOnUse with

--- a/app/src/components/space/orbit-loader.tsx
+++ b/app/src/components/space/orbit-loader.tsx
@@ -81,17 +81,6 @@ export function OrbitLoader() {
                 </animateMotion>
               </ellipse>
             ))}
-            {/* Bright comet head glow, riding under the ship at the head's spot. */}
-            <circle r="12" fill="url(#orbit-comet-glow)">
-              <animateMotion
-                dur={ORBIT_PERIOD}
-                begin="0s"
-                repeatCount="indefinite"
-                rotate="auto"
-              >
-                <mpath href="#orbit-path" xlinkHref="#orbit-path" />
-              </animateMotion>
-            </circle>
             {/* Crisp rocket ship at the head, painted on top of its streak. */}
             <path d={SHIP_PATH} fill="var(--ht-space-foreground)">
               <animateMotion


### PR DESCRIPTION
## Summary
The orbit-loader rocket rode alongside a separate soft-glow circle at the same orbital position, which read as a fuzzy light floating in front of the ship rather than part of it. Removed the circle and its now-unused `orbit-comet-glow` radial gradient — the rocket and its trail already carry enough glow on their own.

## Test plan
- [x] `pnpm check` — Biome clean
- [x] `pnpm check:boundaries` — clean
- [x] `cd app && pnpm tsgo --noEmit` — clean
- [x] Visual verification via the standalone HTML preview in headless Chromium — confirmed the rocket now sits crisp at the head of the trail with no separate glow blob

🤖 Generated with [Claude Code](https://claude.com/claude-code)