### PR TITLE
feat(app): Agent Settings "Use from other apps" section + benefit-first API-keys copy

### DIFF
--- a/app/src/components/settings/sections/api-keys.tsx
+++ b/app/src/components/settings/sections/api-keys.tsx
@@ -1,9 +1,7 @@
 import { Trans, useTranslation } from "react-i18next";
+import { DEVELOPER_DOCS } from "../../../lib/agent-connect-model";
 import { tauriSystem } from "../../../lib/tauri";
 import { ApiKeysBody } from "./api-keys-body";
-
-/** Developer docs for the public API, opened in the OS browser. */
-const DOCS_URL = "https://gethouston.ai/developers";
 
 /**
  * Settings > API keys (C9): mint and revoke personal keys for the public API.
@@ -25,7 +23,9 @@ export function ApiKeysSection() {
             docs: (
               <button
                 type="button"
-                onClick={() => void tauriSystem.openUrl(DOCS_URL)}
+                onClick={() =>
+                  void tauriSystem.openUrl(DEVELOPER_DOCS.overview)
+                }
                 className="cursor-pointer font-medium text-primary underline underline-offset-2 transition-colors hover:text-primary/80"
               />
             ),

--- a/app/src/components/tabs/agent-admin/agent-admin-connect.tsx
+++ b/app/src/components/tabs/agent-admin/agent-admin-connect.tsx
@@ -1,0 +1,121 @@
+import { Button } from "@houston-ai/core";
+import { Bot, KeyRound, Network, Zap } from "lucide-react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { useApiKeys } from "../../../hooks/queries/use-api-keys";
+import { useOrgs } from "../../../hooks/queries/use-spaces";
+import {
+  connectEndpoints,
+  connectOrgSlug,
+  DEVELOPER_DOCS,
+} from "../../../lib/agent-connect-model";
+import { useUIStore } from "../../../stores/ui";
+import { useWorkspaceStore } from "../../../stores/workspaces";
+import { ApiKeyCreateDialog } from "../../settings/sections/api-key-create-dialog";
+import type { AgentAdminScreenProps } from "./agent-admin-nav.ts";
+import { ConnectCard } from "./connect-card";
+
+/**
+ * "Use from other apps" section (C10 public API): shows a non-technical owner
+ * that this agent can take work from outside Houston, and hands them the three
+ * public addresses (MCP for AI assistants, A2A for other agents, missions REST
+ * for automations) plus the API-key step every connection needs. Reached only
+ * on a gateway that advertises `capabilities.apiKeys` (the nav row is gated),
+ * where the agent's client-side id IS its stable public slug.
+ */
+export function AgentAdminConnect({ agent }: AgentAdminScreenProps) {
+  const { t } = useTranslation("connect");
+  const workspace = useWorkspaceStore((s) => s.current);
+  // The section only renders on an apiKeys-capable gateway, so the orgs list
+  // (which carries the personal space's slug for the A2A address) can load.
+  const { data: orgs } = useOrgs(true);
+  const origin = window.__HOUSTON_ENGINE__?.baseUrl ?? null;
+  const endpoints = origin
+    ? connectEndpoints(origin, agent.id, connectOrgSlug(workspace?.id, orgs))
+    : null;
+
+  return (
+    <div className="mx-auto w-full max-w-2xl px-8 py-10">
+      <h2 className="text-lg font-semibold text-ink">{t("section.title")}</h2>
+      <p className="mt-1 text-sm text-ink-muted">
+        {t("section.intro", { name: agent.name })}
+      </p>
+
+      <KeyGate />
+
+      <div className="mt-6 space-y-4">
+        <ConnectCard
+          icon={Bot}
+          title={t("cards.assistant.title")}
+          description={t("cards.assistant.description", { name: agent.name })}
+          addressLabel={t("cards.assistant.addressLabel")}
+          address={endpoints?.mcp ?? null}
+          docsUrl={DEVELOPER_DOCS.mcp}
+        />
+        <ConnectCard
+          icon={Network}
+          title={t("cards.agents.title")}
+          description={t("cards.agents.description", { name: agent.name })}
+          addressLabel={t("cards.agents.addressLabel")}
+          address={endpoints?.a2aCard ?? null}
+          docsUrl={DEVELOPER_DOCS.a2a}
+        />
+        <ConnectCard
+          icon={Zap}
+          title={t("cards.automation.title")}
+          description={t("cards.automation.description", { name: agent.name })}
+          addressLabel={t("cards.automation.addressLabel")}
+          address={endpoints?.missions ?? null}
+          docsUrl={DEVELOPER_DOCS.missions}
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The API-key step: every external connection authenticates with a personal
+ * key. Create one right here (the settings dialog, reused, reveals it once);
+ * the full list lives in Settings > API keys, one deep-link away.
+ */
+function KeyGate() {
+  const { t } = useTranslation("connect");
+  const { data: keys } = useApiKeys();
+  const [createOpen, setCreateOpen] = useState(false);
+  const setViewMode = useUIStore((s) => s.setViewMode);
+  const setSettingsSection = useUIStore((s) => s.setSettingsSection);
+
+  const count = keys?.length ?? 0;
+
+  return (
+    <div className="mt-6 flex items-start gap-3 rounded-xl border border-line bg-card px-4 py-3">
+      <KeyRound className="mt-0.5 size-4 shrink-0 text-ink-muted" />
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-ink">{t("key.title")}</p>
+        <p className="mt-0.5 text-sm text-ink-muted">{t("key.description")}</p>
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <Button
+            size="sm"
+            variant={count === 0 ? "default" : "outline"}
+            onClick={() => setCreateOpen(true)}
+          >
+            {t("key.create")}
+          </Button>
+          {count > 0 && (
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={() => {
+                setSettingsSection("apiKeys");
+                setViewMode("settings");
+              }}
+            >
+              {t("key.manage", { count })}
+            </Button>
+          )}
+        </div>
+      </div>
+      <ApiKeyCreateDialog open={createOpen} onOpenChange={setCreateOpen} />
+    </div>
+  );
+}

--- a/app/src/components/tabs/agent-admin/agent-admin-nav.ts
+++ b/app/src/components/tabs/agent-admin/agent-admin-nav.ts
@@ -1,4 +1,5 @@
 import type { Capabilities } from "@houston-ai/engine-client";
+import { apiKeysSupported } from "../../../lib/api-keys-model.ts";
 import { isMultiplayer } from "../../../lib/org-roles.ts";
 import type { Agent } from "../../../lib/types";
 
@@ -15,14 +16,15 @@ export type AgentAdminScreen =
   | "knowledge"
   | "model"
   | "people"
-  | "integrations";
+  | "integrations"
+  | "connect";
 
 /** Shared props for every Agent Settings section component. */
 export interface AgentAdminScreenProps {
   agent: Agent;
 }
 
-export type AgentAdminCardId = "configuration" | "access";
+export type AgentAdminCardId = "configuration" | "access" | "connect";
 
 export interface AgentAdminCard {
   id: AgentAdminCardId;
@@ -39,6 +41,9 @@ export interface AgentAdminCard {
  *   models lives here (not Configuration) because the ceiling is a multiplayer
  *   concept: single-player has no ceiling, and its sole user picks a model in the
  *   composer, so single-player never shows a model row at all.
+ * - **Connect** (hosted public API only, `capabilities.apiKeys` — C10): use the
+ *   agent from other apps (MCP / A2A / missions REST). Absent on desktop-local,
+ *   self-host, and gateways that predate the public API.
  *
  * Single-player / self-host gets Configuration only — no Access card (no sharing
  * / no ceilings). Only managers/owners (or the single-player sole user) ever
@@ -57,6 +62,10 @@ export function agentAdminCards(
 
   if (isMultiplayer(caps)) {
     cards.push({ id: "access", rows: ["people", "integrations", "model"] });
+  }
+
+  if (apiKeysSupported(caps ?? null)) {
+    cards.push({ id: "connect", rows: ["connect"] });
   }
 
   return cards;

--- a/app/src/components/tabs/agent-admin/agent-admin-screen.tsx
+++ b/app/src/components/tabs/agent-admin/agent-admin-screen.tsx
@@ -1,4 +1,5 @@
 import { AgentAccessSection } from "../agent-access-section";
+import { AgentAdminConnect } from "./agent-admin-connect";
 import { AgentAdminInstructions } from "./agent-admin-instructions";
 import { AgentAdminIntegrations } from "./agent-admin-integrations";
 import { AgentAdminKnowledge } from "./agent-admin-knowledge";
@@ -30,6 +31,8 @@ export function AgentAdminScreenView({
       return <AgentAdminModel agent={agent} />;
     case "integrations":
       return <AgentAdminIntegrations agent={agent} />;
+    case "connect":
+      return <AgentAdminConnect agent={agent} />;
     case "people":
       return (
         <div className="mx-auto w-full max-w-xl px-8 py-10">

--- a/app/src/components/tabs/agent-admin/agent-admin-sidebar.tsx
+++ b/app/src/components/tabs/agent-admin/agent-admin-sidebar.tsx
@@ -2,6 +2,7 @@ import { Badge, cn } from "@houston-ai/core";
 import {
   Blocks,
   Brain,
+  Cable,
   Cpu,
   FileText,
   LibraryBig,
@@ -25,6 +26,7 @@ const ICONS: Record<AgentAdminScreen, LucideIcon> = {
   model: Cpu,
   people: Users,
   integrations: Blocks,
+  connect: Cable,
 };
 
 /**
@@ -39,6 +41,7 @@ const ROW_TITLES = {
   model: "agentAdmin.rows.model.title",
   people: "agentAdmin.rows.people.title",
   integrations: "agentAdmin.rows.integrations.title",
+  connect: "connect:row.title",
 } as const satisfies Record<AgentAdminScreen, string>;
 
 /**

--- a/app/src/components/tabs/agent-admin/connect-card.tsx
+++ b/app/src/components/tabs/agent-admin/connect-card.tsx
@@ -1,0 +1,86 @@
+import { Button, Skeleton } from "@houston-ai/core";
+import { Copy, ExternalLink, type LucideIcon } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { genericErrorDescription } from "../../../lib/error-toast";
+import { tauriSystem } from "../../../lib/tauri";
+import { useUIStore } from "../../../stores/ui";
+
+export interface ConnectCardProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  addressLabel: string;
+  /** `null` while the address can't be built yet (orgs list still loading). */
+  address: string | null;
+  docsUrl: string;
+}
+
+/**
+ * One way into the agent from outside (Connect section): icon + plain-language
+ * pitch + the copyable public address + a "learn how" link into the matching
+ * developer-docs page (opened in the OS browser).
+ */
+export function ConnectCard({
+  icon: Icon,
+  title,
+  description,
+  addressLabel,
+  address,
+  docsUrl,
+}: ConnectCardProps) {
+  const { t } = useTranslation("connect");
+  const addToast = useUIStore((s) => s.addToast);
+
+  async function copyAddress() {
+    if (!address) return;
+    try {
+      await navigator.clipboard.writeText(address);
+      addToast({ title: t("cards.copied") });
+    } catch (err) {
+      addToast({
+        title: t("cards.copyFailed"),
+        description: genericErrorDescription("copy_connect_address", err),
+        variant: "error",
+      });
+    }
+  }
+
+  return (
+    <section className="rounded-xl border border-line bg-card px-4 py-3">
+      <div className="flex items-center gap-2">
+        <Icon className="size-4 shrink-0 text-ink-muted" />
+        <h3 className="flex-1 text-sm font-medium text-ink">{title}</h3>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={() => void tauriSystem.openUrl(docsUrl)}
+        >
+          <ExternalLink className="size-3.5" />
+          {t("cards.docs")}
+        </Button>
+      </div>
+      <p className="mt-1 text-sm text-ink-muted">{description}</p>
+      <div className="mt-2 flex items-center gap-2">
+        {address ? (
+          <>
+            <code className="min-w-0 flex-1 truncate rounded-lg border border-line-input bg-input px-2.5 py-1.5 font-mono text-xs text-ink">
+              <span className="sr-only">{addressLabel}: </span>
+              {address}
+            </code>
+            <Button
+              size="sm"
+              variant="outline"
+              className="shrink-0"
+              onClick={() => void copyAddress()}
+            >
+              <Copy className="size-3.5" />
+              {t("cards.copy")}
+            </Button>
+          </>
+        ) : (
+          <Skeleton className="h-8 w-full rounded-lg" />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/app/src/lib/agent-connect-model.ts
+++ b/app/src/lib/agent-connect-model.ts
@@ -1,0 +1,69 @@
+import type { OrgsList } from "@houston-ai/engine-client";
+import { orgSlugFromWorkspaceId } from "./space-id.ts";
+
+/**
+ * Pure, DOM-free logic behind the Agent Settings "Use from other apps" section
+ * (C10 public API): the three public addresses an external caller uses to reach
+ * one hosted agent, and the org-slug resolution the A2A address needs. Kept out
+ * of the `.tsx` so the URL grammar and the slug fallback unit-test under bare
+ * Node. The section itself is gated on `capabilities.apiKeys` (see
+ * `api-keys-model.ts` `apiKeysSupported`).
+ */
+
+/** Public developer docs (`houston/website/src/developers/*`), one page per face. */
+export const DEVELOPER_DOCS = {
+  overview: "https://gethouston.ai/developers",
+  mcp: "https://gethouston.ai/developers/mcp",
+  a2a: "https://gethouston.ai/developers/a2a",
+  missions: "https://gethouston.ai/developers/missions",
+} as const;
+
+/**
+ * The public addresses for one agent on the hosted gateway (C10). `a2aCard` is
+ * `null` until the caller's org slug is known — the A2A path is org-scoped
+ * (`/a2a/{org}/{agent}`), unlike MCP (one shared endpoint) and missions REST
+ * (agent-scoped, org resolved from the bearer).
+ */
+export interface ConnectEndpoints {
+  mcp: string;
+  missions: string;
+  a2aCard: string | null;
+}
+
+/**
+ * Build the three public addresses from the gateway origin. On a hosted
+ * deployment the agent's client-side `id` IS the gateway's stable external
+ * agent slug (`cloud internal/edge/agents/routes.go` `toAgentJSON`), so the
+ * caller passes `agent.id`.
+ */
+export function connectEndpoints(
+  baseUrl: string,
+  agentSlug: string,
+  orgSlug: string | null,
+): ConnectEndpoints {
+  const base = baseUrl.replace(/\/+$/, "");
+  const agent = encodeURIComponent(agentSlug);
+  return {
+    mcp: `${base}/mcp`,
+    missions: `${base}/v1/agents/${agent}/missions`,
+    a2aCard: orgSlug
+      ? `${base}/a2a/${encodeURIComponent(orgSlug)}/${agent}/.well-known/agent-card.json`
+      : null,
+  };
+}
+
+/**
+ * The org slug the public A2A path addresses for the CURRENT space: a team
+ * workspace carries it in its id (`org:<slug>`); the personal space's id is
+ * opaque, so the slug comes from the caller's `GET /v1/orgs` memberships
+ * (`kind: "personal"`). `null` while the orgs list hasn't loaded (or on a host
+ * without the spaces surface) — the caller renders the address as pending.
+ */
+export function connectOrgSlug(
+  workspaceId: string | null | undefined,
+  orgs: OrgsList | undefined,
+): string | null {
+  const team = workspaceId ? orgSlugFromWorkspaceId(workspaceId) : null;
+  if (team) return team;
+  return orgs?.orgs.find((o) => o.kind === "personal")?.slug ?? null;
+}

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -17,6 +17,7 @@ import aiHubEn from "../locales/en/ai-hub.json";
 import boardEn from "../locales/en/board.json";
 import chatEn from "../locales/en/chat.json";
 import commonEn from "../locales/en/common.json";
+import connectEn from "../locales/en/connect.json";
 import contextEn from "../locales/en/context.json";
 import dashboardEn from "../locales/en/dashboard.json";
 import errorsEn from "../locales/en/errors.json";
@@ -39,6 +40,7 @@ import aiHubEs from "../locales/es/ai-hub.json";
 import boardEs from "../locales/es/board.json";
 import chatEs from "../locales/es/chat.json";
 import commonEs from "../locales/es/common.json";
+import connectEs from "../locales/es/connect.json";
 import contextEs from "../locales/es/context.json";
 import dashboardEs from "../locales/es/dashboard.json";
 import errorsEs from "../locales/es/errors.json";
@@ -61,6 +63,7 @@ import aiHubPt from "../locales/pt/ai-hub.json";
 import boardPt from "../locales/pt/board.json";
 import chatPt from "../locales/pt/chat.json";
 import commonPt from "../locales/pt/common.json";
+import connectPt from "../locales/pt/connect.json";
 import contextPt from "../locales/pt/context.json";
 import dashboardPt from "../locales/pt/dashboard.json";
 import errorsPt from "../locales/pt/errors.json";
@@ -147,6 +150,7 @@ const resources = {
     migration: migrationEn,
     portable: portableEn,
     context: contextEn,
+    connect: connectEn,
     org: orgEn,
     teams: teamsEn,
     agentOnboarding: agentOnboardingEn,
@@ -171,6 +175,7 @@ const resources = {
     migration: migrationEs,
     portable: portableEs,
     context: contextEs,
+    connect: connectEs,
     org: orgEs,
     teams: teamsEs,
     agentOnboarding: agentOnboardingEs,
@@ -195,6 +200,7 @@ const resources = {
     migration: migrationPt,
     portable: portablePt,
     context: contextPt,
+    connect: connectPt,
     org: orgPt,
     teams: teamsPt,
     agentOnboarding: agentOnboardingPt,
@@ -238,6 +244,7 @@ void i18n
       "migration",
       "portable",
       "context",
+      "connect",
       "org",
       "teams",
       "agentOnboarding",

--- a/app/src/locales/en/connect.json
+++ b/app/src/locales/en/connect.json
@@ -1,0 +1,37 @@
+{
+  "row": {
+    "title": "Use from other apps"
+  },
+  "section": {
+    "title": "Use from other apps",
+    "intro": "{{name}} can take work from outside Houston. Connect an AI assistant, another agent, or an automation tool, and the missions they start will show up here like any other mission."
+  },
+  "key": {
+    "title": "Every connection needs a key",
+    "description": "A key works like a password: it lets an app you trust start missions as you. Create one, copy it, and paste it into the app you are connecting.",
+    "create": "Create key",
+    "manage_one": "Manage {{count}} key",
+    "manage_other": "Manage {{count}} keys"
+  },
+  "cards": {
+    "assistant": {
+      "title": "AI assistants",
+      "description": "Add {{name}} to Claude or any assistant that supports tools (MCP). Paste this address and your key where the assistant asks for a new tool.",
+      "addressLabel": "Tool address for AI assistants"
+    },
+    "agents": {
+      "title": "Other agents",
+      "description": "Agents on other platforms can discover {{name}} and hand it tasks using the A2A standard. Share this address with the other platform.",
+      "addressLabel": "Agent card address"
+    },
+    "automation": {
+      "title": "Automations and developers",
+      "description": "Automation tools and scripts can start missions for {{name}} and receive the result when it finishes.",
+      "addressLabel": "Missions address"
+    },
+    "copy": "Copy",
+    "copied": "Address copied",
+    "copyFailed": "Couldn't copy the address",
+    "docs": "Learn how"
+  }
+}

--- a/app/src/locales/en/settings.json
+++ b/app/src/locales/en/settings.json
@@ -125,7 +125,7 @@
     "rows": {
       "members": "People who can use your agents",
       "connectedAccounts": "Apps you've connected to Houston",
-      "apiKeys": "Keys to run your agents from your own tools",
+      "apiKeys": "Let other apps and AI assistants start missions with your agents",
       "workspaceContext": "What every agent knows about this workspace",
       "userContext": "What every agent knows about you",
       "shortcuts": "Run Houston without the mouse",
@@ -150,12 +150,12 @@
   },
   "apiKeys": {
     "title": "API keys",
-    "intro": "Use API keys to start missions from your own tools and scripts. <docs>Read the developer docs</docs>.",
+    "intro": "Other apps, AI assistants, and automation tools can start missions with your agents. Each connection needs a key you create here. <docs>Read the developer docs</docs>.",
     "dialogClose": "Close",
     "createButton": "Create key",
     "empty": {
       "title": "No API keys yet",
-      "description": "An API key lets your own tools and scripts start missions with your agents. Create one to get started."
+      "description": "A key lets an app you trust start missions with your agents. Create one to connect your first app."
     },
     "error": {
       "title": "Couldn't load your keys",

--- a/app/src/locales/es/connect.json
+++ b/app/src/locales/es/connect.json
@@ -1,0 +1,37 @@
+{
+  "row": {
+    "title": "Usar desde otras apps"
+  },
+  "section": {
+    "title": "Usar desde otras apps",
+    "intro": "{{name}} puede recibir trabajo desde fuera de Houston. Conecta un asistente de IA, otro agente o una herramienta de automatización, y las misiones que inicien aparecerán aquí como cualquier otra misión."
+  },
+  "key": {
+    "title": "Cada conexión necesita una clave",
+    "description": "Una clave funciona como una contraseña: permite que una app de tu confianza inicie misiones en tu nombre. Crea una, cópiala y pégala en la app que quieres conectar.",
+    "create": "Crear clave",
+    "manage_one": "Administrar {{count}} clave",
+    "manage_other": "Administrar {{count}} claves"
+  },
+  "cards": {
+    "assistant": {
+      "title": "Asistentes de IA",
+      "description": "Agrega {{name}} a Claude o a cualquier asistente compatible con herramientas (MCP). Pega esta dirección y tu clave donde el asistente pida una nueva herramienta.",
+      "addressLabel": "Dirección para asistentes de IA"
+    },
+    "agents": {
+      "title": "Otros agentes",
+      "description": "Los agentes de otras plataformas pueden descubrir a {{name}} y encargarle tareas con el estándar A2A. Comparte esta dirección con la otra plataforma.",
+      "addressLabel": "Dirección de la tarjeta del agente"
+    },
+    "automation": {
+      "title": "Automatizaciones y desarrolladores",
+      "description": "Las herramientas de automatización y los scripts pueden iniciar misiones para {{name}} y recibir el resultado cuando termine.",
+      "addressLabel": "Dirección de misiones"
+    },
+    "copy": "Copiar",
+    "copied": "Dirección copiada",
+    "copyFailed": "No se pudo copiar la dirección",
+    "docs": "Ver cómo"
+  }
+}

--- a/app/src/locales/es/settings.json
+++ b/app/src/locales/es/settings.json
@@ -125,7 +125,7 @@
     "rows": {
       "members": "Personas que pueden usar tus agentes",
       "connectedAccounts": "Aplicaciones que conectaste a Houston",
-      "apiKeys": "Claves para usar tus agentes desde tus propias herramientas",
+      "apiKeys": "Permite que otras apps y asistentes de IA inicien misiones con tus agentes",
       "workspaceContext": "Lo que cada agente sabe sobre este espacio",
       "userContext": "Lo que cada agente sabe sobre ti",
       "shortcuts": "Usa Houston sin el mouse",
@@ -150,12 +150,12 @@
   },
   "apiKeys": {
     "title": "Claves de API",
-    "intro": "Usa claves de API para iniciar misiones desde tus propias herramientas y scripts. <docs>Lee la documentación para desarrolladores</docs>.",
+    "intro": "Otras apps, asistentes de IA y herramientas de automatización pueden iniciar misiones con tus agentes. Cada conexión necesita una clave que creas aquí. <docs>Lee la documentación para desarrolladores</docs>.",
     "dialogClose": "Cerrar",
     "createButton": "Crear clave",
     "empty": {
       "title": "Aún no tienes claves de API",
-      "description": "Una clave de API permite que tus propias herramientas y scripts inicien misiones con tus agentes. Crea una para empezar."
+      "description": "Una clave permite que una app de tu confianza inicie misiones con tus agentes. Crea una para conectar tu primera app."
     },
     "error": {
       "title": "No se pudieron cargar tus claves",

--- a/app/src/locales/pt/connect.json
+++ b/app/src/locales/pt/connect.json
@@ -1,0 +1,37 @@
+{
+  "row": {
+    "title": "Usar em outros apps"
+  },
+  "section": {
+    "title": "Usar em outros apps",
+    "intro": "{{name}} pode receber trabalho de fora do Houston. Conecte um assistente de IA, outro agente ou uma ferramenta de automação, e as missões iniciadas lá aparecerão aqui como qualquer outra missão."
+  },
+  "key": {
+    "title": "Toda conexão precisa de uma chave",
+    "description": "Uma chave funciona como uma senha: ela permite que um app de sua confiança inicie missões em seu nome. Crie uma, copie e cole no app que você quer conectar.",
+    "create": "Criar chave",
+    "manage_one": "Gerenciar {{count}} chave",
+    "manage_other": "Gerenciar {{count}} chaves"
+  },
+  "cards": {
+    "assistant": {
+      "title": "Assistentes de IA",
+      "description": "Adicione {{name}} ao Claude ou a qualquer assistente compatível com ferramentas (MCP). Cole este endereço e sua chave onde o assistente pedir uma nova ferramenta.",
+      "addressLabel": "Endereço para assistentes de IA"
+    },
+    "agents": {
+      "title": "Outros agentes",
+      "description": "Agentes de outras plataformas podem descobrir {{name}} e delegar tarefas usando o padrão A2A. Compartilhe este endereço com a outra plataforma.",
+      "addressLabel": "Endereço do cartão do agente"
+    },
+    "automation": {
+      "title": "Automações e desenvolvedores",
+      "description": "Ferramentas de automação e scripts podem iniciar missões para {{name}} e receber o resultado quando ele terminar.",
+      "addressLabel": "Endereço de missões"
+    },
+    "copy": "Copiar",
+    "copied": "Endereço copiado",
+    "copyFailed": "Não foi possível copiar o endereço",
+    "docs": "Saiba como"
+  }
+}

--- a/app/src/locales/pt/settings.json
+++ b/app/src/locales/pt/settings.json
@@ -125,7 +125,7 @@
     "rows": {
       "members": "Pessoas que podem usar seus agentes",
       "connectedAccounts": "Aplicativos que você conectou ao Houston",
-      "apiKeys": "Chaves para usar seus agentes a partir das suas próprias ferramentas",
+      "apiKeys": "Permita que outros apps e assistentes de IA iniciem missões com seus agentes",
       "workspaceContext": "O que todo agente sabe sobre este espaço",
       "userContext": "O que todo agente sabe sobre você",
       "shortcuts": "Use o Houston sem o mouse",
@@ -150,12 +150,12 @@
   },
   "apiKeys": {
     "title": "Chaves de API",
-    "intro": "Use chaves de API para iniciar missões a partir das suas próprias ferramentas e scripts. <docs>Leia a documentação para desenvolvedores</docs>.",
+    "intro": "Outros apps, assistentes de IA e ferramentas de automação podem iniciar missões com seus agentes. Cada conexão precisa de uma chave que você cria aqui. <docs>Leia a documentação para desenvolvedores</docs>.",
     "dialogClose": "Fechar",
     "createButton": "Criar chave",
     "empty": {
       "title": "Você ainda não tem chaves de API",
-      "description": "Uma chave de API permite que suas próprias ferramentas e scripts iniciem missões com seus agentes. Crie uma para começar."
+      "description": "Uma chave permite que um app de sua confiança inicie missões com seus agentes. Crie uma para conectar seu primeiro app."
     },
     "error": {
       "title": "Não foi possível carregar suas chaves",

--- a/app/src/types/react-i18next.d.ts
+++ b/app/src/types/react-i18next.d.ts
@@ -13,6 +13,7 @@ import type aiHub from "../locales/en/ai-hub.json";
 import type board from "../locales/en/board.json";
 import type chat from "../locales/en/chat.json";
 import type common from "../locales/en/common.json";
+import type connect from "../locales/en/connect.json";
 import type context from "../locales/en/context.json";
 import type dashboard from "../locales/en/dashboard.json";
 import type errors from "../locales/en/errors.json";
@@ -53,6 +54,7 @@ declare module "react-i18next" {
       migration: typeof migration;
       portable: typeof portable;
       context: typeof context;
+      connect: typeof connect;
       org: typeof org;
       teams: typeof teams;
       agentOnboarding: typeof agentOnboarding;

--- a/app/tests/agent-admin-nav.test.ts
+++ b/app/tests/agent-admin-nav.test.ts
@@ -65,6 +65,31 @@ describe("agentAdminCards — card + row visibility", () => {
       ]);
     }
   });
+
+  it("public API gateway (apiKeys): adds the Connect card, last", () => {
+    deepStrictEqual(cardIds(agentAdminCards(caps({ apiKeys: true }))), [
+      "configuration",
+      "connect",
+    ]);
+    deepStrictEqual(
+      cardIds(agentAdminCards(multiplayer("owner"))).includes("connect"),
+      false,
+    );
+    const hosted = agentAdminCards(
+      caps({ multiplayer: true, role: "owner", apiKeys: true }),
+    );
+    deepStrictEqual(cardIds(hosted), ["configuration", "access", "connect"]);
+    deepStrictEqual(rowsOf(hosted, "connect"), ["connect"]);
+  });
+
+  it("no Connect card off-cloud (absent/false flag, null caps)", () => {
+    for (const c of [caps(), caps({ apiKeys: false }), null]) {
+      strictEqual(
+        agentAdminCards(c).some((card) => card.id === "connect"),
+        false,
+      );
+    }
+  });
 });
 
 describe("targetToScreen — deep-link mapping", () => {

--- a/app/tests/agent-connect-model.test.ts
+++ b/app/tests/agent-connect-model.test.ts
@@ -1,0 +1,92 @@
+import { deepStrictEqual, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import type { OrgsList } from "@houston-ai/engine-client";
+import {
+  connectEndpoints,
+  connectOrgSlug,
+} from "../src/lib/agent-connect-model.ts";
+
+const BASE = "https://gateway.gethouston.ai";
+
+const orgsList = (over: Partial<OrgsList> = {}): OrgsList => ({
+  orgs: [
+    {
+      id: "org-1",
+      slug: "abcdef0123456789",
+      name: "Acme",
+      kind: "team",
+      role: "owner",
+      memberCount: 3,
+      degraded: false,
+    },
+    {
+      id: "org-2",
+      slug: "fedcba9876543210",
+      name: "Personal",
+      kind: "personal",
+      role: "owner",
+      memberCount: 1,
+      degraded: false,
+    },
+  ],
+  invites: [],
+  ...over,
+});
+
+describe("connectEndpoints — public address grammar (C10)", () => {
+  it("builds the three faces from the gateway origin", () => {
+    deepStrictEqual(connectEndpoints(BASE, "my-agent", "fedcba9876543210"), {
+      mcp: `${BASE}/mcp`,
+      missions: `${BASE}/v1/agents/my-agent/missions`,
+      a2aCard: `${BASE}/a2a/fedcba9876543210/my-agent/.well-known/agent-card.json`,
+    });
+  });
+
+  it("a2aCard is null until the org slug is known", () => {
+    strictEqual(connectEndpoints(BASE, "my-agent", null).a2aCard, null);
+  });
+
+  it("strips trailing slashes off the origin (no double slash)", () => {
+    const eps = connectEndpoints(`${BASE}//`, "my-agent", "aa00bb11cc22dd33");
+    strictEqual(eps.mcp, `${BASE}/mcp`);
+    strictEqual(eps.missions, `${BASE}/v1/agents/my-agent/missions`);
+  });
+
+  it("percent-encodes slugs so a hostile name can't break the path", () => {
+    const eps = connectEndpoints(BASE, "a/b?c", "x/y");
+    strictEqual(eps.missions, `${BASE}/v1/agents/a%2Fb%3Fc/missions`);
+    strictEqual(
+      eps.a2aCard,
+      `${BASE}/a2a/x%2Fy/a%2Fb%3Fc/.well-known/agent-card.json`,
+    );
+  });
+});
+
+describe("connectOrgSlug — active-space slug for the A2A path", () => {
+  it("team workspace: the slug rides the workspace id", () => {
+    strictEqual(
+      connectOrgSlug("org:abcdef0123456789", orgsList()),
+      "abcdef0123456789",
+    );
+  });
+
+  it("personal workspace (opaque id): falls back to the personal membership", () => {
+    strictEqual(connectOrgSlug("ws-opaque-id", orgsList()), "fedcba9876543210");
+  });
+
+  it("null while the orgs list hasn't loaded", () => {
+    strictEqual(connectOrgSlug("ws-opaque-id", undefined), null);
+  });
+
+  it("null when no personal membership exists (pre-spaces host)", () => {
+    strictEqual(
+      connectOrgSlug("ws-opaque-id", { orgs: [], invites: [] }),
+      null,
+    );
+  });
+
+  it("no workspace loaded yet: personal membership still resolves", () => {
+    strictEqual(connectOrgSlug(null, orgsList()), "fedcba9876543210");
+    strictEqual(connectOrgSlug(undefined, orgsList()), "fedcba9876543210");
+  });
+});

--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -121,7 +121,13 @@ classifier) in a `lib/*-model.ts` unit-tested under bare Node, and route an
 EXPECTED business 400 (e.g. `key_limit`, read off the gateway's flat top-level
 `body.code`) through `call()`'s `silence` predicate so it renders inline instead
 of the red bug toast. Files: `app/src/{lib/api-keys-model,hooks/queries/use-api-keys}.ts`
-+ `components/settings/sections/api-keys*.tsx`.
++ `components/settings/sections/api-keys*.tsx`. The same flag also gates the
+Agent Settings **Connect** section ("Use from other apps",
+`components/tabs/agent-admin/agent-admin-connect.tsx`), which needs NO new wire
+method: it builds the public MCP / A2A / missions addresses client-side
+(`lib/agent-connect-model.ts`) from the gateway origin
+(`window.__HOUSTON_ENGINE__.baseUrl`), the hosted agent id (= public slug), and
+the org slug (team workspace id, else the personal membership from `GET /v1/orgs`).
 
 **Strict-additive / iOS-safe rule.** `@houston/sdk` is consumed by BOTH web AND
 the native iOS app (via the JavaScriptCore bridge, `bridge/entry.ts`). iOS reaches

--- a/knowledge-base/teams.md
+++ b/knowledge-base/teams.md
@@ -308,7 +308,16 @@ configure surfaces are gated:
   settings nav rail, `agent-admin-sidebar.tsx`, grouping Configuration / Access +
   the selected section), manager-only and fully editable. Name / color / delete
   live on the sidebar agent row, not a "General" section (the old landing,
-  back-bar, and General card are gone).
+  back-bar, and General card are gone). On a public-API gateway
+  (`capabilities.apiKeys`, C10) the rail adds a third card, **Connect** ("Use
+  from other apps", `agent-admin-connect.tsx` + `connect-card.tsx`, `connect`
+  i18n ns): the non-technical pitch that outside apps can drive this agent, the
+  API-key step (reuses the settings `ApiKeyCreateDialog`, deep-links Settings >
+  API keys), and the three copyable public addresses (MCP / A2A agent card /
+  missions REST) built by the pure `lib/agent-connect-model.ts`
+  (`connectEndpoints` from the gateway origin + `agent.id`-as-slug;
+  `connectOrgSlug` resolves the A2A org slug from the team workspace id or the
+  personal membership in `GET /v1/orgs`).
 - **Model / effort pickers** (`chat-model-selector.tsx`,
   `chat-effort-selector.tsx`) are NOT hidden/locked for members (E8 reversed E7).
   In a Teams org the composer shows them to EVERYONE, clamps the option list to


### PR DESCRIPTION
## What

Makes the C10 public agent API (gethouston/cloud#110) **discoverable for non-technical users**. Until now the only surface was Settings > API keys, written in developer language.

### New: Agent Settings > "Use from other apps" (Connect)
- Third card in the Agent Settings rail, gated on `capabilities.apiKeys` (hosted only; invisible on desktop-local, self-host, older gateways).
- Plain-language intro: the agent can take work from outside Houston.
- **Key step**: "Every connection needs a key", explained as a password for apps you trust. Inline create (reuses the show-once `ApiKeyCreateDialog`) + deep-link to Settings > API keys.
- **Three connection cards**, each with a copyable public address + "Learn how" link into `/developers`: AI assistants (MCP), Other agents (A2A agent card), Automations and developers (missions REST).
- **No new wire calls**: addresses are built client-side (`lib/agent-connect-model.ts`, pure + node-tested) from the gateway origin, the hosted agent id (= public slug per cloud `toAgentJSON`), and the org slug (team workspace id, else the personal membership from `GET /v1/orgs`).

### Reworded: Settings > API keys copy (en/es/pt)
Benefit-first instead of key-jargon: "Let other apps and AI assistants start missions with your agents".

## Verification
- App unit tests **1489/1489** (new `agent-connect-model` tests + extended nav-gating tests).
- `app` tsgo, `check-locales` (23 namespaces), `houston-web` typecheck + shim parity, Biome (app scope), `check:parity`, `check:boundaries` — all green.
- Note: root `pnpm check` fails on `packages/design-tokens/test/outputs.test.ts`, pre-existing on `main`, untouched here.
- Not visually verified against a live `apiKeys`-capable gateway (the fake host never advertises the flag) — worth one manual look on the poc gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)