### PR TITLE
Release prep 0.5.7: version bump + notes

### DIFF
--- a/.github/release-notes/0.5.7.es.md
+++ b/.github/release-notes/0.5.7.es.md
@@ -1,0 +1,49 @@
+## Houston 0.5.7
+
+### Comparte tu IA local con tu equipo
+
+- **El modelo de una persona, los agentes de todos.** Conecta un modelo de IA
+  que corre en tu propia computadora (LM Studio, Ollama, Jan), activa
+  "Compartir con mi equipo" y el Houston de cada compañero podrá usarlo. Sus
+  solicitudes pasan por tu computadora mientras esté encendida.
+
+### Mira cuánta IA te queda
+
+- **Nueva vista de Uso en la barra lateral.** Una tarjeta por cada cuenta de
+  IA conectada con sus límites en vivo: cuánto llevas usado de cada período,
+  cuándo se reinicia o el saldo que te queda. Se actualiza sola.
+
+### Correcciones y pulido
+
+- **Los chats quedan abiertos mientras un agente despierta.** Abrir un chat
+  con un agente dormido ya no cierra y reabre el panel a mitad de la
+  conversación.
+- **Se acabaron los chats misteriosamente vacíos.** Una respuesta cuyo texto
+  contenía un código como "401" se confundía con un error de inicio de sesión
+  y se ocultaba. Ahora se muestra.
+- **Los chats se mantienen sincronizados en todas partes.** Cuando tu agente
+  escribe desde otra ventana o dispositivo, la conversación ahora se recarga
+  en vez de actualizar solo su estado.
+- **Las misiones se archivan, no se completan.** Botones, diálogos y pestañas
+  ahora dicen Archivar y Archivadas, que es lo que realmente pasa: la misión
+  va a la pestaña Archivadas y puedes reabrirla.
+- **Un inicio de sesión más ordenado.** Google, Apple y Microsoft quedan en
+  una fila de botones, y el código de correo tiene seis casillas claras que
+  verifican mientras escribes.
+- **Se nota dónde estás.** La barra lateral ahora marca con claridad el
+  elemento seleccionado en ambos temas.
+- **La mudanza a la nube omite un paso vacío.** El asistente de migración ya
+  no muestra una página en blanco de "reconecta tus aplicaciones" cuando no
+  hay nada que reconectar.
+
+### Antes de actualizar
+
+- **Mac:** cierra Houston antes de instalar. macOS no siempre reemplaza bien
+  una aplicación abierta. Ante la duda, elimina `/Applications/Houston.app` y
+  arrastra la copia nueva.
+- **Windows x64:** la actualización automática desde 0.4.7 o posterior te trae
+  al día sola. El MSI aún no tiene firma de código del sistema, así que
+  SmartScreen puede advertir en una instalación nueva.
+- **Windows ARM64:** no hay actualización automática desde una instalación x64
+  emulada. Descarga el MSI ARM64 manualmente, desinstala primero la versión
+  x64 y luego instala la ARM64.

--- a/.github/release-notes/0.5.7.md
+++ b/.github/release-notes/0.5.7.md
@@ -1,0 +1,45 @@
+## Houston 0.5.7
+
+### Share your local AI with your team
+
+- **One teammate's model, everyone's agents.** Connect an AI model running on
+  your own computer (LM Studio, Ollama, Jan), turn on "Share with my team",
+  and every teammate's Houston can use it. Their requests run through your
+  computer while it is online.
+
+### See how much AI you have left
+
+- **New Usage view in the sidebar.** One card per connected AI account with
+  live limits: how much of each window you have used, when it resets, or the
+  balance you have left. It refreshes on its own.
+
+### Fixes and polish
+
+- **Chats stay open while an agent wakes up.** Opening a chat on a sleeping
+  agent no longer closes and reopens the panel mid-conversation.
+- **No more mysteriously empty chats.** A reply whose text happened to contain
+  a code like "401" was mistaken for a sign-in error and hidden. It shows now.
+- **Chats stay in sync everywhere.** When your agent writes from another
+  window or device, the conversation now reloads instead of only its status.
+- **Missions are archived, not completed.** Buttons, dialogs, and tabs now say
+  Archive and Archived, matching what actually happens: the mission moves to
+  the Archived tab and stays reopenable.
+- **A tidier sign-in.** Google, Apple, and Microsoft sit in one row of
+  buttons, and the email code gets six clear boxes that verify as you type.
+- **You can see where you are.** The sidebar now clearly marks the selected
+  item in both light and dark themes.
+- **Moving to the cloud skips an empty step.** The migration assistant no
+  longer shows a blank "reconnect your apps" page when there is nothing to
+  reconnect.
+
+### Before you upgrade
+
+- **Mac:** quit Houston before installing. macOS does not always replace a
+  running app cleanly. If in doubt, remove `/Applications/Houston.app` and drag
+  the new copy in.
+- **Windows x64:** auto-update from 0.4.7 or later pulls you forward
+  automatically. The MSI is still not OS-code-signed, so Windows SmartScreen may
+  warn on a fresh install.
+- **Windows ARM64:** there is no auto-update path from an emulated x64 install.
+  Download the ARM64 MSI manually, uninstall the x64 build first, then install
+  the ARM64 one.

