### PR TITLE
feat(app): wake-on-intent — hovering a cloud agent pre-wakes its pod

### DIFF
--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -12,6 +12,7 @@ import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
 import { useCanCreateAgents } from "../../hooks/use-can-create-agents";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { useSidebarLayout } from "../../hooks/use-sidebar-layout";
+import { prewakeAgent } from "../../lib/agent-prewake";
 import { resolveAutoCollapse } from "../../lib/sidebar-auto-collapse";
 import { isTopLevelView } from "../../lib/top-level-views";
 import { useAgentStore } from "../../stores/agents";
@@ -192,6 +193,12 @@ export function Sidebar({ children }: { children: ReactNode }) {
           onMoveGroup={sidebar.moveGroup}
           selectedId={!isTopLevel ? (currentAgent?.id ?? null) : null}
           onSelect={handleSelectAgent}
+          onItemHover={(agentId) => {
+            // Wake-on-intent: hovering a sleeping cloud agent starts its pod
+            // wake so the click-and-type that usually follows lands warm.
+            const agent = agents.find((a) => a.id === agentId);
+            if (agent) prewakeAgent(agent);
+          }}
           onAdd={canCreateAgents ? () => setDialogOpen(true) : undefined}
           addItemDataAttrs={{ "data-tour-target": "newAgent" }}
           onRename={handleRename}

--- a/app/src/lib/agent-prewake.ts
+++ b/app/src/lib/agent-prewake.ts
@@ -1,0 +1,28 @@
+import { PROVISIONING_PROBE_FILE } from "./agent-provisioning";
+import { getEngine, isCoLocatedEngine } from "./engine";
+
+/**
+ * Wake-on-intent: hovering (or selecting) a cloud agent fires one cheap
+ * fire-and-forget read through the gateway, which scales the agent's sleeping
+ * pod back up (any /agents/:id request wakes it). By the time the user has
+ * clicked and typed a message, the ~13s wake has largely already happened.
+ *
+ * The read is the same side-effect-free probe file the provisioning system
+ * polls, and the result is thrown away — a failure means nothing here (the
+ * chat panel's own asleep-detection remains the source of truth). Deduped per
+ * agent so hovering a list never floods the gateway: one attempt per agent
+ * per TTL window at most.
+ */
+const attempted = new Map<string, number>();
+const PREWAKE_TTL_MS = 60_000;
+
+export function prewakeAgent(agent: { id: string; folderPath: string }): void {
+  if (isCoLocatedEngine()) return; // local engines don't sleep
+  const now = Date.now();
+  const last = attempted.get(agent.id);
+  if (last !== undefined && now - last < PREWAKE_TTL_MS) return;
+  attempted.set(agent.id, now);
+  void getEngine()
+    .readAgentFile(agent.folderPath, PROVISIONING_PROBE_FILE)
+    .catch(() => {}); // intent signal only — the wake either lands or the panel's probe retries
+}

--- a/ui/layout/src/sidebar-collapsed-item.tsx
+++ b/ui/layout/src/sidebar-collapsed-item.tsx
@@ -17,6 +17,8 @@ export interface SidebarCollapsedItemProps {
   editValue: string;
   hasMenu: boolean;
   onSelect: (id: string) => void;
+  /** Pointer entered the row (see SidebarRowContext.onItemHover). */
+  onHover?: (id: string) => void;
   onKeyDown: (e: KeyboardEvent, id: string) => void;
   onEditChange: (value: string) => void;
   onCommitRename: (id: string) => void;
@@ -39,6 +41,7 @@ export function SidebarCollapsedItem({
   editValue,
   hasMenu,
   onSelect,
+  onHover,
   onKeyDown,
   onEditChange,
   onCommitRename,
@@ -81,6 +84,7 @@ export function SidebarCollapsedItem({
           editValue={editValue}
           hasMenu={hasMenu}
           onSelect={onSelect}
+          onHover={onHover}
           onKeyDown={onKeyDown}
           onEditChange={onEditChange}
           onCommitRename={onCommitRename}

--- a/ui/layout/src/sidebar-flat-list.tsx
+++ b/ui/layout/src/sidebar-flat-list.tsx
@@ -42,6 +42,7 @@ export function SidebarFlatList({
             editValue={ctx.editValue}
             hasMenu={ctx.hasDefaultMenu || !!item.menuContent}
             onSelect={ctx.onSelect}
+            onHover={ctx.onItemHover}
             onKeyDown={ctx.onItemKeyDown}
             onEditChange={ctx.onEditChange}
             onCommitRename={ctx.onCommitRename}
@@ -84,6 +85,7 @@ export function SidebarFlatList({
           editValue={ctx.editValue}
           hasMenu={ctx.hasDefaultMenu || !!item.menuContent}
           onSelect={ctx.onSelect}
+          onHover={ctx.onItemHover}
           onKeyDown={ctx.onItemKeyDown}
           onEditChange={ctx.onEditChange}
           onCommitRename={ctx.onCommitRename}

--- a/ui/layout/src/sidebar-group-section.tsx
+++ b/ui/layout/src/sidebar-group-section.tsx
@@ -20,6 +20,9 @@ export interface SidebarRowContext {
   editValue: string;
   hasDefaultMenu: boolean;
   onSelect: (id: string) => void;
+  /** Pointer entered an item row — an intent signal (e.g. pre-wake the agent
+   *  behind it) that must never affect selection or focus. */
+  onItemHover?: (id: string) => void;
   onItemKeyDown: (e: KeyboardEvent, id: string) => void;
   onEditChange: (value: string) => void;
   onCommitRename: (id: string) => void;

--- a/ui/layout/src/sidebar-item-row.tsx
+++ b/ui/layout/src/sidebar-item-row.tsx
@@ -29,6 +29,8 @@ export interface SidebarItemRowProps {
   editValue: string;
   hasMenu: boolean;
   onSelect: (id: string) => void;
+  /** Pointer entered the row (see SidebarRowContext.onItemHover). */
+  onHover?: (id: string) => void;
   onKeyDown: (e: KeyboardEvent, id: string) => void;
   onEditChange: (value: string) => void;
   onCommitRename: (id: string) => void;
@@ -45,6 +47,7 @@ export function SidebarItemRow({
   editValue,
   hasMenu,
   onSelect,
+  onHover,
   onKeyDown,
   onEditChange,
   onCommitRename,
@@ -68,6 +71,7 @@ export function SidebarItemRow({
 
   return (
     <div
+      onPointerEnter={onHover ? () => onHover(item.id) : undefined}
       className={cn(
         sidebarItemRowClasses.root,
         isActive ? "bg-accent" : "hover:bg-accent/50",

--- a/ui/layout/src/sidebar-sortable-row.tsx
+++ b/ui/layout/src/sidebar-sortable-row.tsx
@@ -54,6 +54,7 @@ export function SidebarSortableRow({
         editValue={ctx.editValue}
         hasMenu={ctx.hasDefaultMenu || !!item.menuContent}
         onSelect={ctx.onSelect}
+        onHover={ctx.onItemHover}
         onKeyDown={ctx.onItemKeyDown}
         onEditChange={ctx.onEditChange}
         onCommitRename={ctx.onCommitRename}

--- a/ui/layout/src/sidebar.tsx
+++ b/ui/layout/src/sidebar.tsx
@@ -53,6 +53,8 @@ export interface SidebarProps {
   items: SidebarItem[];
   selectedId?: string | null;
   onSelect: (id: string) => void;
+  /** Pointer entered an item row — intent signal, never selection. */
+  onItemHover?: (id: string) => void;
   onAdd?: () => void;
   /** Extra DOM attributes (e.g. `data-tour-target`) on the add-item button. */
   addItemDataAttrs?: Record<string, string>;
@@ -130,6 +132,7 @@ export function AppSidebar({
   items,
   selectedId,
   onSelect,
+  onItemHover,
   onAdd,
   addItemDataAttrs,
   onDelete,
@@ -183,6 +186,7 @@ export function AppSidebar({
     editValue,
     hasDefaultMenu,
     onSelect,
+    onItemHover,
     onItemKeyDown: handleKeyDown,
     onEditChange: setEditValue,
     onCommitRename: commitRename,


### PR DESCRIPTION
Final item from the wake-latency plan (after houston#794 bundling, #796 eager runtime, cloud#61 fast probe): hide the remaining ~13s wake behind the user's own motions.

## Behavior
Opening a sleeping agent's chat already starts the wake (the HOU-730 asleep-probe read) and #795 parks the first message — but the wake only begins once the panel mounts, so the user still watches the warming state. Hover precedes nearly every selection: pointer-entering an agent row in the sidebar now fires a fire-and-forget pre-wake, so the pod is booting while the user clicks and types. In the common flow the send lands on a warm pod and the parked-message state barely appears.

## Change
- **ui/layout**: `SidebarProps` / row context gain an optional `onItemHover(id)` intent hook, threaded to every rendered item row (flat, sortable, collapsed rail) as `pointerenter` on the row root. Purely an intent signal — no effect on selection, focus, or keyboard flows; undefined = zero behavior change for other consumers.
- **app**: `prewakeAgent()` reuses the provisioning system's side-effect-free probe read (`.houston/config/config.json`) through the gateway — any `/agents/:id` request wakes the pod. Guarded off co-located (local) engines, deduped to one attempt per agent per 60s so sweeping the pointer down the sidebar can't flood the gateway, and the result is discarded: the chat panel's asleep detection + message parking remain the source of truth.

## Verification
app + ui/layout typecheck clean, app test suite green (incl. the provisioning/warming suites this composes with), biome clean, monorepo pre-commit typecheck green. Manual check after deploy: hover a sleeping agent in the sidebar → its Deployment scales 0→1 within a second (`kubectl get deploy -n houston-o-<org> -w`), and idle-sleep reclaims it 15 min later if never opened (hover stamps the activity clock via the probe dispatch, same as any request).

🤖 Generated with [Claude Code](https://claude.com/claude-code)