### PR TITLE
fix(sdk): refresh remote conversation turns

### DIFF
--- a/knowledge-base/client-architecture.md
+++ b/knowledge-base/client-architecture.md
@@ -76,8 +76,12 @@ end-state is that it dissolves into direct SDK consumption
   WRITES. Do not adopt the SDK's scope snapshots as the web read model.
 - **Turn/feed + reactivity already run on the SDK.** `turn-stream.ts` delegates
   to the SDK's `streamTurn`/`observeConversation`; `feed-output.ts` implements the
-  SDK's `FeedOutput`; both the SDK and adapter consume the ONE `streamGlobalEvents`
-  in `runtime-client`. The conversation VM cache is bounded — `ConversationVmOutput`
+  SDK's `FeedOutput`; both the SDK and adapter use the canonical `streamGlobalEvents`
+  loop in `runtime-client`. With SDK reactivity enabled (native), the turns module
+  handles `ConversationsChanged` by reloading subscribed conversation VMs, including
+  an idle open chat whose per-conversation observer has closed. Web/desktop leave
+  SDK reactivity disabled and perform the same invalidation through their existing
+  TanStack Query event bus. The conversation VM cache is bounded — `ConversationVmOutput`
   keeps folded transcripts in an `LruCache` (default `conversationCacheMax` 50);
   idle conversations evict and re-hydrate from history, live/subscribed ones are
   pinned, `turns.forget(id)` drops one explicitly.

