### PR TITLE
feat: API Keys settings + public developer docs (/developers)

### DIFF
--- a/app/src/components/settings/sections/api-key-create-dialog.tsx
+++ b/app/src/components/settings/sections/api-key-create-dialog.tsx
@@ -1,0 +1,175 @@
+import {
+  AsyncButton,
+  Button,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  Input,
+} from "@houston-ai/core";
+import type { ApiKeyCreated } from "@houston-ai/engine-client";
+import { Check, Copy, TriangleAlert } from "lucide-react";
+import { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useCreateApiKey } from "../../../hooks/queries/use-api-keys";
+import {
+  isKeyLimitError,
+  MAX_KEY_NAME_LENGTH,
+} from "../../../lib/api-keys-model";
+import { genericErrorDescription } from "../../../lib/error-toast";
+import { useUIStore } from "../../../stores/ui";
+
+interface ApiKeyCreateDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+/**
+ * Mint an API key, then reveal its secret exactly once. The dialog swaps from a
+ * name form to a show-once view holding the full key in LOCAL state only (never
+ * the query cache), and clears everything on close so the secret cannot linger.
+ */
+export function ApiKeyCreateDialog({
+  open,
+  onOpenChange,
+}: ApiKeyCreateDialogProps) {
+  const { t } = useTranslation("settings");
+  const addToast = useUIStore((s) => s.addToast);
+  const create = useCreateApiKey();
+  const [name, setName] = useState("");
+  const [revealed, setRevealed] = useState<ApiKeyCreated | null>(null);
+  const [copied, setCopied] = useState(false);
+  // Synchronous in-flight guard shared by BOTH submit paths (the AsyncButton
+  // click and the Enter keydown). A ref flips immediately, before React can
+  // re-render, so two rapid Enters can never mint two keys and lose the first
+  // secret forever — `create.isPending` alone lags a render behind.
+  const submitting = useRef(false);
+
+  function close() {
+    // Clear the local secret + form on every close so a revealed key never
+    // survives the dialog. `create.reset()` drops the mutation's cached result
+    // (which also carries the secret) and any inline error.
+    setName("");
+    setRevealed(null);
+    setCopied(false);
+    create.reset();
+    onOpenChange(false);
+  }
+
+  async function submit() {
+    // One mint at a time: bail if a create is already in flight (Enter pressed
+    // twice, or Enter racing the button). Without this the second call mints a
+    // second key whose secret is shown once and then lost.
+    if (submitting.current || create.isPending) return;
+    submitting.current = true;
+    // Caught locally: a genuine failure already surfaced once via `call()`
+    // (bug toast + report) and `key_limit` is silenced for the inline notice
+    // below, so both live in `create.error`. Swallowing the rejection here only
+    // stops it reaching the global unhandledrejection handler as a duplicate.
+    try {
+      setRevealed(await create.mutateAsync(name));
+    } catch {
+      // handled via create.error / the toast surfaced by call()
+    } finally {
+      submitting.current = false;
+    }
+  }
+
+  async function copyKey() {
+    if (!revealed) return;
+    try {
+      await navigator.clipboard.writeText(revealed.key);
+      setCopied(true);
+      addToast({ title: t("apiKeys.create.copied") });
+    } catch (err) {
+      addToast({
+        title: t("apiKeys.create.copyFailed"),
+        description: genericErrorDescription("copy_api_key", err),
+        variant: "error",
+      });
+    }
+  }
+
+  const limitReached = isKeyLimitError(create.error);
+  const canSubmit = name.trim().length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={(next) => !next && close()}>
+      <DialogContent closeLabel={t("apiKeys.dialogClose")}>
+        {revealed ? (
+          <>
+            <DialogHeader>
+              <DialogTitle>{t("apiKeys.create.revealTitle")}</DialogTitle>
+              <DialogDescription>
+                {t("apiKeys.create.revealSubtitle", { name: revealed.name })}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="flex items-center gap-2 rounded-lg border border-border bg-secondary px-3 py-2">
+              <code className="min-w-0 flex-1 break-all font-mono text-xs text-foreground">
+                {revealed.key}
+              </code>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => void copyKey()}
+                className="shrink-0"
+              >
+                {copied ? (
+                  <Check className="size-4" />
+                ) : (
+                  <Copy className="size-4" />
+                )}
+                {copied ? t("apiKeys.create.copied") : t("apiKeys.create.copy")}
+              </Button>
+            </div>
+            <p className="flex items-start gap-2 text-xs text-destructive">
+              <TriangleAlert className="mt-0.5 size-4 shrink-0" />
+              {t("apiKeys.create.warning")}
+            </p>
+            <DialogFooter>
+              <Button onClick={close}>{t("apiKeys.create.done")}</Button>
+            </DialogFooter>
+          </>
+        ) : (
+          <>
+            <DialogHeader>
+              <DialogTitle>{t("apiKeys.create.title")}</DialogTitle>
+              <DialogDescription>
+                {t("apiKeys.create.subtitle")}
+              </DialogDescription>
+            </DialogHeader>
+            <div className="space-y-2">
+              <Input
+                autoFocus
+                value={name}
+                maxLength={MAX_KEY_NAME_LENGTH}
+                placeholder={t("apiKeys.create.namePlaceholder")}
+                aria-label={t("apiKeys.create.nameLabel")}
+                aria-invalid={limitReached}
+                onChange={(e) => setName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" && canSubmit) void submit();
+                }}
+              />
+              {limitReached && (
+                <p className="text-xs text-destructive">
+                  {t("apiKeys.create.limitReached")}
+                </p>
+              )}
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={close}>
+                {t("apiKeys.create.cancel")}
+              </Button>
+              <AsyncButton onClick={submit} disabled={!canSubmit}>
+                {t("apiKeys.create.submit")}
+              </AsyncButton>
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/app/src/components/settings/sections/api-keys-body.tsx
+++ b/app/src/components/settings/sections/api-keys-body.tsx
@@ -1,0 +1,171 @@
+import {
+  Badge,
+  Button,
+  ConfirmDialog,
+  Empty,
+  EmptyContent,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+  Skeleton,
+} from "@houston-ai/core";
+import type { ApiKey } from "@houston-ai/engine-client";
+import { KeyRound, Plus, TriangleAlert } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  useApiKeys,
+  useRevokeApiKey,
+} from "../../../hooks/queries/use-api-keys";
+import { lastUsedState } from "../../../lib/api-keys-model";
+import { formatRelativeTime } from "../../organization/org-time";
+import { ApiKeyCreateDialog } from "./api-key-create-dialog";
+
+/** The list + create/revoke surface of Settings > API keys. */
+export function ApiKeysBody() {
+  const { t, i18n } = useTranslation("settings");
+  const { data: keys, isLoading, isError, refetch } = useApiKeys();
+  const revoke = useRevokeApiKey();
+  const [createOpen, setCreateOpen] = useState(false);
+  const [revokeTarget, setRevokeTarget] = useState<ApiKey | null>(null);
+
+  const hasKeys = (keys?.length ?? 0) > 0;
+
+  return (
+    <div className="space-y-4">
+      {isLoading ? (
+        <div className="space-y-2">
+          {[0, 1].map((i) => (
+            <Skeleton key={i} className="h-16 w-full rounded-xl" />
+          ))}
+        </div>
+      ) : isError ? (
+        <Empty className="border border-border">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <TriangleAlert className="size-6 text-destructive" />
+            </EmptyMedia>
+            <EmptyTitle>{t("apiKeys.error.title")}</EmptyTitle>
+            <EmptyDescription>
+              {t("apiKeys.error.description")}
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button variant="outline" onClick={() => void refetch()}>
+              {t("apiKeys.error.retry")}
+            </Button>
+          </EmptyContent>
+        </Empty>
+      ) : hasKeys ? (
+        <>
+          <div className="divide-y divide-border overflow-hidden rounded-xl border border-border bg-card">
+            {keys?.map((key) => (
+              <ApiKeyRow
+                key={key.id}
+                apiKey={key}
+                locale={i18n.language}
+                onRevoke={() => setRevokeTarget(key)}
+              />
+            ))}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setCreateOpen(true)}
+          >
+            <Plus className="size-4" />
+            {t("apiKeys.createButton")}
+          </Button>
+        </>
+      ) : (
+        <Empty className="border border-border">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <KeyRound className="size-6" />
+            </EmptyMedia>
+            <EmptyTitle>{t("apiKeys.empty.title")}</EmptyTitle>
+            <EmptyDescription>
+              {t("apiKeys.empty.description")}
+            </EmptyDescription>
+          </EmptyHeader>
+          <EmptyContent>
+            <Button onClick={() => setCreateOpen(true)}>
+              <Plus className="size-4" />
+              {t("apiKeys.createButton")}
+            </Button>
+          </EmptyContent>
+        </Empty>
+      )}
+
+      <ApiKeyCreateDialog open={createOpen} onOpenChange={setCreateOpen} />
+
+      <ConfirmDialog
+        open={revokeTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setRevokeTarget(null);
+        }}
+        variant="destructive"
+        title={t("apiKeys.revoke.title")}
+        description={t("apiKeys.revoke.description", {
+          name: revokeTarget?.name ?? "",
+        })}
+        confirmLabel={t("apiKeys.revoke.confirm")}
+        cancelLabel={t("apiKeys.revoke.cancel")}
+        onConfirm={() => {
+          if (revokeTarget) revoke.mutate(revokeTarget.id);
+          setRevokeTarget(null);
+        }}
+      />
+    </div>
+  );
+}
+
+interface ApiKeyRowProps {
+  apiKey: ApiKey;
+  locale: string;
+  onRevoke: () => void;
+}
+
+function ApiKeyRow({ apiKey, locale, onRevoke }: ApiKeyRowProps) {
+  const { t } = useTranslation("settings");
+  const created = new Intl.DateTimeFormat(locale, {
+    dateStyle: "medium",
+  }).format(new Date(apiKey.createdAt));
+  const used = lastUsedState(apiKey);
+
+  return (
+    <div className="flex items-center gap-3 px-4 py-3">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="truncate text-sm font-medium text-foreground">
+            {apiKey.name}
+          </span>
+          <code className="shrink-0 font-mono text-xs text-muted-foreground">
+            {apiKey.prefix}
+          </code>
+        </div>
+        <div className="mt-0.5 flex items-center gap-2 text-xs text-muted-foreground">
+          <span>{t("apiKeys.row.created", { date: created })}</span>
+          {used.kind === "never" ? (
+            <Badge variant="secondary">{t("apiKeys.row.neverUsed")}</Badge>
+          ) : (
+            <span>
+              {t("apiKeys.row.lastUsed", {
+                when: formatRelativeTime(used.atMs, locale),
+              })}
+            </span>
+          )}
+        </div>
+      </div>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="shrink-0 text-destructive hover:text-destructive"
+        onClick={onRevoke}
+      >
+        {t("apiKeys.row.revoke")}
+      </Button>
+    </div>
+  );
+}

--- a/app/src/components/settings/sections/api-keys.tsx
+++ b/app/src/components/settings/sections/api-keys.tsx
@@ -1,0 +1,38 @@
+import { Trans, useTranslation } from "react-i18next";
+import { tauriSystem } from "../../../lib/tauri";
+import { ApiKeysBody } from "./api-keys-body";
+
+/** Developer docs for the public API, opened in the OS browser. */
+const DOCS_URL = "https://gethouston.ai/developers";
+
+/**
+ * Settings > API keys (C9): mint and revoke personal keys for the public API.
+ * Shown only on a gateway that advertises `capabilities.apiKeys` (gated by the
+ * caller in `settings-view`). The header links the concept to the developer
+ * docs; the list, create, and revoke flows live in {@link ApiKeysBody}.
+ */
+export function ApiKeysSection() {
+  const { t } = useTranslation("settings");
+
+  return (
+    <section>
+      <h2 className="mb-1 text-lg font-semibold">{t("apiKeys.title")}</h2>
+      <p className="mb-4 text-sm text-muted-foreground">
+        <Trans
+          t={t}
+          i18nKey="apiKeys.intro"
+          components={{
+            docs: (
+              <button
+                type="button"
+                onClick={() => void tauriSystem.openUrl(DOCS_URL)}
+                className="cursor-pointer font-medium text-primary underline underline-offset-2 transition-colors hover:text-primary/80"
+              />
+            ),
+          }}
+        />
+      </p>
+      <ApiKeysBody />
+    </section>
+  );
+}

--- a/app/src/components/settings/settings-index.tsx
+++ b/app/src/components/settings/settings-index.tsx
@@ -4,6 +4,7 @@ import {
   CloudUpload,
   FileText,
   Keyboard,
+  KeyRound,
   User,
   Users,
 } from "lucide-react";
@@ -29,6 +30,7 @@ import { SettingsCard, SettingsRow } from "./settings-row";
 interface SettingsIndexProps {
   accountAvailable: boolean;
   showMembers: boolean;
+  apiKeysAvailable: boolean;
   migrationAvailable: boolean;
   onSelect: (id: SettingsSectionId) => void;
 }
@@ -42,6 +44,7 @@ interface SettingsIndexProps {
 export function SettingsIndex({
   accountAvailable,
   showMembers,
+  apiKeysAvailable,
   migrationAvailable,
   onSelect,
 }: SettingsIndexProps) {
@@ -117,6 +120,14 @@ export function SettingsIndex({
                 count: memberCount,
               })}
               onClick={() => onSelect("members")}
+            />
+          )}
+          {apiKeysAvailable && (
+            <SettingsRow
+              icon={KeyRound}
+              title={t("settings:nav.apiKeys")}
+              description={t("settings:index.rows.apiKeys")}
+              onClick={() => onSelect("apiKeys")}
             />
           )}
         </SettingsCard>

