### PR TITLE
feat(skills): post-install skill translation offer, machine or AI (HOU-733)

### DIFF
--- a/app/src/components/tabs/agent-admin/agent-admin-skills.tsx
+++ b/app/src/components/tabs/agent-admin/agent-admin-skills.tsx
@@ -1,4 +1,5 @@
 import { SkillDetailPage } from "@houston-ai/skills";
+import { SkillTranslateDialog } from "../skill-translate-dialog";
 import { SkillsContent } from "../skills-content";
 import { useSkillSurface } from "../use-skill-surface";
 import type { AgentAdminScreenProps } from "./agent-admin-nav.ts";
@@ -37,6 +38,14 @@ export function AgentAdminSkills({ agent }: AgentAdminScreenProps) {
         onInstallFromRepo={surface.handleInstallFromRepo}
         onCreateFromScratch={surface.handleCreateFromScratch}
         installedSkillNames={surface.installedSkillNames}
+      />
+      <SkillTranslateDialog
+        open={surface.translateOffer.length > 0}
+        count={surface.translateOffer.length}
+        languageName={surface.translateLanguageName}
+        busy={surface.translating}
+        onChoose={surface.handleTranslateChoose}
+        onDismiss={surface.dismissTranslate}
       />
     </div>
   );

--- a/app/src/components/tabs/skill-translate-dialog.tsx
+++ b/app/src/components/tabs/skill-translate-dialog.tsx
@@ -1,0 +1,93 @@
+import {
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+  Spinner,
+} from "@houston-ai/core";
+import { Languages, Sparkles, Zap } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import type { SkillTranslateMode } from "../../lib/types";
+
+interface SkillTranslateDialogProps {
+  open: boolean;
+  /** How many skills the just-finished install added. */
+  count: number;
+  /** The app locale's own display name ("español", "português"). */
+  languageName: string;
+  /** A translation run is in flight; options disable and the dialog holds. */
+  busy: boolean;
+  onChoose: (mode: SkillTranslateMode) => void;
+  onDismiss: () => void;
+}
+
+const OPTIONS = [
+  { mode: "machine", Icon: Zap, key: "quick" },
+  { mode: "ai", Icon: Sparkles, key: "ai" },
+] as const;
+
+/**
+ * Post-install translation offer (HOU-733): when the app runs in es/pt and
+ * the user installs a marketplace/repo skill, offer to translate the
+ * installed SKILL.md into the app language. Two ways in, both explicit:
+ * a quick machine pass (free, rough) or an AI pass with the user's own
+ * provider (better, slower). Dismissing keeps the original untouched.
+ */
+export function SkillTranslateDialog({
+  open,
+  count,
+  languageName,
+  busy,
+  onChoose,
+  onDismiss,
+}: SkillTranslateDialogProps) {
+  const { t } = useTranslation("skills");
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && !busy && onDismiss()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogTitle className="flex items-center gap-2">
+          <Languages className="size-4 text-muted-foreground" />
+          {t("translate.title", { language: languageName })}
+        </DialogTitle>
+        <DialogDescription>
+          {t("translate.description", { count, language: languageName })}
+        </DialogDescription>
+        <div className="flex flex-col gap-2">
+          {OPTIONS.map(({ mode, Icon, key }) => (
+            <button
+              key={mode}
+              type="button"
+              disabled={busy}
+              onClick={() => onChoose(mode)}
+              className="flex items-start gap-3 rounded-lg border p-3 text-left transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-50"
+            >
+              <Icon className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+              <span>
+                <span className="block text-sm font-medium">
+                  {t(`translate.${key}.title`)}
+                </span>
+                <span className="block text-xs text-muted-foreground">
+                  {t(`translate.${key}.description`)}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+        <DialogFooter>
+          {busy ? (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Spinner className="size-3.5" />
+              {t("translate.inProgress")}
+            </div>
+          ) : (
+            <Button variant="ghost" onClick={onDismiss}>
+              {t("translate.keep")}
+            </Button>
+          )}
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/tabs/use-skill-surface.ts
+++ b/app/src/components/tabs/use-skill-surface.ts
@@ -11,16 +11,19 @@ import {
   useSaveSkill,
   useSkillDetail,
   useSkills,
+  useTranslateSkill,
 } from "../../hooks/queries";
+import { normalizeLocale } from "../../lib/locale";
 import { isMissingSkillError } from "../../lib/missing-skill";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriSkills } from "../../lib/tauri";
+import type { SkillTranslateMode } from "../../lib/types";
 import { useUIStore } from "../../stores/ui";
 import { resolveLoadingSkillName } from "./skill-loading-model";
 import { useSkillSurfaceLabels } from "./use-skill-surface-labels";
 
 export function useSkillSurface(agentPath: string) {
-  const { t } = useTranslation("skills");
+  const { t, i18n } = useTranslation("skills");
   const queryClient = useQueryClient();
   const addToast = useUIStore((s) => s.addToast);
   const { skillDetailLabels } = useSkillSurfaceLabels();
@@ -31,9 +34,15 @@ export function useSkillSurface(agentPath: string) {
   // Render-time reset on agent switch — a useEffect would race the
   // auto-toast in `call()` because the stale-name fetch starts first.
   const [prevAgentPath, setPrevAgentPath] = useState(agentPath);
+  // The post-install translate offer (HOU-733): slugs the last install added,
+  // pending the user's choice. Only set when the app runs in a non-English
+  // locale — an English app installing an English skill has nothing to offer.
+  const [translateOffer, setTranslateOffer] = useState<string[]>([]);
+  const [translating, setTranslating] = useState(false);
   if (agentPath !== prevAgentPath) {
     setPrevAgentPath(agentPath);
     setSelectedSkillName(null);
+    setTranslateOffer([]);
   }
   const {
     data: skillDetail,
@@ -131,14 +140,95 @@ export function useSkillSurface(agentPath: string) {
     [agentPath],
   );
 
+  // The app locale a just-installed skill would translate INTO. English apps
+  // never see the offer: marketplace skills are overwhelmingly English, and
+  // detecting a foreign-language install reliably isn't worth a wrong prompt.
+  const translateTarget = normalizeLocale(i18n.language);
+  const translateLanguageName = useMemo(
+    () =>
+      translateTarget
+        ? (new Intl.DisplayNames([translateTarget], { type: "language" }).of(
+            translateTarget,
+          ) ?? translateTarget)
+        : "",
+    [translateTarget],
+  );
+  const offerTranslation = useCallback(
+    (slugs: string[]) => {
+      const clean = slugs.filter((s) => s.trim());
+      if (!translateTarget || translateTarget === "en" || !clean.length) return;
+      setTranslateOffer(clean);
+    },
+    [translateTarget],
+  );
+
+  const translateSkill = useTranslateSkill(agentPath);
+  const handleTranslateChoose = useCallback(
+    async (mode: SkillTranslateMode) => {
+      if (!translateTarget || translating) return;
+      setTranslating(true);
+      try {
+        const results = await Promise.allSettled(
+          translateOffer.map((slug) =>
+            translateSkill.mutateAsync({
+              name: slug,
+              target: translateTarget,
+              mode,
+            }),
+          ),
+        );
+        const failed = translateOffer.filter(
+          (_, i) => results[i]?.status === "rejected",
+        );
+        if (failed.length === 0) {
+          addToast({
+            title: t("translate.doneToast.title", {
+              count: translateOffer.length,
+            }),
+            description: t("translate.doneToast.description", {
+              count: translateOffer.length,
+            }),
+            variant: "info",
+          });
+          setTranslateOffer([]);
+          return;
+        }
+        // The host answers with a readable reason (provider not connected,
+        // translation service busy, …) — surface it, don't genericize. Keep
+        // only the FAILED slugs pending, so retrying never re-translates a
+        // skill that already succeeded.
+        const first = results.find(
+          (r): r is PromiseRejectedResult => r.status === "rejected",
+        );
+        addToast({
+          title: t("translate.errorToast.title"),
+          description:
+            first?.reason instanceof Error
+              ? first.reason.message
+              : String(first?.reason),
+          variant: "error",
+        });
+        setTranslateOffer(failed);
+      } finally {
+        setTranslating(false);
+      }
+    },
+    [translateOffer, translateTarget, translating, translateSkill, addToast, t],
+  );
+
+  const dismissTranslate = useCallback(() => setTranslateOffer([]), []);
+
   const handleInstallCommunity = useCallback(
-    async (skill: CommunitySkill, signal?: AbortSignal) =>
-      installCommunity.mutateAsync({
+    async (skill: CommunitySkill, signal?: AbortSignal) => {
+      const slug = await installCommunity.mutateAsync({
         source: skill.source,
         skillId: skill.skillId,
         signal,
-      }),
-    [installCommunity],
+      });
+      offerTranslation([slug]);
+      return slug;
+    },
+    [installCommunity, offerTranslation],
   );
 
   const handleListFromRepo = useCallback(
@@ -147,9 +237,12 @@ export function useSkillSurface(agentPath: string) {
   );
 
   const handleInstallFromRepo = useCallback(
-    async (source: string, skills: RepoSkill[]) =>
-      installFromRepo.mutateAsync({ source, skills }),
-    [installFromRepo],
+    async (source: string, skills: RepoSkill[]) => {
+      const slugs = await installFromRepo.mutateAsync({ source, skills });
+      offerTranslation(slugs);
+      return slugs;
+    },
+    [installFromRepo, offerTranslation],
   );
 
   const handleCreateFromScratch = useCallback(
@@ -177,5 +270,11 @@ export function useSkillSurface(agentPath: string) {
     handleInstallFromRepo,
     handleCreateFromScratch,
     installedSkillNames,
+    // Post-install translate offer (HOU-733).
+    translateOffer,
+    translating,
+    translateLanguageName,
+    handleTranslateChoose,
+    dismissTranslate,
   };
 }

--- a/app/src/hooks/queries/index.ts
+++ b/app/src/hooks/queries/index.ts
@@ -71,4 +71,5 @@ export {
   useSaveSkill,
   useSkillDetail,
   useSkills,
+  useTranslateSkill,
 } from "./use-skills";

--- a/app/src/hooks/queries/use-skills.ts
+++ b/app/src/hooks/queries/use-skills.ts
@@ -1,7 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "../../lib/query-keys";
 import { tauriSkills } from "../../lib/tauri";
-import type { RepoSkill } from "../../lib/types";
+import type { RepoSkill, SkillTranslateMode } from "../../lib/types";
 
 export function useSkills(agentPath: string | undefined) {
   return useQuery({
@@ -117,6 +117,32 @@ export function useInstallCommunitySkill(agentPath: string | undefined) {
     onSuccess: () => {
       if (agentPath)
         qc.invalidateQueries({ queryKey: queryKeys.skills(agentPath) });
+    },
+  });
+}
+
+export function useTranslateSkill(agentPath: string | undefined) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      name,
+      target,
+      mode,
+    }: {
+      name: string;
+      target: string;
+      mode: SkillTranslateMode;
+    }) => {
+      if (!agentPath) throw new Error("agentPath is required");
+      return tauriSkills.translate(agentPath, name, target, mode);
+    },
+    onSuccess: (_data, { name }) => {
+      if (agentPath) {
+        qc.invalidateQueries({ queryKey: queryKeys.skills(agentPath) });
+        qc.invalidateQueries({
+          queryKey: queryKeys.skillDetail(agentPath, name),
+        });
+      }
     },
   });
 }

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -50,6 +50,7 @@ import type {
   RepoSkill,
   SkillDetail,
   SkillSummary,
+  SkillTranslateMode,
   Workspace,
 } from "./types";
 
@@ -573,6 +574,35 @@ export const tauriSkills = {
       undefined,
       { toast: false },
     ),
+  translate: (
+    agentPath: string,
+    name: string,
+    target: string,
+    mode: SkillTranslateMode,
+  ) => {
+    blockWriteWhileWarming(agentPath);
+    return call<SkillDetail>(
+      "translate_skill",
+      async () => {
+        const d = await getEngine().translateSkill(name, {
+          workspacePath: agentPath,
+          target,
+          mode,
+        });
+        return {
+          name: d.name,
+          title: d.title ?? null,
+          description: d.description,
+          version: d.version,
+          content: d.content,
+        };
+      },
+      undefined,
+      // The translate dialog surfaces failures inline with plain-English
+      // copy (provider not connected, service busy) — no red bug toast.
+      { toast: false },
+    );
+  },
   installCommunity: (
     agentPath: string,
     source: string,

--- a/app/src/lib/types.ts
+++ b/app/src/lib/types.ts
@@ -151,6 +151,9 @@ export interface SkillDetail {
   content: string;
 }
 
+/** How a post-install skill translation runs (HOU-733). */
+export type SkillTranslateMode = "machine" | "ai";
+
 /** Community skill search result */
 export interface CommunitySkillResult {
   id: string;

--- a/app/src/locales/en/skills.json
+++ b/app/src/locales/en/skills.json
@@ -108,5 +108,29 @@
     "Setup": "Setup",
     "Support": "Support",
     "Tracking": "Tracking"
+  },
+  "translate": {
+    "title": "Translate to {{language}}?",
+    "description_one": "The skill you installed may be written in another language. Houston can translate it to {{language}} for you.",
+    "description_other": "The skills you installed may be written in another language. Houston can translate them to {{language}} for you.",
+    "quick": {
+      "title": "Quick translation",
+      "description": "Free and fast. The wording may come out a little rough."
+    },
+    "ai": {
+      "title": "AI translation",
+      "description": "Uses your AI provider for a natural result. Takes a bit longer."
+    },
+    "keep": "Keep original",
+    "inProgress": "Translating…",
+    "doneToast": {
+      "title_one": "Skill translated",
+      "title_other": "Skills translated",
+      "description_one": "The skill is now in your language.",
+      "description_other": "{{count}} skills are now in your language."
+    },
+    "errorToast": {
+      "title": "Couldn't translate the skill"
+    }
   }
 }

--- a/app/src/locales/es/skills.json
+++ b/app/src/locales/es/skills.json
@@ -108,5 +108,29 @@
     "Setup": "Configuración",
     "Support": "Soporte",
     "Tracking": "Seguimiento"
+  },
+  "translate": {
+    "title": "¿Traducir al {{language}}?",
+    "description_one": "La habilidad que instalaste puede estar escrita en otro idioma. Houston puede traducirla al {{language}} por ti.",
+    "description_other": "Las habilidades que instalaste pueden estar escritas en otro idioma. Houston puede traducirlas al {{language}} por ti.",
+    "quick": {
+      "title": "Traducción rápida",
+      "description": "Gratis y rápida. La redacción puede quedar un poco tosca."
+    },
+    "ai": {
+      "title": "Traducción con IA",
+      "description": "Usa tu proveedor de IA para un resultado natural. Tarda un poco más."
+    },
+    "keep": "Mantener original",
+    "inProgress": "Traduciendo…",
+    "doneToast": {
+      "title_one": "Habilidad traducida",
+      "title_other": "Habilidades traducidas",
+      "description_one": "La habilidad ya está en tu idioma.",
+      "description_other": "{{count}} habilidades ya están en tu idioma."
+    },
+    "errorToast": {
+      "title": "No se pudo traducir la habilidad"
+    }
   }
 }

--- a/app/src/locales/pt/skills.json
+++ b/app/src/locales/pt/skills.json
@@ -108,5 +108,29 @@
     "Setup": "Configuração",
     "Support": "Suporte",
     "Tracking": "Acompanhamento"
+  },
+  "translate": {
+    "title": "Traduzir para {{language}}?",
+    "description_one": "A habilidade que você instalou pode estar escrita em outro idioma. O Houston pode traduzi-la para {{language}} para você.",
+    "description_other": "As habilidades que você instalou podem estar escritas em outro idioma. O Houston pode traduzi-las para {{language}} para você.",
+    "quick": {
+      "title": "Tradução rápida",
+      "description": "Grátis e rápida. O texto pode sair um pouco impreciso."
+    },
+    "ai": {
+      "title": "Tradução com IA",
+      "description": "Usa seu provedor de IA para um resultado natural. Demora um pouco mais."
+    },
+    "keep": "Manter original",
+    "inProgress": "Traduzindo…",
+    "doneToast": {
+      "title_one": "Habilidade traduzida",
+      "title_other": "Habilidades traduzidas",
+      "description_one": "A habilidade já está no seu idioma.",
+      "description_other": "{{count}} habilidades já estão no seu idioma."
+    },
+    "errorToast": {
+      "title": "Não foi possível traduzir a habilidade"
+    }
   }
 }

