### PR TITLE
perf(website): stop continuous re-blur — landing runs smooth on Gecko

### DIFF
--- a/website/PERFORMANCE.md
+++ b/website/PERFORMANCE.md
@@ -1,0 +1,63 @@
+# Landing performance constraints
+
+The landing (`src/index.html` + `src/assets/space.*`) renders a full-page space
+photo behind many dark-glass panels. Two hard rules keep it smooth, learned from
+a real regression: the live page was unusable in **Zen (Gecko/Firefox)** —
+~40 fps idle, ~24 fps on scroll, heavy jank — while Chromium and WebKit looked
+fine. Prior verification only tested Chromium + WebKit and missed it.
+
+## Rule 1 — no continuous/idle animation on the full-page background
+
+A time-based ambient drift on the photo + a star twinkle used to run forever
+(even at rest). On Gecko, animating a full-viewport `position: fixed` layer every
+frame re-composites the whole layer, and doing it **under** the backdrop-blurred
+glass panels forced a full-page re-blur every frame. Measured idle: **~46 fps
+(Gecko) with the ambient on → ~120 fps with it off.** Blink/WebKit hid the cost.
+
+Background motion must be **scroll-driven only** (it changes only while
+scrolling), never a looping keyframe animation.
+
+## Rule 2 — no `backdrop-filter` over a moving background
+
+`backdrop-filter: blur()` on a panel is cheap only while the pixels behind it are
+static. As soon as the panel moves relative to its backdrop (scroll) **or** the
+backdrop moves under it (parallax/ambient), Gecko re-rasterizes the blur every
+frame. With the many glass panels on this page that capped scroll at ~30 fps.
+
+The glass panels therefore carry **no `backdrop-filter`** — they use near-opaque
+dark fills (`--glass` / `--glass-strong` ≈ 0.92–0.95 alpha) instead. Over the
+dark scrimmed photo the frosted look is visually identical (verified with
+before/after screenshots, desktop + mobile). The only kept blur is the transient
+`.dl-overlay` modal, which sits over a now-static background.
+
+## Gecko can't pan a full-bleed layer at 60 fps
+
+Even with ambient + blur removed, transforming the full-viewport photo/star
+layers per scroll frame stays ~35 fps on Gecko — on **both** the CSS
+`animation-timeline: scroll()` path and the rAF fallback, and regardless of image
+size. It's the compositing of a full-bleed fixed layer, not the driver.
+
+So the scroll parallax is **gated off on Gecko** (`space-scroll.js` adds
+`.space-no-parallax` when `CSS.supports("-moz-appearance","none")`): the
+background is static there (still the full photo + stars, just not panning).
+Blink + modern WebKit keep the parallax on the compositor cheaply, so they keep
+it. `prefers-reduced-motion` freezes everything on every engine.
+
+## Test matrix — Gecko is mandatory
+
+Any change to `space.css`, `space-scroll.js`, `micro-interactions.js`, or the
+glass panels MUST be measured on **Firefox/Gecko**, not just Chromium + WebKit.
+Playwright has all three; install Firefox once with
+`npx playwright install firefox`. Measure (a) idle frame cost over ~5 s untouched
+and (b) fps during a scripted 3 s smooth scroll, via in-page `requestAnimationFrame`
+timestamp deltas (the only signal that works identically across engines). Target:
+zero jank frames (> 25 ms) idle, ~60 fps sustained on scroll, on all three.
+
+## Result of the fix (headless Playwright, 1440×900, in-page rAF deltas)
+
+| Engine (idle → scroll fps) | Before | After |
+| --- | --- | --- |
+| Firefox / Gecko | 40 → 27 (94 idle jank frames) | 120 → 118 (0 jank) |
+| Chromium | (8% busy) → 67 | (8% busy) → 120 (0 jank) |
+| Chromium, 4× CPU throttle | → 60 (19 jank) | → 119 (0 jank) |
+| WebKit | 60 → 60 | 60 → 60 |

