### PR TITLE
fix(sdk,runtime): bound conversation caches with LRU/idle eviction

### DIFF
--- a/knowledge-base/architecture.md
+++ b/knowledge-base/architecture.md
@@ -222,6 +222,16 @@ same rebuild rails carry all three modes. Both backends honor it: the pi backend
 swaps its tool allowlist; the Claude-SDK backend keeps its SDK `permissionMode`
 default and simply gets the clamped tool set, so plan/auto still hold.
 
+**Session cache is bounded.** The live-session map in `conversation-cache.ts` is
+an `LruCache` (`packages/runtime/src/lru.ts`), not a raw `Map`: past
+`config.sessionCacheMax` (`HOUSTON_SESSION_CACHE_MAX`, default 40) or after
+`config.sessionCacheIdleMs` idle (`HOUSTON_SESSION_CACHE_IDLE_MS`, default 30 min,
+`0` disables) the least-recently-used SETTLED session is disposed and
+transparently re-hydrated from its on-disk transcript on next `getConversation`.
+A session with a queued/running turn is pinned (`isConvBusy` — `conv.pending > 0`
+maintained by `chat.ts:runTurn`, or `conv.turnId` set) and NEVER evicted, so no
+turn is disposed from under it.
+
 App side: a Mode pill in the composer footer
 (`app/src/components/chat-mode-selector.tsx`) — persona labels **Planner**
 (`plan`), **Coworker** (`execute`), and **Autopilot** (`auto`), ordered top→bottom

--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -75,6 +75,15 @@ mode), letting the whole desktop UI run on the host unchanged. Convergence says
   output decides where it lands.
 - **The global-events reactivity loop** — both the SDK's agents module and the
   web adapter consume the ONE `streamGlobalEvents` in `@houston/runtime-client`.
