### PR TITLE
feat(chat): Planner default, always-skippable onboarding, suggest_reusable, interaction-card redesign

### DIFF
--- a/app/src-tauri/src/houston_prompt/skills_memory.rs
+++ b/app/src-tauri/src/houston_prompt/skills_memory.rs
@@ -12,6 +12,8 @@ Before starting complex work, check whether a relevant Skill already exists.
 
 Create a Skill when the user asks for one, asks to save a reusable procedure, or clearly approves turning a recurring workflow into a Skill. Do not create Skills just because a task had many steps.
 
+When you finish a task that is clearly worth saving as a reusable Skill or scheduled Routine, genuinely reusable multi-step work and not a simple or one-off request, call the `suggest_reusable` tool right before your final message instead of asking about it in plain text or through `ask_user`. Houston shows the user a dismissible card offering to save it. Call it at most once per turn.
+
 Use this shape:
 
 ```

--- a/app/src/components/onboarding/missions/connect-email.tsx
+++ b/app/src/components/onboarding/missions/connect-email.tsx
@@ -1,4 +1,4 @@
-import { AsyncButton, Button, Input } from "@houston-ai/core";
+import { AsyncButton, Button, ConfirmDialog, Input } from "@houston-ai/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
@@ -49,6 +49,7 @@ export function ConnectEmailMission({
   // its OAuth poll resolves, and we must refetch to see the new connection
   // even if the status cache still lags on `ready`.
   const [attempted, setAttempted] = useState(false);
+  const [skipConfirmOpen, setSkipConfirmOpen] = useState(false);
 
   // The gateway is "ready" only once it has the Houston session (App's session
   // sync pushes it). Gate the connection poll on it so we never fire a failing
@@ -100,16 +101,12 @@ export function ConnectEmailMission({
     return connect(chosen.toolkit);
   }, [chosen, connect]);
 
-  // Dead-end escape: the route can exist (capabilities) while the gateway is
-  // unready or the OAuth hop failed; without a skip the first-run has no
-  // Continue and the user is stranded (they can always connect later from the
-  // Integrations tab).
-  const showSkip = shouldOfferConnectSkip({
-    statusKnown: !status.isPending,
-    ready,
-    attempted,
-    connecting,
-  });
+  // Always offered (bar an in-flight connect): the route can exist
+  // (capabilities) while the gateway is unready or the OAuth hop failed, and a
+  // first-run with no Continue strands the user. A confirm dialog is the
+  // actual friction — see `skipConfirmOpen` below — so hiding the affordance
+  // itself would just relocate the dead end.
+  const showSkip = shouldOfferConnectSkip({ connecting });
 
   return (
     <SetupCard
@@ -166,13 +163,23 @@ export function ConnectEmailMission({
               variant="ghost"
               size="sm"
               className="shrink-0"
-              onClick={onSkip}
+              onClick={() => setSkipConfirmOpen(true)}
             >
               {t("tutorial.missions.connectEmail.skip")}
             </Button>
           </div>
         )}
       </div>
+      <ConfirmDialog
+        open={skipConfirmOpen}
+        onOpenChange={setSkipConfirmOpen}
+        title={t("tutorial.missions.connectEmail.skipConfirmTitle")}
+        description={t("tutorial.missions.connectEmail.skipConfirmBody")}
+        confirmLabel={t("tutorial.missions.connectEmail.skipConfirmAction")}
+        cancelLabel={t("tutorial.missions.connectEmail.skipConfirmCancel")}
+        variant="default"
+        onConfirm={onSkip}
+      />
     </SetupCard>
   );
 }

--- a/app/src/components/onboarding/missions/onboarding-flow.ts
+++ b/app/src/components/onboarding/missions/onboarding-flow.ts
@@ -65,25 +65,15 @@ export function stepAfterAgentCreated(
 
 /**
  * Whether the connect-email screen should offer its "skip for now" escape
- * hatch. Capabilities only say the route EXISTS; the gateway can still be
- * unready (the Supabase session push hasn't landed, or errored), and a connect
- * attempt can end without the toolkit landing (abandoned OAuth, provider-side
- * failure). Both are dead ends with no Continue, so we offer the way out —
- * but never while a connect flow is still in flight.
+ * hatch. Always available (a confirm dialog is the actual friction, see
+ * `ConnectEmailMission`) except while a connect flow is in flight — the OAuth
+ * hop + poll owns the screen until it resolves.
  */
 export function shouldOfferConnectSkip(opts: {
-  /** The provider-status query has resolved (data or error). */
-  statusKnown: boolean;
-  /** The integrations gateway reports the provider usable now. */
-  ready: boolean;
-  /** The user kicked off at least one connect attempt. */
-  attempted: boolean;
   /** A connect flow (OAuth hop + poll) is currently in flight. */
   connecting: boolean;
 }): boolean {
-  if (opts.connecting) return false;
-  if (opts.statusKnown && !opts.ready) return true;
-  return opts.attempted;
+  return !opts.connecting;
 }
 
 /**

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -24,9 +24,13 @@ import {
   ChatInteractionCard,
   ChatPlanReadyCard,
   type ChatPlanReadyLabels,
+  ChatSuggestReusableCard,
+  type ChatSuggestReusableLabels,
   decodeAttachmentMessage,
+  decodeInteractionAnswersMessage,
   UserAttachmentMessage,
   type UserAttachmentMessageLabels,
+  UserInteractionAnswersMessage,
 } from "@houston-ai/chat";
 import { Button } from "@houston-ai/core";
 import { useQueryClient } from "@tanstack/react-query";
@@ -74,7 +78,7 @@ import { resolveDictationLangHint } from "../lib/dictation/types";
 import { useDictation } from "../lib/dictation/use-dictation";
 import { genericErrorDescription } from "../lib/error-toast";
 import { skillDisplayTitle } from "../lib/humanize-skill-name";
-import { composeInteractionReply } from "../lib/interaction-reply";
+import { encodeInteractionAnswersMessage } from "../lib/interaction-reply";
 import {
   modelSelectorDecision,
   resolvePersonalModelPin,
@@ -103,6 +107,10 @@ import {
   encodeSkillMessage,
 } from "../lib/skill-message";
 import {
+  resolveSuggestReusableOverride,
+  type SuggestReusableStep,
+} from "../lib/suggest-reusable";
+import {
   tauriActivity,
   tauriAttachments,
   tauriChat,
@@ -110,7 +118,11 @@ import {
   tauriProvider,
   withAttachmentPaths,
 } from "../lib/tauri";
-import { normalizeTurnMode, type TurnMode } from "../lib/turn-mode";
+import {
+  DEFAULT_TURN_MODE,
+  normalizeTurnMode,
+  type TurnMode,
+} from "../lib/turn-mode";
 import type { Agent, AgentDefinition, SkillSummary } from "../lib/types";
 import { useAgentProvisioningStore } from "../stores/agent-provisioning";
 import { newConversationDraftKey, useDraftStore } from "../stores/drafts";
@@ -308,13 +320,13 @@ export function useAgentChatPanel({
   const [agentEffort, setAgentEffort] = useState<string | null>(null);
   // Composer "Mode" pin (execute/plan). Loaded from config as memory only; the
   // send path forwards it as `modeOverride`. Unknown/legacy values → execute.
-  const [turnMode, setTurnMode] = useState<TurnMode>("execute");
+  const [turnMode, setTurnMode] = useState<TurnMode>(DEFAULT_TURN_MODE);
   useEffect(() => {
     if (!path) {
       setAgentProvider(null);
       setAgentModel(null);
       setAgentEffort(null);
-      setTurnMode("execute");
+      setTurnMode(DEFAULT_TURN_MODE);
       return;
     }
     tauriConfig
@@ -937,6 +949,13 @@ export function useAgentChatPanel({
     persisted: selectedActivity?.pending_interaction,
   });
 
+  // A stable key for the CURRENT pending interaction. There is no single id on a
+  // PendingInteraction (only on its individual steps), so the step ids joined in
+  // order identify one sequence — enough to remember "the user abandoned THIS
+  // interaction" across renders without re-showing it.
+  const interactionKey =
+    activeInteraction?.steps.map((s) => s.id).join(",") ?? null;
+
   // Sends the composed interaction reply as a normal user message through the
   // existing follow-up send path; the turn start clears the interaction, so the
   // card retires through the same reactivity. A failure surfaces (no silent
@@ -976,6 +995,8 @@ export function useAgentChatPanel({
       send: t("chat:questionCard.send"),
       back: t("chat:questionCard.back"),
       forward: t("chat:questionCard.forward"),
+      skip: t("chat:questionCard.skip"),
+      dismiss: t("chat:questionCard.dismiss"),
       progress: (current: number, total: number) =>
         t("chat:questionCard.progress", { current, total }),
     }),
@@ -992,9 +1013,24 @@ export function useAgentChatPanel({
   const [dismissedPlanReady, setDismissedPlanReady] = useState<string | null>(
     null,
   );
-  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedSessionKey is the intentional change-trigger that clears the dismissal when the open conversation switches, so a dismissed plan never suppresses a new chat's card.
+  // The optional "save as reusable" offer (suggest_reusable) is dismissed
+  // LOCALLY by id when the user picks "Not now" (or acts on Save), so the card
+  // doesn't reappear for that same offer. Per-conversation, like plan-ready.
+  const [dismissedSuggestReusable, setDismissedSuggestReusable] = useState<
+    string | null
+  >(null);
+  // The user can abandon ANY pending interaction (question stepper, plan_ready,
+  // suggest_reusable) either by the card's dismiss X or by typing a fresh message
+  // in the composer while it shows. Remembering the abandoned interaction's key
+  // suppresses its card uniformly. Per-conversation, like the dismissals above.
+  const [abandonedInteractionKey, setAbandonedInteractionKey] = useState<
+    string | null
+  >(null);
+  // biome-ignore lint/correctness/useExhaustiveDependencies: selectedSessionKey is the intentional change-trigger that clears the dismissals and the abandoned-interaction key when the open conversation switches, so a dismissed plan/offer or abandoned interaction never suppresses a new chat's card.
   useEffect(() => {
     setDismissedPlanReady(null);
+    setDismissedSuggestReusable(null);
+    setAbandonedInteractionKey(null);
   }, [selectedSessionKey]);
 
   // Start a turn from the plan-ready card: flip the composer's Mode pill (and
@@ -1045,6 +1081,58 @@ export function useAgentChatPanel({
     [t],
   );
 
+  // ── Suggest-reusable offer (suggest_reusable) ─────────────────────────
+  // On a clean finish the model may call `suggest_reusable`, arriving as a lone
+  // `{kind:"suggest_reusable", ...}` step. The card offers to save the work as a
+  // Skill or Routine. "Save" sends a follow-up message asking the agent to
+  // actually WRITE the Skill/Routine file, so it always runs in `execute` mode
+  // regardless of the composer's pinned mode (planning it is not enough), and it
+  // does NOT flip the composer's Mode pill (this is a one-off follow-up, not a
+  // change to the ongoing mode). It dismisses the offer locally first so the
+  // card can't fire twice.
+  const suggestReusableLabels = useMemo<ChatSuggestReusableLabels>(
+    () => ({
+      eyebrow: t("chat:suggestReusable.title"),
+      skillTitle: t("chat:suggestReusable.skillTitle"),
+      routineTitle: t("chat:suggestReusable.routineTitle"),
+      notNow: t("chat:suggestReusable.notNow"),
+    }),
+    [t],
+  );
+
+  const saveReusable = useCallback(
+    (step: SuggestReusableStep) => {
+      if (!path || !selectedSessionKey) return;
+      setDismissedSuggestReusable(step.id);
+      const text =
+        step.reusableKind === "skill"
+          ? t("chat:suggestReusable.saveSkillMessage", { title: step.title })
+          : t("chat:suggestReusable.saveRoutineMessage", { title: step.title });
+      tauriChat
+        .send(path, text, selectedSessionKey, {
+          providerOverride: effectiveProvider,
+          modelOverride: effectiveModel,
+          effortOverride: effectiveEffort,
+          modeOverride: "execute",
+        })
+        .catch((err) => {
+          addToast({
+            title: t("chat:errors.sessionStart", { error: String(err) }),
+            variant: "error",
+          });
+        });
+    },
+    [
+      path,
+      selectedSessionKey,
+      effectiveProvider,
+      effectiveModel,
+      effectiveEffort,
+      addToast,
+      t,
+    ],
+  );
+
   // The mission is waiting on a sequence of steps (questions then connections).
   // ONE ChatInteractionCard walks them one at a time; `onComplete` fires after
   // the LAST step, never before, so the card lives until every connection has
@@ -1067,6 +1155,36 @@ export function useAgentChatPanel({
   // array.
   const composerOverride = useMemo<AIBoardProps["composerOverride"]>(() => {
     if (!agent || !activeInteraction) return undefined;
+    // Abandoned (dismiss X, or a fresh composer send while it showed): suppress
+    // the card uniformly, whatever kind it is (suggest_reusable / plan_ready /
+    // stepper), and let the always-mounted composer stand alone.
+    if (interactionKey === abandonedInteractionKey) return undefined;
+    // A lone suggest_reusable step is the optional save offer. Resolve it FIRST
+    // and short-circuit: it is not a plan_ready step, so resolvePlanReadyOverride
+    // would wrongly route it into the interaction stepper. It never coexists with
+    // other step kinds by construction (runtime side), so a lone suggest_reusable
+    // step is fully handled here (card when live, composer when dismissed).
+    if (
+      activeInteraction.steps.length === 1 &&
+      activeInteraction.steps[0].kind === "suggest_reusable"
+    ) {
+      const reusable = resolveSuggestReusableOverride(
+        activeInteraction.steps,
+        dismissedSuggestReusable,
+      );
+      if (reusable.kind === "none") return undefined;
+      const step = reusable.step;
+      return (
+        <ChatSuggestReusableCard
+          reusableKind={step.reusableKind}
+          title={step.title}
+          rationale={step.rationale}
+          labels={suggestReusableLabels}
+          onSave={() => saveReusable(step)}
+          onDismiss={() => setDismissedSuggestReusable(step.id)}
+        />
+      );
+    }
     // A lone plan_ready step becomes the plan-ready card (unless dismissed);
     // everything else feeds the stepper over its plan_ready-free steps.
     const override = resolvePlanReadyOverride(
@@ -1101,12 +1219,15 @@ export function useAgentChatPanel({
       <ChatInteractionCard
         steps={steps}
         labels={interactionLabels}
+        onDismiss={() => setAbandonedInteractionKey(interactionKey)}
         onComplete={(answers: ChatInteractionAnswer[]) => {
           // ONE send after the LAST step: a sequence with questions replies with
           // the user's visible answers; a signin/connect-only sequence resumes
           // the agent with a hidden auto-continue message (no fake user bubble).
+          // The visible reply also carries a structured marker so the transcript
+          // renders the answers as a Q&A card, not an undifferentiated bubble.
           sendInteractionMessage(
-            composeInteractionReply({
+            encodeInteractionAnswersMessage({
               answers,
               connectedNames,
               hasQuestionSteps,
@@ -1145,14 +1266,42 @@ export function useAgentChatPanel({
   }, [
     agent,
     activeInteraction,
+    interactionKey,
+    abandonedInteractionKey,
     dismissedPlanReady,
+    dismissedSuggestReusable,
     planReadyLabels,
+    suggestReusableLabels,
     startPlan,
+    saveReusable,
     interactionLabels,
     sendInteractionMessage,
     capabilities,
     t,
   ]);
+
+  // A fresh message typed into the always-mounted composer WHILE an interaction
+  // card shows is an implicit "abandon this interaction": mark it abandoned so
+  // the card retires (the composerOverride memo suppresses it), then run the
+  // normal composer-submit path unchanged. Only genuine composer submits reach
+  // here — the cards' own composed replies go through sendInteractionMessage /
+  // saveReusable / startPlan, which call tauriChat.send directly and never touch
+  // this handler, so completing/acting on an interaction never self-abandons it.
+  const onComposerSubmit = useCallback<
+    NonNullable<AIBoardProps["onComposerSubmit"]>
+  >(
+    (ctx) => {
+      if (activeInteraction && interactionKey !== abandonedInteractionKey)
+        setAbandonedInteractionKey(interactionKey);
+      return handleSkillComposerSubmit(ctx);
+    },
+    [
+      handleSkillComposerSubmit,
+      activeInteraction,
+      interactionKey,
+      abandonedInteractionKey,
+    ],
+  );
 
   // ── Built JSX bundles ─────────────────────────────────────────────────
   const renderUserMessage = useCallback(
@@ -1167,13 +1316,19 @@ export function useAgentChatPanel({
         );
       }
       const attachmentInvocation = decodeAttachmentMessage(msg.content);
-      if (!attachmentInvocation) return undefined;
-      return (
-        <UserAttachmentMessage
-          invocation={attachmentInvocation}
-          labels={attachmentLabels}
-        />
-      );
+      if (attachmentInvocation) {
+        return (
+          <UserAttachmentMessage
+            invocation={attachmentInvocation}
+            labels={attachmentLabels}
+          />
+        );
+      }
+      const interactionAnswers = decodeInteractionAnswersMessage(msg.content);
+      if (interactionAnswers) {
+        return <UserInteractionAnswersMessage payload={interactionAnswers} />;
+      }
+      return undefined;
     },
     [attachmentLabels],
   );
@@ -1516,7 +1671,7 @@ export function useAgentChatPanel({
     composerHeader,
     composerOverride,
     canSendEmpty: activeSkill != null,
-    onComposerSubmit: handleSkillComposerSubmit,
+    onComposerSubmit,
     footer,
     attachMenu,
     renderUserMessage,

--- a/app/src/lib/interaction-reply.ts
+++ b/app/src/lib/interaction-reply.ts
@@ -1,5 +1,12 @@
-import type { ChatInteractionAnswer } from "@houston-ai/chat";
-import { encodeAutoContinueMessage } from "./auto-continue-message.ts";
+import type {
+  ChatInteractionAnswer,
+  InteractionAnswerLine,
+  InteractionAnswersPayload,
+} from "@houston-ai/chat";
+import {
+  encodeAutoContinueMessage,
+  isAutoContinueMessage,
+} from "./auto-continue-message.ts";
 
 /**
  * The single message an interaction sequence sends when its LAST step
@@ -49,4 +56,40 @@ export function composeInteractionReply(args: {
   for (const name of args.connectedNames) lines.push(args.connectedLine(name));
   const body = lines.join("\n");
   return args.hasQuestionSteps ? body : encodeAutoContinueMessage(body);
+}
+
+const MARKER_PREFIX = "<!--houston:interaction-answers ";
+const MARKER_SUFFIX = "-->";
+
+/**
+ * The interaction reply, wrapped so the transcript can render the answers as a
+ * structured Q&A card instead of an undifferentiated text bubble.
+ *
+ * Takes the SAME inputs as {@link composeInteractionReply} and delegates to it
+ * for the flat body the model reads — behavior for the agent is unchanged. On
+ * top it carries the SAME information in a structured `InteractionAnswersPayload`
+ * (decoded + rendered by `@houston-ai/chat`) behind an HTML-comment marker,
+ * exactly like the Skill marker.
+ *
+ * A hidden auto-continue sequence (connect-only / signin-only, no questions)
+ * never renders a user bubble, so there is nothing to structure-render: the
+ * flat reply is returned unchanged, no marker added.
+ */
+export function encodeInteractionAnswersMessage(
+  args: Parameters<typeof composeInteractionReply>[0],
+): string {
+  const body = composeInteractionReply(args);
+  // Hidden (no visible bubble) → leave the flat reply untouched.
+  if (isAutoContinueMessage(body)) return body;
+
+  const lines: InteractionAnswerLine[] = args.answers.map((a) => ({
+    question: a.question,
+    answer: a.answer,
+  }));
+  if (args.signedIn) lines.push({ answer: args.signedInLine });
+  for (const name of args.connectedNames)
+    lines.push({ answer: args.connectedLine(name) });
+
+  const payload: InteractionAnswersPayload = { lines };
+  return `${MARKER_PREFIX}${JSON.stringify(payload)}${MARKER_SUFFIX}\n\n${body}`;
 }

--- a/app/src/lib/plan-ready.ts
+++ b/app/src/lib/plan-ready.ts
@@ -5,10 +5,14 @@ import type { InteractionStep } from "@houston/protocol";
  *  ask_user. Extracted from the protocol union so the app narrows to it. */
 export type PlanReadyStep = Extract<InteractionStep, { kind: "plan_ready" }>;
 
-/** Every interaction step that is NOT a plan_ready step (question / signin /
- *  connect). These are the ones the existing ChatInteractionCard stepper walks;
- *  a plan_ready step never belongs in that stepper. */
-export type NonPlanReadyStep = Exclude<InteractionStep, { kind: "plan_ready" }>;
+/** Every interaction step the ChatInteractionCard stepper can walk: question /
+ *  signin / connect. Excludes the two composer-replacing card kinds (plan_ready
+ *  and suggest_reusable), which each render their own dedicated card and never
+ *  belong in the stepper. */
+export type NonPlanReadyStep = Exclude<
+  InteractionStep,
+  { kind: "plan_ready" } | { kind: "suggest_reusable" }
+>;
 
 /**
  * Which composer-replacing surface a pending interaction's steps resolve to:
@@ -42,7 +46,8 @@ export function resolvePlanReadyOverride(
       : { kind: "card", summary: lone.summary };
   }
   const rest = steps.filter(
-    (step): step is NonPlanReadyStep => step.kind !== "plan_ready",
+    (step): step is NonPlanReadyStep =>
+      step.kind !== "plan_ready" && step.kind !== "suggest_reusable",
   );
   return rest.length > 0 ? { kind: "stepper", steps: rest } : { kind: "none" };
 }

--- a/app/src/lib/suggest-reusable.ts
+++ b/app/src/lib/suggest-reusable.ts
@@ -1,0 +1,48 @@
+import type { InteractionStep } from "@houston/protocol";
+
+/** A suggest_reusable step: the model called `suggest_reusable` on a clean
+ *  finish to offer saving the just-completed work as a Skill or Routine. It
+ *  reaches the frontend as a lone step in a `PendingInteraction`, exactly like
+ *  plan_ready. Extracted from the protocol union so the app narrows to it. */
+export type SuggestReusableStep = Extract<
+  InteractionStep,
+  { kind: "suggest_reusable" }
+>;
+
+/**
+ * Which composer-replacing surface a pending interaction's steps resolve to for
+ * the reusable-save offer:
+ *
+ *  - `card` — a lone suggest_reusable step that hasn't been dismissed → the
+ *             ChatSuggestReusableCard, carrying the proposed title + rationale.
+ *  - `none` — a lone suggest_reusable step the user dismissed ("Not now"), or
+ *             the steps are not a lone suggest_reusable offer → no card.
+ *
+ * Unlike plan-ready's resolver there is NO "stepper" branch here: a
+ * suggest_reusable step is mutually exclusive with every other step kind by
+ * construction on the runtime side (it arrives alone on a clean-finish `done`
+ * frame; see `packages/protocol/src/domain/interaction.ts` and `turn-settle.ts`
+ * `finishOk`), so it never coexists with question / signin / connect / plan_ready
+ * steps and there is nothing to route into the interaction stepper.
+ *
+ * `dismissedId` is the id of the offer the user chose to skip: dismissal is
+ * per-step-id, so a LATER, different suggestion (different id) re-shows the card.
+ * Pure so the branch is unit-tested without the panel's event plumbing.
+ */
+export type SuggestReusableOverride =
+  | { kind: "card"; step: SuggestReusableStep }
+  | { kind: "none" };
+
+export function resolveSuggestReusableOverride(
+  steps: InteractionStep[],
+  dismissedId: string | null,
+): SuggestReusableOverride {
+  const lone =
+    steps.length === 1 && steps[0].kind === "suggest_reusable"
+      ? steps[0]
+      : null;
+  if (!lone) return { kind: "none" };
+  return dismissedId === lone.id
+    ? { kind: "none" }
+    : { kind: "card", step: lone };
+}

--- a/app/src/lib/turn-mode.ts
+++ b/app/src/lib/turn-mode.ts
@@ -12,27 +12,27 @@
  *
  * The user's last pick is remembered per-agent in `.houston/config` (composer
  * memory only — never synced to engine Settings), so unknown/legacy values on
- * read normalize back to `execute`.
+ * read normalize back to {@link DEFAULT_TURN_MODE}.
  */
 export type TurnMode = "execute" | "plan" | "auto";
 
-export const DEFAULT_TURN_MODE: TurnMode = "execute";
+export const DEFAULT_TURN_MODE: TurnMode = "plan";
 
-/** Tolerant read: only the exact `"plan"` and `"auto"` strings pin a
- *  non-default mode; anything else (a stale value, `undefined`, a typo) falls
- *  back to `execute`. */
+/** Tolerant read: the three known values pass through as-is; anything else
+ *  (a stale value, `undefined`, a typo) falls back to {@link DEFAULT_TURN_MODE}. */
 export function normalizeTurnMode(value: unknown): TurnMode {
   if (value === "plan") return "plan";
   if (value === "auto") return "auto";
-  return "execute";
+  if (value === "execute") return "execute";
+  return DEFAULT_TURN_MODE;
 }
 
 /**
  * The agent's remembered turn mode, for send paths that assemble their own
  * overrides (Mission Control, archived resumes) instead of holding the chat
- * panel's live pill state. A failed config read falls back to `execute` — the
- * safe default for a preference lookup; the send itself still surfaces its own
- * errors.
+ * panel's live pill state. A failed config read falls back to
+ * {@link DEFAULT_TURN_MODE} — the safe default for a preference lookup; the
+ * send itself still surfaces its own errors.
  */
 export async function readAgentTurnMode(
   agentPath: string,

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -41,10 +41,12 @@
     "description": "Type a message to talk to your assistant."
   },
   "questionCard": {
-    "placeholder": "Type your answer...",
-    "send": "Send",
+    "placeholder": "Type something else...",
+    "send": "Next",
     "back": "Back",
     "forward": "Next",
+    "skip": "Skip",
+    "dismiss": "Dismiss",
     "progress": "{{current}} of {{total}}"
   },
   "interaction": {
@@ -66,6 +68,14 @@
     "keepPlanningDescription": "Stay here and adjust the plan.",
     "startWorkingMessage": "Go ahead with the plan.",
     "runAutopilotMessage": "Go ahead and finish it on your own."
+  },
+  "suggestReusable": {
+    "title": "Save this for next time",
+    "skillTitle": "Save as a Skill",
+    "routineTitle": "Save as a Routine",
+    "notNow": "Not now",
+    "saveSkillMessage": "Save what I just did as a Skill called \"{{title}}\".",
+    "saveRoutineMessage": "Set this up as a recurring Routine called \"{{title}}\"."
   },
   "errors": {
     "sessionStart": "Failed to start session: {{error}}",

--- a/app/src/locales/en/setup.json
+++ b/app/src/locales/en/setup.json
@@ -112,7 +112,11 @@
         "connect": "Connect",
         "connecting": "Connecting...",
         "skipHint": "Can't connect right now? You can do this anytime from Integrations.",
-        "skip": "Skip for now"
+        "skip": "Skip for now",
+        "skipConfirmTitle": "Skip connecting your email?",
+        "skipConfirmBody": "You can connect it anytime from Integrations. Your agent won't be able to send or read email until you do.",
+        "skipConfirmAction": "Skip for now",
+        "skipConfirmCancel": "Keep connecting"
       },
       "agentCreated": {
         "title": "Agent created!",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -41,10 +41,12 @@
     "description": "Escribe un mensaje para hablar con tu asistente."
   },
   "questionCard": {
-    "placeholder": "Escribe tu respuesta...",
-    "send": "Enviar",
+    "placeholder": "Escribe otra cosa...",
+    "send": "Siguiente",
     "back": "Atrás",
     "forward": "Siguiente",
+    "skip": "Omitir",
+    "dismiss": "Descartar",
     "progress": "{{current}} de {{total}}"
   },
   "interaction": {
@@ -66,6 +68,14 @@
     "keepPlanningDescription": "Sigue aquí y ajusta el plan.",
     "startWorkingMessage": "Adelante con el plan.",
     "runAutopilotMessage": "Adelante, termínalo por tu cuenta."
+  },
+  "suggestReusable": {
+    "title": "Guarda esto para la próxima vez",
+    "skillTitle": "Guardar como Habilidad",
+    "routineTitle": "Guardar como Rutina",
+    "notNow": "Ahora no",
+    "saveSkillMessage": "Guarda lo que acabo de hacer como una Habilidad llamada \"{{title}}\".",
+    "saveRoutineMessage": "Configura esto como una Rutina recurrente llamada \"{{title}}\"."
   },
   "errors": {
     "sessionStart": "No se pudo iniciar la sesión: {{error}}",

--- a/app/src/locales/es/setup.json
+++ b/app/src/locales/es/setup.json
@@ -112,7 +112,11 @@
         "connect": "Conectar",
         "connecting": "Conectando...",
         "skipHint": "¿No puedes conectar ahora? Puedes hacerlo cuando quieras desde Integraciones.",
-        "skip": "Omitir por ahora"
+        "skip": "Omitir por ahora",
+        "skipConfirmTitle": "¿Omitir la conexión de tu correo?",
+        "skipConfirmBody": "Puedes conectarlo cuando quieras desde Integraciones. Tu agente no podrá enviar ni leer correo hasta que lo hagas.",
+        "skipConfirmAction": "Omitir por ahora",
+        "skipConfirmCancel": "Seguir conectando"
       },
       "agentCreated": {
         "title": "¡Agente creado!",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -41,10 +41,12 @@
     "description": "Digite uma mensagem para falar com seu assistente."
   },
   "questionCard": {
-    "placeholder": "Digite sua resposta...",
-    "send": "Enviar",
+    "placeholder": "Digite outra coisa...",
+    "send": "Avançar",
     "back": "Voltar",
     "forward": "Avançar",
+    "skip": "Pular",
+    "dismiss": "Descartar",
     "progress": "{{current}} de {{total}}"
   },
   "interaction": {
@@ -66,6 +68,14 @@
     "keepPlanningDescription": "Fique aqui e ajuste o plano.",
     "startWorkingMessage": "Pode seguir com o plano.",
     "runAutopilotMessage": "Pode terminar por conta própria."
+  },
+  "suggestReusable": {
+    "title": "Salve isto para a próxima vez",
+    "skillTitle": "Salvar como Habilidade",
+    "routineTitle": "Salvar como Rotina",
+    "notNow": "Agora não",
+    "saveSkillMessage": "Salve o que acabei de fazer como uma Habilidade chamada \"{{title}}\".",
+    "saveRoutineMessage": "Configure isto como uma Rotina recorrente chamada \"{{title}}\"."
   },
   "errors": {
     "sessionStart": "Não foi possível iniciar a sessão: {{error}}",

--- a/app/src/locales/pt/setup.json
+++ b/app/src/locales/pt/setup.json
@@ -112,7 +112,11 @@
         "connect": "Conectar",
         "connecting": "Conectando...",
         "skipHint": "Não consegue conectar agora? Você pode fazer isso quando quiser em Integrações.",
-        "skip": "Pular por enquanto"
+        "skip": "Pular por enquanto",
+        "skipConfirmTitle": "Pular a conexão do seu e-mail?",
+        "skipConfirmBody": "Você pode conectar quando quiser em Integrações. Seu agente não vai poder enviar nem ler e-mails até você fazer isso.",
+        "skipConfirmAction": "Pular por enquanto",
+        "skipConfirmCancel": "Continuar conectando"
       },
       "agentCreated": {
         "title": "Agente criado!",

--- a/app/tests/interaction-reply.test.ts
+++ b/app/tests/interaction-reply.test.ts
@@ -1,8 +1,14 @@
-import { strictEqual } from "node:assert";
+import { deepStrictEqual, strictEqual } from "node:assert";
 import { describe, it } from "node:test";
 import type { ChatInteractionAnswer } from "@houston-ai/chat";
+// Imported from source (not the barrel) so node's --experimental-strip-types
+// runner needn't resolve the package's extensionless .tsx re-exports.
+import { decodeInteractionAnswersMessage } from "../../ui/chat/src/interaction-answers-message.ts";
 import { isAutoContinueMessage } from "../src/lib/auto-continue-message.ts";
-import { composeInteractionReply } from "../src/lib/interaction-reply.ts";
+import {
+  composeInteractionReply,
+  encodeInteractionAnswersMessage,
+} from "../src/lib/interaction-reply.ts";
 
 const connectedLine = (name: string) => `Connected ${name}.`;
 const signedInLine = "Signed in to Houston.";
@@ -137,5 +143,74 @@ describe("composeInteractionReply", () => {
     strictEqual(isAutoContinueMessage(reply), true);
     strictEqual(reply.endsWith("I've signed in. Please continue."), true);
     strictEqual(reply.includes("Signed in to Houston."), false);
+  });
+});
+
+describe("encodeInteractionAnswersMessage", () => {
+  it("keeps the flat model body identical to composeInteractionReply", () => {
+    const shared = {
+      answers,
+      connectedNames: ["Gmail"],
+      hasQuestionSteps: true,
+      signedIn: true,
+      connectedLine,
+      signedInLine,
+      signedInFollowup,
+    } as const;
+    const encoded = encodeInteractionAnswersMessage(shared);
+    const flat = composeInteractionReply(shared);
+    // The marker rides in front; the body after the blank line is the untouched
+    // flat reply the model reads.
+    strictEqual(encoded.endsWith(`\n\n${flat}`), true);
+    strictEqual(encoded.startsWith("<!--houston:interaction-answers "), true);
+  });
+
+  it("carries a structured payload that decodes back to the same Q&A", () => {
+    const encoded = encodeInteractionAnswersMessage({
+      answers,
+      connectedNames: ["Gmail"],
+      hasQuestionSteps: true,
+      signedIn: true,
+      connectedLine,
+      signedInLine,
+      signedInFollowup,
+    });
+    const payload = decodeInteractionAnswersMessage(encoded);
+    deepStrictEqual(payload, {
+      lines: [
+        { question: "To whom?", answer: "john@example.com" },
+        { question: "Saying what?", answer: "Running late" },
+        { answer: "Signed in to Houston." },
+        { answer: "Connected Gmail." },
+      ],
+    });
+  });
+
+  it("does NOT mark a hidden connect-only sequence (no visible bubble)", () => {
+    const encoded = encodeInteractionAnswersMessage({
+      answers: [],
+      connectedNames: ["Gmail"],
+      hasQuestionSteps: false,
+      signedIn: false,
+      connectedLine,
+      signedInLine,
+      signedInFollowup,
+    });
+    strictEqual(isAutoContinueMessage(encoded), true);
+    strictEqual(decodeInteractionAnswersMessage(encoded), null);
+  });
+
+  it("does NOT mark a hidden signin-only sequence", () => {
+    const encoded = encodeInteractionAnswersMessage({
+      answers: [],
+      connectedNames: [],
+      hasQuestionSteps: false,
+      signedIn: true,
+      connectedLine,
+      signedInLine,
+      signedInFollowup,
+    });
+    strictEqual(isAutoContinueMessage(encoded), true);
+    strictEqual(decodeInteractionAnswersMessage(encoded), null);
   });
 });

--- a/app/tests/onboarding-flow.test.ts
+++ b/app/tests/onboarding-flow.test.ts
@@ -104,41 +104,12 @@ describe("stepAfterAgentCreated", () => {
 });
 
 describe("shouldOfferConnectSkip (dead-end escape hatch)", () => {
-  const base = {
-    statusKnown: true,
-    ready: true,
-    attempted: false,
-    connecting: false,
-  };
-
-  it("hidden on the happy path (gateway ready, nothing attempted)", () => {
-    strictEqual(shouldOfferConnectSkip(base), false);
-  });
-
-  it("hidden while the provider status is still loading", () => {
-    strictEqual(
-      shouldOfferConnectSkip({ ...base, statusKnown: false, ready: false }),
-      false,
-    );
-  });
-
-  it("offered when the gateway resolved as not ready (no session)", () => {
-    strictEqual(shouldOfferConnectSkip({ ...base, ready: false }), true);
-  });
-
-  it("offered after a connect attempt ended without the toolkit landing", () => {
-    strictEqual(shouldOfferConnectSkip({ ...base, attempted: true }), true);
+  it("offered on the happy path (gateway ready, nothing attempted) — the confirm dialog is the friction", () => {
+    strictEqual(shouldOfferConnectSkip({ connecting: false }), true);
   });
 
   it("never offered while a connect flow is in flight", () => {
-    strictEqual(
-      shouldOfferConnectSkip({ ...base, attempted: true, connecting: true }),
-      false,
-    );
-    strictEqual(
-      shouldOfferConnectSkip({ ...base, ready: false, connecting: true }),
-      false,
-    );
+    strictEqual(shouldOfferConnectSkip({ connecting: true }), false);
   });
 });
 

--- a/app/tests/suggest-reusable.test.ts
+++ b/app/tests/suggest-reusable.test.ts
@@ -1,0 +1,62 @@
+import { deepStrictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { InteractionStep } from "@houston/protocol";
+import { resolveSuggestReusableOverride } from "../src/lib/suggest-reusable.ts";
+
+const suggest: InteractionStep = {
+  kind: "suggest_reusable",
+  id: "r1",
+  reusableKind: "skill",
+  title: "Weekly investor update",
+  rationale: "You will likely want to repeat this every week.",
+};
+const question: InteractionStep = {
+  kind: "question",
+  id: "q1",
+  question: "Which account?",
+};
+
+describe("resolveSuggestReusableOverride", () => {
+  it("renders the card for a lone, undismissed suggest_reusable step", () => {
+    deepStrictEqual(resolveSuggestReusableOverride([suggest], null), {
+      kind: "card",
+      step: suggest,
+    });
+  });
+
+  it("returns none once THIS offer is dismissed (Not now)", () => {
+    deepStrictEqual(resolveSuggestReusableOverride([suggest], suggest.id), {
+      kind: "none",
+    });
+  });
+
+  it("re-shows the card for a later, different offer", () => {
+    const next: InteractionStep = {
+      kind: "suggest_reusable",
+      id: "r2",
+      reusableKind: "routine",
+      title: "Daily standup digest",
+      rationale: "This runs on a schedule.",
+    };
+    deepStrictEqual(resolveSuggestReusableOverride([next], suggest.id), {
+      kind: "card",
+      step: next,
+    });
+  });
+
+  it("returns none when the sole step is not a suggest_reusable step", () => {
+    deepStrictEqual(resolveSuggestReusableOverride([question], null), {
+      kind: "none",
+    });
+  });
+
+  it("returns none for a multi-step sequence (never coexists by construction)", () => {
+    deepStrictEqual(resolveSuggestReusableOverride([question, suggest], null), {
+      kind: "none",
+    });
+  });
+
+  it("returns none for an empty sequence", () => {
+    deepStrictEqual(resolveSuggestReusableOverride([], null), { kind: "none" });
+  });
+});

--- a/app/tests/turn-mode.test.ts
+++ b/app/tests/turn-mode.test.ts
@@ -7,8 +7,8 @@ import {
 } from "../src/lib/turn-mode.ts";
 
 // The composer "Mode" pin is loaded from per-agent config, which is untyped on
-// disk. `normalizeTurnMode` is the read-side guard: only the exact `"plan"` and
-// `"auto"` strings pin a non-default mode; everything else falls back to execute
+// disk. `normalizeTurnMode` is the read-side guard: only the three known mode
+// strings pass through as-is; everything else falls back to the default mode
 // so a stale or garbage value never strands the composer in an unknown mode.
 describe("normalizeTurnMode", () => {
   it("keeps the three known modes", () => {
@@ -17,24 +17,24 @@ describe("normalizeTurnMode", () => {
     strictEqual(normalizeTurnMode("execute"), "execute");
   });
 
-  it("normalizes absent / unset values to execute", () => {
-    strictEqual(normalizeTurnMode(undefined), "execute");
-    strictEqual(normalizeTurnMode(null), "execute");
-    strictEqual(normalizeTurnMode(""), "execute");
+  it("normalizes absent / unset values to the default mode", () => {
+    strictEqual(normalizeTurnMode(undefined), DEFAULT_TURN_MODE);
+    strictEqual(normalizeTurnMode(null), DEFAULT_TURN_MODE);
+    strictEqual(normalizeTurnMode(""), DEFAULT_TURN_MODE);
   });
 
-  it("normalizes unknown / legacy / wrong-typed values to execute", () => {
-    strictEqual(normalizeTurnMode("planning"), "execute");
-    strictEqual(normalizeTurnMode("Plan"), "execute"); // case-sensitive
-    strictEqual(normalizeTurnMode("Auto"), "execute"); // case-sensitive
-    strictEqual(normalizeTurnMode("autopilot"), "execute");
-    strictEqual(normalizeTurnMode("readonly"), "execute");
-    strictEqual(normalizeTurnMode(42), "execute");
-    strictEqual(normalizeTurnMode({ mode: "plan" }), "execute");
+  it("normalizes unknown / legacy / wrong-typed values to the default mode", () => {
+    strictEqual(normalizeTurnMode("planning"), DEFAULT_TURN_MODE);
+    strictEqual(normalizeTurnMode("Plan"), DEFAULT_TURN_MODE); // case-sensitive
+    strictEqual(normalizeTurnMode("Auto"), DEFAULT_TURN_MODE); // case-sensitive
+    strictEqual(normalizeTurnMode("autopilot"), DEFAULT_TURN_MODE);
+    strictEqual(normalizeTurnMode("readonly"), DEFAULT_TURN_MODE);
+    strictEqual(normalizeTurnMode(42), DEFAULT_TURN_MODE);
+    strictEqual(normalizeTurnMode({ mode: "plan" }), DEFAULT_TURN_MODE);
   });
 
-  it("defaults to execute (unpinned turns are execute)", () => {
-    strictEqual(DEFAULT_TURN_MODE, "execute");
+  it("defaults to plan (fresh agents open in Planner)", () => {
+    strictEqual(DEFAULT_TURN_MODE, "plan");
   });
 });
 
@@ -49,18 +49,25 @@ describe("readAgentTurnMode", () => {
       "auto",
     );
     strictEqual(
-      await readAgentTurnMode("Agent", async () => ({ mode: "legacy" })),
+      await readAgentTurnMode("Agent", async () => ({ mode: "execute" })),
       "execute",
     );
-    strictEqual(await readAgentTurnMode("Agent", async () => ({})), "execute");
+    strictEqual(
+      await readAgentTurnMode("Agent", async () => ({ mode: "legacy" })),
+      DEFAULT_TURN_MODE,
+    );
+    strictEqual(
+      await readAgentTurnMode("Agent", async () => ({})),
+      DEFAULT_TURN_MODE,
+    );
   });
 
-  it("falls back to execute when the config read fails", async () => {
+  it("falls back to the default mode when the config read fails", async () => {
     strictEqual(
       await readAgentTurnMode("Agent", async () => {
         throw new Error("missing config");
       }),
-      "execute",
+      DEFAULT_TURN_MODE,
     );
   });
 });

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,35 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v12 - 2026-07-10
+
+Interaction cards stop replacing the composer, and two new chat surfaces land.
+
+`interaction-card` redesign: the card now floats ABOVE the always-mounted
+composer; typing a fresh message there (or the new header dismiss X) abandons
+the whole pending sequence. The header becomes a "current/total" pill plus the
+question text; option rows show a right-aligned position number (1, 2, 3...)
+selectable by that number key when focus is outside a text field, replacing the
+check-on-selected indicator; the free-text field reads as the "something else"
+escape hatch so option lists never need an "Other" row. ALL navigation moves to
+one footer row, Back leftmost: Back / Skip (advance past a question unanswered,
+omitted from the reply) / Next (commit), with a bare Forward for revisited
+signin/connect steps. The old header back/forward chevrons and the collapse
+toggle are gone. `plan-ready-card` inherits the composer-visible behavior
+unchanged otherwise.
+
+New `suggest-reusable-card`: on a clean mission finish the agent may call
+`suggest_reusable`; a dismissible offer proposes saving the work as a Skill
+(Sparkles) or Routine (CalendarClock). Uniquely, its lone step keeps the board
+status at `done` — nothing is waiting on the user. Save sends an execute-mode
+follow-up asking the agent to write the Skill/Routine; "Not now" dismisses
+locally.
+
+New `interaction-answers-message`: a completed question sequence now sends a
+marker-encoded user message rendered as structured question/answer pairs (muted
+question, bold answer) instead of a flat text blob; the plain-text body the
+model reads is unchanged.
+
 ## v11 - 2026-07-09
 
 `routine-row` grows a state icon and quick actions. The 8px status dot becomes

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 11
+version: 12
 
 components:
   - id: agent-avatar
@@ -229,33 +229,39 @@ components:
 
   - id: interaction-card
     title: Interaction card
-    purpose: In-chat surface shown when the agent pauses mid-turn to gather what it needs before continuing; a stepper that walks the user through one step at a time (questions, then sign-in, then connections), replacing the composer until done.
-    anatomy: [stepper-header, progress-indicator, back-chevron, question-step, option-row, free-text-input, send-action, signin-step, connect-step]
-    states: [single-step, multi-step, with-options, free-text-only, signin-step, connect-step, revisited, disabled]
+    purpose: In-chat surface shown when the agent pauses mid-turn to gather what it needs before continuing; a stepper that walks the user through one step at a time (questions, then sign-in, then connections), floating ABOVE the always-mounted composer.
+    anatomy: [stepper-header, progress-pill, question-text, dismiss-action, option-row, position-number, free-text-input, footer-nav, back-action, skip-action, next-action, signin-step, connect-step]
+    states: [single-step, multi-step, with-options, free-text-only, signin-step, connect-step, revisited, abandoned, disabled]
     variants: [choice, open-ended, signin, connect, mixed-sequence]
     behavior: >-
       Rendered from the turn's pending interaction (steps[]: 1-3 question steps,
-      then at most one signin step, then connect steps). Shows ONE step at a time
-      with a quiet "N of X" progress indicator (only when total > 1) and a back
-      chevron from step 2 on. Question step: one prominent question, vertical
-      single-select option rows (role=radio), and a free-text input ALWAYS
-      visible below as the escape hatch; clicking an option OR submitting typed
-      text answers the current step and advances. Signin step: renders the
-      app-supplied sign-in card and advances only when it reports signed in
-      (ui/chat stays auth-unaware via a renderSignin prop). Connect step: renders
-      the app-supplied connect card and advances only when it reports connected.
-      Signin and connect steps carry no answer text. Revisiting a step
-      pre-selects its prior answer; re-answering replaces it. A single
-      question-with-options step keeps the one-tap feel (click = answer =
-      complete). After the last step, emits each question answer in step order to
-      the consumer, which formats the resume message. Disabled while another turn
-      is active.
-    a11y: one step announced at a time; option rows are role=radio in a radiogroup, keyboard-toggleable and visible at rest (no hover gate); free-text input always present on question steps; back chevron is a labeled button; progress uses tabular-nums to avoid width jitter.
+      then at most one signin step, then connect steps). Shows ONE step at a
+      time. Header: a "current/total" pill (only when total > 1), the question
+      text, and a dismiss X that abandons the WHOLE sequence. The card never
+      replaces the composer: the real composer stays mounted below it, and
+      sending a fresh message there abandons the sequence exactly like the X.
+      Question step: single-select option rows (role=radio) each showing its
+      1-based position number right-aligned; pressing that number key selects
+      the row whenever focus is not in a text field; a free-text input below is
+      the "something else" escape hatch (so option lists never need an "Other"
+      row). ALL step navigation lives in one footer row, Back leftmost: Back
+      revisits the previous already-reached step, Skip advances past the current
+      question without answering (omitted from the composed reply), Next commits
+      the answer; a revisited signin/connect step shows a bare Forward instead
+      (its own card cannot re-fire completion). Signin/connect steps render
+      app-supplied cards (ui/chat stays auth/Composio-unaware) and advance on
+      their completion callbacks. Revisiting a question pre-selects its prior
+      answer; re-answering replaces it. A single question-with-options step
+      keeps the one-tap feel (click = answer = complete). After the last step,
+      emits each answered question in step order; the consumer encodes the
+      structured interaction-answers message. Disabled while another turn is
+      active.
+    a11y: one step announced at a time; option rows are role=radio in a radiogroup, keyboard-selectable by position number and visible at rest (no hover gate); free-text input always present on question steps; Back/Skip/Next are labeled buttons in one predictable footer; dismiss X labeled; progress pill carries an sr-only "N of X" and uses tabular-nums.
     since: 4
 
   - id: plan-ready-card
     title: Plan-ready card
-    purpose: In-chat surface shown when the agent finishes planning (plan mode) and calls plan_ready; presents the drafted plan and three ways forward as composer mode-menu rows, replacing the composer until the user chooses.
+    purpose: In-chat surface shown when the agent finishes planning (plan mode) and calls plan_ready; presents the drafted plan and three ways forward as composer mode-menu rows, floating above the always-mounted composer (typing there instead abandons it).
     anatomy: [title, plan-summary, coworker-row, autopilot-row, keep-planning-row]
     states: [default, disabled]
     variants: [default]
@@ -275,6 +281,49 @@ components:
       not a filled button. Disabled gates all three rows.
     a11y: title then plan summary read in order; three labeled row buttons visible at rest (no hover gate), keyboard-reachable, each with a foreground-color icon inline with its title; disabled state marks the surface aria-disabled and gates every row.
     since: 9
+
+  - id: suggest-reusable-card
+    title: Suggest-reusable card
+    purpose: In-chat offer shown when the agent finishes a mission cleanly and calls suggest_reusable; proposes saving the just-completed work as a reusable Skill or a scheduled Routine, floating above the always-mounted composer.
+    anatomy: [eyebrow, proposed-title, rationale, save-row, not-now-row]
+    states: [default, disabled]
+    variants: [skill, routine]
+    behavior: >-
+      Rendered from a pending interaction carrying a single suggest_reusable
+      step (reusableKind, title, rationale) on the terminal done frame. Unlike
+      every other interaction step, a lone suggest_reusable step keeps the
+      mission's board status at done (the offer is optional, nothing is
+      waiting). Shows the eyebrow, the model-proposed name prominently, and the
+      model's one-line rationale, then two full-width rows in the plan-ready
+      card's idiom: Save (Sparkles icon for a Skill, CalendarClock for a
+      Routine; label names the kind) sends a follow-up message asking the agent
+      to actually write the Skill/Routine, always as an execute turn regardless
+      of the composer's pinned mode, dismissing the offer locally first; "Not
+      now" dismisses locally. Typing in the composer instead abandons it like
+      any interaction card. Dismissal is per-offer (step id) and per
+      conversation.
+    a11y: eyebrow then title then rationale read in order; two labeled row buttons visible at rest (no hover gate), keyboard-reachable; disabled marks the surface aria-disabled and gates both rows.
+    since: 12
+
+  - id: interaction-answers-message
+    title: Interaction answers message
+    purpose: The structured user-message bubble a completed question sequence sends; shows each question with its answer instead of a flat "question - answer" text blob.
+    anatomy: [bubble-frame, question-line, answer-line]
+    states: [default]
+    variants: [questions-only, mixed-with-confirmations]
+    behavior: >-
+      A completed interaction card encodes its answers as a marker-prefixed
+      user message (houston:interaction-answers) whose plain-text body is what
+      the model reads, byte-identical to the pre-existing flat reply. The
+      renderer decodes the marker and shows an ordered list of line groups
+      inside one user-side bubble: each answered question as a small muted line
+      with the user's answer bold directly below; confirmation lines with no
+      question (a connected app, a sign-in) render as a lone bold line. Skipped
+      questions emit no line. Malformed or empty payloads fall through to the
+      plain-text bubble; connect/signin-only sequences stay hidden
+      auto-continue messages and never render this bubble.
+    a11y: reads in document order as question-then-answer pairs; pass-through content only, no interactive elements, no hover-gated information.
+    since: 12
 
   - id: deliverable-card
     title: Deliverable card

--- a/design/inventory/manifests/android.yaml
+++ b/design/inventory/manifests/android.yaml
@@ -67,3 +67,7 @@ components:
     status: not-started
   plan-ready-card:
     status: not-started
+  suggest-reusable-card:
+    status: not-started
+  interaction-answers-message:
+    status: not-started

--- a/design/inventory/manifests/ios.yaml
+++ b/design/inventory/manifests/ios.yaml
@@ -136,3 +136,9 @@ components:
   plan-ready-card:
     status: not-started
     notes: Plan-ready confirmation card (plan_ready) with Start working / Run on Autopilot / Keep planning; plan-mode flow not in mobile v1.
+  suggest-reusable-card:
+    status: not-started
+    notes: Save-as-Skill/Routine offer on a clean mission finish (suggest_reusable); not in mobile v1.
+  interaction-answers-message:
+    status: not-started
+    notes: Structured question/answer user bubble from a completed interaction sequence; not in mobile v1.

--- a/design/inventory/manifests/web.yaml
+++ b/design/inventory/manifests/web.yaml
@@ -95,6 +95,15 @@ components:
     status: implemented
     ref: "@houston-ai/chat ChatPlanReadyCard (chat-plan-ready-card + chat-plan-ready-card-model)"
 
+  suggest-reusable-card:
+    status: implemented
+    ref: "@houston-ai/chat ChatSuggestReusableCard (chat-suggest-reusable-card + chat-suggest-reusable-card-model)"
+
+  interaction-answers-message:
+    status: partial
+    ref: "@houston-ai/chat interaction-answers-message (decode) + UserInteractionAnswersMessage; encode in app/"
+    notes: Decode + render are shared; the marker encoder is composed in app/ (interaction-reply), mirroring skill-invocation-message.
+
   deliverable-card:
     status: implemented
     ref: "@houston-ai/review DeliverableCard / UserFeedback"

--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -133,9 +133,12 @@ Behavior is **never** written in surface code. Change it in the SDK, then bind.
 > signal: `needs_you` = handled / your attention, `error` = genuine failure. A
 > *clean* turn splits on whether it ended on an interaction: nothing outstanding →
 > the terminal `done`; ended on `ask_user`/`request_connection` → `needs_you`
-> carrying the `pendingInteraction` VM field (the composer-replacing question /
-> connect card). (`packages/sdk/src/modules/turns/turn-settle.ts` /
-> `vm-output.ts`; full lifecycle in `knowledge-base/architecture.md`.)
+> carrying the `pendingInteraction` VM field (the question / connect card shown
+> above the always-mounted composer). ONE exception: a lone `suggest_reusable`
+> step (the save-as-Skill/Routine offer) settles `done`, not `needs_you` — the
+> offer is optional, nothing is waiting on the user.
+> (`packages/sdk/src/modules/turns/turn-settle.ts` / `vm-output.ts`; full
+> lifecycle in `knowledge-base/architecture.md`.)
 
 ### b. Visual change → tokens procedure
 

--- a/packages/host/src/houston-prompt.ts
+++ b/packages/host/src/houston-prompt.ts
@@ -105,6 +105,8 @@ Before starting complex work, check whether a relevant Skill already exists.
 
 Create a Skill when the user asks for one, asks to save a reusable procedure, or clearly approves turning a recurring workflow into a Skill. Do not create Skills just because a task had many steps.
 
+When you finish a task that is clearly worth saving as a reusable Skill or scheduled Routine, genuinely reusable multi-step work and not a simple or one-off request, call the \`suggest_reusable\` tool right before your final message instead of asking about it in plain text or through \`ask_user\`. Houston shows the user a dismissible card offering to save it. Call it at most once per turn.
+
 Use this shape:
 
 \`\`\`

--- a/packages/protocol/src/domain/interaction.test.ts
+++ b/packages/protocol/src/domain/interaction.test.ts
@@ -33,6 +33,41 @@ test("isPendingInteraction accepts the step-sequence shape and rejects legacy sh
     }),
   ).toBe(false);
 
+  // A suggest_reusable step needs kind + id + reusableKind + title + rationale.
+  expect(
+    isPendingInteraction({
+      steps: [
+        {
+          kind: "suggest_reusable",
+          id: "r1",
+          reusableKind: "skill",
+          title: "Weekly report digest",
+          rationale: "This multi-step task looks reusable.",
+        },
+      ],
+    }),
+  ).toBe(true);
+  // An invalid reusableKind is invalid.
+  expect(
+    isPendingInteraction({
+      steps: [
+        {
+          kind: "suggest_reusable",
+          id: "r1",
+          reusableKind: "workflow",
+          title: "x",
+          rationale: "x",
+        },
+      ],
+    }),
+  ).toBe(false);
+  // A missing title/rationale is invalid.
+  expect(
+    isPendingInteraction({
+      steps: [{ kind: "suggest_reusable", id: "r1", reusableKind: "routine" }],
+    }),
+  ).toBe(false);
+
   // A signin step with a non-string reason is invalid.
   expect(
     isPendingInteraction({ steps: [{ kind: "signin", id: "s1", reason: 7 }] }),

--- a/packages/protocol/src/domain/interaction.ts
+++ b/packages/protocol/src/domain/interaction.ts
@@ -10,6 +10,13 @@
 // Houston first) FOLLOWED BY the connect steps (one per request_connection
 // call, deduped by toolkit). Any single kind alone still yields a valid
 // sequence.
+//
+// `suggest_reusable` is the ONE exception to "present → needs_you": the model
+// calls it on a clean finish to suggest saving the just-completed work as a
+// Skill or Routine, so the mission genuinely IS done. `turn-settle.ts` treats
+// a lone `suggest_reusable` step as `done`, not `needs_you` — see that file's
+// `finishOk`. It arrives on the same `done` frame and renders a card the same
+// way; only the board-status mapping differs.
 
 export interface InteractionOption {
   id: string;
@@ -31,7 +38,14 @@ export type InteractionStep =
     }
   | { kind: "signin"; id: string; reason?: string }
   | { kind: "connect"; id: string; toolkit: string; reason?: string }
-  | { kind: "plan_ready"; id: string; summary: string };
+  | { kind: "plan_ready"; id: string; summary: string }
+  | {
+      kind: "suggest_reusable";
+      id: string;
+      reusableKind: "skill" | "routine";
+      title: string;
+      rationale: string;
+    };
 
 /** The ordered steps the mission is waiting on: question steps first (at most 3),
  *  then at most one signin step, then connect steps. Always at least one step. */
@@ -50,6 +64,12 @@ export const isInteractionStep = (v: unknown): v is InteractionStep => {
     return v.reason === undefined || typeof v.reason === "string";
   if (v.kind === "connect") return typeof v.toolkit === "string";
   if (v.kind === "plan_ready") return typeof v.summary === "string";
+  if (v.kind === "suggest_reusable")
+    return (
+      (v.reusableKind === "skill" || v.reusableKind === "routine") &&
+      typeof v.title === "string" &&
+      typeof v.rationale === "string"
+    );
   return false;
 };
 

--- a/packages/runtime/src/backends/claude/backend-mcp.test.ts
+++ b/packages/runtime/src/backends/claude/backend-mcp.test.ts
@@ -86,10 +86,12 @@ test("backend options carry the houston MCP server and its allowlist", async () 
   expect(options.allowedTools).toContain("mcp__houston__integration_execute");
 });
 
-test("without the integrations gate only ask_user is allow-listed", async () => {
+test("without the integrations gate only ask_user + suggest_reusable are allow-listed", async () => {
   const options = await runTurn(undefined);
   expect(options.mcpServers?.houston).toBeDefined();
-  expect(options.allowedTools).toEqual(["mcp__houston__ask_user"]);
+  expect(new Set(options.allowedTools)).toEqual(
+    new Set(["mcp__houston__ask_user", "mcp__houston__suggest_reusable"]),
+  );
 });
 
 test("AskUserQuestion stays disabled — Houston ships its own ask_user", async () => {
@@ -117,9 +119,9 @@ test("plan mode builds the MCP server WITHOUT integrations — ask_user + plan_r
 });
 
 test("auto mode builds the MCP with integrations ON and ask_user OFF", async () => {
-  // Autopilot is the inverse of plan: it KEEPS the acting integration tools but
-  // drops the two blocking tools (ask_user, request_connection) so the agent
-  // never waits on the user.
+  // Autopilot is the inverse of plan: it KEEPS the acting integration tools (and
+  // the non-blocking suggest_reusable) but drops the two blocking tools
+  // (ask_user, request_connection) so the agent never waits on the user.
   const options = await runTurn(
     { baseUrl: "http://host.local", sandboxToken: "tok" },
     "auto",
@@ -127,12 +129,13 @@ test("auto mode builds the MCP with integrations ON and ask_user OFF", async () 
   expect(options.mcpServers?.houston).toBeDefined();
   const exposed = h.capturedMcp?.tools.map((t) => t.name) ?? [];
   expect(new Set(exposed)).toEqual(
-    new Set(["integration_search", "integration_execute"]),
+    new Set(["suggest_reusable", "integration_search", "integration_execute"]),
   );
   expect(exposed).not.toContain("ask_user");
   expect(exposed).not.toContain("request_connection");
   expect(new Set(options.allowedTools)).toEqual(
     new Set([
+      "mcp__houston__suggest_reusable",
       "mcp__houston__integration_search",
       "mcp__houston__integration_execute",
     ]),

--- a/packages/runtime/src/backends/claude/custom-tools.test.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.test.ts
@@ -69,18 +69,25 @@ const handlerOf = (t: SdkMcpToolDefinition): LooseHandler =>
 
 // --- gating ----------------------------------------------------------------
 
-test("exposes only ask_user when integrations are absent", () => {
+test("exposes ask_user + suggest_reusable when integrations are absent", () => {
+  // execute (undefined mode) keeps the always-on non-blocking tools: ask_user
+  // and suggest_reusable (plan_ready is plan-only, so it is stripped here).
   const { mcp, tools, serverName } = build(undefined);
   expect(serverName).toBe(HOUSTON_MCP_SERVER_NAME);
-  expect(tools.map((t) => t.name)).toEqual(["ask_user"]);
-  expect(mcp.allowedTools).toEqual(["mcp__houston__ask_user"]);
+  expect(new Set(tools.map((t) => t.name))).toEqual(
+    new Set(["ask_user", "suggest_reusable"]),
+  );
+  expect(new Set(mcp.allowedTools)).toEqual(
+    new Set(["mcp__houston__ask_user", "mcp__houston__suggest_reusable"]),
+  );
 });
 
-test("exposes ask_user + integration tools when the integrations gate is open", () => {
+test("exposes ask_user + suggest_reusable + integration tools when the integrations gate is open", () => {
   const { mcp, tools } = build(INTEGRATIONS);
   expect(new Set(tools.map((t) => t.name))).toEqual(
     new Set([
       "ask_user",
+      "suggest_reusable",
       "integration_search",
       "integration_execute",
       "request_connection",
@@ -89,6 +96,7 @@ test("exposes ask_user + integration tools when the integrations gate is open", 
   expect(new Set(mcp.allowedTools)).toEqual(
     new Set([
       "mcp__houston__ask_user",
+      "mcp__houston__suggest_reusable",
       "mcp__houston__integration_search",
       "mcp__houston__integration_execute",
       "mcp__houston__request_connection",
@@ -125,27 +133,47 @@ test("plan_ready is exposed ONLY in plan mode", () => {
   );
 });
 
-test("auto mode keeps the integration tools but drops the blocking tools", () => {
+test("suggest_reusable is bridged for execute/auto but stripped from plan", () => {
+  // The inverse of plan_ready: kept in execute (undefined) and auto, filtered
+  // out of plan by `toolNamesForMode`, even though it is in the built set.
+  expect(build(INTEGRATIONS).tools.map((t) => t.name)).toContain(
+    "suggest_reusable",
+  );
+  expect(build(INTEGRATIONS, "execute").tools.map((t) => t.name)).toContain(
+    "suggest_reusable",
+  );
+  expect(build(INTEGRATIONS, "auto").tools.map((t) => t.name)).toContain(
+    "suggest_reusable",
+  );
+  expect(build(INTEGRATIONS, "plan").tools.map((t) => t.name)).not.toContain(
+    "suggest_reusable",
+  );
+});
+
+test("auto mode keeps the integration + suggest_reusable tools but drops the blocking tools", () => {
   const { tools, mcp } = build(INTEGRATIONS, "auto");
   // Autopilot never waits on the user: ask_user + request_connection are gone
-  // (and plan_ready is plan-only), the acting integration tools stay.
+  // (and plan_ready is plan-only), the acting integration tools stay, and
+  // suggest_reusable stays too (it never blocks the turn).
   expect(new Set(tools.map((t) => t.name))).toEqual(
-    new Set(["integration_search", "integration_execute"]),
+    new Set(["suggest_reusable", "integration_search", "integration_execute"]),
   );
   expect(new Set(mcp.allowedTools)).toEqual(
     new Set([
+      "mcp__houston__suggest_reusable",
       "mcp__houston__integration_search",
       "mcp__houston__integration_execute",
     ]),
   );
 });
 
-test("auto mode with no integrations gate exposes NO custom tools", () => {
-  // The always-on custom tools are ask_user (auto drops it) and plan_ready
-  // (plan-only) — so with the integration gate closed the server exposes nothing.
+test("auto mode with no integrations gate exposes only suggest_reusable", () => {
+  // The always-on custom tools are ask_user (auto drops it), plan_ready
+  // (plan-only), and suggest_reusable (auto keeps it) — so with the integration
+  // gate closed the server exposes exactly suggest_reusable.
   const { tools, mcp } = build(undefined, "auto");
-  expect(tools).toEqual([]);
-  expect(mcp.allowedTools).toEqual([]);
+  expect(tools.map((t) => t.name)).toEqual(["suggest_reusable"]);
+  expect(mcp.allowedTools).toEqual(["mcp__houston__suggest_reusable"]);
 });
 
 test("the allowlist always matches the exposed tool set", () => {

--- a/packages/runtime/src/backends/claude/custom-tools.ts
+++ b/packages/runtime/src/backends/claude/custom-tools.ts
@@ -17,10 +17,11 @@ import {
   makeIntegrationTools,
 } from "../../session/tools/integrations";
 import { makePlanReadyTool } from "../../session/tools/plan-ready";
+import { makeSuggestReusableTool } from "../../session/tools/suggest-reusable";
 
 /**
  * Bridge Houston's pi-shaped custom tools (`ask_user`, `plan_ready`,
- * `request_connection`, `integration_search`, `integration_execute`) onto the Claude Agent SDK's
+ * `suggest_reusable`, `request_connection`, `integration_search`, `integration_execute`) onto the Claude Agent SDK's
  * in-process MCP transport (`createSdkMcpServer`), so the `anthropic` backend —
  * a `claude` subprocess that only sees SDK built-ins — can call the SAME tools
  * the pi backend exposes.
@@ -77,6 +78,8 @@ export interface HoustonMcpInput {
    * `request_connection`) and `plan_ready` while KEEPING `integration_search` /
    * `integration_execute`, and "execute" (or absent) exposes the full built set
    * minus `plan_ready` (plan-only). `plan_ready` never survives outside plan.
+   * `suggest_reusable` mirrors the acting tools' reach — it survives execute AND
+   * auto (it never blocks the turn) but never plan (plan is not a finished task).
    */
   mode?: TurnMode;
 }
@@ -129,6 +132,9 @@ export function buildHoustonMcpServer(input: HoustonMcpInput): HoustonMcp {
     // plan_ready is in the built set but name-gated by `toolNamesForMode`: it
     // survives only on a plan turn (filtered out of execute/auto below).
     makePlanReadyTool(),
+    // suggest_reusable is the inverse gating: name-kept in execute/auto, filtered
+    // out of plan by `toolNamesForMode`.
+    makeSuggestReusableTool(),
     ...(input.integrations ? makeIntegrationTools(input.integrations) : []),
   ] as unknown as BridgedPiTool[];
   const allowed = new Set(

--- a/packages/runtime/src/session/conversation-cache.ts
+++ b/packages/runtime/src/session/conversation-cache.ts
@@ -20,6 +20,7 @@ import { makeIdTokenProvider } from "./tools/gcp-id-token";
 import { makeIntegrationTools } from "./tools/integrations";
 import { makePlanReadyTool } from "./tools/plan-ready";
 import { makeRunCodeTool } from "./tools/run-code";
+import { makeSuggestReusableTool } from "./tools/suggest-reusable";
 import type { ProvidedContext } from "./workspace-context";
 
 /**
@@ -47,6 +48,13 @@ const askUserTool = makeAskUserTool();
 // name is in the mode's allowlist). Records the turn's plan-ready step so it
 // rides the terminal `done` frame as a plan-approval card.
 const planReadyTool = makePlanReadyTool();
+
+// The reusable-suggestion tool: registered always, reaches execute/auto via the
+// tool-selection allowlist and is filtered out of plan by name (`toolNamesForMode`).
+// Records the turn's suggest-reusable step so a clean finish can ride the terminal
+// `done` frame as a dismissible save-as-Skill/Routine card, without flipping the
+// board to `needs_you`.
+const suggestReusableTool = makeSuggestReusableTool();
 
 // Integration tools (Composio, platform mode): available whenever this runtime
 // can reach its host with a sandbox token (server mode — local desktop +
@@ -92,6 +100,7 @@ const piBackend = createPiBackend({
     ...fileTools,
     askUserTool,
     planReadyTool,
+    suggestReusableTool,
     ...(runCodeTool ? [runCodeTool] : []),
     ...integrationTools,
   ],

--- a/packages/runtime/src/session/interaction.test.ts
+++ b/packages/runtime/src/session/interaction.test.ts
@@ -6,6 +6,7 @@ import {
   recordPlanReady,
   recordQuestions,
   recordSignin,
+  recordSuggestReusable,
   runWithInteractionCapture,
 } from "./interaction";
 
@@ -162,6 +163,13 @@ test("recording outside a turn is a no-op (undefined store)", () => {
   expect(() => recordConnection({ toolkit: "gmail" })).not.toThrow();
   expect(() => recordSignin({ reason: "orphan" })).not.toThrow();
   expect(() => recordPlanReady({ summary: "orphan plan" })).not.toThrow();
+  expect(() =>
+    recordSuggestReusable({
+      reusableKind: "skill",
+      title: "orphan",
+      rationale: "no turn",
+    }),
+  ).not.toThrow();
 });
 
 test("recordPlanReady records the single plan-ready step (id p1, trimmed)", () => {
@@ -205,6 +213,80 @@ test("the protocol guard accepts a valid plan_ready step and rejects a bad summa
   );
   // No id is invalid (shared step rule).
   expect(isInteractionStep({ kind: "plan_ready", summary: "x" })).toBe(false);
+});
+
+test("recordSuggestReusable records the single suggest-reusable step (id r1, trimmed)", () => {
+  const holder = newInteractionHolder();
+  runWithInteractionCapture(holder, () =>
+    recordSuggestReusable({
+      reusableKind: "routine",
+      title: "  Morning digest  ",
+      rationale: "  Runs on its own each day.  ",
+    }),
+  );
+  expect(holder.pending).toEqual({
+    steps: [
+      {
+        kind: "suggest_reusable",
+        id: "r1",
+        reusableKind: "routine",
+        title: "Morning digest",
+        rationale: "Runs on its own each day.",
+      },
+    ],
+  });
+});
+
+test("a suggest-reusable step ALONE surfaces as the pending sequence", () => {
+  const holder = newInteractionHolder();
+  runWithInteractionCapture(holder, () =>
+    recordSuggestReusable({
+      reusableKind: "skill",
+      title: "Weekly report",
+      rationale: "Reuse it next week.",
+    }),
+  );
+  expect(holder.pending).toEqual({
+    steps: [
+      {
+        kind: "suggest_reusable",
+        id: "r1",
+        reusableKind: "skill",
+        title: "Weekly report",
+        rationale: "Reuse it next week.",
+      },
+    ],
+  });
+});
+
+test("suggest-reusable is FALLBACK-ONLY: a question this same turn wins and drops it", () => {
+  const holder = newInteractionHolder();
+  runWithInteractionCapture(holder, () => {
+    recordSuggestReusable({
+      reusableKind: "skill",
+      title: "Weekly report",
+      rationale: "Reuse it next week.",
+    });
+    recordQuestions([q("q1", "Which week?")]);
+  });
+  // The question means the mission is NOT done, so it takes priority and the
+  // suggestion is dropped from `pending` entirely — never surfaced alongside.
+  expect(holder.pending).toEqual({ steps: [q("q1", "Which week?")] });
+});
+
+test("plan-ready wins over a suggest-reusable step set the same turn", () => {
+  const holder = newInteractionHolder();
+  runWithInteractionCapture(holder, () => {
+    recordSuggestReusable({
+      reusableKind: "skill",
+      title: "Weekly report",
+      rationale: "Reuse it next week.",
+    });
+    recordPlanReady({ summary: "Here is the plan." });
+  });
+  expect(holder.pending).toEqual({
+    steps: [{ kind: "plan_ready", id: "p1", summary: "Here is the plan." }],
+  });
 });
 
 test("the holder survives async work inside the capture (ALS propagation)", async () => {

--- a/packages/runtime/src/session/interaction.ts
+++ b/packages/runtime/src/session/interaction.ts
@@ -24,6 +24,13 @@ import type {
  *   everything the model queued in one flow. Any single kind alone still yields
  *   a valid sequence.
  *
+ * Precedence across the step kinds (see {@link InteractionHolder.pending}): a
+ * `plan_ready` step OWNS the interaction exclusively; otherwise the sequence is
+ * the questions, then the signin step, then the connects; and a
+ * `suggest_reusable` step is FALLBACK-ONLY — it surfaces solely when there are
+ * no other steps at all this turn, because it means the mission genuinely IS
+ * done (any question/signin/connect/plan_ready means it is not).
+ *
  * Turn-scoping mechanism (mirrors acting-context.ts): an `AsyncLocalStorage`
  * whose store — a fresh mutable holder — is established for the DURATION of
  * `session.prompt()`. The tool `execute` callbacks run inside that same async
@@ -38,6 +45,10 @@ type QuestionStep = Extract<InteractionStep, { kind: "question" }>;
 type SigninStep = Extract<InteractionStep, { kind: "signin" }>;
 type ConnectStep = Extract<InteractionStep, { kind: "connect" }>;
 type PlanReadyStep = Extract<InteractionStep, { kind: "plan_ready" }>;
+type SuggestReusableStep = Extract<
+  InteractionStep,
+  { kind: "suggest_reusable" }
+>;
 
 export interface InteractionHolder {
   /** Question steps from the last `ask_user` call this turn (replace semantics). */
@@ -49,6 +60,14 @@ export interface InteractionHolder {
   /** The single plan-ready step, once the model called `plan_ready` (plan mode
    *  only). When set it OWNS the interaction exclusively — see {@link pending}. */
   readonly planReady: PlanReadyStep | undefined;
+  /** The single suggest-reusable step (id `r1`), once the model called
+   *  `suggest_reusable` on a clean finish to offer saving the work as a Skill or
+   *  Routine. CRITICALLY DIFFERENT FROM {@link planReady}: it does NOT own the
+   *  interaction exclusively. It is a FALLBACK ONLY — used solely when there are
+   *  no other steps at all this turn. Questions/signin/connects/planReady all
+   *  take priority, because any of those means the mission genuinely is not done
+   *  yet, whereas a suggestion means it IS done. See {@link pending}. */
+  readonly suggestReusable: SuggestReusableStep | undefined;
   /** The recorded sequence — question steps, then the signin step, then connect
    *  steps — or undefined when the model asked for nothing this turn. Derived:
    *  read after prompt(). */
@@ -60,6 +79,7 @@ class Holder implements InteractionHolder {
   signin: SigninStep | undefined;
   readonly connects: ConnectStep[] = [];
   planReady: PlanReadyStep | undefined;
+  suggestReusable: SuggestReusableStep | undefined;
 
   get pending(): PendingInteraction | undefined {
     // A plan-ready step is exclusive: the plan-mode overlay tells the model to
@@ -72,7 +92,13 @@ class Holder implements InteractionHolder {
       ...(this.signin ? [this.signin] : []),
       ...this.connects,
     ];
-    return steps.length > 0 ? { steps } : undefined;
+    if (steps.length > 0) return { steps };
+    // suggest_reusable is FALLBACK-ONLY: it surfaces solely when nothing else
+    // was queued this turn. Any question/signin/connect above means the mission
+    // is not done, so it wins and the suggestion is dropped entirely — a
+    // suggestion must NEVER flip the board to `needs_you`.
+    if (this.suggestReusable) return { steps: [this.suggestReusable] };
+    return undefined;
   }
 }
 
@@ -156,5 +182,29 @@ export function recordPlanReady(input: { summary: string }): void {
     kind: "plan_ready",
     id: "p1",
     summary: input.summary.trim(),
+  };
+}
+
+/**
+ * Record the single suggest-reusable step for this turn (the model called
+ * `suggest_reusable` on a clean finish to offer saving the work as a Skill or
+ * Routine). There is at most one such step (id `r1`); it is FALLBACK-ONLY —
+ * surfaced only when nothing else was queued this turn (see
+ * {@link InteractionHolder.pending}). The title and rationale are trimmed. A
+ * no-op outside a turn.
+ */
+export function recordSuggestReusable(input: {
+  reusableKind: "skill" | "routine";
+  title: string;
+  rationale: string;
+}): void {
+  const holder = store.getStore();
+  if (!holder) return;
+  (holder as Holder).suggestReusable = {
+    kind: "suggest_reusable",
+    id: "r1",
+    reusableKind: input.reusableKind,
+    title: input.title.trim(),
+    rationale: input.rationale.trim(),
   };
 }

--- a/packages/runtime/src/session/tool-selection.test.ts
+++ b/packages/runtime/src/session/tool-selection.test.ts
@@ -9,6 +9,7 @@ import {
 } from "./tool-selection";
 import { CLAMPED_FILE_TOOL_NAMES } from "./tools/clamped-fs";
 import { PLAN_READY_TOOL_NAME } from "./tools/plan-ready";
+import { SUGGEST_REUSABLE_TOOL_NAME } from "./tools/suggest-reusable";
 
 describe("buildToolSelection", () => {
   test("local mode keeps clamped file tools plus ask_user and bash", () => {
@@ -19,6 +20,7 @@ describe("buildToolSelection", () => {
     expect(selection.toolNames).toEqual([
       ...CLAMPED_FILE_TOOL_NAMES,
       "ask_user",
+      "suggest_reusable",
       "bash",
     ]);
     expect(selection.includeRunCode).toBe(false);
@@ -32,6 +34,7 @@ describe("buildToolSelection", () => {
     expect(selection.toolNames).toEqual([
       ...CLAMPED_FILE_TOOL_NAMES,
       "ask_user",
+      "suggest_reusable",
       "run_code",
     ]);
     expect(selection.includeRunCode).toBe(true);
@@ -45,6 +48,7 @@ describe("buildToolSelection", () => {
     expect(selection.toolNames).toEqual([
       ...CLAMPED_FILE_TOOL_NAMES,
       "ask_user",
+      "suggest_reusable",
     ]);
     expect(selection.toolNames).not.toContain("bash");
     expect(selection.toolNames).not.toContain("run_code");
@@ -68,6 +72,7 @@ describe("buildToolSelection", () => {
     expect(selection.toolNames).toEqual([
       ...CLAMPED_FILE_TOOL_NAMES,
       "ask_user",
+      "suggest_reusable",
       "integration_search",
       "integration_execute",
       "request_connection",
@@ -129,6 +134,7 @@ describe("autoToolNames", () => {
     // blocking tools. Order is preserved (filter, not reorder).
     expect(autoToolNames(local.toolNames)).toEqual([
       ...CLAMPED_FILE_TOOL_NAMES,
+      "suggest_reusable",
       "bash",
       "integration_search",
       "integration_execute",
@@ -159,6 +165,7 @@ describe("autoToolNames", () => {
     });
     expect(autoToolNames(disabled.toolNames)).toEqual([
       ...CLAMPED_FILE_TOOL_NAMES,
+      "suggest_reusable",
     ]);
   });
 
@@ -240,6 +247,30 @@ describe("toolNamesForMode dispatcher", () => {
       const withPlanReady = [...local.toolNames, PLAN_READY_TOOL_NAME];
       expect(toolNamesForMode("execute", withPlanReady)).toEqual(
         local.toolNames,
+      );
+    });
+  });
+
+  // suggest_reusable is the inverse of plan_ready: it must reach execute AND
+  // auto (it never blocks the turn) but NEVER plan (plan is read-only planning,
+  // not a finished task). It stays out of plan automatically — it is not in
+  // PLAN_MODE_TOOL_NAMES — and stays in auto because it is not in
+  // AUTO_MODE_EXCLUDED_TOOL_NAMES.
+  describe("suggest_reusable gating", () => {
+    const withSuggest = [...local.toolNames, SUGGEST_REUSABLE_TOOL_NAME];
+
+    test("present in execute / absent (undefined) and auto, but never plan", () => {
+      expect(toolNamesForMode("execute", withSuggest)).toContain(
+        SUGGEST_REUSABLE_TOOL_NAME,
+      );
+      expect(toolNamesForMode(undefined, withSuggest)).toContain(
+        SUGGEST_REUSABLE_TOOL_NAME,
+      );
+      expect(toolNamesForMode("auto", withSuggest)).toContain(
+        SUGGEST_REUSABLE_TOOL_NAME,
+      );
+      expect(toolNamesForMode("plan", withSuggest)).not.toContain(
+        SUGGEST_REUSABLE_TOOL_NAME,
       );
     });
   });

--- a/packages/runtime/src/session/tool-selection.ts
+++ b/packages/runtime/src/session/tool-selection.ts
@@ -6,6 +6,7 @@ import {
   REQUEST_CONNECTION_TOOL_NAME,
 } from "./tools/integrations";
 import { PLAN_READY_TOOL_NAME } from "./tools/plan-ready";
+import { SUGGEST_REUSABLE_TOOL_NAME } from "./tools/suggest-reusable";
 
 export type CodeExecutionMode = "local" | "remote" | "disabled";
 
@@ -115,6 +116,13 @@ export function buildToolSelection(input: ToolSelectionInput): ToolSelection {
       // ask_user is available in EVERY mode/backend — any blocking question,
       // choice, or approval goes through it instead of plain-text.
       ASK_USER_TOOL_NAME,
+      // suggest_reusable is available in execute AND auto — it holds no
+      // credential, takes no real-world action, and never blocks the turn (a
+      // clean finish offering to save the work as a Skill/Routine). It must
+      // NEVER reach plan mode, and it won't automatically: PLAN_MODE_TOOL_NAMES
+      // (the plan allowlist) doesn't list it, so `planToolNames` filters it out;
+      // and it isn't in AUTO_MODE_EXCLUDED_TOOL_NAMES, so auto keeps it.
+      SUGGEST_REUSABLE_TOOL_NAME,
       ...executable,
       ...(input.integrations ? INTEGRATION_TOOL_NAMES : []),
     ],

--- a/packages/runtime/src/session/tools/ask-user.ts
+++ b/packages/runtime/src/session/tools/ask-user.ts
@@ -40,7 +40,7 @@ const AskUserParams = Type.Object({
           }),
           {
             description:
-              "Optional 2-6 short, mutually-exclusive choices for this question, offered as single-select rows. Use for a choice or an approval; omit for an open question.",
+              "Optional 2-6 short, mutually-exclusive choices for this question, offered as single-select rows. Use for a choice or an approval; omit for an open question. The user can always type a custom answer instead of picking one, so never add a catch-all choice like 'Other' or 'Something else' to this list.",
           },
         ),
       ),

--- a/packages/runtime/src/session/tools/suggest-reusable.test.ts
+++ b/packages/runtime/src/session/tools/suggest-reusable.test.ts
@@ -1,0 +1,122 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { expect, test } from "vitest";
+import {
+  newInteractionHolder,
+  runWithInteractionCapture,
+} from "../interaction";
+import {
+  makeSuggestReusableTool,
+  SUGGEST_REUSABLE_TOOL_NAME,
+} from "./suggest-reusable";
+
+/**
+ * The execute/auto reusable-suggestion tool. These pin: the tool records the
+ * single suggest-reusable step (id `r1`), trims title/rationale, rejects an
+ * empty title or rationale, returns the do-not-repeat-and-finish-normally
+ * instruction (NOT an end-your-turn block), and is a no-op outside a turn.
+ */
+
+const suggestReusable = makeSuggestReusableTool();
+
+// pi's tool.execute takes (id, params, signal, onUpdate, ctx); the last three
+// are irrelevant here, so one helper supplies them.
+const ctx = {} as unknown as ExtensionContext;
+const run = (params: unknown) =>
+  suggestReusable.execute("id", params as never, undefined, undefined, ctx);
+
+test("is named suggest_reusable", () => {
+  expect(suggestReusable.name).toBe("suggest_reusable");
+  expect(SUGGEST_REUSABLE_TOOL_NAME).toBe("suggest_reusable");
+});
+
+test("records the suggest-reusable step with an r1 id and does NOT end the turn", async () => {
+  const holder = newInteractionHolder();
+  const out = await runWithInteractionCapture(holder, () =>
+    run({
+      reusableKind: "skill",
+      title: "Weekly sales summary",
+      rationale: "Saves you rebuilding it every Monday.",
+    }),
+  );
+  expect(holder.pending).toEqual({
+    steps: [
+      {
+        kind: "suggest_reusable",
+        id: "r1",
+        reusableKind: "skill",
+        title: "Weekly sales summary",
+        rationale: "Saves you rebuilding it every Monday.",
+      },
+    ],
+  });
+  const text = (out.content[0] as { text: string }).text;
+  expect(text).toMatch(/did NOT end your turn/i);
+  expect(text).toMatch(/do not repeat/i);
+});
+
+test("carries the routine kind through unchanged", async () => {
+  const holder = newInteractionHolder();
+  await runWithInteractionCapture(holder, () =>
+    run({
+      reusableKind: "routine",
+      title: "Morning digest",
+      rationale: "Runs on its own each day.",
+    }),
+  );
+  expect(holder.pending?.steps[0]).toMatchObject({
+    kind: "suggest_reusable",
+    reusableKind: "routine",
+  });
+});
+
+test("trims the title and rationale before recording", async () => {
+  const holder = newInteractionHolder();
+  await runWithInteractionCapture(holder, () =>
+    run({
+      reusableKind: "skill",
+      title: "   Book the trip   ",
+      rationale: "   Reuse the whole flow next time.   ",
+    }),
+  );
+  expect(holder.pending).toEqual({
+    steps: [
+      {
+        kind: "suggest_reusable",
+        id: "r1",
+        reusableKind: "skill",
+        title: "Book the trip",
+        rationale: "Reuse the whole flow next time.",
+      },
+    ],
+  });
+});
+
+test("throws on an empty / whitespace title and records nothing", async () => {
+  const holder = newInteractionHolder();
+  await expect(
+    runWithInteractionCapture(holder, () =>
+      run({ reusableKind: "skill", title: "   ", rationale: "why" }),
+    ),
+  ).rejects.toThrow(/non-empty title/i);
+  expect(holder.pending).toBeUndefined();
+});
+
+test("throws on an empty / whitespace rationale and records nothing", async () => {
+  const holder = newInteractionHolder();
+  await expect(
+    runWithInteractionCapture(holder, () =>
+      run({ reusableKind: "routine", title: "A title", rationale: "   " }),
+    ),
+  ).rejects.toThrow(/non-empty rationale/i);
+  expect(holder.pending).toBeUndefined();
+});
+
+test("recording outside a turn is a no-op but still returns the instruction", async () => {
+  const out = await run({
+    reusableKind: "skill",
+    title: "Orphan skill",
+    rationale: "No turn around it.",
+  });
+  const text = (out.content[0] as { text: string }).text;
+  expect(text).toMatch(/Houston will show/i);
+});

--- a/packages/runtime/src/session/tools/suggest-reusable.ts
+++ b/packages/runtime/src/session/tools/suggest-reusable.ts
@@ -1,0 +1,81 @@
+import { defineTool } from "@earendil-works/pi-coding-agent";
+import { type Static, Type } from "typebox";
+import { recordSuggestReusable } from "../interaction";
+
+/**
+ * The reusable-suggestion tool — available in execute AND auto. When the model
+ * has FINISHED a task whose work is clearly worth keeping (genuinely reusable,
+ * multi-step work), it calls `suggest_reusable` right before its final message
+ * INSTEAD OF asking the user about it in plain text or via `ask_user`. Executing
+ * it records the single suggest-reusable step of this turn's interaction sequence
+ * (carried on the terminal `done` frame + the persisted assistant message), and
+ * Houston shows the user a dismissible card offering to save the work as a Skill
+ * or a scheduled Routine.
+ *
+ * CRITICALLY, this is NOT a turn-ending block like `plan_ready`: the task is
+ * genuinely DONE, so the model wraps up its final message to the user as usual.
+ * The suggestion is an optional offer, never something blocking completion — a
+ * LONE `suggest_reusable` step keeps the mission on `done`, not `needs_you` (see
+ * `interaction.ts`'s fallback-only precedence and `turn-settle.ts`'s `finishOk`).
+ *
+ * It holds no credential and makes no network call, and it is name-gated OUT of
+ * plan mode by `session/tool-selection.ts` (plan is read-only planning, not a
+ * finished task). It reaches execute and auto because it never blocks the turn.
+ */
+
+const SuggestReusableParams = Type.Object({
+  reusableKind: Type.Union([Type.Literal("skill"), Type.Literal("routine")], {
+    description:
+      'What kind of reusable thing this work should be saved as. Use "skill" for a reusable procedure the user runs on demand, or "routine" for work that should run automatically on a schedule.',
+  }),
+  title: Type.String({
+    description:
+      'A short, plain-language name for the suggested Skill or Routine, in the user\'s language. A few words at most (e.g. "Weekly sales summary").',
+  }),
+  rationale: Type.String({
+    description:
+      "One short sentence, in the user's language, explaining why saving this is useful: what it will save them next time. The user sees this on the card.",
+  }),
+});
+type SuggestReusableParams = Static<typeof SuggestReusableParams>;
+
+/** The instruction returned to the model after the suggestion is recorded. */
+const SUGGEST_REUSABLE_INSTRUCTION =
+  "Your suggestion was recorded. Houston will show the user a dismissible card offering to save this work. Do not repeat the suggestion in plain text and do not ask about it again. This did NOT end your turn. The task is done, so finish your final message to the user normally.";
+
+/** The reusable-suggestion tool (execute + auto; never plan). */
+export function makeSuggestReusableTool() {
+  return defineTool({
+    name: "suggest_reusable",
+    label: "Suggest saving as reusable",
+    description:
+      "Suggest saving the just-completed work as a reusable Skill or a scheduled Routine. Call this when you finish a task that is clearly worth reusing (genuinely reusable, multi-step work, not a simple or one-off request), right before your final message, INSTEAD OF asking about it in plain text or via ask_user. Houston shows the user a dismissible card offering to save it. Call it at most once per turn, and still finish your final message normally. This does not end your turn.",
+    promptSnippet: "Suggest saving the completed work as a Skill or Routine",
+    parameters: SuggestReusableParams,
+    executionMode: "sequential",
+    async execute(_id: string, params: SuggestReusableParams) {
+      const title = params.title?.trim();
+      const rationale = params.rationale?.trim();
+      if (!title) {
+        throw new Error("suggest_reusable needs a non-empty title.");
+      }
+      if (!rationale) {
+        throw new Error("suggest_reusable needs a non-empty rationale.");
+      }
+      recordSuggestReusable({
+        reusableKind: params.reusableKind,
+        title,
+        rationale,
+      });
+      return {
+        content: [
+          { type: "text" as const, text: SUGGEST_REUSABLE_INSTRUCTION },
+        ],
+        details: { reusableKind: params.reusableKind, title, rationale },
+      };
+    },
+  });
+}
+
+/** The tool name — pi's allowlist needs it alongside the object. */
+export const SUGGEST_REUSABLE_TOOL_NAME = "suggest_reusable";

--- a/packages/sdk/src/modules/turns/turn-settle.test.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.test.ts
@@ -268,6 +268,51 @@ test("finishOk with a captured interaction settles needs_you and keeps the inter
   expect(statuses).toEqual([["completed", undefined]]);
 });
 
+test("finishOk with a LONE suggest_reusable step settles the card to done, not needs_you", () => {
+  const { statuses, output } = recorder();
+  const s = newTurnState("Houston/Bo", "activity-suggest", output);
+  s.text = "Done. Sales summary is ready.";
+  // The mission genuinely IS done — the suggestion card is an optional offer, so
+  // it must NOT flip the board to needs_you (the core property of the feature).
+  s.pendingInteraction = {
+    steps: [
+      {
+        kind: "suggest_reusable",
+        id: "r1",
+        reusableKind: "skill",
+        title: "Weekly sales summary",
+        rationale: "Saves you rebuilding it every Monday.",
+      },
+    ],
+  };
+  finishOk(s);
+  expect(s.terminal).toBe("done");
+  expect(statuses).toEqual([["completed", undefined]]);
+});
+
+test("finishOk with suggest_reusable co-occurring with a question still settles needs_you", () => {
+  const { output } = recorder();
+  const s = newTurnState("Houston/Bo", "activity-suggest-mixed", output);
+  s.text = "which one?";
+  // Defensive: the holder never produces this combination (suggest_reusable is
+  // fallback-only), but if anything else is outstanding the mission is NOT done,
+  // so the `only-suggestion` guard must not fire.
+  s.pendingInteraction = {
+    steps: [
+      { kind: "question", id: "q1", question: "Which week?" },
+      {
+        kind: "suggest_reusable",
+        id: "r1",
+        reusableKind: "skill",
+        title: "Weekly sales summary",
+        rationale: "Saves you rebuilding it every Monday.",
+      },
+    ],
+  };
+  finishOk(s);
+  expect(s.terminal).toBe("needs_you");
+});
+
 /**
  * finishErr — the not-connected refusal (HOU-676). A logged-out send is
  * refused BEFORE the message reaches the engine, so it must settle as the

--- a/packages/sdk/src/modules/turns/turn-settle.ts
+++ b/packages/sdk/src/modules/turns/turn-settle.ts
@@ -90,6 +90,12 @@ const invisibleFinal = (s: TurnState) =>
  * board split is on the captured interaction (the `done` frame stashes it into
  * `s.pendingInteraction` before calling here): the turn ended asking the user
  * for something → `needs_you`; it ended with nothing outstanding → `done`.
+ *
+ * The ONE exception is a LONE `suggest_reusable` step: the mission genuinely IS
+ * done, and the card is just an optional offer to save the work as a Skill or
+ * Routine, not something blocking completion — so it settles `done`, not
+ * `needs_you`. Any other step kind, or `suggest_reusable` co-occurring with
+ * anything else, still means `needs_you`.
  */
 export function finishOk(s: TurnState): void {
   if (s.settled) return;
@@ -101,7 +107,10 @@ export function finishOk(s: TurnState): void {
     data: { result: s.text, cost_usd: null, duration_ms: null, usage: s.usage },
   });
   s.output.sessionStatus(s.agentPath, s.sessionKey, "completed");
-  s.terminal = s.pendingInteraction ? "needs_you" : "done";
+  const onlySuggestion =
+    s.pendingInteraction?.steps.length === 1 &&
+    s.pendingInteraction.steps[0].kind === "suggest_reusable";
+  s.terminal = s.pendingInteraction && !onlySuggestion ? "needs_you" : "done";
 }
 
 /**

--- a/packages/web/e2e/interaction.spec.ts
+++ b/packages/web/e2e/interaction.spec.ts
@@ -2,19 +2,23 @@ import { FAKE_HOST_URL } from "@houston/fake-host";
 import { expect, test } from "./support/fixtures";
 
 /**
- * Element 4 (v3): the pending-interaction hand-off, now a STEPPER. When a turn
+ * Element 4 (v3): the pending-interaction hand-off, a STEPPER. When a turn
  * ends on an `ask_user` / `request_connection`, its `done` frame carries a
  * `PendingInteraction { steps }`; the SDK settles the board to `needs_you` and
- * the app REPLACES the composer with ONE `ChatInteractionCard` that walks the
- * user through the steps ONE AT A TIME with a "N of X" progress indicator. These
- * specs arm the fake host's `/__test__/chat-interaction` control with the new
- * `{ steps }` shape, then drive the whole seam: card replaces composer -> user
- * answers each step -> normal composer returns.
+ * the app shows ONE `ChatInteractionCard` ABOVE the composer (which stays
+ * mounted and usable throughout) that walks the user through the steps ONE AT
+ * A TIME with a "current/total" pill. Typing a fresh message directly into the
+ * composer while the card shows abandons the whole sequence and sends the
+ * typed text as a normal message instead of an answer. These specs arm the
+ * fake host's `/__test__/chat-interaction` control with the `{ steps }`
+ * shape, then drive the whole seam: card appears above the composer -> user
+ * answers each step (or abandons) -> card retires, composer stands alone.
  *
  * A turn's steps are the question steps (from one ask_user call, 1 to 3) FOLLOWED
  * BY at most one signin step (the user must sign in to Houston first) FOLLOWED BY
  * the connect steps (one per request_connection). Question answers compose one
- * user message on completion; a signin/connect-only sequence keeps the hidden
+ * structured user message on completion (each question in muted text, its answer
+ * in bold directly below); a signin/connect-only sequence keeps the hidden
  * auto-continue. Real Google SSO cannot run in the harness, so the signin specs
  * assert the card RENDERS (button + reason + progress), not the landing.
  */
@@ -36,12 +40,13 @@ async function startMission(
 }
 
 /**
- * The three-question stepper: only ONE step shows at a time with a "N of 3"
- * progress. Answer step 1 by option, step 2 by free text, step 3 by option; the
- * completion composes ONE user message carrying all three answers, and the
- * normal follow-up composer returns.
+ * The three-question stepper: only ONE step shows at a time with a
+ * "current/total" pill. Answer step 1 by option, step 2 by free text, step 3
+ * by option; the completion composes ONE structured user message carrying all
+ * three answers, and the normal follow-up composer (which was visible the
+ * whole time) is all that's left.
  */
-test("walks three questions one at a time and composes a single reply", async ({
+test("walks three questions one at a time and composes a single structured reply", async ({
   page,
   request,
 }) => {
@@ -83,7 +88,7 @@ test("walks three questions one at a time and composes a single reply", async ({
   await expect(page.getByText("Which city are you flying to?")).toBeVisible({
     timeout: 15_000,
   });
-  await expect(page.getByText("1 of 3")).toBeVisible();
+  await expect(page.getByText("1/3")).toBeVisible();
   // The other questions are NOT on screen yet (one step at a time).
   await expect(
     page.getByText("Anything special I should know about the trip?"),
@@ -91,11 +96,13 @@ test("walks three questions one at a time and composes a single reply", async ({
   await expect(page.getByText("Morning or evening flight?")).toHaveCount(0);
 
   // Exactly this step's two options, plus the escape-hatch free-text field, and
-  // the normal follow-up composer is gone.
+  // the real composer stays visible and usable alongside the card.
   await expect(page.getByRole("radio")).toHaveCount(2);
-  const freeText = page.getByPlaceholder("Type your answer...");
+  const freeText = page.getByPlaceholder("Type something else...");
   await expect(freeText).toBeVisible();
-  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+  const composer = page.getByPlaceholder("Send a follow-up...");
+  await expect(composer).toBeVisible();
+  await expect(composer).toBeEditable();
 
   // Answer step 1 by option -> advances to step 2 of 3 (a free-text-only
   // question). On a multi-step sequence the click advances, it does not send.
@@ -103,16 +110,17 @@ test("walks three questions one at a time and composes a single reply", async ({
   await expect(
     page.getByText("Anything special I should know about the trip?"),
   ).toBeVisible();
-  await expect(page.getByText("2 of 3")).toBeVisible();
+  await expect(page.getByText("2/3")).toBeVisible();
   await expect(page.getByText("Which city are you flying to?")).toHaveCount(0);
   await expect(page.getByRole("radio")).toHaveCount(0);
-  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+  await expect(composer).toBeVisible();
 
-  // Answer step 2 by free text -> advances to step 3 of 3.
+  // Answer step 2 by free text -> advances to step 3 of 3. The footer's "Next"
+  // button commits the draft (no per-field submit icon anymore).
   await freeText.fill("Window seat please");
-  await page.getByRole("button", { name: "Send" }).click();
+  await page.getByRole("button", { name: "Next" }).click();
   await expect(page.getByText("Morning or evening flight?")).toBeVisible();
-  await expect(page.getByText("3 of 3")).toBeVisible();
+  await expect(page.getByText("3/3")).toBeVisible();
 
   // Answer the LAST step by option -> completes and sends ONE composed message.
   await page.getByRole("radio", { name: "Evening flight" }).click();
@@ -123,12 +131,19 @@ test("walks three questions one at a time and composes a single reply", async ({
   await expect(composed).toHaveCount(1);
   await expect(composed).toContainText("Paris");
   await expect(composed).toContainText("Evening flight");
+  // Structured rendering, not a flat "question: answer" line: the question
+  // text itself renders as its own muted-text element above the bold answer.
+  await expect(
+    composed
+      .locator("span")
+      .filter({ hasText: "Which city are you flying to?" }),
+  ).toBeVisible();
 
-  // The answering turn starts, so the card retires and the composer returns.
+  // The answering turn starts, so the card retires and the composer remains.
   await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible({
     timeout: 15_000,
   });
-  await expect(page.getByText("1 of 3")).toHaveCount(0);
+  await expect(page.getByText("1/3")).toHaveCount(0);
 });
 
 /**
@@ -172,24 +187,27 @@ test("back chevron returns to the previous answered step, pre-selected", async (
   await expect(page.getByText("Which city are you flying to?")).toBeVisible({
     timeout: 15_000,
   });
-  await expect(page.getByText("1 of 2")).toBeVisible();
+  await expect(page.getByText("1/2")).toBeVisible();
   await page.getByRole("radio", { name: "Paris" }).click();
   await expect(page.getByText("Morning or evening flight?")).toBeVisible();
-  await expect(page.getByText("2 of 2")).toBeVisible();
+  await expect(page.getByText("2/2")).toBeVisible();
 
   // Back -> step 1 again, with Paris pre-selected (the committed answer).
   await page.getByRole("button", { name: "Back" }).click();
   await expect(page.getByText("Which city are you flying to?")).toBeVisible();
-  await expect(page.getByText("1 of 2")).toBeVisible();
+  await expect(page.getByText("1/2")).toBeVisible();
   await expect(page.getByRole("radio", { name: "Paris" })).toHaveAttribute(
     "aria-checked",
     "true",
   );
 
   // Re-answer with the other option -> replaces the answer and advances again.
+  // (Clicking an option advances directly; no ambiguity with the header's
+  // forward chevron, which also carries the "Next" accessible name here since
+  // this step was already reached.)
   await page.getByRole("radio", { name: "Tokyo" }).click();
   await expect(page.getByText("Morning or evening flight?")).toBeVisible();
-  await expect(page.getByText("2 of 2")).toBeVisible();
+  await expect(page.getByText("2/2")).toBeVisible();
 
   // Finish; the composed message carries the REPLACED answer (Tokyo, not Paris).
   await page.getByRole("radio", { name: "Evening flight" }).click();
@@ -202,7 +220,7 @@ test("back chevron returns to the previous answered step, pre-selected", async (
 /**
  * The single-question fast path: one question with options and no progress
  * chrome (total is 1). Clicking an option completes immediately — click = answer
- * = send — and the follow-up composer returns.
+ * = send — and the composer (already visible throughout) is all that's left.
  */
 test("single question with options sends on option click (fast path)", async ({
   page,
@@ -228,8 +246,8 @@ test("single question with options sends on option click (fast path)", async ({
 
   await startMission(page, "book my flight");
 
-  // The lone question owns the composer slot; a single step shows NO progress
-  // indicator and NO back chevron (the one-tap feel is preserved).
+  // The lone question shows above the composer; a single step shows NO
+  // progress chrome and NO back chevron (the one-tap feel is preserved).
   await expect(
     page.getByText("Do you want the morning or evening flight?"),
   ).toBeVisible({ timeout: 15_000 });
@@ -237,14 +255,14 @@ test("single question with options sends on option click (fast path)", async ({
   await expect(page.getByRole("button", { name: "Back" })).toHaveCount(0);
   const morning = page.getByRole("radio", { name: "Morning flight" });
   await expect(morning).toBeVisible();
-  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
 
   // Clicking an option completes immediately as one composed user message...
   await morning.click();
   await expect(
     page.locator(".is-user").filter({ hasText: "Morning flight" }),
   ).toHaveCount(1);
-  // ...the answering turn starts, so the card retires and the composer returns.
+  // ...the answering turn starts, so the card retires and the composer remains.
   await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible({
     timeout: 15_000,
   });
@@ -254,10 +272,52 @@ test("single question with options sends on option click (fast path)", async ({
 });
 
 /**
+ * Number-key shortcuts: pressing "2" selects the second option row, mirroring
+ * its visible position number, without needing to click.
+ */
+test("pressing a number key selects the matching option", async ({
+  page,
+  request,
+}) => {
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: {
+      interaction: {
+        steps: [
+          {
+            kind: "question",
+            id: "q1",
+            question: "Which city are you flying to?",
+            options: [
+              { id: "paris", label: "Paris" },
+              { id: "tokyo", label: "Tokyo" },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  await startMission(page, "plan my trip");
+
+  const question = page.getByText("Which city are you flying to?");
+  await expect(question).toBeVisible({ timeout: 15_000 });
+
+  // Move focus off the real composer first (the shortcut is ignored while
+  // typing in a text field), then press "2" to pick the second option (Tokyo).
+  await question.click();
+  await page.keyboard.press("2");
+
+  await expect(
+    page.locator(".is-user").filter({ hasText: "Tokyo" }),
+  ).toHaveCount(1);
+});
+
+/**
  * A mixed sequence (question THEN connect): answering the question advances the
- * SAME card to the connect step as the final step, with "2 of 2" progress and
+ * SAME card to the connect step as the final step, with "2/2" progress and
  * the rich integration connect card. (The connect can't complete real OAuth in
- * the harness, so this asserts the render, not the landing.)
+ * the harness, so this asserts the render, not the landing.) The composer stays
+ * visible throughout, even mid-sequence.
  */
 test("advances from a question to a connect step in one sequence", async ({
   page,
@@ -289,7 +349,7 @@ test("advances from a question to a connect step in one sequence", async ({
   await expect(
     page.getByText("Who should I send the itinerary to?"),
   ).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByText("1 of 2")).toBeVisible();
+  await expect(page.getByText("1/2")).toBeVisible();
   await expect(
     page.getByText("I need access to your Gmail to send the trip itinerary."),
   ).toHaveCount(0);
@@ -297,12 +357,12 @@ test("advances from a question to a connect step in one sequence", async ({
 
   // Answer the question -> advance to the connect step (2 of 2). The reason and
   // the rich IntegrationConnectCard (its Connect action is the proof it rendered)
-  // now own the card; the question text is gone.
-  const freeText = page.getByPlaceholder("Type your answer...");
+  // now own the card body; the question text is gone.
+  const freeText = page.getByPlaceholder("Type something else...");
   await freeText.fill("john@example.com");
-  await page.getByRole("button", { name: "Send" }).click();
+  await page.getByRole("button", { name: "Next" }).click();
 
-  await expect(page.getByText("2 of 2")).toBeVisible();
+  await expect(page.getByText("2/2")).toBeVisible();
   await expect(
     page.getByText("I need access to your Gmail to send the trip itinerary."),
   ).toBeVisible();
@@ -310,8 +370,8 @@ test("advances from a question to a connect step in one sequence", async ({
   await expect(
     page.getByText("Who should I send the itinerary to?"),
   ).toHaveCount(0);
-  // The composer is still replaced: the sequence isn't complete until connect.
-  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+  // The composer stays visible and usable throughout, even mid-sequence.
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
 });
 
 /**
@@ -320,7 +380,7 @@ test("advances from a question to a connect step in one sequence", async ({
  * reason, the "Sign in to Houston" card, and a Sign in button. Real Google SSO
  * can't run in the harness, so this asserts the signin step RENDERS in the middle
  * of the sequence, not that it lands — the connect step (3 of 3) stays queued
- * behind it and the composer stays replaced.
+ * behind it and the composer stays visible throughout.
  */
 test("advances from a question to a signin step in a three-step sequence", async ({
   page,
@@ -357,20 +417,20 @@ test("advances from a question to a signin step in a three-step sequence", async
   await expect(
     page.getByText("Who should I send the itinerary to?"),
   ).toBeVisible({ timeout: 15_000 });
-  await expect(page.getByText("1 of 3")).toBeVisible();
+  await expect(page.getByText("1/3")).toBeVisible();
   await expect(
     page.getByText("Sign in to Houston so I can send email on your behalf."),
   ).toHaveCount(0);
   await expect(page.getByRole("button", { name: "Sign in" })).toHaveCount(0);
 
   // Answer the question -> advance to the SIGNIN step (2 of 3). Its reason, the
-  // "Sign in to Houston" card and the Sign in button now own the card; the
+  // "Sign in to Houston" card and the Sign in button now own the card body; the
   // question text is gone and the connect step (3 of 3) is still queued behind it.
-  const freeText = page.getByPlaceholder("Type your answer...");
+  const freeText = page.getByPlaceholder("Type something else...");
   await freeText.fill("john@example.com");
-  await page.getByRole("button", { name: "Send" }).click();
+  await page.getByRole("button", { name: "Next" }).click();
 
-  await expect(page.getByText("2 of 3")).toBeVisible();
+  await expect(page.getByText("2/3")).toBeVisible();
   await expect(
     page.getByText("Sign in to Houston so I can send email on your behalf."),
   ).toBeVisible();
@@ -378,9 +438,9 @@ test("advances from a question to a signin step in a three-step sequence", async
   await expect(
     page.getByText("Who should I send the itinerary to?"),
   ).toHaveCount(0);
-  // The connect step hasn't been reached, and the composer is still replaced.
+  // The connect step hasn't been reached, and the composer stays visible.
   await expect(page.getByRole("button", { name: "Connect" })).toHaveCount(0);
-  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
 });
 
 /**
@@ -409,20 +469,20 @@ test("shows a lone signin step for a signin-only sequence", async ({
 
   await startMission(page, "check my email");
 
-  // The signin card owns the composer slot: the reason plus the Sign in button,
-  // a single step (no progress chrome), composer gone.
+  // The signin card shows above the composer: the reason plus the Sign in
+  // button, a single step (no progress chrome), composer stays visible.
   await expect(
     page.getByText("Sign in to Houston to use your connected apps."),
   ).toBeVisible({ timeout: 15_000 });
   await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
   await expect(page.getByText(/ of /)).toHaveCount(0);
-  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
 });
 
 /**
  * A connect-only sequence (single request_connection, no questions): the card
  * shows the reason plus the rich integration connect card as the ONLY step, with
- * no progress chrome, unchanged from before the stepper.
+ * no progress chrome, and the composer stays visible alongside it.
  */
 test("shows a lone connect step for a connect-only sequence", async ({
   page,
@@ -445,12 +505,100 @@ test("shows a lone connect step for a connect-only sequence", async ({
 
   await startMission(page, "email me the itinerary");
 
-  // The connect card owns the composer slot: the reason plus the rich
-  // integration connect card, a single step (no progress), composer gone.
+  // The connect card shows above the composer: the reason plus the rich
+  // integration connect card, a single step (no progress), composer visible.
   await expect(
     page.getByText("I need access to your Gmail to send the trip itinerary."),
   ).toBeVisible({ timeout: 15_000 });
   await expect(page.getByRole("button", { name: "Connect" })).toBeVisible();
   await expect(page.getByText(/ of /)).toHaveCount(0);
-  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
+});
+
+/**
+ * The escape hatch: instead of engaging with the card at all, the user can type
+ * straight into the always-visible real composer. Sending that message abandons
+ * the WHOLE pending interaction (mirrors clicking the card's own dismiss X) and
+ * the typed text goes out as a normal message.
+ */
+test("typing a fresh message in the composer abandons the pending interaction", async ({
+  page,
+  request,
+}) => {
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: {
+      interaction: {
+        steps: [
+          {
+            kind: "question",
+            id: "q1",
+            question: "Which city are you flying to?",
+            options: [
+              { id: "paris", label: "Paris" },
+              { id: "tokyo", label: "Tokyo" },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  await startMission(page, "plan my trip");
+
+  await expect(page.getByText("Which city are you flying to?")).toBeVisible({
+    timeout: 15_000,
+  });
+
+  const composer = page.getByPlaceholder("Send a follow-up...");
+  await expect(composer).toBeVisible();
+  await composer.fill("actually just book the cheapest option");
+  await composer.press("Enter");
+
+  // The card retires entirely (question, options, and free-text field all gone)
+  // and the typed message sends as a normal user turn, not an answer.
+  await expect(page.getByText("Which city are you flying to?")).toHaveCount(0);
+  await expect(page.getByPlaceholder("Type something else...")).toHaveCount(0);
+  await expect(
+    page
+      .locator(".is-user")
+      .filter({ hasText: "actually just book the cheapest option" }),
+  ).toHaveCount(1);
+});
+
+/**
+ * The explicit escape hatch: the card's own header X button abandons the whole
+ * sequence without requiring the user to type anything.
+ */
+test("the dismiss X button abandons the pending interaction", async ({
+  page,
+  request,
+}) => {
+  await request.post(`${FAKE_HOST_URL}/__test__/chat-interaction`, {
+    data: {
+      interaction: {
+        steps: [
+          {
+            kind: "question",
+            id: "q1",
+            question: "Which city are you flying to?",
+            options: [
+              { id: "paris", label: "Paris" },
+              { id: "tokyo", label: "Tokyo" },
+            ],
+          },
+        ],
+      },
+    },
+  });
+
+  await startMission(page, "plan my trip");
+
+  await expect(page.getByText("Which city are you flying to?")).toBeVisible({
+    timeout: 15_000,
+  });
+
+  await page.getByRole("button", { name: "Dismiss" }).click();
+
+  await expect(page.getByText("Which city are you flying to?")).toHaveCount(0);
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
 });

--- a/packages/web/e2e/routine-setup-chat.spec.ts
+++ b/packages/web/e2e/routine-setup-chat.spec.ts
@@ -91,15 +91,16 @@ test("mid-interview: no board card, tab switch leaves a Continue banner on the g
     timeout: 15_000,
   });
 
-  // The ask_user question card REPLACES the composer once the turn settles —
-  // this is the interview's whole interaction surface, so the setup panel
-  // must forward composerOverride like the board panel does. Settle-dependent,
-  // so generous for a CI drop + resync cycle.
+  // The ask_user question card shows ABOVE the composer once the turn settles
+  // — this is the interview's whole interaction surface, so the setup panel
+  // must forward composerOverride like the board panel does. The real composer
+  // stays mounted and visible alongside it. Settle-dependent, so generous for a
+  // CI drop + resync cycle.
   await expect(page.getByText("What should the routine do?")).toBeVisible({
     timeout: 45_000,
   });
   await expect(page.getByRole("radio")).toHaveCount(2);
-  await expect(page.getByPlaceholder("Send a follow-up...")).toHaveCount(0);
+  await expect(page.getByPlaceholder("Send a follow-up...")).toBeVisible();
 
   // No VISIBLE card on the Activity board (the setup surface's own hidden
   // list still holds the item, so assert visibility, not count).

--- a/ui/agent-schemas/src/activity.schema.json
+++ b/ui/agent-schemas/src/activity.schema.json
@@ -54,7 +54,13 @@
               "properties": {
                 "kind": {
                   "type": "string",
-                  "enum": ["question", "signin", "connect"]
+                  "enum": [
+                    "question",
+                    "signin",
+                    "connect",
+                    "plan_ready",
+                    "suggest_reusable"
+                  ]
                 },
                 "id": { "type": "string" },
                 "question": { "type": "string" },
@@ -70,7 +76,14 @@
                   }
                 },
                 "toolkit": { "type": "string" },
-                "reason": { "type": "string" }
+                "reason": { "type": "string" },
+                "summary": { "type": "string" },
+                "reusableKind": {
+                  "type": "string",
+                  "enum": ["skill", "routine"]
+                },
+                "title": { "type": "string" },
+                "rationale": { "type": "string" }
               },
               "oneOf": [
                 {
@@ -83,6 +96,14 @@
                 {
                   "properties": { "kind": { "const": "connect" } },
                   "required": ["toolkit"]
+                },
+                {
+                  "properties": { "kind": { "const": "plan_ready" } },
+                  "required": ["summary"]
+                },
+                {
+                  "properties": { "kind": { "const": "suggest_reusable" } },
+                  "required": ["reusableKind", "title", "rationale"]
                 }
               ]
             }

--- a/ui/chat/src/chat-panel.tsx
+++ b/ui/chat/src/chat-panel.tsx
@@ -171,34 +171,38 @@ export function ChatPanel({
         </div>
       )}
 
-      {composerOverride ? (
-        <div className="shrink-0 px-4 pb-6 pt-2">
+      {/* The composer stays mounted at all times. A pending interaction renders
+          its card ABOVE the input (both visible) rather than replacing it, so the
+          user can always type a fresh message — doing so abandons the card. The
+          override block drops the input's own top padding for its gap, avoiding
+          doubled spacing between the two. */}
+      {composerOverride && (
+        <div className="shrink-0 px-4 pt-2">
           <div className="max-w-3xl mx-auto">{composerOverride}</div>
         </div>
-      ) : (
-        <ChatInput
-          onSend={handleSend}
-          onStop={onStop}
-          status={status}
-          placeholder={placeholder}
-          value={value}
-          onValueChange={onValueChange}
-          attachments={files}
-          onAttachmentsChange={setFiles}
-          onNotice={onNotice}
-          prepareAttachments={prepareAttachments}
-          onAttachmentRejections={onAttachmentRejections}
-          footer={footer}
-          header={composerHeader}
-          attachMenu={attachMenu}
-          queuedMessages={queuedMessages}
-          onRemoveQueuedMessage={onRemoveQueuedMessage}
-          queuedLabels={queuedLabels}
-          canSendEmpty={canSendEmpty}
-          labels={composerLabels}
-          dictation={dictation}
-        />
       )}
+      <ChatInput
+        onSend={handleSend}
+        onStop={onStop}
+        status={status}
+        placeholder={placeholder}
+        value={value}
+        onValueChange={onValueChange}
+        attachments={files}
+        onAttachmentsChange={setFiles}
+        onNotice={onNotice}
+        prepareAttachments={prepareAttachments}
+        onAttachmentRejections={onAttachmentRejections}
+        footer={footer}
+        header={composerHeader}
+        attachMenu={attachMenu}
+        queuedMessages={queuedMessages}
+        onRemoveQueuedMessage={onRemoveQueuedMessage}
+        queuedLabels={queuedLabels}
+        canSendEmpty={canSendEmpty}
+        labels={composerLabels}
+        dictation={dictation}
+      />
     </div>
   );
 }

--- a/ui/chat/src/chat-suggest-reusable-card-model.ts
+++ b/ui/chat/src/chat-suggest-reusable-card-model.ts
@@ -1,0 +1,42 @@
+// Shared labels + a pure presentation helper for ChatSuggestReusableCard.
+// DOM-free (mirroring chat-plan-ready-card-model.ts) so the node:test suite can
+// drive the save-label decision without a DOM runner; the .tsx component maps
+// the resolved label to a row verbatim (icons are internal to the component).
+//
+// This card is simpler than the plan-ready card: it has exactly TWO actions
+// (Save, Not now), not three, and the two rows have no per-row description. So
+// there is no generic action-list resolver here (that would be over-engineering
+// for two fixed rows). The one branch that isn't a plain prop is the save
+// label, which depends on `reusableKind` — that is the single pure helper below.
+
+/** English defaults live in the app; consumers pass `t()` results in. This
+ *  constant is the fallback for apps that don't localize the card yet. */
+export interface ChatSuggestReusableLabels {
+  /** Small eyebrow label above the proposed title (like plan-ready's "Plan ready"). */
+  eyebrow: string;
+  /** Save action label shown when `reusableKind === "skill"`. */
+  skillTitle: string;
+  /** Save action label shown when `reusableKind === "routine"`. */
+  routineTitle: string;
+  /** Dismiss action label. */
+  notNow: string;
+}
+
+/** English fallbacks for apps that don't localize the suggest-reusable card
+ *  yet. No em dashes. */
+export const DEFAULT_SUGGEST_REUSABLE_LABELS: ChatSuggestReusableLabels = {
+  eyebrow: "Save this for next time",
+  skillTitle: "Save as a Skill",
+  routineTitle: "Save as a Routine",
+  notNow: "Not now",
+};
+
+/** The save row's label: the model's just-completed work can be saved either as
+ *  a reusable Skill or a scheduled Routine, and the label names which. Pure so
+ *  the mapping is unit-tested without a DOM. */
+export function resolveSuggestReusableSaveLabel(
+  reusableKind: "skill" | "routine",
+  labels: ChatSuggestReusableLabels,
+): string {
+  return reusableKind === "skill" ? labels.skillTitle : labels.routineTitle;
+}

--- a/ui/chat/src/chat-suggest-reusable-card.tsx
+++ b/ui/chat/src/chat-suggest-reusable-card.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { cn } from "@houston-ai/core";
+import { CalendarClock, Sparkles, X } from "lucide-react";
+import {
+  type ChatSuggestReusableLabels,
+  resolveSuggestReusableSaveLabel,
+} from "./chat-suggest-reusable-card-model";
+
+export type { ChatSuggestReusableLabels } from "./chat-suggest-reusable-card-model";
+export { DEFAULT_SUGGEST_REUSABLE_LABELS } from "./chat-suggest-reusable-card-model";
+
+export interface ChatSuggestReusableCardProps {
+  /** Whether the work is being offered as a reusable Skill or a scheduled Routine. */
+  reusableKind: "skill" | "routine";
+  /** The model's proposed name for the Skill/Routine, shown as the prominent head. */
+  title: string;
+  /** The model's one-line rationale for saving it (model-generated, passed through). */
+  rationale: string;
+  /** Gates both actions uniformly (another turn is active). */
+  disabled?: boolean;
+  /** Send the follow-up message that asks the agent to write the Skill/Routine. */
+  onSave: () => void;
+  /** Dismiss the offer locally and return the composer. */
+  onDismiss: () => void;
+  labels: ChatSuggestReusableLabels;
+}
+
+/**
+ * The in-chat surface shown when the agent finishes cleanly and calls
+ * `suggest_reusable`: an optional, dismissible offer to save the just-completed
+ * work as a reusable Skill or a scheduled Routine. It REPLACES the composer, so
+ * it borrows the plan-ready card's vocabulary (rounded-[28px] grey
+ * `bg-secondary` surface) with the proposed title raised as the prominent head
+ * and the rationale below it. The two actions (Save / Not now) render as
+ * full-width rows using the SAME row button classes as the plan-ready card, so
+ * the card family reads as one system. Everything is visible at rest (no hover
+ * gate). `disabled` gates both rows.
+ */
+export function ChatSuggestReusableCard({
+  reusableKind,
+  title,
+  rationale,
+  disabled = false,
+  onSave,
+  onDismiss,
+  labels,
+}: ChatSuggestReusableCardProps) {
+  const saveLabel = resolveSuggestReusableSaveLabel(reusableKind, labels);
+  // A Skill is reusable know-how (Sparkles); a Routine runs on a schedule
+  // (CalendarClock). Icons are internal so the labels contract stays icon-free.
+  const SaveIcon = reusableKind === "skill" ? Sparkles : CalendarClock;
+
+  return (
+    <div
+      aria-disabled={disabled || undefined}
+      className={cn(
+        "overflow-clip rounded-[28px] border border-border/50 bg-secondary p-2.5",
+        "shadow-[0_1px_6px_rgba(0,0,0,0.06)] dark:shadow-[0_1px_6px_rgba(0,0,0,0.2)]",
+        disabled && "opacity-50",
+      )}
+    >
+      <div className="flex flex-col px-2.5 pt-2 pb-2">
+        <p className="font-medium text-muted-foreground text-xs">
+          {labels.eyebrow}
+        </p>
+        <p className="mt-1.5 text-base text-foreground leading-relaxed">
+          {title}
+        </p>
+        <p className="mt-1 text-muted-foreground text-sm leading-relaxed">
+          {rationale}
+        </p>
+        <div className="mt-3 flex flex-col gap-1.5">
+          <button
+            className="flex w-full items-center rounded-xl border border-border bg-background px-3 py-2.5 text-left shadow-xs transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            disabled={disabled}
+            onClick={onSave}
+            type="button"
+          >
+            <span className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <SaveIcon className="size-4 shrink-0 text-foreground" />
+              {saveLabel}
+            </span>
+          </button>
+          <button
+            className="flex w-full items-center rounded-xl border border-border bg-background px-3 py-2.5 text-left shadow-xs transition-colors hover:bg-accent disabled:pointer-events-none disabled:opacity-50 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+            disabled={disabled}
+            onClick={onDismiss}
+            type="button"
+          >
+            <span className="flex items-center gap-2 text-sm font-medium text-foreground">
+              <X className="size-4 shrink-0 text-foreground" />
+              {labels.notNow}
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/chat/src/index.ts
+++ b/ui/chat/src/index.ts
@@ -206,6 +206,18 @@ export type { ChatSidebarProps } from "./chat-sidebar";
 export { ChatSidebar } from "./chat-sidebar";
 export type { ChatStatusLineProps } from "./chat-status-line";
 export { ChatStatusLine } from "./chat-status-line";
+// === Suggest-reusable card ===
+// The composer-replacing surface shown when the agent finishes cleanly and calls
+// `suggest_reusable`: an optional, dismissible offer to save the just-completed
+// work as a Skill or a scheduled Routine (Save / Not now). Props-only; the app
+// supplies localized labels and wires the send.
+export type { ChatSuggestReusableCardProps } from "./chat-suggest-reusable-card";
+export { ChatSuggestReusableCard } from "./chat-suggest-reusable-card";
+export type { ChatSuggestReusableLabels } from "./chat-suggest-reusable-card-model";
+export {
+  DEFAULT_SUGGEST_REUSABLE_LABELS,
+  resolveSuggestReusableSaveLabel,
+} from "./chat-suggest-reusable-card-model";
 // === Dictation ===
 export type {
   DictationControl,
@@ -233,6 +245,15 @@ export type {
   ToolEntry,
 } from "./feed-to-messages";
 export { distinctAuthorCount } from "./feed-to-messages";
+export type {
+  InteractionAnswerLine,
+  InteractionAnswersPayload,
+} from "./interaction-answers-message";
+// === Interaction-answers Messages ===
+// Encoded user-message marker that signals "this message is the answers the
+// user gave to an ask_user interaction sequence". Decoded into a structured
+// payload so consumers (desktop, mobile) can render the same Q&A card.
+export { decodeInteractionAnswersMessage } from "./interaction-answers-message";
 // === Interaction Card ===
 // The in-chat surface shown when the agent pauses to gather what it needs before
 // continuing; a stepper (one question or connect step at a time) that replaces
@@ -283,3 +304,4 @@ export {
   UserAttachmentBadge,
   UserAttachmentMessage,
 } from "./user-attachment-message";
+export { UserInteractionAnswersMessage } from "./user-interaction-answers-message";

--- a/ui/chat/src/interaction-answers-message.ts
+++ b/ui/chat/src/interaction-answers-message.ts
@@ -1,0 +1,73 @@
+/**
+ * Interaction-answers message marker.
+ *
+ * When a user finishes an `ask_user` interaction sequence (the stepper card),
+ * the app sends ONE user message carrying every answer. The body the model
+ * reads stays the same flat `"<question>: <answer>"` text; an HTML-comment
+ * marker rides in front of it carrying the SAME information in a structured
+ * shape so the chat renderer can show a Q&A card instead of an undifferentiated
+ * text bubble, for both the live message and reloaded history.
+ *
+ * The marker is intentionally framework-agnostic: parsing lives in
+ * `@houston-ai/chat` so any consumer (desktop app, mobile, future embedded
+ * chats) can decode + render the same way without inheriting the desktop's
+ * interaction/composer code. Mirrors `skill-message.ts`.
+ *
+ * Format (single line, rest of body is the flat text the model reads):
+ *
+ *     <!--houston:interaction-answers {"lines":[...]}-->
+ *
+ *     To whom?: john@example.com
+ *     Saying what?: Running late
+ */
+
+const MARKER_RE = /^<!--houston:interaction-answers (\{[\s\S]*?\})-->\s*\n?\n?/;
+
+export interface InteractionAnswerLine {
+  /**
+   * The question text, or undefined for a non-question line (a connected app, a
+   * signin confirmation) which renders as a single bold line with no muted
+   * question line above it.
+   */
+  question?: string;
+  /** The answer / confirmation text, always present. */
+  answer: string;
+}
+
+export interface InteractionAnswersPayload {
+  lines: InteractionAnswerLine[];
+}
+
+/**
+ * Try to extract an interaction-answers payload from a user-message body.
+ * Returns `null` when the message is plain text or the marker JSON is
+ * malformed. Individual malformed entries (missing/non-string `answer`) are
+ * dropped rather than failing the whole decode; if no valid entries remain the
+ * whole decode returns `null` so the caller falls through to plain text.
+ */
+export function decodeInteractionAnswersMessage(
+  body: string,
+): InteractionAnswersPayload | null {
+  const match = body.match(MARKER_RE);
+  if (!match) return null;
+  try {
+    const payload = JSON.parse(match[1]) as Partial<InteractionAnswersPayload> &
+      Record<string, unknown>;
+    if (!Array.isArray(payload?.lines)) return null;
+    const lines: InteractionAnswerLine[] = [];
+    for (const raw of payload.lines) {
+      if (!raw || typeof raw !== "object") continue;
+      const entry = raw as Partial<InteractionAnswerLine>;
+      if (typeof entry.answer !== "string") continue;
+      lines.push(
+        typeof entry.question === "string"
+          ? { question: entry.question, answer: entry.answer }
+          : { answer: entry.answer },
+      );
+    }
+    if (lines.length === 0) return null;
+    return { lines };
+  } catch {
+    return null;
+  }
+}

--- a/ui/chat/src/interaction-card-logic.ts
+++ b/ui/chat/src/interaction-card-logic.ts
@@ -20,7 +20,6 @@ export {
   hasSelectableOptions,
   normalizeAnswer,
   optionLabel,
-  QUESTION_TEXT_CLASS,
 } from "./interaction-card-model.ts";
 
 /** A committed answer for one question step: the resolved text plus, when the
@@ -195,6 +194,21 @@ export function answerWithText(
     answer: { answer: text, optionId: null },
     clearDraft: false,
   });
+}
+
+/** Advance past the current QUESTION step WITHOUT recording an answer. Mirrors
+ *  `advance`'s frontier-advancing mechanics but commits nothing, so
+ *  `toCompletedAnswers` simply omits the skipped step (its `if (committed)`
+ *  guard). A no-op on a non-question step, since Skip is only ever offered for
+ *  question steps. When the skipped question is the last step, completion still
+ *  fires exactly like every other terminal transition, with the prior answers. */
+export function skipQuestion(
+  state: StepperState,
+  steps: ChatInteractionStep[],
+): Transition {
+  const step = steps[state.current];
+  if (step?.kind !== "question") return { state };
+  return advance(state, steps);
 }
 
 /** Advance past a connect step once the app reports it connected. */

--- a/ui/chat/src/interaction-card-model.ts
+++ b/ui/chat/src/interaction-card-model.ts
@@ -24,11 +24,6 @@ export interface ChatInteractionAnswer {
   answer: string;
 }
 
-/** Every step now shows exactly one question, so the head always reads as the
- *  single next action: sized up and weighted (matches the composer replace). */
-export const QUESTION_TEXT_CLASS =
-  "text-lg font-medium leading-snug text-foreground";
-
 /** True when the agent offered concrete choices (option rows render). */
 export function hasSelectableOptions(
   options?: ChatInteractionOption[],

--- a/ui/chat/src/interaction-card-parts.tsx
+++ b/ui/chat/src/interaction-card-parts.tsx
@@ -1,19 +1,24 @@
 "use client";
 
 import { Button, cn } from "@houston-ai/core";
-import { CheckIcon, ChevronLeftIcon, ChevronRightIcon } from "lucide-react";
+import { XIcon } from "lucide-react";
 import type { ChatInteractionOption } from "./interaction-card-logic";
 
-/** One selectable answer, a full-width single-select row (click = answer). */
+/** One selectable answer, a full-width single-select row (click = answer). The
+ *  bold label sits on the left; its 1-based `position` shows as quiet muted text
+ *  on the right (always visible, replacing the old check-on-selected indicator —
+ *  the number is the stable affordance, selection is carried by the border). */
 export function OptionRow({
   option,
   selected,
   disabled,
+  position,
   onSelect,
 }: {
   option: ChatInteractionOption;
   selected: boolean;
   disabled: boolean;
+  position: number;
   onSelect: () => void;
 }) {
   return (
@@ -32,72 +37,71 @@ export function OptionRow({
       role="radio"
       type="button"
     >
-      <span className="flex-1">{option.label}</span>
-      <span className="flex size-4 shrink-0 items-center justify-center">
-        {selected && <CheckIcon className="size-4 text-primary" />}
+      <span className="flex-1 font-medium">{option.label}</span>
+      <span className="shrink-0 text-muted-foreground text-xs tabular-nums">
+        {position}
       </span>
     </button>
   );
 }
 
-/** Quiet header: a back chevron (from step 2 on) and a right-aligned "1 of X".
- *  Once the user walks back onto an already-completed step, a forward chevron
- *  joins the progress on the right so they can return to the live frontier. That
- *  matters most for a revisited connect step, whose card can't re-fire
- *  onConnected once connected, leaving the forward chevron the only way onward.
- *  Renders only when there is more than one step, so a lone step shows no chrome
- *  and keeps the one-tap feel. `min-h-8` reserves the chevron's height so the
- *  progress text never shifts between step 1 and later steps. */
-export function StepperHeader({
-  progressText,
-  canGoBack,
-  onBack,
-  backLabel,
-  canGoForward,
-  onForward,
-  forwardLabel,
-  disabled,
-}: {
-  progressText: string;
-  canGoBack: boolean;
-  onBack: () => void;
-  backLabel: string;
-  canGoForward: boolean;
-  onForward: () => void;
-  forwardLabel: string;
+export interface StepperHeaderProps {
+  /** 1-based index of the current step and the total step count (drives the pill). */
+  current: number;
+  total: number;
+  /** Full accessible progress copy, e.g. "1 of 4" (aria-label on the pill). */
+  progressLabel: string;
+  /** The current step's question text; omitted for signin/connect steps. */
+  questionText?: string;
+  /** Dismisses the WHOLE interaction sequence. The X button renders only when
+   *  supplied, so a caller with no dismiss affordance simply omits it. */
+  onDismiss?: () => void;
+  dismissLabel: string;
   disabled: boolean;
-}) {
+}
+
+/** Card header: a "current/total" pill and the step's question text on the
+ *  left, an optional dismiss X on the right. Purely informational + the one
+ *  escape hatch — all step-to-step navigation (back/skip/next) lives together
+ *  in the footer, see `ChatInteractionCard`. */
+export function StepperHeader({
+  current,
+  total,
+  progressLabel,
+  questionText,
+  onDismiss,
+  dismissLabel,
+  disabled,
+}: StepperHeaderProps) {
   return (
-    <div className="mb-1 flex min-h-8 items-center justify-between px-1">
-      {canGoBack ? (
+    <div className="mb-1 flex min-h-8 items-center gap-1.5 px-1">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        {total > 1 && (
+          <span className="shrink-0 rounded-md bg-muted px-1.5 py-0.5 font-medium text-muted-foreground text-xs tabular-nums">
+            <span aria-hidden="true">
+              {current}/{total}
+            </span>
+            <span className="sr-only">{progressLabel}</span>
+          </span>
+        )}
+        {questionText && (
+          <span className="min-w-0 truncate font-medium text-foreground text-sm">
+            {questionText}
+          </span>
+        )}
+      </div>
+
+      {onDismiss && (
         <Button
-          aria-label={backLabel}
+          aria-label={dismissLabel}
           disabled={disabled}
-          onClick={onBack}
+          onClick={onDismiss}
           size="icon-sm"
           variant="ghost"
         >
-          <ChevronLeftIcon className="size-4" />
+          <XIcon className="size-4" />
         </Button>
-      ) : (
-        <span className="size-8" />
       )}
-      <div className="flex items-center gap-1">
-        <span className="font-medium text-muted-foreground text-xs tabular-nums">
-          {progressText}
-        </span>
-        {canGoForward && (
-          <Button
-            aria-label={forwardLabel}
-            disabled={disabled}
-            onClick={onForward}
-            size="icon-sm"
-            variant="ghost"
-          >
-            <ChevronRightIcon className="size-4" />
-          </Button>
-        )}
-      </div>
     </div>
   );
 }

--- a/ui/chat/src/interaction-card.tsx
+++ b/ui/chat/src/interaction-card.tsx
@@ -1,13 +1,14 @@
 "use client";
 
-import { cn } from "@houston-ai/core";
+import { Button, cn } from "@houston-ai/core";
+import { CornerDownLeftIcon } from "lucide-react";
 import {
-  type KeyboardEvent,
+  type KeyboardEvent as ReactKeyboardEvent,
   type ReactNode,
   useCallback,
+  useEffect,
   useState,
 } from "react";
-import { PromptInputSubmit } from "./ai-elements/prompt-input";
 import {
   advanceConnect,
   advanceSignin,
@@ -23,9 +24,9 @@ import {
   goForward,
   hasSelectableOptions,
   initialStepperState,
-  QUESTION_TEXT_CLASS,
   selectedOptionId,
   setDraft,
+  skipQuestion,
   type Transition,
 } from "./interaction-card-logic";
 import { OptionRow, StepperHeader } from "./interaction-card-parts";
@@ -57,12 +58,18 @@ export interface ChatInteractionCardProps {
     step: SigninStep,
     api: { onSignedIn: () => void },
   ) => ReactNode;
+  /** Dismisses the WHOLE interaction sequence. When omitted, the header shows no
+   *  dismiss (X) button. */
+  onDismiss?: () => void;
   disabled?: boolean;
   labels?: {
     placeholder?: string;
+    /** Visible label + aria-label of the commit-and-advance button ("Next"). */
     send?: string;
     back?: string;
     forward?: string;
+    skip?: string;
+    dismiss?: string;
     progress?: (current: number, total: number) => string;
   };
 }
@@ -70,16 +77,24 @@ export interface ChatInteractionCardProps {
 /**
  * The in-chat surface shown when the agent pauses to gather what it needs before
  * continuing: a stepper that walks the user through ONE step at a time (question
- * or connect), with a quiet "1 of X" progress and a back chevron. It REPLACES
- * the composer, so it borrows the composer's vocabulary (rounded-[28px] surface,
- * borderless inline textarea, round submit). The surface is grey (`bg-secondary`)
- * so the white option rows and free-text input read as raised, distinct chips.
+ * or connect). The header carries a "current/total" pill, the question text, and
+ * an optional dismiss X. ALL step-to-step navigation (back / skip / next) lives
+ * together in one footer row, Back leftmost, so there's a single place to look
+ * for "how do I move." A question step's option rows are also keyboard-selectable
+ * by their visible position number (1, 2, 3...) whenever focus isn't in a text
+ * field. It renders ABOVE the real composer (which the caller keeps mounted
+ * alongside it, see `chat-panel.tsx`), so it borrows the composer's vocabulary
+ * (rounded-[28px] surface, borderless inline textarea) without replacing it —
+ * typing directly into the real composer instead is the caller's job to treat
+ * as an implicit abandon of this card. The surface is grey (`bg-secondary`) so
+ * the white option rows and free-text input read as raised, distinct chips.
  */
 export function ChatInteractionCard({
   steps,
   onComplete,
   renderConnect,
   renderSignin,
+  onDismiss,
   disabled = false,
   labels,
 }: ChatInteractionCardProps) {
@@ -88,8 +103,11 @@ export function ChatInteractionCard({
   const total = steps.length;
   const current = Math.min(state.current, total - 1);
   const step = steps[current];
-  const placeholder = labels?.placeholder ?? "Type your answer...";
-  const sendLabel = labels?.send ?? "Send";
+  const placeholder = labels?.placeholder ?? "Type something else...";
+  const nextLabel = labels?.send ?? "Next";
+  const backLabel = labels?.back ?? "Back";
+  const forwardLabel = labels?.forward ?? "Next";
+  const skipLabel = labels?.skip ?? "Skip";
   const progress = labels?.progress ?? defaultProgress;
 
   const apply = useCallback(
@@ -113,9 +131,37 @@ export function ChatInteractionCard({
     [apply, disabled, state, steps],
   );
 
+  // Number-key shortcuts (1, 2, 3...) select the matching option row, mirroring
+  // the visible position numbers. Ignored while focus is in a text field, so
+  // typing digits into the free-text answer or the real composer is unaffected.
+  useEffect(() => {
+    if (disabled || !step || step.kind !== "question") return;
+    const options = step.options ?? [];
+    if (options.length === 0) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isEditable =
+        target?.tagName === "TEXTAREA" ||
+        target?.tagName === "INPUT" ||
+        target?.isContentEditable;
+      if (isEditable) return;
+      const option = options[Number(e.key) - 1];
+      if (!option) return;
+      e.preventDefault();
+      onOption(option.id);
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [disabled, step, onOption]);
+
   const onSend = useCallback(() => {
     if (disabled) return;
     apply(answerWithText(state, steps));
+  }, [apply, disabled, state, steps]);
+
+  const onSkip = useCallback(() => {
+    if (disabled) return;
+    apply(skipQuestion(state, steps));
   }, [apply, disabled, state, steps]);
 
   const onConnected = useCallback(() => {
@@ -127,7 +173,7 @@ export function ChatInteractionCard({
   }, [apply, state, steps]);
 
   const onKeyDown = useCallback(
-    (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    (e: ReactKeyboardEvent<HTMLTextAreaElement>) => {
       if (e.key === "Enter" && !e.shiftKey) {
         e.preventDefault();
         onSend();
@@ -152,18 +198,15 @@ export function ChatInteractionCard({
       )}
     >
       <div className="flex flex-col px-2.5 pt-2 pb-2">
-        {total > 1 && (
-          <StepperHeader
-            backLabel={labels?.back ?? "Back"}
-            canGoBack={current > 0}
-            canGoForward={canGoForward(state)}
-            disabled={disabled}
-            forwardLabel={labels?.forward ?? "Next"}
-            onBack={() => setState(goBack)}
-            onForward={() => setState(goForward)}
-            progressText={progress(current + 1, total)}
-          />
-        )}
+        <StepperHeader
+          current={current + 1}
+          disabled={disabled}
+          dismissLabel={labels?.dismiss ?? "Dismiss"}
+          onDismiss={onDismiss}
+          progressLabel={progress(current + 1, total)}
+          questionText={isQuestion ? step.question : undefined}
+          total={total}
+        />
 
         {/* Content changes, chrome doesn't: a single quiet fade on step swap. */}
         <div
@@ -172,20 +215,34 @@ export function ChatInteractionCard({
         >
           {isQuestion ? (
             <>
-              <p className={QUESTION_TEXT_CLASS}>{step.question}</p>
               {hasSelectableOptions(step.options) && (
                 <div className="mt-3 flex flex-col gap-2" role="radiogroup">
-                  {step.options?.map((option) => (
+                  {step.options?.map((option, index) => (
                     <OptionRow
                       disabled={disabled}
                       key={option.id}
                       onSelect={() => onOption(option.id)}
                       option={option}
+                      position={index + 1}
                       selected={selectedId === option.id}
                     />
                   ))}
                 </div>
               )}
+
+              <div className="mt-4 flex items-end gap-2 rounded-2xl border border-border/50 bg-background px-3 py-2 transition-colors focus-within:border-border">
+                <textarea
+                  className="max-h-40 flex-1 resize-none border-none bg-transparent py-1 text-base text-foreground leading-[1.2] outline-none placeholder:text-muted-foreground/50"
+                  disabled={disabled}
+                  onChange={(e) =>
+                    setState((s) => setDraft(s, stepId, e.target.value))
+                  }
+                  onKeyDown={onKeyDown}
+                  placeholder={placeholder}
+                  rows={1}
+                  value={draft}
+                />
+              </div>
             </>
           ) : step.kind === "signin" ? (
             renderSignin(step, { onSignedIn })
@@ -194,25 +251,61 @@ export function ChatInteractionCard({
           )}
         </div>
 
-        {isQuestion && (
-          <div className="mt-4 flex items-end gap-2 rounded-2xl border border-border/50 bg-background px-3 py-2 transition-colors focus-within:border-border">
-            <textarea
-              className="max-h-40 flex-1 resize-none border-none bg-transparent py-1 text-base text-foreground leading-[1.2] outline-none placeholder:text-muted-foreground/50"
-              disabled={disabled}
-              onChange={(e) =>
-                setState((s) => setDraft(s, stepId, e.target.value))
-              }
-              onKeyDown={onKeyDown}
-              placeholder={placeholder}
-              rows={1}
-              value={draft}
-            />
-            <PromptInputSubmit
-              aria-label={sendLabel}
-              className="shrink-0"
-              disabled={disabled || !canSend}
-              onClick={onSend}
-            />
+        {/* ALL step-to-step navigation lives here, one row, Back leftmost: a
+            single place to look for "how do I move." Back walks to the previous
+            already-reached step (any kind); Skip/Next are question-only (Next
+            commits, or on a revisited step re-commits the pre-filled answer,
+            which doubles as its own "forward"); a bare Forward only shows for a
+            revisited non-question step, since a connect/signin step's own card
+            can't re-fire its completion callback once already done. */}
+        {(current > 0 ||
+          isQuestion ||
+          (!isQuestion && canGoForward(state))) && (
+          <div className="mt-3 flex justify-end gap-2">
+            {current > 0 && (
+              <Button
+                disabled={disabled}
+                onClick={() => setState(goBack)}
+                size="sm"
+                type="button"
+                variant="outline"
+              >
+                {backLabel}
+              </Button>
+            )}
+            {isQuestion ? (
+              <>
+                <Button
+                  disabled={disabled}
+                  onClick={onSkip}
+                  size="sm"
+                  type="button"
+                  variant="outline"
+                >
+                  {skipLabel}
+                </Button>
+                <Button
+                  disabled={disabled || !canSend}
+                  onClick={onSend}
+                  size="sm"
+                  type="button"
+                >
+                  {nextLabel}
+                  <CornerDownLeftIcon className="size-4" />
+                </Button>
+              </>
+            ) : (
+              canGoForward(state) && (
+                <Button
+                  disabled={disabled}
+                  onClick={() => setState(goForward)}
+                  size="sm"
+                  type="button"
+                >
+                  {forwardLabel}
+                </Button>
+              )
+            )}
           </div>
         )}
       </div>

--- a/ui/chat/src/user-interaction-answers-message.tsx
+++ b/ui/chat/src/user-interaction-answers-message.tsx
@@ -1,0 +1,45 @@
+import type { InteractionAnswersPayload } from "./interaction-answers-message.ts";
+
+interface UserInteractionAnswersMessageProps {
+  payload: InteractionAnswersPayload;
+}
+
+/**
+ * Read-only card rendered in place of a plain user_message body when the user
+ * finished an `ask_user` interaction sequence. Each answered question shows as
+ * a small muted line with the user's answer in bold directly below; a
+ * non-question line (a connected app, a signin confirmation) shows as a single
+ * bold line. Sits in the right column of the conversation where user bubbles
+ * live, matching the Skill / attachment bubble family. Content is pass-through
+ * data, so no i18n labels are needed.
+ */
+export function UserInteractionAnswersMessage({
+  payload,
+}: UserInteractionAnswersMessageProps) {
+  return (
+    <div className="flex max-w-md flex-col items-end gap-2">
+      <div className="inline-block max-w-full rounded-2xl bg-secondary px-4 py-3 text-left">
+        <div className="flex flex-col gap-3">
+          {payload.lines.map((line, index) => (
+            <div
+              // Lines are an ordered, stable list rebuilt only on new messages;
+              // there is no better key than position for these pass-through rows.
+              // biome-ignore lint/suspicious/noArrayIndexKey: order-stable render list
+              key={index}
+              className="flex flex-col gap-0.5"
+            >
+              {line.question !== undefined && (
+                <span className="text-xs leading-5 text-muted-foreground">
+                  {line.question}
+                </span>
+              )}
+              <span className="whitespace-pre-wrap break-words text-sm font-semibold leading-6 text-foreground">
+                {line.answer}
+              </span>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/ui/chat/tests/chat-suggest-reusable-card.test.ts
+++ b/ui/chat/tests/chat-suggest-reusable-card.test.ts
@@ -1,0 +1,44 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  type ChatSuggestReusableLabels,
+  DEFAULT_SUGGEST_REUSABLE_LABELS,
+  resolveSuggestReusableSaveLabel,
+} from "../src/chat-suggest-reusable-card-model.ts";
+
+const LABELS: ChatSuggestReusableLabels = {
+  eyebrow: "Save this for next time",
+  skillTitle: "Save as a Skill",
+  routineTitle: "Save as a Routine",
+  notNow: "Not now",
+};
+
+describe("resolveSuggestReusableSaveLabel", () => {
+  it("uses the skill label for a skill suggestion", () => {
+    assert.equal(
+      resolveSuggestReusableSaveLabel("skill", LABELS),
+      "Save as a Skill",
+    );
+  });
+
+  it("uses the routine label for a routine suggestion", () => {
+    assert.equal(
+      resolveSuggestReusableSaveLabel("routine", LABELS),
+      "Save as a Routine",
+    );
+  });
+});
+
+describe("DEFAULT_SUGGEST_REUSABLE_LABELS", () => {
+  it("ships the English fallback copy with no em dashes", () => {
+    assert.equal(DEFAULT_SUGGEST_REUSABLE_LABELS.skillTitle, "Save as a Skill");
+    assert.equal(
+      DEFAULT_SUGGEST_REUSABLE_LABELS.routineTitle,
+      "Save as a Routine",
+    );
+    assert.equal(DEFAULT_SUGGEST_REUSABLE_LABELS.notNow, "Not now");
+    for (const value of Object.values(DEFAULT_SUGGEST_REUSABLE_LABELS)) {
+      assert.ok(!value.includes("—"), `"${value}" must not use an em dash`);
+    }
+  });
+});

--- a/ui/chat/tests/interaction-answers-message.test.ts
+++ b/ui/chat/tests/interaction-answers-message.test.ts
@@ -1,0 +1,102 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { decodeInteractionAnswersMessage } from "../src/interaction-answers-message.ts";
+
+const marker = (json: string, body = "the flat body") =>
+  `<!--houston:interaction-answers ${json}-->\n\n${body}`;
+
+describe("decodeInteractionAnswersMessage", () => {
+  it("decodes a valid payload of question + answer pairs", () => {
+    const payload = decodeInteractionAnswersMessage(
+      marker(
+        JSON.stringify({
+          lines: [
+            { question: "To whom?", answer: "john@example.com" },
+            { question: "Saying what?", answer: "Running late" },
+          ],
+        }),
+      ),
+    );
+    assert.deepEqual(payload, {
+      lines: [
+        { question: "To whom?", answer: "john@example.com" },
+        { question: "Saying what?", answer: "Running late" },
+      ],
+    });
+  });
+
+  it("keeps question-less lines (connected app / signin) as answer-only", () => {
+    const payload = decodeInteractionAnswersMessage(
+      marker(
+        JSON.stringify({
+          lines: [
+            { question: "To whom?", answer: "john@example.com" },
+            { answer: "Signed in to Houston." },
+            { answer: "Connected Gmail." },
+          ],
+        }),
+      ),
+    );
+    assert.deepEqual(payload, {
+      lines: [
+        { question: "To whom?", answer: "john@example.com" },
+        { answer: "Signed in to Houston." },
+        { answer: "Connected Gmail." },
+      ],
+    });
+  });
+
+  it("returns null for plain text with no marker", () => {
+    assert.equal(decodeInteractionAnswersMessage("just a message"), null);
+  });
+
+  it("returns null for malformed marker JSON", () => {
+    assert.equal(
+      decodeInteractionAnswersMessage(marker("{not valid json")),
+      null,
+    );
+  });
+
+  it("drops individual entries missing a string answer but keeps the rest", () => {
+    const payload = decodeInteractionAnswersMessage(
+      marker(
+        JSON.stringify({
+          lines: [
+            { question: "Q1", answer: "kept" },
+            { question: "Q2" },
+            { question: "Q3", answer: 42 },
+            null,
+            "nope",
+            { question: 7, answer: "kept too" },
+          ],
+        }),
+      ),
+    );
+    assert.deepEqual(payload, {
+      lines: [{ question: "Q1", answer: "kept" }, { answer: "kept too" }],
+    });
+  });
+
+  it("returns null when lines is not an array", () => {
+    assert.equal(
+      decodeInteractionAnswersMessage(marker(JSON.stringify({ lines: "x" }))),
+      null,
+    );
+  });
+
+  it("returns null when lines is empty after filtering", () => {
+    assert.equal(
+      decodeInteractionAnswersMessage(
+        marker(JSON.stringify({ lines: [{ question: "Q" }, {}] })),
+      ),
+      null,
+    );
+  });
+
+  it("returns null when lines is an empty array", () => {
+    assert.equal(
+      decodeInteractionAnswersMessage(marker(JSON.stringify({ lines: [] }))),
+      null,
+    );
+  });
+});

--- a/ui/chat/tests/interaction-card.test.ts
+++ b/ui/chat/tests/interaction-card.test.ts
@@ -17,15 +17,11 @@ import {
   isLastStep,
   normalizeAnswer,
   optionLabel,
-  QUESTION_TEXT_CLASS,
   selectedOptionId,
   setDraft,
+  skipQuestion,
   toCompletedAnswers,
 } from "../src/interaction-card-logic.ts";
-
-function tokens(className: string): Set<string> {
-  return new Set(className.split(/\s+/).filter(Boolean));
-}
 
 const Q1: ChatInteractionStep = {
   kind: "question",
@@ -196,6 +192,43 @@ describe("stepper flow: question, question, connect", () => {
   });
 });
 
+describe("skipQuestion", () => {
+  const steps = [Q1, Q2, CONNECT];
+
+  it("skips a middle question and omits it from the completed answers", () => {
+    let s = skipQuestion(initialStepperState(), steps).state; // skip Q1 -> Q2
+    assert.equal(s.current, 1);
+    assert.equal(s.answers.q1, undefined);
+    s = setDraft(s, "q2", "Running late");
+    s = answerWithText(s, steps).state; // answer Q2 -> connect
+    const done = advanceConnect(s, steps);
+    assert.deepEqual(done.completed, [
+      { stepId: "q2", question: "What should it say?", answer: "Running late" },
+    ]);
+  });
+
+  it("skipping the LAST question still completes with the prior answers", () => {
+    const s = answerWithOption(initialStepperState(), [Q1, Q2], "o1").state;
+    assert.equal(s.current, 1); // on Q2, the last step
+    const done = skipQuestion(s, [Q1, Q2]);
+    assert.deepEqual(done.completed, [
+      { stepId: "q1", question: "Who is it for?", answer: "John" },
+    ]);
+  });
+
+  it("is a no-op on a non-question step", () => {
+    const s = answerWithOption(
+      initialStepperState(),
+      [Q1, CONNECT],
+      "o1",
+    ).state;
+    assert.equal(s.current, 1); // on the connect step
+    const t = skipQuestion(s, [Q1, CONNECT]);
+    assert.equal(t.state, s);
+    assert.equal(t.completed, undefined);
+  });
+});
+
 describe("stepper flow: question, signin, connect", () => {
   const steps = [Q2, SIGNIN, CONNECT];
 
@@ -335,13 +368,5 @@ describe("toCompletedAnswers", () => {
       { stepId: "q1", question: "Who is it for?", answer: "John" },
       { stepId: "q2", question: "What should it say?", answer: "hi" },
     ]);
-  });
-});
-
-describe("interaction-card class tokens", () => {
-  it("renders each step's question prominently (text-lg)", () => {
-    const t = tokens(QUESTION_TEXT_CLASS);
-    assert.ok(t.has("text-lg"));
-    assert.ok(t.has("font-medium"));
   });
 });

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -521,7 +521,19 @@ export type InteractionStep =
   | { kind: "connect"; id: string; toolkit: string; reason?: string }
   /** The model finished planning: a short plan summary the user approves by
    *  choosing a mode (start working / Autopilot) or dismisses to keep planning. */
-  | { kind: "plan_ready"; id: string; summary: string };
+  | { kind: "plan_ready"; id: string; summary: string }
+  /** The model finished cleanly and offers to save the just-completed work as a
+   *  reusable Skill or a scheduled Routine. Optional and dismissible: unlike the
+   *  other kinds, a lone `suggest_reusable` step does NOT flip the board to
+   *  `needs_you` (the mission genuinely finished). Mirrors
+   *  `packages/protocol/src/domain/interaction.ts`. */
+  | {
+      kind: "suggest_reusable";
+      id: string;
+      reusableKind: "skill" | "routine";
+      title: string;
+      rationale: string;
+    };
 
 /**
  * The ordered steps a mission is waiting on the user for — recorded when the


### PR DESCRIPTION
Four user-facing changes to the chat and onboarding experience, shipped together:

## 1. Planner is the default chat mode
`DEFAULT_TURN_MODE` flips to `plan`; `normalizeTurnMode` falls back to it (recognizing `execute` explicitly). Fresh agents open in Planner; remembered per-agent picks still win.

## 2. Onboarding: connect-email skip always offered
The skip affordance was hidden on the happy path, stranding fresh users on a non-skippable step. It now always shows (except mid-connect), with a confirm dialog as the friction instead. en/es/pt.

## 3. Agent suggests saving finished work as a Skill or Routine
New `suggest_reusable` runtime tool: on a clean finish the model may propose saving the just-completed work. Rides the terminal `done` frame as a new `InteractionStep` kind, renders as a dismissible offer card. **A lone suggestion settles the board to `done`, not `needs_you`** — the offer is optional. Reaches execute+auto, never plan. Prompt guidance in TS + Rust mirror.

## 4. Interaction cards float above an always-visible composer (inventory v12)
- Composer stays mounted under any card (questions / plan_ready / suggest_reusable); typing there — or the new dismiss X — abandons the sequence.
- Question card: current/total pill, numbered option rows selectable by number key, "Type something else..." free-text (option lists never need an "Other" row — ask_user guidance updated), one footer nav row: Back / Skip / Next.
- Completed sequences send a marker-encoded message rendered as structured Q&A pairs; the plain-text body the model reads is unchanged.

## Verification
- Typecheck all 22 workspace projects; Biome; boundaries; parity (inventory v12 + manifests); check-locales.
- Tests: app 1268, runtime 591, host 693, sdk 261, ui/chat 137 — all green post-rebase onto C8 Spaces main.
- Full Playwright e2e suite (53/53) including new specs: type-to-abandon, dismiss X, number-key selection, structured answers bubble.
- Live browser verification of the redesign via fake-host harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)