### PR TITLE
fix(ci): include agent store contract in engine pod build

### DIFF
--- a/selfhost/Dockerfile
+++ b/selfhost/Dockerfile
@@ -32,6 +32,7 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY selfhost/bundle.mjs /app/selfhost/bundle.mjs
 COPY ui/agent-schemas/ /app/ui/agent-schemas/
+COPY packages/agentstore-contract/ /app/packages/agentstore-contract/
 COPY packages/protocol/ /app/packages/protocol/
 COPY packages/runtime-client/ /app/packages/runtime-client/
 COPY packages/domain/ /app/packages/domain/
@@ -61,6 +62,7 @@ WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY ui/agent-schemas/ /app/ui/agent-schemas/
+COPY packages/agentstore-contract/ /app/packages/agentstore-contract/
 COPY packages/protocol/ /app/packages/protocol/
 COPY packages/runtime-client/ /app/packages/runtime-client/
 COPY packages/domain/ /app/packages/domain/


### PR DESCRIPTION
## Summary
- copy `packages/agentstore-contract` into the engine-pod bundle stage
- copy the package into the production install stage so pnpm can link the complete workspace dependency graph

## Root cause
The Agent Store work added imports of `@houston/agentstore-contract` to `packages/domain` and `packages/host`, but `selfhost/Dockerfile` only copied the older workspace packages. The image workflow therefore failed in `selfhost/bundle.mjs` when esbuild could not resolve the new package.

## Verification
- reproduced the linked CI failure with `docker build -f selfhost/Dockerfile --target bundle-builder -t houston-bundle-repro .`
- `docker build -f selfhost/Dockerfile --target bundle-builder -t houston-bundle-fixed .`
- `docker build -f selfhost/Dockerfile --target engine-pod -t houston/engine-pod:ci-fix .`
- booted the built image and verified `/health` and authenticated `/v1/capabilities`
- `pnpm check`
- `pnpm check:boundaries`