--- a/packages/domain/src/index.ts
+++ b/packages/domain/src/index.ts
@@ -13,5 +13,6 @@ export * from "./routines";
 export * from "./scan";
 export * from "./schedule";
 export * from "./skill-install";
+export * from "./skill-translate";
 export * from "./skills";
 export * from "./store";

--- a/packages/domain/src/skill-install.ts
+++ b/packages/domain/src/skill-install.ts
@@ -50,11 +50,19 @@ export function composeInstalledSkillMd(input: {
   if (source.summary?.image) fm.image = source.summary.image;
   if (source.summary?.tags.length) fm.tags = source.summary.tags;
 
-  return `---\n${stringifyYaml(fm).trimEnd()}\n---\n\n${source.body}\n`;
+  return renderSkillMd(fm, source.body);
+}
+
+/** The one SKILL.md serialization both install and translate emit. */
+export function renderSkillMd(
+  fm: Record<string, unknown>,
+  body: string,
+): string {
+  return `---\n${stringifyYaml(fm).trimEnd()}\n---\n\n${body}\n`;
 }
 
 /** Truncate to `max` characters without splitting a surrogate pair. */
-function clampLen(s: string, max: number): string {
+export function clampLen(s: string, max: number): string {
   if (s.length <= max) return s;
   const chars = [...s];
   let out = "";

--- a/packages/domain/src/skill-translate.test.ts
+++ b/packages/domain/src/skill-translate.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from "vitest";
+import {
+  composeTranslatedSkillMd,
+  skillTranslateSegments,
+} from "./skill-translate";
+import { parseSkillMd } from "./skills";
+
+const MD = `---
+name: research-company
+title: Research a company
+description: Deep-dive on pricing and positioning
+version: 3
+created: 2026-01-10
+last_used: 2026-06-01
+category: research
+featured: true
+integrations:
+  - tavily
+  - gmail
+image: magnifying-glass-tilted-left
+tags:
+  - sales
+---
+
+## Procedure
+
+1. Search the company site.
+2. Summarize pricing.
+`;
+
+describe("skillTranslateSegments", () => {
+  it("extracts title, description, and body", () => {
+    const segs = skillTranslateSegments("research-company", MD);
+    if ("error" in segs) throw new Error(segs.error);
+    expect(segs.map((s) => s.id)).toEqual(["title", "description", "body"]);
+    expect(segs[1]?.text).toBe("Deep-dive on pricing and positioning");
+    expect(segs[2]?.text).toContain("## Procedure");
+  });
+
+  it("omits absent surfaces", () => {
+    const segs = skillTranslateSegments(
+      "bare",
+      "---\nname: bare\ndescription: Only this\n---\n\n",
+    );
+    if ("error" in segs) throw new Error(segs.error);
+    expect(segs.map((s) => s.id)).toEqual(["description"]);
+  });
+
+  it("refuses a file it cannot parse", () => {
+    expect(skillTranslateSegments("x", "no frontmatter here")).toHaveProperty(
+      "error",
+    );
+  });
+});
+
+describe("composeTranslatedSkillMd", () => {
+  it("splices translations and preserves identity + bookkeeping", () => {
+    const out = composeTranslatedSkillMd({
+      slug: "research-company",
+      original: MD,
+      translated: {
+        title: "Investigar una empresa",
+        description: "Análisis a fondo de precios y posicionamiento",
+        body: "## Procedimiento\n\n1. Busca el sitio de la empresa.\n2. Resume los precios.",
+      },
+    });
+    if (typeof out !== "string") throw new Error(out.error);
+    const parsed = parseSkillMd("research-company", out);
+    if ("error" in parsed) throw new Error(parsed.error);
+    expect(parsed.summary.title).toBe("Investigar una empresa");
+    expect(parsed.summary.description).toBe(
+      "Análisis a fondo de precios y posicionamiento",
+    );
+    expect(parsed.body.trim()).toContain("## Procedimiento");
+    // Untouched: identity + bookkeeping + presentation metadata.
+    expect(parsed.summary.name).toBe("research-company");
+    expect(parsed.summary.version).toBe(3);
+    expect(parsed.summary.created).toBe("2026-01-10");
+    expect(parsed.summary.lastUsed).toBe("2026-06-01");
+    expect(parsed.summary.category).toBe("research");
+    expect(parsed.summary.featured).toBe(true);
+    expect(parsed.summary.integrations).toEqual(["tavily", "gmail"]);
+    expect(parsed.summary.image).toBe("magnifying-glass-tilted-left");
+    expect(parsed.summary.tags).toEqual(["sales"]);
+  });
+
+  it("keeps original text for surfaces the translator skipped", () => {
+    const out = composeTranslatedSkillMd({
+      slug: "research-company",
+      original: MD,
+      translated: { description: "Solo la descripción" },
+    });
+    if (typeof out !== "string") throw new Error(out.error);
+    const parsed = parseSkillMd("research-company", out);
+    if ("error" in parsed) throw new Error(parsed.error);
+    expect(parsed.summary.title).toBe("Research a company");
+    expect(parsed.summary.description).toBe("Solo la descripción");
+    expect(parsed.body).toContain("Search the company site.");
+  });
+
+  it("clamps an over-long translated description", () => {
+    const out = composeTranslatedSkillMd({
+      slug: "research-company",
+      original: MD,
+      translated: { description: "x".repeat(400) },
+    });
+    if (typeof out !== "string") throw new Error(out.error);
+    const parsed = parseSkillMd("research-company", out);
+    if ("error" in parsed) throw new Error(parsed.error);
+    expect(parsed.summary.description.length).toBeLessThanOrEqual(256);
+  });
+
+  it("refuses an unparseable original", () => {
+    expect(
+      composeTranslatedSkillMd({
+        slug: "x",
+        original: "garbage",
+        translated: {},
+      }),
+    ).toHaveProperty("error");
+  });
+});

--- a/packages/domain/src/skill-translate.ts
+++ b/packages/domain/src/skill-translate.ts
@@ -1,0 +1,85 @@
+import {
+  clampLen,
+  MAX_SKILL_DESCRIPTION_LEN,
+  renderSkillMd,
+} from "./skill-install";
+import { parseSkillMd } from "./skills";
+
+/**
+ * Frontmatter-aware split + reassembly for translating an installed skill
+ * (HOU-733). Only the human-language surfaces travel to the translator —
+ * `title`, `description`, and the body — while identity and bookkeeping
+ * (slug, version, dates, featured, integrations, image, tags, category) are
+ * re-emitted verbatim from the original, so a translator (machine or model)
+ * can never mangle a slug or reset the install metadata.
+ *
+ * Pure: callers read/write SKILL.md themselves.
+ */
+
+/** One translatable surface of a SKILL.md. */
+export interface SkillTranslateSegment {
+  id: "title" | "description" | "body";
+  text: string;
+}
+
+/**
+ * Extract the translatable segments of a SKILL.md. Empty surfaces are
+ * omitted (nothing to translate). Unparseable frontmatter is an error — a
+ * translation must never destroy a file it can't faithfully rebuild.
+ */
+export function skillTranslateSegments(
+  slug: string,
+  content: string,
+): SkillTranslateSegment[] | { error: string } {
+  const parsed = parseSkillMd(slug, content);
+  if ("error" in parsed) return parsed;
+  const segments: SkillTranslateSegment[] = [];
+  const title = parsed.summary.title?.trim();
+  if (title) segments.push({ id: "title", text: title });
+  const description = parsed.summary.description.trim();
+  if (description) segments.push({ id: "description", text: description });
+  const body = parsed.body.trim();
+  if (body) segments.push({ id: "body", text: body });
+  return segments;
+}
+
+/**
+ * Rebuild the SKILL.md with translated surfaces spliced in. Any surface the
+ * translator did not return keeps the original text. The frontmatter is
+ * rebuilt from the ORIGINAL parse (same field set `composeInstalledSkillMd`
+ * emits), so nothing the translator says can touch identity or bookkeeping.
+ */
+export function composeTranslatedSkillMd(input: {
+  slug: string;
+  original: string;
+  translated: Partial<Record<SkillTranslateSegment["id"], string>>;
+}): string | { error: string } {
+  const parsed = parseSkillMd(input.slug, input.original);
+  if ("error" in parsed) return parsed;
+  const s = parsed.summary;
+
+  const pick = (id: SkillTranslateSegment["id"], fallback: string): string => {
+    const t = input.translated[id]?.trim();
+    return t || fallback;
+  };
+
+  const fm: Record<string, unknown> = {
+    name: input.slug,
+    description: clampLen(
+      pick("description", s.description.trim()),
+      MAX_SKILL_DESCRIPTION_LEN,
+    ),
+  };
+  const title = pick("title", s.title?.trim() ?? "");
+  if (title) fm.title = title;
+  fm.version = s.version;
+  if (s.created) fm.created = s.created;
+  if (s.lastUsed) fm.last_used = s.lastUsed;
+  if (s.category) fm.category = s.category;
+  if (s.featured) fm.featured = true;
+  if (s.integrations.length) fm.integrations = s.integrations;
+  if (s.image) fm.image = s.image;
+  if (s.tags.length) fm.tags = s.tags;
+
+  return renderSkillMd(fm, pick("body", parsed.body.trim()));
+}

--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -183,6 +183,40 @@ export class ProxyChannel implements RuntimeChannel {
     return body.items;
   }
 
+  /**
+   * The post-install skill translation's AI mode: wake the standing runtime
+   * and run the SKILL.md surfaces through its `POST /skills/translate`
+   * one-shot (the runtime is where the provider credential lives). A non-2xx
+   * throws with the runtime's own reason so the host route can surface it —
+   * user-initiated work, beta no-silent-failure (HOU-733).
+   */
+  async translateTexts(
+    ctx: ChannelCtx,
+    items: { id: string; text: string }[],
+    targetLanguage: string,
+  ): Promise<{ id: string; text: string }[]> {
+    const endpoint = await this.opts.launcher.ensureAwake(ctx.agent);
+    const res = await fetch(`${endpoint.baseUrl}/skills/translate`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        Authorization: `Bearer ${endpoint.token}`,
+      },
+      body: JSON.stringify({ items, targetLanguage }),
+    });
+    const body = (await res.json().catch(() => ({}))) as {
+      items?: { id: string; text: string }[];
+      error?: string;
+    };
+    if (!res.ok) {
+      throw new Error(body.error ?? `runtime ${res.status}`);
+    }
+    if (!Array.isArray(body.items)) {
+      throw new Error("runtime translate: malformed response body");
+    }
+    return body.items;
+  }
+
   async cancelTurn(ctx: ChannelCtx, conversationId: string): Promise<boolean> {
     // An asleep/absent runtime cannot be running a turn (turns live inside the
     // runtime process; sleep kills it) — answer false without paying a cold

--- a/packages/host/src/ports.ts
+++ b/packages/host/src/ports.ts
@@ -196,6 +196,19 @@ export interface RuntimeChannel {
     ctx: ChannelCtx,
     items: { id: string; text: string }[],
   ): Promise<{ id: string; text: string; summary: string }[]>;
+  /**
+   * AI-translate the given texts in the agent's runtime — the post-install
+   * skill translation's "better quality" mode runs the LLM where the provider
+   * credentials live (HOU-733). Optional: channels with no standing runtime
+   * omit it and the route answers 503 with the reason (the quick machine mode
+   * stays available). Throws with the runtime's real reason (no provider
+   * connected, unparseable model reply).
+   */
+  translateTexts?(
+    ctx: ChannelCtx,
+    items: { id: string; text: string }[],
+    targetLanguage: string,
+  ): Promise<{ id: string; text: string }[]>;
   /** Tear down the agent's runtime-side state (volume / object prefix) before record deletion. */
   teardown(ctx: ChannelCtx): Promise<void>;
   /**

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -28,6 +28,7 @@ import { handlePortablePreview } from "./portable-preview";
 import { handleRoutineRuns } from "./routine-runs";
 import { handleSkills } from "./skills";
 import { handleSkillsRemote } from "./skills-remote";
+import { handleSkillTranslate } from "./skills-translate";
 
 // The deps bag + authz helpers moved to agent-authz.ts (shared with
 // routine-runs.ts); re-exported so existing importers keep working.
@@ -542,6 +543,24 @@ export async function handleAgents(
       return true;
     if (
       await handleAgentFile(deps.vfs, paths, ctx, method, rest, req, res, emit)
+    )
+      return true;
+    // The channel carries the AI mode into the agent's runtime; absent, the
+    // route answers 503 and the quick machine mode still works.
+    if (
+      await handleSkillTranslate(
+        {
+          vfs: deps.vfs,
+          paths,
+          channel: channelFor(deps, authz.workspace) ?? undefined,
+        },
+        ctx,
+        method,
+        rest,
+        req,
+        res,
+        emit,
+      )
     )
       return true;
     if (await handleSkills(deps.vfs, paths, ctx, method, rest, req, res, emit))

--- a/packages/host/src/routes/skills-translate.test.ts
+++ b/packages/host/src/routes/skills-translate.test.ts
@@ -1,0 +1,243 @@
+import { createServer, type Server } from "node:http";
+import type { HoustonEvent } from "@houston/protocol";
+import { afterAll, beforeAll, beforeEach, expect, test } from "vitest";
+import type { Agent, Workspace } from "../domain/types";
+import { CloudPaths } from "../paths";
+import type { RuntimeChannel } from "../ports";
+import { MemoryVfs } from "../vfs";
+import { handleSkillTranslate } from "./skills-translate";
+
+/**
+ * The post-install translate route (HOU-733): reads the installed SKILL.md,
+ * translates its human surfaces in the requested mode (machine host-side, ai
+ * via the runtime channel), rebuilds the file with identity/bookkeeping
+ * untouched, and emits SkillsChanged.
+ */
+
+const ws = { id: "w1", ownerUserId: "alice" } as Workspace;
+const agent = { id: "a1", workspaceId: "w1" } as Agent;
+const paths = new CloudPaths();
+const vfs = new MemoryVfs();
+const events: HoustonEvent[] = [];
+
+const MD = `---
+name: research
+title: Research a company
+description: Deep research
+version: 2
+created: 2026-01-01
+featured: true
+integrations:
+  - tavily
+---
+
+# Research
+
+\`\`\`bash
+echo untouched
+\`\`\`
+
+Steps.
+`;
+
+const root = paths.agentRoot(ws, agent);
+const key = `${root}/.agents/skills/research/SKILL.md`;
+
+/** Fake quick translator: uppercases so assertions are unambiguous. */
+const fakeMachine = async (texts: string[]) => texts.map((t) => `MT:${t}`);
+
+/** Fake channel: only translateTexts matters here. */
+let channelCalls: { targetLanguage: string; ids: string[] }[] = [];
+const channel = {
+  translateTexts: async (
+    _ctx: unknown,
+    items: { id: string; text: string }[],
+    targetLanguage: string,
+  ) => {
+    channelCalls.push({ targetLanguage, ids: items.map((i) => i.id) });
+    return items.map((i) => ({ id: i.id, text: `AI:${i.text}` }));
+  },
+} as unknown as RuntimeChannel;
+
+let withChannel = true;
+let server: Server;
+let base = "";
+
+beforeAll(async () => {
+  server = createServer((req, res) => {
+    const rest = (req.url ?? "").replace(/^\//, "");
+    void handleSkillTranslate(
+      {
+        vfs,
+        paths,
+        channel: withChannel ? channel : undefined,
+        translator: fakeMachine,
+      },
+      { workspace: ws, agent },
+      req.method ?? "GET",
+      rest,
+      req,
+      res,
+      (e) => events.push(e),
+    ).then((handled) => {
+      if (!handled) {
+        res.writeHead(404);
+        res.end();
+      }
+    });
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", () => r()));
+  const addr = server.address();
+  base = `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((r) => server.close(() => r()));
+});
+
+beforeEach(async () => {
+  await vfs.writeText(key, MD);
+  events.length = 0;
+  channelCalls = [];
+  withChannel = true;
+});
+
+const post = (path: string, body?: unknown) =>
+  fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+
+test("machine mode translates surfaces, preserves identity, emits SkillsChanged", async () => {
+  const res = await post("/skills/research/translate", {
+    target: "es",
+    mode: "machine",
+  });
+  expect(res.status).toBe(200);
+  const detail = (await res.json()) as { name: string; description: string };
+  expect(detail.name).toBe("research");
+  expect(detail.description).toBe("MT:Deep research");
+
+  const md = (await vfs.readText(key)) ?? "";
+  expect(md).toContain("name: research");
+  expect(md).toContain("version: 2");
+  expect(md).toContain("title: MT:Research a company");
+  expect(md).toContain("MT:# Research");
+  expect(events.some((e) => e.type === "SkillsChanged")).toBe(true);
+});
+
+test("ai mode goes through the channel with the target language", async () => {
+  const res = await post("/skills/research/translate", {
+    target: "pt",
+    mode: "ai",
+  });
+  expect(res.status).toBe(200);
+  expect(channelCalls).toEqual([
+    { targetLanguage: "pt", ids: ["title", "description", "body"] },
+  ]);
+  const md = (await vfs.readText(key)) ?? "";
+  expect(md).toContain("AI:Deep research");
+});
+
+test("ai mode without a channel answers 503 and changes nothing", async () => {
+  withChannel = false;
+  const res = await post("/skills/research/translate", {
+    target: "es",
+    mode: "ai",
+  });
+  expect(res.status).toBe(503);
+  expect(await vfs.readText(key)).toBe(MD);
+});
+
+test("missing skill answers 404; bad input answers 400", async () => {
+  const missing = await post("/skills/ghost/translate", {
+    target: "es",
+    mode: "machine",
+  });
+  expect(missing.status).toBe(404);
+
+  const badTarget = await post("/skills/research/translate", {
+    target: "not a lang",
+    mode: "machine",
+  });
+  expect(badTarget.status).toBe(400);
+
+  const badMode = await post("/skills/research/translate", {
+    target: "es",
+    mode: "telepathy",
+  });
+  expect(badMode.status).toBe(400);
+});
+
+test("a short translator reply answers 502, never a half-translated write", async () => {
+  const short = async (texts: string[]) => texts.slice(1).map((t) => `MT:${t}`);
+  const res = await new Promise<number>((resolve) => {
+    const srv = createServer((req, rsp) => {
+      void handleSkillTranslate(
+        { vfs, paths, translator: short },
+        { workspace: ws, agent },
+        req.method ?? "GET",
+        (req.url ?? "").replace(/^\//, ""),
+        req,
+        rsp,
+      );
+    });
+    srv.listen(0, "127.0.0.1", async () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const r = await fetch(
+        `http://127.0.0.1:${port}/skills/research/translate`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ target: "es", mode: "machine" }),
+        },
+      );
+      resolve(r.status);
+      srv.close();
+    });
+  });
+  expect(res).toBe(502);
+  expect(await vfs.readText(key)).toBe(MD);
+});
+
+test("translator failure answers 502 with the reason and changes nothing", async () => {
+  const failing = async () => {
+    throw new Error("translation service answered 429");
+  };
+  const res = await new Promise<{ status: number; body: string }>((resolve) => {
+    const srv = createServer((req, rsp) => {
+      void handleSkillTranslate(
+        { vfs, paths, translator: failing },
+        { workspace: ws, agent },
+        req.method ?? "GET",
+        (req.url ?? "").replace(/^\//, ""),
+        req,
+        rsp,
+      );
+    });
+    srv.listen(0, "127.0.0.1", async () => {
+      const addr = srv.address();
+      const port = typeof addr === "object" && addr ? addr.port : 0;
+      const r = await fetch(
+        `http://127.0.0.1:${port}/skills/research/translate`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ target: "es", mode: "machine" }),
+        },
+      );
+      resolve({ status: r.status, body: await r.text() });
+      srv.close();
+    });
+  });
+  expect(res.status).toBe(502);
+  expect(res.body).toContain("429");
+  expect(await vfs.readText(key)).toBe(MD);
+});
+
+test("non-translate paths fall through", async () => {
+  const res = await post("/skills/research/other");
+  expect(res.status).toBe(404);
+});

