### PR TITLE
release: v0.4.27 — GPT-5.6 Sol, Terra, Luna (HOU-728)

### DIFF
--- a/.github/release-notes/0.4.27.es.md
+++ b/.github/release-notes/0.4.27.es.md
@@ -4,8 +4,8 @@
 
 - **GPT-5.6 Sol, Terra y Luna están en el selector de modelos.** La familia
   más nueva de OpenAI, lanzada el 9 de julio. Elígelos por agente o por misión.
-- **Sol desbloquea el nuevo nivel de razonamiento "max".** El pensamiento más
-  profundo que ofrece OpenAI, para los problemas más difíciles.
+- **Los tres desbloquean el nuevo nivel de razonamiento "max".** El
+  pensamiento más profundo que ofrece OpenAI, para los problemas más difíciles.
 
 ### Antes de actualizar
 

--- a/.github/release-notes/0.4.27.es.md
+++ b/.github/release-notes/0.4.27.es.md
@@ -1,0 +1,20 @@
+## Houston 0.4.27
+
+### Modelos
+
+- **GPT-5.6 Sol, Terra y Luna están en el selector de modelos.** La familia
+  más nueva de OpenAI, lanzada el 9 de julio. Elígelos por agente o por misión.
+- **Sol desbloquea el nuevo nivel de razonamiento "max".** El pensamiento más
+  profundo que ofrece OpenAI, para los problemas más difíciles.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza
+  limpiamente una app en ejecución. Ante la duda, elimina
+  `/Applications/Houston.app` y arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde 0.4.7 o posterior te lleva
+  adelante sola. El MSI todavía no tiene firma de código del sistema, así que
+  Windows SmartScreen puede advertir en una instalación nueva.
+- **Windows ARM64:** no hay ruta de actualización automática desde una
+  instalación x64 emulada. Descarga el MSI ARM64 manualmente, desinstala
+  primero la versión x64 y luego instala la ARM64.

--- a/.github/release-notes/0.4.27.md
+++ b/.github/release-notes/0.4.27.md
@@ -4,8 +4,8 @@
 
 - **GPT-5.6 Sol, Terra, and Luna are in the model picker.** OpenAI's newest
   family, released July 9. Pick them per agent or per mission.
-- **Sol unlocks the new "max" reasoning level.** The deepest thinking OpenAI
-  offers, for the hardest problems.
+- **All three unlock the new "max" reasoning level.** The deepest thinking
+  OpenAI offers, for the hardest problems.
 
 ### Before you upgrade
 

--- a/.github/release-notes/0.4.27.md
+++ b/.github/release-notes/0.4.27.md
@@ -1,0 +1,20 @@
+## Houston 0.4.27
+
+### Models
+
+- **GPT-5.6 Sol, Terra, and Luna are in the model picker.** OpenAI's newest
+  family, released July 9. Pick them per agent or per mission.
+- **Sol unlocks the new "max" reasoning level.** The deepest thinking OpenAI
+  offers, for the hardest problems.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a
+  running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag
+  the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward
+  automatically. The MSI is still not OS-code-signed, so Windows SmartScreen may
+  warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install.
+  Download the ARM64 MSI manually, uninstall the x64 build first, then install
+  the ARM64 one.

--- a/.github/release-notes/0.4.27.pt.md
+++ b/.github/release-notes/0.4.27.pt.md
@@ -1,0 +1,20 @@
+## Houston 0.4.27
+
+### Modelos
+
+- **GPT-5.6 Sol, Terra e Luna estão no seletor de modelos.** A família mais
+  nova da OpenAI, lançada em 9 de julho. Escolha por agente ou por missão.
+- **Sol libera o novo nível de raciocínio "max".** O pensamento mais profundo
+  que a OpenAI oferece, para os problemas mais difíceis.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui
+  corretamente um app em execução. Na dúvida, remova
+  `/Applications/Houston.app` e arraste a cópia nova.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou posterior
+  acontece sozinha. O MSI ainda não tem assinatura de código do sistema, então
+  o Windows SmartScreen pode alertar em uma instalação nova.
+- **Windows ARM64:** não há caminho de atualização automática a partir de uma
+  instalação x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a
+  versão x64 e depois instale a ARM64.

--- a/.github/release-notes/0.4.27.pt.md
+++ b/.github/release-notes/0.4.27.pt.md
@@ -4,8 +4,8 @@
 
 - **GPT-5.6 Sol, Terra e Luna estão no seletor de modelos.** A família mais
   nova da OpenAI, lançada em 9 de julho. Escolha por agente ou por missão.
-- **Sol libera o novo nível de raciocínio "max".** O pensamento mais profundo
-  que a OpenAI oferece, para os problemas mais difíceis.
+- **Os três liberam o novo nível de raciocínio "max".** O pensamento mais
+  profundo que a OpenAI oferece, para os problemas mais difíceis.
 
 ### Antes de atualizar
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2424,7 +2424,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-files"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "chrono",
  "serde",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agent-portable"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "chrono",
  "serde",