--- a/app/src/components/settings/settings-view.tsx
+++ b/app/src/components/settings/settings-view.tsx
@@ -3,6 +3,7 @@ import { ChevronLeft } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useCapabilities } from "../../hooks/use-capabilities";
+import { apiKeysSupported } from "../../lib/api-keys-model";
 import { canSeeMembers } from "../../lib/org-roles";
 import {
   parseSettingsSection,
@@ -11,6 +12,7 @@ import {
 import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { useAccountAvailable } from "./sections/account";
+import { ApiKeysSection } from "./sections/api-keys";
 import { ConnectedAccountsSection } from "./sections/connected-accounts";
 import { MembersSection } from "./sections/members";
 import { MigrationSection, useMigrationAvailable } from "./sections/migration";
@@ -29,6 +31,7 @@ export function SettingsView() {
   const migrationAvailable = useMigrationAvailable();
   const { capabilities } = useCapabilities();
   const showMembers = canSeeMembers(capabilities);
+  const apiKeysAvailable = apiKeysSupported(capabilities);
   const setSettingsSection = useUIStore((s) => s.setSettingsSection);
   // Consume the one-shot deep-link the moment this view mounts: another surface
   // may have pinned a section (e.g. "connectedAccounts") right before switching
@@ -56,6 +59,7 @@ export function SettingsView() {
         <SettingsIndex
           accountAvailable={accountAvailable}
           showMembers={showMembers}
+          apiKeysAvailable={apiKeysAvailable}
           migrationAvailable={migrationAvailable}
           onSelect={setActive}
         />
@@ -84,6 +88,7 @@ export function SettingsView() {
           <div className="mx-auto max-w-xl px-8 pb-10">
             {active === "members" && <MembersSection />}
             {active === "connectedAccounts" && <ConnectedAccountsSection />}
+            {active === "apiKeys" && <ApiKeysSection />}
             {active === "shortcuts" && <ShortcutsSection />}
             {active === "reportBug" && <ReportBugSection />}
             {active === "migration" && <MigrationSection />}

--- a/app/src/hooks/queries/use-api-keys.ts
+++ b/app/src/hooks/queries/use-api-keys.ts
@@ -1,0 +1,58 @@
+import type { ApiKey } from "@houston-ai/engine-client";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { apiKeysSupported } from "../../lib/api-keys-model";
+import { queryKeys } from "../../lib/query-keys";
+import { tauriApiKeys } from "../../lib/tauri";
+import { useCapabilities } from "../use-capabilities";
+
+/**
+ * C9 personal API-key hooks (`GET/POST/DELETE /v1/keys`). Hosted-gateway only:
+ * every hook self-gates on `capabilities.apiKeys`, so off-cloud (desktop,
+ * self-host) the query never fires and the section never renders.
+ *
+ * The wire calls route through `tauriApiKeys.*` → the engine client's `call()`
+ * wrapper, which surfaces any failure once as a red bug toast + Sentry report
+ * (the required no-silent-failures path). So these hooks carry no `onError` — a
+ * second toast would double up (same as `use-billing.ts`). The one exception is
+ * the mint's `key_limit`, which `tauriApiKeys.create` silences so the section
+ * can render it inline; the mutation error is read by the caller for that.
+ */
+
+/** The caller's active API keys, newest first. Enabled only on a gateway that
+ *  serves the public API. */
+export function useApiKeys() {
+  const { capabilities } = useCapabilities();
+  return useQuery<ApiKey[]>({
+    queryKey: queryKeys.apiKeys(),
+    queryFn: () => tauriApiKeys.list(),
+    enabled: apiKeysSupported(capabilities),
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * Mint a personal API key. On success the full secret is returned to the caller
+ * (for the one-time reveal) and the list is invalidated so the new key appears;
+ * the secret is deliberately NOT written into any cache. A `key_limit` rejection
+ * is surfaced inline by the caller (see the hook-file doc), not toasted.
+ */
+export function useCreateApiKey() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => tauriApiKeys.create(name.trim()),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.apiKeys() });
+    },
+  });
+}
+
+/** Revoke a key by id, then refresh the list. */
+export function useRevokeApiKey() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => tauriApiKeys.revoke(id),
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: queryKeys.apiKeys() });
+    },
+  });
+}

--- a/app/src/lib/api-keys-model.ts
+++ b/app/src/lib/api-keys-model.ts
@@ -1,0 +1,70 @@
+import type { ApiKey, Capabilities } from "@houston-ai/engine-client";
+
+/**
+ * Pure, DOM-free logic behind the API-keys settings section (C9). Kept out of
+ * the `.tsx` so the capability gate, the name validation, the `key_limit`
+ * classifier, and the last-used state all unit-test under bare Node.
+ */
+
+/** Server-enforced bounds on a key name (C9: trimmed 1..100). */
+export const MAX_KEY_NAME_LENGTH = 100;
+
+/**
+ * True when this deployment serves the C9 public API, so the API-keys section
+ * should show. Absent/false on desktop, self-host, and gateways that predate the
+ * public API, so the whole surface stays hidden there.
+ */
+export function apiKeysSupported(caps: Capabilities | null): boolean {
+  return caps?.apiKeys === true;
+}
+
+/**
+ * True when `name` is an acceptable key name: non-empty after trimming and at
+ * most {@link MAX_KEY_NAME_LENGTH} characters. Drives the create button's enabled
+ * state so an empty/too-long name never reaches the gateway.
+ */
+export function isValidKeyName(name: string): boolean {
+  const trimmed = name.trim();
+  return trimmed.length >= 1 && trimmed.length <= MAX_KEY_NAME_LENGTH;
+}
+
+/**
+ * True for the gateway's `400 {code:"key_limit"}` — the caller already holds the
+ * maximum active keys (C9). An EXPECTED business state (revoke one to free a
+ * slot), NOT a Houston bug, so the create flow silences it from the red
+ * "report a bug" toast and renders it inline instead. Reads the raw top-level
+ * `code` on the error body (the gateway's flat `{error, code}` shape), not the
+ * nested `error.code` that the engine-client `.code` getter looks at.
+ */
+export function isKeyLimitError(err: unknown): boolean {
+  const e = err as { status?: unknown; body?: unknown } | null | undefined;
+  if (e?.status !== 400) return false;
+  const code = (e.body as { code?: unknown } | null | undefined)?.code;
+  return code === "key_limit";
+}
+
+/**
+ * True for the gateway's `404 Not Found` on a revoke — the key is already gone.
+ * The list is cached for 30s, and two revoke clicks can land in the same window,
+ * so revoking a key the gateway no longer has is EXPECTED idempotency, NOT a
+ * Houston bug. The revoke flow silences it from the red "report a bug" toast and
+ * treats it as success (the row disappears once the list refreshes).
+ */
+export function isKeyGoneError(err: unknown): boolean {
+  const e = err as { status?: unknown } | null | undefined;
+  return e?.status === 404;
+}
+
+/**
+ * How a key's "last used" should read: `never` until it first authenticates a
+ * request, otherwise the instant it last did. An absent OR unparseable
+ * `lastUsedAt` both collapse to `never` so the row never shows a misleading
+ * date. The caller localizes the instant (relative time) and the "never" label.
+ */
+export type LastUsedState = { kind: "never" } | { kind: "at"; atMs: number };
+
+export function lastUsedState(key: Pick<ApiKey, "lastUsedAt">): LastUsedState {
+  if (!key.lastUsedAt) return { kind: "never" };
+  const atMs = Date.parse(key.lastUsedAt);
+  return Number.isNaN(atMs) ? { kind: "never" } : { kind: "at", atMs };
+}

