### PR TITLE
fix(web): add setEndpoint to the v3 adapter client — hosted token refresh crashed the app

### DIFF
--- a/packages/web/src/engine-adapter/client/base.ts
+++ b/packages/web/src/engine-adapter/client/base.ts
@@ -45,6 +45,19 @@ export class HoustonClientBase {
   }
 
   /**
+   * Point this client at a new engine endpoint in place. The desktop shell
+   * calls this whenever a config lands on an already-built client: the
+   * sidecar restarting on a fresh random port (HOU-432), and every hosted
+   * bearer rotation (`setHostedEngineSessionToken`) — so the instance every
+   * hook holds keeps working instead of being rebuilt. Delegates to the ONE
+   * {@link AdapterContext}. Mirrors `HoustonClient.setEndpoint` in
+   * `ui/engine-client` — the shell treats the two clients interchangeably.
+   */
+  setEndpoint(config: { baseUrl: string; token: string }): void {
+    this.ctx.setEndpoint(config);
+  }
+
+  /**
    * The web-side {@link HoustonSdk} (migration wave 1). Exposes the SDK's write
    * modules — `agents`, `activities`, `providers`, `integrations`,
    * `preferences` — so later waves delegate control-plane WRITES here (matching

--- a/packages/web/src/engine-adapter/client/context.ts
+++ b/packages/web/src/engine-adapter/client/context.ts
@@ -41,18 +41,21 @@ export const LAST_AGENT_PREF = "houston.pref.last_agent_id";
  * through one source of truth with no rebuild (C8 §Active space).
  */
 export class AdapterContext {
-  readonly engine: HoustonEngineClient;
-  readonly baseUrl: string;
-  readonly token: string;
+  // engine/sdk/baseUrl/token are mutable ONLY through setEndpoint below — the
+  // in-place repoint the desktop shell relies on when the sidecar restarts.
+  engine: HoustonEngineClient;
+  baseUrl: string;
+  token: string;
   /** The single web-side {@link HoustonSdk} (migration wave 1), built INERT
    *  (reactivity off) over the shared `authFetch`. Later waves delegate
    *  control-plane WRITES to its modules. */
-  readonly sdk: HoustonSdk;
+  sdk: HoustonSdk;
   /** Live-token auth fetch (not a pinned `token`): hosted mode rotates the
-   *  bearer mid-session and a 401 refreshes + replays (HOU-687). Built ONCE and
-   *  shared by `engine` and the SDK, so `x-houston-org` has one live source
-   *  (`setActiveOrg` mutates `_cp` in place; both re-read it). */
-  readonly authFetch: typeof fetch;
+   *  bearer mid-session and a 401 refreshes + replays (HOU-687). Shared by
+   *  `engine` and the SDK, so `x-houston-org` has one live source
+   *  (`setActiveOrg` mutates `_cp` in place; both re-read it). Rebuilt only by
+   *  `setEndpoint`, which keeps its fallback bearer current. */
+  authFetch: typeof fetch;
   /** In-flight cloud device-code logins, keyed `${agentId}:${providerId}` — the poll guard. */
   readonly activeLogins = new Set<string>();
   /** Per-provider auth-status pollers that translate login completion into events (local mode). */
@@ -102,6 +105,39 @@ export class AdapterContext {
   /** The live control-plane config (cloud), or null (local/self-host). */
   get cp(): ControlPlaneConfig | null {
     return this._cp;
+  }
+
+  /**
+   * Repoint this context at a new engine endpoint IN PLACE (HOU-432): the
+   * desktop shell calls `HoustonClient.setEndpoint` when the sidecar restarts
+   * on a fresh random port, and on every hosted bearer rotation
+   * (`setHostedEngineSessionToken`). The bearer needs no rework — every fetch
+   * reads it live per attempt (`liveToken` off `window.__HOUSTON_ENGINE__`,
+   * which the caller updates first). The pinned base URLs do: the shared
+   * `ControlPlaneConfig` is mutated in place (per-agent runtime clients and
+   * `cpFetch` re-read it per call), while `authFetch` + the direct runtime
+   * client + the SDK are rebuilt, because their requesters capture the base
+   * URL (and the fetch its fallback bearer) at construction.
+   */
+  setEndpoint(opts: { baseUrl: string; token: string }): void {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.token = opts.token;
+    if (this._cp) {
+      this._cp.baseUrl = this.baseUrl;
+      this._cp.token = opts.token;
+    }
+    this.authFetch = gatewayAuthFetch(
+      opts.token,
+      () => this._cp?.activeOrgSlug,
+    );
+    this.engine = new HoustonEngineClient({
+      baseUrl: this.baseUrl,
+      fetch: this.authFetch,
+    });
+    this.sdk = createEngineSdk({
+      baseUrl: this.baseUrl,
+      fetch: this.authFetch,
+    });
   }
 
   /**

--- a/packages/web/tests/set-endpoint.test.ts
+++ b/packages/web/tests/set-endpoint.test.ts
@@ -1,0 +1,69 @@
+import { afterEach, expect, test, vi } from "vitest";
+import { HoustonClient } from "../src/engine-adapter/client";
+
+// The desktop shell repoints an already-built client whenever a new engine
+// config lands (`applyConfig` in app/src/lib/engine.ts): every hosted bearer
+// rotation (`setHostedEngineSessionToken` — fires again on each Supabase token
+// refresh, and immediately in dev under StrictMode's double effect) and a
+// sidecar restart on a fresh random port (HOU-432). The adapter client shipped
+// without `setEndpoint`, so the SECOND config crashed the whole app with
+// "_client.setEndpoint is not a function". These pin the method and its
+// in-place repointing on both transports.
+
+const BASE_A = "https://gateway-a.example";
+const BASE_B = "https://gateway-b.example";
+
+function captureFetch(): { urls: string[]; bearers: (string | null)[] } {
+  const urls: string[] = [];
+  const bearers: (string | null)[] = [];
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: unknown, init?: RequestInit) => {
+      urls.push(String(input));
+      bearers.push(new Headers(init?.headers).get("Authorization"));
+      return new Response(JSON.stringify([]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+  );
+  return { urls, bearers };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+test("setEndpoint repoints gateway calls to the new base URL and bearer", async () => {
+  const cap = captureFetch();
+  const client = new HoustonClient({
+    baseUrl: BASE_A,
+    token: "token-1",
+    controlPlane: true,
+  });
+  await client.listAgents("ws");
+  expect(cap.urls[0]).toBe(`${BASE_A}/agents`);
+  expect(cap.bearers[0]).toBe("Bearer token-1");
+
+  // The hosted token-refresh path: same shape the shell applies, twice.
+  client.setEndpoint({ baseUrl: BASE_B, token: "token-2" });
+  await client.listAgents("ws");
+  expect(cap.urls[1]).toBe(`${BASE_B}/agents`);
+  expect(cap.bearers[1]).toBe("Bearer token-2");
+});
+
+test("setEndpoint rebuilds the direct runtime client on the new port (local sidecar restart)", async () => {
+  const cap = captureFetch();
+  const client = new HoustonClient({
+    baseUrl: "http://127.0.0.1:50001",
+    token: "t1",
+    controlPlane: false,
+  });
+  await client.providerStatus("anthropic");
+  expect(cap.urls[0]).toBe("http://127.0.0.1:50001/providers");
+
+  client.setEndpoint({ baseUrl: "http://127.0.0.1:50002", token: "t2" });
+  await client.providerStatus("anthropic");
+  expect(cap.urls[1]).toBe("http://127.0.0.1:50002/providers");
+  expect(cap.bearers[1]).toBe("Bearer t2");
+});


### PR DESCRIPTION
## Problem

Signing in with Google on a hosted-gateway build crashed the whole app:

```
_client.setEndpoint is not a function
  applyConfig @ src/lib/engine.ts:40
  setHostedEngineSessionToken @ src/lib/engine.ts:74
  @ src/components/shell/engine-gate.tsx:66
```

The v3 host adapter's `HoustonClient` (what `@houston-ai/engine-client` is vite-aliased to) never implemented `setEndpoint`. The shell calls it in `applyConfig` whenever a config lands on an already-built client — which in hosted-OAuth mode happens right after sign-in (StrictMode double-fires the session effect in dev) and again on every Supabase token refresh in any build. The same gap would also crash a local desktop build on a sidecar restart (the HOU-432 repoint path).

It typechecked because the *type* resolves from `ui/engine-client` (which has `setEndpoint`) while the *runtime* resolves the aliased adapter.

## Fix

- `client/base.ts`: `setEndpoint` on `HoustonClientBase`, delegating to the one `AdapterContext`, mirroring the original client's contract.
- `client/context.ts`: `AdapterContext.setEndpoint` mutates the shared `ControlPlaneConfig` in place (`cpFetch` + per-agent runtime clients re-read it per call) and rebuilds `authFetch` + the direct runtime client + the SDK, whose requesters pin the base URL at construction. The live-bearer path (`liveToken` off `window.__HOUSTON_ENGINE__`) is unchanged.

## Tests

`packages/web/tests/set-endpoint.test.ts` pins both repoint paths:
- hosted token rotation: second config on a live client routes to the new base URL + bearer (the exact crash)
- local sidecar restart: the direct runtime client is rebuilt on the new port

Full `houston-web` suite green (34 files / 164 tests), workspace typecheck + Biome clean.