### PR TITLE
refactor(web): delegate preferences + integration grants to the SDK (wave 2a)

### DIFF
--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -643,7 +643,17 @@ export class HoustonClient {
   }
   async setPreference(key: string, value: string): Promise<void> {
     if (ACCOUNT_PREF_KEYS.has(key)) {
-      await controlPlane.setPreference(this.prefConfig(), key, value);
+      // Delegate the account-key WRITE to the SDK (migration wave 2a): its
+      // PreferencesClient issues the identical `PUT /v1/preferences/:key` with
+      // body `{value}` over the SAME shared gateway fetch (bearer +
+      // `x-houston-org`), and — unlike the agents/activities facades — does NOT
+      // refetch. The SDK echoes the stored value; this caller discards it, so
+      // the observable request and the `void` result are byte-identical to the
+      // old `controlPlane.setPreference`. PUTs never transient-retry in either
+      // path, so nothing is lost. The READ stays on `controlPlane.getPreference`
+      // (below): cpFetch wraps GETs in `transientRetryFetch`, which the SDK path
+      // lacks — delegating it would drop that boot-path retry resilience.
+      await this.engineSdk.preferences.set(key, value);
       removeLocalPref(key);
       return;
     }
@@ -2116,12 +2126,17 @@ export class HoustonClient {
     agentSlugOrId: string,
     toolkits: string[],
   ): Promise<void> {
+    // Grants are cloud-only: off-cloud there is no per-agent grants model, so
+    // this stays a no-op (never a network call) — the guard is preserved.
     if (!this.cp) return;
-    return controlPlane.setAgentIntegrationGrants(
-      this.cp,
-      agentSlugOrId,
-      toolkits,
-    );
+    // Delegate the WRITE to the SDK (migration wave 2a): its IntegrationsClient
+    // issues the identical `PUT /v1/agents/:id/integration-grants` with body
+    // `{toolkits}` over the SAME shared gateway fetch (bearer + `x-houston-org`)
+    // and does NOT read the response or refetch — byte-identical to the old
+    // `controlPlane.setAgentIntegrationGrants`. The READ (`agentIntegrationGrants`
+    // above) stays on cpFetch: its GET carries `transientRetryFetch`, which the
+    // SDK path lacks, so delegating it would drop that retry resilience.
+    await this.engineSdk.integrations.setGrants(agentSlugOrId, toolkits);
   }
 
   // ---- lifecycle no-ops the shell calls ----

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -1503,15 +1503,3 @@ export async function agentIntegrationGrants(
     throw err;
   }
 }
-
-export async function setAgentIntegrationGrants(
-  cfg: ControlPlaneConfig,
-  agentSlugOrId: string,
-  toolkits: string[],
-): Promise<void> {
-  await cpFetch(
-    cfg,
-    `/v1/agents/${encodeURIComponent(agentSlugOrId)}/integration-grants`,
-    { method: "PUT", body: JSON.stringify({ toolkits }) },
-  );
-}

