### PR TITLE
refactor(web): delegate remaining CRUD writes to the SDK (migration wave 2b)

### DIFF
--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -144,6 +144,52 @@ its bridge command are byte-identical to before), and `IntegrationsClient`
 provider/agent on `connect`/`disconnect`. Web's actual delegation to these seams
 is a SEPARATE later wave (2b).
 
+**The wave-2b delegation: web WRITES now go through the SDK.** The engine-adapter
+mixins delegate their control-plane WRITES to the wave-2a seams (byte-identical
+route/method/body/headers incl. `x-houston-org`, no post-write refetch — web
+still owns its TanStack reads + `/v1/events` bus). Per module:
+
+- **Agents** (`client/agents-mixin.ts`) — `createAgent`/`renameAgent`/`deleteAgent`
+  delegate to `sdk.agents.writes.create/rename/delete`. The **color overlay stays
+  adapter-side**: the SDK returns the wire agent (incl. its id), and `cp/agents.ts`
+  `createdAgentToUi`/`renamedAgentToUi` layer web's overlay-only color on top
+  (`setColor`/`moveColor`) then map to the UI `Agent`; delete calls `clearColor` +
+  `dropLastAgentPref` after. `updateAgent` (color-only) + all reads stay. `cp`
+  keeps `createAgent` for the portable-install flow (a `cfg`-scoped function with
+  no SDK handle); it reuses `createdAgentToUi`.
+- **Activities** (`client/activities-mixin.ts`) — `createActivity`/`deleteActivity`
+  delegate to `sdk.activities.writes.create/delete` (local-echo kept adapter-side).
+  `updateActivity` STAYS: it is a GENERIC `ActivityUpdate` PATCH (status +
+  `pending_interaction`, title, …) that no single SDK write (`setStatus {status}`
+  / `rename {title}`) reproduces byte-for-byte — delegating would drop fields.
+- **Integrations** (`client/integrations-mixin.ts`) — `connectIntegration` →
+  `sdk.integrations.connect(provider,toolkit,agent?)`; `disconnectIntegration` →
+  `writes.disconnect(toolkit,{provider})`; `setIntegrationSession` →
+  `setSession`; `dismissIntegrationsReconnectNotice` → `dismissReconnectNotice`.
+  **The setSession 404-swallow is preserved adapter-side**: the SDK PROPAGATES a
+  404 (a deployment with no gateway session sink — self-host / direct-key), so
+  the mixin catches `EngineError` status 404 and returns (benign), rethrowing
+  anything else. Reads stay.
+- **Providers** — NOT delegated; kept adapter-side. The SDK provider writes route
+  through `clientFor(agentId)` (the per-agent runtime client, a single-runtime
+  credential model matching iOS/desktop-new-engine). Web-cloud instead uses the
+  gateway's connect-once CENTRAL-credential routes (`/agents/:id/credential/*`,
+  `/provider/openai-compatible`) with sibling fan-out (OpenCode Zen+Go),
+  `claimActiveProvider`, a `ProviderLoginComplete` event, and the pre-agent
+  setup-runtime path — none of which the SDK writes reproduce. Delegating would
+  change routes and regress connect-once (e.g. `logout` without `forgetCredential`
+  reconnects itself). Provider status also reads `listProviders` (→ `ProviderStatus`),
+  not the SDK writes' `authStatus` (→ `AuthStatus`). The **login-poller state
+  machine** (`provider-login-*.ts`, `activeLogins`/`loginWatchers`) likewise stays
+  adapter-side.
+
+Transient-retry parity holds for every delegated write: `cpFetch`'s
+`transientRetryFetch` only blind-retries GET/HEAD, and the SDK requester never
+retries — so POST/PATCH/PUT/DELETE surface the first response in both paths.
+Errors still reach `errorMessage(err)` → toast; the SDK may throw `EngineError`
+instead of `HoustonEngineError`, which is acceptable (it still surfaces, wave-2a
+precedent). Guarded by `packages/web/tests/sdk-delegation-wave2b.test.ts`.
+
 **The strict-additive / iOS-safe contract rule (why the above is shaped this
 way).** `@houston/sdk` is consumed by BOTH the web engine-adapter AND the native
 iOS app (via the JavaScriptCore bridge, `bridge/entry.ts` → `new HoustonSdk()`).

