### PR TITLE
Fix login input text contrast

### DIFF
--- a/packages/web/e2e/sign-in.spec.ts
+++ b/packages/web/e2e/sign-in.spec.ts
@@ -73,6 +73,19 @@ test.describe("sign-in screen (GCIP)", () => {
     await expect(page.getByRole("button", { name: "Send code" })).toBeVisible();
   });
 
+  test("email and code fields use the pinned dark foreground", async ({
+    page,
+  }) => {
+    const emailInput = page.getByPlaceholder("you@example.com");
+    await emailInput.fill("pilot@example.com");
+    await expect(emailInput).toHaveCSS("color", "rgb(229, 229, 229)");
+
+    await page.getByRole("button", { name: "Send code" }).click();
+    const codeInput = page.getByPlaceholder("123456");
+    await codeInput.fill("123456");
+    await expect(codeInput).toHaveCSS("color", "rgb(229, 229, 229)");
+  });
+
   test("email entry advances to the 6-digit code screen", async ({ page }) => {
     await submitEmail(page, "pilot@example.com");
     // The code step: the numeric input + the confirmation copy naming the email.

--- a/ui/core/src/components/input.tsx
+++ b/ui/core/src/components/input.tsx
@@ -8,7 +8,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
       type={type}
       data-slot="input"
       className={cn(
-        "h-9 w-full min-w-0 rounded-lg border border-line-input bg-transparent px-3 py-1 text-base transition-colors duration-200 outline-none selection:bg-action selection:text-action-text file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-ink placeholder:text-ink-muted disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-line-input/30",
+        "h-9 w-full min-w-0 rounded-lg border border-line-input bg-transparent px-3 py-1 text-base text-ink transition-colors duration-200 outline-none selection:bg-action selection:text-action-text file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-ink placeholder:text-ink-muted disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 dark:bg-line-input/30",
         "focus:border-focus",
         "aria-invalid:border-danger aria-invalid:ring-danger/20 dark:aria-invalid:ring-danger/40",
         className,


### PR DESCRIPTION
## Summary
- set the shared `Input` foreground explicitly to the semantic `text-ink` token
- prevent the `text-base` font-size/color token collision from rendering near-black values in the dark-pinned login card
- add Playwright coverage for both the email and six-digit code fields

## Verification
- `pnpm check`
- `pnpm typecheck`
- `pnpm --filter houston-web exec playwright test e2e/sign-in.spec.ts --project=auth` (5 passed)
- `pnpm --filter houston-web typecheck:e2e`
- `pnpm check:parity`
- manual WebKit screenshots for email and code states; both compute to `rgb(229, 229, 229)`

## Broader suite note
`pnpm --filter houston-web test:e2e` passed 118/119 tests. The unrelated existing routine test `clicking app chrome never dismisses the routine chat` timed out waiting for a seeded routine row; it also failed when rerun alone. The login suite remained green.
