### PR TITLE
feat(store): browse the Agent Store inside the app + one-click install

### DIFF
--- a/app/src/components/command-palette.tsx
+++ b/app/src/components/command-palette.tsx
@@ -10,7 +10,7 @@ import {
   HoustonAvatar,
   resolveAgentColor,
 } from "@houston-ai/core";
-import { Keyboard, LayoutDashboard, Plus, Settings } from "lucide-react";
+import { Keyboard, LayoutDashboard, Plus, Settings, Store } from "lucide-react";
 import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { DEFAULT_TAB_ID } from "../agents/standard-tabs";
@@ -22,6 +22,7 @@ import { shortcutLabel } from "../lib/shortcuts";
 import { useAgentStore } from "../stores/agents";
 import { useUIStore } from "../stores/ui";
 import { useWorkspaceStore } from "../stores/workspaces";
+import { STORE_VIEW_ID } from "./store-view";
 
 // 28px outer circle so the inner helmet (forced to 20px by cmdk's
 // `[&_[cmdk-item]_svg]:h-5` rule) sits at roughly its native 65%
@@ -164,6 +165,16 @@ export function CommandPalette() {
             <LayoutDashboard />
             <span>{t("shell:palette.actions.missionControl")}</span>
             <CommandShortcut>{shortcutLabel("missionControl")}</CommandShortcut>
+          </CommandItem>
+          <CommandItem
+            onSelect={() => {
+              setViewMode(STORE_VIEW_ID);
+              close();
+            }}
+            value="action agent-store"
+          >
+            <Store />
+            <span>{t("shell:sidebar.agentStore")}</span>
           </CommandItem>
           <CommandItem
             onSelect={() => {

--- a/app/src/components/portable/import-wizard.tsx
+++ b/app/src/components/portable/import-wizard.tsx
@@ -48,6 +48,7 @@ import { useAgentStore } from "../../stores/agents";
 import { useUIStore } from "../../stores/ui";
 import { useWorkspaceStore } from "../../stores/workspaces";
 import { ChatModelSelector } from "../chat-model-selector";
+import { STORE_VIEW_ID } from "../store-view";
 import { InstallFromLinkPanel } from "./install-from-link";
 
 type StepId = "upload" | "name" | "skills" | "routines" | "learnings";
@@ -152,6 +153,17 @@ export function ImportAgentWizard() {
       !prev && result.manifest.agentName ? result.manifest.agentName : prev,
     );
   }, []);
+
+  // The Agent Store's one-click install opens the wizard with the preview
+  // already fetched: adopt the one-shot seed on open, exactly as if the user
+  // had pasted the listing's link — the scan choice and every later step stay
+  // in the flow untouched.
+  const seedPreview = useUIStore((s) => s.importSeedPreview);
+  useEffect(() => {
+    if (!open || !seedPreview) return;
+    useUIStore.getState().setImportSeedPreview(null);
+    applyPreview(seedPreview);
+  }, [open, seedPreview, applyPreview]);
 
   const handleOpenFile = async () => {
     try {
@@ -440,6 +452,17 @@ function UploadStep({
             </span>
           </div>
           <InstallFromLinkPanel onPreview={onPreview} />
+          <button
+            type="button"
+            onClick={() => {
+              const ui = useUIStore.getState();
+              ui.setImportFromFriendOpen(false);
+              ui.setViewMode(STORE_VIEW_ID);
+            }}
+            className="text-sm text-ink-muted underline-offset-4 transition-colors hover:text-ink hover:underline"
+          >
+            {t("import.link.browseStore")}
+          </button>
         </div>
       ) : (
         <section className="space-y-2 text-sm">

--- a/app/src/components/portable/manage-publication.tsx
+++ b/app/src/components/portable/manage-publication.tsx
@@ -7,6 +7,9 @@
 import { Button, ConfirmDialog } from "@houston-ai/core";
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
+import { useUIStore } from "../../stores/ui";
+import { STORE_VIEW_ID } from "../store-view";
+import { storeSlugFromShareUrl } from "../store-view/store-view-model";
 import { ShareLink, UnlistedNote } from "./share-screen";
 
 export function ManagePublication({
@@ -24,6 +27,7 @@ export function ManagePublication({
 }) {
   const { t } = useTranslation("portable");
   const [confirming, setConfirming] = useState(false);
+  const storeSlug = storeSlugFromShareUrl(shareUrl);
 
   return (
     <div className="space-y-8">
@@ -44,6 +48,21 @@ export function ManagePublication({
           <Button className="rounded-full" onClick={onUpdate} disabled={busy}>
             {t("publish.manage.update")}
           </Button>
+          {storeSlug && (
+            <Button
+              variant="outline"
+              className="rounded-full"
+              disabled={busy}
+              onClick={() => {
+                const ui = useUIStore.getState();
+                ui.setShareAgentId(null);
+                ui.setStoreFocusSlug(storeSlug);
+                ui.setViewMode(STORE_VIEW_ID);
+              }}
+            >
+              {t("publish.manage.seeInStore")}
+            </Button>
+          )}
           <Button
             variant="outline"
             className="rounded-full text-destructive hover:text-destructive"

--- a/app/src/components/shell/sidebar-chrome.tsx
+++ b/app/src/components/shell/sidebar-chrome.tsx
@@ -7,12 +7,14 @@ import {
   Building2,
   LayoutDashboard,
   Settings,
+  Store,
 } from "lucide-react";
 import { useState } from "react";
 import { useCapabilities } from "../../hooks/use-capabilities";
 import { hasSpaces } from "../../lib/org-roles";
 import { INTEGRATIONS_VIEW_ID } from "../integrations-view";
 import { ORGANIZATION_VIEW_ID } from "../organization";
+import { STORE_VIEW_ID } from "../store-view";
 import { CreateTeamDialog } from "./create-team-dialog";
 
 type ShellT = TFunction<["shell", "common", "portable", "teams"]>;
@@ -58,6 +60,13 @@ export function buildSidebarNavItems(args: {
           },
         ]
       : []),
+    {
+      id: STORE_VIEW_ID,
+      label: t("shell:sidebar.agentStore"),
+      icon: <Store className="h-4 w-4" />,
+      onClick: () => setViewMode(STORE_VIEW_ID),
+      dataAttrs: { "data-tour-target": "nav-agent-store" },
+    },
     ...(showOrganization
       ? [
           {

--- a/app/src/components/shell/workspace-shell.tsx
+++ b/app/src/components/shell/workspace-shell.tsx
@@ -56,6 +56,7 @@ import { ExportAgentWizard } from "../portable/export-wizard";
 import { ImportAgentWizard } from "../portable/import-wizard";
 import { SettingsView } from "../settings/settings-view";
 import { ShortcutCheatsheet } from "../shortcut-cheatsheet";
+import { STORE_VIEW_ID, StoreView } from "../store-view";
 import { AgentShareButton } from "../tabs/agent-share-button";
 import { AgentWarmingDialog } from "./agent-warming-dialog";
 import { CreateAgentDialog } from "./create-workspace-dialog";
@@ -233,6 +234,8 @@ export function WorkspaceShell({
                     <SettingsView />
                   ) : viewMode === INTEGRATIONS_VIEW_ID && showIntegrations ? (
                     <IntegrationsView />
+                  ) : viewMode === STORE_VIEW_ID ? (
+                    <StoreView />
                   ) : viewMode === ORGANIZATION_VIEW_ID && showOrganization ? (
                     <OrganizationView />
                   ) : currentAgent && agentDef && isAgentView ? (

--- a/app/src/components/store-view/id.ts
+++ b/app/src/components/store-view/id.ts
@@ -1,0 +1,2 @@
+/** The Agent Store top-level view id (sidebar destination). */
+export const STORE_VIEW_ID = "agent-store";

--- a/app/src/components/store-view/index.ts
+++ b/app/src/components/store-view/index.ts
@@ -1,0 +1,2 @@
+export { STORE_VIEW_ID } from "./id";
+export { StoreView } from "./store-view";

--- a/app/src/components/store-view/store-agent-icon.tsx
+++ b/app/src/components/store-view/store-agent-icon.tsx
@@ -1,0 +1,27 @@
+import type { StoreCatalogAgent } from "@houston-ai/engine-client";
+import { storeAgentGlyph } from "./store-view-model";
+
+/**
+ * A listing's leading art (~40px), the same slot every catalog row leads
+ * with: the agent's emoji on a quiet chip, or a letter avatar fallback.
+ * Decorative — the row/dialog title carries the accessible name.
+ */
+export function StoreAgentIcon({
+  agent,
+  className = "size-10 text-xl",
+}: {
+  agent: Pick<StoreCatalogAgent, "name" | "icon">;
+  className?: string;
+}) {
+  const glyph = storeAgentGlyph(agent);
+  return (
+    <span
+      aria-hidden
+      className={`flex shrink-0 items-center justify-center rounded-xl bg-chip ${
+        glyph.kind === "letter" ? "font-semibold text-ink-muted" : ""
+      } ${className}`}
+    >
+      {glyph.value}
+    </span>
+  );
+}

--- a/app/src/components/store-view/store-detail-dialog.tsx
+++ b/app/src/components/store-view/store-detail-dialog.tsx
@@ -1,0 +1,118 @@
+import { Badge, Button, CatalogDetailDialog, Spinner } from "@houston-ai/core";
+import type { StoreCatalogAgent } from "@houston-ai/engine-client";
+import { fetchStoreAgent } from "@houston-ai/engine-client";
+import { useQuery } from "@tanstack/react-query";
+import { useTranslation } from "react-i18next";
+import {
+  isStoreCategory,
+  storeCategoryLabelKey,
+} from "../../lib/store-categories";
+import { StoreAgentIcon } from "./store-agent-icon";
+
+/**
+ * A listing's "more info" modal — the catalog family's detail surface. The
+ * summary renders immediately from the row's data; the IR extras (skills,
+ * learnings) stream in from the detail endpoint. The footer CTA is the same
+ * one-click install the row's `+` runs.
+ */
+export function StoreDetailDialog({
+  agent,
+  onClose,
+  onInstall,
+  installing,
+}: {
+  agent: StoreCatalogAgent | null;
+  onClose: () => void;
+  onInstall: (slug: string) => void;
+  installing: boolean;
+}) {
+  const { t } = useTranslation("store");
+  const { t: tPortable } = useTranslation("portable");
+  const slug = agent?.slug ?? null;
+
+  const detail = useQuery({
+    queryKey: ["store-agent", slug],
+    queryFn: () => fetchStoreAgent(slug ?? ""),
+    enabled: slug !== null,
+    staleTime: 60_000,
+  });
+
+  if (!agent || !slug) return null;
+
+  const skills = detail.data?.ir.skills ?? [];
+  const learnings = detail.data?.ir.learnings ?? [];
+  const categoryLabel = isStoreCategory(agent.category)
+    ? tPortable(storeCategoryLabelKey(agent.category))
+    : agent.category;
+
+  return (
+    <CatalogDetailDialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+      icon={<StoreAgentIcon agent={agent} />}
+      title={agent.name}
+      tags={
+        <>
+          <Badge variant="secondary">{categoryLabel}</Badge>
+          {agent.tags.map((tag) => (
+            <Badge key={tag} variant="outline">
+              {tag}
+            </Badge>
+          ))}
+        </>
+      }
+      description={agent.description}
+      action={
+        <Button
+          onClick={() => onInstall(slug)}
+          disabled={installing}
+          className="rounded-full"
+        >
+          {installing && <Spinner className="size-4" />}
+          {t("install")}
+        </Button>
+      }
+    >
+      <div className="space-y-3 text-sm">
+        <p className="text-ink-muted">
+          {t("detail.by", { name: agent.creator.displayName })}
+          {" · "}
+          {t("installs", { count: agent.installsCount })}
+        </p>
+        {skills.length > 0 && (
+          <div>
+            <p className="mb-1.5 font-medium text-ink">{t("detail.skills")}</p>
+            <div className="flex flex-wrap gap-1.5">
+              {skills.map((skill) => (
+                <Badge key={skill.slug} variant="outline">
+                  {skill.slug}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+        {agent.integrations.length > 0 && (
+          <div>
+            <p className="mb-1.5 font-medium text-ink">
+              {t("detail.integrations")}
+            </p>
+            <div className="flex flex-wrap gap-1.5">
+              {agent.integrations.map((toolkit) => (
+                <Badge key={toolkit} variant="outline">
+                  {toolkit.toLowerCase()}
+                </Badge>
+              ))}
+            </div>
+          </div>
+        )}
+        {learnings.length > 0 && (
+          <p className="text-ink-muted">
+            {t("detail.learnings", { count: learnings.length })}
+          </p>
+        )}
+      </div>
+    </CatalogDetailDialog>
+  );
+}

--- a/app/src/components/store-view/store-filters.tsx
+++ b/app/src/components/store-view/store-filters.tsx
@@ -1,0 +1,83 @@
+import type { StoreCatalogSort } from "@houston-ai/engine-client";
+import { useTranslation } from "react-i18next";
+import {
+  STORE_CATEGORIES,
+  storeCategoryLabelKey,
+} from "../../lib/store-categories";
+
+/** The category pill strip: "All" plus the store's 14 seeded categories,
+ *  labelled from the SAME i18n entries the publish wizard's select uses. */
+export function StoreCategoryChips({
+  category,
+  onCategoryChange,
+}: {
+  /** The active category slug, or "all". */
+  category: string;
+  onCategoryChange: (category: string) => void;
+}) {
+  const { t } = useTranslation("store");
+  const { t: tPortable } = useTranslation("portable");
+  const chips: Array<{ slug: string; label: string }> = [
+    { slug: "all", label: t("allCategories") },
+    ...STORE_CATEGORIES.map((slug) => ({
+      slug,
+      label: tPortable(storeCategoryLabelKey(slug)),
+    })),
+  ];
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {chips.map((chip) => {
+        const active = category === chip.slug;
+        return (
+          <button
+            key={chip.slug}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onCategoryChange(chip.slug)}
+            className={`rounded-full px-3 py-1 text-[13px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/40 ${
+              active
+                ? "bg-chip font-medium text-ink"
+                : "text-ink-muted hover:bg-hover hover:text-ink"
+            }`}
+          >
+            {chip.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** The quiet sort toggle: newest vs most installed. */
+export function StoreSortToggle({
+  sort,
+  onSortChange,
+}: {
+  sort: StoreCatalogSort;
+  onSortChange: (sort: StoreCatalogSort) => void;
+}) {
+  const { t } = useTranslation("store");
+  const options: StoreCatalogSort[] = ["recent", "installs"];
+  return (
+    <div className="flex shrink-0 gap-1">
+      {options.map((option) => {
+        const active = sort === option;
+        return (
+          <button
+            key={option}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onSortChange(option)}
+            className={`rounded-full px-3 py-1 text-[13px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-focus/40 ${
+              active
+                ? "bg-chip font-medium text-ink"
+                : "text-ink-muted hover:bg-hover hover:text-ink"
+            }`}
+          >
+            {t(`sort.${option}`)}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/app/src/components/store-view/store-view-model.ts
+++ b/app/src/components/store-view/store-view-model.ts
@@ -1,0 +1,33 @@
+/**
+ * Pure helpers for the Agent Store view — kept free of React so the mapping
+ * rules are unit-testable under node:test.
+ */
+
+import type { StoreCatalogAgent } from "@houston-ai/engine-client";
+
+/** The art a listing renders: its emoji when it shipped one, else the name's
+ *  first grapheme as a letter avatar. URL icons render as letters too — the
+ *  catalog never hotlinks third-party images into the app. */
+export function storeAgentGlyph(
+  agent: Pick<StoreCatalogAgent, "name" | "icon">,
+): { kind: "emoji" | "letter"; value: string } {
+  if (agent.icon?.kind === "emoji" && agent.icon.value.trim()) {
+    return { kind: "emoji", value: agent.icon.value.trim() };
+  }
+  const first = [...agent.name.trim()][0] ?? "?";
+  return { kind: "letter", value: first.toUpperCase() };
+}
+
+/** Compact install count for row trailings ("1.2K"), localized. */
+export function formatInstalls(count: number, locale: string): string {
+  return new Intl.NumberFormat(locale, {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }).format(count);
+}
+
+/** The slug out of a store share URL (`…/a/<slug>`), or null when it isn't one. */
+export function storeSlugFromShareUrl(shareUrl: string): string | null {
+  const match = /\/a\/([a-z0-9][a-z0-9-]{0,63})\/?$/.exec(shareUrl.trim());
+  return match ? match[1] : null;
+}

--- a/app/src/components/store-view/store-view.tsx
+++ b/app/src/components/store-view/store-view.tsx
@@ -1,0 +1,194 @@
+import {
+  Button,
+  CatalogAddButton,
+  CatalogGrid,
+  CatalogRow,
+  CatalogSearchField,
+  CatalogShowMore,
+} from "@houston-ai/core";
+import type {
+  StoreCatalogAgent,
+  StoreCatalogSort,
+} from "@houston-ai/engine-client";
+import { fetchStoreAgent, fetchStoreCatalog } from "@houston-ai/engine-client";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { reportError } from "../../lib/error-toast";
+import { useUIStore } from "../../stores/ui";
+import { PageContainer, PageHeader } from "../shell/page-shell";
+import { StoreAgentIcon } from "./store-agent-icon";
+import { StoreDetailDialog } from "./store-detail-dialog";
+import { StoreCategoryChips, StoreSortToggle } from "./store-filters";
+import { formatInstalls } from "./store-view-model";
+import { useStoreInstall } from "./use-store-install";
+
+/**
+ * The Agent Store page (sidebar destination): the public catalog rendered in
+ * the app's own catalog grammar — search + category chips over the flat row
+ * grid, a row body opening the detail modal, and the row's `+` running the
+ * one-click install (which hands off to the import wizard's scan/name flow).
+ * All reads are the anonymous CORS-open gateway API; nothing here needs an
+ * account until the moment of install.
+ */
+export function StoreView() {
+  const { t, i18n } = useTranslation("store");
+  const [search, setSearch] = useState("");
+  const [q, setQ] = useState("");
+  const [category, setCategory] = useState("all");
+  const [sort, setSort] = useState<StoreCatalogSort>("recent");
+  const [detailAgent, setDetailAgent] = useState<StoreCatalogAgent | null>(
+    null,
+  );
+  const { install, installingSlug } = useStoreInstall();
+
+  // Debounce typing into the server-side full-text query.
+  useEffect(() => {
+    const handle = setTimeout(() => setQ(search.trim()), 300);
+    return () => clearTimeout(handle);
+  }, [search]);
+
+  const catalog = useInfiniteQuery({
+    queryKey: ["store-catalog", q, category, sort],
+    queryFn: ({ pageParam }) =>
+      fetchStoreCatalog({
+        q: q || undefined,
+        category: category === "all" ? undefined : category,
+        sort,
+        page: pageParam,
+      }),
+    initialPageParam: 1,
+    getNextPageParam: (last, all) =>
+      last.hasMore ? all.length + 1 : undefined,
+    staleTime: 60_000,
+  });
+
+  // One-shot deep link: "See it in the store" surfaces set a slug before
+  // switching views; consume it into the detail dialog (a vanished listing
+  // just reports — the catalog behind it is already the right fallback).
+  const focusSlug = useUIStore((s) => s.storeFocusSlug);
+  useEffect(() => {
+    if (!focusSlug) return;
+    useUIStore.getState().setStoreFocusSlug(null);
+    fetchStoreAgent(focusSlug)
+      .then((detail) => setDetailAgent(detail.agent))
+      .catch((err: unknown) => {
+        reportError(
+          "store_focus",
+          `store focus fetch failed (${focusSlug})`,
+          err,
+        );
+      });
+  }, [focusSlug]);
+
+  const items = catalog.data?.pages.flatMap((page) => page.items) ?? [];
+
+  const handleInstall = async (slug: string) => {
+    if (await install(slug)) setDetailAgent(null);
+  };
+
+  return (
+    <div className="h-full overflow-auto">
+      <PageContainer className="py-10">
+        <PageHeader
+          title={t("title")}
+          subtitle={t("subtitle")}
+          className="mb-7"
+        />
+
+        <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center">
+          <CatalogSearchField
+            value={search}
+            onChange={setSearch}
+            label={t("searchPlaceholder")}
+            className="flex-1"
+          />
+          <StoreSortToggle sort={sort} onSortChange={setSort} />
+        </div>
+        <StoreCategoryChips
+          category={category}
+          onCategoryChange={setCategory}
+        />
+
+        <div className="mt-6">
+          {catalog.isPending ? (
+            <RowsSkeleton />
+          ) : catalog.isError ? (
+            <div className="flex flex-col items-center gap-3 py-16">
+              <p className="text-sm text-ink-muted">{t("loadFailed")}</p>
+              <Button
+                variant="outline"
+                className="rounded-full"
+                onClick={() => void catalog.refetch()}
+              >
+                {t("retry")}
+              </Button>
+            </div>
+          ) : items.length === 0 ? (
+            <p className="py-16 text-center text-sm text-ink-muted">
+              {t("empty")}
+            </p>
+          ) : (
+            <>
+              <CatalogGrid>
+                {items.map((agent) => (
+                  <CatalogRow
+                    key={agent.id}
+                    icon={<StoreAgentIcon agent={agent} />}
+                    title={agent.name}
+                    description={agent.tagline ?? agent.description}
+                    trailing={
+                      <span
+                        className="shrink-0 text-[12px] text-ink-muted tabular-nums"
+                        title={t("installs", { count: agent.installsCount })}
+                      >
+                        {formatInstalls(agent.installsCount, i18n.language)}
+                      </span>
+                    }
+                    action={
+                      agent.slug ? (
+                        <CatalogAddButton
+                          label={t("installLabel", { name: agent.name })}
+                          busy={installingSlug === agent.slug}
+                          disabled={installingSlug !== null}
+                          onClick={() => void handleInstall(agent.slug ?? "")}
+                        />
+                      ) : undefined
+                    }
+                    onClick={() => setDetailAgent(agent)}
+                  />
+                ))}
+              </CatalogGrid>
+              {catalog.hasNextPage && (
+                <CatalogShowMore
+                  disabled={catalog.isFetchingNextPage}
+                  onClick={() => void catalog.fetchNextPage()}
+                >
+                  {t("showMore")}
+                </CatalogShowMore>
+              )}
+            </>
+          )}
+        </div>
+
+        <StoreDetailDialog
+          agent={detailAgent}
+          onClose={() => setDetailAgent(null)}
+          onInstall={(slug) => void handleInstall(slug)}
+          installing={installingSlug !== null}
+        />
+      </PageContainer>
+    </div>
+  );
+}
+
+/** Row placeholders while the first page settles. Decorative only. */
+function RowsSkeleton() {
+  return (
+    <div aria-hidden className="grid grid-cols-1 gap-1 lg:grid-cols-2">
+      {[0, 1, 2, 3, 4, 5].map((i) => (
+        <div key={i} className="h-[60px] animate-pulse rounded-xl bg-chip" />
+      ))}
+    </div>
+  );
+}

--- a/app/src/components/store-view/use-store-install.ts
+++ b/app/src/components/store-view/use-store-install.ts
@@ -1,0 +1,47 @@
+import { pingStoreInstall } from "@houston-ai/engine-client";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { getEngine } from "../../lib/engine";
+import { reportError } from "../../lib/error-toast";
+import { useUIStore } from "../../stores/ui";
+
+/**
+ * One-click install from the Agent Store: fetch the listing through the host
+ * (the exact `importFromStoreLink` path the "Install from a link" panel uses,
+ * SSRF-guarded and IR-validated), seed the import wizard with the preview and
+ * open it — so scan choice, naming, and content pickers stay identical to
+ * every other way an agent arrives. The install counter ping is fire-and-
+ * forget: it must never block or fail an install, only a Sentry report.
+ */
+export function useStoreInstall() {
+  const { t } = useTranslation("store");
+  const addToast = useUIStore((s) => s.addToast);
+  const [installingSlug, setInstallingSlug] = useState<string | null>(null);
+
+  /** Returns true when the wizard opened (callers close their own surface). */
+  const install = async (slug: string): Promise<boolean> => {
+    if (installingSlug) return false;
+    setInstallingSlug(slug);
+    try {
+      const preview = await getEngine().importFromStoreLink(slug);
+      const ui = useUIStore.getState();
+      ui.setImportSeedPreview(preview);
+      ui.setImportFromFriendOpen(true);
+      pingStoreInstall(slug).catch((err: unknown) => {
+        reportError("store_install_ping", `install ping failed (${slug})`, err);
+      });
+      return true;
+    } catch (err) {
+      reportError("store_install", `store install failed (${slug})`, err);
+      addToast({
+        variant: "error",
+        title: t("installFailed"),
+      });
+      return false;
+    } finally {
+      setInstallingSlug(null);
+    }
+  };
+
+  return { install, installingSlug };
+}

--- a/app/src/lib/i18n.ts
+++ b/app/src/lib/i18n.ts
@@ -33,6 +33,7 @@ import settingsEn from "../locales/en/settings.json";
 import setupEn from "../locales/en/setup.json";
 import shellEn from "../locales/en/shell.json";
 import skillsEn from "../locales/en/skills.json";
+import storeEn from "../locales/en/store.json";
 import teamsEn from "../locales/en/teams.json";
 import agentOnboardingEs from "../locales/es/agent-onboarding.json";
 import agentsEs from "../locales/es/agents.json";
@@ -56,6 +57,7 @@ import settingsEs from "../locales/es/settings.json";
 import setupEs from "../locales/es/setup.json";
 import shellEs from "../locales/es/shell.json";
 import skillsEs from "../locales/es/skills.json";
+import storeEs from "../locales/es/store.json";
 import teamsEs from "../locales/es/teams.json";
 import agentOnboardingPt from "../locales/pt/agent-onboarding.json";
 import agentsPt from "../locales/pt/agents.json";
@@ -79,6 +81,7 @@ import settingsPt from "../locales/pt/settings.json";
 import setupPt from "../locales/pt/setup.json";
 import shellPt from "../locales/pt/shell.json";
 import skillsPt from "../locales/pt/skills.json";
+import storePt from "../locales/pt/store.json";
 import teamsPt from "../locales/pt/teams.json";
 import {
   activeWorkspaceLocale,
@@ -149,6 +152,7 @@ const resources = {
     integrations: integrationsEn,
     migration: migrationEn,
     portable: portableEn,
+    store: storeEn,
     context: contextEn,
     connect: connectEn,
     org: orgEn,
@@ -174,6 +178,7 @@ const resources = {
     integrations: integrationsEs,
     migration: migrationEs,
     portable: portableEs,
+    store: storeEs,
     context: contextEs,
     connect: connectEs,
     org: orgEs,
@@ -199,6 +204,7 @@ const resources = {
     integrations: integrationsPt,
     migration: migrationPt,
     portable: portablePt,
+    store: storePt,
     context: contextPt,
     connect: connectPt,
     org: orgPt,
@@ -243,6 +249,7 @@ void i18n
       "events",
       "migration",
       "portable",
+      "store",
       "context",
       "connect",
       "org",

--- a/app/src/lib/top-level-views.ts
+++ b/app/src/lib/top-level-views.ts
@@ -8,6 +8,7 @@
  */
 import { INTEGRATIONS_VIEW_ID } from "../components/integrations-view/id.ts";
 import { ORGANIZATION_VIEW_ID } from "../components/organization/id.ts";
+import { STORE_VIEW_ID } from "../components/store-view/id.ts";
 
 export const TOP_LEVEL_VIEWS = new Set<string>([
   "dashboard",
@@ -15,6 +16,7 @@ export const TOP_LEVEL_VIEWS = new Set<string>([
   "ai-hub",
   INTEGRATIONS_VIEW_ID,
   ORGANIZATION_VIEW_ID,
+  STORE_VIEW_ID,
 ]);
 
 /** Whether a `viewMode` is a top-level (non-agent) view. */

--- a/app/src/locales/en/portable.json
+++ b/app/src/locales/en/portable.json
@@ -145,7 +145,8 @@
         "unreadable": "That agent could not be read. Ask the person who shared it to publish it again.",
         "network": "We could not reach the Agent Store. Check your connection and try again.",
         "generic": "Something went wrong fetching that agent. Please try again."
-      }
+      },
+      "browseStore": "Or browse the Agent Store"
     },
     "actions": {
       "back": "Back",
@@ -229,7 +230,8 @@
       "removeConfirmTitle": "Remove from the store?",
       "removeConfirmBody": "{{name}} will no longer be installable from its link. You can publish it again later.",
       "removeConfirm": "Remove",
-      "removeCancel": "Keep it up"
+      "removeCancel": "Keep it up",
+      "seeInStore": "See it in the store"
     },
     "errors": {
       "generic": "Something went wrong. Please try again.",

--- a/app/src/locales/en/shell.json
+++ b/app/src/locales/en/shell.json
@@ -3,6 +3,7 @@
     "missionControl": "Mission Control",
     "aiModels": "AI Models",
     "integrations": "Integrations",
+    "agentStore": "Agent Store",
     "settings": "Settings",
     "yourAgents": "Your Agents",
     "selectWorkspace": "Select workspace",

--- a/app/src/locales/en/store.json
+++ b/app/src/locales/en/store.json
@@ -1,0 +1,26 @@
+{
+  "title": "Agent Store",
+  "subtitle": "Ready-made agents from the Houston community. Install one and make it yours.",
+  "searchPlaceholder": "Search agents",
+  "allCategories": "All",
+  "sort": {
+    "recent": "Newest",
+    "installs": "Most installed"
+  },
+  "installs_one": "{{count}} install",
+  "installs_other": "{{count}} installs",
+  "install": "Install",
+  "installLabel": "Install {{name}}",
+  "empty": "No agents here yet. Try another category or search.",
+  "loadFailed": "The store could not be reached. Check your connection and try again.",
+  "retry": "Try again",
+  "showMore": "Show more agents",
+  "detail": {
+    "by": "Made by {{name}}",
+    "skills": "Skills",
+    "integrations": "Works with",
+    "learnings_one": "Comes with {{count}} learning from real use",
+    "learnings_other": "Comes with {{count}} learnings from real use"
+  },
+  "installFailed": "Houston could not fetch that agent from the store. Try again in a moment."
+}

--- a/app/src/locales/es/portable.json
+++ b/app/src/locales/es/portable.json
@@ -145,7 +145,8 @@
         "unreadable": "No se pudo leer ese agente. Pide a quien lo compartió que lo publique de nuevo.",
         "network": "No pudimos conectar con la Agent Store. Revisa tu conexión e inténtalo de nuevo.",
         "generic": "Algo salió mal al traer ese agente. Inténtalo de nuevo."
-      }
+      },
+      "browseStore": "O explora la Tienda de agentes"
     },
     "actions": {
       "back": "Atrás",
@@ -229,7 +230,8 @@
       "removeConfirmTitle": "¿Quitar de la tienda?",
       "removeConfirmBody": "{{name}} ya no se podrá instalar desde su enlace. Puedes publicarlo de nuevo más adelante.",
       "removeConfirm": "Quitar",
-      "removeCancel": "Dejarlo"
+      "removeCancel": "Dejarlo",
+      "seeInStore": "Verlo en la tienda"
     },
     "errors": {
       "generic": "Algo salió mal. Inténtalo de nuevo.",

--- a/app/src/locales/es/shell.json
+++ b/app/src/locales/es/shell.json
@@ -3,6 +3,7 @@
     "missionControl": "Centro de misiones",
     "aiModels": "Modelos de IA",
     "integrations": "Integraciones",
+    "agentStore": "Tienda de agentes",
     "settings": "Configuración",
     "yourAgents": "Tus agentes",
     "selectWorkspace": "Elige un espacio de trabajo",

--- a/app/src/locales/es/store.json
+++ b/app/src/locales/es/store.json
@@ -1,0 +1,26 @@
+{
+  "title": "Tienda de agentes",
+  "subtitle": "Agentes listos para usar, creados por la comunidad de Houston. Instala uno y hazlo tuyo.",
+  "searchPlaceholder": "Buscar agentes",
+  "allCategories": "Todos",
+  "sort": {
+    "recent": "Más nuevos",
+    "installs": "Más instalados"
+  },
+  "installs_one": "{{count}} instalación",
+  "installs_other": "{{count}} instalaciones",
+  "install": "Instalar",
+  "installLabel": "Instalar {{name}}",
+  "empty": "Aún no hay agentes aquí. Prueba otra categoría o búsqueda.",
+  "loadFailed": "No pudimos conectar con la tienda. Revisa tu conexión e intenta de nuevo.",
+  "retry": "Intentar de nuevo",
+  "showMore": "Mostrar más agentes",
+  "detail": {
+    "by": "Creado por {{name}}",
+    "skills": "Habilidades",
+    "integrations": "Funciona con",
+    "learnings_one": "Incluye {{count}} aprendizaje de uso real",
+    "learnings_other": "Incluye {{count}} aprendizajes de uso real"
+  },
+  "installFailed": "Houston no pudo traer ese agente de la tienda. Intenta de nuevo en un momento."
+}

--- a/app/src/locales/pt/portable.json
+++ b/app/src/locales/pt/portable.json
@@ -145,7 +145,8 @@
         "unreadable": "Não foi possível ler esse agente. Peça para quem compartilhou publicar de novo.",
         "network": "Não conseguimos falar com a Agent Store. Verifique sua conexão e tente de novo.",
         "generic": "Algo deu errado ao buscar esse agente. Tente de novo."
-      }
+      },
+      "browseStore": "Ou explore a Loja de agentes"
     },
     "actions": {
       "back": "Voltar",
@@ -229,7 +230,8 @@
       "removeConfirmTitle": "Remover da loja?",
       "removeConfirmBody": "{{name}} não poderá mais ser instalado pelo link. Você pode publicá-lo de novo depois.",
       "removeConfirm": "Remover",
-      "removeCancel": "Manter"
+      "removeCancel": "Manter",
+      "seeInStore": "Ver na loja"
     },
     "errors": {
       "generic": "Algo deu errado. Tente de novo.",

--- a/app/src/locales/pt/shell.json
+++ b/app/src/locales/pt/shell.json
@@ -43,7 +43,8 @@
     "needsYouCount_other": "{{count}} assuntos precisam de você",
     "runningCount_one": "{{count}} assunto em execução",
     "runningCount_other": "{{count}} assuntos em execução",
-    "integrations": "Integrações"
+    "integrations": "Integrações",
+    "agentStore": "Loja de agentes"
   },
   "tabActions": {
     "newMission": "Nova missão",

--- a/app/src/locales/pt/store.json
+++ b/app/src/locales/pt/store.json
@@ -1,0 +1,26 @@
+{
+  "title": "Loja de agentes",
+  "subtitle": "Agentes prontos para usar, criados pela comunidade Houston. Instale um e deixe do seu jeito.",
+  "searchPlaceholder": "Buscar agentes",
+  "allCategories": "Todos",
+  "sort": {
+    "recent": "Mais novos",
+    "installs": "Mais instalados"
+  },
+  "installs_one": "{{count}} instalação",
+  "installs_other": "{{count}} instalações",
+  "install": "Instalar",
+  "installLabel": "Instalar {{name}}",
+  "empty": "Ainda não há agentes aqui. Tente outra categoria ou busca.",
+  "loadFailed": "Não foi possível conectar à loja. Verifique sua conexão e tente de novo.",
+  "retry": "Tentar de novo",
+  "showMore": "Mostrar mais agentes",
+  "detail": {
+    "by": "Criado por {{name}}",
+    "skills": "Habilidades",
+    "integrations": "Funciona com",
+    "learnings_one": "Vem com {{count}} aprendizado de uso real",
+    "learnings_other": "Vem com {{count}} aprendizados de uso real"
+  },
+  "installFailed": "O Houston não conseguiu buscar esse agente na loja. Tente de novo em instantes."
+}

--- a/app/src/stores/ui.ts
+++ b/app/src/stores/ui.ts
@@ -1,3 +1,4 @@
+import type { PortableUploadPreviewResponse } from "@houston-ai/engine-client";
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 import type { SettingsSectionId } from "../lib/settings-sections";
@@ -82,6 +83,14 @@ interface UIState {
   shareAgentId: string | null;
   /** Whether the "From a friend" import wizard is open. */
   importFromFriendOpen: boolean;
+  /** A one-shot preview the import wizard adopts on open — set by the Agent
+   * Store's one-click install right before opening the wizard, cleared by the
+   * wizard once applied. Ephemeral, never persisted. */
+  importSeedPreview: PortableUploadPreviewResponse | null;
+  /** A one-shot slug the Agent Store view opens the detail dialog on — set by
+   * "See it in the store" affordances before `setViewMode(STORE_VIEW_ID)`,
+   * cleared by the view once consumed. */
+  storeFocusSlug: string | null;
   /** Whether the left rail is collapsed to an icon-only strip. Persisted. */
   sidebarCollapsed: boolean;
   setViewMode: (mode: string) => void;
@@ -120,6 +129,8 @@ interface UIState {
   setUiTourActive: (active: boolean) => void;
   setShareAgentId: (agentId: string | null) => void;
   setImportFromFriendOpen: (open: boolean) => void;
+  setImportSeedPreview: (preview: PortableUploadPreviewResponse | null) => void;
+  setStoreFocusSlug: (slug: string | null) => void;
   setSidebarCollapsed: (collapsed: boolean) => void;
   toggleSidebarCollapsed: () => void;
 }
@@ -161,6 +172,8 @@ export const useUIStore = create<UIState>()(
       uiTourActive: false,
       shareAgentId: null,
       importFromFriendOpen: false,
+      importSeedPreview: null,
+      storeFocusSlug: null,
       sidebarCollapsed: false,
 
       setViewMode: (viewMode) => set({ viewMode }),
@@ -281,6 +294,8 @@ export const useUIStore = create<UIState>()(
       setShareAgentId: (shareAgentId) => set({ shareAgentId }),
       setImportFromFriendOpen: (importFromFriendOpen) =>
         set({ importFromFriendOpen }),
+      setImportSeedPreview: (importSeedPreview) => set({ importSeedPreview }),
+      setStoreFocusSlug: (storeFocusSlug) => set({ storeFocusSlug }),
       setSidebarCollapsed: (sidebarCollapsed) => set({ sidebarCollapsed }),
       toggleSidebarCollapsed: () =>
         set((s) => ({ sidebarCollapsed: !s.sidebarCollapsed })),

--- a/app/src/types/react-i18next.d.ts
+++ b/app/src/types/react-i18next.d.ts
@@ -29,6 +29,7 @@ import type settings from "../locales/en/settings.json";
 import type setup from "../locales/en/setup.json";
 import type shell from "../locales/en/shell.json";
 import type skills from "../locales/en/skills.json";
+import type store from "../locales/en/store.json";
 import type teams from "../locales/en/teams.json";
 
 declare module "react-i18next" {
@@ -46,6 +47,7 @@ declare module "react-i18next" {
       board: typeof board;
       agents: typeof agents;
       skills: typeof skills;
+      store: typeof store;
       routines: typeof routines;
       providers: typeof providers;
       errors: typeof errors;

--- a/app/tests/store-view-model.test.ts
+++ b/app/tests/store-view-model.test.ts
@@ -1,0 +1,79 @@
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  formatInstalls,
+  storeAgentGlyph,
+  storeSlugFromShareUrl,
+} from "../src/components/store-view/store-view-model.ts";
+
+describe("storeAgentGlyph", () => {
+  it("prefers the listing's emoji icon", () => {
+    deepStrictEqual(
+      storeAgentGlyph({ name: "Mailer", icon: { kind: "emoji", value: "📬" } }),
+      { kind: "emoji", value: "📬" },
+    );
+  });
+
+  it("falls back to a letter avatar for URL icons and missing icons", () => {
+    deepStrictEqual(
+      storeAgentGlyph({
+        name: "mailer",
+        icon: { kind: "url", value: "https://x/y.png" },
+      }),
+      { kind: "letter", value: "M" },
+    );
+    deepStrictEqual(storeAgentGlyph({ name: "ágil", icon: null }), {
+      kind: "letter",
+      value: "Á",
+    });
+  });
+
+  it("survives an empty name", () => {
+    deepStrictEqual(storeAgentGlyph({ name: "  ", icon: null }), {
+      kind: "letter",
+      value: "?",
+    });
+  });
+
+  it("takes the first grapheme, not the first UTF-16 unit", () => {
+    strictEqual(storeAgentGlyph({ name: "🚀 Launch", icon: null }).value, "🚀");
+  });
+});
+
+describe("formatInstalls", () => {
+  it("passes small counts through", () => {
+    strictEqual(formatInstalls(7, "en"), "7");
+  });
+
+  it("compacts large counts", () => {
+    strictEqual(formatInstalls(1200, "en"), "1.2K");
+  });
+});
+
+describe("storeSlugFromShareUrl", () => {
+  it("extracts the slug from a share URL", () => {
+    strictEqual(
+      storeSlugFromShareUrl("https://agents.gethouston.ai/a/inbox-helper"),
+      "inbox-helper",
+    );
+  });
+
+  it("tolerates a trailing slash and whitespace", () => {
+    strictEqual(
+      storeSlugFromShareUrl(" https://agents.gethouston.ai/a/inbox-helper/ "),
+      "inbox-helper",
+    );
+  });
+
+  it("rejects non-share URLs", () => {
+    strictEqual(
+      storeSlugFromShareUrl("https://agents.gethouston.ai/explore"),
+      null,
+    );
+    strictEqual(storeSlugFromShareUrl("not a url"), null);
+    strictEqual(
+      storeSlugFromShareUrl("https://agents.gethouston.ai/a/UPPER"),
+      null,
+    );
+  });
+});

--- a/knowledge-base/agent-store.md
+++ b/knowledge-base/agent-store.md
@@ -22,7 +22,9 @@ The authoritative wire/DB surface is the gateway's contract
 | Domain bridge | `packages/domain/src/store-ir.ts` | `irFromPortable` / `portableFromIr` between Houston portable content and AgentIR. |
 | Host routes | `packages/host/src/routes/portable-store.ts`, `portable-store-ir.ts`, `store-publication-pointer.ts`, `portable-from-store.ts` | Credential-free: gather the IR + record a token-free local pointer; resolve an install link. |
 | Engine seam | `ui/engine-client/src/client.ts` (front door), `packages/web/src/engine-adapter/portable.ts` (impl) + `store-gateway.ts` | `publishAgentToStore` / `updateStorePublication` / `unpublishFromStore` / `getStorePublication` / `importFromStoreLink`. |
-| App UI | `app/src/components/portable/` | Share wizard (`share-screen`, `listing-step`), `manage-publication`, `install-from-link`, `use-store-publication.ts`. |
+| Catalog reads | `ui/engine-client/src/store-catalog.ts` (re-exported by the adapter) | Anonymous CORS-open browse: `fetchStoreCatalog` / `fetchStoreAgent` / `pingStoreInstall`. Plain fetch, no bearer, works signed-out; throws a status-carrying `StoreCatalogError` (deliberately not the engine error class). |
+| App UI (publish/install) | `app/src/components/portable/` | Share wizard (`share-screen`, `listing-step`), `manage-publication` (incl. in-app "See it in the store"), `install-from-link`, `use-store-publication.ts`. |
+| App UI (browse) | `app/src/components/store-view/` | The in-app Agent Store page (sidebar + ⌘K destination, view id `agent-store`): catalog-family rows over the public API, category chips + search + sort, detail modal, one-click install. |
 
 The tie to `cloud/` is the gateway API + a shared Firebase project; the AgentIR
 contract is a byte-copy relationship, not a runtime import. (The standalone
@@ -99,6 +101,33 @@ Two publish identities:
 going `public` is NOT self-serve; `requestPublic: true` only stamps a review flag,
 dropping the agent into the admin queue. Install/report counters are trigger-owned;
 no client writes them.
+
+## In-app browse (the Store view)
+
+The store is browsable INSIDE the app (`app/src/components/store-view/`,
+view id `agent-store` in `TOP_LEVEL_VIEWS`): a sidebar + command-palette
+destination rendering the public catalog in the shared catalog family
+(`CatalogRow`/`CatalogGrid`/`CatalogDetailDialog`/`CatalogSearchField`).
+Reads go straight to the gateway's anonymous CORS-open endpoints via
+`ui/engine-client/src/store-catalog.ts` — no account, no engine round-trip;
+base resolution mirrors the publish adapter (`__HOUSTON_STORE__` →
+`VITE_AGENTSTORE_GATEWAY_URL` → prod).
+
+**One-click install** (`use-store-install.ts`) is the link-install path with
+the paste skipped: `importFromStoreLink(slug)` fetches the preview through the
+host (SSRF-guarded), parks it, and opens the import wizard seeded via the
+one-shot `importSeedPreview` UI-store field — so the threat-scan choice,
+naming, and content pickers are byte-for-byte the file/link flow. The
+anonymous `installs` ping fires after, fire-and-forget (Sentry on failure,
+never blocks). Category chips reuse the publish wizard's
+`portable:publish.categories.*` labels via `storeCategoryLabelKey`; the view's
+own strings live in the `store` namespace (en/es/pt).
+
+Cross-links: the import wizard's upload step offers "browse the Agent Store"
+(closes itself into the view), and `manage-publication` offers "See it in the
+store" (sets the one-shot `storeFocusSlug`, which the view consumes into the
+detail dialog — unlisted listings resolve by direct slug, so owners see their
+own).
 
 ## Host routes + app plumbing
 

--- a/packages/web/src/engine-adapter/index.ts
+++ b/packages/web/src/engine-adapter/index.ts
@@ -6,6 +6,10 @@
  * Types are reused verbatim from the original package; only the HoustonClient
  * and EngineWebSocket implementations change.
  */
+
+// The public store catalog reads (anonymous, CORS-open) are deployment-shape
+// agnostic, so the adapter serves the ui package's implementation as-is.
+export * from "../../../../ui/engine-client/src/store-catalog";
 export * from "../../../../ui/engine-client/src/types";
 export type { HoustonClientOptions } from "./client";
 export {

--- a/ui/engine-client/src/index.ts
+++ b/ui/engine-client/src/index.ts
@@ -11,6 +11,7 @@
  */
 
 export * from "./client.ts";
+export * from "./store-catalog.ts";
 export * from "./types.ts";
 export * from "./vm.ts";
 export * from "./ws.ts";

--- a/ui/engine-client/src/store-catalog.ts
+++ b/ui/engine-client/src/store-catalog.ts
@@ -1,0 +1,109 @@
+/**
+ * The public Agent Store catalog — browse/read endpoints only.
+ *
+ * These routes are anonymous by design (the gateway serves them with
+ * `Access-Control-Allow-Origin: *`), so unlike the publish flow there is no
+ * bearer and no 401 discipline here: plain `fetch` against the store gateway.
+ * Works signed-out, on every deployment shape.
+ *
+ * The API base mirrors the publish adapter's resolution: the desktop shell's
+ * `window.__HOUSTON_STORE__` target when installed (local-sidecar mode, signed
+ * in), else the build-time `VITE_AGENTSTORE_GATEWAY_URL`, else production.
+ */
+
+import type {
+  StoreCatalogAgentDetail,
+  StoreCatalogPage,
+  StoreCatalogQuery,
+} from "./types.ts";
+
+/**
+ * A failed catalog read. Deliberately NOT `HoustonEngineError` (this module
+ * must not pull the engine client into consumers that only browse), but it
+ * carries the same structural `status` every caller switches on.
+ */
+export class StoreCatalogError extends Error {
+  status: number;
+  body: unknown;
+  constructor(status: number, body: unknown) {
+    super(`store catalog request failed (${status})`);
+    this.name = "StoreCatalogError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+declare global {
+  interface Window {
+    __HOUSTON_STORE__?: { baseUrl: string; token: string };
+  }
+}
+
+const DEFAULT_STORE_GATEWAY = "https://gateway.gethouston.ai";
+
+/** The gateway base the public catalog reads go to. */
+export function storeCatalogApiBase(): string {
+  const installed =
+    typeof window !== "undefined" ? window.__HOUSTON_STORE__?.baseUrl : "";
+  const built = (
+    import.meta as unknown as { env?: Record<string, string | undefined> }
+  ).env?.VITE_AGENTSTORE_GATEWAY_URL;
+  return (installed || built || DEFAULT_STORE_GATEWAY).replace(/\/+$/, "");
+}
+
+async function storeGet<T>(path: string, fetchImpl: typeof fetch): Promise<T> {
+  const res = await fetchImpl(`${storeCatalogApiBase()}${path}`, {
+    headers: { Accept: "application/json" },
+  });
+  if (!res.ok) {
+    throw new StoreCatalogError(res.status, await res.json().catch(() => ({})));
+  }
+  return (await res.json()) as T;
+}
+
+/** One page of published + public listings (server page size 24). */
+export function fetchStoreCatalog(
+  query: StoreCatalogQuery = {},
+  fetchImpl: typeof fetch = fetch,
+): Promise<StoreCatalogPage> {
+  const params = new URLSearchParams();
+  if (query.q?.trim()) params.set("q", query.q.trim());
+  if (query.category) params.set("category", query.category);
+  if (query.sort) params.set("sort", query.sort);
+  if (query.page && query.page > 1) params.set("page", String(query.page));
+  const qs = params.toString();
+  return storeGet(`/v1/agentstore/agents${qs ? `?${qs}` : ""}`, fetchImpl);
+}
+
+/** A listing's summary + renderable IR parts. 404s when not published. */
+export function fetchStoreAgent(
+  slug: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<StoreCatalogAgentDetail> {
+  return storeGet(
+    `/v1/agentstore/agents/${encodeURIComponent(slug)}`,
+    fetchImpl,
+  );
+}
+
+/**
+ * Count an in-app install against the listing (anonymous, trigger-maintained).
+ * Callers fire-and-forget this AFTER the install flow starts — a failed ping
+ * must never block an install, so catch + report at the call site.
+ */
+export async function pingStoreInstall(
+  slug: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<void> {
+  const res = await fetchImpl(
+    `${storeCatalogApiBase()}/v1/agentstore/agents/${encodeURIComponent(slug)}/installs`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ target: "houston" }),
+    },
+  );
+  if (!res.ok) {
+    throw new StoreCatalogError(res.status, await res.json().catch(() => ({})));
+  }
+}

--- a/ui/engine-client/src/types.ts
+++ b/ui/engine-client/src/types.ts
@@ -1640,6 +1640,53 @@ export interface StorePublicationStatus {
   identity?: StorePublishIdentity;
 }
 
+/** One public Agent Store listing, exactly as the catalog API serializes it. */
+export interface StoreCatalogAgent {
+  id: string;
+  /** Null only while a listing is a draft; always set for published agents. */
+  slug: string | null;
+  name: string;
+  tagline: string | null;
+  description: string;
+  icon: { kind: string; value: string } | null;
+  color: string | null;
+  category: string;
+  tags: string[];
+  /** UPPERCASE Composio toolkit slugs the agent uses. */
+  integrations: string[];
+  creator: { displayName: string; url?: string };
+  installsCount: number;
+  publishedAt: string | null;
+  updatedAt: string;
+}
+
+/** One page of the public catalog (page size is server-fixed at 24). */
+export interface StoreCatalogPage {
+  items: StoreCatalogAgent[];
+  hasMore: boolean;
+}
+
+export type StoreCatalogSort = "recent" | "installs";
+
+export interface StoreCatalogQuery {
+  /** Full-text search (websearch syntax). */
+  q?: string;
+  /** A store category slug; omit for all categories. */
+  category?: string;
+  sort?: StoreCatalogSort;
+  /** 1-based. */
+  page?: number;
+}
+
+/** A listing's detail: the summary plus the parts of its IR the app renders. */
+export interface StoreCatalogAgentDetail {
+  agent: StoreCatalogAgent;
+  ir: {
+    skills?: Array<{ slug: string }>;
+    learnings?: unknown[];
+  };
+}
+
 // ── integrations (Composio, platform mode) ───────────────────────────────────
 // User-level: no provider account — the user only connects apps (Gmail, Slack…)
 // via OAuth; Houston's platform key lives server-side, keyed by the user's id.

--- a/ui/engine-client/tests/store-catalog.test.ts
+++ b/ui/engine-client/tests/store-catalog.test.ts
@@ -1,0 +1,130 @@
+import { deepStrictEqual, ok, rejects, strictEqual } from "node:assert";
+import { describe, it } from "node:test";
+import {
+  fetchStoreAgent,
+  fetchStoreCatalog,
+  pingStoreInstall,
+  StoreCatalogError,
+  storeCatalogApiBase,
+} from "../src/store-catalog.ts";
+
+/**
+ * The public catalog reads: URL/query construction, the anonymous ping's
+ * body, and the structural error (status-carrying, engine-client-free).
+ * `fetchImpl` is injected, so no network is touched.
+ */
+
+const BASE = "https://gateway.gethouston.ai";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+function capture(body: unknown = { items: [], hasMore: false }) {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fetchImpl = ((url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    return Promise.resolve(jsonResponse(body));
+  }) as typeof fetch;
+  return { calls, fetchImpl };
+}
+
+describe("storeCatalogApiBase", () => {
+  it("defaults to the production gateway outside a browser build", () => {
+    strictEqual(storeCatalogApiBase(), BASE);
+  });
+});
+
+describe("fetchStoreCatalog", () => {
+  it("requests the bare listing when the query is empty", async () => {
+    const { calls, fetchImpl } = capture();
+    await fetchStoreCatalog({}, fetchImpl);
+    strictEqual(calls[0].url, `${BASE}/v1/agentstore/agents`);
+  });
+
+  it("carries q/category/sort and omits page 1", async () => {
+    const { calls, fetchImpl } = capture();
+    await fetchStoreCatalog(
+      {
+        q: "  email helper ",
+        category: "productivity",
+        sort: "installs",
+        page: 1,
+      },
+      fetchImpl,
+    );
+    const url = new URL(calls[0].url);
+    strictEqual(url.searchParams.get("q"), "email helper");
+    strictEqual(url.searchParams.get("category"), "productivity");
+    strictEqual(url.searchParams.get("sort"), "installs");
+    strictEqual(url.searchParams.get("page"), null);
+  });
+
+  it("carries pages past the first", async () => {
+    const { calls, fetchImpl } = capture();
+    await fetchStoreCatalog({ page: 3 }, fetchImpl);
+    strictEqual(new URL(calls[0].url).searchParams.get("page"), "3");
+  });
+
+  it("returns the page payload as-is", async () => {
+    const page = { items: [{ id: "a1" }], hasMore: true };
+    const { fetchImpl } = capture(page);
+    deepStrictEqual(await fetchStoreCatalog({}, fetchImpl), page);
+  });
+
+  it("throws a status-carrying StoreCatalogError on a failed read", async () => {
+    const fetchImpl = (() =>
+      Promise.resolve(
+        jsonResponse({ error: "not_found" }, 404),
+      )) as typeof fetch;
+    await rejects(
+      fetchStoreCatalog({}, fetchImpl),
+      (err: unknown) =>
+        err instanceof StoreCatalogError &&
+        err.status === 404 &&
+        typeof err.body === "object",
+    );
+  });
+});
+
+describe("fetchStoreAgent", () => {
+  it("addresses the listing by encoded slug", async () => {
+    const { calls, fetchImpl } = capture({ agent: {}, ir: {} });
+    await fetchStoreAgent("inbox-helper", fetchImpl);
+    strictEqual(calls[0].url, `${BASE}/v1/agentstore/agents/inbox-helper`);
+  });
+});
+
+describe("pingStoreInstall", () => {
+  it("POSTs the houston install target", async () => {
+    const calls: Array<{ url: string; init?: RequestInit }> = [];
+    const fetchImpl = ((url: string, init?: RequestInit) => {
+      calls.push({ url, init });
+      return Promise.resolve(new Response(null, { status: 204 }));
+    }) as typeof fetch;
+    await pingStoreInstall("inbox-helper", fetchImpl);
+    strictEqual(
+      calls[0].url,
+      `${BASE}/v1/agentstore/agents/inbox-helper/installs`,
+    );
+    strictEqual(calls[0].init?.method, "POST");
+    deepStrictEqual(JSON.parse(String(calls[0].init?.body)), {
+      target: "houston",
+    });
+  });
+
+  it("throws on a rejected ping so the caller can report it", async () => {
+    const fetchImpl = (() =>
+      Promise.resolve(
+        jsonResponse({ error: "not_found" }, 404),
+      )) as typeof fetch;
+    await rejects(pingStoreInstall("ghost", fetchImpl), (err: unknown) => {
+      ok(err instanceof StoreCatalogError);
+      strictEqual(err.status, 404);
+      return true;
+    });
+  });
+});


### PR DESCRIPTION
## What

The Agent Store becomes a first-class in-app surface — closing the two gaps left after launch: you couldn't *see* the store from inside the app, and installing required pasting a link.

### Browse (new top-level view `agent-store`)
- Sidebar + ⌘K palette destination, registered in `TOP_LEVEL_VIEWS`.
- Rendered entirely in the shared **catalog family** (`CatalogRow`/`CatalogGrid`/`CatalogSearchField`/`CatalogDetailDialog`/`CatalogShowMore`) — same grammar as Integrations/Skills/AI Models.
- Category chips (labels reused from the publish wizard's `portable:publish.categories.*`), debounced server-side search, recent/most-installed sort, paged Show-more, install counts, skeleton/error/empty states.
- Data layer: new `ui/engine-client/src/store-catalog.ts` — anonymous CORS-open gateway reads (`fetchStoreCatalog` / `fetchStoreAgent` / `pingStoreInstall`), plain fetch, works signed-out, throws a status-carrying `StoreCatalogError` without pulling in the engine client. Re-exported by the web adapter; base resolution mirrors the publish seam. Verified against the live gateway.

### One-click install
- The row's `+` (or the detail modal CTA) runs `importFromStoreLink(slug)` — the existing SSRF-guarded host path — and opens the **import wizard seeded** with the preview (one-shot `importSeedPreview` UI-store field), so the threat-scan choice, naming, and content pickers are byte-for-byte the file/link flow.
- Anonymous install-counter ping fires after, fire-and-forget (Sentry on failure, never blocks).

### Cross-links
- Import wizard upload step: "Or browse the Agent Store".
- Manage publication: in-app "See it in the store" via one-shot `storeFocusSlug` (owners resolve their unlisted listing by direct slug).

### i18n
New `store` namespace (en/es/pt) + sidebar/portable strings; `check-locales` green.

## Tests / checks
- node:test: catalog fetchers (URL/query building, error mapping, ping body) + view-model helpers (glyph, compact counts, slug parsing) — engine-client 187→+, app 1512 pass.
- Biome clean, full workspace typecheck green, `check:parity` green, live API shape verified.

## Note for a follow-up
`import-wizard.tsx` was already well past the 200-line budget before this change (+~35 here); splitting its steps into modules is a worthwhile standalone refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)