--- a/packages/web/src/engine-adapter/client/activities-mixin.ts
+++ b/packages/web/src/engine-adapter/client/activities-mixin.ts
@@ -25,8 +25,11 @@ export function ActivitiesMixin<TBase extends BaseCtor>(Base: TBase) {
       agentPath: string,
       input: NewActivity,
     ): Promise<Activity> {
+      // SDK delegates the wire write (byte-identical POST
+      // /agents/:id/activities, no refetch); web keeps its own write-through
+      // echo. Standalone (no host) stays localStorage-backed.
       const activity = this.ctx.cp
-        ? await controlPlane.createActivity(this.ctx.cp, agentPath, input)
+        ? await this.ctx.sdk.activities.writes.create(agentPath, input)
         : activities.createActivity(agentPath, input);
       emitLocalEcho("ActivityChanged", { agentPath });
       return activity;
@@ -43,8 +46,10 @@ export function ActivitiesMixin<TBase extends BaseCtor>(Base: TBase) {
       return activity;
     }
     async deleteActivity(agentPath: string, id: string): Promise<void> {
+      // SDK delegates the wire write (byte-identical DELETE
+      // /agents/:id/activities/:id, no refetch).
       if (this.ctx.cp)
-        await controlPlane.deleteActivity(this.ctx.cp, agentPath, id);
+        await this.ctx.sdk.activities.writes.delete(agentPath, id);
       else activities.deleteActivity(agentPath, id);
       // The user deleted the chat — THIS is when its locally cached transcript
       // goes too (a server 404 alone no longer drops it, HOU-731). Missions

--- a/packages/web/src/engine-adapter/client/agents-mixin.ts
+++ b/packages/web/src/engine-adapter/client/agents-mixin.ts
@@ -29,18 +29,18 @@ export function AgentsMixin<TBase extends BaseCtor>(Base: TBase) {
       workspaceId: string,
       req: CreateAgent,
     ): Promise<CreateAgentResult> {
-      if (this.ctx.cp)
-        return {
-          agent: await controlPlane.createAgent(
-            this.ctx.cp,
-            req.name,
-            req.color,
-            {
-              claudeMd: req.claudeMd,
-              seeds: req.seeds,
-            },
-          ),
-        };
+      if (this.ctx.cp) {
+        // Delegate the wire write to the SDK (byte-identical POST /agents with
+        // the full `{ name, claudeMd?, seeds? }` body, no refetch). The RETURNED
+        // wire agent carries the id the color overlay needs — layer it on and map
+        // to the UI shape callers expect.
+        const wire = await this.ctx.sdk.agents.writes.create({
+          name: req.name,
+          claudeMd: req.claudeMd,
+          seeds: req.seeds,
+        });
+        return { agent: controlPlane.createdAgentToUi(wire, req.color) };
+      }
       return agents.createAgent(workspaceId, req);
     }
     async renameAgent(
@@ -48,8 +48,12 @@ export function AgentsMixin<TBase extends BaseCtor>(Base: TBase) {
       agentId: string,
       newName: string,
     ): Promise<Agent> {
-      if (this.ctx.cp)
-        return controlPlane.renameAgent(this.ctx.cp, agentId, newName);
+      if (this.ctx.cp) {
+        // SDK delegates the PATCH /agents/:id write; web carries the color
+        // overlay across the (possibly new) id and maps to the UI shape.
+        const wire = await this.ctx.sdk.agents.writes.rename(agentId, newName);
+        return controlPlane.renamedAgentToUi(agentId, wire);
+      }
       return agents.renameAgent(workspaceId, agentId, newName);
     }
     async updateAgent(
@@ -63,7 +67,10 @@ export function AgentsMixin<TBase extends BaseCtor>(Base: TBase) {
     }
     async deleteAgent(workspaceId: string, agentId: string): Promise<void> {
       if (this.ctx.cp) {
-        await controlPlane.deleteAgent(this.ctx.cp, agentId);
+        // SDK delegates the DELETE /agents/:id write; web forgets the deleted
+        // agent's color overlay (was cp.deleteAgent's clearColor) after.
+        await this.ctx.sdk.agents.writes.delete(agentId);
+        controlPlane.clearColor(agentId);
         // The selection pref must not outlive its agent: when the deleted agent
         // was the remembered one (and it was the last — the app re-points the
         // pref otherwise), provider connects must fall back to the setup runtime.

--- a/packages/web/src/engine-adapter/client/integrations-mixin.ts
+++ b/packages/web/src/engine-adapter/client/integrations-mixin.ts
@@ -1,3 +1,4 @@
+import { EngineError } from "@houston/runtime-client";
 import * as controlPlane from "../control-plane";
 import type { BaseCtor } from "./mixin";
 
@@ -12,7 +13,17 @@ export function IntegrationsMixin<TBase extends BaseCtor>(Base: TBase) {
     }
     async setIntegrationSession(token: string | null): Promise<void> {
       if (!this.ctx.cp) return;
-      return controlPlane.setIntegrationSession(this.ctx.cp, token);
+      // SDK delegates the byte-identical PUT /v1/integrations/session. The SDK
+      // PROPAGATES a 404; web must keep swallowing it — a deployment with no
+      // gateway session sink (the cloud host verifies JWTs itself, self-host /
+      // direct-key) answers 404, which is a legitimate shape, not a failure.
+      // Anything else (network, 5xx) rethrows and the caller surfaces it.
+      try {
+        await this.ctx.sdk.integrations.setSession(token);
+      } catch (err) {
+        if (err instanceof EngineError && err.status === 404) return;
+        throw err;
+      }
     }
     async integrationToolkits(
       provider: string,
@@ -33,12 +44,9 @@ export function IntegrationsMixin<TBase extends BaseCtor>(Base: TBase) {
     ): Promise<{ redirectUrl: string; connectionId: string }> {
       if (!this.ctx.cp)
         throw new Error("Integrations require a connected host");
-      return controlPlane.connectIntegration(
-        this.ctx.cp,
-        provider,
-        toolkit,
-        agent,
-      );
+      // SDK delegates the byte-identical POST /v1/integrations/:provider/connect
+      // with the `{ toolkit, agent? }` body.
+      return this.ctx.sdk.integrations.connect(provider, toolkit, agent);
     }
     async integrationConnection(
       provider: string,
@@ -57,14 +65,19 @@ export function IntegrationsMixin<TBase extends BaseCtor>(Base: TBase) {
       toolkit: string,
     ): Promise<void> {
       if (!this.ctx.cp) return;
-      return controlPlane.disconnectIntegration(this.ctx.cp, provider, toolkit);
+      // SDK delegates the byte-identical POST
+      // /v1/integrations/:provider/disconnect with the `{ toolkit }` body, no
+      // refetch (web owns its reads).
+      await this.ctx.sdk.integrations.writes.disconnect(toolkit, { provider });
     }
     async dismissIntegrationsReconnectNotice(): Promise<void> {
       // The notice only ever renders from a host-reported `reconnect` flag, so
       // dismissing without a host is a real failure — surface it, don't no-op.
       if (!this.ctx.cp)
         throw new Error("Integrations require a connected host");
-      return controlPlane.dismissIntegrationsReconnectNotice(this.ctx.cp);
+      // SDK delegates the byte-identical POST
+      // /v1/integrations/reconnect-notice/dismiss.
+      await this.ctx.sdk.integrations.dismissReconnectNotice();
     }
   }
   return Integrations;

--- a/packages/web/src/engine-adapter/cp/agents.ts
+++ b/packages/web/src/engine-adapter/cp/agents.ts
@@ -6,7 +6,7 @@ import type {
 } from "../../../../../ui/engine-client/src/types";
 import { HoustonEngineError } from "../client/errors";
 import { DEFAULT_AGENT_COLOR, DEFAULT_AGENT_CONFIG_ID } from "../synthetic";
-import { clearColor, colorOverlay, moveColor, setColor } from "./agent-color";
+import { colorOverlay, moveColor, setColor } from "./agent-color";
 import { type ControlPlaneConfig, cpFetch } from "./fetch";
 
 /** What the control plane returns for an agent (id + name + workspace + ts). */
@@ -52,6 +52,26 @@ export async function listAgents(cfg: ControlPlaneConfig): Promise<Agent[]> {
   return ((await res.json()) as CpAgent[]).map((a) => toUiAgent(a, colors));
 }
 
+// The agent-picker create/rename/delete WRITES delegate to `sdk.agents.writes.*`
+// (byte-identical POST/PATCH/DELETE, no refetch) — see `client/agents-mixin.ts`.
+// These pure mappers keep the color overlay colocated with `toUiAgent`: the SDK
+// returns the wire agent (incl. its id), and web layers its overlay-only color
+// on top.
+
+/** Map a freshly created wire agent to the UI shape, seeding its color overlay
+ *  from the picker's choice (overlay-only; color never crosses the wire). */
+export function createdAgentToUi(agent: CpAgent, color?: string): Agent {
+  if (color) setColor(agent.id, color);
+  return toUiAgent(agent);
+}
+
+/**
+ * Create an agent directly over the control plane. The agent-picker path
+ * delegates create to the SDK (see the mixin); this stays for the portable
+ * install flow (`portable.ts install`), a `cfg`-scoped module function with no
+ * SDK handle. Same wire the SDK write issues: `POST /agents` with the seed body
+ * (JSON.stringify drops undefined, so a plain create posts just `{ name }`).
+ */
 export async function createAgent(
   cfg: ControlPlaneConfig,
   name: string,
@@ -63,36 +83,21 @@ export async function createAgent(
 ): Promise<Agent> {
   const res = await cpFetch(cfg, "/agents", {
     method: "POST",
-    // The host seeds CLAUDE.md + the seed-file map on create (builtin
-    // agent-manifest instructions/skills, AI-assist instructions).
-    // JSON.stringify drops undefined fields, so a plain create still posts
-    // just `{ name }`.
     body: JSON.stringify({
       name,
       claudeMd: seed?.claudeMd,
       seeds: seed?.seeds,
     }),
   });
-  const agent = (await res.json()) as CpAgent;
-  if (color) setColor(agent.id, color);
-  return toUiAgent(agent);
+  return createdAgentToUi((await res.json()) as CpAgent, color);
 }
 
-export async function renameAgent(
-  cfg: ControlPlaneConfig,
-  agentId: string,
-  name: string,
-): Promise<Agent> {
-  const res = await cpFetch(cfg, `/agents/${encodeURIComponent(agentId)}`, {
-    method: "PATCH",
-    body: JSON.stringify({ name }),
-  });
-  const renamed = (await res.json()) as CpAgent;
-  // The local store derives an agent's id from its on-disk path, so a rename
-  // changes the id. Carry the color overlay across to the new id or the avatar
-  // reverts to the default color.
-  moveColor(agentId, renamed.id);
-  return toUiAgent(renamed);
+/** Map a renamed wire agent to the UI shape. The local store derives an agent's
+ *  id from its on-disk path, so a rename changes the id — carry the color
+ *  overlay across to the new id or the avatar reverts to the default color. */
+export function renamedAgentToUi(previousId: string, agent: CpAgent): Agent {
+  moveColor(previousId, agent.id);
+  return toUiAgent(agent);
 }
 
 /** Color is overlay-only; the server agent is unchanged. Returns the updated view. */
@@ -109,16 +114,6 @@ export async function updateAgentColor(
       error: { message: "agent not found" },
     });
   return toUiAgent(found);
-}
-
-export async function deleteAgent(
-  cfg: ControlPlaneConfig,
-  agentId: string,
-): Promise<void> {
-  await cpFetch(cfg, `/agents/${encodeURIComponent(agentId)}`, {
-    method: "DELETE",
-  });
-  clearColor(agentId);
 }
 
 // Agent-config library: user-scoped like the marketplace reads — a template

--- a/packages/web/src/engine-adapter/cp/board.ts
+++ b/packages/web/src/engine-adapter/cp/board.ts
@@ -1,7 +1,6 @@
 import type {
   Activity,
   ActivityUpdate,
-  NewActivity,
   Routine,
   RoutineRun,
 } from "../../../../../ui/engine-client/src/types";
@@ -14,17 +13,11 @@ export async function listActivities(
   const res = await cpFetch(cfg, `${agentPath(agentId)}/activities`);
   return ((await res.json()) as { items: Activity[] }).items;
 }
-export async function createActivity(
-  cfg: ControlPlaneConfig,
-  agentId: string,
-  input: NewActivity,
-): Promise<Activity> {
-  const res = await cpFetch(cfg, `${agentPath(agentId)}/activities`, {
-    method: "POST",
-    body: JSON.stringify(input),
-  });
-  return (await res.json()) as Activity;
-}
+// create + delete WRITES delegate to `sdk.activities.writes.*` (byte-identical
+// POST/DELETE, no refetch) — see `client/activities-mixin.ts`. `updateActivity`
+// stays here: it is a GENERIC `ActivityUpdate` PATCH (status, pending_interaction,
+// title, …) that no single SDK write (setStatus `{status}` / rename `{title}`)
+// reproduces byte-for-byte, so it can't delegate without an SDK change.
 export async function updateActivity(
   cfg: ControlPlaneConfig,
   agentId: string,
@@ -41,18 +34,6 @@ export async function updateActivity(
   );
   return (await res.json()) as Activity;
 }
-export async function deleteActivity(
-  cfg: ControlPlaneConfig,
-  agentId: string,
-  id: string,
-): Promise<void> {
-  await cpFetch(
-    cfg,
-    `${agentPath(agentId)}/activities/${encodeURIComponent(id)}`,
-    { method: "DELETE" },
-  );
-}
-
 export async function listRoutines(
   cfg: ControlPlaneConfig,
   agentId: string,

--- a/packages/web/src/engine-adapter/cp/integrations.ts
+++ b/packages/web/src/engine-adapter/cp/integrations.ts
@@ -3,8 +3,11 @@ import type {
   IntegrationProviderStatus,
   IntegrationToolkit,
 } from "../../../../../ui/engine-client/src/types";
-import { HoustonEngineError } from "../client/errors";
 import { type ControlPlaneConfig, cpFetch } from "./fetch";
+
+// The integration WRITES — connect / disconnect / session / reconnect-notice
+// dismiss — delegate to `sdk.integrations.*` (byte-identical routes, no
+// refetch); see `client/integrations-mixin.ts`. Only the READS stay here.
 
 const integrationPath = (provider: string) =>
   `/v1/integrations/${encodeURIComponent(provider)}`;
@@ -14,24 +17,6 @@ export async function integrationStatus(
 ): Promise<IntegrationProviderStatus[]> {
   const res = await cpFetch(cfg, "/v1/integrations");
   return ((await res.json()) as { items: IntegrationProviderStatus[] }).items;
-}
-
-export async function setIntegrationSession(
-  cfg: ControlPlaneConfig,
-  token: string | null,
-): Promise<void> {
-  try {
-    await cpFetch(cfg, "/v1/integrations/session", {
-      method: "PUT",
-      body: JSON.stringify({ token }),
-    });
-  } catch (err) {
-    // 404 = this deployment has no gateway session sink (the cloud host
-    // verifies JWTs itself) — a legitimate shape, not a failure. Anything
-    // else (network, 5xx) rethrows and the caller surfaces it.
-    if (err instanceof HoustonEngineError && err.status === 404) return;
-    throw err;
-  }
 }
 
 export async function integrationConnection(
@@ -60,36 +45,4 @@ export async function integrationConnections(
 ): Promise<IntegrationConnection[]> {
   const res = await cpFetch(cfg, `${integrationPath(provider)}/connections`);
   return ((await res.json()) as { items: IntegrationConnection[] }).items;
-}
-
-export async function connectIntegration(
-  cfg: ControlPlaneConfig,
-  provider: string,
-  toolkit: string,
-  agent?: string,
-): Promise<{ redirectUrl: string; connectionId: string }> {
-  const res = await cpFetch(cfg, `${integrationPath(provider)}/connect`, {
-    method: "POST",
-    body: JSON.stringify({ toolkit, ...(agent ? { agent } : {}) }),
-  });
-  return (await res.json()) as { redirectUrl: string; connectionId: string };
-}
-
-export async function disconnectIntegration(
-  cfg: ControlPlaneConfig,
-  provider: string,
-  toolkit: string,
-): Promise<void> {
-  await cpFetch(cfg, `${integrationPath(provider)}/disconnect`, {
-    method: "POST",
-    body: JSON.stringify({ toolkit }),
-  });
-}
-
-export async function dismissIntegrationsReconnectNotice(
-  cfg: ControlPlaneConfig,
-): Promise<void> {
-  await cpFetch(cfg, "/v1/integrations/reconnect-notice/dismiss", {
-    method: "POST",
-  });
 }

--- a/packages/web/tests/gateway-reauth.test.ts
+++ b/packages/web/tests/gateway-reauth.test.ts
@@ -1,8 +1,8 @@
 import { afterEach, expect, test, vi } from "vitest";
 import {
+  createAgent,
   gatewayAuthFetch,
   listAgents,
-  renameAgent,
 } from "../src/engine-adapter/control-plane";
 import { refreshLiveToken } from "../src/engine-adapter/session-refresh";
 
@@ -134,7 +134,9 @@ test("writes never blind-retry a transient status", async () => {
   setEngineWindow({ token: "tok" });
   const calls = stubFetch(json(503));
 
-  await expect(renameAgent(CFG, "a1", "new name")).rejects.toMatchObject({
+  // `createAgent` is a POST — the cpFetch write path. transientRetryFetch only
+  // blind-retries GET/HEAD, so a write surfaces the 503 on the first attempt.
+  await expect(createAgent(CFG, "new agent")).rejects.toMatchObject({
     status: 503,
   });
   expect(calls).toHaveLength(1);

--- a/packages/web/tests/sdk-delegation-wave2b.test.ts
+++ b/packages/web/tests/sdk-delegation-wave2b.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { HoustonClient } from "../src/engine-adapter/client";
+
+/**
+ * Migration wave 2b — byte-identical route parity for the web-adapter WRITES now
+ * delegated to `@houston/sdk`: agent create/rename/delete, activity
+ * create/delete, and integration connect/disconnect/session/reconnect-dismiss.
+ *
+ * Each delegated path MUST issue the exact request the old `controlPlane.*`
+ * helper did — same method, path, body, and headers (`Content-Type`,
+ * `Authorization` bearer, and the live `x-houston-org`) — over the ONE shared
+ * gateway fetch, with NO post-write refetch (a single request). Writes never
+ * transient-retry in either path (cpFetch only blind-retries GET/HEAD; the SDK
+ * requester never retries), so a single stubbed response is the whole wire.
+ *
+ * The color overlay (agents) and the setSession 404-swallow (integrations) stay
+ * adapter-side and are asserted here alongside the wire.
+ */
+
+const BASE = "http://host";
+const ORG = "abcdef0123456789"; // [a-f0-9]{16}
+
+interface Call {
+  url: string;
+  method: string;
+  body: string | null;
+  headers: Headers;
+}
+
+let calls: Call[];
+const originalFetch = globalThis.fetch;
+
+beforeEach(() => {
+  const store = new Map<string, string>();
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: (k: string) => store.get(k) ?? null,
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+  };
+  calls = [];
+});
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.clearAllMocks();
+});
+
+function stubFetch(...responses: Response[]) {
+  globalThis.fetch = vi.fn(async (input: unknown, init?: RequestInit) => {
+    calls.push({
+      url: String(input),
+      method: (init?.method ?? "GET").toUpperCase(),
+      body: typeof init?.body === "string" ? init.body : null,
+      headers: new Headers(init?.headers),
+    });
+    const next = responses.shift();
+    if (!next) throw new Error("stubFetch: no responses left");
+    return next;
+  }) as unknown as typeof fetch;
+}
+
+function json(status: number, body: unknown = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+const client = (controlPlane = true) =>
+  new HoustonClient({ baseUrl: BASE, token: "t", controlPlane });
+
+// ---- agents ----
+
+test("createAgent delegates a byte-identical single POST /agents (body + headers)", async () => {
+  stubFetch(
+    json(200, { id: "a1", workspaceId: "w", name: "Ada", createdAt: 0 }),
+  );
+
+  const r = await client().createAgent("w", {
+    name: "Ada",
+    color: "#123456",
+    claudeMd: "# hi",
+    seeds: { "a.md": "x" },
+  });
+
+  expect(calls).toHaveLength(1); // no post-write refetch
+  const [post] = calls;
+  expect(post.method).toBe("POST");
+  expect(post.url).toBe(`${BASE}/agents`);
+  expect(post.body).toBe(
+    JSON.stringify({ name: "Ada", claudeMd: "# hi", seeds: { "a.md": "x" } }),
+  );
+  expect(post.headers.get("Content-Type")).toBe("application/json");
+  expect(post.headers.get("Authorization")).toBe("Bearer t");
+  // The RETURNED wire id drives the color overlay web layers on top.
+  expect(r.agent.id).toBe("a1");
+  expect(r.agent.color).toBe("#123456");
+});
+
+test("createAgent with no seeds posts exactly { name }", async () => {
+  stubFetch(
+    json(200, { id: "a1", workspaceId: "w", name: "Ada", createdAt: 0 }),
+  );
+  await client().createAgent("w", { name: "Ada" });
+  expect(calls[0].body).toBe(JSON.stringify({ name: "Ada" }));
+});
+
+test("createAgent carries the live x-houston-org", async () => {
+  stubFetch(
+    json(200, { id: "a1", workspaceId: "w", name: "Ada", createdAt: 0 }),
+  );
+  const c = client();
+  c.setActiveOrg(ORG);
+  await c.createAgent("w", { name: "Ada" });
+  expect(calls[0].headers.get("x-houston-org")).toBe(ORG);
+});
+
+test("renameAgent delegates a byte-identical single PATCH /agents/:id", async () => {
+  stubFetch(
+    json(200, { id: "a1", workspaceId: "w", name: "Neo", createdAt: 0 }),
+  );
+  await client().renameAgent("w", "a1", "Neo");
+  expect(calls).toHaveLength(1);
+  expect(calls[0].method).toBe("PATCH");
+  expect(calls[0].url).toBe(`${BASE}/agents/a1`);
+  expect(calls[0].body).toBe(JSON.stringify({ name: "Neo" }));
+});
+
+test("deleteAgent delegates a byte-identical single DELETE /agents/:id", async () => {
+  stubFetch(json(200, {}));
+  await client().deleteAgent("w", "a1");
+  expect(calls).toHaveLength(1);
+  expect(calls[0].method).toBe("DELETE");
+  expect(calls[0].url).toBe(`${BASE}/agents/a1`);
+  expect(calls[0].body).toBeNull();
+});
+
+test("a failed agent create propagates — never swallowed", async () => {
+  stubFetch(json(500, { error: "boom" }));
+  await expect(client().createAgent("w", { name: "Ada" })).rejects.toThrow();
+});
+
+// ---- activities ----
+
+test("createActivity delegates a byte-identical single POST /agents/:id/activities", async () => {
+  stubFetch(json(200, { id: "m1", title: "Do", status: "todo" }));
+  await client().createActivity("a1", { title: "Do", description: "it" });
+  expect(calls).toHaveLength(1);
+  expect(calls[0].method).toBe("POST");
+  expect(calls[0].url).toBe(`${BASE}/agents/a1/activities`);
+  expect(calls[0].body).toBe(
+    JSON.stringify({ title: "Do", description: "it" }),
+  );
+  expect(calls[0].headers.get("Authorization")).toBe("Bearer t");
+});
+
+test("deleteActivity delegates a byte-identical single DELETE", async () => {
+  stubFetch(json(200, {}));
+  await client().deleteActivity("a1", "m1");
+  expect(calls).toHaveLength(1);
+  expect(calls[0].method).toBe("DELETE");
+  expect(calls[0].url).toBe(`${BASE}/agents/a1/activities/m1`);
+});
+
+// ---- integrations ----
+
+test("connectIntegration delegates a byte-identical POST /v1/integrations/:provider/connect", async () => {
+  stubFetch(json(200, { redirectUrl: "u", connectionId: "c1" }));
+  const r = await client().connectIntegration("composio", "gmail", "agent-1");
+  expect(calls).toHaveLength(1);
+  expect(calls[0].method).toBe("POST");
+  expect(calls[0].url).toBe(`${BASE}/v1/integrations/composio/connect`);
+  expect(calls[0].body).toBe(
+    JSON.stringify({ toolkit: "gmail", agent: "agent-1" }),
+  );
+  expect(r).toEqual({ redirectUrl: "u", connectionId: "c1" });
+});
+
+test("connectIntegration omits agent when absent", async () => {
+  stubFetch(json(200, { redirectUrl: "u", connectionId: "c1" }));
+  await client().connectIntegration("composio", "gmail");
+  expect(calls[0].body).toBe(JSON.stringify({ toolkit: "gmail" }));
+});
+
+test("disconnectIntegration delegates a byte-identical POST .../disconnect", async () => {
+  stubFetch(json(200, {}));
+  await client().disconnectIntegration("composio", "gmail");
+  expect(calls).toHaveLength(1);
+  expect(calls[0].method).toBe("POST");
+  expect(calls[0].url).toBe(`${BASE}/v1/integrations/composio/disconnect`);
+  expect(calls[0].body).toBe(JSON.stringify({ toolkit: "gmail" }));
+});
+
+test("setIntegrationSession delegates a byte-identical PUT .../session", async () => {
+  stubFetch(json(200, {}));
+  await client().setIntegrationSession("tok");
+  expect(calls).toHaveLength(1);
+  expect(calls[0].method).toBe("PUT");
+  expect(calls[0].url).toBe(`${BASE}/v1/integrations/session`);
+  expect(calls[0].body).toBe(JSON.stringify({ token: "tok" }));
+});
+
+test("setIntegrationSession swallows a 404 (deployment with no session sink)", async () => {
+  stubFetch(json(404, { error: "no session sink" }));
+  await expect(client().setIntegrationSession("tok")).resolves.toBeUndefined();
+});
+
+test("setIntegrationSession still surfaces a non-404 failure", async () => {
+  stubFetch(json(500, { error: "boom" }));
+  await expect(client().setIntegrationSession("tok")).rejects.toThrow();
+});
+
+test("dismissIntegrationsReconnectNotice delegates a byte-identical POST", async () => {
+  stubFetch(json(200, {}));
+  await client().dismissIntegrationsReconnectNotice();
+  expect(calls).toHaveLength(1);
+  expect(calls[0].method).toBe("POST");
+  expect(calls[0].url).toBe(`${BASE}/v1/integrations/reconnect-notice/dismiss`);
+});

--- a/packages/web/tests/stale-agent-pref.test.ts
+++ b/packages/web/tests/stale-agent-pref.test.ts
@@ -14,13 +14,17 @@ import { afterEach, beforeEach, expect, test, vi } from "vitest";
  * the deleted agent was the remembered one.
  */
 
-const { cpListAgents, cpDeleteAgent, runtimeClientFor, setupRuntimeClientFor } =
-  vi.hoisted(() => ({
+// `deleteAgent`'s WIRE write is delegated to `sdk.agents.writes.delete` (a real
+// gateway DELETE over the shared fetch, stubbed per-test); only the ADAPTER-side
+// `dropLastAgentPref` after it is under test here. `listAgents`'s pref-pruning
+// and the login-runtime routing stay on the control plane, so those are mocked.
+const { cpListAgents, runtimeClientFor, setupRuntimeClientFor } = vi.hoisted(
+  () => ({
     cpListAgents: vi.fn(),
-    cpDeleteAgent: vi.fn(),
     runtimeClientFor: vi.fn(),
     setupRuntimeClientFor: vi.fn(),
-  }));
+  }),
+);
 
 vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
   const actual =
@@ -30,7 +34,6 @@ vi.mock("../src/engine-adapter/control-plane", async (importOriginal) => {
   return {
     ...actual,
     listAgents: cpListAgents,
-    deleteAgent: cpDeleteAgent,
     runtimeClientFor,
     setupRuntimeClientFor,
   };
@@ -40,6 +43,7 @@ import { HoustonClient } from "../src/engine-adapter/client";
 import { DEFAULT_AGENT_ID } from "../src/engine-adapter/synthetic";
 
 const PREF = "houston.pref.last_agent_id";
+const originalFetch = globalThis.fetch;
 
 let store: Map<string, string>;
 
@@ -53,14 +57,19 @@ beforeEach(() => {
     removeItem: (k: string) => void store.delete(k),
   };
   cpListAgents.mockReset();
-  cpDeleteAgent.mockReset();
   runtimeClientFor.mockReset();
   setupRuntimeClientFor.mockReset();
+  // The delegated agent DELETE lands on the shared gateway fetch — stub a 200 so
+  // the write succeeds and control returns to `dropLastAgentPref`.
+  globalThis.fetch = vi.fn(
+    async () => new Response(null, { status: 200 }),
+  ) as unknown as typeof fetch;
 });
 
 afterEach(() => {
   vi.useRealTimers();
   vi.clearAllMocks();
+  globalThis.fetch = originalFetch;
 });
 
 function client() {
@@ -110,7 +119,6 @@ test("listAgents leaves the synthetic default-agent sentinel alone", async () =>
 
 test("deleteAgent clears the pref when the deleted agent was the remembered one", async () => {
   store.set(PREF, "ws/Doomed");
-  cpDeleteAgent.mockResolvedValue(undefined);
 
   await client().deleteAgent("ws", "ws/Doomed");
 
@@ -119,7 +127,6 @@ test("deleteAgent clears the pref when the deleted agent was the remembered one"
 
 test("deleteAgent keeps the pref when another agent was deleted", async () => {
   store.set(PREF, "ws/Kept");
-  cpDeleteAgent.mockResolvedValue(undefined);
 
   await client().deleteAgent("ws", "ws/Doomed");
 


### PR DESCRIPTION
## What this is

The final wave (2b) of the web↔iOS CRUD de-duplication: the web engine-adapter's WRITE methods now delegate to the SDK's wave-2a `writes.*` seams instead of hand-rolling the HTTP. **Byte-identical on the wire** per module (same route/method/body/headers incl. `x-houston-org`, no post-write refetch). **Reads are untouched** — TanStack Query + the `/v1/events` bus.

## What now delegates (per-module parity)

| Web method | → SDK seam | Wire |
| --- | --- | --- |
| `createAgent` | `sdk.agents.writes.create({name,claudeMd?,seeds?})` | `POST /agents` |
| `renameAgent` | `sdk.agents.writes.rename` | `PATCH /agents/:id {name}` |
| `deleteAgent` | `sdk.agents.writes.delete` | `DELETE /agents/:id` |
| `createActivity` | `sdk.activities.writes.create` | `POST /agents/:id/activities` |
| `deleteActivity` | `sdk.activities.writes.delete` | `DELETE /agents/:id/activities/:id` |
| `connectIntegration` | `sdk.integrations.connect(provider,toolkit,agent?)` | `POST /v1/integrations/:p/connect` |
| `disconnectIntegration` | `sdk.integrations.writes.disconnect(toolkit,{provider})` | `POST /v1/integrations/:p/disconnect` |
| `setIntegrationSession` | `sdk.integrations.setSession` | `PUT /v1/integrations/session` |
| `dismissIntegrationsReconnectNotice` | `sdk.integrations.dismissReconnectNotice` | `POST /v1/integrations/reconnect-notice/dismiss` |

**Color overlay kept adapter-side** (agents): the SDK returns the wire agent incl. its id; `cp/agents.ts` `createdAgentToUi`/`renamedAgentToUi` layer web's overlay-only color (`setColor`/`moveColor`) and map to the UI `Agent`. Delete keeps `clearColor` + `dropLastAgentPref`. Activity local-echo (`emitLocalEcho`) preserved.

**setSession 404-swallow preserved**: the SDK PROPAGATES a 404 (deployments with no gateway session sink — self-host / direct-key); the mixin catches `EngineError` status 404 and returns benign, rethrowing anything else — so no red toast on those builds.

## What stayed adapter-side (with reasons)

- **Providers (all of it)** — the SDK provider writes route through `clientFor(agentId)` (per-agent runtime client, a single-runtime credential model). Web-cloud instead uses the gateway connect-once **central-credential** routes (`/agents/:id/credential/*`, `/provider/openai-compatible`) with sibling fan-out (OpenCode Zen+Go), `claimActiveProvider`, a `ProviderLoginComplete` event, and the pre-agent setup-runtime path — none of which the SDK writes reproduce. Delegating `logout` would drop `forgetCredential` and regress connect-once. Provider status reads `listProviders` (→ `ProviderStatus`), not the SDK's `authStatus` (→ `AuthStatus`). The **login-poller state machine** stays too.
- **`updateActivity`** — a generic `ActivityUpdate` PATCH (status + `pending_interaction`, title, …) that no single SDK write (`setStatus {status}` / `rename {title}`) reproduces byte-for-byte; delegating would drop fields.

## Transient-retry check (per module)

Writes never blind-retry in **either** path: `cpFetch`'s `transientRetryFetch` retries GET/HEAD only, and the SDK requester never retries. So POST/PATCH/PUT/DELETE surface the first response identically. ✓ agents ✓ activities ✓ integrations.

## Errors

Still reach `errorMessage(err)` → toast. The SDK may throw `EngineError` instead of `HoustonEngineError` — acceptable (it still surfaces; wave-2a precedent), except the intentional integrations-setSession 404 swallow.

## Dead code removed

`cp/agents.ts` `renameAgent`/`deleteAgent`, `cp/board.ts` `createActivity`/`deleteActivity`, `cp/integrations.ts` `connectIntegration`/`disconnectIntegration`/`setIntegrationSession`/`dismissIntegrationsReconnectNotice`. `cp/agents.ts createAgent` kept (the portable-install flow is a `cfg`-scoped function with no SDK handle) and now reuses `createdAgentToUi`.

## Tests

New `packages/web/tests/sdk-delegation-wave2b.test.ts` — byte-identical route parity (method/path/body/headers/org, single request) for every delegated write, plus the color-overlay result, the setSession 404-swallow (and non-404 surfacing), and agent+activity create/delete. Two existing tests re-pointed at the delegated paths (`gateway-reauth` no-blind-retry now via cp `createAgent`; `stale-agent-pref` deleteAgent now stubs the gateway DELETE). Full web suite green (162/162); `houston-web` + `@houston/sdk` typecheck clean; `check:boundaries` clean. SDK (`packages/sdk`) untouched.

Reference: SDK wave-2a seams #837; god-file decomposition #839.

🤖 Generated with [Claude Code](https://claude.com/claude-code)