### PR TITLE
feat(sdk): additive no-refetch write variants for web delegation

### DIFF
--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -120,6 +120,42 @@ bodies to `client.engineSdk.<module>` so web matches iOS.
   `engineSdk` yet. Proven by `packages/web/tests/sdk-client.test.ts` and
   `packages/sdk/src/sdk.test.ts` ("reactivity flag").
 
+**The wave-2a write seams: no-refetch write variants (`module.writes.*`).** Web
+can't delegate its CRUD to the SDK's mutating FACADE methods
+(`agents.create/rename/delete`, `activities.create/setStatus/rename/delete`,
+`providers.setApiKey/logout/setModel`, `integrations.disconnect`) because each
+does a post-write `refresh()` (an extra GET) and returns a simplified shape —
+exactly the refetch web runs `reactivity:false` to avoid (web owns its TanStack
+reads). So each of those four modules now also exposes a **`writes` namespace**:
+the SAME underlying HTTP write, but it (a) does NOT call `refresh()` / publish a
+snapshot, and (b) RETURNS the wire entity (`agents.writes.create` returns the
+created agent incl. `id` for web's color overlay; `activities.writes.*` return
+the wire `Activity`; `providers.writes.status` returns `AuthStatus`). The
+refetching facade methods are UNCHANGED and, where sensible, now delegate to the
+same `writes` primitive then `refresh()` (one implementation, no drift — see
+`providers/operations.ts`). Extra additive surface landed with it:
+`agents.writes.create` takes the full `{ name, claudeMd?, seeds? }` body (the
+plain facade still posts `{ name }`); `providers.writes.setCustomEndpoint`
+(`POST /providers/openai-compatible`, no facade sibling);
+`integrations.setSession` / `dismissReconnectNotice`, an additive
+`connect(provider, toolkit, agent?)` overload (the 1-arg `connect(toolkit)` and
+its bridge command are byte-identical to before), and `IntegrationsClient`
+(runtime-client) gained `setSession` / `dismissReconnectNotice` + optional
+provider/agent on `connect`/`disconnect`. Web's actual delegation to these seams
+is a SEPARATE later wave (2b).
+
+**The strict-additive / iOS-safe contract rule (why the above is shaped this
+way).** `@houston/sdk` is consumed by BOTH the web engine-adapter AND the native
+iOS app (via the JavaScriptCore bridge, `bridge/entry.ts` → `new HoustonSdk()`).
+iOS reaches the SDK ONLY through the bridge — dispatched COMMANDS
+(`registerCommand` types) and subscribed SCOPES — never facade methods directly.
+So evolving the SDK for web MUST be strictly additive: never change an existing
+method's signature/route/body or its post-write `refresh()` behavior, register no
+new command for the web-only seams (the bridge can't route to what isn't
+registered, so the new `writes`/session/notice surface is unreachable from iOS),
+and keep every published scope snapshot shape unchanged. A web-needed op that
+can't be added without altering iOS behavior is STOPPED and reported, not forced.
+
 ---
 
 ## THE PROCEDURES

--- a/packages/runtime-client/src/client-integrations.test.ts
+++ b/packages/runtime-client/src/client-integrations.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from "vitest";
+import { IntegrationsClient } from "./client-integrations";
+
+const BASE = "http://127.0.0.1:4317";
+
+interface Recorded {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+/** An {@link IntegrationsClient} over a mock `fetch` recording every call. */
+function makeClient() {
+  const calls: Recorded[] = [];
+  const fetchImpl = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(String(input));
+      calls.push({
+        method: init?.method ?? "GET",
+        path: url.pathname,
+        body:
+          init?.body === undefined ? undefined : JSON.parse(String(init.body)),
+      });
+      return new Response(
+        JSON.stringify({ redirectUrl: "u", connectionId: "c1" }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      );
+    },
+  );
+  const client = new IntegrationsClient({
+    baseUrl: BASE,
+    fetch: fetchImpl as unknown as typeof fetch,
+  });
+  return { client, calls };
+}
+
+const I = "/v1/integrations";
+
+describe("IntegrationsClient — additive connect/disconnect options", () => {
+  it("connect(toolkit) keeps the legacy composio route + { toolkit } body", async () => {
+    const { client, calls } = makeClient();
+    await client.connect("gmail");
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${I}/composio/connect`,
+        body: { toolkit: "gmail" },
+      },
+    ]);
+  });
+
+  it("connect(toolkit, { provider, agent }) routes to the provider and adds agent", async () => {
+    const { client, calls } = makeClient();
+    await client.connect("gmail", { provider: "composio", agent: "ag_1" });
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${I}/composio/connect`,
+        body: { toolkit: "gmail", agent: "ag_1" },
+      },
+    ]);
+  });
+
+  it("disconnect(toolkit) keeps the legacy composio { toolkit } body", async () => {
+    const { client, calls } = makeClient();
+    await client.disconnect("gmail");
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${I}/composio/disconnect`,
+        body: { toolkit: "gmail" },
+      },
+    ]);
+  });
+});
+
+describe("IntegrationsClient — session + reconnect notice", () => {
+  it("setSession PUTs { token }", async () => {
+    const { client, calls } = makeClient();
+    await client.setSession("jwt-1");
+    expect(calls).toEqual([
+      { method: "PUT", path: `${I}/session`, body: { token: "jwt-1" } },
+    ]);
+  });
+
+  it("setSession(null) PUTs { token: null }", async () => {
+    const { client, calls } = makeClient();
+    await client.setSession(null);
+    expect(calls).toEqual([
+      { method: "PUT", path: `${I}/session`, body: { token: null } },
+    ]);
+  });
+
+  it("dismissReconnectNotice POSTs the dismiss route", async () => {
+    const { client, calls } = makeClient();
+    await client.dismissReconnectNotice();
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${I}/reconnect-notice/dismiss`,
+        body: undefined,
+      },
+    ]);
+  });
+});

--- a/packages/runtime-client/src/client-integrations.ts
+++ b/packages/runtime-client/src/client-integrations.ts
@@ -26,6 +26,17 @@ const JSON_HEADERS = { "Content-Type": "application/json" } as const;
  *  route on this segment (`/v1/integrations/composio/*`). */
 const COMPOSIO = "composio";
 
