### PR TITLE
refactor(web): construct a HoustonSdk in the engine-adapter (migration wave 1)

### DIFF
--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -93,6 +93,33 @@ conversation/agent surface first; broader control-plane operations stay on their
 current paths until migrated deliberately" (`packages/sdk/README.md`, *Out of
 scope for v1*).
 
+**The wave-1 seam (adapter → `HoustonSdk`).** `HoustonClient` (`client.ts`) now
+constructs the ONE web-side `HoustonSdk` in `engine-adapter/sdk-client.ts`
+(`createEngineSdk`) and holds it (exposed via the `engineSdk` getter). This is
+the foundation for deleting the dual source of truth: web currently
+RE-implements agents/activities/providers/integrations/preferences CRUD in
+`control-plane.ts` + `client.ts` against the same routes the SDK modules already
+own (the iOS app consumes those modules via the native bridge), which violates
+"no business logic in surface code". Later waves delegate those adapter WRITE
+bodies to `client.engineSdk.<module>` so web matches iOS.
+
+- **Auth/active-space, one source of truth.** The SDK's `ports.fetch` is the
+  SAME `gatewayAuthFetch` instance `engine` uses — live bearer, 401-refresh, and
+  `x-houston-org` off the live `ControlPlaneConfig.activeOrgSlug`. `setActiveOrg`
+  mutates that config in place, so the SDK reroutes with no extra wiring.
+- **Read-path decision: WRITE-DELEGATION ONLY; reads stay on TanStack Query +
+  the `/v1/events` bus.** The SDK is built with `SdkConfig.reactivity: false`
+  (see `packages/sdk/src/ports.ts`), so its agents/activities modules do NOT open
+  their own `/v1/events` streams. Routes and `/v1/events` are untouched, and web
+  keeps its existing read model + `subscribeServerEvents` invalidation. Without
+  this flag, constructing the SDK would open duplicate SSE subscriptions and
+  refetch the agent list — a behavior change. Do NOT adopt the SDK's scope
+  snapshots as the web read model unless a write method hard-depends on an
+  observed scope (none do today).
+- **Inert until wave 2.** Construction issues zero requests; nothing consumes
+  `engineSdk` yet. Proven by `packages/web/tests/sdk-client.test.ts` and
+  `packages/sdk/src/sdk.test.ts` ("reactivity flag").
+
 ---
 
 ## THE PROCEDURES

--- a/packages/sdk/src/modules/activities/index.ts
+++ b/packages/sdk/src/modules/activities/index.ts
@@ -157,27 +157,34 @@ export function createActivitiesModule(ctx: ModuleContext): ActivitiesModule {
       }),
     );
 
-  const dispose = startActivitiesEventStream({
-    baseUrl,
-    fetch: ports.fetch,
-    clock: ports.clock,
-    logger: ports.logger,
-    handlers: {
-      onConnect: () => {
-        for (const id of known) backgroundRefresh(id, "connect");
-      },
-      onActivityChanged: (agentPath) => {
-        // Targeted: only an agent we're showing. A frame with no agentPath can't
-        // be targeted, so refetch every known agent (catch-up, never a miss).
-        if (agentPath === undefined) {
-          for (const id of known) backgroundRefresh(id, "change");
-        } else if (known.has(agentPath)) {
-          backgroundRefresh(agentPath, "change");
-        }
-      },
-      onUnauthorized: emitTokenExpired,
-    },
-  });
+  // Reactivity off (`config.reactivity === false`): the host owns its own read
+  // model + invalidation (the web adapter), so we DON'T open a duplicate
+  // `/v1/events` stream — the module stays write-only and `dispose` is a no-op.
+  const dispose =
+    ctx.config.reactivity === false
+      ? () => {}
+      : startActivitiesEventStream({
+          baseUrl,
+          fetch: ports.fetch,
+          clock: ports.clock,
+          logger: ports.logger,
+          handlers: {
+            onConnect: () => {
+              for (const id of known) backgroundRefresh(id, "connect");
+            },
+            onActivityChanged: (agentPath) => {
+              // Targeted: only an agent we're showing. A frame with no agentPath
+              // can't be targeted, so refetch every known agent (catch-up,
+              // never a miss).
+              if (agentPath === undefined) {
+                for (const id of known) backgroundRefresh(id, "change");
+              } else if (known.has(agentPath)) {
+                backgroundRefresh(agentPath, "change");
+              }
+            },
+            onUnauthorized: emitTokenExpired,
+          },
+        });
 
   return {
     scope: activitiesScope,

--- a/packages/sdk/src/modules/agents/index.ts
+++ b/packages/sdk/src/modules/agents/index.ts
@@ -130,17 +130,23 @@ export function createAgentsModule(ctx: ModuleContext): AgentsModule {
       }),
     );
 