--- a/packages/host/src/routes/skills-translate.ts
+++ b/packages/host/src/routes/skills-translate.ts
@@ -1,0 +1,133 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import {
+  composeTranslatedSkillMd,
+  loadSkillDetail,
+  type SkillTranslateSegment,
+  skillKey,
+  skillTranslateSegments,
+} from "@houston/domain";
+import type { HoustonEvent } from "@houston/protocol";
+import type { Agent, Workspace } from "../domain/types";
+import type { WorkspacePaths } from "../paths";
+import type { RuntimeChannel } from "../ports";
+import {
+  machineTranslate,
+  type TextTranslator,
+} from "../skills/machine-translate";
+import type { Vfs } from "../vfs";
+import { json, readJson } from "./http";
+
+const TARGET = /^[a-z]{2}(-[A-Za-z0-9-]{1,8})?$/;
+
+/**
+ * POST .../skills/:slug/translate — the post-install "translate this skill"
+ * offer (HOU-733). Splits the SKILL.md into its human-language surfaces,
+ * translates them in the requested mode, and rebuilds the file with identity
+ * and bookkeeping untouched:
+ *
+ * - `machine`: the quick free pass, host-side (no provider needed).
+ * - `ai`: the better-quality pass, run in the agent's runtime via the
+ *   channel (where the provider credential lives). Channels without a
+ *   standing runtime answer 503 with the reason.
+ *
+ * Errors carry the real reason — user-initiated work, beta
+ * no-silent-failure. Returns true when handled.
+ */
+export async function handleSkillTranslate(
+  deps: {
+    vfs?: Vfs;
+    paths: WorkspacePaths;
+    channel?: RuntimeChannel;
+    /** Injected in tests; production uses the free gtx translator. */
+    translator?: TextTranslator;
+  },
+  ctx: { workspace: Workspace; agent: Agent },
+  method: string,
+  rest: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+  emit?: (event: HoustonEvent) => void,
+): Promise<boolean> {
+  const m = rest.match(/^skills\/([^/]+)\/translate$/);
+  if (!m || method !== "POST") return false;
+  const slug = decodeURIComponent(m[1] ?? "");
+
+  if (!deps.vfs) {
+    json(res, 503, { error: "agent data not configured" });
+    return true;
+  }
+  const body = await readJson(req);
+  const target = typeof body.target === "string" ? body.target : "";
+  const mode =
+    body.mode === "ai" ? "ai" : body.mode === "machine" ? "machine" : null;
+  if (!TARGET.test(target)) {
+    json(res, 400, { error: "missing or invalid 'target' language" });
+    return true;
+  }
+  if (!mode) {
+    json(res, 400, { error: "'mode' must be 'machine' or 'ai'" });
+    return true;
+  }
+
+  const root = deps.paths.agentRoot(ctx.workspace, ctx.agent);
+  const original = await deps.vfs.readText(skillKey(root, slug));
+  if (original === null) {
+    json(res, 404, { error: "skill not found" });
+    return true;
+  }
+  const segments = skillTranslateSegments(slug, original);
+  if ("error" in segments) {
+    json(res, 422, { error: segments.error });
+    return true;
+  }
+  if (segments.length === 0) {
+    // Nothing translatable; answer with the unchanged detail.
+    json(res, 200, await loadSkillDetail(deps.vfs, root, slug));
+    return true;
+  }
+
+  let results: { id: string; text: string }[];
+  try {
+    if (mode === "ai") {
+      if (!deps.channel?.translateTexts) {
+        json(res, 503, {
+          error: "AI translation is not available on this deployment",
+        });
+        return true;
+      }
+      results = await deps.channel.translateTexts(ctx, segments, target);
+    } else {
+      const translator = deps.translator ?? machineTranslate;
+      const texts = await translator(
+        segments.map((s) => s.text),
+        target,
+      );
+      // A short reply would silently leave a surface untranslated (pick()
+      // keeps the original on empty) — hard-fail like the AI parser does.
+      if (texts.length !== segments.length) {
+        throw new Error(
+          `translator returned ${texts.length} of ${segments.length} texts`,
+        );
+      }
+      results = segments.map((s, i) => ({ id: s.id, text: texts[i] ?? "" }));
+    }
+  } catch (e) {
+    json(res, 502, { error: e instanceof Error ? e.message : String(e) });
+    return true;
+  }
+
+  const translated: Partial<Record<SkillTranslateSegment["id"], string>> = {};
+  for (const r of results) {
+    if (r.id === "title" || r.id === "description" || r.id === "body")
+      translated[r.id] = r.text;
+  }
+  const rebuilt = composeTranslatedSkillMd({ slug, original, translated });
+  if (typeof rebuilt !== "string") {
+    json(res, 422, { error: rebuilt.error });
+    return true;
+  }
+  await deps.vfs.writeText(skillKey(root, slug), rebuilt);
+  emit?.({ type: "SkillsChanged", agentPath: ctx.agent.id });
+  json(res, 200, await loadSkillDetail(deps.vfs, root, slug));
+  return true;
+}

