### PR TITLE
fix: plan-ready options read as clickable cards; no all-caps headers

### DIFF
--- a/ui/chat/src/chat-plan-ready-card.tsx
+++ b/ui/chat/src/chat-plan-ready-card.tsx
@@ -42,7 +42,8 @@ const ACTION_ICONS: Record<PlanReadyActionKey, LucideIcon> = {
  * grey `bg-secondary` surface) with the plan text raised as the prominent head.
  * The options render as the composer mode menu's rows: each a full-width row
  * with its icon inline with the title and a description on its own line below
- * (icon in the title's foreground color), a rounded-xl hover background, and
+ * (icon in the title's foreground color), each option raised on its own
+ * bordered card so it reads clickable, and
  * everything visible at rest (no hover gate). Primary emphasis comes from row
  * order + title weight, not a filled button. `disabled` gates all three rows.
  */
@@ -71,18 +72,18 @@ export function ChatPlanReadyCard({
       )}
     >
       <div className="flex flex-col px-2.5 pt-2 pb-2">
-        <p className="font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        <p className="font-medium text-muted-foreground text-xs">
           {labels.title}
         </p>
         <p className="mt-1.5 text-base text-foreground leading-relaxed">
           {summary}
         </p>
-        <div className="mt-3 flex flex-col gap-0.5">
+        <div className="mt-3 flex flex-col gap-1.5">
           {actions.map((action) => {
             const Icon = ACTION_ICONS[action.key];
             return (
               <button
-                className="flex w-full items-center rounded-xl px-2.5 py-2.5 text-left transition-colors hover:bg-accent disabled:pointer-events-none focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                className="flex w-full items-center rounded-xl border border-border bg-background px-3 py-2.5 text-left shadow-xs transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                 disabled={action.disabled}
                 key={action.key}
                 onClick={handlers[action.key]}

--- a/ui/chat/src/queued-message-list.tsx
+++ b/ui/chat/src/queued-message-list.tsx
@@ -31,7 +31,7 @@ export function QueuedMessageList({
 
   return (
     <div className="mb-2 rounded-lg border border-border/70 bg-muted/35 px-3 py-2 shadow-sm">
-      <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+      <div className="mb-1.5 flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
         <Clock3Icon className="size-3" />
         <span>{title}</span>
       </div>


### PR DESCRIPTION
Polish pass on the Plan-ready card (#787):

- Each option now sits on its **own raised card** (border, background, soft shadow, hover accent) so the three choices clearly read as clickable, with breathing room between them.
- **No all-uppercase text** (new product rule): the card header renders "Plan ready" in sentence case, and the queued-messages header drops its uppercase transform too.

Screenshot-verified via the fake-host interaction seam; ui/chat 124/124 tests, typecheck + biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)