### PR TITLE
feat(web): hosted web client deploy pipeline (preview + promote)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1732,7 +1732,9 @@ jobs:
       - name: Deploy to preview site
         working-directory: packages/web
         run: |
-          npx --yes firebase-tools@latest deploy \
+          # Pinned major: an unpinned @latest would let a breaking firebase-tools
+          # release silently break the deploy. Keep in sync with web-promote.yml.
+          npx --yes firebase-tools@15 deploy \
             --only hosting:preview \
             --project gethouston \
             --non-interactive

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1563,6 +1563,182 @@ jobs:
           echo "::notice::Linux AppImage uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME"
 
   # ============================================================================
+  # Web client — Firebase Hosting.
+  #
+  # ONE bundle for BOTH environments. This job builds packages/web ONCE, ships
+  # it as the `web-dist.tar.gz` release asset, uploads its sourcemaps to Sentry,
+  # and deploys it to the PREVIEW site (preview.gethouston.ai). Promotion to
+  # production (app.gethouston.ai) re-deploys the SAME bytes from the published
+  # release — see .github/workflows/web-promote.yml. There are NO
+  # environment-specific VITE flags: preview vs production is decided at RUNTIME
+  # from window.location.hostname (packages/web/src/deploy-environment.ts), so
+  # the promoted artifact is byte-identical and only the per-site header config
+  # (e.g. the preview site's X-Robots-Tag: noindex) differs.
+  #
+  # Local channel only. cloud-v* tags are prerelease DESKTOP builds and never
+  # touch hosting, so this job is gated to `v*` (which cloud-v* never matches).
+  # The `github.repository` guard makes forks skip it entirely — they have
+  # neither the gateway secret nor deploy access to our GCP project, so running
+  # it there would only red-X their release.
+  #
+  # The gateway URL is reused from the HOSTED_ENGINE_URL secret (the managed
+  # Houston Cloud gateway the desktop cloud channel already bakes) so there is
+  # ONE source of truth and no endpoint literal in this file.
+  #
+  # GCP auth: keyless Workload Identity Federation — the SAME provider as
+  # engine-pod-image.yml, with the web-deploy service account. firebase-tools
+  # reads the ADC that google-github-actions/auth writes
+  # (GOOGLE_APPLICATION_CREDENTIALS), so no FIREBASE_TOKEN is needed.
+  build-web:
+    needs: prep
+    if: ${{ startsWith(github.ref_name, 'v') && github.repository == 'gethouston/houston' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: write # gh release upload the web-dist asset
+      id-token: write # Workload Identity Federation for the Firebase deploy
+    # Job-level so the Sentry upload step's `if: ${{ env.SENTRY_AUTH_TOKEN != '' }}`
+    # can read it — same step-`if`-can't-see-step-env footgun as the desktop jobs.
+    env:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Full history + tags so `sentry-cli releases set-commits --auto` can
+          # associate this release with its commits (mirrors the desktop jobs).
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install
+
+      # The web bundle's Sentry release is `houston-app@<__APP_VERSION__>`, and
+      # __APP_VERSION__ resolves to "<packages/web version>-web". packages/web
+      # ships a 0.0.0 placeholder version, so stamp the real release version onto
+      # the runner's checkout (never committed) — otherwise every release would
+      # collide at `houston-app@0.0.0-web` and its sourcemaps would resolve
+      # against the wrong build. The `-web` suffix keeps web crashes on their own
+      # Sentry release, distinct from the desktop `houston-app@<version>`.
+      - name: Stamp web bundle version
+        id: webversion
+        run: |
+          set -euo pipefail
+          VERSION="${GITHUB_REF_NAME#v}"
+          jq --arg v "$VERSION" '.version = $v' packages/web/package.json > packages/web/package.json.tmp
+          mv packages/web/package.json.tmp packages/web/package.json
+          echo "release=houston-app@${VERSION}-web" >> "$GITHUB_OUTPUT"
+          echo "Web Sentry release: houston-app@${VERSION}-web"
+
+      # Build ONCE. VITE_CONTROL_PLANE_URL selects host/cloud-login mode (every
+      # domain call goes to the managed gateway); the FIREBASE_* trio configures
+      # the app's own GCP Identity Platform (Firebase Auth) sign-in — the web
+      # bundle authenticates with firebase-js-sdk's popup, so FIREBASE_API_KEY is
+      # load-bearing and must be present (it has no build-time default). The
+      # desktop-only OAuth vars (GOOGLE_DESKTOP_*, MICROSOFT_DESKTOP_CLIENT_ID)
+      # are the loopback/PKCE flow that never runs in a browser tab, so they are
+      # deliberately NOT baked here (vite.config.ts defaults them to ""). POSTHOG_*
+      # /SENTRY_DSN power the shared analytics + crash reporting. The deploy
+      # environment is NOT baked — it is derived at runtime from the hostname.
+      - name: Build packages/web
+        env:
+          VITE_CONTROL_PLANE_URL: ${{ secrets.HOSTED_ENGINE_URL }}
+          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN }}
+        run: |
+          set -euo pipefail
+          # A missing gateway URL would silently ship a web app that falls back to
+          # the self-host Connect screen instead of the managed cloud. Fail loudly
+          # (no-silent-failures) rather than deploy a broken product.
+          if [ -z "${VITE_CONTROL_PLANE_URL}" ]; then
+            echo "::error::HOSTED_ENGINE_URL secret is empty — set it to the managed gateway URL (https://gateway.gethouston.ai) before releasing the web app."
+            exit 1
+          fi
+          pnpm --filter houston-web build
+
+      # Inject Sentry Debug IDs into the shipped JS + maps BEFORE tar/deploy, so
+      # the promoted bytes and the uploaded maps share the same IDs (the web build
+      # emits hidden sourcemaps, exactly like the desktop bundle — no
+      # sourceMappingURL comment, resolvable only by Debug ID). Then upload the
+      # maps under the web release. The next step strips the maps from dist so the
+      # public CDN bundle carries only the Debug-ID'd JS.
+      - name: Upload web sourcemaps to Sentry
+        if: ${{ env.SENTRY_AUTH_TOKEN != '' }}
+        env:
+          SENTRY_ORG: houston-cd
+          SENTRY_PROJECT: houston-app
+        run: |
+          set -euo pipefail
+          RELEASE="${{ steps.webversion.outputs.release }}"
+          # Lockfile-pinned sentry-cli (app's @sentry/cli devDep), same binary the
+          # desktop jobs use — not an unpinned get-cli download.
+          SENTRY_CLI="app/node_modules/.bin/sentry-cli"
+          "$SENTRY_CLI" --version
+          "$SENTRY_CLI" releases new "$RELEASE"
+          "$SENTRY_CLI" releases set-commits --auto "$RELEASE" || \
+            echo "::warning::set-commits --auto failed (shallow clone or first release); continuing"
+          "$SENTRY_CLI" sourcemaps inject packages/web/dist
+          "$SENTRY_CLI" sourcemaps upload --release "$RELEASE" packages/web/dist
+          "$SENTRY_CLI" releases finalize "$RELEASE"
+
+      # Keep the shipped bundle map-free (they live in Sentry now). Runs
+      # unconditionally so even a run without SENTRY_AUTH_TOKEN never publishes
+      # .map files to the public CDN.
+      - name: Strip sourcemaps from dist
+        run: find packages/web/dist -name '*.map' -delete
+
+      # Deterministic archive so the byte-for-byte promotion is verifiable: fixed
+      # member order, mtime, and ownership, plus `gzip -n` (no name/timestamp in
+      # the gzip header). This exact archive is what web-promote.yml re-deploys to
+      # production — identical bytes on preview and app.gethouston.ai.
+      - name: Package web-dist.tar.gz
+        run: |
+          set -euo pipefail
+          tar --sort=name --mtime='UTC 2020-01-01' \
+            --owner=0 --group=0 --numeric-owner \
+            -C packages/web/dist -cf - . | gzip -n > web-dist.tar.gz
+          echo "web-dist.tar.gz: $(du -h web-dist.tar.gz | cut -f1)"
+
+      - name: Upload web-dist.tar.gz to draft release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "$GITHUB_REF_NAME" web-dist.tar.gz --clobber
+          echo "::notice::web-dist.tar.gz uploaded to draft https://github.com/${{ github.repository }}/releases/tag/$GITHUB_REF_NAME — web-promote.yml re-deploys these exact bytes to production on publish."
+
+      - name: Auth to GCP (Workload Identity Federation)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/1056698080170/locations/global/workloadIdentityPools/github/providers/houston
+          service_account: github-deploy-web@gethouston.iam.gserviceaccount.com
+
+      # firebase-tools auto-discovers firebase.json + .firebaserc in this dir; the
+      # target `preview` maps to the houston-web-preview site (see .firebaserc), so
+      # no auth-requiring `target:apply` is needed. `public: "dist"` resolves to the
+      # freshly built packages/web/dist.
+      - name: Deploy to preview site
+        working-directory: packages/web
+        run: |
+          npx --yes firebase-tools@latest deploy \
+            --only hosting:preview \
+            --project gethouston \
+            --non-interactive
+          echo "::notice::Deployed the web bundle to preview.gethouston.ai (houston-web-preview)."
+
+  # ============================================================================
   # Stitch the parallel mac + win builds into one finished draft release.
   # Runs on a clean ubuntu runner — no source tree, no signing identities,
   # no platform-specific tooling needed. Just `gh`, `jq`, and `curl`,