--- a/packages/host/src/skills/machine-translate.test.ts
+++ b/packages/host/src/skills/machine-translate.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import {
+  chunkProse,
+  machineTranslate,
+  splitTranslatableChunks,
+} from "./machine-translate";
+
+describe("splitTranslatableChunks", () => {
+  it("keeps fenced code blocks out of the translatable chunks", () => {
+    const md = "Intro.\n\n```js\nconst x = 1;\n```\n\nOutro.";
+    const chunks = splitTranslatableChunks(md);
+    expect(chunks.map((c) => c.translate)).toEqual([true, false, true]);
+    expect(chunks[1]?.text).toContain("const x = 1;");
+    expect(chunks.map((c) => c.text).join("")).toBe(md);
+  });
+
+  it("recognizes indented fences (code nested in lists)", () => {
+    const md = "1. Run this:\n\n   ```bash\n   ls -la\n   ```\n\n2. Done.";
+    const chunks = splitTranslatableChunks(md);
+    const code = chunks.filter((c) => !c.translate);
+    expect(code).toHaveLength(1);
+    expect(code[0]?.text).toContain("ls -la");
+    expect(chunks.map((c) => c.text).join("")).toBe(md);
+  });
+
+  it("handles text with no fences", () => {
+    expect(splitTranslatableChunks("plain text")).toEqual([
+      { text: "plain text", translate: true },
+    ]);
+  });
+});
+
+describe("chunkProse", () => {
+  it("splits on blank lines under the cap and reassembles losslessly", () => {
+    const text = `${"a".repeat(60)}\n\n${"b".repeat(60)}\n\n${"c".repeat(60)}`;
+    const pieces = chunkProse(text, 100);
+    expect(pieces.length).toBeGreaterThan(1);
+    expect(pieces.join("")).toBe(text);
+  });
+
+  it("hard-splits a single block longer than the cap", () => {
+    const table = Array.from({ length: 30 }, (_, i) => `| row ${i} |`).join(
+      "\n",
+    );
+    const pieces = chunkProse(table, 100);
+    expect(pieces.every((p) => p.length <= 100)).toBe(true);
+    expect(pieces.join("")).toBe(table);
+
+    const oneLine = "x".repeat(350);
+    const hard = chunkProse(oneLine, 100);
+    expect(hard.every((p) => p.length <= 100)).toBe(true);
+    expect(hard.join("")).toBe(oneLine);
+  });
+});
+
+describe("machineTranslate", () => {
+  const echoFetch =
+    (seen: string[]): typeof fetch =>
+    async (_url, init) => {
+      const q = decodeURIComponent(String(init?.body ?? "").replace(/^q=/, ""));
+      seen.push(q);
+      return new Response(JSON.stringify([[[`ES(${q})`, q]]]));
+    };
+
+  it("translates prose but never code, via the injected fetch", async () => {
+    const seen: string[] = [];
+    const [out] = await machineTranslate(
+      ["Hello.\n\n```sh\nls\n```\n\nBye."],
+      "es",
+      echoFetch(seen),
+    );
+    expect(out).toContain("```sh\nls\n```");
+    expect(out).toContain("ES(Hello.");
+    expect(seen.join("")).not.toContain("ls");
+  });
+
+  it("keeps the newline margins around fences (gtx strips whitespace)", async () => {
+    const [out] = await machineTranslate(
+      ["Before.\n\n```sh\nls\n```\n\nAfter."],
+      "es",
+      echoFetch([]),
+    );
+    // The fence must stay at line start on both sides.
+    expect(out).toBe("ES(Before.)\n\n```sh\nls\n```\n\nES(After.)");
+  });
+
+  it("throws with the status on a failing service", async () => {
+    const fakeFetch: typeof fetch = async () =>
+      new Response("", { status: 429 });
+    await expect(machineTranslate(["hi"], "es", fakeFetch)).rejects.toThrow(
+      /429/,
+    );
+  });
+});

