### PR TITLE
fix(chat): cloud chats never render empty; local transcript cache survives and stays in sync (HOU-731)

### DIFF
--- a/app/src/components/board/use-agent-board-data.ts
+++ b/app/src/components/board/use-agent-board-data.ts
@@ -5,6 +5,7 @@ import { useCallback, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useActivity,
+  useChatHistory,
   useDeleteActivity,
   useUpdateActivity,
 } from "../../hooks/queries";
@@ -98,6 +99,14 @@ export function useAgentBoardData({
   // SDK). AIBoard only reads `feedItems[activeSessionKey]`, so the
   // single-entry map is the whole contract.
   const activeSessionKey = selectedId ? sessionKeyFor(selectedId) : null;
+  // Live resync (HOU-731): subscribe the open conversation to the
+  // chat-history query key, so a ConversationsChanged event re-reads it and
+  // reseeds the VM (see useChatHistory) — turns written by a teammate,
+  // another device, or a routine repaint without reselecting the mission.
+  useChatHistory(
+    activeSessionKey ? path : undefined,
+    activeSessionKey ?? undefined,
+  );
   const activeFeed = useConversationFeed(path, activeSessionKey);
   const feedItems = useMemo<Record<string, FeedItem[]>>(
     () => (activeSessionKey ? { [activeSessionKey]: activeFeed } : {}),

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -43,6 +43,7 @@ import { useTranslation } from "react-i18next";
 import {
   useActivity,
   useAgentModelChoice,
+  useChatHistory,
   useSetAgentModelChoice,
   useSkills,
 } from "../hooks/queries";
@@ -375,6 +376,13 @@ export function useAgentChatPanel({
   // This conversation's reactive feed — the SDK conversation VM, the app's one
   // turn-state source (history seeded by the adapter on load; live turns
   // folded by the SDK machinery).
+  // Live resync (HOU-731): the chat-history subscription makes a
+  // ConversationsChanged event re-read the open conversation and reseed the
+  // VM, so turns from a teammate / another device / a routine repaint live.
+  useChatHistory(
+    selectedSessionKey && path ? path : undefined,
+    selectedSessionKey ?? undefined,
+  );
   const sessionFeedItems = useConversationFeed(path, selectedSessionKey);
 
   // The live turn state for this conversation, for the pending-interaction

--- a/app/src/hooks/queries/use-conversations.ts
+++ b/app/src/hooks/queries/use-conversations.ts
@@ -31,6 +31,17 @@ export function useAllConversations(agentPaths: string[]) {
   });
 }
 
+/**
+ * Live resync for an OPEN conversation (HOU-731). The transcript renders from
+ * the SDK conversation VM, not from this query's data — but `loadHistory`
+ * seeds that VM (and refreshes the local transcript cache) as a side effect,
+ * so subscribing the open chat to `queryKeys.chatHistory` is what makes the
+ * `ConversationsChanged` → `chatHistoryForAgent` invalidation in
+ * use-agent-invalidation.ts actually repaint it: a turn written by a teammate,
+ * another device, or a routine reaches the open chat without a reselect.
+ * Never refetched on focus/staleness — in hosted mode a background read wakes
+ * the agent's pod; only a real change event (or mount) triggers the read.
+ */
 export function useChatHistory(
   agentPath: string | undefined,
   sessionKey: string | undefined,
@@ -43,5 +54,7 @@ export function useChatHistory(
       return tauriChat.loadHistory(agentPath, sessionKey);
     },
     enabled: !!agentPath && !!sessionKey,
+    staleTime: Number.POSITIVE_INFINITY,
+    refetchOnWindowFocus: false,
   });
 }

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -62,6 +62,7 @@ import { bus, emitEvent, emitLocalEcho } from "./bus";
 import type { ControlPlaneConfig } from "./control-plane";
 import * as controlPlane from "./control-plane";
 import {
+  type CachedFrame,
   conversationCacheScope,
   deleteCachedConversation,
   readCachedConversation,
@@ -87,7 +88,6 @@ import {
 } from "./synthetic";
 import { historyToFeed, isConversationNotFound } from "./translate";
 import {
-  clearConversationVm,
   observeConversation,
   seedConversationVm,
   streamTurn,
@@ -621,6 +621,10 @@ export class HoustonClient {
   async deleteActivity(agentPath: string, id: string): Promise<void> {
     if (this.cp) await controlPlane.deleteActivity(this.cp, agentPath, id);
     else activities.deleteActivity(agentPath, id);
+    // The user deleted the chat — THIS is when its locally cached transcript
+    // goes too (a server 404 alone no longer drops it, HOU-731). Missions
+    // key their conversation `activity-<id>` (see setActivityStatus).
+    if (this.cp) void deleteCachedConversation(agentPath, `activity-${id}`);
     emitLocalEcho("ActivityChanged", { agentPath });
   }
 
@@ -1650,12 +1654,11 @@ export class HoustonClient {
     // let the network read below revalidate whenever it lands. The seed
     // guards in seedConversationVm keep a live or richer VM untouched, so a
     // stale cache can never clobber fresh state.
-    let cacheSeeded = false;
-    if (this.cp && opts.observe !== false) {
-      const cached = await readCachedConversation(agentPath, sessionKey);
-      if (cached && cached.length > 0) {
-        seedConversationVm(agentPath, sessionKey, cached);
-        cacheSeeded = true;
+    let cachedFrames: CachedFrame[] | null = null;
+    if (this.cp) {
+      cachedFrames = await readCachedConversation(agentPath, sessionKey);
+      if (cachedFrames && cachedFrames.length > 0 && opts.observe !== false) {
+        seedConversationVm(agentPath, sessionKey, cachedFrames);
       }
     }
     try {
@@ -1708,11 +1711,16 @@ export class HoustonClient {
       // app's `call()` wrapper toasts it with the Report-bug affordance —
       // returning [] would render a fake empty chat and swallow the error.
       if (isConversationNotFound(err)) {
-        // The server says the conversation is gone: drop the local copy and
-        // clear a cache-seeded VM so no ghost transcript lingers (guarded —
-        // a live turn racing this read keeps its feed).
-        if (this.cp) void deleteCachedConversation(agentPath, sessionKey);
-        if (cacheSeeded) clearConversationVm(agentPath, sessionKey);
+        // A 404 with a locally cached transcript is NOT proof the chat never
+        // existed: an engine pod can answer 404 while its data is lost or not
+        // yet restored (volume recreation, seed self-heal window). The local
+        // copy is the user's only surviving transcript then — serve it and
+        // KEEP it (HOU-731). A truly deleted conversation drops out of the
+        // conversation list, so nothing reopens its cached ghost; the size
+        // cap prunes the orphaned entry eventually.
+        if (cachedFrames && cachedFrames.length > 0) {
+          return cachedFrames as ChatHistoryEntry[];
+        }
         return [];
       }
       throw err;

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -192,42 +192,51 @@ const TRANSIENT_RETRY_DELAYS_MS = [500, 1500];
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
+/**
+ * Wrap a fetch so GET/HEAD attempts ride through a rolling deploy / pod
+ * handoff: transient gateway statuses and network-level drops (connection
+ * refused/reset mid-roll) get two brief blind retries. Writes never
+ * blind-retry — a thrown network error on a POST may have reached the
+ * gateway; the caller decides.
+ */
+export function transientRetryFetch(inner: typeof fetch): typeof fetch {
+  return async (input, init) => {
+    const method = (init?.method ?? "GET").toUpperCase();
+    const retriable = method === "GET" || method === "HEAD";
+    let res: Response | undefined;
+    let failure: unknown;
+    for (let i = 0; ; i++) {
+      failure = undefined;
+      res = undefined;
+      try {
+        res = await inner(input, init);
+      } catch (err) {
+        failure = err;
+      }
+      const transient = res === undefined || TRANSIENT_STATUSES.has(res.status);
+      if (!transient || !retriable || i >= TRANSIENT_RETRY_DELAYS_MS.length) {
+        break;
+      }
+      await sleep(TRANSIENT_RETRY_DELAYS_MS[i]);
+    }
+    if (res === undefined) throw failure;
+    return res;
+  };
+}
+
 async function cpFetch(
   cfg: ControlPlaneConfig,
   path: string,
   init?: RequestInit,
 ): Promise<Response> {
-  const doFetch = gatewayAuthFetch(cfg.token);
-  const attempt = () =>
-    doFetch(`${cfg.baseUrl}${path}`, {
-      ...init,
-      headers: {
-        "Content-Type": "application/json",
-        ...init?.headers,
-      },
-    });
-
-  // Reads retry through the deploy window; writes never blind-retry (a thrown
-  // network error on a POST may have reached the gateway — the caller decides).
-  const method = (init?.method ?? "GET").toUpperCase();
-  const retriable = method === "GET" || method === "HEAD";
-  let res: Response | undefined;
-  let failure: unknown;
-  for (let i = 0; ; i++) {
-    failure = undefined;
-    try {
-      res = await attempt();
-    } catch (err) {
-      failure = err; // network-level: connection refused/reset mid-roll
-    }
-    const transient = res === undefined || TRANSIENT_STATUSES.has(res.status);
-    if (!transient || !retriable || i >= TRANSIENT_RETRY_DELAYS_MS.length) {
-      break;
-    }
-    await sleep(TRANSIENT_RETRY_DELAYS_MS[i]);
-    res = undefined;
-  }
-  if (failure !== undefined || res === undefined) throw failure;
+  const doFetch = transientRetryFetch(gatewayAuthFetch(cfg.token));
+  const res = await doFetch(`${cfg.baseUrl}${path}`, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...init?.headers,
+    },
+  });
   if (!res.ok) {
     // Surface the real failure (auth, not-found, server) — never swallow.
     const body = await res.json().catch(() => ({}));
@@ -441,9 +450,12 @@ export function runtimeClientFor(
   // Auth rides gatewayAuthFetch, never a pinned token: these clients back
   // long-lived turn streams, whose reconnects must present the CURRENT bearer
   // (and refresh it on 401) or a gateway roll kills the turn (HOU-687).
+  // Reads additionally bridge transient gateway 5xx (rolling deploy, pod
+  // handoff) like every cpFetch read does — without it a history load hit
+  // mid-roll threw once and the chat rendered empty until reselected (HOU-731).
   return new HoustonEngineClient({
     baseUrl: `${cfg.baseUrl}/agents/${encodeURIComponent(agentId)}`,
-    fetch: gatewayAuthFetch(cfg.token),
+    fetch: transientRetryFetch(gatewayAuthFetch(cfg.token)),
   });
 }
 

--- a/packages/web/src/engine-adapter/turn-stream.ts
+++ b/packages/web/src/engine-adapter/turn-stream.ts
@@ -108,21 +108,6 @@ export function seedConversationVm(
 }
 
 /**
- * Empty a conversation's VM — the cache-seeded-then-404 cleanup (HOU-712): the
- * server says the conversation is gone, so a transcript painted from the local
- * cache must not linger. Guarded like a seed: a live turn or observer owns its
- * VM (its feed IS the conversation — e.g. a first send racing the history read
- * that 404s because no turn has persisted yet), so never wipe under it.
- */
-export function clearConversationVm(
-  agentPath: string,
-  sessionKey: string,
-): void {
-  if (registry.get(streamKey(agentPath, sessionKey))) return;
-  conversationVm.seedHistory(agentPath, sessionKey, []);
-}
-
-/**
  * Show a user's message in the conversation VM BEFORE any turn exists — the
  * warming-engine send queue (HOU-693): the message is held client-side until
  * the just-created agent's engine answers, but the user must see it as sent

--- a/packages/web/tests/chat-history-cache.test.ts
+++ b/packages/web/tests/chat-history-cache.test.ts
@@ -14,8 +14,10 @@ import { conversationStore } from "../src/engine-adapter/vm";
  * loadChatHistory × the local conversation cache (HOU-712): opening a cloud
  * chat paints the VM from the cached transcript IMMEDIATELY — even while the
  * gateway holds the history read for an engine-pod cold start — and every
- * successful read refreshes the cache. A 404 (conversation gone) drops both
- * the cache entry and the cache-seeded VM.
+ * successful read refreshes the cache. A 404 with a cached transcript KEEPS
+ * and serves the local copy (HOU-731): the pod may have lost or not yet
+ * restored its data, and the cache is the user's only surviving transcript.
+ * Deleting the chat (user intent) is what drops the cache entry.
  */
 
 function memoryBackend() {
@@ -158,7 +160,7 @@ test("a successful read refreshes the cache and reseeds the VM", async () => {
   });
 });
 
-test("a 404 drops the cache entry and clears the cache-seeded VM", async () => {
+test("a 404 with a cached transcript keeps and serves the local copy", async () => {
   const agentPath = "Ws/Agent";
   const sessionKey = `gone-${convSeq++}`;
   const client = cloudClient();
@@ -168,8 +170,37 @@ test("a 404 drops the cache entry and clears the cache-seeded VM", async () => {
   ) as unknown as typeof fetch;
 
   const feed = await client.loadChatHistory(agentPath, sessionKey);
+  // The local copy is the answer AND stays painted + persisted: a pod that
+  // lost (or hasn't restored) its data must never erase the user's transcript.
+  expect(feed).toEqual(CACHED);
+  expect(vmFeed(agentPath, sessionKey)).toEqual(CACHED);
+  expect((await store.backend.keysOldestFirst()).length).toBe(1);
+});
+
+test("a 404 with no cached transcript is an empty conversation", async () => {
+  const agentPath = "Ws/Agent";
+  const sessionKey = `fresh-404-${convSeq++}`;
+  const client = cloudClient();
+  globalThis.fetch = vi.fn(async () =>
+    json(404, { error: "not found" }),
+  ) as unknown as typeof fetch;
+
+  const feed = await client.loadChatHistory(agentPath, sessionKey);
   expect(feed).toEqual([]);
   expect(vmFeed(agentPath, sessionKey)).toEqual([]);
+});
+
+test("deleting the chat drops its cached transcript", async () => {
+  const agentPath = "Ws/Agent";
+  const activityId = `act-${convSeq++}`;
+  const sessionKey = `activity-${activityId}`;
+  const client = cloudClient();
+  await seedCache(agentPath, sessionKey);
+  globalThis.fetch = vi.fn(async () =>
+    json(200, { ok: true }),
+  ) as unknown as typeof fetch;
+
+  await client.deleteActivity(agentPath, activityId);
   await vi.waitFor(async () => {
     expect(await store.backend.keysOldestFirst()).toEqual([]);
   });

--- a/packages/web/tests/transient-retry-fetch.test.ts
+++ b/packages/web/tests/transient-retry-fetch.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, expect, test, vi } from "vitest";
+import {
+  runtimeClientFor,
+  transientRetryFetch,
+} from "../src/engine-adapter/control-plane";
+
+/**
+ * transientRetryFetch (HOU-731): reads bridge a rolling gateway deploy / pod
+ * handoff (transient 5xx, network-level drops) with two brief blind retries,
+ * so a history load hit mid-roll resolves instead of rendering an empty chat.
+ * Writes never blind-retry.
+ */
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.useRealTimers();
+});
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+test("a GET rides through transient 503s and resolves", async () => {
+  vi.useFakeTimers();
+  const inner = vi
+    .fn<typeof fetch>()
+    .mockResolvedValueOnce(json(503, { error: "rolling" }))
+    .mockResolvedValueOnce(json(503, { error: "rolling" }))
+    .mockResolvedValueOnce(json(200, { ok: true }));
+  const doFetch = transientRetryFetch(inner);
+
+  const pending = doFetch("https://gw.example/x");
+  await vi.advanceTimersByTimeAsync(500 + 1500);
+  const res = await pending;
+  expect(res.status).toBe(200);
+  expect(inner).toHaveBeenCalledTimes(3);
+});
+
+test("a GET that keeps failing surfaces the last transient answer", async () => {
+  vi.useFakeTimers();
+  const inner = vi
+    .fn<typeof fetch>()
+    .mockResolvedValue(json(503, { error: "down" }));
+  const doFetch = transientRetryFetch(inner);
+
+  const pending = doFetch("https://gw.example/x");
+  await vi.advanceTimersByTimeAsync(500 + 1500);
+  const res = await pending;
+  expect(res.status).toBe(503);
+  expect(inner).toHaveBeenCalledTimes(3);
+});
+
+test("a network-level drop on a GET retries and can recover", async () => {
+  vi.useFakeTimers();
+  const inner = vi
+    .fn<typeof fetch>()
+    .mockRejectedValueOnce(new TypeError("connection reset"))
+    .mockResolvedValueOnce(json(200, { ok: true }));
+  const doFetch = transientRetryFetch(inner);
+
+  const pending = doFetch("https://gw.example/x");
+  await vi.advanceTimersByTimeAsync(500);
+  const res = await pending;
+  expect(res.status).toBe(200);
+  expect(inner).toHaveBeenCalledTimes(2);
+});
+
+test("a POST never blind-retries", async () => {
+  const inner = vi
+    .fn<typeof fetch>()
+    .mockResolvedValue(json(503, { error: "rolling" }));
+  const doFetch = transientRetryFetch(inner);
+
+  const res = await doFetch("https://gw.example/x", { method: "POST" });
+  expect(res.status).toBe(503);
+  expect(inner).toHaveBeenCalledTimes(1);
+});
+
+test("runtimeClientFor's history read bridges a transient 503", async () => {
+  vi.useFakeTimers();
+  let calls = 0;
+  globalThis.fetch = vi.fn(async () => {
+    calls++;
+    if (calls === 1) return json(503, { error: "pod handoff" });
+    return json(200, { id: "s1", title: "t", messages: [] });
+  }) as unknown as typeof fetch;
+
+  const engine = runtimeClientFor(
+    { baseUrl: "https://gw.example", token: "tok" },
+    "agent-1",
+  );
+  const pending = engine.getHistory("s1");
+  await vi.advanceTimersByTimeAsync(500);
+  const history = await pending;
+  expect(history.messages).toEqual([]);
+  expect(calls).toBe(2);
+});

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -369,7 +369,16 @@ export function AIBoard({
       hydratedKeys.current.add(sk);
       onLoadHistory(sk)
         .then((h) => {
-          if (h.length > 0) onHistoryLoaded?.(sk, h);
+          if (h.length > 0) {
+            onHistoryLoaded?.(sk, h);
+          } else {
+            // An empty load is not proof the chat is empty: the loader
+            // resolves [] while the agent's engine is still warming, or when
+            // the server hasn't restored the conversation yet. Un-mark so the
+            // next selection retries instead of pinning the chat empty until
+            // remount; a genuinely empty chat just re-runs a cheap read.
+            hydratedKeys.current.delete(sk);
+          }
         })
         .catch((err) => {
           // Un-mark the session so re-selecting the conversation retries the


### PR DESCRIPTION
## Problem (HOU-731)

On the desktop app connected to the cloud gateway, some chats render empty even though their messages exist on the engine pod. Some populate after a while (pod cold start resolving), others never do.

Verified against prod: the affected agents' conversation files on their pods are intact — the messages exist server-side. The loss is entirely in the client's loading path. (The previously shipped runtime fix for the stalled-provider/workdir-lock bug is present on the pods; the local conversation cache work has not shipped in any tagged desktop release yet, which is why prod shows the raw cold-start blank.)

## Root causes fixed here

1. **A 404 destroyed the user's local transcript.** `loadChatHistory` treated any 404 as "conversation deleted": it deleted the IndexedDB cache entry and blanked the seeded VM. But a pod can answer 404 while its data is lost or not yet restored (volume recreation, seed self-heal window) — the local copy is the user's only surviving transcript at that moment. Now: a 404 with a cached transcript serves and KEEPS the local copy. The cache entry is dropped when the user deletes the chat (`deleteActivity`), which is the actual intent signal.
2. **History reads had no transient-5xx bridge.** `runtimeClientFor` (the `GET /conversations/:id/messages` path) used the bare auth fetch, unlike `cpFetch` which retries 502/503/504 reads through a rolling deploy / pod handoff. A read hit mid-roll threw once and the chat stayed empty until reselected. Reads now go through a shared `transientRetryFetch` (writes still never blind-retry).
3. **An empty resolve permanently marked the session hydrated.** `ai-board` marks a session hydrated before the load resolves and only un-marked it on *rejection*. A load that resolved `[]` (agent still warming, pod data not yet restored) pinned the chat empty until remount. An empty resolve now un-marks, so the next selection retries; a genuinely empty chat just re-runs a cheap read.
4. **The live-resync invalidation targeted a query nothing mounted.** `ConversationsChanged` invalidates the `chat-history` key "so a teammate's turn reaches an open chat live" — but no component subscribed to that key, so it was dead. The open conversation (agent board + chat panel) now mounts `useChatHistory`, whose `loadHistory` reseeds the VM and refreshes the local cache; turns written by a teammate, another device, or a routine repaint without a reselect. `staleTime: Infinity` + no focus refetch keeps it from waking pods in the background — only real change events (or mount) trigger the read.

Together with the existing cache-first paint, this gives the requested invariant: the conversation is always available locally, painted instantly on open, revalidated by the network, kept in sync by change events, and never erased by a server that is temporarily missing data.

## Tests

- `packages/web/tests/chat-history-cache.test.ts`: 404-with-cache keeps + serves the local copy; 404-without-cache is an empty conversation; deleting the chat drops its cached transcript (6 tests).
- `packages/web/tests/transient-retry-fetch.test.ts` (new): GET rides through 503s and network drops; exhausted retries surface the last answer; POST never blind-retries; `runtimeClientFor().getHistory` bridges a 503 (5 tests).
- Full suites green: `houston-web` vitest (115), app node tests (1055), ui/board tests + typecheck, workspace-wide `tsgo`, Biome, `check:boundaries`.

## Repro (before)

1. Sign into the desktop app against the cloud gateway; open a chat with history on an agent whose pod is asleep → blank transcript for the whole cold start (minutes); if the read dies mid gateway roll, it stays blank until you reselect the mission.
2. Simulate pod data loss (or catch a pod before seed restore) → opening the chat 404s, and the locally cached transcript is *deleted* — the chat is empty forever even locally.
3. Have another device/teammate send a turn into a chat you keep open → it never appears until you reselect.

## Verify (after)

1. Open a previously viewed chat on a sleeping agent → transcript paints instantly from the local cache, then revalidates when the pod wakes.
2. With the pod answering 404 for that conversation, the chat still shows the cached transcript, and the cache entry survives (IndexedDB `houston-conversation-cache`); deleting the chat removes it.
3. Kill a gateway replica / roll a deploy while opening a chat → the read retries through the 503 window and resolves instead of blanking.
4. Send a turn from a second client into an open chat → it appears without reselecting.