--- a/.github/workflows/web-promote.yml
+++ b/.github/workflows/web-promote.yml
@@ -102,7 +102,9 @@ jobs:
         if: ${{ steps.check.outputs.present == 'true' }}
         working-directory: packages/web
         run: |
-          npx --yes firebase-tools@latest deploy \
+          # Pinned major: an unpinned @latest would let a breaking firebase-tools
+          # release silently break promotion. Keep in sync with release.yml build-web.
+          npx --yes firebase-tools@15 deploy \
             --only hosting:production \
             --project gethouston \
             --non-interactive

--- a/.github/workflows/web-promote.yml
+++ b/.github/workflows/web-promote.yml
@@ -1,0 +1,109 @@
+# Web promotion — preview → production (app.gethouston.ai)
+#
+# The release workflow's `build-web` job builds packages/web ONCE, attaches it
+# as the `web-dist.tar.gz` release asset, and deploys those bytes to the PREVIEW
+# site. Publishing a release (draft → public, the manual QA gate) is the signal
+# that the preview build is blessed: this workflow downloads that SAME asset and
+# re-deploys the identical bytes to the PRODUCTION site. No rebuild — what users
+# get on app.gethouston.ai is byte-for-byte what was tested on
+# preview.gethouston.ai for this version. Preview vs production is decided at
+# runtime from the hostname, so one artifact legitimately serves both.
+#
+# Rollback = re-publish an older release (this re-runs and re-deploys that
+# release's web-dist.tar.gz), or roll back in the Firebase Hosting console.
+name: Web promote
+
+on:
+  release:
+    types: [published]
+
+# Serialize overlapping publishes so two rapid promotions can't race the same
+# production site into an inconsistent state; never cancel an in-flight deploy.
+concurrency:
+  group: web-promote
+  cancel-in-progress: false
+
+permissions:
+  contents: read # download the release asset
+  id-token: write # Workload Identity Federation for the Firebase deploy
+
+jobs:
+  promote:
+    # Promote ONLY real, published, non-prerelease LOCAL-channel releases:
+    #   - `v*`               — the local channel the web app tracks. cloud-v*
+    #                          desktop releases start with `c`, so they never match.
+    #   - not a prerelease   — cloud-v* releases are prereleases anyway; this also
+    #                          keeps any hand-made prerelease off production.
+    #   - canonical repo     — forks have no deploy access to our GCP project.
+    if: ${{ startsWith(github.event.release.tag_name, 'v') && !github.event.release.prerelease && github.repository == 'gethouston/houston' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      GH_REPO: ${{ github.repository }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      TAG: ${{ github.event.release.tag_name }}
+    steps:
+      # A release published BEFORE this pipeline existed carries no web asset.
+      # That is not a failure — skip gracefully with a notice rather than red-X an
+      # old release the instant it is published. A PRESENT-but-empty asset, by
+      # contrast, is a real problem and fails loudly below.
+      - name: Check for web-dist.tar.gz asset
+        id: check
+        run: |
+          set -euo pipefail
+          if gh release view "$TAG" --json assets --jq '.assets[].name' | grep -qx 'web-dist.tar.gz'; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Release $TAG has no web-dist.tar.gz asset — nothing to promote (tag predates the web pipeline). Skipping."
+          fi
+
+      # The Firebase config (firebase.json + .firebaserc) is version-controlled,
+      # not in the artifact. Check it out AT THE RELEASE TAG so production's
+      # headers/target mapping match the exact commit that produced the bundle.
+      - name: Checkout hosting config at the release tag
+        if: ${{ steps.check.outputs.present == 'true' }}
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name }}
+          sparse-checkout: |
+            packages/web/firebase.json
+            packages/web/.firebaserc
+          sparse-checkout-cone-mode: false
+
+      # Download the SAME artifact build-web attached to this release and unpack
+      # it into the location firebase.json's `public: "dist"` expects. Reusing the
+      # asset (no rebuild) is what makes the promotion byte-identical.
+      - name: Download + unpack bundle into packages/web/dist
+        if: ${{ steps.check.outputs.present == 'true' }}
+        run: |
+          set -euo pipefail
+          gh release download "$TAG" --pattern 'web-dist.tar.gz' --dir .
+          if [ ! -s web-dist.tar.gz ]; then
+            echo "::error::web-dist.tar.gz is present on $TAG but downloaded empty — refusing to promote a partial artifact."
+            exit 1
+          fi
+          rm -rf packages/web/dist
+          mkdir -p packages/web/dist
+          tar -xzf web-dist.tar.gz -C packages/web/dist
+          test -f packages/web/dist/index.html \
+            || { echo "::error::unpacked bundle has no index.html — the artifact is not a web build"; exit 1; }
+
+      - name: Auth to GCP (Workload Identity Federation)
+        if: ${{ steps.check.outputs.present == 'true' }}
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/1056698080170/locations/global/workloadIdentityPools/github/providers/houston
+          service_account: github-deploy-web@gethouston.iam.gserviceaccount.com
+
+      # `production` maps to the houston-web site (see .firebaserc); firebase-tools
+      # reads the ADC google-github-actions/auth wrote, so no FIREBASE_TOKEN.
+      - name: Deploy to production site
+        if: ${{ steps.check.outputs.present == 'true' }}
+        working-directory: packages/web
+        run: |
+          npx --yes firebase-tools@latest deploy \
+            --only hosting:production \
+            --project gethouston \
+            --non-interactive
+          echo "::notice::Promoted $TAG to production — app.gethouston.ai now serves the same bytes tested on preview."

--- a/app/src/lib/analytics.ts
+++ b/app/src/lib/analytics.ts
@@ -170,12 +170,20 @@ function rawNavigatorPlatform() {
 }
 
 function baseSuperProps() {
+  // The web entry injects the runtime deploy environment on
+  // `window.__HOUSTON_DEPLOY_ENV__` (production / preview / development, derived
+  // from the hostname of the ONE promoted bundle). Attach it as a super property
+  // so preview traffic is filterable out of product metrics. Unset on the
+  // desktop, where `is_debug` already separates dev from release.
+  const deployEnv =
+    typeof window !== "undefined" ? window.__HOUSTON_DEPLOY_ENV__ : undefined;
   return {
     app_version: APP_VERSION,
     app_os: currentPlatformOs,
     os: rawNavigatorPlatform(),
     is_debug: import.meta.env.DEV,
     session_id: SESSION_ID,
+    ...(deployEnv ? { environment: deployEnv } : {}),
   };
 }
 

--- a/app/src/lib/engine.ts
+++ b/app/src/lib/engine.ts
@@ -26,6 +26,12 @@ declare global {
      *  the gateway resolves the caller's personal org). The local host's
      *  header-free `/v1/ws` transport ignores it. */
     __HOUSTON_ACTIVE_ORG__?: string | null;
+    /** Runtime deploy environment injected by the web entry (packages/web
+     *  main.tsx) from the hostname, so ONE promoted bundle reports `preview` on
+     *  the preview site and `production` on app.gethouston.ai. Read by
+     *  `sentry.ts` + `analytics.ts` to tag their `environment`. Undefined on the
+     *  desktop (which derives environment from `import.meta.env.DEV` instead). */
+    __HOUSTON_DEPLOY_ENV__?: "production" | "preview" | "development";
   }
 }
 