--- a/packages/host/src/skills/machine-translate.ts
+++ b/packages/host/src/skills/machine-translate.ts
@@ -1,0 +1,144 @@
+/**
+ * Quick machine translation for installed skills (HOU-733) — the free,
+ * no-provider-needed mode of the post-install translate offer. Uses Google's
+ * public gtx endpoint (the same one the popular translate js packages wrap)
+ * via plain fetch, so no dependency rides into the bun-compiled sidecar.
+ *
+ * Markdown-aware: fenced code blocks (indented ones included) are never sent
+ * to the translator — the text is split on fences and only the prose chunks
+ * travel. Long prose is chunked on blank lines (hard-split as a last resort)
+ * to stay inside the endpoint's request size. Quality is machine-translation
+ * quality by design; the UI offers the AI mode for a better result.
+ */
+
+const ENDPOINT = "https://translate.googleapis.com/translate_a/single";
+/** Keep each request comfortably under the endpoint's size limits. */
+const MAX_CHUNK = 1800;
+
+export type TextTranslator = (
+  texts: string[],
+  targetLanguage: string,
+) => Promise<string[]>;
+
+/** Split markdown into alternating prose/code chunks; code never travels. */
+export function splitTranslatableChunks(
+  text: string,
+): { text: string; translate: boolean }[] {
+  const chunks: { text: string; translate: boolean }[] = [];
+  // Fences may be indented (list-nested code blocks are common in skill
+  // procedures); the closing fence's indentation may differ from the opener's.
+  const fence = /^[ \t]*(```|~~~)[^\n]*\n[\s\S]*?^[ \t]*\1[^\n]*$/gm;
+  let last = 0;
+  for (const m of text.matchAll(fence)) {
+    if (m.index > last)
+      chunks.push({ text: text.slice(last, m.index), translate: true });
+    chunks.push({ text: m[0], translate: false });
+    last = m.index + m[0].length;
+  }
+  if (last < text.length)
+    chunks.push({ text: text.slice(last), translate: true });
+  return chunks;
+}
+
+/**
+ * Split prose on blank lines into pieces of at most `max` characters. A
+ * single block longer than `max` (a big table, one huge paragraph) is
+ * hard-split on line breaks, then raw length, so no piece can exceed the
+ * endpoint's request size.
+ */
+export function chunkProse(text: string, max = MAX_CHUNK): string[] {
+  if (text.length <= max) return [text];
+  const pieces: string[] = [];
+  let current = "";
+  const push = (part: string) => {
+    if (current && current.length + part.length > max) {
+      pieces.push(current);
+      current = part;
+    } else {
+      current += part;
+    }
+  };
+  for (const part of text.split(/(\n\s*\n)/)) {
+    if (part.length <= max) {
+      push(part);
+      continue;
+    }
+    for (const line of part.split(/(\n)/)) {
+      if (line.length <= max) {
+        push(line);
+        continue;
+      }
+      for (let i = 0; i < line.length; i += max) push(line.slice(i, i + max));
+    }
+  }
+  if (current) pieces.push(current);
+  return pieces;
+}
+
+/** Parse the gtx response: `[[["translated","source",…],…],…]`. */
+function parseGtx(body: unknown): string {
+  if (!Array.isArray(body) || !Array.isArray(body[0])) {
+    throw new Error("translation service returned an unexpected response");
+  }
+  let out = "";
+  for (const seg of body[0]) {
+    if (Array.isArray(seg) && typeof seg[0] === "string") out += seg[0];
+  }
+  return out;
+}
+
+async function translateChunk(
+  text: string,
+  targetLanguage: string,
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  // gtx normalizes surrounding whitespace, but the newlines separating prose
+  // from an adjacent code fence are structural markdown — translate the core
+  // and re-attach the original margins so fences stay at line starts.
+  const lead = text.match(/^\s*/)?.[0] ?? "";
+  const core = text.slice(lead.length).trimEnd();
+  const trail = text.slice(lead.length + core.length);
+  if (!core) return text;
+  const res = await fetchImpl(
+    `${ENDPOINT}?client=gtx&sl=auto&tl=${encodeURIComponent(targetLanguage)}&dt=t`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+      body: `q=${encodeURIComponent(core)}`,
+    },
+  );
+  if (!res.ok) {
+    throw new Error(
+      `translation service answered ${res.status}${res.status === 429 ? " (rate limited, try again in a moment)" : ""}`,
+    );
+  }
+  return lead + parseGtx(await res.json()).trimEnd() + trail;
+}
+
+/**
+ * Machine-translate the given texts. Code fences inside each text are
+ * preserved verbatim; everything else goes through the translator. Requests
+ * run sequentially on purpose — the free endpoint rate-limits bursts. Throws
+ * with the real reason on any failure — the user asked for this translation.
+ */
+export async function machineTranslate(
+  texts: string[],
+  targetLanguage: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<string[]> {
+  const out: string[] = [];
+  for (const text of texts) {
+    let translated = "";
+    for (const chunk of splitTranslatableChunks(text)) {
+      if (!chunk.translate) {
+        translated += chunk.text;
+        continue;
+      }
+      for (const piece of chunkProse(chunk.text)) {
+        translated += await translateChunk(piece, targetLanguage, fetchImpl);
+      }
+    }
+    out.push(translated);
+  }
+  return out;
+}

--- a/packages/runtime/src/session/translate-parse.ts
+++ b/packages/runtime/src/session/translate-parse.ts
@@ -1,0 +1,32 @@
+import { parseAnonymizeResult } from "./anonymize-parse";
+
+/**
+ * Parsing for the skill-translate one-shot response. The model returns
+ * `{"items":[{"id","text"}]}`; every requested id must come back exactly once
+ * (a dropped item would silently leave a surface untranslated with no error,
+ * so a missing id is a hard failure). Extra/unknown ids are ignored.
+ *
+ * Delegates to the anonymize reply parser — the wire shape is identical
+ * minus `summary` — so hardening fixes to the fence-stripping / missing-id
+ * handling apply to both one-shots at once.
+ */
+
+export interface TranslateItemInput {
+  id: string;
+  text: string;
+}
+
+export interface TranslateItemResult {
+  id: string;
+  text: string;
+}
+
+export function parseTranslateResult(
+  raw: string,
+  requested: TranslateItemInput[],
+): TranslateItemResult[] {
+  return parseAnonymizeResult(raw, requested).map(({ id, text }) => ({
+    id,
+    text,
+  }));
+}

--- a/packages/runtime/src/session/translate.test.ts
+++ b/packages/runtime/src/session/translate.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+import { translatePrompt } from "./translate";
+import { parseTranslateResult } from "./translate-parse";
+
+describe("parseTranslateResult", () => {
+  const requested = [
+    { id: "title", text: "Research a company" },
+    { id: "body", text: "## Procedure" },
+  ];
+
+  it("maps every requested id, ignoring extras", () => {
+    const raw = JSON.stringify({
+      items: [
+        { id: "body", text: "## Procedimiento" },
+        { id: "title", text: "Investigar una empresa" },
+        { id: "ghost", text: "ignored" },
+      ],
+    });
+    expect(parseTranslateResult(raw, requested)).toEqual([
+      { id: "title", text: "Investigar una empresa" },
+      { id: "body", text: "## Procedimiento" },
+    ]);
+  });
+
+  it("strips markdown fences around the JSON", () => {
+    const raw = `\`\`\`json\n${JSON.stringify({
+      items: requested,
+    })}\n\`\`\``;
+    expect(parseTranslateResult(raw, requested)).toHaveLength(2);
+  });
+
+  it("throws when an id is missing (never silently drop a surface)", () => {
+    const raw = JSON.stringify({
+      items: [{ id: "title", text: "Investigar una empresa" }],
+    });
+    expect(() => parseTranslateResult(raw, requested)).toThrow(/body/);
+  });
+
+  it("throws on non-JSON garbage", () => {
+    expect(() => parseTranslateResult("nope", requested)).toThrow(
+      /JSON parse failed/,
+    );
+  });
+});
+
+describe("translatePrompt", () => {
+  it("names the supported languages", () => {
+    expect(translatePrompt("es")).toContain("Latin-American Spanish");
+    expect(translatePrompt("pt")).toContain("Brazilian Portuguese");
+  });
+
+  it("falls back to the raw tag for unknown languages", () => {
+    expect(translatePrompt("fr")).toContain("'fr'");
+  });
+});

