### PR TITLE
feat(ai-hub): org-wide model policy — one home, mirroring the integrations IA

### DIFF
--- a/app/src/components/ai-hub/ai-hub-policy.tsx
+++ b/app/src/components/ai-hub/ai-hub-policy.tsx
@@ -1,0 +1,80 @@
+import { Spinner } from "@houston-ai/core";
+import { useTranslation } from "react-i18next";
+import {
+  useOrgSettings,
+  useSetOrgAllowedModels,
+} from "../../hooks/queries/use-org-settings";
+import { useCapabilities } from "../../hooks/use-capabilities";
+import { useHubCatalog } from "../../lib/ai-hub/use-hub-catalog";
+import { canEditOrgSettings } from "../../lib/org-roles";
+import { ModelsAllowlistEditor } from "./models-allowlist-editor";
+
+/**
+ * The workspace AI-model policy for the global AI Models hub (Teams owner/admin):
+ * the org-wide model ceiling every agent's effective allowed-models set is
+ * derived under — the model-side twin of the Integrations page's app-allowlist
+ * policy. Owner edits the ceiling; an admin sees it read-only with an owner-only
+ * note. The picker is sourced from the same AI-hub catalog the per-agent
+ * {@link AgentModelsSection} and the model directory use, so the two never drift.
+ * A quiet footer explains that managers can narrow this further per agent.
+ *
+ * Rendered only inside the hub's Teams-gated "policy" tab, which owner/admin
+ * alone reach (plain members lose the AI Hub nav, exactly as they lose the
+ * Integrations nav — providers are org-level, so a member has no account or
+ * policy to act on here).
+ */
+export function AiHubPolicy() {
+  const { t } = useTranslation("teams");
+  const { capabilities } = useCapabilities();
+  const teams = capabilities?.teams === true;
+
+  const orgSettings = useOrgSettings(teams);
+  const setOrgModels = useSetOrgAllowedModels();
+  const { catalog } = useHubCatalog();
+
+  const readOnly = !canEditOrgSettings(capabilities);
+  const loading = orgSettings.isLoading || !catalog;
+
+  return (
+    <div className="mx-auto w-full max-w-3xl">
+      {loading ? (
+        <div className="flex justify-center py-10">
+          <Spinner className="size-5" />
+        </div>
+      ) : (
+        <>
+          <ModelsAllowlistEditor
+            models={catalog.models}
+            allowedModels={orgSettings.data?.allowedModels ?? null}
+            saving={setOrgModels.isPending}
+            readOnly={readOnly}
+            onSave={(next) => setOrgModels.mutate(next)}
+            copy={{
+              question: t("models.orgAllowlist.question"),
+              policyHelper: t("models.orgAllowlist.policyHelper"),
+              anyLabel: t("models.orgAllowlist.anyLabel"),
+              anyDesc: t("models.orgAllowlist.anyDesc"),
+              pickedLabel: t("models.orgAllowlist.pickedLabel"),
+              pickedDesc: t("models.orgAllowlist.pickedDesc"),
+              allowedHeading: t("models.orgAllowlist.allowedHeading"),
+              addHeading: t("models.orgAllowlist.addHeading"),
+              allowedEmpty: t("models.orgAllowlist.allowedEmpty"),
+              allowedEmptyLab: t("models.orgAllowlist.allowedEmptyLab"),
+              searchModels: t("models.orgAllowlist.searchModels"),
+              noModels: t("models.orgAllowlist.noModels"),
+              allowModel: (name) =>
+                t("models.orgAllowlist.allowModel", { name }),
+              readOnlyNote: readOnly
+                ? t("models.orgAllowlist.ownerOnly")
+                : undefined,
+            }}
+          />
+
+          <p className="mt-8 text-center text-xs text-muted-foreground">
+            {t("models.orgAllowlist.perAgentNote")}
+          </p>
+        </>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/ai-hub/ai-hub-tabs.tsx
+++ b/app/src/components/ai-hub/ai-hub-tabs.tsx
@@ -1,7 +1,7 @@
 import { Badge, cn } from "@houston-ai/core";
 import { useTranslation } from "react-i18next";
 
-export type HubTab = "providers" | "models";
+export type HubTab = "providers" | "models" | "policy";
 
 /**
  * The Providers / Models switch, rendered as the SAME underline tab strip the
@@ -18,17 +18,21 @@ export function AiHubTabs({
   active,
   providerCount,
   modelCount,
+  showPolicy,
   onSelect,
 }: {
   active: HubTab;
   providerCount: number;
   modelCount: number;
+  /** Teams owner/admin only: the workspace model-policy tab (no count badge). */
+  showPolicy: boolean;
   onSelect: (tab: HubTab) => void;
 }) {
   const { t } = useTranslation("aiHub");
-  const tabs: { id: HubTab; label: string; count: number }[] = [
+  const tabs: { id: HubTab; label: string; count?: number }[] = [
     { id: "providers", label: t("tabs.providers"), count: providerCount },
     { id: "models", label: t("tabs.models"), count: modelCount },
+    ...(showPolicy ? [{ id: "policy" as const, label: t("tabs.policy") }] : []),
   ];
   return (
     <div
@@ -54,12 +58,14 @@ export function AiHubTabs({
             )}
           >
             {tab.label}
-            <Badge
-              variant="secondary"
-              className="min-w-5 px-1.5 font-normal tabular-nums text-muted-foreground"
-            >
-              {tab.count}
-            </Badge>
+            {tab.count !== undefined && (
+              <Badge
+                variant="secondary"
+                className="min-w-5 px-1.5 font-normal tabular-nums text-muted-foreground"
+              >
+                {tab.count}
+              </Badge>
+            )}
             {isActive && (
               <span className="absolute bottom-0 left-0 right-0 h-[2px] rounded-full bg-primary" />
             )}

--- a/app/src/components/ai-hub/ai-hub-view.tsx
+++ b/app/src/components/ai-hub/ai-hub-view.tsx
@@ -6,6 +6,7 @@ import { useProviderConnections } from "../../hooks/use-provider-connections";
 import type { CatalogModel } from "../../lib/ai-hub/catalog-types";
 import { useHubCatalog } from "../../lib/ai-hub/use-hub-catalog";
 import { newEngineActive } from "../../lib/engine";
+import { isMultiplayer } from "../../lib/org-roles";
 import { osIsTauri } from "../../lib/os-bridge";
 import {
   EMPTY_PROVIDER_CAPABILITIES,
@@ -15,6 +16,7 @@ import {
 import { ProviderBrowser } from "../provider-browser/provider-browser";
 import { ProviderConnectionDialogs } from "../provider-browser/provider-connection-dialogs";
 import { PageContainer } from "../shell/page-shell";
+import { AiHubPolicy } from "./ai-hub-policy";
 import { AiHubTabs, type HubTab } from "./ai-hub-tabs";
 import { HubHero } from "./hub-hero";
 import { ModelDirectory } from "./model-directory";
@@ -46,6 +48,10 @@ export function AiHubView() {
 
   const { capabilities } = useCapabilities();
   const newEngine = newEngineActive();
+  // Teams owner/admin only reach the hub (plain members lose its nav), so the
+  // workspace model-policy tab shows whenever this is a Teams deployment.
+  const showPolicy =
+    isMultiplayer(capabilities) && capabilities?.teams === true;
   const providerCapabilities =
     capabilities ?? (newEngine ? EMPTY_PROVIDER_CAPABILITIES : undefined);
   // The connect cards this deployment can show (merged OpenCode account, engine
@@ -95,6 +101,7 @@ export function AiHubView() {
                 active={tab}
                 providerCount={connectProviders.length}
                 modelCount={catalog.modelCount}
+                showPolicy={showPolicy}
                 onSelect={setTab}
               />
             </PageContainer>
@@ -125,6 +132,8 @@ export function AiHubView() {
                       onOpen={setOpenProvider}
                       renderDialogs={false}
                     />
+                  ) : tab === "policy" && showPolicy ? (
+                    <AiHubPolicy />
                   ) : (
                     <ModelDirectory
                       catalog={catalog}

--- a/app/src/components/ai-hub/models-allowlist-editor.tsx
+++ b/app/src/components/ai-hub/models-allowlist-editor.tsx
@@ -1,0 +1,201 @@
+import { Search } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { CatalogModel } from "../../lib/ai-hub/catalog-types.ts";
+import { filterModels, searchModels } from "../../lib/ai-hub/search.ts";
+import { AccessChoice } from "../tabs/agent-admin/access-choice.tsx";
+import {
+  type AccessMode,
+  ceilingMode,
+} from "../tabs/agent-admin/agent-admin-row-values.ts";
+import { LabFilter } from "../tabs/agent-admin/lab-filter.tsx";
+import { ModelAllowRow } from "../tabs/agent-admin/model-allow-row.tsx";
+import {
+  allowedListView,
+  modelChecked,
+  toggleModel,
+} from "../tabs/agent-admin/model-allowlist.ts";
+import type { ProviderValue } from "./facets.ts";
+
+/** i18n copy for {@link ModelsAllowlistEditor}; the consumer passes translated strings. */
+export interface ModelsAllowlistEditorCopy {
+  question: string;
+  policyHelper: string;
+  anyLabel: string;
+  anyDesc: string;
+  pickedLabel: string;
+  pickedDesc: string;
+  allowedHeading: string;
+  addHeading: string;
+  allowedEmpty: string;
+  allowedEmptyLab: string;
+  searchModels: string;
+  noModels: string;
+  /** aria-label for a per-model allow toggle. */
+  allowModel: (name: string) => string;
+  /** Shown under the question when readOnly (e.g. "Only the owner can change this"). */
+  readOnlyNote?: string;
+}
+
+export interface ModelsAllowlistEditorProps {
+  /** The selectable universe of models (already narrowed to any higher ceiling). */
+  models: CatalogModel[];
+  /** Current ceiling: `null` = any model allowed, else the explicit id set. */
+  allowedModels: string[] | null;
+  /** A write is in flight (disables controls). */
+  saving: boolean;
+  /** Read-only viewer (e.g. a non-owner admin): controls disabled, "Add models" list hidden, `readOnlyNote` shown. */
+  readOnly?: boolean;
+  /** Persist the next ceiling: `null` = allow all, else the explicit set. */
+  onSave: (next: string[] | null) => void;
+  copy: ModelsAllowlistEditorCopy;
+}
+
+/**
+ * Presentational, i18n-agnostic editor for an AI-model allowlist ceiling
+ * (Teams v2), the model-side twin of {@link AllowlistEditor}. An always-visible
+ * {@link AccessChoice} ("Any model" saves `null`, "Only models you pick" saves an
+ * explicit set) over the AI-hub catalog's visual language: one {@link ModelAllowRow}
+ * per {@link CatalogModel} (brand mark + name + lab + allow Switch). Selection is
+ * over provider-native offer ids — toggling a model flips ALL its offers at once
+ * (see {@link toggleModel}) — so a member can pick that model from any provider
+ * connected. Writes are instant; `readOnly` disables every control and hides the
+ * "Add models" list. All copy is passed in; both the per-agent and org ceilings
+ * consume this so they never drift.
+ */
+export function ModelsAllowlistEditor({
+  models,
+  allowedModels,
+  saving,
+  readOnly,
+  onSave,
+  copy,
+}: ModelsAllowlistEditorProps) {
+  const [search, setSearch] = useState("");
+  // View-only lab filter (never touches saved data); composes with the search.
+  const [lab, setLab] = useState<ProviderValue>("all");
+  const labFilter = lab === "all" ? undefined : lab;
+
+  const allowedSet = useMemo(
+    () => new Set(allowedModels ?? []),
+    [allowedModels],
+  );
+  // Every model the ceiling currently allows (before the view-only lab filter).
+  const pickedModels = useMemo(
+    () => models.filter((m) => modelChecked(m, allowedSet)),
+    [models, allowedSet],
+  );
+  const allowedList = useMemo(
+    () => filterModels(pickedModels, { lab: labFilter }),
+    [pickedModels, labFilter],
+  );
+  const allowedView = allowedListView({
+    visibleCount: allowedList.length,
+    hasPicked: pickedModels.length > 0,
+    labFiltered: labFilter !== undefined,
+  });
+  // The remaining (not-yet-allowed) models to add, narrowed to the picked lab
+  // and ranked by the search box — allowed models live in their own list above.
+  const results = useMemo(() => {
+    const base = filterModels(
+      models.filter((m) => !modelChecked(m, allowedSet)),
+      { lab: labFilter },
+    );
+    return searchModels(base, search);
+  }, [models, search, allowedSet, labFilter]);
+
+  const onChoice = (mode: AccessMode) => onSave(mode === "any" ? null : []);
+  const toggle = (model: CatalogModel) =>
+    onSave(toggleModel(model, [...allowedSet]));
+
+  const renderModel = (model: CatalogModel) => (
+    <ModelAllowRow
+      key={model.key}
+      model={model}
+      checked={modelChecked(model, allowedSet)}
+      disabled={saving || !!readOnly}
+      allowLabel={copy.allowModel(model.name)}
+      onToggle={() => toggle(model)}
+    />
+  );
+
+  return (
+    <div>
+      <h2 className="mb-1 text-lg font-medium text-foreground">
+        {copy.question}
+      </h2>
+      <p className="mb-4 text-sm text-muted-foreground">{copy.policyHelper}</p>
+
+      {readOnly && copy.readOnlyNote && (
+        <p className="mb-4 text-sm text-muted-foreground">
+          {copy.readOnlyNote}
+        </p>
+      )}
+
+      <AccessChoice
+        question={copy.question}
+        value={ceilingMode(allowedModels)}
+        disabled={saving || readOnly}
+        onChange={onChoice}
+        options={[
+          { value: "any", label: copy.anyLabel, description: copy.anyDesc },
+          {
+            value: "picked",
+            label: copy.pickedLabel,
+            description: copy.pickedDesc,
+          },
+        ]}
+      />
+
+      {allowedModels !== null && (
+        <div className="mt-6">
+          <section className="mb-8">
+            <h3 className="mb-2 text-sm font-medium text-foreground">
+              {copy.allowedHeading}
+            </h3>
+            {allowedView === "list" ? (
+              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                {allowedList.map(renderModel)}
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                {allowedView === "empty-lab"
+                  ? copy.allowedEmptyLab
+                  : copy.allowedEmpty}
+              </p>
+            )}
+          </section>
+
+          {!readOnly && (
+            <section>
+              <h3 className="mb-3 text-sm font-medium text-foreground">
+                {copy.addHeading}
+              </h3>
+              <div className="mb-3 flex items-center gap-2">
+                <div className="relative flex-1">
+                  <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                  <input
+                    type="text"
+                    value={search}
+                    onChange={(e) => setSearch(e.target.value)}
+                    placeholder={copy.searchModels}
+                    className="h-9 w-full rounded-full border border-border bg-background pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/20"
+                  />
+                </div>
+                <LabFilter models={models} value={lab} onChange={setLab} />
+              </div>
+              {results.length === 0 ? (
+                <p className="py-4 text-center text-sm text-muted-foreground">
+                  {copy.noModels}
+                </p>
+              ) : (
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+                  {results.map(renderModel)}
+                </div>
+              )}
+            </section>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/src/components/shell/sidebar-chrome.tsx
+++ b/app/src/components/shell/sidebar-chrome.tsx
@@ -22,10 +22,12 @@ type ShellT = TFunction<["shell", "common", "portable", "teams"]>;
 export function buildSidebarNavItems(args: {
   t: ShellT;
   showIntegrations: boolean;
+  showAiModels: boolean;
   showOrganization: boolean;
   setViewMode: (view: string) => void;
 }): SidebarNavItemEntry[] {
-  const { t, showIntegrations, showOrganization, setViewMode } = args;
+  const { t, showIntegrations, showAiModels, showOrganization, setViewMode } =
+    args;
   return [
     {
       id: "dashboard",
@@ -45,13 +47,17 @@ export function buildSidebarNavItems(args: {
           },
         ]
       : []),
-    {
-      id: "ai-hub",
-      label: t("shell:sidebar.aiModels"),
-      icon: <Boxes className="h-4 w-4" />,
-      onClick: () => setViewMode("ai-hub"),
-      dataAttrs: { "data-tour-target": "nav-ai-hub" },
-    },
+    ...(showAiModels
+      ? [
+          {
+            id: "ai-hub",
+            label: t("shell:sidebar.aiModels"),
+            icon: <Boxes className="h-4 w-4" />,
+            onClick: () => setViewMode("ai-hub"),
+            dataAttrs: { "data-tour-target": "nav-ai-hub" },
+          },
+        ]
+      : []),
     ...(showOrganization
       ? [
           {

--- a/app/src/components/shell/sidebar.tsx
+++ b/app/src/components/shell/sidebar.tsx
@@ -12,7 +12,10 @@ import { DEFAULT_TAB_ID } from "../../agents/standard-tabs";
 import { useCanCreateAgents } from "../../hooks/use-can-create-agents";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { useSidebarLayout } from "../../hooks/use-sidebar-layout";
-import { canSeeIntegrationsPage } from "../../lib/org-roles";
+import {
+  canSeeAiModelsPage,
+  canSeeIntegrationsPage,
+} from "../../lib/org-roles";
 import { resolveAutoCollapse } from "../../lib/sidebar-auto-collapse";
 import { isTopLevelView } from "../../lib/top-level-views";
 import { useAgentStore } from "../../stores/agents";
@@ -66,6 +69,10 @@ export function Sidebar({ children }: { children: ReactNode }) {
   // plain members lose both the page and its nav entry (they manage apps from
   // the agent tab + Settings). Everyone else keeps it.
   const showIntegrations = canSeeIntegrationsPage(capabilities);
+  // Teams v2: in a Teams workspace the AI Models hub is owner/admin territory
+  // (org-level provider credentials + admin model policy), so plain members lose
+  // its nav entry too — they pick their model per agent in the composer.
+  const showAiModels = canSeeAiModelsPage(capabilities);
   const collapsed = useUIStore((s) => s.sidebarCollapsed);
   const toggleCollapsed = useUIStore((s) => s.toggleSidebarCollapsed);
   const setSidebarCollapsed = useUIStore((s) => s.setSidebarCollapsed);
@@ -183,6 +190,7 @@ export function Sidebar({ children }: { children: ReactNode }) {
           navItems={buildSidebarNavItems({
             t,
             showIntegrations,
+            showAiModels,
             showOrganization,
             setViewMode,
           })}

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -27,7 +27,11 @@ import { useCanCreateAgents } from "../../hooks/use-can-create-agents";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { useKeyboardShortcuts } from "../../hooks/use-keyboard-shortcuts";
 import { analytics } from "../../lib/analytics";
-import { canSeeIntegrationsPage, hasSpaces } from "../../lib/org-roles";
+import {
+  canSeeAiModelsPage,
+  canSeeIntegrationsPage,
+  hasSpaces,
+} from "../../lib/org-roles";
 import { osIsTauri } from "../../lib/os-bridge";
 import { isMac } from "../../lib/platform";
 import { isRoutineSetupMode } from "../../lib/routine-chat-setup";
@@ -110,6 +114,9 @@ export function WorkspaceShell({
   // Teams v2: guard the Integrations render + tour anchor so a stale `viewMode`
   // can never show the page to a plain member (the sidebar already hides it).
   const showIntegrations = canSeeIntegrationsPage(capabilities);
+  // Teams v2: same guard for the AI Models hub — owner/admin only in a Teams
+  // workspace (org-level providers + admin model policy).
+  const showAiModels = canSeeAiModelsPage(capabilities);
   const agentDef = currentAgent ? getById(currentAgent.configId) : undefined;
   const { data: activities } = useActivity(currentAgent?.folderPath);
   const needsYouCount = (activities ?? []).filter(
@@ -136,7 +143,11 @@ export function WorkspaceShell({
       // would fall through every render branch and strand the user on the
       // engine pane with its nav entry hidden; reset to the dashboard.
       if (
-        blockedTopLevelView(viewMode, { showIntegrations, showOrganization })
+        blockedTopLevelView(viewMode, {
+          showIntegrations,
+          showAiModels,
+          showOrganization,
+        })
       ) {
         setViewMode("dashboard");
       }
@@ -152,6 +163,7 @@ export function WorkspaceShell({
     isAgentView,
     setViewMode,
     showIntegrations,
+    showAiModels,
     showOrganization,
     viewMode,
   ]);
@@ -215,7 +227,7 @@ export function WorkspaceShell({
                 <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
                   {viewMode === "dashboard" ? (
                     <Dashboard />
-                  ) : viewMode === "ai-hub" ? (
+                  ) : viewMode === "ai-hub" && showAiModels ? (
                     <AiHubView />
                   ) : viewMode === "settings" ? (
                     <SettingsView />
@@ -578,6 +590,11 @@ export function WorkspaceShell({
               step.targetSelector === "[data-tour-target='nav-integrations']"
             ) {
               return showIntegrations;
+            }
+            // The AI Models hub is hidden from plain Teams members too — drop its
+            // tour step where the anchor never renders.
+            if (step.targetSelector === "[data-tour-target='nav-ai-hub']") {
+              return showAiModels;
             }
             return true;
           })}

--- a/app/src/components/tabs/agent-admin/agent-admin-model.tsx
+++ b/app/src/components/tabs/agent-admin/agent-admin-model.tsx
@@ -44,6 +44,7 @@ export function AgentAdminModel({ agent }: AgentAdminScreenProps) {
         <AgentModelsSection
           key={agent.id}
           allowedModels={settings.allowedModels}
+          orgAllowedModels={settings.orgAllowedModels ?? null}
           models={catalog.models}
           saving={save.isPending}
           onSave={(next) => save.mutate(next)}

--- a/app/src/components/tabs/agent-admin/agent-models-section.tsx
+++ b/app/src/components/tabs/agent-admin/agent-models-section.tsx
@@ -1,22 +1,14 @@
-import { Search } from "lucide-react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import type { CatalogModel } from "../../../lib/ai-hub/catalog-types.ts";
-import { filterModels, searchModels } from "../../../lib/ai-hub/search.ts";
-import type { ProviderValue } from "../../ai-hub/facets.ts";
-import { AccessChoice } from "./access-choice.tsx";
-import { type AccessMode, ceilingMode } from "./agent-admin-row-values.ts";
-import { LabFilter } from "./lab-filter.tsx";
-import { ModelAllowRow } from "./model-allow-row.tsx";
-import {
-  allowedListView,
-  modelChecked,
-  toggleModel,
-} from "./model-allowlist.ts";
+import { ModelsAllowlistEditor } from "../../ai-hub/models-allowlist-editor.tsx";
+import { modelChecked } from "./model-allowlist.ts";
 
 interface AgentModelsSectionProps {
   /** The agent-level model ceiling: `null` = all allowed, else the explicit set. */
   allowedModels: string[] | null;
+  /** The org-wide model ceiling the agent set may only narrow (`null` = all). */
+  orgAllowedModels: string[] | null;
   /** The AI-hub model directory (one entry per model, deduped across providers). */
   models: CatalogModel[];
   /** A write is in flight (disables the controls). */
@@ -27,151 +19,52 @@ interface AgentModelsSectionProps {
 
 /**
  * Agent-manager-only editor for this agent's AI-model ceiling (Teams v2),
- * rendered flush in the Access section's right pane (no card wrapper). Reuses
- * the AI-hub's catalog and visual language: one row per {@link CatalogModel}
- * (its brand mark, name, lab), each with an allow Switch. An always-visible
- * two-option choice ("Any model" saves `null`, "Only models you pick" saves an
- * explicit set); when restricting, the allowed models list above a searchable
- * "Add models" list. Selection is over provider-native offer ids: toggling a
- * model flips ALL its offers at once, so a member can pick that model from any
- * provider they connect. Writes are instant + optimistic; the gateway is the
- * real enforcer.
+ * rendered flush in the Access section's right pane (no card wrapper). A thin
+ * wrapper over the shared {@link ModelsAllowlistEditor}: it narrows the selectable
+ * universe to the org ceiling (a manager can only allow models the org itself
+ * allows, mirroring the app allowlist's `orgAllowedToolkits` narrowing) and
+ * supplies the `teams` i18n copy; all behavior lives in the editor. Each member
+ * then picks their own model from the allowed set in the composer.
  */
 export function AgentModelsSection({
   allowedModels,
+  orgAllowedModels,
   models,
   saving,
   onSave,
 }: AgentModelsSectionProps) {
   const { t } = useTranslation("teams");
-  const [search, setSearch] = useState("");
-  // View-only lab filter (never touches saved data); composes with the search.
-  const [lab, setLab] = useState<ProviderValue>("all");
-  const labFilter = lab === "all" ? undefined : lab;
 
-  const allowedSet = useMemo(
-    () => new Set(allowedModels ?? []),
-    [allowedModels],
-  );
-  // Every model the ceiling currently allows (before the view-only lab filter).
-  const pickedModels = useMemo(
-    () => models.filter((m) => modelChecked(m, allowedSet)),
-    [models, allowedSet],
-  );
-  // The allowed models shown as their own short list above the rest, narrowed to
-  // the picked lab.
-  const allowedList = useMemo(
-    () => filterModels(pickedModels, { lab: labFilter }),
-    [pickedModels, labFilter],
-  );
-  // An empty visible list means either "nothing picked" or "the lab filter hides
-  // every pick" — distinct copy so we never falsely claim nothing is picked.
-  const allowedView = allowedListView({
-    visibleCount: allowedList.length,
-    hasPicked: pickedModels.length > 0,
-    labFiltered: labFilter !== undefined,
-  });
-  // The remaining (not-yet-allowed) models to add, narrowed to the picked lab
-  // and ranked by the search box — allowed models live in their own list above,
-  // so each appears once.
-  const results = useMemo(() => {
-    const base = filterModels(
-      models.filter((m) => !modelChecked(m, allowedSet)),
-      { lab: labFilter },
-    );
-    return searchModels(base, search);
-  }, [models, search, allowedSet, labFilter]);
-
-  const onChoice = (mode: AccessMode) => onSave(mode === "any" ? null : []);
-  const toggle = (model: CatalogModel) =>
-    onSave(toggleModel(model, [...allowedSet]));
-
-  const renderModel = (model: CatalogModel) => (
-    <ModelAllowRow
-      key={model.key}
-      model={model}
-      checked={modelChecked(model, allowedSet)}
-      disabled={saving}
-      allowLabel={t("agentAdmin.models.allowModel", { name: model.name })}
-      onToggle={() => toggle(model)}
-    />
-  );
+  // The selectable universe: the org ceiling if one is set, else the whole
+  // catalog. A model is offerable when any of its offers is within the org
+  // ceiling — models the org disallows are never presented for the agent.
+  const universe = useMemo(() => {
+    if (orgAllowedModels === null) return models;
+    const org = new Set(orgAllowedModels);
+    return models.filter((m) => modelChecked(m, org));
+  }, [models, orgAllowedModels]);
 
   return (
-    <div>
-      <h2 className="mb-4 text-lg font-medium text-foreground">
-        {t("agentAdmin.models.question")}
-      </h2>
-
-      <AccessChoice
-        question={t("agentAdmin.models.question")}
-        value={ceilingMode(allowedModels)}
-        disabled={saving}
-        onChange={onChoice}
-        options={[
-          {
-            value: "any",
-            label: t("agentAdmin.models.anyLabel"),
-            description: t("agentAdmin.models.anyDesc"),
-          },
-          {
-            value: "picked",
-            label: t("agentAdmin.models.pickedLabel"),
-            description: t("agentAdmin.models.pickedDesc"),
-          },
-        ]}
-      />
-
-      {allowedModels !== null && (
-        <div className="mt-6">
-          <section className="mb-8">
-            <h3 className="mb-2 text-sm font-medium text-foreground">
-              {t("agentAdmin.models.allowedHeading")}
-            </h3>
-            {allowedView === "list" ? (
-              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                {allowedList.map(renderModel)}
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                {t(
-                  allowedView === "empty-lab"
-                    ? "agentAdmin.models.allowedEmptyLab"
-                    : "agentAdmin.models.allowedEmpty",
-                )}
-              </p>
-            )}
-          </section>
-
-          <section>
-            <h3 className="mb-3 text-sm font-medium text-foreground">
-              {t("agentAdmin.models.addHeading")}
-            </h3>
-            <div className="mb-3 flex items-center gap-2">
-              <div className="relative flex-1">
-                <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-                <input
-                  type="text"
-                  value={search}
-                  onChange={(e) => setSearch(e.target.value)}
-                  placeholder={t("agentAdmin.models.searchModels")}
-                  className="h-9 w-full rounded-full border border-border bg-background pl-9 pr-3 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring/20"
-                />
-              </div>
-              <LabFilter models={models} value={lab} onChange={setLab} />
-            </div>
-            {results.length === 0 ? (
-              <p className="py-4 text-center text-sm text-muted-foreground">
-                {t("agentAdmin.models.noModels")}
-              </p>
-            ) : (
-              <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
-                {results.map(renderModel)}
-              </div>
-            )}
-          </section>
-        </div>
-      )}
-    </div>
+    <ModelsAllowlistEditor
+      models={universe}
+      allowedModels={allowedModels}
+      saving={saving}
+      onSave={onSave}
+      copy={{
+        question: t("agentAdmin.models.question"),
+        policyHelper: t("agentAdmin.models.policyHelper"),
+        anyLabel: t("agentAdmin.models.anyLabel"),
+        anyDesc: t("agentAdmin.models.anyDesc"),
+        pickedLabel: t("agentAdmin.models.pickedLabel"),
+        pickedDesc: t("agentAdmin.models.pickedDesc"),
+        allowedHeading: t("agentAdmin.models.allowedHeading"),
+        addHeading: t("agentAdmin.models.addHeading"),
+        allowedEmpty: t("agentAdmin.models.allowedEmpty"),
+        allowedEmptyLab: t("agentAdmin.models.allowedEmptyLab"),
+        searchModels: t("agentAdmin.models.searchModels"),
+        noModels: t("agentAdmin.models.noModels"),
+        allowModel: (name) => t("agentAdmin.models.allowModel", { name }),
+      }}
+    />
   );
 }

--- a/app/src/hooks/queries/use-org-settings.ts
+++ b/app/src/hooks/queries/use-org-settings.ts
@@ -4,11 +4,12 @@ import { queryKeys } from "../../lib/query-keys";
 import { tauriOrg } from "../../lib/tauri";
 
 /**
- * Teams v2 only: the org-wide allowed-toolkit ceiling — the integration policy
- * every agent's effective allowlist is derived under. Readable by any member.
- * Gated on the `teams` capability via `enabled`: a host that predates Teams has
- * no org-settings route, so the query stays idle there and no degradation is
- * needed. Feature detection is the `teams` flag, not a swallowed error.
+ * Teams v2 only: the org-wide ceilings — the allowed-toolkit (app) ceiling and
+ * the allowed-models (AI) ceiling every agent's effective set is derived under.
+ * Readable by any member. Gated on the `teams` capability via `enabled`: a host
+ * that predates Teams has no org-settings route, so the query stays idle there
+ * and no degradation is needed. Feature detection is the `teams` flag, not a
+ * swallowed error.
  */
 export function useOrgSettings(enabled: boolean) {
   return useQuery({
@@ -54,6 +55,43 @@ export function useSetOrgSettings() {
       // without a remount.
       qc.invalidateQueries({ queryKey: ["agent-settings"] });
       qc.invalidateQueries({ queryKey: ["agent-grants"] });
+    },
+  });
+}
+
+/**
+ * Teams v2, owner only: replace the org-wide allowed-models ceiling
+ * (`allowedModels`: `null` = every model allowed, `[]` = none) via the same
+ * partial-patch `setOrgSettings` PUT. Optimistic whole-value swap with rollback,
+ * mirroring {@link useSetOrgSettings} — but models carry no server-side grant
+ * pruning, so this only invalidates the org settings and the `agent-settings`
+ * prefix (an org models change narrows every agent's selectable model universe
+ * via `orgAllowedModels`), never `agent-grants`. No `onError` toast: the
+ * `tauriOrg.setSettings` wrapper routes through `call()`, which surfaces +
+ * reports the failure once; `onError` here only rolls the optimistic value back.
+ */
+export function useSetOrgAllowedModels() {
+  const qc = useQueryClient();
+  const key = queryKeys.orgSettings();
+  return useMutation({
+    mutationFn: (allowedModels: string[] | null) =>
+      tauriOrg.setSettings({ allowedModels }),
+    onMutate: async (allowedModels) => {
+      await qc.cancelQueries({ queryKey: key });
+      const prev = qc.getQueryData<OrgSettings>(key);
+      if (prev) {
+        qc.setQueryData<OrgSettings>(key, { ...prev, allowedModels });
+      }
+      return { prev };
+    },
+    onError: (_err, _next, ctx) => {
+      if (ctx?.prev) qc.setQueryData(key, ctx.prev);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: key });
+      // An org models change narrows every agent's selectable model universe;
+      // refresh the agent-settings prefix so per-agent editors re-read it.
+      qc.invalidateQueries({ queryKey: ["agent-settings"] });
     },
   });
 }

--- a/app/src/lib/org-roles.ts
+++ b/app/src/lib/org-roles.ts
@@ -73,10 +73,29 @@ export function canSeeIntegrationsPage(
 }
 
 /**
- * Can this caller EDIT the org-wide integration policy (the app-allowlist
- * ceiling)? Owner only per C7 — admins see the policy page read-only. A cosmetic
- * gate: the gateway 403s a non-owner write, so this only avoids offering a
- * control that would fail.
+ * Should the global AI Models hub be visible to this caller? In a Teams
+ * workspace the hub is owner/admin territory: AI provider connections are
+ * org-level (one credential per org — whoever connects, every member's agents
+ * work; C6), so a plain member has no account to connect there, and the new
+ * workspace model-policy is admin-only. Members pick their own model per agent in
+ * the composer instead, so they lose the hub nav exactly as they lose the
+ * Integrations nav. Everyone else — single-player and non-Teams multiplayer —
+ * keeps the hub unchanged. A cosmetic gate: the gateway is the real enforcer
+ * (a member's provider-connect POST already 403s); this only hides an
+ * affordance that would be dead for a plain member.
+ */
+export function canSeeAiModelsPage(
+  caps: Capabilities | null | undefined,
+): boolean {
+  if (isMultiplayer(caps) && caps?.teams === true) return canSeeMembers(caps);
+  return true;
+}
+
+/**
+ * Can this caller EDIT the org-wide policy ceilings (the app-allowlist ceiling
+ * AND the AI-model ceiling)? Owner only per C7 — admins see the policy surfaces
+ * read-only. A cosmetic gate: the gateway 403s a non-owner write, so this only
+ * avoids offering a control that would fail.
  */
 export function canEditOrgSettings(
   caps: Capabilities | null | undefined,

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -1599,10 +1599,17 @@ export const tauriOrg = {
     call("create_checkout", () => getEngine().createCheckout(interval)),
   /** C8 billing: open the Stripe customer portal (owner only); returns `{url}`. */
   createPortal: () => call("create_portal", () => getEngine().createPortal()),
-  /** Read the org-wide allowed-toolkit ceiling (any member). */
+  /** Read the org-wide ceilings — apps + AI models (any member). */
   getSettings: () =>
     call("get_org_settings", () => getEngine().getOrgSettings()),
-  /** Replace the org-wide allowed-toolkit ceiling (owner only). */
-  setSettings: (settings: { allowedToolkits: string[] | null }) =>
+  /**
+   * Replace an org-wide ceiling (owner only). Partial patch: pass
+   * `allowedToolkits` (apps) and/or `allowedModels` (AI models) to change one
+   * without touching the other.
+   */
+  setSettings: (settings: {
+    allowedToolkits?: string[] | null;
+    allowedModels?: string[] | null;
+  }) =>
     call<void>("set_org_settings", () => getEngine().setOrgSettings(settings)),
 };

--- a/app/src/lib/top-level-views.ts
+++ b/app/src/lib/top-level-views.ts
@@ -24,18 +24,24 @@ export function isTopLevelView(viewMode: string): boolean {
 
 /**
  * Whether a top-level `viewMode` points at a view whose Teams gate is off for
- * this caller (Integrations hides from plain members, Organization from
- * members / single-player). The sidebar entry is already hidden, so a STALE
- * `viewMode` (e.g. the role changed on a space switch while the page was open)
- * would otherwise fall through every render branch and strand the user on the
- * shell's engine pane with no way back; the workspace shell resets a blocked
- * view to the dashboard. Pure so the fallback rule is unit-tested.
+ * this caller (Integrations and the AI Models hub hide from plain members,
+ * Organization from members / single-player). The sidebar entry is already
+ * hidden, so a STALE `viewMode` (e.g. the role changed on a space switch while
+ * the page was open) would otherwise fall through every render branch and strand
+ * the user on the shell's engine pane with no way back; the workspace shell
+ * resets a blocked view to the dashboard. Pure so the fallback rule is
+ * unit-tested.
  */
 export function blockedTopLevelView(
   viewMode: string,
-  gates: { showIntegrations: boolean; showOrganization: boolean },
+  gates: {
+    showIntegrations: boolean;
+    showOrganization: boolean;
+    showAiModels: boolean;
+  },
 ): boolean {
   if (viewMode === INTEGRATIONS_VIEW_ID) return !gates.showIntegrations;
   if (viewMode === ORGANIZATION_VIEW_ID) return !gates.showOrganization;
+  if (viewMode === "ai-hub") return !gates.showAiModels;
   return false;
 }

--- a/app/src/locales/en/ai-hub.json
+++ b/app/src/locales/en/ai-hub.json
@@ -6,7 +6,8 @@
   },
   "tabs": {
     "providers": "Providers",
-    "models": "Models"
+    "models": "Models",
+    "policy": "Workspace policy"
   },
   "sections": {
     "connected": "Connected",

--- a/app/src/locales/en/teams.json
+++ b/app/src/locales/en/teams.json
@@ -25,6 +25,7 @@
     },
     "models": {
       "question": "Which AI models can this agent use?",
+      "policyHelper": "You decide which models this agent can run on. People with access pick their own model from the ones you allow.",
       "anyLabel": "Any model",
       "anyDesc": "People with access can run this agent on any available model.",
       "pickedLabel": "Only models you pick",
@@ -77,6 +78,25 @@
       "title": "Not allowed for this agent",
       "body": "These apps are connected to your account, but this agent isn't allowed to use them. Ask your admin to enable them for this agent.",
       "badge": "Not allowed"
+    }
+  },
+  "models": {
+    "orgAllowlist": {
+      "question": "Which models can agents in this workspace use?",
+      "policyHelper": "You decide which AI models agents here can run on. People with access pick their own model from the ones you allow.",
+      "anyLabel": "Any model",
+      "anyDesc": "Agents in this workspace can use any available model.",
+      "pickedLabel": "Only models you pick",
+      "pickedDesc": "Agents can only use the models you allow below.",
+      "allowModel": "Allow {{name}}",
+      "searchModels": "Search models",
+      "noModels": "No models found",
+      "allowedHeading": "Allowed models",
+      "allowedEmpty": "No models picked yet. Add models below.",
+      "allowedEmptyLab": "No models picked from this lab yet.",
+      "addHeading": "Add models",
+      "ownerOnly": "Only the workspace owner can change this.",
+      "perAgentNote": "Managers can narrow this further for each agent in its settings."
     }
   },
   "org": {

--- a/app/src/locales/es/ai-hub.json
+++ b/app/src/locales/es/ai-hub.json
@@ -6,7 +6,8 @@
   },
   "tabs": {
     "providers": "Proveedores",
-    "models": "Modelos"
+    "models": "Modelos",
+    "policy": "Política del espacio de trabajo"
   },
   "sections": {
     "connected": "Conectados",

--- a/app/src/locales/es/teams.json
+++ b/app/src/locales/es/teams.json
@@ -25,6 +25,7 @@
     },
     "models": {
       "question": "¿Qué modelos de IA puede usar este agente?",
+      "policyHelper": "Tú decides con qué modelos puede ejecutarse este agente. Las personas con acceso eligen su propio modelo entre los que permitas.",
       "anyLabel": "Cualquier modelo",
       "anyDesc": "Las personas con acceso pueden ejecutar este agente con cualquier modelo disponible.",
       "pickedLabel": "Solo los modelos que elijas",
@@ -77,6 +78,25 @@
       "title": "No permitida para este agente",
       "body": "Estas aplicaciones están conectadas a tu cuenta, pero este agente no tiene permitido usarlas. Pídele a tu administrador que las habilite para este agente.",
       "badge": "No permitida"
+    }
+  },
+  "models": {
+    "orgAllowlist": {
+      "question": "¿Qué modelos pueden usar los agentes de este espacio de trabajo?",
+      "policyHelper": "Tú decides con qué modelos de IA pueden ejecutarse los agentes aquí. Las personas con acceso eligen su propio modelo entre los que permitas.",
+      "anyLabel": "Cualquier modelo",
+      "anyDesc": "Los agentes de este espacio de trabajo pueden usar cualquier modelo disponible.",
+      "pickedLabel": "Solo los modelos que elijas",
+      "pickedDesc": "Los agentes solo pueden usar los modelos que permitas abajo.",
+      "allowModel": "Permitir {{name}}",
+      "searchModels": "Buscar modelos",
+      "noModels": "No se encontraron modelos",
+      "allowedHeading": "Modelos permitidos",
+      "allowedEmpty": "Aún no eliges modelos. Agrega modelos abajo.",
+      "allowedEmptyLab": "Aún no eliges modelos de este laboratorio.",
+      "addHeading": "Agregar modelos",
+      "ownerOnly": "Solo el propietario del espacio de trabajo puede cambiar esto.",
+      "perAgentNote": "Los managers pueden restringir esto aún más para cada agente en su configuración."
     }
   },
   "org": {

--- a/app/src/locales/pt/ai-hub.json
+++ b/app/src/locales/pt/ai-hub.json
@@ -6,7 +6,8 @@
   },
   "tabs": {
     "providers": "Provedores",
-    "models": "Modelos"
+    "models": "Modelos",
+    "policy": "Política do espaço de trabalho"
   },
   "sections": {
     "connected": "Conectados",

--- a/app/src/locales/pt/teams.json
+++ b/app/src/locales/pt/teams.json
@@ -25,6 +25,7 @@
     },
     "models": {
       "question": "Quais modelos de IA este agente pode usar?",
+      "policyHelper": "Você decide com quais modelos este agente pode ser executado. Pessoas com acesso escolhem o próprio modelo entre os que você permitir.",
       "anyLabel": "Qualquer modelo",
       "anyDesc": "Pessoas com acesso podem executar este agente com qualquer modelo disponível.",
       "pickedLabel": "Apenas os modelos que você escolher",
@@ -77,6 +78,25 @@
       "title": "Não permitido para este agente",
       "body": "Estes aplicativos estão conectados à sua conta, mas este agente não tem permissão para usá-los. Peça ao seu administrador para habilitá-los para este agente.",
       "badge": "Não permitido"
+    }
+  },
+  "models": {
+    "orgAllowlist": {
+      "question": "Quais modelos os agentes deste espaço de trabalho podem usar?",
+      "policyHelper": "Você decide com quais modelos de IA os agentes aqui podem ser executados. Pessoas com acesso escolhem o próprio modelo entre os que você permitir.",
+      "anyLabel": "Qualquer modelo",
+      "anyDesc": "Os agentes deste espaço de trabalho podem usar qualquer modelo disponível.",
+      "pickedLabel": "Apenas os modelos que você escolher",
+      "pickedDesc": "Os agentes só podem usar os modelos que você permitir abaixo.",
+      "allowModel": "Permitir {{name}}",
+      "searchModels": "Buscar modelos",
+      "noModels": "Nenhum modelo encontrado",
+      "allowedHeading": "Modelos permitidos",
+      "allowedEmpty": "Você ainda não escolheu modelos. Adicione modelos abaixo.",
+      "allowedEmptyLab": "Você ainda não escolheu modelos deste laboratório.",
+      "addHeading": "Adicionar modelos",
+      "ownerOnly": "Apenas o proprietário do espaço de trabalho pode alterar isso.",
+      "perAgentNote": "Os managers podem restringir isso ainda mais para cada agente nas configurações dele."
     }
   },
   "org": {

--- a/app/tests/agent-admin-a11y.test.ts
+++ b/app/tests/agent-admin-a11y.test.ts
@@ -29,11 +29,17 @@ describe("Agent Settings a11y", () => {
     );
     ok(!sidebar.includes("<h1"), "sidebar rail renders no page-level h1");
 
+    // The models editor body (question heading included) lives in the shared
+    // ModelsAllowlistEditor; the agent section is a thin wrapper around it.
     const models = read(
       "../src/components/tabs/agent-admin/agent-models-section.tsx",
     );
-    ok(!models.includes("<h1"), "models section title is not an h1");
-    ok(models.includes("<h2"), "models section title is an h2");
+    ok(!models.includes("<h1"), "models section renders no page-level h1");
+    const modelsEditor = read(
+      "../src/components/ai-hub/models-allowlist-editor.tsx",
+    );
+    ok(!modelsEditor.includes("<h1"), "models editor title is not an h1");
+    ok(modelsEditor.includes("<h2"), "models editor title is an h2");
 
     // The editor body (question heading included) lives in the shared
     // AllowlistEditor; the agent section is a thin wrapper around it.

--- a/app/tests/org-roles.test.ts
+++ b/app/tests/org-roles.test.ts
@@ -5,6 +5,7 @@ import {
   canCreateAgents,
   canEditOrgSettings,
   canManageMembers,
+  canSeeAiModelsPage,
   canSeeBilling,
   canSeeBillingTab,
   canSeeIntegrationsPage,
@@ -95,6 +96,26 @@ describe("canSeeIntegrationsPage", () => {
     strictEqual(canSeeIntegrationsPage(teams("owner")), true);
     strictEqual(canSeeIntegrationsPage(teams("admin")), true);
     strictEqual(canSeeIntegrationsPage(teams("user")), false);
+  });
+});
+
+describe("canSeeAiModelsPage", () => {
+  const teams = (role: OrgRole): Capabilities =>
+    caps({ multiplayer: true, role, teams: true });
+
+  it("single-player keeps the AI Models hub", () => {
+    strictEqual(canSeeAiModelsPage(caps()), true);
+    strictEqual(canSeeAiModelsPage(null), true);
+  });
+
+  it("non-Teams multiplayer keeps it for every role", () => {
+    strictEqual(canSeeAiModelsPage(multiplayer("user")), true);
+  });
+
+  it("in a Teams workspace only owner/admin see it (providers are org-level)", () => {
+    strictEqual(canSeeAiModelsPage(teams("owner")), true);
+    strictEqual(canSeeAiModelsPage(teams("admin")), true);
+    strictEqual(canSeeAiModelsPage(teams("user")), false);
   });
 });
 

--- a/app/tests/top-level-views.test.ts
+++ b/app/tests/top-level-views.test.ts
@@ -27,12 +27,18 @@ describe("isTopLevelView", () => {
 });
 
 describe("blockedTopLevelView", () => {
-  const gates = (
-    showIntegrations: boolean,
-    showOrganization: boolean,
-  ): { showIntegrations: boolean; showOrganization: boolean } => ({
-    showIntegrations,
-    showOrganization,
+  const gates = (over: {
+    showIntegrations?: boolean;
+    showAiModels?: boolean;
+    showOrganization?: boolean;
+  }): {
+    showIntegrations: boolean;
+    showAiModels: boolean;
+    showOrganization: boolean;
+  } => ({
+    showIntegrations: over.showIntegrations ?? true,
+    showAiModels: over.showAiModels ?? true,
+    showOrganization: over.showOrganization ?? true,
   });
 
   it("blocks a stale Integrations view when its gate is off", () => {
@@ -40,29 +46,65 @@ describe("blockedTopLevelView", () => {
     // Integrations page was open. The nav entry is gone, so the stale viewMode
     // must be reported blocked and reset, never left to dead-end the shell.
     strictEqual(
-      blockedTopLevelView(INTEGRATIONS_VIEW_ID, gates(false, false)),
+      blockedTopLevelView(
+        INTEGRATIONS_VIEW_ID,
+        gates({ showIntegrations: false }),
+      ),
       true,
     );
     strictEqual(
-      blockedTopLevelView(INTEGRATIONS_VIEW_ID, gates(true, false)),
+      blockedTopLevelView(
+        INTEGRATIONS_VIEW_ID,
+        gates({ showIntegrations: true }),
+      ),
+      false,
+    );
+  });
+
+  it("blocks a stale AI Models hub when its gate is off", () => {
+    // Same strand for the hub: a Teams member (role flipped) with a stale
+    // `ai-hub` viewMode must be reported blocked and reset to the dashboard.
+    strictEqual(
+      blockedTopLevelView("ai-hub", gates({ showAiModels: false })),
+      true,
+    );
+    strictEqual(
+      blockedTopLevelView("ai-hub", gates({ showAiModels: true })),
       false,
     );
   });
 
   it("blocks a stale Organization view when its gate is off", () => {
     strictEqual(
-      blockedTopLevelView(ORGANIZATION_VIEW_ID, gates(true, false)),
+      blockedTopLevelView(
+        ORGANIZATION_VIEW_ID,
+        gates({ showOrganization: false }),
+      ),
       true,
     );
     strictEqual(
-      blockedTopLevelView(ORGANIZATION_VIEW_ID, gates(false, true)),
+      blockedTopLevelView(
+        ORGANIZATION_VIEW_ID,
+        gates({ showOrganization: true }),
+      ),
       false,
     );
   });
 
   it("never blocks ungated top-level views or agent tabs", () => {
-    for (const id of ["dashboard", "settings", "ai-hub", "chat"]) {
-      strictEqual(blockedTopLevelView(id, gates(false, false)), false, id);
+    for (const id of ["dashboard", "settings", "chat"]) {
+      strictEqual(
+        blockedTopLevelView(
+          id,
+          gates({
+            showIntegrations: false,
+            showAiModels: false,
+            showOrganization: false,
+          }),
+        ),
+        false,
+        id,
+      );
     }
   });
 });

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -96,8 +96,18 @@ that also take `Pick<Agent, "access" | "assigned">` live in `agent-access.ts`
   render branch, tour step): a Teams **plain member** → false, else true
   (owner/admin delegate to `canSeeMembers`; non-Teams and single-player → true). A
   member's account home is instead Settings > Connected accounts.
-- `canEditOrgSettings(caps)` — **owner only**; gates the org allowlist editor on the
-  Integrations page (admins see it read-only). See the allowlist ceiling below.
+- `canSeeAiModelsPage(caps)` — the SAME gate for the global **AI Models hub**
+  (sidebar nav, render branch, tour step): a Teams **plain member** → false, else
+  true. Unlike Composio, AI provider connections are **org-level** (one credential
+  per org — whoever connects, every member's agents work; `cloud/docs/contracts/C6`),
+  so a member has no per-provider account to house anywhere — they pick their model
+  per agent in the composer. The hub is therefore owner/admin-only in Teams and gains
+  the org model-policy tab; a member loses its nav entirely (mirrors the Integrations
+  gate). This also removes a dead affordance — a member's provider-connect POST
+  already 403s at the gateway.
+- `canEditOrgSettings(caps)` — **owner only**; gates BOTH org policy editors — the
+  app allowlist on the Integrations page AND the model ceiling on the AI Models hub
+  (admins see them read-only). See the allowlist + models ceilings below.
 - `GRANTABLE_ROLES = ["admin", "user"]` — owner is never handed out from the UI
   (ownership transfer is out of scope for v1).
 
@@ -324,6 +334,29 @@ The model surface mirrors the integration allowlist: the manager sets a **ceilin
 (which models the agent may run on), and each member picks their own model **within**
 it. (The E5 org-templates feature that used to live here was removed in E8.)
 
+**Both model ceilings have a frontend home** (mirroring the app-allowlist pair) —
+the shared presentational `ModelsAllowlistEditor`
+(`app/src/components/ai-hub/models-allowlist-editor.tsx`, the model-side twin of
+`AllowlistEditor`, extracted from the old inline `AgentModelsSection`): an
+always-visible `AccessChoice` over the AI-hub catalog's `ModelAllowRow`s, `readOnly`
+hides the "Add models" list, all copy passed in.
+
+- **Org ceiling** — the **AI Models hub's "Workspace policy" tab**
+  (`ai-hub/ai-hub-policy.tsx`, a third `AiHubTab` shown when `multiplayer && teams`;
+  the hub itself is owner/admin-only in Teams, see `canSeeAiModelsPage`). Owner-editable,
+  admin READ-ONLY (`canEditOrgSettings` = owner only). Wire: `OrgSettings.allowedModels`;
+  client `getOrgSettings` / `setOrgSettings` (now a **partial patch** — `{allowedToolkits?,
+  allowedModels?}`, matching the gateway). Hook `useSetOrgAllowedModels`
+  (`hooks/queries/use-org-settings.ts`) — optimistic on `["org-settings"]`, invalidates
+  `["agent-settings"]` (an org models change narrows every agent's selectable universe).
+  Copy under `teams:models.orgAllowlist.*` + `aiHub:tabs.policy`.
+- **Per-agent ceiling** — Agent Settings > **Access** > **AI models**
+  (`agent-admin-model.tsx` → `AgentModelsSection`, now a thin wrapper over the shared
+  editor). It **narrows the selectable universe to the org ceiling** via
+  `AgentSettings.orgAllowedModels` (a model is offerable only when an offer is org-allowed,
+  the exact `orgAllowedToolkits` treatment the app allowlist uses), so an org-disallowed
+  model is never offered for an agent. Copy under `teams:agentAdmin.models.*`.
+
 - **Ceiling** — `agent_settings.allowedModels: string[] | null` of provider-native
   model ids (`null` = all models allowed; a set = restricted; treat `[]` defensively).
   Edited manager-only in Agent Settings > **Access** > **Allowed models**
@@ -352,7 +385,10 @@ it. (The E5 org-templates feature that used to live here was removed in E8.)
 - **Enforcement** — the gateway is the sole enforcer: it clamps every turn to the acting
   user's choice ∩ ceiling and strips any client-supplied model/provider. The client picker
   is convenience only.
-- Types: `AgentSettings.allowedModels`, `AgentModelChoice` (`{provider, model, effort?}`),
+- Types: `AgentSettings.allowedModels` + `AgentSettings.orgAllowedModels?` (the org
+  ceiling the agent set is intersected with), `OrgSettings.allowedModels?` (the org
+  ceiling itself; both optional so pre-ceiling hosts read as `undefined` = null),
+  `AgentModelChoice` (`{provider, model, effort?}`),
   `AgentModelChoiceInfo` (`{choice, allowedModels}`).
 - Client: `getAgentModelChoice` (404-degrades to `null` off-Teams) / `setAgentModelChoice`
   (`GET`/`PUT /agents/:slug/model-choice`); `setAgentSettings` widened to
@@ -479,7 +515,8 @@ back to initials. i18n: `dashboard:peopleFilter.*`, `board:people.label` (en/es/
 
 Wire types in `ui/engine-client/src/types.ts`: `OrgRole`, `OrgMember`,
 `OrgInfo`, `OrgInvite`, `AddOrgMemberResult`, `AgentAccess`, `AgentAssignment`,
-`AgentSettings` (with `allowedModels`), `OrgSettings`, `AuditEntry`, `UsageRow`,
+`AgentSettings` (with `allowedModels` + `orgAllowedModels`), `OrgSettings` (with
+`allowedModels`; `setOrgSettings` is a partial patch), `AuditEntry`, `UsageRow`,
 `AgentModelChoice` / `AgentModelChoiceInfo`. `Agent` gains multiplayer-only
 `assigned` / `assignedUserIds` / `access` / `assignments`. All hand-maintained
 against the gateway (the server is source of truth). Methods in `client.ts`:
@@ -496,8 +533,10 @@ against the gateway (the server is source of truth). Methods in `client.ts`:
 All Teams copy lives in the `teams` namespace
 (`app/src/locales/{en,es,pt}/teams.json`, registered in `app/src/lib/i18n.ts`).
 Top-level groups: `agentAdmin` (`groups` incl. the inline `general` card, `rows`,
-`models` ceiling, inline `values`),
-`managedAgent`, `integrations`, `org`, `share`, `people`, `activityTab`,
-`usageTab`, `agentsTab`.
+per-agent `models` ceiling, inline `values`),
+`managedAgent`, `integrations`, `models` (the root `models.orgAllowlist.*` org model
+ceiling, sibling of `integrations.orgAllowlist`), `org`, `share`, `people`,
+`activityTab`, `usageTab`, `agentsTab`. (The AI Models hub's own strings, incl.
+`tabs.policy`, live in the separate `aiHub` namespace.)
 (There is also a separate `org` namespace for pre-v2 org strings.) See
 `i18n.md`.

--- a/packages/fake-host/src/routes-teams.ts
+++ b/packages/fake-host/src/routes-teams.ts
@@ -43,6 +43,7 @@ export function handleTeamsRoutes(
         orgAllowedToolkits: s.orgAllowedToolkits,
         access: s.access,
         allowedModels: s.allowedModels,
+        orgAllowedModels: s.orgAllowedModels,
       });
     }
     if (method === "PUT") {
@@ -62,22 +63,32 @@ export function handleTeamsRoutes(
     return json({ error: "not found" }, 404);
   }
 
-  // /v1/org/settings — the org-wide integration ceiling.
+  // /v1/org/settings — the org-wide app + AI-model ceilings.
   if (
     segs[0] === "v1" &&
     segs[1] === "org" &&
     segs[2] === "settings" &&
     segs.length === 3
   ) {
+    const s = state.getTeamsSettings();
     if (method === "GET") {
       return json({
-        allowedToolkits: state.getTeamsSettings().orgAllowedToolkits,
+        allowedToolkits: s.orgAllowedToolkits,
+        allowedModels: s.orgAllowedModels,
       });
     }
     if (method === "PUT") {
-      state.setTeamsSettings({
-        orgAllowedToolkits: toolkitList(body?.allowedToolkits),
-      });
+      // Partial patch — change one org ceiling without touching the other.
+      if (body && "allowedToolkits" in body) {
+        state.setTeamsSettings({
+          orgAllowedToolkits: toolkitList(body.allowedToolkits),
+        });
+      }
+      if (body && "allowedModels" in body) {
+        state.setTeamsSettings({
+          orgAllowedModels: toolkitList(body.allowedModels),
+        });
+      }
       return json({ ok: true });
     }
     return json({ error: "not found" }, 404);

--- a/packages/fake-host/src/state-store.ts
+++ b/packages/fake-host/src/state-store.ts
@@ -56,6 +56,7 @@ export interface TeamsSettings {
   allowedToolkits: string[] | null;
   orgAllowedToolkits: string[] | null;
   allowedModels: string[] | null;
+  orgAllowedModels: string[] | null;
   access: AgentAccess;
 }
 
@@ -76,6 +77,7 @@ export const DEFAULT_TEAMS_SETTINGS: TeamsSettings = {
   allowedToolkits: null,
   orgAllowedToolkits: null,
   allowedModels: null,
+  orgAllowedModels: null,
   access: "manager",
 };
 

--- a/packages/web/e2e/ai-models-ia.spec.ts
+++ b/packages/web/e2e/ai-models-ia.spec.ts
@@ -1,0 +1,184 @@
+import { FAKE_HOST_URL } from "@houston/fake-host";
+import type { APIRequestContext, Page } from "@playwright/test";
+import { expect, test } from "./support/fixtures";
+
+/**
+ * The AI-models permissioning information architecture — the model-side twin of
+ * `integrations-ia.spec.ts`. Each concept has one home:
+ *  - POLICY (the org-wide allowed-models ceiling) → the AI Models hub's
+ *    "Workspace policy" tab, an owner/admin surface (owner edits, admin
+ *    read-only). AI provider connections are org-level (C6), so a plain member
+ *    has no account or policy to act on in the hub and loses its nav entirely —
+ *    exactly as they lose the Integrations nav.
+ *  - Each member's own model pick lives in the composer, not the hub.
+ *
+ * The Teams-shaped state single-player can't reach is armed via the fake host's
+ * `/__test__/capabilities` (advertise `multiplayer` + `teams` + a `role`) and
+ * `/__test__/agent-settings` (the agent/org model ceilings); the
+ * `/v1/org/settings` gateway route backs the owner's saves. See
+ * `@houston/fake-host` README + `knowledge-base/ui-testing.md`.
+ */
+
+/** Teams owner: multiplayer + Teams, top role. */
+const OWNER_CAPS = {
+  multiplayer: true,
+  teams: true,
+  role: "owner",
+};
+
+async function armCapabilities(
+  request: APIRequestContext,
+  caps: Record<string, unknown>,
+): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/capabilities`, { data: caps });
+}
+
+/** Arm the Teams ceilings the gateway serves (the org model ceiling lives here). */
+async function armAgentSettings(
+  request: APIRequestContext,
+  settings: Record<string, unknown>,
+): Promise<void> {
+  await request.post(`${FAKE_HOST_URL}/__test__/agent-settings`, {
+    data: settings,
+  });
+}
+
+async function openWorkspacePolicy(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.locator('[data-tour-target="nav-ai-hub"]').click();
+  await page.getByRole("tab", { name: "Workspace policy" }).click();
+}
+
+// ── 1. Owner policy editor ─────────────────────────────────────────────────
+
+test("Teams owner: the AI hub's Workspace policy tab is the org model ceiling editor, and restricting persists", async ({
+  page,
+  request,
+}) => {
+  await armCapabilities(request, OWNER_CAPS);
+  await openWorkspacePolicy(page);
+
+  // The tab is the org POLICY question — the two-mode choice at rest.
+  await expect(
+    page.getByRole("heading", {
+      name: "Which models can agents in this workspace use?",
+    }),
+  ).toBeVisible();
+  await expect(page.getByRole("radio", { name: "Any model" })).toBeVisible();
+  await expect(
+    page.getByRole("radio", { name: "Only models you pick" }),
+  ).toBeVisible();
+  // Starts unrestricted (org ceiling is null): "Any model" is the checked mode
+  // and no allowed-models list exists yet.
+  await expect(page.getByRole("radio", { name: "Any model" })).toBeChecked();
+  await expect(page.getByText("Allowed models")).toHaveCount(0);
+
+  // Owner picks "Only models you pick" → a PUT /v1/org/settings persists the
+  // ceiling, and the allowed-models list appears.
+  await page.getByRole("radio", { name: "Only models you pick" }).click();
+  await expect(page.getByText("Allowed models")).toBeVisible();
+  await expect(
+    page.getByRole("radio", { name: "Only models you pick" }),
+  ).toBeChecked();
+
+  // GET round-trip: a full reload re-reads /v1/org/settings from the host, and
+  // the ceiling is still restricted — the save reached the gateway, not just the
+  // client cache.
+  await page.reload();
+  await page.locator('[data-tour-target="nav-ai-hub"]').click();
+  await page.getByRole("tab", { name: "Workspace policy" }).click();
+  await expect(
+    page.getByRole("radio", { name: "Only models you pick" }),
+  ).toBeChecked();
+  await expect(page.getByText("Allowed models")).toBeVisible();
+});
+
+// ── 2. Admin read-only ─────────────────────────────────────────────────────
+
+test("Teams admin: the model policy editor is read-only with an owner-only note and no add list", async ({
+  page,
+  request,
+}) => {
+  // An admin sees the SAME policy tab, but every control is read-only (only the
+  // owner may change the org ceiling). Arm a restricted ceiling so the page has
+  // an allowed list an owner could extend, then confirm the admin cannot.
+  await armCapabilities(request, { ...OWNER_CAPS, role: "admin" });
+  await armAgentSettings(request, { orgAllowedModels: ["claude-opus-4-8"] });
+  await openWorkspacePolicy(page);
+
+  // The policy question renders, with the owner-only explanation at rest.
+  await expect(
+    page.getByRole("heading", {
+      name: "Which models can agents in this workspace use?",
+    }),
+  ).toBeVisible();
+  await expect(
+    page.getByText("Only the workspace owner can change this."),
+  ).toBeVisible();
+
+  // The choice control is disabled — the radios cannot be re-picked...
+  await expect(page.getByRole("radio", { name: "Any model" })).toBeDisabled();
+  await expect(
+    page.getByRole("radio", { name: "Only models you pick" }),
+  ).toBeDisabled();
+  // ...and the "picked" mode stays checked after a click attempt (no write).
+  await page
+    .getByRole("radio", { name: "Only models you pick" })
+    .click({ force: true });
+  await expect(
+    page.getByRole("radio", { name: "Only models you pick" }),
+  ).toBeChecked();
+
+  // The allowed list shows (read-only), but the "Add models" list an owner uses
+  // to widen the ceiling is absent for an admin.
+  await expect(page.getByText("Allowed models")).toBeVisible();
+  await expect(page.getByText("Add models")).toHaveCount(0);
+});
+
+// ── 3. Plain member: no AI Models nav ──────────────────────────────────────
+
+test("Teams member: the AI Models nav item is gone, the rest of the shell stays", async ({
+  page,
+  request,
+}) => {
+  // A plain member never sees the hub: providers are org-level and the model
+  // policy is admin-owned. They pick their own model per agent in the composer.
+  await armCapabilities(request, { ...OWNER_CAPS, role: "user" });
+  await page.goto("/");
+
+  await expect(page.locator('[data-tour-target="nav-ai-hub"]')).toHaveCount(0);
+  // Mission Control and Settings remain — only AI Models is gated off.
+  await expect(
+    page.locator('[data-tour-target="nav-dashboard"]'),
+  ).toBeVisible();
+  await expect(page.locator('[data-tour-target="nav-settings"]')).toBeVisible();
+});
+
+// ── 4. Per-agent editor reflects the org ceiling ───────────────────────────
+
+test("Agent Settings > AI models: the addable set is narrowed to the org ceiling", async ({
+  page,
+  request,
+}) => {
+  // Org ceiling allows only Claude Opus; the agent's own ceiling is unrestricted.
+  // A manager narrowing the agent may only pick from the org-allowed models, so
+  // an org-disallowed model (Claude Sonnet) is never offered for the agent.
+  await armCapabilities(request, OWNER_CAPS);
+  await armAgentSettings(request, { orgAllowedModels: ["claude-opus-4-8"] });
+  await page.goto("/");
+  await page.locator('[data-tour-target="tab-job-description"]').click();
+
+  // Open the Access group's "AI models" section (scoped to the settings rail so
+  // it never matches the top-level AI Models nav item).
+  await page
+    .getByRole("navigation", { name: "Agent settings" })
+    .getByRole("button", { name: "AI models" })
+    .click();
+
+  // Restrict, revealing the "Add models" list, then assert the org narrowing:
+  // Opus (org-allowed) is offerable, Sonnet (org-disallowed) is not.
+  await page.getByRole("radio", { name: "Only models you pick" }).click();
+  await expect(page.getByRole("heading", { name: "Add models" })).toBeVisible();
+  await expect(page.getByText(/Opus/i).first()).toBeVisible();
+  await expect(page.getByText(/Sonnet/i)).toHaveCount(0);
+});

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -2043,7 +2043,8 @@ export class HoustonClient {
     return controlPlane.getOrgSettings(this.cp);
   }
   async setOrgSettings(settings: {
-    allowedToolkits: string[] | null;
+    allowedToolkits?: string[] | null;
+    allowedModels?: string[] | null;
   }): Promise<void> {
     if (!this.cp) throw new Error("multiplayer requires the hosted gateway");
     return controlPlane.setOrgSettings(this.cp, settings);

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -1445,7 +1445,10 @@ export async function getOrgSettings(
 
 export async function setOrgSettings(
   cfg: ControlPlaneConfig,
-  settings: { allowedToolkits: string[] | null },
+  settings: {
+    allowedToolkits?: string[] | null;
+    allowedModels?: string[] | null;
+  },
 ): Promise<void> {
   await cpFetch(cfg, "/v1/org/settings", {
     method: "PUT",

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -1397,13 +1397,19 @@ export class HoustonClient {
       choice,
     );
   }
-  /** Read the org-wide allowed-toolkit ceiling (any member). */
+  /** Read the org-wide ceilings — apps + AI models (any member). */
   getOrgSettings(): Promise<OrgSettings> {
     return this.request("GET", "/org/settings");
   }
-  /** Replace the org-wide allowed-toolkit ceiling (owner only). */
+  /**
+   * Replace the org-wide ceilings (owner only). A partial patch: pass
+   * `allowedToolkits` (the app ceiling) and/or `allowedModels` (the AI-model
+   * ceiling) — `null` = unrestricted, `[]` = none. Both optional, so a caller can
+   * update one ceiling without touching the other.
+   */
   async setOrgSettings(settings: {
-    allowedToolkits: string[] | null;
+    allowedToolkits?: string[] | null;
+    allowedModels?: string[] | null;
   }): Promise<void> {
     await this.request("PUT", "/org/settings", settings);
   }

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -281,13 +281,18 @@ export interface AgentMoveStatus {
  * `allowedModels` is the manager-set AI-model ceiling: which models a member may
  * pick for this agent (`null` = every model allowed, `[]` = none). Each member's
  * own per-agent pick lives in the separate model-choice surface below; the
- * gateway clamps that pick to this ceiling on every turn.
+ * gateway clamps that pick to this ceiling on every turn. `orgAllowedModels` is
+ * the org-wide AI-model ceiling the agent ceiling is intersected with (the same
+ * relationship `orgAllowedToolkits` has to `allowedToolkits`); optional so a host
+ * predating the org models ceiling is read as `undefined` (treat as `null` =
+ * unrestricted).
  */
 export interface AgentSettings {
   allowedToolkits: string[] | null;
   orgAllowedToolkits: string[] | null;
   access: AgentAccess;
   allowedModels: string[] | null;
+  orgAllowedModels?: string[] | null;
 }
 
 // ---------- Per-user model choice (multiplayer) ----------
@@ -315,10 +320,20 @@ export interface AgentModelChoiceInfo {
   allowedModels: string[] | null;
 }
 
-/** Org-wide settings (Teams v2), from `GET /org/settings`. */
+/**
+ * Org-wide settings (Teams v2), from `GET /org/settings`. `PUT /org/settings` is
+ * a partial patch (owner only), so either ceiling can be changed without
+ * touching the other.
+ */
 export interface OrgSettings {
   /** Org-wide integration ceiling; `null` = unrestricted, `[]` = none. */
   allowedToolkits: string[] | null;
+  /**
+   * Org-wide AI-model ceiling: which models any agent in the workspace may run
+   * on (`null` = every model allowed, `[]` = none). Optional so a host predating
+   * the models ceiling is read as `undefined` (treat as `null` = unrestricted).
+   */
+  allowedModels?: string[] | null;
 }
 
 /**


### PR DESCRIPTION
Element C2, the final piece of the integrations/models clarity roadmap (#813, #816; cloud sibling gethouston/cloud#71 which added the `allowedModels` wire).

## What
- **Workspace policy tab on the AI Hub** (Teams only): the org allowed-models ceiling gets its frontend. Owners edit; admins read-only with the owner-only note; identical design family to the Integrations policy page via a shared `ModelsAllowlistEditor` that the per-agent `AgentModelsSection` also consumes (thin wrapper now), so the two ceilings never drift.
- **Members lose the AI Models nav in Teams** — investigated, not assumed: provider credentials are org-level (one per org+provider, contract C6), so members had no account to manage there, and the hub was showing them provider Connect buttons that 403 at the gateway. Dead affordance removed; members keep picking models per agent in the composer.
- **Per-agent models editor narrows by the org ceiling** (`orgAllowedModels`), exactly as the app allowlist narrows by `orgAllowedToolkits` — org-disallowed models are never offerable per agent.
- `setOrgSettings` becomes a partial patch end-to-end (engine-client → web adapter → tauri wrapper → fake-host), matching the gateway. `canSeeAiModelsPage` gate + `blockedTopLevelView` extension reuse C1's mechanism.
- i18n en/es/pt; `teams.md` updated.

## Verification
- New e2e `ai-models-ia.spec.ts` (owner round-trip, admin read-only, member nav absence, per-agent narrowing). Full Playwright suite **72 passed** (one pre-existing tour.spec flake, passes isolated).
- App node tests, check-locales, typecheck (incl. shim parity), Biome: all clean. Policy tab screenshot-reviewed against the Integrations policy page for family consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)