### PR TITLE
fix(host): cap request-body buffering to prevent OOM

### DIFF
--- a/packages/host/src/channel/proxy.ts
+++ b/packages/host/src/channel/proxy.ts
@@ -10,6 +10,7 @@ import type {
   RuntimeLauncher,
   TurnPin,
 } from "../ports";
+import { MAX_JSON_BYTES, readBody } from "../routes/read-body";
 
 /**
  * Forwards one authorized request to a standing runtime and streams the reply
@@ -64,11 +65,15 @@ export class ProxyChannel implements RuntimeChannel {
     // Collect the raw body for non-GET so arbitrary payloads ({text}, {code},
     // {activeProvider}) pass through untouched. Strip the caller's `token` auth
     // param so the user's JWT is never leaked downstream to the runtime.
+    //
+    // Bounded by MAX_JSON_BYTES: file uploads and attachments are intercepted
+    // host-side (handleFiles / handleAttachments) BEFORE this forward, so the
+    // only bodies that reach a standing pod are control-plane JSON (messages,
+    // settings, provider login) — a few MB is generous, and the cap stops an
+    // oversized body from OOM-ing the (memory-capped) engine pod.
     let body: Buffer | undefined;
     if (method !== "GET" && method !== "HEAD") {
-      const chunks: Buffer[] = [];
-      for await (const c of req) chunks.push(c as Buffer);
-      body = Buffer.concat(chunks);
+      body = await readBody(req, MAX_JSON_BYTES);
     }
     const params = new URLSearchParams(url.search);
     params.delete("token");

--- a/packages/host/src/routes/http.ts
+++ b/packages/host/src/routes/http.ts
@@ -1,5 +1,9 @@
 import type { IncomingMessage, ServerResponse } from "node:http";
 
+// The single, byte-capped body reader — shared so the cap can't drift between
+// the many routes that import `readJson` from here.
+export { readBody, readJson } from "./read-body";
+
 export function json(
   res: ServerResponse,
   status: number,
@@ -12,15 +16,6 @@ export function json(
     ...headers,
   });
   res.end(buf);
-}
-
-export async function readJson(
-  req: IncomingMessage,
-): Promise<Record<string, unknown>> {
-  const chunks: Buffer[] = [];
-  for await (const c of req) chunks.push(c as Buffer);
-  const raw = Buffer.concat(chunks).toString("utf8");
-  return raw ? JSON.parse(raw) : {};
 }
 
 /** The caller's bearer, from the Authorization header or a ?token= fallback (SSE). */

