### PR TITLE
fix(runtime): Plan mode keeps bash for live lookups (time, curl/wget)

### DIFF
--- a/packages/runtime/src/backends/claude/tool-policy.test.ts
+++ b/packages/runtime/src/backends/claude/tool-policy.test.ts
@@ -53,14 +53,17 @@ test("buildToolPolicy grants Bash only when code execution is local", () => {
   expect(off.disallowedTools).toContain("Bash");
 });
 
-test("plan mode clamps built-ins to Read/Glob/Grep and denies Edit/Write/Bash", () => {
+test("plan mode clamps built-ins to Read/Glob/Grep (+Bash per localBash) and denies Edit/Write", () => {
+  // Bash stays for live lookups (current time, curl/wget) — the plan overlay
+  // carries the no-mutation mandate; the write tools are denied outright.
   const plan = buildToolPolicy({ localBash: true, mode: "plan" });
-  expect(plan.tools).toEqual(["Read", "Glob", "Grep"]);
-  for (const denied of ["Edit", "Write", "Bash"])
+  expect(plan.tools).toEqual(["Read", "Glob", "Grep", "Bash"]);
+  for (const denied of ["Edit", "Write"])
     expect(plan.disallowedTools).toContain(denied);
-  // The pi-lacking set is still denied on top of the write/exec denials.
+  expect(plan.disallowedTools).not.toContain("Bash");
+  // The pi-lacking set is still denied on top of the write denials.
   expect(plan.disallowedTools).toContain("WebSearch");
-  // localBash is irrelevant in plan mode: no Bash either way.
+  // No local code execution → no Bash in plan either, omitted AND denied.
   const planNoBash = buildToolPolicy({ localBash: false, mode: "plan" });
   expect(planNoBash.tools).toEqual(["Read", "Glob", "Grep"]);
   expect(planNoBash.disallowedTools).toContain("Bash");

--- a/packages/runtime/src/backends/claude/tool-policy.ts
+++ b/packages/runtime/src/backends/claude/tool-policy.ts
@@ -56,7 +56,12 @@ const PI_LACKS = [
   "SlashCommand",
 ] as const;
 
-/** The read-only file tools plan mode allows (SDK names). No Edit/Write. */
+/**
+ * The read-only file tools plan mode allows (SDK names). No Edit/Write; Bash
+ * joins per `localBash` (see `buildToolPolicy`) so a plan turn can do the live
+ * lookups planning needs (current time, curl/wget) — the same subset pi's
+ * PLAN_MODE_TOOL_NAMES grants, kept in lockstep.
+ */
 const PLAN_FILE_TOOLS = ["Read", "Glob", "Grep"] as const;
 
 export interface ToolPolicyInput {
@@ -64,7 +69,9 @@ export interface ToolPolicyInput {
   localBash: boolean;
   /**
    * The turn's execution mode. "plan" clamps the SDK built-ins to the read-only
-   * subset (Read/Glob/Grep) and denies Edit/Write/Bash. "auto" (Autopilot) keeps
+   * subset (Read/Glob/Grep, plus Bash per `localBash`) and denies Edit/Write —
+   * bash stays for live lookups; its no-mutation rule is the plan overlay's
+   * mandate, matching pi's plan selection. "auto" (Autopilot) keeps
    * the SAME built-in policy as execute (file tools + Bash per `localBash`) — the
    * Claude-native built-ins have no blocking `ask_user`, so auto's "never wait on
    * the user" rule is enforced only on the MCP side (custom-tools drops ask_user
@@ -81,14 +88,19 @@ export interface ToolPolicy {
 
 /** Build the `{ tools, disallowedTools }` SDK options (this object sets no `allowedTools` — see above). */
 export function buildToolPolicy(input: ToolPolicyInput): ToolPolicy {
-  // Plan mode: read-only built-ins only, and deny every write/exec tool. We do
-  // NOT switch the SDK to permissionMode "plan" — that forces the ExitPlanMode
-  // tool (which pi lacks) and the SDK's own plan prompt; Houston keeps
-  // permissionMode "default" and enforces plan via this allowlist + the overlay.
+  // Plan mode: read-only built-ins plus Bash (per localBash) for live lookups,
+  // and deny every write tool. We do NOT switch the SDK to permissionMode
+  // "plan" — that forces the ExitPlanMode tool (which pi lacks) and the SDK's
+  // own plan prompt; Houston keeps permissionMode "default" and enforces plan
+  // via this allowlist + the overlay.
   if (input.mode === "plan") {
     return {
-      tools: [...PLAN_FILE_TOOLS],
-      disallowedTools: [...PI_LACKS, "Edit", "Write", "Bash"],
+      tools: input.localBash
+        ? [...PLAN_FILE_TOOLS, "Bash"]
+        : [...PLAN_FILE_TOOLS],
+      disallowedTools: input.localBash
+        ? [...PI_LACKS, "Edit", "Write"]
+        : [...PI_LACKS, "Edit", "Write", "Bash"],
     };
   }
   const tools = input.localBash ? [...FILE_TOOLS, "Bash"] : [...FILE_TOOLS];

--- a/packages/runtime/src/session/mode-overlays.ts
+++ b/packages/runtime/src/session/mode-overlays.ts
@@ -3,9 +3,11 @@ import type { TurnMode } from "@houston/protocol";
 /**
  * Plan mode's system-prompt overlay. Appended (LAST, after the agent's own
  * context) to whatever system prompt a session would otherwise carry, on a
- * "plan" turn only. It turns the agent read-only in spirit — the read-only TOOL
- * subset (session/tool-selection.ts + the Claude tool policy) enforces it in
- * fact; this overlay tells the model WHY and shapes the output into a plan the
+ * "plan" turn only. It turns the agent read-only in spirit — the plan TOOL
+ * subset (session/tool-selection.ts + the Claude tool policy) drops every
+ * writer and integration tool in fact, while `bash` stays for live lookups
+ * (current time, public web fetches) with THIS overlay as its no-mutation
+ * mandate; it tells the model WHY and shapes the output into a plan the
  * user approves before anything is done.
  *
  * Voice: the target user is non-technical (see the product prompt rules), so the
@@ -16,7 +18,7 @@ import type { TurnMode } from "@houston/protocol";
 export const PLAN_MODE_OVERLAY = [
   "You are in Plan mode. Here you help the user think through and design an approach before anything is actually done.",
   "",
-  "- Look into whatever you need to understand the request fully. You may look at the user's information, but you must not change anything, and you must not use the user's connected apps or take any real-world action.",
+  "- Look into whatever you need to understand the request fully. You may look at the user's information and check live details (like the current date and time, or public information on the web), but you must not change anything, and you must not use the user's connected apps or take any real-world action.",
   "- Do not create, edit, or delete anything. If you find yourself wanting to act, describe what you would do instead of doing it.",
   "- Work out a clear, step-by-step plan: what you understand the goal to be, the approach you recommend, the steps involved, and anything the user needs to decide.",
   "- Write the plan in plain, friendly language the user can follow. Keep it concrete and specific to their situation.",

--- a/packages/runtime/src/session/tool-selection.test.ts
+++ b/packages/runtime/src/session/tool-selection.test.ts
@@ -81,20 +81,21 @@ describe("buildToolSelection", () => {
 });
 
 describe("planToolNames", () => {
-  const EXPECTED = ["read", "ls", "grep", "find", "ask_user"];
+  // The read-only core every plan turn keeps; bash joins it only where the
+  // execute selection carried bash (codeExecution=local).
+  const READ_ONLY = ["read", "ls", "grep", "find", "ask_user"];
 
-  test("keeps exactly the read-only subset from the local (bash) selection", () => {
+  test("keeps the read-only subset PLUS bash from the local selection", () => {
     const local = buildToolSelection({
       codeExecution: "local",
       integrations: true,
     });
     // Local selection has edit/write/bash + all integration tools; plan strips
-    // every writer/actor and keeps only read/ls/grep/find/ask_user.
-    expect(planToolNames(local.toolNames)).toEqual(EXPECTED);
+    // every writer/actor but keeps bash for live lookups (time, curl/wget).
+    expect(planToolNames(local.toolNames)).toEqual([...READ_ONLY, "bash"]);
     for (const dropped of [
       "edit",
       "write",
-      "bash",
       "integration_search",
       "integration_execute",
       "request_connection",
@@ -102,25 +103,26 @@ describe("planToolNames", () => {
       expect(planToolNames(local.toolNames)).not.toContain(dropped);
   });
 
-  test("drops run_code from the remote selection", () => {
+  test("drops run_code from the remote selection — no bash there to keep", () => {
     const remote = buildToolSelection({
       codeExecution: "remote",
       integrations: true,
     });
-    expect(planToolNames(remote.toolNames)).toEqual(EXPECTED);
+    expect(planToolNames(remote.toolNames)).toEqual(READ_ONLY);
     expect(planToolNames(remote.toolNames)).not.toContain("run_code");
+    expect(planToolNames(remote.toolNames)).not.toContain("bash");
   });
 
-  test("the disabled, integration-less selection already reduces to the subset", () => {
+  test("the disabled, integration-less selection reduces to the read-only core", () => {
     const disabled = buildToolSelection({
       codeExecution: "disabled",
       integrations: false,
     });
-    expect(planToolNames(disabled.toolNames)).toEqual(EXPECTED);
+    expect(planToolNames(disabled.toolNames)).toEqual(READ_ONLY);
   });
 
-  test("the subset constant is exactly read/ls/grep/find/ask_user", () => {
-    expect([...PLAN_MODE_TOOL_NAMES]).toEqual(EXPECTED);
+  test("the subset constant is exactly read/ls/grep/find/ask_user/bash", () => {
+    expect([...PLAN_MODE_TOOL_NAMES]).toEqual([...READ_ONLY, "bash"]);
   });
 });
 

--- a/packages/runtime/src/session/tool-selection.ts
+++ b/packages/runtime/src/session/tool-selection.ts
@@ -26,12 +26,20 @@ export interface ToolSelection {
  * spinning up a live model session.
  */
 /**
- * The read-only tool subset a "plan" turn is clamped to: the clamped-fs READ
- * tools (`read, ls, grep, find` — never `edit`/`write`) plus `ask_user` (holds
- * no credential, takes no real-world action). Everything that mutates or acts is
- * dropped: `edit, write, bash, run_code`, and ALL integration tools
- * (`integration_search`, `integration_execute`, `request_connection` — an
- * integration call is a real-world action against the user's connected apps).
+ * The tool subset a "plan" turn is clamped to: the clamped-fs READ tools
+ * (`read, ls, grep, find` — never `edit`/`write`), `ask_user` (holds no
+ * credential, takes no real-world action), and `bash` — planning needs live
+ * lookups a file read can't answer (the current time, a `curl`/`wget` fetch of
+ * public information); without them a Planner-default chat stonewalls trivial
+ * questions. `bash` is membership-gated like everything else: it survives only
+ * when the execute selection carried it (codeExecution=local), so
+ * disabled/remote deployments stay bash-less in plan too. Its no-mutation rule
+ * is the overlay's mandate (mode-overlays.ts), not a tool wall — the same
+ * posture as auto-run inside the single-tenant workspace guard. Everything that
+ * WRITES or acts on the user's connected apps is still dropped: `edit, write,
+ * run_code`, and ALL integration tools (`integration_search`,
+ * `integration_execute`, `request_connection` — an integration call is a
+ * real-world action against the user's connected apps).
  */
 export const PLAN_MODE_TOOL_NAMES: readonly string[] = [
   "read",
@@ -39,14 +47,16 @@ export const PLAN_MODE_TOOL_NAMES: readonly string[] = [
   "grep",
   "find",
   ASK_USER_TOOL_NAME,
+  "bash",
 ];
 
 /**
- * Clamp an execute-mode tool allowlist to the plan-mode read-only subset: keep
- * only the names in {@link PLAN_MODE_TOOL_NAMES}, preserving their order. Applied
- * to whatever `buildToolSelection` produced, so plan mode composes with every
- * code-execution / integration selection (a `bash`/`run_code`/`integration_*`
- * name is simply filtered out).
+ * Clamp an execute-mode tool allowlist to the plan-mode subset: keep only the
+ * names in {@link PLAN_MODE_TOOL_NAMES}, preserving their order. Applied to
+ * whatever `buildToolSelection` produced, so plan mode composes with every
+ * code-execution / integration selection (an `edit`/`write`/`run_code`/
+ * `integration_*` name is simply filtered out, and `bash` survives only where
+ * the selection had it).
  */
 export function planToolNames(all: readonly string[]): string[] {
   return all.filter((name) => PLAN_MODE_TOOL_NAMES.includes(name));


### PR DESCRIPTION
## Problem

Since Planner became the default chat mode (#812), agents in a default chat have **no bash at all** — plan mode's tool clamp drops it. A default-mode agent asked "tell me the current time" answers *"I don't have access to a live clock"* (real prod conversation, Jul 11), and can't `curl`/`wget` anything. This read as "the bash tool is gone", but execute/auto turns still have it — verified live against a prod engine pod: an execute-mode probe ran `date` fine, a plan-mode probe reported exactly `read, ls, grep, find, ask_user, plan_ready`.

## Fix

Keep `bash` in the plan-mode tool subset on **both** backends, still gated on local code execution (`disabled`/`remote` deployments stay bash-less in plan too):

- **pi**: `bash` joins `PLAN_MODE_TOOL_NAMES`; `planToolNames` keeps it only where `buildToolSelection` granted it (codeExecution=local).
- **Claude SDK**: plan policy becomes `Read/Glob/Grep` + `Bash` per `localBash`; `Edit`/`Write` stay denied.
- **Overlay**: plan overlay now says the agent may check live details (current date/time, public web) while still mandating no mutation.

Plan still drops every writer and actor: `edit`, `write`, `run_code`, and all integration tools. Bash's no-mutation rule in plan is the overlay's mandate — the same auto-run posture execute/auto already run under, inside the single-tenant workspace guard (this mirrors Claude Code's own plan mode, which allows Bash but not Edit/Write).

## Alternative considered

Reverting `DEFAULT_TURN_MODE` back to `execute` would also restore bash for default chats, but it walks back the Planner-default product decision from #812; this PR keeps Planner default and makes it able to look things up. If you'd rather flip the default instead, it's a one-liner in `app/src/lib/turn-mode.ts`.

## Verification

- `packages/runtime`: all 74 test files / 602 tests pass; typecheck + biome clean.
- Root cause reproduced and both modes probed live against a prod engine pod (bash present in execute, absent in plan, pre-fix).