### PR TITLE
fix(chat): big helmet only while the message loads, mission-log line once the agent works (HOU-724)

### DIFF
--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -156,7 +156,6 @@ export function MissionBoard({ source }: { source: BoardSource }) {
           onOpenLink={handleOpenLink}
           cardAvatar={source.cardAvatar}
           thinkingIndicator={panel.thinkingIndicator}
-          loadingIndicator={panel.loadingIndicator}
           panelAgentName={source.panelAgentName}
           panelAvatar={
             <AgentPanelAvatar

--- a/app/src/components/board/mission-control-archived.tsx
+++ b/app/src/components/board/mission-control-archived.tsx
@@ -140,7 +140,6 @@ export function MissionControlArchived({
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           thinkingIndicator={panel.thinkingIndicator}
-          loadingIndicator={panel.loadingIndicator}
           panelAgentName={activeAgent?.name ?? selectedItem?.subtitle}
           panelAvatar={
             <AgentPanelAvatar color={activeAgent?.color} running={false} />

--- a/app/src/components/tabs/archived-tab.tsx
+++ b/app/src/components/tabs/archived-tab.tsx
@@ -142,7 +142,6 @@ export default function ArchivedTab({ agent, agentDef }: TabProps) {
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           cardAvatar={<AgentCardAvatar color={agent.color} />}
           thinkingIndicator={panel.thinkingIndicator}
-          loadingIndicator={panel.loadingIndicator}
           panelAgentName={agent.name}
           panelAvatar={<AgentPanelAvatar color={agent.color} running={false} />}
           cardLabels={{

--- a/app/src/components/tabs/routine-setup-chat.tsx
+++ b/app/src/components/tabs/routine-setup-chat.tsx
@@ -215,7 +215,6 @@ export function RoutineSetupChat({ agent, agentDef, showBanner }: Props) {
           prepareAttachments={attachmentValidation.prepareAttachments}
           onAttachmentRejections={attachmentValidation.onAttachmentRejections}
           thinkingIndicator={panel.thinkingIndicator}
-          loadingIndicator={panel.loadingIndicator}
           panelAgentName={agent.name}
           panelAvatar={
             <AgentPanelAvatar color={agent.color} running={running} />

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -185,7 +185,6 @@ interface AgentChatPanelProps {
   processLabels: ChatPanelProps["processLabels"];
   getThinkingMessage: ChatPanelProps["getThinkingMessage"];
   thinkingIndicator: ChatPanelProps["thinkingIndicator"];
-  loadingIndicator: ChatPanelProps["loadingIndicator"];
   renderTurnSummary: ChatPanelProps["renderTurnSummary"];
   renderSystemMessage: AIBoardProps["renderSystemMessage"];
   mapFeedItems: AIBoardProps["mapFeedItems"];
@@ -215,12 +214,8 @@ export function useAgentChatPanel({
   onSelectSession,
 }: UseAgentChatPanelArgs): AgentChatPanelProps {
   const { t, i18n } = useTranslation(["board", "chat", "teams"]);
-  const {
-    processLabels,
-    getThinkingMessage,
-    thinkingIndicator,
-    loadingIndicator,
-  } = useChatDisplayLabels();
+  const { processLabels, getThinkingMessage, thinkingIndicator } =
+    useChatDisplayLabels();
   const queryClient = useQueryClient();
   const addToast = useUIStore((s) => s.addToast);
 
@@ -1412,7 +1407,6 @@ export function useAgentChatPanel({
     processLabels,
     getThinkingMessage,
     thinkingIndicator,
-    loadingIndicator,
     renderTurnSummary,
     renderSystemMessage,
     mapFeedItems,

--- a/app/src/components/use-chat-display-labels.tsx
+++ b/app/src/components/use-chat-display-labels.tsx
@@ -6,10 +6,7 @@ import { HoustonLogo } from "./shell/experience-card";
 
 export function useChatDisplayLabels(): Pick<
   ChatPanelProps,
-  | "processLabels"
-  | "getThinkingMessage"
-  | "thinkingIndicator"
-  | "loadingIndicator"
+  "processLabels" | "getThinkingMessage" | "thinkingIndicator"
 > {
   const { t } = useTranslation("chat");
   const processLabels = useMemo(
@@ -34,23 +31,14 @@ export function useChatDisplayLabels(): Pick<
     [t],
   );
 
-  // HOU-655: while a turn is in flight, the loading state is a single blinking
-  // Houston helmet under the "Mission in progress" line. The two pieces are
-  // separate props because they live on different clocks: the shimmering label
-  // (`thinkingIndicator`) yields to the mission-log header the moment a tool
-  // action takes over the status line, while the helmet (`loadingIndicator`)
-  // stays up for the WHOLE turn — under either line — and vanishes the instant
-  // the reply streams. One helmet, no duplicate label; ChatMessages owns the
-  // spacing between them.
+  // HOU-724: two distinct in-flight signals. Before the agent produces any
+  // output (the message is still being sent / queued), the indicator is the
+  // big blinking Houston helmet alone — no text. The moment the agent is
+  // actually working (thinking or running tools) an active mission-log header
+  // is on screen reading "Mission in progress: <action>" with the small helmet
+  // on its left, and that line is the ONLY indicator — ChatMessages suppresses
+  // this standalone one.
   const thinkingIndicator = useMemo(
-    () => (
-      <Shimmer as="span" duration={1} className="text-xs">
-        {t("process.active")}
-      </Shimmer>
-    ),
-    [t],
-  );
-  const loadingIndicator = useMemo(
     () => (
       <HoustonLogo size={20} className="animate-pulse text-muted-foreground" />
     ),
@@ -61,6 +49,5 @@ export function useChatDisplayLabels(): Pick<
     processLabels,
     getThinkingMessage,
     thinkingIndicator,
-    loadingIndicator,
   };
 }

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -71,8 +71,6 @@ export interface AIBoardProps {
   chatEmptyState?: ReactNode;
   /** Custom thinking indicator for the chat panel. */
   thinkingIndicator?: ReactNode;
-  /** Loader shown for the whole in-flight turn (see ChatPanel). */
-  loadingIndicator?: ReactNode;
   /** Avatar element shown on every kanban card (e.g. small agent icon). */
   cardAvatar?: ReactNode;
   /** Avatar element shown in the detail panel header. */
@@ -263,7 +261,6 @@ export function AIBoard({
   onPanelCloserReady,
   chatEmptyState,
   thinkingIndicator,
-  loadingIndicator,
   cardAvatar,
   panelAvatar,
   panelAgentName,
@@ -702,7 +699,6 @@ export function AIBoard({
           }
           emptyState={activeFeed.length === 0 ? chatEmptyState : undefined}
           thinkingIndicator={thinkingIndicator}
-          loadingIndicator={loadingIndicator}
           value={drafts ? (drafts[activeDraftKey] ?? "") : undefined}
           onValueChange={
             onDraftChange

--- a/ui/chat/src/chat-messages.tsx
+++ b/ui/chat/src/chat-messages.tsx
@@ -40,13 +40,11 @@ export { authorLabelFor } from "./author-label";
 export interface ChatMessagesProps {
   messages: ChatMessage[];
   status: "ready" | "streaming" | "submitted";
+  /** Shown while a turn is `"submitted"` and no active mission-log header is
+   *  on screen yet — the pre-first-output loading gap. Once the agent is
+   *  actually working, the active process block's "Mission in progress:
+   *  <action>" line is the only indicator (HOU-724). */
   thinkingIndicator: ReactNode;
-  /** Rendered below the last item for the WHOLE in-flight turn (status
-   *  `"submitted"`), even while an active mission-log header is surfacing
-   *  "Mission in progress: <action>" and the standalone `thinkingIndicator`
-   *  is therefore suppressed (HOU-655: the loading helmet must not vanish
-   *  when a tool label takes over the status line). */
-  loadingIndicator?: ReactNode;
   transformContent?: (content: string) => {
     content: string;
     extra?: ReactNode;
@@ -92,7 +90,6 @@ export function ChatMessages({
   messages,
   status,
   thinkingIndicator,
-  loadingIndicator,
   transformContent,
   toolLabels,
   isSpecialTool,
@@ -218,13 +215,11 @@ export function ChatMessages({
             </Message>
           );
         })}
-        {status === "submitted" &&
-        (showThinkingIndicator || loadingIndicator) ? (
+        {showThinkingIndicator ? (
           <Message from="assistant">
             <MessageContent>
               <div className="flex flex-col items-start gap-4 py-1">
-                {showThinkingIndicator ? thinkingIndicator : null}
-                {loadingIndicator}
+                {thinkingIndicator}
               </div>
             </MessageContent>
           </Message>

--- a/ui/chat/src/chat-panel-types.ts
+++ b/ui/chat/src/chat-panel-types.ts
@@ -67,12 +67,11 @@ export interface ChatPanelProps {
   queuedLabels?: QueuedMessageLabels;
   canSendEmpty?: boolean;
   status?: ChatStatus;
+  /** Indicator for the gap before the agent's first output (the message is
+   *  in flight but nothing is running yet — e.g. the pulsing Houston helmet).
+   *  Suppressed the moment an active mission-log header takes over with
+   *  "Mission in progress: <action>" (HOU-724). */
   thinkingIndicator?: ReactNode;
-  /** Loader (e.g. the pulsing Houston helmet) shown for the WHOLE in-flight
-   *  turn — it stays up while the active mission-log header reads "Mission in
-   *  progress: <action>" and the standalone `thinkingIndicator` is suppressed
-   *  (HOU-655). Hidden the moment the reply text streams or the turn settles. */
-  loadingIndicator?: ReactNode;
   transformContent?: (content: string) => {
     content: string;
     extra?: ReactNode;

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -33,7 +33,6 @@ export function ChatPanel({
   emptyState,
   status: statusProp,
   thinkingIndicator,
-  loadingIndicator,
   transformContent,
   toolLabels,
   isSpecialTool,
@@ -149,7 +148,6 @@ export function ChatPanel({
           messages={messages}
           status={status}
           thinkingIndicator={thinkingIndicator ?? <DefaultThinkingIndicator />}
-          loadingIndicator={loadingIndicator}
           transformContent={transformContent}
           toolLabels={toolLabels}
           isSpecialTool={isSpecialTool}


### PR DESCRIPTION
## Summary

HOU-724. The in-flight chat turn previously showed a shimmering "Mission in progress..." text line plus a pulsing Houston helmet below it, and the helmet stayed on screen for the whole turn — even while the active mission-log header was already saying "Mission in progress: <action>".

Now the two loading states are distinct:

- **Message loading (before any agent output):** only the big pulsing Houston helmet, no text. This covers sending/queueing, the gap before the agent's first thinking or tool call.
- **Agent actually working (thinking / reasoning / tool calls):** only the mission-log header line — "Mission in progress..." / "Mission in progress: <action>" with the small helmet on its left. The standalone helmet disappears the moment that line appears.

## Changes

- `app/src/components/use-chat-display-labels.tsx`: `thinkingIndicator` is now the pulsing helmet (was shimmer text); the separate `loadingIndicator` is gone.
- Removed the `loadingIndicator` prop entirely (it existed only to keep the helmet up for the whole turn, which this issue reverses): `ui/chat` (`chat-panel-types.ts`, `chat-panel.tsx`, `chat-messages.tsx`), `ui/board/ai-board.tsx`, and all app pass-throughs.
- `ChatMessages` renders the indicator only when `shouldShowThinkingIndicator` says no active process block is on screen (existing HOU-471 logic, unchanged).

## Before (reproduce the old behavior)

1. On `main`, start the app and send a message to an agent.
2. While the message is in flight you see shimmering "Mission in progress..." text with a pulsing helmet **below** it.
3. Once the agent starts running tools, the header changes to "Mission in progress: <action>" **and the standalone pulsing helmet is still there underneath** — two indicators at once.

## After (verify the fix)

1. On this branch, send a message to an agent.
2. While the message loads (before any agent activity) you see **only** the big pulsing helmet — no text line.
3. As soon as the agent thinks or runs a tool, the helmet disappears and the only indicator is the mission-log line "Mission in progress: <action>" with the small helmet on the left.
4. When the reply streams, no loading indicator remains.

## Tests

- `pnpm check` (Biome) clean
- `pnpm typecheck` (all 22 workspace projects) passes
- `pnpm --filter @houston-ai/chat test` — 94 tests pass (the `shouldShowThinkingIndicator` suite covers the show/suppress logic this relies on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)