--- a/packages/host/src/routes/read-body.test.ts
+++ b/packages/host/src/routes/read-body.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, test } from "vitest";
+import { BodyTooLargeError, readBody, readJson } from "./read-body";
+
+/**
+ * The byte-cap guard: request bodies are drained WITH a running cap so an
+ * oversized (or slow-loris) body is rejected with a 413 mid-stream, before the
+ * whole thing is buffered into the process. This is the OOM protection the old
+ * post-hoc size checks gave false confidence about.
+ */
+
+/** An async-iterable request that counts how many bytes it has actually yielded. */
+function countingReq(
+  chunkSize: number,
+  chunks: number,
+  headers: Record<string, string> = {},
+) {
+  const state = { pulled: 0 };
+  const req = {
+    headers,
+    async *[Symbol.asyncIterator]() {
+      for (let i = 0; i < chunks; i++) {
+        state.pulled += chunkSize;
+        yield Buffer.alloc(chunkSize, 0x61); // 'a'
+      }
+    },
+  };
+  return { req: req as never, state };
+}
+
+/** A request whose body is a single JSON payload (no Content-Length). */
+function jsonReq(value: unknown) {
+  const buf = Buffer.from(JSON.stringify(value));
+  return {
+    headers: {},
+    async *[Symbol.asyncIterator]() {
+      yield buf;
+    },
+  } as never;
+}
+
+describe("readBody byte cap", () => {
+  test("rejects an oversized chunked body WITHOUT draining the whole stream", async () => {
+    const cap = 1024; // 1 KiB
+    // 100 chunks of 1 KiB = ~100 KiB total; the cap should trip after ~1 KiB.
+    const { req, state } = countingReq(1024, 100);
+    await expect(readBody(req, cap)).rejects.toBeInstanceOf(BodyTooLargeError);
+    // Early abort: only a hair past the cap was ever pulled, never the full body.
+    expect(state.pulled).toBeLessThanOrEqual(cap + 1024);
+  });
+
+  test("a Content-Length over the cap is rejected before ANY body is read", async () => {
+    const cap = 1024;
+    const { req, state } = countingReq(1024, 100, {
+      "content-length": String(100 * 1024),
+    });
+    await expect(readBody(req, cap)).rejects.toBeInstanceOf(BodyTooLargeError);
+    // The fast pre-check fires without touching the stream.
+    expect(state.pulled).toBe(0);
+  });
+
+  test("a lying Content-Length under the cap is still caught by the streaming guard", async () => {
+    const cap = 1024;
+    // Declares 512 bytes but actually streams ~100 KiB (chunked-encoding attack).
+    const { req } = countingReq(1024, 100, { "content-length": "512" });
+    await expect(readBody(req, cap)).rejects.toBeInstanceOf(BodyTooLargeError);
+  });
+
+  test("a body at/under the cap is returned in full", async () => {
+    const { req } = countingReq(256, 4); // 1 KiB total, == cap
+    const buf = await readBody(req, 1024);
+    expect(buf.length).toBe(1024);
+  });
+
+  test("BodyTooLargeError carries the 413 status and no parser text", () => {
+    const err = new BodyTooLargeError(1024);
+    expect(err.status).toBe(413);
+    expect(err.maxBytes).toBe(1024);
+    expect(err.message).toBe("request body exceeds the size limit");
+  });
+});
+
+describe("readJson byte cap", () => {
+  test("parses a JSON body under the cap", async () => {
+    const body = await readJson(jsonReq({ hello: "world" }), 1024);
+    expect(body).toEqual({ hello: "world" });
+  });
+
+  test("an empty body reads as {}", async () => {
+    // An intentionally empty body: an async iterator that is immediately done.
+    const req = {
+      headers: {},
+      [Symbol.asyncIterator]: () => ({
+        next: async () => ({ done: true, value: undefined }),
+      }),
+    } as never;
+    expect(await readJson(req)).toEqual({});
+  });
+
+  test("an oversized JSON body rejects with 413 instead of buffering + parsing it", async () => {
+    const { req } = countingReq(1024, 100); // ~100 KiB
+    await expect(readJson(req, 1024)).rejects.toBeInstanceOf(BodyTooLargeError);
+  });
+});

