### PR TITLE
fix(integrations): agents discover unconnected apps; blocked apps show as locked, not absent

### DIFF
--- a/app/src-tauri/src/houston_prompt/integrations.rs
+++ b/app/src-tauri/src/houston_prompt/integrations.rs
@@ -8,21 +8,31 @@ pub const PI_INTEGRATIONS_GUIDANCE: &str = "\n\n---\n\n\
 You can act on the user's apps (Gmail, Google Calendar, Slack, Notion, and \
 many more) with two tools: `integration_search` finds an action and its \
 input parameters; `integration_execute` runs it. Search first, then \
-execute. The user's own account is used automatically - you never handle \
+execute. The user's own account is used automatically, you never handle \
 credentials.\n\n\
-When a needed app is not connected yet (search marks its actions NOT \
-CONNECTED, or execute fails because no account is linked):\n\n\
-1. Briefly say what must be connected and why, in plain language.\n\
-2. Call the `request_connection` tool for that app, with a short \
-   user-facing reason. Houston shows the user a connect card with a \
-   one-click button in place of the chat box, so there is nothing for you \
-   to write out. Call it once per app that needs connecting, then end your \
-   turn.\n\
-3. Do NOT ask the user to tell you when they're done, and do NOT promise \
-   to \"check\" the connection yourself. Houston detects the moment the \
-   connection goes live and automatically sends you a short message \
-   (e.g. \"I've connected Gmail. Please continue.\") so you can resume the \
-   task on your own. Then stop and wait.\n\n\
+Each search result reports the app's status. Act on the status, one of \
+four:\n\n\
+- Connected: the user already linked this app. Use it: pick the action and \
+   run it with `integration_execute`.\n\
+- Connectable (the app exists but the user has not linked it yet, shown as \
+   NOT CONNECTED): briefly say what must be connected and why, then call the \
+   `request_connection` tool for that app with a short user-facing reason. \
+   Houston shows a one-click connect card in place of the chat box, so there \
+   is nothing for you to write out. Do NOT ask the user to tell you when \
+   they're done and do NOT promise to \"check\" it yourself: Houston detects \
+   the moment the connection goes live and automatically sends you a short \
+   message (e.g. \"I've connected Gmail. Please continue.\") so you can \
+   resume on your own. Then stop and wait.\n\
+- Blocked by admin: the app is real, but the workspace admin has not enabled \
+   it for this agent. Tell the user their admin needs to enable it and to \
+   ask them. NEVER call `request_connection` for a blocked app, and never \
+   imply Houston does not support it.\n\
+- No such app: when the search returns nothing at all, say plainly that no \
+   such app is available.\n\n\
+An empty search result means no matching app or action was found. It does \
+NOT mean the app is unsupported or withheld by policy. Trust the status the \
+search reports: never tell the user an app does not exist, or is \
+unavailable, when the search shows it as connectable or blocked.\n\n\
 If Houston reports that the user must sign in first, a sign-in card joins \
 the same interaction card automatically. Keep queueing whatever else the \
 task needs (call `request_connection` for any app, `ask_user` for any \

--- a/app/src/components/integrations/app-catalog-grid.tsx
+++ b/app/src/components/integrations/app-catalog-grid.tsx
@@ -6,9 +6,10 @@ import { useTranslation } from "react-i18next";
 import { FilterCombobox } from "../shell/filter-combobox.tsx";
 import { type AppDisplay, appDisplay } from "./app-display";
 import { AppRow } from "./app-row";
+import { CatalogLockedSection } from "./catalog-locked-section";
 import {
   BROWSE_PAGE_SIZE,
-  browseCatalog,
+  browseCatalogView,
   categoriesOf,
   categoryLabel,
 } from "./model";
@@ -30,6 +31,12 @@ interface AppCatalogGridProps {
   onCategoryChange: (next: string) => void;
   /** Apps to hide entirely (e.g. already-connected in the connect flow). */
   excludeToolkits?: ReadonlySet<string>;
+  /**
+   * The Teams effective allowlist. When set, apps outside it render as LOCKED
+   * rows below the connectable grid instead of vanishing; `null`/absent (single-
+   * player, or a Teams host with no ceiling) = no locks ever.
+   */
+  allowlist?: string[] | null;
   /** The catalog is still fetching (show a loader, not a "no apps" message). */
   loading?: boolean;
   /** Per-app trailing control (+ optional row click). Owns the row's action. */
@@ -51,6 +58,7 @@ export function AppCatalogGrid({
   category,
   onCategoryChange,
   excludeToolkits,
+  allowlist,
   loading,
   renderRow,
 }: AppCatalogGridProps) {
@@ -65,29 +73,31 @@ export function AppCatalogGrid({
       })),
     [catalog],
   );
