### PR TITLE
feat(host): per-agent activity endpoint for gateway idle-sleep

### DIFF
--- a/packages/host/src/channel/proxy-busy.test.ts
+++ b/packages/host/src/channel/proxy-busy.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { MemoryCredentialStore } from "../credentials/store";
+import type { Agent, Workspace } from "../domain/types";
+import { ProxyChannel } from "./proxy";
+
+const ws: Workspace = {
+  id: "w1",
+  ownerUserId: "alice",
+  kind: "personal",
+  name: "Personal",
+  slug: "alice",
+  runtime: "gke",
+  createdAt: 1,
+};
+const agent: Agent = {
+  id: "agent-1",
+  workspaceId: "w1",
+  name: "Sales",
+  createdAt: 1,
+};
+const ctx = { workspace: ws, agent };
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+test("busy answers false for an asleep runtime without waking it", async () => {
+  const calls: string[] = [];
+  const channel = new ProxyChannel({
+    launcher: {
+      async ensureAwake() {
+        calls.push("ensureAwake");
+        throw new Error("must not wake an asleep runtime for busy");
+      },
+      async sleep() {},
+      async destroy() {},
+      async status() {
+        calls.push("status");
+        return "asleep" as const;
+      },
+    },
+    proxy: { async forward() {} },
+    credentials: new MemoryCredentialStore(),
+    forwardActingHeader: false,
+  });
+
+  await expect(channel.busy(ctx)).resolves.toBe(false);
+  expect(calls).toEqual(["status"]);
+});
+
+test("busy proxies to a running runtime's /busy endpoint", async () => {
+  const fetchSpy = vi
+    .spyOn(globalThis, "fetch")
+    .mockResolvedValue(Response.json({ busy: true }));
+  const channel = new ProxyChannel({
+    launcher: {
+      async ensureAwake() {
+        return { baseUrl: "http://runtime.local", token: "sbx-token" };
+      },
+      async sleep() {},
+      async destroy() {},
+      async status() {
+        return "running" as const;
+      },
+    },
+    proxy: { async forward() {} },
+    credentials: new MemoryCredentialStore(),
+    forwardActingHeader: false,
+  });
+
+  await expect(channel.busy(ctx)).resolves.toBe(true);
+  expect(fetchSpy).toHaveBeenCalledWith("http://runtime.local/busy", {
+    headers: { Authorization: "Bearer sbx-token" },
+  });
+});
+
+test("busy treats an unreachable running runtime as busy", async () => {
+  vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("unreachable"));
+  const channel = new ProxyChannel({
+    launcher: {
+      async ensureAwake() {
+        return { baseUrl: "http://runtime.local", token: "sbx-token" };
+      },
+      async sleep() {},
+      async destroy() {},
+      async status() {
+        return "running" as const;
+      },
+    },
+    proxy: { async forward() {} },
+    credentials: new MemoryCredentialStore(),
+    forwardActingHeader: false,
+  });
+
+  await expect(channel.busy(ctx)).resolves.toBe(true);
+});

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -182,6 +182,28 @@ export class ProxyChannel implements RuntimeChannel {
     return body.cancelled === true;
   }
 
+  async busy(ctx: ChannelCtx): Promise<boolean> {
+    // An asleep/absent runtime cannot be running a turn (turns live inside the
+    // runtime process; sleep kills it) — answer false without waking it.
+    if ((await this.opts.launcher.status(ctx.agent.id)) !== "running")
+      return false;
+    try {
+      const endpoint = await this.opts.launcher.ensureAwake(ctx.agent);
+      const res = await fetch(`${endpoint.baseUrl}/busy`, {
+        headers: { Authorization: `Bearer ${endpoint.token}` },
+      });
+      if (!res.ok) return true;
+      const body = (await res.json()) as { busy?: unknown };
+      return typeof body.busy === "boolean" ? body.busy : true;
+    } catch {
+      return true;
+    }
+  }
+
+  async runtimeStatus(ctx: ChannelCtx) {
+    return this.opts.launcher.status(ctx.agent.id);
+  }
+
   async teardown(ctx: ChannelCtx): Promise<void> {
     await this.opts.launcher.destroy(ctx.agent.id, { dropVolume: true });
   }

