### PR TITLE
feat(routines): state icons + three-dot rename/delete on routine rows

### DIFF
--- a/app/src/components/tabs/routine-flash-sections.ts
+++ b/app/src/components/tabs/routine-flash-sections.ts
@@ -1,0 +1,39 @@
+import type {
+  RoutineEditorSection,
+  RoutineFormData,
+} from "@houston-ai/routines";
+
+/**
+ * Which editor sections an external routine change touched — feeds the
+ * "the agent just changed this" flash (RoutineEditor's `flash` prop). Compares
+ * the editor's previous synced form against the fresh one, so only fields the
+ * user can actually SEE light up:
+ *
+ *  - name / prompt → the hero card ("details")
+ *  - schedule → the "When it runs" card
+ *  - notify + chat-mode toggles and the model/effort pin → the Behavior card
+ *
+ * `integrations` is deliberately unmapped: the editor renders no integrations
+ * row, and flashing an unrelated section would mis-attribute the change.
+ * Pure and type-only in its imports, so the bare node test runner loads it.
+ */
+export function changedEditorSections(
+  prev: RoutineFormData,
+  next: RoutineFormData,
+): RoutineEditorSection[] {
+  const sections: RoutineEditorSection[] = [];
+  if (prev.name !== next.name || prev.prompt !== next.prompt) {
+    sections.push("details");
+  }
+  if (prev.schedule !== next.schedule) sections.push("schedule");
+  if (
+    prev.suppress_when_silent !== next.suppress_when_silent ||
+    prev.chat_mode !== next.chat_mode ||
+    (prev.provider ?? null) !== (next.provider ?? null) ||
+    (prev.model ?? null) !== (next.model ?? null) ||
+    (prev.effort ?? null) !== (next.effort ?? null)
+  ) {
+    sections.push("behavior");
+  }
+  return sections;
+}

--- a/app/src/components/tabs/routines-tab.tsx
+++ b/app/src/components/tabs/routines-tab.tsx
@@ -1,6 +1,10 @@
-import type { RoutineFormData } from "@houston-ai/routines";
+import type {
+  RoutineEditorSection,
+  RoutineFormData,
+  SectionFlash,
+} from "@houston-ai/routines";
 import { RoutineEditor, RoutinesGrid } from "@houston-ai/routines";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   useCancelRoutineRun,
