### PR TITLE
fix(web): routine next-run shows the wrong hour — account preferences never reached the engine (HOU-732)

### DIFF
--- a/app/src/hooks/use-timezone-preference.ts
+++ b/app/src/hooks/use-timezone-preference.ts
@@ -44,9 +44,12 @@ async function fetchOnce(): Promise<string | null> {
         try {
           await tauriPreferences.set(TIMEZONE_KEY, detected);
           value = detected;
-        } catch {
-          // If persisting fails, fall back to the detected value in memory
-          // so the UI still has something to render a cron schedule against.
+        } catch (err) {
+          // Persist failed (the engine-call wrapper already toasted it). Keep
+          // the detected value in memory so the UI can still render a cron
+          // schedule — but the engine never learned the zone, so routines fire
+          // in the HOST's zone until a save succeeds (retried next launch).
+          console.error("[timezone] failed to persist detected zone:", err);
           value = detected;
         }
       }

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -162,6 +162,40 @@ function benignCancelMiss(e: unknown): void {
   throw e;
 }
 
+/**
+ * Preference keys that are ACCOUNT state, not device state. The engine acts on
+ * them — the host scheduler fires routines in `timezone` (hosted mode stamps it
+ * onto each agent's environment), `locale` backs the workspace wire shape, and
+ * the legal/migration flags must survive a reinstall — so they live behind the
+ * host's `/v1/preferences/:key`, never in this browser's localStorage. A
+ * device-local copy is invisible to the scheduler: routines then fire in the
+ * host's zone while the UI renders the browser's, an hours-off "next run"
+ * (HOU-732). Everything else (theme, last_agent_id, recent models, …) is
+ * per-device UI state and stays local.
+ */
+const ACCOUNT_PREF_KEYS = new Set([
+  "timezone",
+  "locale",
+  "legal_acceptance",
+  "migration_reconnect_dismissed",
+]);
+
+function readLocalPref(key: string): string | null {
+  try {
+    return localStorage.getItem(`houston.pref.${key}`);
+  } catch {
+    return null; /* storage disabled */
+  }
+}
+
+function removeLocalPref(key: string): void {
+  try {
+    localStorage.removeItem(`houston.pref.${key}`);
+  } catch {
+    /* storage disabled */
+  }
+}
+
 const SIDEBAR_LAYOUT_PREF = "houston.sidebar-layout";
 const EMPTY_SIDEBAR_LAYOUT: SidebarLayout = {
   groups: [],
@@ -520,13 +554,30 @@ export class HoustonClient {
       suggestedRoutine: r.suggestedRoutine ?? null,
     };
   }
