### PR TITLE
feat(website): deploy the marketing site to Firebase Hosting

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -1,13 +1,34 @@
 name: Website Deploy
 
-# Builds the Eleventy site in website/ and deploys it to Cloudflare Pages
-# (project: houston-site). Runs automatically when website/ changes land on
-# main; can also be triggered manually from the Actions tab.
+# Builds the Eleventy site in website/ and deploys it to Firebase Hosting
+# (project: gethouston, site: gethouston-site). Runs automatically when
+# website/ changes land on main; can also be triggered manually.
 #
-# Required repo secrets:
-#   CLOUDFLARE_API_TOKEN  - token with "Cloudflare Pages: Edit" permission
-#   CLOUDFLARE_ACCOUNT_ID - account id from the Cloudflare dashboard
-#   SUPABASE_ANON_KEY     - public (RLS-protected) Supabase anon key for the /waitlist form
+# ── Cutover choreography (Cloudflare Pages -> Firebase Hosting) ────────────────
+# This job deploys to the gethouston-site.web.app Firebase site ONLY. It does
+# NOT touch DNS and does NOT decommission Cloudflare. The apex/www DNS records
+# for gethouston.ai still point at Cloudflare Pages until the human flip. Order:
+#   1. Orchestrator creates the Firebase site once (see PR body):
+#        firebase hosting:sites:create gethouston-site --project gethouston
+#      (equivalently the Hosting REST API `sites.create` with siteId=gethouston-site).
+#   2. This workflow runs on the next website/ push (or manual dispatch) and
+#      publishes the build to https://gethouston-site.web.app.
+#   3. Verify the deploy on https://gethouston-site.web.app (redirects, headers,
+#      URL shape) while gethouston.ai still serves from Cloudflare.
+#   4. Human adds the custom domain in Firebase Hosting and flips the apex/www
+#      DNS records to Firebase, then retires the Cloudflare Pages project. The
+#      src/_headers and src/_redirects files stay in the repo (harmless, unused
+#      on Firebase — firebase.json is the source of truth) until that cleanup.
+#
+# ── GCP auth: Workload Identity Federation ────────────────────────────────────
+#   SA: github-deploy-web@gethouston.iam.gserviceaccount.com — Firebase Hosting
+#   deploy only. The WIF provider condition restricts this binding to
+#   attribute.repository=='gethouston/houston'. firebase-tools authenticates via
+#   the Application Default Credentials exported by google-github-actions/auth.
+#
+# ── Required repo secrets ─────────────────────────────────────────────────────
+#   SUPABASE_ANON_KEY   - public (RLS-protected) Supabase anon key for the
+#                         /waitlist form. Still Supabase, intentionally unchanged.
 # Optional (committed defaults exist):
 #   SUPABASE_URL, WAITLIST_SHEET_ENDPOINT
 
@@ -25,10 +46,11 @@ concurrency:
 
 jobs:
   deploy:
-    name: Build & deploy to Cloudflare Pages
+    name: Build & deploy to Firebase Hosting
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write # Workload Identity Federation
     steps:
       - uses: actions/checkout@v6
 
@@ -50,10 +72,17 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           WAITLIST_SHEET_ENDPOINT: ${{ secrets.WAITLIST_SHEET_ENDPOINT }}
 
-      - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+      - name: Auth to GCP
+        uses: google-github-actions/auth@v2
         with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          workingDirectory: website
-          command: pages deploy _site --project-name=houston-site --branch=main
+          workload_identity_provider: projects/1056698080170/locations/global/workloadIdentityPools/github/providers/houston
+          service_account: github-deploy-web@gethouston.iam.gserviceaccount.com
+
+      - name: Deploy to Firebase Hosting
+        working-directory: website
+        run: >-
+          npx --yes firebase-tools@15 deploy
+          --only hosting:gethouston-site
+          --project gethouston
+          --non-interactive
+          --message "${{ github.sha }}"

--- a/website/.firebaserc
+++ b/website/.firebaserc
@@ -1,0 +1,5 @@
+{
+  "projects": {
+    "default": "gethouston"
+  }
+}

