### PR TITLE
fix(ui): keep the open chat panel mounted while its card is transiently absent

### DIFF
--- a/app/src/components/board/mission-board.tsx
+++ b/app/src/components/board/mission-board.tsx
@@ -49,10 +49,16 @@ export function MissionBoard({ source }: { source: BoardSource }) {
       ),
     [t, source.openNewMission],
   );
+  const closeOpenChat = useCallback(
+    () => source.setSelectedId(null),
+    [source.setSelectedId],
+  );
   const { columns, selectionProps } = useBoardSelectionUI({
     baseColumns,
     allItems: source.allItems,
     selection: source.selection,
+    openChatId: source.selectedId,
+    onCloseOpenChat: closeOpenChat,
   });
 
   // Per-agent chat panel features (skills, model selector, tool/link

--- a/app/src/components/board/use-board-selection-ui.tsx
+++ b/app/src/components/board/use-board-selection-ui.tsx
@@ -27,10 +27,21 @@ export function useBoardSelectionUI({
   baseColumns,
   allItems,
   selection,
+  openChatId,
+  onCloseOpenChat,
 }: {
   baseColumns: KanbanColumnConfig[];
   allItems: KanbanItem[];
   selection?: BoardSelectionModel;
+  /**
+   * Id of the mission whose chat panel is open. A bulk archive/delete that
+   * covers it also closes the panel via `onCloseOpenChat` — the panel stays
+   * open across ANY other item churn (its visibility keys off the selection,
+   * see `resolvePanelState` in @houston-ai/board), so a removal the user
+   * just ordered must deselect explicitly.
+   */
+  openChatId?: string | null;
+  onCloseOpenChat?: () => void;
 }) {
   const { t } = useTranslation(["board", "dashboard"]);
   const addToast = useUIStore((s) => s.addToast);
@@ -141,6 +152,21 @@ export function useBoardSelectionUI({
     [addToast, t],
   );
 
+  // Run a bulk op that removes cards from the board; when the open chat's
+  // mission is among them, deselect it AFTER the op succeeds so its panel
+  // closes with the cards (membership is read before `op` — success clears
+  // the selection set).
+  const runBulkRemoval = useCallback(
+    (op: () => Promise<void>) =>
+      runBulk(async () => {
+        const closesOpenChat =
+          openChatId != null && selection?.selectedIds.has(openChatId);
+        await op();
+        if (closesOpenChat) onCloseOpenChat?.();
+      }),
+    [runBulk, selection, openChatId, onCloseOpenChat],
+  );
+
   const bulkActions = useMemo(() => {
     if (!selection) return undefined;
     return {
@@ -154,8 +180,8 @@ export function useBoardSelectionUI({
         }),
       ),
       onMove: (status: string) => runBulk(() => selection.move(status)),
-      onArchive: () => runBulk(() => selection.archive()),
-      onDelete: () => runBulk(() => selection.remove()),
+      onArchive: () => runBulkRemoval(() => selection.archive()),
+      onDelete: () => runBulkRemoval(() => selection.remove()),
       onClear: selection.clear,
       labels: {
         selected: (count: number) => t("board:bulk.selected", { count }),
@@ -178,7 +204,7 @@ export function useBoardSelectionUI({
         confirmDeleteAction: t("board:bulk.confirmDelete.action"),
       },
     };
-  }, [selection, selectionLockColumnId, runBulk, t]);
+  }, [selection, selectionLockColumnId, runBulk, runBulkRemoval, t]);
 
   const selectionProps =
     selection && bulkActions

--- a/ui/board/src/ai-board.tsx
+++ b/ui/board/src/ai-board.tsx
@@ -14,6 +14,7 @@ import { KanbanBoard } from "./kanban-board";
 import type { KanbanCardLabels } from "./kanban-card";
 import { KanbanDetailPanel } from "./kanban-detail-panel";
 import { KanbanList } from "./kanban-list";
+import { type ResolvedSelection, resolvePanelState } from "./panel-state";
 import type { BoardSearchSnippet, KanbanColumn, KanbanItem } from "./types";
 
 export interface NewPanelOptions {
@@ -412,35 +413,30 @@ export function AIBoard({
     if (selectedId) hydrateSession(selectedId);
   }, []);
 
-  // Set by handleSend right before it selects the conversation it just
-  // created, so the selection effect below can tell that internal
-  // selection apart from an external one (arrow keys, notification
-  // jump). Only external changes may close the "new mission" panel.
-  const createdSelectionRef = useRef<string | null>(null);
-
-  // When the selection changes from OUTSIDE (e.g. arrow-key navigation
-  // sets selectedId via the controlled prop, or session-notifications
-  // jumps to a different mission), hydrate the new session, close any
-  // "new mission" panel, and bump the composer focus token so the user
-  // can start typing immediately without reaching for the mouse.
+  // When a selection appears (a card click, arrow-key navigation, a
+  // notification jump, or the first send creating a conversation), hydrate
+  // the session, retire the "new mission" panel state, and bump the composer
+  // focus token so the user can start typing immediately without reaching
+  // for the mouse. Closing `newPanelOpen` here is safe even while the
+  // created activity hasn't landed in `items` yet: panel visibility keys off
+  // the selection itself (see resolvePanelState), not the resolved card.
   useEffect(() => {
     if (!selectedId) return;
     hydrateSession(selectedId);
-    if (createdSelectionRef.current === selectedId) {
-      // First-send flow: the freshly created activity isn't in `items`
-      // yet (the parent's list query is still refetching), so closing
-      // `newPanelOpen` would collapse `showPanel` and unmount the chat
-      // panel until the refetch lands (HOU-640).
-      createdSelectionRef.current = null;
-    } else {
-      setNewPanelOpen(false);
-    }
+    setNewPanelOpen(false);
     if (!disableComposerAutoFocus) {
       setComposerFocusToken((prev) => (prev ?? 0) + 1);
     }
   }, [selectedId, hydrateSession, disableComposerAutoFocus]);
 
   const selectedItem = items.find((i) => i.id === selectedId) ?? null;
+  // The same selection's last resolved card — the panel header's fallback
+  // while the card is transiently absent from `items` (engine cold start /
+  // refetch races). Render-time write, idempotent per (selectedId, items).
+  const lastResolvedRef = useRef<ResolvedSelection | null>(null);
+  if (selectedId && selectedItem) {
+    lastResolvedRef.current = { id: selectedId, item: selectedItem };
+  }
 
   const openNewPanel = useCallback(
     (options?: NewPanelOptions) => {
@@ -515,17 +511,11 @@ export function AIBoard({
       } else if (newPanelOpen && onCreateConversation) {
         const activityId = await onCreateConversation(text, files);
         onDraftChange?.(activeDraftKey, "");
-        // Select the new activity so the feed renders. We deliberately
-        // leave `newPanelOpen` truthy: there's a brief race where the
-        // freshly-created activity isn't yet in `items` (the parent
-        // invalidates the activity query asynchronously) and during
-        // that window `selectedItem` is still null. Closing
-        // `newPanelOpen` would collapse `showPanel` to false and
-        // dismiss the panel mid-create — `createdSelectionRef` tells
-        // the selection effect above to keep it open. `newPanelOpen`
-        // resets naturally on the next external selection, card
-        // select, or outside-click close.
-        createdSelectionRef.current = activityId;
+        // Select the new activity so the feed renders. The freshly-created
+        // activity may take a while to appear in `items` (the parent
+        // invalidates the activity query asynchronously; against a warming
+        // engine the row only lands when it wakes) — the panel stays open
+        // regardless, keyed off this selection (see resolvePanelState).
         setSelectedId(activityId);
       }
     },
@@ -555,12 +545,19 @@ export function AIBoard({
         })
       : afterMessages;
 
-  const showPanel = selectedItem || newPanelOpen;
-  const panelTitle = selectedItem?.title ?? "New conversation";
+  const { showPanel, panelItem } = resolvePanelState({
+    selectedId,
+    newPanelOpen,
+    selectedItem,
+    lastResolved: lastResolvedRef.current,
+  });
+  // Blank while a selected chat's card hasn't resolved yet — never the
+  // new-conversation label on an existing chat.
+  const panelTitle = panelItem?.title ?? (selectedId ? "" : "New conversation");
 
   // Notify parent when panel opens/closes
   useEffect(() => {
-    onPanelOpenChange?.(!!showPanel);
+    onPanelOpenChange?.(showPanel);
   }, [showPanel, onPanelOpenChange]);
 
   // Ensure parent resets its "panel open" state when AIBoard unmounts
@@ -716,12 +713,12 @@ export function AIBoard({
       onClose={hidePanelClose ? undefined : closePanel}
       leading={panelLeading}
       avatar={panelAvatar}
-      agentName={panelAgentName ?? selectedItem?.group}
+      agentName={panelAgentName ?? panelItem?.group}
       missionLabelOverride={panelMissionLabel}
-      people={selectedItem?.people}
+      people={panelItem?.people}
       peopleLabel={cardLabels?.people}
       peopleExpandLabel={cardLabels?.peopleExpand}
-      actions={selectedItem ? panelActions?.(selectedItem) : undefined}
+      actions={panelItem ? panelActions?.(panelItem) : undefined}
     >
       <div className="flex-1 min-h-0 flex flex-col">
         <ChatPanel

--- a/ui/board/src/panel-state.ts
+++ b/ui/board/src/panel-state.ts
@@ -1,0 +1,44 @@
+import type { KanbanItem } from "./types";
+
+/** Last selection the board managed to resolve against `items`. */
+export interface ResolvedSelection {
+  id: string;
+  item: KanbanItem;
+}
+
+/**
+ * Detail-panel visibility + header card, derived from the selection.
+ *
+ * Visibility keys off the SELECTION, never off the selected card's presence
+ * in `items`: a selected mission can be transiently absent from the list —
+ * an engine cold start holds the list read, and the refetches racing right
+ * after the engine wakes can resolve before the just-created row lands — and
+ * an item-presence check unmounted the whole chat panel for that window and
+ * remounted it a beat later (a visible close/reopen flicker of an open chat,
+ * HOU-693/HOU-730). The open conversation must outlive its card: only an
+ * explicit deselect (close button, outside click, Escape, delete, agent
+ * switch) closes the panel.
+ *
+ * While the card is absent, `panelItem` falls back to the same selection's
+ * last resolved card, so the header (title, people, actions) doesn't flash
+ * while the row is away. A selection that never resolved (a chat opened
+ * against a still-warming engine) renders with no card until the row lands.
+ */
+export function resolvePanelState({
+  selectedId,
+  newPanelOpen,
+  selectedItem,
+  lastResolved,
+}: {
+  selectedId: string | null;
+  newPanelOpen: boolean;
+  selectedItem: KanbanItem | null;
+  lastResolved: ResolvedSelection | null;
+}): { showPanel: boolean; panelItem: KanbanItem | null } {
+  const panelItem =
+    selectedItem ??
+    (selectedId !== null && lastResolved?.id === selectedId
+      ? lastResolved.item
+      : null);
+  return { showPanel: selectedId !== null || newPanelOpen, panelItem };
+}

--- a/ui/board/tests/panel-state.test.ts
+++ b/ui/board/tests/panel-state.test.ts
@@ -1,0 +1,95 @@
+import { strict as assert } from "node:assert";
+import { describe, it } from "node:test";
+import { resolvePanelState } from "../src/panel-state.ts";
+import type { KanbanItem } from "../src/types.ts";
+
+const card = (id: string, title = `Mission ${id}`): KanbanItem => ({
+  id,
+  title,
+  status: "running",
+  updatedAt: "2026-01-01T00:00:00.000Z",
+});
+
+describe("resolvePanelState", () => {
+  it("shows the panel with the resolved card for a selected mission", () => {
+    const item = card("a1");
+    const state = resolvePanelState({
+      selectedId: "a1",
+      newPanelOpen: false,
+      selectedItem: item,
+      lastResolved: null,
+    });
+    assert.equal(state.showPanel, true);
+    assert.equal(state.panelItem, item);
+  });
+
+  it("keeps the panel open while the selected card is transiently absent", () => {
+    // The engine-cold-start window: the selection exists but the card hasn't
+    // landed in (or briefly dropped out of) `items`. The panel must not
+    // unmount — this was the open-chat close/reopen flicker.
+    const state = resolvePanelState({
+      selectedId: "a1",
+      newPanelOpen: false,
+      selectedItem: null,
+      lastResolved: null,
+    });
+    assert.equal(state.showPanel, true);
+    assert.equal(state.panelItem, null);
+  });
+
+  it("falls back to the same selection's last resolved card", () => {
+    const item = card("a1", "Summarize my inbox");
+    const state = resolvePanelState({
+      selectedId: "a1",
+      newPanelOpen: false,
+      selectedItem: null,
+      lastResolved: { id: "a1", item },
+    });
+    assert.equal(state.showPanel, true);
+    assert.equal(state.panelItem, item);
+  });
+
+  it("never leaks another selection's last resolved card", () => {
+    const state = resolvePanelState({
+      selectedId: "b2",
+      newPanelOpen: false,
+      selectedItem: null,
+      lastResolved: { id: "a1", item: card("a1") },
+    });
+    assert.equal(state.showPanel, true);
+    assert.equal(state.panelItem, null);
+  });
+
+  it("prefers the live card over the remembered one", () => {
+    const live = card("a1", "Renamed title");
+    const state = resolvePanelState({
+      selectedId: "a1",
+      newPanelOpen: false,
+      selectedItem: live,
+      lastResolved: { id: "a1", item: card("a1", "Old title") },
+    });
+    assert.equal(state.panelItem, live);
+  });
+
+  it("shows the empty new-mission panel with no card", () => {
+    const state = resolvePanelState({
+      selectedId: null,
+      newPanelOpen: true,
+      selectedItem: null,
+      lastResolved: { id: "a1", item: card("a1") },
+    });
+    assert.equal(state.showPanel, true);
+    assert.equal(state.panelItem, null);
+  });
+
+  it("hides the panel when nothing is selected and no new panel is open", () => {
+    const state = resolvePanelState({
+      selectedId: null,
+      newPanelOpen: false,
+      selectedItem: null,
+      lastResolved: { id: "a1", item: card("a1") },
+    });
+    assert.equal(state.showPanel, false);
+    assert.equal(state.panelItem, null);
+  });
+});


### PR DESCRIPTION
## Problem

Open a chat on a cold hosted agent (pod scaled to zero / just created) and send a message before the engine is ready: the message bubble and the thinking indicator show correctly — but the moment the engine wakes, the whole chat panel closes and reopens.

## Root cause

`AIBoard` derived detail-panel visibility from the selected card's presence in the current `items` array (`showPanel = selectedItem || newPanelOpen`). On a cold start the created mission is absent from the board list for the entire warm-up (Mission Control has no warming-row overlay; list reads are held by the gateway), so the wake-time list churn collapsed `showPanel` and unmounted the panel; the row landing a beat later remounted it. HOU-640's `createdSelectionRef` was a point patch of the same class.

## Fix

- **Panel visibility keys off the selection**, never off the card's presence in `items` (new pure `resolvePanelState` in `@houston-ai/board`). An open conversation outlives any transient absence of its card; only an explicit deselect (close, outside click, Escape, delete, agent switch) closes the panel.
- The panel **header falls back to the same selection's last resolved card**, so the title/people/actions don't flash while the card is away; a never-resolved selection renders blank (agent name only) instead of a wrong "New conversation" label.
- The now-redundant `createdSelectionRef` workaround is removed.
- Removals **deselect explicitly** instead of relying on the card leaving `items`: bulk archive/delete covering the open mission close its panel via `useBoardSelectionUI` (single delete already cleared the selection).

## Tests

- New `ui/board/tests/panel-state.test.ts` covering all resolution states (transient absence, last-resolved fallback, no cross-selection leaks, new-mission panel, closed).
- `ui/board` unit tests: 31 pass. App unit tests: 1515 pass.
- Full web e2e suite: 119 pass. `pnpm typecheck`, `pnpm check`, `pnpm check:parity`, `pnpm check:boundaries` all clean.