### PR TITLE
feat: plan-ready options in the mode-menu row idiom

### DIFF
--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -1008,9 +1008,12 @@ export function useAgentChatPanel({
   const planReadyLabels = useMemo<ChatPlanReadyLabels>(
     () => ({
       title: t("chat:planReady.title"),
-      startWorking: t("chat:planReady.startWorking"),
-      runAutopilot: t("chat:planReady.runAutopilot"),
-      keepPlanning: t("chat:planReady.keepPlanning"),
+      coworkerTitle: t("chat:planReady.coworkerTitle"),
+      coworkerDescription: t("chat:planReady.coworkerDescription"),
+      autopilotTitle: t("chat:planReady.autopilotTitle"),
+      autopilotDescription: t("chat:planReady.autopilotDescription"),
+      keepPlanningTitle: t("chat:planReady.keepPlanningTitle"),
+      keepPlanningDescription: t("chat:planReady.keepPlanningDescription"),
     }),
     [t],
   );

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -58,9 +58,12 @@
   },
   "planReady": {
     "title": "Plan ready",
-    "startWorking": "Start working",
-    "runAutopilot": "Run on Autopilot",
-    "keepPlanning": "Keep planning",
+    "coworkerTitle": "Continue in Coworker mode",
+    "coworkerDescription": "Works with you and asks when unsure.",
+    "autopilotTitle": "Continue in Autopilot mode",
+    "autopilotDescription": "Finishes it on its own. No questions asked.",
+    "keepPlanningTitle": "Keep planning",
+    "keepPlanningDescription": "Stay here and adjust the plan.",
     "startWorkingMessage": "Go ahead with the plan.",
     "runAutopilotMessage": "Go ahead and finish it on your own."
   },

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -58,9 +58,12 @@
   },
   "planReady": {
     "title": "Plan listo",
-    "startWorking": "Empezar a trabajar",
-    "runAutopilot": "Usar Piloto automático",
-    "keepPlanning": "Seguir planificando",
+    "coworkerTitle": "Continuar en modo Compañero",
+    "coworkerDescription": "Trabaja contigo y te pregunta si tiene dudas.",
+    "autopilotTitle": "Continuar en modo Piloto automático",
+    "autopilotDescription": "Lo termina por su cuenta. Sin preguntas.",
+    "keepPlanningTitle": "Seguir planificando",
+    "keepPlanningDescription": "Sigue aquí y ajusta el plan.",
     "startWorkingMessage": "Adelante con el plan.",
     "runAutopilotMessage": "Adelante, termínalo por tu cuenta."
   },

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -58,9 +58,12 @@
   },
   "planReady": {
     "title": "Plano pronto",
-    "startWorking": "Começar a trabalhar",
-    "runAutopilot": "Usar Piloto automático",
-    "keepPlanning": "Continuar planejando",
+    "coworkerTitle": "Continuar no modo Colega",
+    "coworkerDescription": "Trabalha com você e pergunta quando tem dúvidas.",
+    "autopilotTitle": "Continuar no modo Piloto automático",
+    "autopilotDescription": "Termina sozinho. Sem perguntas.",
+    "keepPlanningTitle": "Continuar planejando",
+    "keepPlanningDescription": "Fique aqui e ajuste o plano.",
     "startWorkingMessage": "Pode seguir com o plano.",
     "runAutopilotMessage": "Pode terminar por conta própria."
   },

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,26 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v10 - 2026-07-08
+
+Revamp `plan-ready-card`'s three options into the composer mode-menu idiom.
+The stacked pill buttons (filled "Start working", outline "Run on Autopilot",
+ghost "Keep planning") become full-width mode-menu rows: each row shows its
+icon inline with the title (Handshake / Rocket / ListTodo, matching the
+`ChatModeSelector` icons, in the title's foreground color) and a one-line
+description on its own line below, with a rounded-xl hover background and
+nothing hover-gated. Copy is now "Continue in Coworker mode", "Continue in
+Autopilot mode", and "Keep planning". Primary emphasis comes from row order +
+title weight, so there is no filled primary button anymore. The card surface
+(rounded-[28px] bg-secondary), the "PLAN READY" title, and the plan summary are
+unchanged; callbacks (`onStartWorking` / `onRunAutopilot` / `onKeepPlanning`)
+and the `disabled`-gates-all-three behavior are unchanged. This is a labels
+CONTRACT change: `ChatPlanReadyCardProps.labels` drops the flat button strings
+and instead carries `{ title, coworkerTitle, coworkerDescription,
+autopilotTitle, autopilotDescription, keepPlanningTitle, keepPlanningDescription
+}` (`DEFAULT_PLAN_READY_LABELS` + the pure model updated to match); icons are
+internal to the component. Web-only; native surfaces still defer plan mode.
+
 ## v9 - 2026-07-08
 
 Add `plan-ready-card`, the composer-replacing surface shown when the agent

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 9
+version: 10
 
 components:
   - id: agent-avatar
@@ -255,20 +255,25 @@ components:
 
   - id: plan-ready-card
     title: Plan-ready card
-    purpose: In-chat surface shown when the agent finishes planning (plan mode) and calls plan_ready; presents the drafted plan and three ways forward, replacing the composer until the user chooses.
-    anatomy: [title, plan-summary, start-working-action, run-autopilot-action, keep-planning-action]
+    purpose: In-chat surface shown when the agent finishes planning (plan mode) and calls plan_ready; presents the drafted plan and three ways forward as composer mode-menu rows, replacing the composer until the user chooses.
+    anatomy: [title, plan-summary, coworker-row, autopilot-row, keep-planning-row]
     states: [default, disabled]
     variants: [default]
     behavior: >-
       Rendered from a pending interaction carrying a single plan_ready step
       (summary), exactly like ask_user reaches the frontend. Shows the plan
-      summary above three always-visible actions. "Start working" starts a
-      normal (execute) turn confirming the plan; "Run on Autopilot" starts an
-      autopilot (auto) turn; both flip the composer Mode pill to match and send a
-      visible user message. "Keep planning" dismisses the card LOCALLY (the
-      composer returns, mode stays plan) without sending; a later, different plan
-      re-shows the card. Disabled gates all three actions.
-    a11y: title then plan summary read in order; three labeled buttons visible at rest (no hover gate), keyboard-reachable; disabled state marks the surface aria-disabled and gates every action.
+      summary above three always-visible option rows built in the composer mode
+      menu's idiom: each a full-width row with its icon inline with the title
+      (Handshake / Rocket / ListTodo, matching the mode selector) and a
+      one-line description below, rounded-xl hover background, nothing
+      hover-gated. "Continue in Coworker mode" starts a normal (execute) turn
+      confirming the plan; "Continue in Autopilot mode" starts an autopilot
+      (auto) turn; both flip the composer Mode pill to match and send a visible
+      user message. "Keep planning" dismisses the card LOCALLY (the composer
+      returns, mode stays plan) without sending; a later, different plan
+      re-shows the card. Primary emphasis comes from row order + title weight,
+      not a filled button. Disabled gates all three rows.
+    a11y: title then plan summary read in order; three labeled row buttons visible at rest (no hover gate), keyboard-reachable, each with a foreground-color icon inline with its title; disabled state marks the surface aria-disabled and gates every row.
     since: 9
 
   - id: deliverable-card

--- a/ui/chat/src/chat-plan-ready-card-model.ts
+++ b/ui/chat/src/chat-plan-ready-card-model.ts
@@ -1,53 +1,58 @@
 // Shared labels + a pure presentation resolver for ChatPlanReadyCard. DOM-free
 // (mirroring interaction-card-model.ts) so the node:test suite can drive the
-// button ordering/variant/disabled decision without a DOM runner; the .tsx
-// component maps the resolved descriptors to buttons verbatim.
+// row ordering/content/disabled decision without a DOM runner; the .tsx
+// component maps the resolved descriptors to rows verbatim (icons are internal
+// to the component).
 
 /** English defaults live in the app; consumers pass `t()` results in. This
- *  constant is the fallback for apps that don't localize the card yet. */
+ *  constant is the fallback for apps that don't localize the card yet. Each
+ *  option carries a title (icon sits inline with it in the .tsx) and a
+ *  one-line description on its own line, matching the composer mode menu. */
 export interface ChatPlanReadyLabels {
   title: string;
-  startWorking: string;
-  runAutopilot: string;
-  keepPlanning: string;
+  coworkerTitle: string;
+  coworkerDescription: string;
+  autopilotTitle: string;
+  autopilotDescription: string;
+  keepPlanningTitle: string;
+  keepPlanningDescription: string;
 }
 
 /** English fallbacks for apps that don't localize the plan-ready card yet.
  *  No em dashes. */
 export const DEFAULT_PLAN_READY_LABELS: ChatPlanReadyLabels = {
   title: "Plan ready",
-  startWorking: "Start working",
-  runAutopilot: "Run on Autopilot",
-  keepPlanning: "Keep planning",
+  coworkerTitle: "Continue in Coworker mode",
+  coworkerDescription: "Works with you and asks when unsure.",
+  autopilotTitle: "Continue in Autopilot mode",
+  autopilotDescription: "Finishes it on its own. No questions asked.",
+  keepPlanningTitle: "Keep planning",
+  keepPlanningDescription: "Stay here and adjust the plan.",
 };
 
-/** Stable key for each action, so the .tsx wires the right callback. */
+/** Stable key for each action, so the .tsx wires the right callback + icon. */
 export type PlanReadyActionKey =
   | "startWorking"
   | "runAutopilot"
   | "keepPlanning";
 
-/** The button variant each action renders as, on the grey (bg-secondary) card
- *  surface: the primary commit is filled, the autopilot alternative is a raised
- *  outline chip (distinct on grey, never grey-on-grey), and the quiet dismissal
- *  is a ghost. */
-export type PlanReadyActionVariant = "default" | "outline" | "ghost";
-
-/** One resolved button descriptor: its stable key, its localized label, the
- *  variant it renders as, and whether it is disabled. */
+/** One resolved row descriptor: its stable key, its localized title +
+ *  description, and whether it is disabled. Icons are internal to the .tsx. */
 export interface PlanReadyAction {
   key: PlanReadyActionKey;
-  label: string;
-  variant: PlanReadyActionVariant;
+  title: string;
+  description: string;
   disabled: boolean;
 }
 
 /**
- * The three actions in render order: Start working (primary) -> Run on
- * Autopilot (raised outline) -> Keep planning (quiet ghost). `disabled` gates
- * ALL three uniformly, so the whole card reads as inert while another turn is
- * active. Pure so the ordering/variant/disabled mapping is unit-tested without
- * a DOM.
+ * The three options in render order: Continue in Coworker mode (execute) ->
+ * Continue in Autopilot mode (auto) -> Keep planning (dismiss). Rendered as
+ * full-width mode-menu rows (icon inline with the title, description below).
+ * Primary emphasis comes from row order + title weight, not a filled button.
+ * `disabled` gates ALL three uniformly, so the whole card reads as inert while
+ * another turn is active. Pure so the ordering/content/disabled mapping is
+ * unit-tested without a DOM.
  */
 export function resolvePlanReadyActions(
   labels: ChatPlanReadyLabels,
@@ -56,20 +61,20 @@ export function resolvePlanReadyActions(
   return [
     {
       key: "startWorking",
-      label: labels.startWorking,
-      variant: "default",
+      title: labels.coworkerTitle,
+      description: labels.coworkerDescription,
       disabled,
     },
     {
       key: "runAutopilot",
-      label: labels.runAutopilot,
-      variant: "outline",
+      title: labels.autopilotTitle,
+      description: labels.autopilotDescription,
       disabled,
     },
     {
       key: "keepPlanning",
-      label: labels.keepPlanning,
-      variant: "ghost",
+      title: labels.keepPlanningTitle,
+      description: labels.keepPlanningDescription,
       disabled,
     },
   ];

--- a/ui/chat/src/chat-plan-ready-card.tsx
+++ b/ui/chat/src/chat-plan-ready-card.tsx
@@ -1,6 +1,8 @@
 "use client";
 
-import { Button, cn } from "@houston-ai/core";
+import { cn } from "@houston-ai/core";
+import type { LucideIcon } from "lucide-react";
+import { Handshake, ListTodo, Rocket } from "lucide-react";
 import {
   type ChatPlanReadyLabels,
   type PlanReadyActionKey,
@@ -24,14 +26,25 @@ export interface ChatPlanReadyCardProps {
   labels: ChatPlanReadyLabels;
 }
 
+/** Each option's icon, matching the composer mode selector: Coworker
+ *  (execute) = Handshake, Autopilot (auto) = Rocket, Keep planning = ListTodo.
+ *  Internal to the card so the labels contract stays icon-free. */
+const ACTION_ICONS: Record<PlanReadyActionKey, LucideIcon> = {
+  startWorking: Handshake,
+  runAutopilot: Rocket,
+  keepPlanning: ListTodo,
+};
+
 /**
  * The in-chat surface shown when the agent finishes planning and calls
  * `plan_ready`: the drafted plan plus three ways forward. It REPLACES the
  * composer, so it borrows the interaction card's vocabulary (rounded-[28px]
  * grey `bg-secondary` surface) with the plan text raised as the prominent head.
- * Every action is visible at rest (no hover gate) and keyboard-reachable; a
- * primary "Start working", a raised-outline "Run on Autopilot", and a quiet
- * ghost "Keep planning" that only dismisses the card.
+ * The options render as the composer mode menu's rows: each a full-width row
+ * with its icon inline with the title and a description on its own line below
+ * (icon in the title's foreground color), a rounded-xl hover background, and
+ * everything visible at rest (no hover gate). Primary emphasis comes from row
+ * order + title weight, not a filled button. `disabled` gates all three rows.
  */
 export function ChatPlanReadyCard({
   summary,
@@ -64,20 +77,29 @@ export function ChatPlanReadyCard({
         <p className="mt-1.5 text-base text-foreground leading-relaxed">
           {summary}
         </p>
-        <div className="mt-4 flex flex-col gap-2">
-          {actions.map((action) => (
-            <Button
-              className="w-full"
-              disabled={action.disabled}
-              key={action.key}
-              onClick={handlers[action.key]}
-              size="lg"
-              type="button"
-              variant={action.variant}
-            >
-              {action.label}
-            </Button>
-          ))}
+        <div className="mt-3 flex flex-col gap-0.5">
+          {actions.map((action) => {
+            const Icon = ACTION_ICONS[action.key];
+            return (
+              <button
+                className="flex w-full items-center rounded-xl px-2.5 py-2.5 text-left transition-colors hover:bg-accent disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                disabled={action.disabled}
+                key={action.key}
+                onClick={handlers[action.key]}
+                type="button"
+              >
+                <span className="flex min-w-0 flex-1 flex-col gap-1">
+                  <span className="flex items-center gap-2 text-sm font-medium text-foreground">
+                    <Icon className="size-4 shrink-0 text-foreground" />
+                    {action.title}
+                  </span>
+                  <span className="text-xs text-muted-foreground">
+                    {action.description}
+                  </span>
+                </span>
+              </button>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -196,7 +196,6 @@ export type {
   ChatPlanReadyLabels,
   PlanReadyAction,
   PlanReadyActionKey,
-  PlanReadyActionVariant,
 } from "./chat-plan-ready-card-model";
 export {
   DEFAULT_PLAN_READY_LABELS,

--- a/ui/chat/tests/chat-plan-ready-card.test.ts
+++ b/ui/chat/tests/chat-plan-ready-card.test.ts
@@ -8,9 +8,12 @@ import {
 
 const LABELS: ChatPlanReadyLabels = {
   title: "Plan ready",
-  startWorking: "Start working",
-  runAutopilot: "Run on Autopilot",
-  keepPlanning: "Keep planning",
+  coworkerTitle: "Continue in Coworker mode",
+  coworkerDescription: "Works with you and asks when unsure.",
+  autopilotTitle: "Continue in Autopilot mode",
+  autopilotDescription: "Finishes it on its own. No questions asked.",
+  keepPlanningTitle: "Keep planning",
+  keepPlanningDescription: "Stay here and adjust the plan.",
 };
 
 describe("resolvePlanReadyActions", () => {
@@ -22,25 +25,25 @@ describe("resolvePlanReadyActions", () => {
     );
   });
 
-  it("maps each action to its label and button variant", () => {
+  it("maps each action to its localized title and description", () => {
     const actions = resolvePlanReadyActions(LABELS, false);
     assert.deepEqual(actions, [
       {
         key: "startWorking",
-        label: "Start working",
-        variant: "default",
+        title: "Continue in Coworker mode",
+        description: "Works with you and asks when unsure.",
         disabled: false,
       },
       {
         key: "runAutopilot",
-        label: "Run on Autopilot",
-        variant: "outline",
+        title: "Continue in Autopilot mode",
+        description: "Finishes it on its own. No questions asked.",
         disabled: false,
       },
       {
         key: "keepPlanning",
-        label: "Keep planning",
-        variant: "ghost",
+        title: "Keep planning",
+        description: "Stay here and adjust the plan.",
         disabled: false,
       },
     ]);
@@ -60,9 +63,15 @@ describe("resolvePlanReadyActions", () => {
 describe("DEFAULT_PLAN_READY_LABELS", () => {
   it("ships the English fallback copy with no em dashes", () => {
     assert.equal(DEFAULT_PLAN_READY_LABELS.title, "Plan ready");
-    assert.equal(DEFAULT_PLAN_READY_LABELS.startWorking, "Start working");
-    assert.equal(DEFAULT_PLAN_READY_LABELS.runAutopilot, "Run on Autopilot");
-    assert.equal(DEFAULT_PLAN_READY_LABELS.keepPlanning, "Keep planning");
+    assert.equal(
+      DEFAULT_PLAN_READY_LABELS.coworkerTitle,
+      "Continue in Coworker mode",
+    );
+    assert.equal(
+      DEFAULT_PLAN_READY_LABELS.autopilotTitle,
+      "Continue in Autopilot mode",
+    );
+    assert.equal(DEFAULT_PLAN_READY_LABELS.keepPlanningTitle, "Keep planning");
     for (const value of Object.values(DEFAULT_PLAN_READY_LABELS)) {
       assert.ok(!value.includes("—"), `"${value}" must not use an em dash`);
     }


### PR DESCRIPTION
## What

Design pass on the Plan-ready card (#786): the three pill buttons become **mode-menu rows** — icon inline with the title (Handshake / Rocket / ListTodo, icon in the title color), description on its own line below, rounded-xl hover rows, nothing hover-gated:

- **Continue in Coworker mode** — works with you and asks when unsure
- **Continue in Autopilot mode** — finishes it on its own, no questions asked
- **Keep planning** — stay here and adjust the plan

Labels contract widened to title+description pairs (defaults updated); en/es/pt copy; inventory bumped to v10 (parity green).

Screenshot-verified against the mode menu's row idiom via the fake-host interaction seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)