### PR TITLE
feat(local-model): share a tunnelled local model with your team

### DIFF
--- a/app/src/components/shell/local-model-dialog.tsx
+++ b/app/src/components/shell/local-model-dialog.tsx
@@ -9,6 +9,8 @@ import { useTranslation } from "react-i18next";
 import { useLocalModelConnect } from "../../hooks/use-local-model-connect";
 import { osIsTauri } from "../../lib/os-bridge";
 import type { ProviderInfo } from "../../lib/providers";
+import { isTeamWorkspace } from "../../lib/space-id";
+import { useWorkspaceStore } from "../../stores/workspaces";
 import {
   BusyScreen,
   EmptyScreen,
@@ -44,6 +46,8 @@ interface Props {
 export function LocalModelDialog({ provider, onClose, onConnected }: Props) {
   const { t } = useTranslation("providers");
   const desktop = osIsTauri();
+  const currentWorkspace = useWorkspaceStore((state) => state.current);
+  const teamWorkspace = isTeamWorkspace(currentWorkspace?.id ?? "");
   const {
     mode,
     servers,
@@ -52,6 +56,8 @@ export function LocalModelDialog({ provider, onClose, onConnected }: Props) {
     setModel,
     reasoning,
     setReasoning,
+    shared,
+    setShared,
     selectServer,
     runDetect,
     connect,
@@ -60,6 +66,8 @@ export function LocalModelDialog({ provider, onClose, onConnected }: Props) {
   } = useLocalModelConnect({
     active: provider != null,
     desktop,
+    teamWorkspace,
+    workspaceId: currentWorkspace?.id ?? "",
     onConnected,
     onClose,
   });
@@ -104,6 +112,9 @@ export function LocalModelDialog({ provider, onClose, onConnected }: Props) {
             onSelectModel={setModel}
             reasoning={reasoning}
             onReasoningChange={setReasoning}
+            shared={shared}
+            onSharedChange={setShared}
+            teamWorkspace={teamWorkspace}
             onConnect={() => void connect()}
             onManual={goManual}
           />
@@ -124,6 +135,9 @@ export function LocalModelDialog({ provider, onClose, onConnected }: Props) {
             onConnected={onConnected}
             onClose={onClose}
             onBack={desktop ? () => void runDetect() : undefined}
+            shared={shared}
+            onSharedChange={setShared}
+            teamWorkspace={teamWorkspace}
           />
         )}
       </DialogContent>

--- a/app/src/components/shell/local-model-manual-form.tsx
+++ b/app/src/components/shell/local-model-manual-form.tsx
@@ -5,6 +5,7 @@ import { useReasoningToggle } from "../../hooks/use-reasoning-toggle";
 import { genericErrorDescription } from "../../lib/error-toast";
 import { connectManualEndpoint } from "../../lib/local-model-connect";
 import { ReasoningToggle } from "./local-model-dialog-parts";
+import { ShareEndpointToggle } from "./local-model-share-toggle";
 import {
   LabeledTextField,
   SecretField,
@@ -21,10 +22,16 @@ export function LocalModelManualForm({
   onConnected,
   onClose,
   onBack,
+  shared,
+  onSharedChange,
+  teamWorkspace,
 }: {
   onConnected?: (model: string) => void;
   onClose: () => void;
   onBack?: () => void;
+  shared: boolean;
+  onSharedChange: (value: boolean) => void;
+  teamWorkspace: boolean;
 }) {
   const { t } = useTranslation("providers");
   const [baseUrl, setBaseUrl] = useState("");
@@ -64,6 +71,7 @@ export function LocalModelManualForm({
         name: name.trim() || undefined,
         apiKey: key.trim() || undefined,
         ...(reasoning ? { reasoning: true } : {}),
+        ...(teamWorkspace && shared ? { shared: true } : {}),
       });
       onConnected?.(trimmedModel);
       onClose();
@@ -124,6 +132,14 @@ export function LocalModelManualForm({
         onChange={setReasoning}
         disabled={submitting}
       />
+      {teamWorkspace && (
+        <ShareEndpointToggle
+          id="lm-manual-share"
+          checked={shared}
+          onChange={onSharedChange}
+          disabled={submitting}
+        />
+      )}
 
       {error && (
         <p className="text-[12px] text-danger" role="alert">

--- a/app/src/components/shell/local-model-pick.tsx
+++ b/app/src/components/shell/local-model-pick.tsx
@@ -10,6 +10,7 @@ import { Check, Laptop } from "lucide-react";
 import { useTranslation } from "react-i18next";
 import { appDisplayName, type DetectedServer } from "../../lib/local-model";
 import { ManualLink, ReasoningToggle } from "./local-model-dialog-parts";
+import { ShareEndpointToggle } from "./local-model-share-toggle";
 
 /**
  * Pick a detected local server + one of its models, then Connect. Non-technical:
@@ -23,6 +24,9 @@ export function PickScreen({
   onSelectModel,
   reasoning,
   onReasoningChange,
+  shared,
+  onSharedChange,
+  teamWorkspace,
   onConnect,
   onManual,
 }: {
@@ -33,6 +37,9 @@ export function PickScreen({
   onSelectModel: (model: string) => void;
   reasoning: boolean;
   onReasoningChange: (value: boolean) => void;
+  shared: boolean;
+  onSharedChange: (value: boolean) => void;
+  teamWorkspace: boolean;
   onConnect: () => void;
   onManual: () => void;
 }) {
@@ -94,6 +101,9 @@ export function PickScreen({
         </Select>
       </div>
       <ReasoningToggle checked={reasoning} onChange={onReasoningChange} />
+      {teamWorkspace && (
+        <ShareEndpointToggle checked={shared} onChange={onSharedChange} />
+      )}
       <div className="flex items-center justify-between gap-2 pt-1">
         <ManualLink onClick={onManual} />
         <Button onClick={onConnect} disabled={!model}>

--- a/app/src/components/shell/local-model-share-toggle.tsx
+++ b/app/src/components/shell/local-model-share-toggle.tsx
@@ -1,0 +1,39 @@
+import { Switch } from "@houston-ai/core";
+import { useTranslation } from "react-i18next";
+
+/** Team-only opt-in for publishing the endpoint through the managed gateway. */
+export function ShareEndpointToggle({
+  id = "lm-share",
+  checked,
+  onChange,
+  disabled,
+}: {
+  id?: string;
+  checked: boolean;
+  onChange: (value: boolean) => void;
+  disabled?: boolean;
+}) {
+  const { t } = useTranslation("providers");
+  return (
+    <div className="flex items-start justify-between gap-3 rounded-xl border border-border bg-secondary px-3 py-2.5">
+      <label
+        htmlFor={id}
+        className="flex min-w-0 flex-1 cursor-pointer flex-col"
+      >
+        <span className="text-[13px] font-medium text-foreground">
+          {t("localModel.share.label")}
+        </span>
+        <span className="text-[11px] leading-relaxed text-muted-foreground">
+          {t("localModel.share.help")}
+        </span>
+      </label>
+      <Switch
+        id={id}
+        checked={checked}
+        onCheckedChange={onChange}
+        disabled={disabled}
+        className="mt-0.5"
+      />
+    </div>
+  );
+}

--- a/app/src/hooks/use-local-model-connect.ts
+++ b/app/src/hooks/use-local-model-connect.ts
@@ -10,38 +10,16 @@ import {
   connectDetectedModel,
   detectLocalModels,
 } from "../lib/local-model-connect";
+import {
+  LOCAL_MODEL_CONNECT_TIMEOUT_MS,
+  LOCAL_MODEL_DETECT_TIMEOUT_MS,
+  type LocalModelMode,
+} from "../lib/local-model-connect-state";
+import { withLocalModelTimeout } from "../lib/local-model-timeout";
+import { useLocalModelShare } from "./use-local-model-share";
 import { useReasoningToggle } from "./use-reasoning-toggle";
 
-export type LocalModelMode =
-  | "detecting"
-  | "empty"
-  | "pick"
-  | "connecting"
-  | "error"
-  | "manual";
-
-/** Detection is a quick localhost scan; the connect mints a tunnel + starts frpc
- *  and can legitimately take longer. Both fall back to the calm error state (with
- *  retry) if they hang, so the dialog can never spin forever. */
-const DETECT_TIMEOUT_MS = 20_000;
-const CONNECT_TIMEOUT_MS = 90_000;
-
-/** Race `work` against a timeout; aborting the controller stops the timer and
- *  (via the signal) rolls back any half-open bridge. */
-function withTimeout<T>(
-  work: (signal: AbortSignal) => Promise<T>,
-  ms: number,
-  controller: AbortController,
-): Promise<T> {
-  const timeout = new Promise<never>((_, reject) => {
-    const id = setTimeout(() => {
-      controller.abort();
-      reject(new Error("local-model timeout"));
-    }, ms);
-    controller.signal.addEventListener("abort", () => clearTimeout(id));
-  });
-  return Promise.race([work(controller.signal), timeout]);
-}
+export type { LocalModelMode } from "../lib/local-model-connect-state";
 
 /**
  * Owns the guided "connect a local model" flow: detection, model pick, and the
@@ -55,14 +33,20 @@ export function useLocalModelConnect(opts: {
   active: boolean;
   /** Native bridge available (desktop). Web opens straight to the manual form. */
   desktop: boolean;
+  /** Whether the active workspace can publish an organization share. */
+  teamWorkspace: boolean;
+  /** Active workspace identity, used to prevent sharing into a newly switched team. */
+  workspaceId: string;
   onConnected?: (model: string) => void;
   onClose: () => void;
 }) {
-  const { active, desktop, onConnected, onClose } = opts;
+  const { active, desktop, teamWorkspace, workspaceId, onConnected, onClose } =
+    opts;
   const [mode, setMode] = useState<LocalModelMode>("detecting");
   const [servers, setServers] = useState<DetectedServer[]>([]);
   const [selected, setSelected] = useState(0);
   const [model, setModelState] = useState("");
+  const { shared, setShared } = useLocalModelShare(workspaceId);
   // "Show the model's thinking" toggle (heuristic default, user can override).
   const {
     reasoning,
@@ -99,9 +83,9 @@ export function useLocalModelConnect(opts: {
     setMode("detecting");
     try {
       const found = connectableServers(
-        await withTimeout(
+        await withLocalModelTimeout(
           () => detectLocalModels(),
-          DETECT_TIMEOUT_MS,
+          LOCAL_MODEL_DETECT_TIMEOUT_MS,
           controller,
         ),
       );
@@ -126,11 +110,12 @@ export function useLocalModelConnect(opts: {
     if (!active) return;
     setServers([]);
     setSelected(0);
+    setShared(false);
     resetReasoning();
     chooseModel("");
     if (desktop) void runDetect();
     else setMode("manual");
-  }, [active, desktop, runDetect, chooseModel, resetReasoning]);
+  }, [active, desktop, runDetect, chooseModel, resetReasoning, setShared]);
 
   const selectServer = useCallback(
     (index: number) => {
@@ -148,7 +133,7 @@ export function useLocalModelConnect(opts: {
     abortRef.current = controller;
     setMode("connecting");
     try {
-      await withTimeout(
+      await withLocalModelTimeout(
         (signal) =>
           connectDetectedModel({
             server,
@@ -156,9 +141,10 @@ export function useLocalModelConnect(opts: {
             name: defaultEndpointName(server.kind, model),
             appName: appDisplayName(server.kind),
             reasoning,
+            shared: teamWorkspace && shared,
             signal,
           }),
-        CONNECT_TIMEOUT_MS,
+        LOCAL_MODEL_CONNECT_TIMEOUT_MS,
         controller,
       );
       if (controller.signal.aborted || !mounted.current) return;
@@ -169,7 +155,16 @@ export function useLocalModelConnect(opts: {
       // the bridge back. Show a calm retry state unless we were cancelled/closed.
       if (!controller.signal.aborted && mounted.current) setMode("error");
     }
-  }, [servers, selected, model, reasoning, onConnected, onClose]);
+  }, [
+    servers,
+    selected,
+    model,
+    reasoning,
+    shared,
+    teamWorkspace,
+    onConnected,
+    onClose,
+  ]);
 
   /** Cancel the in-flight detect/connect: abort the work (the connect's own
    *  abort path rolls back any half-open bridge) and close the dialog. */
@@ -191,6 +186,8 @@ export function useLocalModelConnect(opts: {
     setModel: chooseModel,
     reasoning,
     setReasoning,
+    shared,
+    setShared,
     selectServer,
     runDetect,
     connect,

--- a/app/src/hooks/use-local-model-share.ts
+++ b/app/src/hooks/use-local-model-share.ts
@@ -1,0 +1,13 @@
+import { useEffect, useRef, useState } from "react";
+
+/** Owns the share toggle and clears it when the active workspace changes. */
+export function useLocalModelShare(workspaceId: string) {
+  const [shared, setShared] = useState(false);
+  const previousWorkspaceId = useRef(workspaceId);
+  useEffect(() => {
+    if (previousWorkspaceId.current === workspaceId) return;
+    previousWorkspaceId.current = workspaceId;
+    setShared(false);
+  }, [workspaceId]);
+  return { shared, setShared };
+}

--- a/app/src/lib/local-model-connect-state.ts
+++ b/app/src/lib/local-model-connect-state.ts
@@ -1,0 +1,13 @@
+/** Screens in the guided local-model connection flow. */
+export type LocalModelMode =
+  | "detecting"
+  | "empty"
+  | "pick"
+  | "connecting"
+  | "error"
+  | "manual";
+
+/** Maximum time allowed for the quick local-server scan. */
+export const LOCAL_MODEL_DETECT_TIMEOUT_MS = 20_000;
+/** Maximum time allowed to establish and register the tunnel. */
+export const LOCAL_MODEL_CONNECT_TIMEOUT_MS = 90_000;

--- a/app/src/lib/local-model-connect.ts
+++ b/app/src/lib/local-model-connect.ts
@@ -103,6 +103,8 @@ export async function connectDetectedModel(opts: {
   appName: string;
   /** Surface the model's chain-of-thought as thinking in Houston. */
   reasoning?: boolean;
+  /** Share this endpoint with the active team workspace. */
+  shared?: boolean;
   signal?: AbortSignal;
 }): Promise<void> {
   return withBridgeOp(async () => {
@@ -138,6 +140,7 @@ export async function connectDetectedModel(opts: {
       name: opts.name,
       proxyKey: bridge.proxyKey,
       reasoning: opts.reasoning,
+      shared: opts.shared,
     });
     try {
       await tauriProvider.setCustomEndpoint(endpoint);

--- a/app/src/lib/local-model-timeout.ts
+++ b/app/src/lib/local-model-timeout.ts
@@ -1,0 +1,15 @@
+/** Race local-model work against a timeout while sharing its abort signal. */
+export function withLocalModelTimeout<T>(
+  work: (signal: AbortSignal) => Promise<T>,
+  ms: number,
+  controller: AbortController,
+): Promise<T> {
+  const timeout = new Promise<never>((_, reject) => {
+    const id = setTimeout(() => {
+      controller.abort();
+      reject(new Error("local-model timeout"));
+    }, ms);
+    controller.signal.addEventListener("abort", () => clearTimeout(id));
+  });
+  return Promise.race([work(controller.signal), timeout]);
+}

--- a/app/src/lib/local-model.ts
+++ b/app/src/lib/local-model.ts
@@ -134,6 +134,8 @@ export function buildLocalEndpoint(opts: {
   /** Surface the model's chain-of-thought as thinking in Houston. Omitted from
    *  the payload unless true, to keep saved endpoints clean. */
   reasoning?: boolean;
+  /** Share the endpoint with teammates in the active team workspace. */
+  shared?: boolean;
 }): CustomEndpoint {
   return {
     baseUrl: `${opts.publicUrl.replace(/\/+$/, "")}/v1`,
@@ -141,6 +143,7 @@ export function buildLocalEndpoint(opts: {
     name: opts.name,
     apiKey: opts.proxyKey,
     ...(opts.reasoning ? { reasoning: true } : {}),
+    ...(opts.shared ? { shared: true } : {}),
   };
 }
 

--- a/app/src/locales/en/providers.json
+++ b/app/src/locales/en/providers.json
@@ -142,6 +142,10 @@
       "label": "Show the model's thinking",
       "help": "Turn this on for reasoning models (they think before answering)."
     },
+    "share": {
+      "label": "Share with my team",
+      "help": "Teammates' agents can use this model. Their requests run through your computer while it's online."
+    },
     "error": {
       "body": "Something went wrong while connecting. Make sure the app is still open on your computer, then try again.",
       "retry": "Try again"

--- a/app/src/locales/es/providers.json
+++ b/app/src/locales/es/providers.json
@@ -142,6 +142,10 @@
       "label": "Mostrar el razonamiento del modelo",
       "help": "Actívalo para modelos de razonamiento (piensan antes de responder)."
     },
+    "share": {
+      "label": "Compartir con mi equipo",
+      "help": "Los agentes de tus compañeros pueden usar este modelo. Sus solicitudes se ejecutan en tu computador mientras esté en línea."
+    },
     "error": {
       "body": "Algo salió mal al conectar. Asegúrate de que la app siga abierta en tu computador e inténtalo de nuevo.",
       "retry": "Intentar de nuevo"

--- a/app/src/locales/pt/providers.json
+++ b/app/src/locales/pt/providers.json
@@ -142,6 +142,10 @@
       "label": "Mostrar o raciocínio do modelo",
       "help": "Ative isto para modelos de raciocínio (eles pensam antes de responder)."
     },
+    "share": {
+      "label": "Compartilhar com minha equipe",
+      "help": "Os agentes dos seus colegas podem usar este modelo. As solicitações deles são processadas no seu computador enquanto ele estiver online."
+    },
     "error": {
       "body": "Algo deu errado ao conectar. Confira se o app ainda está aberto no seu computador e tente de novo.",
       "retry": "Tentar de novo"

--- a/app/tests/local-model.test.ts
+++ b/app/tests/local-model.test.ts
@@ -94,6 +94,21 @@ describe("local-model helpers", () => {
     );
   });
 
+  it("marks the endpoint as team-shared only when the toggle is on", () => {
+    const base = {
+      publicUrl: "https://sub.relay.example.com",
+      model: "qwen",
+      name: "n",
+      proxyKey: "k",
+    };
+    strictEqual("shared" in buildLocalEndpoint(base), false);
+    strictEqual(
+      "shared" in buildLocalEndpoint({ ...base, shared: false }),
+      false,
+    );
+    strictEqual(buildLocalEndpoint({ ...base, shared: true }).shared, true);
+  });
+
   it("detects reasoning models by id substring, case-insensitively", () => {
     for (const id of [
       "DeepSeek-R1",

--- a/packages/host/src/credentials/remote-shared-endpoint-store.test.ts
+++ b/packages/host/src/credentials/remote-shared-endpoint-store.test.ts
@@ -1,0 +1,101 @@
+import { expect, test } from "vitest";
+import { RemoteSharedEndpointStore } from "./remote-shared-endpoint-store";
+
+type FetchCall = { url: string; init?: RequestInit };
+
+const BASE = "https://gateway.test";
+const ORG = "0011223344556677";
+const AGENT = "8899aabbccddeeff";
+const PATH = `${BASE}/v1/pod/shared-endpoint/${ORG}/${AGENT}`;
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), { status });
+}
+
+function fakeFetch(handler: (call: FetchCall) => Response | Promise<Response>) {
+  const calls: FetchCall[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const call = { url: String(input), init };
+    calls.push(call);
+    return await handler(call);
+  }) as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+function store(fetchImpl: typeof fetch) {
+  return new RemoteSharedEndpointStore({
+    baseUrl: `${BASE}/`,
+    orgSlug: ORG,
+    agentSlug: AGENT,
+    podToken: "pod-token",
+    fetchImpl,
+  });
+}
+
+function headers(call: FetchCall): Record<string, string> {
+  return call.init?.headers as Record<string, string>;
+}
+
+test("get returns the shared endpoint from the gateway", async () => {
+  const endpoint = {
+    baseUrl: "https://relay.example.com/v1",
+    model: "qwen",
+    name: null,
+    contextWindow: 131_072,
+    reasoning: false,
+    apiKey: "secret",
+    ownerAgent: "fedcba9876543210",
+  };
+  const { calls, fetchImpl } = fakeFetch(() => json(endpoint));
+
+  await expect(store(fetchImpl).get()).resolves.toEqual(endpoint);
+  expect(calls[0]?.url).toBe(PATH);
+  expect(headers(calls[0] as FetchCall).Authorization).toBe("Bearer pod-token");
+});
+
+test("get treats 404 as no organization share", async () => {
+  const { fetchImpl } = fakeFetch(() =>
+    json({ error: "no shared endpoint" }, 404),
+  );
+  await expect(store(fetchImpl).get()).resolves.toBeNull();
+});
+
+test("gateway failures surface with the response detail", async () => {
+  const { fetchImpl } = fakeFetch(() => json({ error: "upstream down" }, 500));
+  await expect(store(fetchImpl).get()).rejects.toThrow(
+    /shared endpoint gateway GET failed \(500\)/,
+  );
+});
+
+test("put writes the endpoint descriptor without undefined fields", async () => {
+  const { calls, fetchImpl } = fakeFetch(() => json({ ok: true }));
+
+  await store(fetchImpl).put({
+    baseUrl: "https://relay.example.com/v1",
+    model: "qwen",
+    reasoning: false,
+    apiKey: "secret",
+  });
+
+  expect(calls[0]?.init?.method).toBe("PUT");
+  expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
+    baseUrl: "https://relay.example.com/v1",
+    model: "qwen",
+    reasoning: false,
+    apiKey: "secret",
+  });
+});
+
+test("owner-only removal sends the ownership guard header", async () => {
+  const { calls, fetchImpl } = fakeFetch(() => json({ ok: true }));
+  const remote = store(fetchImpl);
+
+  await remote.remove({ ownerOnly: true });
+  await remote.remove({ ownerOnly: false });
+
+  expect(calls[0]?.init?.method).toBe("DELETE");
+  expect(headers(calls[0] as FetchCall)["x-houston-owner-only"]).toBe("1");
+  expect(
+    headers(calls[1] as FetchCall)["x-houston-owner-only"],
+  ).toBeUndefined();
+});

--- a/packages/host/src/credentials/remote-shared-endpoint-store.ts
+++ b/packages/host/src/credentials/remote-shared-endpoint-store.ts
@@ -1,0 +1,96 @@
+export interface SharedEndpointInput {
+  baseUrl: string;
+  model: string;
+  name?: string;
+  contextWindow?: number;
+  reasoning?: boolean;
+  apiKey?: string;
+}
+
+export interface OrgSharedEndpoint {
+  baseUrl: string;
+  model: string;
+  name: string | null;
+  contextWindow: number | null;
+  reasoning: boolean;
+  apiKey: string;
+  ownerAgent: string;
+}
+
+export interface SharedEndpointStore {
+  get(): Promise<OrgSharedEndpoint | null>;
+  put(endpoint: SharedEndpointInput): Promise<void>;
+  remove(opts: { ownerOnly: boolean }): Promise<void>;
+}
+
+export interface RemoteSharedEndpointStoreOptions {
+  baseUrl: string;
+  orgSlug: string;
+  agentSlug: string;
+  podToken: string;
+  fetchImpl?: typeof fetch;
+}
+
+/** Managed-pod client for the gateway's single organization endpoint share. */
+export class RemoteSharedEndpointStore implements SharedEndpointStore {
+  private readonly baseUrl: string;
+  private readonly orgSlug: string;
+  private readonly agentSlug: string;
+  private readonly podToken: string;
+  private readonly fetchImpl: typeof fetch;
+
+  constructor(opts: RemoteSharedEndpointStoreOptions) {
+    this.baseUrl = opts.baseUrl.replace(/\/+$/, "");
+    this.orgSlug = opts.orgSlug;
+    this.agentSlug = opts.agentSlug;
+    this.podToken = opts.podToken;
+    this.fetchImpl = opts.fetchImpl ?? fetch;
+  }
+
+  async get(): Promise<OrgSharedEndpoint | null> {
+    const res = await this.fetchImpl(this.url(), {
+      headers: this.authHeaders(),
+    });
+    if (res.status === 404) return null;
+    if (res.status !== 200) throw await this.errorFromResponse(res, "GET");
+    return (await res.json()) as OrgSharedEndpoint;
+  }
+
+  async put(endpoint: SharedEndpointInput): Promise<void> {
+    const res = await this.fetchImpl(this.url(), {
+      method: "PUT",
+      headers: this.authHeaders({ "content-type": "application/json" }),
+      body: JSON.stringify(endpoint),
+    });
+    if (res.status !== 200) throw await this.errorFromResponse(res, "PUT");
+  }
+
+  async remove(opts: { ownerOnly: boolean }): Promise<void> {
+    const res = await this.fetchImpl(this.url(), {
+      method: "DELETE",
+      headers: this.authHeaders(
+        opts.ownerOnly ? { "x-houston-owner-only": "1" } : {},
+      ),
+    });
+    if (res.status !== 200) throw await this.errorFromResponse(res, "DELETE");
+  }
+
+  private url(): string {
+    return `${this.baseUrl}/v1/pod/shared-endpoint/${encodeURIComponent(this.orgSlug)}/${encodeURIComponent(this.agentSlug)}`;
+  }
+
+  private authHeaders(
+    extra: Record<string, string> = {},
+  ): Record<string, string> {
+    return { Authorization: `Bearer ${this.podToken}`, ...extra };
+  }
+
+  private async errorFromResponse(res: Response, method: string) {
+    const body = await res.text().catch(() => "");
+    return new Error(
+      `shared endpoint gateway ${method} failed (${res.status})${
+        body ? `: ${body.slice(0, 200)}` : ""
+      }`,
+    );
+  }
+}

--- a/packages/host/src/launcher/process.test.ts
+++ b/packages/host/src/launcher/process.test.ts
@@ -77,6 +77,53 @@ test("a warm runtime is reused, not respawned", async () => {
   expect(spawns).toHaveLength(1); // reused
 });
 
+test("afterSpawn runs once per fresh runtime, including wake-from-idle respawns", async () => {
+  const { spawner } = recordingSpawner();
+  const started: string[] = [];
+  const launcher = new ProcessLauncher(
+    opts(spawner, {
+      afterSpawn: async (a, endpoint) => {
+        started.push(`${a.id}:${endpoint.baseUrl}`);
+      },
+    }),
+  );
+  const a = agent("shared");
+
+  await launcher.ensureAwake(a);
+  await launcher.ensureAwake(a);
+  await launcher.sleep(a.id);
+  await launcher.ensureAwake(a);
+
+  expect(started).toEqual([
+    "shared:http://127.0.0.1:5000",
+    "shared:http://127.0.0.1:5001",
+  ]);
+});
+
+test("a failed afterSpawn hook reaps the runtime so the next wake retries it", async () => {
+  const { spawner, spawns, killed } = recordingSpawner();
+  let attempts = 0;
+  const launcher = new ProcessLauncher(
+    opts(spawner, {
+      afterSpawn: async () => {
+        attempts++;
+        if (attempts === 1) throw new Error("startup hook failed");
+      },
+    }),
+  );
+  const a = agent("shared");
+
+  await expect(launcher.ensureAwake(a)).rejects.toThrow("startup hook failed");
+  expect(killed).toEqual([5000]);
+  expect(await launcher.status(a.id)).toBe("asleep");
+
+  await expect(launcher.ensureAwake(a)).resolves.toMatchObject({
+    baseUrl: "http://127.0.0.1:5001",
+  });
+  expect(spawns).toHaveLength(2);
+  expect(attempts).toBe(2);
+});
+
 test("sleep kills the process; the next ensureAwake spawns a fresh one", async () => {
   const { spawner, spawns, killed } = recordingSpawner();
   const launcher = new ProcessLauncher(opts(spawner));

--- a/packages/host/src/launcher/process.ts
+++ b/packages/host/src/launcher/process.ts
@@ -60,6 +60,8 @@ export interface ProcessLauncherOptions {
   allocatePort?: () => Promise<number>;
   /** Poll the runtime's /health until ready. Injectable for tests. */
   waitHealthy?: (port: number, token: string) => Promise<void>;
+  /** Run once after each newly spawned runtime becomes healthy. */
+  afterSpawn?: (agent: Agent, endpoint: RuntimeEndpoint) => Promise<void>;
 }
 
 interface Running {
@@ -204,7 +206,18 @@ export class ProcessLauncher implements RuntimeLauncher {
     } finally {
       abortBoot = undefined;
     }
-    return { baseUrl: `http://127.0.0.1:${handle.port}`, token };
+    const endpoint = {
+      baseUrl: `http://127.0.0.1:${handle.port}`,
+      token,
+    };
+    try {
+      await this.opts.afterSpawn?.(agent, endpoint);
+    } catch (error) {
+      handle.kill();
+      if (this.running.get(agent.id) === entry) this.running.delete(agent.id);
+      throw error;
+    }
+    return endpoint;
   }
 
   async sleep(agentId: AgentId): Promise<void> {

--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -7,6 +7,7 @@ import { SingleUserVerifier } from "../auth/verify";
 import { LOCAL_CAPABILITIES } from "../capabilities";
 import { ProxyChannel } from "../channel/proxy";
 import { FileCredentialStore } from "../credentials/file-store";
+import { RemoteSharedEndpointStore } from "../credentials/remote-shared-endpoint-store";
 import { RemoteCredentialStore } from "../credentials/remote-store";
 import { EnvCredentialVault } from "../credentials/vault";
 import { BusEventHub } from "../events/hub";
@@ -31,6 +32,7 @@ import { forward } from "../proxy/route";
 import { ChannelRoutineFirer } from "../schedule/firer";
 import { Scheduler } from "../schedule/scheduler";
 import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
+import { syncSharedEndpoint } from "../shared-endpoint/sync";
 import { LocalWorkspaceStore } from "../store/local";
 import { StoreSyncDaemon } from "../store-sync";
 import { MemoryTurnBus } from "../turn/bus";
@@ -112,6 +114,13 @@ export interface LocalHostOptions {
    * one-time adoption fallback for pods that already captured a legacy credential.
    */
   credentials?: {
+    url: string;
+    orgSlug: string;
+    agentSlug: string;
+    podToken: string;
+  };
+  /** Managed-pod organization endpoint gateway. Absent on desktop/self-host. */
+  sharedEndpoints?: {
     url: string;
     orgSlug: string;
     agentSlug: string;
@@ -204,6 +213,14 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
         fallback: fileCredentials,
       })
     : fileCredentials;
+  const sharedEndpoints = opts.sharedEndpoints
+    ? new RemoteSharedEndpointStore({
+        baseUrl: opts.sharedEndpoints.url,
+        orgSlug: opts.sharedEndpoints.orgSlug,
+        agentSlug: opts.sharedEndpoints.agentSlug,
+        podToken: opts.sharedEndpoints.podToken,
+      })
+    : undefined;
   const controlPlaneUrl = `http://127.0.0.1:${opts.port}`;
 
   const spawner =
@@ -239,6 +256,12 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
       controlPlaneUrl,
       mintSandboxToken: (a) => vault.sandboxToken(a.workspaceId, a.id),
     },
+    afterSpawn:
+      opts.gatewayFronted && sharedEndpoints
+        ? async (_agent, runtime) => {
+            await syncSharedEndpoint({ store: sharedEndpoints, runtime });
+          }
+        : undefined,
   });
 
   const channel = new ProxyChannel({
@@ -406,6 +429,7 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
     verifier: new SingleUserVerifier({ token: opts.token, userId: LOCAL_USER }),
     store,
     credentials,
+    sharedEndpoints,
     vault,
     vfs,
     paths,

--- a/packages/host/src/local/main.ts
+++ b/packages/host/src/local/main.ts
@@ -97,6 +97,7 @@ function storeSyncConfig(hostTokenEnv: string | undefined) {
 const houstonHome = process.env.HOUSTON_HOME || join(homedir(), ".houston");
 const hostTokenEnv = process.env.HOUSTON_HOST_TOKEN;
 const hostToken = hostTokenEnv || randomBytes(32).toString("hex");
+const remoteGateway = remoteCredentialConfig(hostTokenEnv);
 const host = buildLocalHost({
   workspacesRoot:
     process.env.HOUSTON_WORKSPACES_ROOT || join(houstonHome, "workspaces"),
@@ -139,7 +140,8 @@ const host = buildLocalHost({
   // x-houston-acting-as); relay that header to the runtime so integration
   // calls act as the driving user. Desktop/self-host stay direct → false.
   gatewayFronted: process.env.HOUSTON_MANAGED_CLOUD === "1",
-  credentials: remoteCredentialConfig(hostTokenEnv),
+  credentials: remoteGateway,
+  sharedEndpoints: remoteGateway,
   // Migration-source spawns (HOU-719): serve + migrate on boot, but never fire
   // routines or churn watch events while the cloud app reads the old tree.
   passive: process.env.HOUSTON_PASSIVE === "1",

--- a/packages/host/src/routes/agent-authz.ts
+++ b/packages/host/src/routes/agent-authz.ts
@@ -1,5 +1,6 @@
 import type { ServerResponse } from "node:http";
 import type { Capabilities } from "@houston/protocol";
+import type { SharedEndpointStore } from "../credentials/remote-shared-endpoint-store";
 import { canUseAgent } from "../domain/access";
 import type {
   Agent,
@@ -32,6 +33,8 @@ export interface AgentRouteDeps {
   events?: EventHub;
   /** Deployment capabilities; gates local-only routes (OpenAI-compatible connect). */
   capabilities?: Capabilities;
+  /** Managed gateway store for the active organization's shared local endpoint. */
+  sharedEndpoints?: SharedEndpointStore;
   /**
    * The agent's absolute on-disk directory, when this deployment is co-located
    * with the files (local profile). Serialized as `dir` on agent payloads so

--- a/packages/host/src/routes/agents.ts
+++ b/packages/host/src/routes/agents.ts
@@ -297,6 +297,24 @@ export async function handleAgents(
       { workspace: authz.workspace, agent: authz.agent },
       provider,
     );
+    if (
+      provider === "openai-compatible" &&
+      deps.gatewayFronted &&
+      deps.sharedEndpoints
+    ) {
+      try {
+        await deps.sharedEndpoints.remove({ ownerOnly: true });
+      } catch (err) {
+        console.error(
+          "[shared-endpoint] owner-only logout cleanup failed:",
+          err,
+        );
+        json(res, 502, {
+          error: err instanceof Error ? err.message : String(err),
+        });
+        return true;
+      }
+    }
     json(res, 200, { ok: true });
     return true;
   }
@@ -478,15 +496,41 @@ export async function handleAgents(
         typeof body.contextWindow === "number" ? body.contextWindow : undefined,
       reasoning:
         typeof body.reasoning === "boolean" ? body.reasoning : undefined,
+      shared: body.shared === true ? true : undefined,
       apiKey: typeof body.apiKey === "string" ? body.apiKey : undefined,
     };
+    let endpointSaved = false;
     try {
       await channel.saveCustomEndpoint(
         { workspace: authz.workspace, agent: authz.agent },
         endpoint,
       );
+      endpointSaved = true;
+      if (deps.gatewayFronted && deps.sharedEndpoints) {
+        if (endpoint.shared === true) {
+          await deps.sharedEndpoints.put({
+            baseUrl: endpoint.baseUrl,
+            model: endpoint.model,
+            ...(endpoint.name !== undefined ? { name: endpoint.name } : {}),
+            ...(endpoint.contextWindow !== undefined
+              ? { contextWindow: endpoint.contextWindow }
+              : {}),
+            ...(endpoint.reasoning !== undefined
+              ? { reasoning: endpoint.reasoning }
+              : {}),
+            ...(endpoint.apiKey !== undefined
+              ? { apiKey: endpoint.apiKey }
+              : {}),
+          });
+        } else {
+          await deps.sharedEndpoints.remove({ ownerOnly: true });
+        }
+      }
       json(res, 200, { ok: true });
     } catch (err) {
+      if (endpointSaved && deps.gatewayFronted && deps.sharedEndpoints) {
+        console.error("[shared-endpoint] save synchronization failed:", err);
+      }
       json(res, 502, {
         error: err instanceof Error ? err.message : String(err),
       });

--- a/packages/host/src/routes/openai-compatible.test.ts
+++ b/packages/host/src/routes/openai-compatible.test.ts
@@ -1,6 +1,10 @@
 import type { Server } from "node:http";
 import type { Capabilities, CustomEndpoint } from "@houston/protocol";
 import { afterEach, expect, test } from "vitest";
+import type {
+  SharedEndpointInput,
+  SharedEndpointStore,
+} from "../credentials/remote-shared-endpoint-store";
 import { MemoryCredentialStore } from "../credentials/store";
 import type { ChannelCtx, RuntimeChannel, TokenVerifier } from "../ports";
 import { type ControlPlaneDeps, createControlPlaneServer } from "../server";
@@ -49,6 +53,23 @@ class SpyChannel implements RuntimeChannel {
   }
 }
 
+class SpySharedEndpointStore implements SharedEndpointStore {
+  puts: SharedEndpointInput[] = [];
+  removals: { ownerOnly: boolean }[] = [];
+  throwMessage: string | null = null;
+  async get() {
+    return null;
+  }
+  async put(endpoint: SharedEndpointInput) {
+    this.puts.push(endpoint);
+    if (this.throwMessage) throw new Error(this.throwMessage);
+  }
+  async remove(opts: { ownerOnly: boolean }) {
+    this.removals.push(opts);
+    if (this.throwMessage) throw new Error(this.throwMessage);
+  }
+}
+
 const baseCaps: Omit<Capabilities, "profile" | "openaiCompatible"> = {
   revealInOs: false,
   terminal: false,
@@ -89,9 +110,11 @@ async function setup(
   base: string;
   agentId: string;
   channel: SpyChannel;
+  sharedEndpoints: SpySharedEndpointStore;
 }> {
   const store = new MemoryWorkspaceStore();
   const channel = new SpyChannel();
+  const sharedEndpoints = new SpySharedEndpointStore();
   const deps: ControlPlaneDeps = {
     verifier,
     store,
@@ -101,6 +124,7 @@ async function setup(
     vfs: new MemoryVfs(),
     capabilities,
     gatewayFronted,
+    sharedEndpoints,
   };
   server = createControlPlaneServer(deps);
   await new Promise<void>((r) => server?.listen(0, "127.0.0.1", () => r()));
@@ -112,7 +136,7 @@ async function setup(
     body: JSON.stringify({ name: "Helper" }),
   });
   const agentId = ((await created.json()) as { id: string }).id;
-  return { base, agentId, channel };
+  return { base, agentId, channel, sharedEndpoints };
 }
 
 const connect = (base: string, agentId: string, body: unknown, who = "alice") =>
@@ -218,6 +242,88 @@ test("managed cloud forwards a valid public HTTPS endpoint to the channel", asyn
     baseUrl: "https://ollama.example.com/v1",
     model: "llama3.1",
   });
+});
+
+test("managed cloud publishes a team-shared endpoint after the runtime save", async () => {
+  const { base, agentId, channel, sharedEndpoints } = await setup(
+    MANAGED_CLOUD_CAPS,
+    true,
+  );
+  const res = await connect(base, agentId, {
+    baseUrl: "https://ollama.example.com/v1",
+    model: "llama3.1",
+    name: "Team Llama",
+    contextWindow: 131_072,
+    reasoning: false,
+    apiKey: "secret",
+    shared: true,
+  });
+
+  expect(res.status).toBe(200);
+  expect(channel.saved[0]?.shared).toBe(true);
+  expect(sharedEndpoints.puts).toEqual([
+    {
+      baseUrl: "https://ollama.example.com/v1",
+      model: "llama3.1",
+      name: "Team Llama",
+      contextWindow: 131_072,
+      reasoning: false,
+      apiKey: "secret",
+    },
+  ]);
+  expect(sharedEndpoints.removals).toEqual([]);
+});
+
+test("managed cloud owner-only removes its prior share when saving unshared", async () => {
+  const { base, agentId, sharedEndpoints } = await setup(
+    MANAGED_CLOUD_CAPS,
+    true,
+  );
+
+  const res = await connect(base, agentId, {
+    baseUrl: "https://ollama.example.com/v1",
+    model: "llama3.1",
+  });
+
+  expect(res.status).toBe(200);
+  expect(sharedEndpoints.puts).toEqual([]);
+  expect(sharedEndpoints.removals).toEqual([{ ownerOnly: true }]);
+});
+
+test("a share failure surfaces after the local runtime save succeeds", async () => {
+  const { base, agentId, channel, sharedEndpoints } = await setup(
+    MANAGED_CLOUD_CAPS,
+    true,
+  );
+  sharedEndpoints.throwMessage = "share gateway unavailable";
+
+  const res = await connect(base, agentId, {
+    baseUrl: "https://ollama.example.com/v1",
+    model: "llama3.1",
+    shared: true,
+  });
+
+  expect(res.status).toBe(502);
+  expect(channel.saved).toHaveLength(1);
+  expect(((await res.json()) as { error: string }).error).toContain(
+    "share gateway unavailable",
+  );
+});
+
+test("openai-compatible logout owner-only removes the caller's share", async () => {
+  const { base, agentId, sharedEndpoints } = await setup(
+    MANAGED_CLOUD_CAPS,
+    true,
+  );
+
+  const res = await fetch(`${base}/agents/${agentId}/credential/forget`, {
+    method: "POST",
+    headers: auth("alice"),
+    body: JSON.stringify({ provider: "openai-compatible" }),
+  });
+
+  expect(res.status).toBe(200);
+  expect(sharedEndpoints.removals).toEqual([{ ownerOnly: true }]);
 });
 
 test("managed cloud rejects localhost with an actionable 400, never forwarded", async () => {

--- a/packages/host/src/server.ts
+++ b/packages/host/src/server.ts
@@ -5,6 +5,7 @@ import {
   type ServerResponse,
 } from "node:http";
 import { type Capabilities, PROTOCOL_VERSION } from "@houston/protocol";
+import type { SharedEndpointStore } from "./credentials/remote-shared-endpoint-store";
 import type {
   Agent,
   UserId,
@@ -87,6 +88,8 @@ export interface ControlPlaneDeps {
   store: WorkspaceStore;
   /** Connect-once: the one subscription credential per workspace, served to its sandboxes. */
   credentials: CredentialStore;
+  /** Managed gateway store for the active organization's shared local endpoint. */
+  sharedEndpoints?: SharedEndpointStore;
   /** Validates per-sandbox HMAC tokens (the sandbox-facing credential endpoint). */
   vault: CredentialVault;
   /**

--- a/packages/host/src/shared-endpoint/sync.test.ts
+++ b/packages/host/src/shared-endpoint/sync.test.ts
@@ -1,0 +1,187 @@
+import { expect, test, vi } from "vitest";
+import type {
+  OrgSharedEndpoint,
+  SharedEndpointStore,
+} from "../credentials/remote-shared-endpoint-store";
+import type { RuntimeEndpoint } from "../ports";
+import { syncSharedEndpoint } from "./sync";
+
+const runtime: RuntimeEndpoint = {
+  baseUrl: "http://runtime.test",
+  token: "runtime-token",
+};
+
+const shared: OrgSharedEndpoint = {
+  baseUrl: "https://relay.example.com/v1",
+  model: "qwen",
+  name: "Team Qwen",
+  contextWindow: 131_072,
+  reasoning: false,
+  apiKey: "secret",
+  ownerAgent: "0123456789abcdef",
+};
+
+function store(value: OrgSharedEndpoint | null): SharedEndpointStore {
+  return {
+    get: async () => value,
+    put: async () => {},
+    remove: async () => {},
+  };
+}
+
+function runtimeFetch(status: unknown) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fetchImpl = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    calls.push({ url: String(input), init });
+    return new Response(
+      JSON.stringify(init?.method === "POST" ? { ok: true } : status),
+      { status: 200 },
+    );
+  }) as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+function writes(calls: { url: string; init?: RequestInit }[]) {
+  return calls.slice(1).map((call) => ({
+    path: new URL(call.url).pathname,
+    body:
+      typeof call.init?.body === "string"
+        ? JSON.parse(call.init.body)
+        : undefined,
+  }));
+}
+
+test.each([
+  {
+    name: "seeds an unconfigured runtime",
+    gateway: shared,
+    status: { configured: false, orgShared: false },
+    expected: [
+      {
+        path: "/providers/openai-compatible",
+        body: {
+          baseUrl: shared.baseUrl,
+          model: shared.model,
+          name: shared.name,
+          contextWindow: shared.contextWindow,
+          reasoning: shared.reasoning,
+          apiKey: shared.apiKey,
+          orgShared: true,
+        },
+      },
+    ],
+  },
+  {
+    // Re-seed even when the visible descriptor is identical: the status never
+    // exposes the api key, and the owner's reconnect rotates the proxyKey
+    // under the SAME tunnel URL — skipping here would strand teammates on the
+    // dead key.
+    name: "re-seeds an equal-looking organization-hydrated endpoint (key may have rotated)",
+    gateway: shared,
+    status: {
+      configured: true,
+      orgShared: true,
+      endpoint: {
+        baseUrl: shared.baseUrl,
+        model: shared.model,
+        name: shared.name,
+        contextWindow: shared.contextWindow,
+        reasoning: shared.reasoning,
+      },
+    },
+    expected: [
+      {
+        path: "/providers/openai-compatible",
+        body: {
+          baseUrl: shared.baseUrl,
+          model: shared.model,
+          name: shared.name,
+          contextWindow: shared.contextWindow,
+          reasoning: shared.reasoning,
+          apiKey: shared.apiKey,
+          orgShared: true,
+        },
+      },
+    ],
+  },
+  {
+    name: "updates a stale organization-hydrated endpoint",
+    gateway: shared,
+    status: {
+      configured: true,
+      orgShared: true,
+      endpoint: { baseUrl: shared.baseUrl, model: "old-model" },
+    },
+    expected: [
+      {
+        path: "/providers/openai-compatible",
+        body: {
+          baseUrl: shared.baseUrl,
+          model: shared.model,
+          name: shared.name,
+          contextWindow: shared.contextWindow,
+          reasoning: shared.reasoning,
+          apiKey: shared.apiKey,
+          orgShared: true,
+        },
+      },
+    ],
+  },
+  {
+    name: "preserves a user's own configured endpoint",
+    gateway: shared,
+    status: {
+      configured: true,
+      orgShared: false,
+      endpoint: { baseUrl: "https://mine.example.com/v1", model: "mine" },
+    },
+    expected: [],
+  },
+  {
+    name: "clears an organization endpoint after the share disappears",
+    gateway: null,
+    status: {
+      configured: true,
+      orgShared: true,
+      endpoint: { baseUrl: shared.baseUrl, model: shared.model },
+    },
+    expected: [{ path: "/auth/openai-compatible/logout", body: undefined }],
+  },
+  {
+    name: "does nothing without a share or organization marker",
+    gateway: null,
+    status: { configured: false, orgShared: false },
+    expected: [],
+  },
+])("$name", async ({ gateway, status, expected }) => {
+  const { calls, fetchImpl } = runtimeFetch(status);
+
+  await syncSharedEndpoint({
+    store: store(gateway),
+    runtime,
+    fetchImpl,
+    log: vi.fn(),
+  });
+
+  expect(calls[0]?.url).toBe("http://runtime.test/providers/openai-compatible");
+  expect(writes(calls)).toEqual(expected);
+});
+
+test("sync failures are logged and never reject runtime startup", async () => {
+  const log = vi.fn();
+  const failingStore: SharedEndpointStore = {
+    get: async () => {
+      throw new Error("gateway unavailable");
+    },
+    put: async () => {},
+    remove: async () => {},
+  };
+
+  await expect(
+    syncSharedEndpoint({ store: failingStore, runtime, log }),
+  ).resolves.toBeUndefined();
+  expect(log).toHaveBeenCalledWith(
+    "[shared-endpoint] runtime sync failed (continuing):",
+    expect.objectContaining({ message: "gateway unavailable" }),
+  );
+});

--- a/packages/host/src/shared-endpoint/sync.ts
+++ b/packages/host/src/shared-endpoint/sync.ts
@@ -1,0 +1,119 @@
+import type {
+  OrgSharedEndpoint,
+  SharedEndpointStore,
+} from "../credentials/remote-shared-endpoint-store";
+import type { RuntimeEndpoint } from "../ports";
+
+interface RuntimeEndpointDescriptor {
+  baseUrl: string;
+  model: string;
+  name?: string;
+  contextWindow?: number;
+  reasoning?: boolean;
+}
+
+interface RuntimeSharedEndpointStatus {
+  configured: boolean;
+  orgShared: boolean;
+  endpoint?: RuntimeEndpointDescriptor;
+}
+
+interface SyncSharedEndpointOptions {
+  store: SharedEndpointStore;
+  runtime: RuntimeEndpoint;
+  fetchImpl?: typeof fetch;
+  log?: (message: string, error: unknown) => void;
+}
+
+function authHeaders(runtime: RuntimeEndpoint): Record<string, string> {
+  return { Authorization: `Bearer ${runtime.token}` };
+}
+
+async function runtimeStatus(
+  runtime: RuntimeEndpoint,
+  fetchImpl: typeof fetch,
+): Promise<RuntimeSharedEndpointStatus> {
+  const res = await fetchImpl(
+    `${runtime.baseUrl}/providers/openai-compatible`,
+    { headers: authHeaders(runtime) },
+  );
+  if (!res.ok) {
+    throw new Error(`runtime shared endpoint status failed (${res.status})`);
+  }
+  return (await res.json()) as RuntimeSharedEndpointStatus;
+}
+
+async function seedRuntime(
+  runtime: RuntimeEndpoint,
+  shared: OrgSharedEndpoint,
+  fetchImpl: typeof fetch,
+): Promise<void> {
+  const res = await fetchImpl(
+    `${runtime.baseUrl}/providers/openai-compatible`,
+    {
+      method: "POST",
+      headers: {
+        ...authHeaders(runtime),
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({
+        baseUrl: shared.baseUrl,
+        model: shared.model,
+        ...(shared.name !== null ? { name: shared.name } : {}),
+        ...(shared.contextWindow !== null
+          ? { contextWindow: shared.contextWindow }
+          : {}),
+        reasoning: shared.reasoning,
+        apiKey: shared.apiKey,
+        orgShared: true,
+      }),
+    },
+  );
+  if (!res.ok)
+    throw new Error(`runtime shared endpoint seed failed (${res.status})`);
+}
+
+async function clearRuntime(
+  runtime: RuntimeEndpoint,
+  fetchImpl: typeof fetch,
+): Promise<void> {
+  const res = await fetchImpl(
+    `${runtime.baseUrl}/auth/openai-compatible/logout`,
+    {
+      method: "POST",
+      headers: authHeaders(runtime),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`runtime shared endpoint clear failed (${res.status})`);
+  }
+}
+
+/** Synchronize one freshly spawned runtime without making pod startup fatal. */
+export async function syncSharedEndpoint(
+  opts: SyncSharedEndpointOptions,
+): Promise<void> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  try {
+    const [shared, status] = await Promise.all([
+      opts.store.get(),
+      runtimeStatus(opts.runtime, fetchImpl),
+    ]);
+    if (!shared) {
+      if (status.orgShared) await clearRuntime(opts.runtime, fetchImpl);
+      return;
+    }
+    if (status.configured && !status.orgShared) return;
+    // Always re-seed an org-hydrated endpoint, even when the visible
+    // descriptor is identical: the status deliberately never exposes the api
+    // key, and the owner's guided RECONNECT mints a fresh proxyKey under the
+    // SAME tunnel URL — a descriptor-equality skip would strand teammates on
+    // the dead key. One small write per runtime spawn is the cheap side.
+    await seedRuntime(opts.runtime, shared, fetchImpl);
+  } catch (error) {
+    (opts.log ?? console.error)(
+      "[shared-endpoint] runtime sync failed (continuing):",
+      error,
+    );
+  }
+}

--- a/packages/protocol/src/conversation.ts
+++ b/packages/protocol/src/conversation.ts
@@ -104,6 +104,11 @@ export interface CustomEndpoint {
   contextWindow?: number;
   /** Whether to send `reasoning_effort` (only set for a reasoning-capable model). */
   reasoning?: boolean;
+  /**
+   * Share this endpoint with the active organization. Only meaningful when
+   * saving in managed cloud; ignored by desktop and self-hosted runtimes.
+   */
+  shared?: boolean;
   /** Optional API key; blank for keyless servers. */
   apiKey?: string;
 }

--- a/packages/runtime/src/ai/openai-compatible-persistence.test.ts
+++ b/packages/runtime/src/ai/openai-compatible-persistence.test.ts
@@ -1,0 +1,55 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
+
+const previousDataDir = process.env.HOUSTON_DATA_DIR;
+
+afterEach(() => {
+  if (previousDataDir === undefined) delete process.env.HOUSTON_DATA_DIR;
+  else process.env.HOUSTON_DATA_DIR = previousDataDir;
+  vi.resetModules();
+});
+
+test("the org-shared marker persists with the endpoint and clears with it", async () => {
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-shared-endpoint-"));
+  process.env.HOUSTON_DATA_DIR = dataDir;
+  vi.resetModules();
+  const {
+    clearCustomEndpointConfig,
+    customEndpointStatus,
+    setCustomEndpointConfig,
+  } = await import("./openai-compatible");
+
+  setCustomEndpointConfig({
+    baseUrl: "https://local.example.com/v1",
+    model: "qwen",
+    name: "Qwen",
+    reasoning: true,
+    orgShared: true,
+  });
+
+  expect(customEndpointStatus()).toEqual({
+    configured: true,
+    orgShared: true,
+    endpoint: {
+      baseUrl: "https://local.example.com/v1",
+      model: "qwen",
+      name: "Qwen",
+      reasoning: true,
+    },
+  });
+  expect(
+    JSON.parse(readFileSync(join(dataDir, "custom-endpoint.json"), "utf8")),
+  ).toMatchObject({ orgShared: true });
+
+  clearCustomEndpointConfig();
+
+  expect(customEndpointStatus()).toEqual({
+    configured: false,
+    orgShared: false,
+  });
+  expect(
+    JSON.parse(readFileSync(join(dataDir, "custom-endpoint.json"), "utf8")),
+  ).toEqual({});
+});

--- a/packages/runtime/src/ai/openai-compatible.ts
+++ b/packages/runtime/src/ai/openai-compatible.ts
@@ -29,6 +29,7 @@ interface StoredEndpoint {
   name?: string;
   contextWindow?: number;
   reasoning?: boolean;
+  orgShared?: boolean;
 }
 
 const endpointFileIn = (dataDir: string) =>
@@ -60,6 +61,35 @@ function save(e: StoredEndpoint): void {
 export function customEndpointConfigured(dataDir?: string): boolean {
   const e = load(dataDir);
   return !!(e.baseUrl && e.model);
+}
+
+export interface CustomEndpointStatus {
+  configured: boolean;
+  orgShared: boolean;
+  endpoint?: OpenAiCompatibleEndpoint;
+}
+
+/** Internal host sync status. Never includes the endpoint API key. */
+export function customEndpointStatus(dataDir?: string): CustomEndpointStatus {
+  const endpoint = load(dataDir);
+  if (!endpoint.baseUrl || !endpoint.model) {
+    return { configured: false, orgShared: false };
+  }
+  return {
+    configured: true,
+    orgShared: endpoint.orgShared === true,
+    endpoint: {
+      baseUrl: endpoint.baseUrl,
+      model: endpoint.model,
+      ...(endpoint.name !== undefined ? { name: endpoint.name } : {}),
+      ...(endpoint.contextWindow !== undefined
+        ? { contextWindow: endpoint.contextWindow }
+        : {}),
+      ...(endpoint.reasoning !== undefined
+        ? { reasoning: endpoint.reasoning }
+        : {}),
+    },
+  };
 }
 
 /** The configured model id, or "" when unset. */
@@ -161,6 +191,8 @@ export interface CustomEndpointInput {
   name?: string;
   contextWindow?: number;
   reasoning?: boolean;
+  /** Internal marker for endpoints hydrated from the organization share. */
+  orgShared?: boolean;
 }
 
 /**
@@ -191,6 +223,7 @@ export function setCustomEndpointConfig(input: CustomEndpointInput): void {
         ? Math.floor(input.contextWindow)
         : undefined,
     reasoning: input.reasoning ?? undefined,
+    orgShared: input.orgShared === true ? true : undefined,
   });
 }
 

--- a/packages/runtime/src/transport/provider-routes.test.ts
+++ b/packages/runtime/src/transport/provider-routes.test.ts
@@ -154,3 +154,59 @@ test("GET /providers hydrates served credentials before listing providers", asyn
     vi.resetModules();
   }
 });
+
+test("openai-compatible route round-trips the org marker without returning its key", async () => {
+  const prevDataDir = process.env.HOUSTON_DATA_DIR;
+  const dataDir = mkdtempSync(join(tmpdir(), "houston-shared-route-"));
+  process.env.HOUSTON_DATA_DIR = dataDir;
+
+  try {
+    vi.resetModules();
+    const { handleProviderRoute } = await import("./provider-routes");
+    const request = async (method: string, path: string, body?: unknown) => {
+      const { res, out } = mockRes();
+      await handleProviderRoute({
+        method,
+        path,
+        url: new URL(`http://runtime.test${path}`),
+        req:
+          body === undefined
+            ? ({ headers: {} } as IncomingMessage)
+            : mockPostReq(body),
+        res,
+      });
+      return out;
+    };
+
+    expect(
+      (
+        await request("POST", "/providers/openai-compatible", {
+          baseUrl: "https://relay.example.com/v1",
+          model: "qwen",
+          apiKey: "never-return-this",
+          orgShared: true,
+        })
+      ).status,
+    ).toBe(200);
+    const configured = await request("GET", "/providers/openai-compatible");
+    expect(configured.body).toEqual({
+      configured: true,
+      orgShared: true,
+      endpoint: {
+        baseUrl: "https://relay.example.com/v1",
+        model: "qwen",
+      },
+    });
+    expect(JSON.stringify(configured.body)).not.toContain("never-return-this");
+
+    expect(
+      (await request("POST", "/auth/openai-compatible/logout")).status,
+    ).toBe(200);
+    expect((await request("GET", "/providers/openai-compatible")).body).toEqual(
+      { configured: false, orgShared: false },
+    );
+  } finally {
+    restoreEnv("HOUSTON_DATA_DIR", prevDataDir);
+    vi.resetModules();
+  }
+});

--- a/packages/runtime/src/transport/provider-routes.ts
+++ b/packages/runtime/src/transport/provider-routes.ts
@@ -1,4 +1,5 @@
 import { parseClaudeOAuthEnvelope } from "@houston/runtime-client";
+import { customEndpointStatus } from "../ai/openai-compatible";
 import {
   claimActiveProvider,
   listProviders,
@@ -75,6 +76,10 @@ export async function handleProviderRoute(ctx: RouteContext): Promise<boolean> {
     await handleOpenAiCompatible(ctx);
     return true;
   }
+  if (method === "GET" && path === "/providers/openai-compatible") {
+    json(res, 200, customEndpointStatus());
+    return true;
+  }
   if (method === "POST" && path === "/auth/anthropic/oauth-credential") {
     await handleClaudeOAuthCredential(ctx);
     return true;
@@ -108,6 +113,7 @@ async function handleOpenAiCompatible(ctx: RouteContext) {
         typeof body.contextWindow === "number" ? body.contextWindow : undefined,
       reasoning:
         typeof body.reasoning === "boolean" ? body.reasoning : undefined,
+      orgShared: body.orgShared === true ? true : undefined,
       apiKey: typeof body.apiKey === "string" ? body.apiKey : undefined,
     });
     json(ctx.res, 200, { ok: true });

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1766,6 +1766,11 @@ export interface CustomEndpoint {
   name?: string;
   contextWindow?: number;
   reasoning?: boolean;
+  /**
+   * Share this endpoint with the active organization. Only meaningful when
+   * saving in managed cloud; ignored elsewhere.
+   */
+  shared?: boolean;
   apiKey?: string;
 }
 


### PR DESCRIPTION
One team member connects their local LLM (LM Studio / Ollama / Jan, through the tunnel relay) and flips **Share with my team** — every teammate's cloud agent can then use that model. Companion to gethouston/cloud#109, which adds the gateway's org-shared endpoint registry (merge that first; without it the pod host's share calls 404 and surface as save errors).

## How it works

- **Owner side**: saving an openai-compatible endpoint with `shared: true` (new optional field on `CustomEndpoint`) makes the pod host PUT the descriptor + tunnel proxyKey to the gateway registry (`RemoteSharedEndpointStore`, same pod-token pattern as `RemoteCredentialStore`). Saving unshared or logging the provider out DELETEs with `x-houston-owner-only: 1`, so an owner can never clear a teammate's newer share.
- **Teammate side**: `syncSharedEndpoint` runs once per runtime spawn — and pods respawn on every wake-from-idle, so that's also the freshness/revocation mechanism. It seeds unconfigured runtimes with the shared endpoint (marked `orgShared` internally), **always re-seeds** org-hydrated ones (the status never exposes the api key, and a reconnect rotates the proxyKey under the same tunnel URL — a descriptor-equality skip would strand teammates on a dead key), clears them when the share disappears, and never touches an endpoint the user configured themselves. Sync failures log and never break pod startup.
- **Runtime**: `custom-endpoint.json` carries the internal `orgShared` marker; new internal `GET /providers/openai-compatible` serves `{configured, orgShared, endpoint}` — never the key.
- **UI**: `ShareEndpointToggle` in both the guided pick screen and the manual form, **team workspaces only**, with explicit consent copy, en/es/pt.

## Notes

- The tunnel/relay needs zero changes: the tunnel URL is public HTTPS gated by the proxyKey bearer; only tunnel *registration* is bound to the owner.
- Availability follows the owner's machine: teammates get provider errors while the owner is offline. Richer presence is future work.
- Desktop/self-host paths are untouched — the store is only constructed under `HOUSTON_MANAGED_CLOUD` with the credential-gateway env.

## Tests

Host 823 ✓ (new: store client, sync state table incl. the key-rotation re-seed case, share/unshare route behavior, launcher afterSpawn lifecycle) · runtime 604 ✓ (marker persistence) · web 184 ✓ · app 1,414 ✓ · workspace typecheck + biome ✓. The one host flake (skills-remote hitting live skills.sh rate limits under repeated full-suite runs) passes standalone and is unrelated.