### PR TITLE
design(website): softer device shadows + keep Cloudflare fresh until DNS flip

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -86,3 +86,15 @@ jobs:
           --project gethouston
           --non-interactive
           --message "${{ github.sha }}"
+
+      # TEMPORARY dual-deploy: gethouston.ai's apex/www DNS still points at
+      # Cloudflare Pages, so until the DNS flip (cutover step 4 in the header)
+      # Cloudflare must keep receiving deploys or the live site goes stale.
+      # DELETE this step when the DNS flip lands.
+      - name: Deploy to Cloudflare Pages (until DNS flip)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: website
+          command: pages deploy _site --project-name=houston-site --branch=main

--- a/website/src/index.html
+++ b/website/src/index.html
@@ -542,8 +542,8 @@ visionPath: "vision/index.html"
   .device-macbook-pro-2018.device-spacegray .device-frame {
     box-shadow:
       inset 0 0 0 2px #767a7d,
-      0 70px 130px -40px rgba(0,0,0,0.75),
-      0 24px 55px -24px rgba(0,0,0,0.6);
+      0 40px 80px -32px rgba(0,0,0,0.45),
+      0 16px 36px -20px rgba(0,0,0,0.35);
   }
   .device-macbook-pro-2018 .device-frame::after {
     width: 1196px;
@@ -783,8 +783,8 @@ visionPath: "vision/index.html"
     box-shadow:
       0 2px 2px rgba(255,255,255,0.4) inset,
       0 0 0 1.5px rgba(0,0,0,0.5),
-      0 42px 80px -26px rgba(0,0,0,0.78),
-      0 10px 26px -14px rgba(0,0,0,0.6);
+      0 24px 48px -20px rgba(0,0,0,0.45),
+      0 7px 18px -10px rgba(0,0,0,0.35);
   }
 
   /* Thin dark rim between the titanium band and the glass. */


### PR DESCRIPTION
## Summary
- MacBook + iPhone frame shadows softened (peak alpha 0.75/0.78 → 0.45, tighter spread); ring insets untouched
- Restores a TEMPORARY Cloudflare Pages deploy step: since #848 the workflow deploys Firebase-only, but apex/www DNS still points at Cloudflare — the live site was going update-stale. Marked for deletion at the DNS flip.

## Test plan
- [x] Eleventy build green; zero console errors; both frames screenshot-verified at 1440px
- [x] Workflow YAML parses; wrangler step identical to the pre-#848 one (same secrets, still present in repo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)