### PR TITLE
fix(sidebar): move New Agent into the header, next to New group

### DIFF
--- a/ui/layout/src/sidebar-classes.ts
+++ b/ui/layout/src/sidebar-classes.ts
@@ -1,11 +1,5 @@
 export const sidebarClasses = {
   itemsList: "w-0 min-w-full space-y-0.5 pb-2",
-  addButton:
-    "group flex w-full min-w-0 items-center rounded-lg text-accent-foreground transition-colors duration-100 hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring",
-  addButtonInner:
-    "flex min-w-0 flex-1 items-center gap-2 px-3 py-1.5 text-left text-[13px]",
-  addButtonIcon: "size-4 shrink-0 text-muted-foreground",
-  addButtonLabel: "min-w-0 flex-1 truncate",
 } as const;
 
 export const sidebarItemRowClasses = {

--- a/ui/layout/src/sidebar-flat-list.tsx
+++ b/ui/layout/src/sidebar-flat-list.tsx
@@ -93,19 +93,6 @@ export function SidebarFlatList({
           labels={l}
         />
       ))}
-      {onAdd && (
-        <button
-          aria-label={l.addItem}
-          onClick={onAdd}
-          className={sidebarClasses.addButton}
-          {...(addItemDataAttrs ?? {})}
-        >
-          <span className={sidebarClasses.addButtonInner}>
-            <Plus className={sidebarClasses.addButtonIcon} />
-            <span className={sidebarClasses.addButtonLabel}>{l.addItem}</span>
-          </span>
-        </button>
-      )}
     </div>
   );
 }

--- a/ui/layout/src/sidebar-grouped-list.tsx
+++ b/ui/layout/src/sidebar-grouped-list.tsx
@@ -17,7 +17,6 @@ import {
 import { restrictToVerticalAxis } from "@dnd-kit/modifiers";
 import { arrayMove, sortableKeyboardCoordinates } from "@dnd-kit/sortable";
 import { cn } from "@houston-ai/core";
-import { Plus } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { SidebarItem } from "./sidebar";
 import { sidebarClasses } from "./sidebar-classes";
@@ -60,8 +59,6 @@ export interface SidebarGroupedListProps {
     dest: { groupId: string | null; beforeItemId: string | null },
   ) => void;
   onMoveGroup?: (groupId: string, beforeGroupId: string | null) => void;
-  onAdd?: () => void;
-  addItemDataAttrs?: Record<string, string>;
 }
 
 /** Resolve any over-target id to the container (group id, or null default) it
@@ -117,8 +114,6 @@ export function SidebarGroupedList({
   onRenamingGroupIdHandled,
   onMoveItem,
   onMoveGroup,
-  onAdd,
-  addItemDataAttrs,
 }: SidebarGroupedListProps) {
   const [working, setWorking] = useState<WorkingSection[] | null>(null);
   const [activeItemId, setActiveItemId] = useState<string | null>(null);
@@ -301,22 +296,6 @@ export function SidebarGroupedList({
             onDeleteGroup={onDeleteGroup}
           />
         ))}
-        {onAdd && (
-          <button
-            type="button"
-            aria-label={rowCtx.labels.addItem}
-            onClick={onAdd}
-            className={sidebarClasses.addButton}
-            {...(addItemDataAttrs ?? {})}
-          >
-            <span className={sidebarClasses.addButtonInner}>
-              <Plus className={sidebarClasses.addButtonIcon} />
-              <span className={sidebarClasses.addButtonLabel}>
-                {rowCtx.labels.addItem}
-              </span>
-            </span>
-          </button>
-        )}
       </div>
 
       <DragOverlay dropAnimation={{ duration: 180, easing: "ease" }}>

--- a/ui/layout/src/sidebar.tsx
+++ b/ui/layout/src/sidebar.tsx
@@ -5,7 +5,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@houston-ai/core";
-import { PanelLeftClose } from "lucide-react";
+import { PanelLeftClose, Plus } from "lucide-react";
 import {
   type KeyboardEvent,
   type MouseEvent,
@@ -303,6 +303,22 @@ export function AppSidebar({
                 {sectionLabel}
               </div>
               {sectionAction}
+              {onAdd && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      aria-label={l.addItem}
+                      onClick={onAdd}
+                      className="flex size-6 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      {...(addItemDataAttrs ?? {})}
+                    >
+                      <Plus className="size-4" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom">{l.addItem}</TooltipContent>
+                </Tooltip>
+              )}
             </div>
           )}
 
@@ -322,8 +338,6 @@ export function AppSidebar({
                 onRenamingGroupIdHandled={onRenamingGroupIdHandled}
                 onMoveItem={onMoveItem}
                 onMoveGroup={onMoveGroup}
-                onAdd={onAdd}
-                addItemDataAttrs={addItemDataAttrs}
                 rowCtx={baseRowCtx}
               />
             ) : (

--- a/ui/layout/tests/sidebar-item-row-layout.test.ts
+++ b/ui/layout/tests/sidebar-item-row-layout.test.ts
@@ -27,16 +27,6 @@ describe("sidebar item row layout", () => {
     ok(includes(sidebarClasses.itemsList, "min-w-full"));
   });
 
-  it("keeps add action shaped like an item row", () => {
-    ok(includes(sidebarClasses.addButton, "w-full"));
-    ok(includes(sidebarClasses.addButton, "rounded-lg"));
-    ok(includes(sidebarClasses.addButton, "text-accent-foreground"));
-    ok(includes(sidebarClasses.addButton, "hover:bg-accent/50"));
-    ok(includes(sidebarClasses.addButtonInner, "px-3"));
-    ok(includes(sidebarClasses.addButtonInner, "py-1.5"));
-    ok(includes(sidebarClasses.addButtonLabel, "truncate"));
-  });
-
   it("keeps menu trigger in its own visible slot", () => {
     ok(includes(sidebarItemRowClasses.menuButton, "size-7"));
     ok(includes(sidebarItemRowClasses.menuButton, "shrink-0"));


### PR DESCRIPTION
## Summary
- The trailing "+ New Agent" row lived below the whole grouped agent list — easy to miss once a workspace has a few groups, and inconsistent with "New group" which lives as an icon button in the header.
- "New Agent" now renders as an icon button in the "Your AI Agents" header row, right next to "New group", always visible regardless of scroll or group count.
- Removed the now-dead `sidebarClasses.addButton*` styles and their test coverage (only reachable code path was the removed row).

## Test plan
- [x] Existing sidebar e2e suite (`sidebar-dnd.spec.ts`, `sidebar.spec.ts`, `agent-sidebar-menu.spec.ts`) — 7/7 pass, unaffected since they query by accessible role/name.
- [x] Manual Playwright screenshot verification: header shows both "New group" and "New agent" icon buttons side by side; no trailing row; click still opens the create-agent flow.
- [x] `pnpm typecheck` (22 packages), `pnpm check` (biome), `pnpm check:boundaries` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)