### PR TITLE
fix(onboarding): clear the pending flag synchronously so finishing doesn't restart the flow

### DIFF
--- a/app/src/hooks/use-onboarding-pending.ts
+++ b/app/src/hooks/use-onboarding-pending.ts
@@ -66,13 +66,23 @@ export function useOnboardingPending(): OnboardingPendingState {
   // Stable across renders (react-query memoizes `mutateAsync`), so the consumer
   // can safely list `markPending` in an on-mount effect's deps without the
   // effect re-firing on mutation status churn.
+  //
+  // Both writers flip the query cache SYNCHRONOUSLY before the persisted write:
+  // `finishOnboarding` drops `tutorialActive` in the same event handler, and
+  // App.tsx re-renders on that store update before any mutation microtask runs.
+  // If the cache still said `true` in that render, App would remount the
+  // orchestrator via its `onboardingPending` branch, whose mount effect re-pins
+  // the tutorial and re-marks the flag — restarting onboarding from the first
+  // step on every finish. The `onSuccess` write is kept as the settled value.
   const markPending = useCallback(async () => {
+    qc.setQueryData<boolean>(queryKey, true);
     await mutateAsync(true);
-  }, [mutateAsync]);
+  }, [mutateAsync, qc]);
 
   const clearPending = useCallback(async () => {
+    qc.setQueryData<boolean>(queryKey, false);
     await mutateAsync(false);
-  }, [mutateAsync]);
+  }, [mutateAsync, qc]);
 
   return {
     isPending: query.data === true,


### PR DESCRIPTION
## Problem

Finishing (or skipping) the first-run onboarding restarted it from the first step, every time. The durable `onboarding_pending` resume flag was also left set to `1`, so every app relaunch re-entered onboarding as well.

## Root cause

`finishOnboarding` drops `tutorialActive` synchronously in the click handler, and App.tsx re-renders on that zustand update **before any mutation microtask runs**. `clearPending` only updated the react-query cache in the mutation's `onSuccess` (async), so that render still saw `onboardingPending === true` and remounted `PersonalAssistantOnboarding` through the `(firstRun || onboardingPending)` branch — a different tree position, so a fresh mount. Its mount effect then re-pinned `tutorialActive` and re-marked the flag: back to the first step, flag re-armed.

Diagnosed live against the hosted gateway: gateway logs show the whole onboarding flow succeeding server-side (legal/timezone preference PUTs 200, agent created, first message accepted) while the client bounced back to `connect` with zero client-side errors, and the webview localStorage held `houston.pref.onboarding_pending = "1"` after "finishing".

## Fix

`markPending`/`clearPending` now flip the query cache synchronously before the persisted write, so the render that drops `tutorialActive` already sees the settled value. `onSuccess` still writes the confirmed value.

## Testing

- `pnpm check` (Biome) clean, `pnpm tsgo --noEmit` in `app/` passes.
- No automated test: the race is render-ordering between a zustand flush and a react-query mutation; `app/tests` has no React renderer harness to express it.
- Manual end-to-end pass (finish onboarding with the fix, confirm the shell lands and the flag clears on relaunch) still to be run in the dev-desktop-against-gateway setup where the loop reproduced.