### PR TITLE
feat(app): add GPT-5.6 Sol, Terra, Luna to the model picker (HOU-728)

### DIFF
--- a/app/src/lib/providers.test.mjs
+++ b/app/src/lib/providers.test.mjs
@@ -8,15 +8,32 @@ import {
 } from "./providers.ts";
 
 test("effort levels are per model", () => {
-  // Codex: has xhigh, no max. Every catalogued GPT model shares this set
-  // (verified against Codex's models_cache.json supported_reasoning_levels).
-  for (const id of ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"]) {
+  // Codex pre-5.6 models: xhigh top, no max (the server 400-rejects `max`
+  // on them; verified live against gpt-5.5). GPT-5.6 Terra/Luna stay on the
+  // same range until OpenAI confirms `max` beyond Sol.
+  for (const id of [
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex-spark",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+  ]) {
     assert.deepEqual(
       getEffortLevels("openai", id),
       ["low", "medium", "high", "xhigh"],
       id,
     );
   }
+  // GPT-5.6 Sol: the one Codex model with `max` (announced with 5.6).
+  // "ultra" is a subagent mode, not an effort level — never listed.
+  assert.deepEqual(getEffortLevels("openai", "gpt-5.6-sol"), [
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+  ]);
   // Sonnet 4.6: has max, no xhigh.
   assert.deepEqual(getEffortLevels("anthropic", "claude-sonnet-4-6"), [
     "low",
@@ -84,7 +101,15 @@ test("validModelOrNull rejects retired aliases and accepts catalog IDs", () => {
   assert.equal(validModelOrNull("anthropic", "claude-sonnet-4-6"), "claude-sonnet-4-6");
   // Full Codex lineup is catalogued (gpt-5.5 + the gpt-5.4 / mini / spark
   // models added in HOU-589); the phantom gpt-5.5-codex never shipped.
-  for (const id of ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"]) {
+  for (const id of [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex-spark",
+  ]) {
     assert.equal(validModelOrNull("openai", id), id);
   }
   assert.equal(validModelOrNull("openai", "gpt-5.5-codex"), null);

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -1,7 +1,9 @@
 /**
  * Reasoning-effort levels, ordered low→high. The set a given model accepts
  * is model-specific (see `ModelOption.effortLevels`):
- * - Codex `model_reasoning_effort`: low/medium/high/xhigh (no `max`).
+ * - Codex `model_reasoning_effort`: low/medium/high/xhigh; the bundled
+ *   codex (>= 0.143) also parses `max`, which the SERVER accepts only on
+ *   models that support it (GPT-5.6 Sol; gpt-5.5 and older 400-reject it).
  * - Claude `--effort`: Opus 4.7/4.8 and Sonnet 5 = all five; Sonnet 4.6 =
  *   low/medium/high/max (no `xhigh`). Claude self-clamps an unsupported
  *   value; Codex does not.
@@ -93,6 +95,54 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     loginCommand: "codex login",
     cost: "Your ChatGPT subscription",
     models: [
+      {
+        id: "gpt-5.6-sol",
+        label: "GPT-5.6 Sol",
+        description: "OpenAI's new flagship for the hardest problems.",
+        // GPT-5.6 adds `max` at the top of the effort dial; Sol is the one
+        // model OpenAI's announcement confirms it for. Requires the bundled
+        // codex >= 0.143 (older CLIs hard-reject `max` at config parse; the
+        // server 400s it on models that don't support it, e.g. gpt-5.5).
+        // GPT-5.6 "ultra" is a subagent MODE, not an effort level — never
+        // add it here (same rule as Claude's `ultracode`).
+        effortLevels: ["low", "medium", "high", "xhigh", "max"],
+        // OpenAI has published NO context-window spec for the 5.6 family as
+        // of 2026-07-08 (GA 2026-07-09); the "1.5M" figure circulating is
+        // preview-partner observation, not documentation. Codex has capped
+        // every recent model's effective window at 272k raw x 95% = 258_400
+        // (gpt-5.4, gpt-5.5) regardless of larger raw API offers, so start
+        // there. The snap-up ceiling covers the reported 1.5M x 95% =
+        // 1_425_000 so a genuinely larger window can't overflow the
+        // indicator; it only engages once observed usage proves > 258_400.
+        // Revisit against codex's models_cache.json once it lists gpt-5.6.
+        contextWindow: 258_400,
+        contextWindowMax: 1_425_000,
+      },
+      {
+        id: "gpt-5.6-terra",
+        label: "GPT-5.6 Terra",
+        description: "Balanced power and cost for everyday work.",
+        // OpenAI confirms `max` only for Sol; whether Terra/Luna accept it
+        // is unstated and the server hard-400s unsupported efforts, so stay
+        // on the proven Codex range. Extend to `max` only once verified
+        // against the live API / codex models_cache.json.
+        effortLevels: ["low", "medium", "high", "xhigh"],
+        // Same pre-GA estimate rationale as Sol above, but no 1.5M report
+        // exists for Terra, so the ceiling stays at the 5.5-line precedent
+        // (1M x 95% = 950_000).
+        contextWindow: 258_400,
+        contextWindowMax: 950_000,
+      },
+      {
+        id: "gpt-5.6-luna",
+        label: "GPT-5.6 Luna",
+        description: "Fastest and most affordable GPT-5.6.",
+        // See Terra: `max` unconfirmed off-Sol, keep the proven range.
+        effortLevels: ["low", "medium", "high", "xhigh"],
+        // See Terra: pre-GA estimate, 5.5-line snap-up ceiling.
+        contextWindow: 258_400,
+        contextWindowMax: 950_000,
+      },
       {
         id: "gpt-5.5",
         label: "GPT-5.5",

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -79,6 +79,9 @@
       "max": "Deepest thinking, no token limit."
     },
     "modelDescriptions": {
+      "gpt-5_6-sol": "OpenAI's new flagship for the hardest problems.",
+      "gpt-5_6-terra": "Balanced power and cost for everyday work.",
+      "gpt-5_6-luna": "Fastest and most affordable GPT-5.6.",
       "gpt-5_5": "OpenAI's frontier model.",
       "gpt-5_4": "Strong model for everyday coding.",
       "gpt-5_4-mini": "Small, fast, and cost-efficient for simpler tasks.",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -79,6 +79,9 @@
       "max": "Análisis máximo, sin límite de tokens."
     },
     "modelDescriptions": {
+      "gpt-5_6-sol": "El nuevo modelo insignia de OpenAI para los problemas más difíciles.",
+      "gpt-5_6-terra": "Equilibrio entre potencia y costo para el trabajo diario.",
+      "gpt-5_6-luna": "El GPT-5.6 más rápido y económico.",
       "gpt-5_5": "El modelo más avanzado de OpenAI.",
       "gpt-5_4": "Modelo potente para programar a diario.",
       "gpt-5_4-mini": "Pequeño, rápido y económico para tareas más simples.",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -79,6 +79,9 @@
       "max": "Análise máxima, sem limite de tokens."
     },
     "modelDescriptions": {
+      "gpt-5_6-sol": "O novo modelo principal da OpenAI para os problemas mais difíceis.",
+      "gpt-5_6-terra": "Equilíbrio entre potência e custo para o trabalho do dia a dia.",
+      "gpt-5_6-luna": "O GPT-5.6 mais rápido e econômico.",
       "gpt-5_5": "O modelo mais avançado da OpenAI.",
       "gpt-5_4": "Modelo forte para programação do dia a dia.",
       "gpt-5_4-mini": "Pequeno, rápido e econômico para tarefas mais simples.",

--- a/cli-deps.json
+++ b/cli-deps.json
@@ -23,7 +23,7 @@
     }
   },
   "codex": {
-    "version": "0.137.0",
+    "version": "0.143.0",
     "bundled": true,
     "binary_name": "codex",
     "license": "Apache-2.0",
@@ -36,10 +36,10 @@
       "windows-arm64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-aarch64-pc-windows-msvc.exe.zst"
     },
     "checksums": {
-      "darwin-arm64": "628d2278b1fa2a467452635f2fd5aaeee98de4a94f2af06031e4790da6844046",
-      "darwin-x64": "32206ff8e4edb3422832b24d25a521246e4478b67bab2ec63bee632fdf94b306",
-      "windows-x64": "327e93f43d039734353d2ba7feb8ecffd8a0f90c068c5370ac2ae4f80436aa7a",
-      "windows-arm64": "1a24ce2d34a2b9e62a22c2a20626a78bab83250f148ce87b73c67b1b0923b1e7"
+      "darwin-arm64": "7df2384f037519dff7dbf4252e60913a5c1c7fdb66c1467c9125b2b2d3594a86",
+      "darwin-x64": "f776ef1d5e5f03151dd6e6af94cc7b13e9b08c3c52bd60327692009b01dbfb4a",
+      "windows-x64": "c5bd928642b5aa31cd3ca1203d6a4aecdfd39c6e5709a00e2014ab42160ba6d5",
+      "windows-arm64": "856045fa77f851425684fc12b4b638500d56ccc8a16717ffbe86d8955e791d72"
     }
   },
   "composio": {

--- a/engine/houston-engine-core/src/sessions/provider.rs
+++ b/engine/houston-engine-core/src/sessions/provider.rs
@@ -193,7 +193,7 @@ fn read_agent_config(agent_dir: &Path) -> Option<AgentConfig> {
 /// Order:
 /// 1. The agent's `effort` in `config.json`, but only if the provider's CLI
 ///    actually accepts it ([`Provider::effort_levels`]). A value valid for
-///    one provider but not another (e.g. `max` on Codex, or a hand-edited
+///    one provider but not another (e.g. `ultra`, or a hand-edited
 ///    typo) is dropped rather than passed to a CLI that would reject it.
 /// 2. The provider's [`Provider::default_effort`] — the floor every session
 ///    gets when nothing valid is configured.
@@ -419,12 +419,12 @@ mod tests {
     }
 
     #[test]
-    fn effort_accepts_max_on_claude_but_clamps_on_codex() {
-        // `max` is valid for Claude; for Codex it is an unknown variant, so
-        // the configured value is dropped in favor of the provider default.
+    fn effort_accepts_max_on_both_claude_and_codex() {
+        // `max` is in both providers' unions since GPT-5.6 (codex >= 0.143
+        // parses it; the server/model gates whether it is honored).
         let (_d, agent) = agent_with(r#"{"effort":"max"}"#);
         assert_eq!(resolve_effort(&agent, anthropic()).as_deref(), Some("max"));
-        assert_eq!(resolve_effort(&agent, openai()).as_deref(), Some("medium"));
+        assert_eq!(resolve_effort(&agent, openai()).as_deref(), Some("max"));
     }
 
     #[test]
@@ -461,11 +461,11 @@ mod tests {
 
     #[test]
     fn effort_override_dropped_when_provider_rejects_it() {
-        // "max" is invalid for Codex → the override is dropped and the agent's
-        // configured/default effort is used instead.
+        // "ultra" is a GPT-5.6 harness MODE, not an effort level → the
+        // override is dropped and the agent's configured effort is used.
         let (_d, agent) = agent_with(r#"{"provider":"openai","effort":"high"}"#);
         assert_eq!(
-            resolve_effort_with_override(&agent, openai(), Some("max")).as_deref(),
+            resolve_effort_with_override(&agent, openai(), Some("ultra")).as_deref(),
             Some("high"),
         );
     }

--- a/engine/houston-terminal-manager/src/provider/mod.rs
+++ b/engine/houston-terminal-manager/src/provider/mod.rs
@@ -509,11 +509,11 @@ mod tests {
             anthropic.effort_levels().to_vec(),
             vec!["low", "medium", "high", "xhigh", "max"]
         );
-        // Codex `model_reasoning_effort` has no `max` variant — including it
-        // would be an "unknown variant" error with no CLI-side fallback.
+        // Codex >= 0.143 parses `max` (added with GPT-5.6); the server
+        // gates which models honor it, the frontend gates which offer it.
         assert_eq!(
             openai.effort_levels().to_vec(),
-            vec!["low", "medium", "high", "xhigh"]
+            vec!["low", "medium", "high", "xhigh", "max"]
         );
         // Gemini CLI takes no effort flag.
         assert!(gemini.effort_levels().is_empty());

--- a/engine/houston-terminal-manager/src/provider/openai.rs
+++ b/engine/houston-terminal-manager/src/provider/openai.rs
@@ -73,7 +73,8 @@ impl ProviderAdapter for OpenAiAdapter {
         //
         // Codex loads `~/.codex/config.toml` before running any subcommand,
         // including `logout`. A `model_reasoning_effort` value the bundled
-        // CLI's enum doesn't recognize (e.g. `max`, which is Claude-only)
+        // CLI's enum doesn't recognize (a leftover from a newer or older
+        // CLI's enum — e.g. `max` before codex 0.143)
         // makes logout exit 1 with a config error, leaving the user stuck
         // signed in. Force a known-good value, same trick
         // `provider_auth::probe_codex_auth_status` uses for `login status`.
@@ -81,12 +82,16 @@ impl ProviderAdapter for OpenAiAdapter {
     }
 
     fn effort_levels(&self) -> &'static [&'static str] {
-        // Codex `ReasoningEffort` enum (bundled CLI):
-        // none/minimal/low/medium/high/xhigh. We surface the meaningful
-        // tuning range. `max` is Claude-only and would be an "unknown
-        // variant" to codex — and codex has no clamp-to-highest fallback —
-        // so it is deliberately excluded.
-        &["low", "medium", "high", "xhigh"]
+        // Codex `ReasoningEffort` (bundled CLI, >= 0.143 per cli-deps.json):
+        // none/minimal/low/medium/high/xhigh/max. We surface the meaningful
+        // tuning range. `max` arrived with GPT-5.6 — the pre-0.143 CLI
+        // hard-rejected it at config parse ("unknown variant", no
+        // clamp-to-highest fallback), so never ship `max` here with an older
+        // pinned codex. The SERVER still 400-rejects `max` on models that
+        // don't support it (verified live on gpt-5.5), so the engine carries
+        // the full union and the frontend catalog gates which models offer
+        // it (GPT-5.6 Sol only), mirroring the Anthropic adapter's split.
+        &["low", "medium", "high", "xhigh", "max"]
     }
 
     fn default_effort(&self) -> Option<&'static str> {

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -220,14 +220,16 @@ adapter, see `knowledge-base/architecture.md`).
 | Provider id | CLI | Default model | Premium model | Login flow |
 |---|---|---|---|---|
 | `anthropic` (alias `claude`) | `claude` (runtime download) | `claude-sonnet-4-6` | `claude-opus-4-8` | OAuth via `claude auth login --claudeai` |
-| `openai` (alias `codex`) | `codex` (bundled) | `gpt-5.5` | `gpt-5.5` (frontier; no separate tier) | OAuth via `codex login` |
+| `openai` (alias `codex`) | `codex` (bundled) | `gpt-5.5` | `gpt-5.6-sol` (flagship) | OAuth via `codex login` |
 | `gemini` (alias `google`) | `gemini` (bundled, macOS only) | `gemini-2.5-flash` | `gemini-2.5-pro` | API key, no CLI login (see `knowledge-base/auth.md`) |
 
 Notes:
-- OpenAI ships four models in the picker: `gpt-5.5` (default, frontier),
-  `gpt-5.4` (everyday coding), `gpt-5.4-mini` (small/fast/cheap), and
-  `gpt-5.3-codex-spark` (ultra-fast). gpt-5.5 is both default and frontier, so
-  the "Premium model" column repeats it. The full catalog (labels, per-model
+- OpenAI ships seven models in the picker: the GPT-5.6 family
+  `gpt-5.6-sol` (flagship), `gpt-5.6-terra` (balanced), `gpt-5.6-luna`
+  (fast/cheap), plus `gpt-5.5` (default), `gpt-5.4` (everyday coding),
+  `gpt-5.4-mini` (small/fast/cheap), and `gpt-5.3-codex-spark` (ultra-fast).
+  The default stays `gpt-5.5` until 5.6 availability is verified post-GA
+  (2026-07-09). The full catalog (labels, per-model
   context windows, effort levels) lives in `app/src/lib/providers.ts`; codex
   itself enumerates them in `~/.codex/models_cache.json`. The model string is
   passed verbatim to `codex --model`, so the engine never validates against a
@@ -298,6 +300,9 @@ shows only the levels the active model accepts.
 | `anthropic` | `claude-opus-4-7` (Opus 4.7) | low, medium, high, xhigh, max | `--effort <v>` |
 | `anthropic` | `claude-sonnet-5` (Sonnet 5) | low, medium, high, xhigh, max | `--effort <v>` |
 | `anthropic` | `claude-sonnet-4-6` (Sonnet 4.6) | low, medium, high, max (no `xhigh`) | `--effort <v>` |
+| `openai` | `gpt-5.6-sol` (Sol) | low, medium, high, xhigh, max | `-c model_reasoning_effort="<v>"` |
+| `openai` | `gpt-5.6-terra` (Terra) | low, medium, high, xhigh (`max` unconfirmed off-Sol) | `-c model_reasoning_effort="<v>"` |
+| `openai` | `gpt-5.6-luna` (Luna) | low, medium, high, xhigh (`max` unconfirmed off-Sol) | `-c model_reasoning_effort="<v>"` |
 | `openai` | `gpt-5.5` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
 | `openai` | `gpt-5.4` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
 | `openai` | `gpt-5.4-mini` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
@@ -305,8 +310,12 @@ shows only the levels the active model accepts.
 | `gemini` | any | none | (no flag) |
 
 Claude self-clamps an unsupported `--effort` down to its highest supported
-level; codex has no such fallback, so `max` (an unknown variant to codex) is
-never offered for OpenAI. Default for every effort-capable provider is `medium`.
+level; codex has no CLI-side fallback and the SERVER 400-rejects an effort a
+model doesn't support (verified: `max` on gpt-5.5). `max` entered codex's
+config enum in 0.143 alongside GPT-5.6, so it is offered only on `gpt-5.6-sol`
+(the one model OpenAI confirms it for). GPT-5.6 "ultra" is a subagent mode,
+not an effort level, and is never offered. Default for every effort-capable
+provider is `medium`.
 
 ## Workspace
 - Storage: `~/.houston/workspaces/workspaces.json` (index) + one dir per workspace `~/.houston/workspaces/{Name}/`. `HOUSTON_DOCS` env var overrides the root.


### PR DESCRIPTION
## Summary

First step of the HOU-728 v0.4.27 draft release of the legacy Rust-engine desktop app: add OpenAI's GPT-5.6 family (public GA 2026-07-09) to the model picker.

## What the investigation found

- **Model IDs**: `gpt-5.6-sol` (flagship), `gpt-5.6-terra` (balanced), `gpt-5.6-luna` (fast/cheap) — consistent across OpenAI's developer-facing coverage; the docs pages themselves stay unpublished until GA.
- **Efforts**: GPT-5.6 adds `max` at the top of the existing dial. OpenAI confirms it **for Sol only**. `ultra` also exists but it is a subagent **mode**, not an effort level — deliberately excluded (same rule as Claude's `ultracode`).
- **Context windows**: OpenAI has published **no** window spec for 5.6. The circulating "1.5M" figure is preview-partner observation, explicitly absent from OpenAI's own preview post. Given the Sonnet 5 window incident (HOU-618), nothing unverified is encoded as fact.
- **Verified live**: the API hard-400s `reasoning.effort=max` on models that don't support it (tested on gpt-5.5 via codex 0.143.0), and codex 0.137.0 (previous pin) rejects `max` at config parse before any request is sent.

## Changes

- **Catalog** (`app/src/lib/providers.ts`): three new ModelOptions. Sol: `low/medium/high/xhigh/max`; Terra/Luna: `low/medium/high/xhigh` until `max` is confirmed off-Sol. Context windows start at Codex's proven effective cap (272k × 95% = 258 400, same as gpt-5.4/5.5) with snap-up ceilings (Sol 1 425 000 covering the reported 1.5M; Terra/Luna the 5.5-line 950 000) that only engage once observed usage proves a larger window.
- **Codex pin** `0.137.0 → 0.143.0` (`cli-deps.json`): required for `max` to parse client-side. All four platform checksums fetched and verified.
- **Engine** (`houston-terminal-manager` openai adapter): effort union gains `max`; per-model gating stays a frontend picker concern, mirroring the Anthropic adapter's split.
- Locales (en/es/pt), `providers.test.mjs`, engine tests, `knowledge-base/agent-manifest.md`.

Default model stays `gpt-5.5` until 5.6 availability is verified post-GA.

## Verification

Before: the OpenAI picker lists gpt-5.5 / 5.4 / 5.4-mini / 5.3-codex-spark only; effort `max` is impossible on any Codex model (CLI parse reject on the 0.137 pin).
After:
1. `cd app && pnpm typecheck && pnpm test && pnpm check-locales` — clean; `node --experimental-strip-types --test src/lib/providers.test.mjs` covers the new per-model effort sets (355 + 9 pass).
2. `cd engine && cargo test -p houston-terminal-manager -p houston-engine-core` — 654 pass.
3. `./scripts/fetch-cli-deps.sh` — codex 0.143.0 checksums verify OK.
4. In the app: OpenAI model picker shows the three GPT-5.6 entries; Sol offers the `max` effort, Terra/Luna top out at `xhigh`.

## Post-GA checklist (before tagging the release)

- [ ] Re-verify the three model IDs against `codex models_cache.json` / OpenAI docs once GA lands (2026-07-09)
- [ ] Check whether Terra/Luna accept `max` (extend `effortLevels` if so)
- [ ] Replace the estimated context windows once Codex publishes `context_window` for the 5.6 family
- [ ] Smoke-test a packaged build against bundled codex 0.143.0 (event-schema drift 0.137→0.143)

HOU-728