--- a/packages/host/src/channel/turn.ts
+++ b/packages/host/src/channel/turn.ts
@@ -90,6 +90,14 @@ export class TurnChannel implements RuntimeChannel {
     );
   }
 
+  async busy(ctx: ChannelCtx): Promise<boolean> {
+    return this.deps.relay.busy(ctx.agent.id);
+  }
+
+  async runtimeStatus(ctx: ChannelCtx) {
+    return (await this.busy(ctx)) ? "running" : "asleep";
+  }
+
   async teardown(ctx: ChannelCtx): Promise<void> {
     await this.deps.vfs.deletePrefix(prefixFor(ctx.workspace, ctx.agent));
   }

--- a/packages/host/src/config.ts
+++ b/packages/host/src/config.ts
@@ -29,9 +29,6 @@ export const config = {
   sandboxTokenSecret:
     process.env.CP_SANDBOX_TOKEN_SECRET || "dev-insecure-sandbox-secret",
 
-  /** Minutes of inactivity before an agent's sandbox is slept (scale to zero). */
-  idleSleepMinutes: Number(process.env.CP_IDLE_SLEEP_MINUTES || 10),
-
   /** In-cluster URL sandboxes call to serve their workspace's central credential (connect-once). */
   controlPlaneInternalUrl: process.env.CP_INTERNAL_URL || "",
 

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -177,6 +177,14 @@ export interface RuntimeChannel {
    * but never resurrects the run.
    */
   cancelTurn(ctx: ChannelCtx, conversationId: string): Promise<boolean>;
+  /**
+   * Whether this agent has any in-flight turn in the runtime/channel layer.
+   * Unknown transport state must be treated as busy by implementations that
+   * can otherwise sleep live work.
+   */
+  busy(ctx: ChannelCtx): Promise<boolean>;
+  /** Cheap runtime/channel state for diagnostics and idle-sleep callers. */
+  runtimeStatus?(ctx: ChannelCtx): Promise<RuntimeState | "unknown">;
   /** Tear down the agent's runtime-side state (volume / object prefix) before record deletion. */
   teardown(ctx: ChannelCtx): Promise<void>;
   /**

--- a/packages/host/src/routes/agent-authz.ts
+++ b/packages/host/src/routes/agent-authz.ts
@@ -45,6 +45,18 @@ export interface AgentRouteDeps {
    * of this host's single local user id.
    */
   gatewayFronted?: boolean;
+  /**
+   * How many /agents/* requests this server currently holds open, the asking
+   * /activity probe included (server.ts counts them; the reader subtracts
+   * itself). Long-lived per-agent SSE streams — a turn reply, a conversation
+   * events subscription — stay counted for their whole life, which is the
+   * point: an open stream means someone is watching, and the gateway's idle
+   * sweep must not sleep the pod under them. Deliberately scoped to /agents/*:
+   * the top-level /v1/events is held by the gateway's reactivity fan-in for
+   * EVERY awake pod whenever the app is open anywhere, and counting it would
+   * defeat idle-sleep wholesale.
+   */
+  agentRequestCount?: () => number;
 }
 
 export const DEFAULT_PATHS = new CloudPaths();

--- a/packages/host/src/routes/agents-activity.test.ts
+++ b/packages/host/src/routes/agents-activity.test.ts
@@ -1,0 +1,299 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { Readable } from "node:stream";
+import { createRoutineRun, saveRoutineRuns } from "@houston/domain";
+import type { Capabilities, Routine, RoutineRun } from "@houston/protocol";
+import { beforeEach, expect, test, vi } from "vitest";
+import { MemoryCredentialStore } from "../credentials/store";
+import type {
+  CaptureResult,
+  ChannelCtx,
+  RuntimeChannel,
+  TurnPin,
+} from "../ports";
+import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
+import { MemoryWorkspaceStore } from "../store/memory";
+import { MemoryVfs } from "../vfs";
+import { workspaceRoot } from "./agent-data";
+import { handleAgents } from "./agents";
+
+/**
+ * GET /agents/:id/activity — gateway idle-sleep probe. It reports whether any
+ * runtime turn or routine run is still active, without falling through to the
+ * runtime dispatch surface.
+ */
+
+class SpyChannel implements RuntimeChannel {
+  busyResult = false;
+  runtime = "running" as const;
+  dispatched: string[] = [];
+  fired: { conversationId: string; text: string; pin?: TurnPin }[] = [];
+
+  async dispatch(
+    _ctx: ChannelCtx,
+    _method: string,
+    rest: string,
+    _url: URL,
+    _req: IncomingMessage,
+    res: ServerResponse,
+  ) {
+    this.dispatched.push(rest);
+    res.writeHead(500, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "unexpected dispatch" }));
+  }
+  async fireTurn(
+    _ctx: ChannelCtx,
+    conversationId: string,
+    text: string,
+    pin?: TurnPin,
+  ) {
+    this.fired.push({ conversationId, text, pin });
+  }
+  async cancelTurn() {
+    return false;
+  }
+  async busy() {
+    return this.busyResult;
+  }
+  async runtimeStatus() {
+    return this.runtime;
+  }
+  async teardown() {}
+  async captureCredential(): Promise<CaptureResult> {
+    return { ok: true, provider: "openai-codex" };
+  }
+  async forgetCredential() {}
+  async saveApiKeyCredential() {}
+  async saveClaudeOAuthCredential() {}
+  async saveCustomEndpoint() {}
+}
+
+const CAPS: Capabilities = {
+  profile: "cloud",
+  revealInOs: false,
+  terminal: false,
+  tunnel: false,
+  codeExecution: "remote-sandbox",
+  providers: ["openai-codex"],
+  openaiCompatible: false,
+  integrations: [],
+};
+
+let store: MemoryWorkspaceStore;
+let vfs: MemoryVfs;
+let channel: SpyChannel;
+let deps: ControlPlaneDeps;
+let agentId = "";
+
+beforeEach(async () => {
+  store = new MemoryWorkspaceStore();
+  vfs = new MemoryVfs();
+  channel = new SpyChannel();
+  deps = {
+    verifier: {
+      async verify() {
+        return null;
+      },
+    },
+    store,
+    credentials: new MemoryCredentialStore(),
+    vault: { sandboxToken: () => "x", validateSandboxToken: () => null },
+    channels: { gke: channel },
+    vfs,
+    capabilities: CAPS,
+  };
+  const ws = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.createAgent({ workspaceId: ws.id, name: "Helper" });
+  agentId = agent.id;
+});
+
+function req(): IncomingMessage {
+  const stream = Readable.from([]);
+  return Object.assign(stream, { headers: {} }) as IncomingMessage;
+}
+
+function res() {
+  const out = {
+    status: 0,
+    body: "",
+    writeHead(status: number) {
+      this.status = status;
+      return this;
+    },
+    end(chunk?: unknown) {
+      this.body = chunk ? String(chunk) : "";
+      return this;
+    },
+  };
+  return out as unknown as ServerResponse & typeof out;
+}
+
+async function activity(who = "alice", id = agentId) {
+  const path = `/agents/${encodeURIComponent(id)}/activity`;
+  const url = new URL(path, "http://host.local");
+  const response = res();
+  const handled = await handleAgents(
+    deps,
+    who,
+    "GET",
+    path,
+    url,
+    req(),
+    response,
+  );
+  return { handled, response, json: JSON.parse(response.body || "{}") };
+}
+
+async function seedRun(run: RoutineRun): Promise<void> {
+  const ws = await store.getOrCreatePersonalWorkspace("alice");
+  const agent = await store.getAgent(agentId);
+  if (!agent) throw new Error("expected agent to exist");
+  await saveRoutineRuns(vfs, workspaceRoot(ws, agent), [run]);
+}
+
+const routine: Routine = {
+  id: "routine-1",
+  name: "Daily report",
+  description: "",
+  prompt: "write the report",
+  schedule: "0 9 * * *",
+  enabled: true,
+  suppress_when_silent: false,
+  chat_mode: "shared",
+  integrations: [],
+  created_at: "2026-01-01T00:00:00.000Z",
+  updated_at: "2026-01-01T00:00:00.000Z",
+};
+
+test("reports idle activity without falling through to runtime dispatch", async () => {
+  const { handled, response, json } = await activity();
+  expect(handled).toBe(true);
+  expect(response.status).toBe(200);
+  expect(json).toEqual({
+    busy: false,
+    runtime: "running",
+    runningRoutineRuns: 0,
+    activeRequests: 0,
+  });
+  expect(channel.dispatched).toEqual([]);
+});
+
+test("reports busy when the channel has an active turn", async () => {
+  channel.busyResult = true;
+  const { response, json } = await activity();
+  expect(response.status).toBe(200);
+  expect(json).toEqual({
+    busy: true,
+    runtime: "running",
+    runningRoutineRuns: 0,
+    activeRequests: 0,
+  });
+});
+
+test("reports busy when a routine run is still running", async () => {
+  await seedRun(createRoutineRun(routine, "run-1", "2026-01-01T00:00:00.000Z"));
+
+  const { response, json } = await activity();
+  expect(response.status).toBe(200);
+  expect(json).toEqual({
+    busy: true,
+    runtime: "running",
+    runningRoutineRuns: 1,
+    activeRequests: 0,
+  });
+});
+
+test("counts OTHER held /agents/* requests as busy (open SSE stream)", async () => {
+  // The probe itself is one of the counted requests — 1 means "just me".
+  deps.agentRequestCount = () => 1;
+  expect((await activity()).json).toMatchObject({
+    busy: false,
+    activeRequests: 0,
+  });
+
+  // A second held request (a conversation-events subscription, a streaming
+  // turn reply) keeps the pod busy even with no turn and no routine run.
+  deps.agentRequestCount = () => 2;
+  expect((await activity()).json).toMatchObject({
+    busy: true,
+    activeRequests: 1,
+  });
+});
+
+test("unknown or unauthorized agents follow the existing authz statuses", async () => {
+  const unknown = await activity("alice", "nope");
+  expect(unknown.response.status).toBe(404);
+
+  const forbidden = await activity("bob");
+  expect(forbidden.response.status).toBe(403);
+});
+
+test("the real server wires the counter: a held stream reads busy over HTTP", async () => {
+  deps.verifier = {
+    async verify() {
+      return { userId: "alice" };
+    },
+  };
+  // A dispatch that streams and never ends on its own — an open per-agent
+  // SSE subscription, as the gateway proxies it.
+  let release: (() => void) | undefined;
+  channel.dispatch = async (
+    _ctx: ChannelCtx,
+    _method: string,
+    _rest: string,
+    _url: URL,
+    _req: IncomingMessage,
+    streamRes: ServerResponse,
+  ) => {
+    streamRes.writeHead(200, { "content-type": "text/event-stream" });
+    streamRes.write(": hb\n\n");
+    await new Promise<void>((resolve) => {
+      release = () => {
+        streamRes.end();
+        resolve();
+      };
+    });
+  };
+  const server = createControlPlaneServer(deps);
+  await new Promise<void>((r) => {
+    server.listen(0, "127.0.0.1", () => r());
+  });
+  const { port } = server.address() as AddressInfo;
+  const base = `http://127.0.0.1:${port}`;
+  const auth = { Authorization: "Bearer token" };
+  try {
+    const held = fetch(
+      `${base}/agents/${encodeURIComponent(agentId)}/conversations/c1/events`,
+      { headers: auth },
+    );
+    await vi.waitFor(() => {
+      expect(release).toBeDefined();
+    });
+
+    const probe = await fetch(
+      `${base}/agents/${encodeURIComponent(agentId)}/activity`,
+      { headers: auth },
+    );
+    expect(await probe.json()).toMatchObject({
+      busy: true,
+      activeRequests: 1,
+    });
+
+    release?.();
+    await (await held).text();
+    // The stream ended → its count is released and the pod reads idle again.
+    await vi.waitFor(async () => {
+      const after = await fetch(
+        `${base}/agents/${encodeURIComponent(agentId)}/activity`,
+        { headers: auth },
+      );
+      expect(await after.json()).toMatchObject({
+        busy: false,
+        activeRequests: 0,
+      });
+    });
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((r) => server.close(() => r(null)));
+  }
+});

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -1,5 +1,5 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
-import { seedSchemas } from "@houston/domain";
+import { loadRoutineRuns, seedSchemas } from "@houston/domain";
 import {
   type CustomEndpoint,
   type HoustonEvent,
@@ -36,6 +36,42 @@ export type { AgentRouteDeps } from "./agent-authz";
 /** Attach the agent's real directory (`dir`) when this deployment has one. */
 function withAgentDir(deps: AgentRouteDeps, ws: Workspace, agent: Agent) {
   return deps.agentDir ? { ...agent, dir: deps.agentDir(ws, agent) } : agent;
+}
+
+async function activityStatus(
+  deps: AgentRouteDeps,
+  ctx: { workspace: Workspace; agent: Agent },
+) {
+  const channel = channelFor(deps, ctx.workspace);
+  if (!channel) return null;
+  if (!deps.vfs) return { error: "agent data not configured" as const };
+
+  const paths = deps.paths ?? DEFAULT_PATHS;
+  const runs = await loadRoutineRuns(
+    deps.vfs,
+    paths.agentRoot(ctx.workspace, ctx.agent),
+  );
+  const runningRoutineRuns = runs.items.filter(
+    (run) => run.status === "running",
+  ).length;
+  const turnBusy = await channel.busy(ctx);
+  const runtime = channel.runtimeStatus
+    ? await channel.runtimeStatus(ctx)
+    : "unknown";
+  // Other /agents/* requests held open right now — minus this probe itself.
+  // Catches what the turn check cannot: an open conversation-events SSE
+  // subscription (an agent open in a UI tab) between turns. Two probes
+  // overlapping see each other and both answer busy — conservative, and gone
+  // by the next sweep.
+  const activeRequests = deps.agentRequestCount
+    ? Math.max(0, deps.agentRequestCount() - 1)
+    : 0;
+  return {
+    busy: turnBusy || runningRoutineRuns > 0 || activeRequests > 0,
+    runtime,
+    runningRoutineRuns,
+    activeRequests,
+  };
 }
 
 /**
@@ -422,6 +458,34 @@ export async function handleAgents(
   // Routine-run routes (run-now / cancel) — matched before the generic
   // dispatch below; the runtime has no routine routes. See routine-runs.ts.
   if (await handleRoutineRuns(deps, userId, method, path, res)) return true;
+
+  const activity = path.match(/^\/agents\/([^/]+)\/activity$/);
+  if (activity && method === "GET") {
+    const agentId = activity[1] ? decodeURIComponent(activity[1]) : undefined;
+    if (!agentId) {
+      json(res, 404, { error: "not found" });
+      return true;
+    }
+    const authz = await authorizeAgent(deps, userId, agentId);
+    if (!authz.ok) {
+      json(res, authz.status, { error: authz.reason });
+      return true;
+    }
+    const status = await activityStatus(deps, {
+      workspace: authz.workspace,
+      agent: authz.agent,
+    });
+    if (!status) {
+      noChannel(res, authz.workspace.runtime);
+      return true;
+    }
+    if ("error" in status) {
+      json(res, 503, { error: status.error });
+      return true;
+    }
+    json(res, 200, status);
+    return true;
+  }
 
   // The per-agent runtime surface: /agents/:agentId/<anything> → the agent's
   // runtime, via the workspace's channel. The frontend points its runtime

--- a/packages/host/src/routes/openai-compatible.test.ts
+++ b/packages/host/src/routes/openai-compatible.test.ts
@@ -30,6 +30,12 @@ class SpyChannel implements RuntimeChannel {
   async cancelTurn() {
     return false;
   }
+  async busy() {
+    return false;
+  }
+  async runtimeStatus() {
+    return "running" as const;
+  }
   async teardown() {}
   async captureCredential() {
     return { ok: true as const, provider: "openai-codex" };

--- a/packages/host/src/routes/run-cancel.test.ts
+++ b/packages/host/src/routes/run-cancel.test.ts
@@ -32,6 +32,12 @@ class SpyChannel implements RuntimeChannel {
     this.cancelled.push(conversationId);
     return true;
   }
+  async busy() {
+    return false;
+  }
+  async runtimeStatus() {
+    return "running" as const;
+  }
   async teardown() {}
   async captureCredential() {
     return { ok: true as const, provider: "openai-codex" };

--- a/packages/host/src/routes/run-routine.test.ts
+++ b/packages/host/src/routes/run-routine.test.ts
@@ -45,6 +45,12 @@ class SpyChannel implements RuntimeChannel {
   async cancelTurn() {
     return false;
   }
+  async busy() {
+    return false;
+  }
+  async runtimeStatus() {
+    return "running" as const;
+  }
   async teardown() {}
   async captureCredential() {
     return { ok: true as const, provider: "openai-codex" };

--- a/packages/host/src/routes/setup-runtime.test.ts
+++ b/packages/host/src/routes/setup-runtime.test.ts
@@ -62,6 +62,12 @@ class FakeChannel implements RuntimeChannel {
   async cancelTurn(): Promise<boolean> {
     return false;
   }
+  async busy(): Promise<boolean> {
+    return false;
+  }
+  async runtimeStatus() {
+    return "running" as const;
+  }
   async teardown(): Promise<void> {}
   async captureCredential(
     ctx: ChannelCtx,

--- a/packages/host/src/schedule/firer.test.ts
+++ b/packages/host/src/schedule/firer.test.ts
@@ -77,6 +77,12 @@ function recordingChannel(): RuntimeChannel & {
     async cancelTurn() {
       return false;
     },
+    async busy() {
+      return false;
+    },
+    async runtimeStatus() {
+      return "running" as const;
+    },
     async teardown() {},
     async captureCredential() {
       return { ok: true, provider: "openai-codex" };

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -141,6 +141,12 @@ export interface ControlPlaneDeps {
    * untrusted client input and is ignored.
    */
   gatewayFronted?: boolean;
+  /**
+   * Live /agents/* request count (createControlPlaneServer wires it; see the
+   * AgentRouteDeps.agentRequestCount doc for why it exists and why it is
+   * scoped to the per-agent surface only).
+   */
+  agentRequestCount?: () => number;
   corsOrigin?: string;
 }
 
