### PR TITLE
fix(app): stop event fan-out from refetching every agent's conversations

### DIFF
--- a/app/src/hooks/queries/use-conversations.ts
+++ b/app/src/hooks/queries/use-conversations.ts
@@ -19,6 +19,15 @@ export function useAllConversations(agentPaths: string[]) {
     queryFn: () => tauriConversations.listAll(agentPaths),
     enabled: agentPaths.length > 0,
     placeholderData: keepPreviousData,
+    // Fetched ONCE per key (mount / roster change / engine restart), then kept
+    // fresh by single-agent cache patches from the push events stream
+    // (use-agent-invalidation.ts patchAllConversations). Never refetched on
+    // focus or staleness: in hosted mode this queryFn fans out one request to
+    // EVERY agent's pod, and each of those requests resets the pod's
+    // idle-sleep clock — a background full sweep would keep the whole fleet
+    // awake for as long as the app is open.
+    staleTime: Number.POSITIVE_INFINITY,
+    refetchOnWindowFocus: false,
   });
 }
 

--- a/app/src/hooks/use-agent-invalidation.ts
+++ b/app/src/hooks/use-agent-invalidation.ts
@@ -7,6 +7,7 @@ import { subscribeHoustonEvents } from "../lib/events";
 import { logger } from "../lib/logger";
 import { osFocusWindow } from "../lib/os-bridge";
 import { queryKeys } from "../lib/query-keys";
+import { tauriConversations } from "../lib/tauri";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
 import { useWorkspaceStore } from "../stores/workspaces";
@@ -22,6 +23,32 @@ export function useAgentInvalidation() {
   const { t } = useTranslation("shell");
 
   useEffect(() => {
+    // Refresh ONE agent's slice of every cached all-conversations list.
+    // Deliberately not `invalidateQueries({ queryKey: ["all-conversations"] })`:
+    // that refetch fans out one request to EVERY agent's pod, and in hosted
+    // mode each of those requests resets the pod's idle-sleep clock — so a
+    // single busy agent's event stream used to keep the whole fleet awake for
+    // as long as the app was open. Events name their agent; only that agent's
+    // pod is touched (it just emitted, so it is awake by definition), and the
+    // sidebar badges / Mission Control read the patched cache unchanged.
+    const patchAllConversations = (agentPath: string) => {
+      void tauriConversations
+        .list(agentPath)
+        .then((rows) => {
+          qc.setQueriesData<{ agent_path: string }[]>(
+            { queryKey: ["all-conversations"] },
+            (old) =>
+              old && [
+                ...old.filter((c) => c.agent_path !== agentPath),
+                ...rows,
+              ],
+          );
+        })
+        .catch((e) => {
+          // Stale badge until the agent's next event — never a broken app.
+          logger.warn(`[invalidation] conversations patch failed: ${e}`);
+        });
+    };
     const offEngineRestarted = onEngineRestarted(() => {
       qc.invalidateQueries({ queryKey: ["activity"] });
       qc.invalidateQueries({ queryKey: ["all-conversations"] });
@@ -47,7 +74,7 @@ export function useAgentInvalidation() {
           qc.invalidateQueries({
             queryKey: queryKeys.activity(p.data.agent_path),
           });
-          qc.invalidateQueries({ queryKey: ["all-conversations"] });
+          patchAllConversations(p.data.agent_path);
           break;
         case "SkillsChanged":
           qc.invalidateQueries({
@@ -80,7 +107,7 @@ export function useAgentInvalidation() {
           qc.invalidateQueries({
             queryKey: queryKeys.conversations(p.data.agent_path),
           });
-          qc.invalidateQueries({ queryKey: ["all-conversations"] });
+          patchAllConversations(p.data.agent_path);
           // A message landing in ANY of this agent's conversations (e.g. a
           // teammate's turn) must reach an open chat live. The event carries
           // no session key, so invalidate the agent's whole chat-history
@@ -117,7 +144,7 @@ export function useAgentInvalidation() {
         case "SessionStatus":
           if (p.data.status === "completed" || p.data.status === "error") {
             qc.invalidateQueries({ queryKey: ["activity"] });
-            qc.invalidateQueries({ queryKey: ["all-conversations"] });
+            patchAllConversations(p.data.agent_path);
             // Cloud has NO file watcher and no post-turn sync diff, so a running
             // agent that writes its own CLAUDE.md / skills / learnings / files
             // mid-turn never fires a *Changed event. A finished turn is the one

--- a/packages/host/src/routes/agents-activity.test.ts
+++ b/packages/host/src/routes/agents-activity.test.ts
@@ -154,7 +154,6 @@ async function seedRun(run: RoutineRun): Promise<void> {
 const routine: Routine = {
   id: "routine-1",
   name: "Daily report",
-  description: "",
   prompt: "write the report",
   schedule: "0 9 * * *",
   enabled: true,


### PR DESCRIPTION
## Problem
With the desktop app open, the whole org's agent pods never idle-sleep. The sidebar's badge query (`useAllConversations`, mounted at all times) is keyed broadly, and `use-agent-invalidation.ts` invalidated `["all-conversations"]` on every `ActivityChanged` / `ConversationsChanged` / terminal `SessionStatus` — each invalidation refetches the query, whose queryFn fans out one `GET /agents/:id/activities` to **every** agent's pod. Observed in prod: synchronized request bursts to all 11 agents ~every 19s, i.e. one busy agent's event stream re-stamping the whole fleet's idle clocks indefinitely. `refetchOnWindowFocus` (global default, staleTime 2s) added a full-fleet sweep on every alt-tab back.

## Fix
Events already name their agent, so refresh surgically:
- `use-agent-invalidation.ts`: replace the three broad invalidations with `patchAllConversations(agent_path)` — fetch that one agent's conversations (its pod just emitted an event, so it's awake by definition; single-agent `listConversations` returns the exact row shape `listAllConversations` concatenates) and `setQueriesData`-patch its slice into every cached all-conversations list. A failed patch degrades to a stale badge, never a broken app.
- `use-conversations.ts`: `useAllConversations` gets `staleTime: Infinity` + `refetchOnWindowFocus: false` — it fetches once per mount / roster change / engine restart and stays live purely through the event-driven patches.

Sidebar badges and Mission Control read the same cache and stay live, but sleeping pods are never touched: the focused agent keeps its pod awake (per-agent queries unchanged), everyone else actually sleeps.

Also repairs main's currently-broken typecheck: the busy-endpoint test (#780) crossed with the Routine `description` removal (#779); the fixture drops the field.

## Verification
- `app` typecheck + tests green; host typecheck + activity tests green; monorepo pre-commit typecheck green.
- Behavior contract: an event from agent A now causes exactly one request, to agent A; no requests to agents B..N. Will verify in prod post-deploy by watching `agent dispatch forwarding` logs and replica counts with the app open (previously all agents' `last-activity` advanced in lockstep every stamp interval).