### PR TITLE
fix(runtime): classify context-overflow provider errors + learn a custom endpoint's real window

### DIFF
--- a/app/src/components/shell/provider-error-card.tsx
+++ b/app/src/components/shell/provider-error-card.tsx
@@ -22,6 +22,7 @@
 import type { ProviderError } from "@houston-ai/chat";
 import { UnauthenticatedCard } from "./provider-error-cards/auth";
 import {
+  ContextOverflowCard,
   ModelUnavailableCard,
   QuotaExhaustedCard,
 } from "./provider-error-cards/quota";
@@ -71,6 +72,10 @@ export function ProviderErrorCard({
       return <UsageLimitPausedCard error={error} />;
     case "quota_exhausted":
       return <QuotaExhaustedCard error={error} onSwitchModel={onSwitchModel} />;
+    case "context_overflow":
+      return (
+        <ContextOverflowCard error={error} onSwitchModel={onSwitchModel} />
+      );
     case "model_unavailable":
       return (
         <ModelUnavailableCard

--- a/app/src/components/shell/provider-error-cards/quota.tsx
+++ b/app/src/components/shell/provider-error-cards/quota.tsx
@@ -3,9 +3,11 @@
  * QuotaExhausted names the reset time when the provider gives one and offers a
  * "switch provider" CTA; ModelUnavailable offers a one-click "switch to the
  * suggested fallback" (applied directly on the same provider, no picker) plus a
- * "pick another model" CTA that pops the model picker. All render on the
- * unified `RowCard` (HOU-467), with their CTAs mounted as `RowCardButton`s in
- * the card's action slot.
+ * "pick another model" CTA that pops the model picker; ContextOverflow (the
+ * chat outgrew the model's window) offers the picker so the user can move the
+ * conversation onto a larger-window model. All render on the unified `RowCard`
+ * (HOU-467), with their CTAs mounted as `RowCardButton`s in the card's action
+ * slot.
  */
 
 import type { ProviderError } from "@houston-ai/chat";
@@ -46,6 +48,36 @@ export function QuotaExhaustedCard({
             <RowCardButton
               variant="outline"
               label={t("providerError.quotaExhausted.switchProvider")}
+              onClick={onSwitchModel}
+            />
+          )
+        }
+      />
+    </div>
+  );
+}
+
+export function ContextOverflowCard({
+  error,
+  onSwitchModel,
+}: BaseProps & {
+  error: Extract<ProviderError, { kind: "context_overflow" }>;
+}) {
+  const { t } = useTranslation("shell");
+  // Name the model when the wire carried it, else fall back to the provider's
+  // display name — the sentence must always name WHAT ran out of room.
+  const model = error.model ?? providerLabel(error.provider);
+  return (
+    <div className="w-full px-1 py-2">
+      <RowCard
+        media={<AlertTriangleIcon className="size-5" />}
+        title={t("providerError.contextOverflow.title")}
+        description={t("providerError.contextOverflow.body", { model })}
+        action={
+          onSwitchModel && (
+            <RowCardButton
+              variant="outline"
+              label={t("providerError.contextOverflow.switchModel")}
               onClick={onSwitchModel}
             />
           )

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -317,6 +317,11 @@
       "upgrade": "Upgrade plan",
       "switchProvider": "Switch provider"
     },
+    "contextOverflow": {
+      "title": "This chat got too long for its model",
+      "body": "{{model}} can no longer read this whole conversation. Switch this chat to a model with more memory, or start a new mission for the next step.",
+      "switchModel": "Switch model"
+    },
     "modelUnavailable": {
       "title": "Model not available",
       "body": "{{model}} is not available on your {{provider}} account.",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -317,6 +317,11 @@
       "upgrade": "Mejorar plan",
       "switchProvider": "Cambiar de proveedor"
     },
+    "contextOverflow": {
+      "title": "Esta conversación es muy larga para su modelo",
+      "body": "{{model}} ya no puede leer toda esta conversación. Cambia esta conversación a un modelo con más memoria o comienza una nueva misión para el siguiente paso.",
+      "switchModel": "Cambiar modelo"
+    },
     "modelUnavailable": {
       "title": "Modelo no disponible",
       "body": "{{model}} no está disponible en tu cuenta de {{provider}}.",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -302,6 +302,11 @@
       "useApiKey": "Usar chave de API no lugar",
       "bodyWithReset": "Seu plano do {{provider}} chegou ao limite. Ele reinicia {{time}}, ou faça upgrade para continuar."
     },
+    "contextOverflow": {
+      "title": "Esta conversa ficou longa demais para o modelo",
+      "body": "{{model}} não consegue mais ler esta conversa inteira. Mude esta conversa para um modelo com mais memória ou comece uma nova missão para o próximo passo.",
+      "switchModel": "Trocar modelo"
+    },
     "modelUnavailable": {
       "title": "Modelo não disponível",
       "body": "O modelo {{model}} não está disponível na sua conta {{provider}}.",

--- a/design/inventory/CHANGELOG.md
+++ b/design/inventory/CHANGELOG.md
@@ -3,6 +3,20 @@
 Every `version` bump in `inventory.yaml` needs a matching entry here (enforced by
 `pnpm check:parity`). Newest first. Use `## vN` headings.
 
+## v23 - 2026-07-12
+
+`provider-error-card` gains a `context-overflow` state. The engine taxonomy
+(protocol `ProviderError`, mirrored in `ui/chat`) adds `context_overflow`: the
+provider rejected the request because the conversation no longer fits the
+model's context window (llama.cpp/Jan `exceed_context_size_error`, OpenAI
+`context_length_exceeded`, Anthropic "prompt is too long"). Previously this
+fell through to the generic `unknown` card. The card names the model that ran
+out of room and offers the model picker as its CTA (a larger-window model, or
+the user starts a fresh mission). Wire fields carry the provider's own numbers
+(`context_window_tokens`, `prompt_tokens`); the runtime also uses the reported
+window to correct an over-assumed custom-endpoint window so autocompact fires
+at the real boundary on later turns.
+
 ## v22 - 2026-07-12
 
 `suggest-reusable-card` gains a third variant: `learning`. The agent's

--- a/design/inventory/inventory.yaml
+++ b/design/inventory/inventory.yaml
@@ -37,7 +37,7 @@
 #   a11y     roles / labels / focus expectations the surface must honor
 #   since    inventory version this component first appeared in
 
-version: 22
+version: 23
 
 components:
   - id: agent-avatar
@@ -129,7 +129,7 @@ components:
     title: Provider error card
     purpose: Actionable card for a provider failure in the feed (auth, quota, rate-limit).
     anatomy: [icon-bubble, title, reason, primary-action, secondary-action]
-    states: [unauthenticated, quota-exhausted, rate-limited, model-unavailable, transient]
+    states: [unauthenticated, quota-exhausted, rate-limited, model-unavailable, context-overflow, transient]
     variants: [single-action-row-card, multi-action-error-card]
     behavior: >-
       provider_error feed items carry a typed ProviderError (cause/scope). The

--- a/packages/protocol/src/provider-error.ts
+++ b/packages/protocol/src/provider-error.ts
@@ -111,6 +111,26 @@ export type ProviderError =
       message: string;
     }
   | {
+      /**
+       * The conversation no longer fits the model's context window — the
+       * provider rejected the request outright (llama.cpp/Jan's
+       * `exceed_context_size_error`, OpenAI's `context_length_exceeded`,
+       * Anthropic's "prompt is too long"). Distinct from `model_unavailable`
+       * (the model itself is fine) and from rate/quota (nothing to wait out):
+       * the recovery is a larger-window model or a fresh conversation. The
+       * token fields carry the provider's own numbers when it named them —
+       * `context_window_tokens` is the model's REAL window, which the runtime
+       * also uses to correct an over-assumed custom-endpoint window
+       * (`learnCustomContextWindow`).
+       */
+      kind: "context_overflow";
+      provider: string;
+      model: string | null;
+      context_window_tokens: number | null;
+      prompt_tokens: number | null;
+      message: string;
+    }
+  | {
       kind: "provider_internal";
       provider: string;
       http_status: number | null;

--- a/packages/runtime/src/ai/openai-compatible.test.ts
+++ b/packages/runtime/src/ai/openai-compatible.test.ts
@@ -1,0 +1,56 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+
+// config reads HOUSTON_DATA_DIR at import time, and vitest gives each test
+// file its own module registry — so point the data dir at a tmpdir BEFORE the
+// dynamic import to keep the endpoint writes out of the real ~/.houston-ts.
+process.env.HOUSTON_DATA_DIR = mkdtempSync(
+  join(tmpdir(), "houston-oac-learn-"),
+);
+const {
+  buildActiveCustomModel,
+  clearCustomEndpointConfig,
+  learnCustomContextWindow,
+  setCustomEndpointConfig,
+} = await import("./openai-compatible");
+
+const endpointFile = join(process.env.HOUSTON_DATA_DIR, "custom-endpoint.json");
+const storedWindow = () =>
+  JSON.parse(readFileSync(endpointFile, "utf8")).contextWindow;
+
+test("learnCustomContextWindow persists a provider-reported window smaller than the assumed default", () => {
+  // The production incident: a Jan endpoint with no explicit window runs on the
+  // assumed default (32768), but the server's real n_ctx is 8192 — so
+  // autocompact never fired and every turn past 8192 tokens failed. The
+  // overflow rejection names the truth; learning it must make the NEXT
+  // resolveModel (and so autocompact's denominator) use it.
+  setCustomEndpointConfig({
+    baseUrl: "https://tunnel.example.com/v1",
+    model: "Jan-v3.5-4B-Q4_K_XL",
+  });
+  expect(learnCustomContextWindow(8192)).toBe(true);
+  expect(storedWindow()).toBe(8192);
+  expect(buildActiveCustomModel().contextWindow).toBe(8192);
+});
+
+test("learnCustomContextWindow only ever shrinks — a larger report never raises the stored window", () => {
+  // An overflow proves the window is AT MOST the reported value; nothing can
+  // prove a larger one, and a user-set value must never be silently raised.
+  expect(learnCustomContextWindow(32768)).toBe(false);
+  expect(storedWindow()).toBe(8192);
+});
+
+test("learnCustomContextWindow rejects nonsense values", () => {
+  expect(learnCustomContextWindow(0)).toBe(false);
+  expect(learnCustomContextWindow(-8192)).toBe(false);
+  expect(learnCustomContextWindow(4096.5)).toBe(false);
+  expect(storedWindow()).toBe(8192);
+});
+
+test("learnCustomContextWindow is a no-op with no endpoint configured", () => {
+  clearCustomEndpointConfig();
+  expect(learnCustomContextWindow(8192)).toBe(false);
+  expect(JSON.parse(readFileSync(endpointFile, "utf8"))).toEqual({});
+});

--- a/packages/runtime/src/ai/openai-compatible.ts
+++ b/packages/runtime/src/ai/openai-compatible.ts
@@ -198,3 +198,30 @@ export function setCustomEndpointConfig(input: CustomEndpointInput): void {
 export function clearCustomEndpointConfig(): void {
   save({});
 }
+
+/**
+ * Learn the endpoint's REAL context window from a provider context-overflow
+ * rejection (llama.cpp names its `n_ctx`). Local servers don't advertise a
+ * window pi can read, so an unset endpoint runs on the assumed default
+ * (`config.openaiCompatibleContextWindow`) — when that assumption is LARGER
+ * than the truth, autocompact never fires and every turn past the real window
+ * fails. Persisting the reported window makes the next turn's autocompact
+ * divide by the truth, so the conversation compacts instead of dying.
+ *
+ * Only ever sets or SHRINKS the stored window: the overflow proves the real
+ * window is at most `windowTokens`, but a report can't prove a LARGER window
+ * (and must never silently raise a value the user set deliberately). Returns
+ * whether anything was written.
+ */
+export function learnCustomContextWindow(windowTokens: number): boolean {
+  if (!Number.isInteger(windowTokens) || windowTokens <= 0) return false;
+  const e = load();
+  if (!e.baseUrl || !e.model) return false;
+  const stored = e.contextWindow ?? config.openaiCompatibleContextWindow;
+  if (stored <= windowTokens) return false;
+  save({ ...e, contextWindow: windowTokens });
+  console.log(
+    `[custom-endpoint] learned context window ${windowTokens} for ${e.model} (was assuming ${stored})`,
+  );
+  return true;
+}

--- a/packages/runtime/src/ai/provider-error.test.ts
+++ b/packages/runtime/src/ai/provider-error.test.ts
@@ -211,12 +211,12 @@ test("unclassifiable error → unknown, preserving the raw text", () => {
   const err = classifyProviderError({
     provider: "anthropic",
     model: "claude-opus-4-8",
-    message: "prompt is too long: 250000 tokens > 200000 maximum",
+    message: "something odd happened while streaming the response",
   });
   expect(err).toEqual({
     kind: "unknown",
     provider: "anthropic",
-    raw_excerpt: "prompt is too long: 250000 tokens > 200000 maximum",
+    raw_excerpt: "something odd happened while streaming the response",
   });
 });
 
@@ -375,4 +375,68 @@ test("a genuine opencode 401 invalid key still reads as unauthenticated", () => 
   });
   expect(err.kind).toBe("unauthenticated");
   if (err.kind === "unauthenticated") expect(err.cause).toBe("invalid_api_key");
+});
+
+// ---------------------------------------------------------------------------
+// Context overflow — the conversation no longer fits the model's window.
+// The Jan fixture is the VERBATIM llama.cpp rejection from the production
+// incident that used to fall through to `unknown` (a Jan-v3.5-4B custom
+// endpoint with n_ctx=8192 behind a Houston tunnel).
+
+test("llama.cpp/Jan exceed_context_size_error → context_overflow with both token counts", () => {
+  const err = classifyProviderError({
+    provider: "openai-compatible",
+    model: "Jan-v3.5-4B-Q4_K_XL",
+    message:
+      '400: {"code":400,"message":"request (15246 tokens) exceeds the available context size (8192 tokens), try increasing it","type":"exceed_context_size_error","n_prompt_tokens":15246,"n_ctx":8192}',
+  });
+  expect(err).toEqual({
+    kind: "context_overflow",
+    provider: "openai-compatible",
+    model: "Jan-v3.5-4B-Q4_K_XL",
+    context_window_tokens: 8192,
+    prompt_tokens: 15246,
+    message:
+      '400: {"code":400,"message":"request (15246 tokens) exceeds the available context size (8192 tokens), try increasing it","type":"exceed_context_size_error","n_prompt_tokens":15246,"n_ctx":8192}',
+  });
+});
+
+test("OpenAI context_length_exceeded → context_overflow with the window parsed", () => {
+  const err = classifyProviderError({
+    provider: "openai",
+    model: "gpt-4o",
+    message:
+      "OpenAI API error (400): This model's maximum context length is 128000 tokens. However, your messages resulted in 131085 tokens. Please reduce the length of the messages. (context_length_exceeded)",
+  });
+  expect(err.kind).toBe("context_overflow");
+  if (err.kind === "context_overflow") {
+    expect(err.context_window_tokens).toBe(128000);
+  }
+});
+
+test("Anthropic 'prompt is too long' → context_overflow, never rate_limited despite the 400 body", () => {
+  const err = classifyProviderError({
+    provider: "anthropic",
+    model: "claude-opus-4-8",
+    message:
+      '400 {"type":"error","error":{"type":"invalid_request_error","message":"prompt is too long: 213462 tokens > 200000 maximum"}}',
+  });
+  expect(err.kind).toBe("context_overflow");
+  if (err.kind === "context_overflow") {
+    expect(err.prompt_tokens).toBe(213462);
+    expect(err.context_window_tokens).toBe(200000);
+  }
+});
+
+test("overflow text without numbers still classifies, with null token counts", () => {
+  const err = classifyProviderError({
+    provider: "amazon-bedrock",
+    model: "anthropic.claude-3",
+    message: "400: Input is too long for requested model.",
+  });
+  expect(err.kind).toBe("context_overflow");
+  if (err.kind === "context_overflow") {
+    expect(err.context_window_tokens).toBeNull();
+    expect(err.prompt_tokens).toBeNull();
+  }
 });

--- a/packages/runtime/src/ai/provider-error.ts
+++ b/packages/runtime/src/ai/provider-error.ts
@@ -1,3 +1,4 @@
+import { getOverflowPatterns } from "@earendil-works/pi-ai";
 import type { AuthFailureCause, ProviderError } from "@houston/runtime-client";
 
 /**
@@ -151,6 +152,26 @@ export function classifyProviderError(
       message,
     };
   }
+  // Context overflow: the conversation no longer fits the model's window —
+  // never a credential/quota/server fault; the fix is a bigger-window model or
+  // a fresh chat. Detected with pi-ai's per-provider pattern list (llama.cpp's
+  // "exceeds the available context size", Anthropic's "prompt is too long",
+  // OpenAI's context_length_exceeded, …). Checked AFTER rate-limit on purpose:
+  // that ordering is pi's own non-overflow exclusion — a throttling body like
+  // Bedrock's "Too many tokens, please wait" must stay a rate limit even
+  // though it matches the generic /too many tokens/ overflow pattern. Carries
+  // the provider's own numbers so the card can name them and the runtime can
+  // learn a custom endpoint's real window (`learnCustomContextWindow`).
+  if (isContextOverflow(message)) {
+    return {
+      kind: "context_overflow",
+      provider,
+      model,
+      context_window_tokens: extractContextWindowTokens(message),
+      prompt_tokens: extractPromptTokens(message),
+      message,
+    };
+  }
   if (isServerError(lower, status)) {
     return {
       kind: "provider_internal",
@@ -236,6 +257,10 @@ function isRateLimited(lower: string, status: number | null): boolean {
     lower.includes("rate_limit") ||
     lower.includes("ratelimit") ||
     lower.includes("too many requests") ||
+    // Bedrock prefixes throttling as "Throttling error: Too many tokens, …" —
+    // semantically a rate limit, and matching it here is what keeps it out of
+    // the context-overflow branch below (pi's own non-overflow exclusion).
+    lower.includes("throttl") ||
     lower.includes("usage limit") ||
     lower.includes("usage_limit") ||
     lower.includes("quota")
@@ -270,6 +295,43 @@ function isNetwork(lower: string): boolean {
 
 function isModelUnavailable(lower: string): boolean {
   return MODEL_UNAVAILABLE_PATTERNS.some((p) => lower.includes(p));
+}
+
+function isContextOverflow(message: string): boolean {
+  return getOverflowPatterns().some((p) => p.test(message));
+}
+
+/**
+ * The model's REAL context window from an overflow rejection, when the provider
+ * named it: llama.cpp's structured `"n_ctx":8192` / prose "context size (8192
+ * tokens)", OpenAI's "maximum context length is 128000 tokens", Anthropic's
+ * "N tokens > 200000 maximum". Null when no plausible number is present.
+ */
+export function extractContextWindowTokens(message: string): number | null {
+  const m =
+    message.match(/"n_ctx"\s*:\s*(\d+)/) ??
+    message.match(/context size \((\d+)\s*tokens?\)/i) ??
+    message.match(/maximum context length is (\d+)/i) ??
+    message.match(/>\s*(\d+)\s*maximum/i);
+  return m ? positiveInt(m[1]) : null;
+}
+
+/**
+ * The rejected request's prompt size from an overflow rejection, when the
+ * provider named it: llama.cpp's `"n_prompt_tokens":15246` / prose "request
+ * (15246 tokens)", Anthropic's "prompt is too long: N tokens".
+ */
+export function extractPromptTokens(message: string): number | null {
+  const m =
+    message.match(/"n_prompt_tokens"\s*:\s*(\d+)/) ??
+    message.match(/request \((\d+)\s*tokens?\)/i) ??
+    message.match(/too long:?\s*(\d+)\s*tokens?/i);
+  return m ? positiveInt(m[1]) : null;
+}
+
+function positiveInt(raw: string): number | null {
+  const n = Number(raw);
+  return Number.isInteger(n) && n > 0 ? n : null;
 }
 
 function isInsufficientBalance(lower: string): boolean {

--- a/packages/runtime/src/session/context-overflow.test.ts
+++ b/packages/runtime/src/session/context-overflow.test.ts
@@ -1,0 +1,84 @@
+import { mkdtempSync, readFileSync } from "node:fs";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+
+// Isolate this file's runtime state BEFORE the dynamic imports: config reads
+// the env at import time, and vitest gives each test file its own module
+// registry, so the endpoint/auth/settings writes stay out of ~/.houston-ts.
+process.env.HOUSTON_DATA_DIR = mkdtempSync(join(tmpdir(), "houston-ctx-"));
+process.env.HOUSTON_WORKSPACE_DIR = process.env.HOUSTON_DATA_DIR;
+
+const { runTurn } = await import("./chat");
+const { getHistory } = await import("../store/conversations");
+const { setCustomEndpointConfig, OPENAI_COMPATIBLE } = await import(
+  "../ai/openai-compatible"
+);
+const { setSettings } = await import("../ai/providers");
+const { authStorage } = await import("../auth/storage");
+
+// The llama.cpp rejection from the production incident: a Jan custom endpoint
+// (n_ctx=8192) behind a tunnel answered every turn of an overgrown
+// conversation with this 400, and the chat rendered the generic "Something
+// unexpected happened" card because nothing classified it. llama.cpp wraps
+// the payload in the OpenAI `{"error": {…}}` envelope; the openai SDK unwraps
+// it and pi flattens it to `400: {"code":400,…}` — the exact errorMessage the
+// classifier saw in production.
+const JAN_OVERFLOW_BODY = JSON.stringify({
+  error: {
+    code: 400,
+    message:
+      "request (15246 tokens) exceeds the available context size (8192 tokens), try increasing it",
+    type: "exceed_context_size_error",
+    n_prompt_tokens: 15246,
+    n_ctx: 8192,
+  },
+});
+
+test("a turn rejected by the endpoint for context overflow persists a typed error AND teaches the endpoint its real window", async () => {
+  const server = createServer((_req, res) => {
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JAN_OVERFLOW_BODY);
+  });
+  await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  const { port } = server.address() as AddressInfo;
+
+  try {
+    setCustomEndpointConfig({
+      baseUrl: `http://127.0.0.1:${port}/v1`,
+      model: "Jan-v3.5-4B-Q4_K_XL",
+    });
+    // pi resolves a request's key by model.provider — a keyless local server
+    // still needs the placeholder credential (auth/login.ts writes the same).
+    authStorage.set(OPENAI_COMPATIBLE, {
+      type: "api_key",
+      key: "houston-local",
+    });
+    setSettings({ activeProvider: OPENAI_COMPATIBLE });
+
+    await runTurn("conv-ctx-1", "hello");
+
+    const [, assistant] = getHistory("conv-ctx-1")?.messages ?? [];
+    expect(assistant?.providerError).toMatchObject({
+      kind: "context_overflow",
+      provider: OPENAI_COMPATIBLE,
+      context_window_tokens: 8192,
+      prompt_tokens: 15246,
+    });
+
+    // The overflow named the endpoint's REAL window (n_ctx) — it must now be
+    // persisted so the next turn's autocompact divides by 8192, not the
+    // assumed default that let the conversation overflow in the first place.
+    const endpoint = JSON.parse(
+      readFileSync(
+        join(process.env.HOUSTON_DATA_DIR as string, "custom-endpoint.json"),
+        "utf8",
+      ),
+    );
+    expect(endpoint.contextWindow).toBe(8192);
+  } finally {
+    await new Promise((r) => server.close(r));
+  }
+});

--- a/packages/runtime/src/session/exec-turn.ts
+++ b/packages/runtime/src/session/exec-turn.ts
@@ -8,6 +8,10 @@ import type {
   WireEvent,
 } from "@houston/runtime-client";
 import { DEFAULT_REASONING_EFFORT, toThinkingLevel } from "../ai/effort";
+import {
+  learnCustomContextWindow,
+  OPENAI_COMPATIBLE,
+} from "../ai/openai-compatible";
 import { classifyProviderError } from "../ai/provider-error";
 import { activeEffort, resolveModel } from "../ai/providers";
 import { config } from "../config";
@@ -397,6 +401,16 @@ export async function execTurn(
       };
       publish(id, { type: "provider_error", data: providerError, turnId });
     }
+    // A context-overflow rejection names the model's REAL window (llama.cpp's
+    // `n_ctx`). For a custom endpoint — whose window Houston can only assume —
+    // persist it, so the next turn's autocompact divides by the truth and the
+    // conversation compacts instead of overflowing again.
+    if (
+      providerError?.kind === "context_overflow" &&
+      model.provider === OPENAI_COMPATIBLE &&
+      providerError.context_window_tokens
+    )
+      learnCustomContextWindow(providerError.context_window_tokens);
     // Diff what this turn created/modified. Skipped on a failed turn — a
     // provider error means the model never finished, so attributing partial
     // writes would be noise (mirrors the Rust engine's error gate).

--- a/ui/chat/src/types.ts
+++ b/ui/chat/src/types.ts
@@ -156,6 +156,21 @@ export type ProviderError =
        */
       undelivered_prompt?: string;
     }
