### PR TITLE
fix: repair main CI — merge-skew routine fixture + chat composer focus steal (HOU-725)

### DIFF
--- a/app/src/components/tabs/routine-setup-chat.tsx
+++ b/app/src/components/tabs/routine-setup-chat.tsx
@@ -200,6 +200,10 @@ export function RoutineSetupChat({
           // in the editor there is no X either — the routine and its chat
           // are one surface.
           disableOutsideClose
+          // The form's own fields autofocus; the chat grabbing focus when its
+          // selection hydrates (often seconds later) would steal keystrokes
+          // mid-typing from the Name/Prompt inputs.
+          disableComposerAutoFocus
           hidePanelClose={!dismissable}
           feedItems={feedItems}
           isLoading={send.effectiveLoading}

--- a/packages/host/src/routes/agents-activity.test.ts
+++ b/packages/host/src/routes/agents-activity.test.ts
@@ -154,7 +154,6 @@ async function seedRun(run: RoutineRun): Promise<void> {
 const routine: Routine = {
   id: "routine-1",
   name: "Daily report",
-  description: "",
   prompt: "write the report",
   schedule: "0 9 * * *",
   enabled: true,

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -175,6 +175,15 @@ export interface AIBoardProps {
    */
   disableOutsideClose?: boolean;
   /**
+   * Skip the automatic composer focus when a selection hydrates. The board
+   * bumps the composer focus token so keyboard users can type immediately —
+   * but when the panel is a side companion of a form (the routine editor's
+   * chat), that late bump steals focus MID-TYPING from the form's inputs
+   * (the user's keystrokes suddenly land in the chat composer). Explicit
+   * focus requests (openNewPanel with focusComposer) still work.
+   */
+  disableComposerAutoFocus?: boolean;
+  /**
    * Hide the detail panel's close button. For a panel that is a permanent
    * part of its host view (the routine editor's chat), there is nothing for
    * an X to mean — combine with `disableOutsideClose`.
@@ -289,6 +298,7 @@ export function AIBoard({
   panelActions,
   panelContainer,
   disableOutsideClose,
+  disableComposerAutoFocus,
   hidePanelClose,
   drafts,
   onDraftChange,
@@ -410,8 +420,10 @@ export function AIBoard({
     } else {
       setNewPanelOpen(false);
     }
-    setComposerFocusToken((prev) => (prev ?? 0) + 1);
-  }, [selectedId, hydrateSession]);
+    if (!disableComposerAutoFocus) {
+      setComposerFocusToken((prev) => (prev ?? 0) + 1);
+    }
+  }, [selectedId, hydrateSession, disableComposerAutoFocus]);
 
   const selectedItem = items.find((i) => i.id === selectedId) ?? null;
 


### PR DESCRIPTION
## HOU-725

Fixes both failing jobs from the CI run on main after #779 merged (run 28965804089).

## Root causes

**TS checks — merge skew with #780.** `packages/host/src/routes/agents-activity.test.ts` (added by #780) builds a `Routine` fixture with the `description` field that #779 removed from the type. Both PRs were green individually; main got the union. Fix: drop the field from the fixture.

**Web job — a real focus-steal bug, surfaced as e2e flake.** The "chat is claimed by the created routine" test timed out with the Create button disabled. The CI aria snapshot shows why: the routine form's **Name field was empty** while the **chat composer was focused and contained "Morning brief"**. AIBoard bumps its composer focus token whenever a selection hydrates (so keyboard users can type immediately) — but the routine setup panel hydrates seconds after the editor opens, so on a slow machine the bump fires mid-typing and steals focus from the form; Playwright's `insertText` (and a real user's keystrokes) land in the chat composer instead of the Name input. AIBoard gains a `disableComposerAutoFocus` prop and the routine setup chat sets it: the form's own autofocus keeps the caret where the user is working, explicit focus requests (`openNewPanel` with `focusComposer`) still behave.

## Verification

- Before: `pnpm typecheck` on main fails with `agents-activity.test.ts(157,3): 'description' does not exist in type 'Routine'`; the routine e2e flakes on CI with the composer holding the form's text.
- After: `pnpm typecheck` clean across all 22 projects; host vitest 646 passing; app unit tests 1009 passing; full Playwright suite 43 passing, including the routine spec run with `--fail-on-flaky-tests --repeat-each=2` (12/12).
- Manual check for the product bug: open Routines → New routine → start typing the name immediately; the caret now stays in the Name field when the chat panel finishes loading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)