-  const results = useMemo(
+  const { connectable, locked } = useMemo(
     () =>
-      browseCatalog({
+      browseCatalogView({
         catalog,
         query: search,
         category,
         connected: excludeToolkits ?? new Set(),
+        allowlist: allowlist ?? null,
       }),
-    [catalog, search, category, excludeToolkits],
+    [catalog, search, category, excludeToolkits, allowlist],
   );
 
   // A fresh result list (new search or category) collapses the page cap back to
   // the first page. Adjusting state during render (React's documented pattern)
   // keeps the reset in sync with the new list identity without a wasted paint.
+  // Only the connectable list paginates; the locked group is separately capped.
   const [visible, setVisible] = useState(BROWSE_PAGE_SIZE);
-  const [shownFor, setShownFor] = useState(results);
-  if (shownFor !== results) {
-    setShownFor(results);
+  const [shownFor, setShownFor] = useState(connectable);
+  if (shownFor !== connectable) {
+    setShownFor(connectable);
     setVisible(BROWSE_PAGE_SIZE);
   }
 
-  const visibleApps = results.slice(0, visible);
-  const hasMore = visible < results.length;
+  const visibleApps = connectable.slice(0, visible);
+  const hasMore = visible < connectable.length;
 
   return (
     <div>
@@ -116,7 +126,7 @@ export function AppCatalogGrid({
         )}
       </div>
 
-      {results.length === 0 ? (
+      {connectable.length === 0 && locked.length === 0 ? (
         loading ? (
           <div className="flex items-center justify-center gap-2 py-6 text-sm text-muted-foreground">
             <Spinner className="size-4" />
@@ -129,34 +139,39 @@ export function AppCatalogGrid({
         )
       ) : (
         <>
-          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-            {visibleApps.map((tk) => {
-              const display = appDisplay(tk.slug, tk);
-              const row = renderRow(display, tk);
-              return (
-                <AppRow
-                  key={tk.slug}
-                  display={display}
-                  description={display.description}
-                  onClick={row.onClick}
-                  trailing={row.trailing}
-                />
-              );
-            })}
-          </div>
-          {hasMore && (
-            <div className="mt-4 flex justify-center">
-              <button
-                type="button"
-                onClick={() => setVisible((v) => v + BROWSE_PAGE_SIZE)}
-                className="inline-flex h-8 items-center gap-1 rounded-full border border-border bg-background px-4 text-xs font-medium text-foreground transition-colors hover:bg-secondary"
-              >
-                {t("browse.loadMoreWithRemaining", {
-                  count: results.length - visible,
+          {connectable.length > 0 && (
+            <>
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {visibleApps.map((tk) => {
+                  const display = appDisplay(tk.slug, tk);
+                  const row = renderRow(display, tk);
+                  return (
+                    <AppRow
+                      key={tk.slug}
+                      display={display}
+                      description={display.description}
+                      onClick={row.onClick}
+                      trailing={row.trailing}
+                    />
+                  );
                 })}
-              </button>
-            </div>
+              </div>
+              {hasMore && (
+                <div className="mt-4 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => setVisible((v) => v + BROWSE_PAGE_SIZE)}
+                    className="inline-flex h-8 items-center gap-1 rounded-full border border-border bg-background px-4 text-xs font-medium text-foreground transition-colors hover:bg-secondary"
+                  >
+                    {t("browse.loadMoreWithRemaining", {
+                      count: connectable.length - visible,
+                    })}
+                  </button>
+                </div>
+              )}
+            </>
           )}
+          {locked.length > 0 && <CatalogLockedSection locked={locked} />}
         </>
       )}
     </div>

--- a/app/src/components/integrations/catalog-browser.tsx
+++ b/app/src/components/integrations/catalog-browser.tsx
@@ -15,6 +15,8 @@ interface CatalogBrowserProps {
   /** Toolkits to hide entirely (agent context surfaces them elsewhere, e.g. in
    *  the "Ready to activate" group), so no app is listed twice. */
   excludeToolkits?: ReadonlySet<string>;
+  /** The Teams effective allowlist; apps outside it render locked (`null` = none). */
+  allowlist?: string[] | null;
   /** The catalog is still fetching (show a loader, not a "no apps" message). */
   loading?: boolean;
   onConnect: (toolkit: string) => void;
@@ -34,6 +36,7 @@ export function CatalogBrowser({
   connectedToolkits,
   connectingToolkit,
   excludeToolkits,
+  allowlist,
   loading,
   onConnect,
 }: CatalogBrowserProps) {
@@ -46,6 +49,7 @@ export function CatalogBrowser({
       category={category}
       onCategoryChange={onCategoryChange}
       excludeToolkits={excludeToolkits}
+      allowlist={allowlist}
       loading={loading}
       renderRow={(_display, tk) => {
         if (connectedToolkits.has(tk.slug)) {

--- a/app/src/components/integrations/catalog-locked-section.tsx
+++ b/app/src/components/integrations/catalog-locked-section.tsx
@@ -1,0 +1,55 @@
+import type { IntegrationToolkit } from "@houston-ai/engine-client";
+import { Lock } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { appDisplay } from "./app-display";
+import { AppRow } from "./app-row";
+import { LOCKED_PREVIEW_CAP } from "./model";
+
+interface CatalogLockedSectionProps {
+  /** Policy-blocked apps (already filtered + A-Z), rendered read-only. */
+  locked: IntegrationToolkit[];
+}
+
+/**
+ * The policy-blocked apps in the browse catalog, shown as LOCKED rows instead of
+ * being hidden. So a member who searches for an app their admin hasn't enabled
+ * finds a locked row, with the ask-your-admin line visible at rest, rather than
+ * an empty list that reads as "Houston doesn't support it". Each row is
+ * non-interactive (a lock icon where Connect would sit, no click) and carries the
+ * ask-admin subtitle. Capped at {@link LOCKED_PREVIEW_CAP} with a "+N more" line
+ * so a tiny allowlist over the ~1000-app catalog can't flood past the connectable
+ * apps above. Only rendered on a Teams host with a real ceiling — the caller
+ * passes an empty `locked` list off Teams, so nothing shows.
+ */
+export function CatalogLockedSection({ locked }: CatalogLockedSectionProps) {
+  const { t } = useTranslation("integrations");
+  const shown = locked.slice(0, LOCKED_PREVIEW_CAP);
+  const overflow = locked.length - shown.length;
+
+  return (
+    <section className="mt-6">
+      <h4 className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <Lock className="size-3.5" />
+        {t("locked.heading")}
+      </h4>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+        {shown.map((tk) => {
+          const display = appDisplay(tk.slug, tk);
+          return (
+            <AppRow
+              key={tk.slug}
+              display={display}
+              description={t("locked.askAdmin", { name: display.name })}
+              trailing={<Lock className="size-3.5 text-muted-foreground/70" />}
+            />
+          );
+        })}
+      </div>
+      {overflow > 0 && (
+        <p className="mt-2 text-xs text-muted-foreground">
+          {t("locked.more", { count: overflow })}
+        </p>
+      )}
+    </section>
+  );
+}

--- a/app/src/components/integrations/connect-more-apps.tsx
+++ b/app/src/components/integrations/connect-more-apps.tsx
@@ -20,6 +20,11 @@ interface ConnectMoreAppsSectionProps {
    */
   category: string;
   onCategoryChange: (next: string) => void;
+  /**
+   * The Teams effective allowlist (`null` = unrestricted). Apps outside it show
+   * as locked rows instead of being hidden, and the headline count excludes them.
+   */
+  allowlist?: string[] | null;
   /** The catalog is still fetching (show a loader, not a "no apps" message). */
   loading?: boolean;
 }
@@ -39,6 +44,7 @@ export function ConnectMoreAppsSection({
   connectFlow,
   category,
   onCategoryChange,
+  allowlist,
   loading,
 }: ConnectMoreAppsSectionProps) {
   const { t } = useTranslation("integrations");
@@ -53,15 +59,17 @@ export function ConnectMoreAppsSection({
     [connections],
   );
   // How many apps are still connectable — shown next to the title so the ~1000+
-  // catalog reads as a headline number, not a hidden dialog.
-  const availableCount = useMemo(
-    () =>
-      catalog.reduce(
-        (n, tk) => (connectedToolkits.has(tk.slug) ? n : n + 1),
-        0,
-      ),
-    [catalog, connectedToolkits],
-  );
+  // catalog reads as a headline number, not a hidden dialog. Policy-blocked apps
+  // (outside the Teams allowlist) are NOT connectable, so they're excluded here
+  // even though they still render below as locked rows.
+  const availableCount = useMemo(() => {
+    const allowed = allowlist == null ? null : new Set(allowlist);
+    return catalog.reduce((n, tk) => {
+      if (connectedToolkits.has(tk.slug)) return n;
+      if (allowed && !allowed.has(tk.slug)) return n;
+      return n + 1;
+    }, 0);
+  }, [catalog, connectedToolkits, allowlist]);
 
   const connecting = connectFlow.state;
   const connectingName = connecting
@@ -95,6 +103,7 @@ export function ConnectMoreAppsSection({
         connectedToolkits={connectedToolkits}
         connectingToolkit={connecting?.toolkit ?? null}
         excludeToolkits={connectedToolkits}
+        allowlist={allowlist}
         loading={loading}
         onConnect={(toolkit) => void connectFlow.connect(toolkit)}
       />

--- a/app/src/components/integrations/index.ts
+++ b/app/src/components/integrations/index.ts
@@ -17,12 +17,15 @@ export {
 export { IntegrationDisconnectDialog } from "./integration-disconnect-dialog";
 export {
   BROWSE_PAGE_SIZE,
+  type BrowseCatalogView,
   browseCatalog,
+  browseCatalogView,
   type CategoryListView,
   categoriesOf,
   categoryLabel,
   categoryListView,
   INTEGRATION_PROVIDER,
+  LOCKED_PREVIEW_CAP,
   POLL_INTERVAL_MS,
   POLL_MAX_ATTEMPTS,
   type PollOutcome,

--- a/app/src/components/integrations/model.ts
+++ b/app/src/components/integrations/model.ts
@@ -69,6 +69,53 @@ export function browseCatalog(opts: {
 }
 
 /**
+ * Max policy-blocked (locked) apps shown inline in the browse catalog before the
+ * rest collapse into a "+N more" count line. Caps the locked group so a tiny
+ * Teams allowlist over the ~1000-app catalog can't bury the connectable apps.
+ */
+export const LOCKED_PREVIEW_CAP = 8;
+
+/** The browse catalog split by the Teams allowlist ceiling. Both lists A-Z. */
+export interface BrowseCatalogView {
+  /** Apps the member may connect right now (inside the ceiling). */
+  connectable: IntegrationToolkit[];
+  /** Apps the ceiling BLOCKS — shown as locked rows, never connectable. */
+  locked: IntegrationToolkit[];
+}
+
+/**
+ * Partition the browse catalog into the apps a member may connect and the apps a
+ * Teams allowlist ceiling BLOCKS, after the same category + search +
+ * connected-exclusion filter {@link browseCatalog} applies. `allowlist === null`
+ * means unrestricted (single-player, or a Teams host with no ceiling), so nothing
+ * is ever locked — locks never appear off Teams. Both lists keep `browseCatalog`'s
+ * A-Z order so the surface renders the actionable `connectable` apps first and the
+ * `locked` group after them. Pure so it's unit-testable.
+ */
+export function browseCatalogView(opts: {
+  catalog: IntegrationToolkit[];
+  query: string;
+  category: string;
+  connected: ReadonlySet<string>;
+  allowlist: string[] | null;
+}): BrowseCatalogView {
+  const results = browseCatalog({
+    catalog: opts.catalog,
+    query: opts.query,
+    category: opts.category,
+    connected: opts.connected,
+  });
+  if (opts.allowlist === null) return { connectable: results, locked: [] };
+  const allowed = new Set(opts.allowlist);
+  const connectable: IntegrationToolkit[] = [];
+  const locked: IntegrationToolkit[] = [];
+  for (const t of results) {
+    (allowed.has(t.slug) ? connectable : locked).push(t);
+  }
+  return { connectable, locked };
+}
+
+/**
  * Split the user's connections into the two grant buckets:
  *
  *  - `granted`   — connected AND in this agent's grant set.

--- a/app/src/components/tabs/agent-integrations/agent-allowlist-section.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-allowlist-section.tsx
@@ -104,9 +104,12 @@ export function AgentAllowlistSection({
 
   return (
     <div>
-      <h2 className="mb-4 text-lg font-medium text-foreground">
+      <h2 className="mb-1 text-lg font-medium text-foreground">
         {t("integrations.allowlist.question")}
       </h2>
+      <p className="mb-4 text-sm text-muted-foreground">
+        {t("integrations.allowlist.policyHelper")}
+      </p>
 
       <AccessChoice
         question={t("integrations.allowlist.question")}

--- a/app/src/components/tabs/agent-integrations/agent-integrations-body.tsx
+++ b/app/src/components/tabs/agent-integrations/agent-integrations-body.tsx
@@ -17,7 +17,8 @@ interface AgentIntegrationsBodyProps {
   canEdit: boolean;
   /** The full toolkit catalog (drives the category filter + browse list). */
   catalog: IntegrationToolkit[];
-  /** The effective Teams allowlist (`null` = unrestricted) narrowing browse. */
+  /** The effective Teams allowlist (`null` = unrestricted). Apps outside it show
+   *  as locked rows in the browse catalog rather than being hidden. */
   allowlist: string[] | null;
   /** The account's connections, so browse can hide already-connected apps. */
   connections: IntegrationConnection[];
@@ -63,14 +64,6 @@ export function AgentIntegrationsBody({
     [catalog, category],
   );
 
-  // The browse catalog is narrowed to the effective allowlist so a member can
-  // only connect apps the agent is allowed to use (null = unrestricted).
-  const browseCatalog = useMemo(() => {
-    if (allowlist === null) return catalog;
-    const set = new Set(allowlist);
-    return catalog.filter((tk) => set.has(tk.slug));
-  }, [catalog, allowlist]);
-
   return (
     <>
       <AgentAppsBody
@@ -86,11 +79,12 @@ export function AgentIntegrationsBody({
 
       <div className="mt-8">
         <ConnectMoreAppsSection
-          catalog={browseCatalog}
+          catalog={catalog}
           connections={connections}
           connectFlow={connectFlow}
           category={category}
           onCategoryChange={setCategory}
+          allowlist={allowlist}
           loading={catalogLoading}
         />
       </div>

--- a/app/src/locales/en/integrations.json
+++ b/app/src/locales/en/integrations.json
@@ -69,6 +69,12 @@
   "connectMore": {
     "title": "Connect more apps"
   },
+  "locked": {
+    "heading": "Not enabled by your admin",
+    "askAdmin": "Ask your admin to enable {{name}}",
+    "more_one": "{{count}} more app your admin hasn't enabled",
+    "more_other": "{{count}} more apps your admin hasn't enabled"
+  },
   "chips": {
     "more": "+{{count}}"
   },

--- a/app/src/locales/en/teams.json
+++ b/app/src/locales/en/teams.json
@@ -48,6 +48,7 @@
   "integrations": {
     "allowlist": {
       "question": "Which apps can this agent use?",
+      "policyHelper": "You decide which apps this agent is allowed to use. People with access still connect their own accounts for each app you allow.",
       "anyLabel": "Any app",
       "anyDesc": "People with access can connect this agent to any of 1000+ apps.",
       "pickedLabel": "Only apps you pick",
@@ -60,7 +61,7 @@
     },
     "notAllowed": {
       "title": "Not allowed for this agent",
-      "body": "These apps are connected to your account, but your organization does not allow this agent to use them.",
+      "body": "These apps are connected to your account, but this agent isn't allowed to use them. Ask your admin to enable them for this agent.",
       "badge": "Not allowed"
     }
   },

--- a/app/src/locales/es/integrations.json
+++ b/app/src/locales/es/integrations.json
@@ -69,6 +69,12 @@
   "connectMore": {
     "title": "Conecta más apps"
   },
+  "locked": {
+    "heading": "No habilitadas por tu administrador",
+    "askAdmin": "Pídele a tu administrador que habilite {{name}}",
+    "more_one": "{{count}} app más que tu administrador no ha habilitado",
+    "more_other": "{{count}} apps más que tu administrador no ha habilitado"
+  },
   "chips": {
     "more": "+{{count}}"
   },

--- a/app/src/locales/es/teams.json
+++ b/app/src/locales/es/teams.json
@@ -48,6 +48,7 @@
   "integrations": {
     "allowlist": {
       "question": "¿Qué apps puede usar este agente?",
+      "policyHelper": "Tú decides qué apps tiene permitido usar este agente. Las personas con acceso siguen conectando sus propias cuentas para cada app que permitas.",
       "anyLabel": "Cualquier app",
       "anyDesc": "Las personas con acceso pueden conectar este agente a más de 1000 apps.",
       "pickedLabel": "Solo las apps que elijas",
@@ -60,7 +61,7 @@
     },
     "notAllowed": {
       "title": "No permitida para este agente",
-      "body": "Estas aplicaciones están conectadas a tu cuenta, pero tu organización no permite que este agente las use.",
+      "body": "Estas aplicaciones están conectadas a tu cuenta, pero este agente no tiene permitido usarlas. Pídele a tu administrador que las habilite para este agente.",
       "badge": "No permitida"
     }
   },

--- a/app/src/locales/pt/integrations.json
+++ b/app/src/locales/pt/integrations.json
@@ -69,6 +69,12 @@
   "connectMore": {
     "title": "Conecte mais apps"
   },
+  "locked": {
+    "heading": "Não habilitados pelo seu administrador",
+    "askAdmin": "Peça ao seu administrador para habilitar {{name}}",
+    "more_one": "{{count}} app a mais que seu administrador não habilitou",
+    "more_other": "{{count}} apps a mais que seu administrador não habilitou"
+  },
   "chips": {
     "more": "+{{count}}"
   },

--- a/app/src/locales/pt/teams.json
+++ b/app/src/locales/pt/teams.json
@@ -48,6 +48,7 @@
   "integrations": {
     "allowlist": {
       "question": "Quais apps este agente pode usar?",
+      "policyHelper": "Você decide quais apps este agente tem permissão para usar. Pessoas com acesso continuam conectando as próprias contas para cada app que você permitir.",
       "anyLabel": "Qualquer app",
       "anyDesc": "Pessoas com acesso podem conectar este agente a mais de 1000 apps.",
       "pickedLabel": "Apenas os apps que você escolher",
@@ -60,7 +61,7 @@
     },
     "notAllowed": {
       "title": "Não permitido para este agente",
-      "body": "Estes aplicativos estão conectados à sua conta, mas sua organização não permite que este agente os use.",
+      "body": "Estes aplicativos estão conectados à sua conta, mas este agente não tem permissão para usá-los. Peça ao seu administrador para habilitá-los para este agente.",
       "badge": "Não permitido"
     }
   },

--- a/app/tests/agent-integrations.test.ts
+++ b/app/tests/agent-integrations.test.ts
@@ -180,17 +180,26 @@ describe("E7 integrations tab source", () => {
     ok(!src.includes("isAgentManager"), "manager gate no longer needed");
   });
 
-  it("keeps the effective-allowlist filtering of the browse catalog", () => {
-    // The tab still computes the ceiling and hands it to the body, which owns
-    // the browse-catalog narrowing after the per-agent extraction below.
+  it("hands the effective allowlist down so blocked apps render as locked rows", () => {
+    // The tab still computes the ceiling and hands it to the body, which now
+    // passes it to the browse section — blocked apps render as LOCKED rows there
+    // (via browseCatalogView + CatalogLockedSection) instead of being filtered
+    // out and vanishing silently.
     ok(src.includes("effectiveAllowlist"), "still computes the ceiling");
     ok(src.includes("useAgentSettings"), "still reads agent settings");
     ok(src.includes("allowlist={allowlist}"), "hands the ceiling to the body");
     const body = read(
       "../src/components/tabs/agent-integrations/agent-integrations-body.tsx",
     );
-    ok(body.includes("browseCatalog"), "body narrows the browse catalog");
     ok(body.includes("ConnectMoreAppsSection"), "browse section stays");
+    ok(
+      body.includes("allowlist={allowlist}"),
+      "body hands the ceiling to the browse section (locks, not pre-filter)",
+    );
+    ok(
+      !body.includes("catalog.filter"),
+      "body no longer pre-filters blocked apps out of the catalog",
+    );
   });
 
   it("remounts its stateful body per agent so view filters never leak", () => {

--- a/app/tests/integrations-module-catalog.test.ts
+++ b/app/tests/integrations-module-catalog.test.ts
@@ -6,6 +6,7 @@ import type {
 } from "@houston-ai/engine-client";
 import {
   browseCatalog,
+  browseCatalogView,
   categoriesOf,
   categoryLabel,
   categoryListView,
@@ -121,6 +122,111 @@ describe("browseCatalog (new module)", () => {
         connected: new Set(),
       }),
       [],
+    );
+  });
+});
+
+describe("browseCatalogView (allowlist partition)", () => {
+  it("single-player (allowlist null) → everything connectable, nothing locked", () => {
+    const view = browseCatalogView({
+      catalog: CATALOG,
+      query: "",
+      category: "all",
+      connected: new Set(),
+      allowlist: null,
+    });
+    deepStrictEqual(
+      view.connectable.map((t) => t.slug),
+      ["gmail", "googlecalendar", "notion", "serpapi", "slack"],
+    );
+    deepStrictEqual(view.locked, []);
+  });
+
+  it("splits blocked apps into `locked`, both lists A-Z", () => {
+    const view = browseCatalogView({
+      catalog: CATALOG,
+      query: "",
+      category: "all",
+      connected: new Set(),
+      allowlist: ["slack", "gmail"],
+    });
+    deepStrictEqual(
+      view.connectable.map((t) => t.slug),
+      ["gmail", "slack"],
+    );
+    // googlecalendar, notion, serpapi are outside the ceiling → locked, A-Z.
+    deepStrictEqual(
+      view.locked.map((t) => t.slug),
+      ["googlecalendar", "notion", "serpapi"],
+    );
+  });
+
+  it("an empty allowlist locks every app (nothing connectable)", () => {
+    const view = browseCatalogView({
+      catalog: CATALOG,
+      query: "",
+      category: "all",
+      connected: new Set(),
+      allowlist: [],
+    });
+    deepStrictEqual(view.connectable, []);
+    deepStrictEqual(
+      view.locked.map((t) => t.slug),
+      ["gmail", "googlecalendar", "notion", "serpapi", "slack"],
+    );
+  });
+
+  it("search still finds a blocked app as a locked row (not emptiness)", () => {
+    // A member searching for an app the admin hasn't enabled must SEE it locked.
+    const view = browseCatalogView({
+      catalog: CATALOG,
+      query: "serp",
+      category: "all",
+      connected: new Set(),
+      allowlist: ["gmail"],
+    });
+    deepStrictEqual(view.connectable, []);
+    deepStrictEqual(
+      view.locked.map((t) => t.slug),
+      ["serpapi"],
+    );
+  });
+
+  it("excludes connected apps from both buckets before partitioning", () => {
+    const view = browseCatalogView({
+      catalog: CATALOG,
+      query: "",
+      category: "all",
+      connected: new Set(["gmail", "notion"]),
+      allowlist: ["gmail", "slack"],
+    });
+    // gmail + notion connected → gone from browse; slack allowed; the rest locked.
+    deepStrictEqual(
+      view.connectable.map((t) => t.slug),
+      ["slack"],
+    );
+    deepStrictEqual(
+      view.locked.map((t) => t.slug),
+      ["googlecalendar", "serpapi"],
+    );
+  });
+
+  it("category filter narrows before the allowlist partition", () => {
+    const view = browseCatalogView({
+      catalog: CATALOG,
+      query: "",
+      category: "collaboration",
+      connected: new Set(),
+      allowlist: ["notion"],
+    });
+    // collaboration = notion + slack; notion allowed, slack locked.
+    deepStrictEqual(
+      view.connectable.map((t) => t.slug),
+      ["notion"],
+    );
+    deepStrictEqual(
+      view.locked.map((t) => t.slug),
+      ["slack"],
     );
   });
 });

--- a/knowledge-base/integrations.md
+++ b/knowledge-base/integrations.md
@@ -56,6 +56,66 @@ acting without extra plumbing. `search`/`execute` receive the `ActingContext`
 (C2): `actingAs` (per-turn token) or `actingUser` (routine creator's `sub`); the
 direct adapter ignores both (identity is the verified `userId`).
 
+### Search flow + app-status taxonomy (HOU-681)
+
+**The status contract.** Every search result carries an `IntegrationAppStatus`
+(`packages/host/src/integrations/types.ts`) — the load-bearing enum that tells
+the agent which of four speech acts to perform:
+
+- `connected` — the acting user has an active connection: use it.
+- `connectable` — a real toolkit, not connected yet: OFFER to connect
+  (`request_connection`).
+- `blocked` — a real toolkit excluded by org/agent admin policy: tell the user to
+  ask their admin; never imply Houston lacks it, never `request_connection`.
+  **Nothing in THIS repo produces `blocked`** — the allowlist ceiling lives solely
+  in the closed cloud gateway (Teams v2, C7). The enum + rendering + prompt exist
+  now so a later gateway change that annotates its `/search` items with `status`
+  lights it up here with zero further work.
+- `unknown` — not a recognized toolkit (reserved; today an unrecognized query is
+  simply the EMPTY result).
+
+`connected` is kept alongside the legacy `connected` boolean (the grants filter
+`filterMatchesToGranted` still reads the boolean, and HOU-670 keeps
+`connected === false` matches discoverable); `status` is the additive superset.
+
+**Direct-adapter search** (`composio.ts` → `composio-search.ts`): the old
+connected-scoped short-circuit is GONE (its bug: a connected-Gmail user could not
+discover Google Sheets, because a scoped hit `return`ed before global ran). Search
+now runs THREE lookups and merges them (scoped first, deduped by action, then
+catalog entries):
+1. **scoped** query over the user's CONNECTED toolkits (precision; degrades to
+   LISTING their actions on a zero-hit everyday phrasing), then
+2. **global** query — ALWAYS runs, never short-circuited, so new apps are
+   discoverable, then
+3. **catalog resolution** — Composio's action full-text scores ~zero for a plain
+   app NAME, so the query is resolved against the toolkits catalog
+   (`GET /api/v3/toolkits`, cached in-process, 1h TTL, shared in-flight promise)
+   to a real slug and surfaced as a **toolkit-level entry** (`action: ""`) even
+   when no action scored — so the model always learns the slug to pass
+   `request_connection`. Status is derived from the acting user's active
+   connections (`connected`/`connectable`; the direct adapter cannot emit
+   `blocked`/`unknown`).
+
+**Gateway adapter** (`remote.ts`) reads each `/search` item TOLERANTLY: a valid
+`status` passes through verbatim (a future gateway sending `blocked`); an absent
+or unrecognized `status` (today's gateway) derives from the `connected` boolean
+(`statusFromConnected`). The new field is never required.
+
+**Runtime tool text** (`packages/runtime/src/session/tools/integrations.ts`) is
+status-aware: connected actions as before; `connectable` entries name the exact
+slug and teach `request_connection`; `blocked` tells the user to ask their admin
+and forbids `request_connection`; a genuinely EMPTY result says no such
+app/action exists (a real not-found, NOT a policy block).
+
+**Prompt contract — the four speech acts.** `packages/host/src/houston-prompt.ts`
+INTEGRATIONS section and its verbatim Rust mirror
+`app/src-tauri/src/houston_prompt/integrations.rs` (`PI_INTEGRATIONS_GUIDANCE`,
+kept in sync) instruct: connected → use it; connectable → briefly offer +
+`request_connection`; blocked → tell the user their admin must enable it (never
+imply Houston lacks it, never `request_connection`); unknown/empty → say plainly
+no such app is available. An empty result never means an app is unsupported —
+trust the reported status.
+
 ---
 
 ## 2. Grants model — which agents may use which app
@@ -86,9 +146,14 @@ ceiling (`allowedToolkits`, plus the read-only `orgAllowedToolkits` it's
 intersected with and the caller's effective `access`; manager-only write).
 `getOrgSettings` / `setOrgSettings` read/replace the org ceiling (owner-only
 write). Copy lives under `teams:integrations.allowlist` (row titled "Apps"; the
-choice keys `question` / `anyLabel` / `anyDesc` / `pickedLabel` / `pickedDesc`);
-an agent tab also lists apps blocked by the ceiling under
-`teams:integrations.notAllowed`. The manager editor lives in Agent
+choice keys `question` / `policyHelper` / `anyLabel` / `anyDesc` / `pickedLabel` /
+`pickedDesc` — `policyHelper` is the admin-policy helper line under the question,
+noting members still connect their own accounts). The agent tab surfaces
+ceiling-blocked apps in TWO places so policy is never silently invisible:
+connected-but-blocked apps under `teams:integrations.notAllowed` (the disallowed
+section, "Not allowed" badge + an ask-your-admin line), and NOT-connected blocked
+apps as **locked rows** in the browse catalog (see §3, `integrations:locked.*`).
+The manager editor lives in Agent
 Settings > **Access** > **Apps** (`AgentAllowlistSection`); its editing surface
 is an always-visible two-option choice (`AccessChoice`: "Any app" saves `null`,
 "Only apps you pick" saves an explicit set) over the Integrations-tab app catalog
@@ -203,6 +268,23 @@ read-only); `degraded` mode (grants `null`) shows all connected apps usable with
 toggles and no account section. Both modes end with the always-visible **Connect
 more apps** catalog (auto-granting a fresh connection to this agent in grants mode).
 "Manage all integrations" navigates to `INTEGRATIONS_VIEW_ID`.
+
+**Locked browse rows (Teams only).** On a Teams host with a real effective
+allowlist, the browse catalog no longer FILTERS blocked apps out (which read as
+"Houston doesn't support X"); instead the agent tab passes the effective
+`allowlist` down through `ConnectMoreAppsSection` → `CatalogBrowser` →
+`AppCatalogGrid`, which calls the pure `browseCatalogView` (`integrations/model.ts`)
+to split the filtered+A-Z catalog into `connectable` (inside the ceiling,
+paginated as before) and `locked` (outside it). Locked apps render via
+`CatalogLockedSection`: read-only `AppRow`s with a `Lock` trailing icon and the
+`integrations:locked.askAdmin` subtitle ("Ask your admin to enable {app}", visible
+at rest — no hover gating), under a muted `locked.heading`, capped at
+`LOCKED_PREVIEW_CAP` (8) with a `locked.more` "+N more" count line so a tiny
+allowlist over the ~1000-app catalog can't bury the connectable apps. A member
+SEARCHING for a blocked app finds its locked row (search filters before the
+partition), never emptiness. `allowlist === null` (single-player, or Teams with no
+ceiling) → `locked` always empty → no locks ever; the global integrations page and
+the manager's allowlist editor pass no `allowlist`, so they are unchanged.
 
 **Connect flow + pending recovery** — `useConnectFlow` (in the shared module) lives
 on the SURFACE, never inside the picker, so closing the dialog never kills polling.

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -387,6 +387,18 @@ auto-grants on success. Client: `getAgentSettings` / `setAgentSettings`
 (agent ceiling, manager-only), `getOrgSettings` / `setOrgSettings` (org ceiling,
 owner-only). UI under `teams:integrations.allowlist`.
 
+**Blocked apps stay VISIBLE (never silently absent).** The agent Integrations
+tab shows a ceiling-blocked app in one of two places rather than hiding it: a
+CONNECTED blocked app appears in the disallowed section (`teams:integrations.notAllowed`,
+"Not allowed" badge + an ask-your-admin line), and a NOT-connected blocked app
+appears as a **locked row** in the browse catalog (lock icon + `integrations:locked.askAdmin`
+"Ask your admin to enable {app}", capped preview; see `integrations.md` §3
+"Locked browse rows"). The ceiling editor (`AgentAllowlistSection`) reads as admin
+POLICY via `teams:integrations.allowlist.policyHelper`. Member connect surfaces
+stay account-connection language ("connected to your account"), never "allowed".
+The pure split is `browseCatalogView` (`integrations/model.ts`); off Teams
+(`allowlist === null`) nothing is ever locked.
+
 ---
 
 ## Mission attribution + the board surface

--- a/knowledge-base/ui-testing.md
+++ b/knowledge-base/ui-testing.md
@@ -60,6 +60,17 @@ Playwright auto-starts two servers: vite `:1430` (`VITE_NEW_ENGINE=1` → adapte
   `/agents/:id/agentfile/*` (NOT just `/activities`). Fake host backs it with a
   real store, unified with `/activities` (same data, as in the real host),
   so a turn's status flip shows on the board.
+- **Teams mode is armable.** Single-player alone can't reach the Teams-shaped
+  state (multiplayer + an integration allowlist ceiling) that the agent
+  Integrations tab's locked browse rows need. Two fake-host controls arm it:
+  `POST /__test__/capabilities` (merge a `Partial<Capabilities>` into
+  `/v1/capabilities` — e.g. `{ integrations:["composio"], multiplayer:true,
+  teams:true, role:"owner" }`) and `POST /__test__/agent-settings`
+  (`{ allowedToolkits?, orgAllowedToolkits? }`, the ceilings served at
+  `/v1/agents/:slug/settings` + `/v1/org/settings`). The effective allowlist
+  (agent ∩ org) splits the browse catalog into connectable vs locked rows
+  (`integrations-locked.spec.ts`). `SEED_TOOLKIT_SLUGS` (15 A-Z apps) is exported
+  for specs arming allowlists over the catalog.
 
 ## CI
 

--- a/packages/fake-host/README.md
+++ b/packages/fake-host/README.md
@@ -56,12 +56,20 @@ They drive the failure/reactivity scenarios the specs assert against:
 | `/__test__/drop-chat-streams` | — | Sever every open chat stream WITHOUT ending the turns (network blip). Returns `{ dropped }`. |
 | `/__test__/kill-turn` | — | Synthesize the host reaper's terminal `error` frame on every running turn (dead-turn settle). Returns `{ killed }`. |
 | `/__test__/turn-boundary` | `{ nextText }` | End the running turn while nobody watches, then start the next one, so a reconnect resyncs onto a DIFFERENT turnId. Returns `{ advanced }`. |
+| `/__test__/integrations-mode` | `{ mode }` | Composio readiness: `ready` \| `unavailable` (503) \| `signin`. Returns `{ mode }`. |
+| `/__test__/integrations-activate` | `{ connectionId }` | Flip a pending connection to `active` (models the OAuth completing). Returns `{ activated }`. |
+| `/__test__/capabilities` | `Partial<Capabilities>` | Merge a partial into the advertised `/v1/capabilities`. Arm the Teams-shaped state single-player can't reach — e.g. `{ integrations:["composio"], multiplayer:true, teams:true, role:"owner" }` to light up the agent Integrations tab's locked browse rows, or just `{ integrations:["composio"] }` for a single-player-with-apps run. Returns the merged capabilities. |
+| `/__test__/agent-settings` | `{ allowedToolkits?, orgAllowedToolkits?, allowedModels?, access? }` | Set the Teams v2 ceilings served at `/v1/agents/:slug/settings` + `/v1/org/settings` (`allowedToolkits`/`orgAllowedToolkits`: `null` = unrestricted, `[]` = none). The `effectiveAllowlist` = agent ∩ org drives the tab's connectable-vs-locked partition. Returns the merged settings. |
 
 ## Modeled surface
 
 - `/health`, `/version`, `/auth/status`, `/providers` — top-level probes.
-- `/v1/capabilities` (single-player `local` profile), `/v1/workspaces`,
-  `/v1/integrations`, `/v1/preferences`, `/v1/events` (reactivity feed).
+- `/v1/capabilities` (single-player `local` profile by default; armable to a
+  Teams-shaped set), `/v1/workspaces`, `/v1/integrations`, `/v1/preferences`,
+  `/v1/events` (reactivity feed).
+- `/v1/agents/:slug/settings` + `/v1/org/settings` (Teams v2, the gateway-only
+  allowlist/model ceilings `getAgentSettings` / `getOrgSettings` read; GET + the
+  manager/owner PUT). Seeded unrestricted; armed by `/__test__/agent-settings`.
 - `/agents/*` — the per-agent control plane + runtime proxy: agents CRUD,
   activities (backed by the SAME `.houston/activity/activity.json` the board
   reads via `/agents/:id/agentfile/*`), routines/skills (empty), providers/auth/

--- a/packages/fake-host/src/index.ts
+++ b/packages/fake-host/src/index.ts
@@ -9,9 +9,9 @@
  *  - The host + seed constants (ports, token, seeded agent) from `./config`.
  *
  * The server's `POST /__test__/*` control endpoints (reset, emit, chat-config,
- * chat-interaction, drop-chat-streams, kill-turn, turn-boundary) are HTTP routes
- * documented in this package's README; the harness drives them over HTTP, not
- * via exports.
+ * chat-interaction, drop-chat-streams, kill-turn, turn-boundary, capabilities,
+ * agent-settings) are HTTP routes documented in this package's README; the
+ * harness drives them over HTTP, not via exports.
  */
 
 export {
@@ -24,3 +24,6 @@ export {
 } from "./config";
 export type { FakeHost } from "./server";
 export { startFakeHost } from "./server";
+/** The seeded integration catalog's toolkit slugs (A-Z) — for specs arming
+ *  Teams allowlists over the catalog. */
+export { SEED_TOOLKIT_SLUGS } from "./state-integrations";

--- a/packages/fake-host/src/router.ts
+++ b/packages/fake-host/src/router.ts
@@ -8,7 +8,7 @@
  */
 
 import { buildProviderCatalog } from "@houston/host/src/providers/pi-catalog";
-import type { Capabilities, PendingInteraction } from "@houston/protocol";
+import type { PendingInteraction } from "@houston/protocol";
 import { setNextInteraction, setReplyDelay } from "./chat";
 import {
   clearChatStreams,
@@ -19,7 +19,9 @@ import {
 import { CORS, json } from "./http";
 import { authStatusBody, handleAgents, providersBody } from "./routes";
 import { handleUserRoutes } from "./routes-integrations";
+import { handleTeamsRoutes } from "./routes-teams";
 import { sseResponse } from "./sse";
+import type { FakeCapabilities, TeamsSettings } from "./state";
 import * as state from "./state";
 
 async function parseBody(
@@ -112,6 +114,21 @@ export async function handle(req: Request): Promise<Response> {
     );
     return json({ mode: state.integrationsMode() });
   }
+  // Override advertised capabilities (Teams e2e): merge a partial into the set,
+  // e.g. `{ integrations:["composio"], multiplayer:true, teams:true, role:"owner" }`
+  // to reach the Teams-shaped state single-player can't. Reset restores the seed.
+  if (path === "/__test__/capabilities" && method === "POST") {
+    const body = await parseBody(req);
+    return json(
+      state.setCapabilities((body ?? {}) as Partial<FakeCapabilities>),
+    );
+  }
+  // Arm the Teams settings the gateway serves at the settings routes below:
+  // the agent + org integration ceilings, the model ceiling, and agent access.
+  if (path === "/__test__/agent-settings" && method === "POST") {
+    const body = await parseBody(req);
+    return json(state.setTeamsSettings((body ?? {}) as Partial<TeamsSettings>));
+  }
   // Flip a pending connection to active (models the OAuth completing).
   if (path === "/__test__/integrations-activate" && method === "POST") {
     const body = await parseBody(req);
@@ -133,20 +150,11 @@ export async function handle(req: Request): Promise<Response> {
   if (path === "/providers") return json(providersBody());
 
   // --- misc host surface the UI may touch on boot (kept permissive) ---
-  // Single-player local profile: the app's boot routing waits on this
-  // (App.tsx gates onboarding-vs-shell on loaded capabilities).
+  // Deployment capabilities: single-player local by default (the app's boot
+  // routing waits on this — App.tsx gates onboarding-vs-shell on loaded
+  // capabilities). Armed to a Teams-shaped set by `/__test__/capabilities`.
   if (path === "/v1/capabilities" && method === "GET") {
-    const caps: Capabilities = {
-      profile: "local",
-      revealInOs: false,
-      terminal: false,
-      tunnel: false,
-      codeExecution: "disabled",
-      providers: ["anthropic"],
-      openaiCompatible: false,
-      integrations: [],
-    };
-    return json(caps);
+    return json(state.getCapabilities());
   }
   // pi-ai's full static model catalog (`GET /v1/catalog`, wire `ProviderCatalog`).
   // Built from the SAME real `buildProviderCatalog` the host route uses, so the
@@ -161,6 +169,10 @@ export async function handle(req: Request): Promise<Response> {
   // --- user-scoped gateway routes (integrations, grants, preferences, locale) ---
   const userRoute = handleUserRoutes(method, segs, body);
   if (userRoute) return userRoute;
+
+  // --- Teams v2 gateway routes (agent + org settings / allowlist ceilings) ---
+  const teamsRoute = handleTeamsRoutes(method, segs, body);
+  if (teamsRoute) return teamsRoute;
 
   // --- everything under /agents/* ---
   if (segs[0] === "agents") {

--- a/packages/fake-host/src/routes-teams.ts
+++ b/packages/fake-host/src/routes-teams.ts
@@ -1,0 +1,87 @@
+/**
+ * Teams v2 gateway routes for the fake host: the per-agent settings the client
+ * reads with `getAgentSettings` (`GET /v1/agents/:slug/settings`) and the org
+ * ceiling `getOrgSettings` reads (`GET /v1/org/settings`), plus their manager /
+ * owner `PUT` replacers.
+ *
+ * These mirror the closed cloud gateway (C7 Teams v2, `agent_settings` /
+ * `org_settings`) — the surface the host repo itself never serves, since the
+ * ceiling lives only above the engine. They read/write the single-user Teams
+ * settings in state; the wire shapes match `@houston-ai/engine-client`'s
+ * `AgentSettings` / `OrgSettings` exactly so the mock can't drift.
+ */
+
+import { json } from "./http";
+import * as state from "./state";
+
+/** Read a `string[] | null` field from a JSON body, preserving an explicit null. */
+function toolkitList(value: unknown): string[] | null {
+  if (value === null) return null;
+  if (Array.isArray(value) && value.every((v) => typeof v === "string")) {
+    return value as string[];
+  }
+  return null;
+}
+
+/** Route a Teams settings request, or return `undefined` to fall through. */
+export function handleTeamsRoutes(
+  method: string,
+  segs: string[],
+  body: Record<string, unknown> | undefined,
+): Response | undefined {
+  // /v1/agents/:slug/settings — the agent ceiling + org ceiling + access.
+  if (
+    segs[0] === "v1" &&
+    segs[1] === "agents" &&
+    segs.length === 4 &&
+    segs[3] === "settings"
+  ) {
+    const s = state.getTeamsSettings();
+    if (method === "GET") {
+      return json({
+        allowedToolkits: s.allowedToolkits,
+        orgAllowedToolkits: s.orgAllowedToolkits,
+        access: s.access,
+        allowedModels: s.allowedModels,
+      });
+    }
+    if (method === "PUT") {
+      // Both fields optional — update one ceiling without touching the other.
+      if (body && "allowedToolkits" in body) {
+        state.setTeamsSettings({
+          allowedToolkits: toolkitList(body.allowedToolkits),
+        });
+      }
+      if (body && "allowedModels" in body) {
+        state.setTeamsSettings({
+          allowedModels: toolkitList(body.allowedModels),
+        });
+      }
+      return json({ ok: true });
+    }
+    return json({ error: "not found" }, 404);
+  }
+
+  // /v1/org/settings — the org-wide integration ceiling.
+  if (
+    segs[0] === "v1" &&
+    segs[1] === "org" &&
+    segs[2] === "settings" &&
+    segs.length === 3
+  ) {
+    if (method === "GET") {
+      return json({
+        allowedToolkits: state.getTeamsSettings().orgAllowedToolkits,
+      });
+    }
+    if (method === "PUT") {
+      state.setTeamsSettings({
+        orgAllowedToolkits: toolkitList(body?.allowedToolkits),
+      });
+      return json({ ok: true });
+    }
+    return json({ error: "not found" }, 404);
+  }
+
+  return undefined;
+}

--- a/packages/fake-host/src/state-integrations.ts
+++ b/packages/fake-host/src/state-integrations.ts
@@ -19,8 +19,49 @@ import type {
 } from "@houston/runtime-client";
 import { emitDomain, type IntegrationsMode, state } from "./state-store";
 
-/** A small, stable A-Z toolkit catalog — enough for catalog + connect flows. */
+/**
+ * A stable, well-known A-Z toolkit catalog. Kept small but large enough (15
+ * apps) that a restrictive Teams allowlist over it blocks more than the locked
+ * browse section's preview cap (8), so the "+N more" overflow line is
+ * exercisable end to end (integrations-locked.spec.ts). Real app names so the
+ * rows read like production, never machine slugs.
+ */
 export const SEED_TOOLKITS: IntegrationToolkit[] = [
+  {
+    slug: "airtable",
+    name: "Airtable",
+    description: "Spreadsheet-database hybrid",
+    logoUrl: "https://logos.test/airtable.png",
+    categories: ["productivity"],
+  },
+  {
+    slug: "asana",
+    name: "Asana",
+    description: "Tasks and projects",
+    logoUrl: "https://logos.test/asana.png",
+    categories: ["productivity"],
+  },
+  {
+    slug: "calendly",
+    name: "Calendly",
+    description: "Scheduling and bookings",
+    logoUrl: "https://logos.test/calendly.png",
+    categories: ["productivity"],
+  },
+  {
+    slug: "discord",
+    name: "Discord",
+    description: "Community chat",
+    logoUrl: "https://logos.test/discord.png",
+    categories: ["communication"],
+  },
+  {
+    slug: "dropbox",
+    name: "Dropbox",
+    description: "File storage and sharing",
+    logoUrl: "https://logos.test/dropbox.png",
+    categories: ["productivity"],
+  },
   {
     slug: "github",
     name: "GitHub",
@@ -36,13 +77,65 @@ export const SEED_TOOLKITS: IntegrationToolkit[] = [
     categories: ["productivity"],
   },
   {
+    slug: "hubspot",
+    name: "HubSpot",
+    description: "CRM and marketing",
+    logoUrl: "https://logos.test/hubspot.png",
+    categories: ["sales"],
+  },
+  {
+    slug: "jira",
+    name: "Jira",
+    description: "Issue and sprint tracking",
+    logoUrl: "https://logos.test/jira.png",
+    categories: ["developer-tools"],
+  },
+  {
+    slug: "linear",
+    name: "Linear",
+    description: "Issue tracking for software teams",
+    logoUrl: "https://logos.test/linear.png",
+    categories: ["developer-tools"],
+  },
+  {
+    slug: "notion",
+    name: "Notion",
+    description: "Docs and wikis",
+    logoUrl: "https://logos.test/notion.png",
+    categories: ["productivity"],
+  },
+  {
+    slug: "salesforce",
+    name: "Salesforce",
+    description: "Enterprise CRM",
+    logoUrl: "https://logos.test/salesforce.png",
+    categories: ["sales"],
+  },
+  {
     slug: "slack",
     name: "Slack",
     description: "Team messaging",
     logoUrl: "https://logos.test/slack.png",
     categories: ["communication"],
   },
+  {
+    slug: "trello",
+    name: "Trello",
+    description: "Kanban boards",
+    logoUrl: "https://logos.test/trello.png",
+    categories: ["productivity"],
+  },
+  {
+    slug: "zoom",
+    name: "Zoom",
+    description: "Video meetings",
+    logoUrl: "https://logos.test/zoom.png",
+    categories: ["communication"],
+  },
 ];
+
+/** Every seeded toolkit slug, A-Z — handy for specs arming allowlists. */
+export const SEED_TOOLKIT_SLUGS: string[] = SEED_TOOLKITS.map((t) => t.slug);
 
 export function integrationsMode(): IntegrationsMode {
   return state.integrationsMode;

--- a/packages/fake-host/src/state-store.ts
+++ b/packages/fake-host/src/state-store.ts
@@ -12,7 +12,7 @@
  * typecheck here instead of silently drifting the mock.
  */
 
-import type { Activity, SidebarLayout } from "@houston/protocol";
+import type { Activity, Capabilities, SidebarLayout } from "@houston/protocol";
 import type {
   ChatMessage,
   IntegrationConnection,
@@ -28,6 +28,56 @@ import { resetProviders } from "./state-providers";
  *  - `signin` — the provider reports `ready:false, reason:"signin"`.
  */
 export type IntegrationsMode = "ready" | "unavailable" | "signin";
+
+/**
+ * The capabilities the fake host advertises at `GET /v1/capabilities`. It models
+ * the GATEWAY-augmented view the client sees, so it extends the host's protocol
+ * `Capabilities` with the two gateway-only feature-detect flags Teams adds
+ * (`teams`, `spaces` — defined in `@houston-ai/engine-client`, not the host
+ * protocol). `multiplayer` / `role` are already on the protocol type. The
+ * `/__test__/capabilities` control merges a partial into this so a spec can arm
+ * integrations, multiplayer, or the Teams surface without a forked build.
+ */
+export type FakeCapabilities = Capabilities & {
+  teams?: boolean;
+  spaces?: boolean;
+};
+
+/** A caller's effective per-agent access (Teams v2). Mirrors the wire enum. */
+export type AgentAccess = "manager" | "user";
+
+/**
+ * The Teams v2 settings the gateway serves at `/v1/agents/:slug/settings` and
+ * `/v1/org/settings`: the agent + org integration ceilings (`null` =
+ * unrestricted, `[]` = none), the agent's AI-model ceiling, and the caller's
+ * effective agent access. Seeded unrestricted; armed by `/__test__/agent-settings`.
+ */
+export interface TeamsSettings {
+  allowedToolkits: string[] | null;
+  orgAllowedToolkits: string[] | null;
+  allowedModels: string[] | null;
+  access: AgentAccess;
+}
+
+/** Single-player local profile — the default the app boots on (no Teams). */
+export const DEFAULT_CAPABILITIES: FakeCapabilities = {
+  profile: "local",
+  revealInOs: false,
+  terminal: false,
+  tunnel: false,
+  codeExecution: "disabled",
+  providers: ["anthropic"],
+  openaiCompatible: false,
+  integrations: [],
+};
+
+/** Unrestricted, manager access — no policy until a spec arms one. */
+export const DEFAULT_TEAMS_SETTINGS: TeamsSettings = {
+  allowedToolkits: null,
+  orgAllowedToolkits: null,
+  allowedModels: null,
+  access: "manager",
+};
 
 /** The host's agent wire model, mapped to the UI `Agent` by control-plane.ts. */
 export interface CpAgent {
@@ -77,6 +127,10 @@ export interface HostState {
   /** Monotonic counter for minted routine ids. */
   routineSeq: number;
   // ── user-scoped gateway state (integrations, grants, preferences) ──
+  /** Advertised capabilities, armed by `/__test__/capabilities` (Teams e2e). */
+  capabilities: FakeCapabilities;
+  /** Teams v2 integration/model ceilings, armed by `/__test__/agent-settings`. */
+  teamsSettings: TeamsSettings;
   /** Composio readiness, toggled by the `/__test__/integrations-mode` control. */
   integrationsMode: IntegrationsMode;
   /** connectionId -> the acting user's connected account. */
@@ -145,6 +199,8 @@ function freshState(): HostState {
     agentSeq: 1,
     activitySeq: 2,
     routineSeq: 0,
+    capabilities: { ...DEFAULT_CAPABILITIES },
+    teamsSettings: { ...DEFAULT_TEAMS_SETTINGS },
     integrationsMode: "ready",
     connections,
     // No seeded grants record: the seed agent starts "grants unsupported" (404 →

--- a/packages/fake-host/src/state-teams.ts
+++ b/packages/fake-host/src/state-teams.ts
@@ -1,0 +1,47 @@
+/**
+ * Teams v2 state helpers: the advertised capabilities and the agent/org
+ * integration ceilings the gateway serves. These back the Teams-mode arming
+ * controls (`/__test__/capabilities`, `/__test__/agent-settings`) and the
+ * `/v1/agents/:slug/settings` + `/v1/org/settings` gateway routes, so a spec can
+ * put the app into a Teams-shaped state (multiplayer + a restrictive allowlist)
+ * that single-player alone can't reach — the fixture arming the locked browse
+ * rows and, later, the admin policy pages.
+ *
+ * The fields live on `HostState` (state-store.ts); this module is the read/write
+ * surface, mirroring how `state-integrations.ts` operates on the shared `state`.
+ */
+
+import type { FakeCapabilities, TeamsSettings } from "./state-store";
+import { state } from "./state-store";
+
+/** The capabilities served at `GET /v1/capabilities`. */
+export function getCapabilities(): FakeCapabilities {
+  return state.capabilities;
+}
+
+/**
+ * Merge a partial capabilities patch into the advertised set (the
+ * `/__test__/capabilities` control). Arm integrations + `multiplayer`/`teams`/
+ * `role` for Teams e2e, or just `integrations` for a single-player-with-apps run.
+ */
+export function setCapabilities(
+  patch: Partial<FakeCapabilities>,
+): FakeCapabilities {
+  state.capabilities = { ...state.capabilities, ...patch };
+  return state.capabilities;
+}
+
+/** The Teams settings behind the agent/org settings routes. */
+export function getTeamsSettings(): TeamsSettings {
+  return state.teamsSettings;
+}
+
+/**
+ * Merge a partial into the Teams settings (the `/__test__/agent-settings`
+ * control and the `PUT` settings routes). Only the fields present are changed,
+ * so a caller can set the agent ceiling without touching the org one.
+ */
+export function setTeamsSettings(patch: Partial<TeamsSettings>): TeamsSettings {
+  state.teamsSettings = { ...state.teamsSettings, ...patch };
+  return state.teamsSettings;
+}

--- a/packages/fake-host/src/state.ts
+++ b/packages/fake-host/src/state.ts
@@ -26,4 +26,5 @@ export * from "./state-integrations";
 export * from "./state-providers";
 export * from "./state-routines";
 export * from "./state-store";
+export * from "./state-teams";
 export * from "./state-workspace";

--- a/packages/host/src/houston-prompt.ts
+++ b/packages/host/src/houston-prompt.ts
@@ -174,13 +174,16 @@ When saving a Routine, read \`.houston/routines/routines.schema.json\`, then upd
 
 const INTEGRATIONS = `## How-To Guidance: Connected Apps (Integrations)
 
-You can act on the user's apps (Gmail, Google Calendar, Slack, Notion, and many more) with two tools: \`integration_search\` finds an action and its input parameters; \`integration_execute\` runs it. Search first, then execute. The user's own account is used automatically — you never handle credentials.
+You can act on the user's apps (Gmail, Google Calendar, Slack, Notion, and many more) with two tools: \`integration_search\` finds an action and its input parameters; \`integration_execute\` runs it. Search first, then execute. The user's own account is used automatically, you never handle credentials.
 
-When a needed app is not connected yet (search marks its actions NOT CONNECTED, or execute fails because no account is linked):
+Each search result reports the app's status. Act on the status, one of four:
 
-1. Briefly say what must be connected and why, in plain language.
-2. Call the \`request_connection\` tool for that app, with a short user-facing reason. Houston shows the user a connect card with a one-click button in place of the chat box, so there is nothing for you to write out. Call it once per app that needs connecting, then end your turn.
-3. Do NOT ask the user to tell you when they're done, and do NOT promise to "check" the connection yourself. Houston detects the moment the connection goes live and automatically sends you a short message (e.g. "I've connected Gmail. Please continue.") so you can resume the task on your own. Then stop and wait.
+- Connected: the user already linked this app. Use it: pick the action and run it with \`integration_execute\`.
+- Connectable (the app exists but the user has not linked it yet, shown as NOT CONNECTED): briefly say what must be connected and why, then call the \`request_connection\` tool for that app with a short user-facing reason. Houston shows a one-click connect card in place of the chat box, so there is nothing for you to write out. Do NOT ask the user to tell you when they're done and do NOT promise to "check" it yourself: Houston detects the moment the connection goes live and automatically sends you a short message (e.g. "I've connected Gmail. Please continue.") so you can resume on your own. Then stop and wait.
+- Blocked by admin: the app is real, but the workspace admin has not enabled it for this agent. Tell the user their admin needs to enable it and to ask them. NEVER call \`request_connection\` for a blocked app, and never imply Houston does not support it.
+- No such app: when the search returns nothing at all, say plainly that no such app is available.
+
+An empty search result means no matching app or action was found. It does NOT mean the app is unsupported or withheld by policy. Trust the status the search reports: never tell the user an app does not exist, or is unavailable, when the search shows it as connectable or blocked.
 
 If Houston reports that the user must sign in first, a sign-in card joins the same interaction card automatically. Keep queueing whatever else the task needs (call \`request_connection\` for any app, \`ask_user\` for any questions) in the same turn, then end your turn. Never tell the user to open Settings, and never claim connected apps are unavailable unless Houston says they are not set up in this install.
 

--- a/packages/host/src/integrations/composio-search.test.ts
+++ b/packages/host/src/integrations/composio-search.test.ts
@@ -1,0 +1,58 @@
+import { expect, test } from "vitest";
+import { normalizeAppName, resolveCatalogToolkits } from "./composio-search";
+import type { Toolkit } from "./types";
+
+/**
+ * The pure catalog resolver: it turns an app-naming query into real toolkit
+ * slugs so the model always learns what to pass request_connection, even when
+ * Composio's action search scores nothing. These pin the matching + guard rails.
+ */
+
+const CATALOG: Toolkit[] = [
+  { slug: "googlesheets", name: "Google Sheets" },
+  { slug: "gmail", name: "Gmail" },
+  { slug: "google_maps", name: "Google Maps" },
+  { slug: "notion", name: "Notion" },
+];
+
+test("normalizeAppName collapses case, spaces, and punctuation", () => {
+  expect(normalizeAppName("Google Sheets")).toBe("googlesheets");
+  expect(normalizeAppName("google-sheets")).toBe("googlesheets");
+  expect(normalizeAppName("  GOOGLESHEETS ")).toBe("googlesheets");
+});
+
+test("resolves an app name to its slug (name or slug substring of the query)", () => {
+  expect(
+    resolveCatalogToolkits(CATALOG, "connect to google sheets").map(
+      (t) => t.slug,
+    ),
+  ).toEqual(["googlesheets"]);
+  // Matches on the slug too (multi-word slug with underscores).
+  expect(
+    resolveCatalogToolkits(CATALOG, "get a route from google_maps").map(
+      (t) => t.slug,
+    ),
+  ).toEqual(["google_maps"]);
+});
+
+test("prefers the longest (most specific) name and caps the result", () => {
+  // "google sheets" contains both "google sheets" and, as a plain substring of
+  // the normalized form, nothing shorter here — but the longest-first ordering
+  // is what keeps the most specific app on top when several match.
+  const many: Toolkit[] = [
+    { slug: "google", name: "Google" },
+    { slug: "googlesheets", name: "Google Sheets" },
+  ];
+  expect(
+    resolveCatalogToolkits(many, "google sheets").map((t) => t.slug),
+  ).toEqual(["googlesheets", "google"]);
+  expect(
+    resolveCatalogToolkits(many, "google sheets", 1).map((t) => t.slug),
+  ).toEqual(["googlesheets"]);
+});
+
+test("no match for a query that names no app, and an empty query", () => {
+  expect(resolveCatalogToolkits(CATALOG, "please help me out")).toEqual([]);
+  expect(resolveCatalogToolkits(CATALOG, "")).toEqual([]);
+  expect(resolveCatalogToolkits(CATALOG, "   ")).toEqual([]);
+});

--- a/packages/host/src/integrations/composio-search.ts
+++ b/packages/host/src/integrations/composio-search.ts
@@ -1,0 +1,154 @@
+import type {
+  Connection,
+  IntegrationAppStatus,
+  Toolkit,
+  ToolMatch,
+} from "./types";
+
+/**
+ * The Composio search algorithm, extracted from the adapter so composio.ts stays
+ * request-shaping + port-mapping and this holds the discovery policy (and its
+ * pure, unit-testable pieces).
+ *
+ * Discovery has two failure modes Composio's full-text `/tools` search cannot
+ * cover on its own, so search runs THREE lookups and merges them:
+ *
+ *  1. A query scoped to the user's CONNECTED toolkits — high precision for apps
+ *     they already have (Composio ranks unrelated tools above the obvious match
+ *     unqualified). When it scores zero, degrade to LISTING those toolkits'
+ *     actions so an everyday phrasing still lands on a real slug.
+ *  2. A GLOBAL query — so a connected-Gmail user asking for Google Sheets still
+ *     discovers it. This ALWAYS runs; it is never short-circuited by (1) (the
+ *     regression this module fixes: a connected user could not discover any new
+ *     app because a scoped hit returned early).
+ *  3. Catalog resolution — Composio's action search scores ~zero for plain app
+ *     names, so an app named in the query is resolved against the toolkits
+ *     catalog to a real slug and surfaced as a toolkit-level entry, even when no
+ *     action scored. This is what makes "connect to Google Sheets" work.
+ *
+ * Every returned entry carries its IntegrationAppStatus, derived from the acting
+ * user's active connections (the direct adapter cannot produce `blocked` — that
+ * ceiling lives in the closed gateway — nor `unknown`, which is the empty case).
+ */
+
+/** Normalize an app name/slug/query for substring matching: lowercase, drop
+ *  every non-alphanumeric char so "Google Sheets", "google-sheets" and
+ *  "googlesheets" all collapse to one comparable form. */
+export function normalizeAppName(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+/**
+ * Resolve the toolkits an app-naming query plausibly refers to, against the
+ * catalog. A toolkit matches when its normalized name OR slug (length >= 3, to
+ * avoid trivial collisions) is a substring of the normalized query. Ordered
+ * longest-match-first (the most specific name wins) and capped so a broad query
+ * cannot flood the result.
+ */
+export function resolveCatalogToolkits(
+  catalog: Toolkit[],
+  query: string,
+  limit = 3,
+): Toolkit[] {
+  const q = normalizeAppName(query);
+  if (!q) return [];
+  const hits = catalog.filter((tk) => {
+    const name = normalizeAppName(tk.name);
+    const slug = normalizeAppName(tk.slug);
+    return (
+      (name.length >= 3 && q.includes(name)) ||
+      (slug.length >= 3 && q.includes(slug))
+    );
+  });
+  hits.sort(
+    (a, b) => normalizeAppName(b.name).length - normalizeAppName(a.name).length,
+  );
+  return hits.slice(0, limit);
+}
+
+/** Active-connection lookup for one search: which toolkit slugs are connected. */
+export function activeToolkitSlugs(connections: Connection[]): string[] {
+  return [
+    ...new Set(
+      connections.filter((c) => c.status === "active").map((c) => c.toolkit),
+    ),
+  ];
+}
+
+const isConnectedIn = (slugs: string[], toolkit: string): boolean =>
+  slugs.some((s) => s.toLowerCase() === toolkit.toLowerCase());
+
+/** Stamp `connected` + `status` on a raw action match from the user's set. */
+function annotate(match: ToolMatch, connectedSlugs: string[]): ToolMatch {
+  const connected = isConnectedIn(connectedSlugs, match.toolkit);
+  const status: IntegrationAppStatus = connected ? "connected" : "connectable";
+  return { ...match, connected, status };
+}
+
+export interface SearchDeps {
+  listConnections(): Promise<Connection[]>;
+  /** One `/tools` query (already mapped to raw ToolMatch, no status/connected). */
+  queryTools(query: Record<string, string>): Promise<ToolMatch[]>;
+  /** The (cached) toolkits catalog for name resolution. */
+  catalog(): Promise<Toolkit[]>;
+}
+
+/**
+ * Run the merged search. Order: scoped/listing action matches (connected apps)
+ * first, then global action matches (deduped by action slug), then catalog
+ * toolkit-level entries for any resolved app not already represented by an
+ * action match.
+ */
+export async function searchComposio(
+  deps: SearchDeps,
+  query: string,
+): Promise<ToolMatch[]> {
+  const slugs = activeToolkitSlugs(await deps.listConnections());
+  const scopedSlug = slugs.join(",");
+
+  const [scoped, global, catalog] = await Promise.all([
+    slugs.length > 0
+      ? deps.queryTools({ query, limit: "10", toolkit_slug: scopedSlug })
+      : Promise.resolve<ToolMatch[]>([]),
+    deps.queryTools({ query, limit: "10" }),
+    deps.catalog(),
+  ]);
+
+  // A zero-hit scoped query still degrades to listing the connected toolkits'
+  // actions (Composio's naive full-text scores everyday phrasings at zero), so
+  // the model gets a real slug rather than a dead end.
+  const scopedListed =
+    slugs.length > 0 && scoped.length === 0
+      ? await deps.queryTools({ limit: "50", toolkit_slug: scopedSlug })
+      : [];
+
+  const out: ToolMatch[] = [];
+  const seenActions = new Set<string>();
+  const push = (m: ToolMatch) => {
+    const key = m.action.toLowerCase();
+    if (seenActions.has(key)) return;
+    seenActions.add(key);
+    out.push(annotate(m, slugs));
+  };
+  // Scoped (or its listing fallback) first — connected apps, highest precision.
+  for (const m of scoped.length > 0 ? scoped : scopedListed) push(m);
+  // Then global — NEVER dropped when scoped hit (the short-circuit fix).
+  for (const m of global) push(m);
+
+  // Catalog: surface every resolved app that has no action match yet, so the
+  // model always learns the slug to offer via request_connection.
+  const represented = new Set(out.map((m) => m.toolkit.toLowerCase()));
+  for (const tk of resolveCatalogToolkits(catalog, query)) {
+    if (represented.has(tk.slug.toLowerCase())) continue;
+    represented.add(tk.slug.toLowerCase());
+    const connected = isConnectedIn(slugs, tk.slug);
+    out.push({
+      action: "",
+      toolkit: tk.slug,
+      description: tk.description ? `${tk.name}: ${tk.description}` : tk.name,
+      connected,
+      status: connected ? "connected" : "connectable",
+    });
+  }
+  return out;
+}

--- a/packages/host/src/integrations/composio.test.ts
+++ b/packages/host/src/integrations/composio.test.ts
@@ -308,21 +308,29 @@ test("disconnect deletes every connected account for the toolkit", async () => {
   ]);
 });
 
-test("search scopes to the user's connected toolkits and maps tools", async () => {
-  const { provider, calls } = harness((url) => {
-    if (url.pathname === "/api/v3/connected_accounts") {
+test("search runs BOTH the scoped and global query, merges (scoped first, deduped), and stamps status", async () => {
+  const { provider } = harness((url) => {
+    if (url.pathname === "/api/v3/connected_accounts")
+      return {
+        body: {
+          items: [{ toolkit: { slug: "gmail" }, id: "ca_1", status: "ACTIVE" }],
+        },
+      };
+    if (url.pathname === "/api/v3/toolkits") return { body: { items: [] } };
+    // Scoped (toolkit_slug=gmail) → the connected app's action; global (no
+    // toolkit_slug) → a NEW app plus a DUPLICATE of the connected one.
+    if (url.searchParams.has("toolkit_slug"))
       return {
         body: {
           items: [
-            { toolkit: { slug: "gmail" }, id: "ca_1", status: "ACTIVE" },
-            { toolkit: { slug: "slack" }, id: "ca_2", status: "ACTIVE" },
-            // A second gmail account (dedup) and a failed one (excluded).
-            { toolkit: { slug: "gmail" }, id: "ca_3", status: "ACTIVE" },
-            { toolkit: { slug: "notion" }, id: "ca_4", status: "FAILED" },
+            {
+              slug: "GMAIL_SEND_EMAIL",
+              toolkit: { slug: "gmail" },
+              description: "Send an email",
+            },
           ],
         },
       };
-    }
     return {
       body: {
         items: [
@@ -330,40 +338,169 @@ test("search scopes to the user's connected toolkits and maps tools", async () =
             slug: "GMAIL_SEND_EMAIL",
             toolkit: { slug: "gmail" },
             description: "Send an email",
-            input_parameters: { type: "object" },
+          },
+          {
+            slug: "GOOGLESHEETS_CREATE",
+            toolkit: { slug: "googlesheets" },
+            description: "Create a sheet",
           },
         ],
       },
     };
   });
-  expect(await provider.search(USER, "send an email")).toEqual([
+  const found = await provider.search(USER, "send an email");
+  // Scoped connected match first, then the global new app; the duplicate is
+  // dropped, and every entry carries its status.
+  expect(
+    found.map((t) => [t.action, t.toolkit, t.connected, t.status]),
+  ).toEqual([
+    ["GMAIL_SEND_EMAIL", "gmail", true, "connected"],
+    ["GOOGLESHEETS_CREATE", "googlesheets", false, "connectable"],
+  ]);
+});
+
+test("a connected toolkit no longer short-circuits global discovery (the bug)", async () => {
+  // A connected-Gmail user asks for Google Sheets. The scoped query returns a
+  // (loose) Gmail match — the OLD code returned there and never ran global
+  // discovery, so Sheets was undiscoverable. It must surface now.
+  const { provider } = harness((url) => {
+    if (url.pathname === "/api/v3/connected_accounts")
+      return {
+        body: {
+          items: [{ toolkit: { slug: "gmail" }, id: "ca_1", status: "ACTIVE" }],
+        },
+      };
+    if (url.pathname === "/api/v3/toolkits") return { body: { items: [] } };
+    if (url.searchParams.has("toolkit_slug"))
+      return {
+        body: {
+          items: [
+            {
+              slug: "GMAIL_SEARCH_PEOPLE",
+              toolkit: { slug: "gmail" },
+              description: "unrelated but nonzero",
+            },
+          ],
+        },
+      };
+    return {
+      body: {
+        items: [
+          {
+            slug: "GOOGLESHEETS_CREATE_SPREADSHEET",
+            toolkit: { slug: "googlesheets" },
+            description: "Create a spreadsheet",
+          },
+        ],
+      },
+    };
+  });
+  const found = await provider.search(USER, "google sheets");
+  expect(found.find((t) => t.toolkit === "googlesheets")).toMatchObject({
+    action: "GOOGLESHEETS_CREATE_SPREADSHEET",
+    connected: false,
+    status: "connectable",
+  });
+});
+
+test("catalog resolution surfaces a connectable toolkit entry when no action scored", async () => {
+  // Composio's action full-text search scores ~zero for a plain app name, so
+  // the toolkits catalog resolves the name to a real slug the model can pass to
+  // request_connection — as a toolkit-level entry (empty action).
+  const { provider } = harness((url) => {
+    if (url.pathname === "/api/v3/connected_accounts")
+      return { body: { items: [] } };
+    if (url.pathname === "/api/v3/toolkits")
+      return {
+        body: {
+          items: [
+            {
+              slug: "googlesheets",
+              name: "Google Sheets",
+              meta: { description: "Spreadsheets" },
+            },
+            { slug: "gmail", name: "Gmail" },
+          ],
+        },
+      };
+    return { body: { items: [] } }; // no action scored
+  });
+  const found = await provider.search(USER, "connect to google sheets");
+  expect(found).toEqual([
     {
-      action: "GMAIL_SEND_EMAIL",
-      toolkit: "gmail",
-      description: "Send an email",
-      inputParams: { type: "object" },
-      connected: true,
+      action: "",
+      toolkit: "googlesheets",
+      description: "Google Sheets: Spreadsheets",
+      connected: false,
+      status: "connectable",
     },
   ]);
-  // Scoped to the ACTIVE connected toolkits (deduped) — Composio's global
-  // full-text search ranks unrelated tools above the obvious match.
-  expect(calls[1]?.path).toBe(
-    "/api/v3/tools?query=send+an+email&limit=10&toolkit_slug=gmail%2Cslack",
-  );
+});
+
+test("a resolved app the user already connected is a connected toolkit entry", async () => {
+  const { provider } = harness((url) => {
+    if (url.pathname === "/api/v3/connected_accounts")
+      return {
+        body: {
+          items: [
+            { toolkit: { slug: "googlesheets" }, id: "ca_1", status: "ACTIVE" },
+          ],
+        },
+      };
+    if (url.pathname === "/api/v3/toolkits")
+      return {
+        body: { items: [{ slug: "googlesheets", name: "Google Sheets" }] },
+      };
+    return { body: { items: [] } }; // no action scored, only the catalog entry
+  });
+  const found = await provider.search(USER, "google sheets");
+  expect(found).toEqual([
+    {
+      action: "",
+      toolkit: "googlesheets",
+      description: "Google Sheets",
+      connected: true,
+      status: "connected",
+    },
+  ]);
+});
+
+test("the toolkits catalog is fetched once and cached across searches", async () => {
+  const { provider, calls } = harness((url) => {
+    if (url.pathname === "/api/v3/connected_accounts")
+      return { body: { items: [] } };
+    if (url.pathname === "/api/v3/toolkits")
+      return { body: { items: [{ slug: "notion", name: "Notion" }] } };
+    return { body: { items: [] } };
+  });
+  await provider.search(USER, "notion");
+  await provider.search(USER, "notion");
+  expect(
+    calls.filter((c) => c.path.startsWith("/api/v3/toolkits")).length,
+  ).toBe(1);
+});
+
+test("a query naming no app and matching no action returns empty (genuinely unknown)", async () => {
+  const { provider } = harness((url) => {
+    if (url.pathname === "/api/v3/connected_accounts")
+      return { body: { items: [] } };
+    if (url.pathname === "/api/v3/toolkits")
+      return { body: { items: [{ slug: "gmail", name: "Gmail" }] } };
+    return { body: { items: [] } };
+  });
+  expect(await provider.search(USER, "zzznope")).toEqual([]);
 });
 
 test("a zero-hit scoped query degrades to listing the connected toolkits' actions", async () => {
-  // Composio's full-text match is naive: "read my latest 5 emails" scores zero
-  // against GMAIL_FETCH_EMAILS. The scoped retry (no query) must surface the
-  // toolkit's real actions instead of a dead "no results".
-  const { provider, calls } = harness((url) => {
-    if (url.pathname === "/api/v3/connected_accounts") {
+  // "read my latest 5 emails" scores zero against GMAIL_FETCH_EMAILS, so the
+  // scoped retry (no query) surfaces the toolkit's real actions.
+  const { provider } = harness((url) => {
+    if (url.pathname === "/api/v3/connected_accounts")
       return {
         body: { items: [{ toolkit: { slug: "gmail" }, status: "ACTIVE" }] },
       };
-    }
-    // First tools call carries the query → no hits; the fallback (no query)
-    // returns the toolkit listing.
+    if (url.pathname === "/api/v3/toolkits") return { body: { items: [] } };
+    // Every query-bearing call misses; only the no-query listing returns actions.
     if (url.searchParams.has("query")) return { body: { items: [] } };
     return {
       body: {
@@ -379,69 +516,14 @@ test("a zero-hit scoped query degrades to listing the connected toolkits' action
   });
   const found = await provider.search(USER, "read my latest 5 emails");
   expect(found.map((t) => t.action)).toEqual(["GMAIL_FETCH_EMAILS"]);
-  expect(found[0]?.connected).toBe(true);
-  expect(calls[2]?.path).toBe("/api/v3/tools?limit=50&toolkit_slug=gmail");
+  expect(found[0]).toMatchObject({ connected: true, status: "connected" });
 });
 
-test("a scoped miss also surfaces global matches marked NOT connected (HOU-670)", async () => {
-  // "send it via gmail" with only Slack linked: the scoped query misses, so
-  // the fallback must ALSO search globally and mark the gmail actions
-  // connected:false — that is what lets the agent offer the connect card.
-  const { provider, calls } = harness((url) => {
-    if (url.pathname === "/api/v3/connected_accounts") {
-      return {
-        body: { items: [{ toolkit: { slug: "slack" }, status: "ACTIVE" }] },
-      };
-    }
-    // The scoped query (query + toolkit_slug) misses…
-    if (url.searchParams.has("query") && url.searchParams.has("toolkit_slug"))
-      return { body: { items: [] } };
-    // …the connected-toolkit listing returns Slack's actions…
-    if (url.searchParams.has("toolkit_slug")) {
-      return {
-        body: {
-          items: [
-            {
-              slug: "SLACK_SEND_MESSAGE",
-              toolkit: { slug: "slack" },
-              description: "Send a message",
-            },
-          ],
-        },
-      };
-    }
-    // …and the global query finds the not-connected app (plus a duplicate of
-    // an already-connected one, which must be dropped from the global half).
-    return {
-      body: {
-        items: [
-          {
-            slug: "GMAIL_SEND_EMAIL",
-            toolkit: { slug: "gmail" },
-            description: "Send an email",
-          },
-          {
-            slug: "SLACK_SEND_MESSAGE",
-            toolkit: { slug: "slack" },
-            description: "Send a message",
-          },
-        ],
-      },
-    };
-  });
-  const found = await provider.search(USER, "send an email via gmail");
-  expect(found.map((t) => [t.action, t.connected])).toEqual([
-    ["SLACK_SEND_MESSAGE", true],
-    ["GMAIL_SEND_EMAIL", false],
-  ]);
-  // connections + scoped query + (connected listing ∥ global query).
-  expect(calls).toHaveLength(4);
-});
-
-test("search falls back to the global catalog when nothing is connected", async () => {
+test("with nothing connected, global discovery marks matches connectable (HOU-670)", async () => {
   const { provider, calls } = harness((url) => {
     if (url.pathname === "/api/v3/connected_accounts")
       return { body: { items: [] } };
+    if (url.pathname === "/api/v3/toolkits") return { body: { items: [] } };
     return {
       body: {
         items: [
@@ -455,11 +537,12 @@ test("search falls back to the global catalog when nothing is connected", async 
     };
   });
   const found = await provider.search(USER, "send an email");
-  // Discoverable but marked not-connected → the agent offers the card.
-  expect(found.map((t) => [t.action, t.connected])).toEqual([
-    ["GMAIL_SEND_EMAIL", false],
+  // Discoverable but connectable → the agent offers the card.
+  expect(found.map((t) => [t.action, t.connected, t.status])).toEqual([
+    ["GMAIL_SEND_EMAIL", false, "connectable"],
   ]);
-  expect(calls[1]?.path).toBe("/api/v3/tools?query=send+an+email&limit=10");
+  // No scoped query when nothing is connected — just the global one.
+  expect(calls.some((c) => c.path.includes("toolkit_slug"))).toBe(false);
 });
 
 test("execute posts user_id + arguments and maps success and failure", async () => {

--- a/packages/host/src/integrations/composio.ts
+++ b/packages/host/src/integrations/composio.ts
@@ -1,5 +1,6 @@
 import { resolveAuthConfig } from "./composio-auth-config";
 import { ComposioHttp } from "./composio-http";
+import { searchComposio } from "./composio-search";
 import {
   mapConnection,
   mapExecute,
@@ -40,6 +41,10 @@ import type {
 
 const DEFAULT_BASE_URL = "https://backend.composio.dev";
 
+/** The toolkits catalog is large-ish and changes rarely — cache it per process
+ *  for search's name resolution so a hot session does not refetch ~1000 apps. */
+const CATALOG_TTL_MS = 60 * 60 * 1000;
+
 export interface ComposioOptions {
   /** Houston's Composio PROJECT API key (dashboard → Project Settings). */
   apiKey: string;
@@ -57,6 +62,9 @@ export class ComposioProvider implements IntegrationProvider {
   private readonly callbackUrl?: string;
   /** toolkit slug → auth-config id (`ac_…`), resolved once per process. */
   private readonly authConfigs = new Map<string, string>();
+  /** In-process toolkits-catalog cache for search's name resolution. */
+  private catalogCache?: { at: number; toolkits: Toolkit[] };
+  private catalogInflight?: Promise<Toolkit[]>;
 
   constructor(opts: ComposioOptions) {
     if (!opts.apiKey) throw new Error("composio: missing platform api key");
@@ -73,7 +81,7 @@ export class ComposioProvider implements IntegrationProvider {
     return { ready: true };
   }
 
-  async listToolkits(): Promise<Toolkit[]> {
+  private async fetchToolkits(): Promise<Toolkit[]> {
     const body = await this.http.call<{ items?: RawToolkit[] }>(
       "/api/v3/toolkits",
       {
@@ -81,6 +89,29 @@ export class ComposioProvider implements IntegrationProvider {
       },
     );
     return (body?.items ?? []).map(mapToolkit);
+  }
+
+  async listToolkits(): Promise<Toolkit[]> {
+    // The UI wants the freshest catalog; search uses the cached copy instead.
+    return this.fetchToolkits();
+  }
+
+  /** The catalog for search's name resolution: cached per process (TTL), with a
+   *  shared in-flight promise so a burst of searches fetches it at most once. */
+  private async cachedCatalog(): Promise<Toolkit[]> {
+    const fresh =
+      this.catalogCache && Date.now() - this.catalogCache.at < CATALOG_TTL_MS;
+    if (this.catalogCache && fresh) return this.catalogCache.toolkits;
+    if (this.catalogInflight) return this.catalogInflight;
+    this.catalogInflight = this.fetchToolkits()
+      .then((toolkits) => {
+        this.catalogCache = { at: Date.now(), toolkits };
+        return toolkits;
+      })
+      .finally(() => {
+        this.catalogInflight = undefined;
+      });
+    return this.catalogInflight;
   }
 
   async listConnections(userId: string): Promise<Connection[]> {
@@ -166,54 +197,25 @@ export class ComposioProvider implements IntegrationProvider {
   ): Promise<ToolMatch[]> {
     // The direct adapter owns the platform key and derives identity from the
     // verified `userId`; there is no upstream to re-authenticate as, so the
-    // acting context is intentionally ignored (self-host / dev only).
-    // GET /api/v3/tools?query=… (the older `search` param is deprecated).
-    // Composio's full-text search is weak unqualified ("send an email" ranks
-    // unrelated marketing tools above GMAIL_SEND_EMAIL — verified live), so
-    // scope to the user's CONNECTED toolkits when they have any: those are the
-    // only actions execute() can run for them anyway. Every match carries
-    // `connected` so the agent can tell "run it" from "offer to connect it".
-    const connected = await this.listConnections(userId);
-    const slugs = [
-      ...new Set(
-        connected.filter((c) => c.status === "active").map((c) => c.toolkit),
-      ),
-    ];
-    const isConnected = (toolkit: string) =>
-      slugs.some((s) => s.toLowerCase() === toolkit.toLowerCase());
-    const tools = async (query: Record<string, string>) => {
-      const body = await this.http.call<{ items?: RawTool[] }>(
-        "/api/v3/tools",
-        { query },
-      );
-      return (body?.items ?? []).map((t) => {
-        const match = mapTool(t);
-        return { ...match, connected: isConnected(match.toolkit) };
-      });
-    };
-    // No connections yet → global search, so the agent can still discover
-    // what to suggest connecting (every match reports connected:false).
-    if (slugs.length === 0) return tools({ query, limit: "10" });
-    const matched = await tools({
+    // acting context is intentionally ignored (self-host / dev only). The merge
+    // policy (scoped + global + catalog resolution) lives in composio-search.ts;
+    // this wires it to the Composio transport. Every returned entry carries its
+    // IntegrationAppStatus (connected/connectable derived from the user's set).
+    return searchComposio(
+      {
+        listConnections: () => this.listConnections(userId),
+        // GET /api/v3/tools?query=… (the older `search` param is deprecated).
+        queryTools: async (q) => {
+          const body = await this.http.call<{ items?: RawTool[] }>(
+            "/api/v3/tools",
+            { query: q },
+          );
+          return (body?.items ?? []).map(mapTool);
+        },
+        catalog: () => this.cachedCatalog(),
+      },
       query,
-      limit: "10",
-      toolkit_slug: slugs.join(","),
-    });
-    if (matched.length > 0) return matched;
-    // The scoped query missed. Two distinct reasons, both worth answering:
-    //  - Composio's full-text match is naive AND-ish: an everyday phrasing
-    //    like "read my latest 5 emails" scores ZERO against GMAIL_FETCH_EMAILS
-    //    (verified live). Scoped to connected toolkits the catalog is small,
-    //    so degrade to listing their actions — the agent picks the slug.
-    //  - The user wants an app they never connected ("send it via gmail" with
-    //    only Slack linked). A global search surfaces those actions marked
-    //    connected:false, so the agent can offer the in-chat connect card
-    //    (HOU-670) instead of dead-ending.
-    const [listing, global] = await Promise.all([
-      tools({ limit: "50", toolkit_slug: slugs.join(",") }),
-      tools({ query, limit: "10" }),
-    ]);
-    return [...listing, ...global.filter((t) => !t.connected)];
+    );
   }
 
   async execute(

--- a/packages/host/src/integrations/fake.ts
+++ b/packages/host/src/integrations/fake.ts
@@ -118,7 +118,14 @@ export class FakeIntegrationProvider implements IntegrationProvider {
           a.description.toLowerCase().includes(q) ||
           a.action.toLowerCase().includes(q),
       )
-      .map((a) => ({ ...a, connected: activeToolkits.has(a.toolkit) }));
+      .map((a) => {
+        const connected = activeToolkits.has(a.toolkit);
+        return {
+          ...a,
+          connected,
+          status: connected ? ("connected" as const) : ("connectable" as const),
+        };
+      });
   }
 
   async execute(

--- a/packages/host/src/integrations/remote.test.ts
+++ b/packages/host/src/integrations/remote.test.ts
@@ -168,6 +168,73 @@ test("acting mode b: a routine actingUser + pod token → pod bearer + acting-us
   expect(calls[0]?.headers["x-houston-acting-user"]).toBe("sub-123");
 });
 
+// ── Search status: tolerant reading of the gateway's per-item status field ────
+
+test("search passes a valid upstream status through verbatim (incl. the future blocked)", async () => {
+  // A later gateway annotates items with a status (e.g. an admin-blocked app).
+  // The desktop must relay it untouched so the runtime can render the blocked
+  // speech act — no code change here when the gateway starts sending it.
+  const { provider } = harness(
+    () => ({
+      body: {
+        items: [
+          {
+            action: "GMAIL_SEND_EMAIL",
+            toolkit: "gmail",
+            description: "Send",
+            connected: true,
+            status: "connected",
+          },
+          {
+            action: "",
+            toolkit: "salesforce",
+            description: "Salesforce",
+            connected: false,
+            status: "blocked",
+          },
+        ],
+      },
+    }),
+    "jwt-1",
+  );
+  expect(
+    (await provider.search("u", "email")).map((m) => [m.toolkit, m.status]),
+  ).toEqual([
+    ["gmail", "connected"],
+    ["salesforce", "blocked"],
+  ]);
+});
+
+test("search derives status from `connected` when absent, and repairs an invalid one", async () => {
+  const { provider } = harness(
+    () => ({
+      body: {
+        items: [
+          // Today's gateway: no status field → derive from connected.
+          { action: "A", toolkit: "gmail", description: "", connected: true },
+          { action: "B", toolkit: "slack", description: "", connected: false },
+          // A garbage status must not leak through — derive instead.
+          {
+            action: "C",
+            toolkit: "notion",
+            description: "",
+            connected: false,
+            status: "banana",
+          },
+        ],
+      },
+    }),
+    "jwt-1",
+  );
+  expect(
+    (await provider.search("u", "x")).map((m) => [m.toolkit, m.status]),
+  ).toEqual([
+    ["gmail", "connected"],
+    ["slack", "connectable"],
+    ["notion", "connectable"],
+  ]);
+});
+
 test("acting mode c: no acting context falls back to the session token (else signin error)", async () => {
   const signedIn = harness(() => ({ body: { items: [] } }), "session-jwt");
   await signedIn.provider.search("owner", "email");

--- a/packages/host/src/integrations/remote.ts
+++ b/packages/host/src/integrations/remote.ts
@@ -5,10 +5,26 @@ import {
   type ConnectStart,
   IntegrationSigninRequiredError,
   integrationUpstreamErrorFromResponse,
+  isIntegrationAppStatus,
   type ProviderReadiness,
+  statusFromConnected,
   type Toolkit,
   type ToolMatch,
 } from "./types";
+
+/**
+ * Read one search item from the gateway TOLERANTLY: a valid `status` (a later
+ * gateway that annotates `blocked`, etc.) passes through untouched; an absent or
+ * unrecognized `status` (today's gateway) derives from the legacy `connected`
+ * boolean. The new field is never required — the desktop keeps working against
+ * an old gateway, and a new gateway lights up `blocked` here with no change.
+ */
+function readSearchItem(raw: ToolMatch): ToolMatch {
+  const status = isIntegrationAppStatus(raw.status)
+    ? raw.status
+    : statusFromConnected(raw.connected);
+  return { ...raw, status };
+}
 
 /**
  * The gateway adapter — the desktop's IntegrationProvider. The platform API key
@@ -188,7 +204,7 @@ export class RemoteIntegrationProvider implements IntegrationProvider {
       body: { query },
       acting,
     });
-    return this.must(body, "POST /search").items;
+    return this.must(body, "POST /search").items.map(readSearchItem);
   }
 
   async execute(

--- a/packages/host/src/integrations/types.ts
+++ b/packages/host/src/integrations/types.ts
@@ -37,9 +37,58 @@ export interface ConnectStart {
   connectionId: string;
 }
 
-/** One action the agent could run, discovered via search(). */
+/**
+ * The app-level status of one search result, the load-bearing contract that
+ * tells the agent which of four speech acts to perform (rendered by the runtime
+ * tool, driven by the prompt):
+ *
+ *  - `connected`:   the acting user has an active connection — use it.
+ *  - `connectable`: a real toolkit with no connection yet — OFFER to connect it
+ *                   (request_connection).
+ *  - `blocked`:     a real toolkit excluded by org/agent admin policy — tell the
+ *                   user to ask their admin; never imply Houston lacks it, never
+ *                   request_connection. Nothing in THIS repo produces `blocked`
+ *                   today (the allowlist ceiling lives solely in the closed cloud
+ *                   gateway); the enum + rendering + prompt exist now so a later
+ *                   gateway change that annotates its search-proxy items with a
+ *                   `status` lights it up here with zero further work.
+ *  - `unknown`:     not a recognized toolkit.
+ */
+export const INTEGRATION_APP_STATUSES = [
+  "connected",
+  "connectable",
+  "blocked",
+  "unknown",
+] as const;
+export type IntegrationAppStatus = (typeof INTEGRATION_APP_STATUSES)[number];
+
+/** Type guard for a value claimed to be an IntegrationAppStatus (wire input). */
+export function isIntegrationAppStatus(v: unknown): v is IntegrationAppStatus {
+  return (
+    typeof v === "string" &&
+    (INTEGRATION_APP_STATUSES as readonly string[]).includes(v)
+  );
+}
+
+/**
+ * Map the legacy `connected` boolean onto the status enum, the fallback when a
+ * result carries no explicit `status`. A returned match that the user has not
+ * connected is a real, connectable app (a genuine miss surfaces as an EMPTY
+ * result, never a match) — so absent/false → connectable, true → connected.
+ */
+export function statusFromConnected(connected?: boolean): IntegrationAppStatus {
+  return connected === true ? "connected" : "connectable";
+}
+
+/**
+ * One result from search(): either an ACTION the agent could run, or a
+ * toolkit-level entry (the app itself, no specific action — `action` is the
+ * empty string) surfaced by catalog resolution so the model always learns the
+ * slug to pass request_connection even when no action scored.
+ */
 export interface ToolMatch {
-  /** The slug passed to execute(), e.g. "GMAIL_SEND_EMAIL". */
+  /** The slug passed to execute(), e.g. "GMAIL_SEND_EMAIL". Empty ("") marks a
+   *  toolkit-level entry (the app itself, no runnable action). */
   action: string;
   toolkit: string;
   description: string;
@@ -48,9 +97,17 @@ export interface ToolMatch {
   /**
    * Whether the user has an active connection to this action's toolkit.
    * `false` means execute() would fail — the agent should offer the in-chat
-   * connect card instead (HOU-670). Absent = unknown (older adapters).
+   * connect card instead (HOU-670). Absent = unknown (older adapters). Retained
+   * alongside `status` for backward compatibility (grants filter reads it).
    */
   connected?: boolean;
+  /**
+   * The app-level status driving the agent's speech act (see
+   * IntegrationAppStatus). Every match the current adapters return carries it;
+   * absent only from an older adapter, where the runtime derives it from
+   * `connected`.
+   */
+  status?: IntegrationAppStatus;
 }
 
 /** The outcome of running an action. */

--- a/packages/runtime/src/session/tools/integrations.test.ts
+++ b/packages/runtime/src/session/tools/integrations.test.ts
@@ -130,6 +130,66 @@ test("search marks not-connected matches and teaches request_connection", async 
   expect(text).not.toContain("](https://");
 });
 
+test("a connectable toolkit-level entry names the slug and teaches request_connection", async () => {
+  // Catalog resolution surfaces the app itself (empty action) so the model
+  // learns the slug even when no action scored — the Google Sheets bug.
+  mockFetch(() => ({
+    body: {
+      items: [
+        {
+          action: "",
+          toolkit: "googlesheets",
+          description: "Google Sheets: Spreadsheets",
+          connected: false,
+          status: "connectable",
+        },
+      ],
+    },
+  }));
+  const out = await run(search, { query: "connect to google sheets" });
+  const text = (out.content[0] as { text: string }).text;
+  // The app row (not an action row) names the slug.
+  expect(text).toContain("- googlesheets (app, NOT CONNECTED): Google Sheets");
+  // And the connect hand-off is taught, naming the connectable slug.
+  expect(text).toContain("not connected yet (googlesheets)");
+  expect(text).toContain("request_connection tool");
+});
+
+test("a blocked app sends the user to their admin and never offers request_connection", async () => {
+  mockFetch(() => ({
+    body: {
+      items: [
+        {
+          action: "",
+          toolkit: "salesforce",
+          description: "Salesforce",
+          connected: false,
+          status: "blocked",
+        },
+      ],
+    },
+  }));
+  const out = await run(search, { query: "salesforce" });
+  const text = (out.content[0] as { text: string }).text;
+  expect(text).toContain("- salesforce (app, BLOCKED by admin): Salesforce");
+  expect(text).toContain("admin has not enabled these apps");
+  expect(text).toContain("ask their admin");
+  // The guidance explicitly forbids the connect card for a blocked app.
+  expect(text).toContain("Do NOT call request_connection");
+  // And it never offers to connect it (no "not connected yet" connect prompt).
+  expect(text).not.toContain("not connected yet");
+});
+
+test("an empty result is a genuine not-found, not a policy block", async () => {
+  mockFetch(() => ({ body: { items: [] } }));
+  const out = await run(search, { query: "flibbertigibbet" });
+  const text = (out.content[0] as { text: string }).text;
+  expect(text).toContain("No matching app or action found");
+  expect(text).toContain("genuine not-found");
+  expect(text).toContain("does NOT mean an app is blocked");
+  expect(text).not.toContain("request_connection");
+});
+
 test("execute runs an action and returns its data; a failed action surfaces", async () => {
   mockFetch(() => ({ body: { successful: true, data: { id: "msg1" } } }));
   const out = await run(execute, {

--- a/packages/runtime/src/session/tools/integrations.ts
+++ b/packages/runtime/src/session/tools/integrations.ts
@@ -88,13 +88,52 @@ export interface IntegrationToolOptions {
   sandboxToken: string;
 }
 
+/**
+ * The app-level status the host reports per search result (mirrors the host's
+ * IntegrationAppStatus). It, not the raw `connected` boolean, drives which of
+ * four speech acts the model performs — so a real-but-unconnected app is offered
+ * for connection, an admin-blocked app sends the user to their admin, and only a
+ * genuinely empty result means "no such app".
+ */
+type AppStatus = "connected" | "connectable" | "blocked" | "unknown";
+
 interface ToolMatch {
+  /** Empty ("") marks a toolkit-level entry: the app itself, no runnable action. */
   action: string;
   toolkit: string;
   description: string;
   inputParams?: unknown;
   /** Host-reported: does the user have this action's app connected? */
   connected?: boolean;
+  /** Host-reported app status; absent only from an older host (derive it). */
+  status?: AppStatus;
+}
+
+/** Prefer the explicit status; fall back to the legacy connected boolean. */
+function statusOf(m: ToolMatch): AppStatus {
+  if (m.status) return m.status;
+  return m.connected === false ? "connectable" : "connected";
+}
+
+/** The per-status tag shown after an app/action name in the rendered list. */
+const STATUS_TAG: Record<AppStatus, string> = {
+  connected: "",
+  connectable: ", NOT CONNECTED",
+  blocked: ", BLOCKED by admin",
+  unknown: ", not a known app",
+};
+
+/** One rendered line: an action row, or a toolkit-level row (empty action). */
+function renderMatch(m: ToolMatch, status: AppStatus): string {
+  const tag = STATUS_TAG[status];
+  if (m.action === "") {
+    // A toolkit-level entry: the app itself, so the model learns the slug.
+    return `- ${m.toolkit} (app${tag}): ${m.description}`;
+  }
+  const schema = m.inputParams
+    ? `\n  params: ${JSON.stringify(m.inputParams)}`
+    : "";
+  return `- ${m.action} (${m.toolkit}${tag}): ${m.description}${schema}`;
 }
 
 /**
@@ -104,7 +143,7 @@ interface ToolMatch {
  * renders a one-click connect card in place of the chat input.
  */
 const REQUEST_CONNECTION_GUIDANCE =
-  "To let the user connect an app, call the request_connection tool with that app's toolkit (the slug shown in the results). Houston shows the user a one-click connect card in place of the chat input, then automatically sends you a message once the connection is live so you can continue — do not ask the user to confirm.";
+  "To let the user connect an app, call the request_connection tool with that app's toolkit (the slug shown in the results). Houston shows the user a one-click connect card in place of the chat input, then automatically sends you a message once the connection is live so you can continue - do not ask the user to confirm.";
 interface ActionResult {
   successful: boolean;
   data?: unknown;
@@ -196,33 +235,45 @@ export function makeIntegrationTools(opts: IntegrationToolOptions) {
         signal,
       );
       if (items.length === 0) {
+        // Genuinely empty: not a policy block, not "unavailable" - no such app
+        // or action was found. The prompt tells the model to say so plainly.
         return {
           content: [
             {
               type: "text" as const,
-              text: `No actions found for "${params.query}".`,
+              text: `No matching app or action found for "${params.query}". This is a genuine not-found: no such app or action exists here. It does NOT mean an app is blocked or withheld by policy.`,
             },
           ],
           details: { matches: 0, actions: [] as string[] },
         };
       }
-      const list = items
-        .map((m) => {
-          const status = m.connected === false ? ", NOT CONNECTED" : "";
-          const schema = m.inputParams
-            ? `\n  params: ${JSON.stringify(m.inputParams)}`
-            : "";
-          return `- ${m.action} (${m.toolkit}${status}): ${m.description}${schema}`;
-        })
-        .join("\n");
-      // Some matches need a connection first → teach the hand-off inline, at
-      // the moment the model actually faces a not-connected app.
-      const text = items.some((m) => m.connected === false)
-        ? `${list}\n\nActions marked NOT CONNECTED will fail until the user connects that app. ${REQUEST_CONNECTION_GUIDANCE}`
-        : list;
+      const list = items.map((m) => renderMatch(m, statusOf(m))).join("\n");
+
+      // Teach each speech act inline, only for the statuses actually present.
+      const slugsWith = (s: AppStatus) => [
+        ...new Set(
+          items.filter((m) => statusOf(m) === s).map((m) => m.toolkit),
+        ),
+      ];
+      const parts = [list];
+      const connectable = slugsWith("connectable");
+      if (connectable.length > 0) {
+        parts.push(
+          `These apps exist but are not connected yet (${connectable.join(", ")}). ${REQUEST_CONNECTION_GUIDANCE}`,
+        );
+      }
+      const blocked = slugsWith("blocked");
+      if (blocked.length > 0) {
+        parts.push(
+          `Your workspace admin has not enabled these apps for this agent (${blocked.join(", ")}). Tell the user to ask their admin to enable them. Do NOT call request_connection for these, and do NOT imply Houston lacks them.`,
+        );
+      }
       return {
-        content: [{ type: "text" as const, text }],
-        details: { matches: items.length, actions: items.map((m) => m.action) },
+        content: [{ type: "text" as const, text: parts.join("\n\n") }],
+        details: {
+          matches: items.length,
+          actions: items.filter((m) => m.action).map((m) => m.action),
+        },
       };
     },
   });

--- a/packages/web/e2e/README.md
+++ b/packages/web/e2e/README.md
@@ -87,6 +87,24 @@ assistant reply at turn END (both turn-stamped) — the identity contract
   DIFFERENT turnId and the client must settle its turn from history by turnId
   (the turn-boundary spec).
 
+**Teams / integrations arming.** Single-player alone can't reach the Teams-shaped
+state the locked browse rows (and, later, the admin policy pages) need. Two
+controls arm it (documented in the `@houston/fake-host` README):
+
+- `POST /__test__/capabilities` (`Partial<Capabilities>`) — merge a partial into
+  `/v1/capabilities`. `{ integrations:["composio"], multiplayer:true,
+  teams:true, role:"owner" }` puts the agent Integrations tab into Teams mode;
+  `{ integrations:["composio"] }` alone is single-player-with-apps.
+- `POST /__test__/agent-settings` (`{ allowedToolkits?, orgAllowedToolkits?,
+  allowedModels?, access? }`) — the Teams v2 ceilings the fake host serves at
+  `/v1/agents/:slug/settings` + `/v1/org/settings`. The effective allowlist
+  (agent ∩ org) splits the browse catalog into connectable vs locked rows
+  (`integrations-locked.spec.ts`). `null` = unrestricted, `[]` = none.
+
+The seeded catalog (`SEED_TOOLKIT_SLUGS`, exported for specs) holds 15 A-Z apps,
+enough that a tight allowlist blocks past the locked preview cap (8) so the
+"+N more" overflow is exercisable.
+
 **Board.** The mission board is files-first: it reads/writes
 `.houston/activity/activity.json` through `/agents/:id/agentfile/*`. The fake host
 backs that with a real in-memory store, seeded with two missions, and unified with

--- a/packages/web/e2e/integrations-locked.spec.ts
+++ b/packages/web/e2e/integrations-locked.spec.ts
@@ -1,0 +1,161 @@
+import { FAKE_HOST_URL, SEED_TOOLKIT_SLUGS } from "@houston/fake-host";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * Locked browse rows on a Teams host (Element B). On a Teams deployment with a
+ * real effective allowlist the agent Integrations tab no longer HIDES blocked
+ * apps (which read as "Houston doesn't support X") — it shows them as read-only
+ * LOCKED rows in the browse catalog, capped at 8 with a "+N more" line, and an
+ * app inside the ceiling stays connectable. Single-player never renders locks.
+ *
+ * The Teams-shaped state single-player can't reach is armed via the fake host's
+ * `/__test__/capabilities` (advertise `integrations` + `multiplayer` + `teams`)
+ * and `/__test__/agent-settings` (the agent/org allowlist ceilings) controls —
+ * the same real wire shapes `getAgentSettings` / the `teams` capability feed the
+ * frontend. See `@houston/fake-host` README + `knowledge-base/ui-testing.md`.
+ */
+
+/** The realistic Teams team-space capabilities: integrations on, multiplayer + Teams. */
+const TEAMS_CAPS = {
+  integrations: ["composio"],
+  multiplayer: true,
+  teams: true,
+  role: "owner",
+};
+
+async function armCapabilities(
+  request: APIRequestContext,
+  caps: Record<string, unknown>,
+): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/capabilities`, { data: caps });
+}
+
+async function armAllowlist(
+  request: APIRequestContext,
+  settings: {
+    allowedToolkits: string[] | null;
+    orgAllowedToolkits: string[] | null;
+  },
+): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/agent-settings`, {
+    data: settings,
+  });
+}
+
+/** A fresh team member has connected nothing; the seed connects Gmail, so drop it. */
+async function clearConnections(request: APIRequestContext): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/v1/integrations/composio/disconnect`, {
+    data: { toolkit: "gmail" },
+  });
+}
+
+async function openIntegrationsTab(page: Page): Promise<void> {
+  await page.goto("/");
+  // The agent's Integrations TAB (a sidebar "Integrations" nav button shares the
+  // label), keyed by its stable tour anchor.
+  await page.locator('[data-tour-target="tab-integrations"]').click();
+}
+
+test("a blocked app shows as a locked row with the ask-admin line, and clicking does nothing", async ({
+  page,
+  request,
+}) => {
+  // Admin enabled every app except Slack: Slack is the sole blocked (locked) app.
+  const allowlist = SEED_TOOLKIT_SLUGS.filter((s) => s !== "slack");
+  await armCapabilities(request, TEAMS_CAPS);
+  await armAllowlist(request, {
+    allowedToolkits: allowlist,
+    orgAllowedToolkits: null,
+  });
+  await clearConnections(request);
+  await openIntegrationsTab(page);
+
+  // Gmail is inside the ceiling and unconnected → a connectable browse row (a
+  // clickable button), NOT locked.
+  await expect(
+    page.getByRole("button").filter({ hasText: "Gmail" }).first(),
+  ).toBeVisible();
+
+  // Slack is outside the ceiling → a locked row under the muted heading, with
+  // the ask-your-admin subtitle visible AT REST (no hover gating).
+  await expect(page.getByText("Not enabled by your admin")).toBeVisible();
+  await expect(page.getByText("Ask your admin to enable Slack")).toBeVisible();
+
+  // The locked row is non-interactive: no button carries Slack (unlike the
+  // connectable Gmail row), so there is nothing that could start a connect flow.
+  await expect(
+    page.getByRole("button").filter({ hasText: "Slack" }),
+  ).toHaveCount(0);
+
+  // Clicking the locked row changes nothing — the ask-admin line stays and no
+  // connect affordance appears for Slack.
+  await page.getByText("Ask your admin to enable Slack").click();
+  await expect(page.getByText("Ask your admin to enable Slack")).toBeVisible();
+  await expect(
+    page.getByRole("button").filter({ hasText: "Slack" }),
+  ).toHaveCount(0);
+});
+
+test("searching for a blocked app shows its locked row, not the empty state", async ({
+  page,
+  request,
+}) => {
+  const allowlist = SEED_TOOLKIT_SLUGS.filter((s) => s !== "slack");
+  await armCapabilities(request, TEAMS_CAPS);
+  await armAllowlist(request, {
+    allowedToolkits: allowlist,
+    orgAllowedToolkits: null,
+  });
+  await clearConnections(request);
+  await openIntegrationsTab(page);
+
+  // A query that matches ONLY a blocked app must surface its locked row rather
+  // than the "no matching apps" empty state (the search filters before the
+  // connectable/locked partition).
+  await page.getByPlaceholder("Search apps...").fill("slack");
+
+  await expect(page.getByText("Ask your admin to enable Slack")).toBeVisible();
+  await expect(page.getByText("No matching apps found.")).toHaveCount(0);
+});
+
+test("the locked section caps at 8 rows with a +N more line", async ({
+  page,
+  request,
+}) => {
+  // Only Gmail allowed → the other 14 seeded apps are blocked. The locked
+  // preview caps at 8; the remaining 6 collapse into the "+N more" count line.
+  await armCapabilities(request, TEAMS_CAPS);
+  await armAllowlist(request, {
+    allowedToolkits: ["gmail"],
+    orgAllowedToolkits: null,
+  });
+  await clearConnections(request);
+  await openIntegrationsTab(page);
+
+  await expect(page.getByText("Not enabled by your admin")).toBeVisible();
+
+  // Exactly 8 locked rows are shown (each carries the ask-admin subtitle)...
+  await expect(page.getByText(/^Ask your admin to enable /)).toHaveCount(8);
+  // ...and the overflow (14 blocked − 8 shown = 6) folds into the count line.
+  await expect(
+    page.getByText("6 more apps your admin hasn't enabled"),
+  ).toBeVisible();
+});
+
+test("single-player: the browse catalog renders but no locked section ever appears", async ({
+  page,
+  request,
+}) => {
+  // Integrations available, but NOT a Teams host: no allowlist ceiling exists,
+  // so the browse catalog is fully connectable and locks never render.
+  await armCapabilities(request, { integrations: ["composio"] });
+  await openIntegrationsTab(page);
+
+  // The catalog is live — an unconnected app is a connectable browse row.
+  await expect(
+    page.getByRole("button").filter({ hasText: "Slack" }).first(),
+  ).toBeVisible();
+  // No lock treatment anywhere.
+  await expect(page.getByText("Not enabled by your admin")).toHaveCount(0);
+});


### PR DESCRIPTION
Elements A + B of the integrations clarity roadmap (two clean commits, one per element).

## Element A — the agent stops misinforming
With Gmail connected, `integration_search` short-circuited on the connected-scoped query and never ran global discovery, so "connect to Google Sheets" got "I don't see it" instead of an offer to connect.

- Search always merges scoped + global discovery and resolves app names against the Composio toolkit catalog (1h in-process cache) so a named app yields its real slug even when action full-text scores zero.
- New per-match status taxonomy: `connected | connectable | blocked | unknown`. `blocked` is unreachable from this repo today (the allowlist ceiling lives in the cloud gateway, the sole policy enforcer); the gateway adapter already tolerantly reads an optional `status` field, so a later gateway annotation lights it up with zero further change here.
- Tool result text is status-aware and model-actionable; the product prompt (TS + Rust mirror, verbatim-identical) teaches four speech acts: use it / offer to connect / "ask your admin" / no such app. Never implies Houston lacks an app when policy is the reason.
- Live read-only smoke against real Composio: "google sheets" with no connections → toolkit `googlesheets`, status `connectable`.

## Element B — members see policy, not absence
Admin-blocked apps were filtered out of the agent's browse catalog entirely; silent absence read as "Houston doesn't support X."

- Teams mode renders blocked-but-unconnected apps as locked rows: lock icon, "Ask your admin to enable {app}" visible at rest, non-interactive, after the connectable set, capped at 8 + "+N more". Searching a blocked app surfaces its locked row, not the empty state. Single-player never shows locks.
- Copy pass separates admin POLICY (allowlist editor + helper) from member CONNECTIONS (ask-your-admin line on the disallowed section). en/es/pt.
- Fake host can now arm Teams mode (capabilities override + agent/org settings routes + 15-app seed) — groundwork the admin-pages element needs too. New e2e spec (4 cases) incl. screenshot-inspected visuals.

## Verification
- host 703, runtime 594, app 1274, fake-host 9 — all green.
- Full Playwright e2e: 57/57.
- typecheck (all 22 projects), Biome, boundaries, parity, check-locales: clean.
- KB updated in-element: `integrations.md`, `teams.md`, `ui-testing.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)