### PR TITLE
feat: sign-in becomes an interaction step; honest not-configured copy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,22 @@
 HOUSTON_HOST_TOKEN=devtoken
 HOUSTON_HOST_PORT=4318
 
+# --- Connected apps (integrations) — OPTIONAL, off by default ---
+# The host wires connected apps (Gmail, Calendar, ...) two mutually-exclusive
+# ways. Leave BOTH unset to run with integrations OFF (tool calls report the
+# apps aren't set up in this install, and the agent won't offer to connect).
+#
+#   1) Direct provider — one Composio project key (platform mode; free tier at
+#      composio.dev -> Project Settings -> API Keys). The host owns the key and
+#      users only OAuth the apps. Simplest for local dev. Self-host uses this.
+# COMPOSIO_API_KEY=<composio project key>
+#
+#   2) Gateway mode — point at the managed gateway instead of holding a key. The
+#      per-user credential is the Supabase session, so the app prompts Google
+#      sign-in first; a tool call while signed out queues a sign-in card in chat.
+#      This is how the desktop app reaches Houston's cloud.
+# HOUSTON_INTEGRATIONS_URL=<gateway url>
+
 # --- Desktop (app/): point the app at an EXTERNAL host instead of its own
 #     locally-spawned host sidecar. Read by BOTH Vite (the frontend client) and
 #     the Rust shell (app/src-tauri/src/lib.rs), which skips spawning the local

