### PR TITLE
feat(reflection): end-of-mission reflection step suggests Skill, Routine, or Learning

### DIFF
--- a/app/src-tauri/src/houston_prompt/base.rs
+++ b/app/src-tauri/src/houston_prompt/base.rs
@@ -54,8 +54,8 @@ Use this loop silently before acting. Do not show this checklist to the user.
    - If blocked, state the next thing needed.
 6. Consider memory.
    - Save a learning only when it is stable, reusable, non-sensitive, and the user explicitly wants it remembered.
-   - If you infer a useful recurring preference or procedure, use the `ask_user` tool to ask "Want me to remember that for next time?" with Yes and No options, then end your turn.
-   - If the user says yes or directly asks you to remember it, save it using the learnings guidance below.
+   - If the user directly asks you to remember something, save it right away using the learnings guidance below.
+   - If you infer a useful stable preference, fact, or recurring procedure while working, do not interrupt the task to ask about it. Offer it in your end-of-task reflection step through the `suggest_reusable` tool (see the Skills guidance), never through `ask_user` or plain text.
 
 Ask for explicit approval before work that will change persistent user data, publish, delete, buy, schedule, run a long task, or rely on an assumption that could materially change the result. Always request that approval through the `ask_user` tool with clear options (for example Yes and No), then end your turn. Actions on connected apps are the exception: Houston shows its own approval card for them after your turn, so do not pre-ask for those.
 