@@ -54,6 +58,18 @@ export default function RoutinesTab({ agent, agentDef }: TabProps) {
   const [baseline, setBaseline] = useState<RoutineFormData>(
     () => freshRoutinesState().baseline,
   );
+  // "The agent just changed this" flash on the editor. Nonce'd so back-to-back
+  // edits of the same section re-flash; cleared on any view/agent switch so a
+  // stale flash never replays when another routine opens.
+  const [flash, setFlash] = useState<SectionFlash | null>(null);
+  const flashNonceRef = useRef(0);
+  const handleExternalChange = useCallback(
+    (sections: RoutineEditorSection[]) => {
+      flashNonceRef.current += 1;
+      setFlash({ sections, nonce: flashNonceRef.current });
+    },
+    [],
+  );
 
   // `view`/`form`/`baseline` describe a routine belonging to ONE agent, but
   // this RoutinesTab instance is reused across agents — it's keyed by tab, not
@@ -70,6 +86,7 @@ export default function RoutinesTab({ agent, agentDef }: TabProps) {
     setView(fresh.view);
     setForm(fresh.form);
     setBaseline(fresh.baseline);
+    setFlash(null);
   }
 
   // Most recent run per routine, for the grid's "last run" badges.
@@ -93,6 +110,7 @@ export default function RoutinesTab({ agent, agentDef }: TabProps) {
       const next = routineToFormData(r);
       setForm(next);
       setBaseline(next);
+      setFlash(null);
       setView({ type: "editor", editId: routineId });
       // The chat always rides along (HOU-725): resume the routine's own
       // persisted chat, or start (and link) one on its first open.
@@ -107,6 +125,7 @@ export default function RoutinesTab({ agent, agentDef }: TabProps) {
   const handleCreate = useCallback(() => {
     setForm(EMPTY_FORM);
     setBaseline(EMPTY_FORM);
+    setFlash(null);
     setView({ type: "editor" });
     void chatSetup.startDraft();
   }, [chatSetup]);
@@ -121,6 +140,7 @@ export default function RoutinesTab({ agent, agentDef }: TabProps) {
     openEditor,
     setForm,
     setBaseline,
+    onExternalChange: handleExternalChange,
   });
 
   // While a routine is open on the active Routines tab, its chat stays open
@@ -281,6 +301,7 @@ export default function RoutinesTab({ agent, agentDef }: TabProps) {
           onDelete={editing ? () => handleDelete(editing.id) : undefined}
           accountTimezone={tz.timezone}
           hasChanges={!formMatchesRoutine(form, baseline)}
+          flash={flash}
           modelPicker={
             <RoutineModelControls
               agent={agent}

--- a/app/src/components/tabs/routines-tab.tsx
+++ b/app/src/components/tabs/routines-tab.tsx
@@ -174,6 +174,13 @@ export default function RoutinesTab({ agent, agentDef }: TabProps) {
     [deleteRoutine],
   );
 
+  const handleRename = useCallback(
+    async (routineId: string, name: string) => {
+      await updateRoutine.mutateAsync({ routineId, updates: { name } });
+    },
+    [updateRoutine],
+  );
+
   const handleRunNow = useCallback(
     (routineId: string) => {
       // Tracks user-initiated runs only ("Run now" button). Scheduled cron
@@ -311,6 +318,8 @@ export default function RoutinesTab({ agent, agentDef }: TabProps) {
         onSelect={openEditor}
         onCreate={handleCreate}
         onToggle={handleToggle}
+        onRename={handleRename}
+        onDelete={handleDelete}
         labels={labels.grid}
         rowLabels={labels.rowLabels}
         scheduleSummaryLabels={labels.schedule.summary}

--- a/app/src/components/tabs/use-routine-editor-sync.ts
+++ b/app/src/components/tabs/use-routine-editor-sync.ts
@@ -1,6 +1,10 @@
 import type { Routine } from "@houston-ai/engine-client";
-import type { RoutineFormData } from "@houston-ai/routines";
+import type {
+  RoutineEditorSection,
+  RoutineFormData,
+} from "@houston-ai/routines";
 import { useEffect, useRef } from "react";
+import { changedEditorSections } from "./routine-flash-sections";
 import {
   formMatchesRoutine,
   routineToFormData,
@@ -19,6 +23,11 @@ interface Args {
   openEditor: (routineId: string) => void;
   setForm: (form: RoutineFormData) => void;
   setBaseline: (form: RoutineFormData) => void;
+  /**
+   * Fired when an EXTERNAL edit (the setup chat's agent) refreshed the open
+   * form, with the editor sections it touched — drives the section flash.
+   */
+  onExternalChange?: (sections: RoutineEditorSection[]) => void;
 }
 
 /**
@@ -46,6 +55,7 @@ export function useRoutineEditorSync({
   openEditor,
   setForm,
   setBaseline,
+  onExternalChange,
 }: Args) {
   const draftIdRef = useRef<string | null>(null);
   const trackedAgentRef = useRef(agentId);
@@ -72,7 +82,10 @@ export function useRoutineEditorSync({
     if (!formMatchesRoutine(form, baseline)) return; // user has local edits
     setForm(next);
     setBaseline(next);
-  }, [routines, view, form, baseline, setForm, setBaseline]);
+    // Attribute the refresh: light up the sections the agent's edit touched.
+    const sections = changedEditorSections(baseline, next);
+    if (sections.length > 0) onExternalChange?.(sections);
+  }, [routines, view, form, baseline, setForm, setBaseline, onExternalChange]);
 
   return draftIdRef;
 }

--- a/app/src/locales/en/routines.json
+++ b/app/src/locales/en/routines.json
@@ -59,7 +59,14 @@
     "ranHours": "ran {n}h ago",
     "ranDays": "ran {n}d ago",
     "pauseRoutine": "Pause routine",
-    "resumeRoutine": "Resume routine"
+    "resumeRoutine": "Resume routine",
+    "moreActions": "Routine options",
+    "rename": "Rename",
+    "delete": "Delete",
+    "deleteTitle": "Delete \"{name}\"?",
+    "deleteDescription": "The routine stops running and its run history is permanently removed.",
+    "deleteConfirm": "Delete",
+    "deleteCancel": "Cancel"
   },
   "schedule": {
     "presets": {

--- a/app/src/locales/es/routines.json
+++ b/app/src/locales/es/routines.json
@@ -59,7 +59,14 @@
     "ranHours": "hace {n}h",
     "ranDays": "hace {n}d",
     "pauseRoutine": "Pausar rutina",
-    "resumeRoutine": "Reanudar rutina"
+    "resumeRoutine": "Reanudar rutina",
+    "moreActions": "Opciones de la rutina",
+    "rename": "Renombrar",
+    "delete": "Eliminar",
+    "deleteTitle": "¿Eliminar \"{name}\"?",
+    "deleteDescription": "La rutina dejará de ejecutarse y su historial se eliminará para siempre.",
+    "deleteConfirm": "Eliminar",
+    "deleteCancel": "Cancelar"
   },
   "schedule": {
     "presets": {

--- a/app/src/locales/pt/routines.json
+++ b/app/src/locales/pt/routines.json
@@ -59,7 +59,14 @@
     "ranHours": "há {n}h",
     "ranDays": "há {n}d",
     "pauseRoutine": "Pausar rotina",
-    "resumeRoutine": "Retomar rotina"
+    "resumeRoutine": "Retomar rotina",
+    "moreActions": "Opções da rotina",
+    "rename": "Renomear",
+    "delete": "Excluir",
+    "deleteTitle": "Excluir \"{name}\"?",
+    "deleteDescription": "A rotina deixará de ser executada e seu histórico será removido para sempre.",
+    "deleteConfirm": "Excluir",
+    "deleteCancel": "Cancelar"
   },
   "schedule": {
     "presets": {

--- a/app/src/styles/globals.css
+++ b/app/src/styles/globals.css
@@ -2,6 +2,7 @@
 @import "@houston-ai/core/src/globals.css";
 @import "@houston-ai/core/src/styles.css";
 @import "@houston-ai/chat/src/styles.css";
+@import "@houston-ai/routines/src/styles.css";
 /* Futuristic aurora + glass layer — imported LAST so its token
    overrides win at use-time. Delete this line to fully revert. */
 @import "./futuristic.css";

--- a/app/tests/routine-flash-sections.test.ts
+++ b/app/tests/routine-flash-sections.test.ts
@@ -1,0 +1,84 @@
+import { deepStrictEqual } from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { RoutineFormData } from "@houston-ai/routines";
+import { changedEditorSections } from "../src/components/tabs/routine-flash-sections.ts";
+
+// The "agent just changed this" flash lights exactly the editor sections an
+// external routine edit touched — never more (a wrong section mis-attributes
+// the change) and never fields the editor doesn't render (integrations).
+
+const base: RoutineFormData = {
+  name: "Morning digest",
+  prompt: "Summarize my inbox.",
+  schedule: "0 9 * * *",
+  suppress_when_silent: false,
+  chat_mode: "shared",
+  integrations: [],
+  provider: null,
+  model: null,
+  effort: null,
+};
+
+describe("changedEditorSections", () => {
+  it("maps name/prompt to the hero details card", () => {
+    deepStrictEqual(changedEditorSections(base, { ...base, name: "X" }), [
+      "details",
+    ]);
+    deepStrictEqual(changedEditorSections(base, { ...base, prompt: "Y" }), [
+      "details",
+    ]);
+  });
+
+  it("maps the schedule to its own card", () => {
+    deepStrictEqual(
+      changedEditorSections(base, { ...base, schedule: "0 18 * * *" }),
+      ["schedule"],
+    );
+  });
+
+  it("maps toggles and the model pin to the behavior card", () => {
+    deepStrictEqual(
+      changedEditorSections(base, { ...base, suppress_when_silent: true }),
+      ["behavior"],
+    );
+    deepStrictEqual(
+      changedEditorSections(base, { ...base, chat_mode: "per_run" }),
+      ["behavior"],
+    );
+    deepStrictEqual(
+      changedEditorSections(base, { ...base, model: "claude-fable-5" }),
+      ["behavior"],
+    );
+  });
+
+  it("treats an absent and a null model pin as the same value", () => {
+    const { provider: _p, model: _m, effort: _e, ...withoutPins } = base;
+    deepStrictEqual(
+      changedEditorSections(base, withoutPins as RoutineFormData),
+      [],
+    );
+  });
+
+  it("collects every touched section, in editor order", () => {
+    deepStrictEqual(
+      changedEditorSections(base, {
+        ...base,
+        name: "X",
+        schedule: "0 18 * * *",
+        chat_mode: "per_run",
+      }),
+      ["details", "schedule", "behavior"],
+    );
+  });
+
+  it("ignores fields the editor does not render (integrations)", () => {
+    deepStrictEqual(
+      changedEditorSections(base, { ...base, integrations: ["gmail"] }),
+      [],
+    );
+  });
+
+  it("returns nothing when the forms match", () => {
+    deepStrictEqual(changedEditorSections(base, { ...base }), []);
+  });
+});

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,26 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v11 - 2026-07-09
+
+`routine-row` grows a state icon and quick actions. The 8px status dot becomes
+a leading `status-icon` that names the state by shape, not color alone: a clock
+while the routine waits for its schedule (and while disabled, dimmed with the
+row), a pulsing filled bolt while a run is in flight, an amber pause badge
+while the in-flight run sleeps on a usage-limit window, a red alert when the
+last run errored. On the trailing edge, next to the enabled toggle, a new
+always-visible `quick-actions-menu` (three-dot trigger, same overflow idiom as
+the routine editor header) offers Rename and Delete: Rename swaps the title
+into an inline input (Enter/blur commits, Escape cancels — the board card's
+rename pattern), Delete confirms in a dialog before calling back (the board
+card's delete pattern). New states `paused` and `renaming`; anatomy `run-status`
+is renamed `status-icon` and `quick-actions-menu` added. This is a labels
+CONTRACT change: `RoutineRowLabels` gains `moreActions`, `rename`, `delete`,
+`deleteTitle` (`{name}` token), `deleteDescription`, `deleteConfirm`,
+`deleteCancel`; `RoutinesGrid` gains optional `onRename(routineId, name)` /
+`onDelete(routineId)` and `RoutineRow` optional `onRename(name)` / `onDelete`
+— all optional, so existing callers render unchanged minus the dot.
+
 ## v10 - 2026-07-08
 
 Revamp `plan-ready-card`'s three options into the composer mode-menu idiom.

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 10
+version: 11
 
 components:
   - id: agent-avatar
@@ -325,13 +325,27 @@ components:
   - id: routine-row
     title: Routine row
     purpose: A scheduled routine in the routines list -- schedule summary + next run.
-    anatomy: [name, schedule-summary, next-fire, enabled-toggle, run-status]
-    states: [enabled, disabled, running, last-run-failed]
+    anatomy:
+      [
+        status-icon,
+        name,
+        schedule-summary,
+        next-fire,
+        enabled-toggle,
+        quick-actions-menu,
+      ]
+    states: [enabled, disabled, running, paused, last-run-failed, renaming]
     variants: [list-row, grid-card]
     behavior: >-
       Shows a humanized schedule summary and the next fire time; the toggle
-      enables/disables the routine. Authoring the schedule is a separate surface.
-    a11y: listitem role; toggle labeled with the routine name; next-run as text.
+      enables/disables the routine. The leading status icon reflects the live
+      run state (waiting / running / usage-limit paused / last-run-failed).
+      The quick-actions menu renames inline and deletes behind a confirm
+      dialog. Authoring the schedule is a separate surface.
+    a11y: >-
+      listitem role; toggle labeled with the routine name; next-run as text;
+      status never color-alone (icon shape + row text carry it); menu trigger
+      always visible with an accessible label.
     since: 1
 
   - id: skill-row

--- a/packages/web/e2e/routine-agent-edit-flash.spec.ts
+++ b/packages/web/e2e/routine-agent-edit-flash.spec.ts
@@ -1,0 +1,68 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * When the agent modifies the OPEN routine from the setup chat, the editor
+ * refreshes in real time and the changed section lights up (the
+ * `routine-section-flash` animation) so the user can attribute the change.
+ * Here the "agent" is a REST PATCH against the fake host — the same
+ * RoutinesChanged event path a real agent edit rides.
+ */
+
+async function seedAgentId(): Promise<string> {
+  const agents = (await (await fetch(`${FAKE_HOST_URL}/agents`)).json()) as {
+    id: string;
+  }[];
+  return agents[0].id;
+}
+
+test("an agent edit refreshes the open editor and flashes the changed section", async ({
+  page,
+}) => {
+  const agentId = await seedAgentId();
+  const created = (await (
+    await fetch(`${FAKE_HOST_URL}/agents/${agentId}/routines`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        name: "Morning digest",
+        prompt: "Summarize my inbox.",
+        schedule: "0 9 * * *",
+      }),
+    })
+  ).json()) as { id: string };
+
+  await page.goto("/");
+  await page.locator('[data-tour-target="tab-routines"]').click();
+  await page.getByText("Morning digest").first().click();
+  await expect(page.getByRole("button", { name: "Run now" })).toBeVisible({
+    timeout: 10_000,
+  });
+  // No flash on plain open.
+  await expect(page.locator(".routine-section-flash")).toHaveCount(0);
+
+  // The "agent" moves the schedule to 6 PM while the editor is open.
+  await fetch(`${FAKE_HOST_URL}/agents/${agentId}/routines/${created.id}`, {
+    method: "PATCH",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ schedule: "0 18 * * *" }),
+  });
+
+  // The schedule section lights up — and ONLY the schedule section.
+  const flashed = page.locator("section.routine-section-flash");
+  await expect(flashed).toHaveCount(1, { timeout: 15_000 });
+  await expect(flashed).toContainText("When it runs");
+  await page.screenshot({
+    path: test.info().outputPath("routine-agent-edit-flash.png"),
+  });
+
+  // …and the form really shows the agent's change (6:00 PM daily): both the
+  // next-run preview AND the schedule picker itself re-derive from the new
+  // cron — the picker must never keep showing the pre-edit time.
+  await expect(
+    page
+      .getByText("today at 6:00 PM")
+      .or(page.getByText("tomorrow at 6:00 PM")),
+  ).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText("Runs every day at 6:00 PM")).toBeVisible();
+});

--- a/packages/web/e2e/routine-quick-actions.spec.ts
+++ b/packages/web/e2e/routine-quick-actions.spec.ts
@@ -1,0 +1,111 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * The routine row's quick actions: a three-dot menu (always visible, never
+ * hover-gated) offering Rename — an inline title edit, committed on Enter —
+ * and Delete, confirmed in a dialog before anything is removed. The old
+ * status dot is now a state icon, so the row still renders its schedule and
+ * next-run meta unchanged around it.
+ */
+
+async function seedAgentId(): Promise<string> {
+  const agents = (await (await fetch(`${FAKE_HOST_URL}/agents`)).json()) as {
+    id: string;
+  }[];
+  return agents[0].id;
+}
+
+async function seedRoutine(agentId: string, name: string): Promise<void> {
+  await fetch(`${FAKE_HOST_URL}/agents/${agentId}/routines`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ name, prompt: "p", schedule: "0 9 * * *" }),
+  });
+}
+
+async function routineNames(agentId: string): Promise<string[]> {
+  const { items } = (await (
+    await fetch(`${FAKE_HOST_URL}/agents/${agentId}/routines`)
+  ).json()) as { items: { name: string }[] };
+  return items.map((r) => r.name);
+}
+
+async function openRoutinesTab(page: import("@playwright/test").Page) {
+  await page.locator('[data-tour-target="tab-routines"]').click();
+  await expect(
+    page.getByRole("button", { name: "New routine" }).first(),
+  ).toBeVisible();
+}
+
+test("rename from the row menu edits the title inline and persists", async ({
+  page,
+}) => {
+  const agentId = await seedAgentId();
+  await seedRoutine(agentId, "Morning digest");
+
+  await page.goto("/");
+  await openRoutinesTab(page);
+  await expect(page.getByText("Morning digest")).toBeVisible();
+
+  // The three-dot trigger is visible without hovering the row.
+  await page
+    .getByRole("button", { name: "Routine options", exact: true })
+    .click();
+  await page.getByRole("menuitem", { name: "Rename" }).click();
+
+  // Inline edit: the title becomes an input; Enter commits.
+  const input = page.getByRole("textbox", { name: "Rename" });
+  await expect(input).toBeVisible();
+  await input.fill("Evening digest");
+  await input.press("Enter");
+
+  await expect(page.getByText("Evening digest")).toBeVisible();
+  await expect.poll(() => routineNames(agentId)).toEqual(["Evening digest"]);
+
+  // Renaming from the row never opened the editor.
+  await expect(page.getByRole("button", { name: "Run now" })).toHaveCount(0);
+
+  await page.screenshot({
+    path: test.info().outputPath("routine-row-quick-actions.png"),
+  });
+});
+
+test("delete from the row menu confirms first, then removes the routine", async ({
+  page,
+}) => {
+  const agentId = await seedAgentId();
+  await seedRoutine(agentId, "Doomed digest");
+
+  await page.goto("/");
+  await openRoutinesTab(page);
+  await expect(page.getByText("Doomed digest")).toBeVisible();
+
+  await page
+    .getByRole("button", { name: "Routine options", exact: true })
+    .click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+
+  // Nothing is deleted before the dialog confirms.
+  const dialog = page.getByRole("alertdialog");
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText('Delete "Doomed digest"?')).toBeVisible();
+  expect(await routineNames(agentId)).toEqual(["Doomed digest"]);
+
+  // Cancel keeps it…
+  await dialog.getByRole("button", { name: "Cancel" }).click();
+  await expect(page.getByText("Doomed digest")).toBeVisible();
+
+  // …confirm removes it.
+  await page
+    .getByRole("button", { name: "Routine options", exact: true })
+    .click();
+  await page.getByRole("menuitem", { name: "Delete" }).click();
+  await page
+    .getByRole("alertdialog")
+    .getByRole("button", { name: "Delete" })
+    .click();
+
+  await expect(page.getByText("Doomed digest")).toHaveCount(0);
+  await expect.poll(() => routineNames(agentId)).toEqual([]);
+});

