### PR TITLE
fix(host): fan out runtime transcript changes

### DIFF
--- a/knowledge-base/files-first.md
+++ b/knowledge-base/files-first.md
@@ -16,6 +16,12 @@ Houston uses files, not DB, for agent-visible data. SQLite only for chat replay 
 > read/write; on managed cloud its durable copy lives in the object store, and a
 > fresh pod is expected to boot empty and rehydrate. The layout, atomic-write
 > discipline, schemas, and reactivity model are identical in both worlds.
+>
+> **Canonical chat storage:** v3 conversation transcripts live under
+> `.houston/runtime/conversations/`; pi session state lives under
+> `.houston/runtime/sessions/`. The host file watcher classifies writes to both
+> as `ConversationsChanged`, which the gateway fans to every client so an open
+> chat on another device reloads the same transcript.
 
 > **Updated: the backend is the TypeScript host now, not the Rust engine.** The
 > `.houston/` layout, atomic-write discipline, JSON schemas, and AI-native
@@ -187,7 +193,7 @@ Users + LLMs equal participants. Both read/write all workspace data. All changes
 ### Three-layer reactivity stack
 1. **TanStack Query (frontend)** — all `.houston/` fetches via `useQuery`. Query keys: `["activity", agentPath]` etc. Dedup, background refresh, stale-while-revalidate.
 2. **Event emission on engine writes** — the engine's write helpers emit `HoustonEvent` variants (`SkillsChanged`, `ActivityChanged`, `LearningsChanged`, …) onto its broadcast bus. The desktop WS client (`ui/engine-client`) fans them out; global listeners in `app/src/hooks/use-agent-invalidation.ts` invalidate the matching query key.
-3. **File watcher on `.houston/` (Rust `notify`, `houston-file-watcher`)** — catches direct agent writes that bypass the engine's write path. Emits the same events onto the same bus. Debounced.
+3. **Host file watcher (`packages/host/src/watch/`)** — catches direct runtime and agent writes that bypass host routes. It classifies canonical `.houston/runtime/{conversations,sessions}/**` writes as `ConversationsChanged`, emits onto the host `/v1/events` channel, and debounces bursts. In managed cloud, the gateway's pod-event fan-in republishes that event to every connected client for the user.
 
 ### The rule
 Never build feature where agent changes data but UI won't reflect until refresh. If in `.houston/`, must be reactive.

--- a/packages/domain/src/reactivity.ts
+++ b/packages/domain/src/reactivity.ts
@@ -45,8 +45,8 @@ export function agentFileEventType(
   if (relPath.startsWith(".houston/config")) return "ConfigChanged";
   if (relPath.startsWith(".houston/learnings")) return "LearningsChanged";
   if (
-    relPath.startsWith(".houston/conversations") ||
-    relPath.startsWith(".houston/sessions")
+    relPath.startsWith(".houston/runtime/conversations") ||
+    relPath.startsWith(".houston/runtime/sessions")
   ) {
     return "ConversationsChanged";
   }

--- a/packages/host/src/local/reactivity.test.ts
+++ b/packages/host/src/local/reactivity.test.ts
@@ -69,9 +69,11 @@ async function bootLocal(): Promise<{
   // arms (mirrors a real install: schemas are seeded on agent create). The
   // recursive fs.watch then reports the activity.json write at its full path —
   // a dir created AFTER arming can surface as a coarse parent-dir event.
-  mkdirSync(join(workspacesRoot, "Work", "Sales", ".houston", "activity"), {
-    recursive: true,
-  });
+  for (const dir of ["activity", "runtime/conversations"]) {
+    mkdirSync(join(workspacesRoot, "Work", "Sales", ".houston", dir), {
+      recursive: true,
+    });
+  }
   const credentialsPath = join(
     mkdtempSync(join(tmpdir(), "parity-react-cred-")),
     "credentials.json",
@@ -187,6 +189,40 @@ async function waitForEvent(
     ac.abort();
   }
 }
+
+test("a runtime transcript write surfaces ConversationsChanged on /v1/events", async () => {
+  const { host, base, workspacesRoot } = await bootLocal();
+  const conversationsDir = join(
+    workspacesRoot,
+    "Work",
+    "Sales",
+    ".houston",
+    "runtime",
+    "conversations",
+  );
+  try {
+    const event = await waitForEvent(
+      base,
+      () => {
+        setTimeout(() => {
+          writeFileSync(
+            join(conversationsDir, "activity-a1.json"),
+            JSON.stringify({ id: "activity-a1", messages: [] }),
+          );
+        }, 150);
+      },
+      (candidate) =>
+        candidate.type === "ConversationsChanged" &&
+        candidate.agentPath === "Work/Sales",
+    );
+    expect(event).toEqual({
+      type: "ConversationsChanged",
+      agentPath: "Work/Sales",
+    });
+  } finally {
+    host.stop();
+  }
+});
 
 test("a direct .houston file write surfaces on /v1/events (FsWatcher → SSE)", async () => {
   const { host, base, workspacesRoot } = await bootLocal();

--- a/packages/host/src/watch/classify.test.ts
+++ b/packages/host/src/watch/classify.test.ts
@@ -31,12 +31,12 @@ const cases: [string, string | null, string | null][] = [
     "Work/Sales",
   ],
   [
-    "Work/Sales/.houston/conversations/c1.json",
+    "Work/Sales/.houston/runtime/conversations/c1.json",
     "ConversationsChanged",
     "Work/Sales",
   ],
   [
-    "Work/Sales/.houston/sessions/anthropic/s1.json",
+    "Work/Sales/.houston/runtime/sessions/c1/session.jsonl",
     "ConversationsChanged",
     "Work/Sales",
   ],


### PR DESCRIPTION
## Summary

- classify canonical `.houston/runtime/{conversations,sessions}` writes as `ConversationsChanged`
- add an assembled filesystem watcher → `/v1/events` regression test
- update the files-first reactivity documentation

## Root cause

Runtime transcripts moved under `.houston/runtime`, but the shared watcher classifier still matched the deleted legacy paths. Transcript writes were therefore emitted as `FilesChanged` instead of `ConversationsChanged`.

Other connected clients still received `ActivityChanged`, so their composer switched to Stop, but they never invalidated and reloaded the open chat history. The gateway fan-out itself was operating correctly; it was receiving the wrong event vocabulary from the engine pod.

## Verification

- `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test`
- `pnpm --filter @houston/domain --filter @houston/host typecheck`
- `pnpm check`
- `pnpm check:boundaries`
- cloud gateway fan-out/proxy suites: `go test ./internal/edge/events ./internal/proxy`

The new assembled regression test failed before the classifier fix and passes afterward.
