### PR TITLE
fix(migration): skip the empty Reconnect-your-apps step

### DIFF
--- a/app/src/components/onboarding/cloud-migration/done-screen.tsx
+++ b/app/src/components/onboarding/cloud-migration/done-screen.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { hasReconnectAppsStep } from "../../../lib/cloud-migration";
 import { useCloudMigrationStore } from "../../../stores/cloud-migration";
 import { SetupCard } from "../setup-card";
 import { DoneCongrats, DoneStepAi, DoneStepApps } from "./done-followups";
@@ -46,6 +47,17 @@ export function DoneScreen({
     (x) => progress[x.sourceId]?.rejected ?? [],
   );
 
+  // Modern legacy installs (v0.4.2x platform-mode integrations) have no
+  // per-agent integration record on disk, so the apps step would be an empty
+  // shell — skip straight to congrats unless it has apps or leftovers to show.
+  const showAppsStep = hasReconnectAppsStep({
+    integrations: integrations.length,
+    failedAgents: failedTasks.length,
+    excludedFiles: excluded.length,
+    rejectedFiles: rejected.length,
+  });
+  const afterAi: Step = showAppsStep ? "apps" : "congrats";
+
   if (step === "congrats") {
     return <DoneCongrats onFinish={() => persistOutcome("done")} />;
   }
@@ -54,19 +66,19 @@ export function DoneScreen({
     return (
       <SetupCard
         onSpace
-        eyebrow={t("done.stepAi")}
+        eyebrow={showAppsStep ? t("done.stepAi") : undefined}
         title={t("done.reconnectAiTitle")}
         subtitle={t("done.reconnectAiBody")}
         helper={
           <button
             type="button"
-            onClick={() => setStep("apps")}
+            onClick={() => setStep(afterAi)}
             className="underline-offset-4 transition-colors hover:text-ink hover:underline"
           >
             {t("done.skip")}
           </button>
         }
-        onNext={() => setStep("apps")}
+        onNext={() => setStep(afterAi)}
         nextLabel={t("done.continue")}
       >
         <div className="min-h-0 flex-1 overflow-y-auto">

--- a/app/src/lib/cloud-migration.ts
+++ b/app/src/lib/cloud-migration.ts
@@ -194,6 +194,29 @@ export function collectIntegrations(sourceAgents: SourceAgent[]): string[] {
   return [...all].sort();
 }
 
+/**
+ * Whether the done screen's second step ("Reconnect your apps" + the
+ * leftovers report) has anything to show. Modern legacy installs (v0.4.2x)
+ * connected integrations in PLATFORM mode — account-level in Composio, no
+ * per-agent `.houston/integrations.json` on disk — so the manifest's
+ * integration list is empty for them and the step would render as a bare
+ * shell. Skip it then; but leftovers (failed agents, excluded/rejected
+ * files) must always surface, so any of those keeps the step.
+ */
+export function hasReconnectAppsStep(counts: {
+  integrations: number;
+  failedAgents: number;
+  excludedFiles: number;
+  rejectedFiles: number;
+}): boolean {
+  return (
+    counts.integrations > 0 ||
+    counts.failedAgents > 0 ||
+    counts.excludedFiles > 0 ||
+    counts.rejectedFiles > 0
+  );
+}
+
 // The per-agent progress state machine (pending → … → done | error) lives in
 // `cloud-migration-progress.ts`; the wizard's prepare phase (spawn source
 // host, scan, resume-probe, plan) in `cloud-migration-prepare.ts`.

--- a/app/tests/cloud-migration.test.ts
+++ b/app/tests/cloud-migration.test.ts
@@ -4,6 +4,7 @@ import {
   buildMigrationPlan,
   chunkPaths,
   collectIntegrations,
+  hasReconnectAppsStep,
   isPlausibleMigrationTarget,
   type SourceAgent,
   type SourceManifestEntry,
@@ -154,4 +155,33 @@ test("collects the sorted union of toolkit slugs across agents", () => {
     agent("Personal", "Helper", ["slack", "googlecalendar"]),
   ]);
   assert.deepEqual(slugs, ["gmail", "googlecalendar", "slack"]);
+});
+
+// ── hasReconnectAppsStep ──────────────────────────────────────────────
+
+test("the apps step is skipped when there is nothing to show", () => {
+  // The common v0.4.2x case: platform-mode integrations leave no per-agent
+  // record, and a clean migration has no leftovers → no empty-shell step.
+  assert.equal(
+    hasReconnectAppsStep({
+      integrations: 0,
+      failedAgents: 0,
+      excludedFiles: 0,
+      rejectedFiles: 0,
+    }),
+    false,
+  );
+});
+
+test("the apps step shows for integrations OR any leftover kind", () => {
+  const none = {
+    integrations: 0,
+    failedAgents: 0,
+    excludedFiles: 0,
+    rejectedFiles: 0,
+  };
+  assert.equal(hasReconnectAppsStep({ ...none, integrations: 2 }), true);
+  assert.equal(hasReconnectAppsStep({ ...none, failedAgents: 1 }), true);
+  assert.equal(hasReconnectAppsStep({ ...none, excludedFiles: 1 }), true);
+  assert.equal(hasReconnectAppsStep({ ...none, rejectedFiles: 1 }), true);
 });


### PR DESCRIPTION
## Problem

The wizard's done screen always shows "Step 2 of 2 — Reconnect your apps", but the checklist is fed by the legacy per-agent `.houston/integrations.json`. Research against the v0.4.x codebase shows **nothing in that era ever wrote this file** — the Rust engine only read it (a relic of an older layout). Modern legacy installs (v0.4.2x) connect integrations in **platform mode**: account-level in Composio, no on-disk record. So for the entire real migration cohort the step renders as an empty shell (title + body + "Start building", zero tiles).

Carrying the old connections over automatically is not possible from the client either: platform connections are keyed to the Composio `user_id`, which was the Supabase sub in the legacy app and is the GCIP sub now, and the gateway keeps no legacy-uid mapping.

## Fix

Skip the apps step when it has nothing to show, going straight from "Connect your AI" to the congrats beat. Leftovers (failed agents, excluded/rejected files) still force the step — they must never be silent. When the AI step is the only step, its "Step 1 of 2" eyebrow is dropped.

The decision is a pure helper (`hasReconnectAppsStep`) in `lib/cloud-migration.ts` with unit tests covering the skip case and each keep-reason. Ancient installs that DO have per-agent integration records keep the populated checklist unchanged (both legacy JSON shapes verified against the source-host scan).

## Tests

`node --test app/tests/cloud-migration.test.ts` — new cases green; `pnpm tsgo --noEmit` + Biome clean.