### PR TITLE
perf(runtime-client): make ReplayLog append amortized O(1) with a ring buffer

### DIFF
--- a/packages/runtime-client/src/replay.test.ts
+++ b/packages/runtime-client/src/replay.test.ts
@@ -5,6 +5,7 @@ import {
   parseResumeCursor,
   REPLAY_BUFFER_CAP,
   ReplayLog,
+  type SequencedFrame,
 } from "./replay";
 import type { WireEvent } from "./types";
 
@@ -116,6 +117,58 @@ test("clear empties the buffer but keeps the watermark (counter never resets)", 
   expect(log.replayAfter(2)).toEqual([]); // caught up → nothing to send
   expect(log.replayAfter(1)).toBeNull(); // inside the cleared turn → resync
   expect(log.append(text("next turn")).seq).toBe(3);
+});
+
+// ---------------------------------------------------------------------------
+// Behavior lock — the ring buffer must preserve these EXACTLY (append past CAP
+// keeps the last CAP frames in ascending order; replayAfter is a suffix scan
+// with the same boundary semantics as the shift-buffer it replaced).
+// ---------------------------------------------------------------------------
+
+test("append past CAP keeps exactly the last CAP frames, ascending + consecutive", () => {
+  const log = new ReplayLog();
+  const total = REPLAY_BUFFER_CAP * 3 + 7; // well past several overwrites
+  for (let i = 1; i <= total; i++) log.append(text(`${i}`));
+  expect(log.watermark).toBe(total);
+
+  // The whole window is servable from just below its oldest frame.
+  const window = log.replayAfter(total - REPLAY_BUFFER_CAP);
+  expect(window).not.toBeNull();
+  const frames = window as SequencedFrame[];
+  expect(frames).toHaveLength(REPLAY_BUFFER_CAP);
+  // Oldest is watermark-CAP+1, newest is watermark, strictly +1 throughout.
+  expect(frames[0].seq).toBe(total - REPLAY_BUFFER_CAP + 1);
+  expect(frames.at(-1)?.seq).toBe(total);
+  for (let i = 0; i < frames.length; i++) {
+    expect(frames[i].seq).toBe(total - REPLAY_BUFFER_CAP + 1 + i);
+    expect(frames[i].data).toBe(`${total - REPLAY_BUFFER_CAP + 1 + i}`);
+  }
+  // One below the window's oldest is unserviceable.
+  expect(log.replayAfter(total - REPLAY_BUFFER_CAP - 1)).toBeNull();
+});
+
+test("replayAfter boundary sweep across a full window: below / at each / above", () => {
+  const log = new ReplayLog();
+  const total = REPLAY_BUFFER_CAP + 250; // window is seqs [251 .. total]
+  for (let i = 1; i <= total; i++) log.append(text(`${i}`));
+  const min = total - REPLAY_BUFFER_CAP + 1; // oldest buffered seq (251)
+
+  // Below the window → resync (null).
+  expect(log.replayAfter(min - 2)).toBeNull();
+  // Exactly one below the oldest → the entire window.
+  expect(log.replayAfter(min - 1)).toHaveLength(REPLAY_BUFFER_CAP);
+  // At each interior frame → the strict suffix after that seq.
+  for (const cut of [min, min + 1, total - 2, total - 1]) {
+    const suffix = log.replayAfter(cut);
+    expect(suffix).not.toBeNull();
+    const s = suffix as SequencedFrame[];
+    expect(s).toHaveLength(total - cut);
+    expect(s[0]?.seq).toBe(cut + 1);
+    expect(s.at(-1)?.seq).toBe(total);
+  }
+  // At the watermark → empty; above it → resync (null).
+  expect(log.replayAfter(total)).toEqual([]);
+  expect(log.replayAfter(total + 1)).toBeNull();
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/runtime-client/src/replay.ts
+++ b/packages/runtime-client/src/replay.ts
@@ -1,3 +1,4 @@
+import { RingBuffer } from "./ring-buffer";
 import type { WireEventType, WireFrame } from "./types";
 
 /**
@@ -28,7 +29,11 @@ export function isTerminalFrame(type: WireEventType): boolean {
 
 export class ReplayLog {
   #watermark: number;
-  #buffer: SequencedFrame[] = [];
+  // Fixed-size window of the in-flight turn's frames, in ascending seq order.
+  // A ring buffer (not a shift-on-overflow array) keeps `append` amortized
+  // O(1): once full it overwrites the oldest frame instead of memmoving the
+  // whole 1024-element window on every published frame.
+  #buffer = new RingBuffer<SequencedFrame>(REPLAY_BUFFER_CAP);
 
   /** `watermark` seeds the counter (e.g. from a persisted snapshot); frames start at watermark+1. */
   constructor(watermark = 0) {
@@ -52,7 +57,6 @@ export class ReplayLog {
     this.#watermark = seq;
     const frame: SequencedFrame = { ...event, seq };
     this.#buffer.push(frame);
-    if (this.#buffer.length > REPLAY_BUFFER_CAP) this.#buffer.shift();
     return frame;
   }
 
@@ -65,14 +69,30 @@ export class ReplayLog {
   replayAfter(after: number): SequencedFrame[] | null {
     if (after > this.#watermark) return null;
     if (after === this.#watermark) return [];
-    const first = this.#buffer[0]?.seq ?? this.#watermark + 1;
+    const first = this.#buffer.at(0)?.seq ?? this.#watermark + 1;
     if (after < first - 1) return null;
-    return this.#buffer.filter((f) => f.seq > after);
+    // Frames are buffered in ascending seq order, so the frames still needed
+    // are a contiguous suffix: binary-search its start and copy from there,
+    // instead of scanning the whole window.
+    return this.#buffer.sliceFrom(this.#firstIndexAfter(after));
+  }
+
+  /** Lowest buffer index whose frame.seq > `after` (frames are seq-ascending). */
+  #firstIndexAfter(after: number): number {
+    let lo = 0;
+    let hi = this.#buffer.length; // exclusive; frames [lo, hi) are the window
+    while (lo < hi) {
+      const mid = (lo + hi) >>> 1;
+      // mid < length, so `at(mid)` is always defined here.
+      if ((this.#buffer.at(mid) as SequencedFrame).seq > after) hi = mid;
+      else lo = mid + 1;
+    }
+    return lo;
   }
 
   /** Drop the buffered frames (turn ended). The seq counter is NOT reset. */
   clear(): void {
-    this.#buffer = [];
+    this.#buffer.clear();
   }
 }
 

--- a/packages/runtime-client/src/ring-buffer.test.ts
+++ b/packages/runtime-client/src/ring-buffer.test.ts
@@ -1,0 +1,74 @@
+import { expect, test } from "vitest";
+import { RingBuffer } from "./ring-buffer";
+
+test("rejects a non-positive or non-integer capacity", () => {
+  expect(() => new RingBuffer(0)).toThrow(RangeError);
+  expect(() => new RingBuffer(-1)).toThrow(RangeError);
+  expect(() => new RingBuffer(2.5)).toThrow(RangeError);
+});
+
+test("fills up to capacity in insertion order", () => {
+  const rb = new RingBuffer<number>(3);
+  expect(rb.length).toBe(0);
+  rb.push(1);
+  rb.push(2);
+  expect(rb.length).toBe(2);
+  expect(rb.sliceFrom(0)).toEqual([1, 2]);
+  rb.push(3);
+  expect(rb.length).toBe(3);
+  expect(rb.sliceFrom(0)).toEqual([1, 2, 3]);
+});
+
+test("once full, push overwrites the oldest and keeps order", () => {
+  const rb = new RingBuffer<number>(3);
+  for (const n of [1, 2, 3, 4, 5]) rb.push(n);
+  expect(rb.length).toBe(3); // never exceeds capacity
+  expect(rb.sliceFrom(0)).toEqual([3, 4, 5]); // oldest two dropped
+  rb.push(6);
+  expect(rb.sliceFrom(0)).toEqual([4, 5, 6]);
+});
+
+test("at() reads by logical index; out of range is undefined", () => {
+  const rb = new RingBuffer<string>(2);
+  rb.push("a");
+  rb.push("b");
+  rb.push("c"); // wraps: window is now [b, c]
+  expect(rb.at(0)).toBe("b");
+  expect(rb.at(1)).toBe("c");
+  expect(rb.at(-1)).toBeUndefined();
+  expect(rb.at(2)).toBeUndefined();
+});
+
+test("sliceFrom copies a suffix; a negative start clamps to 0", () => {
+  const rb = new RingBuffer<number>(4);
+  for (const n of [10, 20, 30, 40, 50]) rb.push(n); // window [20,30,40,50]
+  expect(rb.sliceFrom(2)).toEqual([40, 50]);
+  expect(rb.sliceFrom(4)).toEqual([]); // at/after the end
+  expect(rb.sliceFrom(-3)).toEqual([20, 30, 40, 50]);
+  // The returned array is a copy, not a live view.
+  const copy = rb.sliceFrom(0);
+  copy.push(999);
+  expect(rb.sliceFrom(0)).toEqual([20, 30, 40, 50]);
+});
+
+test("clear empties the buffer and lets it refill from scratch", () => {
+  const rb = new RingBuffer<number>(3);
+  for (const n of [1, 2, 3, 4]) rb.push(n);
+  rb.clear();
+  expect(rb.length).toBe(0);
+  expect(rb.sliceFrom(0)).toEqual([]);
+  expect(rb.at(0)).toBeUndefined();
+  rb.push(7);
+  rb.push(8);
+  expect(rb.sliceFrom(0)).toEqual([7, 8]);
+});
+
+test("stays correct across many wraps (invariant: length capped, order kept)", () => {
+  const cap = 8;
+  const rb = new RingBuffer<number>(cap);
+  const total = cap * 50 + 3;
+  for (let i = 1; i <= total; i++) rb.push(i);
+  expect(rb.length).toBe(cap);
+  const expected = Array.from({ length: cap }, (_, k) => total - cap + 1 + k);
+  expect(rb.sliceFrom(0)).toEqual(expected);
+});

--- a/packages/runtime-client/src/ring-buffer.ts
+++ b/packages/runtime-client/src/ring-buffer.ts
@@ -1,0 +1,66 @@
+/**
+ * A fixed-capacity ring buffer: `push` is amortized O(1) and, once full,
+ * overwrites the oldest element in place — no array `shift` (which re-indexes
+ * the whole backing array on every call). Elements are presented in insertion
+ * order: logical index 0 is the oldest still buffered.
+ *
+ * Deliberately tiny and generic (no seq/domain knowledge) so it can back any
+ * fixed-size "last N in order" window; `ReplayLog` is its first user.
+ */
+export class RingBuffer<T> {
+  readonly capacity: number;
+  #store: (T | undefined)[];
+  /** Backing index of logical element 0. */
+  #head = 0;
+  #length = 0;
+
+  constructor(capacity: number) {
+    if (!Number.isInteger(capacity) || capacity <= 0) {
+      throw new RangeError(
+        `RingBuffer capacity must be a positive integer, got ${capacity}`,
+      );
+    }
+    this.capacity = capacity;
+    this.#store = new Array<T | undefined>(capacity);
+  }
+
+  /** How many elements are currently buffered (0..capacity). */
+  get length(): number {
+    return this.#length;
+  }
+
+  /** Append; when full, drop (overwrite) the oldest element. */
+  push(value: T): void {
+    if (this.#length < this.capacity) {
+      this.#store[(this.#head + this.#length) % this.capacity] = value;
+      this.#length++;
+      return;
+    }
+    // Full: overwrite the oldest and advance the window one step.
+    this.#store[this.#head] = value;
+    this.#head = (this.#head + 1) % this.capacity;
+  }
+
+  /** Logical element at `index` (0 = oldest), or undefined if out of range. */
+  at(index: number): T | undefined {
+    if (index < 0 || index >= this.#length) return undefined;
+    return this.#store[(this.#head + index) % this.capacity];
+  }
+
+  /** A fresh array of the elements from logical `from` (inclusive) onward. */
+  sliceFrom(from: number): T[] {
+    const start = from < 0 ? 0 : from;
+    const out: T[] = [];
+    for (let i = start; i < this.#length; i++) {
+      out.push(this.#store[(this.#head + i) % this.capacity] as T);
+    }
+    return out;
+  }
+
+  /** Drop all elements (and release their references for GC). */
+  clear(): void {
+    this.#store = new Array<T | undefined>(this.capacity);
+    this.#head = 0;
+    this.#length = 0;
+  }
+}


### PR DESCRIPTION
## Problem (LOW severity — a clean micro-optimization)

`ReplayLog.append` (`packages/runtime-client/src/replay.ts`) runs for **every** published wire frame: `StreamChannel.publish` → `#sequence` → `#log.append`, once per streamed token / tool event. Once the buffer reaches `REPLAY_BUFFER_CAP` (1024), each subsequent append did:

```ts
this.#buffer.push(frame);
if (this.#buffer.length > REPLAY_BUFFER_CAP) this.#buffer.shift();
```

`Array.prototype.shift()` is **O(n)** — V8 re-indexes / memmoves the whole 1024-element array on every frame. A long turn emits thousands of deltas, so it paid `O(frames × 1024)` memmoves purely to maintain a fixed-size window. `replayAfter` additionally did a full `.filter` scan of the window on every resume.

## Fix

- New generic `packages/runtime-client/src/ring-buffer.ts` — a fixed-capacity `RingBuffer<T>` (backing array + `head`/`length`, overwrite-oldest on overflow). `push` is **amortized O(1)**: no `shift`, no memmove.
- `ReplayLog` now backs its window with `RingBuffer<SequencedFrame>`. Since frames are buffered in ascending `seq` order, `replayAfter` **binary-searches** the suffix start (`#firstIndexAfter`) and copies from there via `sliceFrom`, instead of `.filter`-scanning the whole window.
- **Public API of `ReplayLog` is unchanged** — same method names/signatures/return types — so `stream-channel.ts` and every other caller (`stitch.ts`, host relay) are untouched.

## Behavior is identical

`replayAfter` semantics are byte-identical, including every boundary case: cursor below the window's min → `null` (resync), cursor exactly one below the oldest → the full window, cursor at an interior frame → the strict suffix, cursor at the watermark → `[]`, cursor above the watermark → `null`. The empty-buffer / post-`clear` guard (`first = at(0)?.seq ?? watermark + 1`) is preserved exactly.

## Tests (behavior-lock, written before the refactor and green against BOTH implementations)

- `replay.test.ts`:
  - `append past CAP keeps exactly the last CAP frames, ascending + consecutive`
  - `replayAfter boundary sweep across a full window: below / at each / above`
  - (existing `overflow drops the oldest frames…`, `a cursor at the watermark…`, `an empty log serves only cursor 0`, `clear empties the buffer…` all stay green.)
- `ring-buffer.test.ts` — 7 unit tests: capacity validation, fill order, overwrite-oldest wrap, `at()` bounds, `sliceFrom` copy semantics, `clear`, many-wrap invariant.

## Scoped checks

- `pnpm --filter @houston/runtime-client test` → **82 passed** (full suite: resume / stitch / snapshot / stream-channel all green).
- `pnpm --filter @houston/runtime-client typecheck` → clean (full-workspace typecheck also green via pre-commit hook).
- Biome clean on all touched files. `replay.ts` 130 lines, `ring-buffer.ts` 66 lines (under the 200-line limit).

## Audit origin

Hot-path performance finding (LOW / performance). No user-visible behavior change — a pure internal micro-optimization of the replay window's data structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)