--- a/packages/host/src/routes/read-body.ts
+++ b/packages/host/src/routes/read-body.ts
@@ -1,0 +1,63 @@
+import type { IncomingMessage } from "node:http";
+
+/**
+ * Default cap for control-plane JSON routes. A few MB is orders of magnitude
+ * beyond any settings / message / credential payload, yet keeps a hostile or
+ * runaway body from ever being buffered whole into the process. Upload routes
+ * pass a larger, explicit cap (files-import.ts `MAX_UPLOAD_BODY_BYTES`).
+ */
+export const MAX_JSON_BYTES = 4 * 1024 * 1024;
+
+/**
+ * A request body exceeded its byte cap. Carries the 413 status so the server's
+ * top-level handler (and every route) maps it to a clean "Payload Too Large"
+ * without leaking parser internals.
+ */
+export class BodyTooLargeError extends Error {
+  readonly status = 413;
+  constructor(public readonly maxBytes: number) {
+    super("request body exceeds the size limit");
+    this.name = "BodyTooLargeError";
+  }
+}
+
+/**
+ * Drain a request body into a Buffer, enforcing `maxBytes` WHILE streaming so an
+ * oversized (or slow-loris) body is never buffered whole — the OOM guard the old
+ * post-hoc size checks could not give. A declared Content-Length over the cap is
+ * rejected up front (cheap, and lets a legitimate over-limit client get a clean
+ * 413 before any body is read). But the running-total check is the real guard:
+ * Content-Length is client-controlled and absent on chunked bodies. Crossing the
+ * cap throws out of the async iteration, which destroys the request stream — no
+ * further bytes are read into memory.
+ */
+export async function readBody(
+  req: IncomingMessage,
+  maxBytes: number,
+): Promise<Buffer> {
+  const declared = Number(req.headers?.["content-length"]);
+  if (Number.isFinite(declared) && declared > maxBytes) {
+    throw new BodyTooLargeError(maxBytes);
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  for await (const c of req) {
+    const chunk = c as Buffer;
+    total += chunk.length;
+    if (total > maxBytes) throw new BodyTooLargeError(maxBytes);
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
+ * Parse a JSON request body under a hard byte cap (default `MAX_JSON_BYTES`;
+ * upload routes pass the larger transport cap). An empty body reads as `{}`.
+ */
+export async function readJson(
+  req: IncomingMessage,
+  maxBytes: number = MAX_JSON_BYTES,
+): Promise<Record<string, unknown>> {
+  const raw = (await readBody(req, maxBytes)).toString("utf8");
+  return raw ? (JSON.parse(raw) as Record<string, unknown>) : {};
+}

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -43,6 +43,7 @@ import {
 } from "./routes/integrations";
 import { handleSandboxIntegrations } from "./routes/integrations-sandbox";
 import { handlePortableAccount } from "./routes/portable";
+import { BodyTooLargeError } from "./routes/read-body";
 import { handleSetupRuntime } from "./routes/setup-runtime";
 import { handleSkillsDirectory } from "./routes/skills-directory";
 import type { Vfs } from "./vfs";
@@ -244,6 +245,9 @@ async function handle(
     try {
       payload = parseFeedbackPayload(await readJson(req));
     } catch (err) {
+      // An oversized body is a 413 (mapped by the top-level handler), not a
+      // malformed-payload 400 — let it propagate rather than mislabel it.
+      if (err instanceof BodyTooLargeError) throw err;
       return json(res, 400, {
         error: err instanceof Error ? err.message : String(err),
       });
@@ -293,9 +297,24 @@ export function createControlPlaneServer(deps: ControlPlaneDeps): Server {
       });
     }
     handle(counted, req, res).catch((err) => {
+      // An over-cap body maps to 413 (Payload Too Large) with its own clean
+      // message; everything else is a 500. Close the connection on 413: capping
+      // the body leaves unread bytes on the socket that would poison keep-alive.
+      const tooLarge = err instanceof BodyTooLargeError;
       const message = err instanceof Error ? err.message : String(err);
-      if (!res.headersSent) json(res, 500, { error: message });
-      else if (!res.writableEnded) res.end();
+      try {
+        if (!res.headersSent) {
+          json(
+            res,
+            tooLarge ? 413 : 500,
+            { error: message },
+            tooLarge ? { Connection: "close" } : {},
+          );
+        } else if (!res.writableEnded) res.end();
+      } catch {
+        // The socket was already torn down while aborting the oversized body —
+        // there is nothing left to respond on.
+      }
     });
   });
 }

--- a/packages/host/src/turn/attachments.ts
+++ b/packages/host/src/turn/attachments.ts
@@ -4,7 +4,7 @@ import type { Agent, Workspace } from "../domain/types";
 import type { WorkspacePaths } from "../paths";
 import type { Vfs } from "../vfs";
 import { json, readJson } from "./deps";
-import { MAX_UPLOAD_BYTES } from "./files-import";
+import { MAX_UPLOAD_BODY_BYTES, MAX_UPLOAD_BYTES } from "./files-import";
 
 /**
  * Composer attachments — files the user drops on a chat message, uploaded INTO
@@ -36,9 +36,11 @@ import { MAX_UPLOAD_BYTES } from "./files-import";
 /** The on-disk dir name — a visible, durable folder in the agent's workspace. */
 const UPLOADS_DIR = "uploads";
 