--- a/ui/routines/src/index.ts
+++ b/ui/routines/src/index.ts
@@ -44,3 +44,7 @@ export type {
   SchedulePreset,
 } from "./types";
 export { SCHEDULE_PRESET_LABELS } from "./types";
+export type {
+  RoutineEditorSection,
+  SectionFlash,
+} from "./use-section-flash";

--- a/ui/routines/src/labels-default.ts
+++ b/ui/routines/src/labels-default.ts
@@ -157,4 +157,12 @@ export const DEFAULT_ROW_LABELS: RoutineRowLabels = {
   ranDays: "ran {n}d ago",
   pauseRoutine: "Pause routine",
   resumeRoutine: "Resume routine",
+  moreActions: "Routine options",
+  rename: "Rename",
+  delete: "Delete",
+  deleteTitle: 'Delete "{name}"?',
+  deleteDescription:
+    "The routine stops running and its run history is permanently removed.",
+  deleteConfirm: "Delete",
+  deleteCancel: "Cancel",
 };

--- a/ui/routines/src/labels.ts
+++ b/ui/routines/src/labels.ts
@@ -181,6 +181,16 @@ export interface RoutineRowLabels {
   ranDays: string;
   pauseRoutine: string;
   resumeRoutine: string;
+  /** aria-label for the row's three-dot quick-actions menu trigger. */
+  moreActions: string;
+  /** "Rename" menu item; also names the inline title input. */
+  rename: string;
+  delete: string;
+  /** Delete confirm title; `{name}` is the routine's display name. */
+  deleteTitle: string;
+  deleteDescription: string;
+  deleteConfirm: string;
+  deleteCancel: string;
 }
 
 // English default values, co-located in a sibling file to keep this one small.