--- a/packages/web/tests/sdk-delegation-parity.test.ts
+++ b/packages/web/tests/sdk-delegation-parity.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { HoustonClient } from "../src/engine-adapter/client";
+
+/**
+ * Migration wave 2a — byte-identical route parity for the TWO web-adapter
+ * WRITES now delegated to `@houston/sdk`: account-preference set and
+ * integration-grants set. Each delegated path MUST issue the exact request the
+ * old `controlPlane.*` helper did — same method, path, body, and headers
+ * (`Content-Type`, `Authorization` bearer, and the live `x-houston-org`) — over
+ * the ONE shared gateway fetch, with NO post-write refetch (the property that
+ * keeps these two out of the SDK-facade refetch that blocks agents/activities).
+ *
+ * Reproduce-first: `account-preferences.test.ts` already pins the pref-write
+ * WIRE (exact PUT, single call) and stays green through this delegation; these
+ * tests additionally lock the request HEADERS and the grants-write wire, and
+ * guard the grants-read degrade (404 -> null) that stays on the adapter.
+ */
+
+const BASE = "http://host";
+const ORG = "abcdef0123456789"; // [a-f0-9]{16}
+
+interface Call {
+  url: string;
+  method: string;
+  body: string | null;
+  headers: Headers;
+}
+
+let calls: Call[];
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  const store = new Map<string, string>();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  calls = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+function stubFetch(...responses: Response[]) {
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      method: (init?.method ?? "GET").toUpperCase(),
+      body: typeof init?.body === "string" ? init.body : null,
+      headers: new Headers(init?.headers),
+    });
+    const next = responses.shift();
+    if (!next) throw new Error("stubFetch: no responses left");
+    return next;
+  }) as unknown as typeof fetch;
+}
+
+function json(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const client = (controlPlane: boolean) =>
+  new HoustonClient({ baseUrl: BASE, token: "t", controlPlane });
+
+// ---- preferences.set delegation ----
+
+test("setPreference delegates a byte-identical single PUT (path+body+headers)", async () => {
+  // The host echoes `{value}` on PUT; the SDK reads it (and this caller
+  // discards it) — still ONE request, so no refetch.
+  stubFetch(json(200, { value: "America/Bogota" }));
+
+  await client(true).setPreference("timezone", "America/Bogota");
+
+  expect(calls).toHaveLength(1); // no post-write refetch
+  const [put] = calls;
+  expect(put.method).toBe("PUT");
+  expect(put.url).toBe(`${BASE}/v1/preferences/timezone`);
+  expect(put.body).toBe(JSON.stringify({ value: "America/Bogota" }));
+  expect(put.headers.get("Content-Type")).toBe("application/json");
+  expect(put.headers.get("Authorization")).toBe("Bearer t");
+});
+
+test("setPreference carries the live x-houston-org for the active team space", async () => {
+  stubFetch(json(200, { value: "es" }));
+  const c = client(true);
+  c.setActiveOrg(ORG);
+
+  await c.setPreference("locale", "es");
+
+  expect(calls).toHaveLength(1);
+  expect(calls[0].headers.get("x-houston-org")).toBe(ORG);
+});
+
+test("a failed preference write propagates — never swallowed", async () => {
+  stubFetch(json(500, { error: "boom" }));
+
+  await expect(
+    client(true).setPreference("timezone", "America/Bogota"),
+  ).rejects.toThrow();
+});
+
+// ---- integrations.setGrants delegation ----
+
+test("setAgentIntegrationGrants delegates a byte-identical single PUT", async () => {
+  stubFetch(json(200, {}));
+
+  await client(true).setAgentIntegrationGrants("agent-1", ["gmail", "slack"]);
+
+  expect(calls).toHaveLength(1); // no refetch
+  const [put] = calls;
+  expect(put.method).toBe("PUT");
+  expect(put.url).toBe(`${BASE}/v1/agents/agent-1/integration-grants`);
+  expect(put.body).toBe(JSON.stringify({ toolkits: ["gmail", "slack"] }));
+  expect(put.headers.get("Content-Type")).toBe("application/json");
+  expect(put.headers.get("Authorization")).toBe("Bearer t");
+});
+
+test("setAgentIntegrationGrants carries the live x-houston-org", async () => {
+  stubFetch(json(200, {}));
+  const c = client(true);
+  c.setActiveOrg(ORG);
+
+  await c.setAgentIntegrationGrants("agent-1", []);
+
+  expect(calls[0].headers.get("x-houston-org")).toBe(ORG);
+});
+
+test("setAgentIntegrationGrants stays a no-op off-cloud (no network call)", async () => {
+  stubFetch(); // any fetch would throw "no responses left"
+
+  await client(false).setAgentIntegrationGrants("agent-1", ["gmail"]);
+
+  expect(calls).toEqual([]);
+});
+
+test("a failed grants write propagates — never swallowed", async () => {
+  stubFetch(json(500, { error: "boom" }));
+
+  await expect(
+    client(true).setAgentIntegrationGrants("agent-1", ["gmail"]),
+  ).rejects.toThrow();
+});
+
+// ---- grants READ stays on the adapter: degrade + wire preserved ----
+
+test("agentIntegrationGrants returns the toolkit set on 200 (read unchanged)", async () => {
+  stubFetch(json(200, { toolkits: ["gmail"] }));
+
+  await expect(client(true).agentIntegrationGrants("agent-1")).resolves.toEqual(
+    ["gmail"],
+  );
+  expect(calls[0].url).toBe(`${BASE}/v1/agents/agent-1/integration-grants`);
+  expect(calls[0].method).toBe("GET");
+});
+
+test("agentIntegrationGrants degrades 404 -> null (deployment without grants)", async () => {
+  stubFetch(json(404, { error: "no grants model" }));
+
+  await expect(
+    client(true).agentIntegrationGrants("agent-1"),
+  ).resolves.toBeNull();
+});


### PR DESCRIPTION
## What

Migration **wave 2a**: delegate the web engine-adapter's two byte-identical control-plane **WRITES** to `@houston/sdk`, matching iOS and removing that dual source of truth.

| Adapter method | Now delegates to | Wire |
| --- | --- | --- |
| `setPreference` (account keys) | `sdk.preferences.set` | `PUT /v1/preferences/:key` body `{value}` |
| `setAgentIntegrationGrants` | `sdk.integrations.setGrants` | `PUT /v1/agents/:id/integration-grants` body `{toolkits}` |

## Byte-identical parity evidence

Both delegated writes issue the **identical** request the old `controlPlane.*` helper did — same route, method, body, and headers (`Content-Type: application/json`, `Authorization` bearer, live `x-houston-org`) over the **same shared gateway `authFetch`** (verified: `this.cp.baseUrl === this.baseUrl === createEngineSdk baseUrl`, all from the trimmed `opts.baseUrl`; org header sourced from the same `() => this.cp?.activeOrgSlug`). Crucially, **no post-write refetch**: `preferences.set` reads its own PUT response (the host echoes `{value}`, which the caller discards) and `integrations.setGrants` uses `r.request` (no body read) — one request each. The SDK's `agents/activities/providers` facades, by contrast, refetch a list after every write (see `sdk-client.test.ts` — `sdk.agents.create` fires POST **+** list), which is exactly why those modules are deferred.

New route-parity tests (`sdk-delegation-parity.test.ts`) capture method+path+body+headers for both writes, assert a **single** call (no refetch), assert the live `x-houston-org` rides each write, assert failures propagate (no swallow), and lock the grants read's **404 → null** degrade.

## Why the reads are NOT delegated (and the other modules deferred)

The paired **reads** (`getPreference`, `agentIntegrationGrants`) are deliberately kept on the adapter. `cpFetch` wraps every call in `transientRetryFetch` (two blind retries on 502/503/504 for GET/HEAD) **and** injects `Content-Type` on the GET; the SDK path has neither. Delegating the (boot-path) preference read would silently drop that rolling-deploy retry resilience and change the request headers — a behavior change. PUTs never transient-retry in either path, so the **writes lose nothing**. Reads stay unchanged (TanStack Query + `subscribeServerEvents`).

The broader CRUD modules (agents/activities/providers/integrations-session) need **additive SDK write variants** that skip the facade refetch and match the adapter's shapes — tracked follow-up, out of scope here.

## Verification

- `pnpm --filter houston-web typecheck` + `pnpm --filter @houston/sdk typecheck` — green (pre-commit also ran repo-wide `-r typecheck`, all 22 projects green)
- `pnpm --filter houston-web test` — 144/144 green (incl. existing `account-preferences.test.ts`, which stays green through the delegation — reproduce-first proof of no-refetch parity)
- `pnpm check` clean on touched files; `pnpm check:boundaries` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)