### PR TITLE
test(e2e): deflake the routine-chat Escape test

### DIFF
--- a/packages/web/e2e/routine-setup-chat.spec.ts
+++ b/packages/web/e2e/routine-setup-chat.spec.ts
@@ -486,16 +486,23 @@ test("Escape returns from a routine chat to the grid", async ({ page }) => {
     timeout: 15_000,
   });
 
-  // A focused composer eats the FIRST Escape (blur, app convention)…
+  // A focused composer eats the FIRST Escape (blur, app convention); the
+  // SECOND backs out to the grid. Press them back-to-back and assert only
+  // the user-visible outcome — asserting the intermediate blur is racy on
+  // CI because chat activity (a settling reply, the focus token) can
+  // legitimately re-focus the composer an instant later.
   const composer = page.getByPlaceholder("Send a follow-up...");
   await composer.click();
   await expect(composer).toBeFocused();
   await page.keyboard.press("Escape");
-  await expect(composer).not.toBeFocused();
-
-  // …the SECOND backs out to the grid.
   await page.keyboard.press("Escape");
   await expect(
     page.getByRole("button", { name: "New routine" }).first(),
   ).toBeVisible();
+
+  // The chat still opens fine afterwards (Escape never wedged the view).
+  await editRoutineWithAi(page, "Escapable");
+  await expect(page.getByText("Routine: Escapable")).toBeVisible({
+    timeout: 15_000,
+  });
 });


### PR DESCRIPTION
Follow-up to #815. The Web CI job (non-required) failed there on exactly one test: the new Escape e2e asserted an intermediate `not.toBeFocused()` state that races the composer's legitimate refocus (settling reply / focus token) on slow CI runners — 62/63 passed otherwise.

Fix: assert only the user-visible contract — two Escapes from a focused composer land on the grid, and the chat reopens cleanly afterwards. Passed 3/3 isolated runs + the full 11-test routine spec locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)