### PR TITLE
fix(chat): stop hiding a reply whose text contains an auth code (HOU-734)

### DIFF
--- a/app/src/components/tabs/provider-auth-feed.ts
+++ b/app/src/components/tabs/provider-auth-feed.ts
@@ -25,9 +25,25 @@ const AUTH_PATTERNS = [
   "no provider connected",
 ] as const;
 
+/**
+ * Match each pattern on WORD BOUNDARIES, not as a bare substring: a raw
+ * `.includes("401")` fired inside any token that merely contained the digits —
+ * fatally, inside a hex UUID like `…d96401409c01…`. The routine-setup kickoff
+ * embeds the chat's activity UUID (`setup_activity_id`) in its prompt, and the
+ * agent's reply can echo it, so a conversation whose id happened to contain
+ * `401` had its whole reply misread as an auth error and hidden — the chat
+ * rendered empty (HOU-734). Boundaries keep the intended hits (`Error 401:`,
+ * `401 Unauthorized`) while a code buried in a longer alphanumeric run no
+ * longer matches. The patterns start and end with word characters, so `\b`
+ * anchors both ends cleanly.
+ */
+const AUTH_PATTERN_RES = AUTH_PATTERNS.map(
+  (pattern) =>
+    new RegExp(`\\b${pattern.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}\\b`, "i"),
+);
+
 export function isProviderAuthMessage(message: string): boolean {
-  const lower = message.toLowerCase();
-  return AUTH_PATTERNS.some((pattern) => lower.includes(pattern));
+  return AUTH_PATTERN_RES.some((re) => re.test(message));
 }
 
 export function isProviderAuthFeedItem(item: FeedItem): boolean {

--- a/app/tests/provider-auth-feed.test.ts
+++ b/app/tests/provider-auth-feed.test.ts
@@ -39,6 +39,41 @@ describe("isProviderAuthMessage", () => {
     );
     strictEqual(isProviderAuthMessage("Hallo! Wie kann ich helfen?"), false);
   });
+
+  it("does not match a code buried inside a longer token (HOU-734)", () => {
+    // A `.includes("401")` fired on any hex UUID that contained the digits,
+    // e.g. the activity id the routine-setup kickoff echoes — hiding the whole
+    // reply. Word-boundary matching leaves such an embedded code alone.
+    strictEqual(
+      isProviderAuthMessage(
+        'Set its "setup_activity_id" field to exactly ' +
+          '"9a7a4276-750e-43dc-a551-d96401409c01".',
+      ),
+      false,
+    );
+    // Neither does a plain sentence that merely spells the digits inside a word.
+    strictEqual(isProviderAuthMessage("Order #40199 shipped."), false);
+    // …but a standalone status code is still an auth signal.
+    strictEqual(isProviderAuthMessage("Request failed: 401"), true);
+  });
+});
+
+describe("filterProviderAuthFeedItems keeps a real reply that echoes a 401-bearing id (HOU-734)", () => {
+  it("does not drop the assistant reply or its final_result", () => {
+    const reply =
+      'Roger that. Set "setup_activity_id" to ' +
+      '"9a7a4276-750e-43dc-a551-d96401409c01".';
+    const items: FeedItem[] = [
+      { feed_type: "user_message", data: "" },
+      { feed_type: "assistant_text", data: reply },
+      {
+        feed_type: "final_result",
+        data: { result: reply, cost_usd: null, duration_ms: null, usage: null },
+      },
+    ];
+    const filtered = filterProviderAuthFeedItems(items);
+    strictEqual(filtered.length, 3);
+  });
 });
 
 describe("providerAuthSignalKey", () => {


### PR DESCRIPTION
## The bug (HOU-734)

A chat would occasionally render **empty** — no user bubble, no reply, thinking spinner stuck, composer on Stop — even though the turn had settled correctly and the reply was fully persisted (visible in history and the VM pushes). Rate ~0.17% of e2e repeats; first suspected as a panel-hydration race (the branch name reflects that original hypothesis).

## The actual root cause — empirically confirmed, not the suspected race

`isProviderAuthMessage` matched its auth patterns as **bare substrings**: `lower.includes("401")`. Any message containing the digits `401` anywhere — fatally, **inside a hex UUID** like `d96`**`401`**`409c01` — was classified as a provider-auth error, and `filterProviderAuthFeedItems` (the chat's `mapFeedItems`) hid the entire assistant reply and its `final_result` echo.

The routine-setup kickoff embeds the chat's activity UUID (`setup_activity_id`) in its prompt, and the agent's reply echoes it — so every conversation whose randomly generated UUID happened to contain `401` had its reply silently hidden. UUID probability (~0.2–0.7%) matches the observed flake rate. Diagnosis ground truth came from store probes under an amplified repro: VM scope complete and subscribed (`[user_message, assistant_text, final_result]`, status completed), raw feed length 3, filtered feed length 1.

## Fix

Match each pattern on **word boundaries** (precompiled `\b…\b` regexes) instead of `.includes`: `Error 401:` / `401 Unauthorized` still count as auth signals; a code buried inside a longer alphanumeric run no longer does. Two files: the matcher and its tests.

## Verification

- New regression tests (`app/tests/provider-auth-feed.test.ts`), red on the pre-fix matcher, green post-fix: a code buried in a longer token does not match; a real reply echoing a 401-bearing id is not dropped.
- `routine-setup-chat.spec.ts --repeat-each=40 --workers=1`: 440/440.
- Full Playwright suite with `--fail-on-flaky-tests`: 117/117.
- Unit suites: app 1514, sdk 364, web 187, fake-host 12. Biome + all 24 workspace typechecks clean.
- All diagnostic instrumentation stripped.