### PR TITLE
perf(selfhost): bundle host+runtime at image build — cold boot without tsx

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@types/react": "19.2.17",
     "@types/react-dom": "19.2.3",
     "@typescript/native-preview": "7.0.0-dev.20260607.1",
+    "esbuild": "0.25.12",
     "husky": "9.1.7",
     "lint-staged": "17.0.8",
     "mprocs": "0.9.6",

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -1,7 +1,6 @@
 import { randomBytes } from "node:crypto";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { join } from "node:path";
 import {
   LOCAL_CAPABILITIES,
   MANAGED_CLOUD_CAPABILITIES,
@@ -9,6 +8,7 @@ import {
 import { houstonSystemPrompt } from "../houston-prompt";
 import { installParentWatchdog } from "../parent-watchdog";
 import { buildLocalHost } from "./host";
+import { runtimeCommand } from "./runtime-command";
 
 /**
  * The local host entry point — the desktop sidecar the Tauri shell spawns. Same
@@ -31,35 +31,12 @@ import { buildLocalHost } from "./host";
  *   HOUSTON_RUNTIME_COMMAND   argv to launch a pi-runtime (space-separated);
  *                             explicit override (highest priority). Otherwise:
  *                             the compiled sidecar spawns ITSELF (in runtime
- *                             role via HOUSTON_SIDECAR_ROLE — see host.ts); the
- *                             dev fallback is `node --import tsx <repo>/packages/runtime/src/main.ts`.
+ *                             role via HOUSTON_SIDECAR_ROLE — see host.ts);
+ *                             bundled Docker spawns dist/runtime/main.mjs; dev
+ *                             falls back to `node --import tsx <repo>/packages/runtime/src/main.ts`.
  *   HOUSTON_APP_SYSTEM_PROMPT the product voice prompt (from the app)
  *   HOUSTON_MANAGED_CLOUD=1  serve managed-cloud capabilities (K8s pod)
  */
-function runtimeCommand(): string[] {
-  // 1. Explicit override always wins.
-  const explicit = process.env.HOUSTON_RUNTIME_COMMAND;
-  if (explicit) return explicit.split(" ").filter(Boolean);
-  // 2. Packaged: we ARE the compiled sidecar (sidecar-entry.ts set
-  // HOUSTON_SIDECAR_BINARY to our own execPath). Spawn that same binary; the
-  // host adds HOUSTON_SIDECAR_ROLE=runtime so it dispatches into runtime mode.
-  // The packaged .app has no `bun` and no repo source, so this is the ONLY path
-  // that can launch a runtime there.
-  const selfBinary = process.env.HOUSTON_SIDECAR_BINARY;
-  if (selfBinary) return [selfBinary];
-  // 3. Dev fallback: run the runtime from source, resolved relative to this file
-  // (src/local/main.ts → ../../../runtime/src/main.ts).
-  const runtimeMain = join(
-    dirname(fileURLToPath(import.meta.url)),
-    "..",
-    "..",
-    "..",
-    "runtime",
-    "src",
-    "main.ts",
-  );
-  return [process.execPath, "--import", "tsx", runtimeMain];
-}
 
 function remoteCredentialConfig(hostTokenEnv: string | undefined) {
   const url = process.env.HOUSTON_CREDENTIALS_URL;

--- a/packages/host/src/local/runtime-command.test.ts
+++ b/packages/host/src/local/runtime-command.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "vitest";
+import { runtimeCommand } from "./runtime-command";
+
+describe("runtimeCommand", () => {
+  test("uses an explicit env command first", () => {
+    expect(
+      runtimeCommand({
+        env: { HOUSTON_RUNTIME_COMMAND: "node /app/dist/runtime/main.mjs" },
+      }),
+    ).toEqual(["node", "/app/dist/runtime/main.mjs"]);
+  });
+
+  test("spawns the desktop sidecar binary when present", () => {
+    expect(
+      runtimeCommand({
+        env: { HOUSTON_SIDECAR_BINARY: "/Applications/Houston/host" },
+      }),
+    ).toEqual(["/Applications/Houston/host"]);
+  });
+
+  test("uses the sibling runtime bundle when running from dist", () => {
+    expect(
+      runtimeCommand({
+        env: {},
+        execPath: "/usr/local/bin/node",
+        moduleUrl: "file:///app/dist/host/main.mjs",
+        exists: (path) => path === "/app/dist/runtime/main.mjs",
+      }),
+    ).toEqual(["/usr/local/bin/node", "/app/dist/runtime/main.mjs"]);
+  });
+
+  test("falls back to source through tsx in dev", () => {
+    expect(
+      runtimeCommand({
+        env: {},
+        execPath: "/usr/local/bin/node",
+        moduleUrl: "file:///repo/packages/host/src/local/runtime-command.ts",
+        exists: () => false,
+      }),
+    ).toEqual([
+      "/usr/local/bin/node",
+      "--import",
+      "tsx",
+      "/repo/packages/runtime/src/main.ts",
+    ]);
+  });
+});

--- a/packages/host/src/local/runtime-command.ts
+++ b/packages/host/src/local/runtime-command.ts
@@ -1,0 +1,44 @@
+import { existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+interface RuntimeCommandDeps {
+  env?: NodeJS.ProcessEnv;
+  execPath?: string;
+  moduleUrl?: string;
+  exists?: (path: string) => boolean;
+}
+
+/**
+ * Resolve the pi-runtime command for local-profile hosts.
+ *
+ * Order matters: explicit deployment env wins, packaged desktop sidecars spawn
+ * themselves, bundled Docker hosts spawn the sibling runtime bundle, and dev
+ * falls back to source through tsx.
+ */
+export function runtimeCommand(deps: RuntimeCommandDeps = {}): string[] {
+  const env = deps.env ?? process.env;
+  const explicit = env.HOUSTON_RUNTIME_COMMAND;
+  if (explicit) return explicit.split(" ").filter(Boolean);
+
+  const selfBinary = env.HOUSTON_SIDECAR_BINARY;
+  if (selfBinary) return [selfBinary];
+
+  const currentDir = dirname(fileURLToPath(deps.moduleUrl ?? import.meta.url));
+  const exists = deps.exists ?? existsSync;
+  const bundledRuntimeMain = join(currentDir, "..", "runtime", "main.mjs");
+  if (exists(bundledRuntimeMain)) {
+    return [deps.execPath ?? process.execPath, bundledRuntimeMain];
+  }
+
+  const runtimeMain = join(
+    currentDir,
+    "..",
+    "..",
+    "..",
+    "runtime",
+    "src",
+    "main.ts",
+  );
+  return [deps.execPath ?? process.execPath, "--import", "tsx", runtimeMain];
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,9 @@ importers:
       '@typescript/native-preview':
         specifier: 7.0.0-dev.20260607.1
         version: 7.0.0-dev.20260607.1
+      esbuild:
+        specifier: 0.25.12
+        version: 0.25.12
       husky:
         specifier: 9.1.7
         version: 9.1.7

--- a/selfhost/Dockerfile
+++ b/selfhost/Dockerfile
@@ -22,6 +22,27 @@
 #   docker build -t houston/self-host -f selfhost/Dockerfile .
 #   # or just `docker compose up -d --build` from selfhost/ (wires the proxy + volumes).
 
+FROM node:22-bookworm-slim AS bundle-builder
+ENV PNPM_HOME=/pnpm \
+    PATH=/pnpm:$PATH
+RUN corepack enable
+
+WORKDIR /app
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY selfhost/bundle.mjs /app/selfhost/bundle.mjs
+COPY ui/agent-schemas/ /app/ui/agent-schemas/
+COPY packages/protocol/ /app/packages/protocol/
+COPY packages/runtime-client/ /app/packages/runtime-client/
+COPY packages/domain/ /app/packages/domain/
+COPY packages/runtime/ /app/packages/runtime/
+COPY packages/host/ /app/packages/host/
+RUN pnpm install --frozen-lockfile \
+      --filter houston-ai \
+      --filter @houston/runtime... \
+      --filter @houston/host...
+RUN node selfhost/bundle.mjs
+
 # The bookworm-slim variant ships bash + coreutils, which the agent's bash/file
 # tools rely on. Swap node:22 for a digest for a fully reproducible build.
 FROM node:22-bookworm-slim AS host-base
@@ -50,13 +71,20 @@ COPY packages/host/ /app/packages/host/
 # provider, and self-host / managed-pod users connect their OWN Anthropic
 # subscription. That pulls the SDK's per-platform native `claude` binary
 # (@anthropic-ai/claude-agent-sdk-linux-<arch>, ~250 MB, glibc — bookworm is
-# glibc, so the glibc variant is the right one). It resolves via require.resolve
-# under `node --import tsx` (NOT Bun), so no pathToClaudeCodeExecutable override
-# is needed here. The CLOUD-only per-turn image (packages/runtime/Dockerfile)
-# strips this binary because Anthropic stays off there (ToS).
+# glibc, so the glibc variant is the right one). The esbuild bundle keeps the
+# SDK external, so its require.resolve of the native binary still reaches
+# /app/node_modules; no pathToClaudeCodeExecutable override is needed here. The
+# CLOUD-only per-turn image (packages/runtime/Dockerfile) strips this binary
+# because Anthropic stays off there (ToS).
 RUN pnpm install --frozen-lockfile --prod \
       --filter @houston/runtime... \
       --filter @houston/host...
+COPY --from=bundle-builder /app/dist /app/dist
+# The bundles live outside their package dirs, while pnpm keeps external
+# packages in its virtual store. Give Node's ESM resolver a normal upward path
+# from /app/dist/{host,runtime}/main.mjs to those external deps.
+RUN ln -s /app/node_modules/.pnpm/node_modules /app/dist/host/node_modules \
+ && ln -s /app/node_modules/.pnpm/node_modules /app/dist/runtime/node_modules
 
 # The whole ~/.houston equivalent (workspaces + credentials + db) lives here so a
 # single named volume persists everything. Owned by the non-root node user so a
@@ -67,12 +95,12 @@ ENV NODE_ENV=production \
     HOUSTON_HOME=/data \
     HOUSTON_HOST_BIND=0.0.0.0 \
     HOUSTON_HOST_PORT=4318 \
-    HOUSTON_RUNTIME_COMMAND="node --import tsx /app/packages/runtime/src/main.ts"
+    HOUSTON_RUNTIME_COMMAND="node /app/dist/runtime/main.mjs"
 # HOUSTON_HOST_TOKEN is deliberately NOT defaulted: an unset token would leave the
 # host open to anyone who can reach the port. docker-compose.yml requires it.
 
 USER node
-WORKDIR /app/packages/host
+WORKDIR /app
 EXPOSE 4318
 
 # /health is public (no token). Uses Node fetch so the image needs no curl.
@@ -81,7 +109,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
 
 # Exec form → node is PID 1 and gets SIGTERM from `docker stop`; local/main.ts
 # handles it (stops the scheduler/watcher and kills spawned runtimes).
-CMD ["node", "--import", "tsx", "src/local/main.ts"]
+CMD ["node", "dist/host/main.mjs"]
 
 FROM host-base AS engine-pod
 

--- a/selfhost/bundle.mjs
+++ b/selfhost/bundle.mjs
@@ -1,0 +1,51 @@
+import { build } from "esbuild";
+
+const workspaceImport = /^(?:@houston\/|@houston-ai\/agent-schemas(?:\/|$))/;
+
+function shouldExternalize(path) {
+  if (
+    path.startsWith(".") ||
+    path.startsWith("/") ||
+    workspaceImport.test(path)
+  )
+    return false;
+  return true;
+}
+
+const externalNodeModules = {
+  name: "external-node-modules",
+  setup(build) {
+    build.onResolve({ filter: /.*/ }, (args) => {
+      if (!shouldExternalize(args.path)) return undefined;
+      return { path: args.path, external: true };
+    });
+  },
+};
+
+const banner = {
+  js: 'import { createRequire as __houstonCreateRequire } from "node:module"; const require = __houstonCreateRequire(import.meta.url);',
+};
+
+const shared = {
+  bundle: true,
+  platform: "node",
+  format: "esm",
+  target: "node22",
+  packages: "bundle",
+  banner,
+  plugins: [externalNodeModules],
+  logLevel: "info",
+};
+
+await Promise.all([
+  build({
+    ...shared,
+    entryPoints: ["packages/host/src/local/main.ts"],
+    outfile: "dist/host/main.mjs",
+  }),
+  build({
+    ...shared,
+    entryPoints: ["packages/runtime/src/main.ts"],
+    outfile: "dist/runtime/main.mjs",
+  }),
+]);


### PR DESCRIPTION
Part of the pod wake-latency plan (follows cloud#57 idle scale-to-zero; measured breakdown in the linked investigation). The engine pod boots `node --import tsx` for both the host and the runtime child, transpiling the entire TS graph on every process start. In production that read as **~50s from container start to `/health`** on a fresh Autopilot node — with GKE image streaming, a tsx boot faults thousands of small files in from the registry one by one, on top of the transpile.

## Change
- New `bundle-builder` Docker stage runs esbuild over two entrypoints → `dist/host/main.mjs` + `dist/runtime/main.mjs`: workspace packages bundled in, third-party `node_modules` external (a symlink into pnpm's virtual store gives the bundles a normal ESM resolution path), Claude SDK's native-binary `require.resolve` untouched.
- Image CMD becomes `node dist/host/main.mjs`; `HOUSTON_RUNTIME_COMMAND` becomes `node /app/dist/runtime/main.mjs`.
- `runtimeCommand()` extracted to its own module with explicit resolution order: env override → desktop sidecar binary → bundled sibling runtime → dev tsx fallback. Desktop/dev flows unchanged (+4 unit tests).

## Measured (docker, --cpus=1)
| | tsx (baseline) | bundled |
|---|---|---|
| host boot → /health | 1.62s | **0.55s** |
| first dispatch (runtime child spawn) | 16.4s | 15.8s |

Local numbers understate the prod host-boot win: the laptop has all files on SSD, while prod's ~50s was dominated by image-streaming page-ins that the single-file bundle eliminates. The runtime child's ~16s is dominated by loading its external deps (250MB Claude SDK, pi) — unchanged by bundling by design; that's the follow-up work (eager runtime spawn at pod boot + stripping the Claude SDK from the pod image).

Verified end-to-end on the bundled image: agent create + a runtime-dispatched SSE stream both serve (`: connected`); host+runtime typecheck/tests and biome green. Definitive prod validation: re-run the wake timing experiment after this image deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)