--- a/website/firebase.json
+++ b/website/firebase.json
@@ -18,10 +18,16 @@
       {
         "source": "**",
         "headers": [
-          { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
+          {
+            "key": "Strict-Transport-Security",
+            "value": "max-age=31536000; includeSubDomains; preload"
+          },
           { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
           { "key": "X-Content-Type-Options", "value": "nosniff" },
-          { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+          {
+            "key": "Referrer-Policy",
+            "value": "strict-origin-when-cross-origin"
+          }
         ]
       },
       {
@@ -38,15 +44,30 @@
       },
       {
         "source": "**/*.html",
-        "headers": [{ "key": "Cache-Control", "value": "public, max-age=60, must-revalidate" }]
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=60, must-revalidate"
+          }
+        ]
       },
       {
         "source": "**/*.css",
-        "headers": [{ "key": "Cache-Control", "value": "public, max-age=60, must-revalidate" }]
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=60, must-revalidate"
+          }
+        ]
       },
       {
         "source": "/",
-        "headers": [{ "key": "Cache-Control", "value": "public, max-age=60, must-revalidate" }]
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=60, must-revalidate"
+          }
+        ]
       }
     ]
   }

--- a/website/firebase.json
+++ b/website/firebase.json
@@ -1,0 +1,53 @@
+{
+  "hosting": {
+    "site": "gethouston-site",
+    "public": "_site",
+    "cleanUrls": true,
+    "ignore": [
+      "firebase.json",
+      "**/.*",
+      "**/node_modules/**",
+      "**/_headers",
+      "**/_redirects"
+    ],
+    "redirects": [
+      { "source": "/pricing/", "destination": "/#pricing", "type": 301 },
+      { "source": "/pricing/es/", "destination": "/#pricing", "type": 301 }
+    ],
+    "headers": [
+      {
+        "source": "**",
+        "headers": [
+          { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
+          { "key": "X-Frame-Options", "value": "SAMEORIGIN" },
+          { "key": "X-Content-Type-Options", "value": "nosniff" },
+          { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" }
+        ]
+      },
+      {
+        "source": "/early-access/**",
+        "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }]
+      },
+      {
+        "source": "/auth/**",
+        "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }]
+      },
+      {
+        "source": "/slack/**",
+        "headers": [{ "key": "X-Robots-Tag", "value": "noindex, nofollow" }]
+      },
+      {
+        "source": "**/*.html",
+        "headers": [{ "key": "Cache-Control", "value": "public, max-age=60, must-revalidate" }]
+      },
+      {
+        "source": "**/*.css",
+        "headers": [{ "key": "Cache-Control", "value": "public, max-age=60, must-revalidate" }]
+      },
+      {
+        "source": "/",
+        "headers": [{ "key": "Cache-Control", "value": "public, max-age=60, must-revalidate" }]
+      }
+    ]
+  }
+}

--- a/website/package.json
+++ b/website/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npx @11ty/eleventy",
     "dev": "npx @11ty/eleventy --serve",
-    "deploy": "npm run build && npx wrangler pages deploy _site --project-name=houston-site --branch=main --commit-dirty=true"
+    "deploy": "npm run build && npx --yes firebase-tools@15 deploy --only hosting:gethouston-site --project gethouston --non-interactive"
   },
   "dependencies": {
     "@11ty/eleventy": "^3.1.5",


### PR DESCRIPTION
## Summary
- Moves the marketing-site deploy from Cloudflare Pages (wrangler) to Firebase Hosting site `gethouston-site` in the `gethouston` GCP project (created), via the existing WIF SA — part of the GCP consolidation
- `website/firebase.json` ports every `_redirects`/`_headers` rule (security headers, per-path noindex, cache-control, the /pricing 301s); URL shape (`cleanUrls` + default trailing-slash) verified empirically against superstatic (Firebase Hosting's engine): full request matrix passes, no redirect loops
- Cloudflare remains live and untouched — cutover choreography (deploy → verify on gethouston-site.web.app → DNS flip) documented in the workflow header

## Test plan
- [x] Eleventy build green; JSON/YAML validate
- [x] superstatic request matrix: clean URLs 200, .html→301 clean, directory slashes stable both directions, /pricing/ 301 → /#pricing, noindex headers on early-access/auth/slack, 404 page
- [ ] Post-merge: first CI deploy, then manual verify on https://gethouston-site.web.app before any DNS change

🤖 Generated with [Claude Code](https://claude.com/claude-code)