### PR TITLE
fix(app): move the orbit-loader glow behind the ship as an engine flare

### DIFF
--- a/app/src/components/space/orbit-core.tsx
+++ b/app/src/components/space/orbit-core.tsx
@@ -2,9 +2,9 @@ import { ORBIT_CENTER } from "./orbit-path";
 
 /**
  * Shared SVG <defs> for {@link OrbitLoader}: the invisible motion path, the
- * core-bloom radial gradient, and the trail-blur filter that blends the streak
- * capsules into one continuous glow. Split out so the loader component stays
- * under the 200-line limit.
+ * core-bloom + engine-glow radial gradients, and the trail-blur filter that
+ * blends the streak capsules into one continuous glow. Split out so the loader
+ * component stays under the 200-line limit.
  */
 export function OrbitDefs({ path }: { path: string }) {
   return (
@@ -26,6 +26,14 @@ export function OrbitDefs({ path }: { path: string }) {
           offset="60%"
           stopColor="var(--ht-space-star)"
           stopOpacity="0.14"
+        />
+        <stop offset="100%" stopColor="var(--ht-space-star)" stopOpacity="0" />
+      </radialGradient>
+      <radialGradient id="orbit-engine-glow">
+        <stop
+          offset="0%"
+          stopColor="var(--ht-space-foreground)"
+          stopOpacity="0.8"
         />
         <stop offset="100%" stopColor="var(--ht-space-star)" stopOpacity="0" />
       </radialGradient>

--- a/app/src/components/space/orbit-loader.tsx
+++ b/app/src/components/space/orbit-loader.tsx
@@ -54,11 +54,15 @@ export function OrbitLoader() {
           strokeWidth="1.2"
         />
         {reduce ? (
-          <path
-            d={SHIP_PATH}
-            fill="var(--ht-space-foreground)"
-            transform={`translate(${STATIC_SHIP.x} ${STATIC_SHIP.y})`}
-          />
+          <g transform={`translate(${STATIC_SHIP.x} ${STATIC_SHIP.y})`}>
+            <circle
+              cx="-7"
+              r="5"
+              fill="url(#orbit-engine-glow)"
+              opacity="0.6"
+            />
+            <path d={SHIP_PATH} fill="var(--ht-space-foreground)" />
+          </g>
         ) : (
           <>
             {/* Comet streak, tail-first so the bright head paints on top. */}
@@ -81,8 +85,18 @@ export function OrbitLoader() {
                 </animateMotion>
               </ellipse>
             ))}
-            {/* Crisp rocket ship at the head, painted on top of its streak. */}
-            <path d={SHIP_PATH} fill="var(--ht-space-foreground)">
+            {/* Crisp rocket ship at the head, painted on top of its streak, with
+                a small engine glow riding fixed at its tail (behind it, not a
+                light out in front of the nose). Grouped under one animateMotion
+                so the glow stays locked to the ship's local frame as it banks. */}
+            <g>
+              <circle
+                cx="-7"
+                r="5"
+                fill="url(#orbit-engine-glow)"
+                opacity="0.6"
+              />
+              <path d={SHIP_PATH} fill="var(--ht-space-foreground)" />
               <animateMotion
                 dur={ORBIT_PERIOD}
                 begin="0s"
@@ -91,7 +105,7 @@ export function OrbitLoader() {
               >
                 <mpath href="#orbit-path" xlinkHref="#orbit-path" />
               </animateMotion>
-            </path>
+            </g>
           </>
         )}
       </g>

--- a/app/src/components/space/orbit-path.ts
+++ b/app/src/components/space/orbit-path.ts
@@ -40,10 +40,14 @@ const mix = (head: number) => `color-mix(in srgb, ${WHITE} ${head}%, ${STAR})`;
 
 /**
  * One soft blurred capsule in the comet streak. Each rides {@link ORBIT_PATH}
- * on the same period, offset by a negative `begin` so it lags behind the head,
- * shrinking and fading into the tail. Elongated along travel (`rx` > `ry`,
- * banked by `rotate="auto"`) and blurred, so the tightly-spaced copies overlap
- * into ONE continuous glowing streak rather than a line of discrete blobs.
+ * on the same period, offset by a POSITIVE `begin` (a delayed start) so it
+ * lags behind the head, shrinking and fading into the tail. A negative begin
+ * would do the opposite: SMIL treats it as "started earlier," so the element
+ * has already travelled further along the path than the head, putting it
+ * ahead of the ship instead of trailing it. Elongated along travel (`rx` >
+ * `ry`, banked by `rotate="auto"`) and blurred, so the tightly-spaced copies
+ * overlap into ONE continuous glowing streak rather than a line of discrete
+ * blobs.
  */
 export interface TrailCapsule {
   begin: string;
@@ -62,18 +66,18 @@ export interface TrailCapsule {
  * depth. Close `begin` spacing keeps the blurred capsules overlapping.
  */
 export const TRAIL: TrailCapsule[] = [
-  { begin: "-1.04s", rx: 4.4, ry: 1.9, opacity: 0.22, fill: mix(0) },
-  { begin: "-0.96s", rx: 4.7, ry: 2.0, opacity: 0.28, fill: mix(0) },
-  { begin: "-0.88s", rx: 5.0, ry: 2.1, opacity: 0.34, fill: mix(20) },
-  { begin: "-0.8s", rx: 5.4, ry: 2.2, opacity: 0.4, fill: mix(38) },
-  { begin: "-0.72s", rx: 5.8, ry: 2.3, opacity: 0.45, fill: mix(54) },
-  { begin: "-0.64s", rx: 6.2, ry: 2.4, opacity: 0.5, fill: mix(66) },
-  { begin: "-0.56s", rx: 6.6, ry: 2.5, opacity: 0.55, fill: mix(76) },
-  { begin: "-0.48s", rx: 7.0, ry: 2.7, opacity: 0.62, fill: mix(84) },
-  { begin: "-0.4s", rx: 7.4, ry: 2.8, opacity: 0.7, fill: mix(90) },
-  { begin: "-0.32s", rx: 7.8, ry: 2.9, opacity: 0.78, fill: mix(95) },
-  { begin: "-0.24s", rx: 8.2, ry: 3.0, opacity: 0.86, fill: mix(100) },
-  { begin: "-0.16s", rx: 8.6, ry: 3.2, opacity: 0.94, fill: mix(100) },
+  { begin: "1.04s", rx: 4.4, ry: 1.9, opacity: 0.22, fill: mix(0) },
+  { begin: "0.96s", rx: 4.7, ry: 2.0, opacity: 0.28, fill: mix(0) },
+  { begin: "0.88s", rx: 5.0, ry: 2.1, opacity: 0.34, fill: mix(20) },
+  { begin: "0.8s", rx: 5.4, ry: 2.2, opacity: 0.4, fill: mix(38) },
+  { begin: "0.72s", rx: 5.8, ry: 2.3, opacity: 0.45, fill: mix(54) },
+  { begin: "0.64s", rx: 6.2, ry: 2.4, opacity: 0.5, fill: mix(66) },
+  { begin: "0.56s", rx: 6.6, ry: 2.5, opacity: 0.55, fill: mix(76) },
+  { begin: "0.48s", rx: 7.0, ry: 2.7, opacity: 0.62, fill: mix(84) },
+  { begin: "0.4s", rx: 7.4, ry: 2.8, opacity: 0.7, fill: mix(90) },
+  { begin: "0.32s", rx: 7.8, ry: 2.9, opacity: 0.78, fill: mix(95) },
+  { begin: "0.24s", rx: 8.2, ry: 3.0, opacity: 0.86, fill: mix(100) },
+  { begin: "0.16s", rx: 8.6, ry: 3.2, opacity: 0.94, fill: mix(100) },
 ];
 
 /** Reduced-motion resting pose: a single ship parked on the ring's top vertex,


### PR DESCRIPTION
## Summary
Puts the glow back that was removed in #773, but repositioned: it now rides fixed at the ship's tail (grouped with the rocket path under a single `animateMotion`, offset to `cx="-7"` in the ship's local frame) instead of centered on the ship's own origin, which is what made it read as a light poking out ahead of the nose. It now reads as a small engine flare trailing behind the rocket, blending into the comet streak.

## Test plan
- [x] `pnpm check` — Biome clean
- [x] `pnpm check:boundaries` — clean
- [x] `cd app && pnpm tsgo --noEmit` — clean
- [x] Visual verification via the standalone HTML preview in headless Chromium — confirmed the nose is now clean with nothing ahead of it, and the glow sits behind blending into the trail

🤖 Generated with [Claude Code](https://claude.com/claude-code)