### PR TITLE
fix(sdk)+ios: URLSearchParams shim, SDK log routing, ship-readiness plist keys, iOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,7 @@ jobs:
         working-directory: mobile/ios
         run: |
           set -o pipefail
+          xcodebuild -version
           # Pick an available iPhone simulator dynamically; device names vary by
           # Xcode image, so hardcoding one would break on image bumps.
           DEVICE=$(xcrun simctl list devices available \
@@ -204,22 +205,14 @@ jobs:
             exit 1
           fi
           echo "Using simulator: $DEVICE"
-          if command -v xcpretty >/dev/null 2>&1; then
-            xcodebuild test \
-              -project Houston.xcodeproj \
-              -scheme Houston \
-              -destination "platform=iOS Simulator,name=$DEVICE" \
-              -resultBundlePath "$RUNNER_TEMP/HoustonTests.xcresult" \
-              CODE_SIGNING_ALLOWED=NO \
-              | xcpretty
-          else
-            xcodebuild test \
-              -project Houston.xcodeproj \
-              -scheme Houston \
-              -destination "platform=iOS Simulator,name=$DEVICE" \
-              -resultBundlePath "$RUNNER_TEMP/HoustonTests.xcresult" \
-              CODE_SIGNING_ALLOWED=NO
-          fi
+          # Plain xcodebuild output on purpose: xcpretty swallows the compiler
+          # error lines, which makes a red run undiagnosable from the log.
+          xcodebuild test \
+            -project Houston.xcodeproj \
+            -scheme Houston \
+            -destination "platform=iOS Simulator,name=$DEVICE" \
+            -resultBundlePath "$RUNNER_TEMP/HoustonTests.xcresult" \
+            CODE_SIGNING_ALLOWED=NO
 
       - name: Upload xcresult bundle
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,6 +182,16 @@ jobs:
       - name: Build design tokens
         run: pnpm --filter @houston/design-tokens build
 
+      - name: Select latest Xcode
+        # The image default (Xcode 16.4 / Swift 6.1) crashes in SILGen on the
+        # IsolatedDefaultValues pattern the app uses; the app targets the
+        # Xcode 26 toolchain it is developed against.
+        run: |
+          XCODE=$(ls -d /Applications/Xcode_*.app | sort -V | tail -1)
+          echo "Selecting $XCODE"
+          sudo xcode-select -s "$XCODE"
+          xcodebuild -version
+
       - name: Install XcodeGen
         run: brew install xcodegen
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,30 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      ios: ${{ steps.filter.outputs.ios }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Filter paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            ios:
+              - 'mobile/ios/**'
+              - 'packages/sdk/**'
+              - 'packages/design-tokens/**'
+              - 'packages/runtime-client/**'
+              - 'packages/protocol/**'
+              - 'pnpm-lock.yaml'
+              - '.github/workflows/ci.yml'
+
   checks:
     name: TS checks (lint · typecheck · contract tests)
     runs-on: ubuntu-latest
@@ -129,3 +153,78 @@ jobs:
 
       - name: Unit tests (app)
         run: pnpm --filter houston-app test
+
+  ios:
+    name: iOS (xcodegen + xcodebuild test)
+    needs: changes
+    if: ${{ needs.changes.outputs.ios == 'true' }}
+    runs-on: macos-15
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Build SDK bridge
+        run: pnpm --filter @houston/sdk build:bridge
+
+      - name: Build design tokens
+        run: pnpm --filter @houston/design-tokens build
+
+      - name: Install XcodeGen
+        run: brew install xcodegen
+
+      - name: Generate Xcode project
+        run: xcodegen generate
+        working-directory: mobile/ios
+
+      - name: Run tests (xcodebuild)
+        working-directory: mobile/ios
+        run: |
+          set -o pipefail
+          # Pick an available iPhone simulator dynamically; device names vary by
+          # Xcode image, so hardcoding one would break on image bumps.
+          DEVICE=$(xcrun simctl list devices available \
+            | grep -E "iPhone" \
+            | head -1 \
+            | sed -E 's/^ *//; s/ \(.*//')
+          if [ -z "$DEVICE" ]; then
+            echo "error: no available iPhone simulator found." >&2
+            exit 1
+          fi
+          echo "Using simulator: $DEVICE"
+          if command -v xcpretty >/dev/null 2>&1; then
+            xcodebuild test \
+              -project Houston.xcodeproj \
+              -scheme Houston \
+              -destination "platform=iOS Simulator,name=$DEVICE" \
+              -resultBundlePath "$RUNNER_TEMP/HoustonTests.xcresult" \
+              CODE_SIGNING_ALLOWED=NO \
+              | xcpretty
+          else
+            xcodebuild test \
+              -project Houston.xcodeproj \
+              -scheme Houston \
+              -destination "platform=iOS Simulator,name=$DEVICE" \
+              -resultBundlePath "$RUNNER_TEMP/HoustonTests.xcresult" \
+              CODE_SIGNING_ALLOWED=NO
+          fi
+
+      - name: Upload xcresult bundle
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-xcresult
+          path: ${{ runner.temp }}/HoustonTests.xcresult
+          retention-days: 14

--- a/mobile/PARITY-SETTINGS.md
+++ b/mobile/PARITY-SETTINGS.md
@@ -17,6 +17,11 @@
 
 ## 1. Settings surface (desktop: SettingsView/SettingsIndex)
 
+> **SUPERSEDED for iOS by PARITY-CHAT §7 (founder directive 2026-07-06):** the iOS Settings
+> surface is pared to **Account + Appearance only**. The ✅ marks below describe the pre-cut
+> port and stay as the reference for the desktop rows; every other row (workspace name,
+> language, contexts, report bug, danger zone, version footer) is NOT shipped on iOS today.
+
 Header "Settings" (`settings:title`); subtitle "Manage your workspace and account."
 Rows/groups in desktop order (iOS ports all marked ✅):
 

--- a/mobile/ios/Houston/Core/Bridge/BridgeMessages.swift
+++ b/mobile/ios/Houston/Core/Bridge/BridgeMessages.swift
@@ -4,11 +4,12 @@ import Foundation
 /// — the machine-readable form of `packages/sdk/BRIDGE.md`.
 ///
 /// Two halves: ``BridgeInbound`` (host → SDK, what we *produce*) and
-/// ``BridgeOutbound`` (SDK → host, what we *consume*). Only the SDK-level members
-/// are modeled here. The native-port members (`fetch/*`, `storage/*`, `log`) are
-/// the ports agent's; ``SdkClient`` peeks their `kind` and routes the raw string
-/// through ``SdkPortRouter`` without decoding them, so this transport layer stays
-/// agnostic to how the host backs fetch and storage.
+/// ``BridgeOutbound`` (SDK → host, what we *consume*). The SDK-level members plus
+/// the one-way `log` diagnostic (§9.3) are modeled here. The native-port members
+/// (`fetch/*`, `storage/*`) are the ports agent's; ``SdkClient`` peeks their
+/// `kind` and routes the raw string through ``SdkPortRouter`` without decoding
+/// them, so this transport layer stays agnostic to how the host backs fetch and
+/// storage.
 ///
 /// Versioning is additive (BRIDGE.md §4): an unknown outbound `kind` decodes to
 /// ``BridgeOutbound/unknown(kind:)`` and is treated as inert, never a crash.
@@ -96,9 +97,9 @@ enum BridgeCodecError: Error { case notUTF8 }
 
 // MARK: - Outbound (SDK → host)
 
-/// SDK → host messages the host consumes. The SDK-level members only; port
-/// members are routed by `kind` before this decodes. An unrecognized `kind`
-/// (a future member, or a port message with no router) is inert `.unknown`.
+/// SDK → host messages the host consumes: the SDK-level members plus the `log`
+/// diagnostic (§9.3). The `fetch/*`/`storage/*` port members are routed by `kind`
+/// before this decodes; an unrecognized `kind` is inert `.unknown`.
 enum BridgeOutbound: Equatable {
   case ready(v: Int)
   case result(CommandResult)
@@ -107,12 +108,14 @@ enum BridgeOutbound: Equatable {
   case event(SdkEventPayload)
   case fatal(reason: String, message: String)
   case error(message: String, detail: JSONValue?)
+  case log(SdkLogPayload)
   case unknown(kind: String)
 }
 
 extension BridgeOutbound: Codable {
   private enum CodingKeys: String, CodingKey {
     case kind, v, result, sub, scope, snapshot, event, reason, message, detail
+    case level, fields
   }
 
   func encode(to encoder: Encoder) throws {
@@ -145,6 +148,10 @@ extension BridgeOutbound: Codable {
       try c.encode("error", forKey: .kind)
       try c.encode(message, forKey: .message)
       try c.encodeIfPresent(detail, forKey: .detail)
+    case let .log(payload):
+      try c.encode("log", forKey: .kind)
+      // Level/message/fields are flat siblings of `kind` on the frame (§9.3).
+      try payload.encode(to: encoder)
     case let .unknown(kind):
       try c.encode(kind, forKey: .kind)
     }
@@ -178,6 +185,10 @@ extension BridgeOutbound: Codable {
       self = .error(
         message: try container.decode(String.self, forKey: .message),
         detail: try container.decodeIfPresent(JSONValue.self, forKey: .detail))
+    case "log":
+      // Flat frame (§9.3): payload reads level/message/fields off this decoder,
+      // so a `log` line is dispatched, never dropped into inert `.unknown`.
+      self = .log(try SdkLogPayload(from: decoder))
     default:
       self = .unknown(kind: kind)
     }
@@ -185,5 +196,5 @@ extension BridgeOutbound: Codable {
 }
 
 /// Cheap first-pass parse: read only `kind` so ``SdkClient`` can route port
-/// messages (`fetch/*`, `storage/*`, `log`) without decoding their bodies.
+/// messages (`fetch/*`, `storage/*`) without decoding their bodies.
 struct BridgeKindPeek: Decodable { let kind: String }

--- a/mobile/ios/Houston/Core/Bridge/SdkClient+Outbound.swift
+++ b/mobile/ios/Houston/Core/Bridge/SdkClient+Outbound.swift
@@ -1,4 +1,9 @@
 import Foundation
+import os
+
+/// SDK diagnostics arrive on the `log` frame (BRIDGE.md §9.3). They land under
+/// the SDK subsystem, category `sdk`, beside the client/transport loggers.
+private let sdkDiagnostics = Logger(subsystem: "ai.gethouston.sdk", category: "sdk")
 
 /// The SDK → host receive path: offer native-port traffic to the ``portHandler``,
 /// decode the rest as ``BridgeOutbound``, and dispatch it. Runs on the main
@@ -6,8 +11,9 @@ import Foundation
 extension SdkClient {
   /// Entry point the transport calls for each outbound message string.
   func receiveOutbound(_ raw: String) {
-    // Native-port frames (`fetch/*`, `storage/*`) are claimed by the handler; a
-    // `log` frame the handler declines falls through to the inert branch below.
+    // Native-port frames (`fetch/*`, `storage/*`) are claimed by the handler.
+    // Everything else, including the SDK `log` diagnostic frame (§9.3), decodes
+    // as ``BridgeOutbound`` and is dispatched below.
     if portHandler?(raw) == true { return }
     guard let data = raw.data(using: .utf8) else {
       log.error("outbound message was not UTF-8")
@@ -42,9 +48,25 @@ extension SdkClient {
     case let .error(message, detail):
       log.error("protocol error: \(message, privacy: .public)")
       emit(.protocolError(message: message, detail: detail))
+    case let .log(payload):
+      dispatchLog(payload)
     case let .unknown(kind):
       // Inert per BRIDGE.md §4 — a future/unmodeled member, ignored not crashed.
       log.debug("ignoring inert outbound kind: \(kind, privacy: .public)")
+    }
+  }
+
+  /// Route an SDK diagnostic line (BRIDGE.md §9.3) to os.Logger. One-way: no
+  /// reply and no JS re-entry, just a cheap main-actor log call. An unknown level
+  /// falls through to `.info` so a future severity never drops the line. Message
+  /// text uses os.Logger's default redaction, like the `console` polyfill, since
+  /// a diagnostic line may carry user content.
+  private func dispatchLog(_ payload: SdkLogPayload) {
+    switch payload.level {
+    case "debug": sdkDiagnostics.debug("\(payload.message)")
+    case "warn": sdkDiagnostics.warning("\(payload.message)")
+    case "error": sdkDiagnostics.error("\(payload.message)")
+    default: sdkDiagnostics.info("\(payload.message)")
     }
   }
 

--- a/mobile/ios/Houston/Core/Bridge/SdkLogPayload.swift
+++ b/mobile/ios/Houston/Core/Bridge/SdkLogPayload.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// The `{ level, message, fields? }` body of a `log` diagnostic frame
+/// (BRIDGE.md §9.3): a one-way SDK to host line the host routes to its native
+/// log. Decoding is forward-compatible like the rest of the wire (BRIDGE.md §4):
+/// an absent `level`/`message`, an unknown `level` string, or extra keys never
+/// fail, so a newer SDK never has a diagnostic silently dropped.
+struct SdkLogPayload: Equatable {
+  /// SDK severity: `debug` | `info` | `warn` | `error` today. An unrecognized
+  /// value is preserved here and maps to `info` at dispatch, never dropped.
+  var level: String
+  /// The human-readable diagnostic text.
+  var message: String
+  /// Optional structured context the SDK attached to the line.
+  var fields: JSONValue?
+}
+
+extension SdkLogPayload: Codable {
+  private enum CodingKeys: String, CodingKey { case level, message, fields }
+
+  init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    level = try c.decodeIfPresent(String.self, forKey: .level) ?? "info"
+    message = try c.decodeIfPresent(String.self, forKey: .message) ?? ""
+    fields = try c.decodeIfPresent(JSONValue.self, forKey: .fields)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(level, forKey: .level)
+    try c.encode(message, forKey: .message)
+    try c.encodeIfPresent(fields, forKey: .fields)
+  }
+}

--- a/mobile/ios/HoustonTests/SdkClient/BridgeMessagesTests.swift
+++ b/mobile/ios/HoustonTests/SdkClient/BridgeMessagesTests.swift
@@ -94,7 +94,56 @@ final class BridgeMessagesTests: XCTestCase {
   func testUnknownKindIsInert() throws {
     // A future member (or an unrouted port frame) decodes to `.unknown`, never a throw.
     XCTAssertEqual(try decodeOutbound(#"{"kind":"fetch/start","id":"f1"}"#), .unknown(kind: "fetch/start"))
-    XCTAssertEqual(try decodeOutbound(#"{"kind":"log","level":"info","message":"hi"}"#), .unknown(kind: "log"))
+    XCTAssertEqual(try decodeOutbound(#"{"kind":"future/frame"}"#), .unknown(kind: "future/frame"))
+  }
+
+  // MARK: Log frame (§9.3)
+
+  private enum LogTestError: Error { case notLog }
+
+  private func logPayload(_ raw: String) throws -> SdkLogPayload {
+    // A log frame must decode to `.log`, never fall through to inert `.unknown`.
+    let decoded = try decodeOutbound(raw)
+    guard case let .log(payload) = decoded else {
+      XCTFail("expected .log, got \(decoded)")
+      throw LogTestError.notLog
+    }
+    return payload
+  }
+
+  func testDecodesLogFrameEachLevel() throws {
+    for level in ["debug", "info", "warn", "error"] {
+      let payload = try logPayload(#"{"kind":"log","level":"\#(level)","message":"diag"}"#)
+      XCTAssertEqual(payload.level, level)
+      XCTAssertEqual(payload.message, "diag")
+      XCTAssertNil(payload.fields)
+    }
+  }
+
+  func testDecodesLogFrameWithFields() throws {
+    let payload = try logPayload(
+      #"{"kind":"log","level":"error","message":"boom","fields":{"code":500}}"#)
+    XCTAssertEqual(payload.fields, .object(["code": .int(500)]))
+  }
+
+  func testLogFrameToleratesUnknownLevel() throws {
+    // A future severity is preserved verbatim (mapped to `.info` only at dispatch),
+    // and crucially still decodes as `.log`, not `.unknown`.
+    let payload = try logPayload(#"{"kind":"log","level":"trace","message":"hmm"}"#)
+    XCTAssertEqual(payload.level, "trace")
+  }
+
+  func testLogFrameToleratesMissingFields() throws {
+    // Forward-compatible: absent level/message default rather than throwing.
+    let payload = try logPayload(#"{"kind":"log"}"#)
+    XCTAssertEqual(payload.level, "info")
+    XCTAssertEqual(payload.message, "")
+  }
+
+  func testLogFrameIsNotUnknown() throws {
+    // Guards the regression: `log` used to fall to `.unknown(kind:"log")` and drop.
+    let decoded = try decodeOutbound(#"{"kind":"log","level":"info","message":"hi"}"#)
+    XCTAssertNotEqual(decoded, .unknown(kind: "log"))
   }
 
   func testOutboundRoundTrips() throws {
@@ -103,6 +152,7 @@ final class BridgeMessagesTests: XCTestCase {
       .result(CommandResult(id: "c1", ok: true, value: .string("v"), error: nil)),
       .snapshot(sub: "s1", scope: "agents", snapshot: .array([])),
       .fatal(reason: "tokenExpired", message: "gone"),
+      .log(SdkLogPayload(level: "warn", message: "slow", fields: .object(["ms": .int(12)]))),
     ]
     for value in cases {
       XCTAssertEqual(try decodeOutbound(BridgeTestJSON.encode(value)), value)

--- a/mobile/ios/project.yml
+++ b/mobile/ios/project.yml
@@ -66,6 +66,13 @@ targets:
           - en
           - es
           - pt
+        # Version comes from the build settings above; without these XcodeGen
+        # writes literal 1.0/1 and the target's MARKETING_VERSION is ignored.
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
+        # HTTPS-only standard crypto: exempt, so TestFlight uploads skip the
+        # per-build export-compliance question.
+        ITSAppUsesNonExemptEncryption: false
         UILaunchScreen: {}
         # OAuth callback deep link: Supabase redirects to houston://auth-callback.
         CFBundleURLTypes:

--- a/packages/sdk/BRIDGE.md
+++ b/packages/sdk/BRIDGE.md
@@ -694,6 +694,8 @@ NOT polyfill them, but MAY:
 - `AbortController` / `AbortSignal` — stream cancellation.
 - `TextEncoder` / `TextDecoder` — UTF-8 SSE decoding (`TextDecoder` with
   `{ stream: true }`).
+- `URLSearchParams` — `startLogin` assembles the `providers/login` query string
+  (`deviceAuth` / `enterpriseDomain`) with it.
 
 **Optional** (used if present, gracefully degraded if not):
 

--- a/packages/sdk/src/bridge/shims.ts
+++ b/packages/sdk/src/bridge/shims.ts
@@ -10,6 +10,8 @@
  *  - `AbortController` / `AbortSignal` — the resume/turn/observe/global-events
  *    loops abort streams with these.
  *  - `TextEncoder` / `TextDecoder` — SSE parsing decodes UTF-8 stream chunks.
+ *  - `URLSearchParams`: `runtime-client`'s `startLogin` builds the
+ *    `providers/login` query string with it (see `url-search-params.ts`).
  *
  * NOT shimmed (must come from the host — see BRIDGE.md "Host polyfills"):
  *  - `setTimeout` / `clearTimeout` / `setInterval` / `clearInterval` — timers
@@ -17,6 +19,8 @@
  *  - `crypto.getRandomValues` (optional; nonce falls back to `Math.random`) and
  *    `console` (optional diagnostics).
  */
+
+import { URLSearchParamsShim } from "./url-search-params";
 
 interface GlobalWithShims {
   [key: string]: unknown;
@@ -186,4 +190,6 @@ export function installGlobalShims(): void {
   if (typeof g.AbortSignal === "undefined") g.AbortSignal = AbortSignalShim;
   if (typeof g.TextDecoder === "undefined") g.TextDecoder = TextDecoderShim;
   if (typeof g.TextEncoder === "undefined") g.TextEncoder = TextEncoderShim;
+  if (typeof g.URLSearchParams === "undefined")
+    g.URLSearchParams = URLSearchParamsShim;
 }

--- a/packages/sdk/src/bridge/url-search-params.ts
+++ b/packages/sdk/src/bridge/url-search-params.ts
@@ -1,0 +1,140 @@
+/**
+ * `URLSearchParams` fallback for a bare embedded JS engine (JavaScriptCore /
+ * Hermes outside a WebKit web context) that does not provide it. Kept in its
+ * own module so `shims.ts` stays within the 200-line limit; installed only when
+ * absent by `installGlobalShims`.
+ *
+ * `runtime-client`'s `startLogin` builds `new URLSearchParams()` + `set` +
+ * `toString` to assemble the `providers/login` query string; without this shim
+ * that path throws a ReferenceError on iOS and blocks provider connect. The
+ * full spec surface is implemented so any other consumer keeps working too.
+ */
+
+/** application/x-www-form-urlencoded: encodeURIComponent, space -> "+". */
+function encode(value: string): string {
+  return encodeURIComponent(value).replace(/%20/g, "+");
+}
+
+/** Inverse of {@link encode}: "+" -> space, then percent-decode. */
+function decode(value: string): string {
+  return decodeURIComponent(value.replace(/\+/g, " "));
+}
+
+type Pair = [string, string];
+
+export class URLSearchParamsShim {
+  private readonly pairs: Pair[] = [];
+
+  constructor(init?: unknown) {
+    if (init === undefined || init === null || init === "") return;
+    if (typeof init === "string") {
+      const query = init.charAt(0) === "?" ? init.slice(1) : init;
+      for (const part of query.split("&")) {
+        if (part === "") continue;
+        const eq = part.indexOf("=");
+        if (eq === -1) this.pairs.push([decode(part), ""]);
+        else
+          this.pairs.push([
+            decode(part.slice(0, eq)),
+            decode(part.slice(eq + 1)),
+          ]);
+      }
+      return;
+    }
+    const iterable = init as { [Symbol.iterator]?: unknown };
+    if (typeof iterable[Symbol.iterator] === "function") {
+      for (const entry of init as Iterable<[unknown, unknown]>) {
+        this.pairs.push([String(entry[0]), String(entry[1])]);
+      }
+      return;
+    }
+    const rec = init as Record<string, unknown>;
+    for (const k of Object.keys(rec)) this.pairs.push([k, String(rec[k])]);
+  }
+
+  get size(): number {
+    return this.pairs.length;
+  }
+
+  append(name: string, value: string): void {
+    this.pairs.push([String(name), String(value)]);
+  }
+
+  set(name: string, value: string): void {
+    const key = String(name);
+    const val = String(value);
+    const kept: Pair[] = [];
+    let replaced = false;
+    for (const pair of this.pairs) {
+      if (pair[0] !== key) kept.push(pair);
+      else if (!replaced) {
+        kept.push([key, val]);
+        replaced = true;
+      }
+    }
+    if (!replaced) kept.push([key, val]);
+    this.pairs.length = 0;
+    this.pairs.push(...kept);
+  }
+
+  get(name: string): string | null {
+    const key = String(name);
+    for (const [k, v] of this.pairs) if (k === key) return v;
+    return null;
+  }
+
+  getAll(name: string): string[] {
+    const key = String(name);
+    return this.pairs.filter(([k]) => k === key).map(([, v]) => v);
+  }
+
+  has(name: string): boolean {
+    const key = String(name);
+    return this.pairs.some(([k]) => k === key);
+  }
+
+  delete(name: string): void {
+    const key = String(name);
+    for (let i = this.pairs.length - 1; i >= 0; i--) {
+      if (this.pairs[i][0] === key) this.pairs.splice(i, 1);
+    }
+  }
+
+  forEach(
+    cb: (value: string, key: string, parent: URLSearchParamsShim) => void,
+  ): void {
+    for (const [k, v] of [...this.pairs]) cb(v, k, this);
+  }
+
+  *entries(): IterableIterator<Pair> {
+    for (const [k, v] of this.pairs) yield [k, v];
+  }
+
+  *keys(): IterableIterator<string> {
+    for (const [k] of this.pairs) yield k;
+  }
+
+  *values(): IterableIterator<string> {
+    for (const [, v] of this.pairs) yield v;
+  }
+
+  [Symbol.iterator](): IterableIterator<Pair> {
+    return this.entries();
+  }
+
+  /** Stable sort by name (UTF-16 code units), preserving equal-key order. */
+  sort(): void {
+    const indexed = this.pairs.map((p, i) => [p, i] as const);
+    indexed.sort((a, b) => {
+      if (a[0][0] < b[0][0]) return -1;
+      if (a[0][0] > b[0][0]) return 1;
+      return a[1] - b[1];
+    });
+    this.pairs.length = 0;
+    for (const [p] of indexed) this.pairs.push(p);
+  }
+
+  toString(): string {
+    return this.pairs.map(([k, v]) => `${encode(k)}=${encode(v)}`).join("&");
+  }
+}

--- a/packages/sdk/tests/bridge-bundle.smoke.test.ts
+++ b/packages/sdk/tests/bridge-bundle.smoke.test.ts
@@ -64,6 +64,25 @@ describe("embeddable bundle in a bare vm", () => {
     expect(typeof g.create).toBe("function");
   });
 
+  it("installs a working URLSearchParams when the engine lacks it", () => {
+    // The bare vm context omits URLSearchParams (JavaScriptCore parity); the
+    // bundle must self-shim it so runtime-client's providers/login path works.
+    const context = createContext(documentedPolyfills());
+    expect(
+      (context as { URLSearchParams?: unknown }).URLSearchParams,
+    ).toBeUndefined();
+    runInContext(bundle, context);
+    const ctor = (
+      context as { URLSearchParams: new (init?: unknown) => unknown }
+    ).URLSearchParams;
+    expect(typeof ctor).toBe("function");
+    const serialized = runInContext(
+      "const p = new URLSearchParams(); p.set('deviceAuth', 'false'); p.set('enterpriseDomain', 'acme.ghe.com'); p.toString();",
+      context,
+    );
+    expect(serialized).toBe("deviceAuth=false&enterpriseDomain=acme.ghe.com");
+  });
+
   it("round-trips a command with only the documented polyfills present", async () => {
     const context = createContext(documentedPolyfills());
     runInContext(bundle, context);

--- a/packages/sdk/tests/url-search-params.test.ts
+++ b/packages/sdk/tests/url-search-params.test.ts
@@ -1,0 +1,124 @@
+/**
+ * Unit coverage for the `URLSearchParams` bundle shim (`src/bridge/
+ * url-search-params.ts`), the fallback a bare JavaScriptCore lacks. Exercises
+ * every construction form, the read/write surface, iteration order, and the
+ * application/x-www-form-urlencoded serialization the runtime-client login path
+ * depends on.
+ */
+
+import { describe, expect, it } from "vitest";
+import { URLSearchParamsShim } from "../src/bridge/url-search-params";
+
+describe("URLSearchParamsShim construction", () => {
+  it("starts empty with no argument", () => {
+    const p = new URLSearchParamsShim();
+    expect(p.size).toBe(0);
+    expect(p.toString()).toBe("");
+  });
+
+  it("parses a query string, tolerating a leading '?'", () => {
+    const a = new URLSearchParamsShim("a=1&b=2");
+    const b = new URLSearchParamsShim("?a=1&b=2");
+    expect(a.get("a")).toBe("1");
+    expect(a.get("b")).toBe("2");
+    expect(b.toString()).toBe("a=1&b=2");
+  });
+
+  it("builds from a record", () => {
+    const p = new URLSearchParamsShim({ deviceAuth: "false", n: 2 });
+    expect(p.get("deviceAuth")).toBe("false");
+    expect(p.get("n")).toBe("2");
+  });
+
+  it("builds from an iterable of pairs, keeping duplicates", () => {
+    const p = new URLSearchParamsShim([
+      ["a", "1"],
+      ["a", "2"],
+    ]);
+    expect(p.getAll("a")).toEqual(["1", "2"]);
+  });
+});
+
+describe("URLSearchParamsShim read/write surface", () => {
+  it("get returns the first value, getAll returns all in order", () => {
+    const p = new URLSearchParamsShim();
+    p.append("a", "1");
+    p.append("a", "2");
+    expect(p.get("a")).toBe("1");
+    expect(p.getAll("a")).toEqual(["1", "2"]);
+    expect(p.get("missing")).toBeNull();
+  });
+
+  it("set replaces all existing entries for the name in place", () => {
+    const p = new URLSearchParamsShim("a=1&b=2&a=3");
+    p.set("a", "9");
+    expect(p.getAll("a")).toEqual(["9"]);
+    expect(p.toString()).toBe("a=9&b=2");
+  });
+
+  it("set appends when the name is absent", () => {
+    const p = new URLSearchParamsShim("a=1");
+    p.set("b", "2");
+    expect(p.toString()).toBe("a=1&b=2");
+  });
+
+  it("has and delete cover every matching entry", () => {
+    const p = new URLSearchParamsShim("a=1&a=2&b=3");
+    expect(p.has("a")).toBe(true);
+    p.delete("a");
+    expect(p.has("a")).toBe(false);
+    expect(p.size).toBe(1);
+    expect(p.get("b")).toBe("3");
+  });
+});
+
+describe("URLSearchParamsShim iteration", () => {
+  it("preserves insertion order across entries/keys/values/forEach", () => {
+    const p = new URLSearchParamsShim("z=1&a=2&z=3");
+    expect([...p.entries()]).toEqual([
+      ["z", "1"],
+      ["a", "2"],
+      ["z", "3"],
+    ]);
+    expect([...p.keys()]).toEqual(["z", "a", "z"]);
+    expect([...p.values()]).toEqual(["1", "2", "3"]);
+    const seen: string[] = [];
+    p.forEach((v, k) => {
+      seen.push(`${k}=${v}`);
+    });
+    expect(seen).toEqual(["z=1", "a=2", "z=3"]);
+    expect([...p]).toEqual([...p.entries()]);
+  });
+
+  it("sort orders by name and keeps equal-key order stable", () => {
+    const p = new URLSearchParamsShim("b=1&a=2&b=3&a=4");
+    p.sort();
+    expect(p.toString()).toBe("a=2&a=4&b=1&b=3");
+  });
+});
+
+describe("URLSearchParamsShim serialization", () => {
+  it("encodes spaces as '+' and percent-encodes reserved + unicode", () => {
+    const p = new URLSearchParamsShim();
+    p.set("q", "a b");
+    p.set("path", "x/y&z");
+    p.set("name", "café");
+    expect(p.toString()).toBe("q=a+b&path=x%2Fy%26z&name=caf%C3%A9");
+  });
+
+  it("round-trips 'a=1&a=2&b=x+y' with '+' decoding to a space", () => {
+    const p = new URLSearchParamsShim("a=1&a=2&b=x+y");
+    expect(p.getAll("a")).toEqual(["1", "2"]);
+    expect(p.get("b")).toBe("x y");
+    expect(p.toString()).toBe("a=1&a=2&b=x+y");
+  });
+
+  it("mirrors the runtime-client startLogin query assembly", () => {
+    const params = new URLSearchParamsShim();
+    params.set("deviceAuth", "false");
+    params.set("enterpriseDomain", "acme.ghe.com");
+    expect(params.toString()).toBe(
+      "deviceAuth=false&enterpriseDomain=acme.ghe.com",
+    );
+  });
+});


### PR DESCRIPTION
## What

Closes out the remaining findings from the iOS app review (follow-up to #863):

1. **`fix(sdk)`: URLSearchParams shim** — bare JavaScriptCore has no `URLSearchParams`, so `providers/login` threw a ReferenceError on iOS and blocked connecting any AI provider (= no turns). The bridge bundle now self-installs a spec-faithful shim when the global is absent (same pattern as Headers/Request/TextEncoder); `BRIDGE.md` §10 updated. 13 new vitest cases + a built-bundle smoke test, and verified against a real bare `JSContext`: `typeof URLSearchParams = function`, `a+b=c%2Fd&x=1` serialization.
2. **`feat(ios)`: SDK log frames → os_log** — `{kind:"log"}` frames were decoded as `.unknown` and dropped, losing all SDK diagnostics. Now a typed `.log` case (forward-compatible decode) dispatched to `os.Logger(subsystem: "ai.gethouston.sdk")` with level mapping. 5 new tests.
3. **`chore(ios)`: plist ship-readiness** — `CFBundleShortVersionString`/`CFBundleVersion` now resolve from `MARKETING_VERSION`/`CURRENT_PROJECT_VERSION` (the app shipped as literal 1.0/1 before, ignoring project.yml's 0.1.0), and `ITSAppUsesNonExemptEncryption: false` skips the per-upload compliance question. Also annotates the superseded PARITY-SETTINGS §1 table.
4. **`ci`: iOS job** — `macOS-15` job (xcodegen + xcodebuild test) gated by `dorny/paths-filter` on iOS-relevant paths so the expensive runner only fires when `mobile/ios`, `packages/sdk`, `packages/design-tokens`, `packages/runtime-client`, or `packages/protocol` change. Uploads the xcresult on failure. This PR exercises it.

## Verification

- `@houston/sdk`: 358/358 vitest, typecheck, biome clean.
- iOS: full simulator build, **547/547 unit tests pass**.
- Built app Info.plist resolves `0.1.0 (1)` + encryption exemption.
- Built bridge bundle proven in a bare JavaScriptCore context (the actual iOS runtime).

## Not in this PR

- Sign in with Apple: **not in the repo yet** (AuthController still hardcodes Google) — tracked as in-flight sign-in work.
- Archive/export automation for TestFlight (needs a signing team decision).

🤖 Generated with [Claude Code](https://claude.com/claude-code)