### PR TITLE
Tour gaps, store agent renames, provisioning fix, Memory rename, status-indicator consistency

### DIFF
--- a/app/src/agents/builtin/store-catalog.ts
+++ b/app/src/agents/builtin/store-catalog.ts
@@ -8,7 +8,7 @@ import type { AgentConfig } from "../../lib/types";
 export const storeCatalogConfigs: AgentConfig[] = [
   {
     id: "bookkeeping",
-    name: "Bookkeeping",
+    name: "Bookkeeper",
     description:
       "Categorize transactions, reconcile accounts, close the books every month, and generate investor-ready financials. Connects to QuickBooks, Xero, Stripe, and your bank feeds. Drafts journal entries and statements - never posts to your ledger or moves money.",
     version: "0.1.8",
@@ -45,7 +45,7 @@ export const storeCatalogConfigs: AgentConfig[] = [
   },
   {
     id: "legal",
-    name: "Legal",
+    name: "General Counsel",
     description:
       "Review contracts, audit privacy compliance, prep Delaware filings, run trademark searches, and answer legal questions on the spot. Drafts NDAs, policies, and escalation briefs - never files, signs, or sends anything on your behalf.",
     version: "0.2.4",
@@ -78,7 +78,7 @@ export const storeCatalogConfigs: AgentConfig[] = [
   },
   {
     id: "marketing",
-    name: "Marketing",
+    name: "Growth Lead",
     description:
       "Build positioning, plan campaigns, write blog posts and landing pages, audit SEO and AI-search visibility, and draft email sequences. Strategy through execution across content, paid, social, and conversion copy - all drafts, never published.",
     version: "0.1.8",
@@ -123,7 +123,7 @@ export const storeCatalogConfigs: AgentConfig[] = [
   },
   {
     id: "operations",
-    name: "Operations",
+    name: "Chief of Staff",
     description:
       "Triage your inbox, prep meetings, track goals, manage vendor renewals, audit SaaS spend, and run data queries. Covers planning, scheduling, finance hygiene, and reporting - drafts only, never sends or commits.",
     version: "0.1.10",
@@ -162,7 +162,7 @@ export const storeCatalogConfigs: AgentConfig[] = [
   },
   {
     id: "outbound",
-    name: "Outbound",
+    name: "Growth Hacker",
     description:
       "Turn a single LinkedIn post into a paused cold email campaign in Instantly. I scrape the commenters or reactors, store them in Airtable, find verified emails through Apollo, co-write a 3-email sequence with you, then load it all into Instantly. The campaign always stays paused for your review - I never auto-launch.",
     version: "0.1.2",
@@ -193,7 +193,7 @@ export const storeCatalogConfigs: AgentConfig[] = [
   },
   {
     id: "people",
-    name: "People",
+    name: "Head of Talent",
     description:
       "Source and evaluate candidates, coordinate interview loops, draft offer letters, run review cycles, and track compliance deadlines. Covers hiring through retention - drafts only, never sends or modifies your HR systems.",
     version: "0.1.9",
@@ -231,7 +231,7 @@ export const storeCatalogConfigs: AgentConfig[] = [
   },
   {
     id: "sales",
-    name: "Sales",
+    name: "Chief Revenue Officer",
     description:
       "Find leads, research accounts, prep calls, draft outreach, manage your CRM, and forecast pipeline. Covers prospecting through expansion - drafts only, never sends or changes deal stages without your approval.",
     version: "0.1.9",
@@ -271,7 +271,7 @@ export const storeCatalogConfigs: AgentConfig[] = [
   },
   {
     id: "support",
-    name: "Support",
+    name: "Head of Customer Success",
     description:
       "Triage tickets, draft replies, write help-center articles, score customer health, and build churn-save playbooks. Covers inbox through customer success - drafts only, never sends.",
     version: "0.2.2",

--- a/app/src/components/ai-hub/hub-badges.tsx
+++ b/app/src/components/ai-hub/hub-badges.tsx
@@ -11,6 +11,7 @@
 import { cn } from "@houston-ai/core";
 import { CreditCard, KeyRound, Monitor } from "lucide-react";
 import type { ReactNode } from "react";
+import { StatusDot } from "../integrations/connection-status-badge";
 
 /** Base neutral pill every hub chip is built from. */
 export function SpecChip({
@@ -69,15 +70,17 @@ export function PriceText({ text }: { text: string }) {
   );
 }
 
-/** The only always-green element: a live dot + label for connected state. */
+/**
+ * The only always-green element: a live dot + label for connected state.
+ * Same primitive + proportions as the Integrations tab's `ConnectionStatusBadge`
+ * (`StatusDot` + `text-xs`) so "connected" reads identically everywhere in the
+ * app, not just here.
+ */
 export function LiveStatus({ label }: { label: string }) {
   return (
-    <span className="inline-flex items-center gap-1.5">
-      <span
-        className="size-1.5 rounded-full bg-success ring-2 ring-success/25"
-        aria-hidden="true"
-      />
-      <span className="text-[12.5px] font-medium text-success">{label}</span>
+    <span className="inline-flex items-center gap-1.5 text-xs font-medium text-success">
+      <StatusDot status="active" />
+      {label}
     </span>
   );
 }

--- a/app/src/components/integrations/app-row.tsx
+++ b/app/src/components/integrations/app-row.tsx
@@ -2,14 +2,20 @@ import { cn } from "@houston-ai/core";
 import type React from "react";
 import type { AppDisplay } from "./app-display";
 import { AppLogo } from "./app-logo";
-import { type ConnectionStatus, StatusDot } from "./connection-status-badge";
+import {
+  type ConnectionStatus,
+  ConnectionStatusBadge,
+} from "./connection-status-badge";
 
 /**
- * The generic integrations list row shared by both surfaces: logo + name (+ an
- * optional live status dot) + description, a trailing action slot, and an
- * optional `children` block that renders under the main line (used for the
- * pending / error recovery callouts). Renders as a button when `onClick` is
- * given, otherwise a plain row. Actions live in `trailing`, never hover-gated.
+ * The generic integrations list row shared by both surfaces: logo + name (+ a
+ * live status dot + label, right of the name) + description, a trailing
+ * action slot, and an optional `children` block that renders under the main
+ * line (used for the pending / error recovery callouts). Renders as a button
+ * when `onClick` is given, otherwise a plain row. Actions live in `trailing`,
+ * never hover-gated. The card itself stays the plain neutral surface — status
+ * reads from the dot + label, not a tinted background (that read as loud/
+ * cheap in review; a colored label next to the name is the sober version).
  */
 export function AppRow({
   display,
@@ -30,9 +36,9 @@ export function AppRow({
     <>
       <AppLogo display={display} />
       <div className="min-w-0 flex-1">
-        <p className="flex items-center gap-1.5 truncate text-[13px] font-medium text-foreground">
-          <span className="truncate">{display.name}</span>
-          {status && <StatusDot status={status} />}
+        <p className="flex min-w-0 items-center gap-2 text-[13px] font-medium text-foreground">
+          <span className="min-w-0 truncate">{display.name}</span>
+          {status && <ConnectionStatusBadge status={status} />}
         </p>
         {description && (
           <p className="truncate text-[11px] text-muted-foreground">

--- a/app/src/components/integrations/connection-status-badge.tsx
+++ b/app/src/components/integrations/connection-status-badge.tsx
@@ -4,9 +4,15 @@ import { useTranslation } from "react-i18next";
 export type ConnectionStatus = "active" | "pending" | "error";
 
 const DOT: Record<ConnectionStatus, string> = {
-  active: "bg-emerald-500",
-  pending: "bg-amber-500",
+  active: "bg-success",
+  pending: "bg-warning",
   error: "bg-destructive",
+};
+
+const TEXT: Record<ConnectionStatus, string> = {
+  active: "text-success",
+  pending: "text-warning",
+  error: "text-destructive",
 };
 
 /** A small colored status dot, sized for inline use next to an app name. */
@@ -25,7 +31,11 @@ export function StatusDot({
   );
 }
 
-/** Colored dot + localized label describing a connection's live status. */
+/**
+ * Colored dot + colored, localized label describing a connection's live
+ * status — the sober "green thing next to the name" treatment (mirrors the
+ * AI Hub's `LiveStatus`), not a tinted card background.
+ */
 export function ConnectionStatusBadge({
   status,
 }: {
@@ -33,7 +43,12 @@ export function ConnectionStatusBadge({
 }) {
   const { t } = useTranslation("integrations");
   return (
-    <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+    <span
+      className={cn(
+        "inline-flex items-center gap-1.5 text-xs font-medium",
+        TEXT[status],
+      )}
+    >
       <StatusDot status={status} />
       {t(`status.${status}`)}
     </span>

--- a/app/src/components/provider-browser/provider-row.tsx
+++ b/app/src/components/provider-browser/provider-row.tsx
@@ -16,6 +16,7 @@ import { AsyncButton, Button } from "@houston-ai/core";
 import { Info, Loader2, X } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import type { ProviderInfo } from "../../lib/providers";
+import { LiveStatus } from "../ai-hub/hub-badges";
 import { BrandMark } from "./brand-mark";
 
 interface ProviderRowProps {
@@ -56,8 +57,9 @@ export function ProviderRow({
     <div className="flex items-center gap-3 rounded-xl bg-secondary px-3 py-2.5 text-left">
       <BrandMark providerId={provider.id} size="md" />
       <div className="flex min-w-0 flex-1 flex-col">
-        <span className="truncate text-[13px] font-medium text-foreground">
-          {provider.name}
+        <span className="flex min-w-0 items-center gap-1.5 text-[13px] font-medium text-foreground">
+          <span className="min-w-0 truncate">{provider.name}</span>
+          {connected && <LiveStatus label={t("card.connected")} />}
         </span>
         <span className="truncate text-[11px] text-muted-foreground">
           {modelCount > 0 && (

--- a/app/src/components/shell/agent-warming-dialog.tsx
+++ b/app/src/components/shell/agent-warming-dialog.tsx
@@ -27,6 +27,12 @@ export function AgentWarmingDialog() {
   const anyWarming = useAgentProvisioningStore(
     (s) => Object.keys(s.provisioning).length > 0,
   );
+  // Any entry past its normal TTL (HOU-693 regression: this used to clear
+  // silently instead of surfacing here). Still warming, just slower than
+  // usual — the copy below says so instead of implying failure.
+  const anyStalled = useAgentProvisioningStore((s) =>
+    Object.values(s.provisioning).some((entry) => entry.timedOut),
+  );
 
   // The agent finished while the notice was up: the blocked action is
   // available again, so the notice has nothing left to say.
@@ -40,9 +46,19 @@ export function AgentWarmingDialog() {
         <div className="flex flex-col items-center gap-5 py-4 text-center">
           <HoustonAvatar diameter={72} running />
           <div className="flex flex-col gap-2">
-            <DialogTitle>{t("shell:agentProvisioning.title")}</DialogTitle>
+            <DialogTitle>
+              {t(
+                anyStalled
+                  ? "shell:agentProvisioning.stalledTitle"
+                  : "shell:agentProvisioning.title",
+              )}
+            </DialogTitle>
             <DialogDescription>
-              {t("shell:agentProvisioning.blockedBody")}
+              {t(
+                anyStalled
+                  ? "shell:agentProvisioning.stalledBody"
+                  : "shell:agentProvisioning.blockedBody",
+              )}
             </DialogDescription>
           </div>
           <Button className="min-w-28" onClick={() => setOpen(false)}>

--- a/app/src/components/shell/sidebar-chrome.tsx
+++ b/app/src/components/shell/sidebar-chrome.tsx
@@ -41,6 +41,7 @@ export function buildSidebarNavItems(args: {
       label: t("shell:sidebar.aiModels"),
       icon: <Boxes className="h-4 w-4" />,
       onClick: () => setViewMode("ai-hub"),
+      dataAttrs: { "data-tour-target": "nav-ai-hub" },
     },
     ...(showOrganization
       ? [
@@ -49,6 +50,7 @@ export function buildSidebarNavItems(args: {
             label: t("teams:org.nav"),
             icon: <Building2 className="h-4 w-4" />,
             onClick: () => setViewMode(ORGANIZATION_VIEW_ID),
+            dataAttrs: { "data-tour-target": "nav-organization" },
           },
         ]
       : []),
@@ -57,6 +59,7 @@ export function buildSidebarNavItems(args: {
       label: t("shell:sidebar.settings"),
       icon: <Settings className="h-4 w-4" />,
       onClick: () => setViewMode("settings"),
+      dataAttrs: { "data-tour-target": "nav-settings" },
     },
   ];
 }

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -406,10 +406,22 @@ export function WorkspaceShell({
                 onEnter: () => setViewMode(tabOr("routines")),
               },
               {
+                title: t("shell:uiTour.steps.tabIntegrations.title"),
+                body: t("shell:uiTour.steps.tabIntegrations.body"),
+                targetSelector: "[data-tour-target='tab-integrations']",
+                onEnter: () => setViewMode(tabOr("integrations")),
+              },
+              {
                 title: t("shell:uiTour.steps.tabFiles.title"),
                 body: t("shell:uiTour.steps.tabFiles.body"),
                 targetSelector: "[data-tour-target='tab-files']",
                 onEnter: () => setViewMode(tabOr("files")),
+              },
+              {
+                title: t("shell:uiTour.steps.tabArchived.title"),
+                body: t("shell:uiTour.steps.tabArchived.body"),
+                targetSelector: "[data-tour-target='tab-archived']",
+                onEnter: () => setViewMode(tabOr("archived")),
               },
               {
                 title: t("shell:uiTour.steps.tabJobDescription.title"),
@@ -422,6 +434,30 @@ export function WorkspaceShell({
                 body: t("shell:uiTour.steps.missionControl.body"),
                 targetSelector: "[data-tour-target='nav-dashboard']",
                 onEnter: () => setViewMode("dashboard"),
+              },
+              {
+                title: t("shell:uiTour.steps.navIntegrations.title"),
+                body: t("shell:uiTour.steps.navIntegrations.body"),
+                targetSelector: "[data-tour-target='nav-integrations']",
+                onEnter: () => setViewMode(INTEGRATIONS_VIEW_ID),
+              },
+              {
+                title: t("shell:uiTour.steps.aiHub.title"),
+                body: t("shell:uiTour.steps.aiHub.body"),
+                targetSelector: "[data-tour-target='nav-ai-hub']",
+                onEnter: () => setViewMode("ai-hub"),
+              },
+              {
+                title: t("shell:uiTour.steps.organization.title"),
+                body: t("shell:uiTour.steps.organization.body"),
+                targetSelector: "[data-tour-target='nav-organization']",
+                onEnter: () => setViewMode(ORGANIZATION_VIEW_ID),
+              },
+              {
+                title: t("shell:uiTour.steps.settings.title"),
+                body: t("shell:uiTour.steps.settings.body"),
+                targetSelector: "[data-tour-target='nav-settings']",
+                onEnter: () => setViewMode("settings"),
               },
               {
                 title: t("shell:uiTour.steps.newAgent.title"),
@@ -459,20 +495,28 @@ export function WorkspaceShell({
                 onEnter: () => setCreateAgentDialogOpen(false),
               },
             ] satisfies UiTourStep[]
-          ).filter(
+          ).filter((step) => {
             // The Agent Settings (job-description) step targets a tab plain
-            // members never see. Drop it for them so the tour never highlights a
-            // missing anchor or leaves them on a blank agent pane.
-            (step) =>
-              step.targetSelector !==
-                "[data-tour-target='tab-job-description']" ||
-              (!!currentAgent &&
-                isVisibleAgentTab(
-                  capabilities,
-                  currentAgent,
-                  "job-description",
-                )),
-          )}
+            // members never see. Drop it for them so the tour never
+            // highlights a missing anchor or leaves them on a blank pane.
+            if (
+              step.targetSelector === "[data-tour-target='tab-job-description']"
+            ) {
+              return (
+                !!currentAgent &&
+                isVisibleAgentTab(capabilities, currentAgent, "job-description")
+              );
+            }
+            // The Organization nav item only renders for multiplayer
+            // workspaces — same reasoning, drop the step where the anchor
+            // never exists.
+            if (
+              step.targetSelector === "[data-tour-target='nav-organization']"
+            ) {
+              return showOrganization;
+            }
+            return true;
+          })}
           onDismiss={() => {
             setUiTourActive(false);
             setCreateAgentDialogOpen(false);

--- a/app/src/components/tabs/agent-admin/agent-admin-knowledge.tsx
+++ b/app/src/components/tabs/agent-admin/agent-admin-knowledge.tsx
@@ -7,7 +7,7 @@ import {
 import { LearningsContent } from "../learnings-content";
 import type { AgentAdminScreenProps } from "./agent-admin-nav.ts";
 
-/** Knowledge (learnings) section. Always editable (managers/owners only). */
+/** Memory (learnings) section. Always editable (managers/owners only). */
 export function AgentAdminKnowledge({ agent }: AgentAdminScreenProps) {
   const path = agent.folderPath;
   const { data } = useLearnings(path);

--- a/app/src/components/tabs/agent-admin/agent-admin-nav.ts
+++ b/app/src/components/tabs/agent-admin/agent-admin-nav.ts
@@ -64,7 +64,7 @@ export function agentAdminCards(
 
 /**
  * Deep-link from a turn-summary file target (a semantic file update the agent
- * wrote) into the matching section. Learnings surface as "Knowledge".
+ * wrote) into the matching section. Learnings surface as "Memory".
  */
 export function targetToScreen(
   target: "instructions" | "skills" | "learnings",

--- a/app/src/components/tabs/agent-integrations/agent-app-row.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-app-row.tsx
@@ -2,7 +2,6 @@ import { useTranslation } from "react-i18next";
 import {
   AppRow,
   type ConnectFlow,
-  ConnectionStatusBadge,
   PendingConnectionCallout,
 } from "../../integrations";
 import type { AgentAppRow as AgentAppRowVM } from "./model";
@@ -57,14 +56,7 @@ export function AgentAppRow({
   }
 
   return (
-    <AppRow
-      display={app}
-      description={app.description}
-      status={status}
-      trailing={
-        !canEdit ? <ConnectionStatusBadge status={status} /> : undefined
-      }
-    >
+    <AppRow display={app} description={app.description} status={status}>
       {canEdit && (
         <PendingConnectionCallout
           status={status}

--- a/app/src/lib/agent-provisioning.ts
+++ b/app/src/lib/agent-provisioning.ts
@@ -133,6 +133,15 @@ export interface ProvisioningEntry {
   since: number;
   /** Messages queued while warming, flushed on ready (in order). */
   pendingSends?: PendingWarmingSend[];
+  /**
+   * The TTL elapsed with no answer yet (HOU-693 regression: the entry used to
+   * be cleared here, silently dropping the user's still-visible first chat).
+   * Sticky once set — the store re-arms a fresh probe window on it rather
+   * than giving up, and the UI switches to a "still starting" state instead
+   * of the initial "we're creating your agent" copy. Never cleared back to
+   * false; a fresh entry (new create/rename) replaces it instead.
+   */
+  timedOut?: boolean;
 }
 
 /**
@@ -166,12 +175,17 @@ export function parsePersistedProvisioning(
   return parsed
     .filter((e): e is ProvisioningEntry => {
       if (!e || typeof e !== "object") return false;
-      const { agentId, agentPath, since } = e as Partial<ProvisioningEntry>;
+      const { agentId, agentPath, since, timedOut } =
+        e as Partial<ProvisioningEntry>;
       return (
         typeof agentId === "string" &&
         typeof agentPath === "string" &&
         typeof since === "number" &&
-        now - since < PROVISIONING_TTL_MS
+        // A timed-out entry is kept regardless of age: it's still visibly
+        // parked (its board row / chat bubble persists) and re-arms its own
+        // probe on rehydrate rather than expiring off the TTL clock a second
+        // time, which would silently drop it right back.
+        (timedOut === true || now - since < PROVISIONING_TTL_MS)
       );
     })
     .map((e) =>

--- a/app/src/locales/en/agents.json
+++ b/app/src/locales/en/agents.json
@@ -9,35 +9,35 @@
       "description": "A blank agent with no pre-configured actions, instructions, or learnings. Build it your way."
     },
     "bookkeeping": {
-      "name": "Bookkeeping",
+      "name": "Bookkeeper",
       "description": "Categorize transactions, reconcile accounts, close the books every month, and generate investor-ready financials. Connects to QuickBooks, Xero, Stripe, and your bank feeds. Drafts journal entries and statements, never posts to your ledger or moves money."
     },
     "legal": {
-      "name": "Legal",
+      "name": "General Counsel",
       "description": "Review contracts, audit privacy compliance, prep Delaware filings, run trademark searches, and answer legal questions on the spot. Drafts NDAs, policies, and escalation briefs, never files, signs, or sends anything on your behalf."
     },
     "marketing": {
-      "name": "Marketing",
+      "name": "Growth Lead",
       "description": "Build positioning, plan campaigns, write blog posts and landing pages, audit SEO and AI-search visibility, and draft email sequences. Strategy through execution across content, paid, social, and conversion copy, all drafts, never published."
     },
     "operations": {
-      "name": "Operations",
+      "name": "Chief of Staff",
       "description": "Triage your inbox, prep meetings, track goals, manage vendor renewals, audit SaaS spend, and run data queries. Covers planning, scheduling, finance hygiene, and reporting, drafts only, never sends or commits."
     },
     "people": {
-      "name": "People",
+      "name": "Head of Talent",
       "description": "Source and evaluate candidates, coordinate interview loops, draft offer letters, run review cycles, and track compliance deadlines. Covers hiring through retention, drafts only, never sends or modifies your HR systems."
     },
     "sales": {
-      "name": "Sales",
+      "name": "Chief Revenue Officer",
       "description": "Find leads, research accounts, prep calls, draft outreach, manage your CRM, and forecast pipeline. Covers prospecting through expansion, drafts only, never sends or changes deal stages without your approval."
     },
     "support": {
-      "name": "Support",
+      "name": "Head of Customer Success",
       "description": "Triage tickets, draft replies, write help-center articles, score customer health, and build churn-save playbooks. Covers inbox through customer success, drafts only, never sends."
     },
     "outbound": {
-      "name": "Outbound",
+      "name": "Growth Hacker",
       "description": "Turn a single LinkedIn post into a paused cold email campaign in Instantly. I scrape the commenters or reactors, store them in Airtable, find verified emails through Apollo, co-write a 3-email sequence with you, then load it all into Instantly. The campaign always stays paused for your review, I never auto-launch."
     }
   },

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -87,9 +87,17 @@
         "title": "Routines",
         "body": "Schedule work to run in the background. Useful for daily briefs and recurring tasks."
       },
+      "tabIntegrations": {
+        "title": "Integrations",
+        "body": "Tools your agents can use, like Gmail and Calendar. Connections live here, shared across all your agents."
+      },
       "tabFiles": {
         "title": "Files",
         "body": "Docs your assistant can read or share with you. Drop anything here for context."
+      },
+      "tabArchived": {
+        "title": "Completed",
+        "body": "Missions this agent has wrapped up. Send a message to reopen one and it comes right back to the active board."
       },
       "tabJobDescription": {
         "title": "Agent Settings",
@@ -99,9 +107,21 @@
         "title": "Mission Control",
         "body": "When you add more agents, this becomes the single board across all of them. One place to see everything."
       },
-      "integrations": {
-        "title": "Integrations",
-        "body": "Tools your agents can use, like Gmail and Calendar. Connections live here, shared across all your agents."
+      "navIntegrations": {
+        "title": "Connect your apps",
+        "body": "Link Gmail, Calendar, and hundreds more here. Every agent can use what you connect."
+      },
+      "aiHub": {
+        "title": "AI Models",
+        "body": "Add providers like Claude and OpenAI. Manage your subscriptions and API keys here."
+      },
+      "organization": {
+        "title": "Organization",
+        "body": "Invite teammates, assign roles, and manage access here."
+      },
+      "settings": {
+        "title": "Settings",
+        "body": "Your account, workspace, and app preferences live here."
       },
       "appTour": {
         "title": "Replay the tour",
@@ -144,8 +164,10 @@
   },
   "agentProvisioning": {
     "title": "We are creating your agent",
-    "failed": "We could not finish creating your agent. Please try again in a moment.",
-    "blockedBody": "It is almost ready. This action will be available in a moment, as soon as your agent finishes setting up."
+    "stillStarting": "Your agent is taking longer than usual to start. We are still trying, hang tight.",
+    "blockedBody": "It is almost ready. This action will be available in a moment, as soon as your agent finishes setting up.",
+    "stalledTitle": "Still working on it",
+    "stalledBody": "This is taking longer than a normal start. We have not given up, your chat and messages are safe and will pick up the moment your agent answers."
   },
   "agentWelcome": {
     "missionTitle": "Meet {{name}}",

--- a/app/src/locales/en/teams.json
+++ b/app/src/locales/en/teams.json
@@ -3,7 +3,7 @@
     "title": "Agent settings",
     "rows": {
       "knowledge": {
-        "title": "Knowledge"
+        "title": "Memory"
       },
       "model": {
         "title": "AI models"

--- a/app/src/locales/es/agents.json
+++ b/app/src/locales/es/agents.json
@@ -9,35 +9,35 @@
       "description": "Un agente en blanco, sin acciones, instrucciones ni aprendizajes preconfigurados. Constrúyelo a tu manera."
     },
     "bookkeeping": {
-      "name": "Contabilidad",
+      "name": "Contador",
       "description": "Categoriza transacciones, concilia cuentas, cierra los libros cada mes y genera estados financieros listos para inversionistas. Se conecta con QuickBooks, Xero, Stripe y tus conexiones bancarias. Redacta asientos contables y estados, pero nunca registra en tu libro mayor ni mueve dinero."
     },
     "legal": {
-      "name": "Legal",
+      "name": "Director Jurídico",
       "description": "Revisa contratos, audita el cumplimiento de privacidad, prepara presentaciones ante Delaware, hace búsquedas de marcas registradas y responde dudas legales al instante. Redacta acuerdos de confidencialidad, políticas y resúmenes de escalamiento, pero nunca presenta, firma ni envía nada en tu nombre."
     },
     "marketing": {
-      "name": "Marketing",
+      "name": "Líder de Crecimiento",
       "description": "Define el posicionamiento, planifica campañas, escribe artículos de blog y páginas de aterrizaje, audita el SEO y la visibilidad en búsquedas con IA, y redacta secuencias de correo. De la estrategia a la ejecución en contenido, medios pagados, redes sociales y textos de conversión, todo en borradores, nunca publicado."
     },
     "operations": {
-      "name": "Operaciones",
+      "name": "Jefe de Gabinete",
       "description": "Prioriza tu bandeja de entrada, prepara reuniones, da seguimiento a objetivos, gestiona renovaciones con proveedores, audita el gasto en SaaS y ejecuta consultas de datos. Abarca planificación, agenda, orden financiero y reportes, solo borradores, nunca envía ni confirma nada."
     },
     "people": {
-      "name": "Personas",
+      "name": "Jefe de Talento",
       "description": "Busca y evalúa candidatos, coordina rondas de entrevistas, redacta cartas de oferta, gestiona ciclos de evaluación y da seguimiento a plazos de cumplimiento. Abarca desde la contratación hasta la retención, solo borradores, nunca envía ni modifica tus sistemas de recursos humanos."
     },
     "sales": {
-      "name": "Ventas",
+      "name": "Chief Revenue Officer",
       "description": "Encuentra prospectos, investiga cuentas, prepara llamadas, redacta mensajes de contacto, gestiona tu CRM y proyecta el pipeline. Abarca desde la prospección hasta la expansión, solo borradores, nunca envía ni cambia la etapa de un trato sin tu aprobación."
     },
     "support": {
-      "name": "Soporte",
+      "name": "Jefe de Éxito del Cliente",
       "description": "Prioriza tickets, redacta respuestas, escribe artículos del centro de ayuda, evalúa la salud de los clientes y crea planes para evitar cancelaciones. Abarca desde la bandeja de entrada hasta el éxito del cliente, solo borradores, nunca envía."
     },
     "outbound": {
-      "name": "Prospección",
+      "name": "Growth Hacker",
       "description": "Convierte una sola publicación de LinkedIn en una campaña de correo en frío pausada en Instantly. Extraigo a quienes comentan o reaccionan, los guardo en Airtable, busco correos verificados con Apollo, escribo contigo una secuencia de 3 correos y luego cargo todo en Instantly. La campaña siempre queda en pausa para que la revises, nunca la lanzo sola."
     }
   },

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -87,9 +87,17 @@
         "title": "Rutinas",
         "body": "Programa trabajo para que corra en segundo plano. Útil para resúmenes diarios y tareas recurrentes."
       },
+      "tabIntegrations": {
+        "title": "Integraciones",
+        "body": "Herramientas que tus agentes pueden usar, como Gmail y Calendar. Las conexiones viven aquí, compartidas entre todos tus agentes."
+      },
       "tabFiles": {
         "title": "Archivos",
         "body": "Documentos que tu asistente puede leer o compartir contigo. Arrastra lo que quieras para dar contexto."
+      },
+      "tabArchived": {
+        "title": "Completadas",
+        "body": "Misiones que este agente ya terminó. Envía un mensaje para reabrir una y vuelve directo al tablero activo."
       },
       "tabJobDescription": {
         "title": "Configuración del agente",
@@ -99,9 +107,21 @@
         "title": "Centro de Misión",
         "body": "Cuando agregues más agentes, esto se vuelve el tablero único de todos. Un solo lugar para verlo todo."
       },
-      "integrations": {
-        "title": "Integraciones",
-        "body": "Herramientas que tus agentes pueden usar, como Gmail y Calendar. Las conexiones viven aquí, compartidas entre todos tus agentes."
+      "navIntegrations": {
+        "title": "Conecta tus apps",
+        "body": "Vincula Gmail, Calendar y cientos más aquí. Cada agente puede usar lo que conectes."
+      },
+      "aiHub": {
+        "title": "Modelos de IA",
+        "body": "Agrega proveedores como Claude y OpenAI. Gestiona tus suscripciones y llaves de API aquí."
+      },
+      "organization": {
+        "title": "Organización",
+        "body": "Invita a tu equipo, asigna roles y gestiona el acceso aquí."
+      },
+      "settings": {
+        "title": "Configuración",
+        "body": "Tu cuenta, espacio de trabajo y preferencias de la app viven aquí."
       },
       "appTour": {
         "title": "Repite el tour",
@@ -144,8 +164,10 @@
   },
   "agentProvisioning": {
     "title": "Estamos creando tu agente",
-    "failed": "No pudimos terminar de crear tu agente. Inténtalo de nuevo en un momento.",
-    "blockedBody": "Ya casi está listo. Esta acción estará disponible en un momento, en cuanto tu agente termine de configurarse."
+    "stillStarting": "Tu agente está tardando más de lo normal en iniciar. Seguimos intentándolo, un momento.",
+    "blockedBody": "Ya casi está listo. Esta acción estará disponible en un momento, en cuanto tu agente termine de configurarse.",
+    "stalledTitle": "Seguimos en eso",
+    "stalledBody": "Esto está tardando más de lo normal. No nos hemos rendido, tu chat y tus mensajes están a salvo y continuarán en cuanto tu agente responda."
   },
   "agentWelcome": {
     "missionTitle": "Conoce a {{name}}",

--- a/app/src/locales/es/teams.json
+++ b/app/src/locales/es/teams.json
@@ -3,7 +3,7 @@
     "title": "Configuración del agente",
     "rows": {
       "knowledge": {
-        "title": "Conocimiento"
+        "title": "Memoria"
       },
       "model": {
         "title": "Modelos de IA"

--- a/app/src/locales/pt/agents.json
+++ b/app/src/locales/pt/agents.json
@@ -9,35 +9,35 @@
       "description": "Um agente em branco, sem ações, instruções ou aprendizados pré-configurados. Monte do seu jeito."
     },
     "bookkeeping": {
-      "name": "Contabilidade",
+      "name": "Contador",
       "description": "Categoriza transações, concilia contas, fecha os livros todo mês e gera demonstrações financeiras prontas para investidores. Conecta com QuickBooks, Xero, Stripe e os feeds do seu banco. Prepara lançamentos contábeis e demonstrações, mas nunca registra no seu livro-razão nem movimenta dinheiro."
     },
     "legal": {
-      "name": "Jurídico",
+      "name": "Diretor Jurídico",
       "description": "Revisa contratos, audita a conformidade de privacidade, prepara registros em Delaware, faz buscas de marcas registradas e responde dúvidas jurídicas na hora. Prepara acordos de confidencialidade, políticas e resumos de escalonamento, mas nunca protocola, assina nem envia nada em seu nome."
     },
     "marketing": {
-      "name": "Marketing",
+      "name": "Líder de Crescimento",
       "description": "Define o posicionamento, planeja campanhas, escreve posts de blog e páginas de destino, audita o SEO e a visibilidade em buscas com IA, e redige sequências de e-mail. Da estratégia à execução em conteúdo, mídia paga, redes sociais e textos de conversão, tudo em rascunhos, nunca publicado."
     },
     "operations": {
-      "name": "Operações",
+      "name": "Chefe de Gabinete",
       "description": "Prioriza sua caixa de entrada, prepara reuniões, acompanha metas, gerencia renovações com fornecedores, audita os gastos com SaaS e executa consultas de dados. Abrange planejamento, agenda, organização financeira e relatórios, apenas rascunhos, nunca envia nem confirma nada."
     },
     "people": {
-      "name": "Pessoas",
+      "name": "Chefe de Talentos",
       "description": "Busca e avalia candidatos, coordena rodadas de entrevistas, redige cartas de oferta, conduz ciclos de avaliação e acompanha prazos de conformidade. Abrange da contratação à retenção, apenas rascunhos, nunca envia nem modifica seus sistemas de RH."
     },
     "sales": {
-      "name": "Vendas",
+      "name": "Chief Revenue Officer",
       "description": "Encontra leads, pesquisa contas, prepara ligações, redige mensagens de contato, gerencia seu CRM e projeta o pipeline. Abrange da prospecção à expansão, apenas rascunhos, nunca envia nem muda o estágio de uma negociação sem a sua aprovação."
     },
     "support": {
-      "name": "Suporte",
+      "name": "Chefe de Sucesso do Cliente",
       "description": "Prioriza tickets, redige respostas, escreve artigos da central de ajuda, avalia a saúde dos clientes e cria planos para evitar cancelamentos. Abrange da caixa de entrada ao sucesso do cliente, apenas rascunhos, nunca envia."
     },
     "outbound": {
-      "name": "Prospecção",
+      "name": "Growth Hacker",
       "description": "Transforma uma única publicação do LinkedIn em uma campanha de e-mail frio pausada no Instantly. Extraio quem comenta ou reage, guardo essas pessoas no Airtable, busco e-mails verificados com o Apollo, escrevo com você uma sequência de 3 e-mails e depois carrego tudo no Instantly. A campanha sempre fica pausada para você revisar, nunca disparo sozinho."
     }
   },

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -87,9 +87,17 @@
         "title": "Rotinas",
         "body": "Agende trabalho para rodar em segundo plano. Útil para resumos diários e tarefas recorrentes."
       },
+      "tabIntegrations": {
+        "title": "Integrações",
+        "body": "Ferramentas que seus agentes podem usar, como Gmail e Calendar. As conexões ficam aqui, compartilhadas entre todos os seus agentes."
+      },
       "tabFiles": {
         "title": "Arquivos",
         "body": "Documentos que seu assistente pode ler ou compartilhar com você. Solte qualquer coisa aqui para dar contexto."
+      },
+      "tabArchived": {
+        "title": "Concluídas",
+        "body": "Missões que este agente já concluiu. Envie uma mensagem para reabrir uma e ela volta direto para o painel ativo."
       },
       "tabJobDescription": {
         "title": "Configurações do agente",
@@ -98,6 +106,22 @@
       "missionControl": {
         "title": "Central de Missão",
         "body": "Quando adicionar mais agentes, isso vira o painel único de todos. Um lugar só para ver tudo."
+      },
+      "navIntegrations": {
+        "title": "Conecte seus apps",
+        "body": "Vincule Gmail, Calendar e centenas de outros aqui. Todo agente pode usar o que você conectar."
+      },
+      "aiHub": {
+        "title": "Modelos de IA",
+        "body": "Adicione provedores como Claude e OpenAI. Gerencie suas assinaturas e chaves de API aqui."
+      },
+      "organization": {
+        "title": "Organização",
+        "body": "Convide sua equipe, atribua funções e gerencie o acesso aqui."
+      },
+      "settings": {
+        "title": "Configurações",
+        "body": "Sua conta, espaço de trabalho e preferências do app ficam aqui."
       },
       "appTour": {
         "title": "Repita o tour",
@@ -115,10 +139,6 @@
         "title": "Agora vai construir algo incrível",
         "body": "Esse é o tour inteiro. O resto é com você, divirta-se.",
         "confirm": "Vou fazer algo incrível"
-      },
-      "integrations": {
-        "title": "Integrações",
-        "body": "Ferramentas que seus agentes podem usar, como Gmail e Calendar. As conexões ficam aqui, compartilhadas entre todos os seus agentes."
       }
     }
   },
@@ -144,8 +164,10 @@
   },
   "agentProvisioning": {
     "title": "Estamos criando seu agente",
-    "failed": "Não conseguimos terminar de criar seu agente. Tente novamente em instantes.",
-    "blockedBody": "Está quase pronto. Essa ação estará disponível em instantes, assim que seu agente terminar de se configurar."
+    "stillStarting": "Seu agente está demorando mais que o normal para iniciar. Ainda estamos tentando, aguarde um momento.",
+    "blockedBody": "Está quase pronto. Essa ação estará disponível em instantes, assim que seu agente terminar de se configurar.",
+    "stalledTitle": "Ainda estamos nessa",
+    "stalledBody": "Isso está demorando mais que o normal. Não desistimos, seu chat e suas mensagens estão seguros e vão continuar assim que seu agente responder."
   },
   "agentWelcome": {
     "missionTitle": "Conheça {{name}}",

--- a/app/src/locales/pt/teams.json
+++ b/app/src/locales/pt/teams.json
@@ -3,7 +3,7 @@
     "title": "Configurações do agente",
     "rows": {
       "knowledge": {
-        "title": "Conhecimento"
+        "title": "Memória"
       },
       "model": {
         "title": "Modelos de IA"

--- a/app/src/stores/agent-provisioning.ts
+++ b/app/src/stores/agent-provisioning.ts
@@ -156,13 +156,16 @@ export const useAgentProvisioningStore = create<AgentProvisioningState>(
       const previous = get().provisioning[oldId];
       if (!previous) return;
       get().clearProvisioning(oldId);
-      // Keep the original TTL anchor: the rename didn't restart the warm-up.
+      // Keep the original TTL anchor and timed-out flag: the rename didn't
+      // restart the warm-up, and carrying `timedOut` avoids re-showing the
+      // "still starting" toast for a stall the user already saw.
       // Queued sends move with the agent (their session keys are stable).
       startEntry({
         agentId: agent.id,
         agentPath: agent.folderPath,
         since: previous.since,
         pendingSends: previous.pendingSends,
+        timedOut: previous.timedOut,
       });
     },
 
@@ -241,13 +244,31 @@ function startProbe(entry: ProvisioningEntry): void {
         .finally(() => store.clearProvisioning(id, entry));
     },
     onTimeout: (id, lastError) => {
-      store.clearProvisioning(id, entry);
-      showErrorToast(
-        "agent_provisioning",
-        lastError instanceof Error ? lastError.message : String(lastError),
-        lastError,
-        { userMessage: i18n.t("shell:agentProvisioning.failed") },
-      );
+      // A newer mark (rename, or a fresh create reusing the id) already
+      // retired this exact entry — nothing to do.
+      if (useAgentProvisioningStore.getState().provisioning[id] !== entry) {
+        return;
+      }
+      // HOU-693 regression: this used to clearProvisioning here, silently
+      // dropping the user's still-visible first chat the moment a cold start
+      // ran past the TTL. Never make a visible mission disappear on its own —
+      // flag it once (toast + sticky UI state) and keep waiting instead of
+      // giving up. A pod that's merely slow to schedule still comes up.
+      if (!entry.timedOut) {
+        entry.timedOut = true;
+        showErrorToast(
+          "agent_provisioning",
+          lastError instanceof Error ? lastError.message : String(lastError),
+          lastError,
+          { userMessage: i18n.t("shell:agentProvisioning.stillStarting") },
+        );
+      }
+      entry.since = Date.now();
+      useAgentProvisioningStore.setState((s) => {
+        storageWrite(s.provisioning);
+        return { sendsVersion: s.sendsVersion + 1 };
+      });
+      startProbe(entry);
     },
     sleep,
     now: () => Date.now(),
@@ -267,6 +288,10 @@ void whenEngineReady().then(() => {
     return;
   }
   for (const entry of fresh) {
+    // A timed-out entry's `since` may be hours stale (kept regardless of age
+    // by the parse filter above) — re-anchor it so the resumed probe gets a
+    // fresh TTL window instead of immediately re-timing-out.
+    if (entry.timedOut) entry.since = Date.now();
     startEntry(entry);
     // The relaunch emptied the in-memory VM: re-render the queued bubbles so
     // the sent-but-not-yet-delivered messages stay visible.

--- a/app/tests/agent-provisioning.test.ts
+++ b/app/tests/agent-provisioning.test.ts
@@ -109,6 +109,19 @@ describe("parsePersistedProvisioning", () => {
     );
   });
 
+  it("keeps a timed-out entry regardless of age (HOU-693 regression)", () => {
+    const stalled = {
+      agentId: "a3",
+      agentPath: "/w/a3",
+      since: now - PROVISIONING_TTL_MS * 10,
+      timedOut: true,
+    };
+    deepStrictEqual(
+      parsePersistedProvisioning(JSON.stringify([stalled, fresh]), now),
+      [stalled, fresh],
+    );
+  });
+
   it("survives malformed storage", () => {
     deepStrictEqual(parsePersistedProvisioning(null, now), []);
     deepStrictEqual(parsePersistedProvisioning("not json", now), []);

--- a/store/agents/bookkeeping/houston.json
+++ b/store/agents/bookkeeping/houston.json
@@ -1,6 +1,6 @@
 {
   "id": "bookkeeping",
-  "name": "Bookkeeping",
+  "name": "Bookkeeper",
   "description": "Categorize transactions, reconcile accounts, close the books every month, and generate investor-ready financials. Connects to QuickBooks, Xero, Stripe, and your bank feeds. Drafts journal entries and statements - never posts to your ledger or moves money.",
   "icon": "Calculator",
   "category": "business",

--- a/store/agents/legal/houston.json
+++ b/store/agents/legal/houston.json
@@ -1,6 +1,6 @@
 {
   "id": "legal",
-  "name": "Legal",
+  "name": "General Counsel",
   "description": "Review contracts, audit privacy compliance, prep Delaware filings, run trademark searches, and answer legal questions on the spot. Drafts NDAs, policies, and escalation briefs - never files, signs, or sends anything on your behalf.",
   "icon": "Scale",
   "category": "business",

--- a/store/agents/marketing/houston.json
+++ b/store/agents/marketing/houston.json
@@ -1,6 +1,6 @@
 {
   "id": "marketing",
-  "name": "Marketing",
+  "name": "Growth Lead",
   "description": "Build positioning, plan campaigns, write blog posts and landing pages, audit SEO and AI-search visibility, and draft email sequences. Strategy through execution across content, paid, social, and conversion copy - all drafts, never published.",
   "icon": "Sparkles",
   "category": "business",

--- a/store/agents/operations/houston.json
+++ b/store/agents/operations/houston.json
@@ -1,6 +1,6 @@
 {
   "id": "operations",
-  "name": "Operations",
+  "name": "Chief of Staff",
   "description": "Triage your inbox, prep meetings, track goals, manage vendor renewals, audit SaaS spend, and run data queries. Covers planning, scheduling, finance hygiene, and reporting - drafts only, never sends or commits.",
   "icon": "Briefcase",
   "category": "business",

--- a/store/agents/outbound/houston.json
+++ b/store/agents/outbound/houston.json
@@ -1,6 +1,6 @@
 {
   "id": "outbound",
-  "name": "Outbound",
+  "name": "Growth Hacker",
   "description": "Turn a single LinkedIn post into a paused cold email campaign in Instantly. I scrape the commenters or reactors, store them in Airtable, find verified emails through Apollo, co-write a 3-email sequence with you, then load it all into Instantly. The campaign always stays paused for your review - I never auto-launch.",
   "icon": "Mail",
   "category": "business",

--- a/store/agents/people/houston.json
+++ b/store/agents/people/houston.json
@@ -1,6 +1,6 @@
 {
   "id": "people",
-  "name": "People",
+  "name": "Head of Talent",
   "description": "Source and evaluate candidates, coordinate interview loops, draft offer letters, run review cycles, and track compliance deadlines. Covers hiring through retention - drafts only, never sends or modifies your HR systems.",
   "icon": "Users",
   "category": "business",

--- a/store/agents/sales/houston.json
+++ b/store/agents/sales/houston.json
@@ -1,6 +1,6 @@
 {
   "id": "sales",
-  "name": "Sales",
+  "name": "Chief Revenue Officer",
   "description": "Find leads, research accounts, prep calls, draft outreach, manage your CRM, and forecast pipeline. Covers prospecting through expansion - drafts only, never sends or changes deal stages without your approval.",
   "icon": "Target",
   "category": "business",

--- a/store/agents/support/houston.json
+++ b/store/agents/support/houston.json
@@ -1,6 +1,6 @@
 {
   "id": "support",
-  "name": "Support",
+  "name": "Head of Customer Success",
   "description": "Triage tickets, draft replies, write help-center articles, score customer health, and build churn-save playbooks. Covers inbox through customer success - drafts only, never sends.",
   "icon": "Headset",
   "category": "business",

--- a/store/catalog.json
+++ b/store/catalog.json
@@ -3,7 +3,7 @@
   "agents": [
     {
       "id": "bookkeeping",
-      "name": "Bookkeeping",
+      "name": "Bookkeeper",
       "description": "Categorize transactions, reconcile accounts, close the books every month, and generate investor-ready financials. Connects to QuickBooks, Xero, Stripe, and your bank feeds. Drafts journal entries and statements - never posts to your ledger or moves money.",
       "category": "business",
       "author": "Houston",
@@ -43,7 +43,7 @@
     },
     {
       "id": "legal",
-      "name": "Legal",
+      "name": "General Counsel",
       "description": "Review contracts, audit privacy compliance, prep Delaware filings, run trademark searches, and answer legal questions on the spot. Drafts NDAs, policies, and escalation briefs - never files, signs, or sends anything on your behalf.",
       "category": "business",
       "author": "Houston",
@@ -79,7 +79,7 @@
     },
     {
       "id": "marketing",
-      "name": "Marketing",
+      "name": "Growth Lead",
       "description": "Build positioning, plan campaigns, write blog posts and landing pages, audit SEO and AI-search visibility, and draft email sequences. Strategy through execution across content, paid, social, and conversion copy - all drafts, never published.",
       "category": "business",
       "author": "Houston",
@@ -127,7 +127,7 @@
     },
     {
       "id": "operations",
-      "name": "Operations",
+      "name": "Chief of Staff",
       "description": "Triage your inbox, prep meetings, track goals, manage vendor renewals, audit SaaS spend, and run data queries. Covers planning, scheduling, finance hygiene, and reporting - drafts only, never sends or commits.",
       "category": "business",
       "author": "Houston",
@@ -169,7 +169,7 @@
     },
     {
       "id": "people",
-      "name": "People",
+      "name": "Head of Talent",
       "description": "Source and evaluate candidates, coordinate interview loops, draft offer letters, run review cycles, and track compliance deadlines. Covers hiring through retention - drafts only, never sends or modifies your HR systems.",
       "category": "business",
       "author": "Houston",
@@ -210,7 +210,7 @@
     },
     {
       "id": "sales",
-      "name": "Sales",
+      "name": "Chief Revenue Officer",
       "description": "Find leads, research accounts, prep calls, draft outreach, manage your CRM, and forecast pipeline. Covers prospecting through expansion - drafts only, never sends or changes deal stages without your approval.",
       "category": "business",
       "author": "Houston",
@@ -253,7 +253,7 @@
     },
     {
       "id": "support",
-      "name": "Support",
+      "name": "Head of Customer Success",
       "description": "Triage tickets, draft replies, write help-center articles, score customer health, and build churn-save playbooks. Covers inbox through customer success - drafts only, never sends.",
       "category": "business",
       "author": "Houston",
@@ -294,7 +294,7 @@
     },
     {
       "id": "outbound",
-      "name": "Outbound",
+      "name": "Growth Hacker",
       "description": "Turn a single LinkedIn post into a paused cold email campaign in Instantly. I scrape the commenters or reactors, store them in Airtable, find verified emails through Apollo, co-write a 3-email sequence with you, then load it all into Instantly. The campaign always stays paused for your review - I never auto-launch.",
       "category": "business",
       "author": "Houston",


### PR DESCRIPTION
## Summary
- Add missing product-tour steps: per-agent Integrations/Archived tabs, and sidebar Integrations/AI Models/Organization/Settings.
- Rename store agents to distinct role titles (Bookkeeper, General Counsel, Growth Lead, Chief of Staff, Head of Talent, Chief Revenue Officer, Head of Customer Success, Growth Hacker) instead of naming them after their discipline.
- Fix HOU-693 regression: a user's first chat could silently vanish when a cold-starting pod outran `PROVISIONING_TTL_MS` — timeout no longer clears the provisioning entry, it flags it `timedOut` and keeps retrying with a clear "still starting" state.
- Rename "Knowledge" to "Memory" in agent settings (display string only; internal id unchanged).
- Make connected vs. not-connected cards consistent across the Integrations tab and AI Models tab: a colored dot + label next to the name everywhere, no card-level tinting.

## Test plan
- [x] `pnpm --filter houston-app` (app) `tsgo --noEmit` — clean
- [x] `pnpm --filter houston-web typecheck` (Tauri shim-parity + tsgo) — clean
- [x] `pnpm check-locales` (en/es/pt) — in sync
- [x] `pnpm check:boundaries` — clean
- [x] `node --experimental-strip-types --test tests/*.test.ts` — 1073/1073 passing (includes new regression test for the provisioning-TTL persisted-storage filter)
- [x] Biome clean on every touched file
- [ ] No browser/screenshot tool was available this session, so the visual result wasn't checked in an actual browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)