+/** Options for a provider-scoped {@link IntegrationsClient.connect} /
+ *  {@link IntegrationsClient.disconnect}. `provider` defaults to composio (the
+ *  only provider today, so an omitted value keeps the exact legacy route);
+ *  `agent` scopes an OAuth connect to a single agent slug (the gateway's
+ *  per-agent grant capture). Both optional and additive — a bare
+ *  `connect(toolkit)` is byte-for-byte the pre-existing call. */
+export interface IntegrationConnectOptions {
+  provider?: string;
+  agent?: string;
+}
+
 /** Integrations + per-agent grants (C1/C4). All calls carry the session JWT. */
 export class IntegrationsClient {
   private readonly r: Requester;
@@ -69,23 +80,67 @@ export class IntegrationsClient {
   }
 
   /** Start an OAuth connect. The caller opens `redirectUrl`, then polls
-   *  {@link getConnection} on `connectionId` until it is `active`. */
+   *  {@link getConnection} on `connectionId` until it is `active`. `opts`
+   *  (provider/agent) is additive — omitted, this is the legacy composio call
+   *  with a `{ toolkit }` body. */
   connect(
     toolkit: string,
+    opts?: IntegrationConnectOptions,
   ): Promise<{ redirectUrl: string; connectionId: string }> {
-    return this.r.json(`/v1/integrations/${COMPOSIO}/connect`, {
-      method: "POST",
+    const provider = opts?.provider ?? COMPOSIO;
+    return this.r.json(
+      `/v1/integrations/${encodeURIComponent(provider)}/connect`,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({
+          toolkit,
+          ...(opts?.agent ? { agent: opts.agent } : {}),
+        }),
+      },
+    );
+  }
+
+  /** Disconnect a toolkit for the user everywhere (removes its connections).
+   *  `opts.provider` is additive; omitted keeps the legacy composio route. */
+  async disconnect(
+    toolkit: string,
+    opts?: Pick<IntegrationConnectOptions, "provider">,
+  ): Promise<void> {
+    const provider = opts?.provider ?? COMPOSIO;
+    await this.r.request(
+      `/v1/integrations/${encodeURIComponent(provider)}/disconnect`,
+      {
+        method: "POST",
+        headers: JSON_HEADERS,
+        body: JSON.stringify({ toolkit }),
+      },
+    );
+  }
+
+  /**
+   * Push the caller's Supabase session token to the gateway adapter
+   * (`PUT /v1/integrations/session`); `null` on sign-out. A deployment without a
+   * session sink answers 404 — this method does NOT swallow it (errors
+   * propagate); the CALLER decides whether a 404 is benign for its deployment.
+   */
+  async setSession(token: string | null): Promise<void> {
+    await this.r.request("/v1/integrations/session", {
+      method: "PUT",
       headers: JSON_HEADERS,
-      body: JSON.stringify({ toolkit }),
+      body: JSON.stringify({ token }),
     });
   }
 
-  /** Disconnect a toolkit for the user everywhere (removes its connections). */
-  async disconnect(toolkit: string): Promise<void> {
-    await this.r.request(`/v1/integrations/${COMPOSIO}/disconnect`, {
+  /**
+   * Dismiss the one-time "reconnect your integrations" notice
+   * (`POST /v1/integrations/reconnect-notice/dismiss`) — the host deletes the
+   * retired legacy per-user credentials file. Idempotent host-side.
+   */
+  async dismissReconnectNotice(): Promise<void> {
+    await this.r.request("/v1/integrations/reconnect-notice/dismiss", {
       method: "POST",
       headers: JSON_HEADERS,
-      body: JSON.stringify({ toolkit }),
     });
   }
 

--- a/packages/runtime-client/src/index.ts
+++ b/packages/runtime-client/src/index.ts
@@ -1,5 +1,6 @@
 export type { EventStreamOptions, SendOptions } from "./client";
 export { EngineError, HoustonEngineClient } from "./client";
+export type { IntegrationConnectOptions } from "./client-integrations";
 export { IntegrationsClient, PreferencesClient } from "./client-integrations";
 export type { GlobalEventsOptions } from "./global-events";
 export { streamGlobalEvents } from "./global-events";

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -52,6 +52,7 @@ export {
   ActivitiesHttpError,
   type ActivitiesModule,
   type ActivitiesViewModel,
+  type ActivitiesWrites,
   type ActivityItem,
   activitiesScope,
   type CreatedActivity,
@@ -60,12 +61,14 @@ export {
 export {
   AGENTS_CHANGED_EVENT,
   AGENTS_SCOPE,
+  type AgentCreateInput,
   type AgentListItem,
   AgentsCommand,
   type AgentsCommandType,
   AgentsHttpError,
   type AgentsModule,
   type AgentsViewModel,
+  type AgentsWrites,
   type WireAgent,
 } from "./modules/agents";
 // ===== Conversations module contract ===================================
@@ -84,6 +87,7 @@ export {
   type IntegrationsModule,
   type IntegrationsUnavailableReason,
   type IntegrationsViewModel,
+  type IntegrationsWrites,
   type IntegrationToolkit,
 } from "./modules/integrations";
 // ===== Mission-search module contract ==================================
@@ -100,6 +104,8 @@ export {
 } from "./modules/preferences";
 // ===== Providers module contract =======================================
 export {
+  type AuthStatus,
+  type CustomEndpoint,
   type LoginInfo,
   type LoginOptions,
   type LoginState,
@@ -110,6 +116,7 @@ export {
   type ProvidersCommandType,
   type ProvidersModule,
   type ProvidersViewModel,
+  type ProvidersWrites,
   type ProviderVM,
   providersScope,
   type SetModelOptions,

--- a/packages/sdk/src/modules/activities/http.ts
+++ b/packages/sdk/src/modules/activities/http.ts
@@ -16,6 +16,7 @@
 
 import type { Activity, ActivityUpdate, NewActivity } from "@houston/protocol";
 import type { SdkPorts } from "../../ports";
+import type { ActivitiesWrites } from "./types";
 
 /** A failed `/activities` request. `status` is the upstream HTTP status. */
 export class ActivitiesHttpError extends Error {
@@ -89,5 +90,20 @@ export function createActivitiesHttp(
         method: "DELETE",
       });
     },
+  };
+}
+
+/**
+ * The no-refetch {@link ActivitiesWrites}: the underlying http ops surfaced
+ * directly (returning the wire entity), with no post-write refresh. `setStatus`
+ * and `rename` are the `update` PATCH with a `{ status }` / `{ title }` body —
+ * the same wire writes the refetching facade issues, minus the refetch.
+ */
+export function createActivitiesWrites(http: ActivitiesHttp): ActivitiesWrites {
+  return {
+    create: (agentId, input) => http.create(agentId, input),
+    setStatus: (agentId, id, status) => http.update(agentId, id, { status }),
+    rename: (agentId, id, title) => http.update(agentId, id, { title }),
+    delete: (agentId, id) => http.remove(agentId, id),
   };
 }

--- a/packages/sdk/src/modules/activities/index.ts
+++ b/packages/sdk/src/modules/activities/index.ts
@@ -19,7 +19,7 @@ import type { PendingInteraction } from "@houston/protocol";
 import type { ModuleContext } from "../../module-context";
 import { registerActivitiesCommands } from "./commands";
 import { startActivitiesEventStream } from "./events-stream";
-import { createActivitiesHttp } from "./http";
+import { createActivitiesHttp, createActivitiesWrites } from "./http";
 import {
   type ActivitiesModule,
   type ActivitiesViewModel,
@@ -31,18 +31,17 @@ import {
 } from "./types";
 
 export { ActivitiesHttpError } from "./http";
-export type {
-  ActivitiesModule,
-  ActivitiesViewModel,
-  ActivityItem,
-  CreatedActivity,
-} from "./types";
 export {
   ACTIVITY_CHANGED_EVENT,
   ACTIVITY_STATUSES,
   ActivitiesCommand,
   type ActivitiesCommandType,
+  type ActivitiesModule,
+  type ActivitiesViewModel,
+  type ActivitiesWrites,
+  type ActivityItem,
   activitiesScope,
+  type CreatedActivity,
 } from "./types";
 
 export function createActivitiesModule(ctx: ModuleContext): ActivitiesModule {
@@ -194,6 +193,7 @@ export function createActivitiesModule(ctx: ModuleContext): ActivitiesModule {
     setStatusBySessionKey,
     rename,
     delete: del,
+    writes: createActivitiesWrites(http),
     dispose,
   };
 }

--- a/packages/sdk/src/modules/activities/types.ts
+++ b/packages/sdk/src/modules/activities/types.ts
@@ -11,7 +11,11 @@
  * `Activity` provides; nothing is invented.
  */
 
-import type { Activity, PendingInteraction } from "@houston/protocol";
+import type {
+  Activity,
+  NewActivity,
+  PendingInteraction,
+} from "@houston/protocol";
 
 /**
  * The canonical activity statuses (`packages/domain/src/activities.ts`,
@@ -64,6 +68,26 @@ export interface CreatedActivity {
   sessionKey: string;
 }
 
+/**
+ * No-refetch board writes for a host that owns its own read model (the web
+ * engine-adapter under `reactivity:false`): each performs the SAME
+ * `POST`/`PATCH`/`DELETE` as its {@link ActivitiesModule} sibling but does NOT
+ * call `refresh()` afterward, and RETURNS the raw wire {@link Activity}
+ * (`create`/`setStatus`/`rename`) so the host updates its cache without an extra
+ * `GET /agents/:id/activities`. The refetching facade methods are untouched —
+ * iOS keeps using those verbatim.
+ */
+export interface ActivitiesWrites {
+  /** `POST /agents/:id/activities`; returns the created wire activity. */
+  create(agentId: string, input: NewActivity): Promise<Activity>;
+  /** `PATCH …/:id` with `{ status }`; returns the updated wire activity. */
+  setStatus(agentId: string, id: string, status: string): Promise<Activity>;
+  /** `PATCH …/:id` with `{ title }`; returns the updated wire activity. */
+  rename(agentId: string, id: string, title: string): Promise<Activity>;
+  /** `DELETE …/:id`. */
+  delete(agentId: string, id: string): Promise<void>;
+}
+
 /** The typed facade for board/missions reads + writes. */
 export interface ActivitiesModule {
   /** Scope string for `sdk.subscribe(...)` / `sdk.getSnapshot(...)`. */
@@ -100,6 +124,12 @@ export interface ActivitiesModule {
   rename(agentId: string, id: string, title: string): Promise<void>;
   /** Delete a mission, then refetch. */
   delete(agentId: string, id: string): Promise<void>;
+  /**
+   * No-refetch write variants for a host that owns its own reads (web under
+   * `reactivity:false`): same wire writes, no post-write `refresh()`, and they
+   * return the wire entity. iOS keeps using the refetching methods above.
+   */
+  writes: ActivitiesWrites;
   /** Stop the reactivity stream. Module-local; the kernel calls it on dispose. */
   dispose(): void;
 }

--- a/packages/sdk/src/modules/activities/writes.test.ts
+++ b/packages/sdk/src/modules/activities/writes.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SdkConfig, SdkPorts } from "../../ports";
+import { HoustonSdk } from "../../sdk";
+import { type ActivitiesViewModel, activitiesScope } from "./index";
+
+const BASE = "http://127.0.0.1:4317";
+const AGENT = "ag_1";
+
+interface Recorded {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+/**
+ * A write-only SDK (`reactivity:false`, so NO `/v1/events` stream) over a mock
+ * `fetch` that records every `/activities` call. `reactivity:false` is what lets
+ * a "does not refetch" assertion be exact: a GET on the list route can only come
+ * from a facade `refresh()` — a no-refetch write must issue none.
+ */
+function makeSdk() {
+  const calls: Recorded[] = [];
+  const wireActivity = (over: Record<string, unknown>) => ({
+    id: "m1",
+    title: "T",
+    description: "",
+    status: "running",
+    ...over,
+  });
+  const fetchImpl = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      const body =
+        init?.body === undefined ? undefined : JSON.parse(String(init.body));
+      calls.push({ method, path: url.pathname, body });
+      if (url.pathname.endsWith("/v1/events"))
+        return new Response("", { status: 200 });
+      if (method === "GET") return json({ items: [] });
+      if (method === "DELETE") return json({ ok: true });
+      // POST create / PATCH update echo a wire Activity.
+      return json(wireActivity((body as Record<string, unknown>) ?? {}));
+    },
+  );
+  const json = (b: unknown) =>
+    new Response(JSON.stringify(b), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  const store = new Map<string, string>();
+  const ports: SdkPorts = {
+    fetch: fetchImpl as unknown as typeof fetch,
+    storage: {
+      get: async (k) => store.get(k) ?? null,
+      set: async (k, v) => void store.set(k, v),
+      delete: async (k) => void store.delete(k),
+    },
+    clock: {
+      now: () => 0,
+      setTimeout: () => 0,
+      clearTimeout: () => {},
+    },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+  const config: SdkConfig = { baseUrl: BASE, ports, reactivity: false };
+  const sdk = new HoustonSdk(config);
+  return { sdk, calls };
+}
+
+const base = `/agents/${AGENT}/activities`;
+const gets = (calls: Recorded[]) => calls.filter((c) => c.method === "GET");
+
+describe("activities module — no-refetch writes", () => {
+  it("writes.create POSTs the input and returns the wire activity, no refetch", async () => {
+    const { sdk, calls } = makeSdk();
+    const created = await sdk.activities.writes.create(AGENT, {
+      title: "Reconcile",
+    });
+    expect(calls).toEqual([
+      { method: "POST", path: base, body: { title: "Reconcile" } },
+    ]);
+    expect(created).toMatchObject({ id: "m1", title: "Reconcile" });
+    expect(gets(calls)).toEqual([]); // no refresh() GET
+    expect(sdk.getSnapshot(activitiesScope(AGENT))).toBeUndefined();
+    sdk.dispose();
+  });
+
+  it("writes.setStatus PATCHes { status } and returns the activity, no refetch", async () => {
+    const { sdk, calls } = makeSdk();
+    const updated = await sdk.activities.writes.setStatus(AGENT, "m1", "done");
+    expect(calls).toEqual([
+      { method: "PATCH", path: `${base}/m1`, body: { status: "done" } },
+    ]);
+    expect(updated).toMatchObject({ id: "m1", status: "done" });
+    expect(gets(calls)).toEqual([]);
+    sdk.dispose();
+  });
+
+  it("writes.rename PATCHes { title }, no refetch", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.activities.writes.rename(AGENT, "m1", "New title");
+    expect(calls).toEqual([
+      { method: "PATCH", path: `${base}/m1`, body: { title: "New title" } },
+    ]);
+    expect(gets(calls)).toEqual([]);
+    sdk.dispose();
+  });
+
+  it("writes.delete DELETEs, no refetch", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.activities.writes.delete(AGENT, "m1");
+    expect(calls).toEqual([{ method: "DELETE", path: `${base}/m1` }]);
+    expect(gets(calls)).toEqual([]);
+    sdk.dispose();
+  });
+
+  it("the refetching facade create() DOES list afterward (contrast)", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.activities.create(AGENT, "Reconcile");
+    // POST then a GET list (the facade's refresh) — the behavior iOS relies on.
+    expect(calls.map((c) => c.method)).toEqual(["POST", "GET"]);
+    const snap = sdk.getSnapshot(activitiesScope(AGENT)) as ActivitiesViewModel;
+    expect(snap.loaded).toBe(true);
+    sdk.dispose();
+  });
+});

--- a/packages/sdk/src/modules/agents/agents.test.ts
+++ b/packages/sdk/src/modules/agents/agents.test.ts
@@ -77,6 +77,8 @@ interface Harness {
     agents: WireAgent[];
     listCalls: number;
     posted: unknown[];
+    /** Every non-GET `/agents` call (POST/PATCH/DELETE): method + path + body. */
+    mutations: { method: string; path: string; body?: unknown }[];
     eventsResponder: () => Response | Promise<Response>;
   };
 }
@@ -86,6 +88,9 @@ function makeHarness(
     agents?: WireAgent[];
     agentsStatus?: number;
     eventsResponder?: () => Response | Promise<Response>;
+    /** `false` opens NO `/v1/events` stream (write-only host), so no background
+     *  refetch can confound a "does not refetch" assertion. Default: on. */
+    reactivity?: boolean;
   } = {},
 ): Harness {
   const clock = makeClock();
@@ -93,8 +98,12 @@ function makeHarness(
     agents: overrides.agents ?? [],
     listCalls: 0,
     posted: [],
+    mutations: [],
     eventsResponder: overrides.eventsResponder ?? closedSse,
   };
+  const path = (url: string) => new URL(url).pathname;
+  const parseBody = (init?: RequestInit) =>
+    init?.body === undefined ? undefined : JSON.parse(String(init.body));
   const json = (body: unknown, status = 200) =>
     new Response(JSON.stringify(body), {
       status,
@@ -114,8 +123,9 @@ function makeHarness(
         return json(state.agents);
       }
       if (url.endsWith("/agents") && method === "POST") {
-        const body = JSON.parse(String(init?.body)) as { name: string };
+        const body = parseBody(init) as { name: string };
         state.posted.push(body);
+        state.mutations.push({ method, path: path(url), body });
         const agent: WireAgent = {
           id: `id-${state.agents.length + 1}`,
           workspaceId: "w1",
@@ -128,7 +138,8 @@ function makeHarness(
       const single = url.match(/\/agents\/([^/]+)$/);
       if (single && method === "PATCH") {
         const id = decodeURIComponent(single[1]);
-        const body = JSON.parse(String(init?.body)) as { name: string };
+        const body = parseBody(init) as { name: string };
+        state.mutations.push({ method, path: path(url), body });
         state.agents = state.agents.map((a) =>
           a.id === id ? { ...a, name: body.name } : a,
         );
@@ -136,6 +147,7 @@ function makeHarness(
       }
       if (single && method === "DELETE") {
         const id = decodeURIComponent(single[1]);
+        state.mutations.push({ method, path: path(url) });
         state.agents = state.agents.filter((a) => a.id !== id);
         return json({ ok: true });
       }
@@ -158,7 +170,13 @@ function makeHarness(
     clock: clock.clock,
     logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
   };
-  const config: SdkConfig = { baseUrl: BASE, ports };
+  const config: SdkConfig = {
+    baseUrl: BASE,
+    ports,
+    ...(overrides.reactivity !== undefined
+      ? { reactivity: overrides.reactivity }
+      : {}),
+  };
   const sdk = new HoustonSdk(config);
   const events: SdkEvent[] = [];
   sdk.on((e) => events.push(e));
@@ -310,6 +328,60 @@ describe("agents module — reactivity", () => {
     await vi.waitFor(() => expect(h.state.listCalls).toBe(2));
     // The ActivityChanged frame did not add its own refetch.
     expect(h.state.listCalls).toBe(2);
+  });
+});
+
+describe("agents module — no-refetch writes", () => {
+  // reactivity:false → no /v1/events stream, so `listCalls` (GET /agents) counts
+  // ONLY a facade refresh(). A write variant must leave it at 0.
+  it("writes.create posts the full body, returns the agent, and does NOT refetch", async () => {
+    const h = makeHarness({ agents: [], reactivity: false });
+    disposeCurrent = h.sdk.agents.dispose;
+    const created = await h.sdk.agents.writes.create({
+      name: "Newton",
+      claudeMd: "# hi",
+      seeds: { "a.txt": "x" },
+    });
+    expect(h.state.mutations).toEqual([
+      {
+        method: "POST",
+        path: "/agents",
+        body: { name: "Newton", claudeMd: "# hi", seeds: { "a.txt": "x" } },
+      },
+    ]);
+    expect(created).toMatchObject({ id: "id-1", name: "Newton" });
+    expect(h.state.listCalls).toBe(0); // no refresh() GET
+    // The write publishes NOTHING itself: any snapshot is only the module's
+    // async loading seed, never the created agent.
+    expect(snapshot(h.sdk)?.items ?? []).toEqual([]);
+  });
+
+  it("writes.create with only a name posts exactly {name} (iOS-identical body)", async () => {
+    const h = makeHarness({ agents: [], reactivity: false });
+    disposeCurrent = h.sdk.agents.dispose;
+    await h.sdk.agents.writes.create({ name: "Solo" });
+    expect(h.state.mutations[0]?.body).toEqual({ name: "Solo" });
+  });
+
+  it("writes.rename PATCHes and returns the updated agent, no refetch", async () => {
+    const h = makeHarness({ agents: [A("a1", "Old")], reactivity: false });
+    disposeCurrent = h.sdk.agents.dispose;
+    const renamed = await h.sdk.agents.writes.rename("a1", "New");
+    expect(h.state.mutations).toEqual([
+      { method: "PATCH", path: "/agents/a1", body: { name: "New" } },
+    ]);
+    expect(renamed).toMatchObject({ id: "a1", name: "New" });
+    expect(h.state.listCalls).toBe(0);
+  });
+
+  it("writes.delete DELETEs and does NOT refetch", async () => {
+    const h = makeHarness({ agents: [A("a1", "Gone")], reactivity: false });
+    disposeCurrent = h.sdk.agents.dispose;
+    await h.sdk.agents.writes.delete("a1");
+    expect(h.state.mutations).toEqual([
+      { method: "DELETE", path: "/agents/a1" },
+    ]);
+    expect(h.state.listCalls).toBe(0);
   });
 });
 

--- a/packages/sdk/src/modules/agents/http.ts
+++ b/packages/sdk/src/modules/agents/http.ts
@@ -15,7 +15,7 @@
  */
 
 import type { SdkPorts } from "../../ports";
-import type { WireAgent } from "./types";
+import type { AgentCreateInput, WireAgent } from "./types";
 
 /** A failed `/agents` request. `status` is the upstream HTTP status. */
 export class AgentsHttpError extends Error {
@@ -31,7 +31,7 @@ export class AgentsHttpError extends Error {
 /** The four agent-list operations the module needs. */
 export interface AgentsHttp {
   list(): Promise<WireAgent[]>;
-  create(name: string): Promise<WireAgent>;
+  create(input: AgentCreateInput): Promise<WireAgent>;
   rename(id: string, name: string): Promise<WireAgent>;
   remove(id: string): Promise<void>;
 }
@@ -63,10 +63,12 @@ export function createAgentsHttp(
     async list() {
       return (await (await req("/agents")).json()) as WireAgent[];
     },
-    async create(name) {
+    async create(input) {
+      // `JSON.stringify` drops undefined optionals, so a `{ name }` input posts
+      // exactly `{ "name": … }` — byte-identical to the legacy body iOS sends.
       const res = await req("/agents", {
         method: "POST",
-        body: JSON.stringify({ name }),
+        body: JSON.stringify(input),
       });
       return (await res.json()) as WireAgent;
     },

--- a/packages/sdk/src/modules/agents/index.ts
+++ b/packages/sdk/src/modules/agents/index.ts
@@ -21,13 +21,21 @@ import { startAgentsEventStream } from "./events-stream";
 import { createAgentsHttp } from "./http";
 import {
   AGENTS_SCOPE,
+  type AgentCreateInput,
   AgentsCommand,
   type AgentsViewModel,
+  type AgentsWrites,
   type WireAgent,
 } from "./types";
 
 export { AgentsHttpError } from "./http";
-export type { AgentListItem, AgentsViewModel, WireAgent } from "./types";
+export type {
+  AgentCreateInput,
+  AgentListItem,
+  AgentsViewModel,
+  AgentsWrites,
+  WireAgent,
+} from "./types";
 export {
   AGENTS_CHANGED_EVENT,
   AGENTS_SCOPE,
@@ -45,6 +53,12 @@ export interface AgentsModule {
   rename(id: string, name: string): Promise<void>;
   /** Delete agent `id`, then refetch. */
   delete(id: string): Promise<void>;
+  /**
+   * No-refetch write variants for a host that owns its own reads (web under
+   * `reactivity:false`): same wire writes, no post-write `refresh()`, and they
+   * return the wire entity. iOS keeps using the refetching methods above.
+   */
+  writes: AgentsWrites;
   /** Stop the reactivity stream. Module-local; the kernel has no dispose seam. */
   dispose(): void;
 }
@@ -87,7 +101,7 @@ export function createAgentsModule(ctx: ModuleContext): AgentsModule {
   }
 
   async function create(name: string): Promise<void> {
-    await http.create(name);
+    await http.create({ name });
     await refresh();
   }
   async function rename(id: string, name: string): Promise<void> {
@@ -98,6 +112,14 @@ export function createAgentsModule(ctx: ModuleContext): AgentsModule {
     await http.remove(id);
     await refresh();
   }
+
+  // No-refetch writes: the underlying http op verbatim (returns the wire
+  // entity), WITHOUT the post-write refresh. For a host that owns its reads.
+  const writes: AgentsWrites = {
+    create: (input: AgentCreateInput) => http.create(input),
+    rename: (id, name) => http.rename(id, name),
+    delete: (id) => http.remove(id),
+  };
 
   ctx.registerCommand(AgentsCommand.Refresh, () => refresh());
   ctx.registerCommand(AgentsCommand.Create, (p) =>
@@ -148,5 +170,5 @@ export function createAgentsModule(ctx: ModuleContext): AgentsModule {
           },
         });
 
-  return { refresh, create, rename, delete: del, dispose };
+  return { refresh, create, rename, delete: del, writes, dispose };
 }

--- a/packages/sdk/src/modules/agents/types.ts
+++ b/packages/sdk/src/modules/agents/types.ts
@@ -29,6 +29,38 @@ export interface AgentListItem {
   createdAt: number;
 }
 
+/**
+ * The full create body the host's `POST /agents` accepts (protocol v3): a
+ * required `name`, plus the optional seed payload a rich create carries —
+ * `claudeMd` (the agent's CLAUDE.md) and `seeds` (a relative-path → contents
+ * map the host writes into the new agent). `JSON.stringify` drops the undefined
+ * optionals, so a `{ name }` create posts exactly `{ name }` on the wire (the
+ * shape the existing {@link AgentsModule.create} facade and the bridge command
+ * send — unchanged). Used by the no-refetch {@link AgentsWrites.create}.
+ */
+export interface AgentCreateInput {
+  name: string;
+  claudeMd?: string;
+  seeds?: Record<string, string>;
+}
+
+/**
+ * No-refetch agent writes for a host that owns its own read model (the web
+ * engine-adapter under `reactivity:false`): each performs the SAME `POST`/
+ * `PATCH`/`DELETE` as its {@link AgentsModule} sibling but does NOT call
+ * `refresh()` afterward, and RETURNS the wire entity (`create`/`rename`) so the
+ * host can update its cache without an extra `GET /agents`. The refetching
+ * facade methods are untouched — iOS keeps using those verbatim.
+ */
+export interface AgentsWrites {
+  /** `POST /agents` with the full body; returns the created agent (with id). */
+  create(input: AgentCreateInput): Promise<WireAgent>;
+  /** `PATCH /agents/:id`; returns the updated agent. */
+  rename(id: string, name: string): Promise<WireAgent>;
+  /** `DELETE /agents/:id`. */
+  delete(id: string): Promise<void>;
+}
+
 /** The `agents` scope view-model: the WHOLE snapshot, republished on any change. */
 export interface AgentsViewModel {
   /** False until the first successful list resolves; true thereafter. */

--- a/packages/sdk/src/modules/integrations/index.ts
+++ b/packages/sdk/src/modules/integrations/index.ts
@@ -33,6 +33,7 @@ import {
   requireStringArray,
   unavailableVm,
 } from "./types";
+import { createIntegrationsWrites, type IntegrationsWrites } from "./writes";
 
 export type {
   IntegrationConnection,
@@ -42,6 +43,7 @@ export type {
   IntegrationToolkit,
 } from "./types";
 export { INTEGRATIONS_SCOPE, IntegrationsCommand } from "./types";
+export type { IntegrationsWrites } from "./writes";
 
 /** The result of a connect: the URL the surface opens, plus the id to poll. */
 export interface ConnectResult {
@@ -55,8 +57,14 @@ export interface IntegrationsModule {
   readonly scope: string;
   /** Refetch readiness + catalog + connections and republish the VM. */
   refresh(): Promise<IntegrationsViewModel>;
-  /** Start an OAuth connect; the surface opens `redirectUrl`, then polls. */
+  /** Start an OAuth connect (composio); the surface opens `redirectUrl`, then polls. */
   connect(toolkit: string): Promise<ConnectResult>;
+  /** Provider-scoped connect (additive): `agent` scopes it to one agent slug. */
+  connect(
+    provider: string,
+    toolkit: string,
+    agent?: string,
+  ): Promise<ConnectResult>;
   /** Poll one connection until its OAuth finishes (status flips to active). */
   pollConnection(connectionId: string): Promise<IntegrationConnection>;
   /** Disconnect a toolkit everywhere, then refetch the VM. */
@@ -65,6 +73,13 @@ export interface IntegrationsModule {
   grants(agentId: string): Promise<string[] | null>;
   /** Replace `agentId`'s granted toolkit slugs. */
   setGrants(agentId: string, toolkits: string[]): Promise<void>;
+  /** Push the caller's Supabase token to the gateway adapter (`null` on sign-out). */
+  setSession(token: string | null): Promise<void>;
+  /** Dismiss the one-time "reconnect your integrations" notice (idempotent). */
+  dismissReconnectNotice(): Promise<void>;
+  /** No-refetch write variants for a host that owns its own reads (web under
+   *  `reactivity:false`). The refetching methods above are untouched (iOS-safe). */
+  writes: IntegrationsWrites;
 }
 
 export function createIntegrationsModule(
@@ -117,8 +132,26 @@ export function createIntegrationsModule(
     return publish({ loaded: true, ready: true, toolkits, connections });
   }
 
-  async function connect(toolkit: string): Promise<ConnectResult> {
-    return run(() => client.connect(toolkit));
+  function connect(toolkit: string): Promise<ConnectResult>;
+  function connect(
+    provider: string,
+    toolkit: string,
+    agent?: string,
+  ): Promise<ConnectResult>;
+  function connect(
+    a: string,
+    b?: string,
+    agent?: string,
+  ): Promise<ConnectResult> {
+    // 1-arg = legacy `connect(toolkit)` (composio, `{ toolkit }` body — what the
+    // bridge command / iOS send, unchanged); 3-arg = `(provider, toolkit, agent?)`.
+    const [provider, toolkit] = b === undefined ? [undefined, a] : [a, b];
+    return run(() =>
+      client.connect(toolkit, {
+        ...(provider ? { provider } : {}),
+        ...(agent ? { agent } : {}),
+      }),
+    );
   }
 
   function pollConnection(
@@ -173,5 +206,6 @@ export function createIntegrationsModule(
     disconnect,
     grants,
     setGrants,
+    ...createIntegrationsWrites(client, run),
   };
 }

--- a/packages/sdk/src/modules/integrations/writes.test.ts
+++ b/packages/sdk/src/modules/integrations/writes.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SdkConfig, SdkPorts } from "../../ports";
+import { HoustonSdk } from "../../sdk";
+import { IntegrationsCommand } from "./index";
+
+const BASE = "http://127.0.0.1:4317";
+
+interface Recorded {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+/** A write-only SDK (`reactivity:false`) over a mock `fetch` recording every
+ *  `/v1/integrations` call. The refetching facade `disconnect` ends with a
+ *  `refresh()` (GET /v1/integrations …); a no-refetch write issues no GET. */
+function makeSdk() {
+  const calls: Recorded[] = [];
+  const json = (b: unknown) =>
+    new Response(JSON.stringify(b), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  const fetchImpl = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      const body =
+        init?.body === undefined ? undefined : JSON.parse(String(init.body));
+      calls.push({ method, path: url.pathname, body });
+      const p = url.pathname;
+      if (p.endsWith("/connect"))
+        return json({ redirectUrl: "u", connectionId: "c1" });
+      if (p === "/v1/integrations")
+        return json({ items: [{ provider: "composio", ready: true }] });
+      if (p.endsWith("/toolkits") || p.endsWith("/connections"))
+        return json({ items: [] });
+      return json({ ok: true });
+    },
+  );
+  const store = new Map<string, string>();
+  const ports: SdkPorts = {
+    fetch: fetchImpl as unknown as typeof fetch,
+    storage: {
+      get: async (k) => store.get(k) ?? null,
+      set: async (k, v) => void store.set(k, v),
+      delete: async (k) => void store.delete(k),
+    },
+    clock: { now: () => 0, setTimeout: () => 0, clearTimeout: () => {} },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+  const config: SdkConfig = { baseUrl: BASE, ports, reactivity: false };
+  return { sdk: new HoustonSdk(config), calls };
+}
+
+const I = "/v1/integrations";
+const gets = (c: Recorded[]) => c.filter((x) => x.method === "GET");
+
+describe("integrations module — connect overload", () => {
+  it("connect(toolkit) posts { toolkit } to the composio route (legacy, iOS-safe)", async () => {
+    const { sdk, calls } = makeSdk();
+    const res = await sdk.integrations.connect("gmail");
+    expect(res).toEqual({ redirectUrl: "u", connectionId: "c1" });
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${I}/composio/connect`,
+        body: { toolkit: "gmail" },
+      },
+    ]);
+    sdk.dispose();
+  });
+
+  it("connect(provider, toolkit, agent) posts { toolkit, agent } to the provider route", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.integrations.connect("composio", "gmail", "ag_1");
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${I}/composio/connect`,
+        body: { toolkit: "gmail", agent: "ag_1" },
+      },
+    ]);
+    sdk.dispose();
+  });
+
+  it("the bridge dispatch path still posts the legacy composio { toolkit } body", async () => {
+    const { sdk, calls } = makeSdk();
+    const ok = await sdk.dispatch({
+      id: "c1",
+      type: IntegrationsCommand.Connect,
+      payload: { toolkit: "slack" },
+    });
+    expect(ok).toMatchObject({ id: "c1", ok: true });
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${I}/composio/connect`,
+        body: { toolkit: "slack" },
+      },
+    ]);
+    sdk.dispose();
+  });
+});
+
+describe("integrations module — no-refetch writes + session/notice ops", () => {
+  it("writes.disconnect POSTs disconnect and does NOT refetch", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.integrations.writes.disconnect("gmail");
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${I}/composio/disconnect`,
+        body: { toolkit: "gmail" },
+      },
+    ]);
+    expect(gets(calls)).toEqual([]);
+    sdk.dispose();
+  });
+
+  it("the refetching facade disconnect() DOES refetch afterward (contrast)", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.integrations.disconnect("gmail");
+    // POST then the refresh reads: GET /v1/integrations, toolkits, connections.
+    expect(calls[0]).toEqual({
+      method: "POST",
+      path: `${I}/composio/disconnect`,
+      body: { toolkit: "gmail" },
+    });
+    expect(gets(calls).map((c) => c.path)).toEqual([
+      I,
+      `${I}/composio/toolkits`,
+      `${I}/composio/connections`,
+    ]);
+    sdk.dispose();
+  });
+
+  it("setSession PUTs { token } to the gateway session sink", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.integrations.setSession("jwt-1");
+    expect(calls).toEqual([
+      { method: "PUT", path: `${I}/session`, body: { token: "jwt-1" } },
+    ]);
+    sdk.dispose();
+  });
+
+  it("setSession(null) PUTs { token: null } (sign-out)", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.integrations.setSession(null);
+    expect(calls).toEqual([
+      { method: "PUT", path: `${I}/session`, body: { token: null } },
+    ]);
+    sdk.dispose();
+  });
+
+  it("dismissReconnectNotice POSTs the dismiss route", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.integrations.dismissReconnectNotice();
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${I}/reconnect-notice/dismiss`,
+        body: undefined,
+      },
+    ]);
+    sdk.dispose();
+  });
+});

--- a/packages/sdk/src/modules/integrations/writes.ts
+++ b/packages/sdk/src/modules/integrations/writes.ts
@@ -1,0 +1,48 @@
+/**
+ * The integrations module's no-refetch writes + the gateway session/notice ops
+ * a host needs that have no refetching facade sibling.
+ *
+ * `writes.disconnect` is the {@link IntegrationsModule.disconnect} write WITHOUT
+ * the post-write `refresh()` — for a host that owns its own read model (the web
+ * engine-adapter under `reactivity:false`). `setSession` and
+ * `dismissReconnectNotice` are new user-scoped gateway calls (no prior SDK
+ * equivalent). Every call routes through the shared `run` wrapper so a 401 still
+ * surfaces as the SDK's `session/tokenExpired` signal.
+ *
+ * Kept out of `index.ts` so the module factory there stays within the file-size
+ * budget; the refetching facade methods there are untouched (iOS-safe).
+ */
+
+import type { IntegrationsClient } from "@houston/runtime-client";
+
+/** No-refetch integration writes for a host that owns its own reads. */
+export interface IntegrationsWrites {
+  /** Disconnect a toolkit for the user everywhere; no refetch. `opts.provider`
+   *  defaults to composio (the only provider today). */
+  disconnect(toolkit: string, opts?: { provider?: string }): Promise<void>;
+}
+
+/** The session/notice ops plus the {@link IntegrationsWrites} namespace. */
+export interface IntegrationsWriteOps {
+  /** Push the caller's Supabase token to the gateway adapter (`null` on sign-out).
+   *  Errors propagate (a 404 = no session sink is the CALLER's call to ignore). */
+  setSession(token: string | null): Promise<void>;
+  /** Dismiss the one-time "reconnect your integrations" notice (idempotent). */
+  dismissReconnectNotice(): Promise<void>;
+  /** No-refetch write variants for a host that owns its own reads. */
+  writes: IntegrationsWrites;
+}
+
+export function createIntegrationsWrites(
+  client: IntegrationsClient,
+  run: <T>(fn: () => Promise<T>) => Promise<T>,
+): IntegrationsWriteOps {
+  return {
+    setSession: (token) => run(() => client.setSession(token)),
+    dismissReconnectNotice: () => run(() => client.dismissReconnectNotice()),
+    writes: {
+      disconnect: (toolkit, opts) =>
+        run(() => client.disconnect(toolkit, opts)),
+    },
+  };
+}

--- a/packages/sdk/src/modules/providers/index.ts
+++ b/packages/sdk/src/modules/providers/index.ts
@@ -39,15 +39,19 @@ import {
   type ProvidersModule,
   providersScope,
 } from "./types";
+import { createProviderWrites } from "./writes";
 
 export { mergeProviders, overlayStatus } from "./merge";
 export type {
+  AuthStatus,
+  CustomEndpoint,
   LoginInfo,
   LoginOptions,
   LoginState,
   ProviderId,
   ProvidersModule,
   ProvidersViewModel,
+  ProvidersWrites,
   ProviderVM,
   SetModelOptions,
 } from "./types";
@@ -58,7 +62,8 @@ export {
 } from "./types";
 
 export function createProvidersModule(ctx: ModuleContext): ProvidersModule {
-  const ops = createProviderOps(ctx);
+  const writes = createProviderWrites(ctx);
+  const ops = createProviderOps(ctx, writes);
 
   ctx.registerCommand(ProvidersCommand.Refresh, (p) =>
     ops.refresh(parseRefresh(p).agentId),
@@ -91,5 +96,5 @@ export function createProvidersModule(ctx: ModuleContext): ProvidersModule {
     return ops.setModel(agentId, { model, effort, provider });
   });
 
-  return { scope: providersScope, ...ops };
+  return { scope: providersScope, ...ops, writes };
 }

--- a/packages/sdk/src/modules/providers/operations.ts
+++ b/packages/sdk/src/modules/providers/operations.ts
@@ -11,13 +11,13 @@
  */
 
 import type { ModuleContext } from "../../module-context";
-import { resolveModelSettings } from "../turns/model-settings";
 import { mergeProviders, overlayStatus } from "./merge";
 import {
   type LoginInfo,
   type LoginOptions,
   type ProviderId,
   type ProvidersViewModel,
+  type ProvidersWrites,
   providersScope,
   type SetModelOptions,
 } from "./types";
@@ -41,7 +41,10 @@ export interface ProviderOps {
   setModel(agentId: string, opts: SetModelOptions): Promise<void>;
 }
 
-export function createProviderOps(ctx: ModuleContext): ProviderOps {
+export function createProviderOps(
+  ctx: ModuleContext,
+  writes: ProvidersWrites,
+): ProviderOps {
   const { store } = ctx;
 
   // Monotonic per-agent request sequence: a slow full refresh that resolves
@@ -117,17 +120,19 @@ export function createProviderOps(ctx: ModuleContext): ProviderOps {
     await refresh(agentId);
   }
 
+  // Credential writes delegate to the no-refetch primitives (`writes.ts`) and
+  // then refresh — one implementation of each underlying call, no drift.
   async function setApiKey(
     agentId: string,
     provider: ProviderId,
     key: string,
   ): Promise<void> {
-    await ctx.clientFor(agentId).setApiKey(provider, key);
+    await writes.setApiKey(agentId, provider, key);
     await refresh(agentId);
   }
 
   async function logout(agentId: string, provider: ProviderId): Promise<void> {
-    await ctx.clientFor(agentId).logout(provider);
+    await writes.logout(agentId, provider);
     await refresh(agentId);
   }
 
@@ -135,19 +140,7 @@ export function createProviderOps(ctx: ModuleContext): ProviderOps {
     agentId: string,
     opts: SetModelOptions,
   ): Promise<void> {
-    const client = ctx.clientFor(agentId);
-    // Reuse the shared resolver: it pairs a model with its owning provider (the
-    // runtime hard-fails a model that belongs to a different active provider).
-    // `mode` is a per-turn pin only — never an agent-wide setting (HOU-695) —
-    // so a settings write always resolves it as undefined.
-    const settings = await resolveModelSettings(
-      client,
-      opts.model,
-      opts.effort,
-      undefined,
-    );
-    if (opts.provider !== undefined) settings.activeProvider = opts.provider;
-    await client.setSettings(settings);
+    await writes.setModel(agentId, opts);
     await refresh(agentId);
   }
 

--- a/packages/sdk/src/modules/providers/types.ts
+++ b/packages/sdk/src/modules/providers/types.ts
@@ -16,12 +16,14 @@
  */
 
 import type {
+  AuthStatus,
+  CustomEndpoint,
   LoginInfo,
   LoginState,
   ProviderId,
 } from "@houston/runtime-client";
 
-export type { LoginInfo, LoginState, ProviderId };
+export type { AuthStatus, CustomEndpoint, LoginInfo, LoginState, ProviderId };
 
 /**
  * One provider inside the `providers/<agentId>` snapshot: the `ProviderInfo`
@@ -99,6 +101,31 @@ export interface SetModelOptions {
 }
 
 /**
+ * No-refetch provider writes for a host that owns its own read model (the web
+ * engine-adapter under `reactivity:false`): each performs the SAME per-agent-pod
+ * runtime call as its {@link ProvidersModule} sibling but does NOT publish/
+ * refresh the merged `providers/<agentId>` snapshot afterward — the host owns
+ * that invalidation. `status` is the raw `GET /auth/status` read (no publish);
+ * `setCustomEndpoint` (`POST /providers/openai-compatible`) has no refetching
+ * facade sibling and is exposed here only. The login flow's imperative state
+ * (login/cancelLogin/completeLogin) is deliberately NOT here — the surface owns
+ * that poller (see `index.ts`). The refetching facade methods are untouched — iOS
+ * keeps using those verbatim.
+ */
+export interface ProvidersWrites {
+  /** `GET /auth/status` for the agent's pod; returns it raw, publishes nothing. */
+  status(agentId: string): Promise<AuthStatus>;
+  /** Store an API key for an api-key provider; no refetch. */
+  setApiKey(agentId: string, provider: ProviderId, key: string): Promise<void>;
+  /** Disconnect a provider; no refetch. */
+  logout(agentId: string, provider: ProviderId): Promise<void>;
+  /** Apply a model/effort/provider switch (resolveModelSettings); no refetch. */
+  setModel(agentId: string, opts: SetModelOptions): Promise<void>;
+  /** Connect an OpenAI-compatible (local) server; LOCAL profile only. No refetch. */
+  setCustomEndpoint(agentId: string, endpoint: CustomEndpoint): Promise<void>;
+}
+
+/**
  * The typed facade for per-agent provider reads + writes.
  *
  * Every mutating call refreshes the agent's snapshot before it resolves, so a
@@ -138,4 +165,10 @@ export interface ProvidersModule {
   logout(agentId: string, provider: ProviderId): Promise<void>;
   /** Apply a model/effort/provider switch (resolveModelSettings), then refresh. */
   setModel(agentId: string, opts: SetModelOptions): Promise<void>;
+  /**
+   * No-refetch write variants for a host that owns its own reads (web under
+   * `reactivity:false`): same runtime calls, no post-write snapshot refresh,
+   * plus `setCustomEndpoint`. iOS keeps using the refetching methods above.
+   */
+  writes: ProvidersWrites;
 }

--- a/packages/sdk/src/modules/providers/writes.test.ts
+++ b/packages/sdk/src/modules/providers/writes.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import type { SdkConfig, SdkPorts } from "../../ports";
+import { HoustonSdk } from "../../sdk";
+import { providersScope } from "./index";
+
+const BASE = "http://127.0.0.1:4317";
+const AGENT = "ag_1";
+const root = `/agents/${AGENT}`;
+
+interface Recorded {
+  method: string;
+  path: string;
+  body?: unknown;
+}
+
+/**
+ * A write-only SDK (`reactivity:false`) over a mock `fetch` recording every
+ * per-agent runtime call. The refetching facade writes end with a full
+ * `refresh()` = `GET /providers` + `GET /auth/status`; a no-refetch write must
+ * NOT issue that trailing `GET /auth/status`, so counting it pins "no refetch".
+ */
+function makeSdk() {
+  const calls: Recorded[] = [];
+  const json = (b: unknown) =>
+    new Response(JSON.stringify(b), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  const fetchImpl = vi.fn(
+    async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+      const url = new URL(String(input));
+      const method = init?.method ?? "GET";
+      const body =
+        init?.body === undefined ? undefined : JSON.parse(String(init.body));
+      calls.push({ method, path: url.pathname, body });
+      const p = url.pathname;
+      if (p.endsWith("/auth/status"))
+        return json({ activeProvider: "claude", providers: [] });
+      if (p.endsWith("/providers"))
+        return json([
+          {
+            id: "claude",
+            name: "Claude",
+            configured: true,
+            activeModel: "",
+            models: ["opus"],
+          },
+        ]);
+      return json({ ok: true });
+    },
+  );
+  const store = new Map<string, string>();
+  const ports: SdkPorts = {
+    fetch: fetchImpl as unknown as typeof fetch,
+    storage: {
+      get: async (k) => store.get(k) ?? null,
+      set: async (k, v) => void store.set(k, v),
+      delete: async (k) => void store.delete(k),
+    },
+    clock: { now: () => 0, setTimeout: () => 0, clearTimeout: () => {} },
+    logger: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  };
+  const config: SdkConfig = { baseUrl: BASE, ports, reactivity: false };
+  return { sdk: new HoustonSdk(config), calls };
+}
+
+const statusGets = (calls: Recorded[]) =>
+  calls.filter((c) => c.method === "GET" && c.path.endsWith("/auth/status"));
+
+describe("providers module — no-refetch writes", () => {
+  it("writes.status GETs /auth/status, returns it, publishes nothing", async () => {
+    const { sdk, calls } = makeSdk();
+    const status = await sdk.providers.writes.status(AGENT);
+    expect(calls).toEqual([
+      { method: "GET", path: `${root}/auth/status`, body: undefined },
+    ]);
+    expect(status).toEqual({ activeProvider: "claude", providers: [] });
+    expect(sdk.getSnapshot(providersScope(AGENT))).toBeUndefined();
+    sdk.dispose();
+  });
+
+  it("writes.setApiKey POSTs the key and does NOT refetch", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.providers.writes.setApiKey(AGENT, "openai", "sk-1");
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${root}/auth/openai/api-key`,
+        body: { key: "sk-1" },
+      },
+    ]);
+    expect(statusGets(calls)).toEqual([]);
+    sdk.dispose();
+  });
+
+  it("writes.logout POSTs logout and does NOT refetch", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.providers.writes.logout(AGENT, "claude");
+    expect(calls).toEqual([
+      { method: "POST", path: `${root}/auth/claude/logout`, body: undefined },
+    ]);
+    expect(statusGets(calls)).toEqual([]);
+    sdk.dispose();
+  });
+
+  it("writes.setModel resolves the provider then PUTs settings, no status refetch", async () => {
+    const { sdk, calls } = makeSdk();
+    await sdk.providers.writes.setModel(AGENT, { model: "opus" });
+    expect(calls).toEqual([
+      { method: "GET", path: `${root}/providers`, body: undefined },
+      {
+        method: "PUT",
+        path: `${root}/settings`,
+        body: { activeProvider: "claude", model: "opus" },
+      },
+    ]);
+    // The refetching facade would add a trailing GET /auth/status; the write does not.
+    expect(statusGets(calls)).toEqual([]);
+    sdk.dispose();
+  });
+
+  it("writes.setCustomEndpoint POSTs the endpoint (no facade sibling), no refetch", async () => {
+    const { sdk, calls } = makeSdk();
+    const endpoint = { baseUrl: "http://localhost:1234/v1", model: "llama" };
+    await sdk.providers.writes.setCustomEndpoint(AGENT, endpoint);
+    expect(calls).toEqual([
+      {
+        method: "POST",
+        path: `${root}/providers/openai-compatible`,
+        body: endpoint,
+      },
+    ]);
+    expect(statusGets(calls)).toEqual([]);
+    sdk.dispose();
+  });
+});

--- a/packages/sdk/src/modules/providers/writes.ts
+++ b/packages/sdk/src/modules/providers/writes.ts
@@ -1,0 +1,47 @@
+/**
+ * The providers module's no-refetch writes ({@link ProvidersWrites}) — the
+ * per-agent-pod runtime calls surfaced WITHOUT the post-write snapshot refresh
+ * the {@link ProviderOps} facade does, for a host that owns its own read model
+ * (the web engine-adapter under `reactivity:false`).
+ *
+ * These are the write PRIMITIVES: the refetching facade ops (`operations.ts`)
+ * delegate their credential writes here and then call `refresh()`, so there is
+ * one implementation of each underlying call and the two never drift.
+ * `setCustomEndpoint` has no refetching sibling — it is exposed only here.
+ */
+
+import type { ModuleContext } from "../../module-context";
+import { resolveModelSettings } from "../turns/model-settings";
+import type { ProvidersWrites } from "./types";
+
+export function createProviderWrites(ctx: ModuleContext): ProvidersWrites {
+  return {
+    status(agentId) {
+      return ctx.clientFor(agentId).authStatus();
+    },
+    async setApiKey(agentId, provider, key) {
+      await ctx.clientFor(agentId).setApiKey(provider, key);
+    },
+    async logout(agentId, provider) {
+      await ctx.clientFor(agentId).logout(provider);
+    },
+    async setModel(agentId, opts) {
+      const client = ctx.clientFor(agentId);
+      // Reuse the shared resolver: it pairs a model with its owning provider (the
+      // runtime hard-fails a model that belongs to a different active provider).
+      // `mode` is a per-turn pin only — never an agent-wide setting (HOU-695) —
+      // so a settings write always resolves it as undefined.
+      const settings = await resolveModelSettings(
+        client,
+        opts.model,
+        opts.effort,
+        undefined,
+      );
+      if (opts.provider !== undefined) settings.activeProvider = opts.provider;
+      await client.setSettings(settings);
+    },
+    async setCustomEndpoint(agentId, endpoint) {
+      await ctx.clientFor(agentId).setCustomEndpoint(endpoint);
+    },
+  };
+}


### PR DESCRIPTION
## The blocker this unblocks

The web engine-adapter constructs `@houston/sdk` with `reactivity:false` (write-only; web owns its own TanStack Query reads + `/v1/events` invalidation). It therefore **cannot delegate its CRUD** to the SDK's mutating FACADE methods (`agents.create/rename/delete`, `activities.create/setStatus/rename/delete`, `providers.setApiKey/logout/setModel`, `integrations.disconnect`), because each does a post-write `refresh()` (an extra GET) and returns a simplified shape (often `void`) — exactly the refetch `reactivity:false` exists to avoid. Web also needs richer results/ops the facades don't expose (the created agent's `id`, a custom-endpoint write, the integration session/notice ops).

This PR adds the seams so web can delegate, **without changing anything iOS depends on**. Web's actual delegation is a separate later wave (2b).

## The additive / iOS-safe design

`@houston/sdk` is consumed by BOTH the web adapter AND the native iOS app (via the JavaScriptCore bridge, `bridge/entry.ts` → `new HoustonSdk()`). iOS reaches the SDK **only through the bridge** — dispatched COMMANDS (`registerCommand` types) and subscribed SCOPES — never facade methods directly. So this change is strictly additive:

- No existing method signature / route / body / post-write `refresh()` changed.
- **No new command registered** → the bridge cannot route to the new surface → it is unreachable from iOS.
- Every published scope-snapshot shape is unchanged.
- `bridge/`, `commands.ts`, and every `*/commands.ts` are untouched; the registered command set is identical.

## Per-module new surface (all additive)

- **agents** — `writes.create(input) → WireAgent` (takes the full `{ name, claudeMd?, seeds? }` body; the plain `create(name)` facade still posts exactly `{ name }`, byte-identical), `writes.rename(id,name) → WireAgent`, `writes.delete(id)`. All skip `refresh()`.
- **activities** — `writes.create/setStatus/rename/delete`, no refresh, returning the wire `Activity` (`setStatus`/`rename` are the `update` PATCH with `{status}`/`{title}`).
- **providers** — `writes.{status,setApiKey,logout,setModel,setCustomEndpoint}`: the per-agent-pod runtime calls with no snapshot refresh. `setCustomEndpoint` (`POST /providers/openai-compatible`) has no facade sibling. The refetching facade `setApiKey/logout/setModel` now **delegate to these primitives then `refresh()`** (one implementation, no drift).
- **integrations** — additive `connect(provider, toolkit, agent?)` overload (the 1-arg `connect(toolkit)` and its bridge command are byte-identical), `setSession(token)`, `dismissReconnectNotice()`, and `writes.disconnect(toolkit, opts?)` (no refresh).
- **runtime-client `IntegrationsClient`** — additive `setSession`, `dismissReconnectNotice`, and optional `{ provider, agent }` on `connect` / `{ provider }` on `disconnect` (default composio → identical wire).

## Tests

Each new variant gets a vitest asserting the exact route+method+body, that it fires **no second (refresh) request**, and the returned entity shape (mock-`fetch` unit tests with `reactivity:false` to isolate the refetch signal). The integrations connect overload covers **both** the legacy 1-arg and new 3-arg forms, plus the **bridge dispatch path** (proving iOS stays composio `{toolkit}`). New runtime-client test covers the extended `IntegrationsClient`. Full `@houston/sdk` suite (344) + runtime-client suite (88) green; typecheck (whole workspace, incl. `packages/web`), biome, and `check:boundaries` clean.

`packages/web` is intentionally untouched — web delegation (wave 2b) follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)