--- a/app/src/lib/sentry.ts
+++ b/app/src/lib/sentry.ts
@@ -41,6 +41,20 @@ const REPLAYS_ON_ERROR_SAMPLE_RATE = 1.0;
 
 let initialized = false;
 
+/**
+ * Sentry `environment` tag. The web entry injects the runtime deploy
+ * environment (`production` / `preview` / `development`, derived from the
+ * hostname of the ONE promoted bundle) on `window.__HOUSTON_DEPLOY_ENV__`; use
+ * it when present so preview and production crashes are filterable apart. On the
+ * desktop the global is unset, so we keep the original dev/prod split.
+ */
+function resolveEnvironment(): string {
+  const injected =
+    typeof window !== "undefined" ? window.__HOUSTON_DEPLOY_ENV__ : undefined;
+  if (injected) return injected;
+  return import.meta.env.DEV ? "development" : "production";
+}
+
 // Per-event delivery outcome recorded by the confirming transport (below) and
 // read+cleared by captureException: true once Sentry accepts the event with a
 // 2xx. Bounded so it can't grow unboundedly from envelopes captured outside
@@ -85,7 +99,7 @@ export function initSentry(): void {
   Sentry.init({
     dsn: DSN,
     release: RELEASE,
-    environment: import.meta.env.DEV ? "development" : "production",
+    environment: resolveEnvironment(),
     // Keep PII off for Session Replay — Houston serves non-technical users
     // whose chat messages, prompts, agent + workspace names and file paths must
     // never enter a recording (the masking integration options below enforce

--- a/app/src/locales/en/common.json
+++ b/app/src/locales/en/common.json
@@ -36,6 +36,9 @@
     "label": "Interface language",
     "toastChanged": "Language changed"
   },
+  "env": {
+    "preview": "Preview"
+  },
   "notifications": {
     "sessionComplete": {
       "title": "{{workspace}} · {{agent}}",

--- a/app/src/locales/es/common.json
+++ b/app/src/locales/es/common.json
@@ -36,6 +36,9 @@
     "label": "Idioma de la interfaz",
     "toastChanged": "Idioma cambiado"
   },
+  "env": {
+    "preview": "Vista previa"
+  },
   "notifications": {
     "sessionComplete": {
       "title": "{{workspace}} · {{agent}}",

--- a/app/src/locales/pt/common.json
+++ b/app/src/locales/pt/common.json
@@ -36,6 +36,9 @@
     "label": "Idioma da interface",
     "toastChanged": "Idioma alterado"
   },
+  "env": {
+    "preview": "Prévia"
+  },
   "notifications": {
     "sessionComplete": {
       "title": "{{workspace}} · {{agent}}",

--- a/knowledge-base/production-infra.md
+++ b/knowledge-base/production-infra.md
@@ -224,10 +224,34 @@ CI also needs as Secrets:
 prep (ubuntu, ~30s)               creates empty draft + release-notes.md artifact
   ├── build-macos (mac, ~25m)     bun-compiles host sidecar (both arches) → signs, notarizes, uploads DMG/tar/sig/latest.json
   ├── build-windows (win, ~15m)   bun-compiles host sidecar per arch → uploads MSI + .sig (x64 + arm64)
-  └── build-linux (ubuntu, ~15m)  bun-compiles host sidecar → uploads AppImage (download-only, not in latest.json)
-        └── finalize (ubuntu, ~30s) [needs mac + win] extends latest.json with windows entries, posts Slack
+  ├── build-linux (ubuntu, ~15m)  bun-compiles host sidecar → uploads AppImage (download-only, not in latest.json)
+  ├── build-web (ubuntu, ~5m)     builds packages/web → uploads web-dist.tar.gz + Sentry maps, deploys PREVIEW site
+  └── finalize (ubuntu, ~30s) [needs mac + win] extends latest.json with windows entries, posts Slack
 ```
-Mac, Windows, and Linux run in parallel because they only need the empty draft `prep` creates, not each other's output. `finalize` stitches `latest.json` together (the macOS-only base from build-macos plus the Windows entries assembled from the MSI .sig in the draft) and posts the team Slack notification — it needs only mac + win, so a flaky new Linux leg never blocks the updater manifest or the mac/win artifacts already on the draft. Linux is UNSIGNED + download-only (no auto-update entry). Slack lives in `finalize` (not Windows) because it needs `release-notes.md` and the file is published as a workflow artifact by `prep`.
+Mac, Windows, Linux, and web run in parallel because they only need the empty draft `prep` creates, not each other's output. `finalize` stitches `latest.json` together (the macOS-only base from build-macos plus the Windows entries assembled from the MSI .sig in the draft) and posts the team Slack notification — it needs only mac + win, so a flaky new Linux/web leg never blocks the updater manifest or the mac/win artifacts already on the draft. Linux is UNSIGNED + download-only (no auto-update entry). Slack lives in `finalize` (not Windows) because it needs `release-notes.md` and the file is published as a workflow artifact by `prep`.
+
+## Web client hosting (Firebase Hosting)
+
+The browser web client (`packages/web`) is served from **Firebase Hosting** in GCP project `gethouston`, on two sites:
+
+| Site ID | Domain | Role |
+| --- | --- | --- |
+| `houston-web` | app.gethouston.ai | production |
+| `houston-web-preview` | preview.gethouston.ai (+ `*.web.app`) | preview / QA gate |
+
+**One build, promoted byte-for-byte.** There are **NO environment-specific VITE flags**. `build-web` (in `release.yml`, gated to `v*` tags on `gethouston/houston`) builds `packages/web` ONCE, and the environment is derived at **runtime** from `window.location.hostname` (`packages/web/src/deploy-environment.ts`): app.gethouston.ai → `production`, preview.gethouston.ai / `*.web.app` → `preview`, localhost → `development`. `main.tsx` publishes the result on `window.__HOUSTON_DEPLOY_ENV__` before the app graph loads; the shared `sentry.ts` + `analytics.ts` read it to tag their `environment`, and the web-only `PreviewBadge` (`packages/web/src/preview-badge.tsx`) renders a small "Preview" pill only on preview.
+
+**Flow:**
+1. `build-web` builds with the gateway URL (`VITE_CONTROL_PLANE_URL` ← the `HOSTED_ENGINE_URL` secret, i.e. `https://gateway.gethouston.ai` — host/cloud-login mode: the app's own GCP Identity Platform (Firebase Auth) gates sign-in, all domain calls hit the gateway), the `FIREBASE_API_KEY`/`FIREBASE_AUTH_DOMAIN`/`FIREBASE_PROJECT_ID` trio that configures that GCIP sign-in (the web bundle authenticates with firebase-js-sdk's popup, so `FIREBASE_API_KEY` is load-bearing and has no build-time default; the desktop-only `GOOGLE_DESKTOP_*`/`MICROSOFT_DESKTOP_CLIENT_ID` loopback vars are deliberately NOT baked — that flow never runs in a browser tab), and `POSTHOG_*`/`SENTRY_DSN`. It injects Sentry Debug IDs, uploads sourcemaps under the web release **`houston-app@<version>-web`** (the `-web` suffix keeps web crashes on their own Sentry release; the runner stamps the real version onto `packages/web/package.json`, which ships a `0.0.0` placeholder), strips the `.map` files, tars `dist` **deterministically** into `web-dist.tar.gz`, attaches it to the draft release, and deploys those bytes to the **preview** site.
+2. `web-promote.yml` (trigger: `release: published`, guarded to `v*` + not-prerelease + canonical repo) downloads the SAME `web-dist.tar.gz` from the published release, checks out `firebase.json`/`.firebaserc` at the release tag, unpacks, and deploys the identical bytes to the **production** site. No rebuild. A published release with **no** web asset (tag predates this pipeline) is **skipped with a notice**, never red-X'd; a present-but-empty asset fails loudly. `concurrency: web-promote` serializes overlapping publishes.
+
+**Auth:** keyless **Workload Identity Federation**, same provider as `engine-pod-image.yml` (`…/workloadIdentityPools/github/providers/houston`), service account `github-deploy-web@gethouston.iam.gserviceaccount.com`. `firebase-tools` reads the ADC `google-github-actions/auth` writes — no `FIREBASE_TOKEN`.
+
+**Config** lives in `packages/web/firebase.json` + `.firebaserc` (targets `production`→`houston-web`, `preview`→`houston-web-preview`). SPA rewrite all→`/index.html`; hashed `/assets/**` get `immutable` 1-year cache, everything else `no-cache`; security headers (`X-Content-Type-Options: nosniff`, `Referrer-Policy: strict-origin-when-cross-origin`, `X-Frame-Options: DENY` + CSP `frame-ancestors 'none'`) on both; the **preview** target additionally serves `X-Robots-Tag: noindex`. Header differences live in per-target config, so the promoted artifact stays byte-identical.
+
+**Rollback:** re-publish an older release (re-runs `web-promote` and re-deploys that release's `web-dist.tar.gz`), or roll back in the Firebase Hosting console (`firebase hosting:clone` / version pinning).
+
+**Required GitHub secrets** are all pre-existing (reused from the desktop jobs): `HOSTED_ENGINE_URL` (must equal the managed gateway URL), `FIREBASE_API_KEY`, `FIREBASE_AUTH_DOMAIN`, `FIREBASE_PROJECT_ID`, `POSTHOG_KEY`, `POSTHOG_HOST`, `SENTRY_DSN`, `SENTRY_AUTH_TOKEN`. No NEW secrets. The one prerequisite is the GCP-side WIF binding for `github-deploy-web@` (Firebase Hosting Admin) — infra, not a repo secret.
 
 ## macOS Universal (arm64 + Intel)
 

--- a/packages/web/.firebaserc
+++ b/packages/web/.firebaserc
@@ -1,0 +1,13 @@
+{
+  "projects": {
+    "default": "gethouston"
+  },
+  "targets": {
+    "gethouston": {
+      "hosting": {
+        "production": ["houston-web"],
+        "preview": ["houston-web-preview"]
+      }
+    }
+  }
+}

--- a/packages/web/firebase.json
+++ b/packages/web/firebase.json
@@ -1,0 +1,71 @@
+{
+  "hosting": [
+    {
+      "target": "production",
+      "public": "dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [{ "source": "**", "destination": "/index.html" }],
+      "headers": [
+        {
+          "source": "**",
+          "headers": [
+            { "key": "X-Content-Type-Options", "value": "nosniff" },
+            {
+              "key": "Referrer-Policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            { "key": "X-Frame-Options", "value": "DENY" },
+            {
+              "key": "Content-Security-Policy",
+              "value": "frame-ancestors 'none'"
+            },
+            { "key": "Cache-Control", "value": "no-cache" }
+          ]
+        },
+        {
+          "source": "/assets/**",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "public, max-age=31536000, immutable"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "target": "preview",
+      "public": "dist",
+      "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+      "rewrites": [{ "source": "**", "destination": "/index.html" }],
+      "headers": [
+        {
+          "source": "**",
+          "headers": [
+            { "key": "X-Content-Type-Options", "value": "nosniff" },
+            {
+              "key": "Referrer-Policy",
+              "value": "strict-origin-when-cross-origin"
+            },
+            { "key": "X-Frame-Options", "value": "DENY" },
+            {
+              "key": "Content-Security-Policy",
+              "value": "frame-ancestors 'none'"
+            },
+            { "key": "Cache-Control", "value": "no-cache" },
+            { "key": "X-Robots-Tag", "value": "noindex" }
+          ]
+        },
+        {
+          "source": "/assets/**",
+          "headers": [
+            {
+              "key": "Cache-Control",
+              "value": "public, max-age=31536000, immutable"
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/packages/web/src/app-tree.tsx
+++ b/packages/web/src/app-tree.tsx
@@ -30,6 +30,7 @@ import { TooltipProvider } from "@houston-ai/core";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Component, type ReactNode, useEffect, useState } from "react";
 import { I18nextProvider } from "react-i18next";
+import { PreviewBadge } from "./preview-badge";
 import "@houston/app/styles/globals.css";
 
 // Sentry first so the global handlers below can capture from the first render.
@@ -143,6 +144,10 @@ export default function AppTree() {
         <TooltipProvider>
           <EngineGate>
             <I18nextProvider i18n={i18n}>
+              {/* Web-only "Preview" pill — fixed + pointer-events-none, so it
+                  overlays every gate/screen without disturbing layout or clicks.
+                  Renders null off the preview deployment. */}
+              <PreviewBadge />
               <LanguageGate>
                 <DisclaimerGate>
                   <App />

--- a/packages/web/src/deploy-environment.ts
+++ b/packages/web/src/deploy-environment.ts
@@ -1,0 +1,54 @@
+/**
+ * Runtime deploy-environment detection (web only).
+ *
+ * ONE web bundle is built and promoted byte-for-byte from the preview site to
+ * the production site (see .github/workflows/web-promote.yml), so the
+ * environment can NOT be baked in at build time — it is derived at runtime from
+ * the hostname the tab is actually served from. The same bytes therefore report
+ * `preview` on preview.gethouston.ai and `production` on app.gethouston.ai.
+ *
+ * Consumers:
+ *  - `main.tsx` publishes the result on `window.__HOUSTON_DEPLOY_ENV__` before
+ *    the app graph loads, so the shared Sentry (`app/src/lib/sentry.ts`) and
+ *    PostHog (`app/src/lib/analytics.ts`) init can tag their `environment`.
+ *  - `preview-badge.tsx` renders the "Preview" pill only when this is `preview`.
+ */
+
+export type DeployEnvironment = "production" | "preview" | "development";
+
+/**
+ * Classify a hostname into a deploy environment. Pure + exported for testing.
+ *
+ * Rules (production is intentionally the single canonical domain — everything
+ * that is not clearly production or local development is treated as preview, so
+ * an unrecognized host is never mistaken for production):
+ *  - `production`  → app.gethouston.ai
+ *  - `development` → localhost / loopback (and `*.localhost`)
+ *  - `preview`     → preview.gethouston.ai, the Firebase default domains
+ *                    (`*.web.app`, `*.firebaseapp.com`), and anything else
+ */
+export function classifyDeployEnvironment(hostname: string): DeployEnvironment {
+  const host = hostname.toLowerCase();
+
+  if (host === "app.gethouston.ai") return "production";
+
+  if (
+    host === "localhost" ||
+    host.endsWith(".localhost") ||
+    host === "127.0.0.1" ||
+    host === "::1" ||
+    host === "[::1]"
+  ) {
+    return "development";
+  }
+
+  // preview.gethouston.ai, houston-web(-preview).web.app, *.firebaseapp.com,
+  // and any not-yet-mapped host — never silently promoted to `production`.
+  return "preview";
+}
+
+/** The current tab's deploy environment, derived from `window.location`. */
+export function currentDeployEnvironment(): DeployEnvironment {
+  if (typeof window === "undefined") return "development";
+  return classifyDeployEnvironment(window.location.hostname);
+}

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -11,11 +11,19 @@
  *    or are entered at runtime on the Connect screen.
  */
 import { createRoot } from "react-dom/client";
+import { currentDeployEnvironment } from "./deploy-environment";
 import {
   type EngineConfig,
   NEW_ENGINE_STORAGE_KEY,
   readStoredEngineConfig,
 } from "./engine-config";
+
+// Publish the runtime deploy environment BEFORE the app module graph loads: the
+// shared Sentry + PostHog init (app/src) read `window.__HOUSTON_DEPLOY_ENV__` to
+// tag their `environment`, and those run as soon as `./app-tree` is imported
+// below. ONE bundle serves both sites, so this is derived from the hostname, not
+// baked at build time (see ./deploy-environment).
+window.__HOUSTON_DEPLOY_ENV__ = currentDeployEnvironment();
 
 const rootEl = document.getElementById("root");
 if (!rootEl) throw new Error("Missing #root element");

--- a/packages/web/src/preview-badge.tsx
+++ b/packages/web/src/preview-badge.tsx
@@ -1,0 +1,33 @@
+import { Badge } from "@houston-ai/core";
+import { FlaskConical } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { currentDeployEnvironment } from "./deploy-environment";
+
+/**
+ * Small "Preview" pill shown ONLY on the preview deployment
+ * (preview.gethouston.ai / *.web.app). It marks a non-production build so a
+ * tester never mistakes preview for the live app they share with users.
+ *
+ * Web-only chrome: rendered by `app-tree.tsx`, never by the shared `app/src`
+ * tree, so the desktop app and production web never carry it. Purely
+ * informational — `pointer-events-none` means it can never intercept a click on
+ * the real UI beneath it, and it sits below the toast layer (z-50) so transient
+ * toasts always win.
+ */
+export function PreviewBadge() {
+  const { t } = useTranslation("common");
+
+  if (currentDeployEnvironment() !== "preview") return null;
+
+  return (
+    <div className="pointer-events-none fixed top-2 left-1/2 z-40 -translate-x-1/2 select-none">
+      <Badge
+        variant="outline"
+        className="gap-1.5 border-border/70 bg-background/80 text-muted-foreground shadow-sm backdrop-blur-sm"
+      >
+        <FlaskConical aria-hidden="true" />
+        {t("env.preview")}
+      </Badge>
+    </div>
+  );
+}

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -34,6 +34,10 @@ interface Window {
   __HOUSTON_ENGINE__?: { baseUrl: string; token: string };
   /** When true, the engine-adapter routes agents + chat through the control plane (cloud). */
   __HOUSTON_CP__?: boolean;
+  /** Runtime deploy environment, set by main.tsx from the hostname so the shared
+   *  Sentry/PostHog init can tag `environment` on ONE bundle served from both
+   *  the preview and production sites (see src/deploy-environment.ts). */
+  __HOUSTON_DEPLOY_ENV__?: "production" | "preview" | "development";
   /** Hosted-session refresher: mints a fresh Supabase access token on a
    *  gateway 401 so the adapter can replay the request (HOU-687). */
   __HOUSTON_SESSION_REFRESH__?: () => Promise<string | null>;

--- a/packages/web/tests/deploy-environment.test.ts
+++ b/packages/web/tests/deploy-environment.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "vitest";
+import {
+  classifyDeployEnvironment,
+  type DeployEnvironment,
+} from "../src/deploy-environment";
+
+const cases: Array<[string, DeployEnvironment]> = [
+  // Production is the single canonical domain.
+  ["app.gethouston.ai", "production"],
+  ["APP.GETHOUSTON.AI", "production"],
+  // Preview: the vanity domain + Firebase default domains for both sites.
+  ["preview.gethouston.ai", "preview"],
+  ["houston-web.web.app", "preview"],
+  ["houston-web-preview.web.app", "preview"],
+  ["houston-web.firebaseapp.com", "preview"],
+  // Local development.
+  ["localhost", "development"],
+  ["app.localhost", "development"],
+  ["127.0.0.1", "development"],
+  ["::1", "development"],
+  ["[::1]", "development"],
+  // Anything unrecognized must never be mistaken for production.
+  ["some-preview-channel--abc123.web.app", "preview"],
+  ["staging.gethouston.ai", "preview"],
+];
+
+for (const [hostname, expected] of cases) {
+  test(`classifies ${hostname} as ${expected}`, () => {
+    expect(classifyDeployEnvironment(hostname)).toBe(expected);
+  });
+}
+
+test("a lookalike production host is NOT production", () => {
+  // Guards against a naive `includes("app.gethouston.ai")` regression.
+  expect(classifyDeployEnvironment("app.gethouston.ai.evil.com")).toBe(
+    "preview",
+  );
+  expect(classifyDeployEnvironment("notapp.gethouston.ai")).toBe("preview");
+});


### PR DESCRIPTION
## What

Ships the hosted web client (`packages/web`) deploy pipeline on Firebase Hosting, with a preview → production promotion model.

**One bundle, promoted byte-for-byte.** `build-web` (in `release.yml`, gated to `v*` tags on the canonical repo) builds `packages/web` **once**, attaches it as the `web-dist.tar.gz` release asset, uploads hidden sourcemaps to Sentry under `houston-app@<version>-web`, and deploys those bytes to the **preview** site (`houston-web-preview`, preview.gethouston.ai). Publishing the release triggers `web-promote.yml`, which downloads the **same** asset and re-deploys the identical bytes to the **production** site (`houston-web`, app.gethouston.ai). No rebuild — production is byte-identical to what was QA'd on preview.

Preview vs production is decided at **runtime** from `window.location.hostname` (`packages/web/src/deploy-environment.ts`), not baked at build time, so one artifact legitimately serves both. `main.tsx` publishes the result on `window.__HOUSTON_DEPLOY_ENV__`; the shared Sentry + PostHog init read it to tag their `environment`, and a web-only `PreviewBadge` renders a "Preview" pill only on preview.

## Post-GCIP modernization (this revision)

Rebased onto current `main` (after the GCP Identity Platform auth migration #846). The `build-web` job's baked env was retargeted to the current hosted-web contract:

- **Added** the `FIREBASE_API_KEY` / `FIREBASE_AUTH_DOMAIN` / `FIREBASE_PROJECT_ID` trio — the web bundle now authenticates with firebase-js-sdk's popup (GCIP), and `FIREBASE_API_KEY` has no build-time default, so it is load-bearing.
- **Removed** `SUPABASE_URL` / `SUPABASE_ANON_KEY` — no longer read by `packages/web/vite.config.ts`.
- **Kept** `VITE_CONTROL_PLANE_URL ← HOSTED_ENGINE_URL` (still the gateway var `main.tsx` reads), plus `POSTHOG_*` / `SENTRY_DSN`.
- **Deliberately excluded** `GOOGLE_DESKTOP_*` / `MICROSOFT_DESKTOP_CLIENT_ID` — the desktop loopback/PKCE OAuth flow never runs in a browser tab; `vite.config.ts` defaults them to `""`.

All secrets are pre-existing (reused from the desktop jobs); no new repo secrets. The one infra prerequisite is the GCP-side WIF binding for `github-deploy-web@` (Firebase Hosting Admin).

## Config coexistence

`packages/web/firebase.json` (targets `production`→`houston-web`, `preview`→`houston-web-preview`; `public: dist`) is separate from the marketing site's `website/firebase.json` (single `gethouston-site`, `public: _site`). Different directories, sites, and public dirs; each workflow runs `firebase-tools` with the correct `working-directory`, so they cannot cross-fire.

## Auth / deploy

Keyless Workload Identity Federation (same provider as `engine-pod-image.yml`), service account `github-deploy-web@gethouston.iam.gserviceaccount.com`. `firebase-tools` is pinned to major `15` in both jobs.

## Test plan

- `pnpm install`; `pnpm -r typecheck` — clean.
- `pnpm --filter houston-web test` — 184 passing, incl. 14 `deploy-environment` classification tests.
- `pnpm --filter houston-web build` with representative hosted env — succeeds (dist + hidden sourcemaps).
- Biome clean on all touched files (`firebase.json` included).
- Both workflow YAMLs parse; `release.yml` jobs = prep, build-macos, build-windows, build-linux, build-web, finalize.

## CI expectations

Standard PR CI (typecheck, biome, web unit/e2e) should pass. `build-web` / `web-promote` only run on `v*` release tags, not on PRs, so they won't execute here — first real exercise is the next `v*` release (requires the GCP WIF binding to be in place).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