+  | {
+      /**
+       * The conversation no longer fits the model's context window — the
+       * provider rejected the request outright. Not a credential/quota/server
+       * fault: the recovery is a larger-window model or a fresh conversation,
+       * so the card's CTA opens the model picker. Token counts are the
+       * provider's own numbers when it named them.
+       */
+      kind: "context_overflow";
+      provider: string;
+      model: string | null;
+      context_window_tokens: number | null;
+      prompt_tokens: number | null;
+      message: string;
+    }
   | { kind: "network_unreachable"; provider: string; message: string }
   | {
       kind: "provider_internal";


### PR DESCRIPTION
## Problem

A cloud chat on a custom OpenAI-compatible endpoint (Jan, llama.cpp, `n_ctx=8192`) died once the conversation outgrew the model's window:

- Houston assumes the default window (32,768) for a custom endpoint that doesn't declare one, so **autocompact never fired** — the failing 15k-token request read as 46% full against the assumed window while the real server capacity was 8,192.
- llama.cpp's rejection (`400 exceed_context_size_error`) fell through the classifier to `unknown`, so the user saw the generic **"Something unexpected happened"** card on every subsequent turn with no way to understand or recover.

Chat data was never at risk — failed turns persist as empty assistant messages with a typed `providerError` — but the loop was unrecoverable from the UI and undiagnosable from the card.

## Fix

**1. New `ProviderError` variant `context_overflow`** (`packages/protocol`, mirrored in `ui/chat`), classified in the runtime with pi-ai's per-provider overflow pattern list (`getOverflowPatterns()`: llama.cpp, OpenAI, Anthropic, Bedrock, LM Studio, OpenRouter, …). It carries the provider's own numbers (`context_window_tokens`, `prompt_tokens`). Rate-limit is checked before overflow, mirroring pi's non-overflow exclusion so throttling bodies like Bedrock's "Too many tokens, please wait" stay rate limits (`isRateLimited` also matches "throttl" now).

**2. The runtime learns the endpoint's real window.** llama.cpp's rejection names the truth (`n_ctx`); `learnCustomContextWindow` persists it into `custom-endpoint.json` (shrink-only — a report can prove the window is at most N, never more, and must never raise a user-set value). The next turn resolves the model with the real window, so autocompact fires at the actual boundary (93% of 8,192) instead of letting the conversation overflow again.

**3. A typed card instead of the generic one.** `ContextOverflowCard` names the model that ran out of room and opens the model picker (switching the chat to a larger-window model compacts/replays via the existing provider-switch path). i18n en/es/pt; inventory v22 (`provider-error-card` gains the `context-overflow` state) + CHANGELOG.

## Tests

- Classifier cases with verbatim fixtures (the production llama.cpp body, OpenAI `context_length_exceeded`, Anthropic "prompt is too long", Bedrock, no-numbers variants).
- `learnCustomContextWindow` unit tests (set, shrink-only, nonsense values, unconfigured endpoint).
- An end-to-end turn test (`context-overflow.test.ts`): a real `runTurn` against an HTTP stub answering with llama.cpp's `{"error":{…}}` envelope asserts the persisted message carries the typed error AND that `custom-endpoint.json` learned `contextWindow: 8192`.

## Gates

runtime 627 / host 916 / domain 137 vitest, app + web typechecks, Biome, `check:boundaries`, `check-locales`, `check:parity` — all green.