### PR TITLE
feat(sidebar): group shared context (GROUP.md) + group polish

### DIFF
--- a/app/src/components/shell/group-context-dialog.tsx
+++ b/app/src/components/shell/group-context-dialog.tsx
@@ -1,0 +1,85 @@
+import {
+  AsyncButton,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@houston-ai/core";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Name of the group whose shared context is being edited (dialog title). */
+  groupName: string;
+  /** The group's current shared context. */
+  content: string;
+  onSave: (content: string) => Promise<void> | void;
+}
+
+/**
+ * Edits a sidebar group's shared context: prose injected into every member
+ * agent's system prompt as `GROUP.md`. A controlled dialog with a textarea; the
+ * draft resets to the group's current context each time the dialog opens so a
+ * cancelled edit never leaks into the next one.
+ */
+export function GroupContextDialog({
+  open,
+  onOpenChange,
+  groupName,
+  content,
+  onSave,
+}: Props) {
+  const { t } = useTranslation("shell");
+  const [draft, setDraft] = useState(content);
+
+  // Reseed the draft from the group's current context whenever the dialog
+  // opens (a new target group, or the same one after external edits).
+  useEffect(() => {
+    if (open) setDraft(content);
+  }, [open, content]);
+
+  const handleSave = async () => {
+    await onSave(draft);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>
+            {t("sidebar.groups.contextDialog.title", { name: groupName })}
+          </DialogTitle>
+          <DialogDescription>
+            {t("sidebar.groups.contextDialog.description")}
+          </DialogDescription>
+        </DialogHeader>
+        <textarea
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          placeholder={t("sidebar.groups.contextDialog.placeholder")}
+          rows={8}
+          className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-ring resize-none"
+          autoFocus
+        />
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+          >
+            {t("sidebar.groups.contextDialog.cancel")}
+          </Button>
+          <AsyncButton type="button" onClick={handleSave}>
+            {t("sidebar.groups.contextDialog.save")}
+          </AsyncButton>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/shell/sidebar-chrome.tsx
+++ b/app/src/components/shell/sidebar-chrome.tsx
@@ -72,6 +72,7 @@ export function buildSidebarLabels(t: ShellT): SidebarLabels {
     createGroup: t("shell:sidebar.groups.new"),
     renameGroup: t("shell:sidebar.groups.rename"),
     deleteGroup: t("shell:sidebar.groups.delete"),
+    editGroupContext: t("shell:sidebar.groups.editContext"),
     groupMenu: t("shell:sidebar.groups.menu"),
     newGroupPlaceholder: t("shell:sidebar.groups.namePlaceholder"),
     emptyGroupHint: t("shell:sidebar.groups.emptyHint"),

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -5,7 +5,7 @@ import {
   TooltipTrigger,
 } from "@houston-ai/core";
 import { AppSidebar } from "@houston-ai/layout";
-import { FolderPlus } from "lucide-react";
+import { Users } from "lucide-react";
 import { type ReactNode, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
@@ -19,6 +19,7 @@ import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { canSeeOrganization } from "../organization";
 import { buildAgentSidebarLists } from "./agent-sidebar-items";
+import { GroupContextDialog } from "./group-context-dialog";
 import {
   buildSidebarLabels,
   buildSidebarNavItems,
@@ -46,6 +47,10 @@ export function Sidebar({ children }: { children: ReactNode }) {
   const [createWsOpen, setCreateWsOpen] = useState(false);
   // A just-created group: the sidebar opens it straight into inline-rename.
   const [renamingGroupId, setRenamingGroupId] = useState<string | null>(null);
+  // The group whose shared context is open in the editor dialog (null = closed).
+  const [editingContextGroupId, setEditingContextGroupId] = useState<
+    string | null
+  >(null);
 
   const viewMode = useUIStore((s) => s.viewMode);
   const setViewMode = useUIStore((s) => s.setViewMode);
@@ -122,6 +127,10 @@ export function Sidebar({ children }: { children: ReactNode }) {
     setPendingDeleteId(null);
   };
 
+  const editingContextGroup = editingContextGroupId
+    ? sidebar.layout.groups.find((g) => g.id === editingContextGroupId)
+    : undefined;
+
   return (
     <>
       <ConfirmDialog
@@ -137,6 +146,18 @@ export function Sidebar({ children }: { children: ReactNode }) {
       <CreateWorkspaceDialog
         open={createWsOpen}
         onOpenChange={setCreateWsOpen}
+      />
+      <GroupContextDialog
+        open={editingContextGroup !== undefined}
+        onOpenChange={(open) => {
+          if (!open) setEditingContextGroupId(null);
+        }}
+        groupName={editingContextGroup?.name ?? ""}
+        content={editingContextGroup?.context ?? ""}
+        onSave={(next) => {
+          if (editingContextGroupId)
+            sidebar.setGroupContext(editingContextGroupId, next);
+        }}
       />
       <div className="flex h-full flex-1 min-w-0">
         <AppSidebar
@@ -172,7 +193,7 @@ export function Sidebar({ children }: { children: ReactNode }) {
                     }}
                     className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
                   >
-                    <FolderPlus className="size-4" />
+                    <Users className="size-4" />
                   </button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom">
@@ -186,6 +207,7 @@ export function Sidebar({ children }: { children: ReactNode }) {
           renamingGroupId={renamingGroupId}
           onRenamingGroupIdHandled={() => setRenamingGroupId(null)}
           onToggleGroupCollapsed={sidebar.toggleGroupCollapsed}
+          onEditGroupContext={(id) => setEditingContextGroupId(id)}
           onRenameGroup={sidebar.renameGroup}
           onDeleteGroup={sidebar.deleteGroup}
           onMoveItem={sidebar.moveItem}

--- a/app/src/hooks/use-sidebar-layout.ts
+++ b/app/src/hooks/use-sidebar-layout.ts
@@ -11,6 +11,7 @@ import {
   moveItemOp,
   normalizeSidebarLayout,
   renameGroupOp,
+  setGroupContextOp,
   toggleGroupCollapsedOp,
 } from "../lib/sidebar-layout-ops";
 import { tauriSidebar } from "../lib/tauri";
@@ -34,6 +35,7 @@ export interface UseSidebarLayout {
   /** Create a group and return its new id (so the caller can focus its name). */
   createGroup: (name: string) => string | null;
   renameGroup: (id: string, name: string) => void;
+  setGroupContext: (id: string, context: string) => void;
   deleteGroup: (id: string) => void;
   toggleGroupCollapsed: (id: string) => void;
   moveItem: (agentId: string, dest: ItemDest) => void;
@@ -100,6 +102,8 @@ export function useSidebarLayout(
       return id;
     },
     renameGroup: (id, name) => apply((c) => renameGroupOp(c, id, name)),
+    setGroupContext: (id, context) =>
+      apply((c) => setGroupContextOp(c, id, context)),
     deleteGroup: (id) => apply((c) => deleteGroupOp(c, id)),
     toggleGroupCollapsed: (id) => apply((c) => toggleGroupCollapsedOp(c, id)),
     moveItem: (agentId, dest) => apply((c) => moveItemOp(c, agentId, dest)),

--- a/app/src/lib/sidebar-layout-ops.test.mjs
+++ b/app/src/lib/sidebar-layout-ops.test.mjs
@@ -8,6 +8,7 @@ import {
   moveItemOp,
   normalizeSidebarLayout,
   renameGroupOp,
+  setGroupContextOp,
   toggleGroupCollapsedOp,
 } from "./sidebar-layout-ops.ts";
 
@@ -37,6 +38,49 @@ test("renameGroupOp renames only the target", () => {
   const next = renameGroupOp(l, "g2", "Renamed");
   assert.equal(next.groups[1].name, "Renamed");
   assert.equal(next.groups[0].name, "g1");
+});
+
+test("setGroupContextOp sets context only on the target", () => {
+  const l = base({ groups: [group("g1", ["a"]), group("g2", [])] });
+  const next = setGroupContextOp(l, "g1", "We are a design studio.");
+  assert.equal(next.groups[0].context, "We are a design studio.");
+  assert.equal(next.groups[1].context, undefined);
+  // The target's other fields are preserved.
+  assert.deepEqual(next.groups[0].agentIds, ["a"]);
+});
+
+test("setGroupContextOp overwrites an existing context", () => {
+  const l = base({ groups: [group("g1", [], { context: "old" })] });
+  const next = setGroupContextOp(l, "g1", "new");
+  assert.equal(next.groups[0].context, "new");
+});
+
+test("setGroupContextOp can clear the context to empty", () => {
+  const l = base({ groups: [group("g1", [], { context: "old" })] });
+  const next = setGroupContextOp(l, "g1", "");
+  assert.equal(next.groups[0].context, "");
+});
+
+test("setGroupContextOp is a no-op for an unknown id", () => {
+  const l = base({ groups: [group("g1", [])] });
+  const next = setGroupContextOp(l, "nope", "x");
+  assert.equal(next.groups[0].context, undefined);
+});
+
+test("normalizeSidebarLayout round-trips a context string", () => {
+  const out = normalizeSidebarLayout({
+    groups: [group("g1", ["a"], { context: "shared note" })],
+    ungroupedOrder: [],
+  });
+  assert.equal(out.groups[0].context, "shared note");
+});
+
+test("normalizeSidebarLayout drops a group with a non-string context", () => {
+  const out = normalizeSidebarLayout({
+    groups: [group("g1", ["a"], { context: 42 })],
+    ungroupedOrder: [],
+  });
+  assert.deepEqual(out.groups, []);
 });
 
 test("deleteGroupOp frees members to ungrouped (appended)", () => {

--- a/app/src/lib/sidebar-layout-ops.ts
+++ b/app/src/lib/sidebar-layout-ops.ts
@@ -38,7 +38,8 @@ export function normalizeSidebarLayout(raw: unknown): SidebarLayout {
           typeof gr.id !== "string" ||
           typeof gr.name !== "string" ||
           typeof gr.collapsed !== "boolean" ||
-          !isStringArray(gr.agentIds)
+          !isStringArray(gr.agentIds) ||
+          (gr.context !== undefined && typeof gr.context !== "string")
         )
           return [];
         return [
@@ -47,6 +48,7 @@ export function normalizeSidebarLayout(raw: unknown): SidebarLayout {
             name: gr.name,
             collapsed: gr.collapsed,
             agentIds: gr.agentIds,
+            ...(gr.context !== undefined ? { context: gr.context } : {}),
           },
         ];
       })
@@ -91,6 +93,19 @@ export function renameGroupOp(
   return {
     ...layout,
     groups: layout.groups.map((g) => (g.id === id ? { ...g, name } : g)),
+  };
+}
+
+/** Set a group's shared context, injected into every member agent's system
+ *  prompt as `GROUP.md` (no-op if the id is unknown). */
+export function setGroupContextOp(
+  layout: SidebarLayout,
+  id: string,
+  context: string,
+): SidebarLayout {
+  return {
+    ...layout,
+    groups: layout.groups.map((g) => (g.id === id ? { ...g, context } : g)),
   };
 }
 

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -34,7 +34,15 @@
       "menu": "Group options",
       "namePlaceholder": "Group name",
       "emptyHint": "Drag agents here",
-      "ungrouped": "Ungrouped"
+      "ungrouped": "Ungrouped",
+      "editContext": "Edit shared context",
+      "contextDialog": {
+        "title": "Shared context for {{name}}",
+        "description": "This note is added to every agent in this group, so they all share the same background.",
+        "placeholder": "e.g. We are a design studio. Keep replies short and never share client names.",
+        "save": "Save",
+        "cancel": "Cancel"
+      }
     }
   },
   "tabActions": {

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -34,7 +34,15 @@
       "menu": "Opciones de grupo",
       "namePlaceholder": "Nombre del grupo",
       "emptyHint": "Arrastra agentes aquí",
-      "ungrouped": "Sin grupo"
+      "ungrouped": "Sin grupo",
+      "editContext": "Editar contexto compartido",
+      "contextDialog": {
+        "title": "Contexto compartido de {{name}}",
+        "description": "Esta nota se agrega a cada agente de este grupo, así todos comparten el mismo trasfondo.",
+        "placeholder": "ej. Somos un estudio de diseño. Mantén las respuestas cortas y nunca compartas nombres de clientes.",
+        "save": "Guardar",
+        "cancel": "Cancelar"
+      }
     }
   },
   "tabActions": {

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -18,7 +18,15 @@
       "menu": "Opções do grupo",
       "namePlaceholder": "Nome do grupo",
       "emptyHint": "Arraste agentes aqui",
-      "ungrouped": "Sem grupo"
+      "ungrouped": "Sem grupo",
+      "editContext": "Editar contexto compartilhado",
+      "contextDialog": {
+        "title": "Contexto compartilhado de {{name}}",
+        "description": "Esta nota é adicionada a todos os agentes deste grupo, então todos compartilham o mesmo contexto.",
+        "placeholder": "ex. Somos um estúdio de design. Mantenha as respostas curtas e nunca compartilhe nomes de clientes.",
+        "save": "Salvar",
+        "cancel": "Cancelar"
+      }
     },
     "color": "Cor",
     "changeColor": "Alterar cor",

--- a/knowledge-base/agent-manifest.md
+++ b/knowledge-base/agent-manifest.md
@@ -224,7 +224,7 @@ Engine route: `POST /v1/store/workspaces/install-from-github`. Rust impl: `houst
 | > Connections               |  workspace-wide integrations
 | > Organization              |  Teams v2 dashboard (owner/admin + multiplayer only)
 |-----------------------------|
-| Your AI Agents          [+] |  section label + folder-plus "New group" button
+| Your AI Agents          [+] |  section label + a people (Users) icon "New group" button
 |   ▾ Work                 [2]|  a named, collapsible group (drag its title to move it)
 |     > Research Agent    [2] |
 |     > Project Manager       |
@@ -278,6 +278,23 @@ end of the default section). Absent/corrupt reads as `{ [], [] }`.
   ordering in `lib/agent-order.ts` (`resolveSidebarSections` / `flatSidebarOrder`
   — the SAME order feeds ⌘[ / ⌘] cycling + the command palette). Group labels
   live under `shell:sidebar.groups.*` (en/es/pt).
+- **Group shared context.** `SidebarGroup.context?: string` — one note shared
+  by every agent in that group (a group-scoped `WORKSPACE.md`). Edited from the
+  group header's "..." menu → "Edit shared context"
+  (`app/src/components/shell/group-context-dialog.tsx`), saved via
+  `sidebar.setGroupContext` → `setGroupContextOp` → the same `PUT
+  sidebar-layout` write. On every PUT, `routes/account.ts` diffs the previous
+  vs. new per-agent resolved context (`routes/group-context-sync.ts`:
+  `resolveGroupContextByAgent` / `diffGroupContext`) and mirrors it to a
+  `GROUP.md` file at each affected member agent's root (same location as
+  `WORKSPACE.md`; written/deleted via `paths.agentRoot(ws, agent)`, best-effort
+  — never fails the primary layout write), firing `ContextChanged` per agent.
+  Runtime read side: `buildGroupContextSection` in
+  `packages/runtime/src/session/workspace-context.ts`, injected after the
+  workspace/user context section and before the mode overlay — present only
+  for grouped agents (no empty-marker stub, unlike WORKSPACE.md/USER.md, since
+  group membership is optional). Local/self-host only; no cloud "provided"
+  variant yet (would need gateway wiring in the closed `cloud` repo).
 
 Agent rows show a count chip for `needs_you` activity items. If any
 activity item is `running`, the row avatar uses the same comet glow as
@@ -734,12 +751,13 @@ Built in `engine/houston-engine-core/src/agents/prompt.rs::build_agent_context`:
 2. Mode file `.houston/prompts/modes/<mode>.md` (optional, user-editable).
 3. Learnings snapshot — `.houston/learnings/learnings.json`, text fields only, rendered as bounded background context. IDs/timestamps stay storage/UI-only.
 4. **Workspace context block** — assembled from `<workspace>/WORKSPACE.md` + `<workspace>/USER.md` (the agent's parent dir) by `workspace_context::build_prompt_section`. Always included for any agent whose parent dir has a `.houston/`. Files are NOT seeded — they only exist once the user or an agent writes them; until then the section renders an "(empty so far, ask the user when relevant)" marker so the agent knows the slot exists. Section explicitly authorizes the agent to read/write these two files (carve-out from the working-directory rule) and tells it that edits take effect on the **next** chat.
+4a. **Group context block** (current TS host only, no Rust-era equivalent) — `<agent-root>/GROUP.md`, present only when the agent belongs to a sidebar group with shared context set; see "Group shared context" under the sidebar section above. Unlike the workspace block there is no empty-marker stub: an ungrouped agent gets nothing appended.
 5. Skills index — `.agents/skills/` via `houston_skills::build_skills_index`.
 6. Integrations block — based on `.houston/integrations.json` if present.
 
 `CLAUDE.md` is read by the CLI (claude/codex) itself at startup, not injected by the engine.
 
-Users cannot edit the product prompt — it's compiled into the app binary. Per-agent surfaces that ARE user-editable: `CLAUDE.md` (job description), `.agents/skills/` (skills), `.houston/learnings/learnings.json` (learnings), `.houston/prompts/modes/*.md` (mode overrides). Per-workspace surfaces (shared by every agent in the workspace): `WORKSPACE.md` (about the company/project), `USER.md` (about the human running it). Both edited from Settings → Workspace → Shared context, or directly by agents when the user shares new info.
+Users cannot edit the product prompt — it's compiled into the app binary. Per-agent surfaces that ARE user-editable: `CLAUDE.md` (job description), `.agents/skills/` (skills), `.houston/learnings/learnings.json` (learnings), `.houston/prompts/modes/*.md` (mode overrides). Per-workspace surfaces (shared by every agent in the workspace): `WORKSPACE.md` (about the company/project), `USER.md` (about the human running it). Both edited from Settings → Workspace → Shared context, or directly by agents when the user shares new info. Per-group surfaces (shared by every agent in one sidebar group only): `GROUP.md`, edited from the group's "..." menu → Edit shared context, mirrored to member agents by the host on every sidebar-layout write.
 
 ## Board / Activity tab
 `@houston-ai/board::AIBoard` = `KanbanBoard` + `KanbanDetailPanel` + `ChatPanel`. Generic, props-only. Each card = activity from `.houston/activity/activity.json`. Click → opens chat w/ conversation history.

--- a/packages/domain/src/reactivity.ts
+++ b/packages/domain/src/reactivity.ts
@@ -62,7 +62,8 @@ export function agentFileEventType(
     relPath === "AGENTS.md" ||
     relPath === "GEMINI.md" ||
     relPath === "WORKSPACE.md" ||
-    relPath === "USER.md"
+    relPath === "USER.md" ||
+    relPath === "GROUP.md"
   )
     return "ContextChanged";
   // Internal bookkeeping we never surface.

--- a/packages/host/src/routes/account.test.ts
+++ b/packages/host/src/routes/account.test.ts
@@ -9,6 +9,7 @@ import { afterAll, beforeAll, expect, test } from "vitest";
 import { ProxyChannel } from "../channel/proxy";
 import { MemoryCredentialStore } from "../credentials/store";
 import type { EventHub } from "../events/hub";
+import { CloudPaths } from "../paths";
 import type { RuntimeEndpoint, RuntimeLauncher, TokenVerifier } from "../ports";
 import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
 import { MemoryWorkspaceStore } from "../store/memory";
@@ -288,4 +289,191 @@ test("sidebar-layout routes 503 without a vfs", async () => {
   } finally {
     await new Promise<void>((r) => noVfs.close(() => r()));
   }
+});
+
+/**
+ * A group's shared `context` is mirrored to each member agent's own `GROUP.md`
+ * on PUT, so the runtime can fold it into that agent's system prompt. The
+ * canonical copy is the sidebar_layout pref itself; this file is the derived
+ * mirror. Exercised with a real `paths` dep (the default `deps()` omits it, so
+ * the sync would no-op — see the last test).
+ */
+const groupPaths = new CloudPaths();
+
+/** Boot a server with the given deps override; returns its base URL + closer. */
+async function startServer(
+  over: Partial<ControlPlaneDeps>,
+): Promise<{ base: string; close: () => Promise<void> }> {
+  const srv = createControlPlaneServer(deps(over));
+  await new Promise<void>((r) => srv.listen(0, "127.0.0.1", () => r()));
+  const addr = srv.address();
+  return {
+    base: `http://127.0.0.1:${typeof addr === "object" && addr ? addr.port : 0}`,
+    close: () => new Promise<void>((r) => srv.close(() => r())),
+  };
+}
+
+/** The vfs key an agent's GROUP.md lands at under the cloud layout. */
+async function groupFileKey(wsId: string, agentId: string): Promise<string> {
+  const ws = await store.getWorkspace(wsId);
+  const agent = await store.getAgent(agentId);
+  if (!ws || !agent) throw new Error("expected ws + agent to exist");
+  return `${groupPaths.agentRoot(ws, agent)}/GROUP.md`;
+}
+
+async function putLayout(
+  b: string,
+  who: string,
+  wsId: string,
+  layout: SidebarLayout,
+): Promise<Response> {
+  return fetch(`${b}/v1/workspaces/${wsId}/sidebar-layout`, {
+    method: "PUT",
+    headers: auth(who),
+    body: JSON.stringify(layout),
+  });
+}
+
+test("PUT a group with context writes GROUP.md into each member agent", async () => {
+  const { base: b, close } = await startServer({ paths: groupPaths });
+  try {
+    const wsId = await wsIdOf("greg");
+    const agent = await store.createAgent({ workspaceId: wsId, name: "Ada" });
+    const put = await putLayout(b, "greg", wsId, {
+      groups: [
+        {
+          id: "g1",
+          name: "Ops",
+          collapsed: false,
+          agentIds: [agent.id],
+          context: "  reply in French  ",
+        },
+      ],
+      ungroupedOrder: [],
+    });
+    expect(put.status).toBe(200);
+    await put.json();
+    expect(await vfs.readText(await groupFileKey(wsId, agent.id))).toBe(
+      "reply in French",
+    );
+  } finally {
+    await close();
+  }
+});
+
+test("editing a group's context updates the member's GROUP.md", async () => {
+  const { base: b, close } = await startServer({ paths: groupPaths });
+  try {
+    const wsId = await wsIdOf("gwen");
+    const agent = await store.createAgent({ workspaceId: wsId, name: "Bo" });
+    const g = (context: string): SidebarLayout => ({
+      groups: [
+        {
+          id: "g1",
+          name: "Ops",
+          collapsed: false,
+          agentIds: [agent.id],
+          context,
+        },
+      ],
+      ungroupedOrder: [],
+    });
+    await (await putLayout(b, "gwen", wsId, g("first"))).json();
+    const key = await groupFileKey(wsId, agent.id);
+    expect(await vfs.readText(key)).toBe("first");
+
+    await (await putLayout(b, "gwen", wsId, g("second"))).json();
+    expect(await vfs.readText(key)).toBe("second");
+  } finally {
+    await close();
+  }
+});
+
+test("removing an agent from the group deletes its GROUP.md", async () => {
+  const { base: b, close } = await startServer({ paths: groupPaths });
+  try {
+    const wsId = await wsIdOf("gus");
+    const agent = await store.createAgent({ workspaceId: wsId, name: "Cy" });
+    await (
+      await putLayout(b, "gus", wsId, {
+        groups: [
+          {
+            id: "g1",
+            name: "Ops",
+            collapsed: false,
+            agentIds: [agent.id],
+            context: "stay concise",
+          },
+        ],
+        ungroupedOrder: [],
+      })
+    ).json();
+    const key = await groupFileKey(wsId, agent.id);
+    expect(await vfs.readText(key)).toBe("stay concise");
+
+    await (
+      await putLayout(b, "gus", wsId, {
+        groups: [
+          {
+            id: "g1",
+            name: "Ops",
+            collapsed: false,
+            agentIds: [],
+            context: "stay concise",
+          },
+        ],
+        ungroupedOrder: [agent.id],
+      })
+    ).json();
+    expect(await vfs.readText(key)).toBeNull();
+  } finally {
+    await close();
+  }
+});
+
+test("an agent in no group never gets a GROUP.md", async () => {
+  const { base: b, close } = await startServer({ paths: groupPaths });
+  try {
+    const wsId = await wsIdOf("gia");
+    const agent = await store.createAgent({ workspaceId: wsId, name: "Di" });
+    await (
+      await putLayout(b, "gia", wsId, {
+        groups: [
+          {
+            id: "g1",
+            name: "Ops",
+            collapsed: false,
+            agentIds: [],
+            context: "hello",
+          },
+        ],
+        ungroupedOrder: [agent.id],
+      })
+    ).json();
+    expect(await vfs.readText(await groupFileKey(wsId, agent.id))).toBeNull();
+  } finally {
+    await close();
+  }
+});
+
+test("the group-context mirror is a no-op (PUT still 200) without a paths dep", async () => {
+  const wsId = await wsIdOf("gil");
+  const agent = await store.createAgent({ workspaceId: wsId, name: "Ed" });
+  // `base` is the shared server built from deps() — no `paths`, so the sync
+  // degrades to a no-op while the primary preference write still succeeds.
+  const put = await putLayout(base, "gil", wsId, {
+    groups: [
+      {
+        id: "g1",
+        name: "Ops",
+        collapsed: false,
+        agentIds: [agent.id],
+        context: "hi",
+      },
+    ],
+    ungroupedOrder: [],
+  });
+  expect(put.status).toBe(200);
+  await put.json();
+  expect(await vfs.readText(await groupFileKey(wsId, agent.id))).toBeNull();
 });

--- a/packages/host/src/routes/account.ts
+++ b/packages/host/src/routes/account.ts
@@ -3,8 +3,10 @@ import { getPreference, loadPreferences, setPreference } from "@houston/domain";
 import type { Workspace as WireWorkspace } from "@houston/protocol";
 import type { UserId, Workspace } from "../domain/types";
 import type { EventHub } from "../events/hub";
+import type { WorkspacePaths } from "../paths";
 import type { WorkspaceStore } from "../ports";
 import type { Vfs } from "../vfs";
+import { syncGroupContextFiles } from "./group-context-sync";
 import { json, readJson } from "./http";
 import { parseSidebarLayout, readSidebarLayout } from "./sidebar-layout";
 
@@ -12,6 +14,8 @@ export interface AccountDeps {
   store: WorkspaceStore;
   /** Backs the per-workspace preferences doc; absent → preference routes 503. */
   vfs?: Vfs;
+  /** Where agent files live in the vfs; needed to mirror group context to GROUP.md. */
+  paths?: WorkspacePaths;
   /** Global reactivity fan-out; a sidebar-layout write emits on it. Absent → skipped. */
   events?: EventHub;
 }
@@ -116,6 +120,9 @@ export async function handleAccount(
       json(res, 400, { error: "invalid sidebar layout" });
       return true;
     }
+    const prevLayout = readSidebarLayout(
+      await getPreference(deps.vfs, wsId, "sidebar_layout"),
+    );
     await setPreference(
       deps.vfs,
       wsId,
@@ -126,6 +133,7 @@ export async function handleAccount(
       type: "SidebarLayoutChanged",
       workspaceId: wsId,
     });
+    await syncGroupContextFiles(deps, ws, prevLayout, layout);
     json(res, 200, layout);
     return true;
   }

--- a/packages/host/src/routes/group-context-sync.test.ts
+++ b/packages/host/src/routes/group-context-sync.test.ts
@@ -1,0 +1,101 @@
+import type { SidebarLayout } from "@houston/protocol";
+import { describe, expect, test } from "vitest";
+import {
+  diffGroupContext,
+  resolveGroupContextByAgent,
+} from "./group-context-sync";
+
+const layout = (groups: SidebarLayout["groups"]): SidebarLayout => ({
+  groups,
+  ungroupedOrder: [],
+});
+
+const group = (
+  id: string,
+  agentIds: string[],
+  context?: string,
+): SidebarLayout["groups"][number] => ({
+  id,
+  name: id,
+  collapsed: false,
+  agentIds,
+  ...(context !== undefined ? { context } : {}),
+});
+
+describe("resolveGroupContextByAgent", () => {
+  test("maps each member of a group with context to the trimmed context", () => {
+    const map = resolveGroupContextByAgent(
+      layout([group("g1", ["a1", "a2"], "  be terse  ")]),
+    );
+    expect([...map]).toEqual([
+      ["a1", "be terse"],
+      ["a2", "be terse"],
+    ]);
+  });
+
+  test("a blank or whitespace-only context contributes nothing", () => {
+    const map = resolveGroupContextByAgent(
+      layout([group("g1", ["a1"], "   "), group("g2", ["a2"], "")]),
+    );
+    expect(map.size).toBe(0);
+  });
+
+  test("a group without a context field contributes nothing", () => {
+    const map = resolveGroupContextByAgent(layout([group("g1", ["a1"])]));
+    expect(map.has("a1")).toBe(false);
+  });
+
+  test("an agent in two groups with context: last in array order wins", () => {
+    const map = resolveGroupContextByAgent(
+      layout([group("g1", ["a1"], "first"), group("g2", ["a1"], "second")]),
+    );
+    expect(map.get("a1")).toBe("second");
+  });
+});
+
+describe("diffGroupContext", () => {
+  test("agent added to a group with context is reported changed", () => {
+    const prev = layout([group("g1", [], "ctx")]);
+    const next = layout([group("g1", ["a1"], "ctx")]);
+    expect(diffGroupContext(prev, next)).toEqual(["a1"]);
+  });
+
+  test("editing a group's context text reports its members changed", () => {
+    const prev = layout([group("g1", ["a1", "a2"], "old")]);
+    const next = layout([group("g1", ["a1", "a2"], "new")]);
+    expect(diffGroupContext(prev, next).sort()).toEqual(["a1", "a2"]);
+  });
+
+  test("clearing a group's context reports its former members changed", () => {
+    const prev = layout([group("g1", ["a1"], "ctx")]);
+    const next = layout([group("g1", ["a1"], "")]);
+    expect(diffGroupContext(prev, next)).toEqual(["a1"]);
+  });
+
+  test("deleting the group entirely removes its members' context", () => {
+    const prev = layout([group("g1", ["a1"], "ctx")]);
+    const next = layout([]);
+    expect(diffGroupContext(prev, next)).toEqual(["a1"]);
+  });
+
+  test("removing an agent from the group reports it changed", () => {
+    const prev = layout([group("g1", ["a1", "a2"], "ctx")]);
+    const next = layout([group("g1", ["a1"], "ctx")]);
+    expect(diffGroupContext(prev, next)).toEqual(["a2"]);
+  });
+
+  test("no context change (only order/name churn) reports nothing", () => {
+    const prev = layout([group("g1", ["a1", "a2"], "ctx")]);
+    const next = layout([group("g1", ["a2", "a1"], "ctx")]);
+    expect(diffGroupContext(prev, next)).toEqual([]);
+  });
+
+  test("an unchanged member keeps its context and is not reported", () => {
+    const prev = layout([group("g1", ["a1", "a2"], "ctx")]);
+    const next = layout([
+      group("g1", ["a1", "a2"], "ctx"),
+      group("g2", ["a3"], "other"),
+    ]);
+    expect(diffGroupContext(prev, next)).toEqual(["a3"]);
+  });
+});

--- a/packages/host/src/routes/group-context-sync.ts
+++ b/packages/host/src/routes/group-context-sync.ts
@@ -1,0 +1,91 @@
+import type { SidebarLayout } from "@houston/protocol";
+import type { Workspace } from "../domain/types";
+import type { EventHub } from "../events/hub";
+import type { WorkspacePaths } from "../paths";
+import type { WorkspaceStore } from "../ports";
+import type { Vfs } from "../vfs";
+
+/** The per-agent mirror file each group member's shared context is written to. */
+const GROUP_CONTEXT_FILE = "GROUP.md";
+
+/**
+ * Every agent that inherits a group's shared context, mapped to that context.
+ * A group whose `context` is blank (post-`trim`) or absent contributes nothing,
+ * so an agent missing from the map simply has no group context — never a `""`
+ * placeholder. The sidebar model keeps an agent in at most one group, but this
+ * pure function does not lean on that: when an id appears in two groups the
+ * last one in array order wins.
+ */
+export function resolveGroupContextByAgent(
+  layout: SidebarLayout,
+): Map<string, string> {
+  const byAgent = new Map<string, string>();
+  for (const group of layout.groups) {
+    const context = group.context?.trim();
+    if (!context) continue;
+    for (const agentId of group.agentIds) byAgent.set(agentId, context);
+  }
+  return byAgent;
+}
+
+/**
+ * Agent ids whose resolved group context differs between two layouts — added,
+ * edited, or removed (a present↔absent flip counts as a change). These are
+ * exactly the agents whose `GROUP.md` mirror must be rewritten or deleted.
+ */
+export function diffGroupContext(
+  prev: SidebarLayout,
+  next: SidebarLayout,
+): string[] {
+  const before = resolveGroupContextByAgent(prev);
+  const after = resolveGroupContextByAgent(next);
+  const changed: string[] = [];
+  for (const id of new Set([...before.keys(), ...after.keys()])) {
+    if (before.get(id) !== after.get(id)) changed.push(id);
+  }
+  return changed;
+}
+
+/** The dependency slice `syncGroupContextFiles` needs (a subset of AccountDeps). */
+interface GroupContextSyncDeps {
+  store: WorkspaceStore;
+  vfs?: Vfs;
+  paths?: WorkspacePaths;
+  events?: EventHub;
+}
+
+/**
+ * Mirror each affected agent's group context to its own `GROUP.md` after a
+ * sidebar-layout write, so the runtime can fold it into the system prompt. This
+ * is a best-effort DERIVED copy: the canonical data is the `sidebar_layout`
+ * preference that already persisted, so a missing `vfs`/`paths` dep is a clean
+ * no-op that never fails or rolls back the primary write. A stale id that no
+ * longer resolves to a real agent is skipped — nothing to write.
+ */
+export async function syncGroupContextFiles(
+  deps: GroupContextSyncDeps,
+  ws: Workspace,
+  prev: SidebarLayout,
+  next: SidebarLayout,
+): Promise<void> {
+  const { vfs, paths } = deps;
+  if (!vfs || !paths) return;
+  const changed = diffGroupContext(prev, next);
+  if (changed.length === 0) return;
+  const resolved = resolveGroupContextByAgent(next);
+  const agents = new Map(
+    (await deps.store.listAgents(ws.id)).map((a) => [a.id, a]),
+  );
+  for (const agentId of changed) {
+    const agent = agents.get(agentId);
+    if (!agent) continue;
+    const key = `${paths.agentRoot(ws, agent)}/${GROUP_CONTEXT_FILE}`;
+    const context = resolved.get(agentId);
+    if (context === undefined) await vfs.deleteKey(key);
+    else await vfs.writeText(key, context);
+    deps.events?.emit(ws.ownerUserId, {
+      type: "ContextChanged",
+      agentPath: agent.id,
+    });
+  }
+}

--- a/packages/host/src/routes/sidebar-layout.ts
+++ b/packages/host/src/routes/sidebar-layout.ts
@@ -27,7 +27,8 @@ export function parseSidebarLayout(body: unknown): SidebarLayout | null {
       typeof gr.id !== "string" ||
       typeof gr.name !== "string" ||
       typeof gr.collapsed !== "boolean" ||
-      !isStringArray(gr.agentIds)
+      !isStringArray(gr.agentIds) ||
+      (gr.context !== undefined && typeof gr.context !== "string")
     )
       return null;
     groups.push({
@@ -35,6 +36,7 @@ export function parseSidebarLayout(body: unknown): SidebarLayout | null {
       name: gr.name,
       collapsed: gr.collapsed,
       agentIds: gr.agentIds,
+      ...(gr.context !== undefined ? { context: gr.context } : {}),
     });
   }
   if (!isStringArray(b.ungroupedOrder)) return null;

--- a/packages/host/src/watch/classify.test.ts
+++ b/packages/host/src/watch/classify.test.ts
@@ -50,6 +50,7 @@ const cases: [string, string | null, string | null][] = [
   ["Work/Sales/AGENTS.md", "ContextChanged", "Work/Sales"],
   ["Work/Sales/WORKSPACE.md", "ContextChanged", "Work/Sales"],
   ["Work/Sales/USER.md", "ContextChanged", "Work/Sales"],
+  ["Work/Sales/GROUP.md", "ContextChanged", "Work/Sales"],
   ["Work/Sales/report.xlsx", "FilesChanged", "Work/Sales"],
   ["Work/Sales/subdir/notes.md", "FilesChanged", "Work/Sales"],
   // Not classifiable:

--- a/packages/protocol/src/domain/workspace.ts
+++ b/packages/protocol/src/domain/workspace.ts
@@ -79,6 +79,10 @@ export interface SidebarGroup {
   collapsed: boolean;
   /** Member agent ids, in drag order. */
   agentIds: string[];
+  /** Shared context injected into every member agent's system prompt (a
+   *  group-scoped `WORKSPACE.md`), mirrored to each member's `GROUP.md`.
+   *  Absent/empty = no group context. */
+  context?: string;
 }
 
 /**

--- a/packages/runtime/src/backends/claude/system-prompt.test.ts
+++ b/packages/runtime/src/backends/claude/system-prompt.test.ts
@@ -38,3 +38,18 @@ test("a non-workspace cwd gets only the base prompt (no context section)", () =>
   const prompt = buildSystemPrompt(dir, "You are Houston.");
   expect(prompt).toBe("You are Houston.");
 });
+
+test("group context is appended after the workspace/user section", () => {
+  const dir = freshWorkspace();
+  writeFileSync(join(dir, "WORKSPACE.md"), "Acme Corp.");
+  writeFileSync(join(dir, "GROUP.md"), "Q3 launch squad.");
+
+  const prompt = buildSystemPrompt(dir, "You are Houston.");
+  expect(prompt).toContain("# Workspace Context");
+  expect(prompt).toContain("# Group Context");
+  expect(prompt).toContain("Q3 launch squad.");
+  // Ordering: base prompt → workspace/user context → group context.
+  expect(prompt.indexOf("# Group Context")).toBeGreaterThan(
+    prompt.indexOf("# Workspace Context"),
+  );
+});

--- a/packages/runtime/src/backends/claude/system-prompt.ts
+++ b/packages/runtime/src/backends/claude/system-prompt.ts
@@ -3,6 +3,7 @@ import { join } from "node:path";
 import type { TurnMode } from "@houston/protocol";
 import { withModeOverlay } from "../../session/mode-overlays";
 import {
+  buildGroupContextSection,
   buildWorkspaceContextSection,
   type ProvidedContext,
 } from "../../session/workspace-context";
@@ -37,10 +38,15 @@ export function buildSystemPrompt(
   // `provided` is the gateway's Supabase copy (cloud), else the cwd files (local).
   const section = buildWorkspaceContextSection(cwd, provided);
   const withContext = section ? `${base}\n\n${section}` : base;
-  // Mode overlay LAST — after Houston's prompt, the context file, AND the context
-  // section — so the plan (read-only) or auto (Autopilot) mandate is the final
-  // word the model reads. Execute passes through unchanged.
-  return withModeOverlay(withContext, mode);
+  // Group context section AFTER workspace/user (HOU-711), local-only: `GROUP.md`
+  // the host mirrors into each grouped agent's cwd from its sidebar group's
+  // shared context. Null for ungrouped agents.
+  const group = buildGroupContextSection(cwd);
+  const withGroup = group ? `${withContext}\n\n${group}` : withContext;
+  // Mode overlay LAST — after Houston's prompt, the context file, AND both
+  // context sections — so the plan (read-only) or auto (Autopilot) mandate is the
+  // final word the model reads. Execute passes through unchanged.
+  return withModeOverlay(withGroup, mode);
 }
 
 /** The first workspace-root context file's contents, or null when none exists. */

--- a/packages/runtime/src/session/resource-loader.ts
+++ b/packages/runtime/src/session/resource-loader.ts
@@ -6,6 +6,7 @@ import { config } from "../config";
 import { makeCompactionGuard } from "./compaction-guard";
 import { withModeOverlay } from "./mode-overlays";
 import {
+  buildGroupContextSection,
   buildWorkspaceContextSection,
   type ProvidedContext,
 } from "./workspace-context";
@@ -80,17 +81,21 @@ export function makeAgentLoader(
   mode?: TurnMode,
   provided?: ProvidedContext,
 ) {
-  // Two overlays compose onto Houston's base prompt, in the SAME order as the
-  // claude backend (system-prompt.ts): first the workspace + user CONTEXT section
+  // Overlays compose onto Houston's base prompt, in the SAME order as the claude
+  // backend (system-prompt.ts): first the workspace + user CONTEXT section
   // (HOU-711 — `provided` is the gateway's Supabase copy in cloud, else the two
-  // files at cwd), then the turn MODE overlay LAST so the plan/auto mandate is the
-  // final word. CLAUDE.md/AGENTS.md still load via agentsFilesOverride below.
+  // files at cwd), then the GROUP context section (local-only `GROUP.md` the host
+  // mirrors into each grouped agent's cwd; null when ungrouped), then the turn
+  // MODE overlay LAST so the plan/auto mandate is the final word. CLAUDE.md/
+  // AGENTS.md still load via agentsFilesOverride below.
   const section = buildWorkspaceContextSection(cwd, provided);
   const base = config.systemPrompt || SYSTEM_PROMPT;
   const withContext = section ? `${base}\n\n${section}` : base;
+  const group = buildGroupContextSection(cwd);
+  const withGroup = group ? `${withContext}\n\n${group}` : withContext;
   return buildAgentLoader({
     cwd,
     skillsDir: config.skillsDirOverride || join(cwd, ".agents", "skills"),
-    systemPrompt: withModeOverlay(withContext, mode),
+    systemPrompt: withModeOverlay(withGroup, mode),
   });
 }

--- a/packages/runtime/src/session/workspace-context.test.ts
+++ b/packages/runtime/src/session/workspace-context.test.ts
@@ -3,7 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
 import {
+  buildGroupContextSection,
   buildWorkspaceContextSection,
+  GROUP_MD,
   USER_MD,
   WORKSPACE_MD,
 } from "./workspace-context";
@@ -105,4 +107,38 @@ test("provided (cloud) needs no .houston dir and renders a one-sided section", (
   expect(out).not.toBeNull();
   expect(out).toContain("Acme only");
   expect(out).toContain("(none provided.)"); // the empty user slot's marker
+});
+
+// ── group context: GROUP.md the host mirrors into each grouped agent's cwd ────
+
+test("filled GROUP.md renders the group section with heading, content, and path", () => {
+  const dir = freshWorkspace();
+  writeFileSync(join(dir, GROUP_MD), "Q3 launch squad. Ship the new pricing.");
+
+  const out = buildGroupContextSection(dir);
+  expect(out).not.toBeNull();
+  expect(out).toContain("# Group Context");
+  expect(out).toContain("Q3 launch squad. Ship the new pricing.");
+  // The absolute path tells the agent where the shared context lives.
+  expect(out).toContain(join(dir, GROUP_MD));
+});
+
+test("missing GROUP.md injects nothing (no empty-marker stub)", () => {
+  const dir = freshWorkspace();
+  expect(buildGroupContextSection(dir)).toBeNull();
+});
+
+test("whitespace-only GROUP.md injects nothing", () => {
+  const dir = freshWorkspace();
+  writeFileSync(join(dir, GROUP_MD), "   \n  ");
+  expect(buildGroupContextSection(dir)).toBeNull();
+});
+
+test("group context needs no .houston dir — the file's presence is enough", () => {
+  const dir = freshWorkspace(false);
+  writeFileSync(join(dir, GROUP_MD), "Shared plan for the group.");
+
+  const out = buildGroupContextSection(dir);
+  expect(out).not.toBeNull();
+  expect(out).toContain("Shared plan for the group.");
 });

--- a/packages/runtime/src/session/workspace-context.ts
+++ b/packages/runtime/src/session/workspace-context.ts
@@ -14,6 +14,7 @@ import { join } from "node:path";
  */
 export const WORKSPACE_MD = "WORKSPACE.md";
 export const USER_MD = "USER.md";
+export const GROUP_MD = "GROUP.md";
 
 /** Gateway-provided context (cloud): the two blobs read from Supabase. */
 export interface ProvidedContext {
@@ -23,6 +24,7 @@ export interface ProvidedContext {
 
 const WORKSPACE_HEADING = "# Workspace Context";
 const USER_HEADING = "# User Context";
+const GROUP_HEADING = "# Group Context";
 
 // File-mode empty markers (local): the agent is told to write the files.
 const FILE_WORKSPACE_EMPTY =
@@ -113,4 +115,33 @@ export function buildWorkspaceContextSection(
       "exception to your working-directory rule: you are allowed to read and " +
       "write them. Edits take effect on the next chat.",
   );
+}
+
+/**
+ * Build the "# Group Context" section appended to an agent's system prompt from
+ * `GROUP.md` at `cwd`, or null when there is nothing to inject.
+ *
+ * Unlike workspace/user context there is NO empty-marker stub and no `.houston`
+ * gate: group membership is optional per-agent, and the host only writes
+ * `GROUP.md` into an agent that actually belongs to a sidebar group. So the
+ * file's mere presence with non-blank content is the whole signal — an ungrouped
+ * agent (no file) or a group whose shared context is blank injects nothing.
+ */
+export function buildGroupContextSection(cwd: string): string | null {
+  const groupPath = join(cwd, GROUP_MD);
+  const content = readOrEmpty(groupPath).trim();
+  if (!content) return null;
+  return [
+    GROUP_HEADING,
+    "",
+    content,
+    "",
+    "The section above is context shared by every agent in this agent's " +
+      `sidebar group, loaded from the file at \`${groupPath}\`. Like ` +
+      "WORKSPACE.md/USER.md it is an exception to your working-directory rule: " +
+      "you may read and write it directly. But a person edits this group's " +
+      "shared context from the sidebar, and doing so overwrites whatever you " +
+      "wrote here, so treat it as theirs to own. Edits take effect on the next " +
+      "chat.",
+  ].join("\n");
 }

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -287,6 +287,10 @@ export interface SidebarGroup {
   collapsed: boolean;
   /** Member agent ids, in drag order. */
   agentIds: string[];
+  /** Shared context injected into every member agent's system prompt (a
+   *  group-scoped `WORKSPACE.md`), mirrored to each member's `GROUP.md`.
+   *  Absent/empty = no group context. */
+  context?: string;
 }
 
 /**

--- a/ui/layout/src/sidebar-classes.ts
+++ b/ui/layout/src/sidebar-classes.ts
@@ -34,7 +34,7 @@ export const sidebarGroupClasses = {
     "group/gh relative flex w-full min-w-0 items-center gap-1 rounded-md px-1.5 py-1 transition-colors duration-100 hover:bg-accent/40",
   caret:
     "flex size-4 shrink-0 items-center justify-center rounded text-muted-foreground/50 transition-colors duration-100 hover:text-muted-foreground focus-visible:outline-none motion-reduce:transition-none cursor-grab active:cursor-grabbing",
-  name: "min-w-0 flex-1 truncate text-left text-[12px] font-medium text-muted-foreground cursor-grab active:cursor-grabbing",
+  name: "min-w-0 flex-1 truncate text-left text-[13px] font-medium text-muted-foreground cursor-grab active:cursor-grabbing",
   count:
     "shrink-0 text-[10px] font-medium tabular-nums text-muted-foreground/40 transition-opacity duration-100 group-hover/gh:opacity-0",
   menuButton:

--- a/ui/layout/src/sidebar-group-header.tsx
+++ b/ui/layout/src/sidebar-group-header.tsx
@@ -24,6 +24,7 @@ export interface SidebarGroupHeaderProps {
   startRenaming?: boolean;
   onRenameStarted?: () => void;
   onToggleCollapsed?: (groupId: string) => void;
+  onEditContext?: (groupId: string) => void;
   onRenameGroup?: (groupId: string, newName: string) => void;
   onDeleteGroup?: (groupId: string) => void;
 }
@@ -44,6 +45,7 @@ export function SidebarGroupHeader({
   startRenaming,
   onRenameStarted,
   onToggleCollapsed,
+  onEditContext,
   onRenameGroup,
   onDeleteGroup,
 }: SidebarGroupHeaderProps) {
@@ -122,7 +124,7 @@ export function SidebarGroupHeader({
         </button>
       )}
       {!renaming && <span className={sidebarGroupClasses.count}>{count}</span>}
-      {!renaming && (onRenameGroup || onDeleteGroup) && (
+      {!renaming && (onEditContext || onRenameGroup || onDeleteGroup) && (
         <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
           <DropdownMenuTrigger asChild>
             <button
@@ -134,6 +136,11 @@ export function SidebarGroupHeader({
             </button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end" side="bottom">
+            {onEditContext && (
+              <DropdownMenuItem onSelect={() => onEditContext(group.id)}>
+                {labels.editGroupContext}
+              </DropdownMenuItem>
+            )}
             {onRenameGroup && (
               <DropdownMenuItem
                 onSelect={() => {

--- a/ui/layout/src/sidebar-group-section.tsx
+++ b/ui/layout/src/sidebar-group-section.tsx
@@ -48,6 +48,7 @@ export interface SidebarGroupSectionProps {
   renaming?: boolean;
   onRenameHandled?: () => void;
   onToggleCollapsed?: (groupId: string) => void;
+  onEditGroupContext?: (groupId: string) => void;
   onRenameGroup?: (groupId: string, newName: string) => void;
   onDeleteGroup?: (groupId: string) => void;
 }
@@ -69,6 +70,7 @@ export function SidebarGroupSection({
   renaming,
   onRenameHandled,
   onToggleCollapsed,
+  onEditGroupContext,
   onRenameGroup,
   onDeleteGroup,
 }: SidebarGroupSectionProps) {
@@ -125,6 +127,7 @@ export function SidebarGroupSection({
             startRenaming={renaming}
             onRenameStarted={onRenameHandled}
             onToggleCollapsed={onToggleCollapsed}
+            onEditContext={onEditGroupContext}
             onRenameGroup={onRenameGroup}
             onDeleteGroup={onDeleteGroup}
           />

--- a/ui/layout/src/sidebar-grouped-list.tsx
+++ b/ui/layout/src/sidebar-grouped-list.tsx
@@ -50,6 +50,7 @@ export interface SidebarGroupedListProps {
   groups: SidebarGroupView[];
   rowCtx: SidebarBaseRowContext;
   onToggleGroupCollapsed?: (groupId: string) => void;
+  onEditGroupContext?: (groupId: string) => void;
   onRenameGroup?: (groupId: string, newName: string) => void;
   onDeleteGroup?: (groupId: string) => void;
   renamingGroupId?: string | null;
@@ -109,6 +110,7 @@ export function SidebarGroupedList({
   groups,
   rowCtx,
   onToggleGroupCollapsed,
+  onEditGroupContext,
   onRenameGroup,
   onDeleteGroup,
   renamingGroupId,
@@ -294,6 +296,7 @@ export function SidebarGroupedList({
             renaming={!!section.groupId && section.groupId === renamingGroupId}
             onRenameHandled={onRenamingGroupIdHandled}
             onToggleCollapsed={onToggleGroupCollapsed}
+            onEditGroupContext={onEditGroupContext}
             onRenameGroup={onRenameGroup}
             onDeleteGroup={onDeleteGroup}
           />

--- a/ui/layout/src/sidebar.tsx
+++ b/ui/layout/src/sidebar.tsx
@@ -70,6 +70,7 @@ export interface SidebarProps {
    */
   groups?: SidebarGroupView[];
   onToggleGroupCollapsed?: (groupId: string) => void;
+  onEditGroupContext?: (groupId: string) => void;
   onRenameGroup?: (groupId: string, newName: string) => void;
   onDeleteGroup?: (groupId: string) => void;
   /** A group id to open directly in inline-rename (e.g. a just-created group). */
@@ -98,6 +99,8 @@ export interface SidebarLabels extends SidebarItemRowLabels {
   createGroup?: string;
   renameGroup?: string;
   deleteGroup?: string;
+  /** Menu item that opens the group's shared-context editor. */
+  editGroupContext?: string;
   /** aria label for the group "..." menu trigger. */
   groupMenu?: string;
   newGroupPlaceholder?: string;
@@ -116,6 +119,7 @@ const DEFAULT_LABELS: Required<SidebarLabels> = {
   createGroup: "New group",
   renameGroup: "Rename group",
   deleteGroup: "Delete group",
+  editGroupContext: "Edit shared context",
   groupMenu: "Group options",
   newGroupPlaceholder: "Group name",
   emptyGroupHint: "Drag agents here",
@@ -138,6 +142,7 @@ export function AppSidebar({
   sectionAction,
   groups,
   onToggleGroupCollapsed,
+  onEditGroupContext,
   onRenameGroup,
   onDeleteGroup,
   renamingGroupId,
@@ -310,6 +315,7 @@ export function AppSidebar({
                 items={items}
                 groups={groups}
                 onToggleGroupCollapsed={onToggleGroupCollapsed}
+                onEditGroupContext={onEditGroupContext}
                 onRenameGroup={onRenameGroup}
                 onDeleteGroup={onDeleteGroup}
                 renamingGroupId={renamingGroupId}


### PR DESCRIPTION
## Summary
- Sidebar groups can now hold a shared `context` note (a group-scoped `WORKSPACE.md`), injected into every member agent's system prompt.
  - Edited from the group header's "..." menu → "Edit shared context".
  - The host mirrors it to a `GROUP.md` file in each member agent's own directory on every sidebar-layout write (`packages/host/src/routes/group-context-sync.ts`), best-effort, never blocking the primary layout save.
  - The runtime injects it as a "# Group Context" section after workspace/user context and before the mode overlay — present only for grouped agents, no empty stub.
  - Local/self-host only for now; cloud gateway wiring is an explicit follow-up in the closed `cloud` repo.
- "New group" now uses a people icon (`Users`) instead of a folder (`FolderPlus`), reading as "grouping people" rather than a folder.
- Group name in the sidebar bumped from 12px to 13px, matching sibling agent-item names in the same list.

## Test plan
- [x] `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test` — 682 host + 578 runtime tests pass
- [x] `pnpm typecheck` — all 22 workspace packages clean
- [x] `pnpm check:boundaries` — clean
- [x] `cd app && pnpm check-locales` — en/es/pt in sync
- [x] `pnpm check` (biome) — clean across 1787 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)