### PR TITLE
fix(ci): unblock the Agent Store frontend deploy (Firebase config source)

### DIFF
--- a/.github/workflows/agentstore-image.yml
+++ b/.github/workflows/agentstore-image.yml
@@ -21,10 +21,12 @@
 #   provider + registry the engine-pod-image.yml build uses; do NOT reuse the
 #   broader github-deploy@ SA (that one also carries Kubernetes Engine Developer).
 #
-# ── Required GitHub secret ─────────────────────────────────────────────────────
+# ── Required GitHub secrets ────────────────────────────────────────────────────
 #   CLOUD_DISPATCH_TOKEN — fine-grained PAT scoped ONLY to gethouston/cloud, with
 #   the minimum permission GitHub requires for the repository_dispatch endpoint.
 #   Used solely to notify cloud that a new image is ready; carries no GCP access.
+#   FIREBASE_API_KEY / FIREBASE_AUTH_DOMAIN / FIREBASE_PROJECT_ID — the Firebase
+#   web client config (public identifiers by design), shared with release.yml.
 
 name: Agent Store Image
 
@@ -100,19 +102,20 @@ jobs:
         id: build
         env:
           # The Firebase web config, inlined into the client bundle at build time
-          # (NEXT_PUBLIC_*). Public web identifiers, so they live as repo
-          # Variables (not Secrets) — a project change is one edit in repo
-          # settings. store.gethouston.ai signs users in against this project.
-          FIREBASE_API_KEY: ${{ vars.NEXT_PUBLIC_FIREBASE_API_KEY }}
-          FIREBASE_AUTH_DOMAIN: ${{ vars.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN }}
-          FIREBASE_PROJECT_ID: ${{ vars.NEXT_PUBLIC_FIREBASE_PROJECT_ID }}
+          # (NEXT_PUBLIC_*). Public web identifiers by design, sourced from the
+          # same FIREBASE_* repo secrets release.yml already bakes into the
+          # desktop/web app — one Firebase project, one place to rotate it.
+          # store.gethouston.ai signs users in against this project.
+          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
+          FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
         run: |
           # Fail loudly rather than ship a bundle with a dead sign-in surface:
           # a missing NEXT_PUBLIC_FIREBASE_* value inlines as undefined and
           # silently kills publish/claim/me/admin in production.
           for var in FIREBASE_API_KEY FIREBASE_AUTH_DOMAIN FIREBASE_PROJECT_ID; do
             if [ -z "${!var}" ]; then
-              echo "::error::$var is empty — set the NEXT_PUBLIC_FIREBASE_* repository variables" >&2
+              echo "::error::$var is empty — set the FIREBASE_* repository secrets (shared with release.yml)" >&2
               exit 1
             fi
           done

--- a/knowledge-base/agent-store.md
+++ b/knowledge-base/agent-store.md
@@ -24,9 +24,10 @@ The authoritative wire/DB surface is the gateway's contract
 | Engine seam | `ui/engine-client/src/client.ts` (front door), `packages/web/src/engine-adapter/portable.ts` (impl) + `store-gateway.ts` | `publishAgentToStore` / `updateStorePublication` / `unpublishFromStore` / `getStorePublication` / `importFromStoreLink`. |
 | App UI | `app/src/components/portable/` | Share wizard (`share-screen`, `listing-step`), `manage-publication`, `install-from-link`, `use-store-publication.ts`. |
 
-The store shares **no code** with `theagentlibrary/`. The tie to `cloud/` is the
-gateway API + a shared Firebase project; the AgentIR contract is a byte-copy
-relationship, not a runtime import.
+The tie to `cloud/` is the gateway API + a shared Firebase project; the AgentIR
+contract is a byte-copy relationship, not a runtime import. (The standalone
+`gethouston/theagentlibrary` repo was retired in July 2026 — this store
+supersedes it; they never shared code.)
 
 ## AgentIR 2.0.0 (the schema of record)
 
@@ -186,7 +187,7 @@ with the key named (beta policy: surface, never silently orphan the store agent)
 | `AGENTSTORE_GATEWAY_URL` | store frontend (server) | Gateway base for public catalog reads (RSC). Default `https://gateway.gethouston.ai`. |
 | `NEXT_PUBLIC_AGENTSTORE_GATEWAY_URL` | store frontend (browser) | Gateway base for client authed/anonymous writes (claim, publish, `/me`, admin, report). |
 | `NEXT_PUBLIC_SITE_URL` | store build | Canonical public URL for OG + share/schema links. |
-| `FIREBASE_API_KEY` / `AUTH_DOMAIN` / `PROJECT_ID` | store frontend | GCIP sign-in (SAME Firebase project as the gateway). |
+| `FIREBASE_API_KEY` / `AUTH_DOMAIN` / `PROJECT_ID` | store frontend | GCIP sign-in (SAME Firebase project as the gateway). In CI the image build reads the `FIREBASE_*` repo secrets shared with `release.yml`. |
 | `VITE_AGENTSTORE_GATEWAY_URL` | app build | Store gateway target in desktop LOCAL-sidecar mode. Default `https://gateway.gethouston.ai`. |
 | `VITE_AGENTSTORE_SITE_URL` | app build | Public store SITE base for "browse the store" links. Default `https://store.gethouston.ai`. |
 | `HOUSTON_AGENTSTORE_API_URL` | host | Gateway base for install-from-link IR fetch. Default `https://gateway.gethouston.ai`. |


### PR DESCRIPTION
## What

The Agent Store backend is live (`gateway.gethouston.ai/v1/agentstore` answers in prod), but **store.gethouston.ai is 404**: the only `agentstore-image` run ([29207454116](https://github.com/gethouston/houston/actions/runs/29207454116)) failed at preflight because the workflow reads `vars.NEXT_PUBLIC_FIREBASE_*` repository **variables** that were never created. The image was never pushed, so cloud's `roll-agentstore` never fired.

## Fix

Read the existing `FIREBASE_API_KEY` / `FIREBASE_AUTH_DOMAIN` / `FIREBASE_PROJECT_ID` repo **secrets** instead — the same three public-by-design web identifiers `release.yml` already bakes into the desktop/web app. One Firebase project, one place to rotate it, zero new repo settings.

Also updates `knowledge-base/agent-store.md`: records the CI secret source and notes the retirement of the standalone `gethouston/theagentlibrary` repo (superseded by this store; they never shared code).

## After merge

Merging auto-triggers the image build (the workflow file is in its own `paths` filter) → pushes `agentstore:<sha>` → dispatches `roll-agentstore` in `gethouston/cloud`. If the roll fails because the `agentstore-web` Deployment isn't applied in GKE yet, that's a `cloud/` follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)