### PR TITLE
Release prep 0.5.6: gate Continue-with-Apple + version bump + notes

### DIFF
--- a/.github/release-notes/0.5.6.es.md
+++ b/.github/release-notes/0.5.6.es.md
@@ -1,0 +1,35 @@
+## Houston 0.5.6
+
+### Una nueva primera impresión
+
+- **Houston ahora abre bajo la Vía Láctea real.** El inicio de sesión, la
+  configuración y la pantalla de carga flotan sobre la misma fotografía del
+  cielo nocturno de nuestro sitio web, con tarjetas de cristal que dejan ver
+  las estrellas.
+- **La mudanza a la nube se ve como debe.** Rediseñamos las pantallas de
+  migración desde cero: un titular claro, un cohete en camino mientras tus
+  datos se mueven y confeti al llegar. Menos lectura, más acción.
+
+### Conectar tu IA ahora es confiable
+
+- **Conectar Claude termina solo.** Inicia sesión una vez en tu navegador y
+  Houston completa el resto, incluso durante la configuración inicial. Se
+  acabó pegar tokens.
+- **Si una conexión falla, Houston la termina después.** ¿Algo salió mal a
+  mitad de camino? Houston la completa en silencio la próxima vez que abras la
+  aplicación. Nada que rehacer.
+- **Mensajes más claros cuando algo anda mal.** Los errores repetidos se
+  agrupan en una sola nota con un contador, y hablan en lenguaje simple en vez
+  de códigos técnicos.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza bien
+  una aplicación abierta. Ante la duda, elimina `/Applications/Houston.app` y
+  arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde 0.4.7 o posterior te trae
+  al día sola. El MSI aún no tiene firma de código del sistema, así que
+  SmartScreen puede advertir en una instalación nueva.
+- **Windows ARM64:** no hay actualización automática desde una instalación x64
+  emulada. Descarga el MSI ARM64 manualmente, desinstala primero la versión
+  x64 y luego instala la ARM64.

--- a/.github/release-notes/0.5.6.md
+++ b/.github/release-notes/0.5.6.md
@@ -1,0 +1,34 @@
+## Houston 0.5.6
+
+### A new first impression
+
+- **Houston now opens under the real Milky Way.** Sign-in, setup, and loading
+  all float over the same night-sky photograph as our website, with glassy
+  cards that let the stars show through.
+- **Moving to the cloud looks the part.** The migration screens were rebuilt
+  from scratch: one clear headline, a rocket in transit while your data moves,
+  and confetti when you land. Less reading, more doing.
+
+### Connecting your AI got dependable
+
+- **Connecting Claude finishes by itself.** Sign in once in your browser and
+  Houston completes the rest, even during first-time setup. No more pasting
+  setup tokens.
+- **If a connection hiccups, Houston finishes it later.** Started connecting
+  and something went wrong? Houston quietly completes it the next time the app
+  opens. Nothing to redo.
+- **Clearer messages when something is off.** Repeated errors now stack into a
+  single note with a counter, and they speak plain language instead of
+  technical codes.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a
+  running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag
+  the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward
+  automatically. The MSI is still not OS-code-signed, so Windows SmartScreen may
+  warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install.
+  Download the ARM64 MSI manually, uninstall the x64 build first, then install
+  the ARM64 one.