--- a/app/src-tauri/src/houston_prompt/integrations.rs
+++ b/app/src-tauri/src/houston_prompt/integrations.rs
@@ -23,6 +23,12 @@ CONNECTED, or execute fails because no account is linked):\n\n\
    connection goes live and automatically sends you a short message \
    (e.g. \"I've connected Gmail. Please continue.\") so you can resume the \
    task on your own. Then stop and wait.\n\n\
+If Houston reports that the user must sign in first, a sign-in card joins \
+the same interaction card automatically. Keep queueing whatever else the \
+task needs (call `request_connection` for any app, `ask_user` for any \
+questions) in the same turn, then end your turn. Never tell the user to open \
+Settings, and never claim connected apps are unavailable unless Houston says \
+they are not set up in this install.\n\n\
 Never spell out a connection link in your reply and never read any internal \
 identifier out loud to the user, and never name the integrations provider. \
 The card speaks for itself.";

--- a/app/src-tauri/src/houston_prompt/mod.rs
+++ b/app/src-tauri/src/houston_prompt/mod.rs
@@ -63,6 +63,10 @@ mod tests {
         assert!(prompt.contains("integration_execute"));
         assert!(prompt.contains("request_connection"));
         assert!(prompt.contains("I've connected Gmail. Please continue."));
+        // …the sign-in card joins the same flow, and app powers are never
+        // claimed unavailable unless Houston says they are not set up…
+        assert!(prompt.contains("a sign-in card joins"));
+        assert!(prompt.contains("not set up in this install"));
         // …the markdown-link connect hack is gone…
         assert!(!prompt.contains("houston_toolkit"));
         assert!(!prompt.contains("markdown link"));

--- a/app/src/components/chat-signin-interaction-card.tsx
+++ b/app/src/components/chat-signin-interaction-card.tsx
@@ -1,0 +1,77 @@
+import { useEffect, useRef } from "react";
+import { useTranslation } from "react-i18next";
+import { RowCard } from "./cards/row-card";
+import { RowCardButton } from "./cards/row-card-button";
+import { useIntegrationsGate } from "./integrations/use-integrations-gate";
+import { HoustonLogo } from "./shell/agent-avatar";
+
+interface ChatSigninInteractionCardProps {
+  /** Why the agent needs the user signed in, shown above the card when present. */
+  reason?: string;
+  /** Fired once the gate resolves `ready` (the Supabase session landed) so the
+   *  interaction sequence advances past this step. */
+  onSignedIn: () => void;
+}
+
+/**
+ * The signin-step content for a queued sign-in inside the shared
+ * {@link ChatInteractionCard} sequence (its `renderSignin` prop). A tool call hit
+ * `signin_required` (the desktop host has an integration registry but the user
+ * is signed out), so the host queued this step; the Sign in button drives the
+ * SAME Google SSO the Integrations tab uses (via {@link useIntegrationsGate}),
+ * and the sequence advances the instant the gate reports `ready`.
+ *
+ * Auto-advance also covers the STALE step: the user may have signed in elsewhere
+ * (the Integrations tab) between the turn ending and this card rendering, so the
+ * gate is ALREADY `ready` on first render with no button to click — fire
+ * `onSignedIn` once so the queued connects/answers still send, mirroring the
+ * connect card's already-connected self-report.
+ */
+export function ChatSigninInteractionCard({
+  reason,
+  onSignedIn,
+}: ChatSigninInteractionCardProps) {
+  const { t } = useTranslation("chat");
+  const gate = useIntegrationsGate();
+
+  // Advance at most once, the moment the session is live — whether the user
+  // signed in from the button here or had already signed in before the card
+  // mounted (stale step). A ref, not state: firing must not re-arm on re-render.
+  const fired = useRef(false);
+  useEffect(() => {
+    if (gate.kind === "ready" && !fired.current) {
+      fired.current = true;
+      onSignedIn();
+    }
+  }, [gate.kind, onSignedIn]);
+
+  const signingIn = gate.kind === "signin" && gate.signingIn;
+  // Sign-in kicked off (browser SSO) or the post-sign-in session resync is in
+  // flight (`loading`) / already resolved (`ready`, about to auto-advance):
+  // hold the pending look so the button never invites a second click.
+  const pending = signingIn || gate.kind === "loading" || gate.kind === "ready";
+
+  return (
+    <div className="flex flex-col gap-2">
+      <p className="text-sm text-foreground">
+        {reason ?? t("interaction.signinReason")}
+      </p>
+      <RowCard
+        surface="secondary"
+        media={<HoustonLogo size={20} />}
+        title={t("interaction.signinTitle")}
+        description={t("interaction.signinDescription")}
+        action={
+          <RowCardButton
+            label={t("interaction.signin")}
+            onClick={() => {
+              if (gate.kind === "signin") gate.signIn();
+            }}
+            loading={pending}
+            disabled={gate.kind !== "signin"}
+          />
+        }
+      />
+    </div>
+  );
+}

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -115,6 +115,7 @@ import { resolveEffectiveProvider } from "./chat-effective-provider";
 import { ChatEffortSelector } from "./chat-effort-selector";
 import { ChatModeSelector } from "./chat-mode-selector";
 import { ChatModelSelector } from "./chat-model-selector";
+import { ChatSigninInteractionCard } from "./chat-signin-interaction-card";
 import { ContextCompactedDivider } from "./context-compacted-divider";
 import { ContextIndicator } from "./context-indicator";
 import { DictationSetupDialog } from "./dictation-setup-dialog";
@@ -980,6 +981,10 @@ export function useAgentChatPanel({
     if (!agent || !activeInteraction) return undefined;
     const steps = activeInteraction.steps;
     const hasQuestionSteps = steps.some((step) => step.kind === "question");
+    // A completed sequence has walked EVERY step, so a signin step present here
+    // means the user signed in (the step advances only via `onSignedIn`) — no
+    // separate accumulator needed, unlike connections which carry a display name.
+    const hasSigninStep = steps.some((step) => step.kind === "signin");
     const connectedNames: string[] = [];
     return (
       <ChatInteractionCard
@@ -987,18 +992,27 @@ export function useAgentChatPanel({
         labels={interactionLabels}
         onComplete={(answers: ChatInteractionAnswer[]) => {
           // ONE send after the LAST step: a sequence with questions replies with
-          // the user's visible answers; a connect-only sequence resumes the
-          // agent with a hidden auto-continue message (no fake user bubble).
+          // the user's visible answers; a signin/connect-only sequence resumes
+          // the agent with a hidden auto-continue message (no fake user bubble).
           sendInteractionMessage(
             composeInteractionReply({
               answers,
               connectedNames,
               hasQuestionSteps,
+              signedIn: hasSigninStep,
               connectedLine: (name) =>
                 t("chat:interaction.connectedLine", { name }),
+              signedInLine: t("chat:interaction.signedInLine"),
+              signedInFollowup: t("chat:interaction.signedInFollowup"),
             }),
           );
         }}
+        renderSignin={(step, api) => (
+          <ChatSigninInteractionCard
+            reason={step.reason}
+            onSignedIn={api.onSignedIn}
+          />
+        )}
         renderConnect={(step, api) => (
           <ChatConnectInteractionCard
             toolkit={step.toolkit}

--- a/app/src/hooks/use-session-events.ts
+++ b/app/src/hooks/use-session-events.ts
@@ -147,13 +147,17 @@ export function useSessionEvents() {
                         "common:notifications.sessionComplete.question",
                         { count: interactionQuestionCount(interaction) },
                       )
-                    : bodyKey === "sessionComplete.connect"
+                    : bodyKey === "sessionComplete.signin"
                       ? handlersRef.current.t(
-                          "common:notifications.sessionComplete.connect",
+                          "common:notifications.sessionComplete.signin",
                         )
-                      : handlersRef.current.t(
-                          "common:notifications.sessionComplete.body",
-                        );
+                      : bodyKey === "sessionComplete.connect"
+                        ? handlersRef.current.t(
+                            "common:notifications.sessionComplete.connect",
+                          )
+                        : handlersRef.current.t(
+                            "common:notifications.sessionComplete.body",
+                          );
                 sendSessionNotification(title, body, nav);
               },
             );

--- a/app/src/lib/active-interaction.ts
+++ b/app/src/lib/active-interaction.ts
@@ -50,20 +50,28 @@ export function interactionQuestionCount(
 }
 
 /**
- * Which completion-notification body an ended turn takes. A sequence with ANY
- * question steps reads as the (pluralized) question body; a connect-only
- * sequence reads as the connect body; everything else (a clean finish, a user
- * stop, a provider error) reads as the plain "finished" body. Pure so the copy
- * mapping is unit-tested without the event plumbing.
+ * Which completion-notification body an ended turn takes, by FIRST unmet need
+ * (steps are ordered questions → sign-in → connections). A sequence with ANY
+ * question steps reads as the (pluralized) question body; else a sign-in step
+ * reads as the sign-in body; else a connect step reads as the connect body;
+ * everything else (a clean finish, a user stop, a provider error) reads as the
+ * plain "finished" body. Pure so the copy mapping is unit-tested without the
+ * event plumbing.
  */
 export function interactionNotificationBodyKey(
   interaction: PendingInteraction | null | undefined,
 ):
   | "sessionComplete.body"
   | "sessionComplete.question"
+  | "sessionComplete.signin"
   | "sessionComplete.connect" {
   if (interactionQuestionCount(interaction) > 0)
     return "sessionComplete.question";
+  if (
+    isPendingInteraction(interaction) &&
+    interaction.steps.some((step) => step.kind === "signin")
+  )
+    return "sessionComplete.signin";
   if (
     isPendingInteraction(interaction) &&
     interaction.steps.some((step) => step.kind === "connect")

--- a/app/src/lib/interaction-reply.ts
+++ b/app/src/lib/interaction-reply.ts
@@ -8,23 +8,44 @@ import { encodeAutoContinueMessage } from "./auto-continue-message.ts";
  * would tear the interaction card down before the remaining steps could be
  * walked, so the whole sequence resumes the agent with exactly this one send.
  *
- * The body is `"<question>: <answer>"` per answered question followed by
- * `"Connected <app>."` per connection that landed. A sequence with questions
- * sends that body visibly (the user typed those answers). A connect-ONLY
+ * The body is `"<question>: <answer>"` per answered question, then
+ * `"Signed in to Houston."` if a sign-in step completed, then `"Connected
+ * <app>."` per connection that landed. A sequence with questions sends that body
+ * visibly (the user typed those answers). A connect-ONLY / signin+connect
  * sequence has no user-typed text, so it wraps the body in the auto-continue
  * marker: the agent still receives the instruction, but the transcript hides the
  * bubble the user never actually typed.
  *
- * `connectedLine` is injected so this stays i18n-agnostic and unit-testable —
- * the caller passes `t("chat:interaction.connectedLine", { name })`.
+ * A SIGNIN-ONLY sequence (no questions, no connections) has nothing factual to
+ * relay, so it resumes the agent with the dedicated hidden `signedInFollowup`
+ * ("I've signed in. Please continue.") instead of the bare status line.
+ *
+ * `connectedLine` / `signedInLine` / `signedInFollowup` are injected so this
+ * stays i18n-agnostic and unit-testable — the caller passes the `t(...)` results.
  */
 export function composeInteractionReply(args: {
   answers: ChatInteractionAnswer[];
   connectedNames: string[];
   hasQuestionSteps: boolean;
+  /** A sign-in step completed in this sequence (the user is now signed in). */
+  signedIn: boolean;
   connectedLine: (name: string) => string;
+  /** The status line a completed sign-in contributes to a composed reply. */
+  signedInLine: string;
+  /** The hidden resume message for a signin-ONLY sequence (nothing else to say). */
+  signedInFollowup: string;
 }): string {
+  // Signin-only: no answers to relay and no connection to name, so send the
+  // friendlier hidden followup rather than a lone "Signed in to Houston." line.
+  if (
+    !args.hasQuestionSteps &&
+    args.signedIn &&
+    args.connectedNames.length === 0
+  )
+    return encodeAutoContinueMessage(args.signedInFollowup);
+
   const lines = args.answers.map((a) => `${a.question}: ${a.answer}`);
+  if (args.signedIn) lines.push(args.signedInLine);
   for (const name of args.connectedNames) lines.push(args.connectedLine(name));
   const body = lines.join("\n");
   return args.hasQuestionSteps ? body : encodeAutoContinueMessage(body);

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -48,7 +48,13 @@
     "progress": "{{current}} of {{total}}"
   },
   "interaction": {
-    "connectedLine": "Connected {{name}}."
+    "connectedLine": "Connected {{name}}.",
+    "signedInLine": "Signed in to Houston.",
+    "signedInFollowup": "I've signed in. Please continue.",
+    "signinReason": "Sign in to Houston to continue.",
+    "signinTitle": "Sign in to Houston",
+    "signinDescription": "Your accounts stay yours; the agent acts on your behalf.",
+    "signin": "Sign in"
   },
   "errors": {
     "sessionStart": "Failed to start session: {{error}}",

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -42,6 +42,7 @@
       "body": "Your agent has finished working.",
       "question_one": "Your agent has a question for you.",
       "question_other": "Your agent has questions for you.",
+      "signin": "Your agent needs you to sign in.",
       "connect": "Your agent needs you to connect an app."
     }
   }

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -48,7 +48,13 @@
     "progress": "{{current}} de {{total}}"
   },
   "interaction": {
-    "connectedLine": "Conectaste {{name}}."
+    "connectedLine": "Conectaste {{name}}.",
+    "signedInLine": "Sesión iniciada en Houston.",
+    "signedInFollowup": "Ya inicié sesión. Continúa, por favor.",
+    "signinReason": "Inicia sesión en Houston para continuar.",
+    "signinTitle": "Inicia sesión en Houston",
+    "signinDescription": "Tus cuentas siguen siendo tuyas; el agente actúa en tu nombre.",
+    "signin": "Iniciar sesión"
   },
   "errors": {
     "sessionStart": "No se pudo iniciar la sesión: {{error}}",

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -42,6 +42,7 @@
       "body": "Tu agente terminó de trabajar.",
       "question_one": "Tu agente tiene una pregunta para ti.",
       "question_other": "Tu agente tiene preguntas para ti.",
+      "signin": "Tu agente necesita que inicies sesión.",
       "connect": "Tu agente necesita que conectes una aplicación."
     }
   }

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -48,7 +48,13 @@
     "progress": "{{current}} de {{total}}"
   },
   "interaction": {
-    "connectedLine": "Conectou {{name}}."
+    "connectedLine": "Conectou {{name}}.",
+    "signedInLine": "Sessão iniciada no Houston.",
+    "signedInFollowup": "Já entrei. Pode continuar.",
+    "signinReason": "Entre no Houston para continuar.",
+    "signinTitle": "Entre no Houston",
+    "signinDescription": "Suas contas continuam sendo suas; o agente age em seu nome.",
+    "signin": "Entrar"
   },
   "errors": {
     "sessionStart": "Não foi possível iniciar a sessão: {{error}}",

--- a/app/src/locales/pt/common.json
+++ b/app/src/locales/pt/common.json
@@ -42,6 +42,7 @@
       "body": "Seu agente terminou de trabalhar.",
       "question_one": "Seu agente tem uma pergunta para você.",
       "question_other": "Seu agente tem perguntas para você.",
+      "signin": "Seu agente precisa que você entre.",
       "connect": "Seu agente precisa que você conecte um aplicativo."
     }
   }

--- a/app/tests/active-interaction.test.ts
+++ b/app/tests/active-interaction.test.ts
@@ -28,6 +28,21 @@ const mixed: PendingInteraction = {
     { kind: "connect", id: "c1", toolkit: "gmail" },
   ],
 };
+const signin: PendingInteraction = {
+  steps: [{ kind: "signin", id: "s1", reason: "Sign in to keep going." }],
+};
+const signinConnect: PendingInteraction = {
+  steps: [
+    { kind: "signin", id: "s1" },
+    { kind: "connect", id: "c1", toolkit: "gmail" },
+  ],
+};
+const questionSignin: PendingInteraction = {
+  steps: [
+    { kind: "question", id: "q1", question: "Which account?" },
+    { kind: "signin", id: "s1" },
+  ],
+};
 
 describe("deriveActiveInteraction", () => {
   it("hides the override while a turn is running", () => {
@@ -142,6 +157,31 @@ describe("interactionNotificationBodyKey", () => {
     );
   });
 
+  it("maps a signin-only sequence to the signin body", () => {
+    strictEqual(
+      interactionNotificationBodyKey(signin),
+      "sessionComplete.signin",
+    );
+  });
+
+  // Steps are ordered questions -> sign-in -> connections, so a signin+connect
+  // sequence's FIRST unmet need is the sign-in.
+  it("maps a signin+connect sequence to the signin body (sign-in first)", () => {
+    strictEqual(
+      interactionNotificationBodyKey(signinConnect),
+      "sessionComplete.signin",
+    );
+  });
+
+  // Questions still win: a sequence that also has questions reads as the
+  // question body even when a sign-in is queued after them.
+  it("maps a question+signin sequence to the question body", () => {
+    strictEqual(
+      interactionNotificationBodyKey(questionSignin),
+      "sessionComplete.question",
+    );
+  });
+
   it("maps a mixed sequence (has questions) to the question body", () => {
     strictEqual(
       interactionNotificationBodyKey(mixed),
@@ -159,10 +199,12 @@ describe("interactionNotificationBodyKey", () => {
 });
 
 describe("interactionQuestionCount", () => {
-  it("counts the question steps, ignoring connect steps", () => {
+  it("counts the question steps, ignoring connect + signin steps", () => {
     strictEqual(interactionQuestionCount(question), 1);
     strictEqual(interactionQuestionCount(mixed), 2);
     strictEqual(interactionQuestionCount(connect), 0);
+    strictEqual(interactionQuestionCount(signin), 0);
+    strictEqual(interactionQuestionCount(questionSignin), 1);
   });
 
   it("is 0 with no pending interaction", () => {

--- a/app/tests/interaction-reply.test.ts
+++ b/app/tests/interaction-reply.test.ts
@@ -5,6 +5,8 @@ import { isAutoContinueMessage } from "../src/lib/auto-continue-message.ts";
 import { composeInteractionReply } from "../src/lib/interaction-reply.ts";
 
 const connectedLine = (name: string) => `Connected ${name}.`;
+const signedInLine = "Signed in to Houston.";
+const signedInFollowup = "I've signed in. Please continue.";
 
 const answers: ChatInteractionAnswer[] = [
   { stepId: "q1", question: "To whom?", answer: "john@example.com" },
@@ -17,7 +19,10 @@ describe("composeInteractionReply", () => {
       answers,
       connectedNames: [],
       hasQuestionSteps: true,
+      signedIn: false,
       connectedLine,
+      signedInLine,
+      signedInFollowup,
     });
     strictEqual(isAutoContinueMessage(reply), false);
     strictEqual(
@@ -31,7 +36,10 @@ describe("composeInteractionReply", () => {
       answers,
       connectedNames: ["Gmail"],
       hasQuestionSteps: true,
+      signedIn: false,
       connectedLine,
+      signedInLine,
+      signedInFollowup,
     });
     strictEqual(isAutoContinueMessage(reply), false);
     strictEqual(
@@ -48,7 +56,10 @@ describe("composeInteractionReply", () => {
       answers: [],
       connectedNames: ["Gmail", "Slack"],
       hasQuestionSteps: false,
+      signedIn: false,
       connectedLine,
+      signedInLine,
+      signedInFollowup,
     });
     strictEqual(isAutoContinueMessage(reply), true);
     strictEqual(reply.split("\n").length, 4); // marker + blank + two lines
@@ -61,9 +72,70 @@ describe("composeInteractionReply", () => {
       answers: [],
       connectedNames: ["Gmail"],
       hasQuestionSteps: false,
+      signedIn: false,
       connectedLine,
+      signedInLine,
+      signedInFollowup,
     });
     strictEqual(isAutoContinueMessage(reply), true);
     strictEqual(reply.endsWith("Connected Gmail."), true);
+  });
+
+  // ── Sign-in composition ────────────────────────────────────────────────
+  // The signin line joins a VISIBLE reply BEFORE any Connected line when the
+  // sequence also asked questions (the user typed those answers).
+  it("adds the signed-in line before Connected lines in a question+signin+connect sequence", () => {
+    const reply = composeInteractionReply({
+      answers,
+      connectedNames: ["Gmail"],
+      hasQuestionSteps: true,
+      signedIn: true,
+      connectedLine,
+      signedInLine,
+      signedInFollowup,
+    });
+    strictEqual(isAutoContinueMessage(reply), false);
+    strictEqual(
+      reply,
+      "To whom?: john@example.com\nSaying what?: Running late\nSigned in to Houston.\nConnected Gmail.",
+    );
+  });
+
+  // A signin+connect sequence with no questions has nothing the user typed, so
+  // it resumes the agent hidden — the signed-in status line before the connects.
+  it("hides a signin+connect sequence and orders sign-in before connects", () => {
+    const reply = composeInteractionReply({
+      answers: [],
+      connectedNames: ["Gmail"],
+      hasQuestionSteps: false,
+      signedIn: true,
+      connectedLine,
+      signedInLine,
+      signedInFollowup,
+    });
+    strictEqual(isAutoContinueMessage(reply), true);
+    strictEqual(reply.includes("Signed in to Houston."), true);
+    strictEqual(
+      reply.indexOf("Signed in to Houston.") <
+        reply.indexOf("Connected Gmail."),
+      true,
+    );
+  });
+
+  // A signin-ONLY sequence has nothing factual to relay, so it uses the
+  // dedicated hidden followup, never a lone status line.
+  it("resumes a signin-only sequence with the hidden followup", () => {
+    const reply = composeInteractionReply({
+      answers: [],
+      connectedNames: [],
+      hasQuestionSteps: false,
+      signedIn: true,
+      connectedLine,
+      signedInLine,
+      signedInFollowup,
+    });
+    strictEqual(isAutoContinueMessage(reply), true);
+    strictEqual(reply.endsWith("I've signed in. Please continue."), true);
+    strictEqual(reply.includes("Signed in to Houston."), false);
   });
 });

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,22 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v7 - 2026-07-08
+
+Add a `signin` step to `interaction-card`. The pending-interaction sequence now
+orders question steps, THEN at most one signin step, THEN connect steps. A signin
+step appears when Houston reports the user must sign in before a tool call can run
+(the runtime queues it alongside any connect steps in the same flow). Like a
+connect step it carries no answer text and advances only when the app reports the
+user signed in; ui/chat stays auth-unaware via a required `renderSignin` prop
+(mirrors `renderConnect`), and the app supplies the sign-in card driving the
+existing sign-in machinery. It counts in "N of X" and supports back/forward like
+any other step (a revisited signin step relies on the stepper's forward chevron
+since its card never re-fires once signed in). Completion contributes a
+"Signed in to Houston." line before any connected lines. No design/surface change
+to the card chrome. Web keeps `@houston-ai/chat` `ChatInteractionCard`, so it
+stays `implemented`.
+
 ## v6 - 2026-07-07
 
 Rename `question-card` to `interaction-card` and rebuild it as a one-step-at-a-time

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 6
+version: 7
 
 components:
   - id: agent-avatar
@@ -229,23 +229,27 @@ components:
 
   - id: interaction-card
     title: Interaction card
-    purpose: In-chat surface shown when the agent pauses mid-turn to gather what it needs before continuing; a stepper that walks the user through one step at a time (questions then connections), replacing the composer until done.
-    anatomy: [stepper-header, progress-indicator, back-chevron, question-step, option-row, free-text-input, send-action, connect-step]
-    states: [single-step, multi-step, with-options, free-text-only, connect-step, revisited, disabled]
-    variants: [choice, open-ended, connect, mixed-sequence]
+    purpose: In-chat surface shown when the agent pauses mid-turn to gather what it needs before continuing; a stepper that walks the user through one step at a time (questions, then sign-in, then connections), replacing the composer until done.
+    anatomy: [stepper-header, progress-indicator, back-chevron, question-step, option-row, free-text-input, send-action, signin-step, connect-step]
+    states: [single-step, multi-step, with-options, free-text-only, signin-step, connect-step, revisited, disabled]
+    variants: [choice, open-ended, signin, connect, mixed-sequence]
     behavior: >-
-      Rendered from the turn's pending interaction (steps[]: 1-3 question steps
-      then connect steps). Shows ONE step at a time with a quiet "N of X"
-      progress indicator (only when total > 1) and a back chevron from step 2 on.
-      Question step: one prominent question, vertical single-select option rows
-      (role=radio), and a free-text input ALWAYS visible below as the escape
-      hatch; clicking an option OR submitting typed text answers the current step
-      and advances. Connect step: renders the app-supplied connect card and
-      advances only when it reports connected. Revisiting a step pre-selects its
-      prior answer; re-answering replaces it. A single question-with-options step
-      keeps the one-tap feel (click = answer = complete). After the last step,
-      emits each question answer in step order to the consumer, which formats the
-      resume message. Disabled while another turn is active.
+      Rendered from the turn's pending interaction (steps[]: 1-3 question steps,
+      then at most one signin step, then connect steps). Shows ONE step at a time
+      with a quiet "N of X" progress indicator (only when total > 1) and a back
+      chevron from step 2 on. Question step: one prominent question, vertical
+      single-select option rows (role=radio), and a free-text input ALWAYS
+      visible below as the escape hatch; clicking an option OR submitting typed
+      text answers the current step and advances. Signin step: renders the
+      app-supplied sign-in card and advances only when it reports signed in
+      (ui/chat stays auth-unaware via a renderSignin prop). Connect step: renders
+      the app-supplied connect card and advances only when it reports connected.
+      Signin and connect steps carry no answer text. Revisiting a step
+      pre-selects its prior answer; re-answering replaces it. A single
+      question-with-options step keeps the one-tap feel (click = answer =
+      complete). After the last step, emits each question answer in step order to
+      the consumer, which formats the resume message. Disabled while another turn
+      is active.
     a11y: one step announced at a time; option rows are role=radio in a radiogroup, keyboard-toggleable and visible at rest (no hover gate); free-text input always present on question steps; back chevron is a labeled button; progress uses tabular-nums to avoid width jitter.
     since: 4
 

--- a/design/inventory/manifests/ios.yaml
+++ b/design/inventory/manifests/ios.yaml
@@ -132,4 +132,4 @@ components:
     notes: Hosted-engine warm-up notice (HOU-693); mobile v1 has no create-agent flow yet.
   interaction-card:
     status: not-started
-    notes: In-chat gather-what-I-need stepper (questions then connections); mid-turn pending-interaction flow not in mobile v1.
+    notes: In-chat gather-what-I-need stepper (questions, sign-in, then connections); mid-turn pending-interaction flow not in mobile v1.

--- a/packages/host/src/houston-prompt.ts
+++ b/packages/host/src/houston-prompt.ts
@@ -180,6 +180,8 @@ When a needed app is not connected yet (search marks its actions NOT CONNECTED, 
 2. Call the \`request_connection\` tool for that app, with a short user-facing reason. Houston shows the user a connect card with a one-click button in place of the chat box, so there is nothing for you to write out. Call it once per app that needs connecting, then end your turn.
 3. Do NOT ask the user to tell you when they're done, and do NOT promise to "check" the connection yourself. Houston detects the moment the connection goes live and automatically sends you a short message (e.g. "I've connected Gmail. Please continue.") so you can resume the task on your own. Then stop and wait.
 
+If Houston reports that the user must sign in first, a sign-in card joins the same interaction card automatically. Keep queueing whatever else the task needs (call \`request_connection\` for any app, \`ask_user\` for any questions) in the same turn, then end your turn. Never tell the user to open Settings, and never claim connected apps are unavailable unless Houston says they are not set up in this install.
+
 Never spell out a connection link in your reply and never read any internal identifier out loud to the user, and never name the integrations provider. The card speaks for itself.`;
 
 /** The composite Houston product prompt (base + skills/memory + routines + integrations). */

--- a/packages/host/src/routes/integrations-sandbox.ts
+++ b/packages/host/src/routes/integrations-sandbox.ts
@@ -51,7 +51,15 @@ export async function handleSandboxIntegrations(
     return true;
   }
   if (!deps.integrations) {
-    json(res, 503, { error: "integrations not configured" });
+    // A stable `code` marks THIS as the host's own not-configured signal (no
+    // key in this install) — distinct from a transient upstream 503 the proxy
+    // relays verbatim during an outage. The runtime tool classifies on the
+    // code, never the bare status, so it never misdirects the user to set
+    // COMPOSIO_API_KEY during a temporary gateway/provider failure.
+    json(res, 503, {
+      error: "integrations not configured",
+      code: "integrations_not_configured",
+    });
     return true;
   }
   const { registry } = deps.integrations;

--- a/packages/protocol/src/domain/interaction.test.ts
+++ b/packages/protocol/src/domain/interaction.test.ts
@@ -6,10 +6,23 @@ test("isPendingInteraction accepts the step-sequence shape and rejects legacy sh
     isPendingInteraction({
       steps: [
         { kind: "question", id: "q1", question: "Which deck?" },
+        { kind: "signin", id: "s1", reason: "Sign in to use your apps." },
         { kind: "connect", id: "c1", toolkit: "gmail", reason: "to send it" },
       ],
     }),
   ).toBe(true);
+
+  // A signin step needs only kind + id; reason is optional.
+  expect(isPendingInteraction({ steps: [{ kind: "signin", id: "s1" }] })).toBe(
+    true,
+  );
+
+  // A signin step with a non-string reason is invalid.
+  expect(
+    isPendingInteraction({ steps: [{ kind: "signin", id: "s1", reason: 7 }] }),
+  ).toBe(false);
+  // A signin step without an id is invalid.
+  expect(isPendingInteraction({ steps: [{ kind: "signin" }] })).toBe(false);
 
   // Pre-step shapes persisted by older builds: no `steps`.
   expect(
@@ -45,6 +58,7 @@ test("the protocol index re-exports PendingInteraction", () => {
         question: "Send it now?",
         options: [{ id: "yes", label: "Send" }],
       },
+      { kind: "signin", id: "s1", reason: "Sign in first." },
       { kind: "connect", id: "c1", toolkit: "gmail", reason: "to send it" },
     ],
   };

--- a/packages/protocol/src/domain/interaction.ts
+++ b/packages/protocol/src/domain/interaction.ts
@@ -6,8 +6,10 @@
 // steps one at a time, with a "1 of X" progress indicator.
 //
 // A turn's steps are the question steps (from one ask_user call, 1 to 3
-// questions) FOLLOWED BY the connect steps (one per request_connection call,
-// deduped by toolkit). Either tool alone still yields a valid sequence.
+// questions) FOLLOWED BY at most one signin step (the user must sign in to
+// Houston first) FOLLOWED BY the connect steps (one per request_connection
+// call, deduped by toolkit). Any single kind alone still yields a valid
+// sequence.
 
 export interface InteractionOption {
   id: string;
@@ -15,9 +17,11 @@ export interface InteractionOption {
 }
 
 /** One step in the interaction sequence. `id` is tool-assigned (`q1`..`qN` for
- *  question steps, `c1`..`cN` for connect steps) so each step's outcome is
- *  addressable. A `question` carries its text + optional single-select options;
- *  a `connect` names the toolkit to connect with an optional user-facing reason. */
+ *  question steps, `s1` for the single signin step, `c1`..`cN` for connect
+ *  steps) so each step's outcome is addressable. A `question` carries its text +
+ *  optional single-select options; a `signin` asks the user to sign in to
+ *  Houston with an optional user-facing reason; a `connect` names the toolkit to
+ *  connect with an optional user-facing reason. */
 export type InteractionStep =
   | {
       kind: "question";
@@ -25,10 +29,11 @@ export type InteractionStep =
       question: string;
       options?: InteractionOption[];
     }
+  | { kind: "signin"; id: string; reason?: string }
   | { kind: "connect"; id: string; toolkit: string; reason?: string };
 
 /** The ordered steps the mission is waiting on: question steps first (at most 3),
- *  then connect steps. Always at least one step. */
+ *  then at most one signin step, then connect steps. Always at least one step. */
 export interface PendingInteraction {
   steps: InteractionStep[];
 }
@@ -40,6 +45,8 @@ const isRecord = (v: unknown): v is Record<string, unknown> =>
 export const isInteractionStep = (v: unknown): v is InteractionStep => {
   if (!isRecord(v) || typeof v.id !== "string") return false;
   if (v.kind === "question") return typeof v.question === "string";
+  if (v.kind === "signin")
+    return v.reason === undefined || typeof v.reason === "string";
   if (v.kind === "connect") return typeof v.toolkit === "string";
   return false;
 };

--- a/packages/runtime/src/session/interaction.test.ts
+++ b/packages/runtime/src/session/interaction.test.ts
@@ -3,6 +3,7 @@ import {
   newInteractionHolder,
   recordConnection,
   recordQuestions,
+  recordSignin,
   runWithInteractionCapture,
 } from "./interaction";
 
@@ -72,6 +73,54 @@ test("connect steps dedupe by toolkit, keep call order, and take c1..cN ids", ()
   });
 });
 
+test("recordSignin orders the signin step between questions and connects", () => {
+  const holder = newInteractionHolder();
+  runWithInteractionCapture(holder, () => {
+    recordConnection({ toolkit: "gmail", reason: "to send it" });
+    recordSignin({ reason: "Sign in first." });
+    recordQuestions([q("q1", "Which address?")]);
+  });
+  // Regardless of call order: questions, then the signin step, then connects.
+  expect(holder.pending).toEqual({
+    steps: [
+      q("q1", "Which address?"),
+      { kind: "signin", id: "s1", reason: "Sign in first." },
+      { kind: "connect", id: "c1", toolkit: "gmail", reason: "to send it" },
+    ],
+  });
+});
+
+test("recordSignin is idempotent — one step, last reason wins", () => {
+  const holder = newInteractionHolder();
+  runWithInteractionCapture(holder, () => {
+    recordSignin({ reason: "first reason" });
+    recordSignin({ reason: "  second reason  " });
+  });
+  expect(holder.pending).toEqual({
+    steps: [{ kind: "signin", id: "s1", reason: "second reason" }],
+  });
+});
+
+test("recordSignin omits an empty/whitespace reason", () => {
+  const holder = newInteractionHolder();
+  runWithInteractionCapture(holder, () => {
+    recordSignin({ reason: "   " });
+  });
+  expect(holder.pending).toEqual({ steps: [{ kind: "signin", id: "s1" }] });
+
+  const noReason = newInteractionHolder();
+  runWithInteractionCapture(noReason, () => recordSignin({}));
+  expect(noReason.pending).toEqual({ steps: [{ kind: "signin", id: "s1" }] });
+});
+
+test("a signin step alone yields a valid sequence", () => {
+  const holder = newInteractionHolder();
+  runWithInteractionCapture(holder, () => recordSignin({ reason: "Sign in." }));
+  expect(holder.pending).toEqual({
+    steps: [{ kind: "signin", id: "s1", reason: "Sign in." }],
+  });
+});
+
 test("either tool alone still yields a valid sequence", () => {
   const questionsOnly = newInteractionHolder();
   runWithInteractionCapture(questionsOnly, () =>
@@ -109,6 +158,7 @@ test("a fresh holder each turn is the reset — nothing leaks across turns", () 
 test("recording outside a turn is a no-op (undefined store)", () => {
   expect(() => recordQuestions([q("q1", "orphan?")])).not.toThrow();
   expect(() => recordConnection({ toolkit: "gmail" })).not.toThrow();
+  expect(() => recordSignin({ reason: "orphan" })).not.toThrow();
 });
 
 test("the holder survives async work inside the capture (ALS propagation)", async () => {

--- a/packages/runtime/src/session/interaction.ts
+++ b/packages/runtime/src/session/interaction.ts
@@ -10,15 +10,19 @@ import type {
  * `prompt()` resolves, and attached to the terminal clean `done` frame so the
  * board card can settle to `needs_you`.
  *
- * Merge semantics within one turn (the tools may call both):
+ * Merge semantics within one turn (the tools may call any combination):
  * - `ask_user` SETS the question steps — a second `ask_user` call REPLACES them
  *   (ids `q1`..`qN`).
+ * - A `signin_required` (409) from the integrations host RECORDS the single
+ *   signin step (id `s1`) — idempotent: a repeat call keeps the one step and
+ *   the LAST call's reason wins.
  * - `request_connection` APPENDS a connect step, deduped by normalized toolkit —
  *   a repeat call for the same toolkit updates its reason (ids `c1`..`cN` in
  *   first-seen order).
  * - The recorded {@link PendingInteraction} is the question steps THEN the
- *   connect steps, so the UI walks the user through everything the model queued
- *   in one flow. Either tool alone still yields a valid sequence.
+ *   signin step THEN the connect steps, so the UI walks the user through
+ *   everything the model queued in one flow. Any single kind alone still yields
+ *   a valid sequence.
  *
  * Turn-scoping mechanism (mirrors acting-context.ts): an `AsyncLocalStorage`
  * whose store — a fresh mutable holder — is established for the DURATION of
@@ -31,24 +35,33 @@ import type {
  */
 
 type QuestionStep = Extract<InteractionStep, { kind: "question" }>;
+type SigninStep = Extract<InteractionStep, { kind: "signin" }>;
 type ConnectStep = Extract<InteractionStep, { kind: "connect" }>;
 
 export interface InteractionHolder {
   /** Question steps from the last `ask_user` call this turn (replace semantics). */
   readonly questions: QuestionStep[];
+  /** The single signin step, once the host reported the user must sign in. */
+  readonly signin: SigninStep | undefined;
   /** Connect steps appended by `request_connection`, deduped by toolkit. */
   readonly connects: ConnectStep[];
-  /** The recorded sequence — question steps then connect steps — or undefined
-   *  when the model asked for nothing this turn. Derived: read after prompt(). */
+  /** The recorded sequence — question steps, then the signin step, then connect
+   *  steps — or undefined when the model asked for nothing this turn. Derived:
+   *  read after prompt(). */
   readonly pending: PendingInteraction | undefined;
 }
 
 class Holder implements InteractionHolder {
   readonly questions: QuestionStep[] = [];
+  signin: SigninStep | undefined;
   readonly connects: ConnectStep[] = [];
 
   get pending(): PendingInteraction | undefined {
-    const steps = [...this.questions, ...this.connects];
+    const steps = [
+      ...this.questions,
+      ...(this.signin ? [this.signin] : []),
+      ...this.connects,
+    ];
     return steps.length > 0 ? { steps } : undefined;
   }
 }
@@ -77,6 +90,23 @@ export function recordQuestions(questions: QuestionStep[]): void {
   if (!holder) return;
   holder.questions.length = 0;
   holder.questions.push(...questions);
+}
+
+/**
+ * Record the single signin step for this turn (the host reported the user must
+ * sign in to Houston before integrations can act). Idempotent: there is at most
+ * one signin step (id `s1`), so a repeat call keeps that one step and the LAST
+ * call's reason wins. A no-op outside a turn.
+ */
+export function recordSignin(input: { reason?: string }): void {
+  const holder = store.getStore();
+  if (!holder) return;
+  const reason = input.reason?.trim();
+  (holder as Holder).signin = {
+    kind: "signin",
+    id: "s1",
+    ...(reason ? { reason } : {}),
+  };
 }
 
 /**

--- a/packages/runtime/src/session/tools/integrations.test.ts
+++ b/packages/runtime/src/session/tools/integrations.test.ts
@@ -213,14 +213,90 @@ test("request_connection records nothing outside a turn (no ambient holder)", as
   ).resolves.toBeDefined();
 });
 
-test("a 409 (not connected) becomes an actionable message, not a crash dump", async () => {
+test("a 409 (signed out) queues a signin step and tells the model to end its turn", async () => {
   mockFetch(() => ({
     status: 409,
-    body: { error: "integration not connected" },
+    body: { error: "signin_required", code: "signin_required" },
   }));
-  await expect(run(execute, { action: "X" })).rejects.toThrow(
-    /connect their apps/i,
+  const holder = newInteractionHolder();
+  const failure = runWithInteractionCapture(holder, () =>
+    run(execute, { action: "X" }),
   );
+  await expect(failure).rejects.toThrow(/signed out of Houston/i);
+  await expect(failure).rejects.toThrow(/end your turn/i);
+  // The guidance tells the model NOT to send the user to Settings.
+  await expect(failure).rejects.toThrow(
+    /Do NOT tell the user to open Settings/,
+  );
+  // The signin step is queued in this turn's interaction flow, id "s1".
+  expect(holder.pending).toEqual({
+    steps: [
+      {
+        kind: "signin",
+        id: "s1",
+        reason: "Sign in to Houston to use your connected apps.",
+      },
+    ],
+  });
+});
+
+test("a 503 (not set up) is an honest, closed message and queues nothing", async () => {
+  mockFetch(() => ({
+    status: 503,
+    body: {
+      error: "integrations not configured",
+      code: "integrations_not_configured",
+    },
+  }));
+  const holder = newInteractionHolder();
+  const failure = runWithInteractionCapture(holder, () =>
+    run(execute, { action: "X" }),
+  );
+  await expect(failure).rejects.toThrow(/not set up in this Houston install/i);
+  await expect(failure).rejects.toThrow(/COMPOSIO_API_KEY/);
+  // A closed state: no sign-in card, no connect offer, and never "workspace".
+  await expect(failure).rejects.not.toThrow(/workspace/i);
+  expect(holder.pending).toBeUndefined();
+});
+
+test("a RELAYED upstream 503 (transient outage) is NOT the not-set-up message", async () => {
+  // The host's sandbox proxy relays ANY non-ok upstream status verbatim. In
+  // gateway mode a transient Composio/gateway outage returns 503 with the
+  // upstream's body (NO integrations_not_configured code) — the key IS set, so
+  // the model must NOT tell the user "connected apps aren't set up here / set
+  // COMPOSIO_API_KEY". It is a generic transient failure.
+  mockFetch(() => ({
+    status: 503,
+    body: { error: "upstream temporarily unavailable" },
+  }));
+  const holder = newInteractionHolder();
+  const failure = runWithInteractionCapture(holder, () =>
+    run(execute, { action: "X" }),
+  );
+  await expect(failure).rejects.toThrow(/integrations execute failed \(503\)/);
+  await expect(failure).rejects.not.toThrow(
+    /not set up in this Houston install/i,
+  );
+  await expect(failure).rejects.not.toThrow(/COMPOSIO_API_KEY/);
+  expect(holder.pending).toBeUndefined();
+});
+
+test("a RELAYED upstream 409 (transient conflict) queues NO signin card", async () => {
+  // Symmetric to the 503 case: an upstream 409 the host relays verbatim lacks
+  // the signin_required code, so it must NOT record a sign-in step nor tell the
+  // model to end its turn.
+  mockFetch(() => ({
+    status: 409,
+    body: { error: "conflict: resource busy" },
+  }));
+  const holder = newInteractionHolder();
+  const failure = runWithInteractionCapture(holder, () =>
+    run(execute, { action: "X" }),
+  );
+  await expect(failure).rejects.toThrow(/integrations execute failed \(409\)/);
+  await expect(failure).rejects.not.toThrow(/signed out of Houston/i);
+  await expect(failure).rejects.not.toThrow(/end your turn/i);
+  expect(holder.pending).toBeUndefined();
 });
 
 test("C2: attaches the turn's acting-as header inside a turn, and nothing outside one", async () => {

--- a/packages/runtime/src/session/tools/integrations.ts
+++ b/packages/runtime/src/session/tools/integrations.ts
@@ -1,7 +1,7 @@
 import { defineTool } from "@earendil-works/pi-coding-agent";
 import { type Static, Type } from "typebox";
 import { currentActingContext } from "../acting-context";
-import { recordConnection } from "../interaction";
+import { recordConnection, recordSignin } from "../interaction";
 
 /**
  * The agent's window into the user's connected third-party apps (Gmail, Google
@@ -59,6 +59,26 @@ type ConnectParams = Static<typeof ConnectParams>;
  */
 function normalizeToolkitSlug(slug: string): string {
   return slug.trim().toLowerCase();
+}
+
+/**
+ * The `code` the host stamps on its OWN actionable error signals (409
+ * "signin_required", 503 "integrations_not_configured"). Returns it, or
+ * undefined for a body that carries none — including any upstream error the
+ * host relays verbatim during a transient outage, which must NOT be read as one
+ * of those states. A non-JSON or malformed body is simply uncoded.
+ */
+function signalCode(detail: string): string | undefined {
+  try {
+    const body: unknown = JSON.parse(detail);
+    if (body && typeof body === "object") {
+      const { code } = body as { code?: unknown };
+      if (typeof code === "string") return code;
+    }
+  } catch {
+    // Non-JSON body (e.g. an HTML proxy error page) → uncoded, generic error.
+  }
+  return undefined;
 }
 
 export interface IntegrationToolOptions {
@@ -120,12 +140,34 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
     });
     if (!res.ok) {
       const detail = await res.text().catch(() => "");
-      // 409 = integrations can't act for this user yet (on desktop: they're
-      // signed out of Houston, so the gateway has no session to forward) — a
-      // normal, actionable state the agent should relay, not a crash.
-      if (res.status === 409) {
+      // The host tags its OWN actionable signals with a stable `code` on the
+      // JSON error body. A relayed upstream error (a transient gateway/provider
+      // outage the host passes through VERBATIM) carries the upstream's status
+      // + body and NO such code — so we classify on the code, never the bare
+      // status, and let any uncoded failure fall through to the generic error
+      // below rather than a false "sign in" / "not set up" claim.
+      const code = signalCode(detail);
+      // signin_required (409): integrations can't act for this user yet (on
+      // desktop: they're signed out of Houston, so the gateway has no session to
+      // forward) — a normal, actionable state. Queue a signin step in THIS
+      // turn's interaction flow so Houston renders a sign-in card in place of
+      // the chat input, then tell the model to keep queuing what it needs and
+      // end its turn.
+      if (code === "signin_required") {
+        recordSignin({
+          reason: "Sign in to Houston to use your connected apps.",
+        });
         throw new Error(
-          "Connected apps aren't available yet: the user needs to sign in to Houston (Settings), then connect their apps in Integrations. Ask them to do that, then try again.",
+          "The user is signed out of Houston, so connected apps can't act for them yet. A sign-in card has been queued in the interaction flow. Queue any request_connection you still need (it will follow the sign-in step), then end your turn. Do NOT tell the user to open Settings — Houston sends you a message automatically once they're signed in.",
+        );
+      }
+      // integrations_not_configured (503): connected apps are not set up in this
+      // Houston install (dev with no key, self-host that never set
+      // COMPOSIO_API_KEY). A closed, honest state: there is nothing to sign into
+      // or connect here.
+      if (code === "integrations_not_configured") {
+        throw new Error(
+          "Connected apps are not set up in this Houston install. Tell the user plainly that connected apps aren't available here (a self-hoster enables them by setting COMPOSIO_API_KEY), and do not offer to connect any apps.",
         );
       }
       throw new Error(

--- a/packages/web/e2e/interaction.spec.ts
+++ b/packages/web/e2e/interaction.spec.ts
@@ -12,9 +12,11 @@ import { expect, test } from "./support/fixtures";
  * answers each step -> normal composer returns.
  *
  * A turn's steps are the question steps (from one ask_user call, 1 to 3) FOLLOWED
- * BY the connect steps (one per request_connection). Question answers compose one
- * user message on completion; a connect-only sequence keeps the hidden
- * auto-continue.
+ * BY at most one signin step (the user must sign in to Houston first) FOLLOWED BY
+ * the connect steps (one per request_connection). Question answers compose one
+ * user message on completion; a signin/connect-only sequence keeps the hidden
+ * auto-continue. Real Google SSO cannot run in the harness, so the signin specs
+ * assert the card RENDERS (button + reason + progress), not the landing.
  */
 
 /** Kick off a fresh mission whose next turn ends on the armed interaction. */
@@ -309,6 +311,111 @@ test("advances from a question to a connect step in one sequence", async ({
     page.getByText("Who should I send the itinerary to?"),
   ).toHaveCount(0);
   // The composer is still replaced: the sequence isn't complete until connect.
+  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+});
+
+/**
+ * A three-step sequence (question THEN signin THEN connect): answering the
+ * question advances the SAME card to the signin step (2 of 3), which renders the
+ * reason, the "Sign in to Houston" card, and a Sign in button. Real Google SSO
+ * can't run in the harness, so this asserts the signin step RENDERS in the middle
+ * of the sequence, not that it lands — the connect step (3 of 3) stays queued
+ * behind it and the composer stays replaced.
+ */
+test("advances from a question to a signin step in a three-step sequence", async ({
+  page,
+  request,
+}) => {
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: {
+      interaction: {
+        steps: [
+          {
+            kind: "question",
+            id: "q1",
+            question: "Who should I send the itinerary to?",
+          },
+          {
+            kind: "signin",
+            id: "s1",
+            reason: "Sign in to Houston so I can send email on your behalf.",
+          },
+          {
+            kind: "connect",
+            id: "c1",
+            toolkit: "gmail",
+            reason: "I need access to your Gmail to send the trip itinerary.",
+          },
+        ],
+      },
+    },
+  });
+
+  await startMission(page, "email me the itinerary");
+
+  // Step 1 of 3: the question, free-text only. No signin/connect surface yet.
+  await expect(
+    page.getByText("Who should I send the itinerary to?"),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText("1 of 3")).toBeVisible();
+  await expect(
+    page.getByText("Sign in to Houston so I can send email on your behalf."),
+  ).toHaveCount(0);
+  await expect(page.getByRole("button", { name: "Sign in" })).toHaveCount(0);
+
+  // Answer the question -> advance to the SIGNIN step (2 of 3). Its reason, the
+  // "Sign in to Houston" card and the Sign in button now own the card; the
+  // question text is gone and the connect step (3 of 3) is still queued behind it.
+  const freeText = page.getByPlaceholder("Type your answer...");
+  await freeText.fill("john@example.com");
+  await page.getByRole("button", { name: "Send" }).click();
+
+  await expect(page.getByText("2 of 3")).toBeVisible();
+  await expect(
+    page.getByText("Sign in to Houston so I can send email on your behalf."),
+  ).toBeVisible();
+  await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
+  await expect(
+    page.getByText("Who should I send the itinerary to?"),
+  ).toHaveCount(0);
+  // The connect step hasn't been reached, and the composer is still replaced.
+  await expect(page.getByRole("button", { name: "Connect" })).toHaveCount(0);
+  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+});
+
+/**
+ * A signin-only sequence (a tool 409'd with the user signed out, no questions and
+ * no connections): the card shows the reason plus the "Sign in to Houston" card
+ * and a Sign in button as the ONLY step, with no progress chrome. SSO can't run
+ * in the harness, so this asserts the lone signin card renders.
+ */
+test("shows a lone signin step for a signin-only sequence", async ({
+  page,
+  request,
+}) => {
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: {
+      interaction: {
+        steps: [
+          {
+            kind: "signin",
+            id: "s1",
+            reason: "Sign in to Houston to use your connected apps.",
+          },
+        ],
+      },
+    },
+  });
+
+  await startMission(page, "check my email");
+
+  // The signin card owns the composer slot: the reason plus the Sign in button,
+  // a single step (no progress chrome), composer gone.
+  await expect(
+    page.getByText("Sign in to Houston to use your connected apps."),
+  ).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
+  await expect(page.getByText(/ of /)).toHaveCount(0);
   await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
 });
 

--- a/ui/agent-schemas/src/activity.schema.json
+++ b/ui/agent-schemas/src/activity.schema.json
@@ -25,7 +25,7 @@
       "model": { "type": "string" },
       "pending_interaction": {
         "type": "object",
-        "description": "The ordered steps this mission is waiting on the user for, walked one at a time: question steps first (at most 3), then connect steps.",
+        "description": "The ordered steps this mission is waiting on the user for, walked one at a time: question steps first (at most 3), then at most one signin step, then connect steps.",
         "required": ["steps"],
         "properties": {
           "steps": {
@@ -35,7 +35,10 @@
               "type": "object",
               "required": ["kind", "id"],
               "properties": {
-                "kind": { "type": "string", "enum": ["question", "connect"] },
+                "kind": {
+                  "type": "string",
+                  "enum": ["question", "signin", "connect"]
+                },
                 "id": { "type": "string" },
                 "question": { "type": "string" },
                 "options": {
@@ -56,6 +59,9 @@
                 {
                   "properties": { "kind": { "const": "question" } },
                   "required": ["question"]
+                },
+                {
+                  "properties": { "kind": { "const": "signin" } }
                 },
                 {
                   "properties": { "kind": { "const": "connect" } },

--- a/ui/chat/src/interaction-card-logic.ts
+++ b/ui/chat/src/interaction-card-logic.ts
@@ -204,3 +204,11 @@ export function advanceConnect(
 ): Transition {
   return advance(state, steps);
 }
+
+/** Advance past a signin step once the app reports the user signed in. */
+export function advanceSignin(
+  state: StepperState,
+  steps: ChatInteractionStep[],
+): Transition {
+  return advance(state, steps);
+}

--- a/ui/chat/src/interaction-card-model.ts
+++ b/ui/chat/src/interaction-card-model.ts
@@ -14,6 +14,7 @@ export type ChatInteractionStep =
       question: string;
       options?: ChatInteractionOption[];
     }
+  | { kind: "signin"; id: string; reason?: string }
   | { kind: "connect"; id: string; toolkit: string; reason?: string };
 
 /** One completed question answer handed to `onComplete`, in step order. */

--- a/ui/chat/src/interaction-card.tsx
+++ b/ui/chat/src/interaction-card.tsx
@@ -10,6 +10,7 @@ import {
 import { PromptInputSubmit } from "./ai-elements/prompt-input";
 import {
   advanceConnect,
+  advanceSignin,
   answerWithOption,
   answerWithText,
   type ChatInteractionAnswer,
@@ -36,9 +37,11 @@ export type {
 } from "./interaction-card-logic";
 
 type ConnectStep = Extract<ChatInteractionStep, { kind: "connect" }>;
+type SigninStep = Extract<ChatInteractionStep, { kind: "signin" }>;
 
 export interface ChatInteractionCardProps {
-  /** The ordered interaction steps: question steps then connect steps (>=1). */
+  /** The ordered interaction steps: question steps, then at most one signin
+   *  step, then connect steps (>=1 total). */
   steps: ChatInteractionStep[];
   /** Receives every question answer, in step order, once the last step is done. */
   onComplete: (answers: ChatInteractionAnswer[]) => void;
@@ -47,6 +50,12 @@ export interface ChatInteractionCardProps {
   renderConnect: (
     step: ConnectStep,
     api: { onConnected: () => void },
+  ) => ReactNode;
+  /** Renders a signin step's body; call `api.onSignedIn` to advance. ui/chat
+   *  stays auth-unaware, so the app supplies the sign-in card. */
+  renderSignin: (
+    step: SigninStep,
+    api: { onSignedIn: () => void },
   ) => ReactNode;
   disabled?: boolean;
   labels?: {
@@ -70,6 +79,7 @@ export function ChatInteractionCard({
   steps,
   onComplete,
   renderConnect,
+  renderSignin,
   disabled = false,
   labels,
 }: ChatInteractionCardProps) {
@@ -110,6 +120,10 @@ export function ChatInteractionCard({
 
   const onConnected = useCallback(() => {
     apply(advanceConnect(state, steps));
+  }, [apply, state, steps]);
+
+  const onSignedIn = useCallback(() => {
+    apply(advanceSignin(state, steps));
   }, [apply, state, steps]);
 
   const onKeyDown = useCallback(
@@ -173,6 +187,8 @@ export function ChatInteractionCard({
                 </div>
               )}
             </>
+          ) : step.kind === "signin" ? (
+            renderSignin(step, { onSignedIn })
           ) : (
             renderConnect(step, { onConnected })
           )}

--- a/ui/chat/tests/interaction-card.test.ts
+++ b/ui/chat/tests/interaction-card.test.ts
@@ -2,6 +2,7 @@ import { strict as assert } from "node:assert";
 import { describe, it } from "node:test";
 import {
   advanceConnect,
+  advanceSignin,
   answerWithOption,
   answerWithText,
   type ChatInteractionStep,
@@ -45,6 +46,11 @@ const CONNECT: ChatInteractionStep = {
   id: "c1",
   toolkit: "gmail",
   reason: "to send the email",
+};
+const SIGNIN: ChatInteractionStep = {
+  kind: "signin",
+  id: "s1",
+  reason: "to use connected apps",
 };
 
 describe("hasSelectableOptions", () => {
@@ -187,6 +193,80 @@ describe("stepper flow: question, question, connect", () => {
     s = answerWithOption(s, steps, "o2").state;
     assert.deepEqual(s.answers.q1, { answer: "Jane", optionId: "o2" });
     assert.equal(s.current, 1);
+  });
+});
+
+describe("stepper flow: question, signin, connect", () => {
+  const steps = [Q2, SIGNIN, CONNECT];
+
+  it("walks all steps and completes with question answers only", () => {
+    // Answer Q2, advance the signin step, then the connect step.
+    let s = setDraft(initialStepperState(), "q2", "Running late");
+    s = answerWithText(s, steps).state; // -> signin step (index 1)
+    assert.equal(s.current, 1);
+
+    const afterSignin = advanceSignin(s, steps);
+    assert.equal(afterSignin.completed, undefined);
+    assert.equal(afterSignin.state.current, 2); // now on the connect step
+
+    // Signin contributes no answer text; only question answers complete.
+    const done = advanceConnect(afterSignin.state, steps);
+    assert.deepEqual(done.completed, [
+      { stepId: "q2", question: "What should it say?", answer: "Running late" },
+    ]);
+  });
+
+  it("advances the progress counter across the signin step", () => {
+    // "N of X" is derived from current+1 / total; signin counts like any step.
+    assert.equal(defaultProgress(2, steps.length), "2 of 3");
+  });
+});
+
+describe("advanceSignin", () => {
+  it("completes when the signin step is the last step", () => {
+    const s = setDraft(initialStepperState(), "q2", "hi");
+    const afterQ = answerWithText(s, [Q2, SIGNIN]).state; // -> signin (last)
+    const done = advanceSignin(afterQ, [Q2, SIGNIN]);
+    assert.deepEqual(done.completed, [
+      { stepId: "q2", question: "What should it say?", answer: "hi" },
+    ]);
+  });
+
+  it("contributes no answer for a signin-only sequence", () => {
+    const done = advanceSignin(initialStepperState(), [SIGNIN]);
+    assert.deepEqual(done.completed, []);
+  });
+});
+
+describe("optionLabel on a signin step", () => {
+  it("returns null (signin steps carry no options)", () => {
+    assert.equal(optionLabel(SIGNIN, "o1"), null);
+  });
+});
+
+describe("forward navigation past a completed signin step", () => {
+  // Mirror of the connect regression: [question, signin, connect]. Signing in
+  // advances to connect; a revisited signin step never re-fires onSignedIn, so
+  // Back onto it strands the sequence unless the forward affordance is offered.
+  const steps = [Q2, SIGNIN, CONNECT];
+
+  it("lets the user return to a completed signin step and still finish", () => {
+    let s = setDraft(initialStepperState(), "q2", "Running late");
+    s = answerWithText(s, steps).state; // -> signin (index 1)
+    s = advanceSignin(s, steps).state; // signed in -> connect (index 2)
+    s = goBack(s); // Back onto the completed signin step (index 1)
+    assert.equal(s.current, 1);
+
+    // Already signed in: its card never re-fires onSignedIn, so the stepper's
+    // own forward affordance is the only way onward.
+    assert.equal(canGoForward(s), true);
+    s = goForward(s); // -> connect (index 2)
+    assert.equal(s.current, 2);
+
+    const done = advanceConnect(s, steps); // connected -> complete
+    assert.deepEqual(done.completed, [
+      { stepId: "q2", question: "What should it say?", answer: "Running late" },
+    ]);
   });
 });
 

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -353,8 +353,8 @@ export interface InteractionOption {
 }
 
 /** One step in the interaction sequence. `id` is tool-assigned (`q1`..`qN` for
- *  question steps, `c1`..`cN` for connect steps) so each step's outcome is
- *  addressable. */
+ *  question steps, `s1` for the single signin step, `c1`..`cN` for connect
+ *  steps) so each step's outcome is addressable. */
 export type InteractionStep =
   | {
       kind: "question";
@@ -362,6 +362,7 @@ export type InteractionStep =
       question: string;
       options?: InteractionOption[];
     }
+  | { kind: "signin"; id: string; reason?: string }
   | { kind: "connect"; id: string; toolkit: string; reason?: string };
 
 /**
@@ -370,7 +371,7 @@ export type InteractionStep =
  * (request_connection). Present drives the `needs_you` board card and the
  * composer-replacing card, which walks the user through the steps one at a time;
  * absent means the mission needs nothing. Question steps come first (at most 3),
- * then connect steps.
+ * then at most one signin step, then connect steps.
  */
 export interface PendingInteraction {
   steps: InteractionStep[];


### PR DESCRIPTION
## What

The agent no longer refuses when integrations are blocked — it proposes the action.

- **`signin` step kind**: a 409 from the integrations proxy queues a sign-in step in the same stepper (questions → signin → connects); the card drives the existing Google-SSO gate, auto-advances if already signed in, and completion feeds "Signed in to Houston." into the composed reply. Signin-only sequences auto-continue hidden, exactly once.
- **Honest failure taxonomy** (review finding fixed): classification by the host error body code, not bare HTTP status — signed-out vs not-set-up-in-this-install vs transient upstream outage each get distinct model guidance; no more improvised "not available in this workspace", and a Composio outage can't masquerade as a config problem.
- Prompt (host + Rust mirror): sign-in joins the flow automatically; never claim app powers are unavailable unless Houston says they aren't set up.
- `.env.example`: documented dev integration modes (`COMPOSIO_API_KEY` direct / `HOUSTON_INTEGRATIONS_URL` gateway + in-app sign-in).
- Inventory v7; e2e covers the signin step render in mixed and signin-only sequences.

## Tests

protocol 21, runtime 518, host 634, web 90, app 957, ui card 32, cargo prompt 9; full e2e suite green; typecheck/check-locales/check:parity/biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)