### PR TITLE
fix(app): restore cached chats before board reads

### DIFF
--- a/app/src/components/shell/query-persistence-provider.tsx
+++ b/app/src/components/shell/query-persistence-provider.tsx
@@ -1,0 +1,38 @@
+import { useQueryClient } from "@tanstack/react-query";
+import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
+import { type ReactNode, useMemo } from "react";
+import { logger } from "../../lib/logger";
+import { queryPersistenceOptions } from "../../lib/query-persist";
+
+/**
+ * Restores cloud list queries before their observers start network reads.
+ *
+ * This lives inside EngineGate because the persistence buster needs the hosted
+ * user's JWT, and nests the same QueryClient so EngineGate's session query can
+ * run before restoration. PersistQueryClientProvider still mounts the shell,
+ * but pauses descendant query fetches until IndexedDB hydration settles.
+ */
+export function QueryPersistenceProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const queryClient = useQueryClient();
+  const persistOptions = useMemo(
+    () => queryPersistenceOptions(queryClient),
+    [queryClient],
+  );
+
+  if (!persistOptions) return <>{children}</>;
+  return (
+    <PersistQueryClientProvider
+      client={queryClient}
+      persistOptions={persistOptions}
+      onError={() => {
+        logger.warn("[query-persist] restore failed; using network data");
+      }}
+    >
+      {children}
+    </PersistQueryClientProvider>
+  );
+}

--- a/app/src/lib/query-persist.ts
+++ b/app/src/lib/query-persist.ts
@@ -22,8 +22,7 @@ import {
 } from "@houston-ai/engine-client";
 import { createAsyncStoragePersister } from "@tanstack/query-async-storage-persister";
 import type { QueryClient } from "@tanstack/react-query";