--- a/packages/runtime/src/session/translate.ts
+++ b/packages/runtime/src/session/translate.ts
@@ -1,0 +1,81 @@
+import { activeProvider, resolveModel } from "../ai/providers";
+import { authStorage, modelRegistry } from "../auth/storage";
+import { oneShotWithClaude } from "../backends/claude/one-shot";
+import { readAnthropicToken } from "../backends/claude/read-token";
+import { config } from "../config";
+import { oneShotText } from "./one-shot";
+import {
+  parseTranslateResult,
+  type TranslateItemInput,
+  type TranslateItemResult,
+} from "./translate-parse";
+
+/**
+ * AI translation for installed skills (HOU-733): the host splits a SKILL.md
+ * into its human-language surfaces (title, description, body) and sends the
+ * texts here — the runtime is where the provider credential lives. The model
+ * translates content only; identity and bookkeeping never travel, the host
+ * reassembles the frontmatter deterministically.
+ *
+ * Failures THROW so the route answers 400 with the real reason — the user
+ * asked for this translation, no silent fallback (beta no-silent-failure).
+ *
+ * COMPLIANCE GATE: like titles (`session/summarize.ts` dispatchTitle) and the
+ * anonymize pass, when the active provider is `anthropic` the one-shot runs
+ * through the Claude Agent SDK — never pi's in-process Anthropic client.
+ */
+
+const LANGUAGE_NAMES: Record<string, string> = {
+  en: "English",
+  es: "Latin-American Spanish",
+  pt: "Brazilian Portuguese",
+};
+
+export function translatePrompt(targetLanguage: string): string {
+  const name =
+    LANGUAGE_NAMES[targetLanguage] ??
+    `the '${targetLanguage}' language (BCP-47)`;
+  return `You translate the content of an AI assistant's skill file (markdown with optional metadata strings) into ${name}.
+
+The user sends JSON: {"items":[{"id":"...","text":"..."}]}. Translate each item's text into ${name}.
+
+Rules:
+- Preserve markdown structure exactly: headers, lists, tables, links, emphasis, blank lines.
+- NEVER translate: fenced code blocks, inline code, URLs, file paths, email addresses, CLI commands, tool or product names, kebab-case identifiers (like research-company), and placeholder tokens such as {{name}} or <email>. Copy them verbatim.
+- Translate naturally and idiomatically; do not add, remove, shorten, or reorder content.
+- If an item is already written in ${name}, return it unchanged.
+
+Return ONLY valid JSON (no markdown fences), with every input id exactly once:
+{"items":[{"id":"...","text":"..."}]}`;
+}
+
+/**
+ * Translate the given texts with the active provider's model. Empty input
+ * skips the model call entirely.
+ */
+export async function translateTexts(
+  items: TranslateItemInput[],
+  targetLanguage: string,
+): Promise<TranslateItemResult[]> {
+  if (items.length === 0) return [];
+  const systemPrompt = translatePrompt(targetLanguage);
+  const prompt = JSON.stringify({ items });
+  const raw =
+    activeProvider() === "anthropic"
+      ? await oneShotWithClaude({
+          prompt,
+          systemPrompt,
+          workspaceDir: config.workspaceDir,
+          readToken: () => readAnthropicToken(authStorage),
+          modelId: resolveModel().id,
+        })
+      : await oneShotText({
+          cwd: config.workspaceDir,
+          model: resolveModel(),
+          authStorage,
+          modelRegistry,
+          systemPrompt,
+          prompt,
+        });
+  return parseTranslateResult(raw, items);
+}