-  const dispose = startAgentsEventStream({
-    baseUrl,
-    fetch: ports.fetch,
-    clock: ports.clock,
-    logger: ports.logger,
-    handlers: {
-      onConnect: () => backgroundRefresh("connect"),
-      onAgentsChanged: () => backgroundRefresh("change"),
-      onUnauthorized: emitTokenExpired,
-    },
-  });
+  // Reactivity off (`config.reactivity === false`): the host owns its own read
+  // model + invalidation (the web adapter), so we DON'T open a duplicate
+  // `/v1/events` stream — the module stays write-only and `dispose` is a no-op.
+  const dispose =
+    ctx.config.reactivity === false
+      ? () => {}
+      : startAgentsEventStream({
+          baseUrl,
+          fetch: ports.fetch,
+          clock: ports.clock,
+          logger: ports.logger,
+          handlers: {
+            onConnect: () => backgroundRefresh("connect"),
+            onAgentsChanged: () => backgroundRefresh("change"),
+            onUnauthorized: emitTokenExpired,
+          },
+        });
 
   return { refresh, create, rename, delete: del, dispose };
 }

--- a/packages/sdk/src/ports.ts
+++ b/packages/sdk/src/ports.ts
@@ -86,4 +86,17 @@ export interface SdkConfig {
    * that keeps many chats hot, lower it under tight memory.
    */
   conversationCacheMax?: number;
+  /**
+   * Whether the reactive modules (agents, activities) open their own long-lived
+   * `GET /v1/events` streams at construction to keep their scope snapshots live.
+   *
+   * Default `true` — the native/desktop path, where the SDK is the single
+   * source of truth for reads. A host that owns its OWN read model and cache
+   * invalidation — the web engine-adapter keeps TanStack Query plus its existing
+   * `/v1/events` bus — sets this `false` to get a WRITE-ONLY SDK: the same
+   * command/mutation handlers, but no module-started streams, so no duplicate
+   * subscriptions or refetches. With reactivity off, `getSnapshot`/`subscribe`
+   * for those scopes stay empty (the host reads its own model instead).
+   */
+  reactivity?: boolean;
 }

--- a/packages/sdk/src/sdk.test.ts
+++ b/packages/sdk/src/sdk.test.ts
@@ -39,6 +39,29 @@ describe("HoustonSdk construction", () => {
   });
 });
 
