### PR TITLE
fix(ci): dual-deploy the website until the Cloudflare DNS flip

### DIFF
--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -86,3 +86,15 @@ jobs:
           --project gethouston
           --non-interactive
           --message "${{ github.sha }}"
+
+      # TEMPORARY dual-deploy: gethouston.ai's apex/www DNS still points at
+      # Cloudflare Pages, so until the DNS flip (cutover step 4 in the header)
+      # Cloudflare must keep receiving deploys or the live site goes stale.
+      # DELETE this step when the DNS flip lands.
+      - name: Deploy to Cloudflare Pages (until DNS flip)
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          workingDirectory: website
+          command: pages deploy _site --project-name=houston-site --branch=main


### PR DESCRIPTION
## Summary
Since the Firebase Hosting cutover (#848) the website deploy job publishes to Firebase only, but gethouston.ai's apex/www DNS still points at Cloudflare Pages — so the LIVE site stopped receiving updates. Re-adds the wrangler deploy step (identical to pre-#848, secrets still present), clearly marked TEMPORARY for deletion at the DNS flip.

## Test plan
- [x] Workflow YAML parses; step is byte-equivalent to the removed pre-#848 one
- [ ] Post-merge: deploy run publishes to BOTH hosts; verify gethouston.ai picks up the next website change

🤖 Generated with [Claude Code](https://claude.com/claude-code)