### PR TITLE
feat: Plan ready card - approving the plan is the mode switch

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -22,6 +22,8 @@ import type { ChatMessage, ChatPanelProps, FeedItem } from "@houston-ai/chat";
 import {
   type ChatInteractionAnswer,
   ChatInteractionCard,
+  ChatPlanReadyCard,
+  type ChatPlanReadyLabels,
   decodeAttachmentMessage,
   UserAttachmentMessage,
   type UserAttachmentMessageLabels,
@@ -78,6 +80,7 @@ import {
 } from "../lib/model-selector-lock";
 import { canManageAgentGrants, isMultiplayer } from "../lib/org-roles";
 import { osIsTauri } from "../lib/os-bridge";
+import { resolvePlanReadyOverride } from "../lib/plan-ready";
 import {
   decideHandoffMode,
   estimateConversationTokens,
@@ -952,6 +955,66 @@ export function useAgentChatPanel({
     [t],
   );
 
+  // ── Plan-ready override (plan_ready) ──────────────────────────────────
+  // When the model finishes planning it calls `plan_ready`, arriving as a lone
+  // `{kind:"plan_ready", summary}` step (like ask_user). The card offers three
+  // ways forward; "Keep planning" dismisses it LOCALLY (composer returns, mode
+  // stays plan) by remembering THIS plan's summary — a later, different plan
+  // re-shows the card. The dismissal is per-conversation, so it resets when the
+  // open session changes.
+  const [dismissedPlanReady, setDismissedPlanReady] = useState<string | null>(
+    null,
+  );
+  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedSessionKey is the intentional change-trigger that clears the dismissal when the open conversation switches, so a dismissed plan never suppresses a new chat's card.
+  useEffect(() => {
+    setDismissedPlanReady(null);
+  }, [selectedSessionKey]);
+
+  // Start a turn from the plan-ready card: flip the composer's Mode pill (and
+  // persist it) to the chosen mode, then send the confirming message with an
+  // EXPLICIT `modeOverride` — never the async `turnMode` state, which the pill
+  // flip has not yet committed. The user's message bubble is visible (no
+  // suppress flags): the plan approval is a real user turn.
+  const startPlan = useCallback(
+    (mode: TurnMode, text: string) => {
+      if (!path || !selectedSessionKey) return;
+      void handleModeSelect(mode);
+      tauriChat
+        .send(path, text, selectedSessionKey, {
+          providerOverride: effectiveProvider,
+          modelOverride: effectiveModel,
+          effortOverride: effectiveEffort,
+          modeOverride: mode,
+        })
+        .catch((err) => {
+          addToast({
+            title: t("chat:errors.sessionStart", { error: String(err) }),
+            variant: "error",
+          });
+        });
+    },
+    [
+      path,
+      selectedSessionKey,
+      handleModeSelect,
+      effectiveProvider,
+      effectiveModel,
+      effectiveEffort,
+      addToast,
+      t,
+    ],
+  );
+
+  const planReadyLabels = useMemo<ChatPlanReadyLabels>(
+    () => ({
+      title: t("chat:planReady.title"),
+      startWorking: t("chat:planReady.startWorking"),
+      runAutopilot: t("chat:planReady.runAutopilot"),
+      keepPlanning: t("chat:planReady.keepPlanning"),
+    }),
+    [t],
+  );
+
   // The mission is waiting on a sequence of steps (questions then connections).
   // ONE ChatInteractionCard walks them one at a time; `onComplete` fires after
   // the LAST step, never before, so the card lives until every connection has
@@ -974,7 +1037,30 @@ export function useAgentChatPanel({
   // array.
   const composerOverride = useMemo<AIBoardProps["composerOverride"]>(() => {
     if (!agent || !activeInteraction) return undefined;
-    const steps = activeInteraction.steps;
+    // A lone plan_ready step becomes the plan-ready card (unless dismissed);
+    // everything else feeds the stepper over its plan_ready-free steps.
+    const override = resolvePlanReadyOverride(
+      activeInteraction.steps,
+      dismissedPlanReady,
+    );
+    if (override.kind === "none") return undefined;
+    if (override.kind === "card") {
+      const summary = override.summary;
+      return (
+        <ChatPlanReadyCard
+          summary={summary}
+          labels={planReadyLabels}
+          onStartWorking={() =>
+            startPlan("execute", t("chat:planReady.startWorkingMessage"))
+          }
+          onRunAutopilot={() =>
+            startPlan("auto", t("chat:planReady.runAutopilotMessage"))
+          }
+          onKeepPlanning={() => setDismissedPlanReady(summary)}
+        />
+      );
+    }
+    const steps = override.steps;
     const hasQuestionSteps = steps.some((step) => step.kind === "question");
     // A completed sequence has walked EVERY step, so a signin step present here
     // means the user signed in (the step advances only via `onSignedIn`) — no
@@ -1029,6 +1115,9 @@ export function useAgentChatPanel({
   }, [
     agent,
     activeInteraction,
+    dismissedPlanReady,
+    planReadyLabels,
+    startPlan,
     interactionLabels,
     sendInteractionMessage,
     capabilities,

--- a/app/src/lib/plan-ready.ts
+++ b/app/src/lib/plan-ready.ts
@@ -1,0 +1,48 @@
+import type { InteractionStep } from "@houston/protocol";
+
+/** A plan_ready step: the model called `plan_ready` with the drafted plan. It
+ *  reaches the frontend as a lone step in a `PendingInteraction`, exactly like
+ *  ask_user. Extracted from the protocol union so the app narrows to it. */
+export type PlanReadyStep = Extract<InteractionStep, { kind: "plan_ready" }>;
+
+/** Every interaction step that is NOT a plan_ready step (question / signin /
+ *  connect). These are the ones the existing ChatInteractionCard stepper walks;
+ *  a plan_ready step never belongs in that stepper. */
+export type NonPlanReadyStep = Exclude<InteractionStep, { kind: "plan_ready" }>;
+
+/**
+ * Which composer-replacing surface a pending interaction's steps resolve to:
+ *
+ *  - `card`    — a lone plan_ready step that hasn't been dismissed → the
+ *                ChatPlanReadyCard, carrying its plan summary.
+ *  - `stepper` — anything else with at least one non-plan_ready step → the
+ *                existing ChatInteractionCard, over the plan_ready-free steps
+ *                (defensive: a plan_ready step never enters the stepper).
+ *  - `none`    — a lone plan_ready step the user dismissed ("Keep planning"),
+ *                or nothing renderable → the composer returns.
+ *
+ * `dismissed` is the summary of the plan_ready step the user chose to keep
+ * planning on: a LATER, different plan (different summary) re-shows the card.
+ * Pure so the branch is unit-tested without the panel's event plumbing.
+ */
+export type PlanReadyOverride =
+  | { kind: "card"; summary: string }
+  | { kind: "stepper"; steps: NonPlanReadyStep[] }
+  | { kind: "none" };
+
+export function resolvePlanReadyOverride(
+  steps: InteractionStep[],
+  dismissed: string | null,
+): PlanReadyOverride {
+  const lone =
+    steps.length === 1 && steps[0].kind === "plan_ready" ? steps[0] : null;
+  if (lone) {
+    return dismissed === lone.summary
+      ? { kind: "none" }
+      : { kind: "card", summary: lone.summary };
+  }
+  const rest = steps.filter(
+    (step): step is NonPlanReadyStep => step.kind !== "plan_ready",
+  );
+  return rest.length > 0 ? { kind: "stepper", steps: rest } : { kind: "none" };
+}

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -56,6 +56,14 @@
     "signinDescription": "Your accounts stay yours; the agent acts on your behalf.",
     "signin": "Sign in"
   },
+  "planReady": {
+    "title": "Plan ready",
+    "startWorking": "Start working",
+    "runAutopilot": "Run on Autopilot",
+    "keepPlanning": "Keep planning",
+    "startWorkingMessage": "Go ahead with the plan.",
+    "runAutopilotMessage": "Go ahead and finish it on your own."
+  },
   "errors": {
     "sessionStart": "Failed to start session: {{error}}",
     "stopSession": "Couldn't stop the mission: {{error}}",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -56,6 +56,14 @@
     "signinDescription": "Tus cuentas siguen siendo tuyas; el agente actúa en tu nombre.",
     "signin": "Iniciar sesión"
   },
+  "planReady": {
+    "title": "Plan listo",
+    "startWorking": "Empezar a trabajar",
+    "runAutopilot": "Usar Piloto automático",
+    "keepPlanning": "Seguir planificando",
+    "startWorkingMessage": "Adelante con el plan.",
+    "runAutopilotMessage": "Adelante, termínalo por tu cuenta."
+  },
   "errors": {
     "sessionStart": "No se pudo iniciar la sesión: {{error}}",
     "stopSession": "No se pudo detener la misión: {{error}}",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -56,6 +56,14 @@
     "signinDescription": "Suas contas continuam sendo suas; o agente age em seu nome.",
     "signin": "Entrar"
   },
+  "planReady": {
+    "title": "Plano pronto",
+    "startWorking": "Começar a trabalhar",
+    "runAutopilot": "Usar Piloto automático",
+    "keepPlanning": "Continuar planejando",
+    "startWorkingMessage": "Pode seguir com o plano.",
+    "runAutopilotMessage": "Pode terminar por conta própria."
+  },
   "errors": {
     "sessionStart": "Não foi possível iniciar a sessão: {{error}}",
     "stopSession": "Não foi possível parar a missão: {{error}}",

--- a/app/tests/plan-ready.test.ts
+++ b/app/tests/plan-ready.test.ts
@@ -1,0 +1,64 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { InteractionStep } from "@houston/protocol";
+import { resolvePlanReadyOverride } from "../src/lib/plan-ready.ts";
+
+const planReady: InteractionStep = {
+  kind: "plan_ready",
+  id: "p1",
+  summary: "Draft the email, build the guest list, schedule the send.",
+};
+const question: InteractionStep = {
+  kind: "question",
+  id: "q1",
+  question: "Which account?",
+};
+const connect: InteractionStep = {
+  kind: "connect",
+  id: "c1",
+  toolkit: "gmail",
+};
+
+describe("resolvePlanReadyOverride", () => {
+  it("renders the card for a lone, undismissed plan_ready step", () => {
+    deepStrictEqual(resolvePlanReadyOverride([planReady], null), {
+      kind: "card",
+      summary: planReady.summary,
+    });
+  });
+
+  it("returns the composer once THIS plan is dismissed (Keep planning)", () => {
+    deepStrictEqual(resolvePlanReadyOverride([planReady], planReady.summary), {
+      kind: "none",
+    });
+  });
+
+  it("re-shows the card for a later, different plan", () => {
+    const next: InteractionStep = {
+      kind: "plan_ready",
+      id: "p2",
+      summary: "A revised plan the agent drafted next.",
+    };
+    deepStrictEqual(resolvePlanReadyOverride([next], planReady.summary), {
+      kind: "card",
+      summary: next.summary,
+    });
+  });
+
+  it("routes a question sequence to the stepper", () => {
+    const result = resolvePlanReadyOverride([question, connect], null);
+    strictEqual(result.kind, "stepper");
+    if (result.kind === "stepper")
+      deepStrictEqual(result.steps, [question, connect]);
+  });
+
+  it("defensively strips a plan_ready step from a mixed sequence", () => {
+    const result = resolvePlanReadyOverride([question, planReady], null);
+    strictEqual(result.kind, "stepper");
+    if (result.kind === "stepper") deepStrictEqual(result.steps, [question]);
+  });
+
+  it("returns none when nothing renderable survives the filter", () => {
+    deepStrictEqual(resolvePlanReadyOverride([], null), { kind: "none" });
+  });
+});

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,23 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v9 - 2026-07-08
+
+Add `plan-ready-card`, the composer-replacing surface shown when the agent
+finishes planning (plan mode) and calls `plan_ready`. A pending interaction
+carrying a single `plan_ready` step (its plan `summary`) reaches the frontend
+exactly like `ask_user`; the card presents the drafted plan above three
+always-visible actions: "Start working" (starts a normal execute turn
+confirming the plan), "Run on Autopilot" (starts an autopilot turn), and "Keep
+planning" (dismisses the card locally so the composer returns with the Mode pill
+still on plan; a later, different plan re-shows it). The first two flip the
+composer Mode pill to match and send a visible user message; the third sends
+nothing. `disabled` gates all three actions. New `@houston-ai/chat`
+`ChatPlanReadyCard` (props-only, i18n-agnostic with a `DEFAULT_PLAN_READY_LABELS`
+fallback), so Web ships `implemented`; native surfaces defer it (plan-mode flow
+is not in mobile v1). No change to `interaction-card`: the app defensively
+filters any `plan_ready` step out of the stepper.
+
 ## v8 - 2026-07-08
 
 Rebuild `ai-model-row` from the multi-column Mercury ledger into a compact card,

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 8
+version: 9
 
 components:
   - id: agent-avatar
@@ -252,6 +252,24 @@ components:
       is active.
     a11y: one step announced at a time; option rows are role=radio in a radiogroup, keyboard-toggleable and visible at rest (no hover gate); free-text input always present on question steps; back chevron is a labeled button; progress uses tabular-nums to avoid width jitter.
     since: 4
+
+  - id: plan-ready-card
+    title: Plan-ready card
+    purpose: In-chat surface shown when the agent finishes planning (plan mode) and calls plan_ready; presents the drafted plan and three ways forward, replacing the composer until the user chooses.
+    anatomy: [title, plan-summary, start-working-action, run-autopilot-action, keep-planning-action]
+    states: [default, disabled]
+    variants: [default]
+    behavior: >-
+      Rendered from a pending interaction carrying a single plan_ready step
+      (summary), exactly like ask_user reaches the frontend. Shows the plan
+      summary above three always-visible actions. "Start working" starts a
+      normal (execute) turn confirming the plan; "Run on Autopilot" starts an
+      autopilot (auto) turn; both flip the composer Mode pill to match and send a
+      visible user message. "Keep planning" dismisses the card LOCALLY (the
+      composer returns, mode stays plan) without sending; a later, different plan
+      re-shows the card. Disabled gates all three actions.
+    a11y: title then plan summary read in order; three labeled buttons visible at rest (no hover gate), keyboard-reachable; disabled state marks the surface aria-disabled and gates every action.
+    since: 9
 
   - id: deliverable-card
     title: Deliverable card

--- a/design/inventory/manifests/android.yaml
+++ b/design/inventory/manifests/android.yaml
@@ -65,3 +65,5 @@ components:
     status: not-started
   interaction-card:
     status: not-started
+  plan-ready-card:
+    status: not-started

--- a/design/inventory/manifests/ios.yaml
+++ b/design/inventory/manifests/ios.yaml
@@ -133,3 +133,6 @@ components:
   interaction-card:
     status: not-started
     notes: In-chat gather-what-I-need stepper (questions, sign-in, then connections); mid-turn pending-interaction flow not in mobile v1.
+  plan-ready-card:
+    status: not-started
+    notes: Plan-ready confirmation card (plan_ready) with Start working / Run on Autopilot / Keep planning; plan-mode flow not in mobile v1.

--- a/design/inventory/manifests/web.yaml
+++ b/design/inventory/manifests/web.yaml
@@ -91,6 +91,10 @@ components:
     status: implemented
     ref: "@houston-ai/chat ChatInteractionCard (interaction-card + interaction-card-logic)"
 
+  plan-ready-card:
+    status: implemented
+    ref: "@houston-ai/chat ChatPlanReadyCard (chat-plan-ready-card + chat-plan-ready-card-model)"
+
   deliverable-card:
     status: implemented
     ref: "@houston-ai/review DeliverableCard / UserFeedback"

--- a/packages/protocol/src/domain/interaction.test.ts
+++ b/packages/protocol/src/domain/interaction.test.ts
@@ -17,6 +17,22 @@ test("isPendingInteraction accepts the step-sequence shape and rejects legacy sh
     true,
   );
 
+  // A plan_ready step needs kind + id + a string summary.
+  expect(
+    isPendingInteraction({
+      steps: [{ kind: "plan_ready", id: "p1", summary: "The plan." }],
+    }),
+  ).toBe(true);
+  // A plan_ready step with a missing / non-string summary is invalid.
+  expect(
+    isPendingInteraction({ steps: [{ kind: "plan_ready", id: "p1" }] }),
+  ).toBe(false);
+  expect(
+    isPendingInteraction({
+      steps: [{ kind: "plan_ready", id: "p1", summary: 7 }],
+    }),
+  ).toBe(false);
+
   // A signin step with a non-string reason is invalid.
   expect(
     isPendingInteraction({ steps: [{ kind: "signin", id: "s1", reason: 7 }] }),

--- a/packages/protocol/src/domain/interaction.ts
+++ b/packages/protocol/src/domain/interaction.ts
@@ -30,7 +30,8 @@ export type InteractionStep =
       options?: InteractionOption[];
     }
   | { kind: "signin"; id: string; reason?: string }
-  | { kind: "connect"; id: string; toolkit: string; reason?: string };
+  | { kind: "connect"; id: string; toolkit: string; reason?: string }
+  | { kind: "plan_ready"; id: string; summary: string };
 
 /** The ordered steps the mission is waiting on: question steps first (at most 3),
  *  then at most one signin step, then connect steps. Always at least one step. */
@@ -48,6 +49,7 @@ export const isInteractionStep = (v: unknown): v is InteractionStep => {
   if (v.kind === "signin")
     return v.reason === undefined || typeof v.reason === "string";
   if (v.kind === "connect") return typeof v.toolkit === "string";
+  if (v.kind === "plan_ready") return typeof v.summary === "string";
   return false;
 };
 

--- a/packages/runtime/src/backends/claude/backend-mcp.test.ts
+++ b/packages/runtime/src/backends/claude/backend-mcp.test.ts
@@ -97,16 +97,21 @@ test("AskUserQuestion stays disabled — Houston ships its own ask_user", async 
   expect(options.disallowedTools).toContain("AskUserQuestion");
 });
 
-test("plan mode builds the MCP server WITHOUT integrations — only ask_user", async () => {
+test("plan mode builds the MCP server WITHOUT integrations — ask_user + plan_ready", async () => {
   // Even with the integrations gate present, plan mode withholds the integration
-  // tools (they act on the user's connected apps), leaving just ask_user.
+  // tools (they act on the user's connected apps), leaving ask_user plus the
+  // plan-only plan_ready presentation tool.
   const options = await runTurn(
     { baseUrl: "http://host.local", sandboxToken: "tok" },
     "plan",
   );
   expect(options.mcpServers?.houston).toBeDefined();
-  expect(options.allowedTools).toEqual(["mcp__houston__ask_user"]);
-  expect(h.capturedMcp?.tools.map((t) => t.name)).toEqual(["ask_user"]);
+  expect(new Set(options.allowedTools)).toEqual(
+    new Set(["mcp__houston__ask_user", "mcp__houston__plan_ready"]),
+  );
+  expect(new Set(h.capturedMcp?.tools.map((t) => t.name))).toEqual(
+    new Set(["ask_user", "plan_ready"]),
+  );
   // And the built-ins are the read-only plan subset.
   expect(options.tools).toEqual(["Read", "Glob", "Grep"]);
 });

--- a/packages/runtime/src/backends/claude/custom-tools.test.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.test.ts
@@ -96,16 +96,39 @@ test("exposes ask_user + integration tools when the integrations gate is open", 
   );
 });
 
-test("plan mode keeps only ask_user even with the integrations gate open", () => {
+test("plan mode keeps ask_user + plan_ready even with the integrations gate open", () => {
+  // Plan withholds every acting tool but keeps the blocking-question tool and
+  // adds the plan-only plan_ready presentation tool.
   const { tools, mcp } = build(INTEGRATIONS, "plan");
-  expect(tools.map((t) => t.name)).toEqual(["ask_user"]);
-  expect(mcp.allowedTools).toEqual(["mcp__houston__ask_user"]);
+  expect(new Set(tools.map((t) => t.name))).toEqual(
+    new Set(["ask_user", "plan_ready"]),
+  );
+  expect(new Set(mcp.allowedTools)).toEqual(
+    new Set(["mcp__houston__ask_user", "mcp__houston__plan_ready"]),
+  );
+});
+
+test("plan_ready is exposed ONLY in plan mode", () => {
+  // Present in plan…
+  expect(build(INTEGRATIONS, "plan").tools.map((t) => t.name)).toContain(
+    "plan_ready",
+  );
+  // …and stripped from execute and auto, even though it is in the built set.
+  expect(build(INTEGRATIONS).tools.map((t) => t.name)).not.toContain(
+    "plan_ready",
+  );
+  expect(build(INTEGRATIONS, "execute").tools.map((t) => t.name)).not.toContain(
+    "plan_ready",
+  );
+  expect(build(INTEGRATIONS, "auto").tools.map((t) => t.name)).not.toContain(
+    "plan_ready",
+  );
 });
 
 test("auto mode keeps the integration tools but drops the blocking tools", () => {
   const { tools, mcp } = build(INTEGRATIONS, "auto");
-  // Autopilot never waits on the user: ask_user + request_connection are gone,
-  // the acting integration tools stay.
+  // Autopilot never waits on the user: ask_user + request_connection are gone
+  // (and plan_ready is plan-only), the acting integration tools stay.
   expect(new Set(tools.map((t) => t.name))).toEqual(
     new Set(["integration_search", "integration_execute"]),
   );
@@ -118,8 +141,8 @@ test("auto mode keeps the integration tools but drops the blocking tools", () =>
 });
 
 test("auto mode with no integrations gate exposes NO custom tools", () => {
-  // The only always-on custom tool is ask_user, which auto drops — so with the
-  // integration gate closed the server exposes nothing.
+  // The always-on custom tools are ask_user (auto drops it) and plan_ready
+  // (plan-only) — so with the integration gate closed the server exposes nothing.
   const { tools, mcp } = build(undefined, "auto");
   expect(tools).toEqual([]);
   expect(mcp.allowedTools).toEqual([]);

--- a/packages/runtime/src/backends/claude/custom-tools.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.ts
@@ -16,10 +16,11 @@ import {
   type IntegrationToolOptions,
   makeIntegrationTools,
 } from "../../session/tools/integrations";
+import { makePlanReadyTool } from "../../session/tools/plan-ready";
 
 /**
- * Bridge Houston's pi-shaped custom tools (`ask_user`, `request_connection`,
- * `integration_search`, `integration_execute`) onto the Claude Agent SDK's
+ * Bridge Houston's pi-shaped custom tools (`ask_user`, `plan_ready`,
+ * `request_connection`, `integration_search`, `integration_execute`) onto the Claude Agent SDK's
  * in-process MCP transport (`createSdkMcpServer`), so the `anthropic` backend —
  * a `claude` subprocess that only sees SDK built-ins — can call the SAME tools
  * the pi backend exposes.
@@ -71,17 +72,18 @@ export interface HoustonMcpInput {
   integrations?: IntegrationToolOptions;
   /**
    * The turn's execution mode, applied as the SAME tool filter the pi path uses
-   * (`toolNamesForMode`): "plan" keeps only `ask_user` (the acting integration
-   * tools are withheld), "auto" drops the blocking tools (`ask_user`,
-   * `request_connection`) while KEEPING `integration_search` /
-   * `integration_execute`, and "execute" (or absent) exposes the full built set.
+   * (`toolNamesForMode`): "plan" keeps `ask_user` + `plan_ready` (the acting
+   * integration tools are withheld), "auto" drops the blocking tools (`ask_user`,
+   * `request_connection`) and `plan_ready` while KEEPING `integration_search` /
+   * `integration_execute`, and "execute" (or absent) exposes the full built set
+   * minus `plan_ready` (plan-only). `plan_ready` never survives outside plan.
    */
   mode?: TurnMode;
 }
 
 /**
  * The minimal slice of a pi tool this bridge reads. `execute`'s trailing
- * `onUpdate`/`ctx` params are inert for all four Houston custom tools (verified:
+ * `onUpdate`/`ctx` params are inert for every Houston custom tool (verified:
  * none read them), so the adapter passes inert placeholders — see {@link NOOP_CTX}.
  * A pi `ToolDefinition<S>` narrows `params` to `Static<S>`; here it is widened to
  * `unknown` so heterogeneous tools share one adapter, and the SDK-validated args
@@ -101,7 +103,7 @@ interface BridgedPiTool {
 }
 
 /**
- * Inert `ExtensionContext` placeholder. The four bridged tools never touch `ctx`
+ * Inert `ExtensionContext` placeholder. The bridged tools never touch `ctx`
  * (they use the turn-scoped AsyncLocalStorage stores instead), so an empty object
  * is safe. Cast once here rather than threading a real context the SDK path has
  * no way to supply.
@@ -114,8 +116,8 @@ const NOOP_CTX = {} as ExtensionContext;
  */
 export function buildHoustonMcpServer(input: HoustonMcpInput): HoustonMcp {
   // Reuse the EXISTING tool implementations verbatim; build the full set this
-  // runtime could expose (ask_user always, the integration tools when the gate
-  // is open), then apply the turn's mode filter — the SAME `toolNamesForMode`
+  // runtime could expose (ask_user + plan_ready always, the integration tools
+  // when the gate is open), then apply the turn's mode filter — the SAME `toolNamesForMode`
   // the pi path clamps its name allowlist with, so the two backends never drift
   // on what a mode allows. On the pi path filtering the NAME list is enough (pi
   // gates custom tools by name); here the MCP server exposes exactly the tools it
@@ -124,6 +126,9 @@ export function buildHoustonMcpServer(input: HoustonMcpInput): HoustonMcp {
   // shape is bridged by one documented assertion at this single boundary.
   const built = [
     makeAskUserTool(),
+    // plan_ready is in the built set but name-gated by `toolNamesForMode`: it
+    // survives only on a plan turn (filtered out of execute/auto below).
+    makePlanReadyTool(),
     ...(input.integrations ? makeIntegrationTools(input.integrations) : []),
   ] as unknown as BridgedPiTool[];
   const allowed = new Set(
@@ -184,8 +189,8 @@ interface McpTextContent {
 }
 
 /**
- * Map a pi tool result onto the MCP `CallToolResult` content shape. All four
- * bridged tools return text; a non-text block (never produced today) is coerced
+ * Map a pi tool result onto the MCP `CallToolResult` content shape. Every
+ * bridged tool returns text; a non-text block (never produced today) is coerced
  * to a JSON string rather than dropped.
  */
 function toCallToolResult(result: AgentToolResult<unknown>): {

--- a/packages/runtime/src/session/conversation-cache.ts
+++ b/packages/runtime/src/session/conversation-cache.ts
@@ -18,6 +18,7 @@ import { makeAskUserTool } from "./tools/ask-user";
 import { makeClampedFileTools } from "./tools/clamped-fs";
 import { makeIdTokenProvider } from "./tools/gcp-id-token";
 import { makeIntegrationTools } from "./tools/integrations";
+import { makePlanReadyTool } from "./tools/plan-ready";
 import { makeRunCodeTool } from "./tools/run-code";
 import type { ProvidedContext } from "./workspace-context";
 
@@ -40,6 +41,12 @@ const fileTools = makeClampedFileTools(config.workspaceDir);
 // makes no network call). Records the turn's pending question so it rides the
 // terminal `done` frame and Houston renders it as a card in place of the input.
 const askUserTool = makeAskUserTool();
+
+// The plan-presentation tool: registered always, name-gated to Plan mode by
+// `toolNamesForMode` (harmless in execute/auto — pi only exposes it when its
+// name is in the mode's allowlist). Records the turn's plan-ready step so it
+// rides the terminal `done` frame as a plan-approval card.
+const planReadyTool = makePlanReadyTool();
 
 // Integration tools (Composio, platform mode): available whenever this runtime
 // can reach its host with a sandbox token (server mode — local desktop +
@@ -84,6 +91,7 @@ const piBackend = createPiBackend({
   customTools: [
     ...fileTools,
     askUserTool,
+    planReadyTool,
     ...(runCodeTool ? [runCodeTool] : []),
     ...integrationTools,
   ],

--- a/packages/runtime/src/session/interaction.test.ts
+++ b/packages/runtime/src/session/interaction.test.ts
@@ -1,7 +1,9 @@
+import { isInteractionStep } from "@houston/protocol";
 import { expect, test } from "vitest";
 import {
   newInteractionHolder,
   recordConnection,
+  recordPlanReady,
   recordQuestions,
   recordSignin,
   runWithInteractionCapture,
@@ -159,6 +161,50 @@ test("recording outside a turn is a no-op (undefined store)", () => {
   expect(() => recordQuestions([q("q1", "orphan?")])).not.toThrow();
   expect(() => recordConnection({ toolkit: "gmail" })).not.toThrow();
   expect(() => recordSignin({ reason: "orphan" })).not.toThrow();
+  expect(() => recordPlanReady({ summary: "orphan plan" })).not.toThrow();
+});
+
+test("recordPlanReady records the single plan-ready step (id p1, trimmed)", () => {
+  const holder = newInteractionHolder();
+  runWithInteractionCapture(holder, () =>
+    recordPlanReady({ summary: "  Book it, then confirm.  " }),
+  );
+  expect(holder.pending).toEqual({
+    steps: [
+      { kind: "plan_ready", id: "p1", summary: "Book it, then confirm." },
+    ],
+  });
+});
+
+test("a plan-ready step OWNS the interaction exclusively (wins over queued steps)", () => {
+  const holder = newInteractionHolder();
+  runWithInteractionCapture(holder, () => {
+    // Even if the model somehow queued questions/signin/connects this turn, a
+    // plan_ready call collapses the interaction to the single plan card.
+    recordQuestions([q("q1", "Which one?")]);
+    recordSignin({ reason: "Sign in first." });
+    recordConnection({ toolkit: "gmail", reason: "to send it" });
+    recordPlanReady({ summary: "Here is the plan." });
+  });
+  expect(holder.pending).toEqual({
+    steps: [{ kind: "plan_ready", id: "p1", summary: "Here is the plan." }],
+  });
+});
+
+test("the protocol guard accepts a valid plan_ready step and rejects a bad summary", () => {
+  // Guard coverage lands here because @houston/protocol has no test runner of
+  // its own; the runtime suite imports the same guard the wire/persist seams use.
+  expect(
+    isInteractionStep({ kind: "plan_ready", id: "p1", summary: "The plan." }),
+  ).toBe(true);
+  // A missing summary is invalid.
+  expect(isInteractionStep({ kind: "plan_ready", id: "p1" })).toBe(false);
+  // A non-string summary is invalid.
+  expect(isInteractionStep({ kind: "plan_ready", id: "p1", summary: 7 })).toBe(
+    false,
+  );
+  // No id is invalid (shared step rule).
+  expect(isInteractionStep({ kind: "plan_ready", summary: "x" })).toBe(false);
 });
 
 test("the holder survives async work inside the capture (ALS propagation)", async () => {

--- a/packages/runtime/src/session/interaction.ts
+++ b/packages/runtime/src/session/interaction.ts
@@ -37,6 +37,7 @@ import type {
 type QuestionStep = Extract<InteractionStep, { kind: "question" }>;
 type SigninStep = Extract<InteractionStep, { kind: "signin" }>;
 type ConnectStep = Extract<InteractionStep, { kind: "connect" }>;
+type PlanReadyStep = Extract<InteractionStep, { kind: "plan_ready" }>;
 
 export interface InteractionHolder {
   /** Question steps from the last `ask_user` call this turn (replace semantics). */
@@ -45,6 +46,9 @@ export interface InteractionHolder {
   readonly signin: SigninStep | undefined;
   /** Connect steps appended by `request_connection`, deduped by toolkit. */
   readonly connects: ConnectStep[];
+  /** The single plan-ready step, once the model called `plan_ready` (plan mode
+   *  only). When set it OWNS the interaction exclusively — see {@link pending}. */
+  readonly planReady: PlanReadyStep | undefined;
   /** The recorded sequence — question steps, then the signin step, then connect
    *  steps — or undefined when the model asked for nothing this turn. Derived:
    *  read after prompt(). */
@@ -55,8 +59,14 @@ class Holder implements InteractionHolder {
   readonly questions: QuestionStep[] = [];
   signin: SigninStep | undefined;
   readonly connects: ConnectStep[] = [];
+  planReady: PlanReadyStep | undefined;
 
   get pending(): PendingInteraction | undefined {
+    // A plan-ready step is exclusive: the plan-mode overlay tells the model to
+    // call `plan_ready` ALONE (and the tool subset withholds the ways to act),
+    // so if it somehow also queued questions/signin/connects this turn, the plan
+    // card still wins. Defensive normalization — one card, one meaning.
+    if (this.planReady) return { steps: [this.planReady] };
     const steps = [
       ...this.questions,
       ...(this.signin ? [this.signin] : []),
@@ -131,4 +141,20 @@ export function recordConnection(input: {
     toolkit: input.toolkit,
     ...(input.reason ? { reason: input.reason } : {}),
   });
+}
+
+/**
+ * Record the single plan-ready step for this turn (the model called `plan_ready`
+ * in Plan mode to present its finished plan). There is at most one such step
+ * (id `p1`); it OWNS the interaction exclusively (see {@link InteractionHolder.pending}).
+ * The summary is trimmed. A no-op outside a turn.
+ */
+export function recordPlanReady(input: { summary: string }): void {
+  const holder = store.getStore();
+  if (!holder) return;
+  (holder as Holder).planReady = {
+    kind: "plan_ready",
+    id: "p1",
+    summary: input.summary.trim(),
+  };
 }

--- a/packages/runtime/src/session/mode-overlays.test.ts
+++ b/packages/runtime/src/session/mode-overlays.test.ts
@@ -45,7 +45,10 @@ test("the plan overlay establishes the read-only, plan-then-approve contract", (
   const lower = PLAN_MODE_OVERLAY.toLowerCase();
   expect(lower).toContain("plan mode");
   expect(lower).toContain("must not change anything");
-  expect(lower).toContain("review");
+  // The finished plan is presented for the user's approval via the plan_ready
+  // tool (replacing the older "review it" plain-text phrasing).
+  expect(lower).toContain("approval");
+  expect(lower).toContain("plan_ready");
 });
 
 test("the auto overlay establishes the never-wait, act-and-report contract", () => {

--- a/packages/runtime/src/session/mode-overlays.ts
+++ b/packages/runtime/src/session/mode-overlays.ts
@@ -9,7 +9,9 @@ import type { TurnMode } from "@houston/protocol";
  * user approves before anything is done.
  *
  * Voice: the target user is non-technical (see the product prompt rules), so the
- * overlay names no files, JSON, CLIs, or tools — it speaks in plain outcomes.
+ * overlay names no files, JSON, or CLIs — it speaks in plain outcomes. The one
+ * tool it names is `plan_ready` (the plan-presentation tool), so the model
+ * presents its finished plan through the approval card instead of plain text.
  */
 export const PLAN_MODE_OVERLAY = [
   "You are in Plan mode. Here you help the user think through and design an approach before anything is actually done.",
@@ -18,7 +20,7 @@ export const PLAN_MODE_OVERLAY = [
   "- Do not create, edit, or delete anything. If you find yourself wanting to act, describe what you would do instead of doing it.",
   "- Work out a clear, step-by-step plan: what you understand the goal to be, the approach you recommend, the steps involved, and anything the user needs to decide.",
   "- Write the plan in plain, friendly language the user can follow. Keep it concrete and specific to their situation.",
-  "- Finish by presenting the plan and asking the user to review it, so they can approve it or ask for changes before you carry it out.",
+  "- When your plan is ready, do not just write it out and ask in words. Present it for the user's approval with the plan_ready tool, passing a short, plain summary of what you propose to do. Houston shows the user the plan with three choices: have you start on it now, hand it to you to finish on its own, or keep planning together. End your turn right after.",
 ].join("\n");
 
 /**

--- a/packages/runtime/src/session/tool-selection.test.ts
+++ b/packages/runtime/src/session/tool-selection.test.ts
@@ -8,6 +8,7 @@ import {
   toolNamesForMode,
 } from "./tool-selection";
 import { CLAMPED_FILE_TOOL_NAMES } from "./tools/clamped-fs";
+import { PLAN_READY_TOOL_NAME } from "./tools/plan-ready";
 
 describe("buildToolSelection", () => {
   test("local mode keeps clamped file tools plus ask_user and bash", () => {
@@ -175,10 +176,11 @@ describe("toolNamesForMode dispatcher", () => {
     integrations: true,
   });
 
-  test("plan → the read-only subset", () => {
-    expect(toolNamesForMode("plan", local.toolNames)).toEqual(
-      planToolNames(local.toolNames),
-    );
+  test("plan → the read-only subset plus plan_ready", () => {
+    expect(toolNamesForMode("plan", local.toolNames)).toEqual([
+      ...planToolNames(local.toolNames),
+      PLAN_READY_TOOL_NAME,
+    ]);
   });
 
   test("auto → everything minus the blocking tools", () => {
@@ -194,5 +196,51 @@ describe("toolNamesForMode dispatcher", () => {
     expect(toolNamesForMode(undefined, local.toolNames)).toEqual(
       local.toolNames,
     );
+  });
+
+  // plan_ready is plan-mode-only: present iff plan, and stripped from
+  // execute/auto EVEN WHEN the incoming set already carries it (the Claude
+  // backend hands `toolNamesForMode` a built list that includes plan_ready).
+  describe("plan_ready gating (strip-then-reinject)", () => {
+    test("plan_ready is present iff the mode is plan", () => {
+      expect(toolNamesForMode("plan", local.toolNames)).toContain(
+        PLAN_READY_TOOL_NAME,
+      );
+      expect(toolNamesForMode("auto", local.toolNames)).not.toContain(
+        PLAN_READY_TOOL_NAME,
+      );
+      expect(toolNamesForMode("execute", local.toolNames)).not.toContain(
+        PLAN_READY_TOOL_NAME,
+      );
+      expect(toolNamesForMode(undefined, local.toolNames)).not.toContain(
+        PLAN_READY_TOOL_NAME,
+      );
+    });
+
+    test("plan_ready in the incoming set never survives execute/auto", () => {
+      // The Claude case: `all` already includes plan_ready.
+      const withPlanReady = [...local.toolNames, PLAN_READY_TOOL_NAME];
+      expect(toolNamesForMode("execute", withPlanReady)).not.toContain(
+        PLAN_READY_TOOL_NAME,
+      );
+      expect(toolNamesForMode(undefined, withPlanReady)).not.toContain(
+        PLAN_READY_TOOL_NAME,
+      );
+      expect(toolNamesForMode("auto", withPlanReady)).not.toContain(
+        PLAN_READY_TOOL_NAME,
+      );
+      // …and plan does not duplicate it (stripped first, re-added once).
+      const plan = toolNamesForMode("plan", withPlanReady);
+      expect(plan.filter((n) => n === PLAN_READY_TOOL_NAME)).toEqual([
+        PLAN_READY_TOOL_NAME,
+      ]);
+    });
+
+    test("execute passes everything else through unchanged (plan_ready aside)", () => {
+      const withPlanReady = [...local.toolNames, PLAN_READY_TOOL_NAME];
+      expect(toolNamesForMode("execute", withPlanReady)).toEqual(
+        local.toolNames,
+      );
+    });
   });
 });

--- a/packages/runtime/src/session/tool-selection.ts
+++ b/packages/runtime/src/session/tool-selection.ts
@@ -5,6 +5,7 @@ import {
   INTEGRATION_TOOL_NAMES,
   REQUEST_CONNECTION_TOOL_NAME,
 } from "./tools/integrations";
+import { PLAN_READY_TOOL_NAME } from "./tools/plan-ready";
 
 export type CodeExecutionMode = "local" | "remote" | "disabled";
 
@@ -75,21 +76,29 @@ export function autoToolNames(all: readonly string[]): string[] {
 
 /**
  * The one place a turn's mode picks its tool allowlist: "plan" clamps to the
- * read-only subset, "auto" drops the blocking tools, and "execute" (or an absent
- * mode) passes the full allowlist through unchanged. Both backends dispatch
- * through here so the pi and Claude paths never drift on what a mode allows.
+ * read-only subset PLUS the plan-only `plan_ready` tool, "auto" drops the
+ * blocking tools, and "execute" (or an absent mode) passes the full allowlist
+ * through unchanged. Both backends dispatch through here so the pi and Claude
+ * paths never drift on what a mode allows.
+ *
+ * Strip-then-reinject: `plan_ready` is a plan-mode-only tool that must never
+ * survive into execute/auto, yet the incoming `all` set (e.g. the Claude
+ * backend's built list) may include it. So it is filtered out unconditionally
+ * first, then re-added ONLY on the plan branch. This keeps `plan_ready` out of
+ * the execute base allowlist regardless of how `all` was assembled.
  */
 export function toolNamesForMode(
   mode: TurnMode | undefined,
   all: readonly string[],
 ): string[] {
+  const base = all.filter((name) => name !== PLAN_READY_TOOL_NAME);
   switch (mode) {
     case "plan":
-      return planToolNames(all);
+      return [...planToolNames(base), PLAN_READY_TOOL_NAME];
     case "auto":
-      return autoToolNames(all);
+      return autoToolNames(base);
     default:
-      return [...all];
+      return [...base];
   }
 }
 

--- a/packages/runtime/src/session/tools/plan-ready.test.ts
+++ b/packages/runtime/src/session/tools/plan-ready.test.ts
@@ -1,0 +1,70 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { expect, test } from "vitest";
+import {
+  newInteractionHolder,
+  runWithInteractionCapture,
+} from "../interaction";
+import { makePlanReadyTool, PLAN_READY_TOOL_NAME } from "./plan-ready";
+
+/**
+ * The plan-mode-only plan-presentation tool. These pin: the tool records the
+ * single plan-ready step (id `p1`), trims the summary, rejects an empty summary,
+ * returns the end-your-turn instruction, and is a no-op outside a turn.
+ */
+
+const planReady = makePlanReadyTool();
+
+// pi's tool.execute takes (id, params, signal, onUpdate, ctx); the last three
+// are irrelevant here, so one helper supplies them.
+const ctx = {} as unknown as ExtensionContext;
+const run = (params: unknown) =>
+  planReady.execute("id", params as never, undefined, undefined, ctx);
+
+test("is named plan_ready", () => {
+  expect(planReady.name).toBe("plan_ready");
+  expect(PLAN_READY_TOOL_NAME).toBe("plan_ready");
+});
+
+test("records the plan-ready step with a p1 id and ends the turn", async () => {
+  const holder = newInteractionHolder();
+  const out = await runWithInteractionCapture(holder, () =>
+    run({ summary: "Draft the deck, then send it for review." }),
+  );
+  expect(holder.pending).toEqual({
+    steps: [
+      {
+        kind: "plan_ready",
+        id: "p1",
+        summary: "Draft the deck, then send it for review.",
+      },
+    ],
+  });
+  const text = (out.content[0] as { text: string }).text;
+  expect(text).toMatch(/end your turn/i);
+});
+
+test("trims the summary before recording", async () => {
+  const holder = newInteractionHolder();
+  await runWithInteractionCapture(holder, () =>
+    run({ summary: "   Book the flights and hotel.   " }),
+  );
+  expect(holder.pending).toEqual({
+    steps: [
+      { kind: "plan_ready", id: "p1", summary: "Book the flights and hotel." },
+    ],
+  });
+});
+
+test("throws on an empty / whitespace summary and records nothing", async () => {
+  const holder = newInteractionHolder();
+  await expect(
+    runWithInteractionCapture(holder, () => run({ summary: "   " })),
+  ).rejects.toThrow(/non-empty plan summary/i);
+  expect(holder.pending).toBeUndefined();
+});
+
+test("recording outside a turn is a no-op but still returns the instruction", async () => {
+  const out = await run({ summary: "A plan with no turn around it." });
+  const text = (out.content[0] as { text: string }).text;
+  expect(text).toMatch(/end your turn/i);
+});

--- a/packages/runtime/src/session/tools/plan-ready.ts
+++ b/packages/runtime/src/session/tools/plan-ready.ts
@@ -1,0 +1,57 @@
+import { defineTool } from "@earendil-works/pi-coding-agent";
+import { type Static, Type } from "typebox";
+import { recordPlanReady } from "../interaction";
+
+/**
+ * The plan-presentation tool — Plan mode ONLY. When the model has finished
+ * planning it calls `plan_ready` INSTEAD OF writing the plan out and asking the
+ * user in plain text to approve or switch modes. Executing it records the single
+ * plan-ready step of this turn's interaction sequence (carried on the terminal
+ * `done` frame + the persisted assistant message), and Houston shows the user a
+ * card with three choices — start working, hand it to Autopilot, or keep
+ * planning — in place of the chat input. The model is still in Plan mode for THIS
+ * turn (it cannot act), so it ends its turn right after; if the user chooses to
+ * proceed, the app sends a NEW turn telling the model to begin.
+ *
+ * Gated to plan mode by name (`session/tool-selection.ts`): it never joins the
+ * execute/auto base allowlist. It holds no credential and makes no network call.
+ */
+
+const PlanReadyParams = Type.Object({
+  summary: Type.String({
+    description:
+      "A short, plain-language summary of the plan you are presenting for approval, in the user's language. A few sentences at most, the user already saw your full plan.",
+  }),
+});
+type PlanReadyParams = Static<typeof PlanReadyParams>;
+
+/** The instruction returned to the model after the plan step is recorded. */
+const PLAN_READY_INSTRUCTION =
+  "Your plan was presented to the user as a card with three choices: start working on it now, hand it to you to run on Autopilot, or keep planning together. You are still in Plan mode for THIS turn, so end your turn now without taking any action. If they choose to proceed, Houston will send you a message telling you to begin, and you will be able to act then. Do not repeat the plan or ask anything else in plain text.";
+
+/** The plan-mode-only plan-presentation tool. */
+export function makePlanReadyTool() {
+  return defineTool({
+    name: "plan_ready",
+    label: "Present the plan",
+    description:
+      "Present your finished plan for the user to approve. Call this when you are done planning INSTEAD OF writing the plan out and asking in plain text. Pass a short summary; Houston shows the user a card with three choices (start working, run on Autopilot, or keep planning) in place of the chat input. End your turn right after calling this.",
+    promptSnippet: "Present your finished plan for the user to approve",
+    parameters: PlanReadyParams,
+    executionMode: "sequential",
+    async execute(_id: string, params: PlanReadyParams) {
+      const summary = params.summary?.trim();
+      if (!summary) {
+        throw new Error("plan_ready needs a non-empty plan summary.");
+      }
+      recordPlanReady({ summary });
+      return {
+        content: [{ type: "text" as const, text: PLAN_READY_INSTRUCTION }],
+        details: { summary },
+      };
+    },
+  });
+}
+
+/** The tool name — pi's allowlist needs it alongside the object. */
+export const PLAN_READY_TOOL_NAME = "plan_ready";

--- a/packages/runtime/src/turn/turn-session.ts
+++ b/packages/runtime/src/turn/turn-session.ts
@@ -26,6 +26,7 @@ import { buildToolSelection } from "../session/tool-selection";
 import { makeAskUserTool } from "../session/tools/ask-user";
 import { makeClampedFileTools } from "../session/tools/clamped-fs";
 import { makeIdTokenProvider } from "../session/tools/gcp-id-token";
+import { makePlanReadyTool } from "../session/tools/plan-ready";
 import { makeRunCodeTool } from "../session/tools/run-code";
 import {
   appendAssistantMessageAt,
@@ -167,6 +168,10 @@ export async function runPiTurn(
         // already in toolSelection.toolNames. request_connection is NOT — it is
         // gated with the integration tools, which are off in cloud turn mode.
         makeAskUserTool(),
+        // plan_ready is registered always but name-gated to Plan mode by
+        // toolNamesForMode (harmless in execute/auto — pi exposes it only when
+        // its name is in the mode's allowlist).
+        makePlanReadyTool(),
         ...(sandbox ? [sandbox] : []),
       ],
     });

--- a/ui/chat/src/chat-plan-ready-card-model.ts
+++ b/ui/chat/src/chat-plan-ready-card-model.ts
@@ -1,0 +1,76 @@
+// Shared labels + a pure presentation resolver for ChatPlanReadyCard. DOM-free
+// (mirroring interaction-card-model.ts) so the node:test suite can drive the
+// button ordering/variant/disabled decision without a DOM runner; the .tsx
+// component maps the resolved descriptors to buttons verbatim.
+
+/** English defaults live in the app; consumers pass `t()` results in. This
+ *  constant is the fallback for apps that don't localize the card yet. */
+export interface ChatPlanReadyLabels {
+  title: string;
+  startWorking: string;
+  runAutopilot: string;
+  keepPlanning: string;
+}
+
+/** English fallbacks for apps that don't localize the plan-ready card yet.
+ *  No em dashes. */
+export const DEFAULT_PLAN_READY_LABELS: ChatPlanReadyLabels = {
+  title: "Plan ready",
+  startWorking: "Start working",
+  runAutopilot: "Run on Autopilot",
+  keepPlanning: "Keep planning",
+};
+
+/** Stable key for each action, so the .tsx wires the right callback. */
+export type PlanReadyActionKey =
+  | "startWorking"
+  | "runAutopilot"
+  | "keepPlanning";
+
+/** The button variant each action renders as, on the grey (bg-secondary) card
+ *  surface: the primary commit is filled, the autopilot alternative is a raised
+ *  outline chip (distinct on grey, never grey-on-grey), and the quiet dismissal
+ *  is a ghost. */
+export type PlanReadyActionVariant = "default" | "outline" | "ghost";
+
+/** One resolved button descriptor: its stable key, its localized label, the
+ *  variant it renders as, and whether it is disabled. */
+export interface PlanReadyAction {
+  key: PlanReadyActionKey;
+  label: string;
+  variant: PlanReadyActionVariant;
+  disabled: boolean;
+}
+
+/**
+ * The three actions in render order: Start working (primary) -> Run on
+ * Autopilot (raised outline) -> Keep planning (quiet ghost). `disabled` gates
+ * ALL three uniformly, so the whole card reads as inert while another turn is
+ * active. Pure so the ordering/variant/disabled mapping is unit-tested without
+ * a DOM.
+ */
+export function resolvePlanReadyActions(
+  labels: ChatPlanReadyLabels,
+  disabled: boolean,
+): PlanReadyAction[] {
+  return [
+    {
+      key: "startWorking",
+      label: labels.startWorking,
+      variant: "default",
+      disabled,
+    },
+    {
+      key: "runAutopilot",
+      label: labels.runAutopilot,
+      variant: "outline",
+      disabled,
+    },
+    {
+      key: "keepPlanning",
+      label: labels.keepPlanning,
+      variant: "ghost",
+      disabled,
+    },
+  ];
+}

--- a/ui/chat/src/chat-plan-ready-card.tsx
+++ b/ui/chat/src/chat-plan-ready-card.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { Button, cn } from "@houston-ai/core";
+import {
+  type ChatPlanReadyLabels,
+  type PlanReadyActionKey,
+  resolvePlanReadyActions,
+} from "./chat-plan-ready-card-model";
+
+export type { ChatPlanReadyLabels } from "./chat-plan-ready-card-model";
+export { DEFAULT_PLAN_READY_LABELS } from "./chat-plan-ready-card-model";
+
+export interface ChatPlanReadyCardProps {
+  /** The plan the agent drafted, shown as the card body. */
+  summary: string;
+  /** Gates all three actions uniformly (another turn is active). */
+  disabled?: boolean;
+  /** Send the plan as a normal (execute) turn. */
+  onStartWorking: () => void;
+  /** Send the plan as an Autopilot (auto) turn. */
+  onRunAutopilot: () => void;
+  /** Dismiss the card locally and return the composer; mode stays plan. */
+  onKeepPlanning: () => void;
+  labels: ChatPlanReadyLabels;
+}
+
+/**
+ * The in-chat surface shown when the agent finishes planning and calls
+ * `plan_ready`: the drafted plan plus three ways forward. It REPLACES the
+ * composer, so it borrows the interaction card's vocabulary (rounded-[28px]
+ * grey `bg-secondary` surface) with the plan text raised as the prominent head.
+ * Every action is visible at rest (no hover gate) and keyboard-reachable; a
+ * primary "Start working", a raised-outline "Run on Autopilot", and a quiet
+ * ghost "Keep planning" that only dismisses the card.
+ */
+export function ChatPlanReadyCard({
+  summary,
+  disabled = false,
+  onStartWorking,
+  onRunAutopilot,
+  onKeepPlanning,
+  labels,
+}: ChatPlanReadyCardProps) {
+  const handlers: Record<PlanReadyActionKey, () => void> = {
+    startWorking: onStartWorking,
+    runAutopilot: onRunAutopilot,
+    keepPlanning: onKeepPlanning,
+  };
+  const actions = resolvePlanReadyActions(labels, disabled);
+
+  return (
+    <div
+      aria-disabled={disabled || undefined}
+      className={cn(
+        "overflow-clip rounded-[28px] border border-border/50 bg-secondary p-2.5",
+        "shadow-[0_1px_6px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_6px_rgba(0,0,0,0.2)]",
+        disabled && "opacity-50",
+      )}
+    >
+      <div className="flex flex-col px-2.5 pt-2 pb-2">
+        <p className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+          {labels.title}
+        </p>
+        <p className="mt-1.5 text-base text-foreground leading-relaxed">
+          {summary}
+        </p>
+        <div className="mt-4 flex flex-col gap-2">
+          {actions.map((action) => (
+            <Button
+              className="w-full"
+              disabled={action.disabled}
+              key={action.key}
+              onClick={handlers[action.key]}
+              size="lg"
+              type="button"
+              variant={action.variant}
+            >
+              {action.label}
+            </Button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -186,6 +186,22 @@ export type {
   PrepareAttachments,
   PreparedAttachments,
 } from "./chat-panel-types";
+// === Plan-ready card ===
+// The composer-replacing surface shown when the agent finishes planning
+// (plan_ready): the drafted plan + Start working / Run on Autopilot / Keep
+// planning. Props-only; the app supplies localized labels and wires the sends.
+export type { ChatPlanReadyCardProps } from "./chat-plan-ready-card";
+export { ChatPlanReadyCard } from "./chat-plan-ready-card";
+export type {
+  ChatPlanReadyLabels,
+  PlanReadyAction,
+  PlanReadyActionKey,
+  PlanReadyActionVariant,
+} from "./chat-plan-ready-card-model";
+export {
+  DEFAULT_PLAN_READY_LABELS,
+  resolvePlanReadyActions,
+} from "./chat-plan-ready-card-model";
 export type { ChatProcessLabels } from "./chat-process-block";
 export type { ChatSidebarProps } from "./chat-sidebar";
 export { ChatSidebar } from "./chat-sidebar";

--- a/ui/chat/tests/chat-plan-ready-card.test.ts
+++ b/ui/chat/tests/chat-plan-ready-card.test.ts
@@ -1,0 +1,70 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  type ChatPlanReadyLabels,
+  DEFAULT_PLAN_READY_LABELS,
+  resolvePlanReadyActions,
+} from "../src/chat-plan-ready-card-model.ts";
+
+const LABELS: ChatPlanReadyLabels = {
+  title: "Plan ready",
+  startWorking: "Start working",
+  runAutopilot: "Run on Autopilot",
+  keepPlanning: "Keep planning",
+};
+
+describe("resolvePlanReadyActions", () => {
+  it("resolves the three actions in render order", () => {
+    const actions = resolvePlanReadyActions(LABELS, false);
+    assert.deepEqual(
+      actions.map((a) => a.key),
+      ["startWorking", "runAutopilot", "keepPlanning"],
+    );
+  });
+
+  it("maps each action to its label and button variant", () => {
+    const actions = resolvePlanReadyActions(LABELS, false);
+    assert.deepEqual(actions, [
+      {
+        key: "startWorking",
+        label: "Start working",
+        variant: "default",
+        disabled: false,
+      },
+      {
+        key: "runAutopilot",
+        label: "Run on Autopilot",
+        variant: "outline",
+        disabled: false,
+      },
+      {
+        key: "keepPlanning",
+        label: "Keep planning",
+        variant: "ghost",
+        disabled: false,
+      },
+    ]);
+  });
+
+  it("gates every action uniformly when disabled", () => {
+    const actions = resolvePlanReadyActions(LABELS, true);
+    assert.ok(actions.every((a) => a.disabled));
+  });
+
+  it("leaves every action enabled when not disabled", () => {
+    const actions = resolvePlanReadyActions(LABELS, false);
+    assert.ok(actions.every((a) => !a.disabled));
+  });
+});
+
+describe("DEFAULT_PLAN_READY_LABELS", () => {
+  it("ships the English fallback copy with no em dashes", () => {
+    assert.equal(DEFAULT_PLAN_READY_LABELS.title, "Plan ready");
+    assert.equal(DEFAULT_PLAN_READY_LABELS.startWorking, "Start working");
+    assert.equal(DEFAULT_PLAN_READY_LABELS.runAutopilot, "Run on Autopilot");
+    assert.equal(DEFAULT_PLAN_READY_LABELS.keepPlanning, "Keep planning");
+    for (const value of Object.values(DEFAULT_PLAN_READY_LABELS)) {
+      assert.ok(!value.includes("—"), `"${value}" must not use an em dash`);
+    }
+  });
+});

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -363,7 +363,10 @@ export type InteractionStep =
       options?: InteractionOption[];
     }
   | { kind: "signin"; id: string; reason?: string }
-  | { kind: "connect"; id: string; toolkit: string; reason?: string };
+  | { kind: "connect"; id: string; toolkit: string; reason?: string }
+  /** The model finished planning: a short plan summary the user approves by
+   *  choosing a mode (start working / Autopilot) or dismisses to keep planning. */
+  | { kind: "plan_ready"; id: string; summary: string };
 
 /**
  * The ordered steps a mission is waiting on the user for — recorded when the


### PR DESCRIPTION
## What

In Planner mode the model can't act, so it resorted to **asking the user in prose** to switch modes. Now finishing a plan produces a structured card, and approving it *is* the mode switch:

- The plan-mode overlay tells the model to present its finished plan with a new **`plan_ready` tool** (exposed ONLY in plan mode, on both the pi and Claude backends) instead of asking in text. The tool rides the exact ask_user rails: it records a pending interaction, the turn ends, and the card replaces the composer.
- **"Plan ready" card**: the model's short summary plus three choices — **Start working** (Coworker), **Run on Autopilot**, **Keep planning**. Choosing a mode flips + persists the Mode pill and sends a visible go-ahead turn ("Go ahead with the plan." / "Go ahead and finish it on your own.") pinned explicitly to the chosen mode — the runtime rebuilds the session via the existing `switchModeIfNeeded` rails. Keep planning dismisses locally (re-shows for a genuinely new plan).
- A `plan_ready` interaction is **exclusive** in the holder (wins over queued questions, defensively), and `toolNamesForMode` strips the tool from every non-plan turn even if a backend hands it in.
- Protocol `InteractionStep` gains the variant (guard + engine-client mirrored union); SDK/web pass it through untouched. Inventory bumped to **v9** (main took v8 while this branched; parity green).

## Verification

runtime 568 / ui/chat 119 / app 1022 tests green; typecheck, biome, boundaries, parity, locales all clean; card screenshot-verified by arming the fake host's real interaction seam (no UI stub).

Follows the modes series (#744, #763, #777, #781).

🤖 Generated with [Claude Code](https://claude.com/claude-code)