### PR TITLE
chore(release): bump version to 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.5.0"
+version = "0.5.3"
 dependencies = [
  "bytes",
  "chrono",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.5.0"
+version = "0.5.3"
 edition = "2021"
 
 [lib]


### PR DESCRIPTION
Tag/manifest version alignment for the v0.5.3 release (first GCIP release: desktop + web preview). 🤖 Generated with [Claude Code](https://claude.com/claude-code)