--- a/app/src-tauri/src/houston_prompt/mod.rs
+++ b/app/src-tauri/src/houston_prompt/mod.rs
@@ -111,7 +111,10 @@ mod tests {
     fn memory_guidance_requires_user_opt_in() {
         let prompt = system_prompt_pi();
 
-        assert!(prompt.contains("Want me to remember that for next time?"));
+        // Inferred learnings are offered in the end-of-task reflection step
+        // (the suggest_reusable card), never asked mid-task via ask_user.
+        assert!(prompt.contains("end-of-task reflection step"));
+        assert!(prompt.contains("Reflection step:"));
         assert!(prompt.contains("Save a learning only when"));
         assert!(!prompt.contains("Save ALL"));
         assert!(!prompt.contains("do NOT wait"));

--- a/app/src-tauri/src/houston_prompt/skills_memory.rs
+++ b/app/src-tauri/src/houston_prompt/skills_memory.rs
@@ -12,7 +12,7 @@ Before starting complex work, check whether a relevant Skill already exists.
 
 Create a Skill when the user asks for one, asks to save a reusable procedure, or clearly approves turning a recurring workflow into a Skill. Do not create Skills just because a task had many steps.
 
-When you finish a task that is clearly worth saving as a reusable Skill or scheduled Routine, genuinely reusable multi-step work and not a simple or one-off request, call the `suggest_reusable` tool right before your final message instead of asking about it in plain text or through `ask_user`. Houston shows the user a dismissible card offering to save it. Call it at most once per turn.
+Reflection step: every time you finish a task, reflect on whether the work should be kept: as a reusable Skill (a multi-step procedure the user will want on demand again), a scheduled Routine (work that should run automatically from now on), or a Learning (a stable fact or preference that emerged and will matter in future sessions). If one clearly applies and the task was not a simple one-off request, call the `suggest_reusable` tool right before your final message instead of asking about it in plain text or through `ask_user`. Houston shows the user a dismissible card offering to save it; if they accept, Houston asks you to create it in a follow-up message. Call it at most once per turn, and still finish your final message normally. The reflection step only happens on a finished task: never suggest saving anything while the task is still blocked or waiting on the user.
 
 Use this shape:
 
@@ -54,7 +54,7 @@ Update a Skill when you use it and find a step that is wrong or incomplete.
 Learnings are stable memory for future sessions. Save only facts that are useful later, not one-time task details.
 
 Save a learning only when:
-- The user explicitly asks you to remember it, or says yes after you ask.
+- The user explicitly asks you to remember it, says yes after you ask, or accepts your `suggest_reusable` learning suggestion.
 - It is stable and likely to matter in future sessions.
 - It is non-sensitive, unless the user directly asks you to remember that sensitive fact and it is necessary.
 - It is not already present in existing learnings or instructions.

--- a/app/src/components/use-agent-chat-panel.tsx
+++ b/app/src/components/use-agent-chat-panel.tsx
@@ -1153,8 +1153,8 @@ export function useAgentChatPanel({
   // ── Suggest-reusable offer (suggest_reusable) ─────────────────────────
   // On a clean finish the model may call `suggest_reusable`, arriving as a lone
   // `{kind:"suggest_reusable", ...}` step. The card offers to save the work as a
-  // Skill or Routine. "Save" sends a follow-up message asking the agent to
-  // actually WRITE the Skill/Routine file, so it always runs in `execute` mode
+  // Skill, Routine, or Learning. "Save" sends a follow-up message asking the agent
+  // to actually WRITE the Skill/Routine/Learning, so it always runs in `execute` mode
   // regardless of the composer's pinned mode (planning it is not enough), and it
   // does NOT flip the composer's Mode pill (this is a one-off follow-up, not a
   // change to the ongoing mode). It dismisses the offer locally first so the
@@ -1164,6 +1164,7 @@ export function useAgentChatPanel({
       eyebrow: t("chat:suggestReusable.title"),
       skillTitle: t("chat:suggestReusable.skillTitle"),
       routineTitle: t("chat:suggestReusable.routineTitle"),
+      learningTitle: t("chat:suggestReusable.learningTitle"),
       // The unified card-family decline word, shared with the interaction card.
       notNow: t("chat:interaction.notNow"),
     }),
@@ -1177,7 +1178,13 @@ export function useAgentChatPanel({
       const text =
         step.reusableKind === "skill"
           ? t("chat:suggestReusable.saveSkillMessage", { title: step.title })
-          : t("chat:suggestReusable.saveRoutineMessage", { title: step.title });
+          : step.reusableKind === "routine"
+            ? t("chat:suggestReusable.saveRoutineMessage", {
+                title: step.title,
+              })
+            : t("chat:suggestReusable.saveLearningMessage", {
+                title: step.title,
+              });
       tauriChat
         .send(path, text, selectedSessionKey, {
           providerOverride: effectiveProvider,

--- a/app/src/lib/suggest-reusable.ts
+++ b/app/src/lib/suggest-reusable.ts
@@ -1,7 +1,7 @@
 import type { InteractionStep } from "@houston/protocol";
 
 /** A suggest_reusable step: the model called `suggest_reusable` on a clean
- *  finish to offer saving the just-completed work as a Skill or Routine. It
+ *  finish to offer saving the just-completed work as a Skill, Routine, or Learning. It
  *  reaches the frontend as a lone step in a `PendingInteraction`, exactly like
  *  plan_ready. Extracted from the protocol union so the app narrows to it. */
 export type SuggestReusableStep = Extract<

--- a/app/src/locales/en/chat.json
+++ b/app/src/locales/en/chat.json
@@ -92,8 +92,10 @@
     "title": "Save this for next time",
     "skillTitle": "Save as a Skill",
     "routineTitle": "Save as a Routine",
+    "learningTitle": "Remember this",
     "saveSkillMessage": "Save what I just did as a Skill called \"{{title}}\".",
-    "saveRoutineMessage": "Set this up as a recurring Routine called \"{{title}}\"."
+    "saveRoutineMessage": "Set this up as a recurring Routine called \"{{title}}\".",
+    "saveLearningMessage": "Remember \"{{title}}\" as a learning for next time."
   },
   "errors": {
     "sessionStart": "Failed to start session: {{error}}",

--- a/app/src/locales/es/chat.json
+++ b/app/src/locales/es/chat.json
@@ -92,8 +92,10 @@
     "title": "Guarda esto para la próxima vez",
     "skillTitle": "Guardar como Habilidad",
     "routineTitle": "Guardar como Rutina",
+    "learningTitle": "Recordar esto",
     "saveSkillMessage": "Guarda lo que acabo de hacer como una Habilidad llamada \"{{title}}\".",
-    "saveRoutineMessage": "Configura esto como una Rutina recurrente llamada \"{{title}}\"."
+    "saveRoutineMessage": "Configura esto como una Rutina recurrente llamada \"{{title}}\".",
+    "saveLearningMessage": "Recuerda \"{{title}}\" como un aprendizaje para la próxima vez."
   },
   "errors": {
     "sessionStart": "No se pudo iniciar la sesión: {{error}}",

--- a/app/src/locales/pt/chat.json
+++ b/app/src/locales/pt/chat.json
@@ -92,8 +92,10 @@
     "title": "Salve isto para a próxima vez",
     "skillTitle": "Salvar como Habilidade",
     "routineTitle": "Salvar como Rotina",
+    "learningTitle": "Lembrar disto",
     "saveSkillMessage": "Salve o que acabei de fazer como uma Habilidade chamada \"{{title}}\".",
-    "saveRoutineMessage": "Configure isto como uma Rotina recorrente chamada \"{{title}}\"."
+    "saveRoutineMessage": "Configure isto como uma Rotina recorrente chamada \"{{title}}\".",
+    "saveLearningMessage": "Lembre \"{{title}}\" como um aprendizado para a próxima vez."
   },
   "errors": {
     "sessionStart": "Não foi possível iniciar a sessão: {{error}}",

--- a/app/tests/suggest-reusable.test.ts
+++ b/app/tests/suggest-reusable.test.ts
@@ -44,6 +44,20 @@ describe("resolveSuggestReusableOverride", () => {
     });
   });
 
+  it("renders the card for a learning suggestion (the reflection step's third kind)", () => {
+    const learning: InteractionStep = {
+      kind: "suggest_reusable",
+      id: "r1",
+      reusableKind: "learning",
+      title: "Preferred report format",
+      rationale: "You always want the summary first.",
+    };
+    deepStrictEqual(resolveSuggestReusableOverride([learning], null), {
+      kind: "card",
+      step: learning,
+    });
+  });
+
   it("returns none when the sole step is not a suggest_reusable step", () => {
     deepStrictEqual(resolveSuggestReusableOverride([question], null), {
       kind: "none",

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,19 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v22 - 2026-07-12
+
+`suggest-reusable-card` gains a third variant: `learning`. The agent's
+end-of-mission REFLECTION STEP (the `suggest_reusable` tool, fired only on a
+clean `done` finish, never on `needs_you`) can now offer to keep the
+just-completed work as a reusable Skill, a scheduled Routine, OR a Learning (a
+stable fact/preference saved to `.houston/learnings/learnings.json`). Same
+card, same two rows; the save row's label and icon name the kind (Sparkles /
+CalendarClock / Lightbulb), and accepting sends the same follow-up-message
+flow (an execute turn asking the agent to write the Skill/Routine/Learning).
+Protocol `InteractionStep` kind=suggest_reusable widens `reusableKind` with
+`"learning"` — additive, no anatomy/state change, no new component.
+
 ## v21 - 2026-07-12
 
 Two changes: the interaction stepper gains an ACTION-APPROVAL step, and its

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 21
+version: 22
 
 components:
   - id: agent-avatar
@@ -385,10 +385,10 @@ components:
 
   - id: suggest-reusable-card
     title: Suggest-reusable card
-    purpose: In-chat offer shown when the agent finishes a mission cleanly and calls suggest_reusable; proposes saving the just-completed work as a reusable Skill or a scheduled Routine, floating above the always-mounted composer.
+    purpose: In-chat offer shown when the agent finishes a mission cleanly and, in its end-of-task reflection step, calls suggest_reusable; proposes saving the just-completed work as a reusable Skill, a scheduled Routine, or a Learning to remember, floating above the always-mounted composer.
     anatomy: [eyebrow, proposed-title, rationale, save-row, not-now-row]
     states: [default, disabled]
-    variants: [skill, routine]
+    variants: [skill, routine, learning]
     behavior: >-
       Rendered from a pending interaction carrying a single suggest_reusable
       step (reusableKind, title, rationale) on the terminal done frame. Unlike
@@ -397,12 +397,12 @@ components:
       waiting). Shows the eyebrow, the model-proposed name prominently, and the
       model's one-line rationale, then two full-width rows in the plan-ready
       card's idiom: Save (Sparkles icon for a Skill, CalendarClock for a
-      Routine; label names the kind) sends a follow-up message asking the agent
-      to actually write the Skill/Routine, always as an execute turn regardless
-      of the composer's pinned mode, dismissing the offer locally first; "Not
-      now" dismisses locally. Typing in the composer instead abandons it like
-      any interaction card. Dismissal is per-offer (step id) and per
-      conversation.
+      Routine, Lightbulb for a Learning; label names the kind) sends a
+      follow-up message asking the agent to actually write the
+      Skill/Routine/Learning, always as an execute turn regardless of the
+      composer's pinned mode, dismissing the offer locally first; "Not now"
+      dismisses locally. Typing in the composer instead abandons it like any
+      interaction card. Dismissal is per-offer (step id) and per conversation.
     a11y: eyebrow then title then rationale read in order; two labeled row buttons visible at rest (no hover gate), keyboard-reachable; disabled marks the surface aria-disabled and gates both rows.
     since: 12
 

--- a/knowledge-base/architecture.md
+++ b/knowledge-base/architecture.md
@@ -233,6 +233,23 @@ null-clears the interaction at the next turn's start — unchanged. `suggest_reu
 "Not now" also clears the persisted interaction (no stop marker); `plan_ready`
 "Keep planning" stays local-only.
 
+**Reflection step (suggest_reusable).** The prompt names the agent's
+end-of-mission evaluation the REFLECTION STEP: every time the agent finishes a
+task (a clean `done`, never `needs_you`), it reflects on whether the work should
+be kept and, if so, calls `suggest_reusable` right before its final message with
+`reusableKind: "skill" | "routine" | "learning"` — a reusable procedure, a
+scheduled automation, or a stable fact/preference for
+`.houston/learnings/learnings.json`. The step arrives as a LONE
+`suggest_reusable` interaction step on the `done` frame and renders
+`ChatSuggestReusableCard` (Sparkles / CalendarClock / Lightbulb icon per kind);
+accepting sends a follow-up user message (always an `execute` turn) asking the
+agent to actually write the Skill/Routine/Learning, "Not now" dismisses and
+clears the persisted interaction. Inferred learnings route ONLY through this
+card — the old mid-task `ask_user` "Want me to remember that?" flow is gone;
+a direct user "remember this" still saves immediately. Concept name lives in
+prompts/docs only; the wire kind stays `suggest_reusable` (persisted in user
+data). Inventory: `suggest-reusable-card` v22.
+
 The old `#houston_toolkit=` markdown-link connect hack is GONE from the prompt and
 tool guidance; the app's legacy link-card renderer survives only to render old
 transcripts. Client-side settle detail: `knowledge-base/client-architecture.md`.

--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -178,7 +178,8 @@ Behavior is **never** written in surface code. Change it in the SDK, then bind.
 > *clean* turn splits on whether it ended on an interaction: nothing outstanding →
 > the terminal `done`; ended on `ask_user`/`request_connection` → `needs_you`
 > carrying the `pendingInteraction` VM field. ONE exception: a lone
-> `suggest_reusable` step (save-as-Skill/Routine offer) settles `done`, not
+> `suggest_reusable` step (the reflection step's save-as-Skill/Routine/Learning
+> offer) settles `done`, not
 > `needs_you` — nothing is waiting on the user. A user Stop (or dismissing an
 > interaction card, which is a user interruption) now persists a durable
 > `stopped: true` marker on the assistant `ChatMessage`, so settle-FROM-HISTORY

--- a/packages/host/src/houston-prompt.test.ts
+++ b/packages/host/src/houston-prompt.test.ts
@@ -38,9 +38,12 @@ test("skill guidance uses the current SKILL.md layout and omits legacy fields", 
   expect(p).not.toContain("prompt_template");
 });
 
-test("memory guidance requires explicit opt-in", () => {
+test("memory guidance requires explicit opt-in via the reflection step", () => {
   const p = houstonSystemPrompt();
-  expect(p).toContain("Want me to remember that for next time?");
+  // Inferred learnings are offered in the end-of-task reflection step (the
+  // suggest_reusable card), never asked mid-task via ask_user or plain text.
+  expect(p).toContain("end-of-task reflection step");
+  expect(p).toContain("Reflection step:");
   expect(p).toContain("Save a learning only when");
   expect(p).toContain(".houston/learnings/learnings.json");
 });

--- a/packages/host/src/houston-prompt.ts
+++ b/packages/host/src/houston-prompt.ts
@@ -67,8 +67,8 @@ Use this loop silently before acting. Do not show this checklist to the user.
    - If blocked, state the next thing needed.
 6. Consider memory.
    - Save a learning only when it is stable, reusable, non-sensitive, and the user explicitly wants it remembered.
-   - If you infer a useful recurring preference or procedure, use the \`ask_user\` tool to ask "Want me to remember that for next time?" with Yes and No options, then end your turn.
-   - If the user says yes or directly asks you to remember it, save it using the learnings guidance below.
+   - If the user directly asks you to remember something, save it right away using the learnings guidance below.
+   - If you infer a useful stable preference, fact, or recurring procedure while working, do not interrupt the task to ask about it. Offer it in your end-of-task reflection step through the \`suggest_reusable\` tool (see the Skills guidance), never through \`ask_user\` or plain text.
 
 Ask for explicit approval before work that will change persistent user data, publish, delete, buy, schedule, run a long task, or rely on an assumption that could materially change the result. Always request that approval through the \`ask_user\` tool with clear options (for example Yes and No), then end your turn. Actions on connected apps are the exception: Houston shows its own approval card for them after your turn, so do not pre-ask for those.
 
@@ -105,7 +105,7 @@ Before starting complex work, check whether a relevant Skill already exists.
 
 Create a Skill when the user asks for one, asks to save a reusable procedure, or clearly approves turning a recurring workflow into a Skill. Do not create Skills just because a task had many steps.
 
-When you finish a task that is clearly worth saving as a reusable Skill or scheduled Routine, genuinely reusable multi-step work and not a simple or one-off request, call the \`suggest_reusable\` tool right before your final message instead of asking about it in plain text or through \`ask_user\`. Houston shows the user a dismissible card offering to save it. Call it at most once per turn.
+Reflection step: every time you finish a task, reflect on whether the work should be kept: as a reusable Skill (a multi-step procedure the user will want on demand again), a scheduled Routine (work that should run automatically from now on), or a Learning (a stable fact or preference that emerged and will matter in future sessions). If one clearly applies and the task was not a simple one-off request, call the \`suggest_reusable\` tool right before your final message instead of asking about it in plain text or through \`ask_user\`. Houston shows the user a dismissible card offering to save it; if they accept, Houston asks you to create it in a follow-up message. Call it at most once per turn, and still finish your final message normally. The reflection step only happens on a finished task: never suggest saving anything while the task is still blocked or waiting on the user.
 
 Use this shape:
 
@@ -144,7 +144,7 @@ Update a Skill when you use it and find a step that is wrong or incomplete.
 Learnings are stable memory for future sessions. Save only facts that are useful later, not one-time task details.
 
 Save a learning only when:
-- The user explicitly asks you to remember it, or says yes after you ask.
+- The user explicitly asks you to remember it, says yes after you ask, or accepts your \`suggest_reusable\` learning suggestion.
 - It is stable and likely to matter in future sessions.
 - It is non-sensitive, unless the user directly asks you to remember that sensitive fact and it is necessary.
 - It is not already present in existing learnings or instructions.

--- a/packages/protocol/src/domain/interaction.test.ts
+++ b/packages/protocol/src/domain/interaction.test.ts
@@ -47,6 +47,20 @@ test("isPendingInteraction accepts the step-sequence shape and rejects legacy sh
       ],
     }),
   ).toBe(true);
+  // A learning suggestion (the reflection step's third kind) is valid.
+  expect(
+    isPendingInteraction({
+      steps: [
+        {
+          kind: "suggest_reusable",
+          id: "r1",
+          reusableKind: "learning",
+          title: "Preferred report format",
+          rationale: "You always want the summary first.",
+        },
+      ],
+    }),
+  ).toBe(true);
   // An invalid reusableKind is invalid.
   expect(
     isPendingInteraction({

--- a/packages/protocol/src/domain/interaction.ts
+++ b/packages/protocol/src/domain/interaction.ts
@@ -15,7 +15,7 @@
 //
 // `suggest_reusable` is the ONE exception to "present → needs_you": the model
 // calls it on a clean finish to suggest saving the just-completed work as a
-// Skill or Routine, so the mission genuinely IS done. `turn-settle.ts` treats
+// Skill, a Routine, or a Learning, so the mission genuinely IS done. `turn-settle.ts` treats
 // a lone `suggest_reusable` step as `done`, not `needs_you` — see that file's
 // `finishOk`. It arrives on the same `done` frame and renders a card the same
 // way; only the board-status mapping differs.
@@ -55,7 +55,7 @@ export type InteractionStep =
   | {
       kind: "suggest_reusable";
       id: string;
-      reusableKind: "skill" | "routine";
+      reusableKind: "skill" | "routine" | "learning";
       title: string;
       rationale: string;
     }
@@ -98,7 +98,9 @@ export const isInteractionStep = (v: unknown): v is InteractionStep => {
   if (v.kind === "plan_ready") return typeof v.summary === "string";
   if (v.kind === "suggest_reusable")
     return (
-      (v.reusableKind === "skill" || v.reusableKind === "routine") &&
+      (v.reusableKind === "skill" ||
+        v.reusableKind === "routine" ||
+        v.reusableKind === "learning") &&
       typeof v.title === "string" &&
       typeof v.rationale === "string"
     );

--- a/packages/runtime/src/session/interaction.ts
+++ b/packages/runtime/src/session/interaction.ts
@@ -70,8 +70,8 @@ export interface InteractionHolder {
    *  only). When set it OWNS the interaction exclusively — see {@link pending}. */
   readonly planReady: PlanReadyStep | undefined;
   /** The single suggest-reusable step (id `r1`), once the model called
-   *  `suggest_reusable` on a clean finish to offer saving the work as a Skill or
-   *  Routine. CRITICALLY DIFFERENT FROM {@link planReady}: it does NOT own the
+   *  `suggest_reusable` on a clean finish to offer saving the work as a Skill,
+   *  Routine, or Learning. CRITICALLY DIFFERENT FROM {@link planReady}: it does NOT own the
    *  interaction exclusively. It is a FALLBACK ONLY — used solely when there are
    *  no other steps at all this turn. Questions/signin/connects/planReady all
    *  take priority, because any of those means the mission genuinely is not done
@@ -232,14 +232,14 @@ export function recordPlanReady(input: { summary: string }): void {
 
 /**
  * Record the single suggest-reusable step for this turn (the model called
- * `suggest_reusable` on a clean finish to offer saving the work as a Skill or
- * Routine). There is at most one such step (id `r1`); it is FALLBACK-ONLY —
+ * `suggest_reusable` on a clean finish to offer saving the work as a Skill,
+ * Routine, or Learning). There is at most one such step (id `r1`); it is FALLBACK-ONLY —
  * surfaced only when nothing else was queued this turn (see
  * {@link InteractionHolder.pending}). The title and rationale are trimmed. A
  * no-op outside a turn.
  */
 export function recordSuggestReusable(input: {
-  reusableKind: "skill" | "routine";
+  reusableKind: "skill" | "routine" | "learning";
   title: string;
   rationale: string;
 }): void {

--- a/packages/runtime/src/session/tools/suggest-reusable.test.ts
+++ b/packages/runtime/src/session/tools/suggest-reusable.test.ts
@@ -69,6 +69,21 @@ test("carries the routine kind through unchanged", async () => {
   });
 });
 
+test("carries the learning kind through unchanged", async () => {
+  const holder = newInteractionHolder();
+  await runWithInteractionCapture(holder, () =>
+    run({
+      reusableKind: "learning",
+      title: "Preferred report format",
+      rationale: "You always want the summary first.",
+    }),
+  );
+  expect(holder.pending?.steps[0]).toMatchObject({
+    kind: "suggest_reusable",
+    reusableKind: "learning",
+  });
+});
+
 test("trims the title and rationale before recording", async () => {
   const holder = newInteractionHolder();
   await runWithInteractionCapture(holder, () =>

--- a/packages/runtime/src/session/tools/suggest-reusable.ts
+++ b/packages/runtime/src/session/tools/suggest-reusable.ts
@@ -3,14 +3,15 @@ import { type Static, Type } from "typebox";
 import { recordSuggestReusable } from "../interaction";
 
 /**
- * The reusable-suggestion tool — available in execute AND auto. When the model
- * has FINISHED a task whose work is clearly worth keeping (genuinely reusable,
- * multi-step work), it calls `suggest_reusable` right before its final message
+ * The reusable-suggestion tool — the model's end-of-task REFLECTION STEP,
+ * available in execute AND auto. When the model has FINISHED a task whose work
+ * is clearly worth keeping (genuinely reusable, multi-step work, or a stable
+ * fact worth remembering), it calls `suggest_reusable` right before its final message
  * INSTEAD OF asking the user about it in plain text or via `ask_user`. Executing
  * it records the single suggest-reusable step of this turn's interaction sequence
  * (carried on the terminal `done` frame + the persisted assistant message), and
- * Houston shows the user a dismissible card offering to save the work as a Skill
- * or a scheduled Routine.
+ * Houston shows the user a dismissible card offering to save the work as a Skill,
+ * a scheduled Routine, or a Learning the agent remembers for future sessions.
  *
  * CRITICALLY, this is NOT a turn-ending block like `plan_ready`: the task is
  * genuinely DONE, so the model wraps up its final message to the user as usual.
@@ -24,13 +25,16 @@ import { recordSuggestReusable } from "../interaction";
  */
 
 const SuggestReusableParams = Type.Object({
-  reusableKind: Type.Union([Type.Literal("skill"), Type.Literal("routine")], {
-    description:
-      'What kind of reusable thing this work should be saved as. Use "skill" for a reusable procedure the user runs on demand, or "routine" for work that should run automatically on a schedule.',
-  }),
+  reusableKind: Type.Union(
+    [Type.Literal("skill"), Type.Literal("routine"), Type.Literal("learning")],
+    {
+      description:
+        'What kind of reusable thing this work should be saved as. Use "skill" for a reusable procedure the user runs on demand, "routine" for work that should run automatically on a schedule, or "learning" for a stable fact or preference that emerged from this task and is worth remembering for future sessions.',
+    },
+  ),
   title: Type.String({
     description:
-      'A short, plain-language name for the suggested Skill or Routine, in the user\'s language. A few words at most (e.g. "Weekly sales summary").',
+      'A short, plain-language name for the suggested Skill, Routine, or Learning, in the user\'s language. A few words at most (e.g. "Weekly sales summary").',
   }),
   rationale: Type.String({
     description:
@@ -49,8 +53,9 @@ export function makeSuggestReusableTool() {
     name: "suggest_reusable",
     label: "Suggest saving as reusable",
     description:
-      "Suggest saving the just-completed work as a reusable Skill or a scheduled Routine. Call this when you finish a task that is clearly worth reusing (genuinely reusable, multi-step work, not a simple or one-off request), right before your final message, INSTEAD OF asking about it in plain text or via ask_user. Houston shows the user a dismissible card offering to save it. Call it at most once per turn, and still finish your final message normally. This does not end your turn.",
-    promptSnippet: "Suggest saving the completed work as a Skill or Routine",
+      "Suggest saving the just-completed work as a reusable Skill, a scheduled Routine, or a Learning to remember. Call this when you finish a task and the work is clearly worth keeping (a genuinely reusable multi-step procedure, work that should recur on a schedule, or a stable fact worth remembering — not a simple or one-off request), right before your final message, INSTEAD OF asking about it in plain text or via ask_user. Houston shows the user a dismissible card offering to save it. Call it at most once per turn, and still finish your final message normally. This does not end your turn.",
+    promptSnippet:
+      "Suggest saving the completed work as a Skill, Routine, or Learning",
     parameters: SuggestReusableParams,
     executionMode: "sequential",
     async execute(_id: string, params: SuggestReusableParams) {

--- a/ui/chat/src/chat-suggest-reusable-card-model.ts
+++ b/ui/chat/src/chat-suggest-reusable-card-model.ts
@@ -18,6 +18,8 @@ export interface ChatSuggestReusableLabels {
   skillTitle: string;
   /** Save action label shown when `reusableKind === "routine"`. */
   routineTitle: string;
+  /** Save action label shown when `reusableKind === "learning"`. */
+  learningTitle: string;
   /** Dismiss action label. */
   notNow: string;
 }
@@ -28,15 +30,18 @@ export const DEFAULT_SUGGEST_REUSABLE_LABELS: ChatSuggestReusableLabels = {
   eyebrow: "Save this for next time",
   skillTitle: "Save as a Skill",
   routineTitle: "Save as a Routine",
+  learningTitle: "Remember this",
   notNow: "Not now",
 };
 
-/** The save row's label: the model's just-completed work can be saved either as
- *  a reusable Skill or a scheduled Routine, and the label names which. Pure so
- *  the mapping is unit-tested without a DOM. */
+/** The save row's label: the model's just-completed work can be saved as a
+ *  reusable Skill, a scheduled Routine, or a Learning, and the label names
+ *  which. Pure so the mapping is unit-tested without a DOM. */
 export function resolveSuggestReusableSaveLabel(
-  reusableKind: "skill" | "routine",
+  reusableKind: "skill" | "routine" | "learning",
   labels: ChatSuggestReusableLabels,
 ): string {
-  return reusableKind === "skill" ? labels.skillTitle : labels.routineTitle;
+  if (reusableKind === "skill") return labels.skillTitle;
+  if (reusableKind === "routine") return labels.routineTitle;
+  return labels.learningTitle;
 }

--- a/ui/chat/src/chat-suggest-reusable-card.tsx
+++ b/ui/chat/src/chat-suggest-reusable-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { cn } from "@houston-ai/core";
-import { CalendarClock, Sparkles, X } from "lucide-react";
+import { CalendarClock, Lightbulb, Sparkles, X } from "lucide-react";
 import {
   type ChatSuggestReusableLabels,
   resolveSuggestReusableSaveLabel,
@@ -11,15 +11,15 @@ export type { ChatSuggestReusableLabels } from "./chat-suggest-reusable-card-mod
 export { DEFAULT_SUGGEST_REUSABLE_LABELS } from "./chat-suggest-reusable-card-model";
 
 export interface ChatSuggestReusableCardProps {
-  /** Whether the work is being offered as a reusable Skill or a scheduled Routine. */
-  reusableKind: "skill" | "routine";
-  /** The model's proposed name for the Skill/Routine, shown as the prominent head. */
+  /** Whether the work is offered as a reusable Skill, a scheduled Routine, or a Learning. */
+  reusableKind: "skill" | "routine" | "learning";
+  /** The model's proposed name for the Skill/Routine/Learning, shown as the prominent head. */
   title: string;
   /** The model's one-line rationale for saving it (model-generated, passed through). */
   rationale: string;
   /** Gates both actions uniformly (another turn is active). */
   disabled?: boolean;
-  /** Send the follow-up message that asks the agent to write the Skill/Routine. */
+  /** Send the follow-up message that asks the agent to write the Skill/Routine/Learning. */
   onSave: () => void;
   /** Dismiss the offer locally and return the composer. */
   onDismiss: () => void;
@@ -29,7 +29,7 @@ export interface ChatSuggestReusableCardProps {
 /**
  * The in-chat surface shown when the agent finishes cleanly and calls
  * `suggest_reusable`: an optional, dismissible offer to save the just-completed
- * work as a reusable Skill or a scheduled Routine. It REPLACES the composer, so
+ * work as a reusable Skill, a scheduled Routine, or a Learning. It REPLACES the composer, so
  * it borrows the plan-ready card's vocabulary (rounded-[28px] grey
  * `bg-chip` surface) with the proposed title raised as the prominent head
  * and the rationale below it. The two actions (Save / Not now) render as
@@ -48,8 +48,14 @@ export function ChatSuggestReusableCard({
 }: ChatSuggestReusableCardProps) {
   const saveLabel = resolveSuggestReusableSaveLabel(reusableKind, labels);
   // A Skill is reusable know-how (Sparkles); a Routine runs on a schedule
-  // (CalendarClock). Icons are internal so the labels contract stays icon-free.
-  const SaveIcon = reusableKind === "skill" ? Sparkles : CalendarClock;
+  // (CalendarClock); a Learning is remembered insight (Lightbulb). Icons are
+  // internal so the labels contract stays icon-free.
+  const SaveIcon =
+    reusableKind === "skill"
+      ? Sparkles
+      : reusableKind === "routine"
+        ? CalendarClock
+        : Lightbulb;
 
   return (
     <div

--- a/ui/chat/tests/chat-suggest-reusable-card.test.ts
+++ b/ui/chat/tests/chat-suggest-reusable-card.test.ts
@@ -10,6 +10,7 @@ const LABELS: ChatSuggestReusableLabels = {
   eyebrow: "Save this for next time",
   skillTitle: "Save as a Skill",
   routineTitle: "Save as a Routine",
+  learningTitle: "Remember this",
   notNow: "Not now",
 };
 
@@ -27,6 +28,13 @@ describe("resolveSuggestReusableSaveLabel", () => {
       "Save as a Routine",
     );
   });
+
+  it("uses the learning label for a learning suggestion", () => {
+    assert.equal(
+      resolveSuggestReusableSaveLabel("learning", LABELS),
+      "Remember this",
+    );
+  });
 });
 
 describe("DEFAULT_SUGGEST_REUSABLE_LABELS", () => {
@@ -35,6 +43,10 @@ describe("DEFAULT_SUGGEST_REUSABLE_LABELS", () => {
     assert.equal(
       DEFAULT_SUGGEST_REUSABLE_LABELS.routineTitle,
       "Save as a Routine",
+    );
+    assert.equal(
+      DEFAULT_SUGGEST_REUSABLE_LABELS.learningTitle,
+      "Remember this",
     );
     assert.equal(DEFAULT_SUGGEST_REUSABLE_LABELS.notNow, "Not now");
     for (const value of Object.values(DEFAULT_SUGGEST_REUSABLE_LABELS)) {

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -589,14 +589,14 @@ export type InteractionStep =
    *  choosing a mode (start working / Autopilot) or dismisses to keep planning. */
   | { kind: "plan_ready"; id: string; summary: string }
   /** The model finished cleanly and offers to save the just-completed work as a
-   *  reusable Skill or a scheduled Routine. Optional and dismissible: unlike the
-   *  other kinds, a lone `suggest_reusable` step does NOT flip the board to
-   *  `needs_you` (the mission genuinely finished). Mirrors
+   *  reusable Skill, a scheduled Routine, or a Learning to remember. Optional and
+   *  dismissible: unlike the other kinds, a lone `suggest_reusable` step does NOT
+   *  flip the board to `needs_you` (the mission genuinely finished). Mirrors
    *  `packages/protocol/src/domain/interaction.ts`. */
   | {
       kind: "suggest_reusable";
       id: string;
-      reusableKind: "skill" | "routine";
+      reusableKind: "skill" | "routine" | "learning";
       title: string;
       rationale: string;
     }


### PR DESCRIPTION
## What

When an agent marks a mission **done**, it now runs a named **reflection step**: evaluate whether the just-finished work should be kept as a reusable **Skill**, a scheduled **Routine**, or a **Learning**, and offer it to the user through the existing `suggest_reusable` card (composer-replacing, dismissible, Save / Not now).

The trigger is unchanged and deliberate: the offer rides only a clean terminal `done` frame — it never fires on `needs_you`, Autopilot, or plan mode, so it happens exactly when the agent considers the task finished.

## Changes

- **protocol + runtime**: `reusableKind` widens with `"learning"` (additive — persisted cards from older builds keep rendering; the wire kind stays `suggest_reusable`).
- **prompts** (host TS + Tauri Rust mirror, in sync): the end-of-task evaluation is named the *reflection step*. Inferred learnings now route ONLY through the card; the mid-task `ask_user` "Want me to remember that for next time?" flow is removed (no more interrupting a task to ask about memory). A direct user "remember this" still saves immediately.
- **ui/chat**: learning variant of `ChatSuggestReusableCard` — Lightbulb icon, "Remember this" label.
- **app**: accept flow sends the learning follow-up message (always an execute turn); en/es/pt locale keys.
- **inventory v22**: `suggest-reusable-card` gains the `learning` variant (+ CHANGELOG).
- **KB**: reflection step documented in `architecture.md` + `client-architecture.md`.

## Verification

- vitest: protocol 4, runtime 619, host 916, sdk 364 — all pass
- node:test: ui/chat 157, app 1469 — all pass
- `cargo test houston_prompt`: 9 pass
- `pnpm typecheck` (all packages), `tsgo --noEmit` (app), `check-locales`, `check:parity` (v22 consistent), `check:boundaries`, Biome — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)