### PR TITLE
fix(runtime): allowlist the Claude subprocess env

### DIFF
--- a/packages/runtime/src/backends/claude/backend.test.ts
+++ b/packages/runtime/src/backends/claude/backend.test.ts
@@ -60,9 +60,43 @@ test("no connected token clears every ambient credential var", () => {
   expect(env.ANTHROPIC_AUTH_TOKEN).toBeUndefined();
 });
 
-test("non-credential ambient env (PATH) is preserved", () => {
+test("operational ambient env (PATH) is preserved", () => {
   const env = buildClaudeEnv("/cfg", oauth);
   expect(env.PATH).toBe(process.env.PATH);
+});
+
+test("Houston host secrets never reach the subprocess env", () => {
+  // The core of the finding: the SDK subprocess runs model-directed Bash, so any
+  // host secret in its env is one `printenv` away from exfiltration. These are the
+  // control-plane credentials config.ts reads from process.env — none may survive.
+  const secrets = {
+    HOUSTON_SANDBOX_TOKEN: "sbx-tok",
+    HOUSTON_CODE_SANDBOX_TOKEN: "code-sbx-tok",
+    HOUSTON_TURN_TOKEN: "turn-tok",
+    HOUSTON_RUNTIME_TOKEN: "runtime-tok",
+    COMPOSIO_API_KEY: "composio-key",
+    GOOGLE_APPLICATION_CREDENTIALS: "/var/gcp/key.json",
+    SOME_ARBITRARY_HOST_SECRET: "leak-me",
+  } as const;
+  const prev = Object.fromEntries(
+    Object.keys(secrets).map((k) => [k, process.env[k]]),
+  );
+  Object.assign(process.env, secrets);
+  try {
+    const env = buildClaudeEnv("/cfg", oauth);
+    for (const key of Object.keys(secrets)) {
+      expect(env[key]).toBeUndefined();
+    }
+    // The allowlisted essentials still survive so the SDK works.
+    expect(env.PATH).toBe(process.env.PATH);
+    expect(env.CLAUDE_CONFIG_DIR).toBe("/cfg");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("sk-ant-oat01-x");
+  } finally {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
 });
 
 test("browser-login path: shared config dir, NO token env (SDK reads the cached cred)", () => {

--- a/packages/runtime/src/backends/claude/backend.ts
+++ b/packages/runtime/src/backends/claude/backend.ts
@@ -7,6 +7,7 @@ import type {
   HarnessSession,
 } from "../types";
 import { resolveClaudeExecutable } from "./binary-path";
+import { buildClaudeEnv } from "./claude-env";
 import { buildHoustonMcpServer, HOUSTON_MCP_SERVER_NAME } from "./custom-tools";
 import { toSdkModel } from "./model";
 import { claudeLoginConfigDir } from "./paths";
@@ -60,8 +61,9 @@ export class ClaudeBackendUnavailableError extends Error {
  * `claude auth login` caches into, so the SDK reads that cached credential and
  * self-refreshes it) and no filesystem settings (`settingSources: []`), so
  * nothing else on the host machine leaks in. `options.env` REPLACES the
- * subprocess environment, so `process.env` is spread to keep PATH/HOME while
- * pinning the config dir + any degraded-fallback token.
+ * subprocess environment, so `buildClaudeEnv` builds it from an ALLOWLIST — the
+ * few operational vars the SDK needs plus the config dir and the one connected
+ * credential — never spreading `process.env` (see `./claude-env`).
  */
 export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
   return {
@@ -135,51 +137,8 @@ export function createClaudeBackend(deps: ClaudeBackendDeps): HarnessBackend {
   };
 }
 
-/**
- * Every env var the Claude Agent SDK reads to authenticate. The SDK honors all
- * three (verified in the installed `sdk.mjs`): a setup/OAuth token via
- * `CLAUDE_CODE_OAUTH_TOKEN`, and an API key via either `ANTHROPIC_API_KEY` or
- * the `ANTHROPIC_AUTH_TOKEN` alias. We clear ALL of them before setting the one
- * for the connected credential, so exactly one survives.
- */
-const CREDENTIAL_ENV_VARS = [
-  "CLAUDE_CODE_OAUTH_TOKEN",
-  "ANTHROPIC_API_KEY",
-  "ANTHROPIC_AUTH_TOKEN",
-] as const;
-
-/**
- * The single Anthropic auth env var for a credential (empty when none is
- * connected): a setup/OAuth token via `CLAUDE_CODE_OAUTH_TOKEN`, an API key via
- * `ANTHROPIC_API_KEY`.
- */
-function tokenEnv(token: ClaudeToken | undefined): Record<string, string> {
-  if (token?.kind === "oauth-token")
-    return { CLAUDE_CODE_OAUTH_TOKEN: token.value };
-  if (token?.kind === "api-key") return { ANTHROPIC_API_KEY: token.value };
-  return {};
-}
-
-/**
- * Build the SDK subprocess env carrying EXACTLY the connected credential.
- *
- * `options.env` REPLACES the subprocess environment, so we spread `process.env`
- * to keep PATH/HOME, pin the ISOLATED config dir, then make the credential vars
- * deterministic: DELETE all three first, then set the one for the connected
- * token. A stale/ambient `ANTHROPIC_API_KEY` on the host must never survive
- * alongside a user's OAuth token — otherwise a subscription turn could silently
- * bill the machine's (or Houston's) API key. Shared by the turn backend and the
- * one-shot title path (`./title`) so both scrub identically.
- */
-export function buildClaudeEnv(
-  configDir: string,
-  token: ClaudeToken | undefined,
-): Record<string, string> {
-  const env: Record<string, string> = {
-    ...process.env,
-    CLAUDE_CONFIG_DIR: configDir,
-  };
-  for (const key of CREDENTIAL_ENV_VARS) delete env[key];
-  Object.assign(env, tokenEnv(token));
-  return env;
-}
+// The SDK subprocess env is built from an allowlist (not a `process.env` spread)
+// so no host secret reaches a subprocess that runs model-directed Bash. Kept in
+// `./claude-env` and re-exported here so `./title` and `./credential-status`
+// keep their `from "./backend"` import.
+export { buildClaudeEnv } from "./claude-env";

--- a/packages/runtime/src/backends/claude/claude-env.ts
+++ b/packages/runtime/src/backends/claude/claude-env.ts
@@ -1,0 +1,123 @@
+import type { ClaudeToken } from "./backend";
+
+/**
+ * Building the environment for the Claude Agent SDK subprocess.
+ *
+ * The subprocess runs model-directed Bash on the default hosted-pod profile, so
+ * its environment is an exfiltration surface: a prompt-injected agent that runs
+ * `printenv` can read anything we hand it. `options.env` REPLACES the child
+ * environment (it is not merged onto `process.env`), which is exactly the lever
+ * we need — so we build the env from `{}` with an ALLOWLIST of the few
+ * operational vars the SDK genuinely needs, never a denylist over `process.env`.
+ *
+ * Spreading `process.env` and deleting the Anthropic keys (the old approach)
+ * still handed the subprocess every host secret: `HOUSTON_SANDBOX_TOKEN`,
+ * `HOUSTON_CODE_SANDBOX_TOKEN`, `HOUSTON_TURN_TOKEN`, `HOUSTON_RUNTIME_TOKEN`
+ * (config.ts), plus any Composio/GCP credentials. With the sandbox token the
+ * agent could call the control plane's `/sandbox/credential` directly and pull
+ * the workspace's real provider tokens — defeating the short-TTL Gate-#2 design.
+ */
+
+/**
+ * Every env var the Claude Agent SDK reads to authenticate. The SDK honors all
+ * three (verified in the installed `sdk.mjs`): a setup/OAuth token via
+ * `CLAUDE_CODE_OAUTH_TOKEN`, and an API key via either `ANTHROPIC_API_KEY` or
+ * the `ANTHROPIC_AUTH_TOKEN` alias. We never copy these from the ambient env;
+ * exactly the one for the connected credential is set, so exactly one survives.
+ */
+const CREDENTIAL_ENV_VARS = [
+  "CLAUDE_CODE_OAUTH_TOKEN",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+] as const;
+
+/**
+ * The ALLOWLIST of ambient env vars copied verbatim into the subprocess.
+ * Compared case-insensitively (Windows env keys vary in case; the proxy vars are
+ * honored in both `HTTP_PROXY`/`http_proxy` forms), preserving each key's
+ * original case. This is the whole non-credential surface — nothing else from
+ * `process.env` reaches a subprocess that runs model-directed Bash.
+ *
+ * None of these are secrets: they are the process bootstrap (PATH/HOME/shell),
+ * locale, temp dirs, Windows runtime vars, and the SAME proxy/custom-CA network
+ * vars the SDK itself forwards to its helpers, so proxied / private-CA
+ * deployments can still reach the Anthropic API.
+ */
+const PASSTHROUGH_ENV_VARS: ReadonlySet<string> = new Set(
+  [
+    // POSIX process + shell essentials — the subprocess and Bash tool need these
+    // to locate executables and resolve the user's home.
+    "PATH",
+    "HOME",
+    "SHELL",
+    // Locale — correct text handling in the subprocess.
+    "LANG",
+    "LC_ALL",
+    "LC_CTYPE",
+    "LC_MESSAGES",
+    // Temp directories.
+    "TMPDIR",
+    "TMP",
+    "TEMP",
+    // Windows process bootstrap — Node and child processes fail to start without
+    // these on native Windows.
+    "SYSTEMROOT",
+    "WINDIR",
+    "COMSPEC",
+    "PATHEXT",
+    "USERPROFILE",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "APPDATA",
+    "LOCALAPPDATA",
+    // Network config the SDK forwards to its own subprocesses (non-secret): proxy
+    // routing and an extra CA bundle, so proxied / private-CA hosts still connect.
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "ALL_PROXY",
+    "NODE_EXTRA_CA_CERTS",
+  ].map((k) => k.toUpperCase()),
+);
+
+/**
+ * The single Anthropic auth env var for a credential (empty when none is
+ * connected): a setup/OAuth token via `CLAUDE_CODE_OAUTH_TOKEN`, an API key via
+ * `ANTHROPIC_API_KEY`.
+ */
+function tokenEnv(token: ClaudeToken | undefined): Record<string, string> {
+  if (token?.kind === "oauth-token")
+    return { CLAUDE_CODE_OAUTH_TOKEN: token.value };
+  if (token?.kind === "api-key") return { ANTHROPIC_API_KEY: token.value };
+  return {};
+}
+
+/**
+ * Build the SDK subprocess env from an ALLOWLIST, carrying EXACTLY the connected
+ * credential and no host secret.
+ *
+ * `options.env` REPLACES the subprocess environment, so we start from `{}`, copy
+ * only the allowlisted operational vars (`PASSTHROUGH_ENV_VARS`, never the
+ * credential keys), pin the ISOLATED config dir, then set the one credential var
+ * for the connected token. A stale/ambient `ANTHROPIC_API_KEY` on the host can
+ * never survive alongside a user's OAuth token — it was never copied — so a
+ * subscription turn cannot silently bill the machine's API key. Shared by the
+ * turn backend and the one-shot title path (`./title`) so both isolate identically.
+ */
+export function buildClaudeEnv(
+  configDir: string,
+  token: ClaudeToken | undefined,
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined && PASSTHROUGH_ENV_VARS.has(key.toUpperCase())) {
+      env[key] = value;
+    }
+  }
+  env.CLAUDE_CONFIG_DIR = configDir;
+  // Belt-and-braces: the credential keys are not in the allowlist, but assert the
+  // invariant so a future allowlist edit can never re-admit an ambient one.
+  for (const key of CREDENTIAL_ENV_VARS) delete env[key];
+  Object.assign(env, tokenEnv(token));
+  return env;
+}


### PR DESCRIPTION
## The leak (HIGH / security)

`buildClaudeEnv` (`packages/runtime/src/backends/claude/backend.ts`) built the Claude Agent SDK subprocess env by spreading **all** of `process.env` and then deleting only the three Anthropic credential keys — a **denylist**. Because `options.env` **replaces** the child environment, that handed the subprocess every remaining host secret.

## The exploit path

The subprocess runs **model-directed Bash** on the default hosted-pod profile (`HOUSTON_CODE_EXECUTION=local`). `config.ts` reads these secrets straight from `process.env`, so they were all inherited:

- `HOUSTON_SANDBOX_TOKEN`
- `HOUSTON_CODE_SANDBOX_TOKEN`
- `HOUSTON_TURN_TOKEN`
- `HOUSTON_RUNTIME_TOKEN`
- plus any `COMPOSIO_*` / GCP credentials in the environment

The tool-policy permission gate (`tool-policy.ts`) only clamps file **paths** — `env` / `printenv` name no path token and are auto-approved (its own comment says it is **not** a security boundary). A prompt-injected agent could read `HOUSTON_SANDBOX_TOKEN` and call the control plane's `/sandbox/credential` directly to pull the workspace's real provider tokens, defeating the short-TTL Gate-#2 design.

## The fix — invert to an allowlist

Build the subprocess env from `{}`, copying only the operational vars the SDK genuinely needs (verified against the installed `sdk.mjs`, whose `spawnLocalProcess` uses the passed `env` verbatim):

- **Process/shell:** `PATH`, `HOME`, `SHELL`
- **Locale:** `LANG`, `LC_ALL`, `LC_CTYPE`, `LC_MESSAGES`
- **Temp:** `TMPDIR`, `TMP`, `TEMP`
- **Windows bootstrap:** `SYSTEMROOT`, `WINDIR`, `COMSPEC`, `PATHEXT`, `USERPROFILE`, `HOMEDRIVE`, `HOMEPATH`, `APPDATA`, `LOCALAPPDATA`
- **Network (non-secret, the same vars the SDK forwards to its own helpers):** `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`, `ALL_PROXY`, `NODE_EXTRA_CA_CERTS`

Then pin `CLAUDE_CONFIG_DIR` and set **exactly** the one connected Anthropic credential (`CLAUDE_CODE_OAUTH_TOKEN` **or** `ANTHROPIC_API_KEY`). No host secret is ever copied. The passthrough match is case-insensitive (Windows key casing; `HTTP_PROXY`/`http_proxy`) while preserving each key's original case.

Extracted the env construction into `claude-env.ts`; `backend.ts` re-exports `buildClaudeEnv` so `./title` and `./credential-status` keep their `from "./backend"` imports. Both files stay under the 200-line limit (backend.ts 144, claude-env.ts 123).

## Updated test

The old test `"non-credential ambient env (PATH) is preserved"` implicitly encoded the leak (it only checked PATH survived). Added `"Houston host secrets never reach the subprocess env"`, asserting the four `HOUSTON_*` tokens plus `COMPOSIO_API_KEY`, `GOOGLE_APPLICATION_CREDENTIALS`, and an arbitrary host secret are **absent** from the returned env, while `PATH`, `CLAUDE_CONFIG_DIR`, and the credential survive. Confirmed it **failed** against the old spread-based code, then passes after the fix.

## Verification (scoped)

- `pnpm --filter @houston/runtime test` — 591/591 pass
- `pnpm --filter @houston/runtime typecheck` — clean (pre-commit also ran full-workspace typecheck, all green)
- `biome check` on the three touched files — clean

## Audit origin

Filed from a HIGH/security finding: the Claude subprocess inherited every host secret then ran model-directed Bash (denylist env construction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)