### PR TITLE
fix(sdk): settle a turn that completed before its subscription's first sync

### DIFF
--- a/packages/fake-host/src/chat-turn.ts
+++ b/packages/fake-host/src/chat-turn.ts
@@ -112,7 +112,7 @@ export function finishTurn(
     turnId,
     ...(pendingInteraction ? { pendingInteraction } : {}),
   });
-  state.appendAssistantMessage(agentId, cid, reply, turnId);
+  state.appendAssistantMessage(agentId, cid, reply, turnId, pendingInteraction);
   ch.pending = null;
 }
 

--- a/packages/fake-host/src/state-history.ts
+++ b/packages/fake-host/src/state-history.ts
@@ -30,12 +30,19 @@ export function appendUserMessage(
   state.histories.set(key, list);
 }
 
-/** Persist the assistant reply at turn END, stamped with the same turn id. */
+/**
+ * Persist the assistant reply at turn END, stamped with the same turn id.
+ * A turn that ended asking the user persists its interaction ON the reply,
+ * matching the real runtime (`exec-turn.ts` clean path) — so a client that
+ * settles from history (the terminal frame lost, or the turn completed before
+ * its subscription attached) recovers the needs_you split, not a false done.
+ */
 export function appendAssistantMessage(
   agentId: string,
   conversationId: string,
   replyText: string,
   turnId: string,
+  pendingInteraction: ChatMessage["pendingInteraction"] | null = null,
 ): void {
   const key = `${agentId}:${conversationId}`;
   const list = state.histories.get(key) ?? [];
@@ -45,6 +52,7 @@ export function appendAssistantMessage(
     ts: EPOCH,
     usage: SEED_USAGE,
     turnId,
+    ...(pendingInteraction ? { pendingInteraction } : {}),
   });
   state.histories.set(key, list);
 }

--- a/packages/sdk/src/modules/turns/settle-from-history.ts
+++ b/packages/sdk/src/modules/turns/settle-from-history.ts
@@ -90,6 +90,67 @@ function adoptReply(s: TurnState, reply: ChatMessage): void {
 }
 
 /**
+ * The PRE-SETTLED poll's settle source: a turn that finished BEFORE our
+ * subscription's first sync (no frames ever replayed, only a fresh idle sync).
+ * Unlike {@link settleFromHistory} — which is entered on a CONFIRMED
+ * lost-terminal (a boundary / resync) and therefore falls through to
+ * `finishErr(TURN_DIED)` when it finds no reply — this settle is SPECULATIVE:
+ * a fresh idle sync in turn mode is ALSO the normal "turn we're about to
+ * trigger" shape, so a turn that simply hasn't produced its reply yet must NOT
+ * be errored. It settles ONLY on conclusive proof the turn is over — a reply
+ * for our exact `turnId`, or (legacy, no ids) a trailing assistant message the
+ * `guard` accepts as ours — and returns `true` iff it did. Inconclusive (a
+ * trailing USER message, a guard reject, a failed reload, or live evidence that
+ * arrived mid-reload) returns `false` and settles nothing: the poll re-arms and
+ * the stream stays the authority.
+ */
+export async function presettleFromHistory(
+  s: TurnState,
+  reloadHistory: () => Promise<ChatMessage[]>,
+  turnId: string | undefined,
+  guard: (messages: ChatMessage[]) => boolean,
+  hasEvidence: () => boolean,
+): Promise<boolean> {
+  let messages: ChatMessage[];
+  try {
+    messages = await reloadHistory();
+  } catch {
+    // A speculative background reload — swallow and re-arm, never surface noise
+    // on every poll tick. A genuinely lost stream is owned by the reconnect
+    // budget, which settles the turn on its own.
+    return false;
+  }
+  // Live evidence landed while we were reloading, or another path already
+  // settled: the stream now owns the turn — never settle from a stale poll.
+  if (s.settled || hasEvidence()) return false;
+  const reply = conclusiveReply(messages, turnId, guard);
+  if (!reply) return false;
+  adoptReply(s, reply);
+  return true;
+}
+
+/**
+ * The one message that PROVES the turn is over, or null (inconclusive). With a
+ * turnId it must be the reply persisted FOR THIS TURN; without one (legacy) the
+ * trailing message must be an assistant reply the `guard` accepts as ours.
+ */
+function conclusiveReply(
+  messages: ChatMessage[],
+  turnId: string | undefined,
+  guard: (messages: ChatMessage[]) => boolean,
+): ChatMessage | null {
+  if (turnId) {
+    return (
+      messages.find((m) => m.role === "assistant" && m.turnId === turnId) ??
+      null
+    );
+  }
+  const last = messages[messages.length - 1];
+  if (last?.role === "assistant" && guard(messages)) return last;
+  return null;
+}
+
+/**
  * Refetch history and settle from it (`settleFromHistory`), then stop the
  * subscription. A failed reload surfaces as a system message (no silent
  * fallback) and the settle proceeds from the streamed accumulation — the UI

--- a/packages/sdk/src/modules/turns/stream-registry.ts
+++ b/packages/sdk/src/modules/turns/stream-registry.ts
@@ -11,6 +11,14 @@ export interface StreamTuning {
    * running sync) and the turn proceeds as if the send had succeeded.
    */
   sendVerdictMs?: number;