+  /** The one config both deployments share: the gateway in cloud mode, the
+   *  local/self-host host otherwise — each serves `/v1/preferences/:key`. */
+  private prefConfig(): ControlPlaneConfig {
+    return this.cp ?? { baseUrl: this.baseUrl, token: this.token };
+  }
   async getPreference(key: string): Promise<string | null> {
-    try {
-      const stored = localStorage.getItem(`houston.pref.${key}`);
-      if (stored !== null) return stored;
-    } catch {
-      /* storage disabled */
+    if (ACCOUNT_PREF_KEYS.has(key)) {
+      const cfg = this.prefConfig();
+      const value = await controlPlane.getPreference(cfg, key);
+      if (value !== null) return value;
+      // One-time lift of a pre-fix device-local copy: earlier builds kept
+      // account keys in localStorage only, so the host never learned them.
+      // Migrate the stored value up (and drop the local copy) rather than
+      // re-deriving it — a deliberately chosen timezone must survive.
+      const legacy = readLocalPref(key);
+      if (legacy !== null) {
+        await controlPlane.setPreference(cfg, key, legacy);
+        removeLocalPref(key);
+        return legacy;
+      }
+      return null;
     }
+    const stored = readLocalPref(key);
+    if (stored !== null) return stored;
     // Default to the synthetic ids so the shell auto-selects the workspace +
     // agent on first load (otherwise no agent is current and the board is empty).
     if (key === "last_workspace_id") return DEFAULT_WORKSPACE_ID;
@@ -534,6 +585,11 @@ export class HoustonClient {
     return null;
   }
   async setPreference(key: string, value: string): Promise<void> {
+    if (ACCOUNT_PREF_KEYS.has(key)) {
+      await controlPlane.setPreference(this.prefConfig(), key, value);
+      removeLocalPref(key);
+      return;
+    }
     try {
       localStorage.setItem(`houston.pref.${key}`, value);
     } catch {

--- a/packages/web/tests/account-preferences.test.ts
+++ b/packages/web/tests/account-preferences.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { HoustonClient } from "../src/engine-adapter/client";
+
+/**
+ * HOU-732: account-level preferences must reach the ENGINE, not this browser's
+ * localStorage. The adapter used to keep every preference device-local, so the
+ * host scheduler never learned the user's timezone — hosted agents fired
+ * routines in the pod's zone (UTC) while the UI rendered the browser's, an
+ * hours-off "next run". These tests pin the split: account keys ride
+ * `/v1/preferences/:key` (gateway AND local host serve it), device keys stay
+ * in localStorage, and a pre-fix local copy is migrated up once.
+ */
+
+const originalFetch = globalThis.fetch;
+
+let store: Map<string, string>;
+let calls: { url: string; method: string; body: string | null }[];
+
+beforeEach(() => {
+  store = new Map();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  calls = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+function stubFetch(...responses: Response[]) {
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      method: init?.method ?? "GET",
+      body: typeof init?.body === "string" ? init.body : null,
+    });
+    const next = responses.shift();
+    if (!next) throw new Error("stubFetch: no responses left");
+    return next;
+  }) as unknown as typeof fetch;
+}
+
+function json(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const client = (controlPlane: boolean) =>
+  new HoustonClient({ baseUrl: "http://host", token: "t", controlPlane });
+
+test("timezone reads come from the engine, not localStorage", async () => {
+  store.set("houston.pref.timezone", "America/New_York"); // stale device copy
+  stubFetch(json(200, { value: "America/Bogota" }));
+
+  const value = await client(true).getPreference("timezone");
+
+  expect(value).toBe("America/Bogota");
+  expect(calls).toEqual([
+    { url: "http://host/v1/preferences/timezone", method: "GET", body: null },
+  ]);
+});
+
+test("timezone writes reach the engine and drop the device copy", async () => {
+  store.set("houston.pref.timezone", "America/New_York");
+  stubFetch(json(200, { value: "America/Bogota" }));
+
+  await client(true).setPreference("timezone", "America/Bogota");
+
+  expect(calls).toEqual([
+    {
+      url: "http://host/v1/preferences/timezone",
+      method: "PUT",
+      body: JSON.stringify({ value: "America/Bogota" }),
+    },
+  ]);
+  expect(store.has("houston.pref.timezone")).toBe(false);
+});
+
+test("a pre-fix device-local value is migrated up once, then dropped", async () => {
+  store.set("houston.pref.timezone", "America/Bogota");
+  stubFetch(json(200, { value: null }), json(200, { value: "America/Bogota" }));
+
+  const value = await client(true).getPreference("timezone");
+
+  expect(value).toBe("America/Bogota");
+  expect(calls.map((c) => `${c.method} ${c.url}`)).toEqual([
+    "GET http://host/v1/preferences/timezone",
+    "PUT http://host/v1/preferences/timezone",
+  ]);
+  expect(store.has("houston.pref.timezone")).toBe(false);
+});
+
+test("unset everywhere reads as null (the caller then auto-seeds)", async () => {
+  stubFetch(json(200, { value: null }));
+
+  await expect(client(true).getPreference("timezone")).resolves.toBeNull();
+  expect(calls).toHaveLength(1);
+});
+
+test("account keys ride the engine route in LOCAL mode too — the local host scheduler reads the same doc", async () => {
+  stubFetch(json(200, { value: "America/Bogota" }));
+
+  const value = await client(false).getPreference("timezone");
+
+  expect(value).toBe("America/Bogota");
+  expect(calls[0]?.url).toBe("http://host/v1/preferences/timezone");
+});
+
+test("an engine failure propagates — never a silent localStorage fallback", async () => {
+  store.set("houston.pref.timezone", "America/Bogota");
+  stubFetch(json(500, { error: "boom" }));
+
+  await expect(client(true).getPreference("timezone")).rejects.toThrow("boom");
+});
+
+test("device keys never touch the network", async () => {
+  stubFetch(); // any fetch would throw "no responses left"
+  const c = client(true);
+
+  await c.setPreference("theme", "dark");
+  await expect(c.getPreference("theme")).resolves.toBe("dark");
+  await expect(c.getPreference("last_agent_id")).resolves.not.toBeNull();
+
+  expect(calls).toEqual([]);
+});
+
+test("locale, legal_acceptance and the migration flag are account keys", async () => {
+  stubFetch(
+    json(200, { value: "es" }),
+    json(200, { value: '{"version":1}' }),
+    json(200, { value: "1" }),
+  );
+  const c = client(true);
+
+  await expect(c.getPreference("locale")).resolves.toBe("es");
+  await expect(c.getPreference("legal_acceptance")).resolves.toBe(
+    '{"version":1}',
+  );
+  await expect(c.getPreference("migration_reconnect_dismissed")).resolves.toBe(
+    "1",
+  );
+  expect(calls.map((c) => c.url)).toEqual([
+    "http://host/v1/preferences/locale",
+    "http://host/v1/preferences/legal_acceptance",
+    "http://host/v1/preferences/migration_reconnect_dismissed",
+  ]);
+});


### PR DESCRIPTION
## Root cause (HOU-732)

The web/desktop engine adapter kept **every** preference in the browser's `localStorage` — including `timezone`. The host therefore never learned the user's zone:

- **Hosted cloud:** the gateway's preference store stayed empty, so no agent environment ever got the user's timezone reconciled onto it. Every agent's scheduler evaluated cron expressions in **UTC**.
- **UI:** the routine editor computed "Next run" with the browser-detected zone it had auto-seeded locally.

For an every-2-hours routine (`0 */2 * * *`) in America/Bogota (UTC-5), the agent fired at even UTC hours = **odd local hours** (5:00, 7:00, next 9:00), while the editor promised even local hours ("Next run in 34m — today at 8:00 AM"). The runs and the display could never agree.

Verified live: no timezone preference existed server-side for any org, and no agent environment carried a zone, while the client showed `America/Bogota` from its local copy.

## Fix

- `packages/web/src/engine-adapter/client.ts`: account-level keys (`timezone`, `locale`, `legal_acceptance`, `migration_reconnect_dismissed`) now ride `GET/PUT /v1/preferences/:key` — served ConfigMap-backed by the cloud gateway and vfs-backed by the local host, both feeding the same scheduler that fires the routines. Device-state keys (theme, last_agent_id, recent models, …) stay in localStorage. A pre-fix device-local value is migrated up once (so a deliberately chosen zone survives), then dropped so it can never shadow server truth.
- `app/src/hooks/use-timezone-preference.ts`: the silent catch around the auto-seed persist no longer pretends success — the failure is logged (the engine-call wrapper already raises the red toast) and the comment states the consequence honestly.
- New `packages/web/tests/account-preferences.test.ts` pins the account/device split, the one-time migration, local-mode routing, and that engine failures propagate instead of falling back silently.

Once the timezone reaches the gateway, the existing reconcile loop stamps it onto each agent's environment within one sweep (~30s), so **existing agents self-heal** — no data migration needed.

Real-time display was verified intact: the host emits `RoutineRunsChanged`/`RoutinesChanged` on fire/complete/cancel, the gateway fans pod events into `/v1/events`, and the client invalidates the routines + run-history queries, so runs appear live.

## Repro (before)

1. Sign in to hosted Houston from a machine in a non-UTC zone (e.g. America/Bogota).
2. Create a routine "every 2 hours" on an agent; leave it enabled.
3. Note the editor's "Next run … · <your zone>" time, then compare with the actual run timestamps in Recent runs after a few hours: runs land offset from the promised hours (in Bogota: runs at odd hours, display promising even hours).

## Verify (after)

1. With this build, open the Routines tab once (the timezone auto-seed now PUTs `/v1/preferences/timezone` — confirm a 200 in the network log, or `GET /v1/preferences/timezone` returns the zone).
2. Within a minute the agent's environment picks up the zone (its pod restarts once); the routine's next fire, the "Next run" label, and subsequent Recent-runs timestamps all agree in the account zone.
3. `pnpm --filter houston-web test` — the new `account-preferences.test.ts` suite passes (123 tests total).

## Gates

- `pnpm --filter houston-web test` ✓ (123 passed)
- `pnpm --filter houston-web typecheck` ✓ (shim parity + tsgo)
- `cd app && pnpm tsgo --noEmit` ✓, `pnpm check-locales` ✓
- `pnpm check` (Biome) ✓