### PR TITLE
feat(app): metadata-driven cloud-migration gate — user_metadata.migrated (HOU-719)

### DIFF
--- a/app/src/components/settings/sections/migration.tsx
+++ b/app/src/components/settings/sections/migration.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from "react-i18next";
 import { useSession } from "../../../hooks/use-session";
 import { isHostedGatewayEngine } from "../../../lib/engine";
 import { reportError } from "../../../lib/error-toast";
-import { readMigrationStatus } from "../../../lib/migration-status";
+import { readMigrated } from "../../../lib/migration-status";
 import { osDetectLegacyHouston, osIsTauri } from "../../../lib/os-bridge";
 import { queryKeys } from "../../../lib/query-keys";
 
@@ -21,9 +21,7 @@ const STORAGE_PREFIX = "houston.cloudMigration.";
 export function useMigrationAvailable(): boolean {
   const { data: session } = useSession();
   const gates =
-    isHostedGatewayEngine() &&
-    osIsTauri() &&
-    readMigrationStatus(session) !== "completed";
+    isHostedGatewayEngine() && osIsTauri() && readMigrated(session) !== true;
   const detect = useQuery({
     queryKey: queryKeys.cloudMigrationDetect(),
     queryFn: async () => {

--- a/app/src/hooks/cloud-migration-trigger.ts
+++ b/app/src/hooks/cloud-migration-trigger.ts
@@ -30,11 +30,13 @@ export interface CloudMigrationInputs {
   /** This user already finished or declined the wizard on this machine. */
   outcome: CloudMigrationOutcome | null;
   /**
-   * The AUTHORITATIVE, cross-machine flag from the user's Supabase metadata:
-   * `true` once `migration_status === "completed"`. Wins over everything else —
-   * a user who migrated on any machine is never offered the wizard again.
+   * The AUTHORITATIVE, cross-machine gate from the user's Supabase metadata
+   * (`readMigrated`): `true` = done (migrated, or a new user past onboarding),
+   * `false` = an existing user marked for migration, `null` = a brand-new cloud
+   * user. Only an explicit `false` is ever a wizard candidate; `true` and
+   * absent both fall straight through to the app / onboarding.
    */
-  migrationCompleted: boolean;
+  migrated: boolean | null;
   /** The detection probe is still in flight. */
   loading: boolean;
 }
@@ -53,10 +55,15 @@ export function cloudMigrationGateState(
   if (!i.remoteGateway) return "pass";
   if (!i.isTauri) return "pass";
   if (!i.signedIn) return "pass";
-  // Cross-machine authority first: a completed account never sees the wizard,
-  // even on a new machine that still has a leftover `.houston` folder.
-  if (i.migrationCompleted) return "pass";
+  // Authoritative cross-machine metadata gate. `true` (migrated, or a new user
+  // past onboarding) and `null` (a brand-new cloud user → normal onboarding)
+  // both pass; ONLY an explicit `false` marks a migration candidate. This is
+  // what lets "absent = new": the whole existing base is backfilled to `false`.
+  if (i.migrated !== false) return "pass";
   if (i.outcome) return "pass";
   if (i.loading) return "loading";
+  // Marked for migration, but the data is machine-local: only surface the
+  // wizard where a `~/.houston` actually exists. A marked user on a fresh
+  // machine keeps `migrated:false` and migrates on the device that holds it.
   return i.hasLegacyWorkspaces ? "show" : "pass";
 }

--- a/app/src/hooks/use-cloud-migration.ts
+++ b/app/src/hooks/use-cloud-migration.ts
@@ -4,7 +4,7 @@ import type { LegacyDetection } from "../lib/cloud-migration";
 import { DEMO_DETECTION, isMigrationDemo } from "../lib/cloud-migration-demo";
 import { isHostedGatewayEngine } from "../lib/engine";
 import { reportError } from "../lib/error-toast";
-import { readMigrationStatus } from "../lib/migration-status";
+import { readMigrated } from "../lib/migration-status";
 import { osDetectLegacyHouston, osIsTauri } from "../lib/os-bridge";
 import { queryKeys } from "../lib/query-keys";
 import {
@@ -58,7 +58,9 @@ export interface CloudMigrationTrigger {
 export function useCloudMigration(): CloudMigrationTrigger {
   const { data: session } = useSession();
   const userId = session?.user?.id ?? null;
-  const migrationCompleted = readMigrationStatus(session) === "completed";
+  // The authoritative gate: only an explicit `migrated:false` is ever a wizard
+  // candidate (`true` = done, absent = brand-new user → onboarding).
+  const migrated = readMigrated(session);
   const remoteGateway = isHostedGatewayEngine();
   const isTauri = osIsTauri();
 
@@ -71,7 +73,7 @@ export function useCloudMigration(): CloudMigrationTrigger {
     isTauri &&
     Boolean(userId) &&
     !outcome &&
-    !migrationCompleted;
+    migrated === false;
   const detectQuery = useQuery({
     queryKey: queryKeys.cloudMigrationDetect(),
     // Read-only filesystem scan; stable for the app's lifetime. An automatic
@@ -130,7 +132,7 @@ export function useCloudMigration(): CloudMigrationTrigger {
     signedIn: Boolean(userId),
     hasLegacyWorkspaces: detectQuery.data?.hasWorkspaces ?? false,
     outcome,
-    migrationCompleted,
+    migrated,
     loading: gatesOpen && detectQuery.isLoading,
   });
 

--- a/app/src/lib/migration-status.ts
+++ b/app/src/lib/migration-status.ts
@@ -63,3 +63,45 @@ export async function writeMigrationStatus(
     );
   }
 }
+
+/**
+ * The single top-level cloud-migration GATE on the user's Supabase metadata
+ * (HOU-719), a plain boolean that decides which first-run surface a signed-in
+ * desktop user sees:
+ *
+ *   - `true`  — done: migrated (or a brand-new user who finished onboarding).
+ *               Never show onboarding OR the migration wizard again.
+ *   - `false` — an existing local-app user marked for migration. The wizard is
+ *               offered on whichever machine still holds their `~/.houston`.
+ *   - absent  — a brand-new user who only ever downloaded the cloud app; they
+ *               go through normal onboarding.
+ *
+ * The whole existing user base is backfilled to `false` at cutover, so "absent"
+ * can reliably mean "new". `migration_status` above stays the finer-grained
+ * resume/retry detail; `migrated` is the authoritative on/off switch the gate
+ * reads.
+ */
+export function readMigrated(
+  session: Session | null | undefined,
+): boolean | null {
+  const raw = session?.user?.user_metadata?.migrated;
+  return typeof raw === "boolean" ? raw : null;
+}
+
+/** Write the `migrated` gate flag to the signed-in user's metadata.
+ *  Best-effort, mirroring `writeMigrationStatus` — a failure is reported, never
+ *  silent, and the next successful write reconciles the account. */
+export async function writeMigrated(value: boolean): Promise<void> {
+  try {
+    const { error } = await supabase.auth.updateUser({
+      data: { migrated: value },
+    });
+    if (error) throw error;
+  } catch (e) {
+    reportError(
+      "cloud_migration_migrated_write",
+      e instanceof Error ? e.message : String(e),
+      e,
+    );
+  }
+}

--- a/app/src/stores/cloud-migration-finish.ts
+++ b/app/src/stores/cloud-migration-finish.ts
@@ -9,7 +9,7 @@ import { analytics } from "../lib/analytics";
 import type { MigrationTask } from "../lib/cloud-migration";
 import type { AgentMigrationProgress } from "../lib/cloud-migration-progress";
 import { reportError } from "../lib/error-toast";
-import { writeMigrationStatus } from "../lib/migration-status";
+import { writeMigrated, writeMigrationStatus } from "../lib/migration-status";
 import { osStopMigrationSourceHost } from "../lib/os-bridge";
 import { useAgentStore } from "./agents";
 import { useWorkspaceStore } from "./workspaces";
@@ -44,8 +44,10 @@ export async function finishRun(
     workspace_count: new Set(tasks.map((t) => t.workspace)).size,
   });
   // The single completion point of a run (all agents done or continue-anyway):
-  // stamp the AUTHORITATIVE cross-machine "migrated" flag so the wizard is
-  // never offered again on any of the user's machines. Best-effort.
+  // flip the AUTHORITATIVE cross-machine gate to `migrated:true` so neither the
+  // wizard nor onboarding is offered again on any of the user's machines, and
+  // keep the finer-grained status at "completed" for detail. Both best-effort.
+  await writeMigrated(true);
   await writeMigrationStatus("completed");
   setScreenDone();
 }

--- a/app/tests/cloud-migration-trigger.test.ts
+++ b/app/tests/cloud-migration-trigger.test.ts
@@ -2,27 +2,31 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { cloudMigrationGateState } from "../src/hooks/cloud-migration-trigger.ts";
 
-// The "show" case: a signed-in user on the remote-gateway desktop build, with
-// legacy data on disk, no persisted outcome, every signal resolved.
+// The "show" case: a signed-in user on the remote-gateway desktop build,
+// explicitly marked `migrated:false`, with legacy data on disk, no persisted
+// outcome, every signal resolved.
 const SHOW = {
   remoteGateway: true,
   isTauri: true,
   signedIn: true,
   hasLegacyWorkspaces: true,
   outcome: null,
-  migrationCompleted: false,
+  migrated: false,
   loading: false,
 } as const;
 
-test("shows for a signed-in gateway desktop with legacy data", () => {
+test("shows for a signed-in gateway desktop marked migrated:false with legacy data", () => {
   assert.equal(cloudMigrationGateState(SHOW), "show");
 });
 
-test("never shows once the account has migrated (cross-machine), even with leftover legacy data", () => {
-  assert.equal(
-    cloudMigrationGateState({ ...SHOW, migrationCompleted: true }),
-    "pass",
-  );
+test("never shows once the account is migrated (cross-machine), even with leftover legacy data", () => {
+  assert.equal(cloudMigrationGateState({ ...SHOW, migrated: true }), "pass");
+});
+
+test("never shows for a brand-new cloud user (absent metadata) even with local data — they onboard", () => {
+  // A truly new user has no `migrated` field; absent must route to onboarding,
+  // never the wizard, regardless of what happens to be on disk.
+  assert.equal(cloudMigrationGateState({ ...SHOW, migrated: null }), "pass");
 });
 
 test("never shows outside remote gateway mode (local sidecar / dev host)", () => {

--- a/scripts/backfill-migrated-flag.mjs
+++ b/scripts/backfill-migrated-flag.mjs
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+// One-time cutover backfill for the cloud-migration gate (HOU-719).
+//
+// The desktop wizard reads `user_metadata.migrated` (app/src/lib/migration-status.ts):
+//   false  → existing local-app user, offer the migration wizard
+//   true   → done (migrated, or a new user past onboarding)
+//   absent → a brand-NEW cloud user → normal onboarding
+//
+// For "absent = new" to hold, the ENTIRE existing user base must be stamped
+// before the cloud app ships. This walks every Supabase user and sets:
+//   - migrated:true   if they already finished (migration_status === "completed")
+//   - migrated:false  otherwise
+// Users who already carry a `migrated` boolean are left untouched (idempotent).
+//
+// Usage (dry-run prints the plan and changes nothing):
+//   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node scripts/backfill-migrated-flag.mjs
+//   SUPABASE_URL=... SUPABASE_SERVICE_ROLE_KEY=... node scripts/backfill-migrated-flag.mjs --apply
+//
+// The SERVICE ROLE key is admin-scoped — never commit it, pass it via env only.
+
+import { createClient } from "@supabase/supabase-js";
+
+const URL = process.env.SUPABASE_URL;
+const KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const APPLY = process.argv.includes("--apply");
+
+if (!URL || !KEY) {
+  console.error(
+    "ERROR: set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (admin key) in the env.",
+  );
+  process.exit(1);
+}
+
+const admin = createClient(URL, KEY, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+/** Decide the target flag for one user; null = leave untouched. */
+function target(user) {
+  const meta = user.user_metadata ?? {};
+  if (typeof meta.migrated === "boolean") return null; // already stamped
+  return meta.migration_status === "completed";
+}
+
+async function main() {
+  const summary = {
+    scanned: 0,
+    setTrue: 0,
+    setFalse: 0,
+    skipped: 0,
+    failed: 0,
+  };
+  const perPage = 1000;
+  for (let page = 1; ; page++) {
+    const { data, error } = await admin.auth.admin.listUsers({ page, perPage });
+    if (error) {
+      console.error(`listUsers page ${page} failed: ${error.message}`);
+      process.exit(1);
+    }
+    const users = data?.users ?? [];
+    if (users.length === 0) break;
+
+    for (const user of users) {
+      summary.scanned++;
+      const want = target(user);
+      if (want === null) {
+        summary.skipped++;
+        continue;
+      }
+      const countKey = want ? "setTrue" : "setFalse";
+      if (!APPLY) {
+        summary[countKey]++;
+        continue;
+      }
+      const { error: upErr } = await admin.auth.admin.updateUserById(user.id, {
+        user_metadata: { ...user.user_metadata, migrated: want },
+      });
+      if (upErr) {
+        summary.failed++;
+        console.error(`  update ${user.id} failed: ${upErr.message}`);
+      } else {
+        summary[countKey]++;
+      }
+    }
+    if (users.length < perPage) break;
+  }
+
+  const mode = APPLY ? "APPLIED" : "DRY-RUN (pass --apply to write)";
+  console.log(`\n${mode}`);
+  console.table(summary);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## What

The first-run cloud-migration gate now keys off a single authoritative, cross-machine boolean on the user's Supabase metadata — `user_metadata.migrated` — instead of inferring "is this an existing user" from local disk.

| `migrated` | Meaning | First-run surface |
|---|---|---|
| `true` | Done: migrated, or a new user past onboarding | App |
| `false` | Existing local-app user marked for migration | **Migration wizard** (only where a `~/.houston` actually exists on this machine) |
| absent | Brand-new cloud user | Normal onboarding |

The whole existing user base is backfilled to `false` at cutover (`scripts/backfill-migrated-flag.mjs`, idempotent, reconciles already-completed accounts to `true`), so **"absent = new"** reliably holds.

## Why

The previous gate inferred existing-vs-new from a local `~/.houston` scan plus a `migration_status` string. Keying the decision off server-side metadata makes it deterministic and cross-machine: a marked user is offered the wizard on whichever machine still holds their data, a migrated user never sees it again anywhere, and a truly new user goes straight to onboarding.

Local detection stays, but only in its correct role now: *does THIS machine hold the data to migrate* (a `false` user on a fresh machine keeps `false` and migrates on the device that has it).

## Changes
- `lib/migration-status.ts`: add `readMigrated` / `writeMigrated`.
- `hooks/cloud-migration-trigger.ts`: gate on `migrated` (only explicit `false` is a candidate; `true`/absent pass).
- `hooks/use-cloud-migration.ts`: feed `migrated`; only probe disk for marked users.
- `stores/cloud-migration-finish.ts`: stamp `migrated:true` on completion.
- `components/settings/sections/migration.tsx`: "Continue migration" gates on `migrated !== true`.
- `scripts/backfill-migrated-flag.mjs`: one-time cutover backfill (dry-run by default).

## Tests
- `cloud-migration-trigger.test.ts` updated + new "brand-new user (absent) → onboarding" case. 10 pass.
- `pnpm tsgo`, `pnpm check-locales`, `pnpm check` all green.

HOU-719