-import { persistQueryClient } from "@tanstack/react-query-persist-client";
-import { whenEngineReady } from "./engine";
+import type { PersistQueryClientOptions } from "@tanstack/react-query-persist-client";
 import { logger } from "./logger";
 import {
   isPersistedQueryKey,
@@ -82,43 +81,41 @@ function queryPersistScope(): string | null {
   return conversationCacheScope(engine.baseUrl, engine.token);
 }
 
+export type QueryPersistenceOptions = Omit<
+  PersistQueryClientOptions,
+  "queryClient"
+>;
+
 /**
- * Start list-query persistence once the engine handshake (and, hosted, the
- * signed-in Supabase bearer) is in place. Restores persisted lists into the
- * cache, then mirrors every whitelisted cache change back to disk. No cloud
- * identity (local sidecar, static tokens, tests) → no-op. Never throws — a
- * broken IndexedDB degrades to exactly today's network-only behavior.
+ * Build the provider options after EngineGate has established the hosted user.
+ * The provider owns restore ordering: observers may mount, but their fetches
+ * stay paused until hydration finishes. Cached lists can paint before a cold
+ * pod read, and fresh results cannot be missed before persistence subscribes.
+ * No cloud identity means no persistence.
  */
-export async function setupQueryPersistence(
+export function queryPersistenceOptions(
   queryClient: QueryClient,
-): Promise<void> {
-  try {
-    await whenEngineReady();
-    const scope = queryPersistScope();
-    if (!scope || typeof indexedDB === "undefined") return;
-    // Restored-but-not-yet-observed queries must outlive the in-memory GC for
-    // as long as they are restorable, or the persist mirror drops them from
-    // disk before the user revisits that agent (see query-persist-policy.ts).
-    for (const prefix of PERSISTED_QUERY_PREFIXES) {
-      queryClient.setQueryDefaults([prefix], { gcTime: PERSIST_MAX_AGE_MS });
-    }
-    persistQueryClient({
-      queryClient,
-      persister: createAsyncStoragePersister({
-        storage: idbStorage,
-        key: PERSIST_KEY,
-      }),
-      maxAge: PERSIST_MAX_AGE_MS,
-      buster: scope,
-      dehydrateOptions: {
-        shouldDehydrateQuery: (query) =>
-          query.state.status === "success" &&
-          isPersistedQueryKey(query.queryKey),
-      },
-    });
-  } catch (err) {
-    logger.warn(`[query-persist] disabled — persistence failed: ${err}`);
+): QueryPersistenceOptions | null {
+  const scope = queryPersistScope();
+  if (!scope || typeof indexedDB === "undefined") return null;
+  // Restored-but-not-yet-observed queries must outlive the in-memory GC for
+  // as long as they are restorable, or the persist mirror drops them from
+  // disk before the user revisits that agent (see query-persist-policy.ts).
+  for (const prefix of PERSISTED_QUERY_PREFIXES) {
+    queryClient.setQueryDefaults([prefix], { gcTime: PERSIST_MAX_AGE_MS });
   }
+  return {
+    persister: createAsyncStoragePersister({
+      storage: idbStorage,
+      key: PERSIST_KEY,
+    }),
+    maxAge: PERSIST_MAX_AGE_MS,
+    buster: scope,
+    dehydrateOptions: {
+      shouldDehydrateQuery: (query) =>
+        query.state.status === "success" && isPersistedQueryKey(query.queryKey),
+    },
+  };
 }
 
 /**

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -9,13 +9,13 @@ import "./styles/globals.css";
 import { DisclaimerGate } from "./components/shell/disclaimer-gate";
 import { EngineGate } from "./components/shell/engine-gate";
 import { LanguageGate } from "./components/shell/language-gate";
+import { QueryPersistenceProvider } from "./components/shell/query-persistence-provider";
 import { analytics, classifyAnalyticsError } from "./lib/analytics";
 import { whenEngineReady } from "./lib/engine";
 import { showErrorToast } from "./lib/error-toast";
 import { installGlobalErrorHandlers } from "./lib/global-error-handlers";
 import i18n from "./lib/i18n";
 import { initFrontendLogging, logger } from "./lib/logger";
-import { setupQueryPersistence } from "./lib/query-persist";
 import { initSentry } from "./lib/sentry";
 import { installSentrySmokeShortcuts } from "./lib/sentry-smoke";
 import { runStartupAnalytics } from "./lib/startup-analytics";
@@ -45,13 +45,6 @@ initFrontendLogging();
 // can't drift. Must run AFTER initFrontendLogging() so the console.error → log
 // file patch is already in place.
 installGlobalErrorHandlers();
-
-// List-query persistence (HOU-712 follow-up): once the engine handshake (and,
-// hosted, the signed-in bearer) is in, restore the persisted conversation
-// lists/activities so the sidebar and board paint instantly through an
-// engine-pod cold start. No cloud identity → no-op. Mirrored in the web entry
-// (packages/web/src/app-tree.tsx).
-void setupQueryPersistence(queryClient);
 
 class ErrorBoundary extends Component<
   { children: ReactNode },
@@ -159,11 +152,13 @@ createRoot(rootElement).render(
         <TooltipProvider>
           <StartupEffects>
             <EngineGate>
-              <LanguageGate>
-                <DisclaimerGate>
-                  <App />
-                </DisclaimerGate>
-              </LanguageGate>
+              <QueryPersistenceProvider>
+                <LanguageGate>
+                  <DisclaimerGate>
+                    <App />
+                  </DisclaimerGate>
+                </LanguageGate>
+              </QueryPersistenceProvider>
             </EngineGate>
           </StartupEffects>
         </TooltipProvider>

--- a/app/tests/query-persist-policy.test.ts
+++ b/app/tests/query-persist-policy.test.ts
@@ -28,8 +28,8 @@ describe("query persist policy", () => {
   it("keeps restorable age and in-memory gc in lockstep", () => {
     // The persister mirrors the in-memory cache: a restored query must stay
     // in memory (gcTime) for as long as it is restorable (maxAge), or the
-    // next persist sweep drops it from disk. setupQueryPersistence uses this
-    // ONE constant for both — the invariant this test pins.
+    // next persist sweep drops it from disk. queryPersistenceOptions uses this
+    // ONE constant for both, the invariant this test pins.
     ok(PERSIST_MAX_AGE_MS >= 24 * 60 * 60 * 1_000);
     equal(PERSISTED_QUERY_PREFIXES.length, 3);
   });

--- a/packages/web/e2e/board.spec.ts
+++ b/packages/web/e2e/board.spec.ts
@@ -13,6 +13,86 @@ test("renders the seeded missions on the board", async ({ page }) => {
   await expect(page.getByText("Draft the launch email")).toBeVisible();
 });
 
+test("restores cached missions before starting fresh board reads", async ({
+  page,
+}) => {
+  // The standard fake-host token is deliberately non-user-scoped, which turns
+  // persistence off. Give this test a JWT-shaped per-user token; the fake host
+  // accepts it, while the cache correctly scopes itself to `e2e-user`.
+  await page.addInitScript(() => {
+    const key = "houston.web.engine.new";
+    const config = JSON.parse(localStorage.getItem(key) ?? "{}");
+    localStorage.setItem(
+      key,
+      JSON.stringify({
+        ...config,
+        token: "e30.eyJzdWIiOiJlMmUtdXNlciJ9.sig",
+      }),
+    );
+  });
+  await page.goto("/");
+  await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+
+  // Let the async persister commit this populated board, then make its next
+  // IndexedDB read visibly slow. This pins the startup race: no activity read
+  // may start while the older, populated cache is still being restored.
+  await page.waitForFunction(
+    () =>
+      new Promise<boolean>((resolve) => {
+        const open = indexedDB.open("houston-query-cache", 1);
+        open.onsuccess = () => {
+          const request = open.result
+            .transaction("kv", "readonly")
+            .objectStore("kv")
+            .get("houston.list-queries");
+          request.onsuccess = () => resolve(typeof request.result === "string");
+          request.onerror = () => resolve(false);
+        };
+        open.onerror = () => resolve(false);
+      }),
+  );
+  await page.addInitScript(() => {
+    const nativeGet = IDBObjectStore.prototype.get;
+    IDBObjectStore.prototype.get = function delayedGet(query) {
+      const nativeRequest = nativeGet.call(this, query);
+      const delayedRequest = {
+        error: null as DOMException | null,
+        onsuccess: null as ((event: Event) => void) | null,
+        onerror: null as ((event: Event) => void) | null,
+        get result() {
+          return nativeRequest.result;
+        },
+      } as IDBRequest;
+      (
+        window as typeof window & { __queryRestoreStarted?: boolean }
+      ).__queryRestoreStarted = true;
+      nativeRequest.addEventListener("success", (event) => {
+        setTimeout(() => delayedRequest.onsuccess?.(event), 500);
+      });
+      nativeRequest.addEventListener("error", (event) => {
+        setTimeout(() => delayedRequest.onerror?.(event), 500);
+      });
+      return delayedRequest;
+    };
+  });
+
+  let activityReads = 0;
+  await page.route("**/agents/*/activities", async (route) => {
+    if (route.request().method() === "GET") activityReads += 1;
+    await route.continue();
+  });
+  await page.reload();
+  await page.waitForFunction(
+    () =>
+      (window as typeof window & { __queryRestoreStarted?: boolean })
+        .__queryRestoreStarted === true,
+  );
+  await page.waitForTimeout(100);
+
+  expect(activityReads).toBe(0);
+  await expect(page.getByText("Plan a trip to Tokyo")).toBeVisible();
+});
+
 test("opens a mission's chat when its card is clicked", async ({ page }) => {
   await page.goto("/");
 

--- a/packages/web/src/app-tree.tsx
+++ b/packages/web/src/app-tree.tsx
@@ -16,6 +16,7 @@
 import App from "@houston/app/App";
 import { DisclaimerGate } from "@houston/app/components/shell/disclaimer-gate";
 import { LanguageGate } from "@houston/app/components/shell/language-gate";
+import { QueryPersistenceProvider } from "@houston/app/components/shell/query-persistence-provider";
 import { WorkspaceLoading } from "@houston/app/components/shell/workspace-loading";
 import { analytics, classifyAnalyticsError } from "@houston/app/lib/analytics";
 import { isEngineReady, whenEngineReady } from "@houston/app/lib/engine";
@@ -24,7 +25,6 @@ import { installGlobalErrorHandlers } from "@houston/app/lib/global-error-handle
 import i18n from "@houston/app/lib/i18n";
 import { initFrontendLogging, logger } from "@houston/app/lib/logger";
 import { queryClient } from "@houston/app/lib/query-client";
-import { setupQueryPersistence } from "@houston/app/lib/query-persist";
 import { initSentry } from "@houston/app/lib/sentry";
 import { TooltipProvider } from "@houston-ai/core";
 import { QueryClientProvider } from "@tanstack/react-query";
@@ -46,12 +46,6 @@ initFrontendLogging();
 // noise (Supabase Web Locks steal, HOU-435). Must run AFTER initFrontendLogging()
 // so the console.error → log file patch is already in place.
 installGlobalErrorHandlers();
-
-// List-query persistence (HOU-712 follow-up) — shared with the desktop entry
-// (app/src/main.tsx): restore persisted conversation lists/activities so the
-// sidebar/board paint instantly through an engine-pod cold start. No cloud
-// identity → no-op.
-void setupQueryPersistence(queryClient);
 
 class ErrorBoundary extends Component<
   { children: ReactNode },
@@ -143,17 +137,19 @@ export default function AppTree() {
       <ErrorBoundary>
         <TooltipProvider>
           <EngineGate>
-            <I18nextProvider i18n={i18n}>
-              {/* Web-only "Preview" pill — fixed + pointer-events-none, so it
-                  overlays every gate/screen without disturbing layout or clicks.
-                  Renders null off the preview deployment. */}
-              <PreviewBadge />
-              <LanguageGate>
-                <DisclaimerGate>
-                  <App />
-                </DisclaimerGate>
-              </LanguageGate>
-            </I18nextProvider>
+            <QueryPersistenceProvider>
+              <I18nextProvider i18n={i18n}>
+                {/* Web-only "Preview" pill — fixed + pointer-events-none, so it
+                    overlays every gate/screen without disturbing layout or clicks.
+                    Renders null off the preview deployment. */}
+                <PreviewBadge />
+                <LanguageGate>
+                  <DisclaimerGate>
+                    <App />
+                  </DisclaimerGate>
+                </LanguageGate>
+              </I18nextProvider>
+            </QueryPersistenceProvider>
           </EngineGate>
         </TooltipProvider>
       </ErrorBoundary>


### PR DESCRIPTION
## Summary
- restore persisted activity/conversation queries before descendant board reads begin
- use TanStack's persistence provider in both desktop and web app trees
- add a deterministic browser regression test that delays IndexedDB hydration and verifies no activity request races it

## Root cause
List-query persistence was started fire-and-forget before the app mounted. IndexedDB restoration and activity queries could therefore run concurrently, leaving the initial board without its cached missions until switching agents caused a later read.

## Verification
- `pnpm check`
- `pnpm --filter houston-app test` (1,495 passed)
- `pnpm --filter houston-app typecheck`
- `pnpm --filter houston-web typecheck`
- `pnpm --filter houston-web typecheck:e2e`
- Chromium board E2E suite (6 passed)
- targeted WebKit persistence regression (passed)
