### PR TITLE
feat(engine): store-backed /data — hydrate on boot, debounced syncBack

### DIFF
--- a/packages/host/src/launcher/process.ts
+++ b/packages/host/src/launcher/process.ts
@@ -230,4 +230,31 @@ export class ProcessLauncher implements RuntimeLauncher {
     for (const r of this.running.values()) r.handle.kill();
     this.running.clear();
   }
+
+  /**
+   * shutdownAll, but resolved only once every child has ACTUALLY exited (or
+   * timeoutMs passes). The store-sync stop path needs this: a final /data sync
+   * taken while a child is still flushing its last conversation write would
+   * persist a torn file as the agent's durable state. Handles without onExit
+   * (test stubs) count as already exited.
+   */
+  async shutdownAllAndWait(timeoutMs = 5_000): Promise<void> {
+    const waits: Promise<void>[] = [];
+    for (const r of this.running.values()) {
+      const { onExit } = r.handle;
+      if (onExit) {
+        waits.push(new Promise<void>((resolve) => onExit(() => resolve())));
+      }
+      r.handle.kill();
+    }
+    this.running.clear();
+    if (waits.length === 0) return;
+    await Promise.race([
+      Promise.all(waits).then(() => undefined),
+      new Promise<void>((resolve) => {
+        const timer = setTimeout(resolve, timeoutMs);
+        timer.unref?.();
+      }),
+    ]);
+  }
 }

--- a/packages/host/src/local/host.test.ts
+++ b/packages/host/src/local/host.test.ts
@@ -1,9 +1,13 @@
-import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { createServer as createHttpServer } from "node:http";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Capabilities, Workspace } from "@houston/protocol";
+import {
+  LocalDirStore,
+  type ObjectStore,
+} from "@houston/runtime-client/object-sync";
 import { expect, test } from "vitest";
 import { MANAGED_CLOUD_CAPABILITIES } from "../capabilities";
 import { EnvCredentialVault } from "../credentials/vault";