@@ -268,8 +274,25 @@ async function handle(
 
 /** Build the frontend-facing host API server. */
 export function createControlPlaneServer(deps: ControlPlaneDeps): Server {
+  // Live count of /agents/* requests, long-lived SSE streams included — the
+  // /activity busy probe reads it so the gateway's idle sweep never sleeps a
+  // pod with an open per-agent stream. `close` fires on both completion and a
+  // severed connection (and always after `finish` on modern Node), so every
+  // increment has exactly one decrement.
+  let agentRequests = 0;
+  const counted: ControlPlaneDeps = {
+    ...deps,
+    agentRequestCount: () => agentRequests,
+  };
   return createServer((req, res) => {
-    handle(deps, req, res).catch((err) => {
+    const path = (req.url || "/").split("?")[0] ?? "";
+    if (path === "/agents" || path.startsWith("/agents/")) {
+      agentRequests++;
+      res.once("close", () => {
+        agentRequests--;
+      });
+    }
+    handle(counted, req, res).catch((err) => {
       const message = err instanceof Error ? err.message : String(err);
       if (!res.headersSent) json(res, 500, { error: message });
       else if (!res.writableEnded) res.end();

--- a/packages/runtime/src/session/bus.test.ts
+++ b/packages/runtime/src/session/bus.test.ts
@@ -1,6 +1,7 @@
 import type { SequencedFrame } from "@houston/runtime-client";
 import { expect, test } from "vitest";
 import {
+  anyTurnRunning,
   evict,
   publish,
   reduceSnapshot,
@@ -13,6 +14,16 @@ import {
 // Unique id per test so the module-level maps never bleed across cases.
 let counter = 0;
 const freshId = () => `test-conv-${counter++}`;
+
+test("anyTurnRunning reports whether any channel snapshot is running", () => {
+  const id = freshId();
+  expect(anyTurnRunning()).toBe(false);
+  publish(id, { type: "user", data: { content: "go", ts: 1 } });
+  expect(anyTurnRunning()).toBe(true);
+  publish(id, { type: "done", data: null });
+  expect(anyTurnRunning()).toBe(false);
+  evict(id);
+});
 
 test("events reach only that conversation's subscribers, stamped with seq", () => {
   const a = freshId();

--- a/packages/runtime/src/session/bus.ts
+++ b/packages/runtime/src/session/bus.ts
@@ -72,6 +72,14 @@ export function snapshot(id: string): ConversationSnapshot {
   return channels.get(id)?.snapshot ?? EMPTY;
 }
 
+/** Whether any conversation in this runtime currently has an in-flight turn. */
+export function anyTurnRunning(): boolean {
+  for (const ch of channels.values()) {
+    if (ch.snapshot.running) return true;
+  }
+  return false;
+}
+
 /**
  * The frames a resuming subscriber that saw everything up to `after` still
  * needs, in publish order. Null = the cursor cannot be served (older than the

--- a/packages/runtime/src/transport/server.test.ts
+++ b/packages/runtime/src/transport/server.test.ts
@@ -1,6 +1,7 @@
 import type { Server } from "node:http";
 import { expect, test } from "vitest";
 import { config } from "../config";
+import { evict, publish } from "../session/bus";
 import { createRuntimeServer } from "./server";
 
 function listen(server: Server): Promise<string> {
@@ -38,6 +39,28 @@ test("generate-agent without a description is a 400, not a model call", async ()
       error: "missing 'description'",
     });
   } finally {
+    await close(server);
+  }
+});
+
+test("GET /busy reports aggregate in-flight turn state without auth", async () => {
+  const server = createRuntimeServer();
+  const baseUrl = await listen(server);
+  const conversationId = "server-busy-test";
+  try {
+    let res = await fetch(`${baseUrl}/busy`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ busy: false });
+
+    publish(conversationId, {
+      type: "user",
+      data: { content: "work", ts: 1 },
+    });
+    res = await fetch(`${baseUrl}/busy`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ busy: true });
+  } finally {
+    evict(conversationId);
     await close(server);
   }
 });

--- a/packages/runtime/src/transport/server.ts
+++ b/packages/runtime/src/transport/server.ts
@@ -1,6 +1,7 @@
 import { createServer } from "node:http";
 import { primeAnthropicCredential } from "../backends/claude/credential-status";
 import { config } from "../config";
+import { anyTurnRunning } from "../session/bus";
 import { handleConversationRoute } from "./conversation-routes";
 import { applyCors } from "./cors";
 import { handleGenerateRoute } from "./generate-route";
@@ -22,6 +23,10 @@ async function handle(ctx: RouteContext) {
 
   if (ctx.method === "GET" && ctx.path === "/health") {
     json(ctx.res, 200, { status: "ok", version: config.version });
+    return;
+  }
+  if (ctx.method === "GET" && ctx.path === "/busy") {
+    json(ctx.res, 200, { busy: anyTurnRunning() });
     return;
   }
   if (ctx.method === "GET" && ctx.path === "/version") {


### PR DESCRIPTION
The cloud gateway is gaining idle scale-to-zero (gethouston/cloud#57): it scales an agent pod's Deployment to 0 after a quiet period, and must ask the pod "are you busy?" before pulling the plug — a conversation turn can run for minutes after the client disconnected, and nothing at host level reported it.

## What it adds
- **runtime**: `anyTurnRunning()` over the session-bus channel map, exposed as `GET /busy` beside `/health`.
- **host**: `busy()` on the `RuntimeChannel` port. `ProxyChannel` leans on the `cancelTurn` architectural fact (turns die with the runtime child): an asleep/absent child answers `false` with zero round-trips; a running child is asked via `/busy`; any transport doubt reads as busy — the gateway must never sleep what can't be proven quiet. `TurnChannel` relays honestly.
- **host**: `GET /agents/:id/activity` → `{ busy, runtime, runningRoutineRuns, activeRequests }`, handled before the generic runtime dispatch. `busy` folds in:
  - the active-turn check above,
  - `routine_runs` rows with `status: "running"` (the durable host-level signal — a reconcile-timed-out row only ever *delays* sleep, the safe direction),
  - the live `/agents/*` request count: `createControlPlaneServer` counts held requests (long-lived SSE streams included, the probe subtracting itself), so an agent open in a UI tab keeps its pod awake between turns. Deliberately scoped to `/agents/*` — counting the top-level `/v1/events` would let the gateway's reactivity fan-in pin every awake pod forever.
- Drops dead `config.idleSleepMinutes` (unreferenced since the closed control plane retired; the gateway owns sleep).

## Verification
- host: 646 tests green (new: activity route incl. authz statuses + a real-server test holding a stream open over HTTP and watching `busy` flip; ProxyChannel busy truth table). runtime: full suite green (new: `anyTurnRunning`, `/busy` route). Monorepo typecheck + biome clean.
- End-to-end on a kind cluster with the gateway PR: the sweep's probe kept a pod with a held conversation-events stream awake past the threshold and slept it exactly threshold+one-tick after the stream closed; an idle pod slept on schedule and re-woke on dispatch in ~9s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)