### PR TITLE
fix(release): portable (non-host-tuned) macOS whisper-cli build

### DIFF
--- a/scripts/build-whisper.sh
+++ b/scripts/build-whisper.sh
@@ -171,7 +171,15 @@ case "$OS" in
     # but Accelerate's new cblas ILP64 entry points are weak-linked and marked
     # available only on macOS 13.3+, which would crash on our 10.15 floor. Metal
     # is the accelerator on Apple anyway; the CPU fallback uses ggml's own kernels.
+    # GGML_NATIVE=OFF is load-bearing twice over: (1) a SHIPPED binary must be
+    # portable across every user's Mac, never tuned to the CI host's CPU; and
+    # (2) native detection emits `-mcpu=apple-m<N>` for whatever silicon the
+    # runner has, which a same-image clang that predates that chip rejects
+    # ("unknown target CPU 'apple-m3'" — the v0.5.6 build break when GitHub
+    # rotated the macOS runners to M3). Metal is the accelerator on Apple
+    # anyway; the portable CPU kernels are only the fallback.
     CMAKE_FLAGS+=(
+      -DGGML_NATIVE=OFF
       -DGGML_METAL=ON
       -DGGML_METAL_EMBED_LIBRARY=ON
       -DGGML_BLAS=OFF


### PR DESCRIPTION
The v0.5.6 release runs failed on `build-macos`: ggml's `GGML_NATIVE` (default ON) tunes to the CI host CPU and emitted `-mcpu=apple-m3` when GitHub rotated the macOS runners to M3 — a CPU the image's clang doesn't know. Windows-ARM (the v0.5.3 breaker) now passes with the ClangCL fix; macOS was the last red job on both channels.

`-DGGML_NATIVE=OFF` for macOS, matching the windows/linux branches. This is correct independent of the runner break: a shipped universal sidecar must never be tuned to the build host's CPU. Metal is the accelerator on Apple; the portable CPU kernels are only the fallback.

Verified by building `whisper-cli` for `aarch64-apple-darwin` locally with the changed script.

After merge: drop the failed v0.5.6 draft releases + tags and re-tag `v0.5.6` / `cloud-v0.5.6` on the fix commit (the version was never published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)