+- **The conversation VM cache is bounded** — `ConversationVmOutput` keeps folded
+  transcripts in an `LruCache` (`packages/sdk/src/lru.ts`), not an unbounded map,
+  so a multi-hour client's memory tracks its ACTIVE window, not total volume.
+  Past `SdkConfig.conversationCacheMax` (default `DEFAULT_CONVERSATION_CACHE_MAX`
+  = 50) the least-recently-published IDLE conversation is evicted and its retained
+  store snapshot cleared; it re-hydrates from history on the next `observe`. A
+  live conversation (running/streaming/queued/optimistic) or one with active
+  subscribers is pinned and never dropped. `turns.forget(conversationId)` is the
+  explicit drop for a closed/deleted conversation.
 
 **Still adapter-side (not yet SDK):** the control-plane surface
 (agents/activities/routines/skills/board/config CRUD — `client.ts`,

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -149,6 +149,23 @@ export const config = {
    */
   turnStallTimeoutMs: Number(env.HOUSTON_TURN_STALL_TIMEOUT_MS || 300_000),
 
+  /**
+   * Max live agent sessions kept hot in the in-memory conversation cache. Each
+   * cached session holds a backend session (pi/Claude) with its own in-memory
+   * transcript, so an unbounded cache grows without limit over a long-lived
+   * process. Past this bound the least-recently-used SETTLED session is disposed;
+   * it re-hydrates transparently from its on-disk transcript on the next turn (a
+   * session with a queued/running turn is never evicted). Ops can tune it.
+   */
+  sessionCacheMax: Number(env.HOUSTON_SESSION_CACHE_MAX || 40),
+  /**
+   * How long a settled session may sit idle before it is disposed (ms), even
+   * under the {@link sessionCacheMax} bound — reclaims memory for conversations
+   * a user walked away from. Re-hydrated from disk on next access. `0` (or a
+   * non-positive value) disables idle eviction, leaving only the size bound.
+   */
+  sessionCacheIdleMs: Number(env.HOUSTON_SESSION_CACHE_IDLE_MS || 1_800_000),
+
   version: "0.0.0",
 };
 

--- a/packages/runtime/src/lru.test.ts
+++ b/packages/runtime/src/lru.test.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "vitest";
+import { LruCache } from "./lru";
+
+/**
+ * The capacity-bounded, idle-expiring LRU that keeps a long-lived client's
+ * conversation caches from growing with total volume. The guarantees under test:
+ * least-recently-used eviction, pinned entries never dropped, onEvict fires so
+ * the value can be released, recency bumped by get/touch (but not peek), and
+ * idle sweep by an injected clock.
+ */
+
+test("evicts the least-recently-used entry past capacity and fires onEvict", () => {
+  const evicted: string[] = [];
+  const lru = new LruCache<string, { n: number }>({
+    capacity: 2,
+    onEvict: (k) => evicted.push(k),
+  });
+  lru.set("a", { n: 1 });
+  lru.set("b", { n: 2 });
+  lru.set("c", { n: 3 }); // over cap -> "a" (oldest) evicted
+
+  expect(lru.size).toBe(2);
+  expect(lru.has("a")).toBe(false);
+  expect(lru.has("b")).toBe(true);
+  expect(lru.has("c")).toBe(true);
+  expect(evicted).toEqual(["a"]);
+});
+
+test("get bumps recency so the refreshed entry survives eviction", () => {
+  const lru = new LruCache<string, { n: number }>({ capacity: 2 });
+  lru.set("a", { n: 1 });
+  lru.set("b", { n: 2 });
+  lru.get("a"); // "a" is now most-recent
+  lru.set("c", { n: 3 }); // "b" is now oldest -> evicted
+
+  expect(lru.has("a")).toBe(true);
+  expect(lru.has("b")).toBe(false);
+});
+
+test("peek does NOT bump recency", () => {
+  const lru = new LruCache<string, { n: number }>({ capacity: 2 });
+  lru.set("a", { n: 1 });
+  lru.set("b", { n: 2 });
+  lru.peek("a"); // read-only, "a" stays oldest
+  lru.set("c", { n: 3 });
+
+  expect(lru.has("a")).toBe(false);
+  expect(lru.has("b")).toBe(true);
+});
+
+test("a pinned entry is never evicted even when it is the oldest", () => {
+  const lru = new LruCache<string, { pinned: boolean }>({
+    capacity: 1,
+    isPinned: (_k, v) => v.pinned,
+  });
+  lru.set("live", { pinned: true });
+  lru.set("idle", { pinned: false }); // over cap, but "live" is pinned...
+
+  // "live" survives; the unpinned "idle" is what gets dropped once another idle
+  // entry arrives — a pin is honored over the size bound.
+  lru.set("idle2", { pinned: false });
+  expect(lru.has("live")).toBe(true);
+  expect(lru.has("idle")).toBe(false);
+});
+
+test("sweepIdle evicts entries untouched past idleMs, using the injected clock", () => {
+  let now = 0;
+  const evicted: string[] = [];
+  const lru = new LruCache<string, { n: number }>({
+    capacity: 100,
+    idleMs: 1000,
+    now: () => now,
+    onEvict: (k) => evicted.push(k),
+  });
+  lru.set("a", { n: 1 });
+  now = 500;
+  lru.set("b", { n: 2 });
+  now = 1200; // "a" is 1200ms idle (> 1000), "b" is 700ms idle (< 1000)
+  lru.sweepIdle();
+
+  expect(lru.has("a")).toBe(false);
+  expect(lru.has("b")).toBe(true);
+  expect(evicted).toEqual(["a"]);
+});
+
+test("sweepIdle spares a pinned entry no matter how idle", () => {
+  let now = 0;
+  const lru = new LruCache<string, { pinned: boolean }>({
+    capacity: 100,
+    idleMs: 100,
+    now: () => now,
+    isPinned: (_k, v) => v.pinned,
+  });
+  lru.set("busy", { pinned: true });
+  now = 10_000;
+  lru.sweepIdle();
+  expect(lru.has("busy")).toBe(true);
+});
+
+test("touch restamps both recency and the idle clock", () => {
+  let now = 0;
+  const lru = new LruCache<string, { n: number }>({
+    capacity: 100,
+    idleMs: 1000,
+    now: () => now,
+  });
+  lru.set("a", { n: 1 });
+  now = 900;
+  lru.touch("a"); // resets idle clock to 900
+  now = 1500; // 600ms since touch, under the 1000 window
+  lru.sweepIdle();
+  expect(lru.has("a")).toBe(true);
+});
+
+test("delete and clear drop entries without firing onEvict", () => {
+  const evicted: string[] = [];
+  const lru = new LruCache<string, { n: number }>({
+    capacity: 100,
+    onEvict: (k) => evicted.push(k),
+  });
+  lru.set("a", { n: 1 });
+  lru.set("b", { n: 2 });
+  expect(lru.delete("a")).toBe(true);
+  expect(lru.has("a")).toBe(false);
+  lru.clear();
+  expect(lru.size).toBe(0);
+  expect(evicted).toEqual([]); // explicit removal is the caller's own cleanup
+});

--- a/packages/runtime/src/lru.ts
+++ b/packages/runtime/src/lru.ts
@@ -1,0 +1,129 @@
+/**
+ * A capacity-bounded, optionally idle-expiring LRU map.
+ *
+ * A long-lived runtime process opens an unbounded number of agent sessions over
+ * its lifetime; a plain `Map` keyed by conversation would retain every one
+ * forever. This map keeps only the {@link LruOptions.capacity} most-recently
+ * used entries (plus any {@link LruOptions.isPinned pinned} ones, which are
+ * NEVER evicted — a session running or queuing a turn must not be disposed from
+ * under it). {@link LruOptions.onEvict} runs on eviction so the caller can
+ * release the evicted value (dispose a session, clear a snapshot). Eviction is
+ * safe only where the value can be transparently rebuilt on next access — here
+ * both callers re-hydrate from authoritative on-disk / history state.
+ *
+ * Recency is insertion order in the backing `Map`: {@link get}/{@link set}/
+ * {@link touch} move a key to the most-recent end, and eviction walks from the
+ * least-recent end. Values are objects (never `undefined`), so `undefined` is an
+ * unambiguous "absent".
+ *
+ * NOTE: an identical copy lives in `@houston/sdk`'s `src/lru.ts`. The two
+ * packages share no code dependency they could host a common util in (protocol
+ * is wire types only), so this small, standard structure is duplicated rather
+ * than forced through a boundary it doesn't belong in.
+ */
+export interface LruOptions<K, V> {
+  /** Max unpinned entries retained. Exceeding it evicts least-recently-used. */
+  capacity: number;
+  /**
+   * Optional idle expiry (ms). {@link sweepIdle} evicts every unpinned entry
+   * untouched for at least this long. Omit to disable idle eviction (cap only).
+   */
+  idleMs?: number;
+  /** Clock, injectable for tests. Defaults to {@link Date.now}. */
+  now?: () => number;
+  /** Pinned entries are never evicted (a live/in-flight value). */
+  isPinned?: (key: K, value: V) => boolean;
+  /** Runs after an entry is evicted (release/dispose the value). */
+  onEvict?: (key: K, value: V) => void;
+}
+
+export class LruCache<K, V> {
+  private readonly map = new Map<K, V>();
+  private readonly seen = new Map<K, number>();
+  private readonly now: () => number;
+
+  constructor(private readonly opts: LruOptions<K, V>) {
+    this.now = opts.now ?? Date.now;
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key);
+  }
+
+  /** Read WITHOUT bumping recency. */
+  peek(key: K): V | undefined {
+    return this.map.get(key);
+  }
+
+  /** Read and mark most-recently-used. */
+  get(key: K): V | undefined {
+    const v = this.map.get(key);
+    if (v !== undefined) this.touch(key);
+    return v;
+  }
+
+  set(key: K, value: V): void {
+    this.map.delete(key);
+    this.map.set(key, value);
+    this.seen.set(key, this.now());
+    this.evictOverflow();
+  }
+
+  /** Move `key` to most-recently-used and restamp its idle clock. */
+  touch(key: K): void {
+    const v = this.map.get(key);
+    if (v === undefined) return;
+    this.map.delete(key);
+    this.map.set(key, v);
+    this.seen.set(key, this.now());
+  }
+
+  delete(key: K): boolean {
+    this.seen.delete(key);
+    return this.map.delete(key);
+  }
+
+  clear(): void {
+    this.map.clear();
+    this.seen.clear();
+  }
+
+  values(): IterableIterator<V> {
+    return this.map.values();
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    return this.map.entries();
+  }
+
+  /** Evict every unpinned entry idle for at least {@link LruOptions.idleMs}. */
+  sweepIdle(): void {
+    const { idleMs } = this.opts;
+    if (idleMs === undefined) return;
+    const cutoff = this.now() - idleMs;
+    for (const [k, v] of [...this.map]) {
+      if ((this.seen.get(k) ?? 0) > cutoff) continue;
+      if (this.opts.isPinned?.(k, v)) continue;
+      this.evictEntry(k, v);
+    }
+  }
+
+  private evictOverflow(): void {
+    if (this.map.size <= this.opts.capacity) return;
+    for (const [k, v] of [...this.map]) {
+      if (this.map.size <= this.opts.capacity) break;
+      if (this.opts.isPinned?.(k, v)) continue;
+      this.evictEntry(k, v);
+    }
+  }
+
+  private evictEntry(k: K, v: V): void {
+    this.map.delete(k);
+    this.seen.delete(k);
+    this.opts.onEvict?.(k, v);
+  }
+}