--- a/.github/release-notes/0.5.7.pt.md
+++ b/.github/release-notes/0.5.7.pt.md
@@ -1,0 +1,48 @@
+## Houston 0.5.7
+
+### Compartilhe sua IA local com o time
+
+- **O modelo de uma pessoa, os agentes de todos.** Conecte um modelo de IA
+  rodando no seu próprio computador (LM Studio, Ollama, Jan), ative
+  "Compartilhar com meu time" e o Houston de cada colega poderá usá-lo. As
+  solicitações deles passam pelo seu computador enquanto ele estiver ligado.
+
+### Veja quanta IA ainda resta
+
+- **Nova visão de Uso na barra lateral.** Um cartão para cada conta de IA
+  conectada com os limites ao vivo: quanto você já usou de cada período,
+  quando ele reinicia ou o saldo que resta. Atualiza sozinho.
+
+### Correções e polimento
+
+- **Os chats ficam abertos enquanto um agente acorda.** Abrir um chat com um
+  agente adormecido não fecha e reabre mais o painel no meio da conversa.
+- **Chega de chats misteriosamente vazios.** Uma resposta cujo texto continha
+  um código como "401" era confundida com um erro de login e ficava oculta.
+  Agora ela aparece.
+- **Os chats ficam sincronizados em todo lugar.** Quando seu agente escreve de
+  outra janela ou dispositivo, a conversa agora recarrega em vez de atualizar
+  só o status.
+- **Missões são arquivadas, não concluídas.** Botões, diálogos e abas agora
+  dizem Arquivar e Arquivadas, que é o que realmente acontece: a missão vai
+  para a aba Arquivadas e pode ser reaberta.
+- **Um login mais organizado.** Google, Apple e Microsoft ficam em uma fileira
+  de botões, e o código do e-mail ganha seis caixas claras que verificam
+  enquanto você digita.
+- **Dá para ver onde você está.** A barra lateral agora marca com clareza o
+  item selecionado nos dois temas.
+- **A mudança para a nuvem pula uma etapa vazia.** O assistente de migração
+  não mostra mais uma página em branco de "reconecte seus aplicativos" quando
+  não há nada para reconectar.
+
+### Antes de atualizar
+
+- **Mac:** feche o Houston antes de instalar. O macOS nem sempre substitui bem
+  um aplicativo aberto. Na dúvida, remova `/Applications/Houston.app` e
+  arraste a cópia nova.
+- **Windows x64:** a atualização automática a partir da 0.4.7 ou posterior te
+  traz para frente sozinha. O MSI ainda não tem assinatura de código do
+  sistema, então o SmartScreen pode avisar em uma instalação nova.
+- **Windows ARM64:** não há atualização automática a partir de uma instalação
+  x64 emulada. Baixe o MSI ARM64 manualmente, desinstale primeiro a versão x64
+  e depois instale a ARM64.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,7 +1927,7 @@ dependencies = [
 
 [[package]]
 name = "houston-app"
-version = "0.5.6"
+version = "0.5.7"
 dependencies = [
  "bytes",
  "chrono",

--- a/app/package.json
+++ b/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "houston-app",
   "private": true,
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/app/src-tauri/Cargo.toml
+++ b/app/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "houston-app"
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 
 [lib]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "houston-ai",
-  "version": "0.5.0",
+  "version": "0.5.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/ui/board/package.json
+++ b/ui/board/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/board",
-  "version": "0.5.0",
+  "version": "0.5.7",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/chat/package.json
+++ b/ui/chat/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/chat",
-  "version": "0.5.0",
+  "version": "0.5.7",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/core/package.json
+++ b/ui/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/core",
-  "version": "0.5.0",
+  "version": "0.5.7",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/events/package.json
+++ b/ui/events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/events",
-  "version": "0.5.0",
+  "version": "0.5.7",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/layout/package.json
+++ b/ui/layout/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/layout",
-  "version": "0.5.0",
+  "version": "0.5.7",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/review/package.json
+++ b/ui/review/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/review",
-  "version": "0.5.0",
+  "version": "0.5.7",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/routines/package.json
+++ b/ui/routines/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/routines",
-  "version": "0.5.0",
+  "version": "0.5.7",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",

--- a/ui/skills/package.json
+++ b/ui/skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@houston-ai/skills",
-  "version": "0.5.0",
+  "version": "0.5.7",
   "type": "module",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Prep for the next cloud release (`cloud-v0.5.7`).

- `./scripts/version.sh 0.5.7`: all shared packages + `app/src-tauri/Cargo.toml` + `Cargo.lock` bumped to 0.5.7.
- Release notes `.github/release-notes/0.5.7.md` (+ `.es.md`, `.pt.md`) covering what shipped since 0.5.6: shared local models for teams (#860), the Usage view (#890), the wake-up chat-panel fix (#891), the hidden-reply fix (HOU-734, #885), cross-client chat sync (#888/#889), Archive copy, sidebar selected state, sign-in polish, and the empty migration step skip (#893).

After merge: tag the squash commit `cloud-v0.5.7` and push the tag; CI builds the draft "Houston Cloud v0.5.7" prerelease. The same commit can also take a plain `v0.5.7` tag if a new local-channel draft is wanted.