--- a/packages/runtime/src/transport/server.ts
+++ b/packages/runtime/src/transport/server.ts
@@ -13,6 +13,7 @@ import {
   routeContext,
 } from "./http-helpers";
 import { handleProviderRoute } from "./provider-routes";
+import { handleTranslateRoute } from "./translate-route";
 
 async function handle(ctx: RouteContext) {
   applyCors(ctx.req, ctx.res);
@@ -43,6 +44,7 @@ async function handle(ctx: RouteContext) {
   if (await handleConversationRoute(ctx)) return;
   if (await handleGenerateRoute(ctx)) return;
   if (await handleAnonymizeRoute(ctx)) return;
+  if (await handleTranslateRoute(ctx)) return;
 
   json(ctx.res, 404, { error: "not found" });
 }

--- a/packages/runtime/src/transport/translate-route.ts
+++ b/packages/runtime/src/transport/translate-route.ts
@@ -1,0 +1,43 @@
+import { translateTexts } from "../session/translate";
+import { json, type RouteContext, readJson } from "./http-helpers";
+
+const TARGET = /^[a-z]{2}(-[A-Za-z0-9-]{1,8})?$/;
+
+/**
+ * `POST /skills/translate` — the AI translation pass behind the post-install
+ * "translate this skill" offer (HOU-733). The host splits the SKILL.md and
+ * sends the human-language surfaces here (the runtime is where provider
+ * credentials live). Errors answer 400 with the real reason (no provider
+ * connected, model reply unparseable, …) so the host can surface why —
+ * user-initiated work, beta no-silent-failure.
+ */
+export async function handleTranslateRoute(
+  ctx: RouteContext,
+): Promise<boolean> {
+  if (ctx.method !== "POST" || ctx.path !== "/skills/translate") return false;
+
+  const { items, targetLanguage } = await readJson(ctx.req);
+  if (
+    !Array.isArray(items) ||
+    !items.every(
+      (i: unknown): i is { id: string; text: string } =>
+        !!i &&
+        typeof i === "object" &&
+        typeof (i as { id?: unknown }).id === "string" &&
+        typeof (i as { text?: unknown }).text === "string",
+    )
+  ) {
+    json(ctx.res, 400, { error: "missing 'items' [{id, text}] array" });
+    return true;
+  }
+  if (typeof targetLanguage !== "string" || !TARGET.test(targetLanguage)) {
+    json(ctx.res, 400, { error: "missing or invalid 'targetLanguage'" });
+    return true;
+  }
+  try {
+    json(ctx.res, 200, { items: await translateTexts(items, targetLanguage) });
+  } catch (e) {
+    json(ctx.res, 400, { error: e instanceof Error ? e.message : String(e) });
+  }
+  return true;
+}

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -47,6 +47,7 @@ import type {
   SessionStartResponse,
   SidebarLayout,
   SkillDetail,
+  TranslateSkillRequest,
   TunnelCredentials,
   UpdateAgent,
   Workspace,
@@ -1107,6 +1108,22 @@ export class HoustonClient {
     );
     emitLocalEcho("SkillsChanged", { agentPath: req.workspacePath });
     return installed;
+  }
+  /** Translate an installed skill to the app locale (HOU-733). */
+  async translateSkill(
+    name: string,
+    req: TranslateSkillRequest,
+  ): Promise<SkillDetail> {
+    if (!this.cp)
+      throw new Error("Translating skills needs a cloud workspace.");
+    const detail = await controlPlane.translateSkill(
+      this.cp,
+      req.workspacePath,
+      name,
+      { target: req.target, mode: req.mode },
+    );
+    emitLocalEcho("SkillsChanged", { agentPath: req.workspacePath });
+    return detail;
   }
 
   // ---- providers (auth) ----

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -15,6 +15,7 @@ import type {
   RoutineRun,
   SkillDetail,
   SkillSummary,
+  SkillTranslateMode,
   TunnelCredentials,
   Workspace,
 } from "../../../../ui/engine-client/src/types";
@@ -753,6 +754,25 @@ export async function installCommunitySkill(
   );
   return (await res.json()) as string;
 }