+  /**
+   * Grace before the PRE-SETTLED poll fires (see {@link PRESETTLED_POLL_MS}).
+   * A turn that completes BEFORE our subscription's first sync leaves us with a
+   * fresh idle sync and no frames ever replayed; after this grace with still no
+   * stream evidence, the sink reloads history and settles ONLY on conclusive
+   * proof the turn finished. Tests shrink it to fire quickly.
+   */
+  presettledPollMs?: number;
 }
 
 /**
@@ -43,6 +51,20 @@ export const SEND_IN_FLIGHT_MESSAGE = "A message is already being sent.";
  * send doesn't leave the user staring at a spinner.
  */
 export const SEND_VERDICT_MS = 15_000;
+/**
+ * How long the sink waits, after a FRESH idle sync in turn mode with the send
+ * accepted, before it suspects the turn completed BEFORE the subscription's
+ * first sync (the fake host's ~45ms canned reply, or a real instant error /
+ * cancel) — a window in which the user echo, frames and terminal were all
+ * emitted before we attached and are never replayed, so the stream carries no
+ * evidence and the card would hang on "running" forever (0407aaa0). On fire the
+ * sink reloads history and settles ONLY on conclusive proof the turn finished;
+ * inconclusive (a healthy slow turn whose reply hasn't persisted) re-arms the
+ * poll, and any stream evidence cancels it. Long enough that a turn that simply
+ * hasn't started yet isn't polled needlessly, short enough that a genuinely
+ * pre-settled turn leaves the spinner quickly.
+ */
+export const PRESETTLED_POLL_MS = 1_500;
 /**
  * Copy for a send that provably never landed: the send fetch failed at the
  * transport level AND no evidence of the turn arrived within the verdict

--- a/packages/sdk/src/modules/turns/turn-sink-options.ts
+++ b/packages/sdk/src/modules/turns/turn-sink-options.ts
@@ -29,6 +29,13 @@ export interface TurnSinkOptions {
   /** Refetch persisted history (the resync settle source). */
   reloadHistory: () => Promise<ChatMessage[]>;
   /**
+   * Turn mode only: the grace before the pre-settled poll fires (a turn that
+   * finished before our first sync, so no frames ever replayed — see
+   * `PRESETTLED_POLL_MS`). Absent disables the poll (observer mode never arms
+   * it): the sink then relies solely on frames and the reconnect budget.
+   */
+  presettledPollMs?: number;
+  /**
    * LEGACY-only guard for settle-from-history (servers/histories without turn
    * ids): whether the trailing assistant message really is THE settling turn's
    * reply. Turn mode matches the prompt (weak against two identical prompts in

--- a/packages/sdk/src/modules/turns/turn-sink.ts
+++ b/packages/sdk/src/modules/turns/turn-sink.ts
@@ -1,6 +1,6 @@
 import type { PendingInteraction, WireFrame } from "@houston/runtime-client";
 import type { TerminalBoardStatus } from "./feed-output";
-import { reloadAndSettle } from "./settle-from-history";
+import { presettleFromHistory, reloadAndSettle } from "./settle-from-history";
 import { applyTurnFrame } from "./turn-frames";
 import { classifyFrame, classifyRunningSync } from "./turn-identity";
 import { finishErr, newTurnState, push, type TurnState } from "./turn-settle";
@@ -41,6 +41,10 @@ export class TurnSink {
   private settling = false;
   /** Turn mode: the send was accepted — gates resync turn-id adoption. */
   private accepted = false;