--- a/website/src/assets/space-scroll.js
+++ b/website/src/assets/space-scroll.js
@@ -1,39 +1,40 @@
 /*
- * Space background motion controller.
+ * Space background scroll controller.
  *
- * Two jobs:
- *   1. Pause the ambient CSS motion (photo drift + star twinkle, see space.css)
- *      while the tab is hidden, by toggling `.space-idle` on <html>. Runs on
- *      EVERY engine — the ambient animations are plain time-based CSS.
- *   2. Drive the scroll-driven pan as a rAF fallback where CSS scroll-driven
- *      animations (animation-timeline: scroll(), the primary path in space.css)
- *      are unsupported (older/most WebKit), setting the exact same transforms
- *      the CSS @keyframes would. transform-only, so it stays on the compositor
- *      with no layout or paint.
+ * The background pans only while scrolling (no continuous/ambient motion — see
+ * space.css). This file has two jobs, both progressive enhancement:
  *
- * No-ops entirely under prefers-reduced-motion (static background, per the
- * design — nothing to pause, nothing to pan).
+ *   1. Opt Gecko (Firefox/Zen) out of the pan entirely. Gecko composites the
+ *      full-viewport fixed layers too slowly to transform them every frame
+ *      (measured ~35fps scroll vs ~118fps static, on BOTH the CSS scroll-timeline
+ *      and rAF paths), and that was the landing's "scrolling is slow" bug. The
+ *      `.space-no-parallax` class (space.css) cancels the pan so the background
+ *      stays static there — still the full photo + stars, just not moving.
+ *
+ *   2. Drive the pan as a rAF fallback on engines that lack CSS scroll-driven
+ *      animations (older WebKit), setting the exact transforms the @keyframes
+ *      would. transform-only, so it stays on the compositor (no layout/paint).
+ *
+ * No-ops under prefers-reduced-motion (static background, per the design).
  */
 (() => {
   var reduce = window.matchMedia?.("(prefers-reduced-motion: reduce)");
   if (reduce?.matches) return;
 
-  // (1) Pause ambient drift/twinkle when the tab is backgrounded — no wasted
-  // compositor work, and motion resumes cleanly on return. Always attached.
   var root = document.documentElement;
-  function syncVisibility() {
-    root.classList.toggle("space-idle", document.hidden);
+  var supports = window.CSS && typeof CSS.supports === "function";
+
+  // (1) Gecko → static background. `-moz-appearance` is Firefox-only among
+  // current engines, so it cleanly identifies Gecko (incl. Zen).
+  if (supports && CSS.supports("-moz-appearance", "none")) {
+    root.classList.add("space-no-parallax");
+    return;
   }
-  document.addEventListener("visibilitychange", syncVisibility);
-  syncVisibility();
 
   // Native scroll timeline available → CSS drives the pan, so we're done.
-  var hasScrollTimeline =
-    window.CSS &&
-    typeof CSS.supports === "function" &&
-    CSS.supports("animation-timeline", "scroll()");
-  if (hasScrollTimeline) return;
+  if (supports && CSS.supports("animation-timeline", "scroll()")) return;
 
+  // (2) rAF fallback (older WebKit): drive the same transforms inline.
   var img = document.querySelector(".space-bg img");
   var stars = document.querySelector(".space-stars");
   if (!img && !stars) return;

--- a/website/src/assets/space.css
+++ b/website/src/assets/space.css
@@ -6,29 +6,28 @@
  * position:fixed layers sit behind the page content (negative z-index, so the
  * normal-flow sections paint on top):
  *
- *   .space-bg     the photo itself (object-fit: cover). Two independent motions
- *                 compose here: a slow AMBIENT drift on the <picture> wrapper
- *                 (time-based, alive even when nobody scrolls) UNDER a
- *                 scroll-driven pan + zoom on the <img> (the galactic band
- *                 travels as you move down the page). NOT
- *                 background-attachment: fixed (broken on iOS); a real fixed
+ *   .space-bg     the photo itself (object-fit: cover), panned + zoomed on the
+ *                 <img> as you scroll (the galactic band travels down the page).
+ *                 NOT background-attachment: fixed (broken on iOS); a real fixed
  *                 element transformed on the compositor instead.
  *   .space-scrim  a readability veil (darker at top/bottom, lighter through the
  *                 middle so the bright band stays visible) — keeps every dark
  *                 glass panel + light body text well above contrast minimums.
  *   .space-stars  one sparse foreground star layer at a FASTER parallax rate,
- *                 for depth. Its star pixels live on ::before/::after and
- *                 TWINKLE (two out-of-phase opacity cycles) independent of the
- *                 pan, so the field shimmers even at rest.
+ *                 for depth. Star pixels live on ::before/::after.
  *
- * Motion is transform/opacity only (zero layout, zero paint, no scroll jank).
- * The scroll pan uses CSS scroll-driven animations (animation-timeline:
- * scroll()) where supported, with a rAF transform fallback
- * (assets/space-scroll.js) where not (WebKit lags here). The ambient drift +
- * twinkle are plain time-based CSS animations (every engine), paused while the
- * tab is hidden via the `.space-idle` class that space-scroll.js toggles.
- * prefers-reduced-motion freezes everything — static photo, no parallax, no
- * drift, no twinkle.
+ * Motion is transform-only, scroll-driven, and happens ONLY while scrolling —
+ * there is no continuous/idle animation. Perf constraint learned the hard way
+ * (see the git history / knowledge-base note): full-viewport fixed layers that
+ * animate every frame are cheap on Blink/WebKit but expensive on Gecko, and any
+ * continuous animation under the backdrop-blurred glass panels forced a per-frame
+ * re-blur. So: (1) no ambient drift/twinkle, (2) the glass panels carry no
+ * backdrop-filter (near-opaque fills instead), (3) the scroll pan runs via CSS
+ * scroll-driven animations (animation-timeline: scroll()) where supported, with
+ * a rAF transform fallback (assets/space-scroll.js) for older WebKit, and is
+ * disabled entirely on Gecko (static background there — it can't pan a full-bleed
+ * layer at 60fps). prefers-reduced-motion freezes everything — static photo,
+ * no parallax.
  */
 
 /* Dark base so nothing ever flashes white while the photo decodes. */
@@ -42,7 +41,6 @@ html {
   position: fixed;
   inset: 0;
   pointer-events: none;
-  will-change: transform;
   contain: strict;
 }
 
@@ -60,12 +58,15 @@ html {
   height: 100%;
   object-fit: cover;
   object-position: center 42%;
-  /* Base scale leaves headroom so the scroll pan + drift never expose an edge. */
+  /* Base scale leaves headroom so the scroll pan never exposes an edge. */
   transform: scale(1.16) translate3d(0, 0, 0);
   transform-origin: center 38%;
 }
 
-.space-bg picture {
+/* Compositing hint reserved ONLY for the element that actually moves on scroll
+   (the photo), and only where the pan runs — dropped on Gecko below, where the
+   background is static. Deliberately not on the container/scrim (never move). */
+.space-bg img {
   will-change: transform;
 }
 
@@ -101,6 +102,7 @@ html {
    fully independent of the scroll pan (transform) that rides on the parent. */
 .space-stars {
   z-index: -1;
+  will-change: transform;
 }
 
 .space-stars::before,
@@ -126,62 +128,21 @@ html {
   background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='520' height='520'%3E%3Cg fill='%23ffffff'%3E%3Ccircle cx='95' cy='55' r='0.7' opacity='0.8'/%3E%3Ccircle cx='250' cy='90' r='0.5' opacity='0.5'/%3E%3Ccircle cx='400' cy='45' r='0.8' opacity='0.7'/%3E%3Ccircle cx='150' cy='160' r='0.6' opacity='0.6'/%3E%3Ccircle cx='330' cy='185' r='0.9' opacity='0.85'/%3E%3Ccircle cx='60' cy='260' r='0.6' opacity='0.55'/%3E%3Ccircle cx='210' cy='300' r='0.7' opacity='0.7'/%3E%3Ccircle cx='450' cy='290' r='0.5' opacity='0.5'/%3E%3Ccircle cx='120' cy='420' r='0.8' opacity='0.75'/%3E%3Ccircle cx='290' cy='460' r='0.6' opacity='0.55'/%3E%3Ccircle cx='390' cy='430' r='0.7' opacity='0.65'/%3E%3Ccircle cx='480' cy='150' r='0.6' opacity='0.5'/%3E%3Ccircle cx='30' cy='120' r='0.5' opacity='0.45'/%3E%3Ccircle cx='175' cy='380' r='0.6' opacity='0.6'/%3E%3C/g%3E%3C/svg%3E");
 }
 
-/* ── Ambient motion (time-based, every engine) ───────────────────────────────
-   The photo breathes with a very slow drift + zoom around its base transform;
-   the two star fields cross-fade to twinkle. All paused when the tab is hidden
-   (`.space-idle`, toggled by space-scroll.js) and off under reduced motion. */
-@media (prefers-reduced-motion: no-preference) {
-  .space-bg picture {
-    animation: space-drift 78s ease-in-out infinite;
-  }
-  .space-stars::before {
-    animation: star-twinkle-a 6.5s ease-in-out infinite;
-  }
-  .space-stars::after {
-    animation: star-twinkle-b 8.5s ease-in-out infinite;
-  }
-}
+/* ── Scroll-driven parallax ───────────────────────────────────────────────────
+   The ONLY motion on the background: it pans as you scroll (progress 0 at page
+   top → 1 at bottom); the photo drifts up + zooms in, the stars drift up ~3x
+   faster for depth. There is deliberately NO continuous/idle animation. A slow
+   time-based ambient drift + star twinkle used to live here; it was removed
+   because on Gecko (Firefox/Zen) it re-composited the full-viewport fixed layers
+   every frame even at rest (~46fps idle, constant jank) and, under the glass
+   panels, forced a per-frame re-blur. Motion now happens only while scrolling.
 
-html.space-idle .space-bg picture,
-html.space-idle .space-stars::before,
-html.space-idle .space-stars::after {
-  animation-play-state: paused;
-}
-
-@keyframes space-drift {
-  0% {
-    transform: scale(1.16) translate3d(0, 0, 0);
-  }
-  25% {
-    transform: scale(1.175) translate3d(-1.2%, -0.7%, 0);
-  }
-  50% {
-    transform: scale(1.19) translate3d(0.5%, -1.4%, 0);
-  }
-  75% {
-    transform: scale(1.175) translate3d(1.2%, -0.6%, 0);
-  }
-  100% {
-    transform: scale(1.16) translate3d(0, 0, 0);
-  }
-}
-
-@keyframes star-twinkle-a {
-  0%, 100% { opacity: 0.72; }
-  50% { opacity: 0.42; }
-}
-
-@keyframes star-twinkle-b {
-  0%, 100% { opacity: 0.4; }
-  50% { opacity: 0.68; }
-}
-
-/* ── Scroll-driven parallax (CSS timeline path) ──────────────────────────────
-   Progress 0 (page top) → 1 (page bottom). The photo drifts up + zooms in; the
-   stars drift up ~3x faster. Guarded by @supports so only browsers with a
-   working scroll timeline take this path; everyone else gets the JS fallback
-   (which sets the same transforms inline). Ambient drift/twinkle above are
-   unaffected either way. */
+   CSS scroll-timeline path (Blink + modern WebKit), guarded by @supports.
+   Engines without a working scroll timeline get the rAF fallback in
+   space-scroll.js (same transforms, inline). Gecko is opted out entirely (see
+   .space-no-parallax below): it composites these full-bleed layers too slowly to
+   pan per frame (~35fps scroll on BOTH the CSS and rAF paths), so its background
+   stays static — the photo + stars still read premium, they just don't pan. */
 @supports (animation-timeline: scroll()) {
   @media (prefers-reduced-motion: no-preference) {
     .space-bg img {
@@ -213,13 +174,29 @@ html.space-idle .space-stars::after {
   }
 }
 
-/* The JS fallback adds this class to opt the pan layers out of the CSS pan
-   animation while it drives those transforms itself (belt-and-braces; the
-   @supports guard already excludes non-timeline engines). Ambient drift lives
-   on <picture> and twinkle on the star pseudos, so neither is touched here. */
+/* The rAF fallback (space-scroll.js) adds this class to opt the pan layers out
+   of the CSS pan animation while it drives those transforms inline itself
+   (belt-and-braces; the @supports guard already excludes non-timeline engines). */
 .space-js-parallax .space-bg img,
 .space-js-parallax .space-stars {
   animation: none;
+}
+
+/* Gecko (Firefox/Zen): keep the background fully static. space-scroll.js adds
+   this class on Gecko, cancelling the CSS-timeline pan and any inherited pan
+   transform, and dropping the compositing hint since nothing moves. Full-bleed
+   fixed layers are too costly to pan per frame there (measured ~35fps vs ~118fps
+   static); a static photo keeps the premium look with zero scroll cost. */
+.space-no-parallax .space-bg img,
+.space-no-parallax .space-stars {
+  animation: none !important;
+  will-change: auto;
+}
+.space-no-parallax .space-bg img {
+  transform: scale(1.16) translate3d(0, 0, 0);
+}
+.space-no-parallax .space-stars {
+  transform: none;
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/website/src/index.html
+++ b/website/src/index.html
@@ -74,13 +74,16 @@ visionPath: "vision/index.html"
     --border-light: rgba(255,255,255,0.08);
     --border-medium: rgba(255,255,255,0.18);
     --composer-shadow: 0 4px 30px rgba(0,0,0,0.35), 0 0 0 1px rgba(255,255,255,0.06);
-    /* Dark glass panels — translucent dark surfaces over the photo. */
-    --glass: rgba(22,24,36,0.75);
-    --glass-strong: rgba(16,18,28,0.85);
+    /* Dark glass panels — translucent dark surfaces over the photo. Kept
+       backdrop-blur-free on purpose: blurring the moving space photo behind
+       these many panels forced a full re-blur every scroll frame (measured
+       ~30fps on Gecko). The panels are near-opaque dark fills instead, so the
+       frosted-glass look survives with zero per-frame cost. See space.css. */
+    --glass: rgba(22,24,36,0.92);
+    --glass-strong: rgba(16,18,28,0.95);
     --glass-raise: rgba(255,255,255,0.05);
     --glass-border: rgba(255,255,255,0.10);
     --glass-border-strong: rgba(255,255,255,0.16);
-    --glass-blur: saturate(1.15) blur(14px);
     --panel-shadow: 0 1px 0 rgba(255,255,255,0.04) inset, 0 20px 50px -24px rgba(0,0,0,0.7);
   }
 
@@ -158,14 +161,14 @@ visionPath: "vision/index.html"
     align-items: center;
     justify-content: space-between;
     background: transparent;
-    transition: background 0.3s ease, backdrop-filter 0.3s ease;
+    transition: background 0.3s ease;
   }
 
-  /* Scrolled: frosted DARK glass over the space page below (the page is dark
-     top to bottom now, so the nav stays dark-on-dark, never light). */
+  /* Scrolled: solid DARK bar over the space page below (the page is dark
+     top to bottom now, so the nav stays dark-on-dark, never light). Near-opaque
+     instead of blurred — blur re-rasterized every scroll frame on Gecko. */
   nav.scrolled {
-    background: rgba(11,12,19,0.85);
-    backdrop-filter: saturate(1.2) blur(20px);
+    background: rgba(11,12,19,0.94);
     border-bottom: 1px solid rgba(255,255,255,0.08);
   }
 
@@ -252,8 +255,7 @@ visionPath: "vision/index.html"
     left: 0;
     right: 0;
     z-index: 99;
-    background: rgba(11,12,19,0.92);
-    backdrop-filter: saturate(1.2) blur(20px);
+    background: rgba(11,12,19,0.97);
     padding: 8px 20px 16px;
     flex-direction: column;
     gap: 0;
@@ -963,8 +965,6 @@ visionPath: "vision/index.html"
     border-radius: 14px;
     background: var(--glass);
     border: 1px solid var(--glass-border);
-    -webkit-backdrop-filter: var(--glass-blur);
-    backdrop-filter: var(--glass-blur);
     z-index: 0;
     transition: background 0.2s;
   }
@@ -1178,9 +1178,7 @@ visionPath: "vision/index.html"
   footer {
     padding: 40px;
     border-top: 1px solid var(--border-light);
-    background: rgba(8,9,15,0.75);
-    -webkit-backdrop-filter: saturate(1.1) blur(12px);
-    backdrop-filter: saturate(1.1) blur(12px);
+    background: rgba(8,9,15,0.9);
     text-align: center;
     font-size: 13px;
     color: var(--gray-500);
@@ -1217,8 +1215,6 @@ visionPath: "vision/index.html"
     border: 1px solid var(--glass-border);
     overflow: hidden;
     background: var(--glass-strong);
-    -webkit-backdrop-filter: var(--glass-blur);
-    backdrop-filter: var(--glass-blur);
     text-align: left;
   }
 
@@ -1335,8 +1331,6 @@ visionPath: "vision/index.html"
   .glass-panel {
     background: var(--glass);
     border: 1px solid var(--glass-border);
-    -webkit-backdrop-filter: var(--glass-blur);
-    backdrop-filter: var(--glass-blur);
   }
 
   /* Agent selector pills (how-it-works). Class-driven so the active state is a


### PR DESCRIPTION
## Problem

The live gethouston.ai landing was reported unusable in **Zen (Gecko/Firefox)** — slow animations, slow scrolling, jank everywhere. All prior verification ran **Chromium + WebKit only**, which hid the cost entirely. Measured with Playwright across all three engines (in-page `requestAnimationFrame` timestamp deltas — the only signal comparable across engines; Firefox installed via `npx playwright install firefox`).

## Measured cause ranking (by ablation, not intuition)

Three **independent** Gecko costs, each isolated by patching one thing at a time:

1. **Continuous ambient animation** (photo drift + star twinkle) — the idle jank. Animating full-viewport `position:fixed` layers every frame re-composites them even at rest, and under the glass panels it forced a full-page re-blur. **Idle 40 → 120 fps** just by removing it. (Dropping `backdrop-filter` alone did *not* help idle — the animation was the trigger.)
2. **`backdrop-filter` blur** on the many glass panels — the scroll jank. Cheap only while the backdrop is static; as panels scroll over it, Gecko re-rasterizes the blur every frame. Capped scroll at ~30 fps.
3. **Panning the full-bleed photo layer** per scroll frame — ~35 fps on Gecko on **both** the CSS `animation-timeline: scroll()` path and the rAF fallback, regardless of image size. It's compositing a full-bleed fixed layer, not the driver.

Clean 2×2 on Gecko (ambient off): blur×parallax — both must be off to reach 60 fps (30/35/31/**119**).

## Fix (design language fully preserved)

- **Removed the continuous ambient animation.** Background motion is now scroll-driven only.
- **Removed `backdrop-filter` from the glass panels**, compensated with near-opaque dark fills (`--glass`/`--glass-strong` 0.92/0.95). Over the dark scrimmed photo the frosted look is visually identical — verified with before/after screenshots (desktop + mobile, hero/glass/pricing). Only the transient `.dl-overlay` modal keeps its blur (sits over a static background).
- **Gated the scroll parallax off on Gecko** (`space-scroll.js` adds `.space-no-parallax` via `CSS.supports("-moz-appearance","none")`): static background there — still the full photo + stars, just not panning. **Blink + WebKit keep the parallax** on the compositor cheaply.
- `will-change` reserved only for elements that actually pan (dropped on Gecko). `prefers-reduced-motion` still freezes everything.

> Note on "keep the parallax" from the brief: the evidence shows any per-frame transform of a full-bleed layer caps Gecko — the owner's browser — at ~35 fps, so keeping parallax there directly contradicts the "smooth" goal. Resolved by keeping parallax where it's free (Blink/WebKit) and making Gecko static. Happy to make Gecko parallax an explicit opt-in instead if preferred.

## Before → after (headless Playwright, 1440×900, in-page rAF deltas)

| Engine (idle → scroll fps) | Before | After |
| --- | --- | --- |
| **Firefox / Gecko** | 40 → 27 (94 idle jank frames >25ms) | **120 → 118 (0 jank)** |
| Chromium | (8% busy) → 67 (6 scroll jank) | (8% busy) → 120 (0 jank) |
| Chromium, 4× CPU throttle | → 60 (19 jank) | → 119 (0 jank) |
| WebKit | 60 → 60 | 60 → 60 |

Zero console errors on Chromium + WebKit; Firefox's one console message is a pre-existing third-party `_fontshare_key` cross-site-cookie warning (present before this change, unrelated to the fix). Biome clean. Reduced-motion fully static on all engines.

Perf constraints documented in `website/PERFORMANCE.md` (incl. the mandatory Gecko test matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)