+describe("HoustonSdk reactivity flag", () => {
+  it("with reactivity:false, construction opens no stream (no fetch fires)", async () => {
+    const fetch = vi.fn(async () => new Response("[]", { status: 200 }));
+    const sdk = makeSdk({ reactivity: false, ports: fakePorts({ fetch }) });
+    // Flush the microtask queue + one macrotask: a deferred stream connect would
+    // have fired by now. Nothing does — the write-only SDK is inert.
+    await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fetch).not.toHaveBeenCalled();
+    // The write facades are still fully present for a host to delegate to.
+    expect(sdk.agents.create).toBeTypeOf("function");
+    expect(sdk.activities.create).toBeTypeOf("function");
+    // dispose is a no-op when no stream was started; it must not throw.
+    sdk.dispose();
+  });
+
+  it("by default opens the agents reactivity stream on construction", async () => {
+    const fetch = vi.fn(async () => new Response("[]", { status: 200 }));
+    makeSdk({ ports: fakePorts({ fetch }) });
+    await vi.waitFor(() => expect(fetch).toHaveBeenCalled());
+  });
+});
+
 describe("HoustonSdk reactive surface", () => {
   it("delegates getSnapshot/subscribe to the internal store", () => {
     const sdk = makeSdk();

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -6,7 +6,7 @@ import {
   HoustonEngineClient,
   type ProviderId,
 } from "@houston/runtime-client";
-import type { BoardStatus } from "@houston/sdk";
+import type { BoardStatus, HoustonSdk } from "@houston/sdk";
 import { historyToFeed as sdkHistoryToFeed } from "@houston/sdk";
 import type {
   Activity,
@@ -71,6 +71,7 @@ import {
   writeCachedConversation,
 } from "./conversation-cache";
 import * as portable from "./portable";
+import { createEngineSdk } from "./sdk-client";
 import {
   flushQueuedSends,
   maybeQueueSend,
@@ -237,6 +238,16 @@ export class HoustonClient {
   private token: string;
   /** Non-null in cloud mode: agents + chat go through the control plane. */
   private cp: ControlPlaneConfig | null;
+  /**
+   * The single web-side {@link HoustonSdk} (migration wave 1). Built INERT
+   * (reactivity off — no `/v1/events` streams), sharing the same gateway auth
+   * fetch as `engine`, so its calls carry the live bearer + active-space header.
+   * Later waves delegate control-plane WRITES (agents/activities/providers/
+   * integrations/preferences) to its modules instead of re-implementing them
+   * here; reads stay on TanStack Query + the `subscribeServerEvents` bus. Held
+   * but unused this wave.
+   */
+  private readonly sdk: HoustonSdk;
   /** In-flight cloud device-code logins, keyed `${agentId}:${providerId}` — the poll guard. */
   private activeLogins = new Set<string>();
   /** Per-provider auth-status pollers that translate login completion into events (local mode). */
@@ -264,14 +275,23 @@ export class HoustonClient {
     // Live-token auth fetch (not a pinned `token`): hosted mode rotates the
     // Supabase bearer mid-session, and a 401 must refresh + replay instead of
     // surfacing (HOU-687). Outside hosted mode liveToken falls back to the
-    // captured static token, so local/static hosts are unchanged.
+    // captured static token, so local/static hosts are unchanged. Built ONCE
+    // and shared by `engine` and the SDK below, so `x-houston-org` has a single
+    // live source (`setActiveOrg` mutates `this.cp` in place; both re-read it).
+    const authFetch = controlPlane.gatewayAuthFetch(
+      opts.token,
+      () => this.cp?.activeOrgSlug,
+    );
     this.engine = new HoustonEngineClient({
       baseUrl: opts.baseUrl,
-      fetch: controlPlane.gatewayAuthFetch(
-        opts.token,
-        () => this.cp?.activeOrgSlug,
-      ),
+      fetch: authFetch,
     });
+    // The single web-side HoustonSdk (migration wave 1). INERT: reactivity is
+    // off, so constructing it opens NO stream and fires NO request — it only
+    // holds the SDK's write surface for later waves. It rides the SAME
+    // `authFetch`, so its bearer, 401-refresh, and active-space header match
+    // every other gateway call with no extra wiring.
+    this.sdk = createEngineSdk({ baseUrl: this.baseUrl, fetch: authFetch });
     // Mark the new TS engine as the active backend so the frontend can surface
     // new-engine-only capabilities (e.g. API-key providers like OpenCode). The
     // Rust engine uses the real `@houston-ai/engine-client`, never this adapter,
@@ -325,6 +345,18 @@ export class HoustonClient {
    */
   setActiveOrg(slug: string | null): void {
     if (this.cp) this.cp.activeOrgSlug = slug;
+  }
+
+  /**
+   * The web-side {@link HoustonSdk} (migration wave 1). Exposes the SDK's write
+   * modules — `agents`, `activities`, `providers`, `integrations`,
+   * `preferences` — so later waves delegate control-plane WRITES here (matching
+   * iOS) instead of re-implementing them in this adapter. It is INERT: no
+   * `/v1/events` stream, no request until a write is dispatched; reads stay on
+   * TanStack Query + the `subscribeServerEvents` bus. Nothing consumes this yet.
+   */
+  get engineSdk(): HoustonSdk {
+    return this.sdk;
   }
 
   private async activeOld(): Promise<{ provider: string; model: string }> {

--- a/packages/web/src/engine-adapter/sdk-client.ts
+++ b/packages/web/src/engine-adapter/sdk-client.ts
@@ -1,0 +1,123 @@
+/**
+ * The web engine-adapter's single {@link HoustonSdk} construction point
+ * (migration wave 1).
+ *
+ * Houston's behavior — agents/activities/providers/integrations/preferences
+ * CRUD, turn lifecycle, reconnection — is written ONCE in `@houston/sdk` and
+ * every surface binds to it (the iOS app already consumes ALL of it via the
+ * native bridge). The web adapter still RE-implements the control-plane CRUD in
+ * `control-plane.ts` + `client.ts` against the same routes — a dual source of
+ * truth this migration removes. This file builds the ONE web-side `HoustonSdk`
+ * that later waves delegate those writes to, so web matches iOS.
+ *
+ * **Wave 1 is the inert seam.** Construction opens NO network: the SDK is built
+ * with `reactivity: false`, so its agents/activities modules do NOT start their
+ * `/v1/events` streams — web keeps its own read model (TanStack Query) and its
+ * own `/v1/events` bus (`client.ts subscribeServerEvents`) unchanged. The SDK
+ * exposes only its WRITE surface for wave 2 (`sdk.agents/activities/providers/
+ * integrations/preferences` mutations, which hit the SAME gateway routes).
+ *
+ * **One source of truth for auth + active space.** The `fetch` handed in is the
+ * SAME `gatewayAuthFetch` the adapter's own engine client uses: it reads the
+ * live Supabase bearer per attempt, retries a 401 after one refresh, and stamps
+ * `x-houston-org` from the live `ControlPlaneConfig.activeOrgSlug`. Sharing that
+ * one fetch means `HoustonClient.setActiveOrg` (which mutates the config in
+ * place) reroutes the SDK's calls too, with no extra threading.
+ */
+
+import { HoustonSdk, type KeyValueStore, type SdkLogger } from "@houston/sdk";
+
+/** Namespace for every SDK-owned `localStorage` key, so nothing the SDK
+ *  persists can collide with the adapter's existing browser state. */
+const SDK_STORAGE_PREFIX = "houston.sdk.";
+
+/**
+ * A {@link KeyValueStore} over `localStorage`, namespaced under
+ * {@link SDK_STORAGE_PREFIX}. Falls back to an in-memory map where
+ * `localStorage` is absent or disabled (SSR, private-mode denials, tests) so
+ * construction never throws.
+ */
+function createWebStorage(): KeyValueStore {
+  const memory = new Map<string, string>();
+  const hasLocal = (() => {
+    try {
+      return typeof localStorage !== "undefined";
+    } catch {
+      return false;
+    }
+  })();
+  const key = (k: string) => `${SDK_STORAGE_PREFIX}${k}`;
+  return {
+    async get(k) {
+      if (!hasLocal) return memory.get(k) ?? null;
+      try {
+        return localStorage.getItem(key(k));
+      } catch {
+        return memory.get(k) ?? null;
+      }
+    },
+    async set(k, value) {
+      memory.set(k, value);
+      if (!hasLocal) return;
+      try {
+        localStorage.setItem(key(k), value);
+      } catch {
+        /* storage disabled — the in-memory copy still answers this session */
+      }
+    },
+    async delete(k) {
+      memory.delete(k);
+      if (!hasLocal) return;
+      try {
+        localStorage.removeItem(key(k));
+      } catch {
+        /* storage disabled */
+      }
+    },
+  };
+}
+
+/** A {@link SdkLogger} that routes to `console`, so nothing is ever swallowed. */
+const webLogger: SdkLogger = {
+  debug: (msg, fields) => console.debug(`[engine-adapter/sdk] ${msg}`, fields),
+  info: (msg, fields) => console.info(`[engine-adapter/sdk] ${msg}`, fields),
+  warn: (msg, fields) => console.warn(`[engine-adapter/sdk] ${msg}`, fields),
+  error: (msg, fields) => console.error(`[engine-adapter/sdk] ${msg}`, fields),
+};
+
+/** Everything {@link createEngineSdk} needs from the host adapter. */
+export interface EngineSdkOptions {
+  /** The gateway/host base URL the SDK's clients root at (trailing slashes trimmed). */
+  baseUrl: string;
+  /**
+   * The SHARED gateway auth fetch — the exact `typeof fetch` the adapter's own
+   * engine client runs on, carrying the live bearer, 401-refresh, and the
+   * `x-houston-org` header off the live active space. Passing the same instance
+   * keeps auth + active-space behavior identical across the adapter and the SDK.
+   */
+  fetch: typeof fetch;
+}
+
+/**
+ * Construct the web engine-adapter's single, INERT {@link HoustonSdk}: wired to
+ * the shared gateway auth fetch, with reactivity OFF (no `/v1/events` streams,
+ * no refetch-on-construct) so it changes nothing at runtime until a later wave
+ * delegates a write to `sdk.agents/activities/providers/integrations/
+ * preferences`. Constructing it issues NO network request.
+ */
+export function createEngineSdk(opts: EngineSdkOptions): HoustonSdk {
+  return new HoustonSdk({
+    baseUrl: opts.baseUrl.replace(/\/+$/, ""),
+    reactivity: false,
+    ports: {
+      fetch: opts.fetch,
+      storage: createWebStorage(),
+      clock: {
+        now: () => Date.now(),
+        setTimeout: (fn, ms) => setTimeout(fn, ms) as unknown as number,
+        clearTimeout: (id) => clearTimeout(id),
+      },
+      logger: webLogger,
+    },
+  });
+}

--- a/packages/web/tests/sdk-client.test.ts
+++ b/packages/web/tests/sdk-client.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { gatewayAuthFetch } from "../src/engine-adapter/control-plane";
+import { createEngineSdk } from "../src/engine-adapter/sdk-client";
+
+/**
+ * The migration-wave-1 seam: the web engine-adapter builds ONE `HoustonSdk`
+ * wired to the SAME gateway auth fetch every other adapter call uses, and it is
+ * INERT — constructing it opens no stream and fires no request (reactivity is
+ * off; web keeps its own reads). These tests pin both halves of that contract:
+ *
+ *  - construction issues ZERO requests, and
+ *  - a delegated WRITE goes through the injected gateway fetch with the right
+ *    base URL, `Authorization` bearer, and live `x-houston-org` header.
+ */
+
+const SLUG = "0123456789abcdef"; // [a-f0-9]{16}
+const BASE = "https://gateway.example";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+function json(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+interface Call {
+  url: string;
+  init: RequestInit | undefined;
+}
+
+/** Stub the global fetch with a queue of responses; records every call. */
+function stubFetch(...responses: Response[]): Call[] {
+  const calls: Call[] = [];
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    const next = responses.shift();
+    if (!next) throw new Error("stubFetch: no responses left");
+    return next;
+  }) as unknown as typeof fetch;
+  return calls;
+}
+
+function headerOf(call: Call, name: string): string | null {
+  return new Headers(call.init?.headers).get(name);
+}
+
+test("constructing the SDK fires no request (inert seam)", async () => {
+  const calls = stubFetch();
+  const sdk = createEngineSdk({
+    baseUrl: `${BASE}/`,
+    fetch: gatewayAuthFetch("tok", () => null),
+  });
+  // The write modules exist for later waves…
+  expect(sdk.agents).toBeDefined();
+  expect(sdk.activities).toBeDefined();
+  expect(sdk.providers).toBeDefined();
+  expect(sdk.integrations).toBeDefined();
+  expect(sdk.preferences).toBeDefined();
+  // …but nothing has touched the network, even after microtasks flush.
+  await Promise.resolve();
+  await new Promise((r) => setTimeout(r, 0));
+  expect(calls).toHaveLength(0);
+});
+
+test("a delegated write rides the shared gateway fetch (base URL + bearer)", async () => {
+  const calls = stubFetch(
+    json(200, { id: "a1", name: "New", workspaceId: "w1", createdAt: 0 }),
+    json(200, []), // the post-write refresh list
+  );
+  const sdk = createEngineSdk({
+    baseUrl: `${BASE}/`, // trailing slash must be trimmed
+    fetch: gatewayAuthFetch("tok-123", () => null),
+  });
+
+  await sdk.agents.create("New");
+
+  expect(calls[0].url).toBe(`${BASE}/agents`);
+  expect((calls[0].init?.method ?? "GET").toUpperCase()).toBe("POST");
+  expect(headerOf(calls[0], "Authorization")).toBe("Bearer tok-123");
+  expect(calls[0].init?.body).toBe(JSON.stringify({ name: "New" }));
+  // The refresh read is the same rooted route.
+  expect(calls[1].url).toBe(`${BASE}/agents`);
+});
+
+test("writes carry the live x-houston-org header, re-read per call", async () => {
+  let org: string | null = null;
+  const sdk = createEngineSdk({
+    baseUrl: BASE,
+    fetch: gatewayAuthFetch("tok", () => org),
+  });
+
+  // Personal space: no org header.
+  const personal = stubFetch(json(200, []));
+  await sdk.agents.refresh();
+  expect(headerOf(personal[0], "x-houston-org")).toBeNull();
+
+  // Switch to a team space (mirrors HoustonClient.setActiveOrg mutating the
+  // shared config) — the same fetch closure picks it up with no re-wiring.
+  org = SLUG;
+  const team = stubFetch(json(200, []));
+  await sdk.agents.refresh();
+  expect(headerOf(team[0], "x-houston-org")).toBe(SLUG);
+});


### PR DESCRIPTION
## The problem — a dual source of truth

Houston's client behavior (agents/activities/providers/integrations/preferences CRUD, turn lifecycle) is written ONCE in `@houston/sdk`, and the iOS app consumes ALL of those modules via the native bridge. The **web** engine-adapter, however, RE-implements the same control-plane CRUD in `control-plane.ts` (~1.5k lines) + `client.ts` (~2.1k-line `HoustonClient`) against the SAME routes — a dual source of truth that violates the repo rule "no business logic in surface code; behavior goes in `@houston/sdk` first, surfaces bind, never re-implement in surface code" (`knowledge-base/client-architecture.md`).

## Direction — finish the migration

Make web **delegate to the SDK modules like iOS does**, then delete the adapter's re-implemented CRUD. This is staged across waves.

## What THIS wave does (foundation only — inert seam)

No CRUD is migrated yet. It lands the seam later waves build on:

- **`engine-adapter/sdk-client.ts` (`createEngineSdk`)** builds the ONE web-side `HoustonSdk`. `HoustonClient` constructs it once and exposes it via the `engineSdk` getter for later waves to delegate writes to (`agents`, `activities`, `providers`, `integrations`, `preferences`).
- **One source of truth for auth + active space.** The SDK's `ports.fetch` is the SAME `gatewayAuthFetch` instance the adapter's `engine` client uses — live Supabase bearer, 401-refresh-and-replay, and `x-houston-org` off the live `ControlPlaneConfig.activeOrgSlug`. `setActiveOrg` mutates that config in place, so the SDK reroutes with no extra wiring.

## Read-path decision — WRITE-DELEGATION ONLY

Reads stay on **TanStack Query + the existing `/v1/events` bus** (`subscribeServerEvents`). Routes and `/v1/events` are untouched, so there is no reason to move the read model. Later waves delegate only the CRUD **mutations** to `sdk.*` (same routes). We do NOT adopt the SDK's scope snapshots as the web read model — no write method hard-depends on an observed scope today.

## Behavior-neutral / inert this wave

The SDK's agents + activities modules normally open their own long-lived `GET /v1/events` streams at construction (agents also refetches the list on connect). On web that would be **duplicate SSE subscriptions + an extra agent-list fetch** — a runtime behavior change. To neutralize it cleanly, this PR adds an **additive** `SdkConfig.reactivity` flag (default `true`, so the native/desktop bridge path is unchanged); `createEngineSdk` passes `reactivity: false` to get a **write-only** SDK with no module-started streams. Every other module is already network-inert at construction (session only reads storage + registers a no-op 401 hook for a non-SDK auth-fetch).

Result: constructing the SDK issues **zero requests**, and nothing consumes `engineSdk` yet.

## Tests

- `packages/web/tests/sdk-client.test.ts` — constructing the SDK fires no request (inert); a delegated write rides the shared gateway fetch with the right base URL + `Authorization` bearer; writes carry the live `x-houston-org` header, re-read per call (mirrors `setActiveOrg`).
- `packages/sdk/src/sdk.test.ts` — "reactivity flag": `reactivity: false` opens no stream on construct; default opens the agents stream.

## Verification (scoped)

- `pnpm --filter @houston/sdk typecheck` + `pnpm --filter houston-web typecheck` — clean (pre-commit also ran full `pnpm -r typecheck` — clean).
- `pnpm --filter @houston/sdk test` (308 passed) + full `pnpm --filter houston-web test` (135 passed).
- `biome check --error-on-warnings` on touched files — clean; `pnpm check:boundaries` — clean.

## Follow-up

Waves 2–3: delegate the adapter's CRUD write bodies to `engineSdk.*` and delete the re-implementations, then update `knowledge-base/client-architecture.md`.

This came out of an architecture audit of the web↔SDK↔iOS parity surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)