### PR TITLE
perf(host): eagerly spawn the runtime at pod boot (HOUSTON_EAGER_RUNTIME)

### DIFF
--- a/packages/host/src/local/host.test.ts
+++ b/packages/host/src/local/host.test.ts
@@ -45,6 +45,7 @@ async function setup(opts?: {
   gatewayFronted?: boolean;
   credentials?: LocalHostOptions["credentials"];
   spawner?: RuntimeSpawner;
+  eagerRuntime?: boolean;
 }) {
   const workspacesRoot = mkdtempSync(join(tmpdir(), "houston-localhost-"));
   mkdirSync(join(workspacesRoot, "Work", "Sales"), { recursive: true });
@@ -64,6 +65,7 @@ async function setup(opts?: {
     integrations: opts?.integrations,
     gatewayFronted: opts?.gatewayFronted,
     credentials: opts?.credentials,
+    eagerRuntime: opts?.eagerRuntime,
   });
   await host.start();
   return { host, base: `http://127.0.0.1:${port}`, workspacesRoot };
@@ -368,5 +370,51 @@ test("preferences persist via the vfs under the workspace", async () => {
     expect(((await got.json()) as { value: string }).value).toBe("es");
   } finally {
     host.stop();
+  }
+});
+
+test("eagerRuntime spawns the stored agents' runtimes at start, lazily otherwise", async () => {
+  // A real /health endpoint the launcher's poll can succeed against — the
+  // fake spawner hands out its port so ensureAwake completes.
+  const health = createHttpServer((_req, res) => {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end('{"status":"ok"}');
+  });
+  await new Promise<void>((r) => {
+    health.listen(0, "127.0.0.1", () => r());
+  });
+  const healthAddr = health.address();
+  const healthPort =
+    typeof healthAddr === "object" && healthAddr ? healthAddr.port : 0;
+  const spawned: string[] = [];
+  const recordingSpawner: RuntimeSpawner = {
+    spawn: (spec) => {
+      spawned.push(spec.workspaceDir);
+      return { port: healthPort, kill: () => {} };
+    },
+  };
+
+  const eager = await setup({ spawner: recordingSpawner, eagerRuntime: true });
+  try {
+    // Fire-and-forget after listen: poll until the spawn landed.
+    const deadline = Date.now() + 5_000;
+    while (spawned.length === 0 && Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, 25));
+    }
+    expect(spawned).toHaveLength(1);
+    expect(spawned[0]).toContain(join("Work", "Sales"));
+  } finally {
+    eager.host.stop();
+  }
+
+  // Control: without the flag nothing spawns until a dispatch asks.
+  spawned.length = 0;
+  const lazy = await setup({ spawner: recordingSpawner });
+  try {
+    await new Promise((r) => setTimeout(r, 200));
+    expect(spawned).toHaveLength(0);
+  } finally {
+    lazy.host.stop();
+    await new Promise<void>((r) => health.close(() => r()));
   }
 });

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -77,6 +77,15 @@ export interface LocalHostOptions {
   /** Test seam: a fake spawner so the wiring is exercisable without real processes. */
   spawner?: RuntimeSpawner;
   /**
+   * Spawn every stored agent's runtime right after listen instead of on its
+   * first dispatch (managed pods set HOUSTON_EAGER_RUNTIME=1). A woken pod's
+   * runtime boot (~10s — mostly loading the provider SDKs) then overlaps the
+   * wake's volume-attach/readiness window instead of taxing the user's first
+   * message. Leave off for the desktop: spawning every agent's runtime at app
+   * start would burn laptop RAM/CPU on agents that may never be opened.
+   */
+  eagerRuntime?: boolean;
+  /**
    * Path to the Rust-era chat-history db (`~/.houston/db/houston.db`). When set
    * AND the file exists, the host runs the one-time chat-history migration on
    * boot (idempotent, additive — see migrate/chat-history.ts). Omit (or point at
@@ -397,6 +406,26 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
           redactToken: opts.redactBannerToken ?? false,
         }),
       );
+      if (opts.eagerRuntime) {
+        // Fire-and-forget AFTER the banner: /health (and the supervisor)
+        // must never wait on a runtime boot — the point is overlap, and a
+        // runtime that fails here heals exactly like it always has (the
+        // next dispatch retries the spawn). Sequential on purpose: a pod
+        // hosts one agent, and a multi-agent tree shouldn't stampede the
+        // CPU it shares with the boot it is overlapping.
+        void (async () => {
+          for (const ws of await store.listWorkspaces()) {
+            for (const agent of await store.listAgents(ws.id)) {
+              await launcher.ensureAwake(agent).catch((err) => {
+                console.error(
+                  `[local-host] eager runtime spawn failed for ${agent.id} (continuing):`,
+                  err,
+                );
+              });
+            }
+          }
+        })();
+      }
     },
     stop() {
       scheduler.stop();

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -90,6 +90,9 @@ const host = buildLocalHost({
   redactBannerToken:
     !!hostTokenEnv || process.env.HOUSTON_MANAGED_CLOUD === "1",
   runtimeCommand: runtimeCommand(),
+  // Managed pods pre-spawn their agent's runtime at boot so the ~10s runtime
+  // start overlaps the pod wake instead of the user's first message.
+  eagerRuntime: process.env.HOUSTON_EAGER_RUNTIME === "1",
   // The real Tauri app hands over its own product prompt; this is the built-in
   // default so the agent knows how to create Skills/Routines/learnings.
   systemPrompt: process.env.HOUSTON_APP_SYSTEM_PROMPT || houstonSystemPrompt(),

--- a/selfhost/Dockerfile
+++ b/selfhost/Dockerfile
@@ -117,6 +117,7 @@ FROM host-base AS engine-pod
 # and network-policied by the private repo, so the container IS the sandbox —
 # same posture as self-host. "local" = pi's built-in bash + clamped file tools.
 ENV HOUSTON_MANAGED_CLOUD=1 \
-    HOUSTON_CODE_EXECUTION=local
+    HOUSTON_CODE_EXECUTION=local \
+    HOUSTON_EAGER_RUNTIME=1
 
 FROM host-base AS selfhost


### PR DESCRIPTION
Wake-latency plan item #2 (follows #794's bundling). Today "pod Ready" is not "chat ready": the runtime child spawns lazily on the first dispatch, so the user's first message pays the runtime's ~10s boot (dominated by loading the provider SDKs from node_modules — bundling doesn't touch it by design).

## Change
- `buildLocalHost` gains `eagerRuntime`: after `server.listen` + the banner, spawn every stored agent's runtime via the existing `launcher.ensureAwake` — fire-and-forget (readiness never waits on it), sequential (no CPU stampede on multi-agent trees), failures logged and healed by the next dispatch exactly as the lazy path always did.
- Wired from `HOUSTON_EAGER_RUNTIME=1`, set **only** in the engine-pod Docker stage. The desktop keeps lazy spawning — pre-booting every agent's runtime at app start would burn laptop RAM/CPU on agents that may never be opened.
- A pod woken by the gateway overlaps the runtime boot with its volume-attach + readiness window, so by the time the user's message arrives the turn starts immediately.

Interplay with idle scale-to-zero (cloud#57): an eagerly-spawned idle runtime does **not** hold the pod awake — the busy probe reports turns/routine-runs/held requests, not child liveness.

## Verification
New test in `host.test.ts`: with the flag, the stored agent's runtime spawns right after start (fake spawner + real /health for the launcher's poll); without it, nothing spawns until dispatched. Host suite 665 passed, typecheck + biome green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)