-// A single request is capped at MAX_UPLOAD_BYTES (shared with files/import so
-// the composer's client-side per-file limit and the host cap can't drift; the
-// client uploads one request per file, so per-file = per-request).
+// A single request's decoded payload is capped at MAX_UPLOAD_BYTES (shared with
+// files/import so the composer's client-side per-file limit and the host cap
+// can't drift; the client uploads one request per file, so per-file =
+// per-request). The RAW body is bounded during draining by MAX_UPLOAD_BODY_BYTES
+// so an oversized upload can never buffer into the process.
 
 export class AttachmentError extends Error {
   constructor(
@@ -140,7 +142,10 @@ function parseUploadBody(body: Record<string, unknown>): UploadFile[] {
         `file[${i}] needs string 'name' and 'contentBase64'`,
       );
     }
-    // base64 is ~4/3 the byte size; estimate to fail oversized uploads loudly.
+    // Semantic decoded-size limit (base64 is ~3/4 the byte size). The raw body
+    // is already capped DURING draining by readJson(MAX_UPLOAD_BODY_BYTES) — the
+    // OOM guard — so this estimate is now purely the user-facing size limit, not
+    // the memory backstop it used to (wrongly) stand in for.
     total += Math.floor((f.contentBase64.length * 3) / 4);
     if (total > MAX_UPLOAD_BYTES) {
       throw new AttachmentError(
@@ -186,7 +191,7 @@ export async function handleAttachments(
   const root = paths.agentRoot(ctx.workspace, ctx.agent);
   try {
     if (method === "POST") {
-      const files = parseUploadBody(await readJson(req));
+      const files = parseUploadBody(await readJson(req, MAX_UPLOAD_BODY_BYTES));
       const saved = await saveAttachments(vfs, root, files);
       if (saved.length > 0)
         emit?.({ type: "FilesChanged", agentPath: ctx.agent.id });

--- a/packages/host/src/turn/deps.ts
+++ b/packages/host/src/turn/deps.ts
@@ -1,4 +1,4 @@
-import type { IncomingMessage, ServerResponse } from "node:http";
+import type { ServerResponse } from "node:http";
 import type { Agent, Workspace } from "../domain/types";
 import type { CredentialStore, WorkspaceCredential } from "../ports";
 import type { Vfs } from "../vfs";
@@ -40,16 +40,9 @@ export function json(res: ServerResponse, status: number, body: unknown) {
   res.end(JSON.stringify(body));
 }
 
-export async function readJson(
-  req: IncomingMessage,
-): Promise<Record<string, unknown>> {
-  const chunks: Buffer[] = [];
-  for await (const c of req) chunks.push(c as Buffer);
-  return JSON.parse(Buffer.concat(chunks).toString("utf8") || "{}") as Record<
-    string,
-    unknown
-  >;
-}
+// The byte-capped body reader lives once in routes/read-body.ts; re-exported so
+// the turn dispatch path shares the exact same cap as every other route.
+export { readJson } from "../routes/read-body";
 
 export const prefixFor = (ws: Workspace, agent: Agent) =>
   `ws/${ws.id}/${agent.id}`;

--- a/packages/host/src/turn/files-import.ts
+++ b/packages/host/src/turn/files-import.ts
@@ -15,6 +15,19 @@ import { FileOpError, FilePathError, fileKey, safeRel } from "./files-ops";
  */
 export const MAX_UPLOAD_BYTES = 100 * 1024 * 1024;
 
+/**
+ * The raw HTTP body cap for an upload request. Files ride as base64 inside JSON,
+ * which inflates the byte count ~4/3, so the transport body is larger than the
+ * decoded payload `MAX_UPLOAD_BYTES` bounds. Cap the drained body at that
+ * inflated size (plus a 1 MiB JSON-envelope allowance for field names and, on
+ * files/import, several files' metadata) so a legitimately-sized upload is never
+ * rejected by the transport cap — while an oversized body is still cut off DURING
+ * draining, before it can OOM the process. The decoded-byte `MAX_UPLOAD_BYTES`
+ * check in the body parsers remains the semantic limit shown to the user.
+ */
+export const MAX_UPLOAD_BODY_BYTES =
+  Math.ceil((MAX_UPLOAD_BYTES * 4) / 3) + 1024 * 1024;
+
 /** One uploaded file: original name + its base64-encoded bytes. */
 export interface UploadFile {
   name: string;

--- a/packages/host/src/turn/files.ts
+++ b/packages/host/src/turn/files.ts
@@ -7,6 +7,7 @@ import { json, readJson } from "./deps";
 import { archiveWorkspace } from "./files-archive";
 import {
   importWorkspaceFiles,
+  MAX_UPLOAD_BODY_BYTES,
   moveWorkspaceEntry,
   parseImportBody,
 } from "./files-import";
@@ -167,7 +168,9 @@ export async function handleFiles(
       return true;
     }
     if (method === "POST" && rest === "files/import") {
-      const { dir, files } = parseImportBody(await readJson(req));
+      const { dir, files } = parseImportBody(
+        await readJson(req, MAX_UPLOAD_BODY_BYTES),
+      );
       const saved = await importWorkspaceFiles(vfs, root, dir, files);
       changed();
       await json(res, 200, { paths: saved });


### PR DESCRIPTION
## The problem: false confidence

Request bodies were drained into memory with **no byte cap**. The 100 MB upload limit was enforced only *after* the whole body had been buffered, `Buffer.concat`'d, `.toString()`'d and `JSON.parse`'d (four copies in flight). So the constant gave false confidence: a malicious, oversized, or slow-loris body could OOM-kill a memory-capped engine pod **before** the 413 ever fired.

Three unbounded drains existed:
- `routes/http.ts` `readJson` — `for await (const c of req) chunks.push(c)` then concat/parse.
- `turn/deps.ts` `readJson` — a second, near-identical duplicate (the cap could drift between them).
- `channel/proxy.ts` — the same inline drain for every non-GET forwarded to a standing pod.
- `turn/attachments.ts` computed its base64 estimate and threw 413 only *after* `readJson` had already buffered everything.

## The fix: streaming cap + dedup

- **Shared, byte-capped reader** (`routes/read-body.ts`): `readBody` tracks a running total while draining and throws `BodyTooLargeError` (413) the moment it crosses `maxBytes`, aborting the stream so no further bytes are read. A declared `Content-Length` over the cap is rejected up front (cheap, clean 413), but the **streaming total is the real guard** — Content-Length is client-controlled and absent on chunked bodies.
- **De-duplicated**: the two identical `readJson` bodies now re-export the ONE shared helper; `channel/proxy.ts` drains through it too. The cap can no longer drift.
- **Caps per route class**:
  - control-plane JSON → `MAX_JSON_BYTES` (4 MB). The proxy passthrough only ever carries control-plane JSON — files/attachments are host-intercepted *before* the forward.
  - uploads (`attachments`, `files/import`) → `MAX_UPLOAD_BODY_BYTES`, the base64+JSON transport inflation (~4/3) of `MAX_UPLOAD_BYTES` plus a 1 MiB envelope allowance, so a legitimately-sized upload is never wrongly rejected while the raw body is still bounded during draining.
  - `attachments` keeps its decoded base64-estimate check as the **semantic** user-facing limit; it no longer stands in for the OOM backstop.
- **Clean 413 mapping**: `BodyTooLargeError` maps to a `413` (with `Connection: close`) at the server's top-level handler; the `/feedback` route re-throws it rather than mislabel it a `400`. No internal parser text is leaked.

## Test (reproduce-first)

New `routes/read-body.test.ts`. The reproduction driver feeds an oversized async-iterable that **counts bytes actually yielded**, proving early abort:
- `rejects an oversized chunked body WITHOUT draining the whole stream` — first run against the old `readJson` drained all ~100 KiB and parse-errored (RED); the capped reader aborts after ~1 KiB (GREEN).
- plus: Content-Length fast-reject (0 bytes pulled), a lying Content-Length still caught by the streaming guard, at/under-cap passthrough, 413 status/message, JSON parse + empty-body cases.

## Audit origin

MEDIUM/reliability finding: request bodies buffered into memory with no byte cap; the 100 MB limit enforced only after the whole body was in memory, so it did not protect the process from OOM.

## Scoped checks

- `pnpm --filter @houston/host test` → 95 files, 750 passing (+8 new).
- `pnpm --filter @houston/host typecheck` → clean (pre-commit ran the full `-r typecheck`, all green).
- Biome clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)