+/**
+ * Translate an installed skill to the app locale (HOU-733). `mode: "machine"`
+ * is the quick host-side pass; `mode: "ai"` runs in the agent's runtime with
+ * the user's provider. Answers the refreshed SkillDetail.
+ */
+export async function translateSkill(
+  cfg: ControlPlaneConfig,
+  agentId: string,
+  slug: string,
+  body: { target: string; mode: SkillTranslateMode },
+): Promise<SkillDetail> {
+  const res = await cpFetch(
+    cfg,
+    `${agentPath(agentId)}/skills/${encodeURIComponent(slug)}/translate`,
+    { method: "POST", body: JSON.stringify(body) },
+  );
+  return (await res.json()) as SkillDetail;
+}
+
 export async function installSkillsFromRepo(
   cfg: ControlPlaneConfig,
   agentId: string,

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -90,6 +90,7 @@ import type {
   StoreListing,
   SummarizeOptions,
   SummarizeResult,
+  TranslateSkillRequest,
   TunnelCredentials,
   TunnelStatus,
   UpdateAgent,
@@ -904,6 +905,13 @@ export class HoustonClient {
     signal?: AbortSignal,
   ): Promise<string[]> {
     return this.request("POST", "/skills/repo/install", req, undefined, signal);
+  }
+  /** Translate an installed skill to the app locale (HOU-733). */
+  translateSkill(
+    name: string,
+    req: TranslateSkillRequest,
+  ): Promise<SkillDetail> {
+    return this.request("POST", `/skills/${this.seg(name)}/translate`, req);
   }
 
   // ---------- preferences ----------

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -678,6 +678,16 @@ export interface InstallCommunityRequest {
   skillId: string;
 }
 
+/** How a post-install skill translation runs (HOU-733). */
+export type SkillTranslateMode = "machine" | "ai";
+
+export interface TranslateSkillRequest {
+  workspacePath: string;
+  /** BCP-47 base tag of the app locale (en/es/pt). */
+  target: string;
+  mode: SkillTranslateMode;
+}
+
 export interface CommunitySkill {
   id: string;
   skillId: string;


### PR DESCRIPTION
Implements HOU-733.

## What

After installing a skill from the marketplace (skills.sh) or a GitHub repo while the app runs in Spanish or Portuguese, a dialog offers to translate the installed skill into the app language, with two options:

- **Quick translation** — a free machine pass. The host calls Google's public gtx endpoint via plain fetch (no new dependency, nothing added to the bun-compiled sidecar). Markdown-aware: fenced code blocks (indented ones included) never reach the translator; prose is chunked to respect the endpoint's request size, with newline margins around fences preserved.
- **AI translation** — a one-shot run in the agent's runtime, where the provider credential lives, using the user's own AI provider. Mirrors the anonymize/title pattern, including the Anthropic compliance gate (Claude Agent SDK one-shot for `anthropic`, pi one-shot for everyone else).

"Keep original" (or dismissing) leaves the file untouched. English-locale apps never see the offer.

## How

- `packages/domain/skill-translate.ts` — splits SKILL.md into its human surfaces (`title`, `description`, `body`) and rebuilds the file deterministically from the original parse, so the translator (machine or model) can never touch the slug, version, dates, `featured`, `integrations`, `image`, or `tags`. Shares `renderSkillMd`/`clampLen` with the install composer.
- `packages/runtime` — `POST /skills/translate` one-shot route (`transport/translate-route.ts` → `session/translate.ts`); reply parsing delegates to the anonymize parser (identical wire shape, missing item = hard failure).
- `packages/host` — agent-scoped `POST /agents/:id/skills/:slug/translate` (`routes/skills-translate.ts`), `mode: "machine" | "ai"`. Machine mode translates host-side (`skills/machine-translate.ts`); AI mode goes through a new optional `RuntimeChannel.translateTexts` implemented by `ProxyChannel` (503 with the reason when the channel can't). Writes fire `SkillsChanged`. A short/failed translator reply answers 502 and writes nothing.
- **Clients** — `translateSkill` threaded through `ui/engine-client`, the web adapter + control-plane (agent-scoped, so the hosted gateway proxies it), and `tauriSkills.translate`.
- **App** — `SkillTranslateDialog` + offer state in `useSkillSurface` (community installs offer per skill; repo installs offer once for all installed slugs; a partial failure keeps only the failed slugs pending so retrying never re-translates a finished skill). Full i18n (en/es/pt, `skills:translate.*`), errors surface with the host's real reason.

## Tests

- `packages/domain/src/skill-translate.test.ts` — segment extraction, identity/bookkeeping preservation, clamping, unparseable originals.
- `packages/host/src/skills/machine-translate.test.ts` — fence shielding (flush + indented), lossless chunking, hard-split of oversized blocks, whitespace margins, failure surfacing.
- `packages/host/src/routes/skills-translate.test.ts` — machine + AI modes end-to-end over a real HTTP server + MemoryVfs, 503 without a channel, 404/400 validation, 502 on translator failure or short reply (file never half-written), SkillsChanged emission.
- `packages/runtime/src/session/translate.test.ts` — reply parsing (missing id = hard error), prompt language naming.

## Verifying the feature (before/after)

Before this branch there is no translation offer: installing any marketplace skill in a Spanish workspace just adds the English SKILL.md silently (nothing else to reproduce; this is a new feature).

After:
1. `pnpm dev`, set the workspace language to Español (Settings → Workspace), open an agent → Skills → Add skills.
2. Install any community skill (e.g. search "research"). The "¿Traducir al español?" dialog appears.
3. Pick **Traducción rápida** → the skill's title/description/body are machine-translated in place; code blocks stay untouched; the Skills list refreshes live (SkillsChanged).
4. Reinstall another skill and pick **Traducción con IA** (provider connected) → same result via the runtime one-shot. With no provider connected the dialog surfaces the real reason as an error toast.
5. "Mantener original" leaves the file byte-identical.

Out of scope, noted for follow-ups: offering translation for skills acquired through portable agent import, and detecting a foreign-language skill in an English-locale app.