+  /** Turn mode: a FRESH idle sync was seen — half the pre-settled poll trigger. */
+  private sawFreshIdleSync = false;
+  /** The pre-settled poll timer, live only while armed (see `maybeArmPresettlePoll`). */
+  private presettleTimer: ReturnType<typeof setTimeout> | undefined;
 
   constructor(private readonly o: TurnSinkOptions) {
     this.s = newTurnState(o.agentPath, o.sessionKey, o.output, {
@@ -69,6 +73,9 @@ export class TurnSink {
     // The engine acknowledged the send — the message reached it, so the
     // optimistic bubble is delivered even if the turn later errors.
     this.s.delivered = true;
+    // The send landed while the stream already showed a fresh idle sync: the
+    // turn may have completed before we attached — arm the pre-settled poll.
+    this.maybeArmPresettlePoll();
   }
   /**
    * Turn mode: the send failed at the TRANSPORT level, so the engine may have
@@ -78,6 +85,10 @@ export class TurnSink {
    */
   sendMaybeAccepted(): void {
     this.accepted = true;
+    // If the engine did accept it and the turn already finished, the pre-settled
+    // poll can settle it conclusively — faster than the ambiguous-send verdict
+    // window failing it as lost.
+    this.maybeArmPresettlePoll();
   }
   /** The send failed / stream broke before a terminal frame: settle as error. */
   fail(msg: string): void {
@@ -118,6 +129,7 @@ export class TurnSink {
     if (ev.type !== "done" && ev.type !== "error") {
       this.sawRunning = true;
       this.s.delivered = true; // a real frame proves the turn started
+      this.cancelPresettlePoll(); // stream evidence: the poll's job is done
     }
     applyTurnFrame(this.s, ev, this.o.stop);
   }
@@ -131,6 +143,7 @@ export class TurnSink {
       this.accepted = true;
       this.sawRunning = true;
       this.s.delivered = true; // the engine echoed our send — it landed
+      this.cancelPresettlePoll(); // the turn is demonstrably live on the stream
       return;
     }
     if (classifyFrame(this.turnId, ev.turnId) === "boundary") {
@@ -158,8 +171,17 @@ export class TurnSink {
     }
     if (!reconnect) {
       // Fresh-connect sync of an idle conversation: a turn we're about to
-      // trigger (turn mode — ignore) or nothing to watch (observer — close).
-      if (this.o.mode === "observer") this.o.stop();
+      // trigger (turn mode — ignore for an immediate settle) or nothing to
+      // watch (observer — close). In turn mode this same shape ALSO covers a
+      // turn that finished before we attached (frames never replayed): remember
+      // we saw it and arm the pre-settled poll, which settles conclusively from
+      // history if no stream evidence follows.
+      if (this.o.mode === "observer") {
+        this.o.stop();
+      } else {
+        this.sawFreshIdleSync = true;
+        this.maybeArmPresettlePoll();
+      }
     } else if (this.o.mode === "turn" || this.sawRunning) {
       // The turn ended while we were disconnected; persisted history is
       // complete once a turn ends — settle from it, not from partial text.
@@ -263,10 +285,12 @@ export class TurnSink {
     }
     this.sawRunning = true;
     this.s.delivered = true; // a running sync proves the turn is live on the engine
+    this.cancelPresettlePoll(); // a running turn on the stream: the poll is moot
   }
 
   private settleFromHistorySoon(): void {
     if (this.settling || this.s.settled) return;
+    this.cancelPresettlePoll(); // a confirmed-lost-terminal settle supersedes the poll
     this.settling = true;
     void reloadAndSettle(
       this.s,
@@ -275,5 +299,62 @@ export class TurnSink {
       this.o.historyGuard,
       this.o.stop,
     );
+  }
+
+  /**
+   * Arm the pre-settled poll when BOTH triggers hold — a fresh idle sync was
+   * seen AND the send is accepted — and no evidence/settle already closed the
+   * question. Idempotent: a second call while armed is a no-op. Absent
+   * `presettledPollMs` (observer mode) disables the poll entirely.
+   */
+  private maybeArmPresettlePoll(): void {
+    if (this.o.presettledPollMs === undefined) return;
+    if (!this.accepted || !this.sawFreshIdleSync) return;
+    if (this.sawRunning || this.settling || this.s.settled) return;
+    if (this.presettleTimer !== undefined) return;
+    this.presettleTimer = setTimeout(() => {
+      this.presettleTimer = undefined;
+      void this.pollForPresettled();
+    }, this.o.presettledPollMs);
+  }
+
+  private cancelPresettlePoll(): void {
+    if (this.presettleTimer !== undefined) {
+      clearTimeout(this.presettleTimer);
+      this.presettleTimer = undefined;
+    }
+  }
+
+  /**
+   * Reload history and settle ONLY on conclusive proof the turn finished (a
+   * reply for our turnId, or a legacy trailing reply the guard accepts). This
+   * is the sole caller of the CONCLUSIVE-ONLY {@link presettleFromHistory} —
+   * never the fall-through `settleFromHistory`, whose no-reply branch would
+   * WRONGLY error a healthy slow turn (its history ends on our trailing user
+   * message). Inconclusive re-arms the poll; any stream evidence in the interim
+   * cancels it, and the reconnect budget still owns a genuinely lost stream.
+   */
+  private async pollForPresettled(): Promise<void> {
+    if (this.settling || this.s.settled || this.sawRunning) return;
+    const settled = await presettleFromHistory(
+      this.s,
+      this.o.reloadHistory,
+      this.turnId,
+      this.o.historyGuard,
+      () => this.sawRunning,
+    );
+    if (settled) {
+      this.settling = true;
+      this.o.stop();
+      return;
+    }
+    // Inconclusive: the turn hasn't proven it finished. Re-arm and keep the
+    // stream as the authority (frames cancel the poll; the budget owns loss).
+    this.maybeArmPresettlePoll();
+  }
+
+  /** Teardown: clear the poll timer so an aborted stream leaves nothing pending. */
+  dispose(): void {
+    this.cancelPresettlePoll();
   }
 }

--- a/packages/sdk/src/modules/turns/turn-stream.test.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.test.ts
@@ -15,6 +15,7 @@ import {
   STREAM_LOST_MESSAGE,
   StreamRegistry,
 } from "./stream-registry";
+import { TurnSink } from "./turn-sink";
 import {
   observeConversation,
   type StreamTuning,
@@ -49,6 +50,8 @@ function fakeEngine(
   const sendOpts: Array<Record<string, unknown> | undefined> = [];
   /** The `text` (real model prompt) each sendMessage carried. */
   const texts: string[] = [];
+  /** How many times history was refetched (the pre-settled poll's reload). */
+  const historyCalls = { n: 0 };
   const engine = {
     async streamEvents(_id: string, streamOpts: EventStreamOptions) {
       const h = handlers[Math.min(afters.length, handlers.length - 1)];
@@ -66,10 +69,11 @@ function fakeEngine(
       if (opts.sendError !== undefined) throw opts.sendError;
     },
     async getHistory() {
+      historyCalls.n++;
       return { id: "c", title: "", messages: history };
     },
   } as unknown as HoustonEngineClient;
-  return { engine, afters, nonces, sendOpts, texts };
+  return { engine, afters, nonces, sendOpts, texts, historyCalls };
 }
 
 // Each test drives its own instance registry (no package global); a test that
@@ -1514,4 +1518,180 @@ test("a definitive send rejection (the engine answered) still fails the turn imm
     data: "A turn is already running",
     fails_pending: true,
   });
+});
+
+// ── Pre-settled turn poll (0407aaa0) ─────────────────────────────────────────
+// A turn that COMPLETES before our subscription's first sync leaves a fresh
+// idle sync and no frames ever replayed — the sink used to ignore it as "a turn
+// we're about to trigger" and hang forever. The conclusive-only history poll
+// settles it, without ever erroring a healthy slow turn.
+
+test("a turn that finished before the first sync settles from history via the poll — no hang, no TURN_DIED", async () => {
+  // The turn's frames were emitted before we attached and are never replayed;
+  // the stream only carries a FRESH idle sync, then goes quiet. History holds
+  // the finished reply.
+  const history: ChatMessage[] = [
+    { role: "user", content: "hi", ts: 1 },
+    { role: "assistant", content: "Hello from history", ts: 2 },
+  ];
+  const { engine } = fakeEngine(
+    [
+      (o) => {
+        o.onEvent(sync(false, "", 0));
+        return hang(o); // no user echo, no frames, no running sync ever arrive
+      },
+    ],
+    history,
+  );
+  const { items, sessionStatuses, board, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-presettled",
+    "hi",
+    output,
+    registry,
+    { tuning: { ...fast, presettledPollMs: 20 } },
+  );
+
+  // Settled conclusively from the persisted reply — never hung, never errored.
+  const texts = items.filter((i) => i.feed_type === "assistant_text");
+  expect(texts).toEqual([
+    { feed_type: "assistant_text", data: "Hello from history" },
+  ]);
+  expect(finals(items)).toHaveLength(1);
+  expect(items).not.toContainEqual({
+    feed_type: "system_message",
+    data: TURN_DIED_MESSAGE,
+  });
+  expect(sessionStatuses).toEqual(["running", "completed"]);
+  // The board leaves "running" — the card no longer eats Escape.
+  expect(board).toEqual(["running", "done"]);
+});
+
+test("a pre-settled ask_user turn recovers its persisted interaction: needs_you, not a false done", async () => {
+  // The mid-interview shape under the race: the turn ended asking the user and
+  // completed before we attached. The runtime persists the interaction ON the
+  // reply, so the poll's history settle must split to needs_you and carry it.
+  const interaction: PendingInteraction = {
+    steps: [
+      {
+        kind: "question",
+        id: "q1",
+        question: "What should the routine do?",
+        options: [{ id: "email", label: "Check my email" }],
+      },
+    ],
+  };
+  const history: ChatMessage[] = [
+    { role: "user", content: "hi", ts: 1 },
+    {
+      role: "assistant",
+      content: "Pick one:",
+      ts: 2,
+      pendingInteraction: interaction,
+    },
+  ];
+  const { engine } = fakeEngine(
+    [
+      (o) => {
+        o.onEvent(sync(false, "", 0));
+        return hang(o);
+      },
+    ],
+    history,
+  );
+  const { board, boardInteractions, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-presettled-ask",
+    "hi",
+    output,
+    registry,
+    { tuning: { ...fast, presettledPollMs: 20 } },
+  );
+
+  expect(board).toEqual(["running", "needs_you"]);
+  expect(boardInteractions).toEqual([null, interaction]);
+});
+
+test("the poll does NOT settle a healthy slow turn (trailing user in history), then frames settle it and cancel the poll", async () => {
+  // History ends on OUR user message the whole time the turn is slow: the reply
+  // hasn't persisted yet. Every poll reload is therefore INCONCLUSIVE — the poll
+  // must re-arm and settle nothing — until the live frames arrive.
+  const history: ChatMessage[] = [{ role: "user", content: "hi", ts: 1 }];
+  const { engine, historyCalls } = fakeEngine(
+    [
+      (o) =>
+        new Promise<void>((resolve) => {
+          o.onEvent(sync(false, "", 0)); // fresh idle sync → arms the poll
+          // The turn is genuinely slow: its frames land well after a poll tick.
+          setTimeout(() => {
+            o.onEvent({ type: "text", data: "slow reply", seq: 1 });
+            o.onEvent({ type: "done", data: null, seq: 2 });
+            resolve();
+          }, 90);
+        }),
+    ],
+    history,
+  );
+  const { items, sessionStatuses, board, output } = makeOutput();
+
+  await streamTurn(
+    engine,
+    "Houston/Bo",
+    "activity-slow-turn",
+    "hi",
+    output,
+    registry,
+    { tuning: { ...fast, presettledPollMs: 25 } },
+  );
+
+  // The poll fired at least once (reloaded history) but found it inconclusive —
+  // it never surfaced a premature error against the still-running turn.
+  expect(historyCalls.n).toBeGreaterThanOrEqual(1);
+  expect(sessionStatuses).not.toContain("error");
+  expect(items).not.toContainEqual({
+    feed_type: "system_message",
+    data: TURN_DIED_MESSAGE,
+  });
+  // The live frames settled it normally; the poll was cancelled by the evidence.
+  const texts = items.filter((i) => i.feed_type === "assistant_text");
+  expect(texts).toEqual([{ feed_type: "assistant_text", data: "slow reply" }]);
+  expect(sessionStatuses).toEqual(["running", "completed"]);
+  expect(board).toEqual(["running", "done"]);
+});
+
+test("dispose clears an armed pre-settled poll — teardown leaves nothing pending", async () => {
+  const { output } = makeOutput();
+  let historyCalls = 0;
+  const sink = new TurnSink({
+    agentPath: "Houston/Bo",
+    sessionKey: "activity-teardown",
+    output,
+    mode: "turn",
+    nonce: "n",
+    prompt: "hi",
+    stop: () => {},
+    reloadHistory: async () => {
+      historyCalls++;
+      return [];
+    },
+    historyGuard: () => false,
+    presettledPollMs: 20,
+  });
+
+  // Arm the poll: send accepted + a fresh idle sync are its two triggers.
+  sink.sendAccepted();
+  sink.onFrame(sync(false, "", 0));
+  // Tear down BEFORE the 20ms timer would fire.
+  sink.dispose();
+  await new Promise((r) => setTimeout(r, 60));
+
+  // The timer was cleared: history was never reloaded, nothing settled.
+  expect(historyCalls).toBe(0);
+  expect(sink.settled).toBe(false);
 });

--- a/packages/sdk/src/modules/turns/turn-stream.ts
+++ b/packages/sdk/src/modules/turns/turn-stream.ts
@@ -4,6 +4,7 @@ import type { FeedOutput } from "./feed-output";
 import { randomNonce } from "./random-nonce";
 import {
   type ActiveStream,
+  PRESETTLED_POLL_MS,
   SEND_IN_FLIGHT_MESSAGE,
   SEND_LOST_MESSAGE,
   SEND_VERDICT_MS,
@@ -220,6 +221,9 @@ export async function streamTurn(
     // against two identical prompts in a row; turnId matching replaces it.
     historyGuard: (messages) =>
       messages.filter((m) => m.role === "user").at(-1)?.content === prompt,
+    // The grace before the pre-settled poll fires — a turn that finished before
+    // our first sync (its frames never replayed) hangs the card without it.
+    presettledPollMs: opts.tuning?.presettledPollMs ?? PRESETTLED_POLL_MS,
   });
   if (sent) sink.sendAccepted();
 
@@ -276,6 +280,7 @@ export async function streamTurn(
     if (!sink.settled) sink.fail(turnErrorMessage(e));
   } finally {
     if (sendVerdict !== undefined) clearTimeout(sendVerdict);
+    sink.dispose(); // clear any armed pre-settled poll — the stream is done
     ac.abort();
     registry.release(key, entry);
   }


### PR DESCRIPTION
## The race

In turn mode the client subscribes to the conversation stream and POSTs the send. When the turn **completes before the subscription's first sync** (a near-instant reply, an instant error/cancel — and deterministically the e2e fake host's ~45ms canned replies), that first sync arrives idle and fresh, which `TurnSink` deliberately ignores ("a turn we're about to trigger"). The terminal frames were emitted before the subscription attached and are never replayed — so the sink never settles: the board card hangs on "running" and the reply never renders.

This is the race #844 trace-diagnosed and deferred ("a shared turn-settle contract change, out of scope for a deflake"). It has since kept failing main's CI as a flake under `--fail-on-flaky-tests` (run 29169675507, `routine-setup-chat.spec.ts:133`), and it can hit real users as a stuck mission card.

## The fix — a conclusive-only history poll

When the send is accepted, a fresh idle sync was observed, and no stream evidence arrives for `presettledPollMs` (new additive `StreamTuning` knob, default 1.5s; unset in observer mode = disabled), the sink reloads history and settles **only on conclusive proof** the turn finished: a persisted reply for our exact `turnId`, or — legacy servers without ids — the trailing assistant reply accepted by the existing `historyGuard`. Conclusive settles reuse the existing `adoptReply` semantics (provider-error card, usage, `pendingInteraction` → `needs_you`).

Anything inconclusive settles **nothing** and re-arms: a blind timer into the existing `settleFromHistory` was rejected because its no-reply branch errors the turn (`TURN_DIED`) — fired speculatively it would kill every healthy slow turn, whose history ends on the trailing *user* message mid-turn. Any stream evidence (nonce echo, frame, running sync) cancels the poll permanently; teardown clears it; the reconnect budget still owns genuinely lost streams.

Also: a fake-host fidelity fix this surfaced — the real runtime persists `pendingInteraction` on the assistant reply; the fake host didn't, so an ask_user turn hit by the race would have history-settled to a false `done`, silently dropping the interview card.

## Verification

- 4 new SDK unit tests: the race settles from history (no hang, no TURN_DIED); a pre-settled ask_user turn recovers its interaction as `needs_you`; a healthy slow turn is NOT settled by the poll and settles normally from frames; dispose clears an armed poll.
- Suites: SDK 344, fake-host 9, app 1413, full Playwright **96/96 with `--fail-on-flaky-tests`**, Biome + all workspace typechecks clean.
- Deflake bar: `e2e/routine-setup-chat.spec.ts --repeat-each=40 --workers=1` — the previously-flaky `:133` passed **199/200** repeats across runs; every residual failure was trace-diagnosed with the new code path provably inactive (a distinct pre-existing panel-hydration bug at ~0.17%, being filed separately, plus environment stalls with zero conversation traffic).

## Contract notes

`presettledPollMs` is additive/optional; observer behavior unchanged; the legacy guard's known weakness (two identical prompts in a row) is inherited, not new — turnId matching supersedes it wherever ids exist.