--- a/.github/release-notes/0.5.6.pt.md
+++ b/.github/release-notes/0.5.6.pt.md
@@ -1,0 +1,35 @@
+## Houston 0.5.6
+
+### Uma nova primeira impressão
+
+- **O Houston agora abre sob a Via Láctea de verdade.** O login, a
+  configuração e a tela de carregamento flutuam sobre a mesma fotografia do
+  céu noturno do nosso site, com cartões de vidro que deixam as estrelas
+  aparecerem.
+- **A mudança para a nuvem ficou à altura.** As telas de migração foram
+  refeitas do zero: um título claro, um foguete a caminho enquanto seus dados
+  se movem e confete na chegada. Menos leitura, mais ação.
+
+### Conectar sua IA ficou confiável
+
+- **Conectar o Claude termina sozinho.** Entre uma vez no navegador e o
+  Houston completa o resto, mesmo durante a primeira configuração. Chega de
+  colar tokens.
+- **Se uma conexão falhar, o Houston termina depois.** Algo deu errado no meio
+  do caminho? O Houston completa em silêncio na próxima vez que o aplicativo
+  abrir. Nada para refazer.
+- **Mensagens mais claras quando algo está errado.** Erros repetidos agora se
+  agrupam em uma única nota com contador, e falam linguagem simples em vez de
+  códigos técnicos.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui bem
+  um aplicativo aberto. Na dúvida, remova `/Applications/Houston.app` e
+  arraste a cópia nova.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou posterior te
+  traz para frente sozinha. O MSI ainda não tem assinatura de código do
+  sistema, então o SmartScreen pode avisar em uma instalação nova.
+- **Windows ARM64:** não há atualização automática a partir de uma instalação
+  x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a versão x64
+  e depois instale a ARM64.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -618,6 +618,9 @@ jobs:
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          # Gates "Continue with Apple" (repo variable, not a secret): set to 1
+          # once the GCIP apple.com provider is configured (knowledge-base/auth.md).
+          APPLE_SIGN_IN_ENABLED: ${{ vars.APPLE_SIGN_IN_ENABLED || '' }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           GOOGLE_DESKTOP_CLIENT_ID: ${{ secrets.GOOGLE_DESKTOP_CLIENT_ID }}
@@ -1235,6 +1238,9 @@ jobs:
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          # Gates "Continue with Apple" (repo variable, not a secret): set to 1
+          # once the GCIP apple.com provider is configured (knowledge-base/auth.md).
+          APPLE_SIGN_IN_ENABLED: ${{ vars.APPLE_SIGN_IN_ENABLED || '' }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           GOOGLE_DESKTOP_CLIENT_ID: ${{ secrets.GOOGLE_DESKTOP_CLIENT_ID }}
@@ -1496,6 +1502,9 @@ jobs:
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          # Gates "Continue with Apple" (repo variable, not a secret): set to 1
+          # once the GCIP apple.com provider is configured (knowledge-base/auth.md).
+          APPLE_SIGN_IN_ENABLED: ${{ vars.APPLE_SIGN_IN_ENABLED || '' }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           GOOGLE_DESKTOP_CLIENT_ID: ${{ secrets.GOOGLE_DESKTOP_CLIENT_ID }}
@@ -1662,6 +1671,9 @@ jobs:
         env:
           VITE_CONTROL_PLANE_URL: ${{ secrets.HOSTED_ENGINE_URL }}
           FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+          # Gates "Continue with Apple" (repo variable, not a secret): set to 1
+          # once the GCIP apple.com provider is configured (knowledge-base/auth.md).
+          APPLE_SIGN_IN_ENABLED: ${{ vars.APPLE_SIGN_IN_ENABLED || '' }}
           FIREBASE_AUTH_DOMAIN: ${{ secrets.FIREBASE_AUTH_DOMAIN }}
           FIREBASE_PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.5.3"
+version = "0.5.6"
 dependencies = [
  "bytes",
  "chrono",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.5.3",
+  "version": "0.5.6",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.5.3"
+version = "0.5.6"
 edition = "2021"
 
 [lib]

--- a/app/src/components/auth/sign-in-screen.tsx
+++ b/app/src/components/auth/sign-in-screen.tsx
@@ -9,6 +9,7 @@ import {
   signInWithGoogle,
   signInWithMicrosoft,
 } from "../../lib/auth";
+import { isAppleSignInEnabled } from "../../lib/identity";
 import { logger } from "../../lib/logger";
 import { tauriSystem } from "../../lib/tauri";
 import { HoustonLogo } from "../shell/experience-card";
@@ -127,19 +128,24 @@ export function SignInScreen() {
                 )}
                 Continue with Google
               </Button>
-              <Button
-                variant="default"
-                onClick={handleSignIn("apple")}
-                disabled={pending !== null}
-                className="h-10 w-full justify-center rounded-full border-none! shadow-none"
-              >
-                {pending === "apple" ? (
-                  <Loader2 className="size-4 animate-spin" />
-                ) : (
-                  <AppleIcon />
-                )}
-                Continue with Apple
-              </Button>
+              {/* Gated: renders only once the GCIP apple.com provider is
+                  configured (APPLE_SIGN_IN_ENABLED) — an unconfigured build
+                  must never show a sign-in method that can only error. */}
+              {isAppleSignInEnabled() && (
+                <Button
+                  variant="default"
+                  onClick={handleSignIn("apple")}
+                  disabled={pending !== null}
+                  className="h-10 w-full justify-center rounded-full border-none! shadow-none"
+                >
+                  {pending === "apple" ? (
+                    <Loader2 className="size-4 animate-spin" />
+                  ) : (
+                    <AppleIcon />
+                  )}
+                  Continue with Apple
+                </Button>
+              )}
               <Button
                 variant="default"
                 onClick={handleSignIn("azure")}

--- a/app/src/lib/identity/config.ts
+++ b/app/src/lib/identity/config.ts
@@ -52,6 +52,33 @@ export function identityConfigured(config: IdentityConfig): boolean {
   return Boolean(config.apiKey && config.projectId);
 }
 
+/**
+ * Pure predicate for the Apple sign-in gate: truthy flag values switch the
+ * button on. Baked value wins, dev env is the fallback (same precedence as
+ * the identity config). Testable.
+ */
+export function appleSignInFlagEnabled(baked: string, dev: string): boolean {
+  const v = (baked || dev).trim().toLowerCase();
+  return v === "1" || v === "true" || v === "on" || v === "yes";
+}
+
+/**
+ * Whether "Continue with Apple" renders. Gated separately from
+ * `isIdentityConfigured()`: the GCIP `apple.com` provider needs one-time
+ * Apple Developer + console config (see knowledge-base/auth.md), and an
+ * unconfigured build must never show a sign-in method that can only error.
+ * Bake `APPLE_SIGN_IN_ENABLED=1` (or set `VITE_APPLE_SIGN_IN_ENABLED=1` in
+ * dev) once the provider is live.
+ */
+export function isAppleSignInEnabled(): boolean {
+  return appleSignInFlagEnabled(
+    typeof __APPLE_SIGN_IN_ENABLED__ !== "undefined"
+      ? __APPLE_SIGN_IN_ENABLED__
+      : "",
+    devEnv("VITE_APPLE_SIGN_IN_ENABLED"),
+  );
+}
+
 /** The resolved config for the current build. */
 export const identityConfig: IdentityConfig = resolveIdentityConfig({
   apiKey:

--- a/app/src/lib/identity/index.ts
+++ b/app/src/lib/identity/index.ts
@@ -11,7 +11,11 @@
 // `.ts`-subpath imports, so they are intentionally NOT re-exported here — a
 // slim barrel keeps the public surface honest.
 
-export { identityConfig, isIdentityConfigured } from "./config.ts";
+export {
+  identityConfig,
+  isAppleSignInEnabled,
+  isIdentityConfigured,
+} from "./config.ts";
 export {
   IdentityError,
   type IdentityErrorCode,

--- a/app/src/vite-env.d.ts
+++ b/app/src/vite-env.d.ts
@@ -6,6 +6,7 @@ declare const __POSTHOG_HOST__: string;
 declare const __FIREBASE_API_KEY__: string;
 declare const __FIREBASE_AUTH_DOMAIN__: string;
 declare const __FIREBASE_PROJECT_ID__: string;
+declare const __APPLE_SIGN_IN_ENABLED__: string;
 declare const __GOOGLE_DESKTOP_CLIENT_ID__: string;
 declare const __GOOGLE_DESKTOP_CLIENT_SECRET__: string;
 declare const __MICROSOFT_DESKTOP_CLIENT_ID__: string;

--- a/app/tests/identity-config.test.ts
+++ b/app/tests/identity-config.test.ts
@@ -1,6 +1,7 @@
 import { strictEqual } from "node:assert/strict";
 import { describe, it } from "node:test";
 import {
+  appleSignInFlagEnabled,
   identityConfigured,
   resolveIdentityConfig,
 } from "../src/lib/identity/config.ts";
@@ -61,5 +62,24 @@ describe("identity/config gating (identityConfigured)", () => {
       identityConfigured({ apiKey: "", authDomain: "", projectId: "" }),
       false,
     );
+  });
+});
+
+describe("appleSignInFlagEnabled (the Continue-with-Apple gate)", () => {
+  it("is OFF by default — an unconfigured build never shows the button", () => {
+    strictEqual(appleSignInFlagEnabled("", ""), false);
+    strictEqual(appleSignInFlagEnabled("0", ""), false);
+    strictEqual(appleSignInFlagEnabled("off", ""), false);
+  });
+
+  it("truthy baked values switch it on", () => {
+    for (const v of ["1", "true", "on", "yes", " TRUE "]) {
+      strictEqual(appleSignInFlagEnabled(v, ""), true, v);
+    }
+  });
+
+  it("the dev env is the fallback; the baked value wins", () => {
+    strictEqual(appleSignInFlagEnabled("", "1"), true);
+    strictEqual(appleSignInFlagEnabled("0", "1"), false);
   });
 });

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -80,6 +80,13 @@ export default defineConfig(({ mode }) => {
       __FIREBASE_PROJECT_ID__: JSON.stringify(
         env.FIREBASE_PROJECT_ID ?? "gethouston",
       ),
+      // Gates the "Continue with Apple" button: the GCIP apple.com provider
+      // needs one-time Apple Developer + console config, and an unconfigured
+      // build must not show a sign-in method that can only error. Set
+      // APPLE_SIGN_IN_ENABLED=1 once the provider is live.
+      __APPLE_SIGN_IN_ENABLED__: JSON.stringify(
+        env.APPLE_SIGN_IN_ENABLED ?? "",
+      ),
       // Desktop-only: the "Desktop app" Google OAuth client used by the
       // loopback + PKCE sign-in. Google installed-app clients require the
       // client secret in the code→token exchange; it is non-confidential

--- a/knowledge-base/auth.md
+++ b/knowledge-base/auth.md
@@ -128,6 +128,13 @@ handler, team ID, key ID + private key → GCIP console / terraform), and add
 `127.0.0.1` to the project's **authorized domains** so the desktop loopback
 `continueUri` is accepted by `createAuthUri`.
 
+**The button is GATED until that setup is done:** `isAppleSignInEnabled()`
+(`identity/config.ts`) reads the baked `APPLE_SIGN_IN_ENABLED` flag (Vite
+define; release CI reads the `APPLE_SIGN_IN_ENABLED` repo VARIABLE, dev
+override `VITE_APPLE_SIGN_IN_ENABLED=1`) — default off, so an unconfigured
+build never shows a sign-in method that can only error. Flip the repo
+variable to `1` after the provider is live; the next release shows the button.
+
 ### Google / Microsoft — web (firebase-js-sdk popup)
 
 `packages/web/src/identity/firebase-popup.ts`: `initializeApp` + `getAuth` +

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -82,6 +82,8 @@ export default defineConfig({
       env: {
         HOUSTON_E2E_WEB_PORT: String(AUTH_WEB_PORT),
         FIREBASE_API_KEY: FAKE_FIREBASE_API_KEY,
+        // Keep the gated Apple button rendered (and covered) in the auth suite.
+        APPLE_SIGN_IN_ENABLED: "1",
       },
       reuseExistingServer: !process.env.CI,
       stdout: "pipe",

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -9,6 +9,7 @@ declare const __POSTHOG_HOST__: string;
 declare const __FIREBASE_API_KEY__: string;
 declare const __FIREBASE_AUTH_DOMAIN__: string;
 declare const __FIREBASE_PROJECT_ID__: string;
+declare const __APPLE_SIGN_IN_ENABLED__: string;
 declare const __GOOGLE_DESKTOP_CLIENT_ID__: string;
 declare const __GOOGLE_DESKTOP_CLIENT_SECRET__: string;
 declare const __MICROSOFT_DESKTOP_CLIENT_ID__: string;

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -92,6 +92,11 @@ export default defineConfig(({ mode }) => {
       // uses firebase-js-sdk (popup); the desktop client id below is a no-op here
       // but kept for define parity so app/src references it in both bundles.
       __FIREBASE_API_KEY__: JSON.stringify(env.FIREBASE_API_KEY ?? ""),
+      // Gates "Continue with Apple" until the GCIP apple.com provider is
+      // configured (see app/vite.config.ts).
+      __APPLE_SIGN_IN_ENABLED__: JSON.stringify(
+        env.APPLE_SIGN_IN_ENABLED ?? "",
+      ),
       __FIREBASE_AUTH_DOMAIN__: JSON.stringify(
         env.FIREBASE_AUTH_DOMAIN ?? "gethouston.firebaseapp.com",
       ),


### PR DESCRIPTION
Release prep for v0.5.6 / cloud-v0.5.6 (follow-up to #882):

**Apple gate** — the Apple button must not ship visible before the one-time GCIP/Apple Developer setup is done (a rendered sign-in method that can only error):
- `isAppleSignInEnabled()` — baked `APPLE_SIGN_IN_ENABLED` Vite define in both bundles, `VITE_APPLE_SIGN_IN_ENABLED` dev override, default **off**.
- Release CI reads the `APPLE_SIGN_IN_ENABLED` repo **variable** in all four build env blocks — flip it to `1` after the provider is configured; the next release shows the button. No code change.
- Playwright auth server bakes the flag on, so the sign-in suite still covers all four methods. 3 new unit tests for the predicate; KB documents the enable procedure.

**Version bump** — 0.5.3 → 0.5.6 (`app/package.json`, `app/src-tauri/Cargo.toml`, `Cargo.lock`), clearing the tag⇄manifest verification for the next release on both channels.

**Release notes** — `.github/release-notes/0.5.6.md` + `.es.md` + `.pt.md`: the Milky Way backdrop + glass cards, the rebuilt migration flow, and the dependable Claude connect (auto-handoff, next-launch self-heal, coalesced human-language errors).

After merge: tag `v0.5.6` and `cloud-v0.5.6` → draft releases + preview deploy; publishing the release (manual QA gate) promotes app.gethouston.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)