### PR TITLE
fix(release): whisper-cli via ClangCL on Windows-ARM

### DIFF
--- a/scripts/build-whisper.sh
+++ b/scripts/build-whisper.sh
@@ -182,6 +182,14 @@ case "$OS" in
   windows | linux)
     # CPU-only, portable across CPUs (no -march=native), self-contained.
     CMAKE_FLAGS+=(-DGGML_NATIVE=OFF)
+    # ggml hard-refuses plain MSVC for ARM64 ("MSVC is not supported for ARM,
+    # use clang" — ggml-cpu/CMakeLists.txt): its ARM kernels need clang's
+    # NEON/ACLE intrinsics. Visual Studio's bundled ClangCL toolset compiles
+    # arm64 natively on the windows-11-arm runners while keeping the MSVC
+    # ABI + linker, which satisfies ggml's compiler check.
+    if [ "$OS" = "windows" ] && [ "$ARCH" = "aarch64" ]; then
+      CMAKE_FLAGS+=(-T ClangCL -A ARM64)
+    fi
     ;;
 esac
 


### PR DESCRIPTION
ggml refuses MSVC for ARM64 kernels; VS's bundled ClangCL toolset satisfies its clang requirement with the MSVC ABI/linker intact. Second (and per the cmake log, final) blocker on the windows-11-arm leg. Only provable by a tag run. 🤖 Generated with [Claude Code](https://claude.com/claude-code)