### PR TITLE
ci(website): pin to Node 22 instead of deprecated Node 20

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: '20'
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: website/package-lock.json
 


### PR DESCRIPTION
## Summary
- `website-deploy.yml` pinned Node 20, which GitHub Actions now force-upgrades to 24 mid-run (deprecation warning surfaced in the last deploy run). Bumped to Node 22, matching `ci.yml`'s existing standard.

## Test plan
- [x] No behavior change to the build itself (Eleventy + wrangler-action are Node-version-agnostic here); will confirm green on next `website/**` merge, same as this PR's own CI run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)