### PR TITLE
fix(ios): adopt the owner token vocabulary from #865

### DIFF
--- a/mobile/PARITY-CHAT.md
+++ b/mobile/PARITY-CHAT.md
@@ -111,7 +111,7 @@ See `packages/sdk/BRIDGE.md` §7. `ts` is OPTIONAL: older data has none, so ever
 degrades gracefully (a flat, separator-less feed; no crash).
 
 - **In-bubble user timestamp** — bottom-right inside the user bubble (WhatsApp convention),
-  `Typography.caption`, `primaryFg` @ opacity `0.6` (`ChatMetrics.bubbleTimeOpacity`),
+  `Typography.caption`, `actionText` @ opacity `0.6` (`ChatMetrics.bubbleTimeOpacity`),
   `Date.FormatStyle(time: .shortened)` (locale clock: 3:45 PM / 15:45), rendered in the
   device's local time zone. A custom `TimedBubbleLayout` (`Layout`) places it inline on the
   last line, or drops it to its own bottom-right line when the block is full — never overlaps.
@@ -137,7 +137,7 @@ degrades gracefully (a flat, separator-less feed; no crash).
   returning to the bottom clears it. State: `UnreadCounter` (`ChatTimelineScroll.swift`).
 - **Title bar (principal)** — a WhatsApp-style bar: agent avatar (`HoustonAvatar`, 26pt) + the
   agent name (line 1, `bodyMedium`) + a status line (line 2, `caption`): "Working…" (shimmer,
-  `mutedFg`) while running, "Needs your attention" (`warning`) when settled needs-you, else
+  `inkMuted`) while running, "Needs your attention" (`warning`) when settled needs-you, else
   hidden. Derivation: `ChatTitleStatus.derive(running:boardStatus:)`. Files: `ChatTitleView.swift`,
   `ChatTitleStatus.swift`, `Strings.Chat.TitleBar`. The name is threaded via
   `ChatView(agentId:conversationId:title:agentName:)` (optional; Mission Control opens a chat by
@@ -157,7 +157,7 @@ pending. Optional: absent → confirmed, so every consumer degrades to a plain c
 
 - **Delivery ticks (clock → check)** — the in-bubble user timestamp gains a trailing tick glyph:
   `clock` (SF Symbol) while `pending`, `checkmark` once confirmed — WhatsApp's sending/sent cue.
-  Same `Typography.caption` + `primaryFg` @ `0.6` as the time, `.imageScale(.small)`, morphing via
+  Same `Typography.caption` + `actionText` @ `0.6` as the time, `.imageScale(.small)`, morphing via
   `.contentTransition(.symbolEffect(.replace))` + `.animation(.snappy(Motion.fast), value: pending)`.
   The tick renders only inside the time cluster (no `ts` → no tick). Pure selector:
   `ChatBubbleTick.symbolName(pending:)`. VoiceOver: `Strings.Chat.deliveryPending` / `.deliverySent`.

--- a/mobile/PARITY.md
+++ b/mobile/PARITY.md
@@ -58,9 +58,9 @@ Left-to-right order and status→column mapping (single source of truth):
 
 ### Card color/glow semantics — `ui/board/src/kanban-card.tsx`
 - `running` → `card-running-glow` animated conic border + blue shadow `rgba(59,130,246,0.12)`.
-- `error` → `border-destructive/60`.
+- `error` → `border-danger/60`.
 - `needs_you` → renders the Approve check button ("Move to done").
-- selected/highlighted → `bg-accent`.
+- selected/highlighted → `bg-hover`.
 
 ## 2. Archive semantics
 - Archiving = the activity `status` field set to `"archived"` (`ARCHIVED_STATUS`, `app/src/lib/mission-selection.ts:9`). No separate flag.
@@ -82,7 +82,7 @@ Left-to-right order and status→column mapping (single source of truth):
 |---|---|---|
 | title | activity title | AI-generated async after create; fallback = truncated first message. Rename via pencil. `line-clamp-2`. |
 | description | `messagePreviewText(description)` | User's first message; `<!--houston:...-->` markers decoded. `line-clamp-2`. |
-| group (above title) | `agent_name` | muted |
+| group (above title) | `agent_name` | ink-muted |
 | icon | `AgentCardAvatar{color}` | colored Houston helmet |
 | tags | `missionCardTags(...)` | e.g. "Routine" (`board.json:tags.routine`), agent-mode pill |
 | updatedAt | `updated_at` | |
@@ -103,7 +103,7 @@ Left-to-right order and status→column mapping (single source of truth):
 
 ## 4. Agent presentation
 - Avatar = `HoustonAvatar` (`ui/core/src/components/houston-avatar.tsx`): colored circle
-  (`color-mix secondary 82% + agentColor 18%`) with the Houston helmet SVG glyph (~65% size).
+  (`color-mix chip 82% + agentColor 18%`) with the Houston helmet SVG glyph (~65% size).
   **No initials, no photos** — always the helmet tinted by `agent.color` (fallback `#9b9b9b`).
   `running` → comet-glow halo wrap.
 - Per-agent status aggregation (`app/src/components/shell/agent-activity-summary-model.ts`):
@@ -118,21 +118,21 @@ Left-to-right order and status→column mapping (single source of truth):
 The mobile Agents home restyles each agent as a WhatsApp chat-list cell. Native-only; the
 aggregation (`needsYouCount`/`runningCount`) and avatar rules above are unchanged — this is layout.
 - **Two-line cell** (`AgentRow.swift`) — line 1: agent name + right-aligned relative time
-  (`Typography.caption`, `mutedFg`); line 2: preview text + a trailing **filled** `NeedsYouChip`.
+  (`Typography.caption`, `inkMuted`); line 2: preview text + a trailing **filled** `NeedsYouChip`.
 - **Relative time** (`AgentRowTime.label`, from `AgentOverview.lastActivityAt` = most-recent
   mission `updatedAt`, parsed by `ActivityTimestamp`): today → short locale time (reuses
   `ChatBubbleTime`); yesterday → `Strings.Chat.Timeline.yesterday`; ≤6 days → weekday; older → short
   date. `nil` when no dated mission. Injectable `now`/`calendar`/`locale`; formatters pinned to the
   calendar's timezone.
 - **Preview line — ONE signal per state** (`AgentRowPreview.derive`): running → "Working…"
-  (`Strings.Chat.TitleBar.working`, accent-tinted) **whenever `runningCount > 0`, regardless of any
+  (`Strings.Chat.TitleBar.working`, inkMuted like the chat title bar) **whenever `runningCount > 0`, regardless of any
   needs-you count** — the filled `NeedsYouChip` is the sole needs-you signal, so the preview never
   repeats it (WhatsApp shows "typing…" even with an unread badge). No running mission → the
   last-activity line (`Strings.Agents.lastActivity`), which renders a **bare title** for `needs_you`
   (the badge carries the rest) and keeps **"Hit a snag on …"** for `error` (a genuine failure is
   information and carries no badge — the fold does not count `error` into `needsYouCount`). No
   missions → the no-missions line.
-- **Filled needs-you badge** — `NeedsYouChip` now defaults to `.filled` (`warning` fill + `warningFg`
+- **Filled needs-you badge** — `NeedsYouChip` now defaults to `.filled` (`warning` fill + `warningText`
   text) instead of the outline capsule; the "99+" cap is unchanged (`StatusChip.swift`). `AgentRow`
   is its only caller; Mission Control uses the native `BadgeModel`, not this chip.
 - **Pull-down search** (`AgentsView.swift`, `.searchable(placement: .navigationBarDrawer)`): a pure
@@ -152,9 +152,9 @@ rebuilt from a card grid into a WhatsApp-style conversation list. Native-only; t
   the helmet, so the old 40pt avatar + title block was removed. Body is just the grouped list.
 - **Slim two-line rows** (`MissionRowContent.swift`, derived by the pure `MissionRowLine.swift`):
   line 1 = mission title + right-aligned relative time (`MissionTimestamp.relativeLabel`, hidden when
-  unparseable); line 2 = a state signal that **collapses away when empty** — accent "Working…" (reuses
-  `Strings.Chat.TitleBar.working`) while running, destructive `Strings.AgentMissions.snag`
-  ("Hit a snag", title-less — the title is already on line 1) for error, else a muted description
+  unparseable); line 2 = a state signal that **collapses away when empty** — inkMuted "Working…" (reuses
+  `Strings.Chat.TitleBar.working`) while running, danger `Strings.AgentMissions.snag`
+  ("Hit a snag", title-less — the title is already on line 1) for error, else an ink-muted description
   preview. Running dominates, then error, then description. **No** avatar / agent name / tags / card
   border / fill / glow; the `List` supplies inset hairline separators; rows keep a ~44pt tap target.
 - **Grouping unchanged** — one `Section` per non-empty group in PARITY order (Needs you incl. error,

--- a/mobile/ios/Houston/Core/Auth/SignInView.swift
+++ b/mobile/ios/Houston/Core/Auth/SignInView.swift
@@ -12,7 +12,7 @@ struct SignInView: View {
 
     var body: some View {
         ZStack {
-            HoustonColors.background.resolve(theme).ignoresSafeArea()
+            HoustonColors.input.resolve(theme).ignoresSafeArea()
             VStack(spacing: HoustonSpacing.space24) {
                 Spacer()
                 HoustonMark()
@@ -22,13 +22,13 @@ struct SignInView: View {
                 if let message = controller.errorMessage {
                     Text(message)
                         .font(.system(size: HoustonFontSize.xs))
-                        .foregroundStyle(HoustonColors.destructive.resolve(theme))
+                        .foregroundStyle(HoustonColors.danger.resolve(theme))
                         .multilineTextAlignment(.center)
                 }
                 Spacer()
                 Text(Strings.Auth.retryHint)
                     .font(.system(size: HoustonFontSize.xs))
-                    .foregroundStyle(HoustonColors.mutedFg.resolve(theme))
+                    .foregroundStyle(HoustonColors.inkMuted.resolve(theme))
                     .multilineTextAlignment(.center)
             }
             .padding(.horizontal, HoustonSpacing.space24)
@@ -40,10 +40,10 @@ struct SignInView: View {
         VStack(spacing: HoustonSpacing.space8) {
             Text(Strings.Auth.welcomeTitle)
                 .font(.system(size: HoustonFontSize.h1, weight: HoustonFontWeight.semibold))
-                .foregroundStyle(HoustonColors.foreground.resolve(theme))
+                .foregroundStyle(HoustonColors.ink.resolve(theme))
             Text(Strings.Auth.welcomeSubtitle)
                 .font(.system(size: HoustonFontSize.sm))
-                .foregroundStyle(HoustonColors.mutedFg.resolve(theme))
+                .foregroundStyle(HoustonColors.inkMuted.resolve(theme))
                 .multilineTextAlignment(.center)
         }
     }
@@ -54,7 +54,7 @@ struct SignInView: View {
         } label: {
             HStack(spacing: HoustonSpacing.space8) {
                 if controller.state == .signingIn {
-                    ProgressView().tint(HoustonColors.primaryFg.resolve(theme))
+                    ProgressView().tint(HoustonColors.actionText.resolve(theme))
                 }
                 Text(controller.state == .signingIn
                     ? Strings.Auth.continuePending
@@ -62,8 +62,8 @@ struct SignInView: View {
                     .font(.system(size: HoustonFontSize.base, weight: HoustonFontWeight.medium))
             }
             .frame(maxWidth: .infinity, minHeight: 44)
-            .foregroundStyle(HoustonColors.primaryFg.resolve(theme))
-            .background(HoustonColors.primary.resolve(theme))
+            .foregroundStyle(HoustonColors.actionText.resolve(theme))
+            .background(HoustonColors.action.resolve(theme))
             .clipShape(RoundedRectangle(cornerRadius: HoustonRadius.full))
         }
         .disabled(controller.state == .signingIn)

--- a/mobile/ios/Houston/DesignSystem/HoustonMark.swift
+++ b/mobile/ios/Houston/DesignSystem/HoustonMark.swift
@@ -14,7 +14,7 @@ struct HoustonMark: View {
 
     var body: some View {
         HelmetShape()
-            .fill(HoustonColors.foreground.resolve(theme))
+            .fill(HoustonColors.ink.resolve(theme))
             .accessibilityHidden(true)
     }
 }

--- a/mobile/ios/Houston/DesignSystem/Primitives/EmptyStateView.swift
+++ b/mobile/ios/Houston/DesignSystem/Primitives/EmptyStateView.swift
@@ -17,26 +17,26 @@ struct EmptyStateView: View {
             if let systemImage {
                 Image(systemName: systemImage)
                     .font(Typography.font(HoustonFontSize.h1))
-                    .foregroundStyle(theme.mutedFg)
+                    .foregroundStyle(theme.inkMuted)
             }
             Text(title)
                 .font(Typography.title)
-                .foregroundStyle(theme.foreground)
+                .foregroundStyle(theme.ink)
                 .multilineTextAlignment(.center)
             if let description {
                 Text(description)
                     .font(Typography.callout)
-                    .foregroundStyle(theme.mutedFg)
+                    .foregroundStyle(theme.inkMuted)
                     .multilineTextAlignment(.center)
             }
             if let ctaTitle, let ctaAction {
                 Button(action: ctaAction) {
                     Text(ctaTitle)
                         .font(Typography.label)
-                        .foregroundStyle(theme.primaryFg)
+                        .foregroundStyle(theme.actionText)
                         .padding(.horizontal, Spacing.space16)
                         .padding(.vertical, Spacing.space8)
-                        .background(theme.primary, in: Capsule())
+                        .background(theme.action, in: Capsule())
                 }
                 .padding(.top, Spacing.space4)
             }

--- a/mobile/ios/Houston/DesignSystem/Primitives/HighlightedText.swift
+++ b/mobile/ios/Houston/DesignSystem/Primitives/HighlightedText.swift
@@ -15,7 +15,7 @@ struct HighlightedText: View {
     var body: some View {
         Text(attributed)
             .font(Typography.callout)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
             .lineLimit(lineLimit)
     }
 
@@ -36,7 +36,7 @@ struct HighlightedText: View {
             let aLower = chars.index(chars.startIndex, offsetBy: lower)
             let aUpper = chars.index(chars.startIndex, offsetBy: upper)
             attr[aLower..<aUpper].backgroundColor = theme.highlight
-            attr[aLower..<aUpper].foregroundColor = theme.highlightFg
+            attr[aLower..<aUpper].foregroundColor = theme.highlightText
             from = match.upperBound
         }
         return attr

--- a/mobile/ios/Houston/DesignSystem/Primitives/ListRow.swift
+++ b/mobile/ios/Houston/DesignSystem/Primitives/ListRow.swift
@@ -14,7 +14,7 @@ struct ListRow<Content: View>: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, Spacing.space12)
             .padding(.vertical, Spacing.space10)
-            .background(isSelected ? theme.accent : Color.clear)
+            .background(isSelected ? theme.hover : Color.clear)
             .clipShape(RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
             .contentShape(RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
     }

--- a/mobile/ios/Houston/DesignSystem/Primitives/SearchField.swift
+++ b/mobile/ios/Houston/DesignSystem/Primitives/SearchField.swift
@@ -12,10 +12,10 @@ struct SearchField: View {
         HStack(spacing: Spacing.space8) {
             Image(systemName: "magnifyingglass")
                 .font(Typography.callout)
-                .foregroundStyle(theme.mutedFg)
+                .foregroundStyle(theme.inkMuted)
             TextField(placeholder, text: $text)
                 .font(Typography.body)
-                .foregroundStyle(theme.foreground)
+                .foregroundStyle(theme.ink)
                 .textInputAutocapitalization(.never)
                 .autocorrectionDisabled()
                 .submitLabel(.search)
@@ -24,17 +24,17 @@ struct SearchField: View {
                     text = ""
                 } label: {
                     Image(systemName: "xmark.circle.fill")
-                        .foregroundStyle(theme.mutedFg)
+                        .foregroundStyle(theme.inkMuted)
                 }
                 .accessibilityLabel(Strings.Search.clear)
             }
         }
         .padding(.horizontal, Spacing.space12)
         .padding(.vertical, Spacing.space10)
-        .background(theme.muted, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+        .background(theme.chipSubtle, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
-                .strokeBorder(theme.border, lineWidth: 1)
+                .strokeBorder(theme.line, lineWidth: 1)
         )
     }
 }

--- a/mobile/ios/Houston/DesignSystem/Primitives/SectionHeader.swift
+++ b/mobile/ios/Houston/DesignSystem/Primitives/SectionHeader.swift
@@ -11,7 +11,7 @@ struct SectionHeader<Accessory: View>: View {
         HStack(spacing: Spacing.space8) {
             Text(title)
                 .font(Typography.captionStrong)
-                .foregroundStyle(theme.mutedFg)
+                .foregroundStyle(theme.inkMuted)
                 .textCase(.uppercase)
             Spacer(minLength: Spacing.space8)
             accessory()

--- a/mobile/ios/Houston/DesignSystem/ProviderLogos/ProviderLogoShape.swift
+++ b/mobile/ios/Houston/DesignSystem/ProviderLogos/ProviderLogoShape.swift
@@ -42,7 +42,7 @@ struct FilledProviderLogo: View {
 
     var body: some View {
         ProviderLogoShape(viewBox: viewBox, paths: paths)
-            .fill(color ?? theme.foreground, style: FillStyle(eoFill: eoFill))
+            .fill(color ?? theme.ink, style: FillStyle(eoFill: eoFill))
             .frame(width: size, height: size)
             .accessibilityHidden(true)
     }
@@ -69,12 +69,12 @@ struct StrokedProviderLogo: View {
             ZStack {
                 ProviderLogoShape(viewBox: viewBox, paths: paths, roundedRects: roundedRects)
                     .stroke(
-                        theme.foreground,
+                        theme.ink,
                         style: StrokeStyle(lineWidth: strokeWidth * scale, lineCap: .round, lineJoin: .round)
                     )
                 if !filledEllipses.isEmpty {
                     ProviderLogoShape(viewBox: viewBox, ellipses: filledEllipses)
-                        .fill(theme.foreground)
+                        .fill(theme.ink)
                 }
             }
         }

--- a/mobile/ios/Houston/DesignSystem/ProviderLogos/ProviderLogos.swift
+++ b/mobile/ios/Houston/DesignSystem/ProviderLogos/ProviderLogos.swift
@@ -132,7 +132,7 @@ struct ProviderInitialFallback: View {
         Text(initial)
             .font(.system(size: 10, weight: .semibold))
             .tracking(-0.25)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
             .frame(width: size, height: size)
             .accessibilityHidden(true)
     }

--- a/mobile/ios/Houston/DesignSystem/StatusChip.swift
+++ b/mobile/ios/Houston/DesignSystem/StatusChip.swift
@@ -14,12 +14,12 @@ struct StatusChip: View {
                 .frame(width: 6, height: 6)
             Text(label)
                 .font(Typography.label)
-                .foregroundStyle(theme.foreground)
+                .foregroundStyle(theme.ink)
         }
         .padding(.horizontal, Spacing.space8)
         .padding(.vertical, Spacing.space4)
-        .background(theme.muted, in: Capsule())
-        .overlay(Capsule().strokeBorder(theme.border, lineWidth: 1))
+        .background(theme.chipSubtle, in: Capsule())
+        .overlay(Capsule().strokeBorder(theme.line, lineWidth: 1))
     }
 
     private var label: String {
@@ -36,9 +36,9 @@ struct StatusChip: View {
         switch state {
         case .running: return GlowColor.running
         case .needsYou: return theme.warning
-        case .error: return theme.destructive
+        case .error: return theme.danger
         case .done: return theme.success
-        case .archived, .unknown: return theme.mutedFg
+        case .archived, .unknown: return theme.inkMuted
         }
     }
 }
@@ -54,7 +54,7 @@ struct NeedsYouChip: View {
     var body: some View {
         Text(Strings.cappedCount(count))
             .font(Typography.captionStrong)
-            .foregroundStyle(theme.warningFg)
+            .foregroundStyle(theme.warningText)
             .padding(.horizontal, Spacing.space6)
             .padding(.vertical, Spacing.space2)
             .background(Capsule().fill(theme.warning))

--- a/mobile/ios/Houston/DesignSystem/Theme.swift
+++ b/mobile/ios/Houston/DesignSystem/Theme.swift
@@ -4,7 +4,7 @@ import SwiftUI
 //
 // Every colour the app draws comes from here. `Theme` wraps the generated
 // `HoustonColors` token pairs (packages/design-tokens/dist/swift) and resolves
-// each pair against the app's own light/dark mode — matching how the web/desktop
+// each pair against the app's own light/dark mode, matching how the web/desktop
 // app toggles `[data-theme]` rather than following the system appearance.
 //
 // Roles mirror the `--ht-*` CSS custom properties one-for-one. NO raw hex or
@@ -12,51 +12,55 @@ import SwiftUI
 struct Theme: Equatable {
     let mode: HoustonTheme
 
-    // Surfaces
+    // Grounds — base (the app frame) then background (the main pane) then input (the white surface)
+    var base: Color { HoustonColors.base.resolve(mode) }
     var background: Color { HoustonColors.background.resolve(mode) }
-    var foreground: Color { HoustonColors.foreground.resolve(mode) }
+    var input: Color { HoustonColors.input.resolve(mode) }
+
+    // Ink (text)
+    var ink: Color { HoustonColors.ink.resolve(mode) }
+    var inkMuted: Color { HoustonColors.inkMuted.resolve(mode) }
+
+    // Elevated surfaces
     var card: Color { HoustonColors.card.resolve(mode) }
-    var cardFg: Color { HoustonColors.cardFg.resolve(mode) }
-    var cardRest: Color { HoustonColors.cardRest.resolve(mode) }
+    var cardText: Color { HoustonColors.cardText.resolve(mode) }
+    var cardSolid: Color { HoustonColors.cardSolid.resolve(mode) }
     var popover: Color { HoustonColors.popover.resolve(mode) }
-    var popoverFg: Color { HoustonColors.popoverFg.resolve(mode) }
-    var canvasGutter: Color { HoustonColors.canvasGutter.resolve(mode) }
-    var canvasScreen: Color { HoustonColors.canvasScreen.resolve(mode) }
+    var popoverText: Color { HoustonColors.popoverText.resolve(mode) }
 
     // Accents / emphasis
-    var primary: Color { HoustonColors.primary.resolve(mode) }
-    var primaryFg: Color { HoustonColors.primaryFg.resolve(mode) }
-    var secondary: Color { HoustonColors.secondary.resolve(mode) }
-    var secondaryFg: Color { HoustonColors.secondaryFg.resolve(mode) }
-    var muted: Color { HoustonColors.muted.resolve(mode) }
-    var mutedFg: Color { HoustonColors.mutedFg.resolve(mode) }
-    var accent: Color { HoustonColors.accent.resolve(mode) }
-    var accentFg: Color { HoustonColors.accentFg.resolve(mode) }
+    var action: Color { HoustonColors.action.resolve(mode) }
+    var actionText: Color { HoustonColors.actionText.resolve(mode) }
+    var chip: Color { HoustonColors.chip.resolve(mode) }
+    var chipText: Color { HoustonColors.chipText.resolve(mode) }
+    var chipSubtle: Color { HoustonColors.chipSubtle.resolve(mode) }
+    var hover: Color { HoustonColors.hover.resolve(mode) }
+    var hoverText: Color { HoustonColors.hoverText.resolve(mode) }
 
     // Status
-    var destructive: Color { HoustonColors.destructive.resolve(mode) }
-    var destructiveFg: Color { HoustonColors.destructiveFg.resolve(mode) }
+    var danger: Color { HoustonColors.danger.resolve(mode) }
+    var dangerText: Color { HoustonColors.dangerText.resolve(mode) }
     var success: Color { HoustonColors.success.resolve(mode) }
-    var successFg: Color { HoustonColors.successFg.resolve(mode) }
+    var successText: Color { HoustonColors.successText.resolve(mode) }
     var warning: Color { HoustonColors.warning.resolve(mode) }
-    var warningFg: Color { HoustonColors.warningFg.resolve(mode) }
+    var warningText: Color { HoustonColors.warningText.resolve(mode) }
     var highlight: Color { HoustonColors.highlight.resolve(mode) }
-    var highlightFg: Color { HoustonColors.highlightFg.resolve(mode) }
+    var highlightText: Color { HoustonColors.highlightText.resolve(mode) }
 
     // Chrome
-    var border: Color { HoustonColors.border.resolve(mode) }
-    var input: Color { HoustonColors.input.resolve(mode) }
-    var ring: Color { HoustonColors.ring.resolve(mode) }
+    var line: Color { HoustonColors.line.resolve(mode) }
+    var lineInput: Color { HoustonColors.lineInput.resolve(mode) }
+    var focus: Color { HoustonColors.focus.resolve(mode) }
     var sidebar: Color { HoustonColors.sidebar.resolve(mode) }
-    var sidebarFg: Color { HoustonColors.sidebarFg.resolve(mode) }
-    var sidebarBorder: Color { HoustonColors.sidebarBorder.resolve(mode) }
-    var sidebarAccent: Color { HoustonColors.sidebarAccent.resolve(mode) }
-    var sidebarAccentFg: Color { HoustonColors.sidebarAccentFg.resolve(mode) }
+    var sidebarText: Color { HoustonColors.sidebarText.resolve(mode) }
+    var sidebarLine: Color { HoustonColors.sidebarLine.resolve(mode) }
+    var sidebarHover: Color { HoustonColors.sidebarHover.resolve(mode) }
+    var sidebarHoverText: Color { HoustonColors.sidebarHoverText.resolve(mode) }
 
-    /// The faint circle tint behind an agent's helmet: `secondary 82% + agentColor 18%`
+    /// The faint circle tint behind an agent's helmet: `chip 82% + agentColor 18%`
     /// (PARITY §4). `agentColor` is the agent's themed hex; nil falls back to Houston gray.
     func agentAvatarBackground(_ agentColor: Color?) -> Color {
-        ColorMix.mix(secondary, agentColor ?? AgentColor.fallback, ratio: 0.18)
+        ColorMix.mix(chip, agentColor ?? AgentColor.fallback, ratio: 0.18)
     }
 }
 

--- a/mobile/ios/Houston/Features/AIModels/AIModelsAgentView.swift
+++ b/mobile/ios/Houston/Features/AIModels/AIModelsAgentView.swift
@@ -34,7 +34,7 @@ struct AIModelsAgentView: View {
     content
       .navigationTitle(Strings.AIModels.title)
       .navigationBarTitleDisplayMode(.inline)
-      .background(theme.background)
+      .background(theme.input)
       .onAppear { if retention == nil { retention = model.retain() } }
       .onDisappear { retention?.cancel(); retention = nil }
       .sheet(item: $connectCard) { card in
@@ -82,7 +82,7 @@ struct AIModelsAgentView: View {
   private var footer: some View {
     Text(scopingLine)
       .font(Typography.caption)
-      .foregroundStyle(theme.mutedFg)
+      .foregroundStyle(theme.inkMuted)
       .multilineTextAlignment(.center)
       .frame(maxWidth: .infinity)
       .padding(.horizontal, Spacing.space24)

--- a/mobile/ios/Houston/Features/AIModels/AIModelsView.swift
+++ b/mobile/ios/Houston/Features/AIModels/AIModelsView.swift
@@ -52,7 +52,7 @@ private struct AIModelsAgentPicker: View {
     content
       .navigationTitle(Strings.AIModels.title)
       .navigationBarTitleDisplayMode(.inline)
-      .background(theme.background)
+      .background(theme.input)
       .navigationDestination(for: AIModelsAgentRoute.self) { route in
         AIModelsAgentView(agentId: route.id)
       }
@@ -78,10 +78,10 @@ private struct AIModelsAgentPicker: View {
           VStack(alignment: .leading, spacing: Spacing.space4) {
             Text(Strings.AIModels.Picker.title)
               .font(Typography.title)
-              .foregroundStyle(theme.foreground)
+              .foregroundStyle(theme.ink)
             Text(Strings.AIModels.Picker.description)
               .font(Typography.callout)
-              .foregroundStyle(theme.mutedFg)
+              .foregroundStyle(theme.inkMuted)
           }
           .textCase(nil)
           .padding(.bottom, Spacing.space8)
@@ -89,7 +89,7 @@ private struct AIModelsAgentPicker: View {
       }
       .listStyle(.plain)
       .scrollContentBackground(.hidden)
-      .background(theme.background)
+      .background(theme.input)
     }
   }
 
@@ -99,7 +99,7 @@ private struct AIModelsAgentPicker: View {
         HoustonAvatar(agentColorHex: nil, diameter: 32)
         Text(agent.name)
           .font(Typography.bodyMedium)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
       }
     }
     .listRowBackground(Color.clear)

--- a/mobile/ios/Houston/Features/AIModels/ApiKeyView.swift
+++ b/mobile/ios/Houston/Features/AIModels/ApiKeyView.swift
@@ -20,17 +20,17 @@ struct ApiKeyView: View {
         VStack(alignment: .leading, spacing: Spacing.space8) {
           Text(Strings.AIModels.ApiKey.title(card.name))
             .font(Typography.title)
-            .foregroundStyle(theme.foreground)
+            .foregroundStyle(theme.ink)
           Text(Strings.AIModels.ApiKey.description(card.name))
             .font(Typography.callout)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
         }
 
         if let urlString = card.apiKeyUrl, let url = URL(string: urlString) {
           Button { openURL(url) } label: {
             Label(Strings.AIModels.ApiKey.getKey, systemImage: "arrow.up.right.square")
               .font(Typography.label)
-              .foregroundStyle(theme.primary)
+              .foregroundStyle(theme.action)
           }
           .buttonStyle(.plain)
         }
@@ -38,18 +38,18 @@ struct ApiKeyView: View {
         VStack(alignment: .leading, spacing: Spacing.space6) {
           Text(Strings.AIModels.ApiKey.label)
             .font(Typography.caption)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
           SecureField(Strings.AIModels.ApiKey.placeholder, text: $key)
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
             .padding(Spacing.space12)
-            .background(theme.input, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+            .background(theme.lineInput, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
         }
 
         if let error {
           Text(error)
             .font(Typography.caption)
-            .foregroundStyle(theme.destructive)
+            .foregroundStyle(theme.danger)
         }
 
         Button(action: connect) {
@@ -58,10 +58,10 @@ struct ApiKeyView: View {
             Text(Strings.AIModels.ApiKey.save)
           }
           .font(Typography.label)
-          .foregroundStyle(theme.primaryFg)
+          .foregroundStyle(theme.actionText)
           .frame(maxWidth: .infinity)
           .padding(.vertical, Spacing.space12)
-          .background(theme.primary, in: Capsule())
+          .background(theme.action, in: Capsule())
         }
         .buttonStyle(.plain)
         .disabled(submitting)

--- a/mobile/ios/Houston/Features/AIModels/AuthCodeView.swift
+++ b/mobile/ios/Houston/Features/AIModels/AuthCodeView.swift
@@ -24,20 +24,20 @@ struct AuthCodeView: View {
         VStack(alignment: .leading, spacing: Spacing.space8) {
           Text(Strings.AIModels.Login.title(card.name))
             .font(Typography.title)
-            .foregroundStyle(theme.foreground)
+            .foregroundStyle(theme.ink)
           Text(instructions ?? Strings.AIModels.Login.authCodeDescription(card.name))
             .font(Typography.callout)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
         }
 
         if let link = URL(string: url) {
           Button { openURL(link) } label: {
             Label(Strings.AIModels.Login.openUrl, systemImage: "arrow.up.right.square")
               .font(Typography.label)
-              .foregroundStyle(theme.primaryFg)
+              .foregroundStyle(theme.actionText)
               .frame(maxWidth: .infinity)
               .padding(.vertical, Spacing.space12)
-              .background(theme.primary, in: Capsule())
+              .background(theme.action, in: Capsule())
           }
           .buttonStyle(.plain)
         }
@@ -45,16 +45,16 @@ struct AuthCodeView: View {
         VStack(alignment: .leading, spacing: Spacing.space6) {
           Text(Strings.AIModels.Login.codeLabel)
             .font(Typography.caption)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
           TextField(Strings.AIModels.Login.codePlaceholder, text: $code)
             .textInputAutocapitalization(.never)
             .autocorrectionDisabled()
             .padding(Spacing.space12)
-            .background(theme.input, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+            .background(theme.lineInput, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
         }
 
         if let error {
-          Text(error).font(Typography.caption).foregroundStyle(theme.destructive)
+          Text(error).font(Typography.caption).foregroundStyle(theme.danger)
         }
 
         Button(action: submit) {
@@ -63,11 +63,11 @@ struct AuthCodeView: View {
             Text(Strings.AIModels.Login.submit)
           }
           .font(Typography.label)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
           .frame(maxWidth: .infinity)
           .padding(.vertical, Spacing.space12)
-          .background(theme.secondary, in: Capsule())
-          .overlay(Capsule().strokeBorder(theme.border, lineWidth: 1))
+          .background(theme.chip, in: Capsule())
+          .overlay(Capsule().strokeBorder(theme.line, lineWidth: 1))
         }
         .buttonStyle(.plain)
         .disabled(submitting)

--- a/mobile/ios/Houston/Features/AIModels/CopilotConnectView.swift
+++ b/mobile/ios/Houston/Features/AIModels/CopilotConnectView.swift
@@ -20,10 +20,10 @@ struct CopilotConnectView: View {
         VStack(alignment: .leading, spacing: Spacing.space8) {
           Text(Strings.AIModels.Copilot.title)
             .font(Typography.title)
-            .foregroundStyle(theme.foreground)
+            .foregroundStyle(theme.ink)
           Text(Strings.AIModels.Copilot.description)
             .font(Typography.callout)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
         }
 
         option(
@@ -37,26 +37,26 @@ struct CopilotConnectView: View {
           VStack(alignment: .leading, spacing: Spacing.space6) {
             Text(Strings.AIModels.Copilot.domainLabel)
               .font(Typography.caption)
-              .foregroundStyle(theme.mutedFg)
+              .foregroundStyle(theme.inkMuted)
             TextField(Strings.AIModels.Copilot.domainPlaceholder, text: $domain)
               .textInputAutocapitalization(.never)
               .autocorrectionDisabled()
               .keyboardType(.URL)
               .padding(Spacing.space12)
-              .background(theme.input, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+              .background(theme.lineInput, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
             Text(Strings.AIModels.Copilot.domainHint)
               .font(Typography.caption)
-              .foregroundStyle(theme.mutedFg)
+              .foregroundStyle(theme.inkMuted)
           }
         }
 
         Button(action: submit) {
           Text(Strings.AIModels.Copilot.cont)
             .font(Typography.label)
-            .foregroundStyle(theme.primaryFg)
+            .foregroundStyle(theme.actionText)
             .frame(maxWidth: .infinity)
             .padding(.vertical, Spacing.space12)
-            .background(theme.primary, in: Capsule())
+            .background(theme.action, in: Capsule())
         }
         .buttonStyle(.plain)
         .disabled(plan == .company && domain.trimmingCharacters(in: .whitespaces).isEmpty)
@@ -69,19 +69,19 @@ struct CopilotConnectView: View {
     Button { plan = value } label: {
       HStack(spacing: Spacing.space12) {
         Image(systemName: plan == value ? "largecircle.fill.circle" : "circle")
-          .foregroundStyle(plan == value ? theme.primary : theme.mutedFg)
+          .foregroundStyle(plan == value ? theme.action : theme.inkMuted)
         VStack(alignment: .leading, spacing: Spacing.space2) {
-          Text(title).font(Typography.bodyMedium).foregroundStyle(theme.foreground)
-          Text(desc).font(Typography.caption).foregroundStyle(theme.mutedFg)
+          Text(title).font(Typography.bodyMedium).foregroundStyle(theme.ink)
+          Text(desc).font(Typography.caption).foregroundStyle(theme.inkMuted)
         }
         Spacer(minLength: 0)
       }
       .padding(Spacing.space12)
       .background(
-        theme.secondary, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+        theme.chip, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
       .overlay(
         RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
-          .strokeBorder(plan == value ? theme.primary : theme.border, lineWidth: 1))
+          .strokeBorder(plan == value ? theme.action : theme.line, lineWidth: 1))
       .contentShape(RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
     }
     .buttonStyle(.plain)

--- a/mobile/ios/Houston/Features/AIModels/DeviceCodeView.swift
+++ b/mobile/ios/Houston/Features/AIModels/DeviceCodeView.swift
@@ -31,25 +31,25 @@ struct DeviceCodeView: View {
         VStack(alignment: .leading, spacing: Spacing.space8) {
           Text(Strings.AIModels.Login.title(card.name))
             .font(Typography.title)
-            .foregroundStyle(theme.foreground)
+            .foregroundStyle(theme.ink)
           Text(Strings.AIModels.Login.deviceDescription)
             .font(Typography.callout)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
         }
 
         codeBlock
         Text(Strings.AIModels.Login.deviceCodeHint(card.name))
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
 
         if let url = URL(string: verificationUri) {
           Button { openURL(url) } label: {
             Label(Strings.AIModels.Login.openUrl, systemImage: "arrow.up.right.square")
               .font(Typography.label)
-              .foregroundStyle(theme.primaryFg)
+              .foregroundStyle(theme.actionText)
               .frame(maxWidth: .infinity)
               .padding(.vertical, Spacing.space12)
-              .background(theme.primary, in: Capsule())
+              .background(theme.action, in: Capsule())
           }
           .buttonStyle(.plain)
         }
@@ -57,17 +57,17 @@ struct DeviceCodeView: View {
         if card.id == "openai" {
           Text(Strings.AIModels.Login.deviceSettingsHint)
             .font(Typography.caption)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
         }
 
         if let failure {
-          Text(failure).font(Typography.caption).foregroundStyle(theme.destructive)
+          Text(failure).font(Typography.caption).foregroundStyle(theme.danger)
         } else {
           HStack(spacing: Spacing.space8) {
             ProgressView().controlSize(.small)
             Text(Strings.AIModels.Login.deviceWaiting)
               .font(Typography.caption)
-              .foregroundStyle(theme.mutedFg)
+              .foregroundStyle(theme.inkMuted)
           }
         }
       }
@@ -87,7 +87,7 @@ struct DeviceCodeView: View {
     HStack(spacing: Spacing.space12) {
       Text(userCode)
         .font(.system(.title2, design: .monospaced))
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
         .textSelection(.enabled)
       Spacer(minLength: 0)
       Button(action: copyCode) {
@@ -95,16 +95,16 @@ struct DeviceCodeView: View {
           copied ? Strings.AIModels.Login.codeCopied : Strings.AIModels.Login.copyCode,
           systemImage: copied ? "checkmark" : "doc.on.doc")
           .font(Typography.label)
-          .foregroundStyle(copied ? theme.success : theme.primary)
+          .foregroundStyle(copied ? theme.success : theme.action)
       }
       .buttonStyle(.plain)
     }
     .padding(Spacing.space16)
     .frame(maxWidth: .infinity)
-    .background(theme.secondary, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+    .background(theme.chip, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
     .overlay(
       RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
-        .strokeBorder(theme.border, lineWidth: 1))
+        .strokeBorder(theme.line, lineWidth: 1))
   }
 
   private func copyCode() {

--- a/mobile/ios/Houston/Features/AIModels/ModelPickerView.swift
+++ b/mobile/ios/Houston/Features/AIModels/ModelPickerView.swift
@@ -19,13 +19,13 @@ struct ModelPickerView: View {
     VStack(alignment: .leading, spacing: Spacing.space8) {
       Text(member.name.isEmpty ? Strings.AIModels.Detail.models : member.name)
         .font(Typography.captionStrong)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
         .textCase(.uppercase)
 
       if member.models.isEmpty {
         Text(Strings.AIModels.Detail.noModels)
           .font(Typography.callout)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
       } else {
         VStack(spacing: Spacing.space2) {
           ForEach(member.models, id: \.self) { modelId in
@@ -45,17 +45,17 @@ struct ModelPickerView: View {
           VStack(alignment: .leading, spacing: Spacing.space2) {
             Text(meta?.label ?? modelId)
               .font(Typography.bodyMedium)
-              .foregroundStyle(theme.foreground)
+              .foregroundStyle(theme.ink)
             if let description = meta?.description, !description.isEmpty {
               Text(description)
                 .font(Typography.caption)
-                .foregroundStyle(theme.mutedFg)
+                .foregroundStyle(theme.inkMuted)
                 .multilineTextAlignment(.leading)
             }
           }
           Spacer(minLength: Spacing.space8)
           if isSelected {
-            Image(systemName: "checkmark.circle.fill").foregroundStyle(theme.primary)
+            Image(systemName: "checkmark.circle.fill").foregroundStyle(theme.action)
           }
         }
         .contentShape(Rectangle())
@@ -69,7 +69,7 @@ struct ModelPickerView: View {
     }
     .padding(Spacing.space12)
     .background(
-      isSelected ? theme.accent : Color.clear,
+      isSelected ? theme.hover : Color.clear,
       in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
   }
 
@@ -77,17 +77,17 @@ struct ModelPickerView: View {
     VStack(alignment: .leading, spacing: Spacing.space6) {
       Text(Strings.AIModels.Detail.effort)
         .font(Typography.caption)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
       HStack(spacing: Spacing.space6) {
         ForEach(levels, id: \.self) { level in
           Button { setEffort(level, modelId: modelId) } label: {
             Text(Strings.AIModels.effortLabel(level))
               .font(Typography.caption)
-              .foregroundStyle(effort == level ? theme.primaryFg : theme.foreground)
+              .foregroundStyle(effort == level ? theme.actionText : theme.ink)
               .padding(.horizontal, Spacing.space10)
               .padding(.vertical, Spacing.space6)
               .background(
-                effort == level ? theme.primary : theme.secondary, in: Capsule())
+                effort == level ? theme.action : theme.chip, in: Capsule())
           }
           .buttonStyle(.plain)
         }

--- a/mobile/ios/Houston/Features/AIModels/ProviderCardView.swift
+++ b/mobile/ios/Houston/Features/AIModels/ProviderCardView.swift
@@ -17,13 +17,13 @@ struct ProviderCardView: View {
           ProviderGlyph(providerId: card.glyphId, size: 22)
           Text(card.name)
             .font(Typography.bodyMedium)
-            .foregroundStyle(theme.foreground)
+            .foregroundStyle(theme.ink)
             .lineLimit(1)
         }
         if let description = Strings.AIModels.providerDescription(card.descriptionKey) {
           Text(description)
             .font(Typography.caption)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
             .lineLimit(2)
             .multilineTextAlignment(.leading)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -33,10 +33,10 @@ struct ProviderCardView: View {
       }
       .padding(Spacing.space16)
       .frame(maxWidth: .infinity, minHeight: 132, alignment: .topLeading)
-      .background(theme.secondary, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+      .background(theme.chip, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
       .overlay(
         RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
-          .strokeBorder(theme.border, lineWidth: 1))
+          .strokeBorder(theme.line, lineWidth: 1))
       .contentShape(RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
     }
     .buttonStyle(.plain)
@@ -53,10 +53,10 @@ struct ProviderCardView: View {
     } else {
       Text(Strings.AIModels.Card.connect)
         .font(Typography.label)
-        .foregroundStyle(theme.primaryFg)
+        .foregroundStyle(theme.actionText)
         .padding(.horizontal, Spacing.space12)
         .padding(.vertical, Spacing.space6)
-        .background(theme.primary, in: Capsule())
+        .background(theme.action, in: Capsule())
     }
   }
 
@@ -68,7 +68,7 @@ struct ProviderCardView: View {
       if let dot { Circle().fill(dot).frame(width: 6, height: 6) }
       Text(text)
         .font(Typography.label)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
     }
   }
 }
@@ -84,29 +84,29 @@ struct ComingSoonCardView: View {
       HStack(spacing: Spacing.space8) {
         Text(provider.mark)
           .font(Typography.captionStrong)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
           .frame(width: 22, height: 22)
-          .background(theme.muted, in: RoundedRectangle(cornerRadius: Radius.sm, style: .continuous))
+          .background(theme.chipSubtle, in: RoundedRectangle(cornerRadius: Radius.sm, style: .continuous))
         Text(provider.name)
           .font(Typography.bodyMedium)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
           .lineLimit(1)
       }
       Text(provider.subtitle)
         .font(Typography.caption)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
         .lineLimit(2)
       Spacer(minLength: Spacing.space4)
       Text(Strings.AIModels.Card.comingSoon)
         .font(Typography.label)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
     }
     .padding(Spacing.space16)
     .frame(maxWidth: .infinity, minHeight: 132, alignment: .topLeading)
-    .background(theme.secondary, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
+    .background(theme.chip, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
     .overlay(
       RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
-        .strokeBorder(theme.border, lineWidth: 1))
+        .strokeBorder(theme.line, lineWidth: 1))
     .opacity(0.7)
   }
 }

--- a/mobile/ios/Houston/Features/AIModels/ProviderConnectSheet.swift
+++ b/mobile/ios/Houston/Features/AIModels/ProviderConnectSheet.swift
@@ -35,7 +35,7 @@ struct ProviderConnectSheet: View {
   var body: some View {
     NavigationStack {
       stageBody
-        .background(theme.background)
+        .background(theme.input)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
           ToolbarItem(placement: .cancellationAction) {

--- a/mobile/ios/Houston/Features/AIModels/ProviderDetailSheet.swift
+++ b/mobile/ios/Houston/Features/AIModels/ProviderDetailSheet.swift
@@ -30,7 +30,7 @@ struct ProviderDetailSheet: View {
         }
         .padding(Spacing.space20)
       }
-      .background(theme.background)
+      .background(theme.input)
       .navigationTitle(live.name)
       .navigationBarTitleDisplayMode(.inline)
       .toolbar {
@@ -51,10 +51,10 @@ struct ProviderDetailSheet: View {
     HStack(spacing: Spacing.space12) {
       ProviderGlyph(providerId: live.glyphId, size: 28)
       VStack(alignment: .leading, spacing: Spacing.space2) {
-        Text(live.name).font(Typography.title).foregroundStyle(theme.foreground)
+        Text(live.name).font(Typography.title).foregroundStyle(theme.ink)
         Text(Strings.AIModels.Detail.signedInWith(live.name))
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
       }
       Spacer(minLength: 0)
     }
@@ -64,11 +64,11 @@ struct ProviderDetailSheet: View {
     Button { confirmingSignOut = true } label: {
       Text(Strings.AIModels.Detail.signOut)
         .font(Typography.label)
-        .foregroundStyle(theme.destructive)
+        .foregroundStyle(theme.danger)
         .frame(maxWidth: .infinity)
         .padding(.vertical, Spacing.space12)
-        .background(theme.secondary, in: Capsule())
-        .overlay(Capsule().strokeBorder(theme.border, lineWidth: 1))
+        .background(theme.chip, in: Capsule())
+        .overlay(Capsule().strokeBorder(theme.line, lineWidth: 1))
     }
     .buttonStyle(.plain)
   }

--- a/mobile/ios/Houston/Features/AgentMissions/AgentArchivedMissionsView.swift
+++ b/mobile/ios/Houston/Features/AgentMissions/AgentArchivedMissionsView.swift
@@ -47,7 +47,7 @@ struct AgentArchivedMissionsView: View {
                 .scrollContentBackground(.hidden)
             }
         }
-        .background(theme.background)
+        .background(theme.input)
         .navigationTitle(Strings.Board.archived)
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/mobile/ios/Houston/Features/AgentMissions/AgentMissionsSectionList.swift
+++ b/mobile/ios/Houston/Features/AgentMissions/AgentMissionsSectionList.swift
@@ -28,7 +28,7 @@ struct AgentMissionsSectionList: View {
                 } header: {
                     Text(section.column.label)
                         .font(Typography.captionStrong)
-                        .foregroundStyle(theme.mutedFg)
+                        .foregroundStyle(theme.inkMuted)
                         .textCase(.uppercase)
                 }
             }
@@ -45,16 +45,16 @@ struct AgentMissionsSectionList: View {
             HStack(spacing: Spacing.space8) {
                 Label(Strings.Board.archived, systemImage: "archivebox")
                     .font(Typography.bodyMedium)
-                    .foregroundStyle(theme.foreground)
+                    .foregroundStyle(theme.ink)
                 Spacer(minLength: Spacing.space8)
                 if grouping.archivedCount > 0 {
                     Text("\(grouping.archivedCount)")
                         .font(Typography.callout)
-                        .foregroundStyle(theme.mutedFg)
+                        .foregroundStyle(theme.inkMuted)
                 }
                 Image(systemName: "chevron.right")
                     .font(Typography.caption)
-                    .foregroundStyle(theme.mutedFg)
+                    .foregroundStyle(theme.inkMuted)
             }
         }
         .buttonStyle(.plain)

--- a/mobile/ios/Houston/Features/AgentMissions/AgentMissionsView.swift
+++ b/mobile/ios/Houston/Features/AgentMissions/AgentMissionsView.swift
@@ -45,7 +45,7 @@ struct AgentMissionsView: View {
 
     var body: some View {
         content
-            .background(theme.background)
+            .background(theme.input)
             .navigationTitle(agent.name)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/mobile/ios/Houston/Features/AgentMissions/MissionRowContent.swift
+++ b/mobile/ios/Houston/Features/AgentMissions/MissionRowContent.swift
@@ -17,13 +17,13 @@ struct MissionRowContent: View {
             HStack(alignment: .firstTextBaseline, spacing: Spacing.space8) {
                 Text(line.title)
                     .font(Typography.bodyMedium)
-                    .foregroundStyle(theme.foreground)
+                    .foregroundStyle(theme.ink)
                     .lineLimit(1)
                 Spacer(minLength: Spacing.space8)
                 if let time = line.time {
                     Text(time)
                         .font(Typography.caption)
-                        .foregroundStyle(theme.mutedFg)
+                        .foregroundStyle(theme.inkMuted)
                         .lineLimit(1)
                 }
             }
@@ -43,9 +43,11 @@ struct MissionRowContent: View {
 
     private var secondLineColor: Color {
         switch line.secondLine {
-        case .working: return theme.accent
-        case .snag: return theme.destructive
-        case .description, .none: return theme.mutedFg
+        // Working reads inkMuted like the chat title bar; the old accent role
+        // became the opaque hover fill in the token rename and is not for text.
+        case .working: return theme.inkMuted
+        case .snag: return theme.danger
+        case .description, .none: return theme.inkMuted
         }
     }
 }

--- a/mobile/ios/Houston/Features/Agents/AgentRow.swift
+++ b/mobile/ios/Houston/Features/Agents/AgentRow.swift
@@ -36,13 +36,13 @@ struct AgentRow: View {
         HStack(spacing: Spacing.space8) {
             Text(overview.name)
                 .font(Typography.bodyMedium)
-                .foregroundStyle(theme.foreground)
+                .foregroundStyle(theme.ink)
                 .lineLimit(1)
             Spacer(minLength: Spacing.space8)
             if let timeLabel {
                 Text(timeLabel)
                     .font(Typography.caption)
-                    .foregroundStyle(theme.mutedFg)
+                    .foregroundStyle(theme.inkMuted)
                     .lineLimit(1)
             }
         }
@@ -53,7 +53,7 @@ struct AgentRow: View {
         HStack(spacing: Spacing.space8) {
             Text(preview.text)
                 .font(Typography.callout)
-                .foregroundStyle(preview.isWorking ? theme.accent : theme.mutedFg)
+                .foregroundStyle(theme.inkMuted)
                 .lineLimit(1)
             Spacer(minLength: Spacing.space8)
             if overview.needsYouCount > 0 {

--- a/mobile/ios/Houston/Features/Agents/AgentsView.swift
+++ b/mobile/ios/Houston/Features/Agents/AgentsView.swift
@@ -38,7 +38,7 @@ struct AgentsView: View {
         NavigationStack(path: $path) {
             content
                 .navigationTitle(Strings.Agents.title)
-                .background(theme.background)
+                .background(theme.input)
                 .searchable(
                     text: $query,
                     placement: .navigationBarDrawer(displayMode: .automatic),

--- a/mobile/ios/Houston/Features/Chat/AttachmentChips.swift
+++ b/mobile/ios/Houston/Features/Chat/AttachmentChips.swift
@@ -25,29 +25,29 @@ struct StagedAttachmentChips: View {
     HStack(spacing: Spacing.space6) {
       Image(systemName: "doc")
         .imageScale(.small)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
       Text(attachment.name)
         .font(Typography.caption)
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
         .lineLimit(1)
       Button {
         onRemove(attachment.id)
       } label: {
         Image(systemName: "xmark.circle.fill")
           .imageScale(.small)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
       }
       .buttonStyle(.plain)
       .accessibilityLabel(Strings.Chat.Attachments.remove(attachment.name))
     }
     .padding(.horizontal, Spacing.space10)
     .padding(.vertical, Spacing.space6)
-    .background(theme.secondary, in: Capsule())
+    .background(theme.chip, in: Capsule())
   }
 }
 
 /// A compact, read-only chips row rendered INSIDE a user bubble under the text
-/// (doc icon + name on a `theme.secondary` capsule). Shown when a persisted user
+/// (doc icon + name on a `theme.chip` capsule). Shown when a persisted user
 /// message decodes to attachment references (``AttachmentMessage/decode(_:)``).
 struct BubbleAttachmentChips: View {
   @Environment(\.theme) private var theme
@@ -65,8 +65,8 @@ struct BubbleAttachmentChips: View {
         }
         .padding(.horizontal, Spacing.space8)
         .padding(.vertical, Spacing.space4)
-        .foregroundStyle(theme.secondaryFg)
-        .background(theme.secondary, in: Capsule())
+        .foregroundStyle(theme.chipText)
+        .background(theme.chip, in: Capsule())
       }
     }
     .accessibilityLabel(Strings.Chat.Attachments.label)

--- a/mobile/ios/Houston/Features/Chat/ChatBubbles.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatBubbles.swift
@@ -3,7 +3,7 @@ import UIKit
 
 /// The two conversational messages.
 ///
-/// User (you): a right-aligned bubble on a solid `theme.primary` fill — the
+/// User (you): a right-aligned bubble on a solid `theme.action` fill — the
 /// "sent" bubble, clearly visible (continuous corner). When a `timestamp` is
 /// known it renders bottom-right INSIDE the bubble (WhatsApp convention); a
 /// long-press lifts the bubble for a native Copy menu.
@@ -38,7 +38,7 @@ struct UserBubble: View {
         if let author {
           Text(author)
             .font(Typography.caption)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
         }
         bubble
       }
@@ -50,7 +50,7 @@ struct UserBubble: View {
       .padding(.horizontal, Spacing.space16)
       .padding(.vertical, Spacing.space10)
       .background(
-        theme.primary,
+        theme.action,
         in: RoundedRectangle(cornerRadius: ChatMetrics.bubbleRadius, style: .continuous))
       .contextMenu {
         Button {
@@ -116,12 +116,12 @@ struct UserBubble: View {
         // alert, not quiet metadata; sending/sent stay quiet like the time.
         .foregroundStyle(
           delivery == .failed
-            ? theme.primaryFg : theme.primaryFg.opacity(ChatMetrics.bubbleTimeOpacity)
+            ? theme.actionText : theme.actionText.opacity(ChatMetrics.bubbleTimeOpacity)
         )
         .animation(.snappy(duration: Motion.fast), value: delivery)
         .accessibilityLabel(deliveryLabel)
     }
-    .foregroundStyle(theme.primaryFg.opacity(ChatMetrics.bubbleTimeOpacity))
+    .foregroundStyle(theme.actionText.opacity(ChatMetrics.bubbleTimeOpacity))
   }
 
   /// VoiceOver label for the delivery tick, matching the resolved ``delivery``.
@@ -136,7 +136,7 @@ struct UserBubble: View {
   private func messageText(_ value: String) -> some View {
     Text(value)
       .font(Typography.body)
-      .foregroundStyle(theme.primaryFg)
+      .foregroundStyle(theme.actionText)
   }
 }
 

--- a/mobile/ios/Houston/Features/Chat/ChatTimelineViews.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatTimelineViews.swift
@@ -18,10 +18,10 @@ struct DayPill: View {
   var body: some View {
     Text(text)
       .font(Typography.caption)
-      .foregroundStyle(theme.mutedFg)
+      .foregroundStyle(theme.inkMuted)
       .padding(.horizontal, Spacing.space10)
       .padding(.vertical, Spacing.space4)
-      .background(theme.secondary.opacity(0.8), in: Capsule())
+      .background(theme.chip.opacity(0.8), in: Capsule())
   }
 }
 
@@ -58,9 +58,9 @@ struct UnreadBadge: View {
   var body: some View {
     Text(Strings.cappedCount(count))
       .font(Typography.captionStrong)
-      .foregroundStyle(theme.primaryFg)
+      .foregroundStyle(theme.actionText)
       .padding(.horizontal, Spacing.space6)
       .padding(.vertical, Spacing.space2)
-      .background(theme.primary, in: Capsule())
+      .background(theme.action, in: Capsule())
   }
 }

--- a/mobile/ios/Houston/Features/Chat/ChatTitleView.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatTitleView.swift
@@ -22,7 +22,7 @@ struct ChatTitleView: View {
       VStack(alignment: .leading, spacing: Spacing.space2) {
         Text(name)
           .font(Typography.bodyMedium)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
           .lineLimit(1)
         statusLine
       }
@@ -38,7 +38,7 @@ struct ChatTitleView: View {
     case .working:
       Text(Strings.Chat.TitleBar.working)
         .font(Typography.caption)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
         .lineLimit(1)
         .shimmer(active: true)
     case .needsAttention:

--- a/mobile/ios/Houston/Features/Chat/ChatView.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatView.swift
@@ -56,7 +56,7 @@ struct ChatView: View {
       .safeAreaInset(edge: .bottom, spacing: 0) { footer }
       // The signature branded wallpaper sits behind the whole surface — applied
       // after the composer inset so it bleeds under the composer material (and
-      // supplies the base `theme.background` the flat fill used to provide).
+      // supplies the base `theme.input` the flat fill used to provide).
       .background { ChatWallpaperView() }
       .onAppear { model.appear() }
       .onDisappear { model.disappear() }

--- a/mobile/ios/Houston/Features/Chat/ChatWallpaperLayout.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatWallpaperLayout.swift
@@ -28,7 +28,7 @@ enum ChatWallpaperLayout {
   /// the half-row offset produces a clear diagonal cadence. Feature constant.
   static let rowSpacing: CGFloat = 60
 
-  /// The pattern's fill opacity, applied to `theme.foreground`. Very low so the
+  /// The pattern's fill opacity, applied to `theme.ink`. Very low so the
   /// wallpaper is a texture, not decoration — it must never compete with bubbles
   /// or the day/date pills layered over it. Feature constant.
   static let patternOpacity: CGFloat = 0.035
@@ -70,7 +70,7 @@ enum ChatWallpaperLayout {
 }
 
 /// Whether the branded pattern draws, or the surface falls back to a flat
-/// `theme.background`. Split out as a pure predicate so the accessibility gate
+/// `theme.input`. Split out as a pure predicate so the accessibility gate
 /// is unit-tested without touching SwiftUI's environment.
 enum ChatWallpaperVisibility {
   /// The pattern is suppressed under Reduce Transparency: users who ask for a

--- a/mobile/ios/Houston/Features/Chat/ChatWallpaperView.swift
+++ b/mobile/ios/Houston/Features/Chat/ChatWallpaperView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// The signature chat wallpaper: `theme.background` overlaid with a sparse,
+/// The signature chat wallpaper: `theme.input` overlaid with a sparse,
 /// static diagonal lattice of the Houston helmet glyph at very low contrast —
 /// the Houston-branded answer to WhatsApp's doodle background, whose flat
 /// backdrop is the #1 "this isn't a messenger" tell.
@@ -19,7 +19,7 @@ struct ChatWallpaperView: View {
 
   var body: some View {
     ZStack {
-      theme.background
+      theme.input
       if ChatWallpaperVisibility.showsPattern(reduceTransparency: reduceTransparency) {
         pattern
       }
@@ -35,7 +35,7 @@ struct ChatWallpaperView: View {
       let side = ChatWallpaperLayout.glyphSize
       let base = HelmetShape().path(in: CGRect(x: 0, y: 0, width: side, height: side))
       let shading = GraphicsContext.Shading.color(
-        theme.foreground.opacity(ChatWallpaperLayout.patternOpacity))
+        theme.ink.opacity(ChatWallpaperLayout.patternOpacity))
 
       for center in ChatWallpaperLayout.glyphCenters(in: size) {
         let stamped = base.applying(

--- a/mobile/ios/Houston/Features/Chat/EffortSheet.swift
+++ b/mobile/ios/Houston/Features/Chat/EffortSheet.swift
@@ -81,10 +81,10 @@ struct EffortSheet: View {
       HStack {
         Text(label)
           .font(Typography.body)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
         Spacer(minLength: Spacing.space8)
         if isCurrent {
-          Image(systemName: "checkmark").foregroundStyle(theme.primary)
+          Image(systemName: "checkmark").foregroundStyle(theme.action)
         }
       }
       .contentShape(Rectangle())

--- a/mobile/ios/Houston/Features/Chat/FeedDivider.swift
+++ b/mobile/ios/Houston/Features/Chat/FeedDivider.swift
@@ -12,7 +12,7 @@ struct FeedDivider: View {
       rule
       Text(caption)
         .font(Typography.caption)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
         .fixedSize(horizontal: false, vertical: true)
         .multilineTextAlignment(.center)
       rule
@@ -22,7 +22,7 @@ struct FeedDivider: View {
 
   private var rule: some View {
     Rectangle()
-      .fill(theme.border)
+      .fill(theme.line)
       .frame(height: 1)
       .frame(maxWidth: .infinity)
   }

--- a/mobile/ios/Houston/Features/Chat/FileChangesBlock.swift
+++ b/mobile/ios/Houston/Features/Chat/FileChangesBlock.swift
@@ -13,20 +13,20 @@ struct FileChangesBlock: View {
       HStack(spacing: Spacing.space6) {
         Image(systemName: "doc.badge.gearshape")
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
         Text(Strings.Chat.updatesMade)
           .font(Typography.label)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
       }
       ForEach(FileChangesSummary.lines(created: created, modified: modified), id: \.self) { line in
         Text(line)
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
       }
       ForEach(paths, id: \.self) { path in
         Text(path)
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
           .lineLimit(1)
           .truncationMode(.middle)
       }
@@ -34,7 +34,7 @@ struct FileChangesBlock: View {
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(.horizontal, Spacing.space12)
     .padding(.vertical, Spacing.space8)
-    .background(theme.muted, in: RoundedRectangle(cornerRadius: Radius.lg))
+    .background(theme.chipSubtle, in: RoundedRectangle(cornerRadius: Radius.lg))
   }
 
   private var paths: [String] { created + modified }

--- a/mobile/ios/Houston/Features/Chat/HelmetIndicator.swift
+++ b/mobile/ios/Houston/Features/Chat/HelmetIndicator.swift
@@ -15,7 +15,7 @@ struct PulsingHelmet: View {
 
     var body: some View {
         HelmetShape()
-            .fill(theme.mutedFg)
+            .fill(theme.inkMuted)
             .frame(width: size, height: size)
             .opacity(pulsing && !reduceMotion ? (dimmed ? 0.5 : 1) : 1)
             .animation(
@@ -43,7 +43,7 @@ struct PendingTurnIndicator: View {
             if showLabel {
                 Text(Strings.Chat.missionInProgress)
                     .font(Typography.caption)
-                    .foregroundStyle(theme.mutedFg)
+                    .foregroundStyle(theme.inkMuted)
                     .shimmer(active: true)
             }
             PulsingHelmet(size: ChatMetrics.loadingHelmetSize)

--- a/mobile/ios/Houston/Features/Chat/InteractionActionSteps.swift
+++ b/mobile/ios/Houston/Features/Chat/InteractionActionSteps.swift
@@ -18,11 +18,11 @@ struct InteractionSigninView: View {
     VStack(alignment: .leading, spacing: Spacing.space8) {
       Text(reason ?? Strings.Interaction.signinReason)
         .font(Typography.body)
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
         .fixedSize(horizontal: false, vertical: true)
       Text(Strings.Interaction.signinDescription)
         .font(Typography.callout)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
         .fixedSize(horizontal: false, vertical: true)
       InteractionPrimaryButton(
         title: Strings.Interaction.signin, isSending: isSending, action: onSignin)
@@ -51,11 +51,11 @@ struct InteractionConnectView: View {
     VStack(alignment: .leading, spacing: Spacing.space8) {
       Text(toolkit)
         .font(Typography.bodyMedium)
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
       if let reason {
         Text(reason)
           .font(Typography.callout)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
           .fixedSize(horizontal: false, vertical: true)
       }
       InteractionPrimaryButton(
@@ -82,21 +82,21 @@ struct InteractionPlanReadyView: View {
     VStack(alignment: .leading, spacing: Spacing.space10) {
       Text(Strings.Interaction.planTitle)
         .font(Typography.captionStrong)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
       MarkdownText(text: summary)
       Button(action: onApprove) {
         VStack(alignment: .leading, spacing: Spacing.space2) {
           Text(Strings.Interaction.planApproveTitle)
             .font(Typography.label)
-            .foregroundStyle(theme.foreground)
+            .foregroundStyle(theme.ink)
           Text(Strings.Interaction.planApproveDescription)
             .font(Typography.caption)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, Spacing.space12)
         .padding(.vertical, Spacing.space10)
-        .background(theme.secondary, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+        .background(theme.chip, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
         .contentShape(RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
       }
       .buttonStyle(.plain)
@@ -120,10 +120,10 @@ struct InteractionPrimaryButton: View {
     Button(action: action) {
       Text(title)
         .font(Typography.label)
-        .foregroundStyle(theme.primaryFg)
+        .foregroundStyle(theme.actionText)
         .frame(maxWidth: .infinity)
         .padding(.vertical, Spacing.space10)
-        .background(theme.primary, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+        .background(theme.action, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
     }
     .buttonStyle(.plain)
     .disabled(isSending)
@@ -144,7 +144,7 @@ struct InteractionContinueButton: View {
     Button(action: action) {
       Text(Strings.Interaction.continueStep)
         .font(Typography.label)
-        .foregroundStyle(theme.primary)
+        .foregroundStyle(theme.action)
     }
     .buttonStyle(.plain)
     .disabled(isSending)

--- a/mobile/ios/Houston/Features/Chat/InteractionCard.swift
+++ b/mobile/ios/Houston/Features/Chat/InteractionCard.swift
@@ -54,7 +54,7 @@ struct InteractionCard: View {
       if stepper.showsProgress {
         Text(Strings.Interaction.progress(stepper.progress.current, stepper.progress.total))
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
       }
       stepContent(step)
         .id(stepper.index)
@@ -65,7 +65,7 @@ struct InteractionCard: View {
     .background(theme.card, in: RoundedRectangle(cornerRadius: Radius.composer, style: .continuous))
     .overlay(
       RoundedRectangle(cornerRadius: Radius.composer, style: .continuous)
-        .strokeBorder(theme.border, lineWidth: 1))
+        .strokeBorder(theme.line, lineWidth: 1))
   }
 
   @ViewBuilder private func stepContent(_ step: InteractionStep) -> some View {

--- a/mobile/ios/Houston/Features/Chat/InteractionQuestionView.swift
+++ b/mobile/ios/Houston/Features/Chat/InteractionQuestionView.swift
@@ -19,7 +19,7 @@ struct InteractionQuestionView: View {
     VStack(alignment: .leading, spacing: Spacing.space12) {
       Text(question)
         .font(Typography.bodyMedium)
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
         .fixedSize(horizontal: false, vertical: true)
 
       if !options.isEmpty {
@@ -35,12 +35,12 @@ struct InteractionQuestionView: View {
 
       Text(Strings.Interaction.freeTextHint)
         .font(Typography.caption)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
     }
   }
 }
 
-/// One full-width option row: a raised `theme.secondary` chip (Radius.lg) that
+/// One full-width option row: a raised `theme.chip` chip (Radius.lg) that
 /// reads clickable at rest (no hover gate). Disabled — dimmed and inert — while a
 /// send is in flight.
 struct InteractionOptionRow: View {
@@ -54,11 +54,11 @@ struct InteractionOptionRow: View {
     Button(action: action) {
       Text(label)
         .font(Typography.body)
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, Spacing.space12)
         .padding(.vertical, Spacing.space10)
-        .background(theme.secondary, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+        .background(theme.chip, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
         .contentShape(RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
     }
     .buttonStyle(.plain)

--- a/mobile/ios/Houston/Features/Chat/MarkdownText.swift
+++ b/mobile/ios/Houston/Features/Chat/MarkdownText.swift
@@ -18,30 +18,30 @@ struct MarkdownText: View {
             }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .tint(theme.primary)
+        .tint(theme.action)
         .textSelection(.enabled)
     }
 
     @ViewBuilder private func view(for block: MarkdownBlock) -> some View {
         switch block {
         case let .paragraph(content):
-            Text(content).font(Typography.body).foregroundStyle(theme.foreground)
+            Text(content).font(Typography.body).foregroundStyle(theme.ink)
         case let .heading(level, content):
             Text(content)
                 .font(headingFont(level))
-                .foregroundStyle(theme.foreground)
+                .foregroundStyle(theme.ink)
                 .padding(.top, Spacing.space4)
         case let .listItem(ordered, ordinal, depth, content):
             listRow(ordered: ordered, ordinal: ordinal, depth: depth, content: content)
         case let .blockquote(content):
             HStack(spacing: Spacing.space8) {
-                Rectangle().fill(theme.border).frame(width: 2)
-                Text(content).font(Typography.body).foregroundStyle(theme.mutedFg)
+                Rectangle().fill(theme.line).frame(width: 2)
+                Text(content).font(Typography.body).foregroundStyle(theme.inkMuted)
             }
         case let .codeBlock(_, code):
             CodeSlab(code: code)
         case .thematicBreak:
-            Rectangle().fill(theme.border).frame(height: 1).padding(.vertical, Spacing.space4)
+            Rectangle().fill(theme.line).frame(height: 1).padding(.vertical, Spacing.space4)
         }
     }
 
@@ -51,9 +51,9 @@ struct MarkdownText: View {
         HStack(alignment: .firstTextBaseline, spacing: Spacing.space8) {
             Text(ordered ? "\(ordinal)." : "•")
                 .font(Typography.body)
-                .foregroundStyle(theme.mutedFg)
+                .foregroundStyle(theme.inkMuted)
                 .monospacedDigit()
-            Text(content).font(Typography.body).foregroundStyle(theme.foreground)
+            Text(content).font(Typography.body).foregroundStyle(theme.ink)
         }
         .padding(.leading, CGFloat(depth - 1) * Spacing.space16)
     }
@@ -78,10 +78,10 @@ private struct CodeSlab: View {
         ScrollView(.horizontal, showsIndicators: false) {
             Text(code)
                 .font(.system(size: HoustonFontSize.sm, design: .monospaced))
-                .foregroundStyle(theme.foreground)
+                .foregroundStyle(theme.ink)
                 .textSelection(.enabled)
                 .padding(Spacing.space12)
         }
-        .background(theme.secondary, in: RoundedRectangle(cornerRadius: Radius.lg))
+        .background(theme.chip, in: RoundedRectangle(cornerRadius: Radius.lg))
     }
 }

--- a/mobile/ios/Houston/Features/Chat/MissionComposer.swift
+++ b/mobile/ios/Houston/Features/Chat/MissionComposer.swift
@@ -81,7 +81,7 @@ struct MissionComposer<PlusMenu: View>: View {
       .fill(.regularMaterial)
       .overlay(alignment: .top) {
         Rectangle()
-          .fill(theme.border)
+          .fill(theme.line)
           .frame(height: ChatMetrics.inputBarHairline)
       }
       .ignoresSafeArea(.container, edges: .bottom)
@@ -97,7 +97,7 @@ struct MissionComposer<PlusMenu: View>: View {
     } label: {
       Image(systemName: "plus")
         .font(.system(size: ChatMetrics.plusGlyphSize, weight: .regular))
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
         .frame(width: ChatMetrics.plusButtonSize, height: ChatMetrics.plusButtonSize)
     }
     .buttonStyle(.plain)
@@ -109,13 +109,13 @@ struct MissionComposer<PlusMenu: View>: View {
       .textFieldStyle(.plain)
       .lineLimit(1...ChatMetrics.inputFieldMaxLines)
       .font(Typography.body)
-      .foregroundStyle(theme.foreground)
-      .tint(theme.primary)
+      .foregroundStyle(theme.ink)
+      .tint(theme.action)
       .padding(.horizontal, ChatMetrics.inputFieldHInset)
       .padding(.vertical, ChatMetrics.inputFieldVInset)
       .background(
         RoundedRectangle(cornerRadius: ChatMetrics.inputFieldRadius, style: .continuous)
-          .fill(theme.secondary))
+          .fill(theme.chip))
       .focused($focused)
   }
 
@@ -127,7 +127,7 @@ struct MissionComposer<PlusMenu: View>: View {
       isRunning ? onStop() : onSend()
     } label: {
       ZStack {
-        Circle().fill(active ? theme.primary : theme.muted)
+        Circle().fill(active ? theme.action : theme.chipSubtle)
         glyph
       }
       .frame(width: ChatMetrics.sendButtonSize, height: ChatMetrics.sendButtonSize)
@@ -149,11 +149,11 @@ struct MissionComposer<PlusMenu: View>: View {
     if isSending && !isRunning {
       ProgressView()
         .controlSize(.small)
-        .tint(theme.primaryFg)
+        .tint(theme.actionText)
     } else {
       Image(systemName: isRunning ? "stop.fill" : "paperplane.fill")
         .font(.system(size: ChatMetrics.sendGlyphSize, weight: .semibold))
-        .foregroundStyle(active ? theme.primaryFg : theme.mutedFg)
+        .foregroundStyle(active ? theme.actionText : theme.inkMuted)
         .contentTransition(.symbolEffect(.replace))
     }
   }

--- a/mobile/ios/Houston/Features/Chat/MissionFeed.swift
+++ b/mobile/ios/Houston/Features/Chat/MissionFeed.swift
@@ -190,10 +190,10 @@ struct MissionFeed: View {
     Button(action: action) {
       Image(systemName: "chevron.down")
         .font(Typography.label)
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
         .padding(Spacing.space10)
         .background(theme.card, in: Circle())
-        .overlay(Circle().strokeBorder(theme.border, lineWidth: 1))
+        .overlay(Circle().strokeBorder(theme.line, lineWidth: 1))
         .floatingChromeShadow()
     }
     .overlay(alignment: .topTrailing) {

--- a/mobile/ios/Houston/Features/Chat/ModelPickerSheet.swift
+++ b/mobile/ios/Houston/Features/Chat/ModelPickerSheet.swift
@@ -88,10 +88,10 @@ struct ModelPickerSheet: View {
       HStack {
         Text(label)
           .font(Typography.body)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
         Spacer(minLength: Spacing.space8)
         if modelId == current {
-          Image(systemName: "checkmark").foregroundStyle(theme.primary)
+          Image(systemName: "checkmark").foregroundStyle(theme.action)
         }
       }
       .contentShape(Rectangle())

--- a/mobile/ios/Houston/Features/Chat/ProcessBlockView.swift
+++ b/mobile/ios/Houston/Features/Chat/ProcessBlockView.swift
@@ -34,12 +34,12 @@ struct ProcessBlockView: View {
                 PulsingHelmet(size: ChatMetrics.headerHelmetSize, pulsing: false)
                 Text(ProcessHeader.label(for: group))
                     .font(Typography.caption)
-                    .foregroundStyle(theme.mutedFg)
+                    .foregroundStyle(theme.inkMuted)
                     .lineLimit(1)
                     .shimmer(active: group.active)
                 Image(systemName: "chevron.down")
                     .font(Typography.caption)
-                    .foregroundStyle(theme.mutedFg)
+                    .foregroundStyle(theme.inkMuted)
                     .rotationEffect(.degrees(expanded ? 180 : 0))
                 Spacer(minLength: 0)
             }
@@ -55,12 +55,12 @@ struct ProcessBlockView: View {
                 // once settled (PARITY §4 copy).
                 Text(ThinkingCopy.label(streaming: streaming))
                     .font(Typography.label)
-                    .foregroundStyle(theme.mutedFg)
+                    .foregroundStyle(theme.inkMuted)
                     .shimmer(active: streaming)
                 if !text.isEmpty {
                     Text(text)
                         .font(Typography.callout)
-                        .foregroundStyle(theme.mutedFg)
+                        .foregroundStyle(theme.inkMuted)
                         .textSelection(.enabled)
                 }
             }
@@ -91,7 +91,7 @@ private struct ToolRowView: View {
                 HStack(alignment: .firstTextBaseline, spacing: Spacing.space6) {
                     Image(systemName: ToolLabel.symbol(call.name))
                         .font(Typography.caption)
-                        .foregroundStyle(theme.mutedFg)
+                        .foregroundStyle(theme.inkMuted)
                         .frame(width: Spacing.space16)
                     Text(label)
                         .font(Typography.caption)
@@ -106,11 +106,11 @@ private struct ToolRowView: View {
             if showResult, let result {
                 Text(result.content)
                     .font(.system(size: HoustonFontSize.xs, design: .monospaced))
-                    .foregroundStyle(result.isError ? theme.destructive : theme.mutedFg)
+                    .foregroundStyle(result.isError ? theme.danger : theme.inkMuted)
                     .textSelection(.enabled)
                     .padding(Spacing.space8)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(theme.secondary, in: RoundedRectangle(cornerRadius: Radius.md))
+                    .background(theme.chip, in: RoundedRectangle(cornerRadius: Radius.md))
             }
         }
     }
@@ -119,11 +119,11 @@ private struct ToolRowView: View {
     /// joined with " — " (desktop `tool-block.tsx:98-101`).
     private var label: AttributedString {
         var verb = AttributedString(ToolLabel.action(call.name, done: done))
-        verb.foregroundColor = theme.mutedFg
+        verb.foregroundColor = theme.inkMuted
         guard let detail = ToolDetail.string(name: call.name, input: call.input), !detail.isEmpty
         else { return verb }
         var suffix = AttributedString(" — \(detail)")
-        suffix.foregroundColor = theme.mutedFg.opacity(0.5)
+        suffix.foregroundColor = theme.inkMuted.opacity(0.5)
         return verb + suffix
     }
 }

--- a/mobile/ios/Houston/Features/Chat/ProviderErrorCardView.swift
+++ b/mobile/ios/Houston/Features/Chat/ProviderErrorCardView.swift
@@ -13,23 +13,23 @@ struct ProviderErrorCardView: View {
       HStack(spacing: Spacing.space6) {
         Image(systemName: "exclamationmark.triangle.fill")
           .font(Typography.caption)
-          .foregroundStyle(theme.destructive)
+          .foregroundStyle(theme.danger)
         Text(presentation.title)
           .font(Typography.label)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
       }
       Text(presentation.detail)
         .font(Typography.callout)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
         .fixedSize(horizontal: false, vertical: true)
       if let raw = presentation.rawExcerpt {
         VStack(alignment: .leading, spacing: Spacing.space2) {
           Text(Strings.Chat.ProviderErrorCopy.rawLabel)
             .font(Typography.captionStrong)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
           Text(raw)
             .font(Typography.caption)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
             .textSelection(.enabled)
             .lineLimit(8)
         }
@@ -38,9 +38,9 @@ struct ProviderErrorCardView: View {
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(Spacing.space12)
-    .background(theme.destructive.opacity(0.08), in: RoundedRectangle(cornerRadius: Radius.lg))
+    .background(theme.danger.opacity(0.08), in: RoundedRectangle(cornerRadius: Radius.lg))
     .overlay(
       RoundedRectangle(cornerRadius: Radius.lg)
-        .strokeBorder(theme.destructive.opacity(0.5), lineWidth: 1))
+        .strokeBorder(theme.danger.opacity(0.5), lineWidth: 1))
   }
 }

--- a/mobile/ios/Houston/Features/Chat/QueuedMessagesView.swift
+++ b/mobile/ios/Houston/Features/Chat/QueuedMessagesView.swift
@@ -35,18 +35,18 @@ private struct QueuedBubble: View {
       Spacer(minLength: Spacing.space40)
       Image(systemName: "clock")
         .font(Typography.caption)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
       VStack(alignment: .trailing, spacing: Spacing.space2) {
         Text(message.text)
           .font(Typography.body)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
           .padding(.horizontal, Spacing.space16)
           .padding(.vertical, Spacing.space10)
-          .background(theme.muted, in: RoundedRectangle(cornerRadius: ChatMetrics.bubbleRadius))
+          .background(theme.chipSubtle, in: RoundedRectangle(cornerRadius: ChatMetrics.bubbleRadius))
         if let names = message.attachmentNames, !names.isEmpty {
           Text(names.joined(separator: ", "))
             .font(Typography.caption)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
             .lineLimit(1)
         }
       }

--- a/mobile/ios/Houston/Features/Chat/SystemFeedViews.swift
+++ b/mobile/ios/Houston/Features/Chat/SystemFeedViews.swift
@@ -8,7 +8,7 @@ struct SystemLineView: View {
   var body: some View {
     Text(text)
       .font(Typography.caption)
-      .foregroundStyle(theme.mutedFg)
+      .foregroundStyle(theme.inkMuted)
       .multilineTextAlignment(.center)
       .frame(maxWidth: .infinity, alignment: .center)
       .padding(.vertical, Spacing.space4)
@@ -26,19 +26,19 @@ struct ToolRuntimeErrorView: View {
     VStack(alignment: .leading, spacing: Spacing.space4) {
       Text(Strings.Chat.toolRuntimeError)
         .font(Typography.label)
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
       if !error.details.isEmpty {
         Text(error.details)
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
       }
       Text(Strings.Chat.tryAgain)
         .font(Typography.caption)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .padding(.horizontal, Spacing.space12)
     .padding(.vertical, Spacing.space8)
-    .background(theme.muted, in: RoundedRectangle(cornerRadius: Radius.lg))
+    .background(theme.chipSubtle, in: RoundedRectangle(cornerRadius: Radius.lg))
   }
 }

--- a/mobile/ios/Houston/Features/Integrations/AgentIntegrationsView.swift
+++ b/mobile/ios/Houston/Features/Integrations/AgentIntegrationsView.swift
@@ -23,7 +23,7 @@ struct AgentIntegrationsView: View {
     content
       .navigationTitle(Strings.Integrations.title)
       .navigationBarTitleDisplayMode(.inline)
-      .background(theme.background)
+      .background(theme.input)
       .onAppear {
         if retention == nil { retention = model.retain() }
         if flow == nil {
@@ -70,7 +70,7 @@ struct AgentIntegrationsView: View {
           Button(action: onManageAll) {
             Text(Strings.Integrations.agentManageAll)
               .font(Typography.callout)
-              .foregroundStyle(theme.mutedFg)
+              .foregroundStyle(theme.inkMuted)
           }
           .frame(maxWidth: .infinity)
         }
@@ -78,7 +78,7 @@ struct AgentIntegrationsView: View {
       .padding(.horizontal, Spacing.space16)
       .padding(.vertical, Spacing.space16)
     }
-    .background(theme.background)
+    .background(theme.input)
     .sheet(item: sessionBinding(flow)) { session in
       ConnectWaitingSheet(session: session, flow: flow)
     }
@@ -121,7 +121,7 @@ struct AgentIntegrationsView: View {
       if let subtitle {
         Text(subtitle)
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
           .padding(.horizontal, Spacing.space12)
       }
       if empty {
@@ -143,13 +143,13 @@ struct AgentIntegrationsView: View {
   }
 
   private func deactivateButton(toolkit: String) -> some View {
-    pill(Strings.Integrations.agentDeactivate, tint: theme.mutedFg) {
+    pill(Strings.Integrations.agentDeactivate, tint: theme.inkMuted) {
       Task { await model.setGrant(toolkit: toolkit, agentId: agentId, active: false) }
     }
   }
 
   private func activateButton(toolkit: String) -> some View {
-    pill(Strings.Integrations.agentActivate, tint: theme.primary) {
+    pill(Strings.Integrations.agentActivate, tint: theme.action) {
       Task { await model.setGrant(toolkit: toolkit, agentId: agentId, active: true) }
     }
   }
@@ -161,8 +161,8 @@ struct AgentIntegrationsView: View {
         .foregroundStyle(tint)
         .padding(.horizontal, Spacing.space10)
         .padding(.vertical, Spacing.space6)
-        .background(theme.muted, in: Capsule())
-        .overlay(Capsule().strokeBorder(theme.border, lineWidth: 1))
+        .background(theme.chipSubtle, in: Capsule())
+        .overlay(Capsule().strokeBorder(theme.line, lineWidth: 1))
     }
     .buttonStyle(.plain)
   }

--- a/mobile/ios/Houston/Features/Integrations/AppDetailSheet.swift
+++ b/mobile/ios/Houston/Features/Integrations/AppDetailSheet.swift
@@ -28,7 +28,7 @@ struct AppDetailSheet: View {
         }
         .padding(Spacing.space16)
       }
-      .background(theme.background)
+      .background(theme.input)
       .safeAreaInset(edge: .bottom) { actions }
       .navigationBarTitleDisplayMode(.inline)
     }
@@ -51,7 +51,7 @@ struct AppDetailSheet: View {
       VStack(alignment: .leading, spacing: Spacing.space4) {
         Text(display.name)
           .font(Typography.title)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
           .lineLimit(1)
         ConnectionStatusBadge(status: connection.status)
       }
@@ -63,7 +63,7 @@ struct AppDetailSheet: View {
     VStack(alignment: .leading, spacing: Spacing.space8) {
       Text(Strings.Integrations.detailActiveOn)
         .font(Typography.label)
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
       if let error = model.grantsError {
         grantsError(error)
       } else if !model.grants.supported {
@@ -83,7 +83,7 @@ struct AppDetailSheet: View {
       HoustonAvatar(agentColorHex: nil, diameter: 24)
       Text(agent.name)
         .font(Typography.body)
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
         .lineLimit(1)
       Spacer(minLength: Spacing.space8)
       Toggle("", isOn: binding(for: agent.id))
@@ -111,7 +111,7 @@ struct AppDetailSheet: View {
       } label: {
         Text(Strings.Integrations.grantsRetry)
           .font(Typography.label)
-          .foregroundStyle(theme.primary)
+          .foregroundStyle(theme.action)
       }
       .accessibilityHint(message)
     }
@@ -120,10 +120,10 @@ struct AppDetailSheet: View {
   private func note(_ text: String) -> some View {
     Text(text)
       .font(Typography.caption)
-      .foregroundStyle(theme.mutedFg)
+      .foregroundStyle(theme.inkMuted)
       .frame(maxWidth: .infinity, alignment: .leading)
       .padding(Spacing.space12)
-      .background(theme.muted, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+      .background(theme.chipSubtle, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
   }
 
   private var actions: some View {
@@ -132,17 +132,17 @@ struct AppDetailSheet: View {
         dismiss()
         Task { await flow.connect(toolkit: connection.toolkit, appName: display.name) }
       } label: {
-        actionLabel(Strings.Integrations.detailReconnect, icon: "arrow.clockwise", tint: theme.foreground)
-          .overlay(Capsule().strokeBorder(theme.border, lineWidth: 1))
+        actionLabel(Strings.Integrations.detailReconnect, icon: "arrow.clockwise", tint: theme.ink)
+          .overlay(Capsule().strokeBorder(theme.line, lineWidth: 1))
       }
       Button {
         confirmingDisconnect = true
       } label: {
-        actionLabel(Strings.Integrations.detailDisconnect, icon: "bolt.slash", tint: theme.destructive)
+        actionLabel(Strings.Integrations.detailDisconnect, icon: "bolt.slash", tint: theme.danger)
       }
     }
     .padding(Spacing.space16)
-    .background(theme.background)
+    .background(theme.input)
   }
 
   private func actionLabel(_ title: String, icon: String, tint: Color) -> some View {
@@ -154,6 +154,6 @@ struct AppDetailSheet: View {
     .foregroundStyle(tint)
     .frame(maxWidth: .infinity)
     .padding(.vertical, Spacing.space12)
-    .background(theme.muted, in: Capsule())
+    .background(theme.chipSubtle, in: Capsule())
   }
 }

--- a/mobile/ios/Houston/Features/Integrations/AppLogoView.swift
+++ b/mobile/ios/Houston/Features/Integrations/AppLogoView.swift
@@ -26,10 +26,10 @@ struct AppLogoView: View {
       }
     }
     .frame(width: diameter, height: diameter)
-    .background(theme.muted, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
+    .background(theme.chipSubtle, in: RoundedRectangle(cornerRadius: Radius.md, style: .continuous))
     .overlay(
       RoundedRectangle(cornerRadius: Radius.md, style: .continuous)
-        .strokeBorder(theme.border, lineWidth: 1)
+        .strokeBorder(theme.line, lineWidth: 1)
     )
     .accessibilityHidden(true)
   }
@@ -37,7 +37,7 @@ struct AppLogoView: View {
   private var fallback: some View {
     Text(display.initial)
       .font(Typography.font(diameter * 0.4, HoustonFontWeight.semibold))
-      .foregroundStyle(theme.mutedFg)
+      .foregroundStyle(theme.inkMuted)
       .frame(maxWidth: .infinity, maxHeight: .infinity)
   }
 }

--- a/mobile/ios/Houston/Features/Integrations/AppRowView.swift
+++ b/mobile/ios/Houston/Features/Integrations/AppRowView.swift
@@ -27,12 +27,12 @@ struct AppRowView<Trailing: View>: View {
         VStack(alignment: .leading, spacing: Spacing.space2) {
           Text(display.name)
             .font(Typography.bodyMedium)
-            .foregroundStyle(theme.foreground)
+            .foregroundStyle(theme.ink)
             .lineLimit(1)
           if let subtitle, !subtitle.isEmpty {
             Text(subtitle)
               .font(Typography.caption)
-              .foregroundStyle(theme.mutedFg)
+              .foregroundStyle(theme.inkMuted)
               .lineLimit(1)
           }
         }

--- a/mobile/ios/Houston/Features/Integrations/ConnectCatalogView.swift
+++ b/mobile/ios/Houston/Features/Integrations/ConnectCatalogView.swift
@@ -31,7 +31,7 @@ struct ConnectCatalogView: View {
       if results.isEmpty {
         Text(Strings.Integrations.pickerNoResults)
           .font(Typography.callout)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
           .frame(maxWidth: .infinity)
           .padding(.vertical, Spacing.space16)
       } else {
@@ -67,13 +67,13 @@ struct ConnectCatalogView: View {
               .lineLimit(1)
             Image(systemName: "chevron.down").font(Typography.caption)
           }
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
           .padding(.horizontal, Spacing.space12)
           .padding(.vertical, Spacing.space10)
-          .background(theme.muted, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
+          .background(theme.chipSubtle, in: RoundedRectangle(cornerRadius: Radius.lg, style: .continuous))
           .overlay(
             RoundedRectangle(cornerRadius: Radius.lg, style: .continuous)
-              .strokeBorder(theme.border, lineWidth: 1))
+              .strokeBorder(theme.line, lineWidth: 1))
         }
       }
     }
@@ -94,7 +94,7 @@ struct ConnectCatalogView: View {
       } else {
         Image(systemName: "plus")
           .font(Typography.label)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
       }
     }
   }
@@ -105,11 +105,11 @@ struct ConnectCatalogView: View {
     } label: {
       Text(Strings.Integrations.loadMore(remaining: results.count - visible))
         .font(Typography.label)
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
         .padding(.horizontal, Spacing.space16)
         .padding(.vertical, Spacing.space8)
-        .background(theme.muted, in: Capsule())
-        .overlay(Capsule().strokeBorder(theme.border, lineWidth: 1))
+        .background(theme.chipSubtle, in: Capsule())
+        .overlay(Capsule().strokeBorder(theme.line, lineWidth: 1))
     }
     .frame(maxWidth: .infinity)
     .padding(.top, Spacing.space4)

--- a/mobile/ios/Houston/Features/Integrations/ConnectWaitingSheet.swift
+++ b/mobile/ios/Houston/Features/Integrations/ConnectWaitingSheet.swift
@@ -19,11 +19,11 @@ struct ConnectWaitingSheet: View {
       VStack(spacing: Spacing.space8) {
         Text(Strings.Integrations.waitingTitle(app: session.appName))
           .font(Typography.title)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
           .multilineTextAlignment(.center)
         Text(Strings.Integrations.waitingBody(app: session.appName))
           .font(Typography.callout)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
           .multilineTextAlignment(.center)
       }
       VStack(spacing: Spacing.space8) {
@@ -32,28 +32,28 @@ struct ConnectWaitingSheet: View {
         } label: {
           Text(Strings.Integrations.waitingCheck)
             .font(Typography.label)
-            .foregroundStyle(theme.primaryFg)
+            .foregroundStyle(theme.actionText)
             .frame(maxWidth: .infinity)
             .padding(.vertical, Spacing.space12)
-            .background(theme.primary, in: Capsule())
+            .background(theme.action, in: Capsule())
         }
         Button {
           showSafari = true
         } label: {
           Text(Strings.Integrations.waitingReopen)
             .font(Typography.label)
-            .foregroundStyle(theme.foreground)
+            .foregroundStyle(theme.ink)
             .frame(maxWidth: .infinity)
             .padding(.vertical, Spacing.space12)
-            .background(theme.muted, in: Capsule())
-            .overlay(Capsule().strokeBorder(theme.border, lineWidth: 1))
+            .background(theme.chipSubtle, in: Capsule())
+            .overlay(Capsule().strokeBorder(theme.line, lineWidth: 1))
         }
         Button {
           flow.cancel()
         } label: {
           Text(Strings.Integrations.cancel)
             .font(Typography.label)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
             .frame(maxWidth: .infinity)
             .padding(.vertical, Spacing.space12)
         }
@@ -61,7 +61,7 @@ struct ConnectWaitingSheet: View {
     }
     .padding(Spacing.space24)
     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
-    .background(theme.background)
+    .background(theme.input)
     .presentationDetents([.medium])
     .onAppear { showSafari = true }
     .fullScreenCover(isPresented: $showSafari) {

--- a/mobile/ios/Houston/Features/Integrations/ConnectedAppCard.swift
+++ b/mobile/ios/Houston/Features/Integrations/ConnectedAppCard.swift
@@ -20,14 +20,14 @@ struct ConnectedAppCard: View {
           AppLogoView(display: display, diameter: 40)
           Text(display.name)
             .font(Typography.bodyMedium)
-            .foregroundStyle(theme.foreground)
+            .foregroundStyle(theme.ink)
             .lineLimit(1)
           Spacer(minLength: 0)
         }
         ConnectionStatusBadge(status: connection.status)
         Text(usedByLine)
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
           .lineLimit(1)
       }
       .frame(maxWidth: .infinity, alignment: .leading)
@@ -35,7 +35,7 @@ struct ConnectedAppCard: View {
       .background(theme.card, in: RoundedRectangle(cornerRadius: Radius.xl, style: .continuous))
       .overlay(
         RoundedRectangle(cornerRadius: Radius.xl, style: .continuous)
-          .strokeBorder(theme.border, lineWidth: 1))
+          .strokeBorder(theme.line, lineWidth: 1))
     }
     .buttonStyle(.plain)
   }

--- a/mobile/ios/Houston/Features/Integrations/ConnectionStatusBadge.swift
+++ b/mobile/ios/Houston/Features/Integrations/ConnectionStatusBadge.swift
@@ -15,7 +15,7 @@ struct ConnectionStatusBadge: View {
         .frame(width: 6, height: 6)
       Text(Strings.Integrations.status(status))
         .font(Typography.caption)
-        .foregroundStyle(theme.mutedFg)
+        .foregroundStyle(theme.inkMuted)
     }
   }
 
@@ -23,8 +23,8 @@ struct ConnectionStatusBadge: View {
     switch status {
     case .active: return theme.success
     case .pending: return theme.warning
-    case .error: return theme.destructive
-    case .unknown: return theme.mutedFg
+    case .error: return theme.danger
+    case .unknown: return theme.inkMuted
     }
   }
 }

--- a/mobile/ios/Houston/Features/Integrations/IntegrationsReadyView.swift
+++ b/mobile/ios/Houston/Features/Integrations/IntegrationsReadyView.swift
@@ -29,14 +29,14 @@ struct IntegrationsReadyView: View {
       VStack(alignment: .leading, spacing: Spacing.space20) {
         Text(Strings.Integrations.homeDescription)
           .font(Typography.callout)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
         if !connections.isEmpty { connectedSection }
         ConnectCatalogView(model: model, flow: flow)
       }
       .padding(.horizontal, Spacing.space16)
       .padding(.vertical, Spacing.space16)
     }
-    .background(theme.background)
+    .background(theme.input)
     .sheet(item: $selected) { connection in
       AppDetailSheet(model: model, flow: flow, connection: connection)
     }

--- a/mobile/ios/Houston/Features/Integrations/IntegrationsView.swift
+++ b/mobile/ios/Houston/Features/Integrations/IntegrationsView.swift
@@ -17,7 +17,7 @@ struct IntegrationsView: View {
     content
       .navigationTitle(Strings.Integrations.title)
       .navigationBarTitleDisplayMode(.inline)
-      .background(theme.background)
+      .background(theme.input)
       .onAppear {
         if retention == nil { retention = model.retain() }
         if flow == nil {

--- a/mobile/ios/Houston/Features/MissionControl/AgentFilterBar.swift
+++ b/mobile/ios/Houston/Features/MissionControl/AgentFilterBar.swift
@@ -38,13 +38,13 @@ struct AgentFilterBar: View {
         HoustonAvatar(agentColorHex: colorHex, diameter: 20)
         Text(label)
           .font(Typography.label)
-          .foregroundStyle(selected ? theme.accentFg : theme.foreground)
+          .foregroundStyle(selected ? theme.hoverText : theme.ink)
           .lineLimit(1)
       }
       .padding(.horizontal, Spacing.space10)
       .padding(.vertical, Spacing.space6)
-      .background(selected ? theme.accent : theme.muted, in: Capsule())
-      .overlay(Capsule().strokeBorder(theme.border, lineWidth: selected ? 0 : 1))
+      .background(selected ? theme.hover : theme.chipSubtle, in: Capsule())
+      .overlay(Capsule().strokeBorder(theme.line, lineWidth: selected ? 0 : 1))
     }
     .buttonStyle(.plain)
     .accessibilityAddTraits(selected ? [.isSelected] : [])

--- a/mobile/ios/Houston/Features/MissionControl/ArchivedMissionsView.swift
+++ b/mobile/ios/Houston/Features/MissionControl/ArchivedMissionsView.swift
@@ -35,6 +35,6 @@ struct ArchivedMissionsView: View {
         .scrollContentBackground(.hidden)
       }
     }
-    .background(theme.background)
+    .background(theme.input)
   }
 }

--- a/mobile/ios/Houston/Features/MissionControl/ChatRoute.swift
+++ b/mobile/ios/Houston/Features/MissionControl/ChatRoute.swift
@@ -87,6 +87,6 @@ private struct ChatUnavailableView: View {
     )
     .navigationTitle(route.title)
     .navigationBarTitleDisplayMode(.inline)
-    .background(theme.background)
+    .background(theme.input)
   }
 }

--- a/mobile/ios/Houston/Features/MissionControl/ColumnSegmentedControl.swift
+++ b/mobile/ios/Houston/Features/MissionControl/ColumnSegmentedControl.swift
@@ -15,7 +15,7 @@ struct ColumnSegmentedControl: View {
       }
     }
     .padding(Spacing.space4)
-    .background(theme.muted, in: Capsule())
+    .background(theme.chipSubtle, in: Capsule())
     .accessibilityElement(children: .contain)
     .accessibilityLabel(Strings.MissionControl.statusPagerLabel)
   }
@@ -27,12 +27,12 @@ struct ColumnSegmentedControl: View {
     } label: {
       Text(column.label)
         .font(Typography.label)
-        .foregroundStyle(selected ? theme.foreground : theme.mutedFg)
+        .foregroundStyle(selected ? theme.ink : theme.inkMuted)
         .frame(maxWidth: .infinity)
         .padding(.vertical, Spacing.space8)
         .background {
           if selected {
-            Capsule().fill(theme.background)
+            Capsule().fill(theme.input)
           }
         }
     }

--- a/mobile/ios/Houston/Features/MissionControl/MissionCardView.swift
+++ b/mobile/ios/Houston/Features/MissionControl/MissionCardView.swift
@@ -22,16 +22,16 @@ struct MissionCardView: View {
       VStack(alignment: .leading, spacing: Spacing.space4) {
         Text(card.agentName)
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
           .lineLimit(1)
         Text(card.title)
           .font(Typography.title)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
           .lineLimit(2)
         if !card.descriptionPreview.isEmpty {
           Text(card.descriptionPreview)
             .font(Typography.callout)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
             .lineLimit(2)
         }
         footer
@@ -50,16 +50,16 @@ struct MissionCardView: View {
       ForEach(card.tags, id: \.self) { tag in
         Text(tag)
           .font(Typography.label)
-          .foregroundStyle(theme.secondaryFg)
+          .foregroundStyle(theme.chipText)
           .padding(.horizontal, Spacing.space8)
           .padding(.vertical, Spacing.space2)
-          .background(theme.secondary, in: Capsule())
+          .background(theme.chip, in: Capsule())
       }
       Spacer(minLength: Spacing.space8)
       if let updated = MissionTimestamp.relativeLabel(card.updatedAt) {
         Text(updated)
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
       }
     }
     .padding(.top, Spacing.space4)
@@ -67,9 +67,9 @@ struct MissionCardView: View {
 
   @ViewBuilder private var border: some View {
     if isError {
-      shape.strokeBorder(theme.destructive.opacity(0.6), lineWidth: 1)
+      shape.strokeBorder(theme.danger.opacity(0.6), lineWidth: 1)
     } else if !isRunning {
-      shape.strokeBorder(theme.border, lineWidth: 1)
+      shape.strokeBorder(theme.line, lineWidth: 1)
     }
   }
 }

--- a/mobile/ios/Houston/Features/MissionControl/MissionControlPager.swift
+++ b/mobile/ios/Houston/Features/MissionControl/MissionControlPager.swift
@@ -39,6 +39,6 @@ struct MissionControlPager: View {
     }
     .listStyle(.plain)
     .scrollContentBackground(.hidden)
-    .background(theme.background)
+    .background(theme.input)
   }
 }

--- a/mobile/ios/Houston/Features/MissionControl/MissionControlView.swift
+++ b/mobile/ios/Houston/Features/MissionControl/MissionControlView.swift
@@ -36,7 +36,7 @@ struct MissionControlView: View {
         header
         body(for: overview.agents)
       }
-      .background(theme.background)
+      .background(theme.input)
       .navigationTitle(showingArchived ? Strings.Board.archived : Strings.Board.missionControlTitle)
       .navigationBarTitleDisplayMode(.large)
       .toolbar {
@@ -86,7 +86,7 @@ struct MissionControlView: View {
       } label: {
         Label(Strings.Board.archived, systemImage: showingArchived ? "archivebox.fill" : "archivebox")
       }
-      .tint(showingArchived ? theme.primary : theme.foreground)
+      .tint(showingArchived ? theme.action : theme.ink)
       .accessibilityAddTraits(showingArchived ? [.isSelected] : [])
     }
   }

--- a/mobile/ios/Houston/Features/MissionControl/MissionSearchResultsView.swift
+++ b/mobile/ios/Houston/Features/MissionControl/MissionSearchResultsView.swift
@@ -38,7 +38,7 @@ struct MissionSearchResultsView: View {
         resultsList(matches)
       }
     }
-    .background(theme.background)
+    .background(theme.input)
   }
 
   private func resultsList(_ matches: [MissionMatch]) -> some View {
@@ -60,7 +60,7 @@ struct MissionSearchResultsView: View {
     VStack(alignment: .leading, spacing: Spacing.space4) {
       Text(match.title)
         .font(Typography.bodyMedium)
-        .foregroundStyle(theme.foreground)
+        .foregroundStyle(theme.ink)
         .lineLimit(2)
       if match.matchedIn.showsSnippet, let snippet = match.snippet, !snippet.isEmpty {
         HighlightedText(text: snippet, query: query)

--- a/mobile/ios/Houston/Features/NewMission/NewMissionAgentPicker.swift
+++ b/mobile/ios/Houston/Features/NewMission/NewMissionAgentPicker.swift
@@ -28,10 +28,10 @@ struct NewMissionAgentPicker: View {
             VStack(alignment: .leading, spacing: Spacing.space4) {
               Text(Strings.AgentPicker.title)
                 .font(Typography.title)
-                .foregroundStyle(theme.foreground)
+                .foregroundStyle(theme.ink)
               Text(Strings.AgentPicker.description)
                 .font(Typography.callout)
-                .foregroundStyle(theme.mutedFg)
+                .foregroundStyle(theme.inkMuted)
             }
             .textCase(nil)
             .padding(.bottom, Spacing.space8)
@@ -41,7 +41,7 @@ struct NewMissionAgentPicker: View {
         .scrollContentBackground(.hidden)
       }
     }
-    .background(theme.background)
+    .background(theme.input)
     .navigationTitle(Strings.NewMission.title)
     .navigationBarTitleDisplayMode(.inline)
   }
@@ -52,11 +52,11 @@ struct NewMissionAgentPicker: View {
         HoustonAvatar(agentColorHex: nil, diameter: 32)
         Text(agent.name)
           .font(Typography.bodyMedium)
-          .foregroundStyle(theme.foreground)
+          .foregroundStyle(theme.ink)
         Spacer(minLength: Spacing.space8)
         Image(systemName: "chevron.right")
           .font(Typography.caption)
-          .foregroundStyle(theme.mutedFg)
+          .foregroundStyle(theme.inkMuted)
       }
       .contentShape(Rectangle())
     }

--- a/mobile/ios/Houston/Features/Settings/AccountSection.swift
+++ b/mobile/ios/Houston/Features/Settings/AccountSection.swift
@@ -16,12 +16,12 @@ struct AccountSection: View {
                 VStack(alignment: .leading, spacing: Spacing.space2) {
                     Text(profile?.displayName ?? Strings.Settings.accountFallbackName)
                         .font(Typography.bodyMedium)
-                        .foregroundStyle(theme.foreground)
+                        .foregroundStyle(theme.ink)
                         .lineLimit(1)
                     if let email = profile?.email, !email.isEmpty {
                         Text(email)
                             .font(Typography.caption)
-                            .foregroundStyle(theme.mutedFg)
+                            .foregroundStyle(theme.inkMuted)
                             .lineLimit(1)
                     }
                 }
@@ -30,7 +30,7 @@ struct AccountSection: View {
             Button(role: .destructive, action: onSignOut) {
                 Text(Strings.Settings.signOut)
                     .font(Typography.bodyMedium)
-                    .foregroundStyle(theme.destructive)
+                    .foregroundStyle(theme.danger)
             }
         } header: {
             SettingsSectionHeader(Strings.Settings.accountTitle)
@@ -64,16 +64,16 @@ private struct AccountAvatar: View {
         }
         .frame(width: diameter, height: diameter)
         .clipShape(Circle())
-        .overlay(Circle().strokeBorder(theme.border))
+        .overlay(Circle().strokeBorder(theme.line))
         .accessibilityHidden(true)
     }
 
     private var placeholder: some View {
         ZStack {
-            theme.secondary
+            theme.chip
             Image(systemName: "person.fill")
                 .font(Typography.title)
-                .foregroundStyle(theme.mutedFg)
+                .foregroundStyle(theme.inkMuted)
         }
     }
 }

--- a/mobile/ios/Houston/Features/Settings/AppearanceRow.swift
+++ b/mobile/ios/Houston/Features/Settings/AppearanceRow.swift
@@ -17,7 +17,7 @@ struct AppearanceRow: View {
         HStack(spacing: Spacing.space12) {
             Text(Strings.Settings.appearanceTitle)
                 .font(Typography.bodyMedium)
-                .foregroundStyle(theme.foreground)
+                .foregroundStyle(theme.ink)
             Spacer(minLength: Spacing.space8)
             Picker(
                 Strings.Settings.appearanceTitle,

--- a/mobile/ios/Houston/Features/Settings/SettingsRows.swift
+++ b/mobile/ios/Houston/Features/Settings/SettingsRows.swift
@@ -15,7 +15,7 @@ struct SettingsSectionHeader: View {
     var body: some View {
         Text(title)
             .font(Typography.captionStrong)
-            .foregroundStyle(theme.mutedFg)
+            .foregroundStyle(theme.inkMuted)
             .textCase(.uppercase)
     }
 }

--- a/mobile/ios/Houston/Features/Settings/SettingsView.swift
+++ b/mobile/ios/Houston/Features/Settings/SettingsView.swift
@@ -24,10 +24,10 @@ struct SettingsView: View {
             }
             .listStyle(.insetGrouped)
             .scrollContentBackground(.hidden)
-            .background(theme.background)
+            .background(theme.input)
             .navigationTitle(Strings.Settings.title)
         }
-        .tint(theme.primary)
+        .tint(theme.action)
     }
 
     private var appearanceGroup: some View {


### PR DESCRIPTION
## What

#865 renamed the design-token vocabulary and swept desktop/web, but not the iOS app; the new iOS CI job (#864) caught it on its first main run: `Theme.swift` referenced 30 removed `HoustonColors` members and main went red.

- `Theme.swift` and all 72 consuming Swift files now speak the new vocabulary (`foreground→ink`, `mutedFg→inkMuted`, `primary→action`, `secondary→chip`, `border→line`, `ring→focus`, `destructive→danger`, the `input→lineInput` / `background→input` / `canvasScreen→background` ground chain, sidebar suffixes, `-Fg→-Text`). No compat aliases.
- The two "Working…" text sites that used the old `accent` role move to `inkMuted`, matching the chat title bar treatment (PARITY-CHAT §Title bar), since `hover` is now an opaque light fill (#efefef) and unusable as text.
- `PARITY.md` / `PARITY-CHAT.md` token references trued up.

## Verification

- Full simulator build + **547/547 unit tests pass** on the fix.
- Zero old-name references remain (grep-verified; remaining `.destructive`/`.secondary` etc. hits are SwiftUI API, not tokens).
- This PR's iOS CI job run is the end-to-end proof on the runner toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)