@@ -46,16 +50,16 @@ async function setup(opts?: {
   credentials?: LocalHostOptions["credentials"];
   spawner?: RuntimeSpawner;
   eagerRuntime?: boolean;
+  storeSync?: LocalHostOptions["storeSync"];
+  waitForStart?: boolean;
 }) {
-  const workspacesRoot = mkdtempSync(join(tmpdir(), "houston-localhost-"));
+  const houstonHome = mkdtempSync(join(tmpdir(), "houston-localhost-"));
+  const workspacesRoot = join(houstonHome, "workspaces");
   mkdirSync(join(workspacesRoot, "Work", "Sales"), { recursive: true });
   const port = await freePort();
   const host = buildLocalHost({
     workspacesRoot,
-    credentialsPath: join(
-      mkdtempSync(join(tmpdir(), "houston-cred-")),
-      "credentials.json",
-    ),
+    credentialsPath: join(houstonHome, "credentials.json"),
     port,
     token: "boot-secret",
     runtimeCommand: ["true"],
@@ -66,15 +70,68 @@ async function setup(opts?: {
     gatewayFronted: opts?.gatewayFronted,
     credentials: opts?.credentials,
     eagerRuntime: opts?.eagerRuntime,
+    storeSync: opts?.storeSync,
   });
-  await host.start();
-  return { host, base: `http://127.0.0.1:${port}`, workspacesRoot };
+  const startPromise = host.start();
+  if (opts?.waitForStart !== false) await startPromise;
+  return {
+    host,
+    base: `http://127.0.0.1:${port}`,
+    houstonHome,
+    startPromise,
+    workspacesRoot,
+  };
 }
 
 const auth = {
   Authorization: "Bearer boot-secret",
   "Content-Type": "application/json",
 };
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+test("does not listen until store hydration has completed", async () => {
+  const remoteRoot = mkdtempSync(join(tmpdir(), "host-sync-remote-"));
+  const delegate = new LocalDirStore(remoteRoot);
+  const listGate = deferred<string[]>();
+  const gatedStore: ObjectStore = {
+    list: () => listGate.promise,
+    download: (key, dest) => delegate.download(key, dest),
+    upload: (source, key) => delegate.upload(source, key),
+    delete: (key) => delegate.delete(key),
+  };
+  const { base, host, startPromise } = await setup({
+    storeSync: { store: gatedStore },
+    waitForStart: false,
+  });
+  await expect(fetch(`${base}/health`)).rejects.toThrow();
+  listGate.resolve([]);
+  await startPromise;
+  expect((await fetch(`${base}/health`)).status).toBe(200);
+  await host.stop();
+});
+
+test("stop uploads local changes before closing the host", async () => {
+  const remoteRoot = mkdtempSync(join(tmpdir(), "host-sync-remote-"));
+  const remote = new LocalDirStore(remoteRoot);
+  const { host, workspacesRoot } = await setup({
+    storeSync: { store: remote, quietMs: 60_000, intervalMs: 60_000 },
+  });
+  writeFileSync(join(workspacesRoot, "Work", "Sales", "final.txt"), "durable");
+  await host.stop();
+  expect(
+    readFileSync(
+      join(remoteRoot, "workspaces", "Work", "Sales", "final.txt"),
+      "utf8",
+    ),
+  ).toBe("durable");
+});
 
 test("capabilities report the local profile", async () => {
   const { host, base } = await setup();

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -1,6 +1,7 @@
 import { existsSync, rmSync } from "node:fs";
 import type { Server } from "node:http";
 import { basename, dirname, join } from "node:path";
+import type { ObjectStore } from "@houston/runtime-client/object-sync";
 import { SingleUserVerifier } from "../auth/verify";
 import { LOCAL_CAPABILITIES } from "../capabilities";
 import { ProxyChannel } from "../channel/proxy";
@@ -23,6 +24,7 @@ import { ChannelRoutineFirer } from "../schedule/firer";
 import { Scheduler } from "../schedule/scheduler";
 import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
 import { LocalWorkspaceStore } from "../store/local";
+import { StoreSyncDaemon } from "../store-sync";
 import { MemoryTurnBus } from "../turn/bus";
 import { FsVfs } from "../vfs";
 import { FsWatcher } from "../watch/watcher";
@@ -135,12 +137,19 @@ export interface LocalHostOptions {
    * untrusted client input — leave this false (the default) and it is dropped.
    */
   gatewayFronted?: boolean;
+  /** Managed-pod cache persistence. Omit to preserve the local/PVC lifecycle. */
+  storeSync?: {
+    store: ObjectStore;
+    quietMs?: number;
+    intervalMs?: number;
+    maxHydrateBytes?: number;
+  };
 }
 
 export interface LocalHost {
   server: Server;
   start(): Promise<void>;
-  stop(): void;
+  stop(): Promise<void>;
 }
 
 /**
@@ -351,10 +360,22 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     firer: new ChannelRoutineFirer({ local: channel }),
     events,
   });
+  const syncDaemon = opts.storeSync
+    ? new StoreSyncDaemon({
+        ...opts.storeSync,
+        rootDir: dirname(opts.workspacesRoot),
+        log: (message, err) => console.error(message, err ?? ""),
+      })
+    : undefined;
+  let stopPromise: Promise<void> | undefined;
 
   return {
     server,
     async start() {
+      // The object store is authoritative in managed server mode. Hydration is
+      // readiness-critical and must finish before migrations or HTTP listening;
+      // failure propagates so the pod restarts without ever syncing an empty tree.
+      await syncDaemon?.hydrate();
       // One-time, idempotent migration of the pre-v0.4 FLAT `.houston/` layout
       // into the per-type folders the domain reads (ported from the Rust
       // engine's migrate_agent_data). Runs BEFORE the watcher so migrated files
@@ -395,6 +416,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
         server.listen(opts.port, bind, () => resolve()),
       );
       watcher.start();
+      syncDaemon?.start();
       scheduler.start();
       // The banner the Tauri supervisor parses (mirrors the runtime's contract).
       // The full token rides ONLY for the desktop sidecar; a pod/self-host token
@@ -428,10 +450,20 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
       }
     },
     stop() {
-      scheduler.stop();
-      watcher.stop();
-      launcher.shutdownAll(); // kill spawned runtimes — never orphan them
-      server.close();
+      if (stopPromise) return stopPromise;
+      stopPromise = (async () => {
+        scheduler.stop();
+        watcher.stop();
+        // Await actual child exit (bounded): the final sync below must not
+        // walk /data while a runtime is still flushing its last writes.
+        await launcher.shutdownAllAndWait();
+        await syncDaemon?.stop();
+        await new Promise<void>((resolve, reject) => {
+          if (!server.listening) return resolve();
+          server.close((err) => (err ? reject(err) : resolve()));
+        });
+      })();
+      return stopPromise;
     },
   };
 }

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -1,6 +1,7 @@
 import { randomBytes } from "node:crypto";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { HttpObjectStore } from "@houston/runtime-client/object-sync";
 import {
   LOCAL_CAPABILITIES,
   MANAGED_CLOUD_CAPABILITIES,
@@ -36,6 +37,7 @@ import { runtimeCommand } from "./runtime-command";
  *                             falls back to `node --import tsx <repo>/packages/runtime/src/main.ts`.
  *   HOUSTON_APP_SYSTEM_PROMPT the product voice prompt (from the app)
  *   HOUSTON_MANAGED_CLOUD=1  serve managed-cloud capabilities (K8s pod)
+ *   HOUSTON_STORE_URL         managed pod only: object-store gateway base URL
  */
 
 function remoteCredentialConfig(hostTokenEnv: string | undefined) {
@@ -45,7 +47,7 @@ function remoteCredentialConfig(hostTokenEnv: string | undefined) {
   if (url && orgSlug && agentSlug && hostTokenEnv) {
     return { url, orgSlug, agentSlug, podToken: hostTokenEnv };
   }
-  if (url || orgSlug || agentSlug) {
+  if (url || (!process.env.HOUSTON_STORE_URL && (orgSlug || agentSlug))) {
     // A partial env is always a deploy bug — no profile sets only some of these.
     // Falling back to the (empty) file store would make every credential serve
     // read as an org-wide logout, and a legacy pod would even start rotating
@@ -57,6 +59,38 @@ function remoteCredentialConfig(hostTokenEnv: string | undefined) {
     process.exit(1);
   }
   return undefined;
+}
+
+function optionalPositiveNumber(name: string): number | undefined {
+  const raw = process.env[name];
+  if (raw === undefined) return undefined;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be a positive number`);
+  }
+  return value;
+}
+
+function storeSyncConfig(hostTokenEnv: string | undefined) {
+  const url = process.env.HOUSTON_STORE_URL;
+  if (!url) return undefined;
+  const orgSlug = process.env.HOUSTON_ORG_SLUG;
+  const agentSlug = process.env.HOUSTON_AGENT_SLUG;
+  if (!orgSlug || !agentSlug || !hostTokenEnv) {
+    console.error(
+      "[local-host] incomplete managed object-store env: set HOUSTON_STORE_URL, HOUSTON_ORG_SLUG, HOUSTON_AGENT_SLUG, and HOUSTON_HOST_TOKEN together.",
+    );
+    process.exit(1);
+  }
+  const baseUrl = `${url.replace(/\/+$/, "")}/v1/pod/store/${encodeURIComponent(orgSlug)}/${encodeURIComponent(agentSlug)}`;
+  const hydrateMaxMb = optionalPositiveNumber("HOUSTON_HYDRATE_MAX_MB");
+  return {
+    store: new HttpObjectStore({ baseUrl, token: hostTokenEnv }),
+    quietMs: optionalPositiveNumber("HOUSTON_STORE_SYNC_QUIET_MS"),
+    intervalMs: optionalPositiveNumber("HOUSTON_STORE_SYNC_INTERVAL_MS"),
+    maxHydrateBytes:
+      hydrateMaxMb === undefined ? undefined : hydrateMaxMb * 1024 * 1024,
+  };
 }
 
 const houstonHome = process.env.HOUSTON_HOME || join(homedir(), ".houston");
@@ -105,6 +139,7 @@ const host = buildLocalHost({
   // calls act as the driving user. Desktop/self-host stay direct → false.
   gatewayFronted: process.env.HOUSTON_MANAGED_CLOUD === "1",
   credentials: remoteCredentialConfig(hostTokenEnv),
+  storeSync: storeSyncConfig(hostTokenEnv),
   // Platform-mode integrations: desktops get HOUSTON_INTEGRATIONS_URL (the
   // cloud gateway holding Houston's Composio key); self-host + the managed pod
   // set their own COMPOSIO_API_KEY and go direct. Neither → integrations off.
@@ -130,12 +165,24 @@ process.on("unhandledRejection", (reason) => {
   console.error("[local-host] unhandledRejection (staying up):", reason);
 });
 
-await host.start();
+try {
+  await host.start();
+} catch (err) {
+  // Hydration is a boot invariant in store-backed mode. Exit non-zero so the
+  // orchestrator retries with a fresh emptyDir; never linger unready or sync it.
+  console.error("[local-host] startup failed:", err);
+  process.exit(1);
+}
 
+let shuttingDown = false;
 for (const sig of ["SIGINT", "SIGTERM"] as const) {
   process.on(sig, () => {
-    host.stop(); // kills every child runtime before we exit
-    process.exit(0);
+    if (shuttingDown) return process.exit(0);
+    shuttingDown = true;
+    void host
+      .stop()
+      .catch((err) => console.error("[local-host] shutdown failed:", err))
+      .finally(() => process.exit(0));
   });
 }
 
@@ -146,4 +193,4 @@ for (const sig of ["SIGINT", "SIGTERM"] as const) {
 // (its default signal); self-host Docker, plain `tsx`, and tests leave it
 // unset and stay inert. Windows force-quit is covered by the supervisor's
 // kill-on-close Job Object.
-installParentWatchdog({ onParentExit: () => host.stop() });
+installParentWatchdog({ onParentExit: async () => await host.stop() });

--- a/packages/host/src/store-sync/daemon.test.ts
+++ b/packages/host/src/store-sync/daemon.test.ts
@@ -1,0 +1,203 @@
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  LocalDirStore,
+  type ObjectStore,
+} from "@houston/runtime-client/object-sync";
+import { expect, test } from "vitest";
+import { StoreSyncDaemon } from "./daemon";
+
+function setup() {
+  const remoteRoot = mkdtempSync(join(tmpdir(), "store-sync-remote-"));
+  const localRoot = mkdtempSync(join(tmpdir(), "store-sync-local-"));
+  const store = new LocalDirStore(remoteRoot);
+  const logs: Array<{ message: string; err?: unknown }> = [];
+  const daemon = new StoreSyncDaemon({
+    store,
+    rootDir: localRoot,
+    quietMs: 20,
+    intervalMs: 60_000,
+    log: (message, err) => logs.push({ message, err }),
+  });
+  return { daemon, localRoot, logs, remoteRoot, store };
+}
+
+async function eventually(assertion: () => void, timeoutMs = 5_000) {
+  const deadline = Date.now() + timeoutMs;
+  let error: unknown;
+  while (Date.now() < deadline) {
+    try {
+      assertion();
+      return;
+    } catch (err) {
+      error = err;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  }
+  throw error;
+}
+
+test("hydrates the cache and keeps unchanged objects in its baseline", async () => {
+  const { daemon, localRoot, remoteRoot } = setup();
+  mkdirSync(join(remoteRoot, "workspace"), { recursive: true });
+  writeFileSync(join(remoteRoot, "workspace", "notes.txt"), "remote");
+  await daemon.hydrate();
+  expect(readFileSync(join(localRoot, "workspace", "notes.txt"), "utf8")).toBe(
+    "remote",
+  );
+  await daemon.stop();
+  expect(readFileSync(join(remoteRoot, "workspace", "notes.txt"), "utf8")).toBe(
+    "remote",
+  );
+});
+
+test("uploads created files after the quiet period", async () => {
+  const { daemon, localRoot, remoteRoot } = setup();
+  await daemon.hydrate();
+  daemon.start();
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  writeFileSync(join(localRoot, "created.txt"), "created");
+  await eventually(() => {
+    expect(readFileSync(join(remoteRoot, "created.txt"), "utf8")).toBe(
+      "created",
+    );
+  });
+  await daemon.stop();
+});
+
+test("deletes remotely when a hydrated file is deleted locally", async () => {
+  const { daemon, localRoot, remoteRoot } = setup();
+  writeFileSync(join(remoteRoot, "delete-me.txt"), "old");
+  await daemon.hydrate();
+  daemon.start();
+  rmSync(join(localRoot, "delete-me.txt"));
+  await eventually(() =>
+    expect(() => readFileSync(join(remoteRoot, "delete-me.txt"))).toThrow(),
+  );
+  await daemon.stop();
+});
+
+test("never uploads credentials, db files, temp files, or runtime auth", async () => {
+  const { daemon, localRoot, remoteRoot } = setup();
+  await daemon.hydrate();
+  daemon.start();
+  const files = {
+    "credentials.json": "secret",
+    "claude-login/.credentials.json": "secret",
+    "db/houston.db": "db",
+    "workspace/write.tmp": "temp",
+    "workspaces/W/A/.houston/runtime/auth.json": "token",
+    "claude-login/projects/resume.json": "resume",
+  };
+  for (const [rel, content] of Object.entries(files)) {
+    const file = join(localRoot, ...rel.split("/"));
+    mkdirSync(join(file, ".."), { recursive: true });
+    writeFileSync(file, content);
+  }
+  await daemon.stop();
+  expect(() => readFileSync(join(remoteRoot, "credentials.json"))).toThrow();
+  expect(() =>
+    readFileSync(join(remoteRoot, "claude-login", ".credentials.json")),
+  ).toThrow();
+  expect(() => readFileSync(join(remoteRoot, "db", "houston.db"))).toThrow();
+  expect(() =>
+    readFileSync(join(remoteRoot, "workspace", "write.tmp")),
+  ).toThrow();
+  expect(() =>
+    readFileSync(
+      join(
+        remoteRoot,
+        "workspaces",
+        "W",
+        "A",
+        ".houston",
+        "runtime",
+        "auth.json",
+      ),
+    ),
+  ).toThrow();
+  expect(
+    readFileSync(
+      join(remoteRoot, "claude-login", "projects", "resume.json"),
+      "utf8",
+    ),
+  ).toBe("resume");
+});
+
+test("strictly serializes sync attempts", async () => {
+  const { localRoot, remoteRoot } = setup();
+  const delegate = new LocalDirStore(remoteRoot);
+  let active = 0;
+  let maxActive = 0;
+  const slowStore: ObjectStore = {
+    list: (prefix) => delegate.list(prefix),
+    download: (key, dest) => delegate.download(key, dest),
+    upload: async (source, key) => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      await delegate.upload(source, key);
+      active -= 1;
+    },
+    delete: (key) => delegate.delete(key),
+  };
+  const daemon = new StoreSyncDaemon({
+    store: slowStore,
+    rootDir: localRoot,
+    quietMs: 5,
+    intervalMs: 10,
+    log: () => {},
+  });
+  await daemon.hydrate();
+  daemon.start();
+  writeFileSync(join(localRoot, "one.txt"), "one");
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  writeFileSync(join(localRoot, "two.txt"), "two");
+  await eventually(() =>
+    expect(readFileSync(join(remoteRoot, "two.txt"), "utf8")).toBe("two"),
+  );
+  await daemon.stop();
+  expect(maxActive).toBe(1);
+});
+
+test("stop performs a final sync without waiting for the debounce", async () => {
+  const { daemon, localRoot, remoteRoot } = setup();
+  await daemon.hydrate();
+  daemon.start();
+  writeFileSync(join(localRoot, "final.txt"), "final");
+  await daemon.stop();
+  expect(readFileSync(join(remoteRoot, "final.txt"), "utf8")).toBe("final");
+});
+
+test("failed hydration prevents start and never uploads the local tree", async () => {
+  const { localRoot, remoteRoot } = setup();
+  writeFileSync(join(localRoot, "must-not-upload.txt"), "local");
+  let uploads = 0;
+  const broken: ObjectStore = {
+    list: async () => {
+      throw new Error("store unavailable");
+    },
+    download: async () => {},
+    upload: async () => {
+      uploads += 1;
+    },
+    delete: async () => {},
+  };
+  const daemon = new StoreSyncDaemon({
+    store: broken,
+    rootDir: localRoot,
+    log: () => {},
+  });
+  await expect(daemon.hydrate()).rejects.toThrow("store unavailable");
+  expect(() => daemon.start()).toThrow("before successful hydration");
+  await daemon.stop();
+  expect(uploads).toBe(0);
+  expect(await new LocalDirStore(remoteRoot).list("")).toEqual([]);
+});

--- a/packages/host/src/store-sync/daemon.ts
+++ b/packages/host/src/store-sync/daemon.ts
@@ -1,0 +1,175 @@
+import { type FSWatcher, watch } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import {
+  type HydrateManifest,
+  hydrate,
+  type ObjectStore,
+  syncBack,
+} from "@houston/runtime-client/object-sync";
+
+const DEFAULT_QUIET_MS = 3_000;
+const DEFAULT_INTERVAL_MS = 300_000;
+const DEFAULT_MAX_HYDRATE_BYTES = 512 * 1024 * 1024;
+
+export const STORE_SYNC_EXCLUDES = [
+  "credentials.json",
+  "claude-login/.credentials.json",
+  "db/",
+];
+
+export interface StoreSyncOptions {
+  store: ObjectStore;
+  rootDir: string;
+  excludes?: string[];
+  quietMs?: number;
+  intervalMs?: number;
+  maxHydrateBytes?: number;
+  log: (msg: string, err?: unknown) => void;
+}
+
+/**
+ * Owns the managed pod's local cache lifecycle. Hydration must succeed before
+ * observation or synchronization can start; that latch prevents an empty cache
+ * from ever being mistaken for authoritative mass deletion.
+ */
+export class StoreSyncDaemon {
+  private manifest: HydrateManifest = new Map();
+  private hydrated = false;
+  private started = false;
+  private stopping = false;
+  private dirty = false;
+  private dirtyVersion = 0;
+  private watcher: FSWatcher | undefined;
+  private quietTimer: ReturnType<typeof setTimeout> | undefined;
+  private intervalTimer: ReturnType<typeof setInterval> | undefined;
+  private syncPromise: Promise<void> | undefined;
+  private rerunRequested = false;
+
+  constructor(private readonly opts: StoreSyncOptions) {}
+
+  async hydrate(): Promise<void> {
+    this.hydrated = false;
+    await mkdir(this.opts.rootDir, { recursive: true });
+    const manifest = await hydrate(this.opts.store, "", this.opts.rootDir, {
+      excludes: this.excludes,
+      maxBytes: this.opts.maxHydrateBytes ?? DEFAULT_MAX_HYDRATE_BYTES,
+    });
+    this.manifest = manifest;
+    this.hydrated = true;
+  }
+
+  start(): void {
+    if (!this.hydrated) {
+      throw new Error("store sync cannot start before successful hydration");
+    }
+    if (this.started) return;
+    this.started = true;
+    try {
+      this.watcher = watch(this.opts.rootDir, { recursive: true }, () =>
+        this.markDirty(),
+      );
+      this.watcher.on("error", (err) => {
+        this.opts.log(
+          "[store-sync] filesystem watcher failed; using periodic sync",
+          err,
+        );
+        this.watcher?.close();
+        this.watcher = undefined;
+      });
+    } catch (err) {
+      this.opts.log(
+        "[store-sync] filesystem watcher failed; using periodic sync",
+        err,
+      );
+      this.watcher = undefined;
+    }
+    this.intervalTimer = setInterval(
+      () => this.runInBackground("periodic"),
+      this.opts.intervalMs ?? DEFAULT_INTERVAL_MS,
+    );
+    this.intervalTimer.unref?.();
+  }
+
+  async stop(): Promise<void> {
+    this.stopping = true;
+    this.watcher?.close();
+    this.watcher = undefined;
+    if (this.quietTimer) clearTimeout(this.quietTimer);
+    if (this.intervalTimer) clearInterval(this.intervalTimer);
+    this.quietTimer = undefined;
+    this.intervalTimer = undefined;
+    if (!this.hydrated) return;
+
+    if (this.syncPromise) {
+      try {
+        await this.syncPromise;
+      } catch (err) {
+        this.opts.log(
+          "[store-sync] in-flight sync failed during shutdown",
+          err,
+        );
+      }
+    }
+    try {
+      await this.syncOnce();
+    } catch (err) {
+      this.opts.log(
+        "[store-sync] FINAL sync failed; local changes may be lost",
+        err,
+      );
+    }
+    this.started = false;
+  }
+
+  private get excludes(): string[] {
+    return this.opts.excludes ?? STORE_SYNC_EXCLUDES;
+  }
+
+  private markDirty(): void {
+    if (this.stopping) return;
+    this.dirty = true;
+    this.dirtyVersion += 1;
+    if (this.quietTimer) clearTimeout(this.quietTimer);
+    this.quietTimer = setTimeout(
+      () => this.runInBackground("debounced"),
+      this.opts.quietMs ?? DEFAULT_QUIET_MS,
+    );
+    this.quietTimer.unref?.();
+  }
+
+  private runInBackground(trigger: string): void {
+    if (this.stopping || (trigger === "debounced" && !this.dirty)) return;
+    void this.requestSync().catch((err) => {
+      this.opts.log(`[store-sync] ${trigger} sync failed; will retry`, err);
+    });
+  }
+
+  private requestSync(): Promise<void> {
+    if (this.syncPromise) {
+      this.rerunRequested = true;
+      return this.syncPromise;
+    }
+    this.syncPromise = (async () => {
+      do {
+        this.rerunRequested = false;
+        await this.syncOnce();
+      } while (this.rerunRequested && !this.stopping);
+    })().finally(() => {
+      this.syncPromise = undefined;
+    });
+    return this.syncPromise;
+  }
+
+  private async syncOnce(): Promise<void> {
+    const version = this.dirtyVersion;
+    const result = await syncBack(
+      this.opts.store,
+      "",
+      this.opts.rootDir,
+      this.manifest,
+      { excludes: this.excludes },
+    );
+    this.manifest = result.manifest;
+    if (version === this.dirtyVersion) this.dirty = false;
+  }
+}

--- a/packages/host/src/store-sync/index.ts
+++ b/packages/host/src/store-sync/index.ts
@@ -1,0 +1,2 @@
+export type { StoreSyncOptions } from "./daemon";
+export { STORE_SYNC_EXCLUDES, StoreSyncDaemon } from "./daemon";

--- a/packages/runtime-client/package.json
+++ b/packages/runtime-client/package.json
@@ -10,6 +10,10 @@
     ".": {
       "types": "./src/index.ts",
       "import": "./src/index.ts"
+    },
+    "./object-sync": {
+      "types": "./src/object-sync/index.ts",
+      "import": "./src/object-sync/index.ts"
     }
   },
   "files": [

--- a/packages/runtime-client/src/object-sync/http-store.test.ts
+++ b/packages/runtime-client/src/object-sync/http-store.test.ts
@@ -1,0 +1,110 @@
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { HttpObjectStore } from "./http-store";
+
+const metadata = (key: string, size: number) => ({
+  key,
+  size,
+  md5: "md5",
+  updated: "2026-07-10T00:00:00Z",
+});
+
+test("round-trips objects through the agent-scoped HTTP API", async () => {
+  const objects = new Map<string, Uint8Array>();
+  const fetchImpl: typeof fetch = async (input, init) => {
+    const url = new URL(String(input));
+    expect(init?.headers).toEqual({ Authorization: "Bearer pod-token" });
+    if (url.pathname.endsWith("/manifest")) {
+      const keys = [...objects.keys()].sort();
+      return Response.json({
+        objects: keys.map((key) =>
+          metadata(key, objects.get(key)?.byteLength ?? 0),
+        ),
+      });
+    }
+    const marker = "/objects/";
+    const key = url.pathname
+      .slice(url.pathname.indexOf(marker) + marker.length)
+      .split("/")
+      .map(decodeURIComponent)
+      .join("/");
+    if (init?.method === "PUT") {
+      objects.set(key, new Uint8Array(init.body as Uint8Array));
+      return Response.json(metadata(key, objects.get(key)?.byteLength ?? 0));
+    }
+    if (init?.method === "DELETE") {
+      objects.delete(key);
+      return new Response(null, { status: 204 });
+    }
+    const bytes = objects.get(key);
+    return bytes
+      ? new Response(
+          bytes.buffer.slice(
+            bytes.byteOffset,
+            bytes.byteOffset + bytes.byteLength,
+          ) as ArrayBuffer,
+        )
+      : new Response('{"error":"object not found"}', { status: 404 });
+  };
+  const store = new HttpObjectStore({
+    baseUrl: "https://store.test/v1/pod/store/org/agent/",
+    token: "pod-token",
+    fetchImpl,
+  });
+  const dir = mkdtempSync(join(tmpdir(), "http-object-store-"));
+  const source = join(dir, "source.txt");
+  const destination = join(dir, "nested", "destination.txt");
+  writeFileSync(source, "hello");
+
+  await store.upload(source, "folder/file.txt");
+  expect(await store.list("folder")).toEqual(["folder/file.txt"]);
+  await store.download("folder/file.txt", destination);
+  expect(readFileSync(destination, "utf8")).toBe("hello");
+  await store.delete("folder/file.txt");
+  expect(await store.list("")).toEqual([]);
+});
+
+test("encodes each object-key path segment", async () => {
+  let seenUrl = "";
+  const store = new HttpObjectStore({
+    baseUrl: "https://store.test/base",
+    token: "token",
+    fetchImpl: async (input) => {
+      seenUrl = String(input);
+      return new Response(null, { status: 204 });
+    },
+  });
+  await store.delete("folder with space/file#1.txt");
+  expect(seenUrl).toBe(
+    "https://store.test/base/objects/folder%20with%20space/file%231.txt",
+  );
+});
+
+test("propagates response details and rejects malformed success bodies", async () => {
+  const failed = new HttpObjectStore({
+    baseUrl: "https://store.test/base",
+    token: "token",
+    fetchImpl: async () => new Response("gateway exploded", { status: 503 }),
+  });
+  await expect(failed.list("workspace")).rejects.toThrow(
+    "object store GET manifest failed (503): gateway exploded",
+  );
+
+  const malformed = new HttpObjectStore({
+    baseUrl: "https://store.test/base",
+    token: "token",
+    fetchImpl: async () => Response.json({ objects: [{ key: 42 }] }),
+  });
+  await expect(malformed.list("")).rejects.toThrow("malformed body");
+});
+
+test("tolerates delete 404", async () => {
+  const store = new HttpObjectStore({
+    baseUrl: "https://store.test/base",
+    token: "token",
+    fetchImpl: async () => new Response("missing", { status: 404 }),
+  });
+  await expect(store.delete("missing.txt")).resolves.toBeUndefined();
+});

--- a/packages/runtime-client/src/object-sync/http-store.ts
+++ b/packages/runtime-client/src/object-sync/http-store.ts
@@ -1,0 +1,144 @@
+import { randomUUID } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { mkdir, readFile, rename, rm } from "node:fs/promises";
+import { dirname } from "node:path";
+import { Readable } from "node:stream";
+import { pipeline } from "node:stream/promises";
+import type { ReadableStream as NodeReadableStream } from "node:stream/web";
+import type { ObjectStore } from "./object-store";
+
+export interface HttpObjectStoreOptions {
+  /** Full agent-scoped base URL ending in `/v1/pod/store/<org>/<agent>`. */
+  baseUrl: string;
+  token: string;
+  fetchImpl?: typeof fetch;
+}
+
+interface ObjectMetadata {
+  key: string;
+  size: number;
+  md5: string;
+  updated: string;
+}
+
+/**
+ * Agent-scoped remote object adapter for managed engine pods. The gateway owns
+ * tenancy and authorization; this adapter preserves agent-relative keys and
+ * makes downloads atomic so a failed hydration cannot leave a partial cache.
+ */
+export class HttpObjectStore implements ObjectStore {
+  private readonly baseUrl: string;
+  private readonly token: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: HttpObjectStoreOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.token = opts.token;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async list(prefix: string): Promise<string[]> {
+    const query = prefix ? `?prefix=${encodeURIComponent(prefix)}` : "";
+    const res = await this.fetchImpl(`${this.baseUrl}/manifest${query}`, {
+      headers: this.authHeaders(),
+    });
+    if (!res.ok) throw await this.responseError(res, "GET", "manifest");
+    const body: unknown = await res.json();
+    if (!this.isManifest(body)) {
+      throw new Error("object store GET manifest returned a malformed body");
+    }
+    return body.objects
+      .map((object) => object.key)
+      .filter((key) => !prefix || key.startsWith(prefix));
+  }
+
+  async download(key: string, destFile: string): Promise<void> {
+    const res = await this.fetchImpl(this.objectUrl(key), {
+      headers: this.authHeaders(),
+    });
+    if (!res.ok) throw await this.responseError(res, "GET", key);
+    if (!res.body) {
+      throw new Error(`object store GET ${key} returned no response body`);
+    }
+
+    await mkdir(dirname(destFile), { recursive: true });
+    const tempFile = `${destFile}.${randomUUID()}.tmp`;
+    try {
+      await pipeline(
+        Readable.fromWeb(res.body as NodeReadableStream),
+        createWriteStream(tempFile),
+      );
+      await rename(tempFile, destFile);
+    } catch (err) {
+      await rm(tempFile, { force: true });
+      throw err;
+    }
+  }
+
+  async upload(srcFile: string, key: string): Promise<void> {
+    const res = await this.fetchImpl(this.objectUrl(key), {
+      method: "PUT",
+      headers: this.authHeaders(),
+      body: await readFile(srcFile),
+    });
+    if (!res.ok) throw await this.responseError(res, "PUT", key);
+    const body: unknown = await res.json();
+    if (!this.isObjectMetadata(body)) {
+      throw new Error(`object store PUT ${key} returned a malformed body`);
+    }
+  }
+
+  async delete(key: string): Promise<void> {
+    const res = await this.fetchImpl(this.objectUrl(key), {
+      method: "DELETE",
+      headers: this.authHeaders(),
+    });
+    if (!res.ok && res.status !== 404) {
+      throw await this.responseError(res, "DELETE", key);
+    }
+  }
+
+  private objectUrl(key: string): string {
+    const encoded = key.split("/").map(encodeURIComponent).join("/");
+    return `${this.baseUrl}/objects/${encoded}`;
+  }
+
+  private authHeaders(): Record<string, string> {
+    return { Authorization: `Bearer ${this.token}` };
+  }
+
+  private isManifest(value: unknown): value is { objects: ObjectMetadata[] } {
+    if (!value || typeof value !== "object" || !("objects" in value)) {
+      return false;
+    }
+    const { objects } = value as { objects: unknown };
+    return (
+      Array.isArray(objects) &&
+      objects.every((item) => this.isObjectMetadata(item))
+    );
+  }
+
+  private isObjectMetadata(value: unknown): value is ObjectMetadata {
+    if (!value || typeof value !== "object") return false;
+    const item = value as Partial<ObjectMetadata>;
+    return (
+      typeof item.key === "string" &&
+      typeof item.size === "number" &&
+      typeof item.md5 === "string" &&
+      typeof item.updated === "string"
+    );
+  }
+
+  private async responseError(
+    res: Response,
+    method: string,
+    key: string,
+  ): Promise<Error> {
+    const body = await res.text();
+    return new Error(
+      `object store ${method} ${key} failed (${res.status})${
+        body ? `: ${body.slice(0, 200)}` : ""
+      }`,
+    );
+  }
+}

--- a/packages/runtime-client/src/object-sync/hydrate.test.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.test.ts
@@ -9,14 +9,12 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { expect, test } from "vitest";
-import { hydrate, syncBack } from "./hydrate";
+import { excluded, hydrate, syncBack } from "./hydrate";
 import { LocalDirStore } from "./object-store";
 
 /**
- * The hydrate→run→syncBack loop is what makes "agent = a GCS prefix" real.
- * These tests pin: faithful materialization, true diffing (only changed files
- * move), remote deletion of locally-deleted files, the auth.json exclusion
- * (tokens never persist), and the size cap.
+ * The hydrate-to-sync loop pins faithful materialization, content diffing,
+ * manifest ownership, secret exclusions, symlink safety, and hydration limits.
  */
 
 function setup() {
@@ -40,7 +38,7 @@ function seed(
 
 const PREFIX = "ws/w1/agent-1";
 
-test("hydrate materializes the prefix and syncBack uploads only the delta", async () => {
+test("hydrate materializes the prefix and syncBack returns the new manifest", async () => {
   const { storeRoot, store, work } = setup();
   seed(storeRoot, PREFIX, {
     "workspace/notes.txt": "v1",
@@ -55,7 +53,6 @@ test("hydrate materializes the prefix and syncBack uploads only the delta", asyn
   );
   expect(manifest.size).toBe(3);
 
-  // Change one file, add one, delete one — only those move.
   writeFileSync(join(work, "workspace", "notes.txt"), "v2");
   writeFileSync(join(work, "workspace", "deck.pptx"), "DECK");
   rmSync(join(work, "workspace", "sub", "deep.txt"));
@@ -66,18 +63,21 @@ test("hydrate materializes the prefix and syncBack uploads only the delta", asyn
     "workspace/notes.txt",
   ]);
   expect(result.deleted).toEqual(["workspace/sub/deep.txt"]);
-
-  // The store now reflects the new truth.
-  const rehydrated = await hydrate(
-    store,
-    PREFIX,
-    mkdtempSync(join(tmpdir(), "houston-re-")),
-  );
-  expect([...rehydrated.keys()].sort()).toEqual([
+  expect([...result.manifest.keys()].sort()).toEqual([
     "data/conversations/c1.json",
     "workspace/deck.pptx",
     "workspace/notes.txt",
   ]);
+});
+
+test("empty prefix hydrates agent-relative keys", async () => {
+  const { storeRoot, store, work } = setup();
+  seed(storeRoot, "", { "workspace/notes.txt": "hello" });
+  const manifest = await hydrate(store, "", work);
+  expect(readFileSync(join(work, "workspace", "notes.txt"), "utf8")).toBe(
+    "hello",
+  );
+  expect([...manifest.keys()]).toEqual(["workspace/notes.txt"]);
 });
 
 test("auth.json never hydrates in and never syncs out", async () => {
@@ -86,32 +86,40 @@ test("auth.json never hydrates in and never syncs out", async () => {
     "data/auth.json": JSON.stringify({ leaked: "stale-token" }),
     "workspace/file.txt": "x",
   });
-
   const manifest = await hydrate(store, PREFIX, work);
   expect(manifest.has("data/auth.json")).toBe(false);
-  // The per-turn credential is written locally AFTER hydration…
   mkdirSync(join(work, "data"), { recursive: true });
-  writeFileSync(
-    join(work, "data", "auth.json"),
-    JSON.stringify({ access: "AT-turn" }),
-  );
-  const result = await syncBack(store, PREFIX, work, manifest);
-  // …and must not be uploaded.
-  expect(result.uploaded).toEqual([]);
-  const keys = await store.list(PREFIX);
-  const remoteAuth = keys.find((k) => k.endsWith("data/auth.json"));
-  // The stale remote copy is untouched (excluded from the manifest, so not
-  // "deleted locally" either) — and the fresh token never reached the store.
-  expect(remoteAuth).toBeDefined();
+  writeFileSync(join(work, "data", "auth.json"), '{"access":"AT-turn"}');
+  expect((await syncBack(store, PREFIX, work, manifest)).uploaded).toEqual([]);
+  expect(
+    (await store.list(PREFIX)).some((key) => key.endsWith("data/auth.json")),
+  ).toBe(true);
 });
 
-test("an unchanged workspace uploads nothing", async () => {
+test("exclusions support basenames, subtrees, temp files, and runtime auth", () => {
+  const excludes = [
+    "credentials.json",
+    "claude-login/.credentials.json",
+    "db/",
+  ];
+  expect(excluded("credentials.json", excludes)).toBe(true);
+  expect(excluded("nested/credentials.json", excludes)).toBe(true);
+  expect(excluded("db/houston.db", excludes)).toBe(true);
+  expect(excluded("workspace/write.tmp", excludes)).toBe(true);
+  expect(excluded("workspaces/W/A/.houston/runtime/auth.json", excludes)).toBe(
+    true,
+  );
+  expect(excluded("claude-login/projects/cache.json", excludes)).toBe(false);
+});
+
+test("an unchanged workspace uploads nothing and remains in the manifest", async () => {
   const { storeRoot, store, work } = setup();
   seed(storeRoot, PREFIX, { "workspace/a.txt": "a", "workspace/b.txt": "b" });
   const manifest = await hydrate(store, PREFIX, work);
   const result = await syncBack(store, PREFIX, work, manifest);
   expect(result.uploaded).toEqual([]);
   expect(result.deleted).toEqual([]);
+  expect(result.manifest).toEqual(manifest);
 });
 
 test("symlinks created locally are never persisted", async () => {
@@ -119,8 +127,7 @@ test("symlinks created locally are never persisted", async () => {
   seed(storeRoot, PREFIX, { "workspace/a.txt": "a" });
   const manifest = await hydrate(store, PREFIX, work);
   symlinkSync("/etc/passwd", join(work, "workspace", "link"));
-  const result = await syncBack(store, PREFIX, work, manifest);
-  expect(result.uploaded).toEqual([]);
+  expect((await syncBack(store, PREFIX, work, manifest)).uploaded).toEqual([]);
 });
 
 test("hydration size cap throws, never truncates silently", async () => {
@@ -131,8 +138,7 @@ test("hydration size cap throws, never truncates silently", async () => {
   ).rejects.toThrow(/hydration limit/);
 });
 
-test("empty prefix hydrates to an empty manifest (brand-new agent)", async () => {
+test("missing prefix hydrates to an empty manifest", async () => {
   const { store, work } = setup();
-  const manifest = await hydrate(store, "ws/none/agent-x", work);
-  expect(manifest.size).toBe(0);
+  expect((await hydrate(store, "ws/none/agent-x", work)).size).toBe(0);
 });

--- a/packages/runtime-client/src/object-sync/hydrate.ts
+++ b/packages/runtime-client/src/object-sync/hydrate.ts
@@ -1,17 +1,13 @@
 import { createHash } from "node:crypto";
 import { readdir, readFile, stat } from "node:fs/promises";
-import { join, posix, relative, sep } from "node:path";
+import { basename, join, posix, relative, sep } from "node:path";
 import type { ObjectStore } from "./object-store";
 
 /**
- * Workspace hydration for the per-turn runtime: an agent's durable state is a
- * GCS prefix; a turn materializes it into a throwaway local dir, runs, then
- * syncs the delta back and wipes the dir. The manifest (content hashes taken
- * at hydration) is what makes sync-back a real diff: unchanged files are not
- * re-uploaded, locally-deleted files are deleted remotely.
- *
- * auth.json is ALWAYS excluded both ways: the per-turn access token is
- * injected per request and must never persist into object storage.
+ * Durable engine state is materialized into a local cache, then synchronized
+ * back by content hash. The hydration manifest is the ownership boundary: only
+ * objects observed on hydrate may be interpreted as locally deleted later.
+ * Authentication material and temporary files never cross this boundary.
  */
 
 export type HydrateManifest = Map<string, string>; // rel path -> sha256
@@ -22,8 +18,19 @@ const sha256 = (buf: Buffer) => createHash("sha256").update(buf).digest("hex");
 
 const norm = (rel: string) => rel.split(sep).join("/");
 
-function excluded(rel: string, excludes: string[]): boolean {
-  return excludes.includes(rel) || rel.endsWith(".tmp");
+export function excluded(rel: string, excludes: string[]): boolean {
+  const normalized = norm(rel);
+  if (normalized.endsWith(".tmp")) return true;
+  if (normalized.endsWith(".houston/runtime/auth.json")) return true;
+  return excludes.some((exclude) => {
+    const pattern = norm(exclude);
+    if (pattern.endsWith("/")) {
+      const subtree = pattern.slice(0, -1);
+      return normalized === subtree || normalized.startsWith(pattern);
+    }
+    if (!pattern.includes("/")) return basename(normalized) === pattern;
+    return normalized === pattern;
+  });
 }
 
 export interface HydrateOptions {
@@ -44,7 +51,7 @@ export async function hydrate(
   const manifest: HydrateManifest = new Map();
   let total = 0;
   for (const key of await store.list(prefix)) {
-    const rel = key.slice(prefix.length + 1);
+    const rel = prefix ? key.slice(prefix.length + 1) : key;
     if (!rel || excluded(rel, excludes)) continue;
     const dest = join(destDir, ...rel.split("/"));
     await store.download(key, dest);
@@ -65,7 +72,7 @@ async function walkFiles(dir: string, base: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true }).catch(() => []);
   for (const entry of entries) {
     const abs = join(dir, entry.name);
-    if (entry.isSymbolicLink()) continue; // never follow or persist symlinks
+    if (entry.isSymbolicLink()) continue;
     if (entry.isDirectory()) out.push(...(await walkFiles(abs, base)));
     else out.push(norm(relative(base, abs)));
   }
@@ -75,12 +82,13 @@ async function walkFiles(dir: string, base: string): Promise<string[]> {
 export interface SyncResult {
   uploaded: string[];
   deleted: string[];
+  manifest: HydrateManifest;
 }
 
 /**
- * Upload new/changed files under `dir` to `prefix`, delete remote keys whose
- * local files vanished. Errors propagate — a failed sync is data loss the
- * caller MUST surface, never swallow.
+ * Upload new or changed files and remove previously observed objects whose
+ * local files vanished. Errors propagate because a failed sync is data loss
+ * that the owning lifecycle must surface or retry.
  */
 export async function syncBack(
   store: ObjectStore,
@@ -91,25 +99,25 @@ export async function syncBack(
 ): Promise<SyncResult> {
   const excludes = opts.excludes ?? DEFAULT_EXCLUDES;
   const uploaded: string[] = [];
-  const seen = new Set<string>();
+  const nextManifest: HydrateManifest = new Map();
   for (const rel of await walkFiles(dir, dir)) {
     if (excluded(rel, excludes)) continue;
-    seen.add(rel);
     const abs = join(dir, ...rel.split("/"));
-    const s = await stat(abs);
-    if (!s.isFile()) continue;
+    const fileStat = await stat(abs);
+    if (!fileStat.isFile()) continue;
     const hash = sha256(await readFile(abs));
+    nextManifest.set(rel, hash);
     if (manifest.get(rel) !== hash) {
-      await store.upload(abs, posix.join(prefix, rel));
+      await store.upload(abs, prefix ? posix.join(prefix, rel) : rel);
       uploaded.push(rel);
     }
   }
   const deleted: string[] = [];
   for (const rel of manifest.keys()) {
-    if (!seen.has(rel)) {
-      await store.delete(posix.join(prefix, rel));
+    if (!nextManifest.has(rel)) {
+      await store.delete(prefix ? posix.join(prefix, rel) : rel);
       deleted.push(rel);
     }
   }
-  return { uploaded, deleted };
+  return { uploaded, deleted, manifest: nextManifest };
 }

--- a/packages/runtime-client/src/object-sync/index.ts
+++ b/packages/runtime-client/src/object-sync/index.ts
@@ -1,0 +1,15 @@
+export type { HttpObjectStoreOptions } from "./http-store";
+export { HttpObjectStore } from "./http-store";
+export type {
+  HydrateManifest,
+  HydrateOptions,
+  SyncResult,
+} from "./hydrate";
+export {
+  DEFAULT_EXCLUDES,
+  excluded,
+  hydrate,
+  syncBack,
+} from "./hydrate";
+export type { ObjectStore } from "./object-store";
+export { LocalDirStore } from "./object-store";

--- a/packages/runtime-client/src/object-sync/object-store.ts
+++ b/packages/runtime-client/src/object-sync/object-store.ts
@@ -1,14 +1,12 @@
 import { createReadStream, createWriteStream, existsSync } from "node:fs";
 import { mkdir, readdir, rm, stat } from "node:fs/promises";
-import { dirname, join, posix, relative, sep } from "node:path";
+import { dirname, join, posix, relative, resolve, sep } from "node:path";
 import { pipeline } from "node:stream/promises";
 
 /**
- * The object-storage port behind workspace persistence. Keys are
- * forward-slash paths ("ws/<id>/<agent>/workspace/deck.pptx"). GcsStore is the
- * production implementation; LocalDirStore backs tests (and local dev) with a
- * plain directory so hydration logic is tested against a real filesystem
- * without GCS credentials.
+ * The object-storage port behind durable engine state. Keys are forward-slash
+ * relative paths. Production adapters can live with their owning deployment;
+ * LocalDirStore keeps the synchronization contract testable against real files.
  */
 export interface ObjectStore {
   /** All keys under a prefix (prefix itself excluded; no delimiter semantics). */
@@ -19,12 +17,17 @@ export interface ObjectStore {
 }
 
 export class LocalDirStore implements ObjectStore {
-  constructor(private readonly root: string) {}
+  private readonly resolvedRoot: string;
+
+  constructor(root: string) {
+    this.resolvedRoot = resolve(root);
+  }
 
   private fileFor(key: string): string {
-    const abs = join(this.root, ...key.split("/"));
-    if (!abs.startsWith(this.root + sep))
+    const abs = resolve(this.resolvedRoot, ...key.split("/"));
+    if (abs !== this.resolvedRoot && !abs.startsWith(this.resolvedRoot + sep)) {
       throw new Error(`key escapes the store root: ${key}`);
+    }
     return abs;
   }
 
@@ -36,10 +39,10 @@ export class LocalDirStore implements ObjectStore {
       for (const entry of await readdir(dir, { withFileTypes: true })) {
         const abs = join(dir, entry.name);
         if (entry.isDirectory()) await walk(abs);
-        else
-          out.push(
-            posix.join(prefix, relative(base, abs).split(sep).join("/")),
-          );
+        else {
+          const rel = relative(base, abs).split(sep).join("/");
+          out.push(prefix ? posix.join(prefix, rel) : rel);
+        }
       }
     };
     await walk(base);
@@ -61,8 +64,8 @@ export class LocalDirStore implements ObjectStore {
   }
 
   async delete(key: string): Promise<void> {
-    const f = this.fileFor(key);
-    const s = await stat(f).catch(() => null);
-    if (s) await rm(f);
+    const file = this.fileFor(key);
+    const existing = await stat(file).catch(() => null);
+    if (existing) await rm(file);
   }
 }

--- a/packages/runtime/src/main.ts
+++ b/packages/runtime/src/main.ts
@@ -15,7 +15,9 @@ async function start(): Promise<Server> {
   if (config.mode === "turn") {
     const { createTurnServer } = await import("./turn/server");
     const { GcsStore } = await import("./turn/gcs-store");
-    const { LocalDirStore } = await import("./turn/object-store");
+    const { LocalDirStore } = await import(
+      "@houston/runtime-client/object-sync"
+    );
     if (!config.gcsBucket && !config.localStoreDir) {
       throw new Error(
         "turn mode needs HOUSTON_GCS_BUCKET (prod) or HOUSTON_LOCAL_STORE_DIR (dev)",

--- a/packages/runtime/src/turn/gcs-store.ts
+++ b/packages/runtime/src/turn/gcs-store.ts
@@ -1,5 +1,5 @@
 import { Storage } from "@google-cloud/storage";
-import type { ObjectStore } from "./object-store";
+import type { ObjectStore } from "@houston/runtime-client/object-sync";
 
 /**
  * GCS-backed ObjectStore. Auth is Application Default Credentials (the Cloud

--- a/packages/runtime/src/turn/server.test.ts
+++ b/packages/runtime/src/turn/server.test.ts
@@ -3,8 +3,11 @@ import { readFile, writeFile } from "node:fs/promises";
 import type { Server } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  LocalDirStore,
+  type ObjectStore,
+} from "@houston/runtime-client/object-sync";
 import { afterAll, beforeAll, expect, test } from "vitest";
-import { LocalDirStore, type ObjectStore } from "./object-store";
 import { createTurnServer } from "./server";
 import type { runPiTurn } from "./turn-session";
 

--- a/packages/runtime/src/turn/server.ts
+++ b/packages/runtime/src/turn/server.ts
@@ -9,10 +9,13 @@ import {
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { WireFrame } from "@houston/runtime-client";
+import {
+  hydrate,
+  type ObjectStore,
+  syncBack,
+} from "@houston/runtime-client/object-sync";
 import { applyServedCredential } from "../auth/auth-file";
 import { openSSE } from "../transport/sse";
-import { hydrate, syncBack } from "./hydrate";
-import type { ObjectStore } from "./object-store";
 import { runPiTurn, type TurnOutcome } from "./turn-session";
 import { parseTurnRequest, type TurnRequest } from "./types";
 


### PR DESCRIPTION
## What

Managed pods can run `/data` as a disposable cache of the gateway's pod object store instead of a PVC. Inert unless `HOUSTON_STORE_URL` is set — desktop and PVC pods are byte-identical to today.

- **`@houston/runtime-client/object-sync`** — `hydrate`/`syncBack`/`ObjectStore` moved from `packages/runtime/src/turn/` behind a node-only subpath export (browser bundles keep importing the root untouched). Two additive generalizations: empty-prefix hydration and `SyncResult.manifest`. Plus `HttpObjectStore`: the host-token-authenticated client for the control plane's `/v1/pod/store/<org>/<agent>` API, with atomic temp+rename downloads.
- **Host `StoreSyncDaemon`** — hydrates `/data` **before** the HTTP server listens (readiness = hydrated), then syncs manifest deltas on fs.watch debounce (3s quiet) with a periodic floor (5 min), strictly serialized. Final sync on SIGTERM **after** awaiting actual runtime-child exit (`shutdownAllAndWait`) so a dying child's last writes are never persisted torn.
- **Safety invariants**: a failed hydration exits non-zero and never syncs (an empty local tree must never read as authoritative mass deletion); secrets never leave the pod (`credentials.json`, `claude-login/.credentials.json`, `db/`, `*.tmp`, `.houston/runtime/auth.json` excluded both directions).

## Companion PR

gethouston/cloud `apify` — the store itself (blob port, pod store API, emptyDir manifests). Either PR merges safely alone.

## Testing

`pnpm -r typecheck` + runtime-client/host/runtime suites green (73 / 712 / 588). New coverage: daemon lifecycle (debounce, serialization, secret exclusion, failed-hydrate latch, final sync), HttpObjectStore unit tests, host boot-order + shutdown-drain lifecycle tests.