--- a/packages/runtime/src/session/chat.ts
+++ b/packages/runtime/src/session/chat.ts
@@ -123,6 +123,11 @@ export async function runTurn(
   // mutating the same files concurrently (the Rust engine's workdir_locks
   // behavior). The conv.queue link resolves before the lock is requested, so
   // the two layers can't deadlock.
+  // Pin the session against idle/LRU eviction for this turn's whole queued-and-
+  // running lifetime — decremented in `finally` when it settles. Without this a
+  // turn parked in the queue behind the workdir lock (turnId not yet set) could
+  // have its session disposed by a concurrent conversation's eviction sweep.
+  conv.pending++;
   const run = conv.queue.then(() => {
     // Persist + announce the user message BEFORE taking the workdir lock, so a
     // brand-new conversation's message is durable and visible (GET /messages)
@@ -146,7 +151,11 @@ export async function runTurn(
   // Keep the queue chain alive past a turn. execTurn already surfaces its own
   // failure as an `error` event, so this guard never swallows a user-visible one.
   conv.queue = run.catch(() => {});
-  await run;
+  try {
+    await run;
+  } finally {
+    conv.pending--;
+  }
 }
 
 /**

--- a/packages/runtime/src/session/conversation-cache-evict.test.ts
+++ b/packages/runtime/src/session/conversation-cache-evict.test.ts
@@ -1,0 +1,152 @@
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { WireEvent } from "@houston/runtime-client";
+import { afterEach, expect, test, vi } from "vitest";
+import type {
+  CreateSessionOptions,
+  HarnessBackend,
+  HarnessSession,
+  ResolvedModel,
+} from "../backends/types";
+
+/**
+ * The live-session cache is LRU-bounded so a long-lived runtime's memory tracks
+ * its ACTIVE conversations, not every one ever opened. Under test: an idle
+ * session past the bound is disposed and TRANSPARENTLY re-hydrated from its
+ * on-disk transcript on next access (behavior-preserving), and a session with a
+ * queued/executing turn is NEVER evicted from under it.
+ *
+ * The bound is pinned to 1 (and idle TTL disabled) via env BEFORE the module
+ * graph loads — config reads env at import, and conversation-cache builds the
+ * bounded cache at module load.
+ */
+
+process.env.HOUSTON_DATA_DIR = mkdtempSync(
+  join(tmpdir(), "houston-evict-data-"),
+);
+process.env.HOUSTON_WORKSPACE_DIR = mkdtempSync(
+  join(tmpdir(), "houston-evict-ws-"),
+);
+process.env.HOUSTON_SESSION_CACHE_MAX = "1";
+process.env.HOUSTON_SESSION_CACHE_IDLE_MS = "0"; // size bound only, deterministic
+
+const modelState = vi.hoisted(() => ({ model: null as ResolvedModel | null }));
+vi.mock("../ai/providers", async (importOriginal) => {
+  const real = await importOriginal<typeof import("../ai/providers")>();
+  return {
+    ...real,
+    resolveModel: () => modelState.model,
+    activeEffort: () => null,
+  };
+});
+
+await import("./conversation-cache");
+const { getConversation, conversations } = await import("./conversation-cache");
+const { setDefaultBackend } = await import("../backends/registry");
+type Conversation = import("./conversation-cache").Conversation;
+
+const OPENAI: ResolvedModel = {
+  provider: "openai-codex",
+  id: "gpt-5-codex",
+  contextWindow: 400_000,
+};
+
+/**
+ * A session over a shared per-conversation "disk" (its `prompts` array): a
+ * session rebuilt for the same id re-attaches to the SAME transcript, modeling
+ * on-disk rehydration (pi's continueRecent / the Claude store). Records dispose.
+ */
+class DiskSession implements HarnessSession {
+  disposed = false;
+  private listeners = new Set<(e: WireEvent) => void>();
+  constructor(readonly prompts: string[]) {}
+  subscribe(l: (e: WireEvent) => void): () => void {
+    this.listeners.add(l);
+    return () => {
+      this.listeners.delete(l);
+    };
+  }
+  async prompt(text: string): Promise<void> {
+    this.prompts.push(text);
+  }
+  async abort(): Promise<void> {}
+  dispose(): void {
+    this.disposed = true;
+    this.listeners.clear();
+  }
+  async setModel(): Promise<void> {}
+  async compact(): Promise<void> {}
+  setThinkingLevel(): void {}
+  getContextUsage(): { tokens: number | null } {
+    return { tokens: 0 };
+  }
+}
+
+function diskBackend(
+  disk: Map<string, string[]>,
+  built: DiskSession[],
+): HarnessBackend {
+  return {
+    id: "pi",
+    async createSession(opts: CreateSessionOptions): Promise<HarnessSession> {
+      const transcript = disk.get(opts.conversationId) ?? [];
+      disk.set(opts.conversationId, transcript);
+      const s = new DiskSession(transcript);
+      built.push(s);
+      return s;
+    },
+  };
+}
+
+afterEach(() => {
+  modelState.model = null;
+  conversations.clear();
+});
+
+test("an idle session past the bound is disposed and re-hydrated from disk on next access", async () => {
+  modelState.model = OPENAI;
+  const disk = new Map<string, string[]>([["c1", ["prior turn"]]]);
+  const built: DiskSession[] = [];
+  setDefaultBackend(diskBackend(disk, built));
+
+  const conv1 = await getConversation("c1");
+  const session1 = conv1.session as DiskSession;
+  expect(session1.prompts).toContain("prior turn"); // rehydrated at first build
+
+  // Opening a second conversation with cap=1 evicts idle c1 — its session is
+  // disposed to release memory (the on-disk transcript is untouched).
+  await getConversation("c2");
+  expect(session1.disposed).toBe(true);
+  expect(conversations.has("c1")).toBe(false);
+  expect(conversations.size).toBe(1);
+
+  // Re-opening c1 transparently rebuilds a session re-attached to the SAME
+  // on-disk transcript — behavior is preserved, nothing is lost.
+  const conv1b = await getConversation("c1");
+  expect(conv1b.session).not.toBe(session1);
+  expect((conv1b.session as DiskSession).prompts).toContain("prior turn");
+  expect(built).toHaveLength(3); // c1, c2, c1-rebuilt
+});
+
+test("a session with an in-flight turn is never evicted from under it", async () => {
+  modelState.model = OPENAI;
+  const disk = new Map<string, string[]>();
+  const built: DiskSession[] = [];
+  setDefaultBackend(diskBackend(disk, built));
+
+  const conv1 = await getConversation("c1");
+  const session1 = conv1.session as DiskSession;
+  // Simulate a turn queued-and-running: chat.ts pins the session this way for a
+  // turn's whole lifetime (turnId while executing, pending while queued).
+  (conv1 as Conversation).pending = 1;
+  conv1.turnId = "turn-1";
+
+  // Several more conversations, each of which would evict the LRU tail (c1) —
+  // but c1 is busy, so it is retained past the size bound instead of dropped.
+  await getConversation("c2");
+  await getConversation("c3");
+
+  expect(session1.disposed).toBe(false);
+  expect(conversations.has("c1")).toBe(true);
+});

--- a/packages/runtime/src/session/conversation-cache.ts
+++ b/packages/runtime/src/session/conversation-cache.ts
@@ -11,6 +11,7 @@ import {
 } from "../backends/registry";
 import type { HarnessSession, ResolvedModel } from "../backends/types";
 import { config } from "../config";
+import { LruCache } from "../lru";
 import type { TurnPin } from "./exec-turn";
 import { SYSTEM_PROMPT } from "./resource-loader";
 import { buildToolSelection } from "./tool-selection";
@@ -182,10 +183,37 @@ export type Conversation = {
    * settles the turn it actually interrupts, not whatever a client guesses.
    */
   turnId?: string;
+  /**
+   * Turns queued-or-running for this conversation (incremented for a turn's
+   * whole lifetime by chat.ts `runTurn`, decremented when it settles). `> 0`
+   * pins the session against idle/LRU eviction so a session is NEVER disposed
+   * from under a queued turn — `turnId` alone would miss a turn parked in the
+   * queue behind the workdir lock, whose session is not yet executing.
+   */
+  pending: number;
 };
 
-/** Live sessions by conversation id (module state — one workspace per process). */
-export const conversations = new Map<string, Conversation>();
+/**
+ * A session cannot be evicted while it has a turn queued or executing — disposing
+ * it mid-turn would abort work the user is waiting on. Both signals are checked:
+ * `turnId` covers the executing turn, `pending` covers turns still queued.
+ */
+const isConvBusy = (conv: Conversation): boolean =>
+  (conv.pending ?? 0) > 0 || conv.turnId !== undefined;
+
+/**
+ * Live sessions by conversation id (module state — one workspace per process),
+ * LRU-bounded + idle-expiring so a long-lived runtime's memory tracks its ACTIVE
+ * conversations, not every one ever opened. An evicted session is disposed and
+ * transparently re-hydrated from its on-disk transcript on next access — behavior
+ * is preserved; only idle, turn-free sessions are ever evicted (see isConvBusy).
+ */
+export const conversations = new LruCache<string, Conversation>({
+  capacity: config.sessionCacheMax,
+  idleMs: config.sessionCacheIdleMs > 0 ? config.sessionCacheIdleMs : undefined,
+  isPinned: (_id, conv) => isConvBusy(conv),
+  onEvict: (_id, conv) => conv.session.dispose(),
+});
 
 export async function getConversation(
   id: string,
@@ -193,7 +221,12 @@ export async function getConversation(
   context?: ProvidedContext,
 ): Promise<Conversation> {
   const existing = conversations.get(id);
-  if (existing) return existing;
+  if (existing) {
+    // Reap sessions idle past the TTL on every access, so a quiet runtime still
+    // sheds memory between turns (get() above already marked `existing` fresh).
+    conversations.sweepIdle();
+    return existing;
+  }
 
   // The model the session is built with — recorded on the Conversation so a
   // later turn can detect when the active provider/model changed under it.
@@ -224,9 +257,14 @@ export async function getConversation(
     model: builtModel.id,
     backendId: backend.id,
     mode,
+    pending: 0,
     ...(context ? { context } : {}),
   };
+  // set() enforces the size bound (disposing the LRU tail if full); sweepIdle()
+  // then reaps any TTL-expired idle session. Both skip busy sessions, and the
+  // just-built `conv` is the most-recent entry, so it is never the one evicted.
   conversations.set(id, conv);
+  conversations.sweepIdle();
   return conv;
 }
 

--- a/packages/sdk/src/lru.test.ts
+++ b/packages/sdk/src/lru.test.ts
@@ -1,0 +1,128 @@
+import { expect, test } from "vitest";
+import { LruCache } from "./lru";
+
+/**
+ * The capacity-bounded, idle-expiring LRU that keeps a long-lived client's
+ * conversation caches from growing with total volume. The guarantees under test:
+ * least-recently-used eviction, pinned entries never dropped, onEvict fires so
+ * the value can be released, recency bumped by get/touch (but not peek), and
+ * idle sweep by an injected clock.
+ */
+
+test("evicts the least-recently-used entry past capacity and fires onEvict", () => {
+  const evicted: string[] = [];
+  const lru = new LruCache<string, { n: number }>({
+    capacity: 2,
+    onEvict: (k) => evicted.push(k),
+  });
+  lru.set("a", { n: 1 });
+  lru.set("b", { n: 2 });
+  lru.set("c", { n: 3 }); // over cap -> "a" (oldest) evicted
+
+  expect(lru.size).toBe(2);
+  expect(lru.has("a")).toBe(false);
+  expect(lru.has("b")).toBe(true);
+  expect(lru.has("c")).toBe(true);
+  expect(evicted).toEqual(["a"]);
+});
+
+test("get bumps recency so the refreshed entry survives eviction", () => {
+  const lru = new LruCache<string, { n: number }>({ capacity: 2 });
+  lru.set("a", { n: 1 });
+  lru.set("b", { n: 2 });
+  lru.get("a"); // "a" is now most-recent
+  lru.set("c", { n: 3 }); // "b" is now oldest -> evicted
+
+  expect(lru.has("a")).toBe(true);
+  expect(lru.has("b")).toBe(false);
+});
+
+test("peek does NOT bump recency", () => {
+  const lru = new LruCache<string, { n: number }>({ capacity: 2 });
+  lru.set("a", { n: 1 });
+  lru.set("b", { n: 2 });
+  lru.peek("a"); // read-only, "a" stays oldest
+  lru.set("c", { n: 3 });
+
+  expect(lru.has("a")).toBe(false);
+  expect(lru.has("b")).toBe(true);
+});
+
+test("a pinned entry is never evicted even when it is the oldest", () => {
+  const lru = new LruCache<string, { pinned: boolean }>({
+    capacity: 1,
+    isPinned: (_k, v) => v.pinned,
+  });
+  lru.set("live", { pinned: true });
+  lru.set("idle", { pinned: false }); // over cap, but "live" is pinned...
+
+  // "live" survives; the unpinned "idle" is what gets dropped once another idle
+  // entry arrives — a pin is honored over the size bound.
+  lru.set("idle2", { pinned: false });
+  expect(lru.has("live")).toBe(true);
+  expect(lru.has("idle")).toBe(false);
+});
+
+test("sweepIdle evicts entries untouched past idleMs, using the injected clock", () => {
+  let now = 0;
+  const evicted: string[] = [];
+  const lru = new LruCache<string, { n: number }>({
+    capacity: 100,
+    idleMs: 1000,
+    now: () => now,
+    onEvict: (k) => evicted.push(k),
+  });
+  lru.set("a", { n: 1 });
+  now = 500;
+  lru.set("b", { n: 2 });
+  now = 1200; // "a" is 1200ms idle (> 1000), "b" is 700ms idle (< 1000)
+  lru.sweepIdle();
+
+  expect(lru.has("a")).toBe(false);
+  expect(lru.has("b")).toBe(true);
+  expect(evicted).toEqual(["a"]);
+});
+
+test("sweepIdle spares a pinned entry no matter how idle", () => {
+  let now = 0;
+  const lru = new LruCache<string, { pinned: boolean }>({
+    capacity: 100,
+    idleMs: 100,
+    now: () => now,
+    isPinned: (_k, v) => v.pinned,
+  });
+  lru.set("busy", { pinned: true });
+  now = 10_000;
+  lru.sweepIdle();
+  expect(lru.has("busy")).toBe(true);
+});
+
+test("touch restamps both recency and the idle clock", () => {
+  let now = 0;
+  const lru = new LruCache<string, { n: number }>({
+    capacity: 100,
+    idleMs: 1000,
+    now: () => now,
+  });
+  lru.set("a", { n: 1 });
+  now = 900;
+  lru.touch("a"); // resets idle clock to 900
+  now = 1500; // 600ms since touch, under the 1000 window
+  lru.sweepIdle();
+  expect(lru.has("a")).toBe(true);
+});
+
+test("delete and clear drop entries without firing onEvict", () => {
+  const evicted: string[] = [];
+  const lru = new LruCache<string, { n: number }>({
+    capacity: 100,
+    onEvict: (k) => evicted.push(k),
+  });
+  lru.set("a", { n: 1 });
+  lru.set("b", { n: 2 });
+  expect(lru.delete("a")).toBe(true);
+  expect(lru.has("a")).toBe(false);
+  lru.clear();
+  expect(lru.size).toBe(0);
+  expect(evicted).toEqual([]); // explicit removal is the caller's own cleanup
+});

--- a/packages/sdk/src/lru.ts
+++ b/packages/sdk/src/lru.ts
@@ -1,0 +1,129 @@
+/**
+ * A capacity-bounded, optionally idle-expiring LRU map.
+ *
+ * Long-lived clients touch an unbounded number of conversations over a
+ * multi-hour session; a plain `Map` keyed by conversation would retain every
+ * one forever. This map keeps only the {@link LruOptions.capacity} most-recently
+ * used entries (plus any {@link LruOptions.isPinned pinned} ones, which are
+ * NEVER evicted — a live/in-flight entry must not be dropped from under an
+ * active turn). {@link LruOptions.onEvict} runs on eviction so the caller can
+ * release the evicted value (dispose a session, clear a snapshot). Eviction is
+ * safe only where the value can be transparently rebuilt on next access — here
+ * both callers re-hydrate from authoritative on-disk / history state.
+ *
+ * Recency is insertion order in the backing `Map`: {@link get}/{@link set}/
+ * {@link touch} move a key to the most-recent end, and eviction walks from the
+ * least-recent end. Values are objects (never `undefined`), so `undefined` is an
+ * unambiguous "absent".
+ *
+ * NOTE: an identical copy lives in `@houston/runtime`'s `src/lru.ts`. The two
+ * packages share no code dependency they could host a common util in (protocol
+ * is wire types only), so this small, standard structure is duplicated rather
+ * than forced through a boundary it doesn't belong in.
+ */
+export interface LruOptions<K, V> {
+  /** Max unpinned entries retained. Exceeding it evicts least-recently-used. */
+  capacity: number;
+  /**
+   * Optional idle expiry (ms). {@link sweepIdle} evicts every unpinned entry
+   * untouched for at least this long. Omit to disable idle eviction (cap only).
+   */
+  idleMs?: number;
+  /** Clock, injectable for tests. Defaults to {@link Date.now}. */
+  now?: () => number;
+  /** Pinned entries are never evicted (a live/in-flight value). */
+  isPinned?: (key: K, value: V) => boolean;
+  /** Runs after an entry is evicted (release/dispose the value). */
+  onEvict?: (key: K, value: V) => void;
+}
+
+export class LruCache<K, V> {
+  private readonly map = new Map<K, V>();
+  private readonly seen = new Map<K, number>();
+  private readonly now: () => number;
+
+  constructor(private readonly opts: LruOptions<K, V>) {
+    this.now = opts.now ?? Date.now;
+  }
+
+  get size(): number {
+    return this.map.size;
+  }
+
+  has(key: K): boolean {
+    return this.map.has(key);
+  }
+
+  /** Read WITHOUT bumping recency. */
+  peek(key: K): V | undefined {
+    return this.map.get(key);
+  }
+
+  /** Read and mark most-recently-used. */
+  get(key: K): V | undefined {
+    const v = this.map.get(key);
+    if (v !== undefined) this.touch(key);
+    return v;
+  }
+
+  set(key: K, value: V): void {
+    this.map.delete(key);
+    this.map.set(key, value);
+    this.seen.set(key, this.now());
+    this.evictOverflow();
+  }
+
+  /** Move `key` to most-recently-used and restamp its idle clock. */
+  touch(key: K): void {
+    const v = this.map.get(key);
+    if (v === undefined) return;
+    this.map.delete(key);
+    this.map.set(key, v);
+    this.seen.set(key, this.now());
+  }
+
+  delete(key: K): boolean {
+    this.seen.delete(key);
+    return this.map.delete(key);
+  }
+
+  clear(): void {
+    this.map.clear();
+    this.seen.clear();
+  }
+
+  values(): IterableIterator<V> {
+    return this.map.values();
+  }
+
+  entries(): IterableIterator<[K, V]> {
+    return this.map.entries();
+  }
+
+  /** Evict every unpinned entry idle for at least {@link LruOptions.idleMs}. */
+  sweepIdle(): void {
+    const { idleMs } = this.opts;
+    if (idleMs === undefined) return;
+    const cutoff = this.now() - idleMs;
+    for (const [k, v] of [...this.map]) {
+      if ((this.seen.get(k) ?? 0) > cutoff) continue;
+      if (this.opts.isPinned?.(k, v)) continue;
+      this.evictEntry(k, v);
+    }
+  }
+
+  private evictOverflow(): void {
+    if (this.map.size <= this.opts.capacity) return;
+    for (const [k, v] of [...this.map]) {
+      if (this.map.size <= this.opts.capacity) break;
+      if (this.opts.isPinned?.(k, v)) continue;
+      this.evictEntry(k, v);
+    }
+  }
+
+  private evictEntry(k: K, v: V): void {
+    this.map.delete(k);
+    this.seen.delete(k);
+    this.opts.onEvict?.(k, v);
+  }
+}

--- a/packages/sdk/src/modules/turns/index.ts
+++ b/packages/sdk/src/modules/turns/index.ts
@@ -37,7 +37,9 @@ export function createTurnsModule(
   ctx: ModuleContext,
   persistBoardStatus: BoardStatusPersister,
 ) {
-  const vm = new ConversationVmOutput(ctx.store);
+  const vm = new ConversationVmOutput(ctx.store, {
+    cacheMax: ctx.config.conversationCacheMax,
+  });
   // The always-on outputs every turn drives: the conversation VM, plus a board-
   // card persister (the SDK-path counterpart to the web adapter's bus output) so
   // a native shell that never calls `addOutput` still leaves a settled mission
@@ -89,6 +91,16 @@ export function createTurnsModule(
      * {@link buildAttachmentText}.
      */
     saveAttachments: attachments.save,
+    /**
+     * Drop a conversation's folded transcript from the in-memory VM cache (and
+     * its retained snapshot) — call when a surface closes or deletes a
+     * conversation so its memory is released at once. Re-hydrates from history on
+     * the next {@link observe}. Idle conversations are also evicted automatically
+     * by the LRU bound; this is the explicit seam for a known-done conversation.
+     */
+    forget(conversationId: string, agentId?: string): void {
+      vm.forget(agentId ?? "", conversationId);
+    },
     /**
      * Attach an extra {@link FeedOutput} that every subsequent turn also drives
      * (e.g. a host UI bus). Returns a detach function.
@@ -161,6 +173,7 @@ export {
   type ConversationVM,
   ConversationVmOutput,
   conversationScope,
+  DEFAULT_CONVERSATION_CACHE_MAX,
   type FeedItemVM,
   type QueuedMessageVM,
 } from "./vm-output";

--- a/packages/sdk/src/modules/turns/vm-output-evict.test.ts
+++ b/packages/sdk/src/modules/turns/vm-output-evict.test.ts
@@ -1,0 +1,100 @@
+import { expect, test } from "vitest";
+import { ScopeStore } from "../../store";
+import {
+  type ConversationVM,
+  ConversationVmOutput,
+  conversationScope,
+} from "./vm-output";
+
+/**
+ * The conversation VM cache is LRU-bounded so a long-lived client's memory
+ * tracks its ACTIVE window, not total message volume. These pin the guarantees:
+ * an idle conversation past the bound is evicted AND its retained snapshot
+ * cleared; a live/streaming/queued or actively-subscribed conversation is never
+ * evicted; `forget` is an explicit drop; and an evicted conversation re-hydrates
+ * from history (authoritative) on re-seed.
+ */
+
+const frame = (text: string) => ({ feed_type: "assistant_text", data: text });
+const snap = (store: ScopeStore, agent: string, key: string) =>
+  store.getSnapshot(conversationScope(agent, key)) as
+    | ConversationVM
+    | undefined;
+
+test("an idle conversation past the cache bound is evicted and its snapshot cleared", () => {
+  const store = new ScopeStore();
+  const vm = new ConversationVmOutput(store, { cacheMax: 2 });
+
+  vm.seedHistory("a", "c1", [frame("one")]);
+  vm.seedHistory("a", "c2", [frame("two")]);
+  vm.seedHistory("a", "c3", [frame("three")]); // over cap -> c1 (oldest, idle) out
+
+  // The evicted conversation's snapshot — a full copy of its feed — is released,
+  // not left dangling in the store. c2/c3 stay hot.
+  expect(snap(store, "a", "c1")).toBeUndefined();
+  expect(snap(store, "a", "c2")?.feed).toHaveLength(1);
+  expect(snap(store, "a", "c3")?.feed).toHaveLength(1);
+});
+
+test("a RUNNING conversation is never evicted, even as the least-recently-used", () => {
+  const store = new ScopeStore();
+  const vm = new ConversationVmOutput(store, { cacheMax: 1 });
+
+  vm.seedHistory("a", "c1", [frame("hi")]);
+  vm.sessionStatus("a", "c1", "running"); // c1 is now live -> pinned
+  vm.seedHistory("a", "c2", [frame("yo")]); // would evict c1 by age, but it's live
+
+  // Live state is retained past the size bound rather than silently dropped.
+  expect(snap(store, "a", "c1")?.running).toBe(true);
+  expect(snap(store, "a", "c2")).toBeDefined();
+});
+
+test("a conversation with a queued message is not evicted", () => {
+  const store = new ScopeStore();
+  const vm = new ConversationVmOutput(store, { cacheMax: 1 });
+
+  vm.seedHistory("a", "c1", [frame("hi")]);
+  vm.setQueued("a", "c1", [{ id: "q1", text: "later" }]); // queued -> pinned
+  vm.seedHistory("a", "c2", [frame("yo")]);
+
+  expect(snap(store, "a", "c1")?.queued).toHaveLength(1);
+});
+
+test("an actively-subscribed conversation is not evicted (a viewed chat stays)", () => {
+  const store = new ScopeStore();
+  const vm = new ConversationVmOutput(store, { cacheMax: 1 });
+
+  vm.seedHistory("a", "c1", [frame("hi")]);
+  const unsub = store.subscribe(conversationScope("a", "c1"), () => {});
+  vm.seedHistory("a", "c2", [frame("yo")]); // c1 is idle but subscribed -> pinned
+
+  expect(snap(store, "a", "c1")?.feed).toHaveLength(1);
+  unsub();
+});
+
+test("forget drops a conversation's folded state and its retained snapshot", () => {
+  const store = new ScopeStore();
+  const vm = new ConversationVmOutput(store, { cacheMax: 50 });
+
+  vm.seedHistory("a", "c1", [frame("one"), frame("two")]);
+  expect(snap(store, "a", "c1")?.feed).toHaveLength(2);
+
+  vm.forget("a", "c1");
+  expect(snap(store, "a", "c1")).toBeUndefined();
+});
+
+test("an evicted conversation re-hydrates from history on re-seed (behavior-preserving)", () => {
+  const store = new ScopeStore();
+  const vm = new ConversationVmOutput(store, { cacheMax: 1 });
+
+  vm.seedHistory("a", "c1", [frame("one"), frame("two")]);
+  vm.seedHistory("a", "c2", [frame("other")]); // evicts idle c1
+  expect(snap(store, "a", "c1")).toBeUndefined();
+
+  // Re-opening the conversation (observe -> seedHistory) rebuilds it whole from
+  // authoritative history — the transcript is not lost, just re-loaded.
+  vm.seedHistory("a", "c1", [frame("one"), frame("two")]);
+  const feed = snap(store, "a", "c1")?.feed;
+  expect(feed).toHaveLength(2);
+  expect(feed?.map((f) => f.data)).toEqual(["one", "two"]);
+});

--- a/packages/sdk/src/modules/turns/vm-output.ts
+++ b/packages/sdk/src/modules/turns/vm-output.ts
@@ -1,4 +1,5 @@
 import type { PendingInteraction } from "@houston/runtime-client";
+import { LruCache } from "../../lru";
 import type { ScopeStore } from "../../store";
 import type {
   BoardStatus,
@@ -117,6 +118,27 @@ const FINAL_OF: Record<string, string> = {
 };
 
 /**
+ * How many conversations' folded transcripts are retained in memory at once.
+ * Each {@link ConvState} holds a conversation's ENTIRE feed, so an unbounded map
+ * would grow with total message volume across a multi-hour session. The
+ * least-recently-published IDLE conversation is evicted past this bound and
+ * re-hydrated from authoritative history on next {@link ConversationVmOutput.observe}.
+ * Overridable via the SDK config; the default keeps a generous working window.
+ */
+export const DEFAULT_CONVERSATION_CACHE_MAX = 50;
+
+/**
+ * A conversation that must NOT be evicted: a running turn, an open stream, a
+ * queued message, or an unconfirmed optimistic send. Dropping any of these would
+ * lose in-flight state that history cannot yet re-hydrate (it is not settled).
+ */
+const isConvLive = (s: ConvState): boolean =>
+  s.sessionStatus === "running" ||
+  s.streaming.size > 0 ||
+  s.queued.length > 0 ||
+  s.feed.some((f) => f.pending === true);
+
+/**
  * The scope a conversation's VM is published on. Agent-qualified: session keys
  * are unique only within one agent — the same identity `streamKey` uses — so
  * the scope carries BOTH, and the encoding stays in here so no caller ever
@@ -129,9 +151,27 @@ export const conversationScope = (
   `conversation/${encodeURIComponent(agentPath)}/${encodeURIComponent(sessionKey)}`;
 
 export class ConversationVmOutput implements FeedOutput {
-  private readonly convs = new Map<string, ConvState>();
+  /**
+   * Folded conversations, LRU-bounded so a long-lived client's memory tracks its
+   * ACTIVE window, not total message volume. A live conversation (running /
+   * streaming / queued / optimistic) is pinned, as is one a surface is actively
+   * subscribed to — only settled, un-viewed conversations are evicted, and each
+   * re-hydrates from history on next {@link observe}. Eviction also clears the
+   * scope's retained snapshot (a full copy of the feed) so the whole conversation
+   * is released, not just half.
+   */
+  private readonly convs: LruCache<string, ConvState>;
 
-  constructor(private readonly store: ScopeStore) {}
+  constructor(
+    private readonly store: ScopeStore,
+    opts?: { cacheMax?: number },
+  ) {
+    this.convs = new LruCache<string, ConvState>({
+      capacity: opts?.cacheMax ?? DEFAULT_CONVERSATION_CACHE_MAX,
+      isPinned: (key, s) => isConvLive(s) || this.store.hasSubscribers(key),
+      onEvict: (key) => this.store.clear(key),
+    });
+  }
 
   private state(agentPath: string, sessionKey: string): ConvState {
     const key = conversationScope(agentPath, sessionKey);
@@ -149,6 +189,19 @@ export class ConversationVmOutput implements FeedOutput {
       this.convs.set(key, s);
     }
     return s;
+  }
+
+  /**
+   * Explicitly drop a conversation's folded state and its retained snapshot —
+   * the eviction seam a surface calls when it closes/deletes a conversation, so
+   * its transcript is released immediately rather than waiting for the LRU to
+   * age it out. Unlike automatic eviction this is unconditional: the caller owns
+   * the decision. A later {@link observe} re-hydrates it from history.
+   */
+  forget(agentPath: string, sessionKey: string): void {
+    const key = conversationScope(agentPath, sessionKey);
+    this.convs.delete(key);
+    this.store.clear(key);
   }
 
   /**
@@ -333,6 +386,10 @@ export class ConversationVmOutput implements FeedOutput {
       pendingInteraction: s.pendingInteraction,
       ...(s.queued.length ? { queued: s.queued.map((q) => ({ ...q })) } : {}),
     };
-    this.store.publish(conversationScope(agentPath, sessionKey), snapshot);
+    const scope = conversationScope(agentPath, sessionKey);
+    this.store.publish(scope, snapshot);
+    // Every publish makes this the most-recently-published conversation, so the
+    // LRU evicts by real activity — the chats a client is working in stay hot.
+    this.convs.touch(scope);
   }
 }

--- a/packages/sdk/src/ports.ts
+++ b/packages/sdk/src/ports.ts
@@ -78,4 +78,12 @@ export interface SdkConfig {
   baseUrl: string;
   /** Injected capabilities. */
   ports: SdkPorts;
+  /**
+   * Max conversations whose folded transcripts are retained in memory at once
+   * (the reactive `conversation/<id>` VM cache). Settled, un-viewed
+   * conversations past this bound are evicted and re-hydrated from history on
+   * re-open. Defaults to `DEFAULT_CONVERSATION_CACHE_MAX`; raise it for a client
+   * that keeps many chats hot, lower it under tight memory.
+   */
+  conversationCacheMax?: number;
 }

--- a/packages/sdk/src/store.ts
+++ b/packages/sdk/src/store.ts
@@ -54,6 +54,23 @@ export class ScopeStore {
     return this.snapshots.get(scope);
   }
 
+  /** Whether any listener is currently subscribed to `scope`. */
+  hasSubscribers(scope: string): boolean {
+    return (this.subscribers.get(scope)?.size ?? 0) > 0;
+  }
+
+  /**
+   * Drop the retained snapshot for `scope`, freeing the memory it held. Used
+   * when a scope's owner evicts/forgets its state (a bounded cache dropping an
+   * idle conversation): the snapshot is a full copy of that state, so evicting
+   * the source without clearing here would leak the larger half. Notifies
+   * nobody — callers only clear a scope with no live subscribers, and the next
+   * `publish` (a re-seed from authoritative history) restores it.
+   */
+  clear(scope: string): void {
+    this.snapshots.delete(scope);
+  }
+
   /**
    * Store `snapshot` as the latest value for `scope` and synchronously notify
    * every current subscriber of that scope.


### PR DESCRIPTION
## Problem — two long-lived caches grew without eviction

An audit found two feed/session caches that retain state for **every
conversation ever touched**, so a multi-hour, many-conversation session's memory
tracks total message volume rather than the active window (MEDIUM/reliability):

1. **SDK** `ConversationVmOutput.convs` (`packages/sdk/src/modules/turns/vm-output.ts`)
   kept one `ConvState` per conversation forever, each holding the **entire**
   folded transcript (`feed: FeedItemVM[]`). There was no forget/evict API. The
   retained `ScopeStore` snapshot held a **second** full copy of the feed.
2. **Runtime** `conversations` map (`packages/runtime/src/session/conversation-cache.ts`)
   kept one live backend session (pi/Claude, with its own in-memory transcript)
   per conversation ever opened — unbounded over the process lifetime.

(`HoustonSdk.clients` was confirmed out of scope: bounded by agent count and
GC'd on dispose.)

## Fix — bounded caches with a shared-shape `LruCache`

New `LruCache` (`packages/sdk/src/lru.ts` + `packages/runtime/src/lru.ts`): LRU
eviction, optional idle TTL, an `isPinned` predicate (live entries are **never**
evicted), and an `onEvict` release hook. The two packages share no dependency
that could host a common util (protocol is wire types only), so this small
standard structure is duplicated rather than forced through a boundary — noted in
each file.

**SDK** — `convs` is LRU-bounded by `SdkConfig.conversationCacheMax` (default
`DEFAULT_CONVERSATION_CACHE_MAX` = 50). Eviction picks the least-recently-**published**
IDLE conversation and also clears its retained store snapshot (releasing the
second copy). Pinned = live (running / open stream / queued / unconfirmed
optimistic) **or** actively subscribed (a viewed chat), so nothing in-flight or
on-screen is dropped. New `ConversationVmOutput.forget()` (exposed as
`turns.forget(conversationId)`) is the explicit drop for a closed/deleted
conversation. Evicted conversations re-seed from history on the next `observe`.

**Runtime** — `conversations` is an `LruCache` bounded by
`HOUSTON_SESSION_CACHE_MAX` (default 40) and `HOUSTON_SESSION_CACHE_IDLE_MS`
(default 30 min; `0` disables). A settled session past the bound is disposed and
transparently rebuilt from its on-disk transcript on the next `getConversation`.
Pinned = a new `Conversation.pending` counter (maintained across a turn's whole
queued-and-running lifetime by `chat.ts:runTurn`) **or** `conv.turnId` set, so a
session is never disposed from under a queued/executing turn.

## Re-hydration safety

Eviction is behavior-preserving because history is authoritative: the SDK
re-seeds a dropped conversation from `getHistory` on re-observe, and the runtime
backend reopens the persisted session by id (pi `continueRecent` / the Claude
store) so prior turns rehydrate. Eviction touches **no** on-disk state.

## No live/in-flight session evicted

- SDK: `isConvLive` (running/streaming/queued/optimistic) OR `store.hasSubscribers`
  pins the entry; a pinned entry is retained past the size bound rather than dropped.
- Runtime: `isConvBusy` = `pending > 0 || turnId !== undefined`; `pending` is
  incremented before a turn is queued and decremented in `finally`, covering a
  turn parked in the queue behind the workdir lock (where `turnId` isn't set yet).

## Tests

- `packages/{sdk,runtime}/src/lru.test.ts` — LRU eviction, pin skip, idle sweep
  (injected clock), onEvict, get/touch vs peek recency, delete/clear.
- `packages/sdk/src/modules/turns/vm-output-evict.test.ts` — idle evicted +
  snapshot cleared; running / queued / subscribed never evicted; `forget` drops
  state + snapshot; re-seed re-hydrates from history.
- `packages/runtime/src/session/conversation-cache-evict.test.ts` — idle session
  disposed + re-hydrated from a shared on-disk transcript; a busy session never
  evicted from under it.

Scoped checks: `@houston/sdk` typecheck + 320 tests green; `@houston/runtime`
typecheck + 600 tests green; Biome clean on all touched files (pre-commit hook
also ran the full-workspace typecheck — green).

Audit origin: unbounded-memory finding, two related sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)