--- a/packages/fake-host/src/state-history.ts
+++ b/packages/fake-host/src/state-history.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ChatMessage } from "@houston/runtime-client";
-import { EPOCH, SEED_USAGE, state } from "./state-store";
+import { EPOCH, emitDomain, SEED_USAGE, state } from "./state-store";
 
 export function getHistory(
   agentId: string,
@@ -28,6 +28,7 @@ export function appendUserMessage(
   const list = state.histories.get(key) ?? [];
   list.push({ role: "user", content: userText, ts: EPOCH, turnId });
   state.histories.set(key, list);
+  emitDomain("ConversationsChanged", agentId);
 }
 
 /**
@@ -44,6 +45,7 @@ export function appendStoppedMessage(
   const list = state.histories.get(key) ?? [];
   list.push({ role: "assistant", content: "", ts: EPOCH, stopped: true });
   state.histories.set(key, list);
+  emitDomain("ConversationsChanged", agentId);
 }
 
 /**
@@ -71,4 +73,5 @@ export function appendAssistantMessage(
     ...(pendingInteraction ? { pendingInteraction } : {}),
   });
   state.histories.set(key, list);
+  emitDomain("ConversationsChanged", agentId);
 }

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -101,8 +101,10 @@ facade exposed as a property (`sdk.session`, `sdk.agents`, …). The `ctx`
 client resolver (`clientFor(agentId)` — the host nests routes under
 `/agents/<id>`), and the shared auth-expiry notifier, so every module speaks the
 same transport and emits one canonical `session/tokenExpired` signal. Tear the
-SDK down with `sdk.dispose()` (stops the agents reactivity stream and every
-in-flight turn stream).
+SDK down with `sdk.dispose()` (stops the agents, activities, and conversation
+reactivity streams plus every in-flight turn stream). Native clients receive
+`ConversationsChanged` through the turns module: subscribed conversation VMs
+reload their persisted history, including after an idle observer has closed.
 
 ## Native bridge — embedding the SDK in a mobile host
 

--- a/packages/sdk/src/modules/turns/events-stream.test.ts
+++ b/packages/sdk/src/modules/turns/events-stream.test.ts
@@ -1,0 +1,65 @@
+import { streamGlobalEvents } from "@houston/runtime-client";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Clock, SdkLogger } from "../../ports";
+import { startTurnsEventStream } from "./events-stream";
+
+vi.mock("@houston/runtime-client", () => ({
+  streamGlobalEvents: vi.fn(),
+}));
+
+const clock: Clock = {
+  now: () => 0,
+  setTimeout: () => 1,
+  clearTimeout: () => {},
+};
+
+function logger(debug: ReturnType<typeof vi.fn>): SdkLogger {
+  return {
+    debug,
+    info: () => {},
+    warn: () => {},
+    error: () => {},
+  };
+}
+
+describe("turns global event stream", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("routes conversation changes, reconnects, failures, and disposal", () => {
+    let options: Parameters<typeof streamGlobalEvents>[0] | undefined;
+    vi.mocked(streamGlobalEvents).mockImplementation(async (next) => {
+      options = next;
+    });
+    const onConnect = vi.fn();
+    const onConversationsChanged = vi.fn();
+    const onUnauthorized = vi.fn();
+    const debug = vi.fn();
+
+    const stop = startTurnsEventStream({
+      baseUrl: "https://host.example/",
+      fetch: vi.fn(),
+      clock,
+      logger: logger(debug),
+      handlers: { onConnect, onConversationsChanged, onUnauthorized },
+    });
+
+    expect(options?.url()).toBe("https://host.example/v1/events");
+    options?.onConnect?.();
+    options?.onEvent?.({ type: "ActivityChanged", agentPath: "a-1" });
+    options?.onEvent?.({ type: "ConversationsChanged", agentPath: "a-1" });
+    options?.onEvent?.({ type: "ConversationsChanged" });
+    options?.onUnauthorized?.();
+    options?.onError?.(new Error("offline"));
+
+    expect(onConnect).toHaveBeenCalledOnce();
+    expect(onConversationsChanged).toHaveBeenNthCalledWith(1, "a-1");
+    expect(onConversationsChanged).toHaveBeenNthCalledWith(2, undefined);
+    expect(onUnauthorized).toHaveBeenCalledOnce();
+    expect(debug).toHaveBeenCalledWith("turns event stream dropped", {
+      error: "Error: offline",
+    });
+    expect(options?.signal.aborted).toBe(false);
+    stop();
+    expect(options?.signal.aborted).toBe(true);
+  });
+});

--- a/packages/sdk/src/modules/turns/events-stream.ts
+++ b/packages/sdk/src/modules/turns/events-stream.ts
@@ -1,0 +1,70 @@
+import { streamGlobalEvents } from "@houston/runtime-client";
+import type { Clock, SdkLogger } from "../../ports";
+
+const CONVERSATIONS_CHANGED_EVENT = "ConversationsChanged";
+const RECONNECT_DELAY_MS = 1500;
+
+export interface TurnsStreamHandlers {
+  /** Reconnected: refresh every actively viewed conversation to catch up gaps. */
+  onConnect(): void;
+  /** Refresh actively viewed conversations for this agent (or all if absent). */
+  onConversationsChanged(agentPath: string | undefined): void;
+  onUnauthorized(): void;
+}
+
+export interface TurnsStreamDeps {
+  baseUrl: string;
+  fetch: typeof fetch;
+  clock: Clock;
+  logger: SdkLogger;
+  handlers: TurnsStreamHandlers;
+}
+
+/** Keep native conversation VMs current from the host's global event stream. */
+export function startTurnsEventStream(deps: TurnsStreamDeps): () => void {
+  const ac = new AbortController();
+  const { clock, logger, handlers } = deps;
+  const root = deps.baseUrl.replace(/\/+$/, "");
+  void streamGlobalEvents({
+    url: () => `${root}/v1/events`,
+    fetch: deps.fetch,
+    signal: ac.signal,
+    delayMs: RECONNECT_DELAY_MS,
+    sleep: (ms, signal) => sleep(clock, ms, signal),
+    onConnect: handlers.onConnect,
+    onUnauthorized: handlers.onUnauthorized,
+    onError: (err) =>
+      logger.debug("turns event stream dropped", { error: String(err) }),
+    onEvent: (data) => {
+      const agentPath = conversationsChangedAgent(data);
+      if (agentPath !== null) handlers.onConversationsChanged(agentPath);
+    },
+  });
+  return () => ac.abort();
+}
+
+function conversationsChangedAgent(data: unknown): string | undefined | null {
+  if (
+    typeof data !== "object" ||
+    data === null ||
+    (data as { type?: unknown }).type !== CONVERSATIONS_CHANGED_EVENT
+  )
+    return null;
+  const agentPath = (data as { agentPath?: unknown }).agentPath;
+  return typeof agentPath === "string" ? agentPath : undefined;
+}
+
+function sleep(clock: Clock, ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve) => {
+    if (signal.aborted) return resolve();
+    const id = clock.setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    function onAbort() {
+      clock.clearTimeout(id);
+      resolve();
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}

--- a/packages/sdk/src/modules/turns/index.test.ts
+++ b/packages/sdk/src/modules/turns/index.test.ts
@@ -80,6 +80,7 @@ function harness(frames: WireFrame[] = doneTurn) {
     config: {
       baseUrl: "http://x",
       ports: { logger } as unknown as SdkConfig["ports"],
+      reactivity: false,
     },
     store,
     // One injected engine for any agent id — this suite asserts through the

--- a/packages/sdk/src/modules/turns/index.ts
+++ b/packages/sdk/src/modules/turns/index.ts
@@ -7,6 +7,7 @@ import {
   asAttachmentsSaveInput,
   createAttachmentsOperation,
 } from "./attachments";
+import { startTurnsEventStream } from "./events-stream";
 import type { FeedOutput } from "./feed-output";
 import { createTurnOperations } from "./operations";
 import { StreamRegistry } from "./stream-registry";
@@ -54,13 +55,26 @@ export function createTurnsModule(
   // web adapter) can't cross-abort our streams or collide on a shared key.
   const registry = new StreamRegistry();
 
-  const { send, observe, history, cancel } = createTurnOperations(ctx, {
+  const operations = createTurnOperations(ctx, {
     vm,
     defaults,
     external,
     registry,
   });
+  const { send, observe, history, cancel } = operations;
   const attachments = createAttachmentsOperation(ctx);
+  const stopEvents =
+    ctx.config.reactivity === false
+      ? () => {}
+      : startTurnsEventStream({
+          baseUrl: ctx.config.baseUrl,
+          ...ctx.config.ports,
+          handlers: {
+            onConnect: () => operations.refreshObserved(),
+            onConversationsChanged: operations.refreshObserved,
+            onUnauthorized: () => ctx.authExpiry.notifyExpired(),
+          },
+        });
 
   ctx.registerCommand("turns/send", (payload) => send(asSendInput(payload)));
   ctx.registerCommand("turns/attachments/save", (payload) =>
@@ -100,6 +114,7 @@ export function createTurnsModule(
      */
     forget(conversationId: string, agentId?: string): void {
       vm.forget(agentId ?? "", conversationId);
+      operations.forgetObserved(conversationId, agentId);
     },
     /**
      * Attach an extra {@link FeedOutput} that every subsequent turn also drives
@@ -113,6 +128,7 @@ export function createTurnsModule(
     },
     /** Abort every live turn/observer stream this module owns (SDK teardown). */
     dispose(): void {
+      stopEvents();
       registry.disposeAll();
     },
   };

--- a/packages/sdk/src/modules/turns/operations.ts
+++ b/packages/sdk/src/modules/turns/operations.ts
@@ -6,7 +6,7 @@ import { observeConversation } from "./observe-stream";
 import { type StreamRegistry, streamKey } from "./stream-registry";
 import type { TurnSendInput } from "./turn-inputs";
 import { streamTurn, type TurnWirePin } from "./turn-stream";
-import type { ConversationVmOutput } from "./vm-output";
+import { type ConversationVmOutput, conversationScope } from "./vm-output";
 
 /** The always-on state the four turn operations drive and share. */
 export interface TurnOperationsDeps {
@@ -25,6 +25,10 @@ export interface TurnOperations {
   observe(conversationId: string, agentId?: string): Promise<void>;
   history(conversationId: string, agentId?: string): Promise<FeedFrame[]>;
   cancel(conversationId: string, agentId?: string): Promise<void>;
+  /** Refresh actively subscribed conversations after a global change event. */
+  refreshObserved(agentId?: string): void;
+  /** Remove one conversation from the global-refresh registry. */
+  forgetObserved(conversationId: string, agentId?: string): void;
 }
 
 /**
@@ -36,6 +40,10 @@ export function createTurnOperations(
   ctx: ModuleContext,
   { vm, defaults, external, registry }: TurnOperationsDeps,
 ): TurnOperations {
+  const observed = new Map<
+    string,
+    { agentId: string; conversationId: string }
+  >();
   /**
    * Start a turn against the agent's sandbox client (`clientFor(agentId)` — the
    * host nests turn/settings routes under `/agents/<id>`). A model/effort pick
@@ -98,15 +106,17 @@ export function createTurnOperations(
     conversationId: string,
     agentId?: string,
   ): Promise<void> => {
-    const client = ctx.clientFor(agentId ?? "");
-    const key = streamKey(agentId ?? "", conversationId);
+    const resolvedAgentId = agentId ?? "";
+    const client = ctx.clientFor(resolvedAgentId);
+    const key = streamKey(resolvedAgentId, conversationId);
+    observed.set(key, { agentId: resolvedAgentId, conversationId });
     const { messages } = await client.getHistory(conversationId);
     const output = new MultiplexFeedOutput([...defaults, ...external]);
     if (!registry.get(key))
-      vm.seedHistory(agentId ?? "", conversationId, historyToFeed(messages));
+      vm.seedHistory(resolvedAgentId, conversationId, historyToFeed(messages));
     observeConversation(
       client,
-      agentId ?? "",
+      resolvedAgentId,
       conversationId,
       output,
       messages.length,
@@ -137,5 +147,37 @@ export function createTurnOperations(
     await ctx.clientFor(agentId ?? "").cancel(conversationId);
   };
 
-  return { send, observe, history, cancel };
+  const forgetObserved = (conversationId: string, agentId?: string): void => {
+    observed.delete(streamKey(agentId ?? "", conversationId));
+  };
+
+  const refreshObserved = (agentId?: string): void => {
+    for (const [key, ref] of observed) {
+      if (agentId !== undefined && ref.agentId !== agentId) continue;
+      if (
+        !ctx.store.hasSubscribers(
+          conversationScope(ref.agentId, ref.conversationId),
+        )
+      ) {
+        observed.delete(key);
+        continue;
+      }
+      void observe(ref.conversationId, ref.agentId).catch((err) =>
+        ctx.config.ports.logger.debug("conversation refresh failed", {
+          agentId: ref.agentId,
+          conversationId: ref.conversationId,
+          error: String(err),
+        }),
+      );
+    }
+  };
+
+  return {
+    send,
+    observe,
+    history,
+    cancel,
+    refreshObserved,
+    forgetObserved,
+  };
 }

--- a/packages/sdk/tests/turns.contract.test.ts
+++ b/packages/sdk/tests/turns.contract.test.ts
@@ -27,6 +27,7 @@ import {
   type Harness,
   makeSdk,
   resetHost,
+  sleep,
   startHost,
   until,
 } from "./harness";
@@ -179,6 +180,48 @@ describe("turn send → stream → settle", () => {
     // Both messages of a turn share its id (the resync-by-turnId contract).
     expect(messages[0].turnId).toBeTruthy();
     expect(messages[1].turnId).toBe(messages[0].turnId);
+  });
+});
+
+describe("multi-client conversation reactivity", () => {
+  it("reloads an open idle chat when another client completes a turn", async () => {
+    const cid = "c-other-client";
+    const receiver = makeSdk(host.url);
+    const scope = conversationScope(SEED_AGENT_ID, cid);
+    const off = receiver.sdk.subscribe(scope, () => {});
+    try {
+      // iOS opens the chat while it is idle. Its per-conversation observer sees
+      // the idle sync and closes; future turns must arrive through the SDK's
+      // global ConversationsChanged reactivity path.
+      await receiver.sdk.turns.observe(cid, SEED_AGENT_ID);
+      await sleep(100);
+
+      await h.sdk.turns.send({
+        agentId: SEED_AGENT_ID,
+        conversationId: cid,
+        text: "From the other client",
+      });
+
+      await until(
+        () =>
+          convVm(receiver.sdk, cid)?.feed.some(
+            (item) =>
+              item.feed_type === "assistant_text" &&
+              item.data === cannedReply("From the other client"),
+          ) === true,
+        "receiver reloaded the other client's completed turn",
+      );
+      expect(
+        convVm(receiver.sdk, cid)?.feed.some(
+          (item) =>
+            item.feed_type === "user_message" &&
+            item.data === "From the other client",
+        ),
+      ).toBe(true);
+    } finally {
+      off();
+      receiver.sdk.dispose();
+    }
   });
 });
 

--- a/packages/web/src/engine-adapter/sdk-client.ts
+++ b/packages/web/src/engine-adapter/sdk-client.ts
@@ -11,7 +11,7 @@
  * that later waves delegate those writes to, so web matches iOS.
  *
  * **Wave 1 is the inert seam.** Construction opens NO network: the SDK is built
- * with `reactivity: false`, so its agents/activities modules do NOT start their
+ * with `reactivity: false`, so its agents/activities/turns modules do NOT start
  * `/v1/events` streams — web keeps its own read model (TanStack Query) and its
  * own `/v1/events` bus (`client.ts subscribeServerEvents`) unchanged. The SDK
  * exposes only its WRITE surface for wave 2 (`sdk.agents/activities/providers/


### PR DESCRIPTION
## Summary

- handle `ConversationsChanged` in the shared SDK turns module for native clients
- reload only actively subscribed conversation VMs, including idle chats whose per-conversation observer already closed
- refresh active conversations again after global-event reconnects to catch missed notifications
- preserve web/desktop's existing TanStack Query event path because their SDK is intentionally constructed with `reactivity: false`

## Why this follows #888

#888 fixed the source event vocabulary: canonical runtime transcript writes now fan out as `ConversationsChanged`. It merged while the native-client extension was still in progress, so this follow-up consumes that event in `@houston/sdk` for iOS and future native surfaces.

All clients share SDK turn streaming and the Conversation VM. Web/desktop are currently transitional: they use the SDK for turn behavior but keep SDK global reactivity disabled and consume `/v1/events` through the web adapter. iOS uses SDK-owned reactivity, so this PR adds the missing native refresh path without Swift surface logic or duplicate web event streams.

## Tests

- added a two-SDK contract test: an idle receiver opens a chat, another client completes a turn, and the receiver gets both messages
- added event-stream routing, reconnect, failure logging, unauthorized, and disposal coverage
- the existing `reactivity: false` SDK test verifies inert web/desktop construction

Verified:

- `pnpm --filter @houston/sdk test`
- `pnpm --filter @houston/sdk typecheck`
- `pnpm --filter @houston/host --filter @houston/runtime --filter @houston/domain test`
- `pnpm --filter @houston/fake-host typecheck`
- `pnpm --filter houston-web typecheck`
- `pnpm --filter @houston/sdk build:bridge`
- `pnpm check:boundaries`
- `pnpm check`