@@ -2451,7 +2451,7 @@ dependencies = [
 
 [[package]]
 name = "houston-agents-conversations"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "houston-db",
  "houston-terminal-manager",
@@ -2465,7 +2465,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2498,7 +2498,7 @@ dependencies = [
 
 [[package]]
 name = "houston-claude-installer"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "futures-util",
  "hex",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "houston-cli-bundle"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "serde",
  "serde_json",
@@ -2528,7 +2528,7 @@ dependencies = [
 
 [[package]]
 name = "houston-composio"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "base64 0.22.1",
  "dirs 5.0.1",
@@ -2546,7 +2546,7 @@ dependencies = [
 
 [[package]]
 name = "houston-db"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2559,7 +2559,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-core"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -2596,7 +2596,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-protocol"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "chrono",
  "houston-terminal-manager",
@@ -2608,7 +2608,7 @@ dependencies = [
 
 [[package]]
 name = "houston-engine-server"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2648,7 +2648,7 @@ dependencies = [
 
 [[package]]
 name = "houston-events"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2662,7 +2662,7 @@ dependencies = [
 
 [[package]]
 name = "houston-file-watcher"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "houston-ui-events",
  "notify",
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "houston-scheduler"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "houston-skills"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "chrono",
  "reqwest 0.12.28",
@@ -2703,7 +2703,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tauri"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "dirs 5.0.1",
  "houston-agent-files",
@@ -2722,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "houston-terminal-manager"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "chrono",
  "dirs 5.0.1",
@@ -2737,7 +2737,7 @@ dependencies = [
 
 [[package]]
 name = "houston-tunnel"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "houston-ui-events"
-version = "0.4.26"
+version = "0.4.27"
 dependencies = [
  "houston-terminal-manager",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,24 +33,24 @@ async-trait = "0.1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt"] }
 tracing-appender = "0.2"
-houston-terminal-manager = { version = "0.4.26", path = "engine/houston-terminal-manager" }
-houston-db = { version = "0.4.26", path = "engine/houston-db" }
-houston-tauri = { version = "0.4.26", path = "app/houston-tauri" }
-houston-events = { version = "0.4.26", path = "engine/houston-events" }
-houston-scheduler = { version = "0.4.26", path = "engine/houston-scheduler" }
-houston-skills = { version = "0.4.26", path = "engine/houston-skills" }
-houston-tunnel = { version = "0.4.26", path = "engine/houston-tunnel" }
-houston-agent-files = { version = "0.4.26", path = "engine/houston-agent-files" }
-houston-agent-portable = { version = "0.4.26", path = "engine/houston-agent-portable" }
-houston-ui-events = { version = "0.4.26", path = "engine/houston-ui-events" }
-houston-agents-conversations = { version = "0.4.26", path = "engine/houston-agents-conversations" }
-houston-file-watcher = { version = "0.4.26", path = "engine/houston-file-watcher" }
-houston-composio = { version = "0.4.26", path = "engine/houston-composio" }
-houston-cli-bundle = { version = "0.4.26", path = "engine/houston-cli-bundle" }
-houston-claude-installer = { version = "0.4.26", path = "engine/houston-claude-installer" }
-houston-engine-core = { version = "0.4.26", path = "engine/houston-engine-core" }
-houston-engine-protocol = { version = "0.4.26", path = "engine/houston-engine-protocol" }
-houston-engine-server = { version = "0.4.26", path = "engine/houston-engine-server" }
+houston-terminal-manager = { version = "0.4.27", path = "engine/houston-terminal-manager" }
+houston-db = { version = "0.4.27", path = "engine/houston-db" }
+houston-tauri = { version = "0.4.27", path = "app/houston-tauri" }
+houston-events = { version = "0.4.27", path = "engine/houston-events" }
+houston-scheduler = { version = "0.4.27", path = "engine/houston-scheduler" }
+houston-skills = { version = "0.4.27", path = "engine/houston-skills" }
+houston-tunnel = { version = "0.4.27", path = "engine/houston-tunnel" }
+houston-agent-files = { version = "0.4.27", path = "engine/houston-agent-files" }
+houston-agent-portable = { version = "0.4.27", path = "engine/houston-agent-portable" }
+houston-ui-events = { version = "0.4.27", path = "engine/houston-ui-events" }
+houston-agents-conversations = { version = "0.4.27", path = "engine/houston-agents-conversations" }
+houston-file-watcher = { version = "0.4.27", path = "engine/houston-file-watcher" }
+houston-composio = { version = "0.4.27", path = "engine/houston-composio" }
+houston-cli-bundle = { version = "0.4.27", path = "engine/houston-cli-bundle" }
+houston-claude-installer = { version = "0.4.27", path = "engine/houston-claude-installer" }
+houston-engine-core = { version = "0.4.27", path = "engine/houston-engine-core" }
+houston-engine-protocol = { version = "0.4.27", path = "engine/houston-engine-protocol" }
+houston-engine-server = { version = "0.4.27", path = "engine/houston-engine-server" }
 
 # Keep line-table debug info in release binaries so Sentry can symbolicate
 # Rust panics to file:line. Costs ~10-15% binary size; full debug info is

--- a/app/houston-tauri/Cargo.toml
+++ b/app/houston-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tauri"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Thin Tauri adapter for the Houston desktop app. Owns the event-sink bridge, tray UI, path helpers, and shared state. All domain logic lives in the engine crates."
 license = "MIT"

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 
 [lib]

--- a/app/src/lib/providers.test.mjs
+++ b/app/src/lib/providers.test.mjs
@@ -8,15 +8,32 @@ import {
 } from "./providers.ts";
 
 test("effort levels are per model", () => {
-  // Codex: has xhigh, no max. Every catalogued GPT model shares this set
-  // (verified against Codex's models_cache.json supported_reasoning_levels).
-  for (const id of ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"]) {
+  // Codex pre-5.6 models: xhigh top, no max (the server 400-rejects `max`
+  // on them; verified live against gpt-5.5). GPT-5.6 Terra/Luna stay on the
+  // same range until OpenAI confirms `max` beyond Sol.
+  for (const id of [
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex-spark",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+  ]) {
     assert.deepEqual(
       getEffortLevels("openai", id),
       ["low", "medium", "high", "xhigh"],
       id,
     );
   }
+  // GPT-5.6 Sol: the one Codex model with `max` (announced with 5.6).
+  // "ultra" is a subagent mode, not an effort level — never listed.
+  assert.deepEqual(getEffortLevels("openai", "gpt-5.6-sol"), [
+    "low",
+    "medium",
+    "high",
+    "xhigh",
+    "max",
+  ]);
   // Sonnet 4.6: has max, no xhigh.
   assert.deepEqual(getEffortLevels("anthropic", "claude-sonnet-4-6"), [
     "low",
@@ -84,7 +101,15 @@ test("validModelOrNull rejects retired aliases and accepts catalog IDs", () => {
   assert.equal(validModelOrNull("anthropic", "claude-sonnet-4-6"), "claude-sonnet-4-6");
   // Full Codex lineup is catalogued (gpt-5.5 + the gpt-5.4 / mini / spark
   // models added in HOU-589); the phantom gpt-5.5-codex never shipped.
-  for (const id of ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"]) {
+  for (const id of [
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+    "gpt-5.6-luna",
+    "gpt-5.5",
+    "gpt-5.4",
+    "gpt-5.4-mini",
+    "gpt-5.3-codex-spark",
+  ]) {
     assert.equal(validModelOrNull("openai", id), id);
   }
   assert.equal(validModelOrNull("openai", "gpt-5.5-codex"), null);

--- a/app/src/lib/providers.test.mjs
+++ b/app/src/lib/providers.test.mjs
@@ -9,31 +9,23 @@ import {
 
 test("effort levels are per model", () => {
   // Codex pre-5.6 models: xhigh top, no max (the server 400-rejects `max`
-  // on them; verified live against gpt-5.5). GPT-5.6 Terra/Luna stay on the
-  // same range until OpenAI confirms `max` beyond Sol.
-  for (const id of [
-    "gpt-5.5",
-    "gpt-5.4",
-    "gpt-5.4-mini",
-    "gpt-5.3-codex-spark",
-    "gpt-5.6-terra",
-    "gpt-5.6-luna",
-  ]) {
+  // on them; verified live against gpt-5.5).
+  for (const id of ["gpt-5.5", "gpt-5.4", "gpt-5.4-mini", "gpt-5.3-codex-spark"]) {
     assert.deepEqual(
       getEffortLevels("openai", id),
       ["low", "medium", "high", "xhigh"],
       id,
     );
   }
-  // GPT-5.6 Sol: the one Codex model with `max` (announced with 5.6).
-  // "ultra" is a subagent mode, not an effort level — never listed.
-  assert.deepEqual(getEffortLevels("openai", "gpt-5.6-sol"), [
-    "low",
-    "medium",
-    "high",
-    "xhigh",
-    "max",
-  ]);
+  // The whole GPT-5.6 family carries `max` (confirmed in codex's picker
+  // post-GA). "ultra" is a subagent mode, not an effort level — never listed.
+  for (const id of ["gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"]) {
+    assert.deepEqual(
+      getEffortLevels("openai", id),
+      ["low", "medium", "high", "xhigh", "max"],
+      id,
+    );
+  }
   // Sonnet 4.6: has max, no xhigh.
   assert.deepEqual(getEffortLevels("anthropic", "claude-sonnet-4-6"), [
     "low",

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -1,7 +1,9 @@
 /**
  * Reasoning-effort levels, ordered low→high. The set a given model accepts
  * is model-specific (see `ModelOption.effortLevels`):
- * - Codex `model_reasoning_effort`: low/medium/high/xhigh (no `max`).
+ * - Codex `model_reasoning_effort`: low/medium/high/xhigh; the bundled
+ *   codex (>= 0.143) also parses `max`, which the SERVER accepts only on
+ *   models that support it (GPT-5.6 Sol; gpt-5.5 and older 400-reject it).
  * - Claude `--effort`: Opus 4.7/4.8 and Sonnet 5 = all five; Sonnet 4.6 =
  *   low/medium/high/max (no `xhigh`). Claude self-clamps an unsupported
  *   value; Codex does not.
@@ -93,6 +95,54 @@ export const PROVIDERS: readonly ProviderInfo[] = [
     loginCommand: "codex login",
     cost: "Your ChatGPT subscription",
     models: [
+      {
+        id: "gpt-5.6-sol",
+        label: "GPT-5.6 Sol",
+        description: "OpenAI's new flagship for the hardest problems.",
+        // GPT-5.6 adds `max` at the top of the effort dial; Sol is the one
+        // model OpenAI's announcement confirms it for. Requires the bundled
+        // codex >= 0.143 (older CLIs hard-reject `max` at config parse; the
+        // server 400s it on models that don't support it, e.g. gpt-5.5).
+        // GPT-5.6 "ultra" is a subagent MODE, not an effort level — never
+        // add it here (same rule as Claude's `ultracode`).
+        effortLevels: ["low", "medium", "high", "xhigh", "max"],
+        // OpenAI has published NO context-window spec for the 5.6 family as
+        // of 2026-07-08 (GA 2026-07-09); the "1.5M" figure circulating is
+        // preview-partner observation, not documentation. Codex has capped
+        // every recent model's effective window at 272k raw x 95% = 258_400
+        // (gpt-5.4, gpt-5.5) regardless of larger raw API offers, so start
+        // there. The snap-up ceiling covers the reported 1.5M x 95% =
+        // 1_425_000 so a genuinely larger window can't overflow the
+        // indicator; it only engages once observed usage proves > 258_400.
+        // Revisit against codex's models_cache.json once it lists gpt-5.6.
+        contextWindow: 258_400,
+        contextWindowMax: 1_425_000,
+      },
+      {
+        id: "gpt-5.6-terra",
+        label: "GPT-5.6 Terra",
+        description: "Balanced power and cost for everyday work.",
+        // OpenAI confirms `max` only for Sol; whether Terra/Luna accept it
+        // is unstated and the server hard-400s unsupported efforts, so stay
+        // on the proven Codex range. Extend to `max` only once verified
+        // against the live API / codex models_cache.json.
+        effortLevels: ["low", "medium", "high", "xhigh"],
+        // Same pre-GA estimate rationale as Sol above, but no 1.5M report
+        // exists for Terra, so the ceiling stays at the 5.5-line precedent
+        // (1M x 95% = 950_000).
+        contextWindow: 258_400,
+        contextWindowMax: 950_000,
+      },
+      {
+        id: "gpt-5.6-luna",
+        label: "GPT-5.6 Luna",
+        description: "Fastest and most affordable GPT-5.6.",
+        // See Terra: `max` unconfirmed off-Sol, keep the proven range.
+        effortLevels: ["low", "medium", "high", "xhigh"],
+        // See Terra: pre-GA estimate, 5.5-line snap-up ceiling.
+        contextWindow: 258_400,
+        contextWindowMax: 950_000,
+      },
       {
         id: "gpt-5.5",
         label: "GPT-5.5",

--- a/app/src/lib/providers.ts
+++ b/app/src/lib/providers.ts
@@ -3,7 +3,8 @@
  * is model-specific (see `ModelOption.effortLevels`):
  * - Codex `model_reasoning_effort`: low/medium/high/xhigh; the bundled
  *   codex (>= 0.143) also parses `max`, which the SERVER accepts only on
- *   models that support it (GPT-5.6 Sol; gpt-5.5 and older 400-reject it).
+ *   models that support it (the GPT-5.6 family; gpt-5.5 and older
+ *   400-reject it).
  * - Claude `--effort`: Opus 4.7/4.8 and Sonnet 5 = all five; Sonnet 4.6 =
  *   low/medium/high/max (no `xhigh`). Claude self-clamps an unsupported
  *   value; Codex does not.
@@ -98,13 +99,14 @@ export const PROVIDERS: readonly ProviderInfo[] = [
       {
         id: "gpt-5.6-sol",
         label: "GPT-5.6 Sol",
-        description: "OpenAI's new flagship for the hardest problems.",
-        // GPT-5.6 adds `max` at the top of the effort dial; Sol is the one
-        // model OpenAI's announcement confirms it for. Requires the bundled
-        // codex >= 0.143 (older CLIs hard-reject `max` at config parse; the
-        // server 400s it on models that don't support it, e.g. gpt-5.5).
-        // GPT-5.6 "ultra" is a subagent MODE, not an effort level — never
-        // add it here (same rule as Claude's `ultracode`).
+        description: "Latest frontier agentic coding model.",
+        // GPT-5.6 adds `max` at the top of the effort dial; all three 5.6
+        // models carry it (confirmed in codex's own picker post-GA).
+        // Requires the bundled codex >= 0.143 (older CLIs hard-reject `max`
+        // at config parse; the server 400s it on models that don't support
+        // it, e.g. gpt-5.5). GPT-5.6 "ultra" is a subagent MODE, not an
+        // effort level — never add it here (same rule as Claude's
+        // `ultracode`).
         effortLevels: ["low", "medium", "high", "xhigh", "max"],
         // OpenAI has published NO context-window spec for the 5.6 family as
         // of 2026-07-08 (GA 2026-07-09); the "1.5M" figure circulating is
@@ -121,12 +123,10 @@ export const PROVIDERS: readonly ProviderInfo[] = [
       {
         id: "gpt-5.6-terra",
         label: "GPT-5.6 Terra",
-        description: "Balanced power and cost for everyday work.",
-        // OpenAI confirms `max` only for Sol; whether Terra/Luna accept it
-        // is unstated and the server hard-400s unsupported efforts, so stay
-        // on the proven Codex range. Extend to `max` only once verified
-        // against the live API / codex models_cache.json.
-        effortLevels: ["low", "medium", "high", "xhigh"],
+        description: "Balanced agentic coding model for everyday work.",
+        // Same effort dial as Sol — the whole 5.6 family carries `max`
+        // (confirmed in codex's own picker post-GA).
+        effortLevels: ["low", "medium", "high", "xhigh", "max"],
         // Same pre-GA estimate rationale as Sol above, but no 1.5M report
         // exists for Terra, so the ceiling stays at the 5.5-line precedent
         // (1M x 95% = 950_000).
@@ -136,9 +136,9 @@ export const PROVIDERS: readonly ProviderInfo[] = [
       {
         id: "gpt-5.6-luna",
         label: "GPT-5.6 Luna",
-        description: "Fastest and most affordable GPT-5.6.",
-        // See Terra: `max` unconfirmed off-Sol, keep the proven range.
-        effortLevels: ["low", "medium", "high", "xhigh"],
+        description: "Fast and affordable agentic coding model.",
+        // Same effort dial as Sol — the whole 5.6 family carries `max`.
+        effortLevels: ["low", "medium", "high", "xhigh", "max"],
         // See Terra: pre-GA estimate, 5.5-line snap-up ceiling.
         contextWindow: 258_400,
         contextWindowMax: 950_000,

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -79,9 +79,9 @@
       "max": "Deepest thinking, no token limit."
     },
     "modelDescriptions": {
-      "gpt-5_6-sol": "OpenAI's new flagship for the hardest problems.",
-      "gpt-5_6-terra": "Balanced power and cost for everyday work.",
-      "gpt-5_6-luna": "Fastest and most affordable GPT-5.6.",
+      "gpt-5_6-sol": "Latest frontier agentic coding model.",
+      "gpt-5_6-terra": "Balanced agentic coding model for everyday work.",
+      "gpt-5_6-luna": "Fast and affordable agentic coding model.",
       "gpt-5_5": "OpenAI's frontier model.",
       "gpt-5_4": "Strong model for everyday coding.",
       "gpt-5_4-mini": "Small, fast, and cost-efficient for simpler tasks.",

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -79,6 +79,9 @@
       "max": "Deepest thinking, no token limit."
     },
     "modelDescriptions": {
+      "gpt-5_6-sol": "OpenAI's new flagship for the hardest problems.",
+      "gpt-5_6-terra": "Balanced power and cost for everyday work.",
+      "gpt-5_6-luna": "Fastest and most affordable GPT-5.6.",
       "gpt-5_5": "OpenAI's frontier model.",
       "gpt-5_4": "Strong model for everyday coding.",
       "gpt-5_4-mini": "Small, fast, and cost-efficient for simpler tasks.",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -79,9 +79,9 @@
       "max": "Análisis máximo, sin límite de tokens."
     },
     "modelDescriptions": {
-      "gpt-5_6-sol": "El nuevo modelo insignia de OpenAI para los problemas más difíciles.",
-      "gpt-5_6-terra": "Equilibrio entre potencia y costo para el trabajo diario.",
-      "gpt-5_6-luna": "El GPT-5.6 más rápido y económico.",
+      "gpt-5_6-sol": "El modelo de frontera más reciente para programación agéntica.",
+      "gpt-5_6-terra": "Modelo de programación agéntica equilibrado para el trabajo diario.",
+      "gpt-5_6-luna": "Modelo de programación agéntica rápido y económico.",
       "gpt-5_5": "El modelo más avanzado de OpenAI.",
       "gpt-5_4": "Modelo potente para programar a diario.",
       "gpt-5_4-mini": "Pequeño, rápido y económico para tareas más simples.",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -79,6 +79,9 @@
       "max": "Análisis máximo, sin límite de tokens."
     },
     "modelDescriptions": {
+      "gpt-5_6-sol": "El nuevo modelo insignia de OpenAI para los problemas más difíciles.",
+      "gpt-5_6-terra": "Equilibrio entre potencia y costo para el trabajo diario.",
+      "gpt-5_6-luna": "El GPT-5.6 más rápido y económico.",
       "gpt-5_5": "El modelo más avanzado de OpenAI.",
       "gpt-5_4": "Modelo potente para programar a diario.",
       "gpt-5_4-mini": "Pequeño, rápido y económico para tareas más simples.",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -79,6 +79,9 @@
       "max": "Análise máxima, sem limite de tokens."
     },
     "modelDescriptions": {
+      "gpt-5_6-sol": "O novo modelo principal da OpenAI para os problemas mais difíceis.",
+      "gpt-5_6-terra": "Equilíbrio entre potência e custo para o trabalho do dia a dia.",
+      "gpt-5_6-luna": "O GPT-5.6 mais rápido e econômico.",
       "gpt-5_5": "O modelo mais avançado da OpenAI.",
       "gpt-5_4": "Modelo forte para programação do dia a dia.",
       "gpt-5_4-mini": "Pequeno, rápido e econômico para tarefas mais simples.",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -79,9 +79,9 @@
       "max": "Análise máxima, sem limite de tokens."
     },
     "modelDescriptions": {
-      "gpt-5_6-sol": "O novo modelo principal da OpenAI para os problemas mais difíceis.",
-      "gpt-5_6-terra": "Equilíbrio entre potência e custo para o trabalho do dia a dia.",
-      "gpt-5_6-luna": "O GPT-5.6 mais rápido e econômico.",
+      "gpt-5_6-sol": "O modelo de fronteira mais recente para programação agêntica.",
+      "gpt-5_6-terra": "Modelo de programação agêntica equilibrado para o trabalho do dia a dia.",
+      "gpt-5_6-luna": "Modelo de programação agêntica rápido e econômico.",
       "gpt-5_5": "O modelo mais avançado da OpenAI.",
       "gpt-5_4": "Modelo forte para programação do dia a dia.",
       "gpt-5_4-mini": "Pequeno, rápido e econômico para tarefas mais simples.",

--- a/cli-deps.json
+++ b/cli-deps.json
@@ -23,7 +23,7 @@
     }
   },
   "codex": {
-    "version": "0.137.0",
+    "version": "0.143.0",
     "bundled": true,
     "binary_name": "codex",
     "license": "Apache-2.0",
@@ -36,10 +36,10 @@
       "windows-arm64": "https://github.com/openai/codex/releases/download/rust-v{version}/codex-aarch64-pc-windows-msvc.exe.zst"
     },
     "checksums": {
-      "darwin-arm64": "628d2278b1fa2a467452635f2fd5aaeee98de4a94f2af06031e4790da6844046",
-      "darwin-x64": "32206ff8e4edb3422832b24d25a521246e4478b67bab2ec63bee632fdf94b306",
-      "windows-x64": "327e93f43d039734353d2ba7feb8ecffd8a0f90c068c5370ac2ae4f80436aa7a",
-      "windows-arm64": "1a24ce2d34a2b9e62a22c2a20626a78bab83250f148ce87b73c67b1b0923b1e7"
+      "darwin-arm64": "7df2384f037519dff7dbf4252e60913a5c1c7fdb66c1467c9125b2b2d3594a86",
+      "darwin-x64": "f776ef1d5e5f03151dd6e6af94cc7b13e9b08c3c52bd60327692009b01dbfb4a",
+      "windows-x64": "c5bd928642b5aa31cd3ca1203d6a4aecdfd39c6e5709a00e2014ab42160ba6d5",
+      "windows-arm64": "856045fa77f851425684fc12b4b638500d56ccc8a16717ffbe86d8955e791d72"
     }
   },
   "composio": {

--- a/engine/houston-agent-files/Cargo.toml
+++ b/engine/houston-agent-files/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-files"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Generic read/write access to agent files under .houston/<type>/<type>.json with JSON Schema co-location"
 license = "MIT"

--- a/engine/houston-agent-portable/Cargo.toml
+++ b/engine/houston-agent-portable/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agent-portable"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Portable agent package format — share an agent's CLAUDE.md, skills, routines, and learnings as a single .houstonagent file."
 license = "MIT"

--- a/engine/houston-agents-conversations/Cargo.toml
+++ b/engine/houston-agents-conversations/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-agents-conversations"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Orchestrates multi-session conversation lifecycle for Houston agents — spawn, monitor, persist, supervise"
 license = "MIT"

--- a/engine/houston-claude-installer/Cargo.toml
+++ b/engine/houston-claude-installer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-claude-installer"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Runtime installer for Anthropic Claude Code CLI — pinned URL + sha256-verified download"
 license = "MIT"

--- a/engine/houston-cli-bundle/Cargo.toml
+++ b/engine/houston-cli-bundle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-cli-bundle"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Resolve bundled CLI binaries (codex, composio) inside the Houston .app — runtime side"
 license = "MIT"

--- a/engine/houston-composio/Cargo.toml
+++ b/engine/houston-composio/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-composio"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Composio integration — CLI install/lifecycle, OAuth, app catalog (transport-neutral)"
 license = "MIT"

--- a/engine/houston-db/Cargo.toml
+++ b/engine/houston-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-db"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "SQLite database layer for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-engine-core/Cargo.toml
+++ b/engine/houston-engine-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-core"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Runtime container for Houston Engine — owns DB, event sinks, paths, and domain logic shared by HTTP routes and CLI tools"
 license = "MIT"

--- a/engine/houston-engine-core/src/sessions/provider.rs
+++ b/engine/houston-engine-core/src/sessions/provider.rs
@@ -193,7 +193,7 @@ fn read_agent_config(agent_dir: &Path) -> Option<AgentConfig> {
 /// Order:
 /// 1. The agent's `effort` in `config.json`, but only if the provider's CLI
 ///    actually accepts it ([`Provider::effort_levels`]). A value valid for
-///    one provider but not another (e.g. `max` on Codex, or a hand-edited
+///    one provider but not another (e.g. `ultra`, or a hand-edited
 ///    typo) is dropped rather than passed to a CLI that would reject it.
 /// 2. The provider's [`Provider::default_effort`] — the floor every session
 ///    gets when nothing valid is configured.
@@ -419,12 +419,12 @@ mod tests {
     }
 
     #[test]
-    fn effort_accepts_max_on_claude_but_clamps_on_codex() {
-        // `max` is valid for Claude; for Codex it is an unknown variant, so
-        // the configured value is dropped in favor of the provider default.
+    fn effort_accepts_max_on_both_claude_and_codex() {
+        // `max` is in both providers' unions since GPT-5.6 (codex >= 0.143
+        // parses it; the server/model gates whether it is honored).
         let (_d, agent) = agent_with(r#"{"effort":"max"}"#);
         assert_eq!(resolve_effort(&agent, anthropic()).as_deref(), Some("max"));
-        assert_eq!(resolve_effort(&agent, openai()).as_deref(), Some("medium"));
+        assert_eq!(resolve_effort(&agent, openai()).as_deref(), Some("max"));
     }
 
     #[test]
@@ -461,11 +461,11 @@ mod tests {
 
     #[test]
     fn effort_override_dropped_when_provider_rejects_it() {
-        // "max" is invalid for Codex → the override is dropped and the agent's
-        // configured/default effort is used instead.
+        // "ultra" is a GPT-5.6 harness MODE, not an effort level → the
+        // override is dropped and the agent's configured effort is used.
         let (_d, agent) = agent_with(r#"{"provider":"openai","effort":"high"}"#);
         assert_eq!(
-            resolve_effort_with_override(&agent, openai(), Some("max")).as_deref(),
+            resolve_effort_with_override(&agent, openai(), Some("ultra")).as_deref(),
             Some("high"),
         );
     }

--- a/engine/houston-engine-protocol/Cargo.toml
+++ b/engine/houston-engine-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-protocol"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Wire types for Houston Engine — REST DTOs, WS envelope, error codes, version const"
 license = "MIT"

--- a/engine/houston-engine-server/Cargo.toml
+++ b/engine/houston-engine-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-engine-server"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Houston Engine HTTP+WS server — axum binary speaking the Houston wire protocol"
 license = "MIT"

--- a/engine/houston-events/Cargo.toml
+++ b/engine/houston-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-events"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Core event system for AI agent desktop apps — unified input queue"
 license = "MIT"

--- a/engine/houston-file-watcher/Cargo.toml
+++ b/engine/houston-file-watcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-file-watcher"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Filesystem watcher that classifies changes in an agent directory and emits HoustonEvent variants for UI reactivity"
 license = "MIT"

--- a/engine/houston-scheduler/Cargo.toml
+++ b/engine/houston-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-scheduler"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Heartbeat and cron scheduling for AI agent desktop apps"
 license = "MIT"

--- a/engine/houston-skills/Cargo.toml
+++ b/engine/houston-skills/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-skills"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Hermes-style self-improving skills for AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/Cargo.toml
+++ b/engine/houston-terminal-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-terminal-manager"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Terminal/CLI subprocess manager for Claude, Codex, and other CLI-based AI agents"
 license = "MIT"

--- a/engine/houston-terminal-manager/src/provider/mod.rs
+++ b/engine/houston-terminal-manager/src/provider/mod.rs
@@ -509,11 +509,11 @@ mod tests {
             anthropic.effort_levels().to_vec(),
             vec!["low", "medium", "high", "xhigh", "max"]
         );
-        // Codex `model_reasoning_effort` has no `max` variant — including it
-        // would be an "unknown variant" error with no CLI-side fallback.
+        // Codex >= 0.143 parses `max` (added with GPT-5.6); the server
+        // gates which models honor it, the frontend gates which offer it.
         assert_eq!(
             openai.effort_levels().to_vec(),
-            vec!["low", "medium", "high", "xhigh"]
+            vec!["low", "medium", "high", "xhigh", "max"]
         );
         // Gemini CLI takes no effort flag.
         assert!(gemini.effort_levels().is_empty());

--- a/engine/houston-terminal-manager/src/provider/openai.rs
+++ b/engine/houston-terminal-manager/src/provider/openai.rs
@@ -73,7 +73,8 @@ impl ProviderAdapter for OpenAiAdapter {
         //
         // Codex loads `~/.codex/config.toml` before running any subcommand,
         // including `logout`. A `model_reasoning_effort` value the bundled
-        // CLI's enum doesn't recognize (e.g. `max`, which is Claude-only)
+        // CLI's enum doesn't recognize (a leftover from a newer or older
+        // CLI's enum — e.g. `max` before codex 0.143)
         // makes logout exit 1 with a config error, leaving the user stuck
         // signed in. Force a known-good value, same trick
         // `provider_auth::probe_codex_auth_status` uses for `login status`.
@@ -81,12 +82,16 @@ impl ProviderAdapter for OpenAiAdapter {
     }
 
     fn effort_levels(&self) -> &'static [&'static str] {
-        // Codex `ReasoningEffort` enum (bundled CLI):
-        // none/minimal/low/medium/high/xhigh. We surface the meaningful
-        // tuning range. `max` is Claude-only and would be an "unknown
-        // variant" to codex — and codex has no clamp-to-highest fallback —
-        // so it is deliberately excluded.
-        &["low", "medium", "high", "xhigh"]
+        // Codex `ReasoningEffort` (bundled CLI, >= 0.143 per cli-deps.json):
+        // none/minimal/low/medium/high/xhigh/max. We surface the meaningful
+        // tuning range. `max` arrived with GPT-5.6 — the pre-0.143 CLI
+        // hard-rejected it at config parse ("unknown variant", no
+        // clamp-to-highest fallback), so never ship `max` here with an older
+        // pinned codex. The SERVER still 400-rejects `max` on models that
+        // don't support it (verified live on gpt-5.5), so the engine carries
+        // the full union and the frontend catalog gates which models offer
+        // it (GPT-5.6 Sol only), mirroring the Anthropic adapter's split.
+        &["low", "medium", "high", "xhigh", "max"]
     }
 
     fn default_effort(&self) -> Option<&'static str> {

--- a/engine/houston-tunnel/Cargo.toml
+++ b/engine/houston-tunnel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-tunnel"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Outbound reverse tunnel client — engine dials Houston relay, multiplexes mobile HTTP+WS"
 license = "MIT"

--- a/engine/houston-ui-events/Cargo.toml
+++ b/engine/houston-ui-events/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-ui-events"
-version = "0.4.26"
+version = "0.4.27"
 edition = "2021"
 description = "Event types emitted from Houston backend to the UI via Tauri's event bus"
 license = "MIT"

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -220,14 +220,16 @@ adapter, see `knowledge-base/architecture.md`).
 | Provider id | CLI | Default model | Premium model | Login flow |
 |---|---|---|---|---|
 | `anthropic` (alias `claude`) | `claude` (runtime download) | `claude-sonnet-4-6` | `claude-opus-4-8` | OAuth via `claude auth login --claudeai` |
-| `openai` (alias `codex`) | `codex` (bundled) | `gpt-5.5` | `gpt-5.5` (frontier; no separate tier) | OAuth via `codex login` |
+| `openai` (alias `codex`) | `codex` (bundled) | `gpt-5.5` | `gpt-5.6-sol` (flagship) | OAuth via `codex login` |
 | `gemini` (alias `google`) | `gemini` (bundled, macOS only) | `gemini-2.5-flash` | `gemini-2.5-pro` | API key, no CLI login (see `knowledge-base/auth.md`) |
 
 Notes:
-- OpenAI ships four models in the picker: `gpt-5.5` (default, frontier),
-  `gpt-5.4` (everyday coding), `gpt-5.4-mini` (small/fast/cheap), and
-  `gpt-5.3-codex-spark` (ultra-fast). gpt-5.5 is both default and frontier, so
-  the "Premium model" column repeats it. The full catalog (labels, per-model
+- OpenAI ships seven models in the picker: the GPT-5.6 family
+  `gpt-5.6-sol` (flagship), `gpt-5.6-terra` (balanced), `gpt-5.6-luna`
+  (fast/cheap), plus `gpt-5.5` (default), `gpt-5.4` (everyday coding),
+  `gpt-5.4-mini` (small/fast/cheap), and `gpt-5.3-codex-spark` (ultra-fast).
+  The default stays `gpt-5.5` until 5.6 availability is verified post-GA
+  (2026-07-09). The full catalog (labels, per-model
   context windows, effort levels) lives in `app/src/lib/providers.ts`; codex
   itself enumerates them in `~/.codex/models_cache.json`. The model string is
   passed verbatim to `codex --model`, so the engine never validates against a
@@ -298,6 +300,9 @@ shows only the levels the active model accepts.
 | `anthropic` | `claude-opus-4-7` (Opus 4.7) | low, medium, high, xhigh, max | `--effort <v>` |
 | `anthropic` | `claude-sonnet-5` (Sonnet 5) | low, medium, high, xhigh, max | `--effort <v>` |
 | `anthropic` | `claude-sonnet-4-6` (Sonnet 4.6) | low, medium, high, max (no `xhigh`) | `--effort <v>` |
+| `openai` | `gpt-5.6-sol` (Sol) | low, medium, high, xhigh, max | `-c model_reasoning_effort="<v>"` |
+| `openai` | `gpt-5.6-terra` (Terra) | low, medium, high, xhigh (`max` unconfirmed off-Sol) | `-c model_reasoning_effort="<v>"` |
+| `openai` | `gpt-5.6-luna` (Luna) | low, medium, high, xhigh (`max` unconfirmed off-Sol) | `-c model_reasoning_effort="<v>"` |
 | `openai` | `gpt-5.5` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
 | `openai` | `gpt-5.4` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
 | `openai` | `gpt-5.4-mini` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
@@ -305,8 +310,12 @@ shows only the levels the active model accepts.
 | `gemini` | any | none | (no flag) |
 
 Claude self-clamps an unsupported `--effort` down to its highest supported
-level; codex has no such fallback, so `max` (an unknown variant to codex) is
-never offered for OpenAI. Default for every effort-capable provider is `medium`.
+level; codex has no CLI-side fallback and the SERVER 400-rejects an effort a
+model doesn't support (verified: `max` on gpt-5.5). `max` entered codex's
+config enum in 0.143 alongside GPT-5.6, so it is offered only on `gpt-5.6-sol`
+(the one model OpenAI confirms it for). GPT-5.6 "ultra" is a subagent mode,
+not an effort level, and is never offered. Default for every effort-capable
+provider is `medium`.
 
 ## Workspace
 - Storage: `~/.houston/workspaces/workspaces.json` (index) + one dir per workspace `~/.houston/workspaces/{Name}/`. `HOUSTON_DOCS` env var overrides the root.

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -301,8 +301,8 @@ shows only the levels the active model accepts.
 | `anthropic` | `claude-sonnet-5` (Sonnet 5) | low, medium, high, xhigh, max | `--effort <v>` |
 | `anthropic` | `claude-sonnet-4-6` (Sonnet 4.6) | low, medium, high, max (no `xhigh`) | `--effort <v>` |
 | `openai` | `gpt-5.6-sol` (Sol) | low, medium, high, xhigh, max | `-c model_reasoning_effort="<v>"` |
-| `openai` | `gpt-5.6-terra` (Terra) | low, medium, high, xhigh (`max` unconfirmed off-Sol) | `-c model_reasoning_effort="<v>"` |
-| `openai` | `gpt-5.6-luna` (Luna) | low, medium, high, xhigh (`max` unconfirmed off-Sol) | `-c model_reasoning_effort="<v>"` |
+| `openai` | `gpt-5.6-terra` (Terra) | low, medium, high, xhigh, max | `-c model_reasoning_effort="<v>"` |
+| `openai` | `gpt-5.6-luna` (Luna) | low, medium, high, xhigh, max | `-c model_reasoning_effort="<v>"` |
 | `openai` | `gpt-5.5` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
 | `openai` | `gpt-5.4` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
 | `openai` | `gpt-5.4-mini` | low, medium, high, xhigh (no `max`) | `-c model_reasoning_effort="<v>"` |
@@ -312,8 +312,8 @@ shows only the levels the active model accepts.
 Claude self-clamps an unsupported `--effort` down to its highest supported
 level; codex has no CLI-side fallback and the SERVER 400-rejects an effort a
 model doesn't support (verified: `max` on gpt-5.5). `max` entered codex's
-config enum in 0.143 alongside GPT-5.6, so it is offered only on `gpt-5.6-sol`
-(the one model OpenAI confirms it for). GPT-5.6 "ultra" is a subagent mode,
+config enum in 0.143 alongside GPT-5.6 and is offered on the whole 5.6 family
+(Sol, Terra, Luna — confirmed in codex's own picker post-GA). GPT-5.6 "ultra" is a subagent mode,
 not an effort level, and is never offered. Default for every effort-capable
 provider is `medium`.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.4.26",
+  "version": "0.4.27",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
## Summary

Self-contained release PR for **v0.4.27** of the legacy Rust-engine desktop app: **new OpenAI models only**. Base is `release-0.4.26`, cut exactly at the published v0.4.26 commit, so the diff is the complete release against what users run today.

**The HOU-719 migration machinery is deliberately NOT in this PR** — it stays on `rust-final/HOU-719` for a later release. Merging this ships nothing by itself; tagging `v0.4.27` on the merged commit builds the draft release.

Two commits:

1. **GPT-5.6 Sol / Terra / Luna in the model picker** — new OpenAI family (GA 2026-07-09), codex pin 0.137.0 → 0.143.0 (required for the new `max` effort to parse), efforts low/medium/high/xhigh/`max` on all three (family-wide `max` confirmed in codex's picker post-GA); `ultra` excluded (subagent mode, not an effort level). Descriptions copied from codex's own picker. Context windows are conservative pre-GA estimates (Codex's proven 258 400 effective cap + snap-up ceilings) because OpenAI published no window spec — see #792 for the full investigation.
2. **Version 0.4.26 → 0.4.27** across all version-line packages + Cargo.lock (regenerated manually — the version.sh lock-regen fix lives on the migration branch), plus authored release notes (en/es/pt).

## Verification

- `cd app && pnpm typecheck && pnpm test && pnpm check-locales` — clean (355 + 9 provider-catalog tests pass)
- `cd engine && cargo test -p houston-terminal-manager -p houston-engine-core` — all pass
- `./scripts/fetch-cli-deps.sh` — codex 0.143.0 checksums verify OK
- In-app: OpenAI picker shows the three GPT-5.6 entries, all offering `max`

## Before publishing the draft release (post-GA checklist)

- [x] Model IDs confirmed post-GA: codex's picker lists `gpt-5.6-sol` / `gpt-5.6-terra` / `gpt-5.6-luna` verbatim
- [x] Terra/Luna accept `max` — confirmed in codex's picker, all three carry it
- [ ] Replace the estimated context windows once Codex publishes `context_window` for the 5.6 family
- [ ] Smoke-test the packaged build against bundled codex 0.143.0 (event-schema drift 0.137→0.143)

Supersedes #792.

HOU-728