--- a/ui/routines/src/routine-editor.tsx
+++ b/ui/routines/src/routine-editor.tsx
@@ -43,6 +43,7 @@ import { RunHistory } from "./run-history";
 import { ScheduleBuilder } from "./schedule-builder";
 import type { Routine, RoutineChatMode, RoutineRun } from "./types";
 import { useNow } from "./use-now";
+import { type SectionFlash, useSectionFlash } from "./use-section-flash";
 
 export interface RoutineFormData {
   name: string;
@@ -111,6 +112,12 @@ export interface RoutineEditorProps {
   runHistoryLabels?: RunHistoryLabels;
   /** BCP-47 locale for day names + time formatting in schedules. */
   locale?: string;
+  /**
+   * Flash the sections an EXTERNAL edit just changed (the setup chat's agent
+   * modifying the open routine) and scroll the first one into view when it's
+   * off-screen. Pass a fresh `nonce` per change; see useSectionFlash.
+   */
+  flash?: SectionFlash | null;
 }
 
 // ----- Building blocks -----
@@ -123,12 +130,24 @@ export interface RoutineEditorProps {
 function SectionCard({
   title,
   children,
+  flashing,
+  innerRef,
 }: {
   title: string;
   children: React.ReactNode;
+  /** Play the agent-edit flash animation (see useSectionFlash). */
+  flashing?: boolean;
+  /** Registers the card element so the flash can scroll it into view. */
+  innerRef?: (el: HTMLElement | null) => void;
 }) {
   return (
-    <section className="rounded-xl bg-secondary px-5 py-5">
+    <section
+      ref={innerRef}
+      className={cn(
+        "rounded-xl bg-secondary px-5 py-5",
+        flashing && "routine-section-flash",
+      )}
+    >
       <h3 className="text-sm font-medium text-foreground mb-4">{title}</h3>
       <div className="space-y-4">{children}</div>
     </section>
@@ -166,7 +185,9 @@ export function RoutineEditor({
   nextFireLabels = DEFAULT_NEXT_FIRE_LABELS,
   runHistoryLabels = DEFAULT_RUN_HISTORY_LABELS,
   locale = "en-US",
+  flash,
 }: RoutineEditorProps) {
+  const { refFor, isFlashing } = useSectionFlash(flash);
   const runningRun = runs.find((r) => r.status === "running");
   const isEdit = !!routine;
   const canSubmit =
@@ -283,7 +304,13 @@ export function RoutineEditor({
       <div className="flex-1 min-h-0 overflow-y-auto">
         <div className="max-w-3xl mx-auto px-6 pt-3 pb-12 space-y-3">
           {/* Hero composer — gray card holding three labeled white-well fields */}
-          <section className="rounded-xl bg-secondary p-5 space-y-4">
+          <section
+            ref={refFor("details")}
+            className={cn(
+              "rounded-xl bg-secondary p-5 space-y-4",
+              isFlashing("details") && "routine-section-flash",
+            )}
+          >
             <div>
               <FieldLabel>{labels.nameLabel}</FieldLabel>
               <input
@@ -320,7 +347,11 @@ export function RoutineEditor({
             </div>
           </section>
 
-          <SectionCard title={labels.sectionWhen}>
+          <SectionCard
+            title={labels.sectionWhen}
+            innerRef={refFor("schedule")}
+            flashing={isFlashing("schedule")}
+          >
             <ScheduleBuilder
               value={value.schedule}
               onChange={(schedule) => onChange({ schedule })}
@@ -362,7 +393,11 @@ export function RoutineEditor({
             </div>
           </SectionCard>
 
-          <SectionCard title={labels.sectionBehavior}>
+          <SectionCard
+            title={labels.sectionBehavior}
+            innerRef={refFor("behavior")}
+            flashing={isFlashing("behavior")}
+          >
             {modelPicker && (
               <div className="flex items-center justify-between gap-4">
                 <div className="min-w-0">

--- a/ui/routines/src/routine-row-menu.tsx
+++ b/ui/routines/src/routine-row-menu.tsx
@@ -1,0 +1,88 @@
+/**
+ * RoutineRowMenu — the row's three-dot quick-actions menu: Rename (hands off to
+ * the row's inline title editor) and Delete (confirmed in a dialog, like the
+ * board's mission cards). Same trigger + menu idiom as the routine editor's
+ * header overflow. Always visible (never hover-gated); the caller wraps it in a
+ * propagation stop so opening the menu doesn't open the editor.
+ */
+import {
+  Button,
+  ConfirmDialog,
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@houston-ai/core";
+import { MoreHorizontal, Pencil, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { DEFAULT_ROW_LABELS, interp, type RoutineRowLabels } from "./labels";
+
+export interface RoutineRowMenuProps {
+  /** The routine's display name, for the delete confirm title. */
+  name: string;
+  /** Start the row's inline rename. */
+  onRename?: () => void;
+  /** Delete the routine — called only after the dialog confirms. */
+  onDelete?: () => void;
+  labels?: RoutineRowLabels;
+}
+
+export function RoutineRowMenu({
+  name,
+  onRename,
+  onDelete,
+  labels = DEFAULT_ROW_LABELS,
+}: RoutineRowMenuProps) {
+  const [confirming, setConfirming] = useState(false);
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            className="text-muted-foreground/60 hover:text-foreground"
+            aria-label={labels.moreActions}
+          >
+            <MoreHorizontal className="size-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="w-44">
+          {onRename && (
+            <DropdownMenuItem onClick={onRename}>
+              <Pencil className="size-3.5" />
+              {labels.rename}
+            </DropdownMenuItem>
+          )}
+          {onDelete && (
+            <>
+              {onRename && <DropdownMenuSeparator />}
+              <DropdownMenuItem
+                variant="destructive"
+                onClick={() => setConfirming(true)}
+              >
+                <Trash2 className="size-3.5" />
+                {labels.delete}
+              </DropdownMenuItem>
+            </>
+          )}
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <ConfirmDialog
+        open={confirming}
+        onOpenChange={setConfirming}
+        title={interp(labels.deleteTitle, { name })}
+        description={labels.deleteDescription}
+        confirmLabel={labels.deleteConfirm}
+        cancelLabel={labels.deleteCancel}
+        onConfirm={() => {
+          onDelete?.();
+          setConfirming(false);
+        }}
+      />
+    </>
+  );
+}

--- a/ui/routines/src/routine-row-meta.tsx
+++ b/ui/routines/src/routine-row-meta.tsx
@@ -1,0 +1,93 @@
+/**
+ * RoutineRowMeta — the row's right-hand meta column: the next fire time
+ * (relative + absolute, in the account zone) over the last-run recency, with
+ * the amber "waiting" note while an in-flight run sleeps on a usage-limit
+ * window. Hidden below the sm breakpoint, exactly as before the extraction.
+ */
+import {
+  DEFAULT_NEXT_FIRE_LABELS,
+  DEFAULT_ROW_LABELS,
+  interp,
+  type NextFireLabels,
+  type RoutineRowLabels,
+} from "./labels";
+import { describeNextFire, nextFire } from "./next-fire";
+import type { Routine, RoutineRun } from "./types";
+
+export interface RoutineRowMetaProps {
+  routine: Routine;
+  lastRun?: RoutineRun;
+  accountTimezone: string;
+  now: Date;
+  /** True while the in-flight run sleeps on a usage-limit window. */
+  isPaused: boolean;
+  labels?: RoutineRowLabels;
+  nextFireLabels?: NextFireLabels;
+  locale?: string;
+}
+
+function lastRunLabel(
+  lastRun: RoutineRun | undefined,
+  now: Date,
+  labels: RoutineRowLabels,
+): string | null {
+  if (!lastRun) return null;
+  const date = new Date(lastRun.started_at);
+  const diff = now.getTime() - date.getTime();
+  const mins = Math.floor(diff / 60_000);
+  if (mins < 1) return labels.justRan;
+  if (mins < 60) return interp(labels.ranMinutes, { n: mins });
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return interp(labels.ranHours, { n: hours });
+  const days = Math.floor(hours / 24);
+  return interp(labels.ranDays, { n: days });
+}
+
+export function RoutineRowMeta({
+  routine,
+  lastRun,
+  accountTimezone,
+  now,
+  isPaused,
+  labels = DEFAULT_ROW_LABELS,
+  nextFireLabels = DEFAULT_NEXT_FIRE_LABELS,
+  locale = "en-US",
+}: RoutineRowMetaProps) {
+  const next = routine.enabled
+    ? nextFire(routine.schedule, accountTimezone, now)
+    : null;
+  const nextDescr = next
+    ? describeNextFire(next, accountTimezone, now, nextFireLabels, locale)
+    : null;
+  const lastLabel = lastRunLabel(lastRun, now, labels);
+
+  return (
+    <div className="hidden sm:flex flex-col items-end shrink-0 min-w-[140px]">
+      {nextDescr ? (
+        <>
+          <p className="text-xs text-foreground tabular-nums">
+            {interp(labels.next, { relative: nextDescr.relative })}
+          </p>
+          <p className="text-[11px] text-muted-foreground tabular-nums mt-0.5">
+            {nextDescr.absolute}
+          </p>
+        </>
+      ) : routine.enabled ? (
+        <p className="text-xs text-muted-foreground">{labels.noNextRun}</p>
+      ) : (
+        <p className="text-xs text-muted-foreground">{labels.paused}</p>
+      )}
+      {isPaused ? (
+        <p className="text-[11px] text-amber-700 mt-0.5 tabular-nums">
+          {interp(labels.waiting, { time: lastRun?.paused_until ?? "" })}
+        </p>
+      ) : (
+        lastLabel && (
+          <p className="text-[11px] text-muted-foreground/70 mt-0.5 tabular-nums">
+            {lastLabel}
+          </p>
+        )
+      )}
+    </div>
+  );
+}

--- a/ui/routines/src/routine-row-status.tsx
+++ b/ui/routines/src/routine-row-status.tsx
@@ -1,0 +1,46 @@
+/**
+ * RoutineRowStatus — the row's leading state icon. Replaces the old 8px status
+ * dot with a glyph that says WHAT the routine is doing, not just that it has a
+ * color: a clock while it waits for its schedule, a pulsing bolt while a run is
+ * in flight, a pause badge while a run sleeps on a usage-limit window, an alert
+ * when the last run errored. Color still reinforces state, but never alone.
+ *
+ * Decorative (aria-hidden): the row's text meta ("Next in…", "ran 2h ago",
+ * "Waiting · resumes at…") carries the same information for screen readers,
+ * exactly as it did with the dot.
+ */
+import { cn } from "@houston-ai/core";
+import { CircleAlert, Clock, PauseCircle, Zap } from "lucide-react";
+import type { Routine, RoutineRun } from "./types";
+
+export interface RoutineRowStatusProps {
+  routine: Routine;
+  lastRun?: RoutineRun;
+  /** True while the in-flight run sleeps on a usage-limit window. */
+  isPaused: boolean;
+}
+
+export function RoutineRowStatus({
+  routine,
+  lastRun,
+  isPaused,
+}: RoutineRowStatusProps) {
+  const cls = "size-4 shrink-0";
+  if (routine.enabled && lastRun?.status === "running") {
+    if (isPaused) {
+      return <PauseCircle className={cn(cls, "text-amber-500")} aria-hidden />;
+    }
+    return (
+      <Zap
+        className={cn(cls, "text-blue-500 fill-current animate-pulse")}
+        aria-hidden
+      />
+    );
+  }
+  if (routine.enabled && lastRun?.status === "error") {
+    return <CircleAlert className={cn(cls, "text-red-500")} aria-hidden />;
+  }
+  // Idle (scheduled, waiting for the next fire) and disabled both read as a
+  // clock; the row already dims to 55% opacity when disabled.
+  return <Clock className={cn(cls, "text-muted-foreground")} aria-hidden />;
+}

--- a/ui/routines/src/routine-row.tsx
+++ b/ui/routines/src/routine-row.tsx
@@ -1,21 +1,25 @@
 /**
  * RoutineRow — a single full-width row in the routines list.
  *
- * Visual: hairline-divided rows, generous height, status as a left-edge dot
- * + colored accent. Switch on the right. The whole row is clickable; the
- * switch stops propagation so toggling doesn't open the editor.
+ * Visual: hairline-divided rows, generous height, state as a leading icon
+ * (clock waiting, pulsing bolt running — see RoutineRowStatus). Switch + a
+ * three-dot quick-actions menu (rename / delete) on the right. The whole row is
+ * clickable; the trailing controls stop propagation so using them doesn't open
+ * the editor.
  */
 import { cn, Switch } from "@houston-ai/core";
+import { useEffect, useRef, useState } from "react";
 import {
   DEFAULT_NEXT_FIRE_LABELS,
   DEFAULT_ROW_LABELS,
   DEFAULT_SCHEDULE_SUMMARY_LABELS,
-  interp,
   type NextFireLabels,
   type RoutineRowLabels,
   type ScheduleSummaryLabels,
 } from "./labels";
-import { describeNextFire, nextFire } from "./next-fire";
+import { RoutineRowMenu } from "./routine-row-menu";
+import { RoutineRowMeta } from "./routine-row-meta";
+import { RoutineRowStatus } from "./routine-row-status";
 import { cronSummary } from "./schedule-summary";
 import type { Routine, RoutineRun } from "./types";
 import { useNow } from "./use-now";
@@ -27,6 +31,10 @@ export interface RoutineRowProps {
   accountTimezone: string;
   onClick?: () => void;
   onToggle?: (enabled: boolean) => void;
+  /** Rename the routine (three-dot menu → inline title edit). */
+  onRename?: (name: string) => void;
+  /** Delete the routine — the row confirms first. */
+  onDelete?: () => void;
   /** Localized row labels. English defaults so standalone callers still work. */
   labels?: RoutineRowLabels;
   /** Schedule-summary + next-run labels, threaded to the cron/time formatters. */
@@ -36,50 +44,32 @@ export interface RoutineRowProps {
   locale?: string;
 }
 
-const STATUS_DOT: Record<string, string> = {
-  silent: "bg-gray-400",
-  surfaced: "bg-foreground",
-  running: "bg-blue-500",
-  error: "bg-red-500",
-  cancelled: "bg-gray-400",
-};
-
-function lastRunLabel(
-  lastRun: RoutineRun | undefined,
-  now: Date,
-  labels: RoutineRowLabels,
-): string | null {
-  if (!lastRun) return null;
-  const date = new Date(lastRun.started_at);
-  const diff = now.getTime() - date.getTime();
-  const mins = Math.floor(diff / 60_000);
-  if (mins < 1) return labels.justRan;
-  if (mins < 60) return interp(labels.ranMinutes, { n: mins });
-  const hours = Math.floor(mins / 60);
-  if (hours < 24) return interp(labels.ranHours, { n: hours });
-  const days = Math.floor(hours / 24);
-  return interp(labels.ranDays, { n: days });
-}
-
 export function RoutineRow({
   routine,
   lastRun,
   accountTimezone,
   onClick,
   onToggle,
+  onRename,
+  onDelete,
   labels = DEFAULT_ROW_LABELS,
   scheduleSummaryLabels = DEFAULT_SCHEDULE_SUMMARY_LABELS,
   nextFireLabels = DEFAULT_NEXT_FIRE_LABELS,
   locale = "en-US",
 }: RoutineRowProps) {
   const now = useNow(60_000);
-  const next = routine.enabled
-    ? nextFire(routine.schedule, accountTimezone, now)
-    : null;
-  const nextDescr = next
-    ? describeNextFire(next, accountTimezone, now, nextFireLabels, locale)
-    : null;
-  const lastLabel = lastRunLabel(lastRun, now, labels);
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState(routine.name);
+  const inputRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    if (editing) inputRef.current?.focus();
+  }, [editing]);
+
+  const commitRename = () => {
+    const trimmed = editValue.trim();
+    if (trimmed && trimmed !== routine.name) onRename?.(trimmed);
+    setEditing(false);
+  };
   const isPaused = lastRun?.status === "running" && !!lastRun.paused_until;
 
   // The row hosts a nested interactive control (the Switch, which Radix renders
@@ -106,77 +96,86 @@ export function RoutineRow({
         !routine.enabled && "opacity-55",
       )}
     >
-      {/* Status dot — small but always present. Amber when the in-flight run
-          is sleeping on a usage-limit window so the row reads as "waiting"
-          rather than "thrashing". */}
-      <div
-        className={cn(
-          "size-2 rounded-full shrink-0",
-          !routine.enabled
-            ? "bg-gray-300"
-            : isPaused
-              ? "bg-amber-500"
-              : (STATUS_DOT[lastRun?.status ?? "silent"] ?? "bg-gray-300"),
-          lastRun?.status === "running" && !isPaused && "animate-pulse",
-        )}
-        aria-hidden
+      {/* Leading state icon — clock while waiting, pulsing bolt mid-run,
+          amber pause while a run sleeps on a usage-limit window. */}
+      <RoutineRowStatus
+        routine={routine}
+        lastRun={lastRun}
+        isPaused={isPaused}
       />
 
       {/* Title + meta column */}
       <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium text-foreground truncate leading-tight">
-          {routine.name || labels.untitled}
-        </p>
+        {editing ? (
+          <input
+            ref={inputRef}
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              e.stopPropagation();
+              if (e.key === "Enter") commitRename();
+              if (e.key === "Escape") setEditing(false);
+            }}
+            onClick={(e) => e.stopPropagation()}
+            aria-label={labels.rename}
+            className="text-sm font-medium text-foreground bg-transparent border-b border-foreground/20 outline-none w-full leading-tight"
+          />
+        ) : (
+          <p className="text-sm font-medium text-foreground truncate leading-tight">
+            {routine.name || labels.untitled}
+          </p>
+        )}
         <p className="text-xs text-muted-foreground truncate mt-0.5">
           {cronSummary(routine.schedule, scheduleSummaryLabels, locale)}
         </p>
       </div>
 
       {/* Right meta column: next run + last run */}
-      <div className="hidden sm:flex flex-col items-end shrink-0 min-w-[140px]">
-        {nextDescr ? (
-          <>
-            <p className="text-xs text-foreground tabular-nums">
-              {interp(labels.next, { relative: nextDescr.relative })}
-            </p>
-            <p className="text-[11px] text-muted-foreground tabular-nums mt-0.5">
-              {nextDescr.absolute}
-            </p>
-          </>
-        ) : routine.enabled ? (
-          <p className="text-xs text-muted-foreground">{labels.noNextRun}</p>
-        ) : (
-          <p className="text-xs text-muted-foreground">{labels.paused}</p>
-        )}
-        {isPaused ? (
-          <p className="text-[11px] text-amber-700 mt-0.5 tabular-nums">
-            {interp(labels.waiting, { time: lastRun?.paused_until ?? "" })}
-          </p>
-        ) : (
-          lastLabel && (
-            <p className="text-[11px] text-muted-foreground/70 mt-0.5 tabular-nums">
-              {lastLabel}
-            </p>
-          )
-        )}
-      </div>
+      <RoutineRowMeta
+        routine={routine}
+        lastRun={lastRun}
+        accountTimezone={accountTimezone}
+        now={now}
+        isPaused={isPaused}
+        labels={labels}
+        nextFireLabels={nextFireLabels}
+        locale={locale}
+      />
 
-      {/* Switch — stop click and keys from bubbling to the outer row so
-          toggling (mouse or keyboard) never opens the editor. */}
-      {onToggle && (
+      {/* Trailing controls — stop clicks and keys from bubbling to the outer
+          row so toggling or opening the menu never opens the editor. */}
+      {(onToggle || onRename || onDelete) && (
         <div
           role="none"
           onClick={(e) => e.stopPropagation()}
           onKeyDown={(e) => e.stopPropagation()}
-          className="shrink-0"
+          className="shrink-0 flex items-center gap-1"
         >
-          <Switch
-            checked={routine.enabled}
-            onCheckedChange={(checked) => onToggle(checked)}
-            aria-label={
-              routine.enabled ? labels.pauseRoutine : labels.resumeRoutine
-            }
-          />
+          {onToggle && (
+            <Switch
+              checked={routine.enabled}
+              onCheckedChange={(checked) => onToggle(checked)}
+              aria-label={
+                routine.enabled ? labels.pauseRoutine : labels.resumeRoutine
+              }
+            />
+          )}
+          {(onRename || onDelete) && (
+            <RoutineRowMenu
+              name={routine.name || labels.untitled}
+              onRename={
+                onRename
+                  ? () => {
+                      setEditValue(routine.name);
+                      setEditing(true);
+                    }
+                  : undefined
+              }
+              onDelete={onDelete}
+              labels={labels}
+            />
+          )}
         </div>
       )}
     </div>

--- a/ui/routines/src/routine-row.tsx
+++ b/ui/routines/src/routine-row.tsx
@@ -62,7 +62,12 @@ export function RoutineRow({
   const [editValue, setEditValue] = useState(routine.name);
   const inputRef = useRef<HTMLInputElement>(null);
   useEffect(() => {
-    if (editing) inputRef.current?.focus();
+    // Focus AND select: the boxed, highlighted current name reads as "type
+    // to replace" the instant the rename opens.
+    if (editing) {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    }
   }, [editing]);
 
   const commitRename = () => {
@@ -119,7 +124,14 @@ export function RoutineRow({
             }}
             onClick={(e) => e.stopPropagation()}
             aria-label={labels.rename}
-            className="text-sm font-medium text-foreground bg-transparent border-b border-foreground/20 outline-none w-full leading-tight"
+            className={cn(
+              // A full input box (white well + ring), not a bare underline —
+              // the rename must read as editable the moment it opens. Negative
+              // margins absorb the padding so the row's height doesn't jump.
+              "w-full max-w-sm px-2 py-1 -mx-2 -my-1 text-sm font-medium leading-tight",
+              "text-foreground bg-background rounded-md",
+              "border border-ring/50 ring-2 ring-ring/20 outline-none",
+            )}
           />
         ) : (
           <p className="text-sm font-medium text-foreground truncate leading-tight">

--- a/ui/routines/src/routines-grid.tsx
+++ b/ui/routines/src/routines-grid.tsx
@@ -45,6 +45,10 @@ export interface RoutinesGridProps {
   onSelect: (routineId: string) => void;
   onCreate?: () => void;
   onToggle?: (routineId: string, enabled: boolean) => void;
+  /** Rename a routine from its row's quick-actions menu (inline edit). */
+  onRename?: (routineId: string, name: string) => void;
+  /** Delete a routine from its row's quick-actions menu (row confirms first). */
+  onDelete?: (routineId: string) => void;
   /**
    * Localized labels. English defaults so existing callers still work.
    * Consumers pass `t()` results for localization — `ui/` stays i18n-agnostic
@@ -68,6 +72,8 @@ export function RoutinesGrid({
   onSelect,
   onCreate,
   onToggle,
+  onRename,
+  onDelete,
   labels = DEFAULT_GRID_LABELS,
   rowLabels = DEFAULT_ROW_LABELS,
   scheduleSummaryLabels = DEFAULT_SCHEDULE_SUMMARY_LABELS,
@@ -158,6 +164,10 @@ export function RoutinesGrid({
                   ? (enabled) => onToggle(routine.id, enabled)
                   : undefined
               }
+              onRename={
+                onRename ? (name) => onRename(routine.id, name) : undefined
+              }
+              onDelete={onDelete ? () => onDelete(routine.id) : undefined}
               labels={rowLabels}
               scheduleSummaryLabels={scheduleSummaryLabels}
               nextFireLabels={nextFireLabels}

--- a/ui/routines/src/styles.css
+++ b/ui/routines/src/styles.css
@@ -1,1 +1,48 @@
 @source ".";
+
+/* Agent-edit flash — the editor section the agent just changed lights up
+ * white and fades out (~1.1s), so an edit made from the setup chat is
+ * visibly attributed to its section. Applied by useSectionFlash; the wash
+ * rides an ::after overlay so the card's own background never animates.
+ * Dark theme drops the alpha: the same white reads as a bright pulse, not
+ * a blinding flash. */
+.routine-section-flash {
+  position: relative;
+}
+
+.routine-section-flash::after {
+  /* Bright but never a whiteout — the changed values must stay readable
+   * through the flash's peak. */
+  --routine-flash: rgba(255, 255, 255, 0.65);
+  content: "";
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  pointer-events: none;
+  background: var(--routine-flash);
+  box-shadow: 0 0 0 2px
+    color-mix(in srgb, var(--ht-ring, currentColor) 55%, transparent);
+  animation: routine-section-flash 1.1s ease-out forwards;
+}
+
+[data-theme="dark"] .routine-section-flash::after {
+  --routine-flash: rgba(255, 255, 255, 0.14);
+}
+
+@keyframes routine-section-flash {
+  0% {
+    opacity: 1;
+  }
+  30% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .routine-section-flash::after {
+    animation-duration: 1ms;
+  }
+}

--- a/ui/routines/src/use-schedule-builder.ts
+++ b/ui/routines/src/use-schedule-builder.ts
@@ -151,6 +151,39 @@ export function useScheduleBuilder(
       )
     : "";
 
+  // Re-derive the picker when the cron changes OUTSIDE this builder — the
+  // setup chat's agent editing the open routine (HOU-725). Without this the
+  // saved schedule and the "next run" preview move while the preset/time
+  // fields keep showing the old values. A `value` equal to what the current
+  // state emits is our own echo through the parent — skipped, so mid-edit
+  // typing never resets the fields.
+  const emittedCron =
+    unrepresentable && !touched
+      ? value
+      : isCustom
+        ? customCron
+        : weeklyValid
+          ? presetToCron(activePreset, options)
+          : "";
+  // The re-derived state round-trips to `value`, so the emit effect's
+  // follow-up call is a no-op echo.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: sync on the incoming value only — `emittedCron` is derived from the state this effect sets, and reacting to it would fight the user's edits
+  useEffect(() => {
+    if (!value.trim() || value === emittedCron) return;
+    const preset = cronToPreset(value);
+    const interval = preset === "custom" ? cronToInterval(value) : null;
+    // An externally-written cron the picker can't represent: leave the state
+    // alone (same stance as the mount-time `unrepresentable` guard) — the
+    // value prop still drives the summary elsewhere and saving.
+    if (preset === "custom" && !interval) return;
+    setActivePreset(preset ?? "daily");
+    setOptions({ ...DEFAULT_OPTIONS, ...cronToOptions(value) });
+    if (interval) {
+      setEvery(String(interval.every));
+      setUnit(interval.unit);
+    }
+  }, [value]);
+
   // While an unrepresentable legacy cron is still untouched, describe the actual
   // saved schedule rather than the placeholder picker state.
   let summary: string;

--- a/ui/routines/src/use-section-flash.ts
+++ b/ui/routines/src/use-section-flash.ts
@@ -1,0 +1,66 @@
+/**
+ * useSectionFlash — drives the editor's "the agent just changed this" moment.
+ *
+ * When the routine open in the editor is modified from OUTSIDE the form (the
+ * setup chat's agent edits it), the consumer passes which sections changed +
+ * a fresh nonce. The hook applies the `routine-section-flash` animation class
+ * to those sections and scrolls the first one into view when it's off-screen
+ * (`block: "nearest"` — an already-visible section doesn't move). The class is
+ * dropped for one frame before re-applying so back-to-back edits to the same
+ * section restart the CSS animation instead of silently coalescing.
+ */
+import { useEffect, useRef, useState } from "react";
+
+/** The editor's flashable regions: the name+prompt hero, the schedule card,
+ *  and the behavior card. */
+export type RoutineEditorSection = "details" | "schedule" | "behavior";
+
+export interface SectionFlash {
+  sections: RoutineEditorSection[];
+  /** Monotonic per change — a repeat of the same sections still re-flashes. */
+  nonce: number;
+}
+
+/** Matches the `routine-section-flash` animation length, plus slack. */
+const FLASH_MS = 1400;
+
+export function useSectionFlash(flash: SectionFlash | null | undefined) {
+  const refs = useRef<Record<RoutineEditorSection, HTMLElement | null>>({
+    details: null,
+    schedule: null,
+    behavior: null,
+  });
+  const [active, setActive] = useState<SectionFlash | null>(null);
+
+  useEffect(() => {
+    if (!flash || flash.sections.length === 0) return;
+    setActive(null); // drop the class for a frame so the animation restarts
+    const raf = requestAnimationFrame(() => {
+      setActive(flash);
+      const first = flash.sections[0];
+      if (first) {
+        refs.current[first]?.scrollIntoView({
+          behavior: "smooth",
+          block: "nearest",
+        });
+      }
+    });
+    const timer = setTimeout(() => setActive(null), FLASH_MS);
+    return () => {
+      cancelAnimationFrame(raf);
+      clearTimeout(timer);
+    };
+  }, [flash]);
+
+  return {
+    /** Ref callback registering a section's element for the scroll. */
+    refFor:
+      (section: RoutineEditorSection) =>
+      (el: HTMLElement | null): void => {
+        refs.current[section] = el;
+      },
+    /** True while `section` should carry the flash animation class. */
+    isFlashing: (section: RoutineEditorSection): boolean =>
+      active?.sections.includes(section) ?? false,
+  };
+}


### PR DESCRIPTION
## What changed

### 1. Left indicator → state icons
The routine row's 8px gray/blue status dot becomes an icon that names the state by shape, not color alone:

- 🕐 **Clock** (muted) while the routine waits for its next scheduled fire — and while disabled, dimmed with the row.
- ⚡ **Pulsing filled bolt** (blue) while a run is in flight.
- ⏸ **Pause badge** (amber) while the in-flight run sleeps on a usage-limit window.
- ⚠️ **Alert** (red) when the last run errored.

### 2. Three-dot quick actions on each row
Always visible (never hover-gated; same overflow idiom as the routine editor's header), with the board mission card's interaction patterns:

- **Rename** swaps the title into an inline input — a full boxed field (white well + ring) with the current name focused **and selected**, so type-to-replace works the instant it opens. Enter/blur commits, Escape cancels.
- **Delete** confirms in a dialog (`Delete "name"?`) before removing; Cancel is a no-op.

Both stop propagation, so using them never opens the editor.

### 3. Agent edits light up the editor section they changed
When the agent modifies the **open** routine from its setup chat, the editor already refreshed in real time — now the changed section (name/prompt hero, "When it runs", or "Behavior") plays a white flash that fades over ~1.1s, and the editor scrolls it into view when it's off-screen (`block: "nearest"` — a visible section doesn't move). Back-to-back edits re-flash via a nonce; the flash state clears on any view/agent switch so it never replays on an unrelated routine. Dark theme drops the wash alpha so it reads as a bright pulse, and `prefers-reduced-motion` collapses the animation.

### 4. Real-time bug the flash test exposed: stale schedule picker
`useScheduleBuilder` seeded its preset/time/interval state once from the incoming cron and never re-derived it. An external (agent) schedule edit moved the saved cron and the "Next run" preview while the picker kept showing the old time. The builder now re-syncs whenever the incoming value differs from the cron its own state emits (own echoes are skipped, so the user's mid-edit typing never gets reset; unrepresentable legacy crons keep their existing hands-off stance).

## Where

- `ui/routines`: `RoutineRow` (+`onRename`/`onDelete`, boxed rename input), new `routine-row-status` / `routine-row-menu` / `routine-row-meta` modules, `RoutinesGrid` threading, `useSectionFlash` + `flash` prop on `RoutineEditor`, flash CSS in the package stylesheet (now imported by app globals, mirroring `@houston-ai/chat`), `useScheduleBuilder` external re-sync. `RoutineRowLabels` grows menu/confirm strings — all props optional, existing callers render unchanged minus the dot.
- `app`: routines tab wires rename/delete to the existing mutations and holds the nonce'd flash state; `useRoutineEditorSync` reports which sections an external refresh touched via pure `changedEditorSections`; new `row.*` strings in en/es/pt.
- `design/inventory`: v11 bump + CHANGELOG (`routine-row` anatomy `status-icon` + `quick-actions-menu`, states + `paused`/`renaming`); `pnpm check:parity` passes. The routine editor stays out of the inventory by its documented exclusion.

## Verification

- `packages/web/e2e/routine-quick-actions.spec.ts`: rename commits inline and persists via PATCH without opening the editor; delete is confirm-gated (nothing removed until confirmed, Cancel keeps it). **2 passed.**
- `packages/web/e2e/routine-agent-edit-flash.spec.ts`: with the editor open, a REST PATCH (the agent's edit path) flashes exactly the schedule section, and both the next-run preview and the schedule picker show the new time. Screenshots from the runs show the icon row and the mid-flash editor. **1 passed.**
- `app/tests/routine-flash-sections.test.ts`: section mapping (details/schedule/behavior), null-vs-absent model pins, integrations deliberately unmapped. App suite **1072 passed**.
- Existing `routine-setup-chat.spec.ts` **6 passed**; `pnpm typecheck`, Biome, `check-locales`, `check:parity`, `pnpm --filter houston-web test` (123) all green.

## Manual check

1. Open an agent → Routines. Rows show a clock instead of the gray dot; a running routine shows a pulsing blue bolt.
2. ⋯ → Rename: the title becomes a boxed input with the name selected; typing replaces it, Enter saves.
3. ⋯ → Delete: the dialog names the routine; Cancel keeps it, Delete removes it.
4. Open a routine and ask its chat to change the schedule: the "When it runs" card flashes white, scrolls into view if needed, and the picker + next-run both show the new time immediately.