--- a/app/src/lib/query-keys.ts
+++ b/app/src/lib/query-keys.ts
@@ -49,6 +49,14 @@ export const queryKeys = {
   capabilities: () => ["capabilities"] as const,
 
   /**
+   * C9 personal API keys (`GET /v1/keys`). App-scoped (one set per user, not
+   * agent-scoped) and hosted-gateway only — the create/revoke mutations
+   * self-invalidate this key. The full secret from a mint is NEVER cached here;
+   * it lives only in the create dialog's local state for its one-time reveal.
+   */
+  apiKeys: () => ["api-keys"] as const,
+
+  /**
    * Per-workspace sidebar arrangement (sort mode + named groups + drag order).
    * Optimistically updated by the layout mutation; also invalidated on the
    * `SidebarLayoutChanged` event for best-effort cross-surface/tab sync.

--- a/app/src/lib/settings-sections.ts
+++ b/app/src/lib/settings-sections.ts
@@ -8,6 +8,7 @@
 export const SETTINGS_SECTION_IDS = [
   "members",
   "connectedAccounts",
+  "apiKeys",
   "workspaceContext",
   "userContext",
   "shortcuts",

--- a/app/src/lib/tauri.ts
+++ b/app/src/lib/tauri.ts
@@ -28,6 +28,7 @@ import {
   isAgentPathWarming,
   type WarmingWriteOptions,
 } from "./agent-warming-guard";
+import { isKeyGoneError, isKeyLimitError } from "./api-keys-model";
 import {
   beginClaudeBrowserLogin,
   cancelClaudeBrowserLogin,
@@ -1631,4 +1632,39 @@ export const tauriOrg = {
     allowedModels?: string[] | null;
   }) =>
     call<void>("set_org_settings", () => getEngine().setOrgSettings(settings)),
+};
+
+/**
+ * Personal API keys (C9). Hosted-gateway only: `getEngine()` throws off-cloud, so
+ * callers gate the UI on the `apiKeys` capability. Every call routes through
+ * `call()` so a failure toasts + reports exactly once (the no-silent-failures
+ * path) — the section then reflects the query's error state instead of a
+ * misleading empty list. Two expected states are silenced from the red bug toast:
+ * `create` silences the `key_limit` 400 (surfaced inline), and `revoke` silences
+ * the `404` of an already-gone key (stale 30s list / double revoke) and resolves
+ * it as success so the row still disappears.
+ */
+export const tauriApiKeys = {
+  list: () => call("list_api_keys", () => getEngine().listApiKeys()),
+  create: (name: string) =>
+    call("create_api_key", () => getEngine().createApiKey(name), undefined, {
+      silence: isKeyLimitError,
+    }),
+  revoke: (id: string) =>
+    call<void>(
+      "revoke_api_key",
+      () => getEngine().revokeApiKey(id),
+      undefined,
+      {
+        silence: isKeyGoneError,
+      },
+    ).catch((err) => {
+      // A 404 means the key was already revoked (the list is 30s-stale, or a
+      // second revoke landed in the same window). That is idempotent success,
+      // not a failure: swallow it so the mutation resolves and its onSuccess
+      // still invalidates the list, dropping the row. `call()` already silenced
+      // the toast + Sentry report above; every other error rethrows and surfaces.
+      if (isKeyGoneError(err)) return;
+      throw err;
+    }),
 };

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -2,6 +2,7 @@
   "title": "Settings",
   "nav": {
     "connectedAccounts": "Connected accounts",
+    "apiKeys": "API keys",
     "workspaceContext": "Workspace context",
     "userContext": "Your context",
     "language": "Language",
@@ -124,6 +125,7 @@
     "rows": {
       "members": "People who can use your agents",
       "connectedAccounts": "Apps you've connected to Houston",
+      "apiKeys": "Keys to run your agents from your own tools",
       "workspaceContext": "What every agent knows about this workspace",
       "userContext": "What every agent knows about you",
       "shortcuts": "Run Houston without the mouse",
@@ -145,5 +147,48 @@
     "empty": "You haven't connected any apps yet.",
     "connectMore": "Connect more apps",
     "connectHint": "Connect new apps from any agent's Integrations tab."
+  },
+  "apiKeys": {
+    "title": "API keys",
+    "intro": "Use API keys to start missions from your own tools and scripts. <docs>Read the developer docs</docs>.",
+    "dialogClose": "Close",
+    "createButton": "Create key",
+    "empty": {
+      "title": "No API keys yet",
+      "description": "An API key lets your own tools and scripts start missions with your agents. Create one to get started."
+    },
+    "error": {
+      "title": "Couldn't load your keys",
+      "description": "Something went wrong reaching the server. Check your connection and try again.",
+      "retry": "Try again"
+    },
+    "row": {
+      "created": "Created {{date}}",
+      "lastUsed": "Last used {{when}}",
+      "neverUsed": "Never used",
+      "revoke": "Revoke"
+    },
+    "create": {
+      "title": "Create API key",
+      "subtitle": "Give this key a name so you can recognize it later.",
+      "nameLabel": "Key name",
+      "namePlaceholder": "e.g. My automation script",
+      "limitReached": "You've reached the maximum of 20 keys. Revoke one you no longer use to create a new key.",
+      "cancel": "Cancel",
+      "submit": "Create key",
+      "revealTitle": "Copy your API key",
+      "revealSubtitle": "\"{{name}}\" is ready. Copy it now and store it somewhere safe.",
+      "copy": "Copy",
+      "copied": "Copied",
+      "copyFailed": "Couldn't copy the key",
+      "warning": "This is the only time you'll see this key. You won't be able to view it again after closing.",
+      "done": "Done"
+    },
+    "revoke": {
+      "title": "Revoke this key?",
+      "description": "\"{{name}}\" will stop working right away. Any tool using it will lose access. This cannot be undone.",
+      "confirm": "Revoke",
+      "cancel": "Cancel"
+    }
   }
 }

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -2,6 +2,7 @@
   "title": "Configuración",
   "nav": {
     "connectedAccounts": "Cuentas conectadas",
+    "apiKeys": "Claves de API",
     "workspaceContext": "Contexto del espacio",
     "userContext": "Tu contexto",
     "language": "Idioma",
@@ -124,6 +125,7 @@
     "rows": {
       "members": "Personas que pueden usar tus agentes",
       "connectedAccounts": "Aplicaciones que conectaste a Houston",
+      "apiKeys": "Claves para usar tus agentes desde tus propias herramientas",
       "workspaceContext": "Lo que cada agente sabe sobre este espacio",
       "userContext": "Lo que cada agente sabe sobre ti",
       "shortcuts": "Usa Houston sin el mouse",
@@ -145,5 +147,48 @@
     "empty": "Aún no conectaste ninguna aplicación.",
     "connectMore": "Conectar más aplicaciones",
     "connectHint": "Conecta nuevas aplicaciones desde la pestaña Integraciones de cualquier agente."
+  },
+  "apiKeys": {
+    "title": "Claves de API",
+    "intro": "Usa claves de API para iniciar misiones desde tus propias herramientas y scripts. <docs>Lee la documentación para desarrolladores</docs>.",
+    "dialogClose": "Cerrar",
+    "createButton": "Crear clave",
+    "empty": {
+      "title": "Aún no tienes claves de API",
+      "description": "Una clave de API permite que tus propias herramientas y scripts inicien misiones con tus agentes. Crea una para empezar."
+    },
+    "error": {
+      "title": "No se pudieron cargar tus claves",
+      "description": "Algo salió mal al conectar con el servidor. Revisa tu conexión e inténtalo de nuevo.",
+      "retry": "Reintentar"
+    },
+    "row": {
+      "created": "Creada el {{date}}",
+      "lastUsed": "Último uso {{when}}",
+      "neverUsed": "Nunca usada",
+      "revoke": "Revocar"
+    },
+    "create": {
+      "title": "Crear clave de API",
+      "subtitle": "Ponle un nombre a esta clave para reconocerla más tarde.",
+      "nameLabel": "Nombre de la clave",
+      "namePlaceholder": "ej. Mi script de automatización",
+      "limitReached": "Llegaste al máximo de 20 claves. Revoca una que ya no uses para crear una nueva.",
+      "cancel": "Cancelar",
+      "submit": "Crear clave",
+      "revealTitle": "Copia tu clave de API",
+      "revealSubtitle": "\"{{name}}\" está lista. Cópiala ahora y guárdala en un lugar seguro.",
+      "copy": "Copiar",
+      "copied": "Copiada",
+      "copyFailed": "No se pudo copiar la clave",
+      "warning": "Esta es la única vez que verás esta clave. No podrás volver a verla después de cerrar.",
+      "done": "Listo"
+    },
+    "revoke": {
+      "title": "¿Revocar esta clave?",
+      "description": "\"{{name}}\" dejará de funcionar de inmediato. Cualquier herramienta que la use perderá el acceso. Esto no se puede deshacer.",
+      "confirm": "Revocar",
+      "cancel": "Cancelar"
+    }
   }
 }

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -2,6 +2,7 @@
   "title": "Configurações",
   "nav": {
     "connectedAccounts": "Contas conectadas",
+    "apiKeys": "Chaves de API",
     "workspaceContext": "Contexto do espaço",
     "userContext": "Seu contexto",
     "language": "Idioma",
@@ -124,6 +125,7 @@
     "rows": {
       "members": "Pessoas que podem usar seus agentes",
       "connectedAccounts": "Aplicativos que você conectou ao Houston",
+      "apiKeys": "Chaves para usar seus agentes a partir das suas próprias ferramentas",
       "workspaceContext": "O que todo agente sabe sobre este espaço",
       "userContext": "O que todo agente sabe sobre você",
       "shortcuts": "Use o Houston sem o mouse",
@@ -145,5 +147,48 @@
     "empty": "Você ainda não conectou nenhum aplicativo.",
     "connectMore": "Conectar mais aplicativos",
     "connectHint": "Conecte novos aplicativos pela aba Integrações de qualquer agente."
+  },
+  "apiKeys": {
+    "title": "Chaves de API",
+    "intro": "Use chaves de API para iniciar missões a partir das suas próprias ferramentas e scripts. <docs>Leia a documentação para desenvolvedores</docs>.",
+    "dialogClose": "Fechar",
+    "createButton": "Criar chave",
+    "empty": {
+      "title": "Você ainda não tem chaves de API",
+      "description": "Uma chave de API permite que suas próprias ferramentas e scripts iniciem missões com seus agentes. Crie uma para começar."
+    },
+    "error": {
+      "title": "Não foi possível carregar suas chaves",
+      "description": "Algo deu errado ao conectar com o servidor. Verifique sua conexão e tente novamente.",
+      "retry": "Tentar de novo"
+    },
+    "row": {
+      "created": "Criada em {{date}}",
+      "lastUsed": "Último uso {{when}}",
+      "neverUsed": "Nunca usada",
+      "revoke": "Revogar"
+    },
+    "create": {
+      "title": "Criar chave de API",
+      "subtitle": "Dê um nome a esta chave para reconhecê-la depois.",
+      "nameLabel": "Nome da chave",
+      "namePlaceholder": "ex. Meu script de automação",
+      "limitReached": "Você atingiu o máximo de 20 chaves. Revogue uma que não usa mais para criar uma nova.",
+      "cancel": "Cancelar",
+      "submit": "Criar chave",
+      "revealTitle": "Copie sua chave de API",
+      "revealSubtitle": "\"{{name}}\" está pronta. Copie agora e guarde em um lugar seguro.",
+      "copy": "Copiar",
+      "copied": "Copiada",
+      "copyFailed": "Não foi possível copiar a chave",
+      "warning": "Esta é a única vez que você verá esta chave. Você não poderá vê-la novamente depois de fechar.",
+      "done": "Concluído"
+    },
+    "revoke": {
+      "title": "Revogar esta chave?",
+      "description": "\"{{name}}\" vai parar de funcionar imediatamente. Qualquer ferramenta que a use perderá o acesso. Isso não pode ser desfeito.",
+      "confirm": "Revogar",
+      "cancel": "Cancelar"
+    }
   }
 }

--- a/app/tests/api-keys-model.test.ts
+++ b/app/tests/api-keys-model.test.ts
@@ -1,0 +1,103 @@
+import { strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { Capabilities } from "@houston-ai/engine-client";
+import {
+  apiKeysSupported,
+  isKeyGoneError,
+  isKeyLimitError,
+  isValidKeyName,
+  lastUsedState,
+  MAX_KEY_NAME_LENGTH,
+} from "../src/lib/api-keys-model.ts";
+
+const caps = (over: Partial<Capabilities>): Capabilities =>
+  ({
+    profile: "cloud",
+    revealInOs: false,
+    terminal: false,
+    tunnel: false,
+    codeExecution: "remote-sandbox",
+    providers: [],
+    openaiCompatible: false,
+    integrations: [],
+    ...over,
+  }) as Capabilities;
+
+describe("apiKeysSupported", () => {
+  it("is true only when the capability flag is exactly true", () => {
+    strictEqual(apiKeysSupported(caps({ apiKeys: true })), true);
+    strictEqual(apiKeysSupported(caps({ apiKeys: false })), false);
+    strictEqual(apiKeysSupported(caps({})), false);
+    strictEqual(apiKeysSupported(null), false);
+  });
+});
+
+describe("isValidKeyName", () => {
+  it("requires 1..100 chars after trimming", () => {
+    strictEqual(isValidKeyName("My key"), true);
+    strictEqual(isValidKeyName("  padded  "), true);
+    strictEqual(isValidKeyName(""), false);
+    strictEqual(isValidKeyName("   "), false);
+    strictEqual(isValidKeyName("a".repeat(MAX_KEY_NAME_LENGTH)), true);
+    strictEqual(isValidKeyName("a".repeat(MAX_KEY_NAME_LENGTH + 1)), false);
+  });
+});
+
+describe("isKeyLimitError", () => {
+  it("matches only a 400 with a top-level key_limit code", () => {
+    strictEqual(
+      isKeyLimitError({ status: 400, body: { code: "key_limit" } }),
+      true,
+    );
+  });
+  it("rejects other statuses, codes, and shapes", () => {
+    strictEqual(
+      isKeyLimitError({ status: 500, body: { code: "key_limit" } }),
+      false,
+    );
+    strictEqual(
+      isKeyLimitError({ status: 400, body: { code: "other" } }),
+      false,
+    );
+    // The engine-client nests reasons under error.code; a flat key_limit must
+    // NOT be found there, and a nested one must NOT match (it is not top-level).
+    strictEqual(
+      isKeyLimitError({ status: 400, body: { error: { code: "key_limit" } } }),
+      false,
+    );
+    strictEqual(isKeyLimitError({ status: 400 }), false);
+    strictEqual(isKeyLimitError(null), false);
+    strictEqual(isKeyLimitError(new Error("boom")), false);
+  });
+});
+
+describe("isKeyGoneError", () => {
+  it("matches a 404 (revoke of an already-gone key)", () => {
+    strictEqual(isKeyGoneError({ status: 404 }), true);
+    strictEqual(
+      isKeyGoneError({ status: 404, body: { code: "not_found" } }),
+      true,
+    );
+  });
+  it("rejects other statuses and shapes", () => {
+    strictEqual(isKeyGoneError({ status: 400 }), false);
+    strictEqual(isKeyGoneError({ status: 500 }), false);
+    strictEqual(isKeyGoneError(null), false);
+    strictEqual(isKeyGoneError(undefined), false);
+    strictEqual(isKeyGoneError(new Error("boom")), false);
+  });
+});
+
+describe("lastUsedState", () => {
+  it("reports never for an absent or unparseable timestamp", () => {
+    strictEqual(lastUsedState({}).kind, "never");
+    strictEqual(lastUsedState({ lastUsedAt: undefined }).kind, "never");
+    strictEqual(lastUsedState({ lastUsedAt: "not-a-date" }).kind, "never");
+  });
+  it("reports the parsed instant for a valid timestamp", () => {
+    const iso = "2026-07-01T12:00:00.000Z";
+    const state = lastUsedState({ lastUsedAt: iso });
+    strictEqual(state.kind, "at");
+    if (state.kind === "at") strictEqual(state.atMs, Date.parse(iso));
+  });
+});

--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -106,6 +106,23 @@ end-state is that it dissolves into direct SDK consumption
   legacy desktop/Rust methods throw explicitly (`client/legacy-unsupported-mixin.ts`);
   there is no catch-all Proxy returning silent `[]`.
 
+**Hosted, capability-gated surfaces (worked example: C9 personal API keys).** A
+gateway-only feature adds ONE method across the four fetch layers in signature
+lockstep — miss one and the web typecheck fails: `ui/engine-client`
+(`client.ts` `request()` + a wire type in `types.ts`), the web adapter
+(`cp/<feature>.ts` `cpFetch` fns re-exported by `control-plane.ts` + a
+`client/<feature>-mixin.ts` with the `if (!this.ctx.cp)` off-cloud throw, composed
+in `client.ts`), and the app facade (`lib/tauri.ts` `call()` wrapper). Feature-
+detect with an optional `Capabilities` flag (C9 = `apiKeys?: boolean`), absent on
+desktop/self-host/older gateways — `capabilities()` returns the raw `/v1/capabilities`
+JSON, so a new optional flag needs NO adapter mapping. Gate the whole UI on it
+(the settings row + the query's `enabled`), keep pure logic (gate/validation/error
+classifier) in a `lib/*-model.ts` unit-tested under bare Node, and route an
+EXPECTED business 400 (e.g. `key_limit`, read off the gateway's flat top-level
+`body.code`) through `call()`'s `silence` predicate so it renders inline instead
+of the red bug toast. Files: `app/src/{lib/api-keys-model,hooks/queries/use-api-keys}.ts`
++ `components/settings/sections/api-keys*.tsx`.
+
 **Strict-additive / iOS-safe rule.** `@houston/sdk` is consumed by BOTH web AND
 the native iOS app (via the JavaScriptCore bridge, `bridge/entry.ts`). iOS reaches
 the SDK ONLY through dispatched bridge COMMANDS and subscribed SCOPES — never

--- a/packages/web/src/engine-adapter/client.ts
+++ b/packages/web/src/engine-adapter/client.ts
@@ -22,6 +22,7 @@ export { HoustonEngineError, isHoustonEngineError } from "./client/errors";
 import { ActivitiesMixin } from "./client/activities-mixin";
 import { AgentFilesMixin } from "./client/agent-files-mixin";
 import { AgentsMixin } from "./client/agents-mixin";
+import { ApiKeysMixin } from "./client/api-keys-mixin";
 import { HoustonClientBase } from "./client/base";
 import { BootMixin } from "./client/boot-mixin";
 import { ChatHistoryMixin } from "./client/chat-history-mixin";
@@ -61,8 +62,10 @@ const Composed = BootMixin(
                             IntegrationsMixin(
                               OrgsMixin(
                                 TeamsMixin(
-                                  PortableMixin(
-                                    LegacyUnsupportedMixin(HoustonClientBase),
+                                  ApiKeysMixin(
+                                    PortableMixin(
+                                      LegacyUnsupportedMixin(HoustonClientBase),
+                                    ),
                                   ),
                                 ),
                               ),

--- a/packages/web/src/engine-adapter/client/api-keys-mixin.ts
+++ b/packages/web/src/engine-adapter/client/api-keys-mixin.ts
@@ -1,0 +1,25 @@
+import * as controlPlane from "../control-plane";
+import type { BaseCtor } from "./mixin";
+
+/**
+ * Personal API keys (C9) — hosted gateway only. Off-cloud (`this.cp === null`)
+ * there is no public API, so every call throws; the frontend gates the whole
+ * surface on `capabilities.apiKeys`, so these are never reached there.
+ */
+export function ApiKeysMixin<TBase extends BaseCtor>(Base: TBase) {
+  class ApiKeys extends Base {
+    async listApiKeys(): Promise<controlPlane.ApiKey[]> {
+      if (!this.ctx.cp) throw new Error("API keys require the hosted gateway.");
+      return controlPlane.listApiKeys(this.ctx.cp);
+    }
+    async createApiKey(name: string): Promise<controlPlane.ApiKeyCreated> {
+      if (!this.ctx.cp) throw new Error("API keys require the hosted gateway.");
+      return controlPlane.createApiKey(this.ctx.cp, name);
+    }
+    async revokeApiKey(id: string): Promise<void> {
+      if (!this.ctx.cp) throw new Error("API keys require the hosted gateway.");
+      return controlPlane.revokeApiKey(this.ctx.cp, id);
+    }
+  }
+  return ApiKeys;
+}

--- a/packages/web/src/engine-adapter/control-plane.ts
+++ b/packages/web/src/engine-adapter/control-plane.ts
@@ -24,6 +24,8 @@ export type {
   AgentMoveStart,
   AgentMoveStatus,
   AgentSettings,
+  ApiKey,
+  ApiKeyCreated,
   AuditEntry,
   BillingCheckout,
   BillingSummary,
@@ -47,6 +49,7 @@ export type {
 export * from "./cp/agent-color";
 export * from "./cp/agent-teams";
 export * from "./cp/agents";
+export * from "./cp/api-keys";
 export * from "./cp/board";
 export * from "./cp/credentials";
 export * from "./cp/events";

--- a/packages/web/src/engine-adapter/cp/api-keys.ts
+++ b/packages/web/src/engine-adapter/cp/api-keys.ts
@@ -1,0 +1,53 @@
+import type {
+  ApiKey,
+  ApiKeyCreated,
+} from "../../../../../ui/engine-client/src/types";
+import { type ControlPlaneConfig, cpFetch } from "./fetch";
+
+/**
+ * Personal API keys (C9 §Credential) — the user's programmatic credential for
+ * the public API. Always mounted on the gateway (no control-plane dependency),
+ * but the frontend gates the whole surface on `capabilities.apiKeys`, so these
+ * are never reached off a gateway that serves the public API.
+ *
+ * Every call routes through `cpFetch`, so a non-2xx surfaces as a
+ * `HoustonEngineError` carrying the gateway's reason (never swallowed). The
+ * `key_limit` 400 therefore reaches the caller intact for its inline treatment.
+ */
+
+/** The caller's active API keys, newest first. No secrets — display prefixes only. */
+export async function listApiKeys(cfg: ControlPlaneConfig): Promise<ApiKey[]> {
+  const res = await cpFetch(cfg, "/v1/keys");
+  const body = (await res.json()) as { keys: ApiKey[] };
+  return body.keys;
+}
+
+/**
+ * Mint a personal API key. Returns the FULL secret (`key`) exposed ONLY here and
+ * never retrievable again, so the caller reveals it once and keeps it out of any
+ * cache. ≥20 active keys → `400 {code:"key_limit"}`; every error throws so the UI
+ * surfaces the real reason (the limit inline, anything else as a bug toast).
+ */
+export async function createApiKey(
+  cfg: ControlPlaneConfig,
+  name: string,
+): Promise<ApiKeyCreated> {
+  const res = await cpFetch(cfg, "/v1/keys", {
+    method: "POST",
+    body: JSON.stringify({ name }),
+  });
+  return (await res.json()) as ApiKeyCreated;
+}
+
+/**
+ * Soft-revoke a key by id. Idempotent from the user's view: an unknown, foreign,
+ * or already-revoked id answers `404` (no existence leak). No body on success.
+ */
+export async function revokeApiKey(
+  cfg: ControlPlaneConfig,
+  id: string,
+): Promise<void> {
+  await cpFetch(cfg, `/v1/keys/${encodeURIComponent(id)}`, {
+    method: "DELETE",
+  });
+}

--- a/ui/engine-client/src/client.ts
+++ b/ui/engine-client/src/client.ts
@@ -22,6 +22,8 @@ import type {
   AgentMoveStart,
   AgentMoveStatus,
   AgentSettings,
+  ApiKey,
+  ApiKeyCreated,
   AttachmentManifest,
   AttachmentUploadResult,
   AuditEntry,
@@ -1401,6 +1403,41 @@ export class HoustonClient {
    */
   createPortal(): Promise<BillingCheckout> {
     return this.request("POST", "/org/billing/portal", {});
+  }
+
+  // ---------- personal API keys (C9) — hosted gateway only ----------
+  //
+  // The user's programmatic credential for the public API. `listApiKeys` reads
+  // the active keys (no secrets); `createApiKey` mints one and returns the FULL
+  // secret exactly once; `revokeApiKey` soft-revokes by id. The frontend gates
+  // the whole surface on `capabilities.apiKeys`, so off-gateway hosts never call
+  // these.
+
+  /**
+   * The caller's active API keys, newest first (C9 §Routes). No secrets — each
+   * entry carries only its display `prefix`. A GET, so it replays safely on a
+   * transient transport blip.
+   */
+  listApiKeys(): Promise<ApiKey[]> {
+    return this.request<{ keys: ApiKey[] }>("GET", "/keys").then((r) => r.keys);
+  }
+  /**
+   * Mint a personal API key (C9). Returns the FULL secret in `key`, exposed ONLY
+   * here and never retrievable again, so the caller reveals it once and keeps it
+   * out of any cache. `name` is trimmed 1..100 server-side; ≥20 active keys →
+   * `400 {code:"key_limit"}`, which the UI renders inline (revoke to free a
+   * slot). A POST, so `send` never auto-replays it.
+   */
+  createApiKey(name: string): Promise<ApiKeyCreated> {
+    return this.request("POST", "/keys", { name });
+  }
+  /**
+   * Soft-revoke a key by id (C9). Idempotent from the user's view: an unknown,
+   * foreign, or already-revoked id answers `404` (no existence leak). Returns
+   * nothing on success (`204`).
+   */
+  revokeApiKey(id: string): Promise<void> {
+    return this.request("DELETE", `/keys/${this.seg(id)}`);
   }
 
   // ---------- per-agent assignments + integration grants (multiplayer) ----------

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -107,6 +107,14 @@ export interface Capabilities {
    * flag only — the gateway/host is the sole enforcer.
    */
   triggers?: boolean;
+  /**
+   * Whether this deployment serves the C9 public API, so the user can mint and
+   * revoke personal API keys (`GET/POST/DELETE /v1/keys`) to drive their agents
+   * from their own tools. A feature-detect flag the frontend reads to show the
+   * API-keys settings section; absent/false on desktop/self-host and on gateways
+   * that predate the public API. The gateway is the sole enforcer.
+   */
+  apiKeys?: boolean;
 }
 
 // ---------- Org / roles (multiplayer) ----------
@@ -213,6 +221,33 @@ export interface BillingSummary {
  */
 export interface BillingCheckout {
   url: string;
+}
+
+/**
+ * One active personal API key (C9 §Credential), from `GET /v1/keys` and (minus
+ * the secret) the mint response. `prefix` is the display-safe head of the key
+ * (`hst_` + first 8 hex) shown so the user can tell keys apart; the full secret
+ * is NEVER carried here. `lastUsedAt` is absent until the key first authenticates
+ * a request.
+ */
+export interface ApiKey {
+  id: string;
+  name: string;
+  prefix: string;
+  /** ISO-8601 creation instant. */
+  createdAt: string;
+  /** ISO-8601 instant the key last authenticated a request; absent if never used. */
+  lastUsedAt?: string;
+}
+
+/**
+ * The mint response of `POST /v1/keys` (C9): a fresh key plus its FULL secret.
+ * `key` (`hst_` + 64 hex) appears ONLY in this response and can never be
+ * retrieved again, so the UI holds it in local state for the one-time reveal and
+ * MUST keep it out of any query cache.
+ */
+export interface ApiKeyCreated extends ApiKey {
+  key: string;
 }
 
 /**

--- a/website/eleventy.config.js
+++ b/website/eleventy.config.js
@@ -24,6 +24,7 @@ export default function (eleventyConfig) {
   // no bundler, no runtime CDN dependency.
   eleventyConfig.addPassthroughCopy("src/assets");
   eleventyConfig.addPassthroughCopy("src/learn/style.css");
+  eleventyConfig.addPassthroughCopy("src/developers/style.css");
   // Workshop guides: screenshots + downloadable PDFs and agent file
   eleventyConfig.addPassthroughCopy("src/guides/assets");
   eleventyConfig.addPassthroughCopy("src/guides/downloads");

--- a/website/src/_includes/footer-developers.njk
+++ b/website/src/_includes/footer-developers.njk
@@ -1,0 +1,49 @@
+<footer class="footer">
+  <div>
+    Houston is free and open source. The public API runs on Houston Cloud.
+  </div>
+  <div style="margin-top: 12px; display: flex; gap: 16px; font-size: 12px; color: var(--gray-500); flex-wrap: wrap; justify-content: center;">
+    <a href="/learn/" style="color: var(--gray-500);">Learn</a>
+    <a href="/changelog/" style="color: var(--gray-500);">Changelog</a>
+    <a href="/privacy/" style="color: var(--gray-500);">Privacy Policy</a>
+    <a href="/terms/" style="color: var(--gray-500);">Terms of Service</a>
+  </div>
+</footer>
+
+<script>
+  // Hamburger menu (mirrors footer-learn.njk)
+  (function() {
+    var burger = document.getElementById('nav-burger');
+    var dropdown = document.getElementById('nav-dropdown');
+    var icon = document.getElementById('burger-icon');
+    if (!burger || !dropdown) return;
+    burger.addEventListener('click', function() {
+      var open = dropdown.classList.toggle('open');
+      icon.innerHTML = open ? '<path d="M18 6L6 18M6 6l12 12"/>' : '<path d="M4 6h16M4 12h16M4 18h16"/>';
+    });
+    dropdown.querySelectorAll('a').forEach(function(a) {
+      a.addEventListener('click', function() { dropdown.classList.remove('open'); icon.innerHTML = '<path d="M4 6h16M4 12h16M4 18h16"/>'; });
+    });
+  })();
+
+  // Copy-to-clipboard for code blocks.
+  (function() {
+    document.querySelectorAll('.codeblock').forEach(function(block) {
+      var pre = block.querySelector('pre');
+      if (!pre) return;
+      var btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'copy-btn';
+      btn.textContent = 'Copy';
+      btn.setAttribute('aria-label', 'Copy code to clipboard');
+      btn.addEventListener('click', function() {
+        navigator.clipboard.writeText(pre.innerText).then(function() {
+          btn.textContent = 'Copied';
+          btn.classList.add('copied');
+          setTimeout(function() { btn.textContent = 'Copy'; btn.classList.remove('copied'); }, 1600);
+        });
+      });
+      block.appendChild(btn);
+    });
+  })();
+</script>

--- a/website/src/_includes/nav-docs.njk
+++ b/website/src/_includes/nav-docs.njk
@@ -3,6 +3,7 @@
   <a href="/" class="nav-logo">Houston</a>
   <div class="nav-center">
     <a href="/learn/">Learn</a>
+    <a href="/developers/">Developers</a>
     <a href="/vision/">Vision</a>
     <a href="/startups/">For Startups</a>
   </div>
@@ -19,6 +20,7 @@
 
 <div class="nav-dropdown" id="nav-dropdown">
   <a href="/learn/">Learn</a>
+  <a href="/developers/">Developers</a>
   <a href="/vision/">Vision</a>
   <a href="/startups/">For Startups</a>
   <a href="https://github.com/gethouston/houston" target="_blank" rel="noopener noreferrer">

--- a/website/src/_includes/sidebar-developers.njk
+++ b/website/src/_includes/sidebar-developers.njk
@@ -1,0 +1,27 @@
+{# Developers sidebar navigation. Set `activeDoc` in front matter to highlight the current page.
+   Values: "overview", "missions", "a2a", "mcp" #}
+<aside class="sidebar">
+  <div class="sidebar-label">Developers</div>
+  <ul class="sidebar-nav">
+    <li>
+      <a href="/developers/"{% if activeDoc == "overview" %} class="active"{% endif %}>
+        <span class="num">—</span>Overview
+      </a>
+    </li>
+    <li>
+      <a href="/developers/missions/"{% if activeDoc == "missions" %} class="active"{% endif %}>
+        <span class="num">01</span>Missions (REST)
+      </a>
+    </li>
+    <li>
+      <a href="/developers/a2a/"{% if activeDoc == "a2a" %} class="active"{% endif %}>
+        <span class="num">02</span>Agent2Agent
+      </a>
+    </li>
+    <li>
+      <a href="/developers/mcp/"{% if activeDoc == "mcp" %} class="active"{% endif %}>
+        <span class="num">03</span>MCP
+      </a>
+    </li>
+  </ul>
+</aside>

--- a/website/src/developers/a2a/index.html
+++ b/website/src/developers/a2a/index.html
@@ -59,7 +59,7 @@ lang: en
           <span class="method get">GET</span>
           <span class="path">/a2a/<b>:org</b>/<b>:agent</b>/.well-known/agent-card.json</span>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl https://gateway.gethouston.ai/a2a/acme/revenue-manager/.well-known/agent-card.json \
+        <div class="codeblock"><pre><code>{% raw %}curl https://poc-gateway.gethouston.ai/a2a/acme/revenue-manager/.well-known/agent-card.json \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <p>
           Feed that card URL to your A2A client. <code>:org</code> is your
@@ -83,7 +83,7 @@ lang: en
           Send a message to the agent and open a task. The response contains
           the task, whose <code>status.state</code> you then poll or stream.
         </p>
-        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://gateway.gethouston.ai/a2a/acme/revenue-manager \
+        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://poc-gateway.gethouston.ai/a2a/acme/revenue-manager \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
   -H "Content-Type: application/json" \
   -d '{
@@ -116,7 +116,7 @@ lang: en
           and status updates that ends when the task reaches a terminal state.
           Use this for live progress.
         </p>
-        <div class="codeblock"><pre><code>{% raw %}curl -N -X POST https://gateway.gethouston.ai/a2a/acme/revenue-manager \
+        <div class="codeblock"><pre><code>{% raw %}curl -N -X POST https://poc-gateway.gethouston.ai/a2a/acme/revenue-manager \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
   -H "Content-Type: application/json" \
   -d '{

--- a/website/src/developers/a2a/index.html
+++ b/website/src/developers/a2a/index.html
@@ -1,0 +1,220 @@
+---
+activeDoc: a2a
+lang: en
+---
+{% extends "base.njk" %}
+{% block title %}Agent2Agent (A2A) — Houston API{% endblock %}
+{% block meta %}
+<meta name="description" content="Connect any A2A-capable agent to Houston. Fetch the agent card, send messages over JSON-RPC, stream results, and manage tasks with message/send, message/stream, tasks/get, and tasks/cancel.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://gethouston.ai/developers/a2a/">
+<meta property="og:title" content="Agent2Agent (A2A) — Houston API">
+<meta property="og:description" content="Point any A2A-capable agent (LangGraph, CrewAI, ADK) at your Houston agent.">
+<meta property="og:site_name" content="Houston">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="alternate" hreflang="en" href="https://gethouston.ai/developers/a2a/">
+<link rel="alternate" hreflang="x-default" href="https://gethouston.ai/developers/a2a/">
+{% endblock %}
+{% block stylesheets %}
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/developers/style.css">
+{% endblock %}
+{% block body %}
+    {% include "nav-docs.njk" %}
+
+    <div class="layout">
+      {% include "sidebar-developers.njk" %}
+
+      <main class="content">
+        <div class="content-label">Developers · A2A</div>
+        <h1>Agent2Agent.</h1>
+        <p class="lead">
+          Houston agents speak the Agent2Agent (A2A) protocol, so you can
+          point any A2A-capable agent, such as LangGraph, CrewAI, or Google's
+          ADK, straight at a Houston agent and delegate work to it. A2A is
+          JSON-RPC 2.0 over HTTP, authenticated with your
+          <code>hst_...</code> API key.
+        </p>
+
+        <div class="toc">
+          <div class="toc-label">On this page</div>
+          <ol>
+            <li><a href="#card">The agent card</a></li>
+            <li><a href="#endpoint">The JSON-RPC endpoint</a></li>
+            <li><a href="#send">message/send</a></li>
+            <li><a href="#stream">message/stream</a></li>
+            <li><a href="#multiturn">Multi-turn with taskId</a></li>
+            <li><a href="#tasks">tasks/get &amp; tasks/cancel</a></li>
+            <li><a href="#states">Task states</a></li>
+            <li><a href="#errors">Error codes</a></li>
+          </ol>
+        </div>
+
+        <h2 id="card">The agent card</h2>
+        <p>
+          Every Houston agent publishes an A2A agent card describing its name,
+          capabilities, and endpoint. Fetch it (authenticated) at:
+        </p>
+        <div class="endpoint">
+          <span class="method get">GET</span>
+          <span class="path">/a2a/<b>:org</b>/<b>:agent</b>/.well-known/agent-card.json</span>
+        </div>
+        <div class="codeblock"><pre><code>{% raw %}curl https://gateway.gethouston.ai/a2a/acme/revenue-manager/.well-known/agent-card.json \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
+        <p>
+          Feed that card URL to your A2A client. <code>:org</code> is your
+          organization slug and <code>:agent</code> is the agent slug (the
+          same one the REST API uses).
+        </p>
+
+        <h2 id="endpoint">The JSON-RPC endpoint</h2>
+        <div class="endpoint">
+          <span class="method post">POST</span>
+          <span class="path">/a2a/<b>:org</b>/<b>:agent</b></span>
+        </div>
+        <p>
+          All A2A methods are JSON-RPC 2.0 calls to this one endpoint. Houston
+          supports <code>message/send</code>, <code>message/stream</code>,
+          <code>tasks/get</code>, and <code>tasks/cancel</code>.
+        </p>
+
+        <h2 id="send">message/send</h2>
+        <p>
+          Send a message to the agent and open a task. The response contains
+          the task, whose <code>status.state</code> you then poll or stream.
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://gateway.gethouston.ai/a2a/acme/revenue-manager \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/send",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [
+          { "kind": "text", "text": "Run a market pulse for Lisbon next weekend." }
+        ]
+      }
+    }
+  }'{% endraw %}</code></pre></div>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "jsonrpc": "2.0",
+  "id": "1",
+  "result": {
+    "kind": "task",
+    "id": "task_5f2c1a7b4e",
+    "contextId": "ctx_8d0364f1a2",
+    "status": { "state": "working" }
+  }
+}{% endraw %}</code></pre></div>
+
+        <h2 id="stream">message/stream</h2>
+        <p>
+          Same call, but the response is a Server-Sent Events stream of task
+          and status updates that ends when the task reaches a terminal state.
+          Use this for live progress.
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}curl -N -X POST https://gateway.gethouston.ai/a2a/acme/revenue-manager \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": "1",
+    "method": "message/stream",
+    "params": {
+      "message": {
+        "role": "user",
+        "parts": [ { "kind": "text", "text": "Summarize this week for Lisbon." } ]
+      }
+    }
+  }'{% endraw %}</code></pre></div>
+
+        <h2 id="multiturn">Multi-turn with taskId</h2>
+        <p>
+          To continue an existing task, for example to answer a follow-up
+          question the agent asked, send another message with the same
+          <code>taskId</code>. Houston routes it to the same running mission
+          instead of starting a new one.
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "jsonrpc": "2.0",
+  "id": "2",
+  "method": "message/send",
+  "params": {
+    "taskId": "task_5f2c1a7b4e",
+    "message": {
+      "role": "user",
+      "parts": [ { "kind": "text", "text": "Yes, include Porto too." } ]
+    }
+  }
+}{% endraw %}</code></pre></div>
+
+        <h2 id="tasks">tasks/get &amp; tasks/cancel</h2>
+        <p>Fetch a task's current state:</p>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "jsonrpc": "2.0",
+  "id": "3",
+  "method": "tasks/get",
+  "params": { "id": "task_5f2c1a7b4e" }
+}{% endraw %}</code></pre></div>
+        <p>Cancel a running task:</p>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "jsonrpc": "2.0",
+  "id": "4",
+  "method": "tasks/cancel",
+  "params": { "id": "task_5f2c1a7b4e" }
+}{% endraw %}</code></pre></div>
+
+        <h2 id="states">Task states</h2>
+        <p>
+          A2A task states map directly onto Houston mission status:
+        </p>
+        <div class="table-scroll">
+        <table class="fields-table">
+          <thead><tr><th>A2A task state</th><th>Houston mission</th><th>Meaning</th></tr></thead>
+          <tbody>
+            <tr><td><code>working</code></td><td>running</td><td>The agent is actively working.</td></tr>
+            <tr><td><code>completed</code></td><td>completed</td><td>Terminal. The result is attached to the task.</td></tr>
+            <tr><td><code>failed</code></td><td>failed</td><td>Terminal. The mission errored.</td></tr>
+            <tr><td><code>canceled</code></td><td>canceled</td><td>Terminal. The task was canceled.</td></tr>
+          </tbody>
+        </table>
+        </div>
+
+        <h2 id="errors">Error codes</h2>
+        <p>
+          Alongside the standard JSON-RPC errors, Houston returns the A2A
+          task errors:
+        </p>
+        <div class="table-scroll">
+        <table class="fields-table">
+          <thead><tr><th>Code</th><th>Name</th><th>When</th></tr></thead>
+          <tbody>
+            <tr><td><code>-32001</code></td><td>TaskNotFound</td><td>No task exists for the given <code>id</code>.</td></tr>
+            <tr><td><code>-32002</code></td><td>TaskNotCancelable</td><td>The task already reached a terminal state and cannot be canceled.</td></tr>
+          </tbody>
+        </table>
+        </div>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "jsonrpc": "2.0",
+  "id": "4",
+  "error": { "code": -32002, "message": "Task cannot be canceled" }
+}{% endraw %}</code></pre></div>
+
+        <div class="pager">
+          <a href="/developers/missions/">
+            <div class="pager-label">← Previous</div>
+            <div class="pager-title">Missions (REST)</div>
+          </a>
+          <a href="/developers/mcp/" class="next">
+            <div class="pager-label">Next →</div>
+            <div class="pager-title">MCP</div>
+          </a>
+        </div>
+      </main>
+    </div>
+
+    {% include "footer-developers.njk" %}
+  {% endblock %}

--- a/website/src/developers/index.html
+++ b/website/src/developers/index.html
@@ -73,7 +73,7 @@ lang: en
           All endpoints live on the Houston Cloud gateway:
         </p>
         <div class="endpoint">
-          <span class="path"><b>https://gateway.gethouston.ai</b></span>
+          <span class="path"><b>https://poc-gateway.gethouston.ai</b></span>
         </div>
         <p>
           Every path below is relative to that origin. All requests and
@@ -129,7 +129,7 @@ lang: en
           <span class="method post">POST</span>
           <span class="path">/v1/agents/<b>:slug</b>/missions</span>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://gateway.gethouston.ai/v1/agents/revenue-manager/missions \
+        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
   -H "Content-Type: application/json" \
   -d '{
@@ -177,7 +177,7 @@ lang: en
           <span class="method get">GET</span>
           <span class="path">/v1/agents/<b>:slug</b>/missions/<b>:id</b></span>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl https://gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b \
+        <div class="codeblock"><pre><code>{% raw %}curl https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <div class="codeblock"><pre><code>{% raw %}{
   "id": "msn_7Q4c1a9f2b",
@@ -193,7 +193,7 @@ lang: en
           <span class="method get">GET</span>
           <span class="path">/v1/agents/<b>:slug</b>/missions/<b>:id</b>/events</span>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl -N https://gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b/events \
+        <div class="codeblock"><pre><code>{% raw %}curl -N https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b/events \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <div class="callout callout-info">
           <div class="callout-label">Streaming in the browser</div>
@@ -214,7 +214,7 @@ lang: en
           <span class="method get">GET</span>
           <span class="path">/agents</span>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl https://gateway.gethouston.ai/agents \
+        <div class="codeblock"><pre><code>{% raw %}curl https://poc-gateway.gethouston.ai/agents \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
 
         <div class="callout callout-success">

--- a/website/src/developers/index.html
+++ b/website/src/developers/index.html
@@ -1,0 +1,244 @@
+---
+activeDoc: overview
+lang: en
+---
+{% extends "base.njk" %}
+{% block title %}Houston API — Run and drive agent missions programmatically{% endblock %}
+{% block meta %}
+<meta name="description" content="The Houston public API: start and drive AI agent missions from your own code over REST, Agent2Agent (A2A), and MCP. Authenticate with an API key and get running in 60 seconds.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://gethouston.ai/developers/">
+<meta property="og:title" content="Houston API — Run agent missions programmatically">
+<meta property="og:description" content="Start and drive Houston agent missions from your own code over REST, A2A, and MCP.">
+<meta property="og:site_name" content="Houston">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="alternate" hreflang="en" href="https://gethouston.ai/developers/">
+<link rel="alternate" hreflang="x-default" href="https://gethouston.ai/developers/">
+{% endblock %}
+{% block stylesheets %}
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/developers/style.css">
+{% endblock %}
+{% block body %}
+    {% include "nav-docs.njk" %}
+
+    <div class="layout">
+      {% include "sidebar-developers.njk" %}
+
+      <main class="content hero">
+        <div class="content-label">Developers</div>
+        <h1>The Houston API.</h1>
+        <p class="lead">
+          Start and drive your Houston agents' missions from your own code.
+          One API key, three ways in: a REST API, the Agent2Agent (A2A)
+          protocol, and MCP. Give an agent an instruction, then poll, stream,
+          or get a signed webhook when it finishes.
+        </p>
+
+        <div class="hero-actions">
+          <a class="btn btn-primary" href="#quickstart">60-second quickstart</a>
+          <a class="btn btn-secondary" href="/developers/missions/">REST reference</a>
+        </div>
+
+        <h2 id="what">What the API does</h2>
+        <p>
+          Every Houston agent runs <strong>missions</strong>: you hand it an
+          instruction in natural language, it does the work across your
+          connected tools, and it returns a result. The API exposes that
+          exact loop programmatically, so you can trigger agents from a cron
+          job, a backend, another agent, or any tool that speaks MCP or A2A.
+        </p>
+
+        <h2 id="auth">Authentication</h2>
+        <p>
+          The API authenticates with an <strong>API key</strong>. Mint one in
+          the Houston app under <code>Settings → API Keys</code>. Keys look
+          like <code>hst_...</code> and are <strong>shown only once</strong> at
+          creation, so copy it somewhere safe immediately.
+        </p>
+        <p>Send it as a bearer token on every request:</p>
+        <div class="codeblock"><pre><code>{% raw %}Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708{% endraw %}</code></pre></div>
+        <div class="callout callout-warning">
+          <div class="callout-label">Keep keys server-side</div>
+          <p>
+            An API key can start missions and read their results. Treat it
+            like a password: never ship it in a browser, mobile app, or public
+            repository. You can revoke a key at any time from
+            <code>Settings → API Keys</code>.
+          </p>
+        </div>
+
+        <h2 id="base-url">Base URL</h2>
+        <p>
+          All endpoints live on the Houston Cloud gateway:
+        </p>
+        <div class="endpoint">
+          <span class="path"><b>https://gateway.gethouston.ai</b></span>
+        </div>
+        <p>
+          Every path below is relative to that origin. All requests and
+          responses are JSON (<code>application/json</code>), except the
+          streaming endpoints, which are Server-Sent Events.
+        </p>
+
+        <h2 id="surfaces">Three surfaces</h2>
+        <p>
+          Pick the surface that fits how you are integrating. They all drive
+          the same agents and the same missions underneath.
+        </p>
+        <div class="card-grid">
+          <a class="surface-card" href="/developers/missions/">
+            <div class="surface-kicker">REST</div>
+            <div class="surface-title">Missions API</div>
+            <div class="surface-desc">
+              Plain HTTP + JSON. Create a mission, poll or stream it, cancel
+              it, and receive signed webhooks. The most direct way in.
+            </div>
+          </a>
+          <a class="surface-card" href="/developers/a2a/">
+            <div class="surface-kicker">A2A</div>
+            <div class="surface-title">Agent2Agent</div>
+            <div class="surface-desc">
+              A standard JSON-RPC agent protocol. Point any A2A-capable agent
+              (LangGraph, CrewAI, ADK) straight at your Houston agent.
+            </div>
+          </a>
+          <a class="surface-card" href="/developers/mcp/">
+            <div class="surface-kicker">MCP</div>
+            <div class="surface-title">Model Context Protocol</div>
+            <div class="surface-desc">
+              Expose your agents as tools to Claude Code and any MCP client
+              over a single Streamable HTTP endpoint.
+            </div>
+          </a>
+        </div>
+
+        <h2 id="quickstart">60-second quickstart</h2>
+        <p>
+          This uses the REST Missions API. Replace <code>hst_...</code> with
+          your key and <code>revenue-manager</code> with your agent's slug.
+        </p>
+
+        <h3>1 · Start a mission</h3>
+        <p>
+          <code>POST</code> an instruction to the agent. You get a
+          <code>202 Accepted</code> back immediately with the mission id; the
+          agent keeps working in the background.
+        </p>
+        <div class="endpoint">
+          <span class="method post">POST</span>
+          <span class="path">/v1/agents/<b>:slug</b>/missions</span>
+        </div>
+        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://gateway.gethouston.ai/v1/agents/revenue-manager/missions \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "Run a market pulse for Lisbon, check-in 2026-08-14 for 3 nights.",
+    "mode": "auto",
+    "webhook": {
+      "url": "https://api.acme.com/hooks/houston",
+      "secret": "whsec_a1b2c3d4e5f6"
+    }
+  }'{% endraw %}</code></pre></div>
+        <p><strong>202 Accepted</strong></p>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "id": "msn_7Q4c1a9f2b",
+  "agentSlug": "revenue-manager",
+  "conversationId": "cnv_3e8d0364f1",
+  "status": "running",
+  "createdAt": "2026-07-12T09:31:07.482Z"
+}{% endraw %}</code></pre></div>
+
+        <h3>2 · Get the result</h3>
+        <p>
+          You have three ways to learn how the mission ends. Use whichever
+          fits your stack:
+        </p>
+        <ul>
+          <li>
+            <strong>Poll</strong> the mission until <code>status</code>
+            becomes terminal (<code>completed</code>, <code>failed</code>, or
+            <code>canceled</code>). The <code>result</code> field carries the
+            agent's final text.
+          </li>
+          <li>
+            <strong>Stream</strong> live progress over Server-Sent Events, with
+            <code>Last-Event-ID</code> resume.
+          </li>
+          <li>
+            <strong>Webhook</strong> — the simplest for servers. Houston
+            <code>POST</code>s a signed payload to your URL the moment the
+            mission finishes. No polling.
+          </li>
+        </ul>
+
+        <p><strong>Poll:</strong></p>
+        <div class="endpoint">
+          <span class="method get">GET</span>
+          <span class="path">/v1/agents/<b>:slug</b>/missions/<b>:id</b></span>
+        </div>
+        <div class="codeblock"><pre><code>{% raw %}curl https://gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "id": "msn_7Q4c1a9f2b",
+  "agentSlug": "revenue-manager",
+  "conversationId": "cnv_3e8d0364f1",
+  "status": "completed",
+  "result": "Market pulse for Lisbon (Aug 14-17) is ready...",
+  "createdAt": "2026-07-12T09:31:07.482Z"
+}{% endraw %}</code></pre></div>
+
+        <p><strong>Or stream</strong> with Server-Sent Events:</p>
+        <div class="endpoint">
+          <span class="method get">GET</span>
+          <span class="path">/v1/agents/<b>:slug</b>/missions/<b>:id</b>/events</span>
+        </div>
+        <div class="codeblock"><pre><code>{% raw %}curl -N https://gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b/events \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
+        <div class="callout callout-info">
+          <div class="callout-label">Streaming in the browser</div>
+          <p>
+            <code>EventSource</code> cannot set headers, so the events
+            endpoint also accepts the key as a query parameter:
+            <code>?token=hst_...</code>. Reconnect from where you left off by
+            sending the <code>Last-Event-ID</code> header (curl and native SSE
+            clients do this automatically).
+          </p>
+        </div>
+
+        <h3>3 · Find your agents</h3>
+        <p>
+          Do not know an agent's slug? List everything the key can reach:
+        </p>
+        <div class="endpoint">
+          <span class="method get">GET</span>
+          <span class="path">/agents</span>
+        </div>
+        <div class="codeblock"><pre><code>{% raw %}curl https://gateway.gethouston.ai/agents \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
+
+        <div class="callout callout-success">
+          <div class="callout-label">That's the whole loop</div>
+          <p>
+            Create → poll, stream, or await a webhook → read the result. The
+            <a class="link" href="/developers/missions/">Missions reference</a>
+            documents every field, webhook signing, cancellation, and key
+            scoping in full.
+          </p>
+        </div>
+
+        <div class="pager">
+          <a href="/learn/">
+            <div class="pager-label">← Learn</div>
+            <div class="pager-title">Building agents on Houston</div>
+          </a>
+          <a href="/developers/missions/" class="next">
+            <div class="pager-label">Next →</div>
+            <div class="pager-title">Missions (REST) reference</div>
+          </a>
+        </div>
+      </main>
+    </div>
+
+    {% include "footer-developers.njk" %}
+  {% endblock %}

--- a/website/src/developers/mcp/index.html
+++ b/website/src/developers/mcp/index.html
@@ -67,13 +67,13 @@ lang: en
 
         <h2 id="connect">Connect a client</h2>
         <p>
-          Point any MCP client at <code>https://gateway.gethouston.ai/mcp</code>
+          Point any MCP client at <code>https://poc-gateway.gethouston.ai/mcp</code>
           with your key in the <code>Authorization</code> header.
         </p>
 
         <h3>Claude Code</h3>
         <p>Add it from the CLI:</p>
-        <div class="codeblock"><pre><code>{% raw %}claude mcp add --transport http houston https://gateway.gethouston.ai/mcp \
+        <div class="codeblock"><pre><code>{% raw %}claude mcp add --transport http houston https://poc-gateway.gethouston.ai/mcp \
   --header "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <p>
           Or add it to your project's <code>.mcp.json</code> (the same shape
@@ -83,7 +83,7 @@ lang: en
   "mcpServers": {
     "houston": {
       "type": "http",
-      "url": "https://gateway.gethouston.ai/mcp",
+      "url": "https://poc-gateway.gethouston.ai/mcp",
       "headers": {
         "Authorization": "Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"
       }

--- a/website/src/developers/mcp/index.html
+++ b/website/src/developers/mcp/index.html
@@ -1,0 +1,192 @@
+---
+activeDoc: mcp
+lang: en
+---
+{% extends "base.njk" %}
+{% block title %}MCP — Houston API{% endblock %}
+{% block meta %}
+<meta name="description" content="Expose your Houston agents as tools over the Model Context Protocol. A single stateless Streamable HTTP endpoint with list_agents, start_mission, get_mission, and cancel_mission, plus a copy-paste config for Claude Code and other MCP clients.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://gethouston.ai/developers/mcp/">
+<meta property="og:title" content="MCP — Houston API">
+<meta property="og:description" content="Connect Claude Code and any MCP client to your Houston agents over one endpoint.">
+<meta property="og:site_name" content="Houston">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="alternate" hreflang="en" href="https://gethouston.ai/developers/mcp/">
+<link rel="alternate" hreflang="x-default" href="https://gethouston.ai/developers/mcp/">
+{% endblock %}
+{% block stylesheets %}
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/developers/style.css">
+{% endblock %}
+{% block body %}
+    {% include "nav-docs.njk" %}
+
+    <div class="layout">
+      {% include "sidebar-developers.njk" %}
+
+      <main class="content">
+        <div class="content-label">Developers · MCP</div>
+        <h1>MCP.</h1>
+        <p class="lead">
+          Houston exposes your agents as tools over the Model Context Protocol.
+          Connect Claude Code, or any MCP client, to one endpoint and let it
+          list your agents and start, check, and cancel their missions.
+        </p>
+
+        <div class="toc">
+          <div class="toc-label">On this page</div>
+          <ol>
+            <li><a href="#endpoint">The endpoint</a></li>
+            <li><a href="#connect">Connect a client</a></li>
+            <li><a href="#tools">Tools</a></li>
+          </ol>
+        </div>
+
+        <h2 id="endpoint">The endpoint</h2>
+        <div class="endpoint">
+          <span class="method post">POST</span>
+          <span class="path">/mcp</span>
+        </div>
+        <p>
+          A single <strong>Streamable HTTP</strong> MCP endpoint. It is
+          <strong>stateless</strong>, so there is no session to establish:
+          each request stands alone. It speaks protocol version
+          <code>2025-06-18</code>, and authenticates with your
+          <code>hst_...</code> API key as a bearer token.
+        </p>
+        <div class="callout callout-info">
+          <div class="callout-label">Stateless by design</div>
+          <p>
+            Because the endpoint keeps no session, it scales cleanly and
+            reconnects for free. Every call carries the
+            <code>Authorization</code> header; there is no separate
+            initialize-then-reuse handshake to manage.
+          </p>
+        </div>
+
+        <h2 id="connect">Connect a client</h2>
+        <p>
+          Point any MCP client at <code>https://gateway.gethouston.ai/mcp</code>
+          with your key in the <code>Authorization</code> header.
+        </p>
+
+        <h3>Claude Code</h3>
+        <p>Add it from the CLI:</p>
+        <div class="codeblock"><pre><code>{% raw %}claude mcp add --transport http houston https://gateway.gethouston.ai/mcp \
+  --header "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
+        <p>
+          Or add it to your project's <code>.mcp.json</code> (the same shape
+          works for other MCP clients that use a JSON server config):
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "mcpServers": {
+    "houston": {
+      "type": "http",
+      "url": "https://gateway.gethouston.ai/mcp",
+      "headers": {
+        "Authorization": "Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"
+      }
+    }
+  }
+}{% endraw %}</code></pre></div>
+        <div class="callout callout-warning">
+          <div class="callout-label">Do not commit your key</div>
+          <p>
+            <code>.mcp.json</code> is often checked into a repo. Keep the raw
+            key out of version control, for example by referencing an
+            environment variable if your client supports it, and revoke any
+            key that leaks from <code>Settings → API Keys</code>.
+          </p>
+        </div>
+
+        <h2 id="tools">Tools</h2>
+        <p>
+          The server exposes four tools. Their input schemas are standard JSON
+          Schema, so MCP clients render and validate them automatically.
+        </p>
+
+        <h3>list_agents</h3>
+        <p>Lists the agents your key can reach, with their slugs. No input.</p>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "name": "list_agents",
+  "description": "List the Houston agents this API key can drive.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {},
+    "additionalProperties": false
+  }
+}{% endraw %}</code></pre></div>
+
+        <h3>start_mission</h3>
+        <p>Starts a mission on an agent and returns the mission id and status.</p>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "name": "start_mission",
+  "description": "Start a mission on a Houston agent.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "agent": { "type": "string", "description": "The agent slug to run." },
+      "input": { "type": "string", "description": "The instruction for the agent." },
+      "mode":  { "type": "string", "enum": ["execute", "plan", "auto"], "default": "auto" }
+    },
+    "required": ["agent", "input"],
+    "additionalProperties": false
+  }
+}{% endraw %}</code></pre></div>
+
+        <h3>get_mission</h3>
+        <p>Returns a mission's status and, once terminal, its result.</p>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "name": "get_mission",
+  "description": "Get the status and result of a mission.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "missionId": { "type": "string" }
+    },
+    "required": ["missionId"],
+    "additionalProperties": false
+  }
+}{% endraw %}</code></pre></div>
+
+        <h3>cancel_mission</h3>
+        <p>Requests cancellation of a running mission.</p>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "name": "cancel_mission",
+  "description": "Cancel a running mission.",
+  "inputSchema": {
+    "type": "object",
+    "properties": {
+      "missionId": { "type": "string" }
+    },
+    "required": ["missionId"],
+    "additionalProperties": false
+  }
+}{% endraw %}</code></pre></div>
+
+        <div class="callout callout-success">
+          <div class="callout-label">In practice</div>
+          <p>
+            Once connected, ask your MCP client to "list my Houston agents,
+            then start a mission on the revenue manager." It calls
+            <code>list_agents</code>, then <code>start_mission</code>, then
+            <code>get_mission</code> to report the result.
+          </p>
+        </div>
+
+        <div class="pager">
+          <a href="/developers/a2a/">
+            <div class="pager-label">← Previous</div>
+            <div class="pager-title">Agent2Agent (A2A)</div>
+          </a>
+          <a href="/developers/" class="next">
+            <div class="pager-label">Next →</div>
+            <div class="pager-title">Overview</div>
+          </a>
+        </div>
+      </main>
+    </div>
+
+    {% include "footer-developers.njk" %}
+  {% endblock %}

--- a/website/src/developers/missions/index.html
+++ b/website/src/developers/missions/index.html
@@ -32,7 +32,7 @@ lang: en
           The REST Missions API is the most direct way to drive a Houston
           agent. Create a mission, then poll it, stream it, or wait for a
           signed webhook. All paths are on
-          <code>https://gateway.gethouston.ai</code> and take
+          <code>https://poc-gateway.gethouston.ai</code> and take
           <code>Authorization: Bearer hst_...</code>.
         </p>
 
@@ -78,7 +78,7 @@ lang: en
         </table>
         </div>
 
-        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://gateway.gethouston.ai/v1/agents/revenue-manager/missions \
+        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
   -H "Content-Type: application/json" \
   -d '{
@@ -114,7 +114,7 @@ lang: en
           </tbody>
         </table>
         </div>
-        <div class="codeblock"><pre><code>{% raw %}curl "https://gateway.gethouston.ai/v1/agents/revenue-manager/missions?limit=20" \
+        <div class="codeblock"><pre><code>{% raw %}curl "https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions?limit=20" \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <div class="codeblock"><pre><code>{% raw %}{
   "missions": [
@@ -142,7 +142,7 @@ lang: en
           <code>webhook</code> block recording when it was delivered, or the
           last error if delivery has not yet succeeded.
         </p>
-        <div class="codeblock"><pre><code>{% raw %}curl https://gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b \
+        <div class="codeblock"><pre><code>{% raw %}curl https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <div class="codeblock"><pre><code>{% raw %}{
   "id": "msn_7Q4c1a9f2b",
@@ -169,7 +169,7 @@ lang: en
           <code>Last-Event-ID</code> header to resume without gaps. Native SSE
           clients and curl do this for you.
         </p>
-        <div class="codeblock"><pre><code>{% raw %}curl -N https://gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b/events \
+        <div class="codeblock"><pre><code>{% raw %}curl -N https://poc-gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b/events \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
         <div class="callout callout-info">
           <div class="callout-label">Browser (EventSource)</div>
@@ -200,7 +200,7 @@ lang: en
           Lists the agents this key can reach, with the slugs you pass to the
           mission endpoints.
         </p>
-        <div class="codeblock"><pre><code>{% raw %}curl https://gateway.gethouston.ai/agents \
+        <div class="codeblock"><pre><code>{% raw %}curl https://poc-gateway.gethouston.ai/agents \
   -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
 
         <h2 id="scope">API-key scope &amp; limits</h2>

--- a/website/src/developers/missions/index.html
+++ b/website/src/developers/missions/index.html
@@ -1,0 +1,320 @@
+---
+activeDoc: missions
+lang: en
+---
+{% extends "base.njk" %}
+{% block title %}Missions (REST) — Houston API reference{% endblock %}
+{% block meta %}
+<meta name="description" content="Full REST reference for the Houston Missions API: create, list, get, stream, and cancel agent missions, API-key scope, and signed webhooks with HMAC-SHA256 verification.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://gethouston.ai/developers/missions/">
+<meta property="og:title" content="Missions (REST) — Houston API reference">
+<meta property="og:description" content="Create, list, get, stream, and cancel Houston agent missions, plus signed webhooks.">
+<meta property="og:site_name" content="Houston">
+<meta name="twitter:card" content="summary_large_image">
+<link rel="alternate" hreflang="en" href="https://gethouston.ai/developers/missions/">
+<link rel="alternate" hreflang="x-default" href="https://gethouston.ai/developers/missions/">
+{% endblock %}
+{% block stylesheets %}
+<link href="https://api.fontshare.com/v2/css?f[]=general-sans@500,600,700&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="/developers/style.css">
+{% endblock %}
+{% block body %}
+    {% include "nav-docs.njk" %}
+
+    <div class="layout">
+      {% include "sidebar-developers.njk" %}
+
+      <main class="content">
+        <div class="content-label">Developers · REST</div>
+        <h1>Missions.</h1>
+        <p class="lead">
+          The REST Missions API is the most direct way to drive a Houston
+          agent. Create a mission, then poll it, stream it, or wait for a
+          signed webhook. All paths are on
+          <code>https://gateway.gethouston.ai</code> and take
+          <code>Authorization: Bearer hst_...</code>.
+        </p>
+
+        <div class="toc">
+          <div class="toc-label">On this page</div>
+          <ol>
+            <li><a href="#create">Create a mission</a></li>
+            <li><a href="#list">List missions</a></li>
+            <li><a href="#get">Get a mission</a></li>
+            <li><a href="#events">Stream events (SSE)</a></li>
+            <li><a href="#cancel">Cancel a mission</a></li>
+            <li><a href="#agents">List agents</a></li>
+            <li><a href="#scope">API-key scope &amp; limits</a></li>
+            <li><a href="#webhooks">Webhooks</a></li>
+          </ol>
+        </div>
+
+        <h2 id="create">Create a mission</h2>
+        <div class="endpoint">
+          <span class="method post">POST</span>
+          <span class="path">/v1/agents/<b>:slug</b>/missions</span>
+        </div>
+        <p>
+          Starts a mission and returns <code>202 Accepted</code> right away.
+          The agent runs in the background; use the id in the response to
+          track it.
+        </p>
+
+        <h3>Request body</h3>
+        <div class="table-scroll">
+        <table class="fields-table">
+          <thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>input</code> <span class="req">required</span></td><td>string</td><td>The instruction for the agent, in natural language.</td></tr>
+            <tr><td><code>mode</code> <span class="opt">optional</span></td><td>string</td><td>One of <code>execute</code>, <code>plan</code>, or <code>auto</code>. Defaults to <code>auto</code> (the agent decides whether to plan first or act directly).</td></tr>
+            <tr><td><code>model</code> <span class="opt">optional</span></td><td>string</td><td>Override the model for this mission. Defaults to the agent's configured model.</td></tr>
+            <tr><td><code>effort</code> <span class="opt">optional</span></td><td>string</td><td>Reasoning effort for the mission. Defaults to the agent's setting.</td></tr>
+            <tr><td><code>title</code> <span class="opt">optional</span></td><td>string</td><td>A label for the mission, shown in the Houston app. Auto-generated if omitted.</td></tr>
+            <tr><td><code>webhook</code> <span class="opt">optional</span></td><td>object</td><td>Delivers a signed callback when the mission finishes. See <a class="link" href="#webhooks">Webhooks</a>.</td></tr>
+            <tr><td><code>webhook.url</code></td><td>string</td><td>Public <code>https://</code> URL to POST to. Private and internal addresses are rejected.</td></tr>
+            <tr><td><code>webhook.secret</code></td><td>string</td><td>Signing secret used to compute the <code>X-Houston-Signature</code> HMAC.</td></tr>
+          </tbody>
+        </table>
+        </div>
+
+        <div class="codeblock"><pre><code>{% raw %}curl -X POST https://gateway.gethouston.ai/v1/agents/revenue-manager/missions \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "input": "Draft the weekly competitor summary for the Lisbon property.",
+    "mode": "auto",
+    "model": "claude-opus-4-5",
+    "title": "Weekly competitor summary",
+    "webhook": {
+      "url": "https://api.acme.com/hooks/houston",
+      "secret": "whsec_a1b2c3d4e5f6"
+    }
+  }'{% endraw %}</code></pre></div>
+        <p><strong>202 Accepted</strong></p>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "id": "msn_7Q4c1a9f2b",
+  "agentSlug": "revenue-manager",
+  "conversationId": "cnv_3e8d0364f1",
+  "status": "running",
+  "createdAt": "2026-07-12T09:31:07.482Z"
+}{% endraw %}</code></pre></div>
+
+        <h2 id="list">List missions</h2>
+        <div class="endpoint">
+          <span class="method get">GET</span>
+          <span class="path">/v1/agents/<b>:slug</b>/missions</span>
+        </div>
+        <p>Returns the agent's missions, newest first.</p>
+        <div class="table-scroll">
+        <table class="fields-table">
+          <thead><tr><th>Query</th><th>Type</th><th>Description</th></tr></thead>
+          <tbody>
+            <tr><td><code>limit</code> <span class="opt">optional</span></td><td>integer</td><td>How many to return. Defaults to <code>50</code>, maximum <code>200</code>.</td></tr>
+          </tbody>
+        </table>
+        </div>
+        <div class="codeblock"><pre><code>{% raw %}curl "https://gateway.gethouston.ai/v1/agents/revenue-manager/missions?limit=20" \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "missions": [
+    {
+      "id": "msn_7Q4c1a9f2b",
+      "agentSlug": "revenue-manager",
+      "conversationId": "cnv_3e8d0364f1",
+      "status": "completed",
+      "createdAt": "2026-07-12T09:31:07.482Z"
+    }
+  ]
+}{% endraw %}</code></pre></div>
+
+        <h2 id="get">Get a mission</h2>
+        <div class="endpoint">
+          <span class="method get">GET</span>
+          <span class="path">/v1/agents/<b>:slug</b>/missions/<b>:id</b></span>
+        </div>
+        <p>
+          Returns the mission's current state. <code>status</code> is one of
+          <code>running</code>, <code>completed</code>, <code>failed</code>,
+          or <code>canceled</code>. Once the status is terminal,
+          <code>result</code> carries the agent's final text. If the mission
+          was created with a webhook, the response includes a
+          <code>webhook</code> block recording when it was delivered, or the
+          last error if delivery has not yet succeeded.
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}curl https://gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "id": "msn_7Q4c1a9f2b",
+  "agentSlug": "revenue-manager",
+  "conversationId": "cnv_3e8d0364f1",
+  "status": "completed",
+  "result": "Weekly competitor summary is ready. Three properties moved rates...",
+  "createdAt": "2026-07-12T09:31:07.482Z",
+  "webhook": {
+    "url": "https://api.acme.com/hooks/houston",
+    "deliveredAt": "2026-07-12T09:34:52.140Z"
+  }
+}{% endraw %}</code></pre></div>
+
+        <h2 id="events">Stream events (SSE)</h2>
+        <div class="endpoint">
+          <span class="method get">GET</span>
+          <span class="path">/v1/agents/<b>:slug</b>/missions/<b>:id</b>/events</span>
+        </div>
+        <p>
+          Streams the mission's progress as Server-Sent Events and closes when
+          the mission reaches a terminal state. Each event has an id; if the
+          connection drops, reconnect and send the
+          <code>Last-Event-ID</code> header to resume without gaps. Native SSE
+          clients and curl do this for you.
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}curl -N https://gateway.gethouston.ai/v1/agents/revenue-manager/missions/msn_7Q4c1a9f2b/events \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
+        <div class="callout callout-info">
+          <div class="callout-label">Browser (EventSource)</div>
+          <p>
+            <code>EventSource</code> cannot send an <code>Authorization</code>
+            header, so this endpoint also accepts the key as a query
+            parameter: <code>?token=hst_...</code>. Keep that URL out of logs.
+          </p>
+        </div>
+
+        <h2 id="cancel">Cancel a mission</h2>
+        <div class="endpoint">
+          <span class="method post">POST</span>
+          <span class="path">/v1/agents/<b>:slug</b>/missions/<b>:id</b>/cancel</span>
+        </div>
+        <p>
+          Requests cancellation of a running mission. If the mission has
+          already reached a terminal state, you get <code>409 Conflict</code>:
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}{ "code": "mission_finished" }{% endraw %}</code></pre></div>
+
+        <h2 id="agents">List agents</h2>
+        <div class="endpoint">
+          <span class="method get">GET</span>
+          <span class="path">/agents</span>
+        </div>
+        <p>
+          Lists the agents this key can reach, with the slugs you pass to the
+          mission endpoints.
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}curl https://gateway.gethouston.ai/agents \
+  -H "Authorization: Bearer hst_9f2c1a7b4e8d0364f1a2b3c4d5e6f7089f2c1a7b4e8d0364f1a2b3c4d5e6f708"{% endraw %}</code></pre></div>
+
+        <h2 id="scope">API-key scope &amp; limits</h2>
+        <p>
+          API keys are deliberately narrow. A key works
+          <strong>only</strong> on the programmatic surfaces: the Missions
+          endpoints, A2A, MCP, and <code>GET /agents</code>. Point it at any
+          other part of the gateway and you get <code>403 Forbidden</code>:
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}{ "code": "api_key_scope" }{% endraw %}</code></pre></div>
+        <p>
+          You can hold up to <strong>20 active keys</strong>. Creating a 21st
+          returns <code>400 Bad Request</code>; revoke an old one first.
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}{ "code": "key_limit" }{% endraw %}</code></pre></div>
+
+        <h2 id="webhooks">Webhooks</h2>
+        <p>
+          Pass a <code>webhook</code> object when you create a mission and
+          Houston will <code>POST</code> a signed payload to your URL the
+          instant the mission finishes. This is the recommended pattern for
+          servers: no polling, no open connections.
+        </p>
+
+        <h3>Payload</h3>
+        <div class="codeblock"><pre><code>{% raw %}{
+  "event": "mission.completed",
+  "mission": {
+    "id": "msn_7Q4c1a9f2b",
+    "agentSlug": "revenue-manager",
+    "conversationId": "cnv_3e8d0364f1",
+    "status": "completed",
+    "result": "Weekly competitor summary is ready...",
+    "createdAt": "2026-07-12T09:31:07.482Z"
+  }
+}{% endraw %}</code></pre></div>
+        <p>
+          <code>event</code> is one of <code>mission.completed</code>,
+          <code>mission.failed</code>, or <code>mission.canceled</code>.
+        </p>
+
+        <h3>Headers</h3>
+        <div class="table-scroll">
+        <table class="fields-table">
+          <thead><tr><th>Header</th><th>Value</th></tr></thead>
+          <tbody>
+            <tr><td><code>X-Houston-Event</code></td><td>The event name, e.g. <code>mission.completed</code>.</td></tr>
+            <tr><td><code>X-Houston-Delivery</code></td><td>A unique id for this delivery attempt group. Use it to deduplicate.</td></tr>
+            <tr><td><code>X-Houston-Signature</code></td><td><code>sha256=&lt;hex&gt;</code>, the HMAC-SHA256 of the raw request body keyed with your <code>webhook.secret</code>.</td></tr>
+          </tbody>
+        </table>
+        </div>
+
+        <h3>Delivery &amp; reliability</h3>
+        <ul>
+          <li>Houston waits up to <strong>10 seconds</strong> for your endpoint to respond.</li>
+          <li>Delivery is attempted up to <strong>6 times</strong>: the initial POST plus <strong>5 retries</strong>, backing off 30s, 1m, 2m, 4m, then 8m.</li>
+          <li>Delivery is <strong>at-least-once</strong>. Retries can duplicate an event, so treat handlers as idempotent and <strong>deduplicate on <code>X-Houston-Delivery</code></strong>.</li>
+          <li>The URL must be a <strong>public <code>https://</code></strong> address. Private, loopback, and internal addresses are rejected.</li>
+        </ul>
+
+        <h3>Verify the signature</h3>
+        <p>
+          Compute the HMAC over the <strong>raw</strong> request body (not a
+          re-serialized object) and compare in constant time:
+        </p>
+        <div class="codeblock"><pre><code>{% raw %}import crypto from "node:crypto";
+
+// `rawBody` is the exact bytes Houston sent (a Buffer or string).
+// In Express, capture it with express.raw({ type: "application/json" }).
+function verifyHoustonWebhook(rawBody, signatureHeader, secret) {
+  const expected =
+    "sha256=" +
+    crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+  const a = Buffer.from(signatureHeader ?? "");
+  const b = Buffer.from(expected);
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+app.post("/hooks/houston", express.raw({ type: "application/json" }), (req, res) => {
+  const ok = verifyHoustonWebhook(
+    req.body,
+    req.get("X-Houston-Signature"),
+    process.env.HOUSTON_WEBHOOK_SECRET,
+  );
+  if (!ok) return res.sendStatus(401);
+
+  // Deduplicate on the delivery id, then process.
+  const deliveryId = req.get("X-Houston-Delivery");
+  const payload = JSON.parse(req.body.toString("utf8"));
+  // ... handle payload.event / payload.mission ...
+  res.sendStatus(200);
+});{% endraw %}</code></pre></div>
+        <div class="callout callout-warning">
+          <div class="callout-label">Sign over raw bytes</div>
+          <p>
+            Frameworks that auto-parse JSON change the byte stream. Verify
+            against the untouched body Houston sent, or the HMAC will not
+            match even with the right secret.
+          </p>
+        </div>
+
+        <div class="pager">
+          <a href="/developers/">
+            <div class="pager-label">← Previous</div>
+            <div class="pager-title">Overview</div>
+          </a>
+          <a href="/developers/a2a/" class="next">
+            <div class="pager-label">Next →</div>
+            <div class="pager-title">Agent2Agent (A2A)</div>
+          </a>
+        </div>
+      </main>
+    </div>
+
+    {% include "footer-developers.njk" %}
+  {% endblock %}

--- a/website/src/developers/style.css
+++ b/website/src/developers/style.css
@@ -1,0 +1,757 @@
+/* ═══════════════════════════════════════════
+   Houston Developers — Design System
+   Mirrors the Learn section (globals.css)
+   ═══════════════════════════════════════════ */
+
+:root {
+  --background: #ffffff;
+  --foreground: #0d0d0d;
+  --secondary: #f9f9f9;
+  --muted-foreground: #5d5d5d;
+  --border: #e5e5e5;
+  --gray-50: #f9f9f9;
+  --gray-100: #ececec;
+  --gray-200: #e3e3e3;
+  --gray-300: #cdcdcd;
+  --gray-400: #b4b4b4;
+  --gray-500: #9b9b9b;
+  --gray-600: #676767;
+  --gray-700: #424242;
+  --gray-900: #1a1a1a;
+  --gray-950: #0d0d0d;
+  --success: #00a240;
+  --info: #2964aa;
+  --warning: #e0ac00;
+  --danger: #e02e2a;
+  --border-light: rgba(13, 13, 13, 0.05);
+  --border-medium: rgba(0, 0, 0, 0.12);
+  --border-heavy: rgba(13, 13, 13, 0.15);
+}
+
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  html { scroll-behavior: smooth; }
+}
+
+body {
+  font-family: ui-sans-serif, -apple-system, system-ui, "Segoe UI", Helvetica,
+    Arial, sans-serif;
+  color: var(--foreground);
+  background: var(--background);
+  -webkit-font-smoothing: antialiased;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+code,
+.mono {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas,
+    "Liberation Mono", monospace;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+/* ═══════════════════════════════════════════
+   Top Nav (mirrors landing page)
+   ═══════════════════════════════════════════ */
+
+body {
+  padding-top: 65px;
+}
+
+nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 100;
+  padding: 16px 40px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background: rgba(255, 255, 255, 0.85);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+.nav-logo {
+  font-family: 'General Sans', sans-serif;
+  font-size: 22px;
+  font-weight: 500;
+  letter-spacing: -0.02em;
+  color: var(--gray-950);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  text-decoration: none;
+}
+
+.btn-short-text { display: none; }
+
+.nav-burger {
+  display: none;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  color: var(--gray-700);
+  transition: background 0.2s;
+}
+.nav-burger:hover { background: var(--gray-50); }
+.nav-burger svg { width: 20px; height: 20px; }
+
+.nav-dropdown {
+  display: none;
+  position: fixed;
+  top: 52px;
+  left: 0;
+  right: 0;
+  z-index: 99;
+  background: rgba(255,255,255,0.97);
+  backdrop-filter: blur(20px);
+  padding: 8px 20px 16px;
+  flex-direction: column;
+  border-bottom: 1px solid var(--border-light);
+  box-shadow: 0 8px 24px rgba(0,0,0,0.06);
+}
+.nav-dropdown.open { display: flex; }
+.nav-dropdown a {
+  font-size: 15px;
+  color: var(--gray-700);
+  text-decoration: none;
+  padding: 10px 4px;
+  border-bottom: 1px solid var(--border-light);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.nav-dropdown a:last-child { border-bottom: none; }
+.nav-dropdown a svg { width: 16px; height: 16px; opacity: 0.5; }
+
+.nav-center {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 32px;
+  align-items: center;
+}
+
+.nav-center a {
+  font-size: 14px;
+  color: var(--gray-600);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.nav-center a:hover { color: var(--gray-950); }
+
+.nav-right {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+}
+
+.nav-right a:not(.btn) {
+  color: var(--gray-600);
+  text-decoration: none;
+  transition: color 0.2s;
+}
+
+.nav-right a:not(.btn):hover { color: var(--gray-950); }
+
+nav .btn {
+  height: 36px;
+  padding: 0 16px;
+  font-size: 14px;
+  gap: 8px;
+}
+
+@media (max-width: 900px) {
+  nav { padding: 16px 20px; }
+  .nav-center { display: none; }
+  .nav-burger { display: flex; }
+  .nav-right a:not(.btn) { display: none !important; }
+  .nav-right .btn .btn-full-text { display: none; }
+  .nav-right .btn .btn-short-text { display: inline; }
+}
+
+/* ═══════════════════════════════════════════
+   Layout
+   ═══════════════════════════════════════════ */
+
+.layout {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  max-width: 1280px;
+  margin: 0 auto;
+  gap: 48px;
+  padding: 48px 32px 120px;
+}
+
+@media (max-width: 900px) {
+  .layout {
+    grid-template-columns: 1fr;
+    gap: 0;
+    padding: 32px 24px 80px;
+  }
+}
+
+/* ═══════════════════════════════════════════
+   Sidebar
+   ═══════════════════════════════════════════ */
+
+.sidebar {
+  position: sticky;
+  top: 88px;
+  align-self: start;
+  max-height: calc(100vh - 120px);
+  overflow-y: auto;
+  padding-right: 8px;
+}
+
+@media (max-width: 900px) {
+  .sidebar {
+    position: static;
+    max-height: none;
+    margin-bottom: 32px;
+    padding-right: 0;
+    padding-bottom: 24px;
+    border-bottom: 1px solid var(--border-light);
+  }
+}
+
+.sidebar-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-500);
+  margin-bottom: 12px;
+  padding: 0 10px;
+}
+
+.sidebar-nav {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sidebar-nav a {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  border-radius: 8px;
+  font-size: 14px;
+  color: var(--gray-700);
+  transition: background 0.15s, color 0.15s;
+}
+
+.sidebar-nav a:hover {
+  background: var(--gray-50);
+  color: var(--gray-950);
+}
+
+.sidebar-nav a.active {
+  background: var(--gray-100);
+  color: var(--gray-950);
+  font-weight: 500;
+}
+
+.sidebar-nav .num {
+  color: var(--gray-400);
+  font-variant-numeric: tabular-nums;
+  font-size: 12px;
+  min-width: 18px;
+}
+
+.sidebar-nav a.active .num { color: var(--gray-600); }
+
+/* ═══════════════════════════════════════════
+   Content
+   ═══════════════════════════════════════════ */
+
+.content {
+  max-width: 760px;
+  min-width: 0;
+}
+
+.content-label {
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--gray-500);
+  margin-bottom: 16px;
+}
+
+.content h1 {
+  font-size: clamp(32px, 4vw, 44px);
+  font-weight: 400;
+  letter-spacing: -0.03em;
+  line-height: 1.15;
+  color: var(--gray-950);
+  margin-bottom: 20px;
+}
+
+.content .lead {
+  font-size: 19px;
+  line-height: 1.55;
+  color: var(--muted-foreground);
+  margin-bottom: 48px;
+  max-width: 660px;
+}
+
+.content h2 {
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
+  color: var(--gray-950);
+  margin-top: 56px;
+  margin-bottom: 16px;
+  scroll-margin-top: 88px;
+}
+
+.content h2:first-of-type { margin-top: 0; }
+
+.content h3 {
+  font-size: 17px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  color: var(--gray-950);
+  margin-top: 32px;
+  margin-bottom: 10px;
+  scroll-margin-top: 88px;
+}
+
+.content p {
+  font-size: 16px;
+  line-height: 1.65;
+  color: var(--gray-700);
+  margin-bottom: 16px;
+}
+
+.content p strong { color: var(--gray-950); font-weight: 600; }
+
+.content ul,
+.content ol {
+  margin-bottom: 20px;
+  padding-left: 22px;
+  color: var(--gray-700);
+}
+
+.content li { margin-bottom: 8px; line-height: 1.65; }
+.content li::marker { color: var(--gray-400); }
+
+.content a.link {
+  color: var(--info);
+  text-decoration: none;
+}
+.content a.link:hover {
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+.content code {
+  background: var(--gray-100);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 14px;
+  color: var(--gray-950);
+}
+
+/* ═══════════════════════════════════════════
+   Code blocks (with copy button)
+   ═══════════════════════════════════════════ */
+
+.codeblock {
+  position: relative;
+  margin-bottom: 24px;
+}
+
+.codeblock pre {
+  background: var(--gray-950);
+  color: #f0f0f0;
+  padding: 20px 24px;
+  border-radius: 12px;
+  overflow-x: auto;
+  margin: 0;
+  font-size: 13.5px;
+  line-height: 1.65;
+}
+
+.codeblock pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-size: 13.5px;
+}
+
+.content pre {
+  background: var(--gray-950);
+  color: #f0f0f0;
+  padding: 20px 24px;
+  border-radius: 12px;
+  overflow-x: auto;
+  margin-bottom: 24px;
+  font-size: 13.5px;
+  line-height: 1.65;
+}
+
+.content pre code {
+  background: transparent;
+  padding: 0;
+  color: inherit;
+  font-size: 13.5px;
+}
+
+.copy-btn {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #d4d4d4;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 7px;
+  padding: 5px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  font-family: ui-sans-serif, -apple-system, system-ui, sans-serif;
+  cursor: pointer;
+  transition: background 0.15s, color 0.15s;
+  opacity: 0;
+}
+
+.codeblock:hover .copy-btn { opacity: 1; }
+.copy-btn:focus-visible { opacity: 1; outline: none; }
+.copy-btn:hover { background: rgba(255, 255, 255, 0.16); color: #fff; }
+.copy-btn.copied { color: #6fe39a; border-color: rgba(111, 227, 154, 0.4); }
+
+@media (max-width: 900px) {
+  .copy-btn { opacity: 1; }
+}
+
+/* ═══════════════════════════════════════════
+   Endpoint header (method + path)
+   ═══════════════════════════════════════════ */
+
+.endpoint {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 12px 16px;
+  margin: 20px 0;
+  overflow-x: auto;
+}
+
+.method {
+  flex: none;
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  padding: 4px 9px;
+  border-radius: 6px;
+  color: #fff;
+}
+
+.method.get { background: var(--info); }
+.method.post { background: var(--success); }
+.method.delete { background: var(--danger); }
+
+.endpoint .path {
+  font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, monospace;
+  font-size: 14px;
+  color: var(--gray-950);
+  white-space: nowrap;
+}
+
+.endpoint .path b { color: var(--info); font-weight: 600; }
+
+/* ═══════════════════════════════════════════
+   Field / reference tables
+   ═══════════════════════════════════════════ */
+
+.fields-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 20px 0 28px;
+  font-size: 14px;
+}
+
+.fields-table th {
+  text-align: left;
+  font-weight: 600;
+  color: var(--gray-950);
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border);
+  background: var(--gray-50);
+  font-size: 13px;
+}
+
+.fields-table th:first-child { border-top-left-radius: 8px; }
+.fields-table th:last-child { border-top-right-radius: 8px; }
+
+.fields-table td {
+  padding: 11px 14px;
+  border-bottom: 1px solid var(--border-light);
+  color: var(--gray-700);
+  vertical-align: top;
+  line-height: 1.55;
+}
+
+.fields-table td:first-child { white-space: nowrap; }
+
+.fields-table code {
+  background: var(--gray-100);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+  color: var(--gray-950);
+}
+
+.fields-table .req { color: var(--danger); font-weight: 600; font-size: 12px; }
+.fields-table .opt { color: var(--gray-500); font-size: 12px; }
+
+.table-scroll { overflow-x: auto; }
+
+/* ═══════════════════════════════════════════
+   On-this-page TOC
+   ═══════════════════════════════════════════ */
+
+.toc {
+  background: var(--gray-50);
+  border: 1px solid var(--border-light);
+  border-radius: 12px;
+  padding: 20px 24px;
+  margin-bottom: 48px;
+}
+
+.toc-label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--gray-500);
+  margin-bottom: 12px;
+}
+
+.toc ol {
+  list-style: none;
+  padding: 0;
+  counter-reset: toc;
+  margin: 0;
+}
+
+.toc li {
+  counter-increment: toc;
+  margin-bottom: 6px;
+  font-size: 14px;
+  padding-left: 0;
+}
+
+.toc li::before {
+  content: counter(toc) ".";
+  color: var(--gray-400);
+  margin-right: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.toc a { color: var(--gray-700); transition: color 0.15s; }
+.toc a:hover {
+  color: var(--gray-950);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+}
+
+/* ═══════════════════════════════════════════
+   Callouts
+   ═══════════════════════════════════════════ */
+
+.callout {
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 16px 20px;
+  margin: 24px 0;
+  background: var(--gray-50);
+}
+
+.callout-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--gray-600);
+  margin-bottom: 6px;
+}
+
+.callout p { margin-bottom: 0; font-size: 15px; color: var(--gray-700); }
+.callout p + p { margin-top: 10px; }
+.callout code {
+  background: var(--gray-100);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 13px;
+  color: var(--gray-950);
+}
+
+.callout-info {
+  background: color-mix(in oklch, var(--info) 6%, white);
+  border-color: color-mix(in oklch, var(--info) 20%, transparent);
+}
+.callout-info .callout-label { color: var(--info); }
+
+.callout-warning {
+  background: color-mix(in oklch, var(--warning) 6%, white);
+  border-color: color-mix(in oklch, var(--warning) 20%, transparent);
+}
+.callout-warning .callout-label { color: var(--warning); }
+
+.callout-success {
+  background: color-mix(in oklch, var(--success) 6%, white);
+  border-color: color-mix(in oklch, var(--success) 20%, transparent);
+}
+.callout-success .callout-label { color: var(--success); }
+
+/* ═══════════════════════════════════════════
+   Surface cards (overview)
+   ═══════════════════════════════════════════ */
+
+.hero { padding-top: 8px; }
+.hero h1 {
+  font-size: clamp(36px, 5vw, 52px);
+  margin-bottom: 24px;
+}
+.hero .lead { font-size: 20px; margin-bottom: 36px; }
+
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 16px;
+  margin: 28px 0;
+}
+
+.surface-card {
+  display: block;
+  padding: 22px 24px;
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  background: white;
+  transition: border-color 0.15s, box-shadow 0.2s, transform 0.15s;
+}
+
+.surface-card:hover {
+  border-color: var(--border-medium);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03), 0 8px 24px rgba(0, 0, 0, 0.04);
+  transform: translateY(-1px);
+}
+
+.surface-card .surface-kicker {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--info);
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.surface-card .surface-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--gray-950);
+  letter-spacing: -0.01em;
+  margin-bottom: 8px;
+}
+
+.surface-card .surface-desc {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--muted-foreground);
+}
+
+/* ═══════════════════════════════════════════
+   Buttons
+   ═══════════════════════════════════════════ */
+
+.hero-actions { display: flex; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  height: 44px;
+  padding: 0 22px;
+  border-radius: 9999px;
+  font-size: 15px;
+  font-weight: 500;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s;
+}
+
+.btn-primary { background: var(--gray-950); color: white; }
+.btn-primary:hover { background: var(--gray-700); }
+.btn-secondary {
+  background: white;
+  color: var(--gray-950);
+  border: 1px solid var(--border-medium);
+}
+.btn-secondary:hover { background: var(--gray-50); }
+
+/* ═══════════════════════════════════════════
+   Prev / Next
+   ═══════════════════════════════════════════ */
+
+.pager {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+  margin-top: 72px;
+  padding-top: 32px;
+  border-top: 1px solid var(--border-light);
+}
+
+.pager a {
+  display: flex;
+  flex-direction: column;
+  padding: 18px 22px;
+  border: 1px solid var(--border-light);
+  border-radius: 14px;
+  transition: border-color 0.15s, background 0.15s;
+}
+
+.pager a:hover { border-color: var(--border-medium); background: var(--gray-50); }
+.pager .pager-label {
+  font-size: 12px;
+  color: var(--gray-500);
+  margin-bottom: 4px;
+  font-weight: 500;
+}
+.pager .pager-title { font-size: 15px; font-weight: 600; color: var(--gray-950); }
+.pager .next { text-align: right; }
+.pager .spacer { border: none; background: transparent; }
+.pager .spacer:hover { background: transparent; border: none; }
+
+/* ═══════════════════════════════════════════
+   Footer
+   ═══════════════════════════════════════════ */
+
+.footer {
+  border-top: 1px solid var(--border-light);
+  padding: 32px;
+  text-align: center;
+  color: var(--gray-500);
+  font-size: 13px;
+}

--- a/website/src/llms.txt
+++ b/website/src/llms.txt
@@ -10,5 +10,11 @@ Houston lets anyone hire AI agents that actually complete tasks across the apps 
 - [Waitlist](https://gethouston.ai/waitlist/): Join the beta waiting list.
 - [Changelog](https://gethouston.ai/changelog/): Every release in plain language.
 
+## Developers
+- [Developer API](https://gethouston.ai/developers/): Start and drive agent missions programmatically over REST, A2A, and MCP. API keys, base URL, and a 60-second quickstart.
+- [Missions (REST)](https://gethouston.ai/developers/missions/): Full REST reference: create, list, get, stream (SSE), and cancel missions, API-key scope, and signed webhooks.
+- [Agent2Agent (A2A)](https://gethouston.ai/developers/a2a/): Point any A2A-capable agent at a Houston agent over JSON-RPC (message/send, message/stream, tasks/get, tasks/cancel).
+- [MCP](https://gethouston.ai/developers/mcp/): Expose agents as tools over a stateless Streamable HTTP MCP endpoint for Claude Code and other MCP clients.
+
 ## Code
 - [GitHub](https://github.com/gethouston/houston): The open source Houston repository.

--- a/website/src/sitemap.xml
+++ b/website/src/sitemap.xml
@@ -10,6 +10,10 @@
   <url><loc>https://gethouston.ai/guides/es/revenue-manager/</loc><lastmod>2026-07-02</lastmod></url>
   <url><loc>https://gethouston.ai/guides/sdr-linkedin/</loc><lastmod>2026-07-08</lastmod></url>
   <url><loc>https://gethouston.ai/guides/es/sdr-linkedin/</loc><lastmod>2026-07-08</lastmod></url>
+  <url><loc>https://gethouston.ai/developers/</loc><lastmod>2026-07-12</lastmod></url>
+  <url><loc>https://gethouston.ai/developers/missions/</loc><lastmod>2026-07-12</lastmod></url>
+  <url><loc>https://gethouston.ai/developers/a2a/</loc><lastmod>2026-07-12</lastmod></url>
+  <url><loc>https://gethouston.ai/developers/mcp/</loc><lastmod>2026-07-12</lastmod></url>
   <url><loc>https://gethouston.ai/privacy/</loc><lastmod>2026-06-28</lastmod></url>
   <url><loc>https://gethouston.ai/terms/</loc><lastmod>2026-06-28</lastmod></url>
 </urlset>


### PR DESCRIPTION
## What

Client + docs surface for the new hosted public API (cloud PR: gethouston/cloud#110).

### API Keys settings section
- New **Settings → API Keys**: list (name, monospace prefix, created, relative last-used), create with **show-once** secret reveal + copy, revoke via destructive confirm.
- Gated on the gateway's new `capabilities.apiKeys` flag — invisible on desktop-local, self-host, and older gateways. Query never fires when unsupported.
- Four-layer client surface per conventions: `ui/engine-client` types/interface → `packages/web` engine-adapter (`cp/api-keys.ts`, hosted-gated mixin) → `tauri.ts` facade via `call()` → TanStack Query hooks (`queryKeys.apiKeys()`).
- Error UX: `key_limit` (20 keys) renders inline, not as a crash toast; list failures show an explicit error state + retry (empty state unreachable on error); revoke of an already-revoked key resolves idempotently.
- Full en/es/pt i18n, semantic tokens only, `SettingsCard`/`ConfirmDialog`/`AsyncButton` reuse, model unit tests (8/8, node --test).

### Developer docs — `/developers`
Four Eleventy pages matching the Learn design system: overview + 60-second quickstart, missions REST + signed-webhooks reference (with Node signature-verification snippet), A2A, MCP. Nav link, sitemap, llms.txt. Every claim verified line-by-line against the Go gateway implementation (a drift-review pass fixed 7 discrepancies; two claims were made true gateway-side instead: `?token=` SSE auth on mission streams, stable `X-Houston-Delivery` across retries).

## Verification
`pnpm check`, `app` tsgo + `check-locales`, `houston-web` typecheck (shim parity), workspace `pnpm typecheck`, model tests, Eleventy build — all green. Multi-agent adversarial review: 3 confirmed UI bugs fixed test-first (silent list failure, double-Enter double-mint losing a show-once secret, revoke-404 bug toast).

Depends on gethouston/cloud#110 for the gateway routes + capability flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)