### PR TITLE
fix(app): park the first message for a sleeping pod; scope new-chat drafts per agent (HOU-730)

### DIFF
--- a/app/src/components/board/board-source.ts
+++ b/app/src/components/board/board-source.ts
@@ -90,6 +90,13 @@ export interface BoardSource {
   // ── Panel scope (the agent whose chat features the right panel shows) ─────
   activeAgent: Agent | null;
   activeAgentDef: AgentDefinition | null;
+  /**
+   * Scope for the new-conversation composer draft (HOU-730): the agent id on
+   * the per-agent board (a parked first message must never surface in another
+   * agent's composer), a view constant in Mission Control (one composer whose
+   * draft survives switching the target agent).
+   */
+  draftScope: string;
   selectedSessionKey: string | null;
   selectedAgentPath: string | null;
   /** Called with a new conversation id after the panel creates one (Skill

--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -31,7 +31,7 @@ export function MissionBoard({ source }: { source: BoardSource }) {
   const addToast = useUIStore((s) => s.addToast);
   const queuedLabels = useQueuedMessageLabels();
   const { cardLabels, composerLabels } = useBoardLabels();
-  const { drafts, onDraftChange } = useBoardDrafts();
+  const { drafts, onDraftChange } = useBoardDrafts(source.draftScope);
 
   // Columns: base layout (single source of truth for status→section) plus the
   // Done "archive all" / Needs-you "select all" header actions when the source
@@ -63,6 +63,7 @@ export function MissionBoard({ source }: { source: BoardSource }) {
     agentDef: source.activeAgentDef,
     selectedSessionKey: source.selectedSessionKey,
     onSelectSession: source.onSelectSession,
+    draftScope: source.draftScope,
   });
   const overrides = useMemo(
     () => ({

--- a/app/src/components/board/use-agent-board-source.tsx
+++ b/app/src/components/board/use-agent-board-source.tsx
@@ -155,6 +155,7 @@ export function useAgentBoardSource(
     setHighlightedId,
     activeAgent: agent,
     activeAgentDef: agentDef,
+    draftScope: agent.id,
     selectedSessionKey,
     selectedAgentPath: path,
     onSelectSession: setSelectedId,

--- a/app/src/components/board/use-board-drafts.ts
+++ b/app/src/components/board/use-board-drafts.ts
@@ -1,21 +1,38 @@
 import { useCallback, useMemo } from "react";
-import { useDraftStore } from "../../stores/drafts";
+import {
+  boardDraftsView,
+  NEW_CONVERSATION_KEY,
+  newConversationDraftKey,
+  useDraftStore,
+} from "../../stores/drafts";
 
 /**
  * Composer draft persistence for the board, shared by both views. Exposes the
  * text-only draft map AIBoard expects and a setter that writes back to the
  * draft store, so what the user typed survives navigation between missions.
+ *
+ * AIBoard keys its new-mission composer with the plain "new-conversation"
+ * literal, but the store scopes that draft per agent (HOU-730) — otherwise a
+ * first message parked for a sleeping agent shows up in every other agent's
+ * composer. This hook translates between the two on read and write.
  */
-export function useBoardDrafts() {
+export function useBoardDrafts(newConversationScope?: string | null) {
   const rawDrafts = useDraftStore((s) => s.drafts);
-  const drafts = useMemo(() => {
-    const out: Record<string, string> = {};
-    for (const [key, value] of Object.entries(rawDrafts))
-      if (value.text) out[key] = value.text;
-    return out;
-  }, [rawDrafts]);
-  const onDraftChange = useCallback((sessionKey: string, text: string) => {
-    useDraftStore.getState().setDraftText(sessionKey, text);
-  }, []);
+  const scopedKey = newConversationDraftKey(newConversationScope);
+  const drafts = useMemo(
+    () => boardDraftsView(rawDrafts, scopedKey),
+    [rawDrafts, scopedKey],
+  );
+  const onDraftChange = useCallback(
+    (sessionKey: string, text: string) => {
+      useDraftStore
+        .getState()
+        .setDraftText(
+          sessionKey === NEW_CONVERSATION_KEY ? scopedKey : sessionKey,
+          text,
+        );
+    },
+    [scopedKey],
+  );
   return { drafts, onDraftChange };
 }

--- a/app/src/components/board/use-mission-control-source.tsx
+++ b/app/src/components/board/use-mission-control-source.tsx
@@ -153,6 +153,7 @@ export function useMissionControlSource(
     setHighlightedId,
     activeAgent,
     activeAgentDef,
+    draftScope: "mission-control",
     selectedSessionKey,
     selectedAgentPath,
     onSelectSession: mc.setSelectedId,

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -111,7 +111,8 @@ import {
 } from "../lib/tauri";
 import { normalizeTurnMode, type TurnMode } from "../lib/turn-mode";
 import type { Agent, AgentDefinition, SkillSummary } from "../lib/types";
-import { useDraftStore } from "../stores/drafts";
+import { useAgentProvisioningStore } from "../stores/agent-provisioning";
+import { newConversationDraftKey, useDraftStore } from "../stores/drafts";
 import { useUIStore } from "../stores/ui";
 import { ChatConnectInteractionCard } from "./chat-connect-interaction-card";
 import { resolveEffectiveProvider } from "./chat-effective-provider";
@@ -159,6 +160,9 @@ interface UseAgentChatPanelArgs {
   selectedSessionKey: string | null;
   /** Called with the new conversation id after a Skill's "Start". */
   onSelectSession?: (id: string) => void;
+  /** New-conversation draft scope — must match the board's `useBoardDrafts`
+   *  scope so dictation lands in the composer the user sees (HOU-730). */
+  draftScope?: string;
 }
 
 interface AgentChatPanelProps {
@@ -215,6 +219,7 @@ export function useAgentChatPanel({
   agentDef,
   selectedSessionKey,
   onSelectSession,
+  draftScope,
 }: UseAgentChatPanelArgs): AgentChatPanelProps {
   const { t, i18n } = useTranslation(["board", "chat", "teams"]);
   const { processLabels, getThinkingMessage, thinkingIndicator } =
@@ -231,10 +236,11 @@ export function useAgentChatPanel({
   // ── Dictation (desktop-only voice typing) ──────────────────────────────
   // Transcript text is appended to the SAME draft store AIBoard's
   // `drafts`/`onDraftChange` read from (`useBoardDrafts` in mission-board.tsx)
-  // — the key mirrors AIBoard's own `activeSessionKey ?? "new-conversation"`
-  // derivation, so dictating into a fresh composer lands in the same draft
-  // the user would see if they typed instead.
-  const draftKey = selectedSessionKey ?? "new-conversation";
+  // — the key mirrors the board's own derivation (AIBoard's plain
+  // "new-conversation" translated through `useBoardDrafts`'s scope), so
+  // dictating into a fresh composer lands in the same draft the user would
+  // see if they typed instead.
+  const draftKey = selectedSessionKey ?? newConversationDraftKey(draftScope);
   const handleDictationTranscript = useCallback(
     (text: string) => {
       const current = useDraftStore.getState().drafts[draftKey]?.text ?? "";
@@ -274,6 +280,19 @@ export function useAgentChatPanel({
 
   const path = agent?.folderPath ?? null;
   const agentModes = agentDef?.config.agents;
+
+  // Opening an agent whose hosted pod is scaled to zero (HOU-730): the open
+  // itself starts the wake, but every request is held for the whole cold
+  // start — a first message sent then would hang with no bubble. Detect the
+  // asleep engine now so sends park with the same warming machinery a
+  // just-created agent uses, and flush the moment the pod answers.
+  const agentId = agent?.id ?? null;
+  useEffect(() => {
+    if (!agentId || !path) return;
+    useAgentProvisioningStore
+      .getState()
+      .detectSleepingEngine({ id: agentId, folderPath: path });
+  }, [agentId, path]);
 
   // ── Activity / agent tier model resolution ─────────────────────────────
   // Activity is the per-mission override; agent config is the per-agent

--- a/app/src/lib/agent-provisioning.ts
+++ b/app/src/lib/agent-provisioning.ts
@@ -32,6 +32,43 @@ export const PROVISIONING_RETRY_MS = 3_000;
 export const PROVISIONING_TTL_MS = 10 * 60_000;
 
 /**
+ * How long the asleep-check waits before calling the engine asleep (HOU-730).
+ * An awake engine answers the tiny probe read in well under a second; a pod
+ * scaled to zero is held by the gateway for its whole cold start.
+ */
+export const ASLEEP_DETECT_TIMEOUT_MS = 2_000;
+
+export interface AsleepDetectDeps {
+  /** The same cheap per-agent read the readiness probe uses. */
+  readFile: (agentPath: string, relPath: string) => Promise<unknown>;
+  sleep: (ms: number) => Promise<void>;
+}
+
+/**
+ * One-shot asleep check for an EXISTING agent (HOU-730). A hosted pod scaled
+ * to zero holds every per-agent request for its whole cold start — a first
+ * message sent then hangs with no bubble and dies with a reload. Asleep =
+ * the probe read is still held past the window, or the gateway answered a
+ * warm-up status (502/503/504). A fast transport failure is NOT asleep: the
+ * user's own request should surface the real network error instead of
+ * silently parking messages for an engine that isn't coming.
+ */
+export async function detectEngineAsleep(
+  agentPath: string,
+  deps: AsleepDetectDeps,
+): Promise<boolean> {
+  const attempt = deps.readFile(agentPath, PROVISIONING_PROBE_FILE).then(
+    () => false,
+    (err) => {
+      const status = (err as { status?: unknown } | null)?.status;
+      return status === 502 || status === 503 || status === 504;
+    },
+  );
+  const timer = deps.sleep(ASLEEP_DETECT_TIMEOUT_MS).then(() => true);
+  return Promise.race([attempt, timer]);
+}
+
+/**
  * A message sent while the engine was still warming up. The wire send is NOT
  * fired then (a held request dies with load-balancer timeouts or a reload) —
  * the message shows as a local bubble and the real send fires the moment the

--- a/app/src/stores/agent-provisioning.ts
+++ b/app/src/stores/agent-provisioning.ts
@@ -19,6 +19,7 @@
 
 import { create } from "zustand";
 import {
+  detectEngineAsleep,
   type ProvisioningEntry,
   parsePersistedProvisioning,
   runProvisioningProbe,
@@ -49,6 +50,13 @@ interface AgentProvisioningState {
   sendsVersion: number;
   /** Start tracking a just-created agent (no-op on a co-located engine). */
   markProvisioning: (agent: { id: string; folderPath: string }) => void;
+  /**
+   * Asleep-check an EXISTING agent on open (HOU-730, hosted only): a pod
+   * scaled to zero answers nothing until the gateway wakes it, so mark it
+   * exactly like a just-created agent — sends park with a local bubble and
+   * an optimistic mission row, and flush when the readiness probe clears.
+   */
+  detectSleepingEngine: (agent: { id: string; folderPath: string }) => void;
   /** A rename mid-warm-up moves the agent's id/path; re-key the entry. */
   carryRename: (
     oldId: string,
@@ -101,6 +109,9 @@ function storageWrite(state: Record<string, ProvisioningEntry>): void {
 
 const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
 
+/** Agent ids with an asleep-check in flight — one at a time per agent. */
+const asleepChecks = new Set<string>();
+
 /** Non-reactive read for imperative flows (mission creation). */
 export function isAgentProvisioning(agentId: string): boolean {
   return Boolean(useAgentProvisioningStore.getState().provisioning[agentId]);
@@ -118,6 +129,27 @@ export const useAgentProvisioningStore = create<AgentProvisioningState>(
         agentPath: agent.folderPath,
         since: Date.now(),
       });
+    },
+
+    detectSleepingEngine: (agent) => {
+      if (isCoLocatedEngine()) return;
+      if (get().provisioning[agent.id] || asleepChecks.has(agent.id)) return;
+      asleepChecks.add(agent.id);
+      void detectEngineAsleep(agent.folderPath, {
+        readFile: (agentPath, relPath) =>
+          getEngine().readAgentFile(agentPath, relPath),
+        sleep,
+      })
+        .then((asleep) => {
+          // Re-check: a create/rename may have marked the id while we probed.
+          if (!asleep || get().provisioning[agent.id]) return;
+          startEntry({
+            agentId: agent.id,
+            agentPath: agent.folderPath,
+            since: Date.now(),
+          });
+        })
+        .finally(() => asleepChecks.delete(agent.id));
     },
 
     carryRename: (oldId, agent) => {

--- a/app/src/stores/drafts.ts
+++ b/app/src/stores/drafts.ts
@@ -15,6 +15,37 @@ interface DraftsState {
   clearByPrefix: (prefix: string) => void;
 }
 
+/**
+ * AIBoard's key for the not-yet-created conversation composer. The board
+ * contract keeps the plain literal; the app stores it scoped (below) so one
+ * agent's parked first message never surfaces in another agent's composer.
+ */
+export const NEW_CONVERSATION_KEY = "new-conversation";
+
+/**
+ * Store key for a new-conversation draft, scoped per agent (HOU-730). A
+ * missing scope (Mission Control's cross-agent composer) keeps the plain key.
+ */
+export function newConversationDraftKey(scope?: string | null): string {
+  return scope ? `${NEW_CONVERSATION_KEY}:${scope}` : NEW_CONVERSATION_KEY;
+}
+
+/** The text-only view AIBoard consumes: the view's scoped new-conversation
+ *  draft surfaces under the plain key; every other view's stays hidden. */
+export function boardDraftsView(
+  rawDrafts: Record<string, { text: string }>,
+  scopedKey: string,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(rawDrafts)) {
+    if (!value.text) continue;
+    if (key === scopedKey) out[NEW_CONVERSATION_KEY] = value.text;
+    // Another surface's new-conversation draft: never expose it here.
+    else if (!key.startsWith(NEW_CONVERSATION_KEY)) out[key] = value.text;
+  }
+  return out;
+}
+
 const EMPTY_DRAFT: DraftEntry = { text: "", files: [] };
 const EMPTY_FILES: File[] = [];
 

--- a/app/tests/agent-provisioning.test.ts
+++ b/app/tests/agent-provisioning.test.ts
@@ -1,6 +1,7 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import {
+  detectEngineAsleep,
   PROVISIONING_RETRY_MS,
   PROVISIONING_TTL_MS,
   parsePersistedProvisioning,
@@ -9,6 +10,66 @@ import {
 } from "../src/lib/agent-provisioning.ts";
 
 const httpError = (status: number) => Object.assign(new Error("x"), { status });
+
+describe("detectEngineAsleep (HOU-730)", () => {
+  /** Fast-answering read + a timer that never fires (awake engines win). */
+  const fastDeps = (read: Promise<unknown>) => ({
+    readFile: () => read,
+    sleep: () => new Promise<void>(() => {}),
+  });
+
+  it("awake: the probe answers before the window", async () => {
+    strictEqual(
+      await detectEngineAsleep("/w/a", fastDeps(Promise.resolve("ok"))),
+      false,
+    );
+  });
+
+  it("awake: any definitive HTTP answer means something responded", async () => {
+    strictEqual(
+      await detectEngineAsleep(
+        "/w/a",
+        fastDeps(Promise.reject(httpError(404))),
+      ),
+      false,
+    );
+    strictEqual(
+      await detectEngineAsleep(
+        "/w/a",
+        fastDeps(Promise.reject(httpError(401))),
+      ),
+      false,
+    );
+  });
+
+  it("awake: a fast transport failure is a network problem, not sleep", async () => {
+    strictEqual(
+      await detectEngineAsleep(
+        "/w/a",
+        fastDeps(Promise.reject(new TypeError("fetch failed"))),
+      ),
+      false,
+    );
+  });
+
+  it("asleep: a gateway warm-up status", async () => {
+    strictEqual(
+      await detectEngineAsleep(
+        "/w/a",
+        fastDeps(Promise.reject(httpError(503))),
+      ),
+      true,
+    );
+  });
+
+  it("asleep: the read is held past the detection window", async () => {
+    const deps = {
+      readFile: () => new Promise<unknown>(() => {}),
+      sleep: () => Promise.resolve(),
+    };
+    strictEqual(await detectEngineAsleep("/w/a", deps), true);
+  });
+});
 
 describe("probeSaysStillStarting", () => {
   it("keeps waiting on gateway warm-up statuses", () => {

--- a/app/tests/board-drafts-scope.test.ts
+++ b/app/tests/board-drafts-scope.test.ts
@@ -1,0 +1,51 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  boardDraftsView,
+  newConversationDraftKey,
+} from "../src/stores/drafts.ts";
+
+describe("newConversationDraftKey", () => {
+  it("scopes per agent and keeps the plain key without a scope", () => {
+    strictEqual(newConversationDraftKey("agent-a"), "new-conversation:agent-a");
+    strictEqual(newConversationDraftKey(), "new-conversation");
+    strictEqual(newConversationDraftKey(null), "new-conversation");
+  });
+});
+
+describe("boardDraftsView (HOU-730)", () => {
+  const raw = {
+    "activity-1": { text: "follow-up" },
+    "new-conversation:agent-a": { text: "for A" },
+    "new-conversation:agent-b": { text: "for B" },
+    "new-conversation": { text: "mission control" },
+    empty: { text: "" },
+  };
+
+  it("surfaces only this view's scoped draft under the plain key", () => {
+    deepStrictEqual(boardDraftsView(raw, newConversationDraftKey("agent-a")), {
+      "activity-1": "follow-up",
+      "new-conversation": "for A",
+    });
+  });
+
+  it("never leaks another agent's parked first message", () => {
+    deepStrictEqual(boardDraftsView(raw, newConversationDraftKey("agent-c")), {
+      "activity-1": "follow-up",
+    });
+  });
+
+  it("an unscoped view sees only the unscoped draft", () => {
+    deepStrictEqual(boardDraftsView(raw, newConversationDraftKey()), {
+      "activity-1": "follow-up",
+      "new-conversation": "mission control",
+    });
+  });
+
+  it("session-keyed drafts pass through untouched", () => {
+    deepStrictEqual(
+      boardDraftsView({ "chat-x": { text: "hi" } }, newConversationDraftKey()),
+      { "chat-x": "hi" },
+    );
+  });
+});


### PR DESCRIPTION
Fixes HOU-730.

## Root cause

Two bugs behind one symptom:

1. **Held first message.** Opening a hosted agent whose pod scaled to zero starts the wake, but the gateway holds every per-agent request for the whole cold start. The first message of a new chat went out as a normal wire request (`tauriActivity.create` + `tauriChat.send`), so the composer's await hung for minutes: no user bubble, no mission row, and an infra timeout or reload killed the message. The HOU-693 warming machinery that solves exactly this for **just-created** agents never engaged, because only `markProvisioning` (agent creation) populated the provisioning store.
2. **Cross-agent draft leak.** The new-conversation composer draft was keyed by the global literal `"new-conversation"`. Since the hung send never cleared it, the typed text appeared in every other agent's new-chat composer.

## Fix

- `detectEngineAsleep` (`app/src/lib/agent-provisioning.ts`): one-shot asleep check — the readiness-probe read raced against a 2s window; a gateway 502/503/504 also counts as asleep, while a fast transport failure does not (the user's own request should surface the real network error).
- `detectSleepingEngine` (`app/src/stores/agent-provisioning.ts`): runs the check when an agent is opened (wired in `useAgentChatPanel`, hosted profile only, deduped per agent). An asleep agent is marked exactly like a just-created one, so the existing machinery takes over: sends park with a local bubble, the board shows the optimistic "in progress" mission row, and the readiness probe flushes everything the moment the pod answers.
- New-conversation drafts are stored scoped (`new-conversation:<agentId>` on the per-agent board, a view constant in Mission Control) via `useBoardDrafts` / `newConversationDraftKey`; the `ui/` AIBoard contract keeps its plain literal and the app translates on read/write, so one agent's parked draft can never surface in another agent's composer.

Known limitation: detection runs on agent open. A pod that falls asleep *while* the agent stays open (long idle, then a follow-up) still takes the held-request path; that window is much rarer than the reported open→send flow.

## Repro (before the fix)

1. On the hosted cloud, leave an agent idle until its pod scales to zero.
2. Open that agent, start a new chat, type a message, press Enter.
3. Nothing happens: no bubble, no mission card, Send appears dead.
4. Switch to another agent and open a new chat — the text you typed in step 2 sits in this agent's composer.

## Verify (after the fix)

1. Repeat steps 1–2 above.
2. On send: the message renders immediately as a user bubble, a mission card appears in the Running column, and the composer clears.
3. When the pod finishes waking (tens of seconds), the turn starts and the agent replies; the queued message is delivered exactly once (no doubled bubble).
4. Switch to another agent's new chat: the composer is empty.
5. Regression: create a brand-new agent and message it during warm-up — unchanged HOU-693 behavior (bubble + parked send + flush).

## Tests

- `app/tests/agent-provisioning.test.ts`: `detectEngineAsleep` verdicts (awake fast answer, definitive HTTP answers, fast transport failure ≠ asleep, 503 = asleep, held read = asleep).
- `app/tests/board-drafts-scope.test.ts`: draft-key scoping and the board view mapping (no cross-agent leak, unscoped Mission Control view, pass-through session drafts).
- Gates: `app` 1065 node tests green, workspace-wide `tsgo` clean, web Tauri shim parity OK, Biome clean.