### PR TITLE
fix(migrate): never skip chat-history conversion wholesale + guard imported sessions against stale instructions

### DIFF
--- a/packages/host/src/local/host.ts
+++ b/packages/host/src/local/host.ts
@@ -476,11 +476,13 @@ export function buildLocalHost(opts: LocalHostOptions): LocalHost {
           err,
         );
       }
-      // One-time, additive, idempotent migration of the Rust-desktop era's chat
-      // history (SQLite chat_feed) into each agent's `.houston/runtime/`. Runs
-      // BEFORE the watcher so its writes are already on disk when reactivity
-      // turns on, and only when the db is actually present. Never modifies the
-      // db or the existing tree, and a `.migrated` marker makes re-boots no-ops.
+      // Additive, idempotent migration of the Rust-desktop era's chat history
+      // (SQLite chat_feed) into each agent's `.houston/runtime/`. Runs BEFORE
+      // the watcher so its writes are already on disk when reactivity turns
+      // on, and only when the db is actually present. Never modifies the db or
+      // the existing tree; per-conversation existence checks make re-boots
+      // cheap no-ops (deliberately re-scanned every boot — see chat-history.ts
+      // on why a wholesale per-agent marker lost data).
       if (opts.chatHistoryDbPath && existsSync(opts.chatHistoryDbPath)) {
         try {
           migrateChatHistory({

--- a/packages/host/src/migrate/chat-history.test.ts
+++ b/packages/host/src/migrate/chat-history.test.ts
@@ -229,7 +229,7 @@ function readTranscript(agentRoot: string, key: string) {
   };
 }
 
-test("migrates linked conversations into v3 transcripts + a marker", () => {
+test("migrates linked conversations into v3 transcripts", () => {
   const { workspacesRoot, agentRoot, dbPath } = setup();
   const logs: string[] = [];
   const res = migrateChatHistory({
@@ -265,10 +265,6 @@ test("migrates linked conversations into v3 transcripts + a marker", () => {
     .map((m) => m.content);
   expect(bUser).toEqual(["Started on Claude", "Continued on Codex"]);
 
-  // Marker written.
-  const marker = join(agentRoot, ".houston", "runtime", ".migrated");
-  expect(statSync(marker).isFile()).toBe(true);
-
   // Orphan logged, not silently dropped.
   expect(logs.join("\n")).toContain("1 orphan conversation(s)");
 });
@@ -287,9 +283,10 @@ test("the synthesized pi session restores user/assistant TEXT via continueRecent
   const mgr = SessionManager.continueRecent(agentRoot, sessionDir);
   const ctx = mgr.buildSessionContext();
 
-  // user + assistant(final_result) + user + assistant(fallback chunks) = 4 msgs.
-  // NO tool/thinking/file entries leak into the agent's memory.
-  expect(ctx.messages).toHaveLength(4);
+  // user + assistant(final_result) + user + assistant(fallback chunks) + the
+  // imported-history boundary note = 5 msgs. NO tool/thinking/file entries
+  // leak into the agent's memory.
+  expect(ctx.messages).toHaveLength(5);
   const text = JSON.stringify(ctx.messages);
   expect(text).toContain("What's in the zip?");
   expect(text).toContain("It has keys and dotfiles.");
@@ -298,16 +295,27 @@ test("the synthesized pi session restores user/assistant TEXT via continueRecent
   expect(text).not.toContain("unzip");
   expect(text).not.toContain("[tool");
 
-  // Roles alternate user/assistant.
+  // The imported block is closed by the boundary note, as the LAST message —
+  // otherwise a stale imperative in old history reads as pending work (the
+  // "delete all of your routines" incident).
+  const last = ctx.messages[ctx.messages.length - 1] as {
+    role: string;
+    content: string;
+  };
+  expect(last.role).toBe("user");
+  expect(last.content).toContain("[Imported history]");
+
+  // Roles alternate user/assistant, closed by the boundary note.
   expect(ctx.messages.map((m: { role: string }) => m.role)).toEqual([
     "user",
     "assistant",
     "user",
     "assistant",
+    "user",
   ]);
 });
 
-test("a 2nd run is a no-op (marker + per-conversation guard) and writes nothing new", () => {
+test("a 2nd run is a no-op (per-conversation guard) and writes nothing new", () => {
   const { workspacesRoot, agentRoot, dbPath } = setup();
   migrateChatHistory({ workspacesRoot, dbPath });
 
@@ -319,6 +327,51 @@ test("a 2nd run is a no-op (marker + per-conversation guard) and writes nothing 
 
   const after = treeHashes(runtimeRoot);
   expect(after).toEqual(before); // byte-identical runtime tree
+});
+
+test("chats written AFTER an earlier run still migrate on the next boot", () => {
+  // The real-world interleave that once lost data: a TS build boots (migrates,
+  // and in the old design stamped a wholesale per-agent marker), then a
+  // Rust-era build writes NEW chats into the db, then the migration runs again
+  // (e.g. the cloud wizard's source host). The new conversation must migrate.
+  const { workspacesRoot, agentRoot, dbPath } = setup();
+  migrateChatHistory({ workspacesRoot, dbPath });
+
+  // A legacy wholesale marker from an old build must be ignored, not honored.
+  writeFileSync(
+    join(agentRoot, ".houston", "runtime", ".migrated"),
+    "2026-06-26T00:00:00.000Z",
+  );
+
+  // The Rust app appends a new conversation: tracker file + db rows.
+  writeTracker(agentRoot, "anthropic", "activity-LATE", "sid", "sid-LATE");
+  const db = new Database(dbPath, {});
+  const ins = db.query(
+    "INSERT INTO chat_feed (claude_session_id, feed_type, data_json, timestamp) VALUES (?,?,?,?)",
+  );
+  ins.run(
+    "sid-LATE",
+    "user_message",
+    s("Late chat"),
+    "2025-07-01T10:00:00.000Z",
+  );
+  ins.run(
+    "sid-LATE",
+    "final_result",
+    JSON.stringify({ result: "Late reply" }),
+    "2025-07-01T10:00:01.000Z",
+  );
+  db.close();
+
+  const res = migrateChatHistory({ workspacesRoot, dbPath });
+  expect(res.totalMigrated).toBe(1); // only the late conversation
+  expect(res.totalSkipped).toBe(2); // A and B untouched
+
+  const late = readTranscript(agentRoot, "activity-LATE");
+  expect(late.messages.map((m) => m.content)).toEqual([
+    "Late chat",
+    "Late reply",
+  ]);
 });
 
 test("the SOURCE db + agent tree are byte-identical after migration", () => {
@@ -343,7 +396,7 @@ test("the SOURCE db + agent tree are byte-identical after migration", () => {
   void root;
 });
 
-test("an agent with no tracker files is skipped cleanly (no runtime dir, no marker noise)", () => {
+test("an agent with no tracker files is skipped cleanly (nothing written)", () => {
   const root = mkdtempSync(join(tmpdir(), "hmig-empty-"));
   const workspacesRoot = join(root, "workspaces");
   const agentRoot = join(workspacesRoot, "Personal", "Bare");

--- a/packages/host/src/migrate/chat-history.ts
+++ b/packages/host/src/migrate/chat-history.ts
@@ -9,7 +9,13 @@ import {
 import { join } from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { sessionGroupsForAgent } from "./linkage";
-import { messageFor, reconstruct, rowTs, titleFor } from "./reconstruct";
+import {
+  importedHistoryNote,
+  messageFor,
+  reconstruct,
+  rowTs,
+  titleFor,
+} from "./reconstruct";
 import { Database } from "./sqlite";
 import type { ChatFeedRow, SessionPair, StoredConversation } from "./types";
 
@@ -21,8 +27,11 @@ import type { ChatFeedRow, SessionPair, StoredConversation } from "./types";
  *
  * Strictly additive + idempotent: we only WRITE new files under
  * `<agentRoot>/.houston/runtime/`. We NEVER modify, lock, or delete the source
- * db or any existing tree file. The db is opened READ-ONLY. A per-agent
- * `.migrated` marker plus a per-conversation existence check make re-runs no-ops.
+ * db or any existing tree file. The db is opened READ-ONLY. A per-conversation
+ * existence check makes re-runs no-ops — deliberately NO per-agent marker: a
+ * wholesale skip once lost every chat written by a Rust-era build AFTER the
+ * marker was stamped (old and new apps interleave on real machines, and the
+ * migration wizard's own source-host boot stamps first).
  *
  * Linkage (verified, see linkage.ts): the `.sid`/`.history` tracker files per
  * agent map a `session_key` (= conversation id) to its `claude_session_id`s.
@@ -31,7 +40,6 @@ import type { ChatFeedRow, SessionPair, StoredConversation } from "./types";
  */
 
 const RUNTIME_REL = join(".houston", "runtime");
-const MARKER_NAME = ".migrated";
 
 // ---------------------------------------------------------------------------
 // Results + options.
@@ -43,8 +51,6 @@ export interface MigrateAgentResult {
   migrated: number;
   /** Conversations already present (idempotent skip). */
   skipped: number;
-  /** Whether the agent was skipped wholesale via its `.migrated` marker. */
-  alreadyMarked: boolean;
 }
 
 export interface MigrateResult {
@@ -108,10 +114,15 @@ function synthesizeSession(
   if (!hasAssistant) return;
 
   const mgr = SessionManager.create(workspaceDir, sessionDir);
+  let lastTs = 0;
   for (const p of pairs) {
     if (!p.content) continue;
     mgr.appendMessage(messageFor(p));
+    if (p.ts > lastTs) lastTs = p.ts;
   }
+  // Close the imported block so the next live turn treats it as a record, not
+  // as pending instructions (see IMPORTED_HISTORY_NOTE for the incident).
+  mgr.appendMessage(importedHistoryNote(lastTs));
 }
 
 // ---------------------------------------------------------------------------
@@ -135,20 +146,10 @@ export function migrateAgentChatHistory(
   const runtimeDir = join(agentRoot, RUNTIME_REL);
   const conversationsDir = join(runtimeDir, "conversations");
   const sessionsOutDir = join(runtimeDir, "sessions");
-  const marker = join(runtimeDir, MARKER_NAME);
 
   const groups = sessionGroupsForAgent(agentRoot);
   if (referenced)
     for (const set of groups.values()) for (const id of set) referenced.add(id);
-
-  if (existsSync(marker)) {
-    return {
-      agentRoot,
-      migrated: 0,
-      skipped: groups.size,
-      alreadyMarked: true,
-    };
-  }
 
   // One reusable statement for all of this agent's ids.
   const stmt = db.query<ChatFeedRow, [string]>(
@@ -198,10 +199,12 @@ export function migrateAgentChatHistory(
     migrated++;
   }
 
-  mkdirSync(runtimeDir, { recursive: true });
-  writeFileSync(marker, new Date().toISOString());
-  log(`[migrate:chat] ${agentRoot}: migrated ${migrated}, skipped ${skipped}`);
-  return { agentRoot, migrated, skipped, alreadyMarked: false };
+  if (migrated > 0) {
+    log(
+      `[migrate:chat] ${agentRoot}: migrated ${migrated}, skipped ${skipped}`,
+    );
+  }
+  return { agentRoot, migrated, skipped };
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/host/src/migrate/reconstruct.ts
+++ b/packages/host/src/migrate/reconstruct.ts
@@ -189,6 +189,30 @@ export function reconstruct(rows: ChatFeedRow[]): {
 }
 
 /**
+ * The FINAL user message of every synthesized (imported) session, so the next
+ * live turn cannot mistake old imperatives for pending work. Real incident: a
+ * migrated "delete all of your routines" thread made the agent verify the
+ * filesystem on its first post-import turn and wipe the freshly migrated
+ * routines.json ("Sorry — one routine was still there. I've now removed it.").
+ */
+export const IMPORTED_HISTORY_NOTE =
+  "[Imported history] The messages above were imported from my previous " +
+  "Houston installation. They are a read-only record of past conversations, " +
+  "not pending work: do not resume, redo, or undo anything mentioned in them " +
+  "(deleting routines or files, sending anything, changing settings) unless " +
+  "I ask again in a new message after this one.";
+
+/** The imported-history boundary as a pi user message. `ts` should be the last
+ * imported message's timestamp so session ordering stays monotonic. */
+export function importedHistoryNote(ts: number): Message {
+  return {
+    role: "user",
+    content: IMPORTED_HISTORY_NOTE,
+    timestamp: ts || Date.now(),
+  };
+}
+
+/**
  * A pi-ai Message for one user/assistant pair. The literals mirror exactly what
  * packages/runtime/src/session/resume.test.ts proves restores via
  * continueRecent() (same field set the SDK persists for a real turn).

--- a/packages/host/src/routes/migration-import.ts
+++ b/packages/host/src/routes/migration-import.ts
@@ -3,7 +3,7 @@ import { join } from "node:path";
 import { SessionManager } from "@earendil-works/pi-coding-agent";
 import { type AgentFileChangeEvent, agentFileEventType } from "@houston/domain";
 import { unzipSync } from "fflate";
-import { messageFor } from "../migrate/reconstruct";
+import { importedHistoryNote, messageFor } from "../migrate/reconstruct";
 import type { StoredConversation } from "../migrate/types";
 import type { Vfs } from "../vfs";
 import { safeSeedKey } from "./agent-seed";
@@ -67,11 +67,16 @@ function synthesizeSessionFromTranscript(
   );
   if (!pairs.some((m) => m.role === "assistant")) return;
   const mgr = SessionManager.create(agentDir, sessionDir);
+  let lastTs = 0;
   for (const m of pairs) {
     mgr.appendMessage(
       messageFor({ role: m.role, content: m.content, ts: m.ts }),
     );
+    if (m.ts > lastTs) lastTs = m.ts;
   }
+  // Close the imported block so the next live turn treats it as a record, not
+  // as pending instructions (see IMPORTED_HISTORY_NOTE for the incident).
+  mgr.appendMessage(importedHistoryNote(lastTs));
 }
 
 export async function applyMigrationArchive(opts: {

--- a/packages/host/src/routes/migration.test.ts
+++ b/packages/host/src/routes/migration.test.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdtempSync, readdirSync, rmSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -320,7 +326,13 @@ test("imported transcripts re-synthesize pi sessions anchored at agentDir", asyn
     "activity-1",
   );
   expect(existsSync(sessionDir)).toBe(true);
-  expect(readdirSync(sessionDir).length).toBeGreaterThan(0);
+  const sessionFiles = readdirSync(sessionDir);
+  expect(sessionFiles.length).toBeGreaterThan(0);
+  // The imported block is closed by the boundary note so a stale imperative in
+  // old history can never read as pending work on the first post-import turn.
+  const jsonl = readFileSync(join(sessionDir, sessionFiles[0] ?? ""), "utf8");
+  const lines = jsonl.trim().split("\n");
+  expect(lines[lines.length - 1]).toContain("[Imported history]");
   // Re-import: transcript skip-existing AND the session dir left untouched.
   const again = await call(
     vfs,


### PR DESCRIPTION
## Problem

Two data-loss bugs in the desktop→cloud migration (HOU-719 follow-up), both found while migrating a real machine:

**1. Chats written after a marker stamp were silently lost.** `migrateAgentChatHistory` skipped the whole agent when `.houston/runtime/.migrated` existed. The marker is stamped by any TS-engine boot — including the migration wizard's own passive source host — so any chat written by a Rust-era build *after* that stamp (old/new apps interleave on real machines: downgrades, side-by-side use, try-the-cloud-then-migrate-later) was never converted. Symptom: migrated missions show their board card title/description but an empty chat.

**2. Imported session memory replayed stale instructions.** Synthesized pi sessions rebuild raw user/assistant text from old transcripts. On the first live turn after migration, the agent can treat an old imperative as pending work. Observed incident: a months-old "Please delete all of your routines" thread made the agent verify the filesystem, find the freshly migrated routine "still there", and write `[]` to `routines.json` ("Sorry — one routine was still there. I've now removed it.") — which presented as "my routines were not migrated".

## Fix

- **Drop the wholesale marker fast-path.** Per-conversation `existsSync` checks already make re-runs idempotent; the marker is no longer written and legacy markers are ignored. Every boot re-scans tracker keys against the db (cheap: only when `db/houston.db` exists; skipped conversations cost one existence check each).
- **Close every synthesized session with an imported-history boundary note** (`IMPORTED_HISTORY_NOTE` in `migrate/reconstruct.ts`), appended by both synthesis paths — the boot chat-history migration and the pod-side `migration/import` re-synthesis — telling the agent the prior messages are a read-only record, not pending work.

## Tests

- New regression: chats appended to the db after an earlier run (plus a legacy `.migrated` marker on disk) still migrate on the next boot.
- Session-synthesis tests on both paths assert the boundary note is the final session message.
- Existing suites updated for the removed marker; full `@houston/host` + `@houston/domain` suites green (1057 tests).

## Notes

- The source db stays read-only and untouched; conversion remains strictly additive.
- Recovery for already-affected installs: re-running the migration (any host boot with this fix) emits the missing transcripts; the import route's skip-existing then lands them on the cloud agent without touching anything newer.